### PR TITLE
feat(trash-guides): migration notices for German/French unwanted CFs

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/migration-notices.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/migration-notices.test.ts
@@ -15,6 +15,18 @@ const RADARR_UNWANTED_FORMATS = "a3ac6af01d78e4f21fcb75f601ac96df";
 const SONARR_OPTIONAL_MISCELLANEOUS = "f4a0410a1df109a66d6e47dcadcce014";
 const SONARR_UNWANTED_FORMATS = "59c3af66780d08332fdc64e68297098f";
 
+// PR #2719 — split German unwanted formats into a dedicated group
+const RADARR_RELEASE_GROUPS_GERMAN = "bc85e56ee3bd0f01467866d5f1261543";
+const RADARR_UNWANTED_FORMATS_GERMAN = "0ca61b4b233178d07113082a7acff72d";
+const SONARR_RELEASE_GROUPS_GERMAN = "cae54a0be4f9773169e82e129dd1fcfb";
+const SONARR_UNWANTED_FORMATS_GERMAN = "6f0872eebfc95b1f93474b7ac866ced0";
+
+// PR #2721 — split French unwanted formats into a dedicated group
+const RADARR_RELEASE_GROUPS_FRENCH = "12a919c8a5e2342db6e9c0b4e3c0756e";
+const RADARR_UNWANTED_FORMATS_FRENCH = "59f7ab9ff64d0026b011b985b1cc8670";
+const SONARR_RELEASE_GROUPS_FRENCH = "9fa0bf3c8f8f00154431c3323a29eef2";
+const SONARR_UNWANTED_FORMATS_FRENCH = "a23c8675c79118544fd74153394fa589";
+
 describe("getMigrationNotices", () => {
 	it("emits the unwanted-formats notice for Radarr templates that contain only [Optional] Miscellaneous", () => {
 		const notices = getMigrationNotices("RADARR", new Set([RADARR_OPTIONAL_MISCELLANEOUS]));
@@ -57,5 +69,78 @@ describe("getMigrationNotices", () => {
 	it("does not fire when only the introduced group is present (user added unwanted-formats but never had optional-miscellaneous)", () => {
 		const notices = getMigrationNotices("RADARR", new Set([RADARR_UNWANTED_FORMATS]));
 		expect(notices).toEqual([]);
+	});
+
+	// PR #2719 — German unwanted formats
+	it("emits the German unwanted-formats notice for Radarr templates anchored on [Release Groups] German", () => {
+		const notices = getMigrationNotices("RADARR", new Set([RADARR_RELEASE_GROUPS_GERMAN]));
+		expect(notices).toHaveLength(1);
+		expect(notices[0]?.id).toBe("trash-pr-2719-radarr-german-unwanted");
+	});
+
+	it("emits the German unwanted-formats notice for Sonarr templates anchored on [Release Groups] German", () => {
+		const notices = getMigrationNotices("SONARR", new Set([SONARR_RELEASE_GROUPS_GERMAN]));
+		expect(notices).toHaveLength(1);
+		expect(notices[0]?.id).toBe("trash-pr-2719-sonarr-german-unwanted");
+	});
+
+	it("suppresses the Radarr German notice when the new German unwanted group is already present", () => {
+		const notices = getMigrationNotices(
+			"RADARR",
+			new Set([RADARR_RELEASE_GROUPS_GERMAN, RADARR_UNWANTED_FORMATS_GERMAN]),
+		);
+		expect(notices).toEqual([]);
+	});
+
+	it("suppresses the Sonarr German notice when the new German unwanted group is already present", () => {
+		const notices = getMigrationNotices(
+			"SONARR",
+			new Set([SONARR_RELEASE_GROUPS_GERMAN, SONARR_UNWANTED_FORMATS_GERMAN]),
+		);
+		expect(notices).toEqual([]);
+	});
+
+	// PR #2721 — French unwanted formats
+	it("emits the French unwanted-formats notice for Radarr templates anchored on [Release Groups] French", () => {
+		const notices = getMigrationNotices("RADARR", new Set([RADARR_RELEASE_GROUPS_FRENCH]));
+		expect(notices).toHaveLength(1);
+		expect(notices[0]?.id).toBe("trash-pr-2721-radarr-french-unwanted");
+	});
+
+	it("emits the French unwanted-formats notice for Sonarr templates anchored on [Release Groups] French", () => {
+		const notices = getMigrationNotices("SONARR", new Set([SONARR_RELEASE_GROUPS_FRENCH]));
+		expect(notices).toHaveLength(1);
+		expect(notices[0]?.id).toBe("trash-pr-2721-sonarr-french-unwanted");
+	});
+
+	it("suppresses the Radarr French notice when the new French unwanted group is already present", () => {
+		const notices = getMigrationNotices(
+			"RADARR",
+			new Set([RADARR_RELEASE_GROUPS_FRENCH, RADARR_UNWANTED_FORMATS_FRENCH]),
+		);
+		expect(notices).toEqual([]);
+	});
+
+	it("suppresses the Sonarr French notice when the new French unwanted group is already present", () => {
+		const notices = getMigrationNotices(
+			"SONARR",
+			new Set([SONARR_RELEASE_GROUPS_FRENCH, SONARR_UNWANTED_FORMATS_FRENCH]),
+		);
+		expect(notices).toEqual([]);
+	});
+
+	// Co-occurrence sanity: a German Radarr template that happens to also have the
+	// generic optional-miscellaneous group should fire BOTH the #2711 and #2719
+	// notices, not be deduped. This pins that the registry walks all entries.
+	it("emits both #2711 and #2719 Radarr notices when a template has both the generic and German anchors", () => {
+		const notices = getMigrationNotices(
+			"RADARR",
+			new Set([RADARR_OPTIONAL_MISCELLANEOUS, RADARR_RELEASE_GROUPS_GERMAN]),
+		);
+		const ids = notices.map((n) => n.id).sort();
+		expect(ids).toEqual([
+			"trash-pr-2711-radarr-unwanted-formats",
+			"trash-pr-2719-radarr-german-unwanted",
+		]);
 	});
 });

--- a/apps/api/src/lib/trash-guides/migration-notices.ts
+++ b/apps/api/src/lib/trash-guides/migration-notices.ts
@@ -10,6 +10,24 @@
  * customFormatGroups AND absence of `introducedGroupTrashId`. Once the
  * user has both groups, the migration is complete and the notice falls
  * silent — re-displaying it indefinitely would be misleading.
+ *
+ * Anchor (`keptGroupTrashId`) choice — two valid patterns:
+ *   1. **Split-source anchor**: the group the introduced CFs were pulled
+ *      out of. Use when the split is global (every user with the
+ *      kept group is in scope). Example: #2711 anchors on
+ *      [Optional] Miscellaneous because the unwanted CFs were pulled
+ *      out of it.
+ *   2. **Audience-marker anchor**: a different group that signals the
+ *      user is in scope for the migration, even if the introduced CFs
+ *      did not literally come from it. Use when the split is scoped to
+ *      a sub-audience (e.g. language-specific). Example: #2719/#2721
+ *      anchor on [Release Groups] German/French because the upstream
+ *      split pulled language-specific CFs out of the generic unwanted
+ *      group, but firing the notice for every English-only user would
+ *      be noise. The language-presence anchor scopes correctly.
+ *
+ * If you "fix" an audience-marker anchor back to a split-source anchor
+ * without understanding this distinction, you'll create false positives.
  */
 
 import type { TemplateMigrationNotice } from "@arr/shared";
@@ -49,6 +67,62 @@ const REGISTRY: readonly MigrationRegistryEntry[] = [
 			id: "trash-pr-2711-sonarr-unwanted-formats",
 			title: "TRaSH split [Optional] Miscellaneous",
 			body: "Upstream moved the unwanted-format CFs (AV1, BR-DISK, LQ, etc.) into a new [Unwanted] Unwanted Formats group. The new group is default-enabled upstream, so syncing will keep the same CFs in your template — just sourced from a different group.",
+			severity: "info",
+		},
+	},
+	{
+		serviceType: "RADARR",
+		// Radarr [Release Groups] German — anchor for German-focused templates.
+		keptGroupTrashId: "bc85e56ee3bd0f01467866d5f1261543",
+		// Radarr [Unwanted] Unwanted Formats German — new in PR #2719, marked
+		// default-enabled upstream so the merger auto-adopts on sync.
+		introducedGroupTrashId: "0ca61b4b233178d07113082a7acff72d",
+		notice: {
+			id: "trash-pr-2719-radarr-german-unwanted",
+			title: "TRaSH split German unwanted formats",
+			body: "Upstream split the German-specific unwanted-format CFs into a dedicated [Unwanted] Unwanted Formats German group. The new group is default-enabled upstream, so syncing will keep the same CFs in your template — just sourced from a German-specific group.",
+			severity: "info",
+		},
+	},
+	{
+		serviceType: "SONARR",
+		// Sonarr [Release Groups] German — anchor for German-focused templates.
+		keptGroupTrashId: "cae54a0be4f9773169e82e129dd1fcfb",
+		// Sonarr [Unwanted] Unwanted Formats German — new in PR #2719, marked
+		// default-enabled upstream so the merger auto-adopts on sync.
+		introducedGroupTrashId: "6f0872eebfc95b1f93474b7ac866ced0",
+		notice: {
+			id: "trash-pr-2719-sonarr-german-unwanted",
+			title: "TRaSH split German unwanted formats",
+			body: "Upstream split the German-specific unwanted-format CFs into a dedicated [Unwanted] Unwanted Formats German group. The new group is default-enabled upstream, so syncing will keep the same CFs in your template — just sourced from a German-specific group.",
+			severity: "info",
+		},
+	},
+	{
+		serviceType: "RADARR",
+		// Radarr [Release Groups] French — anchor for French-focused templates.
+		keptGroupTrashId: "12a919c8a5e2342db6e9c0b4e3c0756e",
+		// Radarr [Unwanted] Unwanted Formats French — new in PR #2721, marked
+		// default-enabled upstream so the merger auto-adopts on sync.
+		introducedGroupTrashId: "59f7ab9ff64d0026b011b985b1cc8670",
+		notice: {
+			id: "trash-pr-2721-radarr-french-unwanted",
+			title: "TRaSH split French unwanted formats",
+			body: "Upstream split the French-specific unwanted-format CFs into a dedicated [Unwanted] Unwanted Formats French group. The new group is default-enabled upstream, so syncing will keep the same CFs in your template — just sourced from a French-specific group.",
+			severity: "info",
+		},
+	},
+	{
+		serviceType: "SONARR",
+		// Sonarr [Release Groups] French — anchor for French-focused templates.
+		keptGroupTrashId: "9fa0bf3c8f8f00154431c3323a29eef2",
+		// Sonarr [Unwanted] Unwanted Formats French — new in PR #2721, marked
+		// default-enabled upstream so the merger auto-adopts on sync.
+		introducedGroupTrashId: "a23c8675c79118544fd74153394fa589",
+		notice: {
+			id: "trash-pr-2721-sonarr-french-unwanted",
+			title: "TRaSH split French unwanted formats",
+			body: "Upstream split the French-specific unwanted-format CFs into a dedicated [Unwanted] Unwanted Formats French group. The new group is default-enabled upstream, so syncing will keep the same CFs in your template — just sourced from a French-specific group.",
 			severity: "info",
 		},
 	},


### PR DESCRIPTION
## Summary

Extends the `migration-notices.ts` registry with four new entries covering upstream TRaSH-Guides PRs that split language-specific unwanted-format CFs out of the generic `[Unwanted] Unwanted Formats` group:

- **Upstream #2719** (merged 2026-05-02): created `[Unwanted] Unwanted Formats German` for RADARR + SONARR
- **Upstream #2721** (merged 2026-05-08): created `[Unwanted] Unwanted Formats French` for RADARR + SONARR

Each new group is `default: "true"` upstream, so the merger auto-adopts on next sync — users with German/French templates would see a new CF group appear with no explanation. These advisory notices fire once when the kept anchor is present but the introduced group is absent; they fall silent after the user has both (migration complete).

## Why all four (not just the one that fires on dev data)

The maintainer's dev DB only triggers the **Radarr German** entry. The other three are anchored on `[Release Groups]` trash_ids that don't appear in any current dev template. Adding them anyway, because:

1. **Mirror upstream scope.** Both upstream PRs affected RADARR + SONARR symmetrically. The registry should reflect the *upstream PR's coverage*, not the maintainer's local dataset.
2. **Match the existing #2711 precedent.** The current registry already covers RADARR + SONARR for #2711 even though one developer's data only exercises one. Partial coverage here would be a maintenance hazard (someone has to rederive the rationale in 6 months).
3. **arr-dashboard ships to other users.** Someone running a French Sonarr setup will hit exactly the case the notice describes.
4. **Cost is data, not logic.** ~50 lines of registry entries, no new code paths, no schema changes.

## Trash_ids registered

| Service | Kept (anchor) | Introduced (new group) | Source |
|---|---|---|---|
| RADARR | `bc85e56e…1543` `[Release Groups] German` | `0ca61b4b…f72d` `[Unwanted] Unwanted Formats German` | PR #2719 |
| SONARR | `cae54a0b…fcfb` `[Release Groups] German` | `6f0872ee…ced0` `[Unwanted] Unwanted Formats German` | PR #2719 |
| RADARR | `12a919c8…756e` `[Release Groups] French` | `59f7ab9f…8670` `[Unwanted] Unwanted Formats French` | PR #2721 |
| SONARR | `9fa0bf3c…eef2` `[Release Groups] French` | `a23c8675…a589` `[Unwanted] Unwanted Formats French` | PR #2721 |

All trash_ids verified by fetching the raw JSON files from `master`.

## What's NOT in this PR (and why)

Audited 36 upstream PRs since 2026-03 — these are the only structurally-significant ones. The rest are:

- **Pure content updates** (CFs added, release-groups, trash_id corrections, ~21 PRs) — picked up by sync, no code action
- **Quality profile tweaks** (#2651, #2660, #2697, #2704, #2712) — loose Zod schema validates
- **Conflict declarations + JSON schema** (#2681) — our `trashConflictsFileSchema` already loose, tolerates the new `$schema` root field
- **Naming scheme additions** (#2662 Plex Edition) — `fetchNamingData` auto-handles
- **CF Collection Page reorg** (#2727) — renames + 1 new file; auto-discovered, templates reference by trash_id not path
- **SQP variant (#2714)** — no current dev template references the SQP kept group, and there's no evidence anyone hits the trigger; would add a never-firing entry

## Test plan

- [x] 9 new tests in `migration-notices.test.ts`: 4 "fires" + 4 "suppresses when complete" (one per new entry) + 1 co-occurrence sanity test (template with both #2711 and #2719 anchors fires both notices, not deduped)
- [x] Targeted: `pnpm --filter @arr/api exec vitest run src/lib/trash-guides/__tests__/migration-notices.test.ts` → **16 passed** (was 7)
- [x] Full suite: `pnpm run test` → **1631 api passed** (+9 new), 431 web, 38 shared, 0 failed
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean for changed files
- [ ] Manual: with a Radarr German template in your DB, render the template detail/diff modal and confirm the new "TRaSH split German unwanted formats" notice appears (until you re-sync and adopt the new group).

🤖 Generated with [Claude Code](https://claude.com/claude-code)