### PR TITLE
feat(library): extend watch enrichment to Jellyfin/Emby

### DIFF
--- a/apps/api/src/routes/jellyfin/identity-routes.ts
+++ b/apps/api/src/routes/jellyfin/identity-routes.ts
@@ -26,6 +26,8 @@ export async function registerIdentityRoutes(app: FastifyInstance, _opts: Fastif
 				version: info.version,
 				serverName: info.serverName,
 				operatingSystem: info.operatingSystem,
+				baseUrl: instance.baseUrl,
+				service: instance.service.toLowerCase() as "jellyfin" | "emby",
 			};
 		});
 

--- a/apps/api/src/routes/library/insights-routes.ts
+++ b/apps/api/src/routes/library/insights-routes.ts
@@ -96,14 +96,20 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			return reply.send({ success: true, data: { items: [], totalWastedBytes: 0 } });
 		}
 
-		// Get user's Plex instances to load watch data
-		const plexInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "PLEX" },
-			select: { id: true },
-		});
+		// Get user's media server instances to load watch data
+		const [plexInstances, jellyfinInstances] = await Promise.all([
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: "PLEX" },
+				select: { id: true },
+			}),
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: { in: ["JELLYFIN", "EMBY"] } },
+				select: { id: true },
+			}),
+		]);
 
-		// Build Plex watch count map: "movie:tmdbId" | "series:tmdbId" → watchCount
-		const plexWatchCounts = new Map<string, number>();
+		// Build watch count map: "movie:tmdbId" | "series:tmdbId" → watchCount
+		const watchCounts = new Map<string, number>();
 		if (plexInstances.length > 0) {
 			const plexRows = await app.prisma.plexCache.findMany({
 				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
@@ -111,8 +117,17 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			});
 			for (const row of plexRows) {
 				const key = `${row.mediaType}:${row.tmdbId}`;
-				const existing = plexWatchCounts.get(key) ?? 0;
-				plexWatchCounts.set(key, existing + row.watchCount);
+				watchCounts.set(key, (watchCounts.get(key) ?? 0) + row.watchCount);
+			}
+		}
+		if (jellyfinInstances.length > 0) {
+			const jfRows = await app.prisma.jellyfinCache.findMany({
+				where: { instanceId: { in: jellyfinInstances.map((i) => i.id) } },
+				select: { tmdbId: true, mediaType: true, watchCount: true },
+			});
+			for (const row of jfRows) {
+				const key = `${row.mediaType}:${row.tmdbId}`;
+				watchCounts.set(key, (watchCounts.get(key) ?? 0) + row.watchCount);
 			}
 		}
 
@@ -147,7 +162,7 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 
 			// Build Plex lookup key — PlexCache stores "movie" | "series"
 			const mediaType = item.itemType === "movie" ? "movie" : "series";
-			const watchCount = plexWatchCounts.get(`${mediaType}:${tmdbId}`) ?? 0;
+			const watchCount = watchCounts.get(`${mediaType}:${tmdbId}`) ?? 0;
 
 			// Only include items with zero watches
 			if (watchCount > 0) continue;
@@ -179,6 +194,7 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 				items: results,
 				totalWastedBytes,
 				hasPlexData: plexInstances.length > 0,
+				hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
 			},
 		});
 	});
@@ -203,34 +219,56 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		const instanceIds = userInstances.map((i) => i.id);
 
 		if (instanceIds.length === 0) {
-			return reply.send({ success: true, data: { items: [], hasPlexData: false } });
+			return reply.send({ success: true, data: { items: [], hasPlexData: false, hasWatchData: false } });
 		}
 
-		// Get Plex watch data — build map of mediaType:tmdbId → { watchCount, lastWatchedAt }
-		const plexInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "PLEX" },
-			select: { id: true },
-		});
+		// Get media server instances — Plex + Jellyfin/Emby
+		const [plexInstances, jellyfinInstances] = await Promise.all([
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: "PLEX" },
+				select: { id: true },
+			}),
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: { in: ["JELLYFIN", "EMBY"] } },
+				select: { id: true },
+			}),
+		]);
 
