### PR TITLE
refactor(api): extract plugin/route registration into domain bundles

### DIFF
--- a/apps/api/src/bootstrap/index.ts
+++ b/apps/api/src/bootstrap/index.ts
@@ -1,0 +1,4 @@
+export { registerInfrastructure } from "./infrastructure.js";
+export { registerProtectedRoutes } from "./protected-routes.js";
+export { registerPublicRoutes } from "./public-routes.js";
+export { registerSchedulers } from "./schedulers.js";

--- a/apps/api/src/bootstrap/infrastructure.ts
+++ b/apps/api/src/bootstrap/infrastructure.ts
@@ -1,0 +1,36 @@
+import type { FastifyInstance } from "fastify";
+
+import { arrClientPlugin } from "../plugins/arr-client.js";
+import deploymentExecutorPlugin from "../plugins/deployment-executor.js";
+import lifecyclePlugin from "../plugins/lifecycle.js";
+import notificationServicePlugin from "../plugins/notification-service.js";
+import { prismaPlugin } from "../plugins/prisma.js";
+import { securityPlugin } from "../plugins/security.js";
+import seerrCachePlugin from "../plugins/seerr-cache.js";
+import seerrCircuitBreakerPlugin from "../plugins/seerr-circuit-breaker.js";
+
+/**
+ * Core infrastructure plugins — registered first because every domain depends on them.
+ *
+ * Order matters: each plugin below decorates `app` with state used by later
+ * plugins and by route handlers. Do not reorder without reviewing decorations.
+ *
+ *  - prisma            → `app.prisma`
+ *  - security          → `app.encryptor`, `app.sessionService`
+ *  - arrClient         → `createInstanceFetcher` helpers for ARR services
+ *  - seerr circuit     → request breaker for Seerr outbound calls
+ *  - seerr cache       → shared response cache for Seerr requests
+ *  - deploymentExecutor→ `app.deploymentExecutor`
+ *  - notificationService → `app.notificationService`
+ *  - lifecycle         → graceful shutdown + health wiring
+ */
+export function registerInfrastructure(app: FastifyInstance): void {
+	app.register(prismaPlugin);
+	app.register(securityPlugin);
+	app.register(arrClientPlugin);
+	app.register(seerrCircuitBreakerPlugin);
+	app.register(seerrCachePlugin);
+	app.register(deploymentExecutorPlugin);
+	app.register(notificationServicePlugin);
+	app.register(lifecyclePlugin);
+}

