### PR TITLE
fix(pulse): truthful empty state on refresh error + stable collector-error IDs

### DIFF
--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -55,20 +55,29 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 			return reply.send(cached.data);
 		}
 
-		// Run all collectors in parallel, each wrapped in try/catch
+		// Run all collectors in parallel, each wrapped in try/catch.
+		//
+		// On failure we emit a warning pulse item so the operator knows a signal
+		// is missing — never swallow silently, that's the whole trust model.
+		//
+		// Identify the collector by its function name (e.g. `collectArrSignals`)
+		// so (a) the id is stable across refreshes — React Query and the row
+		// animation see the same item instead of a new one each poll, and (b)
+		// the operator can tell *which* signal is missing from the feed.
 		const collectorResults = await Promise.all(
-			pulseCollectors.map(async (collector) => {
+			pulseCollectors.map(async (collector, index) => {
+				const collectorName = collector.name || `collector-${index}`;
 				try {
 					return await collector(app, userId, request.log);
 				} catch (error) {
-					request.log.warn({ err: error }, "pulse: collector failed");
+					request.log.warn({ err: error, collector: collectorName }, "pulse: collector failed");
 					return [
 						{
-							id: `collector-error-${Date.now()}`,
+							id: `collector-error-${collectorName}`,
 							severity: "warning" as const,
 							category: "health" as const,
 							title: "Could not check some signals",
-							detail: "A pulse collector encountered an error",
+							detail: `The ${collectorName} check encountered an error — results may be incomplete.`,
 							source: "system",
 							timestamp: new Date().toISOString(),
 						},

--- a/apps/web/src/features/pulse/components/pulse-client.tsx
+++ b/apps/web/src/features/pulse/components/pulse-client.tsx
@@ -321,6 +321,13 @@ export const PulseClient: React.FC = () => {
 	const infoItems = data.items.filter((i) => i.severity === "info");
 	const totalItems = data.items.length;
 
+	// When the most recent refresh failed we're looking at a cached snapshot.
+	// A zero-item cached snapshot does NOT mean "healthy right now" — it means
+	// "healthy as of the last successful fetch". Treat that as unknown-state so
+	// the big green "All clear" doesn't overclaim. DataFreshness already shows
+	// "Couldn't refresh · showing last result from N ago" in the header.
+	const canAssertHealthy = !isError;
+
 	return (
 		<div className="space-y-6">
 			{/* Page header */}
@@ -339,7 +346,9 @@ export const PulseClient: React.FC = () => {
 						<div className="flex flex-wrap items-center gap-x-3 gap-y-1">
 							<p className="text-sm text-muted-foreground">
 								{totalItems === 0
-									? "Everything looks good"
+									? canAssertHealthy
+										? "Everything looks good"
+										: "No signals in last successful check"
 									: `${totalItems} signal${totalItems === 1 ? "" : "s"} across your stack`}
 							</p>
 							{/* Pulse polls every 2min — operators otherwise have no way to tell
@@ -361,14 +370,23 @@ export const PulseClient: React.FC = () => {
 				/>
 			</div>
 
-			{/* Empty state */}
-			{totalItems === 0 && (
-				<PremiumEmptyState
-					icon={CheckCircle2}
-					title="All clear"
-					description="No issues detected across your connected services. Everything is running smoothly."
-				/>
-			)}
+			{/* Empty state — only claim "all clear" when the refresh actually succeeded.
+			    On a failed refresh we still render the card (so the freshness badge in the
+			    header stays anchored) but swap the copy so we don't overclaim health. */}
+			{totalItems === 0 &&
+				(canAssertHealthy ? (
+					<PremiumEmptyState
+						icon={CheckCircle2}
+						title="All clear"
+						description="No issues detected across your connected services. Everything is running smoothly."
+					/>
+				) : (
+					<PremiumEmptyState
+						icon={AlertTriangle}
+						title="Couldn't refresh signals"
+						description="Showing the last successful check, which found no issues. Current status is unknown until the next refresh succeeds."
+					/>
+				))}
 
 			{/* Severity sections */}
 			<div className="space-y-4">


### PR DESCRIPTION
## Summary

Final pre-release trust hardening for System Pulse. Two changes, no new abstractions, no new endpoints, no redesign.

- **Frontend — don't claim healthy when we can't refresh.** When the current refresh failed but we still have cached data, `pulse-client.tsx` no longer shows "Everything looks good" (subtitle) or the big ✅ "All clear · Everything running smoothly" empty state. Instead it reads "No signals in last successful check" + an `AlertTriangle` card saying "Current status is unknown until the next refresh succeeds." The `DataFreshness` badge in the header continues to show "Couldn't refresh · showing last result from N ago" for precise timing.
- **Backend — stable, named collector-error IDs.** In `routes/pulse.ts` the fallback pulse item emitted when a collector throws now uses `collector-error-${collector.name}` as its ID (previously `${Date.now()}` — a different id every 2-min poll, which re-ran the row animation and made persistent failures look like new ones each tick). The detail string and pino log entry also name the failing collector so operators can act.

## Why this matters

Pulse is the operator's system-health dashboard. A zero-signal UI on top of stale cached data that cannot currently be refreshed is the exact kind of confident-looking lie the freshness work was meant to eliminate. The `DataFreshness` component already reported the truth in small text — the primary header copy was overruling it. This PR makes the big text agree with the small text.

## Files changed

- `apps/web/src/features/pulse/components/pulse-client.tsx`
- `apps/api/src/routes/pulse.ts`

## Intentionally NOT changed

- `PulseClient` keeps its bespoke loading skeleton rather than adopting `AsyncStateView`. Pulse deliberately keeps rendering cached data on refetch error (see inline comment at the `if (!data)` branch), which is the opposite of `AsyncStateView`'s replace-on-error behavior. Swapping it in would regress trust, not improve it.
- Per-collector internal error items (e.g. `arr-unreachable-${instance.id}`) — already critical-severity, stable-ID, visible. No change.
- Cache TTL, polling cadence, severity ordering — out of scope.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api run test` — 1283 passed / 36 skipped / 0 failed
- [x] `biome check` on both files — clean
- [x] Manual: load `/pulse` with no issues, confirm "All clear" still appears on fresh success — verified via Playwright; both real 13-item load and cache-seeded empty-success render correctly (subtitle "Everything looks good" / `CheckCircle2` "All clear")
- [x] Manual: stop the API while `/pulse` is open, confirm empty-state copy switches to "Couldn't refresh signals" and `DataFreshness` shows "Couldn't refresh · showing last result from N ago" — verified by forcing `refetchQueries({ throwOnError: true })` with a `fetch` patch returning HTTP 500; subtitle, `AlertTriangle` empty state, and amber freshness badge all swapped in unison
- [x] Manual: temporarily force one collector to throw, confirm the pulse item ID stays identical across refreshes and the detail names the collector — injected throw in `collectCleanupOpportunities`, observed ID `collector-error-collectCleanupOpportunities` stable across fetches and detail naming the failing collector; injected change reverted

Full test-plan results with screenshots posted as a PR comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)