### PR TITLE
feat(plex-label-sync): execution engine + on-demand run (#384 phase C)

### DIFF
--- a/apps/api/src/lib/plex-label-sync/execute-rule.ts
+++ b/apps/api/src/lib/plex-label-sync/execute-rule.ts
@@ -1,0 +1,312 @@
+/**
+ * Plex Label Sync — rule execution engine (issue #384, phase C)
+ *
+ * Walks a rule end-to-end:
+ *   1. Resolve the *arr instance(s) the rule targets (specific instance,
+ *      or all enabled instances of the rule's service).
+ *   2. For each instance, look up the tag ID matching `arrTagName`.
+ *   3. Fetch all *arr items (series for Sonarr, movies for Radarr) and
+ *      filter to those carrying the resolved tag ID.
+ *   4. For each tagged item, look up its matching Plex item by `tmdbId`
+ *      against PlexCache.
+ *   5. Apply the configured Plex label via the Plex client.
+ *   6. Return a structured result; the caller persists it as the rule's
+ *      lastRunStatus / lastRunMessage.
+ */
+
+import { ArrError } from "arr-sdk";
+import type { FastifyBaseLogger } from "fastify";
+import type { ArrClient, ArrClientFactory } from "../arr/client-factory.js";
+import type { Encryptor } from "../auth/encryption.js";
+import { createPlexClient } from "../plex/plex-client.js";
+import type { PrismaClient, ServiceInstance } from "../prisma.js";
+
+export interface PlexLabelSyncRuleInput {
+	id: string;
+	userId: string;
+	arrService: string; // "sonarr" | "radarr"
+	arrInstanceId: string | null;
+	arrTagName: string;
+	plexInstanceId: string;
+	plexLabel: string;
+}
+
+export interface PlexLabelSyncRunResult {
+	status: "success" | "partial" | "failed";
+	message: string;
+	totals: {
+		arrInstancesScanned: number;
+		taggedItemsFound: number;
+		plexMatchesFound: number;
+		labelsApplied: number;
+		failures: number;
+	};
+}
+
+interface ExecuteOpts {
+	rule: PlexLabelSyncRuleInput;
+	prisma: PrismaClient;
+	arrClientFactory: ArrClientFactory;
+	encryptor: Encryptor;
+	log: FastifyBaseLogger;
+}
+
+const ARR_SERVICE_TO_PRISMA: Record<string, "SONARR" | "RADARR"> = {
+	sonarr: "SONARR",
+	radarr: "RADARR",
+};
+
+const ARR_SERVICE_TO_MEDIA_TYPE: Record<string, "series" | "movie"> = {
+	sonarr: "series",
+	radarr: "movie",
+};
+
+/**
+ * Execute a label-sync rule. Pure-execution function — does NOT persist
+ * the result. Callers should write `lastRunAt` / `lastRunStatus` /
+ * `lastRunMessage` themselves so the rule's persistence model stays
+ * decoupled from the engine.
+ */
+export async function executeLabelSyncRule(opts: ExecuteOpts): Promise<PlexLabelSyncRunResult> {
+	const { rule, prisma, arrClientFactory, encryptor, log } = opts;
+	const childLog = log.child({ ruleId: rule.id, arrService: rule.arrService });
+
+	const prismaService = ARR_SERVICE_TO_PRISMA[rule.arrService];
+	const mediaType = ARR_SERVICE_TO_MEDIA_TYPE[rule.arrService];
+	if (!prismaService || !mediaType) {
+		return failure(`Unsupported arrService: ${rule.arrService}`);
+	}
+
+	// Resolve *arr instances
+	const arrInstanceWhere = rule.arrInstanceId
+		? { id: rule.arrInstanceId, userId: rule.userId, service: prismaService, enabled: true }
+		: { userId: rule.userId, service: prismaService, enabled: true };
+
+	const arrInstances = await prisma.serviceInstance.findMany({ where: arrInstanceWhere });
+	if (arrInstances.length === 0) {
+		return failure(`No enabled ${rule.arrService} instance${rule.arrInstanceId ? "" : "s"} found.`);
+	}
+
+	// Resolve Plex instance + client
+	const plexInstance = await prisma.serviceInstance.findFirst({
+		where: { id: rule.plexInstanceId, userId: rule.userId, service: "PLEX", enabled: true },
+	});
+	if (!plexInstance) {
+		return failure("Plex instance not found or disabled.");
+	}
+
+	let plexClient: ReturnType<typeof createPlexClient>;
+	try {
+		plexClient = createPlexClient(encryptor, plexInstance, childLog);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return failure(`Failed to initialize Plex client: ${message}`);
+	}
+
+	// Aggregate counters
+	let taggedItemsFound = 0;
+	let plexMatchesFound = 0;
+	let labelsApplied = 0;
+	let failures = 0;
+
+	for (const arrInstance of arrInstances) {
+		const result = await processArrInstance({
+			rule,
+			arrInstance,
+			mediaType,
+			prisma,
+			arrClientFactory,
+			plexClient,
+			log: childLog.child({ arrInstanceId: arrInstance.id }),
+		});
+		taggedItemsFound += result.taggedItemsFound;
+		plexMatchesFound += result.plexMatchesFound;
+		labelsApplied += result.labelsApplied;
+		failures += result.failures;
+	}
+
+	const totals = {
+		arrInstancesScanned: arrInstances.length,
+		taggedItemsFound,
+		plexMatchesFound,
+		labelsApplied,
+		failures,
+	};
+
+	if (taggedItemsFound === 0) {
+		return {
+			status: "success",
+			message: `No items in ${rule.arrService} carry tag "${rule.arrTagName}".`,
+			totals,
+		};
+	}
+
+	if (failures > 0 && labelsApplied === 0) {
+		return {
+			status: "failed",
+			message: `All ${failures} label applications failed.`,
+			totals,
+		};
+	}
+
+	if (failures > 0) {
+		return {
+			status: "partial",
+			message: `Applied ${labelsApplied} label${labelsApplied === 1 ? "" : "s"}, ${failures} failure${failures === 1 ? "" : "s"}.`,
+			totals,
+		};
+	}
+
+	return {
+		status: "success",
+		message: `Applied label "${rule.plexLabel}" to ${labelsApplied} item${labelsApplied === 1 ? "" : "s"} (${plexMatchesFound} Plex match${plexMatchesFound === 1 ? "" : "es"} from ${taggedItemsFound} tagged ${mediaType} item${taggedItemsFound === 1 ? "" : "s"}).`,
+		totals,
+	};
+}
+
+interface ProcessInstanceArgs {
+	rule: PlexLabelSyncRuleInput;
+	arrInstance: ServiceInstance;
+	mediaType: "series" | "movie";
+	prisma: PrismaClient;
+	arrClientFactory: ArrClientFactory;
+	plexClient: ReturnType<typeof createPlexClient>;
+	log: FastifyBaseLogger;
+}
+
+interface ProcessInstanceResult {
+	taggedItemsFound: number;
+	plexMatchesFound: number;
+	labelsApplied: number;
+	failures: number;
+}
+
+async function processArrInstance(args: ProcessInstanceArgs): Promise<ProcessInstanceResult> {
+	const { rule, arrInstance, mediaType, prisma, arrClientFactory, plexClient, log } = args;
+
+	let arrClient: ArrClient;
+	try {
+		arrClient = arrClientFactory.create({
+			id: arrInstance.id,
+			baseUrl: arrInstance.baseUrl,
+			encryptedApiKey: arrInstance.encryptedApiKey,
+			encryptionIv: arrInstance.encryptionIv,
+			service: arrInstance.service,
+			label: arrInstance.label,
+		});
+	} catch (err) {
+		log.warn({ err }, "Failed to create *arr client; skipping instance");
+		return { taggedItemsFound: 0, plexMatchesFound: 0, labelsApplied: 0, failures: 0 };
+	}
+
+	// Look up the tag ID matching arrTagName.
+	// arr-sdk's Sonarr/Radarr Tag types are structurally identical
+	// ({ id, label }) but the union return type doesn't unify cleanly,
+	// so we narrow via a local cast to the shared shape.
+	let tagId: number | undefined;
+	try {
+		const tags = (await arrClient.tag.getAll()) as Array<{ id: number; label: string }>;
+		const match = tags.find((t: { id: number; label: string }) => t.label === rule.arrTagName);
+		tagId = match?.id;
+	} catch (err) {
+		const arrErr = err instanceof ArrError ? err.message : String(err);
+		log.warn({ err: arrErr }, "Failed to fetch tags from *arr instance");
+		return { taggedItemsFound: 0, plexMatchesFound: 0, labelsApplied: 0, failures: 1 };
+	}
+
+	if (tagId === undefined) {
+		log.info("Tag not found on this *arr instance; nothing to do");
+		return { taggedItemsFound: 0, plexMatchesFound: 0, labelsApplied: 0, failures: 0 };
+	}
+
+	// Fetch all items and filter by tag
+	let arrItems: Array<{ tmdbId?: number | null; tags?: number[] | null; title?: string }>;
+	try {
+		const itemsAccessor = mediaType === "series" ? "series" : "movie";
+		// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires runtime accessor
+		const resource = (arrClient as any)[itemsAccessor];
+		arrItems = (await resource.getAll()) as typeof arrItems;
+	} catch (err) {
+		log.warn({ err }, "Failed to fetch items from *arr instance");
+		return { taggedItemsFound: 0, plexMatchesFound: 0, labelsApplied: 0, failures: 1 };
+	}
+
+	const tagged = arrItems.filter((item) => Array.isArray(item.tags) && item.tags.includes(tagId));
+	if (tagged.length === 0) {
+		return { taggedItemsFound: 0, plexMatchesFound: 0, labelsApplied: 0, failures: 0 };
+	}
+
+	const tmdbIds = tagged
+		.map((item) => item.tmdbId)
+		.filter((id): id is number => typeof id === "number" && id > 0);
+
+	if (tmdbIds.length === 0) {
+		log.info({ taggedCount: tagged.length }, "Tagged items have no tmdbId; cannot match to Plex");
+		return {
+			taggedItemsFound: tagged.length,
+			plexMatchesFound: 0,
+			labelsApplied: 0,
+			failures: 0,
+		};
+	}
+
+	// Match against PlexCache for the rule's plex instance
+	const plexMatches = await prisma.plexCache.findMany({
+		where: {
+			instanceId: rule.plexInstanceId,
+			mediaType,
+			tmdbId: { in: tmdbIds },
+		},
+		select: { thumb: true, title: true, tmdbId: true },
+	});
+
+	let labelsApplied = 0;
+	let failures = 0;
+	for (const match of plexMatches) {
+		// PlexCache stores `thumb` containing the rating-key path; extract it.
+		// The shape is "/library/metadata/<ratingKey>/thumb/..." so we parse it out.
+		const ratingKey = extractRatingKey(match.thumb);
+		if (!ratingKey) {
+			log.warn({ tmdbId: match.tmdbId, title: match.title }, "Could not extract ratingKey");
+			failures++;
+			continue;
+		}
+
+		try {
+			await plexClient.updateMetadataTags(ratingKey, "label", "add", rule.plexLabel);
+			labelsApplied++;
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+			log.warn({ ratingKey, err: reason }, "Failed to apply Plex label");
+			failures++;
+		}
+	}
+
+	return {
+		taggedItemsFound: tagged.length,
+		plexMatchesFound: plexMatches.length,
+		labelsApplied,
+		failures,
+	};
+}
+
+function extractRatingKey(thumb: string | null): string | undefined {
+	if (!thumb) return undefined;
+	// Plex thumb paths look like "/library/metadata/65486/thumb/..." — pull the digits after metadata/
+	const match = thumb.match(/\/library\/metadata\/(\d+)/);
+	return match?.[1];
+}
+
+function failure(message: string): PlexLabelSyncRunResult {
+	return {
+		status: "failed",
+		message,
+		totals: {
+			arrInstancesScanned: 0,
+			taggedItemsFound: 0,
+			plexMatchesFound: 0,
+			labelsApplied: 0,
+			failures: 0,
+		},
+	};
+}

--- a/apps/api/src/routes/plex-label-sync.ts
+++ b/apps/api/src/routes/plex-label-sync.ts
@@ -16,6 +16,7 @@ import type {
 } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
+import { executeLabelSyncRule } from "../lib/plex-label-sync/execute-rule.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
 const arrServiceSchema = z.enum(["sonarr", "radarr"]);
@@ -227,5 +228,56 @@ export async function registerPlexLabelSyncRoutes(
 
 		await app.prisma.plexLabelSyncRule.delete({ where: { id } });
 		return reply.status(204).send();
+	});
+
+	/**
+	 * POST /api/plex/label-sync/rules/:id/run — execute a rule on demand.
+	 *
+	 * Walks the rule end-to-end (resolve *arr instances → find tagged items
+	 * → match against PlexCache → apply label) and persists the result on
+	 * the rule's lastRunAt/Status/Message fields.
+	 */
+	app.post("/rules/:id/run", async (request, reply) => {
+		const { id } = validateRequest(ruleParams, request.params);
+		const userId = request.currentUser!.id;
+
+		const rule = await app.prisma.plexLabelSyncRule.findFirst({
+			where: { id, userId },
+		});
+		if (!rule) {
+			return reply.status(404).send({ error: "Rule not found" });
+		}
+
+		if (!rule.enabled) {
+			return reply.status(400).send({ error: "Rule is disabled. Enable it before running." });
+		}
+
+		const result = await executeLabelSyncRule({
+			rule: {
+				id: rule.id,
+				userId: rule.userId,
+				arrService: rule.arrService,
+				arrInstanceId: rule.arrInstanceId,
+				arrTagName: rule.arrTagName,
+				plexInstanceId: rule.plexInstanceId,
+				plexLabel: rule.plexLabel,
+			},
+			prisma: app.prisma,
+			arrClientFactory: app.arrClientFactory,
+			encryptor: app.encryptor,
+			log: request.log,
+		});
+
+		const updated = await app.prisma.plexLabelSyncRule.update({
+			where: { id },
+			data: {
+				lastRunAt: new Date(),
+				lastRunStatus: result.status,
+				lastRunMessage: result.message,
+			},
+		});
+
+		const response: PlexLabelSyncRuleResponse = { rule: toDto(updated) };
+		return reply.send(response);
 	});
 }