--- a/apps/api/src/bootstrap/protected-routes.ts
+++ b/apps/api/src/bootstrap/protected-routes.ts
@@ -1,0 +1,67 @@
+import type { FastifyInstance } from "fastify";
+
+import { registerBackupRoutes } from "../routes/backup.js";
+import { registerDashboardRoutes } from "../routes/dashboard.js";
+import { registerHuntingRoutes } from "../routes/hunting.js";
+import { registerJellyfinRoutes } from "../routes/jellyfin/index.js";
+import { registerLibraryRoutes } from "../routes/library.js";
+import { registerLibraryCleanupRoutes } from "../routes/library-cleanup.js";
+import { registerManualImportRoutes } from "../routes/manual-import.js";
+import { registerNotificationRoutes } from "../routes/notifications.js";
+import oidcProvidersRoutes from "../routes/oidc-providers.js";
+import { registerPlexRoutes } from "../routes/plex/index.js";
+import { registerPulseRoutes } from "../routes/pulse.js";
+import { registerQueueCleanerRoutes } from "../routes/queue-cleaner.js";
+import { registerSearchRoutes } from "../routes/search.js";
+import { registerSeerrRoutes } from "../routes/seerr/index.js";
+import { registerServiceRoutes } from "../routes/services.js";
+import { registerSystemRoutes } from "../routes/system.js";
+import { registerTautulliRoutes } from "../routes/tautulli/index.js";
+import { registerTrashGuidesRoutes } from "../routes/trash-guides/index.js";
+
+/**
+ * Protected API routes — gated by the session preHandler registered here.
+ *
+ * The preHandler rejects any request without a populated `request.currentUser`.
+ * Route groups below are organized by product domain so that ownership is
+ * obvious at a glance.
+ */
+export function registerProtectedRoutes(app: FastifyInstance): void {
+	app.register(async (api) => {
+		api.addHook("preHandler", async (request, reply) => {
+			if (!request.currentUser?.id) {
+				return reply.status(401).send({ error: "Authentication required" });
+			}
+		});
+
+		// --- Auth / identity management ---
+		api.register(oidcProvidersRoutes);
+
+		// --- System + operator surface ---
+		api.register(registerSystemRoutes, { prefix: "/api/system" });
+		api.register(registerBackupRoutes, { prefix: "/api/backup" });
+		api.register(registerNotificationRoutes, { prefix: "/api/notifications" });
+
+		// --- ARR services (Sonarr / Radarr / Prowlarr / Lidarr / Readarr) ---
+		api.register(registerServiceRoutes, { prefix: "/api" });
+		api.register(registerDashboardRoutes, { prefix: "/api" });
+		api.register(registerLibraryRoutes, { prefix: "/api" });
+		api.register(registerSearchRoutes, { prefix: "/api" });
+		api.register(registerManualImportRoutes, { prefix: "/api" });
+
+		// --- ARR automation ---
+		api.register(registerHuntingRoutes, { prefix: "/api" });
+		api.register(registerQueueCleanerRoutes, { prefix: "/api" });
+		api.register(registerLibraryCleanupRoutes, { prefix: "/api" });
+
+		// --- Media servers (Plex / Jellyfin / Tautulli) ---
+		api.register(registerPlexRoutes, { prefix: "/api/plex" });
+		api.register(registerJellyfinRoutes, { prefix: "/api/jellyfin" });
+		api.register(registerTautulliRoutes, { prefix: "/api/tautulli" });
+		api.register(registerPulseRoutes, { prefix: "/api" });
+
+		// --- External integrations (Seerr / TRaSH Guides) ---
+		api.register(registerSeerrRoutes, { prefix: "/api/seerr" });
+		api.register(registerTrashGuidesRoutes, { prefix: "/api/trash-guides" });
+	});
+}

--- a/apps/api/src/bootstrap/public-routes.ts
+++ b/apps/api/src/bootstrap/public-routes.ts
@@ -1,0 +1,23 @@
+import type { FastifyInstance } from "fastify";
+import { registerAuthRoutes } from "../routes/auth.js";
+import { registerAuthOidcRoutes } from "../routes/auth-oidc.js";
+import { registerAuthPasskeyRoutes } from "../routes/auth-passkey.js";
+import { registerHealthRoutes } from "../routes/health.js";
+
+/**
+ * Public routes — no authentication required.
+ *
+ *  - /health  → liveness + readiness probes
+ *  - /auth    → password login / logout / setup
+ *  - /auth    → OIDC callback + passkey registration/assertion
+ *
+ * Auth-related endpoints are public because they are the entry points that
+ * establish a session. Session-gated behavior is enforced by the scoped
+ * preHandler registered with the protected routes.
+ */
+export function registerPublicRoutes(app: FastifyInstance): void {
+	app.register(registerHealthRoutes, { prefix: "/health" });
+	app.register(registerAuthRoutes, { prefix: "/auth" });
+	app.register(registerAuthOidcRoutes, { prefix: "/auth" });
+	app.register(registerAuthPasskeyRoutes, { prefix: "/auth" });
+}

