### PR TITLE
feat(notifications): validation health degradation notifications

### DIFF
--- a/apps/api/src/lib/notifications/channels/format-metadata.ts
+++ b/apps/api/src/lib/notifications/channels/format-metadata.ts
@@ -76,6 +76,12 @@ const LABEL_MAP: Record<string, string> = {
 	templateId: "Template",
 	totalInstances: "Total Instances",
 	failedInstances: "Failed",
+
+	// Validation Health
+	integration: "Integration",
+	failureCount: "Failure Count",
+	lastError: "Last Error",
+	affectedCategories: "Affected Categories",
 };
 
 /**

--- a/apps/api/src/plugins/notification-service.ts
+++ b/apps/api/src/plugins/notification-service.ts
@@ -68,6 +68,14 @@ const notificationServicePlugin = fastifyPlugin(
 
 		app.decorate("notificationService", service);
 
+		// Wire validation health degradation notifications
+		const { integrationHealth } = await import("../lib/validation/integration-health.js");
+		integrationHealth.setNotifyFn((payload) => {
+			service.notify(payload as Parameters<typeof service.notify>[0]).catch((err: unknown) =>
+				app.log.warn({ err }, "Failed to send validation health notification"),
+			);
+		});
+
 		// Log retention: purge old logs every 6 hours
 		const LOG_RETENTION_INTERVAL_MS = 6 * 60 * 60 * 1000;
 		let logRetentionInterval: ReturnType<typeof setInterval> | null = null;

--- a/packages/shared/src/types/notifications.ts
+++ b/packages/shared/src/types/notifications.ts
@@ -91,6 +91,7 @@ export const notificationEventTypeSchema = z.enum([
 	// System
 	"SYSTEM_STARTUP",
 	"SYSTEM_ERROR",
+	"VALIDATION_HEALTH_DEGRADED",
 ]);
 
 export type NotificationEventType = z.infer<typeof notificationEventTypeSchema>;


### PR DESCRIPTION
## Summary
- Add `VALIDATION_HEALTH_DEGRADED` to `notificationEventTypeSchema` enum (System section)
- Add metadata labels for `integration`, `failureCount`, `lastError`, `affectedCategories` in format-metadata.ts
- Wire `integrationHealth.setNotifyFn()` in notification-service plugin to fire notifications on healthy→degraded/failing transitions
- Uses dynamic `import()` to avoid circular dependency between validation and notification modules

## Test plan
- [x] Notification firing logic already tested in PR 2 (integration-health.test.ts: 5 notification tests)
- [x] All 1068 tests pass
- [x] TypeScript strict mode passes for `@arr/shared`, `@arr/api`
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)