-		if (plexInstances.length === 0) {
-			return reply.send({ success: true, data: { items: [], hasPlexData: false } });
+		if (plexInstances.length === 0 && jellyfinInstances.length === 0) {
+			return reply.send({ success: true, data: { items: [], hasPlexData: false, hasWatchData: false } });
 		}
 
-		const plexWatchData = new Map<string, { watchCount: number; lastWatchedAt: Date | null }>();
-		const plexRows = await app.prisma.plexCache.findMany({
-			where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-			select: { tmdbId: true, mediaType: true, watchCount: true, lastWatchedAt: true },
-		});
-		for (const row of plexRows) {
-			const key = `${row.mediaType}:${row.tmdbId}`;
-			const existing = plexWatchData.get(key);
+		// Build watch data map: mediaType:tmdbId → { watchCount, lastWatchedAt }
+		const watchData = new Map<string, { watchCount: number; lastWatchedAt: Date | null }>();
+
+		const mergeWatchRow = (key: string, watchCount: number, lastWatchedAt: Date | null) => {
+			const existing = watchData.get(key);
 			if (existing) {
-				existing.watchCount += row.watchCount;
-				if (row.lastWatchedAt && (!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)) {
-					existing.lastWatchedAt = row.lastWatchedAt;
+				existing.watchCount += watchCount;
+				if (lastWatchedAt && (!existing.lastWatchedAt || lastWatchedAt > existing.lastWatchedAt)) {
+					existing.lastWatchedAt = lastWatchedAt;
 				}
 			} else {
-				plexWatchData.set(key, { watchCount: row.watchCount, lastWatchedAt: row.lastWatchedAt });
+				watchData.set(key, { watchCount, lastWatchedAt });
+			}
+		};
+
+		if (plexInstances.length > 0) {
+			const plexRows = await app.prisma.plexCache.findMany({
+				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
+				select: { tmdbId: true, mediaType: true, watchCount: true, lastWatchedAt: true },
+			});
+			for (const row of plexRows) {
+				mergeWatchRow(`${row.mediaType}:${row.tmdbId}`, row.watchCount, row.lastWatchedAt);
+			}
+		}
+		if (jellyfinInstances.length > 0) {
+			const jfRows = await app.prisma.jellyfinCache.findMany({
+				where: { instanceId: { in: jellyfinInstances.map((i) => i.id) } },
+				select: { tmdbId: true, mediaType: true, watchCount: true, lastWatchedAt: true },
+			});
+			for (const row of jfRows) {
+				mergeWatchRow(`${row.mediaType}:${row.tmdbId}`, row.watchCount, row.lastWatchedAt);
 			}
 		}
 
@@ -245,7 +283,7 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			take: params.limit * 5, // Over-fetch — most monitored items may not be watched
 		});
 
-		// Match with Plex watch data
+		// Match with watch data
 		const results: WatchedMonitoredItem[] = [];
 
 		for (const item of candidates) {
@@ -258,12 +296,11 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			const tmdbId = remoteIds?.tmdbId;
 			if (!tmdbId) continue;
 
-			// PlexCache stores "movie" | "series"
 			const mediaType = item.itemType === "movie" ? "movie" : "series";
-			const plexInfo = plexWatchData.get(`${mediaType}:${tmdbId}`);
+			const watchInfo = watchData.get(`${mediaType}:${tmdbId}`);
 
 			// Only include items that have actually been watched
-			if (!plexInfo || plexInfo.watchCount === 0) continue;
+			if (!watchInfo || watchInfo.watchCount === 0) continue;
 
 			// Skip continuing/upcoming series — they should stay monitored for new episodes
 			if (item.itemType === "series" && item.status && item.status !== "ended") continue;
@@ -278,8 +315,8 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 				title: item.title,
 				year: item.year,
 				sizeOnDisk: Number(item.sizeOnDisk),
-				watchCount: plexInfo.watchCount,
-				lastWatchedAt: plexInfo.lastWatchedAt?.toISOString() ?? null,
+				watchCount: watchInfo.watchCount,
+				lastWatchedAt: watchInfo.lastWatchedAt?.toISOString() ?? null,
 				qualityProfileName: item.qualityProfileName,
 			});
 		}
@@ -289,7 +326,11 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 
 		return reply.send({
 			success: true,
-			data: { items: results, hasPlexData: true },
+			data: {
+				items: results,
+				hasPlexData: plexInstances.length > 0,
+				hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
+			},
 		});
 	});
 
@@ -321,25 +362,40 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		});
 
 		if (!seerrInstance) {
-			return reply.send({ success: true, data: { items: [], hasSeerrData: false, hasPlexData: false } });
+			return reply.send({ success: true, data: { items: [], hasSeerrData: false, hasPlexData: false, hasWatchData: false } });
 		}
 
-		// Get Plex watch data
-		const plexInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "PLEX" },
-			select: { id: true },
-		});
+		// Get media server watch data — Plex + Jellyfin/Emby
+		const [plexInstances, jellyfinInstances] = await Promise.all([
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: "PLEX" },
+				select: { id: true },
+			}),
+			app.prisma.serviceInstance.findMany({
+				where: { userId, service: { in: ["JELLYFIN", "EMBY"] } },
+				select: { id: true },
+			}),
+		]);
 
-		const plexWatchCounts = new Map<string, number>();
+		const watchCounts = new Map<string, number>();
 		if (plexInstances.length > 0) {
 			const plexRows = await app.prisma.plexCache.findMany({
 				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
 				select: { tmdbId: true, mediaType: true, watchCount: true },
 			});
 			for (const row of plexRows) {
-				// PlexCache stores "movie" | "series"
 				const key = `${row.mediaType}:${row.tmdbId}`;
-				plexWatchCounts.set(key, (plexWatchCounts.get(key) ?? 0) + row.watchCount);
+				watchCounts.set(key, (watchCounts.get(key) ?? 0) + row.watchCount);
+			}
+		}
+		if (jellyfinInstances.length > 0) {
+			const jfRows = await app.prisma.jellyfinCache.findMany({
+				where: { instanceId: { in: jellyfinInstances.map((i) => i.id) } },
+				select: { tmdbId: true, mediaType: true, watchCount: true },
+			});
+			for (const row of jfRows) {
+				const key = `${row.mediaType}:${row.tmdbId}`;
+				watchCounts.set(key, (watchCounts.get(key) ?? 0) + row.watchCount);
 			}
 		}
 
@@ -377,14 +433,14 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			);
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: false, hasPlexData: plexInstances.length > 0 },
+				data: { items: [], hasSeerrData: false, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
 			});
 		}
 
 		if (seerrRequests.length === 0) {
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0 },
+				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
 			});
 		}
 
@@ -408,7 +464,7 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		if (instanceIds.length === 0) {
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0 },
+				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
 			});
 		}
 
@@ -443,9 +499,8 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			const seerrInfo = seerrMap.get(`${seerrMediaType}:${tmdbId}`);
 			if (!seerrInfo) continue; // Not a Seerr-requested item
 
-			// Plex uses "movie" | "series" for keys
-			const plexMediaType = item.itemType === "movie" ? "movie" : "series";
-			const watchCount = plexWatchCounts.get(`${plexMediaType}:${tmdbId}`) ?? 0;
+			const mediaType = item.itemType === "movie" ? "movie" : "series";
+			const watchCount = watchCounts.get(`${mediaType}:${tmdbId}`) ?? 0;
 			if (watchCount > 0) continue; // Has been watched — not a candidate
 
 			const inst = instanceMap.get(item.instanceId);
@@ -473,6 +528,7 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 				items: results,
 				hasSeerrData: true,
 				hasPlexData: plexInstances.length > 0,
+				hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
 			},
 		});
 	});

