### PR TITLE
fix(security): Critical authentication security fixes and Docker PUID…

### DIFF
--- a/apps/api/src/lib/auth/session.ts
+++ b/apps/api/src/lib/auth/session.ts
@@ -65,6 +65,24 @@ export class SessionService {
 			.catch(() => undefined);
 	}
 
+	async invalidateAllUserSessions(userId: string, exceptToken?: string) {
+		if (exceptToken) {
+			// Invalidate all sessions except the current one
+			const hashedExceptToken = hashToken(exceptToken);
+			await this.prisma.session.deleteMany({
+				where: {
+					userId,
+					id: { not: hashedExceptToken },
+				},
+			});
+		} else {
+			// Invalidate ALL sessions for this user
+			await this.prisma.session.deleteMany({
+				where: { userId },
+			});
+		}
+	}
+
 	async validateRequest(request: FastifyRequest) {
 		const rawCookie = request.cookies?.[this.env.SESSION_COOKIE_NAME];
 		if (!rawCookie) {

--- a/apps/api/src/routes/auth-passkey.ts
+++ b/apps/api/src/routes/auth-passkey.ts
@@ -58,6 +58,29 @@ const authPasskeyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			return reply.status(401).send({ error: "Unauthorized" });
 		}
 
+		// Check if OIDC provider is enabled - if so, passkey registration is disabled
+		const oidcProvider = await app.prisma.oIDCProvider.findFirst({
+			where: { enabled: true },
+		});
+
+		if (oidcProvider) {
+			return reply.status(403).send({
+				error: "Passkey authentication is disabled. Please use OIDC authentication.",
+			});
+		}
+
+		// Check if user has a password - passkeys require password authentication
+		const user = await app.prisma.user.findUnique({
+			where: { id: request.currentUser.id },
+			select: { hashedPassword: true },
+		});
+
+		if (!user?.hashedPassword) {
+			return reply.status(403).send({
+				error: "Passkeys require password authentication. Please set up a password first.",
+			});
+		}
+
 		const parsed = passkeyRegisterOptionsSchema.safeParse(request.body);
 		if (!parsed.success) {
 			return reply.status(400).send({ error: "Invalid request" });
@@ -128,6 +151,17 @@ const authPasskeyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Public endpoint (no authentication required)
 	 */
 	app.post("/passkey/login/options", async (request, reply) => {
+		// Check if OIDC provider is enabled - if so, passkey login is disabled
+		const oidcProvider = await app.prisma.oIDCProvider.findFirst({
+			where: { enabled: true },
+		});
+
+		if (oidcProvider) {
+			return reply.status(403).send({
+				error: "Passkey authentication is disabled. Please use OIDC authentication.",
+			});
+		}
+
 		try {
 			const options = await passkeyService.generateAuthenticationOptions();
 
@@ -279,6 +313,14 @@ const authPasskeyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 			if (!deleted) {
 				return reply.status(404).send({ error: "Credential not found" });
+			}
+
+			// Invalidate all other sessions (keep current session)
+			if (request.sessionToken) {
+				await app.sessionService.invalidateAllUserSessions(
+					request.currentUser.id,
+					request.sessionToken
+				);
 			}
 
 			return reply.send({ success: true, message: "Passkey deleted successfully" });

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -37,8 +37,9 @@ echo "Setting up directories and permissions..."
 # Ensure config directory exists (LinuxServer convention)
 mkdir -p /config
 
-# Set ownership of writable directories
-chown -R abc:abc /config
+# Set ownership of writable directories using numeric IDs
+# This ensures correct permissions even when mounting pre-existing directories
+chown -R $PUID:$PGID /config
 
 # ============================================
 # Signal handling

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -52,3 +52,20 @@ export const oidcProviderResponseSchema = z.object({
 });
 
 export type OIDCProviderResponse = z.infer<typeof oidcProviderResponseSchema>;
+
+/**
+ * Input schema for deleting OIDC provider
+ * Requires replacement password to prevent lockout
+ */
+export const deleteOidcProviderSchema = z.object({
+	replacementPassword: z
+		.string()
+		.min(8, "Password must be at least 8 characters")
+		.max(128, "Password must not exceed 128 characters")
+		.regex(/[a-z]/, "Password must contain at least one lowercase letter")
+		.regex(/[A-Z]/, "Password must contain at least one uppercase letter")
+		.regex(/[0-9]/, "Password must contain at least one number")
+		.regex(/[^a-zA-Z0-9]/, "Password must contain at least one special character"),
+});
+
+export type DeleteOIDCProvider = z.infer<typeof deleteOidcProviderSchema>;


### PR DESCRIPTION
## Summary

This PR addresses critical authentication security vulnerabilities and fixes Docker container permission issues on first-time deployment.

## 🐳 Docker Fix

**Problem:** When running the container for the first time with custom PUID/PGID, database creation fails with permission errors.

**Root Cause:** The startup script used `chown abc:abc` which relied on username resolution. After `usermod` changed the UID, the username could still resolve to the old UID (911) instead of the new PUID, causing permission mismatches.

**Solution:** Use numeric IDs directly in `chown $PUID:$PGID` to ensure atomic permission application.

**Files Changed:**
- `docker/start-combined.sh` (line 42)

---

## 🔒 Authentication Security Fixes

### Bug A: Mixed Authentication Mode Vulnerabilities

**Problem:**
- Password authentication remained active when OIDC was configured
- Passkeys could exist as standalone authentication (without password)
- This allowed bypassing centralized OIDC policies (2FA, audit logs, rate limiting)

**Solution:** Implemented strict authentication mode rules:
- ✅ **OIDC enabled** → Password and passkey authentication completely disabled
- ✅ **Password mode** → Passkeys allowed as optional 2FA (require password)
- ✅ **Passkeys** → Cannot be standalone (must have password)

**Files Changed:**
- `apps/api/src/routes/auth.ts` - Block password login/registration/changes when OIDC enabled
- `apps/api/src/routes/auth-passkey.ts` - Block passkey operations when OIDC enabled, require password for passkey registration

---

### Bug B: OIDC Deletion Causes Permanent Lockout (CRITICAL)

**Problem:**
- Deleting or disabling OIDC provider had no validation
- Users with OIDC-only authentication (no password, no passkeys) became permanently locked out
- No mechanism to prevent or recover from this state

**Solution:** Require immediate replacement password when deleting OIDC:
- ✅ DELETE endpoint now requires `replacementPassword` in request body
- ✅ Automatically sets password for all OIDC-only users
- ✅ Forces password change for other users (`mustChangePassword: true`)
- ✅ Validates password strength (8+ chars, mixed case, numbers, special characters)
- ✅ PUT endpoint blocks disabling OIDC if users would be locked out
- ✅ All sessions invalidated to force re-authentication with new method

**Files Changed:**
- `packages/shared/src/types/oidc-provider.ts` - New `deleteOidcProviderSchema` with password validation
- `apps/api/src/routes/oidc-providers.ts` - Complete rewrite of DELETE endpoint, enhanced PUT validation

---

### Bug C: Session Hijacking After Security Incidents

**Problem:**
- Authentication method changes (password change, OIDC deletion, etc.) did not invalidate existing sessions
- Attackers with stolen session tokens could continue accessing the system after victim changed credentials
- Common post-breach mitigation (changing password) was ineffective

**Solution:** Invalidate sessions on all authentication changes:
- ✅ Password change → Invalidate all other sessions (keeps current)
- ✅ Password removal → Invalidate all other sessions (keeps current)
- ✅ Passkey deletion → Invalidate all other sessions (keeps current)
- ✅ OIDC config changes → Invalidate ALL sessions globally
- ✅ OIDC deletion → Invalidate ALL sessions globally

**Files Changed:**
- `apps/api/src/lib/auth/session.ts` - New `invalidateAllUserSessions()` helper method
- `apps/api/src/routes/auth.ts` - Session invalidation on password changes
- `apps/api/src/routes/auth-passkey.ts` - Session invalidation on passkey deletion
- `apps/api/src/routes/oidc-providers.ts` - Session invalidation on OIDC changes

---

## 📊 Impact Assessment

| Bug | Severity Before | Severity After | Risk Eliminated |
|-----|----------------|----------------|-----------------|
| **A** | ⚠️ Medium | ✅ Fixed | Authentication bypass of centralized OIDC policies |
| **B** | 🔴 **CRITICAL** | ✅ Fixed | Permanent account lockout, complete service outage |
| **C** | 🔴 High | ✅ Fixed | Session hijacking post-breach |

---

## 🧪 Testing Recommendations

**Scenario 1: OIDC → Password Switch**
1. Enable OIDC provider
2. Verify password login returns 403
3. Delete OIDC with `{ "replacementPassword": "SecurePass123!" }`
4. Verify all sessions invalidated
5. Login with username + new password works

**Scenario 2: Password → OIDC Switch**
1. Start with password auth
2. Create OIDC provider
3. Verify password login returns 403
4. Verify OIDC login works

**Scenario 3: Passkey Registration**
1. With OIDC enabled: passkey registration returns 403
2. Without password: passkey registration returns 403
3. With password, no OIDC: passkey registration works

**Scenario 4: Session Invalidation**
1. Login with password (session 1)
2. Login again in another browser (session 2)
3. Change password in session 1
4. Verify session 2 is invalidated
5. Session 1 still works

---

## ✅ Compatibility

- ✅ No breaking changes to database schema
- ✅ Backward compatible (existing deployments won't break)
- ✅ Clear error messages guide users
- ✅ Type-safe with Zod schemas
- ✅ Follows existing conventional commit style

---

## 📝 Files Changed (6 files, +226 -9)

- `apps/api/src/lib/auth/session.ts`
- `apps/api/src/routes/auth.ts`
- `apps/api/src/routes/auth-passkey.ts`
- `apps/api/src/routes/oidc-providers.ts`
- `packages/shared/src/types/oidc-provider.ts`
- `docker/start-combined.sh`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OIDC provider deletion now requires a replacement password to prevent account lockout.
  * Added safety checks to prevent users from being locked out when OIDC provider status changes.

* **Security Enhancements**
  * Password and passkey authentication is now restricted when OIDC provider is enabled.
  * Sessions are invalidated when authentication methods are updated.

* **Chores**
  * Updated Docker permission handling for configuration directories.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->