### PR TITLE
fix(cleanup): add safety rails for bulk approval and execution

### DIFF
--- a/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
+++ b/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
@@ -24,6 +24,14 @@ import {
 	PremiumTabs,
 	StatusBadge,
 } from "@/components/layout";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import {
 	useApproveCleanupItem,
@@ -129,6 +137,7 @@ function ConfigTab({
 
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [editingRule, setEditingRule] = useState<CleanupRuleResponse | null>(null);
+	const [confirmRunOpen, setConfirmRunOpen] = useState(false);
 
 	const actionCounts = useMemo(() => {
 		if (!previewData?.items) return null;
@@ -234,7 +243,7 @@ function ConfigTab({
 				</GradientButton>
 				<GradientButton
 					variant="secondary"
-					onClick={onExecute}
+					onClick={() => setConfirmRunOpen(true)}
 					disabled={isExecuting || !config.enabled}
 				>
 					{isExecuting ? (
@@ -244,6 +253,36 @@ function ConfigTab({
 					)}
 					Run Now
 				</GradientButton>
+
+				{/* Confirmation dialog for destructive cleanup execution */}
+				<Dialog open={confirmRunOpen} onOpenChange={setConfirmRunOpen}>
+					<DialogContent className="max-w-md">
+						<DialogHeader>
+							<DialogTitle>Run Library Cleanup?</DialogTitle>
+							<DialogDescription>
+								This will evaluate your library against all enabled rules and{" "}
+								{config.dryRunMode
+									? "flag matching items (dry run mode — nothing will be removed)."
+									: config.requireApproval
+										? "queue matching items for approval."
+										: "remove or unmonitor matching items. This action cannot be undone."}
+							</DialogDescription>
+						</DialogHeader>
+						<DialogFooter>
+							<GradientButton variant="secondary" onClick={() => setConfirmRunOpen(false)}>
+								Cancel
+							</GradientButton>
+							<GradientButton
+								onClick={() => {
+									setConfirmRunOpen(false);
+									onExecute();
+								}}
+							>
+								{config.dryRunMode ? "Run Preview" : config.requireApproval ? "Run & Queue" : "Run & Execute"}
+							</GradientButton>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
 
 				{executeResult && (
 					<span className="text-sm text-muted-foreground">

--- a/packages/shared/src/types/library-cleanup.ts
+++ b/packages/shared/src/types/library-cleanup.ts
@@ -407,8 +407,10 @@ export type UpdateCleanupConfig = z.infer<typeof updateCleanupConfigSchema>;
 export const approvalActionSchema = z.enum(["approved", "rejected"]);
 export type ApprovalAction = z.infer<typeof approvalActionSchema>;
 
+export const BULK_APPROVAL_MAX_IDS = 100;
+
 export const bulkApprovalSchema = z.object({
-	ids: z.array(z.string()).min(1),
+	ids: z.array(z.string()).min(1).max(BULK_APPROVAL_MAX_IDS),
 	action: approvalActionSchema,
 });
 


### PR DESCRIPTION
## Summary
- **P0-S1**: Library cleanup safety rails
- Caps bulk approval endpoint to 100 IDs per request (`BULK_APPROVAL_MAX_IDS`)
- Adds confirmation dialog to "Run Now" button with context-aware messaging based on mode (dry run / approval queue / direct execution)

## Changes
- `packages/shared/src/types/library-cleanup.ts`: Added `.max(100)` to `bulkApprovalSchema.ids` + exported `BULK_APPROVAL_MAX_IDS`
- `apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx`: Added confirmation Dialog before cleanup execution

## Test plan
- [ ] Bulk approval with >100 IDs returns 400 validation error
- [ ] "Run Now" button shows confirmation dialog before executing
- [ ] Dialog text changes based on `dryRunMode` / `requireApproval` config
- [ ] Cancel in dialog does not trigger execution
- [ ] Confirm in dialog triggers execution normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)