### PR TITLE
feat(label-sync): event-driven triggers (auto-tagger chain + sync delta + per-item button)

### DIFF
--- a/apps/api/src/lib/auto-tag/execute-rule.ts
+++ b/apps/api/src/lib/auto-tag/execute-rule.ts
@@ -15,6 +15,7 @@ import { ArrError } from "arr-sdk";
 import type { FastifyBaseLogger } from "fastify";
 import type { ArrClient, ArrClientFactory } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
+import { triggerLabelSyncForItem } from "../label-sync/trigger-for-item.js";
 import { buildEvalContext } from "../library-cleanup/cleanup-executor.js";
 import { evaluateSingleCondition } from "../library-cleanup/rule-evaluators.js";
 import type { CacheItemForEval, EvalContext } from "../library-cleanup/types.js";
@@ -69,12 +70,7 @@ const SERVICE_TYPE_MAP: Record<string, "SONARR" | "RADARR"> = {
  * decoupled from the engine.
  */
 export async function executeAutoTagRule(opts: ExecuteOpts): Promise<AutoTagRunResult> {
-	const { rule, prisma, arrClientFactory, log } = opts;
-	// `encryptor` is accepted for executor-signature symmetry with Label Sync but
-	// not used directly here — `arrClientFactory.create` handles api-key
-	// decryption internally for the tag-write phase, and the read phase comes
-	// from `LibraryCache` which is already populated.
-	void opts.encryptor;
+	const { rule, prisma, arrClientFactory, encryptor, log } = opts;
 	const childLog = log.child({ ruleId: rule.id, ruleName: rule.name });
 
 	// Resolve scoped instances. Rule scope = (serviceFilter ∩ instanceFilter)
@@ -153,6 +149,7 @@ export async function executeAutoTagRule(opts: ExecuteOpts): Promise<AutoTagRunR
 			instance,
 			prisma,
 			arrClientFactory,
+			encryptor,
 			evalCtx,
 			compiledTitleRegexes,
 			log: childLog.child({ instanceId: instance.id }),
@@ -207,6 +204,7 @@ interface ProcessInstanceArgs {
 	instance: ServiceInstance;
 	prisma: PrismaClient;
 	arrClientFactory: ArrClientFactory;
+	encryptor: Encryptor;
 	evalCtx: EvalContext;
 	compiledTitleRegexes: RegExp[];
 	log: FastifyBaseLogger;
@@ -220,7 +218,16 @@ interface ProcessInstanceResult {
 }
 
 async function processInstance(args: ProcessInstanceArgs): Promise<ProcessInstanceResult> {
-	const { rule, instance, prisma, arrClientFactory, evalCtx, compiledTitleRegexes, log } = args;
+	const {
+		rule,
+		instance,
+		prisma,
+		arrClientFactory,
+		encryptor,
+		evalCtx,
+		compiledTitleRegexes,
+		log,
+	} = args;
 
 	const items = await prisma.libraryCache.findMany({
 		where: { instanceId: instance.id },
@@ -312,6 +319,34 @@ async function processInstance(args: ProcessInstanceArgs): Promise<ProcessInstan
 				tags: merged,
 			});
 			applied++;
+
+			// Chain into Label Sync (Phase B): if any rules source from this
+			// (instance, tagName), fire them inline so the destination service
+			// (Plex/Jellyfin/Emby/etc.) gets the matching label without
+			// waiting for the next scheduled Label Sync run.
+			//
+			// Failures here are non-fatal — auto-tagger's job (apply the tag)
+			// already succeeded. Label Sync chain failures get logged but
+			// don't change auto-tagger's per-item outcome.
+			try {
+				await triggerLabelSyncForItem({
+					userId: rule.userId,
+					sourceService: instance.service,
+					sourceInstanceId: instance.id,
+					arrItemId: item.arrItemId,
+					itemType: item.itemType,
+					tagName: rule.tagName,
+					prisma,
+					arrClientFactory,
+					encryptor,
+					log,
+				});
+			} catch (chainErr) {
+				log.warn(
+					{ err: chainErr, arrItemId: item.arrItemId, tagName: rule.tagName },
+					"Label Sync chain trigger threw after auto-tag write (non-fatal)",
+				);
+			}
 		} catch (err) {
 			const reason = err instanceof ArrError ? err.message : String(err);
 			log.warn({ err: reason, arrItemId: item.arrItemId }, "Failed to apply tag to item");

--- a/apps/api/src/lib/label-sync/__tests__/execute-rule.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/execute-rule.test.ts
@@ -370,4 +370,69 @@ describe("executeLabelSyncRule (orchestration)", () => {
 		// reader called once per source instance
 		expect(mockState.sourceReaderSpy).toHaveBeenCalledTimes(2);
 	});
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Targeted execution (issue #384 follow-up — Phases B/C/D foundation)
+	// ─────────────────────────────────────────────────────────────────────
+
+	it("targetTmdbId: filters source candidates to the target item before invoking writer", async () => {
+		mockState.sonarrReadResult = {
+			matches: [makeMatch(100), makeMatch(200), makeMatch(300)],
+			failed: false,
+		};
+		mockState.plexWriteResult = { matchesFound: 1, labelsApplied: 1, failures: 0 };
+
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([makeInstance()]),
+				findFirst: vi
+					.fn()
+					.mockResolvedValue(makeInstance({ id: "inst-dest", service: "PLEX", label: "Plex" })),
+			},
+		};
+
+		const result = await executeLabelSyncRule({
+			rule: makeRule(),
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: {} as never,
+			log: fakeLogger,
+			targetTmdbId: 100,
+		});
+
+		expect(result.status).toBe("success");
+		// The writer should have received ONLY the candidate matching tmdbId 100
+		const writerCall = mockState.destWriterSpy.mock.calls[0]?.[0] as
+			| { candidates: MatchCandidate[] }
+			| undefined;
+		expect(writerCall?.candidates).toHaveLength(1);
+		expect(writerCall?.candidates[0]?.tmdbId).toBe(100);
+	});
+
+	it("targetTmdbId: returns no-op success when source has no match for the target tmdbId", async () => {
+		mockState.sonarrReadResult = { matches: [makeMatch(999)], failed: false };
+
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([makeInstance()]),
+				findFirst: vi
+					.fn()
+					.mockResolvedValue(makeInstance({ id: "inst-dest", service: "PLEX", label: "Plex" })),
+			},
+		};
+
+		const result = await executeLabelSyncRule({
+			rule: makeRule(),
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: {} as never,
+			log: fakeLogger,
+			targetTmdbId: 100, // not in candidates
+		});
+
+		expect(result.status).toBe("success");
+		expect(result.message).toContain("does not carry tag");
+		expect(result.totals.labelsApplied).toBe(0);
+		expect(mockState.destWriterSpy).not.toHaveBeenCalled();
+	});
 });

