### PR TITLE
fix: use externalUrl for dashboard queue instance links (#297)

### DIFF
--- a/apps/web/src/features/dashboard/components/dashboard-client.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-client.tsx
@@ -390,11 +390,11 @@ export const DashboardClient = () => {
 		return Math.max(plexCount, tautulliCount) + jellyfinCount;
 	}, [hasMediaServer, plexNowPlaying.data, tautulliActivity.data, jellyfinNowPlaying.data]);
 
-	// Build instanceId → baseUrl map
+	// Build instanceId → externalUrl (or baseUrl fallback) map
 	const instanceUrlMap = useMemo<InstanceUrlMap>(() => {
 		const map = new Map<string, string>();
 		for (const service of services) {
-			map.set(service.id, service.baseUrl);
+			map.set(service.id, service.externalUrl ?? service.baseUrl);
 		}
 		return map;
 	}, [services]);


### PR DESCRIPTION
## Summary

- Dashboard Active Queue "Open *arr queue" links were always using `baseUrl` (internal URL), ignoring the configured `externalUrl` (reverse proxy / external address)
- Changed `instanceUrlMap` construction in `dashboard-client.tsx` to prefer `externalUrl ?? baseUrl`
- Single-line change; falls back to `baseUrl` when no external URL is set, preserving existing behaviour

## Test plan

- [ ] Configure a service with an external URL in Settings
- [ ] Open Dashboard → Active Queue
- [ ] Hover over an "Open *arr queue" badge — URL in status bar should show the external URL
- [ ] Without an external URL set, confirm links still use the internal base URL
- [ ] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [ ] `pnpm run test` — 326/326 pass

Fixes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)