### PR TITLE
fix(validation): eliminate dead fallback casts in Plex/Tautulli clients

### DIFF
--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -380,14 +380,11 @@ export class PlexClient {
 		const contentType = response.headers.get("content-type") ?? "";
 		if (contentType.includes("application/json")) {
 			const raw = await response.json();
-			if (options?.schema) {
-				const category = path.split("?")[0] ?? path;
-				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
+			if (!options?.schema) {
+				throw new Error(`Plex API: schema required for JSON responses (path: ${path})`);
 			}
-			if (raw !== null && typeof raw === "object" && Object.keys(raw as Record<string, unknown>).length > 0) {
-				this.log.debug({ path }, "Plex returned JSON but no schema was provided for validation");
-			}
-			return raw as T;
+			const category = path.split("?")[0] ?? path;
+			return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
 		}
 
 		// Non-JSON responses (e.g., from POST /library/sections/{id}/refresh)

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -266,11 +266,11 @@ export class TautulliClient {
 			throw new Error(`Tautulli API error: ${wrapper.response.message ?? "Unknown error"}`);
 		}
 
-		// Validate inner data if schema provided
-		if (schema) {
-			return parseUpstreamOrThrow(wrapper.response.data, schema, { integration: "tautulli", category: cmd });
+		// Validate inner data — schema is required for all Tautulli commands
+		if (!schema) {
+			throw new Error(`Tautulli API: schema required for command responses (cmd: ${cmd})`);
 		}
-		return wrapper.response.data as T;
+		return parseUpstreamOrThrow(wrapper.response.data, schema, { integration: "tautulli", category: cmd });
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace dead-code `return raw as T` in Plex client with `throw new Error("schema required")` for JSON responses
- Replace dead-code `return data as T` in Tautulli client with `throw new Error("schema required")` for command responses
- All current public methods already pass schemas — these fallback paths were dead code but posed a maintenance risk if a future method omitted the schema

## Files changed
- `plex-client.ts` — JSON response path now requires schema, void (non-JSON) responses unchanged
- `tautulli-client.ts` — command response now requires schema

## Test plan
- [ ] Verify all Plex endpoints still work (identity, sections, items, history, sessions, episodes, accounts)
- [ ] Verify all Tautulli commands still work (info, libraries, history, activity, plays, stats, metadata)
- [ ] Verify Plex write operations (refreshSection, updateMetadataTags) still work (non-JSON, no schema needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)