### PR TITLE
chore(memory): MALLOC_ARENA_MAX=2 + RSS-bloat visibility (addresses #427 #471)

### DIFF
--- a/apps/api/src/plugins/heap-monitor.ts
+++ b/apps/api/src/plugins/heap-monitor.ts
@@ -70,6 +70,21 @@ const SAMPLE_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes — enough resolution to 
 const WARN_HEAP_PCT = 0.9;
 const INFO_HEAP_PCT = 0.8;
 
+// RSS-bloat detection (issue #427 / #471 follow-up).
+//
+// A healthy Node process sits at ~1.3–1.6x heap (libuv, V8 metadata, native
+// deps, TLS buffers). Anything ≥ 2x means non-V8 allocations exceed the V8
+// heap itself — classic external/native memory pressure or glibc arena
+// fragmentation. The V8 heap can look healthy while RSS bloats past the
+// container limit, which is exactly what was observed in #471 (heapTotal
+// 347MB / RSS 1227MB → 3.5x).
+//
+// Skip the first hour to avoid startup-spike false positives, and rate-limit
+// the warning so a sustained-bloat process doesn't spam logs every 5 minutes.
+const RSS_BLOAT_RATIO = 2.0;
+const RSS_BLOAT_MIN_UPTIME_SEC = 60 * 60; // 1 hour warmup window
+const RSS_BLOAT_LOG_INTERVAL_MS = 60 * 60 * 1000; // at most once per hour
+
 /**
  * Resolve the heap-snapshot directory. The /config/* path is the Docker
  * production convention (matches logger.ts and config-dev path layout).
@@ -100,6 +115,10 @@ interface MemorySample {
 
 let lastSnapshotAt: number | null = null;
 let snapshotInFlight = false;
+// Module-level mutable state for the once-per-hour bloat throttle.
+// Held as an object property so the binding itself is `const` (biome) while
+// the field is freely reassigned by the sampler.
+const rssBloatState: { lastLogAt: number | null } = { lastLogAt: null };
 
 /**
  * Stream a heap snapshot to disk. Returns true if a file was written.
@@ -197,11 +216,17 @@ const heapMonitorPlugin = fastifyPlugin(
 			const externalMB = Math.round(m.external / 1024 / 1024);
 			const arrayBuffersMB = Math.round((m.arrayBuffers ?? 0) / 1024 / 1024);
 			const now = Date.now();
+			const uptimeSec = Math.round(process.uptime());
 			// `heapPct` is heap-used relative to the V8-allocated heap, not the
 			// `--max-old-space-size` cap. It still tracks pressure: V8 grows
 			// heapTotal toward the cap, so heapPct climbing toward 1.0 means
 			// V8 is squeezing the live set into all the space it has left.
 			const heapPct = heapTotalMB > 0 ? heapUsedMB / heapTotalMB : 0;
+			// `rssToHeapRatio` discriminates JS-side leaks (≈1.3–1.6x, normal)
+			// from external/native memory pressure or glibc fragmentation (≥2x).
+			// V8's heapPct can be healthy while RSS bloats past the container
+			// cap — that's what bit reporters in #471.
+			const rssToHeapRatio = heapTotalMB > 0 ? Math.round((rssMB / heapTotalMB) * 100) / 100 : 0;
 
 			const payload: Record<string, number | undefined> = {
 				heapUsedMB,
@@ -210,7 +235,8 @@ const heapMonitorPlugin = fastifyPlugin(
 				externalMB,
 				arrayBuffersMB,
 				heapPct: Math.round(heapPct * 100) / 100,
-				uptimeSec: Math.round(process.uptime()),
+				rssToHeapRatio,
+				uptimeSec,
 			};
 
 			if (lastSample) {
@@ -246,6 +272,24 @@ const heapMonitorPlugin = fastifyPlugin(
 				app.log.info(payload, "Heap usage above 80%");
 			} else {
 				app.log.debug(payload, "Heap usage sample");
+			}
+
+			// RSS-bloat detection runs independently of heap pressure: the V8
+			// heap can be healthy (heapPct < INFO_HEAP_PCT) while RSS climbs
+			// past the container limit. Skip the warmup window so startup
+			// spikes don't false-positive, and throttle to once-per-hour so
+			// a sustained-bloat process doesn't spam logs.
+			if (
+				rssToHeapRatio >= RSS_BLOAT_RATIO &&
+				uptimeSec >= RSS_BLOAT_MIN_UPTIME_SEC &&
+				(rssBloatState.lastLogAt === null ||
+					now - rssBloatState.lastLogAt >= RSS_BLOAT_LOG_INTERVAL_MS)
+			) {
+				app.log.warn(
+					payload,
+					"RSS is ≥2x V8 heap — likely external/native memory or glibc arena fragmentation. If RSS keeps climbing, try setting MALLOC_ARENA_MAX=2 (issue #471).",
+				);
+				rssBloatState.lastLogAt = now;
 			}
 		};
 

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -356,11 +356,26 @@ if [ "${HEAP_AUTO_SNAPSHOT:-0}" = "1" ]; then
     echo "  - HEAP_AUTO_SNAPSHOT enabled — V8 will write up to 1 snapshot to /config/heap-snapshots/ on near-OOM"
 fi
 
+# OS-level memory hygiene (issue #427 / #471 follow-up).
+#
+# Node on glibc allocates many small chunks for decoded JSON, Prisma rows,
+# and TLS buffers; glibc's default 8-arena allocator rarely returns those
+# pages to the OS. The result is RSS climbing well past V8's heap cap even
+# when the JS heap itself is healthy — reporters with 2900+ -item libraries
+# see RSS at 3-4x heapTotal (see #471). Capping glibc to 2 arenas typically
+# drops long-run RSS 30-50% with no code changes and is the canonical
+# Node-on-Linux deployment tweak.
+#
+# Override via `MALLOC_ARENA_MAX=N` if you have a specific reason
+# (multi-CPU NUMA tuning, very high request concurrency).
+MALLOC_ARENA_MAX="${MALLOC_ARENA_MAX:-2}"
+echo "  - MALLOC_ARENA_MAX: $MALLOC_ARENA_MAX (glibc arena cap — keeps RSS in check on long-running containers)"
+
 # Let stdout/stderr flow directly to the container — Pino handles file logging
 # via its pino-roll transport (writes to /config/logs/arr-dashboard.log).
 # Previous approach redirected stdout to api.log, which conflicted with Pino's
 # worker-thread transport and caused both log files to remain empty.
-run_as_user sh -c "cd /config/heap-snapshots && API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node /app/api/dist/index.js" &
+run_as_user sh -c "cd /config/heap-snapshots && MALLOC_ARENA_MAX=$MALLOC_ARENA_MAX API_HOST=$HOST API_PORT=$API_PORT HOST=$HOST node /app/api/dist/index.js" &
 API_PID=$!
 echo "API started with PID $API_PID"
 


### PR DESCRIPTION
## Background

Issue #471 reports heap pinned at 97% with RSS at 3.5× heapTotal (heapTotal 347 MB, RSS 1227 MB) sustained for 4-day uptime. Prior sweeps (#443, #448–#459) fixed the V8-side accumulators thoroughly; the remaining bloat doesn't look like a JS heap leak — it looks like glibc allocator fragmentation, which the existing heapPct alarm misses by design.

Two changes targeting the OS-side half of the problem.

## 1. `MALLOC_ARENA_MAX=2` default in `start-combined.sh`

Node on glibc allocates many small chunks for decoded JSON, Prisma rows, and TLS buffers; glibc's default 8-arena allocator rarely returns those pages to the OS. The canonical Node-on-Linux deployment tweak is to cap to 2 arenas — typically drops long-run RSS 30–50% with no code changes.

- Default `MALLOC_ARENA_MAX=2`
- Operators can override via env var (`multi-CPU NUMA tuning, very high request concurrency`)
- Logged at startup so it's discoverable

## 2. RSS-bloat visibility in `heap-monitor.ts`

The existing `heapPct >= 0.9` warn catches V8-side leaks; it can't catch RSS bloat because heap stays healthy in that scenario. Adding a parallel signal:

- **New field `rssToHeapRatio`** in every sample payload. Healthy Node sits at ~1.3–1.6×; ≥2× means non-V8 memory exceeds V8 itself — the discriminator the existing alarm doesn't expose.
- **New rate-limited warn** when `rssToHeapRatio >= 2.0` after a 1-hour warmup, throttled to once per hour. Names `MALLOC_ARENA_MAX` directly so operators have a concrete remediation instead of just seeing the symptom.

The existing 90% heapPct warning still fires for the JS-side leak case unchanged.

## What this is NOT

- Not a leak fix. If there's a JS-side accumulator the prior sweeps missed, it'll need a heap snapshot + `heap-retainer-walk.py` analysis. This PR makes that case easier to spot (`rssToHeapRatio` is the smoking gun) but doesn't fix it.
- Not a `Closes` for #427 or #471. Both stay open until reporters can verify (a) RSS drops with `MALLOC_ARENA_MAX=2` and (b) heap-monitor logs no longer trip the bloat warning.

## Test plan

- [x] `tsc --noEmit` on `@arr/api` clean
- [x] Full API vitest suite passes (EXIT=0)
- [ ] Build a container with this change, run for 24h+ with a large library, confirm `rssToHeapRatio` lands in the expected band (1.3–1.6×)
- [ ] Manual: confirm `MALLOC_ARENA_MAX: 2` shows in the startup log
- [ ] Manual: confirm `MALLOC_ARENA_MAX=4` override is honored

Addresses #427 #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)