### PR TITLE
fix(trash-guides): per-service fingerprint keys for naming presets

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
@@ -8,6 +8,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { schemaFingerprints } from "../../validation/schema-fingerprint.js";
 import { TrashGitHubFetcher } from "../github-fetcher.js";
 
 type FetchSpy = ReturnType<typeof vi.fn>;
@@ -85,5 +86,109 @@ describe("TrashGitHubFetcher URL construction (issue #406)", () => {
 		expect(calls[2]).toBe(
 			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/docs/json/radarr/cf/2160p.json",
 		);
+	});
+});
+
+/*
+ * `fetchNamingData` records a schema fingerprint for each service. The fix
+ * keys those fingerprints by service ("radarrNamingPresets" vs
+ * "sonarrNamingPresets") because the two services ship genuinely different
+ * shapes — Radarr returns { folder, file } while Sonarr returns { season,
+ * series, episodes }. Sharing a single "namingPresets" category caused the
+ * registry baseline to oscillate every refresh cycle and produced false
+ * intermittent-drift signals in Settings → System → Schema Drift.
+ *
+ * Pinning the per-service category names here makes regressions show up as
+ * an obvious assertion failure rather than as cosmetic UI noise the user
+ * has to spot.
+ */
+describe("TrashGitHubFetcher.fetchNamingData — per-service fingerprint categories", () => {
+	let fetchSpy: FetchSpy;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+		// The schemaFingerprints registry is a process-global singleton; clear
+		// it so prior tests can't leak state into these assertions.
+		schemaFingerprints.reset();
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		schemaFingerprints.reset();
+	});
+
+	const RADARR_NAMING = {
+		folder: { "TRaSH Recommended": "{Movie CleanTitle} ({Release Year})" },
+		file: { "TRaSH Recommended": "{Movie CleanTitle}" },
+	};
+	const SONARR_NAMING = {
+		season: { Default: "Season {season:00}" },
+		series: { Default: "{Series TitleYear}" },
+		episodes: {
+			standard: { Default: "{Series TitleYear} - S{season:00}E{episode:00}" },
+			daily: { Default: "{Series TitleYear} - {Air-Date}" },
+			anime: { Default: "{Series TitleYear} - S{season:00}E{episode:00}" },
+		},
+	};
+
+	async function primeBothServices(fetcher: TrashGitHubFetcher) {
+		// RADARR: directory listing + one file
+		fetchSpy.mockResolvedValueOnce(
+			buildJsonResponse([{ name: "radarr-naming.json", type: "file" }]),
+		);
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse(RADARR_NAMING));
+		await fetcher.fetchNamingData("RADARR");
+
+		// SONARR: directory listing + one file
+		fetchSpy.mockResolvedValueOnce(
+			buildJsonResponse([{ name: "sonarr-naming.json", type: "file" }]),
+		);
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse(SONARR_NAMING));
+		await fetcher.fetchNamingData("SONARR");
+	}
+
+	it("records separate fingerprint categories for RADARR and SONARR", async () => {
+		const fetcher = new TrashGitHubFetcher();
+		await primeBothServices(fetcher);
+
+		const categories = schemaFingerprints.getByIntegration("trash-guides");
+		expect(categories.radarrNamingPresets).toBeDefined();
+		expect(categories.sonarrNamingPresets).toBeDefined();
+		// The legacy shared key must not be used — that's the regression
+		// guard. If a future refactor reverts to "namingPresets", this
+		// assertion catches it.
+		expect(categories.namingPresets).toBeUndefined();
+	});
+
+	it("does not report drift on first observation for either service", async () => {
+		const fetcher = new TrashGitHubFetcher();
+		await primeBothServices(fetcher);
+
+		const categories = schemaFingerprints.getByIntegration("trash-guides");
+		// Before the fix: SONARR's first call landed against RADARR's baseline
+		// and reported folder/file as missing + season/series/episodes as new.
+		// After the fix: each service has its own baseline, so neither shows
+		// drift on first observation.
+		expect(categories.radarrNamingPresets?.drift.hasDrift).toBe(false);
+		expect(categories.sonarrNamingPresets?.drift.hasDrift).toBe(false);
+	});
+
+	it("each baseline contains only the fields from its own service shape", async () => {
+		const fetcher = new TrashGitHubFetcher();
+		await primeBothServices(fetcher);
+
+		const categories = schemaFingerprints.getByIntegration("trash-guides");
+		expect(categories.radarrNamingPresets?.baseline.fields).toEqual(["_service", "file", "folder"]);
+		// The schemas attach a `_service` discriminant via `.transform()`, so
+		// the fingerprint also sees it — included in the assertion so the
+		// expected shape is explicit.
+		expect(categories.sonarrNamingPresets?.baseline.fields).toEqual([
+			"_service",
+			"episodes",
+			"season",
+			"series",
+		]);
 	});
 });

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -762,19 +762,25 @@ export class TrashGitHubFetcher {
 
 				if (response.ok) {
 					const rawData: unknown = await response.json();
-					// Branch by service type — each schema's .transform() injects the _service discriminant
+					// Branch by service type — each schema's .transform() injects the _service
+					// discriminant. The fingerprint/quarantine category MUST be service-scoped:
+					// Radarr and Sonarr ship genuinely different top-level shapes, so a shared
+					// key would oscillate the registry baseline and surface as constant
+					// intermittent-drift in Settings → System → Schema Drift. The exact field
+					// snapshots live in github-fetcher.test.ts so they fail loudly if upstream
+					// changes shape.
 					if (serviceType === "RADARR") {
 						results.push(
 							...validateAndCollect(rawData, radarrNamingSchema, file, this.log, {
 								integration: "trash-guides",
-								category: "namingPresets",
+								category: "radarrNamingPresets",
 							}).items,
 						);
 					} else {
 						results.push(
 							...validateAndCollect(rawData, sonarrNamingSchema, file, this.log, {
 								integration: "trash-guides",
-								category: "namingPresets",
+								category: "sonarrNamingPresets",
 							}).items,
 						);
 					}


### PR DESCRIPTION
## Summary

- `fetchNamingData` recorded its schema fingerprint under one shared `namingPresets` category for both Radarr and Sonarr.
- The two services ship genuinely different shapes — Radarr: `{ folder, file }`, Sonarr: `{ season, series, episodes }` — so the registry baseline oscillated between two valid shapes every refresh cycle.
- Schema Drift surfaced this as constant intermittent-drift signals (`+ file`, `+ folder`, `~ episodes`, `~ season`, `~ series`) even though nothing was actually drifting upstream. Visible immediately after PR #461 made the section legible — same diagnostic pattern this PR removes.

## Why

Spotted during the validation of PR #462. The merged Schema Drift section was correctly surfacing what the registry recorded; the registry was just being driven incorrectly. Two services with different schemas can't share a fingerprint key without producing false oscillation drift.

## Fix

Scope the fingerprint/quarantine category to the service inside `fetchNamingData`:

```diff
- category: "namingPresets",  // both branches
+ category: "radarrNamingPresets",  // RADARR branch
+ category: "sonarrNamingPresets",  // SONARR branch
```

The category name only flows into the schema-fingerprint registry and the quarantine bucket — both keyed by free-form strings and not exposed on any stable contract — so no migration is needed. Schema drift baselines reset on app restart anyway.

## Test plan

3 new pinning tests in `github-fetcher.test.ts`:

- [x] `records separate fingerprint categories for RADARR and SONARR` — asserts `radarrNamingPresets` AND `sonarrNamingPresets` exist, and that the legacy shared `namingPresets` key does **not**
- [x] `does not report drift on first observation for either service` — pre-fix, SONARR's first call reported drift against RADARR's baseline; post-fix, each service has its own baseline so neither shows drift
- [x] `each baseline contains only the fields from its own service shape` — pins the expected `_service, file, folder` and `_service, episodes, season, series` field sets

Runs:
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm run test` → **1622 passed** (+3 new vs prior baseline of 1619), 41 skipped, 0 failed

Manual (reviewer-side): refresh TRaSH cache once and confirm Schema Drift shows `trash-guides · radarrNamingPresets` and `trash-guides · sonarrNamingPresets` as separate categories, each with `No drift` on subsequent refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)