### PR TITLE
chore: v2.16.1 release — changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1] - 2026-04-16
+
+**Patch release — reverse-proxy link correctness and calendar layout stability.**
+
+Two user-facing bug fixes on top of 2.16.0. No new features, no schema/API breaking changes — both fixes are transparent to existing installs.
+
+### Fixed
+
+- **Calendar narrows on month navigation** — `PageLayout`'s `<main>` was collapsing to its intrinsic content width because `mx-auto` cancels the default `align-items: stretch` when the parent is `flex flex-col`. When a month's content (loading skeleton, dense event chips, sparse weeks) had a different intrinsic width than the previous month, `main` resized and the calendar appeared to grow or shrink between clicks. Pinning `main` to `w-full` keeps it at parent width regardless of content — the grid, filters, and navigation controls now stay anchored across months. Completes the fix for #272 (the earlier #279 addressed only the vertical 6-week grid; this one was the missed horizontal axis).
+- **Instance deep links now prefer `externalUrl` everywhere** — Statistics → Overview → Health Issues "View" link, plus the Calendar event card, History row, and Library card "open in Sonarr/Radarr/etc." links were building hrefs from `baseUrl` — the internal container URL that isn't reachable when the instance sits behind a reverse proxy. All four sites now use `instance.externalUrl ?? instance.baseUrl`, matching the pattern introduced for the dashboard Active Queue in #306. To make this bug harder to reintroduce, `HealthIssue` records now carry `instanceExternalUrl` end-to-end from the API down to the render site, so any future consumer inherits correct URL resolution without a frontend service lookup. Closes #354.
+
 ## [2.16.0] - 2026-04-15
 
 **From monitoring to guided action.** This release turns the attention surface — System Pulse and the new dashboard Needs Attention panel — from a *report* of what's wrong into a place where operators can *fix* the problem in one click. Pulse / Needs Attention is now the canonical issue surface: pre-existing banners that duplicated its signals have been removed, misleading diagnostic copy has been reworded to defer to Pulse as the single source of truth, and three safe actions — Enable a disabled scheduler, Refresh a stale cache, Retry a failed queue item — land inline on their respective rows.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.16.0 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.16.1 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.16.0** — From monitoring to guided action: Needs Attention panel, Actionability V1 (Enable / Refresh now / Retry), media-server reachability signals, duplicate banner cleanup, trust/microcopy alignment
+> **Version 2.16.1** — Patch: reverse-proxy link resolution across Statistics → Health Issues and Calendar / History / Library deep links; Calendar layout stability on month navigation
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -93,6 +93,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.16.1` | Reverse-proxy link resolution in Statistics / Calendar / History / Library; Calendar layout stability |
 | `2.16.0` | Needs Attention, inline Pulse actions (Enable / Refresh now / Retry), media-server reachability, duplicate banner cleanup |
 | `2.15.0` | Scheduler jobs surface, Security Posture, route governance, shared UX primitives, Plex/Tautulli cache hardening |
 | `2.14.0` | Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.16.0** — From monitoring to guided action: Needs Attention panel, Actionability V1 (Enable / Refresh now / Retry), media-server reachability signals, duplicate banner cleanup, trust/microcopy alignment
+> **Version 2.16.1** — Patch: reverse-proxy link resolution across Statistics → Health Issues and Calendar / History / Library deep links; Calendar layout stability on month navigation
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -210,6 +210,7 @@ docker-compose up -d
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.16.1` | Reverse-proxy link resolution in Statistics / Calendar / History / Library; Calendar layout stability |
 | `2.16.0` | Needs Attention, inline Pulse actions (Enable / Refresh now / Retry), media-server reachability, duplicate banner cleanup |
 | `2.15.0` | Scheduler jobs surface, Security Posture, route governance, shared UX primitives, Plex/Tautulli cache hardening |
 | `2.14.0` | Jellyfin & Emby integration, OAuth-assisted setup, notification quiet hours |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arr-dashboard-platform",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "private": true,
   "packageManager": "pnpm@10.33.0",
   "scripts": {


### PR DESCRIPTION
Patch release bundling two user-facing fixes shipped since v2.16.0.

## What's in it

**Fixed**
- **Calendar narrows on month navigation** — `PageLayout`'s `<main>` was collapsing to its intrinsic content width because `mx-auto` cancels `align-items: stretch` in a `flex flex-col` parent. Pinning `main` to `w-full` keeps the grid and controls anchored across months. Completes the fix for #272 (#357)
- **Instance deep links prefer `externalUrl`** — Statistics → Health Issues "View" link plus Calendar / History / Library deep links were using the internal `baseUrl`. All four now prefer `instance.externalUrl ?? instance.baseUrl`. `HealthIssue` schema carries `instanceExternalUrl` end-to-end so this class is closed for future consumers too. Closes #354 (#358)

No new features, no schema breaking changes.

## Release checklist (applied in this PR)

- [x] `package.json` → `2.16.1`
- [x] `CHANGELOG.md` — new `[2.16.1]` section
- [x] `README.md` — tagline + tags-table row
- [x] `DOCKERHUB.md` — tagline + tags-table row
- [x] `CLAUDE.md` — version footer
- [x] Wiki `Home.md` + `Troubleshooting.md` (staged locally in `/tmp/arr-wiki`, will push after this merges)

## Validation

- [x] `pnpm --filter @arr/web exec tsc --noEmit` clean
- [x] `pnpm --filter @arr/api exec tsc --noEmit` clean
- [x] `pnpm run test` — 121 files / 1364 tests passed, 36 skipped, 0 failed
- [x] `pnpm run build` — 3 successful
- [x] `pnpm run lint` — 0 errors

## Post-merge

After CI is green and this merges:
1. Tag `v2.16.1` on main pointing at the squash commit.
2. Push wiki updates.
3. Publish GitHub release notes (mirror the CHANGELOG section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)