### PR TITLE
feat(api): SchedulerRegistry + /api/system/jobs operability surface

### DIFF
--- a/apps/api/src/bootstrap/infrastructure.ts
+++ b/apps/api/src/bootstrap/infrastructure.ts
@@ -5,6 +5,7 @@ import deploymentExecutorPlugin from "../plugins/deployment-executor.js";
 import lifecyclePlugin from "../plugins/lifecycle.js";
 import notificationServicePlugin from "../plugins/notification-service.js";
 import { prismaPlugin } from "../plugins/prisma.js";
+import schedulerRegistryPlugin from "../plugins/scheduler-registry.js";
 import { securityPlugin } from "../plugins/security.js";
 import seerrCachePlugin from "../plugins/seerr-cache.js";
 import seerrCircuitBreakerPlugin from "../plugins/seerr-circuit-breaker.js";
@@ -22,6 +23,7 @@ import seerrCircuitBreakerPlugin from "../plugins/seerr-circuit-breaker.js";
  *  - seerr cache       → shared response cache for Seerr requests
  *  - deploymentExecutor→ `app.deploymentExecutor`
  *  - notificationService → `app.notificationService`
+ *  - schedulerRegistry → `app.schedulerRegistry` (must precede scheduler plugins)
  *  - lifecycle         → graceful shutdown + health wiring
  */
 export function registerInfrastructure(app: FastifyInstance): void {
@@ -32,5 +34,6 @@ export function registerInfrastructure(app: FastifyInstance): void {
 	app.register(seerrCachePlugin);
 	app.register(deploymentExecutorPlugin);
 	app.register(notificationServicePlugin);
+	app.register(schedulerRegistryPlugin);
 	app.register(lifecyclePlugin);
 }

--- a/apps/api/src/lib/scheduler-registry/__tests__/scheduler-registry.test.ts
+++ b/apps/api/src/lib/scheduler-registry/__tests__/scheduler-registry.test.ts
@@ -1,0 +1,259 @@
+/**
+ * SchedulerRegistry unit tests.
+ *
+ * Uses vitest fake timers + an injected Clock so success/failure/duration
+ * tracking is deterministic without relying on real-time wall clocks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	type Clock,
+	SchedulerRegistry,
+	SerialJobBusyError,
+	UnknownJobError,
+} from "../scheduler-registry.js";
+
+/**
+ * Clock that advances through a preset sequence of Dates on each `now()` call.
+ * Each call to `now()` consumes the next value (or repeats the last one).
+ */
+function scriptedClock(times: Date[]): Clock {
+	let i = 0;
+	return {
+		now: () => {
+			const next = times[Math.min(i, times.length - 1)];
+			i += 1;
+			if (!next) throw new Error("scriptedClock exhausted");
+			return next;
+		},
+	};
+}
+
+const BASE_DEFINITION = {
+	id: "example-job",
+	label: "Example Job",
+	description: "A job used in tests.",
+	concurrency: "singleton" as const,
+	intervalMs: 60_000,
+};
+
+describe("SchedulerRegistry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("registers a job and returns default status before any run", () => {
+		const registry = new SchedulerRegistry();
+		registry.register(BASE_DEFINITION);
+
+		const status = registry.getStatus("example-job");
+		expect(status).toMatchObject({
+			id: "example-job",
+			label: "Example Job",
+			state: "idle",
+			lastStartedAt: null,
+			lastFinishedAt: null,
+			lastSuccessAt: null,
+			lastFailureAt: null,
+			lastDurationMs: null,
+			lastError: null,
+			consecutiveFailures: 0,
+			totalRuns: 0,
+			totalFailures: 0,
+			disabled: false,
+			disabledReason: null,
+		});
+	});
+
+	it("tracks a successful run and records duration using the injected clock", async () => {
+		const start = new Date("2026-01-01T00:00:00.000Z");
+		const end = new Date("2026-01-01T00:00:01.250Z");
+		const registry = new SchedulerRegistry(scriptedClock([start, end]));
+		registry.register(BASE_DEFINITION);
+
+		const result = await registry.track("example-job", async () => "ok");
+
+		expect(result).toBe("ok");
+		const status = registry.getStatus("example-job");
+		expect(status).toMatchObject({
+			state: "idle",
+			lastStartedAt: start.toISOString(),
+			lastFinishedAt: end.toISOString(),
+			lastSuccessAt: end.toISOString(),
+			lastFailureAt: null,
+			lastDurationMs: 1250,
+			lastError: null,
+			consecutiveFailures: 0,
+			totalRuns: 1,
+			totalFailures: 0,
+		});
+	});
+
+	it("tracks a failed run, re-throws, and increments consecutiveFailures", async () => {
+		const start = new Date("2026-01-01T00:00:00.000Z");
+		const end = new Date("2026-01-01T00:00:00.500Z");
+		const registry = new SchedulerRegistry(scriptedClock([start, end]));
+		registry.register(BASE_DEFINITION);
+
+		await expect(
+			registry.track("example-job", async () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+
+		const status = registry.getStatus("example-job");
+		expect(status).toMatchObject({
+			state: "idle",
+			lastStartedAt: start.toISOString(),
+			lastFinishedAt: end.toISOString(),
+			lastSuccessAt: null,
+			lastFailureAt: end.toISOString(),
+			lastDurationMs: 500,
+			lastError: "boom",
+			consecutiveFailures: 1,
+			totalRuns: 1,
+			totalFailures: 1,
+		});
+	});
+
+	it("resets consecutiveFailures on the next success but preserves totals", async () => {
+		const registry = new SchedulerRegistry(
+			scriptedClock([
+				new Date("2026-01-01T00:00:00.000Z"),
+				new Date("2026-01-01T00:00:01.000Z"),
+				new Date("2026-01-01T00:00:10.000Z"),
+				new Date("2026-01-01T00:00:11.000Z"),
+				new Date("2026-01-01T00:00:20.000Z"),
+				new Date("2026-01-01T00:00:21.000Z"),
+			]),
+		);
+		registry.register(BASE_DEFINITION);
+
+		await expect(
+			registry.track("example-job", async () => {
+				throw new Error("first");
+			}),
+		).rejects.toThrow("first");
+		await expect(
+			registry.track("example-job", async () => {
+				throw new Error("second");
+			}),
+		).rejects.toThrow("second");
+		await registry.track("example-job", async () => "ok");
+
+		const status = registry.getStatus("example-job");
+		expect(status).toMatchObject({
+			consecutiveFailures: 0,
+			totalRuns: 3,
+			totalFailures: 2,
+			lastError: null,
+		});
+	});
+
+	it("rejects overlapping runs for serial jobs and preserves prior state", async () => {
+		const registry = new SchedulerRegistry(
+			scriptedClock([new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:00:05.000Z")]),
+		);
+		registry.register({ ...BASE_DEFINITION, concurrency: "serial" });
+
+		let resolveFirst: (value: string) => void = () => {};
+		const firstPromise = registry.track(
+			"example-job",
+			() =>
+				new Promise<string>((resolve) => {
+					resolveFirst = resolve;
+				}),
+		);
+
+		// While the first run is still in-flight, a second call should fail fast.
+		await expect(registry.track("example-job", async () => "second")).rejects.toBeInstanceOf(
+			SerialJobBusyError,
+		);
+
+		// State remains "running" until first completes.
+		expect(registry.getStatus("example-job")?.state).toBe("running");
+
+		resolveFirst("done");
+		await firstPromise;
+
+		const status = registry.getStatus("example-job");
+		expect(status).toMatchObject({
+			state: "idle",
+			totalRuns: 1,
+			totalFailures: 0,
+		});
+	});
+
+	it("allows parallel jobs to overlap without throwing", async () => {
+		const registry = new SchedulerRegistry(
+			scriptedClock([
+				new Date("2026-01-01T00:00:00.000Z"),
+				new Date("2026-01-01T00:00:00.500Z"),
+				new Date("2026-01-01T00:00:00.750Z"),
+				new Date("2026-01-01T00:00:01.000Z"),
+			]),
+		);
+		registry.register({ ...BASE_DEFINITION, concurrency: "parallel" });
+
+		const a = registry.track("example-job", async () => "a");
+		const b = registry.track("example-job", async () => "b");
+
+		await expect(Promise.all([a, b])).resolves.toEqual(["a", "b"]);
+		expect(registry.getStatus("example-job")?.totalRuns).toBe(2);
+	});
+
+	it("reflects markDisabled / markEnabled in state and status", () => {
+		const registry = new SchedulerRegistry();
+		registry.register(BASE_DEFINITION);
+
+		registry.markDisabled("example-job", "feature flag off");
+		expect(registry.getStatus("example-job")).toMatchObject({
+			state: "disabled",
+			disabled: true,
+			disabledReason: "feature flag off",
+		});
+
+		registry.markEnabled("example-job");
+		expect(registry.getStatus("example-job")).toMatchObject({
+			state: "idle",
+			disabled: false,
+			disabledReason: null,
+		});
+	});
+
+	it("returns null for unknown jobs and throws from track()", async () => {
+		const registry = new SchedulerRegistry();
+		expect(registry.getStatus("missing")).toBeNull();
+		await expect(registry.track("missing", async () => "x")).rejects.toBeInstanceOf(
+			UnknownJobError,
+		);
+	});
+
+	it("list() returns all jobs sorted by id", () => {
+		const registry = new SchedulerRegistry();
+		registry.register({ ...BASE_DEFINITION, id: "zeta-job", label: "Zeta" });
+		registry.register({ ...BASE_DEFINITION, id: "alpha-job", label: "Alpha" });
+
+		expect(registry.list().map((j) => j.id)).toEqual(["alpha-job", "zeta-job"]);
+	});
+
+	it("re-registering a job preserves accumulated stats", async () => {
+		const registry = new SchedulerRegistry(
+			scriptedClock([new Date("2026-01-01T00:00:00.000Z"), new Date("2026-01-01T00:00:01.000Z")]),
+		);
+		registry.register(BASE_DEFINITION);
+		await registry.track("example-job", async () => "ok");
+
+		registry.register({ ...BASE_DEFINITION, label: "Renamed" });
+
+		expect(registry.getStatus("example-job")).toMatchObject({
+			label: "Renamed",
+			totalRuns: 1,
+		});
+	});
+});

--- a/apps/api/src/lib/scheduler-registry/job-definitions.ts
+++ b/apps/api/src/lib/scheduler-registry/job-definitions.ts
@@ -1,0 +1,157 @@
+/**
+ * Central catalog of background jobs the API process runs.
+ *
+ * Each entry below is the authoritative metadata for one scheduler. This file
+ * is the single source of truth for job ids — constants are exported so that
+ * scheduler plugins (and `registry.track()` call sites) reference the same
+ * string, eliminating the class of bugs where the registry and the telemetry
+ * surface drift apart.
+ *
+ * Concurrency notes belong in the `description` field and summarize the lock
+ * model the plugin enforces today. The registry itself only enforces `serial`;
+ * the other values are informational for operator UIs.
+ */
+
+import type { JobDefinition } from "./scheduler-registry.js";
+
+// Stable ids — reference these from plugins and tests instead of bare strings.
+export const JOB_ID = {
+	backup: "backup",
+	sessionCleanup: "session-cleanup",
+	sessionSnapshot: "session-snapshot",
+	librarySync: "library-sync",
+	hunting: "hunting",
+	queueCleaner: "queue-cleaner",
+	libraryCleanup: "library-cleanup",
+	insightsDigest: "insights-digest",
+	trashBackupCleanup: "trash-backup-cleanup",
+	trashUpdate: "trash-update",
+	trashSync: "trash-sync",
+	plexCache: "plex-cache",
+	plexEpisodeCache: "plex-episode-cache",
+	jellyfinCache: "jellyfin-cache",
+	jellyfinEpisodeCache: "jellyfin-episode-cache",
+	tautulliCache: "tautulli-cache",
+	seerrHealth: "seerr-health",
+} as const;
+
+export const KNOWN_JOBS: readonly JobDefinition[] = [
+	{
+		id: JOB_ID.backup,
+		label: "Backup scheduler",
+		description:
+			"Runs configured automatic backups (database + secrets). Ticks are serialized by BackupScheduler — a new tick cannot start while one is in flight.",
+		concurrency: "singleton",
+	},
+	{
+		id: JOB_ID.sessionCleanup,
+		label: "Session cleanup",
+		description:
+			"Deletes expired session rows every hour. Safe to run concurrently with request-time cleanup because SQL DELETE is idempotent.",
+		concurrency: "singleton",
+		intervalMs: 60 * 60 * 1000,
+	},
+	{
+		id: JOB_ID.sessionSnapshot,
+		label: "Session snapshot",
+		description:
+			"Captures Plex/Jellyfin stream telemetry every 5 minutes. Guarded by an in-plugin `isRunning` flag so ticks never overlap per-process.",
+		concurrency: "singleton",
+		intervalMs: 5 * 60 * 1000,
+	},
+	{
+		id: JOB_ID.librarySync,
+		label: "Library sync",
+		description:
+			"Syncs ARR library metadata on a per-instance cadence. Different ARR instances run independently; each instance is serial against itself.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.hunting,
+		label: "Hunting scheduler",
+		description:
+			"Scans ARR instances for missing episodes/movies and optional upgrades. Per-instance scheduling with internal serialization to avoid hammering an ARR instance.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.queueCleaner,
+		label: "Queue cleaner",
+		description:
+			"Applies configured queue cleanup rules (stalled, slow, rejected imports, …) per instance on a schedule. Per-instance serial.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.libraryCleanup,
+		label: "Library cleanup",
+		description:
+			"Performs scheduled library hygiene (unmonitoring, deletions) per instance based on operator rules.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.insightsDigest,
+		label: "Insights digest",
+		description:
+			"Aggregates dashboard insights and emits digest notifications on the configured cadence. Singleton.",
+		concurrency: "singleton",
+	},
+	{
+		id: JOB_ID.trashBackupCleanup,
+		label: "TRaSH backup cleanup",
+		description: "Prunes old TRaSH Guides ARR-config backups to keep the retention window tidy.",
+		concurrency: "singleton",
+	},
+	{
+		id: JOB_ID.trashUpdate,
+		label: "TRaSH Guides update",
+		description: "Refreshes the upstream TRaSH Guides data the app builds recommendations from.",
+		concurrency: "singleton",
+	},
+	{
+		id: JOB_ID.trashSync,
+		label: "TRaSH Guides sync",
+		description:
+			"Applies enabled TRaSH Guides templates to target ARR instances on the configured interval.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.plexCache,
+		label: "Plex library cache",
+		description:
+			"Refreshes Plex library metadata cache per Plex instance. Per-instance serial with `CacheRefreshStatus` row as the durable witness.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.plexEpisodeCache,
+		label: "Plex episode cache",
+		description: "Refreshes Plex episode metadata used by session views. Per-instance serial.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.jellyfinCache,
+		label: "Jellyfin library cache",
+		description:
+			"Refreshes Jellyfin/Emby library metadata cache per instance. Per-instance serial.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.jellyfinEpisodeCache,
+		label: "Jellyfin episode cache",
+		description:
+			"Refreshes Jellyfin/Emby episode metadata cache per instance. Per-instance serial.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.tautulliCache,
+		label: "Tautulli cache",
+		description: "Refreshes Tautulli history + library caches per instance. Per-instance serial.",
+		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.seerrHealth,
+		label: "Seerr health",
+		description:
+			"Pings configured Seerr (Jellyseerr/Overseerr) instances every 5 minutes. Guarded by an in-plugin `isRunning` flag.",
+		concurrency: "singleton",
+		intervalMs: 5 * 60 * 1000,
+	},
+] as const;

--- a/apps/api/src/lib/scheduler-registry/scheduler-registry.ts
+++ b/apps/api/src/lib/scheduler-registry/scheduler-registry.ts
@@ -1,0 +1,249 @@
+/**
+ * SchedulerRegistry — a minimal, in-memory catalog + runtime-state tracker
+ * for the background schedulers this API runs.
+ *
+ * Design intent:
+ *  - Observability only. The registry does NOT own scheduling, locking, or
+ *    persistence. Each scheduler plugin continues to own its own timer.
+ *  - Incremental adoption. A scheduler can register a job up-front and
+ *    instrument execution later; the read-only status surface degrades
+ *    gracefully if a job has never run.
+ *  - Process-local. State lives in memory and is rebuilt on restart. A
+ *    future iteration may persist runs if we need historical trends.
+ *
+ * See docs/adr/0001-scheduler-registry.md for the full rationale.
+ */
+
+export type JobConcurrency =
+	/** At most one tick in flight at a time (single-process singleton). */
+	| "singleton"
+	/** Ticks are serialized per ARR instance — different instances can run concurrently. */
+	| "per-instance"
+	/** Ticks run to completion before the next fires; registry enforces via `track`. */
+	| "serial"
+	/** Ticks may overlap; registry records the latest stats without gating. */
+	| "parallel";
+
+export type JobState = "idle" | "running" | "disabled";
+
+export interface JobDefinition {
+	/** Stable identifier — used in API responses, URLs, logs. */
+	id: string;
+	/** Short, human-readable label for operator UIs. */
+	label: string;
+	/** One-line description of what the job does. */
+	description: string;
+	/** Declared concurrency model — informational and, for `serial`, enforced by `track`. */
+	concurrency: JobConcurrency;
+	/** Expected cadence between ticks, in ms. Omit for event-driven jobs. */
+	intervalMs?: number;
+}
+
+export interface JobStatus extends JobDefinition {
+	state: JobState;
+	lastStartedAt: string | null;
+	lastFinishedAt: string | null;
+	lastSuccessAt: string | null;
+	lastFailureAt: string | null;
+	lastDurationMs: number | null;
+	lastError: string | null;
+	consecutiveFailures: number;
+	totalRuns: number;
+	totalFailures: number;
+	/** True when the plugin has disabled the job (e.g. feature flag off). */
+	disabled: boolean;
+	/** Optional reason captured when the plugin set `disabled=true`. */
+	disabledReason: string | null;
+}
+
+interface JobRecord {
+	definition: JobDefinition;
+	state: JobState;
+	lastStartedAt: Date | null;
+	lastFinishedAt: Date | null;
+	lastSuccessAt: Date | null;
+	lastFailureAt: Date | null;
+	lastDurationMs: number | null;
+	lastError: string | null;
+	consecutiveFailures: number;
+	totalRuns: number;
+	totalFailures: number;
+	disabled: boolean;
+	disabledReason: string | null;
+}
+
+export interface Clock {
+	now(): Date;
+}
+
+const systemClock: Clock = {
+	now: () => new Date(),
+};
+
+export interface TrackOptions {
+	/**
+	 * Override the concurrency check for this tick. Defaults to the job's
+	 * declared concurrency. `serial` throws if a run is already in flight;
+	 * all other values allow the run to proceed.
+	 */
+	concurrency?: JobConcurrency;
+}
+
+export class SerialJobBusyError extends Error {
+	readonly statusCode = 409;
+
+	constructor(jobId: string) {
+		super(`Job ${jobId} is already running (concurrency=serial)`);
+		this.name = "SerialJobBusyError";
+	}
+}
+
+export class UnknownJobError extends Error {
+	readonly statusCode = 404;
+
+	constructor(jobId: string) {
+		super(`Job ${jobId} is not registered`);
+		this.name = "UnknownJobError";
+	}
+}
+
+export class SchedulerRegistry {
+	private readonly jobs = new Map<string, JobRecord>();
+
+	constructor(private readonly clock: Clock = systemClock) {}
+
+	/**
+	 * Register a job's metadata. Safe to call multiple times with the same id —
+	 * the latest definition wins. Preserves any runtime stats captured so far.
+	 */
+	register(definition: JobDefinition): void {
+		const existing = this.jobs.get(definition.id);
+		if (existing) {
+			existing.definition = definition;
+			return;
+		}
+		this.jobs.set(definition.id, {
+			definition,
+			state: "idle",
+			lastStartedAt: null,
+			lastFinishedAt: null,
+			lastSuccessAt: null,
+			lastFailureAt: null,
+			lastDurationMs: null,
+			lastError: null,
+			consecutiveFailures: 0,
+			totalRuns: 0,
+			totalFailures: 0,
+			disabled: false,
+			disabledReason: null,
+		});
+	}
+
+	/** Mark a job disabled (e.g. feature flag off or init failed). */
+	markDisabled(jobId: string, reason: string): void {
+		const record = this.mustGet(jobId);
+		record.disabled = true;
+		record.disabledReason = reason;
+		record.state = "disabled";
+	}
+
+	/** Clear the disabled flag and return the job to idle. */
+	markEnabled(jobId: string): void {
+		const record = this.mustGet(jobId);
+		record.disabled = false;
+		record.disabledReason = null;
+		if (record.state === "disabled") {
+			record.state = "idle";
+		}
+	}
+
+	/**
+	 * Wrap an async tick with timing, state, and failure tracking.
+	 *
+	 * Returns the awaited result of `fn`. Re-throws the underlying error so
+	 * callers retain existing error-handling semantics; the registry only
+	 * observes, it does not swallow.
+	 */
+	async track<T>(jobId: string, fn: () => Promise<T>, options: TrackOptions = {}): Promise<T> {
+		const record = this.mustGet(jobId);
+		const concurrency = options.concurrency ?? record.definition.concurrency;
+
+		if (concurrency === "serial" && record.state === "running") {
+			throw new SerialJobBusyError(jobId);
+		}
+
+		const startedAt = this.clock.now();
+		record.lastStartedAt = startedAt;
+		record.state = "running";
+
+		try {
+			const result = await fn();
+			const finishedAt = this.clock.now();
+			record.lastFinishedAt = finishedAt;
+			record.lastSuccessAt = finishedAt;
+			record.lastDurationMs = finishedAt.getTime() - startedAt.getTime();
+			record.lastError = null;
+			record.consecutiveFailures = 0;
+			record.totalRuns += 1;
+			if (record.state === "running") {
+				record.state = record.disabled ? "disabled" : "idle";
+			}
+			return result;
+		} catch (error) {
+			const finishedAt = this.clock.now();
+			record.lastFinishedAt = finishedAt;
+			record.lastFailureAt = finishedAt;
+			record.lastDurationMs = finishedAt.getTime() - startedAt.getTime();
+			record.lastError = error instanceof Error ? error.message : String(error);
+			record.consecutiveFailures += 1;
+			record.totalRuns += 1;
+			record.totalFailures += 1;
+			if (record.state === "running") {
+				record.state = record.disabled ? "disabled" : "idle";
+			}
+			throw error;
+		}
+	}
+
+	/** Snapshot of a single job's status, or `null` if unregistered. */
+	getStatus(jobId: string): JobStatus | null {
+		const record = this.jobs.get(jobId);
+		return record ? toStatus(record) : null;
+	}
+
+	/** All registered jobs, stable-sorted by id. */
+	list(): JobStatus[] {
+		return [...this.jobs.values()].map(toStatus).sort((a, b) => a.id.localeCompare(b.id));
+	}
+
+	/** Test helper — reset all state. Not used in production code paths. */
+	reset(): void {
+		this.jobs.clear();
+	}
+
+	private mustGet(jobId: string): JobRecord {
+		const record = this.jobs.get(jobId);
+		if (!record) {
+			throw new UnknownJobError(jobId);
+		}
+		return record;
+	}
+}
+
+function toStatus(record: JobRecord): JobStatus {
+	return {
+		...record.definition,
+		state: record.state,
+		lastStartedAt: record.lastStartedAt?.toISOString() ?? null,
+		lastFinishedAt: record.lastFinishedAt?.toISOString() ?? null,
+		lastSuccessAt: record.lastSuccessAt?.toISOString() ?? null,
+		lastFailureAt: record.lastFailureAt?.toISOString() ?? null,
+		lastDurationMs: record.lastDurationMs,
+		lastError: record.lastError,
+		consecutiveFailures: record.consecutiveFailures,
+		totalRuns: record.totalRuns,
+		totalFailures: record.totalFailures,
+		disabled: record.disabled,
+		disabledReason: record.disabledReason,
+	};
+}

--- a/apps/api/src/plugins/hunting-scheduler.ts
+++ b/apps/api/src/plugins/hunting-scheduler.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { getHuntingScheduler } from "../lib/hunting/scheduler.js";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 
 declare module "fastify" {
@@ -49,6 +50,8 @@ const huntingSchedulerPlugin = fastifyPlugin(
 				app.log.error({ err: error }, "Failed to initialize hunting scheduler - feature disabled");
 				// Store error for user visibility in 503 responses
 				app.decorate("huntingSchedulerInitError", errorMsg);
+				// Reflect the disabled state on the operator surface.
+				app.schedulerRegistry.markDisabled(JOB_ID.hunting, errorMsg);
 				// huntingSchedulerEnabled remains false - routes will return 503
 			}
 		});
@@ -64,7 +67,7 @@ const huntingSchedulerPlugin = fastifyPlugin(
 	},
 	{
 		name: "hunting-scheduler",
-		dependencies: ["prisma"],
+		dependencies: ["prisma", "scheduler-registry"],
 	},
 );
 

