### PR TITLE
feat(dashboard): add Needs Attention panel using filtered Pulse view

### DIFF
--- a/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Behavior-focused tests for <NeedsAttentionPanel />.
+ *
+ * We mock `usePulseQuery` directly so each test drives a specific React
+ * Query state (loading / error-no-data / empty / populated / truncated).
+ * This keeps the surface under test to "given this hook state, what does
+ * the operator see?" which is exactly what the trust requirements in the
+ * PR 3 spec turn on.
+ */
+
+import type { PulseItem, PulseResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+// ---------------------------------------------------------------------------
+// Mock the Pulse query hook
+// ---------------------------------------------------------------------------
+const mockUsePulseQuery = vi.fn();
+
+vi.mock("../../../../hooks/api/usePulse", () => ({
+	usePulseQuery: (args?: { attentionOnly?: boolean }) => mockUsePulseQuery(args),
+}));
+
+// Import after mocks so the component picks up the mocked hook.
+import { NeedsAttentionPanel } from "../needs-attention-panel";
+
+// ---------------------------------------------------------------------------
+// Wrapper: React Query + IncognitoProvider (required by useIncognitoMode)
+// ---------------------------------------------------------------------------
+function createWrapper() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={qc}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>
+	);
+}
+
+function makeItem(overrides: Partial<PulseItem> = {}): PulseItem {
+	return {
+		id: "item-1",
+		severity: "warning",
+		category: "health",
+		title: "Example attention item",
+		detail: "Something that needs a look",
+		actionUrl: "/settings",
+		actionLabel: "Resolve",
+		source: "system",
+		timestamp: "2026-04-14T12:00:00.000Z",
+		...overrides,
+	};
+}
+
+function makeResponse(items: PulseItem[]): PulseResponse {
+	const summary = {
+		critical: items.filter((i) => i.severity === "critical").length,
+		warning: items.filter((i) => i.severity === "warning").length,
+		info: items.filter((i) => i.severity === "info").length,
+	};
+	return { items, summary, generatedAt: "2026-04-14T12:00:00.000Z" };
+}
+
+beforeEach(() => {
+	mockUsePulseQuery.mockReset();
+});
+
+describe("<NeedsAttentionPanel />", () => {
+	it("renders a loading skeleton when the Pulse query is loading and has no data", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: true,
+			isError: false,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+
+		expect(
+			screen.getByTestId("needs-attention-panel-loading"),
+		).toBeInTheDocument();
+		// The loading state must NOT claim "all clear" or show any item rows.
+		expect(screen.queryByText(/All systems operational/i)).not.toBeInTheDocument();
+	});
+
+	it("shows an honest error state (not 'all clear') when the query errors with no cached data", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: undefined,
+			isLoading: false,
+			isError: true,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+
+		expect(screen.getByTestId("needs-attention-panel-error")).toBeInTheDocument();
+		expect(screen.getByText(/Couldn't load attention items/i)).toBeInTheDocument();
+		// Critical trust requirement: a failed fetch must never render the
+		// "all clear" empty state.
+		expect(screen.queryByText(/All systems operational/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the 'all clear' empty state ONLY when the fetch succeeded with zero items", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: makeResponse([]),
+			isLoading: false,
+			isError: false,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+
+		expect(screen.getByTestId("needs-attention-panel-empty")).toBeInTheDocument();
+		expect(screen.getByText(/All systems operational/i)).toBeInTheDocument();
+	});
+
+	it("renders each attention item with title, detail, and action link to its actionUrl", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: makeResponse([
+				makeItem({
+					id: "crit-1",
+					severity: "critical",
+					title: "Sonarr is unreachable",
+					detail: "Timed out after 10s",
+					actionUrl: "/settings/services?instance=sonarr-1",
+					actionLabel: "Open service",
+				}),
+				makeItem({
+					id: "warn-1",
+					severity: "warning",
+					title: "Queue cleaner failed",
+					detail: "ECONNREFUSED on last run",
+					actionUrl: "/queue-cleaner",
+				}),
+			]),
+			isLoading: false,
+			isError: false,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+
+		expect(screen.getByTestId("needs-attention-panel")).toBeInTheDocument();
+
+		// Both titles rendered.
+		expect(screen.getByText("Sonarr is unreachable")).toBeInTheDocument();
+		expect(screen.getByText("Queue cleaner failed")).toBeInTheDocument();
+
+		// Details rendered.
+		expect(screen.getByText("Timed out after 10s")).toBeInTheDocument();
+		expect(screen.getByText("ECONNREFUSED on last run")).toBeInTheDocument();
+
+		// Action links land on the exact actionUrl from the item, and respect
+		// actionLabel when provided (else "Resolve" default).
+		const openService = screen.getByRole("link", { name: /Open service/i });
+		expect(openService).toHaveAttribute(
+			"href",
+			"/settings/services?instance=sonarr-1",
+		);
+		const resolve = screen.getByRole("link", { name: /Resolve/i });
+		expect(resolve).toHaveAttribute("href", "/queue-cleaner");
+
+		// Header shows a "View all in Pulse" link regardless.
+		expect(
+			screen.getByRole("link", { name: /View all in Pulse/i }),
+		).toHaveAttribute("href", "/pulse");
+	});
+
+	it("caps rendered rows at 10 and shows a 'View all N items in Pulse' footer link when truncated", () => {
+		const items: PulseItem[] = Array.from({ length: 13 }, (_, i) =>
+			makeItem({
+				id: `item-${i}`,
+				title: `Attention item ${i}`,
+				actionUrl: `/target/${i}`,
+			}),
+		);
+		mockUsePulseQuery.mockReturnValue({
+			data: makeResponse(items),
+			isLoading: false,
+			isError: false,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+
+		// First 10 rendered, 11th+ suppressed.
+		expect(screen.getByText("Attention item 0")).toBeInTheDocument();
+		expect(screen.getByText("Attention item 9")).toBeInTheDocument();
+		expect(screen.queryByText("Attention item 10")).not.toBeInTheDocument();
+		expect(screen.queryByText("Attention item 12")).not.toBeInTheDocument();
+
+		// Truncation footer announces total and links to /pulse.
+		const footer = screen.getByRole("link", {
+			name: /View all 13 items in Pulse/i,
+		});
+		expect(footer).toHaveAttribute("href", "/pulse");
+	});
+});

--- a/apps/web/src/features/dashboard/components/dashboard-client.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-client.tsx
@@ -49,6 +49,7 @@ import { useDashboardData } from "../hooks/useDashboardData";
 import { useDashboardFilters } from "../hooks/useDashboardFilters";
 import { useDashboardQueue } from "../hooks/useDashboardQueue";
 import { CacheHealthBanner } from "./cache-health-banner";
+import { NeedsAttentionPanel } from "./needs-attention-panel";
 import { type DashboardTab, DashboardTabs } from "./dashboard-tabs";
 import { NowPlayingWidget } from "./now-playing-widget";
 import { OnDeckWidget } from "./on-deck-widget";
@@ -566,7 +567,23 @@ export const DashboardClient = () => {
 				</div>
 			</header>
 
-			{/* Cache Health Banner */}
+			{/* Needs Attention — curated subset of /pulse. Rendered above other
+			    widgets so actionable critical/warning items are the first thing
+			    an operator sees on load.
+
+			    Note on overlap with <CacheHealthBanner />: the Pulse cache
+			    collectors emit `cache-error-*` / `cache-stale-*` items with
+			    severity=warning and actionUrl=/settings, so those will also
+			    show in this panel. The banner is kept because it offers a
+			    different affordance — a one-click inline refresh mutation —
+			    that the panel deliberately doesn't duplicate. Reconciling the
+			    two surfaces (e.g. banner-as-inline-row-action inside the
+			    panel) is a follow-up for a later PR so this one stays small. */}
+			<NeedsAttentionPanel />
+
+			{/* Cache Health Banner — offers inline one-click cache refresh.
+			    Overlap with NeedsAttentionPanel is intentional and documented
+			    above. */}
 			<CacheHealthBanner enabled={hasMediaServer} />
 
 			{/* Tabs */}

--- a/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
+++ b/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+/**
+ * Needs Attention Panel (dashboard home — first user-facing surface for the
+ * curated attention feed).
+ *
+ * Consumes `usePulseQuery({ attentionOnly: true })`, which serves the same
+ * /pulse route through a new server-side filter that keeps only
+ * critical/warning items with an actionUrl. This panel is a *curated subset*
+ * of /pulse — a fast read-only "what needs me today" surface — not a
+ * replacement for the full Pulse view. That boundary is why the empty state
+ * is deliberately narrow ("No critical or warning signals from Pulse right
+ * now") and the header always links out to /pulse.
+ *
+ * Trust rules (enforced here):
+ *   - If the query errored AND we have no cached data, show an honest error
+ *     state — never an "all clear" on a failed fetch.
+ *   - Empty state is ONLY shown when the fetch succeeded.
+ *   - Rows render no severity/logic of their own: the severity visual comes
+ *     straight from the Pulse item, actionUrl decides whether the row gets
+ *     an action button, and we never try to classify items ourselves.
+ *   - Titles/details are passed through `anonymizePulseText` /
+ *     `anonymizeHealthMessage` (same as /pulse) when incognito mode is on.
+ */
+
+import type { PulseItem, PulseSeverity } from "@arr/shared";
+import { AlertTriangle, CheckCircle2, ChevronRight, XCircle } from "lucide-react";
+import Link from "next/link";
+import {
+	anonymizeHealthMessage,
+	anonymizePulseText,
+	useIncognitoMode,
+} from "../../../lib/incognito";
+import { usePulseQuery } from "../../../hooks/api/usePulse";
+import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
+import { cn } from "../../../lib/utils";
+
+const MAX_VISIBLE_ITEMS = 10;
+
+// `PulseSeverity` includes `info`, but the server filter guarantees rows here
+// are only `critical` / `warning`. We still key the visual map off severity
+// directly (no re-classification) and narrow to the two expected severities.
+type SeverityColors = {
+	readonly bg: string;
+	readonly border: string;
+	readonly text: string;
+};
+
+const SEVERITY_VISUAL: Record<
+	Exclude<PulseSeverity, "info">,
+	{ icon: typeof XCircle; colors: SeverityColors; srLabel: string }
+> = {
+	critical: {
+		icon: XCircle,
+		colors: SEMANTIC_COLORS.error,
+		srLabel: "Critical",
+	},
+	warning: {
+		icon: AlertTriangle,
+		colors: SEMANTIC_COLORS.warning,
+		srLabel: "Warning",
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Card shell — matches the existing dashboard widget look (see
+// recently-added-widget.tsx) so the new panel blends with existing cards.
+// ---------------------------------------------------------------------------
+function PanelShell({
+	children,
+	className,
+	testId,
+	ariaLabel,
+}: {
+	children: React.ReactNode;
+	className?: string;
+	testId?: string;
+	ariaLabel?: string;
+}) {
+	return (
+		<section
+			data-testid={testId}
+			aria-label={ariaLabel}
+			className={cn(
+				"overflow-hidden rounded-xl border border-border/30 bg-muted/10",
+				className,
+			)}
+		>
+			{children}
+		</section>
+	);
+}
+
+function PanelHeader({
+	visibleCount,
+	totalCount,
+}: {
+	visibleCount: number;
+	totalCount: number;
+}) {
+	const subtitle =
+		totalCount === 0
+			? "Actionable critical and warning signals"
+			: totalCount === 1
+				? "1 actionable item"
+				: `${totalCount} actionable items${totalCount > visibleCount ? ` (showing ${visibleCount})` : ""}`;
+
+	return (
+		<div className="flex items-center gap-3 border-b border-border/50 px-6 py-4">
+			<div
+				className="flex h-8 w-8 items-center justify-center rounded-lg"
+				style={{
+					backgroundColor: SEMANTIC_COLORS.warning.bg,
+					border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
+				}}
+			>
+				<AlertTriangle
+					className="h-4 w-4"
+					style={{ color: SEMANTIC_COLORS.warning.text }}
+				/>
+			</div>
+			<div className="min-w-0 flex-1">
+				<h3 className="text-sm font-semibold text-foreground">Needs Attention</h3>
+				<p className="text-xs text-muted-foreground">{subtitle}</p>
+			</div>
+			<Link
+				href="/pulse"
+				className="shrink-0 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+			>
+				View all in Pulse
+				<ChevronRight className="inline h-3 w-3 align-[-2px]" />
+			</Link>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// AttentionRow — one row per item. No severity logic beyond "pick the visual
+// for critical vs warning". Severity comes from the item verbatim.
+// ---------------------------------------------------------------------------
+function AttentionRow({
+	item,
+	incognito,
+}: {
+	item: PulseItem;
+	incognito: boolean;
+}) {
+	const visual =
+		item.severity === "critical" || item.severity === "warning"
+			? SEVERITY_VISUAL[item.severity]
+			: null;
+
+	// If a future /pulse change ever leaks an `info` item through the filter,
+	// we'd rather not render it than silently mis-badge it as a warning.
+	if (!visual) return null;
+
+	const Icon = visual.icon;
+	const title = incognito ? anonymizePulseText(item.title) : item.title;
+	const detail =
+		incognito && item.detail ? anonymizeHealthMessage(item.detail) : item.detail;
+
+	return (
+		<li className="flex items-start gap-3 border-b border-border/30 px-6 py-3 last:border-b-0">
+			<div
+				role="img"
+				aria-label={visual.srLabel}
+				className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+				style={{
+					backgroundColor: visual.colors.bg,
+					border: `1px solid ${visual.colors.border}`,
+					color: visual.colors.text,
+				}}
+			>
+				<Icon className="h-3.5 w-3.5" aria-hidden="true" />
+			</div>
+			<div className="min-w-0 flex-1">
+				<p className="truncate text-sm font-medium text-foreground">{title}</p>
+				{detail && (
+					<p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>
+				)}
+			</div>
+			{item.actionUrl && (
+				<Link
+					href={item.actionUrl}
+					className="inline-flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+				>
+					{/* actionLabel is static on today's collectors ("Resolve",
+					    "Open service", etc.), but routing it through the same
+					    anonymizer as detail keeps incognito safe if a future
+					    collector ever interpolates a name into the label. */}
+					{(() => {
+						const label = item.actionLabel ?? "Resolve";
+						return incognito ? anonymizeHealthMessage(label) : label;
+					})()}
+					<ChevronRight className="h-3 w-3" />
+				</Link>
+			)}
+		</li>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Main panel
+// ---------------------------------------------------------------------------
+export function NeedsAttentionPanel() {
+	const { data, isLoading, isError } = usePulseQuery({ attentionOnly: true });
+	const [incognito] = useIncognitoMode();
+
+	// State: loading (no cached data yet).
+	if (isLoading) {
+		return (
+			<PanelShell
+				testId="needs-attention-panel-loading"
+				ariaLabel="Needs Attention — loading"
+			>
+				<div className="flex items-center gap-3 border-b border-border/50 px-6 py-4">
+					<div className="h-8 w-8 animate-pulse rounded-lg bg-muted/30" />
+					<div className="flex-1 space-y-1.5">
+						<div className="h-4 w-32 animate-pulse rounded bg-muted/30" />
+						<div className="h-3 w-56 animate-pulse rounded bg-muted/20" />
+					</div>
+				</div>
+				<div className="space-y-2 px-6 py-4">
+					<div className="h-4 w-full animate-pulse rounded bg-muted/20" />
+					<div className="h-4 w-4/5 animate-pulse rounded bg-muted/20" />
+					<div className="h-4 w-3/4 animate-pulse rounded bg-muted/20" />
+				</div>
+			</PanelShell>
+		);
+	}
+
+	// State: error with no cached data — NEVER imply "all clear" here.
+	if (isError && !data) {
+		return (
+			<PanelShell
+				testId="needs-attention-panel-error"
+				ariaLabel="Needs Attention — unavailable"
+			>
+				<div className="flex items-start gap-3 px-6 py-4">
+					<XCircle
+						className="mt-0.5 h-5 w-5 shrink-0"
+						style={{ color: SEMANTIC_COLORS.error.text }}
+					/>
+					<div className="min-w-0 flex-1">
+						<h3 className="text-sm font-semibold text-foreground">
+							Couldn&apos;t load attention items
+						</h3>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							The attention feed is unavailable right now — other dashboard signals may
+							still be accurate.{" "}
+							<Link
+								href="/pulse"
+								className="underline underline-offset-2 transition-colors hover:text-foreground"
+							>
+								Open Pulse to retry
+							</Link>
+							.
+						</p>
+					</div>
+				</div>
+			</PanelShell>
+		);
+	}
+
+	const items = data?.items ?? [];
+	const visible = items.slice(0, MAX_VISIBLE_ITEMS);
+	const truncated = items.length > MAX_VISIBLE_ITEMS;
+
+	// State: empty — only shown when fetch succeeded.
+	if (visible.length === 0) {
+		return (
+			<PanelShell
+				testId="needs-attention-panel-empty"
+				ariaLabel="Needs Attention — all clear"
+			>
+				<div className="flex items-start gap-3 px-6 py-4">
+					<CheckCircle2
+						className="mt-0.5 h-5 w-5 shrink-0"
+						style={{ color: SEMANTIC_COLORS.success.text }}
+					/>
+					<div className="min-w-0 flex-1">
+						<h3 className="text-sm font-semibold text-foreground">
+							All systems operational
+						</h3>
+						<p className="mt-0.5 text-xs text-muted-foreground">
+							No critical or warning signals from Pulse right now.
+						</p>
+					</div>
+				</div>
+			</PanelShell>
+		);
+	}
+
+	// State: populated.
+	return (
+		<PanelShell testId="needs-attention-panel" ariaLabel="Needs Attention">
+			<PanelHeader visibleCount={visible.length} totalCount={items.length} />
+			<ul>
+				{visible.map((item) => (
+					<AttentionRow key={item.id} item={item} incognito={incognito} />
+				))}
+			</ul>
+			{truncated && (
+				<div className="border-t border-border/30 px-6 py-3 text-right">
+					<Link
+						href="/pulse"
+						className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+					>
+						View all {items.length} items in Pulse
+						<ChevronRight className="inline h-3 w-3 align-[-2px]" />
+					</Link>
+				</div>
+			)}
+		</PanelShell>
+	);
+}

--- a/apps/web/src/features/pulse/components/pulse-client.tsx
+++ b/apps/web/src/features/pulse/components/pulse-client.tsx
@@ -26,34 +26,12 @@ import { usePulseQuery } from "../../../hooks/api/usePulse";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import {
 	anonymizeHealthMessage,
-	getLinuxInstanceName,
+	anonymizePulseText,
 	useIncognitoMode,
 } from "../../../lib/incognito";
 import { POLLING_STATS } from "../../../lib/polling-intervals";
 import { getServiceGradient, SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
-
-// ============================================================================
-// Incognito helper — anonymize "InstanceLabel: health message" titles
-// ============================================================================
-
-function anonymizePulseText(text: string): string {
-	// Pulse titles follow "Label: message" or "Label is unreachable/recovering"
-	const colonIdx = text.indexOf(": ");
-	if (colonIdx > 0) {
-		const label = text.slice(0, colonIdx);
-		const message = text.slice(colonIdx + 2);
-		return `${getLinuxInstanceName(label)}: ${anonymizeHealthMessage(message)}`;
-	}
-	// "Label is unreachable" pattern
-	const isIdx = text.indexOf(" is ");
-	if (isIdx > 0) {
-		const label = text.slice(0, isIdx);
-		const rest = text.slice(isIdx);
-		return `${getLinuxInstanceName(label)}${rest}`;
-	}
-	return anonymizeHealthMessage(text);
-}
 
 // ============================================================================
 // Severity config

--- a/apps/web/src/lib/incognito.ts
+++ b/apps/web/src/lib/incognito.ts
@@ -228,6 +228,34 @@ export function anonymizeHealthMessage(message: string): string {
 	return anonymized;
 }
 
+/**
+ * Anonymize a Pulse item title.
+ *
+ * Pulse titles follow one of two shapes:
+ *   - "InstanceLabel: health message"  (e.g. "Sonarr Prod: Indexer X failed")
+ *   - "InstanceLabel is unreachable"   (status strings)
+ *
+ * We split off the label, replace it with a Linux-themed placeholder via
+ * `getLinuxInstanceName`, and run the message half through
+ * `anonymizeHealthMessage`. Titles with neither shape fall through to
+ * `anonymizeHealthMessage` alone.
+ */
+export function anonymizePulseText(text: string): string {
+	const colonIdx = text.indexOf(": ");
+	if (colonIdx > 0) {
+		const label = text.slice(0, colonIdx);
+		const message = text.slice(colonIdx + 2);
+		return `${getLinuxInstanceName(label)}: ${anonymizeHealthMessage(message)}`;
+	}
+	const isIdx = text.indexOf(" is ");
+	if (isIdx > 0) {
+		const label = text.slice(0, isIdx);
+		const rest = text.slice(isIdx);
+		return `${getLinuxInstanceName(label)}${rest}`;
+	}
+	return anonymizeHealthMessage(text);
+}
+
 // Anonymize queue status/error messages
 export function anonymizeStatusMessage(message: string): string {
 	let anonymized = message;


### PR DESCRIPTION
## Summary

- First user-facing surface for the 2.16.0 **Needs Attention** feature. Adds a compact panel at the top of the dashboard that lists up to 10 actionable critical/warning items from Pulse, each with severity, title, short detail, and an action link pulled verbatim from the Pulse item.
- Consumes `usePulseQuery({ attentionOnly: true })` wired up in PR #334 — no new backend endpoint, no new filter dimensions, no hook surface churn.
- Shared helper `anonymizePulseText` moved from `pulse-client.tsx` into `lib/incognito.ts` so both the Pulse page and the new panel import the same implementation. No behavior change to `/pulse`.

PR 3 of 3 for the 2.16.0 Needs Attention feature. Intentionally does **not** add the optional global/header badge — that's deferred to a later PR.

## Panel behavior

- **Loading** — skeleton shell; does not claim "all clear".
- **Error with no cached data** — dedicated "Couldn't load attention items" state with a retry link to `/pulse`. Critically, never falls through to the empty state.
- **Empty (successful fetch, zero items)** — "All systems operational" with a `CheckCircle2`.
- **Populated** — up to 10 rows with severity icon, title, 1-line detail, and optional action `<Link>` using `item.actionUrl` / `item.actionLabel` verbatim. Header links to `/pulse`.
- **Truncated** (items > 10) — footer reads "View all N items in Pulse" with the real total from `items.length`, not the visible count.

## Trust requirements met

- Severity visuals keyed directly off `item.severity`. No invented severity logic. If a future filter leak lets an `info` item through, the row is dropped rather than mis-badged as warning.
- Every `actionUrl` is used verbatim — no URLs synthesized from `id` / `source`.
- Incognito mode anonymizes `title` (via `anonymizePulseText`), `detail` (via `anonymizeHealthMessage`), and defensively `actionLabel` (today's collectors use static strings, but the anonymizer runs if a future collector interpolates a name).
- Truncation count is honest — it reports `items.length`, not `visible.length`.
- Empty state only renders after a successful fetch. Error branch is checked before the empty branch.

## Placement

Rendered immediately above `CacheHealthBanner` on the dashboard. The overlap is intentional and commented in-line in `dashboard-client.tsx`:

- Pulse cache collectors emit `cache-error-*` / `cache-stale-*` items as `severity: warning` with `actionUrl: /settings`, so those will appear in the new panel.
- `CacheHealthBanner` is kept because it offers a materially different affordance — a one-click inline refresh mutation (`handleRefresh`) — that the panel deliberately doesn't duplicate.
- Reconciling the two surfaces (e.g. promoting the banner's inline-refresh into a panel row action) is a follow-up; this PR is kept minimal to avoid a dashboard redesign.

Per spec the existing titles/details are already generic: the collector side owns instance-name redaction via `anonymizePulseText` in incognito mode, and the panel doesn't introduce any new user-visible fields.

## Files changed

- `apps/web/src/features/dashboard/components/needs-attention-panel.tsx` — new, ~300 lines including header/shell and states.
- `apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx` — new, 5 focused behavior tests.
- `apps/web/src/features/dashboard/components/dashboard-client.tsx` — 2-line import + render of `<NeedsAttentionPanel />` above `<CacheHealthBanner />`, plus an explanatory placement comment.
- `apps/web/src/lib/incognito.ts` — added exported `anonymizePulseText` (lifted from pulse-client).
- `apps/web/src/features/pulse/components/pulse-client.tsx` — removed duplicate local `anonymizePulseText`; imports from `lib/incognito` instead.

## Intentionally deferred

- Global/header attention badge (optional, out of scope for PR 3).
- Any rework of `CacheHealthBanner` to deduplicate the overlap.
- Any additional filter dimensions (category / source / time window).
- Any dashboard redesign.

## Test plan

- [x] `pnpm --filter @arr/web exec vitest run src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx` — 5/5 passing, covering loading / error-with-no-data / empty / populated / truncation>10.
- [x] Each test makes a distinguishing assertion (the loading + error tests explicitly assert the "All systems operational" copy is absent, enforcing the trust rule in tests, not just in review).
- [x] `pnpm --filter @arr/api exec vitest run src/routes/__tests__/pulse` — 11/11 passing (regression check after the `anonymizePulseText` move).
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean.
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean.
- [x] `pnpm run lint` — clean (only 5 pre-existing warnings unrelated to this PR).
- [x] Manual dashboard spot-check with a live Pulse population — done. See the [live-verification comment](https://github.com/Kha-kis/arr-dashboard/pull/335#issuecomment-4246593989) for the DOM introspection of the rendered panel (9 real attention items, 2 critical + 7 warning, info filtered out, 0 console errors). Empty and error states remain covered by the deterministic unit tests since they can't be reproduced on the live instance without mutating the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
