### PR TITLE
feat(validation): quarantine ring buffer for rejected items

### DIFF
--- a/apps/api/src/lib/validation/__tests__/validation-quarantine.test.ts
+++ b/apps/api/src/lib/validation/__tests__/validation-quarantine.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { validationQuarantine } from "../validation-quarantine.js";
+
+function makeItem(integration: string, category: string, index = 0) {
+	return {
+		raw: { id: index, invalid: true },
+		errors: [`field_${index}: Expected string, received number`],
+		integration,
+		category,
+		timestamp: new Date(Date.now() + index).toISOString(),
+	};
+}
+
+describe("ValidationQuarantine", () => {
+	beforeEach(() => {
+		validationQuarantine.clear();
+	});
+
+	it("pushes and retrieves items by integration", () => {
+		validationQuarantine.push(makeItem("plex", "sessions", 0));
+		validationQuarantine.push(makeItem("plex", "sessions", 1));
+		validationQuarantine.push(makeItem("seerr", "getRequests", 0));
+
+		const plexItems = validationQuarantine.getByIntegration("plex");
+		expect(plexItems).toHaveLength(2);
+		expect(plexItems[0]!.integration).toBe("plex");
+
+		const seerrItems = validationQuarantine.getByIntegration("seerr");
+		expect(seerrItems).toHaveLength(1);
+
+		expect(validationQuarantine.count).toBe(3);
+	});
+
+	it("getAll returns items grouped by integration", () => {
+		validationQuarantine.push(makeItem("plex", "sessions"));
+		validationQuarantine.push(makeItem("tautulli", "get_history"));
+
+		const all = validationQuarantine.getAll();
+		expect(Object.keys(all)).toEqual(expect.arrayContaining(["plex", "tautulli"]));
+		expect(all.plex).toHaveLength(1);
+		expect(all.tautulli).toHaveLength(1);
+	});
+
+	it("returns empty array for unknown integration", () => {
+		expect(validationQuarantine.getByIntegration("nonexistent")).toEqual([]);
+	});
+
+	it("enforces per-integration cap of 50", () => {
+		for (let i = 0; i < 55; i++) {
+			validationQuarantine.push(makeItem("plex", "sessions", i));
+		}
+
+		const items = validationQuarantine.getByIntegration("plex");
+		expect(items).toHaveLength(50);
+		// Oldest (0-4) should have been evicted, newest (5-54) retained
+		expect(items[0]!.errors[0]).toContain("field_5");
+		expect(items[49]!.errors[0]).toContain("field_54");
+		expect(validationQuarantine.count).toBe(50);
+	});
+
+	it("enforces global cap of 250", () => {
+		// Fill 5 integrations with 55 each = 250 after per-integration caps
+		// Each integration capped at 50, so 5 * 50 = 250
+		for (let i = 0; i < 5; i++) {
+			for (let j = 0; j < 55; j++) {
+				validationQuarantine.push(makeItem(`int-${i}`, "cat", j));
+			}
+		}
+		expect(validationQuarantine.count).toBe(250);
+
+		// Add one more to a 6th integration — should evict oldest globally
+		validationQuarantine.push(makeItem("int-5", "cat", 0));
+		expect(validationQuarantine.count).toBe(250);
+	});
+
+	it("clear removes all items", () => {
+		validationQuarantine.push(makeItem("plex", "sessions"));
+		validationQuarantine.push(makeItem("seerr", "getRequests"));
+
+		validationQuarantine.clear();
+
+		expect(validationQuarantine.count).toBe(0);
+		expect(validationQuarantine.getByIntegration("plex")).toEqual([]);
+	});
+
+	it("clearIntegration removes only that integration", () => {
+		validationQuarantine.push(makeItem("plex", "sessions"));
+		validationQuarantine.push(makeItem("seerr", "getRequests"));
+
+		validationQuarantine.clearIntegration("plex");
+
+		expect(validationQuarantine.count).toBe(1);
+		expect(validationQuarantine.getByIntegration("plex")).toEqual([]);
+		expect(validationQuarantine.getByIntegration("seerr")).toHaveLength(1);
+	});
+
+	it("stores correct error details", () => {
+		const item = {
+			raw: { badField: 123 },
+			errors: ["badField: Expected string, received number", "missingField: Required"],
+			integration: "plex",
+			category: "sessions",
+			timestamp: new Date().toISOString(),
+		};
+
+		validationQuarantine.push(item);
+
+		const stored = validationQuarantine.getByIntegration("plex")[0]!;
+		expect(stored.raw).toEqual({ badField: 123 });
+		expect(stored.errors).toHaveLength(2);
+		expect(stored.errors[0]).toContain("Expected string");
+		expect(stored.category).toBe("sessions");
+	});
+});

