### PR TITLE
test: add route-auth enforcement and service-lifecycle integration coverage

### DIFF
--- a/apps/api/src/routes/__tests__/route-auth-enforcement.test.ts
+++ b/apps/api/src/routes/__tests__/route-auth-enforcement.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Route-level auth enforcement integration tests.
+ *
+ * Existing route tests in this directory all use `setupAuthInjection()` from
+ * test-helpers.ts, which sets `request.currentUser` in a preHandler when a
+ * test header is present. That bypasses the real cookie -> unsignCookie ->
+ * SessionService.validateRequest -> protected-scope gate. Unit coverage of
+ * SessionService.validateRequest exists in `lib/auth/__tests__/session-validation.test.ts`,
+ * but nothing wires the full HTTP stack together.
+ *
+ * These tests stand up the exact preHandler pair used in production
+ * (server.ts global hook + bootstrap/protected-routes.ts scope hook) with a
+ * real SessionService backed by @fastify/cookie + an in-memory prisma stub,
+ * and exercise a real protected route (registerServiceRoutes) through
+ * genuine cookie-based auth. Regressions that break cookie signing, the
+ * hashing contract between createSession and validateRequest, the expiry
+ * cleanup side effect, or the 401 response shape will surface here.
+ */
+import fastifyCookie from "@fastify/cookie";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionService } from "../../lib/auth/session.js";
+import { registerServiceRoutes } from "../services.js";
+import { registerTestErrorHandler } from "./test-helpers.js";
+
+const COOKIE_NAME = "arr_session";
+const COOKIE_SECRET = "test-cookie-signing-secret-32-bytes-long!!";
+const TTL_HOURS = 24;
+
+/** In-memory prisma stub covering the surfaces SessionService + services GET touch. */
+function createPrismaStub() {
+	const sessions = new Map<
+		string,
+		{
+			id: string;
+			userId: string;
+			expiresAt: Date;
+			createdAt: Date;
+			lastAccessedAt: Date;
+			userAgent: string | null;
+			ipAddress: string | null;
+			user: {
+				id: string;
+				username: string;
+				mustChangePassword: boolean;
+				createdAt: Date;
+				updatedAt: Date;
+			};
+		}
+	>();
+
+	return {
+		_sessions: sessions,
+		session: {
+			create: vi.fn(async ({ data }: any) => {
+				const row = {
+					id: data.id,
+					userId: data.userId,
+					expiresAt: data.expiresAt,
+					createdAt: new Date(),
+					lastAccessedAt: new Date(),
+					userAgent: data.userAgent ?? null,
+					ipAddress: data.ipAddress ?? null,
+					user: {
+						id: data.userId,
+						username: "admin",
+						mustChangePassword: false,
+						createdAt: new Date(),
+						updatedAt: new Date(),
+					},
+				};
+				sessions.set(row.id, row);
+				return row;
+			}),
+			findUnique: vi.fn(async ({ where }: any) => sessions.get(where.id) ?? null),
+			delete: vi.fn(async ({ where }: any) => {
+				const row = sessions.get(where.id);
+				if (!row) {
+					const err = new Error("not found");
+					(err as any).code = "P2025";
+					throw err;
+				}
+				sessions.delete(where.id);
+				return row;
+			}),
+			deleteMany: vi.fn(async () => ({ count: 0 })),
+			update: vi.fn(async ({ where, data }: any) => {
+				const row = sessions.get(where.id);
+				if (row) Object.assign(row, data);
+				return row;
+			}),
+			count: vi.fn(async () => sessions.size),
+		},
+		// Used by the services GET handler below the auth gate. Empty result
+		// is fine — we only care that the handler *ran*, i.e. auth passed.
+		serviceInstance: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
+	};
+}
+
+function createEnv() {
+	return {
+		SESSION_COOKIE_NAME: COOKIE_NAME,
+		SESSION_COOKIE_SECRET: COOKIE_SECRET,
+		SESSION_TTL_HOURS: TTL_HOURS,
+		COOKIE_SECURE: false,
+		TRUST_PROXY: false,
+	} as never;
+}
+
+/**
+ * Build an app wired like production: cookie plugin with signing, global
+ * preHandler populates currentUser via sessionService, protected scope
+ * rejects when currentUser is missing. Mirrors server.ts lines 81-94 and
+ * bootstrap/protected-routes.ts lines 30-35 intentionally — if either of
+ * those evolves, update this too.
+ */
+async function buildApp(prisma: ReturnType<typeof createPrismaStub>) {
+	const app = Fastify();
+	await app.register(fastifyCookie, { secret: COOKIE_SECRET, hook: "onRequest" });
+
+	const sessionService = new SessionService(prisma as any, createEnv());
+
+	app.decorate("prisma", prisma as any);
+	app.decorate("sessionService", sessionService as any);
+	app.decorate("encryptor", {
+		encrypt: vi.fn().mockReturnValue({ value: "enc", iv: "iv" }),
+		decrypt: vi.fn().mockReturnValue("secret"),
+	} as never);
+
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+
+	// --- Global preHandler: resolve session if any (mirrors server.ts:84-94) ---
+	app.addHook("preHandler", async (request) => {
+		(request as any).currentUser = null;
+		(request as any).sessionToken = null;
+		const resolved = await sessionService.validateRequest(request);
+		if (resolved) {
+			(request as any).currentUser = resolved.session.user;
+			(request as any).sessionToken = resolved.token;
+		}
+	});
+
+	registerTestErrorHandler(app);
+
+	// --- Protected scope (mirrors bootstrap/protected-routes.ts:30-35) ---
+	await app.register(async (api) => {
+		api.addHook("preHandler", async (request, reply) => {
+			if (!(request as any).currentUser?.id) {
+				return reply.status(401).send({ error: "Authentication required" });
+			}
+		});
+		await api.register(registerServiceRoutes);
+	});
+
+	await app.ready();
+	return { app, sessionService };
+}
+
+/**
+ * Inject a request carrying a session token that has been cookie-signed
+ * through the SAME @fastify/cookie instance the app uses. This preserves
+ * the signing contract end-to-end.
+ */
+async function injectWithToken(app: FastifyInstance, token: string | null) {
+	const headers: Record<string, string> = {};
+	if (token !== null) {
+		const signed = (app as any).signCookie(token) as string;
+		headers.cookie = `${COOKIE_NAME}=${signed}`;
+	}
+	return app.inject({ method: "GET", url: "/services", headers });
+}
+
+describe("Route-level auth enforcement (protected scope gate)", () => {
+	let prisma: ReturnType<typeof createPrismaStub>;
+	let app: FastifyInstance;
+	let sessionService: SessionService;
+
+	beforeEach(async () => {
+		prisma = createPrismaStub();
+		const built = await buildApp(prisma);
+		app = built.app;
+		sessionService = built.sessionService;
+	});
+
+	afterEach(async () => {
+		await app?.close();
+	});
+
+	it("rejects an unauthenticated request to a protected route with 401", async () => {
+		const res = await injectWithToken(app, null);
+
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.payload)).toEqual({ error: "Authentication required" });
+		// The handler below the gate must NOT have been reached.
+		expect(prisma.serviceInstance.findMany).not.toHaveBeenCalled();
+		// Validation must not have been attempted — no cookie present.
+		expect(prisma.session.findUnique).not.toHaveBeenCalled();
+	});
+
+	it("allows a request carrying a valid session and reaches the downstream handler", async () => {
+		const { token } = await sessionService.createSession("user-1", false, {
+			userAgent: "vitest",
+			ipAddress: "127.0.0.1",
+		});
+
+		const res = await injectWithToken(app, token);
+
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body).toEqual({ services: [] });
+
+		// Prove the handler ran scoped to the right user — the services list
+		// query is filtered by the session-resolved user id.
+		expect(prisma.serviceInstance.findMany).toHaveBeenCalledTimes(1);
+		const findArgs = prisma.serviceInstance.findMany.mock.calls[0]![0] as {
+			where: { userId: string };
+		};
+		expect(findArgs.where.userId).toBe("user-1");
+	});
+
+	it("rejects a tampered / unsigned cookie with 401 and never hits the DB lookup", async () => {
+		// Raw token written directly into the cookie header — no signature.
+		const res = await app.inject({
+			method: "GET",
+			url: "/services",
+			headers: { cookie: `${COOKIE_NAME}=unsigned-raw-token` },
+		});
+
+		expect(res.statusCode).toBe(401);
+		expect(prisma.session.findUnique).not.toHaveBeenCalled();
+		expect(prisma.serviceInstance.findMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects an unknown session token with 401 (validated but not found)", async () => {
+		// Cookie is signed correctly, but the token does not exist in the session store.
+		const res = await injectWithToken(app, "nonexistent-token");
+
+		expect(res.statusCode).toBe(401);
+		// Signature was valid, so we DID reach the DB lookup — and then bounced.
+		expect(prisma.session.findUnique).toHaveBeenCalledTimes(1);
+		expect(prisma.serviceInstance.findMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects an expired session with 401 AND best-effort deletes the stale row", async () => {
+		const { token } = await sessionService.createSession("user-1");
+		const hashedId = [...prisma._sessions.keys()][0]!;
+		// Force expiry in the past.
+		prisma._sessions.get(hashedId)!.expiresAt = new Date(Date.now() - 1000);
+
+		const res = await injectWithToken(app, token);
+
+		expect(res.statusCode).toBe(401);
+		expect(prisma.serviceInstance.findMany).not.toHaveBeenCalled();
+		// Side effect: the expired row must be gone — validateRequest cleans
+		// up on miss so a replay of the same cookie stays rejected.
+		expect(prisma._sessions.has(hashedId)).toBe(false);
+		expect(prisma.session.delete).toHaveBeenCalled();
+	});
+
+	it("rejects a previously-valid token after the session is invalidated", async () => {
+		const { token } = await sessionService.createSession("user-1");
+
+		// First call succeeds.
+		const ok = await injectWithToken(app, token);
+		expect(ok.statusCode).toBe(200);
+
+		// Simulate logout.
+		await sessionService.invalidateSession(token);
+
+		// Same signed cookie — now rejected because the row is gone.
+		const after = await injectWithToken(app, token);
+		expect(after.statusCode).toBe(401);
+	});
+});

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Service instance lifecycle integration tests.
+ *
+ * Existing `services.test.ts` mocks requireInstance, formatServiceInstance,
+ * tag-manager, update-builder, and testServiceConnection — each route is
+ * exercised in isolation against disposable mocks. The full create -> test
+ * -> update -> delete trajectory through a single prisma state is never
+ * covered, so regressions in side-effect ordering (e.g. an update that
+ * silently creates a new row, a delete that ignores ownership) would not
+ * be caught by the current suite.
+ *
+ * This file stands up an in-memory prisma stub whose state persists across
+ * requests and walks the real lifecycle:
+ *
+ *   1. POST /services          → create
+ *   2. GET  /services          → list reflects creation
+ *   3. POST /services/:id/test → connection success
+ *   4. POST /services/:id/test → connection failure (mocked tester)
+ *   5. PUT  /services/:id      → update (label, apiKey rotation)
+ *   6. DELETE /services/:id    → remove
+ *   7. GET  /services          → list reflects deletion
+ *
+ * The connection tester is the only thing mocked — we want deterministic
+ * success/failure without hitting the network, but everything between the
+ * HTTP surface and the DB is real.
+ */
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockTestConnection } = vi.hoisted(() => ({
+	mockTestConnection: vi.fn(),
+}));
+
+vi.mock("../../lib/services/connection-tester.js", () => ({
+	testServiceConnection: (...args: unknown[]) => mockTestConnection(...args),
+}));
+
+import { registerServiceRoutes } from "../services.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "./test-helpers.js";
+
+const USER_ID = "user-1";
+const PLAINTEXT_KEY_V1 = "initial-plaintext-api-key-1234";
+const PLAINTEXT_KEY_V2 = "rotated-plaintext-api-key-5678";
+const ENCRYPTED_V1 = "encrypted-v1-bytes";
+const ENCRYPTED_V2 = "encrypted-v2-bytes";
+const IV_V1 = "iv-v1";
+const IV_V2 = "iv-v2";
+
+/**
+ * In-memory prisma stub that persists state across requests.
+ *
+ * Models only the surfaces registerServiceRoutes touches. Tag-related
+ * methods are stubbed to empty arrays because this lifecycle suite uses
+ * tag-less payloads — the tag path has dedicated coverage elsewhere.
+ */
+function createPrismaStub() {
+	const instances = new Map<string, any>();
+	let nextId = 1;
+
+	const serviceInstance = {
+		findMany: vi.fn(async ({ where }: any) => {
+			return [...instances.values()]
+				.filter((row) => row.userId === where.userId)
+				.map((row) => ({ ...row, tags: [] }));
+		}),
+		findFirst: vi.fn(async ({ where }: any) => {
+			for (const row of instances.values()) {
+				if (where.id && row.id !== where.id) continue;
+				if (where.userId && row.userId !== where.userId) continue;
+				return { ...row, tags: [] };
+			}
+			return null;
+		}),
+		create: vi.fn(async ({ data }: any) => {
+			const id = `inst-${nextId++}`;
+			// `data.tags` is a nested-create directive; drop it for the stored row.
+			const { tags: _tags, ...rest } = data;
+			const row = {
+				id,
+				createdAt: new Date("2026-04-13T00:00:00Z"),
+				updatedAt: new Date("2026-04-13T00:00:00Z"),
+				storageGroupId: null,
+				externalUrl: null,
+				...rest,
+			};
+			instances.set(id, row);
+			return { ...row, tags: [] };
+		}),
+		updateMany: vi.fn(async ({ where, data }: any) => {
+			let count = 0;
+			for (const row of instances.values()) {
+				if (where.id && row.id !== where.id) continue;
+				if (where.userId && row.userId !== where.userId) continue;
+				if (where.NOT?.id && row.id === where.NOT.id) continue;
+				if (where.service && row.service !== where.service) continue;
+				Object.assign(row, data);
+				count++;
+			}
+			return { count };
+		}),
+		delete: vi.fn(async ({ where }: any) => {
+			const row = instances.get(where.id);
+			if (!row || (where.userId && row.userId !== where.userId)) {
+				const err = new Error("not found");
+				(err as any).code = "P2025";
+				throw err;
+			}
+			instances.delete(where.id);
+			return row;
+		}),
+	};
+
+	return {
+		_instances: instances,
+		serviceInstance,
+		serviceTag: {
+			findMany: vi.fn().mockResolvedValue([]),
+			upsert: vi.fn(),
+			delete: vi.fn(),
+		},
+		serviceInstanceTag: {
+			findFirst: vi.fn().mockResolvedValue(null),
+			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			createMany: vi.fn().mockResolvedValue({ count: 0 }),
+		},
+	};
+}
+
+/**
+ * Encryptor stub that returns different ciphertexts for different
+ * plaintexts, so we can tell whether a rotation actually persisted.
+ */
+function createEncryptorStub() {
+	return {
+		encrypt: vi.fn((plain: string) => {
+			if (plain === PLAINTEXT_KEY_V1) return { value: ENCRYPTED_V1, iv: IV_V1 };
+			if (plain === PLAINTEXT_KEY_V2) return { value: ENCRYPTED_V2, iv: IV_V2 };
+			return { value: `enc:${plain}`, iv: "iv" };
+		}),
+		decrypt: vi.fn(({ value }: { value: string }) => {
+			if (value === ENCRYPTED_V1) return PLAINTEXT_KEY_V1;
+			if (value === ENCRYPTED_V2) return PLAINTEXT_KEY_V2;
+			return "unknown";
+		}),
+	};
+}
+
+const FORBIDDEN_SECRET_FIELDS = ["encryptedApiKey", "encryptionIv", "apiKey"] as const;
+const FORBIDDEN_SECRET_VALUES = [
+	PLAINTEXT_KEY_V1,
+	PLAINTEXT_KEY_V2,
+	ENCRYPTED_V1,
+	ENCRYPTED_V2,
+	IV_V1,
+	IV_V2,
+] as const;
+
+/**
+ * Lightweight check — lifecycle-adjacent only. PR #315's
+ * services-secret-leakage.test.ts owns exhaustive secret-leakage coverage;
+ * we repeat the shape check here only to lock the lifecycle chain itself
+ * (an update that leaks a *rotated* key is a distinct regression class).
+ */
+function expectNoSecretsIn(body: unknown) {
+	const serialized = JSON.stringify(body);
+	for (const field of FORBIDDEN_SECRET_FIELDS) {
+		expect(serialized).not.toContain(`"${field}"`);
+	}
+	for (const value of FORBIDDEN_SECRET_VALUES) {
+		expect(serialized).not.toContain(value);
+	}
+}
+
+describe("Service instance lifecycle", () => {
+	let app: FastifyInstance;
+	let prisma: ReturnType<typeof createPrismaStub>;
+	let encryptor: ReturnType<typeof createEncryptorStub>;
+	let inject: ReturnType<typeof createInjectAuthenticated>;
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		mockTestConnection.mockReset();
+
+		prisma = createPrismaStub();
+		encryptor = createEncryptorStub();
+
+		app = Fastify();
+		app.decorate("prisma", prisma as any);
+		app.decorate("encryptor", encryptor as any);
+		app.decorate("notificationService", {
+			notify: vi.fn().mockResolvedValue(undefined),
+		} as never);
+
+		setupAuthInjection(app, { id: USER_ID, username: "admin" });
+		registerTestErrorHandler(app);
+
+		await app.register(registerServiceRoutes);
+		await app.ready();
+
+		inject = createInjectAuthenticated(app);
+	});
+
+	afterEach(async () => {
+		await app?.close();
+	});
+
+	it("walks create → list → test(success) → test(failure) → update → delete with correct side effects", async () => {
+		// --- 1. CREATE ---------------------------------------------------------
+		const createRes = await inject("POST", "/services", {
+			body: {
+				label: "Sonarr Main",
+				baseUrl: "http://sonarr:8989",
+				apiKey: PLAINTEXT_KEY_V1,
+				service: "sonarr",
+			},
+		});
+
+		expect(createRes.statusCode).toBe(201);
+		const created = JSON.parse(createRes.payload).service;
+
+		// Response contract: public fields only, no secrets, hasApiKey flag set.
+		expect(created).toMatchObject({
+			service: "sonarr",
+			label: "Sonarr Main",
+			baseUrl: "http://sonarr:8989",
+			enabled: true,
+			isDefault: false,
+			hasApiKey: true,
+		});
+		expect(created.id).toMatch(/^inst-/);
+		expectNoSecretsIn(createRes.payload);
+
+		// Side effect: the ciphertext landed in the DB, not the plaintext.
+		const storedAfterCreate = prisma._instances.get(created.id);
+		expect(storedAfterCreate).toBeDefined();
+		expect(storedAfterCreate.encryptedApiKey).toBe(ENCRYPTED_V1);
+		expect(storedAfterCreate.encryptionIv).toBe(IV_V1);
+		expect(storedAfterCreate.userId).toBe(USER_ID);
+		// And encrypt was called with the plaintext exactly once.
+		expect(encryptor.encrypt).toHaveBeenCalledWith(PLAINTEXT_KEY_V1);
+
+		// --- 2. LIST reflects creation ----------------------------------------
+		const listRes = await inject("GET", "/services");
+		expect(listRes.statusCode).toBe(200);
+		const listBody = JSON.parse(listRes.payload);
+		expect(listBody.services).toHaveLength(1);
+		expect(listBody.services[0].id).toBe(created.id);
+		expectNoSecretsIn(listRes.payload);
+
+		// --- 3. TEST CONNECTION (success) -------------------------------------
+		mockTestConnection.mockResolvedValueOnce({
+			success: true,
+			message: "Successfully connected to Sonarr",
+			version: "4.0.0",
+		});
+
+		const testOk = await inject("POST", `/services/${created.id}/test`);
+		expect(testOk.statusCode).toBe(200);
+		const okBody = JSON.parse(testOk.payload);
+		expect(okBody).toEqual({
+			success: true,
+			message: "Successfully connected to Sonarr",
+			version: "4.0.0",
+		});
+
+		// Side effect: tester was invoked with the decrypted key — the route
+		// is the only caller that decrypts for an outbound call. If this ever
+		// regresses to passing ciphertext, all test-connection buttons break.
+		expect(mockTestConnection).toHaveBeenCalledWith(
+			"http://sonarr:8989",
+			PLAINTEXT_KEY_V1,
+			"sonarr",
+		);
+
+		// --- 4. TEST CONNECTION (failure) -------------------------------------
+		mockTestConnection.mockResolvedValueOnce({
+			success: false,
+			error: "Connection refused",
+			details: "Could not connect to the service.",
+		});
+
+		const testFail = await inject("POST", `/services/${created.id}/test`);
+		// Contract: connection failure is returned as 200 with success:false
+		// (the HTTP call succeeded; the *probe* failed). This is what the UI
+		// depends on to render the error banner vs. a blown-up toast.
+		expect(testFail.statusCode).toBe(200);
+		const failBody = JSON.parse(testFail.payload);
+		expect(failBody).toMatchObject({
+			success: false,
+			error: "Connection refused",
+		});
+
+		// Failure path must NOT mutate the stored instance.
+		const storedAfterFail = prisma._instances.get(created.id);
+		expect(storedAfterFail.encryptedApiKey).toBe(ENCRYPTED_V1);
+		expect(storedAfterFail.encryptionIv).toBe(IV_V1);
+
+		// --- 5. UPDATE (label + API key rotation) -----------------------------
+		const updateRes = await inject("PUT", `/services/${created.id}`, {
+			body: {
+				label: "Sonarr Renamed",
+				apiKey: PLAINTEXT_KEY_V2,
+			},
+		});
+
+		expect(updateRes.statusCode).toBe(200);
+		const updated = JSON.parse(updateRes.payload).service;
+		expect(updated.label).toBe("Sonarr Renamed");
+		expect(updated.id).toBe(created.id);
+		expect(updated.hasApiKey).toBe(true);
+		// Rotated secrets must not appear in the response either.
+		expectNoSecretsIn(updateRes.payload);
+
+		// Side effect: the NEW ciphertext replaced the old in the store.
+		const storedAfterUpdate = prisma._instances.get(created.id);
+		expect(storedAfterUpdate.label).toBe("Sonarr Renamed");
+		expect(storedAfterUpdate.encryptedApiKey).toBe(ENCRYPTED_V2);
+		expect(storedAfterUpdate.encryptionIv).toBe(IV_V2);
+		expect(encryptor.encrypt).toHaveBeenCalledWith(PLAINTEXT_KEY_V2);
+
+		// --- 6. DELETE --------------------------------------------------------
+		const delRes = await inject("DELETE", `/services/${created.id}`);
+		expect(delRes.statusCode).toBe(204);
+		expect(delRes.payload).toBe("");
+		expect(prisma._instances.has(created.id)).toBe(false);
+
+		// --- 7. LIST reflects deletion ----------------------------------------
+		const listAfter = await inject("GET", "/services");
+		expect(listAfter.statusCode).toBe(200);
+		expect(JSON.parse(listAfter.payload).services).toHaveLength(0);
+	});
+
+	it("PUT against a non-existent instance id returns 404 (ownership gate via requireInstance)", async () => {
+		const res = await inject("PUT", "/services/inst-does-not-exist", {
+			body: { label: "nope" },
+		});
+
+		expect(res.statusCode).toBe(404);
+		// No write should have fired.
+		expect(prisma.serviceInstance.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("DELETE against a non-existent instance id returns 404 without issuing prisma.delete", async () => {
+		const res = await inject("DELETE", "/services/inst-does-not-exist");
+
+		expect(res.statusCode).toBe(404);
+		// requireInstance must have short-circuited before the raw delete call.
+		expect(prisma.serviceInstance.delete).not.toHaveBeenCalled();
+	});
+
+	it("POST /services/:id/test against a non-existent instance returns 404 and never calls the tester", async () => {
+		const res = await inject("POST", "/services/inst-nope/test");
+
+		expect(res.statusCode).toBe(404);
+		expect(mockTestConnection).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

Follow-up to #315 that closes the two coverage gaps the previous PR intentionally deferred: true route-level auth behavior and the end-to-end service-instance lifecycle.

- **`route-auth-enforcement.test.ts`** — stands up the real `@fastify/cookie` plugin + `SessionService` + the exact preHandler pair from `server.ts:84-94` and `bootstrap/protected-routes.ts:31-35`, then exercises a real protected route (`registerServiceRoutes`) through genuine cookie-based auth. Covers unauthenticated 401, valid-session pass-through, tampered/unsigned cookie rejection, unknown token, expired session (with best-effort row cleanup side effect), and post-logout rejection of a previously valid token. Signing uses `app.signCookie` so the signing contract end-to-end matches production.
- **`service-lifecycle.test.ts`** — walks create → list → test(success) → test(failure) → update (with API-key rotation) → delete through a single in-memory prisma stub whose state persists across requests. Asserts response contracts, ciphertext persistence, that the failure path of test-connection does not mutate stored state, and 404 short-circuits for PUT/DELETE/test against missing instance ids (ownership gate via `requireInstance`).

10 new tests, all passing. No production code changes. The `testServiceConnection` helper is the only thing mocked in the lifecycle suite — everything between the HTTP surface and the DB is real.

## What this does NOT cover (and why)

- **Exhaustive secret non-leakage matrix** — #315's `services-secret-leakage.test.ts` owns that. Lifecycle suite only spot-checks per-hop shape and adds one rotation-specific check (new ciphertext must not leak on PUT) that #315 did not cover.
- **OIDC internals** — scoped out per task brief; `auth-oidc.test.ts` already owns OIDC state.
- **Tag lifecycle internals** — unit tests already cover `tag-manager.ts`; the lifecycle suite stubs `serviceInstanceTag` to avoid duplicating that signal.

## Test plan

- [x] `pnpm --filter @arr/api test` — 1242 passed, 36 skipped (10 new)
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec biome lint` on new files — clean
- [x] Verified new suites exercise the real preHandler chain (not `setupAuthInjection`) by confirming `prisma.session.findUnique` is invoked on the signed-cookie path and skipped on the no-cookie / tampered-cookie paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)