--- a/apps/web/src/features/discover/components/media-detail-sections.tsx
+++ b/apps/web/src/features/discover/components/media-detail-sections.tsx
@@ -232,6 +232,7 @@ interface ExternalLinksSectionProps {
 	tvdbId?: number | string | null;
 	mediaType: "movie" | "tv";
 	plexUrl?: string | null;
+	mediaServerLabel?: string;
 }
 
 /**
@@ -245,10 +246,12 @@ export const ExternalLinksSection: React.FC<ExternalLinksSectionProps> = ({
 	tvdbId,
 	mediaType,
 	plexUrl,
+	mediaServerLabel,
 }) => {
 	const { gradient: themeGradient } = useThemeGradient();
 
 	if (!tmdbId && !imdbId && !tvdbId && !plexUrl) return null;
+	const watchLabel = mediaServerLabel ?? "Plex";
 
 	const btnClass =
 		"inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-medium transition-colors hover:opacity-80";
@@ -304,21 +307,28 @@ export const ExternalLinksSection: React.FC<ExternalLinksSectionProps> = ({
 						TVDB
 					</button>
 				)}
-				{plexUrl && (
-					<button
-						type="button"
-						className={btnClass}
-						style={{
-							backgroundColor: "rgba(229, 160, 13, 0.1)",
-							border: "1px solid rgba(229, 160, 13, 0.3)",
-							color: "#e5a00d",
-						}}
-						onClick={() => safeOpenUrl(plexUrl)}
-					>
-						<ExternalLink className="h-3.5 w-3.5" />
-						Watch in Plex
-					</button>
-				)}
+				{plexUrl && (() => {
+					const watchColors = watchLabel === "Jellyfin"
+						? { bg: "rgba(0, 164, 220, 0.1)", border: "rgba(0, 164, 220, 0.3)", text: "#00a4dc" }
+						: watchLabel === "Emby"
+							? { bg: "rgba(82, 181, 75, 0.1)", border: "rgba(82, 181, 75, 0.3)", text: "#52b54b" }
+							: { bg: "rgba(229, 160, 13, 0.1)", border: "rgba(229, 160, 13, 0.3)", text: "#e5a00d" };
+					return (
+						<button
+							type="button"
+							className={btnClass}
+							style={{
+								backgroundColor: watchColors.bg,
+								border: `1px solid ${watchColors.border}`,
+								color: watchColors.text,
+							}}
+							onClick={() => safeOpenUrl(plexUrl)}
+						>
+							<ExternalLink className="h-3.5 w-3.5" />
+							Watch in {watchLabel}
+						</button>
+					);
+				})()}
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/library/components/disk-waste-panel.tsx
+++ b/apps/web/src/features/library/components/disk-waste-panel.tsx
@@ -59,7 +59,7 @@ export function DiskWastePanel({
 		? allItems.filter((i) => !isDismissed(i.instanceId, i.arrItemId))
 		: allItems;
 	const totalWasted = items.reduce((sum, r) => sum + r.sizeOnDisk, 0);
-	const hasPlexData = data?.data?.hasPlexData ?? false;
+	const hasWatchData = data?.data?.hasWatchData ?? data?.data?.hasPlexData ?? false;
 
 	const handleUnmonitor = async (item: DiskWasteItem) => {
 		if (!item.monitored) return;
@@ -80,8 +80,8 @@ export function DiskWastePanel({
 		}
 	};
 
-	// Don't render if no items or still loading
-	if (isLoading || items.length === 0) return null;
+	// Don't render if no items, still loading, or no watch server connected
+	if (isLoading || items.length === 0 || !hasWatchData) return null;
 
 	return (
 		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
@@ -105,8 +105,8 @@ export function DiskWastePanel({
 							{items.length} unwatched item{items.length !== 1 ? "s" : ""} using{" "}
 							{formatSize(totalWasted)}
 						</span>
-						{!hasPlexData && (
-							<span className="text-xs text-muted-foreground ml-2">(no Plex connected)</span>
+						{!hasWatchData && (
+							<span className="text-xs text-muted-foreground ml-2">(no media server connected)</span>
 						)}
 					</div>
 				</div>
@@ -122,7 +122,7 @@ export function DiskWastePanel({
 			{expanded && (
 				<div className="border-t border-border/20 px-4 py-3 space-y-2">
 					<p className="text-xs text-muted-foreground mb-3">
-						Largest library items ({">"}1 GB) added over 30 days ago with zero Plex plays. Sorted by size.
+						Largest library items ({">"}1 GB) added over 30 days ago that have never been watched. Sorted by size.
 					</p>
 					{items.map((item) => (
 						<DiskWasteRow

--- a/apps/web/src/features/library/components/enriched-detail-modal.tsx
+++ b/apps/web/src/features/library/components/enriched-detail-modal.tsx
@@ -84,8 +84,10 @@ export interface EnrichedDetailModalProps {
 	} | null;
 	/** Plex user rating (0-10 scale, null if not rated) */
 	userRating?: number | null;
-	/** Plex deep link URL for "Watch in Plex" */
+	/** Media server deep link URL */
 	plexUrl?: string | null;
