### PR TITLE
fix(security): Address CodeQL code scanning alerts

### DIFF
--- a/apps/api/src/lib/trash-guides/profile-matcher.ts
+++ b/apps/api/src/lib/trash-guides/profile-matcher.ts
@@ -402,8 +402,8 @@ function normalizeProfileName(name: string): string {
 	return name
 		.toLowerCase()
 		.replace(/^trash\s*[-:]\s*/i, "") // Remove "TRaSH - " or "TRaSH:" prefix
-		.replace(/\s*v\d+(\.\d+)?\s*$/i, "") // Remove version suffix like " v4" or " v4.0"
-		.replace(/\s*\(.*\)\s*$/i, "") // Remove parenthetical suffixes
+		.replace(/\s*v\d+(?:\.\d+)?\s*$/i, "") // Remove version suffix like " v4" or " v4.0"
+		.replace(/\s*\([^)]*\)\s*$/i, "") // Remove parenthetical suffixes
 		.replace(/[-_]/g, " ") // Normalize separators to spaces
 		.replace(/\s+/g, " ") // Normalize multiple spaces
 		.trim();

--- a/apps/api/src/routes/trash-guides/cache-routes.ts
+++ b/apps/api/src/routes/trash-guides/cache-routes.ts
@@ -15,6 +15,12 @@ import { validateRequest } from "../../lib/utils/validate.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+const VALID_SERVICE_TYPES = new Set(["RADARR", "SONARR"]);
+
+// ============================================================================
 // Request Schemas
 // ============================================================================
 
