### PR TITLE
build: Upgrade Node.js 20 → 22 and pnpm 9 → 10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@
 # syntax=docker/dockerfile:1
 
 # ===== BUILD BASE =====
-FROM node:20-alpine AS build-base
+FROM node:22-alpine AS build-base
 ENV NEXT_TELEMETRY_DISABLED=1
-RUN corepack enable && corepack prepare pnpm@9.12.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.28.1 --activate
 
 # ===== DEPENDENCIES STAGE =====
 FROM build-base AS deps
@@ -62,7 +62,7 @@ RUN cd /app/apps/web/.next/standalone/node_modules && \
     done
 
 # ===== RUNTIME STAGE =====
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 
 # OCI Image Labels
 LABEL org.opencontainers.image.title="Arr Dashboard" \

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arr-dashboard-platform",
   "version": "2.6.7",
   "private": true,
-  "packageManager": "pnpm@9.12.0",
+  "packageManager": "pnpm@10.28.1",
   "scripts": {
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary
- Upgrade Docker base images from `node:20-alpine` to `node:22-alpine`
- Upgrade pnpm from 9.12.0 to 10.28.1
- Update `packageManager` field in root package.json

## Why
- **Node.js 22** ("Jod") is the current active LTS with support until April 2027
- **pnpm 10** brings significant improvements including the Global Virtual Store feature

## Test plan
- [x] `pnpm install` - lockfile compatible
- [x] `pnpm run build` - all packages build successfully  
- [x] `pnpm run test` - all tests pass (150 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)