### PR TITLE
fix: Add proper /health endpoint for Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,8 +126,8 @@ ENV DATABASE_URL="file:/config/prod.db" \
     # Node.js memory optimization for containers (can be overridden)
     NODE_OPTIONS="--max-old-space-size=512 --dns-result-order=ipv4first"
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
-    CMD wget -q --spider http://localhost:${PORT:-3000}/health || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD wget -q --spider http://127.0.0.1:${PORT:-3000}/health || exit 1
 
 # Signal for graceful shutdown (tini forwards to child processes)
 STOPSIGNAL SIGTERM

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,11 +1,14 @@
-import type { FastifyInstance, FastifyPluginOptions } from "fastify";
-import fp from "fastify-plugin";
+import type { FastifyPluginCallback } from "fastify";
 
-export const registerHealthRoutes = fp(
-	async (app: FastifyInstance, _opts: FastifyPluginOptions) => {
-		app.get("/", async () => ({ status: "ok" }));
-	},
-	{
-		name: "health-routes",
-	},
-);
+export const registerHealthRoutes: FastifyPluginCallback = (app, _opts, done) => {
+	app.get("/", async (request, reply) => {
+		try {
+			await app.prisma.$queryRaw`SELECT 1`;
+			return { status: "ok" };
+		} catch (error) {
+			request.log.error({ err: error }, "Health check failed");
+			return reply.status(503).send({ status: "error", reason: "Database unavailable" });
+		}
+	});
+	done();
+};

--- a/apps/web/app/health/route.ts
+++ b/apps/web/app/health/route.ts
@@ -1,0 +1,33 @@
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+	const apiHost = process.env.API_HOST || "http://localhost:3001";
+	const healthUrl = `${apiHost}/health`;
+	try {
+		const res = await fetch(healthUrl, {
+			signal: AbortSignal.timeout(2000),
+			cache: "no-store",
+		});
+		if (res.ok) {
+			return Response.json({ status: "ok" });
+		}
+
+		// Attempt to read upstream reason for better diagnostics
+		let upstreamReason = `API returned ${res.status}`;
+		try {
+			const body = await res.json();
+			if (body?.reason) {
+				upstreamReason = `API returned ${res.status}: ${body.reason}`;
+			}
+		} catch {
+			// Response body wasn't JSON — use the status code alone
+		}
+
+		console.error(`[health] ${upstreamReason}`);
+		return Response.json({ status: "error", reason: upstreamReason }, { status: 503 });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`[health] API health check failed: ${message}`);
+		return Response.json({ status: "error", reason: "API unreachable" }, { status: 503 });
+	}
+}

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -25,10 +25,6 @@ const nextConfig = {
 				source: "/auth/:path*",
 				destination: `${apiHost}/auth/:path*`,
 			},
-			{
-				source: "/health",
-				destination: `${apiHost}/health`,
-			},
 		];
 	},
 	async headers() {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -77,7 +77,7 @@ function clearSessionAndRedirect(request: NextRequest, targetPath: string): Next
 export async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
 
-	// Skip proxy for API/auth/health routes — handled by rewrites in next.config.mjs
+	// Skip proxy for API/auth/health routes — handled by rewrites or route handlers
 	if (pathname.startsWith("/api/") || pathname.startsWith("/auth/") || pathname === "/health") {
 		return NextResponse.next();
 	}


### PR DESCRIPTION
## Summary
Fixes #117 — Functional containers report as unhealthy because the Docker healthcheck hits `/health` on port 3000 (Next.js), which relied on a rewrite to proxy to the API on port 3001. The rewrite silently breaks in standalone mode, returning 404.

- **Add Next.js route handler** at `app/health/route.ts` that pings the API's `/health` endpoint and returns 200/503 with diagnostic logging
- **Upgrade API health probe** from static `{ status: "ok" }` to a real readiness check (`SELECT 1`) that verifies database connectivity
- **Remove `fastify-plugin` wrapper** from health route — `fp()` was silently stripping the `/health` prefix, registering the route at `/` instead
- **Remove broken `/health` rewrite** from `next.config.mjs` (unreliable in standalone builds)
- **Fix Alpine IPv6 resolution** — use `127.0.0.1` instead of `localhost` in healthcheck (BusyBox `wget` resolves to `::1` first, which fails against IPv4-bound Node.js)
- **Increase Dockerfile healthcheck timing** — `start-period` 10s→30s, `timeout` 3s→5s to account for dual-server startup

## Test plan
- [x] Build Docker image and verify `docker inspect --format='{{.State.Health.Status}}'` reports `healthy`
- [x] Stop the API process inside the container and verify healthcheck reports `unhealthy`
- [x] Verify `curl http://localhost:3000/health` returns `{ "status": "ok" }` when healthy
- [x] Verify `curl http://localhost:3000/health` returns `503` with error reason when API is down
- [x] Verify container logs show `[health] API health check failed` messages on failure

All 5 tests passed on Docker build from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)