### PR TITLE
fix(ci): use production builds for E2E tests to eliminate timeout flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,12 @@ jobs:
         run: pnpm run test
 
   # End-to-End Tests with Playwright (sharded for parallelism)
-  # 3 shards for better load balancing across 13 spec files
+  # Uses production builds for faster, more realistic testing
   e2e:
     name: E2E Tests (${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     needs: [lint-and-test]
-    timeout-minutes: 15
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -119,8 +119,8 @@ jobs:
       - name: Generate Prisma Client
         run: cd apps/api && pnpm exec prisma generate
 
-      - name: Build shared package
-        run: pnpm --filter @arr/shared run build
+      - name: Build all packages (production)
+        run: pnpm run build
 
       - name: Cache Playwright Browsers
         uses: actions/cache@v5
@@ -144,26 +144,32 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          # Start API server in background (disable rate limiting for E2E tests)
-          (cd apps/api && DATABASE_URL=file:./test.db API_RATE_LIMIT_MAX=10000 LOG_LEVEL=warn pnpm run dev) &
+          # Start API production server in background
+          (cd apps/api && DATABASE_URL=file:./test.db API_RATE_LIMIT_MAX=10000 LOG_LEVEL=warn node dist/index.js) &
           API_PID=$!
 
-          # Start Web server in background
-          (cd apps/web && pnpm run dev) &
+          # Start Web production server in background
+          (cd apps/web && pnpm exec next start -p 3000) &
           WEB_PID=$!
 
-          # Wait for servers with faster polling
+          # Wait for servers (production builds start much faster than dev)
           echo "Waiting for servers to start..."
-          for i in {1..40}; do
+          for i in {1..30}; do
             API_OK=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/health 2>/dev/null || echo "000")
             WEB_OK=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 2>/dev/null || echo "000")
             if [ "$API_OK" = "200" ] && [ "$WEB_OK" != "000" ]; then
-              echo "Both servers ready! (API: $API_OK, Web: $WEB_OK)"
+              echo "Both servers ready! (API: $API_OK, Web: $WEB_OK) in ${i}s"
               break
             fi
-            [ $((i % 5)) -eq 0 ] && echo "Waiting... ($i/40) API=$API_OK WEB=$WEB_OK"
+            [ $((i % 5)) -eq 0 ] && echo "Waiting... ($i/30) API=$API_OK WEB=$WEB_OK"
             sleep 1
           done
+
+          if [ "$API_OK" != "200" ] || [ "$WEB_OK" = "000" ]; then
+            echo "::error::Servers failed to start within 30s (API=$API_OK Web=$WEB_OK)"
+            kill $API_PID $WEB_PID 2>/dev/null || true
+            exit 1
+          fi
 
           # Run the E2E tests (sharded)
           pnpm exec playwright test --project=chromium --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
@@ -173,7 +179,7 @@ jobs:
           kill $API_PID $WEB_PID 2>/dev/null || true
           exit $EXIT_CODE
         env:
-          NODE_ENV: test
+          NODE_ENV: production
           CI: true
 
       - name: Upload Playwright Report


### PR DESCRIPTION
## Summary

E2E shard 3/3 timed out at 15 minutes on PR #256 — not a test failure, but slow dev-mode server startup on CI runners. This PR switches E2E tests from dev mode to production builds.

**Before**: `tsx watch` (API) + `next dev` (Web) → JIT compilation per page, 20-30s startup, timeout risk
**After**: `node dist/index.js` (API) + `next start` (Web) → pre-compiled, <5s startup, no timeout risk

## Changes

- Build all packages (`pnpm run build`) before starting servers
- API: `node dist/index.js` instead of `tsx watch src/index.ts`
- Web: `next start` instead of `next dev`
- Timeout: 15m → 10m (generous with production builds)
- Server wait: 40s → 30s polling, with explicit failure guard
- `NODE_ENV=production` for more realistic testing

## Results

| Shard | Before (dev) | After (prod) | Improvement |
|-------|-------------|-------------|-------------|
| 1/3 | 7m 48s | 6m 25s | -18% |
| 2/3 | 5m 56s | 4m 05s | -31% |
| 3/3 | **15m 19s** (timeout ❌) | 4m 35s | **-70%** |
| **Wall clock** | **15m 19s** | **6m 25s** | **-58%** |
| Timeout headroom | 0s (hit limit) | 3m 35s | ∞ → safe |

## Test plan

- [x] CI E2E shards 1/3, 2/3, 3/3 all pass within 10 minutes
- [x] E2E tests behave identically (same test outcomes as dev mode)
- [x] All other CI checks pass (lint, typecheck, test, smoke, Docker, CodeQL, Semgrep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)