### PR TITLE
chore: upgrade pnpm to 10.33.0 and guard action-setup major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,13 @@ updates:
       actions:
         patterns:
           - "*"
+    ignore:
+      # pnpm/action-setup major bumps must be coordinated with a pnpm major
+      # version upgrade — action-setup@v6 bootstraps pnpm v11 internally and
+      # breaks projects still on pnpm v10 lockfile format (v9).
+      # Remove this ignore when upgrading pnpm to v11.
+      - dependency-name: "pnpm/action-setup"
+        update-types: ["version-update:semver-major"]
 
   # Docker base images
   - package-ecosystem: "docker"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "arr-dashboard-platform",
   "version": "2.14.0",
   "private": true,
-  "packageManager": "pnpm@10.28.1",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "turbo run dev --parallel",
     "build": "turbo run build",


### PR DESCRIPTION
## Summary

- Bumps `packageManager` from `pnpm@10.28.1` → `pnpm@10.33.0` (latest stable v10)
- Adds a Dependabot ignore rule for `pnpm/action-setup` major version bumps

## Why

`pnpm/action-setup@v6` (PR #296, now closed) was failing CI with `ERR_PNPM_BROKEN_LOCKFILE`. Root cause traced to the action source code:

1. `action-setup@v6` bootstraps using `pnpm@11.0.0-rc.0` internally
2. When `packageManager` is set in `package.json`, the action intentionally skips `pnpm self-update` and expects pnpm to auto-switch at install time
3. But pnpm v11 validates the lockfile format *before* any version-switching occurs — and a v9 lockfile is rejected by v11 as "broken"

`action-setup@v5` worked correctly because it used pnpm's own self-installer which explicitly downloaded and replaced the binary with `pnpm@10.28.1`.

## Long-term plan

When pnpm v11 goes stable (`next-11` is currently `11.0.0-rc.0`):
1. Upgrade `packageManager` to `pnpm@11.x`
2. Run `pnpm install` to regenerate lockfile in v10 format
3. Remove the Dependabot ignore rule
4. Let Dependabot re-open `pnpm/action-setup@v6`

## Test plan

- [x] CI passes on this branch (lockfile format unchanged — v9 is used by all of pnpm v9/v10)
- [x] Dependabot will no longer open major-version PRs for `pnpm/action-setup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)