+	/** Label for the media server link (e.g., "Plex", "Jellyfin", "Emby") */
+	mediaServerLabel?: string;
 }
 
 export const EnrichedDetailModal: React.FC<EnrichedDetailModalProps> = ({
@@ -99,6 +101,7 @@ export const EnrichedDetailModal: React.FC<EnrichedDetailModalProps> = ({
 	plexData,
 	userRating,
 	plexUrl,
+	mediaServerLabel,
 }) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const focusTrapRef = useFocusTrap<HTMLDivElement>(true, onClose);
@@ -385,7 +388,7 @@ export const EnrichedDetailModal: React.FC<EnrichedDetailModalProps> = ({
 									<span className="text-sm font-semibold" style={{ color: RATING_COLOR }}>
 										{userRating.toFixed(1)}
 									</span>
-									<span className="text-xs text-muted-foreground">Your Plex Rating</span>
+									<span className="text-xs text-muted-foreground">Your Rating</span>
 								</div>
 							)}
 
@@ -1012,6 +1015,7 @@ export const EnrichedDetailModal: React.FC<EnrichedDetailModalProps> = ({
 						tvdbId={item.remoteIds?.tvdbId}
 						mediaType={isMovie ? "movie" : "tv"}
 						plexUrl={plexUrl}
+						mediaServerLabel={mediaServerLabel}
 					/>
 
 					{/* Recommendations */}

--- a/apps/web/src/features/library/components/library-card.tsx
+++ b/apps/web/src/features/library/components/library-card.tsx
@@ -102,8 +102,10 @@ interface LibraryCardProps {
 	plexUserRating?: number | null;
 	/** Plex watch progress for series (watched/total episodes) */
 	seriesProgress?: { watched: number; total: number; percent: number } | null;
-	/** Plex deep link URL for "Watch in Plex" */
+	/** Media server deep link URL */
 	plexUrl?: string | null;
+	/** Label for the media server link (e.g., "Plex", "Jellyfin", "Emby") */
+	mediaServerLabel?: string;
 }
 
 /**
@@ -153,6 +155,7 @@ export const LibraryCard = memo(function LibraryCard({
 	plexUserRating,
 	seriesProgress,
 	plexUrl,
+	mediaServerLabel,
 }: LibraryCardProps) {
 	const [incognitoMode] = useIncognitoMode();
 	const monitored = item.monitored ?? false;
@@ -372,7 +375,7 @@ export const LibraryCard = memo(function LibraryCard({
 	}
 	if (plexUrl) {
 		externalLinks.push({
-			label: "Plex",
+			label: mediaServerLabel ?? "Plex",
 			onClick: () => safeOpenUrl(plexUrl),
 		});
 	}
@@ -534,7 +537,7 @@ export const LibraryCard = memo(function LibraryCard({
 										border: "1px solid rgba(251, 191, 36, 0.3)",
 										color: RATING_COLOR,
 									}}
-									title="Your Plex Rating"
+									title="Your Rating"
 								>
 									<Star className="h-3 w-3 fill-current" />
 									{plexUserRating.toFixed(1)}

--- a/apps/web/src/features/library/components/library-client.tsx
+++ b/apps/web/src/features/library/components/library-client.tsx
@@ -5,12 +5,13 @@ import { useSearchParams } from "next/navigation";
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "../../../components/ui";
 import { useLibraryMonitorMutation } from "../../../hooks/api/useLibrary";
+import { useJellyfinIdentity, useJellyfinSeriesProgress, useJellyfinWatchEnrichment } from "../../../hooks/api/useJellyfin";
 import { usePlexIdentity, useSeriesProgress, useWatchEnrichment } from "../../../hooks/api/usePlex";
 import { useLibraryEnrichment } from "../../../hooks/api/useSeerr";
 import { fetchLibraryItemByTmdbId } from "../../../lib/api-client/library";
 import { useSeerrInstances } from "../../seerr/hooks/use-seerr-instances";
 import { useLibraryActions, useLibraryData, useLibraryFilters } from "../hooks";
-import { buildLibraryExternalLink, buildPlexUrl } from "../lib/library-utils";
+import { buildJellyfinUrl, buildLibraryExternalLink, buildPlexUrl } from "../lib/library-utils";
 import { AlbumBreakdownModal } from "./album-breakdown-modal";
 import { BookBreakdownModal } from "./book-breakdown-modal";
 import { ItemDetailsModal } from "./item-details-modal";
@@ -82,9 +83,16 @@ export const LibraryClient: React.FC = () => {
 	const enrichmentQuery = useLibraryEnrichment(seerrInstanceId, data.items);
 	const enrichmentMap = enrichmentQuery.data?.items ?? null;
 
-	// Plex watch enrichment — fetch watch counts, on-deck status, last watched
-	const watchEnrichmentQuery = useWatchEnrichment(data.items);
-	const watchEnrichmentMap = watchEnrichmentQuery.data?.items ?? null;
+	// Watch enrichment — fetch watch counts, on-deck status, last watched from Plex + Jellyfin/Emby
+	const plexWatchQuery = useWatchEnrichment(data.items);
+	const jellyfinWatchQuery = useJellyfinWatchEnrichment(data.items);
+	const watchEnrichmentMap = useMemo(() => {
+		const plexItems = plexWatchQuery.data?.items;
+		const jfItems = jellyfinWatchQuery.data?.items;
+		if (!plexItems && !jfItems) return null;
+		// Jellyfin first, Plex on top — Plex wins on conflicts (has ratingKey + labels)
+		return { ...jfItems, ...plexItems };
+	}, [plexWatchQuery.data, jellyfinWatchQuery.data]);
 
 	// Plex identity — needed to build "Watch in Plex" deep links
 	const plexIdentityQuery = usePlexIdentity();
@@ -98,7 +106,23 @@ export const LibraryClient: React.FC = () => {
 		return map;
 	}, [plexIdentityQuery.data]);
 
-	// Plex series progress — fetch watched/total episode counts for series items
+	// Jellyfin/Emby identity — needed to build "Watch in Jellyfin/Emby" deep links
+	const jellyfinIdentityQuery = useJellyfinIdentity();
+	const jellyfinServerMap = useMemo(() => {
+		const map = new Map<string, { baseUrl: string; service: "jellyfin" | "emby"; serverId: string }>();
+		if (jellyfinIdentityQuery.data) {
+			for (const server of jellyfinIdentityQuery.data) {
+				map.set(server.instanceId, {
+					baseUrl: server.baseUrl,
+					service: server.service,
+					serverId: server.serverId,
+				});
+			}
+		}
+		return map;
+	}, [jellyfinIdentityQuery.data]);
+
+	// Series progress — fetch watched/total episode counts from Plex + Jellyfin/Emby
 	const seriesTmdbIds = useMemo(
 		() =>
 			data.items
@@ -106,8 +130,14 @@ export const LibraryClient: React.FC = () => {
 				.map((item) => item.remoteIds!.tmdbId!),
 		[data.items],
 	);
-	const seriesProgressQuery = useSeriesProgress(seriesTmdbIds);
-	const seriesProgressMap = seriesProgressQuery.data?.progress ?? null;
+	const plexProgressQuery = useSeriesProgress(seriesTmdbIds);
+	const jellyfinProgressQuery = useJellyfinSeriesProgress(seriesTmdbIds);
+	const seriesProgressMap = useMemo(() => {
+		const plexProgress = plexProgressQuery.data?.progress;
+		const jfProgress = jellyfinProgressQuery.data?.progress;
+		if (!plexProgress && !jfProgress) return null;
+		return { ...jfProgress, ...plexProgress };
+	}, [plexProgressQuery.data, jellyfinProgressQuery.data]);
 
 	// Notify user if Seerr enrichment fails (one-time per error transition)
 	useEffect(() => {
@@ -201,16 +231,24 @@ export const LibraryClient: React.FC = () => {
 		[monitorMutation],
 	);
 
-	// Compute Plex URL for the detail modal item
-	const modalPlexUrl = useMemo(() => {
+	// Compute media server deep link URL for the detail modal item (Plex or Jellyfin/Emby)
+	const modalMediaServerUrl = useMemo(() => {
 		if (!itemDetail || !watchEnrichmentMap || !itemDetail.remoteIds?.tmdbId) return undefined;
 		const key = `${itemDetail.type === "movie" ? "movie" : "series"}:${itemDetail.remoteIds.tmdbId}`;
 		const wd = watchEnrichmentMap[key];
-		if (!wd?.ratingKey || !wd.instanceId) return undefined;
-		const machineId = plexMachineIdMap.get(wd.instanceId);
-		if (!machineId) return undefined;
-		return buildPlexUrl(machineId, wd.ratingKey);
-	}, [itemDetail, watchEnrichmentMap, plexMachineIdMap]);
+		if (!wd?.instanceId) return undefined;
+		// Try Plex first
+		if (wd.ratingKey) {
+			const machineId = plexMachineIdMap.get(wd.instanceId);
+			if (machineId) return buildPlexUrl(machineId, wd.ratingKey);
+		}
+		// Try Jellyfin/Emby
+		if (wd.jellyfinId) {
+			const jfServer = jellyfinServerMap.get(wd.instanceId);
+			if (jfServer) return buildJellyfinUrl(jfServer.baseUrl, wd.jellyfinId, jfServer.service, jfServer.serverId);
+		}
+		return undefined;
+	}, [itemDetail, watchEnrichmentMap, plexMachineIdMap, jellyfinServerMap]);
 
 	return (
 		<>
@@ -274,6 +312,7 @@ export const LibraryClient: React.FC = () => {
 					watchEnrichmentMap={watchEnrichmentMap}
 					seriesProgressMap={seriesProgressMap}
 					plexMachineIdMap={plexMachineIdMap}
+					jellyfinServerMap={jellyfinServerMap}
 				/>
 			</div>
 
@@ -314,7 +353,18 @@ export const LibraryClient: React.FC = () => {
 										]?.userRating
 									: undefined
 							}
-							plexUrl={modalPlexUrl}
+							plexUrl={modalMediaServerUrl}
+							mediaServerLabel={(() => {
+								if (!itemDetail?.remoteIds?.tmdbId || !watchEnrichmentMap) return undefined;
+								const key = `${itemDetail.type === "movie" ? "movie" : "series"}:${itemDetail.remoteIds.tmdbId}`;
+								const wd = watchEnrichmentMap[key];
+								if (!wd?.instanceId) return undefined;
+								if (jellyfinServerMap.has(wd.instanceId)) {
+									const jf = jellyfinServerMap.get(wd.instanceId)!;
+									return jf.service === "emby" ? "Emby" : "Jellyfin";
+								}
+								return "Plex";
+							})()}
 						/>
 					</Suspense>
 				) : (

--- a/apps/web/src/features/library/components/library-content.tsx
+++ b/apps/web/src/features/library/components/library-content.tsx
@@ -10,7 +10,7 @@ import type {
 import { Library as LibraryIcon } from "lucide-react";
 import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
 import { Pagination } from "../../../components/ui";
-import { buildPlexUrl } from "../lib/library-utils";
+import { buildJellyfinUrl, buildPlexUrl } from "../lib/library-utils";
 
 /**
  * Props for LibraryCard component (passthrough)
@@ -41,6 +41,8 @@ interface LibraryCardProps {
 	plexUserRating?: number | null;
 	seriesProgress?: { watched: number; total: number; percent: number } | null;
 	plexUrl?: string | null;
+	/** Label for the media server link (e.g., "Plex", "Jellyfin", "Emby") */
+	mediaServerLabel?: string;
 }
 
 /**
@@ -108,12 +110,14 @@ interface LibraryContentProps {
 	isSyncing?: boolean;
 	/** Seerr enrichment map keyed by "movie:{tmdbId}" or "tv:{tmdbId}" */
 	enrichmentMap?: Record<string, LibraryEnrichmentItem> | null;
-	/** Plex watch enrichment map keyed by "movie:{tmdbId}" or "series:{tmdbId}" */
+	/** Watch enrichment map keyed by "movie:{tmdbId}" or "series:{tmdbId}" (merged from Plex + Jellyfin/Emby) */
 	watchEnrichmentMap?: Record<string, WatchEnrichmentItem> | null;
-	/** Plex series progress map keyed by TMDB ID */
+	/** Series progress map keyed by TMDB ID (merged from Plex + Jellyfin/Emby) */
 	seriesProgressMap?: Record<number, SeriesProgressItem> | null;
 	/** Map of Plex instanceId → machineId for building deep links */
 	plexMachineIdMap?: Map<string, string>;
+	/** Map of Jellyfin/Emby instanceId → server info for building deep links */
+	jellyfinServerMap?: Map<string, { baseUrl: string; service: "jellyfin" | "emby"; serverId: string }>;
 }
 
 /**
@@ -158,6 +162,7 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 	watchEnrichmentMap,
 	seriesProgressMap,
 	plexMachineIdMap,
+	jellyfinServerMap,
 }) => {
 	/** Lookup enrichment for a library item by its tmdbId + type */
 	const getEnrichment = (item: LibraryItem) => {
@@ -173,14 +178,35 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 		return watchEnrichmentMap[key];
 	};
 
-	/** Build a Plex deep link URL for a library item (if Plex data available) */
-	const getPlexUrl = (item: LibraryItem): string | null => {
-		if (!plexMachineIdMap || plexMachineIdMap.size === 0) return null;
+	/** Build a media server deep link URL for a library item (Plex or Jellyfin/Emby) */
+	const getMediaServerUrl = (item: LibraryItem): string | null => {
 		const watchData = getWatchEnrichment(item);
-		if (!watchData?.ratingKey || !watchData.instanceId) return null;
-		const machineId = plexMachineIdMap.get(watchData.instanceId);
-		if (!machineId) return null;
-		return buildPlexUrl(machineId, watchData.ratingKey);
+		if (!watchData?.instanceId) return null;
+		// Try Plex
+		if (watchData.ratingKey && plexMachineIdMap && plexMachineIdMap.size > 0) {
+			const machineId = plexMachineIdMap.get(watchData.instanceId);
+			if (machineId) return buildPlexUrl(machineId, watchData.ratingKey);
+		}
+		// Try Jellyfin/Emby
+		if (watchData.jellyfinId && jellyfinServerMap && jellyfinServerMap.size > 0) {
+			const jfServer = jellyfinServerMap.get(watchData.instanceId);
+			if (jfServer) return buildJellyfinUrl(jfServer.baseUrl, watchData.jellyfinId, jfServer.service, jfServer.serverId);
+		}
+		return null;
+	};
+
+	/** Get the media server label for a library item's watch source */
+	const getMediaServerLabel = (item: LibraryItem): string | undefined => {
+		const watchData = getWatchEnrichment(item);
+		if (!watchData?.instanceId) return undefined;
+		// Check Jellyfin/Emby first (distinguish by service type)
+		if (jellyfinServerMap && jellyfinServerMap.has(watchData.instanceId)) {
+			const jf = jellyfinServerMap.get(watchData.instanceId)!;
+			return jf.service === "emby" ? "Emby" : "Jellyfin";
+		}
+		// Plex
+		if (plexMachineIdMap && plexMachineIdMap.has(watchData.instanceId)) return "Plex";
+		return undefined;
 	};
 
 	/** Lookup Plex series progress for a library item */
@@ -276,7 +302,8 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 								watchedByUsers={watchData?.watchedByUsers}
 								plexUserRating={watchData?.userRating}
 								seriesProgress={getSeriesProgress(item)}
-								plexUrl={getPlexUrl(item)}
+								plexUrl={getMediaServerUrl(item)}
+								mediaServerLabel={getMediaServerLabel(item)}
 							/>
 						);
 					})}
