### PR TITLE
chore: v2.18.2 release — webhook auto-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.2] - 2026-05-03
+
+**Auto-Tagger — one-click Connect webhook auto-install (issue #422).** A follow-up to the real-time webhook plumbing that shipped in 2.18.0: instead of hand-pasting the URL and `Authorization: Bearer …` header into every Sonarr/Radarr's Connect settings, you can now select your enabled instances inside the Auto-Tagger settings panel and push the canonical webhook to all of them in a single click.
+
+### Added
+
+- **One-click webhook auto-install for Sonarr/Radarr Connect.** The Auto-Tagger settings panel grew an **Auto-install** sub-section that lists every enabled Sonarr/Radarr instance with its current install state (Installed / Not installed / Probe failed). Selecting one or more instances and clicking "Install / Update on N instances" pushes the `arr-dashboard auto-tagger` notification (URL + Bearer secret + event flags) to each *arr's `/api/v3/notification` endpoint. Idempotent — re-running updates the existing notification by name match. Per-instance failures (auth error, *arr offline) surface individually without blocking the rest of the batch. The install URL is derived from `SystemSettings.externalUrl` when configured, falling back to Fastify's `trustProxy`-aware request fields, so a forged `Host` header cannot redirect Connect traffic to an attacker. Backed by `GET /api/auto-tag/webhook/install/status` and `POST /api/auto-tag/webhook/install`. Closes #422 (#423).
+
 ## [2.18.1] - 2026-05-03
 
 **Labels & tagging — bug fix + event-driven triggers (issue #384).** Two follow-ups to the Label Sync / Auto-Tagger features that shipped in 2.18.0: a Radarr/Sonarr validator error that broke tag application is fixed, and Label Sync rules now fire within seconds of a tag change instead of waiting for the hourly schedule.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.18.1 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.18.2 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.1** — Labels & tagging follow-up to 2.18.0: fixes a Radarr/Sonarr partial-PUT validator rejection (`'Quality Profile Id' must be greater than '0'`) that broke tag application on stricter releases, plus event-driven Label Sync triggers (auto-tagger chain, library-sync delta detection, per-item "Sync labels now" button) so rules fire within seconds of a tag change instead of waiting for the hourly schedule.
+> **Version 2.18.2** — Auto-Tagger follow-up to 2.18.1: one-click Connect webhook auto-install. The Auto-Tagger settings now discover your enabled Sonarr/Radarr instances and push the `arr-dashboard auto-tagger` Connect notification (URL + Bearer secret + event flags) to each one in a single click — no more hand-pasting into every *arr's Connect settings. Idempotent re-runs update the existing webhook by name match; per-instance failures surface individually without blocking the rest.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -94,6 +94,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |
 | `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.1** — Labels & tagging follow-up to 2.18.0: fixes a Radarr/Sonarr partial-PUT validator rejection (`'Quality Profile Id' must be greater than '0'`) that broke tag application on stricter releases, plus event-driven Label Sync triggers (auto-tagger chain, library-sync delta detection, per-item "Sync labels now" button) so rules fire within seconds of a tag change instead of waiting for the hourly schedule.
+> **Version 2.18.2** — Auto-Tagger follow-up to 2.18.1: one-click Connect webhook auto-install. The Auto-Tagger settings now discover your enabled Sonarr/Radarr instances and push the `arr-dashboard auto-tagger` Connect notification (URL + Bearer secret + event flags) to each one in a single click — no more hand-pasting into every *arr's Connect settings. Idempotent re-runs update the existing webhook by name match; per-instance failures surface individually without blocking the rest.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -225,6 +225,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |
 | `2.17.0` | Statistics overhaul: Jellyfin/Emby tab + Plex tab decoupled from Tautulli (now optional enrichment); SessionSnapshot-derived leaderboards |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.18.1",
+	"version": "2.18.2",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

- Bumps version to **2.18.2** across `package.json`, `README.md`, `DOCKERHUB.md`, `CLAUDE.md`
- Adds 2.18.2 section to `CHANGELOG.md`
- Wiki updates pushed separately (`Home.md`, `Troubleshooting.md`, `Auto-Tagger.md` → new "One-click auto-install" sub-section)

This release contains exactly one PR — #423 (closes #422), the one-click Sonarr/Radarr Connect webhook auto-install for Auto-Tagger.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` (exit 0)
- [x] `pnpm --filter @arr/api exec tsc --noEmit` (exit 0)
- [x] `pnpm run typecheck` — turbo / CI parity (exit 0)
- [x] `pnpm run test` (exit 0)
- [x] `pnpm run build` (exit 0)
- [x] Live E2E for #423 ran twice on the feature branch (post-review-fixes) — install path produced an actual Radarr notification with bearer round-trip and clean cleanup
- [ ] CI green on this branch
- [ ] Merge → tag `v2.18.2` → push wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)