### PR TITLE
fix: improve text readability on indexer page (#428)

### DIFF
--- a/apps/web/src/components/ui/pagination.tsx
+++ b/apps/web/src/components/ui/pagination.tsx
@@ -82,11 +82,11 @@ export const Pagination = ({
 	return (
 		<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
 			{/* Items info and page size selector */}
-			<div className="flex flex-wrap items-center gap-4 text-sm text-white/70">
+			<div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
 				<span>
-					Showing <span className="font-medium text-white">{startItem}</span> to{" "}
-					<span className="font-medium text-white">{endItem}</span> of{" "}
-					<span className="font-medium text-white">{totalItems}</span> items
+					Showing <span className="font-medium text-foreground">{startItem}</span> to{" "}
+					<span className="font-medium text-foreground">{endItem}</span> of{" "}
+					<span className="font-medium text-foreground">{totalItems}</span> items
 				</span>
 				<div className="flex items-center gap-2">
 					<label htmlFor="page-size" className="text-sm">
@@ -144,7 +144,9 @@ export const Pagination = ({
 						>
 							1
 						</Button>
-						{(pageNumbers[0] ?? 1) > 2 && <span className="px-2 text-white/50">...</span>}
+						{(pageNumbers[0] ?? 1) > 2 && (
+							<span className="px-2 text-muted-foreground/50">...</span>
+						)}
 					</>
 				)}
 
@@ -165,7 +167,7 @@ export const Pagination = ({
 				{showLastPage && (
 					<>
 						{(pageNumbers[pageNumbers.length - 1] ?? totalPages) < totalPages - 1 && (
-							<span className="px-2 text-white/50">...</span>
+							<span className="px-2 text-muted-foreground/50">...</span>
 						)}
 						<Button
 							variant="ghost"

--- a/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
+++ b/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
@@ -50,10 +50,10 @@ const FieldRow = ({
 
 				{/* Value */}
 				<div className="flex-1 min-w-0 flex items-center gap-2">
-					{sensitive && <Lock className="h-3 w-3 text-muted-foreground/30 shrink-0" />}
+					{sensitive && <Lock className="h-3 w-3 text-muted-foreground/45 shrink-0" />}
 					<p className={`text-[13px] font-medium leading-tight min-w-0 ${masked ? "select-none" : ""}`}>
 						{masked ? (
-							<span className="text-muted-foreground/30 tracking-[0.2em] font-mono text-xs">
+							<span className="text-muted-foreground/45 tracking-[0.2em] font-mono text-xs">
 								{"●".repeat(Math.min(displayValue.length, 20))}
 							</span>
 						) : (
@@ -64,7 +64,7 @@ const FieldRow = ({
 						<button
 							type="button"
 							onClick={handleCopy}
-							className="shrink-0 rounded-md p-1 text-muted-foreground/30 hover:text-foreground hover:bg-card/60 transition-all opacity-0 group-hover:opacity-100"
+							className="shrink-0 rounded-md p-1 text-muted-foreground/45 hover:text-foreground hover:bg-card/60 transition-all opacity-0 group-hover:opacity-100"
 							title={copied ? "Copied!" : "Copy value"}
 						>
 							{copied ? (
@@ -79,7 +79,7 @@ const FieldRow = ({
 
 			{/* Help text — full description below the key-value row */}
 			{field.helpText && (
-				<p className="text-[10px] text-muted-foreground/40 leading-relaxed mt-1 ml-[152px] sm:ml-[192px]">
+				<p className="text-[10px] text-muted-foreground/55 leading-relaxed mt-1 ml-[152px] sm:ml-[192px]">
 					{field.helpText}
 				</p>
 			)}
@@ -116,17 +116,17 @@ export const IndexerConfigurationFields = ({ fields }: { fields: ProwlarrIndexer
 
 	return (
 		<div
-			className="rounded-lg border border-border/20 bg-card/20 p-4 animate-in fade-in duration-300"
+			className="rounded-lg border border-border/20 bg-card/30 backdrop-blur-sm p-4 animate-in fade-in duration-300"
 			style={{ animationDelay: "250ms", animationFillMode: "backwards" }}
 		>
 			{/* Header */}
 			<div className="flex items-center justify-between mb-1">
 				<div className="flex items-center gap-2">
 					<Settings className="h-3.5 w-3.5" style={{ color: themeGradient.from }} />
-					<span className="text-[10px] uppercase tracking-wider font-semibold text-muted-foreground/50">
+					<span className="text-[10px] uppercase tracking-wider font-semibold text-muted-foreground/65">
 						Configuration
 					</span>
-					<span className="text-[10px] text-muted-foreground/30 font-mono">
+					<span className="text-[10px] text-muted-foreground/45 font-mono">
 						{normalFields.length + sensitiveFields.length}
 					</span>
 				</div>
@@ -174,7 +174,7 @@ export const IndexerConfigurationFields = ({ fields }: { fields: ProwlarrIndexer
 			{showSensitive && sensitiveFields.length > 0 && (
 				<div className="mt-2 pt-2 border-t border-border/15 animate-in fade-in slide-in-from-top-1 duration-200">
 					<div className="flex items-center gap-1.5 mb-1 px-0.5">
-						<Lock className="h-2.5 w-2.5 text-muted-foreground/30" />
+						<Lock className="h-2.5 w-2.5 text-muted-foreground/45" />
 						<span className="text-[10px] text-muted-foreground/35">
 							Hover to copy — these values are read-only in the dashboard
 						</span>

--- a/apps/web/src/features/indexers/components/indexer-details-info.tsx
+++ b/apps/web/src/features/indexers/components/indexer-details-info.tsx
@@ -52,7 +52,7 @@ const StatTile = ({
 				</div>
 			)}
 			<div className="min-w-0">
-				<p className="text-[10px] uppercase tracking-wider font-medium text-muted-foreground/50 leading-none mb-1">
+				<p className="text-[10px] uppercase tracking-wider font-medium text-muted-foreground/60 leading-none mb-1">
 					{label}
 				</p>
 				<p
@@ -91,7 +91,7 @@ const SuccessGauge = ({ rate }: { rate?: number }) => {
 							strokeWidth="4"
 						/>
 					</svg>
-					<span className="absolute text-xs font-medium text-muted-foreground/30">N/A</span>
+					<span className="absolute text-xs font-medium text-muted-foreground/45">N/A</span>
 				</div>
 				<span className="text-[10px] uppercase tracking-wider font-semibold text-muted-foreground/40">
 					Success Rate
@@ -188,7 +188,7 @@ const PerfMetric = ({
 					{label}
 				</p>
 				<p
-					className={`text-[13px] font-medium leading-tight tabular-nums ${hasValue ? "text-foreground" : "text-muted-foreground/25"}`}
+					className={`text-[13px] font-medium leading-tight tabular-nums ${hasValue ? "text-foreground" : "text-muted-foreground/40"}`}
 				>
 					{hasValue ? value : "N/A"}
 				</p>
@@ -242,7 +242,7 @@ export const IndexerDetailsInfo = ({
 		<div className="space-y-0">
 			{/* Zone 1: Info ribbon */}
 			<div
-				className="rounded-lg border border-border/20 bg-card/20 p-4 animate-in fade-in duration-300"
+				className="rounded-lg border border-border/20 bg-card/30 backdrop-blur-sm p-4 animate-in fade-in duration-300"
 				style={{ animationDelay: "50ms", animationFillMode: "backwards" }}
 			>
 				<div className="grid gap-4 grid-cols-2 sm:grid-cols-3 lg:grid-cols-6">
@@ -296,7 +296,7 @@ export const IndexerDetailsInfo = ({
 			{/* Zone 2: Performance panel */}
 			{stats && (
 				<div
-					className="mt-3 rounded-lg border border-border/20 bg-card/20 p-4 animate-in fade-in duration-300"
+					className="mt-3 rounded-lg border border-border/20 bg-card/30 backdrop-blur-sm p-4 animate-in fade-in duration-300"
 					style={{ animationDelay: "120ms", animationFillMode: "backwards" }}
 				>
 					<div className="flex items-center gap-1.5 mb-4">

--- a/apps/web/src/features/indexers/components/indexer-details-panel.tsx
+++ b/apps/web/src/features/indexers/components/indexer-details-panel.tsx
@@ -239,7 +239,7 @@ export const IndexerDetailsPanel = ({
 					<>
 						{/* Floating action bar */}
 						<div className="flex items-center justify-between gap-3">
-							<div className="flex items-center gap-2 text-[11px] text-muted-foreground/45">
+							<div className="flex items-center gap-2 text-[11px] text-muted-foreground/55">
 								<ChevronDown className="h-3 w-3" />
 								{isEditing ? (
 									<span style={{ color: themeGradient.from }}>Editing configuration</span>

--- a/apps/web/src/features/indexers/components/indexer-instance-card.tsx
+++ b/apps/web/src/features/indexers/components/indexer-instance-card.tsx
@@ -49,7 +49,7 @@ export const IndexerInstanceCard = ({
 	const [incognitoMode] = useIncognitoMode();
 
 	return (
-		<article className="rounded-xl border border-border/30 bg-card/15 overflow-hidden">
+		<article className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
 			{/* Slim header */}
 			<header className="flex items-center justify-between px-4 py-3 border-b border-border/20">
 				<div className="flex items-center gap-3">
@@ -81,7 +81,7 @@ export const IndexerInstanceCard = ({
 			{/* Indexer rows */}
 			{indexers.length === 0 ? (
 				<div className="px-4 py-10 text-center">
-					<Globe className="h-8 w-8 mx-auto mb-2 text-muted-foreground/30" />
+					<Globe className="h-8 w-8 mx-auto mb-2 text-muted-foreground/40" />
 					<p className="text-xs text-muted-foreground/50">No indexers configured</p>
 				</div>
 			) : (

--- a/apps/web/src/features/indexers/components/indexer-row.tsx
+++ b/apps/web/src/features/indexers/components/indexer-row.tsx
@@ -119,7 +119,7 @@ const HealthMiniBar = ({
 				</span>
 			)}
 			{/* Last checked */}
-			{lastCheck && <span className="text-muted-foreground/50">{lastCheck}</span>}
+			{lastCheck && <span className="text-muted-foreground/65">{lastCheck}</span>}
 		</div>
 	);
 };
@@ -278,7 +278,7 @@ export const IndexerRow = ({
 
 					{/* Priority badge — only when non-default */}
 					{typeof indexer.priority === "number" && indexer.priority > 0 && (
-						<span className="text-[10px] font-mono text-muted-foreground/50 shrink-0">
+						<span className="text-[10px] font-mono text-muted-foreground/65 shrink-0">
 							P{indexer.priority}
 						</span>
 					)}
@@ -313,7 +313,7 @@ export const IndexerRow = ({
 
 					{/* Expand chevron */}
 					<ChevronRight
-						className={`h-4 w-4 text-muted-foreground/40 transition-transform duration-200 ${
+						className={`h-4 w-4 text-muted-foreground/55 transition-transform duration-200 ${
 							expanded ? "rotate-90" : "group-hover:text-muted-foreground"
 						}`}
 					/>

--- a/apps/web/src/features/indexers/components/indexers-client.tsx
+++ b/apps/web/src/features/indexers/components/indexers-client.tsx
@@ -523,7 +523,7 @@ export const IndexersClient = () => {
 						<div className="flex flex-col gap-3 sm:flex-row sm:items-center">
 							{/* Search */}
 							<div className="relative flex-1">
-								<Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/40" />
+								<Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/55" />
 								<Input
 									placeholder="Search indexers..."
 									value={searchTerm}
@@ -557,7 +557,7 @@ export const IndexersClient = () => {
 											{activeFilterCount}
 										</span>
 									)}
-									<kbd className="hidden sm:inline-flex h-4 items-center rounded border border-border/30 bg-muted/20 px-1 text-[9px] font-mono text-muted-foreground/40">
+									<kbd className="hidden sm:inline-flex h-4 items-center rounded border border-border/30 bg-muted/20 px-1 text-[9px] font-mono text-muted-foreground/55">
 										F
 									</kbd>
 								</button>
@@ -686,7 +686,7 @@ export const IndexersClient = () => {
 						</div>
 					) : (
 						<div className="text-center py-16">
-							<Search className="h-6 w-6 mx-auto mb-2 text-muted-foreground/30" />
+							<Search className="h-6 w-6 mx-auto mb-2 text-muted-foreground/45" />
 							<p className="text-xs text-muted-foreground/50">No indexers match your filters</p>
 						</div>
 					)}


### PR DESCRIPTION
## Summary
- Fixed hardcoded text-white in pagination component → theme-aware text-foreground/text-muted-foreground
- Bumped card backgrounds from bg-card/15-20 to bg-card/30 with backdrop-blur-sm
- Bumped secondary label opacity from text-muted-foreground/25-50 to /40-65

## Why
On the default (light) theme, --card = pure white and --muted-foreground = medium gray. Card backgrounds at 15-20% opacity were invisible, and text at 25-30% opacity was illegible. The pagination bar used hardcoded white text, also invisible on white backgrounds.

## Files
- apps/web/src/components/ui/pagination.tsx — 6 lines (text-white → theme-aware)
- apps/web/src/features/indexers/components/indexer-configuration-fields.tsx — 8 lines (text opacity + bg)
- apps/web/src/features/indexers/components/indexer-details-info.tsx — 12 lines (text opacity + bg)
- apps/web/src/features/indexers/components/indexer-details-panel.tsx — 1 line (text opacity)
- apps/web/src/features/indexers/components/indexer-instance-card.tsx — 2 lines (bg + text opacity)
- apps/web/src/features/indexers/components/indexer-row.tsx — 2 lines (text opacity)
- apps/web/src/features/indexers/components/indexers-client.tsx — 2 lines (text opacity)

## Validation
- TypeScript strict mode: passes (both @arr/web and @arr/api)
- Tests: 426 web + 1,542 API, all pass
- Lint: clean

Closes #428