### PR TITLE
fix(needs-attention): route scheduler items to /pulse + soften empty-state copy

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts
@@ -132,7 +132,7 @@ describe("collectSchedulerHealth — failing jobs", () => {
 			category: "operations",
 			title: "Queue Cleaner is failing",
 			source: "system",
-			actionUrl: "/settings",
+			actionUrl: "/pulse",
 			timestamp: "2026-04-14T09:30:00.000Z",
 		});
 		expect(items[0]!.detail).toContain("2 consecutive failures");
@@ -220,7 +220,7 @@ describe("collectSchedulerHealth — disabled jobs", () => {
 			title: "Hunting is disabled",
 			detail: "Init failed: cannot reach hunting config table",
 			source: "system",
-			actionUrl: "/settings",
+			actionUrl: "/pulse",
 		});
 	});
 

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -528,8 +528,11 @@ const collectSchedulerHealth: Collector = async (app) => {
 				category: "operations",
 				title: `${job.label} is disabled`,
 				detail: truncate(job.disabledReason),
-				actionUrl: "/settings",
-				actionLabel: "View system",
+				// /settings has no scheduler surface, so linking there was a
+				// dead-end. /pulse renders this same item in the full feed
+				// where the operator can read the detail and adjacent signals.
+				actionUrl: "/pulse",
+				actionLabel: "View in Pulse",
 				source: "system",
 				timestamp: job.lastFailureAt ?? now(),
 			});
@@ -545,8 +548,8 @@ const collectSchedulerHealth: Collector = async (app) => {
 				category: "operations",
 				title: `${job.label} is failing`,
 				detail: truncate(`${job.consecutiveFailures} consecutive failures${errorHint}`),
-				actionUrl: "/settings",
-				actionLabel: "View system",
+				actionUrl: "/pulse",
+				actionLabel: "View in Pulse",
 				source: "system",
 				timestamp: job.lastFailureAt ?? now(),
 			});

--- a/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
@@ -108,7 +108,7 @@ describe("GET /pulse — scheduler health signals", () => {
 		expect(item.title).toBe("Hunting is disabled");
 		expect(item.detail).toContain("Init failed");
 		expect(item.source).toBe("system");
-		expect(item.actionUrl).toBe("/settings");
+		expect(item.actionUrl).toBe("/pulse");
 
 		expect(body.summary.warning).toBeGreaterThanOrEqual(1);
 	});

--- a/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
@@ -81,7 +81,7 @@ describe("<NeedsAttentionPanel />", () => {
 			screen.getByTestId("needs-attention-panel-loading"),
 		).toBeInTheDocument();
 		// The loading state must NOT claim "all clear" or show any item rows.
-		expect(screen.queryByText(/All systems operational/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/No actionable items right now/i)).not.toBeInTheDocument();
 	});
 
 	it("shows an honest error state (not 'all clear') when the query errors with no cached data", () => {
@@ -97,7 +97,7 @@ describe("<NeedsAttentionPanel />", () => {
 		expect(screen.getByText(/Couldn't load attention items/i)).toBeInTheDocument();
 		// Critical trust requirement: a failed fetch must never render the
 		// "all clear" empty state.
-		expect(screen.queryByText(/All systems operational/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/No actionable items right now/i)).not.toBeInTheDocument();
 	});
 
 	it("shows the 'all clear' empty state ONLY when the fetch succeeded with zero items", () => {
@@ -110,7 +110,7 @@ describe("<NeedsAttentionPanel />", () => {
 		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
 
 		expect(screen.getByTestId("needs-attention-panel-empty")).toBeInTheDocument();
-		expect(screen.getByText(/All systems operational/i)).toBeInTheDocument();
+		expect(screen.getByText(/No actionable items right now/i)).toBeInTheDocument();
 	});
 
 	it("renders each attention item with title, detail, and action link to its actionUrl", () => {

--- a/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
+++ b/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
@@ -280,10 +280,10 @@ export function NeedsAttentionPanel() {
 					/>
 					<div className="min-w-0 flex-1">
 						<h3 className="text-sm font-semibold text-foreground">
-							All systems operational
+							No actionable items right now
 						</h3>
 						<p className="mt-0.5 text-xs text-muted-foreground">
-							No critical or warning signals from Pulse right now.
+							Open Pulse to view the full signal list.
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary

Pre-release trust-pass for the 2.16.0 **Needs Attention** feature (PRs #333 / #334 / #335). Two tightly-scoped fixes flagged by the post-implementation audit; no new features, no abstractions, no refactors.

## Why each fix improves trust

### 1. Scheduler items: `actionUrl: "/settings"` → `"/pulse"`, label `"View system"` → `"View in Pulse"`

`/settings` has no scheduler surface — `grep` for scheduler-related components under `apps/web/src/features/settings` returns zero results. An operator who saw `"Hunting is disabled"` in the panel and clicked `"View system"` landed on services/profiles/notifications and could not find the referenced job at all. That's a direct violation of the CLAUDE.md rule *"every action link must point to an existing page that shows the relevant data"*, and introducing it in the V1 of a feature built on trust would poison the pattern from day one.

`/pulse` renders the exact same item in the full Pulse feed where the operator can read the detail and adjacent signals. Not a dedicated jobs view (that's a post-2.16.0 candidate), but it's a surface that actually contains the information the link promises — a strict improvement from "dead end" to "readable signal in context". The new `"View in Pulse"` label matches the target honestly.

### 2. Panel empty-state: `"All systems operational"` → `"No actionable items right now"`

The old copy was a global-health claim the panel can't back up. Collector-error fallback items (`collector-error-*`) emit with no `actionUrl`, so the `attentionOnly=true` filter excludes them. If e.g. the ARR collector throws during a fetch, ARR attention signals are missing from the attention-only view entirely — yet the panel would render *"All systems operational"* while the full `/pulse` page shows a `"Could not check some signals"` warning. The panel cannot tell *"truly clean"* from *"partially blind"* without a second query.

The new copy stays strictly within what the filtered feed knows: the panel's scope is actionable critical/warning items, so "no actionable items right now" is exactly honest. The subtext points the operator at `/pulse` for the unfiltered view, which is the trust escape valve for any collector-error case.

## Files changed (5)

- `apps/api/src/lib/pulse/collectors.ts` — `scheduler-disabled-*` and `scheduler-failing-*` builders use `/pulse` + `"View in Pulse"` (plus a one-line comment explaining the change).
- `apps/api/src/lib/pulse/__tests__/collectors-scheduler.test.ts` — two `actionUrl` assertions updated to `"/pulse"`.
- `apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts` — one `actionUrl` assertion updated to `"/pulse"`.
- `apps/web/src/features/dashboard/components/needs-attention-panel.tsx` — 2-line copy change in the empty-state branch.
- `apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx` — three regex literals updated from `/All systems operational/i` to `/No actionable items right now/i`. Test structure unchanged — loading/error branches still assert the empty-state copy is **not** present, populated branch unaffected.

Total: 15 insertions, 12 deletions.

## Test plan

- [x] `pnpm --filter @arr/api exec vitest run src/routes/__tests__/pulse src/lib/pulse/__tests__/collectors-scheduler` — 23/23 passing
- [x] `pnpm --filter @arr/web exec vitest run src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx` — 5/5 passing
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean

## What this unblocks

With these in, the "Needs Attention" V1 is trust-ready for 2.16.0. Deferred items from the audit (cache banner / panel consolidation, generic URL redaction under incognito) are explicitly post-2.16.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)