### PR TITLE
feat(statistics): popular-media leaderboards (Option 3 phase 2)

### DIFF
--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -15,7 +15,7 @@ import { aggregateCodecAnalytics } from "../plex/lib/codec-analytics-helpers.js"
 import { aggregateDeviceAnalytics } from "../plex/lib/device-analytics-helpers.js";
 import { computeForecast } from "../plex/lib/forecast-helpers.js";
 import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
-import { aggregateTopMedia } from "../plex/lib/top-media-helpers.js";
+import { aggregatePopularMedia, aggregateTopMedia } from "../plex/lib/top-media-helpers.js";
 import { aggregateTranscodeAnalytics } from "../plex/lib/transcode-analytics-helpers.js";
 import { aggregateUserAnalytics } from "../plex/lib/user-analytics-helpers.js";
 import { aggregateUserEpisodeCompletion } from "../plex/lib/user-episode-helpers.js";
@@ -449,6 +449,47 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 		if (parseFailures > 0) {
 			request.log.warn(
 				{ parseFailures, totalSnapshots, failedPreviews, route: "jellyfin/top-media", mediaType },
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
+	});
+
+	// ── Popular Media Leaderboard (sorted by distinct watcher count) ──
+	app.get("/popular-media", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(topMediaQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
+			select: { id: true },
+		});
+
+		if (instances.length === 0) {
+			return reply.send({ items: [] });
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregatePopularMedia(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{
+					parseFailures,
+					totalSnapshots,
+					failedPreviews,
+					route: "jellyfin/popular-media",
+					mediaType,
+				},
 				"Session snapshot JSON parse failures detected",
 			);
 		}

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -19,6 +19,7 @@ import { registerImageProxyRoutes } from "./image-proxy-routes.js";
 import { registerNowPlayingRoutes } from "./now-playing-routes.js";
 import { registerOAuthRoutes } from "./oauth-routes.js";
 import { registerOnDeckRoutes } from "./on-deck-routes.js";
+import { registerPopularMediaRoutes } from "./popular-media-routes.js";
 import { registerQualityScoreRoutes } from "./quality-score-routes.js";
 import { registerRecentlyAddedRoutes } from "./recently-added-routes.js";
 import { registerScanRoutes } from "./scan-routes.js";
@@ -55,6 +56,7 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerQualityScoreRoutes, { prefix: "/analytics/quality-score" });
 	app.register(registerForecastRoutes, { prefix: "/analytics/forecast" });
 	app.register(registerTopMediaRoutes, { prefix: "/analytics/top-media" });
