### PR TITLE
fix(pulse): tighten action labels and deep-link validation health to Settings → System

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/collectors-validation-labels.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-validation-labels.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Pins the validation-health pulse item action link + label.
+ *
+ * The collector routes the operator to Settings → System (where the
+ * ValidationHealthSection lives) instead of the default Services tab.
+ * Regressing the URL or label silently drops the operator on the wrong
+ * screen, so these strings are part of the user contract.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
+
+vi.mock("../../validation/integration-health.js", () => ({
+	integrationHealth: {
+		getAll: vi.fn(),
+	},
+}));
+
+import { integrationHealth } from "../../validation/integration-health.js";
+import { pulseCollectors } from "../collectors.js";
+
+const getAllMock = integrationHealth.getAll as unknown as ReturnType<typeof vi.fn>;
+
+const noop = vi.fn();
+const mockLog = {
+	warn: noop,
+	error: noop,
+	info: noop,
+	debug: noop,
+	trace: noop,
+	fatal: noop,
+	child: () => mockLog,
+} as unknown as FastifyBaseLogger;
+
+// Find the validation-health collector by invoking each with an empty app
+// and the mocked integrationHealth. The collector is export-private, so we
+// drive it through the exported array.
+const stats = { total: 0, successful: 0, failed: 0 };
+
+function makeHealth(state: "failing" | "degraded") {
+	return {
+		integrations: {
+			trash: {
+				lastRefreshAt: null,
+				lastSuccessAt: null,
+				lastFailureAt: "2026-04-14T00:00:00Z",
+				consecutiveFailures: state === "failing" ? 5 : 2,
+				state,
+				categories: {},
+				totals: { total: 10, successful: 5, failed: 5 },
+			},
+		},
+		overallTotals: stats,
+		resetAt: null,
+	};
+}
+
+function makeApp(): FastifyInstance {
+	return {
+		prisma: {
+			// All the other collectors short-circuit on empty queries.
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([]) },
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([]) },
+			huntConfig: { count: vi.fn().mockResolvedValue(0) },
+			queueCleanerConfig: { count: vi.fn().mockResolvedValue(0) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			libraryCache: { count: vi.fn().mockResolvedValue(0) },
+			libraryCleanupConfig: { findFirst: vi.fn().mockResolvedValue(null) },
+		},
+		seerrCircuitBreaker: { getState: vi.fn().mockReturnValue("CLOSED") },
+		schedulerRegistry: { list: vi.fn().mockReturnValue([]) },
+		arrClientFactory: { create: vi.fn() },
+	} as unknown as FastifyInstance;
+}
+
+async function runAll(app: FastifyInstance) {
+	const results = await Promise.all(pulseCollectors.map((c) => c(app, "user-1", mockLog)));
+	return results.flat();
+}
+
+describe("validation-health pulse items — action link + label", () => {
+	it("emits /settings#system + 'View validation health' for failing state", async () => {
+		getAllMock.mockReturnValue(makeHealth("failing"));
+
+		const items = await runAll(makeApp());
+		const item = items.find((i) => i.id === "validation-trash");
+
+		expect(item).toBeDefined();
+		expect(item?.severity).toBe("critical");
+		expect(item?.actionUrl).toBe("/settings#system");
+		expect(item?.actionLabel).toBe("View validation health");
+	});
+
+	it("emits /settings#system + 'View validation health' for degraded state", async () => {
+		getAllMock.mockReturnValue(makeHealth("degraded"));
+
+		const items = await runAll(makeApp());
+		const item = items.find((i) => i.id === "validation-trash");
+
+		expect(item).toBeDefined();
+		expect(item?.severity).toBe("warning");
+		expect(item?.actionUrl).toBe("/settings#system");
+		expect(item?.actionLabel).toBe("View validation health");
+	});
+});

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -135,7 +135,7 @@ const collectArrSignals: Collector = async (app, userId, log) => {
 						title: `${instance.label}: ${issue.message}`,
 						detail: issue.source ? `Source: ${issue.source}` : "",
 						actionUrl: "/statistics",
-						actionLabel: "View statistics",
+						actionLabel: "View health issues",
 						source: service,
 						timestamp: now(),
 					});
@@ -287,7 +287,7 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				title: `${label}: ${cacheLabel} cache is stale`,
 				detail: `Last refreshed ${hoursAgo} hours ago`,
 				actionUrl: "/settings",
-				actionLabel: "Refresh cache",
+				actionLabel: "Check settings",
 				source: status.cacheType === "tautulli" ? "tautulli" : "plex",
 				timestamp: status.lastRefreshedAt.toISOString(),
 			});
