### PR TITLE
feat(ux): shared domain status badges for services + integrations

### DIFF
--- a/apps/web/src/components/layout/__tests__/domain-status.test.tsx
+++ b/apps/web/src/components/layout/__tests__/domain-status.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The DomainStatusBadge wraps StatusBadge, which pulls in useThemeGradient.
+// We don't render here (we only exercise the pure derivation helpers), but the
+// import graph still loads premium-data-display, so stub the hook to be safe.
+vi.mock("../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#7c3aed",
+			to: "#a855f7",
+			glow: "rgba(124,58,237,0.4)",
+			fromLight: "rgba(124,58,237,0.15)",
+			fromMuted: "rgba(124,58,237,0.3)",
+		},
+	}),
+}));
+
+import {
+	deriveNotificationChannelStatus,
+	deriveServiceInstanceStatus,
+	getDomainStatusMeta,
+} from "../domain-status";
+
+describe("deriveServiceInstanceStatus", () => {
+	it("returns disabled when the instance is turned off regardless of test state", () => {
+		expect(
+			deriveServiceInstanceStatus({
+				enabled: false,
+				hasApiKey: true,
+				testResult: { success: true },
+			}),
+		).toBe("disabled");
+	});
+
+	it("returns configured when no api key is present", () => {
+		expect(deriveServiceInstanceStatus({ enabled: true, hasApiKey: false, testResult: null })).toBe(
+			"configured",
+		);
+	});
+
+	it("returns configured when enabled + api key but no round-trip has happened", () => {
+		expect(deriveServiceInstanceStatus({ enabled: true, hasApiKey: true, testResult: null })).toBe(
+			"configured",
+		);
+	});
+
+	it("returns healthy when the most recent test succeeded", () => {
+		expect(
+			deriveServiceInstanceStatus({
+				enabled: true,
+				hasApiKey: true,
+				testResult: { success: true },
+			}),
+		).toBe("healthy");
+	});
+
+	it("returns offline when the most recent test failed", () => {
+		expect(
+			deriveServiceInstanceStatus({
+				enabled: true,
+				hasApiKey: true,
+				testResult: { success: false },
+			}),
+		).toBe("offline");
+	});
+});
+
+describe("deriveNotificationChannelStatus", () => {
+	it("returns disabled when the channel is turned off", () => {
+		expect(
+			deriveNotificationChannelStatus({
+				enabled: false,
+				lastTestedAt: "2026-04-10T00:00:00Z",
+				lastTestResult: "success",
+			}),
+		).toBe("disabled");
+	});
+
+	it("returns configured when no test has been run yet", () => {
+		expect(
+			deriveNotificationChannelStatus({
+				enabled: true,
+				lastTestedAt: null,
+				lastTestResult: null,
+			}),
+		).toBe("configured");
+	});
+
+	it("returns healthy on last-success", () => {
+		expect(
+			deriveNotificationChannelStatus({
+				enabled: true,
+				lastTestedAt: "2026-04-10T00:00:00Z",
+				lastTestResult: "success",
+			}),
+		).toBe("healthy");
+	});
+
+	it("returns offline when the last test failed — does NOT overclaim health just because the channel is enabled", () => {
+		expect(
+			deriveNotificationChannelStatus({
+				enabled: true,
+				lastTestedAt: "2026-04-10T00:00:00Z",
+				lastTestResult: "failure",
+			}),
+		).toBe("offline");
+	});
+});
+
+describe("getDomainStatusMeta", () => {
+	it("maps each domain status to a stable semantic badge + label", () => {
+		expect(getDomainStatusMeta("healthy").badge).toBe("success");
+		expect(getDomainStatusMeta("degraded").badge).toBe("warning");
+		expect(getDomainStatusMeta("offline").badge).toBe("error");
+		expect(getDomainStatusMeta("configured").badge).toBe("info");
+		expect(getDomainStatusMeta("disabled").badge).toBe("default");
+	});
+});

