### PR TITLE
chore(deps): Upgrade @types/node 22.18.6 → 25.0.9

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -46,7 +46,7 @@
 	},
 	"devDependencies": {
 		"@types/better-sqlite3": "^7.6.13",
-		"@types/node": "^22.7.4",
+		"@types/node": "^25.0.9",
 		"tsup": "^8.5.1",
 		"tsx": "^4.21.0",
 		"typescript": "^5.9.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,7 +55,7 @@
 	"devDependencies": {
 		"@eslint/eslintrc": "^3.3.3",
 		"@tailwindcss/postcss": "^4.1.18",
-		"@types/node": "^22.7.4",
+		"@types/node": "^25.0.9",
 		"@types/react": "^19.2.9",
 		"@types/react-dom": "^19.2.3",
 		"@typescript-eslint/eslint-plugin": "^8.53.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         specifier: ^7.6.13
         version: 7.6.13
       '@types/node':
-        specifier: ^22.7.4
+        specifier: ^25.0.9
         version: 25.0.9
       tsup:
         specifier: ^8.5.1
@@ -248,7 +248,7 @@ importers:
         specifier: ^4.1.18
         version: 4.1.18
       '@types/node':
-        specifier: ^22.7.4
+        specifier: ^25.0.9
         version: 25.0.9
       '@types/react':
         specifier: ^19.2.9


### PR DESCRIPTION
## Summary
- **MAJOR** version upgrade for Node.js type definitions (22.18.6 → 25.0.9)
- Updated to Node.js 25.x type definitions
- No type errors introduced
- Build and tests passing

## Test plan
- [x] `pnpm run build` passes (no type errors)
- [x] `pnpm run test` passes (150 tests passed)

🤖 Generated with [Claude Code](https://claude.ai/code)