### PR TITLE
fix(validation): consistency & safety hardening

### DIFF
--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -384,6 +384,9 @@ export class PlexClient {
 				const category = path.split("?")[0] ?? path;
 				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
 			}
+			if (raw !== null && typeof raw === "object" && Object.keys(raw as Record<string, unknown>).length > 0) {
+				this.log.debug({ path }, "Plex returned JSON but no schema was provided for validation");
+			}
 			return raw as T;
 		}
 

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -259,7 +259,7 @@ export class TautulliClient {
 		// Validate wrapper structure
 		const wrapper = parseUpstreamOrThrow(raw, tautulliResponseWrapperSchema, {
 			integration: "tautulli",
-			category: `${cmd}/wrapper`,
+			category: cmd,
 		});
 
 		if (wrapper.response.result !== "success") {

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -23,6 +23,7 @@ import type { FastifyBaseLogger } from "fastify";
 import DOMPurify from "isomorphic-dompurify";
 import { z } from "zod";
 import { marked } from "marked";
+import { parseUpstreamOrThrow, UpstreamValidationError } from "../validation/parse-upstream.js";
 import {
 	radarrNamingSchema,
 	sonarrNamingSchema,
@@ -242,11 +243,12 @@ interface FetchOptions {
 	repoConfig?: TrashRepoConfig;
 }
 
-interface TrashMetadata {
-	version?: string;
-	lastUpdated?: string;
-	[key: string]: unknown;
-}
+/** Schema for TRaSH Guides metadata file */
+export const trashMetadataSchema = z.looseObject({
+	version: z.string().optional(),
+	lastUpdated: z.string().optional(),
+});
+type TrashMetadata = z.infer<typeof trashMetadataSchema>;
 
 // ============================================================================
 // Helper Functions
@@ -533,7 +535,10 @@ export class TrashGitHubFetcher {
 			throw new Error(`Failed to fetch metadata: ${response.statusText}`);
 		}
 
-		return (await response.json()) as TrashMetadata;
+		const raw = await response.json();
+		return parseUpstreamOrThrow(raw, trashMetadataSchema, {
+			integration: "trash-guides", category: "metadata",
+		});
 	}
 
 	/**
@@ -807,7 +812,11 @@ export class TrashGitHubFetcher {
 				return [];
 			}
 
-			const files = z.array(githubDirectoryEntrySchema).parse(await response.json());
+			const files = parseUpstreamOrThrow(
+				await response.json(),
+				z.array(githubDirectoryEntrySchema),
+				{ integration: "trash-guides", category: "directory-listing" },
+			);
 
 			// Filter for .md files only
 			const mdFiles = files
@@ -833,7 +842,12 @@ export class TrashGitHubFetcher {
 
 			return descriptions;
 		} catch (error) {
-			this.log.error("Failed to fetch CF descriptions:", error);
+			if (error instanceof UpstreamValidationError) {
+				this.log.warn({ integration: error.integration, issues: error.issues },
+					"GitHub directory listing schema drift");
+			} else {
+				this.log.error("Failed to fetch CF descriptions:", error);
+			}
 			return [];
 		}
 	}
@@ -870,7 +884,11 @@ export class TrashGitHubFetcher {
 				return [];
 			}
 
-			const files = z.array(githubDirectoryEntrySchema).parse(await response.json());
+			const files = parseUpstreamOrThrow(
+				await response.json(),
+				z.array(githubDirectoryEntrySchema),
+				{ integration: "trash-guides", category: "directory-listing" },
+			);
 
 			// Filter for .md files that match known include patterns
 			const includeFiles = files
@@ -926,7 +944,12 @@ export class TrashGitHubFetcher {
 			this.log.debug?.(`Fetched ${includes.length} CF include files`);
 			return includes;
 		} catch (error) {
-			this.log.error("Failed to fetch CF includes:", error);
+			if (error instanceof UpstreamValidationError) {
+				this.log.warn({ integration: error.integration, issues: error.issues },
+					"GitHub directory listing schema drift");
+			} else {
+				this.log.error("Failed to fetch CF includes:", error);
+			}
 			return [];
 		}
 	}
@@ -1009,7 +1032,11 @@ export class TrashGitHubFetcher {
 				return [];
 			}
 
-			const files = z.array(githubDirectoryEntrySchema).parse(await response.json());
+			const files = parseUpstreamOrThrow(
+				await response.json(),
+				z.array(githubDirectoryEntrySchema),
+				{ integration: "trash-guides", category: "directory-listing" },
+			);
 
 			// Filter for .json files only
 			const jsonFiles = files
@@ -1022,7 +1049,12 @@ export class TrashGitHubFetcher {
 
 			return jsonFiles;
 		} catch (error) {
-			this.log.error(`Failed to discover config files at ${baseUrl}:`, error);
+			if (error instanceof UpstreamValidationError) {
+				this.log.warn({ integration: error.integration, issues: error.issues },
+					"GitHub directory listing schema drift");
+			} else {
+				this.log.error(`Failed to discover config files at ${baseUrl}:`, error);
+			}
 			return [];
 		}
 	}

--- a/apps/api/src/lib/validation/__tests__/github-fetcher-validation.test.ts
+++ b/apps/api/src/lib/validation/__tests__/github-fetcher-validation.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for github-fetcher.ts validation improvements.
+ *
+ * Validates:
+ * - parseUpstreamOrThrow with directory schema returns typed array on valid data
+ * - Invalid directory data throws UpstreamValidationError with correct integration
+ * - trashMetadataSchema validates realistic metadata, passes extra fields, rejects non-objects
+ */
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { githubDirectoryEntrySchema, trashMetadataSchema } from "../../trash-guides/github-fetcher.js";
+import { parseUpstreamOrThrow, UpstreamValidationError } from "../parse-upstream.js";
+
+describe("GitHub directory listing validation", () => {
+	const directorySchema = z.array(githubDirectoryEntrySchema);
+	const source = { integration: "trash-guides", category: "directory-listing" };
+
+	it("returns typed array on valid directory listing", () => {
+		const raw = [
+			{ name: "test.json", type: "file", download_url: "https://example.com/test.json" },
+			{ name: "subdir", type: "dir", download_url: null },
+		];
+
+		const result = parseUpstreamOrThrow(raw, directorySchema, source);
+
+		expect(result).toHaveLength(2);
+		expect(result[0]!.name).toBe("test.json");
+		expect(result[0]!.type).toBe("file");
+		expect(result[1]!.type).toBe("dir");
+	});
+
+	it("tolerates extra fields from GitHub API (looseObject)", () => {
+		const raw = [
+			{
+				name: "test.json",
+				type: "file",
+				download_url: "https://example.com/test.json",
+				sha: "abc123",
+				size: 1234,
+				path: "docs/json/radarr/test.json",
+			},
+		];
+
+		const result = parseUpstreamOrThrow(raw, directorySchema, source);
+		expect(result).toHaveLength(1);
+	});
+
+	it("throws UpstreamValidationError on invalid data", () => {
+		const raw = [{ name: 123, type: true }]; // name should be string
+
+		try {
+			parseUpstreamOrThrow(raw, directorySchema, source);
+			expect.fail("Should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(UpstreamValidationError);
+			if (error instanceof UpstreamValidationError) {
+				expect(error.integration).toBe("trash-guides");
+				expect(error.category).toBe("directory-listing");
+				expect(error.issues.length).toBeGreaterThan(0);
+			}
+		}
+	});
+
+	it("throws UpstreamValidationError when response is not an array", () => {
+		const raw = { message: "Not Found" };
+
+		try {
+			parseUpstreamOrThrow(raw, directorySchema, source);
+			expect.fail("Should have thrown");
+		} catch (error) {
+			expect(error).toBeInstanceOf(UpstreamValidationError);
+		}
+	});
+});
+
+describe("trashMetadataSchema", () => {
+	it("validates realistic metadata", () => {
+		const raw = { version: "6.0.0", lastUpdated: "2025-01-15T10:00:00Z" };
+
+		const result = trashMetadataSchema.parse(raw);
+
+		expect(result.version).toBe("6.0.0");
+		expect(result.lastUpdated).toBe("2025-01-15T10:00:00Z");
+	});
+
+	it("passes with extra fields (looseObject)", () => {
+		const raw = {
+			version: "6.0.0",
+			lastUpdated: "2025-01-15",
+			description: "TRaSH Guides data",
+			contributors: ["user1"],
+		};
+
+		const result = trashMetadataSchema.parse(raw);
+		expect(result.version).toBe("6.0.0");
+	});
+
+	it("passes when optional fields are missing", () => {
+		const raw = {};
+
+		const result = trashMetadataSchema.parse(raw);
+		expect(result.version).toBeUndefined();
+		expect(result.lastUpdated).toBeUndefined();
+	});
+
+	it("rejects non-objects", () => {
+		expect(() => trashMetadataSchema.parse("not-an-object")).toThrow();
+		expect(() => trashMetadataSchema.parse(null)).toThrow();
+		expect(() => trashMetadataSchema.parse(42)).toThrow();
+	});
+
+	it("works with parseUpstreamOrThrow", () => {
+		const raw = { version: "5.0.0" };
+
+		const result = parseUpstreamOrThrow(raw, trashMetadataSchema, {
+			integration: "trash-guides",
+			category: "metadata",
+		});
+
+		expect(result.version).toBe("5.0.0");
+	});
+});


### PR DESCRIPTION
## Summary
- Replace 3 direct `.parse()` calls in `github-fetcher.ts` with `parseUpstreamOrThrow` — ZodErrors were silently lost in catch blocks, now they're tracked in health registry and logged with `UpstreamValidationError` discrimination
- Add `trashMetadataSchema` to validate previously unvalidated `TrashMetadata` fetch (was `as TrashMetadata` cast)
- Add debug-level log for Plex JSON responses returned without a validation schema
- Consolidate Tautulli wrapper category from `cmd/wrapper` → `cmd` to reduce 2x health registry bloat

## Test plan
- [x] 9 new tests in `github-fetcher-validation.test.ts` (directory listing + metadata schema)
- [x] All 1049 existing tests pass
- [x] TypeScript strict mode passes (`tsc --noEmit`)
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)