### PR TITLE
feat(qui): add ServiceType.QUI, LibraryCache.infoHash, Zod types

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -18,6 +18,7 @@ enum ServiceType {
   PLEX
   JELLYFIN
   EMBY
+  QUI
 }
 
 // Library item type enum - uses lowercase to match Zod schema in shared package
@@ -767,6 +768,10 @@ model LibraryCache {
   qualityProfileName String?
   sizeOnDisk      BigInt   @default(0)
   cutoffUnmet     Boolean  @default(false)
+
+  // qBittorrent info hash for the active grab; nullable because manual imports
+  // and items predating download-history retention won't have one.
+  infoHash        String?
 
   // Full normalized data as JSON (for API response)
   data            String   // JSON blob of full LibraryItem

--- a/apps/web/src/features/settings/lib/settings-constants.ts
+++ b/apps/web/src/features/settings/lib/settings-constants.ts
@@ -12,7 +12,8 @@ export type ServiceType =
 	| "tautulli"
 	| "plex"
 	| "jellyfin"
-	| "emby";
+	| "emby"
+	| "qui";
 
 export const SERVICE_TYPES: ServiceType[] = [
 	"sonarr",
@@ -25,6 +26,7 @@ export const SERVICE_TYPES: ServiceType[] = [
 	"plex",
 	"jellyfin",
 	"emby",
+	"qui",
 ];
 
 export const OPTION_STYLE = {

--- a/apps/web/src/hooks/api/useServiceMutations.ts
+++ b/apps/web/src/hooks/api/useServiceMutations.ts
@@ -106,7 +106,8 @@ export const useTestConnectionBeforeAdd = () => {
 				| "tautulli"
 				| "plex"
 				| "jellyfin"
-				| "emby";
+				| "emby"
+				| "qui";
 		}
 	>({
 		mutationFn: ({ baseUrl, apiKey, service }) => testConnectionBeforeAdd(baseUrl, apiKey, service),

--- a/apps/web/src/lib/api-client/services.ts
+++ b/apps/web/src/lib/api-client/services.ts
@@ -28,7 +28,8 @@ export type CreateServicePayload = {
 		| "tautulli"
 		| "plex"
 		| "jellyfin"
-		| "emby";
+		| "emby"
+		| "qui";
 	enabled?: boolean;
 	isDefault?: boolean;
 	tags?: string[];
@@ -91,7 +92,8 @@ export async function testConnectionBeforeAdd(
 		| "tautulli"
 		| "plex"
 		| "jellyfin"
-		| "emby",
+		| "emby"
+		| "qui",
 ): Promise<TestConnectionResponse> {
 	return await apiRequest<TestConnectionResponse>("/api/services/test-connection", {
 		method: "POST",

--- a/apps/web/src/lib/theme-gradients.ts
+++ b/apps/web/src/lib/theme-gradients.ts
@@ -334,7 +334,8 @@ export type ServiceType =
 	| "tautulli"
 	| "plex"
 	| "jellyfin"
-	| "emby";
+	| "emby"
+	| "qui";
 
 /**
  * Service-specific gradients for visual distinction
@@ -397,6 +398,11 @@ export const SERVICE_GRADIENTS: Record<ServiceType, ServiceGradient> = {
 		from: "#52b54b", // Emby brand green
 		to: "#2d8a28", // darker green
 		glow: "rgba(82, 181, 75, 0.35)",
+	},
+	qui: {
+		from: "#0891b2", // cyan-600 (deeper than Sonarr's cyan-500)
+		to: "#1e40af", // blue-700 (download / infrastructure tone)
+		glow: "rgba(8, 145, 178, 0.4)",
 	},
 };
 

--- a/packages/shared/src/types/arr.ts
+++ b/packages/shared/src/types/arr.ts
@@ -11,7 +11,14 @@ export const ARR_SERVICES = ["sonarr", "radarr", "prowlarr", "lidarr", "readarr"
 export const LIBRARY_SERVICES = ["sonarr", "radarr", "lidarr", "readarr"] as const;
 
 /** Non-arr integration services (different APIs, used as data sources) */
-export const INTEGRATION_SERVICES = ["seerr", "tautulli", "plex", "jellyfin", "emby"] as const;
+export const INTEGRATION_SERVICES = [
+	"seerr",
+	"tautulli",
+	"plex",
+	"jellyfin",
+	"emby",
+	"qui",
+] as const;
 
 /** All supported service types */
 export const ALL_SERVICES = [...ARR_SERVICES, ...INTEGRATION_SERVICES] as const;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -14,6 +14,7 @@ export * from "./password";
 export * from "./plex";
 export * from "./pulse";
 export * from "./queue-cleaner";
+export * from "./qui";
 export * from "./regex-safety";
 export * from "./rule-criteria";
 export * from "./search";

--- a/packages/shared/src/types/qui.ts
+++ b/packages/shared/src/types/qui.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+
+// ── qui (autobrr/qui) Shared Types ──────────────────────────────────
+// Wire contract between arr-dashboard's API and frontend for the qui
+// integration. Backend translates raw qui responses into these shapes;
+// the frontend should never see qui's API surface directly.
+
+/**
+ * qBittorrent torrent state strings (from qui's Torrent.state field).
+ * `.catch("unknown")` tolerates qBit additions without breaking validation —
+ * the UI degrades to a generic state pill rather than a hard parse failure.
+ */
+export const quiTorrentStateSchema = z
+	.enum([
+		"downloading",
+		"uploading",
+		"stalledUP",
+		"stalledDL",
+		"pausedUP",
+		"pausedDL",
+		"queuedUP",
+		"queuedDL",
+		"checkingUP",
+		"checkingDL",
+		"metaDL",
+		"moving",
+		"forcedUP",
+		"forcedDL",
+		"error",
+		"missingFiles",
+		"unknown",
+	])
+	.catch("unknown");
+
+export type QuiTorrentState = z.infer<typeof quiTorrentStateSchema>;
+
+/**
+ * Friendly tracker health, derived in the backend mapper from qBit's int status (0–4).
+ * 0 = disabled, 1 = not contacted, 2 = working, 3 = updating, 4 = not working.
+ */
+export const quiTrackerHealthSchema = z.enum([
+	"disabled",
+	"not_contacted",
+	"working",
+	"updating",
+	"not_working",
+	"unknown",
+]);
+
+export type QuiTrackerHealth = z.infer<typeof quiTrackerHealthSchema>;
+
+/** Cross-seed match type — confidence varies by source. */
+export const quiCrossSeedMatchTypeSchema = z.enum(["content_path", "name", "release"]);
+
+export type QuiCrossSeedMatchType = z.infer<typeof quiCrossSeedMatchTypeSchema>;
+
+/**
+ * A torrent record as surfaced to the frontend.
+ * `instanceId` / `instanceName` are populated when the torrent is fetched via the
+ * cross-instance endpoint; absent on per-instance lookups.
+ */
+export const quiTorrentSchema = z.object({
+	hash: z.string(),
+	name: z.string(),
+	state: quiTorrentStateSchema,
+	ratio: z.number(),
+	progress: z.number().min(0).max(1),
+	numSeeds: z.number().int(),
+	numLeechs: z.number().int(),
+	tags: z.array(z.string()).default([]),
+	category: z.string().default(""),
+	savePath: z.string(),
+	addedOn: z.number().int(),
+	completedOn: z.number().int().nullable(),
+	eta: z.number().int(),
+	dlSpeed: z.number().int(),
+	upSpeed: z.number().int(),
+	priority: z.number().int(),
+	size: z.number().int(),
+	instanceId: z.number().int().optional(),
+	instanceName: z.string().optional(),
+});
+
+export type QuiTorrent = z.infer<typeof quiTorrentSchema>;
+
+/** Extended properties for a single torrent (lazy-loaded — not in list payloads). */
+export const quiTorrentPropertiesSchema = z.object({
+	additionDate: z.number().int(),
+	completionDate: z.number().int(),
+	comment: z.string().default(""),
+	totalSize: z.number().int(),
+	totalDownloaded: z.number().int(),
+	totalUploaded: z.number().int(),
+	shareRatio: z.number(),
+	uploadSpeed: z.number().int(),
+	downloadSpeed: z.number().int(),
+	uploadLimit: z.number().int(),
+	downloadLimit: z.number().int(),
+	seedsActual: z.number().int(),
+	peersActual: z.number().int(),
+	eta: z.number().int(),
+});
+
+export type QuiTorrentProperties = z.infer<typeof quiTorrentPropertiesSchema>;
+
+/**
+ * Tracker entry for a torrent. `status` is the raw qBit int (kept for diagnostics);
+ * `health` is the friendly mapping the UI renders.
+ */
+export const quiTrackerSchema = z.object({
+	url: z.string(),
+	status: z.number().int(),
+	health: quiTrackerHealthSchema,
+	msg: z.string().default(""),
+	numSeeds: z.number().int().default(0),
+	numLeeches: z.number().int().default(0),
+	numPeers: z.number().int().default(0),
+	tier: z.number().int(),
+});
+
+export type QuiTracker = z.infer<typeof quiTrackerSchema>;
+
+/**
+ * A torrent that qui has identified as a cross-seed sibling of another torrent.
+ * `trackerHealth` is only present when the tracker reports a problem; `matchType`
+ * communicates how confidently qui matched it.
+ */
+export const quiCrossSeedMatchSchema = z.object({
+	hash: z.string(),
+	name: z.string(),
+	instanceId: z.number().int(),
+	instanceName: z.string(),
+	state: z.string(),
+	progress: z.number().min(0).max(1),
+	size: z.number().int(),
+	category: z.string().default(""),
+	savePath: z.string(),
+	contentPath: z.string(),
+	tracker: z.string(),
+	trackerHealth: z.enum(["unregistered", "tracker_down"]).optional(),
+	matchType: quiCrossSeedMatchTypeSchema,
+	tags: z.string().default(""),
+});
+
+export type QuiCrossSeedMatch = z.infer<typeof quiCrossSeedMatchSchema>;
+
+/**
+ * A qBittorrent instance as known to qui. `hasLocalFilesystemAccess` gates
+ * features like hardlink detection — surface to the UI when relevant.
+ */
+export const quiInstanceSchema = z.object({
+	id: z.number().int(),
+	name: z.string(),
+	host: z.string().url(),
+	connected: z.boolean(),
+	hasLocalFilesystemAccess: z.boolean(),
+	useHardlinks: z.boolean(),
+	useReflinks: z.boolean(),
+	hardlinkBaseDir: z.string().nullable(),
+	isActive: z.boolean(),
+});
+
+export type QuiInstance = z.infer<typeof quiInstanceSchema>;
+
+/** Connection-test result returned by the backend's qui health endpoint. */
+export const quiConnectionTestResultSchema = z.discriminatedUnion("ok", [
+	z.object({ ok: z.literal(true) }),
+	z.object({ ok: z.literal(false), reason: z.string() }),
+]);
+
+export type QuiConnectionTestResult = z.infer<typeof quiConnectionTestResultSchema>;


### PR DESCRIPTION
## Summary
First of several PRs introducing [autobrr/qui](https://github.com/autobrr/qui) as a federated peer observability layer for the torrent/download stack. arr-dashboard does not see torrent state today; this lays the groundwork to surface ratio, seed time, tracker health, hardlink scope, and cross-seed siblings alongside library data.

**Schema and types only.** No routes, no UI, no runtime behavior changes. Subsequent PRs will:
- wire a backend client (`apps/api/src/lib/qui/`) and routes (`apps/api/src/routes/qui.ts`)
- backfill `LibraryCache.infoHash` from Sonarr/Radarr history during library sync
- render a Torrent Health panel on library item detail pages

### What's in here
- `ServiceType` enum: `+ QUI`
- `LibraryCache`: `+ infoHash String?` (qBit info hash; nullable for manual imports & pre-history items; **no index** — library queries are still by `arrItemId`, index added later if/when needed)
- `INTEGRATION_SERVICES` array: `+ "qui"` — auto-propagates to `arrServiceTypeSchema` and every `validateRequest()` call via the existing taxonomy
- `packages/shared/src/types/qui.ts` (new) — 8 Zod schemas:
  - `quiTorrentStateSchema` (with `.catch("unknown")` to tolerate qBit additions)
  - `quiTrackerHealthSchema` (friendly enum derived from raw qBit int)
  - `quiCrossSeedMatchTypeSchema`
  - `quiTorrentSchema`, `quiTorrentPropertiesSchema`
  - `quiTrackerSchema`, `quiCrossSeedMatchSchema`
  - `quiInstanceSchema`
  - `quiConnectionTestResultSchema` (discriminated union for narrowing)

## Test plan
- [x] `pnpm --filter @arr/api run db:push` syncs schema + regenerates Prisma client
- [x] `pnpm --filter @arr/shared exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/shared run build` rebuilds `dist/` (vitest reads from dist, per project memory)
- [x] `pnpm run test` — **1457 passed**, 36 skipped (pre-existing), 0 failed
- [ ] Reviewer: confirm `infoHash` is nullable and only on `LibraryCache` (no other model touches it yet)
- [ ] Reviewer: confirm the `INTEGRATION_SERVICES` reflow in `arr.ts` is just Biome auto-formatting
- [ ] Reviewer: spot-check `qui.ts` schemas against the OpenAPI source shapes for any field-name drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)