@@ -311,7 +338,8 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 											watchedByUsers={watchData?.watchedByUsers}
 											plexUserRating={watchData?.userRating}
 											seriesProgress={getSeriesProgress(item)}
-											plexUrl={getPlexUrl(item)}
+											plexUrl={getMediaServerUrl(item)}
+											mediaServerLabel={getMediaServerLabel(item)}
 										/>
 									);
 								})}
@@ -347,7 +375,8 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 											watchedByUsers={watchData?.watchedByUsers}
 											plexUserRating={watchData?.userRating}
 											seriesProgress={getSeriesProgress(item)}
-											plexUrl={getPlexUrl(item)}
+											plexUrl={getMediaServerUrl(item)}
+											mediaServerLabel={getMediaServerLabel(item)}
 										/>
 									);
 								})}
@@ -384,7 +413,8 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 											watchedByUsers={watchData?.watchedByUsers}
 											plexUserRating={watchData?.userRating}
 											seriesProgress={getSeriesProgress(item)}
-											plexUrl={getPlexUrl(item)}
+											plexUrl={getMediaServerUrl(item)}
+											mediaServerLabel={getMediaServerLabel(item)}
 										/>
 									);
 								})}
@@ -421,7 +451,8 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 											watchedByUsers={watchData?.watchedByUsers}
 											plexUserRating={watchData?.userRating}
 											seriesProgress={getSeriesProgress(item)}
