### PR TITLE
chore(deps): Upgrade Tailwind CSS 3 → 4

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,24 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
+
+@config '../tailwind.config.ts';
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
 
 @layer base {
 	/*
@@ -4266,7 +4284,7 @@
 
 	/* Enhanced glassmorphism layers */
 	.glass-subtle {
-		@apply bg-card/40 backdrop-blur-sm border border-border/30;
+		@apply bg-card/40 backdrop-blur-xs border border-border/30;
 	}
 
 	.glass-medium {

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -35,7 +35,7 @@ const HomePage = () => {
 	}, [setupLoading, setupRequired, userLoading, user, router]);
 
 	return (
-		<main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
+		<main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-linear-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
 			<Skeleton className="h-10 w-10 rounded-full" />
 		</main>
 	);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -54,17 +54,17 @@
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.3",
+		"@tailwindcss/postcss": "^4.1.18",
 		"@types/node": "^22.7.4",
 		"@types/react": "^19.2.9",
 		"@types/react-dom": "^19.2.3",
 		"@typescript-eslint/eslint-plugin": "^8.53.1",
 		"@typescript-eslint/parser": "^8.53.1",
-		"autoprefixer": "^10.4.23",
 		"eslint": "^9.39.2",
 		"eslint-config-next": "^16.1.4",
 		"globals": "^17.0.0",
 		"postcss": "^8.4.47",
-		"tailwindcss": "^3.4.14",
+		"tailwindcss": "^4.1.18",
 		"typescript": "^5.6.3"
 	}
 }

--- a/apps/web/postcss.config.js
+++ b/apps/web/postcss.config.js
@@ -1,6 +1,5 @@
 module.exports = {
 	plugins: {
-		tailwindcss: {},
-		autoprefixer: {},
+		'@tailwindcss/postcss': {},
 	},
 };

--- a/apps/web/src/app/(dashboard)/trash-guides/history/[syncId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/trash-guides/history/[syncId]/page.tsx
@@ -310,7 +310,7 @@ export default function SyncDetailPage() {
 									<p className="font-medium text-red-200">{config.name}</p>
 									{config.error && <p className="mt-1 text-sm text-red-300">{config.error}</p>}
 								</div>
-								<XCircle className="h-5 w-5 flex-shrink-0 text-red-400" />
+								<XCircle className="h-5 w-5 shrink-0 text-red-400" />
 							</div>
 						))}
 					</div>
