### PR TITLE
refactor(pulse): drop unused confirmLabel from action envelope

### DIFF
--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -109,7 +109,6 @@ describe("dispatchPulseAction — scheduler.enable", () => {
 		kind: "scheduler.enable",
 		target: { jobId: "hunting" },
 		label: "Enable scheduler",
-		confirmLabel: "Click again to enable",
 		destructive: false,
 	};
 	const cleanerAction: PulseAction = {
@@ -190,7 +189,6 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		kind: "cache.refresh",
 		target: { instanceId: "inst-plex-1", cacheType: "plex" },
 		label: "Refresh now",
-		confirmLabel: "Click again to refresh",
 		destructive: false,
 	};
 	const tautulliAction: PulseAction = {
@@ -396,7 +394,6 @@ describe("dispatchPulseAction — queue.retry", () => {
 			service: "sonarr",
 		},
 		label: "Retry",
-		confirmLabel: "Click again to retry",
 		destructive: false,
 	};
 

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -505,7 +505,6 @@ const collectArrQueueFailures: Collector = async (app, userId, log) => {
 							service,
 						},
 						label: "Retry",
-						confirmLabel: "Click again to retry",
 						destructive: false,
 					},
 				});
@@ -596,7 +595,6 @@ function actionForStaleCache(instanceId: string, cacheType: string): PulseAction
 		kind: "cache.refresh",
 		target: { instanceId, cacheType: cacheType as PulseCacheType },
 		label: "Refresh now",
-		confirmLabel: "Click again to refresh",
 		destructive: false,
 	};
 }
@@ -890,7 +888,6 @@ function actionForDisabledScheduler(jobId: string): PulseAction | undefined {
 		kind: "scheduler.enable",
 		target: { jobId: jobId as SchedulerJobId },
 		label: "Enable",
-		confirmLabel: "Click again to enable",
 		destructive: false,
 	};
 }

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -168,7 +168,6 @@ describe("Pulse actionability — cache.refresh end-to-end", () => {
 			kind: "cache.refresh",
 			target: { instanceId: "inst-plex", cacheType: "plex" },
 			label: "Refresh now",
-			confirmLabel: "Click again to refresh",
 			destructive: false,
 		});
 

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-queue.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-queue.test.ts
@@ -152,7 +152,6 @@ describe("Pulse actionability — queue.retry end-to-end", () => {
 				service: "sonarr",
 			},
 			label: "Retry",
-			confirmLabel: "Click again to retry",
 			destructive: false,
 		});
 

--- a/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e.test.ts
@@ -176,7 +176,6 @@ describe("Pulse actionability — end-to-end (PR 1 + PR 2)", () => {
 			kind: "scheduler.enable",
 			target: { jobId: "hunting" },
 			label: "Enable",
-			confirmLabel: "Click again to enable",
 			destructive: false,
 		});
 

--- a/apps/api/src/routes/__tests__/pulse-action-rate-limit.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-rate-limit.test.ts
@@ -87,7 +87,6 @@ async function injectAction() {
 			kind: "scheduler.enable",
 			target: { jobId: "hunting" },
 			label: "Enable",
-			confirmLabel: "Click again to enable",
 			destructive: false,
 		}),
 	});

--- a/apps/api/src/routes/__tests__/pulse-actions.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-actions.test.ts
@@ -155,7 +155,6 @@ describe("POST /pulse/:id/action — auth", () => {
 				kind: "scheduler.enable",
 				target: { jobId: "hunting" },
 				label: "Enable scheduler",
-				confirmLabel: "Click again",
 				destructive: false,
 			},
 		});
@@ -169,7 +168,6 @@ describe("POST /pulse/:id/action — scheduler.enable", () => {
 		kind: "scheduler.enable",
 		target: { jobId: "hunting" },
 		label: "Enable scheduler",
-		confirmLabel: "Click again to enable",
 		destructive: false,
 	};
 
@@ -208,7 +206,6 @@ describe("POST /pulse/:id/action — cache.refresh", () => {
 		kind: "cache.refresh",
 		target: { instanceId: "inst-plex-1", cacheType: "plex" },
 		label: "Refresh now",
-		confirmLabel: "Click again",
 		destructive: false,
 	};
 

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -88,7 +88,6 @@ describe("GET /pulse — cache.refresh action emission", () => {
 			kind: "cache.refresh",
 			target: { instanceId: "inst-plex", cacheType: "plex" },
 			label: "Refresh now",
-			confirmLabel: "Click again to refresh",
 			destructive: false,
 		});
 	});

--- a/apps/api/src/routes/__tests__/pulse-queue-failures.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-queue-failures.test.ts
@@ -129,7 +129,6 @@ describe("GET /pulse — collectArrQueueFailures emission", () => {
 			kind: "queue.retry",
 			target: { instanceId: "inst-sonarr-1", queueItemId: "7", service: "sonarr" },
 			label: "Retry",
-			confirmLabel: "Click again to retry",
 			destructive: false,
 		});
 	});

