### PR TITLE
ci: Add CodeQL and Semgrep code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,16 +36,16 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: javascript-typescript
           # Use extended query suite for more thorough analysis
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history needed for baseline diff on PRs
+          fetch-depth: 0
 
       - name: Run Semgrep
         run: semgrep scan --config auto --sarif --output semgrep-results.sarif
@@ -45,7 +48,7 @@ jobs:
           SEMGREP_BASELINE_REF: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: semgrep-results.sarif


### PR DESCRIPTION
## Summary
- Adds **CodeQL** workflow for deep semantic security analysis (taint tracking, injection paths, `security-extended` query suite)
- Adds **Semgrep** workflow for fast pattern-based SAST with broad TypeScript rule coverage (`--config auto`)
- Both upload SARIF results to the GitHub Security tab alongside existing Trivy findings
- Scheduled weekly on Sundays (CodeQL at 4am UTC, Semgrep at 5am UTC) plus on every PR and push to main

## Test plan
- [ ] Verify CodeQL workflow completes successfully on this PR
- [ ] Verify Semgrep workflow completes successfully on this PR
- [ ] Check Security tab shows results from both scanners after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)