### PR TITLE
fix(auto-tag, label-sync): preserve full *arr resource on tag-merge updates

### DIFF
--- a/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
@@ -122,12 +122,41 @@ interface MockArrClient {
 		create: ReturnType<typeof vi.fn>;
 	};
 	movie: {
+		getById: ReturnType<typeof vi.fn>;
 		update: ReturnType<typeof vi.fn>;
 	};
 	series: {
+		getById: ReturnType<typeof vi.fn>;
 		update: ReturnType<typeof vi.fn>;
 	};
 }
+
+// Minimal full-resource shapes for getById mocks. Fields chosen to mirror
+// what Radarr/Sonarr's strict PUT validators check — qualityProfileId>0
+// is the field that broke production (see issue #384).
+const fullMovie = (id: number, tags: number[] = []) => ({
+	id,
+	title: `Movie ${id}`,
+	tmdbId: id,
+	qualityProfileId: 1,
+	monitored: true,
+	hasFile: true,
+	tags,
+	rootFolderPath: "/movies",
+	minimumAvailability: "released",
+});
+
+const fullSeries = (id: number, tags: number[] = []) => ({
+	id,
+	title: `Series ${id}`,
+	tvdbId: id,
+	qualityProfileId: 1,
+	monitored: true,
+	tags,
+	rootFolderPath: "/tv",
+	seasonFolder: true,
+	languageProfileId: 1,
+});
 
 function makeArrClient(): MockArrClient {
 	return {
@@ -135,8 +164,14 @@ function makeArrClient(): MockArrClient {
 			getAll: vi.fn().mockResolvedValue([{ id: 7, label: "premium" }]),
 			create: vi.fn().mockResolvedValue({ id: 7, label: "premium" }),
 		},
-		movie: { update: vi.fn().mockResolvedValue({}) },
-		series: { update: vi.fn().mockResolvedValue({}) },
+		movie: {
+			getById: vi.fn((id: number) => Promise.resolve(fullMovie(id))),
+			update: vi.fn().mockResolvedValue({}),
+		},
+		series: {
+			getById: vi.fn((id: number) => Promise.resolve(fullSeries(id))),
+			update: vi.fn().mockResolvedValue({}),
+		},
 	};
 }
 