--- a/apps/api/src/plugins/queue-cleaner-scheduler.ts
+++ b/apps/api/src/plugins/queue-cleaner-scheduler.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { getQueueCleanerScheduler } from "../lib/queue-cleaner/scheduler.js";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { setManualImportLogger } from "../routes/manual-import-utils.js";
 
@@ -50,6 +51,8 @@ const queueCleanerSchedulerPlugin = fastifyPlugin(
 				);
 				// Store error for user visibility in 503 responses
 				app.decorate("queueCleanerInitError", errorMsg);
+				// Reflect the disabled state on the operator surface.
+				app.schedulerRegistry.markDisabled(JOB_ID.queueCleaner, errorMsg);
 				// queueCleanerEnabled remains false - routes will return 503
 			}
 		});
@@ -63,7 +66,7 @@ const queueCleanerSchedulerPlugin = fastifyPlugin(
 	},
 	{
 		name: "queue-cleaner-scheduler",
-		dependencies: ["prisma"],
+		dependencies: ["prisma", "scheduler-registry"],
 	},
 );
 

--- a/apps/api/src/plugins/scheduler-registry.ts
+++ b/apps/api/src/plugins/scheduler-registry.ts
@@ -1,0 +1,42 @@
+import type { FastifyInstance } from "fastify";
+import fastifyPlugin from "fastify-plugin";
+import { KNOWN_JOBS } from "../lib/scheduler-registry/job-definitions.js";
+import { SchedulerRegistry } from "../lib/scheduler-registry/scheduler-registry.js";
+
+declare module "fastify" {
+	interface FastifyInstance {
+		/**
+		 * Process-local catalog of background schedulers + their runtime status.
+		 * Individual scheduler plugins call `app.schedulerRegistry.register(...)`
+		 * in their `onReady` hook and may wrap ticks with `registry.track(...)`.
+		 *
+		 * See lib/scheduler-registry/scheduler-registry.ts for the full model.
+		 */
+		schedulerRegistry: SchedulerRegistry;
+	}
+}
+
+/**
+ * Registers the singleton SchedulerRegistry decoration.
+ *
+ * This plugin must be registered before any scheduler plugin so those plugins
+ * can call `app.schedulerRegistry.register(...)` during their own `onReady`
+ * hooks. The registry itself has no initialization — creation is synchronous.
+ */
+const schedulerRegistryPlugin = fastifyPlugin(
+	async (app: FastifyInstance) => {
+		const registry = new SchedulerRegistry();
+		// Pre-register every known job so the /api/system/jobs surface always
+		// reflects the full catalog — even jobs whose plugin has not yet adopted
+		// `registry.track()` show up as idle with no execution data.
+		for (const definition of KNOWN_JOBS) {
+			registry.register(definition);
+		}
+		app.decorate("schedulerRegistry", registry);
+	},
+	{
+		name: "scheduler-registry",
+	},
+);
+
+export default schedulerRegistryPlugin;

