### PR TITLE
fix(docker): auto-migrate PostgreSQL secrets on v2.9 upgrade

### DIFF
--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -1,5 +1,11 @@
 import { randomBytes } from "node:crypto";
-import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+	copyFileSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname } from "node:path";
 import { loggers } from "../logger.js";
 
@@ -9,6 +15,15 @@ export interface Secrets {
 	encryptionKey: string;
 	sessionCookieSecret: string;
 }
+
+/**
+ * Known legacy secrets paths from previous versions.
+ * When the primary path doesn't exist, these are checked in order
+ * to migrate secrets from an older installation (e.g., v2.8.x → v2.9).
+ */
+const LEGACY_SECRETS_PATHS = [
+	"/app/api/data/secrets.json", // v2.8.x PostgreSQL Docker default
+];
 
 /**
  * Manages persistent secrets for the application.
@@ -22,8 +37,8 @@ export class SecretManager {
 	}
 
 	/**
-	 * Get or create secrets. If secrets file doesn't exist, generates new secrets
-	 * and persists them to disk.
+	 * Get or create secrets. If secrets file doesn't exist, checks legacy paths
+	 * for migration before generating new secrets.
 	 */
 	getOrCreateSecrets(): Secrets {
 		// Try to load existing secrets (no existence check to avoid TOCTOU race)
@@ -43,6 +58,14 @@ export class SecretManager {
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 				log.error({ err: error }, "Failed to load secrets, regenerating");
 			}
+		}
+
+		// Before generating new secrets, check legacy paths for migration.
+		// This prevents data loss when upgrading from v2.8.x where PostgreSQL
+		// secrets were stored at /app/api/data/secrets.json instead of /config/.
+		const migrated = this.tryMigrateLegacySecrets();
+		if (migrated) {
+			return migrated;
 		}
 
 		// Generate new secrets
@@ -68,6 +91,47 @@ export class SecretManager {
 		}
 
 		return secrets;
+	}
+
+	/**
+	 * Check legacy secrets paths and migrate if found.
+	 * Returns the migrated secrets, or null if no legacy file was found.
+	 */
+	private tryMigrateLegacySecrets(): Secrets | null {
+		for (const legacyPath of LEGACY_SECRETS_PATHS) {
+			// Skip if the legacy path is the same as the current path
+			if (legacyPath === this.secretsPath) {
+				continue;
+			}
+
+			try {
+				const content = readFileSync(legacyPath, "utf-8");
+				const secrets = JSON.parse(content) as Secrets;
+
+				if (!this.isValidSecrets(secrets)) {
+					log.warn(
+						{ legacyPath },
+						"Found legacy secrets file but format is invalid, skipping",
+					);
+					continue;
+				}
+
+				// Migrate: copy legacy file to the new path
+				log.info(
+					{ from: legacyPath, to: this.secretsPath },
+					"Migrating secrets from legacy path (v2.8.x upgrade)",
+				);
+				mkdirSync(dirname(this.secretsPath), { recursive: true });
+				copyFileSync(legacyPath, this.secretsPath);
+
+				return secrets;
+			} catch {
+				// File doesn't exist or can't be read — try next legacy path
+				continue;
+			}
+		}
+
+		return null;
 	}
 
 	private isValidSecrets(secrets: unknown): secrets is Secrets {


### PR DESCRIPTION
## Summary
- **P0-S3**: Prevents silent data loss when upgrading PostgreSQL users from v2.8.x to v2.9
- Before generating new secrets, checks legacy path (`/app/api/data/secrets.json`) and copies to new location (`/config/secrets.json`)
- Clear log message when migration occurs

## Problem
In v2.8.x, PostgreSQL Docker users' `secrets.json` was stored at `/app/api/data/secrets.json`. The v2.9 path resolution changed to `/config/secrets.json`. On upgrade, `SecretManager` couldn't find the file, generated new encryption keys, and silently broke all previously encrypted API keys and OIDC secrets.

## Changes
- `apps/api/src/lib/auth/secret-manager.ts`: Added `tryMigrateLegacySecrets()` method and `LEGACY_SECRETS_PATHS` constant

## Test plan
- [ ] Fresh install: no legacy file exists → generates new secrets as before
- [ ] Upgrade: legacy file at `/app/api/data/secrets.json` → migrated to `/config/secrets.json`
- [ ] Both files exist: prefers `/config/secrets.json` (current path checked first)
- [ ] Invalid legacy file: skipped with warning, generates new secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)