### PR TITLE
perf(ci): fix E2E artifact issue, keep merge+parallel optimizations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,74 +76,12 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
-  # Build shared artifacts for E2E shards (setup once, reuse across shards)
-  e2e-setup:
-    name: E2E Setup
-    runs-on: ubuntu-latest
-    needs: [lint-and-test]
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Generate Prisma Client
-        run: cd apps/api && pnpm exec prisma generate
-
-      - name: Build shared package
-        run: pnpm --filter @arr/shared run build
-
-      - name: Build web for production
-        run: pnpm --filter @arr/web run build
-
-      - name: Setup database
-        run: cd apps/api && pnpm exec prisma db push
-        env:
-          DATABASE_URL: file:./test.db
-
-      - name: Cache Playwright Browsers
-        uses: actions/cache@v5
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Install Playwright System Dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm exec playwright install-deps chromium
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-build
-          path: |
-            apps/web/.next/
-            apps/api/src/generated/
-            apps/api/test.db
-            packages/shared/dist/
-          retention-days: 1
-
   # End-to-End Tests with Playwright (sharded for parallelism)
-  # Uses pre-built artifacts from e2e-setup and production web server
+  # 3 shards for better load balancing across 13 spec files
   e2e:
     name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
-    needs: [e2e-setup]
+    needs: [lint-and-test]
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -164,16 +102,22 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
 
+      - name: Cache Turbo build
+        uses: actions/cache@v5
+        with:
+          path: node_modules/.cache/turbo
+          key: turbo-e2e-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            turbo-e2e-${{ runner.os }}-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Generate Prisma Client
         run: cd apps/api && pnpm exec prisma generate
 
-      - name: Download build artifacts
-        uses: actions/download-artifact@v7
-        with:
-          name: e2e-build
+      - name: Build shared package
+        run: pnpm --filter @arr/shared run build
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v5
@@ -182,8 +126,18 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
+      - name: Install Playwright Browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
       - name: Install Playwright System Dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: pnpm exec playwright install-deps chromium
+
+      - name: Setup database
+        run: cd apps/api && pnpm exec prisma db push
+        env:
+          DATABASE_URL: file:./test.db
 
       - name: Run E2E tests
         run: |
@@ -191,8 +145,8 @@ jobs:
           (cd apps/api && DATABASE_URL=file:./test.db API_RATE_LIMIT_MAX=10000 LOG_LEVEL=warn pnpm run dev) &
           API_PID=$!
 
-          # Start Web server in production mode (pre-compiled, no per-page compilation delay)
-          (cd apps/web && pnpm run start) &
+          # Start Web server in background
+          (cd apps/web && pnpm run dev) &
           WEB_PID=$!
 
           # Wait for servers with faster polling


### PR DESCRIPTION
## Summary
Fixes the E2E failure from PR #203 where `download-artifact` couldn't find the `.next/` build directory.

**Root cause:** The artifact upload/download path handling didn't preserve the `apps/web/.next/` directory structure correctly, causing `next start` to fail with "Could not find a production build."

**Fix:** Removed the fragile artifact-sharing approach (e2e-setup → download in shards). Each shard now does its own setup with `next dev`, which is simpler and proven to work.

**Kept from PR #203:**
- Merged lint + test into one job (eliminates duplicate setup)
- Docker build parallel with E2E (saves 5-7 min)
- Cancel-in-progress on new push
- 3 E2E shards with fixed calendar tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)