--- a/apps/web/src/components/layout/domain-status.tsx
+++ b/apps/web/src/components/layout/domain-status.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Circle, PauseCircle, XCircle } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "../../lib/utils";
+import { StatusBadge } from "./premium-data-display";
+
+/* =============================================================================
+   DOMAIN STATUS
+   Shared vocabulary for service + integration health across the app.
+
+   Meanings (prefer runtime/effective state over static config):
+   - healthy     reachable AND validated
+   - degraded    reachable but partially failing (timeouts, auth warnings, etc.)
+   - offline     configured but unreachable / last check failed
+   - configured  set up but never validated yet
+   - disabled    intentionally turned off by the operator
+   ============================================================================= */
+
+export type DomainStatus = "healthy" | "degraded" | "offline" | "configured" | "disabled";
+
+interface DomainStatusMeta {
+	/** Maps to the underlying `StatusBadge` semantic palette */
+	badge: "success" | "warning" | "error" | "info" | "default";
+	/** Default human label shown in the badge */
+	label: string;
+	/** Icon paired with the label in the badge */
+	icon: LucideIcon;
+	/** Short operator-facing description, suitable for a title attribute */
+	description: string;
+}
+
+const STATUS_META: Record<DomainStatus, DomainStatusMeta> = {
+	healthy: {
+		badge: "success",
+		label: "Healthy",
+		icon: CheckCircle2,
+		description: "Reachable and last check succeeded",
+	},
+	degraded: {
+		badge: "warning",
+		label: "Degraded",
+		icon: AlertTriangle,
+		description: "Reachable but the last check reported issues",
+	},
+	offline: {
+		badge: "error",
+		label: "Offline",
+		icon: XCircle,
+		description: "Configured but the last check failed",
+	},
+	configured: {
+		badge: "info",
+		label: "Configured",
+		icon: Circle,
+		description: "Set up but not yet validated",
+	},
+	disabled: {
+		badge: "default",
+		label: "Disabled",
+		icon: PauseCircle,
+		description: "Intentionally turned off",
+	},
+};
+
+/** Look up badge props + label/icon/description for a domain status. */
+export function getDomainStatusMeta(status: DomainStatus): DomainStatusMeta {
+	return STATUS_META[status];
+}
+
+interface DomainStatusBadgeProps {
+	status: DomainStatus;
+	/** Override the default label (e.g. "Active" instead of "Healthy"). */
+	label?: ReactNode;
+	/** Hide the icon when space is tight. */
+	hideIcon?: boolean;
+	className?: string;
+	/** Optional override for the hover description. */
+	title?: string;
+}
+
+/**
+ * Shared status badge for service/integration health.
+ * Wraps the low-level `StatusBadge` primitive with a stable taxonomy so that
+ * `healthy`/`degraded`/etc. render identically across every surface.
+ */
+export function DomainStatusBadge({
+	status,
+	label,
+	hideIcon,
+	className,
+	title,
+}: DomainStatusBadgeProps) {
+	const meta = STATUS_META[status];
+	return (
+		<span title={title ?? meta.description} className={cn("inline-flex", className)}>
+			<StatusBadge status={meta.badge} icon={hideIcon ? undefined : meta.icon}>
+				{label ?? meta.label}
+			</StatusBadge>
+		</span>
+	);
+}
+
+/* =============================================================================
+   DERIVATION HELPERS
+   Thin adapters from concrete runtime shapes -> DomainStatus. Keep each one
+   focused on a single surface so callers stay readable.
+   ============================================================================= */
+
+/**
+ * Derive status for an ARR service instance (Sonarr/Radarr/Prowlarr/Lidarr/Readarr).
+ * Prefers the most recent transient test result when present; falls back to
+ * `configured` whenever we don't yet have a signal from a real round-trip.
+ */
+export function deriveServiceInstanceStatus(input: {
+	enabled: boolean;
+	hasApiKey: boolean;
+	/** Most recent test round-trip, if any. */
+	testResult?: { success: boolean } | null;
+}): DomainStatus {
+	if (!input.enabled) return "disabled";
+	if (!input.hasApiKey) return "configured";
+	if (!input.testResult) return "configured";
+	return input.testResult.success ? "healthy" : "offline";
+}
+
+/**
+ * Derive status for a notification channel. Uses the persisted last-test
+ * outcome so the badge reflects real delivery health, not just the enable toggle.
+ */
+export function deriveNotificationChannelStatus(input: {
+	enabled: boolean;
+	lastTestedAt: string | null;
+	lastTestResult: string | null;
+}): DomainStatus {
+	if (!input.enabled) return "disabled";
+	if (!input.lastTestedAt || !input.lastTestResult) return "configured";
+	if (input.lastTestResult === "success") return "healthy";
+	return "offline";
+}

