### PR TITLE
refactor(shared): extract generic rule-criteria types out of library-cleanup

### DIFF
--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -14,6 +14,7 @@ export * from "./plex";
 export * from "./pulse";
 export * from "./queue-cleaner";
 export * from "./regex-safety";
+export * from "./rule-criteria";
 export * from "./search";
 export * from "./seerr";
 export * from "./tautulli";

--- a/packages/shared/src/types/library-cleanup.ts
+++ b/packages/shared/src/types/library-cleanup.ts
@@ -1,438 +1,51 @@
+/**
+ * Library Cleanup — feature-specific types.
+ *
+ * Generic rule-criteria types (per-rule-type Zod params, the `RuleType`
+ * union, condition shape, composite operator, validation maps) live in
+ * `./rule-criteria.ts` and are re-exported through the shared barrel.
+ * This file owns only the cleanup-specific glue: action enum, the
+ * cleanup-rule write/update schemas (which wrap the generic criteria
+ * with cleanup-specific filter + execution fields), and the response
+ * shapes for the cleanup API surface.
+ */
+
 import { z } from "zod";
 import { getRegexSafetyError, REGEX_MAX_LENGTH } from "./regex-safety.js";
+import {
+	type CompositeOperator,
+	type Condition,
+	compositeOperatorSchema,
+	conditionSchema,
+	type RuleType,
+	ruleTypeSchema,
+} from "./rule-criteria.js";
 
 // ============================================================================
-// Rule Types
+// Legacy name aliases (transitional — prefer RuleType / ruleTypeSchema in
+// new code). Kept to preserve the existing public surface across the
+// codebase while consumers migrate to the generic names.
 // ============================================================================
 
-export const cleanupRuleTypeSchema = z.enum([
-	"age",
-	"size",
-	"rating",
-	"status",
-	"unmonitored",
-	"genre",
-	"year_range",
-	"no_file",
-	"quality_profile",
-	"language",
-	// File metadata rules (from cached ARR data blob)
-	"video_codec",
-	"audio_codec",
-	"resolution",
-	"hdr_type",
-	"custom_format_score",
-	"runtime",
-	"release_group",
-	// Seerr integration rules
-	"seerr_requested_by",
-	"seerr_request_age",
-	"seerr_request_status",
-	"seerr_is_4k",
-	"seerr_request_modified_age",
-	"seerr_modified_by",
-	// Tautulli integration rules
-	"tautulli_last_watched",
-	"tautulli_watch_count",
-	"tautulli_watched_by",
-	// Plex integration rules
-	"plex_last_watched",
-	"plex_watch_count",
-	"plex_on_deck",
-	"plex_user_rating",
-	"plex_watched_by",
-	// Jellyfin integration rules
-	"jellyfin_last_watched",
-	"jellyfin_watch_count",
-	"jellyfin_on_deck",
-	"jellyfin_user_rating",
-	"jellyfin_watched_by",
-	"jellyfin_added_at",
-	// Phase C: New rule types
-	"imdb_rating",
-	"file_path",
-	"seerr_is_requested",
-	"seerr_request_count",
-	"audio_channels",
-	"tag_match",
-	// Phase D: Plex metadata rules
-	"plex_collection",
-	"plex_label",
-	"plex_added_at",
-	// Phase B: Composite rules
-	"composite",
-	// Phase 2: Behavior-aware rules
-	"plex_episode_completion",
-	"jellyfin_episode_completion",
-	"user_retention",
-	"staleness_score",
-	// Phase 3: Advanced automation
-	"recently_active",
-	// Phase 4: Requester-aware cross-service rules
-	"seerr_requester_watched",
-	"seerr_requester_not_watched",
-]);
-
-export type CleanupRuleType = z.infer<typeof cleanupRuleTypeSchema>;
+export const cleanupRuleTypeSchema = ruleTypeSchema;
+export type CleanupRuleType = RuleType;
 
 // ============================================================================
-// Action & Composite Schemas (Phase A + B)
+// Cleanup-specific Action Enum
 // ============================================================================
 
 export const cleanupActionSchema = z.enum(["delete", "unmonitor", "delete_files"]);
 export type CleanupAction = z.infer<typeof cleanupActionSchema>;
 
-export const compositeOperatorSchema = z.enum(["AND", "OR"]);
-export type CompositeOperator = z.infer<typeof compositeOperatorSchema>;
-
-export const conditionSchema = z.object({
-	ruleType: cleanupRuleTypeSchema.exclude(["composite"]),
-	parameters: z.record(z.string(), z.unknown()),
-});
-export type Condition = z.infer<typeof conditionSchema>;
-
 // ============================================================================