+	app.register(registerPopularMediaRoutes, { prefix: "/analytics/popular-media" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
 	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/lib/top-media-helpers.ts
+++ b/apps/api/src/routes/plex/lib/top-media-helpers.ts
@@ -1,9 +1,17 @@
 /**
- * Top Media Helpers
+ * Top Media + Popular Media Helpers
  *
- * Aggregates SessionSnapshot rows into a leaderboard of most-watched titles,
- * bucketed by media type. Replaces Tautulli's pre-aggregated `cmd=get_home_stats`
- * top_* values, so this surface works with or without Tautulli configured.
+ * Aggregates SessionSnapshot rows into leaderboards of most-watched titles,
+ * bucketed by media type. Replaces Tautulli's pre-aggregated home-stats:
+ *
+ *   - aggregateTopMedia    → cmd=get_home_stats top_movies / top_tv / top_music
+ *                            (sorted by total play count)
+ *   - aggregatePopularMedia → cmd=get_home_stats popular_movies / popular_tv / popular_music
+ *                            (sorted by distinct watcher count)
+ *
+ * Both helpers share the same internal aggregator — they only differ in
+ * sort order, so adding new metrics (e.g. "longest watched" by total minutes)
+ * is a one-liner.
  *
  * "Play count" semantics match Tautulli: each user×title viewing session
  * counts as one play. Consecutive 5-minute snapshot ticks within a 10-minute
@@ -17,7 +25,7 @@ import type { AggregationMeta } from "./user-analytics-helpers.js";
 /** Normalized media type as stored in EnrichedSession.mediaType */
 type SnapshotMediaType = "movie" | "series" | "music" | "other";
 
-/** Snapshot row required for top-media aggregation */
+/** Snapshot row required for media aggregation */
 export interface SnapshotForTopMedia {
 	capturedAt: Date;
 	sessionsJson: string;
@@ -29,6 +37,16 @@ interface ParsedSession {
 	title?: string;
 	grandparentTitle?: string;
 	mediaType?: SnapshotMediaType;
+}
+
+/** Internal aggregate row before sort/slice/projection to TopMediaItem */
+interface AggregatedItem {
+	title: string;
+	mediaType: TopMediaType;
+	playCount: number;
+	distinctUsers: Set<string>;
+	tickCount: number;
+	lastWatchedAt: Date;
 }
 
 /** Snapshot interval in minutes — used to estimate watch duration from tick count */
@@ -49,28 +67,29 @@ function deriveGroupingTitle(session: ParsedSession): string | null {
 	return session.title ?? null;
 }
 
-export function aggregateTopMedia(
+/** Project an internal aggregate row into the public TopMediaItem shape. */
+function projectItem(item: AggregatedItem): TopMediaItem {
+	return {
+		title: item.title,
+		mediaType: item.mediaType,
+		playCount: item.playCount,
+		distinctUserCount: item.distinctUsers.size,
+		totalDurationMinutes: item.tickCount * SNAPSHOT_INTERVAL_MINUTES,
+		lastWatchedAt: item.lastWatchedAt.toISOString(),
+	};
+}
+
+/**
+ * Walk snapshots once and build a Map<groupingTitle, AggregatedItem>. Both
+ * aggregateTopMedia and aggregatePopularMedia consume this output and only
+ * differ in how they sort the resulting items.
+ */
+function buildMediaAggregate(
 	snapshots: SnapshotForTopMedia[],
-	opts: { mediaType: TopMediaType; limit: number },
-): TopMediaResponse & AggregationMeta {
-	const { mediaType, limit } = opts;
-
-	// Per-key aggregation: groupKey = `${mediaType}|${groupingTitle}`
-	const itemMap = new Map<
-		string,
-		{
-			title: string;
-			mediaType: TopMediaType;
-			playCount: number;
-			tickCount: number;
-			lastWatchedAt: Date;
-		}
-	>();
-
-	// Per (key, user) dedup state — anchors the most recent emitted timestamp so
-	// chained ticks within the dedup window collapse into one play.
+	mediaType: TopMediaType,
+): { items: AggregatedItem[]; meta: AggregationMeta } {
+	const itemMap = new Map<string, AggregatedItem>();
 	const lastPlayAnchorByUserKey = new Map<string, number>();
-
 	let parseFailures = 0;
 	const failedPreviews: string[] = [];
 
@@ -95,58 +114,81 @@ export function aggregateTopMedia(
 			if (!groupingTitle) continue;
 
 			const user = session.user ?? "Unknown";
-			const groupKey = groupingTitle; // mediaType already filtered above
-			const userKey = `${groupKey}::${user}`;
+			const userKey = `${groupingTitle}::${user}`;
 			const tickTime = snap.capturedAt.getTime();
 
-			const existingItem = itemMap.get(groupKey) ?? {
+			const existingItem = itemMap.get(groupingTitle) ?? {
 				title: groupingTitle,
 				mediaType,
 				playCount: 0,
+				distinctUsers: new Set<string>(),
 				tickCount: 0,
 				lastWatchedAt: snap.capturedAt,
 			};
 
-			// Always increment tick count (used for duration estimate)
 			existingItem.tickCount += 1;
+			existingItem.distinctUsers.add(user);
 			if (snap.capturedAt > existingItem.lastWatchedAt) {
 				existingItem.lastWatchedAt = snap.capturedAt;
 			}
 
-			// Determine whether this tick starts a new play for this user
 			const prevAnchor = lastPlayAnchorByUserKey.get(userKey);
 			const isNewPlay = prevAnchor === undefined || prevAnchor - tickTime > DEDUP_WINDOW_MS;
 
 			if (isNewPlay) {
 				existingItem.playCount += 1;
-				lastPlayAnchorByUserKey.set(userKey, tickTime);
-			} else {
-				// Within dedup window — extend the anchor backward so chained ticks keep collapsing
-				lastPlayAnchorByUserKey.set(userKey, tickTime);
 			}
+			// Either way, refresh the anchor so chained ticks keep collapsing
+			lastPlayAnchorByUserKey.set(userKey, tickTime);
 
-			itemMap.set(groupKey, existingItem);
+			itemMap.set(groupingTitle, existingItem);
 		}
 	}
 
-	const items: TopMediaItem[] = [...itemMap.values()]
+	return {
+		items: [...itemMap.values()],
+		meta: { parseFailures, totalSnapshots: snapshots.length, failedPreviews },
+	};
+}
+
+/**
+ * Top media by total play count. Ties broken by total duration so a title
+ * watched longer in aggregate ranks above an equally-played but shorter one.
+ */
+export function aggregateTopMedia(
+	snapshots: SnapshotForTopMedia[],
+	opts: { mediaType: TopMediaType; limit: number },
+): TopMediaResponse & AggregationMeta {
+	const { items, meta } = buildMediaAggregate(snapshots, opts.mediaType);
+	const sorted = items
 		.sort((a, b) => {
 			if (b.playCount !== a.playCount) return b.playCount - a.playCount;
 			return b.tickCount - a.tickCount;
 		})
-		.slice(0, limit)
-		.map((item) => ({
-			title: item.title,
-			mediaType: item.mediaType,
-			playCount: item.playCount,
-			totalDurationMinutes: item.tickCount * SNAPSHOT_INTERVAL_MINUTES,
-			lastWatchedAt: item.lastWatchedAt.toISOString(),
-		}));
+		.slice(0, opts.limit)
+		.map(projectItem);
 
-	return {
-		items,
-		parseFailures,
-		totalSnapshots: snapshots.length,
-		failedPreviews,
-	};
+	return { items: sorted, ...meta };
+}
+
+/**
+ * Popular media by distinct watcher count. Ties broken by play count so
+ * a title with the same audience size but more rewatching ranks higher.
+ */
+export function aggregatePopularMedia(
+	snapshots: SnapshotForTopMedia[],
+	opts: { mediaType: TopMediaType; limit: number },
+): TopMediaResponse & AggregationMeta {
+	const { items, meta } = buildMediaAggregate(snapshots, opts.mediaType);
+	const sorted = items
+		.sort((a, b) => {
+			const aUsers = a.distinctUsers.size;
+			const bUsers = b.distinctUsers.size;
+			if (bUsers !== aUsers) return bUsers - aUsers;
+			return b.playCount - a.playCount;
+		})
+		.slice(0, opts.limit)
+		.map(projectItem);
+
+	return { items: sorted, ...meta };
 }

--- a/apps/api/src/routes/plex/popular-media-routes.ts
+++ b/apps/api/src/routes/plex/popular-media-routes.ts
@@ -1,0 +1,80 @@
+/**
+ * Plex Popular Media Routes
+ *
+ * Aggregates SessionSnapshot rows into a leaderboard of titles ranked by
+ * distinct watcher count. Replaces Tautulli's pre-aggregated home-stats
+ * popular_movies / popular_tv / popular_music.
+ */
+
+import type { TopMediaResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { aggregatePopularMedia } from "./lib/top-media-helpers.js";
+
+const popularMediaQuery = z.object({
+	mediaType: z.enum(["movie", "series", "music"]),
+	days: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 30;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+		}),
+	limit: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 10;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 50) : 10;
+		}),
+});
+
+export async function registerPopularMediaRoutes(
+	app: FastifyInstance,
+	_opts: FastifyPluginOptions,
+) {
+	/**
+	 * GET /api/plex/analytics/popular-media?mediaType=movie&days=30&limit=10
+	 *
+	 * Returns the top-N titles of the given media type ranked by distinct
+	 * watcher count from SessionSnapshot rows for this user's Plex instances.
+	 */
+	app.get("/", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(popularMediaQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const plexInstances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			select: { id: true },
+		});
+
+		if (plexInstances.length === 0) {
+			const empty: TopMediaResponse = { items: [] };
+			return reply.send(empty);
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: {
+				instanceId: { in: plexInstances.map((i) => i.id) },
+				capturedAt: { gte: cutoff },
+			},
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregatePopularMedia(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{ parseFailures, totalSnapshots, failedPreviews, route: "popular-media", mediaType },
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
+	});
+}

