### PR TITLE
fix(hunting): grab detection without eventType filter (closes #472)

### DIFF
--- a/apps/api/src/lib/hunting/__tests__/grab-detector.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/grab-detector.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for grab-detector.
+ *
+ * Issue #472 driver: Radarr 6.x / Sonarr 4.x reject `eventType=grabbed` as
+ * an invalid history-endpoint query value ("The value 'grabbed' is not valid").
+ * The fix dropped the server-side filter and moved it to client-side iteration.
+ *
+ * These tests pin the contract so a future contributor doesn't re-add the
+ * broken server-side filter "for performance":
+ *
+ *   1. `client.history.get` is called WITHOUT `eventType` in the request options.
+ *   2. Records whose `eventType !== "grabbed"` are filtered out client-side
+ *      (otherwise we'd over-count by also matching imports/renames/deletes by ID).
+ *   3. Records older than `searchStartTime` are still filtered out.
+ *   4. Matching grab records (by movie/series/episode ID, with eventType=grabbed,
+ *      newer than searchStartTime) are returned in the result.
+ */
+
+import type { RadarrClient } from "arr-sdk/radarr";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { detectGrabbedItemsFromHistoryWithSdk } from "../grab-detector.js";
+import type { ApiCallCounter } from "../pagination-helpers.js";
+
+const stubLogger = {
+	child: vi.fn().mockReturnThis(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+};
+
+interface HistoryRecord {
+	eventType: string;
+	date: string;
+	movieId?: number;
+	seriesId?: number;
+	episodeId?: number;
+	sourceTitle?: string;
+}
+
+function makeClient(records: HistoryRecord[]): {
+	client: RadarrClient;
+	getMock: ReturnType<typeof vi.fn>;
+} {
+	const getMock = vi.fn().mockResolvedValue({ records });
+	const client = {
+		history: { get: getMock },
+	} as unknown as RadarrClient;
+	return { client, getMock };
+}
+
+const FUTURE = new Date("2030-01-01T00:00:00Z");
+const PAST = new Date("2020-01-01T00:00:00Z");
+
+describe("detectGrabbedItemsFromHistoryWithSdk", () => {
+	let counter: ApiCallCounter;
+
+	beforeEach(() => {
+		counter = { count: 0 };
+		// Stub the 10s grab-check delay so tests are fast — the delay is
+		// production-realism, not behavior under test.
+		vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+			fn();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		}) as typeof setTimeout);
+	});
+
+	it("does NOT send eventType in the history request (issue #472 regression pin)", async () => {
+		const { client, getMock } = makeClient([]);
+
+		await detectGrabbedItemsFromHistoryWithSdk(
+			client,
+			PAST,
+			[1],
+			[],
+			[],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(getMock).toHaveBeenCalledTimes(1);
+		const options = getMock.mock.calls[0]![0] as Record<string, unknown>;
+		expect(options).not.toHaveProperty("eventType");
+		// Sanity: still uses the expected sort + paging
+		expect(options.sortKey).toBe("date");
+		expect(options.sortDirection).toBe("descending");
+		expect(options.pageSize).toBeGreaterThanOrEqual(100);
+	});
+
+	it("filters out non-grabbed event types client-side", async () => {
+		// All three records match the searched movieId but only one is a grab.
+		// Without client-side filtering, an import / delete would be miscounted
+		// as a grab.
+		const { client } = makeClient([
+			{
+				eventType: "downloadFolderImported",
+				date: "2026-05-26T12:00:00Z",
+				movieId: 42,
+				sourceTitle: "Should be ignored — import",
+			},
+			{
+				eventType: "movieFileDeleted",
+				date: "2026-05-26T12:00:00Z",
+				movieId: 42,
+				sourceTitle: "Should be ignored — delete",
+			},
+			{
+				eventType: "grabbed",
+				date: "2026-05-26T12:00:00Z",
+				movieId: 42,
+				sourceTitle: "The actual grab",
+			},
+		]);
+
+		const result = await detectGrabbedItemsFromHistoryWithSdk(
+			client,
+			PAST,
+			[42],
+			[],
+			[],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(result.failed).toBe(false);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]!.title).toBe("The actual grab");
+	});
+
+	it("filters out grabbed records older than searchStartTime", async () => {
+		const { client } = makeClient([
+			{
+				eventType: "grabbed",
+				date: "2026-05-26T12:00:00Z",
+				movieId: 42,
+				sourceTitle: "Old grab — predates this hunt",
+			},
+		]);
+
+		const result = await detectGrabbedItemsFromHistoryWithSdk(
+			client,
+			FUTURE,
+			[42],
+			[],
+			[],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(result.failed).toBe(false);
+		expect(result.items).toEqual([]);
+	});
+
+	it("returns grabbed records matching any of the searched ID buckets", async () => {
+		const { client } = makeClient([
+			{ eventType: "grabbed", date: "2026-05-26T12:00:00Z", movieId: 1, sourceTitle: "Movie 1" },
+			{ eventType: "grabbed", date: "2026-05-26T12:00:00Z", seriesId: 2, sourceTitle: "Series 2" },
+			{
+				eventType: "grabbed",
+				date: "2026-05-26T12:00:00Z",
+				episodeId: 3,
+				sourceTitle: "Episode 3",
+			},
+			{
+				eventType: "grabbed",
+				date: "2026-05-26T12:00:00Z",
+				movieId: 99,
+				sourceTitle: "Unmatched movie",
+			},
+		]);
+
+		const result = await detectGrabbedItemsFromHistoryWithSdk(
+			client,
+			PAST,
+			[1],
+			[2],
+			[3],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(result.failed).toBe(false);
+		expect(result.items.map((i) => i.title)).toEqual(["Movie 1", "Series 2", "Episode 3"]);
+	});
+});

--- a/apps/api/src/lib/hunting/__tests__/grab-detector.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/grab-detector.test.ts
@@ -16,10 +16,16 @@
  *      newer than searchStartTime) are returned in the result.
  */
 
+import type { LidarrClient } from "arr-sdk/lidarr";
 import type { RadarrClient } from "arr-sdk/radarr";
+import type { ReadarrClient } from "arr-sdk/readarr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { detectGrabbedItemsFromHistoryWithSdk } from "../grab-detector.js";
+import {
+	detectGrabbedItemsFromHistoryWithSdk,
+	detectLidarrGrabbedItems,
+	detectReadarrGrabbedItems,
+} from "../grab-detector.js";
 import type { ApiCallCounter } from "../pagination-helpers.js";
 
 const stubLogger = {
@@ -87,7 +93,10 @@ describe("detectGrabbedItemsFromHistoryWithSdk", () => {
 		// Sanity: still uses the expected sort + paging
 		expect(options.sortKey).toBe("date");
 		expect(options.sortDirection).toBe("descending");
-		expect(options.pageSize).toBeGreaterThanOrEqual(100);
+		// Pin exact pageSize — accidentally reverting to 100 would meaningfully
+		// shrink the grab-detection window now that the page contains mixed
+		// event types (test-analyzer recommendation on PR #479).
+		expect(options.pageSize).toBe(250);
 	});
 
 	it("filters out non-grabbed event types client-side", async () => {
@@ -184,5 +193,169 @@ describe("detectGrabbedItemsFromHistoryWithSdk", () => {
 
 		expect(result.failed).toBe(false);
 		expect(result.items.map((i) => i.title)).toEqual(["Movie 1", "Series 2", "Episode 3"]);
+	});
+
+	it("falls back to queue detection when history.get rejects", async () => {
+		// Simulates network/auth/transient failure on the history call.
+		// Queue fallback must still return matching items so itemsGrabbed is
+		// reported accurately when only the history path is broken.
+		const historyMock = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+		const queueMock = vi.fn().mockResolvedValue({
+			records: [
+				{
+					movieId: 42,
+					title: "From queue fallback",
+					quality: { quality: { name: "WEBDL-1080p" } },
+				},
+			],
+		});
+		const client = {
+			history: { get: historyMock },
+			queue: { get: queueMock },
+		} as unknown as RadarrClient;
+
+		const result = await detectGrabbedItemsFromHistoryWithSdk(
+			client,
+			PAST,
+			[42],
+			[],
+			[],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(historyMock).toHaveBeenCalledTimes(1);
+		expect(queueMock).toHaveBeenCalledTimes(1);
+		expect(result.failed).toBe(false);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]!.title).toBe("From queue fallback");
+	});
+});
+
+// ===========================================================================
+// Lidarr parity tests (issue #472 regression pin across services)
+//
+// The fix was applied identically to Lidarr and Readarr — without service-
+// specific tests, a future contributor "cleaning up" only one branch would
+// silently re-introduce the bug for that service while these tests pass.
+// ===========================================================================
+
+describe("detectLidarrGrabbedItems", () => {
+	let counter: ApiCallCounter;
+
+	beforeEach(() => {
+		counter = { count: 0 };
+		vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+			fn();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		}) as typeof setTimeout);
+	});
+
+	it("does NOT send eventType in the history request (issue #472 regression pin)", async () => {
+		const getMock = vi.fn().mockResolvedValue({ records: [] });
+		const client = { history: { get: getMock } } as unknown as LidarrClient;
+
+		await detectLidarrGrabbedItems(client, PAST, [1], counter, stubLogger as never);
+
+		const options = getMock.mock.calls[0]![0] as Record<string, unknown>;
+		expect(options).not.toHaveProperty("eventType");
+		expect(options.pageSize).toBe(250);
+	});
+
+	it("filters out non-grabbed events and matches by albumId", async () => {
+		const getMock = vi.fn().mockResolvedValue({
+			records: [
+				{
+					eventType: "trackFileImported",
+					date: "2026-05-26T12:00:00Z",
+					albumId: 7,
+					sourceTitle: "Should be ignored — import",
+				},
+				{
+					eventType: "grabbed",
+					date: "2026-05-26T12:00:00Z",
+					albumId: 7,
+					sourceTitle: "The actual album grab",
+				},
+				{
+					eventType: "grabbed",
+					date: "2026-05-26T12:00:00Z",
+					albumId: 99,
+					sourceTitle: "Unmatched album",
+				},
+			],
+		});
+		const client = { history: { get: getMock } } as unknown as LidarrClient;
+
+		const result = await detectLidarrGrabbedItems(client, PAST, [7], counter, stubLogger as never);
+
+		expect(result.failed).toBe(false);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]!.title).toBe("The actual album grab");
+	});
+});
+
+// ===========================================================================
+// Readarr parity tests (issue #472 regression pin across services)
+// ===========================================================================
+
+describe("detectReadarrGrabbedItems", () => {
+	let counter: ApiCallCounter;
+
+	beforeEach(() => {
+		counter = { count: 0 };
+		vi.spyOn(global, "setTimeout").mockImplementation(((fn: () => void) => {
+			fn();
+			return 0 as unknown as ReturnType<typeof setTimeout>;
+		}) as typeof setTimeout);
+	});
+
+	it("does NOT send eventType in the history request (issue #472 regression pin)", async () => {
+		const getMock = vi.fn().mockResolvedValue({ records: [] });
+		const client = { history: { get: getMock } } as unknown as ReadarrClient;
+
+		await detectReadarrGrabbedItems(client, PAST, [1], counter, stubLogger as never);
+
+		const options = getMock.mock.calls[0]![0] as Record<string, unknown>;
+		expect(options).not.toHaveProperty("eventType");
+		expect(options.pageSize).toBe(250);
+	});
+
+	it("filters out non-grabbed events and matches by bookId", async () => {
+		const getMock = vi.fn().mockResolvedValue({
+			records: [
+				{
+					eventType: "bookFileImported",
+					date: "2026-05-26T12:00:00Z",
+					bookId: 11,
+					sourceTitle: "Should be ignored — import",
+				},
+				{
+					eventType: "grabbed",
+					date: "2026-05-26T12:00:00Z",
+					bookId: 11,
+					sourceTitle: "The actual book grab",
+				},
+				{
+					eventType: "grabbed",
+					date: "2026-05-26T12:00:00Z",
+					bookId: 99,
+					sourceTitle: "Unmatched book",
+				},
+			],
+		});
+		const client = { history: { get: getMock } } as unknown as ReadarrClient;
+
+		const result = await detectReadarrGrabbedItems(
+			client,
+			PAST,
+			[11],
+			counter,
+			stubLogger as never,
+		);
+
+		expect(result.failed).toBe(false);
+		expect(result.items).toHaveLength(1);
+		expect(result.items[0]!.title).toBe("The actual book grab");
 	});
 });

