### PR TITLE
feat(statistics): add Jellyfin/Emby analytics tab

### DIFF
--- a/apps/web/src/features/statistics/components/bandwidth-chart.tsx
+++ b/apps/web/src/features/statistics/components/bandwidth-chart.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useBandwidthAnalytics } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { BandwidthAnalytics } from "@arr/shared";
 import { Activity, ArrowUpDown, Users, Wifi } from "lucide-react";
-import { Sparkline, MiniStatCard, formatBandwidth } from "./chart-primitives";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+import { formatBandwidth, MiniStatCard, Sparkline } from "./chart-primitives";
 
 // LAN/WAN colors — Tautulli-enriched data distinction
 const LAN_COLOR = SEMANTIC_COLORS.success.from;
@@ -17,13 +17,21 @@ const WAN_COLOR = SEMANTIC_COLORS.info.from;
 // ============================================================================
 
 interface BandwidthChartProps {
-	days: number;
-	enabled: boolean;
+	data: BandwidthAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const BandwidthChart = ({ days, enabled }: BandwidthChartProps) => {
+export const BandwidthChart = ({
+	data,
+	isLoading,
+	isError,
+	service = "plex",
+}: BandwidthChartProps) => {
 	const { gradient } = useThemeGradient();
-	const { data, isLoading, isError } = useBandwidthAnalytics(days, enabled);
+	const serviceColor = SERVICE_GRADIENTS[service].from;
+	const serviceLabel = service === "jellyfin" ? "Jellyfin" : "Plex";
 
 	const bandwidthSeries = useMemo(() => data?.timeSeries.map((d) => d.bandwidth) ?? [], [data]);
 
@@ -68,7 +76,7 @@ export const BandwidthChart = ({ days, enabled }: BandwidthChartProps) => {
 			<PremiumEmptyState
 				icon={Wifi}
 				title="Failed to Load Bandwidth Data"
-				description="Could not fetch bandwidth analytics. Check your Plex connection and try again."
+				description={`Could not fetch bandwidth analytics. Check your ${serviceLabel} connection and try again.`}
 			/>
 		);
 	}
@@ -104,7 +112,7 @@ export const BandwidthChart = ({ days, enabled }: BandwidthChartProps) => {
 					icon={ArrowUpDown}
 					label="Peak Bandwidth"
 					value={formatBandwidth(data.peakBandwidth)}
-					color={SERVICE_GRADIENTS.plex.from}
+					color={serviceColor}
 				/>
 				<MiniStatCard
 					icon={Activity}
@@ -123,8 +131,8 @@ export const BandwidthChart = ({ days, enabled }: BandwidthChartProps) => {
 							data={bandwidthSeries}
 							width={600}
 							height={60}
-							color={SERVICE_GRADIENTS.plex.from}
-							fillColor={SERVICE_GRADIENTS.plex.from}
+							color={serviceColor}
+							fillColor={serviceColor}
 						/>
 					</div>
 					{dates.length > 1 && (

--- a/apps/web/src/features/statistics/components/codec-chart.tsx
+++ b/apps/web/src/features/statistics/components/codec-chart.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useCodecAnalytics } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { CodecAnalytics } from "@arr/shared";
 import { FileVideo } from "lucide-react";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
 // ============================================================================
 // Donut Chart (reused pattern from transcode-chart)
@@ -16,15 +16,6 @@ interface DonutSegment {
 	value: number;
 	color: string;
 }
-
-const DONUT_COLORS = [
-	SERVICE_GRADIENTS.plex.from,
-	SEMANTIC_COLORS.success.text,
-	SEMANTIC_COLORS.warning.text,
-	SEMANTIC_COLORS.info.text,
-	SERVICE_GRADIENTS.sonarr.from,
-	SERVICE_GRADIENTS.radarr.from,
-];
 
 const DonutChart = ({
 	segments,
@@ -141,31 +132,44 @@ const ResolutionBars = ({
 // ============================================================================
 
 interface CodecChartProps {
-	days: number;
-	enabled: boolean;
+	data: CodecAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const CodecChart = ({ days, enabled }: CodecChartProps) => {
+export const CodecChart = ({ data, isLoading, isError, service = "plex" }: CodecChartProps) => {
 	const { gradient } = useThemeGradient();
-	const { data, isLoading, isError } = useCodecAnalytics(days, enabled);
+
+	const donutColors = useMemo(
+		() => [
+			SERVICE_GRADIENTS[service].from,
+			SEMANTIC_COLORS.success.text,
+			SEMANTIC_COLORS.warning.text,
+			SEMANTIC_COLORS.info.text,
+			SERVICE_GRADIENTS.sonarr.from,
+			SERVICE_GRADIENTS.radarr.from,
+		],
+		[service],
+	);
 
 	const videoSegments = useMemo((): DonutSegment[] => {
 		if (!data?.videoCodecs) return [];
 		return data.videoCodecs.slice(0, 6).map((c: { codec: string; count: number }, i: number) => ({
 			label: c.codec,
 			value: c.count,
-			color: DONUT_COLORS[i % DONUT_COLORS.length]!,
+			color: donutColors[i % donutColors.length]!,
 		}));
-	}, [data]);
+	}, [data, donutColors]);
 
 	const audioSegments = useMemo((): DonutSegment[] => {
 		if (!data?.audioCodecs) return [];
 		return data.audioCodecs.slice(0, 6).map((c: { codec: string; count: number }, i: number) => ({
 			label: c.codec,
 			value: c.count,
-			color: DONUT_COLORS[(i + 2) % DONUT_COLORS.length]!,
+			color: donutColors[(i + 2) % donutColors.length]!,
 		}));
-	}, [data]);
+	}, [data, donutColors]);
 
 	if (isLoading) {
 		return (
@@ -194,7 +198,7 @@ export const CodecChart = ({ days, enabled }: CodecChartProps) => {
 			<PremiumEmptyState
 				icon={FileVideo}
 				title="No Codec Data Yet"
-				description="Codec data requires Tautulli enrichment. Ensure Tautulli is connected and sessions are being captured."
+				description="Codec data appears once active sessions are captured by the snapshot scheduler."
 			/>
 		);
 	}

--- a/apps/web/src/features/statistics/components/device-chart.tsx
+++ b/apps/web/src/features/statistics/components/device-chart.tsx
@@ -1,25 +1,16 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useDeviceAnalytics } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { DeviceAnalytics } from "@arr/shared";
 import { Smartphone } from "lucide-react";
-import { useIncognitoMode, getLinuxDevice } from "../../../lib/incognito";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxDevice, useIncognitoMode } from "../../../lib/incognito";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
 // ============================================================================
 // Donut Chart (consistent with codec-chart)
 // ============================================================================
-
-const DONUT_COLORS = [
-	SERVICE_GRADIENTS.plex.from,
-	SEMANTIC_COLORS.success.text,
-	SEMANTIC_COLORS.warning.text,
-	SEMANTIC_COLORS.info.text,
-	SERVICE_GRADIENTS.sonarr.from,
-	SERVICE_GRADIENTS.radarr.from,
-];
 
 interface DonutSegment {
 	label: string;
@@ -78,14 +69,27 @@ const DonutChart = ({ segments, size = 120 }: { segments: DonutSegment[]; size?:
 // ============================================================================
 
 interface DeviceChartProps {
-	days: number;
-	enabled: boolean;
+	data: DeviceAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const DeviceChart = ({ days, enabled }: DeviceChartProps) => {
+export const DeviceChart = ({ data, isLoading, isError, service = "plex" }: DeviceChartProps) => {
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
-	const { data, isLoading, isError } = useDeviceAnalytics(days, enabled);
+
+	const donutColors = useMemo(
+		() => [
+			SERVICE_GRADIENTS[service].from,
+			SEMANTIC_COLORS.success.text,
+			SEMANTIC_COLORS.warning.text,
+			SEMANTIC_COLORS.info.text,
+			SERVICE_GRADIENTS.sonarr.from,
+			SERVICE_GRADIENTS.radarr.from,
+		],
+		[service],
+	);
 
 	const platformSegments = useMemo((): DonutSegment[] => {
 		if (!data?.platforms) return [];
@@ -94,9 +98,9 @@ export const DeviceChart = ({ days, enabled }: DeviceChartProps) => {
 			.map((p: { platform: string; sessions: number }, i: number) => ({
 				label: incognitoMode ? "Linux" : p.platform,
 				value: p.sessions,
-				color: DONUT_COLORS[i % DONUT_COLORS.length]!,
+				color: donutColors[i % donutColors.length]!,
 			}));
-	}, [data, incognitoMode]);
+	}, [data, incognitoMode, donutColors]);
 
 	if (isLoading) {
 		return (
@@ -125,7 +129,7 @@ export const DeviceChart = ({ days, enabled }: DeviceChartProps) => {
 			<PremiumEmptyState
 				icon={Smartphone}
 				title="No Device Data Yet"
-				description="Device data requires Tautulli enrichment. Ensure Tautulli is connected and sessions are being captured."
+				description="Device data appears once active sessions are captured by the snapshot scheduler."
 			/>
 		);
 	}

--- a/apps/web/src/features/statistics/components/forecast-chart.tsx
+++ b/apps/web/src/features/statistics/components/forecast-chart.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useBandwidthForecast } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { BandwidthForecast } from "@arr/shared";
 import { TrendingUp } from "lucide-react";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 import { formatBandwidth } from "./chart-primitives";
 
 // ============================================================================
@@ -142,13 +142,20 @@ const PeakHoursChart = ({
 // ============================================================================
 
 interface ForecastChartProps {
-	days: number;
-	enabled: boolean;
+	data: BandwidthForecast | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const ForecastChart = ({ days, enabled }: ForecastChartProps) => {
+export const ForecastChart = ({
+	data,
+	isLoading,
+	isError,
+	service = "plex",
+}: ForecastChartProps) => {
 	const { gradient } = useThemeGradient();
-	const { data, isLoading, isError } = useBandwidthForecast(days, enabled);
+	const historicalColor = SERVICE_GRADIENTS[service].from;
 
 	const historicalPeaks = useMemo(
 		() => data?.historicalDaily.map((d: { peakBandwidth: number }) => d.peakBandwidth) ?? [],
@@ -227,10 +234,7 @@ export const ForecastChart = ({ days, enabled }: ForecastChartProps) => {
 			<div>
 				<div className="flex gap-4 text-[10px] text-muted-foreground mb-2">
 					<span className="flex items-center gap-1.5">
-						<div
-							className="h-0.5 w-4 rounded-full"
-							style={{ backgroundColor: SERVICE_GRADIENTS.plex.from }}
-						/>
+						<div className="h-0.5 w-4 rounded-full" style={{ backgroundColor: historicalColor }} />
 						Historical Peak
 					</span>
 					<span className="flex items-center gap-1.5">
@@ -245,7 +249,7 @@ export const ForecastChart = ({ days, enabled }: ForecastChartProps) => {
 					<ForecastLine
 						historicalData={historicalPeaks}
 						forecastData={forecastPeaks}
-						historicalColor={SERVICE_GRADIENTS.plex.from}
+						historicalColor={historicalColor}
 						forecastColor={SEMANTIC_COLORS.info.text}
 					/>
 				</div>

--- a/apps/web/src/features/statistics/components/jellyfin-tab.tsx
+++ b/apps/web/src/features/statistics/components/jellyfin-tab.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Activity, TrendingUp } from "lucide-react";
+import { useState } from "react";
+import {
+	useJellyfinBandwidthAnalytics,
+	useJellyfinBandwidthForecast,
+	useJellyfinCodecAnalytics,
+	useJellyfinDeviceAnalytics,
+	useJellyfinQualityScore,
+	useJellyfinTranscodeAnalytics,
+	useJellyfinUserAnalytics,
+	useJellyfinWatchHistory,
+} from "../../../hooks/api/useJellyfin";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { BandwidthChart } from "./bandwidth-chart";
+import { CodecChart } from "./codec-chart";
+import { DeviceChart } from "./device-chart";
+import { ForecastChart } from "./forecast-chart";
+import { QualityScoreChart } from "./quality-score-chart";
+import { TranscodeChart } from "./transcode-chart";
+import { UserAnalyticsChart } from "./user-analytics-chart";
+import { WatchHistoryWidget } from "./watch-history-widget";
+
+const TIME_RANGES = [7, 14, 30] as const;
+
+export const JellyfinTab = () => {
+	const [timeRange, setTimeRange] = useState<number>(30);
+	const { gradient } = useThemeGradient();
+
+	// Session-snapshot analytics — Jellyfin/Emby instances write to the same
+	// SessionSnapshot table as Plex (see session-snapshot-scheduler.ts), so
+	// the analytics endpoints share aggregation logic with the Plex routes.
+	const transcodeQuery = useJellyfinTranscodeAnalytics(timeRange);
+	const bandwidthQuery = useJellyfinBandwidthAnalytics(timeRange);
+	const userAnalyticsQuery = useJellyfinUserAnalytics(timeRange);
+	const watchHistoryQuery = useJellyfinWatchHistory(timeRange, 20);
+	const codecQuery = useJellyfinCodecAnalytics(timeRange);
+	const deviceQuery = useJellyfinDeviceAnalytics(timeRange);
+	const qualityQuery = useJellyfinQualityScore(timeRange);
+	const forecastQuery = useJellyfinBandwidthForecast(timeRange);
+
+	return (
+		<div className="space-y-6 animate-in fade-in duration-300">
+			{/* Time Range Selector */}
+			<div className="flex items-center justify-between">
+				<h2 className="text-lg font-semibold flex items-center gap-2">
+					<TrendingUp className="h-5 w-5" style={{ color: gradient.from }} />
+					Watch Statistics
+				</h2>
+				<div className="inline-flex rounded-lg bg-muted/30 border border-border/50 p-1">
+					{TIME_RANGES.map((range) => (
+						<button
+							key={range}
+							type="button"
+							onClick={() => setTimeRange(range)}
+							className={`px-3 py-1.5 text-xs font-medium rounded-md transition-all ${
+								timeRange === range
+									? "bg-card text-foreground shadow-sm"
+									: "text-muted-foreground hover:text-foreground"
+							}`}
+						>
+							{range}d
+						</button>
+					))}
+				</div>
+			</div>
+
+			{/* Source banner — explain that data is captured from active sessions */}
+			<div className="rounded-xl border border-border/30 bg-card/30 p-4 flex items-start gap-3">
+				<Activity className="h-4 w-4 mt-0.5 shrink-0" style={{ color: gradient.from }} />
+				<p className="text-xs text-muted-foreground">
+					Statistics are captured from Jellyfin/Emby session snapshots taken every 5 minutes while
+					streams are active. Data accumulates over time as users watch.
+				</p>
+			</div>
+
+			{/* Session Snapshot Analytics */}
+			<TranscodeChart
+				data={transcodeQuery.data}
+				isLoading={transcodeQuery.isLoading}
+				isError={transcodeQuery.isError}
+				service="jellyfin"
+			/>
+			<BandwidthChart
+				data={bandwidthQuery.data}
+				isLoading={bandwidthQuery.isLoading}
+				isError={bandwidthQuery.isError}
+				service="jellyfin"
+			/>
+
+			{/* Tier 1: User Analytics + Watch History */}
+			<UserAnalyticsChart
+				data={userAnalyticsQuery.data}
+				isLoading={userAnalyticsQuery.isLoading}
+				isError={userAnalyticsQuery.isError}
+				service="jellyfin"
+			/>
+			<WatchHistoryWidget
+				data={watchHistoryQuery.data}
+				isLoading={watchHistoryQuery.isLoading}
+				isError={watchHistoryQuery.isError}
+				service="jellyfin"
+			/>
+
+			{/* Tier 1/2: Codec + Device Analytics */}
+			<div className="grid gap-6 md:grid-cols-2">
+				<CodecChart
+					data={codecQuery.data}
+					isLoading={codecQuery.isLoading}
+					isError={codecQuery.isError}
+					service="jellyfin"
+				/>
+				<DeviceChart
+					data={deviceQuery.data}
+					isLoading={deviceQuery.isLoading}
+					isError={deviceQuery.isError}
+					service="jellyfin"
+				/>
+			</div>
+
+			{/* Tier 3: Quality Score + Forecast */}
+			<QualityScoreChart
+				data={qualityQuery.data}
+				isLoading={qualityQuery.isLoading}
+				isError={qualityQuery.isError}
+				service="jellyfin"
+			/>
+			<ForecastChart
+				data={forecastQuery.data}
+				isLoading={forecastQuery.isLoading}
+				isError={forecastQuery.isError}
+				service="jellyfin"
+			/>
+		</div>
+	);
+};

--- a/apps/web/src/features/statistics/components/plex-tab.tsx
+++ b/apps/web/src/features/statistics/components/plex-tab.tsx
@@ -15,20 +15,36 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { PremiumSkeleton } from "../../../components/layout";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import {
+	useBandwidthAnalytics,
+	useBandwidthForecast,
+	useCodecAnalytics,
+	useDeviceAnalytics,
+	useQualityScore,
+	useTranscodeAnalytics,
+	useUserAnalytics,
+	useWatchHistory,
+} from "../../../hooks/api/usePlex";
 import { useTautulliPlaysByDate, useTautulliStats } from "../../../hooks/api/useTautulli";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import {
+	getLinuxDevice,
+	getLinuxIsoName,
+	getLinuxSectionName,
+	getLinuxUsername,
+	useIncognitoMode,
+} from "../../../lib/incognito";
 import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { useIncognitoMode, getLinuxUsername, getLinuxIsoName, getLinuxSectionName, getLinuxDevice } from "../../../lib/incognito";
-import { Sparkline, MiniStatCard } from "./chart-primitives";
-import { TranscodeChart } from "./transcode-chart";
 import { BandwidthChart } from "./bandwidth-chart";
+import { MiniStatCard, Sparkline } from "./chart-primitives";
+import { CodecChart } from "./codec-chart";
+import { CollectionStatsChart } from "./collection-stats-chart";
+import { DeviceChart } from "./device-chart";
+import { ForecastChart } from "./forecast-chart";
+import { QualityScoreChart } from "./quality-score-chart";
+import { TranscodeChart } from "./transcode-chart";
 import { UserAnalyticsChart } from "./user-analytics-chart";
 import { WatchHistoryWidget } from "./watch-history-widget";
-import { CodecChart } from "./codec-chart";
-import { DeviceChart } from "./device-chart";
-import { CollectionStatsChart } from "./collection-stats-chart";
-import { QualityScoreChart } from "./quality-score-chart";
-import { ForecastChart } from "./forecast-chart";
 
 // ============================================================================
 // Bar Chart Component
@@ -221,16 +237,16 @@ export const PlexTab = () => {
 					color: style.color,
 					items: s.rows.map((r: TautulliHomeStatRow) => {
 						const isUser = s.statId.includes("user");
-						const rawLabel = isPlatform ? (r.platform || r.title) : r.title;
+						const rawLabel = isPlatform ? r.platform || r.title : r.title;
 						const anonLabel = isPlatform
 							? getLinuxDevice(rawLabel)
 							: isUser
 								? getLinuxUsername(rawLabel)
 								: getLinuxIsoName(rawLabel);
 						return {
-						label: incognitoMode ? anonLabel : rawLabel,
-						value: r.totalPlays,
-						secondaryLabel: r.totalDuration > 0 ? formatDuration(r.totalDuration) : undefined,
+							label: incognitoMode ? anonLabel : rawLabel,
+							value: r.totalPlays,
+							secondaryLabel: r.totalDuration > 0 ? formatDuration(r.totalDuration) : undefined,
 						};
 					}),
 				};
@@ -239,6 +255,18 @@ export const PlexTab = () => {
 
 	const isLoading = statsQuery.isLoading || playsQuery.isLoading;
 	const isError = statsQuery.isError && playsQuery.isError;
+
+	// Session-snapshot analytics — fetch in parallel with Tautulli stats. These
+	// hooks read from SessionSnapshot rows scoped to the user's Plex instances,
+	// so they are independent of Tautulli availability.
+	const transcodeQuery = useTranscodeAnalytics(timeRange);
+	const bandwidthQuery = useBandwidthAnalytics(timeRange);
+	const userAnalyticsQuery = useUserAnalytics(timeRange);
+	const watchHistoryQuery = useWatchHistory(timeRange, 20);
+	const codecQuery = useCodecAnalytics(timeRange);
+	const deviceQuery = useDeviceAnalytics(timeRange);
+	const qualityQuery = useQualityScore(timeRange);
+	const forecastQuery = useBandwidthForecast(timeRange);
 
 	if (isLoading) {
 		return (
@@ -343,10 +371,7 @@ export const PlexTab = () => {
 					{perMediaSeries.map((series) => {
 						const Icon = series.icon;
 						return (
-							<div
-								key={series.name}
-								className="rounded-xl border border-border/30 bg-card/30 p-4"
-							>
+							<div key={series.name} className="rounded-xl border border-border/30 bg-card/30 p-4">
 								<div className="flex items-center justify-between mb-3">
 									<h3 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
 										<Icon className="h-4 w-4" style={{ color: series.color }} />
@@ -432,25 +457,57 @@ export const PlexTab = () => {
 			)}
 
 			{/* Session Snapshot Analytics */}
-			<TranscodeChart days={timeRange} enabled={!isLoading} />
-			<BandwidthChart days={timeRange} enabled={!isLoading} />
+			<TranscodeChart
+				data={transcodeQuery.data}
+				isLoading={transcodeQuery.isLoading}
+				isError={transcodeQuery.isError}
+			/>
+			<BandwidthChart
+				data={bandwidthQuery.data}
+				isLoading={bandwidthQuery.isLoading}
+				isError={bandwidthQuery.isError}
+			/>
 
 			{/* Tier 1: User Analytics + Watch History */}
-			<UserAnalyticsChart days={timeRange} enabled={!isLoading} />
-			<WatchHistoryWidget days={timeRange} enabled={!isLoading} />
+			<UserAnalyticsChart
+				data={userAnalyticsQuery.data}
+				isLoading={userAnalyticsQuery.isLoading}
+				isError={userAnalyticsQuery.isError}
+			/>
+			<WatchHistoryWidget
+				data={watchHistoryQuery.data}
+				isLoading={watchHistoryQuery.isLoading}
+				isError={watchHistoryQuery.isError}
+			/>
 
 			{/* Tier 1/2: Codec + Device Analytics */}
 			<div className="grid gap-6 md:grid-cols-2">
-				<CodecChart days={timeRange} enabled={!isLoading} />
-				<DeviceChart days={timeRange} enabled={!isLoading} />
+				<CodecChart
+					data={codecQuery.data}
+					isLoading={codecQuery.isLoading}
+					isError={codecQuery.isError}
+				/>
+				<DeviceChart
+					data={deviceQuery.data}
+					isLoading={deviceQuery.isLoading}
+					isError={deviceQuery.isError}
+				/>
 			</div>
 
 			{/* Tier 2: Collection Stats */}
 			<CollectionStatsChart enabled={!isLoading} />
 
 			{/* Tier 3: Quality Score + Forecast */}
-			<QualityScoreChart days={timeRange} enabled={!isLoading} />
-			<ForecastChart days={timeRange} enabled={!isLoading} />
+			<QualityScoreChart
+				data={qualityQuery.data}
+				isLoading={qualityQuery.isLoading}
+				isError={qualityQuery.isError}
+			/>
+			<ForecastChart
+				data={forecastQuery.data}
+				isLoading={forecastQuery.isLoading}
+				isError={forecastQuery.isError}
+			/>
 		</div>
 	);
 };

--- a/apps/web/src/features/statistics/components/quality-score-chart.tsx
+++ b/apps/web/src/features/statistics/components/quality-score-chart.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useQualityScore } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { QualityScoreAnalytics } from "@arr/shared";
 import { Gauge } from "lucide-react";
-import { useIncognitoMode, getLinuxUsername } from "../../../lib/incognito";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
 // ============================================================================
 // Circular Gauge (0-100)
@@ -126,14 +126,21 @@ const TrendSparkline = ({
 // ============================================================================
 
 interface QualityScoreChartProps {
-	days: number;
-	enabled: boolean;
+	data: QualityScoreAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const QualityScoreChart = ({ days, enabled }: QualityScoreChartProps) => {
+export const QualityScoreChart = ({
+	data,
+	isLoading,
+	isError,
+	service = "plex",
+}: QualityScoreChartProps) => {
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
-	const { data, isLoading, isError } = useQualityScore(days, enabled);
+	const resolutionScoreColor = SERVICE_GRADIENTS[service].from;
 
 	const scoreColor = useMemo(() => {
 		if (!data) return gradient.from;
@@ -197,7 +204,7 @@ export const QualityScoreChart = ({ days, enabled }: QualityScoreChartProps) => 
 						score={data.breakdown.resolutionScore}
 						size={90}
 						label="Resolution"
-						color={SERVICE_GRADIENTS.plex.from}
+						color={resolutionScoreColor}
 					/>
 					<CircularGauge
 						score={data.breakdown.transcodeScore}
@@ -235,9 +242,13 @@ export const QualityScoreChart = ({ days, enabled }: QualityScoreChartProps) => 
 										className="h-6 w-6 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0"
 										style={{ backgroundColor: `${gradient.from}20`, color: gradient.from }}
 									>
-										{(incognitoMode ? getLinuxUsername(user.username) : user.username).charAt(0).toUpperCase()}
+										{(incognitoMode ? getLinuxUsername(user.username) : user.username)
+											.charAt(0)
+											.toUpperCase()}
 									</div>
-									<span className="w-20 truncate text-muted-foreground">{incognitoMode ? getLinuxUsername(user.username) : user.username}</span>
+									<span className="w-20 truncate text-muted-foreground">
+										{incognitoMode ? getLinuxUsername(user.username) : user.username}
+									</span>
 									<div className="flex-1 h-3 rounded-full bg-muted/30 overflow-hidden">
 										<div
 											className="h-full rounded-full transition-all duration-500"

--- a/apps/web/src/features/statistics/components/statistics-client.tsx
+++ b/apps/web/src/features/statistics/components/statistics-client.tsx
@@ -5,13 +5,14 @@ import { useMemo, useState } from "react";
 import { PremiumSkeleton } from "../../../components/layout";
 import { Alert, AlertDescription } from "../../../components/ui";
 import { Button } from "../../../components/ui/button";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { useRefreshState } from "../../../hooks/useRefreshState";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
 import { useStatisticsData } from "../hooks/useStatisticsData";
-import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { ArrServiceTab } from "./arr-service-tab";
+import { JellyfinTab } from "./jellyfin-tab";
 import { OverviewTab } from "./overview-tab";
 import { PlexTab } from "./plex-tab";
 import { ProwlarrTab } from "./prowlarr-tab";
@@ -25,6 +26,14 @@ export const StatisticsClient = () => {
 	const { data: services = [] } = useServicesQuery();
 	const hasTautulli = useMemo(
 		() => services.some((s) => s.service.toLowerCase() === "tautulli" && s.enabled),
+		[services],
+	);
+	const hasJellyfin = useMemo(
+		() =>
+			services.some((s) => {
+				const svc = s.service.toLowerCase();
+				return (svc === "jellyfin" || svc === "emby") && s.enabled;
+			}),
 		[services],
 	);
 
@@ -98,6 +107,16 @@ export const StatisticsClient = () => {
 						label: "Plex",
 						icon: Activity,
 						gradient: SERVICE_GRADIENTS.plex,
+					},
+				]
+			: []),
+		...(hasJellyfin
+			? [
+					{
+						id: "jellyfin" as const,
+						label: "Jellyfin",
+						icon: Activity,
+						gradient: SERVICE_GRADIENTS.jellyfin,
 					},
 				]
 			: []),
@@ -316,6 +335,8 @@ export const StatisticsClient = () => {
 			)}
 
 			{activeTab === "plex" && <PlexTab />}
+
+			{activeTab === "jellyfin" && <JellyfinTab />}
 		</>
 	);
 };

--- a/apps/web/src/features/statistics/components/statistics-tabs.tsx
+++ b/apps/web/src/features/statistics/components/statistics-tabs.tsx
@@ -5,4 +5,5 @@ export type StatisticsTab =
 	| "prowlarr"
 	| "lidarr"
 	| "readarr"
-	| "plex";
+	| "plex"
+	| "jellyfin";

--- a/apps/web/src/features/statistics/components/transcode-chart.tsx
+++ b/apps/web/src/features/statistics/components/transcode-chart.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useTranscodeAnalytics } from "../../../hooks/api/usePlex";
-import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { TranscodeAnalytics } from "@arr/shared";
 import { Cpu, MonitorPlay, Play, Radio } from "lucide-react";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
 // ============================================================================
 // Donut Chart Component
@@ -140,21 +140,28 @@ const StackedBarChart = ({
 // ============================================================================
 
 interface TranscodeChartProps {
-	days: number;
-	enabled: boolean;
+	data: TranscodeAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const TranscodeChart = ({ days, enabled }: TranscodeChartProps) => {
+export const TranscodeChart = ({
+	data,
+	isLoading,
+	isError,
+	service = "plex",
+}: TranscodeChartProps) => {
 	const { gradient } = useThemeGradient();
-	const { data, isLoading, isError } = useTranscodeAnalytics(days, enabled);
+	const serviceLabel = service === "jellyfin" ? "Jellyfin" : "Plex";
 
 	const colors = useMemo(
 		() => ({
 			directPlay: SEMANTIC_COLORS.success.text,
 			transcode: SEMANTIC_COLORS.warning.text,
-			directStream: SERVICE_GRADIENTS.plex.from,
+			directStream: SERVICE_GRADIENTS[service].from,
 		}),
-		[],
+		[service],
 	);
 
 	const segments: DonutSegment[] = useMemo(() => {
@@ -183,7 +190,7 @@ export const TranscodeChart = ({ days, enabled }: TranscodeChartProps) => {
 			<PremiumEmptyState
 				icon={Cpu}
 				title="Failed to Load Transcode Data"
-				description="Could not fetch transcode analytics. Check your Plex connection and try again."
+				description={`Could not fetch transcode analytics. Check your ${serviceLabel} connection and try again.`}
 			/>
 		);
 	}
@@ -193,7 +200,7 @@ export const TranscodeChart = ({ days, enabled }: TranscodeChartProps) => {
 			<PremiumEmptyState
 				icon={Cpu}
 				title="No Transcode Data Yet"
-				description="Session data is collected every 5 minutes while streams are active. Check back once Plex has been in use."
+				description={`Session data is collected every 5 minutes while streams are active. Check back once ${serviceLabel} has been in use.`}
 			/>
 		);
 	}

--- a/apps/web/src/features/statistics/components/user-analytics-chart.tsx
+++ b/apps/web/src/features/statistics/components/user-analytics-chart.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useMemo } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useUserAnalytics } from "../../../hooks/api/usePlex";
-import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
-import { useIncognitoMode, getLinuxUsername } from "../../../lib/incognito";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { UserAnalytics } from "@arr/shared";
 import { Clock, Users } from "lucide-react";
+import { useMemo } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
+import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
 // ============================================================================
 // Bar Chart (reusable horizontal bars)
@@ -160,24 +160,30 @@ function formatWatchTime(minutes: number): string {
 }
 
 interface UserAnalyticsChartProps {
-	days: number;
-	enabled: boolean;
+	data: UserAnalytics | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const UserAnalyticsChart = ({ days, enabled }: UserAnalyticsChartProps) => {
+export const UserAnalyticsChart = ({
+	data,
+	isLoading,
+	isError,
+	service = "plex",
+}: UserAnalyticsChartProps) => {
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
-	const { data, isLoading, isError } = useUserAnalytics(days, enabled);
 
 	const userColors = useMemo(
 		() => [
 			gradient.from,
 			gradient.to,
-			SERVICE_GRADIENTS.plex.from,
+			SERVICE_GRADIENTS[service].from,
 			SERVICE_GRADIENTS.sonarr.from,
 			SERVICE_GRADIENTS.radarr.from,
 		],
-		[gradient.from, gradient.to],
+		[gradient.from, gradient.to, service],
 	);
 
 	const barItems = useMemo((): BarItem[] => {

--- a/apps/web/src/features/statistics/components/watch-history-widget.tsx
+++ b/apps/web/src/features/statistics/components/watch-history-widget.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
-import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import { useWatchHistory } from "../../../hooks/api/usePlex";
-import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import type { WatchHistoryResponse } from "@arr/shared";
 import { ChevronDown, ChevronUp, Clock, MonitorPlay } from "lucide-react";
-import { useIncognitoMode, getLinuxUsername, getLinuxIsoName } from "../../../lib/incognito";
+import { useState } from "react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxIsoName, getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
 
 // ============================================================================
 // Time Formatting
@@ -29,14 +29,15 @@ function formatRelativeTime(isoDate: string): string {
 const INITIAL_VISIBLE = 5;
 
 interface WatchHistoryWidgetProps {
-	days: number;
-	enabled: boolean;
+	data: WatchHistoryResponse | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	service?: "plex" | "jellyfin";
 }
 
-export const WatchHistoryWidget = ({ days, enabled }: WatchHistoryWidgetProps) => {
+export const WatchHistoryWidget = ({ data, isLoading, isError }: WatchHistoryWidgetProps) => {
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
-	const { data, isLoading, isError } = useWatchHistory(days, 20, enabled);
 	const [expanded, setExpanded] = useState(false);
 
 	if (isLoading) {
@@ -117,12 +118,16 @@ export const WatchHistoryWidget = ({ days, enabled }: WatchHistoryWidgetProps) =
 								className="h-8 w-8 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
 								style={{ backgroundColor: `${gradient.from}20`, color: gradient.from }}
 							>
-								{(incognitoMode ? getLinuxUsername(event.user) : event.user).charAt(0).toUpperCase()}
+								{(incognitoMode ? getLinuxUsername(event.user) : event.user)
+									.charAt(0)
+									.toUpperCase()}
 							</div>
 
 							{/* Content */}
 							<div className="flex-1 min-w-0">
-								<p className="text-sm font-medium truncate">{incognitoMode ? getLinuxIsoName(event.title) : event.title}</p>
+								<p className="text-sm font-medium truncate">
+									{incognitoMode ? getLinuxIsoName(event.title) : event.title}
+								</p>
 								<p className="text-[10px] text-muted-foreground flex items-center gap-2">
 									<span>{incognitoMode ? getLinuxUsername(event.user) : event.user}</span>
 									{event.platform && (


### PR DESCRIPTION
## Summary

Wires the existing Jellyfin/Emby analytics endpoints (already shipped at `/api/jellyfin/analytics/*` since v2.x) to the Statistics page UI. Adds a new **Jellyfin** tab that mirrors the Plex tab's analytics section, gated on the user having at least one enabled Jellyfin or Emby instance.

## Why this is a last-mile fix, not a feature build

Layer-by-layer audit of the existing surface:

| Layer | Plex | Jellyfin/Emby | Status |
|---|---|---|---|
| Snapshot capture (`session-snapshot-scheduler.ts`) | ✅ | ✅ | parity |
| Aggregation helpers (`routes/plex/lib/*`) | source | imported by Jellyfin | shared code |
| Backend routes | 6 split files | 9 endpoints in 1 combined file | parity in coverage |
| API client | `plex.ts` 9 fns | `jellyfin.ts` 9 fns | parity |
| React Query hooks | `usePlex.ts` | `useJellyfin.ts` (lines 218–283) | parity |
| Chart components | wired to `usePlex` | **never wired** | ❌ gap (this PR) |
| Statistics tab orchestration | `PlexTab` exists | no `JellyfinTab` | ❌ gap (this PR) |

## What changed

**8 chart components made source-agnostic** — they now take `{ data, isLoading, isError, service? }` props and pull service-specific accent colors from `SERVICE_GRADIENTS[service]`. Affected files:
- `transcode-chart.tsx`, `bandwidth-chart.tsx`, `codec-chart.tsx`, `device-chart.tsx`, `user-analytics-chart.tsx`, `forecast-chart.tsx`, `quality-score-chart.tsx`, `watch-history-widget.tsx`

**`PlexTab`** lifts hook calls to the top and passes data down — no behavior change for users.

**New `JellyfinTab`** mirrors PlexTab's analytics section (no Tautulli summary cards, no `CollectionStatsChart`), wired to the `useJellyfin*Analytics` hooks with `service="jellyfin"`.

**Statistics tab registry** adds a "Jellyfin" tab gated on `hasJellyfin` (any enabled Jellyfin/Emby instance).

## Out of scope

- **Collections for Jellyfin** — Plex has `collection-routes.ts` + `CollectionStatsChart`; Jellyfin's collection model differs structurally and warrants its own design exercise.
- **Pre-existing gate quirk** — `PlexTab` is gated on `hasTautulli`, not `hasPlex`. So a Plex-without-Tautulli user sees no analytics today even though the SessionSnapshot data is there. Pre-existing; out of scope for this PR. Worth a separate decision (split Tautulli summary from session-snapshot section, or relax the gate).
- **Unified "All Sources" tab** — the helpers are source-agnostic enough to support this, but most users probably want to see Plex vs Jellyfin separately to spot per-server bottlenecks.

## Behavior matrix

| User has | Tabs visible |
|---|---|
| Plex only (no Tautulli) | Overview + arr tabs (no media-server tab — pre-existing gap) |
| Plex + Tautulli | Overview + arr tabs + Plex |
| Jellyfin only | Overview + arr tabs + Jellyfin |
| Plex + Tautulli + Jellyfin | Overview + arr tabs + Plex + Jellyfin (independent) |
| Emby only | Overview + arr tabs + Jellyfin (Emby instances roll into the Jellyfin tab) |

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — passes
- [ ] Manual UI verification with a configured Jellyfin instance (not available in author's environment — requires reviewer or downstream verification)
- [ ] Manual UI verification with both Plex and Jellyfin configured to confirm tab independence
- [ ] Confirm `service="jellyfin"` accent color (Jellyfin gradient) renders on the right chart elements (transcode donut "Direct Stream" segment, bandwidth peak card, forecast historical line, quality-score "Resolution" gauge)
- [ ] Confirm Plex tab still renders identically after the hook-lift refactor
- [ ] Confirm tab does NOT appear when user has no Jellyfin/Emby instance configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)