### PR TITLE
fix(e2e): Resolve flaky sidebar navigation tests

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -84,6 +84,8 @@ test.describe("Navigation - Route Changes", () => {
 	for (const { name, route, heading } of routes) {
 		test(`should navigate to ${name} page via sidebar`, async ({ page }) => {
 			await page.goto(ROUTES.dashboard);
+			// Wait for hydration so client-side router is active
+			await page.waitForLoadState("networkidle");
 
 			// Click sidebar link
 			await clickSidebarLink(page, name);

--- a/e2e/utils/test-helpers.ts
+++ b/e2e/utils/test-helpers.ts
@@ -83,7 +83,17 @@ export async function clickSidebarLink(page: Page, linkName: string): Promise<vo
 
 	// Wait for the link to be visible before clicking
 	await expect(link).toBeVisible({ timeout: TIMEOUTS.short });
+
+	// Get the target href so we can wait for the URL to actually change
+	const href = await link.getAttribute("href");
+
 	await link.click();
+
+	// Wait for URL to change (handles Next.js hydration delay where click
+	// may fire before client-side router is attached)
+	if (href) {
+		await page.waitForURL(`**${href}`, { timeout: TIMEOUTS.navigation });
+	}
 	await page.waitForLoadState("networkidle");
 }
 


### PR DESCRIPTION
## Summary
- Fixes intermittent E2E failure in `navigation.spec.ts` where sidebar click doesn't navigate (URL stays at `/dashboard`)
- Root cause: click fires before Next.js hydration attaches client-side router to `<Link>` elements
- `clickSidebarLink` now uses `waitForURL` after clicking (waits for actual URL change, not just `networkidle`)
- Navigation test waits for `networkidle` after initial `goto` to give React time to hydrate

## Test plan
- [ ] E2E Tests (both shards) pass on this PR
- [ ] Re-run on main after merge to verify fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)