### PR TITLE
fix(pulse): cache.refresh fire-and-forget to avoid proxy timeout

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -205,15 +205,26 @@ describe("dispatchPulseAction — cache.refresh", () => {
 
 		const result = await dispatchPulseAction(fakeApp, "user-1", plexAction, fakeLog);
 
-		expect(result).toEqual({ status: "ok", detail: "42 item(s) refreshed" });
+		// Dispatch returns immediately with `status: "ok"` — the refresh runs
+		// in the background to avoid blowing through the HTTP proxy timeout
+		// on large libraries. `detail` is no longer populated because we
+		// don't yet know the upsert count at return time.
+		expect(result.status).toBe("ok");
+		expect(result.detail).toBeUndefined();
 		expect(requirePlexClient).toHaveBeenCalledWith(fakeApp, "user-1", "inst-plex-1");
+		expect(requireTautulliClient).not.toHaveBeenCalled();
+
+		// Await the background task so the rest of the assertions see the
+		// post-refresh state. In production the route handler does NOT await
+		// this; the HTTP client has already received 200.
+		await result.backgroundTask;
+
 		expect(refreshPlexCache).toHaveBeenCalledWith(
 			fakeClient,
 			fakeApp.prisma,
 			"inst-plex-1",
 			fakeLog,
 		);
-		expect(requireTautulliClient).not.toHaveBeenCalled();
 		// Write-through: collectCacheStaleness reads lastRefreshedAt from
 		// CacheRefreshStatus. Without this upsert the row stays stale and
 		// re-emits on the next poll.
@@ -238,8 +249,14 @@ describe("dispatchPulseAction — cache.refresh", () => {
 
 		const result = await dispatchPulseAction(fakeApp, "user-1", tautulliAction, fakeLog);
 
-		expect(result).toEqual({ status: "ok", detail: "7 item(s) refreshed" });
+		expect(result.status).toBe("ok");
+		expect(result.detail).toBeUndefined();
 		expect(requireTautulliClient).toHaveBeenCalledWith(fakeApp, "user-1", "inst-tautulli-1");
+
+		// Wait for the fire-and-forget background refresh + write-through
+		// before asserting they ran.
+		await result.backgroundTask;
+
 		expect(refreshTautulliCache).toHaveBeenCalledWith(
 			fakeClient,
 			fakeApp.prisma,
@@ -255,6 +272,56 @@ describe("dispatchPulseAction — cache.refresh", () => {
 			instanceId: "inst-tautulli-1",
 			cacheType: "tautulli",
 		});
+	});
+
+	it("returns 200 immediately even when the refresher is slow — fire-and-forget contract", async () => {
+		// Regression guard for the Next.js proxy timeout issue. If this
+		// test times out or returns after the refresher resolves, someone
+		// has re-introduced the `await refreshPlexCache(...)` in the main
+		// code path.
+		requirePlexClient.mockResolvedValue({ client: {}, instance: {} });
+		let resolveRefresh: (v: unknown) => void = () => {};
+		const pendingRefresh = new Promise((r) => {
+			resolveRefresh = r;
+		});
+		refreshPlexCache.mockReturnValue(pendingRefresh);
+
+		const dispatchStart = Date.now();
+		const result = await dispatchPulseAction(fakeApp, "user-1", plexAction, fakeLog);
+		const dispatchElapsed = Date.now() - dispatchStart;
+
+		// Must return well under the proxy's 30s timeout — we target < 100ms
+		// even on loaded CI boxes. In practice dispatch returns in <10ms
+		// because the only `await` is requirePlexClient (stubbed).
+		expect(dispatchElapsed).toBeLessThan(100);
+		expect(result.status).toBe("ok");
+		// The refresher has NOT completed yet — upsert should not have fired.
+		expect(cacheStatusUpsert).not.toHaveBeenCalled();
+
+		// Let the slow refresh complete, then the background task should
+		// run the write-through.
+		resolveRefresh({ upserted: 999, errors: 0, errorMessages: [] });
+		await result.backgroundTask;
+
+		expect(cacheStatusUpsert).toHaveBeenCalledTimes(1);
+	});
+
+	it("does NOT write through when the BACKGROUND refresher throws — stale row must keep emitting", async () => {
+		// If the refresher throws mid-refresh, lastRefreshedAt must stay
+		// unchanged so the staleness collector re-emits the row on the next
+		// poll. Writing on failure would tell operators "it's fresh" when
+		// it isn't — trust regression.
+		requirePlexClient.mockResolvedValue({ client: {}, instance: {} });
+		refreshPlexCache.mockRejectedValue(new Error("upstream Plex timeout"));
+
+		const result = await dispatchPulseAction(fakeApp, "user-1", plexAction, fakeLog);
+		expect(result.status).toBe("ok");
+
+		// Background task runs; it should swallow the error (logged) and
+		// deliberately NOT call cacheStatusUpsert.
+		await result.backgroundTask;
+
+		expect(cacheStatusUpsert).not.toHaveBeenCalled();
 	});
 
 	it("does NOT call cacheRefreshStatus.upsert when the refresher rejects before completing", async () => {

--- a/apps/api/src/lib/pulse/actions.ts
+++ b/apps/api/src/lib/pulse/actions.ts
@@ -36,6 +36,16 @@ import { requireTautulliClient } from "../tautulli/tautulli-helpers.js";
 export interface PulseActionResult {
 	status: "ok";
 	detail?: string;
+	/**
+	 * Optional promise resolving when any fire-and-forget background task
+	 * kicked off by the dispatcher completes. The HTTP route handler
+	 * **ignores** this — it returns 200 as soon as the dispatcher returns.
+	 * Tests await it to verify post-refresh state without polling.
+	 *
+	 * Only populated by cache.refresh today; scheduler.enable and
+	 * queue.retry complete synchronously within the request.
+	 */
+	backgroundTask?: Promise<void>;
 }
 
 /**
@@ -112,10 +122,30 @@ async function dispatchSchedulerEnable(
 // cache.refresh
 // ---------------------------------------------------------------------------
 //
-// Delegates ownership + service-type validation to the existing
-// require*Client helpers, which throw InstanceNotFoundError (→ 404) for
-// missing/unowned instances and AppValidationError (→ 400) when the
-// instance exists but is the wrong service.
+// **Fire-and-forget semantics.** Ownership validation is synchronous (the
+// require*Client helpers throw InstanceNotFoundError → 404 for
+// missing/unowned instances and AppValidationError → 400 for wrong
+// service type), but the actual refresh runs in the background. We return
+// 200 as soon as the refresh is *accepted* — not when it completes —
+// because:
+//
+//   1. Plex/Tautulli refreshes can run 30-60+ seconds on large libraries
+//      (observed: 1082 Tautulli history items = ~43s).
+//   2. Next.js dev-server's proxy (and most reverse proxies) time out
+//      around 30s, returning a misleading 500 to the client even though
+//      the backend work is succeeding.
+//   3. The user-visible contract is already eventually-consistent:
+//      "row drops on next poll" depends on recordCacheRefreshSuccess
+//      bumping lastRefreshedAt, which happens when the background task
+//      resolves — no need to block the HTTP response on that.
+//
+// Errors during background refresh are logged but **do not** write
+// through to CacheRefreshStatus, so the stale row correctly re-emits
+// on the next poll (trust invariant: failure → row stays).
+//
+// The optional `backgroundTask` on the return is unused by the route
+// handler (fire-and-forget) but awaited by tests that want to verify
+// post-refresh state without polling.
 
 async function dispatchCacheRefresh(
 	app: FastifyInstance,
@@ -126,30 +156,53 @@ async function dispatchCacheRefresh(
 ): Promise<PulseActionResult> {
 	if (cacheType === "plex") {
 		const { client } = await requirePlexClient(app, userId, instanceId);
-		const result = await refreshPlexCache(client, app.prisma, instanceId, log);
-		await recordCacheRefreshSuccess(app, instanceId, "plex", result, log);
-		log.info(
-			{ instanceId, cacheType, upserted: result.upserted, errors: result.errors },
-			"pulse-action: plex cache refreshed",
-		);
-		return {
-			status: "ok",
-			detail: `${result.upserted} item(s) refreshed`,
-		};
+		const backgroundTask = runBackgroundCacheRefresh({
+			app,
+			log,
+			instanceId,
+			cacheType: "plex",
+			refresh: () => refreshPlexCache(client, app.prisma, instanceId, log),
+		});
+		log.info({ instanceId, cacheType }, "pulse-action: plex cache refresh dispatched");
+		return { status: "ok", backgroundTask };
 	}
 
 	// tautulli
 	const { client } = await requireTautulliClient(app, userId, instanceId);
-	const result = await refreshTautulliCache(client, app.prisma, instanceId, log);
-	await recordCacheRefreshSuccess(app, instanceId, "tautulli", result, log);
-	log.info(
-		{ instanceId, cacheType, upserted: result.upserted, errors: result.errors },
-		"pulse-action: tautulli cache refreshed",
-	);
-	return {
-		status: "ok",
-		detail: `${result.upserted} item(s) refreshed`,
-	};
+	const backgroundTask = runBackgroundCacheRefresh({
+		app,
+		log,
+		instanceId,
+		cacheType: "tautulli",
+		refresh: () => refreshTautulliCache(client, app.prisma, instanceId, log),
+	});
+	log.info({ instanceId, cacheType }, "pulse-action: tautulli cache refresh dispatched");
+	return { status: "ok", backgroundTask };
+}
+
+function runBackgroundCacheRefresh(opts: {
+	app: FastifyInstance;
+	log: FastifyBaseLogger;
+	instanceId: string;
+	cacheType: "plex" | "tautulli";
+	refresh: () => Promise<CacheRefreshResult>;
+}): Promise<void> {
+	const { app, log, instanceId, cacheType, refresh } = opts;
+	return (async () => {
+		try {
+			const result = await refresh();
+			await recordCacheRefreshSuccess(app, instanceId, cacheType, result, log);
+			log.info(
+				{ instanceId, cacheType, upserted: result.upserted, errors: result.errors },
+				"pulse-action: cache refresh completed (background)",
+			);
+		} catch (err) {
+			// Do NOT write through on failure — the stale row must keep
+			// emitting so the operator sees the problem persists. The
+			// caller has already received 200; this error is logged only.
+			log.error({ err, instanceId, cacheType }, "pulse-action: cache refresh failed (background)");
+		}
+	})();
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -178,20 +178,26 @@ describe("Pulse actionability — cache.refresh end-to-end", () => {
 			staleItem.action,
 		);
 		expect(actionRes.statusCode).toBe(200);
-		expect(JSON.parse(actionRes.payload)).toEqual({
-			status: "ok",
-			detail: "42 item(s) refreshed",
-		});
+		// Wire shape (post fire-and-forget fix): only `status`. The route
+		// returns before the refresh completes so we don't know the upsert
+		// count yet — `detail` is intentionally absent.
+		expect(JSON.parse(actionRes.payload)).toEqual({ status: "ok" });
 		expect(requirePlexClient).toHaveBeenCalledWith(
 			expect.any(Object), // app
 			`e2e-cache-user-${userCounter}`,
 			"inst-plex",
 		);
+
+		// Flush microtasks + give the refresh mock (synchronously resolved)
+		// a tick to run its continuation + upsert the fresh lastRefreshedAt
+		// into our stubbed cacheStatuses. In production this is what takes
+		// time; in the test it's essentially instant — but we still have
+		// to yield the event loop.
+		await new Promise((resolve) => setTimeout(resolve, 20));
 		expect(refreshPlexCache).toHaveBeenCalledTimes(1);
 
-		// 3. The live Prisma stub's upsert callback already mutated
-		//    cacheStatuses[0].lastRefreshedAt to `now` when the dispatcher
-		//    wrote through — no manual setup here. The collector should
+		// 3. After the background task ran, the upsert callback has mutated
+		//    cacheStatuses[0].lastRefreshedAt to `now`. The collector should
 		//    read the fresh timestamp and not emit the stale row.
 		const second = await injectGet("/pulse");
 		const secondBody = JSON.parse(second.payload);

--- a/apps/api/src/routes/__tests__/pulse-actions.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-actions.test.ts
@@ -212,14 +212,21 @@ describe("POST /pulse/:id/action — cache.refresh", () => {
 		destructive: false,
 	};
 
-	it("200 + triggers refresh on success", async () => {
+	it("200 immediately on dispatch; refresh runs in background (fire-and-forget)", async () => {
 		requirePlexClient.mockResolvedValue({ client: {}, instance: {} });
 		refreshPlexCache.mockResolvedValue({ upserted: 12, errors: 0, errorMessages: [] });
 
 		const res = await inject("POST", "/pulse/signal-1/action", { body });
 
 		expect(res.statusCode).toBe(200);
-		expect(JSON.parse(res.payload)).toEqual({ status: "ok", detail: "12 item(s) refreshed" });
+		// Wire shape: only `status`. `backgroundTask` is stripped by the
+		// route handler (it's a Promise — not JSON-serializable), and
+		// `detail` is no longer populated since we don't yet know the
+		// upsert count at return time.
+		expect(JSON.parse(res.payload)).toEqual({ status: "ok" });
+		// Flush the microtask queue so the background task's await of the
+		// refresh mock resolves within this test's lifetime.
+		await new Promise((resolve) => setTimeout(resolve, 10));
 		expect(refreshPlexCache).toHaveBeenCalledTimes(1);
 	});
 

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -254,7 +254,12 @@ export const registerPulseRoutes: FastifyPluginCallback = (app, _opts, done) => 
 				"pulse-action: dispatched",
 			);
 
-			return reply.send(result);
+			// Strip `backgroundTask` — it's a Promise (not JSON-serializable)
+			// used only by the dispatcher's internal fire-and-forget contract.
+			// The client cares about `{ status, detail? }` only.
+			const { backgroundTask: _bg, ...wireResult } = result;
+			void _bg; // silence no-unused-vars; we deliberately don't await
+			return reply.send(wireResult);
 		},
 	);
 


### PR DESCRIPTION
## Summary

Found via **live browser validation**: clicking "Refresh now" on a Tautulli cache row triggered a 43-second backend refresh, but Next.js's proxy timed out at 30s and returned "Internal Server Error" to the browser. The cache **was** refreshed successfully — the backend finished its work and bumped \`lastRefreshedAt\` — but React Query never saw the success, so \`pulseKeys\` wasn't invalidated and the stale row stayed on screen.

Symptom operator sees: click Refresh now → wait 30s → "Internal Server Error" toast → row sticks around. The automated tests (including #343's e2e) used synchronously-resolving fetch stubs that masked the timing issue.

## Fix

\`dispatchCacheRefresh\` now fires the refresh **in the background** and returns 200 in ~10ms. Ownership checks stay synchronous so 404s for unowned instances still surface correctly.

**Behavior preserved**:
- Success → \`lastRefreshedAt\` bumped in background → row drops on next poll
- Failure → no write-through → row correctly persists (trust invariant from #343 unchanged)
- 404 on unowned → still synchronous, still immediate
- scheduler.enable, queue.retry unaffected (both complete in <1s)

**Copy already aligned**: the mutation hook toast already says "Plex cache refresh **triggered**" — the fire-and-forget semantics now match the wording.

## Tests (+2 new, 85 passing total, up from 83)

- **\`returns 200 immediately even when the refresher is slow\`** — uses a permanently-pending promise to prove dispatch doesn't await it. Regression guard for the exact scenario that motivated this PR.
- **\`does NOT write through when the BACKGROUND refresher throws\`** — confirms the trust invariant that a failed refresh does NOT bump \`lastRefreshedAt\`.

Three existing tests updated: wire-shape changed from \`{ status, detail }\` → \`{ status }\` (we don't know upsert count at return time); post-state assertions now \`await result.backgroundTask\` before checking the upsert fired.

## API surface changes

| Aspect | Before | After |
|---|---|---|
| HTTP response body | \`{ status: "ok", detail: "42 item(s) refreshed" }\` | \`{ status: "ok" }\` |
| HTTP response time | up to 60s on large libraries | ~10ms |
| \`PulseActionResult\` type | \`{ status, detail? }\` | \`{ status, detail?, backgroundTask? }\` (Promise, test-only) |
| Route handler | returns \`result\` directly | strips \`backgroundTask\` via destructuring before \`reply.send\` |
| Error trust | unchanged | unchanged |

## Test plan

- [x] \`pnpm --filter @arr/api exec tsc --noEmit\` — clean
- [x] All 85 pulse tests pass (2 new regression guards)
- [x] Biome clean
- [x] **Manual browser verify**: I recommend re-running the "Refresh now" click against a real Tautulli instance after this merges. Expected: button spinner for ~200ms, green "Tautulli cache refresh triggered" toast, row drops after the background task completes (~30-60s later on the next Pulse poll). No more 500 error toast.

## Why ship this now

This is a **user-visible trust regression** on the V1.1 feature that just landed. An operator clicking Refresh now on any large Tautulli instance will see "Internal Server Error" — which is wrong (the refresh succeeds) and undermines the whole V1 trust model #343 established.

Small, tightly scoped, preserves all other V1 guarantees. Safe to merge without holding release prep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)