### PR TITLE
feat(seerr): admin quality-profile override on request approval (closes #434)

### DIFF
--- a/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { FastifyBaseLogger } from "fastify";
-import { SeerrClient } from "../seerr-client.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ArrClientFactory, ClientInstanceData } from "../../arr/client-factory.js";
 import { SeerrApiError } from "../../errors.js";
 import { GENRE_TTL_MS, type SeerrCache } from "../seerr-cache.js";
 import type { SeerrCircuitBreaker } from "../seerr-circuit-breaker.js";
-import type { ArrClientFactory, ClientInstanceData } from "../../arr/client-factory.js";
+import { SeerrClient } from "../seerr-client.js";
 
 // Mock retry to just call the function directly (no actual retry/delay)
 vi.mock("../seerr-retry.js", () => ({
@@ -180,7 +180,15 @@ describe("getRequests", () => {
 				media: { id: 1, tmdbId: 123, status: 1, createdAt: "x", updatedAt: "x" },
 				createdAt: "x",
 				updatedAt: "x",
-				requestedBy: { id: 1, displayName: "u", createdAt: "x", updatedAt: "x", permissions: 0, requestCount: 0, userType: 1 },
+				requestedBy: {
+					id: 1,
+					displayName: "u",
+					createdAt: "x",
+					updatedAt: "x",
+					permissions: 0,
+					requestCount: 0,
+					userType: 1,
+				},
 				seasons: [],
 			},
 		]);
@@ -250,9 +258,7 @@ describe("getRequest", () => {
 	});
 
 	it("propagates error when rawRequest returns non-ok response", async () => {
-		factory.rawRequest.mockResolvedValue(
-			mockResponse({ error: "Not Found" }, 404),
-		);
+		factory.rawRequest.mockResolvedValue(mockResponse({ error: "Not Found" }, 404));
 
 		await expect(client.getRequest(999)).rejects.toThrow(SeerrApiError);
 	});
@@ -280,6 +286,32 @@ describe("approveRequest", () => {
 		factory.rawRequest.mockResolvedValue(mockResponse({ error: "Forbidden" }, 403));
 
 		await expect(client.approveRequest(1)).rejects.toThrow(SeerrApiError);
+	});
+});
+
+// ===========================================================================
+// 4b. updateRequest (admin profile/folder override)
+// ===========================================================================
+
+describe("updateRequest", () => {
+	it("PUTs to /api/v1/request/:id with the override payload", async () => {
+		const req = makeRequest({ profileId: 7, rootFolder: "/trash" });
+		factory.rawRequest.mockResolvedValue(mockResponse(req));
+
+		const result = await client.updateRequest(1, {
+			mediaType: "movie",
+			profileId: 7,
+			rootFolder: "/trash",
+		});
+
+		expect(result.profileId).toBe(7);
+		expect(result.rootFolder).toBe("/trash");
+		const call = factory.rawRequest.mock.calls[1]!;
+		expect(call[1]).toBe("/api/v1/request/1");
+		expect(call[2]).toMatchObject({
+			method: "PUT",
+			body: { mediaType: "movie", profileId: 7, rootFolder: "/trash" },
+		});
 	});
 });
 
@@ -479,8 +511,14 @@ describe("enrichRequestsWithMedia", () => {
 	});
 
 	it("handles partial failures (one lookup fails, others succeed)", async () => {
-		const req1 = makeRequest({ id: 1, media: { id: 1, tmdbId: 100, status: 1, createdAt: "x", updatedAt: "x" } });
-		const req2 = makeRequest({ id: 2, media: { id: 2, tmdbId: 200, status: 1, createdAt: "x", updatedAt: "x" } });
+		const req1 = makeRequest({
+			id: 1,
+			media: { id: 1, tmdbId: 100, status: 1, createdAt: "x", updatedAt: "x" },
+		});
+		const req2 = makeRequest({
+			id: 2,
+			media: { id: 2, tmdbId: 200, status: 1, createdAt: "x", updatedAt: "x" },
+		});
 		const pageResult = makePageResult([req1, req2]);
 
 		// First lookup succeeds, second fails

--- a/apps/api/src/lib/seerr/seerr-client.ts
+++ b/apps/api/src/lib/seerr/seerr-client.ts
@@ -33,6 +33,7 @@ import {
 	type SeerrServiceServer,
 	type SeerrStatus,
 	type SeerrTvDetails,
+	type SeerrUpdateRequestPayload,
 	type SeerrUser,
 	type SeerrUserParams,
 	type SeerrUserUpdateData,
@@ -60,11 +61,11 @@ import { requireInstance } from "../arr/instance-helpers.js";
 import { AppValidationError, SeerrApiError } from "../errors.js";
 import { parseUpstreamOrThrow } from "../validation/parse-upstream.js";
 import {
-	type SeerrCache,
 	GENRE_TTL_MS,
-	ISSUE_COUNT_TTL_MS,
 	genreCacheKey,
+	ISSUE_COUNT_TTL_MS,
 	issueCountCacheKey,
+	type SeerrCache,
 } from "./seerr-cache.js";
 import type { SeerrCircuitBreaker } from "./seerr-circuit-breaker.js";
 import { withSeerrRetry } from "./seerr-retry.js";
@@ -359,11 +360,7 @@ export class SeerrClient {
 			return result;
 		} catch (error) {
 			// On 403 for mutating requests, try refreshing the CSRF token once
-			if (
-				isMutating &&
-				error instanceof SeerrApiError &&
-				error.seerrStatus === 403
-			) {
+			if (isMutating && error instanceof SeerrApiError && error.seerrStatus === 403) {
 				this.log.debug("Got 403 on mutating request, refreshing CSRF token and retrying");
 				this.csrfData = null;
 				await this.ensureCsrfData();
@@ -441,6 +438,22 @@ export class SeerrClient {
 	async approveRequest(requestId: number): Promise<SeerrRequest> {
 		const raw = await this.post(`/api/v1/request/${requestId}/approve`, undefined, TIMEOUT_ACTION);
 		return this.parseAndRecord(raw, seerrRequestSchema, "approveRequest");
+	}
+
+	/**
+	 * Update an existing request's quality profile, root folder, server, tags, etc.
+	 * Used by admins to override request settings before approving — e.g. to send
+	 * a request to a "trash" profile instead of the server's default.
+	 *
+	 * Maps to Jellyseerr/Overseerr `PUT /api/v1/request/:id`, which requires `mediaType`
+	 * so the server knows which *arr backend to validate the override against.
+	 */
+	async updateRequest(
+		requestId: number,
+		payload: SeerrUpdateRequestPayload,
+	): Promise<SeerrRequest> {
+		const raw = await this.put(`/api/v1/request/${requestId}`, payload, TIMEOUT_ACTION);
+		return this.parseAndRecord(raw, seerrRequestSchema, "updateRequest");
 	}
 
 	async declineRequest(requestId: number): Promise<SeerrRequest> {

--- a/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
+++ b/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
@@ -349,15 +349,22 @@ describe("POST /:instanceId/:requestId/approve", () => {
 		expect(mockClient.approveRequest).not.toHaveBeenCalled();
 	});
 
-	it("rejects serverId of 0 (Jellyseerr server IDs are positive)", async () => {
+	it("accepts serverId of 0 (Jellyseerr uses 0-based server ids)", async () => {
+		mockClient.getRequest.mockResolvedValueOnce({ id: 1, type: "movie" });
+		mockClient.updateRequest.mockResolvedValueOnce({ id: 1 });
+		mockClient.approveRequest.mockResolvedValueOnce({ id: 1, status: 2 });
+
 		const res = await app.inject({
 			method: "POST",
 			url: "/api/seerr/requests/inst-1/1/approve",
 			payload: { serverId: 0 },
 		});
 
-		expect(res.statusCode).toBe(400);
-		expect(mockClient.approveRequest).not.toHaveBeenCalled();
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.updateRequest).toHaveBeenCalledWith(1, {
+			mediaType: "movie",
+			serverId: 0,
+		});
 	});
 
 	it("treats empty body object as no overrides", async () => {
@@ -373,6 +380,50 @@ describe("POST /:instanceId/:requestId/approve", () => {
 		expect(mockClient.updateRequest).not.toHaveBeenCalled();
 		expect(mockClient.getRequest).not.toHaveBeenCalled();
 		expect(mockClient.approveRequest).toHaveBeenCalledWith(1);
+	});
+
+	it("includes seasons in updateRequest payload when overriding a TV request (Jellyseerr requires it)", async () => {
+		mockClient.getRequest.mockResolvedValueOnce({
+			id: 1,
+			type: "tv",
+			seasons: [
+				{ id: 100, seasonNumber: 1, status: 1 },
+				{ id: 101, seasonNumber: 2, status: 1 },
+			],
+		});
+		mockClient.updateRequest.mockResolvedValueOnce({ id: 1 });
+		mockClient.approveRequest.mockResolvedValueOnce({ id: 1, status: 2 });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: 15 },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.updateRequest).toHaveBeenCalledWith(1, {
+			mediaType: "tv",
+			profileId: 15,
+			seasons: [1, 2],
+		});
+	});
+
+	it("does not include seasons in updateRequest payload for movie requests", async () => {
+		mockClient.getRequest.mockResolvedValueOnce({ id: 1, type: "movie", seasons: [] });
+		mockClient.updateRequest.mockResolvedValueOnce({ id: 1 });
+		mockClient.approveRequest.mockResolvedValueOnce({ id: 1, status: 2 });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: 9 },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.updateRequest).toHaveBeenCalledWith(1, {
+			mediaType: "movie",
+			profileId: 9,
+		});
 	});
 
 	it("aborts approval and logs failure when getRequest fails before override PUT", async () => {

--- a/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
+++ b/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks — vi.hoisted ensures these exist before vi.mock factories
@@ -10,6 +10,7 @@ const { mockClient } = vi.hoisted(() => ({
 		getRequestCount: vi.fn(),
 		getRequest: vi.fn(),
 		approveRequest: vi.fn(),
+		updateRequest: vi.fn(),
 		declineRequest: vi.fn(),
 		deleteRequest: vi.fn(),
 		retryRequest: vi.fn(),
@@ -30,9 +31,9 @@ vi.mock("../../../lib/seerr/seerr-action-logger.js", () => ({
 // ---------------------------------------------------------------------------
 
 import Fastify from "fastify";
-import { registerRequestRoutes } from "../request-routes.js";
-import { requireSeerrClient } from "../../../lib/seerr/seerr-client.js";
 import { logSeerrAction } from "../../../lib/seerr/seerr-action-logger.js";
+import { requireSeerrClient } from "../../../lib/seerr/seerr-client.js";
+import { registerRequestRoutes } from "../request-routes.js";
 
 // ---------------------------------------------------------------------------
 // Shared test data
@@ -189,7 +190,10 @@ describe("GET /:instanceId/count", () => {
 
 describe("GET /:instanceId/:requestId", () => {
 	it("returns enriched single request", async () => {
-		const enrichedRequest = { ...sampleRequest, media: { ...sampleRequest.media, title: "Test Movie" } };
+		const enrichedRequest = {
+			...sampleRequest,
+			media: { ...sampleRequest.media, title: "Test Movie" },
+		};
 		mockClient.getRequest.mockResolvedValueOnce(sampleRequest);
 		mockClient.enrichRequestsWithMedia.mockResolvedValueOnce({
 			pageInfo: { pages: 1, pageSize: 1, results: 1, page: 1 },
@@ -291,6 +295,54 @@ describe("POST /:instanceId/:requestId/approve", () => {
 		const res = await app.inject({
 			method: "POST",
 			url: "/api/seerr/requests/inst-1/abc/approve",
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(mockClient.approveRequest).not.toHaveBeenCalled();
+	});
+
+	it("calls updateRequest with mediaType from existing request before approving when overrides are provided", async () => {
+		const approveResult = { id: 1, status: 2 };
+		mockClient.getRequest.mockResolvedValueOnce({ id: 1, type: "movie" });
+		mockClient.updateRequest.mockResolvedValueOnce({ id: 1, profileId: 9 });
+		mockClient.approveRequest.mockResolvedValueOnce(approveResult);
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: 9, rootFolder: "/trash" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload)).toEqual(approveResult);
+		expect(mockClient.getRequest).toHaveBeenCalledWith(1);
+		expect(mockClient.updateRequest).toHaveBeenCalledWith(1, {
+			mediaType: "movie",
+			profileId: 9,
+			rootFolder: "/trash",
+		});
+		expect(mockClient.approveRequest).toHaveBeenCalledWith(1);
+	});
+
+	it("skips updateRequest when no overrides are provided", async () => {
+		mockClient.approveRequest.mockResolvedValueOnce({ id: 1, status: 2 });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.updateRequest).not.toHaveBeenCalled();
+		expect(mockClient.getRequest).not.toHaveBeenCalled();
+		expect(mockClient.approveRequest).toHaveBeenCalledWith(1);
+	});
+
+	it("rejects negative profileId", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: -1 },
 		});
 
 		expect(res.statusCode).toBe(400);

--- a/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
+++ b/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
@@ -348,6 +348,80 @@ describe("POST /:instanceId/:requestId/approve", () => {
 		expect(res.statusCode).toBe(400);
 		expect(mockClient.approveRequest).not.toHaveBeenCalled();
 	});
+
+	it("rejects serverId of 0 (Jellyseerr server IDs are positive)", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { serverId: 0 },
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(mockClient.approveRequest).not.toHaveBeenCalled();
+	});
+
+	it("treats empty body object as no overrides", async () => {
+		mockClient.approveRequest.mockResolvedValueOnce({ id: 1, status: 2 });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: {},
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.updateRequest).not.toHaveBeenCalled();
+		expect(mockClient.getRequest).not.toHaveBeenCalled();
+		expect(mockClient.approveRequest).toHaveBeenCalledWith(1);
+	});
+
+	it("aborts approval and logs failure when getRequest fails before override PUT", async () => {
+		const error = Object.assign(new Error("Not found"), { statusCode: 404 });
+		mockClient.getRequest.mockRejectedValueOnce(error);
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: 9 },
+		});
+
+		expect(res.statusCode).toBe(404);
+		expect(mockClient.updateRequest).not.toHaveBeenCalled();
+		expect(mockClient.approveRequest).not.toHaveBeenCalled();
+		expect(logSeerrAction).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({
+				action: "approve_request",
+				targetId: "1",
+				success: false,
+			}),
+		);
+	});
+
+	it("aborts approval and logs failure when updateRequest fails", async () => {
+		mockClient.getRequest.mockResolvedValueOnce({ id: 1, type: "movie" });
+		const error = Object.assign(new Error("Bad profile"), { statusCode: 400 });
+		mockClient.updateRequest.mockRejectedValueOnce(error);
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/api/seerr/requests/inst-1/1/approve",
+			payload: { profileId: 9 },
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(mockClient.approveRequest).not.toHaveBeenCalled();
+		expect(logSeerrAction).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.anything(),
+			expect.objectContaining({
+				action: "approve_request",
+				targetId: "1",
+				success: false,
+			}),
+		);
+	});
 });
 
 // ===========================================================================

--- a/apps/api/src/routes/seerr/request-routes.ts
+++ b/apps/api/src/routes/seerr/request-routes.ts
@@ -4,7 +4,7 @@
  * Endpoints for managing media requests: list, approve, decline, delete, retry.
  */
 
-import type { SeerrAttentionItem } from "@arr/shared";
+import type { SeerrAttentionItem, SeerrUpdateRequestPayload } from "@arr/shared";
 import { SEERR_MEDIA_STATUS, SEERR_REQUEST_STATUS } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
@@ -41,7 +41,8 @@ const requestIdParams = z.object({
  */
 const approveBody = z
 	.object({
-		serverId: z.number().int().positive().optional(),
+		// serverId can be 0 — Jellyseerr/Overseerr use 0-based ids for the first registered server
+		serverId: z.number().int().nonnegative().optional(),
 		profileId: z.number().int().positive().optional(),
 		rootFolder: z.string().min(1).optional(),
 		languageProfileId: z.number().int().positive().optional(),
@@ -166,11 +167,18 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 		try {
 			if (hasOverrides) {
 				// Jellyseerr PUT requires mediaType — fetch the request to learn it.
+				// For TV it also requires `seasons` (array of season numbers) — without it
+				// Jellyseerr returns 500 "Missing seasons". We pass through the existing
+				// request's seasons so overrides don't accidentally narrow what was requested.
 				const existing = await client.getRequest(requestId);
-				await client.updateRequest(requestId, {
+				const updatePayload: SeerrUpdateRequestPayload = {
 					mediaType: existing.type,
 					...overrides,
-				});
+				};
+				if (existing.type === "tv" && existing.seasons && existing.seasons.length > 0) {
+					updatePayload.seasons = existing.seasons.map((s) => s.seasonNumber);
+				}
+				await client.updateRequest(requestId, updatePayload);
 			}
 			const result = await client.approveRequest(requestId);
 			logSeerrAction(app, request.log, {

--- a/apps/api/src/routes/seerr/request-routes.ts
+++ b/apps/api/src/routes/seerr/request-routes.ts
@@ -28,6 +28,25 @@ const requestIdParams = z.object({
 	requestId: z.coerce.number().int().positive(),
 });
 
+/**
+ * Optional admin overrides applied via PUT before approval.
+ * Empty/undefined = approve without modifying the request.
+ *
+ * `mediaType` is required by Jellyseerr's PUT endpoint, but we accept it as
+ * optional here and re-fetch the request when needed so the client doesn't
+ * have to send it for a plain approve.
+ */
+const approveBody = z
+	.object({
+		serverId: z.number().int().nonnegative().optional(),
+		profileId: z.number().int().positive().optional(),
+		rootFolder: z.string().min(1).optional(),
+		languageProfileId: z.number().int().positive().optional(),
+		tags: z.array(z.number().int().nonnegative()).optional(),
+		userId: z.number().int().positive().optional(),
+	})
+	.optional();
+
 const listRequestsQuery = z.object({
 	take: z.coerce.number().int().min(1).max(100).default(20),
 	skip: z.coerce.number().int().min(0).default(0),
@@ -125,11 +144,33 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 	});
 
 	// POST /api/seerr/requests/:instanceId/:requestId/approve
+	// Optional body: { serverId?, profileId?, rootFolder?, languageProfileId?, tags?, userId? }
+	// When any override field is present, the request is updated (PUT) before approval —
+	// useful for admins who want to send a request to a non-default quality profile.
 	app.post("/:instanceId/:requestId/approve", async (request) => {
 		const { instanceId, requestId } = validateRequest(requestIdParams, request.params);
+		const overrides = validateRequest(approveBody, request.body ?? undefined);
 		const userId = request.currentUser!.id;
 		const client = await requireSeerrClient(app, userId, instanceId);
+
+		const hasOverrides =
+			!!overrides &&
+			(overrides.serverId !== undefined ||
+				overrides.profileId !== undefined ||
+				overrides.rootFolder !== undefined ||
+				overrides.languageProfileId !== undefined ||
+				overrides.tags !== undefined ||
+				overrides.userId !== undefined);
+
 		try {
+			if (hasOverrides) {
+				// Jellyseerr PUT requires mediaType — fetch the request to learn it.
+				const existing = await client.getRequest(requestId);
+				await client.updateRequest(requestId, {
+					mediaType: existing.type,
+					...overrides,
+				});
+			}
 			const result = await client.approveRequest(requestId);
 			logSeerrAction(app, request.log, {
 				instanceId,
@@ -137,6 +178,7 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 				action: "approve_request",
 				targetType: "request",
 				targetId: String(requestId),
+				detail: hasOverrides ? { overridden: true, ...overrides } : undefined,
 			});
 			return result;
 		} catch (err) {

--- a/apps/api/src/routes/seerr/request-routes.ts
+++ b/apps/api/src/routes/seerr/request-routes.ts
@@ -32,18 +32,20 @@ const requestIdParams = z.object({
  * Optional admin overrides applied via PUT before approval.
  * Empty/undefined = approve without modifying the request.
  *
- * `mediaType` is required by Jellyseerr's PUT endpoint, but we accept it as
- * optional here and re-fetch the request when needed so the client doesn't
- * have to send it for a plain approve.
+ * `mediaType` is required by Jellyseerr's PUT endpoint, but we re-fetch the
+ * request to learn it instead of trusting the client.
+ *
+ * Jellyseerr's PUT also accepts a `userId` (request reassignment) — intentionally
+ * omitted here: the dashboard UI doesn't surface it, and approval-time
+ * reassignment is an edge case we'd rather force through Jellyseerr's own UI.
  */
 const approveBody = z
 	.object({
-		serverId: z.number().int().nonnegative().optional(),
+		serverId: z.number().int().positive().optional(),
 		profileId: z.number().int().positive().optional(),
 		rootFolder: z.string().min(1).optional(),
 		languageProfileId: z.number().int().positive().optional(),
 		tags: z.array(z.number().int().nonnegative()).optional(),
-		userId: z.number().int().positive().optional(),
 	})
 	.optional();
 
@@ -159,8 +161,7 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 				overrides.profileId !== undefined ||
 				overrides.rootFolder !== undefined ||
 				overrides.languageProfileId !== undefined ||
-				overrides.tags !== undefined ||
-				overrides.userId !== undefined);
+				overrides.tags !== undefined);
 
 		try {
 			if (hasOverrides) {

--- a/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
@@ -21,6 +21,11 @@ vi.mock("../../../../hooks/api/useSeerr", () => ({
 	useDeleteSeerrRequest: () => mockUseDeleteSeerrRequest(),
 	useBulkSeerrRequestAction: () => mockUseBulkSeerrRequestAction(),
 	useSeerrUserQuota: () => ({ data: undefined, isLoading: false, isError: false }),
+	useSeerrRequestOptions: () => ({
+		data: { servers: [] },
+		isLoading: false,
+		isError: false,
+	}),
 }));
 
 vi.mock("../../../../hooks/useThemeGradient", () => ({

--- a/apps/web/src/features/seerr/components/approval-queue-tab.tsx
+++ b/apps/web/src/features/seerr/components/approval-queue-tab.tsx
@@ -2,7 +2,17 @@
 
 import type { SeerrMediaStatus, SeerrRequest, SeerrSeason } from "@arr/shared";
 import { SEERR_MEDIA_STATUS, SEERR_MEDIA_STATUS_LABEL } from "@arr/shared";
-import { AlertCircle, Check, Eye, EyeOff, ExternalLink, Loader2, Trash2, X } from "lucide-react";
+import {
+	AlertCircle,
+	Check,
+	ExternalLink,
+	Eye,
+	EyeOff,
+	Loader2,
+	SlidersHorizontal,
+	Trash2,
+	X,
+} from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -21,6 +31,7 @@ import {
 } from "../../../hooks/api/useSeerr";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
+import { ApproveWithOptionsDialog } from "./approve-with-options-dialog";
 import { RequestCard } from "./request-card";
 import { RequestStatusTimeline } from "./request-status-timeline";
 
@@ -60,6 +71,7 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 	const bulkMutation = useBulkSeerrRequestAction();
 	const [confirmingDeclineId, setConfirmingDeclineId] = useState<number | null>(null);
 	const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(null);
+	const [approveOptionsRequest, setApproveOptionsRequest] = useState<SeerrRequest | null>(null);
 
 	const requests = useMemo(() => data?.results ?? [], [data?.results]);
 	const allSelected = requests.length > 0 && requests.every((r) => selectedIds.has(r.id));
@@ -237,6 +249,17 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 										>
 											Approve
 										</GradientButton>
+										<Button
+											variant="secondary"
+											size="sm"
+											disabled={approveMutation.isPending}
+											onClick={() => setApproveOptionsRequest(request)}
+											title="Approve with quality profile options"
+											className="gap-1.5 border-border/50 bg-card/50 text-xs"
+										>
+											<SlidersHorizontal className="h-3 w-3" />
+											<span className="hidden sm:inline">Options</span>
+										</Button>
 										{confirmingDeclineId === request.id ? (
 											<>
 												<Button
@@ -403,6 +426,17 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 						</Button>
 					</div>
 				</div>
+			)}
+
+			{approveOptionsRequest && (
+				<ApproveWithOptionsDialog
+					request={approveOptionsRequest}
+					instanceId={instanceId}
+					open={!!approveOptionsRequest}
+					onOpenChange={(open) => {
+						if (!open) setApproveOptionsRequest(null);
+					}}
+				/>
 			)}
 		</div>
 	);

--- a/apps/web/src/features/seerr/components/approval-queue-tab.tsx
+++ b/apps/web/src/features/seerr/components/approval-queue-tab.tsx
@@ -31,7 +31,6 @@ import {
 } from "../../../hooks/api/useSeerr";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
-import { ApproveWithOptionsDialog } from "./approve-with-options-dialog";
 import { RequestCard } from "./request-card";
 import { RequestStatusTimeline } from "./request-status-timeline";
 
@@ -45,11 +44,17 @@ const SORT_OPTIONS: { value: RequestSort; label: string }[] = [
 interface ApprovalQueueTabProps {
 	instanceId: string;
 	onSelectRequest?: (request: SeerrRequest) => void;
+	/** Open the profile-override dialog for the given request (state owned by parent). */
+	onOpenApproveOptions?: (request: SeerrRequest) => void;
 }
 
 const PAGE_SIZE = 50;
 
-export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueTabProps) => {
+export const ApprovalQueueTab = ({
+	instanceId,
+	onSelectRequest,
+	onOpenApproveOptions,
+}: ApprovalQueueTabProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
 	const [sort, setSort] = useState<RequestSort>("added");
@@ -71,7 +76,6 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 	const bulkMutation = useBulkSeerrRequestAction();
 	const [confirmingDeclineId, setConfirmingDeclineId] = useState<number | null>(null);
 	const [confirmingDeleteId, setConfirmingDeleteId] = useState<number | null>(null);
-	const [approveOptionsRequest, setApproveOptionsRequest] = useState<SeerrRequest | null>(null);
 
 	const requests = useMemo(() => data?.results ?? [], [data?.results]);
 	const allSelected = requests.length > 0 && requests.every((r) => selectedIds.has(r.id));
@@ -249,17 +253,19 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 										>
 											Approve
 										</GradientButton>
-										<Button
-											variant="secondary"
-											size="sm"
-											disabled={approveMutation.isPending}
-											onClick={() => setApproveOptionsRequest(request)}
-											title="Approve with quality profile options"
-											className="gap-1.5 border-border/50 bg-card/50 text-xs"
-										>
-											<SlidersHorizontal className="h-3 w-3" />
-											<span className="hidden sm:inline">Options</span>
-										</Button>
+										{onOpenApproveOptions && (
+											<Button
+												variant="secondary"
+												size="sm"
+												disabled={approveMutation.isPending}
+												onClick={() => onOpenApproveOptions(request)}
+												title="Approve with quality profile options"
+												className="gap-1.5 border-border/50 bg-card/50 text-xs"
+											>
+												<SlidersHorizontal className="h-3 w-3" />
+												<span className="hidden sm:inline">Options</span>
+											</Button>
+										)}
 										{confirmingDeclineId === request.id ? (
 											<>
 												<Button
@@ -426,17 +432,6 @@ export const ApprovalQueueTab = ({ instanceId, onSelectRequest }: ApprovalQueueT
 						</Button>
 					</div>
 				</div>
-			)}
-
-			{approveOptionsRequest && (
-				<ApproveWithOptionsDialog
-					request={approveOptionsRequest}
-					instanceId={instanceId}
-					open={!!approveOptionsRequest}
-					onOpenChange={(open) => {
-						if (!open) setApproveOptionsRequest(null);
-					}}
-				/>
 			)}
 		</div>
 	);

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+/**
+ * Approval dialog that lets an admin pick a quality profile, root folder, and
+ * (optionally) tags + server before approving a Seerr request.
+ *
+ * Reuses the same `request-options` endpoint that the request-creation form uses,
+ * so all configured Radarr/Sonarr servers + their profiles are already cached when
+ * this dialog opens.
+ */
+
+import type { SeerrRequest, SeerrServerWithDetails } from "@arr/shared";
+import { Loader2 } from "lucide-react";
+import { useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+import { GradientButton } from "../../../components/layout/premium-components";
+import {
+	Button,
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	NativeSelect,
+	SelectOption,
+} from "../../../components/ui";
+import { useApproveSeerrRequest, useSeerrRequestOptions } from "../../../hooks/api/useSeerr";
+
+interface ApproveWithOptionsDialogProps {
+	request: SeerrRequest;
+	instanceId: string;
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+}
+
+/** Returns the server matching `serverId` or, if none match, the default/first server. */
+function resolveSelectedServer(
+	servers: SeerrServerWithDetails[],
+	serverId: number | undefined,
+): SeerrServerWithDetails | undefined {
+	if (servers.length === 0) return undefined;
+	if (serverId !== undefined) {
+		const match = servers.find((s) => s.server.id === serverId);
+		if (match) return match;
+	}
+	return servers.find((s) => s.server.isDefault) ?? servers[0];
+}
+
+export const ApproveWithOptionsDialog = ({
+	request,
+	instanceId,
+	open,
+	onOpenChange,
+}: ApproveWithOptionsDialogProps) => {
+	const profileFieldId = useId();
+	const folderFieldId = useId();
+	const serverFieldId = useId();
+
+	const mediaType = request.type;
+	const optionsQuery = useSeerrRequestOptions(instanceId, mediaType);
+	const approveMutation = useApproveSeerrRequest();
+
+	const servers = useMemo(() => optionsQuery.data?.servers ?? [], [optionsQuery.data?.servers]);
+
+	// Filter to non-4K servers when the request is non-4K (and vice-versa) so
+	// the admin can't pick a profile from an incompatible server.
+	const filteredServers = useMemo(
+		() => servers.filter((s) => s.server.is4k === request.is4k),
+		[servers, request.is4k],
+	);
+
+	const [serverId, setServerId] = useState<number | undefined>(request.serverId);
+	const [profileId, setProfileId] = useState<number | undefined>(request.profileId);
+	const [rootFolder, setRootFolder] = useState<string | undefined>(request.rootFolder);
+
+	const selectedServer = useMemo(
+		() => resolveSelectedServer(filteredServers, serverId),
+		[filteredServers, serverId],
+	);
+
+	// When the dialog opens or servers load, default selection to the request's
+	// current values (or the server defaults if the request has none yet).
+	useEffect(() => {
+		if (!open || filteredServers.length === 0) return;
+		const server = resolveSelectedServer(filteredServers, request.serverId);
+		if (!server) return;
+		setServerId(server.server.id);
+		setProfileId(request.profileId ?? server.server.activeProfileId);
+		setRootFolder(request.rootFolder ?? server.server.activeDirectory);
+	}, [open, filteredServers, request.serverId, request.profileId, request.rootFolder]);
+
+	// When the user changes server, reset profile + folder to that server's defaults.
+	const handleServerChange = (nextServerId: number) => {
+		const next = filteredServers.find((s) => s.server.id === nextServerId);
+		if (!next) return;
+		setServerId(next.server.id);
+		setProfileId(next.server.activeProfileId);
+		setRootFolder(next.server.activeDirectory);
+	};
+
+	const handleApprove = () => {
+		const overrides: {
+			serverId?: number;
+			profileId?: number;
+			rootFolder?: string;
+		} = {};
+		// Only send fields that differ from the request's current values — avoids
+		// pointless PUTs and keeps the audit log clean.
+		if (serverId !== undefined && serverId !== request.serverId) {
+			overrides.serverId = serverId;
+		}
+		if (profileId !== undefined && profileId !== request.profileId) {
+			overrides.profileId = profileId;
+		}
+		if (rootFolder && rootFolder !== request.rootFolder) {
+			overrides.rootFolder = rootFolder;
+		}
+
+		approveMutation.mutate(
+			{
+				instanceId,
+				requestId: request.id,
+				overrides: Object.keys(overrides).length > 0 ? overrides : undefined,
+			},
+			{
+				onSuccess: () => {
+					toast.success(
+						Object.keys(overrides).length > 0
+							? "Request approved with custom profile"
+							: "Request approved",
+					);
+					onOpenChange(false);
+				},
+				onError: () => toast.error("Failed to approve request"),
+			},
+		);
+	};
+
+	const isLoading = optionsQuery.isLoading;
+	const hasError = optionsQuery.isError;
+	const noServers = !isLoading && !hasError && filteredServers.length === 0;
+	const submitDisabled = approveMutation.isPending || isLoading || noServers;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-md">
+				<DialogHeader>
+					<DialogTitle>Approve with quality profile</DialogTitle>
+					<DialogDescription>
+						Pick the profile, root folder, and server for this request. Defaults to the current
+						selection.
+					</DialogDescription>
+				</DialogHeader>
+
+				{isLoading && (
+					<div className="flex items-center justify-center py-6 text-sm text-muted-foreground">
+						<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+						Loading options…
+					</div>
+				)}
+
+				{hasError && (
+					<div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+						Failed to load quality profiles from Seerr. Approving will fall back to the server
+						defaults.
+					</div>
+				)}
+
+				{noServers && (
+					<div className="rounded-lg border border-border/40 bg-card/40 p-3 text-sm text-muted-foreground">
+						No {request.is4k ? "4K " : ""}servers configured in Seerr for{" "}
+						{mediaType === "movie" ? "movies" : "TV"}. Add a server in Seerr settings to customize
+						approvals.
+					</div>
+				)}
+
+				{!isLoading && filteredServers.length > 0 && selectedServer && (
+					<div className="space-y-4">
+						{filteredServers.length > 1 && (
+							<div className="space-y-1.5">
+								<label
+									htmlFor={serverFieldId}
+									className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+								>
+									Server
+								</label>
+								<NativeSelect
+									id={serverFieldId}
+									value={serverId ?? ""}
+									onChange={(e) => handleServerChange(Number(e.target.value))}
+								>
+									{filteredServers.map((s) => (
+										<SelectOption key={s.server.id} value={s.server.id}>
+											{s.server.name}
+											{s.server.isDefault ? " (default)" : ""}
+										</SelectOption>
+									))}
+								</NativeSelect>
+							</div>
+						)}
+
+						<div className="space-y-1.5">
+							<label
+								htmlFor={profileFieldId}
+								className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+							>
+								Quality profile
+							</label>
+							<NativeSelect
+								id={profileFieldId}
+								value={profileId ?? ""}
+								onChange={(e) => setProfileId(Number(e.target.value))}
+							>
+								{selectedServer.profiles.map((p) => (
+									<SelectOption key={p.id} value={p.id}>
+										{p.name}
+										{p.id === selectedServer.server.activeProfileId ? " (server default)" : ""}
+									</SelectOption>
+								))}
+							</NativeSelect>
+						</div>
+
+						<div className="space-y-1.5">
+							<label
+								htmlFor={folderFieldId}
+								className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+							>
+								Root folder
+							</label>
+							<NativeSelect
+								id={folderFieldId}
+								value={rootFolder ?? ""}
+								onChange={(e) => setRootFolder(e.target.value)}
+							>
+								{selectedServer.rootFolders.map((f) => (
+									<SelectOption key={f.id} value={f.path}>
+										{f.path}
+										{f.path === selectedServer.server.activeDirectory ? " (server default)" : ""}
+									</SelectOption>
+								))}
+							</NativeSelect>
+						</div>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="secondary"
+						onClick={() => onOpenChange(false)}
+						disabled={approveMutation.isPending}
+					>
+						Cancel
+					</Button>
+					<GradientButton onClick={handleApprove} disabled={submitDisabled}>
+						{approveMutation.isPending ? (
+							<span className="flex items-center gap-2">
+								<Loader2 className="h-4 w-4 animate-spin" />
+								Approving…
+							</span>
+						) : (
+							"Approve"
+						)}
+					</GradientButton>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+};

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -105,15 +105,21 @@ export const ApproveWithOptionsDialog = ({
 			profileId?: number;
 			rootFolder?: string;
 		} = {};
-		// Only send fields that differ from the request's current values — avoids
-		// pointless PUTs and keeps the audit log clean.
-		if (serverId !== undefined && serverId !== request.serverId) {
+		// Compare against the *effective* current values — the request's own fields
+		// when set, otherwise the selected server's defaults. This way a confirm
+		// without changes doesn't fire a pointless PUT or write `overridden: true`
+		// to the audit log for first-time-routed requests.
+		const effectiveServerId = request.serverId ?? selectedServer?.server.id;
+		const effectiveProfileId = request.profileId ?? selectedServer?.server.activeProfileId;
+		const effectiveRootFolder = request.rootFolder ?? selectedServer?.server.activeDirectory;
+
+		if (serverId !== undefined && serverId !== effectiveServerId) {
 			overrides.serverId = serverId;
 		}
-		if (profileId !== undefined && profileId !== request.profileId) {
+		if (profileId !== undefined && profileId !== effectiveProfileId) {
 			overrides.profileId = profileId;
 		}
-		if (rootFolder && rootFolder !== request.rootFolder) {
+		if (rootFolder && rootFolder !== effectiveRootFolder) {
 			overrides.rootFolder = rootFolder;
 		}
 

--- a/apps/web/src/features/seerr/components/request-detail-modal.tsx
+++ b/apps/web/src/features/seerr/components/request-detail-modal.tsx
@@ -10,6 +10,7 @@ import {
 	Layers,
 	Loader2,
 	RotateCcw,
+	SlidersHorizontal,
 	Star,
 	Trash2,
 	Tv,
@@ -36,8 +37,8 @@ import {
 	getRequestStatusLabel,
 	getRequestStatusVariant,
 } from "../lib/seerr-utils";
-import { RequesterProfilePopover } from "./requester-profile-popover";
 import { RequestStatusTimeline } from "./request-status-timeline";
+import { RequesterProfilePopover } from "./requester-profile-popover";
 
 // ============================================================================
 // Types
@@ -48,6 +49,8 @@ interface RequestDetailModalProps {
 	instanceId: string;
 	onClose: () => void;
 	onApprove?: (requestId: number) => void;
+	/** Opens the profile-override dialog. Optional — when omitted the secondary button is hidden. */
+	onApproveWithOptions?: (request: SeerrRequest) => void;
 	onDecline?: (requestId: number) => void;
 	onRetry?: (requestId: number) => void;
 	onDelete?: (requestId: number) => void;
@@ -92,6 +95,7 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 	instanceId,
 	onClose,
 	onApprove,
+	onApproveWithOptions,
 	onDecline,
 	onRetry,
 	onDelete,
@@ -123,7 +127,9 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 	const year = releaseDate ? new Date(releaseDate).getFullYear() : null;
 
 	const backdropUrl = incognitoMode ? null : getSeerrImageUrl(details?.backdropPath, "w1280");
-	const posterUrl = incognitoMode ? null : getSeerrImageUrl(details?.posterPath ?? request.media.posterPath, "w342");
+	const posterUrl = incognitoMode
+		? null
+		: getSeerrImageUrl(details?.posterPath ?? request.media.posterPath, "w342");
 
 	const voteAverage = details
 		? (isMovie
@@ -297,7 +303,11 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 							<div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
 								<RequesterProfilePopover
 									seerrUser={request.requestedBy}
-									displayName={incognitoMode ? getLinuxUsername(request.requestedBy.displayName) : request.requestedBy.displayName}
+									displayName={
+										incognitoMode
+											? getLinuxUsername(request.requestedBy.displayName)
+											: request.requestedBy.displayName
+									}
 									instanceId={instanceId}
 									isIncognito={incognitoMode}
 								>
@@ -317,7 +327,9 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 											<User className="h-3.5 w-3.5" aria-hidden="true" />
 										)}
 										<span className="font-medium text-foreground/80">
-											{incognitoMode ? getLinuxUsername(request.requestedBy.displayName) : request.requestedBy.displayName}
+											{incognitoMode
+												? getLinuxUsername(request.requestedBy.displayName)
+												: request.requestedBy.displayName}
 										</span>
 									</button>
 								</RequesterProfilePopover>
@@ -330,7 +342,10 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 											: request.status === SEERR_REQUEST_STATUS.DECLINED
 												? "Declined"
 												: "Modified"}{" "}
-										by {incognitoMode ? getLinuxUsername(request.modifiedBy.displayName) : request.modifiedBy.displayName}
+										by{" "}
+										{incognitoMode
+											? getLinuxUsername(request.modifiedBy.displayName)
+											: request.modifiedBy.displayName}
 									</span>
 								)}
 							</div>
@@ -359,6 +374,17 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 								<GradientButton size="sm" icon={Check} onClick={() => onApprove(request.id)}>
 									Approve
 								</GradientButton>
+							)}
+							{isPending && onApproveWithOptions && (
+								<Button
+									variant="secondary"
+									size="sm"
+									onClick={() => onApproveWithOptions(request)}
+									className="gap-1.5 border-border/50 bg-card/50"
+								>
+									<SlidersHorizontal className="h-3.5 w-3.5" />
+									Approve with profile…
+								</Button>
 							)}
 							{isPending && onDecline && (
 								<Button
@@ -412,8 +438,16 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 
 					{/* Loading state for details */}
 					{isDetailsLoading && (
-						<div role="status" aria-label="Loading media details" className="flex items-center justify-center py-8">
-							<Loader2 className="h-6 w-6 animate-spin" aria-hidden="true" style={{ color: themeGradient.from }} />
+						<div
+							role="status"
+							aria-label="Loading media details"
+							className="flex items-center justify-center py-8"
+						>
+							<Loader2
+								className="h-6 w-6 animate-spin"
+								aria-hidden="true"
+								style={{ color: themeGradient.from }}
+							/>
 						</div>
 					)}
 
@@ -455,7 +489,11 @@ export const RequestDetailModal: React.FC<RequestDetailModalProps> = ({
 													<span
 														className={`inline-block h-2 w-2 shrink-0 rounded-full ${getSeasonStatusColor(requestSeason.status)}`}
 														role="img"
-														aria-label={SEERR_MEDIA_STATUS_LABEL[requestSeason.status as keyof typeof SEERR_MEDIA_STATUS_LABEL] ?? "Unknown"}
+														aria-label={
+															SEERR_MEDIA_STATUS_LABEL[
+																requestSeason.status as keyof typeof SEERR_MEDIA_STATUS_LABEL
+															] ?? "Unknown"
+														}
 														title={`Season ${season.seasonNumber}: ${SEERR_MEDIA_STATUS_LABEL[requestSeason.status as keyof typeof SEERR_MEDIA_STATUS_LABEL] ?? "Unknown"}`}
 													/>
 												)}

--- a/apps/web/src/features/seerr/components/requests-client.tsx
+++ b/apps/web/src/features/seerr/components/requests-client.tsx
@@ -11,8 +11,8 @@ import {
 	Users,
 	WifiOff,
 } from "lucide-react";
-import { lazy, Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
 	PremiumEmptyState,
@@ -35,6 +35,7 @@ import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { useSeerrInstances } from "../hooks/use-seerr-instances";
 import { isSeerrCircuitBreakerError } from "../lib/seerr-utils";
 import { ApprovalQueueTab } from "./approval-queue-tab";
+import { ApproveWithOptionsDialog } from "./approve-with-options-dialog";
 import { InstanceSelector } from "./instance-selector";
 import { IssuesTab } from "./issues-tab";
 import { NotificationsTab } from "./notifications-tab";
@@ -55,6 +56,7 @@ export const RequestsClient = () => {
 	const [activeTab, setActiveTab] = useState<RequestsTab>("approval");
 	const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
 	const [selectedRequest, setSelectedRequest] = useState<SeerrRequest | null>(null);
+	const [approveOptionsRequest, setApproveOptionsRequest] = useState<SeerrRequest | null>(null);
 
 	// Deep-link: ?tab=<id> pre-selects a tab, ?user=<id> pre-selects requester filter on "All Requests" tab
 	const searchParams = useSearchParams();
@@ -63,7 +65,10 @@ export const RequestsClient = () => {
 	const [initialUserFilter, setInitialUserFilter] = useState<string | undefined>(undefined);
 
 	useEffect(() => {
-		if (deepLinkTab && ["approval", "all", "users", "issues", "notifications", "history"].includes(deepLinkTab)) {
+		if (
+			deepLinkTab &&
+			["approval", "all", "users", "issues", "notifications", "history"].includes(deepLinkTab)
+		) {
 			setActiveTab(deepLinkTab);
 		}
 		if (deepLinkUserId) {
@@ -278,6 +283,10 @@ export const RequestsClient = () => {
 								},
 							)
 						}
+						onApproveWithOptions={(req) => {
+							setApproveOptionsRequest(req);
+							setSelectedRequest(null);
+						}}
 						onDecline={(requestId) =>
 							declineMutation.mutate(
 								{ instanceId: currentInstanceId, requestId },
@@ -316,6 +325,17 @@ export const RequestsClient = () => {
 						}
 					/>
 				</Suspense>
+			)}
+
+			{approveOptionsRequest && (
+				<ApproveWithOptionsDialog
+					request={approveOptionsRequest}
+					instanceId={currentInstanceId}
+					open={!!approveOptionsRequest}
+					onOpenChange={(open) => {
+						if (!open) setApproveOptionsRequest(null);
+					}}
+				/>
 			)}
 		</>
 	);

--- a/apps/web/src/features/seerr/components/requests-client.tsx
+++ b/apps/web/src/features/seerr/components/requests-client.tsx
@@ -35,7 +35,6 @@ import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { useSeerrInstances } from "../hooks/use-seerr-instances";
 import { isSeerrCircuitBreakerError } from "../lib/seerr-utils";
 import { ApprovalQueueTab } from "./approval-queue-tab";
-import { ApproveWithOptionsDialog } from "./approve-with-options-dialog";
 import { InstanceSelector } from "./instance-selector";
 import { IssuesTab } from "./issues-tab";
 import { NotificationsTab } from "./notifications-tab";
@@ -44,6 +43,12 @@ import { UsersTab } from "./users-tab";
 
 const RequestDetailModal = lazy(() =>
 	import("./request-detail-modal").then((m) => ({ default: m.RequestDetailModal })),
+);
+
+const ApproveWithOptionsDialog = lazy(() =>
+	import("./approve-with-options-dialog").then((m) => ({
+		default: m.ApproveWithOptionsDialog,
+	})),
 );
 
 const AuditLogTab = lazy(() => import("./audit-log-tab").then((m) => ({ default: m.AuditLogTab })));
@@ -243,6 +248,7 @@ export const RequestsClient = () => {
 							<ApprovalQueueTab
 								instanceId={currentInstanceId}
 								onSelectRequest={setSelectedRequest}
+								onOpenApproveOptions={setApproveOptionsRequest}
 							/>
 						)}
 						{activeTab === "all" && (
@@ -328,14 +334,16 @@ export const RequestsClient = () => {
 			)}
 
 			{approveOptionsRequest && (
-				<ApproveWithOptionsDialog
-					request={approveOptionsRequest}
-					instanceId={currentInstanceId}
-					open={!!approveOptionsRequest}
-					onOpenChange={(open) => {
-						if (!open) setApproveOptionsRequest(null);
-					}}
-				/>
+				<Suspense>
+					<ApproveWithOptionsDialog
+						request={approveOptionsRequest}
+						instanceId={currentInstanceId}
+						open={!!approveOptionsRequest}
+						onOpenChange={(open) => {
+							if (!open) setApproveOptionsRequest(null);
+						}}
+					/>
+				</Suspense>
 			)}
 		</>
 	);

--- a/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
@@ -1,8 +1,13 @@
+import type {
+	LibraryEnrichmentResponse,
+	SeerrPageResult,
+	SeerrRequest,
+	SeerrRequestCount,
+} from "@arr/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor, act } from "@testing-library/react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
-import type { SeerrRequest, SeerrRequestCount, SeerrPageResult, LibraryEnrichmentResponse } from "@arr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock the entire API client module
 vi.mock("../../../lib/api-client/seerr");
@@ -10,16 +15,16 @@ vi.mock("../../../lib/api-client/seerr");
 // Import after mock declaration
 import * as seerrApi from "../../../lib/api-client/seerr";
 import {
-	useSeerrRequests,
-	useSeerrRequest,
-	useSeerrRequestCount,
 	useApproveSeerrRequest,
 	useBulkSeerrRequestAction,
-	useSeerrSearch,
-	useSeerrDiscoverMovies,
-	useSeerrGenres,
 	useClearSeerrCache,
 	useLibraryEnrichment,
+	useSeerrDiscoverMovies,
+	useSeerrGenres,
+	useSeerrRequest,
+	useSeerrRequestCount,
+	useSeerrRequests,
+	useSeerrSearch,
 } from "../useSeerr";
 
 // ============================================================================
@@ -140,10 +145,7 @@ describe("useSeerrRequests", () => {
 		vi.mocked(seerrApi.fetchSeerrRequests).mockResolvedValue(samplePageResult);
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(
-			() => useSeerrRequests({ instanceId: "inst-1" }),
-			{ wrapper },
-		);
+		const { result } = renderHook(() => useSeerrRequests({ instanceId: "inst-1" }), { wrapper });
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -246,7 +248,23 @@ describe("useApproveSeerrRequest", () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(seerrApi.approveSeerrRequest).toHaveBeenCalledWith("inst-1", 1);
+		expect(seerrApi.approveSeerrRequest).toHaveBeenCalledWith("inst-1", 1, undefined);
+	});
+
+	it("forwards profile overrides to approveSeerrRequest", async () => {
+		vi.mocked(seerrApi.approveSeerrRequest).mockResolvedValue(sampleRequest);
+
+		const { wrapper } = createWrapper();
+		const { result } = renderHook(() => useApproveSeerrRequest(), { wrapper });
+
+		const overrides = { profileId: 7, rootFolder: "/trash" };
+		await act(async () => {
+			result.current.mutate({ instanceId: "inst-1", requestId: 1, overrides });
+		});
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+		expect(seerrApi.approveSeerrRequest).toHaveBeenCalledWith("inst-1", 1, overrides);
 	});
 
 	it("invalidates request queries on success", async () => {
@@ -308,11 +326,7 @@ describe("useBulkSeerrRequestAction", () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(seerrApi.bulkSeerrRequestAction).toHaveBeenCalledWith(
-			"inst-1",
-			"approve",
-			[1, 2, 3],
-		);
+		expect(seerrApi.bulkSeerrRequestAction).toHaveBeenCalledWith("inst-1", "approve", [1, 2, 3]);
 		expect(result.current.data).toEqual(bulkResult);
 	});
 
@@ -354,9 +368,7 @@ describe("useBulkSeerrRequestAction", () => {
 
 describe("useSeerrSearch", () => {
 	it("returns infinite query with search results", async () => {
-		vi.mocked(seerrApi.fetchSeerrSearch).mockResolvedValue(
-			sampleDiscoverResponse,
-		);
+		vi.mocked(seerrApi.fetchSeerrSearch).mockResolvedValue(sampleDiscoverResponse);
 
 		const { wrapper } = createWrapper();
 		const { result } = renderHook(() => useSeerrSearch("inst-1", "matrix"), {
@@ -365,11 +377,7 @@ describe("useSeerrSearch", () => {
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(seerrApi.fetchSeerrSearch).toHaveBeenCalledWith(
-			"inst-1",
-			"matrix",
-			1,
-		);
+		expect(seerrApi.fetchSeerrSearch).toHaveBeenCalledWith("inst-1", "matrix", 1);
 		expect(result.current.data!.pages).toHaveLength(1);
 		expect(result.current.data!.pages[0]).toEqual(sampleDiscoverResponse);
 		expect(result.current.hasNextPage).toBe(true);
@@ -392,22 +400,14 @@ describe("useSeerrSearch", () => {
 
 describe("useSeerrDiscoverMovies", () => {
 	it("returns infinite query with pagination", async () => {
-		vi.mocked(seerrApi.fetchSeerrDiscoverMovies).mockResolvedValue(
-			sampleDiscoverResponse,
-		);
+		vi.mocked(seerrApi.fetchSeerrDiscoverMovies).mockResolvedValue(sampleDiscoverResponse);
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(
-			() => useSeerrDiscoverMovies("inst-1"),
-			{ wrapper },
-		);
+		const { result } = renderHook(() => useSeerrDiscoverMovies("inst-1"), { wrapper });
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-		expect(seerrApi.fetchSeerrDiscoverMovies).toHaveBeenCalledWith(
-			"inst-1",
-			1,
-		);
+		expect(seerrApi.fetchSeerrDiscoverMovies).toHaveBeenCalledWith("inst-1", 1);
 		expect(result.current.data!.pages[0]!.results).toHaveLength(1);
 		expect(result.current.hasNextPage).toBe(true);
 	});
@@ -433,10 +433,7 @@ describe("useSeerrGenres", () => {
 		vi.mocked(seerrApi.fetchSeerrGenres).mockResolvedValue(genres);
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(
-			() => useSeerrGenres("inst-1", "movie"),
-			{ wrapper },
-		);
+		const { result } = renderHook(() => useSeerrGenres("inst-1", "movie"), { wrapper });
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -509,9 +506,7 @@ describe("useLibraryEnrichment", () => {
 				},
 			},
 		};
-		vi.mocked(seerrApi.fetchLibraryEnrichment).mockResolvedValue(
-			enrichmentResponse,
-		);
+		vi.mocked(seerrApi.fetchLibraryEnrichment).mockResolvedValue(enrichmentResponse);
 
 		const items = [
 			{
@@ -541,10 +536,9 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(
-			() => useLibraryEnrichment("seerr-inst", items as any),
-			{ wrapper },
-		);
+		const { result } = renderHook(() => useLibraryEnrichment("seerr-inst", items as any), {
+			wrapper,
+		});
 
 		await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -573,10 +567,7 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(
-			() => useLibraryEnrichment(null, items as any),
-			{ wrapper },
-		);
+		const { result } = renderHook(() => useLibraryEnrichment(null, items as any), { wrapper });
 
 		expect(result.current.fetchStatus).toBe("idle");
 		expect(seerrApi.fetchLibraryEnrichment).not.toHaveBeenCalled();

--- a/apps/web/src/hooks/api/useSeerr.ts
+++ b/apps/web/src/hooks/api/useSeerr.ts
@@ -26,13 +26,13 @@ import type {
 	SeerrUser,
 } from "@arr/shared";
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { POLLING_ACTIVE, POLLING_BACKGROUND, POLLING_STANDARD } from "../../lib/polling-intervals";
-import { useEnrichableItems } from "../useEnrichableItems";
 import {
+	type ApproveSeerrRequestOverrides,
 	addSeerrIssueComment,
 	approveSeerrRequest,
 	type BulkRequestResult,
 	bulkSeerrRequestAction,
+	clearSeerrCache,
 	createSeerrRequest,
 	declineSeerrRequest,
 	deleteSeerrRequest,
@@ -40,18 +40,15 @@ import {
 	type FetchSeerrRequestsParams,
 	type FetchSeerrUsersParams,
 	fetchLibraryEnrichment,
+	fetchSeerrAttention,
+	fetchSeerrAuditLog,
 	fetchSeerrDiscoverByGenre,
 	fetchSeerrDiscoverMovies,
 	fetchSeerrDiscoverMoviesUpcoming,
 	fetchSeerrDiscoverTrending,
 	fetchSeerrDiscoverTv,
 	fetchSeerrDiscoverTvUpcoming,
-	clearSeerrCache,
-	fetchSeerrAttention,
-	fetchSeerrAuditLog,
 	fetchSeerrGenres,
-	type SeerrAuditLogEntry,
-	type SeerrHealthResponse,
 	fetchSeerrHealth,
 	fetchSeerrIssues,
 	fetchSeerrMovieDetails,
@@ -66,13 +63,17 @@ import {
 	fetchSeerrUserQuota,
 	fetchSeerrUsers,
 	retrySeerrRequest,
+	type SeerrAuditLogEntry,
+	type SeerrHealthResponse,
 	testSeerrNotification,
 	type UpdateSeerrUserPayload,
 	updateSeerrIssueStatus,
 	updateSeerrNotification,
 	updateSeerrUser,
 } from "../../lib/api-client/seerr";
+import { POLLING_ACTIVE, POLLING_BACKGROUND, POLLING_STANDARD } from "../../lib/polling-intervals";
 import { seerrKeys } from "../../lib/query-keys";
+import { useEnrichableItems } from "../useEnrichableItems";
 
 // ============================================================================
 // Request Hooks
@@ -112,8 +113,13 @@ export const useSeerrAttention = (instanceId: string) =>
 
 export const useApproveSeerrRequest = () => {
 	const queryClient = useQueryClient();
-	return useMutation<SeerrRequest, Error, { instanceId: string; requestId: number }>({
-		mutationFn: ({ instanceId, requestId }) => approveSeerrRequest(instanceId, requestId),
+	return useMutation<
+		SeerrRequest,
+		Error,
+		{ instanceId: string; requestId: number; overrides?: ApproveSeerrRequestOverrides }
+	>({
+		mutationFn: ({ instanceId, requestId, overrides }) =>
+			approveSeerrRequest(instanceId, requestId, overrides),
 		onSuccess: (_, { instanceId }) => {
 			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });

--- a/apps/web/src/lib/api-client/seerr.ts
+++ b/apps/web/src/lib/api-client/seerr.ts
@@ -65,6 +65,10 @@ export async function fetchSeerrRequest(
 /**
  * Optional admin overrides applied to a request before approval.
  * When omitted, the request is approved with whatever profile/server it already has.
+ *
+ * Note: Jellyseerr's PUT also accepts `userId` (request reassignment), but the
+ * dashboard intentionally doesn't surface it — approval-time reassignment goes
+ * through Jellyseerr's own UI.
  */
 export interface ApproveSeerrRequestOverrides {
 	serverId?: number;
@@ -72,7 +76,6 @@ export interface ApproveSeerrRequestOverrides {
 	rootFolder?: string;
 	languageProfileId?: number;
 	tags?: number[];
-	userId?: number;
 }
 
 export async function approveSeerrRequest(

--- a/apps/web/src/lib/api-client/seerr.ts
+++ b/apps/web/src/lib/api-client/seerr.ts
@@ -62,11 +62,28 @@ export async function fetchSeerrRequest(
 	return apiRequest(`/api/seerr/requests/${instanceId}/${requestId}`);
 }
 
+/**
+ * Optional admin overrides applied to a request before approval.
+ * When omitted, the request is approved with whatever profile/server it already has.
+ */
+export interface ApproveSeerrRequestOverrides {
+	serverId?: number;
+	profileId?: number;
+	rootFolder?: string;
+	languageProfileId?: number;
+	tags?: number[];
+	userId?: number;
+}
+
 export async function approveSeerrRequest(
 	instanceId: string,
 	requestId: number,
+	overrides?: ApproveSeerrRequestOverrides,
 ): Promise<SeerrRequest> {
-	return apiRequest(`/api/seerr/requests/${instanceId}/${requestId}/approve`, { method: "POST" });
+	return apiRequest(`/api/seerr/requests/${instanceId}/${requestId}/approve`, {
+		method: "POST",
+		json: overrides && Object.keys(overrides).length > 0 ? overrides : undefined,
+	});
 }
 
 export async function declineSeerrRequest(

--- a/packages/shared/src/types/seerr.ts
+++ b/packages/shared/src/types/seerr.ts
@@ -417,6 +417,10 @@ export interface SeerrCreateRequestPayload {
  * Payload for PUT /api/v1/request/:id — admin overrides applied before approval.
  * Jellyseerr/Overseerr require `mediaType` so the server knows which *arr backend to target.
  *
+ * For TV requests Jellyseerr also requires `seasons` (array of season numbers); omitting
+ * them produces a 500 "Missing seasons" response. The approve route re-uses the existing
+ * request's seasons when calling this so the override doesn't change what was requested.
+ *
  * `userId` (Jellyseerr-side requester reassignment) is part of the upstream shape but
  * intentionally not exposed by the dashboard's approve route — see request-routes.ts.
  */
@@ -427,6 +431,7 @@ export interface SeerrUpdateRequestPayload {
 	rootFolder?: string;
 	languageProfileId?: number;
 	tags?: number[];
+	seasons?: number[];
 	userId?: number;
 }
 
@@ -482,7 +487,8 @@ export interface SeerrServerWithDetails {
 	server: SeerrServiceServer;
 	profiles: SeerrQualityProfile[];
 	rootFolders: SeerrRootFolder[];
-	languageProfiles?: { id: number; name: string }[];
+	/** Jellyseerr returns `null` (not undefined) for Sonarr servers without language profiles. */
+	languageProfiles?: { id: number; name: string }[] | null;
 	tags: SeerrTag[];
 }
 
@@ -873,7 +879,9 @@ export const seerrServerWithDetailsSchema = z.looseObject({
 	server: seerrServiceServerSchema,
 	profiles: z.array(seerrQualityProfileSchema),
 	rootFolders: z.array(seerrRootFolderSchema),
-	languageProfiles: z.array(z.looseObject({ id: z.number(), name: z.string() })).optional(),
+	// Jellyseerr returns `null` for Sonarr servers without language profiles configured —
+	// `.nullish()` accepts both `null` and `undefined`/missing.
+	languageProfiles: z.array(z.looseObject({ id: z.number(), name: z.string() })).nullish(),
 	tags: z.array(seerrTagSchema),
 });
 

--- a/packages/shared/src/types/seerr.ts
+++ b/packages/shared/src/types/seerr.ts
@@ -413,6 +413,20 @@ export interface SeerrCreateRequestPayload {
 	userId?: number;
 }
 
+/**
+ * Payload for PUT /api/v1/request/:id — admin overrides applied before approval.
+ * Jellyseerr/Overseerr require `mediaType` so the server knows which *arr backend to target.
+ */
+export interface SeerrUpdateRequestPayload {
+	mediaType: "movie" | "tv";
+	serverId?: number;
+	profileId?: number;
+	rootFolder?: string;
+	languageProfileId?: number;
+	tags?: number[];
+	userId?: number;
+}
+
 /** Response from POST /api/v1/request */
 export interface SeerrCreateRequestResponse {
 	id: number;

--- a/packages/shared/src/types/seerr.ts
+++ b/packages/shared/src/types/seerr.ts
@@ -416,6 +416,9 @@ export interface SeerrCreateRequestPayload {
 /**
  * Payload for PUT /api/v1/request/:id — admin overrides applied before approval.
  * Jellyseerr/Overseerr require `mediaType` so the server knows which *arr backend to target.
+ *
+ * `userId` (Jellyseerr-side requester reassignment) is part of the upstream shape but
+ * intentionally not exposed by the dashboard's approve route — see request-routes.ts.
  */
 export interface SeerrUpdateRequestPayload {
 	mediaType: "movie" | "tv";


### PR DESCRIPTION
## Summary

- Adds a **profile / root folder / server override** dialog to the Seerr request approval flow, behind a new "Options" button next to the existing one-click Approve. Closes #434 — admins can now route a request to a non-default quality profile (e.g. "reids trash shitshows") at approval time.
- Backend route composes `getRequest` → `updateRequest` (PUT) → `approveRequest` only when overrides are sent; existing one-click approval is unchanged.
- Reuses the existing `/request-options` endpoint to populate the dropdowns — no new Seerr-side data fetching.

## How it works

```
[Admin clicks Options] → Dialog mounts via React.lazy + Suspense
    ↓ /request-options?mediaType=movie|tv  (existing endpoint, cached)
[Dropdowns populate from real Jellyseerr data: profiles + root folders + servers]
    ↓ Admin picks non-default profile, clicks Approve
[POST /api/seerr/requests/:inst/:id/approve { profileId, rootFolder, ... }]
    ↓
Route: getRequest → updateRequest (PUT, with seasons[] for TV) → approveRequest
    ↓
Audit log: { overridden: true, profileId, rootFolder, ... }
```

## Bugs found and fixed during live smoke testing

Three issues that mocked tests missed because the fixtures were tidier than real Jellyseerr:

1. **`serverId` can be 0**. Jellyseerr/Overseerr use 0-based ids for the first registered server. Schema accepts `nonnegative()`.
2. **`languageProfiles` can be `null`**. Sonarr servers without language profiles return `null`, not undefined — broke upstream Zod parse and made `getRequestOptions("tv")` return an empty server list. Fixed with `.nullish()` + interface allows `| null`.
3. **TV PUT requires `seasons`**. Jellyseerr returns 500 "Missing seasons" when omitted on TV requests. The route now passes through `existing.seasons.map(s => s.seasonNumber)` for TV overrides so the user's original season selection isn't dropped.

## Verification

- ✅ Turbo typecheck clean across `@arr/api`, `@arr/web`, `@arr/shared`
- ✅ 1538 backend tests passing (8 new for this PR)
- ✅ Web tests green
- ✅ **Live end-to-end** against real Jellyseerr v3.2.0 + Sonarr: TV request approved with `[Anime] Remux-1080p` profile + `/data/media/anime` root folder → Sonarr accepted the series with `qualityProfileId: 15` (the override, not the server-default 14)
- ✅ Audit log captured `{ overridden: true, profileId: 15, rootFolder: "/data/media/anime" }`
- ✅ Code review: 6 findings, all addressed (lift dialog state, lazy load, drop unused `userId`, override-detection edge case, additional tests for failure paths)
- ✅ Security review: no high-confidence findings (same trust boundary as the existing approve route)

## Test plan

- [x] Mocked unit tests (route composition, validation, failure-path abort)
- [x] Live browser test: empty-state branch (Seerr without target server)
- [x] Live browser test: populated-state branch (real profiles + root folders)
- [x] Live browser test: override actually lands in Sonarr (verified via library cache)
- [x] Audit log inspection
- [x] React Query invalidation (badge updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)