### PR TITLE
fix(api): harden request validation (safeParse)

### DIFF
--- a/apps/api/src/lib/utils/__tests__/validate.test.ts
+++ b/apps/api/src/lib/utils/__tests__/validate.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Unit tests for validateRequest helper.
+ *
+ * Verifies that valid data passes through typed, and invalid data
+ * throws ZodValidationError with statusCode 400 and flattened details.
+ *
+ * Run with: npx vitest run validate.test.ts
+ */
+
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { validateRequest, ZodValidationError } from "../validate.js";
+
+const testSchema = z.object({
+	name: z.string().min(1),
+	age: z.number().int().positive(),
+	email: z.string().email().optional(),
+});
+
+describe("validateRequest", () => {
+	it("returns typed data for valid input", () => {
+		const input = { name: "Alice", age: 30 };
+		const result = validateRequest(testSchema, input);
+
+		expect(result).toEqual({ name: "Alice", age: 30 });
+		// Type-level check: result.name is a string, result.age is a number
+		expect(typeof result.name).toBe("string");
+		expect(typeof result.age).toBe("number");
+	});
+
+	it("strips unknown keys (Zod default behavior)", () => {
+		const input = { name: "Bob", age: 25, unknownField: "should be stripped" };
+		const result = validateRequest(testSchema, input);
+
+		expect(result).toEqual({ name: "Bob", age: 25 });
+		expect("unknownField" in result).toBe(false);
+	});
+
+	it("throws ZodValidationError for missing required fields", () => {
+		const input = { name: "Charlie" }; // missing age
+
+		try {
+			validateRequest(testSchema, input);
+			expect.fail("Expected ZodValidationError to be thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ZodValidationError);
+			const validationError = err as ZodValidationError;
+			expect(validationError.statusCode).toBe(400);
+			expect(validationError.message).toBe("Invalid payload");
+			expect(validationError.name).toBe("ZodValidationError");
+			expect(validationError.details.fieldErrors).toHaveProperty("age");
+		}
+	});
+
+	it("throws ZodValidationError for wrong types", () => {
+		const input = { name: 123, age: "not a number" };
+
+		try {
+			validateRequest(testSchema, input);
+			expect.fail("Expected ZodValidationError to be thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ZodValidationError);
+			const validationError = err as ZodValidationError;
+			expect(validationError.statusCode).toBe(400);
+			expect(validationError.details.fieldErrors).toHaveProperty("name");
+			expect(validationError.details.fieldErrors).toHaveProperty("age");
+		}
+	});
+
+	it("throws ZodValidationError for constraint violations", () => {
+		const input = { name: "", age: -5, email: "not-an-email" };
+
+		try {
+			validateRequest(testSchema, input);
+			expect.fail("Expected ZodValidationError to be thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ZodValidationError);
+			const validationError = err as ZodValidationError;
+			expect(validationError.statusCode).toBe(400);
+			expect(validationError.details.fieldErrors).toHaveProperty("name");
+			expect(validationError.details.fieldErrors).toHaveProperty("age");
+			expect(validationError.details.fieldErrors).toHaveProperty("email");
+		}
+	});
+
+	it("throws ZodValidationError for completely invalid input (null)", () => {
+		try {
+			validateRequest(testSchema, null);
+			expect.fail("Expected ZodValidationError to be thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ZodValidationError);
+			const validationError = err as ZodValidationError;
+			expect(validationError.statusCode).toBe(400);
+		}
+	});
+});
+
+describe("ZodValidationError", () => {
+	it("has correct shape for centralized error handler", () => {
+		const schema = z.object({ id: z.string().uuid() });
+		const result = schema.safeParse({ id: "not-a-uuid" });
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const error = new ZodValidationError(result.error);
+
+			// These properties are checked by the centralized error handler in server.ts
+			expect(error.statusCode).toBe(400);
+			expect(error.message).toBe("Invalid payload");
+			expect(error.name).toBe("ZodValidationError");
+			expect(error.details).toHaveProperty("formErrors");
+			expect(error.details).toHaveProperty("fieldErrors");
+			expect(Array.isArray(error.details.formErrors)).toBe(true);
+			expect(error.details.fieldErrors).toHaveProperty("id");
+		}
+	});
+});

--- a/apps/api/src/routes/dashboard/calendar-routes.ts
+++ b/apps/api/src/routes/dashboard/calendar-routes.ts
@@ -14,6 +14,7 @@ import {
 	formatDateOnly,
 	normalizeCalendarItem,
 } from "../../lib/dashboard/calendar-utils.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 const calendarQuerySchema = z.object({
 	start: z.string().optional(),
@@ -30,7 +31,7 @@ export const calendarRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Fetches upcoming releases from all enabled Sonarr, Radarr, Lidarr, and Readarr instances
 	 */
 	app.get("/dashboard/calendar", async (request, reply) => {
-		const { start, end, unmonitored } = calendarQuerySchema.parse(request.query ?? {});
+		const { start, end, unmonitored } = validateRequest(calendarQuerySchema, request.query ?? {});
 		const now = new Date();
 		const defaultStart = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 

--- a/apps/api/src/routes/dashboard/history-routes.ts
+++ b/apps/api/src/routes/dashboard/history-routes.ts
@@ -10,6 +10,7 @@ import {
 	isSonarrClient,
 } from "../../lib/arr/client-helpers.js";
 import { type HistoryService, normalizeHistoryItem } from "../../lib/dashboard/history-utils.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Query schema for history endpoint.
@@ -30,7 +31,7 @@ export const historyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Fetches download history from all enabled Sonarr, Radarr, Prowlarr, Lidarr, and Readarr instances
 	 */
 	app.get("/dashboard/history", async (request, reply) => {
-		const { startDate, endDate } = historyQuerySchema.parse(request.query ?? {});
+		const { startDate, endDate } = validateRequest(historyQuerySchema, request.query ?? {});
 
 		const response = await executeOnInstances(
 			app,

--- a/apps/api/src/routes/library/fetch-routes.ts
+++ b/apps/api/src/routes/library/fetch-routes.ts
@@ -34,6 +34,7 @@ import { buildMovieFile } from "../../lib/library/movie-normalizer.js";
 import { normalizeTrack } from "../../lib/library/track-normalizer.js";
 import { libraryQuerySchema } from "../../lib/library/validation-schemas.js";
 import { getLibrarySyncScheduler } from "../../lib/library-sync/index.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 import type { Prisma, LibraryItemType as PrismaLibraryItemType } from "../../lib/prisma.js";
 
 /**
@@ -47,7 +48,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Fetches library items from cache with server-side pagination, search, and filtering
 	 */
 	app.get("/library", async (request, reply) => {
-		const parsed = libraryQuerySchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryQuerySchema, request.query ?? {});
 		const userId = request.currentUser!.id;
 
 		// Get user's instances to filter cache by
@@ -332,7 +333,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Note: Episodes are NOT cached - fetched directly from ARR
 	 */
 	app.get("/library/episodes", async (request, reply) => {
-		const parsed = libraryEpisodesRequestSchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryEpisodesRequestSchema, request.query ?? {});
 
 		const clientResult = await getClientForInstance(app, request, parsed.instanceId);
 		if (!clientResult.success) {
@@ -381,7 +382,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * the Radarr version — we merge the richest data from both responses.
 	 */
 	app.get("/library/movie-file", async (request, reply) => {
-		const parsed = libraryMovieFileRequestSchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryMovieFileRequestSchema, request.query ?? {});
 
 		const clientResult = await getClientForInstance(app, request, parsed.instanceId);
 		if (!clientResult.success) {
@@ -459,7 +460,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Note: Albums are NOT cached - fetched directly from ARR
 	 */
 	app.get("/library/albums", async (request, reply) => {
-		const parsed = libraryAlbumsRequestSchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryAlbumsRequestSchema, request.query ?? {});
 
 		const clientResult = await getClientForInstance(app, request, parsed.instanceId);
 		if (!clientResult.success) {
@@ -500,7 +501,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Note: Books are NOT cached - fetched directly from ARR
 	 */
 	app.get("/library/books", async (request, reply) => {
-		const parsed = libraryBooksRequestSchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryBooksRequestSchema, request.query ?? {});
 
 		const clientResult = await getClientForInstance(app, request, parsed.instanceId);
 		if (!clientResult.success) {
@@ -541,7 +542,7 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Note: Tracks are NOT cached - fetched directly from ARR
 	 */
 	app.get("/library/tracks", async (request, reply) => {
-		const parsed = libraryTracksRequestSchema.parse(request.query ?? {});
+		const parsed = validateRequest(libraryTracksRequestSchema, request.query ?? {});
 
 		const clientResult = await getClientForInstance(app, request, parsed.instanceId);
 		if (!clientResult.success) {

--- a/apps/api/src/routes/library/monitor-routes.ts
+++ b/apps/api/src/routes/library/monitor-routes.ts
@@ -14,6 +14,7 @@ import {
 	isSonarrClient,
 } from "../../lib/arr/client-helpers.js";
 import { toNumber } from "../../lib/library/type-converters.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Optimistically update the library cache after a monitoring change
@@ -71,7 +72,7 @@ export const registerMonitorRoutes: FastifyPluginCallback = (app, _opts, done) =
 	 * Toggles monitoring status for movies, series, or specific seasons
 	 */
 	app.post("/library/monitor", async (request, reply) => {
-		const payload = libraryToggleMonitorRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryToggleMonitorRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -241,7 +242,7 @@ export const registerMonitorRoutes: FastifyPluginCallback = (app, _opts, done) =
 	 * Toggles monitoring status for specific episodes
 	 */
 	app.post("/library/episode/monitor", async (request, reply) => {
-		const payload = libraryEpisodeMonitorRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryEpisodeMonitorRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -291,7 +292,7 @@ export const registerMonitorRoutes: FastifyPluginCallback = (app, _opts, done) =
 	 * Toggles monitoring status for specific albums in Lidarr
 	 */
 	app.post("/library/album/monitor", async (request, reply) => {
-		const payload = libraryAlbumMonitorRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryAlbumMonitorRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -344,7 +345,7 @@ export const registerMonitorRoutes: FastifyPluginCallback = (app, _opts, done) =
 	 * Toggles monitoring status for specific books in Readarr
 	 */
 	app.post("/library/book/monitor", async (request, reply) => {
-		const payload = libraryBookMonitorRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryBookMonitorRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {

--- a/apps/api/src/routes/library/search-routes.ts
+++ b/apps/api/src/routes/library/search-routes.ts
@@ -17,6 +17,7 @@ import {
 	isReadarrClient,
 	isSonarrClient,
 } from "../../lib/arr/client-helpers.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Register search operation routes for library
@@ -35,7 +36,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues a season search in Sonarr
 	 */
 	app.post("/library/season/search", async (request, reply) => {
-		const payload = librarySeasonSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(librarySeasonSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -83,7 +84,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues a series search in Sonarr
 	 */
 	app.post("/library/series/search", async (request, reply) => {
-		const payload = librarySeriesSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(librarySeriesSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -123,7 +124,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues a movie search in Radarr
 	 */
 	app.post("/library/movie/search", async (request, reply) => {
-		const payload = libraryMovieSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryMovieSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -163,7 +164,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues an episode search in Sonarr
 	 */
 	app.post("/library/episode/search", async (request, reply) => {
-		const payload = libraryEpisodeSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryEpisodeSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -202,7 +203,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues an artist search in Lidarr
 	 */
 	app.post("/library/artist/search", async (request, reply) => {
-		const payload = libraryArtistSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryArtistSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -242,7 +243,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues an album search in Lidarr
 	 */
 	app.post("/library/album/search", async (request, reply) => {
-		const payload = libraryAlbumSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryAlbumSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -281,7 +282,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues an author search in Readarr
 	 */
 	app.post("/library/author/search", async (request, reply) => {
-		const payload = libraryAuthorSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryAuthorSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {
@@ -321,7 +322,7 @@ export const registerSearchRoutes: FastifyPluginCallback = (app, _opts, done) =>
 	 * Queues a book search in Readarr
 	 */
 	app.post("/library/book/search", async (request, reply) => {
-		const payload = libraryBookSearchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(libraryBookSearchRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {

--- a/apps/api/src/routes/manual-import.ts
+++ b/apps/api/src/routes/manual-import.ts
@@ -10,6 +10,7 @@ import {
 	setManualImportLogger,
 	submitManualImportCommandWithSdk,
 } from "./manual-import-utils.js";
+import { validateRequest } from "../lib/utils/validate.js";
 
 const manualImportQuerySchema = manualImportFetchQuerySchema.extend({
 	instanceId: z.string(),
@@ -24,7 +25,7 @@ const manualImportRoute: FastifyPluginCallback = (app, _opts, done) => {
 	});
 
 	app.get("/manual-import", async (request, reply) => {
-		const query = manualImportQuerySchema.parse(request.query ?? {});
+		const query = validateRequest(manualImportQuerySchema, request.query ?? {});
 
 		if (!query.downloadId && !query.folder) {
 			reply.status(400);
@@ -97,7 +98,7 @@ const manualImportRoute: FastifyPluginCallback = (app, _opts, done) => {
 	});
 
 	app.post("/manual-import", async (request, reply) => {
-		const body = manualImportSubmissionSchema.parse(request.body ?? {}) as ManualImportSubmission;
+		const body = validateRequest(manualImportSubmissionSchema, request.body ?? {}) as ManualImportSubmission;
 
 		const instance = await requireInstance(app, request.currentUser!.id, body.instanceId);
 

--- a/apps/api/src/routes/search/grab-routes.ts
+++ b/apps/api/src/routes/search/grab-routes.ts
@@ -2,6 +2,7 @@ import { searchGrabRequestSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { getClientForInstance, isProwlarrClient } from "../../lib/arr/client-helpers.js";
 import { grabProwlarrReleaseWithSdk } from "../../lib/search/prowlarr-api.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Registers grab/download routes for Prowlarr.
@@ -15,7 +16,7 @@ export const registerGrabRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Grabs a search result and sends it to the configured download client in Prowlarr.
 	 */
 	app.post("/search/grab", async (request, reply) => {
-		const payload = searchGrabRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(searchGrabRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {

--- a/apps/api/src/routes/search/indexer-routes.ts
+++ b/apps/api/src/routes/search/indexer-routes.ts
@@ -20,6 +20,7 @@ import {
 	updateProwlarrIndexerWithSdk,
 } from "../../lib/search/prowlarr-api.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Registers indexer-related routes for Prowlarr.
@@ -135,7 +136,8 @@ export const registerIndexerRoutes: FastifyPluginCallback = (app, _opts, done) =
 			});
 		}
 
-		const payload: SearchIndexerUpdateRequest = searchIndexerUpdateRequestSchema.parse(
+		const payload: SearchIndexerUpdateRequest = validateRequest(
+			searchIndexerUpdateRequestSchema,
 			request.body ?? {},
 		);
 		const instanceId = payload.instanceId ?? paramInstanceId;
@@ -188,7 +190,7 @@ export const registerIndexerRoutes: FastifyPluginCallback = (app, _opts, done) =
 	 * Tests an indexer connection to verify it's working correctly.
 	 */
 	app.post("/search/indexers/test", async (request, reply) => {
-		const payload = searchIndexerTestRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(searchIndexerTestRequestSchema, request.body ?? {});
 
 		const clientResult = await getClientForInstance(app, request, payload.instanceId);
 		if (!clientResult.success) {

--- a/apps/api/src/routes/search/query-routes.ts
+++ b/apps/api/src/routes/search/query-routes.ts
@@ -2,6 +2,7 @@ import { multiInstanceSearchResponseSchema, searchRequestSchema } from "@arr/sha
 import type { FastifyPluginCallback } from "fastify";
 import { executeOnInstances, isProwlarrClient } from "../../lib/arr/client-helpers.js";
 import { performProwlarrSearchWithSdk } from "../../lib/search/prowlarr-api.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Registers search query routes for Prowlarr.
@@ -16,7 +17,7 @@ export const registerQueryRoutes: FastifyPluginCallback = (app, _opts, done) => 
 	 * Supports filtering by indexer IDs and categories per instance.
 	 */
 	app.post("/search/query", async (request, _reply) => {
-		const payload = searchRequestSchema.parse(request.body ?? {});
+		const payload = validateRequest(searchRequestSchema, request.body ?? {});
 
 		// Build a map of instance-specific filters
 		const filterMap = new Map<string, { indexerIds?: number[]; categories?: number[] }>();


### PR DESCRIPTION
## Summary

- Replace 26 unsafe Zod `.parse()` calls on request inputs (`request.body`, `request.query`) with the existing `validateRequest()` helper across 9 route files
- `validateRequest()` uses `.safeParse()` internally and throws `ZodValidationError` (statusCode 400), which the centralized error handler catches — preventing raw `ZodError` from surfacing as HTTP 500
- Response validation `.parse()` calls (outgoing data) are intentionally unchanged — schema mismatches there indicate bugs, not bad input
- Adds 7 unit tests for `validateRequest()` and `ZodValidationError` shape

### Files changed (9 routes + 1 test)

| File | `.parse()` → `validateRequest()` |
|------|----------------------------------|
| `routes/library/monitor-routes.ts` | 4 calls |
| `routes/library/search-routes.ts` | 8 calls |
| `routes/library/fetch-routes.ts` | 6 calls (request input only) |
| `routes/search/query-routes.ts` | 1 call |
| `routes/search/indexer-routes.ts` | 2 calls |
| `routes/search/grab-routes.ts` | 1 call |
| `routes/dashboard/calendar-routes.ts` | 1 call |
| `routes/dashboard/history-routes.ts` | 1 call |
| `routes/manual-import.ts` | 2 calls |
| **Total** | **26 trust boundary calls** |

### New test

`apps/api/src/lib/utils/__tests__/validate.test.ts` — 7 tests covering:
- Valid data passthrough with type safety
- Unknown key stripping
- Missing required fields → 400 with field errors
- Wrong types → 400 with field errors
- Constraint violations → 400 with field errors
- Null input → 400
- ZodValidationError shape matches centralized handler expectations

## Test plan

- [x] `npx vitest run validate.test.ts` — 7/7 passing
- [x] `tsc --noEmit` — no new errors (all pre-existing errors unrelated)
- [ ] Manual smoke: hit any converted endpoint with malformed body → expect 400 with `{ error, message, details }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)