### PR TITLE
feat: add Seerr auto-setup via Plex sign-in

### DIFF
--- a/apps/api/src/lib/plex/token-store.ts
+++ b/apps/api/src/lib/plex/token-store.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-side Plex Token Store
+ *
+ * Keeps Plex auth tokens in-memory on the backend so they never
+ * reach the browser during OAuth flows. Used by both the Plex OAuth
+ * setup and Seerr auto-setup (which bootstraps via a Plex token).
+ *
+ * Tokens are short-lived (10 min TTL) with bounded capacity (100 entries).
+ */
+
+import { randomBytes } from "node:crypto";
+
+interface StoredToken {
+	authToken: string;
+	expiresAt: number;
+}
+
+const tokenStore = new Map<string, StoredToken>();
+const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const TOKEN_MAX_ENTRIES = 100;
+
+/** Start the cleanup interval. Returns the timer ref for graceful shutdown. */
+export function startCleanupInterval(): ReturnType<typeof setInterval> {
+	return setInterval(
+		() => {
+			const now = Date.now();
+			for (const [ref, data] of tokenStore.entries()) {
+				if (data.expiresAt < now) {
+					tokenStore.delete(ref);
+				}
+			}
+		},
+		5 * 60 * 1000,
+	);
+}
+
+/** Store a token server-side and return a short-lived opaque reference. */
+export function storeToken(authToken: string): string {
+	// Evict oldest if at capacity
+	if (tokenStore.size >= TOKEN_MAX_ENTRIES) {
+		const oldestKey = tokenStore.keys().next().value;
+		if (oldestKey) tokenStore.delete(oldestKey);
+	}
+	const ref = randomBytes(32).toString("hex");
+	tokenStore.set(ref, { authToken, expiresAt: Date.now() + TOKEN_TTL_MS });
+	return ref;
+}
+
+/** Retrieve a stored token without deleting it. Returns null if expired or missing. */
+export function peekToken(ref: string): string | null {
+	const stored = tokenStore.get(ref);
+	if (!stored || stored.expiresAt < Date.now()) {
+		tokenStore.delete(ref);
+		return null;
+	}
+	return stored.authToken;
+}

--- a/apps/api/src/routes/plex/oauth-routes.ts
+++ b/apps/api/src/routes/plex/oauth-routes.ts
@@ -15,57 +15,10 @@ import type {
 	PlexServerConnection,
 } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { randomBytes } from "node:crypto";
 import { z } from "zod";
+import { peekToken, startCleanupInterval, storeToken } from "../../lib/plex/token-store.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
-
-// ============================================================================
-// Server-side token store — keeps Plex auth tokens off the browser
-// ============================================================================
-
-interface StoredToken {
-	authToken: string;
-	expiresAt: number;
-}
-
-const plexTokenStore = new Map<string, StoredToken>();
-const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
-const TOKEN_MAX_ENTRIES = 100;
-
-/** Start the cleanup interval. Returns the timer ref for graceful shutdown. */
-function startCleanupInterval(): ReturnType<typeof setInterval> {
-	return setInterval(() => {
-		const now = Date.now();
-		for (const [ref, data] of plexTokenStore.entries()) {
-			if (data.expiresAt < now) {
-				plexTokenStore.delete(ref);
-			}
-		}
-	}, 5 * 60 * 1000);
-}
-
-/** Store a token server-side and return a short-lived reference. */
-function storeToken(authToken: string): string {
-	// Evict oldest if at capacity
-	if (plexTokenStore.size >= TOKEN_MAX_ENTRIES) {
-		const oldestKey = plexTokenStore.keys().next().value;
-		if (oldestKey) plexTokenStore.delete(oldestKey);
-	}
-	const ref = randomBytes(32).toString("hex");
-	plexTokenStore.set(ref, { authToken, expiresAt: Date.now() + TOKEN_TTL_MS });
-	return ref;
-}
-
-/** Retrieve a stored token without deleting it. Returns null if expired or missing. */
-function peekToken(ref: string): string | null {
-	const stored = plexTokenStore.get(ref);
-	if (!stored || stored.expiresAt < Date.now()) {
-		plexTokenStore.delete(ref);
-		return null;
-	}
-	return stored.authToken;
-}
 
 const PLEX_TV_BASE = "https://plex.tv";
 const PLEX_PRODUCT_NAME = "Arr Control Center";
@@ -263,7 +216,10 @@ export async function registerOAuthRoutes(app: FastifyInstance, _opts: FastifyPl
 		}
 		const parsed = plexTvPinCheckSchema.safeParse(raw);
 		if (!parsed.success) {
-			request.log.warn({ zodError: parsed.error.issues }, "plex.tv PIN poll response did not match expected schema");
+			request.log.warn(
+				{ zodError: parsed.error.issues },
+				"plex.tv PIN poll response did not match expected schema",
+			);
 			return reply.status(502).send(errorPayload("Unexpected response from plex.tv"));
 		}
 