-// Rule Parameter Schemas
-// ============================================================================
-
-export const ageRuleParamsSchema = z.object({
-	field: z.enum(["arrAddedAt"]).default("arrAddedAt"),
-	operator: z.enum(["older_than", "newer_than"]),
-	days: z.number().int().min(1),
-});
-
-export const sizeRuleParamsSchema = z.object({
-	operator: z.enum(["greater_than", "less_than"]),
-	sizeGb: z.number().positive(),
-});
-
-export const ratingRuleParamsSchema = z.object({
-	source: z.enum(["tmdb"]),
-	operator: z.enum(["less_than", "greater_than", "unrated"]),
-	score: z.number().min(0).max(10).optional(),
-});
-
-export const statusRuleParamsSchema = z.object({
-	statuses: z.array(z.string().min(1)).min(1),
-});
-
-export const unmonitoredRuleParamsSchema = z.object({});
-
-export const genreRuleParamsSchema = z.object({
-	operator: z.enum(["includes_any", "excludes_all"]),
-	genres: z.array(z.string().min(1)).min(1),
-});
-
-export const yearRangeRuleParamsSchema = z
-	.object({
-		operator: z.enum(["before", "after", "between"]),
-		year: z.number().int().optional(),
-		yearFrom: z.number().int().optional(),
-		yearTo: z.number().int().optional(),
-	})
-	.refine(
-		(data) => {
-			if (data.operator === "between")
-				return data.yearFrom != null && data.yearTo != null && data.yearFrom <= data.yearTo;
-			return data.year != null;
-		},
-		{ message: "Required fields missing for selected operator" },
-	);
-
-export const noFileRuleParamsSchema = z.object({});
-
-export const qualityProfileRuleParamsSchema = z.object({
-	profileNames: z.array(z.string().min(1)).min(1),
-});
-
-export const languageRuleParamsSchema = z.object({
-	operator: z.enum(["includes_any", "excludes_all"]),
-	languages: z.array(z.string().min(1)).min(1),
-});
-
-export const seerrRequestedByParamsSchema = z.object({
-	userNames: z.array(z.string().min(1)).min(1),
-});
-
-export const seerrRequestAgeParamsSchema = z.object({
-	operator: z.enum(["older_than", "newer_than"]),
-	days: z.number().int().min(1),
-});
-
-export const seerrRequestStatusParamsSchema = z.object({
-	statuses: z.array(z.enum(["pending", "approved", "declined", "failed", "completed"])).min(1),
-});
-
-// ── File Metadata Rule Params ────────────────────────────────────────
-
-export const videoCodecRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not"]),
-	codecs: z.array(z.string().min(1)).min(1),
-});
-
-export const audioCodecRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not"]),
-	codecs: z.array(z.string().min(1)).min(1),
-});
-
-export const resolutionRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not"]),
-	resolutions: z.array(z.string().min(1)).min(1),
-});
-
-export const hdrTypeRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not", "none"]),
-	types: z.array(z.string().min(1)).optional(), // optional when operator is "none"
-});
-
-export const customFormatScoreRuleParamsSchema = z.object({
-	operator: z.enum(["greater_than", "less_than"]),
-	score: z.number().int(),
-});
-
-export const runtimeRuleParamsSchema = z.object({
-	operator: z.enum(["greater_than", "less_than"]),
-	minutes: z.number().int().min(0),
-});
-
-export const releaseGroupRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not"]),
-	groups: z.array(z.string().min(1)).min(1),
-});
-
-// ── Enhanced Seerr Rule Params ───────────────────────────────────────
-
-export const seerrIs4kParamsSchema = z.object({
-	is4k: z.boolean(),
-});
-
-export const seerrRequestModifiedAgeParamsSchema = z.object({
-	operator: z.enum(["older_than", "newer_than"]),
-	days: z.number().int().min(1),
-});
-
-export const seerrModifiedByParamsSchema = z.object({
-	userNames: z.array(z.string().min(1)).min(1),
-});
-
-// ── Tautulli Rule Params ─────────────────────────────────────────────
-
-export const tautulliLastWatchedParamsSchema = z.object({
-	operator: z.enum(["older_than", "never"]),
-	days: z.number().int().min(1).optional(), // optional when operator is "never"
-});
-
-export const tautulliWatchCountParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than"]),
-	count: z.number().int().min(0),
-});
-
-export const tautulliWatchedByParamsSchema = z.object({
-	operator: z.enum(["includes_any", "excludes_all"]),
-	userNames: z.array(z.string().min(1)).min(1),
-});
-
-// ── Plex Rule Params ────────────────────────────────────────────────
-
-export const plexLastWatchedParamsSchema = z.object({
-	operator: z.enum(["older_than", "never"]),
-	days: z.number().int().min(1).optional(), // optional when operator is "never"
-});
-
-export const plexWatchCountParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than"]),
-	count: z.number().int().min(0),
-});
-
-export const plexOnDeckParamsSchema = z.object({
-	isDeck: z.boolean(), // true = IS on deck, false = is NOT on deck
-});
-
-export const plexUserRatingParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than", "unrated"]),
-	rating: z.number().min(0).max(10).optional(), // optional when operator is "unrated"
-});
-
-export const plexWatchedByParamsSchema = z.object({
-	operator: z.enum(["includes_any", "excludes_all"]),
-	userNames: z.array(z.string().min(1)).min(1),
-});
-
-// ── Phase C: New Rule Parameter Schemas ──────────────────────────────
-
-export const imdbRatingRuleParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than", "unrated"]),
-	score: z.number().min(0).max(10).optional(),
-});
-
-export const filePathRuleParamsSchema = z.object({
-	operator: z.enum(["matches", "not_matches"]),
-	pattern: z
-		.string()
-		.min(1)
-		.max(REGEX_MAX_LENGTH)
-		.refine((p) => getRegexSafetyError(p) === null, {
-			message:
-				"Invalid or unsafe regular expression (nested quantifiers, backreferences, or excessive repetition are not allowed)",
-		}),
-	field: z.enum(["path", "rootFolderPath"]).default("path"),
-});
-
-export const seerrIsRequestedParamsSchema = z.object({
-	isRequested: z.boolean(),
-});
-
-export const seerrRequestCountParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than", "equals"]),
-	count: z.number().int().min(0),
-});
-
-export const audioChannelsRuleParamsSchema = z.object({
-	operator: z.enum(["is", "is_not", "greater_than", "less_than"]),
-	channels: z.number().min(1).max(20),
-});
-
-export const tagMatchRuleParamsSchema = z.object({
-	operator: z.enum(["includes_any", "excludes_all"]),
-	tagIds: z.array(z.number()).min(1),
-});
-
-// ── Phase D: Plex Metadata Rule Parameter Schemas ───────────────────
-
-export const plexCollectionRuleParamsSchema = z.object({
-	operator: z.enum(["in", "not_in"]),
-	collections: z.array(z.string().min(1)).min(1),
-});
-
-export const plexLabelRuleParamsSchema = z.object({
-	operator: z.enum(["has_any", "has_none"]),
-	labels: z.array(z.string().min(1)).min(1),
-});
-
-export const plexAddedAtParamsSchema = z.object({
-	operator: z.enum(["older_than", "newer_than"]),
-	days: z.number().int().min(1),
-});
-
-// ── Jellyfin Integration Rule Parameter Schemas ─────────────────────
-// Jellyfin params share the same shapes as Plex (same operator/value patterns)
-export const jellyfinLastWatchedParamsSchema = plexLastWatchedParamsSchema;
-export const jellyfinWatchCountParamsSchema = plexWatchCountParamsSchema;
-export const jellyfinOnDeckParamsSchema = plexOnDeckParamsSchema;
-export const jellyfinUserRatingParamsSchema = plexUserRatingParamsSchema;
-export const jellyfinWatchedByParamsSchema = plexWatchedByParamsSchema;
-export const jellyfinAddedAtParamsSchema = plexAddedAtParamsSchema;
-
-// ── Phase 2: Behavior-Aware Rule Parameter Schemas ───────────────────
-
-export const plexEpisodeCompletionParamsSchema = z.object({
-	operator: z.enum(["less_than", "greater_than"]),
-	percentage: z.number().min(0).max(100),
-	minSeason: z.number().int().min(1).optional(),
-});
-
-export const jellyfinEpisodeCompletionParamsSchema = plexEpisodeCompletionParamsSchema;
-
-export const userRetentionParamsSchema = z.object({
-	operator: z.enum(["watched_by_none", "watched_by_all", "watched_by_count"]),
-	userNames: z.array(z.string().min(1)).optional(),
-	minUsers: z.number().int().min(1).optional(),
-	source: z.enum(["plex", "tautulli", "either"]).default("plex"),
-});
-
-export const stalenessScoreParamsSchema = z.object({
-	operator: z.enum(["greater_than"]),
-	threshold: z.number().min(0).max(100),
-	weights: z
-		.object({
-			daysSinceLastWatch: z.number().min(0).max(1).default(0.3),
-			inverseWatchCount: z.number().min(0).max(1).default(0.2),
-			notOnDeck: z.number().min(0).max(1).default(0.1),
-			lowUserRating: z.number().min(0).max(1).default(0.15),
-			lowTmdbRating: z.number().min(0).max(1).default(0.15),
-			sizeOnDisk: z.number().min(0).max(1).default(0.1),
-		})
-		.optional(),
-});
-
-// ── Phase 3: Advanced Automation Rule Parameter Schemas ──────────────
-
-export const recentlyActiveParamsSchema = z.object({
-	protectionDays: z.number().int().min(1).max(365),
-	requireActivity: z.boolean().default(true),
-});
-
-// ── Phase 4: Requester-Aware Cross-Service Rule Parameter Schemas ────
-
-// No user-configurable parameters — matching is automatic via display name comparison
-export const seerrRequesterWatchedParamsSchema = z.object({});
-export const seerrRequesterNotWatchedParamsSchema = z.object({});
-
-// ── Type Exports ─────────────────────────────────────────────────────
-
-export type AgeRuleParams = z.infer<typeof ageRuleParamsSchema>;
-export type SizeRuleParams = z.infer<typeof sizeRuleParamsSchema>;
-export type RatingRuleParams = z.infer<typeof ratingRuleParamsSchema>;
-export type StatusRuleParams = z.infer<typeof statusRuleParamsSchema>;
-export type UnmonitoredRuleParams = z.infer<typeof unmonitoredRuleParamsSchema>;
-export type GenreRuleParams = z.infer<typeof genreRuleParamsSchema>;
-export type YearRangeRuleParams = z.infer<typeof yearRangeRuleParamsSchema>;
-export type NoFileRuleParams = z.infer<typeof noFileRuleParamsSchema>;
-export type QualityProfileRuleParams = z.infer<typeof qualityProfileRuleParamsSchema>;
-export type LanguageRuleParams = z.infer<typeof languageRuleParamsSchema>;
-export type VideoCodecRuleParams = z.infer<typeof videoCodecRuleParamsSchema>;
-export type AudioCodecRuleParams = z.infer<typeof audioCodecRuleParamsSchema>;
-export type ResolutionRuleParams = z.infer<typeof resolutionRuleParamsSchema>;
-export type HdrTypeRuleParams = z.infer<typeof hdrTypeRuleParamsSchema>;
-export type CustomFormatScoreRuleParams = z.infer<typeof customFormatScoreRuleParamsSchema>;
-export type RuntimeRuleParams = z.infer<typeof runtimeRuleParamsSchema>;
-export type ReleaseGroupRuleParams = z.infer<typeof releaseGroupRuleParamsSchema>;
-export type SeerrRequestedByParams = z.infer<typeof seerrRequestedByParamsSchema>;
-export type SeerrRequestAgeParams = z.infer<typeof seerrRequestAgeParamsSchema>;
-export type SeerrRequestStatusParams = z.infer<typeof seerrRequestStatusParamsSchema>;
-export type SeerrIs4kParams = z.infer<typeof seerrIs4kParamsSchema>;
-export type SeerrRequestModifiedAgeParams = z.infer<typeof seerrRequestModifiedAgeParamsSchema>;
-export type SeerrModifiedByParams = z.infer<typeof seerrModifiedByParamsSchema>;
-export type TautulliLastWatchedParams = z.infer<typeof tautulliLastWatchedParamsSchema>;
-export type TautulliWatchCountParams = z.infer<typeof tautulliWatchCountParamsSchema>;
-export type TautulliWatchedByParams = z.infer<typeof tautulliWatchedByParamsSchema>;
-export type PlexLastWatchedParams = z.infer<typeof plexLastWatchedParamsSchema>;
-export type PlexWatchCountParams = z.infer<typeof plexWatchCountParamsSchema>;
-export type PlexOnDeckParams = z.infer<typeof plexOnDeckParamsSchema>;
-export type PlexUserRatingParams = z.infer<typeof plexUserRatingParamsSchema>;
-export type PlexWatchedByParams = z.infer<typeof plexWatchedByParamsSchema>;
-export type ImdbRatingRuleParams = z.infer<typeof imdbRatingRuleParamsSchema>;
-export type FilePathRuleParams = z.infer<typeof filePathRuleParamsSchema>;
-export type SeerrIsRequestedParams = z.infer<typeof seerrIsRequestedParamsSchema>;
-export type SeerrRequestCountParams = z.infer<typeof seerrRequestCountParamsSchema>;
-export type AudioChannelsRuleParams = z.infer<typeof audioChannelsRuleParamsSchema>;
-export type TagMatchRuleParams = z.infer<typeof tagMatchRuleParamsSchema>;
-export type PlexCollectionRuleParams = z.infer<typeof plexCollectionRuleParamsSchema>;
-export type PlexLabelRuleParams = z.infer<typeof plexLabelRuleParamsSchema>;
-export type PlexAddedAtParams = z.infer<typeof plexAddedAtParamsSchema>;
-export type JellyfinLastWatchedParams = z.infer<typeof jellyfinLastWatchedParamsSchema>;
-export type JellyfinWatchCountParams = z.infer<typeof jellyfinWatchCountParamsSchema>;
-export type JellyfinOnDeckParams = z.infer<typeof jellyfinOnDeckParamsSchema>;
-export type JellyfinUserRatingParams = z.infer<typeof jellyfinUserRatingParamsSchema>;
-export type JellyfinWatchedByParams = z.infer<typeof jellyfinWatchedByParamsSchema>;
-export type JellyfinAddedAtParams = z.infer<typeof jellyfinAddedAtParamsSchema>;
-export type JellyfinEpisodeCompletionParams = z.infer<typeof jellyfinEpisodeCompletionParamsSchema>;
-export type PlexEpisodeCompletionParams = z.infer<typeof plexEpisodeCompletionParamsSchema>;
-export type UserRetentionParams = z.infer<typeof userRetentionParamsSchema>;
-export type StalenessScoreParams = z.infer<typeof stalenessScoreParamsSchema>;
-export type RecentlyActiveParams = z.infer<typeof recentlyActiveParamsSchema>;
-export type SeerrRequesterWatchedParams = z.infer<typeof seerrRequesterWatchedParamsSchema>;
-export type SeerrRequesterNotWatchedParams = z.infer<typeof seerrRequesterNotWatchedParamsSchema>;
-
-// ============================================================================
-// Configuration Types
+// Cleanup Rule Schema — generic criteria + cleanup-specific filters/action
 // ============================================================================
 
 const baseCleanupRuleSchema = z.object({
 	name: z.string().min(1).max(100),
 	enabled: z.boolean().optional().default(true),
 	priority: z.number().int().optional().default(0),
-	ruleType: cleanupRuleTypeSchema,
+	ruleType: ruleTypeSchema,
 	parameters: z.record(z.string(), z.unknown()), // Validated per-type at runtime
 	serviceFilter: z.array(z.string()).nullable().optional(),
 	instanceFilter: z.array(z.string()).nullable().optional(),
@@ -516,7 +129,7 @@ export interface CleanupRuleResponse {
 	name: string;
 	enabled: boolean;
 	priority: number;
-	ruleType: CleanupRuleType;
+	ruleType: RuleType;
 	parameters: Record<string, unknown>;
 	serviceFilter: string[] | null;
 	instanceFilter: string[] | null;
@@ -713,105 +326,3 @@ export interface CleanupStatisticsResponse {
 		expired: number;
 	};
 }
-
-// ============================================================================
-// Rule Parameter Validation Map
-// ============================================================================
-
-/** Map of rule type → its Zod parameter schema, used for write-time validation */
-export const ruleParamSchemaMap: Record<string, z.ZodType> = {
-	age: ageRuleParamsSchema,
-	size: sizeRuleParamsSchema,
-	rating: ratingRuleParamsSchema,
-	status: statusRuleParamsSchema,
-	unmonitored: unmonitoredRuleParamsSchema,
-	genre: genreRuleParamsSchema,
-	year_range: yearRangeRuleParamsSchema,
-	no_file: noFileRuleParamsSchema,
-	quality_profile: qualityProfileRuleParamsSchema,
-	language: languageRuleParamsSchema,
-	video_codec: videoCodecRuleParamsSchema,
-	audio_codec: audioCodecRuleParamsSchema,
-	resolution: resolutionRuleParamsSchema,
-	hdr_type: hdrTypeRuleParamsSchema,
-	custom_format_score: customFormatScoreRuleParamsSchema,
-	runtime: runtimeRuleParamsSchema,
-	release_group: releaseGroupRuleParamsSchema,
-	seerr_requested_by: seerrRequestedByParamsSchema,
-	seerr_request_age: seerrRequestAgeParamsSchema,
-	seerr_request_status: seerrRequestStatusParamsSchema,
-	seerr_is_4k: seerrIs4kParamsSchema,
-	seerr_request_modified_age: seerrRequestModifiedAgeParamsSchema,
-	seerr_modified_by: seerrModifiedByParamsSchema,
-	seerr_is_requested: seerrIsRequestedParamsSchema,
-	seerr_request_count: seerrRequestCountParamsSchema,
-	tautulli_last_watched: tautulliLastWatchedParamsSchema,
-	tautulli_watch_count: tautulliWatchCountParamsSchema,
-	tautulli_watched_by: tautulliWatchedByParamsSchema,
-	plex_last_watched: plexLastWatchedParamsSchema,
-	plex_watch_count: plexWatchCountParamsSchema,
-	plex_on_deck: plexOnDeckParamsSchema,
-	plex_user_rating: plexUserRatingParamsSchema,
-	plex_watched_by: plexWatchedByParamsSchema,
-	plex_collection: plexCollectionRuleParamsSchema,
-	plex_label: plexLabelRuleParamsSchema,
-	plex_added_at: plexAddedAtParamsSchema,
-	jellyfin_last_watched: jellyfinLastWatchedParamsSchema,
-	jellyfin_watch_count: jellyfinWatchCountParamsSchema,
-	jellyfin_on_deck: jellyfinOnDeckParamsSchema,
-	jellyfin_user_rating: jellyfinUserRatingParamsSchema,
-	jellyfin_watched_by: jellyfinWatchedByParamsSchema,
-	jellyfin_added_at: jellyfinAddedAtParamsSchema,
-	imdb_rating: imdbRatingRuleParamsSchema,
-	file_path: filePathRuleParamsSchema,
-	audio_channels: audioChannelsRuleParamsSchema,
-	tag_match: tagMatchRuleParamsSchema,
-	plex_episode_completion: plexEpisodeCompletionParamsSchema,
-	jellyfin_episode_completion: jellyfinEpisodeCompletionParamsSchema,
-	user_retention: userRetentionParamsSchema,
-	staleness_score: stalenessScoreParamsSchema,
-	recently_active: recentlyActiveParamsSchema,
-	seerr_requester_watched: seerrRequesterWatchedParamsSchema,
-	seerr_requester_not_watched: seerrRequesterNotWatchedParamsSchema,
-};
-
-/**
- * Data source each rule type depends on.
- * Rules whose data source fails should be skipped to avoid false matches.
- */
-export type DataSourceDependency = "seerr" | "tautulli" | "plex" | "jellyfin" | null;
-
-export const ruleDataSourceMap: Record<string, DataSourceDependency> = {
-	seerr_requested_by: "seerr",
-	seerr_request_age: "seerr",
-	seerr_request_status: "seerr",
-	seerr_is_4k: "seerr",
-	seerr_request_modified_age: "seerr",
-	seerr_modified_by: "seerr",
-	seerr_is_requested: "seerr",
-	seerr_request_count: "seerr",
-	tautulli_last_watched: "tautulli",
-	tautulli_watch_count: "tautulli",
-	tautulli_watched_by: "tautulli",
-	plex_last_watched: "plex",
-	plex_watch_count: "plex",
-	plex_on_deck: "plex",
-	plex_user_rating: "plex",
-	plex_watched_by: "plex",
-	plex_collection: "plex",
-	plex_label: "plex",
-	plex_added_at: "plex",
-	jellyfin_last_watched: "jellyfin",
-	jellyfin_watch_count: "jellyfin",
-	jellyfin_on_deck: "jellyfin",
-	jellyfin_user_rating: "jellyfin",
-	jellyfin_watched_by: "jellyfin",
-	jellyfin_added_at: "jellyfin",
-	jellyfin_episode_completion: "jellyfin",
-	plex_episode_completion: "plex",
-	user_retention: null, // Dynamic: depends on params.source (plex, tautulli, or either)
-	staleness_score: "plex", // Uses multiple sources; plex is the primary
-	recently_active: "plex", // Checks Plex on-deck/watch status
-	seerr_requester_watched: "seerr", // Also needs plex — both prefetch lists include these types
-	seerr_requester_not_watched: "seerr", // Also needs plex — both prefetch lists include these types
-};

--- a/packages/shared/src/types/rule-criteria.ts
+++ b/packages/shared/src/types/rule-criteria.ts
@@ -1,0 +1,539 @@
+/**
+ * Rule Criteria — generic, feature-agnostic types for the rule engine.
+ *
+ * These types describe the *criteria* half of a rule (what to match against
+ * a media item). Features that consume this — like Library Cleanup or the
+ * Auto-Tagger — wrap these criteria with their own action layer (delete /
+ * unmonitor / apply-tag / etc.) and rule-management metadata (priority,
+ * action-specific filters, …).
+ *
+ * Feature-specific shapes live in their own type files (e.g.
+ * `library-cleanup.ts`); this file is the single source of truth for the
+ * cross-feature criteria language.
+ */
+
+import { z } from "zod";
+import { getRegexSafetyError, REGEX_MAX_LENGTH } from "./regex-safety.js";
+
+// ============================================================================
+// Rule Type Enum
+// ============================================================================
+
+export const ruleTypeSchema = z.enum([
+	"age",
+	"size",
+	"rating",
+	"status",
+	"unmonitored",
+	"genre",
+	"year_range",
+	"no_file",
+	"quality_profile",
+	"language",
+	// File metadata rules (from cached ARR data blob)
+	"video_codec",
+	"audio_codec",
+	"resolution",
+	"hdr_type",
+	"custom_format_score",
+	"runtime",
+	"release_group",
+	// Seerr integration rules
+	"seerr_requested_by",
+	"seerr_request_age",
+	"seerr_request_status",
+	"seerr_is_4k",
+	"seerr_request_modified_age",
+	"seerr_modified_by",
+	// Tautulli integration rules
+	"tautulli_last_watched",
+	"tautulli_watch_count",
+	"tautulli_watched_by",
+	// Plex integration rules
+	"plex_last_watched",
+	"plex_watch_count",
+	"plex_on_deck",
+	"plex_user_rating",
+	"plex_watched_by",
+	// Jellyfin integration rules
+	"jellyfin_last_watched",
+	"jellyfin_watch_count",
+	"jellyfin_on_deck",
+	"jellyfin_user_rating",
+	"jellyfin_watched_by",
+	"jellyfin_added_at",
+	// Phase C: New rule types
+	"imdb_rating",
+	"file_path",
+	"seerr_is_requested",
+	"seerr_request_count",
+	"audio_channels",
+	"tag_match",
+	// Phase D: Plex metadata rules
+	"plex_collection",
+	"plex_label",
+	"plex_added_at",
+	// Phase B: Composite rules
+	"composite",
+	// Phase 2: Behavior-aware rules
+	"plex_episode_completion",
+	"jellyfin_episode_completion",
+	"user_retention",
+	"staleness_score",
+	// Phase 3: Advanced automation
+	"recently_active",
+	// Phase 4: Requester-aware cross-service rules
+	"seerr_requester_watched",
+	"seerr_requester_not_watched",
+]);
+
+export type RuleType = z.infer<typeof ruleTypeSchema>;
+
+// ============================================================================
+// Composite Operator + Condition shape
+// ============================================================================
+
+export const compositeOperatorSchema = z.enum(["AND", "OR"]);
+export type CompositeOperator = z.infer<typeof compositeOperatorSchema>;
+
+export const conditionSchema = z.object({
+	ruleType: ruleTypeSchema.exclude(["composite"]),
+	parameters: z.record(z.string(), z.unknown()),
+});
+export type Condition = z.infer<typeof conditionSchema>;
+
+// ============================================================================
+// Per-Rule-Type Parameter Schemas
+// ============================================================================
+
+export const ageRuleParamsSchema = z.object({
+	field: z.enum(["arrAddedAt"]).default("arrAddedAt"),
+	operator: z.enum(["older_than", "newer_than"]),
+	days: z.number().int().min(1),
+});
+
+export const sizeRuleParamsSchema = z.object({
+	operator: z.enum(["greater_than", "less_than"]),
+	sizeGb: z.number().positive(),
+});
+
+export const ratingRuleParamsSchema = z.object({
+	source: z.enum(["tmdb"]),
+	operator: z.enum(["less_than", "greater_than", "unrated"]),
+	score: z.number().min(0).max(10).optional(),
+});
+
+export const statusRuleParamsSchema = z.object({
+	statuses: z.array(z.string().min(1)).min(1),
+});
+
+export const unmonitoredRuleParamsSchema = z.object({});
+
+export const genreRuleParamsSchema = z.object({
+	operator: z.enum(["includes_any", "excludes_all"]),
+	genres: z.array(z.string().min(1)).min(1),
+});
+
+export const yearRangeRuleParamsSchema = z
+	.object({
+		operator: z.enum(["before", "after", "between"]),
+		year: z.number().int().optional(),
+		yearFrom: z.number().int().optional(),
+		yearTo: z.number().int().optional(),
+	})
+	.refine(
+		(data) => {
+			if (data.operator === "between")
+				return data.yearFrom != null && data.yearTo != null && data.yearFrom <= data.yearTo;
+			return data.year != null;
+		},
+		{ message: "Required fields missing for selected operator" },
+	);
+
+export const noFileRuleParamsSchema = z.object({});
+
+export const qualityProfileRuleParamsSchema = z.object({
+	profileNames: z.array(z.string().min(1)).min(1),
+});
+
+export const languageRuleParamsSchema = z.object({
+	operator: z.enum(["includes_any", "excludes_all"]),
+	languages: z.array(z.string().min(1)).min(1),
+});
+
+export const seerrRequestedByParamsSchema = z.object({
+	userNames: z.array(z.string().min(1)).min(1),
+});
+
+export const seerrRequestAgeParamsSchema = z.object({
+	operator: z.enum(["older_than", "newer_than"]),
+	days: z.number().int().min(1),
+});
+
+export const seerrRequestStatusParamsSchema = z.object({
+	statuses: z.array(z.enum(["pending", "approved", "declined", "failed", "completed"])).min(1),
+});
+
+// ── File Metadata Rule Params ────────────────────────────────────────
+
+export const videoCodecRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not"]),
+	codecs: z.array(z.string().min(1)).min(1),
+});
+
+export const audioCodecRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not"]),
+	codecs: z.array(z.string().min(1)).min(1),
+});
+
+export const resolutionRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not"]),
+	resolutions: z.array(z.string().min(1)).min(1),
+});
+
+export const hdrTypeRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not", "none"]),
+	types: z.array(z.string().min(1)).optional(), // optional when operator is "none"
+});
+
+export const customFormatScoreRuleParamsSchema = z.object({
+	operator: z.enum(["greater_than", "less_than"]),
+	score: z.number().int(),
+});
+
+export const runtimeRuleParamsSchema = z.object({
+	operator: z.enum(["greater_than", "less_than"]),
+	minutes: z.number().int().min(0),
+});
+
+export const releaseGroupRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not"]),
+	groups: z.array(z.string().min(1)).min(1),
+});
+
+// ── Enhanced Seerr Rule Params ───────────────────────────────────────
+
+export const seerrIs4kParamsSchema = z.object({
+	is4k: z.boolean(),
+});
+
+export const seerrRequestModifiedAgeParamsSchema = z.object({
+	operator: z.enum(["older_than", "newer_than"]),
+	days: z.number().int().min(1),
+});
+
+export const seerrModifiedByParamsSchema = z.object({
+	userNames: z.array(z.string().min(1)).min(1),
+});
+
+// ── Tautulli Rule Params ─────────────────────────────────────────────
+
+export const tautulliLastWatchedParamsSchema = z.object({
+	operator: z.enum(["older_than", "never"]),
+	days: z.number().int().min(1).optional(),
+});
+
+export const tautulliWatchCountParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than"]),
+	count: z.number().int().min(0),
+});
+
+export const tautulliWatchedByParamsSchema = z.object({
+	operator: z.enum(["includes_any", "excludes_all"]),
+	userNames: z.array(z.string().min(1)).min(1),
+});
+
+// ── Plex Rule Params ────────────────────────────────────────────────
+
+export const plexLastWatchedParamsSchema = z.object({
+	operator: z.enum(["older_than", "never"]),
+	days: z.number().int().min(1).optional(),
+});
+
+export const plexWatchCountParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than"]),
+	count: z.number().int().min(0),
+});
+
+export const plexOnDeckParamsSchema = z.object({
+	isDeck: z.boolean(),
+});
+
+export const plexUserRatingParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than", "unrated"]),
+	rating: z.number().min(0).max(10).optional(),
+});
+
+export const plexWatchedByParamsSchema = z.object({
+	operator: z.enum(["includes_any", "excludes_all"]),
+	userNames: z.array(z.string().min(1)).min(1),
+});
+
+// ── Phase C: New Rule Parameter Schemas ──────────────────────────────
+
+export const imdbRatingRuleParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than", "unrated"]),
+	score: z.number().min(0).max(10).optional(),
+});
+
+export const filePathRuleParamsSchema = z.object({
+	operator: z.enum(["matches", "not_matches"]),
+	pattern: z
+		.string()
+		.min(1)
+		.max(REGEX_MAX_LENGTH)
+		.refine((p) => getRegexSafetyError(p) === null, {
+			message:
+				"Invalid or unsafe regular expression (nested quantifiers, backreferences, or excessive repetition are not allowed)",
+		}),
+	field: z.enum(["path", "rootFolderPath"]).default("path"),
+});
+
+export const seerrIsRequestedParamsSchema = z.object({
+	isRequested: z.boolean(),
+});
+
+export const seerrRequestCountParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than", "equals"]),
+	count: z.number().int().min(0),
+});
+
+export const audioChannelsRuleParamsSchema = z.object({
+	operator: z.enum(["is", "is_not", "greater_than", "less_than"]),
+	channels: z.number().min(1).max(20),
+});
+
+export const tagMatchRuleParamsSchema = z.object({
+	operator: z.enum(["includes_any", "excludes_all"]),
+	tagIds: z.array(z.number()).min(1),
+});
+
+// ── Phase D: Plex Metadata Rule Parameter Schemas ───────────────────
+
+export const plexCollectionRuleParamsSchema = z.object({
+	operator: z.enum(["in", "not_in"]),
+	collections: z.array(z.string().min(1)).min(1),
+});
+
+export const plexLabelRuleParamsSchema = z.object({
+	operator: z.enum(["has_any", "has_none"]),
+	labels: z.array(z.string().min(1)).min(1),
+});
+
+export const plexAddedAtParamsSchema = z.object({
+	operator: z.enum(["older_than", "newer_than"]),
+	days: z.number().int().min(1),
+});
+
+// ── Jellyfin Integration Rule Parameter Schemas ─────────────────────
+// Jellyfin params share the same shapes as Plex (same operator/value patterns)
+export const jellyfinLastWatchedParamsSchema = plexLastWatchedParamsSchema;
+export const jellyfinWatchCountParamsSchema = plexWatchCountParamsSchema;
+export const jellyfinOnDeckParamsSchema = plexOnDeckParamsSchema;
+export const jellyfinUserRatingParamsSchema = plexUserRatingParamsSchema;
+export const jellyfinWatchedByParamsSchema = plexWatchedByParamsSchema;
+export const jellyfinAddedAtParamsSchema = plexAddedAtParamsSchema;
+
+// ── Phase 2: Behavior-Aware Rule Parameter Schemas ───────────────────
+
+export const plexEpisodeCompletionParamsSchema = z.object({
+	operator: z.enum(["less_than", "greater_than"]),
+	percentage: z.number().min(0).max(100),
+	minSeason: z.number().int().min(1).optional(),
+});
+
+export const jellyfinEpisodeCompletionParamsSchema = plexEpisodeCompletionParamsSchema;
+
+export const userRetentionParamsSchema = z.object({
+	operator: z.enum(["watched_by_none", "watched_by_all", "watched_by_count"]),
+	userNames: z.array(z.string().min(1)).optional(),
+	minUsers: z.number().int().min(1).optional(),
+	source: z.enum(["plex", "tautulli", "either"]).default("plex"),
+});
+
+export const stalenessScoreParamsSchema = z.object({
+	operator: z.enum(["greater_than"]),
+	threshold: z.number().min(0).max(100),
+	weights: z
+		.object({
+			daysSinceLastWatch: z.number().min(0).max(1).default(0.3),
+			inverseWatchCount: z.number().min(0).max(1).default(0.2),
+			notOnDeck: z.number().min(0).max(1).default(0.1),
+			lowUserRating: z.number().min(0).max(1).default(0.15),
+			lowTmdbRating: z.number().min(0).max(1).default(0.15),
+			sizeOnDisk: z.number().min(0).max(1).default(0.1),
+		})
+		.optional(),
+});
+
+// ── Phase 3: Advanced Automation Rule Parameter Schemas ──────────────
+
+export const recentlyActiveParamsSchema = z.object({
+	protectionDays: z.number().int().min(1).max(365),
+	requireActivity: z.boolean().default(true),
+});
+
+// ── Phase 4: Requester-Aware Cross-Service Rule Parameter Schemas ────
+
+export const seerrRequesterWatchedParamsSchema = z.object({});
+export const seerrRequesterNotWatchedParamsSchema = z.object({});
+
+// ============================================================================
+// Type Exports — z.infer projections of every params schema
+// ============================================================================
+
+export type AgeRuleParams = z.infer<typeof ageRuleParamsSchema>;
+export type SizeRuleParams = z.infer<typeof sizeRuleParamsSchema>;
+export type RatingRuleParams = z.infer<typeof ratingRuleParamsSchema>;
+export type StatusRuleParams = z.infer<typeof statusRuleParamsSchema>;
+export type UnmonitoredRuleParams = z.infer<typeof unmonitoredRuleParamsSchema>;
+export type GenreRuleParams = z.infer<typeof genreRuleParamsSchema>;
+export type YearRangeRuleParams = z.infer<typeof yearRangeRuleParamsSchema>;
+export type NoFileRuleParams = z.infer<typeof noFileRuleParamsSchema>;
+export type QualityProfileRuleParams = z.infer<typeof qualityProfileRuleParamsSchema>;
+export type LanguageRuleParams = z.infer<typeof languageRuleParamsSchema>;
+export type VideoCodecRuleParams = z.infer<typeof videoCodecRuleParamsSchema>;
+export type AudioCodecRuleParams = z.infer<typeof audioCodecRuleParamsSchema>;
+export type ResolutionRuleParams = z.infer<typeof resolutionRuleParamsSchema>;
+export type HdrTypeRuleParams = z.infer<typeof hdrTypeRuleParamsSchema>;
+export type CustomFormatScoreRuleParams = z.infer<typeof customFormatScoreRuleParamsSchema>;
+export type RuntimeRuleParams = z.infer<typeof runtimeRuleParamsSchema>;
+export type ReleaseGroupRuleParams = z.infer<typeof releaseGroupRuleParamsSchema>;
+export type SeerrRequestedByParams = z.infer<typeof seerrRequestedByParamsSchema>;
+export type SeerrRequestAgeParams = z.infer<typeof seerrRequestAgeParamsSchema>;
+export type SeerrRequestStatusParams = z.infer<typeof seerrRequestStatusParamsSchema>;
+export type SeerrIs4kParams = z.infer<typeof seerrIs4kParamsSchema>;
+export type SeerrRequestModifiedAgeParams = z.infer<typeof seerrRequestModifiedAgeParamsSchema>;
+export type SeerrModifiedByParams = z.infer<typeof seerrModifiedByParamsSchema>;
+export type TautulliLastWatchedParams = z.infer<typeof tautulliLastWatchedParamsSchema>;
+export type TautulliWatchCountParams = z.infer<typeof tautulliWatchCountParamsSchema>;
+export type TautulliWatchedByParams = z.infer<typeof tautulliWatchedByParamsSchema>;
+export type PlexLastWatchedParams = z.infer<typeof plexLastWatchedParamsSchema>;
+export type PlexWatchCountParams = z.infer<typeof plexWatchCountParamsSchema>;
+export type PlexOnDeckParams = z.infer<typeof plexOnDeckParamsSchema>;
+export type PlexUserRatingParams = z.infer<typeof plexUserRatingParamsSchema>;
+export type PlexWatchedByParams = z.infer<typeof plexWatchedByParamsSchema>;
+export type ImdbRatingRuleParams = z.infer<typeof imdbRatingRuleParamsSchema>;
+export type FilePathRuleParams = z.infer<typeof filePathRuleParamsSchema>;
+export type SeerrIsRequestedParams = z.infer<typeof seerrIsRequestedParamsSchema>;
+export type SeerrRequestCountParams = z.infer<typeof seerrRequestCountParamsSchema>;
+export type AudioChannelsRuleParams = z.infer<typeof audioChannelsRuleParamsSchema>;
+export type TagMatchRuleParams = z.infer<typeof tagMatchRuleParamsSchema>;
+export type PlexCollectionRuleParams = z.infer<typeof plexCollectionRuleParamsSchema>;
+export type PlexLabelRuleParams = z.infer<typeof plexLabelRuleParamsSchema>;
+export type PlexAddedAtParams = z.infer<typeof plexAddedAtParamsSchema>;
+export type JellyfinLastWatchedParams = z.infer<typeof jellyfinLastWatchedParamsSchema>;
+export type JellyfinWatchCountParams = z.infer<typeof jellyfinWatchCountParamsSchema>;
+export type JellyfinOnDeckParams = z.infer<typeof jellyfinOnDeckParamsSchema>;
+export type JellyfinUserRatingParams = z.infer<typeof jellyfinUserRatingParamsSchema>;
+export type JellyfinWatchedByParams = z.infer<typeof jellyfinWatchedByParamsSchema>;
+export type JellyfinAddedAtParams = z.infer<typeof jellyfinAddedAtParamsSchema>;
+export type JellyfinEpisodeCompletionParams = z.infer<typeof jellyfinEpisodeCompletionParamsSchema>;
+export type PlexEpisodeCompletionParams = z.infer<typeof plexEpisodeCompletionParamsSchema>;
+export type UserRetentionParams = z.infer<typeof userRetentionParamsSchema>;
+export type StalenessScoreParams = z.infer<typeof stalenessScoreParamsSchema>;
+export type RecentlyActiveParams = z.infer<typeof recentlyActiveParamsSchema>;
+export type SeerrRequesterWatchedParams = z.infer<typeof seerrRequesterWatchedParamsSchema>;
+export type SeerrRequesterNotWatchedParams = z.infer<typeof seerrRequesterNotWatchedParamsSchema>;
+
+// ============================================================================
+// Rule Parameter Validation Map
+// ============================================================================
+
+/** Map of rule type → its Zod parameter schema, used for write-time validation */
+export const ruleParamSchemaMap: Record<string, z.ZodType> = {
+	age: ageRuleParamsSchema,
+	size: sizeRuleParamsSchema,
+	rating: ratingRuleParamsSchema,
+	status: statusRuleParamsSchema,
+	unmonitored: unmonitoredRuleParamsSchema,
+	genre: genreRuleParamsSchema,
+	year_range: yearRangeRuleParamsSchema,
+	no_file: noFileRuleParamsSchema,
+	quality_profile: qualityProfileRuleParamsSchema,
+	language: languageRuleParamsSchema,
+	video_codec: videoCodecRuleParamsSchema,
+	audio_codec: audioCodecRuleParamsSchema,
+	resolution: resolutionRuleParamsSchema,
+	hdr_type: hdrTypeRuleParamsSchema,
+	custom_format_score: customFormatScoreRuleParamsSchema,
+	runtime: runtimeRuleParamsSchema,
+	release_group: releaseGroupRuleParamsSchema,
+	seerr_requested_by: seerrRequestedByParamsSchema,
+	seerr_request_age: seerrRequestAgeParamsSchema,
+	seerr_request_status: seerrRequestStatusParamsSchema,
+	seerr_is_4k: seerrIs4kParamsSchema,
+	seerr_request_modified_age: seerrRequestModifiedAgeParamsSchema,
+	seerr_modified_by: seerrModifiedByParamsSchema,
+	seerr_is_requested: seerrIsRequestedParamsSchema,
+	seerr_request_count: seerrRequestCountParamsSchema,
+	tautulli_last_watched: tautulliLastWatchedParamsSchema,
+	tautulli_watch_count: tautulliWatchCountParamsSchema,
+	tautulli_watched_by: tautulliWatchedByParamsSchema,
+	plex_last_watched: plexLastWatchedParamsSchema,
+	plex_watch_count: plexWatchCountParamsSchema,
+	plex_on_deck: plexOnDeckParamsSchema,
+	plex_user_rating: plexUserRatingParamsSchema,
+	plex_watched_by: plexWatchedByParamsSchema,
+	plex_collection: plexCollectionRuleParamsSchema,
+	plex_label: plexLabelRuleParamsSchema,
+	plex_added_at: plexAddedAtParamsSchema,
+	jellyfin_last_watched: jellyfinLastWatchedParamsSchema,
+	jellyfin_watch_count: jellyfinWatchCountParamsSchema,
+	jellyfin_on_deck: jellyfinOnDeckParamsSchema,
+	jellyfin_user_rating: jellyfinUserRatingParamsSchema,
+	jellyfin_watched_by: jellyfinWatchedByParamsSchema,
+	jellyfin_added_at: jellyfinAddedAtParamsSchema,
+	imdb_rating: imdbRatingRuleParamsSchema,
+	file_path: filePathRuleParamsSchema,
+	audio_channels: audioChannelsRuleParamsSchema,
+	tag_match: tagMatchRuleParamsSchema,
+	plex_episode_completion: plexEpisodeCompletionParamsSchema,
+	jellyfin_episode_completion: jellyfinEpisodeCompletionParamsSchema,
+	user_retention: userRetentionParamsSchema,
+	staleness_score: stalenessScoreParamsSchema,
+	recently_active: recentlyActiveParamsSchema,
+	seerr_requester_watched: seerrRequesterWatchedParamsSchema,
+	seerr_requester_not_watched: seerrRequesterNotWatchedParamsSchema,
+};
+
+/**
+ * Data source each rule type depends on.
+ * Rules whose data source fails should be skipped to avoid false matches.
+ */
+export type DataSourceDependency = "seerr" | "tautulli" | "plex" | "jellyfin" | null;
+
+export const ruleDataSourceMap: Record<string, DataSourceDependency> = {
+	seerr_requested_by: "seerr",
+	seerr_request_age: "seerr",
+	seerr_request_status: "seerr",
+	seerr_is_4k: "seerr",
+	seerr_request_modified_age: "seerr",
+	seerr_modified_by: "seerr",
+	seerr_is_requested: "seerr",
+	seerr_request_count: "seerr",
+	tautulli_last_watched: "tautulli",
+	tautulli_watch_count: "tautulli",
+	tautulli_watched_by: "tautulli",
+	plex_last_watched: "plex",
+	plex_watch_count: "plex",
+	plex_on_deck: "plex",
+	plex_user_rating: "plex",
+	plex_watched_by: "plex",
+	plex_collection: "plex",
+	plex_label: "plex",
+	plex_added_at: "plex",
+	jellyfin_last_watched: "jellyfin",
+	jellyfin_watch_count: "jellyfin",
+	jellyfin_on_deck: "jellyfin",
+	jellyfin_user_rating: "jellyfin",
+	jellyfin_watched_by: "jellyfin",
+	jellyfin_added_at: "jellyfin",
+	jellyfin_episode_completion: "jellyfin",
+	plex_episode_completion: "plex",
+	user_retention: null, // Dynamic: depends on params.source
+	staleness_score: "plex",
+	recently_active: "plex",
+	seerr_requester_watched: "seerr",
+	seerr_requester_not_watched: "seerr",
+};


