### PR TITLE
fix(auto-tag): per-rule lock prevents scheduler/on-demand race

### DIFF
--- a/apps/api/src/lib/auto-tag/__tests__/run-with-lock.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/run-with-lock.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Tests for the per-rule concurrency lock.
+ *
+ * The lock's whole job is preventing two concurrent runs of the same rule —
+ * which is exactly what these tests pin: a second invocation arriving while
+ * the first is still in flight must be rejected with `skipped`.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { _clearInFlightForTesting, runRuleWithLock } from "../run-with-lock.js";
+
+describe("runRuleWithLock", () => {
+	afterEach(() => {
+		_clearInFlightForTesting();
+	});
+
+	it("ran path: returns the function's result wrapped with status='ran'", async () => {
+		const fn = vi.fn().mockResolvedValue({ message: "ok", count: 3 });
+		const result = await runRuleWithLock("rule-1", fn);
+		expect(result).toEqual({ status: "ran", result: { message: "ok", count: 3 } });
+		expect(fn).toHaveBeenCalledOnce();
+	});
+
+	it("skips a second concurrent call for the same rule id", async () => {
+		// First call hangs forever (controlled via promise resolver) — the
+		// second call must arrive while the first is still in flight.
+		let resolveFirst: (value: string) => void = () => {};
+		const firstPromise = new Promise<string>((r) => {
+			resolveFirst = r;
+		});
+
+		const fnFirst = vi.fn().mockImplementation(() => firstPromise);
+		const fnSecond = vi.fn().mockResolvedValue("second");
+
+		const inflight = runRuleWithLock("rule-1", fnFirst);
+		// Yield a tick so the lock acquisition happens
+		await Promise.resolve();
+
+		const skipped = await runRuleWithLock("rule-1", fnSecond);
+		expect(skipped).toEqual({ status: "skipped", reason: "already-running" });
+		expect(fnSecond).not.toHaveBeenCalled();
+
+		// Clean up the in-flight call so the test doesn't leak state
+		resolveFirst("first");
+		await inflight;
+	});
+
+	it("releases the lock after the first call completes — second call afterwards runs", async () => {
+		const fn1 = vi.fn().mockResolvedValue("first");
+		await runRuleWithLock("rule-1", fn1);
+
+		const fn2 = vi.fn().mockResolvedValue("second");
+		const result = await runRuleWithLock("rule-1", fn2);
+		expect(result).toEqual({ status: "ran", result: "second" });
+		expect(fn2).toHaveBeenCalledOnce();
+	});
+
+	it("releases the lock even when fn throws", async () => {
+		const fn1 = vi.fn().mockRejectedValue(new Error("boom"));
+		await expect(runRuleWithLock("rule-1", fn1)).rejects.toThrow("boom");
+
+		// Lock must be released so subsequent calls can run.
+		const fn2 = vi.fn().mockResolvedValue("recovered");
+		const result = await runRuleWithLock("rule-1", fn2);
+		expect(result).toEqual({ status: "ran", result: "recovered" });
+	});
+
+	it("different rule ids run concurrently without blocking each other", async () => {
+		// Both first calls hang. We're proving rule-1's lock doesn't block rule-2.
+		let resolveA: (v: string) => void = () => {};
+		let resolveB: (v: string) => void = () => {};
+		const aPromise = new Promise<string>((r) => {
+			resolveA = r;
+		});
+		const bPromise = new Promise<string>((r) => {
+			resolveB = r;
+		});
+
+		const aRun = runRuleWithLock("rule-a", () => aPromise);
+		const bRun = runRuleWithLock("rule-b", () => bPromise);
+
+		// Both should be in-flight, neither skipped.
+		await Promise.resolve();
+
+		resolveA("a-done");
+		resolveB("b-done");
+
+		const [aResult, bResult] = await Promise.all([aRun, bRun]);
+		expect(aResult).toEqual({ status: "ran", result: "a-done" });
+		expect(bResult).toEqual({ status: "ran", result: "b-done" });
+	});
+});

