### PR TITLE
feat(governance): lightweight route surface governance via manifest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,40 @@ If a change is just "added a feature in the obvious place," it does
 not need an ADR. ADRs are expensive to read; reserve them for the
 decisions whose absence would cost a future reader an hour.
 
+### Route Surface Governance
+
+Every top-level API route group has a **maturity tier** declared in
+[`apps/api/src/routes/route-manifest.ts`](apps/api/src/routes/route-manifest.ts).
+The tier tells you how careful to be when changing the route's
+contract. See
+[`docs/adr/0004-route-surface-governance.md`](docs/adr/0004-route-surface-governance.md)
+for the full definitions; the short version:
+
+| Tier | Change discipline |
+|---|---|
+| `stable` | Preserve request/response shape within a minor. CHANGELOG breaking changes. |
+| `operator` | Treat behavior changes as user-visible. Document in CHANGELOG. |
+| `internal` | Free to reshape — update the bundled frontend in the **same PR**. |
+| `experimental` | May move or be removed. Mark loudly in release notes. |
+
+When you add a new route group:
+
+1. Add an entry to `route-manifest.ts` (this is what registers the
+   route — the bootstrap files iterate the manifest).
+2. Add a row to the governance table in
+   [`docs/API-ROUTES.md`](docs/API-ROUTES.md).
+3. The contract test
+   (`apps/api/src/routes/__tests__/route-manifest.test.ts`) will fail if
+   either is forgotten.
+
+When you change an existing route, check its tier first:
+
+- `stable` / `operator` shape change → CHANGELOG entry required.
+- `internal` shape change → update the consuming frontend code in the
+  same PR, no CHANGELOG entry needed.
+- Promoting a route from `internal` to `stable` is a deliberate
+  decision; mention it in the PR description.
+
 ### Architecture-affecting examples
 
 - ✅ Adding a new auth method (Auth domain doc + ADR if it changes the

--- a/apps/api/src/bootstrap/protected-routes.ts
+++ b/apps/api/src/bootstrap/protected-routes.ts
@@ -1,30 +1,18 @@
 import type { FastifyInstance } from "fastify";
 
-import { registerBackupRoutes } from "../routes/backup.js";
-import { registerDashboardRoutes } from "../routes/dashboard.js";
-import { registerHuntingRoutes } from "../routes/hunting.js";
-import { registerJellyfinRoutes } from "../routes/jellyfin/index.js";
-import { registerLibraryRoutes } from "../routes/library.js";
-import { registerLibraryCleanupRoutes } from "../routes/library-cleanup.js";
-import { registerManualImportRoutes } from "../routes/manual-import.js";
-import { registerNotificationRoutes } from "../routes/notifications.js";
-import oidcProvidersRoutes from "../routes/oidc-providers.js";
-import { registerPlexRoutes } from "../routes/plex/index.js";
-import { registerPulseRoutes } from "../routes/pulse.js";
-import { registerQueueCleanerRoutes } from "../routes/queue-cleaner.js";
-import { registerSearchRoutes } from "../routes/search.js";
-import { registerSeerrRoutes } from "../routes/seerr/index.js";
-import { registerServiceRoutes } from "../routes/services.js";
-import { registerSystemRoutes } from "../routes/system.js";
-import { registerTautulliRoutes } from "../routes/tautulli/index.js";
-import { registerTrashGuidesRoutes } from "../routes/trash-guides/index.js";
+import { PROTECTED_ROUTE_GROUPS } from "../routes/route-manifest.js";
 
 /**
  * Protected API routes — gated by the session preHandler registered here.
  *
  * The preHandler rejects any request without a populated `request.currentUser`.
- * Route groups below are organized by product domain so that ownership is
- * obvious at a glance.
+ * The set of protected route groups (and their stability/audience tier) is
+ * defined in `routes/route-manifest.ts`. Iterating that manifest is the
+ * only way a route reaches this scope, so registration and governance
+ * cannot drift apart.
+ *
+ * See ADR-0003 (protected-route auth model) and
+ * ADR-0004 (route surface governance).
  */
 export function registerProtectedRoutes(app: FastifyInstance): void {
 	app.register(async (api) => {
@@ -34,34 +22,12 @@ export function registerProtectedRoutes(app: FastifyInstance): void {
 			}
 		});
 
-		// --- Auth / identity management ---
-		api.register(oidcProvidersRoutes);
-
-		// --- System + operator surface ---
-		api.register(registerSystemRoutes, { prefix: "/api/system" });
-		api.register(registerBackupRoutes, { prefix: "/api/backup" });
-		api.register(registerNotificationRoutes, { prefix: "/api/notifications" });
-
-		// --- ARR services (Sonarr / Radarr / Prowlarr / Lidarr / Readarr) ---
-		api.register(registerServiceRoutes, { prefix: "/api" });
-		api.register(registerDashboardRoutes, { prefix: "/api" });
-		api.register(registerLibraryRoutes, { prefix: "/api" });
-		api.register(registerSearchRoutes, { prefix: "/api" });
-		api.register(registerManualImportRoutes, { prefix: "/api" });
-
-		// --- ARR automation ---
-		api.register(registerHuntingRoutes, { prefix: "/api" });
-		api.register(registerQueueCleanerRoutes, { prefix: "/api" });
-		api.register(registerLibraryCleanupRoutes, { prefix: "/api" });
-
-		// --- Media servers (Plex / Jellyfin / Tautulli) ---
-		api.register(registerPlexRoutes, { prefix: "/api/plex" });
-		api.register(registerJellyfinRoutes, { prefix: "/api/jellyfin" });
-		api.register(registerTautulliRoutes, { prefix: "/api/tautulli" });
-		api.register(registerPulseRoutes, { prefix: "/api" });
-
-		// --- External integrations (Seerr / TRaSH Guides) ---
-		api.register(registerSeerrRoutes, { prefix: "/api/seerr" });
-		api.register(registerTrashGuidesRoutes, { prefix: "/api/trash-guides" });
+		for (const group of PROTECTED_ROUTE_GROUPS) {
+			if (group.prefix !== undefined) {
+				api.register(group.register, { prefix: group.prefix });
+			} else {
+				api.register(group.register);
+			}
+		}
 	});
 }

