### PR TITLE
fix(notifications): resolve relative URLs to absolute for all notification channels (closes #430)

### DIFF
--- a/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
@@ -70,6 +70,7 @@ describe("NotificationService", () => {
 			mockLogger,
 			mockDedupGate as any,
 			mockRetryHandler as any,
+			"http://localhost:3000",
 		);
 	});
 

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -43,6 +43,7 @@ export class NotificationService {
 	private retryHandler: RetryHandler;
 	private ruleEngine: RuleEngine | null;
 	private aggregationBuffer: AggregationBuffer | null;
+	private baseUrl: string;
 	private deferredQueue: Array<{ payload: NotificationPayload; deliverAt: number }> = [];
 	private deferFlushTimer: ReturnType<typeof setInterval> | null = null;
 	private static readonly MAX_DEFERRED_QUEUE_SIZE = 200;
@@ -54,6 +55,7 @@ export class NotificationService {
 		logger: NotificationLogger,
 		dedupGate: DedupGate,
 		retryHandler: RetryHandler,
+		baseUrl: string,
 		ruleEngine?: RuleEngine,
 		aggregationBuffer?: AggregationBuffer,
 	) {
@@ -63,6 +65,7 @@ export class NotificationService {
 		this.logger = logger;
 		this.dedupGate = dedupGate;
 		this.retryHandler = retryHandler;
+		this.baseUrl = baseUrl.replace(/\/$/, "");
 		this.ruleEngine = ruleEngine ?? null;
 		this.aggregationBuffer = aggregationBuffer ?? null;
 
@@ -79,7 +82,11 @@ export class NotificationService {
 	}
 
 	/** Queue a notification for delivery after quiet hours end. */
-	private deferNotification(payload: NotificationPayload, deferUntil: string, ruleId: string): void {
+	private deferNotification(
+		payload: NotificationPayload,
+		deferUntil: string,
+		ruleId: string,
+	): void {
 		// Cap queue to prevent unbounded growth
 		if (this.deferredQueue.length >= NotificationService.MAX_DEFERRED_QUEUE_SIZE) {
 			this.logger.warn(
@@ -204,6 +211,12 @@ export class NotificationService {
 				this.logger.debug({ eventType: payload.eventType }, "Notification queued for aggregation");
 				return;
 			}
+		}
+
+		// Resolve relative URLs to absolute so external notification clients
+		// (Telegram, Discord, Pushover, etc.) can generate clickable links
+		if (payload.url) {
+			payload = { ...payload, url: resolveUrl(payload.url, this.baseUrl) };
 		}
 
 		this.logger.info(
@@ -506,4 +519,14 @@ export class NotificationService {
 			}),
 		]);
 	}
+}
+
+/**
+ * Resolve a potentially relative URL against a base URL.
+ * Returns absolute URLs unchanged; resolves relative paths against baseUrl.
+ */
+function resolveUrl(url: string, baseUrl: string): string {
+	if (/^https?:\/\//i.test(url)) return url;
+	if (url.startsWith("/")) return `${baseUrl}${url}`;
+	return `${baseUrl}/${url}`;
 }

--- a/apps/api/src/plugins/notification-service.ts
+++ b/apps/api/src/plugins/notification-service.ts
@@ -55,6 +55,12 @@ const notificationServicePlugin = fastifyPlugin(
 			await service.notify(digest);
 		});
 
+		// Resolve the public-facing base URL for notification links.
+		// Prefer admin-configured externalUrl so links resolve behind reverse proxies;
+		// fall back to APP_URL env var (defaults to http://localhost:3000).
+		const settings = await app.prisma.systemSettings.findUnique({ where: { id: 1 } });
+		const baseUrl = settings?.externalUrl?.replace(/\/$/, "") ?? app.config.APP_URL;
+
 		service = new NotificationService(
 			app.prisma,
 			app.encryptor,
@@ -62,6 +68,7 @@ const notificationServicePlugin = fastifyPlugin(
 			app.log,
 			dedupGate,
 			retryHandler,
+			baseUrl,
 			ruleEngine,
 			aggregationBuffer,
 		);


### PR DESCRIPTION
## Summary

- Notification payloads pass relative URLs (e.g. `/statistics`) to external notification clients, but external clients have no implicit origin to resolve against — making "View Details" links dead in **all** channels (Telegram, Discord, Pushover, Gotify, Email, etc.)
- Added a `resolveUrl()` helper in `NotificationService` that prepends the application's base URL before dispatching to any channel
- Base URL resolution prefers `SystemSettings.externalUrl` (admin-configured canonical URL for reverse proxies) and falls back to `APP_URL` env var

## Changes

- `notification-service.ts` — added `baseUrl` constructor param + `resolveUrl()` called in `notify()` before dispatch
- `notification-service.ts` plugin — resolves base URL from `SystemSettings.externalUrl` or `APP_URL`
- `notification-service.test.ts` — updated constructor call

## Verification

- TypeScript strict mode: clean
- Biome lint: clean
- All 1504 tests pass (0 failures)