### PR TITLE
chore: v2.18.3 release — notification links, indexer readability, sync memory fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.3] - 2026-05-05
+
+### Fixed
+
+- **Notification "View Details" links broken in all external channels.** Notification payloads sent to Telegram, Discord, Pushover, Gotify, Email, etc. contained relative URLs (`/statistics`, `/library`) that external clients could not resolve. URLs are now resolved to absolute form (preferring `SystemSettings.externalUrl`, falling back to `APP_URL`) before dispatch (#430).
+- **Indexer page text hard to read.** Card backgrounds on the indexer page used very low opacity (`bg-card/15-20`) rendering text near-invisible on the light theme. Raised background opacity and fixed hardcoded `text-white` in the pagination component to use theme-aware semantic classes (#428).
+- **Excessive memory usage during Readarr/Lidarr library sync.** Sync was loading the full normalized item array into memory for Readarr/Lidarr services that don't need tag-delta diffing. Now skips the `data` column in cache reads and processes items in batches, reducing peak heap usage. JSON blobs are still written on create/update so `/library` responses stay complete (#427).
+
 ## [2.18.2] - 2026-05-03
 
 **Auto-Tagger — one-click Connect webhook auto-install (issue #422).** A follow-up to the real-time webhook plumbing that shipped in 2.18.0: instead of hand-pasting the URL and `Authorization: Bearer …` header into every Sonarr/Radarr's Connect settings, you can now select your enabled instances inside the Auto-Tagger settings panel and push the canonical webhook to all of them in a single click.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.18.2 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.18.3 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.2** — Auto-Tagger follow-up to 2.18.1: one-click Connect webhook auto-install. The Auto-Tagger settings now discover your enabled Sonarr/Radarr instances and push the `arr-dashboard auto-tagger` Connect notification (URL + Bearer secret + event flags) to each one in a single click — no more hand-pasting into every *arr's Connect settings. Idempotent re-runs update the existing webhook by name match; per-instance failures surface individually without blocking the rest.
+> **Version 2.18.3** — Three user-facing fixes: notification "View Details" links now resolve to absolute URLs for all external channels (#430), indexer page text readability restored on the light theme (#428), and Readarr/Lidarr library sync memory footprint reduced (#427).
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -94,6 +94,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.2** — Auto-Tagger follow-up to 2.18.1: one-click Connect webhook auto-install. The Auto-Tagger settings now discover your enabled Sonarr/Radarr instances and push the `arr-dashboard auto-tagger` Connect notification (URL + Bearer secret + event flags) to each one in a single click — no more hand-pasting into every *arr's Connect settings. Idempotent re-runs update the existing webhook by name match; per-instance failures surface individually without blocking the rest.
+> **Version 2.18.3** — Three user-facing fixes: notification "View Details" links now resolve to absolute URLs for all external channels (#430), indexer page text readability restored on the light theme (#428), and Readarr/Lidarr library sync memory footprint reduced (#427).
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -225,6 +225,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |
 | `2.18.0` | Auto-Tagger: criteria-based Sonarr/Radarr tagging with composite (AND/OR) rules, Connect webhooks, and TMDb/Trakt list-membership; library deep-link fix; TRaSH cache empty-result fix; Plex log-leak hardening |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.18.2",
+	"version": "2.18.3",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
Patch release bundling three user-facing bug fixes from main:
- Notification View Details links now resolve to absolute URLs (#430)
- Indexer page text readability restored on light theme (#428)
- Readarr/Lidarr library sync memory footprint reduced (#427)

Files: package.json, CHANGELOG.md, README.md, DOCKERHUB.md, CLAUDE.md

Wiki updated in separate commit.