### PR TITLE
feat(auto-tag): one-click Connect webhook auto-install (closes #422)

### DIFF
--- a/apps/api/src/lib/auto-tag/__tests__/webhook-installer.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/webhook-installer.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for the auto-install Connect webhook helper (issue #422).
+ *
+ * Mocks the *arr-sdk client's notification accessor; verifies:
+ *   - Probe correctly detects existing arr-dashboard webhook by name match
+ *   - Install creates new notification when none exists
+ *   - Install updates existing notification when found (idempotent re-install)
+ *   - Install failures are surfaced per-instance without throwing
+ *   - Listing scopes to enabled SONARR/RADARR instances only
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../prisma.js";
+import {
+	ARR_DASHBOARD_NOTIFICATION_NAME,
+	installOnInstance,
+	listEligibleInstances,
+	probeInstallStatus,
+} from "../webhook-installer.js";
+
+const radarrInstance = (over: Partial<ServiceInstance> = {}): ServiceInstance =>
+	({
+		id: "inst-1",
+		userId: "u1",
+		service: "RADARR",
+		label: "Primary Radarr",
+		baseUrl: "http://radarr",
+		externalUrl: null,
+		encryptedApiKey: "enc",
+		encryptionIv: "iv",
+		isDefault: false,
+		enabled: true,
+		storageGroupId: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...over,
+	}) as ServiceInstance;
+
+interface MockClient {
+	notification: {
+		getAll: ReturnType<typeof vi.fn>;
+		create: ReturnType<typeof vi.fn>;
+		update: ReturnType<typeof vi.fn>;
+	};
+}
+
+const buildClient = (existing: Array<{ id: number; name: string }> = []): MockClient => ({
+	notification: {
+		getAll: vi.fn().mockResolvedValue(existing),
+		create: vi.fn(async (n) => ({ ...n, id: 99 })),
+		update: vi.fn(async (id, n) => ({ ...n, id })),
+	},
+});
+
+const factory = (client: MockClient) =>
+	({
+		create: vi.fn().mockReturnValue(client),
+	}) as never;
+
+describe("probeInstallStatus", () => {
+	it("returns installed=false when no arr-dashboard notification exists", async () => {
+		const client = buildClient([{ id: 1, name: "Discord" }]);
+		const result = await probeInstallStatus(
+			{ prisma: {} as never, arrClientFactory: factory(client) },
+			radarrInstance(),
+		);
+		expect(result.installed).toBe(false);
+		expect(result.notificationId).toBeNull();
+		expect(result.error).toBeNull();
+	});
+
+	it("returns installed=true with notificationId when matching name found", async () => {
+		const client = buildClient([
+			{ id: 1, name: "Discord" },
+			{ id: 7, name: ARR_DASHBOARD_NOTIFICATION_NAME },
+		]);
+		const result = await probeInstallStatus(
+			{ prisma: {} as never, arrClientFactory: factory(client) },
+			radarrInstance(),
+		);
+		expect(result.installed).toBe(true);
+		expect(result.notificationId).toBe(7);
+	});
+
+	it("captures the error message and reports installed=false on probe failure", async () => {
+		const factoryErr = {
+			create: vi.fn().mockImplementation(() => {
+				throw new Error("api key invalid");
+			}),
+		} as never;
+		const result = await probeInstallStatus(
+			{ prisma: {} as never, arrClientFactory: factoryErr },
+			radarrInstance(),
+		);
+		expect(result.installed).toBe(false);
+		expect(result.error).toBe("api key invalid");
+	});
+});
+
+describe("installOnInstance", () => {
+	const args = {
+		webhookUrl: "https://arr-dash.example/api/auto-tag/webhook/inst-1",
+		bearerSecret: "test-secret-32-chars-or-more-here",
+		events: { onDownload: true, onUpgrade: true, onGrab: false },
+	};
+
+	it("creates a new notification when none exists with the canonical name", async () => {
+		const client = buildClient([{ id: 1, name: "Discord" }]);
+		const result = await installOnInstance(
+			{ prisma: {} as never, arrClientFactory: factory(client) },
+			radarrInstance(),
+			args,
+		);
+		expect(result.status).toBe("installed");
+		expect(client.notification.create).toHaveBeenCalledOnce();
+		expect(client.notification.update).not.toHaveBeenCalled();
+
+		const payload = client.notification.create.mock.calls[0]?.[0];
+		expect(payload.name).toBe(ARR_DASHBOARD_NOTIFICATION_NAME);
+		expect(payload.implementation).toBe("Webhook");
+		expect(payload.onDownload).toBe(true);
+		expect(payload.onUpgrade).toBe(true);
+		expect(payload.onGrab).toBe(false);
+
+		// URL + Bearer secret threaded through fields
+		const fields = payload.fields as Array<{ name: string; value: unknown }>;
+		expect(fields.find((f) => f.name === "url")?.value).toBe(args.webhookUrl);
+		const headers = fields.find((f) => f.name === "headers")?.value as Array<{
+			key: string;
+			value: string;
+		}>;
+		expect(headers[0]?.value).toBe(`Bearer ${args.bearerSecret}`);
+	});
+
+	it("updates the existing notification (idempotent re-install)", async () => {
+		const client = buildClient([{ id: 7, name: ARR_DASHBOARD_NOTIFICATION_NAME }]);
+		const result = await installOnInstance(
+			{ prisma: {} as never, arrClientFactory: factory(client) },
+			radarrInstance(),
+			args,
+		);
+		expect(result.status).toBe("updated");
+		expect(result.notificationId).toBe(7);
+		expect(client.notification.update).toHaveBeenCalledOnce();
+		expect(client.notification.create).not.toHaveBeenCalled();
+		const [id, payload] = client.notification.update.mock.calls[0] ?? [];
+		expect(id).toBe(7);
+		expect((payload as { id: number }).id).toBe(7);
+	});
+
+	it("returns status=failed with error message on SDK exception", async () => {
+		const client = {
+			notification: {
+				getAll: vi.fn().mockRejectedValue(new Error("503 Service Unavailable")),
+				create: vi.fn(),
+				update: vi.fn(),
+			},
+		};
+		const result = await installOnInstance(
+			{ prisma: {} as never, arrClientFactory: factory(client) },
+			radarrInstance(),
+			args,
+		);
+		expect(result.status).toBe("failed");
+		expect(result.error).toContain("Service Unavailable");
+		expect(client.notification.create).not.toHaveBeenCalled();
+		expect(client.notification.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("listEligibleInstances", () => {
+	it("scopes to enabled SONARR/RADARR for the given user", async () => {
+		const findMany = vi.fn().mockResolvedValue([radarrInstance()]);
+		const prisma = { serviceInstance: { findMany } } as never;
+		await listEligibleInstances(prisma, "u1");
+		expect(findMany).toHaveBeenCalledOnce();
+		const where = findMany.mock.calls[0]?.[0]?.where;
+		expect(where.userId).toBe("u1");
+		expect(where.service).toEqual({ in: ["SONARR", "RADARR"] });
+		expect(where.enabled).toBe(true);
+	});
+});

--- a/apps/api/src/lib/auto-tag/webhook-installer.ts
+++ b/apps/api/src/lib/auto-tag/webhook-installer.ts
@@ -1,0 +1,226 @@
+/**
+ * Programmatic Sonarr/Radarr Connect webhook installer (issue #422).
+ *
+ * Auto-discovers the user's enabled Sonarr/Radarr instances, queries each
+ * for an existing arr-dashboard webhook, and either creates or updates the
+ * notification with the current arr-dashboard webhook URL + Bearer secret.
+ *
+ * The plaintext webhook secret is NOT stored at rest. It comes from the
+ * frontend (which has it in session memory after the user clicked Generate
+ * or Rotate) and is passed through this module to the *arr's notification
+ * API. We never log the secret and never echo it in error messages.
+ */
+
+import type { ArrError } from "arr-sdk";
+import type { ArrClient, ArrClientFactory } from "../arr/client-factory.js";
+import type { PrismaClient, ServiceInstance } from "../prisma.js";
+
+/** Notification name used to identify arr-dashboard's webhook in *arr's UI. */
+export const ARR_DASHBOARD_NOTIFICATION_NAME = "arr-dashboard auto-tagger";
+
+export interface InstallEvents {
+	onDownload: boolean; // post-import — primary event
+	onUpgrade: boolean;
+	onGrab: boolean;
+}
+
+export const DEFAULT_EVENTS: InstallEvents = {
+	onDownload: true,
+	onUpgrade: true,
+	onGrab: false,
+};
+
+export interface InstallStatusEntry {
+	instanceId: string;
+	label: string;
+	service: "SONARR" | "RADARR";
+	installed: boolean;
+	/** Notification id in the *arr (only present when installed). */
+	notificationId: number | null;
+	/** Last error encountered probing this instance (e.g. "instance unreachable"). */
+	error: string | null;
+}
+
+export interface InstallResultEntry {
+	instanceId: string;
+	label: string;
+	service: "SONARR" | "RADARR";
+	status: "installed" | "updated" | "skipped" | "failed";
+	notificationId: number | null;
+	error: string | null;
+}
+
+interface InstallerDeps {
+	prisma: PrismaClient;
+	arrClientFactory: ArrClientFactory;
+}
+
+/**
+ * Build the Connect webhook notification payload for a given *arr instance.
+ *
+ * Field-name spelling differs slightly between *arr versions, but all
+ * versions accept the lowercase forms used here. Forwards-compatible by
+ * checking field names case-insensitively when reading existing
+ * notifications.
+ */
+function buildNotificationPayload(args: {
+	webhookUrl: string;
+	bearerSecret: string;
+	events: InstallEvents;
+}) {
+	return {
+		name: ARR_DASHBOARD_NOTIFICATION_NAME,
+		implementation: "Webhook",
+		implementationName: "Webhook",
+		configContract: "WebhookSettings",
+		// Connect's webhook fields use a name/value pair list; the *arr UI
+		// renders these as the form inputs. method=1 → POST.
+		fields: [
+			{ name: "url", value: args.webhookUrl },
+			{ name: "method", value: 1 },
+			{ name: "username", value: "" },
+			{ name: "password", value: "" },
+			{
+				name: "headers",
+				value: [{ key: "Authorization", value: `Bearer ${args.bearerSecret}` }],
+			},
+		],
+		tags: [],
+		onGrab: args.events.onGrab,
+		onDownload: args.events.onDownload,
+		onUpgrade: args.events.onUpgrade,
+		onRename: false,
+		onMovieAdded: false,
+		onMovieDelete: false,
+		onMovieFileDelete: false,
+		onMovieFileDeleteForUpgrade: false,
+		onSeriesAdd: false,
+		onSeriesDelete: false,
+		onEpisodeFileDelete: false,
+		onEpisodeFileDeleteForUpgrade: false,
+		onHealthIssue: false,
+		onHealthRestored: false,
+		onApplicationUpdate: false,
+		onManualInteractionRequired: false,
+		includeHealthWarnings: false,
+	};
+}
+
+/** Find an existing arr-dashboard notification on this *arr by name match. */
+async function findExistingNotification(client: ArrClient): Promise<{
+	id: number;
+} | null> {
+	// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires the cast
+	const all = (await (client as any).notification.getAll()) as Array<{
+		id?: number;
+		name?: string | null;
+	}>;
+	const match = all.find((n) => n.name === ARR_DASHBOARD_NOTIFICATION_NAME);
+	if (!match || typeof match.id !== "number") return null;
+	return { id: match.id };
+}
+
+/** Probe one instance for current install state. Failures don't throw. */
+export async function probeInstallStatus(
+	deps: InstallerDeps,
+	instance: ServiceInstance,
+): Promise<InstallStatusEntry> {
+	const base: Pick<InstallStatusEntry, "instanceId" | "label" | "service"> = {
+		instanceId: instance.id,
+		label: instance.label,
+		service: instance.service as "SONARR" | "RADARR",
+	};
+
+	try {
+		const client = deps.arrClientFactory.create({
+			id: instance.id,
+			baseUrl: instance.baseUrl,
+			encryptedApiKey: instance.encryptedApiKey,
+			encryptionIv: instance.encryptionIv,
+			service: instance.service,
+			label: instance.label,
+		});
+		const found = await findExistingNotification(client);
+		return {
+			...base,
+			installed: found !== null,
+			notificationId: found?.id ?? null,
+			error: null,
+		};
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err);
+		return { ...base, installed: false, notificationId: null, error: reason };
+	}
+}
+
+/** Install or update arr-dashboard's webhook on a single instance. */
+export async function installOnInstance(
+	deps: InstallerDeps,
+	instance: ServiceInstance,
+	args: { webhookUrl: string; bearerSecret: string; events: InstallEvents },
+): Promise<InstallResultEntry> {
+	const base: Pick<InstallResultEntry, "instanceId" | "label" | "service"> = {
+		instanceId: instance.id,
+		label: instance.label,
+		service: instance.service as "SONARR" | "RADARR",
+	};
+
+	try {
+		const client = deps.arrClientFactory.create({
+			id: instance.id,
+			baseUrl: instance.baseUrl,
+			encryptedApiKey: instance.encryptedApiKey,
+			encryptionIv: instance.encryptionIv,
+			service: instance.service,
+			label: instance.label,
+		});
+		const existing = await findExistingNotification(client);
+		const payload = buildNotificationPayload(args);
+
+		if (existing) {
+			// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires the cast
+			const updated = (await (client as any).notification.update(existing.id, {
+				...payload,
+				id: existing.id,
+			})) as { id?: number };
+			return {
+				...base,
+				status: "updated",
+				notificationId: updated.id ?? existing.id,
+				error: null,
+			};
+		}
+
+		// biome-ignore lint/suspicious/noExplicitAny: SDK union typing requires the cast
+		const created = (await (client as any).notification.create(payload)) as { id?: number };
+		return {
+			...base,
+			status: "installed",
+			notificationId: created.id ?? null,
+			error: null,
+		};
+	} catch (err) {
+		// Best effort error message — the *arr-sdk's ArrError has a `.message`
+		// already; for unknown failure modes we fall back to String(err).
+		const reason =
+			err instanceof Error
+				? `${(err as ArrError).statusCode ?? ""} ${err.message}`.trim()
+				: String(err);
+		return { ...base, status: "failed", notificationId: null, error: reason };
+	}
+}
+
+/** List the user's enabled Sonarr/Radarr instances eligible for auto-install. */
+export async function listEligibleInstances(
+	prisma: PrismaClient,
+	userId: string,
+): Promise<ServiceInstance[]> {
+	return prisma.serviceInstance.findMany({
+		where: {
+			userId,
+			service: { in: ["SONARR", "RADARR"] },
+			enabled: true,
+		},
+		orderBy: [{ service: "asc" }, { label: "asc" }],
+	});
+}

--- a/apps/api/src/lib/auto-tag/webhook-installer.ts
+++ b/apps/api/src/lib/auto-tag/webhook-installer.ts
@@ -11,9 +11,10 @@
  * API. We never log the secret and never echo it in error messages.
  */
 
-import type { ArrError } from "arr-sdk";
+import { ArrError } from "arr-sdk";
 import type { ArrClient, ArrClientFactory } from "../arr/client-factory.js";
 import type { PrismaClient, ServiceInstance } from "../prisma.js";
+import { getErrorMessage } from "../utils/error-message.js";
 
 /** Notification name used to identify arr-dashboard's webhook in *arr's UI. */
 export const ARR_DASHBOARD_NOTIFICATION_NAME = "arr-dashboard auto-tagger";
@@ -148,8 +149,7 @@ export async function probeInstallStatus(
 			error: null,
 		};
 	} catch (err) {
-		const reason = err instanceof Error ? err.message : String(err);
-		return { ...base, installed: false, notificationId: null, error: reason };
+		return { ...base, installed: false, notificationId: null, error: getErrorMessage(err) };
 	}
 }
 
@@ -200,12 +200,10 @@ export async function installOnInstance(
 			error: null,
 		};
 	} catch (err) {
-		// Best effort error message — the *arr-sdk's ArrError has a `.message`
-		// already; for unknown failure modes we fall back to String(err).
-		const reason =
-			err instanceof Error
-				? `${(err as ArrError).statusCode ?? ""} ${err.message}`.trim()
-				: String(err);
+		// Prefix the HTTP status code only when the error is an ArrError —
+		// avoids the unsafe `as ArrError` cast that hid type-narrowing.
+		const message = getErrorMessage(err);
+		const reason = err instanceof ArrError ? `${err.statusCode} ${message}`.trim() : message;
 		return { ...base, status: "failed", notificationId: null, error: reason };
 	}
 }

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -21,6 +21,12 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { executeAutoTagRule } from "../lib/auto-tag/execute-rule.js";
 import { runRuleWithLock } from "../lib/auto-tag/run-with-lock.js";
+import {
+	DEFAULT_EVENTS,
+	installOnInstance,
+	listEligibleInstances,
+	probeInstallStatus,
+} from "../lib/auto-tag/webhook-installer.js";
 import { safeJsonParse } from "../lib/utils/json.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
@@ -412,6 +418,116 @@ export async function registerAutoTagRoutes(app: FastifyInstance, _opts: Fastify
 	// mounted in `PUBLIC_ROUTE_GROUPS` via `auto-tag-webhook.ts` so
 	// Sonarr/Radarr can reach it without a session cookie. It authenticates
 	// via Bearer token (the user's hashed webhook secret).
+
+	// ─────────────────────────────────────────────────────────────────────
+	// Programmatic Connect webhook auto-install (issue #422).
+	//
+	// Auto-discovers the user's enabled Sonarr/Radarr instances and
+	// installs/updates the arr-dashboard webhook in each via *arr's
+	// notification API. The plaintext webhook secret is passed in the
+	// install request body (the frontend has it from a recent rotation/
+	// generation) — we never persist plaintext.
+	// ─────────────────────────────────────────────────────────────────────
+
+	app.get("/webhook/install/status", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const instances = await listEligibleInstances(app.prisma, userId);
+		const probes = await Promise.all(
+			instances.map((instance) =>
+				probeInstallStatus(
+					{ prisma: app.prisma, arrClientFactory: app.arrClientFactory },
+					instance,
+				),
+			),
+		);
+		return reply.send({ instances: probes });
+	});
+
+	const installBody = z.object({
+		// The plaintext webhook secret. We never read this from the DB —
+		// frontend gets it via /webhook-config (which only returns it on
+		// freshly-generated/rotated requests) and passes it through here.
+		secret: z.string().min(16),
+		instanceIds: z.array(z.string().min(1)).min(1).max(20),
+		events: z
+			.object({
+				onDownload: z.boolean().optional(),
+				onUpgrade: z.boolean().optional(),
+				onGrab: z.boolean().optional(),
+			})
+			.optional(),
+	});
+
+	app.post("/webhook/install", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const {
+			secret,
+			instanceIds,
+			events: eventsOverride,
+		} = validateRequest(installBody, request.body);
+
+		// Verify the supplied secret matches the user's stored hash. This is
+		// the same fast-path check the inbound Connect webhook handler uses,
+		// just inverted (we have plaintext + hash, want to confirm match).
+		const user = await app.prisma.user.findUnique({ where: { id: userId } });
+		if (!user || !user.hashedWebhookSecret) {
+			return reply
+				.status(412)
+				.send({ error: "Webhook secret not configured. Generate one first." });
+		}
+		const supplied = createHash("sha256").update(secret).digest("hex");
+		if (supplied !== user.hashedWebhookSecret) {
+			return reply.status(401).send({
+				error:
+					"Supplied webhook secret does not match the stored value. Rotate via the Webhook Config panel and try again.",
+			});
+		}
+
+		// Resolve the public-facing URL the *arr will POST to. The Connect
+		// webhook mount path is /api/auto-tag/webhook/:instanceId. We build
+		// it from the request's own host so reverse-proxy setups work.
+		const protocol = (request.headers["x-forwarded-proto"] as string) ?? request.protocol;
+		const host =
+			(request.headers["x-forwarded-host"] as string) ??
+			(request.headers.host as string | undefined) ??
+			"";
+		const externalBase = `${protocol}://${host}`;
+		const events = { ...DEFAULT_EVENTS, ...(eventsOverride ?? {}) };
+
+		// Resolve instances scoped to this user and the eligible service set.
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: {
+				userId,
+				id: { in: instanceIds },
+				service: { in: ["SONARR", "RADARR"] },
+				enabled: true,
+			},
+		});
+		if (instances.length === 0) {
+			return reply.status(404).send({ error: "No matching enabled Sonarr/Radarr instances" });
+		}
+
+		const results = await Promise.all(
+			instances.map((instance) =>
+				installOnInstance(
+					{ prisma: app.prisma, arrClientFactory: app.arrClientFactory },
+					instance,
+					{
+						webhookUrl: `${externalBase}/api/auto-tag/webhook/${instance.id}`,
+						bearerSecret: secret,
+						events,
+					},
+				),
+			),
+		);
+
+		const installed = results.filter(
+			(r) => r.status === "installed" || r.status === "updated",
+		).length;
+		const failed = results.filter((r) => r.status === "failed").length;
+
+		return reply.send({ results, summary: { total: results.length, installed, failed } });
+	});
 }
 
 function generateWebhookSecret(): string {

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -483,15 +483,17 @@ export async function registerAutoTagRoutes(app: FastifyInstance, _opts: Fastify
 			});
 		}
 
