### PR TITLE
chore: v2.18.4 release — changelog + Seerr feature docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.18.4] - 2026-05-07
 
+### Added
+
+- **Admin quality-profile override on Seerr request approval (closes #434).** A new "Options" button next to each pending request opens a profile-picker dialog where admins can pick a non-default quality profile, root folder, or server before approval — useful when a specific requester's content should land in a different profile than the server default (e.g. a "trash shows" profile for a user who watches everything). Jellyseerr/Overseerr stamps the override onto the request before handing off to Sonarr/Radarr. The one-click Approve path is unchanged — overrides are opt-in. Audit log records `{ overridden: true, profileId, rootFolder, ... }` for accountability. Live-tested end-to-end against a real Jellyseerr v3.2.0 + Sonarr instance, which surfaced three real-data bugs that mocked unit tests didn't catch: `serverId: 0` is valid (Jellyseerr is 0-indexed), `languageProfiles: null` is valid (was strict `.optional()`), and TV PUT requires `seasons` (Jellyseerr 500s otherwise). Lazy-loaded modal, dropdowns reuse the existing `/request-options` endpoint (#436).
+
 ### Fixed
 
 - **Out-of-memory crash during scheduled backup (closes #427 follow-up).** v2.18.3 fixed Readarr/Lidarr library-sync OOM, but a separate report showed scheduled backups still hitting the 768 MB heap cap. Root cause: `exportDatabase` ran 21 `findMany()` calls in parallel and the encryption chain (`JSON.stringify` → buffer → buffer → base64 → stringify) held ~5–6× row data simultaneously. Fixes:

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.4** — Backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
+> **Version 2.18.4** — New: admin quality-profile override on Seerr request approval (closes #434) — pick a non-default profile / root folder / server in a one-click "Options" dialog before approving. Plus a backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -94,7 +94,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `2.18.4` | Patch release — backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
+| `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.4** — Backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
+> **Version 2.18.4** — New: admin quality-profile override on Seerr request approval (closes #434) — pick a non-default profile / root folder / server in a one-click "Options" dialog before approving. Plus a backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -231,7 +231,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
-| `2.18.4` | Patch release — backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
+| `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
 | `2.18.1` | Labels & tagging fixes: Radarr/Sonarr partial-PUT validator rejection (#418) + event-driven Label Sync triggers (#420) so rules fire seconds after a tag change |


### PR DESCRIPTION
## Summary

Documentation updates for the v2.18.4 release. The release docs were prepped for the backup-OOM fix only — this adds the Seerr admin profile-override feature (#434, PR #436) that merged after the prep.

- **CHANGELOG.md** — new `### Added` section under `[2.18.4]` describing the override dialog, audit-log entry shape, and the three real-data bugs that live testing surfaced (`serverId: 0` valid, `languageProfiles: null` valid, TV PUT requires `seasons`).
- **README.md / DOCKERHUB.md** — lede tagline now leads with the new Seerr feature alongside the memory fixes; `2.18.4` row in the version-tag table updated to match.

`package.json` and `CLAUDE.md` are already at `2.18.4` from the earlier prep — no change needed.

## Wiki

Pushed separately to the wiki repo (`Kha-kis/arr-dashboard.wiki`) in commit `cb63a01`:
- `Home.md` — Current Version → 2.18.4
- `Troubleshooting.md` — version example → 2.18.4
- `Seerr-Integration.md` — new "Approving with a Custom Quality Profile" subsection under "Approval Queue Tab" documenting the new Options button

## Test plan

- [x] Diff stat covers only the three intended files (CHANGELOG / README / DOCKERHUB)
- [x] `package.json` and `CLAUDE.md` already at 2.18.4 (no churn)
- [x] Version-tag table 2.18.4 row updated in both README and DOCKERHUB
- [x] Wiki pushed to `Kha-kis/arr-dashboard.wiki`
- [x] After merge: tag `v2.18.4` and push the tag to trigger the Docker build

🤖 Generated with [Claude Code](https://claude.com/claude-code)