--- a/apps/web/src/components/layout/index.ts
+++ b/apps/web/src/components/layout/index.ts
@@ -24,6 +24,11 @@ export {
 	// Async State Composer
 	AsyncErrorCard,
 	AsyncStateView,
+	type DomainStatus,
+	DomainStatusBadge,
+	// Domain Status
+	deriveNotificationChannelStatus,
+	deriveServiceInstanceStatus,
 	// Form Elements
 	FilterSelect,
 	GlassmorphicCard,

--- a/apps/web/src/components/layout/premium-components.tsx
+++ b/apps/web/src/components/layout/premium-components.tsx
@@ -7,9 +7,17 @@
  * - premium-interactive.tsx:   Tabs, Selects, Buttons, Skeletons
  */
 
+export type { AsyncStateEmptyConfig, AsyncStateViewProps } from "./async-state-view";
 // Async State Composer
 export { AsyncErrorCard, AsyncStateView } from "./async-state-view";
-export type { AsyncStateEmptyConfig, AsyncStateViewProps } from "./async-state-view";
+export type { DomainStatus } from "./domain-status";
+// Domain Status (shared service/integration health taxonomy)
+export {
+	DomainStatusBadge,
+	deriveNotificationChannelStatus,
+	deriveServiceInstanceStatus,
+	getDomainStatusMeta,
+} from "./domain-status";
 export type { GlassmorphicCardProps } from "./premium-containers";
 // Containers & Layout
 export {

--- a/apps/web/src/features/notifications/components/browser-push-card.tsx
+++ b/apps/web/src/features/notifications/components/browser-push-card.tsx
@@ -2,11 +2,49 @@
 
 import { Bell, BellOff, Loader2 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { StatusBadge } from "@/components/layout/premium-components";
+import { type DomainStatus, DomainStatusBadge } from "@/components/layout/premium-components";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import { notificationsApi } from "../../../lib/api-client/notifications";
 
 type PushState = "loading" | "unsupported" | "denied" | "enabled" | "disabled" | "error";
+
+/**
+ * Collapse the 6 push states into the shared domain status taxonomy so this
+ * card uses the same colors/semantics as the services and channels lists.
+ * `loading` maps to `configured` (not yet validated) rather than a bespoke
+ * shade — matches the "configured but never validated" meaning.
+ */
+function pushStateToDomainStatus(state: PushState): DomainStatus {
+	switch (state) {
+		case "enabled":
+			return "healthy";
+		case "denied":
+		case "error":
+			return "offline";
+		case "disabled":
+			return "disabled";
+		case "loading":
+		case "unsupported":
+			return "configured";
+	}
+}
+
+function pushStateLabel(state: PushState): string {
+	switch (state) {
+		case "enabled":
+			return "Active";
+		case "denied":
+			return "Blocked";
+		case "loading":
+			return "Checking…";
+		case "error":
+			return "Error";
+		case "disabled":
+			return "Inactive";
+		case "unsupported":
+			return "Unsupported";
+	}
+}
 
 /**
  * Convert a base64 URL-safe string to a Uint8Array for the applicationServerKey.
@@ -129,17 +167,10 @@ export function BrowserPushCard() {
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
 						<span className="font-medium">Browser Push Notifications</span>
-						<StatusBadge
-							status={state === "enabled" ? "success" : state === "denied" ? "error" : "info"}
-						>
-							{state === "enabled"
-								? "Active"
-								: state === "denied"
-									? "Blocked"
-									: state === "loading"
-										? "Checking..."
-										: "Inactive"}
-						</StatusBadge>
+						<DomainStatusBadge
+							status={pushStateToDomainStatus(state)}
+							label={pushStateLabel(state)}
+						/>
 					</div>
 					<p className="text-xs text-muted-foreground mt-0.5">
 						{state === "denied"

--- a/apps/web/src/features/notifications/components/notifications-tab.tsx
+++ b/apps/web/src/features/notifications/components/notifications-tab.tsx
@@ -15,13 +15,13 @@ import {
 	Trash2,
 	X,
 } from "lucide-react";
-import { Suspense, lazy, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import {
+	DomainStatusBadge,
+	deriveNotificationChannelStatus,
 	GradientButton,
-	StatusBadge,
 } from "@/components/layout/premium-components";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
-import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	useChannelTypes,
 	useDeleteChannel,
@@ -29,6 +29,7 @@ import {
 	useTestChannel,
 } from "../../../hooks/api/useNotifications";
 import type { NotificationChannel } from "../../../lib/api-client/notifications";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { ChannelForm } from "./channel-form";
 import { NotificationLogTable } from "./notification-log-table";
 import { SubscriptionGrid as SubscriptionGridView } from "./subscription-grid";
@@ -276,10 +277,16 @@ function ChannelRow({
 
 				<div className="min-w-0 flex-1">
 					<div className="flex items-center gap-2">
-						<span className="font-medium truncate">{incognitoMode ? getLinuxInstanceName(channel.name) : channel.name}</span>
-						<StatusBadge status={channel.enabled ? "success" : "warning"}>
-							{channel.enabled ? "Active" : "Disabled"}
-						</StatusBadge>
+						<span className="font-medium truncate">
+							{incognitoMode ? getLinuxInstanceName(channel.name) : channel.name}
+						</span>
+						<DomainStatusBadge
+							status={deriveNotificationChannelStatus({
+								enabled: channel.enabled,
+								lastTestedAt: channel.lastTestedAt,
+								lastTestResult: channel.lastTestResult,
+							})}
+						/>
 						<span className="text-xs text-muted-foreground">{typeInfo.label}</span>
 					</div>
 					{channel.lastTestedAt && (

--- a/apps/web/src/features/settings/components/service-instance-card.tsx
+++ b/apps/web/src/features/settings/components/service-instance-card.tsx
@@ -13,7 +13,11 @@ import {
 	Zap,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { ServiceBadge, StatusBadge } from "../../../components/layout";
+import {
+	DomainStatusBadge,
+	deriveServiceInstanceStatus,
+	ServiceBadge,
+} from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { getLinuxInstanceName, getLinuxUrl, useIncognitoMode } from "../../../lib/incognito";
@@ -102,6 +106,15 @@ export const ServiceInstanceCard = ({
 	const testSuccess = hasTestResult && testResult.success;
 	const _testFailed = hasTestResult && !testResult.success;
 
+	// Derive runtime health for the shared badge. Prefer the transient test
+	// result when present; otherwise fall back to `configured` so we don't
+	// overclaim health before any round-trip has happened.
+	const domainStatus = deriveServiceInstanceStatus({
+		enabled: instance.enabled,
+		hasApiKey: instance.hasApiKey,
+		testResult: hasTestResult ? { success: testResult.success } : null,
+	});
+
 	return (
 		<div
 			className={cn(
@@ -148,7 +161,7 @@ export const ServiceInstanceCard = ({
 									Default
 								</div>
 							)}
-							{!instance.enabled && <StatusBadge status="default">Disabled</StatusBadge>}
+							<DomainStatusBadge status={domainStatus} />
 						</div>
 
 						{/* URL */}


### PR DESCRIPTION
## Summary

Follow-up to #321. PR #321 standardized the *async* surface (loading / error / empty / retry). This PR does the same for *health*: introduces a small shared taxonomy so operators can glance at the services list, notification channels, or browser-push card and read the same colors/labels mean the same thing everywhere.

### Statuses chosen (5)

| Status | Meaning | Palette |
|---|---|---|
| `healthy` | Reachable AND last check succeeded | success (green) |
| `degraded` | Reachable but last check reported issues | warning (amber) |
| `offline` | Configured but last check failed / unreachable | error (red) |
| `configured` | Set up but not yet validated (no round-trip) | info (theme) |
| `disabled` | Intentionally turned off | default (gray) |

Chosen to distinguish the four failure modes an operator actually cares about: *is it off*, *have we tried it*, *does it work*, *is it broken*. `degraded` stays in the vocabulary for surfaces that can distinguish "reachable but failing" from "unreachable" (e.g. future partial-response signals), but today no surface uses it — that's intentional: we don't fabricate signal we can't compute (see CLAUDE.md Trust & UX rule).

### Shared helper/component added

`apps/web/src/components/layout/domain-status.tsx`
- `DomainStatusBadge` — wraps existing `StatusBadge` primitive with a stable taxonomy
- `getDomainStatusMeta(status)` — maps a `DomainStatus` to `{ badge, label, icon, description }`
- `deriveServiceInstanceStatus({ enabled, hasApiKey, testResult })` — ARR instance adapter
- `deriveNotificationChannelStatus({ enabled, lastTestedAt, lastTestResult })` — channel adapter

Re-exported from the existing `premium-components` barrel. The underlying `StatusBadge` is unchanged — all 29 existing call sites keep working.

### Surfaces updated (3)

1. **Settings > Services > each instance card** (`service-instance-card.tsx`)
   Previously showed only a "Disabled" pill when toggled off — offered no health signal otherwise. Now always renders the full taxonomy: `disabled` / `configured` / `healthy` / `offline` derived from `enabled + hasApiKey + testResult`.

2. **Settings > Notifications > Channels** (`notifications-tab.tsx`)
   Previously rendered "Active" whenever `enabled === true`, **even when `lastTestResult === "failure"`** — a concrete overclaim of health. Now honors `lastTestResult` and `lastTestedAt`: never-tested channels are `configured`, failed ones are `offline`.

3. **Settings > Notifications > Browser Push** (`browser-push-card.tsx`)
   Ad-hoc 3-branch color mapping over 6 push states collapsed onto the shared taxonomy via `pushStateToDomainStatus`. Label overrides preserve the existing copy ("Active"/"Blocked"/"Inactive").

### Intentionally deferred

- **Plex / Seerr / Tautulli settings sections.** These don't yet emit a persisted last-check result in the shape the derivation helpers expect; adding that would require touching backend state. Scope for a follow-up.
- **System tab integration health panel.** Would be a genuine new surface rather than re-standardizing existing ones — deferred to avoid scope creep.
- **`degraded` surfacing.** No current signal distinguishes "reachable but partially failing"; adding one would be fabricated until the backend exposes it.
- **Unifying Seerr request-status badges and ARR history status badges.** Those are *domain* statuses (request lifecycle, download outcome) not *integration health* — different taxonomy, not in scope.
- **Push `configured`-as-catchall note.** `loading` and `unsupported` both collapse onto `configured` in the push card; in practice only `loading` ever renders (the card early-returns on `unsupported`). If the push surface grows, the fix is either a 6th `checking` status or more aggressive `label` overrides. Watch-item if a second async-probe surface adopts the same pattern.

### Tests

New `domain-status.test.tsx` pins the derivation policy with 10 cases, including the explicit anti-overclaim: a notification channel with `enabled=true, lastTestResult="failure"` maps to `offline`, not `healthy`. Full suite: 349 / 349 passing, tsc clean.

## Test plan

### Automated
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web run test` — 349/349 passing (10 new in `domain-status.test.tsx`)
- [x] `pnpm run lint` — no new warnings

### Visual (verified via Playwright against local dev server)

**Services list** — all four reachable states observed on real instance cards:

| Instance | Initial | After action | Observed badge |
|---|---|---|---|
| Primary Radarr | `Configured` | Test → success | `Healthy` ✅ |
| Test Jellyfin | `Configured` | Disable toggle | `Disabled` ✅ |
| Test Jellyfin | `Disabled` | Re-enable + Test → fail | `Offline` ✅ |
| Untested instances | n/a | (no round-trip yet) | `Configured` ✅ |

**Notification channels** — critical anti-overclaim case verified:

| Channel | `enabled` | `lastTestResult` | Expected | Observed |
|---|---|---|---|---|
| Untested Webhook (post-failure) | `true` | `"failure"` | `Offline` | **`Offline`** ✅ (this is the pre-change overclaim the PR fixes) |
| Disabled Webhook | `false` | `null` | `Disabled` | **`Disabled`** ✅ |

**Browser Push** — card renders via shared badge with "Inactive" label mapping to `disabled` status ✅.

All visual verification done with test data cleaned up after. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)