### PR TITLE
feat(statistics): last-watched aggregator (Option 3 phase 3)

### DIFF
--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -15,7 +15,11 @@ import { aggregateCodecAnalytics } from "../plex/lib/codec-analytics-helpers.js"
 import { aggregateDeviceAnalytics } from "../plex/lib/device-analytics-helpers.js";
 import { computeForecast } from "../plex/lib/forecast-helpers.js";
 import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
-import { aggregatePopularMedia, aggregateTopMedia } from "../plex/lib/top-media-helpers.js";
+import {
+	aggregateLastWatched,
+	aggregatePopularMedia,
+	aggregateTopMedia,
+} from "../plex/lib/top-media-helpers.js";
 import { aggregateTranscodeAnalytics } from "../plex/lib/transcode-analytics-helpers.js";
 import { aggregateUserAnalytics } from "../plex/lib/user-analytics-helpers.js";
 import { aggregateUserEpisodeCompletion } from "../plex/lib/user-episode-helpers.js";
@@ -488,6 +492,47 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 					totalSnapshots,
 					failedPreviews,
 					route: "jellyfin/popular-media",
+					mediaType,
+				},
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
+	});
+
+	// ── Last Watched Feed (titles deduped, sorted by most-recent watch) ──
+	app.get("/last-watched", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(topMediaQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
+			select: { id: true },
+		});
+
+		if (instances.length === 0) {
+			return reply.send({ items: [] });
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateLastWatched(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{
+					parseFailures,
+					totalSnapshots,
+					failedPreviews,
+					route: "jellyfin/last-watched",
 					mediaType,
 				},
 				"Session snapshot JSON parse failures detected",

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -16,6 +16,7 @@ import { registerEpisodeRoutes } from "./episode-routes.js";
 import { registerForecastRoutes } from "./forecast-routes.js";
 import { registerIdentityRoutes } from "./identity-routes.js";
 import { registerImageProxyRoutes } from "./image-proxy-routes.js";
+import { registerLastWatchedRoutes } from "./last-watched-routes.js";
 import { registerNowPlayingRoutes } from "./now-playing-routes.js";
 import { registerOAuthRoutes } from "./oauth-routes.js";
 import { registerOnDeckRoutes } from "./on-deck-routes.js";
@@ -57,6 +58,7 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerForecastRoutes, { prefix: "/analytics/forecast" });
 	app.register(registerTopMediaRoutes, { prefix: "/analytics/top-media" });
 	app.register(registerPopularMediaRoutes, { prefix: "/analytics/popular-media" });
+	app.register(registerLastWatchedRoutes, { prefix: "/analytics/last-watched" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
 	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/last-watched-routes.ts
+++ b/apps/api/src/routes/plex/last-watched-routes.ts
@@ -1,0 +1,71 @@
+/**
+ * Plex Last Watched Routes
+ *
+ * Aggregates SessionSnapshot rows into a feed of recently-watched titles
+ * (deduped by title). Replaces Tautulli's pre-aggregated home-stats
+ * `last_watched`. Distinct from /analytics/history, which is event-level.
+ */
+
+import type { TopMediaResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { aggregateLastWatched } from "./lib/top-media-helpers.js";
+
+const lastWatchedQuery = z.object({
+	mediaType: z.enum(["movie", "series", "music"]),
+	days: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 30;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+		}),
+	limit: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 10;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 50) : 10;
+		}),
+});
+
+export async function registerLastWatchedRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/", async (request, reply) => {
+		const { mediaType, days, limit } = validateRequest(lastWatchedQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const plexInstances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			select: { id: true },
+		});
+
+		if (plexInstances.length === 0) {
+			const empty: TopMediaResponse = { items: [] };
+			return reply.send(empty);
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: {
+				instanceId: { in: plexInstances.map((i) => i.id) },
+				capturedAt: { gte: cutoff },
+			},
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateLastWatched(
+			snapshots,
+			{ mediaType, limit },
+		);
+		if (parseFailures > 0) {
+			request.log.warn(
+				{ parseFailures, totalSnapshots, failedPreviews, route: "last-watched", mediaType },
+				"Session snapshot JSON parse failures detected",
+			);
+		}
+		return reply.send(response);
+	});
+}

--- a/apps/api/src/routes/plex/lib/top-media-helpers.ts
+++ b/apps/api/src/routes/plex/lib/top-media-helpers.ts
@@ -192,3 +192,21 @@ export function aggregatePopularMedia(
 
 	return { items: sorted, ...meta };
 }
+
+/**
+ * Most recently watched media (deduped by title). Mirrors Tautulli's
+ * `last_watched` home stat — answers "what did anyone watch most recently?"
+ * Distinct from WatchHistoryResponse, which is event-level (per user×title).
+ */
+export function aggregateLastWatched(
+	snapshots: SnapshotForTopMedia[],
+	opts: { mediaType: TopMediaType; limit: number },
+): TopMediaResponse & AggregationMeta {
+	const { items, meta } = buildMediaAggregate(snapshots, opts.mediaType);
+	const sorted = items
+		.sort((a, b) => b.lastWatchedAt.getTime() - a.lastWatchedAt.getTime())
+		.slice(0, opts.limit)
+		.map(projectItem);
+
+	return { items: sorted, ...meta };
+}