@@ -179,7 +214,19 @@ describe("executeAutoTagRule (orchestration)", () => {
 		expect(result.status).toBe("success");
 		expect(result.totals.itemsMatched).toBe(1);
 		expect(result.totals.tagsApplied).toBe(1);
-		expect(arrClient.movie.update).toHaveBeenCalledWith(100, { id: 100, tags: [7] });
+		// Update body must include the full Radarr/Sonarr resource — Radarr's
+		// PUT validator rejects partial bodies with "'Quality Profile Id' must
+		// be greater than '0'" (issue #384). Spreading the getById result
+		// preserves qualityProfileId, rootFolderPath, etc.
+		expect(arrClient.movie.getById).toHaveBeenCalledWith(100);
+		expect(arrClient.movie.update).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({
+				id: 100,
+				tags: [7],
+				qualityProfileId: 1,
+			}),
+		);
 	});
 
 	it("idempotent: item that already has the tag counts as applied without re-update", async () => {
@@ -234,10 +281,14 @@ describe("executeAutoTagRule (orchestration)", () => {
 			log,
 		});
 
-		expect(arrClient.movie.update).toHaveBeenCalledWith(100, {
-			id: 100,
-			tags: [3, 5, 7],
-		});
+		expect(arrClient.movie.update).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({
+				id: 100,
+				tags: [3, 5, 7],
+				qualityProfileId: 1,
+			}),
+		);
 	});
 
 	it("non-matching item: no write, status success with 'no items matched' message", async () => {

--- a/apps/api/src/lib/auto-tag/execute-rule.ts
+++ b/apps/api/src/lib/auto-tag/execute-rule.ts
@@ -301,7 +301,16 @@ async function processInstance(args: ProcessInstanceArgs): Promise<ProcessInstan
 			const accessor = item.itemType === "series" ? "series" : "movie";
 			// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires runtime accessor
 			const resource = (arrClient as any)[accessor];
-			await resource.update(item.arrItemId, { id: item.arrItemId, tags: merged });
+			// Radarr/Sonarr PUT endpoints require the full resource — validators
+			// reject partial bodies with errors like "'Quality Profile Id' must
+			// be greater than '0'". Fetch the current item so the update preserves
+			// every field the *arr expects.
+			const fullItem = await resource.getById(item.arrItemId);
+			await resource.update(item.arrItemId, {
+				...fullItem,
+				id: item.arrItemId,
+				tags: merged,
+			});
 			applied++;
 		} catch (err) {
 			const reason = err instanceof ArrError ? err.message : String(err);

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/arr-writer.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/arr-writer.test.ts
@@ -1,0 +1,263 @@
+/**
+ * arr-writer regression tests.
+ *
+ * Locks in the fix for issue #384 — Radarr/Sonarr's PUT endpoints reject
+ * partial bodies with "'Quality Profile Id' must be greater than '0'".
+ * The writer must fetch the full item via getById and spread it into the
+ * update payload so every field the *arr validator expects is preserved.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { LabelSyncRuleInput } from "../../execute-rule.js";
+import type { DestWriterOpts, MatchCandidate } from "../../strategy-types.js";
+import { radarrDestWriter, sonarrDestWriter } from "../arr-writer.js";
+
+const log = {
+	child: vi.fn().mockReturnThis(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+const fullMovie = (id: number, tags: number[] = []) => ({
+	id,
+	title: `Movie ${id}`,
+	tmdbId: id,
+	qualityProfileId: 1,
+	monitored: true,
+	hasFile: true,
+	tags,
+	rootFolderPath: "/movies",
+	minimumAvailability: "released",
+});
+
+const fullSeries = (id: number, tags: number[] = []) => ({
+	id,
+	title: `Series ${id}`,
+	tvdbId: id,
+	tmdbId: id, // arr-writer matches by tmdbId across both movies and series
+	qualityProfileId: 1,
+	monitored: true,
+	tags,
+	rootFolderPath: "/tv",
+	seasonFolder: true,
+	languageProfileId: 1,
+});
+
+function makeRule(overrides: Partial<LabelSyncRuleInput> = {}): LabelSyncRuleInput {
+	return {
+		id: "rule-1",
+		userId: "user-1",
+		name: "kids → kids",
+		sourceService: "PLEX",
+		destService: "RADARR",
+		sourceInstanceId: "src-1",
+		destInstanceId: "dest-1",
+		sourceTagName: "kids",
+		destTagName: "kids",
+		strategy: "label-to-tag",
+		direction: "source-to-dest",
+		excludeFilters: null,
+		includeFilters: null,
+		...overrides,
+	} as LabelSyncRuleInput;
+}
+
+function makeMatch(tmdbId: number, mediaType: "series" | "movie" = "movie"): MatchCandidate {
+	return { tmdbId, mediaType, title: `Item ${tmdbId}` };
+}
+
+function makeOpts(over: Partial<DestWriterOpts>): DestWriterOpts {
+	return {
+		rule: makeRule(),
+		destInstance: {
+			id: "dest-1",
+			service: "RADARR",
+			label: "Radarr",
+			baseUrl: "http://radarr",
+			encryptedApiKey: "x",
+			encryptionIv: "y",
+		} as DestWriterOpts["destInstance"],
+		candidates: [makeMatch(100)],
+		prisma: {} as DestWriterOpts["prisma"],
+		arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+		encryptor: {} as DestWriterOpts["encryptor"],
+		log,
+		...over,
+	};
+}
+
+describe("radarrDestWriter — issue #384 regression", () => {
+	it("fetches full movie via getById and spreads it into the update body", async () => {
+		const movieGetById = vi.fn((id: number) => Promise.resolve(fullMovie(id)));
+		const movieUpdate = vi.fn().mockResolvedValue({});
+		const arrClient = {
+			tag: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, label: "kids" }]),
+				create: vi.fn(),
+			},
+			movie: {
+				getAll: vi.fn().mockResolvedValue([fullMovie(100)]),
+				getById: movieGetById,
+				update: movieUpdate,
+			},
+		};
+		const arrClientFactory = {
+			create: vi.fn().mockReturnValue(arrClient),
+		} as unknown as DestWriterOpts["arrClientFactory"];
+
+		const result = await radarrDestWriter.applyLabels(makeOpts({ arrClientFactory }));
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 1, failures: 0 });
+		expect(movieGetById).toHaveBeenCalledWith(100);
+
+		// The update body MUST include qualityProfileId (or any other strict
+		// field the *arr validator checks). The original bug sent only
+		// { id, tags } which Radarr rejected.
+		expect(movieUpdate).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({
+				id: 100,
+				tags: [7],
+				qualityProfileId: 1,
+				rootFolderPath: "/movies",
+			}),
+		);
+	});
+
+	it("merges new tag id into existing tags rather than replacing", async () => {
+		const movieGetById = vi.fn(() => Promise.resolve(fullMovie(100, [3, 5])));
+		const movieUpdate = vi.fn().mockResolvedValue({});
+		const arrClient = {
+			tag: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, label: "kids" }]),
+				create: vi.fn(),
+			},
+			movie: {
+				getAll: vi.fn().mockResolvedValue([fullMovie(100, [3, 5])]),
+				getById: movieGetById,
+				update: movieUpdate,
+			},
+		};
+		const arrClientFactory = {
+			create: vi.fn().mockReturnValue(arrClient),
+		} as unknown as DestWriterOpts["arrClientFactory"];
+
+		await radarrDestWriter.applyLabels(makeOpts({ arrClientFactory }));
+
+		expect(movieUpdate).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({
+				id: 100,
+				tags: [3, 5, 7],
+			}),
+		);
+	});
+
+	it("skips items already carrying the tag (idempotent)", async () => {
+		const movieGetById = vi.fn();
+		const movieUpdate = vi.fn();
+		const arrClient = {
+			tag: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, label: "kids" }]),
+				create: vi.fn(),
+			},
+			movie: {
+				getAll: vi.fn().mockResolvedValue([fullMovie(100, [7])]),
+				getById: movieGetById,
+				update: movieUpdate,
+			},
+		};
+		const arrClientFactory = {
+			create: vi.fn().mockReturnValue(arrClient),
+		} as unknown as DestWriterOpts["arrClientFactory"];
+
+		const result = await radarrDestWriter.applyLabels(makeOpts({ arrClientFactory }));
+
+		expect(result.labelsApplied).toBe(1);
+		expect(movieGetById).not.toHaveBeenCalled();
+		expect(movieUpdate).not.toHaveBeenCalled();
+	});
+
+	it("counts a failure (and continues) when getById or update throws", async () => {
+		const movieGetById = vi.fn().mockRejectedValue(new Error("Quality Profile Id"));
+		const movieUpdate = vi.fn();
+		const arrClient = {
+			tag: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, label: "kids" }]),
+				create: vi.fn(),
+			},
+			movie: {
+				getAll: vi.fn().mockResolvedValue([fullMovie(100), fullMovie(200), fullMovie(300)]),
+				getById: movieGetById,
+				update: movieUpdate,
+			},
+		};
+		const arrClientFactory = {
+			create: vi.fn().mockReturnValue(arrClient),
+		} as unknown as DestWriterOpts["arrClientFactory"];
+
+		const result = await radarrDestWriter.applyLabels(
+			makeOpts({
+				arrClientFactory,
+				candidates: [makeMatch(100), makeMatch(200), makeMatch(300)],
+			}),
+		);
+
+		expect(result.matchesFound).toBe(3);
+		expect(result.labelsApplied).toBe(0);
+		expect(result.failures).toBe(3);
+	});
+});
+
+describe("sonarrDestWriter — issue #384 regression", () => {
+	it("uses the series accessor (getById + update) with the full series body", async () => {
+		const seriesGetById = vi.fn((id: number) => Promise.resolve(fullSeries(id)));
+		const seriesUpdate = vi.fn().mockResolvedValue({});
+		const arrClient = {
+			tag: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, label: "kids" }]),
+				create: vi.fn(),
+			},
+			series: {
+				getAll: vi.fn().mockResolvedValue([fullSeries(100)]),
+				getById: seriesGetById,
+				update: seriesUpdate,
+			},
+		};
+		const arrClientFactory = {
+			create: vi.fn().mockReturnValue(arrClient),
+		} as unknown as DestWriterOpts["arrClientFactory"];
+
+		await sonarrDestWriter.applyLabels(
+			makeOpts({
+				arrClientFactory,
+				destInstance: {
+					id: "dest-2",
+					service: "SONARR",
+					label: "Sonarr",
+					baseUrl: "http://sonarr",
+					encryptedApiKey: "x",
+					encryptionIv: "y",
+				} as DestWriterOpts["destInstance"],
+				candidates: [makeMatch(100, "series")],
+				rule: makeRule({ destService: "SONARR" }),
+			}),
+		);
+
+		expect(seriesGetById).toHaveBeenCalledWith(100);
+		expect(seriesUpdate).toHaveBeenCalledWith(
+			100,
+			expect.objectContaining({
+				id: 100,
+				tags: [7],
+				qualityProfileId: 1,
+				rootFolderPath: "/tv",
+			}),
+		);
+	});
+});

--- a/apps/api/src/lib/label-sync/dest-writers/arr-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/arr-writer.ts
@@ -106,7 +106,17 @@ function createWriter(config: ArrWriterConfig): DestWriter {
 				try {
 					// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires runtime accessor
 					const resource = (arrClient as any)[config.itemsAccessor];
-					await resource.update(item.id, { id: item.id, tags: mergedTags });
+					// Radarr/Sonarr PUT endpoints require the full resource —
+					// validators reject partial bodies with errors like
+					// "'Quality Profile Id' must be greater than '0'". Fetch the
+					// current item so the update preserves every field the *arr
+					// expects.
+					const fullItem = await resource.getById(item.id);
+					await resource.update(item.id, {
+						...fullItem,
+						id: item.id,
+						tags: mergedTags,
+					});
 					labelsApplied++;
 				} catch (err) {
 					const reason = err instanceof ArrError ? err.message : String(err);


### PR DESCRIPTION
## Summary
Fixes two bugs reported on #384 by @m0lez where applying tags through the auto-tagger or Label Sync fails on Radarr/Sonarr with:

> 'Quality Profile Id' must be greater than '0'.

Both code paths were sending partial PUT bodies (`{ id, tags }`) — Radarr's stricter validator rejects updates that don't include the full movie resource. Same root cause in two places.

## Root cause
`apps/api/src/lib/auto-tag/execute-rule.ts:304` and `apps/api/src/lib/label-sync/dest-writers/arr-writer.ts:109` both did:

\`\`\`ts
await resource.update(item.id, { id: item.id, tags: merged });
\`\`\`

Radarr's PUT /movie/{id} treats this as the **full** new resource and validates every field. Missing \`qualityProfileId\` → defaults to 0 → validator rejects. The canonical pattern already lives at \`lib/library-cleanup/cleanup-executor.ts:1399-1400\`:

\`\`\`ts
const movie = await radarr.movie.getById(arrItemId);
await radarr.movie.update(arrItemId, { ...movie, id: arrItemId, /* updates */ });
\`\`\`

## Fix
Both writers now fetch the full item via \`getById\` and spread it into the update body. One extra GET per write — fast and correct.

## Test plan
- [x] \`pnpm --filter @arr/api exec tsc --noEmit\` clean
- [x] \`pnpm --filter @arr/web exec tsc --noEmit\` clean
- [x] \`pnpm run test\` — full suite passes
- [x] Auto-tagger tests updated to mock \`getById\` and assert the spread (now includes \`qualityProfileId\`)
- [x] **New** \`apps/api/src/lib/label-sync/dest-writers/__tests__/arr-writer.test.ts\` (5 cases: full-spread happy path, tag merge with existing tags, idempotency, partial-failure, Sonarr accessor variant)
- [ ] Reviewer (live verification): @m0lez's reproduction — tag a Radarr movie via auto-tagger or Label Sync; confirm no \`Quality Profile Id\` errors in the API log and the tag actually lands on the item.

## Out of scope
The issue thread also asks about a Sonarr/Radarr Connect webhook for Label Sync (parallel to the auto-tagger's existing webhook in PR #396). That's a separate enhancement and not required to clear the qualityProfileId errors — leaving for a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)