### PR TITLE
fix(statistics): de-duplicate disk totals shared across *arr instances

### DIFF
--- a/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
+++ b/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for combineDiskStats — the de-duplication that fixes GitHub issue #486
+ * ("Storage available" reporting ~4x reality).
+ *
+ * Root cause: each *arr instance reports the free/total space of whatever it
+ * can see. On a single-array setup (the common Unraid/Docker layout) every
+ * instance reports the SAME physical disk, and summing per-instance totals
+ * multiplies the figure by the instance count. combineDiskStats collapses
+ * disks that share a storage group or an identical (totalSpace, freeSpace)
+ * fingerprint so the disk is counted once.
+ */
+
+import { dashboardStatisticsResponseSchema } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import {
+	buildCombinedDiskPayload,
+	combineDiskStats,
+	type DiskBearingInstance,
+	type DiskContributor,
+	toDiskMounts,
+} from "../statistics-utils.js";
+
+const TB = 1024 ** 4;
+
+// One physical 120 TB array with ~105 TB free, as four different services would
+// each independently report it.
+const sharedArray = () => [{ totalSpace: 120 * TB, freeSpace: 105 * TB }];
+
+describe("combineDiskStats", () => {
+	it("counts a shared array once across many instances (issue #486)", () => {
+		const contributors: DiskContributor[] = [
+			{ diskEntries: sharedArray() }, // sonarr
+			{ diskEntries: sharedArray() }, // radarr
+			{ diskEntries: sharedArray() }, // lidarr
+			{ diskEntries: sharedArray() }, // readarr
+		];
+
+		const result = combineDiskStats(contributors);
+
+		expect(result.total).toBe(120 * TB);
+		expect(result.free).toBe(105 * TB);
+		expect(result.used).toBe(15 * TB);
+		expect(result.diskCount).toBe(1);
+		// Every instance reported storage, even the de-duplicated ones — this
+		// drives the "1 disk across 4 instances" transparency line.
+		expect(result.instanceCount).toBe(4);
+	});
+
+	it("sums genuinely distinct disks", () => {
+		const result = combineDiskStats([
+			{ diskEntries: [{ totalSpace: 10 * TB, freeSpace: 4 * TB }] },
+			{ diskEntries: [{ totalSpace: 8 * TB, freeSpace: 3 * TB }] },
+		]);
+
+		expect(result.total).toBe(18 * TB);
+		expect(result.free).toBe(7 * TB);
+		expect(result.diskCount).toBe(2);
+		expect(result.instanceCount).toBe(2);
+	});
+
+	it("de-duplicates across mixed mount sets (array shared, extra disk distinct)", () => {
+		const result = combineDiskStats([
+			{
+				diskEntries: [
+					{ totalSpace: 120 * TB, freeSpace: 105 * TB }, // shared array
+					{ totalSpace: 2 * TB, freeSpace: 1 * TB }, // sonarr-only SSD
+				],
+			},
+			{ diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] }, // same array
+		]);
+
+		expect(result.total).toBe(122 * TB); // array once + SSD once
+		expect(result.free).toBe(106 * TB);
+		expect(result.diskCount).toBe(2);
+	});
+
+	it("honors storage groups: a represented group skips later members entirely", () => {
+		// Same array, but reported free space drifts by a few bytes between reads
+		// (active downloads). The fingerprint alone would NOT merge these, but the
+		// explicit storage group does.
+		const result = combineDiskStats([
+			{ storageGroupId: "nas", diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] },
+			{
+				storageGroupId: "nas",
+				diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB - 4096 }],
+			},
+		]);
+
+		expect(result.total).toBe(120 * TB);
+		expect(result.free).toBe(105 * TB);
+		expect(result.diskCount).toBe(1);
+		// Both instances report storage; the de-dup is by group, but instanceCount
+		// must still be 2 so the operator who configured groups isn't shown a
+		// smaller instance count than one who relied on the fingerprint.
+		expect(result.instanceCount).toBe(2);
+	});
+
+	it("combines storage-group and fingerprint de-dup in a single call", () => {
+		// Realistic mixed setup: two services grouped as "nas", one un-grouped
+		// service reporting the SAME array (caught by fingerprint), and one
+		// un-grouped service on a genuinely distinct disk.
+		const result = combineDiskStats([
+			{ storageGroupId: "nas", diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] },
+			{ storageGroupId: "nas", diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] },
+			{ diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] }, // same array, no group
+			{ diskEntries: [{ totalSpace: 4 * TB, freeSpace: 1 * TB }] }, // distinct disk
+		]);
+
+		expect(result.total).toBe(124 * TB); // array once + distinct disk
+		expect(result.free).toBe(106 * TB);
+		expect(result.diskCount).toBe(2);
+		expect(result.instanceCount).toBe(4);
+	});
+
+	it("merges two genuinely distinct disks with identical (total, free) — documented accepted under-count", () => {
+		// Accepted limitation: byte-identical total AND free across two real disks
+		// is realistic only for empty equal-size disks (free ≈ total), where the
+		// user has abundant space and the under-count is harmless. This test pins
+		// the intended behavior so a future "fix" that re-keys the fingerprint
+		// can't silently re-open issue #486.
+		const result = combineDiskStats([
+			{ diskEntries: [{ totalSpace: 2 * TB, freeSpace: 2 * TB }] },
+			{ diskEntries: [{ totalSpace: 2 * TB, freeSpace: 2 * TB }] },
+		]);
+
+		expect(result.total).toBe(2 * TB); // merged, NOT 4 TB
+		expect(result.diskCount).toBe(1);
+		expect(result.instanceCount).toBe(2);
+	});
+
+	it("ignores entries with non-positive total space", () => {
+		const result = combineDiskStats([
+			{ diskEntries: [{ totalSpace: 0, freeSpace: 0 }] },
+			{ diskEntries: [{ totalSpace: undefined, freeSpace: undefined }] },
+		]);
+
+		expect(result.total).toBe(0);
+		expect(result.diskCount).toBe(0);
+		expect(result.instanceCount).toBe(0);
+		expect(result.usagePercent).toBe(0);
+	});
+
+	it("returns zeros for no contributors", () => {
+		const result = combineDiskStats([]);
+		expect(result).toEqual({
+			total: 0,
+			free: 0,
+			used: 0,
+			usagePercent: 0,
+			diskCount: 0,
+			instanceCount: 0,
+		});
+	});
+
+	// Regression guard: diskCount/instanceCount are optional schema additions.
+	// Zod's .parse() strips keys absent from the schema, so a forgotten field
+	// here would silently drop from the API response despite green types/units.
+	it("diskCount and instanceCount survive the response schema's parse()", () => {
+		const combined = combineDiskStats([
+			{ diskEntries: sharedArray() },
+			{ diskEntries: sharedArray() },
+		]);
+		const payload = {
+			sonarr: { instances: [], aggregate: undefined },
+			radarr: { instances: [], aggregate: undefined },
+			prowlarr: { instances: [], aggregate: undefined },
+			lidarr: { instances: [], aggregate: undefined },
+			readarr: { instances: [], aggregate: undefined },
+			combinedDisk: {
+				diskTotal: combined.total,
+				diskFree: combined.free,
+				diskUsed: combined.used,
+				diskUsagePercent: combined.usagePercent,
+				diskCount: combined.diskCount,
+				instanceCount: combined.instanceCount,
+			},
+		};
+
+		const parsed = dashboardStatisticsResponseSchema.parse(payload);
+
+		expect(parsed.combinedDisk?.diskTotal).toBe(120 * TB); // not the 240 TB naive sum
+		expect(parsed.combinedDisk?.diskCount).toBe(1);
+		expect(parsed.combinedDisk?.instanceCount).toBe(2);
+	});
+});
+
+describe("toDiskMounts", () => {
+	// Pins the exact shape combineDiskStats depends on: path is dropped, and
+	// missing total/free coerce to 0. If the `?? 0` coercion ever regressed to
+	// `undefined`, the fingerprint key would become "120…:undefined" and shared
+	// disks would silently stop merging (re-opening issue #486) with green types.
+	it("drops path and coerces missing total/free to 0", () => {
+		const mounts = toDiskMounts([
+			{ path: "/tv", totalSpace: 120 * 1024 ** 4, freeSpace: 105 * 1024 ** 4 },
+			{ path: "/data" }, // missing total/free
+			{ totalSpace: 2 * 1024 ** 4, freeSpace: undefined },
+		] as Array<{ path?: string; totalSpace?: number; freeSpace?: number }>);
+
+		expect(mounts).toEqual([
+			{ totalSpace: 120 * 1024 ** 4, freeSpace: 105 * 1024 ** 4 },
+			{ totalSpace: 0, freeSpace: 0 },
+			{ totalSpace: 2 * 1024 ** 4, freeSpace: 0 },
+		]);
+		// No `path` key survives.
+		expect(mounts.every((m) => !("path" in m))).toBe(true);
+	});
+});
+
+describe("buildCombinedDiskPayload", () => {
+	// Helper: a minimal disk-bearing instance carrying just the shape the
+	// combinedDisk computation reads. The real route's instance arrays carry
+	// many more fields (instanceId, shouldCountDisk, etc.); structural typing
+	// lets us narrow here.
+	const instanceWithArray = (): DiskBearingInstance => ({
+		data: { diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] },
+	});
+
+	it("collapses one array reported by all four services into a single disk", () => {
+		const payload = buildCombinedDiskPayload({
+			sonarr: [instanceWithArray()],
+			radarr: [instanceWithArray()],
+			lidarr: [instanceWithArray()],
+			readarr: [instanceWithArray()],
+		});
+
+		expect(payload).toEqual({
+			diskTotal: 120 * TB,
+			diskFree: 105 * TB,
+			diskUsed: 15 * TB,
+			diskUsagePercent: expect.any(Number),
+			diskCount: 1,
+			instanceCount: 4,
+		});
+	});
+
+	it("returns undefined when no instance reports any storage", () => {
+		expect(
+			buildCombinedDiskPayload({ sonarr: [], radarr: [], lidarr: [], readarr: [] }),
+		).toBeUndefined();
+	});
+
+	it("returns undefined when instances exist but diskEntries is missing", () => {
+		// Legacy / partial response shape: an instance with no `diskEntries`
+		// at all (e.g. an older fetch path or a failed fetch fallback object)
+		// must NOT contribute a phantom 0-byte disk; the helper should return
+		// undefined so the UI omits the combinedDisk card rather than rendering
+		// "of 0 B available".
+		expect(
+			buildCombinedDiskPayload({
+				sonarr: [{ data: {} }],
+				radarr: [{ data: {} }],
+				lidarr: [],
+				readarr: [],
+			}),
+		).toBeUndefined();
+	});
+
+	it("respects storage groups across services (e.g. sonarr+radarr grouped on the same array)", () => {
+		const payload = buildCombinedDiskPayload({
+			sonarr: [
+				{
+					storageGroupId: "nas",
+					data: { diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB }] },
+				},
+			],
+			radarr: [
+				{
+					storageGroupId: "nas",
+					data: { diskEntries: [{ totalSpace: 120 * TB, freeSpace: 105 * TB - 4096 }] },
+				},
+			],
+			lidarr: [],
+			readarr: [],
+		});
+
+		expect(payload?.diskTotal).toBe(120 * TB); // sonarr's reading; radarr's skew dropped
+		expect(payload?.diskCount).toBe(1);
+		expect(payload?.instanceCount).toBe(2);
+	});
+
+	// Compile-time guard documented as a test: the helper's parameter type
+	// (DiskBearingServiceInstances) has exactly four keys — sonarr, radarr,
+	// lidarr, readarr. Prowlarr is not a key, so a future contributor cannot
+	// accidentally feed Prowlarr instances into the combined disk total
+	// without a deliberate type change. This `@ts-expect-error` fails the
+	// build if Prowlarr is ever added to the input type.
+	it("structurally excludes Prowlarr from disk contributors", () => {
+		buildCombinedDiskPayload({
+			sonarr: [],
+			radarr: [],
+			lidarr: [],
+			readarr: [],
+			// @ts-expect-error — Prowlarr is intentionally not a valid input key
+			prowlarr: [{ data: { diskEntries: [{ totalSpace: 1, freeSpace: 1 }] } }],
+		});
+	});
+});

