### PR TITLE
fix(hunting): slim wanted records inside the paginator (#427)

### DIFF
--- a/apps/api/src/lib/hunting/__tests__/pagination-helpers.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/pagination-helpers.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Tests for fetchWantedWithWrapAround — the paginator that drives the
+ * Sonarr/Radarr/Lidarr/Readarr wanted-missing and wanted-cutoff hunts.
+ *
+ * Why this layer matters for issue #427: a 50k-album Lidarr returns
+ * up to 10,000 fat records (~13 KB each, with embedded artist.links[])
+ * across 20 pages. The pre-fix accumulator held all 10k fat records
+ * simultaneously before the caller's `.map(projectAlbum).filter(...)`
+ * chain could slim them — ~130-200 MB resident at peak, which on a
+ * 768 MB container heap was enough to push the process toward OOM.
+ *
+ * The `project` option moves slimming inside the page loop, so each
+ * page's fat records become GC-eligible at the iteration boundary.
+ * These tests pin the contract:
+ *
+ *   1. Back-compat — no `project` ⇒ raw records flow through as before.
+ *   2. With `project` ⇒ only the slim shape is in the result.
+ *   3. `project` returning null drops the record (orphan-FK case).
+ *   4. Page completion still uses the *raw* record count, so a fully
+ *      loaded page whose projection drops every record still advances.
+ *   5. The 20-page cap still bounds API usage on pathological libraries.
+ *   6. Counter increments per actual fetch, not per projected record.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+
+import { type ApiCallCounter, fetchWantedWithWrapAround } from "../pagination-helpers.js";
+
+const stubLogger = {
+	child: vi.fn().mockReturnThis(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+type Raw = { id: number; bulk: string };
+type Slim = { id: number };
+
+/** Build a paginated fetcher that serves `pageCount` fully-loaded pages
+ *  followed by an empty page. Each page has `pageSize` records.
+ */
+function makePagedFetcher(
+	pageCount: number,
+	pageSize: number,
+): { fetcher: (p: number, ps: number) => Promise<{ records: Raw[] }>; calls: number[] } {
+	const calls: number[] = [];
+	const fetcher = async (page: number, _ps: number) => {
+		calls.push(page);
+		if (page > pageCount) return { records: [] };
+		const records: Raw[] = Array.from({ length: pageSize }, (_, i) => ({
+			id: (page - 1) * pageSize + i + 1,
+			bulk: "x".repeat(50),
+		}));
+		return { records };
+	};
+	return { fetcher, calls };
+}
+
+describe("fetchWantedWithWrapAround", () => {
+	it("returns raw records when no project is supplied (back-compat)", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher } = makePagedFetcher(2, 3);
+
+		const out = await fetchWantedWithWrapAround<Raw>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 3,
+		});
+
+		expect(out).toHaveLength(6);
+		expect(out[0]).toEqual({ id: 1, bulk: "x".repeat(50) });
+		expect(out[5]).toEqual({ id: 6, bulk: "x".repeat(50) });
+	});
+
+	it("slims records when project is supplied", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher } = makePagedFetcher(2, 3);
+
+		const out = await fetchWantedWithWrapAround<Raw, Slim>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 3,
+			project: (raw) => ({ id: raw.id }),
+		});
+
+		expect(out).toEqual([{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }, { id: 6 }]);
+		// No `.bulk` field survives — that's the whole point of projecting in-loop.
+		expect(out[0]).not.toHaveProperty("bulk");
+	});
+
+	it("drops records when project returns null", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher } = makePagedFetcher(1, 4);
+
+		const out = await fetchWantedWithWrapAround<Raw, Slim>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 4,
+			project: (raw) => (raw.id % 2 === 0 ? { id: raw.id } : null),
+		});
+
+		expect(out).toEqual([{ id: 2 }, { id: 4 }]);
+	});
+
+	it("advances past a fully-loaded page even when projection drops every record", async () => {
+		// Regression guard: the page-completion check must use the *raw* record
+		// count, not the projected count. Otherwise a page where every record
+		// fails the FK check would falsely terminate the loop early and hide
+		// later pages from the hunt.
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher, calls } = makePagedFetcher(2, 3);
+
+		const out = await fetchWantedWithWrapAround<Raw, Slim>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 3,
+			// Drop page 1's records; keep page 2's.
+			project: (raw) => (raw.id > 3 ? { id: raw.id } : null),
+		});
+
+		expect(out).toEqual([{ id: 4 }, { id: 5 }, { id: 6 }]);
+		// Should have fetched both data pages plus the trailing empty page.
+		expect(calls).toEqual([1, 2, 3]);
+	});
+
+	it("stops on a partial page (end-of-list signal)", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const calls: number[] = [];
+		const fetcher = async (page: number, _ps: number) => {
+			calls.push(page);
+			// Page 1: full (3 records). Page 2: partial (1 record) ⇒ end of list.
+			if (page === 1) {
+				return {
+					records: [
+						{ id: 1, bulk: "" },
+						{ id: 2, bulk: "" },
+						{ id: 3, bulk: "" },
+					],
+				};
+			}
+			if (page === 2) return { records: [{ id: 4, bulk: "" }] };
+			return { records: [] };
+		};
+
+		const out = await fetchWantedWithWrapAround<Raw>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 3,
+		});
+
+		expect(out).toHaveLength(4);
+		expect(calls).toEqual([1, 2]);
+	});
+
+	it("respects the 20-page MAX_PAGES cap even when more pages exist", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher, calls } = makePagedFetcher(100, 2); // way more than the cap
+
+		const out = await fetchWantedWithWrapAround<Raw>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 2,
+		});
+
+		// 20 pages × 2 records each = 40 records max under the cap.
+		expect(out).toHaveLength(40);
+		expect(calls).toHaveLength(20);
+		expect(counter.count).toBe(20);
+	});
+
+	it("increments the API counter per fetch, not per projected record", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher } = makePagedFetcher(3, 5);
+
+		await fetchWantedWithWrapAround<Raw, Slim>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 5,
+			// Even though projection drops half the records, counter still tracks pages.
+			project: (raw) => (raw.id % 2 === 0 ? { id: raw.id } : null),
+		});
+
+		// 3 data pages + 1 trailing empty page = 4 fetches.
+		expect(counter.count).toBe(4);
+	});
+
+	it("handles null records gracefully (e.g. malformed upstream response)", async () => {
+		const counter: ApiCallCounter = { count: 0 };
+		const fetcher = async () => ({ records: null });
+
+		const out = await fetchWantedWithWrapAround<Raw>(fetcher, {
+			counter,
+			logger: stubLogger,
+			fetchSize: 10,
+		});
+
+		expect(out).toEqual([]);
+		expect(counter.count).toBe(1);
+	});
+
+	it("propagates errors thrown by `project` without silently returning a partial result", async () => {
+		// The pre-fix code path ran projection in `.map()` after the paginator
+		// returned, so a throw killed the post-fetch transform cleanly. Now
+		// projection runs inside the page loop. We DO NOT want the helper to
+		// swallow a thrown error and return a partial accumulator — that would
+		// silently lose records from later pages. Pinning current behavior so
+		// any future "defensive try/catch" addition is a deliberate decision.
+		const counter: ApiCallCounter = { count: 0 };
+		const { fetcher } = makePagedFetcher(2, 3);
+
+		await expect(
+			fetchWantedWithWrapAround<Raw, Slim>(fetcher, {
+				counter,
+				logger: stubLogger,
+				fetchSize: 3,
+				project: (raw) => {
+					if (raw.id === 4) throw new Error("malformed record");
+					return { id: raw.id };
+				},
+			}),
+		).rejects.toThrow("malformed record");
+
+		// The first page's fetch did happen — counter reflects observable work.
+		expect(counter.count).toBeGreaterThanOrEqual(1);
+	});
+
+	it("propagates errors thrown by `fetcher` without silently returning a partial result", async () => {
+		// Same contract as the projection-throws case: a transient upstream
+		// failure (network blip, 5xx) must propagate so the outer hunt handler
+		// at hunt-executor.ts:1205/1456/1702 can mark the hunt failed. The
+		// helper must not return a partial `allRecords` from earlier pages.
+		const counter: ApiCallCounter = { count: 0 };
+		let page = 0;
+		const fetcher = async () => {
+			page++;
+			if (page === 2) throw new Error("upstream 503");
+			return {
+				records: [
+					{ id: page, bulk: "" },
+					{ id: page + 100, bulk: "" },
+					{ id: page + 200, bulk: "" },
+				],
+			};
+		};
+
+		await expect(
+			fetchWantedWithWrapAround<Raw>(fetcher, {
+				counter,
+				logger: stubLogger,
+				fetchSize: 3,
+			}),
+		).rejects.toThrow("upstream 503");
+	});
+});

