### PR TITLE
fix(ci): skip Docker Hub login for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,9 +203,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Only login for internal PRs/pushes (fork PRs don't have access to secrets)
+      # Only login for internal PRs/pushes (fork PRs and Dependabot don't have access to secrets)
       - name: Log in to Docker Hub (for cache)
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -221,7 +221,7 @@ jobs:
           load: true
           tags: arr-dashboard:ci-test
           cache-from: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:buildcache-linux-amd64
-          cache-to: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref={0}:buildcache-linux-amd64,mode=max', env.DOCKERHUB_IMAGE) || '' }}
+          cache-to: ${{ (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]' && format('type=registry,ref={0}:buildcache-linux-amd64,mode=max', env.DOCKERHUB_IMAGE) || '' }}
 
       - name: Validate runtime file layout
         run: docker run --rm --entrypoint sh arr-dashboard:ci-test /app/api/validate-runtime.sh

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -40,7 +40,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub (for cache)
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary
Dependabot PRs fail Docker build/smoke CI checks because the Docker Hub
login step executes but repository secrets are empty. Dependabot opens
PRs from the same repo (not a fork), so the existing same-repo guard
passes, but GitHub runs Dependabot workflows in a read-only context
without secrets.

### Changes
- Add `github.actor != 'dependabot[bot]'` to Docker Hub login conditions
  in `ci.yml` and `docker-smoke.yml`
- Add the same guard to `cache-to` in `ci.yml` to prevent unauthenticated
  cache push attempts
- Docker builds still run on Dependabot PRs (validating the Dockerfile)
  but skip registry cache

## Files changed
- `.github/workflows/ci.yml` — login + cache-to conditions
- `.github/workflows/docker-smoke.yml` — login condition

## Test plan
- [ ] This PR's own CI should pass (non-Dependabot, has secrets)
- [ ] Next Dependabot PR should no longer fail Docker login
- [ ] Push to main should still login and use cache (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)