--- a/apps/api/src/lib/validation/index.ts
+++ b/apps/api/src/lib/validation/index.ts
@@ -51,6 +51,9 @@ export {
 	type Logger,
 } from "./validate-batch.js";
 
+// --- Quarantine ---
+export { validationQuarantine, type QuarantinedItem } from "./validation-quarantine.js";
+
 // --- Health observability ---
 export { integrationHealth, type IntegrationHealth, type AllIntegrationHealth, type HealthState } from "./integration-health.js";
 export { schemaFingerprints, type DriftReport, type CategoryFingerprint, type SchemaFingerprint } from "./schema-fingerprint.js";

--- a/apps/api/src/lib/validation/parse-upstream.ts
+++ b/apps/api/src/lib/validation/parse-upstream.ts
@@ -25,6 +25,7 @@
 import type { z } from "zod";
 import { integrationHealth } from "./integration-health.js";
 import { schemaFingerprints } from "./schema-fingerprint.js";
+import { validationQuarantine } from "./validation-quarantine.js";
 
 // ============================================================================
 // Types
@@ -121,6 +122,15 @@ export function parseUpstream<T>(
 		total: 1,
 		validated: 0,
 		rejected: 1,
+	});
+
+	// Quarantine rejected item for later inspection
+	validationQuarantine.push({
+		raw,
+		errors: issues,
+		integration: source.integration,
+		category: source.category,
+		timestamp: new Date().toISOString(),
 	});
 
 	return {

--- a/apps/api/src/lib/validation/validate-batch.ts
+++ b/apps/api/src/lib/validation/validate-batch.ts
@@ -10,6 +10,7 @@
 
 import type { z } from "zod";
 import { type DriftReport, schemaFingerprints } from "./schema-fingerprint.js";
+import { validationQuarantine } from "./validation-quarantine.js";
 
 // ============================================================================
 // Types
@@ -110,6 +111,17 @@ export function validateAndCollect<T>(
 				// tolerant: skip invalid items
 				log.warn(`Skipping invalid item ${i} in ${fileName}: ${detail}`);
 				issues.push(detail);
+
+				// Quarantine rejected items when integration/category are known
+				if (options?.integration && options?.category) {
+					validationQuarantine.push({
+						raw: items[i],
+						errors: [detail],
+						integration: options.integration,
+						category: options.category,
+						timestamp: new Date().toISOString(),
+					});
+				}
 			}
 		}
 	}

