### PR TITLE
fix(trash-guides): improve error-message diagnosability (#406 follow-up)

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/github-fetcher-errors.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/github-fetcher-errors.test.ts
@@ -71,8 +71,9 @@ describe("TrashGitHubFetcher error diagnosability (issue #406 follow-up)", () =>
 	});
 
 	it("includes the metadata URL and HTTP status in fetchMetadata errors", async () => {
-		// Make the fetch return 404 for two attempts (default retry count) so
-		// the request resolves rather than throwing inside fetchWithRetry.
+		// 404 short-circuits fetchWithRetry's retry loop (only 5xx is retried),
+		// so the response is returned immediately and the !response.ok branch
+		// in fetchMetadata is what throws.
 		fetchSpy.mockResolvedValue(buildJsonResponse({}, 404));
 
 		const fetcher = new TrashGitHubFetcher({ logger: createCapturingLogger([]) as any });

--- a/apps/api/src/lib/trash-guides/__tests__/github-fetcher-errors.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/github-fetcher-errors.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for TrashGitHubFetcher error-message diagnosability.
+ *
+ * Issue #406 was hard to triage because the failure messages omitted the
+ * URL being fetched, and the discovery error named the raw URL while the
+ * actual fetch was to api.github.com. These tests pin the diagnostic
+ * content of those error sites so the regression cannot recur silently.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TrashGitHubFetcher } from "../github-fetcher.js";
+
+type FetchSpy = ReturnType<typeof vi.fn>;
+
+interface CapturedLogEntry {
+	level: "error" | "warn";
+	mergeObject: unknown;
+	message: string;
+}
+
+function buildJsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+		statusText: status === 404 ? "Not Found" : "OK",
+	});
+}
+
+function createCapturingLogger(captured: CapturedLogEntry[]) {
+	const capture =
+		(level: "error" | "warn") =>
+		(...args: unknown[]) => {
+			// Pino convention: log.error(mergeObject, message) OR log.error(message).
+			if (typeof args[0] === "string") {
+				captured.push({ level, mergeObject: undefined, message: args[0] });
+			} else {
+				captured.push({
+					level,
+					mergeObject: args[0],
+					message: typeof args[1] === "string" ? args[1] : "",
+				});
+			}
+		};
+	return {
+		debug: () => {},
+		info: () => {},
+		warn: capture("warn"),
+		error: capture("error"),
+		fatal: () => {},
+		trace: () => {},
+		silent: () => {},
+		child: () => createCapturingLogger(captured),
+		level: "error",
+		bindings: () => ({}),
+		flush: () => {},
+		isLevelEnabled: () => true,
+	};
+}
+
+describe("TrashGitHubFetcher error diagnosability (issue #406 follow-up)", () => {
+	let fetchSpy: FetchSpy;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("includes the metadata URL and HTTP status in fetchMetadata errors", async () => {
+		// Make the fetch return 404 for two attempts (default retry count) so
+		// the request resolves rather than throwing inside fetchWithRetry.
+		fetchSpy.mockResolvedValue(buildJsonResponse({}, 404));
+
+		const fetcher = new TrashGitHubFetcher({ logger: createCapturingLogger([]) as any });
+
+		await expect(fetcher.fetchMetadata()).rejects.toThrow(/metadata\.json/);
+		await expect(fetcher.fetchMetadata()).rejects.toThrow(/404/);
+	});
+
+	it("includes the failing URL in fetchWithRetry attempt logs", async () => {
+		const captured: CapturedLogEntry[] = [];
+		const logger = createCapturingLogger(captured) as any;
+		fetchSpy.mockRejectedValue(
+			new TypeError("fetch failed: getaddrinfo ENOTFOUND raw.githubusercontent.com"),
+		);
+
+		const fetcher = new TrashGitHubFetcher({ logger });
+		await expect(fetcher.fetchMetadata()).rejects.toThrow();
+
+		const retryLogs = captured.filter((entry) => entry.message.includes("Fetch attempt"));
+		expect(retryLogs.length).toBeGreaterThan(0);
+		// Each retry log must name the URL — both in the message and in the
+		// structured merge object so log scrapers can filter on it.
+		for (const entry of retryLogs) {
+			expect(entry.message).toMatch(/metadata\.json/);
+			expect(entry.mergeObject).toMatchObject({
+				url: expect.stringContaining("metadata.json"),
+				attempt: expect.any(Number),
+				retries: expect.any(Number),
+			});
+		}
+	});
+
+	it("names the api.github.com URL (not the raw URL) when discovery fails", async () => {
+		const captured: CapturedLogEntry[] = [];
+		const logger = createCapturingLogger(captured) as any;
+
+		// All discovery attempts (and any retries within fetchWithRetry) reject.
+		fetchSpy.mockRejectedValue(new TypeError("fetch failed"));
+
+		const fetcher = new TrashGitHubFetcher({ logger });
+		await fetcher.fetchCustomFormats("RADARR");
+
+		const discoveryError = captured.find(
+			(entry) =>
+				entry.level === "error" && entry.message.includes("Failed to discover config files"),
+		);
+		expect(discoveryError).toBeDefined();
+		// The user-visible message must point at api.github.com (where the
+		// fetch actually went), not at raw.githubusercontent.com.
+		expect(discoveryError?.message).toContain("api.github.com");
+		expect(discoveryError?.message).not.toContain("raw.githubusercontent.com");
+		// The merge object should still carry the raw baseUrl for context,
+		// alongside the apiUrl that failed.
+		expect(discoveryError?.mergeObject).toMatchObject({
+			apiUrl: expect.stringContaining("api.github.com"),
+			baseUrl: expect.stringContaining("raw.githubusercontent.com"),
+			err: expect.any(Error),
+		});
+	});
+});

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -411,7 +411,10 @@ async function fetchWithRetry(
 			throw new Error(`HTTP ${response.status}: ${response.statusText}`);
 		} catch (error) {
 			lastError = error instanceof Error ? error : new Error(String(error));
-			log.error(`Fetch attempt ${attempt}/${retries} failed:`, lastError.message);
+			log.error(
+				{ err: lastError, url, attempt, retries },
+				`Fetch attempt ${attempt}/${retries} failed for ${url}`,
+			);
 
 			if (attempt < retries) {
 				await delay(retryDelay * attempt); // Exponential backoff
@@ -534,7 +537,9 @@ export class TrashGitHubFetcher {
 		const response = await fetchWithRetry(this.metadataUrl, this.fetchOptions, this.log);
 
 		if (!response.ok) {
-			throw new Error(`Failed to fetch metadata: ${response.statusText}`);
+			throw new Error(
+				`Failed to fetch metadata from ${this.metadataUrl}: HTTP ${response.status} ${response.statusText}`,
+			);
 		}
 
 		const raw = await response.json();
@@ -1133,7 +1138,14 @@ export class TrashGitHubFetcher {
 					"GitHub directory listing schema drift",
 				);
 			} else {
-				this.log.error(`Failed to discover config files at ${baseUrl}:`, error);
+				// Name the URL we actually fetched (apiUrl, on api.github.com),
+				// not the raw URL the caller passed in — the original message
+				// pointed users at raw.githubusercontent.com when the failure
+				// was actually on the GitHub API.
+				this.log.error(
+					{ err: error, apiUrl, baseUrl },
+					`Failed to discover config files via ${apiUrl}`,
+				);
 			}
 			return [];
 		}

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -869,7 +869,7 @@ export class TrashGitHubFetcher {
 				fetchedAt: new Date().toISOString(),
 			};
 		} catch (error) {
-			this.log.error(`Failed to fetch CF description for ${cfName}:`, error);
+			this.log.error({ err: error, cfName }, `Failed to fetch CF description for ${cfName}`);
 			return null;
 		}
 	}