--- a/apps/api/src/routes/seerr/__tests__/oauth-routes.test.ts
+++ b/apps/api/src/routes/seerr/__tests__/oauth-routes.test.ts
@@ -1,0 +1,304 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — vi.hoisted ensures these exist before vi.mock factories
+// ---------------------------------------------------------------------------
+
+const { mockPeekToken } = vi.hoisted(() => ({
+	mockPeekToken: vi.fn(),
+}));
+
+vi.mock("../../../lib/plex/token-store.js", () => ({
+	peekToken: (...args: unknown[]) => mockPeekToken(...args),
+}));
+
+// Mock global.fetch
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// ---------------------------------------------------------------------------
+// Imports (after mocks)
+// ---------------------------------------------------------------------------
+
+import Fastify from "fastify";
+import { registerSeerrOAuthRoutes } from "../oauth-routes.js";
+import {
+	setupAuthInjection,
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+} from "../../__tests__/test-helpers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(data: unknown, status = 200, cookies: string[] = []) {
+	return new Response(JSON.stringify(data), {
+		status,
+		headers: {
+			"Content-Type": "application/json",
+			...(cookies.length > 0 ? { "Set-Cookie": cookies.join(", ") } : {}),
+		},
+	});
+}
+
+/** Mock the CSRF preflight GET /status call that happens before auth */
+function mockCsrfPreflight() {
+	mockFetch.mockResolvedValueOnce(
+		jsonResponse({ version: "2.0.0" }, 200, ["_csrf=secret; Path=/", "XSRF-TOKEN=token123; Path=/"]),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Fastify setup
+// ---------------------------------------------------------------------------
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	mockFetch.mockReset();
+
+	app = Fastify();
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	await app.register(registerSeerrOAuthRoutes, { prefix: "/oauth" });
+	await app.ready();
+
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => {
+	await app.close();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /oauth/fetch-key", () => {
+	const validBody = { seerrUrl: "http://seerr:5055", tokenRef: "test-ref" };
+
+	// ================================================================
+	// Success path
+	// ================================================================
+
+	it("returns apiKey and version when Plex token valid and Seerr admin", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+
+		mockFetch
+			// Step 1: POST auth/plex → 200 with session cookie
+			.mockResolvedValueOnce(
+				jsonResponse({ id: 1, permissions: 2 }, 200, ["connect.sid=abc123; Path=/"]),
+			)
+			// Step 2: GET settings/main → 200 with apiKey
+			.mockResolvedValueOnce(jsonResponse({ apiKey: "seerr-key-456" }))
+			// Step 3: GET status → 200 with version
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body).toEqual({ apiKey: "seerr-key-456", version: "2.0.0" });
+
+		// Verify fetch calls (4 total: CSRF preflight + auth + settings + status)
+		expect(mockFetch).toHaveBeenCalledTimes(4);
+		expect(mockFetch.mock.calls[0]![0]).toBe("http://seerr:5055/api/v1/status"); // CSRF
+		expect(mockFetch.mock.calls[1]![0]).toBe("http://seerr:5055/api/v1/auth/plex");
+		expect(mockFetch.mock.calls[2]![0]).toBe("http://seerr:5055/api/v1/settings/main");
+		expect(mockFetch.mock.calls[3]![0]).toBe("http://seerr:5055/api/v1/status"); // version
+	});
+
+	// ================================================================
+	// Token store errors
+	// ================================================================
+
+	it("returns 400 when tokenRef not found (peekToken returns null)", async () => {
+		mockPeekToken.mockReturnValue(null);
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(400);
+		const body = res.json();
+		expect(body.error).toMatch(/Plex token expired/i);
+		expect(mockFetch).not.toHaveBeenCalled();
+	});
+
+	// ================================================================
+	// Seerr network errors
+	// ================================================================
+
+	it("returns 502 when Seerr is unreachable (fetch throws)", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+		// CSRF preflight also fails if Seerr is unreachable — but the code catches it
+		// The auth POST fetch will then throw
+		mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(502);
+		const body = res.json();
+		expect(body.error).toMatch(/Could not reach Seerr/i);
+	});
+
+	// ================================================================
+	// Seerr auth errors
+	// ================================================================
+
+	it("returns 400 when Seerr returns 403 (not admin)", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+		mockFetch.mockResolvedValueOnce(jsonResponse({ error: "Forbidden" }, 403));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(400);
+		const body = res.json();
+		expect(body.error).toMatch(/does not have admin access/i);
+	});
+
+	it("returns 400 when Seerr returns 500 with 'Plex login is disabled'", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+		mockFetch.mockResolvedValueOnce(
+			jsonResponse({ error: "Plex login is disabled for this Overseerr instance" }, 500),
+		);
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(400);
+		const body = res.json();
+		expect(body.error).toMatch(/Plex sign-in is disabled/i);
+	});
+
+	it("returns 502 when Seerr returns generic 500", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+		mockFetch.mockResolvedValueOnce(jsonResponse({ error: "Internal Server Error" }, 500));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(502);
+		const body = res.json();
+		expect(body.error).toMatch(/Seerr returned an error/i);
+	});
+
+	// ================================================================
+	// Session cookie errors
+	// ================================================================
+
+	it("returns 502 when no session cookie in auth response", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+		// Auth succeeds but no Set-Cookie header
+		mockFetch.mockResolvedValueOnce(jsonResponse({ id: 1, permissions: 2 }, 200));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(502);
+		const body = res.json();
+		expect(body.error).toMatch(/no session was created/i);
+	});
+
+	// ================================================================
+	// Settings errors
+	// ================================================================
+
+	it("returns 400 when settings response is missing apiKey (non-admin fallthrough)", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+
+		mockFetch
+			// Auth succeeds with session cookie
+			.mockResolvedValueOnce(
+				jsonResponse({ id: 1, permissions: 2 }, 200, ["connect.sid=abc123; Path=/"]),
+			)
+			// Settings returns object without apiKey (non-admin user)
+			.mockResolvedValueOnce(jsonResponse({ applicationTitle: "Seerr" }));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(400);
+		const body = res.json();
+		expect(body.error).toMatch(/Could not retrieve API key/i);
+	});
+
+	// ================================================================
+	// Validation errors
+	// ================================================================
+
+	it("returns 400 for invalid seerrUrl (not a URL)", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", {
+			body: { seerrUrl: "not-a-url", tokenRef: "test-ref" },
+		});
+
+		expect(res.statusCode).toBe(400);
+	});
+
+	// ================================================================
+	// Version fallback
+	// ================================================================
+
+	it("returns 'unknown' version when status endpoint fails", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockFetch.mockReset(); // Clear any leftover mocks completely
+		// 4 fetches: CSRF preflight, auth, settings, version (fails)
+		mockFetch
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }, 200, ["_csrf=s; Path=/", "XSRF-TOKEN=t; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ id: 1, permissions: 2 }, 200, ["connect.sid=abc123; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ apiKey: "seerr-key-789" }))
+			.mockRejectedValueOnce(new Error("timeout"));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body).toEqual({ apiKey: "seerr-key-789", version: "unknown" });
+	});
+
+	it("returns 'unknown' version when status endpoint returns non-OK", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		// 4 fetches: CSRF preflight, auth, settings, version (non-OK)
+		mockFetch
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }, 200, ["_csrf=s; Path=/", "XSRF-TOKEN=t; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ id: 1, permissions: 2 }, 200, ["connect.sid=abc123; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ apiKey: "seerr-key-789" }))
+			.mockResolvedValueOnce(jsonResponse({ error: "Internal error" }, 500));
+
+		const res = await injectAuthenticated("POST", "/oauth/fetch-key", { body: validBody });
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.version).toBe("unknown");
+	});
+
+	// ================================================================
+	// Trailing slash normalization
+	// ================================================================
+
+	it("strips trailing slash from seerrUrl", async () => {
+		mockPeekToken.mockReturnValue("plex-token-abc");
+		mockCsrfPreflight();
+
+		// 4 fetches: CSRF preflight, auth, settings, version
+		mockFetch
+			.mockResolvedValueOnce(jsonResponse({ version: "1.0.0" }, 200, ["_csrf=s; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ id: 1, permissions: 2 }, 200, ["connect.sid=abc123; Path=/"]))
+			.mockResolvedValueOnce(jsonResponse({ apiKey: "key-123" }))
+			.mockResolvedValueOnce(jsonResponse({ version: "1.0.0" }));
+
+		await injectAuthenticated("POST", "/oauth/fetch-key", {
+			body: { seerrUrl: "http://seerr:5055/", tokenRef: "test-ref" },
+		});
+
+		// calls[0] is CSRF preflight, calls[1] is auth
+		expect(mockFetch.mock.calls[1]![0]).toBe("http://seerr:5055/api/v1/auth/plex");
+	});
+});

--- a/apps/api/src/routes/seerr/index.ts
+++ b/apps/api/src/routes/seerr/index.ts
@@ -10,6 +10,7 @@ import { registerIssueRoutes } from "./issue-routes.js";
 import { registerLibraryEnrichmentRoutes } from "./library-enrichment-routes.js";
 import { registerNotificationRoutes } from "./notification-routes.js";
 import { registerRequestRoutes } from "./request-routes.js";
+import { registerSeerrOAuthRoutes } from "./oauth-routes.js";
 import { registerStatusRoutes } from "./status-routes.js";
 import { registerUserRoutes } from "./user-routes.js";
 
@@ -21,4 +22,5 @@ export async function registerSeerrRoutes(app: FastifyInstance, _opts: FastifyPl
 	app.register(registerStatusRoutes, { prefix: "/status" });
 	app.register(registerDiscoverRoutes, { prefix: "/discover" });
 	app.register(registerLibraryEnrichmentRoutes, { prefix: "/library-enrichment" });
+	app.register(registerSeerrOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/seerr/oauth-routes.ts
+++ b/apps/api/src/routes/seerr/oauth-routes.ts
@@ -1,0 +1,293 @@
+/**
+ * Seerr OAuth Routes
+ *
+ * Bootstraps Seerr API key retrieval using a Plex auth token.
+ * Flow: user signs in with Plex → backend authenticates to Seerr
+ * via POST /api/v1/auth/plex → retrieves API key from settings.
+ */
+
+import type { SeerrFetchKeyResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { peekToken } from "../../lib/plex/token-store.js";
+import { getErrorMessage } from "../../lib/utils/error-message.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+const SEERR_TIMEOUT = 10_000;
+const FETCH_KEY_RATE_LIMIT = { max: 10, timeWindow: "1 minute" };
+
+/** Build an error payload with both `error` and `message` fields for frontend compatibility. */
+function errorPayload(error: string, details?: string) {
+	return details ? { error, message: error, details } : { error, message: error };
+}
+
+/** Safely parse JSON from a Response, returning null on malformed bodies. */
+async function safeJson(response: Response): Promise<unknown> {
+	try {
+		return await response.json();
+	} catch {
+		return null;
+	}
+}
+
+// ============================================================================
+// Request validation
+// ============================================================================
+
+const fetchKeySchema = z.object({
+	seerrUrl: z.string().url(),
+	tokenRef: z.string().min(1),
+});
+
+// ============================================================================
+// Zod schemas for Seerr upstream responses (internal only)
+// ============================================================================
+
+const seerrAuthResponseSchema = z.object({
+	id: z.number(),
+	permissions: z.number().optional(),
+});
+
+const seerrSettingsMainSchema = z.object({
+	apiKey: z.string().min(1),
+});
+
+const seerrStatusSchema = z.object({
+	version: z.string(),
+});
+
+// ============================================================================
+// Route handler
+// ============================================================================
+
+export async function registerSeerrOAuthRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	/**
+	 * POST /api/seerr/oauth/fetch-key
+	 *
+	 * Authenticates to a Seerr instance using a stored Plex token,
+	 * then retrieves the API key from Seerr's settings endpoint.
+	 *
+	 * Requires: the user has completed Plex OAuth and has a valid tokenRef.
+	 * Returns: { apiKey, version } for form pre-fill.
+	 */
+	app.post(
+		"/fetch-key",
+		{ config: { rateLimit: FETCH_KEY_RATE_LIMIT } },
+		async (request, reply) => {
+			const { seerrUrl, tokenRef } = validateRequest(fetchKeySchema, request.body);
+
+			// Look up the stored Plex auth token
+			const plexToken = peekToken(tokenRef);
+			if (!plexToken) {
+				return reply
+					.status(400)
+					.send(errorPayload("Plex token expired. Please sign in with Plex again."));
+			}
+
+			const baseUrl = seerrUrl.replace(/\/$/, "");
+
+			// Only allow http/https schemes to prevent SSRF
+			try {
+				const scheme = new URL(baseUrl).protocol;
+				if (scheme !== "http:" && scheme !== "https:") {
+					return reply
+						.status(400)
+						.send(errorPayload("Invalid URL scheme. Use http:// or https://."));
+				}
+			} catch {
+				return reply.status(400).send(errorPayload("Invalid Seerr URL."));
+			}
+
+			// Step 1a: Fetch CSRF token from Seerr (required if CSRF protection is enabled)
+			let csrfCookie = "";
+			let csrfToken = "";
+			try {
+				const csrfResponse = await fetch(`${baseUrl}/api/v1/status`, {
+					headers: { Accept: "application/json" },
+					signal: AbortSignal.timeout(SEERR_TIMEOUT),
+				});
+				const csrfCookies = csrfResponse.headers.getSetCookie?.() ?? [];
+				if (csrfCookies.length === 0) {
+					const raw = csrfResponse.headers.get("set-cookie") ?? "";
+					if (raw) csrfCookies.push(...raw.split(/,(?=\s*\w+=)/));
+				}
+				// Extract cookie values for the request header
+				const cookieParts = csrfCookies.map((c) => c.split(";")[0]).filter(Boolean);
+				csrfCookie = cookieParts.join("; ");
+				// Extract XSRF-TOKEN value for the X-XSRF-TOKEN header
+				const xsrfCookie = cookieParts.find((c) => c?.startsWith("XSRF-TOKEN="));
+				if (xsrfCookie) {
+					csrfToken = decodeURIComponent(xsrfCookie.split("=").slice(1).join("="));
+				}
+			} catch (err: unknown) {
+				// CSRF fetch failed — proceed without it (works if CSRF is disabled)
+				request.log.debug({ err }, "CSRF preflight failed — proceeding without CSRF tokens");
+			}
+
+			// Step 1b: Authenticate to Seerr using the Plex token
+			let authResponse: Response;
+			try {
+				const authHeaders: Record<string, string> = {
+					"Content-Type": "application/json",
+					Accept: "application/json",
+				};
+				if (csrfCookie) authHeaders.Cookie = csrfCookie;
+				if (csrfToken) authHeaders["x-xsrf-token"] = csrfToken;
+
+				authResponse = await fetch(`${baseUrl}/api/v1/auth/plex`, {
+					method: "POST",
+					headers: authHeaders,
+					body: JSON.stringify({ authToken: plexToken }),
+					signal: AbortSignal.timeout(SEERR_TIMEOUT),
+				});
+			} catch (err: unknown) {
+				request.log.warn({ err }, "Seerr auth network error");
+				return reply
+					.status(502)
+					.send(errorPayload("Could not reach Seerr", getErrorMessage(err, "Network error")));
+			}
+
+			if (authResponse.status === 403) {
+				return reply
+					.status(400)
+					.send(
+						errorPayload("Your Plex account does not have admin access to this Seerr instance."),
+					);
+			}
+
+			if (authResponse.status === 500) {
+				const raw = await safeJson(authResponse);
+				const body = raw as { error?: string } | null;
+				if (body?.error?.toLowerCase().includes("plex login is disabled")) {
+					return reply
+						.status(400)
+						.send(errorPayload("Plex sign-in is disabled on this Seerr instance."));
+				}
+				return reply
+					.status(502)
+					.send(errorPayload("Seerr returned an error during authentication."));
+			}
+
+			if (!authResponse.ok) {
+				request.log.warn({ status: authResponse.status }, "Seerr auth failed");
+				return reply
+					.status(502)
+					.send(
+						errorPayload(
+							"Failed to authenticate to Seerr",
+							`Seerr returned HTTP ${authResponse.status}`,
+						),
+					);
+			}
+
+			// Validate auth response
+			const authRaw = await safeJson(authResponse);
+			if (authRaw === null) {
+				request.log.warn("Seerr auth response was not valid JSON");
+				return reply.status(502).send(errorPayload("Unexpected response from Seerr"));
+			}
+			const authParsed = seerrAuthResponseSchema.safeParse(authRaw);
+			if (!authParsed.success) {
+				return reply.status(502).send(errorPayload("Unexpected response from Seerr"));
+			}
+
+			// Extract session cookie from the auth response
+			// Use getSetCookie() when available (Node 18.14+), fallback to header splitting
+			let setCookieHeaders = authResponse.headers.getSetCookie?.() ?? [];
+			if (setCookieHeaders.length === 0) {
+				const raw = authResponse.headers.get("set-cookie") ?? "";
+				if (raw) setCookieHeaders = raw.split(/,(?=\s*\w+=)/);
+			}
+			const sessionCookie = setCookieHeaders
+				.map((c) => c.split(";")[0])
+				.filter((c) => c?.startsWith("connect.sid="))
+				.join("; ");
+
+			if (!sessionCookie) {
+				request.log.warn("Seerr auth succeeded but no session cookie returned");
+				return reply
+					.status(502)
+					.send(errorPayload("Seerr authentication succeeded but no session was created."));
+			}
+
+			// Step 2: Fetch the API key from settings (requires admin session)
+			let settingsResponse: Response;
+			try {
+				settingsResponse = await fetch(`${baseUrl}/api/v1/settings/main`, {
+					headers: {
+						Accept: "application/json",
+						Cookie: sessionCookie,
+					},
+					signal: AbortSignal.timeout(SEERR_TIMEOUT),
+				});
+			} catch (err: unknown) {
+				request.log.warn({ err }, "Seerr settings fetch network error");
+				return reply
+					.status(502)
+					.send(errorPayload("Could not reach Seerr", getErrorMessage(err, "Network error")));
+			}
+
+			if (settingsResponse.status === 403) {
+				return reply
+					.status(400)
+					.send(
+						errorPayload("Your Plex account does not have admin access to this Seerr instance."),
+					);
+			}
+
+			if (!settingsResponse.ok) {
+				request.log.warn({ status: settingsResponse.status }, "Seerr settings fetch failed");
+				return reply
+					.status(502)
+					.send(
+						errorPayload(
+							"Failed to retrieve Seerr settings",
+							`Seerr returned HTTP ${settingsResponse.status}`,
+						),
+					);
+			}
+
+			const settingsRaw = await safeJson(settingsResponse);
+			if (settingsRaw === null) {
+				request.log.warn("Seerr settings response was not valid JSON");
+				return reply.status(502).send(errorPayload("Unexpected response from Seerr"));
+			}
+			const settingsParsed = seerrSettingsMainSchema.safeParse(settingsRaw);
+			if (!settingsParsed.success) {
+				// apiKey missing — likely non-admin user (defense-in-depth on Seerr's side)
+				return reply
+					.status(400)
+					.send(
+						errorPayload(
+							"Could not retrieve API key. Your Plex account may not have admin permissions in Seerr.",
+						),
+					);
+			}
+
+			// Step 3: Get Seerr version for the label
+			let version = "unknown";
+			try {
+				const statusResponse = await fetch(`${baseUrl}/api/v1/status`, {
+					headers: { Accept: "application/json", Cookie: sessionCookie },
+					signal: AbortSignal.timeout(SEERR_TIMEOUT),
+				});
+				if (statusResponse.ok) {
+					const statusRaw = await safeJson(statusResponse);
+					const statusParsed = seerrStatusSchema.safeParse(statusRaw);
+					if (statusParsed.success) {
+						version = statusParsed.data.version;
+					}
+				}
+			} catch (err: unknown) {
+				// Version fetch is best-effort — log but don't fail the whole flow
+				request.log.debug({ err }, "Seerr version fetch failed (best-effort)");
+			}
+
+			const result: SeerrFetchKeyResponse = {
+				apiKey: settingsParsed.data.apiKey,
+				version,
+			};
+			return reply.send(result);
+		},
+	);
+}

--- a/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
@@ -1,0 +1,233 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../../../../hooks/api/usePlexOAuth");
+vi.mock("../../../../lib/api-client/seerr");
+vi.mock("../../../../lib/theme-gradients", () => ({
+	SERVICE_GRADIENTS: {
+		seerr: {
+			from: "#6366f1",
+			to: "#8b5cf6",
+			glow: "rgba(99,102,241,0.3)",
+		},
+	},
+}));
+
+// Import after mock declarations
+import { usePlexOAuth } from "../../../../hooks/api/usePlexOAuth";
+import { fetchSeerrApiKey } from "../../../../lib/api-client/seerr";
+import { SeerrAutoSetupSection } from "../seerr-auto-setup-section";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockPlexOAuth(overrides: Partial<ReturnType<typeof usePlexOAuth>> = {}) {
+	return {
+		status: "idle" as const,
+		servers: [],
+		tokenRef: null as string | null,
+		error: null as string | null,
+		startOAuth: vi.fn(),
+		cancel: vi.fn(),
+		...overrides,
+	};
+}
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 } },
+	});
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+}
+
+function renderSection(
+	seerrUrl = "http://seerr:5055",
+	onApiKeyFetched = vi.fn(),
+	mode: "add" | "edit" = "add",
+	onTestConnection = vi.fn(),
+) {
+	return render(
+		<SeerrAutoSetupSection
+			seerrUrl={seerrUrl}
+			onApiKeyFetched={onApiKeyFetched as (apiKey: string) => void}
+			onTestConnection={onTestConnection as () => void}
+			mode={mode}
+		/>,
+		{ wrapper: createWrapper() },
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth());
+	vi.mocked(fetchSeerrApiKey).mockResolvedValue({ apiKey: "fetched-key", version: "2.0.0" });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SeerrAutoSetupSection", () => {
+	// ================================================================
+	// Idle state
+	// ================================================================
+
+	it("renders 'Sign in to Seerr with Plex' button in add mode", () => {
+		renderSection();
+
+		expect(screen.getByText("Sign in to Seerr with Plex")).toBeInTheDocument();
+	});
+
+	it("renders 'Re-authenticate Seerr with Plex' in edit mode", () => {
+		renderSection(undefined, undefined, "edit");
+
+		expect(screen.getByText("Re-authenticate Seerr with Plex")).toBeInTheDocument();
+	});
+
+	it("disables button when seerrUrl is empty", () => {
+		renderSection("");
+
+		const button = screen.getByRole("button", { name: /Sign in to Seerr with Plex/i });
+		expect(button).toBeDisabled();
+	});
+
+	it("shows 'Enter the Seerr Base URL above first' when URL empty", () => {
+		renderSection("");
+
+		expect(screen.getByText(/Enter the Seerr Base URL above first/i)).toBeInTheDocument();
+	});
+
+	it("shows 'or enter manually' divider", () => {
+		renderSection();
+
+		expect(screen.getByText("or enter manually")).toBeInTheDocument();
+	});
+
+	// ================================================================
+	// Plex OAuth flow → fetch key
+	// ================================================================
+
+	it("calls fetchSeerrApiKey when tokenRef is available and button clicked", async () => {
+		// Start with tokenRef already available (user previously authed with Plex)
+		vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth({ tokenRef: "existing-ref" }));
+
+		const onApiKeyFetched = vi.fn();
+		renderSection(undefined, onApiKeyFetched);
+
+		fireEvent.click(screen.getByText("Sign in to Seerr with Plex"));
+
+		await waitFor(() => {
+			expect(fetchSeerrApiKey).toHaveBeenCalledWith("http://seerr:5055", "existing-ref");
+		});
+	});
+
+	// ================================================================
+	// Success state
+	// ================================================================
+
+	it("shows success message after API key fetched", async () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth({ tokenRef: "plex-ref-123" }));
+		vi.mocked(fetchSeerrApiKey).mockResolvedValue({ apiKey: "seerr-key", version: "2.0.0" });
+
+		const onApiKeyFetched = vi.fn();
+		renderSection(undefined, onApiKeyFetched);
+
+		fireEvent.click(screen.getByText("Sign in to Seerr with Plex"));
+
+		await waitFor(() => {
+			expect(screen.getByText("API key retrieved successfully.")).toBeInTheDocument();
+		});
+		expect(onApiKeyFetched).toHaveBeenCalledWith("seerr-key");
+	});
+
+	// ================================================================
+	// Error state
+	// ================================================================
+
+	it("shows error message on fetch failure", async () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth({ tokenRef: "plex-ref-123" }));
+		vi.mocked(fetchSeerrApiKey).mockRejectedValue(
+			new Error("Your Plex account does not have admin access"),
+		);
+
+		renderSection();
+
+		fireEvent.click(screen.getByText("Sign in to Seerr with Plex"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Your Plex account does not have admin access")).toBeInTheDocument();
+		});
+	});
+
+	// ================================================================
+	// Loading states
+	// ================================================================
+
+	it("shows loading state during plex-auth", () => {
+		vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth({ status: "polling" }));
+
+		// To get into plex-auth state, we need to click the button without a tokenRef
+		renderSection();
+		fireEvent.click(screen.getByText("Sign in to Seerr with Plex"));
+
+		expect(screen.getByText(/Waiting for Plex authorization/i)).toBeInTheDocument();
+		expect(screen.getByText("Cancel")).toBeInTheDocument();
+	});
+
+	it("shows 'Fetching Seerr API key...' during fetching state", async () => {
+		// Use a never-resolving promise to keep the component in fetching state
+		let resolvePromise!: (value: { apiKey: string; version: string }) => void;
+		vi.mocked(fetchSeerrApiKey).mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolvePromise = resolve;
+				}),
+		);
+
+		vi.mocked(usePlexOAuth).mockReturnValue(mockPlexOAuth({ tokenRef: "plex-ref-123" }));
+
+		renderSection();
+		fireEvent.click(screen.getByText("Sign in to Seerr with Plex"));
+
+		await waitFor(() => {
+			expect(screen.getByText("Fetching Seerr API key...")).toBeInTheDocument();
+		});
+
+		// Clean up: resolve the pending promise
+		resolvePromise({ apiKey: "key", version: "1.0" });
+	});
+
+	// ================================================================
+	// Edit mode specifics
+	// ================================================================
+
+	it("shows 'or edit manually' divider in edit mode", () => {
+		renderSection(undefined, undefined, "edit");
+
+		expect(screen.getByText("or edit manually")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/settings/components/seerr-auto-setup-section.tsx
+++ b/apps/web/src/features/settings/components/seerr-auto-setup-section.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+/**
+ * Seerr Auto-Setup Section
+ *
+ * Inline component shown in ServiceForm for Seerr services (add and edit mode).
+ * Uses Plex sign-in to authenticate to Seerr and retrieve the API key automatically.
+ * Requires the user to enter the Seerr Base URL first.
+ */
+
+import { Loader2, Server } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert, AlertDescription } from "../../../components/ui";
+import { usePlexOAuth } from "../../../hooks/api/usePlexOAuth";
+import { fetchSeerrApiKey } from "../../../lib/api-client/seerr";
+import { getErrorMessage } from "../../../lib/error-utils";
+import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+
+const SEERR_GRADIENT = SERVICE_GRADIENTS.seerr;
+
+interface SeerrAutoSetupSectionProps {
+	seerrUrl: string;
+	onApiKeyFetched: (apiKey: string) => void;
+	onTestConnection: () => void;
+	mode: "add" | "edit";
+}
+
+type SetupStatus = "idle" | "plex-auth" | "fetching" | "done" | "error";
+
+export const SeerrAutoSetupSection = ({
+	seerrUrl,
+	onApiKeyFetched,
+	onTestConnection,
+	mode,
+}: SeerrAutoSetupSectionProps) => {
+	const isEdit = mode === "edit";
+	const { status: plexStatus, tokenRef, startOAuth, cancel: cancelPlex } = usePlexOAuth();
+	const [setupStatus, setSetupStatus] = useState<SetupStatus>("idle");
+	const [error, setError] = useState<string | null>(null);
+
+	const fetchKey = useCallback(
+		async (ref: string) => {
+			if (!seerrUrl.trim()) {
+				setSetupStatus("error");
+				setError("Seerr Base URL was cleared. Please enter a URL and try again.");
+				return;
+			}
+			setSetupStatus("fetching");
+			setError(null);
+			try {
+				const { apiKey } = await fetchSeerrApiKey(seerrUrl.trim(), ref);
+				onApiKeyFetched(apiKey);
+				setSetupStatus("done");
+				setTimeout(onTestConnection, 100);
+			} catch (err: unknown) {
+				setSetupStatus("error");
+				setError(getErrorMessage(err, "Failed to retrieve Seerr API key"));
+			}
+		},
+		[seerrUrl, onApiKeyFetched, onTestConnection],
+	);
+
+	const handleConnect = useCallback(() => {
+		if (!seerrUrl.trim()) {
+			setError("Enter the Seerr Base URL first.");
+			setSetupStatus("error");
+			return;
+		}
+
+		// If we already have a Plex token, skip straight to fetching the key
+		if (tokenRef) {
+			fetchKey(tokenRef);
+			return;
+		}
+
+		// Otherwise, start Plex OAuth — we'll fetch the key after it completes
+		setSetupStatus("plex-auth");
+		setError(null);
+		startOAuth();
+	}, [seerrUrl, tokenRef, fetchKey, startOAuth]);
+
+	// Bridge Plex OAuth completion → Seerr key fetch
+	const prevTokenRef = useRef<string | null>(null);
+	useEffect(() => {
+		if (tokenRef && tokenRef !== prevTokenRef.current && setupStatus === "plex-auth") {
+			prevTokenRef.current = tokenRef;
+			fetchKey(tokenRef);
+		}
+	}, [tokenRef, setupStatus, fetchKey]);
+
+	// Bridge Plex OAuth failures → surface to Seerr setup status
+	useEffect(() => {
+		if (setupStatus !== "plex-auth") return;
+		if (plexStatus === "error") {
+			setSetupStatus("error");
+			setError("Plex authentication failed. Please try again.");
+		}
+		if (plexStatus === "cancelled") {
+			setSetupStatus("idle");
+		}
+	}, [plexStatus, setupStatus]);
+
+	const handleCancel = useCallback(() => {
+		cancelPlex();
+		setSetupStatus("idle");
+		setError(null);
+	}, [cancelPlex]);
+
+	const needsUrl = !seerrUrl.trim();
+
+	// Idle / error / done — show the connect button
+	if (setupStatus === "idle" || setupStatus === "error" || setupStatus === "done") {
+		return (
+			<div className="space-y-3">
+				<button
+					type="button"
+					onClick={handleConnect}
+					disabled={needsUrl}
+					className="flex w-full items-center justify-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium transition-all duration-200 hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+					style={{
+						borderColor: SEERR_GRADIENT.from,
+						backgroundColor: `${SEERR_GRADIENT.from}15`,
+						color: SEERR_GRADIENT.from,
+					}}
+				>
+					<Server className="h-4 w-4" />
+					{isEdit ? "Re-authenticate Seerr with Plex" : "Sign in to Seerr with Plex"}
+				</button>
+
+				{needsUrl && (
+					<p className="text-center text-xs text-muted-foreground">
+						Enter the Seerr Base URL above first.
+					</p>
+				)}
+
+				{setupStatus === "error" && error && (
+					<Alert variant="danger">
+						<AlertDescription>{error}</AlertDescription>
+					</Alert>
+				)}
+
+				{setupStatus === "done" && (
+					<Alert variant="success">
+						<AlertDescription>
+							{isEdit
+								? "API key updated — click Save changes to apply."
+								: "API key retrieved successfully."}
+						</AlertDescription>
+					</Alert>
+				)}
+
+				<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+			</div>
+		);
+	}
+
+	// Plex auth in progress or fetching key
+	if (setupStatus === "plex-auth" || setupStatus === "fetching") {
+		return (
+			<div className="space-y-3">
+				<div className="flex items-center justify-between rounded-lg border border-border/50 bg-card/30 px-4 py-3">
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" style={{ color: SEERR_GRADIENT.from }} />
+						{setupStatus === "plex-auth" && plexStatus === "pending" && "Connecting to Plex..."}
+						{setupStatus === "plex-auth" &&
+							plexStatus === "polling" &&
+							"Waiting for Plex authorization..."}
+						{setupStatus === "plex-auth" && plexStatus === "discovering" && "Plex authorized..."}
+						{setupStatus === "fetching" && "Fetching Seerr API key..."}
+						{setupStatus === "plex-auth" &&
+							plexStatus !== "pending" &&
+							plexStatus !== "polling" &&
+							plexStatus !== "discovering" &&
+							"Connecting to Plex..."}
+					</div>
+					<button
+						type="button"
+						onClick={handleCancel}
+						className="text-xs text-muted-foreground hover:text-foreground"
+					>
+						Cancel
+					</button>
+				</div>
+
+				<Divider text={isEdit ? "or edit manually" : "or enter manually"} />
+			</div>
+		);
+	}
+
+	return null;
+};
+
+/** Visual divider with configurable text */
+const Divider = ({ text = "or enter manually" }: { text?: string }) => (
+	<div className="relative">
+		<div className="absolute inset-0 flex items-center">
+			<span className="w-full border-t border-border" />
+		</div>
+		<div className="relative flex justify-center text-xs uppercase">
+			<span className="bg-card px-2 text-muted-foreground">{text}</span>
+		</div>
+	</div>
+);