--- a/apps/web/src/features/statistics/components/jellyfin-tab.tsx
+++ b/apps/web/src/features/statistics/components/jellyfin-tab.tsx
@@ -7,6 +7,7 @@ import {
 	useJellyfinBandwidthForecast,
 	useJellyfinCodecAnalytics,
 	useJellyfinDeviceAnalytics,
+	useJellyfinPopularMedia,
 	useJellyfinQualityScore,
 	useJellyfinTopMedia,
 	useJellyfinTranscodeAnalytics,
@@ -44,6 +45,9 @@ export const JellyfinTab = () => {
 	const topMoviesQuery = useJellyfinTopMedia("movie", timeRange);
 	const topShowsQuery = useJellyfinTopMedia("series", timeRange);
 	const topMusicQuery = useJellyfinTopMedia("music", timeRange);
+	const popularMoviesQuery = useJellyfinPopularMedia("movie", timeRange);
+	const popularShowsQuery = useJellyfinPopularMedia("series", timeRange);
+	const popularMusicQuery = useJellyfinPopularMedia("music", timeRange);
 
 	return (
 		<div className="space-y-6 animate-in fade-in duration-300">
@@ -100,6 +104,32 @@ export const JellyfinTab = () => {
 				isLoading={topMusicQuery.isLoading}
 				isError={topMusicQuery.isError}
 				mediaType="music"
+				service="jellyfin"
+			/>
+
+			{/* Popular Media (sorted by distinct watcher count) */}
+			<TopMediaChart
+				data={popularMoviesQuery.data}
+				isLoading={popularMoviesQuery.isLoading}
+				isError={popularMoviesQuery.isError}
+				mediaType="movie"
+				metric="popularity"
+				service="jellyfin"
+			/>
+			<TopMediaChart
+				data={popularShowsQuery.data}
+				isLoading={popularShowsQuery.isLoading}
+				isError={popularShowsQuery.isError}
+				mediaType="series"
+				metric="popularity"
+				service="jellyfin"
+			/>
+			<TopMediaChart
+				data={popularMusicQuery.data}
+				isLoading={popularMusicQuery.isLoading}
+				isError={popularMusicQuery.isError}
+				mediaType="music"
+				metric="popularity"
 				service="jellyfin"
 			/>
 

--- a/apps/web/src/features/statistics/components/top-media-chart.tsx
+++ b/apps/web/src/features/statistics/components/top-media-chart.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import type { TopMediaResponse, TopMediaType } from "@arr/shared";
-import { Film, Music, Trophy, Tv } from "lucide-react";
+import { Film, Music, Trophy, Tv, Users } from "lucide-react";
 import { PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+
+type Metric = "plays" | "popularity";
 
 const ICON_FOR_MEDIA_TYPE: Record<TopMediaType, typeof Film> = {
 	movie: Film,
@@ -13,16 +15,22 @@ const ICON_FOR_MEDIA_TYPE: Record<TopMediaType, typeof Film> = {
 	music: Music,
 };
 
-const HEADING_FOR_MEDIA_TYPE: Record<TopMediaType, string> = {
+const SUBJECT_FOR_MEDIA_TYPE: Record<TopMediaType, string> = {
+	movie: "movies",
+	series: "shows",
+	music: "tracks",
+};
+
+const HEADING_FOR_MEDIA_TYPE_TOP: Record<TopMediaType, string> = {
 	movie: "Top Movies",
 	series: "Top Shows",
 	music: "Top Music",
 };
 
-const SUBJECT_FOR_MEDIA_TYPE: Record<TopMediaType, string> = {
-	movie: "movies",
-	series: "shows",
-	music: "tracks",
+const HEADING_FOR_MEDIA_TYPE_POPULAR: Record<TopMediaType, string> = {
+	movie: "Most Popular Movies",
+	series: "Most Popular Shows",
+	music: "Most Popular Music",
 };
 
 function formatWatchTime(minutes: number): string {
@@ -43,6 +51,12 @@ interface TopMediaChartProps {
 	isError: boolean;
 	mediaType: TopMediaType;
 	service?: "plex" | "jellyfin";
+	/**
+	 * Which metric to surface as the primary number column.
+	 * - "plays" (default): item.playCount, labelled "plays". Use with /top-media endpoint.
+	 * - "popularity": item.distinctUserCount, labelled "viewers". Use with /popular-media endpoint.
+	 */
+	metric?: Metric;
 }
 
 export const TopMediaChart = ({
@@ -51,13 +65,18 @@ export const TopMediaChart = ({
 	isError,
 	mediaType,
 	service = "plex",
+	metric = "plays",
 }: TopMediaChartProps) => {
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
 	const accentColor = SERVICE_GRADIENTS[service].from;
 	const Icon = ICON_FOR_MEDIA_TYPE[mediaType];
-	const heading = HEADING_FOR_MEDIA_TYPE[mediaType];
+	const heading =
+		metric === "popularity"
+			? HEADING_FOR_MEDIA_TYPE_POPULAR[mediaType]
+			: HEADING_FOR_MEDIA_TYPE_TOP[mediaType];
 	const subject = SUBJECT_FOR_MEDIA_TYPE[mediaType];
+	const HeaderIcon = metric === "popularity" ? Users : Icon;
 
 	if (isLoading) {
 		return (
@@ -82,7 +101,7 @@ export const TopMediaChart = ({
 			<PremiumEmptyState
 				icon={Trophy}
 				title={`Failed to Load ${heading}`}
-				description={`Could not fetch top ${subject}. Try refreshing.`}
+				description={`Could not fetch ${subject} leaderboard. Try refreshing.`}
 			/>
 		);
 	}
@@ -97,19 +116,23 @@ export const TopMediaChart = ({
 		);
 	}
 
-	const maxPlayCount = Math.max(...data.items.map((item) => item.playCount), 1);
+	const primaryValue = (item: TopMediaResponse["items"][number]): number =>
+		metric === "popularity" ? item.distinctUserCount : item.playCount;
+	const primaryLabel = metric === "popularity" ? "viewers" : "plays";
+	const maxPrimary = Math.max(...data.items.map(primaryValue), 1);
 
 	return (
 		<div className="rounded-xl border border-border/30 bg-card/30 p-6 space-y-4">
 			<h3 className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-				<Icon className="h-4 w-4" style={{ color: gradient.from }} />
+				<HeaderIcon className="h-4 w-4" style={{ color: gradient.from }} />
 				{heading}
 			</h3>
 
 			<div className="space-y-2">
 				{data.items.map((item, i) => {
 					const displayTitle = incognitoMode ? getLinuxIsoName(item.title) : item.title;
-					const widthPercent = (item.playCount / maxPlayCount) * 100;
+					const value = primaryValue(item);
+					const widthPercent = (value / maxPrimary) * 100;
 					return (
 						<div key={`${item.title}-${i}`} className="flex items-center gap-3 text-sm group">
 							<span
@@ -135,8 +158,8 @@ export const TopMediaChart = ({
 								</div>
 							</div>
 							<span className="w-16 text-right font-medium tabular-nums">
-								{item.playCount.toLocaleString()}
-								<span className="text-[10px] text-muted-foreground ml-1">plays</span>
+								{value.toLocaleString()}
+								<span className="text-[10px] text-muted-foreground ml-1">{primaryLabel}</span>
 							</span>
 							<span className="w-20 text-right text-xs text-muted-foreground tabular-nums">
 								{formatWatchTime(item.totalDurationMinutes)}

--- a/apps/web/src/hooks/api/useJellyfin.ts
+++ b/apps/web/src/hooks/api/useJellyfin.ts
@@ -43,6 +43,7 @@ import {
 	fetchJellyfinIdentity,
 	fetchJellyfinNowPlaying,
 	fetchJellyfinOnDeck,
+	fetchJellyfinPopularMedia,
 	fetchJellyfinQualityScore,
 	fetchJellyfinRecentlyAdded,
 	fetchJellyfinSections,
@@ -299,6 +300,20 @@ export const useJellyfinTopMedia = (
 	return useQuery<TopMediaResponse>({
 		queryKey: jellyfinKeys.topMedia(mediaType, days, limit),
 		queryFn: () => fetchJellyfinTopMedia(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useJellyfinPopularMedia = (
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+	enabled = true,
+) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: jellyfinKeys.popularMedia(mediaType, days, limit),
+		queryFn: () => fetchJellyfinPopularMedia(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/hooks/api/usePlex.ts
+++ b/apps/web/src/hooks/api/usePlex.ts
@@ -48,6 +48,7 @@ import {
 	fetchPlexIdentity,
 	fetchPlexLabels,
 	fetchPlexSections,
+	fetchPopularMedia,
 	fetchQualityScore,
 	fetchRecentlyAdded,
 	fetchSeriesProgress,
@@ -406,6 +407,15 @@ export const useTopMedia = (mediaType: TopMediaType, days = 30, limit = 10, enab
 	return useQuery<TopMediaResponse>({
 		queryKey: plexKeys.topMedia(mediaType, days, limit),
 		queryFn: () => fetchTopMedia(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const usePopularMedia = (mediaType: TopMediaType, days = 30, limit = 10, enabled = true) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: plexKeys.popularMedia(mediaType, days, limit),
+		queryFn: () => fetchPopularMedia(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -274,3 +274,13 @@ export async function fetchJellyfinTopMedia(
 		`/api/jellyfin/analytics/top-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
 	);
 }
+
+export async function fetchJellyfinPopularMedia(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/jellyfin/analytics/popular-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
+}

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -283,6 +283,17 @@ export async function fetchTopMedia(
 	);
 }
 
+/** Fetch the top-N titles ranked by distinct watcher count from SessionSnapshot. */
+export async function fetchPopularMedia(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/plex/analytics/popular-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
+}
+
 // ============================================================================
 // OAuth Setup Assistance
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -300,6 +300,8 @@ export const plexKeys = {
 	bandwidthForecast: (days: number) => ["plex", "bandwidth-forecast", days] as const,
 	topMedia: (mediaType: string, days: number, limit: number) =>
 		["plex", "top-media", mediaType, days, limit] as const,
+	popularMedia: (mediaType: string, days: number, limit: number) =>
+		["plex", "popular-media", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -332,6 +334,8 @@ export const jellyfinKeys = {
 		["jellyfin", "analytics", "episode-completion", key] as const,
 	topMedia: (mediaType: string, days: number, limit: number) =>
 		["jellyfin", "analytics", "top-media", mediaType, days, limit] as const,
+	popularMedia: (mediaType: string, days: number, limit: number) =>
+		["jellyfin", "analytics", "popular-media", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -390,6 +390,8 @@ export interface TopMediaItem {
 	mediaType: TopMediaType;
 	/** Number of distinct user×title viewing sessions (deduplicated across consecutive 5-min ticks) */
 	playCount: number;
+	/** Number of distinct users who watched this title at least once in the window */
+	distinctUserCount: number;
 	/** Approximate total time (in minutes) the title was actively streaming, summed across users */
 	totalDurationMinutes: number;
 	/** ISO timestamp of the most recent watch event */


### PR DESCRIPTION
## Summary

Phase A2 of the [Tautulli deprecation arc](memory). Adds the "Most Popular" companion to the existing "Top" leaderboards from PR #375 — same SessionSnapshot data, different sort order.

| Sort | Tautulli equivalent | Question it answers |
|---|---|---|
| `aggregateTopMedia` (PR #375) | `cmd=get_home_stats top_movies` | What got played the most? |
| `aggregatePopularMedia` (this PR) | `cmd=get_home_stats popular_movies` | What got watched by the most distinct people? |

These differ when a single user rewatches obsessively (high play count, single watcher) vs a broadly-loved title (modest play count, many distinct watchers).

## What changed

### Backend
- **Refactored** `top-media-helpers.ts`: factored out a private `buildMediaAggregate` that does the single-pass walk and returns both `playCount` (deduped per user×title) and `distinctUsers` (`Set<string>`). Both public helpers now consume this and only differ in sort order — adding new metrics in the future is a one-liner.
- **Extended** `TopMediaItem` with `distinctUserCount: number`. Additive field; existing `/top-media` consumers just ignore it.
- **New endpoints** `GET /api/plex/analytics/popular-media` + `GET /api/jellyfin/analytics/popular-media`. Reuse the same `mediaType` / `days` / `limit` query schema as the top-media endpoints.

### Frontend
- **TopMediaChart** gets a new `metric: "plays" | "popularity"` prop (default `"plays"`). Drives:
  - Heading: "Top Movies" vs "Most Popular Movies"
  - Primary value column: `playCount` vs `distinctUserCount`
  - Unit label: "plays" vs "viewers"
  - Header icon: Trophy vs Users (visual cue for the metric being ranked)
- **New hooks** `usePopularMedia` / `useJellyfinPopularMedia` + query keys + fetchers for both services.
- **JellyfinTab** now renders 6 leaderboards: 3 Top + 3 Most Popular, above the existing 8 analytics charts.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail (per the [feedback note from PR #375](memory/feedback_run_tests_before_pr.md), I ran the full vitest suite locally before pushing this time)
- [x] `tsc --noEmit` clean across `@arr/api`, `@arr/shared`, `@arr/web`
- [x] Live test on the e2e integration compose: all 6 leaderboards render their `PremiumEmptyState` correctly. The "Most Popular" headings are visually distinct from "Top".
- [x] `GET /api/jellyfin/analytics/popular-media?mediaType=movie&days=30` returns `{"items":[]}` HTTP 200
- [x] `GET /api/plex/analytics/popular-media?mediaType=series` returns `{"items":[]}` HTTP 200

Screenshot saved as `popular-media-verified.png` showing all 6 leaderboards on the Jellyfin tab.

## Up next (Option 3 phases A3–A5)

Per `memory/tautulli-deprecation-plan.md`:
- **A3** `aggregateLastWatched` — replaces Tautulli `last_watched`
- **A4** `aggregateMostConcurrent` — replaces Tautulli `most_concurrent`
- **A5** `aggregatePlaysByDate` — replaces Tautulli `cmd=get_plays_by_date`
- Then **Phase C**: single dedicated PR migrating PlexTab's top section off Tautulli once all helpers exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)