### PR TITLE
fix(api): preserve independent failure isolation in session-snapshot tick

### DIFF
--- a/apps/api/src/plugins/session-snapshot-scheduler.ts
+++ b/apps/api/src/plugins/session-snapshot-scheduler.ts
@@ -523,10 +523,28 @@ const sessionSnapshotSchedulerPlugin = fastifyPlugin(
 
 		// Combined tick: both Plex and Jellyfin captures form one scheduler tick
 		// from the operator's perspective. The registry sees one run per interval.
+		//
+		// Behavior preservation: the prior implementation fired the two captures
+		// independently (`captureSnapshots().catch(...); captureJellyfinSnapshots().catch(...)`)
+		// so a Plex failure never prevented the Jellyfin capture from running.
+		// We keep that "both always run" semantic by using Promise.allSettled, then
+		// re-throw an aggregate error if either side rejected so the registry still
+		// observes a failed tick.
 		const runSnapshotTick = () =>
 			app.schedulerRegistry.track(JOB_ID.sessionSnapshot, async () => {
-				await captureSnapshots();
-				await captureJellyfinSnapshots();
+				const results = await Promise.allSettled([
+					captureSnapshots(),
+					captureJellyfinSnapshots(),
+				]);
+				const failures = results.filter(
+					(r): r is PromiseRejectedResult => r.status === "rejected",
+				);
+				if (failures.length > 0) {
+					throw new AggregateError(
+						failures.map((f) => f.reason),
+						"session snapshot tick: one or more captures failed",
+					);
+				}
 			});
 
 		app.addHook("onReady", async () => {


### PR DESCRIPTION
## Summary

PR #295 wrapped `captureSnapshots()` and `captureJellyfinSnapshots()` inside a single `schedulerRegistry.track(...)` call using sequential awaits:

```ts
await captureSnapshots();
await captureJellyfinSnapshots();
```

That regressed the prior behavior, where the two captures were fired independently (`captureSnapshots().catch(...); captureJellyfinSnapshots().catch(...)`) so a Plex capture failure never prevented the Jellyfin capture from running (and vice versa).

## Fix

Use `Promise.allSettled` so both captures always run to completion, then re-throw an `AggregateError` if either rejected so the registry still records a failed tick on `/api/system/jobs`:

```ts
const runSnapshotTick = () =>
  app.schedulerRegistry.track(JOB_ID.sessionSnapshot, async () => {
    const results = await Promise.allSettled([
      captureSnapshots(),
      captureJellyfinSnapshots(),
    ]);
    const failures = results.filter(
      (r): r is PromiseRejectedResult => r.status === "rejected",
    );
    if (failures.length > 0) {
      throw new AggregateError(
        failures.map((f) => f.reason),
        "session snapshot tick: one or more captures failed",
      );
    }
  });
```

The thrown error only surfaces **after** both sides were attempted, so:

- Both captures are attempted on every tick, even if one throws (matches pre-#295 semantic).
- `/api/system/jobs` still observes a failed tick when either side fails (via the aggregate error).
- Timing, intervals, and the 60-second startup delay are untouched.

## Scope

- One file changed: `apps/api/src/plugins/session-snapshot-scheduler.ts`
- No other schedulers touched
- No changes to intervals, startup delays, notification logic, or concurrency guards

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] Simulate a Plex capture throwing and confirm the Jellyfin capture still runs on the same tick
- [ ] Confirm `/api/system/jobs` shows `lastFailureAt` + incremented `consecutiveFailures` for `session-snapshot` when either side fails

https://claude.ai/code/session_014SQXZ22NibxzdRFR3ewWk7