### PR DESCRIPTION
## Summary

Pure-refactor prep for the upcoming Auto-Tagger feature. Splits the rule-criteria types out of `library-cleanup.ts` into a new neutral `packages/shared/src/types/rule-criteria.ts` so the auto-tagger can share the same DSL (and 30+ rule types) without depending on a cleanup-named module.

**No behavior change.** Library Cleanup is byte-identical at runtime.

## What moved

- `cleanupRuleTypeSchema` → renamed `ruleTypeSchema` (legacy alias kept)
- `CleanupRuleType` → renamed `RuleType` (legacy alias kept)
- `Condition`, `CompositeOperator`, `compositeOperatorSchema`, `conditionSchema`
- ~50 `*RuleParams` schemas + types (age, size, rating, status, genre, year_range, video/audio codec, resolution, hdr_type, custom_format_score, runtime, release_group, all the seerr_*/tautulli_*/plex_*/jellyfin_* rules, file_path, tag_match, plex_collection, plex_label, plex_added_at, behavior-aware staleness/retention rules)
- `ruleParamSchemaMap` (write-time validation dispatch)
- `DataSourceDependency`, `ruleDataSourceMap`

## What stayed in `library-cleanup.ts`

Strictly cleanup-specific surface:
- `cleanupActionSchema` / `CleanupAction` (delete/unmonitor/delete_files)
- `baseCleanupRuleSchema` and create/update/reorder/config schemas (wrap the generic criteria with cleanup-specific filters + action)
- All response shapes (`CleanupRuleResponse`, `CleanupConfigResponse`, `CleanupApprovalResponse`, …)
- Preview, explain, statistics, prefetch-health types
- Approval queue types

## Backward compatibility

Legacy export names (`cleanupRuleTypeSchema`, `CleanupRuleType`) kept as aliases pointing to the new generic names. **Every existing import across the codebase continues to resolve unchanged.**

## What did *not* move (and why)

- **Evaluator** (`apps/api/src/lib/library-cleanup/rule-evaluators.ts`) — stays where it is. The Auto-Tagger PR will import from there directly. Moving it is pure code-organization churn that doesn't unblock anything new and would inflate this PR's review surface.
- **Criteria UI components** (`condition-params-fields.tsx`, `multi-select-field.tsx`) — same reasoning. Auto-Tagger UI can import from `features/library-cleanup/components/`.

Both could move in a follow-up cleanup PR if desired, but they're not on the critical path.

## Test plan

- [x] `pnpm --filter @arr/shared build` — clean (dist 352 KB → 355 KB for the re-exports)
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api run test` — **1383 passed / 36 skipped, no regressions**
- [x] `pnpm run lint` — no new findings
- [ ] CI green
- [ ] Library Cleanup page rule builder still works (smoke check via UI)

Refs: prep for Auto-Tagger arc (`memory/auto-tagger-arc.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)