### PR TITLE
fix(pulse): operator-friendly labels in collector failure detail

### DIFF
--- a/apps/api/src/routes/__tests__/pulse-collector-error.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-collector-error.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Integration test for the Pulse collector-failure surface.
+ *
+ * Boots Fastify with the real `/pulse` route, swaps in a throwing collector,
+ * and asserts the end-to-end operator-visible `detail` string — replaces the
+ * manual "throw inside a collector and eyeball the UI" check from the PR
+ * test plan with automated coverage.
+ */
+
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Swap the collectors module BEFORE the route imports it. One collector
+// throws (to force the failure branch), one succeeds (to confirm partial
+// results still flow through).
+vi.mock("../../lib/pulse/collectors.js", () => {
+	async function collectArrSignals() {
+		throw new Error("boom — simulated ARR fetch failure");
+	}
+	async function collectCacheStaleness() {
+		return [];
+	}
+	return { pulseCollectors: [collectArrSignals, collectCacheStaleness] };
+});
+
+import { registerPulseRoutes } from "../pulse.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("GET /pulse — collector failure detail wording", () => {
+	it("renders the operator-friendly label, not the raw function name", async () => {
+		const res = await injectAuthenticated("GET", "/pulse");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		const errorItem = body.items.find((i: { id: string }) =>
+			i.id.startsWith("collector-error-"),
+		);
+
+		expect(errorItem).toBeDefined();
+
+		// The id still keys off the function name — #330's stability contract.
+		expect(errorItem.id).toBe("collector-error-collectArrSignals");
+
+		// But the operator-visible copy must not leak the function name.
+		expect(errorItem.detail).toBe(
+			"The ARR health and disk space check encountered an error — results may be incomplete.",
+		);
+		expect(errorItem.detail).not.toContain("collectArrSignals");
+		expect(errorItem.title).toBe("Could not check some signals");
+		expect(errorItem.severity).toBe("warning");
+
+		// Summary still counts it as a warning — partial-failure trust model.
+		expect(body.summary.warning).toBeGreaterThanOrEqual(1);
+	});
+});

--- a/apps/api/src/routes/__tests__/pulse-collector-label.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-collector-label.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Regression test for v2.15.1 — operator-facing Pulse collector error
+ * messages must not leak internal function names like `collectArrSignals`.
+ *
+ * `labelForCollector` is the pure helper that translates a collector's
+ * function name into plain-English copy for the failure `detail` string.
+ */
+
+import { describe, expect, it } from "vitest";
+import { labelForCollector } from "../pulse.js";
+
+describe("labelForCollector", () => {
+	it("returns the operator label for every known collector", () => {
+		const knownPairs: Array<[string, string]> = [
+			["collectArrSignals", "ARR health and disk space"],
+			["collectSeerrCircuitBreaker", "Seerr circuit breaker"],
+			["collectCacheStaleness", "cache freshness"],
+			["collectValidationHealth", "validation health"],
+			["collectLibraryInsightCounts", "library insights"],
+			["collectHuntFailures", "hunt failures"],
+			["collectQueueCleanerFailures", "queue cleaner"],
+			["collectTrashSyncFailures", "TRaSH sync"],
+			["collectCleanupOpportunities", "cleanup opportunities"],
+		];
+
+		for (const [name, expected] of knownPairs) {
+			expect(labelForCollector(name)).toBe(expected);
+		}
+	});
+
+	it("humanizes unknown camelCase names instead of leaking them", () => {
+		// A future collector that wasn't added to the label map still gets
+		// a readable label — the operator copy never contains raw source names.
+		expect(labelForCollector("collectFooBar")).toBe("foo bar");
+		expect(labelForCollector("collectSomethingNew")).toBe("something new");
+	});
+
+	it("falls back to a safe label when the function name is empty", () => {
+		// Defensive: `collector.name` can be empty for anonymous functions.
+		// We still must not render an empty sentence fragment.
+		expect(labelForCollector("")).toBe("signal");
+	});
+});

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -32,6 +32,38 @@ const SEVERITY_ORDER: Record<string, number> = {
 	info: 2,
 };
 
