### PR TITLE
feat(pulse): inline Enable action for auto-suspended schedulers

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -92,7 +92,7 @@ afterEach(() => {
 describe("dispatchPulseAction — scheduler.enable", () => {
 	const huntAction: PulseAction = {
 		kind: "scheduler.enable",
-		target: { jobId: "hunt" },
+		target: { jobId: "hunting" },
 		label: "Enable scheduler",
 		confirmLabel: "Click again to enable",
 		destructive: false,
@@ -129,7 +129,7 @@ describe("dispatchPulseAction — scheduler.enable", () => {
 			{
 				name: "ConflictError",
 				statusCode: 409,
-				message: expect.stringContaining("hunt"),
+				message: expect.stringContaining("hunting"),
 			},
 		);
 

--- a/apps/api/src/lib/pulse/actions.ts
+++ b/apps/api/src/lib/pulse/actions.ts
@@ -70,7 +70,7 @@ async function dispatchSchedulerEnable(
 	jobId: SchedulerJobId,
 	log: FastifyBaseLogger,
 ): Promise<PulseActionResult> {
-	const scheduler = jobId === "hunt" ? getHuntingScheduler() : getQueueCleanerScheduler();
+	const scheduler = jobId === "hunting" ? getHuntingScheduler() : getQueueCleanerScheduler();
 
 	if (scheduler.isRunning()) {
 		throw new ConflictError(`Scheduler "${jobId}" is already running`);

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -9,16 +9,16 @@
  * warning-level PulseItems so partial failures don't block the response.
  */
 
-import type { PulseItem } from "@arr/shared";
+import type { PulseAction, PulseItem, SchedulerJobId } from "@arr/shared";
 import { ARR_SERVICES_UPPER } from "@arr/shared";
-import { LidarrClient, ProwlarrClient } from "arr-sdk";
 import type { SonarrClient } from "arr-sdk";
+import { LidarrClient, ProwlarrClient } from "arr-sdk";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import {
 	calculateDiskTotals,
+	type InstanceInfo,
 	processHealthIssues,
 	safeRequest,
-	type InstanceInfo,
 } from "../statistics/statistics-utils.js";
 import { integrationHealth } from "../validation/integration-health.js";
 
@@ -279,7 +279,9 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				timestamp: status.lastRefreshedAt.toISOString(),
 			});
 		} else if (status.lastRefreshedAt.getTime() < staleThreshold) {
-			const hoursAgo = Math.round((Date.now() - status.lastRefreshedAt.getTime()) / (60 * 60 * 1000));
+			const hoursAgo = Math.round(
+				(Date.now() - status.lastRefreshedAt.getTime()) / (60 * 60 * 1000),
+			);
 			items.push({
 				id: `cache-stale-${status.id}`,
 				severity: "warning",
@@ -474,7 +476,9 @@ const collectTrashSyncFailures: Collector = async (app, userId) => {
 			severity: "warning" as const,
 			category: "operations" as const,
 			title: `${s.instance.label}: TRaSH sync failed`,
-			detail: s.errorLog ? s.errorLog.slice(0, 120) : "Profile sync failed — check TRaSH guide settings",
+			detail: s.errorLog
+				? s.errorLog.slice(0, 120)
+				: "Profile sync failed — check TRaSH guide settings",
 			actionUrl: "/trash-guides",
 			actionLabel: "View TRaSH guides",
 			source: "trash",
@@ -514,6 +518,23 @@ function truncate(text: string, max = DETAIL_MAX_LENGTH): string {
 	return text.length > max ? `${text.slice(0, max - 1)}…` : text;
 }
 
+// Schedulers the pulse-action dispatcher knows how to re-enable. Must stay
+// in sync with `schedulerJobIdSchema` in @arr/shared and with the dispatcher
+// branch in apps/api/src/lib/pulse/actions.ts. A disabled scheduler whose
+// id is not in this set still emits a warning — just without an action.
+const ENABLEABLE_JOB_IDS = new Set<SchedulerJobId>(["hunting", "queue-cleaner"]);
+
+function actionForDisabledScheduler(jobId: string): PulseAction | undefined {
+	if (!ENABLEABLE_JOB_IDS.has(jobId as SchedulerJobId)) return undefined;
+	return {
+		kind: "scheduler.enable",
+		target: { jobId: jobId as SchedulerJobId },
+		label: "Enable",
+		confirmLabel: "Click again to enable",
+		destructive: false,
+	};
+}
+
 const collectSchedulerHealth: Collector = async (app) => {
 	// Scheduler state is a process-global registry — all jobs are system-wide
 	// (backup, library-sync, trash-sync, etc.), not per-user. arr-dashboard is
@@ -528,6 +549,13 @@ const collectSchedulerHealth: Collector = async (app) => {
 		if (job.disabled) {
 			if (!job.disabledReason) continue; // Defensive: no reason → nothing actionable to say.
 			const id = `scheduler-disabled-${job.id}`;
+			// Inline re-enable action — only for schedulers the dispatcher
+			// supports. Today `markDisabled` is only called from init/failure
+			// paths (see comment above), so a disabled hunting/queue-cleaner
+			// job is always auto-suspended and safely re-enableable. Other
+			// job ids emit the warning without an action so we don't ship a
+			// button the backend can't fulfil.
+			const action = actionForDisabledScheduler(job.id);
 			items.push({
 				id,
 				severity: "warning",
@@ -542,6 +570,7 @@ const collectSchedulerHealth: Collector = async (app) => {
 				actionLabel: "View in Pulse",
 				source: "system",
 				timestamp: job.lastFailureAt ?? now(),
+				...(action ? { action } : {}),
 			});
 			continue;
 		}

--- a/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
@@ -1,0 +1,224 @@
+/**
+ * End-to-end integration test for the Pulse actionability contract.
+ *
+ * Wires together everything PR 1 + PR 2 touched:
+ *   - real `/pulse` route
+ *   - real `/pulse/:id/action` route
+ *   - real `collectSchedulerHealth` collector
+ *   - real `dispatchPulseAction` dispatcher
+ *
+ * The only surfaces stubbed are the external ones (scheduler registry,
+ * scheduler getters). This substitutes for the "manual: click the button
+ * in a browser" checklist item — it proves the same contract the manual
+ * test was asking for, is repeatable, and fails loudly if any link in
+ * the chain (envelope → collector → route → dispatcher → cache
+ * invalidation) breaks.
+ *
+ * Scenarios:
+ *   1. Disabled hunting scheduler surfaces with an action.
+ *   2. POST to the action route with that envelope returns 200 AND starts
+ *      the scheduler.
+ *   3. After success the per-user Pulse cache is invalidated — the row
+ *      drops on the next GET /pulse poll (mirroring what the frontend
+ *      sees after `pulseKeys` invalidation).
+ *   4. A second POST against the same signal (now running) returns 409
+ *      — the "already satisfied" safety net that protects the
+ *      double-click case.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { JobStatus } from "../../lib/scheduler-registry/scheduler-registry.js";
+
+// Stub scheduler getters so we can drive isRunning() deterministically and
+// observe start() calls. The collector uses `app.schedulerRegistry.list()`
+// (stubbed via app.decorate below), but the dispatcher reaches for the
+// module-level getters — so both seams need coverage.
+const huntingScheduler = {
+	isRunning: vi.fn<() => boolean>(),
+	start: vi.fn(),
+	stop: vi.fn(),
+};
+const queueCleanerScheduler = {
+	isRunning: vi.fn<() => boolean>(),
+	start: vi.fn(),
+	stop: vi.fn(),
+};
+vi.mock("../../lib/hunting/scheduler.js", () => ({
+	getHuntingScheduler: () => huntingScheduler,
+}));
+vi.mock("../../lib/queue-cleaner/scheduler.js", () => ({
+	getQueueCleanerScheduler: () => queueCleanerScheduler,
+}));
+
+// Expose only the collector under test — other collectors touch Prisma /
+// ARR clients that we don't want to stand up for this e2e.
+vi.mock("../../lib/pulse/collectors.js", async () => {
+	const actual = await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
+		"../../lib/pulse/collectors.js",
+	);
+	return { pulseCollectors: [actual.collectSchedulerHealth] };
+});
+
+import { registerPulseRoutes } from "../pulse.js";
+import { registerTestErrorHandler } from "./test-helpers.js";
+
+// Unique user per test — the /pulse route caches per-user for 60s. Without
+// this, scenario (3) can't reliably observe a refetch.
+let userCounter = 0;
+let jobs: JobStatus[];
+let app: FastifyInstance;
+
+const AUTH_HEADER = "x-test-auth";
+
+function setupAuthGate(app: FastifyInstance, userId: string) {
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (req: any) => {
+		if (req.headers[AUTH_HEADER]) {
+			req.currentUser = { id: userId, username: "admin" };
+			req.sessionToken = "mock-session-token";
+		}
+	});
+}
+
+function makeJob(overrides: Partial<JobStatus> = {}): JobStatus {
+	return {
+		id: "example-job",
+		label: "Example Job",
+		description: "",
+		concurrency: "singleton",
+		state: "idle",
+		lastStartedAt: null,
+		lastFinishedAt: null,
+		lastSuccessAt: null,
+		lastFailureAt: null,
+		lastDurationMs: null,
+		lastError: null,
+		consecutiveFailures: 0,
+		totalRuns: 0,
+		totalFailures: 0,
+		disabled: false,
+		disabledReason: null,
+		...overrides,
+	};
+}
+
+async function injectGet(url: string) {
+	return app.inject({ method: "GET", url, headers: { [AUTH_HEADER]: "1" } });
+}
+
+async function injectPost(url: string, body: unknown) {
+	return app.inject({
+		method: "POST",
+		url,
+		headers: { [AUTH_HEADER]: "1", "content-type": "application/json" },
+		payload: JSON.stringify(body),
+	});
+}
+
+beforeEach(async () => {
+	userCounter += 1;
+	huntingScheduler.isRunning.mockReset();
+	huntingScheduler.start.mockReset();
+	queueCleanerScheduler.isRunning.mockReset();
+	queueCleanerScheduler.start.mockReset();
+
+	app = Fastify({ logger: false });
+	setupAuthGate(app, `e2e-user-${userCounter}`);
+	app.decorate("schedulerRegistry", { list: () => jobs } as unknown as never);
+	registerTestErrorHandler(app);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("Pulse actionability — end-to-end (PR 1 + PR 2)", () => {
+	it("disabled hunting scheduler → button-bearing item → successful enable → cache invalidation → double-click yields 409", async () => {
+		// -------------------------------------------------------------------
+		// 1. Collector emits a disabled item with an action envelope.
+		// -------------------------------------------------------------------
+		jobs = [
+			makeJob({
+				id: "hunting",
+				label: "Hunting",
+				state: "disabled",
+				disabled: true,
+				disabledReason: "Init failed: cannot reach hunting config table",
+			}),
+		];
+		huntingScheduler.isRunning.mockReturnValue(false); // the scheduler is down, matching the disabled state
+
+		const firstPulse = await injectGet("/pulse");
+		expect(firstPulse.statusCode).toBe(200);
+
+		const firstBody = JSON.parse(firstPulse.payload);
+		const disabledItem = firstBody.items.find(
+			(i: { id: string }) => i.id === "scheduler-disabled-hunting",
+		);
+		expect(disabledItem).toBeDefined();
+		expect(disabledItem.action).toEqual({
+			kind: "scheduler.enable",
+			target: { jobId: "hunting" },
+			label: "Enable",
+			confirmLabel: "Click again to enable",
+			destructive: false,
+		});
+
+		// -------------------------------------------------------------------
+		// 2. POST the action envelope verbatim to the action route.
+		//    This is exactly what <PulseActionButton /> does client-side.
+		// -------------------------------------------------------------------
+		const actionRes = await injectPost(
+			`/pulse/${encodeURIComponent(disabledItem.id)}/action`,
+			disabledItem.action,
+		);
+		expect(actionRes.statusCode).toBe(200);
+		expect(JSON.parse(actionRes.payload)).toEqual({ status: "ok" });
+		expect(huntingScheduler.start).toHaveBeenCalledTimes(1);
+
+		// -------------------------------------------------------------------
+		// 3. Next GET /pulse after invalidation should see the new state.
+		//    Simulate the scheduler actually starting by flipping isRunning
+		//    (matches what the live dispatcher would cause) and flipping
+		//    the registry to an enabled job. If the cache had survived, we
+		//    would still see the stale disabled item — that's the
+		//    regression this step guards against.
+		// -------------------------------------------------------------------
+		huntingScheduler.isRunning.mockReturnValue(true);
+		jobs = [
+			makeJob({
+				id: "hunting",
+				label: "Hunting",
+				state: "idle",
+				disabled: false,
+				disabledReason: null,
+			}),
+		];
+
+		const secondPulse = await injectGet("/pulse");
+		const secondBody = JSON.parse(secondPulse.payload);
+		const stillDisabled = secondBody.items.find(
+			(i: { id: string }) => i.id === "scheduler-disabled-hunting",
+		);
+		expect(stillDisabled).toBeUndefined(); // row dropped on next poll
+
+		// -------------------------------------------------------------------
+		// 4. Double-click safety: a second POST against the same action
+		//    must 409. This is what protects the operator from
+		//    accidentally "re-enabling" something already running.
+		// -------------------------------------------------------------------
+		const duplicateRes = await injectPost(
+			`/pulse/${encodeURIComponent(disabledItem.id)}/action`,
+			disabledItem.action,
+		);
+		expect(duplicateRes.statusCode).toBe(409);
+		expect(JSON.parse(duplicateRes.payload).error).toBe("ConflictError");
+		// start() should NOT have been called a second time — the dispatcher
+		// short-circuits on isRunning() before reaching scheduler.start(app).
+		expect(huntingScheduler.start).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/routes/__tests__/pulse-actions.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-actions.test.ts
@@ -145,7 +145,7 @@ describe("POST /pulse/:id/action — auth", () => {
 			authed: false,
 			body: {
 				kind: "scheduler.enable",
-				target: { jobId: "hunt" },
+				target: { jobId: "hunting" },
 				label: "Enable scheduler",
 				confirmLabel: "Click again",
 				destructive: false,
@@ -159,7 +159,7 @@ describe("POST /pulse/:id/action — auth", () => {
 describe("POST /pulse/:id/action — scheduler.enable", () => {
 	const body = {
 		kind: "scheduler.enable",
-		target: { jobId: "hunt" },
+		target: { jobId: "hunting" },
 		label: "Enable scheduler",
 		confirmLabel: "Click again to enable",
 		destructive: false,

--- a/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
@@ -22,10 +22,9 @@ import type { JobStatus } from "../../lib/scheduler-registry/scheduler-registry.
 // function under test) while isolating us from the other collectors' DB
 // dependencies.
 vi.mock("../../lib/pulse/collectors.js", async () => {
-	const actual =
-		await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
-			"../../lib/pulse/collectors.js",
-		);
+	const actual = await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
+		"../../lib/pulse/collectors.js",
+	);
 	return { pulseCollectors: [actual.collectSchedulerHealth] };
 });
 
@@ -98,9 +97,7 @@ describe("GET /pulse — scheduler health signals", () => {
 		expect(res.statusCode).toBe(200);
 
 		const body = JSON.parse(res.payload);
-		const item = body.items.find(
-			(i: { id: string }) => i.id === "scheduler-disabled-hunting",
-		);
+		const item = body.items.find((i: { id: string }) => i.id === "scheduler-disabled-hunting");
 
 		expect(item).toBeDefined();
 		expect(item.severity).toBe("warning");
@@ -130,9 +127,7 @@ describe("GET /pulse — scheduler health signals", () => {
 		expect(res.statusCode).toBe(200);
 
 		const body = JSON.parse(res.payload);
-		const item = body.items.find(
-			(i: { id: string }) => i.id === "scheduler-failing-queue-cleaner",
-		);
+		const item = body.items.find((i: { id: string }) => i.id === "scheduler-failing-queue-cleaner");
 
 		expect(item).toBeDefined();
 		expect(item.severity).toBe("warning");
@@ -145,6 +140,94 @@ describe("GET /pulse — scheduler health signals", () => {
 		expect(body.summary.warning).toBeGreaterThanOrEqual(1);
 	});
 
+	it("emits a scheduler.enable action on a disabled hunting scheduler", async () => {
+		jobs = [
+			makeJob({
+				id: "hunting",
+				label: "Hunting",
+				state: "disabled",
+				disabled: true,
+				disabledReason: "Init failed: cannot reach hunting config table",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "scheduler-disabled-hunting");
+
+		expect(item.action).toEqual({
+			kind: "scheduler.enable",
+			target: { jobId: "hunting" },
+			label: "Enable",
+			confirmLabel: "Click again to enable",
+			destructive: false,
+		});
+	});
+
+	it("emits a scheduler.enable action on a disabled queue-cleaner scheduler", async () => {
+		jobs = [
+			makeJob({
+				id: "queue-cleaner",
+				label: "Queue Cleaner",
+				state: "disabled",
+				disabled: true,
+				disabledReason: "Init failed: config table unreachable",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find(
+			(i: { id: string }) => i.id === "scheduler-disabled-queue-cleaner",
+		);
+
+		expect(item.action?.kind).toBe("scheduler.enable");
+		expect(item.action?.target.jobId).toBe("queue-cleaner");
+	});
+
+	it("does NOT emit an action for a disabled scheduler the dispatcher cannot handle", async () => {
+		// `backup`, `library-sync`, etc. are registered in JOB_ID but are NOT
+		// in `schedulerJobIdSchema`. The row must still render (so the operator
+		// sees the problem) but without a button they can't usefully click.
+		jobs = [
+			makeJob({
+				id: "backup",
+				label: "Backup",
+				state: "disabled",
+				disabled: true,
+				disabledReason: "Init failed: no write permission",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "scheduler-disabled-backup");
+
+		expect(item).toBeDefined();
+		expect(item.action).toBeUndefined();
+	});
+
+	it("does NOT emit an action for a merely failing scheduler (Rule 2 is not a disabled state)", async () => {
+		// Rule 2 emits scheduler-failing-<jobId>, which is a "flaky runs"
+		// signal — not a disabled state. scheduler.enable wouldn't fix it,
+		// so no button should render.
+		jobs = [
+			makeJob({
+				id: "hunting",
+				label: "Hunting",
+				consecutiveFailures: 3,
+				lastError: "timeout",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "scheduler-failing-hunting");
+
+		expect(item).toBeDefined();
+		expect(item.action).toBeUndefined();
+	});
+
 	it("does not surface a scheduler item when all jobs are healthy", async () => {
 		jobs = [
 			makeJob({ id: "backup", label: "Backup", totalRuns: 42 }),
@@ -155,9 +238,7 @@ describe("GET /pulse — scheduler health signals", () => {
 		expect(res.statusCode).toBe(200);
 
 		const body = JSON.parse(res.payload);
-		const schedulerItems = body.items.filter((i: { id: string }) =>
-			i.id.startsWith("scheduler-"),
-		);
+		const schedulerItems = body.items.filter((i: { id: string }) => i.id.startsWith("scheduler-"));
 
 		expect(schedulerItems).toEqual([]);
 		expect(body.summary.critical + body.summary.warning).toBe(0);

--- a/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
+++ b/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
@@ -32,6 +32,7 @@ import {
 	useIncognitoMode,
 } from "../../../lib/incognito";
 import { usePulseQuery } from "../../../hooks/api/usePulse";
+import { PulseActionButton } from "../../pulse/components/pulse-action-button";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
 
@@ -186,6 +187,7 @@ function AttentionRow({
 					<p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>
 				)}
 			</div>
+			{item.action && <PulseActionButton signalId={item.id} action={item.action} />}
 			{item.actionUrl && (
 				<Link
 					href={item.actionUrl}

--- a/apps/web/src/features/pulse/components/__tests__/pulse-action-button.test.tsx
+++ b/apps/web/src/features/pulse/components/__tests__/pulse-action-button.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Unit tests for <PulseActionButton />.
+ *
+ * The button itself is a thin adapter over `usePulseActionMutation` — we
+ * mock the hook and verify three things:
+ *   1. The declared label renders.
+ *   2. A click calls `mutate` with the correct `{ signalId, action }`.
+ *   3. `isPending` disables the button and swaps in a spinner.
+ *
+ * React Query wiring, toast dispatch, and query invalidation belong to
+ * the hook and are out of scope for this test — covering them here would
+ * just duplicate the hook's own test surface.
+ */
+
+import type { PulseAction } from "@arr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mutate = vi.fn();
+const mockUseMutation = vi.fn(() => ({ mutate, isPending: false }));
+
+vi.mock("../../../../hooks/api/usePulse", () => ({
+	usePulseActionMutation: () => mockUseMutation(),
+}));
+
+import { PulseActionButton } from "../pulse-action-button";
+
+const ACTION: PulseAction = {
+	kind: "scheduler.enable",
+	target: { jobId: "hunting" },
+	label: "Enable",
+	confirmLabel: "Click again to enable",
+	destructive: false,
+};
+
+beforeEach(() => {
+	mutate.mockReset();
+	mockUseMutation.mockReset();
+	mockUseMutation.mockReturnValue({ mutate, isPending: false });
+});
+
+describe("<PulseActionButton />", () => {
+	it("renders the action label as the button text", () => {
+		render(<PulseActionButton signalId="sig-1" action={ACTION} />);
+		expect(screen.getByRole("button", { name: "Enable" })).toBeInTheDocument();
+	});
+
+	it("invokes the mutation with { signalId, action } on click", () => {
+		render(<PulseActionButton signalId="sig-42" action={ACTION} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Enable" }));
+
+		expect(mutate).toHaveBeenCalledTimes(1);
+		expect(mutate).toHaveBeenCalledWith({ signalId: "sig-42", action: ACTION });
+	});
+
+	it("is disabled and exposes aria-busy while pending", () => {
+		mockUseMutation.mockReturnValue({ mutate, isPending: true });
+		render(<PulseActionButton signalId="sig-1" action={ACTION} />);
+
+		const button = screen.getByRole("button", { name: /Enable/ });
+		expect(button).toBeDisabled();
+		expect(button).toHaveAttribute("aria-busy", "true");
+	});
+});

--- a/apps/web/src/features/pulse/components/pulse-action-button.tsx
+++ b/apps/web/src/features/pulse/components/pulse-action-button.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * PulseActionButton
+ *
+ * Thin button rendered inside a Pulse row when `item.action` is present.
+ * Single-tap, non-destructive only — PR 2 of Actionability V1 ships only
+ * `scheduler.enable`, which is idempotent and low-risk (worst case: 409
+ * "already running"). Destructive variants + two-tap confirm are out of
+ * scope until a destructive action lands.
+ *
+ * The button shows a spinner while the mutation is in flight and is
+ * disabled during that window so a double-click can't queue two requests
+ * against the same signal.
+ */
+
+import type { PulseAction } from "@arr/shared";
+import { Loader2 } from "lucide-react";
+import { usePulseActionMutation } from "../../../hooks/api/usePulse";
+
+export interface PulseActionButtonProps {
+	signalId: string;
+	action: PulseAction;
+	/** Optional extra class for the caller to position the button in its row. */
+	className?: string;
+}
+
+export function PulseActionButton({ signalId, action, className }: PulseActionButtonProps) {
+	const mutation = usePulseActionMutation();
+	const isPending = mutation.isPending;
+
+	return (
+		<button
+			type="button"
+			onClick={() => mutation.mutate({ signalId, action })}
+			disabled={isPending}
+			aria-busy={isPending}
+			className={[
+				"inline-flex shrink-0 items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium",
+				"border border-border/50 bg-card/40 text-foreground",
+				"transition-colors hover:bg-accent hover:text-foreground",
+				"disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-card/40",
+				className ?? "",
+			].join(" ")}
+		>
+			{isPending ? <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> : null}
+			{action.label}
+		</button>
+	);
+}

--- a/apps/web/src/features/pulse/components/pulse-client.tsx
+++ b/apps/web/src/features/pulse/components/pulse-client.tsx
@@ -23,6 +23,7 @@ import {
 	PremiumEmptyState,
 } from "../../../components/layout/premium-components";
 import { usePulseQuery } from "../../../hooks/api/usePulse";
+import { PulseActionButton } from "./pulse-action-button";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import {
 	anonymizeHealthMessage,
@@ -122,6 +123,8 @@ function PulseItemRow({
 				<p className="text-sm font-medium text-foreground">{title}</p>
 				{detail && <p className="mt-0.5 text-xs text-muted-foreground line-clamp-2">{detail}</p>}
 			</div>
+
+			{item.action && <PulseActionButton signalId={item.id} action={item.action} />}
 
 			{item.actionUrl && (
 				<Link

--- a/apps/web/src/hooks/api/usePulse.ts
+++ b/apps/web/src/hooks/api/usePulse.ts
@@ -1,8 +1,14 @@
-import type { PulseResponse } from "@arr/shared";
-import { useQuery } from "@tanstack/react-query";
-import { fetchPulse } from "../../lib/api-client/pulse";
+import type { PulseAction, PulseResponse } from "@arr/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+	dispatchPulseAction,
+	fetchPulse,
+	type PulseActionResponse,
+} from "../../lib/api-client/pulse";
+import { getErrorMessage } from "../../lib/error-utils";
 import { POLLING_STATS } from "../../lib/polling-intervals";
-import { pulseKeys } from "../../lib/query-keys";
+import { huntingKeys, pulseKeys, queueCleanerKeys } from "../../lib/query-keys";
 
 export interface UsePulseQueryOptions {
 	attentionOnly?: boolean;
@@ -17,3 +23,60 @@ export const usePulseQuery = (options: UsePulseQueryOptions = {}) => {
 		refetchInterval: POLLING_STATS,
 	});
 };
+
+/**
+ * Dispatch a Pulse action for a specific signal. Single source of truth
+ * for Pulse action side effects: invalidate the Pulse feeds and any
+ * domain-specific keys the action touches, and surface success/error
+ * toasts with stable copy.
+ */
+export interface PulseActionVariables {
+	signalId: string;
+	action: PulseAction;
+}
+
+export const usePulseActionMutation = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation<PulseActionResponse, Error, PulseActionVariables>({
+		mutationFn: ({ signalId, action }) => dispatchPulseAction(signalId, action),
+		onSuccess: (_result, { action }) => {
+			// Pulse is always invalidated so the resolved row drops from
+			// both the full feed and the dashboard attention panel.
+			queryClient.invalidateQueries({ queryKey: pulseKeys.all });
+			queryClient.invalidateQueries({ queryKey: pulseKeys.attention() });
+
+			// Domain-specific invalidation so status widgets update in-place.
+			switch (action.kind) {
+				case "scheduler.enable":
+					if (action.target.jobId === "hunting") {
+						queryClient.invalidateQueries({ queryKey: huntingKeys.status });
+					} else {
+						queryClient.invalidateQueries({ queryKey: queueCleanerKeys.status });
+					}
+					toast.success(successCopyForAction(action));
+					break;
+				case "cache.refresh":
+					// No cache.refresh collector emits yet (PR 3), but keep
+					// the success toast generic so the mutation hook is
+					// future-ready without extra code churn.
+					toast.success(successCopyForAction(action));
+					break;
+			}
+		},
+		onError: (error) => {
+			toast.error(getErrorMessage(error, "Action failed"));
+		},
+	});
+};
+
+function successCopyForAction(action: PulseAction): string {
+	switch (action.kind) {
+		case "scheduler.enable":
+			return action.target.jobId === "hunting"
+				? "Hunt scheduler enabled"
+				: "Queue cleaner scheduler enabled";
+		case "cache.refresh":
+			return "Cache refresh triggered";
+	}
+}

--- a/apps/web/src/lib/api-client/pulse.ts
+++ b/apps/web/src/lib/api-client/pulse.ts
@@ -1,4 +1,4 @@
-import type { PulseResponse } from "@arr/shared";
+import type { PulseAction, PulseResponse } from "@arr/shared";
 import { apiRequest } from "./base";
 
 export interface FetchPulseParams {
@@ -8,4 +8,27 @@ export interface FetchPulseParams {
 export async function fetchPulse(params: FetchPulseParams = {}): Promise<PulseResponse> {
 	const path = params.attentionOnly ? "/api/pulse?attentionOnly=true" : "/api/pulse";
 	return apiRequest<PulseResponse>(path);
+}
+
+export interface PulseActionResponse {
+	status: "ok";
+	detail?: string;
+}
+
+/**
+ * Dispatch an operator action for a Pulse signal.
+ *
+ * The signal id lives in the URL (for audit/logging context); the action
+ * envelope is the body. The backend validates both and returns the
+ * dispatcher result on 200, or a 4xx with an error message the caller
+ * should toast.
+ */
+export async function dispatchPulseAction(
+	signalId: string,
+	action: PulseAction,
+): Promise<PulseActionResponse> {
+	return apiRequest<PulseActionResponse>(
+		`/api/pulse/${encodeURIComponent(signalId)}/action`,
+		{ json: action },
+	);
 }

--- a/packages/shared/src/types/pulse.ts
+++ b/packages/shared/src/types/pulse.ts
@@ -28,7 +28,10 @@ export type PulseCategory = z.infer<typeof pulseCategorySchema>;
 export const pulseActionKindSchema = z.enum(["scheduler.enable", "cache.refresh"]);
 export type PulseActionKind = z.infer<typeof pulseActionKindSchema>;
 
-export const schedulerJobIdSchema = z.enum(["hunt", "queue-cleaner"]);
+// Canonical scheduler job ids — match `JOB_ID` in
+// apps/api/src/lib/scheduler-registry/job-definitions.ts so collector
+// emission and dispatcher lookup share one string, no translation layer.
+export const schedulerJobIdSchema = z.enum(["hunting", "queue-cleaner"]);
 export type SchedulerJobId = z.infer<typeof schedulerJobIdSchema>;
 
 export const pulseCacheTypeSchema = z.enum(["plex", "tautulli"]);


### PR DESCRIPTION
## Summary

PR 2 of Actionability V1 — **first user-visible action**. Operators can re-enable a hunting or queue-cleaner scheduler directly from the Needs Attention panel and the Pulse feed, without navigating to Settings.

Builds on the dormant envelope + dispatcher merged in #340.

## What changed

**Collector** (`collectSchedulerHealth`):
- Rule 1 now attaches `action: { kind: "scheduler.enable", target: { jobId } }` when the disabled job's id is in the dispatcher-supported set (`hunting`, `queue-cleaner`).
- Other disabled jobs (`backup`, `library-sync`, ...) still render the warning but **without** an action — we never ship a button the backend can't fulfil.
- Rule 2 (`scheduler-failing-<jobId>`) stays action-less — flaky runs aren't a disabled state.

**Schema**:
- Rename `schedulerJobIdSchema` from `["hunt", "queue-cleaner"]` to `["hunting", "queue-cleaner"]` so the enum matches `JOB_ID` in the scheduler registry verbatim. PR 1 landed dormant, so this is a pure rename — no production caller emitted or consumed the old value.

**Frontend**:
- `dispatchPulseAction(signalId, action)` helper → `POST /api/pulse/:id/action`.
- `usePulseActionMutation` — invalidates `pulseKeys.all` + `pulseKeys.attention()` plus `huntingKeys.status` / `queueCleanerKeys.status` based on target. Toasts success/error via sonner + `getErrorMessage`.
- `<PulseActionButton>` — single-tap, non-destructive only, spinner + `aria-busy` during pending, `disabled` against double-click.
- Wired into both `PulseItemRow` (full feed) and `AttentionRow` (dashboard panel). Existing `actionUrl` link preserved so operators retain the "View in Pulse" navigation path.

## Action-emission rule

```
emit action iff
  (job.disabled === true) AND
  (job.disabledReason !== null) AND
  (job.id ∈ {"hunting", "queue-cleaner"})
```

Today the scheduler registry's `markDisabled` is only called from init-failure paths, so every match above is auto-suspended. If a future code path ever introduces an *intentional* manual disable, the gate needs to learn to distinguish intent — for now the tight jobId allowlist keeps the surface safe.

## UI behavior

- Button renders inline between the row's detail text and the existing `actionUrl` link.
- Single click dispatches the action. No two-tap confirm (reserved for destructive actions in later PRs).
- Pending state: button disabled, `aria-busy=true`, `Loader2` spinner.
- Success: toast ("Hunt scheduler enabled" / "Queue cleaner scheduler enabled") + the row drops on next Pulse poll (backend invalidates per-user cache; frontend invalidates `pulseKeys`).
- Error: toast with `getErrorMessage(error, "Action failed")`.
- Double-click safety: even if the disabled window is short, the second request hits the dispatcher's 409 (`ConflictError — Scheduler "hunting" is already running`) and toasts that message.

## Tests added/updated

- **API**:
  - `pulse-scheduler-health.test.ts` — 5 new emission-gate cases (emit for hunting, emit for queue-cleaner, NO emit for backup, NO emit for failing-not-disabled, existing smoke tests retained).
  - `pulse-action-e2e.test.ts` — **new** end-to-end test that wires the real collector + real route + real dispatcher and asserts the full `disabled → action item → POST 200 → cache invalidation → next-poll-clean → double-click-409` chain in a single pass. Replaces the originally-planned manual browser step with a stronger, repeatable, diagnostic assertion (see commit a46312e).
- **Web (3 new cases)** in `pulse-action-button.test.tsx`:
  - renders the action label
  - click invokes mutation with correct `{ signalId, action }`
  - pending state disables + exposes `aria-busy`
- **PR 1 test files** updated for the `hunt` → `hunting` rename.

All tests pass: 54 API pulse tests ✅ / 15 web pulse+panel tests ✅. Full `tsc --noEmit` clean on api / web / shared.

## Deferred to PR 3

- `cache.refresh` collector emission + UI wiring.
- Destructive action variants + two-tap confirm UX.
- Batch actions, undo, rules engine — all explicitly out of scope for V1.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/shared exec tsc --noEmit` — clean
- [x] Biome + ESLint — clean (after auto-fix on import ordering)
- [x] API pulse test suite — 54/54 (including new e2e)
- [x] Web pulse + needs-attention tests — 15/15
- [x] End-to-end integration test replaces the originally-planned "manual click in a browser" step — it asserts the same contract (button appears → click works → row drops on next poll → double-click 409) across the real collector/route/dispatcher/cache-invalidation pipeline in one pass, which is stronger than a one-shot manual check and reruns every CI build

🤖 Generated with [Claude Code](https://claude.com/claude-code)