### PR TITLE
fix(cache): evict stale Plex and Tautulli cache rows after refresh

### DIFF
--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -221,9 +221,10 @@ export async function refreshPlexCache(
 		}
 
 		// 6. Upsert into PlexCache (per-section rows)
+		const upsertedIds: string[] = [];
 		for (const agg of aggregations.values()) {
 			try {
-				await prisma.plexCache.upsert({
+				const row = await prisma.plexCache.upsert({
 					where: {
 						instanceId_tmdbId_mediaType_sectionId: {
 							instanceId,
@@ -261,6 +262,7 @@ export async function refreshPlexCache(
 						addedAt: agg.addedAt,
 					},
 				});
+				upsertedIds.push(row.id);
 				upserted++;
 			} catch (error) {
 				errors++;
@@ -268,6 +270,16 @@ export async function refreshPlexCache(
 					{ err: error, instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType },
 					"Plex cache: failed to upsert item",
 				);
+			}
+		}
+
+		// Evict stale rows: items that were in a previous refresh but no longer exist in Plex
+		if (upsertedIds.length > 0) {
+			const evicted = await prisma.plexCache.deleteMany({
+				where: { instanceId, id: { notIn: upsertedIds } },
+			});
+			if (evicted.count > 0) {
+				log.info({ instanceId, evicted: evicted.count }, "Plex cache: evicted stale rows");
 			}
 		}
 

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -139,12 +139,13 @@ export async function refreshTautulliCache(
 		}
 
 		// 5. Upsert into TautulliCache
+		const upsertedIds: string[] = [];
 		for (const [ratingKey, info] of itemMap) {
 			const guid = ratingKeyToGuid.get(ratingKey);
 			if (!guid) continue;
 
 			try {
-				await prisma.tautulliCache.upsert({
+				const row = await prisma.tautulliCache.upsert({
 					where: {
 						instanceId_tmdbId_mediaType: {
 							instanceId,
@@ -166,6 +167,7 @@ export async function refreshTautulliCache(
 						watchedByUsers: JSON.stringify([...info.users]),
 					},
 				});
+				upsertedIds.push(row.id);
 				upserted++;
 			} catch (error) {
 				errors++;
@@ -173,6 +175,16 @@ export async function refreshTautulliCache(
 					{ err: error, instanceId, tmdbId: guid.tmdbId, mediaType: guid.mediaType },
 					"Tautulli cache: failed to upsert item",
 				);
+			}
+		}
+
+		// Evict stale rows: items that were in a previous refresh but no longer exist in Tautulli
+		if (upsertedIds.length > 0) {
+			const evicted = await prisma.tautulliCache.deleteMany({
+				where: { instanceId, id: { notIn: upsertedIds } },
+			});
+			if (evicted.count > 0) {
+				log.info({ instanceId, evicted: evicted.count }, "Tautulli cache: evicted stale rows");
 			}
 		}
 


### PR DESCRIPTION
## Summary
- **P0-S4**: Cache eviction for Plex/Tautulli integration caches
- After each refresh cycle, deletes rows for the instance that weren't touched (stale entries from removed items)
- Prevents unbounded cache table growth over time

## Changes
- `apps/api/src/lib/plex/plex-cache-refresher.ts`: Track upserted IDs, deleteMany for stale rows
- `apps/api/src/lib/tautulli/tautulli-cache-refresher.ts`: Same eviction pattern

## Test plan
- [ ] Plex cache refresh evicts rows for items removed from Plex
- [ ] Tautulli cache refresh evicts rows for items no longer in history
- [ ] Fresh instance with empty cache — no errors from eviction step
- [ ] Failed upserts don't incorrectly evict (only successful upserts tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)