### PR TITLE
fix(tautulli): chunk stale cache eviction to avoid SQLite P2029

### DIFF
--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -3,11 +3,15 @@
  *
  * Proactive hardening to match the Plex fix from PR #328 / issue #323.
  *
- * The original `deleteMany({ id: { notIn: upsertedIds } })` shape would
- * exceed SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999) whenever the
- * upsert set is large, surfacing as Prisma P2029. These tests pin the
- * replacement read-then-diff-then-chunked-`in`-delete contract so the
- * Tautulli refresher cannot regress into the same failure mode.
+ * The original `deleteMany({ id: { notIn: upsertedIds } })` shape binds one
+ * parameter per kept id, so the query overflows SQLite's SQLITE_MAX_VARIABLE_NUMBER
+ * (default 999) — and for Tautulli specifically, the unbounded dimension is
+ * the *accumulated table size* (i.e. the stale diff), not the per-refresh
+ * upsert set. A single refresh is capped by `MAX_METADATA_LOOKUPS`, but the
+ * cache keeps growing over time, so the keep-list that would be passed into
+ * `notIn` grows with cache age regardless of how small any one refresh is.
+ * These tests pin the replacement read-then-diff-then-chunked-`in`-delete
+ * contract so the Tautulli refresher cannot regress into that failure mode.
  */
 
 import { describe, expect, it, vi } from "vitest";

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -13,9 +13,27 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	evictStaleRows,
+	refreshTautulliCache,
 	STALE_EVICTION_CHUNK_SIZE,
 } from "../tautulli-cache-refresher.js";
 import type { PrismaClient } from "../../prisma.js";
