### PR TITLE
chore(deps): Upgrade dotenv 16.6.1 → 17.2.3

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -33,7 +33,7 @@
 		"arr-sdk": "^0.3.0",
 		"better-sqlite3": "^12.6.2",
 		"dequal": "^2.0.3",
-		"dotenv": "^16.4.5",
+		"dotenv": "^17.2.3",
 		"fastify": "5.7.1",
 		"fastify-plugin": "^5.1.0",
 		"isomorphic-dompurify": "^2.35.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.3",
     "@playwright/test": "^1.57.0",
-    "dotenv": "^16.4.5",
+    "dotenv": "^17.2.3",
     "turbo": "^2.7.5",
     "typescript": "^5.9.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: ^1.57.0
         version: 1.57.0
       dotenv:
-        specifier: ^16.4.5
+        specifier: ^17.2.3
         version: 17.2.3
       turbo:
         specifier: ^2.7.5
@@ -69,7 +69,7 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3
       dotenv:
-        specifier: ^16.4.5
+        specifier: ^17.2.3
         version: 17.2.3
       fastify:
         specifier: 5.7.1


### PR DESCRIPTION
## Summary
- **MAJOR** version upgrade for dotenv (16.6.1 → 17.2.3)
- Updated environment variable loading library
- No breaking changes affecting current usage
- Build and tests passing

## Test plan
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (150 tests passed)

🤖 Generated with [Claude Code](https://claude.ai/code)