### PR TITLE
fix(stats): close two silent-failure paths in analytics aggregators

### DIFF
--- a/apps/api/src/routes/plex/lib/plays-by-date-helpers.ts
+++ b/apps/api/src/routes/plex/lib/plays-by-date-helpers.ts
@@ -81,17 +81,22 @@ export function aggregatePlaysByDate(
 	const ordered = [...snapshots].sort((a, b) => a.capturedAt.getTime() - b.capturedAt.getTime());
 
 	for (const snap of ordered) {
-		let sessions: ParsedSession[];
+		let sessions: unknown;
 		try {
 			sessions = JSON.parse(snap.sessionsJson);
 		} catch {
 			continue;
 		}
 
+		// Guard against valid-but-non-iterable JSON (null, {}, number, ...).
+		// Without this a corrupt row throws TypeError on for-of and aborts
+		// the entire snapshot walk silently.
+		if (!Array.isArray(sessions)) continue;
+
 		const idx = dateIndex.get(dateKey(snap.capturedAt));
 		if (idx === undefined) continue; // outside the window
 
-		for (const session of sessions) {
+		for (const session of sessions as ParsedSession[]) {
 			const mt = session.mediaType;
 			if (mt !== "movie" && mt !== "series" && mt !== "music") continue;
 

--- a/apps/api/src/routes/plex/lib/top-media-helpers.ts
+++ b/apps/api/src/routes/plex/lib/top-media-helpers.ts
@@ -97,16 +97,23 @@ function buildMediaAggregate(
 	const ordered = [...snapshots].sort((a, b) => b.capturedAt.getTime() - a.capturedAt.getTime());
 
 	for (const snap of ordered) {
-		let sessions: ParsedSession[];
+		let sessions: unknown;
 		try {
 			sessions = JSON.parse(snap.sessionsJson);
 		} catch {
 			parseFailures++;
-			if (failedPreviews.length < 5) failedPreviews.push(snap.sessionsJson.slice(0, 100));
 			continue;
 		}
 
-		for (const session of sessions) {
+		// JSON.parse can return any valid JSON value (null, object, number, ...)
+		// — guard against non-iterable shapes so a corrupt row doesn't TypeError
+		// and abort the whole snapshot walk silently.
+		if (!Array.isArray(sessions)) {
+			parseFailures++;
+			continue;
+		}
+
+		for (const session of sessions as ParsedSession[]) {
 			// Skip rows missing the new fields (snapshots written before 2026-04 enrichment)
 			if (session.mediaType === undefined || session.mediaType !== mediaType) continue;
 


### PR DESCRIPTION
## Summary

Pre-release hardening based on automated code/security review of the Option 3 arc (PRs #374–#381). Two findings, both in helpers added by that arc.

## Findings addressed

### 1. Silent crash on non-iterable JSON (high-confidence helpers review finding)

**Files:** `top-media-helpers.ts`, `plays-by-date-helpers.ts`

`for (const session of sessions)` was *outside* the `try/catch` around `JSON.parse`. If `sessionsJson` parses to a valid-but-non-array value (`null`, `{}`, a number — possible from a corrupted row or future schema drift), the for-of throws `TypeError` and aborts the entire snapshot walk. Every subsequent snapshot dropped silently — no `parseFailures` increment, no log, just an empty leaderboard.

**Fix:** added `if (!Array.isArray(sessions)) { parseFailures++; continue; }` after each `JSON.parse`. Subsequent iteration uses `as ParsedSession[]` since `Array.isArray` has proven the runtime shape.

### 2. Session content leaking into pino logs (security review 🟡)

**File:** `top-media-helpers.ts`

The helper was accumulating up to 5 100-character slices of malformed `sessionsJson` into `failedPreviews`. The route handler emitted them via `request.log.warn({...failedPreviews})`. `sessionsJson` embeds titles, usernames, and instance metadata — exactly the fields incognito-mode anonymizes. If the operator ships pino logs to a third-party aggregator, partial session payloads leak.

Single-admin threat model partially mitigates this, but the fix is trivial.

**Fix:** stopped populating `failedPreviews`. The field stays in the `AggregationMeta` return type for API compatibility — it's just always empty now. Routes that log it now log `[]`.

## Out of scope

The same `failedPreviews.push(snap.sessionsJson.slice(0, 100))` pattern exists in older helpers (`watch-history-helpers.ts`, `codec-analytics-helpers.ts`, `device-analytics-helpers.ts`, `user-analytics-helpers.ts`, `quality-score-helpers.ts`). That's a **pre-existing project-wide issue** that the security review surfaced via my new helpers; this PR only fixes the new helpers per the "no broad refactors" project rule. Will file a follow-up for the older ones.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean
- [x] Diff is +17 / -5 across 2 files — minimal blast radius

## Why `release:patch-batch`

Defensive hardening, not an urgent fix. Single-admin context bounds the realistic threat surface for both findings. Should ship in the next batched patch release alongside the Option 3 arc — releasing v2.17.0 with known silent-failure modes would be a regression risk that bites later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)