### PR TITLE
feat(statistics): most-concurrent aggregator (Option 3 phase 4)

### DIFF
--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -14,6 +14,7 @@ import { aggregateBandwidthAnalytics } from "../plex/lib/bandwidth-analytics-hel
 import { aggregateCodecAnalytics } from "../plex/lib/codec-analytics-helpers.js";
 import { aggregateDeviceAnalytics } from "../plex/lib/device-analytics-helpers.js";
 import { computeForecast } from "../plex/lib/forecast-helpers.js";
+import { aggregateMostConcurrent } from "../plex/lib/most-concurrent-helpers.js";
 import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
 import {
 	aggregateLastWatched,
@@ -539,5 +540,47 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			);
 		}
 		return reply.send(response);
+	});
+
+	// ── Most Concurrent Peaks (snapshot-level, no sessionsJson parse) ──
+	const mostConcurrentQuery = z.object({
+		days: z
+			.string()
+			.optional()
+			.transform((val) => {
+				const n = val ? Number.parseInt(val, 10) : 30;
+				return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+			}),
+		limit: z
+			.string()
+			.optional()
+			.transform((val) => {
+				const n = val ? Number.parseInt(val, 10) : 5;
+				return Number.isFinite(n) && n > 0 ? Math.min(n, 25) : 5;
+			}),
+	});
+
+	app.get("/most-concurrent", async (request, reply) => {
+		const { days, limit } = validateRequest(mostConcurrentQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
+			select: { id: true },
+		});
+
+		if (instances.length === 0) {
+			return reply.send({ peakConcurrent: 0, events: [] });
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
+			select: { capturedAt: true, concurrentStreams: true, totalBandwidth: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		return reply.send(aggregateMostConcurrent(snapshots, { limit }));
 	});
 }

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -17,6 +17,7 @@ import { registerForecastRoutes } from "./forecast-routes.js";
 import { registerIdentityRoutes } from "./identity-routes.js";
 import { registerImageProxyRoutes } from "./image-proxy-routes.js";
 import { registerLastWatchedRoutes } from "./last-watched-routes.js";
+import { registerMostConcurrentRoutes } from "./most-concurrent-routes.js";
 import { registerNowPlayingRoutes } from "./now-playing-routes.js";
 import { registerOAuthRoutes } from "./oauth-routes.js";
 import { registerOnDeckRoutes } from "./on-deck-routes.js";
@@ -59,6 +60,7 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerTopMediaRoutes, { prefix: "/analytics/top-media" });
 	app.register(registerPopularMediaRoutes, { prefix: "/analytics/popular-media" });
 	app.register(registerLastWatchedRoutes, { prefix: "/analytics/last-watched" });
