### PR TITLE
fix: Seerr widget hydration error and attention item navigation (v2.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ Seerr Requests Experience, API stability improvements, and full security sweep.
 - **API heap out-of-memory crash** — Four cache schedulers (Plex, Tautulli, episode, session-snapshot) all fired within 30 seconds of startup. With many service instances, overlapping memory peaks exceeded the 512MB heap limit. Staggered startup delays (30s/2min/5min), paginated session snapshot platform cache, released Plex refresher intermediates earlier, and bumped default heap to 768MB (#239, #242)
 - **Plex session schema** — Relaxed schema validation to tolerate type variance across Plex server versions (#228)
 - **Pino logging conflict** — Removed shell stdout redirect that conflicted with Pino's worker-thread transport, causing empty log files (#238)
+- **Seerr widget hydration error** — Fixed nested `<a>` tags in the dashboard Seerr widget that caused React hydration mismatches
+- **Seerr "View" link destination** — Stuck attention items now link to the "All Requests" tab instead of the pending approval tab where they wouldn't appear. Added `?tab=` deep-link support to the requests page
 - **Tautulli/Plex validation** — Improved statistics code quality and data validation (#233, #241)
 
 ### Changed

--- a/apps/api/src/routes/seerr/request-routes.ts
+++ b/apps/api/src/routes/seerr/request-routes.ts
@@ -80,7 +80,7 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 			}
 		}
 
-		// Processing requests are only "stuck" if approved + processing media + older than threshold
+		// Processing requests are only "stuck" if approved + still processing + older than threshold
 		if (processingResult.status === "fulfilled") {
 			for (const req of processingResult.value.results) {
 				if (

--- a/apps/web/src/features/dashboard/components/seerr-requests-widget.tsx
+++ b/apps/web/src/features/dashboard/components/seerr-requests-widget.tsx
@@ -18,6 +18,7 @@ import {
 } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -43,6 +44,7 @@ export const SeerrRequestsWidget = ({
 	instanceId,
 	animationDelay = 0,
 }: SeerrRequestsWidgetProps) => {
+	const router = useRouter();
 	const { data: counts, isError } = useSeerrRequestCount(instanceId);
 	const { data: pendingData } = useSeerrRequests({
 		instanceId,
@@ -115,7 +117,14 @@ export const SeerrRequestsWidget = ({
 			className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 			style={{ animationDelay: `${animationDelay}ms`, animationFillMode: "backwards" }}
 		>
-			<Link href="/requests" className="block">
+			{/* Use div instead of Link to avoid nested <a> tags from inner Links/buttons */}
+			<div
+				role="link"
+				tabIndex={0}
+				className="block cursor-pointer"
+				onClick={() => router.push("/requests")}
+				onKeyDown={(e) => { if (e.key === "Enter") router.push("/requests"); }}
+			>
 				<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10 group transition-all hover:border-border/80">
 					{/* Accent line */}
 					<div
@@ -191,7 +200,7 @@ export const SeerrRequestsWidget = ({
 						</div>
 					</div>
 				</div>
-			</Link>
+			</div>
 		</div>
 	);
 };
@@ -308,7 +317,7 @@ function AttentionItemRow({
 				</button>
 			) : (
 				<Link
-					href="/requests"
+					href="/requests?tab=all"
 					onClick={handleViewClick}
 					className="shrink-0 flex items-center gap-0.5 rounded px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
 					aria-label={`View stuck request for ${title}`}

--- a/apps/web/src/features/seerr/components/requests-client.tsx
+++ b/apps/web/src/features/seerr/components/requests-client.tsx
@@ -56,12 +56,16 @@ export const RequestsClient = () => {
 	const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
 	const [selectedRequest, setSelectedRequest] = useState<SeerrRequest | null>(null);
 
-	// Deep-link: ?user=<id> pre-selects requester filter on "All Requests" tab
+	// Deep-link: ?tab=<id> pre-selects a tab, ?user=<id> pre-selects requester filter on "All Requests" tab
 	const searchParams = useSearchParams();
+	const deepLinkTab = searchParams.get("tab") as RequestsTab | null;
 	const deepLinkUserId = searchParams.get("user");
 	const [initialUserFilter, setInitialUserFilter] = useState<string | undefined>(undefined);
 
 	useEffect(() => {
+		if (deepLinkTab && ["approval", "all", "users", "issues", "notifications", "history"].includes(deepLinkTab)) {
+			setActiveTab(deepLinkTab);
+		}
 		if (deepLinkUserId) {
 			const parsed = Number(deepLinkUserId);
 			if (Number.isInteger(parsed) && parsed > 0) {
@@ -71,7 +75,7 @@ export const RequestsClient = () => {
 		} else {
 			setInitialUserFilter(undefined);
 		}
-	}, [deepLinkUserId]);
+	}, [deepLinkTab, deepLinkUserId]);
 
 	// Resolve current instance
 	const currentInstanceId = selectedInstanceId ?? defaultInstance?.id ?? "";


### PR DESCRIPTION
## Summary
Two fixes for the Seerr dashboard widget discovered during v2.12.0 release testing.

### Fixes
- **Hydration error** — Outer `<Link>` wrapper caused nested `<a>` tags (inner "View"
  link rendered another `<a>` inside). Replaced with `<div role="link">` using `router.push()`
- **"View" link destination** — Stuck attention items linked to `/requests` (defaults to
  pending/approval tab where stuck items don't appear). Now links to `/requests?tab=all`
- **Tab deep-linking** — Added `?tab=` query param support to the requests page for
  direct navigation to any tab

## Files changed
- `apps/web/src/features/dashboard/components/seerr-requests-widget.tsx` — hydration fix + link update
- `apps/web/src/features/seerr/components/requests-client.tsx` — `?tab=` deep-link support
- `apps/api/src/routes/seerr/request-routes.ts` — comment clarification
- `CHANGELOG.md` — added to v2.12.0 section

## Test plan
- [x] TypeScript: 0 errors
- [x] Trust check: all pass (privacy, navigation, accuracy, accessibility, gating)
- [x] Verify no hydration error in browser console
- [x] Verify "View" on stuck item navigates to All Requests tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)