### PR TITLE
fix(dashboard-statistics): stream-aggregate the bulk library list

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -28,6 +28,7 @@
 		"@prisma/adapter-pg": "^7.8.0",
 		"@prisma/client": "^7.8.0",
 		"@simplewebauthn/server": "^13.3.0",
+		"@streamparser/json": "^0.0.22",
 		"argon2": "^0.44.0",
 		"arr-sdk": "^0.6.0",
 		"better-sqlite3": "^12.9.0",

--- a/apps/api/src/lib/arr/__tests__/library-stream.test.ts
+++ b/apps/api/src/lib/arr/__tests__/library-stream.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for streamLibraryItems — the streaming JSON consumer that replaces
+ * the SDK's buffer-then-parse `getAll()` for the bulk library-sync path
+ * (issue #427).
+ *
+ * Coverage:
+ * - Yields each top-level array element as a separate object
+ * - Handles chunked input where boundaries fall mid-object
+ * - Throws on HTTP error status (4xx/5xx)
+ * - Throws on malformed JSON
+ * - Filters non-object top-level values (defensive — real arr endpoints
+ *   return arrays-of-objects, but we should never yield a primitive)
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../../lib/prisma.js";
+import type { ArrClientFactory } from "../client-factory.js";
+import { streamLibraryItems } from "../library-stream.js";
+
+const INSTANCE_ID = "instance-1";
+
+function makeMockInstance(service: "SONARR" | "RADARR" | "LIDARR" | "READARR") {
+	return {
+		id: INSTANCE_ID,
+		label: `Test ${service}`,
+		service,
+		baseUrl: "http://localhost:8989",
+		encryptedApiKey: "enc-key",
+		encryptionIv: "iv",
+	} as ServiceInstance & { service: typeof service };
+}
+
+function makeMockLog(): FastifyBaseLogger {
+	return {
+		level: "debug",
+		debug: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		fatal: vi.fn(),
+		trace: vi.fn(),
+		silent: vi.fn(),
+		child: vi.fn(() => makeMockLog()),
+	} as unknown as FastifyBaseLogger;
+}
+
+/** Build a Response whose body is a stream of UTF-8 chunks. */
+function streamingResponse(chunks: string[], status = 200): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const c of chunks) controller.enqueue(encoder.encode(c));
+			controller.close();
+		},
+	});
+	return new Response(stream, { status });
+}
+
+function makeFactory(response: Response | Response[]): ArrClientFactory {
+	const queue = Array.isArray(response) ? [...response] : [response];
+	return {
+		rawRequest: vi.fn().mockImplementation(async () => {
+			return queue.shift() ?? new Response("", { status: 500 });
+		}),
+	} as unknown as ArrClientFactory;
+}
+
+async function collect<T>(gen: AsyncIterable<T>): Promise<T[]> {
+	const out: T[] = [];
+	for await (const item of gen) out.push(item);
+	return out;
+}
+
+describe("streamLibraryItems", () => {
+	it("yields each top-level array element of the JSON response", async () => {
+		const body = JSON.stringify([
+			{ id: 1, title: "A" },
+			{ id: 2, title: "B" },
+			{ id: 3, title: "C" },
+		]);
+		const factory = makeFactory(streamingResponse([body]));
+		const log = makeMockLog();
+
+		const items = await collect(streamLibraryItems(factory, makeMockInstance("LIDARR"), log));
+
+		expect(items).toHaveLength(3);
+		expect(items[0]).toMatchObject({ id: 1, title: "A" });
+		expect(items[2]).toMatchObject({ id: 3, title: "C" });
+	});
+
+	it("parses correctly when chunks split mid-object", async () => {
+		const body = JSON.stringify([
+			{ id: 1, name: "Artist One" },
+			{ id: 2, name: "Artist Two" },
+		]);
+		// Chunk every 7 bytes so boundaries fall mid-string and mid-object.
+		const chunks: string[] = [];
+		for (let i = 0; i < body.length; i += 7) {
+			chunks.push(body.slice(i, i + 7));
+		}
+		expect(chunks.length).toBeGreaterThan(2);
+
+		const factory = makeFactory(streamingResponse(chunks));
+		const items = await collect(
+			streamLibraryItems(factory, makeMockInstance("LIDARR"), makeMockLog()),
+		);
+
+		expect(items).toHaveLength(2);
+		expect(items[1]).toMatchObject({ id: 2, name: "Artist Two" });
+	});
+
+	it("throws on HTTP error status with a bounded body preview", async () => {
+		const factory = makeFactory(streamingResponse(["Internal Server Error"], 500));
+		const log = makeMockLog();
+
+		await expect(
+			collect(streamLibraryItems(factory, makeMockInstance("LIDARR"), log)),
+		).rejects.toThrow(/HTTP 500/);
+	});
+
+	it("throws on malformed JSON", async () => {
+		const factory = makeFactory(streamingResponse(['[{"id": 1, "bro']));
+		const log = makeMockLog();
+
+		await expect(
+			collect(streamLibraryItems(factory, makeMockInstance("LIDARR"), log)),
+		).rejects.toThrow();
+	});
+
+	it("uses the correct endpoint path per service", async () => {
+		// Verify we hit /api/v1/artist for Lidarr (matches the SDK's getAll
+		// path for issue #427's affected client).
+		const factory = makeFactory(streamingResponse(["[]"]));
+		await collect(streamLibraryItems(factory, makeMockInstance("LIDARR"), makeMockLog()));
+
+		expect(factory.rawRequest).toHaveBeenCalledWith(
+			expect.objectContaining({ service: "LIDARR" }),
+			"/api/v1/artist",
+			expect.objectContaining({ method: "GET" }),
+		);
+	});
+
+	it("uses /api/v3/series for Sonarr and /api/v3/movie for Radarr", async () => {
+		const factory = makeFactory([streamingResponse(["[]"]), streamingResponse(["[]"])]);
+		await collect(streamLibraryItems(factory, makeMockInstance("SONARR"), makeMockLog()));
+		await collect(streamLibraryItems(factory, makeMockInstance("RADARR"), makeMockLog()));
+
+		expect(factory.rawRequest).toHaveBeenNthCalledWith(
+			1,
+			expect.anything(),
+			"/api/v3/series",
+			expect.anything(),
+		);
+		expect(factory.rawRequest).toHaveBeenNthCalledWith(
+			2,
+			expect.anything(),
+			"/api/v3/movie",
+			expect.anything(),
+		);
+	});
+
+	it("skips non-object top-level values (defensive — primitives in an array)", async () => {
+		// Real *arr endpoints never return mixed arrays, but be defensive: we
+		// only emit Records, not numbers/strings/nulls. This guards against a
+		// future endpoint shape change yielding garbage.
+		const body = JSON.stringify([{ id: 1, title: "A" }, 42, "skip me", null]);
+		const factory = makeFactory(streamingResponse([body]));
+		const items = await collect(
+			streamLibraryItems(factory, makeMockInstance("LIDARR"), makeMockLog()),
+		);
+
+		expect(items).toHaveLength(1);
+		expect(items[0]).toMatchObject({ id: 1, title: "A" });
+	});
+
+	it("yields nothing for an empty array without error", async () => {
+		const factory = makeFactory(streamingResponse(["[]"]));
+		const items = await collect(
+			streamLibraryItems(factory, makeMockInstance("READARR"), makeMockLog()),
+		);
+		expect(items).toEqual([]);
+	});
+});

