### PR TITLE
feat(validation): union fingerprinting to reduce false-positive drift

### DIFF
--- a/apps/api/src/lib/validation/__tests__/schema-fingerprint.test.ts
+++ b/apps/api/src/lib/validation/__tests__/schema-fingerprint.test.ts
@@ -41,27 +41,75 @@ describe("SchemaFingerprintRegistry", () => {
 		expect(drift.missingFields).toEqual([]);
 	});
 
-	it("detects missing fields (potential breaking change)", () => {
+	it("grows baseline union when new fields appear", () => {
+		schemaFingerprints.record("test", "items", [{ a: 1 }], mockLog);
+		schemaFingerprints.record("test", "items", [{ a: 1, b: 2 }], mockLog);
+
+		const fp = schemaFingerprints.get("test", "items");
+		// Baseline should now include both a and b
+		expect(fp!.baseline.fields).toEqual(["a", "b"]);
+	});
+
+	it("does NOT flag missing fields after 1-2 consecutive absences", () => {
 		const baseline = [{ name: "foo", score: 10, description: "test" }];
-		const updated = [{ name: "foo", score: 10 }];
+		const updated = [{ name: "foo", score: 10 }]; // description absent
 
 		schemaFingerprints.record("test", "items", baseline, mockLog);
-		const drift = schemaFingerprints.record("test", "items", updated, mockLog);
+
+		// 1st absence — no missing drift
+		let drift = schemaFingerprints.record("test", "items", updated, mockLog);
+		expect(drift.missingFields).toEqual([]);
+
+		// 2nd absence — still no missing drift
+		drift = schemaFingerprints.record("test", "items", updated, mockLog);
+		expect(drift.missingFields).toEqual([]);
+	});
+
+	it("flags missing fields after 3 consecutive absences", () => {
+		const baseline = [{ name: "foo", score: 10, description: "test" }];
+		const updated = [{ name: "foo", score: 10 }]; // description absent
+
+		schemaFingerprints.record("test", "items", baseline, mockLog);
+		schemaFingerprints.record("test", "items", updated, mockLog); // miss 1
+		schemaFingerprints.record("test", "items", updated, mockLog); // miss 2
+		const drift = schemaFingerprints.record("test", "items", updated, mockLog); // miss 3
 
 		expect(drift.hasDrift).toBe(true);
-		expect(drift.newFields).toEqual([]);
 		expect(drift.missingFields).toEqual(["description"]);
 	});
 
-	it("detects both new and missing fields simultaneously", () => {
-		const baseline = [{ name: "foo", oldField: true }];
-		const updated = [{ name: "foo", newField: "added" }];
+	it("resets miss counter when field reappears", () => {
+		const baseline = [{ name: "foo", opt: "present" }];
+		const absent = [{ name: "foo" }];
+		const present = [{ name: "foo", opt: "back" }];
 
 		schemaFingerprints.record("test", "items", baseline, mockLog);
-		const drift = schemaFingerprints.record("test", "items", updated, mockLog);
+		schemaFingerprints.record("test", "items", absent, mockLog); // miss 1
+		schemaFingerprints.record("test", "items", absent, mockLog); // miss 2
 
-		expect(drift.hasDrift).toBe(true);
+		// Field reappears — should reset counter
+		schemaFingerprints.record("test", "items", present, mockLog);
+
+		// 1 more absence — counter should be at 1 (reset from 2), not 3
+		const drift = schemaFingerprints.record("test", "items", absent, mockLog);
+		expect(drift.missingFields).toEqual([]);
+	});
+
+	it("detects new fields and missing fields simultaneously (with threshold)", () => {
+		const baseline = [{ name: "foo", oldField: true }];
+		const updated = [{ name: "foo", newField: "added" }]; // oldField absent
+
+		schemaFingerprints.record("test", "items", baseline, mockLog);
+
+		// First absence — new field detected, but missing not yet (threshold not met)
+		let drift = schemaFingerprints.record("test", "items", updated, mockLog);
 		expect(drift.newFields).toEqual(["newField"]);
+		expect(drift.missingFields).toEqual([]); // only 1 miss
+
+		// 2 more absences to reach threshold
+		schemaFingerprints.record("test", "items", updated, mockLog);
+		drift = schemaFingerprints.record("test", "items", updated, mockLog); // miss 3
+
 		expect(drift.missingFields).toEqual(["oldField"]);
 	});
 
@@ -129,7 +177,7 @@ describe("SchemaFingerprintRegistry", () => {
 		expect(fp!.baseline.fields).toEqual(["name"]);
 	});
 
-	it("logs warning for new and missing fields", () => {
+	it("logs warning for new fields immediately", () => {
 		const warnings: string[] = [];
 		const logSpy = {
 			warn: (msg: string | object) => { warnings.push(String(msg)); },
@@ -139,8 +187,36 @@ describe("SchemaFingerprintRegistry", () => {
 		schemaFingerprints.record("test", "items", [{ a: 1, b: 2 }], logSpy);
 		schemaFingerprints.record("test", "items", [{ a: 1, c: 3 }], logSpy);
 
-		expect(warnings).toHaveLength(2);
+		// Should log new field warning for c
+		expect(warnings).toHaveLength(1);
 		expect(warnings[0]).toContain("new fields detected: c");
-		expect(warnings[1]).toContain("missing fields: b");
+	});
+
+	it("logs warning for missing fields only after threshold", () => {
+		const warnings: string[] = [];
+		const logSpy = {
+			warn: (msg: string | object) => { warnings.push(String(msg)); },
+			error: () => {},
+		};
+
+		schemaFingerprints.record("test", "items", [{ a: 1, b: 2 }], logSpy);
+
+		// 3 consecutive absences of b
+		schemaFingerprints.record("test", "items", [{ a: 1 }], logSpy);
+		schemaFingerprints.record("test", "items", [{ a: 1 }], logSpy);
+		schemaFingerprints.record("test", "items", [{ a: 1 }], logSpy);
+
+		const missingWarnings = warnings.filter((w) => w.includes("missing fields"));
+		expect(missingWarnings).toHaveLength(1);
+		expect(missingWarnings[0]).toContain("b");
+	});
+
+	it("exposes fieldMissCounts in CategoryFingerprint", () => {
+		schemaFingerprints.record("test", "items", [{ a: 1, b: 2 }], mockLog);
+		schemaFingerprints.record("test", "items", [{ a: 1 }], mockLog); // b miss 1
+		schemaFingerprints.record("test", "items", [{ a: 1 }], mockLog); // b miss 2
+
+		const fp = schemaFingerprints.get("test", "items");
+		expect(fp!.fieldMissCounts.b).toBe(2);
 	});
 });

--- a/apps/api/src/lib/validation/schema-fingerprint.ts
+++ b/apps/api/src/lib/validation/schema-fingerprint.ts
@@ -4,18 +4,27 @@
  * Tracks the set of field names seen in validated upstream data and detects
  * when the shape of that data changes (new fields added, existing fields removed).
  *
- * How it works:
+ * **Union strategy** — the baseline grows to include all fields ever observed.
+ * This reduces false-positive drift from optional upstream fields:
+ *
  * 1. On each validation run, collect top-level field names from validated items
- * 2. First run for a category → store as "baseline"
- * 3. Subsequent runs → compare against baseline, log drift
- * 4. New fields = info (forward-compatible, expected from z.looseObject)
- * 5. Missing fields = warn (potential breaking change upstream)
+ * 2. New fields are added to the baseline union immediately (reported as newFields)
+ * 3. Missing fields increment a per-field miss counter
+ * 4. A field is only reported as "missing" after 3+ consecutive absences
+ * 5. When a field reappears, its miss counter resets to 0
  *
  * All state is in-memory — baselines reset on app restart, and the first
  * validation run after restart re-establishes them.
  */
 
 import type { Logger } from "./validate-batch.js";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Number of consecutive misses before a field is flagged as missing */
+const MISSING_THRESHOLD = 3;
 
 // ============================================================================
 // Types
@@ -33,7 +42,7 @@ export interface SchemaFingerprint {
 export interface DriftReport {
 	/** Fields present in current data but not in the baseline */
 	newFields: string[];
-	/** Fields present in baseline but missing from current data */
+	/** Fields in baseline that have been missing for 3+ consecutive observations */
 	missingFields: string[];
 	/** Whether any drift was detected */
 	hasDrift: boolean;
@@ -43,6 +52,8 @@ export interface CategoryFingerprint {
 	baseline: SchemaFingerprint;
 	latest: SchemaFingerprint;
 	drift: DriftReport;
+	/** Per-field consecutive miss counts (only for fields that have been absent) */
+	fieldMissCounts: Record<string, number>;
 }
 
 // ============================================================================
@@ -63,10 +74,10 @@ class SchemaFingerprintRegistry {
 	 */
 	record(integration: string, category: string, items: unknown[], log: Logger): DriftReport {
 		const key = `${integration}:${category}`;
-		const fields = this.extractFields(items);
+		const currentFields = this.extractFields(items);
 		const now = new Date().toISOString();
 		const fingerprint: SchemaFingerprint = {
-			fields,
+			fields: currentFields,
 			recordedAt: now,
 			sampleCount: items.length,
 		};
@@ -76,12 +87,54 @@ class SchemaFingerprintRegistry {
 		if (!existing) {
 			// First observation — establish baseline
 			const drift: DriftReport = { newFields: [], missingFields: [], hasDrift: false };
-			this.data.set(key, { baseline: fingerprint, latest: fingerprint, drift });
+			this.data.set(key, {
+				baseline: fingerprint,
+				latest: fingerprint,
+				drift,
+				fieldMissCounts: {},
+			});
 			return drift;
 		}
 
-		// Compare against baseline
-		const drift = this.computeDrift(existing.baseline, fingerprint);
+		const currentSet = new Set(currentFields);
+		const baselineSet = new Set(existing.baseline.fields);
+
+		// Detect new fields (in current but not in baseline union)
+		const newFields = currentFields.filter((f) => !baselineSet.has(f));
+
+		// Grow baseline union with new fields
+		if (newFields.length > 0) {
+			const mergedFields = new Set([...existing.baseline.fields, ...newFields]);
+			existing.baseline = {
+				...existing.baseline,
+				fields: [...mergedFields].sort(),
+			};
+		}
+
+		// Update miss counters for all baseline fields
+		const missCounts = { ...existing.fieldMissCounts };
+		for (const field of existing.baseline.fields) {
+			if (currentSet.has(field)) {
+				// Present — reset miss counter
+				delete missCounts[field];
+			} else {
+				// Absent — increment miss counter
+				missCounts[field] = (missCounts[field] ?? 0) + 1;
+			}
+		}
+		existing.fieldMissCounts = missCounts;
+
+		// Only flag as missing if miss count >= threshold
+		const missingFields = Object.entries(missCounts)
+			.filter(([, count]) => count >= MISSING_THRESHOLD)
+			.map(([field]) => field)
+			.sort();
+
+		const drift: DriftReport = {
+			newFields,
+			missingFields,
+			hasDrift: newFields.length > 0 || missingFields.length > 0,
+		};
 
 		// Update latest + drift
 		existing.latest = fingerprint;
@@ -95,7 +148,7 @@ class SchemaFingerprintRegistry {
 		}
 		if (drift.missingFields.length > 0) {
 			log.warn(
-				`[schema-drift] ${key}: missing fields: ${drift.missingFields.join(", ")} — potential breaking change upstream`,
+				`[schema-drift] ${key}: missing fields (${MISSING_THRESHOLD}+ consecutive absences): ${drift.missingFields.join(", ")} — potential breaking change upstream`,
 			);
 		}
 
@@ -164,21 +217,6 @@ class SchemaFingerprintRegistry {
 			}
 		}
 		return [...fieldSet].sort();
-	}
-
-	/** Compare current fingerprint against baseline to find drift */
-	private computeDrift(baseline: SchemaFingerprint, current: SchemaFingerprint): DriftReport {
-		const baselineSet = new Set(baseline.fields);
-		const currentSet = new Set(current.fields);
-
-		const newFields = current.fields.filter((f) => !baselineSet.has(f));
-		const missingFields = baseline.fields.filter((f) => !currentSet.has(f));
-
-		return {
-			newFields,
-			missingFields,
-			hasDrift: newFields.length > 0 || missingFields.length > 0,
-		};
 	}
 }
 


### PR DESCRIPTION
## Summary
- Change fingerprint baseline from frozen-first-observation to **union of all fields ever seen** — new fields grow the baseline instead of being permanent "drift"
- Add per-field consecutive miss counter with **threshold of 3** before flagging as "missing" — eliminates false positives from optional upstream fields
- Field reappearance resets its miss counter to 0
- Add `fieldMissCounts: Record<string, number>` to `CategoryFingerprint` interface for UI per-field status display

## Test plan
- [x] 4 existing tests updated for union semantics
- [x] 5 new tests: union growth, 1-2 miss = no drift, 3 miss = drift, reappearance resets counter, fieldMissCounts exposed
- [x] All 1073 tests pass
- [x] TypeScript strict mode passes
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)