### PR TITLE
feat(ux): adopt shared primitives on three outlier panels

### DIFF
--- a/apps/web/src/features/notifications/components/notification-rules-tab.tsx
+++ b/apps/web/src/features/notifications/components/notification-rules-tab.tsx
@@ -1,18 +1,10 @@
 "use client";
 
-import {
-	AlertTriangle,
-	ChevronDown,
-	ChevronUp,
-	Loader2,
-	Minus,
-	Plus,
-	Shield,
-	Trash2,
-} from "lucide-react";
+import { ChevronDown, ChevronUp, Loader2, Minus, Plus, Shield, Trash2 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import type { RuleCondition } from "@arr/shared";
+import { AsyncStateView } from "@/components/layout/async-state-view";
 import { GradientButton, StatusBadge } from "@/components/layout/premium-components";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import { INPUT_BASE_CLASSES } from "@/lib/theme-input-styles";
@@ -85,7 +77,7 @@ function conditionsFromRule(rule: NotificationRuleResponse): RuleCondition[] {
 
 export function NotificationRulesTab() {
 	const { gradient } = useThemeGradient();
-	const { data: rules = [], isLoading, isError } = useNotificationRules();
+	const { data: rules = [], isLoading, isError, refetch } = useNotificationRules();
 	const { data: channels = [] } = useNotificationChannels();
 	const createRule = useCreateRule();
 	const updateRule = useUpdateRule();
@@ -209,405 +201,411 @@ export function NotificationRulesTab() {
 
 	const inputClass = INPUT_BASE_CLASSES.input;
 
-	if (isLoading) {
-		return (
-			<div className="flex items-center justify-center py-12">
-				<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-			</div>
-		);
-	}
-
-	if (isError) {
-		return (
-			<div className="flex flex-col items-center justify-center gap-2 py-12 text-muted-foreground">
-				<AlertTriangle className="h-6 w-6" />
-				<p className="text-sm">
-					Failed to load notification rules. Please try refreshing the page.
-				</p>
-			</div>
-		);
-	}
-
+	// Delegate loading / error / first-run empty state to AsyncStateView so
+	// wording, retry, and empty-state affordances match the rest of the app.
+	// The empty branch is suppressed while the inline form is open — a user
+	// creating their first rule shouldn't see the "you have no rules" CTA
+	// under the form they're filling in.
 	return (
-		<div className="space-y-4">
-			<div className="flex items-center justify-between">
-				<p className="text-sm text-muted-foreground">
-					Rules filter and route notifications before delivery. Higher priority rules run first.
-				</p>
-				{!showForm && (
+		<AsyncStateView
+			isLoading={isLoading}
+			isError={isError}
+			isEmpty={rules.length === 0 && !showForm}
+			onRetry={() => {
+				void refetch();
+			}}
+			errorTitle="Couldn't load notification rules"
+			emptyState={{
+				icon: Shield,
+				title: "No notification rules configured yet",
+				description:
+					"Rules let you suppress, throttle, route, or schedule quiet hours for notifications.",
+				action: (
 					<GradientButton onClick={openCreate}>
 						<Plus className="mr-2 h-4 w-4" />
-						Add Rule
+						Add your first rule
 					</GradientButton>
-				)}
-			</div>
+				),
+			}}
+		>
+			<div className="space-y-4">
+				<div className="flex items-center justify-between">
+					<p className="text-sm text-muted-foreground">
+						Rules filter and route notifications before delivery. Higher priority rules run first.
+					</p>
+					{!showForm && (
+						<GradientButton onClick={openCreate}>
+							<Plus className="mr-2 h-4 w-4" />
+							Add Rule
+						</GradientButton>
+					)}
+				</div>
 
-			{/* Inline form */}
-			{showForm && (
-				<div className="rounded-xl border border-border/30 bg-muted/10 p-4">
-					<div className="space-y-5">
-						<h3 className="font-semibold text-foreground">
-							{editingRule ? "Edit Rule" : "New Rule"}
-						</h3>
+				{/* Inline form */}
+				{showForm && (
+					<div className="rounded-xl border border-border/30 bg-muted/10 p-4">
+						<div className="space-y-5">
+							<h3 className="font-semibold text-foreground">
+								{editingRule ? "Edit Rule" : "New Rule"}
+							</h3>
 
-						{/* Name + priority row */}
-						<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-							<div className="sm:col-span-2">
-								<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-									Rule name
-								</label>
-								<input
-									type="text"
-									value={formData.name}
-									onChange={(e) => setFormData((p) => ({ ...p, name: e.target.value }))}
-									placeholder="e.g. Suppress hunt noise"
-									className={inputClass}
-									style={{ borderColor: formData.name ? undefined : undefined }}
-									onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-									onBlur={(e) => (e.target.style.borderColor = "")}
-								/>
-							</div>
-							<div>
-								<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-									Priority (0 = first)
-								</label>
-								<input
-									type="number"
-									min={0}
-									max={1000}
-									value={formData.priority}
-									onChange={(e) => setFormData((p) => ({ ...p, priority: Number(e.target.value) }))}
-									className={inputClass}
-									onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-									onBlur={(e) => (e.target.style.borderColor = "")}
-								/>
-							</div>
-						</div>
-
-						{/* Action selector */}
-						<div>
-							<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-								Action
-							</label>
-							<div className="flex flex-wrap gap-2">
-								{(["suppress", "throttle", "route", "quiet_hours"] as const).map((action) => (
-									<button
-										type="button"
-										key={action}
-										onClick={() => setFormData((p) => ({ ...p, action }))}
-										className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors border ${
-											formData.action === action
-												? "text-white border-transparent"
-												: "text-muted-foreground border-border/50 bg-card/30 hover:text-foreground"
-										}`}
-										style={
-											formData.action === action ? { backgroundColor: gradient.from } : undefined
-										}
-									>
-										{ACTION_LABELS[action]}
-									</button>
-								))}
-							</div>
-							<p className="mt-1.5 text-xs text-muted-foreground">
-								{ACTION_DESCRIPTIONS[formData.action]}
-							</p>
-						</div>
-
-						{/* Throttle sub-field */}
-						{formData.action === "throttle" && (
-							<div className="max-w-xs">
-								<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-									Throttle window (minutes)
-								</label>
-								<input
-									type="number"
-									min={1}
-									max={1440}
-									value={formData.throttleMinutes}
-									onChange={(e) =>
-										setFormData((p) => ({ ...p, throttleMinutes: Number(e.target.value) }))
-									}
-									className={inputClass}
-									onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-									onBlur={(e) => (e.target.style.borderColor = "")}
-								/>
-							</div>
-						)}
-
-						{/* Quiet hours sub-fields */}
-						{formData.action === "quiet_hours" && (
-							<div className="grid gap-3 sm:grid-cols-3">
-								<div>
+							{/* Name + priority row */}
+							<div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+								<div className="sm:col-span-2">
 									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-										Start time
-									</label>
-									<input
-										type="time"
-										value={formData.quietHoursStart}
-										onChange={(e) =>
-											setFormData((p) => ({ ...p, quietHoursStart: e.target.value }))
-										}
-										className={inputClass}
-										onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-										onBlur={(e) => (e.target.style.borderColor = "")}
-									/>
-								</div>
-								<div>
-									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-										End time
-									</label>
-									<input
-										type="time"
-										value={formData.quietHoursEnd}
-										onChange={(e) => setFormData((p) => ({ ...p, quietHoursEnd: e.target.value }))}
-										className={inputClass}
-										onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-										onBlur={(e) => (e.target.style.borderColor = "")}
-									/>
-								</div>
-								<div>
-									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-										Timezone
+										Rule name
 									</label>
 									<input
 										type="text"
-										value={formData.quietHoursTimezone}
+										value={formData.name}
+										onChange={(e) => setFormData((p) => ({ ...p, name: e.target.value }))}
+										placeholder="e.g. Suppress hunt noise"
+										className={inputClass}
+										style={{ borderColor: formData.name ? undefined : undefined }}
+										onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+										onBlur={(e) => (e.target.style.borderColor = "")}
+									/>
+								</div>
+								<div>
+									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+										Priority (0 = first)
+									</label>
+									<input
+										type="number"
+										min={0}
+										max={1000}
+										value={formData.priority}
 										onChange={(e) =>
-											setFormData((p) => ({ ...p, quietHoursTimezone: e.target.value }))
+											setFormData((p) => ({ ...p, priority: Number(e.target.value) }))
 										}
-										placeholder="America/New_York"
 										className={inputClass}
 										onFocus={(e) => (e.target.style.borderColor = gradient.from)}
 										onBlur={(e) => (e.target.style.borderColor = "")}
 									/>
 								</div>
 							</div>
-						)}
 
-						{/* Route sub-field: channel multi-select */}
-						{formData.action === "route" && (
+							{/* Action selector */}
 							<div>
 								<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
-									Target channels
+									Action
 								</label>
-								{channels.length === 0 ? (
-									<p className="text-xs text-muted-foreground">No channels configured yet.</p>
-								) : (
-									<div className="flex flex-wrap gap-2">
-										{channels.map((ch) => {
-											const selected = formData.targetChannelIds.includes(ch.id);
-											return (
-												<button
-													type="button"
-													key={ch.id}
-													onClick={() => toggleChannel(ch.id)}
-													className={`rounded-lg px-3 py-1.5 text-sm border transition-colors ${
-														selected
-															? "text-white border-transparent"
-															: "text-muted-foreground border-border/50 bg-card/30 hover:text-foreground"
-													}`}
-													style={selected ? { backgroundColor: gradient.from } : undefined}
-												>
-													{ch.name}
-												</button>
-											);
-										})}
-									</div>
-								)}
-							</div>
-						)}
-
-						{/* Conditions */}
-						<div>
-							<div className="mb-2 flex items-center justify-between">
-								<label className="text-xs font-medium text-muted-foreground">Conditions</label>
-								<button
-									type="button"
-									onClick={addCondition}
-									className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-								>
-									<Plus className="h-3 w-3" />
-									Add condition
-								</button>
-							</div>
-							<div className="space-y-2">
-								{formData.conditions.map((cond, i) => (
-									<div key={`cond-${i}`} className="flex items-center gap-2">
-										<select
-											value={cond.field}
-											onChange={(e) => updateCondition(i, { field: e.target.value })}
-											className={`${inputClass} flex-1`}
-											onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-											onBlur={(e) => (e.target.style.borderColor = "")}
-										>
-											{FIELD_OPTIONS.map((f) => (
-												<option key={f.value} value={f.value}>
-													{f.label}
-												</option>
-											))}
-										</select>
-										<select
-											value={cond.operator}
-											onChange={(e) =>
-												updateCondition(i, {
-													operator: e.target.value as RuleCondition["operator"],
-												})
+								<div className="flex flex-wrap gap-2">
+									{(["suppress", "throttle", "route", "quiet_hours"] as const).map((action) => (
+										<button
+											type="button"
+											key={action}
+											onClick={() => setFormData((p) => ({ ...p, action }))}
+											className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors border ${
+												formData.action === action
+													? "text-white border-transparent"
+													: "text-muted-foreground border-border/50 bg-card/30 hover:text-foreground"
+											}`}
+											style={
+												formData.action === action ? { backgroundColor: gradient.from } : undefined
 											}
-											className={`${inputClass} flex-1`}
-											onFocus={(e) => (e.target.style.borderColor = gradient.from)}
-											onBlur={(e) => (e.target.style.borderColor = "")}
 										>
-											{OPERATOR_OPTIONS.map((o) => (
-												<option key={o.value} value={o.value}>
-													{o.label}
-												</option>
-											))}
-										</select>
+											{ACTION_LABELS[action]}
+										</button>
+									))}
+								</div>
+								<p className="mt-1.5 text-xs text-muted-foreground">
+									{ACTION_DESCRIPTIONS[formData.action]}
+								</p>
+							</div>
+
+							{/* Throttle sub-field */}
+							{formData.action === "throttle" && (
+								<div className="max-w-xs">
+									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+										Throttle window (minutes)
+									</label>
+									<input
+										type="number"
+										min={1}
+										max={1440}
+										value={formData.throttleMinutes}
+										onChange={(e) =>
+											setFormData((p) => ({ ...p, throttleMinutes: Number(e.target.value) }))
+										}
+										className={inputClass}
+										onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+										onBlur={(e) => (e.target.style.borderColor = "")}
+									/>
+								</div>
+							)}
+
+							{/* Quiet hours sub-fields */}
+							{formData.action === "quiet_hours" && (
+								<div className="grid gap-3 sm:grid-cols-3">
+									<div>
+										<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+											Start time
+										</label>
 										<input
-											type="text"
-											value={String(cond.value)}
-											onChange={(e) => updateCondition(i, { value: e.target.value })}
-											placeholder="Value"
-											className={`${inputClass} flex-[2]`}
+											type="time"
+											value={formData.quietHoursStart}
+											onChange={(e) =>
+												setFormData((p) => ({ ...p, quietHoursStart: e.target.value }))
+											}
+											className={inputClass}
 											onFocus={(e) => (e.target.style.borderColor = gradient.from)}
 											onBlur={(e) => (e.target.style.borderColor = "")}
 										/>
+									</div>
+									<div>
+										<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+											End time
+										</label>
+										<input
+											type="time"
+											value={formData.quietHoursEnd}
+											onChange={(e) =>
+												setFormData((p) => ({ ...p, quietHoursEnd: e.target.value }))
+											}
+											className={inputClass}
+											onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+											onBlur={(e) => (e.target.style.borderColor = "")}
+										/>
+									</div>
+									<div>
+										<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+											Timezone
+										</label>
+										<input
+											type="text"
+											value={formData.quietHoursTimezone}
+											onChange={(e) =>
+												setFormData((p) => ({ ...p, quietHoursTimezone: e.target.value }))
+											}
+											placeholder="America/New_York"
+											className={inputClass}
+											onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+											onBlur={(e) => (e.target.style.borderColor = "")}
+										/>
+									</div>
+								</div>
+							)}
+
+							{/* Route sub-field: channel multi-select */}
+							{formData.action === "route" && (
+								<div>
+									<label className="mb-1.5 block text-xs font-medium text-muted-foreground">
+										Target channels
+									</label>
+									{channels.length === 0 ? (
+										<p className="text-xs text-muted-foreground">No channels configured yet.</p>
+									) : (
+										<div className="flex flex-wrap gap-2">
+											{channels.map((ch) => {
+												const selected = formData.targetChannelIds.includes(ch.id);
+												return (
+													<button
+														type="button"
+														key={ch.id}
+														onClick={() => toggleChannel(ch.id)}
+														className={`rounded-lg px-3 py-1.5 text-sm border transition-colors ${
+															selected
+																? "text-white border-transparent"
+																: "text-muted-foreground border-border/50 bg-card/30 hover:text-foreground"
+														}`}
+														style={selected ? { backgroundColor: gradient.from } : undefined}
+													>
+														{ch.name}
+													</button>
+												);
+											})}
+										</div>
+									)}
+								</div>
+							)}
+
+							{/* Conditions */}
+							<div>
+								<div className="mb-2 flex items-center justify-between">
+									<label className="text-xs font-medium text-muted-foreground">Conditions</label>
+									<button
+										type="button"
+										onClick={addCondition}
+										className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+									>
+										<Plus className="h-3 w-3" />
+										Add condition
+									</button>
+								</div>
+								<div className="space-y-2">
+									{formData.conditions.map((cond, i) => (
+										<div key={`cond-${i}`} className="flex items-center gap-2">
+											<select
+												value={cond.field}
+												onChange={(e) => updateCondition(i, { field: e.target.value })}
+												className={`${inputClass} flex-1`}
+												onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+												onBlur={(e) => (e.target.style.borderColor = "")}
+											>
+												{FIELD_OPTIONS.map((f) => (
+													<option key={f.value} value={f.value}>
+														{f.label}
+													</option>
+												))}
+											</select>
+											<select
+												value={cond.operator}
+												onChange={(e) =>
+													updateCondition(i, {
+														operator: e.target.value as RuleCondition["operator"],
+													})
+												}
+												className={`${inputClass} flex-1`}
+												onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+												onBlur={(e) => (e.target.style.borderColor = "")}
+											>
+												{OPERATOR_OPTIONS.map((o) => (
+													<option key={o.value} value={o.value}>
+														{o.label}
+													</option>
+												))}
+											</select>
+											<input
+												type="text"
+												value={String(cond.value)}
+												onChange={(e) => updateCondition(i, { value: e.target.value })}
+												placeholder="Value"
+												className={`${inputClass} flex-[2]`}
+												onFocus={(e) => (e.target.style.borderColor = gradient.from)}
+												onBlur={(e) => (e.target.style.borderColor = "")}
+											/>
+											<button
+												type="button"
+												onClick={() => removeCondition(i)}
+												disabled={formData.conditions.length === 1}
+												className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-red-400 disabled:opacity-30 transition-colors"
+												title="Remove condition"
+											>
+												<Minus className="h-4 w-4" />
+											</button>
+										</div>
+									))}
+								</div>
+								<p className="mt-1.5 text-xs text-muted-foreground">
+									All conditions must match for the rule to apply.
+								</p>
+							</div>
+
+							{/* Actions */}
+							<div className="flex items-center gap-3 pt-1">
+								<GradientButton onClick={handleSave} disabled={isSaving}>
+									{isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+									{editingRule ? "Update Rule" : "Create Rule"}
+								</GradientButton>
+								<button
+									type="button"
+									onClick={cancelForm}
+									className="rounded-lg px-4 py-2 text-sm text-muted-foreground hover:text-foreground bg-card/30 border border-border/50 transition-colors"
+								>
+									Cancel
+								</button>
+							</div>
+						</div>
+					</div>
+				)}
+
+				{/* Rules list. Empty state is handled by the outer AsyncStateView when
+			    no form is open — falling through to this block means there is
+			    either at least one rule OR the inline form is mid-edit. */}
+				{rules.length > 0 && (
+					<div className="space-y-3">
+						{rules.map((rule, index) => (
+							<div key={rule.id} className="rounded-xl border border-border/30 bg-muted/10 p-3">
+								<div
+									className="flex items-start gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300"
+									style={{ animationDelay: `${index * 30}ms`, animationFillMode: "backwards" }}
+								>
+									<div
+										className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg mt-0.5"
+										style={{ backgroundColor: gradient.fromLight }}
+									>
+										<Shield className="h-5 w-5" style={{ color: gradient.from }} />
+									</div>
+
+									<div className="min-w-0 flex-1 space-y-1">
+										<div className="flex flex-wrap items-center gap-2">
+											<span className="font-medium">{rule.name}</span>
+											<StatusBadge status={rule.enabled ? "success" : "warning"}>
+												{rule.enabled ? "Active" : "Disabled"}
+											</StatusBadge>
+											<span
+												className="rounded px-2 py-0.5 text-xs font-medium"
+												style={{
+													backgroundColor: gradient.fromLight,
+													color: gradient.from,
+												}}
+											>
+												{ACTION_LABELS[rule.action]}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												Priority {rule.priority}
+											</span>
+										</div>
+										<p className="text-xs text-muted-foreground">
+											{rule.conditions.length} condition
+											{rule.conditions.length !== 1 ? "s" : ""}
+											{rule.action === "throttle" && rule.throttleMinutes
+												? ` · ${rule.throttleMinutes}m window`
+												: ""}
+											{rule.action === "route" && rule.targetChannelIds?.length
+												? ` · ${rule.targetChannelIds.length} channel${rule.targetChannelIds.length !== 1 ? "s" : ""}`
+												: ""}
+											{rule.action === "quiet_hours" && rule.quietHoursStart && rule.quietHoursEnd
+												? ` · ${rule.quietHoursStart}–${rule.quietHoursEnd} ${rule.quietHoursTimezone ?? "UTC"}`
+												: ""}
+										</p>
+									</div>
+
+									<div className="flex items-center gap-1 shrink-0">
 										<button
 											type="button"
-											onClick={() => removeCondition(i)}
-											disabled={formData.conditions.length === 1}
-											className="shrink-0 rounded-md p-1.5 text-muted-foreground hover:text-red-400 disabled:opacity-30 transition-colors"
-											title="Remove condition"
+											onClick={() => toggleEnabled(rule)}
+											disabled={updateRule.isPending}
+											className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-card/50 transition-colors"
+											title={rule.enabled ? "Disable rule" : "Enable rule"}
 										>
-											<Minus className="h-4 w-4" />
+											{rule.enabled ? (
+												<ChevronDown className="h-4 w-4" />
+											) : (
+												<ChevronUp className="h-4 w-4" />
+											)}
+										</button>
+										<button
+											type="button"
+											onClick={() => openEdit(rule)}
+											className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-card/50 transition-colors"
+											title="Edit rule"
+										>
+											<Shield className="h-4 w-4" />
+										</button>
+										<button
+											type="button"
+											onClick={() => handleDelete(rule.id)}
+											disabled={deleteRule.isPending}
+											className={`rounded-md p-2 text-muted-foreground hover:bg-card/50 transition-colors ${
+												confirmDeleteId === rule.id ? "text-red-400" : "hover:text-red-400"
+											}`}
+											title={confirmDeleteId === rule.id ? "Click again to confirm" : "Delete rule"}
+										>
+											{confirmDeleteId === rule.id ? (
+												<span className="text-xs font-medium">Confirm?</span>
+											) : (
+												<Trash2 className="h-4 w-4" />
+											)}
 										</button>
 									</div>
-								))}
-							</div>
-							<p className="mt-1.5 text-xs text-muted-foreground">
-								All conditions must match for the rule to apply.
-							</p>
-						</div>
-
-						{/* Actions */}
-						<div className="flex items-center gap-3 pt-1">
-							<GradientButton onClick={handleSave} disabled={isSaving}>
-								{isSaving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-								{editingRule ? "Update Rule" : "Create Rule"}
-							</GradientButton>
-							<button
-								type="button"
-								onClick={cancelForm}
-								className="rounded-lg px-4 py-2 text-sm text-muted-foreground hover:text-foreground bg-card/30 border border-border/50 transition-colors"
-							>
-								Cancel
-							</button>
-						</div>
-					</div>
-				</div>
-			)}
-
-			{/* Rules list */}
-			{rules.length === 0 && !showForm ? (
-				<div className="rounded-xl border border-border/30 bg-muted/10 p-6">
-					<div className="text-center py-8">
-						<Shield className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
-						<p className="text-muted-foreground">No notification rules configured yet.</p>
-						<p className="mt-1 text-sm text-muted-foreground/70">
-							Rules let you suppress, throttle, route, or schedule quiet hours for notifications.
-						</p>
-					</div>
-				</div>
-			) : (
-				<div className="space-y-3">
-					{rules.map((rule, index) => (
-						<div key={rule.id} className="rounded-xl border border-border/30 bg-muted/10 p-3">
-							<div
-								className="flex items-start gap-4 animate-in fade-in slide-in-from-bottom-2 duration-300"
-								style={{ animationDelay: `${index * 30}ms`, animationFillMode: "backwards" }}
-							>
-								<div
-									className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg mt-0.5"
-									style={{ backgroundColor: gradient.fromLight }}
-								>
-									<Shield className="h-5 w-5" style={{ color: gradient.from }} />
-								</div>
-
-								<div className="min-w-0 flex-1 space-y-1">
-									<div className="flex flex-wrap items-center gap-2">
-										<span className="font-medium">{rule.name}</span>
-										<StatusBadge status={rule.enabled ? "success" : "warning"}>
-											{rule.enabled ? "Active" : "Disabled"}
-										</StatusBadge>
-										<span
-											className="rounded px-2 py-0.5 text-xs font-medium"
-											style={{
-												backgroundColor: gradient.fromLight,
-												color: gradient.from,
-											}}
-										>
-											{ACTION_LABELS[rule.action]}
-										</span>
-										<span className="text-xs text-muted-foreground">Priority {rule.priority}</span>
-									</div>
-									<p className="text-xs text-muted-foreground">
-										{rule.conditions.length} condition
-										{rule.conditions.length !== 1 ? "s" : ""}
-										{rule.action === "throttle" && rule.throttleMinutes
-											? ` · ${rule.throttleMinutes}m window`
-											: ""}
-										{rule.action === "route" && rule.targetChannelIds?.length
-											? ` · ${rule.targetChannelIds.length} channel${rule.targetChannelIds.length !== 1 ? "s" : ""}`
-											: ""}
-										{rule.action === "quiet_hours" && rule.quietHoursStart && rule.quietHoursEnd
-											? ` · ${rule.quietHoursStart}–${rule.quietHoursEnd} ${rule.quietHoursTimezone ?? "UTC"}`
-											: ""}
-									</p>
-								</div>
-
-								<div className="flex items-center gap-1 shrink-0">
-									<button
-										type="button"
-										onClick={() => toggleEnabled(rule)}
-										disabled={updateRule.isPending}
-										className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-card/50 transition-colors"
-										title={rule.enabled ? "Disable rule" : "Enable rule"}
-									>
-										{rule.enabled ? (
-											<ChevronDown className="h-4 w-4" />
-										) : (
-											<ChevronUp className="h-4 w-4" />
-										)}
-									</button>
-									<button
-										type="button"
-										onClick={() => openEdit(rule)}
-										className="rounded-md p-2 text-muted-foreground hover:text-foreground hover:bg-card/50 transition-colors"
-										title="Edit rule"
-									>
-										<Shield className="h-4 w-4" />
-									</button>
-									<button
-										type="button"
-										onClick={() => handleDelete(rule.id)}
-										disabled={deleteRule.isPending}
-										className={`rounded-md p-2 text-muted-foreground hover:bg-card/50 transition-colors ${
-											confirmDeleteId === rule.id ? "text-red-400" : "hover:text-red-400"
-										}`}
-										title={confirmDeleteId === rule.id ? "Click again to confirm" : "Delete rule"}
-									>
-										{confirmDeleteId === rule.id ? (
-											<span className="text-xs font-medium">Confirm?</span>
-										) : (
-											<Trash2 className="h-4 w-4" />
-										)}
-									</button>
 								</div>
 							</div>
-						</div>
-					))}
-				</div>
-			)}
-		</div>
+						))}
+					</div>
+				)}
+			</div>
+		</AsyncStateView>
 	);
 }

--- a/apps/web/src/features/settings/components/__tests__/security-posture-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/security-posture-section.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+import type { SecurityPosture } from "../../../../lib/api-client/system";
+import { SecurityPostureSection } from "../security-posture-section";
+
+const renderWithTheme = (ui: ReactElement) => render(<ColorThemeProvider>{ui}</ColorThemeProvider>);
+
+/*
+ * Verifies the AsyncStateView adoption on SecurityPostureSection (#326).
+ *
+ * The underlying `AsyncStateView` + `AsyncErrorCard` primitives are already
+ * tested elsewhere — what this suite locks in is the *wiring*:
+ *   - loading branch renders the skeleton scaffold, not the bespoke text
+ *   - error branch renders a retry button that actually calls `onRetry`
+ *   - posture present renders the full content (no AsyncStateView takeover)
+ *
+ * Without these checks, a future refactor could silently regress the retry
+ * affordance (e.g. by forgetting to thread `onRetry` through) and the
+ * operator would be stuck on a broken panel with no way out.
+ */
+
+function makePosture(overrides: Partial<SecurityPosture> = {}): SecurityPosture {
+	const base: SecurityPosture = {
+		capturedAt: new Date(0).toISOString(),
+		overall: "healthy",
+		checks: [],
+		auth: {
+			passwordEnabled: true,
+			passwordUserCount: 1,
+			oidcEnabled: false,
+			passkeyCount: 0,
+		},
+		effective: {
+			nodeEnv: "development",
+			trustProxy: false,
+			secureCookies: false,
+			sessionTtlHours: 24,
+			sessionCookieName: "arr.sid",
+			passwordPolicy: "strict",
+			appUrl: "http://localhost:3000",
+		},
+	};
+	return { ...base, ...overrides };
+}
+
+describe("SecurityPostureSection", () => {
+	it("renders a skeleton scaffold while loading with no posture yet", () => {
+		renderWithTheme(<SecurityPostureSection posture={undefined} isLoading={true} />);
+		// Section chrome stays visible so the layout doesn't jump.
+		expect(screen.getByText("Security Posture")).toBeInTheDocument();
+		// Loading branch uses role="status" via AsyncStateView.
+		expect(screen.getByRole("status")).toBeInTheDocument();
+	});
+
+	it("renders the themed error card with a retry button when isError && no posture", () => {
+		const onRetry = vi.fn();
+		renderWithTheme(
+			<SecurityPostureSection
+				posture={undefined}
+				isLoading={false}
+				isError={true}
+				onRetry={onRetry}
+			/>,
+		);
+		// Error title comes from the prop we passed into AsyncStateView.
+		expect(screen.getByText("Couldn't load security posture")).toBeInTheDocument();
+		const retry = screen.getByRole("button", { name: /try again/i });
+		fireEvent.click(retry);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders the empty branch with a shield icon when the request finished but returned nothing", () => {
+		renderWithTheme(<SecurityPostureSection posture={undefined} isLoading={false} />);
+		expect(screen.getByText(/Security posture unavailable/i)).toBeInTheDocument();
+	});
+
+	it("renders the full posture content when data is present (AsyncStateView does not take over)", () => {
+		const posture = makePosture({
+			overall: "warning",
+			checks: [
+				{
+					id: "auth-methods",
+					label: "Authentication",
+					severity: "warning",
+					detail: "Password-only authentication is in use.",
+					remediation: "Enable a passkey or OIDC.",
+				},
+			],
+		});
+		renderWithTheme(<SecurityPostureSection posture={posture} isLoading={false} />);
+		expect(screen.getByText("Authentication")).toBeInTheDocument();
+		expect(screen.getByText("Password-only authentication is in use.")).toBeInTheDocument();
+		// The "Recommended improvements" banner copy only appears on the loaded path.
+		expect(screen.getByText("Recommended improvements")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/settings/components/security-posture-section.tsx
+++ b/apps/web/src/features/settings/components/security-posture-section.tsx
@@ -19,11 +19,17 @@ import {
 	KeyRound,
 	ShieldAlert,
 	ShieldCheck,
+	ShieldOff,
 	ShieldX,
 	UserCheck,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { PremiumSection, PremiumSkeleton, StatusBadge } from "../../../components/layout";
+import {
+	AsyncStateView,
+	PremiumSection,
+	PremiumSkeleton,
+	StatusBadge,
+} from "../../../components/layout";
 import type {
 	SecurityCheck,
 	SecurityPosture,
@@ -34,6 +40,8 @@ import { cn } from "../../../lib/utils";
 interface Props {
 	posture: SecurityPosture | undefined;
 	isLoading: boolean;
+	isError?: boolean;
+	onRetry?: () => void;
 }
 
 const SEVERITY_BADGE: Record<
@@ -68,24 +76,11 @@ const OVERALL_ICON: Record<SecuritySeverity, typeof ShieldCheck> = {
 	misconfigured: ShieldX,
 };
 
-export function SecurityPostureSection({ posture, isLoading }: Props) {
-	if (isLoading && !posture) {
-		return (
-			<PremiumSection
-				title="Security Posture"
-				description="Effective runtime security configuration and warnings"
-				icon={ShieldCheck}
-			>
-				<div className="space-y-3">
-					<PremiumSkeleton className="h-20" />
-					<PremiumSkeleton className="h-12" />
-					<PremiumSkeleton className="h-12" />
-					<PremiumSkeleton className="h-12" />
-				</div>
-			</PremiumSection>
-		);
-	}
-
+export function SecurityPostureSection({ posture, isLoading, isError, onRetry }: Props) {
+	// Defer loading / error / empty to AsyncStateView so the wording + retry
+	// affordance match the rest of the app. The section chrome (title, icon,
+	// description) always renders so the operator can still see what the panel
+	// *is* while it's loading or broken.
 	if (!posture) {
 		return (
 			<PremiumSection
@@ -93,7 +88,29 @@ export function SecurityPostureSection({ posture, isLoading }: Props) {
 				description="Effective runtime security configuration and warnings"
 				icon={ShieldCheck}
 			>
-				<p className="text-sm text-muted-foreground">Unable to load security posture.</p>
+				<AsyncStateView
+					isLoading={isLoading}
+					isError={Boolean(isError)}
+					isEmpty={!isLoading && !isError}
+					onRetry={onRetry}
+					errorTitle="Couldn't load security posture"
+					emptyState={{
+						icon: ShieldOff,
+						title: "Security posture unavailable",
+						description:
+							"We couldn't evaluate your current security configuration. Try refreshing the page.",
+					}}
+					loadingFallback={
+						<div className="space-y-3">
+							<PremiumSkeleton className="h-20" />
+							<PremiumSkeleton className="h-12" />
+							<PremiumSkeleton className="h-12" />
+							<PremiumSkeleton className="h-12" />
+						</div>
+					}
+				>
+					{null}
+				</AsyncStateView>
 			</PremiumSection>
 		);
 	}

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -130,7 +130,12 @@ export function SystemTab() {
 		isError: isValidationHealthError,
 		dataUpdatedAt: validationHealthUpdatedAt,
 	} = useValidationHealth();
-	const { data: securityPosture, isLoading: isSecurityPostureLoading } = useSecurityPosture();
+	const {
+		data: securityPosture,
+		isLoading: isSecurityPostureLoading,
+		isError: isSecurityPostureError,
+		refetch: refetchSecurityPosture,
+	} = useSecurityPosture();
 	const resetHealthMutation = useResetValidationHealth();
 	const updateMutation = useUpdateSystemSettings();
 	const restartMutation = useRestartSystem();
@@ -349,6 +354,10 @@ export function SystemTab() {
 			<SecurityPostureSection
 				posture={securityPosture?.data}
 				isLoading={isSecurityPostureLoading}
+				isError={isSecurityPostureError}
+				onRetry={() => {
+					void refetchSecurityPosture();
+				}}
 			/>
 
 			{/* Validation Health Section */}

--- a/apps/web/src/features/settings/components/validation-health-section.tsx
+++ b/apps/web/src/features/settings/components/validation-health-section.tsx
@@ -12,7 +12,8 @@ import {
 	XCircle,
 } from "lucide-react";
 import { useState } from "react";
-import { PremiumSection } from "../../../components/layout";
+import { DomainStatusBadge, PremiumSection } from "../../../components/layout";
+import type { DomainStatus } from "../../../components/layout/domain-status";
 import { Button } from "../../../components/ui/button";
 import { useClearQuarantine, useValidationQuarantine } from "../../../hooks/api/useSystem";
 import type {
@@ -22,6 +23,25 @@ import type {
 	ValidationHealthResponse,
 } from "../../../lib/api-client/system";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
+
+/**
+ * Map validation-health state onto the shared domain-status taxonomy.
+ *
+ * `failing` → `offline` because the domain vocabulary reserves `offline` for
+ * "last check failed". `degraded` matches 1:1. There is no validation-side
+ * equivalent of `configured`/`disabled` (those only make sense at the
+ * integration-setup layer), so no other states are reachable here.
+ */
+function healthStateToDomainStatus(state: HealthState): DomainStatus {
+	switch (state) {
+		case "healthy":
+			return "healthy";
+		case "degraded":
+			return "degraded";
+		case "failing":
+			return "offline";
+	}
+}
 
 // ============================================================================
 // Helper Components
@@ -57,33 +77,6 @@ function SystemInfoCard({
 				)}
 			</div>
 		</div>
-	);
-}
-
-function HealthStateBadge({ state }: { state: HealthState }) {
-	const colors = {
-		healthy: SEMANTIC_COLORS.success,
-		degraded: SEMANTIC_COLORS.warning,
-		failing: SEMANTIC_COLORS.error,
-	};
-	const labels = {
-		healthy: "Healthy",
-		degraded: "Degraded",
-		failing: "Failing",
-	};
-	const color = colors[state];
-
-	return (
-		<span
-			className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-full text-xs font-medium"
-			style={{
-				backgroundColor: `${color.from}20`,
-				color: color.from,
-			}}
-		>
-			<span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: color.from }} />
-			{labels[state]}
-		</span>
 	);
 }
 
@@ -333,7 +326,16 @@ export function ValidationHealthSection({
 														)}
 													</td>
 													<td className="p-3 text-center">
-														<HealthStateBadge state={health.state} />
+														<DomainStatusBadge
+															status={healthStateToDomainStatus(health.state)}
+															label={
+																health.state === "healthy"
+																	? "Healthy"
+																	: health.state === "degraded"
+																		? "Degraded"
+																		: "Failing"
+															}
+														/>
 													</td>
 													<td className="p-3 text-right font-mono text-foreground">
 														{health.totals.total.toLocaleString()}


### PR DESCRIPTION
## Summary

Focused UX-consistency consolidation pass. Applies the existing shared primitives from #321 (`AsyncStateView`), #324 (`DomainStatusBadge`), and #325 (`DataFreshness`) to three operator-facing surfaces that still carried bespoke loading / error / empty / status treatments.

**No new primitives introduced** — this PR only adopts what's already there.

## Surfaces changed (3)

### 1. `ValidationHealthSection` — `DomainStatusBadge`
- Deleted inline `HealthStateBadge` (25 lines of ad-hoc color + pill markup).
- Added a local `healthStateToDomainStatus` adapter (`failing → offline`) so the shared domain vocabulary stays honest: "offline" in the taxonomy means "last check failed".
- User-facing labels preserved as **Healthy / Degraded / Failing** via the badge's `label` override. Styling unifies with the rest of the app; domain wording stays accurate.

### 2. `SecurityPostureSection` — `AsyncStateView`
- Replaced two early-return branches (bespoke skeleton, plain "Unable to load security posture." text) with a single `AsyncStateView`.
- Added `isError` + `onRetry` props, wired to `refetchSecurityPosture` in `system-tab.tsx`. Operators now get a **retry button** instead of being stuck.
- Section chrome (title / icon / description) stays visible in all states so the layout doesn't jump.
- Original 4-skeleton layout preserved via `loadingFallback`.

### 3. `NotificationRulesTab` — `AsyncStateView`
- Replaced bespoke `Loader2` spinner + inline `AlertTriangle` error text (no retry) + separate inline empty state with a single `AsyncStateView`.
- Matches sibling `notification-log-table.tsx` which already uses this pattern.
- Empty state now carries an **"Add your first rule"** CTA. Empty state is suppressed while the inline form is open, so first-run users filling the form don't see a redundant CTA underneath.
- Retry wired to the query's `refetch`.

## Intentionally deferred (with rationale)

- **`PlexServerInfoWidget`** — returns `null` on loading/error by design. It's a dashboard accent, not a primary panel; forcing visible skeleton/error chrome would add noise where silence is correct.
- **Security posture severity badges** (`healthy` / `warning` / `misconfigured`) — these are *config-audit* severity, not *runtime reachability*. `DomainStatusBadge` encodes the latter; mixing them would misuse the taxonomy.
- **Schema Drift & Quarantine mini-badges** in ValidationHealth — count summaries ("3 items", "No drift"), not per-entity health states. Not in the `DomainStatus` taxonomy.
- **Statistics tabs** (`plex-tab`, `arr-service-tab`, `prowlarr-tab`) — already use `PremiumSkeleton` consistently; a full refactor across 4 parameterized service variants is out of scope for a consolidation pass.

## Helper changes (minimal)

- `healthStateToDomainStatus(state: HealthState): DomainStatus` — single local adapter in `validation-health-section.tsx`. **Not promoted to the shared module** — the existing `deriveServiceInstanceStatus` / `deriveNotificationChannelStatus` helpers were only promoted because multiple callers share them. Premature promotion creates abstractions before a second caller exists.
- `SecurityPostureSection` props: added opt-in `isError?` + `onRetry?`. Existing callers are unaffected.

## Files changed

- `apps/web/src/features/settings/components/validation-health-section.tsx`
- `apps/web/src/features/settings/components/security-posture-section.tsx`
- `apps/web/src/features/settings/components/system-tab.tsx`
- `apps/web/src/features/notifications/components/notification-rules-tab.tsx`
- `apps/web/src/features/settings/components/__tests__/security-posture-section.test.tsx` *(new — 4 tests pinning the AsyncStateView wiring)*

Large diff in `notification-rules-tab.tsx` is mostly re-indentation from wrapping the body in `AsyncStateView` (biome re-formatted).

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` passes
- [x] `pnpm --filter @arr/web run test` — all **366 tests pass** (362 prior + 4 new)
- [x] `pnpm --filter @arr/web run lint` — no new warnings (5 pre-existing unrelated)
- [x] **Manual (Validation Health):** Per-integration state column renders `DomainStatusBadge` with canonical tooltip `"Reachable and last check succeeded"` — visual parity with other domain-status surfaces (services, notifications) confirmed. Header `DataFreshness` from #325 still renders beside the new badges.
- [x] **Manual (Notifications → Rules empty state):** First-run empty state shows the `Shield` icon, heading `"No notification rules configured yet"`, and the new `"Add your first rule"` CTA — confirmed visually.
- [x] **Manual (form-open suppresses empty state):** Clicking the empty-state CTA opens the inline rule form; empty state disappears (`rules.length === 0 && !showForm` correctly resolves to `false`). Prevents the regression where first-run users would see a redundant CTA below the form they're filling in.
- [x] **Automated (SecurityPosture retry):** Forcing a cold-cache fetch failure in-browser was frustrated by React Query's cached-data shielding, so the retry affordance is pinned by the new component test suite instead — 4 deterministic cases covering loading / error+retry / empty / loaded branches. `fireEvent.click(retry)` asserts `onRetry` is called exactly once.

## Out-of-scope issues noticed during verification (NOT introduced by this PR)

- `ValidationHealthSection` has a pre-existing `<>...</>` fragment inside `integrationNames.map()` at line 310 with `key` on the `<tr>` instead of the fragment — triggers a React "unique key" warning. Reproduces on `main`.
- `NotificationRulesTab` tab triggers two "Maximum update depth exceeded" warnings when the Rules sub-tab mounts. **Confirmed reproducible on `main`** with the original file, so not a regression from this PR — likely upstream in one of the notification hooks or the parent tab orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)