+	app.register(registerMostConcurrentRoutes, { prefix: "/analytics/most-concurrent" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
 	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/lib/most-concurrent-helpers.ts
+++ b/apps/api/src/routes/plex/lib/most-concurrent-helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Most Concurrent Helpers
+ *
+ * Aggregates SessionSnapshot rows into a list of peak concurrent-stream
+ * events. Replaces Tautulli's pre-aggregated home-stat `most_concurrent`.
+ *
+ * Unlike top-media / popular-media / last-watched, this aggregator works
+ * on snapshot top-level fields (concurrentStreams, totalBandwidth,
+ * capturedAt) rather than parsing sessionsJson — every snapshot row
+ * already carries the concurrent count.
+ */
+
+import type { MostConcurrentResponse } from "@arr/shared";
+
+/** Snapshot row required for concurrent-peak aggregation */
+export interface SnapshotForConcurrent {
+	capturedAt: Date;
+	concurrentStreams: number;
+	totalBandwidth: number;
+}
+
+/**
+ * Dedup window: consecutive snapshots within this window of an already-emitted
+ * peak are treated as part of the same peak event. Wider than watch-history's
+ * 10 minutes because concurrent peaks plausibly hold for tens of minutes.
+ */
+const DEDUP_WINDOW_MS = 30 * 60 * 1000;
+
+export function aggregateMostConcurrent(
+	snapshots: SnapshotForConcurrent[],
+	opts: { limit: number },
+): MostConcurrentResponse {
+	if (snapshots.length === 0) {
+		return { peakConcurrent: 0, events: [] };
+	}
+
+	// Walk snapshots ordered by concurrent count DESC. For ties, prefer the
+	// earlier timestamp so the "first time we hit this peak" wins.
+	const ordered = [...snapshots].sort((a, b) => {
+		if (b.concurrentStreams !== a.concurrentStreams) {
+			return b.concurrentStreams - a.concurrentStreams;
+		}
+		return a.capturedAt.getTime() - b.capturedAt.getTime();
+	});
+
+	const peakConcurrent = ordered[0]?.concurrentStreams ?? 0;
+
+	// Emit top-N distinct peak events; collapse consecutive ticks within the
+	// dedup window into a single event so a 30-min peak doesn't dominate the list.
+	const emitted: SnapshotForConcurrent[] = [];
+	for (const snap of ordered) {
+		if (snap.concurrentStreams === 0) break; // ignore idle snapshots
+		const tooCloseToExisting = emitted.some(
+			(e) => Math.abs(e.capturedAt.getTime() - snap.capturedAt.getTime()) <= DEDUP_WINDOW_MS,
+		);
+		if (tooCloseToExisting) continue;
+		emitted.push(snap);
+		if (emitted.length >= opts.limit) break;
+	}
+
+	return {
+		peakConcurrent,
+		events: emitted.map((e) => ({
+			capturedAt: e.capturedAt.toISOString(),
+			concurrentStreams: e.concurrentStreams,
+			totalBandwidth: e.totalBandwidth,
+		})),
+	};
+}

--- a/apps/api/src/routes/plex/most-concurrent-routes.ts
+++ b/apps/api/src/routes/plex/most-concurrent-routes.ts
@@ -1,0 +1,62 @@
+/**
+ * Plex Most Concurrent Routes
+ *
+ * Aggregates SessionSnapshot rows into peak concurrent-stream events.
+ * Replaces Tautulli's pre-aggregated home-stats `most_concurrent`.
+ */
+
+import type { MostConcurrentResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { aggregateMostConcurrent } from "./lib/most-concurrent-helpers.js";
+
+const mostConcurrentQuery = z.object({
+	days: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 30;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+		}),
+	limit: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 5;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 25) : 5;
+		}),
+});
+
+export async function registerMostConcurrentRoutes(
+	app: FastifyInstance,
+	_opts: FastifyPluginOptions,
+) {
+	app.get("/", async (request, reply) => {
+		const { days, limit } = validateRequest(mostConcurrentQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const plexInstances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			select: { id: true },
+		});
+
+		if (plexInstances.length === 0) {
+			const empty: MostConcurrentResponse = { peakConcurrent: 0, events: [] };
+			return reply.send(empty);
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: {
+				instanceId: { in: plexInstances.map((i) => i.id) },
+				capturedAt: { gte: cutoff },
+			},
+			select: { capturedAt: true, concurrentStreams: true, totalBandwidth: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		return reply.send(aggregateMostConcurrent(snapshots, { limit }));
+	});
+}

--- a/apps/web/src/hooks/api/useJellyfin.ts
+++ b/apps/web/src/hooks/api/useJellyfin.ts
@@ -13,6 +13,7 @@ import type {
 	DeviceAnalytics,
 	JellyfinNowPlayingResponse,
 	LibraryItem,
+	MostConcurrentResponse,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
 	TopMediaResponse,
@@ -42,6 +43,7 @@ import {
 	fetchJellyfinEpisodeWatchStatus,
 	fetchJellyfinIdentity,
 	fetchJellyfinLastWatched,
+	fetchJellyfinMostConcurrent,
 	fetchJellyfinNowPlaying,
 	fetchJellyfinOnDeck,
 	fetchJellyfinPopularMedia,
@@ -329,6 +331,15 @@ export const useJellyfinLastWatched = (
 	return useQuery<TopMediaResponse>({
 		queryKey: jellyfinKeys.lastWatched(mediaType, days, limit),
 		queryFn: () => fetchJellyfinLastWatched(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useJellyfinMostConcurrent = (days = 30, limit = 5, enabled = true) => {
+	return useQuery<MostConcurrentResponse>({
+		queryKey: jellyfinKeys.mostConcurrent(days, limit),
+		queryFn: () => fetchJellyfinMostConcurrent(days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/hooks/api/usePlex.ts
+++ b/apps/web/src/hooks/api/usePlex.ts
@@ -13,6 +13,7 @@ import type {
 	CollectionStats,
 	DeviceAnalytics,
 	LibraryItem,
+	MostConcurrentResponse,
 	PlexAccountsResponse,
 	PlexIdentityResponse,
 	PlexNowPlayingResponse,
@@ -42,6 +43,7 @@ import {
 	fetchDeviceAnalytics,
 	fetchEpisodeWatchStatus,
 	fetchLastWatched,
+	fetchMostConcurrent,
 	fetchNowPlaying,
 	fetchOnDeck,
 	fetchPlexAccounts,
@@ -426,6 +428,15 @@ export const useLastWatched = (mediaType: TopMediaType, days = 30, limit = 10, e
 	return useQuery<TopMediaResponse>({
 		queryKey: plexKeys.lastWatched(mediaType, days, limit),
 		queryFn: () => fetchLastWatched(mediaType, days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useMostConcurrent = (days = 30, limit = 5, enabled = true) => {
+	return useQuery<MostConcurrentResponse>({
+		queryKey: plexKeys.mostConcurrent(days, limit),
+		queryFn: () => fetchMostConcurrent(days, limit),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -12,6 +12,7 @@ import type {
 	CodecAnalytics,
 	DeviceAnalytics,
 	JellyfinNowPlayingResponse,
+	MostConcurrentResponse,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
 	TopMediaResponse,
@@ -293,4 +294,11 @@ export async function fetchJellyfinLastWatched(
 	return apiRequest(
 		`/api/jellyfin/analytics/last-watched?mediaType=${mediaType}&days=${days}&limit=${limit}`,
 	);
+}
+
+export async function fetchJellyfinMostConcurrent(
+	days = 30,
+	limit = 5,
+): Promise<MostConcurrentResponse> {
+	return apiRequest(`/api/jellyfin/analytics/most-concurrent?days=${days}&limit=${limit}`);
 }

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -12,6 +12,7 @@ import type {
 	CodecAnalytics,
 	CollectionStats,
 	DeviceAnalytics,
+	MostConcurrentResponse,
 	PlexAccountsResponse,
 	PlexDiscoverServersResponse,
 	PlexEpisodeStatusResponse,
@@ -303,6 +304,11 @@ export async function fetchLastWatched(
 	return apiRequest(
 		`/api/plex/analytics/last-watched?mediaType=${mediaType}&days=${days}&limit=${limit}`,
 	);
+}
+
+/** Fetch peak concurrent-stream events from SessionSnapshot. */
+export async function fetchMostConcurrent(days = 30, limit = 5): Promise<MostConcurrentResponse> {
+	return apiRequest(`/api/plex/analytics/most-concurrent?days=${days}&limit=${limit}`);
 }
 
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -304,6 +304,8 @@ export const plexKeys = {
 		["plex", "popular-media", mediaType, days, limit] as const,
 	lastWatched: (mediaType: string, days: number, limit: number) =>
 		["plex", "last-watched", mediaType, days, limit] as const,
+	mostConcurrent: (days: number, limit: number) =>
+		["plex", "most-concurrent", days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -340,6 +342,8 @@ export const jellyfinKeys = {
 		["jellyfin", "analytics", "popular-media", mediaType, days, limit] as const,
 	lastWatched: (mediaType: string, days: number, limit: number) =>
 		["jellyfin", "analytics", "last-watched", mediaType, days, limit] as const,
+	mostConcurrent: (days: number, limit: number) =>
+		["jellyfin", "analytics", "most-concurrent", days, limit] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -403,6 +403,24 @@ export interface TopMediaResponse {
 }
 
 // ============================================================================
+// Most Concurrent (Tier 1) — replaces Tautulli home-stats most_concurrent
+// ============================================================================
+
+export interface MostConcurrentEntry {
+	/** ISO timestamp of the snapshot tick where this peak was observed */
+	capturedAt: string;
+	concurrentStreams: number;
+	totalBandwidth: number;
+}
+
+export interface MostConcurrentResponse {
+	/** Highest concurrent-stream count seen anywhere in the time window */
+	peakConcurrent: number;
+	/** Top-N peak events, deduped by 30-min proximity so a held peak collapses to one entry */
+	events: MostConcurrentEntry[];
+}
+
+// ============================================================================
 // Bandwidth Forecast (Tier 3)
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Phase A4 of the Tautulli deprecation arc. Aggregates `SessionSnapshot` rows into peak concurrent-stream events. Replaces Tautulli's `most_concurrent` home stat.

| Helper | Source | Tautulli equivalent |
|---|---|---|
| `aggregateTopMedia` (PR #375) | sessionsJson | `top_*` |
| `aggregatePopularMedia` (PR #376) | sessionsJson | `popular_*` |
| `aggregateLastWatched` (PR #377) | sessionsJson | `last_watched` |
| `aggregateMostConcurrent` (this PR) | **snapshot top-level fields** | `most_concurrent` |

## Why this one is different

Unlike A1–A3, this aggregator works on top-level snapshot fields (`concurrentStreams`, `totalBandwidth`, `capturedAt`) rather than parsing `sessionsJson`. Every snapshot row already carries the concurrent count and bandwidth — no per-title aggregation needed. So this gets its own helper file (`most-concurrent-helpers.ts`) rather than extending `top-media-helpers.ts`.

## Dedup design

A 30-minute peak at 10 streams produces 6 consecutive snapshots all reporting "10". Naive top-N would return 6 identical entries.

The helper sorts by `concurrentStreams` DESC, then walks the sorted list and emits an event only if no previously-emitted event is within 30 minutes. This collapses a held peak into a single representative event while still surfacing distinct peak moments. (Wider window than the 10-min watch-history dedup because concurrent peaks plausibly hold for tens of minutes.)

Ties on `concurrentStreams` prefer the earlier timestamp — "the first time we hit this peak" wins.

## What changed

- **Backend:** `aggregateMostConcurrent` helper, new shared types `MostConcurrentEntry` + `MostConcurrentResponse`, new routes `GET /api/{plex,jellyfin}/analytics/most-concurrent`
- **Frontend:** API client fetchers, `useMostConcurrent` / `useJellyfinMostConcurrent` hooks, query keys

## Why no UI in this PR

The existing `BandwidthChart` already shows `peakConcurrent` as a stat card; this aggregator adds the *when* and a top-N list. Phase C is the right place to either enrich `BandwidthChart` with timestamps or add a small "peak events" card next to it. Hooks are wired and ready.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean across `@arr/api` and `@arr/web`
- [x] `GET /api/jellyfin/analytics/most-concurrent` returns `{"peakConcurrent":0,"events":[]}` HTTP 200
- [x] `GET /api/plex/analytics/most-concurrent?days=7&limit=3` returns `{"peakConcurrent":0,"events":[]}` HTTP 200

## Up next

- **A5** `aggregatePlaysByDate` — replaces Tautulli `cmd=get_plays_by_date` (per-day plays segmented by mediaType)
- Then **Phase C**: single PR migrating PlexTab's top section off Tautulli

🤖 Generated with [Claude Code](https://claude.com/claude-code)