### PR TITLE
chore(deps): override picomatch 2.x and brace-expansion 1.x to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
       "flatted@<3.4.2": "3.4.2",
       "effect@<3.20.0": "3.20.0",
       "picomatch@>=4.0.0 <4.0.4": "4.0.4",
+      "picomatch@>=2.0.0 <2.3.2": "2.3.2",
       "yaml": "2.8.3",
-      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5"
+      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
+      "brace-expansion@>=1.0.0 <1.1.13": "1.1.13"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,10 @@ overrides:
   flatted@<3.4.2: 3.4.2
   effect@<3.20.0: 3.20.0
   picomatch@>=4.0.0 <4.0.4: 4.0.4
+  picomatch@>=2.0.0 <2.3.2: 2.3.2
   yaml: 2.8.3
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  brace-expansion@>=1.0.0 <1.1.13: 1.1.13
 
 importers:
 
@@ -2812,8 +2814,8 @@ packages:
   bn.js@4.12.3:
     resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.13:
+    resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -4234,8 +4236,8 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
@@ -7598,7 +7600,7 @@ snapshots:
 
   bn.js@4.12.3: {}
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
@@ -9010,7 +9012,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mimic-response@3.1.0: {}
 
@@ -9024,11 +9026,11 @@ snapshots:
 
   minimatch@3.1.4:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
 
@@ -9270,7 +9272,7 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 


### PR DESCRIPTION
## Summary
Add pnpm overrides for the last 3 open Dependabot alerts targeting
older major versions of picomatch and brace-expansion.

### Overrides added
- **picomatch** >=2.0.0 <2.3.2 → 2.3.2 — ReDoS + method injection (alerts #38, #39)
- **brace-expansion** >=1.0.0 <1.1.13 → 1.1.13 — memory exhaustion (alert #40)

## Test plan
- [x] TypeScript: 0 errors (API + Web)
- [x] Tests: 1,425 passed (1,145 API + 280 Web)
- [x] Verified: only picomatch 2.3.2/4.0.4 and brace-expansion 1.1.13/5.0.5 in lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)