### PR TITLE
fix(dashboard): switch to tolerant validation for queue/history/calendar

### DIFF
--- a/apps/api/src/routes/dashboard/calendar-routes.ts
+++ b/apps/api/src/routes/dashboard/calendar-routes.ts
@@ -15,6 +15,7 @@ import {
 	normalizeCalendarItem,
 } from "../../lib/dashboard/calendar-utils.js";
 import { validateRequest } from "../../lib/utils/validate.js";
+import { validateAndCollect } from "../../lib/validation/validate-batch.js";
 
 const calendarQuerySchema = z.object({
 	start: z.string().optional(),
@@ -95,15 +96,19 @@ export const calendarRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					});
 				}
 
-				// Normalize and enrich items
-				const items = rawItems.map((raw) => {
-					const normalized = normalizeCalendarItem(raw, service);
-					return calendarItemSchema.parse({
-						...normalized,
-						instanceId: instance.id,
-						instanceName: instance.label,
-					});
-				});
+				// Normalize and enrich items, then validate in tolerant mode
+				const normalized = rawItems.map((raw) => ({
+					...normalizeCalendarItem(raw, service),
+					instanceId: instance.id,
+					instanceName: instance.label,
+				}));
+				const { items } = validateAndCollect(
+					normalized,
+					calendarItemSchema,
+					`dashboard/calendar/${service}`,
+					request.log,
+					{ integration: "dashboard", category: "calendar", mode: "tolerant" },
+				);
 
 				// Sort by date
 				items.sort(compareCalendarItems);

--- a/apps/api/src/routes/dashboard/history-routes.ts
+++ b/apps/api/src/routes/dashboard/history-routes.ts
@@ -11,6 +11,7 @@ import {
 } from "../../lib/arr/client-helpers.js";
 import { type HistoryService, normalizeHistoryItem } from "../../lib/dashboard/history-utils.js";
 import { validateRequest } from "../../lib/utils/validate.js";
+import { validateAndCollect } from "../../lib/validation/validate-batch.js";
 
 /**
  * Query schema for history endpoint.
@@ -100,15 +101,19 @@ export const historyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					totalRecords = result.totalRecords ?? rawRecords.length;
 				}
 
-				// Normalize and enrich items
-				const items = rawRecords.map((raw) => {
-					const normalized = normalizeHistoryItem(raw, service);
-					return historyItemSchema.parse({
-						...normalized,
-						instanceId: instance.id,
-						instanceName: instance.label,
-					});
-				});
+				// Normalize and enrich items, then validate in tolerant mode
+				const normalized = rawRecords.map((raw) => ({
+					...normalizeHistoryItem(raw, service),
+					instanceId: instance.id,
+					instanceName: instance.label,
+				}));
+				const { items } = validateAndCollect(
+					normalized,
+					historyItemSchema,
+					`dashboard/history/${service}`,
+					request.log,
+					{ integration: "dashboard", category: "history", mode: "tolerant" },
+				);
 
 				return {
 					items,

--- a/apps/api/src/routes/dashboard/queue-routes.ts
+++ b/apps/api/src/routes/dashboard/queue-routes.ts
@@ -22,6 +22,7 @@ import {
 	triggerQueueSearchWithSdk,
 } from "../../lib/dashboard/queue-utils.js";
 import { validateRequest } from "../../lib/utils/validate.js";
+import { validateAndCollect } from "../../lib/validation/validate-batch.js";
 import { autoImportByDownloadIdWithSdk, setManualImportLogger } from "../manual-import-utils.js";
 
 /**
@@ -75,15 +76,21 @@ export const queueRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					return [];
 				}
 
-				// Normalize and enrich items
-				return rawItems.map((raw) => {
-					const normalized = normalizeQueueItem(raw, service);
-					return queueItemSchema.parse({
-						...normalized,
-						instanceId: instance.id,
-						instanceName: instance.label,
-					});
-				});
+				// Normalize and enrich items, then validate in tolerant mode
+				// so one malformed item doesn't break the entire queue response
+				const normalized = rawItems.map((raw) => ({
+					...normalizeQueueItem(raw, service),
+					instanceId: instance.id,
+					instanceName: instance.label,
+				}));
+				const { items } = validateAndCollect(
+					normalized,
+					queueItemSchema,
+					`dashboard/queue/${service}`,
+					request.log,
+					{ integration: "dashboard", category: "queue", mode: "tolerant" },
+				);
+				return items;
 			},
 		);
 


### PR DESCRIPTION
## Summary
- Switch dashboard queue, history, and calendar routes from strict `schema.parse()` to `validateAndCollect()` in tolerant mode
- One malformed item from an ARR instance no longer crashes the entire dashboard request — invalid items are skipped and the rest are returned
- Rejected items are logged, quarantined, and schema-fingerprinted for drift detection via the validation health platform (PRs #170-#174)

## Test plan
- [ ] Verify dashboard queue loads normally with all ARR instances
- [ ] Verify dashboard history loads and sorts correctly
- [ ] Verify calendar view renders upcoming releases
- [ ] Confirm validation stats appear in validation health UI when items are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)