### PR TITLE
chore(web): remove redundant console.* calls in trash-guides surface

### DIFF
--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -157,7 +157,6 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 				if (error instanceof Error && error.name === "AbortError") {
 					return;
 				}
-				console.error("Error fetching bulk overrides:", error);
 				toast.error("Failed to fetch quality profile overrides");
 			}
 		},
@@ -272,7 +271,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 			setModifiedScores(new Map());
 			onOperationComplete?.();
 		} catch (error) {
-			console.error("Error saving scores:", error);
+			// error surfaced through mutation state
 		}
 	};
 
@@ -389,7 +388,6 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 				`Successfully reset ${totalDeleted} override${totalDeleted === 1 ? "" : "s"} to template defaults`,
 			);
 		} catch (error) {
-			console.error("Failed to bulk reset:", error);
 			const errorMessage = getErrorMessage(error, "Unknown error occurred");
 			toast.error(
 				`Failed to reset overrides: ${errorMessage}. Some overrides may have been reset. Please refresh to see the current state.`,

--- a/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
@@ -113,7 +113,6 @@ export function EnhancedTemplateExportModal({
 				}
 			}
 		} catch (error) {
-			console.error("Failed to export template:", error);
 			alert("Failed to export template");
 		} finally {
 			setIsExporting(false);

--- a/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
@@ -68,7 +68,6 @@ export function EnhancedTemplateImportModal({
 			setJsonData(text);
 			await validateTemplate(text);
 		} catch (error) {
-			console.error("Failed to read file:", error);
 			alert("Failed to read template file");
 		}
 	};
@@ -91,7 +90,6 @@ export function EnhancedTemplateImportModal({
 			setValidation(result.data.validation);
 			setCompatibility(result.data.compatibility);
 		} catch (error) {
-			console.error("Failed to validate template:", error);
 			alert("Failed to validate template");
 		} finally {
 			setIsValidating(false);

--- a/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
+++ b/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
@@ -187,7 +187,6 @@ export const InstanceOverrideEditor = ({
 			setHasChanges(false);
 			toast.success("Instance overrides saved successfully");
 		} catch (err) {
-			console.error("Failed to save instance overrides:", err);
 			toast.error("Failed to save instance overrides");
 		}
 	};
@@ -211,7 +210,6 @@ export const InstanceOverrideEditor = ({
 			setHasChanges(false);
 			toast.success("All instance overrides deleted");
 		} catch (err) {
-			console.error("Failed to delete instance overrides:", err);
 			toast.error("Failed to delete instance overrides");
 		}
 	};

--- a/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
@@ -72,7 +72,7 @@ export function QualityProfileImporter({
 			});
 			setImportedProfile(result.profile);
 		} catch (error) {
-			console.error("Failed to import profile:", error);
+			// error surfaced through mutation state
 		}
 	};
 

--- a/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
+++ b/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
@@ -107,7 +107,6 @@ export const SchedulerStatusDashboard = () => {
 		try {
 			await triggerCheck.mutateAsync();
 		} catch (error) {
-			console.error("Failed to trigger update check:", error);
 			alert("Failed to trigger update check. Please try again.");
 		}
 	};
@@ -193,7 +192,9 @@ export const SchedulerStatusDashboard = () => {
 			/>
 			<div
 				className="absolute left-0 top-0 bottom-0 w-[3px]"
-				style={{ background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})` }}
+				style={{
+					background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
+				}}
 			/>
 			<div className="relative p-6 space-y-6">
 				{/* Header */}

--- a/apps/web/src/features/trash-guides/components/template-diff-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/template-diff-modal.tsx
@@ -214,7 +214,6 @@ export const TemplateDiffModal = ({
 			onSyncSuccess?.();
 			onClose();
 		} catch (err) {
-			console.error("Sync failed:", err);
 			toast.error("Sync failed", {
 				description: getErrorMessage(err, "An unexpected error occurred"),
 			});

--- a/apps/web/src/features/trash-guides/components/template-list.tsx
+++ b/apps/web/src/features/trash-guides/components/template-list.tsx
@@ -124,7 +124,6 @@ export const TemplateList = ({
 			await deleteMutation.mutateAsync(templateId);
 			dispatch({ type: "CLOSE_DELETE" });
 		} catch (error) {
-			console.error("Delete failed:", error);
 			const errorMessage = getErrorMessage(error, "Unknown error occurred");
 			toast.error("Failed to delete template", { description: errorMessage });
 		}
@@ -143,7 +142,6 @@ export const TemplateList = ({
 			});
 			dispatch({ type: "CLOSE_DUPLICATE" });
 		} catch (error) {
-			console.error("Duplicate failed:", error);
 			const errorMessage = getErrorMessage(error, "Unknown error occurred");
 			toast.error("Failed to duplicate template", { description: errorMessage });
 		}
@@ -169,7 +167,6 @@ export const TemplateList = ({
 				},
 			});
 		} catch (error) {
-			console.error("Sync execution failed:", error);
 			const errorMessage = getErrorMessage(error, "Unknown error occurred");
 			toast.error("Failed to start sync operation", { description: errorMessage });
 		}
@@ -669,7 +666,11 @@ export const TemplateList = ({
 							</h3>
 							<p className="text-sm text-muted-foreground">
 								Are you sure you want to unlink template &quot;{modals.unlinkConfirm.templateName}
-								&quot; from instance &quot;{incognitoMode ? getLinuxInstanceName(modals.unlinkConfirm.instanceName) : modals.unlinkConfirm.instanceName}&quot;?
+								&quot; from instance &quot;
+								{incognitoMode
+									? getLinuxInstanceName(modals.unlinkConfirm.instanceName)
+									: modals.unlinkConfirm.instanceName}
+								&quot;?
 							</p>
 							<p className="text-xs text-muted-foreground">
 								This will remove the deployment mapping. Custom Formats already on the instance will

--- a/apps/web/src/features/trash-guides/components/template-schedule-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/template-schedule-modal.tsx
@@ -183,7 +183,6 @@ export const TemplateScheduleModal = ({
 			});
 			onClose();
 		} catch (err) {
-			console.error("Failed to save schedule:", err);
 			setError(getErrorMessage(err, "Failed to save schedule. Please try again."));
 		} finally {
 			setIsSaving(false);
@@ -555,30 +554,30 @@ export const TemplateScheduleModal = ({
 						)}
 					</div>
 					<div className="flex gap-3">
-					<Button variant="outline" onClick={onClose} className="rounded-xl">
-						Cancel
-					</Button>
-					<Button
-						onClick={handleSave}
-						disabled={isSaving}
-						className="gap-2 rounded-xl font-medium"
-						style={{
-							background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-							boxShadow: `0 4px 12px -4px ${themeGradient.glow}`,
-						}}
-					>
-						{isSaving ? (
-							<>
-								<Loader2 className="h-4 w-4 animate-spin" />
-								Saving...
-							</>
-						) : (
-							<>
-								<Clock className="h-4 w-4" />
-								{existingSchedule ? "Update Schedule" : "Create Schedule"}
-							</>
-						)}
-					</Button>
+						<Button variant="outline" onClick={onClose} className="rounded-xl">
+							Cancel
+						</Button>
+						<Button
+							onClick={handleSave}
+							disabled={isSaving}
+							className="gap-2 rounded-xl font-medium"
+							style={{
+								background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
+								boxShadow: `0 4px 12px -4px ${themeGradient.glow}`,
+							}}
+						>
+							{isSaving ? (
+								<>
+									<Loader2 className="h-4 w-4 animate-spin" />
+									Saving...
+								</>
+							) : (
+								<>
+									<Clock className="h-4 w-4" />
+									{existingSchedule ? "Update Schedule" : "Create Schedule"}
+								</>
+							)}
+						</Button>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -283,7 +283,8 @@ export const TemplateCreation = ({
 				editingTemplate?.config.customFormatGroups.map((g) => ({
 					trash_id: g.trashId,
 					name: g.name || "",
-					custom_formats: (g.originalConfig?.custom_formats as WizardCFGroup["custom_formats"]) || [],
+					custom_formats:
+						(g.originalConfig?.custom_formats as WizardCFGroup["custom_formats"]) || [],
 				})) ||
 				[]
 			: data?.cfGroups || [];
@@ -366,14 +367,6 @@ export const TemplateCreation = ({
 			onComplete();
 		} catch (error) {
 			// Error will be displayed through mutation state
-			console.error(
-				isEditMode
-					? "Update failed:"
-					: isCloned
-						? "Cloned template creation failed:"
-						: "Import failed:",
-				error,
-			);
 		}
 	};
 

--- a/apps/web/src/hooks/api/useDeploymentPreview.ts
+++ b/apps/web/src/hooks/api/useDeploymentPreview.ts
@@ -19,7 +19,7 @@ import {
 	unlinkTemplateFromInstance,
 	updateSyncStrategy,
 } from "../../lib/api-client/trash-guides";
-import { TEMPLATES_QUERY_KEY, deploymentHistoryKeys, trashGuidesKeys } from "../../lib/query-keys";
+import { deploymentHistoryKeys, TEMPLATES_QUERY_KEY, trashGuidesKeys } from "../../lib/query-keys";
 
 export type InstancePreviewResult = {
 	instanceId: string;
@@ -151,7 +151,6 @@ export function useUpdateSyncStrategy() {
 			});
 		},
 		onError: (error) => {
-			console.error("Failed to update sync strategy:", error);
 			toast.error("Failed to update sync strategy", {
 				description: error.message,
 			});
@@ -178,7 +177,6 @@ export function useBulkUpdateSyncStrategy() {
 			});
 		},
 		onError: (error) => {
-			console.error("Failed to bulk update sync strategy:", error);
 			toast.error("Failed to update sync strategy", {
 				description: error.message,
 			});
@@ -214,7 +212,6 @@ export function useUnlinkTemplateFromInstance() {
 			});
 		},
 		onError: (error) => {
-			console.error("Unlink failed:", error);
 			toast.error("Failed to unlink template from instance", {
 				description: error.message,
 			});

--- a/apps/web/src/hooks/api/useQualityProfileOverrides.ts
+++ b/apps/web/src/hooks/api/useQualityProfileOverrides.ts
@@ -10,9 +10,9 @@ import {
 	promoteOverrideToTemplate,
 } from "../../lib/api-client/trash-guides";
 import {
-	TEMPLATES_QUERY_KEY,
 	bulkScoreKeys,
 	qualityProfileKeys,
+	TEMPLATES_QUERY_KEY,
 	trashGuidesKeys,
 } from "../../lib/query-keys";
 
@@ -95,7 +95,6 @@ export function useDeleteOverride() {
 			}
 		},
 		onError: (error) => {
-			console.error("Failed to delete override:", error);
 			toast.error("Failed to delete override", {
 				description: error.message,
 			});
@@ -134,7 +133,6 @@ export function useBulkDeleteOverrides() {
 			}
 		},
 		onError: (error) => {
-			console.error("Failed to bulk delete overrides:", error);
 			toast.error("Failed to delete overrides", {
 				description: error.message,
 			});

--- a/apps/web/src/hooks/api/useQualityProfileScores.ts
+++ b/apps/web/src/hooks/api/useQualityProfileScores.ts
@@ -138,9 +138,7 @@ export function useBulkUpdateScores() {
 					.join(", ");
 
 				const error = Object.assign(
-					new Error(
-						`Failed to update ${failureCount} quality profile(s): ${errorMessages}`,
-					),
+					new Error(`Failed to update ${failureCount} quality profile(s): ${errorMessages}`),
 					{
 						results: {
 							totalProfiles: entries.length,
@@ -184,7 +182,6 @@ export function useBulkUpdateScores() {
 			}
 		},
 		onError: (error) => {
-			console.error("Failed to bulk update scores:", error);
 			toast.error("Failed to update custom format scores", {
 				description: error.message,
 			});


### PR DESCRIPTION
## Summary

- Removes 22 `console.error` / `console.warn` calls across 13 web files in the TRaSH Guides feature surface, all of which were the "log-then-toast" pattern: the user-facing `toast.error()`, `alert()`, or `setError()` already surfaced the error, so the console line added nothing in production.
- Per CLAUDE.md: *"Use `request.log` or `app.log` (pino), never `console.log` in production code"*. The web side has no pino equivalent, so the principle here is "rely on the user-facing surface, don't dual-log."
- Identified during code review of [#364](https://github.com/Kha-kis/arr-dashboard/pull/364) as a one-line note. After auditing, the actual surface was much larger and concentrated in trash-guides — fixing it as a unit is higher leverage than picking off one line.

## Audit context

Pre-cleanup: **35** `console.*` calls in trash-guides + adjacent React Query hooks (excluding tests).
Post-cleanup: **13** calls remaining — all intentionally preserved.

## What was preserved (and why)

These 13 remaining calls are intentional diagnostics aligned with the project's silent-failure-hunter principles, not log-then-toast noise: | File | Why kept |
|---|---|
| `useSync.ts:185, 205, 209, 271, 277` | Silent-failure detection on validation; SSE fallback signals |
| `useSync.ts:212` | Already has `// eslint-disable-next-line no-console -- dev-only debug logging` + `NODE_ENV === "development"` gate |
| `sync-validation-modal.tsx:111, 131` | Silent-failure timing/context instrumentation (matches `[useValidateSync]` pattern) |
| `pattern-tester.tsx:236` | Per-line regex error detail for dev (UI shows generic indicator) |
| `useCFConfiguration.ts:245, 609` | Optional-enrichment fallback warns with explanatory comments |
| `useQualityProfileScores.ts:92, 99` | Parse failure warnings during CF mapping |

API side: **0 production violations**. The 147 `console.*` calls in `lib/queue-cleaner` are all in diagnostic/test scripts (`analyze-status-patterns.ts`, `test-arr-integration.ts`, etc.); the 10 in `launcher.ts`/`index.ts` are bootstrap-time before pino is available. All legitimate.

## Audit decision: log vs. toast

For each removed call, the surrounding handler already surfaced the error:
- `toast.error(...)` — user-visible toast (most common)
- `alert(...)` — modal alert (legacy)
- `setError(...)` — inline form error
- React Query mutation `error` state — for `quality-profile-importer.tsx:75` and `bulk-score-manager.tsx:275`, the mutation's error state is available to consuming components

The deleted `console.error` calls added zero information beyond what the user already saw, only dev-time noise.

## Test plan

- [x] `tsc --noEmit` clean on `@arr/web`
- [x] `lint` shows 0 errors, 14 warnings (all pre-existing — no new warnings introduced)
- [x] `git show --stat HEAD` confirms only the 13 intended files modified
- [ ] Maintainer to spot-check that error toasts still appear in trash-guides flows (delete, duplicate, sync, import, export, etc.)

## Out of scope

The full web has 41 production violations total — this PR addresses ~30 in the trash-guides cluster. The remaining ~11 are scattered 1-offs (`url-validation`, `backup`, etc.) that didn't fit a coherent feature surface and would warrant a separate audit if cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)