--- a/apps/api/src/lib/hunting/constants.ts
+++ b/apps/api/src/lib/hunting/constants.ts
@@ -64,7 +64,6 @@ export const MIN_HOURLY_API_CAP = 10;
  */
 export const MAX_HOURLY_API_CAP = 500;
 
-
 /**
  * Delay between individual search commands within a hunt (30 seconds)
  * Prevents overwhelming indexers with simultaneous requests.
@@ -79,9 +78,7 @@ export const SEARCH_DELAY_MS = 30_000;
  */
 export const MAX_QUEUE_THRESHOLD = 100;
 
-
 // === DEFAULT INTERVALS ===
-
 
 // === SONARR SEARCH OPTIMIZATION ===
 
@@ -93,7 +90,6 @@ export const MAX_QUEUE_THRESHOLD = 100;
 export const SEASON_SEARCH_THRESHOLD = 3;
 
 // === SEARCH HISTORY / RE-SEARCH SETTINGS ===
-
 
 /**
  * Maximum re-search interval (90 days)
@@ -110,9 +106,12 @@ export const MAX_RESEARCH_AFTER_DAYS = 90;
  * - Sonarr/Radarr to evaluate and grab releases
  * - History event to be recorded
  *
- * We use history-based detection (checking /api/v3/history?eventType=grabbed)
- * rather than queue checking, which is more reliable because history persists
- * even after downloads complete, while queue items can disappear quickly.
+ * We use history-based detection (checking /api/v3/history and filtering for
+ * grab events client-side) rather than queue checking, which is more reliable
+ * because history persists even after downloads complete, while queue items
+ * can disappear quickly. The server-side `?eventType=grabbed` filter was
+ * dropped in the #472 fix — current Radarr/Sonarr versions reject it as
+ * "not valid"; client-side filtering is version-agnostic.
  *
  * Default: 10 seconds
  */
