### PR TITLE
chore: v2.17.0 release — changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.17.0] - 2026-04-29
 
 **Statistics overhaul: Jellyfin/Emby parity + Tautulli is now optional.** The Statistics page gains a full Jellyfin/Emby tab matching the Plex feature set, and the Plex tab no longer requires Tautulli — all leaderboards and analytics now flow from the dashboard's own SessionSnapshot capture (every 5 minutes during active streams) rather than Tautulli's pre-aggregated home-stats. Tautulli stays around as an *optional enrichment source* that adds richer codec, LAN/WAN bandwidth, and platform metadata when configured; without it, snapshot-driven data still populates the same charts.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.16.2 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.17.0 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.16.2** — Security patch: Fastify HIGH bypass + DOMPurify/hono/postcss vulnerabilities patched; GitHub Actions shell-injection vector closed; TRaSH Guides migration notices for upstream CF-group restructures
+> **Version 2.17.0** — Statistics overhaul: full Jellyfin/Emby analytics tab; Plex tab no longer requires Tautulli; 5 SessionSnapshot-derived leaderboards (top + popular media, last-watched, most-concurrent, plays-by-date) replace Tautulli's pre-aggregations
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -93,6 +93,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |
 | `2.16.2` | Security patch — Fastify HIGH bypass + DOMPurify/hono/postcss fixes; workflow shell-injection closed; TRaSH migration notices |
 | `2.16.1` | Reverse-proxy link resolution in Statistics / Calendar / History / Library; Calendar layout stability |
 | `2.16.0` | Needs Attention, inline Pulse actions (Enable / Refresh now / Retry), media-server reachability, duplicate banner cleanup |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.16.2** — Security patch: Fastify HIGH bypass + DOMPurify/hono/postcss vulnerabilities patched; GitHub Actions shell-injection vector closed; TRaSH Guides migration notices for upstream CF-group restructures
+> **Version 2.17.0** — Statistics overhaul: full Jellyfin/Emby analytics tab; Plex tab no longer requires Tautulli; 5 SessionSnapshot-derived leaderboards (top + popular media, last-watched, most-concurrent, plays-by-date) replace Tautulli's pre-aggregations
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -210,6 +210,7 @@ docker-compose up -d
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |
 | `2.16.2` | Security patch — Fastify HIGH bypass + DOMPurify/hono/postcss fixes; workflow shell-injection closed; TRaSH migration notices |
 | `2.16.1` | Reverse-proxy link resolution in Statistics / Calendar / History / Library; Calendar layout stability |
 | `2.16.0` | Needs Attention, inline Pulse actions (Enable / Refresh now / Retry), media-server reachability, duplicate banner cleanup |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.16.2",
+	"version": "2.17.0",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

Release prep for **v2.17.0** — the Statistics overhaul / Tautulli deprecation arc.

Promotes the `[Unreleased]` CHANGELOG section to `[2.17.0] - 2026-04-29` and bumps version references across `package.json`, `README.md`, `DOCKERHUB.md`, and `CLAUDE.md`. Wiki bumps committed separately to `arr-dashboard.wiki.git` (`c324b3e`).

## What's in v2.17.0

10 merged PRs since v2.16.2:

| PR | Title |
|---|---|
| #373 | docs(release): release-bucketing scope step + /release-ops command |
| #374 | feat(statistics): Jellyfin/Emby analytics tab |
| #375 | feat(statistics): top-media leaderboards (Option 3 phase 1) |
| #376 | feat(statistics): popular-media leaderboards (Option 3 phase 2) |
| #377 | feat(statistics): last-watched aggregator (Option 3 phase 3) |
| #378 | feat(statistics): most-concurrent aggregator (Option 3 phase 4) |
| #379 | feat(statistics): plays-by-date aggregator (Option 3 phase 5) |
| #380 | feat(statistics): migrate PlexTab off Tautulli (Option 3 phase C) |
| #381 | docs: surface Tautulli-now-optional |
| #382 | fix(stats): close silent-failure paths in new analytics helpers |

## Headline behavior changes

- **Plex tab no longer requires Tautulli.** Plex-only users finally see the Statistics tab.
- **Jellyfin/Emby gain a full analytics tab** at parity with Plex (14 cards: 6 leaderboards + 8 SessionSnapshot analytics).
- **Tautulli becomes optional enrichment** — when configured, codec/LAN-WAN/platform metadata gets richer; without it, snapshot-driven data still populates all charts.

See `CHANGELOG.md` for the full behavior matrix and migration notes.

## Pre-release validation (already run)

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm run test` — 1373 pass, 0 fail (4/4 turbo tasks successful)
- [x] `pnpm run build` — production build succeeds
- [x] Code/security audit completed via parallel review agents — one CRITICAL finding (silent-failure path) and one 🟡 finding (log leak) both fixed in #382
- [x] Main-branch CI scan: zero open CodeQL/Semgrep/Dependabot alerts
- [x] Visual test: both Plex and Jellyfin tabs verified end-to-end via Playwright; tab gating + time-range selector + Tautulli enrichment badge all working

## Next steps after this PR merges

Per `docs/RELEASING.md`:
1. **Tag**: `git tag -a v2.17.0 -m "v2.17.0 — Statistics overhaul: Jellyfin/Emby parity + Tautulli optional"`
2. **Push tag**: `git push origin v2.17.0` (triggers `docker-combined.yml` workflow → builds linux/amd64 + linux/arm64 + Trivy scan + pushes to Docker Hub + GHCR)
3. Create GitHub Release from tag with CHANGELOG body
4. Verify `latest` Docker tag points to v2.17.0 after CI

## Why `release:patch-now` label

Despite being a minor version bump, the label "patch-now" is the closest semantic fit in our bucketing system for "ship this immediately when CI is green." All preceding feature PRs are labeled `release:next-minor` per the system; this release-prep PR is the one that actually flips the next-minor queue into a shipped release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)