### PR TITLE
fix: Add delete button and fix refresh for queue cleaner configs

### DIFF
--- a/apps/web/src/features/queue-cleaner/components/dry-run-preview.tsx
+++ b/apps/web/src/features/queue-cleaner/components/dry-run-preview.tsx
@@ -12,6 +12,7 @@ import {
 	Play,
 	Shield,
 	Trash2,
+	Sparkles,
 	Wifi,
 	WifiOff,
 	X,
@@ -196,7 +197,7 @@ export const EnhancedDryRunPreview = ({
 								border: `1px solid ${serviceGradient.from}30`,
 							}}
 						>
-							<Trash2 className="h-5 w-5" style={{ color: serviceGradient.from }} />
+							<Sparkles className="h-5 w-5" style={{ color: serviceGradient.from }} />
 						</div>
 						<div>
 							<div className="flex items-center gap-2">

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-overview.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-overview.tsx
@@ -10,6 +10,7 @@ import {
 	Zap,
 	ShieldAlert,
 	SkipForward,
+	Sparkles,
 } from "lucide-react";
 import { Button, toast } from "../../../components/ui";
 import {
@@ -187,7 +188,7 @@ const InstanceStatusCard = ({
 										border: `1px solid ${serviceGradient.from}30`,
 									}}
 								>
-									<Trash2
+									<Sparkles
 										className="h-4 w-4"
 										style={{ color: serviceGradient.from }}
 									/>

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-statistics.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-statistics.tsx
@@ -8,6 +8,7 @@ import {
 	Clock,
 	TrendingUp,
 	Activity,
+	Sparkles,
 } from "lucide-react";
 import {
 	StatCard,
@@ -315,7 +316,7 @@ const InstanceBreakdownList = ({
 										border: `1px solid ${gradient.from}30`,
 									}}
 								>
-									<Trash2 className="h-4 w-4" style={{ color: gradient.from }} />
+									<Sparkles className="h-4 w-4" style={{ color: gradient.from }} />
 								</div>
 								<div>
 									<div className="flex items-center gap-2">
@@ -383,7 +384,7 @@ const RecentActivityList = ({
 									border: `1px solid ${gradient.from}30`,
 								}}
 							>
-								<Trash2 className="h-3.5 w-3.5" style={{ color: gradient.from }} />
+								<Sparkles className="h-3.5 w-3.5" style={{ color: gradient.from }} />
 							</div>
 							<div>
 								<div className="text-sm font-medium text-foreground">

--- a/apps/web/src/features/queue-cleaner/hooks/useQueueCleanerStatus.ts
+++ b/apps/web/src/features/queue-cleaner/hooks/useQueueCleanerStatus.ts
@@ -12,7 +12,6 @@ interface UseQueueCleanerStatusResult {
 	status: QueueCleanerStatus | null;
 	isLoading: boolean;
 	error: Error | null;
-	refetch: () => Promise<unknown>;
 }
 
 /**
@@ -30,6 +29,5 @@ export function useQueueCleanerStatus(): UseQueueCleanerStatusResult {
 		status: query.data ?? null,
 		isLoading: query.isLoading,
 		error: query.error,
-		refetch: query.refetch,
 	};
 }


### PR DESCRIPTION
## Summary
- **Delete button missing** — The backend DELETE endpoint, API client, mutation hook, and export all existed, but no UI button was rendered. Added a Delete button with two-click confirmation to each config card.
- **Misleading trash icon** — Decorative `Trash2` icons next to instance names were being mistaken for delete buttons. Replaced with `Sparkles` across all queue cleaner views.
- **Refresh button not working** — Previously only refetched status data (invisible on other tabs) with no visual feedback. Now invalidates all `["queue-cleaner"]` queries, shows a 600ms minimum spinner, and surfaces errors via toast.

Closes #110

## Changes
| File | Change |
|------|--------|
| `queue-cleaner-config.tsx` | Delete button with two-click confirm + `Sparkles` icon |
| `queue-cleaner-client.tsx` | Refresh with `invalidateQueries`, error handling, spinner |
| `queue-cleaner-overview.tsx` | `Sparkles` icon for instance status cards |
| `queue-cleaner-statistics.tsx` | `Sparkles` icon for instance breakdown/activity |
| `dry-run-preview.tsx` | `Sparkles` icon for preview header |
| `useQueueCleanerStatus.ts` | Removed unused `refetch`/`isFetching` exports |

## Test plan
- [ ] Navigate to `/queue-cleaner` → Overview tab: verify Sparkles icon (not trash can) next to each instance
- [ ] Click Refresh button: verify spinning icon for ~600ms, data refreshes across all tabs
- [ ] Switch to Configuration tab: verify Delete button on left side of each config card
- [ ] Click Delete once: verify it shows "Confirm Delete?" with red styling
- [ ] Click away (blur): verify it resets back to "Delete"
- [ ] Click Delete → Confirm Delete: verify config is removed and toast appears
- [ ] Disconnect API and click Refresh: verify error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)