### PR TITLE
fix(ui): pin PageLayout main width to stop calendar narrowing on month nav

### DIFF
--- a/apps/web/src/components/layout/page-layout.tsx
+++ b/apps/web/src/components/layout/page-layout.tsx
@@ -56,7 +56,11 @@ export const PageLayout = ({
 	return (
 		<main
 			className={cn(
-				"mx-auto flex flex-col px-3 py-8 sm:px-4 sm:py-12 md:px-6 md:py-16",
+				// w-full pins main to the template's flex-col parent width; without it,
+				// mx-auto cancels align-items:stretch and main collapses to its intrinsic
+				// content width, so brief loading skeletons or content-width changes cause
+				// visible layout shifts (e.g. calendar narrowing on month nav — issue #272).
+				"mx-auto w-full flex flex-col px-3 py-8 sm:px-4 sm:py-12 md:px-6 md:py-16",
 				MAX_WIDTH_CLASSES[maxWidth],
 				GAP_CLASSES[gap],
 				className,


### PR DESCRIPTION
## Summary

- Completes the fix for #272 (prior PR #279 handled vertical shift only; this handles horizontal).
- Adds `w-full` to `PageLayout`'s `<main>` so it always fills its parent wrapper.

## Root cause

`PageLayout`'s `<main>` uses `mx-auto max-w-[1600px] flex flex-col` and lives inside `template.tsx`'s `<motion.div className="flex-1 flex flex-col">`. In a `flex-col` parent, auto horizontal margins **cancel** the default `align-items: stretch` — so main sizes to its **intrinsic content width**, not the parent's width.

Consequences in the calendar:
- Between months the `isLoading` skeleton renders; its intrinsic width is narrower than a populated calendar, so main briefly collapses mid-transition.
- Months with denser event chips produce wider intrinsic content, sparser months narrower — so main ends up at different widths per month even after loading completes.

The user-visible effect is the calendar appearing to "get narrower with each click forward and wider going back" — exactly what was reported in [#272 comment](https://github.com/Kha-kis/arr-dashboard/issues/272#issuecomment-4260697072).

## Fix

One line in `apps/web/src/components/layout/page-layout.tsx`: add `w-full` to the class list, with an inline comment pinning the reason so nobody strips it as "redundant" with `mx-auto max-w-*`.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] Playwright at 1600×900: navigated 4 months forward + 4 back + rapid-click sequences; `main` stays 1288px and grid column stays 836px across every transition, including the loading flash.
- [x] Dashboard page spot-checked — no visual regression.
- [ ] Please re-verify against the original reproduction (user's @daFreeMan GIF in #272).

🤖 Generated with [Claude Code](https://claude.com/claude-code)