### PR TITLE
refactor(cross-seed): future-proof discriminated-union narrowing

### DIFF
--- a/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { CrossSeedDiscoveryAvailability } from "@arr/shared";
 import {
 	ArrowRight,
 	CheckSquare,
@@ -23,6 +24,22 @@ import { getErrorMessage } from "../../../lib/error-utils";
 import { CrossSeedBulkToolbar } from "./cross-seed-bulk-toolbar";
 import { CrossSeedItemCard } from "./cross-seed-item-card";
 
+/**
+ * Narrowed shape of the `available: true` branch of the discovery union.
+ * Pulled out via `Extract<>` so the narrowing site below carries an explicit
+ * annotation instead of relying on TypeScript's control-flow analysis of the
+ * Zod-inferred discriminated-union type.
+ *
+ * Why this matters: Zod minor bumps occasionally change how `z.discriminatedUnion`
+ * surfaces its TypeScript shape, and patterns like
+ *   `data?.available === true ? data : null`
+ * can silently lose narrowing when the inferred type's discriminator gets
+ * re-wrapped. Stating the result type explicitly removes that exposure.
+ * Observed concretely when dependabot's bump bundle included zod 4.3 → 4.4
+ * (see dependabot PR ignoring zod for that group).
+ */
+type AvailableDiscovery = Extract<CrossSeedDiscoveryAvailability, { available: true }>;
+
 const SCAN_BATCH_SIZE = 100;
 
 /**
@@ -38,7 +55,11 @@ export const CrossSeedClient = () => {
 	const [selectionMode, setSelectionMode] = useState(false);
 	const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
 
-	const isAvailable = availability.data?.available === true ? availability.data : null;
+	// Explicit annotation (rather than relying on TS narrowing the Zod-inferred
+	// union) keeps the call sites below working across Zod minor bumps that
+	// change discriminator inference. See AvailableDiscovery comment above.
+	const isAvailable: AvailableDiscovery | null =
+		availability.data?.available === true ? availability.data : null;
 
 	const discovery = useCrossSeedDiscovery(Boolean(isAvailable), SCAN_BATCH_SIZE);
 


### PR DESCRIPTION
## Why

A `dependabot` bundle (the bunch closing #473 / opened as #483) tried to bump \`zod 4.3.6 → 4.4.3\`. Five TS2339 errors fired in \`cross-seed-client.tsx\` because TypeScript stopped narrowing the \`CrossSeedDiscoveryAvailability\` discriminated union after the bump.

The narrowing pattern that broke:

\`\`\`ts
const isAvailable = availability.data?.available === true ? availability.data : null;
\`\`\`

It works under standard TS control-flow analysis as long as Zod's inferred type for \`z.discriminatedUnion(\"available\", [...])\` preserves \`available: true\` as a literal boolean. When Zod minor bumps change how that inference surfaces, the narrowing silently falls back to the full union and every property access (\`quiInstanceLabel\`, \`scanCandidates\`, \`quiInstanceId\`) becomes a TS error.

## Fix

Pull out the \`available: true\` branch with \`Extract<>\` and annotate the result variable explicitly:

\`\`\`ts
type AvailableDiscovery = Extract<CrossSeedDiscoveryAvailability, { available: true }>;

const isAvailable: AvailableDiscovery | null =
  availability.data?.available === true ? availability.data : null;
\`\`\`

The annotation removes the dependency on TS deriving the narrowed shape from the inferred union. Result: the same call sites (\`isAvailable.quiInstanceLabel\`, \`isAvailable.scanCandidates\`, etc.) typecheck under any Zod version that produces a union with an \`available: true\` member.

## Compatibility

- ✅ Compiles cleanly under current main (zod 4.3.6)
- ✅ Should compile under zod 4.4.x once we accept that bump (this PR is the prerequisite for unblocking the zod portion of the next dependabot production-deps bundle)
- ✅ No behavior change — pure type-system robustness

## Out of scope

The other three discriminated unions in \`packages/shared\` (\`quiConnectionTestResult\`, \`pulseAction\`, \`manualImportCandidate\`) are not audited here. Their consumers may have similar fragility under Zod 4.4+, but none are currently failing, so the audit is deferred. When we eventually bump Zod, this same Extract-annotation pattern can be applied if those sites trip.

## Test plan

- [x] \`tsc --noEmit\` on \`@arr/web\` clean on current main
- [ ] Verifies the fix is forward-compatible once zod 4.4+ lands (separate dependabot cycle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)