--- a/apps/api/src/plugins/seerr-health-scheduler.ts
+++ b/apps/api/src/plugins/seerr-health-scheduler.ts
@@ -8,6 +8,7 @@
 
 import type { FastifyInstance } from "fastify";
 import fp from "fastify-plugin";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { SeerrClient } from "../lib/seerr/seerr-client.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 
@@ -27,61 +28,32 @@ const seerrHealthSchedulerPlugin = fp(
 			}
 			isRunning = true;
 			try {
-				// System-level scheduler: queries ALL enabled Seerr instances (no userId filter)
-				// because health checks run as a background system task, not per-user.
-				const instances = await app.prisma.serviceInstance.findMany({
-					where: { service: "SEERR", enabled: true },
-				});
+				// Route the tick through the scheduler registry so last run / duration /
+				// failure counts surface on /api/system/jobs. The registry re-throws,
+				// so fatal errors reach the outer .catch() handlers below just as before.
+				await app.schedulerRegistry.track(JOB_ID.seerrHealth, async () => {
+					// System-level scheduler: queries ALL enabled Seerr instances (no userId filter)
+					// because health checks run as a background system task, not per-user.
+					const instances = await app.prisma.serviceInstance.findMany({
+						where: { service: "SEERR", enabled: true },
+					});
 
-				if (instances.length === 0) {
-					app.log.debug("Seerr health check: no enabled Seerr instances, skipping");
-					return;
-				}
+					if (instances.length === 0) {
+						app.log.debug("Seerr health check: no enabled Seerr instances, skipping");
+						return;
+					}
 
-				for (const instance of instances) {
-					try {
-						const client = new SeerrClient(
-							app.arrClientFactory,
-							instance,
-							app.log,
-							app.seerrCircuitBreaker,
-						);
-						const status = await client.getStatus();
+					for (const instance of instances) {
+						try {
+							const client = new SeerrClient(
+								app.arrClientFactory,
+								instance,
+								app.log,
+								app.seerrCircuitBreaker,
+							);
+							const status = await client.getStatus();
 
-						await app.prisma.cacheRefreshStatus.upsert({
-							where: {
-								instanceId_cacheType: {
-									instanceId: instance.id,
-									cacheType: "seerr_health",
-								},
-							},
-							create: {
-								instanceId: instance.id,
-								cacheType: "seerr_health",
-								lastRefreshedAt: new Date(),
-								lastResult: "success",
-								lastErrorMessage: null,
-								itemCount: 0,
-							},
-							update: {
-								lastRefreshedAt: new Date(),
-								lastResult: "success",
-								lastErrorMessage: null,
-							},
-						});
-
-						app.log.debug(
-							{ instanceId: instance.id, version: status.version },
-							"Seerr health check OK",
-						);
-					} catch (err) {
-						app.log.warn(
-							{ err, instanceId: instance.id, label: instance.label },
-							"Seerr health check failed for instance",
-						);
-
-						await app.prisma.cacheRefreshStatus
-							.upsert({
+							await app.prisma.cacheRefreshStatus.upsert({
 								where: {
 									instanceId_cacheType: {
 										instanceId: instance.id,
@@ -92,25 +64,60 @@ const seerrHealthSchedulerPlugin = fp(
 									instanceId: instance.id,
 									cacheType: "seerr_health",
 									lastRefreshedAt: new Date(),
-									lastResult: "error",
-									lastErrorMessage: getErrorMessage(err, "Unknown error"),
+									lastResult: "success",
+									lastErrorMessage: null,
 									itemCount: 0,
 								},
 								update: {
 									lastRefreshedAt: new Date(),
-									lastResult: "error",
-									lastErrorMessage: getErrorMessage(err, "Unknown error"),
+									lastResult: "success",
+									lastErrorMessage: null,
 								},
-							})
-							.catch((trackErr) => {
-								app.log.warn(
-									{ err: trackErr, instanceId: instance.id },
-									"Failed to record Seerr health check failure status",
-								);
 							});
+
+							app.log.debug(
+								{ instanceId: instance.id, version: status.version },
+								"Seerr health check OK",
+							);
+						} catch (err) {
+							app.log.warn(
+								{ err, instanceId: instance.id, label: instance.label },
+								"Seerr health check failed for instance",
+							);
+
+							await app.prisma.cacheRefreshStatus
+								.upsert({
+									where: {
+										instanceId_cacheType: {
+											instanceId: instance.id,
+											cacheType: "seerr_health",
+										},
+									},
+									create: {
+										instanceId: instance.id,
+										cacheType: "seerr_health",
+										lastRefreshedAt: new Date(),
+										lastResult: "error",
+										lastErrorMessage: getErrorMessage(err, "Unknown error"),
+										itemCount: 0,
+									},
+									update: {
+										lastRefreshedAt: new Date(),
+										lastResult: "error",
+										lastErrorMessage: getErrorMessage(err, "Unknown error"),
+									},
+								})
+								.catch((trackErr) => {
+									app.log.warn(
+										{ err: trackErr, instanceId: instance.id },
+										"Failed to record Seerr health check failure status",
+									);
+								});
+						}
 					}
-				}
+				});
 			} catch (err) {
+				// Registry already recorded the failure; preserve existing log semantics.
 				app.log.error({ err }, "Seerr health scheduler: failed to query instances");
 			} finally {
 				isRunning = false;
@@ -141,7 +148,7 @@ const seerrHealthSchedulerPlugin = fp(
 	},
 	{
 		name: "seerr-health-scheduler",
-		dependencies: ["prisma", "security", "seerr-circuit-breaker"],
+		dependencies: ["prisma", "security", "seerr-circuit-breaker", "scheduler-registry"],
 	},
 );
 

--- a/apps/api/src/plugins/session-cleanup.ts
+++ b/apps/api/src/plugins/session-cleanup.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 
 /**
  * Session cleanup interval in milliseconds
@@ -20,11 +21,16 @@ const sessionCleanupPlugin = fastifyPlugin(
 
 		const runCleanup = async () => {
 			try {
-				const deletedCount = await app.sessionService.cleanupExpiredSessions();
-				if (deletedCount > 0) {
-					app.log.info({ deletedCount }, "Cleaned up expired sessions");
-				}
+				// Route the tick through the scheduler registry so last run /
+				// duration / failure counts are visible via /api/system/jobs.
+				await app.schedulerRegistry.track(JOB_ID.sessionCleanup, async () => {
+					const deletedCount = await app.sessionService.cleanupExpiredSessions();
+					if (deletedCount > 0) {
+						app.log.info({ deletedCount }, "Cleaned up expired sessions");
+					}
+				});
 			} catch (error) {
+				// Registry already recorded the failure; preserve existing log behavior.
 				app.log.error({ err: error }, "Failed to clean up expired sessions");
 			}
 		};
@@ -49,7 +55,7 @@ const sessionCleanupPlugin = fastifyPlugin(
 	},
 	{
 		name: "session-cleanup",
-		dependencies: ["prisma", "security"],
+		dependencies: ["prisma", "security", "scheduler-registry"],
 	},
 );
 

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -554,8 +554,9 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	/**
 	 * GET /system/jobs
 	 * Read-only runtime status of every registered background scheduler.
-	 * Gated by the global protected-routes preHandler — any authenticated
-	 * admin can view. The endpoint never triggers job execution.
+	 *
+	 * Security: Requires authentication (single-admin architecture - all authenticated users are admins)
+	 * The endpoint never triggers job execution.
 	 */
 	app.get("/jobs", async (_request, reply) => {
 		const jobs = app.schedulerRegistry.list();

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -551,6 +551,24 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		});
 	});
 
+	/**
+	 * GET /system/jobs
+	 * Read-only runtime status of every registered background scheduler.
+	 * Gated by the global protected-routes preHandler — any authenticated
+	 * admin can view. The endpoint never triggers job execution.
+	 */
+	app.get("/jobs", async (_request, reply) => {
+		const jobs = app.schedulerRegistry.list();
+		return reply.send({
+			success: true,
+			data: {
+				jobs,
+				count: jobs.length,
+				capturedAt: new Date().toISOString(),
+			},
+		});
+	});
+
 	done();
 };
 

--- a/docs/adr/0001-scheduler-registry.md
+++ b/docs/adr/0001-scheduler-registry.md
@@ -1,0 +1,123 @@
+# ADR 0001: Lightweight in-process SchedulerRegistry
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+- **Deciders:** Backend maintainers
+- **Supersedes:** —
+
+## Context
+
+The API runs 17 background schedulers (backup, hunting, queue cleaner, media
+caches, TRaSH sync, Seerr health, …). Until now, each scheduler owned its own
+`setInterval` and its own ad-hoc logging, and there was no unified way for an
+operator to answer:
+
+- When did each job last run? Did it succeed?
+- How long did the last run take?
+- Is any job currently in flight?
+- Has a given job failed repeatedly?
+- Which jobs are disabled, and why?
+
+Without that visibility, regressions in scheduled work are only caught when a
+user reports symptoms. We need a single place to see job state, and a single
+helper that the existing schedulers can adopt incrementally.
+
+## Decision
+
+Introduce a process-local `SchedulerRegistry` class that serves as both a
+catalog of known jobs and a runtime-state tracker. It does **not** replace
+any scheduler's timer or execution logic — it observes.
+
+### Data model
+
+Each job carries:
+
+- **Definition** (static): `id`, `label`, `description`, `concurrency`, optional `intervalMs`.
+- **Runtime status**: `state` (`idle` / `running` / `disabled`), `lastStartedAt`,
+  `lastFinishedAt`, `lastSuccessAt`, `lastFailureAt`, `lastDurationMs`,
+  `lastError`, `consecutiveFailures`, `totalRuns`, `totalFailures`,
+  `disabled`, `disabledReason`.
+
+### API surface
+
+```ts
+registry.register(definition)
+registry.markDisabled(id, reason)
+registry.markEnabled(id)
+registry.track(id, async () => { /* tick body */ })
+registry.getStatus(id)
+registry.list()
+```
+
+`track()` is the adoption seam: it wraps an existing tick function with
+timing + state transitions, re-throws the tick's original error, and updates
+stats. Callers preserve their existing error handlers.
+
+### HTTP surface
+
+`GET /api/system/jobs` returns `{ jobs, count, capturedAt }`. The endpoint is
+read-only and gated by the existing protected-routes preHandler.
+
+### Concurrency declarations
+
+Each job declares one of `singleton`, `per-instance`, `serial`, `parallel`.
+The registry only *enforces* `serial` (throws `SerialJobBusyError` when a run
+is already in flight). The other values are advisory and document the lock
+model the plugin itself enforces. Plugins are free to ignore the registry's
+concurrency value and keep their existing `isRunning` guards.
+
+## Why intentionally lightweight
+
+1. **No persistence.** Runs are not written to the database. Operator value
+   comes from the current/recent picture — historical trends can be added
+   later (e.g., `SchedulerRun` table with 30-day retention) without breaking
+   the public shape. Storing every tick from 17 schedulers would bloat the
+   database and buy us little before we know which metrics we actually want.
+2. **No global scheduler abstraction.** We did *not* migrate every scheduler
+   onto a shared cron / queue framework. Each plugin still owns its own
+   timer, because the existing timers already encode nuanced startup-delay,
+   retention, per-instance, and notification logic. A framework migration
+   would be a multi-week project with real behavior risk; that is not where
+   the observability value is today.
+3. **Incremental adoption.** Every known job is pre-registered centrally in
+   `lib/scheduler-registry/job-definitions.ts`, so the `/api/system/jobs`
+   catalog is complete from day one. Execution instrumentation (via
+   `registry.track()` or `markDisabled()`) is opt-in per scheduler and can
+   land in follow-up PRs.
+4. **Process-local.** `arr-dashboard` is a single-process self-hosted app.
+   Cross-process job coordination (e.g., distributed locks) is not required
+   and would be dead weight.
+
+## Consequences
+
+### Positive
+
+- Operators get a single `/api/system/jobs` view today, for free, for every
+  scheduler — even ones whose plugin has not yet adopted `track()`.
+- Plugins can adopt instrumentation one file at a time with a ~5-line change.
+- The registry has no side effects beyond in-memory bookkeeping, so tests do
+  not need a database or Fastify instance.
+- Concurrency intent is documented next to the job definition and visible in
+  the API response.
+
+### Negative / trade-offs
+
+- Stats are lost on restart. This is acceptable for a dashboard surface;
+  users who care about long-term trends will get them when we add
+  persistence in a follow-up.
+- Jobs that have not adopted `track()` appear as `idle` with `totalRuns: 0`.
+  The endpoint is honest about this (no fake data), but operators must know
+  that "idle + 0 runs" on an un-adopted job is unknown, not confirmed-idle.
+  Resolved by rolling out `track()` adoption across the remaining schedulers
+  in subsequent PRs.
+- The registry enforces only `serial` concurrency. Plugins retain their own
+  `isRunning` guards; there is some duplication until adoption is complete.
+
+## Follow-ups
+
+- Instrument remaining schedulers with `registry.track()`.
+- Persist runs to `SchedulerRun` if/when operators ask for trend data.
+- Add a UI panel (Settings → Jobs) that renders the `/api/system/jobs`
+  response with a "running / healthy / failing" summary.
+- Consider exposing a `POST /api/system/jobs/:id/run` trigger once we have a
+  clear safety model (right now, ticks are triggered only by timers).


### PR DESCRIPTION
## Summary

Adds a lightweight in-memory `SchedulerRegistry` that catalogs every background scheduler the API runs and tracks runtime status (last start, last success, last failure, last duration, current state, consecutive failure count, totals). Exposes a read-only `GET /api/system/jobs` endpoint protected by the existing authenticated-user preHandler — in the current single-admin architecture, all authenticated users are effectively admins. No new auth logic is introduced.

The registry is **observability only** — it does not replace any scheduler's timer or error handling. Each scheduler plugin continues to own its own execution. Adoption is incremental: all 17 known jobs are pre-registered centrally so the `/api/system/jobs` catalog is complete from day one, and individual plugins opt in to execution tracking via a small helper surface.

## What's in this PR

**Core registry** (`apps/api/src/lib/scheduler-registry/`)
- `scheduler-registry.ts` — `SchedulerRegistry` class with `register` / `track` / `markDisabled` / `markEnabled` / `getStatus` / `list`. Injectable `Clock` for deterministic tests. Enforces `serial` concurrency via `SerialJobBusyError`; other values (`singleton` / `per-instance` / `parallel`) are advisory and document the lock model the plugin itself owns.
- `job-definitions.ts` — `JOB_ID` constants + `KNOWN_JOBS` catalog for all 17 schedulers, with per-job concurrency model in the description. Single source of truth for job ids.

**Wiring**
- `plugins/scheduler-registry.ts` — Fastify plugin decorating `app.schedulerRegistry`, pre-registers `KNOWN_JOBS`.
- `bootstrap/infrastructure.ts` — registers the registry plugin before scheduler plugins.

**HTTP surface**
- `routes/system.ts` — `GET /api/system/jobs` returning `{ jobs, count, capturedAt }`. Read-only; protected by the authenticated-user preHandler (consistent with `/system/restart` — single-admin architecture, all authenticated users are admins). Does not trigger job execution.

**Pilot instrumentation** (incremental adoption, no behavior change)
- `session-cleanup.ts` — tick wrapped with `registry.track()`
- `seerr-health-scheduler.ts` — tick wrapped with `registry.track()`
- `hunting-scheduler.ts` — `markDisabled()` on init failure
- `queue-cleaner-scheduler.ts` — `markDisabled()` on init failure
- Each pilot adds `scheduler-registry` to its plugin `dependencies`.

**Tests** (`apps/api/src/lib/scheduler-registry/__tests__/scheduler-registry.test.ts`)
10 deterministic unit tests using `vi.useFakeTimers()` + an injected scripted `Clock`:
- registers a job with default idle status
- records duration on success via injected clock
- records failure, re-throws, increments consecutive failure count
- resets consecutive failures on next success, preserves totals
- serial concurrency rejects overlap with `SerialJobBusyError`
- parallel concurrency allows overlap
- `markDisabled` / `markEnabled` transitions
- unknown-job returns null / throws `UnknownJobError`
- `list()` is stable-sorted by id
- re-registering preserves runtime stats

**ADR**
`docs/adr/0001-scheduler-registry.md` — captures the model, the four explicit design constraints (no persistence, no framework migration, incremental adoption, process-local), positive/negative consequences, and follow-up work.

## Intentionally deferred

- Persisting runs to a `SchedulerRun` table (no operator has asked for historical trends; schema-change cost > current value)
- Instrumenting the remaining 13 schedulers — the catalog pre-registers them so `/api/system/jobs` is complete; `track()` adoption lands incrementally
- UI panel rendering `/api/system/jobs`
- `POST /api/system/jobs/:id/run` manual trigger (needs a safety model first)
- Role-based authorization — not part of the current architecture; any future multi-user/role work is a separate change

## Risk

Low. The registry is additive. If `registry.track()` ever throws unexpectedly, the four instrumented plugins still funnel errors through their existing log paths. The remaining 13 schedulers are unchanged in execution; they show up in the catalog with `totalRuns: 0` until they adopt `track()`.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api run test` — 1189 passed, 36 skipped (10 new registry tests)
- [x] `pnpm --filter @arr/api run lint` — clean on touched files
- [ ] `GET /api/system/jobs` returns all 17 jobs with correct `state`/`disabled` fields after boot
- [ ] Kill a Seerr instance and confirm `seerr-health` job surfaces `lastFailureAt` + incremented `consecutiveFailures`
- [ ] Disable hunting in config and confirm `hunting` job surfaces `state: "disabled"` with a populated `disabledReason`

https://claude.ai/code/session_014SQXZ22NibxzdRFR3ewWk7