### PR TITLE
docs: add domain operating manuals + ADRs for posture and route auth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,73 @@ The main development reference is [`CLAUDE.md`](CLAUDE.md) — it covers:
 - **Tested** — Types pass, lint clean, tests pass
 - **Documented** — Update CLAUDE.md if you add patterns, routes, or conventions
 
+## Architecture-Affecting Changes
+
+Some changes need a docs update beyond code comments. Use this checklist
+to decide what to touch.
+
+### Update the relevant domain doc when you …
+
+The domain docs under [`docs/domains/`](docs/domains/) are short
+operating manuals: where code goes, what invariants must hold, what
+fails in the wild. Update the appropriate doc when you:
+
+- add or remove a service / scheduler / auth method / `/system/*` endpoint,
+- change an invariant listed in a domain doc (most common: a new
+  ownership rule, a new encryption requirement, a relaxation of an
+  existing constraint),
+- introduce a new shared abstraction the domain depends on
+  (e.g., a new client factory, a new pure evaluator),
+- change the "where to add new code" answer for that domain.
+
+| Domain | Doc |
+|---|---|
+| Auth, sessions, encryption | [`docs/domains/auth.md`](docs/domains/auth.md) |
+| Background jobs, registry | [`docs/domains/schedulers.md`](docs/domains/schedulers.md) |
+| External integrations | [`docs/domains/services.md`](docs/domains/services.md) |
+| Operator diagnostics surface | [`docs/domains/system.md`](docs/domains/system.md) |
+
+Domain docs are *not* exhaustive references — per-route response shapes
+live in [`docs/API-ROUTES.md`](docs/API-ROUTES.md), auth internals live
+in [`docs/AUTH.md`](docs/AUTH.md). Keep domain docs concise; if you find
+yourself documenting a per-handler detail, that probably belongs as a
+comment at the call site instead.
+
+### Write an ADR when …
+
+Open a new file under [`docs/adr/`](docs/adr/) (next sequential number,
+copy the shape of an existing one) when a change has any of these
+properties:
+
+- **Cross-cutting** — touches multiple domains or sets a precedent
+  others will follow (e.g., the scheduler registry, the protected-route
+  model, the security-posture evaluator pattern).
+- **Reversed direction** — replaces or significantly reshapes an
+  existing approach. The ADR captures *why we changed our mind*.
+- **Reverse-engineering risk** — a future contributor would otherwise
+  need to read across many files to understand the intent. Especially
+  true for "we explicitly chose not to do X" decisions.
+- **Trade-off worth recording** — there was a real alternative we
+  rejected, and the reasoning is non-obvious.
+
+If a change is just "added a feature in the obvious place," it does
+not need an ADR. ADRs are expensive to read; reserve them for the
+decisions whose absence would cost a future reader an hour.
+
+### Architecture-affecting examples
+
+- ✅ Adding a new auth method (Auth domain doc + ADR if it changes the
+  invariants).
+- ✅ Replacing the in-process scheduler registry with a persisted store
+  (Schedulers domain doc + ADR superseding 0001).
+- ✅ Adding a new severity tier to the security posture evaluator
+  (System domain doc + amend ADR-0002).
+- ❌ Adding a new field to an existing API response (CHANGELOG entry,
+  no doc/ADR change).
+- ❌ Tightening a Zod schema (no doc change unless an invariant moved).
+
+When in doubt, ask in the PR — it is cheaper than a stale doc.
+
 ## Reporting Issues
 
 - **Bugs**: Use the [bug report template](https://github.com/Kha-kis/arr-dashboard/issues/new?template=bug_report.yml)

--- a/docs/adr/0002-security-posture-evaluator.md
+++ b/docs/adr/0002-security-posture-evaluator.md
@@ -1,0 +1,133 @@
+# ADR 0002: Security Posture Evaluator + Diagnostics Surface
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+- **Deciders:** Backend + frontend maintainers
+- **Supersedes:** —
+- **Related:** [ADR-0001](0001-scheduler-registry.md) (same observer-not-actor shape)
+
+## Context
+
+The app exposes several security-relevant settings (trust proxy, secure
+cookies, OIDC, passkeys, password policy, session TTL). Some are stored
+in the DB, some come from the environment, and the *effective* value at
+runtime depends on both. Operators had no way to ask, from inside the
+product, "is my setup safe?" — the only signal was reading code or env.
+
+Worse, certain combinations are actively dangerous (e.g., `COOKIE_SECURE=true`
+with `TRUST_PROXY=false` over plain HTTP locks users out), and the
+existing `PUT /system/settings` validator only catches the *DB-write*
+path. The env-var path bypassed it entirely.
+
+We needed a visibility surface that:
+
+- aggregates effective config + observable auth state (OIDC enabled,
+  passkey count, password user count),
+- flags genuinely broken combinations,
+- offers opinionated hardening recommendations *without* drowning the
+  broken-combination signal,
+- can be unit-tested without spinning up Fastify or Prisma.
+
+## Decision
+
+Introduce a **pure evaluator** (`lib/security/security-posture.ts`) and
+a **thin aggregator route** (`GET /system/security-posture`).
+
+### Pure evaluator
+
+`evaluateSecurityPosture(input) → SecurityPostureResult`
+
+- Input is a plain object: env snapshot + OIDC enabled + passkey count
+  + password user count + total user count.
+- Output: per-check severity-tagged list, a worst-case overall severity,
+  the `effective` runtime values verbatim, and an `auth` summary.
+- Three severities: `healthy`, `warning`, `misconfigured`.
+- No I/O. No Fastify. No Prisma. The route handler is responsible for
+  gathering the inputs.
+
+### Severity discipline
+
+The roll-up is the load-bearing UI signal — admins read the top badge to
+decide whether to act. We deliberately separate two kinds of finding:
+
+| Severity | Meaning | Examples |
+|---|---|---|
+| `misconfigured` | Cannot work / will lock users out / actively harms | Secure cookies + no trust proxy; users exist but no auth methods active |
+| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https `APP_URL` in production |
+| `healthy` | No issue detected | — |
+
+Hardening warnings must never be promoted to `misconfigured`. Doing so
+collapses the "do not ship" signal into "could be slightly better,"
+which trains operators to ignore the banner.
+
+### Route
+
+`GET /system/security-posture` queries the four counts in parallel,
+calls the pure evaluator, and returns its result with a `capturedAt`
+timestamp. No mutation, no caching, no rate limit (it polls on
+`POLLING_STANDARD`).
+
+### Frontend
+
+A single section component (`SecurityPostureSection`) renders inside
+the existing `SystemTab`, between System Information and Validation
+Health. No new tab, no new route. Reuses `StatusBadge` /
+`PremiumSection` / `PremiumSkeleton` — no new design primitives.
+
+## Why a pure evaluator
+
+1. **Testable without harness.** Every check is a unit test against a
+   plain input object. The PR landed with 21 unit tests covering every
+   severity branch plus malformed-URL edge cases.
+2. **Single source of truth for severity.** The route, the UI, future
+   notification triggers, and any CLI tool all read from the same
+   evaluator. No drift.
+3. **Composability.** A future "send me a Slack alert when posture goes
+   misconfigured" job can call the evaluator with the same inputs and
+   compare against a stored baseline — no new evaluation logic needed.
+
+## Why not …
+
+- **A `SecuritySettings` model in Prisma.** Most posture inputs are
+  derived from `app.config` (env) or counted from existing tables. A
+  dedicated table would only encode opinions about thresholds, which
+  belong in code where they're reviewed alongside changes.
+- **Inline `if`s in the route handler.** Tested through HTTP, less
+  reusable, and the severity rules drift from any future consumer.
+- **A new "Security" tab in Settings.** Would split diagnostic surfaces
+  across two tabs (System and Security) and dilute discoverability. The
+  System tab is already where operators look for "is this app okay?"
+
+## Consequences
+
+### Positive
+
+- Operators get a single banner ("Action required" / "Recommended
+  improvements" / "All checks passing") that they can trust.
+- Adding a check is a one-file change to `security-posture.ts` plus a
+  test; the UI updates automatically.
+- The dangerous `COOKIE_SECURE=true` + `TRUST_PROXY=false` env-var path
+  is now visible — previously only the DB-write path was guarded.
+
+### Negative / trade-offs
+
+- The check rules are opinionated (especially the >14-day TTL warning
+  and the "consider passkeys" nudge). We accept that opinion explicitly
+  by tagging them as `warning`-severity, distinct from real
+  misconfiguration.
+- Counts are read on every poll. At the current cardinality (a handful
+  of users / passkeys) this is negligible; if it grows, batch into a
+  short-TTL in-memory cache before profiling.
+- Severity discipline is enforced by convention, not types. A future
+  contributor adding a hardening check at `misconfigured` severity
+  would degrade the roll-up signal. The check list in this ADR plus
+  the unit tests are the reviewer's cue.
+
+## Follow-ups
+
+- Action links from each check into the relevant settings sub-section
+  (requires sub-route refactor in Settings).
+- Optional notification trigger when overall severity transitions to
+  `misconfigured` (uses the same evaluator).
+- Encryption-key age tracking, once `secret-manager.ts` records a
+  generated-at timestamp.

--- a/docs/adr/0003-protected-route-auth-model.md
+++ b/docs/adr/0003-protected-route-auth-model.md
@@ -1,0 +1,124 @@
+# ADR 0003: Protected-Route Auth Model
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+- **Deciders:** Backend maintainers
+- **Supersedes:** —
+
+## Context
+
+Most API routes need an authenticated user. Without a uniform model, each
+route would either re-implement the check (drift, missed routes) or rely
+on a global hook that gates *all* requests including login itself
+(impossible). Reviewers also need a single answer to "is this route
+protected, and how do I know?" without reading every handler.
+
+The choice of mechanism — middleware vs. preHandler vs. wrapper function
+— shapes how easy it is to get this right and how confidently a new
+contributor can plug into the system.
+
+## Decision
+
+Group every protected route under a single Fastify `register(async (api) => …)`
+scope in `apps/api/src/bootstrap/protected-routes.ts`. That scope adds
+**one `preHandler` hook** that rejects any request without a populated
+`request.currentUser`.
+
+```ts
+api.addHook("preHandler", async (request, reply) => {
+  if (!request.currentUser?.id) {
+    return reply.status(401).send({ error: "Authentication required" });
+  }
+});
+```
+
+`request.currentUser` and `request.sessionToken` are populated by the
+session-enrichment plugin that runs earlier in the pipeline. The
+preHandler simply enforces what the enrichment plugin already attempted.
+
+Public routes (login, OIDC initiate/callback, passkey challenge, the
+"setup-required" probe) are registered *outside* this scope and run
+without the preHandler.
+
+### What handlers see
+
+Inside any protected handler:
+
+```ts
+const userId = request.currentUser!.id;     // safe: preHandler guaranteed it
+const token = request.sessionToken;          // present iff the user is logged in
+```
+
+The non-null assertion on `currentUser!` is the convention. It's not a
+trick: the preHandler returned 401 before this code ran. Hand-checking
+inside every handler would add noise without changing behavior.
+
+## Why this shape
+
+1. **One place to read.** A reviewer asks "is route X protected?" by
+   confirming X is `register`'d inside `protected-routes.ts`. No reading
+   of the route file required.
+2. **No middleware framework.** Next.js-style middleware is not used —
+   there is nothing in the request path between Fastify and the route.
+   Fewer layers, fewer surprises.
+3. **Composes with Fastify's plugin model.** Each route module is still
+   a `FastifyPluginCallback`; protection is a wrapper, not a runtime
+   condition. Test harnesses can register a route plugin without the
+   preHandler and inject auth via `setupAuthInjection()` for unit tests.
+4. **Single-admin model.** This codebase is single-admin per tenant, so
+   "authenticated" *is* "authorized" for product routes. There is no
+   role-check layer to integrate with. If that ever changes, the
+   `preHandler` is the natural seam to add it (one location).
+
+## Why not …
+
+- **Per-route guards** (`{ preHandler: requireAuth }` per route). Easy
+  to forget; reviewers cannot enumerate protected vs. public by
+  scanning one file.
+- **Global hook on the root app**. Would gate `/api/auth/login` itself —
+  the chicken-and-egg problem.
+- **Express-style middleware library**. Fastify's hook + plugin scope
+  model already supplies the primitives; pulling in middleware machinery
+  adds dependency surface for no gain.
+- **JWT bearer tokens with stateless verification.** Sessions are
+  cookie-backed and DB-tracked because we need server-side
+  invalidation (after password change, OIDC unlink, passkey deletion).
+  See [`docs/AUTH.md`](../AUTH.md).
+
+## Consequences
+
+### Positive
+
+- One file (`protected-routes.ts`) is the authoritative answer to "what
+  is gated."
+- The `request.currentUser!.id` pattern is uniform across every handler
+  and reads as a contract, not as a non-null gamble.
+- Adding a new route domain is a one-liner registration; protection is
+  inherited.
+- A regression test (`route-auth-enforcement.test.ts`) walks every
+  registered route and asserts that calls without a session return 401.
+
+### Negative / trade-offs
+
+- The `!` non-null assertion can look risky to a reviewer who hasn't
+  internalized the convention. Mitigated by (a) the centralized
+  preHandler, (b) the contract-test that exercises the unauthenticated
+  path, (c) this ADR.
+- Public routes must be registered *outside* the protected scope. Easy
+  to get wrong by reflex (a contributor adds a new "auth" route inside
+  `protected-routes.ts` because that's where it looks like auth lives).
+  Reviewer cue: anything that must work pre-login goes in `server.ts`,
+  not `protected-routes.ts`.
+- All-or-nothing: there is no notion of a "partially protected" route.
+  If a route needs to behave differently for anonymous vs. authenticated
+  callers, the route must be public and check `request.currentUser`
+  itself. So far this has not been needed.
+
+## Follow-ups
+
+- If a roles model is ever introduced, extend the preHandler with a
+  per-scope role check. Do not introduce route-level role decorators —
+  preserve the "one file answers what's protected" property.
+- If the public-route list grows, consider a parallel
+  `registerPublicRoutes()` boundary so the public surface is also
+  enumerable in one place.

--- a/docs/domains/README.md
+++ b/docs/domains/README.md
@@ -1,0 +1,20 @@
+# Domain operating manuals
+
+Short, durable docs answering **where does this change belong**, **what
+invariants must hold**, and **what fails in the wild** for each major
+backend domain.
+
+These are intentionally not exhaustive references. They link out to
+deep dives (`docs/AUTH.md`, `docs/API-ROUTES.md`) and ADRs
+(`docs/adr/`) for the *what* and *why*. The job here is the *where*.
+
+| Domain | Read this when … |
+|---|---|
+| [Auth](auth.md) | touching login, sessions, encryption, OIDC, passkeys, or anything that decides who a request belongs to |
+| [Schedulers](schedulers.md) | adding or modifying a background job, or wiring something into `/system/jobs` |
+| [Services](services.md) | adding or modifying a Sonarr / Radarr / Plex / Tautulli / Jellyfin / Seerr integration |
+| [System](system.md) | adding a `/system/*` endpoint or a section to the System tab in Settings |
+
+For when to update these docs vs. when to write an ADR, see the
+"Architecture-Affecting Changes" section in
+[`CONTRIBUTING.md`](../../CONTRIBUTING.md).

--- a/docs/domains/auth.md
+++ b/docs/domains/auth.md
@@ -1,0 +1,114 @@
+# Domain: Auth
+
+Operating manual for the authentication subsystem. For protocol-level deep
+dives (Argon2 params, OIDC PKCE flow, WebAuthn counter rules, encryption
+internals) see [`docs/AUTH.md`](../AUTH.md). This doc covers **where to put
+things, what to never break, and what fails in the wild**.
+
+## Purpose
+
+Establish that an HTTP request belongs to a known user, decide whether the
+request is allowed, and protect the credentials needed to do that on every
+subsequent request. Also: keep the secrets that other domains rely on
+(`app.encryptor` for service credentials, `app.sessionService` for cookies)
+behind a stable interface.
+
+## Key files
+
+| Concern | File |
+|---|---|
+| Password login + setup + lockout | `apps/api/src/routes/auth.ts` |
+| OIDC initiate / callback / linking | `apps/api/src/routes/auth-oidc.ts` |
+| Passkey register / login / list / delete | `apps/api/src/routes/auth-passkey.ts` |
+| OIDC provider config (singleton) | `apps/api/src/routes/oidc-providers.ts` |
+| Session create / invalidate / cookie | `apps/api/src/lib/auth/session.ts` |
+| Argon2id hashing | `apps/api/src/lib/auth/password.ts` |
+| AES-256-GCM encryption | `apps/api/src/lib/auth/encryption.ts` |
+| WebAuthn wrapper (@simplewebauthn) | `apps/api/src/lib/auth/passkey-service.ts` |
+| Auto-generated secrets | `apps/api/src/lib/auth/secret-manager.ts` |
+| Protected-route preHandler | `apps/api/src/bootstrap/protected-routes.ts` |
+| Password schema (shared) | `packages/shared/src/types/password.ts` |
+
+Frontend session UI lives under
+`apps/web/src/features/settings/components/sessions-section.tsx` and the
+auth flow pages are in `apps/web/app/login/`, `apps/web/app/setup/`.
+
+## Invariants
+
+These are load-bearing. Breaking any of them is a security regression.
+
+1. **Every protected route runs the `protected-routes` preHandler.** It is
+   what populates `request.currentUser` and `request.sessionToken`. If a
+   handler reads `request.currentUser!.id` without that preHandler having
+   run, you have an unauthenticated route claiming to be authenticated.
+   See ADR-0003.
+2. **Every user-owned query filters by `userId: request.currentUser!.id`.**
+   This is the single defense against id-guessing across users in a
+   single-admin-per-tenant model. The reviewer checklist exists for this
+   reason — it is invisible at the type level.
+3. **All secret material is encrypted at rest** with `app.encryptor.encrypt()`
+   and stored as `{ value, iv }` columns. No plaintext API keys, OIDC client
+   secrets, or webhook tokens in the DB. Ever.
+4. **Credential changes invalidate other sessions.** After password change,
+   OIDC unlink, or passkey deletion, call
+   `app.sessionService.invalidateAllUserSessions(userId, exceptToken)`.
+   Failing to do this leaves a stolen-cookie attacker logged in after the
+   user "rotated."
+5. **Passkeys require a password as prerequisite, and the last passkey can
+   only be deleted if another method exists.** The user must always have a
+   working way back in.
+6. **Counter-on-replay**: WebAuthn responses with non-incrementing counters
+   are rejected. This is enforced in `passkey-service.ts`; do not weaken it.
+7. **Cookies are HttpOnly + SameSite=Lax always.** The `Secure` flag is the
+   only one that varies with environment (`COOKIE_SECURE ?? TRUST_PROXY`).
+
+## Major integration points
+
+- **`app.sessionService`** — every domain that needs to invalidate or read
+  sessions goes through this Fastify decoration.
+- **`app.encryptor`** — used by services, backups, OIDC config, webhook
+  config, and anywhere else credentials live in the DB.
+- **`request.currentUser`** — the dependency contract every protected route
+  takes from this domain.
+- **Security Posture (`/system/security-posture`)** consumes auth state
+  (OIDC enabled, passkey count, password user count) to evaluate hardening
+  warnings. See [`docs/domains/system.md`](system.md).
+
+## Common failure modes / operational notes
+
+- **Account lockout** — 5 failed logins ⇒ 15-minute lock. Cleared on
+  successful login. Visible to operators only via DB inspection right now.
+- **OIDC discovery flake** — provider metadata fetch can time out. The
+  callback handler returns 502; the user re-clicks "Sign in with OIDC."
+  Do not auto-retry server-side, it amplifies provider downtime.
+- **Passkey counter regressions** — happens when a user restores from a
+  backup of an older OS profile. The fix is to delete and re-enroll the
+  passkey, not to relax the counter check.
+- **Session cookie not sent over HTTP** — happens when `COOKIE_SECURE=true`
+  but the operator is reaching the app over plain HTTP without a TLS-
+  terminating proxy. Caught by the Security Posture check
+  (`secure-cookies` ⇒ misconfigured).
+- **`secrets.json` rotation** — rotating `ENCRYPTION_KEY` invalidates every
+  encrypted blob in the DB (service API keys, OIDC secret, webhook
+  secrets). There is no rotation tooling; treat the key as long-lived.
+
+## Where to add new code
+
+| Change | Goes in |
+|---|---|
+| New password rule | `packages/shared/src/types/password.ts` (Zod schema) |
+| New auth method (e.g., magic link) | new `apps/api/src/routes/auth-<method>.ts` + helper in `apps/api/src/lib/auth/` + Posture check in `lib/security/security-posture.ts` |
+| Tightening lockout / rate-limit | `apps/api/src/routes/auth.ts` (constants at top of file) |
+| Surfacing auth state in UI | extend `SecurityPostureSection` in `apps/web/src/features/settings/components/security-posture-section.tsx` (don't create parallel surface) |
+| New session-invalidation trigger | call `app.sessionService.invalidateAllUserSessions()` from the route that performs the credential change |
+| New encrypted DB column | add `value` + `iv` columns; encrypt via `app.encryptor.encrypt()`; never store plaintext fallback |
+
+## When to update this doc
+
+- A new auth method is added, or an existing one is removed.
+- An invariant in the list above changes (severity: also write an ADR).
+- Session-cookie defaults change (`SameSite`, `HttpOnly`, `Secure`).
+- A new shared-encryption consumer is introduced.
+
+Operational details (timeouts, lockout numbers, hashing params) belong in
+[`docs/AUTH.md`](../AUTH.md) — not here.

--- a/docs/domains/auth.md
+++ b/docs/domains/auth.md
@@ -57,10 +57,12 @@ These are load-bearing. Breaking any of them is a security regression.
 5. **Passkeys require a password as prerequisite, and the last passkey can
    only be deleted if another method exists.** The user must always have a
    working way back in.
-6. **Counter-on-replay**: WebAuthn responses with non-incrementing counters
-   are rejected. This is enforced in `passkey-service.ts`; do not weaken it.
-7. **Cookies are HttpOnly + SameSite=Lax always.** The `Secure` flag is the
-   only one that varies with environment (`COOKIE_SECURE ?? TRUST_PROXY`).
+6. **Counter-on-replay** for WebAuthn must not be weakened. See
+   [`docs/AUTH.md`](../AUTH.md) §Passkey Authentication for the exact
+   predicate; the rule lives in `passkey-service.ts`.
+7. **Cookies are HttpOnly + SameSite=Lax always.** Only the `Secure` flag
+   varies with environment; see [`docs/AUTH.md`](../AUTH.md) §Session
+   Management for the fallback chain.
 
 ## Major integration points
 
@@ -76,8 +78,9 @@ These are load-bearing. Breaking any of them is a security regression.
 
 ## Common failure modes / operational notes
 
-- **Account lockout** — 5 failed logins ⇒ 15-minute lock. Cleared on
-  successful login. Visible to operators only via DB inspection right now.
+- **Account lockout** — triggers after repeated failed logins (see
+  [`docs/AUTH.md`](../AUTH.md) for thresholds), cleared on successful
+  login. Visible to operators only via DB inspection right now.
 - **OIDC discovery flake** — provider metadata fetch can time out. The
   callback handler returns 502; the user re-clicks "Sign in with OIDC."
   Do not auto-retry server-side, it amplifies provider downtime.
@@ -97,7 +100,7 @@ These are load-bearing. Breaking any of them is a security regression.
 | Change | Goes in |
 |---|---|
 | New password rule | `packages/shared/src/types/password.ts` (Zod schema) |
-| New auth method (e.g., magic link) | new `apps/api/src/routes/auth-<method>.ts` + helper in `apps/api/src/lib/auth/` + Posture check in `lib/security/security-posture.ts` |
+| New auth method (e.g., magic link) | (1) new `apps/api/src/routes/auth-<method>.ts` registered in `apps/api/src/server.ts` (public surface) — *not* in `bootstrap/protected-routes.ts`, since the route must work pre-login; (2) helper in `apps/api/src/lib/auth/`; (3) Zod schema in `packages/shared/src/types/`; (4) posture check in `lib/security/security-posture.ts`; (5) frontend hook in `apps/web/src/hooks/api/useAuth.ts` + section in the Settings auth tab |
 | Tightening lockout / rate-limit | `apps/api/src/routes/auth.ts` (constants at top of file) |
 | Surfacing auth state in UI | extend `SecurityPostureSection` in `apps/web/src/features/settings/components/security-posture-section.tsx` (don't create parallel surface) |
 | New session-invalidation trigger | call `app.sessionService.invalidateAllUserSessions()` from the route that performs the credential change |

--- a/docs/domains/schedulers.md
+++ b/docs/domains/schedulers.md
@@ -29,6 +29,7 @@ This split is intentional. The registry observes; it does not schedule.
 | Registry class (state + invariants) | `apps/api/src/lib/scheduler-registry/scheduler-registry.ts` |
 | Static catalog of known job IDs + metadata | `apps/api/src/lib/scheduler-registry/job-definitions.ts` |
 | Fastify plugin (decorates `app.schedulerRegistry`) | `apps/api/src/plugins/scheduler-registry.ts` |
+| Where every scheduler plugin gets registered | `apps/api/src/bootstrap/schedulers.ts` |
 | HTTP surface | `apps/api/src/routes/system.ts` (`GET /system/jobs`) |
 | Job plugins (one per scheduler) | `apps/api/src/plugins/*-scheduler.ts` (e.g. `hunting-scheduler.ts`, `backup-scheduler.ts`, `queue-cleaner-scheduler.ts`) |
 | Job tick implementations | `apps/api/src/lib/<domain>/*-executor.ts` (e.g. `lib/hunting/hunt-executor.ts`) |
@@ -86,7 +87,7 @@ This split is intentional. The registry observes; it does not schedule.
 
 | Change | Goes in |
 |---|---|
-| New scheduler | (1) add ID to `JOB_ID` and entry to `KNOWN_JOBS` in `job-definitions.ts`; (2) create `apps/api/src/plugins/<name>-scheduler.ts` registering itself and wrapping the tick in `app.schedulerRegistry.track()`; (3) put the tick body in `apps/api/src/lib/<domain>/<name>-executor.ts` |
+| New scheduler | (1) add ID to `JOB_ID` and entry to `KNOWN_JOBS` in `job-definitions.ts`; (2) create `apps/api/src/plugins/<name>-scheduler.ts` registering itself and wrapping the tick in `app.schedulerRegistry.track()`; (3) put the tick body in `apps/api/src/lib/<domain>/<name>-executor.ts`; (4) **register the plugin in `apps/api/src/bootstrap/schedulers.ts`** (without this the plugin never loads and the catalog entry stays at `idle`/`totalRuns: 0` forever) |
 | Adopt `track()` on an existing scheduler | wrap the body of the existing tick function — no other changes needed |
 | Disable a job at startup | call `app.schedulerRegistry.markDisabled(JOB_ID.x, "reason")` from the plugin instead of registering the timer |
 | Add a runtime stat to the API response | extend `JobStatus` in `scheduler-registry.ts` and update `system-jobs.test.ts` (the contract test) |

--- a/docs/domains/schedulers.md
+++ b/docs/domains/schedulers.md
@@ -1,0 +1,106 @@
+# Domain: Schedulers
+
+Operating manual for background work — periodic jobs that the API runs on
+its own timers (backups, hunting, queue cleanup, library sync, TRaSH sync,
+Seerr health, media caches, etc.).
+
+For the *why* of the central registry design, see
+[ADR-0001](../adr/0001-scheduler-registry.md). This doc covers *where to
+plug in* and *what to never break*.
+
+## Purpose
+
+Two distinct things, kept deliberately separate:
+
+1. **Execution** — each scheduler plugin owns its own `setInterval`,
+   startup-delay logic, per-instance fan-out, retention rules, and
+   concurrency guards. There is *no* shared scheduler framework.
+2. **Observability** — a process-local `SchedulerRegistry` catalogs every
+   known job and tracks its runtime state (last started/finished/succeeded/
+   failed, durations, totals). The `/api/system/jobs` endpoint reads from
+   this registry.
+
+This split is intentional. The registry observes; it does not schedule.
+
+## Key files
+
+| Concern | File |
+|---|---|
+| Registry class (state + invariants) | `apps/api/src/lib/scheduler-registry/scheduler-registry.ts` |
+| Static catalog of known job IDs + metadata | `apps/api/src/lib/scheduler-registry/job-definitions.ts` |
+| Fastify plugin (decorates `app.schedulerRegistry`) | `apps/api/src/plugins/scheduler-registry.ts` |
+| HTTP surface | `apps/api/src/routes/system.ts` (`GET /system/jobs`) |
+| Job plugins (one per scheduler) | `apps/api/src/plugins/*-scheduler.ts` (e.g. `hunting-scheduler.ts`, `backup-scheduler.ts`, `queue-cleaner-scheduler.ts`) |
+| Job tick implementations | `apps/api/src/lib/<domain>/*-executor.ts` (e.g. `lib/hunting/hunt-executor.ts`) |
+
+## Invariants
+
+1. **Every scheduler is pre-registered in `job-definitions.ts`.** This is
+   what makes the catalog complete from day one even before a plugin
+   adopts `track()`. If you add a scheduler and do not add it to the
+   catalog, it is invisible to operators.
+2. **Job IDs are stable strings, exposed via `JOB_ID.*`.** Tests pin to
+   them; UI keys off them. Renaming a job ID is a breaking change.
+3. **`registry.track()` re-throws the original error.** Existing error
+   handling, retries, and notification logic still run. Adoption is purely
+   additive.
+4. **`registry.track()` is the only legitimate way to update runtime
+   stats.** Do not write to registry internals from plugins; read via
+   `getStatus()`/`list()`, mutate via `track()` / `markDisabled()` /
+   `markEnabled()`.
+5. **No cross-process coordination.** This is a single-process app. Any
+   "is anything running anywhere?" check is local to this process.
+6. **The `/system/jobs` endpoint never triggers a tick.** It is read-only.
+   Pinned by `system-jobs.test.ts`.
+
+## Major integration points
+
+- **`app.schedulerRegistry`** — the single Fastify decoration every
+  scheduler plugin uses to register itself and wrap its tick.
+- **`/api/system/jobs`** — consumed by the System tab in the UI (see
+  [`docs/domains/system.md`](system.md)).
+- **`KNOWN_JOBS` catalog** — the source of truth for "what schedulers
+  exist." Used by tests, UI, and runtime registration alike.
+
+## Common failure modes / operational notes
+
+- **Job appears as `idle` with `totalRuns: 0`** — it is registered in
+  `job-definitions.ts` but the plugin has not yet adopted `track()`.
+  Honest signal of "unknown," not "confirmed idle." Resolve by wrapping
+  the plugin's tick body in `app.schedulerRegistry.track(JOB_ID.x, …)`.
+- **Stats lost on restart** — by design (ADR-0001). Operators who need
+  trend data across restarts will get it when the `SchedulerRun`
+  persistence follow-up lands.
+- **Two ticks running concurrently for a `serial` job** — registry throws
+  `SerialJobBusyError`. The plugin should propagate it, not swallow it,
+  so the rejection shows up in `lastError`.
+- **`disabledReason` not surfaced** — when calling `markDisabled(id, reason)`,
+  always pass a human-readable reason. The `/system/jobs` payload exposes
+  it; the UI displays it; debugging without it is painful.
+- **Adding a scheduler that should not auto-start in dev** — gate the
+  `setInterval` in the plugin, not in the registry. Registry just
+  observes; the registration call should still happen so the job appears
+  in the catalog as `disabled`.
+
+## Where to add new code
+
+| Change | Goes in |
+|---|---|
+| New scheduler | (1) add ID to `JOB_ID` and entry to `KNOWN_JOBS` in `job-definitions.ts`; (2) create `apps/api/src/plugins/<name>-scheduler.ts` registering itself and wrapping the tick in `app.schedulerRegistry.track()`; (3) put the tick body in `apps/api/src/lib/<domain>/<name>-executor.ts` |
+| Adopt `track()` on an existing scheduler | wrap the body of the existing tick function — no other changes needed |
+| Disable a job at startup | call `app.schedulerRegistry.markDisabled(JOB_ID.x, "reason")` from the plugin instead of registering the timer |
+| Add a runtime stat to the API response | extend `JobStatus` in `scheduler-registry.ts` and update `system-jobs.test.ts` (the contract test) |
+| Surface a job in a new UI panel | consume `/api/system/jobs`; do not duplicate the registry on the frontend |
+
+## When to update this doc
+
+- A new scheduler is added or removed.
+- The registry's public API changes (new method on `SchedulerRegistry`,
+  new field on `JobStatus`).
+- A new concurrency model is introduced (currently `singleton`,
+  `per-instance`, `serial`, `parallel`).
+- Persistence is added (will warrant a new ADR + an update here).
+
+Implementation details of individual schedulers (interval, retention
+rules, per-instance behavior) belong in code comments at the plugin file,
+not here.

--- a/docs/domains/services.md
+++ b/docs/domains/services.md
@@ -106,20 +106,33 @@ A new ARR-style service (rare, since the SDK covers them):
 3. Reuse `routes/services.ts` — no new route file.
 
 A new media or request service (more common):
-1. `prisma/schema.prisma` — extend `ServiceType`.
-2. `apps/api/src/lib/<service>/<service>-client.ts` — factory
-   `create<Service>Client(encryptor, instance, log)` with the right
-   auth model. Sanitize tokens before logging.
+1. `prisma/schema.prisma` — extend `ServiceType`. Then run
+   `pnpm --filter @arr/api run db:push` to sync the schema and
+   regenerate the Prisma client.
+2. `apps/api/src/lib/<service>/<service>-client.ts` — mirror an existing
+   peer rather than inventing a signature: `plex-client.ts` for simple
+   token-header auth, `tautulli-client.ts` for query-param API keys,
+   `seerr-client.ts` for resilient (retry + circuit breaker) clients
+   over `ArrClientFactory.rawRequest()`. Sanitize tokens before logging
+   in all cases.
 3. Routes:
    - if it slots into the generic CRUD shape → reuse `routes/services.ts`
      and only add a connection-test branch.
    - if it has feature endpoints (discover, stats, request, …) → new
      `apps/api/src/routes/<service>/` with one file per feature.
-4. Normalizers in `apps/api/src/lib/<service>/<service>-normalizer.ts`
-   when the upstream shape doesn't match the existing typed contract.
+4. Normalizers — the dominant convention is `apps/api/src/lib/library/<thing>-normalizer.ts`
+   for library-shaped data shared across services, and
+   `apps/api/src/lib/<service>/` only when the shape is genuinely
+   service-specific. Look at `lib/library/` and `lib/search/` before
+   creating a new directory.
 5. `packages/shared/src/types/<service>.ts` — Zod schema + TS type.
-6. Frontend: `apps/web/src/lib/api-client/<service>.ts` and
-   `apps/web/src/hooks/api/use<Service>.ts` (mirror the existing pairs).
+6. Frontend: `apps/web/src/lib/api-client/<service>.ts`,
+   `apps/web/src/hooks/api/use<Service>.ts`, and a query-key entry in
+   `apps/web/src/lib/query-keys.ts` (mirror the existing pairs;
+   inline string arrays are forbidden by `CLAUDE.md`).
+7. If the integration emits validation stats, wire them into
+   `lib/validation/integration-health.ts` so they surface in
+   `/system/validation-health` automatically.
 
 ## When to update this doc
 

--- a/docs/domains/services.md
+++ b/docs/domains/services.md
@@ -1,0 +1,132 @@
+# Domain: Services
+
+Operating manual for external integrations: Sonarr, Radarr, Prowlarr,
+Lidarr, Readarr, Plex, Tautulli, Jellyfin/Emby, Seerr (Jellyseerr /
+Overseerr).
+
+## Purpose
+
+Talk to user-configured external services on behalf of the user, without
+ever leaking credentials or letting one user touch another user's
+instance. All service-specific quirks — auth header shape, error mapping,
+field-name drift across versions — are absorbed here so route handlers
+and the UI deal in normalized, typed shapes.
+
+## Service shape categories
+
+| Shape | Services | Client style |
+|---|---|---|
+| ARR | Sonarr, Radarr, Prowlarr, Lidarr, Readarr | shared `ArrClientFactory` over `arr-sdk` |
+| Media server | Plex, Jellyfin, Emby, Tautulli | per-service hand-written client (different auth headers) |
+| Request | Seerr (Jellyseerr / Overseerr) | hand-written client over `ArrClientFactory.rawRequest()` with retry + circuit breaker |
+
+All three categories share the same Prisma model (`ServiceInstance`) and
+the same lookup helper (`requireInstance`). The split is in *how to talk
+to them*, not in *how we own them*.
+
+## Key files
+
+| Concern | File |
+|---|---|
+| CRUD + connection test for any service | `apps/api/src/routes/services.ts` |
+| Ownership-checked instance lookup | `apps/api/src/lib/arr/instance-helpers.ts` (`requireInstance`, `requireEnabledInstance`) |
+| ARR client factory + error types | `apps/api/src/lib/arr/client-factory.ts` |
+| Plex / Tautulli / Jellyfin clients | `apps/api/src/lib/plex/plex-client.ts`, `apps/api/src/lib/tautulli/tautulli-client.ts`, `apps/api/src/lib/jellyfin/*` |
+| Seerr client (resilient) | `apps/api/src/lib/seerr/seerr-client.ts` |
+| Encrypted update helper | `apps/api/src/lib/services/update-builder.ts` |
+| Library/search normalizers | `apps/api/src/lib/library/*-normalizer.ts`, `apps/api/src/lib/search/normalizers.ts` |
+| Centralized error mapping | `apps/api/src/server.ts` (error handler) + `apps/api/src/lib/errors.ts` |
+| Schema (single discriminated row) | `apps/api/prisma/schema.prisma` (`ServiceInstance`, `ServiceType` enum) |
+
+## Invariants
+
+These are the rules every contributor must hold. Most are not type-checkable.
+
+1. **Every instance lookup goes through `requireInstance(app, userId, id)`.**
+   Never query `serviceInstance.findFirst({ where: { id } })` directly —
+   that elides the `userId` filter and creates a cross-tenant read.
+2. **Credentials are encrypted on write through `app.encryptor.encrypt()`,
+   stored as `{ encryptedApiKey, encryptionIv }`, and decrypted only at
+   the moment of use.** No plaintext on the wire to the DB, no caching
+   of decrypted material across requests.
+3. **`buildUpdateData()` is the only legitimate place that re-encrypts on
+   update.** Routes pass through it; they do not call `encryptor` directly
+   for service updates.
+4. **Errors map through the centralized error handler in `server.ts`.**
+   Throw `ArrError` subclasses (or rely on `arr-sdk` to throw them); do
+   not hand-roll `reply.status(...).send(...)` with bespoke error shapes.
+5. **No URL leakage in error messages.** `server.ts` redacts URLs from
+   `ArrError.message` so internal IPs / ports are not echoed to clients
+   or logs. If you add a new client, sanitize before logging.
+6. **Frontend never calls service endpoints directly.** All traffic flows
+   `apps/web/src/lib/api-client/*` → `/api/*` (Next.js rewrite) → Fastify
+   route → service client. Never `fetch("http://sonarr:8989", …)` from
+   the browser.
+
+## Major integration points
+
+- **`requireInstance()`** — used by every domain that resolves a service
+  by id (hunting, queue cleaner, library, search, statistics, pulse).
+- **`app.encryptor`** — provided by the auth domain
+  ([`docs/domains/auth.md`](auth.md)).
+- **Validation health** — every external integration emits validation
+  stats consumed by `/system/validation-health` (see
+  [`docs/domains/system.md`](system.md)).
+- **Centralized error handler** — `ArrError` / `SeerrApiError` /
+  `InstanceNotFoundError` all collapse into clean HTTP responses there.
+
+## Common failure modes / operational notes
+
+- **`InstanceNotFoundError` (404)** — either the id doesn't exist or the
+  caller doesn't own it. The route should not branch on which; both
+  surface as 404 to avoid id-existence oracles.
+- **Connection test failures** — most user-facing; surfaced via the
+  `POST /services/:id/test` route. Use the existing client factory so
+  errors map through the same paths as production calls.
+- **Field-name drift across upstream versions** — Sonarr v3 vs. v4,
+  Prowlarr API revisions, Plex schema additions. Absorb in a normalizer
+  with defensive type converters (`toNumber`, `toString`, `toBoolean`),
+  not in the route or the UI.
+- **Token leakage in logs** — Tautulli's `apikey=…` query param is the
+  most common offender. Sanitize before any `app.log` call. Same rule
+  for Plex's `X-Plex-Token`.
+- **Seerr/Jellyseerr 5xx storms** — handled by retry + circuit breaker
+  in `seerr-client.ts`. Do not add ad-hoc retries on top of that in
+  routes.
+- **Concurrent writes to the same instance** — Prisma will serialize at
+  the row level, but two near-simultaneous `PUT /services/:id` calls can
+  re-encrypt with different IVs. The last write wins; clients must not
+  assume read-after-write coherence within milliseconds.
+
+## Where to add new code
+
+A new ARR-style service (rare, since the SDK covers them):
+1. Add the enum value to `ServiceType` in `schema.prisma`; run `db push`.
+2. Add a constructor in `ArrClientFactory` if `arr-sdk` ships one.
+3. Reuse `routes/services.ts` — no new route file.
+
+A new media or request service (more common):
+1. `prisma/schema.prisma` — extend `ServiceType`.
+2. `apps/api/src/lib/<service>/<service>-client.ts` — factory
+   `create<Service>Client(encryptor, instance, log)` with the right
+   auth model. Sanitize tokens before logging.
+3. Routes:
+   - if it slots into the generic CRUD shape → reuse `routes/services.ts`
+     and only add a connection-test branch.
+   - if it has feature endpoints (discover, stats, request, …) → new
+     `apps/api/src/routes/<service>/` with one file per feature.
+4. Normalizers in `apps/api/src/lib/<service>/<service>-normalizer.ts`
+   when the upstream shape doesn't match the existing typed contract.
+5. `packages/shared/src/types/<service>.ts` — Zod schema + TS type.
+6. Frontend: `apps/web/src/lib/api-client/<service>.ts` and
+   `apps/web/src/hooks/api/use<Service>.ts` (mirror the existing pairs).
+
+## When to update this doc
+
+- A new service or service category is added.
+- An invariant in the list above changes.
+- A new shared abstraction lands (e.g., a generic media-server client).
+- The credential-encryption shape changes (would also warrant an ADR).
+
+Per-service quirks (auth header shape, version-specific field names)
+belong in code comments at the relevant client file, not here.

--- a/docs/domains/system.md
+++ b/docs/domains/system.md
@@ -117,9 +117,9 @@ For the full route table, see [`docs/API-ROUTES.md`](../API-ROUTES.md).
 
 | Change | Goes in |
 |---|---|
-| New `/system/X` GET diagnostic | (1) handler in `routes/system.ts`; (2) optional pure evaluator under `lib/<area>/`; (3) types + `fetch*` in `lib/api-client/system.ts`; (4) `use*` hook in `hooks/api/useSystem.ts`; (5) section component under `features/settings/components/`; (6) render in `system-tab.tsx` |
+| New `/system/X` GET diagnostic | (1) handler in `routes/system.ts`; (2) optional pure evaluator under `lib/<area>/`; (3) types + `fetch*` in `lib/api-client/system.ts`; (4) query-key entry in `apps/web/src/lib/query-keys.ts` under `systemKeys`; (5) `use*` hook in `hooks/api/useSystem.ts`; (6) section component under `features/settings/components/`; (7) render in `system-tab.tsx`; (8) add a row to [`docs/API-ROUTES.md`](../API-ROUTES.md) |
 | New mutating `/system/X` route | same as above + a real justification + rate limit + an audit log line via `request.log.info(…)` including `userId` |
-| New `SystemSettings` field | add to `prisma/schema.prisma`; thread through GET + PUT handlers; decide and document whether it needs restart |
+| New `SystemSettings` field | add to `prisma/schema.prisma`; run `pnpm --filter @arr/api run db:push`; thread through GET + PUT handlers; if env-driven, also expose an `effective<Field>` twin per the stored-vs-effective pattern; decide and document whether it needs restart |
 | New posture check | extend `lib/security/security-posture.ts` (pure) + a unit test; choose severity per ADR-0002; UI updates automatically |
 | New validation integration | wire into `integrationHealth` in `lib/validation/`; it surfaces in `/validation-health` automatically |
 

--- a/docs/domains/system.md
+++ b/docs/domains/system.md
@@ -1,0 +1,135 @@
+# Domain: System
+
+Operating manual for the operator-facing diagnostic surface — settings,
+runtime info, logs, scheduler observability, validation health, security
+posture, and restart.
+
+This domain is not a feature; it's the *console*. Everything here exists
+to answer "what is this app doing right now, and is it healthy?"
+
+## Purpose
+
+Make the running state of the application observable and (where safe)
+configurable from the UI without shell access. Read endpoints are the
+default; mutating endpoints are narrow, audited, and rate-limited.
+
+## Key files
+
+| Concern | File |
+|---|---|
+| All `/system/*` HTTP routes | `apps/api/src/routes/system.ts` |
+| Pure security-posture evaluator | `apps/api/src/lib/security/security-posture.ts` |
+| Scheduler registry | `apps/api/src/lib/scheduler-registry/` (see [`schedulers.md`](schedulers.md)) |
+| Validation health + fingerprints + quarantine | `apps/api/src/lib/validation/` |
+| Logger + log-rotation config | `apps/api/src/lib/logger.ts` |
+| App version | `apps/api/src/lib/utils/version.ts` |
+| Lifecycle (restart) decoration | `apps/api/src/plugins/lifecycle.ts` |
+| `SystemSettings` table (singleton row) | `apps/api/prisma/schema.prisma` |
+| Frontend tab (single consumer) | `apps/web/src/features/settings/components/system-tab.tsx` |
+| API client + hooks | `apps/web/src/lib/api-client/system.ts`, `apps/web/src/hooks/api/useSystem.ts` |
+
+## The "stored vs. effective" pattern
+
+`/system/settings` returns *both* the value the operator last saved (e.g.
+`trustProxy`) and the value actually being used at runtime (e.g.
+`effectiveTrustProxy`, read from `app.config`). When the two diverge,
+`requiresRestart: true` tells the UI to show a banner.
+
+This pattern matters because the API process reads most env-derived
+config at startup. Saving a new value to the DB does not change the
+running process — it changes what the process will pick up next time.
+Surfacing both lets operators see *and trust* that distinction.
+
+The Security Posture endpoint follows the same convention: it reports
+`effective` runtime values (from `app.config`) alongside its derived
+checks. Never report stored values as if they were live.
+
+## Subsystems plugged into `/system`
+
+| Endpoint | Backed by |
+|---|---|
+| `GET /system/settings`, `PUT /system/settings` | `SystemSettings` row + `app.config` |
+| `GET /system/info` | `getAppVersionInfo()`, `app.dbProvider`, `process.*`, logger constants |
+| `GET /system/logs`, `GET /system/logs/download/:filename` | `LOG_DIR` filesystem |
+| `POST /system/restart` | `app.lifecycle.restart()` |
+| `GET /system/jobs` | `app.schedulerRegistry` (see [`schedulers.md`](schedulers.md)) |
+| `GET /system/security-posture` | `evaluateSecurityPosture()` (see [ADR-0002](../adr/0002-security-posture-evaluator.md)) |
+| `GET/PUT/DELETE /system/validation-health`, `*/validation-quarantine`, `PUT /system/validation-modes` | `lib/validation/integration-health.ts` + `schemaFingerprints` + `validationQuarantine` |
+
+For the full route table, see [`docs/API-ROUTES.md`](../API-ROUTES.md).
+
+## Invariants
+
+1. **All `/system/*` routes are read-only by default**; mutating routes
+   are explicitly justified (settings PUT, validation-mode toggles,
+   restart, quarantine clear). Adding a new diagnostic should land as a
+   GET unless mutation is the whole point.
+2. **The `requiresRestart` flag is computed, not stored.** If you add a
+   new field to `SystemSettings`, decide whether it needs restart, and
+   if so include it in the comparison block in both GET and PUT handlers.
+3. **`PUT /system/settings` blocks lockout-inducing combos** before
+   writing. The current example: secure cookies on, trust proxy off (the
+   browser will refuse to send the cookie over HTTP). Add similar
+   guards for any future setting that can lock the operator out.
+4. **`GET /system/logs` falls back gracefully** when the log directory
+   is unreadable — it returns `success: true` with an empty file list
+   and a warning, never 500. Preserve this when extending the route.
+5. **`GET /system/validation-quarantine` strips raw payloads** before
+   returning. They can contain upstream tokens / PII. Do not "improve"
+   the response by re-including them.
+6. **Log download paths are sanitized** against traversal — basename
+   only, must resolve inside `LOG_DIR`. Do not relax this.
+7. **The Security Posture roll-up severity reserves `misconfigured` for
+   "do not ship / cannot work" conditions.** Hardening recommendations
+   live at `warning`. See [ADR-0002](../adr/0002-security-posture-evaluator.md).
+
+## Major integration points
+
+- **Auth domain** provides `app.encryptor` and `app.sessionService`,
+  consumed indirectly by the security-posture evaluator (auth-method
+  counts) and by every protected route on this domain.
+- **Schedulers domain** provides `app.schedulerRegistry`, surfaced via
+  `/system/jobs`.
+- **Services domain** emits validation stats consumed by
+  `/system/validation-health`.
+- **Frontend** has exactly one consumer file (`system-tab.tsx`). Do not
+  fan out diagnostics into other tabs without a strong reason —
+  centralizing them is the point.
+
+## Common failure modes / operational notes
+
+- **Restart endpoint hammered** — rate-limited to 2 per 5 minutes; clients
+  see 429. By design.
+- **Log directory missing in dev** — returns empty file list with a
+  warning, not an error. Operator can confirm `LOG_DIR` is set correctly.
+- **Settings change shows "Restart Required" forever** — usually means
+  the env var being compared (e.g., `TRUST_PROXY`) wasn't actually set in
+  the environment, so the running process default doesn't match the new
+  DB value. Check the actual env.
+- **Posture flips between healthy/warning across reloads** — usually
+  reflects a real condition flipping (e.g., setup just completed,
+  passkey just registered). The endpoint polls on `POLLING_STANDARD`.
+- **Long `/system/jobs` polling load** — the response size scales with
+  the number of registered jobs (currently O(20)). It is not paginated;
+  if catalog grows substantially, paginate before profiling.
+
+## Where to add new code
+
+| Change | Goes in |
+|---|---|
+| New `/system/X` GET diagnostic | (1) handler in `routes/system.ts`; (2) optional pure evaluator under `lib/<area>/`; (3) types + `fetch*` in `lib/api-client/system.ts`; (4) `use*` hook in `hooks/api/useSystem.ts`; (5) section component under `features/settings/components/`; (6) render in `system-tab.tsx` |
+| New mutating `/system/X` route | same as above + a real justification + rate limit + an audit log line via `request.log.info(…)` including `userId` |
+| New `SystemSettings` field | add to `prisma/schema.prisma`; thread through GET + PUT handlers; decide and document whether it needs restart |
+| New posture check | extend `lib/security/security-posture.ts` (pure) + a unit test; choose severity per ADR-0002; UI updates automatically |
+| New validation integration | wire into `integrationHealth` in `lib/validation/`; it surfaces in `/validation-health` automatically |
+
+## When to update this doc
+
+- A new `/system/X` endpoint is added.
+- The "stored vs. effective" or "requiresRestart" model changes.
+- A new diagnostic subsystem is plugged in (e.g., metrics, tracing).
+- An invariant in the list above changes (severity: also write an ADR).
+
+Per-route response shapes belong in [`docs/API-ROUTES.md`](../API-ROUTES.md).
+Per-check posture rules belong in code comments inside
+`security-posture.ts` (single source of truth).


### PR DESCRIPTION
## Summary

Turn architecture knowledge that lived in PR descriptions and reviewer heads into a small, maintainable set of code-adjacent docs that can stay current. No code changes.

## What's added

### Domain operating manuals (`docs/domains/`)

Concise (~100-line) docs answering: *where does this change belong, what invariants must hold, what fails in the wild, where to add new code.* Deliberately not exhaustive references — they link to existing deep dives instead of duplicating them.

- **`auth.md`** — auth invariants (preHandler-populated `currentUser`, ownership filtering, encryption discipline, session invalidation on credential change). Defers to `docs/AUTH.md` for protocol internals.
- **`schedulers.md`** — observer-not-actor split between job plugins and the registry; what `track()` adoption looks like; how to add a new scheduler. Defers to ADR-0001.
- **`services.md`** — the three integration shapes (ARR / media server / request), the non-type-checkable invariants (ownership filter, `app.encryptor` discipline, no plaintext credentials), and the concrete file list for adding a new service.
- **`system.md`** — the diagnostic surface, the \"stored vs effective\" pattern, subsystem mapping per `/system/*` route, and severity discipline for posture checks.
- **`README.md`** — one-table index.

### ADRs (`docs/adr/`)

Only added where a future contributor would otherwise have to reverse-engineer intent.

- **`0002-security-posture-evaluator.md`** — pure-evaluator + thin-route pattern; three-severity model; why hardening recommendations must stay at `warning` rather than `misconfigured`.
- **`0003-protected-route-auth-model.md`** — single-preHandler scope in `bootstrap/protected-routes.ts`; the `request.currentUser!` convention; rejected alternatives (per-route guards, global hooks, JWT bearer).

ADR-0001 (scheduler registry) is already exhaustive — **not** duplicated.

### Maintenance expectations (`CONTRIBUTING.md`)

New \"Architecture-Affecting Changes\" section answering when to update a domain doc, when to write an ADR, and what counts as architecture-affecting (with concrete ✅/❌ examples).

## Intentionally left out

- **\"Pulse\" / dashboard / hunting / library** as domains — they are product features, not operating-manual-shaped subsystems.
- **A full ADR backfill** for older decisions — those are archaeology, not living docs.
- **Per-endpoint route docs** — `docs/API-ROUTES.md` already serves that purpose.
- **A docs CI link checker** — verified manually for this PR (script in commit). Worth adding only if links start drifting.

## Test plan

- [x] All internal markdown links resolve (verified with a bash script over all new files)
- [x] No code touched — no type-check / test runs needed
- [x] **Reviewer scan for duplication against existing docs.** Ran a structured audit. Found 3 drift hazards in `auth.md` where facts were restated from `docs/AUTH.md` (cookie Secure formula, passkey counter rule, lockout numbers) — fixed in 2nd commit by converting them to pointers, in line with the doc's own \"operational details belong in AUTH.md\" intent. Other overlaps were either intentional cross-links or low-risk single-line restatements of project-wide rules.
- [x] **Reviewer sanity check that \"where to add new code\" tables match how they'd actually do the work today.** Ran a structured audit against current code + recent precedent (PR #317). Found and fixed:
   - `schedulers.md` was missing the `bootstrap/schedulers.ts` registration step — load-bearing; without it, a new plugin never loads.
   - `services.md` prescribed a uniform `create<Service>Client(encryptor, instance, log)` signature that doesn't exist in practice — replaced with \"mirror an existing peer\" guidance.
   - `services.md` claimed normalizers go under `lib/<service>/<service>-normalizer.ts`; actual convention is `lib/library/<thing>-normalizer.ts` for shared shapes. Corrected.
   - `system.md` `GET diagnostic` row missed the `lib/query-keys.ts` step (which PR #317 itself performed) and the `API-ROUTES.md` row update.
   - `system.md` `SystemSettings field` row missed `pnpm --filter @arr/api run db:push` and the `effective<Field>` twin per its own stored-vs-effective pattern.
   - `auth.md` \"new auth method\" row missed the public-route registration distinction (must go in `server.ts`, NOT `bootstrap/protected-routes.ts`, since auth routes work pre-login), Zod, and frontend hook.

All fixes in commit \`0cf4caf\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)