### PR TITLE
feat(ux): standardize async state presentation across data panels

### DIFF
--- a/apps/web/src/components/layout/__tests__/async-state-view.test.tsx
+++ b/apps/web/src/components/layout/__tests__/async-state-view.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { Inbox } from "lucide-react";
+import { describe, expect, it, vi } from "vitest";
+
+// useThemeGradient pulls in a context provider; mock with a stub gradient.
+vi.mock("../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#7c3aed",
+			to: "#a855f7",
+			glow: "rgba(124,58,237,0.4)",
+			fromLight: "rgba(124,58,237,0.15)",
+		},
+	}),
+}));
+
+import { AsyncStateView } from "../async-state-view";
+
+const baseEmpty = {
+	icon: Inbox,
+	title: "Nothing here",
+	description: "Items will appear soon.",
+};
+
+describe("AsyncStateView", () => {
+	it("renders children in success state", () => {
+		render(
+			<AsyncStateView emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(screen.getByText("Loaded content")).toBeInTheDocument();
+	});
+
+	it("renders the loading skeleton with aria-busy", () => {
+		const { container } = render(
+			<AsyncStateView isLoading emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(container.querySelector("[aria-busy='true']")).not.toBeNull();
+		expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+	});
+
+	it("renders the empty state when isEmpty is true", () => {
+		render(
+			<AsyncStateView isEmpty emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(screen.getByText("Nothing here")).toBeInTheDocument();
+		expect(screen.getByText("Items will appear soon.")).toBeInTheDocument();
+		expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+	});
+
+	it("renders the error state with retry, calling onRetry on click", () => {
+		const onRetry = vi.fn();
+		render(
+			<AsyncStateView
+				isError
+				error={new Error("Network exploded")}
+				onRetry={onRetry}
+				emptyState={baseEmpty}
+			>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+
+		expect(screen.getByText("Couldn't load data")).toBeInTheDocument();
+		expect(screen.getByText("Network exploded")).toBeInTheDocument();
+		expect(screen.queryByText("Loaded content")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("falls back to a default error description when no error provided", () => {
+		render(
+			<AsyncStateView isError emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+	});
+
+	it("prioritises error over loading and empty", () => {
+		render(
+			<AsyncStateView isError isLoading isEmpty error={new Error("Nope")} emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+		expect(screen.queryByText("Nothing here")).not.toBeInTheDocument();
+	});
+
+	it("omits the retry button when no onRetry handler is supplied", () => {
+		render(
+			<AsyncStateView isError error={new Error("X")} emptyState={baseEmpty}>
+				<p>Loaded content</p>
+			</AsyncStateView>,
+		);
+		expect(screen.queryByRole("button", { name: /try again/i })).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/components/layout/async-state-view.tsx
+++ b/apps/web/src/components/layout/async-state-view.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { AlertTriangle, type LucideIcon, RefreshCw } from "lucide-react";
+import type { ReactNode } from "react";
+import { useThemeGradient } from "../../hooks/useThemeGradient";
+import { cn } from "../../lib/utils";
+import { PremiumEmptyState } from "./premium-containers";
+import { SkeletonTable } from "../ui/skeleton";
+
+const errorToMessage = (error: unknown, fallback: string): string => {
+	if (error instanceof Error && error.message) return error.message;
+	if (typeof error === "string" && error.length > 0) return error;
+	return fallback;
+};
+
+/* =============================================================================
+   ASYNC STATE VIEW
+   Standardized loading / error / empty / content presentation for data panels.
+
+   Why this exists:
+   - Data panels across the app each invented their own "spinner-or-nothing"
+     loading UI, silently swallowed errors, and rendered ad-hoc empty messages.
+   - This composer dispatches to existing primitives (PremiumSkeleton,
+     PremiumEmptyState) and adds the missing piece — a themed error card with a
+     retry button — so panels can opt into all four states with one wrapper.
+
+   Order of precedence: error > loading > empty > content.
+   Errors win even while loading so a stale failure isn't masked by a refetch.
+   ============================================================================= */
+
+export interface AsyncStateEmptyConfig {
+	icon: LucideIcon;
+	title: string;
+	description?: string;
+	action?: ReactNode;
+}
+
+export interface AsyncStateViewProps {
+	/** Whether the underlying query is currently fetching (initial load). */
+	isLoading?: boolean;
+	/** Whether the underlying query failed. */
+	isError?: boolean;
+	/** The error from the failed query, if any. Rendered as the error description. */
+	error?: unknown;
+	/** Whether the loaded data is empty. Ignored while loading or in error. */
+	isEmpty?: boolean;
+	/** Optional retry handler. When provided and `isError` is true, a retry button is shown. */
+	onRetry?: () => void;
+	/** Optional override for the loading state. Defaults to a themed table skeleton. */
+	loadingFallback?: ReactNode;
+	/** Configuration for the empty state. */
+	emptyState: AsyncStateEmptyConfig;
+	/** Optional title for the error state. Defaults to "Couldn't load data". */
+	errorTitle?: string;
+	/** Optional override for the error description. Defaults to the error message. */
+	errorDescription?: string;
+	/** Content to render in the success state. */
+	children: ReactNode;
+	/** Optional className applied to the error / loading wrapper (not the content). */
+	className?: string;
+}
+
+export const AsyncStateView = ({
+	isLoading = false,
+	isError = false,
+	error,
+	isEmpty = false,
+	onRetry,
+	loadingFallback,
+	emptyState,
+	errorTitle = "Couldn't load data",
+	errorDescription,
+	children,
+	className,
+}: AsyncStateViewProps) => {
+	if (isError) {
+		return (
+			<AsyncErrorCard
+				title={errorTitle}
+				description={
+					errorDescription ?? errorToMessage(error, "Something went wrong while loading.")
+				}
+				onRetry={onRetry}
+				className={className}
+			/>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div className={className} role="status" aria-live="polite" aria-busy="true">
+				{loadingFallback ?? <SkeletonTable rows={4} columns={4} themed />}
+				<span className="sr-only">Loading…</span>
+			</div>
+		);
+	}
+
+	if (isEmpty) {
+		return (
+			<PremiumEmptyState
+				icon={emptyState.icon}
+				title={emptyState.title}
+				description={emptyState.description}
+				action={emptyState.action}
+				className={className}
+			/>
+		);
+	}
+
+	return <>{children}</>;
+};
+
+/* =============================================================================
+   ASYNC ERROR CARD
+   Themed inline error with retry. Exported so callers can render it standalone
+   (e.g. on the side of a layout where AsyncStateView's other branches don't
+   apply).
+   ============================================================================= */
+
+interface AsyncErrorCardProps {
+	title: string;
+	description: string;
+	onRetry?: () => void;
+	className?: string;
+}
+
+export const AsyncErrorCard = ({ title, description, onRetry, className }: AsyncErrorCardProps) => {
+	const { gradient: themeGradient } = useThemeGradient();
+
+	return (
+		<div
+			className={cn(
+				"flex flex-col items-center justify-center py-12 px-6 text-center",
+				"rounded-2xl border border-red-500/20 bg-red-500/[0.04]",
+				className,
+			)}
+			role="alert"
+		>
+			<div
+				className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl"
+				style={{
+					background: "linear-gradient(135deg, rgba(239,68,68,0.15), rgba(239,68,68,0.05))",
+					border: "1px solid rgba(239,68,68,0.25)",
+				}}
+			>
+				<AlertTriangle className="h-7 w-7 text-red-400" aria-hidden="true" />
+			</div>
+			<h3 className="text-base font-semibold mb-1">{title}</h3>
+			<p className="text-sm text-muted-foreground max-w-md mb-5 break-words">{description}</p>
+			{onRetry && (
+				<button
+					type="button"
+					onClick={onRetry}
+					className="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity hover:opacity-90"
+					style={{
+						background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
+					}}
+				>
+					<RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+					Try again
+				</button>
+			)}
+		</div>
+	);
+};

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -21,6 +21,9 @@ export { PageLayout } from "./page-layout";
 
 // Premium Components - Extended
 export {
+	// Async State Composer
+	AsyncErrorCard,
+	AsyncStateView,
 	// Form Elements
 	FilterSelect,
 	GlassmorphicCard,

--- a/apps/web/src/components/layout/premium-components.tsx
+++ b/apps/web/src/components/layout/premium-components.tsx
@@ -7,6 +7,9 @@
  * - premium-interactive.tsx:   Tabs, Selects, Buttons, Skeletons
  */
 
+// Async State Composer
+export { AsyncErrorCard, AsyncStateView } from "./async-state-view";
+export type { AsyncStateEmptyConfig, AsyncStateViewProps } from "./async-state-view";
 export type { GlassmorphicCardProps } from "./premium-containers";
 // Containers & Layout
 export {

--- a/apps/web/src/features/notifications/components/__tests__/notification-log-table.test.tsx
+++ b/apps/web/src/features/notifications/components/__tests__/notification-log-table.test.tsx
@@ -1,0 +1,103 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — we exercise the surface, not the network, so we stub the hooks that
+// AsyncStateView reads from and any context providers the component pulls in.
+// ---------------------------------------------------------------------------
+
+const mockUseNotificationLogs = vi.fn();
+
+vi.mock("../../../../hooks/api/useNotifications", () => ({
+	useNotificationLogs: (...args: unknown[]) => mockUseNotificationLogs(...args),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [false, vi.fn()],
+	getLinuxIsoName: (s: string) => s,
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#7c3aed",
+			to: "#a855f7",
+			glow: "rgba(124,58,237,0.4)",
+			fromLight: "rgba(124,58,237,0.15)",
+		},
+	}),
+}));
+
+import { NotificationLogTable } from "../notification-log-table";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("NotificationLogTable — AsyncStateView wiring", () => {
+	beforeEach(() => {
+		mockUseNotificationLogs.mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the error card with retry when the logs query fails", () => {
+		const refetch = vi.fn();
+		mockUseNotificationLogs.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+			error: new Error("notification api offline"),
+			refetch,
+		});
+
+		render(<NotificationLogTable />, { wrapper });
+
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+		expect(screen.getByText(/couldn't load notification logs/i)).toBeInTheDocument();
+		expect(screen.getByText(/notification api offline/i)).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("shows a 'Clear filters' affordance when empty AND a filter is active", () => {
+		mockUseNotificationLogs.mockReturnValue({
+			data: { logs: [], total: 0, limit: 15 },
+			isLoading: false,
+			isError: false,
+			error: null,
+			refetch: vi.fn(),
+		});
+
+		render(<NotificationLogTable />, { wrapper });
+
+		// Apply a status filter so `hasFilters` becomes true.
+		fireEvent.click(screen.getByRole("button", { name: "Failed" }));
+
+		expect(screen.getByText(/no matching logs/i)).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /clear filters/i })).toBeInTheDocument();
+	});
+
+	it("shows the generic empty copy when there are no logs and no filter", () => {
+		mockUseNotificationLogs.mockReturnValue({
+			data: { logs: [], total: 0, limit: 15 },
+			isLoading: false,
+			isError: false,
+			error: null,
+			refetch: vi.fn(),
+		});
+
+		render(<NotificationLogTable />, { wrapper });
+
+		expect(screen.getByText(/no notification logs yet/i)).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /clear filters/i })).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/notifications/components/notification-log-table.tsx
+++ b/apps/web/src/features/notifications/components/notification-log-table.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { ChevronLeft, ChevronRight, Loader2, X } from "lucide-react";
+import { Bell, ChevronLeft, ChevronRight, X } from "lucide-react";
 import { useState } from "react";
-import { StatusBadge } from "@/components/layout/premium-components";
+import { AsyncStateView, StatusBadge } from "@/components/layout/premium-components";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { useNotificationLogs } from "../../../hooks/api/useNotifications";
@@ -60,7 +60,7 @@ export function NotificationLogTable() {
 		eventType: filters.eventType || undefined,
 	};
 
-	const { data, isLoading } = useNotificationLogs(page, 15, activeFilters);
+	const { data, isLoading, isError, error, refetch } = useNotificationLogs(page, 15, activeFilters);
 
 	const setFilter = <K extends keyof Filters>(key: K, value: Filters[K]) => {
 		setFilters((prev) => ({ ...prev, [key]: value }));
@@ -128,103 +128,126 @@ export function NotificationLogTable() {
 				)}
 			</div>
 
-			{isLoading ? (
-				<div className="flex items-center justify-center py-12">
-					<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-				</div>
-			) : !data || data.logs.length === 0 ? (
-				<div className="rounded-xl border border-border/30 bg-muted/10 p-6">
-					<p className="text-center text-muted-foreground py-8">
-						{hasFilters
-							? "No logs match the current filters."
-							: "No notification logs yet. Logs appear after notifications are sent."}
-					</p>
-				</div>
-			) : (
-				<>
-					<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10">
-						<div className="overflow-x-auto">
-							<table className="w-full text-sm">
-								<thead>
-									<tr className="border-b border-border/30">
-										<th className="px-4 py-3 text-left text-muted-foreground font-medium">Event</th>
-										<th className="px-4 py-3 text-left text-muted-foreground font-medium">Title</th>
-										<th className="px-4 py-3 text-left text-muted-foreground font-medium">
-											Channel
-										</th>
-										<th className="px-4 py-3 text-left text-muted-foreground font-medium">
-											Status
-										</th>
-										<th className="px-4 py-3 text-left text-muted-foreground font-medium">Sent</th>
-									</tr>
-								</thead>
-								<tbody>
-									{data.logs.map((log) => (
-										<tr key={log.id} className="border-b border-border/10 hover:bg-card/20">
-											<td className="px-4 py-2.5 text-xs text-muted-foreground font-mono">
-												{log.eventType}
-											</td>
-											<td className="px-4 py-2.5 truncate max-w-[200px]">{incognitoMode ? getLinuxIsoName(log.title) : log.title}</td>
-											<td className="px-4 py-2.5 text-xs text-muted-foreground">
-												{log.channelType}
-											</td>
-											<td className="px-4 py-2.5">
-												<StatusBadge
-													status={
-														log.status === "sent"
-															? "success"
-															: log.status === "dead_letter"
-																? "warning"
-																: "error"
-													}
-												>
-													{log.status === "dead_letter" ? "Dead Letter" : log.status}
-												</StatusBadge>
-												{log.error && (
-													<p
-														className="text-xs text-red-400/70 mt-1 max-w-[200px] truncate"
-														title={log.error}
-													>
-														{log.error}
-													</p>
-												)}
-											</td>
-											<td className="px-4 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
-												{new Date(log.sentAt).toLocaleString()}
-											</td>
+			<AsyncStateView
+				isLoading={isLoading}
+				isError={isError}
+				error={error}
+				isEmpty={!data || data.logs.length === 0}
+				onRetry={() => refetch()}
+				errorTitle="Couldn't load notification logs"
+				emptyState={{
+					icon: Bell,
+					title: hasFilters ? "No matching logs" : "No notification logs yet",
+					description: hasFilters
+						? "No logs match the current filters. Try clearing them."
+						: "Logs appear here after notifications are sent.",
+					action: hasFilters ? (
+						<button
+							type="button"
+							onClick={clearFilters}
+							className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground bg-card/30 border border-border/50"
+						>
+							<X className="h-3.5 w-3.5" /> Clear filters
+						</button>
+					) : undefined,
+				}}
+			>
+				{data && data.logs.length > 0 && (
+					<>
+						<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10">
+							<div className="overflow-x-auto">
+								<table className="w-full text-sm">
+									<thead>
+										<tr className="border-b border-border/30">
+											<th className="px-4 py-3 text-left text-muted-foreground font-medium">
+												Event
+											</th>
+											<th className="px-4 py-3 text-left text-muted-foreground font-medium">
+												Title
+											</th>
+											<th className="px-4 py-3 text-left text-muted-foreground font-medium">
+												Channel
+											</th>
+											<th className="px-4 py-3 text-left text-muted-foreground font-medium">
+												Status
+											</th>
+											<th className="px-4 py-3 text-left text-muted-foreground font-medium">
+												Sent
+											</th>
 										</tr>
-									))}
-								</tbody>
-							</table>
+									</thead>
+									<tbody>
+										{data.logs.map((log) => (
+											<tr key={log.id} className="border-b border-border/10 hover:bg-card/20">
+												<td className="px-4 py-2.5 text-xs text-muted-foreground font-mono">
+													{log.eventType}
+												</td>
+												<td className="px-4 py-2.5 truncate max-w-[200px]">
+													{incognitoMode ? getLinuxIsoName(log.title) : log.title}
+												</td>
+												<td className="px-4 py-2.5 text-xs text-muted-foreground">
+													{log.channelType}
+												</td>
+												<td className="px-4 py-2.5">
+													<StatusBadge
+														status={
+															log.status === "sent"
+																? "success"
+																: log.status === "dead_letter"
+																	? "warning"
+																	: "error"
+														}
+													>
+														{log.status === "dead_letter" ? "Dead Letter" : log.status}
+													</StatusBadge>
+													{log.error && (
+														<p
+															className="text-xs text-red-400/70 mt-1 max-w-[200px] truncate"
+															title={log.error}
+														>
+															{log.error}
+														</p>
+													)}
+												</td>
+												<td className="px-4 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+													{new Date(log.sentAt).toLocaleString()}
+												</td>
+											</tr>
+										))}
+									</tbody>
+								</table>
+							</div>
 						</div>
-					</div>
 
-					{/* Pagination */}
-					{data.total > data.limit && (
-						<div className="flex items-center justify-center gap-4">
-							<button
-								type="button"
-								onClick={() => setPage((p) => Math.max(1, p - 1))}
-								disabled={page === 1}
-								className="rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-							>
-								<ChevronLeft className="h-4 w-4" />
-							</button>
-							<span className="text-sm text-muted-foreground">
-								Page {page} of {Math.ceil(data.total / data.limit)}
-							</span>
-							<button
-								type="button"
-								onClick={() => setPage((p) => Math.min(Math.ceil(data.total / data.limit), p + 1))}
-								disabled={page === Math.ceil(data.total / data.limit)}
-								className="rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
-							>
-								<ChevronRight className="h-4 w-4" />
-							</button>
-						</div>
-					)}
-				</>
-			)}
+						{/* Pagination */}
+						{data.total > data.limit && (
+							<div className="flex items-center justify-center gap-4">
+								<button
+									type="button"
+									onClick={() => setPage((p) => Math.max(1, p - 1))}
+									disabled={page === 1}
+									className="rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+								>
+									<ChevronLeft className="h-4 w-4" />
+								</button>
+								<span className="text-sm text-muted-foreground">
+									Page {page} of {Math.ceil(data.total / data.limit)}
+								</span>
+								<button
+									type="button"
+									onClick={() =>
+										setPage((p) => Math.min(Math.ceil(data.total / data.limit), p + 1))
+									}
+									disabled={page === Math.ceil(data.total / data.limit)}
+									className="rounded-md p-1.5 text-muted-foreground hover:text-foreground disabled:opacity-30"
+								>
+									<ChevronRight className="h-4 w-4" />
+								</button>
+							</div>
+						)}
+					</>
+				)}
+			</AsyncStateView>
 		</div>
 	);
 }

--- a/apps/web/src/features/notifications/components/notification-statistics.tsx
+++ b/apps/web/src/features/notifications/components/notification-statistics.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { BarChart3, Loader2 } from "lucide-react";
+import { BarChart3, Inbox } from "lucide-react";
 import { useState } from "react";
+import { AsyncStateView } from "@/components/layout/premium-components";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import { useNotificationStatistics } from "../../../hooks/api/useNotifications";
 
@@ -44,31 +45,10 @@ const EVENT_LABELS: Record<string, string> = {
 export function NotificationStatistics() {
 	const { gradient } = useThemeGradient();
 	const [days, setDays] = useState(30);
-	const { data: stats, isLoading } = useNotificationStatistics(days);
+	const { data: stats, isLoading, isError, error, refetch } = useNotificationStatistics(days);
 
-	if (isLoading) {
-		return (
-			<div className="flex items-center justify-center py-12">
-				<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-			</div>
-		);
-	}
-
-	if (!stats) {
-		return (
-			<div className="rounded-xl border border-border/30 bg-muted/10 p-6">
-				<p className="text-center text-muted-foreground py-8">
-					No statistics available yet. Statistics appear after notifications are sent.
-				</p>
-			</div>
-		);
-	}
-
-	const { totals, perChannel, perEventType, dailyTrend } = stats;
-
-	// Find max for scaling the bar chart
-	const trendMax = Math.max(...dailyTrend.map((d) => d.sent + d.failed), 1);
-	const channelMax = Math.max(...perChannel.map((c) => c.sent + c.failed), 1);
+	const trendMax = stats ? Math.max(...stats.dailyTrend.map((d) => d.sent + d.failed), 1) : 1;
+	const channelMax = stats ? Math.max(...stats.perChannel.map((c) => c.sent + c.failed), 1) : 1;
 
 	return (
 		<div className="space-y-5">
@@ -96,6 +76,44 @@ export function NotificationStatistics() {
 				</div>
 			</div>
 
+			<AsyncStateView
+				isLoading={isLoading}
+				isError={isError}
+				error={error}
+				isEmpty={!stats}
+				onRetry={() => refetch()}
+				errorTitle="Couldn't load notification statistics"
+				emptyState={{
+					icon: Inbox,
+					title: "No statistics yet",
+					description: "Statistics appear after notifications are sent.",
+				}}
+			>
+				{stats && (
+					<StatisticsContent
+						stats={stats}
+						trendMax={trendMax}
+						channelMax={channelMax}
+						gradient={gradient}
+					/>
+				)}
+			</AsyncStateView>
+		</div>
+	);
+}
+
+interface StatisticsContentProps {
+	stats: NonNullable<ReturnType<typeof useNotificationStatistics>["data"]>;
+	trendMax: number;
+	channelMax: number;
+	gradient: ReturnType<typeof useThemeGradient>["gradient"];
+}
+
+function StatisticsContent({ stats, trendMax, channelMax, gradient }: StatisticsContentProps) {
+	const { totals, perChannel, perEventType, dailyTrend } = stats;
+
+	return (
+		<div className="space-y-5">
 			{/* Summary cards */}
 			<div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
 				<SummaryCard label="Total Sent" value={totals.sent} color="text-emerald-400" />

--- a/apps/web/src/features/queue-cleaner/components/__tests__/queue-cleaner-activity.test.tsx
+++ b/apps/web/src/features/queue-cleaner/components/__tests__/queue-cleaner-activity.test.tsx
@@ -1,0 +1,115 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — we exercise the migration (AsyncStateView wiring + filter-aware
+// empty copy) without touching the network or the real theme/incognito
+// providers.
+// ---------------------------------------------------------------------------
+
+const mockUseQueueCleanerLogs = vi.fn();
+
+vi.mock("../../hooks/useQueueCleanerLogs", () => ({
+	useQueueCleanerLogs: (...args: unknown[]) => mockUseQueueCleanerLogs(...args),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [false, vi.fn()],
+	getLinuxIsoName: (s: string) => s,
+	getLinuxInstanceName: (s: string) => s,
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#7c3aed",
+			to: "#a855f7",
+			glow: "rgba(124,58,237,0.4)",
+			fromLight: "rgba(124,58,237,0.15)",
+		},
+	}),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#7c3aed",
+			to: "#a855f7",
+			glow: "rgba(124,58,237,0.4)",
+			fromLight: "rgba(124,58,237,0.15)",
+		},
+	}),
+}));
+
+import { QueueCleanerActivity } from "../queue-cleaner-activity";
+
+function wrapper({ children }: { children: ReactNode }) {
+	const client = new QueryClient({
+		defaultOptions: { queries: { retry: false } },
+	});
+	return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function emptyState(overrides: Record<string, unknown> = {}) {
+	return {
+		logs: [],
+		totalCount: 0,
+		isLoading: false,
+		error: null,
+		refetch: vi.fn(),
+		hasRunningCleans: false,
+		...overrides,
+	};
+}
+
+describe("QueueCleanerActivity — AsyncStateView wiring", () => {
+	beforeEach(() => {
+		mockUseQueueCleanerLogs.mockReset();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders the generic 'No activity yet' empty state when no filter is active", () => {
+		mockUseQueueCleanerLogs.mockReturnValue(emptyState());
+
+		render(<QueueCleanerActivity />, { wrapper });
+
+		expect(screen.getByText(/no activity yet/i)).toBeInTheDocument();
+		expect(screen.getByText(/queue cleaner activity will appear here/i)).toBeInTheDocument();
+	});
+
+	it("renders filter-specific empty copy when a status filter yields no rows", () => {
+		mockUseQueueCleanerLogs.mockReturnValue(emptyState());
+
+		render(<QueueCleanerActivity />, { wrapper });
+
+		// Choose a non-default status from the FilterSelect combobox.
+		fireEvent.change(screen.getByRole("combobox"), { target: { value: "error" } });
+
+		expect(screen.getByText(/no matching activity/i)).toBeInTheDocument();
+		expect(screen.getByText(/no runs match the current status filter/i)).toBeInTheDocument();
+	});
+
+	it("surfaces the error card with retry when the logs hook reports an error", () => {
+		const refetch = vi.fn();
+		mockUseQueueCleanerLogs.mockReturnValue(
+			emptyState({
+				error: new Error("queue cleaner offline"),
+				refetch,
+			}),
+		);
+
+		render(<QueueCleanerActivity />, { wrapper });
+
+		expect(screen.getByRole("alert")).toBeInTheDocument();
+		expect(screen.getByText(/couldn't load activity log/i)).toBeInTheDocument();
+		expect(screen.getByText(/queue cleaner offline/i)).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-activity.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-activity.tsx
@@ -12,8 +12,8 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import {
+	AsyncStateView,
 	FilterSelect,
-	PremiumEmptyState,
 	PremiumSection,
 	ServiceBadge,
 	StatusBadge,
@@ -28,7 +28,7 @@ export const QueueCleanerActivity = () => {
 	const [page, setPage] = useState(1);
 	const [expandedLogId, setExpandedLogId] = useState<string | null>(null);
 
-	const { logs, totalCount, isLoading } = useQueueCleanerLogs({
+	const { logs, totalCount, isLoading, error, refetch } = useQueueCleanerLogs({
 		status: statusFilter !== "all" ? statusFilter : undefined,
 		page,
 		pageSize: 20,
@@ -36,6 +36,7 @@ export const QueueCleanerActivity = () => {
 	});
 
 	const totalPages = Math.ceil(totalCount / 20);
+	const hasFilter = statusFilter !== "all";
 
 	return (
 		<PremiumSection
@@ -65,25 +66,33 @@ export const QueueCleanerActivity = () => {
 			</div>
 
 			{/* Log entries */}
-			{logs.length === 0 && !isLoading && (
-				<PremiumEmptyState
-					icon={Activity}
-					title="No activity yet"
-					description="Queue cleaner activity will appear here once runs begin."
-				/>
-			)}
-
-			<div className="space-y-2">
-				{logs.map((logEntry, index) => (
-					<LogEntryRow
-						key={logEntry.id}
-						log={logEntry}
-						isExpanded={expandedLogId === logEntry.id}
-						onToggle={() => setExpandedLogId(expandedLogId === logEntry.id ? null : logEntry.id)}
-						animationDelay={index * 30}
-					/>
-				))}
-			</div>
+			<AsyncStateView
+				isLoading={isLoading}
+				isError={!!error}
+				error={error}
+				isEmpty={logs.length === 0}
+				onRetry={() => refetch()}
+				errorTitle="Couldn't load activity log"
+				emptyState={{
+					icon: Activity,
+					title: hasFilter ? "No matching activity" : "No activity yet",
+					description: hasFilter
+						? "No runs match the current status filter."
+						: "Queue cleaner activity will appear here once runs begin.",
+				}}
+			>
+				<div className="space-y-2">
+					{logs.map((logEntry, index) => (
+						<LogEntryRow
+							key={logEntry.id}
+							log={logEntry}
+							isExpanded={expandedLogId === logEntry.id}
+							onToggle={() => setExpandedLogId(expandedLogId === logEntry.id ? null : logEntry.id)}
+							animationDelay={index * 30}
+						/>
+					))}
+				</div>
+			</AsyncStateView>
 
 			{/* Pagination */}
 			{totalPages > 1 && (
@@ -234,10 +243,7 @@ const LogEntryRow = ({ log, isExpanded, onToggle, animationDelay }: LogEntryRowP
 					</span>
 					{(log.itemsWarned ?? 0) > 0 && (
 						<span className="inline-flex items-center gap-1 text-[11px] text-muted-foreground/50">
-							<AlertTriangle
-								className="h-3 w-3"
-								style={{ color: SEMANTIC_COLORS.warning.text }}
-							/>
+							<AlertTriangle className="h-3 w-3" style={{ color: SEMANTIC_COLORS.warning.text }} />
 							{log.itemsWarned}
 						</span>
 					)}
@@ -266,10 +272,7 @@ const LogEntryRow = ({ log, isExpanded, onToggle, animationDelay }: LogEntryRowP
 						{log.cleanedItems && log.cleanedItems.length > 0 && (
 							<div>
 								<h5 className="flex items-center gap-1.5 text-xs font-medium mb-2">
-									<Trash2
-										className="h-3 w-3"
-										style={{ color: SEMANTIC_COLORS.error.text }}
-									/>
+									<Trash2 className="h-3 w-3" style={{ color: SEMANTIC_COLORS.error.text }} />
 									Removed ({log.cleanedItems.length})
 								</h5>
 								<div className="space-y-1">
@@ -318,15 +321,12 @@ const LogEntryRow = ({ log, isExpanded, onToggle, animationDelay }: LogEntryRowP
 												{incognitoMode ? getLinuxIsoName(item.title) : item.title}
 											</span>
 											<div className="flex items-center gap-2 ml-2 shrink-0">
-												{item.strikeCount !== undefined &&
-													item.maxStrikes !== undefined && (
-														<span className="inline-flex items-center rounded-md bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-medium text-amber-400">
-															Strike {item.strikeCount}/{item.maxStrikes}
-														</span>
-													)}
-												<span className="text-[10px] text-muted-foreground">
-													{item.reason}
-												</span>
+												{item.strikeCount !== undefined && item.maxStrikes !== undefined && (
+													<span className="inline-flex items-center rounded-md bg-amber-500/20 px-1.5 py-0.5 text-[9px] font-medium text-amber-400">
+														Strike {item.strikeCount}/{item.maxStrikes}
+													</span>
+												)}
+												<span className="text-[10px] text-muted-foreground">{item.reason}</span>
 											</div>
 										</div>
 									))}


### PR DESCRIPTION
## Summary

- Add `<AsyncStateView>` — a small composer in `apps/web/src/components/layout/` that orchestrates loading / error / empty / success around existing primitives (`SkeletonTable`, `PremiumEmptyState`) and adds a themed `<AsyncErrorCard>` with a retry button.
- Migrate three data panels that previously had **silent loading**, **swallowed errors**, and **ad-hoc empty messages**: notification statistics, notification log table, queue cleaner activity log.
- Cover both the composer and each migrated surface with focused tests pinning state precedence, retry click, and filter-aware empty copy.

## Why

Audit of the frontend showed each data panel had reinvented its own "spinner-or-nothing" loading UI and silently failed on errors. The primitives (`PremiumSkeleton`, `PremiumEmptyState`, `ErrorBoundary`) already existed — what was missing was a consistent **composer** that gives every panel the same shape: skeleton on first load, themed error card with retry on failure, themed empty state when there's no data.

Error precedence (`error > loading > empty`) is intentional: a stale failure shouldn't be visually masked by the next refetch's loading state. A11y bonuses come for free — `aria-busy` on loading and `role="alert"` on errors.

## What changed

| Surface | Before | After |
|---|---|---|
| `notification-statistics.tsx` | Loader2 spinner, no error UI | Themed skeleton, error+retry, themed empty |
| `notification-log-table.tsx` | Silent loading, no error UI, generic empty text | Themed skeleton, error+retry, "Clear filters" affordance when filter-empty |
| `queue-cleaner-activity.tsx` | No loading, no error UI, single empty copy | Themed skeleton, error+retry, distinguishes filter-empty vs no-activity-yet |

## Intentionally deferred

- Calendar event list (data is a prop, not async — composer doesn't fit).
- Dashboard client (already has skeleton + Alert; broader refactor needed).
- Wizards / deployment flows (bespoke designs, not "data panel" pattern).
- Stale-data / freshness pattern — separate concern, separate PR.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec vitest run src/components/layout/__tests__/async-state-view.test.tsx` — 7 / 7 pass (composer behaviour)
- [x] `pnpm --filter @arr/web run lint` — no new warnings
- [x] **Notifications log table — error + retry**: covered by `notification-log-table.test.tsx` (error card surfaces, retry click invokes `refetch`).
- [x] **Notifications log table — filter-empty copy**: covered by the same test (applies a status filter, asserts "No matching logs" + "Clear filters" affordance).
- [x] **Queue Cleaner Activity — filter-empty copy**: covered by `queue-cleaner-activity.test.tsx` (selects a non-default status, asserts "No matching activity" + filter-specific description).
- [x] **Queue Cleaner Activity — error + retry**: covered by the same test, mirroring the notifications coverage.

Total: 13 / 13 passing across `async-state-view.test.tsx`, `notification-log-table.test.tsx`, `queue-cleaner-activity.test.tsx`.

> Note: The original test plan listed the last four items as manual browser checks. Converted them to integration tests so the wiring (hook → AsyncStateView props) is guarded against regression on every CI run instead of relying on one-shot eyeballing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)