--- a/apps/api/src/bootstrap/public-routes.ts
+++ b/apps/api/src/bootstrap/public-routes.ts
@@ -1,8 +1,6 @@
 import type { FastifyInstance } from "fastify";
-import { registerAuthRoutes } from "../routes/auth.js";
-import { registerAuthOidcRoutes } from "../routes/auth-oidc.js";
-import { registerAuthPasskeyRoutes } from "../routes/auth-passkey.js";
-import { registerHealthRoutes } from "../routes/health.js";
+
+import { PUBLIC_ROUTE_GROUPS } from "../routes/route-manifest.js";
 
 /**
  * Public routes — no authentication required.
@@ -11,13 +9,19 @@ import { registerHealthRoutes } from "../routes/health.js";
  *  - /auth    → password login / logout / setup
  *  - /auth    → OIDC callback + passkey registration/assertion
  *
- * Auth-related endpoints are public because they are the entry points that
- * establish a session. Session-gated behavior is enforced by the scoped
- * preHandler registered with the protected routes.
+ * Auth-related endpoints are public because they are the entry points
+ * that establish a session. Session-gated behavior is enforced by the
+ * scoped preHandler in `protected-routes.ts`.
+ *
+ * The set of public route groups is defined in
+ * `routes/route-manifest.ts`. See ADR-0004 (route surface governance).
  */
 export function registerPublicRoutes(app: FastifyInstance): void {
-	app.register(registerHealthRoutes, { prefix: "/health" });
-	app.register(registerAuthRoutes, { prefix: "/auth" });
-	app.register(registerAuthOidcRoutes, { prefix: "/auth" });
-	app.register(registerAuthPasskeyRoutes, { prefix: "/auth" });
+	for (const group of PUBLIC_ROUTE_GROUPS) {
+		if (group.prefix !== undefined) {
+			app.register(group.register, { prefix: group.prefix });
+		} else {
+			app.register(group.register);
+		}
+	}
 }

