### PR TITLE
test: add risk-based integration coverage for 4 critical flows

### DIFF
--- a/apps/api/src/lib/auth/__tests__/session-validation.test.ts
+++ b/apps/api/src/lib/auth/__tests__/session-validation.test.ts
@@ -1,0 +1,207 @@
+/**
+ * SessionService.validateRequest integration tests.
+ *
+ * Existing route tests bypass real session validation via setupAuthInjection,
+ * so the actual cookie -> hash -> DB lookup -> expiry check pipeline has no
+ * direct coverage. These tests exercise the full pipeline against an
+ * in-memory Prisma stub, including the createSession round-trip so the
+ * hashing contract between create and validate is locked in.
+ */
+
+import type { FastifyRequest } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionService } from "../session.js";
+
+const COOKIE_NAME = "arr_session";
+const TTL_HOURS = 24;
+
+function createEnv() {
+	return {
+		SESSION_COOKIE_NAME: COOKIE_NAME,
+		SESSION_TTL_HOURS: TTL_HOURS,
+		COOKIE_SECURE: false,
+		TRUST_PROXY: false,
+	} as never; // ApiEnv has many other fields irrelevant to SessionService
+}
+
+/**
+ * In-memory Prisma stub matching the surface SessionService touches.
+ * Stores sessions by hashed id and supports findUnique / create / delete /
+ * deleteMany / update / count.
+ */
+function createPrismaStub() {
+	const sessions = new Map<
+		string,
+		{
+			id: string;
+			userId: string;
+			expiresAt: Date;
+			createdAt: Date;
+			lastAccessedAt: Date;
+			userAgent: string | null;
+			ipAddress: string | null;
+			user: {
+				id: string;
+				username: string;
+				mustChangePassword: boolean;
+				createdAt: Date;
+				updatedAt: Date;
+			};
+		}
+	>();
+
+	return {
+		_sessions: sessions,
+		session: {
+			create: vi.fn(async ({ data }: any) => {
+				const row = {
+					id: data.id,
+					userId: data.userId,
+					expiresAt: data.expiresAt,
+					createdAt: new Date(),
+					lastAccessedAt: new Date(),
+					userAgent: data.userAgent ?? null,
+					ipAddress: data.ipAddress ?? null,
+					user: {
+						id: data.userId,
+						username: "admin",
+						mustChangePassword: false,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					},
+				};
+				sessions.set(row.id, row);
+				return row;
+			}),
+			findUnique: vi.fn(async ({ where }: any) => sessions.get(where.id) ?? null),
+			delete: vi.fn(async ({ where }: any) => {
+				const row = sessions.get(where.id);
+				if (!row) {
+					const err = new Error("not found");
+					(err as any).code = "P2025";
+					throw err;
+				}
+				sessions.delete(where.id);
+				return row;
+			}),
+			deleteMany: vi.fn(async () => ({ count: 0 })),
+			update: vi.fn(async ({ where, data }: any) => {
+				const row = sessions.get(where.id);
+				if (row) Object.assign(row, data);
+				return row;
+			}),
+			count: vi.fn(async () => sessions.size),
+		},
+	};
+}
+
+/**
+ * Build a stub FastifyRequest that exposes only `cookies` + `unsignCookie`,
+ * matching the @fastify/cookie contract. validateRequest treats unsigned
+ * cookies as invalid.
+ */
+function makeRequest(
+	rawCookie: string | undefined,
+	unsigned: { valid: boolean; value: string | null },
+): FastifyRequest {
+	return {
+		cookies: rawCookie ? { [COOKIE_NAME]: rawCookie } : {},
+		unsignCookie: () => unsigned,
+	} as unknown as FastifyRequest;
+}
+
+describe("SessionService.validateRequest", () => {
+	let prisma: ReturnType<typeof createPrismaStub>;
+	let service: SessionService;
+
+	beforeEach(() => {
+		prisma = createPrismaStub();
+		service = new SessionService(prisma as any, createEnv());
+	});
+
+	it("returns null when no session cookie is present", async () => {
+		const req = makeRequest(undefined, { valid: false, value: null });
+		await expect(service.validateRequest(req)).resolves.toBeNull();
+		expect(prisma.session.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("returns null when the cookie signature is invalid (tampered)", async () => {
+		const req = makeRequest("tampered.cookie", { valid: false, value: null });
+		await expect(service.validateRequest(req)).resolves.toBeNull();
+		expect(prisma.session.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("returns null when the session token is unknown to the database", async () => {
+		const req = makeRequest("signed-cookie", { valid: true, value: "unknown-token" });
+		await expect(service.validateRequest(req)).resolves.toBeNull();
+		expect(prisma.session.findUnique).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns null AND best-effort deletes the row when the session is expired", async () => {
+		const created = await service.createSession("user-1");
+		const hashedId = [...prisma._sessions.keys()][0]!;
+		prisma._sessions.get(hashedId)!.expiresAt = new Date(Date.now() - 1000);
+
+		const req = makeRequest("signed-cookie", { valid: true, value: created.token });
+
+		await expect(service.validateRequest(req)).resolves.toBeNull();
+
+		// Best-effort cleanup: row should be gone after the failed validation
+		expect(prisma._sessions.has(hashedId)).toBe(false);
+		expect(prisma.session.delete).toHaveBeenCalled();
+	});
+
+	it("returns the session + token round-trip from createSession", async () => {
+		const { token, expiresAt } = await service.createSession("user-1", false, {
+			userAgent: "vitest",
+			ipAddress: "127.0.0.1",
+		});
+
+		const req = makeRequest("signed-cookie", { valid: true, value: token });
+		const result = await service.validateRequest(req);
+
+		expect(result).not.toBeNull();
+		expect(result!.token).toBe(token);
+		expect(result!.session.userId).toBe("user-1");
+		expect(result!.session.user.username).toBe("admin");
+		expect(result!.session.userAgent).toBe("vitest");
+		expect(result!.session.ipAddress).toBe("127.0.0.1");
+		expect(expiresAt.getTime()).toBeGreaterThan(Date.now());
+	});
+
+	it("rememberMe extends the TTL beyond the default session TTL", async () => {
+		const standard = await service.createSession("user-1", false);
+		const remembered = await service.createSession("user-1", true);
+
+		// Remember-me TTL (30d) should significantly exceed standard TTL (24h)
+		const standardTtlMs = standard.expiresAt.getTime() - Date.now();
+		const rememberedTtlMs = remembered.expiresAt.getTime() - Date.now();
+		expect(rememberedTtlMs).toBeGreaterThan(standardTtlMs * 10);
+	});
+
+	it("invalidateAllUserSessions(userId, exceptToken) hashes the exceptToken before scoping the delete", async () => {
+		const a = await service.createSession("user-1");
+		await service.createSession("user-1");
+		expect(prisma._sessions.size).toBe(2);
+
+		await service.invalidateAllUserSessions("user-1", a.token);
+
+		expect(prisma.session.deleteMany).toHaveBeenCalledWith({
+			where: {
+				userId: "user-1",
+				id: { not: expect.any(String) },
+			},
+		});
+
+		// CRITICAL contract: exceptToken must be hashed, never raw — otherwise the
+		// "preserve current session" semantics break (raw token != stored hashed id).
+		const calls = prisma.session.deleteMany.mock.calls as unknown as Array<
+			[{ where: { id: { not: string } } }]
+		>;
+		expect(calls.length).toBeGreaterThan(0);
+		const callArg = calls[0]![0];
+		expect(callArg.where.id.not).not.toBe(a.token);
+		expect(typeof callArg.where.id.not).toBe("string");
+		expect(callArg.where.id.not.length).toBe(64); // sha256 hex length
+	});
+});

--- a/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
+++ b/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Queue Cleaner executor integration tests.
+ *
+ * These exercise the end-to-end executor contract — ARR client is mocked,
+ * Prisma is mocked, but the real executeQueueCleaner function runs the full
+ * fetch -> validate -> evaluate -> remove pipeline. Existing unit tests
+ * cover rule evaluation and auto-import in isolation; this file covers:
+ *
+ *  - successful clean path: queue item matched by a rule -> client.queue.del
+ *    actually called with the item id (side-effect verification)
+ *  - silent-failure contract: ARR queue.get throws -> executor returns a
+ *    status:"error" result object WITHOUT throwing, so the scheduler sees a
+ *    structured failure instead of an unhandled promise rejection
+ *  - defensive config parsing: invalid whitelist JSON aborts the clean
+ *    instead of silently running with an empty whitelist
+ *  - registry integration: wrapping the executor in registry.track() surfaces
+ *    both the successful result AND the failure result correctly
+ *    (track() only observes thrown errors, so a structured error result
+ *    counts as a successful tick from the registry's perspective — verifying
+ *    this documents the contract between the two layers)
+ */
+
+import type { FastifyInstance } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { QueueCleanerConfig, ServiceInstance } from "../../prisma.js";
+import { JOB_ID } from "../../scheduler-registry/job-definitions.js";
+import { SchedulerRegistry } from "../../scheduler-registry/scheduler-registry.js";
+import { executeQueueCleaner } from "../cleaner-executor.js";
+
+function makeInstance(overrides: Partial<ServiceInstance> = {}): ServiceInstance {
+	return {
+		id: "inst-1",
+		userId: "user-1",
+		service: "SONARR",
+		label: "Sonarr",
+		baseUrl: "http://sonarr:8989",
+		externalUrl: null,
+		encryptedApiKey: "x",
+		encryptionIv: "y",
+		enabled: true,
+		isDefault: true,
+		storageGroupId: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	} as ServiceInstance;
+}
+
+function makeConfig(overrides: Partial<QueueCleanerConfig> = {}): QueueCleanerConfig {
+	// Conservative config: only the stalled rule, no strike system, live mode.
+	// This keeps the executor path short and deterministic.
+	return {
+		id: "cfg-1",
+		instanceId: "inst-1",
+		enabled: true,
+		dryRunMode: false,
+		minQueueAgeMins: 0,
+		maxRemovalsPerRun: 100,
+		// Stalled rule: remove items stalled > 0 mins (so our old stalled item always matches)
+		stalledEnabled: true,
+		stalledThresholdMins: 0,
+		// Other rules off
+		slowEnabled: false,
+		slowSpeedThreshold: 0,
+		slowGracePeriodMins: 0,
+		importPendingEnabled: false,
+		importPendingMins: 0,
+		importBlockEnabled: false,
+		importBlockCleanupLevel: "item",
+		importBlockPatternMode: "any",
+		errorPatternsEnabled: false,
+		errorPatterns: null,
+		seedingTimeoutEnabled: false,
+		seedingTimeoutHours: 0,
+		estimatedEnabled: false,
+		estimatedMultiplier: 2,
+		skipFutureEpisodes: false,
+		whitelistEnabled: false,
+		whitelistPatterns: null,
+		tagFilterMode: "all",
+		tagFilterIds: null,
+		profileFilterMode: "all",
+		profileFilterIds: null,
+		strikeSystemEnabled: false,
+		maxStrikes: 3,
+		strikeDecayHours: 24,
+		autoImportEnabled: false,
+		blocklistOnRemove: false,
+		removeFromClient: true,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	} as QueueCleanerConfig;
+}
+
+/**
+ * Build a mock FastifyInstance with just enough surface for executeQueueCleaner.
+ * Accepts a queue-get behavior so we can inject success and failure.
+ */
+function makeApp(queueBehavior: {
+	get: () => Promise<unknown>;
+	del: ReturnType<typeof vi.fn>;
+}): FastifyInstance {
+	const app = {
+		arrClientFactory: {
+			create: () => ({
+				queue: {
+					get: queueBehavior.get,
+					delete: queueBehavior.del,
+				},
+			}),
+		},
+		prisma: {
+			$transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => fn({})),
+			queueCleanerStrike: {
+				findMany: vi.fn().mockResolvedValue([]),
+				create: vi.fn(),
+				update: vi.fn(),
+				deleteMany: vi.fn(),
+			},
+		},
+		log: {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		},
+	};
+	return app as unknown as FastifyInstance;
+}
+
+describe("executeQueueCleaner — integration", () => {
+	const STALLED_ITEM = {
+		id: 42,
+		title: "Stalled.Show.S01E01",
+		added: new Date(Date.now() - 60 * 60 * 1000).toISOString(), // 1h ago
+		size: 1_000_000_000,
+		sizeleft: 1_000_000_000,
+		status: "warning",
+		trackedDownloadStatus: "warning",
+		trackedDownloadState: "stalled",
+		statusMessages: [
+			{ title: "Stalled", messages: ["The download is stalled with no connections"] },
+		],
+		downloadId: "dl-42",
+		protocol: "torrent",
+		indexer: "TestIndexer",
+		errorMessage: "The download is stalled with no connections",
+	};
+
+	it("matches a stalled queue item and calls client.queue.del (side-effect verification)", async () => {
+		const del = vi.fn().mockResolvedValue(undefined);
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+
+		const result = await executeQueueCleaner(app, makeInstance(), makeConfig());
+
+		// Structured result surfaces the matched item
+		expect(result.status).toBe("completed");
+		expect(result.isDryRun).toBe(false);
+		expect(result.itemsCleaned).toBeGreaterThanOrEqual(1);
+		expect(result.cleanedItems.some((i) => i.id === 42)).toBe(true);
+
+		// Side effect: ARR client was actually asked to remove the item
+		expect(del).toHaveBeenCalled();
+		const delArgs = del.mock.calls[0];
+		expect(delArgs?.[0]).toBe(42); // item id
+	});
+
+	it("dry-run mode returns the same matches WITHOUT calling client.queue.del", async () => {
+		const del = vi.fn();
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+
+		const result = await executeQueueCleaner(app, makeInstance(), makeConfig({ dryRunMode: true }));
+
+		expect(result.isDryRun).toBe(true);
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("silent-failure contract: ARR queue.get throwing yields status:error, NOT an unhandled rejection", async () => {
+		const del = vi.fn();
+		const app = makeApp({
+			get: async () => {
+				throw new Error("Connection refused");
+			},
+			del,
+		});
+
+		// CRITICAL: must not throw. Silent rejection here would crash the scheduler tick
+		// and leave the user with no structured error in queueCleanerLog.
+		const result = await executeQueueCleaner(app, makeInstance(), makeConfig());
+
+		expect(result.status).toBe("error");
+		expect(result.message).toContain("Failed to fetch queue");
+		expect(result.message).toContain("Connection refused");
+		expect(result.itemsCleaned).toBe(0);
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("invalid whitelist JSON aborts the clean for safety (defensive failure, not silent success)", async () => {
+		const del = vi.fn();
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+
+		const result = await executeQueueCleaner(
+			app,
+			makeInstance(),
+			makeConfig({
+				whitelistEnabled: true,
+				whitelistPatterns: "not-valid-json{{{",
+			}),
+		);
+
+		expect(result.status).toBe("error");
+		expect(result.message).toContain("Whitelist");
+		expect(result.itemsCleaned).toBe(0);
+		// Under no circumstances should a broken whitelist cause deletions
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("registry.track wrapping captures a structured-error result as a SUCCESSFUL tick (documents contract)", async () => {
+		// The executor returns structured errors instead of throwing. This means
+		// the registry — which observes thrown errors — will see the tick as
+		// successful. This test documents that contract so future refactors that
+		// change the error shape (e.g. to throwing) would need to update the
+		// registry wiring to match.
+		const app = makeApp({
+			get: async () => {
+				throw new Error("boom");
+			},
+			del: vi.fn(),
+		});
+
+		const registry = new SchedulerRegistry();
+		registry.register({
+			id: JOB_ID.queueCleaner,
+			label: "Queue cleaner",
+			description: "test",
+			concurrency: "per-instance",
+		});
+
+		const result = await registry.track(JOB_ID.queueCleaner, () =>
+			executeQueueCleaner(app, makeInstance(), makeConfig()),
+		);
+
+		// Structured error result is returned, not thrown
+		expect(result.status).toBe("error");
+
+		const status = registry.getStatus(JOB_ID.queueCleaner)!;
+		// From the registry's perspective the tick completed successfully
+		expect(status.totalRuns).toBe(1);
+		expect(status.totalFailures).toBe(0);
+		expect(status.lastSuccessAt).not.toBeNull();
+		// The contract for surfacing structured errors to operators is queueCleanerLog,
+		// not registry.lastError — this test locks that in.
+	});
+
+	it("registry.track wrapping surfaces a thrown error as a FAILED tick", async () => {
+		// Mirror: if the delegate does throw (e.g. an unexpected bug escapes the
+		// executor's try/catch), the registry counter MUST increment so ops sees it.
+		const registry = new SchedulerRegistry();
+		registry.register({
+			id: JOB_ID.queueCleaner,
+			label: "Queue cleaner",
+			description: "test",
+			concurrency: "per-instance",
+		});
+
+		await expect(
+			registry.track(JOB_ID.queueCleaner, async () => {
+				throw new Error("unexpected executor bug");
+			}),
+		).rejects.toThrow("unexpected executor bug");
+
+		const status = registry.getStatus(JOB_ID.queueCleaner)!;
+		expect(status.totalFailures).toBe(1);
+		expect(status.consecutiveFailures).toBe(1);
+		expect(status.lastError).toBe("unexpected executor bug");
+	});
+});

--- a/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
+++ b/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Service-instance secret non-leakage contract tests.
+ *
+ * Existing services.test.ts covers create/update/delete and SSRF, but does
+ * NOT assert that API responses never leak `encryptedApiKey`, `encryptionIv`,
+ * or the raw key on ANY service endpoint. This file locks that contract in
+ * across GET /services, POST /services, and PUT /services/:id.
+ *
+ * Why this matters: formatServiceInstance is the single chokepoint that
+ * strips secrets. A future refactor that bypasses it (e.g. `reply.send(instance)`
+ * directly) would silently leak secrets to the authenticated admin UI — and
+ * to any log pipeline that captures response bodies.
+ */
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockRequireInstance, mockBuildUpdateData, mockUpsertTags, mockUpdateInstanceTags } =
+	vi.hoisted(() => ({
+		mockRequireInstance: vi.fn(),
+		mockBuildUpdateData: vi.fn().mockReturnValue({}),
+		mockUpsertTags: vi.fn().mockResolvedValue([]),
+		mockUpdateInstanceTags: vi.fn().mockResolvedValue(undefined),
+	}));
+
+vi.mock("../../lib/arr/instance-helpers.js", () => ({
+	requireInstance: (...args: unknown[]) => mockRequireInstance(...args),
+}));
+
+vi.mock("../../lib/services/update-builder.js", () => ({
+	buildUpdateData: (...args: unknown[]) => mockBuildUpdateData(...args),
+}));
+
+vi.mock("../../lib/services/tag-manager.js", () => ({
+	upsertTags: (...args: unknown[]) => mockUpsertTags(...args),
+	updateInstanceTags: (...args: unknown[]) => mockUpdateInstanceTags(...args),
+}));
+
+import Fastify from "fastify";
+import { registerServiceRoutes } from "../services.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "./test-helpers.js";
+
+const SECRET_KEY = "super-secret-plaintext-api-key-xxxx";
+const ENCRYPTED_VALUE = "encrypted-base64-value";
+const ENCRYPTION_IV = "random-iv-bytes";
+
+function makeInstanceRow(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "inst-1",
+		userId: "user-1",
+		service: "SONARR",
+		label: "My Sonarr",
+		baseUrl: "http://sonarr:8989",
+		externalUrl: null,
+		encryptedApiKey: ENCRYPTED_VALUE,
+		encryptionIv: ENCRYPTION_IV,
+		enabled: true,
+		isDefault: false,
+		createdAt: new Date("2024-01-01T00:00:00Z"),
+		updatedAt: new Date("2024-01-01T00:00:00Z"),
+		storageGroupId: null,
+		tags: [],
+		...overrides,
+	};
+}
+
+/**
+ * Recursively assert that NONE of the forbidden secret fields appear anywhere
+ * in the response body — including inside nested objects or arrays. This
+ * catches regressions that pass objects through untransformed.
+ */
+function assertNoSecretLeakage(body: unknown): void {
+	const FORBIDDEN = ["encryptedApiKey", "encryptionIv", "apiKey"];
+	const serialized = JSON.stringify(body);
+	for (const field of FORBIDDEN) {
+		expect(serialized).not.toContain(`"${field}"`);
+	}
+	// Also check that the plaintext secret value itself never appears —
+	// guards against accidentally serializing a decrypted form.
+	expect(serialized).not.toContain(SECRET_KEY);
+	expect(serialized).not.toContain(ENCRYPTED_VALUE);
+	expect(serialized).not.toContain(ENCRYPTION_IV);
+}
+
+let app: ReturnType<typeof Fastify>;
+let mockPrisma: any;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+
+	mockPrisma = {
+		serviceInstance: {
+			findMany: vi
+				.fn()
+				.mockResolvedValue([
+					makeInstanceRow(),
+					makeInstanceRow({ id: "inst-2", service: "RADARR", label: "My Radarr" }),
+				]),
+			findFirst: vi.fn().mockResolvedValue(makeInstanceRow()),
+			create: vi.fn().mockImplementation(({ data }: any) => ({
+				...makeInstanceRow(),
+				...data,
+				id: "inst-new",
+				tags: [],
+			})),
+			updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+			delete: vi.fn().mockResolvedValue(undefined),
+		},
+		serviceTag: {
+			findMany: vi.fn().mockResolvedValue([]),
+			upsert: vi.fn(),
+			delete: vi.fn(),
+		},
+		serviceInstanceTag: { findFirst: vi.fn().mockResolvedValue(null) },
+	};
+
+	mockRequireInstance.mockResolvedValue(makeInstanceRow());
+	mockBuildUpdateData.mockReturnValue({});
+
+	app = Fastify();
+	app.decorate("prisma", mockPrisma);
+	// Encryptor returns exactly the values that would leak if passed through
+	app.decorate("encryptor", {
+		encrypt: vi.fn().mockReturnValue({ value: ENCRYPTED_VALUE, iv: ENCRYPTION_IV }),
+		decrypt: vi.fn().mockReturnValue(SECRET_KEY),
+	});
+	app.decorate("notificationService", { notify: vi.fn().mockResolvedValue(undefined) } as never);
+
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+
+	await app.register(registerServiceRoutes);
+	await app.ready();
+
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("Service instance secret non-leakage", () => {
+	it("GET /services never exposes encrypted fields or the plaintext key", async () => {
+		const res = await injectAuthenticated("GET", "/services");
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+
+		expect(body.services).toHaveLength(2);
+		assertNoSecretLeakage(body);
+
+		// Positive contract: hasApiKey must be present and truthy (existing UI depends on it)
+		for (const svc of body.services) {
+			expect(svc.hasApiKey).toBe(true);
+			expect(svc.id).toBeDefined();
+			expect(svc.label).toBeDefined();
+		}
+	});
+
+	it("POST /services response carries hasApiKey but never the secret that was just sent", async () => {
+		const res = await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Fresh Sonarr",
+				baseUrl: "http://sonarr:8989",
+				apiKey: SECRET_KEY,
+				service: "sonarr",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		const body = JSON.parse(res.payload);
+
+		expect(body.service.hasApiKey).toBe(true);
+		assertNoSecretLeakage(body);
+	});
+
+	it("PUT /services/:id response does not echo the updated secret back to the caller", async () => {
+		mockBuildUpdateData.mockReturnValue({
+			encryptedApiKey: ENCRYPTED_VALUE,
+			encryptionIv: ENCRYPTION_IV,
+		});
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(makeInstanceRow({ label: "Rotated" }));
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { apiKey: SECRET_KEY },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+		assertNoSecretLeakage(body);
+	});
+
+	it("Prisma create is called with encrypted values — the raw key never touches the DB layer", async () => {
+		await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Encrypt Check",
+				baseUrl: "http://sonarr:8989",
+				apiKey: SECRET_KEY,
+				service: "sonarr",
+			},
+		});
+
+		const createCall = mockPrisma.serviceInstance.create.mock.calls[0][0];
+		// Raw plaintext must never appear in the data payload
+		expect(JSON.stringify(createCall.data)).not.toContain(SECRET_KEY);
+		expect(createCall.data.encryptedApiKey).toBe(ENCRYPTED_VALUE);
+		expect(createCall.data.encryptionIv).toBe(ENCRYPTION_IV);
+	});
+});

--- a/apps/api/src/routes/__tests__/system-jobs.test.ts
+++ b/apps/api/src/routes/__tests__/system-jobs.test.ts
@@ -1,0 +1,174 @@
+/**
+ * GET /system/jobs HTTP integration tests.
+ *
+ * Boots Fastify with the REAL scheduler-registry plugin (no mock) so the
+ * full wiring — KNOWN_JOBS catalog -> registry.list() -> route response
+ * shape — is exercised end-to-end. Existing scheduler-registry.test.ts only
+ * covers the registry class in isolation; this fills the HTTP surface gap.
+ */
+
+import Fastify from "fastify";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { JOB_ID } from "../../lib/scheduler-registry/job-definitions.js";
+import schedulerRegistryPlugin from "../../plugins/scheduler-registry.js";
+import { registerSystemRoutes } from "../system.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	app = Fastify();
+
+	// Decorations system.ts touches that aren't relevant to /jobs but are
+	// referenced when the plugin loads (lifecycle, prisma, dbProvider, config).
+	app.decorate("prisma", {
+		systemSettings: { findUnique: vi.fn(), create: vi.fn(), upsert: vi.fn() },
+	} as never);
+	app.decorate("config", { TRUST_PROXY: false, COOKIE_SECURE: false } as never);
+	app.decorate("dbProvider", "sqlite" as never);
+	app.decorate("lifecycle", {
+		getRestartMessage: () => "ok",
+		restart: vi.fn(),
+	} as never);
+
+	setupAuthInjection(app);
+	await app.register(schedulerRegistryPlugin);
+	await app.register(registerSystemRoutes, { prefix: "/system" });
+	await app.ready();
+
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("GET /system/jobs", () => {
+	it("returns the full pre-registered job catalog with shape contract", async () => {
+		const res = await injectAuthenticated("GET", "/system/jobs");
+
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+
+		expect(body.success).toBe(true);
+		expect(typeof body.data.capturedAt).toBe("string");
+		expect(body.data.count).toBe(body.data.jobs.length);
+		expect(body.data.jobs.length).toBeGreaterThan(0);
+
+		// Every known job ID should appear — guards against a plugin silently
+		// dropping a registration during refactors.
+		const ids = new Set(body.data.jobs.map((j: any) => j.id));
+		expect(ids.has(JOB_ID.queueCleaner)).toBe(true);
+		expect(ids.has(JOB_ID.libraryCleanup)).toBe(true);
+		expect(ids.has(JOB_ID.hunting)).toBe(true);
+
+		// Every job has the JobStatus contract — fields exist even when never run
+		const sample = body.data.jobs[0];
+		expect(sample).toMatchObject({
+			id: expect.any(String),
+			label: expect.any(String),
+			description: expect.any(String),
+			state: expect.stringMatching(/^(idle|running|disabled)$/),
+			lastStartedAt: null,
+			lastSuccessAt: null,
+			lastFailureAt: null,
+			lastError: null,
+			consecutiveFailures: 0,
+			totalRuns: 0,
+			totalFailures: 0,
+			disabled: false,
+		});
+
+		// Sorted by id (stable contract for UI rendering)
+		const sorted = [...body.data.jobs]
+			.map((j: any) => j.id)
+			.slice()
+			.sort();
+		expect(body.data.jobs.map((j: any) => j.id)).toEqual(sorted);
+	});
+
+	it("reflects runtime updates after a successful track() — totalRuns + lastSuccessAt", async () => {
+		// Simulate one tick of the queue cleaner via the live registry
+		const result = await app.schedulerRegistry.track(JOB_ID.queueCleaner, async () => "ok");
+		expect(result).toBe("ok");
+
+		const res = await injectAuthenticated("GET", "/system/jobs");
+		const body = JSON.parse(res.payload);
+		const job = body.data.jobs.find((j: any) => j.id === JOB_ID.queueCleaner);
+
+		expect(job).toBeDefined();
+		expect(job.totalRuns).toBe(1);
+		expect(job.totalFailures).toBe(0);
+		expect(job.consecutiveFailures).toBe(0);
+		expect(job.lastSuccessAt).not.toBeNull();
+		expect(job.lastFailureAt).toBeNull();
+		expect(job.lastError).toBeNull();
+		expect(typeof job.lastDurationMs).toBe("number");
+		expect(job.state).toBe("idle");
+	});
+
+	it("increments consecutiveFailures and surfaces lastError after a failed track()", async () => {
+		await expect(
+			app.schedulerRegistry.track(JOB_ID.libraryCleanup, async () => {
+				throw new Error("simulated library cleanup failure");
+			}),
+		).rejects.toThrow("simulated library cleanup failure");
+
+		// Second consecutive failure to confirm the counter actually accumulates
+		// (not just toggles 0 -> 1).
+		await expect(
+			app.schedulerRegistry.track(JOB_ID.libraryCleanup, async () => {
+				throw new Error("second failure");
+			}),
+		).rejects.toThrow("second failure");
+
+		const res = await injectAuthenticated("GET", "/system/jobs");
+		const body = JSON.parse(res.payload);
+		const job = body.data.jobs.find((j: any) => j.id === JOB_ID.libraryCleanup);
+
+		expect(job.consecutiveFailures).toBe(2);
+		expect(job.totalFailures).toBe(2);
+		expect(job.totalRuns).toBe(2);
+		expect(job.lastError).toBe("second failure");
+		expect(job.lastFailureAt).not.toBeNull();
+		expect(job.lastSuccessAt).toBeNull();
+	});
+
+	it("resets consecutiveFailures on the next success but preserves total counters", async () => {
+		await expect(
+			app.schedulerRegistry.track(JOB_ID.hunting, async () => {
+				throw new Error("transient");
+			}),
+		).rejects.toThrow();
+		await app.schedulerRegistry.track(JOB_ID.hunting, async () => "recovered");
+
+		const res = await injectAuthenticated("GET", "/system/jobs");
+		const body = JSON.parse(res.payload);
+		const job = body.data.jobs.find((j: any) => j.id === JOB_ID.hunting);
+
+		expect(job.consecutiveFailures).toBe(0);
+		expect(job.totalRuns).toBe(2);
+		expect(job.totalFailures).toBe(1);
+		expect(job.lastError).toBeNull();
+	});
+
+	it("endpoint never triggers job execution — totalRuns stays flat across repeated GETs", async () => {
+		// Contract from the route docstring: "The endpoint never triggers job execution."
+		await app.schedulerRegistry.track(JOB_ID.queueCleaner, async () => "ok");
+		const baselineRuns = JSON.parse(
+			(await injectAuthenticated("GET", "/system/jobs")).payload,
+		).data.jobs.find((j: any) => j.id === JOB_ID.queueCleaner).totalRuns;
+
+		// Hammer the endpoint — totalRuns must not change
+		for (let i = 0; i < 5; i++) {
+			await injectAuthenticated("GET", "/system/jobs");
+		}
+
+		const afterRuns = JSON.parse(
+			(await injectAuthenticated("GET", "/system/jobs")).payload,
+		).data.jobs.find((j: any) => j.id === JOB_ID.queueCleaner).totalRuns;
+
+		expect(afterRuns).toBe(baselineRuns);
+	});
+});


### PR DESCRIPTION
## Summary

Adds targeted integration test coverage for four high-blast-radius backend
flows that previously had gaps vs existing broad coverage. Production code
is unchanged — this is test-only. 22 new tests, all passing.

## New coverage

**Session validation pipeline** — `SessionService.validateRequest` exercises
the real cookie → SHA-256 hash → DB lookup → expiry check path. Existing
route tests mock auth at the preHandler, so the actual session gate had no
direct coverage. Also locks in the contract that `invalidateAllUserSessions`
hashes the `exceptToken` (raw-token leakage there would silently delete the
current session on password change).

**Scheduler registry HTTP surface** — `GET /system/jobs` exercised against
the real `scheduler-registry` plugin (no mocks). Verifies the full
`KNOWN_JOBS` catalog is registered, runtime fields update after
`registry.track()`, `consecutiveFailures` / `lastError` increment on
failures, and the endpoint never triggers job execution (contract
documented in the route comment).

**Service secret non-leakage** — asserts that `encryptedApiKey`,
`encryptionIv`, and the plaintext key never appear in `GET /services`,
`POST /services`, or `PUT /services/:id` response bodies. Uses a
response-wide `JSON.stringify().not.toContain()` guard so any future
refactor that bypasses `formatServiceInstance` (e.g. `reply.send(instance)`
directly) would fail loudly.

**Queue cleaner automation path** — `executeQueueCleaner` end-to-end: a
stalled-item match actually triggers `client.queue.delete` (side-effect
verification), dry-run mode skips the delete, ARR fetch failure yields a
structured `status: "error"` result instead of throwing (silent-failure
contract), and invalid whitelist JSON aborts safely. Two final tests
document the `registry.track` contract: structured-error results count as
a successful tick (failures surface via `queueCleanerLog`, not the
registry), while thrown errors do increment failure counters.

## Files changed

- `apps/api/src/lib/auth/__tests__/session-validation.test.ts` — 7 tests against a real `SessionService` + in-memory Prisma stub
- `apps/api/src/routes/__tests__/system-jobs.test.ts` — 4 tests against a live Fastify app with the real scheduler-registry plugin
- `apps/api/src/routes/__tests__/services-secret-leakage.test.ts` — 4 tests asserting zero secret leakage across service routes
- `apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts` — 6 tests covering success path, silent-failure, defensive parsing, and registry-integration contracts

## Intentionally out of scope

- OIDC ↔ password auth-method switching (already covered by `auth-oidc.test.ts` + `oidc-integration.test.ts`)
- Library cleanup + hunting end-to-end runs (queue cleaner is the representative automation; phase1/2/3 rule coverage already exists for library cleanup, and the registry.track contract generalizes)
- Full cookie-signing round-trip with `@fastify/cookie` registered (the `unsignCookie` stub covers the contract `SessionService` actually depends on)

## Test plan

- [x] `pnpm --filter @arr/api exec vitest run` — 1232 passing, 36 skipped
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — 0 errors
- [x] `pnpm exec biome check` on the 4 new files — clean
- [x] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)