--- a/apps/web/src/hooks/api/useJellyfin.ts
+++ b/apps/web/src/hooks/api/useJellyfin.ts
@@ -41,6 +41,7 @@ import {
 	fetchJellyfinDeviceAnalytics,
 	fetchJellyfinEpisodeWatchStatus,
 	fetchJellyfinIdentity,
+	fetchJellyfinLastWatched,
 	fetchJellyfinNowPlaying,
 	fetchJellyfinOnDeck,
 	fetchJellyfinPopularMedia,
@@ -314,6 +315,20 @@ export const useJellyfinPopularMedia = (
 	return useQuery<TopMediaResponse>({
 		queryKey: jellyfinKeys.popularMedia(mediaType, days, limit),
 		queryFn: () => fetchJellyfinPopularMedia(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useJellyfinLastWatched = (
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+	enabled = true,
+) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: jellyfinKeys.lastWatched(mediaType, days, limit),
+		queryFn: () => fetchJellyfinLastWatched(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/hooks/api/usePlex.ts
+++ b/apps/web/src/hooks/api/usePlex.ts
@@ -41,6 +41,7 @@ import {
 	fetchCollectionStats,
 	fetchDeviceAnalytics,
 	fetchEpisodeWatchStatus,
+	fetchLastWatched,
 	fetchNowPlaying,
 	fetchOnDeck,
 	fetchPlexAccounts,
@@ -416,6 +417,15 @@ export const usePopularMedia = (mediaType: TopMediaType, days = 30, limit = 10, 
 	return useQuery<TopMediaResponse>({
 		queryKey: plexKeys.popularMedia(mediaType, days, limit),
 		queryFn: () => fetchPopularMedia(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useLastWatched = (mediaType: TopMediaType, days = 30, limit = 10, enabled = true) => {
+	return useQuery<TopMediaResponse>({
+		queryKey: plexKeys.lastWatched(mediaType, days, limit),
+		queryFn: () => fetchLastWatched(mediaType, days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -284,3 +284,13 @@ export async function fetchJellyfinPopularMedia(
 		`/api/jellyfin/analytics/popular-media?mediaType=${mediaType}&days=${days}&limit=${limit}`,
 	);
 }
+
+export async function fetchJellyfinLastWatched(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/jellyfin/analytics/last-watched?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
+}

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -294,6 +294,17 @@ export async function fetchPopularMedia(
 	);
 }
 
+/** Fetch the most-recently-watched titles (deduped) from SessionSnapshot. */
+export async function fetchLastWatched(
+	mediaType: TopMediaType,
+	days = 30,
+	limit = 10,
+): Promise<TopMediaResponse> {
+	return apiRequest(
+		`/api/plex/analytics/last-watched?mediaType=${mediaType}&days=${days}&limit=${limit}`,
+	);
+}
+
 // ============================================================================
 // OAuth Setup Assistance
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -302,6 +302,8 @@ export const plexKeys = {
 		["plex", "top-media", mediaType, days, limit] as const,
 	popularMedia: (mediaType: string, days: number, limit: number) =>
 		["plex", "popular-media", mediaType, days, limit] as const,
+	lastWatched: (mediaType: string, days: number, limit: number) =>
+		["plex", "last-watched", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -336,6 +338,8 @@ export const jellyfinKeys = {
 		["jellyfin", "analytics", "top-media", mediaType, days, limit] as const,
 	popularMedia: (mediaType: string, days: number, limit: number) =>
 		["jellyfin", "analytics", "popular-media", mediaType, days, limit] as const,
+	lastWatched: (mediaType: string, days: number, limit: number) =>
+		["jellyfin", "analytics", "last-watched", mediaType, days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

Phase A3 of the Tautulli deprecation arc. Adds the third sort variant on top of `buildMediaAggregate` from PR #376: items deduped by title, sorted by `lastWatchedAt` descending. Mirrors Tautulli's `last_watched` home stat.

| Helper | Sort | Tautulli equivalent |
|---|---|---|
| `aggregateTopMedia` (PR #375) | by play count | `top_movies` / `top_tv` / `top_music` |
| `aggregatePopularMedia` (PR #376) | by distinct watcher count | `popular_*` |
| `aggregateLastWatched` (this PR) | by most-recent watch | `last_watched` |

## Why this is small

The shared `buildMediaAggregate` from PR #376 already produces `lastWatchedAt` per title. So the helper is ~12 lines (just a different sort), and the route is mechanical. No new types, no new chart, no new shared abstraction.

## Why no UI in this PR

The existing `WatchHistoryWidget` already shows recent watch *events* (per user×title) on the Jellyfin tab. Adding a second "recent items" widget would visually duplicate that surface. The new endpoint is needed for the Phase C migration: PlexTab's `homeStatSections` dynamically renders whatever Tautulli home_stats are returned, including `last_watched`. When Phase C migrates that section off Tautulli, it'll consume `useLastWatched` directly.

The frontend hook is wired through (`useLastWatched`, `useJellyfinLastWatched`, query keys, fetchers) so Phase C consumption is a one-line change.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean across `@arr/api` and `@arr/web`
- [x] `GET /api/jellyfin/analytics/last-watched?mediaType=movie` returns `{"items":[]}` HTTP 200
- [x] `GET /api/plex/analytics/last-watched?mediaType=series&days=7` returns `{"items":[]}` HTTP 200

No browser screenshot — backend-only PR with no rendering changes.

## Up next

- **A4** `aggregateMostConcurrent` — replaces Tautulli `most_concurrent`
- **A5** `aggregatePlaysByDate` — replaces Tautulli `cmd=get_plays_by_date`
- Then **Phase C**: single PR migrating PlexTab's top section off Tautulli, consuming all 5 helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)