### PR TITLE
chore(release): v2.15.0 — operability, trust, cache hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,59 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.0] - 2026-04-14
+
+Operability and trust release — a scheduler jobs surface for operators, a Security Posture diagnostic panel, route surface governance, shared UX primitives for consistent trust signals across panels, and targeted cache-refresh hardening for Plex and Tautulli. No new end-user feature modules; every change is aimed at making the existing app more legible, more trustworthy, and easier to ship.
+
+### Added
+
+#### Reliability & Observability
+- **Scheduler jobs surface** — New `SchedulerRegistry` centralizes every background job (session snapshot, Plex/Tautulli/Jellyfin cache refresh, hunt, cleaner, TRaSH sync, backups, notifications, etc.) behind a single `/api/system/jobs` operability surface. Operators can inspect last run, next run, last error, and failure isolation per job (#294, #295)
+- **Explicit scheduler init failure-handling policy** — New `runSchedulerInit` helper makes scheduler startup failures a deliberate, testable decision per job rather than silent boot-time drift. Pinned by tests that lock the init-failure operator surface (#319)
+- **Session-snapshot tick isolation** — A failure in one snapshot collector no longer short-circuits the remaining collectors in the same tick (#303)
+- **Integration test coverage** — Risk-based integration tests cover auth, services, scheduler, queue cleaner, and route auth / service lifecycle gaps — reducing the chance a regression in these critical paths ships unnoticed (#315, #316)
+
+#### Security & Trust
+- **Security Posture panel** — New diagnostic surface under System → Security Posture flags configuration that weakens the deployment (missing `SESSION_COOKIE_SECRET`, weak `ENCRYPTION_KEY`, lax cookie flags, etc.). Advisory only; nothing is auto-changed. Distinguishes true misconfiguration from opinionated hardening to avoid false alarms (#317)
+- **Route surface governance** — Lightweight manifest-driven tier system (`stable` / `operator` / `internal` / `experimental`) classifies every backend route and is enforced in tests. Documented in ADR-0004 (#320)
+
+#### UX Consistency
+- **Shared async state presentation** — New `AsyncStateView` primitive standardizes loading / error / empty states across data panels so operators see the same shapes and wording for the same states everywhere (#321, #326)
+- **Domain status badges** — Shared `DomainStatusBadge` + 5-state taxonomy (healthy / degraded / offline / configured / disabled) replaces ad-hoc badge variants across Services and Integrations (#324)
+- **Data freshness indicator** — Shared `<DataFreshness>` + `describeFreshness()` wired into Pulse, Queue Cleaner, and Validation Health, driven by a scoped ticker so every polling panel reports age consistently (#325)
+
+#### Contributor Experience
+- **Domain operating manuals + ADRs** — New per-domain operating manuals plus ADRs covering security posture and route auth, giving contributors and operators a durable reference beyond code comments (#318)
+
+### Fixed
+
+#### Cache Refresh Hardening
+- **Plex stale-cache eviction hits Prisma parameter limit** — Bulk stale-cache evictions are now chunked, eliminating sporadic SQLite `P2029` "too many bind variables" failures on larger libraries (#323, #328)
+- **Tautulli stale-cache eviction hits Prisma parameter limit** — Same chunking fix applied to the Tautulli eviction path (#329)
+
+#### Pulse Trust
+- **Truthful empty state on refresh error** — Pulse no longer shows a misleadingly-clean "all healthy" view after a failed refresh; collector errors now produce a stable, visible failure state with consistent collector-error IDs (#330)
+- **Truthful errors + domain-correct tooltips** — Trust surfaces (Pulse, Validation Health, Rules) now surface real error text instead of generic placeholders, and tooltips describe the domain rather than the underlying transport (#327)
+
+#### Service Integrations
+- **Lidarr falsely reported unreachable in System Pulse** — Reachability probe now matches Lidarr's response shape (#300, #307)
+- **Seerr notification agent types** — Default to `0` when absent rather than erroring out on the requests page (#309)
+- **Tautulli activity fields** — Default to empty values when absent rather than breaking the activity view (#302, #310)
+- **Jellyfin/Emby partial-watch enrichment** — Populate `lastWatchedAt` for partially-watched series instead of leaving the field null (#311)
+- **Jellyfin cleanup rule copy** — Corrected rule description and backfilled the missing Jellyfin test (#314)
+- **Queue instance links use `externalUrl`** — Queue item links now respect the configured external URL per instance (#297, #306)
+- **Service type buttons overflow in narrow panels** — Settings service-type selector now wraps cleanly in narrow layouts (#291, #305)
+
+### Changed
+
+#### Architecture
+- **Plugin/route registration extracted into domain bundles** — `server.ts` now composes domain bundles rather than inlining every `register()` call, making the startup surface easier to audit and extend (#293)
+- **Library watch enrichment extended to Jellyfin/Emby** — Watch state enrichment (now-playing, last-watched, episode completion) parity across Plex / Jellyfin / Emby (#304)
+
+#### Tooling
+- **pnpm 10.33.0** — Bumped and guarded `action-setup` major bumps in CI (#312)
+- **Dependency updates** — Production-dependencies group (17 updates, #298) and dev-dependencies group (3 updates, #299), plus a follow-up production group bump (#313)
+
 ## [2.14.0] - 2026-04-09
 
 Media server expansion and setup experience overhaul — full Jellyfin and Emby support with Plex feature parity, OAuth-assisted setup for Plex and Seerr, notification quiet hours, TRaSH Custom Format conflict detection, and a host of UX refinements.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.14.0 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.15.0 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.14.0** — Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours
+> **Version 2.15.0** — Operability & trust: scheduler jobs surface, security posture diagnostics, route governance, shared UX primitives, cache refresh hardening
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -93,6 +93,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.15.0` | Scheduler jobs surface, Security Posture, route governance, shared UX primitives, Plex/Tautulli cache hardening |
 | `2.14.0` | Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours |
 | `2.13.0` | Codebase hardening, TypeScript 6, security audit, CI optimization |
 | `2.12.0` | Seerr Requests Experience, API stability, security sweep |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.14.0** — Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours
+> **Version 2.15.0** — Operability & trust: scheduler jobs surface, security posture diagnostics, route governance, shared UX primitives, cache refresh hardening
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -210,6 +210,7 @@ docker-compose up -d
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.15.0` | Scheduler jobs surface, Security Posture, route governance, shared UX primitives, Plex/Tautulli cache hardening |
 | `2.14.0` | Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours |
 | `2.13.0` | Codebase hardening, TypeScript 6, security audit, CI optimization |
 | `2.12.0` | Seerr Requests Experience, API stability, security sweep |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arr-dashboard-platform",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
## Summary

Release prep for **v2.15.0**. Docs + version metadata only — no code changes.

- Bump root `package.json` 2.14.0 → 2.15.0
- Add 2.15.0 entry to `CHANGELOG.md`, organized by theme (not by PR)
- Update version tagline + tag table in `README.md` and `DOCKERHUB.md`
- Update `CLAUDE.md` footer version
- Wiki version bump (`Home.md`, `Troubleshooting.md`) pushed separately to `arr-dashboard.wiki.git` (commit `57c4e28`)

## Version choice — minor, not patch

2.14.0 → 2.15.0. The window since 2.14.0 includes substantial new operator-visible surfaces, not just fixes:

- `SchedulerRegistry` + `/api/system/jobs` operability surface (#294, #295)
- Security Posture diagnostic panel (#317)
- Route surface governance manifest + ADR-0004 (#320)
- Shared UX primitives: `AsyncStateView` (#321, #326), `DomainStatusBadge` (#324), `DataFreshness` (#325)
- Explicit scheduler init failure-handling policy (#319)
- Domain operating manuals + ADRs (#318)

Plus the bugfix tail (Plex/Tautulli cache chunking, Pulse trust, Lidarr reachability, Seerr/Tautulli/Jellyfin field defaults, queue links).

## Release notes themes

- **Reliability / observability** — jobs registry, init policy, snapshot isolation, integration tests
- **Security / trust** — Security Posture, route governance, Pulse truthfulness
- **UX consistency** — shared async / status / freshness primitives
- **Cache refresh hardening** — Plex + Tautulli chunked eviction (SQLite P2029 fix)
- **Contributor / architecture** — domain bundles, operating manuals, ADRs

## Commit coverage

Audited every commit from `v2.14.0..HEAD` (31 commits) against the CHANGELOG:

- **30/31** mapped to explicit CHANGELOG entries.
- **1 intentionally omitted:** #292 (`fix(api): build shared package before API test run`) — CI/test-ordering fix, no user or operator visibility, omitted per Keep-a-Changelog convention. Can be added under Tooling on request.

## Smoke-risk / operator-visible changes to call out

Nothing blocking, but worth a heads-up in the release notes (already reflected in CHANGELOG wording):

- **Pulse truthfulness change** — after a failed refresh, Pulse will now show a visible failure state instead of the previous (misleading) clean "all healthy" look. Operators used to the old state may briefly perceive this as a regression. It is intentional.
- **Domain status badges** — badge wording/colour across Services and Integrations now follows the 5-state taxonomy (healthy / degraded / offline / configured / disabled). Same underlying states, more uniform presentation.
- **Data freshness indicator** — Pulse, Queue Cleaner, and Validation Health now display a uniform "updated Xs ago" indicator. Cosmetic; no behaviour change.
- **Security Posture panel** — new diagnostic surface. Advisory only — does not auto-remediate or block anything.

## Intentionally deferred to post-merge

- **Tag `v2.15.0`** and push the tag (triggers Docker image build for the `2.15.0` tag). Requires maintainer action after this PR merges.
- No code refactors, no dependency bumps beyond what already landed, no new features.

## Test plan

- [x] **CI green on this branch** — Lint/Type/Test, Docker Build, Build Image, CodeQL, Semgrep, SQLite + PostgreSQL smoke tests all passed on both workflow runs. E2E 1/3 + 3/3 green on both runs. E2E 2/3 green on run [`24407608819`](https://github.com/Kha-kis/arr-dashboard/actions/runs/24407608819) (3m46s); flaked on the twin run [`24407630806`](https://github.com/Kha-kis/arr-dashboard/actions/runs/24407630806) at the `Install Playwright System Dependencies` step (hit the 10m job timeout before tests started). Runner-environment flake, not a code regression — no plausible causal path from a markdown-only diff to a Playwright apt-install timeout.
- [x] **Manual eyeball of rendered CHANGELOG section** — `## [2.15.0] - 2026-04-14` heading renders correctly above the prior 2.14.0 section; themed sub-sections render cleanly.
- [x] **README / DOCKERHUB version tables render correctly** — Both taglines render as `Version 2.15.0 — Operability & trust…`. Tag tables show 2.15.0 as the first row above 2.14.0 with aligned pipes.
- [x] **Local typecheck** — `pnpm --filter @arr/web exec tsc --noEmit` and `pnpm --filter @arr/api exec tsc --noEmit` both pass with no output.
- [x] **Wiki version bump pushed** — `Home.md` Current Version and `Troubleshooting.md` issue-template example now show 2.15.0 (commit `57c4e28` on `arr-dashboard.wiki.git`).
- [ ] **Post-merge: tag `v2.15.0`, push tag, Docker image build** — deferred to post-merge; requires maintainer action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)