### PR TITLE
feat(seerr): permission-aware Test Connection + surface upstream errors

### DIFF
--- a/apps/api/src/lib/services/__tests__/connection-tester.test.ts
+++ b/apps/api/src/lib/services/__tests__/connection-tester.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pins the Seerr-specific permission probe added in #465.
+ *
+ * Why this test exists:
+ *   Seerr's `/api/v1/status` is tagged `public` in its openapi spec and
+ *   skips the `isAuthenticated` middleware. That means a Seerr instance
+ *   whose API-key-backed user (user ID 1 by default, per
+ *   `seerr/server/middleware/auth.ts`) has no usable permissions still
+ *   passes the status probe — the connection check then reports
+ *   "success" while every real feature call (Discover, Requests, Users)
+ *   returns 403. We added a second probe to `/api/v1/request/count`
+ *   to surface this misconfiguration at setup time. These tests pin
+ *   that flow so a future refactor can't silently drop it.
+ *
+ *   For non-Seerr services, the second probe MUST NOT run — they don't
+ *   share Seerr's user-1-permission semantic. Test that too.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testServiceConnection } from "../connection-tester.js";
+
+type FetchSpy = ReturnType<typeof vi.fn>;
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("testServiceConnection — Seerr permission probe (#465)", () => {
+	let fetchSpy: FetchSpy;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("returns success when both /status and /request/count succeed", async () => {
+		fetchSpy
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }))
+			.mockResolvedValueOnce(jsonResponse({ pending: 0, approved: 0, available: 0 }));
+
+		const result = await testServiceConnection("http://seerr:5055", "secret", "seerr");
+
+		expect(result.success).toBe(true);
+		expect(result.version).toBe("2.0.0");
+		expect(fetchSpy.mock.calls[0]?.[0]).toBe("http://seerr:5055/api/v1/status");
+		expect(fetchSpy.mock.calls[1]?.[0]).toBe("http://seerr:5055/api/v1/request/count");
+	});
+
+	it("returns the permission-specific error when /request/count returns 403", async () => {
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" })).mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					status: 403,
+					error: "You do not have permission to access this endpoint",
+				}),
+				{ status: 403, headers: { "Content-Type": "application/json" } },
+			),
+		);
+
+		const result = await testServiceConnection("http://seerr:5055", "secret", "seerr");
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/lacks required permissions/i);
+		// The detail must mention user ID 1 — that's the actionable diagnostic
+		// per `seerr/server/middleware/auth.ts:13-22`. Without naming user 1,
+		// operators won't know which user account to edit in Seerr.
+		expect(result.details).toMatch(/user id 1/i);
+		// The detail must also mention Seerr's Settings → Users path —
+		// that's the operator's next step. If a refactor removes the path
+		// guidance, this test fails before users get a useless error.
+		expect(result.details).toMatch(/settings.+users/i);
+		// Version from the first probe should still be reported so support
+		// requests have it without re-asking.
+		expect(result.version).toBe("2.0.0");
+	});
+
+	it("falls through to success when the permission probe fails with a non-403 status", async () => {
+		// Rationale: the status probe already proved reachability + key
+		// validity. A transient 500 or 429 on the second probe shouldn't
+		// flunk the connection test — the user should still be allowed to
+		// proceed, and any real problem will surface at feature-call time.
+		fetchSpy
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }))
+			.mockResolvedValueOnce(new Response("internal", { status: 500 }));
+
+		const result = await testServiceConnection("http://seerr:5055", "secret", "seerr");
+
+		expect(result.success).toBe(true);
+		expect(result.version).toBe("2.0.0");
+	});
+
+	it("falls through to success when the permission probe throws (network blip)", async () => {
+		// Same rationale as the non-403 case — don't fail the whole test
+		// on a transient on the second hop.
+		fetchSpy
+			.mockResolvedValueOnce(jsonResponse({ version: "2.0.0" }))
+			.mockRejectedValueOnce(new TypeError("fetch failed"));
+
+		const result = await testServiceConnection("http://seerr:5055", "secret", "seerr");
+
+		expect(result.success).toBe(true);
+	});
+
+	it("does NOT probe /request/count for non-Seerr services", async () => {
+		// Only Seerr has the user-1-permission semantic. Probing
+		// /request/count against Sonarr/Radarr/Prowlarr would either 404
+		// or hit a totally unrelated endpoint.
+		fetchSpy.mockResolvedValueOnce(jsonResponse({ version: "4.0.0" }));
+
+		const result = await testServiceConnection("http://sonarr:8989", "secret", "sonarr");
+
+		expect(result.success).toBe(true);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		expect(fetchSpy.mock.calls[0]?.[0]).toBe("http://sonarr:8989/api/v3/system/status");
+	});
+
+	it("still returns the existing /status error when the first probe fails (no second probe)", async () => {
+		// 401 on the first probe should short-circuit — there's no point
+		// probing a permission-gated endpoint when the API key itself is
+		// rejected.
+		fetchSpy.mockResolvedValueOnce(
+			new Response("unauthorized", {
+				status: 401,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		const result = await testServiceConnection("http://seerr:5055", "secret", "seerr");
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/authentication failed/i);
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/lib/services/connection-tester.ts
+++ b/apps/api/src/lib/services/connection-tester.ts
@@ -128,6 +128,20 @@ export async function testServiceConnection(
 		const data = (await response.json()) as { version?: string };
 		const version = data.version ?? "unknown";
 
+		// Seerr-specific second probe: `/api/v1/status` is tagged `public` in Seerr's
+		// openapi spec and skips the `isAuthenticated` middleware. That means a Seerr
+		// instance whose API-key-backed user (user ID 1 by default; see
+		// https://github.com/seerr-team/seerr/blob/main/server/middleware/auth.ts)
+		// has no usable permissions still passes the status probe — the connection
+		// check then reports "success" while every real feature call (Discover,
+		// Requests, Users) returns 403. Probe one permission-gated endpoint here so
+		// that under-powered configurations fail at setup time rather than later in
+		// the user's flow. See issue #465.
+		if (service === "seerr") {
+			const permissionProbe = await probeSeerrPermissions(normalizedBaseUrl, apiKey, version);
+			if (permissionProbe) return permissionProbe;
+		}
+
 		return {
 			success: true,
 			message: `Successfully connected to ${service.charAt(0).toUpperCase() + service.slice(1)}`,
@@ -136,6 +150,59 @@ export async function testServiceConnection(
 	} catch (error: unknown) {
 		return handleConnectionError(error);
 	}
+}
+
+/**
+ * Probe a permission-gated Seerr endpoint after `/api/v1/status` has succeeded.
+ * Returns a failing `ConnectionTestResult` when the probe shows the API key's
+ * backing user can't actually exercise the endpoints arr-dashboard relies on,
+ * `null` when the probe passed (the caller continues with its success response).
+ *
+ * `/api/v1/request/count` is the right probe because (a) it's a tiny response,
+ * (b) it requires the same permission class (`Manage Requests` / `Admin`) that
+ * Discover, Requests, and Users surfaces all need, and (c) Seerr returns a
+ * clean 403 with the documented "You do not have permission…" body when the
+ * user lacks permission rather than a noisy empty success. Match the literal
+ * status here so the actionable error copy can be specific.
+ */
+async function probeSeerrPermissions(
+	baseUrl: string,
+	apiKey: string,
+	version: string,
+): Promise<ConnectionTestResult | null> {
+	const probeUrl = `${baseUrl}/api/v1/request/count`;
+	let probeResponse: Response;
+	try {
+		probeResponse = await fetch(probeUrl, {
+			headers: { "X-Api-Key": apiKey, Accept: "application/json" },
+			signal: AbortSignal.timeout(5000),
+		});
+	} catch {
+		// The status probe already succeeded, so a network blip on the second
+		// hop is more likely a transient than a misconfiguration. Don't fail
+		// the connection test on transient probe failures — let the user
+		// proceed and surface errors at feature-call time instead.
+		return null;
+	}
+
+	if (probeResponse.ok) {
+		return null;
+	}
+
+	if (probeResponse.status === 403) {
+		return {
+			success: false,
+			error: "Connected, but Seerr API key lacks required permissions",
+			details:
+				"Reached Seerr successfully, but the API-key-backed user account (user ID 1 — the original administrator — by default) cannot access permission-gated endpoints. Open Seerr → Settings → Users, find the first user listed (user ID 1), and either grant Admin or enable Manage Requests + Manage Users + Request Movies/TV. If user ID 1 has been deleted, a Seerr-side recovery is required.",
+			version,
+		};
+	}
+
+	// Any other non-2xx from the probe is interesting but not necessarily
+	// fatal (could be a partial outage, rate limit, etc.). Fall through to
+	// success — the status probe already proved reachability + key validity.
+	return null;
 }
 
 /**

--- a/apps/web/src/features/discover/components/__tests__/discover-carousel-error.test.tsx
+++ b/apps/web/src/features/discover/components/__tests__/discover-carousel-error.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Pins the error-message surfacing added in #465.
+ *
+ * Before this PR the carousel rendered a flat "Failed to load <title>"
+ * banner with no underlying detail, which made Seerr permission 403s
+ * (and any other upstream failure) look identical to "no results yet."
+ * Operators had to read server logs to figure out why a page was empty.
+ *
+ * These tests pin two invariants:
+ *   1. When `isError` is true and `error.message` is provided, the
+ *      message appears inline below the generic banner.
+ *   2. When `isError` is true and `error` is null/undefined, the
+ *      component still works (no crash) and falls back to the generic
+ *      banner — backward-compatible with callers that haven't been
+ *      updated to forward the error object.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+import { DiscoverCarousel } from "../discover-carousel";
+
+function wrapper({ children }: { children: ReactNode }) {
+	return <ColorThemeProvider>{children}</ColorThemeProvider>;
+}
+
+describe("<DiscoverCarousel /> error surface (#465)", () => {
+	it("renders the underlying error message inline when error is provided", () => {
+		render(
+			<DiscoverCarousel
+				title="Trending Movies"
+				items={[]}
+				onSelectItem={() => {}}
+				isError
+				error={{
+					message:
+						"Seerr GET /api/v1/discover/trending?page=1 failed: 403 Forbidden — You do not have permission to access this endpoint",
+				}}
+			/>,
+			{ wrapper },
+		);
+		expect(screen.getByText(/failed to load trending movies/i)).toBeInTheDocument();
+		expect(screen.getByText(/403 forbidden/i)).toBeInTheDocument();
+		expect(screen.getByText(/you do not have permission/i)).toBeInTheDocument();
+	});
+
+	it("falls back to the generic banner when no error is provided", () => {
+		render(
+			<DiscoverCarousel title="Popular TV Shows" items={[]} onSelectItem={() => {}} isError />,
+			{ wrapper },
+		);
+		expect(screen.getByText(/failed to load popular tv shows/i)).toBeInTheDocument();
+		// No "underlying" message paragraph should exist when error is omitted.
+		expect(screen.queryByText(/permission/i)).not.toBeInTheDocument();
+	});
+
+	it("ignores empty / whitespace-only error messages (no blank detail paragraph)", () => {
+		// React-query error objects can have empty `message` strings in some
+		// transient states. Don't render an empty paragraph for them — it
+		// looks like a layout bug.
+		render(
+			<DiscoverCarousel
+				title="Coming Soon"
+				items={[]}
+				onSelectItem={() => {}}
+				isError
+				error={{ message: "   " }}
+			/>,
+			{ wrapper },
+		);
+		expect(screen.getByText(/failed to load coming soon/i)).toBeInTheDocument();
+		// No second paragraph should render for whitespace messages.
+		const container = screen.getByText(/failed to load/i).closest("div");
+		expect(container?.querySelectorAll("p").length ?? 0).toBe(1);
+	});
+});

--- a/apps/web/src/features/discover/components/discover-carousel.tsx
+++ b/apps/web/src/features/discover/components/discover-carousel.tsx
@@ -52,6 +52,13 @@ interface DiscoverCarouselProps {
 	onSelectItem: (item: SeerrDiscoverResult) => void;
 	isLoading?: boolean;
 	isError?: boolean;
+	/**
+	 * Optional underlying error from the React Query result. When provided,
+	 * its message is rendered inline below the generic "Failed to load…"
+	 * banner so the operator sees the actual upstream reason (Seerr 403,
+	 * network error, etc.) instead of a silent empty state. See issue #465.
+	 */
+	error?: { message?: string } | null;
 	isFetchingNextPage?: boolean;
 	hasNextPage?: boolean;
 	onLoadMore?: () => void;
@@ -66,6 +73,7 @@ export const DiscoverCarousel: React.FC<DiscoverCarouselProps> = ({
 	onSelectItem,
 	isLoading,
 	isError,
+	error,
 	isFetchingNextPage,
 	hasNextPage,
 	onLoadMore,
@@ -151,15 +159,23 @@ export const DiscoverCarousel: React.FC<DiscoverCarouselProps> = ({
 	}
 
 	if (isError) {
+		// Surface the underlying error message when the React Query result
+		// includes one — without this, a Seerr 403 (or any upstream failure)
+		// looked identical to "no results yet" and operators had to dig in
+		// server logs to figure out why a page was empty. Issue #465.
+		const detail = error?.message?.trim();
 		return (
 			<section
 				className="space-y-4 animate-in fade-in slide-in-from-bottom-4 duration-500"
 				style={{ animationDelay: `${animationDelay}ms`, animationFillMode: "backwards" }}
 			>
 				<SectionHeader />
-				<div className="flex items-center gap-3 rounded-xl border border-border/30 bg-muted/10 px-4 py-6 text-sm text-muted-foreground">
-					<AlertCircle className="h-4 w-4 shrink-0" />
-					<span>Failed to load {title.toLowerCase()}</span>
+				<div className="flex items-start gap-3 rounded-xl border border-border/30 bg-muted/10 px-4 py-6 text-sm text-muted-foreground">
+					<AlertCircle className="h-4 w-4 shrink-0 mt-0.5" />
+					<div className="space-y-1">
+						<p>Failed to load {title.toLowerCase()}</p>
+						{detail && <p className="text-xs opacity-80">{detail}</p>}
+					</div>
 				</div>
 			</section>
 		);

--- a/apps/web/src/features/discover/components/discover-client.tsx
+++ b/apps/web/src/features/discover/components/discover-client.tsx
@@ -248,6 +248,7 @@ export const DiscoverClient = () => {
 					data={searchQuery.data}
 					isLoading={searchQuery.isLoading}
 					isError={searchQuery.isError}
+					error={searchQuery.error}
 					isFetchingNextPage={searchQuery.isFetchingNextPage}
 					hasNextPage={searchQuery.hasNextPage}
 					onLoadMore={() => searchQuery.fetchNextPage()}
@@ -265,6 +266,7 @@ export const DiscoverClient = () => {
 					onSelectItem={selectItem}
 					isLoading={genreQuery.isLoading}
 					isError={genreQuery.isError}
+					error={genreQuery.error}
 					isFetchingNextPage={genreQuery.isFetchingNextPage}
 					hasNextPage={genreQuery.hasNextPage}
 					onLoadMore={() => genreQuery.fetchNextPage()}
@@ -282,6 +284,7 @@ export const DiscoverClient = () => {
 							onSelectItem={selectItem}
 							isLoading={trendingQuery.isLoading}
 							isError={trendingQuery.isError}
+							error={trendingQuery.error}
 							isFetchingNextPage={trendingQuery.isFetchingNextPage}
 							hasNextPage={trendingQuery.hasNextPage}
 							onLoadMore={() => trendingQuery.fetchNextPage()}
@@ -296,6 +299,7 @@ export const DiscoverClient = () => {
 							onSelectItem={selectItem}
 							isLoading={popularQuery.isLoading}
 							isError={popularQuery.isError}
+							error={popularQuery.error}
 							isFetchingNextPage={popularQuery.isFetchingNextPage}
 							hasNextPage={popularQuery.hasNextPage}
 							onLoadMore={() => popularQuery.fetchNextPage()}
@@ -312,6 +316,7 @@ export const DiscoverClient = () => {
 							onSelectItem={selectItem}
 							isLoading={upcomingQuery.isLoading}
 							isError={upcomingQuery.isError}
+							error={upcomingQuery.error}
 							isFetchingNextPage={upcomingQuery.isFetchingNextPage}
 							hasNextPage={upcomingQuery.hasNextPage}
 							onLoadMore={() => upcomingQuery.fetchNextPage()}

--- a/apps/web/src/features/discover/components/discover-search-results.tsx
+++ b/apps/web/src/features/discover/components/discover-search-results.tsx
@@ -3,19 +3,24 @@
 import type { SeerrDiscoverResponse, SeerrDiscoverResult } from "@arr/shared";
 import type { InfiniteData } from "@tanstack/react-query";
 import { AlertCircle, Loader2, Search } from "lucide-react";
-import { PremiumSkeleton } from "../../../components/layout";
+import { useMemo } from "react";
+import { FilterSelect, PremiumSkeleton } from "../../../components/layout";
 import { Button } from "../../../components/ui";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import type { SearchSortOption } from "../hooks/use-discover-state";
-import { FilterSelect } from "../../../components/layout";
-import { useMemo } from "react";
 import { DiscoverPosterCard } from "./discover-poster-card";
 
 interface DiscoverSearchResultsProps {
 	data: InfiniteData<SeerrDiscoverResponse> | undefined;
 	isLoading: boolean;
 	isError?: boolean;
+	/**
+	 * Optional underlying error from the React Query result. When provided,
+	 * its message is rendered inline below the generic "Search failed" copy
+	 * so the operator sees the actual upstream reason. See issue #465.
+	 */
+	error?: { message?: string } | null;
 	isFetchingNextPage?: boolean;
 	hasNextPage?: boolean;
 	onLoadMore?: () => void;
@@ -35,6 +40,7 @@ export const DiscoverSearchResults: React.FC<DiscoverSearchResultsProps> = ({
 	data,
 	isLoading,
 	isError,
+	error,
 	isFetchingNextPage,
 	hasNextPage,
 	onLoadMore,
@@ -89,6 +95,11 @@ export const DiscoverSearchResults: React.FC<DiscoverSearchResultsProps> = ({
 	}
 
 	if (isError) {
+		// Surface the underlying error message when the React Query result
+		// includes one — without this, a Seerr 403 or any upstream failure
+		// rendered as a generic "Search failed" with no actionable detail.
+		// Issue #465.
+		const detail = error?.message?.trim();
 		return (
 			<div className="flex flex-col items-center justify-center py-16 text-center space-y-4 animate-in fade-in duration-300">
 				<div
@@ -100,11 +111,15 @@ export const DiscoverSearchResults: React.FC<DiscoverSearchResultsProps> = ({
 				>
 					<AlertCircle className="h-6 w-6" style={{ color: SEMANTIC_COLORS.error.text }} />
 				</div>
-				<div className="space-y-1">
+				<div className="space-y-1 max-w-md">
 					<p className="text-sm font-medium text-foreground">Search failed</p>
-					<p className="text-xs text-muted-foreground">
-						Please try again. If the problem persists, check your Seerr connection.
-					</p>
+					{detail ? (
+						<p className="text-xs text-muted-foreground">{detail}</p>
+					) : (
+						<p className="text-xs text-muted-foreground">
+							Please try again. If the problem persists, check your Seerr connection.
+						</p>
+					)}
 				</div>
 			</div>
 		);


### PR DESCRIPTION
Closes #465

## Summary

Two trust failures discovered while diagnosing #454, fixed together since they're the same theme (silent failures on Seerr surfaces):

1. **Test Connection** now probes a permission-gated endpoint after `/status` so an under-powered Seerr API key fails at setup time rather than later in the user's flow.
2. **Discover page + Search results** now surface the underlying `SeerrApiError.message` inline instead of swallowing it into a generic "Failed to load" banner.

## Why

Diagnosing #454 took a log dive because:
- `Test Connection` only hit `/api/v1/status`, which is tagged `public` in Seerr's openapi spec and skips the `isAuthenticated` middleware. A Seerr user with zero permissions still passed the check.
- The Discover page rendered an empty state when the underlying `SeerrApiError` was already on the wire with a clear `"403 Forbidden — You do not have permission to access this endpoint"` message — the operator had to read server logs to find out.

Both are trust-correctness failures per `CLAUDE.md`'s rule: *"arr-dashboard runs as a thin permission-aware wrapper around Seerr."* Silent fail at the wrapper layer is worse than a noisy upstream error.

## Mechanism

### Test Connection probe (`apps/api/src/lib/services/connection-tester.ts`)

After `/api/v1/status` succeeds for service=seerr, probe `/api/v1/request/count`:

| Probe result | Connection test result |
|---|---|
| 200 | Success (unchanged) |
| 403 | Specific "Connected, but Seerr API key lacks required permissions" error naming user ID 1 and the Settings → Users path |
| Other 4xx/5xx | Success (status probe already proved reachability + key validity; transient probe failure shouldn't fail the whole test) |
| Network error | Success (same rationale) |

Non-Seerr services are unaffected — the second probe runs only when `service === "seerr"`.

### Error surface (`discover-carousel.tsx`, `discover-search-results.tsx`)

Both components now accept an optional `error?: { message?: string }` prop alongside `isError`. When provided, the message renders as a second paragraph below the generic banner. When omitted or whitespace-only, the components fall back to the existing copy — backward-compatible with any caller that hasn't been updated.

`SeerrApiError.message` was already flowing on the wire via the central error handler in `server.ts` (statusCode branch → `{ message }` JSON response → `ApiError.message` on the frontend). The fix is purely to display it.

## Scope explicitly NOT in this PR

The optional `X-API-User` config field (lets operators point arr-dashboard at a different Seerr user when user ID 1 has been demoted/deleted) was scoped out — it requires a DB schema change to `ServiceInstance` and is a separate PR. Recovery path is still flagged in #465 for follow-up.

The broader "audit all Seerr-consuming surfaces (Requests, Issues, Users) for the swallow-403 pattern" item from #465 is also follow-up — this PR fixes the surface called out by the original bug reporter (Discover), and the pattern there generalizes to the others. Following the principle of fixing the reported surface first.

## Test plan

**Backend (`connection-tester.test.ts`, +6 tests)**:
- [x] Both probes succeed → success
- [x] Status 200, probe 403 → specific error with user-ID-1 guidance + Settings → Users path
- [x] Status 200, probe 5xx → falls through to success
- [x] Status 200, probe network error → falls through to success
- [x] Non-Seerr service → second probe NOT made
- [x] Status probe 401 → short-circuits (no second probe)

**Frontend (`discover-carousel-error.test.tsx`, +3 tests)**:
- [x] `error.message` provided → renders inline below banner
- [x] `error` omitted → falls back to generic banner
- [x] Whitespace-only `error.message` → no blank paragraph

**Runs**:
- [x] `pnpm run test` → **1637 api passed** (+6 new), **434 web passed** (+3 new), 38 shared passed, 0 failed
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [ ] Manual: configure a Seerr instance whose user ID 1 has reduced permissions, click Test Connection, confirm the specific error message appears. Then open Discover and confirm the 403 detail renders inline on the carousels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)