### PR TITLE
docs: clarify PUID/PGID usage, warn against --user flag

### DIFF
--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -81,7 +81,7 @@ services:
 | `WEBAUTHN_RP_ID` | `localhost` | Your domain (no protocol) |
 | `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Full URL with protocol |
 
-> **Note:** Set `PUID` and `PGID` to match the owner of your config directory. Run `id -u` and `id -g` on your host to find your user/group IDs.
+> **Note:** Set `PUID` and `PGID` to match the owner of your config directory. Run `id -u` and `id -g` on your host to find your user/group IDs. The container must start as root — do not use Docker's `--user` flag, as it bypasses the internal permission setup and privilege drop.
 
 ## Version Tags
 

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ The `/config` volume contains critical data that must be preserved:
 | `LOG_LEVEL` | `info` | Logging level (`debug`, `info`, `warn`, `error`) |
 | `GITHUB_TOKEN` | - | Optional GitHub token for TRaSH Guides (higher rate limits) |
 
-> **Note:** Set `PUID` and `PGID` to match the owner of your config directory. Run `id -u` and `id -g` on your host to find your user/group IDs. This follows the [LinuxServer.io](https://docs.linuxserver.io/general/understanding-puid-and-pgid) convention.
+> **Note:** Set `PUID` and `PGID` to match the owner of your config directory. Run `id -u` and `id -g` on your host to find your user/group IDs. This follows the [LinuxServer.io](https://docs.linuxserver.io/general/understanding-puid-and-pgid) convention. The container must start as root — do not use Docker's `--user` flag, as it bypasses the internal permission setup and privilege drop.
 
 ## Platform Support
 


### PR DESCRIPTION
## Summary
- Adds a note to README.md and DOCKERHUB.md that the container must start as root and Docker's `--user` flag bypasses the internal permission setup
- Wiki pages (Environment-Variables, Security-Best-Practices, Troubleshooting) already updated and pushed separately

Closes #273

## Context
Issue #273 reported `su-exec: setgroups: Operation not permitted` when running the container with `--user 911:911`. The container follows the LinuxServer.io PUID/PGID convention which requires root at startup to adjust the internal user and fix permissions before dropping privileges via `su-exec`. Using `--user` bypasses this flow entirely.

Re-opened #273 as an enhancement to track potential future rootless/`--user` support.

## Test plan
- [x] Verify README.md PUID/PGID note reads correctly
- [x] Verify DOCKERHUB.md PUID/PGID note reads correctly
- [ ] Confirm wiki pages reflect the same guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)