### PR TITLE
fix(validation): address code review and security findings

### DIFF
--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -381,7 +381,8 @@ export class PlexClient {
 		if (contentType.includes("application/json")) {
 			const raw = await response.json();
 			if (options?.schema) {
-				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category: path });
+				const category = path.split("?")[0] ?? path;
+				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
 			}
 			return raw as T;
 		}

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -257,7 +257,10 @@ export class TautulliClient {
 		const raw = await response.json();
 
 		// Validate wrapper structure
-		const wrapper = tautulliResponseWrapperSchema.parse(raw);
+		const wrapper = parseUpstreamOrThrow(raw, tautulliResponseWrapperSchema, {
+			integration: "tautulli",
+			category: `${cmd}/wrapper`,
+		});
 
 		if (wrapper.response.result !== "success") {
 			throw new Error(`Tautulli API error: ${wrapper.response.message ?? "Unknown error"}`);

--- a/apps/api/src/lib/validation/__tests__/validation-modes.test.ts
+++ b/apps/api/src/lib/validation/__tests__/validation-modes.test.ts
@@ -93,7 +93,7 @@ describe("Validation Modes", () => {
 			const result = validateAndCollect(data, schema, "test", mockLog, { mode: "disabled" });
 
 			expect(result.items).toHaveLength(3);
-			expect(result.stats.validated).toBe(3);
+			expect(result.stats.validated).toBe(0); // disabled mode: nothing was actually validated
 			expect(result.stats.rejected).toBe(0);
 		});
 	});

--- a/apps/api/src/lib/validation/validate-batch.ts
+++ b/apps/api/src/lib/validation/validate-batch.ts
@@ -77,11 +77,11 @@ export function validateAndCollect<T>(
 	const mode = options?.mode ?? getValidationMode(options?.integration);
 	const items = Array.isArray(rawData) ? rawData : [rawData];
 
-	// Disabled mode: skip validation entirely
+	// Disabled mode: skip validation entirely (stats reflect no validation occurred)
 	if (mode === "disabled") {
 		return {
 			items: items as T[],
-			stats: { total: items.length, validated: items.length, rejected: 0 },
+			stats: { total: items.length, validated: 0, rejected: 0 },
 		};
 	}
 

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -6,6 +6,7 @@ import { LOG_DIR, LOG_LEVEL, LOG_MAX_FILES, LOG_MAX_SIZE } from "../lib/logger.j
 import { getAppVersionInfo } from "../lib/utils/version.js";
 import { integrationHealth } from "../lib/validation/integration-health.js";
 import { schemaFingerprints } from "../lib/validation/schema-fingerprint.js";
+import { KNOWN_INTEGRATIONS } from "../lib/validation/index.js";
 import { type ValidationMode, getAllValidationModes, setValidationMode } from "../lib/validation/validate-batch.js";
 
 const RESTART_RATE_LIMIT = { max: 2, timeWindow: "5 minutes" };
@@ -456,6 +457,12 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		if (!integration || typeof integration !== "string") {
 			return reply.status(400).send({ error: "integration is required and must be a string" });
+		}
+
+		if (!KNOWN_INTEGRATIONS.includes(integration as (typeof KNOWN_INTEGRATIONS)[number])) {
+			return reply.status(400).send({
+				error: `Unknown integration "${integration}". Valid integrations: ${KNOWN_INTEGRATIONS.join(", ")}`,
+			});
 		}
 
 		const validModes: ValidationMode[] = ["strict", "tolerant", "log-only", "disabled"];

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -328,6 +328,11 @@ function ValidationHealthSection({
 				</div>
 
 				{/* Per-Integration Breakdown */}
+				{integrationNames.length === 0 && (
+					<p className="text-sm text-muted-foreground text-center py-4">
+						No validation data yet — stats appear after the first API call to each integration.
+					</p>
+				)}
 				{integrationNames.length > 0 && (
 					<GlassmorphicCard padding="none">
 						<div className="overflow-x-auto">


### PR DESCRIPTION
## Summary

Fixes 5 issues found during code review and security audit of PRs #160–#165:

| # | Severity | Fix | File |
|---|----------|-----|------|
| 1 | Important | Tautulli wrapper `.parse()` → `parseUpstreamOrThrow` (was bypassing health registry + throwing raw ZodError) | `tautulli-client.ts` |
| 2 | Important | Strip query params from Plex path before using as category key (was creating unbounded category entries per pagination offset) | `plex-client.ts` |
| 3 | Medium | Validate integration name against `KNOWN_INTEGRATIONS` in PUT endpoint | `system.ts` |
| 4 | Medium | `disabled` mode: report `validated: 0` instead of `items.length` (misleading health stats) | `validate-batch.ts` |
| 5 | Minor | Add empty state message in UI when no validation data exists yet | `system-tab.tsx` |

### Not addressed (accepted risks)
- Unbounded memory growth in health registry — acceptable for a single-admin self-hosted app; can add rolling windows in a future PR if needed
- `UpstreamValidationError` messages include schema field names — acceptable since all users are admins and messages are useful for debugging

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` passes
- [x] `pnpm --filter @arr/web exec tsc --noEmit` passes
- [x] Full test suite passes (1040 tests)
- [x] Updated `disabled` mode test to expect `validated: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)