--- a/apps/web/src/features/settings/components/service-form.tsx
+++ b/apps/web/src/features/settings/components/service-form.tsx
@@ -19,6 +19,7 @@ import { SERVICE_TYPES } from "../lib/settings-constants";
 import type { ServiceFormState } from "../lib/settings-utils";
 import { getServicePlaceholders } from "../lib/settings-utils";
 import { PlexOAuthSection } from "./plex-oauth-section";
+import { SeerrAutoSetupSection } from "./seerr-auto-setup-section";
 
 /**
  * Props for the ServiceForm component
@@ -174,6 +175,19 @@ export const ServiceForm = ({
 							data-form-type="other"
 						/>
 					</SimpleFormField>
+					{formState.service === "seerr" && (
+						<SeerrAutoSetupSection
+							seerrUrl={formState.baseUrl}
+							mode={selectedService ? "edit" : "add"}
+							onApiKeyFetched={(apiKey) =>
+								onFormStateChange((prev) => ({
+									...prev,
+									apiKey,
+								}))
+							}
+							onTestConnection={onTestConnection}
+						/>
+					)}
 					<SimpleFormField
 						label="External URL"
 						htmlFor="service-externalurl"

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -291,7 +291,7 @@ export async function discoverPlexServers(
 	return apiRequest("/api/plex/oauth/servers", { json: { tokenRef, clientId } });
 }
 
-/** Consume a stored Plex token (single-use) for service form pre-fill. */
+/** Retrieve a stored Plex token for service form pre-fill. */
 export async function retrievePlexToken(tokenRef: string): Promise<{ authToken: string }> {
 	return apiRequest("/api/plex/oauth/token", { json: { tokenRef } });
 }