+import type { TautulliClient } from "../tautulli-client.js";
+import type { FastifyBaseLogger } from "fastify";
+
+// Neutralise the inter-lookup rate-limit delay so the end-to-end test runs fast.
+vi.mock("../../utils/delay.js", () => ({
+	delay: vi.fn(async () => {}),
+}));
+
+const silentLog = {
+	warn: vi.fn(),
+	info: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+	child: vi.fn(),
+} as unknown as FastifyBaseLogger;
 
 /**
  * Build a minimal Prisma stub that records every `deleteMany` call so tests
@@ -101,5 +119,104 @@ describe("evictStaleRows (tautulli)", () => {
 
 		// Sanity: we actually issued multiple chunked statements.
 		expect(deleteCalls.length).toBe(Math.ceil(TOTAL_EXISTING / STALE_EVICTION_CHUNK_SIZE));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: refreshTautulliCache against a realistic "large stale tail" shape
+// ---------------------------------------------------------------------------
+
+describe("refreshTautulliCache (end-to-end)", () => {
+	it("large stale-tail regression: refresh succeeds with only bounded DELETEs", async () => {
+		// Models the real failure mode: a cache that accumulated many rows over
+		// previous refreshes, where one refresh returns a smaller fresh set. The
+		// stale diff is what blows past SQLite's parameter limit, not the upsert
+		// set — so we use a small fresh set and a large pre-existing tail.
+		const FRESH_COUNT = 10;
+		const STALE_TAIL = 2_000;
+
+		// Tautulli history: one entry per fresh item, all movies.
+		const libraries = [
+			{ section_id: "1", section_name: "Movies", section_type: "movie", count: "10" },
+		];
+		const history = Array.from({ length: FRESH_COUNT }, (_, i) => ({
+			rating_key: `rk-${i}`,
+			parent_rating_key: "",
+			grandparent_rating_key: "",
+			title: `Movie ${i}`,
+			grandparent_title: "",
+			media_type: "movie",
+			user: "alice",
+			date: 1_700_000_000 + i,
+			play_count: 1,
+		}));
+
+		const mockClient = {
+			getLibraries: vi.fn().mockResolvedValue(libraries),
+			// First page fills below HISTORY_PAGE_SIZE (50) so the pagination loop
+			// exits after one call. Subsequent pages would return empty.
+			getHistory: vi.fn().mockResolvedValue({
+				data: history,
+				recordsFiltered: FRESH_COUNT,
+				recordsTotal: FRESH_COUNT,
+			}),
+			getMetadata: vi.fn(async (ratingKey: string) => {
+				const i = Number.parseInt(ratingKey.replace("rk-", ""), 10);
+				return {
+					guids: [`tmdb://${20_000 + i}`],
+					media_type: "movie",
+					title: `Movie ${i}`,
+					rating_key: ratingKey,
+				};
+			}),
+		} as unknown as TautulliClient;
+
+		const upsertedIds: string[] = [];
+		const existingStaleIds = Array.from({ length: STALE_TAIL }, (_, i) => `stale-${i}`);
+		const deleteCalls: Array<{ idsInFilter: string[] }> = [];
+
+		const mockPrisma = {
+			tautulliCache: {
+				upsert: vi.fn(async () => {
+					const id = `fresh-${upsertedIds.length}`;
+					upsertedIds.push(id);
+					return { id };
+				}),
+				findMany: vi.fn(async () =>
+					[...existingStaleIds, ...upsertedIds].map((id) => ({ id })),
+				),
+				deleteMany: vi.fn(
+					async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
+						const inList = args.where.id?.in;
+						if (!inList) {
+							throw new Error(
+								"Regression: Tautulli eviction used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
+							);
+						}
+						deleteCalls.push({ idsInFilter: inList });
+						return { count: inList.length };
+					},
+				),
+			},
+		} as unknown as PrismaClient;
+
+		const result = await refreshTautulliCache(mockClient, mockPrisma, "inst-1", silentLog);
+
+		expect(result.errors).toBe(0);
+		expect(result.errorMessages).toEqual([]);
+		expect(result.upserted).toBe(FRESH_COUNT);
+
+		// Every eviction DELETE stays under SQLite's 999-parameter ceiling.
+		const SQLITE_PARAM_CEILING = 999;
+		expect(deleteCalls.length).toBeGreaterThan(0);
+		for (const call of deleteCalls) {
+			expect(call.idsInFilter.length).toBeLessThanOrEqual(STALE_EVICTION_CHUNK_SIZE);
+			expect(call.idsInFilter.length).toBeLessThan(SQLITE_PARAM_CEILING);
+		}
+
+		// Chunks together wipe exactly the stale tail, nothing more.
+		const deletedIds = deleteCalls.flatMap((c) => c.idsInFilter);
+		expect(deletedIds.length).toBe(STALE_TAIL);
+		expect(new Set(deletedIds)).toEqual(new Set(existingStaleIds));
 	});
 });

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tautulli Cache Refresher — stale row eviction tests
+ *
+ * Proactive hardening to match the Plex fix from PR #328 / issue #323.
+ *
+ * The original `deleteMany({ id: { notIn: upsertedIds } })` shape would
+ * exceed SQLite's SQLITE_MAX_VARIABLE_NUMBER (default 999) whenever the
+ * upsert set is large, surfacing as Prisma P2029. These tests pin the
+ * replacement read-then-diff-then-chunked-`in`-delete contract so the
+ * Tautulli refresher cannot regress into the same failure mode.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+	evictStaleRows,
+	STALE_EVICTION_CHUNK_SIZE,
+} from "../tautulli-cache-refresher.js";
+import type { PrismaClient } from "../../prisma.js";
+
+/**
+ * Build a minimal Prisma stub that records every `deleteMany` call so tests
+ * can assert on chunking behaviour without needing a real database.
+ */
+function makeMockPrisma(existingIds: string[]) {
+	const deleteCalls: Array<{ idsInFilter: string[] }> = [];
+
+	const stub = {
+		tautulliCache: {
+			findMany: vi.fn(async () => existingIds.map((id) => ({ id }))),
+			deleteMany: vi.fn(
+				async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
+					const inList = args.where.id?.in;
+					if (!inList) {
+						throw new Error(
+							"Regression: DELETE used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
+						);
+					}
+					deleteCalls.push({ idsInFilter: inList });
+					return { count: inList.length };
+				},
+			),
+		},
+	} as unknown as PrismaClient;
+
+	return { prisma: stub, deleteCalls };
+}
+
+describe("evictStaleRows (tautulli)", () => {
+	it("returns 0 and issues no DELETE when nothing is stale", async () => {
+		const keepIds = ["a", "b", "c"];
+		const { prisma, deleteCalls } = makeMockPrisma(keepIds);
+
+		const deleted = await evictStaleRows(prisma, "inst-1", keepIds);
+
+		expect(deleted).toBe(0);
+		expect(deleteCalls).toHaveLength(0);
+	});
+
+	it("deletes only rows whose id is not in keepIds", async () => {
+		const existing = ["keep-1", "stale-1", "keep-2", "stale-2"];
+		const keepIds = ["keep-1", "keep-2"];
+		const { prisma, deleteCalls } = makeMockPrisma(existing);
+
+		const deleted = await evictStaleRows(prisma, "inst-1", keepIds);
+
+		expect(deleted).toBe(2);
+		expect(deleteCalls).toHaveLength(1);
+		expect(new Set(deleteCalls[0]!.idsInFilter)).toEqual(new Set(["stale-1", "stale-2"]));
+	});
+
+	it("chunks large stale sets so no single DELETE exceeds the SQLite parameter limit (parallels #328)", async () => {
+		// Simulate a cache table large enough that the old `notIn: upsertedIds`
+		// path would have generated a multi-thousand-parameter query, well past
+		// SQLite's default 999-parameter ceiling.
+		const TOTAL_EXISTING = 5_000;
+		const existingIds = Array.from({ length: TOTAL_EXISTING }, (_, i) => `row-${i}`);
+		// Keep none — worst case for parameter count.
+		const keepIds: string[] = [];
+		const { prisma, deleteCalls } = makeMockPrisma(existingIds);
+
+		const deleted = await evictStaleRows(prisma, "inst-1", keepIds);
+
+		expect(deleted).toBe(TOTAL_EXISTING);
+
+		// Every DELETE must stay under SQLite's conservative 999-parameter ceiling.
+		const SQLITE_PARAM_CEILING = 999;
+		for (const call of deleteCalls) {
+			expect(call.idsInFilter.length).toBeLessThanOrEqual(STALE_EVICTION_CHUNK_SIZE);
+			expect(call.idsInFilter.length).toBeLessThan(SQLITE_PARAM_CEILING);
+		}
+
+		// Chunks must cover the full stale set with no duplicates.
+		const seen = new Set<string>();
+		for (const call of deleteCalls) {
+			for (const id of call.idsInFilter) {
+				expect(seen.has(id)).toBe(false);
+				seen.add(id);
+			}
+		}
+		expect(seen.size).toBe(TOTAL_EXISTING);
+
+		// Sanity: we actually issued multiple chunked statements.
+		expect(deleteCalls.length).toBe(Math.ceil(TOTAL_EXISTING / STALE_EVICTION_CHUNK_SIZE));
+	});
+});

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -184,13 +184,18 @@ export async function refreshTautulliCache(
 			}
 		}
 
