### PR TITLE
feat(plex-label-sync): scheduler integration (#384 phase D)

### DIFF
--- a/apps/api/src/bootstrap/schedulers.ts
+++ b/apps/api/src/bootstrap/schedulers.ts
@@ -9,6 +9,7 @@ import libraryCleanupSchedulerPlugin from "../plugins/library-cleanup-scheduler.
 import librarySyncSchedulerPlugin from "../plugins/library-sync-scheduler.js";
 import plexCacheSchedulerPlugin from "../plugins/plex-cache-scheduler.js";
 import plexEpisodeCacheSchedulerPlugin from "../plugins/plex-episode-cache-scheduler.js";
+import plexLabelSyncSchedulerPlugin from "../plugins/plex-label-sync-scheduler.js";
 import queueCleanerSchedulerPlugin from "../plugins/queue-cleaner-scheduler.js";
 import seerrHealthSchedulerPlugin from "../plugins/seerr-health-scheduler.js";
 import sessionCleanupPlugin from "../plugins/session-cleanup.js";
@@ -36,6 +37,7 @@ export function registerSchedulers(app: FastifyInstance): void {
 	app.register(huntingSchedulerPlugin);
 	app.register(queueCleanerSchedulerPlugin);
 	app.register(libraryCleanupSchedulerPlugin);
+	app.register(plexLabelSyncSchedulerPlugin);
 	app.register(insightsDigestSchedulerPlugin);
 
 	// TRaSH Guides sync + cleanup

--- a/apps/api/src/lib/plex-label-sync/label-sync-scheduler.ts
+++ b/apps/api/src/lib/plex-label-sync/label-sync-scheduler.ts
@@ -1,0 +1,168 @@
+/**
+ * Plex Label Sync Scheduler
+ *
+ * Walks enabled PlexLabelSyncRule rows and runs each through the same
+ * execution engine that powers the on-demand "Run now" endpoint
+ * (`executeLabelSyncRule`). Per-rule cooldown skips rules that already
+ * ran in the last hour, so a manually-triggered run and a scheduled
+ * tick don't double-fire on the same rule.
+ *
+ * Mirrors the BackupScheduler / CleanupScheduler pattern:
+ * - Singleton: in-flight guard prevents overlapping ticks
+ * - Tick interval: 5 minutes (the registry-declared `intervalMs`)
+ * - Per-rule cooldown: 60 minutes since last successful run
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import type { ArrClientFactory } from "../arr/client-factory.js";
+import type { Encryptor } from "../auth/encryption.js";
+import type { PrismaClient } from "../prisma.js";
+import {
+	passthroughTickWrapper,
+	type TickWrapper,
+} from "../scheduler-registry/scheduler-registry.js";
+import { executeLabelSyncRule } from "./execute-rule.js";
+
+const TICK_INTERVAL_MS = 5 * 60 * 1000; // Wake every 5 minutes
+const RULE_COOLDOWN_MS = 60 * 60 * 1000; // Skip rules that ran in the last hour
+
+export class LabelSyncScheduler {
+	private intervalId: NodeJS.Timeout | null = null;
+	private inFlight = false;
+	private trackTick: TickWrapper;
+
+	constructor(
+		private prisma: PrismaClient,
+		private arrClientFactory: ArrClientFactory,
+		private encryptor: Encryptor,
+		private log: FastifyBaseLogger,
+		options?: { trackTick?: TickWrapper },
+	) {
+		this.trackTick = options?.trackTick ?? passthroughTickWrapper;
+	}
+
+	start(): void {
+		if (this.intervalId) {
+			this.log.warn("Label sync scheduler already running");
+			return;
+		}
+
+		this.log.info({ intervalMs: TICK_INTERVAL_MS }, "Starting Plex label sync scheduler");
+
+		// Fire one tick immediately so a recently-modified rule doesn't wait the
+		// full interval before its first scheduled run.
+		this.trackTick(() => this.tick()).catch((err) => {
+			this.log.error({ err }, "Initial label-sync tick failed");
+		});
+
+		this.intervalId = setInterval(() => {
+			this.trackTick(() => this.tick()).catch((err) => {
+				this.log.error({ err }, "Scheduled label-sync tick failed");
+			});
+		}, TICK_INTERVAL_MS);
+	}
+
+	stop(): void {
+		if (this.intervalId) {
+			clearInterval(this.intervalId);
+			this.intervalId = null;
+			this.log.info("Plex label sync scheduler stopped");
+		}
+	}
+
+	/**
+	 * One scheduler tick. Selects rules that are due (enabled, and either
+	 * never run or last-run is older than the cooldown), executes each
+	 * serially, persists the result.
+	 */
+	private async tick(): Promise<void> {
+		if (this.inFlight) {
+			this.log.debug("Label sync tick skipped — previous tick still in flight");
+			return;
+		}
+		this.inFlight = true;
+
+		try {
+			const cooldownThreshold = new Date(Date.now() - RULE_COOLDOWN_MS);
+			const dueRules = await this.prisma.plexLabelSyncRule.findMany({
+				where: {
+					enabled: true,
+					OR: [{ lastRunAt: null }, { lastRunAt: { lt: cooldownThreshold } }],
+				},
+			});
+
+			if (dueRules.length === 0) {
+				this.log.debug("No label-sync rules due this tick");
+				return;
+			}
+
+			this.log.info({ ruleCount: dueRules.length }, "Running scheduled label-sync rules");
+
+			let succeeded = 0;
+			let partial = 0;
+			let failed = 0;
+
+			for (const rule of dueRules) {
+				try {
+					const result = await executeLabelSyncRule({
+						rule: {
+							id: rule.id,
+							userId: rule.userId,
+							arrService: rule.arrService,
+							arrInstanceId: rule.arrInstanceId,
+							arrTagName: rule.arrTagName,
+							plexInstanceId: rule.plexInstanceId,
+							plexLabel: rule.plexLabel,
+						},
+						prisma: this.prisma,
+						arrClientFactory: this.arrClientFactory,
+						encryptor: this.encryptor,
+						log: this.log,
+					});
+
+					await this.prisma.plexLabelSyncRule.update({
+						where: { id: rule.id },
+						data: {
+							lastRunAt: new Date(),
+							lastRunStatus: result.status,
+							lastRunMessage: result.message,
+						},
+					});
+
+					if (result.status === "success") succeeded++;
+					else if (result.status === "partial") partial++;
+					else failed++;
+				} catch (err) {
+					failed++;
+					const message = err instanceof Error ? err.message : String(err);
+					this.log.warn(
+						{ err, ruleId: rule.id },
+						"Label-sync rule execution threw — recording as failure",
+					);
+					await this.prisma.plexLabelSyncRule
+						.update({
+							where: { id: rule.id },
+							data: {
+								lastRunAt: new Date(),
+								lastRunStatus: "failed",
+								lastRunMessage: `Scheduler exception: ${message}`,
+							},
+						})
+						.catch((updateErr) => {
+							this.log.error(
+								{ err: updateErr, ruleId: rule.id },
+								"Failed to persist rule failure status",
+							);
+						});
+				}
+			}
+
+			this.log.info(
+				{ ruleCount: dueRules.length, succeeded, partial, failed },
+				"Scheduled label-sync tick complete",
+			);
+		} finally {
+			this.inFlight = false;
+		}
+	}
+}

--- a/apps/api/src/lib/scheduler-registry/job-definitions.ts
+++ b/apps/api/src/lib/scheduler-registry/job-definitions.ts
@@ -33,6 +33,7 @@ export const JOB_ID = {
 	jellyfinEpisodeCache: "jellyfin-episode-cache",
 	tautulliCache: "tautulli-cache",
 	seerrHealth: "seerr-health",
+	plexLabelSync: "plex-label-sync",
 } as const;
 
 export const KNOWN_JOBS: readonly JobDefinition[] = [
@@ -151,6 +152,14 @@ export const KNOWN_JOBS: readonly JobDefinition[] = [
 		label: "Seerr health",
 		description:
 			"Pings configured Seerr (Jellyseerr/Overseerr) instances every 5 minutes. Guarded by an in-plugin `isRunning` flag.",
+		concurrency: "singleton",
+		intervalMs: 5 * 60 * 1000,
+	},
+	{
+		id: JOB_ID.plexLabelSync,
+		label: "Plex label sync",
+		description:
+			"Walks enabled PlexLabelSyncRule rows once per hour and applies the configured Plex label to *arr items carrying the matching tag. Per-rule cooldown skips rules that ran in the last hour, so on-demand runs and scheduled ticks don't double-fire.",
 		concurrency: "singleton",
 		intervalMs: 5 * 60 * 1000,
 	},

--- a/apps/api/src/plugins/plex-label-sync-scheduler.ts
+++ b/apps/api/src/plugins/plex-label-sync-scheduler.ts
@@ -1,0 +1,51 @@
+import type { FastifyInstance } from "fastify";
+import fastifyPlugin from "fastify-plugin";
+import { LabelSyncScheduler } from "../lib/plex-label-sync/label-sync-scheduler.js";
+import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
+
+declare module "fastify" {
+	interface FastifyInstance {
+		labelSyncScheduler: LabelSyncScheduler;
+	}
+}
+
+const plexLabelSyncSchedulerPlugin = fastifyPlugin(
+	async (app: FastifyInstance) => {
+		app.addHook("onReady", async () => {
+			await runSchedulerInit(
+				{ registry: app.schedulerRegistry, log: app.log },
+				JOB_ID.plexLabelSync,
+				"plex label sync",
+				async () => {
+					app.log.info("Initializing Plex label sync scheduler");
+
+					const scheduler = new LabelSyncScheduler(
+						app.prisma,
+						app.arrClientFactory,
+						app.encryptor,
+						app.log,
+						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.plexLabelSync, fn) },
+					);
+					app.decorate("labelSyncScheduler", scheduler);
+
+					scheduler.start();
+					app.log.info("Plex label sync scheduler started successfully");
+				},
+			);
+		});
+
+		app.addHook("onClose", async () => {
+			if (app.labelSyncScheduler) {
+				app.log.info("Stopping Plex label sync scheduler");
+				app.labelSyncScheduler.stop();
+			}
+		});
+	},
+	{
+		name: "plex-label-sync-scheduler",
+		dependencies: ["prisma", "arr-client", "scheduler-registry"],
+	},
+);
+
+export default plexLabelSyncSchedulerPlugin;