--- a/apps/web/src/lib/api-client/seerr.ts
+++ b/apps/web/src/lib/api-client/seerr.ts
@@ -10,6 +10,7 @@ import type {
 	SeerrCreateRequestPayload,
 	SeerrCreateRequestResponse,
 	SeerrDiscoverResponse,
+	SeerrFetchKeyResponse,
 	SeerrGenre,
 	SeerrIssue,
 	SeerrIssueComment,
@@ -357,6 +358,18 @@ export async function fetchLibraryEnrichment(
 // ============================================================================
 // Helpers
 // ============================================================================
+
+// ============================================================================
+// OAuth Auto-Setup
+// ============================================================================
+
+/** Fetch Seerr API key using a stored Plex token. */
+export async function fetchSeerrApiKey(
+	seerrUrl: string,
+	tokenRef: string,
+): Promise<SeerrFetchKeyResponse> {
+	return apiRequest("/api/seerr/oauth/fetch-key", { json: { seerrUrl, tokenRef } });
+}
 
 function buildQueryString(params: Record<string, unknown>): string {
 	const entries = Object.entries(params).filter(([, v]) => v !== undefined);

--- a/packages/shared/src/types/seerr.ts
+++ b/packages/shared/src/types/seerr.ts
@@ -880,3 +880,12 @@ export interface LibraryEnrichmentResponse {
 	/** Number of media enrichment lookups that failed */
 	enrichmentFailures?: number;
 }
+
+// ============================================================================
+// Seerr OAuth Auto-Setup
+// ============================================================================
+
+export interface SeerrFetchKeyResponse {
+	apiKey: string;
+	version: string;
+}


### PR DESCRIPTION
## Summary
- Add "Sign in to Seerr with Plex" button for Seerr service setup (add + edit mode)
- Uses Plex OAuth token to authenticate to Seerr and retrieve the API key automatically
- Handles CSRF-enabled Seerr instances (preflight token negotiation)
- Extracts shared Plex token store for cross-feature reuse
- Manual API key entry remains as fallback

## What changed

**Backend** (`apps/api/src/routes/seerr/oauth-routes.ts`):
- `POST /api/seerr/oauth/fetch-key` — CSRF preflight → Plex auth to Seerr → session cookie → API key from settings → version from status
- SSRF protection (http/https only), rate limiting (10/min), Zod validation on all inputs and upstream responses
- Plex token stays server-side via shared `token-store.ts` — only opaque `tokenRef` crosses to frontend

**Shared** (`apps/api/src/lib/plex/token-store.ts`):
- Extracted from `plex/oauth-routes.ts` — now shared between Plex OAuth and Seerr auto-setup
- Same behavior: 10-min TTL, 100-entry cap, graceful shutdown cleanup

**Frontend** (`seerr-auto-setup-section.tsx`):
- Reuses `usePlexOAuth` hook for Plex sign-in flow
- `useEffect` bridges: Plex OAuth completion → Seerr key fetch, Plex failures → error state
- Shows loading states for both Plex auth and Seerr key fetch phases
- Auto-triggers connection test after API key is retrieved

## What did not change
- `POST /services` contract — unchanged
- Database schema — no changes
- Plex OAuth feature — unchanged (only token store extracted to shared module)
- Other service types — unaffected

## Validation
- `tsc --noEmit` clean for @arr/api, @arr/web, @arr/shared
- `pnpm run lint` — 0 errors
- 1537 tests passing (23 new: 12 backend + 11 component)
- 3 code/security/silent-failure reviews — all clean

## Test plan
- [x] Happy path: enter Seerr URL → sign in with Plex → API key auto-fills → auto-test
- [x] CSRF-enabled Seerr: tokens fetched and injected correctly
- [x] Not Seerr admin → clear error message + manual fallback
- [x] Plex auth disabled in Seerr → clear error message
- [x] Seerr unreachable → 502 with helpful message
- [x] Plex token expired → clear message to re-authenticate
- [x] Plex popup closed/cancelled → status bridges to idle/error
- [x] Empty URL during flow → error state (not stuck spinner)
- [x] Edit mode: "Re-authenticate Seerr with Plex" + save reminder
- [x] Manual fallback always available

🤖 Generated with [Claude Code](https://claude.com/claude-code)