### PR TITLE
fix(seerr): accept person/collection in discover schema

### DIFF
--- a/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
@@ -429,6 +429,38 @@ describe("discoverMovies", () => {
 });
 
 // ===========================================================================
+// 9b. Shared discover funnel — getDiscover() filter behavior (issue #454)
+// ===========================================================================
+
+describe("discover funnel (shared)", () => {
+	// Regression: Seerr's trending endpoint returns mixed-type items (movies,
+	// TV, persons, collections). The schema must accept all four, and the
+	// client must filter out non-movie/tv entries so the frontend only sees
+	// `mediaType: "movie" | "tv"`. See issue #454.
+	it("accepts mixed-type results from trending and filters non-movie/tv items", async () => {
+		const mixed = {
+			page: 1,
+			totalPages: 1,
+			totalResults: 4,
+			results: [
+				{ id: 1, mediaType: "movie" as const, title: "Movie A", posterPath: "/a.jpg" },
+				{ id: 2, mediaType: "tv" as const, name: "Show B", posterPath: "/b.jpg" },
+				{ id: 3, mediaType: "person", name: "Person C", profilePath: "/c.jpg" },
+				{ id: 4, mediaType: "collection", name: "Collection D", posterPath: "/d.jpg" },
+			],
+		};
+		factory.rawRequest.mockResolvedValue(mockResponse(mixed));
+
+		const result = await client.discoverTrending();
+
+		expect(result.results).toHaveLength(2);
+		expect(result.results.map((r) => r.mediaType)).toEqual(["movie", "tv"]);
+		// totalResults reflects upstream's count for pagination — not the filtered length
+		expect(result.totalResults).toBe(4);
+	});
+});
+
+// ===========================================================================
 // 10. getMovieGenres
 // ===========================================================================
 

--- a/apps/api/src/lib/seerr/seerr-client.ts
+++ b/apps/api/src/lib/seerr/seerr-client.ts
@@ -723,10 +723,26 @@ export class SeerrClient {
 		return this.getDiscover(`/api/v1/discover/tv/genre/${genreId}${qs}`);
 	}
 
-	/** Shared discover fetch with schema validation */
+	/**
+	 * Shared discover fetch with schema validation.
+	 *
+	 * Seerr's trending endpoint (and occasionally others) returns mixed-type items
+	 * — movies, TV, persons, and collections. The schema accepts all four, but we
+	 * filter to `movie`/`tv` here so the frontend never has to handle person or
+	 * collection cards. `totalResults` is left untouched because it represents
+	 * upstream's count and drives `hasNextPage` for pagination.
+	 */
 	private async getDiscover(path: string): Promise<SeerrDiscoverResponse> {
 		const raw = await this.get<SeerrDiscoverResponse>(path, TIMEOUT_INTERACTIVE);
-		return this.parseAndRecord<SeerrDiscoverResponse>(raw, seerrDiscoverResponseSchema, "discover");
+		const parsed = this.parseAndRecord<SeerrDiscoverResponse>(
+			raw,
+			seerrDiscoverResponseSchema,
+			"discover",
+		);
+		const filtered = parsed.results.filter(
+			(item) => item.mediaType === "movie" || item.mediaType === "tv",
+		);
+		return { ...parsed, results: filtered };
 	}
 
 	// --- Search ---

--- a/packages/shared/src/types/seerr.ts
+++ b/packages/shared/src/types/seerr.ts
@@ -612,10 +612,18 @@ export function seerrPageResultSchema<T extends z.ZodTypeAny>(itemSchema: T) {
 	});
 }
 
-/** Mirrors SeerrDiscoverResult */
+/**
+ * Mirrors SeerrDiscoverResult.
+ *
+ * `mediaType` accepts `"person"` and `"collection"` because Seerr's
+ * `/api/v1/discover/trending` (and occasionally other endpoints) returns
+ * mixed-type items. The server filters non-movie/tv entries at the boundary
+ * before returning to the frontend, so the public {@link SeerrDiscoverResult}
+ * interface stays narrow (`"movie" | "tv"`).
+ */
 export const seerrDiscoverResultSchema = z.looseObject({
 	id: z.number(),
-	mediaType: z.enum(["movie", "tv"]),
+	mediaType: z.enum(["movie", "tv", "person", "collection"]),
 	title: z.string().optional(),
 	name: z.string().optional(),
 	originalTitle: z.string().optional(),


### PR DESCRIPTION
## Summary
- Widen \`seerrDiscoverResultSchema.mediaType\` to accept \`"movie" | "tv" | "person" | "collection"\` — Seerr's \`/api/v1/discover/trending\` returns all four. The previous \`z.enum(["movie", "tv"])\` rejected a single \`person\` item and threw \`UpstreamValidationError\` (HTTP 502), surfacing as the empty/error state in #454.
- Filter non-movie/tv items at the server boundary inside \`getDiscover()\` so the public \`SeerrDiscoverResult\` interface stays narrow (\`"movie" | "tv"\`). Frontend consumers (poster card, detail modal, request dialog) are unchanged.
- Preserve upstream \`totalResults\` so infinite-query pagination (\`hasNextPage\` derived from \`totalPages\`) keeps working.
- Add a regression test in a sibling \`describe("discover funnel (shared)")\` block that mocks a mixed-type trending response and asserts persons/collections are filtered while movies/TV are preserved.

## Why Test Connection passed but Discover didn't
Test Connection validates \`seerrStatusSchema\`, which never touches \`mediaType\`. Only \`/api/v1/discover/*\` (and \`/api/v1/search\`) flow through \`seerrDiscoverResponseSchema\` → \`parseUpstreamOrThrow\`, so the strict enum only bit the Discover surface.

## Why this slipped past existing tests
The pre-existing \`makeDiscoverResponse\` fixture in \`seerr-client.test.ts\` only contained a single \`mediaType: "movie"\` item — it never exercised the mixed-type trending shape that real Jellyseerr/Overseerr instances return.

## Known follow-up (not in this PR)
\`apps/web/src/features/discover/components/discover-search-results.tsx\` renders \`Found {totalResults} results\` using upstream's unfiltered count. After this fix, that label can show a number slightly higher than the rendered cards for person/collection-heavy searches. Out of scope for this bug-fix (label has always read upstream's number); flagged for a cosmetic follow-up.

## Test plan
- [x] \`pnpm --filter @arr/api exec vitest run src/lib/seerr\` — 82/82 passing (new mixed-type regression covered)
- [x] \`pnpm --filter @arr/api exec tsc --noEmit\` — clean
- [x] \`pnpm --filter @arr/shared exec tsc --noEmit\` — clean; \`@arr/shared\` dist rebuilt
- [ ] Manual: hit Discover against a real Jellyseerr/Overseerr trending response containing person results and confirm carousels render

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)