--- a/apps/api/src/lib/arr/library-stream.ts
+++ b/apps/api/src/lib/arr/library-stream.ts
@@ -1,0 +1,173 @@
+/**
+ * Streaming library fetcher for the ARR services.
+ *
+ * Background (issue #427):
+ * The SDK's `client.series.getAll()` / `movie.getAll()` / `artist.getAll()` /
+ * `author.getAll()` calls `response.json()` under the hood, which buffers the
+ * ENTIRE response body in memory and then parses it into a JS array in one
+ * allocation. For a 1.5M-track Lidarr library (~50k artist objects with
+ * embedded statistics) this is a 200-500 MB heap spike before any of the
+ * library-sync pop-drain logic (PR #443) can release memory.
+ *
+ * This helper bypasses the SDK for that one heavy fetch. It streams the
+ * response body through @streamparser/json, yielding individual items as
+ * they parse. Peak memory is bounded by:
+ *   - The streaming parser's internal buffer (~tens of KB)
+ *   - One in-flight HTTP chunk (~32 KB from undici)
+ *   - The caller's current batch
+ *
+ * Everything else (cutoff-unmet, tag lookups, individual item operations)
+ * keeps using the SDK — those endpoints are paginated or small enough that
+ * the buffer-then-parse pattern is fine.
+ */
+
+import { JSONParser } from "@streamparser/json";
+import type { FastifyBaseLogger } from "fastify";
+
+import type { ServiceInstance } from "../../lib/prisma.js";
+import { getErrorMessage } from "../utils/error-message.js";
+import type { ArrClientFactory, ClientInstanceData } from "./client-factory.js";
+
+/**
+ * The bulk-list endpoint per ARR service. These are the same endpoints the
+ * SDK's `getAll()` calls hit — we just consume them via a streaming parser
+ * instead of `response.json()`.
+ */
+const BULK_LIST_PATH: Record<string, string> = {
+	SONARR: "/api/v3/series",
+	RADARR: "/api/v3/movie",
+	LIDARR: "/api/v1/artist",
+	READARR: "/api/v1/author",
+};
+
+// Allow plenty of headroom for huge libraries — Lidarr with 1.5M tracks can
+// take a few minutes end-to-end. The streaming nature means we yield work to
+// the caller continuously, so this is just an upper bound on total wall time.
+const STREAM_TIMEOUT_MS = 10 * 60_000; // 10 minutes
+
+export interface StreamLibraryOptions {
+	/** Override the timeout (mostly for tests). */
+	timeoutMs?: number;
+}
+
+/**
+ * Stream items from the ARR service's bulk-list endpoint.
+ *
+ * @throws if the response is not OK (HTTP 4xx/5xx) or if the parser hits
+ *         malformed JSON. Caller is responsible for transaction handling and
+ *         partial-progress semantics.
+ */
+export async function* streamLibraryItems(
+	factory: ArrClientFactory,
+	instance: ClientInstanceData & Pick<ServiceInstance, "service" | "label">,
+	log: FastifyBaseLogger,
+	options?: StreamLibraryOptions,
+): AsyncGenerator<Record<string, unknown>, void, undefined> {
+	const path = BULK_LIST_PATH[instance.service];
+	if (!path) {
+		throw new Error(`streamLibraryItems: unsupported service ${instance.service}`);
+	}
+
+	const startedAt = Date.now();
+	const response = await factory.rawRequest(instance, path, {
+		method: "GET",
+		timeout: options?.timeoutMs ?? STREAM_TIMEOUT_MS,
+	});
+
+	if (!response.ok) {
+		// Surface the body for diagnostic logging — bounded to first 512 chars
+		// so we never log entire error pages.
+		const preview = (await response.text().catch(() => "")).slice(0, 512);
+		throw new Error(
+			`streamLibraryItems: HTTP ${response.status} ${response.statusText} from ${path} — ${preview}`,
+		);
+	}
+
+	if (!response.body) {
+		throw new Error(`streamLibraryItems: empty response body from ${path}`);
+	}
+
+	// `$.*` selects every direct child of the root. For the ARR bulk-list
+	// endpoints (top-level JSON arrays), that means each array element.
+	// `keepStack: false` lets the parser discard processed elements instead of
+	// retaining them for ancestor queries — our memory win.
+	const parser = new JSONParser({ paths: ["$.*"], keepStack: false });
+	const queue: Array<Record<string, unknown>> = [];
+	let parserError: Error | null = null;
+	let itemCount = 0;
+
+	parser.onValue = ({ value }) => {
+		// Skip primitives. The endpoints return arrays-of-objects; a primitive
+		// at the top level would be malformed input.
+		if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+			queue.push(value as Record<string, unknown>);
+			itemCount++;
+		}
+	};
+	parser.onError = (err) => {
+		parserError = err;
+	};
+
+	const reader = response.body.getReader();
+	try {
+		while (true) {
+			if (parserError) throw parserError;
+			const { done, value } = await reader.read();
+			if (done) break;
+			parser.write(value);
+			while (queue.length > 0) {
+				const item = queue.shift();
+				if (item) yield item;
+			}
+		}
+		// Flush the parser — but only if it hasn't already auto-ended after a
+		// complete top-level value. @streamparser/json with the default
+		// `separator: undefined` auto-ends at `]`/`}`. Calling end() again on
+		// an already-ended tokenizer throws "ended in the middle of a token".
+		// We still call end() when not auto-ended so that a truncated stream
+		// (network disconnect mid-JSON) surfaces a clear error.
+		if (!parser.isEnded) {
+			parser.end();
+		}
+		if (parserError) throw parserError;
+		while (queue.length > 0) {
+			const item = queue.shift();
+			if (item) yield item;
+		}
+
+		log.debug(
+			{
+				instanceId: instance.id,
+				service: instance.service,
+				itemCount,
+				durationMs: Date.now() - startedAt,
+			},
+			"Streamed library items from ARR endpoint",
+		);
+	} catch (err) {
+		log.warn(
+			{
+				err,
+				message: getErrorMessage(err),
+				instanceId: instance.id,
+				service: instance.service,
+				itemsBeforeError: itemCount,
+			},
+			"Stream of ARR library items failed",
+		);
+		throw err;
+	} finally {
+		// Cancel reads if the consumer aborted (e.g., transaction failure
+		// upstream). releaseLock() alone doesn't cancel the underlying body
+		// stream; cancel() does — important so we don't leak an open
+		// connection to the *arr instance.
+		try {
+			reader.releaseLock();
+		} catch {
+			// ignore — reader may already be released if done was hit
+		}
+		response.body.cancel().catch(() => {
+			// Ignore — body may already be drained/closed.
+		});
+	}
+}

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient, ServiceType } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
 import type { Encryptor } from "../../auth/encryption.js";