--- a/apps/api/src/routes/__tests__/route-manifest.test.ts
+++ b/apps/api/src/routes/__tests__/route-manifest.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Route manifest contract test.
+ *
+ * The manifest in `routes/route-manifest.ts` is the single source of truth
+ * for both route registration and the governance section in
+ * `docs/API-ROUTES.md`. This test pins three properties:
+ *
+ *   1. Every entry is well-formed (valid maturity, non-empty fields,
+ *      no duplicate `path`s).
+ *   2. Every documented `path` actually appears in `docs/API-ROUTES.md` —
+ *      so the doc and the code cannot drift apart silently.
+ *   3. The set of registered Fastify route prefixes matches the union of
+ *      manifest paths — i.e., nothing slipped past the manifest into the
+ *      bootstrap files.
+ *
+ * If you add a route, add a manifest entry AND a row to the governance
+ * table in `docs/API-ROUTES.md`. This test will tell you exactly which
+ * one you forgot.
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+	ALL_ROUTE_GROUPS,
+	PROTECTED_ROUTE_GROUPS,
+	PUBLIC_ROUTE_GROUPS,
+	type RouteMaturity,
+} from "../route-manifest.js";
+
+const VALID_MATURITY = new Set<RouteMaturity>(["stable", "operator", "internal", "experimental"]);
+
+const here = dirname(fileURLToPath(import.meta.url));
+// __tests__ → routes → src → apps/api → apps → repo root
+const DOC_PATH = join(here, "..", "..", "..", "..", "..", "docs", "API-ROUTES.md");
+
+describe("route manifest", () => {
+	it("contains both public and protected groups", () => {
+		expect(PUBLIC_ROUTE_GROUPS.length).toBeGreaterThan(0);
+		expect(PROTECTED_ROUTE_GROUPS.length).toBeGreaterThan(0);
+		expect(ALL_ROUTE_GROUPS.length).toBe(
+			PUBLIC_ROUTE_GROUPS.length + PROTECTED_ROUTE_GROUPS.length,
+		);
+	});
+
+	it("every entry is well-formed", () => {
+		for (const group of ALL_ROUTE_GROUPS) {
+			expect(group.path, `path missing for group: ${JSON.stringify(group)}`).toMatch(/^\//);
+			expect(group.summary.trim().length, `empty summary for ${group.path}`).toBeGreaterThan(0);
+			expect(VALID_MATURITY.has(group.maturity), `bad maturity for ${group.path}`).toBe(true);
+			expect(typeof group.register, `register must be a function for ${group.path}`).toBe(
+				"function",
+			);
+		}
+	});
+
+	it("paths are unique across the manifest", () => {
+		const seen = new Set<string>();
+		for (const group of ALL_ROUTE_GROUPS) {
+			expect(seen.has(group.path), `duplicate path: ${group.path}`).toBe(false);
+			seen.add(group.path);
+		}
+	});
+
+	it("every manifest path is referenced in docs/API-ROUTES.md", () => {
+		const doc = readFileSync(DOC_PATH, "utf8");
+		const missing = ALL_ROUTE_GROUPS.filter((group) => !doc.includes(group.path)).map(
+			(g) => g.path,
+		);
+		expect(
+			missing,
+			`Missing from docs/API-ROUTES.md governance table: ${missing.join(", ")}`,
+		).toEqual([]);
+	});
+});

--- a/apps/api/src/routes/__tests__/route-manifest.test.ts
+++ b/apps/api/src/routes/__tests__/route-manifest.test.ts
@@ -3,15 +3,20 @@
  *
  * The manifest in `routes/route-manifest.ts` is the single source of truth
  * for both route registration and the governance section in
- * `docs/API-ROUTES.md`. This test pins three properties:
+ * `docs/API-ROUTES.md`. This test pins two properties:
  *
- *   1. Every entry is well-formed (valid maturity, non-empty fields,
- *      no duplicate `path`s).
- *   2. Every documented `path` actually appears in `docs/API-ROUTES.md` —
+ *   1. Every entry is well-formed (valid maturity tier, non-empty
+ *      summary, function-typed `register`, unique `path`).
+ *   2. Every manifest `path` actually appears in `docs/API-ROUTES.md`
  *      so the doc and the code cannot drift apart silently.
- *   3. The set of registered Fastify route prefixes matches the union of
- *      manifest paths — i.e., nothing slipped past the manifest into the
- *      bootstrap files.
+ *
+ * What this test does NOT cover: it does not boot Fastify and compare
+ * the registered route prefixes against the manifest. The structural
+ * guarantee that registration cannot bypass the manifest comes from
+ * `bootstrap/{public,protected}-routes.ts` iterating the manifest
+ * directly — a reviewer enforces that, not this test. If a future
+ * change reintroduces inline route registration in the bootstrap files,
+ * add a Fastify-boot assertion here.
  *
  * If you add a route, add a manifest entry AND a row to the governance
  * table in `docs/API-ROUTES.md`. This test will tell you exactly which

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -1,0 +1,269 @@
+/**
+ * Route Surface Manifest
+ *
+ * Single source of truth for every top-level route group registered on the
+ * Fastify server. Drives both the actual `register()` calls in
+ * `bootstrap/{public,protected}-routes.ts` AND the governance section in
+ * `docs/API-ROUTES.md`.
+ *
+ * If you add a new route group, add an entry here. The bootstrap files
+ * iterate this list — there is no second place to register a route. A
+ * companion test (`__tests__/route-manifest.test.ts`) asserts that every
+ * entry is well-formed and that every documented path appears in
+ * `docs/API-ROUTES.md`.
+ *
+ * See `docs/adr/0004-route-surface-governance.md` for the rationale and
+ * the meaning of each maturity tier.
+ */
+import type { FastifyInstance, FastifyPluginAsync, FastifyPluginCallback } from "fastify";
+
+import { registerAuthRoutes } from "./auth.js";
+import { registerAuthOidcRoutes } from "./auth-oidc.js";
+import { registerAuthPasskeyRoutes } from "./auth-passkey.js";
+import { registerBackupRoutes } from "./backup.js";
+import { registerDashboardRoutes } from "./dashboard.js";
+import { registerHealthRoutes } from "./health.js";
+import { registerHuntingRoutes } from "./hunting.js";
+import { registerJellyfinRoutes } from "./jellyfin/index.js";
+import { registerLibraryRoutes } from "./library.js";
+import { registerLibraryCleanupRoutes } from "./library-cleanup.js";
+import { registerManualImportRoutes } from "./manual-import.js";
+import { registerNotificationRoutes } from "./notifications.js";
+import oidcProvidersRoutes from "./oidc-providers.js";
+import { registerPlexRoutes } from "./plex/index.js";
+import { registerPulseRoutes } from "./pulse.js";
+import { registerQueueCleanerRoutes } from "./queue-cleaner.js";
+import { registerSearchRoutes } from "./search.js";
+import { registerSeerrRoutes } from "./seerr/index.js";
+import { registerServiceRoutes } from "./services.js";
+import { registerSystemRoutes } from "./system.js";
+import { registerTautulliRoutes } from "./tautulli/index.js";
+import { registerTrashGuidesRoutes } from "./trash-guides/index.js";
+
+/**
+ * Maturity tier of a route group.
+ *
+ * - `stable`       Web UI and external scripts may depend on this shape.
+ *                  Preserve request/response contract within a minor
+ *                  version. Breaking changes need a CHANGELOG entry.
+ * - `operator`     Operator/admin actions with real-world side effects
+ *                  (restart, restore, configure providers). Treat changes
+ *                  as user-visible behavior; document in CHANGELOG.
+ * - `internal`     Consumed only by the bundled dashboard. Frontend is
+ *                  updated in the same PR. Free to reshape.
+ * - `experimental` Newer surface, may move or be removed. Mark loudly in
+ *                  release notes if exposed in the UI.
+ */
+export type RouteMaturity = "stable" | "operator" | "internal" | "experimental";
+
+/** Type that matches both Fastify plugin signatures we register. */
+type RoutePlugin = FastifyPluginCallback | FastifyPluginAsync | ((app: FastifyInstance) => unknown);
+
+export type RouteGroup = {
+	/**
+	 * Canonical user-facing path or prefix for this group. Used in docs
+	 * and tests. For self-prefixed plugins (e.g. oidc-providers, which
+	 * declares `/api/oidc-providers` inside its handlers), this is the
+	 * documentation path even though `prefix` is omitted.
+	 */
+	path: string;
+	/** Stability/audience tier. See `RouteMaturity` for definitions. */
+	maturity: RouteMaturity;
+	/** One-line summary shown in the governance table. */
+	summary: string;
+	/** The route plugin to register. */
+	register: RoutePlugin;
+	/**
+	 * Fastify `register({ prefix })` option. Omit when the plugin
+	 * declares full paths internally (self-prefixed plugins).
+	 */
+	prefix?: string;
+};
+
+/**
+ * Public, unauthenticated routes — no session required.
+ *
+ * These are entry points that establish a session (login, OIDC callback,
+ * passkey assertion) plus the health probe. Anything that must work
+ * pre-login lives here. See ADR-0003.
+ */
+export const PUBLIC_ROUTE_GROUPS: readonly RouteGroup[] = [
+	{
+		path: "/health",
+		prefix: "/health",
+		register: registerHealthRoutes,
+		maturity: "stable",
+		summary: "Liveness/readiness probes for orchestrators",
+	},
+	{
+		path: "/auth",
+		prefix: "/auth",
+		register: registerAuthRoutes,
+		maturity: "stable",
+		summary: "Password login, registration, account management",
+	},
+	{
+		path: "/auth/oidc",
+		prefix: "/auth",
+		register: registerAuthOidcRoutes,
+		maturity: "stable",
+		summary: "OIDC initiate + callback",
+	},
+	{
+		path: "/auth/passkey",
+		prefix: "/auth",
+		register: registerAuthPasskeyRoutes,
+		maturity: "stable",
+		summary: "WebAuthn registration + assertion",
+	},
+];
+
+/**
+ * Protected routes — gated by the scoped session preHandler in
+ * `bootstrap/protected-routes.ts`. Authentication is uniform; there is
+ * no per-route auth check (single-admin model). See ADR-0003.
+ */
+export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
+	// --- Auth / identity admin ---
+	{
+		path: "/api/oidc-providers",
+		register: oidcProvidersRoutes,
+		maturity: "operator",
+		summary: "OIDC provider configuration (single-admin)",
+	},
+
+	// --- Operator / system surface ---
+	{
+		path: "/api/system",
+		prefix: "/api/system",
+		register: registerSystemRoutes,
+		maturity: "operator",
+		summary: "Settings, restart, jobs, posture diagnostics",
+	},
+	{
+		path: "/api/backup",
+		prefix: "/api/backup",
+		register: registerBackupRoutes,
+		maturity: "operator",
+		summary: "Create, download, restore, scheduled backups",
+	},
+	{
+		path: "/api/notifications",
+		prefix: "/api/notifications",
+		register: registerNotificationRoutes,
+		maturity: "stable",
+		summary: "Channels, subscriptions, rules, delivery aggregation",
+	},
+
+	// --- ARR services (Sonarr / Radarr / Prowlarr / Lidarr / Readarr) ---
+	{
+		path: "/api/services",
+		prefix: "/api",
+		register: registerServiceRoutes,
+		maturity: "stable",
+		summary: "ARR instance CRUD + connection testing",
+	},
+	{
+		path: "/api/dashboard",
+		prefix: "/api",
+		register: registerDashboardRoutes,
+		maturity: "stable",
+		summary: "Queue, history, calendar, statistics aggregates",
+	},
+	{
+		path: "/api/library",
+		prefix: "/api",
+		register: registerLibraryRoutes,
+		maturity: "stable",
+		summary: "Movies/series listing, episodes, monitor, search",
+	},
+	{
+		path: "/api/search",
+		prefix: "/api",
+		register: registerSearchRoutes,
+		maturity: "stable",
+		summary: "Prowlarr indexer search + grab",
+	},
+	{
+		path: "/api/manual-import",
+		prefix: "/api",
+		register: registerManualImportRoutes,
+		maturity: "stable",
+		summary: "Manual import candidates and submission",
+	},
+
+	// --- ARR automation (dashboard-driven) ---
+	{
+		path: "/api/hunting",
+		prefix: "/api",
+		register: registerHuntingRoutes,
+		maturity: "internal",
+		summary: "Auto-search configuration and execution",
+	},
+	{
+		path: "/api/queue-cleaner",
+		prefix: "/api",
+		register: registerQueueCleanerRoutes,
+		maturity: "internal",
+		summary: "Queue cleanup rules, strikes, dry-run preview",
+	},
+	{
+		path: "/api/library-cleanup",
+		prefix: "/api",
+		register: registerLibraryCleanupRoutes,
+		maturity: "internal",
+		summary: "Library cleanup rules, approvals, execution",
+	},
+
+	// --- Media servers (Plex / Jellyfin / Tautulli) ---
+	{
+		path: "/api/plex",
+		prefix: "/api/plex",
+		register: registerPlexRoutes,
+		maturity: "stable",
+		summary: "Now playing, on-deck, history, analytics, forecasts",
+	},
+	{
+		path: "/api/jellyfin",
+		prefix: "/api/jellyfin",
+		register: registerJellyfinRoutes,
+		maturity: "stable",
+		summary: "Jellyfin activity and library data",
+	},
+	{
+		path: "/api/tautulli",
+		prefix: "/api/tautulli",
+		register: registerTautulliRoutes,
+		maturity: "stable",
+		summary: "Activity, watch history enrichment, statistics",
+	},
+	{
+		path: "/api/pulse",
+		prefix: "/api",
+		register: registerPulseRoutes,
+		maturity: "internal",
+		summary: "System Pulse health signals + attention items",
+	},
+
+	// --- External integrations (Seerr / TRaSH Guides) ---
+	{
+		path: "/api/seerr",
+		prefix: "/api/seerr",
+		register: registerSeerrRoutes,
+		maturity: "stable",
+		summary: "Request management, discovery, library enrichment",
+	},
+	{
+		path: "/api/trash-guides",
+		prefix: "/api/trash-guides",
+		register: registerTrashGuidesRoutes,
+		maturity: "internal",
+		summary: "TRaSH cache, templates, deployment, profiles",
+	},
+];
+
+/** All route groups, regardless of auth scope. Used for governance reporting. */
+export const ALL_ROUTE_GROUPS: readonly RouteGroup[] = [
+	...PUBLIC_ROUTE_GROUPS,
+	...PROTECTED_ROUTE_GROUPS,
+];

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -4,6 +4,64 @@
 
 All routes in `apps/api/src/routes/`. Protected routes use preHandler authentication.
 