-		// Resolve the public-facing URL the *arr will POST to. The Connect
-		// webhook mount path is /api/auto-tag/webhook/:instanceId. We build
-		// it from the request's own host so reverse-proxy setups work.
-		const protocol = (request.headers["x-forwarded-proto"] as string) ?? request.protocol;
-		const host =
-			(request.headers["x-forwarded-host"] as string) ??
-			(request.headers.host as string | undefined) ??
-			"";
-		const externalBase = `${protocol}://${host}`;
+		// Resolve the public-facing URL the *arr will POST to. Precedence:
+		//   1. SystemSettings.externalUrl — admin-configured canonical URL
+		//   2. Fastify-managed request.protocol/hostname — already respects
+		//      the trustProxy flag (set in server.ts), so X-Forwarded-* are
+		//      only honoured behind a real reverse proxy
+		// Reading X-Forwarded-* directly would bypass that trust gate and
+		// let a forged Host header redirect the bearer secret to an attacker.
+		const settings = await app.prisma.systemSettings.findUnique({ where: { id: 1 } });
+		const externalBase = settings?.externalUrl
+			? settings.externalUrl.replace(/\/$/, "")
+			: `${request.protocol}://${request.hostname}`;
 		const events = { ...DEFAULT_EVENTS, ...(eventsOverride ?? {}) };
 
 		// Resolve instances scoped to this user and the eligible service set.

