### PR TITLE
fix(hunting): suppress overlapping scheduler ticks (#457)

### DIFF
--- a/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
@@ -56,7 +56,6 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 					create: vi.fn(),
 					update: vi.fn(),
 				},
-				// biome-ignore lint/suspicious/noExplicitAny: test fixture
 			} as any,
 		};
 
@@ -78,14 +77,11 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		vi.clearAllMocks();
 		// Drop any residual in-flight promise from a prior test before the next
 		// runs (the scheduler is a singleton across tests).
-		// biome-ignore lint/suspicious/noExplicitAny: reach into private state for test isolation
 		(getHuntingScheduler() as any).inFlightTick = null;
-		// biome-ignore lint/suspicious/noExplicitAny: reach into private state for test isolation
 		(getHuntingScheduler() as any).skippedTicksWhileBusy = 0;
 	});
 
 	it("skips a second tick while the first is still in flight", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
 		const scheduler = getHuntingScheduler() as any;
 
 		// Make processScheduledHunts hang on a controllable deferred so we can
@@ -129,7 +125,6 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 	});
 
 	it("resumes normal cadence after the busy tick completes", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
 		const scheduler = getHuntingScheduler() as any;
 
 		const firstTick = defer<void>();
@@ -161,7 +156,6 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 	});
 
 	it("does not log skip warnings when ticks fit inside the cadence", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
 		const scheduler = getHuntingScheduler() as any;
 
 		const tickSpy = vi.spyOn(scheduler, "processScheduledHunts").mockResolvedValue(undefined);
@@ -183,7 +177,6 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 	});
 
 	it("clears in-flight state even if the tick throws", async () => {
-		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
 		const scheduler = getHuntingScheduler() as any;
 
 		vi.spyOn(scheduler, "processScheduledHunts").mockRejectedValueOnce(
@@ -200,5 +193,94 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		// tick() method (not surfaced to trackTick), so the outer error log is
 		// not expected here. The contract this test pins is that the in-flight
 		// flag clears regardless of tick outcome.
+	});
+
+	it("start() wires setInterval to runTickIfIdle and skips overlapping fires", async () => {
+		// Integration test: exercise the full start() → setInterval →
+		// runTickIfIdle → trackTick chain with fake timers, not just
+		// runTickIfIdle in isolation. Pins that the production wiring matches
+		// the unit-level guarantees.
+		vi.useFakeTimers();
+		try {
+			const scheduler = getHuntingScheduler() as any;
+
+			const firstTick = defer<void>();
+			const tickSpy = vi
+				.spyOn(scheduler, "processScheduledHunts")
+				.mockImplementationOnce(() => firstTick.promise)
+				.mockImplementation(() => Promise.resolve());
+
+			// Track that trackTick is invoked exactly once per real tick — this
+			// is what keeps SchedulerRegistry stats accurate.
+			const trackTickSpy = vi.fn((fn: () => Promise<void>) => fn());
+			scheduler.setTrackTick(trackTickSpy);
+
+			scheduler.start(mockApp as FastifyInstance);
+
+			// Before any time advances, no tick has fired.
+			expect(tickSpy).toHaveBeenCalledTimes(0);
+
+			// Advance one cadence (60s). setInterval fires runTickIfIdle, which
+			// invokes trackTick(() => tick()).
+			await vi.advanceTimersByTimeAsync(60 * 1000);
+			expect(tickSpy).toHaveBeenCalledTimes(1);
+			expect(trackTickSpy).toHaveBeenCalledTimes(1);
+
+			// The first tick is still hanging on firstTick.promise. Advance
+			// three more cadences (3 × 60s). Each setInterval fire must be
+			// suppressed because inFlightTick is still set.
+			await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+			expect(tickSpy).toHaveBeenCalledTimes(1);
+			expect(trackTickSpy).toHaveBeenCalledTimes(1);
+			expect(warnSpy).toHaveBeenCalledTimes(3);
+			expect(warnSpy).toHaveBeenLastCalledWith(
+				{ skippedSinceLastRun: 3 },
+				"Skipping hunt scheduler tick — prior tick still in flight",
+			);
+
+			// Resolve the slow tick. Recovery log fires and the next cadence
+			// runs a normal tick.
+			firstTick.resolve();
+			await vi.advanceTimersByTimeAsync(0); // drain microtasks
+			expect(infoSpy).toHaveBeenCalledWith(
+				{ skippedSinceLastRun: 3 },
+				"Hunt scheduler tick completed; resuming normal cadence",
+			);
+
+			await vi.advanceTimersByTimeAsync(60 * 1000);
+			expect(tickSpy).toHaveBeenCalledTimes(2);
+			expect(trackTickSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			getHuntingScheduler().stop();
+			vi.useRealTimers();
+		}
+	});
+
+	it("triggerManualHunt does not engage the in-flight tick guard", () => {
+		// Regression guard: my fix should not make manual hunts wait on
+		// scheduled-tick state, nor vice versa. The reviewer confirmed manual
+		// hunts call runHunt() directly, bypassing runTickIfIdle — this pins
+		// that contract so a future refactor can't accidentally route manual
+		// hunts through the guard and break the user-action latency.
+		const scheduler = getHuntingScheduler() as any;
+
+		// Simulate a slow scheduled tick in-flight.
+		scheduler.inFlightTick = new Promise<void>(() => {
+			// never resolves
+		});
+
+		// Spy on runHunt to confirm it gets called despite inFlightTick being
+		// set — manual hunts must not be blocked by the scheduler guard.
+		const runHuntSpy = vi.spyOn(scheduler, "runHunt").mockImplementation(() => Promise.resolve());
+
+		const result = scheduler.triggerManualHunt("inst-1", "missing");
+
+		expect(result.queued).toBe(true);
+		expect(runHuntSpy).toHaveBeenCalledTimes(1);
+		expect(runHuntSpy).toHaveBeenCalledWith("inst-1", "missing", true);
+
+		// Manual hunt must NOT touch the scheduled-tick guard.
+		expect(scheduler.inFlightTick).not.toBeNull();
+		expect(scheduler.skippedTicksWhileBusy).toBe(0);
 	});
 });