--- a/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-scheduler-health.test.ts
@@ -159,7 +159,6 @@ describe("GET /pulse — scheduler health signals", () => {
 			kind: "scheduler.enable",
 			target: { jobId: "hunting" },
 			label: "Enable",
-			confirmLabel: "Click again to enable",
 			destructive: false,
 		});
 	});

--- a/apps/web/src/features/pulse/components/__tests__/pulse-action-button.test.tsx
+++ b/apps/web/src/features/pulse/components/__tests__/pulse-action-button.test.tsx
@@ -29,7 +29,6 @@ const ACTION: PulseAction = {
 	kind: "scheduler.enable",
 	target: { jobId: "hunting" },
 	label: "Enable",
-	confirmLabel: "Click again to enable",
 	destructive: false,
 };
 

--- a/packages/shared/src/types/pulse.ts
+++ b/packages/shared/src/types/pulse.ts
@@ -53,7 +53,6 @@ export const pulseActionSchema = z.discriminatedUnion("kind", [
 		kind: z.literal("scheduler.enable"),
 		target: z.object({ jobId: schedulerJobIdSchema }),
 		label: z.string().min(1),
-		confirmLabel: z.string().min(1),
 		destructive: z.boolean(),
 	}),
 	z.object({
@@ -63,7 +62,6 @@ export const pulseActionSchema = z.discriminatedUnion("kind", [
 			cacheType: pulseCacheTypeSchema,
 		}),
 		label: z.string().min(1),
-		confirmLabel: z.string().min(1),
 		destructive: z.boolean(),
 	}),
 	z.object({
@@ -76,7 +74,6 @@ export const pulseActionSchema = z.discriminatedUnion("kind", [
 			service: queueRetryServiceSchema,
 		}),
 		label: z.string().min(1),
-		confirmLabel: z.string().min(1),
 		destructive: z.boolean(),
 	}),
 ]);


### PR DESCRIPTION
## Summary

\`confirmLabel\` was added in #340 as forward-fitting for a possible two-tap destructive action UX. V1 + V1.1 shipped without any destructive action, and the upcoming roadmap doesn't include one. **A grep confirms zero production reads** — only the schema validating the field and tests setting it because the schema required it. Pure dead weight.

## Audit result

\`grep -rn confirmLabel\` across the repo finds 18 references in 12 files:

| Where | Reads it? |
|---|---|
| \`packages/shared/src/types/pulse.ts\` (schema) | declares the requirement |
| \`apps/api/src/lib/pulse/collectors.ts\` (3 emit sites) | sets it on outbound action envelopes |
| 9 test files | set it in test fixtures, occasionally assert it round-trips |
| **PulseActionButton component** | ❌ does not read |
| **usePulseActionMutation hook** | ❌ does not read |
| **dispatchPulseAction** | ❌ does not read |
| **POST /pulse/:id/action route handler** | ❌ does not read |
| Anywhere else in the dashboard / pulse rendering | ❌ does not read |

## Removed

- \`confirmLabel: z.string().min(1)\` from all 3 variants of \`pulseActionSchema\`
- \`confirmLabel: \"...\"\` from \`actionForDisabledScheduler\`, \`actionForStaleCache\`, and the inline queue.retry emit
- 18 \`confirmLabel\` lines across 10 test files (fixtures / assertions)

## What about future destructive actions?

If a destructive variant lands later (e.g. \`queue.remove\` with two-tap confirm), it can:
- **Add** \`confirmLabel\` only to that specific variant in the discriminated union, keeping safer kinds free of the field
- **Or** introduce a kind-specific UX prop (more honest scoping)

Strictly better than carrying a field nobody reads on every action kind \"in case we need it someday\". Removing it now also makes it easier to spot the day someone *does* add a confirm UX — they'll consciously add the field rather than reaching for a coincidentally-existing one.

## Validation

- \`pnpm --filter @arr/api exec tsc --noEmit\` — clean
- \`pnpm --filter @arr/web exec tsc --noEmit\` — clean
- \`pnpm --filter @arr/shared exec tsc --noEmit\` — clean
- **91/91 API pulse tests pass** (no behavior change)
- **18/18 web pulse + needs-attention tests pass**

## Files changed (12)

| File | Δ |
|---|---|
| \`packages/shared/src/types/pulse.ts\` | -3 lines (one per variant) |
| \`apps/api/src/lib/pulse/collectors.ts\` | -3 lines (one per emit site) |
| 10 test files | -1 to -3 lines each (fixtures only) |

**Net: -20 lines, no behavior change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)