+## Route Surface Governance
+
+Every top-level route group is registered through a single manifest at
+[`apps/api/src/routes/route-manifest.ts`](../apps/api/src/routes/route-manifest.ts).
+The manifest assigns each group a **maturity tier** that tells contributors
+how careful they need to be when changing it.
+
+| Tier | Audience | Change discipline |
+|---|---|---|
+| **stable** | Bundled web UI **and** potential external scripts/integrations | Preserve request/response shape within a minor version. Breaking changes need a CHANGELOG entry and (if user-visible) a release-notes call-out. |
+| **operator** | Self-hosting operator (single-admin) via the UI or scripted ops | Real-world side effects (restart, restore, configure providers). Treat behavior changes as user-visible; document in CHANGELOG. |
+| **internal** | Bundled dashboard only — frontend ships in lockstep | Free to reshape as long as the matching frontend code is updated in the same PR. No external compatibility promise. |
+| **experimental** | Opt-in / iterating | May move or be removed. Mark loudly in release notes if surfaced in the UI. |
+
+This is **not** a semantic API versioning scheme. The app remains
+single-admin and self-hosted; the tiers exist to set reviewer expectations,
+not to gate routing. See
+[`docs/adr/0004-route-surface-governance.md`](adr/0004-route-surface-governance.md)
+for the full rationale.
+
+### Public route groups
+
+| Path | Maturity | Summary |
+|---|---|---|
+| `/health` | stable | Liveness/readiness probes for orchestrators |
+| `/auth` | stable | Password login, registration, account management |
+| `/auth/oidc` | stable | OIDC initiate + callback |
+| `/auth/passkey` | stable | WebAuthn registration + assertion |
+
+### Protected route groups
+
+| Path | Maturity | Summary |
+|---|---|---|
+| `/api/oidc-providers` | operator | OIDC provider configuration (single-admin) |
+| `/api/system` | operator | Settings, restart, jobs, posture diagnostics |
+| `/api/backup` | operator | Create, download, restore, scheduled backups |
+| `/api/notifications` | stable | Channels, subscriptions, rules, delivery aggregation |
+| `/api/services` | stable | ARR instance CRUD + connection testing |
+| `/api/dashboard` | stable | Queue, history, calendar, statistics aggregates |
+| `/api/library` | stable | Movies/series listing, episodes, monitor, search |
+| `/api/search` | stable | Prowlarr indexer search + grab |
+| `/api/manual-import` | stable | Manual import candidates and submission |
+| `/api/hunting` | internal | Auto-search configuration and execution |
+| `/api/queue-cleaner` | internal | Queue cleanup rules, strikes, dry-run preview |
+| `/api/library-cleanup` | internal | Library cleanup rules, approvals, execution |
+| `/api/plex` | stable | Now playing, on-deck, history, analytics, forecasts |
+| `/api/jellyfin` | stable | Jellyfin activity and library data |
+| `/api/tautulli` | stable | Activity, watch history enrichment, statistics |
+| `/api/pulse` | internal | System Pulse health signals + attention items |
+| `/api/seerr` | stable | Request management, discovery, library enrichment |
+| `/api/trash-guides` | internal | TRaSH cache, templates, deployment, profiles |
+
+> When you add a new route group, add a manifest entry **and** a row above.
+> A contract test (`apps/api/src/routes/__tests__/route-manifest.test.ts`)
+> will fail loudly if either is missing.
+
+## Per-group route detail
+
 ## Authentication Routes (`/auth`)
 
 | Method | Route | Auth | Purpose |

