### PR TITLE
chore(deps): Upgrade Framer Motion 11 → 12

### DIFF
--- a/apps/web/app/template.tsx
+++ b/apps/web/app/template.tsx
@@ -23,8 +23,8 @@ const pageEnterVariants = {
 		opacity: 1,
 		y: 0,
 		transition: {
-			type: "tween",
-			ease: [0.25, 0.1, 0.25, 1],
+			type: "tween" as const,
+			ease: [0.25, 0.1, 0.25, 1] as [number, number, number, number],
 			duration: 0.3,
 		},
 	},

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
 		"date-fns": "^4.1.0",
 		"dequal": "^2.0.3",
 		"dompurify": "^3.3.1",
-		"framer-motion": "^11.11.17",
+		"framer-motion": "^12.28.1",
 		"lucide-react": "^0.441.0",
 		"next": "^16.1.4",
 		"next-themes": "^0.4.6",

--- a/apps/web/src/components/motion/page-transition.tsx
+++ b/apps/web/src/components/motion/page-transition.tsx
@@ -30,8 +30,8 @@ const pageVariants: Variants = {
  * Fast enough to not feel sluggish, slow enough to be noticeable
  */
 const pageTransition = {
-	type: "tween",
-	ease: [0.25, 0.1, 0.25, 1], // Smooth ease-out curve
+	type: "tween" as const,
+	ease: [0.25, 0.1, 0.25, 1] as [number, number, number, number], // Smooth ease-out curve
 	duration: 0.25,
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1
       framer-motion:
-        specifier: ^11.11.17
-        version: 11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+        specifier: ^12.28.1
+        version: 12.28.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.441.0
         version: 0.441.0(react@19.2.3)
@@ -3204,8 +3204,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  framer-motion@11.18.2:
-    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
+  framer-motion@12.28.1:
+    resolution: {integrity: sha512-72GkO7DS4FfcSjf26wx0v+rzkW8Fhn4Djh04aDbuEg7NYG8X8MhJZc6/5weG/YeEgIP+fCo8FS2y1HnXH8k8fQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -3788,11 +3788,11 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
-  motion-dom@11.18.1:
-    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+  motion-dom@12.28.1:
+    resolution: {integrity: sha512-xqgID69syDvXwFJnUd5bW6ajGUAr/qevRoUe/EqpsXUbVIopyWrAOiwQOhpgVQD+B7Ra60zTdj5gVkmwncebMg==}
 
-  motion-utils@11.18.1:
-    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
+  motion-utils@12.27.2:
+    resolution: {integrity: sha512-B55gcoL85Mcdt2IEStY5EEAsrMSVE2sI14xQ/uAdPL+mfQxhKKFaEag9JmfxedJOR4vZpBGoPeC/Gm13I/4g5Q==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -7856,10 +7856,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  framer-motion@11.18.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+  framer-motion@12.28.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
-      motion-dom: 11.18.1
-      motion-utils: 11.18.1
+      motion-dom: 12.28.1
+      motion-utils: 12.27.2
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.3
@@ -8419,11 +8419,11 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
-  motion-dom@11.18.1:
+  motion-dom@12.28.1:
     dependencies:
-      motion-utils: 11.18.1
+      motion-utils: 12.27.2
 
-  motion-utils@11.18.1: {}
+  motion-utils@12.27.2: {}
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary
- Upgrades framer-motion from v11.11.17 to v12.28.1
- Fixes stricter TypeScript types in v12

## TypeScript Changes Required

### Transition `type` Property
v12 requires literal types instead of `string`:
```typescript
// Before (v11)
type: "tween"  // inferred as string

// After (v12)
type: "tween" as const  // literal type
```

### Transition `ease` Property
v12 expects bezier curves as 4-element tuples:
```typescript
// Before (v11)
ease: [0.25, 0.1, 0.25, 1]  // inferred as number[]

// After (v12)
ease: [0.25, 0.1, 0.25, 1] as [number, number, number, number]
```

## Files Modified
- `app/template.tsx` - Page enter animation variants
- `src/components/motion/page-transition.tsx` - Page transition timing

## Test plan
- [x] TypeScript compilation passes
- [x] All 150 tests pass (28 skipped)

## Sources
- [Motion Upgrade Guide](https://motion.dev/docs/react-upgrade-guide)

🤖 Generated with [Claude Code](https://claude.com/claude-code)