### PR TITLE
fix(pulse): suppress tautological /pulse self-links on the /pulse page

### DIFF
--- a/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
@@ -314,4 +314,32 @@ describe("<NeedsAttentionPanel />", () => {
 		});
 		expect(footer).toHaveAttribute("href", "/pulse");
 	});
+
+	it("preserves /pulse#<id> deep-links on Needs Attention rows (paired with PulseClient self-link suppression)", () => {
+		// Counterpart to the suppression added in pulse-client.tsx: items
+		// with `actionUrl: "/pulse#..."` (e.g. from collectSchedulerHealth)
+		// MUST keep their link here on the dashboard, because clicking it
+		// is the whole point — it deep-links to the full Pulse feed and
+		// scrolls/highlights the matching row. Only the /pulse page itself
+		// is allowed to drop the self-link.
+		mockUsePulseQuery.mockReturnValue({
+			data: makeResponse([
+				makeItem({
+					id: "scheduler-failing-queue-cleaner",
+					title: "Queue Cleaner is failing",
+					actionUrl: "/pulse#scheduler-failing-queue-cleaner",
+					actionLabel: "View in Pulse",
+				}),
+			]),
+			isLoading: false,
+			isError: false,
+		});
+
+		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
+		const link = screen.getByRole("link", { name: /View in Pulse/i });
+		expect(link).toHaveAttribute(
+			"href",
+			"/pulse#scheduler-failing-queue-cleaner",
+		);
+	});
 });

--- a/apps/web/src/features/pulse/components/__tests__/pulse-client-hash-scroll.test.tsx
+++ b/apps/web/src/features/pulse/components/__tests__/pulse-client-hash-scroll.test.tsx
@@ -178,3 +178,81 @@ describe("<PulseClient /> hash-scroll effect", () => {
 		expect(scrollIntoViewSpy).not.toHaveBeenCalled();
 	});
 });
+
+describe("<PulseClient /> tautological self-link suppression", () => {
+	// PulseItemRow only renders on /pulse, so any actionUrl pointing back at
+	// /pulse (e.g. `/pulse#scheduler-failing-...` from collectSchedulerHealth)
+	// is a useless self-link in this context. The Needs Attention panel uses
+	// a different row component (AttentionRow) and is unaffected — its tests
+	// in needs-attention-panel.test.tsx still verify the link renders there.
+
+	function setupQueryWithMixedActionUrls(): PulseResponse {
+		return {
+			items: [
+				{
+					id: "scheduler-failing-queue-cleaner",
+					severity: "warning",
+					category: "operations",
+					title: "Queue Cleaner is failing",
+					detail: "2 consecutive failures",
+					source: "system",
+					timestamp: "2026-04-14T09:30:00.000Z",
+					// Tautological — points at /pulse from /pulse.
+					actionUrl: "/pulse#scheduler-failing-queue-cleaner",
+					actionLabel: "View in Pulse",
+				},
+				{
+					id: "arr-unreachable-inst-1",
+					severity: "critical",
+					category: "health",
+					title: "Sonarr is unreachable",
+					detail: "Could not connect",
+					source: "sonarr",
+					timestamp: "2026-04-14T09:30:00.000Z",
+					// Useful — navigates off /pulse to a different page.
+					actionUrl: "/settings",
+					actionLabel: "Check connection",
+				},
+			],
+			summary: { critical: 1, warning: 1, info: 0 },
+			generatedAt: "2026-04-14T09:30:00.000Z",
+		};
+	}
+
+	it("does NOT render a /pulse self-link on a row whose actionUrl points back at /pulse", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: setupQueryWithMixedActionUrls(),
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+			dataUpdatedAt: Date.now(),
+		});
+
+		const { container } = render(<PulseClient />, { wrapper: Wrapper });
+		const row = container.querySelector("#scheduler-failing-queue-cleaner");
+		expect(row).not.toBeNull();
+		// The "View in Pulse" anchor must not appear inside this row — it
+		// would just scroll to the same row already in view.
+		const selfLink = row?.querySelector('a[href="/pulse#scheduler-failing-queue-cleaner"]');
+		expect(selfLink).toBeNull();
+	});
+
+	it("DOES render non-/pulse links normally on the same page", () => {
+		mockUsePulseQuery.mockReturnValue({
+			data: setupQueryWithMixedActionUrls(),
+			isLoading: false,
+			isError: false,
+			isFetching: false,
+			dataUpdatedAt: Date.now(),
+		});
+
+		const { container } = render(<PulseClient />, { wrapper: Wrapper });
+		const row = container.querySelector("#arr-unreachable-inst-1");
+		expect(row).not.toBeNull();
+		// Non-/pulse links must keep working — they navigate off-page to
+		// where the operator can actually fix the problem.
+		const offPageLink = row?.querySelector('a[href="/settings"]');
+		expect(offPageLink).not.toBeNull();
+		expect(offPageLink?.textContent).toContain("Check connection");
+	});
+});