-											plexUrl={getPlexUrl(item)}
+											plexUrl={getMediaServerUrl(item)}
+											mediaServerLabel={getMediaServerLabel(item)}
 										/>
 									);
 								})}

--- a/apps/web/src/features/library/components/library-insights-section.tsx
+++ b/apps/web/src/features/library/components/library-insights-section.tsx
@@ -30,22 +30,22 @@ export function LibraryInsightsSection() {
 	const diskWasteCount = diskWaste.data?.data?.items?.length ?? 0;
 	const watchedMonitoredCount = watchedMonitored.data?.data?.items?.length ?? 0;
 	const requestedUnwatchedCount = requestedUnwatched.data?.data?.items?.length ?? 0;
-	const hasPlexData = watchedMonitored.data?.data?.hasPlexData ?? false;
+	const hasWatchData = watchedMonitored.data?.data?.hasWatchData ?? watchedMonitored.data?.data?.hasPlexData ?? false;
 	const hasSeerrData = requestedUnwatched.data?.data?.hasSeerrData ?? false;
-	const hasRequestedPlexData = requestedUnwatched.data?.data?.hasPlexData ?? false;
+	const hasRequestedWatchData = requestedUnwatched.data?.data?.hasWatchData ?? requestedUnwatched.data?.data?.hasPlexData ?? false;
 	const isLoading = diskWaste.isLoading || watchedMonitored.isLoading || requestedUnwatched.isLoading;
 
 	// Don't render the section if all panels are empty and done loading
 	const hasContent =
 		diskWasteCount > 0 ||
-		(watchedMonitoredCount > 0 && hasPlexData) ||
-		(requestedUnwatchedCount > 0 && hasSeerrData && hasRequestedPlexData);
+		(watchedMonitoredCount > 0 && hasWatchData) ||
+		(requestedUnwatchedCount > 0 && hasSeerrData && hasRequestedWatchData);
 	if (!isLoading && !hasContent) return null;
 	if (isLoading) return null; // Don't flash the heading before data arrives
 
 	// Effective counts — only count signals where the required services are configured
-	const effectiveWatchedCount = hasPlexData ? watchedMonitoredCount : 0;
-	const effectiveRequestedCount = hasSeerrData && hasRequestedPlexData ? requestedUnwatchedCount : 0;
+	const effectiveWatchedCount = hasWatchData ? watchedMonitoredCount : 0;
+	const effectiveRequestedCount = hasSeerrData && hasRequestedWatchData ? requestedUnwatchedCount : 0;
 	const totalCount = diskWasteCount + effectiveWatchedCount + effectiveRequestedCount;
 
 	// Build breakdown segments (only non-zero)

--- a/apps/web/src/features/library/components/requested-unwatched-panel.tsx
+++ b/apps/web/src/features/library/components/requested-unwatched-panel.tsx
@@ -47,9 +47,9 @@ export function RequestedUnwatchedPanel({
 		? allItems.filter((i) => !isDismissed(i.instanceId, i.arrItemId))
 		: allItems;
 	const hasSeerrData = data?.data?.hasSeerrData ?? false;
-	const hasPlexData = data?.data?.hasPlexData ?? false;
+	const hasWatchData = data?.data?.hasWatchData ?? data?.data?.hasPlexData ?? false;
 
-	if (isLoading || items.length === 0 || !hasSeerrData || !hasPlexData) return null;
+	if (isLoading || items.length === 0 || !hasSeerrData || !hasWatchData) return null;
 
 	return (
 		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
@@ -82,7 +82,7 @@ export function RequestedUnwatchedPanel({
 			{expanded && (
 				<div className="border-t border-border/20 px-4 py-3 space-y-2">
 					<p className="text-xs text-muted-foreground mb-3">
-						Items requested via Seerr that are available but have zero Plex plays after 7+ days.
+						Items requested via Seerr that are available but have never been watched after 7+ days.
 					</p>
 					{items.map((item) => (
 						<RequestedRow

--- a/apps/web/src/features/library/components/watched-monitored-panel.tsx
+++ b/apps/web/src/features/library/components/watched-monitored-panel.tsx
@@ -68,9 +68,9 @@ export function WatchedMonitoredPanel({
 	const items = isDismissed
 		? allItems.filter((i) => !isDismissed(i.instanceId, i.arrItemId))
 		: allItems;
-	const hasPlexData = data?.data?.hasPlexData ?? false;
+	const hasWatchData = data?.data?.hasWatchData ?? data?.data?.hasPlexData ?? false;
 
-	if (isLoading || items.length === 0 || !hasPlexData) return null;
+	if (isLoading || items.length === 0 || !hasWatchData) return null;
 
 	return (
 		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
@@ -103,7 +103,7 @@ export function WatchedMonitoredPanel({
 			{expanded && (
 				<div className="border-t border-border/20 px-4 py-3 space-y-2">
 					<p className="text-xs text-muted-foreground mb-3">
-						Movies and ended series with Plex plays that are still monitored. Continuing series are excluded. Sorted by watch count.
+						Movies and ended series with watch history that are still monitored. Continuing series are excluded. Sorted by watch count.
 					</p>
 					{items.map((item) => (
 						<WatchedRow

--- a/apps/web/src/features/library/lib/library-utils.ts
+++ b/apps/web/src/features/library/lib/library-utils.ts
@@ -88,3 +88,21 @@ export const buildPlexUrl = (machineId: string, ratingKey: string): string => {
 	return `https://app.plex.tv/desktop/#!/server/${machineId}/details?key=${encodeURIComponent(`/library/metadata/${ratingKey}`)}`;
 };
 
+/**
+ * Build a Jellyfin or Emby deep link URL for opening an item in the web UI.
+ * Jellyfin: {baseUrl}/web/#/details?id={jellyfinId}
+ * Emby:     {baseUrl}/web/index.html#!/item?id={jellyfinId}&serverId={serverId}
+ */
+export const buildJellyfinUrl = (
+	baseUrl: string,
+	jellyfinId: string,
+	service: "jellyfin" | "emby",
+	serverId?: string,
+): string => {
+	const base = normalizeBaseUrl(baseUrl);
+	if (service === "emby" && serverId) {
+		return `${base}/web/index.html#!/item?id=${encodeURIComponent(jellyfinId)}&serverId=${encodeURIComponent(serverId)}`;
+	}
+	return `${base}/web/#/details?id=${encodeURIComponent(jellyfinId)}`;
+};
+

--- a/apps/web/src/hooks/api/useDiskWasteInsights.ts
+++ b/apps/web/src/hooks/api/useDiskWasteInsights.ts
@@ -20,6 +20,7 @@ interface DiskWasteResponse {
 		items: DiskWasteItem[];
 		totalWastedBytes: number;
 		hasPlexData: boolean;
+		hasWatchData: boolean;
 	};
 }
 

--- a/apps/web/src/hooks/api/useRequestedUnwatchedInsights.ts
+++ b/apps/web/src/hooks/api/useRequestedUnwatchedInsights.ts
@@ -20,6 +20,7 @@ interface RequestedUnwatchedResponse {
 		items: RequestedUnwatchedItem[];
 		hasSeerrData: boolean;
 		hasPlexData: boolean;
+		hasWatchData: boolean;
 	};
 }
 

--- a/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
+++ b/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
@@ -19,6 +19,7 @@ interface WatchedMonitoredResponse {
 	data: {
 		items: WatchedMonitoredItem[];
 		hasPlexData: boolean;
+		hasWatchData: boolean;
 	};
 }
 

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -33,6 +33,8 @@ export interface JellyfinServerIdentity {
 	version: string;
 	serverName: string;
 	operatingSystem: string;
+	baseUrl: string;
+	service: "jellyfin" | "emby";
 }
 
 /** Identity route returns a flat array (not wrapped in { servers }) */

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -14,12 +14,14 @@ export interface WatchEnrichmentItem {
 	watchedByUsers: string[];
 	onDeck: boolean;
 	userRating: number | null;
-	source: "plex" | "tautulli" | "both";
+	source: "plex" | "tautulli" | "both" | "jellyfin";
 	/** Plex ratingKey for write-back operations (null if not available) */
 	ratingKey: string | null;
-	/** Instance ID of the Plex instance this item belongs to */
+	/** Jellyfin/Emby item ID for deep links (null if source is Plex) */
+	jellyfinId?: string | null;
+	/** Instance ID of the media server instance this item belongs to */
 	instanceId: string | null;
-	/** Plex collections this item belongs to */
+	/** Collections this item belongs to */
 	collections: string[];
 	/** Plex labels applied to this item */
 	labels: string[];


### PR DESCRIPTION
## Summary

Library watch enrichment, series progress, and the three insights panels (Disk Waste, Watched+Monitored, Requested+Unwatched) now pull watch history from both Plex and Jellyfin/Emby. Users who only have Jellyfin or Emby configured will now see accurate watch signals in their library — previously these panels were Plex-exclusive.

## Watch enrichment across media servers

**Unified watch map (backend)**
Both \`PlexCache\` and \`JellyfinCache\` are queried in parallel and merged into a single \`mediaType:tmdbId → { watchCount, lastWatchedAt }\` map via a shared \`mergeWatchRow\` helper. Plex and Jellyfin play counts are additive (e.g., watched once on each server = 2 plays). The \`lastWatchedAt\` always reflects the most recent timestamp across all servers.

**Client-side merge**
\`library-client.tsx\` fetches Plex and Jellyfin watch enrichment in parallel, then merges the result maps with Plex taking priority on key conflicts (Plex carries \`ratingKey\` + labels that Jellyfin can't provide).

**Jellyfin/Emby deep links**
\`buildJellyfinUrl()\` builds correct deep links for both services:
- Jellyfin: \`{baseUrl}/web/#/details?id={jellyfinId}\`
- Emby: \`{baseUrl}/web/index.html#!/item?id={jellyfinId}&serverId={serverId}\`

Deep link resolution in card/modal uses a priority chain: Plex → Jellyfin → Emby.

**Service-branded UI**
The "Watch in …" button in \`ExternalLinksSection\` adopts the correct brand color per service — Plex gold, Jellyfin teal (#00a4dc), Emby green (#52b54b). The \`mediaServerLabel\` prop propagates from \`library-client\` → \`library-content\` → \`library-card\` / \`enriched-detail-modal\`.

## Insights panels

All three panels are updated to use \`hasWatchData\` (true if any Plex or Jellyfin/Emby instance is configured) instead of \`hasPlexData\`:

- **Disk Waste** — previously missing the \`hasWatchData\` guard; a Sonarr-only user could see "unwatched" items that were unverifiable. Fixed.
- **Watched+Monitored** and **Requested+Unwatched** — guard logic was already correct; updated to read from the broader \`hasWatchData\` flag and use media-server-neutral copy.

Panel copy updated throughout: "zero Plex plays" → "never been watched", "no Plex connected" → "no media server connected".

## Identity route

\`GET /api/jellyfin/identity\` now returns \`baseUrl\` and \`service\` (\`"jellyfin"\` | \`"emby"\`) per instance, so the frontend can build deep links without a separate lookup.

## Files changed

- \`apps/api/src/routes/jellyfin/identity-routes.ts\` — expose \`baseUrl\` + \`service\` on identity response
- \`apps/api/src/routes/library/insights-routes.ts\` — merge Plex + Jellyfin watch data in all three insight routes; return \`hasWatchData\`
- \`apps/web/src/features/library/components/library-client.tsx\` — merge watch enrichment and series progress from both servers; build \`jellyfinServerMap\`
- \`apps/web/src/features/library/components/library-content.tsx\` — \`getMediaServerUrl\` + \`getMediaServerLabel\` helpers; pass \`jellyfinServerMap\`
- \`apps/web/src/features/library/components/library-card.tsx\` — dynamic label + generic "Your Rating" copy
- \`apps/web/src/features/library/components/enriched-detail-modal.tsx\` — \`mediaServerLabel\` prop
- \`apps/web/src/features/library/lib/library-utils.ts\` — \`buildJellyfinUrl()\` for Jellyfin + Emby URL formats
- \`apps/web/src/features/discover/components/media-detail-sections.tsx\` — service-branded watch button colors
- \`apps/web/src/features/library/components/disk-waste-panel.tsx\` — add missing \`!hasWatchData\` render guard
- \`apps/web/src/features/library/components/watched-monitored-panel.tsx\` — use \`hasWatchData\`; neutral copy
- \`apps/web/src/features/library/components/requested-unwatched-panel.tsx\` — use \`hasWatchData\`; neutral copy
- \`apps/web/src/features/library/components/library-insights-section.tsx\` — use \`hasWatchData\`
- \`apps/web/src/hooks/api/use{DiskWaste,WatchedMonitored,RequestedUnwatched}Insights.ts\` — add \`hasWatchData\` to response type
- \`apps/web/src/lib/api-client/jellyfin.ts\` — add \`baseUrl\` + \`service\` to \`JellyfinServerIdentity\`
- \`packages/shared/src/types/plex.ts\` — add \`"jellyfin"\` to \`WatchEnrichmentItem.source\`; add \`jellyfinId\` field

## Test plan

All items verified via Playwright CLI against live app (DB backup/restore used for isolated scenarios).

- [x] TypeScript: \`tsc --noEmit\` passes on both \`@arr/api\` and \`@arr/web\`
- [x] With Plex+Jellyfin configured: all three insight routes return \`hasWatchData=true\` and \`hasPlexData=true\`
- [x] \`hasPlexData\` backward-compat preserved alongside new \`hasWatchData\` field
- [x] With only Jellyfin configured (Plex removed via DB backup test): \`hasWatchData=true\`, \`hasPlexData=false\` across all three routes
- [x] Jellyfin watch-enrichment returns correct \`jellyfinId\` per item (verified: \`eb4af75b…\` for tmdbId=550, source="jellyfin")
- [x] No "Watch in Plex" text appears when Plex is not configured
- [x] Jellyfin deep link URL format correct: \`/web/#/details?id={jellyfinId}\` (verified: \`buildJellyfinUrl\` in \`library-utils.ts\`)
- [x] Emby deep link URL format correct: \`/web/index.html#!/item?id=&serverId=\` (verified: same function, service branch)
- [x] Sonarr-only / no media server: all three panels hidden — all three guards include \`!hasWatchData\`
- [x] "Your Plex Rating" string removed — generic "Your Rating" confirmed absent via live page scan
- [x] Incognito coverage: all panels use \`useIncognitoMode()\` + correct anonymizers (trust audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)