### PR TITLE
fix(plex,tautulli): harden Zod schemas and surface cache refresh error messages

### DIFF
--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -15,6 +15,7 @@
  */
 
 import type { FastifyBaseLogger } from "fastify";
+import { getErrorMessage } from "../utils/error-message.js";
 import type { PrismaClient } from "../prisma.js";
 import type { PlexClient } from "./plex-client.js";
 
@@ -73,9 +74,10 @@ export async function refreshPlexCache(
 	prisma: PrismaClient,
 	instanceId: string,
 	log: FastifyBaseLogger,
-): Promise<{ upserted: number; errors: number }> {
+): Promise<{ upserted: number; errors: number; errorMessages: string[] }> {
 	let upserted = 0;
 	let errors = 0;
+	const errorMessages: string[] = [];
 
 	try {
 		// 1. Build accountId → username map
@@ -130,11 +132,10 @@ export async function refreshPlexCache(
 					});
 				}
 			} catch (err) {
-				log.warn(
-					{ err, sectionId: lib.key, sectionTitle: lib.title },
-					"Failed to fetch Plex library items",
-				);
+				const msg = `Failed to fetch library "${lib.title}": ${getErrorMessage(err)}`;
+				log.warn({ err, sectionId: lib.key, sectionTitle: lib.title }, msg);
 				errors++;
+				errorMessages.push(msg);
 			}
 		}
 
@@ -280,11 +281,10 @@ export async function refreshPlexCache(
 				upsertedIds.push(row.id);
 				upserted++;
 			} catch (error) {
+				const msg = `Failed to upsert ${agg.mediaType} tmdb:${agg.tmdbId}: ${getErrorMessage(error)}`;
 				errors++;
-				log.warn(
-					{ err: error, instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType },
-					"Plex cache: failed to upsert item",
-				);
+				errorMessages.push(msg);
+				log.warn({ err: error, instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType }, msg);
 			}
 		}
 
@@ -310,9 +310,11 @@ export async function refreshPlexCache(
 			"Plex cache refresh complete",
 		);
 	} catch (error) {
-		log.error({ err: error, instanceId }, "Plex cache refresh failed");
+		const msg = `Plex cache refresh failed: ${getErrorMessage(error)}`;
+		log.error({ err: error, instanceId }, msg);
 		errors++;
+		errorMessages.push(msg);
 	}
 
-	return { upserted, errors };
+	return { upserted, errors, errorMessages };
 }

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -7,6 +7,7 @@
  */
 
 import type { FastifyBaseLogger } from "fastify";
+import { getErrorMessage } from "../utils/error-message.js";
 import type { PrismaClientInstance } from "../prisma.js";
 import type { PlexClient } from "./plex-client.js";
 
@@ -26,9 +27,10 @@ export async function refreshPlexEpisodeCache(
 	prisma: PrismaClientInstance,
 	instanceId: string,
 	log: FastifyBaseLogger,
-): Promise<{ upserted: number; errors: number }> {
+): Promise<{ upserted: number; errors: number; errorMessages: string[] }> {
 	let upserted = 0;
 	let errors = 0;
+	const errorMessages: string[] = [];
 
 	// Find shows with recent watch activity (have a ratingKey and non-zero watchCount)
 	const recentlyWatchedShows = await prisma.plexCache.findMany({
@@ -48,7 +50,7 @@ export async function refreshPlexEpisodeCache(
 
 	if (recentlyWatchedShows.length === 0) {
 		log.debug({ instanceId }, "No recently watched shows to refresh episodes for");
-		return { upserted, errors };
+		return { upserted, errors, errorMessages };
 	}
 
 	// Deduplicate by tmdbId (same show may appear in multiple sections)
@@ -86,7 +88,8 @@ export async function refreshPlexEpisodeCache(
 		}
 	} catch (err) {
 		log.warn({ err, instanceId }, "Failed to fetch history for episode cache refresh");
-		return { upserted, errors: 1 };
+		errorMessages.push(`Failed to fetch history: ${getErrorMessage(err)}`);
+		return { upserted, errors: 1, errorMessages };
 	}
 
 	// Process each show
@@ -147,11 +150,17 @@ export async function refreshPlexEpisodeCache(
 							"Failed to upsert episode cache entry",
 						);
 					}
+					if (errorMessages.length < 5) {
+						errorMessages.push(`Failed to upsert S${episode.seasonNumber}E${episode.episodeNumber}: ${getErrorMessage(err)}`);
+					}
 				}
 			}
 		} catch (err) {
 			errors++;
 			log.warn({ err, instanceId, tmdbId, showRatingKey }, "Failed to fetch episodes for show");
+			if (errorMessages.length < 5) {
+				errorMessages.push(`Failed to fetch episodes for show tmdb:${tmdbId}: ${getErrorMessage(err)}`);
+			}
 		}
 	}
 