--- a/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
@@ -1,15 +1,18 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Copy, RotateCw, Webhook } from "lucide-react";
+import { AlertCircle, Check, Copy, RotateCw, Webhook } from "lucide-react";
 import { useState } from "react";
 import { GlassmorphicCard } from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import { useIncognitoMode } from "../../../contexts/IncognitoContext";
 import {
 	fetchWebhookConfig,
+	fetchWebhookInstallStatus,
+	installWebhookOnInstances,
 	regenerateWebhookSecret,
 	type WebhookConfig,
+	type WebhookInstallResponse,
 } from "../../../lib/api-client/auto-tag-webhook";
 
 const QUERY_KEY = ["auto-tag", "webhook-config"] as const;
@@ -150,7 +153,211 @@ export const WebhookConfigPanel = () => {
 						Rotate secret
 					</Button>
 				</div>
+
+				<AutoInstallSection plaintextSecret={data?.secret ?? null} />
 			</div>
 		</GlassmorphicCard>
+	);
+};
+
+// ─── Auto-install sub-panel ──────────────────────────────────────────
+//
+// Discovers the user's enabled Sonarr/Radarr instances and installs the
+// arr-dashboard Connect webhook in one click. The plaintext secret only
+// exists in the browser session after a recent generation/rotation, so
+// the install button is gated on that.
+
+const INSTALL_STATUS_QUERY_KEY = ["auto-tag", "webhook-install-status"] as const;
+
+const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | null }) => {
+	const queryClient = useQueryClient();
+	const [selected, setSelected] = useState<Set<string>>(new Set());
+	const [events, setEvents] = useState({ onDownload: true, onUpgrade: true, onGrab: false });
+	const [lastResults, setLastResults] = useState<WebhookInstallResponse["results"] | null>(null);
+
+	const statusQuery = useQuery({
+		queryKey: INSTALL_STATUS_QUERY_KEY,
+		queryFn: fetchWebhookInstallStatus,
+	});
+
+	const install = useMutation({
+		mutationFn: () =>
+			installWebhookOnInstances({
+				secret: plaintextSecret as string,
+				instanceIds: Array.from(selected),
+				events,
+			}),
+		onSuccess: (response) => {
+			setLastResults(response.results);
+			queryClient.invalidateQueries({ queryKey: INSTALL_STATUS_QUERY_KEY });
+		},
+	});
+
+	const instances = statusQuery.data?.instances ?? [];
+	const hasSecret = Boolean(plaintextSecret);
+	const canInstall = hasSecret && selected.size > 0 && !install.isPending;
+
+	const toggleInstance = (id: string) => {
+		setSelected((prev) => {
+			const next = new Set(prev);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
+
+	const selectAll = () => setSelected(new Set(instances.map((i) => i.instanceId)));
+	const clearAll = () => setSelected(new Set());
+
+	if (statusQuery.isLoading) {
+		return (
+			<div className="border-t border-border/40 pt-3">
+				<p className="text-xs text-muted-foreground">Discovering *arr instances…</p>
+			</div>
+		);
+	}
+
+	if (instances.length === 0) {
+		return (
+			<div className="border-t border-border/40 pt-3 space-y-1">
+				<h4 className="text-sm font-semibold flex items-center gap-2">
+					<Webhook className="h-3.5 w-3.5" />
+					Auto-install
+				</h4>
+				<p className="text-xs text-muted-foreground">
+					No enabled Sonarr or Radarr instances configured. Add one in Settings → Services to enable
+					webhook auto-install.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="border-t border-border/40 pt-3 space-y-3">
+			<div className="flex items-start justify-between gap-2">
+				<div>
+					<h4 className="text-sm font-semibold flex items-center gap-2">
+						<Webhook className="h-3.5 w-3.5" />
+						Auto-install
+					</h4>
+					<p className="text-xs text-muted-foreground mt-0.5">
+						Push the webhook config above to your Sonarr/Radarr instances in one click — no manual
+						copy/paste in each *arr's Connect settings.
+					</p>
+				</div>
+				<div className="flex gap-1 shrink-0">
+					<button
+						type="button"
+						onClick={selectAll}
+						className="text-xs text-muted-foreground hover:text-foreground transition"
+					>
+						Select all
+					</button>
+					<span className="text-xs text-muted-foreground">·</span>
+					<button
+						type="button"
+						onClick={clearAll}
+						className="text-xs text-muted-foreground hover:text-foreground transition"
+					>
+						None
+					</button>
+				</div>
+			</div>
+
+			<ul className="space-y-1">
+				{instances.map((inst) => {
+					const result = lastResults?.find((r) => r.instanceId === inst.instanceId);
+					return (
+						<li
+							key={inst.instanceId}
+							className="flex items-center justify-between gap-3 rounded-md border border-border/40 bg-card/20 px-3 py-2 text-xs"
+						>
+							<label className="flex items-center gap-2 flex-1 cursor-pointer">
+								<input
+									type="checkbox"
+									checked={selected.has(inst.instanceId)}
+									onChange={() => toggleInstance(inst.instanceId)}
+									className="h-3.5 w-3.5"
+								/>
+								<span className="font-medium">{inst.label}</span>
+								<span className="text-muted-foreground">({inst.service.toLowerCase()})</span>
+							</label>
+							<span className="text-xs">
+								{result ? (
+									result.status === "failed" ? (
+										<span className="text-rose-400" title={result.error ?? "Failed"}>
+											<AlertCircle className="h-3 w-3 inline mr-1" />
+											{result.error?.slice(0, 60) ?? "Failed"}
+										</span>
+									) : (
+										<span className="text-emerald-400">
+											<Check className="h-3 w-3 inline mr-1" />
+											{result.status === "updated" ? "Updated" : "Installed"}
+										</span>
+									)
+								) : inst.error ? (
+									<span className="text-amber-400" title={inst.error}>
+										Probe failed
+									</span>
+								) : inst.installed ? (
+									<span className="text-emerald-400/70">
+										<Check className="h-3 w-3 inline mr-1" />
+										Installed
+									</span>
+								) : (
+									<span className="text-muted-foreground">Not installed</span>
+								)}
+							</span>
+						</li>
+					);
+				})}
+			</ul>
+
+			<div className="flex flex-wrap items-center gap-3 text-xs">
+				<span className="text-muted-foreground">Events:</span>
+				{(["onDownload", "onUpgrade", "onGrab"] as const).map((ev) => (
+					<label key={ev} className="flex items-center gap-1.5 cursor-pointer">
+						<input
+							type="checkbox"
+							checked={events[ev]}
+							onChange={(e) => setEvents((prev) => ({ ...prev, [ev]: e.target.checked }))}
+							className="h-3 w-3"
+						/>
+						<span>
+							{ev === "onDownload" ? "On Import" : ev === "onUpgrade" ? "On Upgrade" : "On Grab"}
+						</span>
+					</label>
+				))}
+			</div>
+
+			{!hasSecret && (
+				<div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
+					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
+					<span>
+						Click <strong>Rotate secret</strong> above to display the secret — needed for one-click
+						install. (Existing manual webhooks will need to be reconfigured if you rotate.)
+					</span>
+				</div>
+			)}
+
+			{install.isError && (
+				<div className="flex items-center gap-2 rounded-md border border-rose-500/30 bg-rose-500/10 px-3 py-2 text-xs text-rose-300">
+					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
+					<span>{(install.error as Error).message}</span>
+				</div>
+			)}
+
+			<Button
+				type="button"
+				size="sm"
+				onClick={() => install.mutate()}
+				disabled={!canInstall}
+				className="text-xs"
+			>
+				{install.isPending
+					? "Installing…"
+					: `Install / Update on ${selected.size} instance${selected.size === 1 ? "" : "s"}`}
+			</Button>
+		</div>
 	);
 };

--- a/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
@@ -14,8 +14,7 @@ import {
 	type WebhookConfig,
 	type WebhookInstallResponse,
 } from "../../../lib/api-client/auto-tag-webhook";
-
-const QUERY_KEY = ["auto-tag", "webhook-config"] as const;
+import { autoTagKeys } from "../../../lib/query-keys";
 
 export const WebhookConfigPanel = () => {
 	const [copied, setCopied] = useState<"url" | "secret" | null>(null);
@@ -23,14 +22,14 @@ export const WebhookConfigPanel = () => {
 	const queryClient = useQueryClient();
 
 	const { data, isLoading } = useQuery({
-		queryKey: QUERY_KEY,
+		queryKey: autoTagKeys.webhookConfig,
 		queryFn: fetchWebhookConfig,
 	});
 
 	const regenerate = useMutation({
 		mutationFn: regenerateWebhookSecret,
 		onSuccess: (next: WebhookConfig) => {
-			queryClient.setQueryData<WebhookConfig>(QUERY_KEY, next);
+			queryClient.setQueryData<WebhookConfig>(autoTagKeys.webhookConfig, next);
 		},
 	});
 
@@ -167,8 +166,6 @@ export const WebhookConfigPanel = () => {
 // exists in the browser session after a recent generation/rotation, so
 // the install button is gated on that.
 
-const INSTALL_STATUS_QUERY_KEY = ["auto-tag", "webhook-install-status"] as const;
-
 const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | null }) => {
 	const queryClient = useQueryClient();
 	const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -176,7 +173,7 @@ const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | nul
 	const [lastResults, setLastResults] = useState<WebhookInstallResponse["results"] | null>(null);
 
 	const statusQuery = useQuery({
-		queryKey: INSTALL_STATUS_QUERY_KEY,
+		queryKey: autoTagKeys.webhookInstallStatus,
 		queryFn: fetchWebhookInstallStatus,
 	});
 
@@ -189,7 +186,7 @@ const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | nul
 			}),
 		onSuccess: (response) => {
 			setLastResults(response.results);
-			queryClient.invalidateQueries({ queryKey: INSTALL_STATUS_QUERY_KEY });
+			queryClient.invalidateQueries({ queryKey: autoTagKeys.webhookInstallStatus });
 		},
 	});
 

--- a/apps/web/src/lib/api-client/auto-tag-webhook.ts
+++ b/apps/web/src/lib/api-client/auto-tag-webhook.ts
@@ -27,3 +27,57 @@ export async function regenerateWebhookSecret(): Promise<WebhookConfig> {
 		method: "POST",
 	});
 }
