### PR TITLE
fix: prevent genre scrollbar from overlapping content on discover page

### DIFF
--- a/apps/web/src/features/discover/components/discover-genre-filter.tsx
+++ b/apps/web/src/features/discover/components/discover-genre-filter.tsx
@@ -84,8 +84,9 @@ export const DiscoverGenreFilter: React.FC<DiscoverGenreFilterProps> = ({
 			{/* Genre pills */}
 			<div
 				ref={scrollRef}
-				className="flex items-center gap-2 overflow-x-auto scrollbar-none px-1"
+				className="flex items-center gap-2 overflow-x-auto px-1 pb-3"
 				style={{
+					scrollbarWidth: "thin",
 					maskImage: "linear-gradient(to right, transparent, black 2%, black 98%, transparent)",
 					WebkitMaskImage:
 						"linear-gradient(to right, transparent, black 2%, black 98%, transparent)",


### PR DESCRIPTION
## Summary

- Genre filter scrollbar on `/discover` was overlapping the pill content
- Root cause: `scrollbar-none` is a Tailwind plugin class that isn't registered in the project, so it was silently ignored
- Fix: Add `pb-3` padding below pills for scrollbar space + `scrollbar-width: thin` for a subtle native scrollbar

## Test plan

- [x] Manually verified on `/discover` — scrollbar sits below genre pills without overlap
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)