### PR TITLE
fix(security): resolve Semgrep unsafe format string alert

### DIFF
--- a/apps/api/src/lib/statistics/statistics-utils.ts
+++ b/apps/api/src/lib/statistics/statistics-utils.ts
@@ -140,7 +140,7 @@ export const safeRequest = async <T>(
 		return await operation();
 	} catch (err) {
 		if (context) {
-			console.warn(`[statistics] ${context} failed:`, err instanceof Error ? err.message : err);
+			console.warn('[statistics] %s failed:', context, err instanceof Error ? err.message : err);
 		}
 		return undefined;
 	}


### PR DESCRIPTION
## Summary
Resolves code scanning alert #158 — Semgrep flagged template literal in `console.warn` as unsafe format string.

Changed from:
```js
console.warn(`[statistics] ${context} failed:`, err)
```
To:
```js
console.warn('[statistics] %s failed:', context, err)
```

The `context` parameter is always a hardcoded string from our code, but using `%s` format specifier is the standard pattern and clears the alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)