@@ -316,8 +316,8 @@ const collectValidationHealth: Collector = async () => {
 				category: "health",
 				title: `${displayName} validation failing`,
 				detail: `${integration.consecutiveFailures} consecutive failures`,
-				actionUrl: "/settings",
-				actionLabel: "View health",
+				actionUrl: "/settings#system",
+				actionLabel: "View validation health",
 				source: "system",
 				timestamp: integration.lastFailureAt ?? now(),
 			});
@@ -328,8 +328,8 @@ const collectValidationHealth: Collector = async () => {
 				category: "health",
 				title: `${displayName} validation degraded`,
 				detail: `${integration.consecutiveFailures} recent failure(s)`,
-				actionUrl: "/settings",
-				actionLabel: "View health",
+				actionUrl: "/settings#system",
+				actionLabel: "View validation health",
 				source: "system",
 				timestamp: integration.lastFailureAt ?? now(),
 			});

--- a/apps/web/src/features/settings/components/__tests__/settings-client-hash.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/settings-client-hash.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Pins the `/settings#<tab>` deep-link behaviour.
+ *
+ * Pulse items (e.g. validation-health) deep-link to `/settings#system`
+ * expecting to land on the System tab. Without this, the client mounts
+ * on the default Services tab and the operator has to hunt — silently
+ * eroding the trust that action links point where they claim.
+ *
+ * We mock every child tab + data hook to a stub so this test only
+ * exercises the hash → activeTab wiring.
+ */
+
+import { render } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// --- Stub every hook the SettingsClient touches -----------------------------
+vi.mock("../../../../hooks/api/useAuth", () => ({
+	useCurrentUser: () => ({ data: { id: "u1", email: "op@example.com" } }),
+}));
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({ data: [], isLoading: false }),
+}));
+vi.mock("../../../../hooks/api/useTags", () => ({
+	useTagsQuery: () => ({ data: [] }),
+}));
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({ gradient: "" }),
+}));
+vi.mock("../../hooks", () => ({
+	useServiceFormState: () => ({
+		formState: {},
+		selectedServiceForEdit: null,
+		resetForm: vi.fn(),
+		handleEdit: vi.fn(),
+	}),
+	useServicesManagement: () => ({
+		handleSubmit: vi.fn(),
+		handleTestConnection: vi.fn(),
+		handleTestFormConnection: vi.fn(),
+		handleDeleteService: vi.fn(),
+		toggleDefault: vi.fn(),
+		toggleEnabled: vi.fn(),
+		resetFormTestResult: vi.fn(),
+		testingConnection: null,
+		testingFormConnection: false,
+		testResult: null,
+		formTestResult: null,
+		createServiceMutation: { isPending: false },
+		updateServiceMutation: { isPending: false },
+	}),
+	useTagsManagement: () => ({}),
+	useAccountManagement: () => ({}),
+}));
+
+// --- Stub every child tab so we don't pull in their deps --------------------
+// Factories are inline because vi.mock hoists above any module-scope helpers.
+vi.mock("../services-tab", () => ({
+	ServicesTab: () => <div data-testid="tab-services">services</div>,
+}));
+vi.mock("../tags-tab", () => ({ TagsTab: () => <div data-testid="tab-tags">tags</div> }));
+vi.mock("../account-tab", () => ({
+	AccountTab: () => <div data-testid="tab-account">account</div>,
+}));
+vi.mock("../appearance-tab", () => ({
+	AppearanceTab: () => <div data-testid="tab-appearance">appearance</div>,
+}));
+vi.mock("../backup-tab", () => ({
+	BackupTab: () => <div data-testid="tab-backup">backup</div>,
+}));
+vi.mock("../system-tab", () => ({
+	SystemTab: () => <div data-testid="tab-system">system</div>,
+}));
+vi.mock("../../../notifications/components/notifications-tab", () => ({
+	NotificationsTab: () => <div data-testid="tab-notifications">notifications</div>,
+}));
+vi.mock("../oidc-provider-section", () => ({ OIDCProviderSection: () => <div /> }));
+vi.mock("../passkey-section", () => ({ PasskeySection: () => <div /> }));
+vi.mock("../password-section", () => ({ PasswordSection: () => <div /> }));
+vi.mock("../getting-started-banner", () => ({ GettingStartedBanner: () => <div /> }));
+vi.mock("../service-form", () => ({ ServiceForm: () => <div /> }));
+vi.mock("../sessions-section", () => ({ SessionsSection: () => <div /> }));
+vi.mock("../../../../components/layout", () => ({
+	PremiumPageHeader: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+	PremiumPageLoading: () => <div>loading</div>,
+	PremiumTabs: () => <div />,
+}));
+
+import { SettingsClient } from "../settings-client";
+
+describe("SettingsClient — URL hash deep-link", () => {
+	beforeEach(() => {
+		window.location.hash = "";
+	});
+
+	it("defaults to the services tab when no hash is present", () => {
+		const { queryByTestId } = render(<SettingsClient />);
+		expect(queryByTestId("tab-services")).not.toBeNull();
+		expect(queryByTestId("tab-system")).toBeNull();
+	});
+
+	it("selects the System tab when hash is #system (validation-health Pulse link)", () => {
+		window.location.hash = "#system";
+		const { queryByTestId } = render(<SettingsClient />);
+		expect(queryByTestId("tab-system")).not.toBeNull();
+		expect(queryByTestId("tab-services")).toBeNull();
+	});
+
+	it("ignores an unknown hash and falls back to the default tab", () => {
+		window.location.hash = "#not-a-tab";
+		const { queryByTestId } = render(<SettingsClient />);
+		expect(queryByTestId("tab-services")).not.toBeNull();
+	});
+});