--- a/apps/api/src/bootstrap/schedulers.ts
+++ b/apps/api/src/bootstrap/schedulers.ts
@@ -1,0 +1,55 @@
+import type { FastifyInstance } from "fastify";
+
+import backupSchedulerPlugin from "../plugins/backup-scheduler.js";
+import huntingSchedulerPlugin from "../plugins/hunting-scheduler.js";
+import insightsDigestSchedulerPlugin from "../plugins/insights-digest-scheduler.js";
+import jellyfinCacheSchedulerPlugin from "../plugins/jellyfin-cache-scheduler.js";
+import jellyfinEpisodeCacheSchedulerPlugin from "../plugins/jellyfin-episode-cache-scheduler.js";
+import libraryCleanupSchedulerPlugin from "../plugins/library-cleanup-scheduler.js";
+import librarySyncSchedulerPlugin from "../plugins/library-sync-scheduler.js";
+import plexCacheSchedulerPlugin from "../plugins/plex-cache-scheduler.js";
+import plexEpisodeCacheSchedulerPlugin from "../plugins/plex-episode-cache-scheduler.js";
+import queueCleanerSchedulerPlugin from "../plugins/queue-cleaner-scheduler.js";
+import seerrHealthSchedulerPlugin from "../plugins/seerr-health-scheduler.js";
+import sessionCleanupPlugin from "../plugins/session-cleanup.js";
+import sessionSnapshotSchedulerPlugin from "../plugins/session-snapshot-scheduler.js";
+import tautulliCacheSchedulerPlugin from "../plugins/tautulli-cache-scheduler.js";
+import trashBackupCleanupPlugin from "../plugins/trash-backup-cleanup.js";
+import trashSyncSchedulerPlugin from "../plugins/trash-sync-scheduler.js";
+import trashUpdateSchedulerPlugin from "../plugins/trash-update-scheduler.js";
+
+/**
+ * Background scheduler plugins — registered after infrastructure so they can
+ * rely on `app.prisma`, `app.notificationService`, etc.
+ *
+ * Grouped by domain below to make it easier to reason about which schedulers
+ * belong together. Order within a group is not significant.
+ */
+export function registerSchedulers(app: FastifyInstance): void {
+	// Backups + session lifecycle
+	app.register(backupSchedulerPlugin);
+	app.register(sessionCleanupPlugin);
+	app.register(sessionSnapshotSchedulerPlugin);
+
+	// Library sync + automation (ARR side)
+	app.register(librarySyncSchedulerPlugin);
+	app.register(huntingSchedulerPlugin);
+	app.register(queueCleanerSchedulerPlugin);
+	app.register(libraryCleanupSchedulerPlugin);
+	app.register(insightsDigestSchedulerPlugin);
+
+	// TRaSH Guides sync + cleanup
+	app.register(trashBackupCleanupPlugin);
+	app.register(trashUpdateSchedulerPlugin);
+	app.register(trashSyncSchedulerPlugin);
+
+	// Media server caches (Plex / Jellyfin / Tautulli)
+	app.register(plexCacheSchedulerPlugin);
+	app.register(plexEpisodeCacheSchedulerPlugin);
+	app.register(jellyfinCacheSchedulerPlugin);
+	app.register(jellyfinEpisodeCacheSchedulerPlugin);
+	app.register(tautulliCacheSchedulerPlugin);
+
+	// Seerr health monitoring
+	app.register(seerrHealthSchedulerPlugin);
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,57 +1,16 @@
+import { randomBytes } from "node:crypto";
 import fastifyCors from "@fastify/cors";
 import fastifyHelmet from "@fastify/helmet";
 import fastifyRateLimit from "@fastify/rate-limit";
-import { randomBytes } from "node:crypto";
 import Fastify, { type FastifyBaseLogger, type FastifyInstance } from "fastify";
+import {
+	registerInfrastructure,
+	registerProtectedRoutes,
+	registerPublicRoutes,
+	registerSchedulers,
+} from "./bootstrap/index.js";
 import { type ApiEnv, envSchema } from "./config/env.js";
 import { arrErrorToHttpStatus, isArrError } from "./lib/arr/client-factory.js";
-import { arrClientPlugin } from "./plugins/arr-client.js";
-import backupSchedulerPlugin from "./plugins/backup-scheduler.js";
-import deploymentExecutorPlugin from "./plugins/deployment-executor.js";
-import huntingSchedulerPlugin from "./plugins/hunting-scheduler.js";
-import insightsDigestSchedulerPlugin from "./plugins/insights-digest-scheduler.js";
-import libraryCleanupSchedulerPlugin from "./plugins/library-cleanup-scheduler.js";
-import librarySyncSchedulerPlugin from "./plugins/library-sync-scheduler.js";
-import lifecyclePlugin from "./plugins/lifecycle.js";
-import notificationServicePlugin from "./plugins/notification-service.js";
-import { prismaPlugin } from "./plugins/prisma.js";
-import queueCleanerSchedulerPlugin from "./plugins/queue-cleaner-scheduler.js";
-import { securityPlugin } from "./plugins/security.js";
-import seerrCachePlugin from "./plugins/seerr-cache.js";
-import seerrCircuitBreakerPlugin from "./plugins/seerr-circuit-breaker.js";
-import seerrHealthSchedulerPlugin from "./plugins/seerr-health-scheduler.js";
-import sessionCleanupPlugin from "./plugins/session-cleanup.js";
-import trashBackupCleanupPlugin from "./plugins/trash-backup-cleanup.js";
-import jellyfinCacheSchedulerPlugin from "./plugins/jellyfin-cache-scheduler.js";
-import jellyfinEpisodeCacheSchedulerPlugin from "./plugins/jellyfin-episode-cache-scheduler.js";
-import plexCacheSchedulerPlugin from "./plugins/plex-cache-scheduler.js";
-import tautulliCacheSchedulerPlugin from "./plugins/tautulli-cache-scheduler.js";
-import plexEpisodeCacheSchedulerPlugin from "./plugins/plex-episode-cache-scheduler.js";
-import sessionSnapshotSchedulerPlugin from "./plugins/session-snapshot-scheduler.js";
-import trashSyncSchedulerPlugin from "./plugins/trash-sync-scheduler.js";
-import trashUpdateSchedulerPlugin from "./plugins/trash-update-scheduler.js";
-import { registerAuthRoutes } from "./routes/auth.js";
-import { registerAuthOidcRoutes } from "./routes/auth-oidc.js";
-import { registerAuthPasskeyRoutes } from "./routes/auth-passkey.js";
-import { registerBackupRoutes } from "./routes/backup.js";
-import { registerDashboardRoutes } from "./routes/dashboard.js";
-import { registerHealthRoutes } from "./routes/health.js";
-import { registerHuntingRoutes } from "./routes/hunting.js";
-import { registerLibraryRoutes } from "./routes/library.js";
-import { registerLibraryCleanupRoutes } from "./routes/library-cleanup.js";
-import { registerManualImportRoutes } from "./routes/manual-import.js";
-import { registerNotificationRoutes } from "./routes/notifications.js";
-import oidcProvidersRoutes from "./routes/oidc-providers.js";
-import { registerQueueCleanerRoutes } from "./routes/queue-cleaner.js";
-import { registerSearchRoutes } from "./routes/search.js";
-import { registerSeerrRoutes } from "./routes/seerr/index.js";
-import { registerServiceRoutes } from "./routes/services.js";
-import { registerSystemRoutes } from "./routes/system.js";
-import { registerTrashGuidesRoutes } from "./routes/trash-guides/index.js";
-import { registerJellyfinRoutes } from "./routes/jellyfin/index.js";
-import { registerPlexRoutes } from "./routes/plex/index.js";
-import { registerPulseRoutes } from "./routes/pulse.js";
-import { registerTautulliRoutes } from "./routes/tautulli/index.js";
 import { logger } from "./lib/logger.js";
 
 function isPrismaKnownError(
@@ -113,32 +72,11 @@ export const buildServer = (options: ServerOptions = {}): FastifyInstance => {
 		timeWindow: env.API_RATE_LIMIT_WINDOW,
 	});
 
-	// Register Prisma, Security, ARR Client, Lifecycle, and Scheduler plugins
-	app.register(prismaPlugin);
-	app.register(securityPlugin);
-	app.register(arrClientPlugin);
-	app.register(seerrCircuitBreakerPlugin);
-	app.register(seerrCachePlugin);
-	app.register(deploymentExecutorPlugin);
-	app.register(notificationServicePlugin);
-	app.register(lifecyclePlugin);
-	app.register(backupSchedulerPlugin);
-	app.register(librarySyncSchedulerPlugin);
-	app.register(sessionCleanupPlugin);
-	app.register(trashBackupCleanupPlugin);
-	app.register(trashUpdateSchedulerPlugin);
-	app.register(trashSyncSchedulerPlugin);
-	app.register(huntingSchedulerPlugin);
-	app.register(queueCleanerSchedulerPlugin);
-	app.register(libraryCleanupSchedulerPlugin);
-	app.register(insightsDigestSchedulerPlugin);
-	app.register(plexCacheSchedulerPlugin);
-	app.register(plexEpisodeCacheSchedulerPlugin);
-	app.register(jellyfinCacheSchedulerPlugin);
-	app.register(jellyfinEpisodeCacheSchedulerPlugin);
-	app.register(tautulliCacheSchedulerPlugin);
-	app.register(sessionSnapshotSchedulerPlugin);
-	app.register(seerrHealthSchedulerPlugin);
+	// Core infrastructure + background schedulers. Infrastructure must run
+	// before schedulers because schedulers rely on decorations like `app.prisma`
+	// and `app.notificationService`.
+	registerInfrastructure(app);
+	registerSchedulers(app);
 
 	app.decorateRequest("currentUser", null);
 	app.decorateRequest("sessionToken", null);
@@ -228,39 +166,8 @@ export const buildServer = (options: ServerOptions = {}): FastifyInstance => {
 		});
 	});
 
