### PR TITLE
chore(deps): Migrate biome.json config for Biome 2.x

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,26 +1,31 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "formatter": {
-    "enabled": true,
-    "lineWidth": 100
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "style": {
-        "noNonNullAssertion": "warn",
-        "noUselessElse": "warn"
-      },
-      "suspicious": {
-        "noExplicitAny": "warn"
-      }
-    }
-  },
-  "organizeImports": {
-    "enabled": true
-  },
-  "files": {
-    "ignore": ["legacy/**", "**/node_modules/**", "**/dist/**", "**/__tests__/**", "**/generated/**"]
-  }
+	"$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+	"formatter": {
+		"enabled": true,
+		"lineWidth": 100
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"style": {
+				"noNonNullAssertion": "warn",
+				"noUselessElse": "warn"
+			},
+			"suspicious": {
+				"noExplicitAny": "warn"
+			}
+		}
+	},
+	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"files": {
+		"includes": [
+			"**",
+			"!**/legacy/**",
+			"!**/node_modules/**",
+			"!**/dist/**",
+			"!**/__tests__/**",
+			"!**/generated/**"
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "turbo prune --scope='@arr/*' --docker"
   },
   "devDependencies": {
-    "@biomejs/biome": "^1.9.3",
+    "@biomejs/biome": "^2.3.11",
     "@playwright/test": "^1.57.0",
     "dotenv": "^17.2.3",
     "turbo": "^2.7.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^1.9.3
+        specifier: ^2.3.11
         version: 2.3.11
       '@playwright/test':
         specifier: ^1.57.0


### PR DESCRIPTION
## Summary
- Migrate biome.json configuration for Biome 2.x compatibility
- Run `biome migrate` to update config format
- Update schema from 1.9.4 to 2.3.11
- Convert organizeImports to new assist.actions format
- Convert files.ignore to files.includes with negation patterns

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] `pnpm run test` passes (150 tests passed)

🤖 Generated with [Claude Code](https://claude.ai/code)