### PR TITLE
fix(queue-cleaner): tighten rawQueueItemSchema with expected fields

### DIFF
--- a/apps/api/src/lib/queue-cleaner/queue-item-utils.ts
+++ b/apps/api/src/lib/queue-cleaner/queue-item-utils.ts
@@ -35,12 +35,28 @@ export interface RawQueueItem {
 
 /**
  * Zod schema for raw queue items from the ARR API.
- * Validates that each item is a plain object — the individual fields are all
- * `unknown` and are type-checked at point-of-use throughout the codebase.
- * This catches non-object values (strings, numbers, null) that would cause
- * runtime errors in property access code.
+ * Declares expected field names with `z.unknown()` for schema fingerprinting
+ * and drift detection, while `.passthrough()` preserves any new fields the
+ * ARR API may add. Individual fields are type-checked at point-of-use.
  */
-export const rawQueueItemSchema = z.record(z.string(), z.unknown());
+export const rawQueueItemSchema = z.looseObject({
+	id: z.unknown(),
+	title: z.unknown().optional(),
+	added: z.unknown().optional(),
+	size: z.unknown().optional(),
+	sizeleft: z.unknown().optional(),
+	estimatedCompletionTime: z.unknown().optional(),
+	trackedDownloadStatus: z.unknown().optional(),
+	trackedDownloadState: z.unknown().optional(),
+	statusMessages: z.unknown().optional(),
+	errorMessage: z.unknown().optional(),
+	indexer: z.unknown().optional(),
+	protocol: z.unknown().optional(),
+	downloadClient: z.unknown().optional(),
+	downloadId: z.unknown().optional(),
+	tags: z.unknown().optional(),
+	status: z.unknown().optional(),
+});
 
 /**
  * Safely parse a date value from unknown, returning null if invalid.


### PR DESCRIPTION
## Summary
- Replace permissive `z.record(z.string(), z.unknown())` with `z.looseObject({...})` that declares expected ARR queue item fields
- Fields remain `z.unknown()` (type-checked at point-of-use), but the schema now documents expected structure and supports drift detection via fingerprinting
- Uses Zod v4's `z.looseObject()` to preserve forward compatibility — new fields from ARR API updates pass through

## Test plan
- [ ] Verify queue cleaner rules still evaluate correctly against queue items
- [ ] Verify whitelist matching (tracker, tag, category, title) still works
- [ ] Confirm schema fingerprinting detects field changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)