### PR TITLE
fix(notifications): add payload truncation for Discord and Telegram

### DIFF
--- a/apps/api/src/lib/notifications/channels/discord-sender.ts
+++ b/apps/api/src/lib/notifications/channels/discord-sender.ts
@@ -3,26 +3,41 @@ import type { ChannelSender, NotificationPayload } from "../types.js";
 import { extractMetadataFields } from "./format-metadata.js";
 
 const DISCORD_TIMEOUT_MS = 10000;
+/** Discord embed limits */
+const DISCORD_MAX_FIELDS = 25;
+const DISCORD_MAX_FIELD_VALUE = 1024;
+const DISCORD_MAX_EMBED_TOTAL = 5500; // Leave buffer under 6000
 
 export const discordSender: ChannelSender = {
 	async send(config: Record<string, unknown>, payload: NotificationPayload): Promise<void> {
 		const { webhookUrl } = config as DiscordConfig;
 
-		const fields = extractMetadataFields(payload.metadata).map((f) => ({
+		const allFields = extractMetadataFields(payload.metadata).map((f) => ({
 			name: f.label,
-			value: f.value,
+			value: f.value.length > DISCORD_MAX_FIELD_VALUE ? `${f.value.slice(0, DISCORD_MAX_FIELD_VALUE - 3)}...` : f.value,
 			inline: f.value.length < 30,
 		}));
+		// Discord allows max 25 fields per embed
+		const fields = allFields.slice(0, DISCORD_MAX_FIELDS);
+
+		const title = payload.title.slice(0, 256);
+		const description = payload.body.slice(0, 4096);
 
 		const embed: Record<string, unknown> = {
-			title: payload.title,
-			description: payload.body,
+			title,
+			description,
 			color: getEventColor(payload.eventType),
 			timestamp: new Date().toISOString(),
 			...(payload.url ? { url: payload.url } : {}),
 			footer: { text: `Arr Dashboard • ${payload.eventType}` },
 			...(fields.length > 0 ? { fields } : {}),
 		};
+
+		// Guard: if total embed JSON exceeds Discord limit, drop fields
+		const embedJson = JSON.stringify(embed);
+		if (embedJson.length > DISCORD_MAX_EMBED_TOTAL && fields.length > 0) {
+			delete embed.fields;
+		}
 
 		const response = await fetch(webhookUrl, {
 			method: "POST",

--- a/apps/api/src/lib/notifications/channels/format-metadata.ts
+++ b/apps/api/src/lib/notifications/channels/format-metadata.ts
@@ -11,6 +11,11 @@ export interface MetadataField {
 	value: string;
 }
 
+/** Max length for a single formatted value (Discord field limit is 1024) */
+const MAX_VALUE_LENGTH = 1000;
+/** Max items to show from an array before truncating */
+const MAX_ARRAY_ITEMS = 15;
+
 /** Pretty-print labels for known metadata keys */
 const LABEL_MAP: Record<string, string> = {
 	// System
@@ -103,18 +108,27 @@ function formatValue(key: string, value: unknown): string {
 
 	if (Array.isArray(value)) {
 		if (value.length === 0) return "";
+		const totalCount = value.length;
+		const limited = value.slice(0, MAX_ARRAY_ITEMS);
+		const suffix = totalCount > MAX_ARRAY_ITEMS ? ` (+${totalCount - MAX_ARRAY_ITEMS} more)` : "";
+
+		let result: string;
 		// Handle arrays of objects with title/rule shape
-		if (typeof value[0] === "object" && value[0] !== null) {
-			return value
-				.map((item) => {
-					const obj = item as Record<string, unknown>;
-					if (obj.title && obj.rule) return `${obj.title} (${obj.rule})`;
-					if (obj.title) return String(obj.title);
-					return JSON.stringify(obj);
-				})
-				.join(", ");
+		if (typeof limited[0] === "object" && limited[0] !== null) {
+			result =
+				limited
+					.map((item) => {
+						const obj = item as Record<string, unknown>;
+						if (obj.title && obj.rule) return `${obj.title} (${obj.rule})`;
+						if (obj.title) return String(obj.title);
+						return JSON.stringify(obj);
+					})
+					.join(", ") + suffix;
+		} else {
+			result = limited.join(", ") + suffix;
 		}
-		return value.join(", ");
+
+		return truncateValue(result);
 	}
 
 	if (typeof value === "object" && value !== null) {
@@ -122,6 +136,12 @@ function formatValue(key: string, value: unknown): string {
 	}
 
 	return String(value);
+}
+
+/** Truncate a value string if it exceeds the max length */
+function truncateValue(value: string): string {
+	if (value.length <= MAX_VALUE_LENGTH) return value;
+	return `${value.slice(0, MAX_VALUE_LENGTH - 3)}...`;
 }
 
 /** Convert camelCase key to Title Case label */

--- a/apps/api/src/lib/notifications/channels/telegram-sender.ts
+++ b/apps/api/src/lib/notifications/channels/telegram-sender.ts
@@ -4,6 +4,8 @@ import { extractMetadataFields } from "./format-metadata.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 const TELEGRAM_TIMEOUT_MS = 10000;
+/** Telegram sendMessage limit is 4096 chars */
+const TELEGRAM_MAX_MESSAGE_LENGTH = 4000; // Buffer for HTML entity expansion
 
 export const telegramSender: ChannelSender = {
 	async send(config: Record<string, unknown>, payload: NotificationPayload): Promise<void> {
@@ -21,6 +23,11 @@ export const telegramSender: ChannelSender = {
 
 		if (payload.url) {
 			text += `\n\n<a href="${escapeHtml(payload.url)}">View Details</a>`;
+		}
+
+		// Truncate if exceeds Telegram's message limit
+		if (text.length > TELEGRAM_MAX_MESSAGE_LENGTH) {
+			text = `${text.slice(0, TELEGRAM_MAX_MESSAGE_LENGTH - 20)}\n\n<i>(truncated)</i>`;
 		}
 
 		await sendMessage(botToken, chatId, text);


### PR DESCRIPTION
## Summary
- **P0-S2**: Prevents silent notification delivery failures from oversized payloads
- Centralizes array truncation in `format-metadata.ts` (15 items max, 1000 char values)
- Discord: field values ≤ 1024, max 25 fields, total embed ≤ 5500 with graceful fallback
- Telegram: message truncated to 4000 chars (buffer under 4096 API limit)

## Changes
- `apps/api/src/lib/notifications/channels/format-metadata.ts`: Array truncation + value length limits
- `apps/api/src/lib/notifications/channels/discord-sender.ts`: Discord-specific embed size guards
- `apps/api/src/lib/notifications/channels/telegram-sender.ts`: Telegram message length guard

## Test plan
- [ ] Notification with >15 items in metadata array shows "... (+N more)" suffix
- [ ] Discord embed with many fields doesn't exceed 6000 chars
- [ ] Telegram message with long metadata is truncated with "(truncated)" suffix
- [ ] Normal notifications (short metadata) render identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)