@@ -322,8 +328,9 @@ export async function registerTrashCacheRoutes(app: FastifyInstance, _opts: Fast
 
 		const results: Record<string, unknown> = {};
 
-		// Fetch custom formats for requested service types
-		const serviceTypes = serviceType ? [serviceType] : ["RADARR", "SONARR"];
+		// Fetch custom formats for requested service types (validated against whitelist)
+		const serviceTypes = (serviceType ? [serviceType] : ["RADARR", "SONARR"])
+			.filter(s => VALID_SERVICE_TYPES.has(s));
 
 		for (const service of serviceTypes) {
 			// Check cache freshness
@@ -365,7 +372,8 @@ export async function registerTrashCacheRoutes(app: FastifyInstance, _opts: Fast
 		const { serviceType } = request.query;
 
 		const results: Record<string, unknown> = {};
-		const serviceTypes = serviceType ? [serviceType] : ["RADARR", "SONARR"];
+		const serviceTypes = (serviceType ? [serviceType] : ["RADARR", "SONARR"])
+			.filter(s => VALID_SERVICE_TYPES.has(s));
 
 		for (const service of serviceTypes) {
 			const isFresh = await cacheManager.isFresh(

--- a/apps/api/src/routes/trash-guides/template-routes.ts
+++ b/apps/api/src/routes/trash-guides/template-routes.ts
@@ -14,6 +14,13 @@ import { requireTemplate } from "../../lib/trash-guides/template-helpers.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 // ============================================================================
+// Constants
+// ============================================================================
+
+/** Keys that must never be used as property names (prototype pollution prevention) */
+const UNSAFE_PROPERTY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+// ============================================================================
 // Request Schemas
 // ============================================================================
 
@@ -472,6 +479,9 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 		Params: { templateId: string; instanceId: string };
 	}>("/:templateId/instance-overrides/:instanceId", async (request, reply) => {
 		const { templateId, instanceId } = request.params;
+		if (UNSAFE_PROPERTY_KEYS.has(instanceId)) {
+			return reply.status(400).send({ error: "Invalid instance ID" });
+		}
 		const template = await requireTemplate(app.prisma, request.currentUser!.id, templateId);
 
 		const instanceOverrides = parseInstanceOverrides(
@@ -508,6 +518,9 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 		};
 	}>("/:templateId/instance-overrides/:instanceId", async (request, reply) => {
 		const { templateId, instanceId } = request.params;
+		if (UNSAFE_PROPERTY_KEYS.has(instanceId)) {
+			return reply.status(400).send({ error: "Invalid instance ID" });
+		}
 		const { scoreOverrides, cfOverrides, qualityConfigOverride } = request.body;
 		const template = await requireTemplate(app.prisma, request.currentUser!.id, templateId);
 
@@ -574,6 +587,9 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 		Params: { templateId: string; instanceId: string };
 	}>("/:templateId/instance-overrides/:instanceId", async (request, reply) => {
 		const { templateId, instanceId } = request.params;
+		if (UNSAFE_PROPERTY_KEYS.has(instanceId)) {
+			return reply.status(400).send({ error: "Invalid instance ID" });
+		}
 		const template = await requireTemplate(app.prisma, request.currentUser!.id, templateId);
 
 		// Parse existing overrides with error handling for malformed JSON

--- a/apps/web/src/features/trash-guides/lib/description-utils.ts
+++ b/apps/web/src/features/trash-guides/lib/description-utils.ts
@@ -4,6 +4,17 @@
 
 import type { CFInclude } from "../../../lib/api-client/trash-guides";
 
+/** Iteratively remove HTML comments until none remain (prevents partial match remnants) */
+function stripHtmlComments(text: string): string {
+	const pattern = /<!--.*?-->/gs;
+	let result = text;
+	while (pattern.test(result)) {
+		result = result.replace(pattern, '');
+		pattern.lastIndex = 0;
+	}
+	return result;
+}
+
 /**
  * Map of include path to content for quick lookup
  */
@@ -60,9 +71,8 @@ export function resolveIncludes(markdown: string, includesMap: IncludesMap): str
 export function cleanDescription(rawMarkdown: string, titleToRemove?: string): string {
 	// Remove markdown comment blocks and formatting
 	// Order matters: handle multi-char markers before single-char ones
-	let cleaned = rawMarkdown
+	let cleaned = stripHtmlComments(rawMarkdown)
 		// Comments and metadata
-		.replace(/<!--.*?-->/gs, '')  // Remove all HTML comments (including markdownlint)
 		.replace(/\{:.*?\}/g, '')  // Remove standalone markdown attributes {:target="_blank" rel="noopener noreferrer"}
 
 		// MkDocs-specific syntax
@@ -139,9 +149,8 @@ export function cleanDescription(rawMarkdown: string, titleToRemove?: string): s
  * @returns HTML string with preserved formatting
  */
 export function markdownToFormattedHtml(rawMarkdown: string, titleToRemove?: string): string {
-	let text = rawMarkdown
+	let text = stripHtmlComments(rawMarkdown)
 		// Comments and metadata
-		.replace(/<!--.*?-->/gs, '')
 		.replace(/\{:.*?\}/g, '')
 
 		// Fenced code blocks → styled code blocks


### PR DESCRIPTION
## Summary

Addresses all open code scanning alerts from the Security tab. 18 CodeQL alerts fixed across 7 files, 28 alerts dismissed (15 CodeQL + 25 Semgrep) with documented justifications.

### Fixed (18 CodeQL alerts across 7 files)

**Remote property injection (8 alerts)**
- `cache-routes.ts`: Added `VALID_SERVICE_TYPES` whitelist (`Set<"RADARR" | "SONARR">`) to validate `serviceType` query param before using as object key
- `template-routes.ts`: Added `UNSAFE_PROPERTY_KEYS` guard (`__proto__`, `constructor`, `prototype`) in 3 instance-override routes (GET/PUT/DELETE)

**Polynomial ReDoS (2 alerts)**
- `profile-matcher.ts`: Changed `\(.*\)` to `\([^)]*\)` in `normalizeProfileName` — prevents exponential backtracking on nested parentheses

**Incomplete URL substring sanitization (1 alert)**
- `github-fetcher.ts`: Changed `url.includes("api.github.com")` to `new URL(url).hostname === "api.github.com"` — prevents bypass via subdomains like `api.github.com.evil.com`

**Log injection (2 alerts)**
- `utils.ts`: Added `sanitizeForLog()` helper stripping `\r\n` — applied to all interpolated values in `safeJsonParse` and `parseInstanceOverrides` log messages + structured data

**File system race condition (1 alert)**
- `secret-manager.ts`: Eliminated `existsSync()` TOCTOU race — now attempts `readFileSync` directly and catches `ENOENT` for first-run scenario. Write path already uses atomic temp+rename.

**Incomplete multi-character sanitization (4 alerts)**
- `description-utils.ts`: Extracted `stripHtmlComments()` helper that iteratively removes `<!--...-->` until stable (single-pass can leave remnants from nested/overlapping comments)
- `github-fetcher.ts`: Same iterative pattern for HTML comment stripping in CF description parsing

### Dismissed (40 alerts total)

**CodeQL dismissals (15):**
| Category | Count | Reason |
|----------|-------|--------|
| SSRF | 2 | Intentional admin feature (user-configured instance URLs) / hardcoded GitHub API URLs |
| Missing rate limiting | 7 | Already has `@fastify/rate-limit` globally + auth lockout after 5 failed attempts |
| Insecure temp file | 3 | Test-only code (vitest), not production |
| Incomplete code sanitization | 1 | Compile-time constant regex, not user input |
| Clear-text logging | 2 | Dev-only seed script (`seed-admin.ts`), not production code |

**Semgrep dismissals (25):**
| Category | Count | Reason |
|----------|-------|--------|
| Non-literal RegExp (tests) | 8 | Test helpers use controlled fixture names |
| Detected secrets (tests) | 3 | Test-only OIDC secret, TLS cert, JWT token |
| XSS direct-response-write | 8 | Fastify JSON API (Content-Type: application/json), not Express HTML |
| Non-literal RegExp (features) | 4 | Intentional regex editor/tester features with `escapeRegExp()` |
| Unsafe format string | 1 | Client-side regex pattern tester, no server-side evaluation |
| GCM no tag length | 1 | Node.js defaults to 16-byte (128-bit) NIST-recommended tag length |

## Test plan

- [x] TypeScript compilation clean (`tsc --noEmit`) for both `@arr/api` and `@arr/web`
- [ ] CI passes (lint, type check, E2E, tests)
- [ ] CodeQL re-scan resolves the fixed alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)