--- a/apps/web/src/features/pulse/components/pulse-client.tsx
+++ b/apps/web/src/features/pulse/components/pulse-client.tsx
@@ -126,7 +126,20 @@ function PulseItemRow({
 
 			{item.action && <PulseActionButton signalId={item.id} action={item.action} />}
 
-			{item.actionUrl && (
+			{/*
+			 * Suppress tautological self-links. Some collectors (e.g.
+			 * collectSchedulerHealth) emit `actionUrl: "/pulse#<id>"` so
+			 * operators arriving from the dashboard Needs Attention panel
+			 * land on the matching row. On the /pulse page itself, that
+			 * link just scrolls to the row already in view — useless
+			 * decoration. PulseItemRow only ever renders on /pulse, so a
+			 * simple prefix check is sufficient; no router hook needed.
+			 *
+			 * Other actionUrls (/settings, /statistics, /dashboard) still
+			 * render normally — they navigate the operator off /pulse to
+			 * a useful destination.
+			 */}
+			{item.actionUrl && !item.actionUrl.startsWith("/pulse") && (
 				<Link
 					href={item.actionUrl}
 					className="shrink-0 flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"


### PR DESCRIPTION
## Summary

Some collectors (today: \`collectSchedulerHealth\`) emit \`actionUrl: \"/pulse#<id>\"\` so operators arriving from the dashboard Needs Attention panel land on the matching row in the full feed. **On the \`/pulse\` page itself, that link just scrolls to the row already in view** — useless decoration. Drop it there; keep it everywhere else.

This was previously identified during the V1 audit as low-risk cleanup. Doing it now while the surface is fresh.

## The change

Two-line behavioral change inside \`PulseItemRow\`:

\`\`\`diff
- {item.actionUrl && (
+ {item.actionUrl && !item.actionUrl.startsWith(\"/pulse\") && (
\`\`\`

\`PulseItemRow\` is page-scoped to \`/pulse\` (only rendered there), so a simple prefix check on the URL is sufficient — no need for \`usePathname\` or any router hook.

## What's preserved (paired test)

- **Needs Attention panel** — separate component (\`AttentionRow\`), untouched. Items with \`actionUrl: \"/pulse#<id>\"\` still render the \"View in Pulse\" link there. That's the whole reason the deep-link exists.
- **Non-/pulse links on /pulse** — \`/settings\`, \`/statistics\`, \`/dashboard\` etc. still render normally.
- **Action buttons** (Enable / Refresh now / Retry from V1) — unaffected.

## Tests (+3, 80/80 web pulse+dashboard tests pass)

| Test | Asserts |
|---|---|
| **PulseClient — self-link suppression** | Row with \`actionUrl: \"/pulse#scheduler-...\"\` does NOT render the anchor |
| **PulseClient — non-/pulse links unchanged** | Same render: row with \`actionUrl: \"/settings\"\` DOES render the anchor (regression guard against over-suppression) |
| **Needs Attention — link preserved** | \`/pulse#<id>\` link IS preserved on Needs Attention rows (proves suppression is local to /pulse, not global) |

## Files changed

- \`apps/web/src/features/pulse/components/pulse-client.tsx\` — 2 lines of behavior + ~10 lines of explanatory comment
- \`apps/web/src/features/pulse/components/__tests__/pulse-client-hash-scroll.test.tsx\` — +2 tests
- \`apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx\` — +1 paired test

## Deferred (intentional)

- **No router-hook plumbing** — page-scoped component, prefix check is sufficient.
- **No general link cleanup** — only the specific tautological /pulse-from-/pulse case.
- **No collector-side change** — collectors still emit \`/pulse#<id>\`. The deep-link from Needs Attention keeps working. Suppression is purely a render-time decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)