### PR TITLE
fix(memory): heap-pressure sweep + diagnostics for #427 (v2.18.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.5] - 2026-05-08
+
+### Fixed
+
+- **Out-of-memory crash triggered by `/api/dashboard/calendar` (closes #427 follow-up).** A new OOM trace on v2.18.4 showed the calendar request as the trigger, but the trace shape (766 MB live heap after Mark-Compact freed only ~0.4 MB) pointed at retention/peak across multiple paths the prior fixes didn't cover. This release sweeps the remaining unbounded `findMany` reads on tables with large JSON blob columns (`LibraryCache.data`, plex/jellyfin/tautulli cache rows) and reduces transient peaks on the heaviest dashboard request paths:
+  - **Library cleanup field-options endpoint** (`GET /api/library-cleanup/field-options`) was loading every `LibraryCache.data` JSON blob for the user with no `take:` cap — for a 50k-item Sonarr-heavy library, ~1 GB transient just to populate codec/resolution dropdowns. Now cursor-paginates at 500 rows. Three formerly-separate full-table scans of `plexCache` (one each for users, libraries, collections+labels) are now a single merged cursor walk that selects the four columns together.
+  - **Library sync existing-items load** for Sonarr/Radarr (`syncInstance` in `library-sync/sync-executor.ts`) was loading every cached row with the `data` JSON column for tag-delta detection. For a 100k-item library the unbounded read peaked over the heap cap. Now cursor-paginates at 500 rows; the post-sync deletion-id diff is collected in the same walk.
+  - **Plex collection-routes** (`GET /api/plex/:instanceId/{collections,labels}`) ran unbounded `plexCache.findMany` per request. Cursor-paginated at 1000 rows.
+  - **Insights digest scheduler** (`requested-unwatched` and `watched-monitored` checks, every 6h) ran unbounded `plexCache.findMany`. Cursor-paginated at 1000 rows.
+  - **Calendar + history dashboard handlers** held both raw upstream payloads AND normalized copies in memory simultaneously (Sonarr's `includeSeries: true, includeEpisodeFile: true` payloads are 5–10 KB per row). Refactored to drop each raw item as it's normalized, halving peak heap during the iteration.
+  - **Plex/Jellyfin analytics queries** that select `sessionsJson` lowered `take: 50000` → `take: 20000` (queries selecting only scalar columns are unchanged). With session captures every 5 min, 20000 rows = ~70 days of single-instance history — preserves typical-case behavior. Heavy multi-instance + 30-day-window users hit the cap as before but at lower memory.
+- **`last-watched` analytics dropped recent watch events when the snapshot cap was hit.** Both `GET /api/jellyfin/analytics/last-watched` and `GET /api/plex/last-watched` ordered `sessionSnapshot.findMany` by `capturedAt asc`, so when the `take` cap was reached the OLDEST rows were kept and the most recent watch events the panel exists to surface were silently dropped. Now uses `desc` to match the `history` endpoint's pattern. Pre-existing bug, surfaced by code review during the issue #427 sweep.
+
+### Added
+
+- **Heap-monitor plugin** logs `process.memoryUsage()` every 5 minutes via pino, including deltas vs. the previous sample. Severity escalates with pressure: `info` at heap > 80%, `warn` at heap > 90% with a copy-paste manual-snapshot command in the warning. A slow leak now shows up as monotonic `heapDeltaMB` growth instead of an opaque OOM.
+- **`--heapsnapshot-signal=SIGUSR2`** added to default `NODE_OPTIONS`. Cost = zero (only writes when the signal is received). Operators who notice climbing baseline in heap-monitor logs can capture a snapshot on demand:
+  ```
+  docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
+  ```
+  Snapshots land on `/config/heap-snapshots/` (persisted volume, owned by `PUID:PGID`).
+- **`HEAP_AUTO_SNAPSHOT=1` env var (opt-in)** appends `--heapsnapshot-near-heap-limit=1` so V8 auto-captures a snapshot just before OOM. Off by default — each snapshot is ~3x the heap (~2.3 GB at the 768 MB cap), too much to write to a `/config` volume that may be a small partition. Set in compose / Unraid template alongside other env vars.
+
+### Changed
+
+- **`GET /api/library?limit=0` now returns 400 Bad Request.** Previously this signaled "fetch all" for an internal `useLibraryForFiltering` hook that has been removed. The fetch-all path mass-loaded every `LibraryCache.data` blob and trivially OOM'd the 768 MB heap on any large library — a foot-gun for any future caller (or external API user) who happened to pass `limit=0`. Schema now requires `limit >= 1`. External callers hitting `/api/library?limit=0` directly will need to use a positive limit value.
+
+### Notes
+
+- This patch went through a multi-file fix sweep, an automated heap-retainer audit, an independent code review pass (which caught the `last-watched` ordering bug), and end-to-end Docker smoke testing (heap-monitor logs verified, SIGUSR2 snapshot capture verified end-to-end producing a 157 MB `.heapsnapshot` file in `/config/heap-snapshots/`). Test additions: 4 new tests — cursor-pagination integration test for `field-options`, library-sync deletion-set equivalence under cursor pagination across multiple batches.
+- Memory peak reductions (estimated for a 50k-item library, 5 instances, 30-day window): field-options 1 GB → 10 MB; library-sync 250 MB → 10 MB; plex collection-routes 30 MB → 5 MB; calendar/history 2× peak → 1× peak; sessionsJson analytics 500 MB max → 200 MB max.
+- If you hit a future OOM, set `HEAP_AUTO_SNAPSHOT=1` and reproduce. Share the resulting `.heapsnapshot` file in your bug report so we can identify the actual retainer instead of guessing.
+
 ## [2.18.4] - 2026-05-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.18.4 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.18.5 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.4** — New: admin quality-profile override on Seerr request approval (closes #434) — pick a non-default profile / root folder / server in a one-click "Options" dialog before approving. Plus a backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
+> **Version 2.18.5** — Comprehensive heap-pressure sweep + diagnostic instrumentation closing out issue #427. Cursor-paginates every remaining unbounded `LibraryCache.data` / `plexCache` / `jellyfinCache` / `tautulliCache` read, reduces calendar + history transient peaks, lowers `take` caps on `sessionsJson` analytics, rejects the `/api/library?limit=0` foot-gun. Adds an always-on heap-monitor plugin and opt-in `HEAP_AUTO_SNAPSHOT=1` env var so future OOMs ship actual evidence. Also fixes a pre-existing `last-watched` ordering bug.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -74,6 +74,7 @@ services:
 | `BACKUP_PASSWORD` | Auto-generated | Password for encrypted backups |
 | `LOG_LEVEL` | `info` | Logging level (`debug`, `info`, `warn`, `error`) |
 | `GITHUB_TOKEN` | - | Optional GitHub token for TRaSH Guides (higher rate limits) |
+| `HEAP_AUTO_SNAPSHOT` | `0` | Set to `1` to capture a V8 heap snapshot just before OOM (lands in `/config/heap-snapshots/`, ~2.3 GB per snapshot). Off by default. Manual snapshots via `kill -USR2 <pid>` always available. |
 
 ### WebAuthn/Passkeys (Optional)
 
@@ -94,6 +95,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.5` | Comprehensive heap-pressure sweep closing out issue #427 — cursor-paginates remaining unbounded JSON-blob reads, reduces calendar/history transient peaks, caps sessionsJson analytics, rejects `/api/library?limit=0`. Adds heap-monitor plugin + opt-in `HEAP_AUTO_SNAPSHOT=1` for diagnostics. Fixes `last-watched` ordering bug |
 | `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |

--- a/Dockerfile
+++ b/Dockerfile
@@ -138,7 +138,23 @@ ENV DATABASE_URL="file:/config/prod.db" \
     PGID=911 \
     # Node.js memory optimization for containers (can be overridden)
     # 768MB accommodates users with many service instances (3+ Plex/Tautulli)
-    NODE_OPTIONS="--max-old-space-size=768 --dns-result-order=ipv4first"
+    #
+    # Heap diagnostics (issue #427 follow-up):
+    #   --heapsnapshot-signal=SIGUSR2  Always on. Cost = zero (only writes
+    #     when the signal is received). If periodic heap-monitor logs show
+    #     a climbing baseline, an operator can capture a snapshot:
+    #       docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
+    #     Snapshots land on the persisted volume (/config/heap-snapshots/).
+    #
+    #   Auto-capture on near-OOM is OPT-IN via the HEAP_AUTO_SNAPSHOT env
+    #   var (read by start-combined.sh). Set HEAP_AUTO_SNAPSHOT=1 in your
+    #   compose / Unraid template to have V8 write a single .heapsnapshot
+    #   file just before OOM. Default off because each snapshot is ~3x the
+    #   heap (~2.3 GB at the 768 MB cap) — a lot for small /config volumes.
+    NODE_OPTIONS="--max-old-space-size=768 --dns-result-order=ipv4first --heapsnapshot-signal=SIGUSR2" \
+    # Set to "1" to auto-capture a heap snapshot just before OOM (issue #427).
+    # Off by default — see NODE_OPTIONS comment above.
+    HEAP_AUTO_SNAPSHOT=0
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD wget -q --spider http://127.0.0.1:${PORT:-3000}/health || exit 1

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.4** — New: admin quality-profile override on Seerr request approval (closes #434) — pick a non-default profile / root folder / server in a one-click "Options" dialog before approving. Plus a backup OOM fix and broader memory sweep: scheduled backups now skip and cap operational history tables, encryption holds ~50% less peak heap, and library-cleanup + auto-tag now cursor-paginate cache reads to keep large Plex/Jellyfin libraries under the 768 MB container cap (#427 follow-up).
+> **Version 2.18.5** — Comprehensive heap-pressure sweep + diagnostic instrumentation closing out issue #427. Cursor-paginates every remaining unbounded `LibraryCache.data` / `plexCache` / `jellyfinCache` / `tautulliCache` read (library-cleanup, library-sync, plex collection-routes, insights-digest), drops raw-payload references mid-loop on calendar + history dashboard handlers, lowers `take` caps on `sessionsJson` analytics queries, and rejects the `/api/library?limit=0` foot-gun. Ships an always-on heap-monitor plugin (5-min `process.memoryUsage()` samples with deltas) and an opt-in `HEAP_AUTO_SNAPSHOT=1` env var so the next OOM (if any) ships actual evidence. Also fixes a pre-existing `last-watched` ordering bug surfaced by review.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -231,6 +231,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.5` | Comprehensive heap-pressure sweep closing out issue #427 — cursor-paginates remaining unbounded JSON-blob reads (library-cleanup, library-sync, plex collection-routes, insights-digest), reduces calendar/history transient peaks, caps sessionsJson analytics, rejects `/api/library?limit=0`. Adds heap-monitor plugin + opt-in `HEAP_AUTO_SNAPSHOT=1` for diagnostics. Fixes `last-watched` ordering bug |
 | `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |
 | `2.18.2` | Auto-Tagger: one-click Sonarr/Radarr Connect webhook auto-install (#423) — discover enabled instances and push the canonical webhook in a single click |
@@ -302,6 +303,7 @@ The `/config` volume contains critical data that must be preserved:
 | `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Passkey origin URL (full URL with protocol) |
 | `LOG_LEVEL` | `info` | Logging level (`debug`, `info`, `warn`, `error`) |
 | `GITHUB_TOKEN` | - | Optional GitHub token for TRaSH Guides (higher rate limits) |
+| `HEAP_AUTO_SNAPSHOT` | `0` | Set to `1` to capture a V8 heap snapshot just before OOM (lands in `/config/heap-snapshots/`). Off by default — each snapshot is ~3x the heap (~2.3 GB at the 768 MB cap). Manual snapshots via `kill -USR2 <pid>` are always available regardless of this setting. |
 
 > **Note:** Two modes are supported for running as a non-root user:
 >

--- a/apps/api/src/bootstrap/infrastructure.ts
+++ b/apps/api/src/bootstrap/infrastructure.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from "fastify";
 
 import { arrClientPlugin } from "../plugins/arr-client.js";
 import deploymentExecutorPlugin from "../plugins/deployment-executor.js";
+import heapMonitorPlugin from "../plugins/heap-monitor.js";
 import lifecyclePlugin from "../plugins/lifecycle.js";
 import notificationServicePlugin from "../plugins/notification-service.js";
 import { prismaPlugin } from "../plugins/prisma.js";
@@ -25,6 +26,7 @@ import seerrCircuitBreakerPlugin from "../plugins/seerr-circuit-breaker.js";
  *  - notificationService → `app.notificationService`
  *  - schedulerRegistry → `app.schedulerRegistry` (must precede scheduler plugins)
  *  - lifecycle         → graceful shutdown + health wiring
+ *  - heapMonitor       → periodic process.memoryUsage() samples (issue #427 follow-up)
  */
 export function registerInfrastructure(app: FastifyInstance): void {
 	app.register(prismaPlugin);
@@ -36,4 +38,5 @@ export function registerInfrastructure(app: FastifyInstance): void {
 	app.register(notificationServicePlugin);
 	app.register(schedulerRegistryPlugin);
 	app.register(lifecyclePlugin);
+	app.register(heapMonitorPlugin);
 }

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -9,12 +9,12 @@
  * - Memory instrumentation at debug level
  */
 
-import { describe, it, expect, vi } from "vitest";
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient, ServiceType } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
 import type { Encryptor } from "../../auth/encryption.js";
-import type { FastifyBaseLogger } from "fastify";
-import { syncInstance, type SyncExecutorDeps } from "../sync-executor.js";
+import { type SyncExecutorDeps, syncInstance } from "../sync-executor.js";
 
 const MOCK_USER_ID = "user-1";
 const INSTANCE_ID = "instance-1";
@@ -174,30 +174,31 @@ function createMockPrisma(
 			update: vi.fn().mockResolvedValue({}),
 			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 		},
-		$transaction: vi
-			.fn()
-			.mockImplementation(
-				async (
-					fn: (tx: {
-						libraryCache: {
-							update: (args: { where: { id: string }; data: Record<string, unknown> }) => Promise<unknown>;
-							create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
-						};
-					}) => Promise<void>,
-				) => {
-					const tx = {
-						libraryCache: {
-							update: async (args: { where: { id: string }; data: Record<string, unknown> }) => {
-								txUpdates.push(args);
-							},
-							create: async (args: { data: Record<string, unknown> }) => {
-								txCreates.push(args);
-							},
-						},
+		$transaction: vi.fn().mockImplementation(
+			async (
+				fn: (tx: {
+					libraryCache: {
+						update: (args: {
+							where: { id: string };
+							data: Record<string, unknown>;
+						}) => Promise<unknown>;
+						create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
 					};
-					await fn(tx);
-				},
-			),
+				}) => Promise<void>,
+			) => {
+				const tx = {
+					libraryCache: {
+						update: async (args: { where: { id: string }; data: Record<string, unknown> }) => {
+							txUpdates.push(args);
+						},
+						create: async (args: { data: Record<string, unknown> }) => {
+							txCreates.push(args);
+						},
+					},
+				};
+				await fn(tx);
+			},
+		),
 	} as unknown as PrismaClient & {
 		_selectCalls: unknown[];
 		_txCreates: Array<{ data: Record<string, unknown> }>;
@@ -411,10 +412,10 @@ describe("syncInstance", () => {
 		});
 
 		it("Readarr update: writes updated JSON data with current title", async () => {
-			const rawItems = [makeRawItem({ id: 1, title: "Updated Author", authorName: "Updated Author" })];
-			const existingItems = [
-				{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false },
+			const rawItems = [
+				makeRawItem({ id: 1, title: "Updated Author", authorName: "Updated Author" }),
 			];
+			const existingItems = [{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false }];
 
 			const { deps, instance, mockPrisma } = setupSync("READARR", rawItems, existingItems);
 
@@ -435,9 +436,7 @@ describe("syncInstance", () => {
 
 		it("Lidarr update: writes updated JSON data with current title", async () => {
 			const rawItems = [makeRawItem({ id: 1, artistName: "Updated Artist" })];
-			const existingItems = [
-				{ id: "cache-1", arrItemId: 1, itemType: "artist", hasFile: false },
-			];
+			const existingItems = [{ id: "cache-1", arrItemId: 1, itemType: "artist", hasFile: false }];
 
 			const { deps, instance, mockPrisma } = setupSync("LIDARR", rawItems, existingItems);
 
@@ -447,9 +446,10 @@ describe("syncInstance", () => {
 			expect(result.itemsUpdated).toBe(1);
 			expect(mockPrisma._txUpdates.length).toBe(1);
 
-			const parsed = JSON.parse(
-				mockPrisma._txUpdates[0]!.data.data as string,
-			) as Record<string, unknown>;
+			const parsed = JSON.parse(mockPrisma._txUpdates[0]!.data.data as string) as Record<
+				string,
+				unknown
+			>;
 			expect(parsed.type).toBe("artist");
 			expect(parsed.title).toBe("Updated Artist");
 		});
@@ -464,9 +464,10 @@ describe("syncInstance", () => {
 			expect(result.itemsAdded).toBe(1);
 			expect(mockPrisma._txCreates.length).toBe(1);
 
-			const parsed = JSON.parse(
-				mockPrisma._txCreates[0]!.data.data as string,
-			) as Record<string, unknown>;
+			const parsed = JSON.parse(mockPrisma._txCreates[0]!.data.data as string) as Record<
+				string,
+				unknown
+			>;
 			expect(parsed.type).toBe("series");
 			expect(parsed.title).toBe("New Series");
 		});
@@ -500,9 +501,7 @@ describe("syncInstance", () => {
 
 		it("Lidarr: processes a single-item batch correctly", async () => {
 			const rawItems = [makeRawItem()];
-			const existingItems = [
-				{ id: "cache-1", arrItemId: 1, itemType: "artist", hasFile: false },
-			];
+			const existingItems = [{ id: "cache-1", arrItemId: 1, itemType: "artist", hasFile: false }];
 
 			const { deps, instance } = setupSync("LIDARR", rawItems, existingItems);
 
@@ -554,9 +553,7 @@ describe("syncInstance", () => {
 			expect(result.success).toBe(true);
 			expect(result.itemsUpdated).toBe(1);
 
-			const { triggerLabelSyncForItem } = await import(
-				"../../label-sync/trigger-for-item.js"
-			);
+			const { triggerLabelSyncForItem } = await import("../../label-sync/trigger-for-item.js");
 			expect(triggerLabelSyncForItem).toHaveBeenCalledWith(
 				expect.objectContaining({
 					sourceService: "RADARR",
@@ -569,8 +566,7 @@ describe("syncInstance", () => {
 
 			const infoCalls = (log.info as ReturnType<typeof vi.fn>).mock.calls.filter(
 				(call: unknown[]) =>
-					typeof call[1] === "string" &&
-					(call[1] as string).includes("Library sync delta fired"),
+					typeof call[1] === "string" && (call[1] as string).includes("Library sync delta fired"),
 			);
 			expect(infoCalls.length).toBe(1);
 		});
@@ -601,9 +597,7 @@ describe("syncInstance", () => {
 			expect(result.success).toBe(true);
 			expect(result.itemsUpdated).toBe(1);
 
-			const { triggerLabelSyncForItem } = await import(
-				"../../label-sync/trigger-for-item.js"
-			);
+			const { triggerLabelSyncForItem } = await import("../../label-sync/trigger-for-item.js");
 			expect(triggerLabelSyncForItem).toHaveBeenCalledWith(
 				expect.objectContaining({
 					sourceService: "SONARR",
@@ -617,9 +611,7 @@ describe("syncInstance", () => {
 
 		it("Readarr: does NOT fire label sync triggers", async () => {
 			const rawItems = [makeRawItem({ id: 1, tags: [1, 2], authorName: "Author" })];
-			const existingItems = [
-				{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false },
-			];
+			const existingItems = [{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false }];
 
 			const { deps, instance } = setupSync("READARR", rawItems, existingItems);
 
@@ -627,12 +619,8 @@ describe("syncInstance", () => {
 
 			expect(result.success).toBe(true);
 
-			const { triggerLabelSyncForItem } = await import(
-				"../../label-sync/trigger-for-item.js"
-			);
-			const relevantCalls = (
-				triggerLabelSyncForItem as ReturnType<typeof vi.fn>
-			).mock.calls.filter(
+			const { triggerLabelSyncForItem } = await import("../../label-sync/trigger-for-item.js");
+			const relevantCalls = (triggerLabelSyncForItem as ReturnType<typeof vi.fn>).mock.calls.filter(
 				(call: unknown[]) => (call[0] as { itemType?: string }).itemType === "author",
 			);
 			expect(relevantCalls).toHaveLength(0);
@@ -681,9 +669,7 @@ describe("syncInstance", () => {
 					statistics: { bookFileCount: 1 },
 				}),
 			];
-			const existingItems = [
-				{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false },
-			];
+			const existingItems = [{ id: "cache-1", arrItemId: 1, itemType: "author", hasFile: false }];
 
 			const { deps, instance } = setupSync("READARR", rawItems, existingItems);
 
@@ -718,6 +704,92 @@ describe("syncInstance", () => {
 				where: { id: { in: ["cache-2"] } },
 			});
 		});
+
+		// Pins the v2.18.5 cursor-paginated existing-items load (issue #427
+		// follow-up). The pre-refactor shape held a single `existingItems`
+		// array used for both the upsert map AND the post-sync deletion-id
+		// diff. The new shape walks libraryCache in cursor batches, collecting
+		// (id, arrItemId, itemType) into `existingForDeletion` as it goes.
+		// Verify the deletion set is identical when input is delivered across
+		// MULTIPLE cursor batches, not just one — without this, a refactor
+		// that resets `existingForDeletion` per batch would silently leak
+		// zombie cache rows.
+		it("cursor-paginates existing-items load and computes the SAME deletion set across batches", async () => {
+			// 600 existing rows → 2 cursor batches at SYNC_QUERY_BATCH_SIZE=500.
+			const TOTAL = 600;
+			const existingItems = Array.from({ length: TOTAL }, (_, i) => ({
+				id: `cache-${String(i).padStart(4, "0")}`,
+				arrItemId: i + 1,
+				itemType: "series" as const,
+				hasFile: false,
+				data: null as string | null,
+			}));
+
+			// ARR returns the first 200 items; the remaining 400 should be
+			// flagged for deletion.
+			const KEPT = 200;
+			const rawItems = Array.from({ length: KEPT }, (_, i) =>
+				makeRawItem({ id: i + 1, title: `Series ${i + 1}` }),
+			);
+
+			const { deps, instance, mockPrisma } = setupSync(
+				"SONARR",
+				rawItems,
+				// Pass a placeholder so the default mock doesn't deliver all rows
+				// in a single call — we override findMany below to simulate Prisma's
+				// cursor-pagination semantics. The placeholder is just a type hint
+				// for createMockPrisma.
+				existingItems.slice(0, 1),
+			);
+
+			// Override findMany to mimic Prisma's cursor-pagination behavior:
+			// without a cursor, return rows starting at index 0; with a cursor,
+			// return rows AFTER the cursor row (skip:1). Bound by `take`.
+			const findManySpy = vi
+				.fn()
+				.mockImplementation((args: { cursor?: { id: string }; skip?: number; take?: number }) => {
+					const take = args.take ?? existingItems.length;
+					if (!args.cursor) {
+						return Promise.resolve(existingItems.slice(0, take));
+					}
+					const cursorIdx = existingItems.findIndex((row) => row.id === args.cursor!.id);
+					const startIdx = cursorIdx === -1 ? 0 : cursorIdx + (args.skip ?? 0);
+					return Promise.resolve(existingItems.slice(startIdx, startIdx + take));
+				});
+			mockPrisma.libraryCache.findMany = findManySpy;
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.success).toBe(true);
+			// The 400 rows whose arrItemId falls outside the kept set must be deleted.
+			expect(result.itemsRemoved).toBe(TOTAL - KEPT);
+
+			// Cursor walk must have made >= 2 calls — proves the pagination loop
+			// actually advanced past batch 1 instead of degenerating to a single read.
+			expect(findManySpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+			// Second call must carry cursor + skip:1, matching the proven
+			// pattern from cleanup-executor.ts's prefetch helpers.
+			const secondCallArgs = findManySpy.mock.calls[1]?.[0] as
+				| { cursor?: { id: string }; skip?: number }
+				| undefined;
+			expect(secondCallArgs?.cursor).toBeDefined();
+			expect(secondCallArgs?.skip).toBe(1);
+
+			// The deleted ids must be EXACTLY the 400 stale rows — not a subset
+			// (would mean missed evictions / zombies) and not a superset
+			// (would mean live rows wrongly deleted).
+			const deleteCall = (mockPrisma.libraryCache.deleteMany as ReturnType<typeof vi.fn>).mock
+				.calls[0]?.[0];
+			const deletedIds = (deleteCall?.where?.id?.in ?? []) as string[];
+			expect(deletedIds).toHaveLength(TOTAL - KEPT);
+			// Stale rows are arrItemIds 201..600 → cache ids cache-0200..cache-0599.
+			expect(deletedIds).toContain("cache-0200");
+			expect(deletedIds).toContain("cache-0599");
+			// Kept rows must NOT appear in the deletion set.
+			expect(deletedIds).not.toContain("cache-0000");
+			expect(deletedIds).not.toContain("cache-0199");
+		});
 	});
 
 	// --- Memory instrumentation ---------------------------------------------
@@ -731,8 +803,7 @@ describe("syncInstance", () => {
 			const debugCalls = (log.debug as ReturnType<typeof vi.fn>).mock.calls;
 			const memCalls = debugCalls.filter(
 				(call: unknown[]) =>
-					typeof call[1] === "string" &&
-					(call[1] as string) === "Library sync memory usage",
+					typeof call[1] === "string" && (call[1] as string) === "Library sync memory usage",
 			);
 			expect(memCalls.length).toBeGreaterThanOrEqual(1);
 
@@ -751,8 +822,7 @@ describe("syncInstance", () => {
 			const debugCalls = (log.debug as ReturnType<typeof vi.fn>).mock.calls;
 			const memCalls = debugCalls.filter(
 				(call: unknown[]) =>
-					typeof call[1] === "string" &&
-					(call[1] as string) === "Library sync memory usage",
+					typeof call[1] === "string" && (call[1] as string) === "Library sync memory usage",
 			);
 			expect(memCalls.length).toBe(0);
 		});
@@ -865,8 +935,7 @@ describe("syncInstance", () => {
 			const debugCalls = (log.debug as ReturnType<typeof vi.fn>).mock.calls;
 			const memCalls = debugCalls.filter(
 				(call: unknown[]) =>
-					typeof call[1] === "string" &&
-					(call[1] as string) === "Library sync memory usage",
+					typeof call[1] === "string" && (call[1] as string) === "Library sync memory usage",
 			);
 			expect(memCalls.length).toBe(0);
 		});

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -284,23 +284,52 @@ export async function syncInstance(
 
 		// Only pull the `data` column for Sonarr/Radarr (tag-delta detection).
 		// Readarr/Lidarr skip it to avoid loading every cached JSON blob.
-		const existingItems = await prisma.libraryCache.findMany({
-			where: { instanceId: instance.id },
-			select: {
-				id: true,
-				arrItemId: true,
-				itemType: true,
-				hasFile: true,
-				...(tagDeltaService ? { data: true } : {}),
-			},
-		});
-
-		const existingMap = new Map(
-			existingItems.map((item) => [
-				`${item.arrItemId}-${item.itemType}`,
-				{ id: item.id, hasFile: item.hasFile, data: "data" in item ? (item.data as string | null) : null },
-			]),
-		);
+		//
+		// Cursor-paginate at SYNC_QUERY_BATCH_SIZE rows. The previous shape
+		// loaded every row at once; for a 100k Sonarr/Radarr library with
+		// the data JSON column included that easily exceeds the 768 MB
+		// container heap (issue #427). Used both for the existing-item map
+		// AND the deletion-id list at end of sync, so we collect the minimal
+		// fields for both passes here.
+		const SYNC_QUERY_BATCH_SIZE = 500;
+		const existingMap = new Map<string, { id: string; hasFile: boolean; data: string | null }>();
+		// Mirrors `existingItems` from the prior shape — the post-sync
+		// deletion pass at the bottom of this function reads
+		// (id, arrItemId, itemType) to compute the stale-row diff.
+		const existingForDeletion: Array<{ id: string; arrItemId: number; itemType: string }> = [];
+		{
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await prisma.libraryCache.findMany({
+					where: { instanceId: instance.id },
+					select: {
+						id: true,
+						arrItemId: true,
+						itemType: true,
+						hasFile: true,
+						...(tagDeltaService ? { data: true } : {}),
+					},
+					take: SYNC_QUERY_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const item of batch) {
+					existingMap.set(`${item.arrItemId}-${item.itemType}`, {
+						id: item.id,
+						hasFile: item.hasFile,
+						data: "data" in item ? ((item as { data: string | null }).data ?? null) : null,
+					});
+					existingForDeletion.push({
+						id: item.id,
+						arrItemId: item.arrItemId,
+						itemType: item.itemType,
+					});
+				}
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < SYNC_QUERY_BATCH_SIZE) break;
+			}
+		}
 
 		const tagIdToName = new Map<number, string>();
 		if (client instanceof SonarrClient || client instanceof RadarrClient) {
@@ -331,8 +360,7 @@ export async function syncInstance(
 			await prisma.$transaction(async (tx) => {
 				for (const raw of rawBatch) {
 					const item = buildLibraryItem(instance, service, raw);
-					const arrItemId =
-						typeof item.id === "string" ? Number.parseInt(item.id, 10) : item.id;
+					const arrItemId = typeof item.id === "string" ? Number.parseInt(item.id, 10) : item.id;
 					const key = `${arrItemId}-${item.type}`;
 					seenKeys.add(key);
 
@@ -365,10 +393,7 @@ export async function syncInstance(
 									tmdbId?: unknown;
 									remoteIds?: { tmdbId?: unknown } | null;
 								};
-								const tmdbCandidates: unknown[] = [
-									itemAny.remoteIds?.tmdbId,
-									itemAny.tmdbId,
-								];
+								const tmdbCandidates: unknown[] = [itemAny.remoteIds?.tmdbId, itemAny.tmdbId];
 								let tmdbId: number | null = null;
 								for (const v of tmdbCandidates) {
 									if (typeof v === "number" && v > 0) {
@@ -398,7 +423,7 @@ export async function syncInstance(
 
 		logMemoryPhase(log, instance.id, "after-batch-writes");
 
-		const idsToRemove = existingItems
+		const idsToRemove = existingForDeletion
 			.filter((item) => !seenKeys.has(`${item.arrItemId}-${item.itemType}`))
 			.map((item) => item.id);
 

--- a/apps/api/src/lib/library/validation-schemas.ts
+++ b/apps/api/src/lib/library/validation-schemas.ts
@@ -11,9 +11,14 @@ export const libraryQuerySchema = z.object({
 	instanceId: z.string().optional(),
 
 	// Pagination
-	// Note: limit=0 means "fetch all" for internal use cases like discover filtering
+	// Note: limit must be >= 1. Earlier revisions allowed `limit=0` as a
+	// "fetch all" affordance for an internal discover-filtering hook
+	// (`useLibraryForFiltering`). That hook is no longer used and the
+	// fetch-all path mass-loads every LibraryCache row's data JSON blob —
+	// trivially OOMs the 768 MB container heap on a 50k+ item library
+	// (issue #427 follow-up). Reject the request instead.
 	page: z.coerce.number().int().min(1).default(1),
-	limit: z.coerce.number().int().min(0).max(10000).default(50),
+	limit: z.coerce.number().int().min(1).max(10000).default(50),
 
 	// Search
 	search: z.string().optional(),
@@ -31,4 +36,3 @@ export const libraryQuerySchema = z.object({
 	sortBy: z.enum(["title", "sortTitle", "year", "sizeOnDisk", "added"]).default("sortTitle"),
 	sortOrder: z.enum(["asc", "desc"]).default("asc"),
 });
-

--- a/apps/api/src/lib/notifications/insights-digest.ts
+++ b/apps/api/src/lib/notifications/insights-digest.ts
@@ -23,6 +23,12 @@ const MIN_AGE_DAYS = 7; // Only consider items available for 7+ days
 
 const MIN_WATCH_COUNT = 1; // Minimum plays to qualify for watched-monitored signal
 
+// Cursor-paginate the plexCache scans (issue #427 follow-up). Per-row
+// footprint is small (3 scalar columns) but for a 100k-item Plex library
+// the unbounded findMany still allocates several MB of Prisma row objects
+// on every digest tick, on top of the user's normal request load.
+const PLEX_QUERY_BATCH_SIZE = 1000;
+
 export class InsightsDigestScheduler {
 	private intervalId: NodeJS.Timeout | null = null;
 	private lastNotifiedRequestedUnwatched: number = 0;
@@ -160,14 +166,27 @@ export class InsightsDigestScheduler {
 		});
 		if (plexInstances.length === 0) return [];
 
+		// Cursor-paginate plexCache to bound peak heap (issue #427).
 		const plexWatchCounts = new Map<string, number>();
-		const plexRows = await this.prisma.plexCache.findMany({
-			where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-			select: { tmdbId: true, mediaType: true, watchCount: true },
-		});
-		for (const row of plexRows) {
-			const key = `${row.mediaType}:${row.tmdbId}`;
-			plexWatchCounts.set(key, (plexWatchCounts.get(key) ?? 0) + row.watchCount);
+		{
+			const plexInstanceIds = plexInstances.map((i) => i.id);
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await this.prisma.plexCache.findMany({
+					where: { instanceId: { in: plexInstanceIds } },
+					select: { id: true, tmdbId: true, mediaType: true, watchCount: true },
+					take: PLEX_QUERY_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					const key = `${row.mediaType}:${row.tmdbId}`;
+					plexWatchCounts.set(key, (plexWatchCounts.get(key) ?? 0) + row.watchCount);
+				}
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < PLEX_QUERY_BATCH_SIZE) break;
+			}
 		}
 
 		// Fetch available Seerr requests
@@ -261,18 +280,31 @@ export class InsightsDigestScheduler {
 		});
 		if (plexInstances.length === 0) return [];
 
+		// Cursor-paginate plexCache (issue #427).
 		const plexWatchData = new Map<string, { watchCount: number }>();
-		const plexRows = await this.prisma.plexCache.findMany({
-			where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-			select: { tmdbId: true, mediaType: true, watchCount: true },
-		});
-		for (const row of plexRows) {
-			const key = `${row.mediaType}:${row.tmdbId}`;
-			const existing = plexWatchData.get(key);
-			if (existing) {
-				existing.watchCount += row.watchCount;
-			} else {
-				plexWatchData.set(key, { watchCount: row.watchCount });
+		{
+			const plexInstanceIds = plexInstances.map((i) => i.id);
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await this.prisma.plexCache.findMany({
+					where: { instanceId: { in: plexInstanceIds } },
+					select: { id: true, tmdbId: true, mediaType: true, watchCount: true },
+					take: PLEX_QUERY_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					const key = `${row.mediaType}:${row.tmdbId}`;
+					const existing = plexWatchData.get(key);
+					if (existing) {
+						existing.watchCount += row.watchCount;
+					} else {
+						plexWatchData.set(key, { watchCount: row.watchCount });
+					}
+				}
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < PLEX_QUERY_BATCH_SIZE) break;
 			}
 		}
 

--- a/apps/api/src/plugins/heap-monitor.ts
+++ b/apps/api/src/plugins/heap-monitor.ts
@@ -1,0 +1,138 @@
+/**
+ * Heap Monitor Plugin
+ *
+ * Periodically logs `process.memoryUsage()` so operators can spot rising
+ * heap baselines BEFORE the container hits its `--max-old-space-size` cap
+ * and OOMs. Each sample includes deltas vs. the previous sample so a slow
+ * leak shows up as monotonic growth even when individual samples look
+ * reasonable.
+ *
+ * Added in v2.18.5 as the verification half of the issue #427 fix series:
+ * the static-analysis sweep capped most known transient peaks, but the
+ * 766 MB *live* heap reported in the most recent OOM trace pointed at
+ * possible persistent retention that's hard to pin without runtime data.
+ * This plugin is that runtime data.
+ *
+ * What gets logged:
+ *   - heapUsedMB / heapTotalMB / heapPct       — V8 heap pressure
+ *   - rssMB                                     — total RSS the kernel sees
+ *   - externalMB / arrayBuffersMB              — Buffer / native allocations
+ *   - heapDeltaMB / rssDeltaMB                 — change since last sample
+ *   - secondsSinceLast / uptimeSec             — temporal context
+ *
+ * Severity:
+ *   - heapPct > 0.9 → `warn` (visible in default log levels — operator alert)
+ *   - heapPct > 0.8 → `info`
+ *   - else          → `debug`
+ *
+ * Companion runtime knobs:
+ *   - `--heapsnapshot-signal=SIGUSR2`  Always on (set in Dockerfile
+ *     NODE_OPTIONS). An operator who sees heap climbing in these logs can
+ *     capture a snapshot on demand:
+ *       docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
+ *     Snapshots land on /config/heap-snapshots/.
+ *
+ *   - `HEAP_AUTO_SNAPSHOT=1` env var  OPT-IN. When set, start-combined.sh
+ *     appends --heapsnapshot-near-heap-limit=1 so V8 auto-captures a
+ *     snapshot just before OOM. Off by default because each snapshot is ~3x
+ *     the heap (~2.3 GB at the 768 MB cap) — a lot for small /config volumes.
+ *     Set it in your compose / Unraid template alongside the other env vars.
+ */
+
+import type { FastifyInstance } from "fastify";
+import fastifyPlugin from "fastify-plugin";
+
+const SAMPLE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes — enough resolution to spot leaks, light on log volume.
+const WARN_HEAP_PCT = 0.9;
+const INFO_HEAP_PCT = 0.8;
+
+interface MemorySample {
+	heapUsedMB: number;
+	heapTotalMB: number;
+	rssMB: number;
+	externalMB: number;
+	arrayBuffersMB: number;
+	heapPct: number;
+	timestamp: number;
+}
+
+const heapMonitorPlugin = fastifyPlugin(
+	async (app: FastifyInstance) => {
+		let intervalHandle: ReturnType<typeof setInterval> | null = null;
+		let lastSample: MemorySample | null = null;
+
+		const sample = (): void => {
+			const m = process.memoryUsage();
+			const heapUsedMB = Math.round(m.heapUsed / 1024 / 1024);
+			const heapTotalMB = Math.round(m.heapTotal / 1024 / 1024);
+			const rssMB = Math.round(m.rss / 1024 / 1024);
+			const externalMB = Math.round(m.external / 1024 / 1024);
+			const arrayBuffersMB = Math.round((m.arrayBuffers ?? 0) / 1024 / 1024);
+			const now = Date.now();
+			// `heapPct` is heap-used relative to the V8-allocated heap, not the
+			// `--max-old-space-size` cap. It still tracks pressure: V8 grows
+			// heapTotal toward the cap, so heapPct climbing toward 1.0 means
+			// V8 is squeezing the live set into all the space it has left.
+			const heapPct = heapTotalMB > 0 ? heapUsedMB / heapTotalMB : 0;
+
+			const payload: Record<string, number | undefined> = {
+				heapUsedMB,
+				heapTotalMB,
+				rssMB,
+				externalMB,
+				arrayBuffersMB,
+				heapPct: Math.round(heapPct * 100) / 100,
+				uptimeSec: Math.round(process.uptime()),
+			};
+
+			if (lastSample) {
+				payload.heapDeltaMB = heapUsedMB - lastSample.heapUsedMB;
+				payload.rssDeltaMB = rssMB - lastSample.rssMB;
+				payload.secondsSinceLast = Math.round((now - lastSample.timestamp) / 1000);
+			}
+
+			lastSample = {
+				heapUsedMB,
+				heapTotalMB,
+				rssMB,
+				externalMB,
+				arrayBuffersMB,
+				heapPct,
+				timestamp: now,
+			};
+
+			if (heapPct >= WARN_HEAP_PCT) {
+				app.log.warn(
+					payload,
+					"Heap usage above 90% — capture a snapshot before OOM: docker exec <container> sh -c 'kill -USR2 $(pgrep -f \"node /app/api/dist/index.js\")'",
+				);
+			} else if (heapPct >= INFO_HEAP_PCT) {
+				app.log.info(payload, "Heap usage above 80%");
+			} else {
+				app.log.debug(payload, "Heap usage sample");
+			}
+		};
+
+		app.addHook("onReady", async () => {
+			// Log one sample at startup so we have a baseline anchor for deltas.
+			sample();
+			intervalHandle = setInterval(sample, SAMPLE_INTERVAL_MS);
+			// Don't pin the event loop open during shutdown.
+			intervalHandle.unref();
+			app.log.info(
+				{ intervalMs: SAMPLE_INTERVAL_MS },
+				"Heap monitor started — periodic memoryUsage samples enabled",
+			);
+		});
+
+		app.addHook("onClose", async () => {
+			if (intervalHandle) {
+				clearInterval(intervalHandle);
+				intervalHandle = null;
+			}
+		});
+	},
+	{ name: "heap-monitor" },
+);
+
+export default heapMonitorPlugin;

--- a/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Cursor-pagination behavior for `GET /api/library-cleanup/field-options`
+ * (issue #427 follow-up).
+ *
+ * Pins the v2.18.4 OOM fix: the field-options endpoint must walk
+ * `libraryCache`, `tautulliCache`, `plexCache`, and `jellyfinCache` via
+ * cursor pagination at FIELD_OPTIONS_BATCH_SIZE = 500. The previous
+ * shape ran a single unbounded `findMany` per cache type, which
+ * for a 50k+ Sonarr-heavy library trivially OOMs the 768 MB container
+ * heap when the `data` JSON blob is loaded for every row.
+ *
+ * Specifically pinned:
+ *   - libraryCache walk advances cursor across multiple batches and
+ *     aggregates videoCodec values from BOTH batches.
+ *   - plexCache walk is a SINGLE merged pass (not three) and aggregates
+ *     users + libraries + collections + labels in one cursor loop.
+ *   - Loop terminates on a short batch without an extra round-trip.
+ */
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+// Unique user per test — the route caches field options per-user for 5
+// minutes via a module-level Map. Without a unique id, test 2 + 3 see the
+// cached response from test 1 and the prisma mocks are never invoked.
+const counter = { value: 0 };
+const SONARR_INSTANCE_ID = "sonarr-1";
+const PLEX_INSTANCE_ID = "plex-1";
+
+function makeLibraryRow(id: string, videoCodec: string) {
+	return {
+		id,
+		data: JSON.stringify({
+			episodeFile: { videoCodec, audioCodec: "AC3", resolution: "1080p" },
+		}),
+	};
+}
+
+function makePlexRow(
+	id: string,
+	overrides: {
+		sectionTitle?: string;
+		watchedByUsers?: string[];
+		collections?: string[];
+		labels?: string[];
+	} = {},
+) {
+	return {
+		id,
+		sectionTitle: overrides.sectionTitle ?? "Movies",
+		watchedByUsers: JSON.stringify(overrides.watchedByUsers ?? []),
+		collections: JSON.stringify(overrides.collections ?? []),
+		labels: JSON.stringify(overrides.labels ?? []),
+	};
+}
+
+let app: FastifyInstance;
+let libraryCacheFindMany: ReturnType<typeof vi.fn>;
+let plexCacheFindMany: ReturnType<typeof vi.fn>;
+let jellyfinCacheFindMany: ReturnType<typeof vi.fn>;
+let tautulliCacheFindMany: ReturnType<typeof vi.fn>;
+let serviceInstanceFindMany: ReturnType<typeof vi.fn>;
+
+beforeEach(async () => {
+	counter.value += 1;
+	const userId = `user-${counter.value}`;
+	// Default to empty arrays so blocks tests don't exercise stay quiet —
+	// each test overrides only the cache it cares about.
+	libraryCacheFindMany = vi.fn().mockResolvedValue([]);
+	plexCacheFindMany = vi.fn().mockResolvedValue([]);
+	jellyfinCacheFindMany = vi.fn().mockResolvedValue([]);
+	tautulliCacheFindMany = vi.fn().mockResolvedValue([]);
+	serviceInstanceFindMany = vi.fn().mockResolvedValue([]);
+
+	app = Fastify({ logger: false });
+	setupAuthInjection(app, { id: userId, username: "admin" });
+	// Surface route errors as 500s — without this, Fastify's default reply
+	// is a 200 with a serialization error in the body, which is harder to
+	// debug when a test fixture is wrong.
+	app.setErrorHandler((error: Error, _request, reply) =>
+		reply.status(500).send({ error: error.message }),
+	);
+
+	app.decorate("prisma", {
+		serviceInstance: { findMany: serviceInstanceFindMany },
+		libraryCache: { findMany: libraryCacheFindMany },
+		plexCache: { findMany: plexCacheFindMany },
+		jellyfinCache: { findMany: jellyfinCacheFindMany },
+		tautulliCache: { findMany: tautulliCacheFindMany },
+	} as never);
+
+	// ARR client factory — returns a stub whose tag.getAll() yields nothing.
+	// The field-options route fans out to each Sonarr/Radarr instance for
+	// tags but failures are non-fatal, so we keep the stub minimal.
+	app.decorate("arrClientFactory", {
+		createAnyClient: () => ({ tag: { getAll: vi.fn().mockResolvedValue([]) } }),
+	} as never);
+
+	await app.register(registerLibraryCleanupRoutes);
+	await app.ready();
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("GET /library-cleanup/field-options — cursor pagination (issue #427)", () => {
+	it("walks libraryCache via cursor across multiple batches and aggregates values from BOTH", async () => {
+		// One Sonarr instance — only the libraryCache scan kicks in. The
+		// other cache scans are gated behind their own `findMany` for
+		// service instances (tautulli / plex / jellyfin) which we leave
+		// at their default empty mock.
+		serviceInstanceFindMany.mockImplementation(({ where }: { where: { service: unknown } }) => {
+			const svc = where.service;
+			if (
+				typeof svc === "object" &&
+				svc &&
+				"in" in svc &&
+				Array.isArray((svc as { in: unknown[] }).in) &&
+				(svc as { in: string[] }).in.includes("SONARR")
+			) {
+				return Promise.resolve([
+					{
+						id: SONARR_INSTANCE_ID,
+						baseUrl: "http://sonarr",
+						encryptedApiKey: "x",
+						encryptionIv: "x",
+						service: "SONARR",
+						label: "Sonarr",
+					},
+				]);
+			}
+			return Promise.resolve([]);
+		});
+
+		// Batch 1: 500 rows ending in id=lc-499 with videoCodec=h264
+		const batch1 = Array.from({ length: 499 }, (_, i) => makeLibraryRow(`lc-${i}`, "h264"));
+		batch1.push(makeLibraryRow("lc-499", "h264"));
+		// Batch 2: 1 row with a NEW codec (proves cross-batch aggregation)
+		const batch2 = [makeLibraryRow("lc-500", "hevc")];
+
+		libraryCacheFindMany.mockResolvedValueOnce(batch1).mockResolvedValueOnce(batch2);
+
+		const inject = createInjectAuthenticated(app);
+		const res = await inject("GET", "/library-cleanup/field-options");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		expect(body.videoCodecs).toEqual(expect.arrayContaining(["h264", "hevc"]));
+		expect(body.videoCodecs).toHaveLength(2);
+
+		// Two findMany calls — pagination must have continued past batch 1.
+		expect(libraryCacheFindMany).toHaveBeenCalledTimes(2);
+
+		// First call has no cursor.
+		const firstCallArg = libraryCacheFindMany.mock.calls[0]?.[0];
+		expect(firstCallArg).toMatchObject({
+			where: { instanceId: { in: [SONARR_INSTANCE_ID] } },
+			take: 500,
+			orderBy: { id: "asc" },
+		});
+		expect(firstCallArg?.cursor).toBeUndefined();
+
+		// Second call advances past the last id of batch 1.
+		const secondCallArg = libraryCacheFindMany.mock.calls[1]?.[0];
+		expect(secondCallArg?.cursor).toEqual({ id: "lc-499" });
+		expect(secondCallArg?.skip).toBe(1);
+	});
+
+	it("terminates after a short batch without an extra findMany call", async () => {
+		serviceInstanceFindMany.mockImplementation(({ where }: { where: { service: unknown } }) => {
+			const svc = where.service;
+			if (
+				typeof svc === "object" &&
+				svc &&
+				"in" in svc &&
+				Array.isArray((svc as { in: unknown[] }).in) &&
+				(svc as { in: string[] }).in.includes("SONARR")
+			) {
+				return Promise.resolve([
+					{
+						id: SONARR_INSTANCE_ID,
+						baseUrl: "http://sonarr",
+						encryptedApiKey: "x",
+						encryptionIv: "x",
+						service: "SONARR",
+						label: "Sonarr",
+					},
+				]);
+			}
+			return Promise.resolve([]);
+		});
+		libraryCacheFindMany.mockResolvedValueOnce([makeLibraryRow("lc-1", "h264")]);
+
+		const inject = createInjectAuthenticated(app);
+		const res = await inject("GET", "/library-cleanup/field-options");
+		expect(res.statusCode).toBe(200);
+
+		// Only ONE call — short batch terminated the loop. The previous
+		// (unbounded) shape made one call too; the proof here is no second
+		// fetch when batch size < FIELD_OPTIONS_BATCH_SIZE.
+		expect(libraryCacheFindMany).toHaveBeenCalledTimes(1);
+	});
+
+	it("aggregates Plex users / libraries / collections / labels in a SINGLE merged cursor walk", async () => {
+		// Sonarr/Radarr empty so libraryCache loop is skipped; tautulli/jellyfin empty too.
+		serviceInstanceFindMany.mockImplementation(({ where }: { where: { service: unknown } }) => {
+			const svc = where.service;
+			if (svc === "PLEX") {
+				return Promise.resolve([{ id: PLEX_INSTANCE_ID }]);
+			}
+			return Promise.resolve([]);
+		});
+
+		// Two batches of plexCache rows. The fix collapses three formerly-
+		// separate full-table scans into ONE cursor walk; verify only one
+		// scan happens AND that it aggregates all four field types. To
+		// trigger the second fetch, batch 1 must hit the page-size cap
+		// (FIELD_OPTIONS_BATCH_SIZE=500); batch 2 carries the new values
+		// that the cross-batch aggregation must pick up.
+		const plexBatch1 = Array.from({ length: 499 }, (_, i) =>
+			makePlexRow(`pc-${i}`, {
+				sectionTitle: "Movies",
+				watchedByUsers: ["alice"],
+				collections: ["Marvel"],
+				labels: ["fav"],
+			}),
+		);
+		plexBatch1.push(
+			makePlexRow("pc-499", {
+				sectionTitle: "Movies",
+				watchedByUsers: ["alice"],
+				collections: ["Marvel"],
+				labels: ["fav"],
+			}),
+		);
+		const plexBatch2 = [
+			makePlexRow("pc-500", {
+				sectionTitle: "TV Shows",
+				watchedByUsers: ["bob"],
+				collections: ["Sci-Fi"],
+				labels: ["new"],
+			}),
+		];
+		plexCacheFindMany.mockResolvedValueOnce(plexBatch1).mockResolvedValueOnce(plexBatch2);
+
+		const inject = createInjectAuthenticated(app);
+		const res = await inject("GET", "/library-cleanup/field-options");
+		expect(res.statusCode).toBe(200);
+
+		const body = JSON.parse(res.payload);
+		expect(body.plexUsers).toEqual(expect.arrayContaining(["alice", "bob"]));
+		expect(body.plexLibraries).toEqual(expect.arrayContaining(["Movies", "TV Shows"]));
+		expect(body.plexCollections).toEqual(expect.arrayContaining(["Marvel", "Sci-Fi"]));
+		expect(body.plexLabels).toEqual(expect.arrayContaining(["fav", "new"]));
+
+		// CRITICAL: the merge means the same plex rows are scanned ONCE
+		// per batch, not three times (users + libraries + collections/labels
+		// previously each ran their own full-table scan). Two batches → 2
+		// findMany calls total, NOT 6.
+		expect(plexCacheFindMany).toHaveBeenCalledTimes(2);
+
+		// Single merged select must include all four columns at once.
+		const selectArg = plexCacheFindMany.mock.calls[0]?.[0]?.select;
+		expect(selectArg).toMatchObject({
+			id: true,
+			sectionTitle: true,
+			watchedByUsers: true,
+			collections: true,
+			labels: true,
+		});
+	});
+});

--- a/apps/api/src/routes/dashboard/calendar-routes.ts
+++ b/apps/api/src/routes/dashboard/calendar-routes.ts
@@ -1,4 +1,4 @@
-import { LIBRARY_SERVICES_UPPER, calendarItemSchema } from "@arr/shared";
+import { calendarItemSchema, LIBRARY_SERVICES_UPPER } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import {
@@ -20,10 +20,9 @@ import { validateAndCollect } from "../../lib/validation/validate-batch.js";
 const calendarQuerySchema = z.object({
 	start: z.string().optional(),
 	end: z.string().optional(),
-	unmonitored: z.preprocess(
-		(val) => val === true || val === "true" || val === "1",
-		z.boolean(),
-	).optional(),
+	unmonitored: z
+		.preprocess((val) => val === true || val === "true" || val === "1", z.boolean())
+		.optional(),
 });
 
 /**
@@ -99,12 +98,23 @@ export const calendarRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					});
 				}
 
-				// Normalize and enrich items, then validate in tolerant mode
-				const normalized = rawItems.map((raw) => ({
-					...normalizeCalendarItem(raw, service),
-					instanceId: instance.id,
-					instanceName: instance.label,
-				}));
+				// Reduce peak heap (issue #427 follow-up). Sonarr's calendar
+				// payload with includeSeries+includeEpisodeFile inlines full
+				// series metadata + episode files per item — easily 5–10 KB
+				// per row. Drop each raw entry as soon as it's normalized so
+				// only one copy of the data is alive at a time, instead of
+				// raw + normalized for the duration of the closure.
+				const normalized: ReturnType<typeof normalizeCalendarItem>[] = [];
+				for (let i = 0; i < rawItems.length; i++) {
+					normalized.push({
+						...normalizeCalendarItem(rawItems[i], service),
+						instanceId: instance.id,
+						instanceName: instance.label,
+					});
+					rawItems[i] = null;
+				}
+				rawItems = [];
+
 				const { items } = validateAndCollect(
 					normalized,
 					calendarItemSchema,

--- a/apps/api/src/routes/dashboard/history-routes.ts
+++ b/apps/api/src/routes/dashboard/history-routes.ts
@@ -101,12 +101,22 @@ export const historyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					totalRecords = result.totalRecords ?? rawRecords.length;
 				}
 
-				// Normalize and enrich items, then validate in tolerant mode
-				const normalized = rawRecords.map((raw) => ({
-					...normalizeHistoryItem(raw, service),
-					instanceId: instance.id,
-					instanceName: instance.label,
-				}));
+				// Reduce peak heap (issue #427 follow-up). With recordLimit=2500
+				// per instance × N enabled instances, the parallel fan-out inside
+				// executeOnInstances can hold all raw history payloads (each
+				// 1–2 KB) AND their normalized copies simultaneously. Drop each
+				// raw entry as it's normalized so only one copy is alive at a time.
+				const normalized: ReturnType<typeof normalizeHistoryItem>[] = [];
+				for (let i = 0; i < rawRecords.length; i++) {
+					normalized.push({
+						...normalizeHistoryItem(rawRecords[i], service),
+						instanceId: instance.id,
+						instanceName: instance.label,
+					});
+					rawRecords[i] = null;
+				}
+				rawRecords = [];
+
 				const { items } = validateAndCollect(
 					normalized,
 					historyItemSchema,

--- a/apps/api/src/routes/jellyfin/analytics-routes.ts
+++ b/apps/api/src/routes/jellyfin/analytics-routes.ts
@@ -162,7 +162,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =
@@ -243,7 +243,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =
@@ -280,7 +280,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =
@@ -318,7 +318,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =
@@ -445,7 +445,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateTopMedia(
@@ -480,7 +480,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregatePopularMedia(
@@ -517,11 +517,15 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 		}
 
 		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		// `last-watched` is a "most recent activity" feed — when the take cap is
+		// hit (heavy users with >20k snapshots in the cutoff window), `asc` would
+		// silently drop the recent rows the panel exists to surface. Match the
+		// `desc` pattern used by the history endpoint above.
 		const snapshots = await app.prisma.sessionSnapshot.findMany({
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
-			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			orderBy: { capturedAt: "desc" },
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateLastWatched(
@@ -614,7 +618,7 @@ export async function registerAnalyticsRoutes(app: FastifyInstance, _opts: Fasti
 			where: { instanceId: { in: instances.map((i) => i.id) }, capturedAt: { gte: cutoff } },
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		return reply.send(aggregatePlaysByDate(snapshots, { days }));

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -171,7 +171,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		});
 		const instanceIds = instances.map((i) => i.id);
 
-		// Extract distinct file metadata from library cache
+		// Extract distinct file metadata from library cache.
+		//
+		// Cursor-paginate the LibraryCache.data scan to bound peak heap.
+		// A naive `findMany({ select: { data: true } })` over the full table
+		// loads every JSON blob into memory at once — for a Sonarr-heavy
+		// library with full series payloads, that easily peaks past the
+		// 768 MB container cap (issue #427 follow-up). Same pattern PR #435
+		// applied to prefetchPlexData / prefetchJellyfinData / prefetchTautulliData.
+		const FIELD_OPTIONS_BATCH_SIZE = 500;
 		const videoCodecs = new Set<string>();
 		const audioCodecs = new Set<string>();
 		const resolutions = new Set<string>();
@@ -179,113 +187,124 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const releaseGroups = new Set<string>();
 
 		if (instanceIds.length > 0) {
-			const cacheItems = await app.prisma.libraryCache.findMany({
-				where: { instanceId: { in: instanceIds } },
-				select: { data: true },
-			});
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.libraryCache.findMany({
+					where: { instanceId: { in: instanceIds } },
+					select: { id: true, data: true },
+					take: FIELD_OPTIONS_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
 
-			for (const item of cacheItems) {
-				const parsed = safeJsonParse(item.data);
-				if (!parsed) continue;
-				const data = parsed as Record<string, unknown>;
+				if (batch.length === 0) break;
 
-				// Try movieFile (Radarr) then episodeFile (Sonarr)
-				const fileObj = (data.movieFile ?? data.episodeFile) as Record<string, unknown> | undefined;
-				if (!fileObj || typeof fileObj !== "object") continue;
+				for (const item of batch) {
+					const parsed = safeJsonParse(item.data);
+					if (!parsed) continue;
+					const data = parsed as Record<string, unknown>;
 
-				if (typeof fileObj.videoCodec === "string" && fileObj.videoCodec)
-					videoCodecs.add(fileObj.videoCodec);
-				if (typeof fileObj.audioCodec === "string" && fileObj.audioCodec)
-					audioCodecs.add(fileObj.audioCodec);
-				if (typeof fileObj.resolution === "string" && fileObj.resolution)
-					resolutions.add(fileObj.resolution);
-				if (typeof fileObj.videoDynamicRange === "string" && fileObj.videoDynamicRange)
-					hdrTypes.add(fileObj.videoDynamicRange);
-				if (typeof fileObj.releaseGroup === "string" && fileObj.releaseGroup)
-					releaseGroups.add(fileObj.releaseGroup);
+					// Try movieFile (Radarr) then episodeFile (Sonarr)
+					const fileObj = (data.movieFile ?? data.episodeFile) as
+						| Record<string, unknown>
+						| undefined;
+					if (!fileObj || typeof fileObj !== "object") continue;
+
+					if (typeof fileObj.videoCodec === "string" && fileObj.videoCodec)
+						videoCodecs.add(fileObj.videoCodec);
+					if (typeof fileObj.audioCodec === "string" && fileObj.audioCodec)
+						audioCodecs.add(fileObj.audioCodec);
+					if (typeof fileObj.resolution === "string" && fileObj.resolution)
+						resolutions.add(fileObj.resolution);
+					if (typeof fileObj.videoDynamicRange === "string" && fileObj.videoDynamicRange)
+						hdrTypes.add(fileObj.videoDynamicRange);
+					if (typeof fileObj.releaseGroup === "string" && fileObj.releaseGroup)
+						releaseGroups.add(fileObj.releaseGroup);
+				}
+
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < FIELD_OPTIONS_BATCH_SIZE) break;
 			}
 		}
 
-		// Extract distinct Tautulli users (from Tautulli instances owned by the user)
+		// All cache-table scans below cursor-paginate (issue #427 follow-up).
+		// Watch-cache rows are small per-row but a 50k+ Plex/Jellyfin library
+		// loaded in one shot still allocates tens of MB before GC, and the
+		// previous shape ran 3 separate full-table scans of plexCache. Single
+		// merged cursor walk per cache type instead.
+		const collectStrings = (raw: string | null | undefined, sink: Set<string>): void => {
+			const parsed = safeJsonParse(raw);
+			if (!Array.isArray(parsed)) return;
+			for (const v of parsed) {
+				if (typeof v === "string" && v) sink.add(v);
+			}
+		};
+
+		// Extract distinct Tautulli users (cursor-paginated)
 		const tautulliUsers = new Set<string>();
 		const tautulliInstances = await app.prisma.serviceInstance.findMany({
 			where: { userId, service: "TAUTULLI" },
 			select: { id: true },
 		});
 		if (tautulliInstances.length > 0) {
-			const tautulliRows = await app.prisma.tautulliCache.findMany({
-				where: { instanceId: { in: tautulliInstances.map((i) => i.id) } },
-				select: { watchedByUsers: true },
-			});
-			for (const row of tautulliRows) {
-				const users = safeJsonParse(row.watchedByUsers);
-				if (Array.isArray(users)) {
-					for (const u of users) {
-						if (typeof u === "string" && u) tautulliUsers.add(u);
-					}
-				}
+			const tautulliInstanceIds = tautulliInstances.map((i) => i.id);
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.tautulliCache.findMany({
+					where: { instanceId: { in: tautulliInstanceIds } },
+					select: { id: true, watchedByUsers: true },
+					take: FIELD_OPTIONS_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) collectStrings(row.watchedByUsers, tautulliUsers);
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < FIELD_OPTIONS_BATCH_SIZE) break;
 			}
 		}
 
-		// Extract distinct Plex users (from Plex instances owned by the user)
+		// Extract distinct Plex users / libraries / collections / labels in
+		// ONE cursor-paginated scan. The previous shape did three separate
+		// full-table scans of plexCache for the same instance set.
 		const plexUsers = new Set<string>();
+		const plexLibraries = new Set<string>();
+		const plexCollections = new Set<string>();
+		const plexLabels = new Set<string>();
 		const plexInstances = await app.prisma.serviceInstance.findMany({
 			where: { userId, service: "PLEX" },
 			select: { id: true },
 		});
 		if (plexInstances.length > 0) {
-			const plexRows = await app.prisma.plexCache.findMany({
-				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-				select: { watchedByUsers: true },
-			});
-			for (const row of plexRows) {
-				const users = safeJsonParse(row.watchedByUsers);
-				if (Array.isArray(users)) {
-					for (const u of users) {
-						if (typeof u === "string" && u) plexUsers.add(u);
-					}
+			const plexInstanceIds = plexInstances.map((i) => i.id);
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.plexCache.findMany({
+					where: { instanceId: { in: plexInstanceIds } },
+					select: {
+						id: true,
+						sectionTitle: true,
+						watchedByUsers: true,
+						collections: true,
+						labels: true,
+					},
+					take: FIELD_OPTIONS_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					if (row.sectionTitle) plexLibraries.add(row.sectionTitle);
+					collectStrings(row.watchedByUsers, plexUsers);
+					collectStrings(row.collections, plexCollections);
+					collectStrings(row.labels, plexLabels);
 				}
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < FIELD_OPTIONS_BATCH_SIZE) break;
 			}
 		}
 
-		// Extract distinct Plex library names
-		const plexLibraries = new Set<string>();
-		if (plexInstances.length > 0) {
-			const sections = await app.prisma.plexCache.findMany({
-				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-				select: { sectionTitle: true },
-				distinct: ["sectionTitle"],
-			});
-			for (const s of sections) {
-				if (s.sectionTitle) plexLibraries.add(s.sectionTitle);
-			}
-		}
-
-		// Extract distinct Plex collections and labels
-		const plexCollections = new Set<string>();
-		const plexLabels = new Set<string>();
-		if (plexInstances.length > 0) {
-			const plexMetaRows = await app.prisma.plexCache.findMany({
-				where: { instanceId: { in: plexInstances.map((i) => i.id) } },
-				select: { collections: true, labels: true },
-			});
-			for (const row of plexMetaRows) {
-				const cols = safeJsonParse(row.collections);
-				if (Array.isArray(cols)) {
-					for (const c of cols) {
-						if (typeof c === "string" && c) plexCollections.add(c);
-					}
-				}
-				const lbls = safeJsonParse(row.labels);
-				if (Array.isArray(lbls)) {
-					for (const l of lbls) {
-						if (typeof l === "string" && l) plexLabels.add(l);
-					}
-				}
-			}
-		}
-
-		// Extract distinct Jellyfin users and libraries
+		// Extract distinct Jellyfin users + libraries (cursor-paginated)
 		const jellyfinUsers = new Set<string>();
 		const jellyfinLibraries = new Set<string>();
 		const jellyfinInstances = await app.prisma.serviceInstance.findMany({
@@ -293,18 +312,23 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			select: { id: true },
 		});
 		if (jellyfinInstances.length > 0) {
-			const jfRows = await app.prisma.jellyfinCache.findMany({
-				where: { instanceId: { in: jellyfinInstances.map((i) => i.id) } },
-				select: { watchedByUsers: true, libraryName: true },
-			});
-			for (const row of jfRows) {
-				if (row.libraryName) jellyfinLibraries.add(row.libraryName);
-				const users = safeJsonParse(row.watchedByUsers);
-				if (Array.isArray(users)) {
-					for (const u of users) {
-						if (typeof u === "string" && u) jellyfinUsers.add(u);
-					}
+			const jellyfinInstanceIds = jellyfinInstances.map((i) => i.id);
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.jellyfinCache.findMany({
+					where: { instanceId: { in: jellyfinInstanceIds } },
+					select: { id: true, watchedByUsers: true, libraryName: true },
+					take: FIELD_OPTIONS_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					if (row.libraryName) jellyfinLibraries.add(row.libraryName);
+					collectStrings(row.watchedByUsers, jellyfinUsers);
 				}
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < FIELD_OPTIONS_BATCH_SIZE) break;
 			}
 		}
 

--- a/apps/api/src/routes/library/fetch-routes.ts
+++ b/apps/api/src/routes/library/fetch-routes.ts
@@ -35,8 +35,8 @@ import { buildMovieFile } from "../../lib/library/movie-normalizer.js";
 import { normalizeTrack } from "../../lib/library/track-normalizer.js";
 import { libraryQuerySchema } from "../../lib/library/validation-schemas.js";
 import { getLibrarySyncScheduler } from "../../lib/library-sync/index.js";
-import { validateRequest } from "../../lib/utils/validate.js";
 import { Prisma, type LibraryItemType as PrismaLibraryItemType } from "../../lib/prisma.js";
+import { validateRequest } from "../../lib/utils/validate.js";
 
 /**
  * Register data fetching routes for library
@@ -236,17 +236,14 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 				orderBy.sortTitle = "asc";
 		}
 
-		// Fetch items (limit=0 means fetch all for internal use like discover filtering)
-		const fetchAll = parsed.limit === 0;
+		// Schema enforces `limit >= 1`; an earlier `limit=0` "fetch all" path
+		// existed for an internal hook that has since been removed (issue #427
+		// follow-up — the unbounded read trivially OOM'd big libraries).
 		const cachedItems = await app.prisma.libraryCache.findMany({
 			where,
 			orderBy,
-			...(fetchAll
-				? {}
-				: {
-						skip: (parsed.page - 1) * parsed.limit,
-						take: parsed.limit,
-					}),
+			skip: (parsed.page - 1) * parsed.limit,
+			take: parsed.limit,
 		});
 
 		// Parse JSON data back to LibraryItem, injecting cache-only fields
@@ -308,10 +305,10 @@ export const registerFetchRoutes: FastifyPluginCallback = (app, _opts, done) => 
 		const response: PaginatedLibraryResponse = {
 			items,
 			pagination: {
-				page: fetchAll ? 1 : parsed.page,
-				limit: fetchAll ? totalItems : parsed.limit,
+				page: parsed.page,
+				limit: parsed.limit,
 				totalItems,
-				totalPages: fetchAll ? 1 : Math.ceil(totalItems / parsed.limit),
+				totalPages: Math.ceil(totalItems / parsed.limit),
 			},
 			appliedFilters: {
 				search: parsed.search,

--- a/apps/api/src/routes/plex/codec-analytics-routes.ts
+++ b/apps/api/src/routes/plex/codec-analytics-routes.ts
@@ -43,7 +43,7 @@ export async function registerCodecAnalyticsRoutes(
 			},
 			select: { sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =

--- a/apps/api/src/routes/plex/collection-routes.ts
+++ b/apps/api/src/routes/plex/collection-routes.ts
@@ -34,6 +34,11 @@ const ratingKeyParams = z.object({
 // Routes
 // ============================================================================
 
+// Cursor-paginate plexCache scans (issue #427 follow-up). collections/labels
+// are JSON arrays per row; even with small per-row footprint a 50k-item
+// library can transient-peak well past 10 MB without bounds.
+const PLEX_TAG_QUERY_BATCH_SIZE = 1000;
+
 export async function registerCollectionRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
 	/**
 	 * GET /api/plex/:instanceId/collections
@@ -54,22 +59,32 @@ export async function registerCollectionRoutes(app: FastifyInstance, _opts: Fast
 			return reply.status(404).send({ error: "Instance not found or access denied" });
 		}
 
-		// Get all PlexCache rows with non-empty collections for this instance
-		const cacheRows = await app.prisma.plexCache.findMany({
-			where: { instanceId },
-			select: { collections: true },
-		});
-
-		// Count occurrences of each collection name
+		// Get all PlexCache rows with non-empty collections for this instance.
+		// Cursor-paginated to bound peak heap.
 		const collectionCounts = new Map<string, number>();
-		for (const row of cacheRows) {
-			try {
-				const parsed = JSON.parse(row.collections) as string[];
-				for (const name of parsed) {
-					if (name) collectionCounts.set(name, (collectionCounts.get(name) ?? 0) + 1);
+		{
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.plexCache.findMany({
+					where: { instanceId },
+					select: { id: true, collections: true },
+					take: PLEX_TAG_QUERY_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					try {
+						const parsed = JSON.parse(row.collections) as string[];
+						for (const name of parsed) {
+							if (name) collectionCounts.set(name, (collectionCounts.get(name) ?? 0) + 1);
+						}
+					} catch {
+						// Skip malformed JSON
+					}
 				}
-			} catch {
-				// Skip malformed JSON
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < PLEX_TAG_QUERY_BATCH_SIZE) break;
 			}
 		}
 
@@ -99,20 +114,30 @@ export async function registerCollectionRoutes(app: FastifyInstance, _opts: Fast
 			return reply.status(404).send({ error: "Instance not found or access denied" });
 		}
 
-		const cacheRows = await app.prisma.plexCache.findMany({
-			where: { instanceId },
-			select: { labels: true },
-		});
-
 		const labelCounts = new Map<string, number>();
-		for (const row of cacheRows) {
-			try {
-				const parsed = JSON.parse(row.labels) as string[];
-				for (const name of parsed) {
-					if (name) labelCounts.set(name, (labelCounts.get(name) ?? 0) + 1);
+		{
+			let cursor: string | undefined;
+			while (true) {
+				const batch = await app.prisma.plexCache.findMany({
+					where: { instanceId },
+					select: { id: true, labels: true },
+					take: PLEX_TAG_QUERY_BATCH_SIZE,
+					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+					orderBy: { id: "asc" },
+				});
+				if (batch.length === 0) break;
+				for (const row of batch) {
+					try {
+						const parsed = JSON.parse(row.labels) as string[];
+						for (const name of parsed) {
+							if (name) labelCounts.set(name, (labelCounts.get(name) ?? 0) + 1);
+						}
+					} catch {
+						// Skip malformed JSON
+					}
 				}
-			} catch {
-				// Skip malformed JSON
+				cursor = batch[batch.length - 1]!.id;
+				if (batch.length < PLEX_TAG_QUERY_BATCH_SIZE) break;
 			}
 		}
 

--- a/apps/api/src/routes/plex/device-analytics-routes.ts
+++ b/apps/api/src/routes/plex/device-analytics-routes.ts
@@ -38,7 +38,7 @@ export async function registerDeviceAnalyticsRoutes(
 			},
 			select: { sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =

--- a/apps/api/src/routes/plex/last-watched-routes.ts
+++ b/apps/api/src/routes/plex/last-watched-routes.ts
@@ -46,14 +46,17 @@ export async function registerLastWatchedRoutes(app: FastifyInstance, _opts: Fas
 		}
 
 		const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+		// `last-watched` is a "most recent activity" feed — when the take cap is
+		// hit (heavy users with >20k snapshots in the cutoff window), `asc` would
+		// silently drop the recent rows the panel exists to surface.
 		const snapshots = await app.prisma.sessionSnapshot.findMany({
 			where: {
 				instanceId: { in: plexInstances.map((i) => i.id) },
 				capturedAt: { gte: cutoff },
 			},
 			select: { capturedAt: true, sessionsJson: true },
-			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			orderBy: { capturedAt: "desc" },
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateLastWatched(

--- a/apps/api/src/routes/plex/plays-by-date-routes.ts
+++ b/apps/api/src/routes/plex/plays-by-date-routes.ts
@@ -44,7 +44,7 @@ export async function registerPlaysByDateRoutes(app: FastifyInstance, _opts: Fas
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		return reply.send(aggregatePlaysByDate(snapshots, { days }));

--- a/apps/api/src/routes/plex/popular-media-routes.ts
+++ b/apps/api/src/routes/plex/popular-media-routes.ts
@@ -62,7 +62,7 @@ export async function registerPopularMediaRoutes(
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregatePopularMedia(

--- a/apps/api/src/routes/plex/quality-score-routes.ts
+++ b/apps/api/src/routes/plex/quality-score-routes.ts
@@ -44,7 +44,7 @@ export async function registerQualityScoreRoutes(
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =

--- a/apps/api/src/routes/plex/top-media-routes.ts
+++ b/apps/api/src/routes/plex/top-media-routes.ts
@@ -59,7 +59,7 @@ export async function registerTopMediaRoutes(app: FastifyInstance, _opts: Fastif
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...response } = aggregateTopMedia(

--- a/apps/api/src/routes/plex/user-analytics-routes.ts
+++ b/apps/api/src/routes/plex/user-analytics-routes.ts
@@ -38,7 +38,7 @@ export async function registerUserAnalyticsRoutes(
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "asc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { parseFailures, totalSnapshots, failedPreviews, ...analytics } =

--- a/apps/api/src/routes/plex/watch-history-routes.ts
+++ b/apps/api/src/routes/plex/watch-history-routes.ts
@@ -55,7 +55,7 @@ export async function registerWatchHistoryRoutes(
 			},
 			select: { capturedAt: true, sessionsJson: true },
 			orderBy: { capturedAt: "desc" },
-			take: 50000,
+			take: 20000,
 		});
 
 		const { events, parseFailures, totalSnapshots, failedPreviews } = deduplicateWatchEvents(

--- a/apps/web/src/hooks/api/useLibrary.ts
+++ b/apps/web/src/hooks/api/useLibrary.ts
@@ -76,22 +76,6 @@ export const useLibraryQuery = (options: UseLibraryQueryOptions = {}) => {
 };
 
 // ============================================================================
-// Library Query Hook for Filtering (fetches ALL items)
-// Used by discover page to filter out items already in library
-// ============================================================================
-
-export const useLibraryForFiltering = (options: { enabled?: boolean } = {}) => {
-	return useQuery<PaginatedLibraryResponse>({
-		queryKey: ["library", "all-for-filtering"],
-		queryFn: () => fetchLibrary({ limit: 0 }), // limit=0 means fetch all
-		enabled: options.enabled ?? true,
-		staleTime: 2 * 60 * 1000, // 2 minutes - slightly longer since it's expensive
-		gcTime: 3 * 60 * 1000, // 3 minutes - cleanup when leaving discover page
-		refetchInterval: POLLING_BACKGROUND,
-	});
-};
-
-// ============================================================================
 // Library Sync Hooks
 // ============================================================================
 

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -33,8 +33,11 @@ if [ "$(id -u)" -ne 0 ]; then
     echo "  - Skipping PUID/PGID user management"
     echo "  - Skipping ownership changes"
 
-    # Ensure config directory exists (may fail if parent isn't writable)
-    mkdir -p /config /config/logs 2>/dev/null || true
+    # Ensure config directory exists (may fail if parent isn't writable).
+    # /config/heap-snapshots is the CWD for the node process so V8's
+    # --heapsnapshot-near-heap-limit and --heapsnapshot-signal writes land
+    # on the persisted volume (see API launch below + Dockerfile NODE_OPTIONS).
+    mkdir -p /config /config/logs /config/heap-snapshots 2>/dev/null || true
 
     # Verify /config is writable — fail fast with actionable message
     if [ ! -d /config ] || ! touch /config/.startup-check 2>/dev/null; then
@@ -84,9 +87,13 @@ else
     echo ""
     echo "Setting up directories and permissions..."
 
-    # Ensure config directory exists (LinuxServer convention)
+    # Ensure config directory exists (LinuxServer convention).
+    # /config/heap-snapshots is the CWD for the node process so V8's
+    # --heapsnapshot-near-heap-limit and --heapsnapshot-signal writes land
+    # on the persisted volume (see API launch below + Dockerfile NODE_OPTIONS).
     mkdir -p /config
     mkdir -p /config/logs
+    mkdir -p /config/heap-snapshots
 
     # Set ownership of writable directories using numeric IDs
     # This ensures correct permissions even when mounting pre-existing directories
@@ -332,11 +339,28 @@ echo "  - Web Port: $PORT"
 echo ""
 echo "Starting API server on $HOST:$API_PORT..."
 cd /app/api
+
+# Heap diagnostics (issue #427 follow-up).
+#
+# CWD = /config/heap-snapshots so V8's --heapsnapshot-signal writes land on
+# the persisted volume instead of the ephemeral /app/api inside the image.
+# Using the absolute /app/api/dist/index.js lets us change CWD without
+# breaking module resolution for the bundled API.
+#
+# HEAP_AUTO_SNAPSHOT=1 appends --heapsnapshot-near-heap-limit=1 so V8
+# captures a snapshot just before OOM. Off by default because the snapshot
+# is ~3x the heap (~2.3 GB at the 768 MB cap). The manual SIGUSR2 trigger
+# in NODE_OPTIONS works regardless of this flag.
+if [ "${HEAP_AUTO_SNAPSHOT:-0}" = "1" ]; then
+    export NODE_OPTIONS="${NODE_OPTIONS} --heapsnapshot-near-heap-limit=1"
+    echo "  - HEAP_AUTO_SNAPSHOT enabled — V8 will write up to 1 snapshot to /config/heap-snapshots/ on near-OOM"
+fi
+
 # Let stdout/stderr flow directly to the container — Pino handles file logging
 # via its pino-roll transport (writes to /config/logs/arr-dashboard.log).
 # Previous approach redirected stdout to api.log, which conflicted with Pino's
 # worker-thread transport and caused both log files to remain empty.
-run_as_user sh -c "API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node dist/index.js" &
+run_as_user sh -c "cd /config/heap-snapshots && API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node /app/api/dist/index.js" &
 API_PID=$!
 echo "API started with PID $API_PID"
 
@@ -353,10 +377,15 @@ if ! kill -0 "$API_PID" 2>/dev/null; then
     set -e
     echo "  API exit code: $API_EXIT" >&2
 
-    # Re-run the API in the foreground with a timeout to capture the actual error
+    # Re-run the API in the foreground with a timeout to capture the actual error.
+    # Mirror the backgrounded launch above (cd into /config/heap-snapshots,
+    # use the absolute path to dist/index.js) so any heap snapshot V8 writes
+    # during the diagnostic re-run also lands on the persisted volume — and
+    # so this branch doesn't silently break if a future edit changes the
+    # outer shell's CWD between the two launch sites.
     echo "=== Re-running API in foreground (10s timeout) ===" >&2
     set +e
-    timeout 10 run_as_user sh -c "API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node dist/index.js" 2>&1
+    timeout 10 run_as_user sh -c "cd /config/heap-snapshots && API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node /app/api/dist/index.js" 2>&1
     RERUN_EXIT=$?
     set -e
     echo "=== Foreground API exit code: $RERUN_EXIT ===" >&2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.18.4",
+	"version": "2.18.5",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

Comprehensive heap-pressure sweep + diagnostic instrumentation for issue #427 (OOM at 768 MB cap). Two prior PRs (#429, #435) reactively fixed library-sync and backup OOM triggers; this PR bundles the remaining audit findings (cursor-paginating every unbounded `findMany` on tables with large JSON-blob columns, capping `sessionsJson` peak allocations, killing the `limit=0` foot-gun) AND adds runtime diagnostics so the next OOM (if any) ships actual evidence instead of forcing a 4th reactive PR.

Refs #427 (follow-up). Static analysis + audit identified the retainers fixed here; whether this fully resolves the OOM depends on runtime validation under the user's actual workload. The new heap-monitor plugin + opt-in HEAP_AUTO_SNAPSHOT=1 env var close the diagnostic loop if it doesn't. Issue intentionally NOT auto-closed; close based on user-reported runtime evidence.

## Memory fixes (organized by retainer)

| Site | Before | After |
|---|---|---|
| `routes/library-cleanup.ts` field-options | ~1 GB transient (full LibraryCache.data dump + 3 separate plexCache full scans) | ~10 MB per batch × 1 merged plex scan |
| `lib/library-sync/sync-executor.ts:287` existing-items load | ~250 MB (unbounded LibraryCache.data load for tag-delta) | ~10 MB per batch (cursor-paginated) |
| `lib/library/validation-schemas.ts` `limit=0` foot-gun | 500 MB OOM on `/api/library?limit=0` for big libraries | 400 Bad Request |
| `routes/dashboard/calendar-routes.ts` peak | 2× peak (raw + normalized arrays alive concurrently) | 1× peak (drop raw refs mid-iteration) |
| `routes/dashboard/history-routes.ts` peak | 2× peak | 1× peak |
| `routes/plex/collection-routes.ts` | ~30 MB unbounded plexCache | ~5 MB per batch |
| `lib/notifications/insights-digest.ts` | ~3 MB unbounded plexCache (every 6h) | ~1 MB per batch |
| 10 plex/jellyfin sessionsJson queries | ~500 MB max (`take: 50000` × 10 KB) | ~200 MB max (`take: 20000`) |

## Correctness fixes (caught by code review)

- **`last-watched` analytics dropped recent watch events** when the `take` cap was hit. Both Jellyfin and Plex routes ordered `sessionSnapshot.findMany` by `capturedAt asc`, so the cap kept the OLDEST rows and the most recent watch events — the exact data the panel exists to surface — were silently dropped. Now `desc` to match the `history` endpoint pattern. Pre-existing bug, surfaced by review during this sweep.

## Diagnostic instrumentation

If the user OOMs again despite the fixes, they should ship actual evidence:

- **Heap-monitor plugin** (always on, zero default cost): logs `process.memoryUsage()` every 5 minutes via pino with deltas vs. previous sample. Severity escalates with pressure (info > 80%, warn > 90% with copy-paste capture command). A slow leak shows up as monotonic `heapDeltaMB` growth instead of an opaque crash.
- **`--heapsnapshot-signal=SIGUSR2`** (always on, zero default cost): operators can capture a snapshot on demand via `docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'`. Lands in `/config/heap-snapshots/`.
- **`HEAP_AUTO_SNAPSHOT=1` env var (opt-in)**: when set, V8 auto-captures a snapshot just before OOM. Off by default because each snapshot is ~3x the heap (~2.3 GB at the 768 MB cap), too much disk for users with small `/config` partitions.

## Breaking change

`GET /api/library?limit=0` now returns 400 instead of "fetch all". The internal hook that used this (`useLibraryForFiltering`) has been deleted; external API users hitting this directly need a positive `limit` value.

## Test plan

- [x] `pnpm --filter @arr/api exec tsc --noEmit` clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` clean
- [x] `pnpm --filter @arr/api run test` — 1542 / 1583 passing (4 new + 1538 prior, no regressions)
  - New: `library-cleanup-field-options` cursor-pagination integration test (3 cases)
  - New: `sync-executor` cursor-paginated deletion-set equivalence test
- [x] Independent code review pass (catched the `last-watched` ordering bug + the dead-code `fetchAll` branch + a `start-combined.sh` foreground-rerun path; all addressed)
- [x] **Docker smoke test** end-to-end:
  - Container builds + boots healthy
  - Heap-monitor plugin logs at startup (`Heap monitor started — periodic memoryUsage samples enabled`)
  - `HEAP_AUTO_SNAPSHOT=1` activation message appears when env var is set
  - SIGUSR2 → `.heapsnapshot` file lands in `/config/heap-snapshots/` with correct `PUID:PGID` ownership (verified empirically: 157 MB file written)
  - `/config/heap-snapshots/` directory created with correct ownership

## Confidence

~92% RC-ready. Residual ~8% is "the original 766 MB live heap could hide a retainer that static analysis can't see (e.g., a leak in a dependency)." That gap can only close with the user running this build for 24+ hours under their normal workload — at which point the heap-monitor logs tell us if baseline is climbing or stable, and the SIGUSR2 / `HEAP_AUTO_SNAPSHOT=1` paths give us the evidence to fix any remaining cause in one PR instead of guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
