### PR TITLE
fix(dashboard): add unoptimized prop to Plex poster Image components

### DIFF
--- a/apps/web/src/features/dashboard/components/on-deck-widget.tsx
+++ b/apps/web/src/features/dashboard/components/on-deck-widget.tsx
@@ -125,6 +125,7 @@ export const OnDeckWidget = ({ enabled, animationDelay = 0 }: OnDeckWidgetProps)
 													height={210}
 													className="absolute inset-0 w-full h-full object-cover"
 													onError={() => setFailedThumbs((prev) => new Set(prev).add(thumbKey))}
+											unoptimized
 												/>
 											) : (
 												<MediaIcon className="absolute inset-0 m-auto h-10 w-10 text-white/30" />

--- a/apps/web/src/features/dashboard/components/recently-added-widget.tsx
+++ b/apps/web/src/features/dashboard/components/recently-added-widget.tsx
@@ -133,6 +133,7 @@ export const RecentlyAddedWidget = ({ enabled, animationDelay = 0 }: RecentlyAdd
 													height={210}
 													className="absolute inset-0 w-full h-full object-cover"
 													onError={() => setFailedThumbs((prev) => new Set(prev).add(thumbKey))}
+											unoptimized
 												/>
 											) : (
 												<MediaIcon className="absolute inset-0 m-auto h-10 w-10 text-white/30" />


### PR DESCRIPTION
## Summary
Fixes dashboard crash caused by the next/image performance optimization in PR #199.

Next.js 16 requires `images.localPatterns` config for local images with query strings. The Plex thumb proxy URLs use `?path=...` query params which triggers:
```
Image with src "/api/plex/thumb/..." is using a query string which is not configured in images.localPatterns
```

**Fix:** Add `unoptimized` prop to bypass `/_next/image` optimizer. The Plex proxy already sets `Cache-Control: public, max-age=86400, immutable`, so browser caching handles optimization. Layout shift prevention is still active via explicit `width`/`height` props.

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] Dashboard loads without error
- [x] Poster carousels (Recently Added, On Deck) render correctly
- [x] Verified via playwright-cli screenshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)