### PR TITLE
docs: surface Tautulli-now-optional across changelog, README, DOCKERHUB, UI hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Statistics overhaul: Jellyfin/Emby parity + Tautulli is now optional.** The Statistics page gains a full Jellyfin/Emby tab matching the Plex feature set, and the Plex tab no longer requires Tautulli — all leaderboards and analytics now flow from the dashboard's own SessionSnapshot capture (every 5 minutes during active streams) rather than Tautulli's pre-aggregated home-stats. Tautulli stays around as an *optional enrichment source* that adds richer codec, LAN/WAN bandwidth, and platform metadata when configured; without it, snapshot-driven data still populates the same charts.
+
+### Added
+
+- **Jellyfin/Emby analytics tab** — Statistics page now has a "Jellyfin" tab matching the Plex feature set: 6 leaderboards (top movies/shows/music + most-popular movies/shows/music), transcode/codec/device breakdowns, user analytics, watch history, quality score, bandwidth forecast. Gates on having any enabled Jellyfin or Emby instance. Source-agnostic chart components were extracted from the existing Plex chart implementations, parameterized by `service` for theming and messaging (#374).
+- **`aggregateTopMedia` helper** — top-N most-played titles per media type, deduped per user×title within a 10-minute window (matches Tautulli's play-counting semantics). Replaces Tautulli `top_movies / top_tv / top_music` (#375).
+- **`aggregatePopularMedia` helper** — top-N titles by distinct watcher count, surfacing broadly-loved titles vs. items one user rewatches obsessively. Replaces Tautulli `popular_*` (#376).
+- **`aggregateLastWatched` helper** — most-recently-watched titles deduped by title, sorted by recency. Replaces Tautulli `last_watched` (#377).
+- **`aggregateMostConcurrent` helper** — peak concurrent-stream events deduped by 30-minute proximity. Works on snapshot top-level fields (no `sessionsJson` parse). Replaces Tautulli `most_concurrent` (#378).
+- **`aggregatePlaysByDate` helper** — per-day play counts segmented by media type with full date-range zero-fill so sparklines render cleanly even for sparse data. Replaces Tautulli `cmd=get_plays_by_date` (#379).
+- **Tautulli enrichment indicator** — when a Tautulli instance is configured, the Plex tab's source banner now shows an explicit "Tautulli enrichment active" line explaining that codec/LAN-WAN/platform metadata is enriched on captured sessions (#380).
+
+### Changed
+
+- **Plex tab no longer requires Tautulli.** Tab visibility gates on `hasPlex` (any enabled Plex instance) instead of `hasTautulli`. Plex-only users — previously locked out of the Statistics tab — now see the full analytics surface (#380).
+- **Plex tab structure now mirrors Jellyfin tab.** Both render 14 cards (3 Top + 3 Most Popular + 8 SessionSnapshot analytics) sourced from the same shared aggregation helpers. The dynamic Tautulli `homeStatSections` rendering loop and Tautulli summary cards are removed in favor of the unified leaderboard shape (#380).
+- **`EnrichedSession` schema extended** with optional `mediaType` and `grandparentTitle` fields so leaderboards can group TV episodes by show name. Backward compatible — pre-extension snapshots are skipped from leaderboards rather than misclassified (#375).
+
+### Behavior matrix
+
+| User has | Plex tab visible | Source banner |
+|---|---|---|
+| Plex only | ✅ (was ❌) | "Captured from Plex session snapshots…" |
+| Plex + Tautulli | ✅ | "…Tautulli enrichment active — codec, LAN/WAN bandwidth, and platform metadata are enriched…" |
+| Jellyfin/Emby only | n/a (Jellyfin tab visible) | unchanged |
+
+### Notes
+
+- `useTautulliStats` and `useTautulliPlaysByDate` hooks remain in the codebase. They're no longer consumed by the Plex tab but stay available for the OverviewTab's optional Tautulli card and any future Tautulli-admin surface.
+- Leaderboards take a few hours to populate after deploy as new SessionSnapshot rows accrue. Pre-deployment snapshots lack the new `mediaType` field and are skipped from leaderboards (the helpers gracefully degrade rather than misclassify).
+
 ## [2.16.2] - 2026-04-28
 
 **Security patch release.** Closes 8 open code-scanning alerts (1 HIGH-severity Fastify body-schema bypass + 4 medium-severity DOMPurify sanitization issues + 1 GitHub Actions shell-injection vector + 2 transitive hono/postcss vulnerabilities) and 6 Dependabot security advisories. Also adds a small TRaSH Guides feature (migration notices for upstream CF-group restructures) and removes a class of spurious diagnostic warnings. No schema or API breaking changes.

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -37,7 +37,7 @@ services:
 ## Features
 
 - **Unified Dashboard** — Queue, calendar, history, and statistics across all Sonarr, Radarr, Prowlarr, Lidarr, and Readarr instances
-- **Plex & Tautulli Integration** — Now playing, watch history, on deck, recently added, and detailed analytics with user/device/codec charts
+- **Plex Integration** — Now playing, watch history, on deck, recently added, and detailed analytics with leaderboards (top + most-popular) and user/device/codec charts. Tautulli is now optional enrichment, not required
 - **Jellyfin & Emby Integration** — Full media server parity with Plex, sourced directly from native APIs (no Tautulli-equivalent required)
 - **Seerr** — Manage media requests, users, issues, and notification agents, with optional auto-setup via Plex sign-in
 - **Global Search** — Search for content across all indexers via Prowlarr

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, 
 - **Now Playing** — Real-time view of active Plex streams with user avatars, progress bars, transcode/direct play indicators, and bandwidth metrics
 - **Continue Watching / On Deck** — See what's queued up next across your Plex libraries
 - **Recently Added** — Latest additions to your Plex library with poster thumbnails
-- **Watch History** — Historical watch data enriched with Tautulli analytics
-- **Plex Statistics** — Dedicated stats tab with user analytics, device breakdown, codec distribution, bandwidth forecasting, quality scores, and daily activity charts
+- **Watch History** — Historical watch data captured every 5 minutes from active sessions; enriched with codec/LAN-WAN/platform metadata when Tautulli is configured
+- **Plex Statistics** — Dedicated stats tab with leaderboards (top + most-popular per media type), user analytics, device breakdown, codec distribution, bandwidth forecasting, quality scores, and daily activity charts. **Works without Tautulli** — analytics flow from the dashboard's own session-snapshot capture; Tautulli adds optional enrichment
 - **Library Enrichment** — Watch status, play counts, and last-watched dates shown on library items
 - **Connect with Plex** — OAuth-assisted setup discovers your reachable Plex servers and auto-fills the URL and token
 
@@ -200,7 +200,7 @@ docker-compose up -d
 | **Lidarr** | Full | Queue, calendar, library, history, statistics, hunting |
 | **Readarr** | Full | Queue, calendar, library, history, statistics, hunting |
 | **Plex** | Full | Now playing, on deck, recently added, watch history, library enrichment, OAuth setup |
-| **Tautulli** | Full | Activity monitoring, watch statistics, bandwidth analytics |
+| **Tautulli** | Optional enrichment | Adds richer codec/LAN-WAN/platform metadata to Plex session snapshots. Plex analytics work without it |
 | **Jellyfin** | Full | Now playing, on deck, recently added, watch history, native analytics, library cleanup |
 | **Emby** | Full | Shares Jellyfin backend — same capabilities, same setup flow |
 | **Seerr** | Full | Requests, users, issues, notification agents, optional Plex sign-in auto-setup |

--- a/apps/web/src/features/settings/components/getting-started-banner.tsx
+++ b/apps/web/src/features/settings/components/getting-started-banner.tsx
@@ -10,8 +10,8 @@
 
 import type { ServiceInstanceSummary } from "@arr/shared";
 import { ArrowRight, Server } from "lucide-react";
-import { useIncognitoMode } from "../../../lib/incognito";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { useIncognitoMode } from "../../../lib/incognito";
 import { getServiceGradient } from "../../../lib/theme-gradients";
 import type { ServiceType } from "../lib/settings-constants";
 
@@ -55,7 +55,8 @@ const SETUP_STEPS: SetupStep[] = [
 	{
 		service: "tautulli",
 		label: "Tautulli",
-		description: "Plex analytics — API key from Settings > Web Interface",
+		description:
+			"Optional Plex enrichment — adds richer codec/LAN-WAN/platform metadata. Plex analytics work without it.",
 		hasHelper: false,
 	},
 	{


### PR DESCRIPTION
## Summary

**Phase D — the announcement layer for the Tautulli deprecation arc.** Code changes landed in PRs #374–#380; this PR makes the outcome legible to users who haven't read the commit log.

## What changed

### `CHANGELOG.md`
New `[Unreleased]` section summarizing the full arc:
- 6 PRs of work documented (Jellyfin tab + 5 aggregators + PlexTab migration)
- Behavior matrix showing the headline change: **"Plex only" users now see the Statistics tab** (was hidden because gated on Tautulli)
- "Notes" call-out explaining that leaderboards take a few hours to populate post-deploy as new SessionSnapshot rows accrue with the extended `EnrichedSession` schema

### `README.md`
- "Plex & Tautulli Integration" section reframed: data is captured every 5 min from active sessions; Tautulli enriches when configured
- Service capability table: Tautulli row goes from `Full` to `Optional enrichment`

### `DOCKERHUB.md`
Same reframing in the integration bullet so Docker Hub users see the change at install time.

### `getting-started-banner.tsx`
Tautulli onboarding description changes from:
> "Plex analytics — API key from Settings > Web Interface"

to:
> "Optional Plex enrichment — adds richer codec/LAN-WAN/platform metadata. Plex analytics work without it."

Users configuring services for the first time now know what they're trading off.

## Why label `release:patch-batch`

Pure docs + a UI string change. Zero functional changes. Goes in the next patch release.

## Out of scope

- Removing dead `useTautulliStats` / `useTautulliPlaysByDate` hooks (still consumed by OverviewTab's optional Tautulli card)
- Adding a per-service info hint in `service-form.tsx` on Tautulli select — the getting-started-banner already conveys this; adding a duplicate hint in service-form would feel naggy
- CLAUDE.md update calling out Option 3 patterns for future contributors (could be a separate dev-docs PR)

## Verified

- [x] `tsc --noEmit` clean across `@arr/api` and `@arr/web` (markdown changes don't affect typing, but the small TSX edit was checked)
- [x] CHANGELOG markdown renders correctly (Keep-a-Changelog format preserved)
- [x] No code paths broken — this PR is read-only for runtime behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)