### PR TITLE
fix(heap-monitor): honor HEAP_AUTO_SNAPSHOT=0 as kill switch (partial #471)

### DIFF
--- a/apps/api/src/plugins/heap-monitor.ts
+++ b/apps/api/src/plugins/heap-monitor.ts
@@ -36,6 +36,12 @@
  *   Opt out via HEAP_AUTO_SNAPSHOT_AT_WARN=0 if you don't want unsolicited
  *   files in /config (e.g., low-disk hosts).
  *
+ *   Setting HEAP_AUTO_SNAPSHOT=0 (the broader opt-in/opt-out var also read by
+ *   start-combined.sh) ALSO disables warn-time snapshots — operators who set
+ *   either var to 0 expect "no surprise snapshots," and the prior split where
+ *   `HEAP_AUTO_SNAPSHOT=0` left warn-time captures running was a footgun
+ *   (issue #471).
+ *
  * Companion runtime knobs:
  *   - `--heapsnapshot-signal=SIGUSR2`  Always on (set in Dockerfile
  *     NODE_OPTIONS). An operator can also capture a snapshot on demand via:
@@ -47,6 +53,7 @@
  *     appends --heapsnapshot-near-heap-limit=1 so V8 auto-captures a
  *     snapshot just before OOM. Off by default because each snapshot is ~3x
  *     the heap (~2.3 GB at the 768 MB cap) — a lot for small /config volumes.
+ *     Setting it to "0" is treated as a global kill switch (see above).
  */
 
 import {
@@ -84,7 +91,13 @@ function resolveSnapshotDir(): string {
 	return isDocker ? "/config/heap-snapshots" : "./config-dev/heap-snapshots";
 }
 const SNAPSHOT_DIR = resolveSnapshotDir();
-const AUTO_SNAPSHOT_AT_WARN = process.env.HEAP_AUTO_SNAPSHOT_AT_WARN !== "0";
+// Warn-time auto snapshots are on by default; disabled if EITHER the precise
+// opt-out (HEAP_AUTO_SNAPSHOT_AT_WARN=0) or the broader kill switch
+// (HEAP_AUTO_SNAPSHOT=0) is set. The broader var matches operator expectations
+// — see issue #471. Note that an unset HEAP_AUTO_SNAPSHOT does NOT disable
+// warn-time captures; only the explicit string "0" does.
+const AUTO_SNAPSHOT_AT_WARN =
+	process.env.HEAP_AUTO_SNAPSHOT_AT_WARN !== "0" && process.env.HEAP_AUTO_SNAPSHOT !== "0";
 const AUTO_SNAPSHOT_MIN_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes between captures
 const AUTO_SNAPSHOT_MAX_RETAINED = 3; // rotate aggressively — files are ~heap-size MB
 
@@ -233,7 +246,7 @@ const heapMonitorPlugin = fastifyPlugin(
 				app.log.warn(
 					payload,
 					AUTO_SNAPSHOT_AT_WARN
-						? "Heap usage above 90% — auto-capturing snapshot to /config/heap-snapshots/ (set HEAP_AUTO_SNAPSHOT_AT_WARN=0 to disable)"
+						? "Heap usage above 90% — auto-capturing snapshot to /config/heap-snapshots/ (set HEAP_AUTO_SNAPSHOT=0 or HEAP_AUTO_SNAPSHOT_AT_WARN=0 to disable)"
 						: "Heap usage above 90% — capture a snapshot before OOM: `docker exec <container> dump-heap`",
 				);
 				if (AUTO_SNAPSHOT_AT_WARN) {


### PR DESCRIPTION
## Scope

Issue #471 reports **two** problems welded together:
1. The operator-facing env-var ergonomics — `HEAP_AUTO_SNAPSHOT=0` was ineffective
2. The underlying memory leak that pinned heap at ~97% and triggered the snapshot loop in the first place

**This PR only addresses problem (1).** The leak (problem 2) is the actual fire and is the same retention issue tracked in #427; it needs its own investigation and is intentionally NOT closed by this change. Linking via "Addresses" instead of "Closes" so GitHub doesn't auto-close #471 prematurely.

## What this PR does

- Operators expect `HEAP_AUTO_SNAPSHOT=0` to be a global kill switch for *all* heap-snapshot behavior. Today it only affects V8's near-heap-limit hook in `start-combined.sh`; warn-time captures from the heap-monitor plugin keep running, which is exactly the surprise the reporter hit while trying to silence the 5-minute snapshot loop.
- This patch makes the plugin disable warn-time auto snapshots when **either** env var is set to `"0"`:
  - `HEAP_AUTO_SNAPSHOT=0`  → broad kill switch (matches operator mental model)
  - `HEAP_AUTO_SNAPSHOT_AT_WARN=0`  → precise opt-out (existing behavior, preserved)
- The warn log message now lists both env vars so operators landing in logs see the broader switch alongside the precise one.

## Env-var matrix

| `HEAP_AUTO_SNAPSHOT` | `HEAP_AUTO_SNAPSHOT_AT_WARN` | Warn-time captures (before) | Warn-time captures (after) |
|---|---|---|---|
| unset | unset | ON | ON |
| unset | `"0"` | OFF | OFF |
| `"0"` | unset | **ON (bug)** | **OFF (fixed)** |
| `"0"` | `"0"` | OFF | OFF |
| `"1"` | unset | ON | ON |
| `"1"` | `"0"` | OFF | OFF |

## Explicit non-goals

- **Does not fix the memory leak.** Silencing diagnostics is not a fix; the underlying retention needs to be identified and broken. That work belongs to a separate PR linked to #427 / #471.
- **Does not close #471.** The reporter explicitly diagnosed both problems; closing on env-var-only would leave them with the worse half of the bug still active.

## Test plan

- [x] `tsc --noEmit` on `@arr/api` clean
- [ ] Manual: set `HEAP_AUTO_SNAPSHOT=0` in compose, confirm no `auto-*.heapsnapshot` files appear in `/config/heap-snapshots/` and warn-level logs no longer mention "auto-capturing"
- [ ] Manual: unset both vars, confirm warn-time captures still fire (default-on behavior preserved)

Addresses #471 (env-var ergonomics only — see scope above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)