### PR TITLE
fix(diagnostics): auto-capture heap snapshot at 90% + verify dump-heap

### DIFF
--- a/apps/api/src/plugins/heap-monitor.ts
+++ b/apps/api/src/plugins/heap-monitor.ts
@@ -25,28 +25,55 @@
  *   - heapPct > 0.8 → `info`
  *   - else          → `debug`
  *
+ * Auto-snapshot behavior (added 2026-05-12):
+ *   When a sample crosses WARN_HEAP_PCT, the plugin streams a heap snapshot
+ *   to /config/heap-snapshots/ automatically. Rate-limited to one snapshot
+ *   per AUTO_SNAPSHOT_MIN_INTERVAL_MS, with rotation that keeps the most
+ *   recent AUTO_SNAPSHOT_MAX_RETAINED files. This removes the timing
+ *   problem with the manual `dump-heap` helper (V8 takes 10-30s to write a
+ *   half-gig snapshot; operators were ls-ing before the file landed).
+ *
+ *   Opt out via HEAP_AUTO_SNAPSHOT_AT_WARN=0 if you don't want unsolicited
+ *   files in /config (e.g., low-disk hosts).
+ *
  * Companion runtime knobs:
  *   - `--heapsnapshot-signal=SIGUSR2`  Always on (set in Dockerfile
- *     NODE_OPTIONS). An operator who sees heap climbing in these logs can
- *     capture a snapshot on demand via the bundled helper:
+ *     NODE_OPTIONS). An operator can also capture a snapshot on demand via:
  *       docker exec <container> dump-heap
  *     The helper walks /proc to find the API process (no pgrep/procps
- *     required) and sends SIGUSR2. Snapshots land in
- *     /config/heap-snapshots/.
+ *     required), sends SIGUSR2, and waits for the snapshot to appear.
  *
  *   - `HEAP_AUTO_SNAPSHOT=1` env var  OPT-IN. When set, start-combined.sh
  *     appends --heapsnapshot-near-heap-limit=1 so V8 auto-captures a
  *     snapshot just before OOM. Off by default because each snapshot is ~3x
  *     the heap (~2.3 GB at the 768 MB cap) — a lot for small /config volumes.
- *     Set it in your compose / Unraid template alongside the other env vars.
  */
 
-import type { FastifyInstance } from "fastify";
+import {
+	createWriteStream,
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	statSync,
+	unlinkSync,
+} from "node:fs";
+import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
+import { getHeapSnapshot } from "node:v8";
+
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
+
+import { getErrorMessage } from "../lib/utils/error-message.js";
 
 const SAMPLE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes — enough resolution to spot leaks, light on log volume.
 const WARN_HEAP_PCT = 0.9;
 const INFO_HEAP_PCT = 0.8;
