### PR TITLE
ci(trivy): bump scan timeout from default 5m to 20m

### DIFF
--- a/.github/workflows/docker-combined.yml
+++ b/.github/workflows/docker-combined.yml
@@ -241,6 +241,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Default 5m timed out on dev image post-Prisma-7.8 (run 25082617155)
+          timeout: '20m'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -82,6 +82,8 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Default 5m timed out analyzing @prisma/config@7.8.0 (run 25082617155)
+          timeout: '20m'
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
## Summary

Bumps the Trivy scan timeout from its 5-minute default to 20 minutes in both Docker image workflows (`docker-dev.yml` and `docker-combined.yml`).

## Why

Run [25082617155](https://github.com/Kha-kis/arr-dashboard/actions/runs/25082617155) (the post-#369 dev image scan) hit:

```
2026-04-28T23:25:59Z FATAL Fatal error
run error: image scan error: scan failed: failed analysis:
analyze error: pipeline error: failed to analyze layer:
walk error: failed to process the file: failed to analyze file:
failed to analyze app/api/node_modules/.pnpm/@prisma+config@7.8.0/node_modules/@prisma/config/package.json:
semaphore acquire: context deadline exceeded
```

That's exactly the 5-minute default timeout (scanner ran 5:10). Trivy itself logged a `WARN` recommending we provide a higher value.

A `gh run rerun` succeeded on retry, so the immediate problem self-resolved — but the underlying flakiness is now baked into main: `@prisma/config@7.8.0` came in via #363 and isn't going anywhere. Every future Trivy scan has a non-zero chance of hitting the same timeout.

**Critically: `docker-combined.yml` is the release workflow.** Without this fix, cutting a release tag tomorrow could fail at the Security Scan step, blocking the release.

## Changes

```diff
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: ${{ env.DOCKERHUB_IMAGE }}:dev
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'CRITICAL,HIGH'
+          # Default 5m timed out analyzing @prisma/config@7.8.0 (run 25082617155)
+          timeout: '20m'
```

Same change applied to both files.

## Verification

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `timeout` is a documented input on `aquasecurity/trivy-action` (verified against `action.yaml` on master — description: "timeout (default 5m0s)")
- [ ] CI green
- [ ] Trivy completes within new timeout on next dev image build

## Why 20m specifically

4× the default. Generous enough to cover Prisma growth and runner load spikes, conservative enough that a true hang fails the workflow rather than burning the entire GitHub Actions billing minute budget. The actual scan runs in ~5m on average; 20m is the safety ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)