### PR TITLE
chore: v2.18.1 release — changelog and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.1] - 2026-05-03
+
+**Labels & tagging — bug fix + event-driven triggers (issue #384).** Two follow-ups to the Label Sync / Auto-Tagger features that shipped in 2.18.0: a Radarr/Sonarr validator error that broke tag application is fixed, and Label Sync rules now fire within seconds of a tag change instead of waiting for the hourly schedule.
+
+### Fixed
+
+- **Tag application no longer fails with `'Quality Profile Id' must be greater than '0'`.** The auto-tagger and the Label Sync arr-writer were sending partial PUT bodies (`{ id, tags }`) to Radarr/Sonarr, but stricter validator releases require the full resource. Both writers now fetch the existing item via `getById` and spread it into the update body, matching the canonical pattern in `library-cleanup/cleanup-executor.ts` (#418).
+
+### Added
+
+- **Event-driven Label Sync triggers.** Rules used to wait up to an hour for the scheduled run; now they fire on every relevant change. Three triggers shipped: (1) auto-tagger chain — when the auto-tagger applies a tag matched by a Label Sync rule, the rule fires inline; (2) library-sync delta detection — when an external tag change is observed during the existing library-sync poll, matching rules fire (5–15 min latency); (3) per-item "Sync labels now" button on the library item detail modal for instant manual propagation. End-to-end "Radarr import → Plex label" lands in seconds when the Sonarr/Radarr Connect webhook is configured (Settings → Auto-Tagger → Webhook Config); the scheduler-only fallback is bounded by the auto-tagger schedule. Currently *arr-source rules only — Plex-source rules continue to rely on the scheduler; the 1-hour scheduled run remains as the self-healing safety net (#420).
+
+- **Live-integration test for the *arr tag-write pattern.** Gated on `INTEGRATION_TESTS=1` plus per-service env vars; runs the full `getById → spread → update` round-trip against a real Radarr/Sonarr instance to catch regressions of the validator-rejection class shipped in this release. CI never runs it; documented as an operator pre-release step in `docs/RELEASING.md` §2 (#419).
+
 ## [2.18.0] - 2026-05-01
 
 **Auto-Tagger: criteria-based tagging for Sonarr/Radarr — companion to Label Sync.** A new automation feature that applies tags to *arr items when they match a rule's criteria DSL. Same expressiveness as Library Cleanup (50+ rule types: genre, year, codec, watch state, Plex labels/collections, custom format score, audio channels, runtime, file path regex, etc.) plus full composite (AND/OR) rules and real-time tagging via Sonarr/Radarr Connect webhooks. Pair with Label Sync to mirror the tag onto Plex/Jellyfin/Emby labels — Auto-Tagger seeds the source tag, Label Sync propagates it. New `/auto-tag` page in the Maintenance section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.18.0 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.18.1 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.0** — Auto-Tagger: criteria-based tagging for Sonarr/Radarr with composite (AND/OR) rules across 50+ rule types, real-time Sonarr/Radarr Connect webhooks for sub-second tagging, and TMDb/Trakt list-membership rule types. Plus library deep-link fix, TRaSH cache empty-result fix, and Plex log-leak hardening
+> **Version 2.18.1** — Labels & tagging follow-up to 2.18.0: fixes a Radarr/Sonarr partial-PUT validator rejection (`'Quality Profile Id' must be greater than '0'`) that broke tag application on stricter releases, plus event-driven Label Sync triggers (auto-tagger chain, library-sync delta detection, per-item "Sync labels now" button) so rules fire within seconds of a tag change instead of waiting for the hourly schedule.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -94,6 +94,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |
 | `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |
 | `2.16.2` | Security patch — Fastify HIGH bypass + DOMPurify/hono/postcss fixes; workflow shell-injection closed; TRaSH migration notices |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.0** — Auto-Tagger: criteria-based tagging for Sonarr/Radarr with composite (AND/OR) rules across 50+ rule types, real-time Sonarr/Radarr Connect webhooks for sub-second tagging, and TMDb/Trakt list-membership rule types. Plus library deep-link fix, TRaSH cache empty-result fix, and Plex log-leak hardening
+> **Version 2.18.1** — Labels & tagging follow-up to 2.18.0: fixes a Radarr/Sonarr partial-PUT validator rejection (`'Quality Profile Id' must be greater than '0'`) that broke tag application on stricter releases, plus event-driven Label Sync triggers (auto-tagger chain, library-sync delta detection, per-item "Sync labels now" button) so rules fire within seconds of a tag change instead of waiting for the hourly schedule.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -225,6 +225,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |
 | `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |
 | `2.16.2` | Security patch — Fastify HIGH bypass + DOMPurify/hono/postcss fixes; workflow shell-injection closed; TRaSH migration notices |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.18.0",
+	"version": "2.18.1",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
Patch release rolling up the labels/tagging follow-ups since v2.18.0.

### What's in 2.18.1
- **Fix (#418)**: partial-PUT validator rejection on stricter Radarr/Sonarr versions (`'Quality Profile Id' must be greater than '0'`) — both the auto-tagger and the Label Sync arr-writer now fetch via \`getById\` and spread the full resource into the update body
- **Feature (#420)**: event-driven Label Sync triggers — auto-tagger chain (sub-second when Connect webhook configured), library-sync delta detection (5–15 min), per-item "Sync labels now" button. The 1-hour scheduler remains as the self-healing safety net.
- **Tooling (#419)**: gated live-integration test for the *arr tag-write pattern, documented in \`docs/RELEASING.md\` §2

### What's deliberately not in 2.18.1
- **Programmatic webhook auto-install** (track for 2.18.2): one-click "install/update Connect webhook on these *arr instances" UI. Existing manual webhook config from 2.18.0 still works; this is a UX improvement.
- **Plex-source Label Sync rules** in event-driven triggers: deferred to a separate arc; rules using PLEX as the source service continue to rely on the scheduler.
- **qui integration**: lives on \`feat/qui-integration\` branch; will ship as a single tagged release when complete.

### Files updated
- \`package.json\` — version 2.18.0 → 2.18.1
- \`CHANGELOG.md\` — new \`[2.18.1] - 2026-05-03\` section
- \`README.md\` — version tagline + tags table row
- \`DOCKERHUB.md\` — version tagline + tags table row
- \`CLAUDE.md\` — version footer

## Test plan
- [x] \`pnpm run typecheck\` — clean (turbo cached, no source changes)
- [x] \`pnpm run test\` — 1935 passed, 38 skipped, 0 failed (turbo cached)
- [x] Live-validated in #418 and #420 against the dev environment's Sonarr/Radarr/Plex instances
- [ ] CI green on this PR

## Post-merge actions (not in this PR)
- Tag the merge commit as \`v2.18.1\` (manual, after CI green)
- Create GitHub release with the changelog text
- Update wiki: \`Home.md\` and \`Troubleshooting.md\` version references
- Reply on issue #384 confirming the fix shipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)