--- a/apps/web/src/features/settings/components/settings-client.tsx
+++ b/apps/web/src/features/settings/components/settings-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Archive, Bell, Cpu, Palette, Server, Settings, Shield, Tags, User } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
 	PremiumPageHeader,
 	PremiumPageLoading,
@@ -19,7 +19,7 @@ import {
 	useServicesManagement,
 	useTagsManagement,
 } from "../hooks";
-import type { TabType } from "../lib/settings-constants";
+import { TABS, type TabType } from "../lib/settings-constants";
 import { AccountTab } from "./account-tab";
 import { AppearanceTab } from "./appearance-tab";
 import { BackupTab } from "./backup-tab";
@@ -51,6 +51,16 @@ export const SettingsClient = () => {
 
 	// Local state
 	const [activeTab, setActiveTab] = useState<TabType>("services");
+
+	// Deep-link support: `/settings#system` (and other tab ids) selects that
+	// tab on mount. Mirrors the hash-scroll pattern used by /pulse#<item-id>.
+	useEffect(() => {
+		if (typeof window === "undefined") return;
+		const hash = window.location.hash.slice(1);
+		if ((TABS as readonly string[]).includes(hash)) {
+			setActiveTab(hash as TabType);
+		}
+	}, []);
 
 	// Custom hooks
 	const serviceFormState = useServiceFormState();


### PR DESCRIPTION
## Summary

Final v2.16.0 operator-clarity polish. Three tight refinements to Pulse / Needs Attention action links so operators land where the button promised:

- **ARR health items** — `actionLabel` `"View statistics"` → `"View health issues"`. The destination is unchanged (Statistics Overview *does* render the aggregated health banner), but the old label sold it as charts and hid the relevance.
- **Cache staleness** — `actionLabel` `"Refresh cache"` → `"Check settings"`. The button navigates, it doesn't mutate; the new label matches the sibling error variant and stops overclaiming.
- **Validation health** — `actionUrl` `/settings` → `/settings#system` and `actionLabel` `"View health"` → `"View validation health"`. `SettingsClient` now reads `window.location.hash` on mount; if it matches one of the existing `TABS` ids, that tab is selected. Reuses the same deep-link verb `/pulse#<id>` already uses — no new abstraction.

Scope-locked: 4 files, +237 / -8. No new features, no refactors.

## Why this improves operator trust

1. Action button labels now describe outcomes, not nav items.
2. Cache item no longer promises a verb ("Refresh") it can't perform.
3. Validation-health deep-link lands the operator on Settings → System (where `ValidationHealthSection` lives) instead of the default Services tab, which required hunting across 8 tabs.

## Test plan

- [x] `pnpm --filter @arr/api exec vitest run src/lib/pulse` — 24/24 pass (includes 2 new label-pin tests).
- [x] `pnpm --filter @arr/web exec vitest run src/features/settings` — 48/48 pass (includes 3 new hash-deep-link tests).
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean.
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean.
- [x] Biome / ESLint — no new warnings from this diff.
- [x] Manual smoke: navigated to `/settings#system` (the validation-health Pulse link path) — confirmed `settings-panel-system` renders on first load, Services panel absent.
- [x] Manual smoke: navigated to `/settings#appearance` — confirmed `settings-panel-appearance` renders on load (fresh navigation / hard reload, which is the real-world path from a cross-page Pulse click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)