-		// Evict stale rows: items that were in a previous refresh but no longer exist in Tautulli
+		// Evict stale rows: items that were in a previous refresh but no longer exist in Tautulli.
+		//
+		// NOTE: We cannot do `deleteMany({ id: { notIn: upsertedIds } })` here — Prisma binds
+		// each id as a separate parameter, so a large upsert set blows past SQLite's default
+		// SQLITE_MAX_VARIABLE_NUMBER (999) and raises P2029. This is the same shape that was
+		// fixed for the Plex refresher in PR #328 / issue #323. Even though Tautulli's current
+		// MAX_METADATA_LOOKUPS caps a single refresh, the query still reads every row already
+		// in the table, so the parameter count is unbounded in practice. Mirror the Plex fix.
 		if (upsertedIds.length > 0) {
-			const evicted = await prisma.tautulliCache.deleteMany({
-				where: { instanceId, id: { notIn: upsertedIds } },
-			});
-			if (evicted.count > 0) {
-				log.info({ instanceId, evicted: evicted.count }, "Tautulli cache: evicted stale rows");
+			const evictedCount = await evictStaleRows(prisma, instanceId, upsertedIds);
+			if (evictedCount > 0) {
+				log.info({ instanceId, evicted: evictedCount }, "Tautulli cache: evicted stale rows");
 			}
 		}
 
@@ -211,6 +216,59 @@ export async function refreshTautulliCache(
 	}
 
 	return { upserted, errors, errorMessages };
+}
+
+// ============================================================================
+// Stale Row Eviction
+// ============================================================================
+
+/**
+ * Chunk size for `id: { in: ... }` deletes. Stays well below SQLite's historical
+ * SQLITE_MAX_VARIABLE_NUMBER (999) so no single DELETE statement can exceed the
+ * parameter limit. Mirrors the constant used for the Plex refresher (PR #328)
+ * — kept local rather than shared so each cache subsystem can tune independently.
+ *
+ * Exported for tests.
+ */
+export const STALE_EVICTION_CHUNK_SIZE = 500;
+
+/**
+ * Evict rows for `instanceId` whose `id` is not in `keepIds`.
+ *
+ * Reads existing row ids, diffs in memory, then issues bounded `id: { in: chunk }`
+ * deletes. This avoids Prisma P2029 on SQLite when `keepIds` would have been a
+ * giant `notIn` parameter list — proactive hardening mirroring the Plex fix
+ * from PR #328.
+ *
+ * Exported for tests.
+ */
+export async function evictStaleRows(
+	prisma: PrismaClient,
+	instanceId: string,
+	keepIds: string[],
+): Promise<number> {
+	const existing = await prisma.tautulliCache.findMany({
+		where: { instanceId },
+		select: { id: true },
+	});
+
+	const keepSet = new Set(keepIds);
+	const staleIds: string[] = [];
+	for (const row of existing) {
+		if (!keepSet.has(row.id)) staleIds.push(row.id);
+	}
+
+	if (staleIds.length === 0) return 0;
+
+	let totalDeleted = 0;
+	for (let i = 0; i < staleIds.length; i += STALE_EVICTION_CHUNK_SIZE) {
+		const chunk = staleIds.slice(i, i + STALE_EVICTION_CHUNK_SIZE);
+		const { count } = await prisma.tautulliCache.deleteMany({
+			where: { instanceId, id: { in: chunk } },
+		});
+		totalDeleted += count;
+	}
+	return totalDeleted;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Proactive follow-up to #328 / issue #323: the Tautulli cache refresher has the same `deleteMany({ id: { notIn: upsertedIds } })` shape that caused the Plex P2029 failure. No user-reported bug, but the query is latently vulnerable — it reads every pre-existing row for the instance, so parameter count is unbounded in practice even though a single refresh is capped at `MAX_METADATA_LOOKUPS`.
- Fix mirrors PR #328: read existing ids → diff in memory → delete stale ids in chunks of 500 via `id: { in: chunk }`. No schema change, no behavioural change under normal load.

## What changed
- `apps/api/src/lib/tautulli/tautulli-cache-refresher.ts` — replaced oversized `notIn` DELETE with a local `evictStaleRows()` helper. Same shape as the Plex version but scoped to `prisma.tautulliCache`.
- `apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts` — new test file with four tests: three focused unit tests on `evictStaleRows` plus an end-to-end `refreshTautulliCache` regression.

## Why the helpers are duplicated (not shared)
Evaluated extracting a single `evictStale(model, ...)` shared across both cache subsystems and rejected it for this PR:
- A generic would need either a Prisma model-name generic (awkward type-wise) or a `deleteMany` thunk callback — both cost more reader-minutes than the ~30-line inline helper saves.
- The two cache subsystems are allowed to diverge (e.g. if one ever moves to timestamp-based eviction). A shared abstraction would become a hazard at that point.
- Keeping the diff small and mechanical makes review fast and the safety argument obvious by inspection.

If we add a third cache with the same shape, that's the right time to revisit extraction.

## Test plan
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec vitest run src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts` — 4/4 passing
- [x] `pnpm --filter @arr/api exec vitest run` (full API suite) — 1,283 passed / 36 skipped / 0 failed
- [x] `pnpm --filter @arr/api run lint` — clean for this PR's diff (one pre-existing Biome warning in `auth` unchanged from `main`)
- [x] Unit test: `evictStaleRows` returns 0 and issues no DELETE when nothing is stale
- [x] Unit test: deletes exactly the non-kept ids
- [x] Unit test: chunking contract — 5,000-row wipe stays under SQLite's 999-parameter ceiling, full coverage, no duplicate ids
- [x] End-to-end regression: `refreshTautulliCache` against a realistic large-stale-tail shape (10 fresh upserts + 2,000 pre-existing stale rows — the actual #323 failure mode, where the stale diff is what overflows the parameter limit, not the upsert set) completes with `errors: 0`, issues only bounded `id: { in: chunk }` DELETEs, and wipes the stale tail exactly once
- [x] Structural guard: the mock rejects any `deleteMany` that doesn't use `id: { in: [...] }`, so a future revert to `notIn` fails the tests immediately

## Caveats / deferred
- No broader cache subsystem refactor — see "Why the helpers are duplicated" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)