@@ -160,5 +169,5 @@ export async function refreshPlexEpisodeCache(
 		"Plex episode cache refresh completed",
 	);
 
-	return { upserted, errors };
+	return { upserted, errors, errorMessages };
 }

--- a/apps/api/src/lib/plex/plex-schemas.ts
+++ b/apps/api/src/lib/plex/plex-schemas.ts
@@ -32,7 +32,7 @@ export const plexSectionsResponseSchema = z.looseObject({
 			.array(
 				z.looseObject({
 					key: z.string(),
-					title: z.string(),
+					title: z.string().optional().default(""),
 					type: z.string(),
 				}),
 			)
@@ -47,7 +47,7 @@ export const plexLibraryItemsResponseSchema = z.looseObject({
 			.array(
 				z.looseObject({
 					ratingKey: z.string(),
-					title: z.string(),
+					title: z.string().optional().default(""),
 					type: z.string(),
 					year: z.number().optional(),
 					userRating: z.number().optional(),
@@ -69,12 +69,12 @@ export const plexHistoryResponseSchema = z.looseObject({
 		Metadata: z
 			.array(
 				z.looseObject({
-					ratingKey: z.string(),
+					ratingKey: z.string().optional().default(""),
 					parentRatingKey: z.string().optional(),
 					parentKey: z.string().optional(),
 					grandparentRatingKey: z.string().optional(),
 					grandparentKey: z.string().optional(),
-					title: z.string(),
+					title: z.string().optional().default(""),
 					grandparentTitle: z.string().optional(),
 					type: z.string(),
 					viewedAt: z.number(),
@@ -110,7 +110,7 @@ export const plexSessionsResponseSchema = z.looseObject({
 				z.looseObject({
 					sessionKey: z.string(),
 					ratingKey: z.string(),
-					title: z.string(),
+					title: z.string().optional().default(""),
 					grandparentTitle: z.string().optional(),
 					type: z.string(),
 					viewOffset: z.number().optional(),
@@ -119,13 +119,13 @@ export const plexSessionsResponseSchema = z.looseObject({
 					User: z
 						.looseObject({
 							id: z.number(),
-							title: z.string(),
+							title: z.string().optional().default(""),
 							thumb: z.string().optional(),
 						})
 						.optional(),
 					Player: z
 						.looseObject({
-							title: z.string(),
+							title: z.string().optional().default(""),
 							platform: z.string(),
 							product: z.string(),
 							state: z.string(),
@@ -156,7 +156,7 @@ export const plexEpisodesResponseSchema = z.looseObject({
 			.array(
 				z.looseObject({
 					ratingKey: z.string(),
-					title: z.string(),
+					title: z.string().optional().default(""),
 					parentIndex: z.number().optional(),
 					index: z.number().optional(),
 					viewCount: z.number().optional(),

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -13,6 +13,7 @@
  */
 
 import type { FastifyBaseLogger } from "fastify";
+import { getErrorMessage } from "../utils/error-message.js";
 import type { PrismaClient } from "../prisma.js";
 import { delay } from "../utils/delay.js";
 import type { TautulliClient, TautulliHistoryItem } from "./tautulli-client.js";
@@ -39,9 +40,10 @@ export async function refreshTautulliCache(
 	prisma: PrismaClient,
 	instanceId: string,
 	log: FastifyBaseLogger,
-): Promise<{ upserted: number; errors: number }> {
+): Promise<{ upserted: number; errors: number; errorMessages: string[] }> {
 	let upserted = 0;
 	let errors = 0;
+	const errorMessages: string[] = [];
 
 	try {
 		// 1. Get libraries to iterate over
@@ -132,6 +134,9 @@ export async function refreshTautulliCache(
 			} catch (error) {
 				errors++;
 				log.warn({ err: error, ratingKey }, "Tautulli cache: failed to fetch metadata for item");
+				if (errorMessages.length < 5) {
+					errorMessages.push(`Failed to fetch metadata for ratingKey ${ratingKey}: ${getErrorMessage(error)}`);
+				}
 			}
 		}
 
@@ -172,6 +177,9 @@ export async function refreshTautulliCache(
 					{ err: error, instanceId, tmdbId: guid.tmdbId, mediaType: guid.mediaType },
 					"Tautulli cache: failed to upsert item",
 				);
+				if (errorMessages.length < 5) {
+					errorMessages.push(`Failed to upsert tmdb:${guid.tmdbId} (${guid.mediaType}): ${getErrorMessage(error)}`);
+				}
 			}
 		}
 
@@ -198,9 +206,10 @@ export async function refreshTautulliCache(
 	} catch (error) {
 		log.error({ err: error, instanceId }, "Tautulli cache refresh failed");
 		errors++;
+		errorMessages.push(`Tautulli cache refresh failed: ${getErrorMessage(error)}`);
 	}
 
-	return { upserted, errors };
+	return { upserted, errors, errorMessages };
 }
 
 /**

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -34,9 +34,9 @@ export const tautulliLibrarySchema = z.looseObject({
 export const tautulliHistoryDataSchema = z.looseObject({
 	data: z.array(
 		z.looseObject({
-			rating_key: z.string(),
-			parent_rating_key: z.string(),
-			grandparent_rating_key: z.string(),
+			rating_key: z.coerce.string(),
+			parent_rating_key: z.coerce.string(),
+			grandparent_rating_key: z.coerce.string(),
 			title: z.string(),
 			grandparent_title: z.string(),
 			media_type: z.string(),
@@ -54,7 +54,7 @@ export const tautulliActivityDataSchema = z.looseObject({
 	sessions: z.array(
 		z.looseObject({
 			session_key: z.string(),
-			rating_key: z.string(),
+			rating_key: z.coerce.string(),
 			title: z.string(),
 			grandparent_title: z.string().optional(),
 			media_type: z.string(),
@@ -119,8 +119,8 @@ export const tautulliUserWatchTimeStatsSchema = z.looseObject({
 
 /** get_metadata — inner data */
 export const tautulliMetadataSchema = z.looseObject({
-	guids: z.array(z.string()),
-	media_type: z.string(),
-	title: z.string(),
-	rating_key: z.string(),
+	guids: z.preprocess(v => v ?? [], z.array(z.string())),
+	media_type: z.preprocess(v => v ?? "unknown", z.string()),
+	title: z.preprocess(v => v ?? "", z.string()),
+	rating_key: z.coerce.string(),
 });

--- a/apps/api/src/plugins/plex-cache-scheduler.ts
+++ b/apps/api/src/plugins/plex-cache-scheduler.ts
@@ -57,13 +57,13 @@ const plexCacheSchedulerPlugin = fastifyPlugin(
 									cacheType: "plex",
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 								update: {
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 							});

--- a/apps/api/src/plugins/plex-episode-cache-scheduler.ts
+++ b/apps/api/src/plugins/plex-episode-cache-scheduler.ts
@@ -63,13 +63,13 @@ const plexEpisodeCacheSchedulerPlugin = fastifyPlugin(
 									cacheType: "plex_episode",
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 								update: {
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 							});

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -64,13 +64,13 @@ const tautulliCacheSchedulerPlugin = fastifyPlugin(
 									cacheType: "tautulli",
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 								update: {
 									lastRefreshedAt: new Date(),
 									lastResult: result.errors > 0 ? "error" : "success",
-									lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+									lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 									itemCount: result.upserted,
 								},
 							});

--- a/apps/api/src/routes/plex/cache-routes.ts
+++ b/apps/api/src/routes/plex/cache-routes.ts
@@ -69,13 +69,13 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 							cacheType: "plex",
 							lastRefreshedAt: new Date(),
 							lastResult: result.errors > 0 ? "error" : "success",
-							lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+							lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 							itemCount: result.upserted,
 						},
 						update: {
 							lastRefreshedAt: new Date(),
 							lastResult: result.errors > 0 ? "error" : "success",
-							lastErrorMessage: result.errors > 0 ? `${result.errors} item errors` : null,
+							lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
 							itemCount: result.upserted,
 						},
 					})


### PR DESCRIPTION
## Summary
- **Plex/Tautulli schema hardening**: Fix cache refresh errors caused by strict Zod schemas rejecting nullable fields from upstream APIs
- **Error message improvement**: Cache refresh schedulers now store actual error messages instead of generic "N item errors"

### Schema fixes
| API | Field | Issue | Fix |
|-----|-------|-------|-----|
| Plex history | `title`, `ratingKey` | `undefined` on deleted media | `.optional().default("")` |
| Tautulli history | `rating_key` (3 fields) | Number from API, expected string | `z.coerce.string()` |
| Tautulli metadata | `guids`, `media_type`, `title` | `null`/`undefined` on edge cases | `z.preprocess(v => v ?? default)` |

### Error tracking improvement
All 3 refreshers now return `errorMessages: string[]` with actual error text. Schedulers store the first 3 messages (truncated to 200 chars) in `lastErrorMessage` instead of the generic "N item errors" count.

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] All 4 cache types refresh successfully: plex (1306), plex_episode (3530), tautulli (142), seerr_health
- [x] Dashboard no longer shows "Cache refresh errors" banner
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)