### PR TITLE
feat(scheduler): enforce explicit init failure-handling policy

### DIFF
--- a/apps/api/src/lib/scheduler-registry/__tests__/init-helpers.test.ts
+++ b/apps/api/src/lib/scheduler-registry/__tests__/init-helpers.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for `runSchedulerInit` — the helper that standardizes the
+ * scheduler init failure-handling contract documented in
+ * `docs/domains/schedulers.md`.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { runSchedulerInit } from "../init-helpers.js";
+import { SchedulerRegistry } from "../scheduler-registry.js";
+
+const NOOP_DEFINITION = {
+	id: "test-job",
+	label: "Test Job",
+	description: "Used by init-helpers tests.",
+	concurrency: "singleton" as const,
+	intervalMs: 60_000,
+};
+
+function createFakeLogger(): FastifyBaseLogger {
+	const log = {
+		error: vi.fn(),
+		warn: vi.fn(),
+		info: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+		level: "info",
+		silent: vi.fn(),
+		// runSchedulerInit only calls .error() but the FastifyBaseLogger
+		// type requires `child()` so we satisfy it by returning the same fake.
+		child: () => log,
+	};
+	return log as unknown as FastifyBaseLogger;
+}
+
+describe("runSchedulerInit", () => {
+	it("returns true and leaves the job idle when init succeeds", async () => {
+		const registry = new SchedulerRegistry();
+		registry.register(NOOP_DEFINITION);
+		const log = createFakeLogger();
+		const initFn = vi.fn(async () => {
+			// no-op success
+		});
+
+		const ok = await runSchedulerInit({ registry, log }, "test-job", "test", initFn);
+
+		expect(ok).toBe(true);
+		expect(initFn).toHaveBeenCalledOnce();
+		expect(registry.getStatus("test-job")).toMatchObject({
+			state: "idle",
+			disabled: false,
+			disabledReason: null,
+		});
+		expect(log.error).not.toHaveBeenCalled();
+	});
+
+	it("returns false, logs at error level, and marks job disabled on init throw", async () => {
+		const registry = new SchedulerRegistry();
+		registry.register(NOOP_DEFINITION);
+		const log = createFakeLogger();
+		const boom = new Error("missing secrets file");
+
+		const ok = await runSchedulerInit({ registry, log }, "test-job", "test", async () => {
+			throw boom;
+		});
+
+		expect(ok).toBe(false);
+		expect(registry.getStatus("test-job")).toMatchObject({
+			state: "disabled",
+			disabled: true,
+			disabledReason: "Init failed: missing secrets file",
+		});
+		expect(log.error).toHaveBeenCalledWith(
+			expect.objectContaining({ err: boom, jobId: "test-job" }),
+			expect.stringContaining("test scheduler"),
+		);
+	});
+
+	it("does NOT re-throw — sibling scheduler init must keep running", async () => {
+		// This is the key invariant: a single scheduler's init failure must
+		// not propagate up the onReady hook chain and abort startup. The
+		// caller awaits us; if we re-threw, the next plugin's onReady would
+		// never run.
+		const registry = new SchedulerRegistry();
+		registry.register(NOOP_DEFINITION);
+		const log = createFakeLogger();
+
+		await expect(
+			runSchedulerInit({ registry, log }, "test-job", "test", async () => {
+				throw new Error("explosive init");
+			}),
+		).resolves.toBe(false);
+	});
+
+	it("formats non-Error thrown values into a readable disabledReason", async () => {
+		// Some upstream libraries throw non-Error shapes (e.g. plain objects
+		// from native bindings). The helper relies on getErrorMessage() to
+		// produce a useful reason instead of "[object Object]" or empty string.
+		const registry = new SchedulerRegistry();
+		registry.register(NOOP_DEFINITION);
+		const log = createFakeLogger();
+		const weirdError = { code: "ENOENT", toString: () => "ENOENT: file missing" };
+
+		await runSchedulerInit({ registry, log }, "test-job", "test", async () => {
+			throw weirdError;
+		});
+
+		const status = registry.getStatus("test-job");
+		expect(status?.disabled).toBe(true);
+		// Reason starts with the standard prefix and surfaces the value via String().
+		expect(status?.disabledReason).toMatch(/^Init failed:/);
+		expect(status?.disabledReason).toContain("ENOENT");
+	});
+});

--- a/apps/api/src/lib/scheduler-registry/__tests__/init-helpers.test.ts
+++ b/apps/api/src/lib/scheduler-registry/__tests__/init-helpers.test.ts
@@ -77,11 +77,12 @@ describe("runSchedulerInit", () => {
 		);
 	});
 