-	// Public routes — no auth required
-	app.register(registerHealthRoutes, { prefix: "/health" });
-	app.register(registerAuthRoutes, { prefix: "/auth" });
-	app.register(registerAuthOidcRoutes, { prefix: "/auth" });
-	app.register(registerAuthPasskeyRoutes, { prefix: "/auth" });
-
-	// Protected routes — auth enforced by scope-level hook
-	app.register(async (api) => {
-		api.addHook("preHandler", async (request, reply) => {
-			if (!request.currentUser?.id) {
-				return reply.status(401).send({ error: "Authentication required" });
-			}
-		});
-
-		api.register(oidcProvidersRoutes);
-		api.register(registerServiceRoutes, { prefix: "/api" });
-		api.register(registerDashboardRoutes, { prefix: "/api" });
-		api.register(registerLibraryRoutes, { prefix: "/api" });
-		api.register(registerSearchRoutes, { prefix: "/api" });
-		api.register(registerManualImportRoutes, { prefix: "/api" });
-		api.register(registerBackupRoutes, { prefix: "/api/backup" });
-		api.register(registerSystemRoutes, { prefix: "/api/system" });
-		api.register(registerTrashGuidesRoutes, { prefix: "/api/trash-guides" });
-		api.register(registerSeerrRoutes, { prefix: "/api/seerr" });
-		api.register(registerHuntingRoutes, { prefix: "/api" });
-		api.register(registerQueueCleanerRoutes, { prefix: "/api" });
-		api.register(registerNotificationRoutes, { prefix: "/api/notifications" });
-		api.register(registerLibraryCleanupRoutes, { prefix: "/api" });
-		api.register(registerPlexRoutes, { prefix: "/api/plex" });
-		api.register(registerJellyfinRoutes, { prefix: "/api/jellyfin" });
-		api.register(registerPulseRoutes, { prefix: "/api" });
-		api.register(registerTautulliRoutes, { prefix: "/api/tautulli" });
-	});
+	registerPublicRoutes(app);
+	registerProtectedRoutes(app);
 
 	return app;
 };


### PR DESCRIPTION
Move plugin and route registration out of server.ts into dedicated
bootstrap modules organized by concern:

- bootstrap/infrastructure.ts — core cross-cutting plugins (prisma,
  security, arr-client, seerr circuit breaker/cache, deployment
  executor, notification service, lifecycle)
- bootstrap/schedulers.ts — background scheduler plugins grouped by
  sub-domain (backups/session, ARR automation, TRaSH sync, media
  caches, seerr health)
- bootstrap/public-routes.ts — unauthenticated routes (health + auth)
- bootstrap/protected-routes.ts — session-gated routes grouped by
  product domain (auth/identity, system/ops, ARR services, ARR
  automation, media servers, external integrations)

server.ts shrinks from ~266 to ~160 lines and now focuses on
Fastify setup, auth preHandler, and the error handler. No behavior
change: registration order and prefixes are preserved.