--- a/apps/web/src/features/plex-label-sync/components/plex-label-sync-client.tsx
+++ b/apps/web/src/features/plex-label-sync/components/plex-label-sync-client.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import type { PlexLabelSyncRule } from "@arr/shared";
-import { CheckCircle2, Pencil, Plus, Tag, Trash2, XCircle } from "lucide-react";
+import { CheckCircle2, Pencil, Play, Plus, Tag, Trash2, XCircle } from "lucide-react";
 import { useState } from "react";
 import { GlassmorphicCard, PageLayout } from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import {
 	useDeletePlexLabelSyncRule,
 	usePlexLabelSyncRules,
+	useRunPlexLabelSyncRule,
 } from "../../../hooks/api/usePlexLabelSync";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { RuleDialog } from "./rule-dialog";
@@ -16,6 +17,8 @@ export const PlexLabelSyncClient = () => {
 	const { gradient } = useThemeGradient();
 	const { data: rules = [], isLoading } = usePlexLabelSyncRules();
 	const deleteMutation = useDeletePlexLabelSyncRule();
+	const runMutation = useRunPlexLabelSyncRule();
+	const [runningId, setRunningId] = useState<string | null>(null);
 
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [editingRule, setEditingRule] = useState<PlexLabelSyncRule | null>(null);
@@ -33,6 +36,22 @@ export const PlexLabelSyncClient = () => {
 	const handleDelete = async (rule: PlexLabelSyncRule) => {
 		if (!confirm(`Delete rule "${rule.name}"? This cannot be undone.`)) return;
 		await deleteMutation.mutateAsync(rule.id);
+	};
+
+	const handleRun = async (rule: PlexLabelSyncRule) => {
+		if (!rule.enabled) {
+			alert("Rule is disabled. Enable it before running.");
+			return;
+		}
+		setRunningId(rule.id);
+		try {
+			const updated = await runMutation.mutateAsync(rule.id);
+			alert(`${updated.lastRunStatus?.toUpperCase() ?? "DONE"}\n\n${updated.lastRunMessage ?? ""}`);
+		} catch (err) {
+			alert(`Run failed: ${err instanceof Error ? err.message : String(err)}`);
+		} finally {
+			setRunningId(null);
+		}
 	};
 
 	return (
@@ -74,7 +93,13 @@ export const PlexLabelSyncClient = () => {
 					) : rules.length === 0 ? (
 						<EmptyState onCreateClick={openCreate} />
 					) : (
-						<RuleTable rules={rules} onEdit={openEdit} onDelete={handleDelete} />
+						<RuleTable
+							rules={rules}
+							runningId={runningId}
+							onEdit={openEdit}
+							onDelete={handleDelete}
+							onRun={handleRun}
+						/>
 					)}
 				</GlassmorphicCard>
 			</div>
@@ -111,12 +136,16 @@ const EmptyState = ({ onCreateClick }: { onCreateClick: () => void }) => (
 
 const RuleTable = ({
 	rules,
+	runningId,
 	onEdit,
 	onDelete,
+	onRun,
 }: {
 	rules: PlexLabelSyncRule[];
+	runningId: string | null;
 	onEdit: (rule: PlexLabelSyncRule) => void;
 	onDelete: (rule: PlexLabelSyncRule) => void;
+	onRun: (rule: PlexLabelSyncRule) => void;
 }) => (
 	<div className="overflow-x-auto">
 		<table className="w-full text-sm">
@@ -168,6 +197,17 @@ const RuleTable = ({
 						</td>
 						<td className="px-4 py-3 text-right">
 							<div className="inline-flex gap-1">
+								<button
+									type="button"
+									onClick={() => onRun(rule)}
+									disabled={runningId === rule.id || !rule.enabled}
+									className="p-1.5 rounded-md hover:bg-muted/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+									title={rule.enabled ? "Run rule now" : "Enable the rule to run it"}
+								>
+									<Play
+										className={`h-3.5 w-3.5 text-muted-foreground ${runningId === rule.id ? "animate-pulse" : ""}`}
+									/>
+								</button>
 								<button
 									type="button"
 									onClick={() => onEdit(rule)}

--- a/apps/web/src/hooks/api/usePlexLabelSync.ts
+++ b/apps/web/src/hooks/api/usePlexLabelSync.ts
@@ -15,6 +15,7 @@ import {
 	createPlexLabelSyncRule,
 	deletePlexLabelSyncRule,
 	fetchPlexLabelSyncRules,
+	runPlexLabelSyncRule,
 	updatePlexLabelSyncRule,
 } from "../../lib/api-client/plex-label-sync";
 import { plexLabelSyncKeys } from "../../lib/query-keys";
@@ -52,6 +53,16 @@ export const useDeletePlexLabelSyncRule = () => {
 	const queryClient = useQueryClient();
 	return useMutation({
 		mutationFn: (id: string) => deletePlexLabelSyncRule(id),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: plexLabelSyncKeys.rules });
+		},
+	});
+};
+
+export const useRunPlexLabelSyncRule = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (id: string) => runPlexLabelSyncRule(id),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: plexLabelSyncKeys.rules });
 		},