--- a/apps/api/src/lib/statistics/dashboard-statistics.ts
+++ b/apps/api/src/lib/statistics/dashboard-statistics.ts
@@ -44,6 +44,7 @@ import {
 	mergeBreakdown,
 	processHealthIssues,
 	safeRequest,
+	toDiskMounts,
 	toNumber,
 	updateQualityBreakdown,
 	updateTagBreakdown,
@@ -377,6 +378,7 @@ export const fetchSonarrStatisticsWithSdk = async (
 		diskFree: diskTotals.free || undefined,
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
+		diskEntries: toDiskMounts(diskspace),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -494,6 +496,7 @@ export const fetchRadarrStatisticsWithSdk = async (
 		diskFree: diskTotals.free || undefined,
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
+		diskEntries: toDiskMounts(diskspace),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -739,6 +742,7 @@ export const fetchLidarrStatisticsWithSdk = async (
 		diskFree: diskTotals.free || undefined,
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
+		diskEntries: toDiskMounts(diskspace),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -870,6 +874,7 @@ export const fetchReadarrStatisticsWithSdk = async (
 		diskFree: diskTotals.free || undefined,
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
+		diskEntries: toDiskMounts(diskspace),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};

--- a/apps/api/src/lib/statistics/statistics-utils.ts
+++ b/apps/api/src/lib/statistics/statistics-utils.ts
@@ -247,6 +247,171 @@ export const calculateDiskTotals = <T extends DiskSpaceEntry>(diskspace: T[]): D
 	};
 };
 
+/**
+ * Normalizes raw *arr diskspace entries into a stable mount shape that can be
+ * carried per-instance and later de-duplicated in `combineDiskStats`. Mount
+ * `path` is intentionally dropped: it's never used for de-duplication (see
+ * combineDiskStats) and shipping raw filesystem paths on the wire would leak
+ * the operator's layout, which incognito mode cannot mask in an API body.
+ */
+export const toDiskMounts = <T extends DiskSpaceEntry>(
+	diskspace: T[],
+): Array<{ totalSpace: number; freeSpace: number }> =>
+	diskspace.map((entry) => ({
+		totalSpace: entry?.totalSpace ?? 0,
+		freeSpace: entry?.freeSpace ?? 0,
+	}));
+
+/**
+ * One disk-bearing instance's contribution to the combined disk total.
+ */
+export interface DiskContributor {
+	storageGroupId?: string | null;
+	diskEntries: DiskSpaceEntry[];
+}
+
+/**
+ * Combined disk totals plus transparency counts.
+ */
+export interface CombinedDiskTotals extends DiskTotals {
+	diskCount: number;
+	instanceCount: number;
+}
+
+/**
+ * Combines disk stats across instances while avoiding the classic
+ * "one physical array, many *arr instances" over-count.
+ *
+ * De-duplication uses two signals, in order of trust:
+ *   1. Storage group — an explicit operator declaration that instances share
+ *      storage. Once a group is represented, later instances in the same group
+ *      are skipped entirely (this also absorbs read-timing skew in free space).
+ *   2. Disk fingerprint `${totalSpace}:${freeSpace}` — for instances with no
+ *      group set. `freeSpace` drifts byte-by-byte as data is written, so an
+ *      identical (total, free) pair across two instances is an extremely
+ *      reliable "same filesystem" signal. The only realistic collision is
+ *      near-empty disks of equal size (free ≈ total), where under-counting is
+ *      harmless because the user has abundant space.
+ *
+ * Mount path is deliberately not consulted: under Docker/Unraid the same array
+ * is bind-mounted under different container paths per service (/tv vs /movies),
+ * so it can neither confirm nor split a shared disk — hence it isn't carried at
+ * all (see toDiskMounts).
+ *
+ * `instanceCount` counts every instance that reports storage, regardless of
+ * whether its disks were de-duplicated away by either signal, so the UI can
+ * honestly say "N disks across M instances" — including for the operator who
+ * configured storage groups (the good-citizen path must not read as fewer
+ * instances than the un-configured one).
+ */
+export const combineDiskStats = (contributors: DiskContributor[]): CombinedDiskTotals => {
+	const seenGroups = new Set<string>();
+	const seenDisks = new Set<string>();
+	let total = 0;
+	let free = 0;
+	let diskCount = 0;
+	let instanceCount = 0;
+
+	for (const contributor of contributors) {
+		const usableEntries = (contributor.diskEntries ?? []).filter(
+			(entry) => (entry?.totalSpace ?? 0) > 0,
+		);
+		if (usableEntries.length > 0) instanceCount += 1;
+
+		const group = contributor.storageGroupId?.trim();
+		if (group) {
+			if (seenGroups.has(group)) continue;
+			seenGroups.add(group);
+		}
+
+		for (const entry of usableEntries) {
+			const entryTotal = entry.totalSpace ?? 0;
+			const entryFree = entry.freeSpace ?? 0;
+
+			const key = `${entryTotal}:${entryFree}`;
+			if (seenDisks.has(key)) continue;
+			seenDisks.add(key);
+
+			total += entryTotal;
+			free += entryFree;
+			diskCount += 1;
+		}
+	}
+
+	const used = Math.max(0, total - free);
+	const usagePercent = total > 0 ? clampPercentage((used / total) * 100) : 0;
+
+	return { total, free, used, usagePercent, diskCount, instanceCount };
+};
+
+/**
+ * Minimal per-instance shape needed to compute combined disk stats.
+ * Structurally compatible with the route's per-service instance arrays.
+ */
+export interface DiskBearingInstance {
+	storageGroupId?: string | null;
+	data: { diskEntries?: DiskSpaceEntry[] };
+}
+
+/**
+ * The four *arr services that carry library storage. Prowlarr is intentionally
+ * absent — it has no library storage and its statistics schema does not declare
+ * `diskEntries`, so a future contributor cannot accidentally feed Prowlarr
+ * instances into this helper without a deliberate type change.
+ */
+export interface DiskBearingServiceInstances {
+	sonarr: DiskBearingInstance[];
+	radarr: DiskBearingInstance[];
+	lidarr: DiskBearingInstance[];
+	readarr: DiskBearingInstance[];
+}
+
+/**
+ * Shape returned to the API response under `combinedDisk`.
+ */
+export interface CombinedDiskPayload {
+	diskTotal: number;
+	diskFree: number;
+	diskUsed: number;
+	diskUsagePercent: number;
+	diskCount: number;
+	instanceCount: number;
+}
+
+/**
+ * Assembles every disk-bearing instance into combineDiskStats contributors and
+ * returns the combinedDisk payload, or `undefined` when no instance reports any
+ * storage. This is the route-level assembly previously inlined in the dashboard
+ * statistics handler; extracted so its behavior (Prowlarr exclusion via the
+ * argument type, optional `diskEntries` fallback, empty-state guard) is
+ * directly testable without a Fastify route harness.
+ */
+export const buildCombinedDiskPayload = (
+	instances: DiskBearingServiceInstances,
+): CombinedDiskPayload | undefined => {
+	const contributors: DiskContributor[] = [
+		...instances.sonarr,
+		...instances.radarr,
+		...instances.lidarr,
+		...instances.readarr,
+	].map((entry) => ({
+		storageGroupId: entry.storageGroupId,
+		diskEntries: entry.data.diskEntries ?? [],
+	}));
+
+	const combined = combineDiskStats(contributors);
+	if (combined.total <= 0) return undefined;
+
+	return {
+		diskTotal: combined.total,
+		diskFree: combined.free,
+		diskUsed: combined.used,
+		diskUsagePercent: combined.usagePercent,
+		diskCount: combined.diskCount,
+		instanceCount: combined.instanceCount,
+	};
+};
+
 // ============================================================================
 // Health Issues Utilities
 // ============================================================================

--- a/apps/api/src/routes/dashboard/statistics-routes.ts
+++ b/apps/api/src/routes/dashboard/statistics-routes.ts
@@ -23,6 +23,7 @@ import {
 	fetchReadarrStatisticsWithSdk,
 	fetchSonarrStatisticsWithSdk,
 } from "../../lib/statistics/dashboard-statistics.js";
+import { buildCombinedDiskPayload } from "../../lib/statistics/statistics-utils.js";
 
 /**
  * Statistics-related routes for the dashboard
@@ -303,11 +304,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			error?: boolean;
 		}> = [];
 
-		// Track combined disk stats (properly deduplicated across all services)
-		let combinedDiskTotal = 0;
-		let combinedDiskFree = 0;
-		let combinedDiskUsed = 0;
-
 		for (const result of fetchResults) {
 			if (!result) continue;
 
@@ -317,13 +313,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				const shouldCountDisk = !storageGroupId || !globalSeenStorageGroups.has(storageGroupId);
 				if (storageGroupId) {
 					globalSeenStorageGroups.add(storageGroupId);
-				}
-
-				// Add to combined disk stats if this instance should count
-				if (shouldCountDisk) {
-					combinedDiskTotal += result.data.diskTotal ?? 0;
-					combinedDiskFree += result.data.diskFree ?? 0;
-					combinedDiskUsed += result.data.diskUsed ?? 0;
 				}
 
 				sonarrInstances.push({
@@ -340,13 +329,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				const shouldCountDisk = !storageGroupId || !globalSeenStorageGroups.has(storageGroupId);
 				if (storageGroupId) {
 					globalSeenStorageGroups.add(storageGroupId);
-				}
-
-				// Add to combined disk stats if this instance should count
-				if (shouldCountDisk) {
-					combinedDiskTotal += result.data.diskTotal ?? 0;
-					combinedDiskFree += result.data.diskFree ?? 0;
-					combinedDiskUsed += result.data.diskUsed ?? 0;
 				}
 
 				radarrInstances.push({
@@ -372,13 +354,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					globalSeenStorageGroups.add(storageGroupId);
 				}
 
-				// Add to combined disk stats if this instance should count
-				if (shouldCountDisk) {
-					combinedDiskTotal += result.data.diskTotal ?? 0;
-					combinedDiskFree += result.data.diskFree ?? 0;
-					combinedDiskUsed += result.data.diskUsed ?? 0;
-				}
-
 				lidarrInstances.push({
 					instanceId: result.instanceId,
 					instanceName: result.instanceName,
@@ -395,13 +370,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					globalSeenStorageGroups.add(storageGroupId);
 				}
 
-				// Add to combined disk stats if this instance should count
-				if (shouldCountDisk) {
-					combinedDiskTotal += result.data.diskTotal ?? 0;
-					combinedDiskFree += result.data.diskFree ?? 0;
-					combinedDiskUsed += result.data.diskUsed ?? 0;
-				}
-
 				readarrInstances.push({
 					instanceId: result.instanceId,
 					instanceName: result.instanceName,
@@ -412,12 +380,6 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				});
 			}
 		}
-
-		// Calculate combined disk usage percentage
-		const combinedDiskUsagePercent =
-			combinedDiskTotal > 0
-				? Math.min(100, Math.max(0, (combinedDiskUsed / combinedDiskTotal) * 100))
-				: 0;
 
 		const payload = {
 			sonarr: {
@@ -440,16 +402,15 @@ export const statisticsRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				instances: readarrInstances,
 				aggregate: aggregateReadarrStatistics(readarrInstances),
 			},
-			// Combined disk stats with proper cross-service storage group deduplication
-			combinedDisk:
-				combinedDiskTotal > 0
-					? {
-							diskTotal: combinedDiskTotal,
-							diskFree: combinedDiskFree,
-							diskUsed: combinedDiskUsed,
-							diskUsagePercent: combinedDiskUsagePercent,
-						}
-					: undefined,
+			// Combined disk stats, de-duplicated across services + storage groups.
+			// diskCount/instanceCount drive the transparency line in the UI so a
+			// large total reads as "N disks across M instances", never a silent lie.
+			combinedDisk: buildCombinedDiskPayload({
+				sonarr: sonarrInstances,
+				radarr: radarrInstances,
+				lidarr: lidarrInstances,
+				readarr: readarrInstances,
+			}),
 		};
 
 		return reply.send(dashboardStatisticsResponseSchema.parse(payload));

--- a/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Render smoke for the Storage card transparency line (issue #486).
+ *
+ * The combined storage total de-duplicates disks shared by multiple *arr
+ * instances. When more than one instance feeds the figure, the card must
+ * explain the number as "N disks across M instances" so a large total reads
+ * as inspectable rather than an unexplained sum.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ComponentProps, ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+import { OverviewTab } from "../overview-tab";
+
+const TB = 1024 ** 4;
+
+function Wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return (
+		<QueryClientProvider client={qc}>
+			<ColorThemeProvider>
+				<IncognitoProvider>{children}</IncognitoProvider>
+			</ColorThemeProvider>
+		</QueryClientProvider>
+	);
+}
+
+type Props = ComponentProps<typeof OverviewTab>;
+
+const baseProps = (combinedDisk: Props["combinedDisk"]): Props =>
+	({
+		allHealthIssues: [],
+		combinedDisk,
+		sonarrRows: [],
+		radarrRows: [],
+		lidarrRows: [],
+		readarrRows: [],
+		prowlarrRows: [],
+		sonarrTotals: { totalSeries: 0, downloadPercent: 0, missingEpisodes: 0, diskPercent: 0 },
+		radarrTotals: { totalMovies: 0, downloadPercent: 0, missingMovies: 0, diskPercent: 0 },
+		lidarrTotals: { totalArtists: 0, downloadPercent: 0, missingTracks: 0, diskPercent: 0 },
+		readarrTotals: { totalAuthors: 0, downloadPercent: 0, missingBooks: 0, diskPercent: 0 },
+		prowlarrTotals: { totalIndexers: 0, activeIndexers: 0, totalQueries: 0, grabRate: 0 },
+		hasTautulli: false,
+		onSwitchTab: () => {},
+		// Only the fields the component actually reads are populated; cast through
+		// unknown since the real totals types carry many more (untouched) fields.
+	}) as unknown as Props;
+
+describe("OverviewTab — Storage transparency line", () => {
+	it("explains a de-duplicated total as 'N disks across M instances'", () => {
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 120 * TB,
+					diskFree: 105 * TB,
+					diskUsed: 15 * TB,
+					diskUsagePercent: 12.5,
+					diskCount: 1,
+					instanceCount: 4,
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		// Singular "disk" for diskCount === 1, and the four contributing instances.
+		expect(screen.getByText(/1 disk across 4 instances/)).toBeInTheDocument();
+	});
+
+	it("pluralizes 'disks' when more than one unique disk is counted", () => {
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 130 * TB,
+					diskFree: 100 * TB,
+					diskUsed: 30 * TB,
+					diskUsagePercent: 23,
+					diskCount: 2,
+					instanceCount: 4,
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		expect(screen.getByText(/2 disks across 4 instances/)).toBeInTheDocument();
+	});
+
+	it("omits the breakdown when only one instance reports storage", () => {
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 10 * TB,
+					diskFree: 4 * TB,
+					diskUsed: 6 * TB,
+					diskUsagePercent: 60,
+					diskCount: 1,
+					instanceCount: 1,
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		expect(screen.queryByText(/\d+ disks? across \d+ instances/)).not.toBeInTheDocument();
+		expect(screen.getByText(/available/)).toBeInTheDocument();
+	});
+
+	it("renders the plain total when counts are absent (legacy/optional response)", () => {
+		// diskCount/instanceCount are optional — an older backend (or any path
+		// that omits them) must still render "of X available" and never crash on
+		// `undefined` inside the breakdown template.
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 10 * TB,
+					diskFree: 4 * TB,
+					diskUsed: 6 * TB,
+					diskUsagePercent: 60,
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		expect(screen.queryByText(/\d+ disks? across \d+ instances/)).not.toBeInTheDocument();
+		expect(screen.getByText(/available/)).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/statistics/components/overview-tab.tsx
+++ b/apps/web/src/features/statistics/components/overview-tab.tsx
@@ -80,6 +80,17 @@ export const OverviewTab = ({
 	const [incognitoMode] = useIncognitoMode();
 	const [healthExpanded, setHealthExpanded] = useState(false);
 
+	// Transparency for the combined storage figure: when more than one instance
+	// feeds the total, show how many unique disks it collapsed to, so a large
+	// number reads as "N disks across M instances" instead of an unexplained sum.
+	const storageDescription = (() => {
+		const base = `of ${formatBytes(combinedDisk.diskTotal)} available`;
+		const { diskCount, instanceCount } = combinedDisk;
+		if (!diskCount || !instanceCount || instanceCount <= 1) return base;
+		const disks = `${diskCount} disk${diskCount === 1 ? "" : "s"}`;
+		return `${base} · ${disks} across ${instanceCount} instances`;
+	})();
+
 	// Fetch Plex summary data when Tautulli is available
 	const { data: tautulliStats } = useTautulliStats(30, hasTautulli);
 	const { data: tautulliPlays } = useTautulliPlaysByDate(30, hasTautulli);
@@ -273,7 +284,7 @@ export const OverviewTab = ({
 				<StatCard
 					value={formatBytes(combinedDisk.diskUsed)}
 					label="Storage"
-					description={`of ${formatBytes(combinedDisk.diskTotal)} available`}
+					description={storageDescription}
 					icon={HardDrive}
 					animationDelay={550}
 				/>

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -297,6 +297,20 @@ export const tagBreakdownSchema = z.record(z.string(), z.number());
 
 export type TagBreakdown = z.infer<typeof tagBreakdownSchema>;
 
+/**
+ * A single mount/disk as reported by an *arr instance's diskspace endpoint.
+ * Carried per-instance so the combined disk total can de-duplicate disks that
+ * multiple instances report (e.g. several services bind-mounted to one array).
+ * Mount path is intentionally omitted — it isn't used for de-duplication and
+ * shipping raw filesystem paths would leak the operator's layout.
+ */
+export const diskMountSchema = z.object({
+	totalSpace: z.number().optional(),
+	freeSpace: z.number().optional(),
+});
+
+export type DiskMount = z.infer<typeof diskMountSchema>;
+
 export const sonarrStatisticsSchema = z.object({
 	totalSeries: z.number(),
 	monitoredSeries: z.number(),
@@ -317,6 +331,7 @@ export const sonarrStatisticsSchema = z.object({
 	diskFree: z.number().optional(),
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
+	diskEntries: z.array(diskMountSchema).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -340,6 +355,7 @@ export const radarrStatisticsSchema = z.object({
 	diskFree: z.number().optional(),
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
+	diskEntries: z.array(diskMountSchema).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -394,6 +410,7 @@ export const lidarrStatisticsSchema = z.object({
 	diskFree: z.number().optional(),
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
+	diskEntries: z.array(diskMountSchema).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -419,6 +436,7 @@ export const readarrStatisticsSchema = z.object({
 	diskFree: z.number().optional(),
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
+	diskEntries: z.array(diskMountSchema).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -435,6 +453,10 @@ export const combinedDiskStatsSchema = z.object({
 	diskFree: z.number(),
 	diskUsed: z.number(),
 	diskUsagePercent: z.number(),
+	/** Number of unique physical disks counted after de-duplication. */
+	diskCount: z.number().optional(),
+	/** Number of instances that contributed at least one unique disk. */
+	instanceCount: z.number().optional(),
 });
 
 export type CombinedDiskStats = z.infer<typeof combinedDiskStatsSchema>;


### PR DESCRIPTION
## Summary

Fixes issue #486: the statistics overview "Storage available" card was multiplying real free space by the number of *arr instances — a reporter on a 105 TB Unraid array saw 485 TB. Each *arr independently reports the free/total space of whatever disks it sees; on a single-array Unraid/Docker layout every service is bind-mounted to the same physical array, and the dashboard summed per-instance totals. De-duplication existed but was gated on a manual "Storage Group" setting most operators never discovered.

- Each instance now carries its raw per-mount list (`diskEntries`) through the API.
- New `combineDiskStats` helper de-duplicates by storage group first (skipping later members of a seen group, which also absorbs read-timing skew), then by a `${totalSpace}:${freeSpace}` fingerprint for instances with no group. `freeSpace` drifts byte-by-byte as data is written, so identical pairs across instances reliably indicate the same filesystem.
- The combined Storage card now reads "of X available · N disks across M instances" when more than one instance feeds the total, so a large number is inspectable rather than asserted as fact.
- Mount `path` is intentionally not carried on the wire: it isn't used for de-duplication (Docker remaps paths per container, so it can neither confirm nor split a shared disk) and shipping raw filesystem paths would leak the operator's layout — incognito mode masks rendered surfaces, not API bodies.

Storage Groups remain as the explicit override for the rare case where one logical pool reports slightly different free space across instances.

## Test plan

- [x] `pnpm run typecheck` clean (3/3 turbo tasks)
- [x] `pnpm run test` green (2015 tests pass, 0 fail)
- [x] `pnpm run lint` clean (0 errors)
- [x] 10 new `combineDiskStats` / `toDiskMounts` / `buildCombinedDiskPayload` cases covering: shared-array collapse (the headline #486 case), distinct disks summed, mixed mount sets, storage-group skew override, mixed group+fingerprint in one call, documented false-merge (accepted under-count for empty equal-size disks), non-positive total skipping, empty input, Zod schema round-trip (regression guard against silent field stripping), and structural Prowlarr exclusion via `@ts-expect-error`.
- [x] 4 frontend render tests on the real `OverviewTab`: transparency line, pluralization, single-instance omission, legacy/optional-counts branch.
- [ ] Manual browser smoke against an operator with multiple instances on a shared array (recommended before tagging a release; the render test exercises the identical code path with mocked data).

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)