--- a/apps/api/src/lib/auto-tag/auto-tag-scheduler.ts
+++ b/apps/api/src/lib/auto-tag/auto-tag-scheduler.ts
@@ -21,6 +21,7 @@ import {
 	type TickWrapper,
 } from "../scheduler-registry/scheduler-registry.js";
 import { executeAutoTagRule } from "./execute-rule.js";
+import { runRuleWithLock } from "./run-with-lock.js";
 
 const TICK_INTERVAL_MS = 5 * 60 * 1000; // Wake every 5 minutes
 const RULE_COOLDOWN_MS = 60 * 60 * 1000; // Skip rules that ran in the last hour
@@ -93,34 +94,50 @@ export class AutoTagScheduler {
 			let succeeded = 0;
 			let partial = 0;
 			let failed = 0;
+			let skipped = 0;
 
 			for (const rule of dueRules) {
 				try {
-					const result = await executeAutoTagRule({
-						rule: {
-							id: rule.id,
-							userId: rule.userId,
-							name: rule.name,
-							ruleType: rule.ruleType,
-							parameters: parseRecord(rule.parameters),
-							operator: rule.operator as "AND" | "OR" | null,
-							conditions: parseArray<{
-								ruleType: string;
-								parameters: Record<string, unknown>;
-							}>(rule.conditions),
-							serviceFilter: parseArray<string>(rule.serviceFilter),
-							instanceFilter: parseArray<string>(rule.instanceFilter),
-							excludeTags: parseArray<number>(rule.excludeTags),
-							excludeTitles: parseArray<string>(rule.excludeTitles),
-							plexLibraryFilter: parseArray<string>(rule.plexLibraryFilter),
-							tagName: rule.tagName,
-						},
-						prisma: this.prisma,
-						arrClientFactory: this.arrClientFactory,
-						encryptor: this.encryptor,
-						log: this.log,
-					});
+					// Skip if an on-demand "Run now" is currently executing this same
+					// rule — prevents two concurrent series/movie.update calls from
+					// racing and dropping each other's tag merges.
+					const lockResult = await runRuleWithLock(rule.id, () =>
+						executeAutoTagRule({
+							rule: {
+								id: rule.id,
+								userId: rule.userId,
+								name: rule.name,
+								ruleType: rule.ruleType,
+								parameters: parseRecord(rule.parameters),
+								operator: rule.operator as "AND" | "OR" | null,
+								conditions: parseArray<{
+									ruleType: string;
+									parameters: Record<string, unknown>;
+								}>(rule.conditions),
+								serviceFilter: parseArray<string>(rule.serviceFilter),
+								instanceFilter: parseArray<string>(rule.instanceFilter),
+								excludeTags: parseArray<number>(rule.excludeTags),
+								excludeTitles: parseArray<string>(rule.excludeTitles),
+								plexLibraryFilter: parseArray<string>(rule.plexLibraryFilter),
+								tagName: rule.tagName,
+							},
+							prisma: this.prisma,
+							arrClientFactory: this.arrClientFactory,
+							encryptor: this.encryptor,
+							log: this.log,
+						}),
+					);
 
+					if (lockResult.status === "skipped") {
+						skipped++;
+						this.log.debug(
+							{ ruleId: rule.id },
+							"Auto-tag rule skipped — already running (on-demand run in flight)",
+						);
+						continue;
+					}
+
+					const result = lockResult.result;
 					await this.prisma.autoTagRule.update({
 						where: { id: rule.id },
 						data: {
@@ -159,7 +176,7 @@ export class AutoTagScheduler {
 			}
 
 			this.log.info(
-				{ ruleCount: dueRules.length, succeeded, partial, failed },
+				{ ruleCount: dueRules.length, succeeded, partial, failed, skipped },
 				"Scheduled auto-tag tick complete",
 			);
 		} finally {

--- a/apps/api/src/lib/auto-tag/run-with-lock.ts
+++ b/apps/api/src/lib/auto-tag/run-with-lock.ts
@@ -1,0 +1,54 @@
+/**
+ * Per-rule concurrency lock for auto-tag execution.
+ *
+ * Prevents the scheduler tick and an on-demand "Run now" from executing
+ * the same rule simultaneously. Without this, two concurrent
+ * `series.update` calls can read-modify-write the same `tags` array
+ * and one rule's tag can be lost (read [3,5] twice → both write
+ * [3,5,X] then [3,5,Y] — only one X/Y survives).
+ *
+ * Single-process scope: the lock is a Node `Set<ruleId>` in module
+ * state. The app runs as a single Node process per Docker container,
+ * so this is sufficient. If we ever go multi-process / multi-replica,
+ * we'd need to move to a DB-backed `running` boolean column with
+ * compare-and-set semantics.
+ */
+
+const inFlight = new Set<string>();
+
+export type LockedRunResult<T> =
+	| { status: "ran"; result: T }
+	| { status: "skipped"; reason: "already-running" };
+
+/**
+ * Run `fn()` exclusively for `ruleId`. If another caller is already
+ * running for the same `ruleId`, returns immediately with
+ * `{ status: "skipped", reason: "already-running" }` and does NOT
+ * invoke `fn`.
+ *
+ * The lock is released in a `finally` block, so even if `fn` throws,
+ * the rule is unlocked for the next run.
+ */
+export async function runRuleWithLock<T>(
+	ruleId: string,
+	fn: () => Promise<T>,
+): Promise<LockedRunResult<T>> {
+	if (inFlight.has(ruleId)) {
+		return { status: "skipped", reason: "already-running" };
+	}
+	inFlight.add(ruleId);
+	try {
+		const result = await fn();
+		return { status: "ran", result };
+	} finally {
+		inFlight.delete(ruleId);
+	}
+}
+
+/**
+ * Test-only helper to clear the in-flight set between test runs. Don't
+ * call from production code.
+ */
+export function _clearInFlightForTesting(): void {
+	inFlight.clear();
+}

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -20,6 +20,7 @@ import { createAutoTagRuleSchema, ruleParamSchemaMap, updateAutoTagRuleSchema } 
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { executeAutoTagRule } from "../lib/auto-tag/execute-rule.js";
+import { runRuleWithLock } from "../lib/auto-tag/run-with-lock.js";
 import { safeJsonParse } from "../lib/utils/json.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
@@ -310,31 +311,44 @@ export async function registerAutoTagRoutes(app: FastifyInstance, _opts: Fastify
 			return reply.status(400).send({ error: "Rule is disabled. Enable it before running." });
 		}
 
-		const result = await executeAutoTagRule({
-			rule: {
-				id: rule.id,
-				userId: rule.userId,
-				name: rule.name,
-				ruleType: rule.ruleType,
-				parameters: parseJsonRecord(rule.parameters),
-				operator: rule.operator as "AND" | "OR" | null,
-				conditions: parseJsonArray<{
-					ruleType: string;
-					parameters: Record<string, unknown>;
-				}>(rule.conditions),
-				serviceFilter: parseJsonArray<string>(rule.serviceFilter),
-				instanceFilter: parseJsonArray<string>(rule.instanceFilter),
-				excludeTags: parseJsonArray<number>(rule.excludeTags),
-				excludeTitles: parseJsonArray<string>(rule.excludeTitles),
-				plexLibraryFilter: parseJsonArray<string>(rule.plexLibraryFilter),
-				tagName: rule.tagName,
-			},
-			prisma: app.prisma,
-			arrClientFactory: app.arrClientFactory,
-			encryptor: app.encryptor,
-			log: request.log,
-		});
+		// Per-rule lock prevents this on-demand run from racing the scheduler
+		// tick (or another concurrent on-demand request) for the same rule.
+		const lockResult = await runRuleWithLock(rule.id, () =>
+			executeAutoTagRule({
+				rule: {
+					id: rule.id,
+					userId: rule.userId,
+					name: rule.name,
+					ruleType: rule.ruleType,
+					parameters: parseJsonRecord(rule.parameters),
+					operator: rule.operator as "AND" | "OR" | null,
+					conditions: parseJsonArray<{
+						ruleType: string;
+						parameters: Record<string, unknown>;
+					}>(rule.conditions),
+					serviceFilter: parseJsonArray<string>(rule.serviceFilter),
+					instanceFilter: parseJsonArray<string>(rule.instanceFilter),
+					excludeTags: parseJsonArray<number>(rule.excludeTags),
+					excludeTitles: parseJsonArray<string>(rule.excludeTitles),
+					plexLibraryFilter: parseJsonArray<string>(rule.plexLibraryFilter),
+					tagName: rule.tagName,
+				},
+				prisma: app.prisma,
+				arrClientFactory: app.arrClientFactory,
+				encryptor: app.encryptor,
+				log: request.log,
+			}),
+		);
 
+		if (lockResult.status === "skipped") {
+			return reply.status(409).send({
+				error: "Rule is currently running",
+				message:
+					"Another execution of this rule is in progress (scheduler tick or concurrent run). Try again in a moment.",
+			});
+		}
+
+		const result = lockResult.result;
 		const updated = await app.prisma.autoTagRule.update({
 			where: { id },
 			data: {


### PR DESCRIPTION
## Summary

Addresses **deferred finding #5** from PR #396 review: the scheduler tick and the on-demand "Run now" endpoint could execute the same rule simultaneously, racing on \`series.update\` / \`movie.update\` and losing tag merges.

The race scenario:
1. Scheduler tick reads rule's matched items, gets \`existingTags = [3, 5]\`
2. User clicks "Run now" — also reads \`existingTags = [3, 5]\`
3. Scheduler writes \`[3, 5, 7]\` (premium tag)
4. On-demand writes \`[3, 5, 8]\` (kids tag) — **erases 7**

## Implementation

New \`lib/auto-tag/run-with-lock.ts\`:

\`\`\`ts
const inFlight = new Set<string>();

export async function runRuleWithLock<T>(ruleId, fn) {
  if (inFlight.has(ruleId)) return { status: "skipped", reason: "already-running" };
  inFlight.add(ruleId);
  try { return { status: "ran", result: await fn() }; }
  finally { inFlight.delete(ruleId); }
}
\`\`\`

Both call sites wrapped:

- **Scheduler tick** — skipped rules log at debug, increment a \`skipped\` counter in the tick's complete log, do NOT touch \`lastRunAt\` (cooldown will retry next tick).
- **\`POST /rules/:id/run\`** — skipped responses return **HTTP 409 Conflict** with a clear message.

## Why in-memory, not DB

Single Node process per Docker container = in-memory \`Set\` is sufficient. If we ever go multi-replica, this needs to move to a DB-backed \`running\` boolean column with compare-and-set semantics. Documented in the comment above the lock module.

## Tests

5 new tests on the lock primitive:
- \`ran\` path returns wrapped result
- Concurrent call for same ruleId → skipped (and the second \`fn\` is not invoked)
- Lock releases after first call completes — second call afterward runs normally
- Lock releases even when \`fn\` throws (the throw still propagates, but the rule is unlocked)
- Different ruleIds run concurrently without blocking each other

## Test plan

- [x] \`pnpm --filter @arr/api run test\` — **1413 / 1449 passed** (was 1408, +5 new)
- [x] \`tsc --noEmit\` clean both packages
- [x] \`pnpm run lint\` — no new findings
- [ ] CI green

Refs: deferred follow-up #5 from PR #396 review (memory/auto-tagger-arc.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)