### PR TITLE
feat(statistics): plays-by-date aggregator (Option 3 phase 5 — final helper)

### DIFF
--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -15,6 +15,7 @@ import { aggregateCodecAnalytics } from "../plex/lib/codec-analytics-helpers.js"
 import { aggregateDeviceAnalytics } from "../plex/lib/device-analytics-helpers.js";
 import { computeForecast } from "../plex/lib/forecast-helpers.js";
 import { aggregateMostConcurrent } from "../plex/lib/most-concurrent-helpers.js";
+import { aggregatePlaysByDate } from "../plex/lib/plays-by-date-helpers.js";
 import { computeQualityScore } from "../plex/lib/quality-score-helpers.js";
 import {
 	aggregateLastWatched,
@@ -582,5 +583,40 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 		});
 
 		return reply.send(aggregateMostConcurrent(snapshots, { limit }));
+	});
+
+	// ── Plays By Date (per-day plays, segmented by mediaType) ──────
+	const playsByDateQuery = z.object({
+		days: z
+			.string()
+			.optional()
+			.transform((val) => {
+				const n = val ? Number.parseInt(val, 10) : 30;
+				return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+			}),
+	});
+
+	app.get("/plays-by-date", async (request, reply) => {
+		const { days } = validateRequest(playsByDateQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
+			select: { id: true },
+		});
+
+		if (instances.length === 0) {
+			return reply.send({ categories: [], series: [] });
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		return reply.send(aggregatePlaysByDate(snapshots, { days }));
 	});
 }

--- a/apps/api/src/routes/plex/index.ts
+++ b/apps/api/src/routes/plex/index.ts
@@ -21,6 +21,7 @@ import { registerMostConcurrentRoutes } from "./most-concurrent-routes.js";
 import { registerNowPlayingRoutes } from "./now-playing-routes.js";
 import { registerOAuthRoutes } from "./oauth-routes.js";
 import { registerOnDeckRoutes } from "./on-deck-routes.js";
+import { registerPlaysByDateRoutes } from "./plays-by-date-routes.js";
 import { registerPopularMediaRoutes } from "./popular-media-routes.js";
 import { registerQualityScoreRoutes } from "./quality-score-routes.js";
 import { registerRecentlyAddedRoutes } from "./recently-added-routes.js";
@@ -61,6 +62,7 @@ export async function registerPlexRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.register(registerPopularMediaRoutes, { prefix: "/analytics/popular-media" });
 	app.register(registerLastWatchedRoutes, { prefix: "/analytics/last-watched" });
 	app.register(registerMostConcurrentRoutes, { prefix: "/analytics/most-concurrent" });
+	app.register(registerPlaysByDateRoutes, { prefix: "/analytics/plays-by-date" });
 	app.register(registerImageProxyRoutes, { prefix: "/thumb" });
 	app.register(registerOAuthRoutes, { prefix: "/oauth" });
 }