+
+const SNAPSHOT_DIR = process.env.HEAP_SNAPSHOT_DIR ?? "/config/heap-snapshots";
+const AUTO_SNAPSHOT_AT_WARN = process.env.HEAP_AUTO_SNAPSHOT_AT_WARN !== "0";
+const AUTO_SNAPSHOT_MIN_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes between captures
+const AUTO_SNAPSHOT_MAX_RETAINED = 3; // rotate aggressively — files are ~heap-size MB
 
 interface MemorySample {
 	heapUsedMB: number;
@@ -56,6 +83,92 @@ interface MemorySample {
 	arrayBuffersMB: number;
 	heapPct: number;
 	timestamp: number;
+}
+
+let lastSnapshotAt: number | null = null;
+let snapshotInFlight = false;
+
+/**
+ * Stream a heap snapshot to disk. Returns true if a file was written.
+ *
+ * Uses `getHeapSnapshot()` (returns Readable) rather than `writeHeapSnapshot()`
+ * (sync to filename) so the file write doesn't block the event loop beyond the
+ * unavoidable V8 stop-the-world walk. The walk itself still pauses execution
+ * (~2-5s on a 500 MB heap) but that's intrinsic to capturing a consistent
+ * snapshot.
+ */
+async function captureHeapSnapshot(log: FastifyBaseLogger, heapUsedMB: number): Promise<boolean> {
+	const now = Date.now();
+	if (snapshotInFlight) {
+		log.debug("Heap snapshot already in flight, skipping");
+		return false;
+	}
+	if (lastSnapshotAt && now - lastSnapshotAt < AUTO_SNAPSHOT_MIN_INTERVAL_MS) {
+		const minutesSince = Math.round((now - lastSnapshotAt) / 60_000);
+		log.debug(
+			{ minutesSinceLast: minutesSince },
+			"Heap snapshot rate-limited (< 30 min since last capture)",
+		);
+		return false;
+	}
+
+	snapshotInFlight = true;
+	try {
+		if (!existsSync(SNAPSHOT_DIR)) {
+			mkdirSync(SNAPSHOT_DIR, { recursive: true });
+		}
+
+		// Rotate old auto-snapshots. We only manage files we wrote ourselves
+		// (auto-* prefix) — manual `dump-heap` snapshots use V8's default
+		// "Heap.YYYYMMDD.*.heapsnapshot" naming and are left alone.
+		const existing = readdirSync(SNAPSHOT_DIR)
+			.filter((f) => f.startsWith("auto-") && f.endsWith(".heapsnapshot"))
+			.map((f) => {
+				const path = join(SNAPSHOT_DIR, f);
+				return { path, mtime: statSync(path).mtimeMs };
+			})
+			.sort((a, b) => a.mtime - b.mtime);
+
+		while (existing.length >= AUTO_SNAPSHOT_MAX_RETAINED) {
+			const oldest = existing.shift();
+			if (oldest) {
+				try {
+					unlinkSync(oldest.path);
+				} catch (rotateErr) {
+					log.warn({ err: rotateErr, path: oldest.path }, "Failed to rotate old heap snapshot");
+				}
+			}
+		}
+
+		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+		const filename = `auto-${timestamp}-${heapUsedMB}MB.heapsnapshot`;
+		const filepath = join(SNAPSHOT_DIR, filename);
+
+		log.warn(
+			{ filepath, heapUsedMB, expectedFinalSizeMB: heapUsedMB * 3 },
+			"Capturing heap snapshot (V8 may pause event loop ~2-5s)",
+		);
+
+		const captureStart = Date.now();
+		await pipeline(getHeapSnapshot(), createWriteStream(filepath));
+		const elapsedMs = Date.now() - captureStart;
+		const sizeMB = Math.round(statSync(filepath).size / 1024 / 1024);
+
+		lastSnapshotAt = Date.now();
+		log.warn(
+			{ filepath, sizeMB, elapsedMs },
+			`Heap snapshot saved. Retrieve via: docker cp <container>:${filepath} ./`,
+		);
+		return true;
+	} catch (err) {
+		log.error(
+			{ err, message: getErrorMessage(err), snapshotDir: SNAPSHOT_DIR },
+			"Failed to capture heap snapshot — check that the directory is writable by the API user",
+		);
+		return false;
+	} finally {
+		snapshotInFlight = false;
+	}
 }
 
 const heapMonitorPlugin = fastifyPlugin(
@@ -106,8 +219,16 @@ const heapMonitorPlugin = fastifyPlugin(
 			if (heapPct >= WARN_HEAP_PCT) {
 				app.log.warn(
 					payload,
-					"Heap usage above 90% — capture a snapshot before OOM: `docker exec <container> dump-heap` (snapshot lands in /config/heap-snapshots/). Or set HEAP_AUTO_SNAPSHOT=1 in env + restart to auto-capture next near-OOM.",
+					AUTO_SNAPSHOT_AT_WARN
+						? "Heap usage above 90% — auto-capturing snapshot to /config/heap-snapshots/ (set HEAP_AUTO_SNAPSHOT_AT_WARN=0 to disable)"
+						: "Heap usage above 90% — capture a snapshot before OOM: `docker exec <container> dump-heap`",
 				);
+				if (AUTO_SNAPSHOT_AT_WARN) {
+					// Fire-and-forget — captureHeapSnapshot is self-rate-limited and
+					// self-rotating; we don't want sampling to block on the (potentially
+					// multi-second) V8 walk and disk write.
+					void captureHeapSnapshot(app.log, heapUsedMB);
+				}
 			} else if (heapPct >= INFO_HEAP_PCT) {
 				app.log.info(payload, "Heap usage above 80%");
 			} else {

--- a/docker/dump-heap.sh
+++ b/docker/dump-heap.sh
@@ -9,10 +9,17 @@
 # Usage: docker exec <container> dump-heap
 #
 # Self-contained — walks /proc to find the API process, no procps/pgrep
-# required.
+# required. Polls the snapshot directory for up to POLL_TIMEOUT_SEC
+# seconds so operators get clear pass/fail feedback instead of having to
+# `ls` repeatedly and guess whether V8 silently failed.
 
 set -eu
 
+SNAPSHOT_DIR="${HEAP_SNAPSHOT_DIR:-/config/heap-snapshots}"
+POLL_TIMEOUT_SEC=120
+POLL_INTERVAL_SEC=2
+
+# --- find API process ---
 pid=""
 for proc in /proc/[0-9]*; do
 	[ -r "$proc/comm" ] || continue
@@ -37,12 +44,87 @@ if [ -z "$pid" ]; then
 fi
 
 echo "Found API process: PID $pid"
-echo "Sending SIGUSR2 — V8 will write a .heapsnapshot to /config/heap-snapshots/"
-kill -USR2 "$pid"
-echo ""
-echo "The snapshot file may take a few seconds to finish writing (heap size dependent)."
-echo "Once it appears, retrieve from your host with:"
-echo "  docker cp <container>:/config/heap-snapshots/<filename> ./"
-echo ""
-echo "To list current snapshots:"
-echo "  docker exec <container> ls -la /config/heap-snapshots/"
+
+# --- verify NODE_OPTIONS has --heapsnapshot-signal=SIGUSR2 ---
+# Without this flag, SIGUSR2 will be sent but Node will not write a
+# snapshot. Catches the case where an operator overrode NODE_OPTIONS in
+# their compose file (issue #427).
+if [ -r "/proc/$pid/environ" ]; then
+	node_options=$(tr '\0' '\n' < "/proc/$pid/environ" | grep '^NODE_OPTIONS=' | head -1 || true)
+	case "$node_options" in
+		*heapsnapshot-signal=SIGUSR2*)
+			# Good — flag is set.
+			;;
+		"")
+			echo "WARNING: NODE_OPTIONS not visible (cannot verify --heapsnapshot-signal)" >&2
+			;;
+		*)
+			echo "ERROR: NODE_OPTIONS is set but does not include --heapsnapshot-signal=SIGUSR2" >&2
+			echo "  Current: $node_options" >&2
+			echo "  V8 will NOT write a snapshot on SIGUSR2. Restore the default Dockerfile NODE_OPTIONS or add the flag." >&2
+			exit 1
+			;;
+	esac
+fi
+
+# --- snapshot the dir state BEFORE sending the signal ---
+mkdir -p "$SNAPSHOT_DIR" 2>/dev/null || true
+before_count=$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.heapsnapshot' 2>/dev/null | wc -l | tr -d ' ')
+
+echo "Snapshot dir: $SNAPSHOT_DIR (currently holds $before_count file(s))"
+echo "Sending SIGUSR2..."
+if ! kill -USR2 "$pid"; then
+	echo "ERROR: kill -USR2 $pid failed — process may have exited" >&2
+	exit 1
+fi
+
+# --- poll for new file ---
+echo "Waiting up to ${POLL_TIMEOUT_SEC}s for V8 to finish writing snapshot..."
+elapsed=0
+while [ "$elapsed" -lt "$POLL_TIMEOUT_SEC" ]; do
+	sleep "$POLL_INTERVAL_SEC"
+	elapsed=$((elapsed + POLL_INTERVAL_SEC))
+	after_count=$(find "$SNAPSHOT_DIR" -maxdepth 1 -name '*.heapsnapshot' 2>/dev/null | wc -l | tr -d ' ')
+	if [ "$after_count" -gt "$before_count" ]; then
+		# Find the newest matching file by mtime (BusyBox-portable).
+		newest=""
+		newest_mtime=0
+		for f in "$SNAPSHOT_DIR"/*.heapsnapshot; do
+			[ -f "$f" ] || continue
+			# Use ls timestamps via stat fallback chain.
+			mtime=$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || echo 0)
+			if [ "$mtime" -gt "$newest_mtime" ]; then
+				newest_mtime=$mtime
+				newest=$f
+			fi
+		done
+		size_bytes=$(wc -c < "$newest" 2>/dev/null || echo 0)
+		size_mb=$((size_bytes / 1024 / 1024))
+		echo ""
+		echo "Snapshot captured (${elapsed}s):"
+		echo "  Path: $newest"
+		echo "  Size: ${size_mb} MB"
+		echo ""
+		echo "Retrieve from host:"
+		basename=$(basename "$newest")
+		echo "  docker cp <container>:$newest ./"
+		echo "  # then gzip it before sharing: gzip $basename"
+		exit 0
+	fi
+done
+
+# --- timeout — surface diagnostics so the operator knows what to check ---
+echo "" >&2
+echo "TIMEOUT: no .heapsnapshot file appeared in ${POLL_TIMEOUT_SEC}s." >&2
+echo "" >&2
+echo "Diagnostics:" >&2
+echo "  Snapshot dir:       $SNAPSHOT_DIR" >&2
+echo "  Dir listing:        $(ls -ld "$SNAPSHOT_DIR" 2>&1 || echo 'unable to stat')" >&2
+echo "  Process CWD:        $(readlink "/proc/$pid/cwd" 2>/dev/null || echo 'unable to read /proc/$pid/cwd')" >&2
+echo "  Process still alive: $([ -d "/proc/$pid" ] && echo yes || echo NO — process exited)" >&2
+if [ -r "/proc/$pid/environ" ]; then
+	echo "  NODE_OPTIONS:       $(tr '\0' '\n' < /proc/$pid/environ | grep '^NODE_OPTIONS=' | head -1 || echo '(not set)')" >&2
+fi
+echo "" >&2
+echo "If the process exited, set HEAP_AUTO_SNAPSHOT_AT_WARN=1 (default) and let heap-monitor auto-capture next time heap crosses 90%." >&2
+exit 1


### PR DESCRIPTION
## Summary
- `heap-monitor.ts` auto-captures a streaming `.heapsnapshot` to `/config/heap-snapshots/` when `heapPct >= 0.9`. Rate-limited to 1 per 30 min, retains last 3 (rotation only touches `auto-*` files — manual SIGUSR2 captures untouched). Uses `getHeapSnapshot() + pipeline()` so the file write doesn't block the event loop beyond V8's intrinsic stop-the-world walk.
- `dump-heap.sh` now verifies `NODE_OPTIONS` contains `--heapsnapshot-signal=SIGUSR2` before signaling, polls the snapshot dir for up to 120s after sending SIGUSR2, and on timeout dumps diagnostics (dir perms, process CWD, process liveness, current `NODE_OPTIONS`).
- Opt out via `HEAP_AUTO_SNAPSHOT_AT_WARN=0`; override snapshot dir via `HEAP_SNAPSHOT_DIR=...`.

## Why
The user in #427 reported on v2.18.6 `:dev`: `dump-heap` printed "Found API process… Sending SIGUSR2" but the snapshot directory remained empty. Root cause: V8 takes 10-30+ seconds to write a multi-hundred-MB snapshot; the script exited the moment the signal was sent, the user `ls`'d immediately, and (if the container restarted post-OOM) the in-flight write was lost. The script had zero feedback for that failure mode.

The auto-capture half makes the manual command mostly unnecessary — the next time heap crosses 90%, we get a snapshot whether or not the user is watching. The hardened `dump-heap` turns silent failure into actionable failure for ad-hoc captures.

Refs #427. Root-cause fix (streaming JSON parse for arr-SDK `getAll()` — the actual leak path on large Lidarr libraries) is the follow-up to this.

## Test plan
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec vitest run src/plugins` — 16/16 pass
- [x] `sh -n docker/dump-heap.sh` — syntax OK
- [ ] Manual: pull `:dev` after merge, push heap above 90% (e.g. let library sync run on a large Lidarr instance), confirm `auto-*.heapsnapshot` lands in `/config/heap-snapshots/` automatically
- [ ] Manual: run `docker exec <container> dump-heap` and confirm it polls + reports path on success
- [ ] Manual: override `NODE_OPTIONS` to strip `--heapsnapshot-signal=SIGUSR2`, confirm `dump-heap` fails fast with the warning message

🤖 Generated with [Claude Code](https://claude.com/claude-code)