### PR TITLE
refactor: Migrate middleware.ts to proxy.ts (Next.js 16)

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -74,10 +74,10 @@ function clearSessionAndRedirect(request: NextRequest, targetPath: string): Next
 	return response;
 }
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
-	// Skip middleware for API/auth/health routes — handled by rewrites in next.config.mjs
+	// Skip proxy for API/auth/health routes — handled by rewrites in next.config.mjs
 	if (pathname.startsWith("/api/") || pathname.startsWith("/auth/") || pathname === "/health") {
 		return NextResponse.next();
 	}


### PR DESCRIPTION
## Summary

- Renames `middleware.ts` → `proxy.ts` and the exported function `middleware` → `proxy` to follow the Next.js 16 convention
- Eliminates the `⚠ The "middleware" file convention is deprecated` build warning
- No logic changes — pure rename, 96% similarity

## Test plan

- [x] `pnpm --filter @arr/web run build` passes with zero warnings
- [ ] Verify session validation still works (login, logout, redirect to `/login` on expired session)
- [ ] Verify `/` redirects to `/dashboard` when logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)