### PR DESCRIPTION
## Summary

Follow-up to #407. The original issue #406 was hard to triage because the failure messages in `github-fetcher.ts` lost critical context — the user's logs showed `"Fetch attempt 1/2 failed:"` with no URL, then `Failed to discover config files at <raw URL>` while the actual fetch was to `api.github.com`. This PR fixes four error sites; no control-flow changes.

## What changed

### `apps/api/src/lib/trash-guides/github-fetcher.ts`

1. **`fetchWithRetry` retry log** (~line 414) — was: `log.error("Fetch attempt N/N failed:", lastError.message)`. Now: `log.error({ err, url, attempt, retries }, "Fetch attempt N/N failed for <url>")`. Pino's structured-logging convention; URL is in both message and merge object so log scrapers can filter on it.
2. **`fetchMetadata` throw** (~line 537) — was: `throw new Error("Failed to fetch metadata: <statusText>")`. Now includes `metadataUrl` and HTTP status code.
3. **`discoverConfigFiles` error log** (~line 1136) — was: `log.error("Failed to discover config files at <baseUrl>:", error)` — pointed users at `raw.githubusercontent.com` while the actual fetch was to `api.github.com`. Now: `log.error({ err, apiUrl, baseUrl }, "Failed to discover config files via <apiUrl>")`.
4. **`fetchCfDescription` catch** (~line 872, added in code-review touch-up) — fourth straggler using the same broken `log.error(string, error)` pattern. Pino interprets the second positional arg as a `%s` substitution target rather than an error to serialize, so `err.stack`/`err.cause` were silently dropped from JSON output. Converted to `log.error({ err, cfName }, "...")` for parity with the three sites above.

### `apps/api/src/lib/trash-guides/__tests__/github-fetcher-errors.test.ts` (new)

Three vitest tests pinning the diagnostic content:
- Metadata fetch error includes the URL and HTTP status.
- Each retry attempt log includes the URL (in message and merge object).
- Discovery error names the api.github.com URL, not the raw URL, while keeping the raw URL in the merge object for context.

## Test plan

### Local verification
- [x] New tests: 3/3 pass
- [x] All trash-guides tests: 163/163 pass (17 DB-only skipped)
- [x] Full repo suite: 1439/1439 pass
- [x] `tsc --noEmit` (API) clean
- [x] Biome lint on changed files clean

### Reviews
- [x] **Code review**: 1 finding (line 872 straggler) addressed in follow-up commit. Reviewer notes pino arg order is correct, URL duplication in message + merge-object is idiomatic for this codebase, multi-line apiUrl-vs-baseUrl comment is valuable, test invariants are pinned at the right layer.
- [x] **Security review**: No findings ≥ Low. Verified `GITHUB_TOKEN` is only ever placed in `Authorization` headers (never in URLs), pino redaction list (`logger.ts:111-124`) catches `authorization`/`token`/`cookie` keys, central error handler (`server.ts:154-166`) sanitizes 5xx responses to `"Internal server error"` so the richer URL+status string only surfaces in operator logs (not HTTP responses), and pino's JSON output is structurally immune to log injection.

### CI
- [x] Initial run: 12 passed / 0 failed (Build Image, CodeQL Analysis, Lint/Type/Test, Semgrep OSS, Semgrep Scan, Smoke Test PG/SQLite, Docker Build, E2E Tests 1-3)
- [x] Re-run after line-872 touch-up: 12 passed / 0 failed (same set, all green)

## Deployment notes

Stacks on top of #407 in spirit (same area, same root cause), but the two PRs touch disjoint lines and should merge cleanly in either order. The new test file uses a different name (`github-fetcher-errors.test.ts` vs #407's `github-fetcher.test.ts`) so there's no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)