--- a/apps/api/src/lib/validation/validation-quarantine.ts
+++ b/apps/api/src/lib/validation/validation-quarantine.ts
@@ -1,0 +1,135 @@
+/**
+ * Validation Quarantine — Ring Buffer for Rejected Items
+ *
+ * Stores rejected upstream data items for later inspection, with per-integration
+ * and global caps to prevent unbounded memory growth.
+ *
+ * Caps:
+ * - Per-integration: 50 items (FIFO eviction when exceeded)
+ * - Global total: 250 items (evicts oldest globally when exceeded)
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface QuarantinedItem {
+	/** The raw data that failed validation */
+	raw: unknown;
+	/** Human-readable validation error details */
+	errors: string[];
+	/** Which integration produced the invalid data */
+	integration: string;
+	/** Which endpoint/category within the integration */
+	category: string;
+	/** ISO timestamp when the item was quarantined */
+	timestamp: string;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const PER_INTEGRATION_CAP = 50;
+const GLOBAL_CAP = 250;
+
+// ============================================================================
+// Registry
+// ============================================================================
+
+class ValidationQuarantine {
+	private readonly items = new Map<string, QuarantinedItem[]>();
+	private _totalCount = 0;
+
+	/** Push a rejected item into quarantine */
+	push(item: QuarantinedItem): void {
+		const { integration } = item;
+
+		let bucket = this.items.get(integration);
+		if (!bucket) {
+			bucket = [];
+			this.items.set(integration, bucket);
+		}
+
+		// Per-integration cap: evict oldest
+		if (bucket.length >= PER_INTEGRATION_CAP) {
+			bucket.shift();
+			this._totalCount--;
+		}
+
+		bucket.push(item);
+		this._totalCount++;
+
+		// Global cap: evict oldest item across all integrations
+		while (this._totalCount > GLOBAL_CAP) {
+			this.evictOldestGlobally();
+		}
+	}
+
+	/** Get quarantined items for a specific integration */
+	getByIntegration(integration: string): QuarantinedItem[] {
+		return this.items.get(integration) ?? [];
+	}
+
+	/** Get all quarantined items grouped by integration */
+	getAll(): Record<string, QuarantinedItem[]> {
+		const result: Record<string, QuarantinedItem[]> = {};
+		for (const [integration, bucket] of this.items) {
+			result[integration] = [...bucket];
+		}
+		return result;
+	}
+
+	/** Total count of quarantined items */
+	get count(): number {
+		return this._totalCount;
+	}
+
+	/** Clear all quarantined items */
+	clear(): void {
+		this.items.clear();
+		this._totalCount = 0;
+	}
+
+	/** Clear quarantined items for a specific integration */
+	clearIntegration(integration: string): void {
+		const bucket = this.items.get(integration);
+		if (bucket) {
+			this._totalCount -= bucket.length;
+			this.items.delete(integration);
+		}
+	}
+
+	// ============================================================================
+	// Private Helpers
+	// ============================================================================
+
+	/** Evict the single oldest item across all integrations */
+	private evictOldestGlobally(): void {
+		let oldestTime = Number.POSITIVE_INFINITY;
+		let oldestIntegration: string | null = null;
+
+		for (const [integration, bucket] of this.items) {
+			if (bucket.length > 0) {
+				const firstTs = new Date(bucket[0]!.timestamp).getTime();
+				if (firstTs < oldestTime) {
+					oldestTime = firstTs;
+					oldestIntegration = integration;
+				}
+			}
+		}
+
+		if (oldestIntegration) {
+			const bucket = this.items.get(oldestIntegration)!;
+			bucket.shift();
+			this._totalCount--;
+
+			if (bucket.length === 0) {
+				this.items.delete(oldestIntegration);
+			}
+		}
+	}
+}
+
+/** Singleton validation quarantine */
+export const validationQuarantine = new ValidationQuarantine();

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -8,6 +8,7 @@ import { integrationHealth } from "../lib/validation/integration-health.js";
 import { schemaFingerprints } from "../lib/validation/schema-fingerprint.js";
 import { KNOWN_INTEGRATIONS } from "../lib/validation/index.js";
 import { type ValidationMode, getAllValidationModes, setValidationMode } from "../lib/validation/validate-batch.js";
+import { validationQuarantine } from "../lib/validation/validation-quarantine.js";
 
 const RESTART_RATE_LIMIT = { max: 2, timeWindow: "5 minutes" };
 const LOGS_RATE_LIMIT = { max: 30, timeWindow: "1 minute" };
@@ -495,6 +496,36 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				...integrationHealth.getAll(),
 				fingerprints: schemaFingerprints.getAll(),
 				validationModes: getAllValidationModes(),
+			},
+		});
+	});
+
+	/**
+	 * GET /system/validation-quarantine
+	 * Returns quarantined (rejected) validation items for inspection.
+	 */
+	app.get("/validation-quarantine", async (_request, reply) => {
+		return reply.send({
+			success: true,
+			data: {
+				items: validationQuarantine.getAll(),
+				totalCount: validationQuarantine.count,
+			},
+		});
+	});
+
+	/**
+	 * DELETE /system/validation-quarantine
+	 * Clear all quarantined items.
+	 */
+	app.delete("/validation-quarantine", async (request, reply) => {
+		validationQuarantine.clear();
+		request.log.info("Validation quarantine cleared");
+		return reply.send({
+			success: true,
+			data: {
+				items: {},
+				totalCount: 0,
 			},
 		});
 	});


### PR DESCRIPTION
## Summary
- Add `ValidationQuarantine` ring buffer class with per-integration cap (50) and global cap (250) with FIFO eviction
- Wire quarantine into `validate-batch.ts` (tolerant mode rejections) and `parse-upstream.ts` (single-item failures)
- Add `GET /system/validation-quarantine` and `DELETE /system/validation-quarantine` API endpoints
- Add barrel exports for `validationQuarantine` and `QuarantinedItem` type

## Test plan
- [x] 8 new quarantine tests (push, retrieval, per-integration cap, global cap, clear, clearIntegration, error details)
- [x] All 1068 tests pass
- [x] TypeScript strict mode passes (`tsc --noEmit`)
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)