### PR TITLE
fix: add incognito mode to discover page and system settings

### DIFF
--- a/apps/web/src/features/discover/components/discover-detail-modal.tsx
+++ b/apps/web/src/features/discover/components/discover-detail-modal.tsx
@@ -7,6 +7,7 @@ import { useCallback } from "react";
 import { useSeerrMovieDetails, useSeerrTvDetails } from "../../../hooks/api/useSeerr";
 import { useFocusTrap } from "../../../hooks/useFocusTrap";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { RATING_COLOR } from "../../../lib/theme-gradients";
 import {
 	getDisplayTitle,
@@ -35,6 +36,7 @@ export const DiscoverDetailModal: React.FC<DiscoverDetailModalProps> = ({
 	onSelectItem,
 }) => {
 	const { gradient: themeGradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
 	const focusTrapRef = useFocusTrap<HTMLDivElement>(true, onClose);
 	const isMovie = item.mediaType === "movie";
 
@@ -44,11 +46,12 @@ export const DiscoverDetailModal: React.FC<DiscoverDetailModalProps> = ({
 	const details = isMovie ? movieQuery.data : tvQuery.data;
 	const isDetailsLoading = isMovie ? movieQuery.isLoading : tvQuery.isLoading;
 
-	const title = details
+	const rawTitle = details
 		? isMovie
 			? (details as NonNullable<typeof movieQuery.data>).title
 			: (details as NonNullable<typeof tvQuery.data>).name
 		: getDisplayTitle(item);
+	const title = incognitoMode ? getLinuxIsoName(rawTitle ?? "") : rawTitle;
 	const year = getReleaseYear(
 		isMovie
 			? {
@@ -60,8 +63,8 @@ export const DiscoverDetailModal: React.FC<DiscoverDetailModalProps> = ({
 						(details as NonNullable<typeof tvQuery.data>)?.firstAirDate ?? item.firstAirDate,
 				},
 	);
-	const backdropUrl = getSeerrImageUrl(details?.backdropPath ?? item.backdropPath, "w1280");
-	const posterUrl = getSeerrImageUrl(details?.posterPath ?? item.posterPath, "w342");
+	const backdropUrl = incognitoMode ? null : getSeerrImageUrl(details?.backdropPath ?? item.backdropPath, "w1280");
+	const posterUrl = incognitoMode ? null : getSeerrImageUrl(details?.posterPath ?? item.posterPath, "w342");
 
 	const mediaStatus = details?.mediaInfo?.status ?? item.mediaInfo?.status;
 	const statusInfo = getMediaStatusInfo(mediaStatus);
@@ -275,7 +278,7 @@ export const DiscoverDetailModal: React.FC<DiscoverDetailModalProps> = ({
 					)}
 
 					{/* Overview */}
-					{details?.overview && (
+					{details?.overview && !incognitoMode && (
 						<div className="space-y-2">
 							<h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground">
 								Overview

--- a/apps/web/src/features/discover/components/discover-poster-card.tsx
+++ b/apps/web/src/features/discover/components/discover-poster-card.tsx
@@ -4,6 +4,7 @@ import type { SeerrDiscoverResult } from "@arr/shared";
 import { Film, Star, Tv } from "lucide-react";
 import { useState } from "react";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { RATING_COLOR } from "../../../lib/theme-gradients";
 import {
 	getDisplayTitle,
@@ -21,8 +22,9 @@ interface DiscoverPosterCardProps {
 
 export const DiscoverPosterCard: React.FC<DiscoverPosterCardProps> = ({ item, onClick, index }) => {
 	const { gradient: themeGradient } = useThemeGradient();
-	const posterUrl = getSeerrImageUrl(item.posterPath, "w300");
-	const title = getDisplayTitle(item);
+	const [incognitoMode] = useIncognitoMode();
+	const posterUrl = incognitoMode ? null : getSeerrImageUrl(item.posterPath, "w300");
+	const title = incognitoMode ? getLinuxIsoName(getDisplayTitle(item)) : getDisplayTitle(item);
 	const year = getReleaseYear(item);
 	const statusInfo = getMediaStatusInfo(item.mediaInfo?.status);
 	const anime = isLikelyAnime(item);

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -22,6 +22,7 @@ import {
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { PremiumSection, PremiumSkeleton } from "../../../components/layout";
+import { useIncognitoMode } from "../../../lib/incognito";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import { Switch } from "../../../components/ui/switch";
@@ -108,6 +109,7 @@ function SystemInfoCard({ icon, label, value, subtitle, animationDelay = 0 }: Sy
  */
 export function SystemTab() {
 	const { gradient: themeGradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
 	const [apiPort, setApiPort] = useState(3001);
 	const [webPort, setWebPort] = useState(3000);
 	const [listenAddress, setListenAddress] = useState("0.0.0.0");
@@ -294,7 +296,7 @@ export function SystemTab() {
 							}
 							label="Database"
 							value={systemInfo.data.database.type}
-							subtitle={systemInfo.data.database.host || undefined}
+							subtitle={incognitoMode ? "••••••••" : (systemInfo.data.database.host || undefined)}
 							animationDelay={50}
 						/>
 
@@ -468,7 +470,7 @@ export function SystemTab() {
 													}}
 												>
 													<td className="px-4 py-2.5">
-														<span className="font-mono text-xs text-foreground">{file.name}</span>
+														<span className="font-mono text-xs text-foreground">{incognitoMode ? "arr-dashboard.log" : file.name}</span>
 													</td>
 													<td className="px-4 py-2.5 text-muted-foreground text-xs">
 														{formatFileSize(file.size)}
@@ -745,7 +747,7 @@ ports:
 							<Info className="h-3 w-3" />
 							Running on:{" "}
 							<code className="px-1.5 py-0.5 bg-card/50 rounded font-mono text-foreground">
-								{settings?.data?.effectiveListenAddress}
+								{incognitoMode ? "••••••••" : settings?.data?.effectiveListenAddress}
 							</code>
 						</p>
 					</div>


### PR DESCRIPTION
## Summary

Discover page and system settings tab were missing incognito mode coverage.

**Discover page:**
- Poster cards: Hide poster images (show media type icon placeholder), anonymize titles
- Detail modal: Hide backdrop/poster, anonymize title, hide overview text
- Applies to all discover views (carousels, search results) via shared `DiscoverPosterCard`

**System settings:**
- Mask database host, effective listen address, and log file names

## Test plan

- [x] `tsc --noEmit` — 0 errors
- [x] Web tests — 280 pass
- [x] Manual: Enable incognito on `/discover` — posters hidden, titles anonymized
- [x] Manual: Enable incognito on `/settings` system tab — host/address/logs masked
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)