--- a/apps/api/src/lib/hunting/hunt-executor.ts
+++ b/apps/api/src/lib/hunting/hunt-executor.ts
@@ -1007,6 +1007,14 @@ async function executeRadarrHuntWithSdk(
 	streamingDeps?: StreamingDeps,
 ): Promise<HuntResultWithoutApiCount> {
 	try {
+		// Both `wanted.*` paginated records and `movie.getAll()` streamed records
+		// project through the same slim shape — uniform downstream consumers,
+		// 10x lower memory per item (~500 B vs ~5 KB). Issue #427 follow-up.
+		// Projection is pushed into the paginator so each fat page becomes
+		// GC-eligible after slimming, rather than accumulating across pages.
+		const projectIntoSlim = (raw: unknown): SlimMovie | null =>
+			projectMovie(raw as Record<string, unknown>);
+
 		const fetchRadarrWanted = (endpoint: "missing" | "cutoff") =>
 			fetchWantedWithWrapAround(
 				(page, pageSize) => {
@@ -1020,25 +1028,16 @@ async function executeRadarrHuntWithSdk(
 						? client.wanted.missing(params)
 						: client.wanted.cutoff(params);
 				},
-				{ counter, logger },
+				{ counter, logger, project: projectIntoSlim },
 			);
-
-		// Both `wanted.*` paginated records and `movie.getAll()` streamed records
-		// project through the same slim shape — uniform downstream consumers,
-		// 10x lower memory per item (~500 B vs ~5 KB). Issue #427 follow-up.
-		const projectIntoSlim = (raw: unknown): SlimMovie | null =>
-			projectMovie(raw as Record<string, unknown>);
 
 		let movies: SlimMovie[];
 
 		if (type === "missing") {
-			const wanted = await fetchRadarrWanted("missing");
-			movies = wanted.map(projectIntoSlim).filter((m): m is SlimMovie => m !== null);
+			movies = await fetchRadarrWanted("missing");
 		} else {
 			// Upgrade mode — include monitored items if upgradeSearchAll is enabled
-			const wantedMovies = (await fetchRadarrWanted("cutoff"))
-				.map(projectIntoSlim)
-				.filter((m): m is SlimMovie => m !== null);
+			const wantedMovies = await fetchRadarrWanted("cutoff");
 
 			const monitoredMovies: SlimMovie[] = [];
 			if (upgradeSearchAll) {
@@ -1247,6 +1246,15 @@ async function executeLidarrHuntWithSdk(
 					projectArtist,
 				);
 
+		// Project both wanted (paginated SDK) and monitored (streamed) records
+		// to SlimAlbum so the downstream filter / merge / search code reads a
+		// uniform shape. Pushing the projection into the paginator collapses
+		// the per-page heap spike — for issue #427's 92k wanted-missing albums
+		// this is the difference between ~150 MB resident (10 pages of fat
+		// records with embedded artist.links[]) and ~5 MB (slim accumulator).
+		const projectAlbumLoose = (raw: unknown): SlimAlbum | null =>
+			projectAlbum(raw as Record<string, unknown>);
+
 		const fetchLidarrWanted = (endpoint: "missing" | "cutoff") =>
 			fetchWantedWithWrapAround(
 				(page, pageSize) => {
@@ -1260,26 +1268,16 @@ async function executeLidarrHuntWithSdk(
 						? client.wanted.getMissing(params)
 						: client.wanted.getCutoffUnmet(params);
 				},
-				{ counter, logger },
+				{ counter, logger, project: projectAlbumLoose },
 			);
-
-		// Project both wanted (paginated SDK) and monitored (streamed) records
-		// to SlimAlbum so the downstream filter / merge / search code reads a
-		// uniform shape. Memory saving is modest per-item but compounds when
-		// upgrade-all is enabled against a 50k+ album library (issue #427).
-		const projectAlbumLoose = (raw: unknown): SlimAlbum | null =>
-			projectAlbum(raw as Record<string, unknown>);
 
 		let albums: SlimAlbum[];
 
 		if (type === "missing") {
-			const wanted = await fetchLidarrWanted("missing");
-			albums = wanted.map(projectAlbumLoose).filter((a): a is SlimAlbum => a !== null);
+			albums = await fetchLidarrWanted("missing");
 		} else {
 			// Upgrade mode — include monitored items if upgradeSearchAll is enabled
-			const wantedAlbums = (await fetchLidarrWanted("cutoff"))
-				.map(projectAlbumLoose)
-				.filter((a): a is SlimAlbum => a !== null);
+			const wantedAlbums = await fetchLidarrWanted("cutoff");
 
 			const monitoredAlbums: SlimAlbum[] = [];
 			if (upgradeSearchAll) {
@@ -1496,6 +1494,13 @@ async function executeReadarrHuntWithSdk(
 					projectAuthor,
 				);
 
+		// Project both wanted (paginated SDK) and monitored (streamed) records
+		// to SlimBook so the downstream filter / merge / search code reads a
+		// uniform shape. Mirror of the Lidarr album pattern — projection runs
+		// inside the paginator so fat per-page records become GC-eligible.
+		const projectBookLoose = (raw: unknown): SlimBook | null =>
+			projectBook(raw as Record<string, unknown>);
+
 		const fetchReadarrWanted = (endpoint: "missing" | "cutoff") =>
 			fetchWantedWithWrapAround(
 				(page, pageSize) => {
@@ -1509,25 +1514,16 @@ async function executeReadarrHuntWithSdk(
 						? client.wanted.getMissing(params)
 						: client.wanted.getCutoffUnmet(params);
 				},
-				{ counter, logger },
+				{ counter, logger, project: projectBookLoose },
 			);
-
-		// Project both wanted (paginated SDK) and monitored (streamed) records
-		// to SlimBook so the downstream filter / merge / search code reads a
-		// uniform shape. Mirror of the Lidarr album pattern.
-		const projectBookLoose = (raw: unknown): SlimBook | null =>
-			projectBook(raw as Record<string, unknown>);
 
 		let books: SlimBook[];
 
 		if (type === "missing") {
-			const wanted = await fetchReadarrWanted("missing");
-			books = wanted.map(projectBookLoose).filter((b): b is SlimBook => b !== null);
+			books = await fetchReadarrWanted("missing");
 		} else {
 			// Upgrade mode — include monitored items if upgradeSearchAll is enabled
-			const wantedBooks = (await fetchReadarrWanted("cutoff"))
-				.map(projectBookLoose)
-				.filter((b): b is SlimBook => b !== null);
+			const wantedBooks = await fetchReadarrWanted("cutoff");
 
 			const monitoredBooks: SlimBook[] = [];
 			if (upgradeSearchAll) {

--- a/apps/api/src/lib/hunting/pagination-helpers.ts
+++ b/apps/api/src/lib/hunting/pagination-helpers.ts
@@ -32,34 +32,60 @@ const MAX_PAGES = 20;
  * The caller's filter logic (passesFilters, wasRecentlySearched) handles
  * deduplication and eligibility — this function just provides the full pool.
  *
+ * **Memory note (issue #427):** when callers can project each record to a
+ * smaller shape, supply `opts.project`. The helper then keeps only the
+ * projected (slim) record in the accumulator and lets each page's fat raw
+ * records become GC-eligible at the iteration boundary. For a 50k-album
+ * Lidarr the difference is ~150 MB vs ~5 MB resident. Without `project`,
+ * the helper returns the raw records as-is for back-compat.
+ *
  * @param fetcher  - Calls the appropriate wanted endpoint for a given page/pageSize
- * @param opts.counter  - API call counter (incremented per fetch)
- * @param opts.logger   - Structured logger
+ * @param opts.counter   - API call counter (incremented per fetch)
+ * @param opts.logger    - Structured logger
  * @param opts.fetchSize - Override page size (default 500)
- * @returns All records from the wanted endpoint
+ * @param opts.project   - Optional per-record projection; nulls are dropped
+ * @returns All (projected) records from the wanted endpoint
  */
-export async function fetchWantedWithWrapAround<T>(
-	fetcher: (page: number, pageSize: number) => Promise<{ records?: T[] | null; totalRecords?: number | null }>,
+export async function fetchWantedWithWrapAround<TRaw, TProjected = TRaw>(
+	fetcher: (
+		page: number,
+		pageSize: number,
+	) => Promise<{ records?: TRaw[] | null; totalRecords?: number | null }>,
 	opts: {
-		fetchSize?: number; // now used as override, defaults to 500
+		fetchSize?: number;
 		counter: ApiCallCounter;
 		logger: FastifyBaseLogger;
+		project?: (raw: TRaw) => TProjected | null;
 	},
-): Promise<T[]> {
-	const { counter, logger, fetchSize = DEFAULT_PAGE_SIZE } = opts;
-	const allRecords: T[] = [];
+): Promise<TProjected[]> {
+	const { counter, logger, fetchSize = DEFAULT_PAGE_SIZE, project } = opts;
+	const allRecords: TProjected[] = [];
 	let page = 1;
+	let totalRawSeen = 0;
 
 	while (page <= MAX_PAGES) {
 		counter.count++;
 		const data = await fetcher(page, fetchSize);
 		const records = data.records ?? [];
+		totalRawSeen += records.length;
 
 		if (records.length > 0) {
-			allRecords.push(...records);
+			if (project) {
+				// Project per-record so the fat raw record becomes unreachable
+				// the moment the loop iteration ends — keeps peak heap bounded
+				// by the slim accumulator, not the per-page fetch volume.
+				for (const raw of records) {
+					const slim = project(raw);
+					if (slim !== null) allRecords.push(slim);
+				}
+			} else {
+				allRecords.push(...(records as unknown as TProjected[]));
+			}
 		}
 
-		// Stop if page was empty or partial (reached end of results)
+		// Stop when the page is empty or partial — page completion is judged
+		// from the *raw* count so a fully-loaded page where projection drops
+		// everything still advances correctly.
 		if (records.length < fetchSize) {
 			break;
 		}
@@ -67,9 +93,20 @@ export async function fetchWantedWithWrapAround<T>(
 		page++;
 	}
 
-	if (page > 1) {
+	// Log whenever we did any work so single-page fetches whose projection
+	// dropped every record still leave a trace — without this, an
+	// orphan-FK-heavy library would look like "no wanted items" to the
+	// operator debugging a "stopped searching for X" symptom (issue #427).
+	if (totalRawSeen > 0 || page > 1) {
+		const droppedCount = totalRawSeen - allRecords.length;
 		logger.debug(
-			{ pages: page, totalFetched: allRecords.length, fetchSize },
+			{
+				pages: page,
+				totalFetched: allRecords.length,
+				totalRawSeen,
+				droppedCount,
+				fetchSize,
+			},
 			"Fetched complete wanted list",
 		);
 	}


### PR DESCRIPTION
## Summary

Heap retainer-graph analysis of Drewskieza's snapshot from [#427 comment 4438642455](https://github.com/Kha-kis/arr-dashboard/issues/427#issuecomment-4438642455) showed **16 simultaneous `fetchWantedWithWrapAround` paginators alive at once**, each holding 10,003 fat Lidarr album records in its `allRecords` local. Per-record size on Lidarr is heavy because the wanted-missing response embeds full artist data including `links[]` — so the accumulators were pinning roughly **800 MB – 2 GB** of record data on a 768 MB heap.

This change pushes the slim projection into the paginator so each page's fat records become GC-eligible at iteration boundary. Same workload now resident is ~24 MB instead of ~800 MB.

## The retainer chain (snapshot evidence)

Loaded `Heap.20260513.024611.122.0.001.heapsnapshot.gz` (1.1 GB decompressed), built an inverted edge map (15.7M nodes / 47.5M edges), walked retainers from large objects:

- **9.4 MB string** with `{"page":3,"pageSize":500,"totalRecords":92018,...}` → retained by `(Stack roots)`. Transient HTTP body mid-parse, GC-eligible after `JSON.parse`. Not the long-term retainer.
- **Plain Object samples** → `Array (links)` → `Object[property=artist]` → `Array (length=10003)` → `Generator.parameters_and_registers` (V8 storage for suspended async-function locals)

Every chain terminates at Fastify `Hooks.onReady` → scheduler infrastructure. **16 distinct Generator → 10,003-Array retainer chains alive simultaneously.** 10,003 ≈ `MAX_PAGES (20) × pageSize (500) + V8 capacity overshoot` — no other code path in the repo accumulates exactly that shape behind suspended async functions rooted in the scheduler.

The "16 concurrent paginators" pattern is the scheduler firing a new round of hunts before the previous round completed on slow Lidarr. Filed as separate low-priority follow-up since the slim-record fix removes the blast radius.

## The fix

`fetchWantedWithWrapAround` gains an optional `project: (raw) => TProjected | null` callback. When supplied, records are slimmed per-page so fat records become unreachable at the loop iteration boundary.

- **Radarr / Lidarr / Readarr** callers pass their existing `projectMovie / projectAlbum / projectBook`. Post-fetch `.map().filter()` chains drop away.
- **Sonarr stays raw** — episode records don't carry the fat embedded-resource shape, and SDK type inference flows through unchanged via the `<TRaw, TProjected = TRaw>` generic default.
- Per-record `for` loop instead of `.map()` so the in-page `records` array can drop out of scope as soon as projection runs.
- Trailing debug log widened to fire on single-page fetches where projection dropped every record — was previously gated to `page > 1`, hiding observability on the "stopped searching for X" debugging story.

## Math

| Scenario | Per record | × 16 paginators × 10k records | Resident |
|---|---|---|---|
| Before | ~5-13 KB (fat Lidarr album w/ embedded artist) | | **~800 MB – 2 GB** |
| After  | ~150 B (SlimAlbum) | | **~24 MB** |

33-80× reduction on this path. Crosses the OOM safety margin by a comfortable factor.

## Test plan

- [x] 10 new unit tests covering: back-compat (no project), slimming, null-drop, page-completion-uses-raw-count (regression guard; mutation-tested by code-reviewer agent — flipping to projected count fails the test), partial-page stop, MAX_PAGES cap, counter semantics, null-records guard, `project` throwing propagates, `fetcher` throwing propagates
- [x] Full hunting test suite: 49 pass
- [x] Full repo test suite: 1616 pass / 41 skip / 0 fail
- [x] Turbo typecheck across 3 packages: clean
- [x] Three-agent code review (parallel):
  - Project-standards (`pr-review-toolkit:code-reviewer`): "Ship it." Mutation-tested the raw-count assertion.
  - Silent-failure (`pr-review-toolkit:silent-failure-hunter`): 1 observability gap on the drop-counter log — addressed.
  - Test-coverage (`pr-review-toolkit:pr-test-analyzer`): 1 critical gap on `project`-throw test — addressed.

## What it doesn't do

- Doesn't stream the HTTP response body — each per-page fetch still allocates a transient ~9.4 MB JSON string for Lidarr's pageSize=500 wanted-missing response. That's ~16 MB of in-flight allocation per fetch, GC'd after parse. Acceptable at the 768 MB cap.
- Doesn't address the underlying scheduler-concurrency observation (16 simultaneous paginators) — that's the follow-up issue. Slim records remove the blast radius even with overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)