### PR TITLE
feat(pulse): inline Refresh now action for stale Plex/Tautulli caches

### DIFF
--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -9,7 +9,7 @@
  * warning-level PulseItems so partial failures don't block the response.
  */
 
-import type { PulseAction, PulseItem, SchedulerJobId } from "@arr/shared";
+import type { PulseAction, PulseCacheType, PulseItem, SchedulerJobId } from "@arr/shared";
 import { ARR_SERVICES_UPPER } from "@arr/shared";
 import type { SonarrClient } from "arr-sdk";
 import { LidarrClient, ProwlarrClient } from "arr-sdk";
@@ -246,6 +246,25 @@ const collectSeerrCircuitBreaker: Collector = async (app, userId) => {
 // 4. Cache Staleness (Plex / Tautulli)
 // ============================================================================
 
+// Cache types the pulse-action dispatcher knows how to refresh. Must stay
+// in sync with `pulseCacheTypeSchema` in @arr/shared and with the dispatcher
+// branch in apps/api/src/lib/pulse/actions.ts. Stale cache rows for other
+// cacheType values (e.g. "plex_episode") still emit a warning — just
+// without an action button, so we don't ship a click the backend can't
+// fulfil.
+const REFRESHABLE_CACHE_TYPES = new Set<PulseCacheType>(["plex", "tautulli"]);
+
+function actionForStaleCache(instanceId: string, cacheType: string): PulseAction | undefined {
+	if (!REFRESHABLE_CACHE_TYPES.has(cacheType as PulseCacheType)) return undefined;
+	return {
+		kind: "cache.refresh",
+		target: { instanceId, cacheType: cacheType as PulseCacheType },
+		label: "Refresh now",
+		confirmLabel: "Click again to refresh",
+		destructive: false,
+	};
+}
+
 const collectCacheStaleness: Collector = async (app, userId) => {
 	const cacheStatuses = await app.prisma.cacheRefreshStatus.findMany({
 		where: { instance: { userId } },
@@ -267,6 +286,9 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 		const cacheLabel = cacheLabels[status.cacheType] ?? status.cacheType;
 
 		if (status.lastResult === "error") {
+			// Error items intentionally do NOT carry an inline action — a
+			// failed refresh likely fails again on the same network/config
+			// issue, so the "Check settings" link remains the right affordance.
 			items.push({
 				id: `cache-error-${status.id}`,
 				severity: "warning",
@@ -282,6 +304,7 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 			const hoursAgo = Math.round(
 				(Date.now() - status.lastRefreshedAt.getTime()) / (60 * 60 * 1000),
 			);
+			const action = actionForStaleCache(status.instanceId, status.cacheType);
 			items.push({
 				id: `cache-stale-${status.id}`,
 				severity: "warning",
@@ -292,6 +315,7 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				actionLabel: "Check settings",
 				source: status.cacheType === "tautulli" ? "tautulli" : "plex",
 				timestamp: status.lastRefreshedAt.toISOString(),
+				...(action ? { action } : {}),
 			});
 		}
 	}
@@ -691,7 +715,7 @@ function formatBytes(bytes: number): string {
 // ============================================================================
 
 // Exported for testing
-export { collectArrSignals, collectSchedulerHealth };
+export { collectArrSignals, collectCacheStaleness, collectSchedulerHealth };
 
 export const pulseCollectors: Collector[] = [
 	collectArrSignals,

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -1,0 +1,198 @@
+/**
+ * End-to-end integration test for the cache.refresh action path.
+ *
+ * Companion to pulse-action-e2e.test.ts (scheduler.enable). Asserts the
+ * same chain across the cache.refresh dispatcher branch:
+ *   1. A stale Plex cache surfaces with a cache.refresh envelope.
+ *   2. POSTing the envelope invokes the real refresh pipeline
+ *      (requirePlexClient + refreshPlexCache, both stubbed) and 200s.
+ *   3. The per-user Pulse cache is invalidated — next GET sees fresh
+ *      state (we drop the stale row from the stub to model this).
+ *   4. Ownership failure (InstanceNotFoundError from requirePlexClient)
+ *      surfaces as a 404 from the action route, matching the codebase's
+ *      "don't leak existence" convention.
+ *
+ * Stubbing notes: requirePlexClient / refreshPlexCache are mocked
+ * because the dispatcher reaches for them at module level. The Prisma
+ * `cacheRefreshStatus.findMany` surface is stubbed the same way the
+ * staleness collector tests do it.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Dispatcher collaborators — must be mocked before the route module imports.
+const refreshPlexCache = vi.fn();
+const requirePlexClient = vi.fn();
+vi.mock("../../lib/plex/plex-cache-refresher.js", () => ({
+	refreshPlexCache: (...args: unknown[]) => refreshPlexCache(...args),
+}));
+vi.mock("../../lib/plex/plex-helpers.js", () => ({
+	requirePlexClient: (...args: unknown[]) => requirePlexClient(...args),
+}));
+// Tautulli helpers are not exercised by this file but need stubs because
+// the dispatcher module imports them at top level.
+vi.mock("../../lib/tautulli/tautulli-cache-refresher.js", () => ({
+	refreshTautulliCache: vi.fn(),
+}));
+vi.mock("../../lib/tautulli/tautulli-helpers.js", () => ({
+	requireTautulliClient: vi.fn(),
+}));
+
+// Run only the staleness collector — keeps other collectors (ARR health,
+// seerr, etc.) from needing plugin decorations we don't provide.
+vi.mock("../../lib/pulse/collectors.js", async () => {
+	const actual = await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
+		"../../lib/pulse/collectors.js",
+	);
+	return { pulseCollectors: [actual.collectCacheStaleness] };
+});
+
+import { InstanceNotFoundError } from "../../lib/errors.js";
+import { registerPulseRoutes } from "../pulse.js";
+import { registerTestErrorHandler } from "./test-helpers.js";
+
+type CacheStatusRow = {
+	id: string;
+	instanceId: string;
+	cacheType: string;
+	lastRefreshedAt: Date;
+	lastResult: "success" | "error";
+	lastErrorMessage: string | null;
+	itemCount: number;
+	instance: { label: string };
+};
+
+const HOURS = 60 * 60 * 1000;
+
+function makeStaleRow(overrides: Partial<CacheStatusRow> = {}): CacheStatusRow {
+	return {
+		id: "plex-row",
+		instanceId: "inst-plex",
+		cacheType: "plex",
+		lastRefreshedAt: new Date(Date.now() - 24 * HOURS),
+		lastResult: "success",
+		lastErrorMessage: null,
+		itemCount: 0,
+		instance: { label: "Home Plex" },
+		...overrides,
+	};
+}
+
+let app: FastifyInstance;
+let cacheStatuses: CacheStatusRow[];
+let userCounter = 0;
+
+const AUTH_HEADER = "x-test-auth";
+
+function setupAuthGate(app: FastifyInstance, userId: string) {
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (req: any) => {
+		if (req.headers[AUTH_HEADER]) {
+			req.currentUser = { id: userId, username: "admin" };
+			req.sessionToken = "mock-session-token";
+		}
+	});
+}
+
+async function injectGet(url: string) {
+	return app.inject({ method: "GET", url, headers: { [AUTH_HEADER]: "1" } });
+}
+
+async function injectPost(url: string, body: unknown) {
+	return app.inject({
+		method: "POST",
+		url,
+		headers: { [AUTH_HEADER]: "1", "content-type": "application/json" },
+		payload: JSON.stringify(body),
+	});
+}
+
+beforeEach(async () => {
+	userCounter += 1;
+	refreshPlexCache.mockReset();
+	requirePlexClient.mockReset();
+
+	app = Fastify({ logger: false });
+	setupAuthGate(app, `e2e-cache-user-${userCounter}`);
+	app.decorate("prisma", {
+		cacheRefreshStatus: {
+			findMany: async () => cacheStatuses,
+		},
+	} as unknown as never);
+	registerTestErrorHandler(app);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("Pulse actionability — cache.refresh end-to-end", () => {
+	it("stale Plex cache → action item → POST 200 → cache invalidation drops the row on next poll", async () => {
+		cacheStatuses = [makeStaleRow()];
+		requirePlexClient.mockResolvedValue({ client: { id: "plex-client" }, instance: {} });
+		refreshPlexCache.mockResolvedValue({ upserted: 42, errors: 0, errorMessages: [] });
+
+		// 1. Collector surfaces the item with an action envelope.
+		const first = await injectGet("/pulse");
+		const firstBody = JSON.parse(first.payload);
+		const staleItem = firstBody.items.find((i: { id: string }) => i.id === "cache-stale-plex-row");
+		expect(staleItem.action).toEqual({
+			kind: "cache.refresh",
+			target: { instanceId: "inst-plex", cacheType: "plex" },
+			label: "Refresh now",
+			confirmLabel: "Click again to refresh",
+			destructive: false,
+		});
+
+		// 2. POST the envelope verbatim.
+		const actionRes = await injectPost(
+			`/pulse/${encodeURIComponent(staleItem.id)}/action`,
+			staleItem.action,
+		);
+		expect(actionRes.statusCode).toBe(200);
+		expect(JSON.parse(actionRes.payload)).toEqual({
+			status: "ok",
+			detail: "42 item(s) refreshed",
+		});
+		expect(requirePlexClient).toHaveBeenCalledWith(
+			expect.any(Object), // app
+			`e2e-cache-user-${userCounter}`,
+			"inst-plex",
+		);
+		expect(refreshPlexCache).toHaveBeenCalledTimes(1);
+
+		// 3. Drop the row from the stub to model the post-refresh state
+		//    (lastRefreshedAt would now be recent → no longer stale). If the
+		//    per-user Pulse cache had survived, we'd still see the stale item.
+		cacheStatuses = [];
+
+		const second = await injectGet("/pulse");
+		const secondBody = JSON.parse(second.payload);
+		const stillStale = secondBody.items.find(
+			(i: { id: string }) => i.id === "cache-stale-plex-row",
+		);
+		expect(stillStale).toBeUndefined();
+	});
+
+	it("ownership failure returns 404 (InstanceNotFoundError convention)", async () => {
+		cacheStatuses = [makeStaleRow()];
+		requirePlexClient.mockRejectedValue(new InstanceNotFoundError("inst-plex"));
+
+		const listing = await injectGet("/pulse");
+		const staleItem = JSON.parse(listing.payload).items.find(
+			(i: { id: string }) => i.id === "cache-stale-plex-row",
+		);
+
+		const actionRes = await injectPost(
+			`/pulse/${encodeURIComponent(staleItem.id)}/action`,
+			staleItem.action,
+		);
+		expect(actionRes.statusCode).toBe(404);
+		expect(JSON.parse(actionRes.payload).error).toBe("InstanceNotFoundError");
+		expect(refreshPlexCache).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Integration tests for cache.refresh action emission on GET /pulse.
+ *
+ * Mirrors the structure of pulse-scheduler-health.test.ts: run the real
+ * `collectCacheStaleness` against a stubbed Prisma surface and assert the
+ * emission gate for each cacheType × status combination.
+ *
+ * The emission rule under test:
+ *   emit action iff
+ *     status.lastResult !== "error"
+ *     AND status.lastRefreshedAt < now - STALE_CACHE_HOURS
+ *     AND status.cacheType ∈ {"plex", "tautulli"}
+ */
+
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/pulse/collectors.js", async () => {
+	const actual = await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
+		"../../lib/pulse/collectors.js",
+	);
+	return { pulseCollectors: [actual.collectCacheStaleness] };
+});
+
+import { registerPulseRoutes } from "../pulse.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let cacheStatuses: CacheStatusRow[];
+let userCounter = 0;
+
+type CacheStatusRow = {
+	id: string;
+	instanceId: string;
+	cacheType: string;
+	lastRefreshedAt: Date;
+	lastResult: "success" | "error";
+	lastErrorMessage: string | null;
+	itemCount: number;
+	instance: { label: string };
+};
+
+const HOURS = 60 * 60 * 1000;
+
+function makeRow(overrides: Partial<CacheStatusRow> = {}): CacheStatusRow {
+	return {
+		id: "row-1",
+		instanceId: "inst-1",
+		cacheType: "plex",
+		lastRefreshedAt: new Date(Date.now() - 24 * HOURS), // stale
+		lastResult: "success",
+		lastErrorMessage: null,
+		itemCount: 0,
+		instance: { label: "Home Plex" },
+		...overrides,
+	};
+}
+
+beforeEach(async () => {
+	userCounter += 1;
+	app = Fastify({ logger: false });
+	setupAuthInjection(app, { id: `user-cache-${userCounter}`, username: "admin" });
+	app.decorate("prisma", {
+		cacheRefreshStatus: {
+			findMany: async () => cacheStatuses,
+		},
+	} as unknown as never);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("GET /pulse — cache.refresh action emission", () => {
+	it("emits a cache.refresh action on a stale Plex cache row", async () => {
+		cacheStatuses = [makeRow({ id: "plex-row", cacheType: "plex", instanceId: "inst-plex" })];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "cache-stale-plex-row");
+
+		expect(item).toBeDefined();
+		expect(item.action).toEqual({
+			kind: "cache.refresh",
+			target: { instanceId: "inst-plex", cacheType: "plex" },
+			label: "Refresh now",
+			confirmLabel: "Click again to refresh",
+			destructive: false,
+		});
+	});
+
+	it("emits a cache.refresh action on a stale Tautulli cache row", async () => {
+		cacheStatuses = [makeRow({ id: "taut-row", cacheType: "tautulli", instanceId: "inst-taut" })];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "cache-stale-taut-row");
+
+		expect(item.action?.kind).toBe("cache.refresh");
+		expect(item.action?.target).toEqual({ instanceId: "inst-taut", cacheType: "tautulli" });
+	});
+
+	it("does NOT emit an action for unsupported cacheType (plex_episode)", async () => {
+		// plex_episode exists in the data model but the dispatcher does not
+		// support it. The row still renders (so the operator sees the
+		// problem) but without a button they can't usefully click.
+		cacheStatuses = [
+			makeRow({ id: "episode-row", cacheType: "plex_episode", instanceId: "inst-plex" }),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "cache-stale-episode-row");
+
+		expect(item).toBeDefined();
+		expect(item.action).toBeUndefined();
+	});
+
+	it("does NOT emit an action on a cache-error row (even if cacheType is supported)", async () => {
+		// A refresh that just errored likely errors again on the same
+		// network/config issue — the inline "Refresh now" button would feel
+		// like a false promise. "Check settings" stays the right affordance.
+		cacheStatuses = [
+			makeRow({
+				id: "error-row",
+				cacheType: "plex",
+				lastResult: "error",
+				lastErrorMessage: "ECONNREFUSED",
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const item = body.items.find((i: { id: string }) => i.id === "cache-error-error-row");
+
+		expect(item).toBeDefined();
+		expect(item.action).toBeUndefined();
+	});
+
+	it("does not emit any item for a fresh cache row", async () => {
+		cacheStatuses = [
+			makeRow({
+				id: "fresh-row",
+				lastRefreshedAt: new Date(Date.now() - 1 * HOURS), // well under the 12h threshold
+			}),
+		];
+
+		const res = await injectAuthenticated("GET", "/pulse");
+		const body = JSON.parse(res.payload);
+		const cacheItems = body.items.filter((i: { id: string }) => i.id.startsWith("cache-"));
+
+		expect(cacheItems).toEqual([]);
+	});
+});

--- a/apps/web/src/hooks/api/usePulse.ts
+++ b/apps/web/src/hooks/api/usePulse.ts
@@ -8,7 +8,13 @@ import {
 } from "../../lib/api-client/pulse";
 import { getErrorMessage } from "../../lib/error-utils";
 import { POLLING_STATS } from "../../lib/polling-intervals";
-import { huntingKeys, pulseKeys, queueCleanerKeys } from "../../lib/query-keys";
+import {
+	huntingKeys,
+	plexKeys,
+	pulseKeys,
+	queueCleanerKeys,
+	tautulliKeys,
+} from "../../lib/query-keys";
 
 export interface UsePulseQueryOptions {
 	attentionOnly?: boolean;
@@ -57,9 +63,18 @@ export const usePulseActionMutation = () => {
 					toast.success(successCopyForAction(action));
 					break;
 				case "cache.refresh":
-					// No cache.refresh collector emits yet (PR 3), but keep
-					// the success toast generic so the mutation hook is
-					// future-ready without extra code churn.
+					// The cache health banner (/api/plex/cache/health) is
+					// shared across plex + tautulli, so plexKeys.cacheHealth
+					// is the right key for both branches. Also drop the
+					// domain root key so downstream Plex/Tautulli widgets
+					// that depend on the refreshed cache repaint on next
+					// mount without waiting for their own stale window.
+					queryClient.invalidateQueries({ queryKey: plexKeys.cacheHealth() });
+					if (action.target.cacheType === "plex") {
+						queryClient.invalidateQueries({ queryKey: plexKeys.all });
+					} else {
+						queryClient.invalidateQueries({ queryKey: tautulliKeys.all });
+					}
 					toast.success(successCopyForAction(action));
 					break;
 			}
@@ -77,6 +92,8 @@ function successCopyForAction(action: PulseAction): string {
 				? "Hunt scheduler enabled"
 				: "Queue cleaner scheduler enabled";
 		case "cache.refresh":
-			return "Cache refresh triggered";
+			return action.target.cacheType === "plex"
+				? "Plex cache refresh triggered"
+				: "Tautulli cache refresh triggered";
 	}
 }


### PR DESCRIPTION
## Summary

PR 3 of Actionability V1 — **second and final V1 action**. Operators can refresh a stale Plex or Tautulli cache directly from the Needs Attention panel and the Pulse feed, closing out the V1 scope defined in the design doc.

**Zero changes** to the action route, dispatcher, API client, mutation entry point, or button component — PR 1's plumbing and PR 2's UI primitives both carry through unchanged. The only *new* behavior is collector emission plus cache-specific query invalidation in the hook's existing `cache.refresh` success branch.

## What changed

**Collector** (`collectCacheStaleness`):
- Attaches `action: { kind: "cache.refresh", target: { instanceId, cacheType } }` on `cache-stale-*` items when `cacheType ∈ {plex, tautulli}`.
- Other cacheType values (e.g. `plex_episode`) still render the warning but **without** an action — we never ship a button the backend can't fulfil.
- `cache-error-*` items intentionally stay action-less. A refresh that just errored will likely error again on the same network/config issue, so the existing `/settings` link remains the right affordance and the inline "Refresh now" button would feel like a false promise.

**Mutation hook** (`usePulseActionMutation`):
- The `cache.refresh` success branch now invalidates `plexKeys.cacheHealth()` (shared across plex + tautulli banner) plus `plexKeys.all` or `tautulliKeys.all` based on `target.cacheType`. Plex/Tautulli views that depend on the refreshed cache repaint on next mount without waiting out their own stale window.
- Success copy distinguishes plex vs tautulli ("Plex cache refresh triggered" / "Tautulli cache refresh triggered").

## Exact emission rule

```
emit action iff
  status.lastResult !== "error"
  AND status.lastRefreshedAt < now - STALE_CACHE_HOURS
  AND status.cacheType ∈ {"plex", "tautulli"}
```

## UI behavior

Reuses `<PulseActionButton>` verbatim from PR 2:
- Single-tap, non-destructive, `aria-busy` + spinner while pending, disabled against double-click.
- Success: toast + the row drops on next Pulse poll (backend invalidates per-user cache; frontend invalidates `pulseKeys` + cache-health keys).
- Error: toast via `getErrorMessage(error, "Action failed")` — covers the 404-on-unowned-instance case.
- **No confirm flow** — refreshes are idempotent and the rate limit on the underlying refresh endpoint (2/5min) is the backstop against mashing.

## Tests added (7 new)

- **pulse-cache-staleness.test.ts** (5): stale-plex-emits, stale-tautulli-emits, unsupported-plex_episode-no-emit, cache-error-no-emit, fresh-no-emit.
- **pulse-action-e2e-cache.test.ts** (2): happy-path end-to-end through real collector + route + dispatcher + cache invalidation, plus ownership-failure 404 via `InstanceNotFoundError`.

All tests pass: **61 API pulse tests** (up from 54) / **15 web pulse + panel tests** / `tsc --noEmit` clean on api / web / shared / Biome clean.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/shared exec tsc --noEmit` — clean
- [x] Biome + ESLint — clean
- [x] 61/61 API pulse tests pass (including 7 new)
- [x] 15/15 web pulse + needs-attention tests pass
- [x] End-to-end coverage — collector → route → dispatcher → cache invalidation → next-poll-clean, plus 404 ownership path (same pattern as PR #341's scheduler e2e)

## Beyond V1 — explicitly not in this PR

- Destructive actions + two-tap confirm
- Queue retry / remove / blocklist
- Bulk actions, undo, rules/automation engine
- `cache.refresh` on `cache-error` items (would need a retry-safety model the codebase doesn't currently express — open decision for a post-V1 PR)

## V1 wrap-up

With this PR merged, Actionability V1 is complete:
- ✅ Envelope + dispatcher + dormant route (#340)
- ✅ `scheduler.enable` collector + UI primitives (#341)
- ✅ `cache.refresh` collector + invalidation tuning (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)