### PR TITLE
feat(label-sync): widen UI dropdowns to expose any-to-any (#384 sub-arc 3)

### DIFF
--- a/apps/web/src/features/label-sync/components/label-sync-client.tsx
+++ b/apps/web/src/features/label-sync/components/label-sync-client.tsx
@@ -11,6 +11,7 @@ import {
 	useRunLabelSyncRule,
 } from "../../../hooks/api/useLabelSync";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { SERVICE_LABEL_BY_VALUE } from "../service-registry";
 import { RuleDialog } from "./rule-dialog";
 
 export const LabelSyncClient = () => {
@@ -77,8 +78,10 @@ export const LabelSyncClient = () => {
 							</span>
 						</h1>
 						<p className="text-muted-foreground max-w-xl">
-							Auto-apply tags and labels across services. When a rule runs, every source item
-							carrying the configured tag gets the destination label applied to its matching item.
+							Auto-apply tags and labels across — or within — services. Pick any source service
+							(Sonarr, Radarr, Plex, Jellyfin, Emby) and any destination service. When a rule runs,
+							every source item carrying the configured tag gets the destination label applied to
+							its matching item.
 						</p>
 					</div>
 					<Button onClick={openCreate} className="shrink-0">
@@ -125,8 +128,9 @@ const EmptyState = ({ onCreateClick }: { onCreateClick: () => void }) => (
 		</div>
 		<h3 className="text-base font-semibold">No label-sync rules yet</h3>
 		<p className="text-sm text-muted-foreground max-w-sm">
-			Create a rule to map a Sonarr or Radarr tag to a Plex label. Useful for kid-safe collections,
-			user-specific labels, or surfacing requested content.
+			Create a rule to mirror a tag across services — e.g., a Sonarr/Radarr tag to a Plex label, or
+			a Plex label to a Jellyfin tag. Useful for kid-safe collections, user-specific labels, or
+			surfacing requested content.
 		</p>
 		<Button onClick={onCreateClick} variant="secondary" className="mt-2">
 			<Plus className="h-4 w-4 mr-2" /> Create your first rule
@@ -153,6 +157,7 @@ const RuleTable = ({
 				<tr className="text-left text-xs font-medium text-muted-foreground uppercase tracking-wide">
 					<th className="px-4 py-3">Name</th>
 					<th className="px-4 py-3">Source</th>
+					<th className="px-4 py-3">Destination</th>
 					<th className="px-4 py-3">Mapping</th>
 					<th className="px-4 py-3">Status</th>
 					<th className="px-4 py-3">Last Run</th>
@@ -173,12 +178,15 @@ const RuleTable = ({
 							</div>
 						</td>
 						<td className="px-4 py-3 text-muted-foreground">
-							<span className="capitalize">{rule.sourceService}</span>
+							<span>{SERVICE_LABEL_BY_VALUE[rule.sourceService] ?? rule.sourceService}</span>
 							{rule.sourceInstanceId ? (
 								<span className="text-xs ml-1">(instance)</span>
 							) : (
 								<span className="text-xs text-muted-foreground/60 ml-1">(all instances)</span>
 							)}
+						</td>
+						<td className="px-4 py-3 text-muted-foreground">
+							<span>{SERVICE_LABEL_BY_VALUE[rule.destService] ?? rule.destService}</span>
 						</td>
 						<td className="px-4 py-3 font-mono text-xs">
 							<span className="text-muted-foreground">{rule.sourceTagName}</span>

--- a/apps/web/src/features/label-sync/components/rule-dialog.tsx
+++ b/apps/web/src/features/label-sync/components/rule-dialog.tsx
@@ -2,6 +2,7 @@
 
 import type {
 	CreateLabelSyncRuleRequest,
+	LabelSyncDestService,
 	LabelSyncRule,
 	LabelSyncSourceService,
 	ServiceInstanceSummary,
@@ -19,6 +20,7 @@ import {
 import { Input } from "../../../components/ui/input";
 import { useCreateLabelSyncRule, useUpdateLabelSyncRule } from "../../../hooks/api/useLabelSync";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
+import { LABEL_SYNC_SERVICE_OPTIONS } from "../service-registry";
 
 interface RuleDialogProps {
 	rule: LabelSyncRule | null;
@@ -31,6 +33,7 @@ interface FormState {
 	sourceService: LabelSyncSourceService;
 	sourceInstanceId: string; // empty string means "all instances"
 	sourceTagName: string;
+	destService: LabelSyncDestService;
 	destInstanceId: string;
 	destTagName: string;
 }
@@ -41,6 +44,7 @@ const initialForm = (rule: LabelSyncRule | null): FormState => ({
 	sourceService: rule?.sourceService ?? "sonarr",
 	sourceInstanceId: rule?.sourceInstanceId ?? "",
 	sourceTagName: rule?.sourceTagName ?? "",
+	destService: rule?.destService ?? "plex",
 	destInstanceId: rule?.destInstanceId ?? "",
 	destTagName: rule?.destTagName ?? "",
 });
@@ -51,19 +55,33 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 
 	const { data: services = [] } = useServicesQuery();
+
+	// Pre-compute which services have at least one enabled instance so the
+	// dropdowns can disable services the user can't actually pick.
+	const enabledInstanceCountBySlug = useMemo(() => {
+		const counts: Record<string, number> = {};
+		for (const s of services as ServiceInstanceSummary[]) {
+			if (!s.enabled) continue;
+			const slug = s.service.toLowerCase();
+			counts[slug] = (counts[slug] ?? 0) + 1;
+		}
+		return counts;
+	}, [services]);
+
 	const sourceInstances = useMemo(
 		() =>
-			services.filter(
-				(s: ServiceInstanceSummary) => s.service.toLowerCase() === form.sourceService && s.enabled,
+			(services as ServiceInstanceSummary[]).filter(
+				(s) => s.service.toLowerCase() === form.sourceService && s.enabled,
 			),
 		[services, form.sourceService],
 	);
+
 	const destInstances = useMemo(
 		() =>
-			services.filter(
-				(s: ServiceInstanceSummary) => s.service.toLowerCase() === "plex" && s.enabled,
+			(services as ServiceInstanceSummary[]).filter(
+				(s) => s.service.toLowerCase() === form.destService && s.enabled,
 			),
-		[services],
+		[services, form.destService],
 	);
 
 	const createMutation = useCreateLabelSyncRule();
@@ -94,7 +112,7 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 			sourceService: form.sourceService,
 			sourceInstanceId: form.sourceInstanceId || null,
 			sourceTagName: form.sourceTagName.trim(),
-			destService: "plex",
+			destService: form.destService,
 			destInstanceId: form.destInstanceId,
 			destTagName: form.destTagName.trim(),
 		};
@@ -117,8 +135,9 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 				<DialogHeader>
 					<DialogTitle>{isEdit ? "Edit Rule" : "New Label Sync Rule"}</DialogTitle>
 					<DialogDescription>
-						Maps a Sonarr or Radarr tag to a Plex label. Items carrying the source tag get the
-						destination label applied to their matching item (matched by TMDB ID).
+						Apply a destination tag/label to items carrying a source tag/label. Source and
+						destination services can differ or be the same — items are matched across services by
+						TMDB ID.
 					</DialogDescription>
 				</DialogHeader>
 
@@ -163,8 +182,21 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 								}}
 								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
 							>
-								<option value="sonarr">Sonarr</option>
-								<option value="radarr">Radarr</option>
+								{LABEL_SYNC_SERVICE_OPTIONS.map((opt) => {
+									const count = enabledInstanceCountBySlug[opt.matchSlug] ?? 0;
+									const disabled = count === 0;
+									return (
+										<option
+											key={opt.value}
+											value={opt.value}
+											disabled={disabled}
+											title={disabled ? `No enabled ${opt.label} instance configured` : undefined}
+										>
+											{opt.label}
+											{disabled ? " — none configured" : ""}
+										</option>
+									);
+								})}
 							</select>
 						</div>
 						<div className="space-y-1.5">
@@ -178,7 +210,7 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
 							>
 								<option value="">All {form.sourceService} instances</option>
-								{sourceInstances.map((s: ServiceInstanceSummary) => (
+								{sourceInstances.map((s) => (
 									<option key={s.id} value={s.id}>
 										{s.label}
 									</option>
@@ -201,15 +233,45 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 							required
 						/>
 						<p className="text-xs text-muted-foreground">
-							The exact tag name as configured in the source service. Case-sensitive.
+							The exact tag/label name as configured in the source service. Case-sensitive.
 						</p>
 					</div>
 
-					{/* Dest instance + label */}
+					{/* Destination service + instance */}
 					<div className="grid grid-cols-2 gap-3">
 						<div className="space-y-1.5">
+							<label htmlFor="dest-service" className="text-sm font-medium">
+								Destination service
+							</label>
+							<select
+								id="dest-service"
+								value={form.destService}
+								onChange={(e) => {
+									update("destService", e.target.value as LabelSyncDestService);
+									update("destInstanceId", "");
+								}}
+								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+							>
+								{LABEL_SYNC_SERVICE_OPTIONS.map((opt) => {
+									const count = enabledInstanceCountBySlug[opt.matchSlug] ?? 0;
+									const disabled = count === 0;
+									return (
+										<option
+											key={opt.value}
+											value={opt.value}
+											disabled={disabled}
+											title={disabled ? `No enabled ${opt.label} instance configured` : undefined}
+										>
+											{opt.label}
+											{disabled ? " — none configured" : ""}
+										</option>
+									);
+								})}
+							</select>
+						</div>
+						<div className="space-y-1.5">
 							<label htmlFor="dest-instance" className="text-sm font-medium">
-								Destination (Plex)
+								Destination instance
 							</label>
 							<select
 								id="dest-instance"
@@ -218,27 +280,33 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 								className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
 								required
 							>
-								<option value="">Select a Plex instance…</option>
-								{destInstances.map((s: ServiceInstanceSummary) => (
+								<option value="">Select a {form.destService} instance…</option>
+								{destInstances.map((s) => (
 									<option key={s.id} value={s.id}>
 										{s.label}
 									</option>
 								))}
 							</select>
 						</div>
-						<div className="space-y-1.5">
-							<label htmlFor="dest-tag" className="text-sm font-medium">
-								Destination label
-							</label>
-							<Input
-								id="dest-tag"
-								value={form.destTagName}
-								onChange={(e) => update("destTagName", e.target.value)}
-								placeholder="e.g., Kids"
-								maxLength={120}
-								required
-							/>
-						</div>
+					</div>
+
+					{/* Destination tag/label */}
+					<div className="space-y-1.5">
+						<label htmlFor="dest-tag" className="text-sm font-medium">
+							Destination tag/label
+						</label>
+						<Input
+							id="dest-tag"
+							value={form.destTagName}
+							onChange={(e) => update("destTagName", e.target.value)}
+							placeholder="e.g., Kids"
+							maxLength={120}
+							required
+						/>
+						<p className="text-xs text-muted-foreground">
+							The tag/label to apply on the destination service. Created automatically on
+							Sonarr/Radarr if it doesn't already exist.
+						</p>
 					</div>
 
 					{submitError && (

--- a/apps/web/src/features/label-sync/service-registry.ts
+++ b/apps/web/src/features/label-sync/service-registry.ts
@@ -1,0 +1,34 @@
+/**
+ * Label-sync UI service registry.
+ *
+ * Single source of truth for the dropdown options on either side of a rule.
+ * Keep `LabelSyncService` (in @arr/shared) and this list in lockstep —
+ * adding a new service requires both edits.
+ */
+
+import type { LabelSyncService } from "@arr/shared";
+
+export interface LabelSyncServiceOption {
+	value: LabelSyncService;
+	/** Human-readable label shown in dropdowns and rule tables. */
+	label: string;
+	/** Lowercase service slug used to match `ServiceInstanceSummary.service`. */
+	matchSlug: string;
+}
+
+export const LABEL_SYNC_SERVICE_OPTIONS: readonly LabelSyncServiceOption[] = [
+	{ value: "sonarr", label: "Sonarr", matchSlug: "sonarr" },
+	{ value: "radarr", label: "Radarr", matchSlug: "radarr" },
+	{ value: "plex", label: "Plex", matchSlug: "plex" },
+	{ value: "jellyfin", label: "Jellyfin", matchSlug: "jellyfin" },
+	{ value: "emby", label: "Emby", matchSlug: "emby" },
+];
+
+export const SERVICE_LABEL_BY_VALUE: Record<LabelSyncService, string> =
+	LABEL_SYNC_SERVICE_OPTIONS.reduce(
+		(acc, option) => {
+			acc[option.value] = option.label;
+			return acc;
+		},
+		{} as Record<LabelSyncService, string>,
+	);


### PR DESCRIPTION
## Summary

Final sub-arc of issue #384's any-to-any generalization. Surfaces the executor capability that landed in #391: rule creation now accepts any of the 5 supported services on either side, including **same-service rules** (Plex → Plex, Sonarr → Sonarr, etc.).

## What changed

**New file: `apps/web/src/features/label-sync/service-registry.ts`** — single source of truth for the dropdown options + display labels. Keep in lockstep with the `LabelSyncService` union in `@arr/shared`.

**`RuleDialog`:**
- Source service dropdown widened from `sonarr|radarr` to all 5 services. Previously-hardcoded "Plex" destination dropdown is now a service picker too.
- Services with no enabled instances render as **disabled options with " — none configured" suffix + tooltip**, so the full taxonomy stays discoverable without letting the user pick something that won't work.
- Source/destination instance dropdowns re-filter when their service changes.
- Description copy switched from Plex-specific to neutral: *"Apply a destination tag/label to items carrying a source tag/label. Source and destination services can differ or be the same — items are matched by TMDB ID."*
- Help text on destination tag mentions automatic creation on Sonarr/Radarr (matching the executor's `tag.create` get-or-create behavior).

**`LabelSyncClient`:**
- Header paragraph now lists the supported services explicitly.
- Empty state copy mentions cross-service mirroring including reverse-direction examples (Plex label → Jellyfin tag).
- Rule table gains a **separate Destination column** so the direction of every rule is visible at a glance. Service names render via the registry's display labels (e.g., "Jellyfin" not "jellyfin").

## Browser verification

Live-tested against the dev environment:

- Source dropdown shows: Sonarr, Radarr, Plex, Jellyfin, **"Emby — none configured" (disabled)** — matches the user's actual instance set (no Emby configured)
- Destination dropdown: same five options, same disabled state on Emby
- Switching source to Plex repopulates source instance dropdown with the user's Plex instance (`khak1s-media`)
- Switching source to Jellyfin repopulates with `Test Jellyfin`
- Description copy reads correctly without service-specific assumptions
- 0 console errors during interaction

## What is *not* in this PR

- Lidarr / music — deferred (sub-arc 5 if user demand surfaces).
- The `useServicesQuery`-based instance count is computed once per render and used for both dropdowns; no extra fetches.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm run lint` — no new findings (6 pre-existing warnings, all unrelated)
- [x] Browser snapshot of New Rule dialog showing all 5 services with correct disabled states
- [x] Source instance dropdown re-populates correctly when source service changes (verified for Plex + Jellyfin)
- [ ] CI green

Refs: issue #384, memory/label-sync-generalization-arc.md sub-arc 3
Follows: #390 (sub-arc 1), #391 (sub-arc 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)