@@ -128,4 +127,3 @@ export const GRAB_CHECK_DELAY_MS = 10_000;
  * Default: 10 minutes (should be plenty for even large batch sizes with delays)
  */
 export const MAX_HUNT_DURATION_MS = 10 * 60 * 1000;
-

--- a/apps/api/src/lib/hunting/grab-detector.ts
+++ b/apps/api/src/lib/hunting/grab-detector.ts
@@ -48,16 +48,22 @@ export async function detectGrabbedItemsFromHistoryWithSdk(
 		await delay(GRAB_CHECK_DELAY_MS);
 
 		counter.count++;
+		// Issue #472: Radarr 6.x / Sonarr 4.x reject `eventType=grabbed` on the
+		// history endpoint ("The value 'grabbed' is not valid"). Fetch unfiltered
+		// and filter client-side instead — version-agnostic and removes the
+		// dependency on upstream enum encoding entirely. pageSize bumped from
+		// 100 → 250 to keep the same grab-detection window now that the page
+		// contains mixed event types (grabs, imports, deletes, renames).
 		const history = await client.history.get({
-			pageSize: 100,
+			pageSize: 250,
 			sortKey: "date",
 			sortDirection: "descending",
-			eventType: "grabbed",
 		});
 
 		const grabbedItems: GrabbedItem[] = [];
 
 		for (const record of history.records ?? []) {
+			if (record.eventType !== "grabbed") continue;
 			const eventDate = new Date(record.date ?? "");
 			if (eventDate < searchStartTime) continue;
 
@@ -221,16 +227,19 @@ export async function detectLidarrGrabbedItems(
 		await delay(GRAB_CHECK_DELAY_MS);
 
 		counter.count++;
+		// See issue #472 — `eventType=grabbed` is rejected by current Lidarr;
+		// filter client-side instead. pageSize bumped to preserve the window
+		// once non-grab events share the page.
 		const history = await client.history.get({
-			pageSize: 100,
+			pageSize: 250,
 			sortKey: "date",
 			sortDirection: "descending",
-			eventType: "grabbed",
 		});
 
 		const grabbedItems: GrabbedItem[] = [];
 
 		for (const record of history.records ?? []) {
+			if (record.eventType !== "grabbed") continue;
 			const eventDate = new Date(record.date ?? "");
 			if (eventDate < searchStartTime) continue;
 
@@ -297,16 +306,19 @@ export async function detectReadarrGrabbedItems(
 		await delay(GRAB_CHECK_DELAY_MS);
 
 		counter.count++;
+		// See issue #472 — `eventType=grabbed` is rejected by current Readarr;
+		// filter client-side instead. pageSize bumped to preserve the window
+		// once non-grab events share the page.
 		const history = await client.history.get({
-			pageSize: 100,
+			pageSize: 250,
 			sortKey: "date",
 			sortDirection: "descending",
-			eventType: "grabbed",
 		});
 
 		const grabbedItems: GrabbedItem[] = [];
 
 		for (const record of history.records ?? []) {
+			if (record.eventType !== "grabbed") continue;
 			const eventDate = new Date(record.date ?? "");
 			if (eventDate < searchStartTime) continue;
 


### PR DESCRIPTION
## Summary

`arr-sdk@0.6.0` sends `?eventType=grabbed` on the Sonarr/Radarr/Lidarr/Readarr history endpoint, but current upstream versions reject it with HTTP 400:

\`\`\`
"errors": { "eventType": ["The value 'grabbed' is not valid."] }
\`\`\`

This breaks history-based grab detection in the hunt executor. The fallback to queue detection then surfaces as repeated UI errors and unreliable \`itemsGrabbed\` counts.

## Fix

Drop the server-side filter and filter client-side. The function already iterates each history record to match by movie / series / episode / album / book ID — adding \`record.eventType === "grabbed"\` as an early-continue costs nothing and removes the dependency on upstream enum encoding entirely.

Applied to all three call sites in \`grab-detector.ts\`:
- \`detectGrabbedItemsFromHistoryWithSdk\` (Sonarr + Radarr)
- \`detectLidarrGrabbedItems\`
- \`detectReadarrGrabbedItems\`

\`pageSize\` bumped from 100 → 250 to preserve the grab-detection window now that the page contains mixed event types (grabs, imports, deletes, renames).

## Why not just bump arr-sdk?

The SDK's type still claims \`eventType: "grabbed"\` is valid (it's modeled from upstream Swagger), so a version bump alone won't necessarily fix it — and would force every other SDK consumer onto a newer release. The client-side filter is version-agnostic across all current and future Servarr versions and decouples our fix from the SDK release cycle.

## Why not send `eventType` as a number?

Servarr APIs are .NET enums; in theory \`eventType=1\` should work. But the SDK's typed shape rejects numeric values, and casting around the type just to send a number is more fragile than dropping the filter entirely. Client-side filtering also handles the edge case where future versions rename or renumber the enum.

## Trade-offs

- **Performance**: each call now fetches up to 250 mixed records instead of 100 pre-filtered grabs. For a typical hunt cycle that's an extra ~50–100 KB of JSON parsed; for high-volume servers (dozens of imports/grabs per second) it slightly narrows the detection window vs the pre-fix shape but is still bounded.
- **Detection accuracy**: identical — the client-side filter is exact, just runs at a different layer.

## Regression test

New file \`apps/api/src/lib/hunting/__tests__/grab-detector.test.ts\` pins four contracts:
1. \`client.history.get\` is called WITHOUT \`eventType\` (regression pin for #472)
2. Non-grab events (\`downloadFolderImported\`, \`movieFileDeleted\`, etc.) are filtered out
3. Records older than \`searchStartTime\` are filtered out
4. Matching grab records across all ID buckets (movie, series, episode) are returned

If a future contributor re-adds the server-side filter "for performance," the first test fails immediately.

## Test plan

- [x] \`tsc --noEmit\` on \`@arr/api\` clean
- [x] New grab-detector tests pass (4/4)
- [x] Full hunting test suite passes (59/59)
- [ ] Manual verification on a current Radarr/Sonarr (no more \`"The value 'grabbed' is not valid."\` errors, queue UI clean, hunt cycle reports accurate \`itemsGrabbed\`)

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)