### PR TITLE
refine: route remaining console.warn/error calls through Pino logger

### DIFF
--- a/apps/api/src/lib/auth/oidc-provider.ts
+++ b/apps/api/src/lib/auth/oidc-provider.ts
@@ -1,4 +1,5 @@
 import * as oauth from "oauth4webapi";
+import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 
 export interface OIDCProviderConfig {
@@ -198,10 +199,9 @@ export class OIDCProvider {
 					} catch (retryError) {
 						// Retry failed — fall through to the original error
 						// Log for debugging but don't mask the original error
-						console.warn(
-							"[OIDC] Self-healing retry failed for issuer:",
-							this.config.issuer,
-							retryError instanceof Error ? retryError.message : retryError,
+						loggers.auth.warn(
+							{ err: retryError, issuer: this.config.issuer },
+							"OIDC self-healing retry failed",
 						);
 					}
 				}

--- a/apps/api/src/lib/logger.ts
+++ b/apps/api/src/lib/logger.ts
@@ -136,6 +136,11 @@ export const loggers = {
 	deployment: logger.child({ module: "deployment" }),
 	scheduler: logger.child({ module: "scheduler" }),
 	queueCleaner: logger.child({ module: "queue-cleaner" }),
+	seerr: logger.child({ module: "seerr" }),
+	notifications: logger.child({ module: "notifications" }),
+	librarySync: logger.child({ module: "library-sync" }),
+	libraryCleanup: logger.child({ module: "library-cleanup" }),
+	statistics: logger.child({ module: "statistics" }),
 };
 
 /**

--- a/apps/api/src/lib/notifications/aggregation-buffer.ts
+++ b/apps/api/src/lib/notifications/aggregation-buffer.ts
@@ -6,6 +6,7 @@
  * threshold is reached.
  */
 
+import { loggers } from "../logger.js";
 import type { NotificationPayload } from "./types.js";
 
 export interface AggregationConfig {
@@ -77,7 +78,7 @@ export class AggregationBuffer {
 
 		const digest = this.buildDigest(bucket.items, key);
 		this.flushCallback(digest).catch((err) => {
-			console.warn("[aggregation] Flush failed — batched notifications may be lost:", err instanceof Error ? err.message : err);
+			loggers.notifications.warn({ err }, "Aggregation flush failed — batched notifications may be lost");
 		});
 	}
 

--- a/apps/api/src/lib/statistics/statistics-utils.ts
+++ b/apps/api/src/lib/statistics/statistics-utils.ts
@@ -5,6 +5,8 @@
  * These functions extract common patterns from service-specific fetch/aggregate functions.
  */
 
+import { loggers } from "../logger.js";
+
 // ============================================================================
 // Type Definitions
 // ============================================================================
@@ -140,7 +142,7 @@ export const safeRequest = async <T>(
 		return await operation();
 	} catch (err) {
 		if (context) {
-			console.warn('[statistics] %s failed:', context, err instanceof Error ? err.message : err);
+			loggers.statistics.warn({ err, context }, "Statistics request failed");
 		}
 		return undefined;
 	}

--- a/apps/api/src/lib/trash-guides/cache-manager.ts
+++ b/apps/api/src/lib/trash-guides/cache-manager.ts
@@ -417,7 +417,7 @@ export class TrashCacheManager {
 		} catch (err) {
 			// Log unexpected DB errors (P2025 = record not found is expected)
 			if ((err as { code?: string }).code !== "P2025") {
-				console.warn("[cache-manager] delete failed:", err instanceof Error ? err.message : err);
+				log.warn({ err }, "Cache delete failed");
 			}
 			return false;
 		}

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -24,6 +24,7 @@ import DOMPurify from "isomorphic-dompurify";
 import { z } from "zod";
 import { marked } from "marked";
 import { parseUpstreamOrThrow, UpstreamValidationError } from "../validation/parse-upstream.js";
+import { loggers } from "../logger.js";
 import {
 	radarrNamingSchema,
 	sonarrNamingSchema,
@@ -73,15 +74,10 @@ interface Logger {
 }
 
 /**
- * Fallback logger using console — ensures validation warnings and fetch
+ * Fallback logger using Pino — ensures validation warnings and fetch
  * errors are always visible, even if callers forget to pass app.log.
  */
-const fallbackLogger: Logger = {
-	warn: (msg: string | object, ...args: unknown[]) => console.warn("[TrashFetcher]", msg, ...args),
-	error: (msg: string | object, ...args: unknown[]) =>
-		console.error("[TrashFetcher]", msg, ...args),
-	debug: () => {},
-};
+const fallbackLogger: Logger = loggers.trashGuides;
 
 // ============================================================================
 // HTML Sanitization Configuration

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -295,7 +295,7 @@ export class TemplateUpdater {
 		try {
 			config = JSON.parse(configDataJson) as TemplateConfig;
 		} catch (err) {
-			console.warn("[template-updater] Corrupt configDataJson, skipping CF group detection:", err instanceof Error ? err.message : err);
+			log.warn({ err }, "Corrupt configDataJson, skipping CF group detection");
 			return pending;
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #238 (Docker logging fix). Now that Pino output flows correctly to `docker logs`, six production files that used `console.warn/error` would produce unstructured text mixed with Pino's JSON — breaking `jq` parsing and bypassing Pino's automatic redaction of sensitive fields.

## Console calls replaced

| File | Was | Now |
|---|---|---|
| `trash-guides/github-fetcher.ts` | Fallback logger using `console.warn/error` | Uses `loggers.trashGuides` child logger directly |
| `auth/oidc-provider.ts` | `console.warn` for OIDC retry failure with raw error + issuer URL | `loggers.auth.warn({ err, issuer })` — structured + redacted |
| `notifications/aggregation-buffer.ts` | `console.warn` for flush failure | `loggers.notifications.warn({ err })` |
| `statistics/statistics-utils.ts` | `console.warn` for SDK call failure | `loggers.statistics.warn({ err, context })` |
| `trash-guides/cache-manager.ts` | `console.warn` for DB delete failure | `log.warn({ err })` (existing `loggers.trashGuides` alias) |
| `trash-guides/template-updater.ts` | `console.warn` for corrupt JSON | `log.warn({ err })` (existing `loggers.trashGuides` alias) |

## Logger map additions

Added 5 child loggers for modules that previously had no dedicated entry:
`seerr`, `notifications`, `librarySync`, `libraryCleanup`, `statistics`

## Files changed

- `apps/api/src/lib/logger.ts` — 5 new child loggers in `loggers` map
- `apps/api/src/lib/trash-guides/github-fetcher.ts` — fallback logger → Pino
- `apps/api/src/lib/auth/oidc-provider.ts` — console.warn → loggers.auth
- `apps/api/src/lib/notifications/aggregation-buffer.ts` — console.warn → loggers.notifications
- `apps/api/src/lib/statistics/statistics-utils.ts` — console.warn → loggers.statistics
- `apps/api/src/lib/trash-guides/cache-manager.ts` — console.warn → log (existing alias)
- `apps/api/src/lib/trash-guides/template-updater.ts` — console.warn → log (existing alias)

## Test plan

- [x] TypeScript: 0 errors
- [x] Lint: 0 errors
- [x] Tests: 1,139 passed (85 test files)
- [x] Verified: no production console.warn/error remains in `apps/api/src/lib/` (only startup paths + standalone test scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)