-	it("does NOT re-throw — sibling scheduler init must keep running", async () => {
-		// This is the key invariant: a single scheduler's init failure must
-		// not propagate up the onReady hook chain and abort startup. The
-		// caller awaits us; if we re-threw, the next plugin's onReady would
-		// never run.
+	it("does NOT re-throw — preserves Fastify's onReady chain semantics", async () => {
+		// Pins the helper-level invariant: the helper itself must swallow
+		// the error so it isn't re-thrown into the onReady chain. Whether
+		// Fastify subsequently keeps invoking sibling onReady hooks is its
+		// own well-established behavior; this test only locks down the
+		// helper's contribution to that contract.
 		const registry = new SchedulerRegistry();
 		registry.register(NOOP_DEFINITION);
 		const log = createFakeLogger();

--- a/apps/api/src/lib/scheduler-registry/init-helpers.ts
+++ b/apps/api/src/lib/scheduler-registry/init-helpers.ts
@@ -30,9 +30,9 @@ export interface SchedulerInitContext {
  * the registry is marked `disabled` with a human-readable
  * `disabledReason` (`"Init failed: <message>"`), and the helper returns
  * `false`. The job appears as `state: "disabled"` on `/api/system/jobs`
- * with the reason exposed to operators. The error is NOT re-thrown — a
- * single scheduler's init failure must not crash other schedulers'
- * `onReady` hooks or block server startup.
+ * with the reason exposed to operators. The error is NOT re-thrown into
+ * the `onReady` chain (which, given Fastify's hook semantics, would
+ * otherwise abort sibling `onReady` hooks).
  *
  * Plugins that need to gate routes on a feature flag (e.g. setting
  * `app.foobarSchedulerEnabled = true` only on success) should branch on

--- a/apps/api/src/lib/scheduler-registry/init-helpers.ts
+++ b/apps/api/src/lib/scheduler-registry/init-helpers.ts
@@ -1,0 +1,66 @@
+/**
+ * Scheduler initialization helpers.
+ *
+ * Standardizes the failure-handling contract for scheduler plugins so that
+ * an init failure is always visible to operators on `/api/system/jobs`
+ * instead of being silently swallowed by Fastify's error path.
+ *
+ * The full failure-handling policy (init failure / tick error / serial
+ * busy / disabled state) is documented in `docs/domains/schedulers.md`.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { getErrorMessage } from "../utils/error-message.js";
+import type { SchedulerRegistry } from "./scheduler-registry.js";
+
+export interface SchedulerInitContext {
+	registry: SchedulerRegistry;
+	log: FastifyBaseLogger;
+}
+
+/**
+ * Run a scheduler plugin's `onReady` initialization with the standard
+ * failure-handling contract.
+ *
+ * On success: `initFn` runs to completion and the helper returns `true`.
+ * Tick-level state will then be tracked by the plugin's existing
+ * `app.schedulerRegistry.track()` calls.
+ *
+ * On failure: the error is logged at error level with `{ err, jobId }`,
+ * the registry is marked `disabled` with a human-readable
+ * `disabledReason` (`"Init failed: <message>"`), and the helper returns
+ * `false`. The job appears as `state: "disabled"` on `/api/system/jobs`
+ * with the reason exposed to operators. The error is NOT re-thrown — a
+ * single scheduler's init failure must not crash other schedulers'
+ * `onReady` hooks or block server startup.
+ *
+ * Plugins that need to gate routes on a feature flag (e.g. setting
+ * `app.foobarSchedulerEnabled = true` only on success) should branch on
+ * the returned boolean rather than placing flag-setting code inside the
+ * `initFn` after side-effects that may have partially completed.
+ *
+ * @param ctx - Registry + logger (typically `{ registry: app.schedulerRegistry, log: app.log }`)
+ * @param jobId - The `JOB_ID.*` constant for the scheduler being initialized
+ * @param label - Human-readable scheduler name used in the log message (e.g. `"backup"`)
+ * @param initFn - Async initialization body — creates instances, registers decorations, calls `start()`
+ * @returns `true` if init succeeded, `false` if it failed and the job was disabled
+ */
+export async function runSchedulerInit(
+	ctx: SchedulerInitContext,
+	jobId: string,
+	label: string,
+	initFn: () => Promise<void>,
+): Promise<boolean> {
+	try {
+		await initFn();
+		return true;
+	} catch (error) {
+		const reason = `Init failed: ${getErrorMessage(error, "unknown error")}`;
+		ctx.log.error(
+			{ err: error, jobId },
+			`Failed to initialize ${label} scheduler — feature disabled`,
+		);
+		ctx.registry.markDisabled(jobId, reason);
+		return false;
+	}
+}

--- a/apps/api/src/plugins/__tests__/scheduler-init-failure.test.ts
+++ b/apps/api/src/plugins/__tests__/scheduler-init-failure.test.ts
@@ -1,0 +1,97 @@
+/**
+ * End-to-end integration test for the scheduler init failure-handling
+ * contract documented in `docs/domains/schedulers.md`.
+ *
+ * Boots the REAL `backup-scheduler` plugin (not the helper in isolation)
+ * and forces an init failure by stubbing `app.config` with a Proxy that
+ * throws on property access. This proves the full chain works:
+ *
+ *   plugin onReady → runSchedulerInit → markDisabled → /system/jobs surface
+ *
+ * If a future refactor unwraps a plugin's init or bypasses
+ * `runSchedulerInit`, this test fails — preventing silent regression of
+ * the operator-visible contract. The `system-jobs.test.ts` integration
+ * test pins the same surface but exercises the helper directly; this
+ * test pins it through a real plugin's onReady chain.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { JOB_ID } from "../../lib/scheduler-registry/job-definitions.js";
+import backupSchedulerPlugin from "../backup-scheduler.js";
+import schedulerRegistryPlugin from "../scheduler-registry.js";
+
+/**
+ * Minimal stub for the real `prisma` plugin. backup-scheduler declares
+ * `dependencies: ["prisma", "scheduler-registry"]`; Fastify's dependency
+ * check requires a registered plugin with that exact name, not just a
+ * decoration. We don't need a real Prisma client because the forced init
+ * failure happens before backup-scheduler ever touches it.
+ */
+const stubPrismaPlugin = fp(
+	async (app: FastifyInstance) => {
+		app.decorate("prisma", {} as never);
+	},
+	{ name: "prisma" },
+);
+
+let app: ReturnType<typeof Fastify>;
+
+beforeEach(async () => {
+	app = Fastify({ logger: false });
+
+	// notificationService is read by the plugin but not declared as a
+	// fastify-plugin dependency, so a plain decoration is enough.
+	app.decorate("notificationService", { notify: vi.fn() } as never);
+
+	// Force init failure: install a config object whose DATABASE_URL getter
+	// throws. The plugin reads `app.config.DATABASE_URL` first thing inside
+	// the onReady body; this synthetic-but-realistic failure mode mirrors
+	// what would happen if config resolution started returning a poisoned
+	// shape. A Proxy here is too eager — Fastify's `decorate` validates the
+	// value and triggers the trap before onReady runs — so we use a
+	// property-specific getter, which is only evaluated when the property
+	// is actually read.
+	const failingConfig: Record<string, unknown> = {};
+	Object.defineProperty(failingConfig, "DATABASE_URL", {
+		enumerable: true,
+		get() {
+			throw new Error("simulated config failure");
+		},
+	});
+	app.decorate("config", failingConfig as never);
+
+	await app.register(stubPrismaPlugin);
+	await app.register(schedulerRegistryPlugin);
+	await app.register(backupSchedulerPlugin);
+	// `ready()` triggers all onReady hooks. If runSchedulerInit re-threw,
+	// this would reject; that it resolves is itself part of the contract.
+	await app.ready();
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("scheduler init failure surfaces through the plugin chain", () => {
+	it("backup-scheduler init failure is recorded as state=disabled with a human-readable reason", async () => {
+		const status = app.schedulerRegistry.getStatus(JOB_ID.backup);
+
+		expect(status).not.toBeNull();
+		expect(status?.state).toBe("disabled");
+		expect(status?.disabled).toBe(true);
+		expect(status?.disabledReason).toBe("Init failed: simulated config failure");
+		// totalRuns stays at 0 — the failure happened before any tick ran.
+		expect(status?.totalRuns).toBe(0);
+		expect(status?.lastError).toBeNull();
+	});
+
+	it("server.ready() resolves despite the scheduler init failure", () => {
+		// Implicit assertion: beforeEach awaited app.ready() without throwing.
+		// This is what enables sibling onReady hooks to keep running in the
+		// real server. The runSchedulerInit unit test pins the helper-level
+		// no-rethrow invariant; this test pins it at the live-plugin level.
+		expect(app.hasDecorator("schedulerRegistry")).toBe(true);
+	});
+});

--- a/apps/api/src/plugins/backup-scheduler.ts
+++ b/apps/api/src/plugins/backup-scheduler.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { BackupScheduler } from "../lib/backup/backup-scheduler.js";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
 
@@ -14,25 +15,32 @@ const backupSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		// Use onReady hook to ensure config and Prisma are fully initialized before creating scheduler
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing backup scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.backup,
+				"backup",
+				async () => {
+					app.log.info("Initializing backup scheduler");
 
-			// Determine secrets path based on DATABASE_URL from app config (canonical source)
-			const databaseUrl = app.config.DATABASE_URL || "file:./dev.db";
-			const secretsPath = resolveSecretsPath(databaseUrl);
+					// Determine secrets path based on DATABASE_URL from app config (canonical source)
+					const databaseUrl = app.config.DATABASE_URL || "file:./dev.db";
+					const secretsPath = resolveSecretsPath(databaseUrl);
 
-			// Create and register backup scheduler (Prisma and config are guaranteed to be ready)
-			const scheduler = new BackupScheduler(
-				app.prisma,
-				app.log,
-				secretsPath,
-				(payload) => app.notificationService.notify(payload),
-				{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.backup, fn) },
+					// Create and register backup scheduler (Prisma and config are guaranteed to be ready)
+					const scheduler = new BackupScheduler(
+						app.prisma,
+						app.log,
+						secretsPath,
+						(payload) => app.notificationService.notify(payload),
+						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.backup, fn) },
+					);
+					app.decorate("backupScheduler", scheduler);
+
+					// Start scheduler
+					scheduler.start();
+					app.log.info("Backup scheduler started successfully");
+				},
 			);
-			app.decorate("backupScheduler", scheduler);
-
-			// Start scheduler
-			scheduler.start();
-			app.log.info("Backup scheduler started successfully");
 		});
 
 		// Stop scheduler on server close

--- a/apps/api/src/plugins/insights-digest-scheduler.ts
+++ b/apps/api/src/plugins/insights-digest-scheduler.ts
@@ -8,6 +8,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { InsightsDigestScheduler } from "../lib/notifications/insights-digest.js";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 
 declare module "fastify" {
@@ -19,19 +20,26 @@ declare module "fastify" {
 const insightsDigestSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing insights digest scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.insightsDigest,
+				"insights digest",
+				async () => {
+					app.log.info("Initializing insights digest scheduler");
 
-			const scheduler = new InsightsDigestScheduler(
-				app.prisma,
-				app.log,
-				app.arrClientFactory,
-				(payload) => app.notificationService.notify(payload),
-				{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.insightsDigest, fn) },
+					const scheduler = new InsightsDigestScheduler(
+						app.prisma,
+						app.log,
+						app.arrClientFactory,
+						(payload) => app.notificationService.notify(payload),
+						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.insightsDigest, fn) },
+					);
+
+					app.decorate("insightsDigestScheduler", scheduler);
+					scheduler.start();
+					app.log.info("Insights digest scheduler started successfully");
+				},
 			);
-
-			app.decorate("insightsDigestScheduler", scheduler);
-			scheduler.start();
-			app.log.info("Insights digest scheduler started successfully");
 		});
 
 		app.addHook("onClose", async () => {

--- a/apps/api/src/plugins/library-cleanup-scheduler.ts
+++ b/apps/api/src/plugins/library-cleanup-scheduler.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { CleanupScheduler } from "../lib/library-cleanup/cleanup-scheduler.js";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 
 declare module "fastify" {
@@ -12,19 +13,26 @@ declare module "fastify" {
 const libraryCleanupSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing library cleanup scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.libraryCleanup,
+				"library cleanup",
+				async () => {
+					app.log.info("Initializing library cleanup scheduler");
 
-			const scheduler = new CleanupScheduler(
-				app.prisma,
-				app.arrClientFactory,
-				app.log,
-				(payload) => app.notificationService.notify(payload),
-				{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.libraryCleanup, fn) },
+					const scheduler = new CleanupScheduler(
+						app.prisma,
+						app.arrClientFactory,
+						app.log,
+						(payload) => app.notificationService.notify(payload),
+						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.libraryCleanup, fn) },
+					);
+					app.decorate("cleanupScheduler", scheduler);
+
+					scheduler.start();
+					app.log.info("Library cleanup scheduler started successfully");
+				},
 			);
-			app.decorate("cleanupScheduler", scheduler);
-
-			scheduler.start();
-			app.log.info("Library cleanup scheduler started successfully");
 		});
 
 		app.addHook("onClose", async () => {

--- a/apps/api/src/plugins/library-sync-scheduler.ts
+++ b/apps/api/src/plugins/library-sync-scheduler.ts
@@ -8,6 +8,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import { getLibrarySyncScheduler } from "../lib/library-sync/index.js";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 
 declare module "fastify" {
@@ -20,15 +21,22 @@ const librarySyncSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		// Use onReady hook to ensure Prisma and arrClientFactory are available
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing library sync scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.librarySync,
+				"library sync",
+				async () => {
+					app.log.info("Initializing library sync scheduler");
 
-			const scheduler = getLibrarySyncScheduler();
-			scheduler.setTrackTick((fn) => app.schedulerRegistry.track(JOB_ID.librarySync, fn));
-			app.decorate("librarySyncScheduler", scheduler);
+					const scheduler = getLibrarySyncScheduler();
+					scheduler.setTrackTick((fn) => app.schedulerRegistry.track(JOB_ID.librarySync, fn));
+					app.decorate("librarySyncScheduler", scheduler);
 
-			// Start the scheduler
-			scheduler.start(app);
-			app.log.info("Library sync scheduler started successfully");
+					// Start the scheduler
+					scheduler.start(app);
+					app.log.info("Library sync scheduler started successfully");
+				},
+			);
 		});
 
 		// Stop scheduler on server close

