### PR TITLE
fix: mobile responsiveness for settings page and service forms

### DIFF
--- a/apps/web/src/components/layout/premium-interactive.tsx
+++ b/apps/web/src/components/layout/premium-interactive.tsx
@@ -32,7 +32,7 @@ export const PremiumTabs = ({ tabs, activeTab, onTabChange, className }: Premium
 	return (
 		<div
 			className={cn(
-				"inline-flex rounded-xl bg-card/30 backdrop-blur-xs border border-border/50 p-1.5",
+				"flex w-full overflow-x-auto rounded-xl bg-card/30 backdrop-blur-xs border border-border/50 p-1.5 scrollbar-none",
 				className,
 			)}
 		>
@@ -45,9 +45,10 @@ export const PremiumTabs = ({ tabs, activeTab, onTabChange, className }: Premium
 					<button
 						key={tab.id}
 						type="button"
+						aria-label={tab.label}
 						onClick={() => onTabChange(tab.id)}
 						className={cn(
-							"relative flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-lg transition-all duration-300",
+							"relative flex shrink-0 items-center gap-1.5 px-2.5 py-2 text-xs font-medium rounded-lg transition-all duration-300 sm:gap-2 sm:px-4 sm:py-2.5 sm:text-sm",
 							isActive ? "text-white" : "text-muted-foreground hover:text-foreground",
 						)}
 					>
@@ -63,10 +64,15 @@ export const PremiumTabs = ({ tabs, activeTab, onTabChange, className }: Premium
 						)}
 
 						{/* Icon */}
-						{Icon && <Icon className={cn("h-4 w-4 relative z-10", !isActive && "opacity-70")} aria-hidden="true" />}
+						{Icon && (
+							<Icon
+								className={cn("h-4 w-4 relative z-10", !isActive && "opacity-70")}
+								aria-hidden="true"
+							/>
+						)}
 
-						{/* Label */}
-						<span className="relative z-10">{tab.label}</span>
+						{/* Label — hidden on mobile, shown on sm+ */}
+						<span className="relative z-10 hidden sm:inline">{tab.label}</span>
 
 						{/* Badge */}
 						{tab.badge !== undefined && (

--- a/apps/web/src/features/settings/components/getting-started-banner.tsx
+++ b/apps/web/src/features/settings/components/getting-started-banner.tsx
@@ -106,7 +106,7 @@ export const GettingStartedBanner = ({ services, onSelectService }: GettingStart
 				</div>
 			</div>
 
-			<div className="grid gap-2 sm:grid-cols-2">
+			<div className="grid gap-2 sm:gap-3 sm:grid-cols-2">
 				{stepsToShow.slice(0, 4).map((step) => {
 					const gradient = getServiceGradient(step.service);
 					return (
@@ -114,7 +114,7 @@ export const GettingStartedBanner = ({ services, onSelectService }: GettingStart
 							key={step.service}
 							type="button"
 							onClick={() => onSelectService(step.service)}
-							className="group flex items-center gap-3 rounded-lg border border-border/50 bg-card/30 px-3 py-2.5 text-left transition-all duration-200 hover:border-border hover:bg-card/60"
+							className="group flex min-h-[44px] items-center gap-2 rounded-lg border border-border/50 bg-card/30 px-3 py-2.5 text-left transition-all duration-200 hover:border-border hover:bg-card/60 sm:gap-3"
 						>
 							<div
 								className="flex h-6 w-6 shrink-0 items-center justify-center rounded"

--- a/apps/web/src/features/settings/components/plex-oauth-section.tsx
+++ b/apps/web/src/features/settings/components/plex-oauth-section.tsx
@@ -42,7 +42,11 @@ function pickBestConnection(connections: PlexServerConnection[]): PlexServerConn
 	return connections[0];
 }
 
-export const PlexOAuthSection = ({ onServerSelected, onTestConnection, mode }: PlexOAuthSectionProps) => {
+export const PlexOAuthSection = ({
+	onServerSelected,
+	onTestConnection,
+	mode,
+}: PlexOAuthSectionProps) => {
 	const isEdit = mode === "edit";
 	const { status, servers, tokenRef, error, startOAuth, cancel } = usePlexOAuth();
 	const [isIncognito] = useIncognitoMode();
@@ -113,7 +117,7 @@ export const PlexOAuthSection = ({ onServerSelected, onTestConnection, mode }: P
 	if (status === "pending" || status === "polling" || status === "discovering") {
 		return (
 			<div className="space-y-3">
-				<div className="flex items-center justify-between rounded-lg border border-border/50 bg-card/30 px-4 py-3">
+				<div className="flex items-center justify-between gap-2 rounded-lg border border-border/50 bg-card/30 px-3 py-2.5 sm:px-4 sm:py-3">
 					<div className="flex items-center gap-2 text-sm text-muted-foreground">
 						<Loader2 className="h-4 w-4 animate-spin" style={{ color: PLEX_GRADIENT.from }} />
 						{status === "pending" && "Connecting to Plex..."}
@@ -193,7 +197,7 @@ export const PlexOAuthSection = ({ onServerSelected, onTestConnection, mode }: P
 												key={key}
 												type="button"
 												onClick={() => handleSelectConnection(server, conn)}
-												className="flex w-full items-center gap-2 rounded-md border px-3 py-1.5 text-left text-xs transition-all duration-200 hover:bg-accent/50"
+												className="flex w-full items-center gap-1.5 rounded-md border px-2 py-2 text-left text-[11px] transition-all duration-200 hover:bg-accent/50 sm:gap-2 sm:px-3 sm:py-1.5 sm:text-xs"
 												style={
 													isSelected
 														? {
@@ -245,7 +249,8 @@ export const PlexOAuthSection = ({ onServerSelected, onTestConnection, mode }: P
 				{selectedUnreachable && selectedKey && (
 					<Alert variant="danger">
 						<AlertDescription>
-							This connection was unreachable during discovery. You may need to adjust the Base URL below before saving. Use Test connection to verify.
+							This connection was unreachable during discovery. You may need to adjust the Base URL
+							below before saving. Use Test connection to verify.
 						</AlertDescription>
 					</Alert>
 				)}

--- a/apps/web/src/features/settings/components/seerr-auto-setup-section.tsx
+++ b/apps/web/src/features/settings/components/seerr-auto-setup-section.tsx
@@ -158,7 +158,7 @@ export const SeerrAutoSetupSection = ({
 	if (setupStatus === "plex-auth" || setupStatus === "fetching") {
 		return (
 			<div className="space-y-3">
-				<div className="flex items-center justify-between rounded-lg border border-border/50 bg-card/30 px-4 py-3">
+				<div className="flex items-center justify-between gap-2 rounded-lg border border-border/50 bg-card/30 px-3 py-2.5 sm:px-4 sm:py-3">
 					<div className="flex items-center gap-2 text-sm text-muted-foreground">
 						<Loader2 className="h-4 w-4 animate-spin" style={{ color: SEERR_GRADIENT.from }} />
 						{setupStatus === "plex-auth" && plexStatus === "pending" && "Connecting to Plex..."}

--- a/apps/web/src/features/settings/components/service-form.tsx
+++ b/apps/web/src/features/settings/components/service-form.tsx
@@ -89,10 +89,10 @@ export const ServiceForm = ({
 				</CardDescription>
 			</CardHeader>
 			<CardContent>
-				<form className="space-y-4" onSubmit={onSubmit} autoComplete="off">
+				<form className="space-y-3 sm:space-y-4" onSubmit={onSubmit} autoComplete="off">
 					<div className="space-y-2">
 						<label className="text-xs uppercase text-muted-foreground">Service</label>
-						<div className="flex gap-2">
+						<div className="grid grid-cols-4 gap-1.5 lg:grid-cols-8 sm:gap-2">
 							{SERVICE_TYPES.map((service) => (
 								<button
 									key={service}
@@ -105,7 +105,7 @@ export const ServiceForm = ({
 										}))
 									}
 									className={cn(
-										"flex-1 rounded-lg border px-3 py-2 text-sm capitalize transition-all duration-200",
+										"min-h-[40px] rounded-lg border px-2 py-2 text-xs capitalize transition-all duration-200 sm:px-3 sm:text-sm",
 										formState.service !== service &&
 											"border-border bg-card text-muted-foreground hover:text-foreground",
 									)}

--- a/apps/web/src/features/settings/components/service-instance-card.tsx
+++ b/apps/web/src/features/settings/components/service-instance-card.tsx
@@ -132,7 +132,9 @@ export const ServiceInstanceCard = ({
 					<div className="min-w-0 flex-1 space-y-2">
 						<div className="flex flex-wrap items-center gap-2">
 							<ServiceBadge service={instance.service} />
-							<h3 className="text-base font-semibold text-foreground">{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}</h3>
+							<h3 className="text-base font-semibold text-foreground">
+								{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}
+							</h3>
 							{instance.isDefault && (
 								<div
 									className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
@@ -179,7 +181,7 @@ export const ServiceInstanceCard = ({
 					</div>
 
 					{/* Right: Action buttons */}
-					<div className="flex shrink-0 flex-wrap items-center gap-1.5">
+					<div className="flex shrink-0 flex-wrap items-center gap-1 sm:gap-1.5">
 						{/* Test button */}
 						<Button
 							variant="secondary"

--- a/apps/web/src/features/settings/components/settings-client.tsx
+++ b/apps/web/src/features/settings/components/settings-client.tsx
@@ -135,7 +135,7 @@ export const SettingsClient = () => {
 							services={services}
 							onSelectService={(service) => serviceFormState.resetForm(service)}
 						/>
-						<div className="grid gap-6 xl:grid-cols-[2fr_1fr]">
+						<div className="grid gap-4 sm:gap-6 xl:grid-cols-[2fr_1fr]">
 							<ServicesTab
 								services={services}
 								isLoading={servicesLoading}


### PR DESCRIPTION
## Summary
Responsive Tailwind utility class improvements across 7 settings page components. No logic changes — CSS only.

## What changed
- **Tab bar**: Horizontal scroll on mobile, icon-only tabs with `aria-label` accessibility, responsive sizing
- **Service type selector**: 4-column grid on mobile → 8 columns on desktop (was 8-column flex that crushed buttons)
- **Settings grid**: Tighter gaps on mobile
- **Service cards**: Tighter button gaps on mobile
- **Plex/Seerr sections**: Responsive padding and text sizing on loading states and connection rows
- **Getting started banner**: 44px minimum touch targets on service cards
- **Form spacing**: Tighter vertical rhythm on mobile

## What did not change
- No logic changes, no new components, no API changes
- All existing tests pass unchanged (CSS classes don't affect test queries)

## Validation
- `tsc --noEmit` clean
- 326 frontend tests passing
- 3 reviews (code + silent failure + security) — all clean
- Accessibility fix: `aria-label` added for icon-only tab buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)