### PR TITLE
fix(hunting): filter queue threshold to active items (closes #438)

### DIFF
--- a/apps/api/src/lib/hunting/__tests__/queue-threshold.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/queue-threshold.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for queue threshold check in executeHuntWithSdk.
+ *
+ * Regression test for issue #438: Sonarr hunts were being skipped because the
+ * queue threshold counted ALL queue records (including stuck/failed/completed-
+ * waiting items). The fix filters to only "active" statuses so the threshold
+ * reflects items genuinely consuming download slots.
+ */
+
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { executeHuntWithSdk } from "../hunt-executor.js";
+
+const ACTIVE_STATUSES = ["queued", "downloading", "paused", "delay"];
+
+function makeMockApp(client: unknown): Partial<FastifyInstance> {
+	const log = {
+		child: vi.fn().mockReturnValue({
+			info: vi.fn(),
+			debug: vi.fn(),
+			error: vi.fn(),
+			warn: vi.fn(),
+		}),
+		info: vi.fn(),
+		debug: vi.fn(),
+		error: vi.fn(),
+		warn: vi.fn(),
+	};
+	return {
+		log: log as unknown as FastifyInstance["log"],
+		arrClientFactory: {
+			create: vi.fn().mockReturnValue(client),
+		} as unknown as FastifyInstance["arrClientFactory"],
+		prisma: {
+			huntSearchHistory: {
+				findMany: vi.fn().mockResolvedValue([]),
+				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+				create: vi.fn().mockResolvedValue({}),
+				createMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+		} as unknown as FastifyInstance["prisma"],
+	};
+}
+
+const sonarrInstance = {
+	id: "instance-1",
+	service: "SONARR",
+	label: "Test Sonarr",
+};
+
+const baseConfig = {
+	id: "config-1",
+	queueThreshold: 25,
+	missingBatchSize: 10,
+	upgradeBatchSize: 10,
+	researchAfterDays: 7,
+	preferSeasonPacks: false,
+	upgradeSearchAll: false,
+};
+
+const callExecute = (
+	app: Partial<FastifyInstance>,
+	type: "missing" | "upgrade",
+	overrides: Partial<typeof baseConfig> = {},
+) =>
+	executeHuntWithSdk(
+		app as FastifyInstance,
+		sonarrInstance as unknown as Parameters<typeof executeHuntWithSdk>[1],
+		{ ...baseConfig, ...overrides } as unknown as Parameters<typeof executeHuntWithSdk>[2],
+		type,
+	);
+
+describe("executeHuntWithSdk — queue threshold (issue #438)", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("passes ACTIVE_QUEUE_STATUSES filter to queue.get so stuck/failed/completed items don't gate the hunt", async () => {
+		const queueGet = vi.fn().mockResolvedValue({ totalRecords: 5 });
+		const seriesGetAll = vi.fn().mockResolvedValue([]);
+		const wantedMissing = vi.fn().mockResolvedValue({ records: [], totalRecords: 0 });
+
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: seriesGetAll },
+			wanted: { missing: wantedMissing, cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		await callExecute(app, "missing");
+
+		expect(queueGet).toHaveBeenCalledTimes(1);
+		const callArgs = queueGet.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(callArgs.pageSize).toBe(1);
+		expect(callArgs.status).toEqual(ACTIVE_STATUSES);
+	});
+
+	it("does NOT skip when active queue is below threshold even if many stuck items would have totaled higher", async () => {
+		// Sonarr returns totalRecords for the filtered query — only ACTIVE items
+		// counted. Without the filter, the user's full queue (stuck imports, failed
+		// downloads, etc.) could exceed threshold even when downloads aren't busy.
+		const queueGet = vi.fn().mockResolvedValue({ totalRecords: 5 });
+		const seriesGetAll = vi.fn().mockResolvedValue([]);
+		const wantedMissing = vi.fn().mockResolvedValue({ records: [], totalRecords: 0 });
+
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: seriesGetAll },
+			wanted: { missing: wantedMissing, cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		const result = await callExecute(app, "missing");
+
+		expect(result.status).not.toBe("skipped");
+		expect(seriesGetAll).toHaveBeenCalled();
+	});
+
+	it("skips with active-queue message when active queue exceeds threshold", async () => {
+		const queueGet = vi.fn().mockResolvedValue({ totalRecords: 30 });
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: vi.fn() },
+			wanted: { missing: vi.fn(), cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		const result = await callExecute(app, "missing");
+
+		expect(result.status).toBe("skipped");
+		expect(result.message).toMatch(/Active queue \(30\) exceeds threshold \(25\)/);
+		expect(result.apiCallsMade).toBe(1);
+	});
+
+	it("disabled threshold (0) skips queue.get entirely", async () => {
+		const queueGet = vi.fn();
+		const seriesGetAll = vi.fn().mockResolvedValue([]);
+		const wantedMissing = vi.fn().mockResolvedValue({ records: [], totalRecords: 0 });
+
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: seriesGetAll },
+			wanted: { missing: wantedMissing, cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		await callExecute(app, "missing", { queueThreshold: 0 });
+
+		expect(queueGet).not.toHaveBeenCalled();
+	});
+
+	it("queue.get throwing yields skipped (fail-safe) without proceeding to series fetch", async () => {
+		const queueGet = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+		const seriesGetAll = vi.fn();
+
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: seriesGetAll },
+			wanted: { missing: vi.fn(), cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		const result = await callExecute(app, "missing");
+
+		expect(result.status).toBe("skipped");
+		expect(result.message).toMatch(/Queue check failed/);
+		expect(seriesGetAll).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/hunting/__tests__/queue-threshold.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/queue-threshold.test.ts
@@ -1,10 +1,14 @@
 /**
  * Tests for queue threshold check in executeHuntWithSdk.
  *
- * Regression test for issue #438: Sonarr hunts were being skipped because the
- * queue threshold counted ALL queue records (including stuck/failed/completed-
- * waiting items). The fix filters to only "active" statuses so the threshold
- * reflects items genuinely consuming download slots.
+ * Regression coverage for issue #438:
+ *  - Sonarr hunts were being skipped because the queue threshold counted ALL
+ *    queue records (stuck/failed/completed-waiting items). The fix filters to
+ *    "active" statuses only.
+ *
+ * Also pins the post-review distinction between two skip paths:
+ *  - threshold-exceeded → status "skipped" (operator's queue is busy, healthy throttle).
+ *  - check-failed (connectivity, malformed response) → status "error" (actionable).
  */
 
 import type { FastifyInstance } from "fastify";
@@ -49,6 +53,12 @@ const sonarrInstance = {
 	label: "Test Sonarr",
 };
 
+const readarrInstance = {
+	id: "instance-2",
+	service: "READARR",
+	label: "Test Readarr",
+};
+
 const baseConfig = {
 	id: "config-1",
 	queueThreshold: 25,
@@ -63,10 +73,11 @@ const callExecute = (
 	app: Partial<FastifyInstance>,
 	type: "missing" | "upgrade",
 	overrides: Partial<typeof baseConfig> = {},
+	instance: typeof sonarrInstance = sonarrInstance,
 ) =>
 	executeHuntWithSdk(
 		app as FastifyInstance,
-		sonarrInstance as unknown as Parameters<typeof executeHuntWithSdk>[1],
+		instance as unknown as Parameters<typeof executeHuntWithSdk>[1],
 		{ ...baseConfig, ...overrides } as unknown as Parameters<typeof executeHuntWithSdk>[2],
 		type,
 	);
@@ -101,9 +112,6 @@ describe("executeHuntWithSdk — queue threshold (issue #438)", () => {
 	});
 
 	it("does NOT skip when active queue is below threshold even if many stuck items would have totaled higher", async () => {
-		// Sonarr returns totalRecords for the filtered query — only ACTIVE items
-		// counted. Without the filter, the user's full queue (stuck imports, failed
-		// downloads, etc.) could exceed threshold even when downloads aren't busy.
 		const queueGet = vi.fn().mockResolvedValue({ totalRecords: 5 });
 		const seriesGetAll = vi.fn().mockResolvedValue([]);
 		const wantedMissing = vi.fn().mockResolvedValue({ records: [], totalRecords: 0 });
@@ -154,7 +162,7 @@ describe("executeHuntWithSdk — queue threshold (issue #438)", () => {
 		expect(queueGet).not.toHaveBeenCalled();
 	});
 
-	it("queue.get throwing yields skipped (fail-safe) without proceeding to series fetch", async () => {
+	it("queue.get throwing yields status:error (not skipped) so connectivity failures are actionable", async () => {
 		const queueGet = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
 		const seriesGetAll = vi.fn();
 
@@ -167,8 +175,51 @@ describe("executeHuntWithSdk — queue threshold (issue #438)", () => {
 
 		const result = await callExecute(app, "missing");
 
-		expect(result.status).toBe("skipped");
+		expect(result.status).toBe("error");
 		expect(result.message).toMatch(/Queue check failed/);
 		expect(seriesGetAll).not.toHaveBeenCalled();
+	});
+
+	it("malformed response (missing totalRecords) yields status:error to fail safe", async () => {
+		// Reverse-proxy returning HTML, future SDK field rename, etc. — the
+		// queue-check should refuse to interpret a missing field as "empty queue".
+		const queueGet = vi.fn().mockResolvedValue({ records: [] });
+		const seriesGetAll = vi.fn();
+
+		const client = {
+			queue: { get: queueGet },
+			series: { getAll: seriesGetAll },
+			wanted: { missing: vi.fn(), cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		const result = await callExecute(app, "missing");
+
+		expect(result.status).toBe("error");
+		expect(result.message).toMatch(/unexpected response shape/);
+		expect(seriesGetAll).not.toHaveBeenCalled();
+	});
+
+	it("Readarr does NOT receive the status filter (SDK enumerates fields and would drop it)", async () => {
+		// Readarr's arr-sdk QueueResource.get only forwards a known set of fields
+		// — `status` is not among them. Sending it would be a silent no-op, so
+		// we suppress it here and use the unfiltered count, with the message
+		// reflecting that ("Queue" not "Active queue"). Pre-fix behavior is
+		// preserved on Readarr.
+		const queueGet = vi.fn().mockResolvedValue({ totalRecords: 30 });
+		const client = {
+			queue: { get: queueGet },
+			author: { getAll: vi.fn().mockResolvedValue([]) },
+			wanted: { missing: vi.fn(), cutoff: vi.fn() },
+		};
+		const app = makeMockApp(client);
+
+		const result = await callExecute(app, "missing", {}, readarrInstance);
+
+		const callArgs = queueGet.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(callArgs).not.toHaveProperty("status");
+		expect(callArgs.pageSize).toBe(1);
+		expect(result.status).toBe("skipped");
+		expect(result.message).toMatch(/^Queue \(30\) exceeds threshold \(25\)$/);
 	});
 });

--- a/apps/api/src/lib/hunting/hunt-executor.ts
+++ b/apps/api/src/lib/hunting/hunt-executor.ts
@@ -179,7 +179,17 @@ export async function executeHuntWithSdk(
 }
 
 /**
+ * Statuses that count toward the queue threshold — items actively consuming
+ * download capacity. Excludes "completed" (waiting to import), "failed",
+ * "warning", and other stuck states which don't gate further searches.
+ */
+const ACTIVE_QUEUE_STATUSES = ["queued", "downloading", "paused", "delay"] as const;
+
+/**
  * Check queue threshold using SDK.
+ * Counts only items in active states so the threshold reflects actual download
+ * client load, not stuck imports/failed items. (Issue #438.)
+ *
  * Returns ok: false if check fails to prevent overloading queue on connectivity issues.
  */
 async function checkQueueThresholdWithSdk(
@@ -194,17 +204,29 @@ async function checkQueueThresholdWithSdk(
 
 	try {
 		counter.count++;
-		const queue = await client.queue.get({ pageSize: 1 });
+		// `client.queue.get` is a method-union across SDK clients, so calling it
+		// directly requires the intersection of param types. Bind through a
+		// permissive signature — Lidarr/Readarr accept extra keys via index sig.
+		const queueGet = client.queue.get.bind(client.queue) as (
+			options: Record<string, unknown>,
+		) => Promise<{ totalRecords?: number }>;
+		const queue = await queueGet({
+			pageSize: 1,
+			status: [...ACTIVE_QUEUE_STATUSES],
+		});
 		const queueCount = queue.totalRecords ?? 0;
 
 		if (queueCount >= threshold) {
 			return {
 				ok: false,
-				message: `Queue (${queueCount}) exceeds threshold (${threshold})`,
+				message: `Active queue (${queueCount}) exceeds threshold (${threshold})`,
 			};
 		}
 
-		return { ok: true, message: `Queue (${queueCount}) below threshold (${threshold})` };
+		return {
+			ok: true,
+			message: `Active queue (${queueCount}) below threshold (${threshold})`,
+		};
 	} catch (error) {
 		// Fail safely - if we can't check the queue, don't proceed to avoid overloading
 		logger.warn(

--- a/apps/api/src/lib/hunting/hunt-executor.ts
+++ b/apps/api/src/lib/hunting/hunt-executor.ts
@@ -86,18 +86,21 @@ export async function executeHuntWithSdk(
 	// Check queue threshold first
 	const queueCheck = await checkQueueThresholdWithSdk(
 		client,
+		service,
 		config.queueThreshold,
 		apiCallCounter,
 		logger,
 	);
-	if (!queueCheck.ok) {
+	if (queueCheck.outcome !== "pass") {
 		return {
 			itemsSearched: 0,
 			itemsGrabbed: 0,
 			searchedItems: [],
 			grabbedItems: [],
 			message: queueCheck.message,
-			status: "skipped",
+			// Distinguish a healthy throttle from an actionable failure so the
+			// status badge and notification routing are accurate. (Issue #438.)
+			status: queueCheck.outcome === "threshold-exceeded" ? "skipped" : "error",
 			apiCallsMade: apiCallCounter.count,
 		};
 	}
@@ -185,56 +188,96 @@ export async function executeHuntWithSdk(
  */
 const ACTIVE_QUEUE_STATUSES = ["queued", "downloading", "paused", "delay"] as const;
 
+type QueueCheckOutcome =
+	| { outcome: "pass"; message: string }
+	| { outcome: "threshold-exceeded"; message: string }
+	| { outcome: "check-failed"; message: string };
+
 /**
  * Check queue threshold using SDK.
- * Counts only items in active states so the threshold reflects actual download
- * client load, not stuck imports/failed items. (Issue #438.)
  *
- * Returns ok: false if check fails to prevent overloading queue on connectivity issues.
+ * Counts only items in active states (queued/downloading/paused/delay) so the
+ * threshold reflects actual download client load, not stuck imports or failed
+ * items. (Issue #438.)
+ *
+ * Filter applicability by service:
+ * - Sonarr/Radarr: native `status` query param, fully filtered.
+ * - Lidarr: SDK forwards unknown options to the server.
+ * - Readarr: arr-sdk's `QueueResource.get` enumerates known fields and DROPS
+ *   unknown keys, so the `status` filter cannot be applied. We skip it there
+ *   and use the unfiltered count to keep the threshold message honest;
+ *   Readarr's behavior is unchanged from pre-fix.
+ *
+ * Outcomes:
+ * - `pass` → hunt proceeds.
+ * - `threshold-exceeded` → operator's queue is genuinely busy; map to "skipped".
+ * - `check-failed` → connectivity / response-shape failure; map to "error" so
+ *   the operator surface (status badge, notifications) reflects an actionable
+ *   condition rather than a healthy throttle.
  */
 async function checkQueueThresholdWithSdk(
 	client: QueueCapableClient,
+	service: HuntService,
 	threshold: number,
 	counter: ApiCallCounter,
 	logger: HuntLogger,
-): Promise<{ ok: boolean; message: string }> {
+): Promise<QueueCheckOutcome> {
 	if (threshold <= 0) {
-		return { ok: true, message: "Queue threshold check disabled" };
+		return { outcome: "pass", message: "Queue threshold check disabled" };
 	}
+
+	const filterApplicable = service !== "readarr";
+	const label = filterApplicable ? "Active queue" : "Queue";
 
 	try {
 		counter.count++;
-		// `client.queue.get` is a method-union across SDK clients, so calling it
-		// directly requires the intersection of param types. Bind through a
-		// permissive signature — Lidarr/Readarr accept extra keys via index sig.
+		// `client.queue.get` is a method-union across the 4 SDK clients, so
+		// calling it directly requires intersected param types. Bind through a
+		// permissive signature; per-service field handling happens in arr-sdk.
 		const queueGet = client.queue.get.bind(client.queue) as (
 			options: Record<string, unknown>,
 		) => Promise<{ totalRecords?: number }>;
-		const queue = await queueGet({
-			pageSize: 1,
-			status: [...ACTIVE_QUEUE_STATUSES],
-		});
-		const queueCount = queue.totalRecords ?? 0;
+		const options: Record<string, unknown> = { pageSize: 1 };
+		if (filterApplicable) {
+			options.status = [...ACTIVE_QUEUE_STATUSES];
+		}
+		const queue = await queueGet(options);
+
+		// Fail safe on a malformed response (HTML body from a misconfigured
+		// reverse proxy, future SDK field rename, etc.) rather than coalescing
+		// missing `totalRecords` to 0 and proceeding as if the queue were empty.
+		if (typeof queue.totalRecords !== "number") {
+			logger.warn(
+				{ threshold, response: queue },
+				"Queue check returned unexpected shape — failing safe",
+			);
+			return {
+				outcome: "check-failed",
+				message:
+					"Queue check returned unexpected response shape. Verify SDK / instance compatibility.",
+			};
+		}
+
+		const queueCount = queue.totalRecords;
 
 		if (queueCount >= threshold) {
 			return {
-				ok: false,
-				message: `Active queue (${queueCount}) exceeds threshold (${threshold})`,
+				outcome: "threshold-exceeded",
+				message: `${label} (${queueCount}) exceeds threshold (${threshold})`,
 			};
 		}
 
 		return {
-			ok: true,
-			message: `Active queue (${queueCount}) below threshold (${threshold})`,
+			outcome: "pass",
+			message: `${label} (${queueCount}) below threshold (${threshold})`,
 		};
 	} catch (error) {
-		// Fail safely - if we can't check the queue, don't proceed to avoid overloading
 		logger.warn(
 			{ err: error, threshold },
-			"Queue threshold check failed - skipping hunt to prevent potential queue overload",
+			"Queue threshold check failed — surfacing as hunt error",
 		);
 		return {
-			ok: false,
+			outcome: "check-failed",
 			message: `Queue check failed: ${getErrorMessage(error, "Unknown error")}. Please verify instance connectivity.`,
 		};
 	}

--- a/apps/api/src/lib/hunting/scheduler.ts
+++ b/apps/api/src/lib/hunting/scheduler.ts
@@ -446,6 +446,25 @@ class HuntingScheduler {
 							"Hunt notification dispatch failed",
 						);
 					});
+			} else if (result.status === "error") {
+				// A returned error result (e.g., queue-check connectivity failure)
+				// does not throw, so the outer catch below never fires for it.
+				// Surface it explicitly so an offline instance doesn't silently
+				// stop hunting. (Issue #438 follow-up.)
+				this.app.notificationService
+					?.notify({
+						eventType: "HUNT_FAILED",
+						title: `Hunt failed on ${config.instance.label}`,
+						body: result.message,
+						url: "/hunting",
+						metadata: huntMeta,
+					})
+					.catch((err) => {
+						log.warn(
+							{ err, instanceLabel: config.instance.label },
+							"Hunt failure notification dispatch failed",
+						);
+					});
 			}
 
 			// Update config timestamps and API call count (only if we actually made API calls)

--- a/apps/web/src/features/hunting/components/hunting-activity.tsx
+++ b/apps/web/src/features/hunting/components/hunting-activity.tsx
@@ -275,6 +275,9 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 								{isRunning ? "In Progress" : log.status}
 							</StatusBadge>
 						</div>
+						{!isRunning && log.message && (log.status === "skipped" || log.status === "error") && (
+							<p className="mt-1 text-[11.5px] text-muted-foreground/60 truncate">{log.message}</p>
+						)}
 					</div>
 				</div>
 

--- a/apps/web/src/features/hunting/components/hunting-activity.tsx
+++ b/apps/web/src/features/hunting/components/hunting-activity.tsx
@@ -276,7 +276,12 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 							</StatusBadge>
 						</div>
 						{!isRunning && log.message && (log.status === "skipped" || log.status === "error") && (
-							<p className="mt-1 text-[11.5px] text-muted-foreground/60 truncate">{log.message}</p>
+							<p
+								className="mt-1 text-[11.5px] text-muted-foreground/60 truncate"
+								title={log.message}
+							>
+								{log.message}
+							</p>
 						)}
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- Fixes #438 — Sonarr hunts being skipped while Radarr worked. Root cause: queue-threshold pre-flight check counted *all* queue records (including stuck `completed`/`failed`/`warning` items). Sonarr's queue accumulates these (one per episode + import-stalled items), so the default threshold of 25 was easily exceeded; Radarr (one entry per movie) rarely hit it.
- Pass `status: ['queued','downloading','paused','delay']` to `client.queue.get` on Sonarr/Radarr/Lidarr so the threshold reflects items genuinely consuming download capacity. Readarr's arr-sdk enumerates known fields and drops unknowns, so the filter is suppressed there (preserves pre-fix behavior; documented).
- Distinguish *throttle* from *failure*: `checkQueueThresholdWithSdk` now returns a discriminated outcome (`pass` / `threshold-exceeded` / `check-failed`). A connectivity error or malformed response maps to `status: "error"` (not `"skipped"`), and `HUNT_FAILED` notifications fire for returned errors — previously they only fired on thrown errors, so an offline instance silently stopped hunting.
- Surface skip/error messages inline in the collapsed activity row with `title` tooltip for full text on hover.

## Live verification

Read-only probe of the configured production Sonarr — exact bug reproduction:

```
--- BEFORE FIX (unfiltered count) ---
totalRecords: 31

--- AFTER FIX (active filter) ---
totalRecords: 0

--- Per-status breakdown ---
queued        → 0
downloading   → 0
paused        → 0
delay         → 0
completed     → 31   ← all stuck in import limbo
failed        → 0
warning       → 0
```

All 31 entries were `completed` (downloaded, waiting for import). With the old code, `31 ≥ 25` → every hunt skipped. With the fix, `0 < 25` → hunts proceed.

## Test plan
- [x] `pnpm run typecheck` — clean across `@arr/api`, `@arr/web`, `@arr/shared`
- [x] `pnpm run test` — 1549 passed (up from 1547; +2 net cases for malformed-response and Readarr-no-filter)
- [x] `biome check` on touched files — no new violations
- [x] Live SDK round-trip against Sonarr 4.0.16 (test container + production instance) — verified the SDK serializes the array as repeated `?status=queued&status=downloading&...`, that Sonarr validates the param (rejects bogus values with HTTP 400, proving it's parsed not silently ignored), and that the filter actually filters `totalRecords`
- [x] Code review (caught 4 issues, all addressed): connectivity-vs-threshold distinction, Readarr SDK divergence, fail-unsafe on missing `totalRecords`, hidden actionable tail in collapsed UI row
- [x] Manual security pass: no auth/encryption/injection surface changes; `title` attribute exposes only the same `log.message` already rendered as text; status filter is a hardcoded constant, not user input

## Commits
- `d8410c2` — initial fix: active-status filter + inline message
- `20b531a` — review follow-up: discriminated outcome, Readarr gating, fail-safe shape check, scheduler error dispatch, UI tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)