### PR TITLE
fix(pulse): actions write through to collector source-of-truth + rate-limit

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -68,7 +68,19 @@ const fakeLog = {
 	child: vi.fn(() => fakeLog),
 } as unknown as FastifyBaseLogger;
 
-const fakeApp = { prisma: {} } as unknown as FastifyInstance;
+const markEnabled = vi.fn();
+const cacheStatusUpsert = vi.fn();
+
+const fakeApp = {
+	prisma: {
+		cacheRefreshStatus: {
+			upsert: (...args: unknown[]) => cacheStatusUpsert(...args),
+		},
+	},
+	schedulerRegistry: {
+		markEnabled: (jobId: string) => markEnabled(jobId),
+	},
+} as unknown as FastifyInstance;
 
 beforeEach(() => {
 	huntingScheduler.isRunning.mockReset();
@@ -79,6 +91,9 @@ beforeEach(() => {
 	refreshTautulliCache.mockReset();
 	requirePlexClient.mockReset();
 	requireTautulliClient.mockReset();
+	markEnabled.mockReset();
+	cacheStatusUpsert.mockReset();
+	cacheStatusUpsert.mockResolvedValue({});
 });
 
 afterEach(() => {
@@ -110,6 +125,10 @@ describe("dispatchPulseAction — scheduler.enable", () => {
 		expect(result).toEqual({ status: "ok" });
 		expect(huntingScheduler.start).toHaveBeenCalledWith(fakeApp);
 		expect(queueCleanerScheduler.start).not.toHaveBeenCalled();
+		// Write-through: collectSchedulerHealth reads from the registry, not
+		// from the scheduler class — so markEnabled must fire for the row
+		// to actually drop on the next poll.
+		expect(markEnabled).toHaveBeenCalledWith("hunting");
 	});
 
 	it("starts the queue-cleaner scheduler when it is not running", async () => {
@@ -120,6 +139,20 @@ describe("dispatchPulseAction — scheduler.enable", () => {
 		expect(result).toEqual({ status: "ok" });
 		expect(queueCleanerScheduler.start).toHaveBeenCalledWith(fakeApp);
 		expect(huntingScheduler.start).not.toHaveBeenCalled();
+		expect(markEnabled).toHaveBeenCalledWith("queue-cleaner");
+	});
+
+	it("does NOT call markEnabled when the dispatcher short-circuits on already-running (409)", async () => {
+		// Protects against a regression where a 409 inadvertently still wrote
+		// to the registry — which would reset disabledReason audit data we
+		// may want to preserve in future.
+		huntingScheduler.isRunning.mockReturnValue(true);
+
+		await expect(dispatchPulseAction(fakeApp, "user-1", huntAction, fakeLog)).rejects.toMatchObject(
+			{ statusCode: 409 },
+		);
+
+		expect(markEnabled).not.toHaveBeenCalled();
 	});
 
 	it("throws ConflictError (statusCode 409) when the hunt scheduler is already running", async () => {
@@ -181,6 +214,21 @@ describe("dispatchPulseAction — cache.refresh", () => {
 			fakeLog,
 		);
 		expect(requireTautulliClient).not.toHaveBeenCalled();
+		// Write-through: collectCacheStaleness reads lastRefreshedAt from
+		// CacheRefreshStatus. Without this upsert the row stays stale and
+		// re-emits on the next poll.
+		expect(cacheStatusUpsert).toHaveBeenCalledTimes(1);
+		const upsertArgs = cacheStatusUpsert.mock.calls[0]?.[0] as {
+			where: { instanceId_cacheType: { instanceId: string; cacheType: string } };
+			update: { lastRefreshedAt: Date; lastResult: string; itemCount: number };
+		};
+		expect(upsertArgs.where.instanceId_cacheType).toEqual({
+			instanceId: "inst-plex-1",
+			cacheType: "plex",
+		});
+		expect(upsertArgs.update.lastResult).toBe("success");
+		expect(upsertArgs.update.itemCount).toBe(42);
+		expect(upsertArgs.update.lastRefreshedAt).toBeInstanceOf(Date);
 	});
 
 	it("refreshes the tautulli cache via requireTautulliClient + refreshTautulliCache", async () => {
@@ -198,6 +246,28 @@ describe("dispatchPulseAction — cache.refresh", () => {
 			"inst-tautulli-1",
 			fakeLog,
 		);
+		// Same write-through contract for the tautulli branch.
+		expect(cacheStatusUpsert).toHaveBeenCalledTimes(1);
+		const upsertArgs = cacheStatusUpsert.mock.calls[0]?.[0] as {
+			where: { instanceId_cacheType: { instanceId: string; cacheType: string } };
+		};
+		expect(upsertArgs.where.instanceId_cacheType).toEqual({
+			instanceId: "inst-tautulli-1",
+			cacheType: "tautulli",
+		});
+	});
+
+	it("does NOT call cacheRefreshStatus.upsert when the refresher rejects before completing", async () => {
+		// Regression guard: a thrown ownership error (404) should short-circuit
+		// before any write-through. Writing status on a failed refresh would
+		// advance lastRefreshedAt dishonestly.
+		requirePlexClient.mockRejectedValue(new InstanceNotFoundError("inst-plex-1"));
+
+		await expect(dispatchPulseAction(fakeApp, "user-1", plexAction, fakeLog)).rejects.toMatchObject(
+			{ statusCode: 404 },
+		);
+
+		expect(cacheStatusUpsert).not.toHaveBeenCalled();
 	});
 
 	it("propagates InstanceNotFoundError from requirePlexClient (ownership failure)", async () => {

--- a/apps/api/src/lib/pulse/actions.ts
+++ b/apps/api/src/lib/pulse/actions.ts
@@ -77,6 +77,16 @@ async function dispatchSchedulerEnable(
 	}
 
 	scheduler.start(app);
+
+	// Write through to the source-of-truth collectSchedulerHealth reads from.
+	// The scheduler class's `start()` flips its own `running` flag but does
+	// not touch the registry — so without this call the collector would keep
+	// emitting scheduler-disabled-<jobId> on the next poll and a second click
+	// would 409 against a registry still marked disabled. The scheduler row
+	// on the Pulse surface would never drop, which breaks the whole
+	// "click action → issue resolves → row disappears" promise.
+	app.schedulerRegistry.markEnabled(jobId);
+
 	log.info({ jobId }, "pulse-action: scheduler enabled");
 	return { status: "ok" };
 }
@@ -100,6 +110,7 @@ async function dispatchCacheRefresh(
 	if (cacheType === "plex") {
 		const { client } = await requirePlexClient(app, userId, instanceId);
 		const result = await refreshPlexCache(client, app.prisma, instanceId, log);
+		await recordCacheRefreshSuccess(app, instanceId, "plex", result, log);
 		log.info(
 			{ instanceId, cacheType, upserted: result.upserted, errors: result.errors },
 			"pulse-action: plex cache refreshed",
@@ -113,6 +124,7 @@ async function dispatchCacheRefresh(
 	// tautulli
 	const { client } = await requireTautulliClient(app, userId, instanceId);
 	const result = await refreshTautulliCache(client, app.prisma, instanceId, log);
+	await recordCacheRefreshSuccess(app, instanceId, "tautulli", result, log);
 	log.info(
 		{ instanceId, cacheType, upserted: result.upserted, errors: result.errors },
 		"pulse-action: tautulli cache refreshed",
@@ -121,4 +133,65 @@ async function dispatchCacheRefresh(
 		status: "ok",
 		detail: `${result.upserted} item(s) refreshed`,
 	};
+}
+
+// ---------------------------------------------------------------------------
+// CacheRefreshStatus write-through
+// ---------------------------------------------------------------------------
+//
+// Bumps the `lastRefreshedAt` timestamp (and result metadata) on the
+// `CacheRefreshStatus` row the collector reads from. Without this, a
+// successful dispatcher run would leave the row stale on the next GET
+// /pulse poll — the collector determines staleness from this table, not
+// from the refresher's return value.
+//
+// Mirrors the upsert already performed by the inline manual-refresh
+// route at apps/api/src/routes/plex/cache-routes.ts so the two paths
+// behave identically for operators. The status upsert is best-effort
+// (`.catch(...)`): a failure here must not fail the action itself, since
+// the refresh already succeeded.
+
+interface CacheRefreshResult {
+	upserted: number;
+	errors: number;
+	errorMessages?: readonly string[];
+}
+
+async function recordCacheRefreshSuccess(
+	app: FastifyInstance,
+	instanceId: string,
+	cacheType: "plex" | "tautulli",
+	result: CacheRefreshResult,
+	log: FastifyBaseLogger,
+): Promise<void> {
+	const now = new Date();
+	const errorMessages = result.errorMessages ?? [];
+	const lastErrorMessage =
+		errorMessages.length > 0 ? errorMessages.slice(0, 3).join("; ").slice(0, 200) : null;
+	const lastResult = result.errors > 0 ? "error" : "success";
+
+	await app.prisma.cacheRefreshStatus
+		.upsert({
+			where: { instanceId_cacheType: { instanceId, cacheType } },
+			create: {
+				instanceId,
+				cacheType,
+				lastRefreshedAt: now,
+				lastResult,
+				lastErrorMessage,
+				itemCount: result.upserted,
+			},
+			update: {
+				lastRefreshedAt: now,
+				lastResult,
+				lastErrorMessage,
+				itemCount: result.upserted,
+			},
+		})
+		.catch((err: unknown) => {
+			log.warn(
+				{ err, instanceId, cacheType },
+				"pulse-action: cache refreshed but failed to record status",
+			);
+		});
 }

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -116,9 +116,33 @@ beforeEach(async () => {
 
 	app = Fastify({ logger: false });
 	setupAuthGate(app, `e2e-cache-user-${userCounter}`);
+	// Live Prisma stub: `upsert` mutates the `cacheStatuses` array in place
+	// so a subsequent `findMany` reflects the post-action state (fresh
+	// lastRefreshedAt). This is what proves the dispatcher's write-through
+	// genuinely lets the staleness collector drop the row on the next poll
+	// — without the upsert, the row would persist indefinitely.
 	app.decorate("prisma", {
 		cacheRefreshStatus: {
 			findMany: async () => cacheStatuses,
+			upsert: async (args: {
+				where: { instanceId_cacheType: { instanceId: string; cacheType: string } };
+				create: CacheStatusRow;
+				update: Partial<CacheStatusRow>;
+			}) => {
+				const { instanceId, cacheType } = args.where.instanceId_cacheType;
+				const idx = cacheStatuses.findIndex(
+					(s) => s.instanceId === instanceId && s.cacheType === cacheType,
+				);
+				if (idx >= 0) {
+					cacheStatuses[idx] = {
+						...cacheStatuses[idx]!,
+						...args.update,
+					};
+				} else {
+					cacheStatuses.push(args.create);
+				}
+				return cacheStatuses[idx >= 0 ? idx : cacheStatuses.length - 1]!;
+			},
 		},
 	} as unknown as never);
 	registerTestErrorHandler(app);
@@ -165,11 +189,10 @@ describe("Pulse actionability — cache.refresh end-to-end", () => {
 		);
 		expect(refreshPlexCache).toHaveBeenCalledTimes(1);
 
-		// 3. Drop the row from the stub to model the post-refresh state
-		//    (lastRefreshedAt would now be recent → no longer stale). If the
-		//    per-user Pulse cache had survived, we'd still see the stale item.
-		cacheStatuses = [];
-
+		// 3. The live Prisma stub's upsert callback already mutated
+		//    cacheStatuses[0].lastRefreshedAt to `now` when the dispatcher
+		//    wrote through — no manual setup here. The collector should
+		//    read the fresh timestamp and not emit the stale row.
 		const second = await injectGet("/pulse");
 		const secondBody = JSON.parse(second.payload);
 		const stillStale = secondBody.items.find(

--- a/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
@@ -126,7 +126,19 @@ beforeEach(async () => {
 
 	app = Fastify({ logger: false });
 	setupAuthGate(app, `e2e-user-${userCounter}`);
-	app.decorate("schedulerRegistry", { list: () => jobs } as unknown as never);
+	// Live registry stub: `markEnabled` mutates the `jobs` array in place so
+	// a subsequent call to `list()` reflects the post-action state. This is
+	// what proves the dispatcher's write-through genuinely lets the
+	// collector drop the row on the next poll — without the markEnabled
+	// call in the dispatcher, the row would persist forever.
+	app.decorate("schedulerRegistry", {
+		list: () => jobs,
+		markEnabled: (jobId: string) => {
+			jobs = jobs.map((j) =>
+				j.id === jobId ? { ...j, disabled: false, disabledReason: null, state: "idle" } : j,
+			);
+		},
+	} as unknown as never);
 	registerTestErrorHandler(app);
 	await app.register(registerPulseRoutes);
 	await app.ready();
@@ -182,22 +194,13 @@ describe("Pulse actionability — end-to-end (PR 1 + PR 2)", () => {
 
 		// -------------------------------------------------------------------
 		// 3. Next GET /pulse after invalidation should see the new state.
-		//    Simulate the scheduler actually starting by flipping isRunning
-		//    (matches what the live dispatcher would cause) and flipping
-		//    the registry to an enabled job. If the cache had survived, we
-		//    would still see the stale disabled item — that's the
-		//    regression this step guards against.
+		//    The registry stub's markEnabled callback already flipped the
+		//    job to enabled=false when the dispatcher wrote through — no
+		//    manual setup here. We flip isRunning on the scheduler class to
+		//    match what a real running scheduler would report for step 4's
+		//    double-click assertion.
 		// -------------------------------------------------------------------
 		huntingScheduler.isRunning.mockReturnValue(true);
-		jobs = [
-			makeJob({
-				id: "hunting",
-				label: "Hunting",
-				state: "idle",
-				disabled: false,
-				disabledReason: null,
-			}),
-		];
 
 		const secondPulse = await injectGet("/pulse");
 		const secondBody = JSON.parse(secondPulse.payload);

--- a/apps/api/src/routes/__tests__/pulse-action-rate-limit.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-rate-limit.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Rate-limit test for POST /pulse/:id/action.
+ *
+ * The action route declares `config: { rateLimit: { max: 10, timeWindow:
+ * "1m" } }`, which @fastify/rate-limit applies as a per-route override
+ * on top of whatever global limit is registered. This test boots a
+ * minimal Fastify app with the plugin registered (matching the
+ * production topology), sends 11 successful requests against the route,
+ * and asserts the 11th is rejected with 429.
+ *
+ * Why this matters: without this guard, a runaway script (or an
+ * overeager operator mashing "Refresh now") can hammer upstream
+ * Plex/Tautulli via cache.refresh. 10/min is generous for real operator
+ * use — a human clicking one button per minute stays well under — but
+ * bot-scale abuse trips 429 before upstream suffers.
+ */
+
+import fastifyRateLimit from "@fastify/rate-limit";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Scheduler getters + refreshers — stubbed so the dispatcher short-circuits
+// to scheduler.start (always ok) without touching anything real. We're
+// testing the route's rate limiter, not any of the dispatch branches.
+const huntingScheduler = {
+	isRunning: vi.fn<() => boolean>().mockReturnValue(false),
+	start: vi.fn(),
+	stop: vi.fn(),
+};
+vi.mock("../../lib/hunting/scheduler.js", () => ({
+	getHuntingScheduler: () => huntingScheduler,
+}));
+vi.mock("../../lib/queue-cleaner/scheduler.js", () => ({
+	getQueueCleanerScheduler: () => ({
+		isRunning: () => false,
+		start: vi.fn(),
+		stop: vi.fn(),
+	}),
+}));
+vi.mock("../../lib/plex/plex-cache-refresher.js", () => ({
+	refreshPlexCache: vi.fn(),
+}));
+vi.mock("../../lib/tautulli/tautulli-cache-refresher.js", () => ({
+	refreshTautulliCache: vi.fn(),
+}));
+vi.mock("../../lib/plex/plex-helpers.js", () => ({
+	requirePlexClient: vi.fn(),
+}));
+vi.mock("../../lib/tautulli/tautulli-helpers.js", () => ({
+	requireTautulliClient: vi.fn(),
+}));
+// No collectors — this test never calls GET /pulse.
+vi.mock("../../lib/pulse/collectors.js", () => ({
+	pulseCollectors: [],
+}));
+
+import { registerPulseRoutes } from "../pulse.js";
+import { registerTestErrorHandler } from "./test-helpers.js";
+
+const AUTH_HEADER = "x-test-auth";
+let app: FastifyInstance;
+
+function setupAuthGate(app: FastifyInstance) {
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (req: any) => {
+		if (req.headers[AUTH_HEADER]) {
+			req.currentUser = { id: "rate-user", username: "admin" };
+			req.sessionToken = "mock-session-token";
+		}
+	});
+}
+
+async function injectAction() {
+	return app.inject({
+		method: "POST",
+		url: "/pulse/sig-1/action",
+		headers: {
+			[AUTH_HEADER]: "1",
+			"content-type": "application/json",
+			// Stable synthetic IP so every request maps to the same rate-limit
+			// bucket — otherwise fastify-rate-limit keys off req.ip which in
+			// the test harness can drift.
+			"x-forwarded-for": "203.0.113.42",
+		},
+		payload: JSON.stringify({
+			kind: "scheduler.enable",
+			target: { jobId: "hunting" },
+			label: "Enable",
+			confirmLabel: "Click again to enable",
+			destructive: false,
+		}),
+	});
+}
+
+beforeEach(async () => {
+	huntingScheduler.isRunning.mockReturnValue(false);
+	huntingScheduler.start.mockReset();
+
+	app = Fastify({ logger: false, trustProxy: true });
+	setupAuthGate(app);
+	// Stubs the dispatcher touches on successful scheduler.enable.
+	app.decorate("schedulerRegistry", { list: () => [], markEnabled: () => {} } as unknown as never);
+	app.decorate("prisma", { cacheRefreshStatus: { upsert: async () => ({}) } } as unknown as never);
+	// Generous global default — the per-route override is what we're
+	// testing, so the global must not trip first.
+	await app.register(fastifyRateLimit, { max: 10000, timeWindow: "1m" });
+	registerTestErrorHandler(app);
+	await app.register(registerPulseRoutes);
+	await app.ready();
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("POST /pulse/:id/action — rate limit", () => {
+	it("allows 10 requests/min from the same client and 429s the 11th", async () => {
+		const codes: number[] = [];
+		for (let i = 0; i < 11; i += 1) {
+			const res = await injectAction();
+			codes.push(res.statusCode);
+		}
+
+		// First 10 succeed (409 would also be acceptable if the scheduler
+		// had already been started, but we re-stub isRunning=false each
+		// call so every request reaches dispatch).
+		expect(codes.slice(0, 10).every((c) => c === 200)).toBe(true);
+
+		// 11th request tripped the per-route limit.
+		expect(codes[10]).toBe(429);
+	});
+});

--- a/apps/api/src/routes/__tests__/pulse-actions.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-actions.test.ts
@@ -126,6 +126,14 @@ beforeEach(async () => {
 
 	app = Fastify({ logger: false });
 	setupAuthGate(app);
+	// Stubs for the write-through surfaces the dispatcher touches post-PR.
+	// Not the focus of this file (see pulse-action-e2e.test.ts for the
+	// behavioral assertions) — we only need them to exist so the dispatcher
+	// doesn't throw on .markEnabled / .cacheRefreshStatus.upsert.
+	app.decorate("schedulerRegistry", { list: () => [], markEnabled: () => {} } as unknown as never);
+	app.decorate("prisma", {
+		cacheRefreshStatus: { upsert: async () => ({}) },
+	} as unknown as never);
 	registerTestErrorHandler(app);
 	await app.register(registerPulseRoutes);
 	await app.ready();

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -205,27 +205,39 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 
 	const pulseIdParams = z.object({ id: z.string().min(1) });
 
-	app.post("/pulse/:id/action", async (request, reply) => {
-		const userId = request.currentUser!.id;
-		const { id: signalId } = validateRequest(pulseIdParams, request.params);
-		const action = validateRequest(pulseActionSchema, request.body);
+	// Rate limit the action route so a runaway script (or an overeager
+	// operator mashing "Refresh now") can't hammer upstream Plex/Tautulli
+	// via cache.refresh. 10/min is generous for real operator use — a
+	// human clicking one button per row per minute stays well under the
+	// cap, but bot-scale abuse trips 429. Aligns with the {max:2, 5m}
+	// limit on the dedicated manual-refresh routes.
+	app.post(
+		"/pulse/:id/action",
+		{
+			config: { rateLimit: { max: 10, timeWindow: "1m" } },
+		},
+		async (request, reply) => {
+			const userId = request.currentUser!.id;
+			const { id: signalId } = validateRequest(pulseIdParams, request.params);
+			const action = validateRequest(pulseActionSchema, request.body);
 
-		const result = await dispatchPulseAction(app, userId, action, request.log);
+			const result = await dispatchPulseAction(app, userId, action, request.log);
 
-		invalidatePulseCache(userId);
+			invalidatePulseCache(userId);
 
-		request.log.info(
-			{
-				action: action.kind,
-				target: action.target,
-				signalId,
-				userId,
-			},
-			"pulse-action: dispatched",
-		);
+			request.log.info(
+				{
+					action: action.kind,
+					target: action.target,
+					signalId,
+					userId,
+				},
+				"pulse-action: dispatched",
+			);
 
-		return reply.send(result);
-	});
+			return reply.send(result);
+		},
+	);
 
 	done();
 };


### PR DESCRIPTION
## Summary

Required pre-release fix for Actionability V1 (PRs #340/#341/#342) before 2.17.0.

The audit surfaced a critical trust bug: **both action kinds performed the side-effect but did not update the state the collector reads from**, so on the next poll the same row reappeared with the same button. Operators clicking "Enable" or "Refresh now" would see no visible change, think the action failed, click again, and then hit a contradictory 409 "already running" toast (scheduler case) or a recurring stale-cache row (refresh case).

This PR closes both gaps plus adds rate limiting to bring the action route in line with the dedicated manual-refresh routes.

## Three fixes

### 1. `scheduler.enable` → write through to `SchedulerRegistry.markEnabled`

**File**: `apps/api/src/lib/pulse/actions.ts:dispatchSchedulerEnable`

After `scheduler.start(app)`, the dispatcher now calls `app.schedulerRegistry.markEnabled(jobId)`.

**Why it matters**: `grep markEnabled` before this PR returned zero production callers — only tests. The scheduler class's `start()` flipped its own `this.running = true` but `schedulerRegistry.list()` kept reporting `disabled: true, disabledReason: "Init failed: ..."`. `collectSchedulerHealth` reads the *registry*, not the scheduler class.

### 2. `cache.refresh` → write through to `CacheRefreshStatus`

**File**: `apps/api/src/lib/pulse/actions.ts:dispatchCacheRefresh`

After each successful `refreshPlexCache` / `refreshTautulliCache` call, the dispatcher now upserts `CacheRefreshStatus` via a local `recordCacheRefreshSuccess` helper (mirrors the inline upsert already in `apps/api/src/routes/plex/cache-routes.ts` so both paths behave identically).

**Why it matters**: `collectCacheStaleness` determines staleness by `lastRefreshedAt < now - STALE_CACHE_HOURS`. Without the upsert, the refresh succeeded but `lastRefreshedAt` stayed at its old timestamp → the same row re-emitted on the next poll.

The upsert is best-effort (`.catch(logWarn)`): a status-tracking failure must never fail the action itself, since the refresh already succeeded.

### 3. Rate limit on `POST /pulse/:id/action`

**File**: `apps/api/src/routes/pulse.ts`

Added `config: { rateLimit: { max: 10, timeWindow: "1m" } }` on the action route. 10/min is generous for real operator use but trips 429 on bot-scale abuse before upstream Plex/Tautulli suffers. Aligns with the `{max: 2, 5m}` limit on the dedicated manual-refresh routes.

## Tests (+3 new, +4 extended, 64 passing)

- **`actions.test.ts`** — assert `markEnabled` fires for both job ids, does NOT fire on 409 short-circuit. Assert `cacheRefreshStatus.upsert` fires with the correct composite key + `lastResult: "success"` for both cache types, does NOT fire on 404 short-circuit.
- **`pulse-action-e2e.test.ts`** — registry stub's `markEnabled` callback now mutates the `jobs` array in place, so the next `GET /pulse` reads the post-action state via the real collector. Row-drop is proven end-to-end, not hand-crafted.
- **`pulse-action-e2e-cache.test.ts`** — same live-stub pattern: Prisma's `upsert` callback mutates `cacheStatuses[i].lastRefreshedAt`.
- **New `pulse-action-rate-limit.test.ts`** — registers `@fastify/rate-limit`, fires 11 POSTs at `/pulse/sig/action`, asserts first 10 return 200 and the 11th returns 429.

## Confirmation of the trust promise

After this PR, "click action → issue resolves → row disappears" holds end-to-end:

- **scheduler.enable**: `scheduler.start(app)` + `markEnabled(jobId)` → registry reflects enabled state → next collector pass emits nothing for that job. Covered by `pulse-action-e2e.test.ts` (line 205).
- **cache.refresh**: `refreshPlexCache|refreshTautulliCache` + `recordCacheRefreshSuccess` → CacheRefreshStatus.lastRefreshedAt = now → next collector pass reads fresh timestamp, row is not re-emitted. Covered by `pulse-action-e2e-cache.test.ts` (line 196).
- **Rate limit**: 11th request in one minute gets 429. Covered by `pulse-action-rate-limit.test.ts`.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/shared exec tsc --noEmit` — clean
- [x] Biome — clean (auto-fix on import ordering)
- [x] All 64 pulse API tests pass (+3 new, +4 extended)
- [x] All 15 web pulse tests pass
- [x] Audit-identified P1 issues (scheduler registry writeback, cache status writeback) resolved + rate limit added

With this merged, Actionability V1 is trustworthy and `/release-patch` for 2.17.0 is the clean next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)