### PR TITLE
chore: v2.12.0 release — Seerr Requests Experience, API stability, security sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] - 2026-03-30
+
+Seerr Requests Experience, API stability improvements, and full security sweep.
+
+### Added
+
+#### Seerr Requests Experience
+- **Request lifecycle visibility** — Timeline view showing the full journey of each request from creation through approval to availability. Requester popover with user details. Deep-linking to individual requests via query params (#225)
+- **Requests UX improvements** — Lifecycle visibility, accessibility enhancements, and queue preview for the Seerr requests page (#229)
+- **Dashboard Seerr widget upgrade** — Inline pending request display with one-click approve directly from the dashboard (#236)
+- **"Needs Attention" signal** — Seerr dashboard widget now highlights items that need manual action (#237)
+
+#### Library Cleanup
+- **Cross-service cleanup rule templates** — Pre-built templates for common cleanup scenarios across Sonarr, Radarr, Plex, and Tautulli (#221)
+- **Requester evaluators** — Cleanup rules can now evaluate Seerr requester data. New Discover request options for rule authoring (#223)
+
+### Fixed
+- **API heap out-of-memory crash** — Four cache schedulers (Plex, Tautulli, episode, session-snapshot) all fired within 30 seconds of startup. With many service instances, overlapping memory peaks exceeded the 512MB heap limit. Staggered startup delays (30s/2min/5min), paginated session snapshot platform cache, released Plex refresher intermediates earlier, and bumped default heap to 768MB (#239, #242)
+- **Plex session schema** — Relaxed schema validation to tolerate type variance across Plex server versions (#228)
+- **Pino logging conflict** — Removed shell stdout redirect that conflicted with Pino's worker-thread transport, causing empty log files (#238)
+- **Tautulli/Plex validation** — Improved statistics code quality and data validation (#233, #241)
+
+### Changed
+- **Logging** — Routed all remaining `console.warn`/`console.error` calls through Pino structured logger (#240)
+- **CI** — Fixed Docker Hub login for Dependabot PRs — login step now skips when secrets are unavailable (#246)
+
+### Security
+- **nodemailer** 8.0.3 → 8.0.4 — SMTP command injection fix
+- **picomatch** 4.0.3 → 4.0.4, 2.3.1 → 2.3.2 — ReDoS and method injection fixes
+- **brace-expansion** 5.0.4 → 5.0.5, 1.1.12 → 1.1.13 — memory exhaustion fix
+- **yaml** 2.8.2 → 2.8.3 — stack overflow via nested collections fix
+- **prisma** 7.5.0 → 7.6.0, **@tanstack/react-query** 5.95.1 → 5.95.2, **turbo** 2.8.20 → 2.9.1, **@biomejs/biome** 2.4.8 → 2.4.10, **vitest** 4.1.0 → 4.1.2
+
+### Tests
+- First-wave test coverage for library cleanup, auth, services, and notifications (#224)
+- Seerr-backed integration tests for the requests experience (#231)
+
 ## [2.11.0] - 2026-03-24
 
 System Pulse — a unified attention feed that synthesizes health signals from every connected service into a single prioritized page.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.11.0 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.12.0 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.11.0** — System Pulse, Library Intelligence, TRaSH scheduled sync, quality upgrade visibility
+> **Version 2.12.0** — Seerr Requests Experience, API stability, security sweep
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -88,6 +88,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.12.0` | Seerr Requests Experience, API stability, security sweep |
 | `2.11.0` | System Pulse — unified health attention feed across all services |
 | `2.10.1` | Quality filter fix |
 | `2.10.0` | Library Intelligence, TRaSH scheduled sync, quality upgrades, grab detection |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.11.0** — System Pulse, Library Intelligence, TRaSH scheduled sync, quality upgrade visibility
+> **Version 2.12.0** — Seerr Requests Experience, API stability, security sweep
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -201,6 +201,7 @@ docker-compose up -d
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.12.0` | Seerr Requests Experience, API stability, security sweep |
 | `2.11.0` | System Pulse — unified health attention feed across all services |
 | `2.10.1` | Quality filter fix |
 | `2.10.0` | Library Intelligence, TRaSH scheduled sync, quality upgrades, grab detection |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arr-dashboard-platform",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "scripts": {


### PR DESCRIPTION
## Summary
Release v2.12.0 — changelog, version bump, and documentation updates.

### Highlights
- **Seerr Requests Experience** — lifecycle timeline, requester popover, deep-linking, one-click approve from dashboard
- **Library Cleanup** — cross-service rule templates, requester evaluators
- **API heap OOM fix** — staggered scheduler startup, memory release, 768MB heap default
- **Security** — all Dependabot and code scanning alerts resolved (nodemailer, picomatch, brace-expansion, yaml, prisma)
- **CI** — Dependabot PRs now pass Docker build checks

### Files changed
- `package.json` — version 2.11.0 → 2.12.0
- `CHANGELOG.md` — new v2.12.0 section
- `README.md` — version tagline + tags table
- `DOCKERHUB.md` — version tagline + tags table
- `CLAUDE.md` — version reference

### Wiki (already pushed)
- `Home.md` — version → 2.12.0
- `Troubleshooting.md` — version → 2.12.0

## Test plan
- [x] TypeScript: 0 errors (API + Web)
- [x] Tests: 1,425 passed (1,145 API + 280 Web)
- [x] Build: 3 packages successful
- [ ] CI passes on this PR

After merge: tag `v2.12.0` and create GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)