@@ -345,14 +345,14 @@ export default function SyncDetailPage() {
 						aria-modal="true"
 						aria-labelledby="rollback-confirm-title"
 						aria-describedby="rollback-confirm-description"
-						className="w-full max-w-md rounded-xl border border-border bg-background p-6 focus:outline-none"
+						className="w-full max-w-md rounded-xl border border-border bg-background p-6 focus:outline-hidden"
 						onClick={(e) => e.stopPropagation()}
 					>
 						<h3
 							id="rollback-confirm-title"
 							ref={titleRef}
 							tabIndex={-1}
-							className="text-xl font-semibold text-foreground focus:outline-none"
+							className="text-xl font-semibold text-foreground focus:outline-hidden"
 						>
 							Confirm Rollback
 						</h3>

--- a/apps/web/src/components/layout/bento-grid.tsx
+++ b/apps/web/src/components/layout/bento-grid.tsx
@@ -135,7 +135,7 @@ export function BentoCard({
 	return (
 		<motion.div
 			className={cn(
-				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm",
+				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs",
 				"transition-colors duration-300",
 				interactive && "cursor-pointer hover:border-border",
 				sizeClasses,

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -136,7 +136,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 			onClick={() => onOpenChange(false)}
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/60 backdrop-blur-xs" />
 
 			{/* Command Dialog */}
 			<Command
@@ -164,7 +164,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 						onValueChange={setSearch}
 						placeholder="Type a command or search..."
 						className={cn(
-							"flex h-14 w-full bg-transparent py-4 text-base outline-none",
+							"flex h-14 w-full bg-transparent py-4 text-base outline-hidden",
 							"placeholder:text-muted-foreground"
 						)}
 						autoFocus
@@ -199,7 +199,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 									value={`${item.label} ${item.keywords.join(" ")}`}
 									onSelect={() => runCommand(() => router.push(item.href))}
 									className={cn(
-										"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+										"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 										"aria-selected:bg-muted/50"
 									)}
 								>
@@ -233,7 +233,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="light mode theme"
 							onSelect={() => runCommand(() => setTheme("light"))}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -255,7 +255,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="dark mode theme"
 							onSelect={() => runCommand(() => setTheme("dark"))}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -277,7 +277,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="system mode theme auto"
 							onSelect={() => runCommand(() => setTheme("system"))}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -299,7 +299,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="oled dark black amoled pure"
 							onSelect={() => isDarkMode && runCommand(toggleOLED)}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50",
 								!isDarkMode && "opacity-50"
 							)}
@@ -336,7 +336,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 								value={`theme color ${option.label} ${option.name}`}
 								onSelect={() => runCommand(() => setColorTheme(option.name))}
 								className={cn(
-									"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+									"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 									"aria-selected:bg-muted/50"
 								)}
 							>
@@ -370,7 +370,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="refresh data reload"
 							onSelect={() => runCommand(handleRefreshData)}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -387,7 +387,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="account profile user"
 							onSelect={() => runCommand(() => router.push("/settings"))}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -406,7 +406,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 								runCommand(() => window.open("https://github.com/khak1s/arr-dashboard", "_blank"))
 							}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>
@@ -423,7 +423,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							value="logout sign out"
 							onSelect={() => runCommand(handleLogout)}
 							className={cn(
-								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-none transition-colors",
+								"group relative flex cursor-pointer items-center gap-3 rounded-xl px-3 py-2.5 text-sm outline-hidden transition-colors",
 								"aria-selected:bg-muted/50"
 							)}
 						>

--- a/apps/web/src/components/layout/premium-components.tsx
+++ b/apps/web/src/components/layout/premium-components.tsx
@@ -33,7 +33,7 @@ export const PremiumTabs = ({ tabs, activeTab, onTabChange, className }: Premium
 	return (
 		<div
 			className={cn(
-				"inline-flex rounded-xl bg-card/30 backdrop-blur-sm border border-border/50 p-1.5",
+				"inline-flex rounded-xl bg-card/30 backdrop-blur-xs border border-border/50 p-1.5",
 				className
 			)}
 		>
@@ -112,7 +112,7 @@ export const PremiumTable = ({ children, className }: PremiumTableProps) => {
 	return (
 		<div
 			className={cn(
-				"rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-x-auto",
+				"rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-x-auto",
 				className
 			)}
 		>
@@ -401,7 +401,7 @@ export const InstanceCard = ({
 	return (
 		<div
 			className={cn(
-				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm",
+				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs",
 				"transition-all duration-300 hover:border-border hover:shadow-lg",
 				"animate-in fade-in slide-in-from-bottom-4 duration-500",
 				className
@@ -556,7 +556,7 @@ export const GlassmorphicCard = ({
 	return (
 		<div
 			className={cn(
-				"rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm",
+				"rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs",
 				"animate-in fade-in slide-in-from-bottom-4 duration-500",
 				paddingClass,
 				className
@@ -605,7 +605,7 @@ export const FilterSelect = ({
 				value={value}
 				onChange={(e) => onChange(e.target.value)}
 				className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm
-					focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary/20
+					focus:outline-hidden focus:border-primary focus:ring-1 focus:ring-primary/20
 					[&>option]:bg-background [&>option]:text-foreground"
 				style={{
 					// Theme-aware focus state
@@ -688,7 +688,7 @@ export const GradientButton = ({
 				disabled={disabled}
 				className={cn(
 					"relative inline-flex items-center justify-center font-medium rounded-lg",
-					"border border-border/50 bg-card/50 backdrop-blur-sm",
+					"border border-border/50 bg-card/50 backdrop-blur-xs",
 					"text-foreground transition-all duration-300",
 					"disabled:opacity-50 disabled:cursor-not-allowed",
 					"hover:border-border hover:bg-card/80",

--- a/apps/web/src/components/layout/premium-page-header.tsx
+++ b/apps/web/src/components/layout/premium-page-header.tsx
@@ -169,7 +169,7 @@ export const PremiumCard = ({
 	return (
 		<div
 			className={cn(
-				"rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden",
+				"rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden",
 				"animate-in fade-in slide-in-from-bottom-4 duration-500",
 				className
 			)}
@@ -255,7 +255,7 @@ export const StatCard = ({
 			onClick={onClick}
 			disabled={!onClick}
 			className={cn(
-				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 text-left transition-all duration-500",
+				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6 text-left transition-all duration-500",
 				"animate-in fade-in slide-in-from-bottom-4",
 				onClick && "cursor-pointer hover:border-border hover:shadow-lg",
 				!onClick && "cursor-default"

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -151,7 +151,7 @@ export const Sidebar = () => {
 							<Icon
 								className={cn(
 									"relative z-10 h-4 w-4 transition-all duration-300",
-									isActive && "drop-shadow-sm",
+									isActive && "drop-shadow-xs",
 									!isActive && "group-hover:scale-110"
 								)}
 								style={!isActive ? { color: themeGradient.from } : undefined}
@@ -249,7 +249,7 @@ export const Sidebar = () => {
 			<AnimatePresence>
 				{mobileMenuOpen && (
 					<motion.div
-						className="lg:hidden fixed inset-0 bg-black/60 backdrop-blur-sm z-modal-backdrop"
+						className="lg:hidden fixed inset-0 bg-black/60 backdrop-blur-xs z-modal-backdrop"
 						onClick={() => setMobileMenuOpen(false)}
 						aria-hidden="true"
 						initial={{ opacity: 0 }}
@@ -286,7 +286,7 @@ export const Sidebar = () => {
 			</AnimatePresence>
 
 			{/* Desktop sidebar */}
-			<aside data-sidebar className="hidden w-64 flex-shrink-0 flex-col border-r border-border/30 bg-background/50 backdrop-blur-xl p-6 lg:flex relative">
+			<aside data-sidebar className="hidden w-64 shrink-0 flex-col border-r border-border/30 bg-background/50 backdrop-blur-xl p-6 lg:flex relative">
 				{/* Decorative gradient orb */}
 				<div
 					className="absolute top-0 left-0 w-64 h-64 rounded-full blur-3xl -translate-x-1/2 -translate-y-1/2 pointer-events-none"

--- a/apps/web/src/components/layout/topbar.tsx
+++ b/apps/web/src/components/layout/topbar.tsx
@@ -56,10 +56,10 @@ export const TopBar = () => {
 								<Eye className="h-4 w-4" />
 							)}
 						</Button>
-						<div className="group relative flex items-center gap-3 px-3 py-2 rounded-lg bg-card/40 backdrop-blur-sm border border-border/50 hover:border-primary/30 transition-all duration-200 cursor-pointer">
-							<div className="absolute inset-0 rounded-lg bg-gradient-to-r from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
+						<div className="group relative flex items-center gap-3 px-3 py-2 rounded-lg bg-card/40 backdrop-blur-xs border border-border/50 hover:border-primary/30 transition-all duration-200 cursor-pointer">
+							<div className="absolute inset-0 rounded-lg bg-linear-to-r from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
 
-							<div className="relative h-9 w-9 rounded-full bg-gradient-to-br from-primary to-accent text-white flex items-center justify-center shadow-md ring-1 ring-white/10">
+							<div className="relative h-9 w-9 rounded-full bg-linear-to-br from-primary to-accent text-white flex items-center justify-center shadow-md ring-1 ring-white/10">
 								<span className="text-sm font-semibold">
 									{user.username[0]?.toUpperCase() ?? "U"}
 								</span>

--- a/apps/web/src/components/presentational/queue-filters.tsx
+++ b/apps/web/src/components/presentational/queue-filters.tsx
@@ -79,9 +79,9 @@ const PremiumSelect = ({
 				<SelectPrimitive.Trigger
 					className={cn(
 						"relative flex h-11 w-full min-w-[150px] items-center justify-between gap-2 rounded-xl border px-4 py-2.5 text-sm font-medium transition-all duration-300",
-						"bg-card/60 backdrop-blur-sm text-foreground",
-						"focus:outline-none focus:ring-2 focus:ring-offset-0 focus:ring-offset-transparent",
-						"data-[placeholder]:text-muted-foreground",
+						"bg-card/60 backdrop-blur-xs text-foreground",
+						"focus:outline-hidden focus:ring-2 focus:ring-offset-0 focus:ring-offset-transparent",
+						"data-placeholder:text-muted-foreground",
 						"disabled:cursor-not-allowed disabled:opacity-50",
 						isActive
 							? "border-primary/50"
@@ -118,14 +118,14 @@ const PremiumSelect = ({
 				<SelectPrimitive.Portal>
 					<SelectPrimitive.Content
 						className={cn(
-							"relative z-modal max-h-[300px] min-w-[var(--radix-select-trigger-width)] overflow-hidden",
+							"relative z-modal max-h-[300px] min-w-(--radix-select-trigger-width) overflow-hidden",
 							"rounded-xl border border-border/50 bg-card/95 backdrop-blur-xl",
 							"shadow-xl shadow-black/20",
 							"data-[state=open]:animate-in data-[state=closed]:animate-out",
 							"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
 							"data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
 							"data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
-							"origin-[--radix-select-content-transform-origin]"
+							"origin-(--radix-select-content-transform-origin)"
 						)}
 						position="popper"
 						sideOffset={6}
@@ -147,11 +147,11 @@ const PremiumSelect = ({
 									key={option.value}
 									value={option.value}
 									className={cn(
-										"relative flex w-full cursor-pointer select-none items-center rounded-lg py-2.5 pl-9 pr-3 text-sm font-medium outline-none transition-all duration-200",
+										"relative flex w-full cursor-pointer select-none items-center rounded-lg py-2.5 pl-9 pr-3 text-sm font-medium outline-hidden transition-all duration-200",
 										"text-foreground/80",
 										"focus:text-foreground",
-										"data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-										"data-[highlighted]:outline-none"
+										"data-disabled:pointer-events-none data-disabled:opacity-50",
+										"data-highlighted:outline-hidden"
 									)}
 									style={{
 										// Hover/focus background with theme color
@@ -281,7 +281,7 @@ export const QueueFilters = ({
 		<div className="space-y-3">
 			{/* Main filter bar */}
 			<div
-				className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/50 backdrop-blur-sm transition-all duration-300"
+				className="relative overflow-hidden rounded-2xl border border-border/40 bg-card/50 backdrop-blur-xs transition-all duration-300"
 				style={{
 					boxShadow: filtersActive ? `0 4px 20px -4px ${themeGradient.glow}` : undefined,
 				}}

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -51,7 +51,7 @@ const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
       {dismissible && (
         <button
           onClick={onDismiss}
-          className="absolute right-3 top-3 rounded-md p-1 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+          className="absolute right-3 top-3 rounded-md p-1 opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2"
           aria-label="Dismiss alert"
           type="button"
         >

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -14,7 +14,7 @@ import { SEMANTIC_COLORS } from "../../lib/theme-gradients"
  * All variants use rounded-lg for premium feel.
  */
 const badgeVariants = cva(
-  "inline-flex items-center gap-1 rounded-lg border font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center gap-1 rounded-lg border font-medium transition-all duration-200 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
@@ -23,7 +23,7 @@ const badgeVariants = cva(
         // Gradient - theme-aware (handled separately)
         gradient: "border-transparent text-white",
         // Secondary - subtle glassmorphic
-        secondary: "border-border/50 bg-muted/50 text-foreground backdrop-blur-sm",
+        secondary: "border-border/50 bg-muted/50 text-foreground backdrop-blur-xs",
         // Outline - border only
         outline: "border-border text-foreground bg-transparent",
         // Destructive

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -21,7 +21,7 @@ const buttonVariants = cva(
     "rounded-xl", // Premium rounded corners
     "ring-offset-background",
     "transition-all duration-300", // Smooth transitions
-    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
     "disabled:pointer-events-none disabled:opacity-50",
     "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
     "active:scale-[0.98]", // Press-down effect
@@ -44,14 +44,14 @@ const buttonVariants = cva(
         outline: [
           "border border-border/50 bg-transparent",
           "hover:bg-muted/50 hover:border-border",
-          "backdrop-blur-sm",
+          "backdrop-blur-xs",
         ].join(" "),
 
         // Secondary - glassmorphic style
         secondary: [
           "bg-card/50 text-foreground",
           "border border-border/50",
-          "backdrop-blur-sm",
+          "backdrop-blur-xs",
           "hover:bg-card/80 hover:border-border",
         ].join(" "),
 

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -21,13 +21,13 @@ const cardVariants = cva(
     variants: {
       variant: {
         // Default glassmorphic card
-        default: "border border-border/50 bg-card/80 backdrop-blur-sm shadow-sm",
+        default: "border border-border/50 bg-card/80 backdrop-blur-xs shadow-sm",
         // Elevated with stronger presence
         elevated: "border border-border/40 bg-card/90 backdrop-blur-md shadow-lg",
         // Ghost - minimal styling
         ghost: "border border-transparent bg-transparent",
         // Gradient accent - theme-aware top border
-        gradient: "border border-border/30 bg-card/80 backdrop-blur-sm",
+        gradient: "border border-border/30 bg-card/80 backdrop-blur-xs",
       },
       hover: {
         true: "",

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "grid place-content-center peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -27,8 +27,8 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-modal-backdrop backdrop-blur-sm",
-      "bg-gradient-to-br from-black/70 via-black/60 to-black/70",
+      "fixed inset-0 z-modal-backdrop backdrop-blur-xs",
+      "bg-linear-to-br from-black/70 via-black/60 to-black/70",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
@@ -104,7 +104,7 @@ const DialogContent = React.forwardRef<
             "h-8 w-8 flex items-center justify-center",
             "rounded-lg opacity-70 transition-all duration-200",
             "hover:opacity-100 hover:bg-muted/50",
-            "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ring-offset-background",
+            "focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 ring-offset-background",
             "disabled:pointer-events-none"
           )}
         >

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-modal min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      "z-modal min-w-32 overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
       className
     )}
     {...props}
@@ -65,7 +65,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-modal max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        "z-modal max-h-(--radix-dropdown-menu-content-available-height) min-w-32 overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-dropdown-menu-content-transform-origin)",
         className
       )}
       {...props}
@@ -83,7 +83,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -99,7 +99,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     checked={checked}
@@ -123,7 +123,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-hidden transition-colors focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -43,15 +43,15 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           // Premium rounded corners
           "rounded-xl",
           // Border and background
-          "border border-border/50 bg-background/50 backdrop-blur-sm",
+          "border border-border/50 bg-background/50 backdrop-blur-xs",
           // Placeholder
           "placeholder:text-muted-foreground/60",
           // File input styling
           "file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground",
           // Standard focus (non-premium) - kept for compatibility
-          !premium && "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background",
+          !premium && "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ring-offset-background",
           // Premium focus removes default ring for custom styling
-          premium && "focus-visible:outline-none",
+          premium && "focus-visible:outline-hidden",
           // Transitions
           "transition-all duration-300",
           // Disabled state

--- a/apps/web/src/components/ui/legacy-dialog.tsx
+++ b/apps/web/src/components/ui/legacy-dialog.tsx
@@ -90,7 +90,7 @@ export function LegacyDialog({ open, onOpenChange, children, size = "md", dialog
     <div className="fixed inset-0 z-modal-backdrop animate-in fade-in duration-200">
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/70 backdrop-blur-sm"
+        className="fixed inset-0 bg-black/70 backdrop-blur-xs"
         onClick={() => onOpenChange(false)}
         aria-hidden="true"
       />

--- a/apps/web/src/components/ui/native-select.tsx
+++ b/apps/web/src/components/ui/native-select.tsx
@@ -31,7 +31,7 @@ export const NativeSelect = forwardRef<HTMLSelectElement, NativeSelectProps>(
         "w-full rounded-lg border px-4 py-2.5 text-sm transition-colors",
         "bg-background text-foreground",
         "border-input hover:border-input/80",
-        "focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/20",
+        "focus:border-ring focus:outline-hidden focus:ring-2 focus:ring-ring/20",
         "disabled:cursor-not-allowed disabled:opacity-50",
         error && "border-destructive focus:border-destructive focus:ring-destructive/20",
         className,

--- a/apps/web/src/components/ui/password-input.tsx
+++ b/apps/web/src/components/ui/password-input.tsx
@@ -38,7 +38,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
         <input
           type={showPassword ? "text" : "password"}
           className={cn(
-            "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+            "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
             showToggle && "pr-10",
             className
           )}

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -19,7 +19,7 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-popover w-72 max-w-[calc(100vw-2rem)] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-popover-content-transform-origin]",
+        "z-popover w-72 max-w-[calc(100vw-2rem)] rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-popover-content-transform-origin)",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -28,7 +28,7 @@ const RadioGroupItem = React.forwardRef<
     <RadioGroupPrimitive.Item
       ref={ref}
       className={cn(
-        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "aspect-square h-4 w-4 rounded-full border border-primary text-primary ring-offset-background focus:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -33,9 +33,9 @@ const ScrollBar = React.forwardRef<
     className={cn(
       "flex touch-none select-none transition-colors",
       orientation === "vertical" &&
-        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+        "h-full w-2.5 border-l border-l-transparent p-px",
       orientation === "horizontal" &&
-        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+        "h-2.5 flex-col border-t border-t-transparent p-px",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -46,13 +46,13 @@ const SelectTrigger = React.forwardRef<
         // Premium rounded corners
         "rounded-xl",
         // Border and background (glassmorphic)
-        "border border-border/50 bg-background/50 backdrop-blur-sm",
+        "border border-border/50 bg-background/50 backdrop-blur-xs",
         // Placeholder
-        "data-[placeholder]:text-muted-foreground/60",
+        "data-placeholder:text-muted-foreground/60",
         // Standard focus (non-premium)
-        !premium && "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 ring-offset-background",
+        !premium && "focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 ring-offset-background",
         // Premium focus removes default ring
-        premium && "focus:outline-none",
+        premium && "focus:outline-hidden",
         // Transitions
         "transition-all duration-300",
         // States
@@ -133,7 +133,7 @@ const SelectContent = React.forwardRef<
         ref={ref}
         className={cn(
           // Base
-          "relative z-modal max-h-[--radix-select-content-available-height] min-w-[8rem]",
+          "relative z-modal max-h-(--radix-select-content-available-height) min-w-32",
           "overflow-y-auto overflow-x-hidden",
           // Glassmorphic styling
           "rounded-xl border border-border/50 bg-popover/95 backdrop-blur-xl",
@@ -144,7 +144,7 @@ const SelectContent = React.forwardRef<
           "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
           "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-          "origin-[--radix-select-content-transform-origin]",
+          "origin-(--radix-select-content-transform-origin)",
           // Position adjustments
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
@@ -161,7 +161,7 @@ const SelectContent = React.forwardRef<
           className={cn(
             "p-1.5",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+              "h-(--radix-select-trigger-height) w-full min-w-(--radix-select-trigger-width)"
           )}
         >
           {children}
@@ -205,13 +205,13 @@ const SelectItem = React.forwardRef<
       className={cn(
         // Base
         "relative flex w-full cursor-pointer select-none items-center",
-        "rounded-lg py-2 pl-8 pr-3 text-sm outline-none",
+        "rounded-lg py-2 pl-8 pr-3 text-sm outline-hidden",
         // Hover/focus with gradient background
         "focus:text-foreground",
         // Transitions
         "transition-colors duration-150",
         // States
-        "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "data-disabled:pointer-events-none data-disabled:opacity-50",
         className
       )}
       style={{

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -19,7 +19,7 @@ const Separator = React.forwardRef<
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border",
-        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -65,7 +65,7 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -130,7 +130,7 @@ function SkeletonCard({ className, animation, themed }: SkeletonCardProps) {
   return (
     <div
       className={cn(
-        "rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 space-y-4",
+        "rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 space-y-4",
         className
       )}
       role="status"
@@ -197,7 +197,7 @@ function SkeletonTable({
   return (
     <div
       className={cn(
-        "rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden",
+        "rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden",
         className
       )}
       role="status"
@@ -253,7 +253,7 @@ function SkeletonStatCard({ className, animation, themed }: SkeletonStatCardProp
   return (
     <div
       className={cn(
-        "rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6",
+        "rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6",
         className
       )}
       role="status"

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -11,7 +11,7 @@ const Switch = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SwitchPrimitives.Root
     className={cn(
-      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -13,7 +13,7 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-hidden rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm">
+  <div className="relative w-full overflow-hidden rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs">
     <div className="overflow-auto">
       <table
         ref={ref}
@@ -65,7 +65,7 @@ const TableFooter = React.forwardRef<
   <tfoot
     ref={ref}
     className={cn(
-      "border-t border-border/50 bg-muted/20 font-medium [&>tr]:last:border-b-0",
+      "border-t border-border/50 bg-muted/20 font-medium last:[&>tr]:border-b-0",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
     {...props}

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -41,7 +41,7 @@ export function Toaster({ ...props }: ToasterProps) {
 					actionButton: "group-[.toast]:bg-primary group-[.toast]:text-white",
 					cancelButton: "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
 					closeButton:
-						"group-[.toast]:bg-muted group-[.toast]:border-border/50 group-[.toast]:text-muted-foreground hover:group-[.toast]:bg-muted/80",
+						"group-[.toast]:bg-muted group-[.toast]:border-border/50 group-[.toast]:text-muted-foreground group-[.toast]:hover:bg-muted/80",
 					success: "group-[.toaster]:border-success/30 group-[.toaster]:text-success-fg",
 					error: "group-[.toaster]:border-danger/30 group-[.toaster]:text-danger-fg",
 					warning: "group-[.toaster]:border-warning/30 group-[.toaster]:text-warning-fg",

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-tooltip overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+      "z-tooltip overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-(--radix-tooltip-content-transform-origin)",
       className
     )}
     {...props}

--- a/apps/web/src/features/auth/components/login-form.tsx
+++ b/apps/web/src/features/auth/components/login-form.tsx
@@ -188,7 +188,7 @@ export const LoginForm = () => {
 				</div>
 
 				<Card
-					className="w-full max-w-md border-border/50 bg-card/80 backdrop-blur-sm"
+					className="w-full max-w-md border-border/50 bg-card/80 backdrop-blur-xs"
 					style={{
 						borderColor: SEMANTIC_COLORS.error.border,
 						backgroundColor: SEMANTIC_COLORS.error.bg,
@@ -265,7 +265,7 @@ export const LoginForm = () => {
 			</div>
 
 			{/* Login Card */}
-			<Card className="w-full max-w-sm border-border/50 bg-card/80 backdrop-blur-sm">
+			<Card className="w-full max-w-sm border-border/50 bg-card/80 backdrop-blur-xs">
 				<CardHeader>
 					<CardTitle className="text-xl text-foreground">Welcome back</CardTitle>
 					<CardDescription className="text-muted-foreground">

--- a/apps/web/src/features/calendar/components/calendar-filters.tsx
+++ b/apps/web/src/features/calendar/components/calendar-filters.tsx
@@ -47,7 +47,7 @@ export const CalendarFilters = ({
 
 	return (
 		<div
-			className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-500"
+			className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden animate-in fade-in slide-in-from-bottom-4 duration-500"
 			style={{ animationDelay: "100ms", animationFillMode: "backwards" }}
 		>
 			{/* Header */}
@@ -96,7 +96,7 @@ export const CalendarFilters = ({
 						id="calendar-service-filter"
 						value={serviceFilter}
 						onChange={(event) => onServiceFilterChange(event.target.value as ServiceFilterValue)}
-						className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
+						className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
 					>
 						{SERVICE_FILTERS.map((option) => (
 							<option key={option.value} value={option.value}>
@@ -117,7 +117,7 @@ export const CalendarFilters = ({
 						id="calendar-instance-filter"
 						value={instanceFilter}
 						onChange={(event) => onInstanceFilterChange(event.target.value)}
-						className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
+						className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
 					>
 						<option value="all">All instances</option>
 						{instanceOptions.map((option) => (

--- a/apps/web/src/features/calendar/components/calendar-header.tsx
+++ b/apps/web/src/features/calendar/components/calendar-header.tsx
@@ -70,7 +70,7 @@ export const CalendarHeader = ({
 				<div className="flex items-center gap-2">
 					{/* Month navigation group */}
 					<div
-						className="flex items-center rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden"
+						className="flex items-center rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden"
 					>
 						<Button
 							variant="ghost"
@@ -101,7 +101,7 @@ export const CalendarHeader = ({
 						variant="ghost"
 						size="sm"
 						onClick={onGoToday}
-						className="border border-border/50 bg-card/30 backdrop-blur-sm"
+						className="border border-border/50 bg-card/30 backdrop-blur-xs"
 					>
 						Today
 					</Button>

--- a/apps/web/src/features/dashboard/components/dashboard-client.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-client.tsx
@@ -90,7 +90,7 @@ const ServiceStatCard = ({
 			onClick={onClick}
 			disabled={!onClick}
 			className={cn(
-				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 text-left transition-colors duration-300",
+				"group relative overflow-hidden rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6 text-left transition-colors duration-300",
 				onClick && "cursor-pointer hover:border-border",
 				!onClick && "cursor-default"
 			)}
@@ -477,7 +477,7 @@ export const DashboardClient = () => {
 							className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 							style={{ animationDelay: "500ms", animationFillMode: "backwards" }}
 						>
-							<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden">
+							<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden">
 								<div className="flex items-center gap-3 px-6 py-4 border-b border-border/50">
 									<div
 										className="flex h-10 w-10 items-center justify-center rounded-xl"
@@ -529,7 +529,7 @@ export const DashboardClient = () => {
 					<div
 						className="animate-in fade-in duration-300"
 					>
-						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden">
+						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden">
 							<div className="flex items-center justify-between gap-3 px-6 py-4 border-b border-border/50">
 								<div className="flex items-center gap-3">
 									<div

--- a/apps/web/src/features/dashboard/components/queue-action-buttons.tsx
+++ b/apps/web/src/features/dashboard/components/queue-action-buttons.tsx
@@ -132,7 +132,7 @@ const RemoveActionMenu = ({
 					disabled={disabled}
 					className={cn(
 						"group inline-flex h-9 items-center justify-center gap-2 rounded-full border px-4 text-xs font-medium transition-all duration-300",
-						"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-sm",
+						"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-xs",
 						"hover:border-red-500/30 hover:bg-red-500/5 hover:text-red-400",
 						disabled && "cursor-not-allowed opacity-50",
 						fullWidth && "w-full"
@@ -195,7 +195,7 @@ export const QueueActionButtons = ({
 
 	const secondaryButtonClass = cn(
 		"inline-flex h-9 items-center justify-center gap-2 rounded-full border px-4 text-xs font-medium transition-all duration-300",
-		"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-sm",
+		"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-xs",
 		"hover:border-border hover:bg-card hover:text-foreground",
 		fullWidth && "w-full"
 	);

--- a/apps/web/src/features/dashboard/components/queue-group-card.tsx
+++ b/apps/web/src/features/dashboard/components/queue-group-card.tsx
@@ -94,7 +94,7 @@ export const QueueGroupCard = ({
 	return (
 		<div
 			className={cn(
-				"group relative overflow-hidden rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm transition-all duration-300",
+				"group relative overflow-hidden rounded-xl border border-border/40 bg-card/50 backdrop-blur-xs transition-all duration-300",
 				"hover:border-primary/30",
 				expanded && "shadow-xl",
 			)}
@@ -187,7 +187,7 @@ export const QueueGroupCard = ({
 				</div>
 
 				{/* Right column: issue badge, progress, actions */}
-				<div className="flex flex-col gap-3 lg:flex-shrink-0 lg:gap-4 lg:pl-4 lg:border-l lg:border-border/30">
+				<div className="flex flex-col gap-3 lg:shrink-0 lg:gap-4 lg:pl-4 lg:border-l lg:border-border/30">
 					<div className="flex justify-end">
 						<QueueIssueBadge summary={issueSummary} size="sm" />
 					</div>

--- a/apps/web/src/features/dashboard/components/queue-item-card.tsx
+++ b/apps/web/src/features/dashboard/components/queue-item-card.tsx
@@ -76,7 +76,7 @@ export const QueueItemCard = ({
 	return (
 		<div
 			className={cn(
-				"group relative overflow-hidden rounded-xl border border-border/40 bg-card/50 backdrop-blur-sm p-4 transition-all duration-300",
+				"group relative overflow-hidden rounded-xl border border-border/40 bg-card/50 backdrop-blur-xs p-4 transition-all duration-300",
 				selected && "ring-2 ring-primary/50 border-primary/50",
 				"hover:border-primary/30 hover:shadow-xl",
 			)}
@@ -140,7 +140,7 @@ export const QueueItemCard = ({
 				</div>
 
 				{/* Right column: issue badge, progress, actions */}
-				<div className="flex flex-col gap-3 lg:flex-shrink-0 lg:gap-4 lg:pl-4 lg:border-l lg:border-border/30">
+				<div className="flex flex-col gap-3 lg:shrink-0 lg:gap-4 lg:pl-4 lg:border-l lg:border-border/30">
 					<div className="flex justify-end">
 						<QueueIssueBadge summary={issueSummary} size="sm" />
 					</div>

--- a/apps/web/src/features/dashboard/components/queue-progress.tsx
+++ b/apps/web/src/features/dashboard/components/queue-progress.tsx
@@ -23,7 +23,7 @@ export const QueueProgress = ({ value, size = "md", service }: QueueProgressProp
 					"relative overflow-hidden rounded-full bg-muted/30",
 					size === "sm" ? "h-2" : "h-2.5"
 				)}>
-					<div className="absolute inset-0 bg-gradient-to-r from-muted/20 via-muted/40 to-muted/20 animate-pulse" />
+					<div className="absolute inset-0 bg-linear-to-r from-muted/20 via-muted/40 to-muted/20 animate-pulse" />
 				</div>
 				<span className="text-xs text-muted-foreground">–</span>
 			</div>

--- a/apps/web/src/features/dashboard/components/queue-selection-toolbar.tsx
+++ b/apps/web/src/features/dashboard/components/queue-selection-toolbar.tsx
@@ -45,7 +45,7 @@ export const QueueSelectionToolbar = ({
 
 	const actionButtonClass = cn(
 		"group inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-medium uppercase tracking-wide transition-all duration-300",
-		"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-sm",
+		"border-border/50 bg-card/50 text-muted-foreground backdrop-blur-xs",
 		"hover:border-border hover:bg-card hover:text-foreground",
 		"disabled:cursor-not-allowed disabled:opacity-50",
 	);

--- a/apps/web/src/features/dashboard/components/queue-status-messages.tsx
+++ b/apps/web/src/features/dashboard/components/queue-status-messages.tsx
@@ -121,8 +121,8 @@ export const QueueStatusMessages = ({ lines }: QueueStatusMessagesProps) => {
 					animationFillMode: "backwards",
 				}}
 			>
-				<Icon className={cn("mt-0.5 h-3.5 w-3.5 flex-shrink-0 transition-transform duration-300 group-hover:scale-110", style.iconClass)} />
-				<span className="break-words leading-relaxed">
+				<Icon className={cn("mt-0.5 h-3.5 w-3.5 shrink-0 transition-transform duration-300 group-hover:scale-110", style.iconClass)} />
+				<span className="wrap-break-word leading-relaxed">
 					{incognitoMode ? anonymizeStatusMessage(entry.text) : entry.text}
 				</span>
 			</div>
@@ -130,7 +130,7 @@ export const QueueStatusMessages = ({ lines }: QueueStatusMessagesProps) => {
 	};
 
 	return (
-		<div className="space-y-2 break-words">
+		<div className="space-y-2 wrap-break-word">
 			{/* Render standalone messages with staggered animation */}
 			{standalone.map((entry, index) => renderMessage(entry, index))}
 
@@ -150,7 +150,7 @@ export const QueueStatusMessages = ({ lines }: QueueStatusMessagesProps) => {
 								style.container,
 							)}
 						>
-							<Icon className={cn("h-3.5 w-3.5 flex-shrink-0", style.iconClass)} />
+							<Icon className={cn("h-3.5 w-3.5 shrink-0", style.iconClass)} />
 							<span className="flex-1 leading-relaxed font-medium">
 								{group.pattern}
 							</span>

--- a/apps/web/src/features/dashboard/components/queue-table.tsx
+++ b/apps/web/src/features/dashboard/components/queue-table.tsx
@@ -129,7 +129,7 @@ export const QueueTable = ({
 	if (loading) {
 		return (
 			<div
-				className="relative overflow-hidden rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm p-8 text-center"
+				className="relative overflow-hidden rounded-xl border border-border/50 bg-card/50 backdrop-blur-xs p-8 text-center"
 				style={{
 					boxShadow: `0 4px 20px -4px ${themeGradient.glow}`,
 				}}
@@ -163,7 +163,7 @@ export const QueueTable = ({
 	if (items.length === 0) {
 		return (
 			<div
-				className="relative overflow-hidden rounded-xl border border-border/50 bg-card/50 backdrop-blur-sm p-8 text-center"
+				className="relative overflow-hidden rounded-xl border border-border/50 bg-card/50 backdrop-blur-xs p-8 text-center"
 				style={{
 					boxShadow: `0 4px 20px -4px ${themeGradient.glow}`,
 				}}

--- a/apps/web/src/features/discover/components/add-to-library-dialog.tsx
+++ b/apps/web/src/features/discover/components/add-to-library-dialog.tsx
@@ -296,9 +296,9 @@ export const AddToLibraryDialog: React.FC<AddToLibraryDialogProps> = ({
 		(type === "series" && !languageProfileId);
 
 	const selectClassName = cn(
-		"w-full rounded-xl border bg-card/50 backdrop-blur-sm px-4 py-3 text-sm text-foreground",
+		"w-full rounded-xl border bg-card/50 backdrop-blur-xs px-4 py-3 text-sm text-foreground",
 		"hover:border-border transition-all duration-200",
-		"focus:outline-none appearance-none cursor-pointer"
+		"focus:outline-hidden appearance-none cursor-pointer"
 	);
 
 	const getSelectStyle = (id: string): React.CSSProperties => {
@@ -318,7 +318,7 @@ export const AddToLibraryDialog: React.FC<AddToLibraryDialogProps> = ({
 		>
 			{/* Backdrop */}
 			<div
-				className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+				className="absolute inset-0 bg-black/70 backdrop-blur-xs"
 				onClick={onClose}
 			/>
 
@@ -572,7 +572,7 @@ export const AddToLibraryDialog: React.FC<AddToLibraryDialogProps> = ({
 					<div className="grid gap-3 md:grid-cols-2">
 						{/* Monitor Toggle */}
 						<label
-							className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
+							className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
 						>
 							<span className="text-sm font-medium text-foreground">Monitor future releases</span>
 							<div
@@ -600,7 +600,7 @@ export const AddToLibraryDialog: React.FC<AddToLibraryDialogProps> = ({
 
 						{/* Search on Add Toggle */}
 						<label
-							className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
+							className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
 						>
 							<span className="flex items-center gap-2 text-sm font-medium text-foreground">
 								<Search className="h-4 w-4 text-muted-foreground" />
@@ -632,7 +632,7 @@ export const AddToLibraryDialog: React.FC<AddToLibraryDialogProps> = ({
 						{/* Season Folder Toggle (Series only) */}
 						{type === "series" && (
 							<label
-								className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
+								className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-3 cursor-pointer transition-colors hover:border-border/80"
 							>
 								<span className="flex items-center gap-2 text-sm font-medium text-foreground">
 									<FolderOpen className="h-4 w-4 text-muted-foreground" />

--- a/apps/web/src/features/discover/components/instance-badge.tsx
+++ b/apps/web/src/features/discover/components/instance-badge.tsx
@@ -31,7 +31,7 @@ export const InstanceBadge: React.FC<InstanceBadgeProps> = ({ instance, result }
 	if (!state) {
 		return (
 			<span
-				className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-sm"
+				className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-xs"
 				style={{
 					backgroundColor: "rgba(100, 116, 139, 0.1)",
 					border: "1px solid rgba(100, 116, 139, 0.2)",
@@ -49,7 +49,7 @@ export const InstanceBadge: React.FC<InstanceBadgeProps> = ({ instance, result }
 	if (state.exists) {
 		return (
 			<span
-				className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-sm"
+				className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.success.bg,
 					border: `1px solid ${SEMANTIC_COLORS.success.border}`,
@@ -65,7 +65,7 @@ export const InstanceBadge: React.FC<InstanceBadgeProps> = ({ instance, result }
 	// Available State (theme-aware)
 	return (
 		<span
-			className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-sm"
+			className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium backdrop-blur-xs"
 			style={{
 				backgroundColor: `${themeGradient.from}10`,
 				border: `1px solid ${themeGradient.from}25`,

--- a/apps/web/src/features/discover/components/media-card.tsx
+++ b/apps/web/src/features/discover/components/media-card.tsx
@@ -63,7 +63,7 @@ export const MediaCard: React.FC<MediaCardProps> = ({
 				{/* Main Content */}
 				<div className="flex gap-4">
 					{/* Poster */}
-					<div className="relative h-40 w-28 overflow-hidden rounded-xl border border-border/30 bg-gradient-to-br from-slate-800 to-slate-900 shrink-0">
+					<div className="relative h-40 w-28 overflow-hidden rounded-xl border border-border/30 bg-linear-to-br from-slate-800 to-slate-900 shrink-0">
 						{result.images?.poster ? (
 							/* eslint-disable-next-line @next/next/no-img-element -- External TMDB image with dynamic URL */
 							<img

--- a/apps/web/src/features/discover/components/media-type-toggle.tsx
+++ b/apps/web/src/features/discover/components/media-type-toggle.tsx
@@ -39,7 +39,7 @@ export const MediaTypeToggle: React.FC<MediaTypeToggleProps> = ({
 
 	return (
 		<div className="flex flex-wrap items-center gap-4">
-			<div className="inline-flex rounded-xl bg-card/50 backdrop-blur-sm p-1 border border-border/50">
+			<div className="inline-flex rounded-xl bg-card/50 backdrop-blur-xs p-1 border border-border/50">
 				{options.map(({ type, label, icon: Icon }) => {
 					const isActive = searchType === type;
 					return (

--- a/apps/web/src/features/discover/components/recommendation-carousel.tsx
+++ b/apps/web/src/features/discover/components/recommendation-carousel.tsx
@@ -61,9 +61,9 @@ export const RecommendationCarousel: React.FC<RecommendationCarouselProps> = ({
 				</div>
 				<div className="flex gap-4 overflow-hidden">
 					{Array.from({ length: 6 }).map((_, i) => (
-						<div key={i} className="w-[160px] flex-shrink-0">
+						<div key={i} className="w-[160px] shrink-0">
 							<div className="rounded-lg border border-border/30 bg-card/30 overflow-hidden">
-								<PremiumSkeleton variant="card" className="aspect-[2/3] rounded-none" style={{ animationDelay: `${i * 50}ms` }} />
+								<PremiumSkeleton variant="card" className="aspect-2/3 rounded-none" style={{ animationDelay: `${i * 50}ms` }} />
 								<div className="p-2 space-y-2">
 									<PremiumSkeleton variant="line" className="h-4 w-3/4" style={{ animationDelay: `${i * 50 + 25}ms` }} />
 									<PremiumSkeleton variant="line" className="h-3 w-1/2" style={{ animationDelay: `${i * 50 + 50}ms` }} />
@@ -99,10 +99,10 @@ export const RecommendationCarousel: React.FC<RecommendationCarouselProps> = ({
 						return (
 							<div
 								key={result.id}
-								className="group relative w-[160px] flex-shrink-0 cursor-pointer overflow-hidden rounded-lg border border-border/50 bg-card transition-all hover:scale-105 hover:border-border"
+								className="group relative w-[160px] shrink-0 cursor-pointer overflow-hidden rounded-lg border border-border/50 bg-card transition-all hover:scale-105 hover:border-border"
 								onClick={() => onSelectResult(result)}
 							>
-								<div className="relative aspect-[2/3] w-full overflow-hidden bg-gradient-to-br from-slate-700 to-slate-900">
+								<div className="relative aspect-2/3 w-full overflow-hidden bg-linear-to-br from-slate-700 to-slate-900">
 									{result.images?.poster ? (
 										/* eslint-disable-next-line @next/next/no-img-element -- External TMDB image with dynamic URL */
 										<img
@@ -116,12 +116,12 @@ export const RecommendationCarousel: React.FC<RecommendationCarouselProps> = ({
 										</div>
 									)}
 									{typeof ratingValue === "number" && (
-										<div className="absolute right-2 top-2 rounded-full border border-yellow-500/40 bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-200 backdrop-blur-sm">
+										<div className="absolute right-2 top-2 rounded-full border border-yellow-500/40 bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-200 backdrop-blur-xs">
 											{ratingValue.toFixed(1)}
 										</div>
 									)}
 									{!canAdd && (
-										<div className="absolute left-2 top-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-200 backdrop-blur-sm">
+										<div className="absolute left-2 top-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-200 backdrop-blur-xs">
 											<CheckCircle2 className="inline h-3 w-3" />
 										</div>
 									)}

--- a/apps/web/src/features/discover/components/tmdb-carousel.tsx
+++ b/apps/web/src/features/discover/components/tmdb-carousel.tsx
@@ -51,7 +51,7 @@ const RecommendationCard: React.FC<RecommendationCardProps> = ({ item, mediaType
 
 	return (
 		<div
-			className="group relative w-[160px] flex-shrink-0 cursor-pointer overflow-hidden rounded-xl transition-all duration-300 hover:scale-[1.03] animate-in fade-in slide-in-from-bottom-2"
+			className="group relative w-[160px] shrink-0 cursor-pointer overflow-hidden rounded-xl transition-all duration-300 hover:scale-[1.03] animate-in fade-in slide-in-from-bottom-2"
 			style={{
 				animationDelay: `${index * 30}ms`,
 				animationFillMode: "backwards",
@@ -69,9 +69,9 @@ const RecommendationCard: React.FC<RecommendationCardProps> = ({ item, mediaType
 			/>
 
 			{/* Card Content */}
-			<div className="relative rounded-xl border border-border/50 bg-card/80 backdrop-blur-sm overflow-hidden group-hover:border-transparent transition-colors duration-300">
+			<div className="relative rounded-xl border border-border/50 bg-card/80 backdrop-blur-xs overflow-hidden group-hover:border-transparent transition-colors duration-300">
 				{/* Poster */}
-				<div className="relative aspect-[2/3] w-full overflow-hidden bg-gradient-to-br from-slate-800 to-slate-900">
+				<div className="relative aspect-2/3 w-full overflow-hidden bg-linear-to-br from-slate-800 to-slate-900">
 					{item.posterUrl ? (
 						/* eslint-disable-next-line @next/next/no-img-element -- External TMDB image with dynamic URL */
 						<img
@@ -174,10 +174,10 @@ const CarouselSkeleton: React.FC = () => (
 		{Array.from({ length: 7 }).map((_, i) => (
 			<div
 				key={i}
-				className="w-[160px] flex-shrink-0"
+				className="w-[160px] shrink-0"
 			>
 				<div className="rounded-xl border border-border/30 bg-card/30 overflow-hidden">
-					<PremiumSkeleton variant="card" className="aspect-[2/3] rounded-none" style={{ animationDelay: `${i * 50}ms` }} />
+					<PremiumSkeleton variant="card" className="aspect-2/3 rounded-none" style={{ animationDelay: `${i * 50}ms` }} />
 					<div className="p-3 space-y-2">
 						<PremiumSkeleton variant="line" className="h-4 w-3/4" style={{ animationDelay: `${i * 50 + 25}ms` }} />
 						<PremiumSkeleton variant="line" className="h-3 w-1/2" style={{ animationDelay: `${i * 50 + 50}ms` }} />
@@ -422,7 +422,7 @@ export const TMDBCarousel: React.FC<TMDBCarouselProps> = ({
 
 					{/* Loading More Indicator */}
 					{isFetchingNextPage && (
-						<div className="flex w-[160px] flex-shrink-0 items-center justify-center">
+						<div className="flex w-[160px] shrink-0 items-center justify-center">
 							<div
 								className="flex h-12 w-12 items-center justify-center rounded-xl"
 								style={{

--- a/apps/web/src/features/history/components/history-client.tsx
+++ b/apps/web/src/features/history/components/history-client.tsx
@@ -270,7 +270,7 @@ export const HistoryClient = () => {
 									event.target.value as (typeof SERVICE_FILTERS)[number]["value"],
 								)
 							}
-							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
+							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
 						>
 							{SERVICE_FILTERS.map((option) => (
 								<option key={option.value} value={option.value}>
@@ -287,7 +287,7 @@ export const HistoryClient = () => {
 							id="history-instance-filter"
 							value={instanceFilter}
 							onChange={(event) => actions.setInstanceFilter(event.target.value)}
-							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
+							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
 						>
 							<option value="all">All instances</option>
 							{instanceOptions.map((option) => (
@@ -305,7 +305,7 @@ export const HistoryClient = () => {
 							id="history-status-filter"
 							value={statusFilter}
 							onChange={(event) => actions.setStatusFilter(event.target.value)}
-							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
+							className="rounded-lg border border-border/50 bg-background/50 px-3 py-2 text-sm focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/20 [&>option]:bg-background [&>option]:text-foreground"
 						>
 							<option value="all">All statuses</option>
 							{statusOptions.map((option) => (
@@ -351,7 +351,7 @@ export const HistoryClient = () => {
 					{statusSummary.map(([label, count], index) => (
 						<div
 							key={`${index}-${label}`}
-							className="flex items-center gap-2 rounded-full border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-2 text-sm"
+							className="flex items-center gap-2 rounded-full border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-2 text-sm"
 						>
 							<span className="text-muted-foreground">{label}</span>
 							<span

--- a/apps/web/src/features/hunting/components/hunting-activity.tsx
+++ b/apps/web/src/features/hunting/components/hunting-activity.tsx
@@ -221,7 +221,7 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 
 	return (
 		<div
-			className="group rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden
+			className="group rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden
 				animate-in fade-in slide-in-from-bottom-2 duration-300 hover:border-border/80 transition-colors"
 			style={{
 				animationDelay: `${animationDelay}ms`,

--- a/apps/web/src/features/hunting/components/hunting-client.tsx
+++ b/apps/web/src/features/hunting/components/hunting-client.tsx
@@ -81,7 +81,7 @@ export const HuntingClient = () => {
 					<Button
 						variant="secondary"
 						onClick={() => void refetch()}
-						className="gap-2 border-border/50 bg-card/50 backdrop-blur-sm hover:bg-card/80"
+						className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
 					>
 						<RefreshCw className="h-4 w-4" />
 						Refresh

--- a/apps/web/src/features/hunting/components/hunting-config.tsx
+++ b/apps/web/src/features/hunting/components/hunting-config.tsx
@@ -538,7 +538,7 @@ const InstanceConfigCard = ({ config, onSaved, animationDelay = 0 }: InstanceCon
 								size="sm"
 								onClick={() => void handleRunNow("missing")}
 								disabled={isTriggering}
-								className="gap-2 border-border/50 bg-card/50 backdrop-blur-sm"
+								className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs"
 							>
 								{isTriggering ? (
 									<RotateCcw className="h-4 w-4 animate-spin" />
@@ -554,7 +554,7 @@ const InstanceConfigCard = ({ config, onSaved, animationDelay = 0 }: InstanceCon
 								size="sm"
 								onClick={() => void handleRunNow("upgrade")}
 								disabled={isTriggering}
-								className="gap-2 border-border/50 bg-card/50 backdrop-blur-sm"
+								className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs"
 							>
 								{isTriggering ? (
 									<RotateCcw className="h-4 w-4 animate-spin" />
@@ -770,7 +770,7 @@ const UnconfiguredInstanceCard = ({
 				size="sm"
 				onClick={() => void handleConfigure()}
 				disabled={isCreating}
-				className="gap-2 border-border/50 bg-card/50 backdrop-blur-sm"
+				className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs"
 			>
 				{isCreating ? (
 					<RotateCcw className="h-4 w-4 animate-spin" />

--- a/apps/web/src/features/hunting/components/hunting-overview.tsx
+++ b/apps/web/src/features/hunting/components/hunting-overview.tsx
@@ -148,7 +148,7 @@ const HuntDropdown = ({ instance, isTriggering, onTrigger }: HuntDropdownProps) 
 				size="sm"
 				onClick={() => setIsOpen(!isOpen)}
 				disabled={isTriggering}
-				className="gap-2 border-border/50 bg-card/50 backdrop-blur-sm hover:bg-card/80"
+				className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
 			>
 				{isTriggering ? (
 					<Loader2 className="h-4 w-4 animate-spin" />

--- a/apps/web/src/features/indexers/components/empty-indexers-card.tsx
+++ b/apps/web/src/features/indexers/components/empty-indexers-card.tsx
@@ -20,7 +20,7 @@ export const EmptyIndexersCard = () => {
 	const { gradient: themeGradient } = useThemeGradient();
 
 	return (
-		<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-sm p-12 text-center animate-in fade-in slide-in-from-bottom-4 duration-500">
+		<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-xs p-12 text-center animate-in fade-in slide-in-from-bottom-4 duration-500">
 			{/* Icon */}
 			<div
 				className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl"

--- a/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
+++ b/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
@@ -19,7 +19,7 @@ const FieldCard = ({
 
 	return (
 		<div
-			className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 transition-all duration-200 hover:bg-card/50 animate-in fade-in slide-in-from-bottom-1"
+			className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 transition-all duration-200 hover:bg-card/50 animate-in fade-in slide-in-from-bottom-1"
 			style={{
 				animationDelay: `${index * 30}ms`,
 				animationFillMode: "backwards",

--- a/apps/web/src/features/indexers/components/indexer-instance-card.tsx
+++ b/apps/web/src/features/indexers/components/indexer-instance-card.tsx
@@ -48,7 +48,7 @@ export const IndexerInstanceCard = ({
 	const [incognitoMode] = useIncognitoMode();
 
 	return (
-		<article className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden">
+		<article className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden">
 			{/* Header */}
 			<header
 				className="p-5 border-b border-border/30"

--- a/apps/web/src/features/indexers/components/indexer-row.tsx
+++ b/apps/web/src/features/indexers/components/indexer-row.tsx
@@ -84,7 +84,7 @@ export const IndexerRow = ({
 	return (
 		<div className="space-y-0 overflow-hidden">
 			<div
-				className={`rounded-xl border bg-card/40 backdrop-blur-sm p-4 transition-all duration-200 ${
+				className={`rounded-xl border bg-card/40 backdrop-blur-xs p-4 transition-all duration-200 ${
 					expanded ? "rounded-b-none border-b-0" : ""
 				}`}
 				style={{

--- a/apps/web/src/features/indexers/components/indexers-client.tsx
+++ b/apps/web/src/features/indexers/components/indexers-client.tsx
@@ -218,7 +218,7 @@ export const IndexersClient = () => {
 			{/* Error Alert */}
 			{error && (
 				<div
-					className="rounded-2xl border p-5 backdrop-blur-sm animate-in fade-in slide-in-from-top-2 duration-300"
+					className="rounded-2xl border p-5 backdrop-blur-xs animate-in fade-in slide-in-from-top-2 duration-300"
 					style={{
 						backgroundColor: SEMANTIC_COLORS.error.bg,
 						borderColor: SEMANTIC_COLORS.error.border,
@@ -244,7 +244,7 @@ export const IndexersClient = () => {
 			{/* Feedback Alert */}
 			{feedback && (
 				<div
-					className="rounded-2xl border p-5 backdrop-blur-sm animate-in fade-in slide-in-from-top-2 duration-300"
+					className="rounded-2xl border p-5 backdrop-blur-xs animate-in fade-in slide-in-from-top-2 duration-300"
 					style={{
 						backgroundColor: feedback.type === "success" ? SEMANTIC_COLORS.success.bg : SEMANTIC_COLORS.error.bg,
 						borderColor: feedback.type === "success" ? SEMANTIC_COLORS.success.border : SEMANTIC_COLORS.error.border,
@@ -277,7 +277,7 @@ export const IndexersClient = () => {
 
 					{/* Top Pagination */}
 					{aggregated.length > 0 && (
-						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<Pagination
 								currentPage={page}
 								totalItems={aggregated.length}
@@ -320,7 +320,7 @@ export const IndexersClient = () => {
 
 					{/* Bottom Pagination */}
 					{aggregated.length > 0 && (
-						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<Pagination
 								currentPage={page}
 								totalItems={aggregated.length}

--- a/apps/web/src/features/library/components/item-details-modal.tsx
+++ b/apps/web/src/features/library/components/item-details-modal.tsx
@@ -144,7 +144,7 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 			aria-labelledby="item-details-title"
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -174,7 +174,7 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 				>
 					<div className="flex gap-5">
 						{item.poster && (
-							<div className="h-48 w-32 overflow-hidden rounded-xl border border-border/50 shadow-lg flex-shrink-0">
+							<div className="h-48 w-32 overflow-hidden rounded-xl border border-border/50 shadow-lg shrink-0">
 								{/* eslint-disable-next-line @next/next/no-img-element -- External poster from arr instance */}
 								<img src={item.poster} alt={item.title} className="h-full w-full object-cover" />
 							</div>
@@ -334,7 +334,7 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 						<h3 className="text-xs uppercase tracking-wider font-medium text-muted-foreground mb-3">
 							Metadata
 						</h3>
-						<div className="grid grid-cols-2 md:grid-cols-3 gap-4 rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="grid grid-cols-2 md:grid-cols-3 gap-4 rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							{metadata.map((entry) => (
 								<MetadataItem
 									key={entry.label}
@@ -352,7 +352,7 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 							<h3 className="text-xs uppercase tracking-wider font-medium text-muted-foreground mb-3">
 								File Information
 							</h3>
-							<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+							<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 								{locationEntries.map((entry) => (
 									<div key={entry.label} className="space-y-1">
 										<div className="flex items-center gap-1.5">

--- a/apps/web/src/features/library/components/library-card.tsx
+++ b/apps/web/src/features/library/components/library-card.tsx
@@ -233,7 +233,7 @@ export const LibraryCard = ({
 	return (
 		<GlassmorphicCard padding="md" className="flex flex-col gap-3">
 				<div className="flex gap-3">
-					<div className="h-36 w-24 overflow-hidden rounded-lg border border-border bg-muted shadow-md flex-shrink-0">
+					<div className="h-36 w-24 overflow-hidden rounded-lg border border-border bg-muted shadow-md shrink-0">
 						{item.poster ? (
 							/* eslint-disable-next-line @next/next/no-img-element -- External poster from arr instance */
 							<img src={item.poster} alt={item.title} className="h-full w-full object-cover" />

--- a/apps/web/src/features/library/components/library-header.tsx
+++ b/apps/web/src/features/library/components/library-header.tsx
@@ -184,7 +184,7 @@ export const LibraryHeader: React.FC<LibraryHeaderProps> = ({
 					{/* Sync Status Indicator */}
 					{syncStatus && (
 						<div
-							className="flex items-center gap-2 rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-2 text-sm"
+							className="flex items-center gap-2 rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-2 text-sm"
 						>
 							{isSyncing ? (
 								<>

--- a/apps/web/src/features/library/components/season-breakdown-modal.tsx
+++ b/apps/web/src/features/library/components/season-breakdown-modal.tsx
@@ -129,7 +129,7 @@ export const SeasonBreakdownModal = ({
 			aria-labelledby="season-breakdown-title"
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -237,7 +237,7 @@ export const SeasonBreakdownModal = ({
 						return (
 							<div
 								key={season.seasonNumber}
-								className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm overflow-hidden transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
+								className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs overflow-hidden transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
 								style={{
 									animationDelay: `${index * 50}ms`,
 									animationFillMode: "backwards",

--- a/apps/web/src/features/library/components/season-episode-list.tsx
+++ b/apps/web/src/features/library/components/season-episode-list.tsx
@@ -113,7 +113,7 @@ export const SeasonEpisodeList = ({
 							</div>
 						)}
 					</div>
-					<div className="flex items-center gap-2 flex-shrink-0">
+					<div className="flex items-center gap-2 shrink-0">
 						<LibraryBadge tone={episode.hasFile ? "green" : "blue"}>
 							{episode.hasFile ? "Downloaded" : "Missing"}
 						</LibraryBadge>
@@ -123,7 +123,7 @@ export const SeasonEpisodeList = ({
 							</LibraryBadge>
 						)}
 					</div>
-					<div className="flex items-center gap-1.5 flex-shrink-0">
+					<div className="flex items-center gap-1.5 shrink-0">
 						<Button
 							type="button"
 							variant="secondary"

--- a/apps/web/src/features/manual-import/components/candidate-card.tsx
+++ b/apps/web/src/features/manual-import/components/candidate-card.tsx
@@ -106,7 +106,7 @@ export const CandidateCard = ({
 					<div className="min-w-0 space-y-2">
 						<div className="space-y-1">
 							<p className="font-medium text-foreground">{describeCandidate(candidate)}</p>
-							<p className="break-words text-xs text-muted-foreground">{candidateDisplayPath(candidate)}</p>
+							<p className="wrap-break-word text-xs text-muted-foreground">{candidateDisplayPath(candidate)}</p>
 						</div>
 						{chips.length > 0 && (
 							<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">

--- a/apps/web/src/features/manual-import/components/manual-import-modal.tsx
+++ b/apps/web/src/features/manual-import/components/manual-import-modal.tsx
@@ -194,7 +194,7 @@ export const ManualImportModal = ({
 			aria-labelledby="manual-import-title"
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -284,7 +284,7 @@ export const ManualImportModal = ({
 
 				{/* Controls */}
 				<div className="px-6 pt-4">
-					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 						{/* Stats Row */}
 						<div className="flex flex-wrap items-center gap-4 text-sm">
 							<div className="flex items-center gap-2">
@@ -330,7 +330,7 @@ export const ManualImportModal = ({
 									onChange={(event) => setImportMode(event.target.value as ImportMode)}
 									onFocus={() => setIsFocused(true)}
 									onBlur={() => setIsFocused(false)}
-									className="rounded-lg border bg-card/50 backdrop-blur-sm px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none appearance-none cursor-pointer min-w-[200px]"
+									className="rounded-lg border bg-card/50 backdrop-blur-xs px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden appearance-none cursor-pointer min-w-[200px]"
 									style={{
 										borderColor: isFocused ? themeGradient.from : "hsl(var(--border) / 0.5)",
 										boxShadow: isFocused ? `0 0 0 1px ${themeGradient.from}` : undefined,

--- a/apps/web/src/features/search/components/filter-controls.tsx
+++ b/apps/web/src/features/search/components/filter-controls.tsx
@@ -97,7 +97,7 @@ export const FilterControls = ({
 						onBlur={() => setIsFocused(false)}
 						onMouseEnter={() => setIsHovered(true)}
 						onMouseLeave={() => setIsHovered(false)}
-						className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none"
+						className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden"
 						style={selectStyle}
 					>
 						{PROTOCOL_FILTERS.map((option) => (

--- a/apps/web/src/features/search/components/search-results-table.tsx
+++ b/apps/web/src/features/search/components/search-results-table.tsx
@@ -182,9 +182,9 @@ export const SearchResultsTable = ({
 						return (
 							<PremiumTableRow key={key} className="align-top">
 								<td className="px-4 py-4 text-foreground">
-									<div className="space-y-3 break-words">
+									<div className="space-y-3 wrap-break-word">
 										<div className="flex flex-wrap items-center gap-2">
-											<span className="font-semibold leading-tight break-words">
+											<span className="font-semibold leading-tight wrap-break-word">
 												{incognitoMode ? getLinuxIsoName(result.title) : result.title}
 											</span>
 											<StatusBadge status={result.protocol === "torrent" ? "success" : "info"}>
@@ -243,7 +243,7 @@ export const SearchResultsTable = ({
 										) : null}
 
 										{rejectionMessage ? (
-											<div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-xs leading-relaxed text-red-100 whitespace-pre-wrap break-words">
+											<div className="rounded-lg border border-red-400/30 bg-red-500/10 px-3 py-2 text-xs leading-relaxed text-red-100 whitespace-pre-wrap wrap-break-word">
 												{rejectionMessage}
 											</div>
 										) : null}

--- a/apps/web/src/features/search/components/sort-controls.tsx
+++ b/apps/web/src/features/search/components/sort-controls.tsx
@@ -60,7 +60,7 @@ export const SortControls = ({
 					onBlur={() => setIsFocused(false)}
 					onMouseEnter={() => setIsHovered(true)}
 					onMouseLeave={() => setIsHovered(false)}
-					className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none"
+					className="w-full rounded-md border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden"
 					style={selectStyle}
 				>
 					{SORT_OPTIONS.map((option) => (

--- a/apps/web/src/features/settings/components/account-tab.tsx
+++ b/apps/web/src/features/settings/components/account-tab.tsx
@@ -62,7 +62,7 @@ export const AccountTab = ({
 	const { gradient: themeGradient } = useThemeGradient();
 
 	return (
-		<div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+		<div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
 			{/* Main form section */}
 			<PremiumSection
 				title="Account Information"

--- a/apps/web/src/features/settings/components/appearance-tab.tsx
+++ b/apps/web/src/features/settings/components/appearance-tab.tsx
@@ -47,7 +47,7 @@ export function AppearanceTab() {
 		return (
 			<div className="relative min-h-[600px]">
 				<div className="absolute inset-0 flex items-center justify-center">
-					<div className="h-16 w-16 rounded-full bg-gradient-to-br from-primary/20 to-primary/5 animate-pulse" />
+					<div className="h-16 w-16 rounded-full bg-linear-to-br from-primary/20 to-primary/5 animate-pulse" />
 				</div>
 			</div>
 		);
@@ -174,7 +174,7 @@ export function AppearanceTab() {
 				</div>
 
 				{/* Main Grid Layout */}
-				<div className="grid gap-6 lg:grid-cols-[1fr,380px]">
+				<div className="grid gap-6 lg:grid-cols-[1fr_380px]">
 					{/* Left Column - Controls */}
 					<div className="space-y-6">
 						{/* Color Scheme Toggle */}
@@ -183,7 +183,7 @@ export function AppearanceTab() {
 							style={{ animationDelay: "100ms" }}
 						>
 							<div className={cn(
-								"rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 transition-opacity duration-300",
+								"rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6 transition-opacity duration-300",
 								isImmersive && "opacity-60"
 							)}>
 								<h3 className="text-sm font-medium text-foreground mb-4 flex items-center gap-2">
@@ -268,7 +268,7 @@ export function AppearanceTab() {
 								className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 								style={{ animationDelay: "150ms" }}
 							>
-								<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6">
+								<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6">
 									<h3 className="text-sm font-medium text-foreground mb-4 flex items-center gap-2">
 										<span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
 										OLED Mode
@@ -332,7 +332,7 @@ export function AppearanceTab() {
 							className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 							style={{ animationDelay: "200ms" }}
 						>
-							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6">
+							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6">
 								<h3 className="text-sm font-medium text-foreground mb-2 flex items-center gap-2">
 									<span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
 									Standard Themes
@@ -443,7 +443,7 @@ export function AppearanceTab() {
 							className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 							style={{ animationDelay: "250ms" }}
 						>
-							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 relative overflow-hidden">
+							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6 relative overflow-hidden">
 								{/* Subtle background effect for immersive section */}
 								<div className="absolute inset-0 opacity-[0.03] pointer-events-none">
 									<div className="absolute inset-0" style={{
@@ -463,7 +463,7 @@ export function AppearanceTab() {
 											background: "linear-gradient(135deg, #ff00ff, #00ffff)",
 										}} />
 										Immersive Themes
-										<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-gradient-to-r from-purple-500/20 to-cyan-500/20 text-muted-foreground border border-purple-500/20">
+										<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-linear-to-r from-purple-500/20 to-cyan-500/20 text-muted-foreground border border-purple-500/20">
 											<Zap className="inline h-3 w-3 mr-1 -mt-0.5" />
 											Special Effects
 										</span>
@@ -598,7 +598,7 @@ export function AppearanceTab() {
 							className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 							style={{ animationDelay: "300ms" }}
 						>
-							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6 relative overflow-hidden">
+							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6 relative overflow-hidden">
 								{/* Premium shimmer background */}
 								<div className="absolute inset-0 opacity-[0.02] pointer-events-none overflow-hidden">
 									<div
@@ -628,12 +628,12 @@ export function AppearanceTab() {
 										/>
 										Premium Themes
 										{premiumUnlocked ? (
-											<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-gradient-to-r from-green-500/20 to-emerald-500/20 text-green-600 dark:text-green-400 border border-green-500/20">
+											<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-linear-to-r from-green-500/20 to-emerald-500/20 text-green-600 dark:text-green-400 border border-green-500/20">
 												<Zap className="inline h-3 w-3 mr-1 -mt-0.5" />
 												Unlocked (Dev)
 											</span>
 										) : (
-											<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-gradient-to-r from-amber-500/20 to-orange-500/20 text-amber-600 dark:text-amber-400 border border-amber-500/20">
+											<span className="ml-auto text-[10px] font-medium px-2 py-0.5 rounded-full bg-linear-to-r from-amber-500/20 to-orange-500/20 text-amber-600 dark:text-amber-400 border border-amber-500/20">
 												<Crown className="inline h-3 w-3 mr-1 -mt-0.5" />
 												Coming Soon
 											</span>
@@ -831,7 +831,7 @@ export function AppearanceTab() {
 						style={{ animationDelay: "300ms" }}
 					>
 						<div className="sticky top-6">
-							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-sm p-6">
+							<div className="rounded-2xl border border-border/50 bg-card/50 backdrop-blur-xs p-6">
 								<h3 className="text-sm font-medium text-foreground mb-4 flex items-center gap-2">
 									<span className="inline-block h-1.5 w-1.5 rounded-full bg-primary" />
 									Live Preview

--- a/apps/web/src/features/settings/components/backup-tab.tsx
+++ b/apps/web/src/features/settings/components/backup-tab.tsx
@@ -871,7 +871,7 @@ export const BackupTab = () => {
 			{/* Restore Backup Modal */}
 			{showBackupRestoreModal && selectedBackupForRestore && (
 				<div
-					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-sm"
+					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-xs"
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby="restore-backup-title"
@@ -937,7 +937,7 @@ export const BackupTab = () => {
 			{/* Server Restarting Modal */}
 			{isRestarting && (
 				<div
-					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-sm"
+					className="fixed inset-0 z-modal flex items-center justify-center bg-black/80 backdrop-blur-xs"
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby="server-restarting-title"

--- a/apps/web/src/features/settings/components/passkey-section.tsx
+++ b/apps/web/src/features/settings/components/passkey-section.tsx
@@ -271,7 +271,7 @@ export const PasskeySection = () => {
 								{credentials.map((credential, index) => (
 									<div
 										key={credential.id}
-										className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
+										className="flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
 										style={{
 											animationDelay: `${index * 50}ms`,
 											animationFillMode: "backwards",

--- a/apps/web/src/features/settings/components/service-instance-card.tsx
+++ b/apps/web/src/features/settings/components/service-instance-card.tsx
@@ -91,7 +91,7 @@ export const ServiceInstanceCard = ({
 				"group relative rounded-2xl border overflow-hidden transition-all duration-300",
 				"animate-in fade-in slide-in-from-bottom-2",
 				instance.enabled
-					? "border-border/50 bg-card/30 backdrop-blur-sm hover:border-border/80"
+					? "border-border/50 bg-card/30 backdrop-blur-xs hover:border-border/80"
 					: "border-border/30 bg-card/20 opacity-60"
 			)}
 			style={{
@@ -171,7 +171,7 @@ export const ServiceInstanceCard = ({
 							size="sm"
 							onClick={() => onTestConnection(instance)}
 							disabled={isTesting}
-							className="gap-1.5 border-border/50 bg-card/50 backdrop-blur-sm hover:bg-card/80"
+							className="gap-1.5 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
 						>
 							{isTesting ? (
 								<Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/apps/web/src/features/settings/components/settings-client.tsx
+++ b/apps/web/src/features/settings/components/settings-client.tsx
@@ -225,7 +225,7 @@ export const SettingsClient = () => {
 						role="tabpanel"
 						id="settings-panel-services"
 						aria-labelledby="settings-tab-services"
-						className="grid gap-6 xl:grid-cols-[2fr,1fr]"
+						className="grid gap-6 xl:grid-cols-[2fr_1fr]"
 					>
 						<ServicesTab
 							services={services}

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -126,7 +126,7 @@ interface SystemInfoCardProps {
 function SystemInfoCard({ icon, label, value, subtitle, animationDelay = 0 }: SystemInfoCardProps) {
 	return (
 		<div
-			className="flex items-start gap-3 p-4 rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
+			className="flex items-start gap-3 p-4 rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
 			style={{
 				animationDelay: `${animationDelay}ms`,
 				animationFillMode: "backwards",

--- a/apps/web/src/features/settings/components/tag-list-item.tsx
+++ b/apps/web/src/features/settings/components/tag-list-item.tsx
@@ -39,7 +39,7 @@ export const TagListItem = ({
 
 	return (
 		<li
-			className="group flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm px-4 py-3 transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
+			className="group flex items-center justify-between rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs px-4 py-3 transition-all duration-300 hover:border-border/80 animate-in fade-in slide-in-from-bottom-2"
 			style={{
 				animationDelay: `${animationDelay}ms`,
 				animationFillMode: "backwards",

--- a/apps/web/src/features/settings/components/tags-tab.tsx
+++ b/apps/web/src/features/settings/components/tags-tab.tsx
@@ -51,7 +51,7 @@ export const TagsTab = ({
 	const { gradient: themeGradient } = useThemeGradient();
 
 	return (
-		<div className="grid gap-6 lg:grid-cols-[1fr,2fr]">
+		<div className="grid gap-6 lg:grid-cols-[1fr_2fr]">
 			{/* Create tag form */}
 			<GlassmorphicCard padding="lg">
 				<div className="space-y-4">

--- a/apps/web/src/features/settings/lib/settings-constants.ts
+++ b/apps/web/src/features/settings/lib/settings-constants.ts
@@ -12,7 +12,7 @@ export const SERVICE_TYPES: ServiceType[] = ["sonarr", "radarr", "prowlarr"];
  * @see lib/theme-input-styles.ts for focus style utilities
  */
 export const SELECT_CLASS =
-	"w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 hover:border-border/80 focus:outline-none";
+	"w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 hover:border-border/80 focus:outline-hidden";
 
 export const OPTION_STYLE = {
 	backgroundColor: "hsl(var(--color-bg))",

--- a/apps/web/src/features/setup/components/setup-client.tsx
+++ b/apps/web/src/features/setup/components/setup-client.tsx
@@ -49,7 +49,7 @@ export const SetupClient = () => {
 			</div>
 
 			{/* Setup Card */}
-			<Card className="border-border/50 bg-card/80 backdrop-blur-sm">
+			<Card className="border-border/50 bg-card/80 backdrop-blur-xs">
 				<CardHeader>
 					<CardTitle className="text-xl text-foreground">Create Admin Account</CardTitle>
 					<CardDescription className="text-muted-foreground">

--- a/apps/web/src/features/statistics/components/statistics-client.tsx
+++ b/apps/web/src/features/statistics/components/statistics-client.tsx
@@ -172,7 +172,7 @@ export const StatisticsClient = () => {
 				className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 				style={{ animationDelay: "100ms", animationFillMode: "backwards" }}
 			>
-				<div className="inline-flex rounded-xl bg-card/30 backdrop-blur-sm border border-border/50 p-1.5">
+				<div className="inline-flex rounded-xl bg-card/30 backdrop-blur-xs border border-border/50 p-1.5">
 					{tabs.map((tab) => {
 						const Icon = tab.icon;
 						const isActive = activeTab === tab.id;
@@ -289,7 +289,7 @@ export const StatisticsClient = () => {
 						</PremiumCard>
 					) : (
 						<div
-							className="flex items-center gap-4 p-6 rounded-2xl border border-border/50 bg-emerald-500/10 backdrop-blur-sm animate-in fade-in slide-in-from-bottom-4 duration-500"
+							className="flex items-center gap-4 p-6 rounded-2xl border border-border/50 bg-emerald-500/10 backdrop-blur-xs animate-in fade-in slide-in-from-bottom-4 duration-500"
 							style={{ animationDelay: "200ms", animationFillMode: "backwards" }}
 						>
 							<div
@@ -357,7 +357,7 @@ export const StatisticsClient = () => {
 						style={{ animationDelay: "400ms", animationFillMode: "backwards" }}
 					>
 						{/* Sonarr Card */}
-						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 overflow-hidden transition-all duration-300 hover:border-border">
+						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 overflow-hidden transition-all duration-300 hover:border-border">
 							<div
 								className="absolute inset-0 opacity-0 group-hover:opacity-20 transition-opacity duration-500"
 								style={{ background: `radial-gradient(circle at 50% 0%, ${SERVICE_GRADIENTS.sonarr.glow}, transparent 70%)` }}
@@ -407,7 +407,7 @@ export const StatisticsClient = () => {
 						</div>
 
 						{/* Radarr Card */}
-						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 overflow-hidden transition-all duration-300 hover:border-border">
+						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 overflow-hidden transition-all duration-300 hover:border-border">
 							<div
 								className="absolute inset-0 opacity-0 group-hover:opacity-20 transition-opacity duration-500"
 								style={{ background: `radial-gradient(circle at 50% 0%, ${SERVICE_GRADIENTS.radarr.glow}, transparent 70%)` }}
@@ -457,7 +457,7 @@ export const StatisticsClient = () => {
 						</div>
 
 						{/* Prowlarr Card */}
-						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 overflow-hidden transition-all duration-300 hover:border-border">
+						<div className="group relative rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 overflow-hidden transition-all duration-300 hover:border-border">
 							<div
 								className="absolute inset-0 opacity-0 group-hover:opacity-20 transition-opacity duration-500"
 								style={{ background: `radial-gradient(circle at 50% 0%, ${SERVICE_GRADIENTS.prowlarr.glow}, transparent 70%)` }}

--- a/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
@@ -108,7 +108,7 @@ const SyncStrategySelector = ({
 				disabled={disabled}
 				className={cn(
 					"flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition-all duration-200",
-					"border-border/50 bg-card/50 backdrop-blur-sm hover:bg-card/80",
+					"border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80",
 					disabled && "opacity-50 cursor-not-allowed"
 				)}
 			>
@@ -346,7 +346,7 @@ export const BulkDeploymentModal = ({
 
 			<LegacyDialogContent className="space-y-5">
 				{/* Instance Selection with Per-Instance Strategy */}
-				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 					<div className="flex items-center justify-between mb-3">
 						<h3 className="text-sm font-semibold text-foreground">
 							Select Instances ({selectedCount} / {instancePreviews.length})
@@ -487,7 +487,7 @@ export const BulkDeploymentModal = ({
 
 				{/* Summary Statistics */}
 				{allPreviewsLoaded && (
-					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 						<h3 className="text-sm font-semibold text-foreground mb-3">Deployment Summary</h3>
 						<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
 							<div className="space-y-1">

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -409,7 +409,7 @@ export function BulkScoreManager({
 	return (
 		<div className="space-y-6 animate-in fade-in duration-300">
 			{/* Header */}
-			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6">
+			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6">
 				<div className="flex items-center gap-4 mb-6">
 					<div
 						className="flex h-12 w-12 items-center justify-center rounded-xl shrink-0"
@@ -444,7 +444,7 @@ export function BulkScoreManager({
 						<select
 							value={instanceId}
 							onChange={(e) => setInstanceId(e.target.value)}
-							className="w-full appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 pr-10 text-sm font-medium text-foreground focus:outline-none focus:ring-2 transition-all"
+							className="w-full appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 pr-10 text-sm font-medium text-foreground focus:outline-hidden focus:ring-2 transition-all"
 							style={{ ["--tw-ring-color" as string]: themeGradient.from }}
 						>
 							<option value="">Select Instance</option>
@@ -467,7 +467,7 @@ export function BulkScoreManager({
 							placeholder="Search custom formats..."
 							value={searchTerm}
 							onChange={(e) => setSearchTerm(e.target.value)}
-							className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 transition-all"
+							className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 transition-all"
 							style={{ ["--tw-ring-color" as string]: themeGradient.from, paddingLeft: "2.5rem" }}
 						/>
 					</div>
@@ -605,12 +605,12 @@ export function BulkScoreManager({
 			)}
 
 			{/* Scores Table */}
-			<div className="overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm">
+			<div className="overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs">
 				<div className="overflow-x-auto">
 					<table className="w-full table-fixed">
 						<thead>
 							<tr className="border-b border-border/50">
-								<th className="sticky left-0 z-sticky w-12 bg-card/95 backdrop-blur-sm px-3 py-4 text-center">
+								<th className="sticky left-0 z-sticky w-12 bg-card/95 backdrop-blur-xs px-3 py-4 text-center">
 									<button
 										type="button"
 										onClick={toggleSelectAll}
@@ -630,7 +630,7 @@ export function BulkScoreManager({
 										)}
 									</button>
 								</th>
-								<th className="sticky left-12 z-10 w-64 bg-card/95 backdrop-blur-sm px-4 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								<th className="sticky left-12 z-10 w-64 bg-card/95 backdrop-blur-xs px-4 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 									Custom Format
 								</th>
 								{/* Dynamic columns for each unique template */}
@@ -679,7 +679,7 @@ export function BulkScoreManager({
 											animationFillMode: "backwards",
 										}}
 									>
-										<td className="sticky left-0 z-sticky bg-card/95 backdrop-blur-sm px-3 py-3 text-center">
+										<td className="sticky left-0 z-sticky bg-card/95 backdrop-blur-xs px-3 py-3 text-center">
 											<button
 												type="button"
 												onClick={() => toggleCFSelection(score.trashId)}
@@ -699,7 +699,7 @@ export function BulkScoreManager({
 												)}
 											</button>
 										</td>
-										<td className="sticky left-12 z-10 bg-card/95 backdrop-blur-sm px-4 py-3 text-sm">
+										<td className="sticky left-12 z-10 bg-card/95 backdrop-blur-xs px-4 py-3 text-sm">
 											<div className="flex items-center gap-2">
 												<span className="font-medium text-foreground">{score.name}</span>
 												{score.hasAnyModifications && (
@@ -737,7 +737,7 @@ export function BulkScoreManager({
 																const newScore = parseInt(e.target.value) || 0;
 																handleScoreChange(score.trashId, templateScore.templateId, newScore);
 															}}
-															className="w-full rounded-xl border px-3 py-2 text-center text-sm font-medium transition-all duration-200 focus:outline-none focus:ring-2"
+															className="w-full rounded-xl border px-3 py-2 text-center text-sm font-medium transition-all duration-200 focus:outline-hidden focus:ring-2"
 															style={{
 																borderColor: showOverrideUI
 																	? themeGradient.from

--- a/apps/web/src/features/trash-guides/components/condition-editor.tsx
+++ b/apps/web/src/features/trash-guides/components/condition-editor.tsx
@@ -197,9 +197,9 @@ export function ConditionEditor({
 												{pattern}
 											</code>
 											{isValid ? (
-												<CheckCircle className="h-3 w-3 text-green-400 flex-shrink-0" />
+												<CheckCircle className="h-3 w-3 text-green-400 shrink-0" />
 											) : (
-												<AlertCircle className="h-3 w-3 text-red-400 flex-shrink-0" />
+												<AlertCircle className="h-3 w-3 text-red-400 shrink-0" />
 											)}
 										</div>
 									)}
@@ -243,7 +243,7 @@ export function ConditionEditor({
 											});
 										}}
 										rows={2}
-										className="w-full rounded-xl border border-border bg-card px-4 py-3 text-xs font-mono text-foregroundplaceholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
+										className="w-full rounded-xl border border-border bg-card px-4 py-3 text-xs font-mono text-foregroundplaceholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
 										placeholder="Enter regex pattern..."
 									/>
 									<p className="text-xs text-muted-foreground mt-2">

--- a/apps/web/src/features/trash-guides/components/custom-formats-browser.tsx
+++ b/apps/web/src/features/trash-guides/components/custom-formats-browser.tsx
@@ -414,7 +414,7 @@ export const CustomFormatsBrowser = () => {
 		return (
 			<div className="space-y-6 animate-in fade-in duration-300">
 				{/* Header Skeleton */}
-				<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6">
+				<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6">
 					<div className="space-y-4">
 						<div className="flex items-center gap-4">
 							<PremiumSkeleton variant="card" className="h-12 w-12 rounded-xl" />
@@ -444,7 +444,7 @@ export const CustomFormatsBrowser = () => {
 	if (error) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm"
+				className="rounded-2xl border p-6 backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.error.bg,
 					borderColor: SEMANTIC_COLORS.error.border,
@@ -471,7 +471,7 @@ export const CustomFormatsBrowser = () => {
 	return (
 		<div className="space-y-6 animate-in fade-in duration-300">
 			{/* Header and Controls */}
-			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6">
+			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6">
 				<div className="space-y-5">
 					{/* Title */}
 					<div className="flex items-center gap-4">
@@ -511,7 +511,7 @@ export const CustomFormatsBrowser = () => {
 									setSelectedService(e.target.value as "RADARR" | "SONARR" | "ALL");
 									setSelectedFormats(new Set());
 								}}
-								className="appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 pr-10 text-sm font-medium text-foreground focus:outline-none focus:ring-2 transition-all"
+								className="appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 pr-10 text-sm font-medium text-foreground focus:outline-hidden focus:ring-2 transition-all"
 								style={{ ["--tw-ring-color" as string]: themeGradient.from }}
 							>
 								<option value="ALL">All Services</option>
@@ -529,7 +529,7 @@ export const CustomFormatsBrowser = () => {
 								placeholder="Search custom formats..."
 								value={searchQuery}
 								onChange={(e) => setSearchQuery(e.target.value)}
-								className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 transition-all"
+								className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 transition-all"
 								style={{ ["--tw-ring-color" as string]: themeGradient.from, paddingLeft: "2.5rem" }}
 							/>
 						</div>
@@ -576,7 +576,7 @@ export const CustomFormatsBrowser = () => {
 
 			{/* Custom Formats Grid */}
 			{customFormats.length === 0 ? (
-				<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-sm p-12 text-center">
+				<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-xs p-12 text-center">
 					<Package className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
 					<p className="text-lg font-medium text-foreground mb-2">No custom formats found</p>
 					<p className="text-sm text-muted-foreground">
@@ -614,7 +614,7 @@ export const CustomFormatsBrowser = () => {
 				>
 					{/* Backdrop */}
 					<div
-						className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-in fade-in duration-200"
+						className="absolute inset-0 bg-black/60 backdrop-blur-xs animate-in fade-in duration-200"
 						onClick={() => !deployMutation.isPending && setDeployDialogOpen(false)}
 					/>
 
@@ -698,7 +698,7 @@ export const CustomFormatsBrowser = () => {
 										<select
 											value={selectedInstance}
 											onChange={(e) => setSelectedInstance(e.target.value)}
-											className="w-full appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-3 pr-10 text-sm text-foreground focus:outline-none focus:ring-2 transition-all"
+											className="w-full appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-3 pr-10 text-sm text-foreground focus:outline-hidden focus:ring-2 transition-all"
 											style={{ ["--tw-ring-color" as string]: themeGradient.from }}
 										>
 											<option value="">Choose an instance...</option>
@@ -761,7 +761,7 @@ export const CustomFormatsBrowser = () => {
 				>
 					{/* Backdrop */}
 					<div
-						className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-in fade-in duration-200"
+						className="absolute inset-0 bg-black/60 backdrop-blur-xs animate-in fade-in duration-200"
 						onClick={() => setDetailsDialogOpen(false)}
 					/>
 

--- a/apps/web/src/features/trash-guides/components/deployment-history-details-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-history-details-modal.tsx
@@ -78,7 +78,7 @@ export function DeploymentHistoryDetailsModal({
 				{data?.data && (
 					<>
 						{/* Overview Section */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">Overview</h3>
 							<div className="grid grid-cols-2 gap-4">
 								<InfoField
@@ -113,7 +113,7 @@ export function DeploymentHistoryDetailsModal({
 						</div>
 
 						{/* Instance & Template Section */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">
 								Instance & Template
 							</h3>
@@ -151,7 +151,7 @@ export function DeploymentHistoryDetailsModal({
 						</div>
 
 						{/* Results Section */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">Results</h3>
 							<div className="grid grid-cols-3 gap-4">
 								<div className="space-y-1">
@@ -305,7 +305,7 @@ export function DeploymentHistoryDetailsModal({
 
 						{/* Backup Info Section */}
 						{data.data.backup && (
-							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 								<h3 className="text-sm font-medium text-foreground mb-3">Backup</h3>
 								<InfoField
 									label="Backup Created"

--- a/apps/web/src/features/trash-guides/components/deployment-history-table.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-history-table.tsx
@@ -116,7 +116,7 @@ export function DeploymentHistoryTable({
 	// Loading State
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center p-12 rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm">
+			<div className="flex items-center justify-center p-12 rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs">
 				<div
 					className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"
 					style={{ borderColor: `${themeGradient.from}40`, borderTopColor: "transparent" }}
@@ -130,7 +130,7 @@ export function DeploymentHistoryTable({
 	if (error) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm"
+				className="rounded-2xl border p-6 backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.error.bg,
 					borderColor: SEMANTIC_COLORS.error.border,
@@ -150,7 +150,7 @@ export function DeploymentHistoryTable({
 	// Empty State
 	if (!data?.data?.history || data.data.history.length === 0) {
 		return (
-			<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-sm p-12 text-center">
+			<div className="rounded-2xl border border-dashed border-border/50 bg-card/20 backdrop-blur-xs p-12 text-center">
 				<History className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
 				<p className="text-lg font-medium text-foreground mb-2">No deployment history</p>
 				<p className="text-sm text-muted-foreground">
@@ -175,7 +175,7 @@ export function DeploymentHistoryTable({
 	return (
 		<div className="space-y-4 animate-in fade-in duration-300">
 			{/* Table Container */}
-			<div className="overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm">
+			<div className="overflow-hidden rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs">
 				<div className="overflow-x-auto">
 					<table className="w-full">
 						<thead>

--- a/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
@@ -268,7 +268,7 @@ export const DeploymentPreviewModal = ({
 				{data?.data && (
 					<>
 						{/* Instance Status */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<div className="flex items-center gap-3 mb-3">
 								<Server className="h-5 w-5 text-muted-foreground" />
 								<div className="flex-1">
@@ -312,7 +312,7 @@ export const DeploymentPreviewModal = ({
 						</div>
 
 						{/* Sync Strategy Selector */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">
 								Update Behavior
 							</h3>
@@ -430,7 +430,7 @@ export const DeploymentPreviewModal = ({
 						)}
 
 						{/* Summary Statistics */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">
 								Deployment Summary
 							</h3>
@@ -574,7 +574,7 @@ export const DeploymentPreviewModal = ({
 																			}}
 																		>
 																			<p className="font-semibold mb-1.5" style={{ color: SEMANTIC_COLORS.success.from }}>Template:</p>
-																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap break-words text-muted-foreground font-mono text-[10px]">
+																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-muted-foreground font-mono text-[10px]">
 																				{typeof conflict.templateValue === 'object'
 																					? JSON.stringify(conflict.templateValue, null, 2)
 																					: String(conflict.templateValue)}
@@ -588,7 +588,7 @@ export const DeploymentPreviewModal = ({
 																			}}
 																		>
 																			<p className="font-semibold mb-1.5" style={{ color: SEMANTIC_COLORS.warning.from }}>Instance:</p>
-																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap break-words text-muted-foreground font-mono text-[10px]">
+																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-muted-foreground font-mono text-[10px]">
 																				{typeof conflict.instanceValue === 'object'
 																					? JSON.stringify(conflict.instanceValue, null, 2)
 																					: String(conflict.instanceValue)}
@@ -645,7 +645,7 @@ export const DeploymentPreviewModal = ({
 
 						{/* No Changes Message */}
 						{data.data.summary.totalItems === 0 && (
-							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-8 text-center">
+							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-8 text-center">
 								<CheckCircle2 className="h-12 w-12 mx-auto mb-3" style={{ color: SEMANTIC_COLORS.success.from }} />
 								<p className="text-sm font-medium text-foreground">
 									Instance is up to date

--- a/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
@@ -164,7 +164,7 @@ export function EnhancedTemplateExportModal({
 			</div>
 
 			{/* Export Options */}
-			<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+			<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 				<div className="flex items-center gap-2">
 					<Settings2 className="h-4 w-4" style={{ color: themeGradient.from }} />
 					<h4 className="text-sm font-semibold text-foreground">Export Options</h4>
@@ -271,7 +271,7 @@ export function EnhancedTemplateExportModal({
 
 			{/* Metadata */}
 			{options.includeMetadata && (
-				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 					<div className="flex items-center gap-2">
 						<FileJson className="h-4 w-4" style={{ color: themeGradient.from }} />
 						<h4 className="text-sm font-semibold text-foreground">Metadata</h4>
@@ -310,7 +310,7 @@ export function EnhancedTemplateExportModal({
 								onChange={(e) => setCategory(e.target.value)}
 								onFocus={() => setFocusedField("category")}
 								onBlur={() => setFocusedField(null)}
-								className="w-full rounded-lg border bg-card/50 backdrop-blur-sm px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none appearance-none cursor-pointer"
+								className="w-full rounded-lg border bg-card/50 backdrop-blur-xs px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden appearance-none cursor-pointer"
 								style={{
 									borderColor: focusedField === "category" ? themeGradient.from : "hsl(var(--border) / 0.5)",
 									boxShadow: focusedField === "category" ? `0 0 0 1px ${themeGradient.from}` : undefined,
@@ -359,7 +359,7 @@ export function EnhancedTemplateExportModal({
 								onBlur={() => setFocusedField(null)}
 								placeholder="Additional notes about this template..."
 								rows={3}
-								className="w-full rounded-xl border bg-card/50 backdrop-blur-sm px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 focus:outline-none resize-none"
+								className="w-full rounded-xl border bg-card/50 backdrop-blur-xs px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 focus:outline-hidden resize-none"
 								style={{
 									borderColor: focusedField === "notes" ? themeGradient.from : "hsl(var(--border) / 0.5)",
 									boxShadow: focusedField === "notes" ? `0 0 0 1px ${themeGradient.from}` : undefined,

--- a/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
@@ -282,7 +282,7 @@ export function EnhancedTemplateImportModal({
 
 					{/* Conflicts */}
 					{hasConflicts && (
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 							<div className="flex items-center gap-2">
 								<AlertTriangle className="h-4 w-4 text-muted-foreground" />
 								<span className="font-medium text-sm text-foreground">
@@ -309,7 +309,7 @@ export function EnhancedTemplateImportModal({
 														onNameConflict: e.target.value as "rename" | "replace" | "cancel",
 													})
 												}
-												className="w-full rounded-lg border bg-card/50 backdrop-blur-sm px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none appearance-none cursor-pointer"
+												className="w-full rounded-lg border bg-card/50 backdrop-blur-xs px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden appearance-none cursor-pointer"
 												style={{
 													borderColor: focusedSelect ? themeGradient.from : "hsl(var(--border) / 0.5)",
 													boxShadow: focusedSelect ? `0 0 0 1px ${themeGradient.from}` : undefined,
@@ -356,7 +356,7 @@ export function EnhancedTemplateImportModal({
 
 			{/* Import Options */}
 			{validation && validation.valid && (
-				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+				<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 					<div className="flex items-center gap-2">
 						<Settings2 className="h-4 w-4" style={{ color: themeGradient.from }} />
 						<h4 className="text-sm font-semibold text-foreground">Import Options</h4>

--- a/apps/web/src/features/trash-guides/components/pattern-tester.tsx
+++ b/apps/web/src/features/trash-guides/components/pattern-tester.tsx
@@ -172,7 +172,7 @@ export function PatternTester({
 						setSelectedPreset(null);
 					}}
 					rows={6}
-					className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm font-mono text-foregroundplaceholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
+					className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm font-mono text-foregroundplaceholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
 					placeholder="Enter release names or file names to test..."
 				/>
 			</div>
@@ -200,9 +200,9 @@ export function PatternTester({
 								>
 									<div className="flex items-start gap-3">
 										{finalMatch ? (
-											<CheckCircle className="h-5 w-5 text-green-400 flex-shrink-0 mt-0.5" />
+											<CheckCircle className="h-5 w-5 text-green-400 shrink-0 mt-0.5" />
 										) : (
-											<XCircle className="h-5 w-5 text-red-400 flex-shrink-0 mt-0.5" />
+											<XCircle className="h-5 w-5 text-red-400 shrink-0 mt-0.5" />
 										)}
 
 										<div className="flex-1 min-w-0">
@@ -223,7 +223,7 @@ export function PatternTester({
 											)}
 										</div>
 
-										<div className="text-xs font-medium flex-shrink-0">
+										<div className="text-xs font-medium shrink-0">
 											{finalMatch ? (
 												<span className="text-green-400">Match</span>
 											) : (
@@ -242,7 +242,7 @@ export function PatternTester({
 									className="rounded border border-amber-500/30 bg-amber-500/10 p-3"
 								>
 									<div className="flex items-start gap-3">
-										<AlertCircle className="h-5 w-5 text-amber-400 flex-shrink-0 mt-0.5" />
+										<AlertCircle className="h-5 w-5 text-amber-400 shrink-0 mt-0.5" />
 										<div className="flex-1 min-w-0">
 											<code className="text-xs font-mono text-foregroundbreak-all">
 												{line}

--- a/apps/web/src/features/trash-guides/components/promote-override-dialog.tsx
+++ b/apps/web/src/features/trash-guides/components/promote-override-dialog.tsx
@@ -97,7 +97,7 @@ export function PromoteOverrideDialog({
 			role="presentation"
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -160,7 +160,7 @@ export function PromoteOverrideDialog({
 						}}
 					>
 						<AlertTriangle
-							className="h-5 w-5 flex-shrink-0 mt-0.5"
+							className="h-5 w-5 shrink-0 mt-0.5"
 							style={{ color: SEMANTIC_COLORS.warning.from }}
 						/>
 						<div className="text-sm" style={{ color: SEMANTIC_COLORS.warning.text }}>
@@ -172,7 +172,7 @@ export function PromoteOverrideDialog({
 					</div>
 
 					{/* Score Details */}
-					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 						<div className="flex items-center gap-2 mb-3">
 							<Layers className="h-4 w-4" style={{ color: themeGradient.from }} />
 							<span className="text-sm font-semibold text-foreground">Score Details</span>

--- a/apps/web/src/features/trash-guides/components/quality-profile-browser.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-browser.tsx
@@ -68,14 +68,14 @@ export const QualityProfileBrowser = ({
 
 	return (
 		<div
-			className="fixed inset-0 z-modal flex items-center justify-center bg-black/50 backdrop-blur-sm"
+			className="fixed inset-0 z-modal flex items-center justify-center bg-black/50 backdrop-blur-xs"
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="quality-profile-browser-title"
 		>
 			<div className="relative w-full max-w-4xl max-h-[90vh] overflow-hidden rounded-xl border border-border bg-card shadow-xl">
 				{/* Header */}
-				<div className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-card/95 p-6 backdrop-blur">
+				<div className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-card/95 p-6 backdrop-blur-sm">
 					<div>
 						<h2 id="quality-profile-browser-title" className="text-xl font-semibold text-foreground">
 							Browse TRaSH Quality Profiles
@@ -249,7 +249,7 @@ export const QualityProfileBrowser = ({
 												onChange={(e) => setTemplateDescription(e.target.value)}
 												placeholder="Enter template description"
 												rows={4}
-												className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
+												className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
 											/>
 										</div>
 									</div>
@@ -260,7 +260,7 @@ export const QualityProfileBrowser = ({
 				</div>
 
 				{/* Footer */}
-				<div className="sticky bottom-0 flex justify-end gap-2 border-t border-border bg-card/95 p-6 backdrop-blur">
+				<div className="sticky bottom-0 flex justify-end gap-2 border-t border-border bg-card/95 p-6 backdrop-blur-sm">
 					<Button variant="secondary" onClick={onClose}>
 						Cancel
 					</Button>

--- a/apps/web/src/features/trash-guides/components/quality-profile-wizard.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-wizard.tsx
@@ -363,7 +363,7 @@ export const QualityProfileWizard = ({
 	// create a new containing block and break position:fixed
 	return createPortal(
 		<div
-			className="fixed inset-0 z-modal flex items-center justify-center bg-black/70 backdrop-blur-sm"
+			className="fixed inset-0 z-modal flex items-center justify-center bg-black/70 backdrop-blur-xs"
 			onKeyDown={handleKeyDown}
 			role="dialog"
 			aria-modal="true"

--- a/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
+++ b/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
@@ -53,7 +53,7 @@ const StatCard = ({
 
 	return (
 		<div
-			className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 transition-all duration-300 hover:bg-card/50"
+			className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 transition-all duration-300 hover:bg-card/50"
 		>
 			<div className="flex items-center gap-2 mb-3">
 				<div
@@ -110,7 +110,7 @@ export const SchedulerStatusDashboard = () => {
 	// Loading State
 	if (isLoading) {
 		return (
-			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-8 animate-pulse">
+			<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-8 animate-pulse">
 				<div className="space-y-6">
 					<div className="flex items-center justify-between">
 						<div className="space-y-2">
@@ -133,7 +133,7 @@ export const SchedulerStatusDashboard = () => {
 	if (error) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm"
+				className="rounded-2xl border p-6 backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.error.bg,
 					borderColor: SEMANTIC_COLORS.error.border,
@@ -163,7 +163,7 @@ export const SchedulerStatusDashboard = () => {
 	if (!schedulerData) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm"
+				className="rounded-2xl border p-6 backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.info.bg,
 					borderColor: SEMANTIC_COLORS.info.border,
@@ -178,7 +178,7 @@ export const SchedulerStatusDashboard = () => {
 	}
 
 	return (
-		<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
+		<div className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 animate-in fade-in slide-in-from-bottom-4 duration-500">
 			<div className="space-y-6">
 				{/* Header */}
 				<div className="flex items-start justify-between gap-4 flex-wrap">

--- a/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
@@ -158,7 +158,7 @@ export const SyncProgressModal = ({
 			}}
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -168,7 +168,7 @@ export const SyncProgressModal = ({
 				aria-labelledby="sync-progress-title"
 				aria-describedby="sync-progress-description"
 				tabIndex={-1}
-				className="relative w-full max-w-3xl rounded-2xl border border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl outline-none animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
+				className="relative w-full max-w-3xl rounded-2xl border border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl outline-hidden animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
 				style={{
 					boxShadow: `0 25px 50px -12px rgba(0, 0, 0, 0.5), 0 0 0 1px ${themeGradient.from}15`,
 				}}
@@ -317,7 +317,7 @@ export const SyncProgressModal = ({
 							</div>
 
 							{/* Progress Bar */}
-							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 								<div className="mb-2 flex items-center justify-between text-sm">
 									<span className="font-medium text-foreground">{progress.currentStep}</span>
 									<span className="text-muted-foreground">{Math.round(progress.progress)}%</span>
@@ -339,7 +339,7 @@ export const SyncProgressModal = ({
 
 							{/* Statistics */}
 							<div className="grid grid-cols-3 gap-4">
-								<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+								<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 									<p className="text-sm text-muted-foreground">Total Configs</p>
 									<p
 										className="mt-1 text-2xl font-bold"
@@ -389,7 +389,7 @@ export const SyncProgressModal = ({
 								>
 									<div className="flex items-start gap-3">
 										<AlertCircle
-											className="h-5 w-5 flex-shrink-0 mt-0.5"
+											className="h-5 w-5 shrink-0 mt-0.5"
 											style={{ color: SEMANTIC_COLORS.error.from }}
 										/>
 										<div className="flex-1">
@@ -454,7 +454,7 @@ export const SyncProgressModal = ({
 						>
 							<div className="flex items-start gap-3">
 								<XCircle
-									className="h-5 w-5 flex-shrink-0 mt-0.5"
+									className="h-5 w-5 shrink-0 mt-0.5"
 									style={{ color: SEMANTIC_COLORS.error.from }}
 								/>
 								<div>

--- a/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
@@ -329,13 +329,13 @@ export const SyncValidationModal = ({
 			onClick={(e) => e.target === e.currentTarget && onCancel()}
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
 				ref={dialogRef}
 				tabIndex={-1}
-				className="relative w-full max-w-2xl max-h-[90vh] overflow-hidden rounded-2xl border border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl focus:outline-none animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
+				className="relative w-full max-w-2xl max-h-[90vh] overflow-hidden rounded-2xl border border-border/50 bg-card/95 backdrop-blur-xl shadow-2xl focus:outline-hidden animate-in zoom-in-95 slide-in-from-bottom-4 duration-300"
 				style={{
 					boxShadow: `0 25px 50px -12px rgba(0, 0, 0, 0.5), 0 0 0 1px ${themeGradient.from}15`,
 				}}
@@ -428,7 +428,7 @@ export const SyncValidationModal = ({
 									}}
 								>
 									<div className="flex items-start gap-3">
-										<HelpCircle className="h-5 w-5 flex-shrink-0" style={{ color: SEMANTIC_COLORS.warning.from }} />
+										<HelpCircle className="h-5 w-5 shrink-0" style={{ color: SEMANTIC_COLORS.warning.from }} />
 										<div className="flex-1">
 											<h3 className="font-medium" style={{ color: SEMANTIC_COLORS.warning.text }}>
 												Validation Failed
@@ -469,7 +469,7 @@ export const SyncValidationModal = ({
 									}}
 								>
 									<div className="flex items-start gap-3">
-										<XCircle className="h-5 w-5 flex-shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
+										<XCircle className="h-5 w-5 shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
 										<div className="flex-1">
 											<h3 className="font-medium" style={{ color: SEMANTIC_COLORS.error.text }}>
 												Validation Failed
@@ -588,7 +588,7 @@ export const SyncValidationModal = ({
 									}}
 								>
 									<div className="flex items-start gap-3">
-										<AlertCircle className="h-5 w-5 flex-shrink-0" style={{ color: SEMANTIC_COLORS.warning.from }} />
+										<AlertCircle className="h-5 w-5 shrink-0" style={{ color: SEMANTIC_COLORS.warning.from }} />
 										<div className="flex-1">
 											<h3 className="font-medium" style={{ color: SEMANTIC_COLORS.warning.text }}>
 												Warnings
@@ -613,7 +613,7 @@ export const SyncValidationModal = ({
 									}}
 								>
 									<div className="flex items-start gap-3">
-										<Info className="h-5 w-5 flex-shrink-0" style={{ color: themeGradient.from }} />
+										<Info className="h-5 w-5 shrink-0" style={{ color: themeGradient.from }} />
 										<div className="flex-1">
 											<ul className="space-y-1 text-sm text-muted-foreground">
 												{informationalWarnings.map((info, index) => (
@@ -627,9 +627,9 @@ export const SyncValidationModal = ({
 
 							{/* Conflicts */}
 							{hasConflicts && validation.conflicts && (
-								<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+								<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 									<div className="flex items-start gap-3">
-										<Info className="h-5 w-5 flex-shrink-0" style={{ color: themeGradient.from }} />
+										<Info className="h-5 w-5 shrink-0" style={{ color: themeGradient.from }} />
 										<div className="flex-1">
 											<h3 className="font-medium text-foreground">
 												{validation.conflicts.length} Conflict
@@ -727,7 +727,7 @@ export const SyncValidationModal = ({
 							}}
 						>
 							<div className="flex items-start gap-3">
-								<XCircle className="h-5 w-5 flex-shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
+								<XCircle className="h-5 w-5 shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
 								<div className="flex-1">
 									<h3 className="font-medium" style={{ color: SEMANTIC_COLORS.error.text }}>
 										Validation Error

--- a/apps/web/src/features/trash-guides/components/template-diff-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/template-diff-modal.tsx
@@ -399,7 +399,7 @@ export const TemplateDiffModal = ({
 						)}
 
 						{/* Summary Statistics */}
-						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4">
+						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-semibold text-foreground mb-3">Change Summary</h3>
 							<div className="grid grid-cols-2 md:grid-cols-4 gap-4">
 								<div className="space-y-1">
@@ -677,7 +677,7 @@ export const TemplateDiffModal = ({
 
 						{/* No Changes Message */}
 						{data.data.summary.totalChanges === 0 && !data.data.suggestedAdditions?.length && !data.data.suggestedScoreChanges?.length && (
-							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-8 text-center">
+							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-8 text-center">
 								<Check className="h-12 w-12 mx-auto mb-3" style={{ color: SEMANTIC_COLORS.success.from }} />
 								<p className="text-sm font-medium text-foreground">
 									{isHistorical ? "No changes recorded" : "Template is up to date"}

--- a/apps/web/src/features/trash-guides/components/template-editor.tsx
+++ b/apps/web/src/features/trash-guides/components/template-editor.tsx
@@ -312,7 +312,7 @@ export const TemplateEditor = ({ open, onClose, template }: TemplateEditorProps)
 
 	return (
 		<div
-			className="fixed inset-0 z-modal flex items-center justify-center bg-black/50 backdrop-blur-sm"
+			className="fixed inset-0 z-modal flex items-center justify-center bg-black/50 backdrop-blur-xs"
 			role="dialog"
 			aria-modal="true"
 			aria-labelledby="template-editor-title"
@@ -363,7 +363,7 @@ export const TemplateEditor = ({ open, onClose, template }: TemplateEditorProps)
 								onChange={(e) => setDescription(e.target.value)}
 								placeholder="Describe what this template is for..."
 								rows={3}
-								className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
+								className="w-full rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 hover:border-border/80 hover:bg-card/80 focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 focus:bg-card/80"
 							/>
 						</div>
 
@@ -416,7 +416,7 @@ export const TemplateEditor = ({ open, onClose, template }: TemplateEditorProps)
 								</div>
 							</div>
 							<div className="flex items-start gap-2 rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
-								<Shield className="h-4 w-4 text-blue-400 mt-0.5 flex-shrink-0" />
+								<Shield className="h-4 w-4 text-blue-400 mt-0.5 shrink-0" />
 								<div className="text-xs text-muted-foreground">
 									<span className="font-medium text-blue-400">Note:</span> Custom Formats you manually add (marked as &ldquo;User Added&rdquo;) are always preserved regardless of this setting.
 								</div>
@@ -645,7 +645,7 @@ export const TemplateEditor = ({ open, onClose, template }: TemplateEditorProps)
 
 					return (
 						<div
-							className="fixed inset-0 z-popover flex items-center justify-center bg-black/80 backdrop-blur-sm"
+							className="fixed inset-0 z-popover flex items-center justify-center bg-black/80 backdrop-blur-xs"
 							role="dialog"
 							aria-modal="true"
 							aria-label="Condition Editor"

--- a/apps/web/src/features/trash-guides/components/template-import-dialog.tsx
+++ b/apps/web/src/features/trash-guides/components/template-import-dialog.tsx
@@ -138,7 +138,7 @@ export const TemplateImportDialog = ({ open, onClose }: TemplateImportDialogProp
 			role="presentation"
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			<div
@@ -262,7 +262,7 @@ export const TemplateImportDialog = ({ open, onClose }: TemplateImportDialogProp
 							onBlur={() => setIsFocused(false)}
 							placeholder='{"version": "1.0", "template": {...}}'
 							rows={10}
-							className="w-full rounded-xl border bg-card/50 backdrop-blur-sm px-4 py-3 font-mono text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 focus:outline-none resize-none"
+							className="w-full rounded-xl border bg-card/50 backdrop-blur-xs px-4 py-3 font-mono text-sm text-foreground placeholder:text-muted-foreground/60 transition-all duration-200 focus:outline-hidden resize-none"
 							style={{
 								borderColor: isFocused ? themeGradient.from : "hsl(var(--border) / 0.5)",
 								boxShadow: isFocused ? `0 0 0 1px ${themeGradient.from}` : undefined,

--- a/apps/web/src/features/trash-guides/components/template-list.tsx
+++ b/apps/web/src/features/trash-guides/components/template-list.tsx
@@ -241,7 +241,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 	if (error) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm"
+				className="rounded-2xl border p-6 backdrop-blur-xs"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.error.bg,
 					borderColor: SEMANTIC_COLORS.error.border,
@@ -327,7 +327,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 
 			{/* Search and Sort Controls */}
 			<div
-				className="flex flex-col gap-4 rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 sm:flex-row sm:items-center sm:justify-between"
+				className="flex flex-col gap-4 rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 sm:flex-row sm:items-center sm:justify-between"
 			>
 				{/* Search Input */}
 				<div className="flex-1 max-w-md">
@@ -338,7 +338,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 							placeholder="Search templates..."
 							value={searchInput}
 							onChange={(e) => setSearchInput(e.target.value)}
-							className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-border focus:outline-none focus:ring-2 transition-all duration-200"
+							className="w-full rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-border focus:outline-hidden focus:ring-2 transition-all duration-200"
 							style={{ focusRing: `${themeGradient.from}40`, paddingLeft: "2.5rem" } as React.CSSProperties}
 						/>
 					</div>
@@ -349,7 +349,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 					<select
 						value={sortBy}
 						onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
-						className="rounded-xl border border-border/50 bg-card/50 px-3 py-2.5 text-sm text-foreground focus:border-border focus:outline-none focus:ring-2 transition-all duration-200"
+						className="rounded-xl border border-border/50 bg-card/50 px-3 py-2.5 text-sm text-foreground focus:border-border focus:outline-hidden focus:ring-2 transition-all duration-200"
 					>
 						<option value="updatedAt">Last Updated</option>
 						<option value="createdAt">Date Created</option>
@@ -395,7 +395,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 						{templates.map((template, index) => (
 							<article
 								key={template.id}
-								className="group relative flex flex-col rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6 transition-all duration-300 hover:border-border hover:bg-card/50 hover:shadow-lg animate-in fade-in slide-in-from-bottom-2"
+								className="group relative flex flex-col rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6 transition-all duration-300 hover:border-border hover:bg-card/50 hover:shadow-lg animate-in fade-in slide-in-from-bottom-2"
 								style={{
 									animationDelay: `${index * 50}ms`,
 									animationFillMode: "backwards",
@@ -403,7 +403,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 							>
 								{/* Delete Confirmation Overlay */}
 								{deleteConfirm === template.id && (
-									<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 rounded-2xl bg-black/90 backdrop-blur-sm p-6">
+									<div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 rounded-2xl bg-black/90 backdrop-blur-xs p-6">
 										<p className="text-center text-sm text-foreground">
 											Delete &quot;{template.name}&quot;?
 										</p>
@@ -434,14 +434,14 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 
 								{/* Duplicate Dialog Overlay */}
 								{duplicatingId === template.id && (
-									<div className="absolute inset-0 z-10 flex flex-col gap-4 rounded-2xl bg-black/90 backdrop-blur-sm p-6">
+									<div className="absolute inset-0 z-10 flex flex-col gap-4 rounded-2xl bg-black/90 backdrop-blur-xs p-6">
 										<p className="text-sm text-foreground">Duplicate as:</p>
 										<input
 											type="text"
 											value={duplicateName}
 											onChange={(e) => setDuplicateName(e.target.value)}
 											placeholder="New template name"
-											className="rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-border focus:outline-none"
+											className="rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-border focus:outline-hidden"
 											autoFocus
 										/>
 										<div className="flex gap-2">
@@ -675,7 +675,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 			{/* Instance Selector Modal */}
 			{instanceSelectorTemplate && (
 				<div
-					className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
+					className="fixed inset-0 bg-black/80 backdrop-blur-xs flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby="deploy-template-title"
@@ -824,7 +824,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 			{/* Export Modal */}
 			{exportModal && (
 				<div
-					className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
+					className="fixed inset-0 bg-black/80 backdrop-blur-xs flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
 					role="dialog"
 					aria-modal="true"
 					aria-label="Export Template"
@@ -842,7 +842,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 			{/* Import Modal */}
 			{importModal && (
 				<div
-					className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
+					className="fixed inset-0 bg-black/80 backdrop-blur-xs flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
 					role="dialog"
 					aria-modal="true"
 					aria-label="Import Template"
@@ -862,7 +862,7 @@ export const TemplateList = ({ serviceType, onCreateNew, onEdit, onImport, onBro
 			{/* Unlink Confirmation Modal */}
 			{unlinkConfirm && (
 				<div
-					className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
+					className="fixed inset-0 bg-black/80 backdrop-blur-xs flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
 					role="dialog"
 					aria-modal="true"
 					aria-labelledby="unlink-confirm-title"

--- a/apps/web/src/features/trash-guides/components/template-schedule-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/template-schedule-modal.tsx
@@ -153,7 +153,7 @@ export const TemplateScheduleModal = ({
 			onClick={onClose}
 		>
 			{/* Backdrop */}
-			<div className="absolute inset-0 bg-black/70 backdrop-blur-sm" />
+			<div className="absolute inset-0 bg-black/70 backdrop-blur-xs" />
 
 			{/* Modal */}
 			{/* biome-ignore lint/a11y/useSemanticElements: Using custom modal with proper ARIA for consistent styling */}
@@ -226,7 +226,7 @@ export const TemplateScheduleModal = ({
 								border: `1px solid ${SEMANTIC_COLORS.error.border}`,
 							}}
 						>
-							<AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
+							<AlertCircle className="h-4 w-4 mt-0.5 shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
 							<div style={{ color: SEMANTIC_COLORS.error.text }}>
 								<p className="font-medium">Error</p>
 								<p className="text-sm opacity-90">{error}</p>
@@ -280,7 +280,7 @@ export const TemplateScheduleModal = ({
 					</div>
 
 					{/* Options */}
-					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-4">
+					<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4 space-y-4">
 						<h3 className="text-sm font-semibold text-foreground flex items-center gap-2">
 							Sync Options
 						</h3>

--- a/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
+++ b/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
@@ -126,7 +126,7 @@ export const TrashGuidesClient = () => {
 	if (error) {
 		return (
 			<div
-				className="rounded-2xl border p-6 backdrop-blur-sm animate-in fade-in duration-300"
+				className="rounded-2xl border p-6 backdrop-blur-xs animate-in fade-in duration-300"
 				style={{
 					backgroundColor: SEMANTIC_COLORS.error.bg,
 					borderColor: SEMANTIC_COLORS.error.border,
@@ -237,7 +237,7 @@ export const TrashGuidesClient = () => {
 			{/* Refresh Error Alert */}
 			{refreshMutation.isError && (
 				<div
-					className="rounded-2xl border p-4 backdrop-blur-sm animate-in fade-in slide-in-from-top-2 duration-300"
+					className="rounded-2xl border p-4 backdrop-blur-xs animate-in fade-in slide-in-from-top-2 duration-300"
 					style={{
 						backgroundColor: SEMANTIC_COLORS.error.bg,
 						borderColor: SEMANTIC_COLORS.error.border,
@@ -301,7 +301,7 @@ export const TrashGuidesClient = () => {
 					<div className="space-y-6">
 						{/* History Header Card */}
 						<div
-							className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6"
+							className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6"
 						>
 							<div className="flex items-start gap-4">
 								<div
@@ -336,7 +336,7 @@ export const TrashGuidesClient = () => {
 					</div>
 				) : activeTab === "bulk-scores" ? (
 					<div
-						className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-sm p-6"
+						className="rounded-2xl border border-border/50 bg-card/30 backdrop-blur-xs p-6"
 					>
 						{isAuthLoading ? (
 							<div className="flex items-center justify-center py-12">

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
@@ -376,7 +376,7 @@ export const CFConfiguration = ({
 										value={scoreOverride ?? ""}
 										onChange={(e) => updateScore(cfKey, e.target.value)}
 										placeholder={defaultScore.toString()}
-										className="w-20 rounded border border-border/50 bg-background px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/50 transition"
+										className="w-20 rounded border border-border/50 bg-background px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/50 transition"
 									/>
 									{scoreOverride !== undefined && (
 										<button
@@ -418,7 +418,7 @@ export const CFConfiguration = ({
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						placeholder="Search custom formats..."
-						className="w-full rounded-lg border border-border/50 bg-background py-3 pr-4 text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 transition"
+						className="w-full rounded-lg border border-border/50 bg-background py-3 pr-4 text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 transition"
 						style={{ paddingLeft: "2.5rem" }}
 					/>
 				</div>
@@ -656,7 +656,7 @@ export const CFConfiguration = ({
 										value={scoreOverride ?? ""}
 										onChange={(e) => updateScore(cf.trash_id, e.target.value)}
 										placeholder={resolvedDefaultScore.toString()}
-										className="w-20 rounded border border-border/50 bg-background px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/50 transition"
+										className="w-20 rounded border border-border/50 bg-background px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/50 transition"
 									/>
 									{scoreOverride !== undefined && (
 										<button
@@ -807,7 +807,7 @@ export const CFConfiguration = ({
 														{isSelected && (
 															<div className="flex items-center gap-2">
 																<label className="text-xs text-muted-foreground">Score (Default: {displayScore}):</label>
-																<input type="number" value={scoreOverride ?? ""} onChange={(e) => updateScore(cf.trash_id, e.target.value)} placeholder={String(displayScore)} className="w-24 rounded border border-border bg-muted px-2 py-1 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary" onClick={(e) => e.stopPropagation()} />
+																<input type="number" value={scoreOverride ?? ""} onChange={(e) => updateScore(cf.trash_id, e.target.value)} placeholder={String(displayScore)} className="w-24 rounded border border-border bg-muted px-2 py-1 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary" onClick={(e) => e.stopPropagation()} />
 																{scoreOverride !== undefined && (
 																	<button type="button" onClick={(e) => { e.stopPropagation(); updateScore(cf.trash_id, ""); }} className="text-xs text-primary hover:text-primary/80 transition" title="Reset to default">↺ Reset</button>
 																)}
@@ -863,7 +863,7 @@ export const CFConfiguration = ({
 
 				return (
 					<div
-						className="fixed inset-0 z-popover flex items-center justify-center bg-background/80 backdrop-blur-sm"
+						className="fixed inset-0 z-popover flex items-center justify-center bg-background/80 backdrop-blur-xs"
 						role="dialog"
 						aria-modal="true"
 						aria-label="Condition Editor"
@@ -933,7 +933,7 @@ export const CFConfiguration = ({
 					value={searchQuery}
 					onChange={(e) => setSearchQuery(e.target.value)}
 					placeholder="Search custom formats by name or description..."
-					className="w-full rounded-lg border border-border/50 bg-card pr-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20 transition"
+					className="w-full rounded-lg border border-border/50 bg-card pr-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-hidden focus:ring-2 focus:ring-primary/20 transition"
 					style={{ paddingLeft: "2.5rem" }}
 				/>
 				{searchQuery && (
@@ -1126,9 +1126,9 @@ export const CFConfiguration = ({
 						return (
 							<Card key={group.trash_id} className={`transition-all hover:shadow-lg ${
 								isGroupDefault
-									? "!border-amber-500/50 !bg-amber-500/10"
+									? "border-amber-500/50! bg-amber-500/10!"
 									: isGroupRequired
-										? "!border-red-500/50 !bg-red-500/10"
+										? "border-red-500/50! bg-red-500/10!"
 										: "hover:border-primary/20"
 							}`}>
 								<CardHeader>
@@ -1187,7 +1187,7 @@ export const CFConfiguration = ({
 											}}
 										>
 											<div className="flex items-start gap-2">
-												<AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" style={{ color: themeGradient.from }} />
+												<AlertCircle className="h-4 w-4 mt-0.5 shrink-0" style={{ color: themeGradient.from }} />
 												<div
 													className="text-sm"
 													style={{ color: themeGradient.from }}
@@ -1424,7 +1424,7 @@ export const CFConfiguration = ({
 																		}));
 																	}}
 																	placeholder={`Default: ${displayScore}`}
-																	className="w-28 rounded border border-border bg-muted px-3 py-1.5 text-sm text-foregroundfocus:border-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
+																	className="w-28 rounded border border-border bg-muted px-3 py-1.5 text-sm text-foregroundfocus:border-green-500 focus:outline-hidden focus:ring-1 focus:ring-green-500"
 																/>
 															</div>
 															<span className="text-xs text-muted-foreground">

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-resolution.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-resolution.tsx
@@ -670,7 +670,7 @@ export const CFResolution = ({
 				}`}>
 					<div className="flex items-start justify-between gap-4">
 						<div className="flex items-start gap-3">
-							<Sparkles className={`h-5 w-5 mt-0.5 flex-shrink-0 ${
+							<Sparkles className={`h-5 w-5 mt-0.5 shrink-0 ${
 								profileMatchData.matched ? "text-purple-400" : "text-gray-400"
 							}`} />
 							<div>
@@ -717,7 +717,7 @@ export const CFResolution = ({
 						</div>
 						{/* Toggle for recommendations */}
 						{profileMatchData.matched && profileMatchData.recommendations && (
-							<div className="flex items-center gap-2 flex-shrink-0">
+							<div className="flex items-center gap-2 shrink-0">
 								<label htmlFor="use-recommendations" className="text-xs text-foreground/70 cursor-pointer">
 									Auto-exclude non-recommended
 								</label>
@@ -848,7 +848,7 @@ export const CFResolution = ({
 					<select
 						value={filterMode}
 						onChange={(e) => setFilterMode(e.target.value as FilterMode)}
-						className="rounded border border-border bg-card px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-none"
+						className="rounded border border-border bg-card px-2 py-1 text-sm text-foreground focus:border-primary focus:outline-hidden"
 					>
 						<option value="all">All ({data?.results?.length ?? 0})</option>
 						<option value="matched">Matched ({matchStats?.matched || 0})</option>
@@ -862,7 +862,7 @@ export const CFResolution = ({
 						value={searchQuery}
 						onChange={(e) => setSearchQuery(e.target.value)}
 						placeholder="Search Custom Formats..."
-						className="w-full rounded border border-border bg-card pr-3 py-1 text-sm text-foreground placeholder:text-foreground/40 focus:border-primary focus:outline-none"
+						className="w-full rounded border border-border bg-card pr-3 py-1 text-sm text-foreground placeholder:text-foreground/40 focus:border-primary focus:outline-hidden"
 						style={{ paddingLeft: "2.25rem" }}
 					/>
 				</div>
@@ -920,7 +920,7 @@ export const CFResolution = ({
 						<div className="border-t border-purple-500/20 p-3">
 							{/* Info banner */}
 							<div className="flex items-start gap-2 rounded-lg bg-purple-500/10 p-3 mb-3">
-								<Info className="h-4 w-4 text-purple-400 mt-0.5 flex-shrink-0" />
+								<Info className="h-4 w-4 text-purple-400 mt-0.5 shrink-0" />
 								<div className="text-xs text-purple-200/80">
 									<p>
 										These Custom Formats exist in your instance but have a <span className="font-medium text-foreground">score of 0</span> in this profile.
@@ -979,7 +979,7 @@ export const CFResolution = ({
 						<div className="border-t border-amber-500/20 p-3">
 							{/* Info banner */}
 							<div className="flex items-start gap-2 rounded-lg bg-amber-500/10 p-3 mb-3">
-								<Info className="h-4 w-4 text-amber-400 mt-0.5 flex-shrink-0" />
+								<Info className="h-4 w-4 text-amber-400 mt-0.5 shrink-0" />
 								<div className="text-xs text-amber-200/80 space-y-1">
 									{matchStats && matchStats.excludedByScore > 0 && (
 										<p>
@@ -1025,7 +1025,7 @@ export const CFResolution = ({
 			{/* Info about unmatched */}
 			{matchStats && matchStats.unmatched > 0 && (
 				<div className="flex items-start gap-2 rounded-lg border border-border bg-card p-3">
-					<Info className="h-4 w-4 text-foreground/60 mt-0.5 flex-shrink-0" />
+					<Info className="h-4 w-4 text-foreground/60 mt-0.5 shrink-0" />
 					<div className="text-xs text-foreground/60">
 						<span className="font-medium text-foreground/80">{matchStats.unmatched} Custom Format{matchStats.unmatched > 1 ? "s" : ""}</span> couldn&apos;t be matched to TRaSH Guides.
 						These are likely custom formats you created or from a different source.
@@ -1184,7 +1184,7 @@ const CFResolutionItem = ({ result, decision, onDecisionChange, onExclude, isRec
 					</div>
 
 					{/* Actions */}
-					<div className="flex items-center gap-1 flex-shrink-0">
+					<div className="flex items-center gap-1 shrink-0">
 						{/* Expand/Compare button for matched CFs */}
 						{hasComparableData && (
 							<button
@@ -1246,7 +1246,7 @@ const CFResolutionItem = ({ result, decision, onDecisionChange, onExclude, isRec
 
 						{/* Instance score for unmatched */}
 						{!hasMatch && result.instanceCF.score !== undefined && (
-							<div className="text-xs text-foreground/60 flex-shrink-0">
+							<div className="text-xs text-foreground/60 shrink-0">
 								Score: {result.instanceCF.score}
 							</div>
 						)}
@@ -1346,7 +1346,7 @@ const CFComparisonView = ({ instanceCF, trashCF, matchDetails, recommendedScore,
 					<div className="grid grid-cols-2 gap-3">
 						<div className="bg-amber-500/10 rounded-lg p-2.5 border border-amber-500/20">
 							<p className="font-semibold text-amber-600 dark:text-amber-400 mb-1.5">Instance:</p>
-							<pre className="p-2 rounded bg-black/20 overflow-auto max-h-48 whitespace-pre-wrap break-words text-foreground/70 font-mono text-[10px]">
+							<pre className="p-2 rounded bg-black/20 overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-foreground/70 font-mono text-[10px]">
 								{instanceSpecs.length > 0
 									? JSON.stringify(instanceSpecs, null, 2)
 									: "(no specifications)"}
@@ -1354,7 +1354,7 @@ const CFComparisonView = ({ instanceCF, trashCF, matchDetails, recommendedScore,
 						</div>
 						<div className="bg-green-500/10 rounded-lg p-2.5 border border-green-500/20">
 							<p className="font-semibold text-green-600 dark:text-green-400 mb-1.5">TRaSH Guides:</p>
-							<pre className="p-2 rounded bg-black/20 overflow-auto max-h-48 whitespace-pre-wrap break-words text-foreground/70 font-mono text-[10px]">
+							<pre className="p-2 rounded bg-black/20 overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-foreground/70 font-mono text-[10px]">
 								{trashSpecs.length > 0
 									? JSON.stringify(trashSpecs, null, 2)
 									: "(no specifications)"}
@@ -1492,7 +1492,7 @@ const ExcludedCFItem = ({
 					</div>
 
 					{/* Actions */}
-					<div className="flex items-center gap-1 flex-shrink-0">
+					<div className="flex items-center gap-1 shrink-0">
 						{/* Expand/Compare button */}
 						{hasComparableData && (
 							<button

--- a/apps/web/src/features/trash-guides/components/wizard-steps/custom-format-customization.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/custom-format-customization.tsx
@@ -315,7 +315,7 @@ export const CustomFormatCustomization = ({
 													value={scoreOverride ?? ""}
 													onChange={(e) => updateScoreOverride(cf.trash_id, e.target.value)}
 													placeholder="Leave empty for default score"
-													className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+													className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary"
 												/>
 											</div>
 

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -616,7 +616,7 @@ export const TemplateCreation = ({
 						value={templateName}
 						onChange={(e) => setTemplateName(e.target.value)}
 						placeholder="Enter template name"
-						className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+						className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary"
 					/>
 				</div>
 
@@ -629,7 +629,7 @@ export const TemplateCreation = ({
 						onChange={(e) => setTemplateDescription(e.target.value)}
 						placeholder="Enter template description"
 						rows={4}
-						className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+						className="w-full rounded border border-border bg-card px-3 py-2 text-sm text-foregroundplaceholder:text-foreground/40 focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary"
 					/>
 				</div>
 			</div>

--- a/apps/web/src/lib/theme-gradients.ts
+++ b/apps/web/src/lib/theme-gradients.ts
@@ -36,7 +36,7 @@
  * };
  *
  * <select
- *   className="border border-border bg-card focus:outline-none"
+ *   className="border border-border bg-card focus:outline-hidden"
  *   style={getSelectStyle("mySelect")}
  *   onFocus={() => setFocusedSelect("mySelect")}
  *   onBlur={() => setFocusedSelect(null)}

--- a/apps/web/src/lib/theme-input-styles.ts
+++ b/apps/web/src/lib/theme-input-styles.ts
@@ -158,13 +158,13 @@ export const getChipStyles = (gradient: ThemeGradient, isActive: boolean = false
  */
 export const INPUT_BASE_CLASSES = {
 	/** Standard text input */
-	input: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-none",
+	input: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 focus:outline-hidden",
 
 	/** Select/dropdown */
-	select: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 cursor-pointer focus:outline-none",
+	select: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 cursor-pointer focus:outline-hidden",
 
 	/** Textarea */
-	textarea: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 resize-none focus:outline-none",
+	textarea: "w-full rounded-lg border border-border bg-card px-3 py-2 text-sm text-foreground transition-all duration-200 resize-none focus:outline-hidden",
 
 	/** Checkbox/Radio */
 	checkbox: "h-4 w-4 rounded border-2 transition-all duration-200 cursor-pointer border-border/50 bg-card/50 focus:ring-2 focus:ring-offset-0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         version: 22.18.6
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -113,7 +113,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@22.18.6)(jsdom@27.4.0)
+        version: 1.6.1(@types/node@22.18.6)(jsdom@27.4.0)(lightningcss@1.30.2)
 
   apps/web:
     dependencies:
@@ -230,7 +230,7 @@ importers:
         version: 2.6.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.17)
+        version: 1.0.7(tailwindcss@4.1.18)
       zod:
         specifier: ^4.3.5
         version: 4.3.5
@@ -241,6 +241,9 @@ importers:
       '@eslint/eslintrc':
         specifier: ^3.3.3
         version: 3.3.3
+      '@tailwindcss/postcss':
+        specifier: ^4.1.18
+        version: 4.1.18
       '@types/node':
         specifier: ^22.7.4
         version: 22.18.6
@@ -252,19 +255,16 @@ importers:
         version: 19.2.3(@types/react@19.2.9)
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.53.1
-        version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+        version: 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: ^8.53.1
-        version: 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
-      autoprefixer:
-        specifier: ^10.4.23
-        version: 10.4.23(postcss@8.5.6)
+        version: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.2(jiti@2.6.0)
+        version: 9.39.2(jiti@2.6.1)
       eslint-config-next:
         specifier: ^16.1.4
-        version: 16.1.4(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+        version: 16.1.4(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       globals:
         specifier: ^17.0.0
         version: 17.0.0
@@ -272,8 +272,8 @@ importers:
         specifier: ^8.4.47
         version: 8.5.6
       tailwindcss:
-        specifier: ^3.4.14
-        version: 3.4.17
+        specifier: ^4.1.18
+        version: 4.1.18
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
@@ -286,13 +286,13 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.1.0
-        version: 8.5.0(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
+        version: 8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1)
       typescript:
         specifier: ^5.6.3
         version: 5.9.2
       vitest:
         specifier: ^1.6.0
-        version: 1.6.1(@types/node@22.18.6)(jsdom@27.4.0)
+        version: 1.6.1(@types/node@22.18.6)(jsdom@27.4.0)(lightningcss@1.30.2)
 
 packages:
 
@@ -2169,6 +2169,94 @@ packages:
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.18':
+    resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
+
   '@tanstack/query-core@5.90.19':
     resolution: {integrity: sha512-GLW5sjPVIvH491VV1ufddnfldyVB+teCnpPIvweEfkpRx7CfUmUGhoh9cdcUKBh/KwVxk22aNEDxeTsvmyB/WA==}
 
@@ -2442,15 +2530,8 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
   arctic@3.7.0:
     resolution: {integrity: sha512-ZMQ+f6VazDgUJOd+qNV+H7GohNSYal1mVjm5kEaZfE2Ifb7Ss70w+Q7xpJC87qZDkMZIXYf0pTIYZA0OPasSbw==}
-
-  arg@5.0.2:
-    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
 
   argon2@0.44.0:
     resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
@@ -2521,13 +2602,6 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
-  autoprefixer@10.4.23:
-    resolution: {integrity: sha512-YYTXSFulfwytnjAPlw8QHncHJmlvFKtczb8InXaAx9Q0LbfDnfEYDE55omerIJKihhmU61Ft+cAOSzQVaBUmeA==}
-    engines: {node: ^10 || ^12 || >=14}
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.1.0
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -2563,10 +2637,6 @@ packages:
 
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -2626,10 +2696,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-css@2.0.1:
-    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
-    engines: {node: '>= 6'}
-
   caniuse-lite@1.0.30001743:
     resolution: {integrity: sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==}
 
@@ -2646,10 +2712,6 @@ packages:
 
   check-error@1.0.3:
     resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -2723,11 +2785,6 @@ packages:
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
-  cssesc@3.0.0:
-    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   cssstyle@5.3.7:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
@@ -2822,15 +2879,9 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
-  didyoumean@1.2.2:
-    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
-
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  dlv@1.1.3:
-    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -2871,6 +2922,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  enhanced-resolve@5.18.4:
+    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
+    engines: {node: '>=10.13.0'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3075,10 +3130,6 @@ packages:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
 
-  fast-glob@3.3.3:
-    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
-    engines: {node: '>=8.6.0'}
-
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
@@ -3152,9 +3203,6 @@ packages:
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  fraction.js@5.3.4:
-    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
   framer-motion@11.18.2:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
@@ -3265,6 +3313,9 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3362,10 +3413,6 @@ packages:
   is-bigint@1.1.0:
     resolution: {integrity: sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==}
     engines: {node: '>= 0.4'}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
 
   is-boolean-object@1.2.2:
     resolution: {integrity: sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==}
@@ -3486,12 +3533,12 @@ packages:
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
-  jiti@1.21.7:
-    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
-    hasBin: true
-
   jiti@2.6.0:
     resolution: {integrity: sha512-VXe6RjJkBPj0ohtqaO8vSWP3ZhAKo66fKrFNCll4BTcwljPLz03pCbaNKfzGP5MbrCYcbJ7v0nOYYwUzTEIdXQ==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   joycon@3.1.1:
@@ -3566,6 +3613,76 @@ packages:
 
   light-my-request@6.6.0:
     resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3744,10 +3861,6 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3763,10 +3876,6 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-
-  object-hash@3.0.0:
-    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
-    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3882,10 +3991,6 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  pify@2.3.0:
-    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
-    engines: {node: '>=0.10.0'}
-
   pino-abstract-transport@2.0.0:
     resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
 
@@ -3927,30 +4032,6 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss-import@15.1.0:
-    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      postcss: ^8.0.0
-
-  postcss-js@4.1.0:
-    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
-    engines: {node: ^12 || ^14 || >= 16}
-    peerDependencies:
-      postcss: ^8.4.21
-
-  postcss-load-config@4.0.2:
-    resolution: {integrity: sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==}
-    engines: {node: '>= 14'}
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
@@ -3968,19 +4049,6 @@ packages:
         optional: true
       yaml:
         optional: true
-
-  postcss-nested@6.2.0:
-    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
-    engines: {node: '>=12.0'}
-    peerDependencies:
-      postcss: ^8.2.14
-
-  postcss-selector-parser@6.1.2:
-    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
-    engines: {node: '>=4'}
-
-  postcss-value-parser@4.2.0:
-    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
@@ -4103,16 +4171,9 @@ packages:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
 
-  read-cache@1.0.0:
-    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
-
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
-
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
 
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
@@ -4423,10 +4484,12 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders'
 
-  tailwindcss@3.4.17:
-    resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
+  tailwindcss@4.1.18:
+    resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
+
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
 
   tar-fs@2.1.4:
     resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
@@ -5308,9 +5371,9 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.0))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -6491,6 +6554,75 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.18.4
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.18':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/postcss@4.1.18':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      postcss: 8.5.6
+      tailwindcss: 4.1.18
+
   '@tanstack/query-core@5.90.19': {}
 
   '@tanstack/query-devtools@5.92.0': {}
@@ -6536,15 +6668,15 @@ snapshots:
   '@types/trusted-types@2.0.7':
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.53.1
-      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/type-utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.53.1
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.2)
@@ -6552,14 +6684,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.53.1
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.53.1
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -6582,13 +6714,13 @@ snapshots:
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.4.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -6611,13 +6743,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.53.1
       '@typescript-eslint/types': 8.53.1
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -6761,18 +6893,11 @@ snapshots:
 
   any-promise@1.3.0: {}
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
   arctic@3.7.0:
     dependencies:
       '@oslojs/crypto': 1.0.1
       '@oslojs/encoding': 1.1.0
       '@oslojs/jwt': 0.2.0
-
-  arg@5.0.2: {}
 
   argon2@0.44.0:
     dependencies:
@@ -6872,15 +6997,6 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
-  autoprefixer@10.4.23(postcss@8.5.6):
-    dependencies:
-      browserslist: 4.28.1
-      caniuse-lite: 1.0.30001765
-      fraction.js: 5.3.4
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -6910,8 +7026,6 @@ snapshots:
   bidi-js@1.0.3:
     dependencies:
       require-from-string: 2.0.2
-
-  binary-extensions@2.3.0: {}
 
   bindings@1.5.0:
     dependencies:
@@ -6995,8 +7109,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-css@2.0.1: {}
-
   caniuse-lite@1.0.30001743: {}
 
   caniuse-lite@1.0.30001765: {}
@@ -7019,18 +7131,6 @@ snapshots:
   check-error@1.0.3:
     dependencies:
       get-func-name: 2.0.2
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
 
   chokidar@4.0.3:
     dependencies:
@@ -7099,8 +7199,6 @@ snapshots:
     dependencies:
       mdn-data: 2.12.2
       source-map-js: 1.2.1
-
-  cssesc@3.0.0: {}
 
   cssstyle@5.3.7:
     dependencies:
@@ -7184,11 +7282,7 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
-  didyoumean@1.2.2: {}
-
   diff-sequences@29.6.3: {}
-
-  dlv@1.1.3: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -7231,6 +7325,11 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  enhanced-resolve@5.18.4:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
 
   entities@6.0.1: {}
 
@@ -7423,18 +7522,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.1.4(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2):
+  eslint-config-next@16.1.4(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
     dependencies:
       '@next/eslint-plugin-next': 16.1.4
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.0))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.0))
-      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.0))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      typescript-eslint: 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -7451,33 +7550,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.0)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7486,9 +7585,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7500,13 +7599,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.0)):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -7516,7 +7615,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -7525,18 +7624,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.0)):
+  eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.28.6
       '@babel/parser': 7.28.6
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 4.3.5
       zod-validation-error: 4.0.2(zod@4.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.0)):
+  eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -7544,7 +7643,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.2.1
-      eslint: 9.39.2(jiti@2.6.0)
+      eslint: 9.39.2(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -7567,9 +7666,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2(jiti@2.6.0):
+  eslint@9.39.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -7604,7 +7703,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.0
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7655,14 +7754,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.8
-
-  fast-glob@3.3.3:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       '@nodelib/fs.walk': 1.2.8
@@ -7761,8 +7852,6 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  fraction.js@5.3.4: {}
 
   framer-motion@11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -7875,6 +7964,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -7969,10 +8060,6 @@ snapshots:
   is-bigint@1.1.0:
     dependencies:
       has-bigints: 1.1.0
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
 
   is-boolean-object@1.2.2:
     dependencies:
@@ -8103,9 +8190,9 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
-  jiti@1.21.7: {}
-
   jiti@2.6.0: {}
+
+  jiti@2.6.1: {}
 
   joycon@3.1.1: {}
 
@@ -8192,6 +8279,55 @@ snapshots:
       cookie: 1.1.1
       process-warning: 4.0.1
       set-cookie-parser: 2.7.1
+
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
 
   lilconfig@3.1.3: {}
 
@@ -8344,8 +8480,6 @@ snapshots:
 
   node-releases@2.0.27: {}
 
-  normalize-path@3.0.0: {}
-
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -8361,8 +8495,6 @@ snapshots:
   oauth4webapi@3.8.3: {}
 
   object-assign@4.1.1: {}
-
-  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -8480,8 +8612,6 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  pify@2.3.0: {}
-
   pino-abstract-transport@2.0.0:
     dependencies:
       split2: 4.2.0
@@ -8544,45 +8674,14 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-js@4.1.0(postcss@8.5.6):
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.5.6
-
-  postcss-load-config@4.0.2(postcss@8.5.6):
-    dependencies:
-      lilconfig: 3.1.3
-      yaml: 2.8.1
-    optionalDependencies:
-      postcss: 8.5.6
-
-  postcss-load-config@6.0.1(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.6.0
+      jiti: 2.6.1
       postcss: 8.5.6
       tsx: 4.21.0
       yaml: 2.8.1
-
-  postcss-nested@6.2.0(postcss@8.5.6):
-    dependencies:
-      postcss: 8.5.6
-      postcss-selector-parser: 6.1.2
-
-  postcss-selector-parser@6.1.2:
-    dependencies:
-      cssesc: 3.0.0
-      util-deprecate: 1.0.2
-
-  postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
@@ -8711,19 +8810,11 @@ snapshots:
 
   react@19.2.3: {}
 
-  read-cache@1.0.0:
-    dependencies:
-      pify: 2.3.0
-
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
 
   readdirp@4.1.2: {}
 
@@ -9136,36 +9227,13 @@ snapshots:
 
   tailwind-merge@2.6.0: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.17):
+  tailwindcss-animate@1.0.7(tailwindcss@4.1.18):
     dependencies:
-      tailwindcss: 3.4.17
+      tailwindcss: 4.1.18
 
-  tailwindcss@3.4.17:
-    dependencies:
-      '@alloc/quick-lru': 5.2.0
-      arg: 5.0.2
-      chokidar: 3.6.0
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.3.3
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      jiti: 1.21.7
-      lilconfig: 3.1.3
-      micromatch: 4.0.8
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-import: 15.1.0(postcss@8.5.6)
-      postcss-js: 4.1.0(postcss@8.5.6)
-      postcss-load-config: 4.0.2(postcss@8.5.6)
-      postcss-nested: 6.2.0(postcss@8.5.6)
-      postcss-selector-parser: 6.1.2
-      resolve: 1.22.10
-      sucrase: 3.35.0
-    transitivePeerDependencies:
-      - ts-node
+  tailwindcss@4.1.18: {}
+
+  tapable@2.3.0: {}
 
   tar-fs@2.1.4:
     dependencies:
@@ -9258,7 +9326,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.0(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.10)
       cac: 6.7.14
@@ -9269,7 +9337,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1)
       resolve-from: 5.0.0
       rollup: 4.52.2
       source-map: 0.8.0-beta.0
@@ -9286,7 +9354,7 @@ snapshots:
       - tsx
       - yaml
 
-  tsup@8.5.1(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.2)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -9297,7 +9365,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.0)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.1)
       resolve-from: 5.0.0
       rollup: 4.55.3
       source-map: 0.7.6
@@ -9395,13 +9463,13 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2):
+  typescript-eslint@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.53.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
       '@typescript-eslint/typescript-estree': 8.53.1(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.0))(typescript@5.9.2)
-      eslint: 9.39.2(jiti@2.6.0)
+      '@typescript-eslint/utils': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.2)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
@@ -9476,13 +9544,13 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-node@1.6.1(@types/node@22.18.6):
+  vite-node@1.6.1(@types/node@22.18.6)(lightningcss@1.30.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 5.4.20(@types/node@22.18.6)
+      vite: 5.4.20(@types/node@22.18.6)(lightningcss@1.30.2)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -9494,7 +9562,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@5.4.20(@types/node@22.18.6):
+  vite@5.4.20(@types/node@22.18.6)(lightningcss@1.30.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
@@ -9502,8 +9570,9 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.18.6
       fsevents: 2.3.3
+      lightningcss: 1.30.2
 
-  vitest@1.6.1(@types/node@22.18.6)(jsdom@27.4.0):
+  vitest@1.6.1(@types/node@22.18.6)(jsdom@27.4.0)(lightningcss@1.30.2):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -9522,8 +9591,8 @@ snapshots:
       strip-literal: 2.1.1
       tinybench: 2.9.0
       tinypool: 0.8.4
-      vite: 5.4.20(@types/node@22.18.6)
-      vite-node: 1.6.1(@types/node@22.18.6)
+      vite: 5.4.20(@types/node@22.18.6)(lightningcss@1.30.2)
+      vite-node: 1.6.1(@types/node@22.18.6)(lightningcss@1.30.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.6
@@ -9635,7 +9704,8 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.1: {}
+  yaml@2.8.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary
- Major upgrade from Tailwind CSS v3.4 to v4.1.18
- Used official `@tailwindcss/upgrade` tool for automated migration
- 114 files updated with renamed utilities and new syntax

## Breaking Changes Handled

### PostCSS Configuration
| Before | After |
|--------|-------|
| `tailwindcss: {}` | `@tailwindcss/postcss: {}` |
| `autoprefixer: {}` | _(removed - now built-in)_ |

### CSS Import Syntax
| Before | After |
|--------|-------|
| `@tailwind base;` | `@import 'tailwindcss';` |
| `@tailwind components;` | `@config '../tailwind.config.ts';` |
| `@tailwind utilities;` | |

### Renamed Utilities
| v3 | v4 |
|----|-----|
| `shadow-sm` | `shadow-xs` |
| `shadow` | `shadow-sm` |
| `outline-none` | `outline-hidden` |
| `flex-shrink-0` | `shrink-0` |
| `backdrop-blur-sm` | `backdrop-blur-xs` |

### Compatibility Styles Added
- Border color compatibility layer for v4 default change (currentColor → gray-200)

## Manual Fixes
- Reverted incorrect `outline-solid` variant rename back to `outline` in sync-validation-modal.tsx

## Test plan
- [x] TypeScript compilation passes
- [x] Production build succeeds
- [x] All 150 tests pass (28 skipped)
- [ ] Visual regression testing recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)