--- a/docs/adr/0004-route-surface-governance.md
+++ b/docs/adr/0004-route-surface-governance.md
@@ -1,0 +1,137 @@
+# ADR 0004: Route Surface Governance
+
+- **Status:** Accepted
+- **Date:** 2026-04-13
+- **Deciders:** Backend maintainers
+- **Supersedes:** —
+
+## Context
+
+The HTTP surface spans roughly twenty top-level route groups across auth,
+ARR services, automation, media servers, and operator/system tooling.
+Some of these are heavily depended on by the bundled web UI (and
+plausibly by external scripts that operators wire up themselves), while
+others are dashboard-only synthetic surfaces that ship in lockstep with
+the frontend.
+
+A reviewer landing on a PR that touches a route had no quick answer to:
+
+1. **Is this route intended to be stable?** Will breaking the response
+   shape break someone's tooling, or just break the next dashboard
+   build?
+2. **Who is this route for?** External integrations? The operator's
+   own scripts? The dashboard only?
+3. **How careful do I need to be?** Does this need a CHANGELOG entry,
+   release-notes call-out, or coordinated frontend update?
+
+The previous answer was "read the route, read the consumers, guess."
+That works at twenty routes; it gets worse as the surface grows. We did
+not, however, want to introduce semantic API versioning (`/v1`, `/v2`)
+or a heavyweight registry framework — both are theatre at this scale,
+and the app is single-admin self-hosted, not a multi-tenant platform
+API.
+
+## Decision
+
+Introduce a single typed manifest at
+[`apps/api/src/routes/route-manifest.ts`](../../apps/api/src/routes/route-manifest.ts)
+that:
+
+1. Lists every top-level route group (public + protected) with a
+   canonical `path`, a `register` function reference, an optional Fastify
+   `prefix`, a one-line `summary`, and a `maturity` tier.
+2. Is the **only** mechanism by which a route group reaches the server —
+   `bootstrap/public-routes.ts` and `bootstrap/protected-routes.ts`
+   iterate the manifest. There is no parallel list to keep in sync.
+3. Is mirrored in [`docs/API-ROUTES.md`](../API-ROUTES.md)'s "Route
+   Surface Governance" section, with a contract test
+   (`route-manifest.test.ts`) that fails if any manifest path is missing
+   from the doc.
+
+### Maturity tiers
+
+| Tier | Audience | Change discipline |
+|---|---|---|
+| `stable` | Bundled web UI **and** potential external scripts/integrations | Preserve request/response shape within a minor. CHANGELOG breaking changes. |
+| `operator` | Self-hosting operator (single-admin) via UI or scripted ops | Real-world side effects (restart, restore, configure providers). Document behavior changes in CHANGELOG. |
+| `internal` | Bundled dashboard only — frontend ships in lockstep | Free to reshape with a coordinated frontend update in the same PR. |
+| `experimental` | Opt-in, iterating | May move or be removed. Currently empty; reserved. |
+
+The set is deliberately small. Adding more tiers (e.g. `deprecated`,
+`beta`) is cheap when there is real demand, but the cost of a tier no
+one understands is high — reviewers stop trusting any of them.
+
+## Why this shape
+
+1. **One source of truth, by construction.** The bootstrap files iterate
+   the manifest. A contributor cannot register a route "around" the
+   manifest without obviously bypassing the bootstrap loop, which a
+   reviewer will catch. Drift between governance metadata and actual
+   registration is structurally impossible.
+2. **Prefix-level, not handler-level.** The single-admin model means
+   "authenticated" *is* "authorized" (see ADR-0003), and route groups
+   already cluster cleanly by domain. Per-handler annotations would add
+   noise without adding signal.
+3. **Doc + test, not codegen.** The doc table is hand-written. A small
+   substring-based test asserts that every manifest path appears in
+   `docs/API-ROUTES.md`, so contributors get drift detection without a
+   fragile generation pipeline. The full table fits on one screen and is
+   trivial to maintain.
+4. **No URL versioning.** This codebase ships a bundled frontend; a
+   `/v1` prefix would just be ceremony. If we ever need to support
+   multiple incompatible clients, that decision deserves its own ADR.
+
+## Why not …
+
+- **Semantic versioning (`/api/v1/…`).** Adds path noise and a migration
+  story we do not need today. Re-evaluate if external API consumers
+  become a real audience.
+- **Per-handler `@stable` / `@internal` decorators.** Invasive to add,
+  easy to forget, and the natural unit is the route group, not the
+  handler. The manifest captures the same information at the right
+  granularity.
+- **A generated route registry / OpenAPI doc.** Worth considering later,
+  but premature now: most consumers are the bundled UI's typed React
+  Query hooks, not external clients. OpenAPI generation is its own
+  multi-week project; the manifest is a one-PR change.
+- **Comments-only convention** ("just write `// stable` above the
+  route"). No drift detection, no machine-readable surface, no test
+  coverage. Falls out of sync within months.
+
+## Consequences
+
+### Positive
+
+- A reviewer can answer "is this stable / who is it for / how careful do
+  I need to be?" by reading one row in `docs/API-ROUTES.md`.
+- Adding a new route group is a one-place edit (manifest), plus a row in
+  the doc. The test fails fast if either is forgotten.
+- Bootstrap files shrink to ~30 lines apiece and read as the policy
+  ("for each group, register it under the auth scope") rather than a
+  hand-maintained list.
+- The tier vocabulary gives PR descriptions and CHANGELOG entries a
+  shared shorthand: "this is an `internal` surface, dashboard updated
+  in the same PR" closes a class of review questions immediately.
+
+### Negative / trade-offs
+
+- The manifest concentrates a lot of imports in one file. Acceptable —
+  it's an index, not logic.
+- Maturity is a judgment call at the group level, not the handler level.
+  If a single group ends up mixing stable and internal endpoints, the
+  group must either be split or graded down to its weakest tier. So far
+  every group has fit cleanly into one tier.
+- The doc-table check is a substring match. Strong enough to catch
+  forgotten rows; weak enough that it won't catch a wrong tier label
+  in the doc. That is intentional — over-fitting the test would make it
+  noisy without catching real bugs. Wrong labels are caught at PR review.
+
+## Follow-ups
+
+- If `experimental` ever holds a real entry, add a release-notes
+  template line ("⚠️ Experimental — may change in 2.x").
+- If external API consumers materialize, revisit URL versioning in a
+  new ADR rather than retrofitting it onto the manifest.
+- If a `deprecated` tier is added, also add a release-notes line and a
+  removal-window convention (e.g., "deprecated routes are removed no
+  sooner than the second minor release after deprecation").


### PR DESCRIPTION
## Summary

- Adds a typed route manifest (`apps/api/src/routes/route-manifest.ts`) as the single source of truth for top-level route groups. The bootstrap files now iterate the manifest, so registration and governance metadata cannot drift apart.
- Defines four maturity tiers (`stable`, `operator`, `internal`, `experimental`) and surfaces them in `docs/API-ROUTES.md` + `CONTRIBUTING.md`. Reviewers get a one-row answer to "is this stable / who is it for / how careful do I need to be?"
- Adds ADR-0004 with full rationale and alternatives rejected (no URL versioning, no per-handler decorators, no codegen pipeline).
- Adds a small contract test (`route-manifest.test.ts`) that asserts entries are well-formed and that every manifest path appears in the doc table.

## Why this shape

- **One source of truth, by construction.** The bootstrap files iterate the manifest — there is no second place to register a route. Drift between governance and actual routing is structurally impossible.
- **Prefix-level, not handler-level.** Single-admin model means "authenticated" is "authorized" (ADR-0003). Route groups already cluster by domain, so per-handler annotations would add noise without signal.
- **Doc + test, not codegen.** Hand-written table with a substring-based test for drift detection. No fragile generation pipeline.

## Intentionally deferred

- URL versioning (`/api/v1/…`) — not needed at single-admin scale.
- OpenAPI generation — its own multi-week project.
- A `deprecated` tier — add the day a real route needs it.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` clean
- [x] `route-manifest.test.ts` passes (4/4)
- [x] `route-auth-enforcement.test.ts` still passes (6/6) — auth model unchanged
- [x] Biome clean on all touched files
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)