### PR TITLE
feat(security): Security Posture diagnostic panel in System tab

### DIFF
--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Unit tests for the pure security-posture evaluator.
+ *
+ * The evaluator has no IO, so every scenario can be expressed as a plain
+ * input object. Tests target the specific conditions that matter for admins:
+ *   - The dangerous combos that warrant "misconfigured".
+ *   - The nudges that warrant "warning".
+ *   - The healthy baseline (to guard against severity drift).
+ *   - The overall roll-up reducer.
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluateSecurityPosture, type SecurityPostureInput } from "../security-posture.js";
+
+type Overrides = Omit<Partial<SecurityPostureInput>, "env"> & {
+	env?: Partial<SecurityPostureInput["env"]>;
+};
+
+function baseInput(overrides: Overrides = {}): SecurityPostureInput {
+	return {
+		env: {
+			NODE_ENV: "development",
+			TRUST_PROXY: false,
+			COOKIE_SECURE: undefined,
+			SESSION_TTL_HOURS: 24,
+			SESSION_COOKIE_NAME: "arr_session",
+			PASSWORD_POLICY: "strict",
+			APP_URL: "http://localhost:3000",
+			...overrides.env,
+		},
+		oidcEnabled: overrides.oidcEnabled ?? false,
+		passkeyCount: overrides.passkeyCount ?? 0,
+		passwordUserCount: overrides.passwordUserCount ?? 1,
+		totalUserCount: overrides.totalUserCount ?? 1,
+	};
+}
+
+function checkById(result: ReturnType<typeof evaluateSecurityPosture>, id: string) {
+	const check = result.checks.find((c) => c.id === id);
+	if (!check) throw new Error(`missing check: ${id}`);
+	return check;
+}
+
+describe("evaluateSecurityPosture", () => {
+	describe("healthy baseline", () => {
+		it("returns overall=healthy for a dev setup with password-only on localhost http", () => {
+			// Dev + password-only would normally flag the auth-strength warning,
+			// so we enroll a passkey here to get an all-green baseline and guard
+			// against severity drift in future changes.
+			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 1 }));
+
+			expect(result.overall).toBe("healthy");
+			expect(result.checks.every((c) => c.severity === "healthy")).toBe(true);
+		});
+
+		it("exposes effective runtime values verbatim for the UI", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						SESSION_TTL_HOURS: 12,
+						SESSION_COOKIE_NAME: "arr_session",
+						PASSWORD_POLICY: "strict",
+						APP_URL: "https://arr.example.com",
+					},
+					oidcEnabled: true,
+				}),
+			);
+
+			expect(result.effective).toEqual({
+				nodeEnv: "production",
+				trustProxy: true,
+				secureCookies: true,
+				sessionTtlHours: 12,
+				sessionCookieName: "arr_session",
+				passwordPolicy: "strict",
+				appUrl: "https://arr.example.com",
+			});
+			expect(result.auth).toEqual({
+				passwordEnabled: true,
+				passwordUserCount: 1,
+				oidcEnabled: true,
+				passkeyCount: 0,
+			});
+		});
+	});
+
+	describe("secure cookies + trust proxy", () => {
+		it("flags secure cookies without trust proxy as misconfigured (lockout risk)", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: { NODE_ENV: "production", TRUST_PROXY: false, COOKIE_SECURE: true },
+				}),
+			);
+
+			const check = checkById(result, "secure-cookies");
+			expect(check.severity).toBe("misconfigured");
+			expect(check.remediation).toBeDefined();
+			expect(result.overall).toBe("misconfigured");
+		});
+
+		it("auto-derives secureCookies=true from TRUST_PROXY=true when COOKIE_SECURE is unset", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: { TRUST_PROXY: true, COOKIE_SECURE: undefined },
+				}),
+			);
+
+			expect(result.effective.secureCookies).toBe(true);
+			expect(checkById(result, "secure-cookies").severity).toBe("healthy");
+		});
+
+		it("warns when secure cookies are disabled in production", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: false,
+						COOKIE_SECURE: false,
+						APP_URL: "https://arr.example.com",
+					},
+					passkeyCount: 1, // avoid tripping the auth-strength warning
+				}),
+			);
+
+			const check = checkById(result, "secure-cookies");
+			expect(check.severity).toBe("warning");
+			expect(result.overall).toBe("warning");
+		});
+
+		it("treats insecure cookies as acceptable in development", () => {
+			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 1 }));
+			expect(checkById(result, "secure-cookies").severity).toBe("healthy");
+		});
+	});
+
+	describe("authentication posture", () => {
+		it("warns on password-only auth and suggests stronger methods", () => {
+			const result = evaluateSecurityPosture(baseInput({ oidcEnabled: false, passkeyCount: 0 }));
+
+			const check = checkById(result, "authentication");
+			expect(check.severity).toBe("warning");
+			expect(check.detail).toContain("Password-only");
+		});
+
+		it("marks authentication healthy when OIDC is enabled alongside password", () => {
+			const result = evaluateSecurityPosture(baseInput({ oidcEnabled: true }));
+
+			const check = checkById(result, "authentication");
+			expect(check.severity).toBe("healthy");
+			expect(check.detail).toContain("password");
+			expect(check.detail).toContain("OIDC");
+		});
+
+		it("marks authentication healthy when passkeys are enrolled", () => {
+			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 3 }));
+
+			const check = checkById(result, "authentication");
+			expect(check.severity).toBe("healthy");
+			expect(check.detail).toContain("3 passkeys");
+		});
+
+		it("pluralizes passkeys correctly for a single credential", () => {
+			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 1 }));
+			expect(checkById(result, "authentication").detail).toContain("1 passkey");
+			expect(checkById(result, "authentication").detail).not.toContain("passkeys");
+		});
+
+		it("warns when no users exist (setup not completed)", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({ totalUserCount: 0, passwordUserCount: 0 }),
+			);
+			expect(checkById(result, "authentication").severity).toBe("warning");
+		});
+
+		it("reports misconfigured when users exist but no auth methods are active", () => {
+			// Synthetic edge case — guard for a user with hashedPassword=null, no OIDC, no passkeys.
+			const result = evaluateSecurityPosture(
+				baseInput({ totalUserCount: 1, passwordUserCount: 0, oidcEnabled: false, passkeyCount: 0 }),
+			);
+			expect(checkById(result, "authentication").severity).toBe("misconfigured");
+			expect(result.overall).toBe("misconfigured");
+		});
+	});
+
+	describe("password policy", () => {
+		it("warns when relaxed policy runs in production", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						PASSWORD_POLICY: "relaxed",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "https://arr.example.com",
+					},
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "password-policy").severity).toBe("warning");
+		});
+
+		it("does not warn on relaxed policy in development", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: { PASSWORD_POLICY: "relaxed" },
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "password-policy").severity).toBe("healthy");
+		});
+	});
+
+	describe("session TTL", () => {
+		it("warns on long-lived sessions in production (>14 days)", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						SESSION_TTL_HOURS: 24 * 30,
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "https://arr.example.com",
+					},
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "session-ttl").severity).toBe("warning");
+		});
+
+		it("does not warn on default 24h TTL", () => {
+			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 1 }));
+			expect(checkById(result, "session-ttl").severity).toBe("healthy");
+		});
+	});
+
+	describe("app URL", () => {
+		it("warns on non-https APP_URL in production", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						APP_URL: "http://arr.example.com",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+					},
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "app-url").severity).toBe("warning");
+		});
+
+		it("warns when secure cookies are on but APP_URL is http", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "http://arr.example.com",
+					},
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "app-url").severity).toBe("warning");
+		});
+
+		it("handles a malformed APP_URL without throwing", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: { NODE_ENV: "production", APP_URL: "not-a-url" },
+					passkeyCount: 1,
+				}),
+			);
+			expect(checkById(result, "app-url").severity).toBe("warning");
+		});
+	});
+
+	describe("overall severity roll-up", () => {
+		it("returns misconfigured when any single check is misconfigured", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: { TRUST_PROXY: false, COOKIE_SECURE: true },
+					passkeyCount: 1,
+				}),
+			);
+			expect(result.overall).toBe("misconfigured");
+		});
+
+		it("returns warning when the worst severity is a warning", () => {
+			// Password-only auth fires the warning, nothing else does
+			const result = evaluateSecurityPosture(baseInput({ oidcEnabled: false, passkeyCount: 0 }));
+			expect(result.overall).toBe("warning");
+		});
+	});
+});

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -1,0 +1,305 @@
+/**
+ * Pure security-posture evaluator.
+ *
+ * Takes a snapshot of the effective runtime configuration + auth state and
+ * returns a structured set of posture facts + warnings. Designed to be
+ * dependency-free so it can be unit-tested without a Fastify/Prisma harness —
+ * the route handler is responsible for gathering the inputs.
+ *
+ * Design notes:
+ *   - "Effective" values mean "what is actually being used at runtime", not
+ *     "what is stored in the DB settings singleton". The /system/settings
+ *     endpoint already models this distinction; we follow the same convention.
+ *   - Severity levels map 1:1 to UI StatusBadge variants:
+ *       healthy        -> success
+ *       warning        -> warning
+ *       misconfigured  -> error
+ *   - Every check is backed by real app state. No speculative "best-practice"
+ *     nudges that aren't tied to a concrete condition we can detect.
+ */
+
+export type SecuritySeverity = "healthy" | "warning" | "misconfigured";
+
+export interface SecurityCheck {
+	/** Stable machine-readable identifier (kept in sync with UI copy). */
+	id: string;
+	/** Short human-readable label. */
+	label: string;
+	/** One-line operational detail explaining the current state. */
+	detail: string;
+	/** Overall severity of this check. */
+	severity: SecuritySeverity;
+	/**
+	 * Optional remediation hint — a brief, concrete next step. Present only
+	 * when severity !== "healthy" and a meaningful action exists.
+	 */
+	remediation?: string;
+}
+
+export interface SecurityPostureInput {
+	/** From app.config — effective runtime env, not DB-stored settings. */
+	env: {
+		NODE_ENV: "development" | "test" | "production";
+		TRUST_PROXY: boolean;
+		/** Undefined means "auto-derive from TRUST_PROXY". */
+		COOKIE_SECURE: boolean | undefined;
+		SESSION_TTL_HOURS: number;
+		SESSION_COOKIE_NAME: string;
+		PASSWORD_POLICY: "strict" | "relaxed";
+		APP_URL: string;
+	};
+	/** True if at least one OIDC provider is enabled. */
+	oidcEnabled: boolean;
+	/** Total passkey credentials registered across all users. */
+	passkeyCount: number;
+	/** Count of users with a password set (hashedPassword IS NOT NULL). */
+	passwordUserCount: number;
+	/** Total user count. */
+	totalUserCount: number;
+}
+
+export interface SecurityPostureResult {
+	/** Computed roll-up severity — the worst severity across all checks. */
+	overall: SecuritySeverity;
+	/** Individual posture checks. */
+	checks: SecurityCheck[];
+	/** Effective runtime values surfaced verbatim for the UI. */
+	effective: {
+		nodeEnv: "development" | "test" | "production";
+		trustProxy: boolean;
+		secureCookies: boolean;
+		sessionTtlHours: number;
+		sessionCookieName: string;
+		passwordPolicy: "strict" | "relaxed";
+		appUrl: string;
+	};
+	/** Auth-method summary for the UI. */
+	auth: {
+		passwordEnabled: boolean;
+		passwordUserCount: number;
+		oidcEnabled: boolean;
+		passkeyCount: number;
+	};
+}
+
+/** Worst-case reducer for the overall roll-up. */
+function worstSeverity(checks: SecurityCheck[]): SecuritySeverity {
+	if (checks.some((c) => c.severity === "misconfigured")) return "misconfigured";
+	if (checks.some((c) => c.severity === "warning")) return "warning";
+	return "healthy";
+}
+
+export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPostureResult {
+	const effectiveSecureCookies = input.env.COOKIE_SECURE ?? input.env.TRUST_PROXY;
+	const isProduction = input.env.NODE_ENV === "production";
+	const passwordEnabled = input.passwordUserCount > 0;
+	const appUrlProtocol = safeProtocol(input.env.APP_URL);
+	const appUrlIsHttps = appUrlProtocol === "https:";
+
+	const checks: SecurityCheck[] = [];
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 1. Trust Proxy
+	// ──────────────────────────────────────────────────────────────────────
+	checks.push({
+		id: "trust-proxy",
+		label: "Trust Proxy",
+		detail: input.env.TRUST_PROXY
+			? "Enabled — X-Forwarded-* headers from the reverse proxy are trusted."
+			: "Disabled — the app does not trust proxy-forwarded headers.",
+		severity: "healthy",
+	});
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 2. Secure Cookies
+	// ──────────────────────────────────────────────────────────────────────
+	if (effectiveSecureCookies && !input.env.TRUST_PROXY) {
+		// The /system/settings PUT handler already blocks this combo, but the
+		// env-var path (COOKIE_SECURE=true + TRUST_PROXY=false) can still produce
+		// it. Users get locked out over plain HTTP because the browser refuses
+		// to send the Secure cookie.
+		checks.push({
+			id: "secure-cookies",
+			label: "Secure Cookies",
+			detail: "Enabled, but Trust Proxy is off — session cookies will not be sent over HTTP.",
+			severity: "misconfigured",
+			remediation:
+				"Enable Trust Proxy (when terminating TLS at a reverse proxy) or set COOKIE_SECURE=false.",
+		});
+	} else if (effectiveSecureCookies) {
+		checks.push({
+			id: "secure-cookies",
+			label: "Secure Cookies",
+			detail: "Enabled — session cookies are only sent over HTTPS.",
+			severity: "healthy",
+		});
+	} else if (isProduction) {
+		checks.push({
+			id: "secure-cookies",
+			label: "Secure Cookies",
+			detail: "Disabled in production — session cookies can be intercepted over plain HTTP.",
+			severity: "warning",
+			remediation: "Enable Trust Proxy behind HTTPS, or set COOKIE_SECURE=true.",
+		});
+	} else {
+		checks.push({
+			id: "secure-cookies",
+			label: "Secure Cookies",
+			detail: "Disabled — acceptable for local development over HTTP.",
+			severity: "healthy",
+		});
+	}
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 3. Authentication posture
+	// ──────────────────────────────────────────────────────────────────────
+	const authMethodCount =
+		(passwordEnabled ? 1 : 0) + (input.oidcEnabled ? 1 : 0) + (input.passkeyCount > 0 ? 1 : 0);
+
+	if (input.totalUserCount === 0) {
+		checks.push({
+			id: "authentication",
+			label: "Authentication",
+			detail: "No users exist — initial setup has not been completed.",
+			severity: "warning",
+			remediation: "Complete the initial setup to create an admin account.",
+		});
+	} else if (authMethodCount === 0) {
+		// Shouldn't happen if users exist (setup requires a password), but guard anyway.
+		checks.push({
+			id: "authentication",
+			label: "Authentication",
+			detail: "No authentication methods are currently enabled.",
+			severity: "misconfigured",
+			remediation: "Enable password auth, OIDC, or register a passkey.",
+		});
+	} else if (passwordEnabled && !input.oidcEnabled && input.passkeyCount === 0) {
+		checks.push({
+			id: "authentication",
+			label: "Authentication",
+			detail: "Password-only authentication is in use.",
+			severity: "warning",
+			remediation: "Consider enrolling a passkey or enabling OIDC for phishing-resistant sign-in.",
+		});
+	} else {
+		checks.push({
+			id: "authentication",
+			label: "Authentication",
+			detail: buildAuthDetail(passwordEnabled, input.oidcEnabled, input.passkeyCount),
+			severity: "healthy",
+		});
+	}
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 4. Password policy (informational — only flagged if relaxed in prod)
+	// ──────────────────────────────────────────────────────────────────────
+	if (input.env.PASSWORD_POLICY === "relaxed" && isProduction) {
+		checks.push({
+			id: "password-policy",
+			label: "Password Policy",
+			detail: "Relaxed policy is active in production.",
+			severity: "warning",
+			remediation: "Set PASSWORD_POLICY=strict to require stronger passwords.",
+		});
+	} else {
+		checks.push({
+			id: "password-policy",
+			label: "Password Policy",
+			detail:
+				input.env.PASSWORD_POLICY === "strict"
+					? "Strict — 12+ characters with mixed classes required."
+					: "Relaxed — acceptable for local development.",
+			severity: "healthy",
+		});
+	}
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 5. Session lifetime
+	// ──────────────────────────────────────────────────────────────────────
+	// The schema clamps TTL at 30 days (720h). Flag anything over 14 days as
+	// informational-warning in production — long-lived sessions amplify the
+	// blast radius of a stolen cookie.
+	const SESSION_TTL_WARN_HOURS = 24 * 14;
+	if (isProduction && input.env.SESSION_TTL_HOURS > SESSION_TTL_WARN_HOURS) {
+		checks.push({
+			id: "session-ttl",
+			label: "Session Lifetime",
+			detail: `Sessions last ${input.env.SESSION_TTL_HOURS}h — long-lived cookies increase risk if stolen.`,
+			severity: "warning",
+			remediation: `Reduce SESSION_TTL_HOURS (default 24, current ${input.env.SESSION_TTL_HOURS}).`,
+		});
+	} else {
+		checks.push({
+			id: "session-ttl",
+			label: "Session Lifetime",
+			detail: `Sessions last ${input.env.SESSION_TTL_HOURS}h (HttpOnly, SameSite=Lax).`,
+			severity: "healthy",
+		});
+	}
+
+	// ──────────────────────────────────────────────────────────────────────
+	// 6. App URL consistency
+	// ──────────────────────────────────────────────────────────────────────
+	if (isProduction && !appUrlIsHttps) {
+		checks.push({
+			id: "app-url",
+			label: "App URL",
+			detail: `APP_URL uses ${appUrlProtocol ?? "an unrecognized protocol"} in production.`,
+			severity: "warning",
+			remediation: "Set APP_URL to an https:// origin so OIDC redirect URIs and links are secure.",
+		});
+	} else if (effectiveSecureCookies && !appUrlIsHttps) {
+		checks.push({
+			id: "app-url",
+			label: "App URL",
+			detail: "Secure cookies are enabled but APP_URL is not https — clients may fail to log in.",
+			severity: "warning",
+			remediation: "Update APP_URL to match the public https:// origin.",
+		});
+	} else {
+		checks.push({
+			id: "app-url",
+			label: "App URL",
+			detail: `${input.env.APP_URL}`,
+			severity: "healthy",
+		});
+	}
+
+	const effective = {
+		nodeEnv: input.env.NODE_ENV,
+		trustProxy: input.env.TRUST_PROXY,
+		secureCookies: effectiveSecureCookies,
+		sessionTtlHours: input.env.SESSION_TTL_HOURS,
+		sessionCookieName: input.env.SESSION_COOKIE_NAME,
+		passwordPolicy: input.env.PASSWORD_POLICY,
+		appUrl: input.env.APP_URL,
+	};
+
+	return {
+		overall: worstSeverity(checks),
+		checks,
+		effective,
+		auth: {
+			passwordEnabled,
+			passwordUserCount: input.passwordUserCount,
+			oidcEnabled: input.oidcEnabled,
+			passkeyCount: input.passkeyCount,
+		},
+	};
+}
+
+function buildAuthDetail(password: boolean, oidc: boolean, passkeys: number): string {
+	const parts: string[] = [];
+	if (password) parts.push("password");
+	if (oidc) parts.push("OIDC");
+	if (passkeys > 0) parts.push(`${passkeys} passkey${passkeys === 1 ? "" : "s"}`);
+	return `Active methods: ${parts.join(", ")}.`;
+}
+
+function safeProtocol(url: string): string | null {
+	try {
+		return new URL(url).protocol;
+	} catch {
+		return null;
+	}
+}

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -3,14 +3,15 @@ import { readdir, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import type { FastifyPluginCallback } from "fastify";
 import { LOG_DIR, LOG_LEVEL, LOG_MAX_FILES, LOG_MAX_SIZE } from "../lib/logger.js";
+import { evaluateSecurityPosture } from "../lib/security/security-posture.js";
 import { getAppVersionInfo } from "../lib/utils/version.js";
+import { KNOWN_INTEGRATIONS } from "../lib/validation/index.js";
 import { integrationHealth } from "../lib/validation/integration-health.js";
 import { schemaFingerprints } from "../lib/validation/schema-fingerprint.js";
-import { KNOWN_INTEGRATIONS } from "../lib/validation/index.js";
 import {
-	type ValidationMode,
 	getAllValidationModes,
 	setValidationMode,
+	type ValidationMode,
 } from "../lib/validation/validate-batch.js";
 import { validationQuarantine } from "../lib/validation/validation-quarantine.js";
 
@@ -565,6 +566,52 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			data: {
 				jobs,
 				count: jobs.length,
+				capturedAt: new Date().toISOString(),
+			},
+		});
+	});
+
+	/**
+	 * GET /system/security-posture
+	 * Read-only snapshot of the effective security configuration plus a list
+	 * of derived posture checks (healthy / warning / misconfigured).
+	 *
+	 * Inputs gathered: app.config (effective env), enabled OIDC providers,
+	 * total passkey credentials, count of users with a password set.
+	 *
+	 * Security: Requires authentication (single-admin architecture).
+	 */
+	app.get("/security-posture", async (_request, reply) => {
+		const [oidcProvider, passkeyCount, passwordUserCount, totalUserCount] = await Promise.all([
+			app.prisma.oIDCProvider.findFirst({
+				where: { enabled: true },
+				select: { id: true },
+			}),
+			app.prisma.webAuthnCredential.count(),
+			app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
+			app.prisma.user.count(),
+		]);
+
+		const result = evaluateSecurityPosture({
+			env: {
+				NODE_ENV: app.config.NODE_ENV,
+				TRUST_PROXY: app.config.TRUST_PROXY,
+				COOKIE_SECURE: app.config.COOKIE_SECURE,
+				SESSION_TTL_HOURS: app.config.SESSION_TTL_HOURS,
+				SESSION_COOKIE_NAME: app.config.SESSION_COOKIE_NAME,
+				PASSWORD_POLICY: app.config.PASSWORD_POLICY,
+				APP_URL: app.config.APP_URL,
+			},
+			oidcEnabled: oidcProvider !== null,
+			passkeyCount,
+			passwordUserCount,
+			totalUserCount,
+		});
+
+		return reply.send({
+			success: true,
+			data: {
+				...result,
 				capturedAt: new Date().toISOString(),
 			},
 		});

--- a/apps/web/src/features/settings/components/security-posture-section.tsx
+++ b/apps/web/src/features/settings/components/security-posture-section.tsx
@@ -1,0 +1,282 @@
+"use client";
+
+/**
+ * Security Posture section.
+ *
+ * Read-only diagnostic surface that answers three operator questions:
+ *   1. Am I running this safely?              -> overall badge
+ *   2. What is misconfigured right now?       -> per-check severity + detail
+ *   3. What should I fix first?               -> remediation hints
+ *
+ * All severity / copy decisions come from the backend evaluator
+ * (`evaluateSecurityPosture`). This component is presentation-only.
+ */
+
+import {
+	AlertTriangle,
+	CheckCircle2,
+	Fingerprint,
+	KeyRound,
+	ShieldAlert,
+	ShieldCheck,
+	ShieldX,
+	UserCheck,
+} from "lucide-react";
+import type { ReactNode } from "react";
+import { PremiumSection, PremiumSkeleton, StatusBadge } from "../../../components/layout";
+import type {
+	SecurityCheck,
+	SecurityPosture,
+	SecuritySeverity,
+} from "../../../lib/api-client/system";
+import { cn } from "../../../lib/utils";
+
+interface Props {
+	posture: SecurityPosture | undefined;
+	isLoading: boolean;
+}
+
+const SEVERITY_BADGE: Record<
+	SecuritySeverity,
+	{ variant: "success" | "warning" | "error"; icon: typeof CheckCircle2; label: string }
+> = {
+	healthy: { variant: "success", icon: CheckCircle2, label: "Healthy" },
+	warning: { variant: "warning", icon: AlertTriangle, label: "Warning" },
+	misconfigured: { variant: "error", icon: ShieldX, label: "Misconfigured" },
+};
+
+const OVERALL_COPY: Record<SecuritySeverity, { title: string; description: string }> = {
+	healthy: {
+		title: "All checks passing",
+		description: "No misconfigurations detected in your current security setup.",
+	},
+	warning: {
+		title: "Recommended improvements",
+		description:
+			"Your setup is functional but a hardening opportunity is available — review the warnings below.",
+	},
+	misconfigured: {
+		title: "Action required",
+		description:
+			"At least one critical security setting is misconfigured. Address the items below to avoid lockouts or insecure sessions.",
+	},
+};
+
+const OVERALL_ICON: Record<SecuritySeverity, typeof ShieldCheck> = {
+	healthy: ShieldCheck,
+	warning: ShieldAlert,
+	misconfigured: ShieldX,
+};
+
+export function SecurityPostureSection({ posture, isLoading }: Props) {
+	if (isLoading && !posture) {
+		return (
+			<PremiumSection
+				title="Security Posture"
+				description="Effective runtime security configuration and warnings"
+				icon={ShieldCheck}
+			>
+				<div className="space-y-3">
+					<PremiumSkeleton className="h-20" />
+					<PremiumSkeleton className="h-12" />
+					<PremiumSkeleton className="h-12" />
+					<PremiumSkeleton className="h-12" />
+				</div>
+			</PremiumSection>
+		);
+	}
+
+	if (!posture) {
+		return (
+			<PremiumSection
+				title="Security Posture"
+				description="Effective runtime security configuration and warnings"
+				icon={ShieldCheck}
+			>
+				<p className="text-sm text-muted-foreground">Unable to load security posture.</p>
+			</PremiumSection>
+		);
+	}
+
+	// Sort: misconfigured -> warning -> healthy. Within a severity, preserve
+	// backend insertion order so the operator-prioritized list matches the
+	// rule order in security-posture.ts.
+	const severityRank: Record<SecuritySeverity, number> = {
+		misconfigured: 0,
+		warning: 1,
+		healthy: 2,
+	};
+	const sortedChecks = [...posture.checks].sort(
+		(a, b) => severityRank[a.severity] - severityRank[b.severity],
+	);
+
+	return (
+		<PremiumSection
+			title="Security Posture"
+			description="Effective runtime security configuration and warnings"
+			icon={ShieldCheck}
+		>
+			<div className="space-y-4">
+				<OverallBanner posture={posture} />
+				<AuthSummary posture={posture} />
+				<div className="space-y-2">
+					{sortedChecks.map((check, index) => (
+						<CheckRow key={check.id} check={check} index={index} />
+					))}
+				</div>
+				<EnvironmentFootnote posture={posture} />
+			</div>
+		</PremiumSection>
+	);
+}
+
+function OverallBanner({ posture }: { posture: SecurityPosture }) {
+	const Icon = OVERALL_ICON[posture.overall];
+	const copy = OVERALL_COPY[posture.overall];
+	const badge = SEVERITY_BADGE[posture.overall];
+
+	const tone =
+		posture.overall === "misconfigured"
+			? "border-red-500/30 bg-red-500/5"
+			: posture.overall === "warning"
+				? "border-amber-500/30 bg-amber-500/5"
+				: "border-emerald-500/30 bg-emerald-500/5";
+
+	const iconTone =
+		posture.overall === "misconfigured"
+			? "text-red-500"
+			: posture.overall === "warning"
+				? "text-amber-500"
+				: "text-emerald-500";
+
+	return (
+		<div className={cn("flex items-start gap-3 rounded-xl border p-4", tone)}>
+			<Icon className={cn("h-6 w-6 shrink-0 mt-0.5", iconTone)} aria-hidden="true" />
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<p className="text-sm font-semibold text-foreground">{copy.title}</p>
+					<StatusBadge status={badge.variant} icon={badge.icon}>
+						{badge.label}
+					</StatusBadge>
+				</div>
+				<p className="text-xs text-muted-foreground mt-1">{copy.description}</p>
+			</div>
+		</div>
+	);
+}
+
+function AuthSummary({ posture }: { posture: SecurityPosture }) {
+	return (
+		<div className="grid gap-2 sm:grid-cols-3">
+			<AuthBadge
+				icon={KeyRound}
+				label="Password auth"
+				active={posture.auth.passwordEnabled}
+				detail={
+					posture.auth.passwordEnabled
+						? `${posture.auth.passwordUserCount} user${
+								posture.auth.passwordUserCount === 1 ? "" : "s"
+							}`
+						: "No users with password set"
+				}
+			/>
+			<AuthBadge
+				icon={UserCheck}
+				label="OIDC"
+				active={posture.auth.oidcEnabled}
+				detail={posture.auth.oidcEnabled ? "Provider enabled" : "Not configured"}
+			/>
+			<AuthBadge
+				icon={Fingerprint}
+				label="Passkeys"
+				active={posture.auth.passkeyCount > 0}
+				detail={
+					posture.auth.passkeyCount > 0
+						? `${posture.auth.passkeyCount} credential${posture.auth.passkeyCount === 1 ? "" : "s"}`
+						: "None registered"
+				}
+			/>
+		</div>
+	);
+}
+
+function AuthBadge({
+	icon: Icon,
+	label,
+	active,
+	detail,
+}: {
+	icon: typeof KeyRound;
+	label: string;
+	active: boolean;
+	detail: string;
+}) {
+	return (
+		<div
+			className={cn(
+				"flex items-start gap-3 rounded-lg border p-3 transition-colors",
+				active ? "border-emerald-500/30 bg-emerald-500/5" : "border-border/40 bg-muted/10",
+			)}
+		>
+			<Icon
+				className={cn(
+					"h-4 w-4 shrink-0 mt-0.5",
+					active ? "text-emerald-500" : "text-muted-foreground",
+				)}
+				aria-hidden="true"
+			/>
+			<div className="min-w-0 flex-1">
+				<p className="text-xs font-semibold text-foreground">{label}</p>
+				<p className="text-xs text-muted-foreground mt-0.5 truncate">{detail}</p>
+			</div>
+		</div>
+	);
+}
+
+function CheckRow({ check, index }: { check: SecurityCheck; index: number }) {
+	const badge = SEVERITY_BADGE[check.severity];
+	return (
+		<div
+			className="flex items-start gap-3 rounded-lg border border-border/30 bg-muted/10 p-3 animate-in fade-in slide-in-from-bottom-1"
+			style={{ animationDelay: `${index * 30}ms`, animationFillMode: "backwards" }}
+		>
+			<div className="min-w-0 flex-1 space-y-1">
+				<div className="flex items-center gap-2 flex-wrap">
+					<p className="text-sm font-semibold text-foreground">{check.label}</p>
+					<StatusBadge status={badge.variant} icon={badge.icon}>
+						{badge.label}
+					</StatusBadge>
+				</div>
+				<p className="text-xs text-muted-foreground">{check.detail}</p>
+				{check.remediation && (
+					<p className="text-xs font-medium text-foreground/80">
+						<span className="text-muted-foreground">Fix: </span>
+						{check.remediation}
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function EnvironmentFootnote({ posture }: { posture: SecurityPosture }) {
+	const items: { label: string; value: ReactNode }[] = [
+		{ label: "NODE_ENV", value: posture.effective.nodeEnv },
+		{ label: "Trust Proxy", value: posture.effective.trustProxy ? "on" : "off" },
+		{ label: "Secure Cookies", value: posture.effective.secureCookies ? "on" : "off" },
+		{ label: "Session TTL", value: `${posture.effective.sessionTtlHours}h` },
+		{ label: "Password Policy", value: posture.effective.passwordPolicy },
+	];
+
+	return (
+		<div className="flex flex-wrap gap-x-4 gap-y-1 pt-2 border-t border-border/30 text-xs text-muted-foreground">
+			<span className="font-medium text-foreground/70">Effective runtime:</span>
+			{items.map((item) => (
+				<span key={item.label}>
+					<span className="text-foreground/60">{item.label}:</span>{" "}
+					<span className="font-mono">{item.value}</span>
+				</span>
+			))}
+		</div>
+	);
+}

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -22,7 +22,6 @@ import {
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { PremiumSection, PremiumSkeleton } from "../../../components/layout";
-import { useIncognitoMode } from "../../../lib/incognito";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import { Switch } from "../../../components/ui/switch";
@@ -30,14 +29,17 @@ import {
 	useLogFiles,
 	useResetValidationHealth,
 	useRestartSystem,
+	useSecurityPosture,
 	useSystemInfo,
 	useSystemSettings,
 	useUpdateSystemSettings,
 	useValidationHealth,
 } from "../../../hooks/api/useSystem";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { useIncognitoMode } from "../../../lib/incognito";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
+import { SecurityPostureSection } from "./security-posture-section";
 import { ValidationHealthSection } from "./validation-health-section";
 
 function formatUptime(seconds: number): string {
@@ -59,7 +61,6 @@ function formatFileSize(bytes: number): string {
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
 	return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
-
 
 /**
  * Premium System Info Card
@@ -123,6 +124,7 @@ export function SystemTab() {
 	const { data: systemInfo } = useSystemInfo();
 	const { data: logFiles, refetch: refetchLogs, isError: logFilesError } = useLogFiles();
 	const { data: validationHealth } = useValidationHealth();
+	const { data: securityPosture, isLoading: isSecurityPostureLoading } = useSecurityPosture();
 	const resetHealthMutation = useResetValidationHealth();
 	const updateMutation = useUpdateSystemSettings();
 	const restartMutation = useRestartSystem();
@@ -296,7 +298,7 @@ export function SystemTab() {
 							}
 							label="Database"
 							value={systemInfo.data.database.type}
-							subtitle={incognitoMode ? "••••••••" : (systemInfo.data.database.host || undefined)}
+							subtitle={incognitoMode ? "••••••••" : systemInfo.data.database.host || undefined}
 							animationDelay={50}
 						/>
 
@@ -336,6 +338,12 @@ export function SystemTab() {
 					</div>
 				</PremiumSection>
 			)}
+
+			{/* Security Posture Section */}
+			<SecurityPostureSection
+				posture={securityPosture?.data}
+				isLoading={isSecurityPostureLoading}
+			/>
 
 			{/* Validation Health Section */}
 			{validationHealth?.data && (
@@ -470,7 +478,9 @@ export function SystemTab() {
 													}}
 												>
 													<td className="px-4 py-2.5">
-														<span className="font-mono text-xs text-foreground">{incognitoMode ? "arr-dashboard.log" : file.name}</span>
+														<span className="font-mono text-xs text-foreground">
+															{incognitoMode ? "arr-dashboard.log" : file.name}
+														</span>
 													</td>
 													<td className="px-4 py-2.5 text-muted-foreground text-xs">
 														{formatFileSize(file.size)}

--- a/apps/web/src/hooks/api/useSystem.ts
+++ b/apps/web/src/hooks/api/useSystem.ts
@@ -1,21 +1,23 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
-	type LogFilesResponse,
-	type SystemInfoResponse,
-	type SystemSettingsResponse,
-	type UpdateSystemSettingsPayload,
-	type ValidationHealthResponse,
-	type QuarantineResponse,
 	clearValidationQuarantine,
 	fetchLogFiles,
+	fetchSecurityPosture,
 	fetchSystemInfo,
 	fetchSystemSettings,
 	fetchValidationHealth,
 	fetchValidationQuarantine,
+	type LogFilesResponse,
+	type QuarantineResponse,
 	resetValidationHealth,
 	restartSystem,
+	type SecurityPostureResponse,
+	type SystemInfoResponse,
+	type SystemSettingsResponse,
+	type UpdateSystemSettingsPayload,
 	updateSystemSettings,
+	type ValidationHealthResponse,
 } from "../../lib/api-client/system";
 import { getErrorMessage } from "../../lib/error-utils";
 import { POLLING_STANDARD } from "../../lib/polling-intervals";
@@ -121,6 +123,18 @@ export function useValidationQuarantine() {
 	return useQuery<QuarantineResponse>({
 		queryKey: validationKeys.quarantine,
 		queryFn: fetchValidationQuarantine,
+		refetchInterval: POLLING_STANDARD,
+	});
+}
+
+// ============================================================================
+// Security Posture
+// ============================================================================
+
+export function useSecurityPosture() {
+	return useQuery<SecurityPostureResponse>({
+		queryKey: systemKeys.securityPosture,
+		queryFn: fetchSecurityPosture,
 		refetchInterval: POLLING_STANDARD,
 	});
 }

--- a/apps/web/src/lib/api-client/system.ts
+++ b/apps/web/src/lib/api-client/system.ts
@@ -91,7 +91,9 @@ export function fetchLogFiles(): Promise<LogFilesResponse> {
 	return apiRequest<LogFilesResponse>("/api/system/logs");
 }
 
-export function updateSystemSettings(data: UpdateSystemSettingsPayload): Promise<SystemSettingsResponse> {
+export function updateSystemSettings(
+	data: UpdateSystemSettingsPayload,
+): Promise<SystemSettingsResponse> {
 	return apiRequest<SystemSettingsResponse>("/api/system/settings", {
 		method: "PUT",
 		json: data,
@@ -120,6 +122,50 @@ export function fetchValidationQuarantine(): Promise<QuarantineResponse> {
 
 export function clearValidationQuarantine(): Promise<unknown> {
 	return apiRequest("/api/system/validation-quarantine", { method: "DELETE" });
+}
+
+export function fetchSecurityPosture(): Promise<SecurityPostureResponse> {
+	return apiRequest<SecurityPostureResponse>("/api/system/security-posture");
+}
+
+// ============================================================================
+// Security Posture Types
+// ============================================================================
+
+export type SecuritySeverity = "healthy" | "warning" | "misconfigured";
+
+export interface SecurityCheck {
+	id: string;
+	label: string;
+	detail: string;
+	severity: SecuritySeverity;
+	remediation?: string;
+}
+
+export interface SecurityPosture {
+	overall: SecuritySeverity;
+	checks: SecurityCheck[];
+	effective: {
+		nodeEnv: "development" | "test" | "production";
+		trustProxy: boolean;
+		secureCookies: boolean;
+		sessionTtlHours: number;
+		sessionCookieName: string;
+		passwordPolicy: "strict" | "relaxed";
+		appUrl: string;
+	};
+	auth: {
+		passwordEnabled: boolean;
+		passwordUserCount: number;
+		oidcEnabled: boolean;
+		passkeyCount: number;
+	};
+	capturedAt: string;
+}
+
+export interface SecurityPostureResponse {
+	success: boolean;
+	data: SecurityPosture;
 }
 
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -452,6 +452,7 @@ export const systemKeys = {
 	settings: ["system-settings"] as const,
 	info: ["system-info"] as const,
 	logs: ["system-logs"] as const,
+	securityPosture: ["system-security-posture"] as const,
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Adds a read-only **Security Posture** section to the System tab so admins can quickly answer:

- *Am I running this safely?* — overall severity badge (healthy / warning / misconfigured)
- *What is misconfigured right now?* — per-check severity + one-line detail
- *What should I fix first?* — concrete remediation hints on every non-healthy check

This is a **visibility/diagnostics feature**, not an auth refactor. Every check is grounded in real app state — a mix of true misconfiguration detection (e.g., secure cookies without trust proxy will lock users out) and opinionated hardening recommendations layered on top of observed state (e.g., password-only auth, long session TTLs in production).

## Backend

- `apps/api/src/lib/security/security-posture.ts` — pure evaluator (no IO; takes `{ env, oidcEnabled, passkeyCount, passwordUserCount, totalUserCount }` and returns severity-tagged checks)
- `GET /system/security-posture` — aggregates env (via `app.config`) + DB counts (enabled OIDC providers, total passkeys, users with `hashedPassword`) and runs the evaluator
- 21 unit tests covering every check, the worst-case roll-up, and the malformed-URL edge case

## Checks implemented

| # | Check | Kind | Triggers |
|---|---|---|---|
| 1 | Trust Proxy | Informational | Current state |
| 2 | Secure Cookies | **True misconfig** | Enabled with Trust Proxy off — browser will not send the cookie over plain HTTP, locking users out |
| 2 | Secure Cookies | Hardening | Disabled in production |
| 3 | Authentication | True misconfig | No auth methods active despite users existing |
| 3 | Authentication | Hardening | Password-only setup (no OIDC, no passkeys) |
| 4 | Password Policy | Hardening | Relaxed in production |
| 5 | Session Lifetime | Hardening | >14 days in production |
| 6 | App URL | Hardening | Non-https in production, or http while Secure Cookies are on |

The "Secure Cookies + no Trust Proxy" check catches the dangerous `COOKIE_SECURE=true` env-var path that bypasses the existing `/system/settings` PUT validator.

## Frontend

- `apps/web/src/lib/api-client/system.ts` — `fetchSecurityPosture` + types (`SecurityPosture`, `SecurityCheck`, `SecuritySeverity`)
- `apps/web/src/hooks/api/useSystem.ts` — `useSecurityPosture` hook (refetches on `POLLING_STANDARD`)
- `apps/web/src/features/settings/components/security-posture-section.tsx` — overall banner, 3-up auth-method summary, sorted check list with remediation hints, and an effective-runtime footnote
- Inserted into `SystemTab` between System Information and Validation Health (no new tab — keeps the PR focused and the panel discoverable next to other diagnostics)
- Reuses existing `StatusBadge`, `PremiumSection`, `PremiumSkeleton` — no new design primitives

## Intentionally left out (later PRs)

- Action links into the relevant settings sub-sections (would need a sub-route refactor)
- Live edit-from-the-panel UX (kept it strictly read-only)
- Encryption-key rotation status / age (no backend tracking exists yet)
- Failed login attempt / lockout counters (would benefit from a separate operational dashboard)
- Backup encryption posture (orthogonal — has its own settings surface)

## Test plan

- [x] \`pnpm run test\` — full suite green (1263 passed)
- [x] \`pnpm --filter @arr/api exec tsc --noEmit\` — clean
- [x] \`pnpm --filter @arr/web exec tsc --noEmit\` — clean
- [x] Visit Settings → System and verify the section renders for: healthy default dev setup, dev with \`COOKIE_SECURE=true\` + no \`TRUST_PROXY\` (misconfigured), and password-only auth (warning)
- [x] Confirm the auth summary chips correctly reflect OIDC enable/disable and passkey enroll/revoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)