### PR DESCRIPTION
## Summary

Phase D of the Plex Labels arc. **Rules now run automatically on a schedule** — no manual click required.

## What ships

### `LabelSyncScheduler` class

`apps/api/src/lib/plex-label-sync/label-sync-scheduler.ts` — mirrors the `BackupScheduler` / `CleanupScheduler` pattern:

- Singleton in-flight guard
- 5-minute tick interval
- Per-rule cooldown of 60 minutes — rules that ran within the last hour are skipped (prevents on-demand "Run now" + scheduled tick from double-firing)
- Walks due rules, executes each via the existing `executeLabelSyncRule` helper from PR #388, persists `lastRunAt` / `lastRunStatus` / `lastRunMessage`

### Fastify plugin

`apps/api/src/plugins/plex-label-sync-scheduler.ts` — registers the scheduler via the same `runSchedulerInit` helper other schedulers use, so failures surface through the scheduler-status dashboard.

### Job registry

New `JOB_ID.plexLabelSync` + `KNOWN_JOBS` entry — registers `plex-label-sync` as a singleton job with 5-minute interval. Description explains the cooldown semantics so operators understand why rules don't fire every tick.

### Bootstrap registration

`bootstrap/schedulers.ts` registers the new plugin under the "Library sync + automation (ARR side)" group — same conceptual group as Library Cleanup.

## Behavior

- On startup, fires one immediate tick so a recently-added rule doesn't wait the full 5 minutes before its first run
- Each tick selects rules `WHERE enabled = true AND (lastRunAt IS NULL OR lastRunAt < now - 60min)`
- Rules execute serially within a tick; an exception in one rule doesn't abort the others (the rule's `lastRunStatus` is set to `failed` with the exception message and the tick continues)
- Tick logs structured counts: total / succeeded / partial / failed

## What's next

- **Phase E (optional, will discuss before starting):** Sonarr/Radarr webhook listener for real-time label application on import. Adds a public endpoint, signature verification, and per-event rule evaluation. Strictly polish — A through D give users the full feature loop.

## Verified

- [x] `pnpm --filter @arr/api run test` — 1373 pass, 0 fail
- [x] `tsc --noEmit` clean across `@arr/api` and `@arr/web`
- [x] `pnpm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)