--- a/apps/api/src/plugins/trash-sync-scheduler.ts
+++ b/apps/api/src/plugins/trash-sync-scheduler.ts
@@ -7,6 +7,7 @@
 
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { TrashSyncScheduler } from "../lib/trash-guides/sync-scheduler.js";
 
@@ -19,20 +20,27 @@ declare module "fastify" {
 const trashSyncSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing TRaSH sync scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.trashSync,
+				"TRaSH sync",
+				async () => {
+					app.log.info("Initializing TRaSH sync scheduler");
 
-			const scheduler = new TrashSyncScheduler(
-				app.prisma,
-				app.log,
-				app.deploymentExecutor,
-				app.arrClientFactory,
-				(payload) => app.notificationService.notify(payload),
-				{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.trashSync, fn) },
+					const scheduler = new TrashSyncScheduler(
+						app.prisma,
+						app.log,
+						app.deploymentExecutor,
+						app.arrClientFactory,
+						(payload) => app.notificationService.notify(payload),
+						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.trashSync, fn) },
+					);
+
+					app.decorate("trashSyncScheduler", scheduler);
+					scheduler.start();
+					app.log.info("TRaSH sync scheduler started successfully");
+				},
 			);
-
-			app.decorate("trashSyncScheduler", scheduler);
-			scheduler.start();
-			app.log.info("TRaSH sync scheduler started successfully");
 		});
 
 		app.addHook("onClose", async () => {

--- a/apps/api/src/plugins/trash-update-scheduler.ts
+++ b/apps/api/src/plugins/trash-update-scheduler.ts
@@ -6,6 +6,7 @@
 
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { createCacheManager } from "../lib/trash-guides/cache-manager.js";
 import { createTrashFetcher } from "../lib/trash-guides/github-fetcher.js";
@@ -27,65 +28,76 @@ const trashUpdateSchedulerPlugin = fastifyPlugin(
 	async (app: FastifyInstance) => {
 		// Use onReady hook to ensure config and Prisma are fully initialized
 		app.addHook("onReady", async () => {
-			app.log.info("Initializing TRaSH Guides update scheduler");
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.trashUpdate,
+				"TRaSH Guides update",
+				async () => {
+					app.log.info("Initializing TRaSH Guides update scheduler");
 
-			// Get configuration from environment or use defaults
-			const DEFAULT_INTERVAL_HOURS = 12;
-			const parsedInterval = Number.parseInt(
-				process.env.TRASH_UPDATE_CHECK_INTERVAL_HOURS || "",
-				10,
-			);
-			const intervalHours =
-				Number.isFinite(parsedInterval) && parsedInterval > 0
-					? Math.floor(parsedInterval)
-					: DEFAULT_INTERVAL_HOURS;
+					// Get configuration from environment or use defaults
+					const DEFAULT_INTERVAL_HOURS = 12;
+					const parsedInterval = Number.parseInt(
+						process.env.TRASH_UPDATE_CHECK_INTERVAL_HOURS || "",
+						10,
+					);
+					const intervalHours =
+						Number.isFinite(parsedInterval) && parsedInterval > 0
+							? Math.floor(parsedInterval)
+							: DEFAULT_INTERVAL_HOURS;
 
-			const config = {
-				enabled: process.env.TRASH_UPDATE_SCHEDULER_ENABLED !== "false", // Enabled by default
-				intervalHours,
-			};
+					const config = {
+						enabled: process.env.TRASH_UPDATE_SCHEDULER_ENABLED !== "false", // Enabled by default
+						intervalHours,
+					};
 
-			// Build initial services from the current repo config.
-			// The resolver is also passed to the scheduler so it re-reads config on each tick,
-			// automatically picking up custom repo changes without requiring a restart.
-			const repoConfigResolver = () => getGlobalRepoConfig(app.prisma);
-			const repoConfig = await repoConfigResolver();
-			app.log.info(
-				{ repoOwner: repoConfig.owner, repoName: repoConfig.name, repoBranch: repoConfig.branch },
-				"Scheduler using repository configuration",
-			);
-			const versionTracker = createVersionTracker(repoConfig);
-			const cacheManager = createCacheManager(app.prisma);
-			const githubFetcher = createTrashFetcher({ repoConfig, logger: app.log });
-			const templateUpdater = createTemplateUpdater(
-				app.prisma,
-				versionTracker,
-				cacheManager,
-				githubFetcher,
-				app.deploymentExecutor,
-			);
+					// Build initial services from the current repo config.
+					// The resolver is also passed to the scheduler so it re-reads config on each tick,
+					// automatically picking up custom repo changes without requiring a restart.
+					const repoConfigResolver = () => getGlobalRepoConfig(app.prisma);
+					const repoConfig = await repoConfigResolver();
+					app.log.info(
+						{
+							repoOwner: repoConfig.owner,
+							repoName: repoConfig.name,
+							repoBranch: repoConfig.branch,
+						},
+						"Scheduler using repository configuration",
+					);
+					const versionTracker = createVersionTracker(repoConfig);
+					const cacheManager = createCacheManager(app.prisma);
+					const githubFetcher = createTrashFetcher({ repoConfig, logger: app.log });
+					const templateUpdater = createTemplateUpdater(
+						app.prisma,
+						versionTracker,
+						cacheManager,
+						githubFetcher,
+						app.deploymentExecutor,
+					);
 
-			// Create and register scheduler
-			const scheduler = createUpdateScheduler(
-				config,
-				templateUpdater,
-				versionTracker,
-				app.prisma,
-				app.log,
-				app.arrClientFactory,
-				{
-					repoConfigResolver,
-					deploymentExecutor: app.deploymentExecutor,
-					notifyFn: (payload) => app.notificationService.notify(payload),
-					trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.trashUpdate, fn),
+					// Create and register scheduler
+					const scheduler = createUpdateScheduler(
+						config,
+						templateUpdater,
+						versionTracker,
+						app.prisma,
+						app.log,
+						app.arrClientFactory,
+						{
+							repoConfigResolver,
+							deploymentExecutor: app.deploymentExecutor,
+							notifyFn: (payload) => app.notificationService.notify(payload),
+							trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.trashUpdate, fn),
+						},
+					);
+
+					app.decorate("trashUpdateScheduler", scheduler);
+
+					// Start scheduler
+					scheduler.start();
+					app.log.info("TRaSH Guides update scheduler started successfully");
 				},
 			);
-
-			app.decorate("trashUpdateScheduler", scheduler);
-
-			// Start scheduler
-			scheduler.start();
-			app.log.info("TRaSH Guides update scheduler started successfully");
 		});
 
 		// Stop scheduler on server close

--- a/apps/api/src/routes/__tests__/system-jobs.test.ts
+++ b/apps/api/src/routes/__tests__/system-jobs.test.ts
@@ -9,6 +9,7 @@
 
 import Fastify from "fastify";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { runSchedulerInit } from "../../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../../lib/scheduler-registry/job-definitions.js";
 import schedulerRegistryPlugin from "../../plugins/scheduler-registry.js";
 import { registerSystemRoutes } from "../system.js";
@@ -150,6 +151,34 @@ describe("GET /system/jobs", () => {
 		expect(job.consecutiveFailures).toBe(0);
 		expect(job.totalRuns).toBe(2);
 		expect(job.totalFailures).toBe(1);
+		expect(job.lastError).toBeNull();
+	});
+
+	it("surfaces a scheduler init failure as state=disabled with a human-readable disabledReason", async () => {
+		// Pins the failure-handling contract documented in
+		// docs/domains/schedulers.md: when a scheduler plugin's `onReady`
+		// init fails, runSchedulerInit() must mark the job disabled with a
+		// "Init failed: <message>" reason so operators see the failure on
+		// /system/jobs instead of a misleading idle/totalRuns:0 state.
+		const ok = await runSchedulerInit(
+			{ registry: app.schedulerRegistry, log: app.log },
+			JOB_ID.backup,
+			"backup",
+			async () => {
+				throw new Error("simulated secrets file missing");
+			},
+		);
+		expect(ok).toBe(false);
+
+		const res = await injectAuthenticated("GET", "/system/jobs");
+		const body = JSON.parse(res.payload);
+		const job = body.data.jobs.find((j: any) => j.id === JOB_ID.backup);
+
+		expect(job.state).toBe("disabled");
+		expect(job.disabled).toBe(true);
+		expect(job.disabledReason).toBe("Init failed: simulated secrets file missing");
+		// totalRuns stays at 0 because the failure happened in init, not in a tick.
+		expect(job.totalRuns).toBe(0);
 		expect(job.lastError).toBeNull();
 	});
 

--- a/docs/domains/schedulers.md
+++ b/docs/domains/schedulers.md
@@ -54,6 +54,81 @@ This split is intentional. The registry observes; it does not schedule.
 6. **The `/system/jobs` endpoint never triggers a tick.** It is read-only.
    Pinned by `system-jobs.test.ts`.
 
+## Failure-handling policy
+
+A scheduler can fail at four distinct points. Each has a single, agreed
+behavior so operators see a consistent signal on `/api/system/jobs`.
+
+### 1. Tick body throws
+
+A `setInterval`-driven tick threw mid-flight (network error, DB error,
+unhandled bug in the executor).
+
+- **Required**: the tick body MUST be wrapped in
+  `app.schedulerRegistry.track(JOB_ID.x, …)`. The registry records
+  `lastError` (the error message), increments `consecutiveFailures` and
+  `totalFailures`, and **re-throws** so the plugin's existing logging /
+  notification path still fires.
+- **Operator signal**: `state: "idle"`, `lastError: "…"`,
+  `consecutiveFailures > 0`, `lastFailureAt` populated.
+
+### 2. Tick body returns a structured error result
+
+Currently no scheduler uses this pattern (executors either succeed or
+throw). If we adopt structured error results in the future, the plugin
+MUST translate them into a thrown error inside the `track()` callback so
+the registry records the failure. **Returning success while logging an
+internal error is a contract violation** — silent failures erode operator
+trust.
+
+### 3. Startup initialization failure
+
+The plugin's `onReady` body threw before the scheduler began ticking
+(missing secrets, unreachable DB, malformed config).
+
+- **Required**: every scheduler plugin whose `onReady` body performs I/O
+  or constructs a stateful object MUST run that init through
+  [`runSchedulerInit()`](../../apps/api/src/lib/scheduler-registry/init-helpers.ts).
+  The helper:
+    - logs the error at error level with `{ err, jobId }`
+    - calls `markDisabled(jobId, "Init failed: <message>")`
+    - **does not re-throw** — a single scheduler's init failure must
+      never abort the rest of the `onReady` chain
+    - returns a boolean the caller can use to gate feature flags
+- **Exempt**: cache schedulers whose `onReady` body is purely
+  `setTimeout(...)` with no I/O (e.g. `plex-cache-scheduler`,
+  `tautulli-cache-scheduler`). There is nothing meaningful that can throw
+  at init time.
+- **Operator signal**: `state: "disabled"`, `disabled: true`,
+  `disabledReason: "Init failed: <message>"`, `totalRuns: 0`.
+
+### 4. Serial overlap / busy condition
+
+A `serial` job's tick fires while the previous tick is still running.
+
+- **Required**: the registry throws `SerialJobBusyError` from `track()`.
+  The plugin MUST propagate the rejection (or log + re-throw it) — do NOT
+  swallow it silently. Swallowing hides legitimate overlap problems.
+- For non-`serial` jobs, plugins that need their own concurrency guard
+  (e.g. `isRunning` flag in cache schedulers) should keep it — those
+  guards are informational and the registry does not interfere.
+- **Operator signal**: `lastError: "Job <id> is already running …"` after
+  the next tick records the rejection; `consecutiveFailures` increments.
+
+### Quick reference
+
+| Failure | Helper / API | Operator-visible state |
+|---|---|---|
+| Tick throws | `registry.track()` (re-throws) | `lastError`, failure counters |
+| Tick returns structured error | translate into a throw inside `track()` | same as tick throws |
+| Init throws | `runSchedulerInit()` (does NOT re-throw) | `state: "disabled"`, `disabledReason: "Init failed: …"` |
+| Serial overlap | `SerialJobBusyError` from `track()` (propagate) | `lastError` after next tick |
+
+The unit test for `runSchedulerInit` lives at
+`apps/api/src/lib/scheduler-registry/__tests__/init-helpers.test.ts`; the
+integration test that pins the init-failure surface on `/system/jobs`
+lives in `system-jobs.test.ts`.
+
 ## Major integration points
 
 - **`app.schedulerRegistry`** — the single Fastify decoration every
@@ -77,7 +152,14 @@ This split is intentional. The registry observes; it does not schedule.
   so the rejection shows up in `lastError`.
 - **`disabledReason` not surfaced** — when calling `markDisabled(id, reason)`,
   always pass a human-readable reason. The `/system/jobs` payload exposes
-  it; the UI displays it; debugging without it is painful.
+  it; the UI displays it; debugging without it is painful. Init failures
+  routed through `runSchedulerInit()` always produce a
+  `"Init failed: <message>"` reason for free.
+- **Job appears `idle` but the feature is broken** — almost always means
+  the plugin's `onReady` threw and was not wrapped in
+  `runSchedulerInit()`. The error went to Fastify's default error path
+  and never reached the registry. Fix by wrapping init per the policy
+  above.
 - **Adding a scheduler that should not auto-start in dev** — gate the
   `setInterval` in the plugin, not in the registry. Registry just
   observes; the registration call should still happen so the job appears
@@ -89,7 +171,8 @@ This split is intentional. The registry observes; it does not schedule.
 |---|---|
 | New scheduler | (1) add ID to `JOB_ID` and entry to `KNOWN_JOBS` in `job-definitions.ts`; (2) create `apps/api/src/plugins/<name>-scheduler.ts` registering itself and wrapping the tick in `app.schedulerRegistry.track()`; (3) put the tick body in `apps/api/src/lib/<domain>/<name>-executor.ts`; (4) **register the plugin in `apps/api/src/bootstrap/schedulers.ts`** (without this the plugin never loads and the catalog entry stays at `idle`/`totalRuns: 0` forever) |
 | Adopt `track()` on an existing scheduler | wrap the body of the existing tick function — no other changes needed |
-| Disable a job at startup | call `app.schedulerRegistry.markDisabled(JOB_ID.x, "reason")` from the plugin instead of registering the timer |
+| Disable a job at startup | call `app.schedulerRegistry.markDisabled(JOB_ID.x, "reason")` from the plugin instead of registering the timer (e.g. feature flag off) |
+| Handle init failure | wrap `onReady` body with `runSchedulerInit({ registry: app.schedulerRegistry, log: app.log }, JOB_ID.x, "label", async () => { … })` — see Failure-handling policy above |
 | Add a runtime stat to the API response | extend `JobStatus` in `scheduler-registry.ts` and update `system-jobs.test.ts` (the contract test) |
 | Surface a job in a new UI panel | consume `/api/system/jobs`; do not duplicate the registry on the frontend |
 


### PR DESCRIPTION
## Summary

- Adds a `runSchedulerInit()` helper that standardizes the scheduler-plugin init failure-handling contract: log the error, call `markDisabled(jobId, \"Init failed: <message>\")`, and **do not re-throw** so the failure isn't propagated into the `onReady` chain.
- Applies the helper to the 6 scheduler plugins whose init does substantive I/O (`backup`, `library-sync`, `library-cleanup`, `insights-digest`, `trash-sync`, `trash-update`). Init failures now consistently surface on `/api/system/jobs` as `state: \"disabled\"` instead of leaving the job misleadingly idle.
- Documents the full failure-handling policy in `docs/domains/schedulers.md` covering all four failure points (tick throw / structured error / init failure / serial busy) with a quick-reference table.

## Why

Investigation found a split-brain across the scheduler plugins:

- `hunting` and `queue-cleaner` already implemented this contract correctly (try/catch → `markDisabled` → `/system/jobs` shows the disabled state with a human-readable reason).
- The other 6 plugins doing substantive init let errors propagate into Fastify's default error path. Operators saw `state: \"idle\"`, `totalRuns: 0`, `disabled: false` for a scheduler that had never actually started — a misleading \"everything's fine\" signal that erodes operator trust.

This PR normalizes the behavior without introducing a base class or framework: the helper is a 30-line free function, each plugin keeps owning its own lifecycle, and the contract is reviewable in code (one helper) and in docs (one policy section).

## Behavior delta

| Scenario | Before | After |
|---|---|---|
| Backup scheduler init throws (e.g. missing secrets) | `/system/jobs` shows `state: \"idle\"`, no signal that backups are broken | `state: \"disabled\"`, `disabledReason: \"Init failed: <message>\"` |
| One scheduler's `onReady` fails | Error swallowed by Fastify's default handler | Error logged with `{ err, jobId }`, registry updated, helper itself does not re-throw into the `onReady` chain |

## Intentionally deferred

- **Cache schedulers** (plex/jellyfin/tautulli/seerr-health/session-snapshot) are not wrapped — their `onReady` is just `setTimeout(...)` with no I/O. The policy doc explicitly calls these out as exempt with reasoning.
- **No retries / backoff / restart logic** — out of scope. A disabled job stays disabled until process restart; the operator signal is the deliverable.
- **No structured error-result pattern** — documented as \"if adopted, translate to a throw inside `track()`\".
- **No persistent job history, no external queues, no scheduler framework.**

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api run lint` — clean (only a pre-existing warning unrelated to this PR)
- [x] `pnpm --filter @arr/api exec vitest run` — 1270 passed / 36 skipped
- [x] New unit tests for `runSchedulerInit` cover success path, failure path, the no-rethrow invariant at the helper level, and non-Error throw shapes
- [x] New integration test in `system-jobs.test.ts` pins the `/api/system/jobs` operator-visible contract for init failures
- [x] **End-to-end plugin-chain integration test** (`scheduler-init-failure.test.ts`): boots the real `backup-scheduler` plugin against a config decoration whose `DATABASE_URL` getter throws, then asserts (a) `app.ready()` resolves without throwing — proving the helper preserves Fastify's `onReady` chain semantics in real wiring — and (b) the registry surfaces `state: \"disabled\"` with `disabledReason: \"Init failed: simulated config failure\"`. Discharges the previously-pending manual verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)