### PR TITLE
chore(web): silence 9 unused-imports warnings in trash-guides

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -69,6 +69,8 @@ const eslintConfig = [
 					varsIgnorePattern: "^_",
 					args: "after-used",
 					argsIgnorePattern: "^_",
+					caughtErrors: "all",
+					caughtErrorsIgnorePattern: "^_",
 				},
 			],
 			"@typescript-eslint/no-unused-vars": "off", // Handled by unused-imports

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -270,7 +270,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 			await bulkUpdateScores.mutateAsync(entries);
 			setModifiedScores(new Map());
 			onOperationComplete?.();
-		} catch (error) {
+		} catch (_error) {
 			// error surfaced through mutation state
 		}
 	};

--- a/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-export-modal.tsx
@@ -112,7 +112,7 @@ export function EnhancedTemplateExportModal({
 					document.body.removeChild(a);
 				}
 			}
-		} catch (error) {
+		} catch (_error) {
 			alert("Failed to export template");
 		} finally {
 			setIsExporting(false);

--- a/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/enhanced-template-import-modal.tsx
@@ -67,7 +67,7 @@ export function EnhancedTemplateImportModal({
 			const text = await file.text();
 			setJsonData(text);
 			await validateTemplate(text);
-		} catch (error) {
+		} catch (_error) {
 			alert("Failed to read template file");
 		}
 	};
@@ -89,7 +89,7 @@ export function EnhancedTemplateImportModal({
 			const result = await response.json();
 			setValidation(result.data.validation);
 			setCompatibility(result.data.compatibility);
-		} catch (error) {
+		} catch (_error) {
 			alert("Failed to validate template");
 		} finally {
 			setIsValidating(false);

--- a/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
+++ b/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
@@ -186,7 +186,7 @@ export const InstanceOverrideEditor = ({
 			await refetch();
 			setHasChanges(false);
 			toast.success("Instance overrides saved successfully");
-		} catch (err) {
+		} catch (_err) {
 			toast.error("Failed to save instance overrides");
 		}
 	};
@@ -209,7 +209,7 @@ export const InstanceOverrideEditor = ({
 			);
 			setHasChanges(false);
 			toast.success("All instance overrides deleted");
-		} catch (err) {
+		} catch (_err) {
 			toast.error("Failed to delete instance overrides");
 		}
 	};

--- a/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
@@ -71,7 +71,7 @@ export function QualityProfileImporter({
 				profileId: selectedProfileId,
 			});
 			setImportedProfile(result.profile);
-		} catch (error) {
+		} catch (_error) {
 			// error surfaced through mutation state
 		}
 	};

--- a/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
+++ b/apps/web/src/features/trash-guides/components/scheduler-status-dashboard.tsx
@@ -106,7 +106,7 @@ export const SchedulerStatusDashboard = () => {
 
 		try {
 			await triggerCheck.mutateAsync();
-		} catch (error) {
+		} catch (_error) {
 			alert("Failed to trigger update check. Please try again.");
 		}
 	};

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -365,7 +365,7 @@ export const TemplateCreation = ({
 			}
 
 			onComplete();
-		} catch (error) {
+		} catch (_error) {
 			// Error will be displayed through mutation state
 		}
 	};


### PR DESCRIPTION
## Summary

Pre-release lint hygiene. Silences 9 of 14 ESLint warnings flagged by `unused-imports/no-unused-vars` in the trash-guides web surface, ahead of the v2.16.2 patch release.

## What changed

**1. 9 catch-clause params underscore-prefixed (7 files)**
All flagged catches either had empty bodies or routed through a generic `toast.error("...")` that doesn't reference the caught error. Renaming `err`/`error` → `_err`/`_error` signals "intentionally unused" per ESLint convention, matching what Biome already enforces on the API side.

**2. `apps/web/eslint.config.mjs` (2 lines added)**
The existing `unused-imports/no-unused-vars` rule had `argsIgnorePattern: "^_"` for regular params, but ESLint governs catch-clause params via a separate option. Added:
```diff
+ caughtErrors: "all",
+ caughtErrorsIgnorePattern: "^_",
```
Without this, the underscore prefix on catch params wouldn't actually silence the warning. This is the standard pattern when adopting `^_` as the unused-marker convention across all binding sites.

**3. `apps/web/next-env.d.ts` (1 line refreshed)**
Auto-generated by Next; the import path changed from `.next/dev/types/routes.d.ts` → `.next/types/routes.d.ts` after Next 16.2.4 landed in #363. Committing the new state so it stops appearing as a perpetual unstaged diff.

## Net result

- **Before**: 0 errors, 14 warnings
- **After**: 0 errors, 5 warnings
- The remaining 5 (4 `no-explicit-any` + 1 `no-img-element`, all in test files or boundary code) are pre-existing tech debt — out of scope for this PR

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` clean
- [x] `pnpm --filter @arr/web exec eslint .` shows exactly 5 warnings (the deliberately-out-of-scope set)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)