### PR TITLE
fix(seerr): fix 4 broken test assertions for CSRF-prefetched requests

### DIFF
--- a/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
@@ -270,7 +270,8 @@ describe("approveRequest", () => {
 		const result = await client.approveRequest(1);
 
 		expect(result.status).toBe(2);
-		const call = factory.rawRequest.mock.calls[0]!;
+		// calls[0] is the CSRF prefetch to /api/v1/status, calls[1] is the actual request
+		const call = factory.rawRequest.mock.calls[1]!;
 		expect(call[1]).toBe("/api/v1/request/1/approve");
 		expect(call[2]).toMatchObject({ method: "POST" });
 	});
@@ -294,7 +295,7 @@ describe("declineRequest", () => {
 		const result = await client.declineRequest(1);
 
 		expect(result.status).toBe(3);
-		const call = factory.rawRequest.mock.calls[0]!;
+		const call = factory.rawRequest.mock.calls[1]!;
 		expect(call[1]).toBe("/api/v1/request/1/decline");
 	});
 });
@@ -310,7 +311,7 @@ describe("deleteRequest", () => {
 
 		await expect(client.deleteRequest(1)).resolves.toBeUndefined();
 
-		const call = factory.rawRequest.mock.calls[0]!;
+		const call = factory.rawRequest.mock.calls[1]!;
 		expect(call[1]).toBe("/api/v1/request/1");
 		expect(call[2]).toMatchObject({ method: "DELETE" });
 	});
@@ -334,7 +335,7 @@ describe("retryRequest", () => {
 		const result = await client.retryRequest(1);
 
 		expect(result.status).toBe(2);
-		const call = factory.rawRequest.mock.calls[0]!;
+		const call = factory.rawRequest.mock.calls[1]!;
 		expect(call[1]).toBe("/api/v1/request/1/retry");
 	});
 });


### PR DESCRIPTION
## Summary
Fixes 4 failing unit tests in `seerr-client.test.ts` that were checking `mock.calls[0]` for the actual request path, but the CSRF prefetch to `/api/v1/status` is `calls[0]` — the actual request is `calls[1]`.

These tests were failing in CI on PR #136 (v2.9 → main).

## Test plan
- [x] All 1073 tests pass (0 failures, was 4 failures before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)