### PR TITLE
feat(validation): add reset endpoint for validation health stats

### DIFF
--- a/apps/api/src/lib/validation/integration-health.ts
+++ b/apps/api/src/lib/validation/integration-health.ts
@@ -21,6 +21,8 @@ export interface IntegrationHealth {
 export interface AllIntegrationHealth {
 	integrations: Record<string, IntegrationHealth>;
 	overallTotals: ValidationStats;
+	/** ISO timestamp of the last reset (null = never reset, stats since app start) */
+	resetAt: string | null;
 }
 
 // ============================================================================
@@ -29,6 +31,7 @@ export interface AllIntegrationHealth {
 
 class IntegrationHealthRegistry {
 	private readonly data = new Map<string, IntegrationHealth>();
+	private _resetAt: string | null = null;
 
 	/** Record validation stats for a specific integration + category */
 	record(integration: string, category: string, stats: ValidationStats): void {
@@ -75,7 +78,7 @@ class IntegrationHealthRegistry {
 			overallTotals.rejected += health.totals.rejected;
 		}
 
-		return { integrations, overallTotals };
+		return { integrations, overallTotals, resetAt: this._resetAt };
 	}
 
 	/** Reset stats for a specific integration */
@@ -83,8 +86,9 @@ class IntegrationHealthRegistry {
 		this.data.delete(integration);
 	}
 
-	/** Reset all stats */
+	/** Reset all stats and record the reset timestamp */
 	reset(): void {
+		this._resetAt = new Date().toISOString();
 		this.data.clear();
 	}
 }

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -482,6 +482,23 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		});
 	});
 
+	/**
+	 * DELETE /system/validation-health
+	 * Reset all validation health stats. Returns the new (empty) state with resetAt timestamp.
+	 */
+	app.delete("/validation-health", async (request, reply) => {
+		integrationHealth.reset();
+		request.log.info("Validation health stats reset");
+		return reply.send({
+			success: true,
+			data: {
+				...integrationHealth.getAll(),
+				fingerprints: schemaFingerprints.getAll(),
+				validationModes: getAllValidationModes(),
+			},
+		});
+	});
+
 	done();
 };
 

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -115,6 +115,7 @@ interface ValidationHealthResponse {
 		integrations: Record<string, IntegrationHealth>;
 		overallTotals: ValidationStats;
 		validationModes: Record<string, string>;
+		resetAt: string | null;
 	};
 }
 
@@ -132,6 +133,10 @@ async function getLogFiles(): Promise<LogFilesResponse> {
 
 async function getValidationHealth(): Promise<ValidationHealthResponse> {
 	return apiRequest<ValidationHealthResponse>("/api/system/validation-health");
+}
+
+async function resetValidationHealth(): Promise<ValidationHealthResponse> {
+	return apiRequest<ValidationHealthResponse>("/api/system/validation-health", { method: "DELETE" });
 }
 
 function formatUptime(seconds: number): string {
@@ -221,11 +226,15 @@ function SystemInfoCard({ icon, label, value, subtitle, animationDelay = 0 }: Sy
 function ValidationHealthSection({
 	data,
 	themeGradient,
+	onReset,
+	isResetting,
 }: {
 	data: ValidationHealthResponse["data"];
 	themeGradient: { from: string; to: string; glow: string };
+	onReset: () => void;
+	isResetting: boolean;
 }) {
-	const { overallTotals, integrations, validationModes } = data;
+	const { overallTotals, integrations, validationModes, resetAt } = data;
 	const integrationNames = Object.keys(integrations);
 	const rejectionRate =
 		overallTotals.total > 0
@@ -252,6 +261,29 @@ function ValidationHealthSection({
 			icon={ShieldAlert}
 		>
 			<div className="space-y-4">
+				{/* Reset Controls */}
+				<div className="flex items-center justify-between">
+					<p className="text-xs text-muted-foreground">
+						{resetAt
+							? `Stats since: ${new Date(resetAt).toLocaleString()}`
+							: "Stats since app start"}
+					</p>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={onReset}
+						disabled={isResetting || overallTotals.total === 0}
+						className="h-7 text-xs gap-1.5"
+					>
+						{isResetting ? (
+							<Loader2 className="h-3 w-3 animate-spin" />
+						) : (
+							<RefreshCw className="h-3 w-3" />
+						)}
+						Reset Stats
+					</Button>
+				</div>
+
 				{/* Summary Cards */}
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 					<SystemInfoCard
@@ -463,6 +495,17 @@ export function SystemTab() {
 		queryKey: ["validation-health"],
 		queryFn: getValidationHealth,
 		refetchInterval: 60000,
+	});
+
+	const resetHealthMutation = useMutation({
+		mutationFn: resetValidationHealth,
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["validation-health"] });
+			toast.success("Validation health stats reset");
+		},
+		onError: (error) => {
+			toast.error(getErrorMessage(error, "Failed to reset validation health"));
+		},
 	});
 
 	const updateMutation = useMutation({
@@ -699,6 +742,8 @@ export function SystemTab() {
 				<ValidationHealthSection
 					data={validationHealth.data}
 					themeGradient={themeGradient}
+					onReset={() => resetHealthMutation.mutate()}
+					isResetting={resetHealthMutation.isPending}
 				/>
 			)}
 


### PR DESCRIPTION
## Summary
- Adds `DELETE /system/validation-health` endpoint that clears all accumulated stats and records a `resetAt` ISO timestamp
- Adds `resetAt` field to `AllIntegrationHealth` interface for tracking when stats were last cleared
- Adds "Reset Stats" button and "Stats since" timestamp display to the Validation Health section in Settings > System
- DELETE response matches GET response shape (includes `validationModes` and `fingerprints`)

## Context
Addresses the unbounded memory growth concern from the security review in #166. Cumulative counters can obscure recent trends over long uptimes — this gives admins explicit control to reset stats and monitor fresh data.

## Test plan
- [ ] Verify `tsc --noEmit` passes for API, shared, and web packages
- [ ] Verify all 1040 tests pass
- [ ] Verify lint passes with 0 errors
- [ ] Manual: Click "Reset Stats" button — stats should clear, "Stats since" should show current timestamp
- [ ] Manual: After reset, new API calls should accumulate fresh stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)