### PR TITLE
docs: document compatible-services workaround for non-core *arrs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ docker-compose up -d
 | **Emby** | Full | Shares Jellyfin backend — same capabilities, same setup flow |
 | **Seerr** | Full | Requests, users, issues, notification agents, optional Plex sign-in auto-setup |
 
+### Compatible Services
+
+Some newer *arr-style projects (for example Sportarr, or future Readarr-replacement projects like Chaptarr) expose APIs that closely mirror Sonarr or Radarr. These can be added to arr-dashboard today by creating a Sonarr or Radarr instance and pointing it at the compatible service. Most surfaces (queue, calendar, library, history) will work as long as the third-party project stays compatible with the upstream Sonarr or Radarr API contract.
+
+This is a best-effort path rather than a supported integration. arr-dashboard does not test against these services, and behavior outside the documented Servarr API surface is not guaranteed. If a service diverges from the upstream API, expect breakage and treat it as a known limitation rather than a bug.
+
+First-class support is reserved for services listed in the table above.
+
 ## Version Tags
 
 | Tag | Description |


### PR DESCRIPTION
## Summary

Adds a short **Compatible Services** subsection to the README, immediately after the Supported Services table.

The note explains that Sonarr/Radarr-compatible projects (e.g. Sportarr, or future Readarr-replacement projects like Chaptarr) can be added today by creating a Sonarr or Radarr instance and pointing it at the compatible service. It is framed explicitly as best-effort rather than first-class support, and the supported list is reserved for the established Servarr stack.

This delivers on the docs note promised in the closing comment on #271, so future folks evaluating the project can find the workaround without filing a duplicate issue.

## What is *not* in this PR

- No code changes
- No new `ServiceType` values
- No Readarr deprecation work (separate initiative if/when it happens)

## Test plan

- [x] Render README on GitHub and confirm the new subsection lands between **Supported Services** and **Version Tags**
- [x] No CI relevance beyond docs

Refs: #271

Generated with [Claude Code](https://claude.com/claude-code)