+
+// ─── Programmatic install (issue #422) ──────────────────────────────────
+
+export interface WebhookInstallStatusEntry {
+	instanceId: string;
+	label: string;
+	service: "SONARR" | "RADARR";
+	installed: boolean;
+	notificationId: number | null;
+	error: string | null;
+}
+
+export interface WebhookInstallStatusResponse {
+	instances: WebhookInstallStatusEntry[];
+}
+
+export async function fetchWebhookInstallStatus(): Promise<WebhookInstallStatusResponse> {
+	return apiRequest<WebhookInstallStatusResponse>("/api/auto-tag/webhook/install/status");
+}
+
+export interface WebhookInstallEvents {
+	onDownload?: boolean;
+	onUpgrade?: boolean;
+	onGrab?: boolean;
+}
+
+export interface WebhookInstallRequest {
+	secret: string;
+	instanceIds: string[];
+	events?: WebhookInstallEvents;
+}
+
+export interface WebhookInstallResultEntry {
+	instanceId: string;
+	label: string;
+	service: "SONARR" | "RADARR";
+	status: "installed" | "updated" | "skipped" | "failed";
+	notificationId: number | null;
+	error: string | null;
+}
+
+export interface WebhookInstallResponse {
+	results: WebhookInstallResultEntry[];
+	summary: { total: number; installed: number; failed: number };
+}
+
+export async function installWebhookOnInstances(
+	body: WebhookInstallRequest,
+): Promise<WebhookInstallResponse> {
+	return apiRequest<WebhookInstallResponse>("/api/auto-tag/webhook/install", {
+		method: "POST",
+		json: body,
+	});
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -457,6 +457,8 @@ export const labelSyncKeys = {
 export const autoTagKeys = {
 	all: ["auto-tag"] as const,
 	rules: ["auto-tag", "rules"] as const,
+	webhookConfig: ["auto-tag", "webhook-config"] as const,
+	webhookInstallStatus: ["auto-tag", "webhook-install-status"] as const,
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
Closes #422. Removes the manual setup friction for arr-dashboard's auto-tagger Connect webhook. The existing Webhook Config panel now auto-discovers the user's enabled Sonarr/Radarr instances and installs/updates the webhook in one click via each *arr's notification API.

## Before / after

**Before (2.18.1)**: User opens arr-dashboard → copies URL + Bearer secret → opens each Sonarr/Radarr UI → Settings → Connect → Add → Webhook → pastes URL + headers → enables Import/Upgrade events → saves. Repeats for each *arr instance. **5–10 minutes per instance, error-prone.**

**After (this PR / 2.18.2)**: User opens arr-dashboard → Settings → Auto-Tagger → Webhook Config → clicks "Install/Update on N instances" → done. **5 seconds total, idempotent.**

## What's in scope (revised from #422)

| Area | Original | Shipped |
|---|---|---|
| Instance selection | Manual checkboxes | **Auto-discover from Settings → Services** (source of truth) |
| Read-only API key handling | Surface 403 | **Removed** — *arr doesn't have read-only keys |
| Default events | OnImport + OnUpgrade + OnTest | OnImport + OnUpgrade (OnTest is implicit — Connect tests use the same endpoint) |
| Idempotency | Detect by name | **Same** — name match on \`arr-dashboard auto-tagger\` |
| Multi-instance UX | Picker | Inline list with status badges, select-all/none |

## Backend

### \`lib/auto-tag/webhook-installer.ts\` (new)
- \`probeInstallStatus(instance)\` — returns \`{ installed, notificationId, error }\` per instance via \`notification.getAll\`
- \`installOnInstance(instance, args)\` — get-or-create with name match; returns \`{ status: "installed" | "updated" | "failed", error? }\`
- \`listEligibleInstances(userId)\` — scoped to enabled SONARR/RADARR

### \`routes/auto-tag.ts\` (extended)
- \`GET /api/auto-tag/webhook/install/status\` — discovery + state probe
- \`POST /api/auto-tag/webhook/install\` — accepts \`{ secret, instanceIds, events }\`; verifies secret matches \`hashedWebhookSecret\`; constructs URL from request headers (handles reverse-proxy via X-Forwarded-Host/Proto); per-instance upsert; returns per-instance status array

### Security model
**Plaintext webhook secret is never stored at rest.** The frontend holds it transiently in session memory (only available right after generate/rotate), passes it through to the install endpoint, which SHA-256-hashes for comparison against the stored \`hashedWebhookSecret\`, then forwards to *arr. Same threat model as the inbound webhook handler. No schema changes, no encryption-at-rest of the secret.

## Frontend

### \`webhook-config-panel.tsx\` (extended)
New \`AutoInstallSection\` sub-panel below the existing URL/secret display:
- Auto-discovered instance list with status badges (\`Installed\` / \`Not installed\` / \`Probe failed\`)
- Select all / none affordances
- Event checkboxes (defaults: On Import + On Upgrade, On Grab off)
- One-click install/update button — gated on plaintext secret being in the session
- Per-instance result display after install (\`✓ Installed\`, \`✓ Updated\`, or error message)
- Helpful "Rotate to enable" prompt when secret isn't in the session

### \`lib/api-client/auto-tag-webhook.ts\` (extended)
- \`fetchWebhookInstallStatus()\` + \`installWebhookOnInstances({ secret, instanceIds, events })\`
- Type definitions matching the backend response shapes

## Default events

| Event | Default | Why |
|---|---|---|
| On Import / On Download | ✓ ON | Primary event — fires post-import, item is in *arr DB |
| On Upgrade | ✓ ON | Quality upgrade can flip quality-based auto-tag rule eligibility |
| On Grab | OFF | File doesn't exist yet, item may not be in LibraryCache → wasted evaluation |
| All others (Rename, Delete, Health, etc.) | OFF | Not item-level events |

## Test plan

- [x] \`pnpm run typecheck\` — clean across all 3 packages
- [x] \`pnpm run test\` — 1942 passed (+7 new), 38 skipped, 0 failed
- [x] **Live-tested against dev Radarr** via an ephemeral runner:
  - \`probeInstallStatus\`: correctly returns \`{ installed: false }\` when no arr-dashboard webhook exists ✓
  - \`installOnInstance\` SDK call: payload shape is accepted by Radarr — Radarr proceeds to its own URL-validation step ✓
  - \`installOnInstance\` error path: Radarr's URL-reachability validation failure (Radarr POSTs a test message during create) is correctly surfaced as a structured per-instance \`{ status: "failed", error }\` ✓
- [ ] Reviewer (in browser): rotate secret → click install on one Sonarr/Radarr instance → verify the notification appears in that *arr's Connect settings with the correct URL/headers/events ✓

## Behavioral notes for the changelog

**Radarr/Sonarr validate the webhook URL during install** by POSTing a test message and requiring 2xx. This means:
- The arr-dashboard URL must be reachable from the *arr (typically true — they're on the same network)
- If the *arr can't reach arr-dashboard, the install returns a structured error per-instance with the exact reason
- This is the same constraint that already applies to manual webhook setup — no new restriction, just now surfaced earlier

## Out of scope (deliberately deferred)

- **URL override** for users whose *arr can't reach arr-dashboard via the auto-detected host (e.g., split-horizon DNS). Today: the auto-detected URL is used; user falls back to manual setup if it fails. Add an optional override field if real users hit this.
- **Lidarr/Readarr support** — Connect surfaces are similar but field shapes differ; defer until users ask
- **Bulk uninstall / "remove arr-dashboard webhook from all instances"** — defer; users can delete via *arr's Connect UI or via this same UI in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)