### PR TITLE
fix(diagnostics): add dump-heap helper so heap snapshots are reachable (#427)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,9 +123,14 @@ COPY --from=builder --chown=abc:abc /app/apps/web/public ./web/apps/web/public
 COPY --chown=abc:abc docker/start-combined.sh ./
 COPY --chown=abc:abc docker/read-base-path.cjs ./api/
 COPY --chown=abc:abc docker/validate-runtime.sh ./api/
+# Heap-snapshot helper for operators (issue #427). Installed in PATH so
+# users can run `docker exec <container> dump-heap` without needing to
+# know the API's internal process layout.
+COPY --chown=root:root docker/dump-heap.sh /usr/local/bin/dump-heap
 RUN sed -i 's/\r$//' ./start-combined.sh && chmod +x ./start-combined.sh \
     && mv start-combined.sh start.sh \
-    && chmod +x ./api/validate-runtime.sh
+    && chmod +x ./api/validate-runtime.sh \
+    && sed -i 's/\r$//' /usr/local/bin/dump-heap && chmod +x /usr/local/bin/dump-heap
 
 # Configuration
 EXPOSE 3000 3001
@@ -142,8 +147,11 @@ ENV DATABASE_URL="file:/config/prod.db" \
     # Heap diagnostics (issue #427 follow-up):
     #   --heapsnapshot-signal=SIGUSR2  Always on. Cost = zero (only writes
     #     when the signal is received). If periodic heap-monitor logs show
-    #     a climbing baseline, an operator can capture a snapshot:
-    #       docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
+    #     a climbing baseline, an operator can capture a snapshot with the
+    #     `dump-heap` helper that ships in the image:
+    #       docker exec <container> dump-heap
+    #     The helper walks /proc to find the API process and sends SIGUSR2
+    #     (no pgrep / procps required — keeps the base image minimal).
     #     Snapshots land on the persisted volume (/config/heap-snapshots/).
     #
     #   Auto-capture on near-OOM is OPT-IN via the HEAP_AUTO_SNAPSHOT env

--- a/apps/api/src/plugins/heap-monitor.ts
+++ b/apps/api/src/plugins/heap-monitor.ts
@@ -28,9 +28,11 @@
  * Companion runtime knobs:
  *   - `--heapsnapshot-signal=SIGUSR2`  Always on (set in Dockerfile
  *     NODE_OPTIONS). An operator who sees heap climbing in these logs can
- *     capture a snapshot on demand:
- *       docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
- *     Snapshots land on /config/heap-snapshots/.
+ *     capture a snapshot on demand via the bundled helper:
+ *       docker exec <container> dump-heap
+ *     The helper walks /proc to find the API process (no pgrep/procps
+ *     required) and sends SIGUSR2. Snapshots land in
+ *     /config/heap-snapshots/.
  *
  *   - `HEAP_AUTO_SNAPSHOT=1` env var  OPT-IN. When set, start-combined.sh
  *     appends --heapsnapshot-near-heap-limit=1 so V8 auto-captures a
@@ -104,7 +106,7 @@ const heapMonitorPlugin = fastifyPlugin(
 			if (heapPct >= WARN_HEAP_PCT) {
 				app.log.warn(
 					payload,
-					"Heap usage above 90% — capture a snapshot before OOM: docker exec <container> sh -c 'kill -USR2 $(pgrep -f \"node /app/api/dist/index.js\")'",
+					"Heap usage above 90% — capture a snapshot before OOM: `docker exec <container> dump-heap` (snapshot lands in /config/heap-snapshots/). Or set HEAP_AUTO_SNAPSHOT=1 in env + restart to auto-capture next near-OOM.",
 				);
 			} else if (heapPct >= INFO_HEAP_PCT) {
 				app.log.info(payload, "Heap usage above 80%");

--- a/docker/dump-heap.sh
+++ b/docker/dump-heap.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# dump-heap — capture a Node heap snapshot from the API process.
+#
+# Triggered by operators diagnosing OOM / leak issues (see issue #427).
+# Sends SIGUSR2 to the running API node process; V8 then writes a
+# .heapsnapshot file to CWD (start-combined.sh sets CWD to
+# /config/heap-snapshots/, so snapshots land there persistently).
+#
+# Usage: docker exec <container> dump-heap
+#
+# Self-contained — walks /proc to find the API process, no procps/pgrep
+# required.
+
+set -eu
+
+pid=""
+for proc in /proc/[0-9]*; do
+	[ -r "$proc/comm" ] || continue
+	if [ "$(cat "$proc/comm" 2>/dev/null)" = "node" ]; then
+		# Multiple node processes may be running (web + api). Match the
+		# API's entry script in cmdline to pick the right one.
+		cmdline=$(tr '\0' ' ' < "$proc/cmdline" 2>/dev/null || echo "")
+		case "$cmdline" in
+			*"/app/api/dist/index.js"*|*"/app/api/dist/launcher.js"*)
+				pid="${proc##*/}"
+				break
+				;;
+		esac
+	fi
+done
+
+if [ -z "$pid" ]; then
+	echo "ERROR: could not find API node process under /proc." >&2
+	echo "Tried matching 'node /app/api/dist/{index,launcher}.js'." >&2
+	echo "Is the API actually running? Try: docker exec <container> ls /proc | head" >&2
+	exit 1
+fi
+
+echo "Found API process: PID $pid"
+echo "Sending SIGUSR2 — V8 will write a .heapsnapshot to /config/heap-snapshots/"
+kill -USR2 "$pid"
+echo ""
+echo "The snapshot file may take a few seconds to finish writing (heap size dependent)."
+echo "Once it appears, retrieve from your host with:"
+echo "  docker cp <container>:/config/heap-snapshots/<filename> ./"
+echo ""
+echo "To list current snapshots:"
+echo "  docker exec <container> ls -la /config/heap-snapshots/"


### PR DESCRIPTION
## Summary

Companion to #443. Issue #427 reporter ran the documented snapshot command and saw nothing happen:

```bash
docker exec <container> sh -c 'kill -USR2 $(pgrep -f "node /app/api/dist/index.js")'
```

**Root cause**: the Alpine runtime image installs only \`tini su-exec shadow\` (Dockerfile:96) — **no \`procps\`**. busybox silently expands \`$(pgrep ...)\` to an empty string, the resulting \`kill -USR2 ""\` is a syntax error / no-op, and the operator gets zero feedback. Every shipped image has had this latent problem — the heap-monitor itself was telling users to run a command that doesn't work.

## What ships

| File | Change |
|---|---|
| **NEW** \`docker/dump-heap.sh\` | Self-contained script. Walks \`/proc/[0-9]*\`, matches \`comm == "node"\` + cmdline containing the API entry script, sends SIGUSR2, prints clear feedback on where the snapshot lands and how to retrieve it. ~50 lines, zero external dependencies. |
| \`Dockerfile\` | \`COPY docker/dump-heap.sh /usr/local/bin/dump-heap\` + \`chmod +x\`. Updates the NODE_OPTIONS comment block to reference the new working command. |
| \`apps/api/src/plugins/heap-monitor.ts\` | Updates the warn message (which fires at heap > 90%) and module doc-comment to point at \`dump-heap\` instead of the broken pgrep one-liner. Also surfaces \`HEAP_AUTO_SNAPSHOT=1\` as the set-and-forget alternative. |

New command for operators:
\`\`\`bash
docker exec <container> dump-heap
\`\`\`

Output:
\`\`\`
Found API process: PID 121
Sending SIGUSR2 — V8 will write a .heapsnapshot to /config/heap-snapshots/

The snapshot file may take a few seconds to finish writing (heap size dependent).
Once it appears, retrieve from your host with:
  docker cp <container>:/config/heap-snapshots/<filename> ./
\`\`\`

## Why not just install procps?

Considered, rejected. No existing user has working \`pgrep\` scripts to preserve (the docs reference a command broken in every shipped image), and the helper script makes pgrep unnecessary anyway. Installing procps would be dead weight on a minimal Alpine image with no offsetting benefit.

## Test plan

- [x] \`sh -n docker/dump-heap.sh\` — shell syntax valid
- [x] \`tsc --noEmit\` — clean (heap-monitor.ts edit is comment + string only)
- [ ] Docker build smoke test will run in CI (Dockerfile changes path-trigger it)
- [ ] Drewskieza tests \`docker exec <container> dump-heap\` on the \`:dev\` build (post-merge)

The script logic is testable locally without a container build:
\`\`\`bash
# Sanity-check the /proc walk against a local node process
ls /proc/$$/comm   # should show "bash" or similar
sh -x docker/dump-heap.sh   # dry-run with trace (will fail to find API on host, by design)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)