### PR TITLE
fix: Lidarr pulse unreachable + Seerr notification agent types default

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for collectArrSignals pulse collector
+ *
+ * Covers the fix for GitHub issue #300 where Lidarr was falsely reported
+ * as unreachable because LidarrClient exposes .health.get() / .diskSpace.get()
+ * while the collector was calling .getAll() (Sonarr's convention).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { LidarrClient, SonarrClient } from "arr-sdk";
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
+import { collectArrSignals } from "../collectors.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const noop = vi.fn();
+const mockLog = {
+	warn: noop,
+	error: noop,
+	info: noop,
+	debug: noop,
+	trace: noop,
+	fatal: noop,
+	child: () => mockLog,
+} as unknown as FastifyBaseLogger;
+
+function makeInstance(overrides: Partial<{
+	id: string;
+	label: string;
+	service: string;
+	baseUrl: string;
+	storageGroupId: string | null;
+}> = {}) {
+	return {
+		id: "inst-lidarr-1",
+		label: "Lidarr",
+		service: "LIDARR",
+		baseUrl: "http://lidarr:8686",
+		enabled: true,
+		storageGroupId: null,
+		userId: "user-1",
+		...overrides,
+	};
+}
+
+function makeMockApp(instance: ReturnType<typeof makeInstance>, client: unknown) {
+	return {
+		prisma: {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([instance]),
+			},
+		},
+		arrClientFactory: {
+			create: vi.fn().mockReturnValue(client),
+		},
+	} as unknown as FastifyInstance;
+}
+
+// ---------------------------------------------------------------------------
+// Mock client builders
+// ---------------------------------------------------------------------------
+
+// Use Object.create(Cls.prototype) so instanceof checks pass in the collector.
+// Plain object literals ({} as Cls) don't satisfy instanceof at runtime.
+function makeLidarrClient(overrides: {
+	healthResult?: Array<{ type: string; message: string; source?: string; wikiUrl?: string }>;
+	healthError?: boolean;
+	diskResult?: Array<{ totalSpace: number; freeSpace: number }>;
+}): LidarrClient {
+	const client = Object.create(LidarrClient.prototype) as LidarrClient;
+	(client as unknown as Record<string, unknown>).health = {
+		get: overrides.healthError
+			? vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+			: vi.fn().mockResolvedValue(overrides.healthResult ?? []),
+	};
+	(client as unknown as Record<string, unknown>).diskSpace = {
+		get: vi.fn().mockResolvedValue(overrides.diskResult ?? [
+			{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 },
+		]),
+	};
+	return client;
+}
+
+function makeSonarrClient(overrides: {
+	healthResult?: Array<{ type: string; message: string; source?: string }>;
+	healthError?: boolean;
+	diskResult?: Array<{ totalSpace: number; freeSpace: number }>;
+} = {}): SonarrClient {
+	const client = Object.create(SonarrClient.prototype) as SonarrClient;
+	(client as unknown as Record<string, unknown>).health = {
+		getAll: overrides.healthError
+			? vi.fn().mockRejectedValue(new Error("ECONNREFUSED"))
+			: vi.fn().mockResolvedValue(overrides.healthResult ?? []),
+	};
+	(client as unknown as Record<string, unknown>).diskSpace = {
+		getAll: vi.fn().mockResolvedValue(overrides.diskResult ?? [
+			{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 },
+		]),
+	};
+	return client;
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Lidarr (fix for #300)
+// ---------------------------------------------------------------------------
+
+describe("collectArrSignals — Lidarr", () => {
+	it("does NOT emit unreachable signal when Lidarr is healthy", async () => {
+		const client = makeLidarrClient({ healthResult: [] });
+		const app = makeMockApp(makeInstance(), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const unreachable = items.find((i) => i.id.startsWith("arr-unreachable-"));
+		expect(unreachable).toBeUndefined();
+	});
+
+	it("emits unreachable signal when Lidarr.health.get() throws", async () => {
+		const client = makeLidarrClient({ healthError: true });
+		const app = makeMockApp(makeInstance(), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const unreachable = items.find((i) => i.id === "arr-unreachable-inst-lidarr-1");
+		expect(unreachable).toBeDefined();
+		expect(unreachable?.severity).toBe("critical");
+		expect(unreachable?.title).toBe("Lidarr is unreachable");
+	});
+
+	it("surfaces Lidarr health issues as pulse items", async () => {
+		const client = makeLidarrClient({
+			healthResult: [
+				{ type: "error", message: "Indexer unavailable", source: "IndexerLongTermStatusCheck" },
+				{ type: "warning", message: "No download client configured", source: "DownloadClientCheck" },
+			],
+		});
+		const app = makeMockApp(makeInstance({ label: "My Lidarr" }), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const healthItems = items.filter((i) => i.category === "health" && !i.id.startsWith("arr-unreachable-"));
+		expect(healthItems).toHaveLength(2);
+
+		const errorItem = healthItems.find((i) => i.severity === "critical");
+		expect(errorItem?.title).toBe("My Lidarr: Indexer unavailable");
+
+		const warnItem = healthItems.find((i) => i.severity === "warning");
+		expect(warnItem?.title).toBe("My Lidarr: No download client configured");
+	});
+
+	it("calls health.get() — not health.getAll() — on LidarrClient", async () => {
+		const client = makeLidarrClient({ healthResult: [] });
+		const app = makeMockApp(makeInstance(), client);
+
+		await collectArrSignals(app, "user-1", mockLog);
+
+		const healthGet = (client as unknown as { health: { get: ReturnType<typeof vi.fn> } }).health.get;
+		expect(healthGet).toHaveBeenCalledOnce();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests — Sonarr (regression: ensure non-Lidarr services still work)
+// ---------------------------------------------------------------------------
+
+describe("collectArrSignals — Sonarr", () => {
+	it("does NOT emit unreachable signal when Sonarr is healthy", async () => {
+		const client = makeSonarrClient({ healthResult: [] });
+		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const unreachable = items.find((i) => i.id.startsWith("arr-unreachable-"));
+		expect(unreachable).toBeUndefined();
+	});
+
+	it("emits unreachable signal when Sonarr health.getAll() throws", async () => {
+		const client = makeSonarrClient({ healthError: true });
+		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr Main", service: "SONARR" }), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const unreachable = items.find((i) => i.id === "arr-unreachable-inst-sonarr-1");
+		expect(unreachable).toBeDefined();
+		expect(unreachable?.severity).toBe("critical");
+	});
+
+	it("surfaces Sonarr health issues as pulse items", async () => {
+		const client = makeSonarrClient({
+			healthResult: [{ type: "error", message: "Root folder missing" }],
+		});
+		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const healthItems = items.filter((i) => i.category === "health");
+		expect(healthItems).toHaveLength(1);
+		expect(healthItems[0]?.title).toBe("Sonarr: Root folder missing");
+		expect(healthItems[0]?.severity).toBe("critical");
+	});
+
+	it("calls health.getAll() — not health.get() — on SonarrClient", async () => {
+		const client = makeSonarrClient({ healthResult: [] });
+		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+
+		await collectArrSignals(app, "user-1", mockLog);
+
+		const healthGetAll = (client as unknown as { health: { getAll: ReturnType<typeof vi.fn> } }).health.getAll;
+		expect(healthGetAll).toHaveBeenCalledOnce();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Tests — empty / no instances
+// ---------------------------------------------------------------------------
+
+describe("collectArrSignals — edge cases", () => {
+	it("returns empty array when no ARR instances are configured", async () => {
+		const app = {
+			prisma: {
+				serviceInstance: {
+					findMany: vi.fn().mockResolvedValue([]),
+				},
+			},
+			arrClientFactory: { create: vi.fn() },
+		} as unknown as FastifyInstance;
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+		expect(items).toEqual([]);
+	});
+
+	it("emits disk warning when Lidarr disk usage exceeds 80%", async () => {
+		const client = makeLidarrClient({
+			healthResult: [],
+			diskResult: [{ totalSpace: 1_000_000_000_000, freeSpace: 100_000_000_000 }], // 90% full
+		});
+		const app = makeMockApp(makeInstance({ label: "Lidarr" }), client);
+
+		const items = await collectArrSignals(app, "user-1", mockLog);
+
+		const diskItem = items.find((i) => i.category === "storage");
+		expect(diskItem).toBeDefined();
+		expect(diskItem?.severity).toBe("critical");
+		expect(diskItem?.title).toMatch(/90%/);
+	});
+});

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -11,7 +11,7 @@
 
 import type { PulseItem } from "@arr/shared";
 import { ARR_SERVICES_UPPER } from "@arr/shared";
-import { ProwlarrClient } from "arr-sdk";
+import { LidarrClient, ProwlarrClient } from "arr-sdk";
 import type { SonarrClient } from "arr-sdk";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import {
@@ -71,16 +71,35 @@ const collectArrSignals: Collector = async (app, userId, log) => {
 				// Prowlarr has no disk space endpoint
 				const hasDiskSpace = !(client instanceof ProwlarrClient);
 
-				// All ARR clients expose .health.getAll() — use SonarrClient as
-				// the representative type (the return shape is identical across services)
+				// Lidarr uses .get() instead of .getAll() for health and diskSpace
+				// (older API convention); all other ARR services use .getAll()
+				const isLidarr = client instanceof LidarrClient;
 				const typedClient = client as SonarrClient;
+				const lidarrClient = client as LidarrClient;
 
-				const [rawHealth, rawDisk] = await Promise.all([
-					safeRequest(() => typedClient.health.getAll(), `${service} health`),
+				// Normalize health/diskSpace results to a shared shape; Lidarr returns
+				// .get() (string wikiUrl) while other services return .getAll() (object wikiUrl).
+				// processHealthIssues accepts both via its HealthEntry constraint.
+				type ArrHealth = Array<{
+					type?: string | null;
+					message?: string | null;
+					source?: string | null;
+					wikiUrl?: string | { toString(): string } | null;
+				}>;
+				type ArrDisk = Array<{ totalSpace?: number | null; freeSpace?: number | null }>;
+
+				const [rawHealthUntyped, rawDiskUntyped] = await Promise.all([
+					isLidarr
+						? safeRequest(() => lidarrClient.health.get(), `${service} health`)
+						: safeRequest(() => typedClient.health.getAll(), `${service} health`),
 					hasDiskSpace
-						? safeRequest(() => typedClient.diskSpace.getAll(), `${service} disk`)
-						: Promise.resolve([] as Awaited<ReturnType<SonarrClient["diskSpace"]["getAll"]>>),
+						? isLidarr
+							? safeRequest(() => lidarrClient.diskSpace.get(), `${service} disk`)
+							: safeRequest(() => typedClient.diskSpace.getAll(), `${service} disk`)
+						: Promise.resolve([] as ArrDisk),
 				]);
+				const rawHealth = rawHealthUntyped as ArrHealth | undefined;
+				const rawDisk = rawDiskUntyped as ArrDisk | undefined;
 
 				// If health call failed, the instance is likely unreachable
 				if (rawHealth === undefined) {

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -576,6 +576,9 @@ function formatBytes(bytes: number): string {
 // Exported: all collectors
 // ============================================================================
 
+// Exported for testing
+export { collectArrSignals };
+
 export const pulseCollectors: Collector[] = [
 	collectArrSignals,
 	collectSeerrCircuitBreaker,

--- a/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
@@ -537,7 +537,64 @@ describe("circuit breaker integration", () => {
 });
 
 // ===========================================================================
-// 13. Timeout handling
+// 13. getNotificationAgents
+// ===========================================================================
+
+describe("getNotificationAgents", () => {
+	function makeAgentResponse(overrides?: Record<string, unknown>) {
+		return { enabled: true, types: 30, options: {}, ...overrides };
+	}
+
+	it("returns agents with all fields present", async () => {
+		// 11 known agents → 11 requests; return a valid payload for each
+		factory.rawRequest.mockResolvedValue(mockResponse(makeAgentResponse()));
+		cache.get.mockReturnValue(undefined);
+
+		const agents = await client.getNotificationAgents();
+
+		expect(agents.length).toBe(11);
+		expect(agents[0]!.types).toBe(30);
+		expect(agents[0]!.enabled).toBe(true);
+	});
+
+	it("defaults types to 0 when the field is absent in the API response (#301)", async () => {
+		// Simulate Seerr returning an agent without the `types` field
+		factory.rawRequest.mockResolvedValue(mockResponse(makeAgentResponse({ types: undefined })));
+		cache.get.mockReturnValue(undefined);
+
+		const agents = await client.getNotificationAgents();
+
+		expect(agents.length).toBe(11);
+		for (const agent of agents) {
+			expect(agent.types).toBe(0);
+		}
+	});
+
+	it("skips agents that return 404 silently", async () => {
+		const notFound = mockResponse({}, 404);
+		factory.rawRequest.mockResolvedValue(notFound);
+		cache.get.mockReturnValue(undefined);
+
+		const agents = await client.getNotificationAgents();
+
+		// All 11 agents 404 → all skipped, empty array returned
+		expect(agents).toHaveLength(0);
+		expect(log.warn).not.toHaveBeenCalled();
+	});
+
+	it("returns cached result without fetching", async () => {
+		const cached = [{ id: "discord", name: "Discord", enabled: true, types: 10, options: {} }];
+		cache.get.mockReturnValue(cached);
+
+		const agents = await client.getNotificationAgents();
+
+		expect(agents).toBe(cached);
+		expect(factory.rawRequest).not.toHaveBeenCalled();
+	});
+});
+
+// ===========================================================================
+// 14. Timeout handling
 // ===========================================================================
 
 describe("timeout handling", () => {

--- a/apps/api/src/lib/seerr/seerr-client.ts
+++ b/apps/api/src/lib/seerr/seerr-client.ts
@@ -123,7 +123,7 @@ const KNOWN_NOTIFICATION_AGENTS: readonly { id: KnownNotificationAgentId; name: 
 /** Schema for the raw notification agent response from Seerr's API (before id/name are injected) */
 const seerrNotificationAgentRawSchema = z.looseObject({
 	enabled: z.boolean(),
-	types: z.number(),
+	types: z.number().default(0),
 	options: z.record(z.string(), z.unknown()),
 });
 


### PR DESCRIPTION
## Summary

Two pulse/integration bug fixes surfaced by the v2.14.0 quarantine health system:

1. **Lidarr pulse** — `LidarrClient.health.getAll()` doesn't exist; calling `.get()` (the correct method) resolves the "Lidarr unreachable" false-positive in System Pulse (#300).
2. **Seerr notification agents** — Seerr omits the `types` bitmask field for unconfigured agents (webpush, lunasea, etc.). The Zod schema required it as a number, so those agents were logged as quarantine rejections even when Seerr was healthy (#301).

## Fixes

**Lidarr — wrong health method in pulse collector**
- `collectors.ts` was calling `lidarrClient.health.getAll()`, which does not exist on `LidarrClient`. Changed to `.health.get()`, consistent with how Lidarr's `/api/v1/health` endpoint works (returns an array directly, not paginated).

**Seerr — `types` field absent on unconfigured notification agents**
- `seerrNotificationAgentRawSchema` declared `types: z.number()` (required). Seerr omits this field for agents that have never been configured. Changed to `z.number().default(0)` — a bitmask of `0` means no event types enabled, which correctly represents an unconfigured agent. The shared `SeerrNotificationAgent` TypeScript type keeps `types: number` (non-optional) since `.default(0)` guarantees the value is always present post-parse.

## Files changed
- `apps/api/src/lib/pulse/collectors.ts` — call `.health.get()` instead of `.getAll()`
- `apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts` — new tests covering Lidarr signal path
- `apps/api/src/lib/seerr/seerr-client.ts` — add `.default(0)` to `types` schema field
- `apps/api/src/lib/seerr/__tests__/seerr-client.test.ts` — new tests for `getNotificationAgents` including missing `types` regression test

## Test plan
- [ ] Open Settings > System > expand a Seerr quarantine event — no `types` rejections
- [ ] Lidarr shown as healthy in System Pulse (not unreachable)
- [x] TypeScript: 0 errors (API)
- [x] Tests: 33 seerr-client tests pass

Closes #300
Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)