### PR TITLE
fix(settings): explain Schema Drift to users (closes #455)

### DIFF
--- a/apps/web/src/features/settings/components/__tests__/validation-health-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/validation-health-section.test.tsx
@@ -1,9 +1,8 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
-
-import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
 import type { ValidationHealthResponse } from "../../../../lib/api-client/system";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
 import { ValidationHealthSection } from "../validation-health-section";
 
 /*
@@ -116,5 +115,138 @@ describe("ValidationHealthSection — per-row tooltip override", () => {
 		const title = getRowBadgeTitle("sonarr");
 		expect(title).toMatch(/significant share of payloads/i);
 		expect(title).not.toMatch(/last check failed/i);
+	});
+});
+
+/*
+ * Issue #455: the Schema Drift section confused users because the term and
+ * the +/~/- badges were unexplained. These tests pin the user-facing copy so
+ * the explanation tooltip, expanded description, and legend can't silently
+ * disappear in a future refactor — leaving the section opaque again.
+ */
+function dataWithDrift(): ValidationHealthResponse["data"] {
+	const base = makeData("healthy");
+	return {
+		...base,
+		fingerprints: {
+			sonarr: {
+				series: {
+					baseline: {
+						fields: ["id", "title", "year"],
+						recordedAt: new Date(0).toISOString(),
+						sampleCount: 5,
+					},
+					latest: {
+						fields: ["id", "title", "year", "newField"],
+						recordedAt: new Date(0).toISOString(),
+						sampleCount: 5,
+					},
+					drift: {
+						newFields: ["newField"],
+						missingFields: ["year"],
+						hasDrift: true,
+					},
+					fieldMissCounts: { year: 5, flaky: 2 },
+				},
+			},
+		},
+	};
+}
+
+function dataWithoutDrift(): ValidationHealthResponse["data"] {
+	const base = makeData("healthy");
+	return {
+		...base,
+		fingerprints: {
+			sonarr: {
+				series: {
+					baseline: {
+						fields: ["id", "title"],
+						recordedAt: new Date(0).toISOString(),
+						sampleCount: 5,
+					},
+					latest: {
+						fields: ["id", "title"],
+						recordedAt: new Date(0).toISOString(),
+						sampleCount: 5,
+					},
+					drift: { newFields: [], missingFields: [], hasDrift: false },
+					fieldMissCounts: {},
+				},
+			},
+		},
+	};
+}
+
+describe("ValidationHealthSection — Schema Drift explanation (#455)", () => {
+	// The legend lives in a flex row that nests a styled badge inside a span
+	// alongside descriptive text — testing-library's default text matcher
+	// won't span those boundaries, so match on the container's flat text.
+	const hasLegendText = (substr: RegExp) => (_: string, node: Element | null) =>
+		!!node && substr.test(node.textContent ?? "");
+
+	it("renders a help tooltip that explains what schema drift is", () => {
+		renderWithTheme(
+			<ValidationHealthSection
+				data={dataWithoutDrift()}
+				themeGradient={themeGradient}
+				onReset={vi.fn()}
+				isResetting={false}
+			/>,
+		);
+		// The Tooltip primitive puts the explanation text into a hover popover
+		// that lives in the DOM at all times (CSS toggles visibility). Asserting
+		// on the text presence is enough — without the explanation copy this
+		// query throws and pins the regression.
+		expect(screen.getByText(/diagnostic for developers/i)).toBeTruthy();
+		expect(screen.getByText(/baselines reset on app restart/i)).toBeTruthy();
+	});
+
+	it("hides the legend when no drift is detected", () => {
+		renderWithTheme(
+			<ValidationHealthSection
+				data={dataWithoutDrift()}
+				themeGradient={themeGradient}
+				onReset={vi.fn()}
+				isResetting={false}
+			/>,
+		);
+		// Open the Schema Drift section — the "No drift" branch should *not*
+		// render the legend, because there are no symbols to explain.
+		fireEvent.click(screen.getByRole("button", { name: /schema drift/i }));
+		expect(screen.queryAllByText(hasLegendText(/first seen since baseline/i))).toHaveLength(0);
+		expect(screen.queryAllByText(hasLegendText(/absent 3\+ runs/i))).toHaveLength(0);
+	});
+
+	it("shows the legend with +/~/- semantics when drift is present", () => {
+		renderWithTheme(
+			<ValidationHealthSection
+				data={dataWithDrift()}
+				themeGradient={themeGradient}
+				onReset={vi.fn()}
+				isResetting={false}
+			/>,
+		);
+		fireEvent.click(screen.getByRole("button", { name: /schema drift/i }));
+		expect(
+			screen.queryAllByText(hasLegendText(/first seen since baseline/i)).length,
+		).toBeGreaterThan(0);
+		expect(screen.queryAllByText(hasLegendText(/absent 1.+2 runs/i)).length).toBeGreaterThan(0);
+		expect(screen.queryAllByText(hasLegendText(/absent 3\+ runs/i)).length).toBeGreaterThan(0);
+	});
+
+	it("aria-exposes the collapse state of the Schema Drift toggle", () => {
+		renderWithTheme(
+			<ValidationHealthSection
+				data={dataWithoutDrift()}
+				themeGradient={themeGradient}
+				onReset={vi.fn()}
+				isResetting={false}
+			/>,
+		);
+		const toggle = screen.getByRole("button", { name: /schema drift/i });
+		expect(toggle.getAttribute("aria-expanded")).toBe("false");
+		fireEvent.click(toggle);
+		expect(toggle.getAttribute("aria-expanded")).toBe("true");
 	});
 });

--- a/apps/web/src/features/settings/components/validation-health-section.tsx
+++ b/apps/web/src/features/settings/components/validation-health-section.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { DomainStatusBadge, PremiumSection } from "../../../components/layout";
+import { Tooltip } from "../../../components/layout/config-primitives";
 import type { DomainStatus } from "../../../components/layout/domain-status";
 import { Button } from "../../../components/ui/button";
 import { useClearQuarantine, useValidationQuarantine } from "../../../hooks/api/useSystem";
@@ -473,6 +474,14 @@ export function ValidationHealthSection({
 // Schema Drift Section
 // ============================================================================
 
+/**
+ * Plain-language explanation surfaced both as a tooltip on the header and as
+ * a description block inside the expanded panel. Lives in one place so the
+ * two surfaces can't drift apart.
+ */
+const SCHEMA_DRIFT_EXPLANATION =
+	"Schema drift tracks when the field shapes of upstream API responses (Sonarr, Radarr, Plex, etc.) change versus the first response Arr Dashboard observed after start-up. It is a diagnostic for developers — drift is informational, not an error you need to fix. New fields usually mean the upstream service shipped a new release; missing fields can hint at a breaking change. Baselines reset on app restart.";
+
 function SchemaDriftSection({
 	fingerprints,
 	hasDrift,
@@ -487,14 +496,18 @@ function SchemaDriftSection({
 
 	return (
 		<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10">
-			<button
-				type="button"
-				onClick={() => setIsOpen(!isOpen)}
-				className="flex items-center justify-between w-full p-3 text-left hover:bg-card/50 transition-colors"
-			>
-				<div className="flex items-center gap-2">
+			{/* Header row: toggle button is the only interactive child, the help
+			    tooltip is a sibling so hovering it never accidentally collapses
+			    the panel and there are no nested interactive elements. */}
+			<div className="flex items-center justify-between w-full p-3 transition-colors">
+				<button
+					type="button"
+					onClick={() => setIsOpen(!isOpen)}
+					className="flex items-center gap-2 text-left flex-1 min-w-0 hover:opacity-80 transition-opacity"
+					aria-expanded={isOpen}
+				>
 					<ChevronRight
-						className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${isOpen ? "rotate-90" : ""}`}
+						className={`h-4 w-4 text-muted-foreground transition-transform duration-200 shrink-0 ${isOpen ? "rotate-90" : ""}`}
 					/>
 					<span className="text-sm font-medium text-foreground">Schema Drift</span>
 					{hasDrift ? (
@@ -518,92 +531,151 @@ function SchemaDriftSection({
 							No drift
 						</span>
 					)}
+				</button>
+				<div className="flex items-center gap-3 shrink-0">
+					<Tooltip text={SCHEMA_DRIFT_EXPLANATION} />
+					<span className="text-xs text-muted-foreground">
+						{integrationNames.length} integration(s) tracked
+					</span>
 				</div>
-				<span className="text-xs text-muted-foreground">
-					{integrationNames.length} integration(s) tracked
-				</span>
-			</button>
+			</div>
 
 			{isOpen && (
 				<div className="border-t border-border/30 p-3 space-y-3">
+					{/* Always-visible explanation when the section is expanded — addresses
+					    the "what does this mean?" question without making the user hunt
+					    for a tooltip. */}
+					<p className="text-xs text-muted-foreground leading-relaxed">
+						{SCHEMA_DRIFT_EXPLANATION}
+					</p>
 					{!hasDrift ? (
 						<p className="text-sm text-muted-foreground text-center py-2">
 							No schema drift detected — all upstream field shapes match their baselines.
 						</p>
 					) : (
-						integrationNames.map((integration) => {
-							const categories = fingerprints[integration]!;
-							const driftingCategories = Object.entries(categories).filter(
-								([, fp]) => fp.drift.hasDrift,
-							);
-
-							if (driftingCategories.length === 0) return null;
-
-							return (
-								<div key={integration} className="space-y-2">
-									<p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-										{integration}
-									</p>
-									{driftingCategories.map(([category, fp]) => {
-										// Fields with 1-2 misses (intermittent, not yet flagged as missing)
-										const intermittentFields = Object.entries(fp.fieldMissCounts ?? {})
-											.filter(([, count]) => count >= 1 && count < 3)
-											.map(([field]) => field)
-											.sort();
-
-										return (
-											<div
-												key={`${integration}:${category}`}
-												className="rounded-lg border border-border/30 bg-card/20 p-3 space-y-2"
-											>
-												<p className="text-sm font-mono text-foreground">{category}</p>
-												<div className="flex flex-wrap gap-1.5">
-													{fp.drift.newFields.map((field) => (
-														<span
-															key={field}
-															className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
-															style={{
-																backgroundColor: `${SEMANTIC_COLORS.success.from}15`,
-																color: SEMANTIC_COLORS.success.from,
-																border: `1px solid ${SEMANTIC_COLORS.success.from}30`,
-															}}
-														>
-															+ {field}
-														</span>
-													))}
-													{intermittentFields.map((field) => (
-														<span
-															key={field}
-															className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
-															style={{
-																backgroundColor: `${SEMANTIC_COLORS.warning.from}15`,
-																color: SEMANTIC_COLORS.warning.from,
-																border: `1px solid ${SEMANTIC_COLORS.warning.from}30`,
-															}}
-														>
-															~ {field}
-														</span>
-													))}
-													{fp.drift.missingFields.map((field) => (
-														<span
-															key={field}
-															className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
-															style={{
-																backgroundColor: `${SEMANTIC_COLORS.error.from}15`,
-																color: SEMANTIC_COLORS.error.from,
-																border: `1px solid ${SEMANTIC_COLORS.error.from}30`,
-															}}
-														>
-															- {field}
-														</span>
-													))}
-												</div>
-											</div>
-										);
-									})}
+						<>
+							{/* Legend — explains the +/~/- field badges before the user
+							    sees them. Without this, the symbols are jargon. */}
+							<div className="rounded-lg border border-border/30 bg-card/20 p-3">
+								<p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2">
+									Legend
+								</p>
+								<div className="flex flex-wrap gap-x-4 gap-y-1.5 text-xs text-muted-foreground">
+									<span className="inline-flex items-center gap-1.5">
+										<span
+											className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono"
+											style={{
+												backgroundColor: `${SEMANTIC_COLORS.success.from}15`,
+												color: SEMANTIC_COLORS.success.from,
+												border: `1px solid ${SEMANTIC_COLORS.success.from}30`,
+											}}
+										>
+											+ field
+										</span>
+										New — first seen since baseline
+									</span>
+									<span className="inline-flex items-center gap-1.5">
+										<span
+											className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono"
+											style={{
+												backgroundColor: `${SEMANTIC_COLORS.warning.from}15`,
+												color: SEMANTIC_COLORS.warning.from,
+												border: `1px solid ${SEMANTIC_COLORS.warning.from}30`,
+											}}
+										>
+											~ field
+										</span>
+										Intermittent — absent 1–2 runs
+									</span>
+									<span className="inline-flex items-center gap-1.5">
+										<span
+											className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-mono"
+											style={{
+												backgroundColor: `${SEMANTIC_COLORS.error.from}15`,
+												color: SEMANTIC_COLORS.error.from,
+												border: `1px solid ${SEMANTIC_COLORS.error.from}30`,
+											}}
+										>
+											- field
+										</span>
+										Missing — absent 3+ runs (likely removed)
+									</span>
 								</div>
-							);
-						})
+							</div>
+							{integrationNames.map((integration) => {
+								const categories = fingerprints[integration]!;
+								const driftingCategories = Object.entries(categories).filter(
+									([, fp]) => fp.drift.hasDrift,
+								);
+
+								if (driftingCategories.length === 0) return null;
+
+								return (
+									<div key={integration} className="space-y-2">
+										<p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+											{integration}
+										</p>
+										{driftingCategories.map(([category, fp]) => {
+											// Fields with 1-2 misses (intermittent, not yet flagged as missing)
+											const intermittentFields = Object.entries(fp.fieldMissCounts ?? {})
+												.filter(([, count]) => count >= 1 && count < 3)
+												.map(([field]) => field)
+												.sort();
+
+											return (
+												<div
+													key={`${integration}:${category}`}
+													className="rounded-lg border border-border/30 bg-card/20 p-3 space-y-2"
+												>
+													<p className="text-sm font-mono text-foreground">{category}</p>
+													<div className="flex flex-wrap gap-1.5">
+														{fp.drift.newFields.map((field) => (
+															<span
+																key={field}
+																className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
+																style={{
+																	backgroundColor: `${SEMANTIC_COLORS.success.from}15`,
+																	color: SEMANTIC_COLORS.success.from,
+																	border: `1px solid ${SEMANTIC_COLORS.success.from}30`,
+																}}
+															>
+																+ {field}
+															</span>
+														))}
+														{intermittentFields.map((field) => (
+															<span
+																key={field}
+																className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
+																style={{
+																	backgroundColor: `${SEMANTIC_COLORS.warning.from}15`,
+																	color: SEMANTIC_COLORS.warning.from,
+																	border: `1px solid ${SEMANTIC_COLORS.warning.from}30`,
+																}}
+															>
+																~ {field}
+															</span>
+														))}
+														{fp.drift.missingFields.map((field) => (
+															<span
+																key={field}
+																className="inline-flex items-center px-2 py-0.5 rounded text-xs font-mono"
+																style={{
+																	backgroundColor: `${SEMANTIC_COLORS.error.from}15`,
+																	color: SEMANTIC_COLORS.error.from,
+																	border: `1px solid ${SEMANTIC_COLORS.error.from}30`,
+																}}
+															>
+																- {field}
+															</span>
+														))}
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								);
+							})}
+						</>
 					)}
 				</div>
 			)}


### PR DESCRIPTION
## Summary

- Adds plain-language help to the **Validation Health → Schema Drift** section in Settings → System so users stop seeing it as a cryptic error.
- Three layers of context: a help tooltip on the header, an always-visible description inside the expanded panel, and a legend for the `+ / ~ / -` field badges (shown only when drift is actually present).
- No changes to the drift detection logic itself — purely a UX/clarity fix in `validation-health-section.tsx`.

### Why
Issue #455: user opened Settings → System, saw "Drift detected" with no explanation of what schema drift is, what the colored badges meant, or whether they needed to act on it. The backend detection was working as designed; the UI was just exposing raw mechanics.

### What changed
- `apps/web/src/features/settings/components/validation-health-section.tsx`
  - Single `SCHEMA_DRIFT_EXPLANATION` constant so the tooltip copy and the in-panel description can't drift apart.
  - Reuses the existing `Tooltip` primitive from `components/layout/config-primitives.tsx` for consistency with how `hunting-config` etc. expose help.
  - Restructured the header so the toggle `<button>` no longer contains the tooltip — hover/click on the help icon won't accidentally collapse the panel, and `aria-expanded` properly tracks the toggle state.
  - Legend only renders when `hasDrift` is true (no jargon to explain when there's nothing to look at).
- `apps/web/src/features/settings/components/__tests__/validation-health-section.test.tsx`
  - +4 tests pinning the explanation copy, legend gating, and `aria-expanded` behaviour.

## Test plan

- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean for changed file
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm run test` — **1623 passed**, 41 skipped, 0 failed (7 tests now in validation-health-section.test.tsx, was 3)
- [x] All 52 tests in the broader `apps/web/src/features/settings` tree pass
- [ ] Visual smoke test in the dashboard (reviewer): open Settings → System → Validation Health → Schema Drift. Confirm:
  - Help icon appears next to "Drift detected" / "No drift" badge with a tooltip on hover
  - Expanding the panel shows the explanation paragraph at the top
  - With drift present, the legend appears above the per-integration field lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)