--- a/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/trigger-for-item.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Unit tests for triggerLabelSyncForItem — the foundation that B/C/D all
+ * use to fire Label Sync rules in response to per-item events.
+ *
+ * Mocks the rule-execution layer (executeLabelSyncRule) since this file
+ * is just orchestration: rule lookup + tmdbId resolution + per-rule
+ * isolated invocation.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted; use vi.hoisted to share state cleanly with the factory.
+const { executeMock } = vi.hoisted(() => ({ executeMock: vi.fn() }));
+
+vi.mock("../execute-rule.js", () => ({
+	executeLabelSyncRule: executeMock,
+}));
+
+import { triggerLabelSyncForItem } from "../trigger-for-item.js";
+
+const log = {
+	child: vi.fn().mockReturnThis(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+const okOutcome = {
+	status: "success" as const,
+	message: "ok",
+	totals: {
+		sourceInstancesScanned: 1,
+		taggedItemsFound: 1,
+		destMatchesFound: 1,
+		labelsApplied: 1,
+		failures: 0,
+	},
+};
+
+const makePrisma = (overrides: { rules?: unknown[]; cacheData?: string | null }) =>
+	({
+		labelSyncRule: {
+			findMany: vi.fn().mockResolvedValue(overrides.rules ?? []),
+		},
+		libraryCache: {
+			findFirst: vi
+				.fn()
+				.mockResolvedValue(
+					overrides.cacheData !== undefined ? { data: overrides.cacheData } : null,
+				),
+		},
+	}) as never;
+
+const makeArgs = (over: Partial<Parameters<typeof triggerLabelSyncForItem>[0]> = {}) => ({
+	userId: "user-1",
+	sourceService: "RADARR" as const,
+	sourceInstanceId: "inst-1",
+	arrItemId: 100,
+	itemType: "movie" as const,
+	tagName: "kids",
+	prisma: makePrisma({}),
+	arrClientFactory: {} as never,
+	encryptor: {} as never,
+	log,
+	...over,
+});
+
+describe("triggerLabelSyncForItem", () => {
+	beforeEach(() => {
+		executeMock.mockReset();
+		executeMock.mockResolvedValue(okOutcome);
+	});
+
+	it("returns zero result when no matching rules exist", async () => {
+		const result = await triggerLabelSyncForItem(makeArgs({ prisma: makePrisma({ rules: [] }) }));
+		expect(result.rulesFired).toBe(0);
+		expect(executeMock).not.toHaveBeenCalled();
+	});
+
+	it("looks up rules with lowercased sourceService and the optional tagName filter", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "r1",
+					name: "kids",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "plex",
+					destInstanceId: "plex-1",
+					destTagName: "kids",
+				},
+			],
+			cacheData: JSON.stringify({ tmdbId: 555 }),
+		});
+		await triggerLabelSyncForItem(makeArgs({ prisma }));
+
+		const findMany = (
+			prisma as unknown as { labelSyncRule: { findMany: ReturnType<typeof vi.fn> } }
+		).labelSyncRule.findMany;
+		expect(findMany).toHaveBeenCalledOnce();
+		const where = findMany.mock.calls[0]?.[0]?.where;
+		expect(where.sourceService).toBe("radarr"); // lowercased!
+		expect(where.userId).toBe("user-1");
+		expect(where.enabled).toBe(true);
+		expect(where.sourceTagName).toBe("kids");
+	});
+
+	it("skips when tmdbId is unresolvable (item not in cache)", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "r1",
+					name: "kids",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "plex",
+					destInstanceId: "plex-1",
+					destTagName: "kids",
+				},
+			],
+			cacheData: null, // no cache row
+		});
+		const result = await triggerLabelSyncForItem(makeArgs({ prisma }));
+		expect(result.rulesFired).toBe(0);
+		expect(executeMock).not.toHaveBeenCalled();
+	});
+
+	it("uses explicit tmdbId when provided (no cache lookup)", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "r1",
+					name: "kids",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "plex",
+					destInstanceId: "plex-1",
+					destTagName: "kids",
+				},
+			],
+		});
+		await triggerLabelSyncForItem(makeArgs({ prisma, tmdbId: 999 }));
+
+		expect(executeMock).toHaveBeenCalledOnce();
+		expect(executeMock.mock.calls[0]?.[0]?.targetTmdbId).toBe(999);
+		const findFirst = (
+			prisma as unknown as { libraryCache: { findFirst: ReturnType<typeof vi.fn> } }
+		).libraryCache.findFirst;
+		expect(findFirst).not.toHaveBeenCalled();
+	});
+
+	it("fires every matching rule independently — one failure doesn't block others", async () => {
+		const prisma = makePrisma({
+			rules: [
+				{
+					id: "r1",
+					name: "kids",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "plex",
+					destInstanceId: "plex-1",
+					destTagName: "kids",
+				},
+				{
+					id: "r2",
+					name: "kids-jelly",
+					userId: "user-1",
+					sourceService: "radarr",
+					sourceInstanceId: "inst-1",
+					sourceTagName: "kids",
+					destService: "jellyfin",
+					destInstanceId: "jelly-1",
+					destTagName: "kids",
+				},
+			],
+		});
+		executeMock
+			.mockResolvedValueOnce({ ...okOutcome })
+			.mockRejectedValueOnce(new Error("plex unreachable"));
+
+		const result = await triggerLabelSyncForItem(makeArgs({ prisma, tmdbId: 100 }));
+
+		expect(result.rulesFired).toBe(2);
+		expect(result.results).toHaveLength(2);
+		expect(result.results[0]?.outcome.status).toBe("success");
+		expect(result.results[1]?.outcome.status).toBe("failed");
+		expect(result.totals.failures).toBe(1);
+		expect(result.totals.labelsApplied).toBe(1);
+	});
+
+	it("includes rules with sourceInstanceId=null (match-all-instances rules)", async () => {
+		// Schema allows null sourceInstanceId meaning "match every enabled
+		// instance of the source service". The trigger lookup must include
+		// these via OR.
+		const prisma = makePrisma({});
+		await triggerLabelSyncForItem(makeArgs({ prisma, tmdbId: 1 }));
+
+		const findMany = (
+			prisma as unknown as { labelSyncRule: { findMany: ReturnType<typeof vi.fn> } }
+		).labelSyncRule.findMany;
+		const where = findMany.mock.calls[0]?.[0]?.where;
+		expect(where.OR).toEqual([{ sourceInstanceId: "inst-1" }, { sourceInstanceId: null }]);
+	});
+
+	it("omits sourceTagName filter when tagName not provided (D — fire-all-rules-for-instance)", async () => {
+		const prisma = makePrisma({});
+		await triggerLabelSyncForItem(makeArgs({ tagName: undefined, prisma, tmdbId: 1 }));
+		const findMany = (
+			prisma as unknown as { labelSyncRule: { findMany: ReturnType<typeof vi.fn> } }
+		).labelSyncRule.findMany;
+		const where = findMany.mock.calls[0]?.[0]?.where;
+		expect(where.sourceTagName).toBeUndefined();
+	});
+});

