### PR TITLE
feat: add Plex OAuth-assisted setup for services

### DIFF
--- a/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
@@ -1,0 +1,315 @@
+import { vi, describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Global fetch mock (captures plex.tv calls AND testConnection calls)
+// ---------------------------------------------------------------------------
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import Fastify from "fastify";
+import { registerOAuthRoutes } from "../oauth-routes.js";
+import {
+	setupAuthInjection,
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+} from "../../__tests__/test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_CLIENT_ID = "550e8400-e29b-41d4-a716-446655440000";
+
+function jsonResponse(data: unknown, status = 200): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: async () => data,
+	} as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// App setup
+// ---------------------------------------------------------------------------
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeAll(async () => {
+	app = Fastify();
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	app.register(registerOAuthRoutes, { prefix: "/oauth" });
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+beforeEach(() => vi.resetAllMocks());
+afterAll(() => app.close());
+
+// ============================================================================
+// POST /oauth/pin — Create PIN
+// ============================================================================
+
+describe("POST /oauth/pin", () => {
+	it("returns pinId and pinCode on success", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({ id: 12345, code: "abc123" }));
+
+		const res = await injectAuthenticated("POST", "/oauth/pin", {
+			body: { clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({ pinId: 12345, pinCode: "abc123" });
+	});
+
+	it("returns 400 when clientId is missing", async () => {
+		const res = await injectAuthenticated("POST", "/oauth/pin", {
+			body: {},
+		});
+
+		expect(res.statusCode).toBe(400);
+	});
+
+	it("returns 400 when clientId is not a UUID", async () => {
+		const res = await injectAuthenticated("POST", "/oauth/pin", {
+			body: { clientId: "not-a-uuid" },
+		});
+
+		expect(res.statusCode).toBe(400);
+	});
+
+	it("returns 502 when plex.tv returns non-200", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
+
+		const res = await injectAuthenticated("POST", "/oauth/pin", {
+			body: { clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(502);
+		expect(res.json().error).toBe("Failed to create Plex PIN");
+	});
+
+	it("returns 502 when fetch throws a network error", async () => {
+		mockFetch.mockRejectedValueOnce(new Error("DNS resolution failed"));
+
+		const res = await injectAuthenticated("POST", "/oauth/pin", {
+			body: { clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(502);
+		expect(res.json().error).toBe("Could not reach plex.tv");
+	});
+});
+
+// ============================================================================
+// GET /oauth/pin/:pinId — Poll PIN
+// ============================================================================
+
+describe("GET /oauth/pin/:pinId", () => {
+	it("returns null tokenRef when not yet approved", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: null }));
+
+		const res = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
+		);
+
+		expect(res.statusCode).toBe(200);
+		expect(res.json()).toEqual({ tokenRef: null });
+	});
+
+	it("returns tokenRef when approved", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: "plex-token-123" }));
+
+		const res = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
+		);
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		// Token is stored server-side; response contains a reference, not the raw token
+		expect(body.tokenRef).toBeTruthy();
+		expect(typeof body.tokenRef).toBe("string");
+		expect(body.tokenRef).not.toBe("plex-token-123"); // Must NOT leak the raw token
+	});
+
+	it("returns 502 when plex.tv returns an error", async () => {
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
+
+		const res = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
+		);
+
+		expect(res.statusCode).toBe(502);
+	});
+
+	it("returns 502 on network error", async () => {
+		mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+		const res = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
+		);
+
+		expect(res.statusCode).toBe(502);
+		expect(res.json().error).toBe("Could not reach plex.tv");
+	});
+});
+
+// ============================================================================
+// POST /oauth/servers — Discover servers
+// ============================================================================
+
+describe("POST /oauth/servers", () => {
+	/** Helper: poll to get a stored tokenRef, then use it for server discovery */
+	async function getTokenRef(): Promise<string> {
+		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: "plex-token-for-test" }));
+		const pollRes = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/99999?clientId=${VALID_CLIENT_ID}`,
+		);
+		return pollRes.json().tokenRef;
+	}
+
+	it("returns servers with reachability status", async () => {
+		const tokenRef = await getTokenRef();
+		const plexResources = [
+			{
+				name: "My Server",
+				clientIdentifier: "server-id-1",
+				provides: "server",
+				owned: true,
+				platform: "Linux",
+				productVersion: "1.32.0",
+				connections: [
+					{ protocol: "https", address: "192.168.1.10", port: 32400, uri: "https://192.168.1.10:32400", local: true, relay: false },
+					{ protocol: "https", address: "203.0.113.10", port: 32400, uri: "https://203.0.113.10:32400", local: false, relay: false },
+				],
+			},
+		];
+
+		// First call: plex.tv resources lookup
+		mockFetch.mockResolvedValueOnce(jsonResponse(plexResources));
+		// Second + third calls: testConnection for each connection URI
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, 200)); // local reachable
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, 502)); // relay unreachable (non-ok)
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.servers).toHaveLength(1);
+		expect(body.servers[0].name).toBe("My Server");
+		expect(body.servers[0].clientIdentifier).toBe("server-id-1");
+		expect(body.servers[0].connections).toHaveLength(2);
+		expect(body.servers[0].connections[0].reachable).toBe(true);
+		expect(body.servers[0].connections[1].reachable).toBe(false);
+	});
+
+	it("filters out non-server resources", async () => {
+		const tokenRef = await getTokenRef();
+		const plexResources = [
+			{
+				name: "My Server",
+				clientIdentifier: "server-1",
+				provides: "server",
+				owned: true,
+				connections: [],
+			},
+			{
+				name: "My Player",
+				clientIdentifier: "player-1",
+				provides: "player",
+				owned: true,
+				connections: [],
+			},
+		];
+
+		mockFetch.mockResolvedValueOnce(jsonResponse(plexResources));
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.servers).toHaveLength(1);
+		expect(body.servers[0].name).toBe("My Server");
+	});
+
+	it("returns 400 when plex.tv returns 401 (expired token)", async () => {
+		const tokenRef = await getTokenRef();
+		mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(res.json().error).toBe("Invalid or expired Plex token");
+	});
+
+	it("returns 502 on network error", async () => {
+		const tokenRef = await getTokenRef();
+		mockFetch.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(502);
+		expect(res.json().error).toBe("Could not reach plex.tv");
+	});
+});
+
+// ============================================================================
+// POST /oauth/token — Retrieve stored token
+// ============================================================================
+
+describe("POST /oauth/token", () => {
+	async function storeAndGetRef(): Promise<string> {
+		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: "plex-token-for-retrieval" }));
+		const pollRes = await injectAuthenticated(
+			"GET",
+			`/oauth/pin/88888?clientId=${VALID_CLIENT_ID}`,
+		);
+		return pollRes.json().tokenRef;
+	}
+
+	it("returns the stored auth token for a valid tokenRef", async () => {
+		const tokenRef = await storeAndGetRef();
+		const res = await injectAuthenticated("POST", "/oauth/token", { body: { tokenRef } });
+
+		expect(res.statusCode).toBe(200);
+		expect(res.json().authToken).toBe("plex-token-for-retrieval");
+	});
+
+	it("allows multiple retrievals (non-consuming)", async () => {
+		const tokenRef = await storeAndGetRef();
+		const res1 = await injectAuthenticated("POST", "/oauth/token", { body: { tokenRef } });
+		const res2 = await injectAuthenticated("POST", "/oauth/token", { body: { tokenRef } });
+
+		expect(res1.statusCode).toBe(200);
+		expect(res2.statusCode).toBe(200);
+		expect(res1.json().authToken).toBe(res2.json().authToken);
+	});
+
+	it("returns 400 for an unknown tokenRef", async () => {
+		const res = await injectAuthenticated("POST", "/oauth/token", {
+			body: { tokenRef: "nonexistent-ref" },
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(res.json().error).toContain("Token expired");
+	});
+});

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -28,6 +28,7 @@ import { registerUserEpisodeCompletionRoutes } from "./user-episode-completion-r
 import { registerQualityScoreRoutes } from "./quality-score-routes.js";
 import { registerForecastRoutes } from "./forecast-routes.js";
 import { registerImageProxyRoutes } from "./image-proxy-routes.js";
+import { registerOAuthRoutes } from "./oauth-routes.js";
 
 export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
 	app.register(registerWatchEnrichmentRoutes, { prefix: "/watch-enrichment" });
@@ -53,4 +54,5 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerQualityScoreRoutes, { prefix: "/analytics/quality-score" });
 	app.register(registerForecastRoutes, { prefix: "/analytics/forecast" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
+	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/oauth-routes.ts
+++ b/apps/api/src/routes/plex/oauth-routes.ts
@@ -1,0 +1,457 @@
+/**
+ * Plex OAuth Routes
+ *
+ * PIN-based OAuth flow for Plex setup assistance.
+ * Proxies plex.tv API calls to avoid CORS and test server reachability
+ * from the backend's network perspective (important for Docker deployments).
+ *
+ * Flow: create PIN → user approves in popup → poll for token → discover servers
+ */
+
+import type {
+	PlexDiscoverServersResponse,
+	PlexOAuthPinResponse,
+	PlexOAuthTokenResponse,
+	PlexServerConnection,
+} from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { randomBytes } from "node:crypto";
+import { z } from "zod";
+import { getErrorMessage } from "../../lib/utils/error-message.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+// ============================================================================
+// Server-side token store — keeps Plex auth tokens off the browser
+// ============================================================================
+
+interface StoredToken {
+	authToken: string;
+	expiresAt: number;
+}
+
+const plexTokenStore = new Map<string, StoredToken>();
+const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const TOKEN_MAX_ENTRIES = 100;
+
+/** Start the cleanup interval. Returns the timer ref for graceful shutdown. */
+function startCleanupInterval(): ReturnType<typeof setInterval> {
+	return setInterval(() => {
+		const now = Date.now();
+		for (const [ref, data] of plexTokenStore.entries()) {
+			if (data.expiresAt < now) {
+				plexTokenStore.delete(ref);
+			}
+		}
+	}, 5 * 60 * 1000);
+}
+
+/** Store a token server-side and return a short-lived reference. */
+function storeToken(authToken: string): string {
+	// Evict oldest if at capacity
+	if (plexTokenStore.size >= TOKEN_MAX_ENTRIES) {
+		const oldestKey = plexTokenStore.keys().next().value;
+		if (oldestKey) plexTokenStore.delete(oldestKey);
+	}
+	const ref = randomBytes(32).toString("hex");
+	plexTokenStore.set(ref, { authToken, expiresAt: Date.now() + TOKEN_TTL_MS });
+	return ref;
+}
+
+/** Retrieve a stored token without deleting it. Returns null if expired or missing. */
+function peekToken(ref: string): string | null {
+	const stored = plexTokenStore.get(ref);
+	if (!stored || stored.expiresAt < Date.now()) {
+		plexTokenStore.delete(ref);
+		return null;
+	}
+	return stored.authToken;
+}
+
+const PLEX_TV_BASE = "https://plex.tv";
+const PLEX_PRODUCT_NAME = "Arr Control Center";
+const PLEX_TV_TIMEOUT = 10_000;
+const SERVER_TEST_TIMEOUT = 5_000;
+
+// Per-route rate limits (global default is 200/min)
+const PIN_CREATE_RATE_LIMIT = { max: 10, timeWindow: "1 minute" };
+const PIN_POLL_RATE_LIMIT = { max: 150, timeWindow: "1 minute" };
+const SERVER_DISCOVER_RATE_LIMIT = { max: 10, timeWindow: "1 minute" };
+
+/** Standard X-Plex-* headers required by the plex.tv API. */
+function plexTvHeaders(clientId: string): Record<string, string> {
+	return {
+		Accept: "application/json",
+		"X-Plex-Product": PLEX_PRODUCT_NAME,
+		"X-Plex-Version": "1.0",
+		"X-Plex-Client-Identifier": clientId,
+	};
+}
+
+// ============================================================================
+// Local Zod schemas for plex.tv upstream responses (not shared — internal only)
+// ============================================================================
+
+const plexTvPinResponseSchema = z.object({
+	id: z.number(),
+	code: z.string(),
+});
+
+const plexTvPinCheckSchema = z.object({
+	authToken: z.string().nullable(),
+});
+
+const plexTvResourceConnectionSchema = z.object({
+	protocol: z.string(),
+	address: z.string(),
+	port: z.number(),
+	uri: z.string(),
+	local: z.boolean(),
+	relay: z.boolean(),
+});
+
+const plexTvResourceSchema = z.object({
+	name: z.string(),
+	clientIdentifier: z.string(),
+	provides: z.string(),
+	owned: z.boolean().optional(),
+	connections: z.array(plexTvResourceConnectionSchema).optional(),
+	accessToken: z.string().optional(),
+	productVersion: z.string().optional(),
+	platform: z.string().optional(),
+});
+
+const plexTvResourcesResponseSchema = z.array(plexTvResourceSchema);
+
+/** Safely parse JSON from a Response, returning null on malformed bodies. */
+async function safeJson(response: Response): Promise<unknown | null> {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+/** Build an error payload with both `error` and `message` fields for frontend compatibility. */
+function errorPayload(error: string, details?: string) {
+	return details ? { error, message: error, details } : { error, message: error };
+}
+
+// ============================================================================
+// Request validation schemas
+// ============================================================================
+
+const createPinSchema = z.object({
+	clientId: z.string().uuid(),
+});
+
+const pollPinParamsSchema = z.object({
+	pinId: z.coerce.number().int().positive(),
+});
+
+const pollPinQuerySchema = z.object({
+	clientId: z.string().uuid(),
+});
+
+const discoverServersSchema = z.object({
+	tokenRef: z.string().min(1),
+	clientId: z.string().uuid(),
+});
+
+const retrieveTokenSchema = z.object({
+	tokenRef: z.string().min(1),
+});
+
+// ============================================================================
+// Route handlers
+// ============================================================================
+
+export async function registerOAuthRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	// Start token cleanup and register graceful shutdown
+	const cleanupTimer = startCleanupInterval();
+	app.addHook("onClose", () => clearInterval(cleanupTimer));
+
+	/**
+	 * POST /api/plex/oauth/pin
+	 *
+	 * Creates a PIN on plex.tv for the OAuth popup flow.
+	 * Returns { pinId, pinCode } for the frontend to open the auth popup.
+	 */
+	app.post("/pin", { config: { rateLimit: PIN_CREATE_RATE_LIMIT } }, async (request, reply) => {
+		const { clientId } = validateRequest(createPinSchema, request.body);
+
+		let response: Response;
+		try {
+			response = await fetch(`${PLEX_TV_BASE}/api/v2/pins?strong=true`, {
+				method: "POST",
+				headers: plexTvHeaders(clientId),
+				signal: AbortSignal.timeout(PLEX_TV_TIMEOUT),
+			});
+		} catch (err: unknown) {
+			request.log.warn({ err }, "plex.tv PIN creation network error");
+			return reply
+				.status(502)
+				.send(errorPayload("Could not reach plex.tv", getErrorMessage(err, "Network error")));
+		}
+
+		if (!response.ok) {
+			request.log.warn({ status: response.status }, "plex.tv PIN creation failed");
+			return reply
+				.status(502)
+				.send(
+					errorPayload("Failed to create Plex PIN", `plex.tv returned HTTP ${response.status}`),
+				);
+		}
+
+		const raw = await safeJson(response);
+		if (raw === null) {
+			request.log.warn("plex.tv PIN response was not valid JSON");
+			return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+		}
+		const parsed = plexTvPinResponseSchema.safeParse(raw);
+		if (!parsed.success) {
+			request.log.warn("plex.tv PIN response did not match expected schema");
+			return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+		}
+
+		const result: PlexOAuthPinResponse = {
+			pinId: parsed.data.id,
+			pinCode: parsed.data.code,
+		};
+		return reply.send(result);
+	});
+
+	/**
+	 * GET /api/plex/oauth/pin/:pinId
+	 *
+	 * Polls plex.tv for PIN approval status.
+	 * Returns { tokenRef: null } if not yet approved, { tokenRef: "..." } when approved.
+	 * The actual Plex token is stored server-side — only an opaque reference is returned.
+	 */
+	app.get("/pin/:pinId", { config: { rateLimit: PIN_POLL_RATE_LIMIT } }, async (request, reply) => {
+		const { pinId } = validateRequest(pollPinParamsSchema, request.params);
+		const { clientId } = validateRequest(pollPinQuerySchema, request.query);
+
+		let response: Response;
+		try {
+			response = await fetch(`${PLEX_TV_BASE}/api/v2/pins/${pinId}`, {
+				headers: plexTvHeaders(clientId),
+				signal: AbortSignal.timeout(PLEX_TV_TIMEOUT),
+			});
+		} catch (err: unknown) {
+			request.log.warn({ err }, "plex.tv PIN poll network error");
+			return reply
+				.status(502)
+				.send(errorPayload("Could not reach plex.tv", getErrorMessage(err, "Network error")));
+		}
+
+		if (!response.ok) {
+			request.log.warn({ status: response.status }, "plex.tv PIN poll failed");
+			return reply
+				.status(502)
+				.send(
+					errorPayload(
+						"Failed to check Plex PIN status",
+						`plex.tv returned HTTP ${response.status}`,
+					),
+				);
+		}
+
+		const raw = await safeJson(response);
+		if (raw === null) {
+			request.log.warn("plex.tv PIN poll response was not valid JSON");
+			return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+		}
+		const parsed = plexTvPinCheckSchema.safeParse(raw);
+		if (!parsed.success) {
+			request.log.warn({ zodError: parsed.error.issues }, "plex.tv PIN poll response did not match expected schema");
+			return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+		}
+
+		// Store token server-side to keep it off the browser during discovery
+		const authToken = parsed.data.authToken;
+		const tokenRef = authToken ? storeToken(authToken) : null;
+		const result: PlexOAuthTokenResponse = { tokenRef };
+		return reply.send(result);
+	});
+
+	/**
+	 * POST /api/plex/oauth/servers
+	 *
+	 * Discovers Plex servers accessible with the given auth token.
+	 * Tests each connection from the backend network and returns reachability status.
+	 */
+	app.post(
+		"/servers",
+		{ config: { rateLimit: SERVER_DISCOVER_RATE_LIMIT } },
+		async (request, reply) => {
+			const { tokenRef, clientId } = validateRequest(discoverServersSchema, request.body);
+
+			const authToken = peekToken(tokenRef);
+			if (!authToken) {
+				return reply
+					.status(400)
+					.send(errorPayload("Token expired or not found. Please sign in again."));
+			}
+
+			let response: Response;
+			try {
+				response = await fetch(
+					`${PLEX_TV_BASE}/api/v2/resources?includeHttps=1&includeRelay=1&includeIPv6=1`,
+					{
+						headers: {
+							...plexTvHeaders(clientId),
+							"X-Plex-Token": authToken,
+						},
+						signal: AbortSignal.timeout(PLEX_TV_TIMEOUT),
+					},
+				);
+			} catch (err: unknown) {
+				request.log.warn({ err }, "plex.tv server discovery network error");
+				return reply
+					.status(502)
+					.send(errorPayload("Could not reach plex.tv", getErrorMessage(err, "Network error")));
+			}
+
+			if (response.status === 401) {
+				return reply.status(400).send(errorPayload("Invalid or expired Plex token"));
+			}
+
+			if (!response.ok) {
+				request.log.warn({ status: response.status }, "plex.tv resources lookup failed");
+				return reply
+					.status(502)
+					.send(
+						errorPayload(
+							"Failed to discover Plex servers",
+							`plex.tv returned HTTP ${response.status}`,
+						),
+					);
+			}
+
+			const raw = await safeJson(response);
+			if (raw === null) {
+				request.log.warn("plex.tv resources response was not valid JSON");
+				return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+			}
+			const parsed = plexTvResourcesResponseSchema.safeParse(raw);
+			if (!parsed.success) {
+				request.log.warn("plex.tv resources response did not match expected schema");
+				return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
+			}
+
+			// Filter to owned servers only — shared servers lack admin API access
+			const serverResources = parsed.data.filter(
+				(r) => r.provides.includes("server") && r.owned !== false,
+			);
+
+			// Expand connections: when an HTTPS plex.direct URI differs from the raw
+			// address, synthesize an HTTP connection with the raw IP (same as Seerr).
+			// This gives users both the secure plex.direct option and a plain HTTP local option.
+			const servers = await Promise.all(
+				serverResources.map(async (server) => {
+					// Exclude relay connections — they're Plex's cloud proxy, not useful for API access
+					const rawConns = (server.connections ?? []).filter((c) => !c.relay);
+					const expanded: typeof rawConns = [];
+
+					for (const conn of rawConns) {
+						try {
+							const uriHost = new URL(conn.uri).hostname;
+							if (uriHost !== conn.address && uriHost.includes(".plex.direct")) {
+								// Add HTTP variant with raw IP address
+								expanded.push({
+									...conn,
+									protocol: "http",
+									uri: `http://${conn.address}:${conn.port}`,
+								});
+								// Keep HTTPS variant with plex.direct hostname
+								expanded.push(conn);
+							} else {
+								expanded.push(conn);
+							}
+						} catch {
+							expanded.push(conn);
+						}
+					}
+
+					// Deduplicate by URI
+					const seen = new Set<string>();
+					const unique = expanded.filter((c) => {
+						if (seen.has(c.uri)) return false;
+						seen.add(c.uri);
+						return true;
+					});
+
+					// Test each connection in parallel
+					const connections: PlexServerConnection[] = await Promise.all(
+						unique.map(async (conn) => {
+							const reachable = await testConnection(conn.uri, authToken);
+							return {
+								uri: conn.uri,
+								local: conn.local,
+								relay: conn.relay,
+								reachable,
+							};
+						}),
+					);
+
+					return {
+						name: server.name,
+						clientIdentifier: server.clientIdentifier,
+						platform: server.platform,
+						version: server.productVersion,
+						connections,
+					};
+				}),
+			);
+
+			const result: PlexDiscoverServersResponse = { servers };
+			return reply.send(result);
+		},
+	);
+
+	/**
+	 * POST /api/plex/oauth/token
+	 *
+	 * Retrieves the stored Plex auth token for service form pre-fill.
+	 * Token remains valid until TTL expiry so the user can switch between connections.
+	 */
+	app.post(
+		"/token",
+		{ config: { rateLimit: SERVER_DISCOVER_RATE_LIMIT } },
+		async (request, reply) => {
+			const { tokenRef } = validateRequest(retrieveTokenSchema, request.body);
+
+			const authToken = peekToken(tokenRef);
+			if (!authToken) {
+				return reply
+					.status(400)
+					.send(errorPayload("Token expired or not found. Please sign in again."));
+			}
+
+			return reply.send({ authToken });
+		},
+	);
+}
+
+/**
+ * Test if a Plex server connection is reachable from this backend.
+ * Calls GET / (server root) with the auth token and a short timeout.
+ */
+async function testConnection(uri: string, token: string): Promise<boolean> {
+	try {
+		// Only allow http/https schemes to prevent SSRF via non-HTTP protocols
+		const scheme = new URL(uri).protocol;
+		if (scheme !== "http:" && scheme !== "https:") return false;
+
+		const response = await fetch(`${uri}/identity`, {
+			headers: {
+				Accept: "application/json",
+				"X-Plex-Token": token,
+			},
+			signal: AbortSignal.timeout(SERVER_TEST_TIMEOUT),
+		});
+		return response.ok;
+	} catch {
+		return false;
+	}
+}