--- a/apps/api/src/routes/plex/lib/plays-by-date-helpers.ts
+++ b/apps/api/src/routes/plex/lib/plays-by-date-helpers.ts
@@ -1,0 +1,119 @@
+/**
+ * Plays By Date Helpers
+ *
+ * Aggregates SessionSnapshot rows into per-day play counts segmented by
+ * media type. Replaces Tautulli's pre-aggregated `cmd=get_plays_by_date`.
+ *
+ * Output shape mirrors Tautulli's so PlexTab's existing sparkline rendering
+ * can consume it without changes:
+ *
+ *   { categories: ["2026-04-01", ...],  // full date range, ascending
+ *     series: [ { name: "Movies", data: [3, 5, ...] }, ... ] }
+ *
+ * Each "play" is a deduped user×title viewing session (10-min window),
+ * attributed to the date of its first observed tick.
+ */
+
+import type { PlaysByDateResponse } from "@arr/shared";
+
+type SnapshotMediaType = "movie" | "series" | "music" | "other";
+type SeriesMediaType = "movie" | "series" | "music";
+
+/** Snapshot row required for plays-by-date aggregation */
+export interface SnapshotForPlaysByDate {
+	capturedAt: Date;
+	sessionsJson: string;
+}
+
+interface ParsedSession {
+	user?: string;
+	title?: string;
+	grandparentTitle?: string;
+	mediaType?: SnapshotMediaType;
+}
+
+const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const SERIES_NAME: Record<SeriesMediaType, string> = {
+	movie: "Movies",
+	series: "TV",
+	music: "Music",
+};
+
+/** Format a Date as YYYY-MM-DD (UTC). Same convention as user-analytics-helpers. */
+function dateKey(d: Date): string {
+	return d.toISOString().split("T")[0]!;
+}
+
+function deriveGroupingTitle(session: ParsedSession): string | null {
+	if (session.mediaType === "series") {
+		return session.grandparentTitle ?? session.title ?? null;
+	}
+	return session.title ?? null;
+}
+
+export function aggregatePlaysByDate(
+	snapshots: SnapshotForPlaysByDate[],
+	opts: { days: number; now?: Date },
+): PlaysByDateResponse {
+	const now = opts.now ?? new Date();
+	const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+	const start = new Date(today.getTime() - (opts.days - 1) * DAY_MS);
+
+	// Build the full date range (cutoff..today, inclusive)
+	const categories: string[] = [];
+	for (let t = start.getTime(); t <= today.getTime(); t += DAY_MS) {
+		categories.push(dateKey(new Date(t)));
+	}
+	const dateIndex = new Map(categories.map((d, i) => [d, i]));
+
+	// counts[mediaType][dateIndex] = play count
+	const counts: Record<SeriesMediaType, number[]> = {
+		movie: new Array(categories.length).fill(0),
+		series: new Array(categories.length).fill(0),
+		music: new Array(categories.length).fill(0),
+	};
+
+	const lastPlayAnchorByUserKey = new Map<string, number>();
+
+	// Walk snapshots ASC so the dedup anchor moves forward in time
+	const ordered = [...snapshots].sort((a, b) => a.capturedAt.getTime() - b.capturedAt.getTime());
+
+	for (const snap of ordered) {
+		let sessions: ParsedSession[];
+		try {
+			sessions = JSON.parse(snap.sessionsJson);
+		} catch {
+			continue;
+		}
+
+		const idx = dateIndex.get(dateKey(snap.capturedAt));
+		if (idx === undefined) continue; // outside the window
+
+		for (const session of sessions) {
+			const mt = session.mediaType;
+			if (mt !== "movie" && mt !== "series" && mt !== "music") continue;
+
+			const groupingTitle = deriveGroupingTitle(session);
+			if (!groupingTitle) continue;
+
+			const userKey = `${groupingTitle}::${session.user ?? "Unknown"}`;
+			const tickTime = snap.capturedAt.getTime();
+			const prevAnchor = lastPlayAnchorByUserKey.get(userKey);
+			const isNewPlay = prevAnchor === undefined || tickTime - prevAnchor > DEDUP_WINDOW_MS;
+
+			if (isNewPlay) {
+				counts[mt][idx] = (counts[mt][idx] ?? 0) + 1;
+			}
+			lastPlayAnchorByUserKey.set(userKey, tickTime);
+		}
+	}
+
+	const series = (["movie", "series", "music"] as const).map((mt) => ({
+		name: SERIES_NAME[mt],
+		data: counts[mt],
+	}));
+
+	return { categories, series };
+}

--- a/apps/api/src/routes/plex/plays-by-date-routes.ts
+++ b/apps/api/src/routes/plex/plays-by-date-routes.ts
@@ -1,0 +1,52 @@
+/**
+ * Plex Plays By Date Routes
+ *
+ * Aggregates SessionSnapshot rows into per-day play counts segmented by
+ * media type. Replaces Tautulli's pre-aggregated `cmd=get_plays_by_date`.
+ */
+
+import type { PlaysByDateResponse } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { aggregatePlaysByDate } from "./lib/plays-by-date-helpers.js";
+
+const playsByDateQuery = z.object({
+	days: z
+		.string()
+		.optional()
+		.transform((val) => {
+			const n = val ? Number.parseInt(val, 10) : 30;
+			return Number.isFinite(n) && n > 0 ? Math.min(n, 90) : 30;
+		}),
+});
+
+export async function registerPlaysByDateRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/", async (request, reply) => {
+		const { days } = validateRequest(playsByDateQuery, request.query);
+		const userId = request.currentUser!.id;
+
+		const plexInstances = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			select: { id: true },
+		});
+
+		if (plexInstances.length === 0) {
+			const empty: PlaysByDateResponse = { categories: [], series: [] };
+			return reply.send(empty);
+		}
+
+		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		const snapshots = await app.prisma.sessionSnapshot.findMany({
+			where: {
+				instanceId: { in: plexInstances.map((i) => i.id) },
+				capturedAt: { gte: cutoff },
+			},
+			select: { capturedAt: true, sessionsJson: true },
+			orderBy: { capturedAt: "asc" },
+			take: 50000,
+		});
+
+		return reply.send(aggregatePlaysByDate(snapshots, { days }));
+	});
+}