-import { type SyncExecutorDeps, syncInstance } from "../sync-executor.js";
+import { type LibraryStreamFn, type SyncExecutorDeps, syncInstance } from "../sync-executor.js";
 
 const MOCK_USER_ID = "user-1";
 const INSTANCE_ID = "instance-1";
@@ -306,11 +306,22 @@ function setupSync(
 	const mockPrisma = createMockPrisma({ existingItems });
 	const arrClientFactory = buildArrClientFactory(service, items);
 
+	// Inject a stream that yields the same items synchronously — the
+	// SDK's `.getAll()` mocks set in buildArrClientFactory are still
+	// available for non-bulk endpoints (wanted.cutoff, tag.getAll) but
+	// the production bulk-fetch path goes through this stream now.
+	const streamLibraryItems: LibraryStreamFn = async function* () {
+		for (const item of items) {
+			yield item;
+		}
+	};
+
 	const deps: SyncExecutorDeps & { prisma: ReturnType<typeof createMockPrisma> } = {
 		prisma: mockPrisma,
 		arrClientFactory,
 		encryptor: createMockEncryptor(),
 		log,
+		streamLibraryItems,
 	};
 
 	const instance = createMockInstance(service);
@@ -523,15 +534,16 @@ describe("syncInstance", () => {
 			expect(result.itemsProcessed).toBe(1);
 		});
 
-		// Pins the issue #427 pop-based batch drain. Two assertions:
-		// (a) every input id is touched exactly once — sync correctness regardless
-		//     of drain shape.
-		// (b) the FIRST update targets the LAST input id — only true for a
-		//     tail-popping drain (or any other shrinking pattern that consumes
-		//     from the end). A future refactor that re-introduces `slice()` or
-		//     builds a normalized forward copy would process id=1 first and fail
-		//     this assertion, surfacing the regression.
-		it("Lidarr: pop-based drain processes tail-first and touches every arrItemId (issue #427)", async () => {
+		// Pins the issue #427 streaming-batch shape. PR #443 used pop-drain
+		// (tail-first) to release retention during processing; this PR replaces
+		// that with a streaming consumer that accumulates per-batch and yields
+		// in source order. Two assertions:
+		// (a) every input id is touched exactly once — sync correctness
+		//     regardless of consumption order.
+		// (b) the FIRST update targets the HEAD (id=1) — invariant of stream
+		//     consumption. A regression to materializing the whole array and
+		//     processing some other order would fail this.
+		it("Lidarr: streaming consumer processes head-first and touches every arrItemId (issue #427)", async () => {
 			const COUNT = 150; // spans 2 batches at BATCH_SIZE=100
 			const rawItems = Array.from({ length: COUNT }, (_, i) =>
 				makeRawItem({ id: i + 1, artistName: `Artist ${i + 1}` }),
@@ -558,9 +570,10 @@ describe("syncInstance", () => {
 				expect(touchedIds.has(`cache-${i}`)).toBe(true);
 			}
 
-			// (b) Order: first update targets the tail (id=150). Re-introducing
-			// slice() would process id=1 first and fail this.
-			expect(mockPrisma._txUpdates[0]?.where.id).toBe(`cache-${COUNT}`);
+			// (b) Order: first update targets the head (id=1) — invariant of
+			// streaming in source order. A regression that buffers everything
+			// and reverses would fail.
+			expect(mockPrisma._txUpdates[0]?.where.id).toBe("cache-1");
 		});
 	});
 

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -10,6 +10,7 @@ import { LidarrClient, RadarrClient, ReadarrClient, SonarrClient } from "arr-sdk
 import type { FastifyBaseLogger } from "fastify";
 import type { Prisma, PrismaClient, ServiceInstance } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
+import { streamLibraryItems as defaultStreamLibraryItems } from "../arr/library-stream.js";
 import type { Encryptor } from "../auth/encryption.js";
 import { triggerLabelSyncForItem } from "../label-sync/trigger-for-item.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
@@ -38,11 +39,32 @@ export interface SyncResult {
 	error?: string;
 }
 
+/**
+ * Signature for the bulk library streamer. Production uses
+ * `streamLibraryItems` from lib/arr/library-stream.ts (streams the raw HTTP
+ * body through @streamparser/json so peak memory is bounded by batch size,
+ * not library size — see issue #427).
+ *
+ * Exposed as a SyncExecutorDeps override so tests can yield from an array
+ * without standing up a fetch mock.
+ */
+export type LibraryStreamFn = (
+	factory: ArrClientFactory,
+	instance: ServiceInstance,
+	log: FastifyBaseLogger,
+) => AsyncGenerator<Record<string, unknown>, void, undefined>;
+
 export interface SyncExecutorDeps {
 	prisma: PrismaClient;
 	arrClientFactory: ArrClientFactory;
 	encryptor: Encryptor;
 	log: FastifyBaseLogger;
+	/**
+	 * Optional override for the bulk library streamer. Defaults to the
+	 * @streamparser/json-backed implementation in lib/arr/library-stream.ts.
+	 * Tests inject an array-yielding async generator to avoid mocking fetch.
+	 */
+	streamLibraryItems?: LibraryStreamFn;
 }
 
 /**
@@ -198,7 +220,14 @@ export async function syncInstance(
 	deps: SyncExecutorDeps,
 	instance: ServiceInstance,
 ): Promise<SyncResult> {
-	const { prisma, arrClientFactory, encryptor, log } = deps;
+	const {
+		prisma,
+		arrClientFactory,
+		encryptor,
+		log,
+		streamLibraryItems: streamLibraryItemsOverride,
+	} = deps;
+	const streamLibraryItems = streamLibraryItemsOverride ?? defaultStreamLibraryItems;
 	const startTime = Date.now();
 	const tagDeltaService = isTagDeltaService(instance.service);
 
@@ -230,30 +259,25 @@ export async function syncInstance(
 		const client = arrClientFactory.create(instance);
 		const service = instance.service.toLowerCase() as LibraryService;
 
-		// Sample heap BEFORE the full-library fetch so heap-monitor data can
-		// distinguish the parse-spike contribution (issue #427) from the
-		// batch-loop retention window.
+		// Sample heap BEFORE the bulk-library stream so heap-monitor data can
+		// distinguish the streamer's working set (issue #427: streaming
+		// JSON parse via @streamparser/json) from the batch retention window.
 		logMemoryPhase(log, instance.id, "before-fetch");
 
-		let rawItems: unknown[];
-
-		if (client instanceof SonarrClient) {
-			rawItems = await client.series.getAll();
-		} else if (client instanceof RadarrClient) {
-			rawItems = await client.movie.getAll();
-		} else if (client instanceof LidarrClient) {
-			rawItems = await client.artist.getAll();
-		} else if (client instanceof ReadarrClient) {
-			rawItems = await client.author.getAll();
-		} else {
+		if (
+			!(client instanceof SonarrClient) &&
+			!(client instanceof RadarrClient) &&
+			!(client instanceof LidarrClient) &&
+			!(client instanceof ReadarrClient)
+		) {
 			throw new Error(`Unsupported service type: ${instance.service}`);
 		}
 
-		log.debug(
-			{ instanceId: instance.id, itemCount: rawItems.length },
-			"Fetched items from ARR instance",
-		);
-		logMemoryPhase(log, instance.id, "after-fetch");
+		// The bulk-list endpoint is consumed via a streaming JSON parser.
+		// Items yield one at a time; we accumulate into per-transaction
+		// batches below. Peak memory during streaming is bounded by the
+		// batch size, not the library size — the win for issue #427.
+		const itemStream = streamLibraryItems(arrClientFactory, instance, log);
 
 		const cutoffUnmetIds = new Set<number>();
 		if (client instanceof SonarrClient || client instanceof RadarrClient) {
@@ -357,27 +381,19 @@ export async function syncInstance(
 		const seenKeys = new Set<string>();
 		const BATCH_SIZE = 100;
 
-		// Process items in batches directly from rawItems — avoids building
-		// a full parallel normalized array in memory.
-		//
-		// Pop-based drain (issue #427): the previous `for (i ... slice)` shape
-		// kept `rawItems` fully alive until the loop completed because every
-		// slice held an implicit reference back to the source array's
-		// elements. For a 1.5M-track Lidarr library (~50k artist objects,
-		// 200-500 MB parsed) the retention window spanned the entire batch
-		// transaction chain. Pop-draining shrinks the array as we go, so each
-		// processed batch is eligible for GC during the next transaction's
-		// await. Reverse processing order is safe: every item still gets
-		// exactly one create/update and sync is order-independent.
-		while (rawItems.length > 0) {
-			const rawBatch: Array<Record<string, unknown>> = [];
-			const batchSize = Math.min(BATCH_SIZE, rawItems.length);
-			for (let j = 0; j < batchSize; j++) {
-				rawBatch.push(rawItems.pop() as Record<string, unknown>);
-			}
+		// Accumulate streamed items into BATCH_SIZE-sized batches and process
+		// each batch in its own transaction. Peak memory during this loop is
+		// one batch plus the streaming parser's small internal buffer —
+		// independent of total library size (issue #427).
+		let rawBatch: Array<Record<string, unknown>> = [];
+		let streamedItemCount = 0;
 
+		// Inline helper so we don't duplicate the transaction body for the
+		// final partial-batch case below.
+		const processBatch = async (batch: Array<Record<string, unknown>>): Promise<void> => {
+			if (batch.length === 0) return;
 			await prisma.$transaction(async (tx) => {
-				for (const raw of rawBatch) {
+				for (const raw of batch) {
 					const item = buildLibraryItem(instance, service, raw);
 					const arrItemId = typeof item.id === "string" ? Number.parseInt(item.id, 10) : item.id;
 					const key = `${arrItemId}-${item.type}`;
@@ -438,12 +454,27 @@ export async function syncInstance(
 					result.itemsProcessed++;
 				}
 			});
+		};
+
+		for await (const raw of itemStream) {
+			rawBatch.push(raw);
+			streamedItemCount++;
+			if (rawBatch.length >= BATCH_SIZE) {
+				const fullBatch = rawBatch;
+				rawBatch = [];
+				await processBatch(fullBatch);
+			}
+		}
+		if (rawBatch.length > 0) {
+			const finalBatch = rawBatch;
+			rawBatch = [];
+			await processBatch(finalBatch);
 		}
 
-		// Defensive: pop-drain already empties rawItems, but reassign to a
-		// fresh array so any retained closure reference (current or future)
-		// can release the original buffer immediately.
-		rawItems = [];
+		log.debug(
+			{ instanceId: instance.id, itemCount: streamedItemCount },
+			"Streamed items from ARR instance",
+		);
 
 		logMemoryPhase(log, instance.id, "after-batch-writes");
 

--- a/apps/api/src/lib/statistics/dashboard-statistics.ts
+++ b/apps/api/src/lib/statistics/dashboard-statistics.ts
@@ -46,6 +46,44 @@ import {
 	updateTagBreakdown,
 } from "./statistics-utils.js";
 
+/**
+ * Optional injection for streaming the bulk library list (issue #427).
+ *
+ * Production callers (routes/dashboard/statistics-routes.ts) bind this to
+ * `streamLibraryItems(arrClientFactory, instance, log)` from
+ * lib/arr/library-stream.ts so peak memory during stats is bounded by what
+ * the aggregation loop holds, not by library size.
+ *
+ * When not provided, the function falls back to the SDK's buffer-then-parse
+ * `getAll()` — preserves the existing test API (tests inject mock clients,
+ * not factories).
+ */
+export type StatsStreamItems = () => AsyncIterable<Record<string, unknown>>;
+
+export interface StatsOptions {
+	/** Stream the bulk library list — overrides the SDK's getAll() path. */
+	streamItems?: StatsStreamItems;
+}
+
+/** Adapt an existing array to the AsyncIterable contract used by streaming. */
+async function* asAsyncIterable<T>(items: T[]): AsyncIterable<T> {
+	for (const item of items) yield item;
+}
+
+/**
+ * Pick the iterable for the bulk library list: streamed if injected, else
+ * fall back to a buffered `getAll()` wrapped in `asAsyncIterable`. Both paths
+ * feed the same aggregation loop downstream.
+ */
+async function chooseBulkIterable<T>(
+	streamItems: StatsStreamItems | undefined,
+	fetchAll: () => Promise<T[]>,
+): Promise<AsyncIterable<Record<string, unknown>>> {
+	if (streamItems) return streamItems();
+	const items = (await safeRequest(fetchAll).then((r) => r ?? [])) as Record<string, unknown>[];
+	return asAsyncIterable(items);
+}
+
 // ============================================================================
 // Empty Statistics Templates
 // ============================================================================
@@ -167,6 +205,7 @@ export const fetchSonarrStatisticsWithSdk = async (
 	instanceName: string,
 	instanceBaseUrl: string,
 	instanceExternalUrl?: string,
+	options?: StatsOptions,
 ): Promise<SonarrStatistics> => {
 	const instanceInfo: InstanceInfo = {
 		instanceId,
@@ -175,9 +214,11 @@ export const fetchSonarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	// Fetch all data in parallel
-	const [series, diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.series.getAll()).then((r) => r ?? []),
+	// Small ancillary calls — these endpoints return small payloads so the
+	// buffer-then-parse pattern is fine. Series goes through the streaming
+	// path when `options.streamItems` is provided (production) so peak
+	// memory is bounded by the aggregation state, not library size.
+	const [diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.cutoff({ page: 1, pageSize: 1 })).then(
@@ -207,43 +248,68 @@ export const fetchSonarrStatisticsWithSdk = async (
 	const qualityBreakdown: Record<string, number> = {};
 	const tagBreakdown: Record<string, number> = {};
 
-	for (const entry of series) {
-		if (!entry) continue;
-		totalSeries += 1;
-		if (entry.monitored !== false) monitoredSeries += 1;
+	const seriesIterable = await chooseBulkIterable(options?.streamItems, () =>
+		client.series.getAll(),
+	);
+	try {
+		for await (const entryRaw of seriesIterable) {
+			if (!entryRaw) continue;
+			// The fields read here are present on both the SDK-typed series
+			// resource and the streamed raw record. Cast to a permissive view —
+			// downstream readers tolerate missing fields via `??` defaults.
+			const entry = entryRaw as {
+				monitored?: boolean;
+				status?: string;
+				added?: string;
+				tags?: number[];
+				qualityProfileId?: number;
+				statistics?: {
+					totalEpisodeCount?: number;
+					episodeCount?: number;
+					episodeFileCount?: number;
+					sizeOnDisk?: number;
+				};
+			};
+			totalSeries += 1;
+			if (entry.monitored !== false) monitoredSeries += 1;
 
-		if (entry.status === "continuing") continuingSeries += 1;
-		else if (entry.status === "ended") endedSeries += 1;
+			if (entry.status === "continuing") continuingSeries += 1;
+			else if (entry.status === "ended") endedSeries += 1;
 
-		const { within7Days, within30Days } = checkRecentlyAdded(entry.added, thresholds);
-		if (within7Days) recentlyAdded7Days += 1;
-		if (within30Days) recentlyAdded30Days += 1;
+			const { within7Days, within30Days } = checkRecentlyAdded(entry.added, thresholds);
+			if (within7Days) recentlyAdded7Days += 1;
+			if (within30Days) recentlyAdded30Days += 1;
 
-		updateTagBreakdown(entry.tags, tagIdToLabel, tagBreakdown);
+			updateTagBreakdown(entry.tags, tagIdToLabel, tagBreakdown);
 
-		const stats = entry.statistics;
-		const episodesTotal = stats?.totalEpisodeCount ?? stats?.episodeCount ?? 0;
-		// episodeCount = monitored episodes only (excludes unaired/unmonitored/specials)
-		// totalEpisodeCount = ALL episodes including unaired and unmonitored
-		// For "missing" we must use episodeCount to match Sonarr's own missing count (#131)
-		const monitoredEpisodes = stats?.episodeCount ?? episodesTotal;
-		const episodesWithFile = stats?.episodeFileCount ?? 0;
-		const sizeOnDisk = stats?.sizeOnDisk ?? 0;
+			const stats = entry.statistics;
+			const episodesTotal = stats?.totalEpisodeCount ?? stats?.episodeCount ?? 0;
+			// episodeCount = monitored episodes only (excludes unaired/unmonitored/specials)
+			// totalEpisodeCount = ALL episodes including unaired and unmonitored
+			// For "missing" we must use episodeCount to match Sonarr's own missing count (#131)
+			const monitoredEpisodes = stats?.episodeCount ?? episodesTotal;
+			const episodesWithFile = stats?.episodeFileCount ?? 0;
+			const sizeOnDisk = stats?.sizeOnDisk ?? 0;
 
-		totalEpisodes += monitoredEpisodes;
-		episodeFileCount += episodesWithFile;
-		downloadedEpisodes += episodesWithFile;
-		missingEpisodes += Math.max(0, monitoredEpisodes - episodesWithFile);
-		totalFileSize += sizeOnDisk;
+			totalEpisodes += monitoredEpisodes;
+			episodeFileCount += episodesWithFile;
+			downloadedEpisodes += episodesWithFile;
+			missingEpisodes += Math.max(0, monitoredEpisodes - episodesWithFile);
+			totalFileSize += sizeOnDisk;
 
-		if (episodesWithFile > 0) {
-			updateQualityBreakdown(
-				entry.qualityProfileId,
-				profileIdToName,
-				episodesWithFile,
-				qualityBreakdown,
-			);
+			if (episodesWithFile > 0) {
+				updateQualityBreakdown(
+					entry.qualityProfileId,
+					profileIdToName,
+					episodesWithFile,
+					qualityBreakdown,
+				);
+			}
 		}
+	} catch {
+		// Match the legacy `safeRequest` behavior — degrade gracefully on
+		// fetch / stream errors. Counters stay at whatever was accumulated
+		// before the failure (0 if the stream errored before the first item).
 	}
 
 	const diskTotals = calculateDiskTotals(diskspace);
@@ -290,6 +356,7 @@ export const fetchRadarrStatisticsWithSdk = async (
 	instanceName: string,
 	instanceBaseUrl: string,
 	instanceExternalUrl?: string,
+	options?: StatsOptions,
 ): Promise<RadarrStatistics> => {
 	const instanceInfo: InstanceInfo = {
 		instanceId,
@@ -298,8 +365,7 @@ export const fetchRadarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [movies, diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.movie.getAll()).then((r) => r ?? []),
+	const [diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.cutoff({ page: 1, pageSize: 1 })).then(
@@ -313,6 +379,7 @@ export const fetchRadarrStatisticsWithSdk = async (
 	const tagIdToLabel = buildTagIdToLabelMap(tags);
 	const thresholds = getTimeThresholds();
 
+	let totalMovies = 0;
 	let monitoredMovies = 0;
 	let downloadedMovies = 0;
 	let totalFileSize = 0;
@@ -322,29 +389,45 @@ export const fetchRadarrStatisticsWithSdk = async (
 	const qualityBreakdown: Record<string, number> = {};
 	const tagBreakdown: Record<string, number> = {};
 
-	for (const movie of movies) {
-		if (!movie) continue;
+	const moviesIterable = await chooseBulkIterable(options?.streamItems, () =>
+		client.movie.getAll(),
+	);
+	try {
+		for await (const movieRaw of moviesIterable) {
+			if (!movieRaw) continue;
+			const movie = movieRaw as {
+				monitored?: boolean;
+				hasFile?: boolean;
+				runtime?: number;
+				added?: string;
+				tags?: number[];
+				qualityProfileId?: number;
+				sizeOnDisk?: number;
+			};
+			totalMovies += 1;
 
-		const { within7Days, within30Days } = checkRecentlyAdded(movie.added, thresholds);
-		if (within7Days) recentlyAdded7Days += 1;
-		if (within30Days) recentlyAdded30Days += 1;
+			const { within7Days, within30Days } = checkRecentlyAdded(movie.added, thresholds);
+			if (within7Days) recentlyAdded7Days += 1;
+			if (within30Days) recentlyAdded30Days += 1;
 
-		updateTagBreakdown(movie.tags, tagIdToLabel, tagBreakdown);
+			updateTagBreakdown(movie.tags, tagIdToLabel, tagBreakdown);
 
-		if (typeof movie.runtime === "number" && movie.runtime > 0) {
-			totalRuntime += movie.runtime;
+			if (typeof movie.runtime === "number" && movie.runtime > 0) {
+				totalRuntime += movie.runtime;
+			}
+
+			if (movie.monitored !== false) monitoredMovies += 1;
+
+			if (movie.hasFile) {
+				downloadedMovies += 1;
+				totalFileSize += movie.sizeOnDisk ?? 0;
+				updateQualityBreakdown(movie.qualityProfileId, profileIdToName, 1, qualityBreakdown);
+			}
 		}
-
-		if (movie.monitored !== false) monitoredMovies += 1;
-
-		if (movie.hasFile) {
-			downloadedMovies += 1;
-			totalFileSize += movie.sizeOnDisk ?? 0;
-			updateQualityBreakdown(movie.qualityProfileId, profileIdToName, 1, qualityBreakdown);
-		}
+	} catch {
+		// Match legacy safeRequest behavior — degrade gracefully on error.
 	}
 
-	const totalMovies = movies.length;
 	const diskTotals = calculateDiskTotals(diskspace);
 	const healthIssuesList = processHealthIssues(health, instanceInfo, "radarr");
 
@@ -490,6 +573,7 @@ export const fetchLidarrStatisticsWithSdk = async (
 	instanceName: string,
 	instanceBaseUrl: string,
 	instanceExternalUrl?: string,
+	options?: StatsOptions,
 ): Promise<LidarrStatistics> => {
 	const instanceInfo: InstanceInfo = {
 		instanceId,
@@ -498,8 +582,7 @@ export const fetchLidarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [artists, diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.artist.getAll()).then((r) => r ?? []),
+	const [diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.get()).then((r) => r ?? []),
 		safeRequest(() => client.health.get()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
@@ -524,43 +607,63 @@ export const fetchLidarrStatisticsWithSdk = async (
 	const qualityBreakdown: Record<string, number> = {};
 	const tagBreakdown: Record<string, number> = {};
 
-	for (const artist of artists) {
-		if (!artist) continue;
-		totalArtists += 1;
-		if (artist.monitored !== false) monitoredArtists += 1;
+	const artistsIterable = await chooseBulkIterable(options?.streamItems, () =>
+		client.artist.getAll(),
+	);
+	try {
+		for await (const artistRaw of artistsIterable) {
+			if (!artistRaw) continue;
+			const artist = artistRaw as {
+				monitored?: boolean;
+				added?: string;
+				tags?: number[];
+				qualityProfileId?: number;
+				statistics?: {
+					albumCount?: number;
+					trackCount?: number;
+					totalTrackCount?: number;
+					trackFileCount?: number;
+					sizeOnDisk?: number;
+				};
+			};
+			totalArtists += 1;
+			if (artist.monitored !== false) monitoredArtists += 1;
 
-		const { within7Days, within30Days } = checkRecentlyAdded(artist.added, thresholds);
-		if (within7Days) recentlyAdded7Days += 1;
-		if (within30Days) recentlyAdded30Days += 1;
+			const { within7Days, within30Days } = checkRecentlyAdded(artist.added, thresholds);
+			if (within7Days) recentlyAdded7Days += 1;
+			if (within30Days) recentlyAdded30Days += 1;
 
-		updateTagBreakdown(artist.tags, tagIdToLabel, tagBreakdown);
+			updateTagBreakdown(artist.tags, tagIdToLabel, tagBreakdown);
 
-		const stats = artist.statistics;
-		const albumCount = stats?.albumCount ?? 0;
-		// trackCount = monitored album tracks only (excludes unmonitored albums)
-		// totalTrackCount = ALL tracks including unmonitored albums
-		const monitoredTrackCount = stats?.trackCount ?? stats?.totalTrackCount ?? 0;
-		const trackFileCount = stats?.trackFileCount ?? 0;
-		const sizeOnDisk = stats?.sizeOnDisk ?? 0;
+			const stats = artist.statistics;
+			const albumCount = stats?.albumCount ?? 0;
+			// trackCount = monitored album tracks only (excludes unmonitored albums)
+			// totalTrackCount = ALL tracks including unmonitored albums
+			const monitoredTrackCount = stats?.trackCount ?? stats?.totalTrackCount ?? 0;
+			const trackFileCount = stats?.trackFileCount ?? 0;
+			const sizeOnDisk = stats?.sizeOnDisk ?? 0;
 
-		totalAlbums += albumCount;
-		totalFileSize += sizeOnDisk;
+			totalAlbums += albumCount;
+			totalFileSize += sizeOnDisk;
 
-		// Only count tracks from monitored artists, using monitored album track count
-		if (artist.monitored !== false) {
-			totalTracks += monitoredTrackCount;
-			downloadedTracks += trackFileCount;
-			missingTracks += Math.max(0, monitoredTrackCount - trackFileCount);
+			// Only count tracks from monitored artists, using monitored album track count
+			if (artist.monitored !== false) {
+				totalTracks += monitoredTrackCount;
+				downloadedTracks += trackFileCount;
+				missingTracks += Math.max(0, monitoredTrackCount - trackFileCount);
+			}
+
+			if (trackFileCount > 0) {
+				updateQualityBreakdown(
+					artist.qualityProfileId,
+					profileIdToName,
+					trackFileCount,
+					qualityBreakdown,
+				);
+			}
 		}
-
-		if (trackFileCount > 0) {
-			updateQualityBreakdown(
-				artist.qualityProfileId,
-				profileIdToName,
-				trackFileCount,
-				qualityBreakdown,
-			);
-		}
+	} catch {
+		// Match legacy safeRequest behavior — degrade gracefully on error.
 	}
 
 	const monitoredAlbums = Math.round(totalAlbums * (monitoredArtists / Math.max(totalArtists, 1)));
@@ -607,6 +710,7 @@ export const fetchReadarrStatisticsWithSdk = async (
 	instanceName: string,
 	instanceBaseUrl: string,
 	instanceExternalUrl?: string,
+	options?: StatsOptions,
 ): Promise<ReadarrStatistics> => {
 	const instanceInfo: InstanceInfo = {
 		instanceId,
@@ -615,8 +719,7 @@ export const fetchReadarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [authors, diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.author.getAll()).then((r) => r ?? []),
+	const [diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
@@ -641,37 +744,55 @@ export const fetchReadarrStatisticsWithSdk = async (
 	const qualityBreakdown: Record<string, number> = {};
 	const tagBreakdown: Record<string, number> = {};
 
-	for (const author of authors) {
-		if (!author) continue;
-		totalAuthors += 1;
-		if (author.monitored !== false) monitoredAuthors += 1;
+	const authorsIterable = await chooseBulkIterable(options?.streamItems, () =>
+		client.author.getAll(),
+	);
+	try {
+		for await (const authorRaw of authorsIterable) {
+			if (!authorRaw) continue;
+			const author = authorRaw as {
+				monitored?: boolean;
+				added?: string;
+				tags?: number[];
+				qualityProfileId?: number;
+				statistics?: {
+					bookCount?: number;
+					bookFileCount?: number;
+					sizeOnDisk?: number;
+				};
+			};
+			totalAuthors += 1;
+			if (author.monitored !== false) monitoredAuthors += 1;
 
-		const { within7Days, within30Days } = checkRecentlyAdded(author.added, thresholds);
-		if (within7Days) recentlyAdded7Days += 1;
-		if (within30Days) recentlyAdded30Days += 1;
+			const { within7Days, within30Days } = checkRecentlyAdded(author.added, thresholds);
+			if (within7Days) recentlyAdded7Days += 1;
+			if (within30Days) recentlyAdded30Days += 1;
 
-		updateTagBreakdown(author.tags, tagIdToLabel, tagBreakdown);
+			updateTagBreakdown(author.tags, tagIdToLabel, tagBreakdown);
 
-		const stats = author.statistics;
-		const bookCount = stats?.bookCount ?? 0;
-		const bookFileCount = stats?.bookFileCount ?? 0;
-		const sizeOnDisk = stats?.sizeOnDisk ?? 0;
+			const stats = author.statistics;
+			const bookCount = stats?.bookCount ?? 0;
+			const bookFileCount = stats?.bookFileCount ?? 0;
+			const sizeOnDisk = stats?.sizeOnDisk ?? 0;
 
-		totalBooks += bookCount;
-		downloadedBooks += bookFileCount;
-		missingBooks += Math.max(0, bookCount - bookFileCount);
-		totalFileSize += sizeOnDisk;
+			totalBooks += bookCount;
+			downloadedBooks += bookFileCount;
+			missingBooks += Math.max(0, bookCount - bookFileCount);
+			totalFileSize += sizeOnDisk;
 
-		if (author.monitored !== false) monitoredBooks += bookCount;
+			if (author.monitored !== false) monitoredBooks += bookCount;
 
-		if (bookFileCount > 0) {
-			updateQualityBreakdown(
-				author.qualityProfileId,
-				profileIdToName,
-				bookFileCount,
-				qualityBreakdown,
-			);
+			if (bookFileCount > 0) {
+				updateQualityBreakdown(
+					author.qualityProfileId,
+					profileIdToName,
+					bookFileCount,
+					qualityBreakdown,
+				);
+			}
 		}
+	} catch {
+		// Match legacy safeRequest behavior — degrade gracefully on error.
 	}
 
 	const diskTotals = calculateDiskTotals(diskspace);

--- a/apps/api/src/routes/dashboard/statistics-routes.ts
+++ b/apps/api/src/routes/dashboard/statistics-routes.ts
@@ -5,6 +5,7 @@ import {
 } from "@arr/shared";
 import { LidarrClient, ProwlarrClient, RadarrClient, ReadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginCallback } from "fastify";
+import { streamLibraryItems } from "../../lib/arr/library-stream.js";
 import {
 	aggregateLidarrStatistics,
 	aggregateProwlarrStatistics,
@@ -55,6 +56,9 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							instance.label,
 							instance.baseUrl,
 							instance.externalUrl ?? undefined,
+							{
+								streamItems: () => streamLibraryItems(app.arrClientFactory, instance, request.log),
+							},
 						);
 						return {
 							service: "sonarr" as const,
@@ -88,6 +92,9 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							instance.label,
 							instance.baseUrl,
 							instance.externalUrl ?? undefined,
+							{
+								streamItems: () => streamLibraryItems(app.arrClientFactory, instance, request.log),
+							},
 						);
 						return {
 							service: "radarr" as const,
@@ -152,6 +159,9 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							instance.label,
 							instance.baseUrl,
 							instance.externalUrl ?? undefined,
+							{
+								streamItems: () => streamLibraryItems(app.arrClientFactory, instance, request.log),
+							},
 						);
 						return {
 							service: "lidarr" as const,
@@ -185,6 +195,9 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							instance.label,
 							instance.baseUrl,
 							instance.externalUrl ?? undefined,
+							{
+								streamItems: () => streamLibraryItems(app.arrClientFactory, instance, request.log),
+							},
 						);
 						return {
 							service: "readarr" as const,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@simplewebauthn/server':
         specifier: ^13.3.0
         version: 13.3.0
+      '@streamparser/json':
+        specifier: ^0.0.22
+        version: 0.0.22
       argon2:
         specifier: ^0.44.0
         version: 0.44.0
@@ -2152,6 +2155,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@streamparser/json@0.0.22':
+    resolution: {integrity: sha512-b6gTSBjJ8G8SuO3Gbbj+zXbVx8NSs1EbpbMKpzGLWMdkR+98McH9bEjSz3+0mPJf68c5nxa3CrJHp5EQNXM6zQ==}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -6382,6 +6388,8 @@ snapshots:
       '@peculiar/x509': 1.14.3
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@streamparser/json@0.0.22': {}
 
   '@swc/helpers@0.5.15':
     dependencies:


### PR DESCRIPTION
## Summary
- 4 dashboard-stats fetchers (Sonarr / Radarr / Lidarr / Readarr) gain an optional `options.streamItems` injection. When provided, the aggregation loop consumes a streaming JSON parse instead of `client.X.getAll()`.
- Route handler at `routes/dashboard/statistics-routes.ts` binds it to `streamLibraryItems(arrClientFactory, instance, log)` for production traffic.
- Tests keep the legacy path (no `streamItems` passed) — all 12 dashboard-stats tests pass unchanged.

## Why
Follow-up to #448 (library-sync streaming). The same `client.X.getAll()` parse spike afflicts every dashboard request — for Drewskieza's 1.5M-track Lidarr (issue #427), loading the dashboard could trigger a 200-500 MB heap spike. This stacks on top of #448 since both depend on `streamLibraryItems`.

## Architecture

Each fetcher's bulk-list source is selected by a `chooseBulkIterable` helper:

```ts
const seriesIterable = await chooseBulkIterable(options?.streamItems, () => client.series.getAll());
for await (const entryRaw of seriesIterable) {
  // aggregate counters, breakdowns, etc.
}
```

- **With `streamItems`** (production): items are parsed and yielded one at a time; aggregator processes and discards each in turn.
- **Without `streamItems`** (tests): `safeRequest(getAll)` buffers as before, and the array is wrapped in `asAsyncIterable` to feed the same downstream loop.

The downstream aggregation code is unchanged in shape — just `for` → `for await`. Counter math, breakdown maps, and disk / health processing are byte-identical.

## Behavioral notes

- `totalMovies` was previously derived from `movies.length` post-fetch. Now it's incremented inline in the stream loop. Same count, no behavior change.
- Error handling matches the legacy `safeRequest` swallow-and-degrade pattern: a stream error leaves the counters at whatever was accumulated and falls through to the response. The underlying `streamLibraryItems` helper already warn-logs failures.
- The other small endpoints in each fetcher (`diskSpace`, `health`, `wanted.cutoff`, `qualityProfile`, `tag`) still use `Promise.all` + `safeRequest` — they're small and the buffer-then-parse pattern is fine for them.

## Test plan
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/api exec vitest run` — 1558 passing, 41 skipped, 0 failing
- [x] All 12 existing dashboard-statistics tests pass with the legacy fallback path
- [ ] Manual: load dashboard against a large Lidarr instance, confirm stats render correctly and heap doesn't spike

## Stack

This PR stacks on #448 (which introduces `streamLibraryItems`). Merge order: #448 → this. Otherwise this branch has unresolved imports from `lib/arr/library-stream.ts`.

Refs #427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)