### PR TITLE
feat(pulse): surface disabled + failing scheduler jobs

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for collectSchedulerHealth pulse collector.
+ *
+ * V2.16.0 "Needs Attention" — PR 1: reuses the scheduler registry as a pulse
+ * signal so jobs that are disabled with a reason, or failing repeatedly,
+ * surface alongside existing attention items.
+ *
+ * Rules under test:
+ *   - Healthy / idle jobs emit nothing.
+ *   - Jobs with consecutiveFailures >= 2 emit a warning item.
+ *   - Jobs disabled with a reason emit a warning item.
+ *   - Disabled + failing emits only the disabled item (no duplicate).
+ *   - Disabled without a reason emits nothing (defensive — don't invent copy).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
+import type { JobStatus } from "../../scheduler-registry/scheduler-registry.js";
+import { collectSchedulerHealth } from "../collectors.js";
+
+const noop = vi.fn();
+const mockLog = {
+	warn: noop,
+	error: noop,
+	info: noop,
+	debug: noop,
+	trace: noop,
+	fatal: noop,
+	child: () => mockLog,
+} as unknown as FastifyBaseLogger;
+
+function makeJob(overrides: Partial<JobStatus> = {}): JobStatus {
+	return {
+		id: "example-job",
+		label: "Example Job",
+		description: "An example job",
+		concurrency: "singleton",
+		state: "idle",
+		lastStartedAt: null,
+		lastFinishedAt: null,
+		lastSuccessAt: null,
+		lastFailureAt: null,
+		lastDurationMs: null,
+		lastError: null,
+		consecutiveFailures: 0,
+		totalRuns: 0,
+		totalFailures: 0,
+		disabled: false,
+		disabledReason: null,
+		...overrides,
+	};
+}
+
+function makeApp(jobs: JobStatus[]): FastifyInstance {
+	return {
+		schedulerRegistry: { list: () => jobs },
+	} as unknown as FastifyInstance;
+}
+
+describe("collectSchedulerHealth — healthy jobs", () => {
+	it("emits nothing when the registry is empty", async () => {
+		const items = await collectSchedulerHealth(makeApp([]), "user-1", mockLog);
+		expect(items).toEqual([]);
+	});
+
+	it("does not emit items for idle, healthy jobs", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({ id: "backup", label: "Backup" }),
+				makeJob({ id: "library-sync", label: "Library Sync", totalRuns: 42 }),
+			]),
+			"user-1",
+			mockLog,
+		);
+		expect(items).toEqual([]);
+	});
+
+	it("does not emit an item for a single isolated failure (< threshold)", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "hunting",
+					label: "Hunting",
+					consecutiveFailures: 1,
+					lastError: "timeout",
+					lastFailureAt: "2026-04-14T10:00:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+		expect(items).toEqual([]);
+	});
+
+	it("does not emit an item for a running job without failure history", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "library-sync",
+					label: "Library Sync",
+					state: "running",
+					lastStartedAt: "2026-04-14T10:00:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+		expect(items).toEqual([]);
+	});
+});
+
+describe("collectSchedulerHealth — failing jobs", () => {
+	it("emits a warning when consecutiveFailures reaches 2", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "queue-cleaner",
+					label: "Queue Cleaner",
+					consecutiveFailures: 2,
+					lastError: "ECONNREFUSED",
+					lastFailureAt: "2026-04-14T09:30:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0]).toMatchObject({
+			id: "scheduler-failing-queue-cleaner",
+			severity: "warning",
+			category: "operations",
+			title: "Queue Cleaner is failing",
+			source: "system",
+			actionUrl: "/settings",
+			timestamp: "2026-04-14T09:30:00.000Z",
+		});
+		expect(items[0]!.detail).toContain("2 consecutive failures");
+		expect(items[0]!.detail).toContain("ECONNREFUSED");
+	});
+
+	it("includes the failure count in the detail line even without lastError", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "trash-sync",
+					label: "TRaSH Sync",
+					consecutiveFailures: 5,
+					lastError: null,
+					lastFailureAt: "2026-04-14T09:30:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0]!.detail).toBe("5 consecutive failures");
+	});
+
+	it("uses lastFailureAt as the timestamp when available", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "hunting",
+					label: "Hunting",
+					consecutiveFailures: 3,
+					lastFailureAt: "2026-04-14T08:00:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items[0]!.timestamp).toBe("2026-04-14T08:00:00.000Z");
+	});
+
+	it("truncates very long lastError messages in the detail line", async () => {
+		const longError = "x".repeat(500);
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "backup",
+					label: "Backup",
+					consecutiveFailures: 2,
+					lastError: longError,
+					lastFailureAt: "2026-04-14T09:30:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items[0]!.detail.length).toBeLessThanOrEqual(140);
+		expect(items[0]!.detail.endsWith("…")).toBe(true);
+	});
+});
+
+describe("collectSchedulerHealth — disabled jobs", () => {
+	it("emits a warning when a job is disabled with a reason", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "hunting",
+					label: "Hunting",
+					state: "disabled",
+					disabled: true,
+					disabledReason: "Init failed: cannot reach hunting config table",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0]).toMatchObject({
+			id: "scheduler-disabled-hunting",
+			severity: "warning",
+			category: "operations",
+			title: "Hunting is disabled",
+			detail: "Init failed: cannot reach hunting config table",
+			source: "system",
+			actionUrl: "/settings",
+		});
+	});
+
+	it("does NOT emit a separate failing item when a job is both disabled and failing", async () => {
+		// Disabled is the root cause; showing both would be duplicate noise.
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "queue-cleaner",
+					label: "Queue Cleaner",
+					state: "disabled",
+					disabled: true,
+					disabledReason: "Init failed: schema mismatch",
+					consecutiveFailures: 7,
+					lastError: "schema mismatch",
+					lastFailureAt: "2026-04-14T09:30:00.000Z",
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0]!.id).toBe("scheduler-disabled-queue-cleaner");
+	});
+
+	it("does not emit anything when a job is disabled without a reason", async () => {
+		// Defensive — don't invent operator-facing copy we can't substantiate.
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({
+					id: "example",
+					label: "Example",
+					state: "disabled",
+					disabled: true,
+					disabledReason: null,
+				}),
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		expect(items).toEqual([]);
+	});
+});
+
+describe("collectSchedulerHealth — mixed registry", () => {
+	it("emits items only for the jobs that need attention", async () => {
+		const items = await collectSchedulerHealth(
+			makeApp([
+				makeJob({ id: "backup", label: "Backup" }), // healthy
+				makeJob({
+					id: "hunting",
+					label: "Hunting",
+					consecutiveFailures: 3,
+					lastError: "boom",
+					lastFailureAt: "2026-04-14T09:00:00.000Z",
+				}),
+				makeJob({
+					id: "queue-cleaner",
+					label: "Queue Cleaner",
+					state: "disabled",
+					disabled: true,
+					disabledReason: "Init failed: bad config",
+				}),
+				makeJob({ id: "trash-sync", label: "TRaSH Sync", consecutiveFailures: 1 }), // under threshold
+			]),
+			"user-1",
+			mockLog,
+		);
+
+		const ids = items.map((i) => i.id).sort();
+		expect(ids).toEqual(["scheduler-disabled-queue-cleaner", "scheduler-failing-hunting"]);
+	});
+});

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -483,7 +483,81 @@ const collectTrashSyncFailures: Collector = async (app, userId) => {
 };
 
 // ============================================================================