--- a/apps/web/src/features/settings/components/__tests__/plex-oauth-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/plex-oauth-section.test.tsx
@@ -1,0 +1,506 @@
+import type { PlexDiscoveredServer } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../../hooks/api/usePlexOAuth");
+vi.mock("../../../../lib/incognito");
+vi.mock("../../../../lib/api-client/plex");
+vi.mock("../../../../lib/theme-gradients", () => ({
+	SERVICE_GRADIENTS: {
+		plex: {
+			from: "#e5a00d",
+			to: "#f0c040",
+			glow: "rgba(229,160,13,0.3)",
+			fromLight: "#e5a00d10",
+			fromMedium: "#e5a00d20",
+			fromMuted: "#e5a00d30",
+		},
+	},
+	SEMANTIC_COLORS: {
+		success: { text: "#4ade80" },
+		warning: { text: "#fbbf24" },
+	},
+}));
+
+// Import after mock declarations
+import { usePlexOAuth } from "../../../../hooks/api/usePlexOAuth";
+import { getLinuxInstanceName, getLinuxUrl, useIncognitoMode } from "../../../../lib/incognito";
+import { retrievePlexToken } from "../../../../lib/api-client/plex";
+import { PlexOAuthSection } from "../plex-oauth-section";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockOAuthResult(overrides: Partial<ReturnType<typeof usePlexOAuth>> = {}) {
+	return {
+		status: "idle" as const,
+		servers: [] as PlexDiscoveredServer[],
+		tokenRef: null as string | null,
+		error: null as string | null,
+		startOAuth: vi.fn(),
+		cancel: vi.fn(),
+		...overrides,
+	};
+}
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}
+
+function renderSection(onServerSelected = vi.fn(), mode: "add" | "edit" = "add", onTestConnection = vi.fn()) {
+	return render(<PlexOAuthSection onServerSelected={onServerSelected} onTestConnection={onTestConnection} mode={mode} />, {
+		wrapper: createWrapper(),
+	});
+}
+
+const sampleServers: PlexDiscoveredServer[] = [
+	{
+		name: "My Plex Server",
+		clientIdentifier: "abc-123",
+
+		version: "1.40.2",
+		connections: [
+			{ uri: "http://192.168.1.100:32400", local: true, relay: false, reachable: true },
+			{ uri: "https://relay.plex.direct:443", local: false, relay: true, reachable: true },
+		],
+	},
+	{
+		name: "Remote Server",
+		clientIdentifier: "def-456",
+
+		version: "1.39.0",
+		connections: [
+			{ uri: "https://remote.example.com:32400", local: false, relay: false, reachable: false },
+		],
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(useIncognitoMode).mockReturnValue([false, vi.fn()]);
+	vi.mocked(getLinuxInstanceName).mockImplementation((name) => `linux-${name}`);
+	vi.mocked(getLinuxUrl).mockImplementation((_url) => "http://10.0.0.1:8080");
+	vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult());
+	vi.mocked(retrievePlexToken).mockResolvedValue({ authToken: "resolved-plex-token" });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PlexOAuthSection", () => {
+	// ================================================================
+	// Idle state
+	// ================================================================
+
+	it("renders 'Connect with Plex' button in idle state", () => {
+		renderSection();
+
+		expect(screen.getByText("Connect with Plex")).toBeInTheDocument();
+	});
+
+	it("shows 'or enter manually' divider in idle state", () => {
+		renderSection();
+
+		expect(screen.getByText("or enter manually")).toBeInTheDocument();
+	});
+
+	it("calls startOAuth when sign-in button is clicked", () => {
+		const startOAuth = vi.fn();
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ startOAuth }));
+
+		renderSection();
+		fireEvent.click(screen.getByText("Connect with Plex"));
+
+		expect(startOAuth).toHaveBeenCalledTimes(1);
+	});
+
+	// ================================================================
+	// Loading states
+	// ================================================================
+
+	it("shows 'Connecting to Plex...' during pending status", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ status: "pending" }));
+
+		renderSection();
+
+		expect(screen.getByText("Connecting to Plex...")).toBeInTheDocument();
+		expect(screen.getByText("Cancel")).toBeInTheDocument();
+	});
+
+	it("shows 'Waiting for authorization...' during polling status", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ status: "polling" }));
+
+		renderSection();
+
+		expect(screen.getByText("Waiting for authorization...")).toBeInTheDocument();
+	});
+
+	it("shows 'Discovering servers...' during discovering status", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ status: "discovering" }));
+
+		renderSection();
+
+		expect(screen.getByText("Discovering servers...")).toBeInTheDocument();
+	});
+
+	it("calls cancel when Cancel button is clicked during loading", () => {
+		const cancelFn = vi.fn();
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({ status: "polling", cancel: cancelFn }),
+		);
+
+		renderSection();
+		fireEvent.click(screen.getByText("Cancel"));
+
+		expect(cancelFn).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows 'or enter manually' divider during loading states", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ status: "polling" }));
+
+		renderSection();
+
+		expect(screen.getByText("or enter manually")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Error state
+	// ================================================================
+
+	it("shows error message on error status", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "error",
+				error:
+					"Popup was blocked by your browser. Please allow popups for this site and try again.",
+			}),
+		);
+
+		renderSection();
+
+		expect(
+			screen.getByText(
+				"Popup was blocked by your browser. Please allow popups for this site and try again.",
+			),
+		).toBeInTheDocument();
+		// Should still show sign-in button for retry
+		expect(screen.getByText("Connect with Plex")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Cancelled state
+	// ================================================================
+
+	it("shows cancelled message after popup close", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockOAuthResult({ status: "cancelled" }));
+
+		renderSection();
+
+		expect(screen.getByText("Plex sign-in was cancelled.")).toBeInTheDocument();
+		// Should still show sign-in button for retry
+		expect(screen.getByText("Connect with Plex")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Done state — servers found
+	// ================================================================
+
+	it("renders server list with names and reachability badges", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.getByText("My Plex Server")).toBeInTheDocument();
+		expect(screen.getByText("Remote Server")).toBeInTheDocument();
+		expect(screen.getByText(/2 servers found/)).toBeInTheDocument();
+
+		// All connections are shown
+		expect(screen.getByText("http://192.168.1.100:32400")).toBeInTheDocument();
+		expect(screen.getByText("https://relay.plex.direct:443")).toBeInTheDocument();
+		expect(screen.getByText("https://remote.example.com:32400")).toBeInTheDocument();
+
+		// Reachability badges
+		expect(screen.getAllByText("reachable").length).toBeGreaterThanOrEqual(1);
+		expect(screen.getAllByText("unreachable").length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("shows version number when available", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.getByText("v1.40.2")).toBeInTheDocument();
+		expect(screen.getByText("v1.39.0")).toBeInTheDocument();
+	});
+
+	it("calls onServerSelected with resolved token when connection clicked", async () => {
+		const onServerSelected = vi.fn();
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "token-ref-123",
+			}),
+		);
+
+		renderSection(onServerSelected);
+		fireEvent.click(screen.getByText("http://192.168.1.100:32400"));
+
+		await waitFor(() => {
+			expect(onServerSelected).toHaveBeenCalledWith(
+				"My Plex Server",
+				"http://192.168.1.100:32400",
+				"resolved-plex-token",
+			);
+		});
+	});
+
+	it("does not call onServerSelected when tokenRef is null", () => {
+		const onServerSelected = vi.fn();
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: null,
+			}),
+		);
+
+		renderSection(onServerSelected);
+		fireEvent.click(screen.getByText("http://192.168.1.100:32400"));
+
+		expect(onServerSelected).not.toHaveBeenCalled();
+	});
+
+	it("shows '1 server found' for single server", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: [sampleServers[0]!],
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.getByText(/1 server found/)).toBeInTheDocument();
+	});
+
+	it("shows unreachable badge for unreachable connections", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: [sampleServers[1]!],
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.getByText("unreachable")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Done state — empty
+	// ================================================================
+
+	it("shows 'No Plex servers found' for empty result", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: [],
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(
+			screen.getByText("No Plex servers found on your account. You can add one manually below."),
+		).toBeInTheDocument();
+		expect(screen.getByText("Try again")).toBeInTheDocument();
+	});
+
+	it("shows 'or enter manually' divider when done with servers", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.getByText("or enter manually")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Incognito mode
+	// ================================================================
+
+	it("anonymizes server names and URLs in incognito mode", () => {
+		vi.mocked(useIncognitoMode).mockReturnValue([true, vi.fn()]);
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		// Original names should NOT appear
+		expect(screen.queryByText("My Plex Server")).not.toBeInTheDocument();
+		expect(screen.queryByText("http://192.168.1.100:32400")).not.toBeInTheDocument();
+
+		// Anonymized names should appear
+		expect(getLinuxInstanceName).toHaveBeenCalledWith("My Plex Server");
+		expect(getLinuxInstanceName).toHaveBeenCalledWith("Remote Server");
+		expect(getLinuxUrl).toHaveBeenCalled();
+	});
+
+	it("hides version numbers in incognito mode", () => {
+		vi.mocked(useIncognitoMode).mockReturnValue([true, vi.fn()]);
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection();
+
+		expect(screen.queryByText("v1.40.2")).not.toBeInTheDocument();
+		expect(screen.queryByText("v1.39.0")).not.toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Edit mode
+	// ================================================================
+
+	it("shows 'Reconnect with Plex' button in edit mode", () => {
+		renderSection(vi.fn(), "edit");
+
+		expect(screen.getByText("Reconnect with Plex")).toBeInTheDocument();
+	});
+
+	it("shows 'or edit manually' divider in edit mode", () => {
+		renderSection(vi.fn(), "edit");
+
+		expect(screen.getByText("or edit manually")).toBeInTheDocument();
+	});
+
+	it("shows save reminder after selecting a connection in edit mode", async () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection(vi.fn(), "edit");
+		fireEvent.click(screen.getByText("http://192.168.1.100:32400"));
+
+		await waitFor(() => {
+			expect(screen.getByText(/Updated — click Save changes to apply/)).toBeInTheDocument();
+		});
+	});
+
+	it("does not show save reminder in add mode after selection", async () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection(vi.fn(), "add");
+		fireEvent.click(screen.getByText("http://192.168.1.100:32400"));
+
+		// Wait for the async token consumption to settle
+		await waitFor(() => {
+			expect(retrievePlexToken).toHaveBeenCalled();
+		});
+		expect(screen.queryByText(/Updated — click Save changes to apply/)).not.toBeInTheDocument();
+	});
+
+	it("updates form values when connection selected in edit mode", async () => {
+		const onServerSelected = vi.fn();
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: sampleServers,
+				tokenRef: "plex-token-edit",
+			}),
+		);
+
+		renderSection(onServerSelected, "edit");
+		fireEvent.click(screen.getByText("http://192.168.1.100:32400"));
+
+		await waitFor(() => {
+			expect(onServerSelected).toHaveBeenCalledWith(
+				"My Plex Server",
+				"http://192.168.1.100:32400",
+				"resolved-plex-token",
+			);
+		});
+	});
+
+	it("shows edit-appropriate empty state text", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(
+			mockOAuthResult({
+				status: "done",
+				servers: [],
+				tokenRef: "plex-token-123",
+			}),
+		);
+
+		renderSection(vi.fn(), "edit");
+
+		expect(screen.getByText(/You can edit manually below/)).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/settings/components/plex-oauth-section.tsx
+++ b/apps/web/src/features/settings/components/plex-oauth-section.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * Plex OAuth Setup Section
+ *
+ * Inline component shown in ServiceForm for Plex services (add and edit mode).
+ * Provides "Connect with Plex" / "Reconnect with Plex" button, status indicators,
+ * and server selection. Pre-fills the parent form with selected server details.
+ */
+
+import type { PlexDiscoveredServer, PlexServerConnection } from "@arr/shared";
+import { Check, Globe, Loader2, Monitor, Server, Wifi } from "lucide-react";
+import { useCallback, useState } from "react";
+import { Alert, AlertDescription } from "../../../components/ui";
+import { usePlexOAuth } from "../../../hooks/api/usePlexOAuth";
+import { retrievePlexToken } from "../../../lib/api-client/plex";
+import { getLinuxInstanceName, getLinuxUrl, useIncognitoMode } from "../../../lib/incognito";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+
+const PLEX_GRADIENT = SERVICE_GRADIENTS.plex;
+
+interface PlexOAuthSectionProps {
+	onServerSelected: (label: string, baseUrl: string, apiKey: string) => void;
+	onTestConnection: () => void;
+	mode: "add" | "edit";
+}
+
+/**
+ * Choose the best default connection from a server's connection list.
+ * Priority: reachable local > reachable non-relay > first reachable > first available.
+ */
+function pickBestConnection(connections: PlexServerConnection[]): PlexServerConnection | undefined {
+	const reachableLocal = connections.find((c) => c.reachable && c.local && !c.relay);
+	if (reachableLocal) return reachableLocal;
+
+	const reachableNonRelay = connections.find((c) => c.reachable && !c.relay);
+	if (reachableNonRelay) return reachableNonRelay;
+
+	const firstReachable = connections.find((c) => c.reachable);
+	if (firstReachable) return firstReachable;
+
+	return connections[0];
+}
+
+export const PlexOAuthSection = ({ onServerSelected, onTestConnection, mode }: PlexOAuthSectionProps) => {
+	const isEdit = mode === "edit";
+	const { status, servers, tokenRef, error, startOAuth, cancel } = usePlexOAuth();
+	const [isIncognito] = useIncognitoMode();
+	const [selectedKey, setSelectedKey] = useState<string | null>(null);
+	const [consuming, setConsuming] = useState(false);
+	const [selectedUnreachable, setSelectedUnreachable] = useState(false);
+
+	const handleSelectConnection = useCallback(
+		async (server: PlexDiscoveredServer, connection: PlexServerConnection) => {
+			if (!tokenRef || consuming) return;
+
+			const key = `${server.clientIdentifier}:${connection.uri}`;
+			setSelectedKey(key);
+			setSelectedUnreachable(!connection.reachable);
+			setConsuming(true);
+			try {
+				const { authToken } = await retrievePlexToken(tokenRef);
+				onServerSelected(server.name, connection.uri, authToken);
+				// Auto-trigger connection test after form is pre-filled
+				setTimeout(onTestConnection, 100);
+			} catch {
+				// Token expired or retrieval failed — revert selection and restart flow
+				setSelectedKey(null);
+				setSelectedUnreachable(false);
+				cancel();
+				startOAuth();
+			} finally {
+				setConsuming(false);
+			}
+		},
+		[tokenRef, consuming, onServerSelected, onTestConnection, cancel, startOAuth],
+	);
+
+	// Idle / error / cancelled — show the sign-in button
+	if (status === "idle" || status === "error" || status === "cancelled") {
+		return (
+			<div className="space-y-3">
+				<button
+					type="button"
+					onClick={startOAuth}
+					className="flex w-full items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 hover:brightness-110"
+					style={{
+						borderColor: PLEX_GRADIENT.from,
+						backgroundColor: `${PLEX_GRADIENT.from}15`,
+						color: PLEX_GRADIENT.from,
+					}}
+				>
+					<Server className="h-4 w-4" />
+					{isEdit ? "Reconnect with Plex" : "Connect with Plex"}
+				</button>
+
+				{status === "error" && error && (
+					<Alert variant="danger">
+						<AlertDescription>{error}</AlertDescription>
+					</Alert>
+				)}
+
+				{status === "cancelled" && (
+					<p className="text-center text-xs text-muted-foreground">Plex sign-in was cancelled.</p>
+				)}
+
+				<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+			</div>
+		);
+	}
+
+	// Pending / polling / discovering — show loading state
+	if (status === "pending" || status === "polling" || status === "discovering") {
+		return (
+			<div className="space-y-3">
+				<div className="flex items-center justify-between rounded-lg border border-border/50 bg-card/30 px-4 py-3">
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" style={{ color: PLEX_GRADIENT.from }} />
+						{status === "pending" && "Connecting to Plex..."}
+						{status === "polling" && "Waiting for authorization..."}
+						{status === "discovering" && "Discovering servers..."}
+					</div>
+					<button
+						type="button"
+						onClick={cancel}
+						className="text-xs text-muted-foreground hover:text-foreground"
+					>
+						Cancel
+					</button>
+				</div>
+
+				<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+			</div>
+		);
+	}
+
+	// Done — show discovered servers
+	if (status === "done") {
+		if (servers.length === 0) {
+			return (
+				<div className="space-y-3">
+					<Alert variant="default">
+						<AlertDescription>
+							No Plex servers found on your account. You can {isEdit ? "edit" : "add one"} manually
+							below.
+						</AlertDescription>
+					</Alert>
+					<button
+						type="button"
+						onClick={startOAuth}
+						className="text-xs text-muted-foreground underline hover:text-foreground"
+					>
+						Try again
+					</button>
+					<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+				</div>
+			);
+		}
+
+		return (
+			<div className="space-y-3">
+				<p className="text-xs text-muted-foreground">
+					{servers.length === 1 ? "1 server found" : `${servers.length} servers found`} — select one
+					to auto-fill the form:
+				</p>
+
+				<div className="space-y-3">
+					{servers.map((server) => {
+						const best = pickBestConnection(server.connections);
+
+						return (
+							<div key={server.clientIdentifier} className="space-y-1">
+								<div className="flex items-center gap-2 px-1">
+									<Monitor className="h-3.5 w-3.5 shrink-0" style={{ color: PLEX_GRADIENT.from }} />
+									<span className="truncate text-xs font-medium">
+										{isIncognito ? getLinuxInstanceName(server.name) : server.name}
+									</span>
+									{server.version && !isIncognito && (
+										<span className="shrink-0 text-xs text-muted-foreground">
+											v{server.version}
+										</span>
+									)}
+								</div>
+
+								<div className="space-y-1">
+									{server.connections.map((conn) => {
+										const key = `${server.clientIdentifier}:${conn.uri}`;
+										const isSelected = selectedKey === key;
+										const isBest = conn === best;
+
+										return (
+											<button
+												key={key}
+												type="button"
+												onClick={() => handleSelectConnection(server, conn)}
+												className="flex w-full items-center gap-2 rounded-md border px-3 py-1.5 text-left text-xs transition-all duration-200 hover:bg-accent/50"
+												style={
+													isSelected
+														? {
+																borderColor: PLEX_GRADIENT.from,
+																backgroundColor: `${PLEX_GRADIENT.from}10`,
+															}
+														: undefined
+												}
+											>
+												<ConnectionBadge connection={conn} />
+												<span className="min-w-0 flex-1 truncate">
+													{isIncognito ? getLinuxUrl(conn.uri) : conn.uri}
+												</span>
+												{isBest && !isSelected && (
+													<span className="shrink-0 text-[10px] text-muted-foreground">
+														recommended
+													</span>
+												)}
+												{isSelected && (
+													<Check
+														className="h-3 w-3 shrink-0"
+														style={{ color: PLEX_GRADIENT.from }}
+													/>
+												)}
+												{conn.reachable ? (
+													<span
+														className="shrink-0"
+														style={{ color: SEMANTIC_COLORS.success.text }}
+													>
+														reachable
+													</span>
+												) : (
+													<span
+														className="shrink-0"
+														style={{ color: SEMANTIC_COLORS.warning.text }}
+													>
+														unreachable
+													</span>
+												)}
+											</button>
+										);
+									})}
+								</div>
+							</div>
+						);
+					})}
+				</div>
+
+				{selectedUnreachable && selectedKey && (
+					<Alert variant="danger">
+						<AlertDescription>
+							This connection was unreachable during discovery. You may need to adjust the Base URL below before saving. Use Test connection to verify.
+						</AlertDescription>
+					</Alert>
+				)}
+
+				{isEdit && selectedKey && !selectedUnreachable && (
+					<Alert variant="default">
+						<AlertDescription>Updated — click Save changes to apply.</AlertDescription>
+					</Alert>
+				)}
+
+				<div className="flex items-center gap-2">
+					<button
+						type="button"
+						onClick={() => {
+							setSelectedKey(null);
+							setSelectedUnreachable(false);
+							startOAuth();
+						}}
+						className="text-xs text-muted-foreground underline hover:text-foreground"
+					>
+						Re-scan
+					</button>
+				</div>
+
+				<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+			</div>
+		);
+	}
+
+	return null;
+};
+
+/** Visual divider with configurable text */
+const Divider = ({ text = "or enter manually" }: { text?: string }) => (
+	<div className="relative">
+		<div className="absolute inset-0 flex items-center">
+			<span className="w-full border-t border-border" />
+		</div>
+		<div className="relative flex justify-center text-xs uppercase">
+			<span className="bg-card px-2 text-muted-foreground">{text}</span>
+		</div>
+	</div>
+);
+
+/** Connection type label and icon */
+function getConnectionMeta(conn: PlexServerConnection): {
+	label: string;
+	icon: typeof Wifi;
+	secure: boolean;
+} {
+	const secure = conn.uri.startsWith("https://");
+	if (conn.local) return { label: "Local", icon: Wifi, secure };
+	if (conn.relay) return { label: "Relay", icon: Globe, secure };
+	return { label: "Remote", icon: Globe, secure };
+}
+
+/** Badge showing connection type, protocol, and icon */
+const ConnectionBadge = ({ connection }: { connection: PlexServerConnection }) => {
+	const { label, icon: Icon, secure } = getConnectionMeta(connection);
+	return (
+		<span className="inline-flex shrink-0 items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+			<Icon className="h-2.5 w-2.5" />
+			{label}
+			{secure && (
+				<span className="text-[9px]" style={{ color: SEMANTIC_COLORS.success.text }}>
+					SSL
+				</span>
+			)}
+		</span>
+	);
+};

--- a/apps/web/src/features/settings/components/service-form.tsx
+++ b/apps/web/src/features/settings/components/service-form.tsx
@@ -18,6 +18,7 @@ import { cn } from "../../../lib/utils";
 import { SERVICE_TYPES } from "../lib/settings-constants";
 import type { ServiceFormState } from "../lib/settings-utils";
 import { getServicePlaceholders } from "../lib/settings-utils";
+import { PlexOAuthSection } from "./plex-oauth-section";
 
 /**
  * Props for the ServiceForm component
@@ -115,6 +116,20 @@ export const ServiceForm = ({
 							))}
 						</div>
 					</div>
+					{formState.service === "plex" && (
+						<PlexOAuthSection
+							mode={selectedService ? "edit" : "add"}
+							onServerSelected={(label, baseUrl, apiKey) =>
+								onFormStateChange((prev) => ({
+									...prev,
+									label,
+									baseUrl,
+									apiKey,
+								}))
+							}
+							onTestConnection={onTestConnection}
+						/>
+					)}
 					<SimpleFormField
 						label="Label"
 						htmlFor="service-label"

--- a/apps/web/src/hooks/api/__tests__/usePlexOAuth.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/usePlexOAuth.test.tsx
@@ -1,0 +1,351 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — API client
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../lib/api-client/plex");
+vi.mock("../../../lib/error-utils", () => ({
+	getErrorMessage: (err: unknown, fallback: string) =>
+		err instanceof Error ? err.message : fallback,
+}));
+
+import * as plexApi from "../../../lib/api-client/plex";
+import { usePlexOAuth } from "../usePlexOAuth";
+
+// ---------------------------------------------------------------------------
+// Window / global stubs
+// ---------------------------------------------------------------------------
+
+const mockPopup = {
+	closed: false,
+	close: vi.fn(),
+	location: { href: "" },
+};
+
+// localStorage mock
+const store: Record<string, string> = {};
+const mockLocalStorage = {
+	getItem: vi.fn((key: string) => store[key] ?? null),
+	setItem: vi.fn((key: string, val: string) => {
+		store[key] = val;
+	}),
+	removeItem: vi.fn((key: string) => {
+		delete store[key];
+	}),
+	clear: vi.fn(),
+	length: 0,
+	key: vi.fn(),
+};
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: {
+			queries: { retry: false, gcTime: 0 },
+			mutations: { retry: false },
+		},
+	});
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	vi.useFakeTimers();
+	vi.clearAllMocks();
+
+	// Reset popup state
+	mockPopup.closed = false;
+	mockPopup.close.mockClear();
+	mockPopup.location.href = "";
+
+	// Stub window.open
+	vi.stubGlobal(
+		"open",
+		vi.fn(() => mockPopup),
+	);
+
+	// Stub crypto.randomUUID
+	vi.stubGlobal("crypto", {
+		...globalThis.crypto,
+		randomUUID: () => "test-uuid-1234",
+	});
+
+	// Stub localStorage
+	vi.stubGlobal("localStorage", mockLocalStorage);
+	for (const key of Object.keys(store)) {
+		delete store[key];
+	}
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("usePlexOAuth", () => {
+	it("starts in idle status with empty servers", () => {
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.servers).toEqual([]);
+		expect(result.current.tokenRef).toBeNull();
+		expect(result.current.error).toBeNull();
+	});
+
+	it("opens popup and transitions to pending on startOAuth", async () => {
+		// createPlexPin will not resolve yet (pending promise)
+		vi.mocked(plexApi.createPlexPin).mockReturnValue(new Promise(() => {}));
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		expect(globalThis.open).toHaveBeenCalledTimes(1);
+		expect(result.current.status).toBe("pending");
+	});
+
+	it("transitions to polling after PIN is created", async () => {
+		vi.mocked(plexApi.createPlexPin).mockResolvedValue({
+			pinId: 42,
+			pinCode: "ABCD",
+		});
+		vi.mocked(plexApi.pollPlexPin).mockResolvedValue({ tokenRef: null });
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Flush the async IIFE (createPlexPin resolves -> status set to polling)
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+
+		expect(result.current.status).toBe("polling");
+		expect(mockPopup.location.href).toContain("https://app.plex.tv/auth");
+		expect(mockPopup.location.href).toContain("clientID=");
+		expect(mockPopup.location.href).toContain("code=ABCD");
+	});
+
+	it("transitions to done after token received and servers discovered", async () => {
+		const discoveredServers = [
+			{
+				name: "My Server",
+				clientIdentifier: "abc-123",
+
+				version: "1.40.0",
+				connections: [
+					{ uri: "http://192.168.1.100:32400", local: true, relay: false, reachable: true },
+				],
+			},
+		];
+
+		vi.mocked(plexApi.createPlexPin).mockResolvedValue({
+			pinId: 42,
+			pinCode: "ABCD",
+		});
+		// First poll: no token. Second poll: token received.
+		vi.mocked(plexApi.pollPlexPin)
+			.mockResolvedValueOnce({ tokenRef: null })
+			.mockResolvedValueOnce({ tokenRef: "plex-auth-token-999" });
+		vi.mocked(plexApi.discoverPlexServers).mockResolvedValue({
+			servers: discoveredServers,
+		});
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		// Start OAuth
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Let createPlexPin resolve -> sets up setInterval, status = "polling"
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+		expect(result.current.status).toBe("polling");
+
+		// Advance 1s -> first poll fires (returns null token)
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1000);
+		});
+
+		// Advance 1s -> second poll fires (returns token) -> discovers servers
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1000);
+		});
+
+		// Flush the discoverPlexServers promise chain
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+
+		expect(result.current.status).toBe("done");
+		expect(result.current.tokenRef).toBe("plex-auth-token-999");
+		expect(result.current.servers).toEqual(discoveredServers);
+		expect(plexApi.discoverPlexServers).toHaveBeenCalledWith(
+			"plex-auth-token-999",
+			expect.any(String),
+		);
+	});
+
+	it("sets cancelled when popup closes during polling", async () => {
+		vi.mocked(plexApi.createPlexPin).mockResolvedValue({
+			pinId: 42,
+			pinCode: "ABCD",
+		});
+		vi.mocked(plexApi.pollPlexPin).mockResolvedValue({ tokenRef: null });
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Let createPlexPin resolve
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+		expect(result.current.status).toBe("polling");
+
+		// Simulate popup being closed by user
+		mockPopup.closed = true;
+
+		// Advance timer to trigger the next poll interval check
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(1000);
+		});
+
+		expect(result.current.status).toBe("cancelled");
+	});
+
+	it("sets error when popup is blocked (window.open returns null)", async () => {
+		vi.stubGlobal(
+			"open",
+			vi.fn(() => null),
+		);
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toContain("Popup was blocked");
+	});
+
+	it("ignores startOAuth if already in polling state", async () => {
+		vi.mocked(plexApi.createPlexPin).mockResolvedValue({
+			pinId: 42,
+			pinCode: "ABCD",
+		});
+		vi.mocked(plexApi.pollPlexPin).mockResolvedValue({ tokenRef: null });
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Let createPlexPin resolve -> status = "polling"
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+		expect(result.current.status).toBe("polling");
+
+		// Clear the mock call count
+		vi.mocked(globalThis.open).mockClear();
+
+		// Try starting again — should be a no-op
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		expect(globalThis.open).not.toHaveBeenCalled();
+	});
+
+	it("sets error when createPlexPin fails", async () => {
+		vi.mocked(plexApi.createPlexPin).mockRejectedValue(new Error("Network error"));
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Flush the rejected promise in the async IIFE
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+
+		expect(result.current.status).toBe("error");
+		expect(result.current.error).toBe("Network error");
+	});
+
+	it("cancel cleans up and returns to idle", async () => {
+		vi.mocked(plexApi.createPlexPin).mockResolvedValue({
+			pinId: 42,
+			pinCode: "ABCD",
+		});
+		vi.mocked(plexApi.pollPlexPin).mockResolvedValue({ tokenRef: null });
+
+		const { result } = renderHook(() => usePlexOAuth(), {
+			wrapper: createWrapper(),
+		});
+
+		await act(async () => {
+			result.current.startOAuth();
+		});
+
+		// Let createPlexPin resolve
+		await act(async () => {
+			await vi.advanceTimersByTimeAsync(10);
+		});
+		expect(result.current.status).toBe("polling");
+
+		// Cancel
+		await act(async () => {
+			result.current.cancel();
+		});
+
+		expect(result.current.status).toBe("idle");
+		expect(result.current.error).toBeNull();
+		expect(mockPopup.close).toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/hooks/api/usePlexOAuth.ts
+++ b/apps/web/src/hooks/api/usePlexOAuth.ts
@@ -1,0 +1,223 @@
+"use client";
+
+/**
+ * Plex OAuth Setup Hook
+ *
+ * Manages the full Plex PIN-based OAuth flow:
+ * 1. Opens popup to plex.tv auth page
+ * 2. Polls backend for PIN approval
+ * 3. Discovers available Plex servers
+ * 4. Returns servers for user selection
+ *
+ * The popup is opened synchronously in the click handler to avoid browser popup blocking.
+ */
+
+import type { PlexDiscoveredServer } from "@arr/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPlexPin, discoverPlexServers, pollPlexPin } from "../../lib/api-client/plex";
+import { getErrorMessage } from "../../lib/error-utils";
+
+const PLEX_CLIENT_ID_KEY = "plex_client_id";
+const POLL_INTERVAL_MS = 1_000;
+const POLL_TIMEOUT_MS = 120_000;
+const PLEX_AUTH_URL = "https://app.plex.tv/auth#!";
+
+export type PlexOAuthStatus =
+	| "idle"
+	| "pending"
+	| "polling"
+	| "discovering"
+	| "done"
+	| "error"
+	| "cancelled";
+
+export interface UsePlexOAuthResult {
+	status: PlexOAuthStatus;
+	servers: PlexDiscoveredServer[];
+	tokenRef: string | null;
+	error: string | null;
+	startOAuth: () => void;
+	cancel: () => void;
+}
+
+/** Generate a v4-style UUID that works in non-secure contexts (plain HTTP). */
+function generateUUID(): string {
+	// crypto.randomUUID() requires a secure context (HTTPS).
+	// Self-hosted apps often run on HTTP behind a reverse proxy, so fall back
+	// to getRandomValues which works in all contexts.
+	if (typeof crypto.randomUUID === "function") {
+		return crypto.randomUUID();
+	}
+	const bytes = crypto.getRandomValues(new Uint8Array(16));
+	bytes[6] = (bytes[6]! & 0x0f) | 0x40; // version 4
+	bytes[8] = (bytes[8]! & 0x3f) | 0x80; // variant 1
+	const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+	return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+/** Get or create a persistent client identifier for Plex device registration. */
+function getClientId(): string {
+	const existing = localStorage.getItem(PLEX_CLIENT_ID_KEY);
+	if (existing) return existing;
+	const id = generateUUID();
+	localStorage.setItem(PLEX_CLIENT_ID_KEY, id);
+	return id;
+}
+
+export function usePlexOAuth(): UsePlexOAuthResult {
+	const [status, setStatus] = useState<PlexOAuthStatus>("idle");
+	const [servers, setServers] = useState<PlexDiscoveredServer[]>([]);
+	const [tokenRef, setTokenRef] = useState<string | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	const popupRef = useRef<Window | null>(null);
+	const pollIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+	const pollStartRef = useRef<number>(0);
+	const abortRef = useRef(false);
+	const pollInFlightRef = useRef(false);
+
+	/** Clean up polling interval and popup. */
+	const cleanup = useCallback(() => {
+		if (pollIntervalRef.current) {
+			clearInterval(pollIntervalRef.current);
+			pollIntervalRef.current = null;
+		}
+		if (popupRef.current && !popupRef.current.closed) {
+			popupRef.current.close();
+		}
+		popupRef.current = null;
+	}, []);
+
+	// Cleanup on unmount
+	useEffect(() => cleanup, [cleanup]);
+
+	const cancel = useCallback(() => {
+		abortRef.current = true;
+		pollInFlightRef.current = false;
+		cleanup();
+		setStatus("idle");
+		setError(null);
+	}, [cleanup]);
+
+	const startOAuth = useCallback(() => {
+		// Guard against double-start
+		if (status !== "idle" && status !== "error" && status !== "cancelled" && status !== "done") {
+			return;
+		}
+
+		abortRef.current = false;
+		pollInFlightRef.current = false;
+		setError(null);
+		setServers([]);
+		setTokenRef(null);
+		setStatus("pending");
+
+		const clientId = getClientId();
+
+		// Open popup immediately (synchronous, in click handler) to avoid popup blocking.
+		// Centered 600x700 window.
+		const width = 600;
+		const height = 700;
+		const left = window.screenX + (window.innerWidth - width) / 2;
+		const top = window.screenY + (window.innerHeight - height) / 2;
+		const popup = window.open(
+			"about:blank",
+			"plex-oauth",
+			`width=${width},height=${height},left=${left},top=${top},toolbar=no,menubar=no`,
+		);
+
+		if (!popup) {
+			setStatus("error");
+			setError(
+				"Popup was blocked by your browser. Please allow popups for this site and try again.",
+			);
+			return;
+		}
+
+		popupRef.current = popup;
+
+		// Now create the PIN asynchronously, then redirect the popup
+		(async () => {
+			try {
+				const { pinId, pinCode } = await createPlexPin(clientId);
+
+				if (abortRef.current) return;
+
+				// Redirect popup to Plex auth page
+				const authParams = new URLSearchParams({
+					clientID: clientId,
+					code: pinCode,
+					"context[device][product]": "Arr Control Center",
+					"context[device][layout]": "desktop",
+				});
+				popup.location.href = `${PLEX_AUTH_URL}?${authParams.toString()}`;
+
+				setStatus("polling");
+				pollStartRef.current = Date.now();
+
+				// Start polling for token
+				pollIntervalRef.current = setInterval(async () => {
+					// Skip if a previous poll request is still in flight
+					if (pollInFlightRef.current) return;
+
+					// Timeout check
+					if (Date.now() - pollStartRef.current > POLL_TIMEOUT_MS) {
+						cleanup();
+						setStatus("error");
+						setError("Plex authentication timed out. Please try again.");
+						return;
+					}
+
+					pollInFlightRef.current = true;
+					try {
+						const { tokenRef: receivedRef } = await pollPlexPin(pinId, clientId);
+
+						// Check popup closed AFTER polling — the user may have closed
+						// the popup after approving (Plex says "you can close this window")
+						if (!receivedRef) {
+							if (popupRef.current?.closed) {
+								cleanup();
+								setStatus("cancelled");
+							}
+							return;
+						}
+
+						// Token stored server-side — stop polling
+						cleanup();
+
+						if (abortRef.current) return;
+						setTokenRef(receivedRef);
+						setStatus("discovering");
+
+						// Discover servers using server-side token ref
+						try {
+							const { servers: discovered } = await discoverPlexServers(receivedRef, clientId);
+
+							if (abortRef.current) return;
+							setServers(discovered);
+							setStatus("done");
+						} catch (discoverErr: unknown) {
+							if (!abortRef.current) {
+								setStatus("error");
+								setError(getErrorMessage(discoverErr, "Failed to discover Plex servers"));
+							}
+						}
+					} catch {
+						// Poll-check errors are transient — the interval will retry on next tick.
+						// Discovery errors are handled in the inner try-catch above.
+					} finally {
+						pollInFlightRef.current = false;
+					}
+				}, POLL_INTERVAL_MS);
+			} catch (err: unknown) {
+				cleanup();
+				if (!abortRef.current) {
+					setStatus("error");
+					setError(getErrorMessage(err, "Failed to start Plex authentication"));
+				}
+			}
+		})();
+	}, [status, cleanup]);
+
+	return { status, servers, tokenRef, error, startOAuth, cancel };
+}

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -13,9 +13,12 @@ import type {
 	CollectionStats,
 	DeviceAnalytics,
 	PlexAccountsResponse,
+	PlexDiscoverServersResponse,
 	PlexEpisodeStatusResponse,
 	PlexIdentityResponse,
 	PlexNowPlayingResponse,
+	PlexOAuthPinResponse,
+	PlexOAuthTokenResponse,
 	PlexOnDeckResponse,
 	PlexRecentlyAddedResponse,
 	PlexScanResponse,
@@ -261,4 +264,34 @@ export async function fetchQualityScore(days = 30): Promise<QualityScoreAnalytic
 /** Fetch bandwidth forecast with linear regression projections. */
 export async function fetchBandwidthForecast(days = 30): Promise<BandwidthForecast> {
 	return apiRequest(`/api/plex/analytics/forecast?days=${days}`);
+}
+
+// ============================================================================
+// OAuth Setup Assistance
+// ============================================================================
+
+/** Create a Plex OAuth PIN for the popup auth flow. */
+export async function createPlexPin(clientId: string): Promise<PlexOAuthPinResponse> {
+	return apiRequest("/api/plex/oauth/pin", { json: { clientId } });
+}
+
+/** Poll for Plex OAuth PIN approval. Returns null tokenRef until user approves. */
+export async function pollPlexPin(
+	pinId: number,
+	clientId: string,
+): Promise<PlexOAuthTokenResponse> {
+	return apiRequest(`/api/plex/oauth/pin/${pinId}?clientId=${encodeURIComponent(clientId)}`);
+}
+
+/** Discover Plex servers using a server-side token reference. */
+export async function discoverPlexServers(
+	tokenRef: string,
+	clientId: string,
+): Promise<PlexDiscoverServersResponse> {
+	return apiRequest("/api/plex/oauth/servers", { json: { tokenRef, clientId } });
+}
+
+/** Consume a stored Plex token (single-use) for service form pre-fill. */
+export async function retrievePlexToken(tokenRef: string): Promise<{ authToken: string }> {
+	return apiRequest("/api/plex/oauth/token", { json: { tokenRef } });
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -113,8 +113,10 @@ export const trashGuidesKeys = {
 	// Quality Size
 	qualitySize: {
 		all: ["trash-guides", "quality-size"] as const,
-		presets: (serviceType: string) => ["trash-guides", "quality-size", "presets", serviceType] as const,
-		mapping: (instanceId: string) => ["trash-guides", "quality-size", "mapping", instanceId] as const,
+		presets: (serviceType: string) =>
+			["trash-guides", "quality-size", "presets", serviceType] as const,
+		mapping: (instanceId: string) =>
+			["trash-guides", "quality-size", "mapping", instanceId] as const,
 		preview: (instanceId: string, presetTrashId: string) =>
 			["trash-guides", "quality-size", "preview", instanceId, presetTrashId] as const,
 	},
@@ -322,12 +324,10 @@ export const seerrKeys = {
 		["seerr", "request", instanceId, requestId] as const,
 	requestCount: (instanceId: string) => ["seerr", "request-count", instanceId] as const,
 	attention: (instanceId: string) => ["seerr", "attention", instanceId] as const,
-	users: (instanceId: string, params?: object) =>
-		["seerr", "users", instanceId, params] as const,
+	users: (instanceId: string, params?: object) => ["seerr", "users", instanceId, params] as const,
 	userQuota: (instanceId: string, userId: number) =>
 		["seerr", "user-quota", instanceId, userId] as const,
-	issues: (instanceId: string, params?: object) =>
-		["seerr", "issues", instanceId, params] as const,
+	issues: (instanceId: string, params?: object) => ["seerr", "issues", instanceId, params] as const,
 	notifications: (instanceId: string) => ["seerr", "notifications", instanceId] as const,
 	status: (instanceId: string) => ["seerr", "status", instanceId] as const,
 	health: (instanceId: string) => ["seerr", "health", instanceId] as const,

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -379,3 +379,35 @@ export interface BandwidthForecast {
 	peakHours: Array<{ hour: number; avgConcurrent: number; avgBandwidth: number }>;
 	trend: "increasing" | "stable" | "decreasing";
 }
+
+// ============================================================================
+// Plex OAuth Setup (PIN-based auth + server discovery)
+// ============================================================================
+
+export interface PlexOAuthPinResponse {
+	pinId: number;
+	pinCode: string;
+}
+
+export interface PlexOAuthTokenResponse {
+	tokenRef: string | null;
+}
+
+export interface PlexServerConnection {
+	uri: string;
+	local: boolean;
+	relay: boolean;
+	reachable: boolean;
+}
+
+export interface PlexDiscoveredServer {
+	name: string;
+	clientIdentifier: string;
+	platform?: string;
+	version?: string;
+	connections: PlexServerConnection[];
+}
+
+export interface PlexDiscoverServersResponse {
+	servers: PlexDiscoveredServer[];
+}


### PR DESCRIPTION
## Summary
- Add "Connect with Plex" button for Plex service setup (add + edit mode)
- PIN-based OAuth flow discovers owned servers and their connections
- Server-side token storage keeps Plex auth tokens off the browser during discovery
- Synthesizes HTTP connections from plex.direct HTTPS entries (matching Seerr's approach)
- Auto-tests connection after selection, warns on unreachable connections
- Manual token entry preserved as fallback

## What changed

**Backend** (`apps/api/src/routes/plex/oauth-routes.ts`):
- `POST /pin` — creates plex.tv PIN for popup auth
- `GET /pin/:pinId` — polls for approval, stores token server-side, returns opaque `tokenRef`
- `POST /servers` — discovers servers using stored token, tests reachability, filters relays
- `POST /token` — retrieves stored token for form pre-fill
- In-memory token store with 10-min TTL, 100-entry cap, graceful shutdown cleanup
- Per-route rate limits, Zod validation, SSRF protection, `safeJson` for upstream responses

**Frontend** (`usePlexOAuth.ts`, `plex-oauth-section.tsx`):
- OAuth flow hook with popup lifecycle, 1s polling, in-flight guard, split error handling
- Inline server/connection selection with Local/Remote/SSL badges
- Auto-triggers "Test connection" after selection
- Unreachable connection warning with guidance to adjust Base URL
- Incognito mode support (server names, URLs, version numbers)
- Works in add mode ("Connect with Plex") and edit mode ("Reconnect with Plex")

## What did not change
- `POST /services` contract — unchanged
- Database schema — no new models
- Existing Plex client/helpers — untouched
- Other service types — unaffected

## Validation
- `tsc --noEmit` clean for @arr/api, @arr/web, @arr/shared
- `pnpm run lint` — 0 errors
- 1514 tests passing (51 new: 16 backend + 9 hook + 26 component)
- Multiple code + security + silent failure reviews completed
- Manual testing with live Plex account

## Test plan
- [x] Happy path: sign in → approve → select connection → form pre-fills → auto-test fires
- [x] Popup blocked → error message, manual entry available
- [x] Popup closed before approval → cancelled state
- [x] Popup closed after approval → token still detected
- [x] plex.tv unreachable → 502 with helpful message
- [x] No servers found → info message, manual entry available
- [x] Unreachable connection selected → warning + guidance to adjust URL
- [x] Manual fallback: ignore OAuth, fill fields directly
- [x] Edit mode: "Reconnect with Plex" with save reminder
- [x] Incognito mode: server names/URLs anonymized
- [x] Token expires after 10 min → auto-restarts OAuth flow
- [x] Re-scan clears stale selection state
- [x] Local HTTP + HTTPS plex.direct connections both shown
- [x] Relay connections filtered out

🤖 Generated with [Claude Code](https://claude.com/claude-code)