--- a/apps/web/src/lib/api-client/plex-label-sync.ts
+++ b/apps/web/src/lib/api-client/plex-label-sync.ts
@@ -43,3 +43,10 @@ export async function updatePlexLabelSyncRule(
 export async function deletePlexLabelSyncRule(id: string): Promise<void> {
 	await apiRequest<void>(`/api/plex/label-sync/rules/${id}`, { method: "DELETE" });
 }
+
+export async function runPlexLabelSyncRule(id: string): Promise<PlexLabelSyncRule> {
+	const data = await apiRequest<PlexLabelSyncRuleResponse>(`/api/plex/label-sync/rules/${id}/run`, {
+		method: "POST",
+	});
+	return data.rule;
+}


### PR DESCRIPTION
## Summary

Phase C of the Plex Labels arc. **Rules now do work** — the execution engine walks each rule end-to-end and applies labels.

## What this PR ships

### Execution engine (`apps/api/src/lib/plex-label-sync/execute-rule.ts`)

`executeLabelSyncRule(opts)` is a pure-execution helper that:

1. Resolves *arr instances (specific instance, or all enabled of the rule's service)
2. For each instance, looks up the tag ID matching `arrTagName` via `client.tag.getAll()`
3. Fetches all items (`series.getAll()` for Sonarr, `movie.getAll()` for Radarr) and filters to those carrying the resolved tag ID
4. Looks up matching `PlexCache` rows by `tmdbId` + `mediaType`
5. Applies the configured label via `plexClient.updateMetadataTags(ratingKey, "label", "add", labelName)`
6. Returns a structured `{ status, message, totals }` result — does **NOT** persist; persistence stays the route's responsibility (separation of execution from storage)

### On-demand route

`POST /api/plex/label-sync/rules/:id/run`:
- Loads rule, verifies ownership
- Returns 400 if rule is disabled (explicit "enable it first" message rather than silently no-op)
- Runs the executor
- Persists `lastRunAt` / `lastRunStatus` / `lastRunMessage` on the rule
- Returns the updated rule

### Frontend wiring

- `runPlexLabelSyncRule` API client function
- `useRunPlexLabelSyncRule` mutation hook (invalidates rules list on success)
- New "Run now" play-icon button on each rule row in the UI
- Disabled state when the rule is disabled, with tooltip nudge to enable
- Animated pulse during run; result shown in alert with structured message

## Edge cases handled

| Case | Behavior |
|---|---|
| *arr instance not found / disabled | `failed` with explicit reason |
| Tag not found on a particular instance | 0 tagged items, no failure (tag may exist on a different instance when scope is "all") |
| Tagged item without `tmdbId` | counted as found-but-unmatchable, no failure increment |
| PlexCache match with no extractable rating key | counted as failure with warning log |
| Mixed outcomes | `partial` status with applied vs failure counts in message |
| Empty rule scope (no instances of service) | `failed` with explicit message |

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean across `@arr/api` and `@arr/web`
- [x] `pnpm run lint` — 0 errors (4 pre-existing warnings unrelated)

## What's next

- **Phase D (optional):** scheduler integration — apply rules every N minutes
- **Phase E (optional, will discuss before starting):** Sonarr/Radarr webhook listener for real-time application

🤖 Generated with [Claude Code](https://claude.com/claude-code)