### PR TITLE
chore(deps): Upgrade Zustand 4 → 5

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,7 +50,7 @@
 		"tailwind-merge": "^2.2.1",
 		"tailwindcss-animate": "^1.0.7",
 		"zod": "^4.3.5",
-		"zustand": "^4.5.5"
+		"zustand": "^5.0.10"
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.3",

--- a/apps/web/src/features/manual-import/components/manual-import-modal.tsx
+++ b/apps/web/src/features/manual-import/components/manual-import-modal.tsx
@@ -10,6 +10,7 @@ import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { useManualImportQuery } from "../../../hooks/api/useManualImport";
 import type { ManualImportModalProps, ManualImportCandidateUnion } from "../types";
 import { candidateKey, describeRejections } from "../helpers";
+import { useShallow } from "zustand/shallow";
 import { useManualImportStore, getSelectionForCandidate } from "../store";
 import { buildSubmissionDefaults } from "../lib/submission-builder";
 import { useEpisodeSelection } from "../hooks/use-episode-selection";
@@ -52,7 +53,13 @@ export const ManualImportModal = ({
 }: ManualImportModalProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const serviceColor = SERVICE_COLORS[service] ?? themeGradient.from;
-	const { selections, toggleSelection, clear } = useManualImportStore();
+	const { selections, toggleSelection, clear } = useManualImportStore(
+		useShallow((state) => ({
+			selections: state.selections,
+			toggleSelection: state.toggleSelection,
+			clear: state.clear,
+		})),
+	);
 	const focusTrapRef = useFocusTrap<HTMLDivElement>(open, () => onOpenChange(false));
 	const [showSelectedOnly, setShowSelectedOnly] = useState(false);
 	const [importMode, setImportMode] = useState<ImportMode>("auto");

--- a/apps/web/src/features/manual-import/hooks/use-episode-selection.ts
+++ b/apps/web/src/features/manual-import/hooks/use-episode-selection.ts
@@ -7,7 +7,7 @@ import { useManualImportStore } from "../store";
  * Hook for managing episode selection within a candidate
  */
 export const useEpisodeSelection = () => {
-	const { updateSelection } = useManualImportStore();
+	const updateSelection = useManualImportStore((state) => state.updateSelection);
 
 	const toggleEpisode = useCallback(
 		(candidate: ManualImportCandidateUnion, episodeId: number) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: ^4.3.5
         version: 4.3.5
       zustand:
-        specifier: ^4.5.5
-        version: 4.5.7(@types/react@19.2.9)(react@19.2.3)
+        specifier: ^5.0.10
+        version: 5.0.10(@types/react@19.2.9)(react@19.2.3)(use-sync-external-store@1.5.0(react@19.2.3))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.3.3
@@ -4932,19 +4932,22 @@ packages:
   zod@4.3.5:
     resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
 
-  zustand@4.5.7:
-    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
-    engines: {node: '>=12.7.0'}
+  zustand@5.0.10:
+    resolution: {integrity: sha512-U1AiltS1O9hSy3rul+Ub82ut2fqIAefiSuwECWt6jlMVUGejvf+5omLcRBSzqbRagSM3hQZbtzdeRc6QVScXTg==}
+    engines: {node: '>=12.20.0'}
     peerDependencies:
-      '@types/react': '>=16.8'
+      '@types/react': '>=18.0.0'
       immer: '>=9.0.6'
-      react: '>=16.8'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
       immer:
         optional: true
       react:
+        optional: true
+      use-sync-external-store:
         optional: true
 
 snapshots:
@@ -9717,9 +9720,8 @@ snapshots:
 
   zod@4.3.5: {}
 
-  zustand@4.5.7(@types/react@19.2.9)(react@19.2.3):
-    dependencies:
-      use-sync-external-store: 1.5.0(react@19.2.3)
+  zustand@5.0.10(@types/react@19.2.9)(react@19.2.3)(use-sync-external-store@1.5.0(react@19.2.3)):
     optionalDependencies:
       '@types/react': 19.2.9
       react: 19.2.3
+      use-sync-external-store: 1.5.0(react@19.2.3)


### PR DESCRIPTION
## Summary
- Upgrades Zustand from v4.5.2 to v5.0.10
- Updates selector patterns to comply with v5 stability requirements

## Breaking Changes Handled

### Selector Stability
In v5, selectors must return stable references to prevent infinite loops.

| Pattern | Before (v4) | After (v5) |
|---------|-------------|------------|
| Object destructure | `const { a, b } = useStore()` | `useShallow((s) => ({ a: s.a, b: s.b }))` |
| Single action | `const { action } = useStore()` | `(state) => state.action` |

## Files Modified
- `manual-import-modal.tsx`: Added `useShallow` for multi-property selection
- `use-episode-selection.ts`: Direct action selector pattern

## Test plan
- [x] TypeScript compilation passes
- [x] All 150 tests pass (28 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)