--- a/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
@@ -39,7 +39,7 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 	let errorSpy: ReturnType<typeof vi.spyOn>;
 	let mockApp: Partial<FastifyInstance>;
 
-	beforeEach(() => {
+	beforeEach(async () => {
 		warnSpy = vi.spyOn(loggers.hunting, "warn").mockImplementation(() => undefined);
 		infoSpy = vi.spyOn(loggers.hunting, "info").mockImplementation(() => undefined);
 		errorSpy = vi.spyOn(loggers.hunting, "error").mockImplementation(() => undefined);
@@ -61,6 +61,13 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		};
 
 		getHuntingScheduler().initialize(mockApp as FastifyInstance);
+		// initialize() fires cleanupStuckHunts() as a detached promise. Drain
+		// the microtask queue so that cleanup settles against this test's own
+		// mocks (which resolve `[]` synchronously) before the test body runs.
+		// Without this, the cleanup can interleave with the next test's
+		// beforeEach and pollute mock call counts non-deterministically.
+		await Promise.resolve();
+		await Promise.resolve();
 	});
 
 	afterEach(() => {
@@ -88,10 +95,15 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 			.spyOn(scheduler, "processScheduledHunts")
 			.mockImplementation(() => firstTick.promise);
 
-		// First tick fires and is captured as inFlightTick.
+		// First tick fires and is captured as inFlightTick. Bind a local
+		// reference so the cleanup `await` at the end of the test doesn't
+		// re-read `scheduler.inFlightTick` after the IIFE's finally has
+		// already nulled it — the read happens-before the await yields, so
+		// `await null` would be a no-op without it.
 		scheduler.runTickIfIdle();
+		const inFlight = scheduler.inFlightTick as Promise<void>;
 		expect(tickSpy).toHaveBeenCalledTimes(1);
-		expect(scheduler.inFlightTick).not.toBeNull();
+		expect(inFlight).not.toBeNull();
 
 		// Second tick fires before the first resolves — must be skipped, not
 		// chained, queued, or run in parallel.
@@ -111,9 +123,9 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 			"Skipping hunt scheduler tick — prior tick still in flight",
 		);
 
-		// Release the in-flight tick and let microtasks settle.
+		// Release the in-flight tick and wait for the captured promise.
 		firstTick.resolve();
-		await scheduler.inFlightTick;
+		await inFlight;
 	});
 
 	it("resumes normal cadence after the busy tick completes", async () => {
@@ -127,11 +139,12 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 			.mockImplementationOnce(() => Promise.resolve());
 
 		scheduler.runTickIfIdle();
+		const firstInFlight = scheduler.inFlightTick as Promise<void>;
 		scheduler.runTickIfIdle(); // skipped
 		expect(tickSpy).toHaveBeenCalledTimes(1);
 
 		firstTick.resolve();
-		await scheduler.inFlightTick;
+		await firstInFlight;
 
 		// After completion the recovery log fires summarizing skipped ticks.
 		expect(infoSpy).toHaveBeenCalledWith(
@@ -142,8 +155,9 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		expect(scheduler.inFlightTick).toBeNull();
 
 		scheduler.runTickIfIdle();
+		const secondInFlight = scheduler.inFlightTick as Promise<void>;
 		expect(tickSpy).toHaveBeenCalledTimes(2);
-		await scheduler.inFlightTick;
+		await secondInFlight;
 	});
 
 	it("does not log skip warnings when ticks fit inside the cadence", async () => {
@@ -153,9 +167,11 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		const tickSpy = vi.spyOn(scheduler, "processScheduledHunts").mockResolvedValue(undefined);
 
 		scheduler.runTickIfIdle();
-		await scheduler.inFlightTick;
+		const firstInFlight = scheduler.inFlightTick as Promise<void>;
+		await firstInFlight;
 		scheduler.runTickIfIdle();
-		await scheduler.inFlightTick;
+		const secondInFlight = scheduler.inFlightTick as Promise<void>;
+		await secondInFlight;
 
 		expect(tickSpy).toHaveBeenCalledTimes(2);
 		expect(warnSpy).not.toHaveBeenCalled();
@@ -175,7 +191,8 @@ describe("HuntingScheduler - tick overlap protection (#457)", () => {
 		);
 
 		scheduler.runTickIfIdle();
-		await scheduler.inFlightTick;
+		const inFlight = scheduler.inFlightTick as Promise<void>;
+		await inFlight;
 
 		// inFlightTick must clear so the next tick is not permanently blocked.
 		expect(scheduler.inFlightTick).toBeNull();

--- a/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for HuntingScheduler tick-overlap protection (issue #457).
+ *
+ * Confirms that runTickIfIdle() suppresses overlapping ticks while a prior
+ * tick is in flight, and that the scheduler resumes normal cadence once the
+ * busy tick completes. Without this guard a slow ARR service (e.g., 1.5M-
+ * track Lidarr) would let setInterval stack multiple paginator-heavy rounds
+ * on top of each other — the root cause of the 16 concurrent paginators
+ * observed in the #427 heap snapshot.
+ */
+
+import type { FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { loggers } from "../../logger.js";
+import { getHuntingScheduler } from "../scheduler.js";
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (error: unknown) => void;
+};
+
+function defer<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe("HuntingScheduler - tick overlap protection (#457)", () => {
+	// scheduler.ts uses the module-level `loggers.hunting` (not app.log), so
+	// the assertions need to spy on that child logger directly.
+	let warnSpy: ReturnType<typeof vi.spyOn>;
+	let infoSpy: ReturnType<typeof vi.spyOn>;
+	let errorSpy: ReturnType<typeof vi.spyOn>;
+	let mockApp: Partial<FastifyInstance>;
+
+	beforeEach(() => {
+		warnSpy = vi.spyOn(loggers.hunting, "warn").mockImplementation(() => undefined);
+		infoSpy = vi.spyOn(loggers.hunting, "info").mockImplementation(() => undefined);
+		errorSpy = vi.spyOn(loggers.hunting, "error").mockImplementation(() => undefined);
+
+		mockApp = {
+			prisma: {
+				huntConfig: {
+					findMany: vi.fn().mockResolvedValue([]),
+					update: vi.fn().mockResolvedValue({}),
+				},
+				huntLog: {
+					findMany: vi.fn().mockResolvedValue([]),
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+					create: vi.fn(),
+					update: vi.fn(),
+				},
+				// biome-ignore lint/suspicious/noExplicitAny: test fixture
+			} as any,
+		};
+
+		getHuntingScheduler().initialize(mockApp as FastifyInstance);
+	});
+
+	afterEach(() => {
+		getHuntingScheduler().stop();
+		warnSpy.mockRestore();
+		infoSpy.mockRestore();
+		errorSpy.mockRestore();
+		vi.clearAllMocks();
+		// Drop any residual in-flight promise from a prior test before the next
+		// runs (the scheduler is a singleton across tests).
+		// biome-ignore lint/suspicious/noExplicitAny: reach into private state for test isolation
+		(getHuntingScheduler() as any).inFlightTick = null;
+		// biome-ignore lint/suspicious/noExplicitAny: reach into private state for test isolation
+		(getHuntingScheduler() as any).skippedTicksWhileBusy = 0;
+	});
+
+	it("skips a second tick while the first is still in flight", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
+		const scheduler = getHuntingScheduler() as any;
+
+		// Make processScheduledHunts hang on a controllable deferred so we can
+		// observe a second runTickIfIdle() call while the first is mid-flight.
+		const firstTick = defer<void>();
+		const tickSpy = vi
+			.spyOn(scheduler, "processScheduledHunts")
+			.mockImplementation(() => firstTick.promise);
+
+		// First tick fires and is captured as inFlightTick.
+		scheduler.runTickIfIdle();
+		expect(tickSpy).toHaveBeenCalledTimes(1);
+		expect(scheduler.inFlightTick).not.toBeNull();
+
+		// Second tick fires before the first resolves — must be skipped, not
+		// chained, queued, or run in parallel.
+		scheduler.runTickIfIdle();
+		expect(tickSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenCalledWith(
+			{ skippedSinceLastRun: 1 },
+			"Skipping hunt scheduler tick — prior tick still in flight",
+		);
+
+		// And a third — the warning counter accumulates so operators can see
+		// how badly the cadence is slipping.
+		scheduler.runTickIfIdle();
+		expect(tickSpy).toHaveBeenCalledTimes(1);
+		expect(warnSpy).toHaveBeenLastCalledWith(
+			{ skippedSinceLastRun: 2 },
+			"Skipping hunt scheduler tick — prior tick still in flight",
+		);
+
+		// Release the in-flight tick and let microtasks settle.
+		firstTick.resolve();
+		await scheduler.inFlightTick;
+	});
+
+	it("resumes normal cadence after the busy tick completes", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
+		const scheduler = getHuntingScheduler() as any;
+
+		const firstTick = defer<void>();
+		const tickSpy = vi
+			.spyOn(scheduler, "processScheduledHunts")
+			.mockImplementationOnce(() => firstTick.promise)
+			.mockImplementationOnce(() => Promise.resolve());
+
+		scheduler.runTickIfIdle();
+		scheduler.runTickIfIdle(); // skipped
+		expect(tickSpy).toHaveBeenCalledTimes(1);
+
+		firstTick.resolve();
+		await scheduler.inFlightTick;
+
+		// After completion the recovery log fires summarizing skipped ticks.
+		expect(infoSpy).toHaveBeenCalledWith(
+			{ skippedSinceLastRun: 1 },
+			"Hunt scheduler tick completed; resuming normal cadence",
+		);
+		// inFlightTick is cleared and a subsequent call runs a real tick.
+		expect(scheduler.inFlightTick).toBeNull();
+
+		scheduler.runTickIfIdle();
+		expect(tickSpy).toHaveBeenCalledTimes(2);
+		await scheduler.inFlightTick;
+	});
+
+	it("does not log skip warnings when ticks fit inside the cadence", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
+		const scheduler = getHuntingScheduler() as any;
+
+		const tickSpy = vi.spyOn(scheduler, "processScheduledHunts").mockResolvedValue(undefined);
+
+		scheduler.runTickIfIdle();
+		await scheduler.inFlightTick;
+		scheduler.runTickIfIdle();
+		await scheduler.inFlightTick;
+
+		expect(tickSpy).toHaveBeenCalledTimes(2);
+		expect(warnSpy).not.toHaveBeenCalled();
+		// No recovery info-log fires because no ticks were skipped.
+		expect(infoSpy).not.toHaveBeenCalledWith(
+			expect.objectContaining({ skippedSinceLastRun: expect.any(Number) }),
+			expect.stringContaining("resuming normal cadence"),
+		);
+	});
+
+	it("clears in-flight state even if the tick throws", async () => {
+		// biome-ignore lint/suspicious/noExplicitAny: access private members under test
+		const scheduler = getHuntingScheduler() as any;
+
+		vi.spyOn(scheduler, "processScheduledHunts").mockRejectedValueOnce(
+			new Error("simulated tick failure"),
+		);
+
+		scheduler.runTickIfIdle();
+		await scheduler.inFlightTick;
+
+		// inFlightTick must clear so the next tick is not permanently blocked.
+		expect(scheduler.inFlightTick).toBeNull();
+		// Note: processScheduledHunts() rejection is caught inside the inner
+		// tick() method (not surfaced to trackTick), so the outer error log is
+		// not expected here. The contract this test pins is that the in-flight
+		// flag clears regardless of tick outcome.
+	});
+});

--- a/apps/api/src/lib/hunting/scheduler.ts
+++ b/apps/api/src/lib/hunting/scheduler.ts
@@ -35,6 +35,12 @@ class HuntingScheduler {
 	private running = false;
 	private intervalId: NodeJS.Timeout | null = null;
 	private trackTick: TickWrapper = passthroughTickWrapper;
+	// Tracks an in-flight scheduler tick so a new tick (fired by setInterval)
+	// is suppressed while the prior one is still paginating. Slow ARR services
+	// can make a single tick span many minutes; without this, hunt rounds stack
+	// up and multiply paginator memory + API-cap pressure. See issue #457.
+	private inFlightTick: Promise<void> | null = null;
+	private skippedTicksWhileBusy = 0;
 
 	/**
 	 * Wire an optional tick wrapper (used by the plugin to route ticks
@@ -100,12 +106,52 @@ class HuntingScheduler {
 		}
 		this.running = true;
 
-		// Check every minute for hunts that need to run
+		// Check every minute for hunts that need to run. Overlap protection
+		// lives in runTickIfIdle so we don't pollute the SchedulerRegistry
+		// stats with zero-work "ticks" when we skip due to a slow prior round.
 		this.intervalId = setInterval(() => {
-			this.trackTick(() => this.tick()).catch((error) => {
-				log.error({ err: error }, "Scheduler tick failed");
-			});
+			this.runTickIfIdle();
 		}, 60 * 1000);
+	}
+
+	/**
+	 * Run a scheduler tick only when no prior tick is in flight.
+	 *
+	 * The default 60s setInterval cadence is shorter than the worst-case tick
+	 * duration on slow services (e.g., a 1.5M-track Lidarr with ~92k wanted
+	 * albums paginated at several seconds per page). Without this guard a
+	 * second tick fires before the first finishes — observed in issue #427
+	 * as 16 concurrent `fetchWantedWithWrapAround` paginators rooted at the
+	 * same scheduler. Skipped ticks are logged with a running counter so the
+	 * condition is visible to operators; the counter is summarized when the
+	 * busy tick finally completes.
+	 */
+	private runTickIfIdle(): void {
+		if (this.inFlightTick) {
+			this.skippedTicksWhileBusy += 1;
+			log.warn(
+				{ skippedSinceLastRun: this.skippedTicksWhileBusy },
+				"Skipping hunt scheduler tick — prior tick still in flight",
+			);
+			return;
+		}
+
+		this.inFlightTick = (async () => {
+			try {
+				await this.trackTick(() => this.tick());
+			} catch (error) {
+				log.error({ err: error }, "Scheduler tick failed");
+			} finally {
+				if (this.skippedTicksWhileBusy > 0) {
+					log.info(
+						{ skippedSinceLastRun: this.skippedTicksWhileBusy },
+						"Hunt scheduler tick completed; resuming normal cadence",
+					);
+					this.skippedTicksWhileBusy = 0;
+				}
+				this.inFlightTick = null;
+			}
+		})();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

`HuntingScheduler.start()` fires a tick every 60s via `setInterval` with
no check on whether the prior tick is still running. With
`MAX_HUNT_DURATION_MS = 10 min` and a sequential for-loop over configs,
worst-case tick duration can reach ~80 minutes on 4 instances × 2 hunt
types — far past the 60s cadence. The heap retainer-walk on #427's
snapshot showed 16 simultaneous `fetchWantedWithWrapAround` paginators
alive at the OOM moment; the math fits exactly two overlapping rounds
(8 paginators × 2 rounds).

Adds `runTickIfIdle()` between `setInterval` and `tick()`. It tracks an
in-flight tick promise and suppresses overlapping fires, logging each
skip with an accumulating counter and emitting an info-log on tick
completion summarizing how many were skipped. The guard sits *outside*
`SchedulerRegistry.trackTick` so skipped ticks don't pollute the
`/api/system/jobs` run statistics — only real ticks register with the
observability surface.

PR #456 (slim records) already neutralizes the OOM blast radius. This PR
removes the underlying overlap multiplier, which #456's commentary
flagged as "still surprising and worth understanding."

## Investigation answers

Issue #457 raised four checklist items; resolutions:

- **Tick guard added** (`runTickIfIdle`) — was the root cause.
- **Missing+upgrade per service**: already serialized — the per-config
  for-loop awaits each hunt sequentially, and missing-then-upgrade is
  also sequential within a config. The 16-paginator multiplier was
  purely cross-tick.
- **In-tick concurrency cap**: not needed — all hunts in a tick are
  already serialized. Only cross-tick overlap had to be prevented.
- **API counter spillover**: not possible — `apiCallsThisHour` is
  per-config, so a slow Lidarr can't push a fast Sonarr over its cap.
  With overlap fixed, each hunt's API budget is now bounded by the
  per-config cap as designed.

## Files changed

- `apps/api/src/lib/hunting/scheduler.ts` — new `inFlightTick` field
  and `runTickIfIdle()` method; `setInterval` callback now routes
  through the guard.
- `apps/api/src/lib/hunting/__tests__/scheduler-tick-overlap.test.ts`
  — 6 new tests: skip-while-busy, recovery-after-completion,
  no-skip-on-fast-ticks, in-flight-clears-on-throw, fake-timer
  integration of `start()` wiring, manual-hunt-bypasses-guard
  regression guard.

## Test plan

- [x] `pnpm run typecheck` — 3/3 packages clean (matches CI)
- [x] `pnpm --filter @arr/api run test` — 1622 passed / 41 skipped / 0 failed
- [x] `pnpm --filter @arr/web run test` — 427/427 pass
- [x] `pnpm --filter @arr/api run lint` — 0 errors / 0 warnings in changed files
- [x] Fake-timer integration test exercises the real `setInterval`
      cadence: confirms a slow first tick suppresses three subsequent
      ticks with accumulating counter, then resumes normal cadence
      after recovery
- [x] Manual-hunt regression guard pins that `triggerManualHunt` does
      not engage `inFlightTick` (so a slow scheduled round doesn't
      block user actions)
- [ ] Observe in production: warn-log cadence on the next slow Lidarr
      hunt should match the skip counter; recovery info-log should
      fire once when the slow tick completes

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)