-// 9. Cleanup Opportunities
+// 10. Scheduler Health
+// ============================================================================
+//
+// Surfaces background jobs that genuinely need operator attention.
+//
+// Two rules:
+//   - `disabled: true` with a non-empty `disabledReason` → warning. Today the
+//     registry only receives `markDisabled(...)` from real failure paths
+//     (`runSchedulerInit` prefix "Init failed: ..." or legacy plugin catches),
+//     so a disabled job is always an actionable problem. If future code ever
+//     introduces an intentional-opt-out `markDisabled`, this rule needs to
+//     learn to distinguish intent — today it cannot, and pretending otherwise
+//     would overclaim.
+//   - `consecutiveFailures >= 2` → warning. A single failure may be a
+//     transient blip (network hiccup, momentary ARR restart); two in a row
+//     is a pattern worth surfacing.
+//
+// When a job is both disabled and failing, we emit only the disabled item —
+// it's the root cause; showing both would be duplicate noise.
+//
+// Healthy / idle jobs emit nothing. Severity stays at `warning`: the registry
+// does not track whether a job is operationally critical vs nice-to-have, so
+// escalating to `critical` would invent intent the data cannot support.
+
+const FAILING_THRESHOLD = 2;
+const DETAIL_MAX_LENGTH = 140;
+
+function truncate(text: string, max = DETAIL_MAX_LENGTH): string {
+	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+const collectSchedulerHealth: Collector = async (app) => {
+	const jobs = app.schedulerRegistry.list();
+	const items: PulseItem[] = [];
+
+	for (const job of jobs) {
+		// Rule 1: disabled with a meaningful reason takes precedence.
+		if (job.disabled) {
+			if (!job.disabledReason) continue; // Defensive: no reason → nothing actionable to say.
+			items.push({
+				id: `scheduler-disabled-${job.id}`,
+				severity: "warning",
+				category: "operations",
+				title: `${job.label} is disabled`,
+				detail: truncate(job.disabledReason),
+				actionUrl: "/settings",
+				actionLabel: "View system",
+				source: "system",
+				timestamp: job.lastFailureAt ?? now(),
+			});
+			continue;
+		}
+
+		// Rule 2: repeated recent failures.
+		if (job.consecutiveFailures >= FAILING_THRESHOLD) {
+			const errorHint = job.lastError ? ` — last error: ${job.lastError}` : "";
+			items.push({
+				id: `scheduler-failing-${job.id}`,
+				severity: "warning",
+				category: "operations",
+				title: `${job.label} is failing`,
+				detail: truncate(`${job.consecutiveFailures} consecutive failures${errorHint}`),
+				actionUrl: "/settings",
+				actionLabel: "View system",
+				source: "system",
+				timestamp: job.lastFailureAt ?? now(),
+			});
+		}
+	}
+
+	return items;
+};
+
+// ============================================================================
+// 11. Cleanup Opportunities
 // ============================================================================
 
 const collectCleanupOpportunities: Collector = async (app, userId, _log) => {
@@ -577,7 +651,7 @@ function formatBytes(bytes: number): string {
 // ============================================================================
 
 // Exported for testing
-export { collectArrSignals };
+export { collectArrSignals, collectSchedulerHealth };
 
 export const pulseCollectors: Collector[] = [
 	collectArrSignals,
@@ -588,5 +662,6 @@ export const pulseCollectors: Collector[] = [
 	collectHuntFailures,
 	collectQueueCleanerFailures,
 	collectTrashSyncFailures,
+	collectSchedulerHealth,
 	collectCleanupOpportunities,
 ];

--- a/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Integration test for scheduler-health pulse signals on GET /pulse.
+ *
+ * Converts the PR #333 manual test-plan items into automated coverage:
+ *   1. A job disabled with a reason emits `scheduler-disabled-<jobId>`
+ *      in the /pulse response.
+ *   2. A job with consecutiveFailures >= 2 emits
+ *      `scheduler-failing-<jobId>` in the /pulse response.
+ *
+ * We boot Fastify with the real `/pulse` route and the real
+ * `collectSchedulerHealth` collector, stubbing only
+ * `app.schedulerRegistry.list()` so we can drive the two failure
+ * scenarios deterministically without spinning up real schedulers.
+ */
+
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JobStatus } from "../../lib/scheduler-registry/scheduler-registry.js";
+
+// Swap the collectors module to expose ONLY the real collectSchedulerHealth
+// collector. This keeps the route contract honest (we're running the actual
+// function under test) while isolating us from the other collectors' DB
+// dependencies.
+vi.mock("../../lib/pulse/collectors.js", async () => {
+	const actual =
+		await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
+			"../../lib/pulse/collectors.js",
+		);
+	return { pulseCollectors: [actual.collectSchedulerHealth] };
+});
+
+import { registerPulseRoutes } from "../pulse.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let jobs: JobStatus[];
+
+// The pulse route caches responses in a module-level Map keyed by userId for
+// 60 seconds. Each test uses a unique user so results are not served from
+// another test's cache entry.
+let userCounter = 0;
+
+function makeJob(overrides: Partial<JobStatus> = {}): JobStatus {
+	return {
+		id: "example-job",
+		label: "Example Job",
+		description: "",
+		concurrency: "singleton",
+		state: "idle",
+		lastStartedAt: null,
+		lastFinishedAt: null,
+		lastSuccessAt: null,
+		lastFailureAt: null,
+		lastDurationMs: null,
+		lastError: null,
+		consecutiveFailures: 0,
+		totalRuns: 0,
+		totalFailures: 0,
+		disabled: false,
+		disabledReason: null,
+		...overrides,
+	};
+}
+
+beforeEach(async () => {
+	userCounter += 1;
+	app = Fastify({ logger: false });
+	setupAuthInjection(app, { id: `user-sched-${userCounter}`, username: "admin" });
+	// Stub only the registry surface the collector reads. No other plugin
+	// decorations are required — the collector does not touch Prisma or
+	// the ARR client factory.
+	app.decorate("schedulerRegistry", {
+		list: () => jobs,
+	} as unknown as never);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("GET /pulse — scheduler health signals", () => {
+	it("surfaces a disabled scheduler as scheduler-disabled-<jobId>", async () => {
+		jobs = [
+			makeJob({
+				id: "hunting",
+				label: "Hunting",
+				state: "disabled",
+				disabled: true,
+				disabledReason: "Init failed: cannot reach hunting config table",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		const item = body.items.find(
+			(i: { id: string }) => i.id === "scheduler-disabled-hunting",
+		);
+
+		expect(item).toBeDefined();
+		expect(item.severity).toBe("warning");
+		expect(item.category).toBe("operations");
+		expect(item.title).toBe("Hunting is disabled");
+		expect(item.detail).toContain("Init failed");
+		expect(item.source).toBe("system");
+		expect(item.actionUrl).toBe("/settings");
+
+		expect(body.summary.warning).toBeGreaterThanOrEqual(1);
+	});
+
+	it("surfaces two consecutive tick failures as scheduler-failing-<jobId>", async () => {
+		jobs = [
+			makeJob({
+				id: "queue-cleaner",
+				label: "Queue Cleaner",
+				consecutiveFailures: 2,
+				lastError: "ECONNREFUSED",
+				lastFailureAt: "2026-04-14T09:30:00.000Z",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		const item = body.items.find(
+			(i: { id: string }) => i.id === "scheduler-failing-queue-cleaner",
+		);
+
+		expect(item).toBeDefined();
+		expect(item.severity).toBe("warning");
+		expect(item.category).toBe("operations");
+		expect(item.title).toBe("Queue Cleaner is failing");
+		expect(item.detail).toContain("2 consecutive failures");
+		expect(item.detail).toContain("ECONNREFUSED");
+		expect(item.timestamp).toBe("2026-04-14T09:30:00.000Z");
+
+		expect(body.summary.warning).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not surface a scheduler item when all jobs are healthy", async () => {
+		jobs = [
+			makeJob({ id: "backup", label: "Backup", totalRuns: 42 }),
+			makeJob({ id: "library-sync", label: "Library Sync" }),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		const schedulerItems = body.items.filter((i: { id: string }) =>
+			i.id.startsWith("scheduler-"),
+		);
+
+		expect(schedulerItems).toEqual([]);
+		expect(body.summary.critical + body.summary.warning).toBe(0);
+	});
+});

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -50,6 +50,7 @@ const COLLECTOR_LABELS: Record<string, string> = {
 	collectHuntFailures: "hunt failures",
 	collectQueueCleanerFailures: "queue cleaner",
 	collectTrashSyncFailures: "TRaSH sync",
+	collectSchedulerHealth: "scheduler health",
 	collectCleanupOpportunities: "cleanup opportunities",
 };
 


### PR DESCRIPTION
## Summary

First PR of the 2.16.0 **"Needs Attention"** track. Adds a new Pulse collector (`collectSchedulerHealth`) that reuses `app.schedulerRegistry.list()` so scheduler jobs needing operator attention surface in the existing Pulse feed — instead of being visible only via `/api/system/jobs`. No new endpoints, no UI changes, no schema changes.

This is pure signal plumbing. Dashboard presentation and attention-only filtering are deferred to PR 2 / PR 3.

## New Pulse signals

Two rules, in order. A job matching both emits only the first.

- **Disabled with reason** → `warning`, id `scheduler-disabled-<jobId>`, detail = `disabledReason` (truncated to 140 chars). Skips when `disabledReason` is empty — we won't invent operator copy. Today `markDisabled` is only called from real failure paths (`runSchedulerInit` "Init failed: …" / legacy plugin catches), so `disabled: true` is always actionable.
- **`consecutiveFailures >= 2`** → `warning`, id `scheduler-failing-<jobId>`, detail = `"N consecutive failures — last error: <msg>"` (truncated). Threshold of 2 filters out transient single-blip failures.

Severity is capped at `warning`: the registry doesn't distinguish critical-path jobs from nice-to-have ones, so escalating to `critical` would overclaim.

Timestamps prefer `lastFailureAt` (keeps Pulse's severity-then-recency sort truthful), falling back to `now()` only when a job has never ticked (e.g., init-failure case).

## Files changed

- `apps/api/src/lib/pulse/collectors.ts` — new `collectSchedulerHealth` collector + registered in `pulseCollectors`; exported for tests.
- `apps/api/src/routes/pulse.ts` — one-line entry `collectSchedulerHealth: "scheduler health"` in `COLLECTOR_LABELS` so a failed collector produces clean operator-facing copy.
- `apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts` — 12 collector-level tests, 4 describe blocks.
- `apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts` — 3 route-level integration tests that exercise the real `/pulse` handler end-to-end.

## Test plan

- [x] `pnpm --filter @arr/api exec vitest run src/lib/pulse src/routes/__tests__/pulse-*.test.ts` — 29/29 pass (12 new collector + 3 new route + 14 pre-existing)
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] **End-to-end: disabled scheduler** — route-level test `pulse-scheduler-health.test.ts` stubs `app.schedulerRegistry.list()` with a disabled job and asserts the `/pulse` response contains a `scheduler-disabled-<jobId>` warning item with the expected title, detail, category, source, and actionUrl.
- [x] **End-to-end: two consecutive tick failures** — same harness, asserts `/pulse` returns `scheduler-failing-<jobId>` with the correct consecutive-failures count, `lastError` embedded in the detail, and `lastFailureAt` as the timestamp.
- [x] **End-to-end: healthy jobs silent** — third route test asserts healthy registry yields zero `scheduler-*` items and a clean summary.

## Test coverage

**Collector-level** (`collectors-scheduler.test.ts`):
- **Healthy jobs** — empty registry, idle jobs, single failure below threshold, running job without failure history: all emit nothing.
- **Failing jobs** — threshold triggers at 2; detail works without `lastError`; `lastFailureAt` drives timestamp; long errors truncate with ellipsis.
- **Disabled jobs** — reason present → warning; disabled + failing → only the disabled item; disabled with null reason → nothing.
- **Mixed registry** — 4 jobs in varied states resolve to exactly the 2 expected ids.

**Route-level** (`pulse-scheduler-health.test.ts`):
- Boots real `/pulse` route with real `collectSchedulerHealth`, stubbing only `schedulerRegistry.list()`. Each test uses a unique user so the route's 60-second per-user cache does not leak between cases.

## Risk

Low — purely additive. The collector is wrapped by the existing try/catch in `routes/pulse.ts`, so a thrown error degrades to a "could not check scheduler health" warning item rather than a 500. No DB I/O (registry is in-memory), so this cannot contribute to database pressure.

## Deferred

- **PR 2** — `GET /api/pulse?attentionOnly=true` filter (severity critical/warning + `actionUrl != null`)
- **PR 3** — `NeedsAttentionPanel` dashboard component, incognito audit, `/trust-check` pass
- **V2.17+** — header badge, snooze/acknowledge persistence, "configured but never validated" detection, configurable thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)