### PR TITLE
fix: percent-encode query-string spaces (Seerr, Jellyfin, Tautulli) — closes #470

### DIFF
--- a/apps/api/src/lib/jellyfin/jellyfin-client.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-client.ts
@@ -285,8 +285,13 @@ export class JellyfinClient {
 			Limit: "10000",
 		});
 
+		// Force RFC 3986 spaces (%20) instead of form-urlencoded `+` because tag
+		// names like "Kids Stuff" carry user-supplied spaces; strict upstream URL
+		// parsers can reject `+` in query values (see issue #470 for the Seerr
+		// equivalent). Jellyfin's parser usually accepts both, but normalising
+		// removes a class of latent failure.
 		const data = await this.request(
-			`/Users/${encodeURIComponent(userId)}/Items?${params.toString()}`,
+			`/Users/${encodeURIComponent(userId)}/Items?${params.toString().replace(/\+/g, "%20")}`,
 			{ schema: jellyfinItemsResponseSchema },
 		);
 		return data.Items.map(mapItem);

--- a/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-client.test.ts
@@ -377,14 +377,16 @@ describe("retryRequest", () => {
 // ===========================================================================
 
 describe("search", () => {
-	it("forwards query and page params correctly", async () => {
+	it("forwards query and page params with RFC 3986 space encoding", async () => {
 		factory.rawRequest.mockResolvedValue(mockResponse(makeDiscoverResponse()));
 
 		await client.search({ query: "Fight Club", page: 2 });
 
 		const path = factory.rawRequest.mock.calls[0]![1] as string;
 		expect(path).toContain("/api/v1/search");
-		expect(path).toContain("query=Fight+Club");
+		// Issue #470: Jellyseerr/Overseerr reject `+` in query params; spaces must be %20.
+		expect(path).toContain("query=Fight%20Club");
+		expect(path).not.toContain("query=Fight+Club");
 		expect(path).toContain("page=2");
 	});
 

--- a/apps/api/src/lib/seerr/seerr-client.ts
+++ b/apps/api/src/lib/seerr/seerr-client.ts
@@ -938,7 +938,10 @@ function buildQueryString(params?: object): string {
 	for (const [key, value] of entries) {
 		qs.set(key, String(value));
 	}
-	return `?${qs.toString()}`;
+	// Jellyseerr/Overseerr strict-validate `query` params and reject `+`
+	// (form-urlencoded space) as a reserved character — see issue #470.
+	// Force RFC 3986 spaces (%20) so spaces survive the upstream validator.
+	return `?${qs.toString().replace(/\+/g, "%20")}`;
 }
 
 /**

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -219,9 +219,16 @@ export class TautulliClient {
 			}
 		}
 
+		// URL.toString() emits form-urlencoded `+` for spaces in query params.
+		// Strict upstream URL parsers can reject `+` as a reserved character
+		// (see issue #470 for the Seerr equivalent). Normalise to RFC 3986
+		// `%20` in the query portion only — current callers never pass spaces,
+		// so this is preemptive hardening for future ones.
+		const safeUrl = `${url.origin}${url.pathname}${url.search.replace(/\+/g, "%20")}${url.hash}`;
+
 		let response: Response;
 		try {
-			response = await fetch(url.toString(), {
+			response = await fetch(safeUrl, {
 				headers: { Accept: "application/json" },
 				signal: AbortSignal.timeout(this.timeout),
 			});


### PR DESCRIPTION
## Summary

`URLSearchParams.toString()` and `URL.toString()` emit `+` for spaces (form-urlencoded). Jellyseerr/Overseerr's strict validator rejects `+` as a reserved character (issue #470), so any Discover search containing a space failed with a 400. After fixing the user-reported Seerr case, an audit surfaced two more clients that share the same encoding pattern and could fail the same way under strict upstream parsers — patched defensively in the same PR while it's still open.

## Fixes

| File | Change |
|---|---|
| `apps/api/src/lib/seerr/seerr-client.ts` | `buildQueryString()` now `replace(/\+/g, "%20")` — covers all 12 endpoints that build query strings (search, discover, requests, users, issues, notifications, etc.) |
| `apps/api/src/lib/jellyfin/jellyfin-client.ts` | `getItemsByTag` now `%20`-encodes spaces — tag names like "Kids Stuff" from label-sync rules carry user-supplied spaces |
| `apps/api/src/lib/tautulli/tautulli-client.ts` | Central `command()` helper rebuilds the URL with `%20` in the query portion — protects current and future callers from passing free-text params |
| `apps/api/src/lib/seerr/__tests__/seerr-client.test.ts` | Updated test asserts `query=Fight%20Club` and explicitly rejects `query=Fight+Club` — the prior assertion silently codified the bug |

## Why a defensive sweep alongside the user-reported fix

Only the Seerr case is a confirmed live bug — the Jellyfin and Tautulli sites are latent. But (a) the audit was already done as part of triaging #470, (b) the patches are 1–3 lines each, and (c) shipping them in one PR keeps the encoding story consistent across HTTP clients without churn from a follow-up PR. Plex and OIDC providers were audited and are correct — Plex uses `encodeURIComponent` on path segments, and OAuth 2 explicitly defines scope as form-urlencoded so `+` is spec-correct there.

## What is NOT changed

- OIDC `scope` query param (`+` is RFC 6749 §3.3 spec-compliant)
- Frontend `URLSearchParams` usage (hits this app's own Fastify API, which decodes both)
- Plex client (already uses `encodeURIComponent` on user input)
- ARR path-segment interpolations (all numeric IDs / known string enums)

## Test plan

- [x] `vitest run` — 90/90 across Seerr, Jellyfin, Tautulli pass
- [x] `tsc --noEmit` on `@arr/api` — clean
- [ ] Manual: Media → Discover → search "stranger things" against a real Jellyseerr/Overseerr instance — should return results instead of the 400 from #470
- [ ] Manual (optional): label-sync rule sourcing from a Jellyfin tag named with spaces — should still match items

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)