+// ============================================================================
+// Operator-friendly labels for collector failures
+// ============================================================================
+//
+// The collector's function name (e.g. `collectArrSignals`) is used to build a
+// stable id so React Query / row animations see the same failure item across
+// refreshes. That name is jargon to operators, so we translate it to a plain
+// label for the visible `detail` string. Unknown names fall back to a
+// humanized camelCase form so a future collector never leaks raw source names.
+const COLLECTOR_LABELS: Record<string, string> = {
+	collectArrSignals: "ARR health and disk space",
+	collectSeerrCircuitBreaker: "Seerr circuit breaker",
+	collectCacheStaleness: "cache freshness",
+	collectValidationHealth: "validation health",
+	collectLibraryInsightCounts: "library insights",
+	collectHuntFailures: "hunt failures",
+	collectQueueCleanerFailures: "queue cleaner",
+	collectTrashSyncFailures: "TRaSH sync",
+	collectCleanupOpportunities: "cleanup opportunities",
+};
+
+export function labelForCollector(name: string): string {
+	const known = COLLECTOR_LABELS[name];
+	if (known) return known;
+	const humanized = name
+		.replace(/^collect/, "")
+		.replace(/([A-Z])/g, " $1")
+		.trim()
+		.toLowerCase();
+	return humanized || "signal";
+}
+
 function sortPulseItems(items: PulseItem[]): PulseItem[] {
 	return items.sort((a, b) => {
 		const severityDiff = (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9);
@@ -77,7 +109,7 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 							severity: "warning" as const,
 							category: "health" as const,
 							title: "Could not check some signals",
-							detail: `The ${collectorName} check encountered an error — results may be incomplete.`,
+							detail: `The ${labelForCollector(collectorName)} check encountered an error — results may be incomplete.`,
 							source: "system",
 							timestamp: new Date().toISOString(),
 						},


### PR DESCRIPTION
## Summary
- Replaces internal collector function names (e.g. `collectArrSignals`) with operator-friendly labels in the Pulse collector-failure `detail` copy.
- Preserves the stable `collector-error-${collectorName}` id introduced in #330, so row animations and React Query keys are unchanged.
- Adds a small camelCase-humanize fallback so future collectors can never leak raw source names even if their label isn't registered yet.

### Wording change

Before:
> The collectArrSignals check encountered an error — results may be incomplete.

After:
> The ARR health and disk space check encountered an error — results may be incomplete.

Full label map: `ARR health and disk space`, `Seerr circuit breaker`, `cache freshness`, `validation health`, `library insights`, `hunt failures`, `queue cleaner`, `TRaSH sync`, `cleanup opportunities`.

## Why
Closes a small trust/clarity gap from #330 — that PR intentionally surfaces collector failures as visible pulse items, but the copy was still templated off the JS function name, which reads as jargon to operators. Patch-sized follow-up for v2.15.1.

## Scope discipline
- One file of production change (`apps/api/src/routes/pulse.ts`).
- No id/shape changes, no new modules, no refactors.
- Label map colocated with the only call site — not extracted.

## Test plan
- [x] Unit test `apps/api/src/routes/__tests__/pulse-collector-label.test.ts` — covers all 9 known collector labels, camelCase fallback, and empty-name safe fallback.
- [x] Integration test `apps/api/src/routes/__tests__/pulse-collector-error.test.ts` — boots Fastify with the real `/pulse` route, injects a throwing collector, asserts end-to-end:
  - Response status 200 (partial-failure doesn't break the feed)
  - Stable id `collector-error-collectArrSignals` (preserves #330 contract)
  - Full detail string: `"The ARR health and disk space check encountered an error — results may be incomplete."`
  - Negative assertion: detail does NOT contain `collectArrSignals`
  - Summary still counts the failure as a warning
- [x] `pnpm --filter @arr/api exec tsc --noEmit` clean
- [x] Full api suite: 1287 passing / 36 skipped, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)