### PR TITLE
chore(release): v2.18.6 — Sonarr hunt queue-threshold fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.6] - 2026-05-09
+
+### Fixed
+
+- **Sonarr hunt requests skipping while Radarr worked normally (closes #438).** The queue-threshold pre-flight check counted *every* queue entry against the default threshold of 25 — including items in `completed` (downloaded, waiting for import), `failed`, `warning`, and other stuck states that don't actually consume download-client capacity. Sonarr's queue accumulates these (one entry per episode plus stuck imports), so the threshold was easily exceeded and every hunt skipped. Radarr (one entry per movie, faster import lifecycle) rarely hit this. Live verification on a real Sonarr 4.0.16 instance reproduced the bug exactly: 31 stuck `completed` items, 0 actively downloading — every hunt skipped before fix, hunts proceed after.
+  - `checkQueueThresholdWithSdk` now passes `status: ['queued','downloading','paused','delay']` to `client.queue.get` on Sonarr/Radarr/Lidarr so the threshold reflects items genuinely competing for download slots. Readarr's arr-sdk `QueueResource.get` enumerates known fields and silently drops unknown keys, so the filter cannot be applied there — Readarr's behavior is unchanged from pre-fix and the message is labeled "Queue" (vs "Active queue") to keep the wording honest.
+  - **Connectivity failures now surface as errors, not silent throttle.** The catch branch previously returned `status: "skipped"` with the same shape as a healthy threshold-skip, so an offline Sonarr or rotated API key would silently stop hunting with no notification (the scheduler's `HUNT_FAILED` dispatch only fired from thrown errors, not returned ones). The function now returns a discriminated outcome (`pass` / `threshold-exceeded` / `check-failed`); the caller maps `check-failed` to `status: "error"`, and the scheduler now dispatches `HUNT_FAILED` for returned errors as well.
+  - **Fail-safe on malformed queue responses.** A reverse-proxy returning HTML, a future SDK field rename, or any response missing `totalRecords` previously coalesced to `0` and proceeded as if the queue were empty. Now treated as `check-failed` with an explicit "unexpected response shape" message.
+  - **UI**: the skip/error message is shown inline in the collapsed activity row (instead of only after expanding) with a `title` tooltip for full text on hover, so operators see *why* a hunt was skipped at a glance.
+
 ## [2.18.5] - 2026-05-08
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.18.5 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 2.18.6 | **Node:** 22+ | **pnpm:** 10+

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.5** — Comprehensive heap-pressure sweep + diagnostic instrumentation closing out issue #427. Cursor-paginates every remaining unbounded `LibraryCache.data` / `plexCache` / `jellyfinCache` / `tautulliCache` read, reduces calendar + history transient peaks, lowers `take` caps on `sessionsJson` analytics, rejects the `/api/library?limit=0` foot-gun. Adds an always-on heap-monitor plugin and opt-in `HEAP_AUTO_SNAPSHOT=1` env var so future OOMs ship actual evidence. Also fixes a pre-existing `last-watched` ordering bug.
+> **Version 2.18.6** — Fixes Sonarr hunts being silently skipped when the queue contains stuck/import-waiting items (closes #438). Queue threshold now counts only items actively consuming download capacity (`queued`/`downloading`/`paused`/`delay`), not stuck `completed`/`failed` entries. Live-verified against a real Sonarr 4.0.16 instance. Also distinguishes connectivity failures from healthy throttles (returned errors fire `HUNT_FAILED` notifications), fail-safes on malformed queue responses, and surfaces the skip/error message inline in the activity log.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -95,6 +95,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.6` | Fixes Sonarr hunts being silently skipped when the queue contains stuck/import-waiting items (#438). Queue threshold now counts only items actively consuming download capacity. Distinguishes connectivity failures from healthy throttles (returned errors fire `HUNT_FAILED` notifications). Fail-safes on malformed queue responses. Inline message + tooltip in activity log |
 | `2.18.5` | Comprehensive heap-pressure sweep closing out issue #427 — cursor-paginates remaining unbounded JSON-blob reads, reduces calendar/history transient peaks, caps sessionsJson analytics, rejects `/api/library?limit=0`. Adds heap-monitor plugin + opt-in `HEAP_AUTO_SNAPSHOT=1` for diagnostics. Fixes `last-watched` ordering bug |
 | `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.18.5** — Comprehensive heap-pressure sweep + diagnostic instrumentation closing out issue #427. Cursor-paginates every remaining unbounded `LibraryCache.data` / `plexCache` / `jellyfinCache` / `tautulliCache` read (library-cleanup, library-sync, plex collection-routes, insights-digest), drops raw-payload references mid-loop on calendar + history dashboard handlers, lowers `take` caps on `sessionsJson` analytics queries, and rejects the `/api/library?limit=0` foot-gun. Ships an always-on heap-monitor plugin (5-min `process.memoryUsage()` samples with deltas) and an opt-in `HEAP_AUTO_SNAPSHOT=1` env var so the next OOM (if any) ships actual evidence. Also fixes a pre-existing `last-watched` ordering bug surfaced by review.
+> **Version 2.18.6** — Fixes Sonarr hunts being silently skipped when the queue contains stuck/import-waiting items (closes #438). The queue-threshold check now counts only items actively consuming download capacity (`queued`/`downloading`/`paused`/`delay`), not stuck `completed`/`failed` entries. Live-verified against a real Sonarr 4.0.16 instance: 31 stuck items → 0 active → hunts now proceed where they previously skipped indefinitely. Also distinguishes connectivity failures from healthy throttles (returned errors now fire `HUNT_FAILED` notifications instead of silent skips), fail-safes on malformed queue responses, and surfaces the skip/error message inline in the activity log.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -231,6 +231,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.18.6` | Fixes Sonarr hunts being silently skipped when the queue contains stuck/import-waiting items (#438). Queue threshold now counts only items actively consuming download capacity. Distinguishes connectivity failures from healthy throttles (returned errors fire `HUNT_FAILED` notifications). Fail-safes on malformed queue responses. Inline message + tooltip in activity log |
 | `2.18.5` | Comprehensive heap-pressure sweep closing out issue #427 — cursor-paginates remaining unbounded JSON-blob reads (library-cleanup, library-sync, plex collection-routes, insights-digest), reduces calendar/history transient peaks, caps sessionsJson analytics, rejects `/api/library?limit=0`. Adds heap-monitor plugin + opt-in `HEAP_AUTO_SNAPSHOT=1` for diagnostics. Fixes `last-watched` ordering bug |
 | `2.18.4` | Seerr admin profile override on approval (#434) — pick non-default quality profile / root folder / server before approving a request. Plus backup OOM fix and broader memory sweep across cleanup, auto-tag, and history-table reads (#427 follow-up) |
 | `2.18.3` | Patch release — notification URL resolution (#430), indexer readability (#428), Readarr/Lidarr sync memory reduction (#427) |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.18.5",
+	"version": "2.18.6",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary
- Patch release rolling up the Sonarr hunt-queue-threshold fix from #440 (closes #438).
- Version bumped across the 5 in-repo release-checklist files: `package.json`, `CHANGELOG.md`, `README.md` (tagline + tags table), `DOCKERHUB.md` (tagline + tags table), `CLAUDE.md` footer.

## What ships in 2.18.6

Single user-facing fix (#438):
- Sonarr hunts no longer skip silently when the queue accumulates stuck `completed` / `failed` / `warning` items. Threshold now counts only items actively consuming download capacity (`queued` / `downloading` / `paused` / `delay`).
- Live-verified against a real Sonarr 4.0.16 instance: 31 stuck `completed` items, 0 active → previously every hunt skipped indefinitely; now hunts proceed.
- Connectivity failures now surface as `status: "error"` (and fire `HUNT_FAILED` notifications) instead of being indistinguishable from healthy threshold-skips.
- Fail-safe on malformed queue responses (no more silent green-light on missing `totalRecords`).
- Activity log shows skip/error message inline with `title` tooltip.

## Test plan
- [x] `pnpm run typecheck` — clean across all 3 packages
- [x] `pnpm run test` — 1549 tests passing
- [x] All 5 release-checklist files updated and verified consistent at 2.18.6
- [ ] Wiki update (`Home.md` + `Troubleshooting.md`) — done at tag time per project convention

## Release-checklist parity
| File | Updated |
|---|---|
| `package.json` | ✅ 2.18.5 → 2.18.6 |
| `CHANGELOG.md` | ✅ new `[2.18.6] - 2026-05-09` section above 2.18.5 |
| `README.md` tagline | ✅ |
| `README.md` tags table | ✅ new row at top |
| `DOCKERHUB.md` tagline | ✅ |
| `DOCKERHUB.md` tags table | ✅ new row at top |
| `CLAUDE.md` footer | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)