--- a/apps/web/src/hooks/api/useJellyfin.ts
+++ b/apps/web/src/hooks/api/useJellyfin.ts
@@ -14,6 +14,7 @@ import type {
 	JellyfinNowPlayingResponse,
 	LibraryItem,
 	MostConcurrentResponse,
+	PlaysByDateResponse,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
 	TopMediaResponse,
@@ -46,6 +47,7 @@ import {
 	fetchJellyfinMostConcurrent,
 	fetchJellyfinNowPlaying,
 	fetchJellyfinOnDeck,
+	fetchJellyfinPlaysByDate,
 	fetchJellyfinPopularMedia,
 	fetchJellyfinQualityScore,
 	fetchJellyfinRecentlyAdded,
@@ -340,6 +342,15 @@ export const useJellyfinMostConcurrent = (days = 30, limit = 5, enabled = true) 
 	return useQuery<MostConcurrentResponse>({
 		queryKey: jellyfinKeys.mostConcurrent(days, limit),
 		queryFn: () => fetchJellyfinMostConcurrent(days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const useJellyfinPlaysByDate = (days = 30, enabled = true) => {
+	return useQuery<PlaysByDateResponse>({
+		queryKey: jellyfinKeys.playsByDate(days),
+		queryFn: () => fetchJellyfinPlaysByDate(days),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/hooks/api/usePlex.ts
+++ b/apps/web/src/hooks/api/usePlex.ts
@@ -14,6 +14,7 @@ import type {
 	DeviceAnalytics,
 	LibraryItem,
 	MostConcurrentResponse,
+	PlaysByDateResponse,
 	PlexAccountsResponse,
 	PlexIdentityResponse,
 	PlexNowPlayingResponse,
@@ -46,6 +47,7 @@ import {
 	fetchMostConcurrent,
 	fetchNowPlaying,
 	fetchOnDeck,
+	fetchPlaysByDate,
 	fetchPlexAccounts,
 	fetchPlexCollections,
 	fetchPlexIdentity,
@@ -437,6 +439,15 @@ export const useMostConcurrent = (days = 30, limit = 5, enabled = true) => {
 	return useQuery<MostConcurrentResponse>({
 		queryKey: plexKeys.mostConcurrent(days, limit),
 		queryFn: () => fetchMostConcurrent(days, limit),
+		staleTime: 5 * 60_000,
+		enabled,
+	});
+};
+
+export const usePlaysByDate = (days = 30, enabled = true) => {
+	return useQuery<PlaysByDateResponse>({
+		queryKey: plexKeys.playsByDate(days),
+		queryFn: () => fetchPlaysByDate(days),
 		staleTime: 5 * 60_000,
 		enabled,
 	});

--- a/apps/web/src/lib/api-client/jellyfin.ts
+++ b/apps/web/src/lib/api-client/jellyfin.ts
@@ -13,6 +13,7 @@ import type {
 	DeviceAnalytics,
 	JellyfinNowPlayingResponse,
 	MostConcurrentResponse,
+	PlaysByDateResponse,
 	QualityScoreAnalytics,
 	SeriesProgressResponse,
 	TopMediaResponse,
@@ -301,4 +302,8 @@ export async function fetchJellyfinMostConcurrent(
 	limit = 5,
 ): Promise<MostConcurrentResponse> {
 	return apiRequest(`/api/jellyfin/analytics/most-concurrent?days=${days}&limit=${limit}`);
+}
+
+export async function fetchJellyfinPlaysByDate(days = 30): Promise<PlaysByDateResponse> {
+	return apiRequest(`/api/jellyfin/analytics/plays-by-date?days=${days}`);
 }

--- a/apps/web/src/lib/api-client/plex.ts
+++ b/apps/web/src/lib/api-client/plex.ts
@@ -13,6 +13,7 @@ import type {
 	CollectionStats,
 	DeviceAnalytics,
 	MostConcurrentResponse,
+	PlaysByDateResponse,
 	PlexAccountsResponse,
 	PlexDiscoverServersResponse,
 	PlexEpisodeStatusResponse,
@@ -309,6 +310,11 @@ export async function fetchLastWatched(
 /** Fetch peak concurrent-stream events from SessionSnapshot. */
 export async function fetchMostConcurrent(days = 30, limit = 5): Promise<MostConcurrentResponse> {
 	return apiRequest(`/api/plex/analytics/most-concurrent?days=${days}&limit=${limit}`);
+}
+
+/** Fetch per-day play counts segmented by media type. */
+export async function fetchPlaysByDate(days = 30): Promise<PlaysByDateResponse> {
+	return apiRequest(`/api/plex/analytics/plays-by-date?days=${days}`);
 }
 
 // ============================================================================

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -306,6 +306,7 @@ export const plexKeys = {
 		["plex", "last-watched", mediaType, days, limit] as const,
 	mostConcurrent: (days: number, limit: number) =>
 		["plex", "most-concurrent", days, limit] as const,
+	playsByDate: (days: number) => ["plex", "plays-by-date", days] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -344,6 +345,7 @@ export const jellyfinKeys = {
 		["jellyfin", "analytics", "last-watched", mediaType, days, limit] as const,
 	mostConcurrent: (days: number, limit: number) =>
 		["jellyfin", "analytics", "most-concurrent", days, limit] as const,
+	playsByDate: (days: number) => ["jellyfin", "analytics", "plays-by-date", days] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -403,6 +403,23 @@ export interface TopMediaResponse {
 }
 
 // ============================================================================
+// Plays By Date (Tier 1) — replaces Tautulli cmd=get_plays_by_date
+// ============================================================================
+
+export interface PlaysByDateSeries {
+	/** Display name — "Movies" | "TV" | "Music". Matches the legacy Tautulli shape. */
+	name: string;
+	/** One entry per date in `categories`, in the same order. */
+	data: number[];
+}
+
+export interface PlaysByDateResponse {
+	/** Date strings (YYYY-MM-DD) covering the full window, ascending. */
+	categories: string[];
+	series: PlaysByDateSeries[];
+}
+
+// ============================================================================
 // Most Concurrent (Tier 1) — replaces Tautulli home-stats most_concurrent
 // ============================================================================
 


### PR DESCRIPTION
## Summary

Phase A5 of the Tautulli deprecation arc. **Last aggregator helper.** Phase C (PlexTab migration) is unblocked after this lands.

| Helper | Source | Tautulli equivalent |
|---|---|---|
| `aggregateTopMedia` (PR #375) | sessionsJson | `top_*` |
| `aggregatePopularMedia` (PR #376) | sessionsJson | `popular_*` |
| `aggregateLastWatched` (PR #377) | sessionsJson | `last_watched` |
| `aggregateMostConcurrent` (PR #378) | snapshot top-level fields | `most_concurrent` |
| `aggregatePlaysByDate` (this PR) | sessionsJson + capturedAt | `cmd=get_plays_by_date` |

## Why this one straddles patterns

A1–A3 shared `buildMediaAggregate` because they all group by title. A4 used snapshot top-level fields with no parsing. **A5 needs both**: it parses `sessionsJson` (to know mediaType) but groups by date+mediaType — so it gets its own helper file with the same dedup pattern.

## Output shape matches Tautulli exactly

```json
{
  "categories": ["2026-04-01", "2026-04-02", ...],
  "series": [
    { "name": "Movies", "data": [3, 5, ...] },
    { "name": "TV", "data": [...] },
    { "name": "Music", "data": [...] }
  ]
}
```

PlexTab's existing per-media-type sparklines consume this exact shape from `useTautulliPlaysByDate` today. Phase C will swap the hook with no rendering changes.

## Implementation notes

- **Date range fill:** generates `categories` from `cutoff` to `today` (UTC, inclusive), zero-filling days with no plays. Without this, sparklines render gaps for sparse data.
- **Dedup:** 10-min window per user×title (same as `buildMediaAggregate`). Each play is attributed once, to the date of its first observed tick.
- **Walk direction:** ASC by `capturedAt` so the dedup anchor moves forward in time deterministically.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean across `@arr/api`, `@arr/shared`, `@arr/web`
- [x] `GET /api/jellyfin/analytics/plays-by-date?days=7` returns 7 categories + 3 zero-filled series, HTTP 200
- [x] `GET /api/plex/analytics/plays-by-date?days=3` returns empty arrays (no Plex instances in test env; correct early-return)

## Up next: Phase C (final PR)

With all 5 helpers in place, the next PR is the PlexTab migration:
1. Replace `useTautulliStats` with composition of `useTopMedia` + `usePopularMedia` + `useLastWatched` + `useMostConcurrent`
2. Replace `useTautulliPlaysByDate` with `usePlaysByDate`
3. Relax tab gate from `hasTautulli` to `hasPlex`
4. Optionally surface a "Tautulli enrichment present" indicator (LAN/WAN, richer codec metadata) when configured
5. Same chart components and layout — Phase C is purely a data-source swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)