### PR TITLE
fix(cache): add schema parameter to cache decompression

### DIFF
--- a/apps/api/src/lib/trash-guides/cache-manager.ts
+++ b/apps/api/src/lib/trash-guides/cache-manager.ts
@@ -130,6 +130,7 @@ export class TrashCacheManager {
 	async get<T = unknown>(
 		serviceType: "RADARR" | "SONARR",
 		configType: TrashConfigType,
+		schema?: z.ZodType<T>,
 	): Promise<T | null> {
 		const cacheEntry = await this.prisma.trashCache.findUnique({
 			where: {
@@ -150,7 +151,7 @@ export class TrashCacheManager {
 		// Decompress and return data
 		try {
 			if (this.options.compressionEnabled) {
-				return await decompressData<T>(cacheEntry.data);
+				return await decompressData<T>(cacheEntry.data, schema);
 			}
 
 			const parsed = safeJsonParse<T>(cacheEntry.data, {

--- a/apps/api/src/lib/trash-guides/cf-matcher.ts
+++ b/apps/api/src/lib/trash-guides/cf-matcher.ts
@@ -6,6 +6,8 @@
  */
 
 import type { TrashConfigType, TrashCustomFormat } from "@arr/shared";
+import { z } from "zod";
+import { trashCustomFormatSchema } from "./github-schemas.js";
 import { dequal as deepEqual } from "dequal";
 import type { PrismaClient } from "../../lib/prisma.js";
 import { createCacheManager } from "./cache-manager.js";
@@ -233,6 +235,7 @@ export class CFMatcher {
 		const trashCFs = await cacheManager.get<TrashCustomFormat[]>(
 			serviceType,
 			"CUSTOM_FORMATS" as TrashConfigType,
+			z.array(trashCustomFormatSchema),
 		);
 
 		const result = trashCFs || [];

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -21,6 +21,8 @@ import type {
 	TrashCustomFormatGroup,
 	TrashQualityProfile,
 } from "@arr/shared";
+import { z } from "zod";
+import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
 import type { PrismaClient } from "../../lib/prisma.js";
 import { TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
@@ -153,8 +155,8 @@ export class TemplateUpdater {
 					if (!cacheByServiceType.has(serviceType)) {
 						try {
 							const [cfGroups, customFormats] = await Promise.all([
-								this.cacheManager.get<TrashCustomFormatGroup[]>(serviceType, "CF_GROUPS"),
-								this.cacheManager.get<TrashCustomFormat[]>(serviceType, "CUSTOM_FORMATS"),
+								this.cacheManager.get<TrashCustomFormatGroup[]>(serviceType, "CF_GROUPS", z.array(trashCustomFormatGroupSchema)),
+								this.cacheManager.get<TrashCustomFormat[]>(serviceType, "CUSTOM_FORMATS", z.array(trashCustomFormatSchema)),
 							]);
 							cacheByServiceType.set(serviceType, {
 								cfGroups: cfGroups ?? [],
@@ -682,8 +684,8 @@ export class TemplateUpdater {
 	}> {
 		try {
 			const [cfCache, groupCache, cacheCommitHash] = await Promise.all([
-				this.cacheManager.get<TrashCustomFormat[]>(serviceType, "CUSTOM_FORMATS"),
-				this.cacheManager.get<TrashCustomFormatGroup[]>(serviceType, "CF_GROUPS"),
+				this.cacheManager.get<TrashCustomFormat[]>(serviceType, "CUSTOM_FORMATS", z.array(trashCustomFormatSchema)),
+				this.cacheManager.get<TrashCustomFormatGroup[]>(serviceType, "CF_GROUPS", z.array(trashCustomFormatGroupSchema)),
 				this.cacheManager.getCommitHash(serviceType, "CUSTOM_FORMATS"),
 			]);
 

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -13,6 +13,8 @@ import {
 	type TrashQualitySize,
 	type TrashRepoConfig,
 } from "@arr/shared";
+import { z } from "zod";
+import { trashQualitySizeSchema } from "./github-schemas.js";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { PrismaClient } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
@@ -562,6 +564,7 @@ export class UpdateScheduler {
 				const cached = await cacheManager.get<TrashQualitySize[]>(
 					mapping.serviceType as "RADARR" | "SONARR",
 					"QUALITY_SIZE",
+					z.array(trashQualitySizeSchema),
 				);
 				if (!cached) {
 					this.logger.warn(


### PR DESCRIPTION
## Summary
- Add optional `schema` parameter to `TrashCacheManager.get<T>()`, piped through to `decompressData()`
- Wire Zod schemas into critical cache callers: CF, CF groups, and quality size data
- Corrupted cache data (valid JSON but wrong shape) is now caught at decompression time instead of silently passing through as `as T`
- Naming data schemas skipped for now (Zod output type doesn't match the discriminated union `TrashNamingData`)

## Files changed
- `cache-manager.ts` — new optional `schema` parameter on `get()`
- `template-updater.ts` — pass CF + CF group schemas
- `cf-matcher.ts` — pass CF schema
- `update-scheduler.ts` — pass quality size schema

## Test plan
- [ ] Verify TRaSH Guides cache fetch still works for all config types
- [ ] Verify template sync detects corrupted CF cache data
- [ ] Verify quality size sync works with schema validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)