### PR TITLE
fix: default Tautulli activity fields to empty values when absent (#302)

### DIFF
--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -51,35 +51,40 @@ export const tautulliHistoryDataSchema = z.looseObject({
 
 /** get_activity — inner data */
 export const tautulliActivityDataSchema = z.looseObject({
-	sessions: z.array(
-		z.looseObject({
-			session_key: z.string(),
-			rating_key: z.coerce.string(),
-			title: z.string(),
-			grandparent_title: z.string().optional(),
-			media_type: z.string(),
-			user: z.string(),
-			friendly_name: z.string(),
-			player: z.string(),
-			platform: z.string(),
-			product: z.string(),
-			state: z.string(),
-			progress_percent: z.string(),
-			transcode_decision: z.string(),
-			stream_video_decision: z.string(),
-			stream_audio_decision: z.string(),
-			video_resolution: z.string(),
-			audio_codec: z.string(),
-			video_codec: z.string(),
-			bandwidth: z.string(),
-			location: z.string(),
-			thumb: z.string().optional(),
-		}),
+	// Tautulli omits sessions/bandwidth fields entirely when there are no active streams.
+	// Use z.preprocess to coerce undefined → safe defaults (matches v2.17+ idle behaviour).
+	sessions: z.preprocess(
+		(v) => v ?? [],
+		z.array(
+			z.looseObject({
+				session_key: z.string(),
+				rating_key: z.coerce.string(),
+				title: z.string(),
+				grandparent_title: z.string().optional(),
+				media_type: z.string(),
+				user: z.string(),
+				friendly_name: z.string(),
+				player: z.string(),
+				platform: z.string(),
+				product: z.string(),
+				state: z.string(),
+				progress_percent: z.string(),
+				transcode_decision: z.string(),
+				stream_video_decision: z.string(),
+				stream_audio_decision: z.string(),
+				video_resolution: z.string(),
+				audio_codec: z.string(),
+				video_codec: z.string(),
+				bandwidth: z.string(),
+				location: z.string(),
+				thumb: z.string().optional(),
+			}),
+		),
 	),
-	stream_count: z.string(),
-	total_bandwidth: z.number(),
-	lan_bandwidth: z.number(),
-	wan_bandwidth: z.number(),
+	stream_count: z.preprocess((v) => v ?? "0", z.string()),
+	total_bandwidth: z.preprocess((v) => v ?? 0, z.number()),
+	lan_bandwidth: z.preprocess((v) => v ?? 0, z.number()),
+	wan_bandwidth: z.preprocess((v) => v ?? 0, z.number()),
 });
 
 /** get_plays_by_date — inner data */

--- a/apps/api/src/lib/validation/__tests__/upstream-fixtures.test.ts
+++ b/apps/api/src/lib/validation/__tests__/upstream-fixtures.test.ts
@@ -530,6 +530,23 @@ describe("Upstream fixture regression tests", () => {
 			}
 		});
 
+		it("accepts get_activity with all fields absent (idle server — Tautulli v2.17+)", () => {
+			// When Tautulli has no active streams it omits all activity fields entirely.
+			const idle = {};
+			const result = parseUpstream(idle, tautulliActivityDataSchema, {
+				integration: "tautulli",
+				category: "get_activity",
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data.sessions).toEqual([]);
+				expect(result.data.stream_count).toBe("0");
+				expect(result.data.total_bandwidth).toBe(0);
+				expect(result.data.lan_bandwidth).toBe(0);
+				expect(result.data.wan_bandwidth).toBe(0);
+			}
+		});
+
 		it("accepts get_home_stats with all fields present", () => {
 			const result = parseUpstream(TAUTULLI_HOME_STATS_FULL, z.array(tautulliHomeStatSchema), {
 				integration: "tautulli",


### PR DESCRIPTION
## Summary

- Tautulli v2.17+ omits `sessions`, `stream_count`, `total_bandwidth`, `lan_bandwidth`, and `wan_bandwidth` from `get_activity` responses when no streams are active, rather than returning zero/empty values
- The existing Zod schema treated all five fields as required, causing every idle poll to be rejected and quarantined in System Health
- Applied `z.preprocess(v => v ?? default, ...)` wrappers to coerce absent fields to safe defaults (`[]`, `"0"`, `0`)

## Test plan

- [x] Added regression test in `upstream-fixtures.test.ts`: passes empty object `{}` as `get_activity` data and asserts all five fields default correctly
- [x] Existing `get_activity` fixture test (with active session) still passes
- [x] All 1206 tests pass (`pnpm run test`)
- [x] Backend type check clean (`pnpm --filter @arr/api exec tsc --noEmit`)
- [x] Frontend type check clean (`pnpm --filter @arr/web exec tsc --noEmit`)

Fixes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)