### PR TITLE
feat(statistics): top-media leaderboards from SessionSnapshot (Option 3 phase 1)

### DIFF
--- a/apps/api/src/plugins/__tests__/session-enrichment-helpers.test.ts
+++ b/apps/api/src/plugins/__tests__/session-enrichment-helpers.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { TautulliSessionItem } from "../../lib/tautulli/tautulli-client.js";
 import {
-	type PlexSessionInput,
 	buildTautulliSessionMap,
 	enrichSessionsWithTautulli,
+	type PlexSessionInput,
 } from "../lib/session-enrichment-helpers.js";
 
 // ============================================================================
@@ -14,6 +14,7 @@ function plexSession(overrides: Partial<PlexSessionInput> = {}): PlexSessionInpu
 	return {
 		user: { title: "alice" },
 		title: "Test Movie",
+		type: "movie",
 		ratingKey: "12345",
 		videoDecision: "direct play",
 		bandwidth: 5000,
@@ -64,10 +65,7 @@ describe("buildTautulliSessionMap", () => {
 	});
 
 	it("skips sessions with empty rating_key", () => {
-		const sessions = [
-			tautulliSession({ rating_key: "" }),
-			tautulliSession({ rating_key: "100" }),
-		];
+		const sessions = [tautulliSession({ rating_key: "" }), tautulliSession({ rating_key: "100" })];
 		const map = buildTautulliSessionMap(sessions);
 		expect(map.size).toBe(1);
 	});
@@ -97,6 +95,8 @@ describe("enrichSessionsWithTautulli", () => {
 		expect(result[0]).toEqual({
 			user: "alice",
 			title: "Test Movie",
+			grandparentTitle: undefined,
+			mediaType: "movie",
 			videoDecision: "direct play",
 			bandwidth: 5000,
 			state: "playing",
@@ -111,9 +111,7 @@ describe("enrichSessionsWithTautulli", () => {
 
 	it("returns null fields when no Tautulli match found", () => {
 		const plex = [plexSession({ ratingKey: "999" })];
-		const map = buildTautulliSessionMap([
-			tautulliSession({ rating_key: "100" }),
-		]);
+		const map = buildTautulliSessionMap([tautulliSession({ rating_key: "100" })]);
 
 		const result = enrichSessionsWithTautulli(plex, map);
 		expect(result[0]?.audioDecision).toBeNull();
@@ -153,9 +151,7 @@ describe("enrichSessionsWithTautulli", () => {
 	});
 
 	it("formats grandparentTitle correctly", () => {
-		const plex = [
-			plexSession({ grandparentTitle: "Breaking Bad", title: "Pilot" }),
-		];
+		const plex = [plexSession({ grandparentTitle: "Breaking Bad", title: "Pilot" })];
 		const map = new Map<string, TautulliSessionItem>();
 
 		const result = enrichSessionsWithTautulli(plex, map);

--- a/apps/api/src/plugins/lib/session-enrichment-helpers.ts
+++ b/apps/api/src/plugins/lib/session-enrichment-helpers.ts
@@ -12,16 +12,24 @@ export interface PlexSessionInput {
 	user: { title: string };
 	title: string;
 	grandparentTitle?: string;
+	type?: string;
 	ratingKey: string;
 	videoDecision?: string | null;
 	bandwidth?: number | null;
 	state: string;
 }
 
+/** Normalized media type for leaderboard aggregation */
+export type SessionMediaType = "movie" | "series" | "music" | "other";
+
 /** Enriched session entry stored in sessionsJson */
 export interface EnrichedSession {
 	user: string;
 	title: string;
+	/** Show/album name when applicable; absent for movies */
+	grandparentTitle?: string;
+	/** Normalized media type for cross-service aggregation */
+	mediaType?: SessionMediaType;
 	videoDecision: string | null | undefined;
 	bandwidth: number;
 	state: string;
@@ -31,6 +39,41 @@ export interface EnrichedSession {
 	videoResolution: string | null;
 	platform: string | null;
 	player: string | null;
+}
+
+/** Map a Plex session `type` field to a normalized media type. */
+export function normalizePlexMediaType(type: string | undefined): SessionMediaType {
+	switch (type) {
+		case "movie":
+			return "movie";
+		case "episode":
+		case "show":
+		case "season":
+			return "series";
+		case "track":
+		case "album":
+			return "music";
+		default:
+			return "other";
+	}
+}
+
+/** Map a Jellyfin item `Type` field to a normalized media type. */
+export function normalizeJellyfinMediaType(type: string | undefined): SessionMediaType {
+	switch (type) {
+		case "Movie":
+			return "movie";
+		case "Episode":
+		case "Series":
+		case "Season":
+			return "series";
+		case "Audio":
+		case "MusicAlbum":
+		case "MusicVideo":
+			return "music";
+		default:
+			return "other";
+	}
 }
 
 /**
@@ -66,6 +109,8 @@ export function enrichSessionsWithTautulli(
 		return {
 			user: s.user.title,
 			title: s.grandparentTitle ? `${s.grandparentTitle} - ${s.title}` : s.title,
+			grandparentTitle: s.grandparentTitle,
+			mediaType: normalizePlexMediaType(s.type),
 			videoDecision: s.videoDecision,
 			bandwidth: s.bandwidth ?? 0,
 			state: s.state,

--- a/apps/api/src/plugins/session-snapshot-scheduler.ts
+++ b/apps/api/src/plugins/session-snapshot-scheduler.ts
@@ -24,6 +24,7 @@ import { createTautulliClient } from "../lib/tautulli/tautulli-client.js";
 import {
 	buildTautulliSessionMap,
 	enrichSessionsWithTautulli,
+	normalizeJellyfinMediaType,
 } from "./lib/session-enrichment-helpers.js";
 import {
 	classifySessionDecisions,
@@ -441,6 +442,8 @@ const sessionSnapshotSchedulerPlugin = fastifyPlugin(
 							return {
 								user: s.userName ?? "Unknown",
 								title: s.nowPlayingItem?.name ?? "Unknown",
+								grandparentTitle: s.nowPlayingItem?.seriesName,
+								mediaType: normalizeJellyfinMediaType(s.nowPlayingItem?.type),
 								videoDecision:
 									s.transcodingInfo && !s.transcodingInfo.isVideoDirect
 										? "transcode"
@@ -532,13 +535,8 @@ const sessionSnapshotSchedulerPlugin = fastifyPlugin(
 		// observes a failed tick.
 		const runSnapshotTick = () =>
 			app.schedulerRegistry.track(JOB_ID.sessionSnapshot, async () => {
-				const results = await Promise.allSettled([
-					captureSnapshots(),
-					captureJellyfinSnapshots(),
-				]);
-				const failures = results.filter(
-					(r): r is PromiseRejectedResult => r.status === "rejected",
-				);
+				const results = await Promise.allSettled([captureSnapshots(), captureJellyfinSnapshots()]);
+				const failures = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
 				if (failures.length > 0) {
 					throw new AggregateError(
 						failures.map((f) => f.reason),

--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -10,15 +10,16 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { analyticsQuery } from "../plex/analytics-schemas.js";
-import { aggregateTranscodeAnalytics } from "../plex/lib/transcode-analytics-helpers.js";
 import { aggregateBandwidthAnalytics } from "../plex/lib/bandwidth-analytics-helpers.js";
-import { aggregateUserAnalytics } from "../plex/lib/user-analytics-helpers.js";
-import { deduplicateWatchEvents } from "../plex/lib/watch-history-helpers.js";
 import { aggregateCodecAnalytics } from "../plex/lib/codec-analytics-helpers.js";
 import { aggregateDeviceAnalytics } from "../plex/lib/device-analytics-helpers.js";
-import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
 import { computeForecast } from "../plex/lib/forecast-helpers.js";
+import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
+import { aggregateTopMedia } from "../plex/lib/top-media-helpers.js";
+import { aggregateTranscodeAnalytics } from "../plex/lib/transcode-analytics-helpers.js";
+import { aggregateUserAnalytics } from "../plex/lib/user-analytics-helpers.js";
 import { aggregateUserEpisodeCompletion } from "../plex/lib/user-episode-helpers.js";
+import { deduplicateWatchEvents } from "../plex/lib/watch-history-helpers.js";
 
 const watchHistoryQuery = z.object({
 	days: z
@@ -399,5 +400,58 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			);
 		}
 		return reply.send(completion);
+	});
+
+	// ── Top Media Leaderboard ─────────────────────────────────────
+	const topMediaQuery = z.object({
+		mediaType: z.enum(["movie", "series", "music"]),
+		days: z
+			.string()
+			.optional()
+			.transform((val) => {
+				const n = val ? Number.parseInt(val, 10) : 30;
+				return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+			}),
+		limit: z
+			.string()
+			.optional()
+			.transform((val) => {
+				const n = val ? Number.parseInt(val, 10) : 10;
+				return Number.isFinite(n) && n > 0 ? Math.min(n, 50) : 10;
+			}),
+	});
+
+	app.get("/top-media", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(topMediaQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
+			select: { id: true },
+		});
+
+		if (instances.length === 0) {
+			return reply.send({ items: [] });
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateTopMedia(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{ parseFailures, totalSnapshots, failedPreviews, route: "jellyfin/top-media", mediaType },
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
 	});
 }

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -5,30 +5,31 @@
  */
 
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
-import { registerWatchEnrichmentRoutes } from "./watch-enrichment-routes.js";
-import { registerSectionRoutes } from "./section-routes.js";
-import { registerScanRoutes } from "./scan-routes.js";
-import { registerNowPlayingRoutes } from "./now-playing-routes.js";
-import { registerEpisodeRoutes } from "./episode-routes.js";
-import { registerCollectionRoutes } from "./collection-routes.js";
-import { registerCacheRoutes } from "./cache-routes.js";
-import { registerRecentlyAddedRoutes } from "./recently-added-routes.js";
-import { registerIdentityRoutes } from "./identity-routes.js";
-import { registerOnDeckRoutes } from "./on-deck-routes.js";
 import { registerAccountRoutes } from "./account-routes.js";
-import { registerSeriesProgressRoutes } from "./series-progress-routes.js";
-import { registerTranscodeAnalyticsRoutes } from "./transcode-analytics-routes.js";
 import { registerBandwidthAnalyticsRoutes } from "./bandwidth-analytics-routes.js";
-import { registerUserAnalyticsRoutes } from "./user-analytics-routes.js";
-import { registerWatchHistoryRoutes } from "./watch-history-routes.js";
+import { registerCacheRoutes } from "./cache-routes.js";
 import { registerCodecAnalyticsRoutes } from "./codec-analytics-routes.js";
-import { registerDeviceAnalyticsRoutes } from "./device-analytics-routes.js";
+import { registerCollectionRoutes } from "./collection-routes.js";
 import { registerCollectionStatsRoutes } from "./collection-stats-routes.js";
-import { registerUserEpisodeCompletionRoutes } from "./user-episode-completion-routes.js";
-import { registerQualityScoreRoutes } from "./quality-score-routes.js";
+import { registerDeviceAnalyticsRoutes } from "./device-analytics-routes.js";
+import { registerEpisodeRoutes } from "./episode-routes.js";
 import { registerForecastRoutes } from "./forecast-routes.js";
+import { registerIdentityRoutes } from "./identity-routes.js";
 import { registerImageProxyRoutes } from "./image-proxy-routes.js";
+import { registerNowPlayingRoutes } from "./now-playing-routes.js";
 import { registerOAuthRoutes } from "./oauth-routes.js";
+import { registerOnDeckRoutes } from "./on-deck-routes.js";
+import { registerQualityScoreRoutes } from "./quality-score-routes.js";
+import { registerRecentlyAddedRoutes } from "./recently-added-routes.js";
+import { registerScanRoutes } from "./scan-routes.js";
+import { registerSectionRoutes } from "./section-routes.js";
+import { registerSeriesProgressRoutes } from "./series-progress-routes.js";
+import { registerTopMediaRoutes } from "./top-media-routes.js";
+import { registerTranscodeAnalyticsRoutes } from "./transcode-analytics-routes.js";
+import { registerUserAnalyticsRoutes } from "./user-analytics-routes.js";
+import { registerUserEpisodeCompletionRoutes } from "./user-episode-completion-routes.js";
+import { registerWatchEnrichmentRoutes } from "./watch-enrichment-routes.js";
+import { registerWatchHistoryRoutes } from "./watch-history-routes.js";
 
 export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
 	app.register(registerWatchEnrichmentRoutes, { prefix: "/watch-enrichment" });
@@ -53,6 +54,7 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerUserEpisodeCompletionRoutes, { prefix: "/analytics/episode-completion" });
 	app.register(registerQualityScoreRoutes, { prefix: "/analytics/quality-score" });
 	app.register(registerForecastRoutes, { prefix: "/analytics/forecast" });
+	app.register(registerTopMediaRoutes, { prefix: "/analytics/top-media" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
 	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/lib/top-media-helpers.ts
+++ b/apps/api/src/routes/plex/lib/top-media-helpers.ts
@@ -1,0 +1,152 @@
+/**
+ * Top Media Helpers
+ *
+ * Aggregates SessionSnapshot rows into a leaderboard of most-watched titles,
+ * bucketed by media type. Replaces Tautulli's pre-aggregated `cmd=get_home_stats`
+ * top_* values, so this surface works with or without Tautulli configured.
+ *
+ * "Play count" semantics match Tautulli: each user×title viewing session
+ * counts as one play. Consecutive 5-minute snapshot ticks within a 10-minute
+ * window are collapsed into a single play (per the same dedup pattern as
+ * watch-history-helpers.ts).
+ */
+
+import type { TopMediaItem, TopMediaResponse, TopMediaType } from "@arr/shared";
+import type { AggregationMeta } from "./user-analytics-helpers.js";
+
+/** Normalized media type as stored in EnrichedSession.mediaType */
+type SnapshotMediaType = "movie" | "series" | "music" | "other";
+
+/** Snapshot row required for top-media aggregation */
+export interface SnapshotForTopMedia {
+	capturedAt: Date;
+	sessionsJson: string;
+}
+
+/** Session shape parsed out of sessionsJson — fields newer than 2026-04 are optional for backward compat */
+interface ParsedSession {
+	user?: string;
+	title?: string;
+	grandparentTitle?: string;
+	mediaType?: SnapshotMediaType;
+}
+
+/** Snapshot interval in minutes — used to estimate watch duration from tick count */
+const SNAPSHOT_INTERVAL_MINUTES = 5;
+
+/** Dedup window: consecutive ticks for same user+title within this window are one play */
+const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Pick the title to group by:
+ * - For TV episodes: use grandparentTitle (show name) so all episodes of a show aggregate together
+ * - For movies/music/other: use title directly
+ */
+function deriveGroupingTitle(session: ParsedSession): string | null {
+	if (session.mediaType === "series") {
+		return session.grandparentTitle ?? session.title ?? null;
+	}
+	return session.title ?? null;
+}
+
+export function aggregateTopMedia(
+	snapshots: SnapshotForTopMedia[],
+	opts: { mediaType: TopMediaType; limit: number },
+): TopMediaResponse & AggregationMeta {
+	const { mediaType, limit } = opts;
+
+	// Per-key aggregation: groupKey = `${mediaType}|${groupingTitle}`
+	const itemMap = new Map<
+		string,
+		{
+			title: string;
+			mediaType: TopMediaType;
+			playCount: number;
+			tickCount: number;
+			lastWatchedAt: Date;
+		}
+	>();
+
+	// Per (key, user) dedup state — anchors the most recent emitted timestamp so
+	// chained ticks within the dedup window collapse into one play.
+	const lastPlayAnchorByUserKey = new Map<string, number>();
+
+	let parseFailures = 0;
+	const failedPreviews: string[] = [];
+
+	// Sort snapshots descending so dedup walks "newest first" (matches watch-history pattern)
+	const ordered = [...snapshots].sort((a, b) => b.capturedAt.getTime() - a.capturedAt.getTime());
+
+	for (const snap of ordered) {
+		let sessions: ParsedSession[];
+		try {
+			sessions = JSON.parse(snap.sessionsJson);
+		} catch {
+			parseFailures++;
+			if (failedPreviews.length < 5) failedPreviews.push(snap.sessionsJson.slice(0, 100));
+			continue;
+		}
+
+		for (const session of sessions) {
+			// Skip rows missing the new fields (snapshots written before 2026-04 enrichment)
+			if (session.mediaType === undefined || session.mediaType !== mediaType) continue;
+
+			const groupingTitle = deriveGroupingTitle(session);
+			if (!groupingTitle) continue;
+
+			const user = session.user ?? "Unknown";
+			const groupKey = groupingTitle; // mediaType already filtered above
+			const userKey = `${groupKey}::${user}`;
+			const tickTime = snap.capturedAt.getTime();
+
+			const existingItem = itemMap.get(groupKey) ?? {
+				title: groupingTitle,
+				mediaType,
+				playCount: 0,
+				tickCount: 0,
+				lastWatchedAt: snap.capturedAt,
+			};
+
+			// Always increment tick count (used for duration estimate)
+			existingItem.tickCount += 1;
+			if (snap.capturedAt > existingItem.lastWatchedAt) {
+				existingItem.lastWatchedAt = snap.capturedAt;
+			}
+
+			// Determine whether this tick starts a new play for this user
+			const prevAnchor = lastPlayAnchorByUserKey.get(userKey);
+			const isNewPlay = prevAnchor === undefined || prevAnchor - tickTime > DEDUP_WINDOW_MS;
+
+			if (isNewPlay) {
+				existingItem.playCount += 1;
+				lastPlayAnchorByUserKey.set(userKey, tickTime);
+			} else {
+				// Within dedup window — extend the anchor backward so chained ticks keep collapsing
+				lastPlayAnchorByUserKey.set(userKey, tickTime);
+			}
+
+			itemMap.set(groupKey, existingItem);
+		}
+	}
+
+	const items: TopMediaItem[] = [...itemMap.values()]
+		.sort((a, b) => {
+			if (b.playCount !== a.playCount) return b.playCount - a.playCount;
+			return b.tickCount - a.tickCount;
+		})
+		.slice(0, limit)
+		.map((item) => ({
+			title: item.title,
+			mediaType: item.mediaType,
+			playCount: item.playCount,
+			totalDurationMinutes: item.tickCount * SNAPSHOT_INTERVAL_MINUTES,
+			lastWatchedAt: item.lastWatchedAt.toISOString(),
+		}));
+
+	return {
+		items,
+		parseFailures,
+		totalSnapshots: snapshots.length,
+		failedPreviews,
+	};
+}

--- a/apps/api/src/routes/plex/top-media-routes.ts
+++ b/apps/api/src/routes/plex/top-media-routes.ts
@@ -1,0 +1,77 @@
+/**
+ * Plex Top Media Routes
+ *
+ * Aggregates SessionSnapshot rows into a leaderboard of most-watched titles
+ * for a given media type (movie / series / music). Replaces Tautulli's
+ * pre-aggregated home-stats top_movies / top_tv / top_music.
+ */
+
+import type { TopMediaResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { aggregateTopMedia } from "./lib/top-media-helpers.js";
+
+const topMediaQuery = z.object({
+	mediaType: z.enum(["movie", "series", "music"]),
+	days: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 30;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+		}),
+	limit: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 10;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 50) : 10;
+		}),
+});
+
+export async function registerTopMediaRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	/**
+	 * GET /api/plex/analytics/top-media?mediaType=movie&days=30&limit=10
+	 *
+	 * Returns the top-N most-watched titles of the given media type from
+	 * SessionSnapshot rows for this user's Plex instances.
+	 */
+	app.get("/", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(topMediaQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const plexInstances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			select: { id: true },
+		});
+
+		if (plexInstances.length === 0) {
+			const empty: TopMediaResponse = { items: [] };
+			return reply.send(empty);
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: {
+				instanceId: { in: plexInstances.map((i) => i.id) },
+				capturedAt: { gte: cutoff },
+			},
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateTopMedia(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{ parseFailures, totalSnapshots, failedPreviews, route: "top-media", mediaType },
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
+	});
+}

--- a/apps/web/src/features/statistics/components/jellyfin-tab.tsx
+++ b/apps/web/src/features/statistics/components/jellyfin-tab.tsx
@@ -8,6 +8,7 @@ import {
 	useJellyfinCodecAnalytics,
 	useJellyfinDeviceAnalytics,
 	useJellyfinQualityScore,
+	useJellyfinTopMedia,
 	useJellyfinTranscodeAnalytics,
 	useJellyfinUserAnalytics,
 	useJellyfinWatchHistory,
@@ -18,6 +19,7 @@ import { CodecChart } from "./codec-chart";
 import { DeviceChart } from "./device-chart";
 import { ForecastChart } from "./forecast-chart";
 import { QualityScoreChart } from "./quality-score-chart";
+import { TopMediaChart } from "./top-media-chart";
 import { TranscodeChart } from "./transcode-chart";
 import { UserAnalyticsChart } from "./user-analytics-chart";
 import { WatchHistoryWidget } from "./watch-history-widget";
@@ -39,6 +41,9 @@ export const JellyfinTab = () => {
 	const deviceQuery = useJellyfinDeviceAnalytics(timeRange);
 	const qualityQuery = useJellyfinQualityScore(timeRange);
 	const forecastQuery = useJellyfinBandwidthForecast(timeRange);
+	const topMoviesQuery = useJellyfinTopMedia("movie", timeRange);
+	const topShowsQuery = useJellyfinTopMedia("series", timeRange);
+	const topMusicQuery = useJellyfinTopMedia("music", timeRange);
 
 	return (
 		<div className="space-y-6 animate-in fade-in duration-300">
@@ -74,6 +79,29 @@ export const JellyfinTab = () => {
 					streams are active. Data accumulates over time as users watch.
 				</p>
 			</div>
+
+			{/* Top Media Leaderboards (replaces Tautulli home-stats) */}
+			<TopMediaChart
+				data={topMoviesQuery.data}
+				isLoading={topMoviesQuery.isLoading}
+				isError={topMoviesQuery.isError}
+				mediaType="movie"
+				service="jellyfin"
+			/>
+			<TopMediaChart
+				data={topShowsQuery.data}
+				isLoading={topShowsQuery.isLoading}
+				isError={topShowsQuery.isError}
+				mediaType="series"
+				service="jellyfin"
+			/>
+			<TopMediaChart
+				data={topMusicQuery.data}
+				isLoading={topMusicQuery.isLoading}
+				isError={topMusicQuery.isError}
+				mediaType="music"
+				service="jellyfin"
+			/>
 
 			{/* Session Snapshot Analytics */}
 			<TranscodeChart

--- a/apps/web/src/features/statistics/components/top-media-chart.tsx
+++ b/apps/web/src/features/statistics/components/top-media-chart.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { TopMediaResponse, TopMediaType } from "@arr/shared";
+import { Film, Music, Trophy, Tv } from "lucide-react";
+import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
+import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+
+const ICON_FOR_MEDIA_TYPE: Record<TopMediaType, typeof Film> = {
+	movie: Film,
+	series: Tv,
+	music: Music,
+};
+
+const HEADING_FOR_MEDIA_TYPE: Record<TopMediaType, string> = {
+	movie: "Top Movies",
+	series: "Top Shows",
+	music: "Top Music",
+};
+
+const SUBJECT_FOR_MEDIA_TYPE: Record<TopMediaType, string> = {
+	movie: "movies",
+	series: "shows",
+	music: "tracks",
+};
+
+function formatWatchTime(minutes: number): string {
+	if (minutes < 60) return `${minutes}m`;
+	const hours = Math.floor(minutes / 60);
+	if (hours >= 24) {
+		const days = Math.floor(hours / 24);
+		const remH = hours % 24;
+		return remH > 0 ? `${days}d ${remH}h` : `${days}d`;
+	}
+	const mins = minutes % 60;
+	return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+}
+
+interface TopMediaChartProps {
+	data: TopMediaResponse | undefined;
+	isLoading: boolean;
+	isError: boolean;
+	mediaType: TopMediaType;
+	service?: "plex" | "jellyfin";
+}
+
+export const TopMediaChart = ({
+	data,
+	isLoading,
+	isError,
+	mediaType,
+	service = "plex",
+}: TopMediaChartProps) => {
+	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
+	const accentColor = SERVICE_GRADIENTS[service].from;
+	const Icon = ICON_FOR_MEDIA_TYPE[mediaType];
+	const heading = HEADING_FOR_MEDIA_TYPE[mediaType];
+	const subject = SUBJECT_FOR_MEDIA_TYPE[mediaType];
+
+	if (isLoading) {
+		return (
+			<div className="rounded-xl border border-border/30 bg-card/30 p-6">
+				<PremiumSkeleton variant="line" className="h-5 w-40 mb-4" />
+				<div className="space-y-2">
+					{[0, 1, 2, 3].map((i) => (
+						<PremiumSkeleton
+							key={i}
+							variant="line"
+							className="h-8"
+							style={{ animationDelay: `${i * 50}ms` }}
+						/>
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	if (isError) {
+		return (
+			<PremiumEmptyState
+				icon={Trophy}
+				title={`Failed to Load ${heading}`}
+				description={`Could not fetch top ${subject}. Try refreshing.`}
+			/>
+		);
+	}
+
+	if (!data || data.items.length === 0) {
+		return (
+			<PremiumEmptyState
+				icon={Trophy}
+				title={`No ${heading} Yet`}
+				description={`Leaderboard appears once active sessions for ${subject} are captured by the snapshot scheduler.`}
+			/>
+		);
+	}
+
+	const maxPlayCount = Math.max(...data.items.map((item) => item.playCount), 1);
+
+	return (
+		<div className="rounded-xl border border-border/30 bg-card/30 p-6 space-y-4">
+			<h3 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
+				<Icon className="h-4 w-4" style={{ color: gradient.from }} />
+				{heading}
+			</h3>
+
+			<div className="space-y-2">
+				{data.items.map((item, i) => {
+					const displayTitle = incognitoMode ? getLinuxIsoName(item.title) : item.title;
+					const widthPercent = (item.playCount / maxPlayCount) * 100;
+					return (
+						<div key={`${item.title}-${i}`} className="flex items-center gap-3 text-sm group">
+							<span
+								className="w-5 text-right text-xs font-medium tabular-nums text-muted-foreground/60"
+								title={`#${i + 1}`}
+							>
+								{i + 1}
+							</span>
+							<div className="flex-1 min-w-0">
+								<div
+									className="flex items-center gap-2 px-3 py-1.5 rounded-lg overflow-hidden relative"
+									title={displayTitle}
+								>
+									<div
+										className="absolute inset-0 transition-all duration-500"
+										style={{
+											width: `${widthPercent}%`,
+											background: `linear-gradient(90deg, ${accentColor}33, ${accentColor}11)`,
+											animationDelay: `${i * 30}ms`,
+										}}
+									/>
+									<span className="relative z-10 truncate">{displayTitle}</span>
+								</div>
+							</div>
+							<span className="w-16 text-right font-medium tabular-nums">
+								{item.playCount.toLocaleString()}
+								<span className="text-[10px] text-muted-foreground ml-1">plays</span>
+							</span>
+							<span className="w-20 text-right text-xs text-muted-foreground tabular-nums">
+								{formatWatchTime(item.totalDurationMinutes)}
+							</span>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/hooks/api/useJellyfin.ts
+++ b/apps/web/src/hooks/api/useJellyfin.ts
@@ -15,6 +15,8 @@ import type {
 	LibraryItem,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
+	TopMediaResponse,
+	TopMediaType,
 	TranscodeAnalytics,
 	UserAnalytics,
 	UserEpisodeCompletion,
@@ -22,8 +24,6 @@ import type {
 	WatchHistoryResponse,
 } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { POLLING_BACKGROUND, POLLING_REALTIME } from "../../lib/polling-intervals";
-import { useEnrichableItems } from "../useEnrichableItems";
 import type {
 	JellyfinAccountsResponse,
 	JellyfinEpisodeStatusResponse,
@@ -35,6 +35,7 @@ import type {
 import {
 	fetchJellyfinAccounts,
 	fetchJellyfinBandwidthAnalytics,
+	fetchJellyfinBandwidthForecast,
 	fetchJellyfinCacheHealth,
 	fetchJellyfinCodecAnalytics,
 	fetchJellyfinDeviceAnalytics,
@@ -42,20 +43,22 @@ import {
 	fetchJellyfinIdentity,
 	fetchJellyfinNowPlaying,
 	fetchJellyfinOnDeck,
+	fetchJellyfinQualityScore,
 	fetchJellyfinRecentlyAdded,
 	fetchJellyfinSections,
+	fetchJellyfinSeriesProgress,
+	fetchJellyfinTopMedia,
 	fetchJellyfinTranscodeAnalytics,
 	fetchJellyfinUserAnalytics,
+	fetchJellyfinUserEpisodeCompletion,
 	fetchJellyfinWatchEnrichment,
 	fetchJellyfinWatchHistory,
-	fetchJellyfinQualityScore,
-	fetchJellyfinBandwidthForecast,
-	fetchJellyfinSeriesProgress,
-	fetchJellyfinUserEpisodeCompletion,
 	triggerJellyfinCacheRefresh,
 	triggerJellyfinScan,
 } from "../../lib/api-client/jellyfin";
+import { POLLING_BACKGROUND, POLLING_REALTIME } from "../../lib/polling-intervals";
 import { jellyfinKeys } from "../../lib/query-keys";
+import { useEnrichableItems } from "../useEnrichableItems";
 
 // ============================================================================
 // Server Identity
@@ -282,6 +285,20 @@ export const useJellyfinBandwidthForecast = (days = 30, enabled = true) => {
 	return useQuery<BandwidthForecast>({
 		queryKey: jellyfinKeys.bandwidthForecast(days),
 		queryFn: () => fetchJellyfinBandwidthForecast(days),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useJellyfinTopMedia = (
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+	enabled = true,
+) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: jellyfinKeys.topMedia(mediaType, days, limit),
+		queryFn: () => fetchJellyfinTopMedia(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/hooks/api/usePlex.ts
+++ b/apps/web/src/hooks/api/usePlex.ts
@@ -23,6 +23,8 @@ import type {
 	PlexTagUpdateRequest,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
+	TopMediaResponse,
+	TopMediaType,
 	TranscodeAnalytics,
 	UserAnalytics,
 	UserEpisodeCompletion,
@@ -31,8 +33,6 @@ import type {
 } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { POLLING_REALTIME } from "../../lib/polling-intervals";
-import { useEnrichableItems } from "../useEnrichableItems";
 import {
 	fetchBandwidthAnalytics,
 	fetchBandwidthForecast,
@@ -51,6 +51,7 @@ import {
 	fetchQualityScore,
 	fetchRecentlyAdded,
 	fetchSeriesProgress,
+	fetchTopMedia,
 	fetchTranscodeAnalytics,
 	fetchUserAnalytics,
 	fetchUserEpisodeCompletion,
@@ -60,7 +61,9 @@ import {
 	triggerPlexScan,
 	updatePlexTag,
 } from "../../lib/api-client/plex";
+import { POLLING_REALTIME } from "../../lib/polling-intervals";
 import { plexKeys } from "../../lib/query-keys";
+import { useEnrichableItems } from "../useEnrichableItems";
 
 // ============================================================================
 // Watch Enrichment (F1)
@@ -390,6 +393,19 @@ export const useBandwidthForecast = (days = 30, enabled = true) => {
 	return useQuery<BandwidthForecast>({
 		queryKey: plexKeys.bandwidthForecast(days),
 		queryFn: () => fetchBandwidthForecast(days),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+// ============================================================================
+// Top Media Leaderboard (Tier 1)
+// ============================================================================
+
+export const useTopMedia = (mediaType: TopMediaType, days = 30, limit = 10, enabled = true) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: plexKeys.topMedia(mediaType, days, limit),
+		queryFn: () => fetchTopMedia(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -14,6 +14,8 @@ import type {
 	JellyfinNowPlayingResponse,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
+	TopMediaResponse,
+	TopMediaType,
 	TranscodeAnalytics,
 	UserAnalytics,
 	UserEpisodeCompletion,
@@ -228,7 +230,10 @@ export async function fetchJellyfinUserAnalytics(days = 30): Promise<UserAnalyti
 	return apiRequest(`/api/jellyfin/analytics/users?days=${days}`);
 }
 
-export async function fetchJellyfinWatchHistory(days = 7, limit = 50): Promise<WatchHistoryResponse> {
+export async function fetchJellyfinWatchHistory(
+	days = 7,
+	limit = 50,
+): Promise<WatchHistoryResponse> {
 	return apiRequest(`/api/jellyfin/analytics/history?days=${days}&limit=${limit}`);
 }
 
@@ -248,10 +253,24 @@ export async function fetchJellyfinBandwidthForecast(days = 30): Promise<Bandwid
 	return apiRequest(`/api/jellyfin/analytics/forecast?days=${days}`);
 }
 
-export async function fetchJellyfinSeriesProgress(tmdbIds: number[]): Promise<SeriesProgressResponse> {
+export async function fetchJellyfinSeriesProgress(
+	tmdbIds: number[],
+): Promise<SeriesProgressResponse> {
 	return apiRequest(`/api/jellyfin/series-progress?tmdbIds=${tmdbIds.join(",")}`);
 }
 
-export async function fetchJellyfinUserEpisodeCompletion(tmdbIds: number[]): Promise<UserEpisodeCompletion> {
+export async function fetchJellyfinUserEpisodeCompletion(
+	tmdbIds: number[],
+): Promise<UserEpisodeCompletion> {
 	return apiRequest(`/api/jellyfin/analytics/episode-completion?tmdbIds=${tmdbIds.join(",")}`);
+}
+
+export async function fetchJellyfinTopMedia(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/jellyfin/analytics/top-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
 }

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -27,6 +27,8 @@ import type {
 	PlexTagUpdateRequest,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
+	TopMediaResponse,
+	TopMediaType,
 	TranscodeAnalytics,
 	UserAnalytics,
 	UserEpisodeCompletion,
@@ -264,6 +266,21 @@ export async function fetchQualityScore(days = 30): Promise<QualityScoreAnalytic
 /** Fetch bandwidth forecast with linear regression projections. */
 export async function fetchBandwidthForecast(days = 30): Promise<BandwidthForecast> {
 	return apiRequest(`/api/plex/analytics/forecast?days=${days}`);
+}
+
+// ============================================================================
+// Top Media Leaderboard (Tier 1) — replaces Tautulli home-stats top_*
+// ============================================================================
+
+/** Fetch the top-N most-watched titles for a given media type from SessionSnapshot. */
+export async function fetchTopMedia(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/plex/analytics/top-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
 }
 
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -298,6 +298,8 @@ export const plexKeys = {
 	userEpisodeCompletion: (key: string) => ["plex", "user-episode-completion", key] as const,
 	qualityScore: (days: number) => ["plex", "quality-score", days] as const,
 	bandwidthForecast: (days: number) => ["plex", "bandwidth-forecast", days] as const,
+	topMedia: (mediaType: string, days: number, limit: number) =>
+		["plex", "top-media", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -319,13 +321,17 @@ export const jellyfinKeys = {
 	transcodeAnalytics: (days: number) => ["jellyfin", "analytics", "transcode", days] as const,
 	bandwidthAnalytics: (days: number) => ["jellyfin", "analytics", "bandwidth", days] as const,
 	userAnalytics: (days: number) => ["jellyfin", "analytics", "users", days] as const,
-	watchHistory: (days: number, limit: number) => ["jellyfin", "analytics", "history", days, limit] as const,
+	watchHistory: (days: number, limit: number) =>
+		["jellyfin", "analytics", "history", days, limit] as const,
 	codecAnalytics: (days: number) => ["jellyfin", "analytics", "codec", days] as const,
 	deviceAnalytics: (days: number) => ["jellyfin", "analytics", "devices", days] as const,
 	qualityScore: (days: number) => ["jellyfin", "analytics", "quality-score", days] as const,
 	bandwidthForecast: (days: number) => ["jellyfin", "analytics", "forecast", days] as const,
 	seriesProgress: (key: string) => ["jellyfin", "series-progress", key] as const,
-	userEpisodeCompletion: (key: string) => ["jellyfin", "analytics", "episode-completion", key] as const,
+	userEpisodeCompletion: (key: string) =>
+		["jellyfin", "analytics", "episode-completion", key] as const,
+	topMedia: (mediaType: string, days: number, limit: number) =>
+		["jellyfin", "analytics", "top-media", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -206,7 +206,14 @@ export interface PlexAccountsResponse {
 export interface CacheHealthItem {
 	instanceId: string;
 	instanceName: string;
-	cacheType: "plex" | "tautulli" | "plex_episode" | "jellyfin" | "jellyfin_episode" | "emby" | "emby_episode";
+	cacheType:
+		| "plex"
+		| "tautulli"
+		| "plex_episode"
+		| "jellyfin"
+		| "jellyfin_episode"
+		| "emby"
+		| "emby_episode";
 	lastRefreshedAt: string;
 	lastResult: "success" | "error";
 	lastErrorMessage: string | null;
@@ -369,6 +376,28 @@ export interface QualityScoreAnalytics {
 	};
 	trend: Array<{ date: string; score: number }>;
 	perUser: Array<{ username: string; score: number; sessions: number }>;
+}
+
+// ============================================================================
+// Top Media Leaderboard (Tier 1) — replaces Tautulli home-stats top_*
+// ============================================================================
+
+export type TopMediaType = "movie" | "series" | "music";
+
+export interface TopMediaItem {
+	/** Display title — show name for episodes, movie name for movies, album/track for music */
+	title: string;
+	mediaType: TopMediaType;
+	/** Number of distinct user×title viewing sessions (deduplicated across consecutive 5-min ticks) */
+	playCount: number;
+	/** Approximate total time (in minutes) the title was actively streaming, summed across users */
+	totalDurationMinutes: number;
+	/** ISO timestamp of the most recent watch event */
+	lastWatchedAt: string;
+}
+
+export interface TopMediaResponse {
+	items: TopMediaItem[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

First step of the [Tautulli deprecation arc](https://github.com/Kha-kis/arr-dashboard/blob/main/docs/) (Option 3 from PR #374's discussion). Adds top-watched leaderboards for movies, shows, and music — computed entirely from `SessionSnapshot` rows, no Tautulli API calls. Lands on the **Jellyfin tab** today, giving Jellyfin/Emby users a leaderboard surface that previously didn't exist for them.

## Why on Jellyfin first

PR #374 already proved Jellyfin users see no Tautulli-style home stats — they had 8 analytics charts and zero leaderboards. This PR closes that gap. The PlexTab migration is intentionally **not** in this PR — Tautulli's `homeStatSections` renders 9 stat types (top_movies, popular_*, last_watched, most_concurrent, etc.) via a single dynamic loop, and replacing one of them creates a hybrid Tautulli/SessionSnapshot path that's harder to reason about. The PlexTab will get migrated as one cohesive PR once all the helpers exist.

## What changed

### Backend

| File | Change |
|---|---|
| `session-enrichment-helpers.ts` | Extended `EnrichedSession` with optional `mediaType` and `grandparentTitle` so we can group TV episodes by show name. Two new normalizers (`normalizePlexMediaType`, `normalizeJellyfinMediaType`). |
| `session-snapshot-scheduler.ts` | Jellyfin writer now populates `mediaType` and `grandparentTitle` from `nowPlayingItem.{type, seriesName}`. Plex writer flows through enrichSessionsWithTautulli. |
| `routes/plex/lib/top-media-helpers.ts` (new) | `aggregateTopMedia(snapshots, opts)` — same dedup pattern as `deduplicateWatchEvents` (10-min window per user×title). Returns top-N by playCount with estimated watch time. |
| `routes/plex/top-media-routes.ts` (new) | `GET /api/plex/analytics/top-media` |
| `routes/jellyfin/analytics-routes.ts` | Added `GET /api/jellyfin/analytics/top-media` (imports the shared helper from plex/lib like the rest of the file does) |
| `packages/shared/src/types/plex.ts` | New shared types: `TopMediaType`, `TopMediaItem`, `TopMediaResponse` |

### Frontend

| File | Change |
|---|---|
| `top-media-chart.tsx` (new) | Source-agnostic component. Accepts `{ data, isLoading, isError, mediaType, service? }` (matches the pattern from PR #374). |
| `usePlex.ts`, `useJellyfin.ts` | New `useTopMedia` / `useJellyfinTopMedia` hooks |
| `api-client/plex.ts`, `api-client/jellyfin.ts` | New fetcher functions |
| `query-keys.ts` | New `plexKeys.topMedia` / `jellyfinKeys.topMedia` |
| `jellyfin-tab.tsx` | Renders 3 leaderboards (Top Movies / Top Shows / Top Music) above the existing 8 analytics charts |

## Backward compatibility

Snapshots written before this PR don't have `mediaType` or `grandparentTitle`. The helper checks `session.mediaType === undefined` and skips those rows from leaderboards — so old snapshots gracefully degrade rather than appearing as "Unknown". After the merge, leaderboards will populate as new sessions are captured (every 5 minutes by the snapshot scheduler).

## Verified

- [x] `pnpm --filter @arr/api exec tsc --noEmit` clean
- [x] `pnpm --filter @arr/shared run build` clean (regenerated dist for vitest)
- [x] `pnpm --filter @arr/web exec tsc --noEmit` clean
- [x] Live test on the e2e integration compose: all 3 leaderboards render their `PremiumEmptyState` correctly with mediaType-specific copy ("Leaderboard appears once active sessions for movies/shows/tracks are captured by the snapshot scheduler")
- [x] `GET /api/plex/analytics/top-media?mediaType=music` returns `{"items":[]}` HTTP 200
- [x] `GET /api/jellyfin/analytics/top-media?mediaType=movie&days=30` returns `{"items":[]}` HTTP 200
- [x] `GET /api/jellyfin/analytics/top-media?mediaType=series` returns `{"items":[]}` HTTP 200

Screenshot saved as `top-media-leaderboards-verified.png` showing all three leaderboards above the 8 existing charts on the Jellyfin tab.

## Out of scope (next Option 3 PRs)

- `aggregatePopularMedia` (distinct watcher count) — replaces Tautulli `popular_*`
- `aggregateLastWatched` (recency) — replaces Tautulli `last_watched`
- `aggregateMostConcurrent` — replaces Tautulli `most_concurrent`
- `aggregatePlaysByDate` — replaces Tautulli `cmd=get_plays_by_date`
- Then PlexTab migration off Tautulli for the home-stats section

🤖 Generated with [Claude Code](https://claude.com/claude-code)