### PR TITLE
fix(trash-guides): use canonical refs/heads/{branch} raw GitHub URLs (#406)

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for TrashGitHubFetcher URL construction.
+ *
+ * GitHub raw content URLs require the canonical `refs/heads/{branch}` path
+ * — the legacy `…/{branch}/…` form returns 404 for many repos (issue #406).
+ * These tests pin the URL shape for both the default TRaSH-Guides repo and
+ * for custom forks/branches so the regression cannot recur.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrashGitHubFetcher } from "../github-fetcher.js";
+
+type FetchSpy = ReturnType<typeof vi.fn>;
+
+function buildJsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("TrashGitHubFetcher URL construction (issue #406)", () => {
+	let fetchSpy: FetchSpy;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("uses refs/heads/{branch} for the default-repo metadata URL", async () => {
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse({ version: "1.0.0" }));
+
+		const fetcher = new TrashGitHubFetcher();
+		await fetcher.fetchMetadata();
+
+		expect(fetchSpy).toHaveBeenCalledOnce();
+		const requestedUrl = fetchSpy.mock.calls[0]?.[0];
+		expect(requestedUrl).toBe(
+			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/metadata.json",
+		);
+	});
+
+	it("uses refs/heads/{branch} for custom fork metadata URLs", async () => {
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse({ version: "1.0.0" }));
+
+		const fetcher = new TrashGitHubFetcher({
+			repoConfig: { owner: "catchra", name: "TRaSH-Guides", branch: "main" },
+		});
+		await fetcher.fetchMetadata();
+
+		const requestedUrl = fetchSpy.mock.calls[0]?.[0];
+		expect(requestedUrl).toBe(
+			"https://raw.githubusercontent.com/catchra/TRaSH-Guides/refs/heads/main/metadata.json",
+		);
+	});
+
+	it("discovers config files via api.github.com and fetches each via refs/heads raw URL", async () => {
+		// 1st call: discovery → GitHub Contents API directory listing
+		fetchSpy.mockResolvedValueOnce(
+			buildJsonResponse([
+				{ name: "1080p.json", type: "file" },
+				{ name: "2160p.json", type: "file" },
+			]),
+		);
+		// 2nd & 3rd calls: per-file raw fetches. We return invalid bodies so
+		// validateAndCollect logs+drops them; this test only cares about URLs.
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse({}));
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse({}));
+
+		const fetcher = new TrashGitHubFetcher();
+		await fetcher.fetchCustomFormats("RADARR");
+
+		const calls = fetchSpy.mock.calls.map((call) => call[0] as string);
+		expect(calls[0]).toBe(
+			"https://api.github.com/repos/TRaSH-Guides/Guides/contents/docs/json/radarr/cf",
+		);
+		expect(calls[1]).toBe(
+			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/docs/json/radarr/cf/1080p.json",
+		);
+		expect(calls[2]).toBe(
+			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/docs/json/radarr/cf/2160p.json",
+		);
+	});
+});

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -492,7 +492,9 @@ export class TrashGitHubFetcher {
 		// Build URLs from repo config (custom fork or official)
 		this.repoConfig = options.repoConfig ?? DEFAULT_TRASH_REPO;
 		const { owner, name, branch } = this.repoConfig;
-		this.rawBaseUrl = `https://raw.githubusercontent.com/${owner}/${name}/${branch}`;
+		// GitHub now requires the canonical `refs/heads/{branch}` path for raw content.
+		// The legacy `…/{branch}/…` form returns 404 for many repos (issue #406).
+		this.rawBaseUrl = `https://raw.githubusercontent.com/${owner}/${name}/refs/heads/${branch}`;
 		this.baseUrl = `${this.rawBaseUrl}/docs/json`;
 		this.metadataUrl = `${this.rawBaseUrl}/metadata.json`;
 		this.cfDescriptionsBaseUrl = `${this.rawBaseUrl}/includes/cf-descriptions`;
@@ -1090,10 +1092,10 @@ export class TrashGitHubFetcher {
 	 * Discover available config files in a directory using GitHub API
 	 */
 	private async discoverConfigFiles(baseUrl: string): Promise<string[]> {
-		// Extract the path after the branch segment in the raw URL
-		// baseUrl format: https://raw.githubusercontent.com/{owner}/{name}/{branch}/docs/json/{service}/{type}
+		// Extract the repo-relative path from the raw URL.
+		// baseUrl format: https://raw.githubusercontent.com/{owner}/{name}/refs/heads/{branch}/docs/json/{service}/{type}
 		const branchEscaped = this.repoConfig.branch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-		const pathMatch = baseUrl.match(new RegExp(`/${branchEscaped}/(.+)$`));
+		const pathMatch = baseUrl.match(new RegExp(`/refs/heads/${branchEscaped}/(.+)$`));
 		if (!pathMatch) {
 			this.log.warn(`Could not extract path from URL: ${baseUrl}`);
 			return [];


### PR DESCRIPTION
## Summary

- GitHub now requires the canonical `refs/heads/{branch}` segment in `raw.githubusercontent.com` paths; the legacy `…/{branch}/…` form returns 404 for many repos.
- Every TRaSH Guides cache refresh was silently auto-populating with `itemCount: 0` while the UI returned 200 — making the failure invisible to users (issue #406).
- Fix updates `rawBaseUrl` so all derived URLs (metadata, `docs/json`, CF descriptions) inherit the canonical form, and anchors the `discoverConfigFiles` regex on `/refs/heads/{branch}/` for safer path extraction.

## Files changed

- `apps/api/src/lib/trash-guides/github-fetcher.ts` — URL builder + discovery regex
- `apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts` — new vitest pinning the URL shape for default repo, custom forks, and the discovery → file-fetch flow

## Test plan

- [x] New tests: 3/3 pass
- [x] All trash-guides tests: 163/163 pass (17 DB-only skipped)
- [x] Full repo suite: 1439/1439 pass
- [x] `tsc --noEmit` (API) clean
- [x] Biome lint on changed files clean
- [x] Code review (no findings ≥ 80% confidence)
- [x] Security review (no SSRF / ReDoS / token-leak / cache-poisoning concerns — Zod regex at the route boundary already constrains inputs)

Fixes #406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)