--- a/apps/api/src/lib/label-sync/execute-rule.ts
+++ b/apps/api/src/lib/label-sync/execute-rule.ts
@@ -53,6 +53,17 @@ interface ExecuteOpts {
 	arrClientFactory: ArrClientFactory;
 	encryptor: Encryptor;
 	log: FastifyBaseLogger;
+	/**
+	 * When set, the executor only writes labels to the destination item with
+	 * this tmdbId. Used by event-driven triggers (auto-tagger chain, library
+	 * sync delta detection, per-item "Sync now" button) to scope a rule run
+	 * to a single item rather than scanning the full library each time.
+	 *
+	 * Source-side reads still happen (we need to know whether the source
+	 * actually has the tag applied before writing) but candidates with other
+	 * tmdbIds are filtered out before reaching the destination writer.
+	 */
+	targetTmdbId?: number;
 }
 
 const ZERO_TOTALS: LabelSyncRunResult["totals"] = {
@@ -155,11 +166,37 @@ export async function executeLabelSyncRule(opts: ExecuteOpts): Promise<LabelSync
 		};
 	}
 
+	// Targeted execution: when a caller (event-driven trigger) only wants to
+	// sync ONE item, filter the candidate list to that tmdbId before writing.
+	// Source reads stay unchanged because the readers don't know about
+	// tmdbId-level filtering — cheap to filter here instead.
+	const candidatesForWriter =
+		opts.targetTmdbId !== undefined
+			? allCandidates.filter((c) => c.tmdbId === opts.targetTmdbId)
+			: allCandidates;
+
+	if (opts.targetTmdbId !== undefined && candidatesForWriter.length === 0) {
+		// The targeted item doesn't have the source tag — rule simply
+		// doesn't apply to this item. Not an error; not a success worth
+		// counting either. Return a neutral "no-op" result.
+		return {
+			status: "success",
+			message: `Item (tmdbId ${opts.targetTmdbId}) does not carry tag "${rule.sourceTagName}" on ${rule.sourceService}.`,
+			totals: {
+				sourceInstancesScanned: sourceInstances.length,
+				taggedItemsFound: allCandidates.length,
+				destMatchesFound: 0,
+				labelsApplied: 0,
+				failures: sourceFailures,
+			},
+		};
+	}
+
 	// Pass 2: destination-side writes
 	const writeResult = await destWriter.applyLabels({
 		rule,
 		destInstance,
-		candidates: allCandidates,
+		candidates: candidatesForWriter,
 		prisma,
 		arrClientFactory,
 		encryptor,

--- a/apps/api/src/lib/label-sync/trigger-for-item.ts
+++ b/apps/api/src/lib/label-sync/trigger-for-item.ts
@@ -91,9 +91,19 @@ async function resolveTmdbId(
 	});
 	if (!cache?.data) return null;
 	try {
-		const parsed = JSON.parse(cache.data) as { tmdbId?: unknown };
-		const tmdbId = typeof parsed.tmdbId === "number" ? parsed.tmdbId : null;
-		return tmdbId && tmdbId > 0 ? tmdbId : null;
+		// LibraryItem stores tmdbId nested under `remoteIds.tmdbId` per the
+		// shared schema (some normalizers also surface a top-level `tmdbId`
+		// for movies — check both for robustness).
+		const parsed = JSON.parse(cache.data) as {
+			tmdbId?: unknown;
+			remoteIds?: { tmdbId?: unknown } | null;
+		};
+		const candidates: unknown[] = [parsed.remoteIds?.tmdbId, parsed.tmdbId];
+		for (const value of candidates) {
+			const tmdbId = typeof value === "number" ? value : null;
+			if (tmdbId && tmdbId > 0) return tmdbId;
+		}
+		return null;
 	} catch (err) {
 		log.warn({ err, arrItemId }, "Failed to parse LibraryCache.data while resolving tmdbId");
 		return null;

--- a/apps/api/src/lib/label-sync/trigger-for-item.ts
+++ b/apps/api/src/lib/label-sync/trigger-for-item.ts
@@ -1,0 +1,204 @@
+/**
+ * Event-driven trigger for Label Sync rules.
+ *
+ * Used by:
+ *   - Auto-tagger chained trigger (B): after a tag is applied to an *arr item,
+ *     fire any Label Sync rules that source from that (instance, tag).
+ *   - Library-sync delta detection (C): when the cached tag list for an item
+ *     differs from the *arr-side fresh list, fire rules for added/removed tags.
+ *   - Per-item "Sync labels now" button (D): explicit user trigger via
+ *     POST /api/label-sync/run-for-item.
+ *
+ * The helper:
+ *   1. Looks up enabled rules matching the source instance + (optional) tag name
+ *   2. Resolves the item's tmdbId (from cache, then from the *arr instance as
+ *      fallback) so the executor can scope to that specific item
+ *   3. Runs the executor in targeted mode for each matching rule
+ *   4. Returns a summary; the caller decides whether to log/persist failures
+ *
+ * Failures are isolated per rule — one rule failing doesn't block the others.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import type { ArrClientFactory } from "../arr/client-factory.js";
+import type { Encryptor } from "../auth/encryption.js";
+import type { LibraryItemType, PrismaClient, ServiceType } from "../prisma.js";
+import { executeLabelSyncRule, type LabelSyncRunResult } from "./execute-rule.js";
+
+export interface TriggerLabelSyncForItemArgs {
+	userId: string;
+	/** *arr ServiceInstance row this item lives in (uppercase service enum). */
+	sourceInstanceId: string;
+	sourceService: ServiceType;
+	arrItemId: number;
+	itemType: LibraryItemType;
+	/**
+	 * If set, only rules sourcing this exact tag name are fired. Used by B
+	 * (auto-tagger applied a specific tag) and C (specific tag-id delta).
+	 * Omit for D (per-item button) which fires every matching rule.
+	 */
+	tagName?: string;
+	/**
+	 * tmdbId for the item. If omitted the helper resolves it from
+	 * LibraryCache.data; pass it explicitly when the caller already has it
+	 * to skip the lookup.
+	 */
+	tmdbId?: number;
+	prisma: PrismaClient;
+	arrClientFactory: ArrClientFactory;
+	encryptor: Encryptor;
+	log: FastifyBaseLogger;
+}
+
+export interface TriggerLabelSyncForItemResult {
+	/** Number of LabelSyncRule rows that matched and were attempted. */
+	rulesFired: number;
+	/** Per-rule outcomes — caller can log or surface in UI. */
+	results: Array<{
+		ruleId: string;
+		ruleName: string;
+		outcome: LabelSyncRunResult;
+	}>;
+	/** Aggregate counts across all fired rules. */
+	totals: {
+		labelsApplied: number;
+		failures: number;
+	};
+}
+
+const ZERO_RESULT: TriggerLabelSyncForItemResult = {
+	rulesFired: 0,
+	results: [],
+	totals: { labelsApplied: 0, failures: 0 },
+};
+
+/**
+ * Resolve the tmdbId for an item by reading the LibraryCache row's `data`
+ * blob. Returns null if the item isn't cached or the blob doesn't carry a
+ * usable tmdbId — in which case the trigger is a no-op (we can't write to
+ * a destination without knowing what to match on).
+ */
+async function resolveTmdbId(
+	prisma: PrismaClient,
+	instanceId: string,
+	arrItemId: number,
+	itemType: LibraryItemType,
+	log: FastifyBaseLogger,
+): Promise<number | null> {
+	const cache = await prisma.libraryCache.findFirst({
+		where: { instanceId, arrItemId, itemType },
+		select: { data: true },
+	});
+	if (!cache?.data) return null;
+	try {
+		const parsed = JSON.parse(cache.data) as { tmdbId?: unknown };
+		const tmdbId = typeof parsed.tmdbId === "number" ? parsed.tmdbId : null;
+		return tmdbId && tmdbId > 0 ? tmdbId : null;
+	} catch (err) {
+		log.warn({ err, arrItemId }, "Failed to parse LibraryCache.data while resolving tmdbId");
+		return null;
+	}
+}
+
+export async function triggerLabelSyncForItem(
+	args: TriggerLabelSyncForItemArgs,
+): Promise<TriggerLabelSyncForItemResult> {
+	const childLog = args.log.child({
+		trigger: "label-sync-for-item",
+		sourceInstanceId: args.sourceInstanceId,
+		arrItemId: args.arrItemId,
+		tagName: args.tagName ?? "(any)",
+	});
+
+	// 1. Find matching rules. The schema stores `sourceService` lowercase,
+	//    `ServiceInstance.service` uppercase — translate at the boundary.
+	const rules = await args.prisma.labelSyncRule.findMany({
+		where: {
+			userId: args.userId,
+			enabled: true,
+			sourceService: args.sourceService.toLowerCase(),
+			OR: [{ sourceInstanceId: args.sourceInstanceId }, { sourceInstanceId: null }],
+			...(args.tagName ? { sourceTagName: args.tagName } : {}),
+		},
+	});
+
+	if (rules.length === 0) {
+		return ZERO_RESULT;
+	}
+
+	// 2. Resolve tmdbId — use the explicit value when supplied (cheap), else
+	//    look up from cache. If unresolvable we can't proceed safely.
+	const tmdbId =
+		args.tmdbId ??
+		(await resolveTmdbId(
+			args.prisma,
+			args.sourceInstanceId,
+			args.arrItemId,
+			args.itemType,
+			childLog,
+		));
+
+	if (tmdbId === null) {
+		childLog.debug(
+			"Skipping Label Sync trigger: tmdbId unresolvable (item not in cache or missing tmdbId)",
+		);
+		return { rulesFired: 0, results: [], totals: { labelsApplied: 0, failures: 0 } };
+	}
+
+	// 3. Fire each matching rule with targetTmdbId set. Failures isolated.
+	const results: TriggerLabelSyncForItemResult["results"] = [];
+	let labelsApplied = 0;
+	let failures = 0;
+
+	for (const rule of rules) {
+		try {
+			const outcome = await executeLabelSyncRule({
+				rule: {
+					id: rule.id,
+					userId: rule.userId,
+					sourceService: rule.sourceService,
+					sourceInstanceId: rule.sourceInstanceId,
+					sourceTagName: rule.sourceTagName,
+					destService: rule.destService,
+					destInstanceId: rule.destInstanceId,
+					destTagName: rule.destTagName,
+				},
+				prisma: args.prisma,
+				arrClientFactory: args.arrClientFactory,
+				encryptor: args.encryptor,
+				log: childLog,
+				targetTmdbId: tmdbId,
+			});
+			labelsApplied += outcome.totals.labelsApplied;
+			failures += outcome.totals.failures;
+			results.push({ ruleId: rule.id, ruleName: rule.name, outcome });
+		} catch (err) {
+			childLog.warn(
+				{ err, ruleId: rule.id, ruleName: rule.name },
+				"Label Sync rule trigger threw — counted as failure",
+			);
+			failures++;
+			results.push({
+				ruleId: rule.id,
+				ruleName: rule.name,
+				outcome: {
+					status: "failed",
+					message: err instanceof Error ? err.message : String(err),
+					totals: {
+						sourceInstancesScanned: 0,
+						taggedItemsFound: 0,
+						destMatchesFound: 0,
+						labelsApplied: 0,
+						failures: 1,
+					},
+				},
+			});
+		}
+	}
+
+	return {
+		rulesFired: rules.length,
+		results,
+		totals: { labelsApplied, failures },
+	};
+}

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -64,11 +64,29 @@ function parseTagsFromCacheData(data: string | null | undefined): number[] {
 	if (!data) return [];
 	try {
 		const parsed = JSON.parse(data) as { tags?: unknown };
-		if (!Array.isArray(parsed.tags)) return [];
-		return parsed.tags.filter((t): t is number => typeof t === "number");
+		return coerceTagIds(parsed.tags);
 	} catch {
 		return [];
 	}
+}
+
+/**
+ * The shared `LibraryItem.tags` schema is `z.array(z.string())` (each tag id
+ * stored as a string), but the *arr-sdk's raw movie/series resource returns
+ * `tags: number[]`. The library item builder may pass either through
+ * depending on the path. Normalize both to a number list for diffing.
+ */
+function coerceTagIds(value: unknown): number[] {
+	if (!Array.isArray(value)) return [];
+	const out: number[] = [];
+	for (const v of value) {
+		if (typeof v === "number" && Number.isFinite(v)) out.push(v);
+		else if (typeof v === "string" && v.length > 0) {
+			const n = Number.parseInt(v, 10);
+			if (Number.isFinite(n)) out.push(n);
+		}
+	}
+	return out;
 }
 
 /** Diff old vs new tag ids; returns added + removed (set arithmetic). */
@@ -326,9 +344,22 @@ export async function syncInstance(
 							const newTags = parseTagsFromCacheData(JSON.stringify(item));
 							const { added, removed } = diffTags(oldTags, newTags);
 							if (added.length > 0 || removed.length > 0) {
-								const itemAny = item as { tmdbId?: unknown };
-								const tmdbId =
-									typeof itemAny.tmdbId === "number" && itemAny.tmdbId > 0 ? itemAny.tmdbId : null;
+								// LibraryItem stores tmdbId nested under remoteIds.tmdbId per
+								// the shared schema; some normalizers also surface a top-level
+								// tmdbId. Check both. If neither resolves, the trigger will
+								// fall back to a cache lookup (which uses the same logic).
+								const itemAny = item as {
+									tmdbId?: unknown;
+									remoteIds?: { tmdbId?: unknown } | null;
+								};
+								const tmdbCandidates: unknown[] = [itemAny.remoteIds?.tmdbId, itemAny.tmdbId];
+								let tmdbId: number | null = null;
+								for (const v of tmdbCandidates) {
+									if (typeof v === "number" && v > 0) {
+										tmdbId = v;
+										break;
+									}
+								}
 								tagDeltas.push({
 									arrItemId,
 									itemType: item.type,

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -10,6 +10,8 @@ import { LidarrClient, RadarrClient, ReadarrClient, SonarrClient } from "arr-sdk
 import type { FastifyBaseLogger } from "fastify";
 import type { Prisma, PrismaClient, ServiceInstance } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
+import type { Encryptor } from "../auth/encryption.js";
+import { triggerLabelSyncForItem } from "../label-sync/trigger-for-item.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
 import { getErrorMessage } from "../utils/error-message.js";
 
@@ -39,7 +41,45 @@ export interface SyncResult {
 export interface SyncExecutorDeps {
 	prisma: PrismaClient;
 	arrClientFactory: ArrClientFactory;
+	encryptor: Encryptor;
 	log: FastifyBaseLogger;
+}
+
+/**
+ * One tag-list change detected during a sync run. We collect these inside
+ * the per-batch transaction (cheap — just a JSON parse + array diff) and
+ * process them AFTER all transactions complete, so Label Sync's external
+ * HTTP calls don't hold DB connections open.
+ */
+interface TagDelta {
+	arrItemId: number;
+	itemType: "movie" | "series" | "artist" | "author";
+	tmdbId: number | null;
+	addedTagIds: number[];
+	removedTagIds: number[];
+}
+
+/** Parse the tag id list out of a LibraryCache.data blob. Tolerant of malformed JSON. */
+function parseTagsFromCacheData(data: string | null | undefined): number[] {
+	if (!data) return [];
+	try {
+		const parsed = JSON.parse(data) as { tags?: unknown };
+		if (!Array.isArray(parsed.tags)) return [];
+		return parsed.tags.filter((t): t is number => typeof t === "number");
+	} catch {
+		return [];
+	}
+}
+
+/** Diff old vs new tag ids; returns added + removed (set arithmetic). */
+function diffTags(oldTags: number[], newTags: number[]): { added: number[]; removed: number[] } {
+	const oldSet = new Set(oldTags);
+	const newSet = new Set(newTags);
+	const added: number[] = [];
+	const removed: number[] = [];
+	for (const t of newTags) if (!oldSet.has(t)) added.push(t);
+	for (const t of oldTags) if (!newSet.has(t)) removed.push(t);
+	return { added, removed };
 }
 
 // ============================================================================
@@ -113,7 +153,7 @@ export async function syncInstance(
 	deps: SyncExecutorDeps,
 	instance: ServiceInstance,
 ): Promise<SyncResult> {
-	const { prisma, arrClientFactory, log } = deps;
+	const { prisma, arrClientFactory, encryptor, log } = deps;
 	const startTime = Date.now();
 
 	const result: SyncResult = {
@@ -203,18 +243,44 @@ export async function syncInstance(
 			}
 		}
 
-		// Get existing cached items for this instance (include hasFile for download detection)
+		// Get existing cached items for this instance. We pull `data` so we can
+		// diff the previous tag list against the fresh one for Label Sync's
+		// event-driven trigger (Phase C — issue #384 follow-up).
 		const existingItems = await prisma.libraryCache.findMany({
 			where: { instanceId: instance.id },
-			select: { id: true, arrItemId: true, itemType: true, hasFile: true },
+			select: { id: true, arrItemId: true, itemType: true, hasFile: true, data: true },
 		});
 
 		const existingMap = new Map(
 			existingItems.map((item) => [
 				`${item.arrItemId}-${item.itemType}`,
-				{ id: item.id, hasFile: item.hasFile },
+				{ id: item.id, hasFile: item.hasFile, data: item.data },
 			]),
 		);
+
+		// Pre-fetch tag id→name map for Label Sync delta detection. Only
+		// Sonarr/Radarr support tag-write rules today; Lidarr/Readarr skip.
+		// One call per sync amortizes across every item we examine.
+		const tagIdToName = new Map<number, string>();
+		if (client instanceof SonarrClient || client instanceof RadarrClient) {
+			try {
+				const tags = (await client.tag.getAll()) as Array<{ id?: number; label?: string }>;
+				for (const t of tags) {
+					if (typeof t.id === "number" && typeof t.label === "string" && t.label.length > 0) {
+						tagIdToName.set(t.id, t.label);
+					}
+				}
+			} catch (err) {
+				log.warn(
+					{ err, instanceId: instance.id },
+					"Tag list fetch failed — Label Sync delta detection will be skipped this run",
+				);
+			}
+		}
+
+		// Tag deltas collected during the transaction; processed afterward
+		// so external HTTP calls in Label Sync don't hold DB connections.
+		const tagDeltas: TagDelta[] = [];
 
 		// Track which items we've seen
 		const seenKeys = new Set<string>();
@@ -250,6 +316,28 @@ export async function syncInstance(
 						if (!existing.hasFile && fields.hasFile) {
 							result.newDownloads.push({ title: item.title, itemType: item.type });
 						}
+
+						// Phase C: detect tag-list change vs the previously cached
+						// data, queue Label Sync triggers for processing after the
+						// transaction. Only meaningful for instances where we
+						// successfully pulled the tag id→name map.
+						if (tagIdToName.size > 0) {
+							const oldTags = parseTagsFromCacheData(existing.data);
+							const newTags = parseTagsFromCacheData(JSON.stringify(item));
+							const { added, removed } = diffTags(oldTags, newTags);
+							if (added.length > 0 || removed.length > 0) {
+								const itemAny = item as { tmdbId?: unknown };
+								const tmdbId =
+									typeof itemAny.tmdbId === "number" && itemAny.tmdbId > 0 ? itemAny.tmdbId : null;
+								tagDeltas.push({
+									arrItemId,
+									itemType: item.type,
+									tmdbId,
+									addedTagIds: added,
+									removedTagIds: removed,
+								});
+							}
+						}
 					} else {
 						// Create new item
 						await tx.libraryCache.create({
@@ -274,6 +362,68 @@ export async function syncInstance(
 				},
 			});
 			result.itemsRemoved = idsToRemove.length;
+		}
+
+		// Phase C: process collected tag deltas — fire Label Sync triggers for
+		// items where tags were added or removed. Done OUTSIDE the per-batch
+		// transaction so external HTTP calls don't hold DB connections open.
+		// Failures are isolated per item — one bad delta doesn't abort the rest.
+		if (
+			tagDeltas.length > 0 &&
+			tagIdToName.size > 0 &&
+			(instance.service === "SONARR" || instance.service === "RADARR")
+		) {
+			let triggeredCount = 0;
+			for (const delta of tagDeltas) {
+				if (delta.itemType !== "movie" && delta.itemType !== "series") continue;
+				// Build the union of changed tag names — added OR removed both
+				// warrant re-evaluating Label Sync rules for that tag.
+				const changedNames = new Set<string>();
+				for (const id of delta.addedTagIds) {
+					const name = tagIdToName.get(id);
+					if (name) changedNames.add(name);
+				}
+				for (const id of delta.removedTagIds) {
+					const name = tagIdToName.get(id);
+					if (name) changedNames.add(name);
+				}
+				if (changedNames.size === 0) continue;
+
+				for (const tagName of changedNames) {
+					try {
+						const triggerResult = await triggerLabelSyncForItem({
+							userId: instance.userId,
+							sourceService: instance.service,
+							sourceInstanceId: instance.id,
+							arrItemId: delta.arrItemId,
+							itemType: delta.itemType,
+							tagName,
+							tmdbId: delta.tmdbId ?? undefined,
+							prisma,
+							arrClientFactory,
+							encryptor,
+							log,
+						});
+						if (triggerResult.rulesFired > 0) triggeredCount++;
+					} catch (chainErr) {
+						log.warn(
+							{
+								err: chainErr,
+								arrItemId: delta.arrItemId,
+								tagName,
+								instanceId: instance.id,
+							},
+							"Label Sync trigger threw during library-sync delta processing (non-fatal)",
+						);
+					}
+				}
+			}
+			if (triggeredCount > 0) {
+				log.info(
+					{ instanceId: instance.id, triggeredCount },
+					"Library sync delta fired Label Sync rule triggers",
+				);
+			}
 		}
 
 		// Update sync status
@@ -332,4 +482,3 @@ export async function syncInstance(
 
 	return result;
 }
-

--- a/apps/api/src/lib/library-sync/sync-scheduler.ts
+++ b/apps/api/src/lib/library-sync/sync-scheduler.ts
@@ -257,6 +257,7 @@ class LibrarySyncScheduler {
 				{
 					prisma: this.app.prisma,
 					arrClientFactory: this.app.arrClientFactory,
+					encryptor: this.app.encryptor,
 					log: this.app.log,
 				},
 				instance as Parameters<typeof syncInstance>[1],

--- a/apps/api/src/routes/label-sync.ts
+++ b/apps/api/src/routes/label-sync.ts
@@ -19,6 +19,7 @@ import type {
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { executeLabelSyncRule } from "../lib/label-sync/execute-rule.js";
+import { triggerLabelSyncForItem } from "../lib/label-sync/trigger-for-item.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
 const serviceSchema = z.enum(["sonarr", "radarr", "plex", "jellyfin", "emby"]);
@@ -297,5 +298,60 @@ export async function registerLabelSyncRoutes(app: FastifyInstance, _opts: Fasti
 
 		const response: LabelSyncRuleResponse = { rule: toDto(updated) };
 		return reply.send(response);
+	});
+
+	// Per-item event-driven trigger (Phase D — issue #384 follow-up).
+	// Used by the "Sync labels now" button on the library item detail modal.
+	// Fires every enabled Label Sync rule whose source matches this *arr
+	// instance, scoped to the single item via tmdbId. Idempotent — already-
+	// applied labels no-op at the writer layer.
+	app.post("/run-for-item", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const body = validateRequest(
+			z.object({
+				instanceId: z.string().min(1),
+				arrItemId: z.number().int().positive(),
+				itemType: z.enum(["movie", "series", "artist", "author"]),
+			}),
+			request.body,
+		);
+
+		const instance = await app.prisma.serviceInstance.findFirst({
+			where: { id: body.instanceId, userId },
+		});
+		if (!instance) {
+			return reply.status(404).send({ error: "Instance not found or access denied" });
+		}
+		if (instance.service !== "SONARR" && instance.service !== "RADARR") {
+			return reply.status(400).send({
+				error: "Per-item Label Sync is only supported for Sonarr/Radarr instances today.",
+			});
+		}
+
+		const result = await triggerLabelSyncForItem({
+			userId,
+			sourceService: instance.service,
+			sourceInstanceId: instance.id,
+			arrItemId: body.arrItemId,
+			itemType: body.itemType,
+			// No tagName filter — fire every rule sourcing from this instance.
+			prisma: app.prisma,
+			arrClientFactory: app.arrClientFactory,
+			encryptor: app.encryptor,
+			log: request.log,
+		});
+
+		return reply.send({
+			rulesFired: result.rulesFired,
+			labelsApplied: result.totals.labelsApplied,
+			failures: result.totals.failures,
+			outcomes: result.results.map((r) => ({
+				ruleId: r.ruleId,
+				ruleName: r.ruleName,
+				status: r.outcome.status,
+				message: r.outcome.message,
+				labelsApplied: r.outcome.totals.labelsApplied,
+			})),
+		});
 	});
 }

--- a/apps/web/src/features/library/components/item-details-modal.tsx
+++ b/apps/web/src/features/library/components/item-details-modal.tsx
@@ -20,6 +20,7 @@ import { getLinuxInstanceName, getLinuxIsoName, useIncognitoMode } from "../../.
 import { ExternalLinksSection } from "../../discover/components/media-detail-sections";
 import { formatBytes, formatRuntime, SERVICE_COLORS } from "../lib/library-utils";
 import { PosterImage } from "./poster-image";
+import { SyncLabelsNowButton } from "./sync-labels-now-button";
 
 export interface ItemDetailsModalProps {
 	item: LibraryItem;
@@ -99,7 +100,10 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 		icon?: React.ComponentType<{ className?: string }>;
 	}> = [];
 	if (!isMovie) {
-		seriesMetadata.push({ label: "Instance", value: incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName });
+		seriesMetadata.push({
+			label: "Instance",
+			value: incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName,
+		});
 		seriesMetadata.push({ label: "Service", value: serviceLabel });
 		if (resolvedQualityProfileName) {
 			seriesMetadata.push({ label: "Quality profile", value: resolvedQualityProfileName });
@@ -210,7 +214,9 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 										{item.year}
 									</span>
 								)}
-								<span>{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}</span>
+								<span>
+									{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}
+								</span>
 							</div>
 						</div>
 					</div>
@@ -296,7 +302,9 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 								<div className="grid grid-cols-2 sm:grid-cols-3 gap-x-4 gap-y-2 text-sm">
 									<div>
 										<p className="text-xs text-muted-foreground">Instance</p>
-										<p className="font-medium text-foreground">{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}</p>
+										<p className="font-medium text-foreground">
+											{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}
+										</p>
 									</div>
 									{resolvedQualityProfileName && (
 										<div>
@@ -427,6 +435,23 @@ export const ItemDetailsModal = ({ item, onClose }: ItemDetailsModalProps) => {
 							</div>
 						</div>
 					)}
+
+					{/* Per-item Label Sync trigger (Sonarr/Radarr only). Fires every
+					    enabled rule sourcing from this instance, scoped to this item. */}
+					{(item.service === "sonarr" || item.service === "radarr") &&
+						(item.type === "movie" || item.type === "series") && (
+							<div>
+								<h3 className="text-xs uppercase tracking-wider font-medium text-muted-foreground mb-3">
+									Label Sync
+								</h3>
+								<SyncLabelsNowButton
+									instanceId={item.instanceId}
+									arrItemId={typeof item.id === "string" ? Number.parseInt(item.id, 10) : item.id}
+									itemType={item.type}
+									service={item.service}
+								/>
+							</div>
+						)}
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/features/library/components/sync-labels-now-button.tsx
+++ b/apps/web/src/features/library/components/sync-labels-now-button.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import type { LibraryService } from "@arr/shared";
+import { useMutation } from "@tanstack/react-query";
+import { Check, RefreshCw, Tag } from "lucide-react";
+import { useState } from "react";
+import {
+	type RunLabelSyncForItemResponse,
+	runLabelSyncForItem,
+} from "../../../lib/api-client/label-sync";
+
+interface Props {
+	instanceId: string;
+	arrItemId: number;
+	itemType: "movie" | "series";
+	service: LibraryService;
+}
+
+/**
+ * Per-item "Sync labels now" button (Phase D — issue #384 follow-up).
+ *
+ * Fires every enabled Label Sync rule whose source matches this *arr
+ * instance, scoped to this single item. Idempotent — already-applied
+ * labels no-op at the writer layer. Surfaces inline status feedback so
+ * the user sees rules-fired / labels-applied without opening another
+ * panel.
+ */
+export const SyncLabelsNowButton = ({ instanceId, arrItemId, itemType, service }: Props) => {
+	const [feedback, setFeedback] = useState<{
+		kind: "ok" | "warn" | "err";
+		message: string;
+	} | null>(null);
+
+	const mutation = useMutation<RunLabelSyncForItemResponse, Error>({
+		mutationFn: () => runLabelSyncForItem({ instanceId, arrItemId, itemType }),
+		onSuccess: (result) => {
+			if (result.rulesFired === 0) {
+				setFeedback({
+					kind: "warn",
+					message: "No matching Label Sync rules configured.",
+				});
+				return;
+			}
+			if (result.failures > 0 && result.labelsApplied === 0) {
+				setFeedback({
+					kind: "err",
+					message: `Fired ${result.rulesFired} rule${result.rulesFired === 1 ? "" : "s"}, all failed.`,
+				});
+				return;
+			}
+			if (result.failures > 0) {
+				setFeedback({
+					kind: "warn",
+					message: `Applied ${result.labelsApplied} label${result.labelsApplied === 1 ? "" : "s"}, ${result.failures} failure${result.failures === 1 ? "" : "s"}.`,
+				});
+				return;
+			}
+			setFeedback({
+				kind: "ok",
+				message:
+					result.labelsApplied > 0
+						? `Synced ${result.labelsApplied} label${result.labelsApplied === 1 ? "" : "s"}.`
+						: `Fired ${result.rulesFired} rule${result.rulesFired === 1 ? "" : "s"} — nothing to apply.`,
+			});
+		},
+		onError: (err) => {
+			setFeedback({ kind: "err", message: err.message || "Request failed" });
+		},
+	});
+
+	const supported = service === "sonarr" || service === "radarr";
+	if (!supported) return null;
+
+	const isPending = mutation.isPending;
+
+	return (
+		<div className="flex items-center gap-3">
+			<button
+				type="button"
+				onClick={() => {
+					setFeedback(null);
+					mutation.mutate();
+				}}
+				disabled={isPending}
+				className="inline-flex items-center gap-2 rounded-md border border-border/50 bg-card/30 px-3 py-1.5 text-xs font-medium text-foreground/80 backdrop-blur-sm transition hover:bg-card/60 hover:text-foreground disabled:opacity-50"
+				aria-label="Sync labels for this item now"
+			>
+				{isPending ? (
+					<RefreshCw className="h-3.5 w-3.5 animate-spin" />
+				) : feedback?.kind === "ok" ? (
+					<Check className="h-3.5 w-3.5" />
+				) : (
+					<Tag className="h-3.5 w-3.5" />
+				)}
+				<span>{isPending ? "Syncing labels…" : "Sync labels now"}</span>
+			</button>
+			{feedback && (
+				<span
+					className={`text-xs ${
+						feedback.kind === "ok"
+							? "text-emerald-400"
+							: feedback.kind === "warn"
+								? "text-amber-400"
+								: "text-rose-400"
+					}`}
+					role="status"
+					aria-live="polite"
+				>
+					{feedback.message}
+				</span>
+			)}
+		</div>
+	);
+};

--- a/apps/web/src/lib/api-client/label-sync.ts
+++ b/apps/web/src/lib/api-client/label-sync.ts
@@ -50,3 +50,31 @@ export async function runLabelSyncRule(id: string): Promise<LabelSyncRule> {
 	});
 	return data.rule;
 }
+
+export interface RunLabelSyncForItemRequest {
+	instanceId: string;
+	arrItemId: number;
+	itemType: "movie" | "series" | "artist" | "author";
+}
+
+export interface RunLabelSyncForItemResponse {
+	rulesFired: number;
+	labelsApplied: number;
+	failures: number;
+	outcomes: Array<{
+		ruleId: string;
+		ruleName: string;
+		status: "success" | "partial" | "failed";
+		message: string;
+		labelsApplied: number;
+	}>;
+}
+
+export async function runLabelSyncForItem(
+	payload: RunLabelSyncForItemRequest,
+): Promise<RunLabelSyncForItemResponse> {
+	return apiRequest<RunLabelSyncForItemResponse>("/api/label-sync/run-for-item", {
+		method: "POST",
+		json: payload,
+	});
+}


### PR DESCRIPTION
## Summary
Closes the latency gap reported in issue #384 — Label Sync rules used to wait up to an hour for the scheduled run; now they fire within seconds for auto-grabbed items, minutes for manual *arr-side tag changes, and instantly via a new per-item button.

Three new triggers, all *arr-source rules. Plex-source delta detection (Plex → *arr direction) is deferred to a follow-up arc — needs Plex label cache + delta detection, larger scope.

## Triggers shipped

| Phase | Trigger | Latency |
|---|---|---|
| **B** | Auto-tagger chains into Label Sync — after tag write succeeds, fire matching rules inline | Seconds |
| **C** | Library-sync delta detection — diffs cached vs. fresh *arr tags during the existing poll cycle | 5–15 min (library-sync interval) |
| **D** | "Sync labels now" button on the library item detail modal | Instant |

The 1-hour scheduler stays as a self-healing safety net for anything else.

## Architecture

**Foundation: `executeLabelSyncRule(rule, ..., targetTmdbId?)`** — optional parameter that scopes a rule run to a single tmdbId. Without it (scheduler path) behavior is unchanged. With it (event-driven triggers) the executor filters source candidates after read so the destination writer only sees the targeted item — O(rule-count) instead of O(library-size) per change.

**`triggerLabelSyncForItem(args)`** — shared orchestrator used by all three triggers. Finds matching rules, resolves tmdbId, fires each rule with isolated per-rule failure handling.

## Granularity model — unchanged

Rules remain `sourceTagName → destTagName` mappings. The rule list IS the allow-list — tags without a matching rule never propagate. No schema additions for include/exclude filters in this PR; the trigger architecture works equally well for any future granularity extensions (per-rule library scoping, per-item exclusions) without changes.

## What this PR deliberately does NOT include

- **Plex-source delta detection** — separate arc; ~doubles PR size; users who manually label in Plex still rely on the scheduler or click "Sync now"
- **Per-rule include/exclude filters** — current implicit allow-list (rule list = opt-in) covers the reported needs; YAGNI until real users hit the limitation
- **No Connect webhook surface** — *arr Connect doesn't fire on tag changes, only lifecycle events; library-sync delta detection covers the gap better than a webhook would

## Test plan
- [x] `pnpm run typecheck` — clean across all 3 packages
- [x] `pnpm run test` — **1471 (api) + 426 (web) + 38 (shared) = 1935 passed**, 38 skipped (pre-existing), 0 failed
- [x] `__tests__/trigger-for-item.test.ts` (new, 7 cases) — rule lookup, tmdbId resolution, per-rule failure isolation
- [x] `__tests__/execute-rule.test.ts` (extended, +2 cases) — targetTmdbId filter behavior, no-op success
- [x] **Live-validated against the dev environment's real Sonarr+Radarr+Plex instances** via an ephemeral runner:
  - Temp Label Sync rule (radarr "animation" → plex "arr-dashboard-itest-…")
  - Triggered for Spirited Away (tmdbId 129)
  - Result: 9 tagged items found, **1 matched targetTmdbId**, **1 label applied to Plex, 0 failures**
  - Cleanup confirmed
- [ ] Reviewer (live): create a real Label Sync rule, tag an item in Sonarr/Radarr, watch logs for the chain fire (B). Manually edit a tag in Sonarr UI, wait a sync cycle, confirm the label propagates (C). Click "Sync labels now" on a movie detail modal (D).

## Out of scope notes
- Issue #384's other ask (Plex-source webhook trigger) intentionally deferred — see PR description rationale
- Any *arr that doesn't preserve tmdbId on series/movie records won't trigger — items where `LibraryCache.data` lacks tmdbId are skipped (not failed) by the trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)