### PR TITLE
feat(cross-seed): integrity lens reframe + passkey hardening

### DIFF
--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -65,6 +65,24 @@ const wireTorrent = (over: Record<string, unknown> = {}) => ({
 	...over,
 });
 
+// qui's cross-seed local-matches wire shape (snake_case, qBit-native fields).
+const wireCrossSeedMatch = (over: Record<string, unknown> = {}) => ({
+	hash: "sibhash",
+	name: "Sibling",
+	instance_id: 2,
+	instance_name: "qb2",
+	state: "uploading",
+	progress: 1,
+	size: 100,
+	category: "",
+	save_path: "/x",
+	content_path: "/x/Sibling",
+	tracker: "https://tracker.example.com/announce",
+	match_type: "release",
+	tags: "",
+	...over,
+});
+
 describe("createQuiClient", () => {
 	const fetchSpy = vi.spyOn(globalThis, "fetch");
 
@@ -224,6 +242,35 @@ describe("createQuiClient", () => {
 		const client = createQuiClient(buildApp(), buildInstance());
 		const matches = await client.getCrossSeedMatches(1, "abc123");
 		expect(matches).toEqual([]);
+	});
+
+	it("getCrossSeedMatches strips tracker passkeys down to the hostname", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					matches: [
+						// passkey in the path
+						wireCrossSeedMatch({
+							hash: "sib1",
+							tracker: "https://tracker.beyond-hd.me:2053/announce/SECRETPASSKEY123",
+						}),
+						// passkey in the query string
+						wireCrossSeedMatch({
+							hash: "sib2",
+							tracker: "https://hdbits.org/announce.php?passkey=SECRETPASSKEY456",
+						}),
+					],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const matches = await client.getCrossSeedMatches(1, "abc123");
+
+		expect(matches.map((m) => m.tracker)).toEqual(["tracker.beyond-hd.me", "hdbits.org"]);
+		// Defense-in-depth: the secret must not survive anywhere in the payload.
+		expect(JSON.stringify(matches)).not.toContain("SECRETPASSKEY");
 	});
 
 	it("throws QuiApiError with mapped status on 4xx", async () => {

--- a/apps/api/src/lib/qui/__tests__/client-helpers.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-helpers.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { extractHostnameSafe } from "../client-helpers.js";
+
+describe("extractHostnameSafe", () => {
+	it("keeps a bare https announce hostname", () => {
+		expect(extractHostnameSafe("https://tracker.example.com/announce")).toBe("tracker.example.com");
+	});
+
+	it("strips a passkey embedded in the path", () => {
+		expect(extractHostnameSafe("https://tracker.beyond-hd.me:2053/announce/SECRETPASSKEY")).toBe(
+			"tracker.beyond-hd.me",
+		);
+	});
+
+	it("strips a passkey embedded in the query string", () => {
+		expect(extractHostnameSafe("https://hdbits.org/announce.php?passkey=SECRETPASSKEY")).toBe(
+			"hdbits.org",
+		);
+	});
+
+	it("strips userinfo so credentials never leak via the host", () => {
+		expect(extractHostnameSafe("http://user:pass@tracker.example.com/announce")).toBe(
+			"tracker.example.com",
+		);
+	});
+
+	it("handles non-http announce schemes (udp)", () => {
+		expect(extractHostnameSafe("udp://tracker.opentrackr.org:1337/announce")).toBe(
+			"tracker.opentrackr.org",
+		);
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(extractHostnameSafe("")).toBe("");
+	});
+
+	it("returns empty string for an unparseable value rather than risking a leak", () => {
+		expect(extractHostnameSafe("not a url /announce/SECRETPASSKEY")).toBe("");
+	});
+});

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -19,7 +19,12 @@ import {
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { ServiceInstance } from "../prisma.js";
-import { type QuiRequestContext, quiHealthProbe, quiRequest } from "./client-helpers.js";
+import {
+	extractHostnameSafe,
+	type QuiRequestContext,
+	quiHealthProbe,
+	quiRequest,
+} from "./client-helpers.js";
 import { mapTrackerHealth } from "./tracker-health-mapper.js";
 
 export interface QuiClient {
@@ -312,7 +317,7 @@ const wireCrossSeedMatchSchema = z
 			category: w.category,
 			savePath: w.save_path,
 			contentPath: w.content_path,
-			tracker: w.tracker,
+			tracker: extractHostnameSafe(w.tracker),
 			trackerHealth: w.tracker_health,
 			matchType: w.match_type,
 			tags: w.tags,

--- a/apps/api/src/lib/qui/client-helpers.ts
+++ b/apps/api/src/lib/qui/client-helpers.ts
@@ -130,6 +130,31 @@ export async function quiHealthProbe(
 	}
 }
 
+/**
+ * Safe hostname extraction from a qBit announce URL.
+ *
+ * Private-tracker announce URLs include a passkey in the path or query
+ * (`tracker.beyond-hd.me:2053/announce/PASSKEY` or
+ * `hdbits.org/announce.php?passkey=PASSKEY`). The passkey is equivalent
+ * to login credentials — leaking it in an API response or log would
+ * compromise the user's tracker account.
+ *
+ * Returns ONLY the hostname; discards path, query, fragment, userinfo.
+ * Empty string on parse failure — better to lose tracker identification
+ * than to risk passkey exposure.
+ *
+ * Single source of truth for tracker-identity stripping across the qui
+ * integration: the library-seeding summary, torrent trackers list, and
+ * cross-seed match transform all funnel through here.
+ */
+export function extractHostnameSafe(url: string): string {
+	try {
+		return new URL(url).hostname;
+	} catch {
+		return "";
+	}
+}
+
 function buildUrl(baseUrl: string, path: string, query?: Record<string, string>): string {
 	const trimmed = baseUrl.replace(/\/$/, "");
 	const url = new URL(`${trimmed}${path.startsWith("/") ? path : `/${path}`}`);

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -266,9 +266,14 @@ describe("GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/trackers", () =
 
 describe("GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/cross-seed", () => {
 	it("returns cross-seed matches", async () => {
+		// The real `getCrossSeedMatches` applies the wire transform that strips
+		// passkeys from tracker URLs (see wireCrossSeedMatchSchema in
+		// client-factory.ts), so by the time the route sees the match the
+		// `tracker` field is already a bare hostname. The mock returns the
+		// post-transform shape — anything URL-shaped here would be a bug.
 		mockQuiClient.getCrossSeedMatches.mockResolvedValue([
 			{
-				tracker: "http://tracker.example/announce",
+				tracker: "tracker.example.com",
 				infoHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 				matchType: "content_path",
 				trackerHealth: "healthy",
@@ -280,6 +285,16 @@ describe("GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/cross-seed", ()
 		);
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload).matches).toHaveLength(1);
+
+		// Defense-in-depth: pin that the route never serializes a tracker URL
+		// with a passkey query param or an `/announce`-shaped path. The pattern
+		// requires URL form (scheme present) so it doesn't collide with the
+		// legitimate 40-hex `hash`/`infoHash` field. If a future change adds a
+		// raw-URL passthrough or someone "fixes" the mock to feed in
+		// pre-transform data, this assertion fires and reopens issue #486-style
+		// silent regression for tracker credentials.
+		expect(res.payload).not.toMatch(/https?:\/\/[^"\s]*?(\/announce|passkey=)/i);
+		expect(res.payload).not.toMatch(/"passkey"/i);
 	});
 });
 

--- a/apps/api/src/routes/qui/qui-shared.ts
+++ b/apps/api/src/routes/qui/qui-shared.ts
@@ -1,6 +1,7 @@
 import { quiActionSchema } from "@arr/shared";
 import { z } from "zod";
 import { createQuiClient } from "../../lib/qui/client-factory.js";
+import { extractHostnameSafe } from "../../lib/qui/client-helpers.js";
 
 export const HASH_PARAM = z.object({
 	hash: z.string().regex(/^[a-fA-F0-9]{40,64}$/, "Invalid info hash"),
@@ -133,26 +134,10 @@ export interface ClusterCopy {
 	quiUnreachable: boolean;
 }
 
-/**
- * Safe hostname extraction from a qBit announce URL.
- *
- * Private-tracker announce URLs include a passkey in the path or query
- * (`tracker.beyond-hd.me:2053/announce/PASSKEY` or
- * `hdbits.org/announce.php?passkey=PASSKEY`). The passkey is equivalent
- * to login credentials — leaking it in an API response or log would
- * compromise the user's tracker account.
- *
- * Returns ONLY the hostname; discards path, query, fragment, userinfo.
- * Empty string on parse failure — better to lose tracker identification
- * than to risk passkey exposure.
- */
-export function extractHostnameSafe(url: string): string {
-	try {
-		return new URL(url).hostname;
-	} catch {
-		return "";
-	}
-}
+// Canonical home is the lib layer (lib/qui/client-helpers) so the
+// client-factory transform can share it without a routes→lib import.
+// Re-exported here for the route consumers that already import it.
+export { extractHostnameSafe };
 
 export function buildUnreachableCopy(hash: string): ClusterCopy {
 	return {

--- a/apps/web/src/features/cross-seed/components/__tests__/cross-seed-item-card.test.tsx
+++ b/apps/web/src/features/cross-seed/components/__tests__/cross-seed-item-card.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Render-test pin for CrossSeedItemCard's tracker display.
+ *
+ * Tracker passkeys are user-identifying tokens embedded in private-tracker
+ * announce URLs (e.g. `https://tracker.example.org/{40-hex}/announce` or
+ * `?passkey=…`). Leaking one lets anyone seed/leech as that user and is an
+ * ejection-worthy offense on most private trackers. The wire-level strip
+ * happens in `wireCrossSeedMatchSchema.transform` (`apps/api/src/lib/qui/
+ * client-factory.ts`) so this card *should* only ever receive a bare
+ * hostname, but pin it here so a future regression — wrong field passed,
+ * transform reverted, new code path bypassing the strip — fails loudly.
+ */
+
+import type { CrossSeedDiscoveryItem } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+import { CrossSeedItemCard } from "../cross-seed-item-card";
+
+function Wrapper({ children }: { children: ReactNode }) {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return (
+		<QueryClientProvider client={qc}>
+			<ColorThemeProvider>
+				<IncognitoProvider>{children}</IncognitoProvider>
+			</ColorThemeProvider>
+		</QueryClientProvider>
+	);
+}
+
+const baseItem = (overrides?: Partial<CrossSeedDiscoveryItem>): CrossSeedDiscoveryItem => ({
+	libraryCacheId: "lib-1",
+	arrInstanceId: "arr-1",
+	arrInstanceLabel: "Sonarr Main",
+	arrService: "sonarr",
+	itemType: "series",
+	arrItemId: 42,
+	title: "Some Show (2024)",
+	year: 2024,
+	primary: {
+		hash: "a".repeat(40),
+		qbitInstanceId: 1,
+		qbitInstanceName: "qbit-home",
+		state: "uploading",
+		ratio: 1.5,
+		tracker: "tracker.example.com",
+	},
+	siblings: [
+		{
+			hash: "b".repeat(40),
+			name: "Some.Show.2024.1080p.WEB.x264-GROUP",
+			instanceId: 1,
+			instanceName: "qbit-home",
+			state: "uploading",
+			progress: 1,
+			size: 1024 * 1024 * 1024,
+			category: "",
+			savePath: "/data/tv",
+			contentPath: "/data/tv/show",
+			tracker: "tracker.example.com",
+			matchType: "release",
+			tags: "",
+		},
+	],
+	...overrides,
+});
+
+describe("CrossSeedItemCard — passkey display pin", () => {
+	// The wire transform should hand us a bare hostname; assert the rendered
+	// DOM contains zero passkey-shaped substring even if a future bug feeds in
+	// a raw URL with `/announce/{40-hex}` or `?passkey=…`.
+	const PASSKEY_PATTERN = /passkey|\/announce|[a-f0-9]{40}/i;
+
+	it("renders nothing that looks like a passkey for a normal hostname sibling", () => {
+		const { container } = render(<CrossSeedItemCard item={baseItem()} animationDelay={0} />, {
+			wrapper: Wrapper,
+		});
+
+		// Defense-in-depth: hash-shaped strings ARE present internally (the React
+		// `key` is the sibling hash), but they must not survive into rendered
+		// text content. textContent excludes attribute values and React keys.
+		expect(container.textContent ?? "").not.toMatch(PASSKEY_PATTERN);
+		// Sanity that the card actually rendered (title text reaches the DOM) —
+		// avoids the false-positive where a render crash also passes the
+		// passkey-absence assertion. We don't pin the tracker label string itself
+		// because `resolveHostnameBrand` derives a display name from the
+		// hostname's identifying segment, which is a separate concern.
+		expect(screen.getByText(/Some Show/)).toBeInTheDocument();
+	});
+
+	it("strips a passkey-bearing tracker string from rendered text if one ever sneaks through", () => {
+		// Simulate the regression: a sibling whose `tracker` field is the raw
+		// announce URL with a passkey embedded. The card has no business
+		// rendering it verbatim — at worst we expect a fallback string.
+		const compromised = baseItem({
+			siblings: [
+				{
+					...baseItem().siblings[0]!,
+					tracker: "https://tracker.example.com/announce/abcdef0123456789abcdef0123456789abcdef01",
+				},
+			],
+		});
+		const { container } = render(<CrossSeedItemCard item={compromised} animationDelay={0} />, {
+			wrapper: Wrapper,
+		});
+
+		// Render must not bake the passkey-shaped path into visible text. If a
+		// future change ever does (e.g. someone removes the wire strip and the
+		// card displays `sibling.tracker` literally), this assertion fires.
+		expect(container.textContent ?? "").not.toMatch(/[a-f0-9]{40}/i);
+		expect(container.textContent ?? "").not.toMatch(/\/announce/);
+	});
+});

--- a/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
@@ -3,11 +3,14 @@
 import type { CrossSeedDiscoveryAvailability } from "@arr/shared";
 import {
 	ArrowRight,
+	CheckCircle2,
 	CheckSquare,
+	ExternalLink,
 	Loader2,
 	Network,
 	RefreshCw,
 	Settings as SettingsIcon,
+	ShieldAlert,
 	Square,
 } from "lucide-react";
 import Link from "next/link";
@@ -24,6 +27,7 @@ import {
 	useCrossSeedDiscovery,
 	useTrackerIcons,
 } from "../../../hooks/api/useQui";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { CrossSeedBulkToolbar } from "./cross-seed-bulk-toolbar";
 import { CrossSeedItemCard } from "./cross-seed-item-card";
@@ -72,7 +76,8 @@ export const CrossSeedClient = () => {
 	const trackerIcons = useTrackerIcons().data?.trackers;
 
 	const aggregate = useMemo(() => {
-		if (!discovery.data) return { items: [], scanned: 0, found: 0, siblingFetchErrors: 0 };
+		if (!discovery.data)
+			return { items: [], scanned: 0, found: 0, siblingFetchErrors: 0, itemsNeedingAttention: 0 };
 		const items = discovery.data.pages.flatMap((p) => p.items);
 		const scanned = discovery.data.pages.reduce((sum, p) => sum + p.scannedThisBatch, 0);
 		const found = discovery.data.pages.reduce((sum, p) => sum + p.foundThisBatch, 0);
@@ -83,8 +88,36 @@ export const CrossSeedClient = () => {
 			(sum, p) => sum + (p.siblingFetchErrors ?? 0),
 			0,
 		);
-		return { items, scanned, found, siblingFetchErrors };
+		// The page's primary signal: items with ≥1 sibling whose tracker reports
+		// a problem (unregistered / tracker_down). This is what the Library
+		// tracker strip can't show — the integrity of the cross-seed layer.
+		const itemsNeedingAttention = items.filter((it) =>
+			it.siblings.some((s) => s.trackerHealth),
+		).length;
+		return { items, scanned, found, siblingFetchErrors, itemsNeedingAttention };
 	}, [discovery.data]);
+
+	// Lead with problems: when any item needs attention, the operator can filter
+	// to just those. Default to "all" (predictable — no items vanish on load);
+	// the prominent stat nudges them to the attention filter when it matters.
+	const [healthFilter, setHealthFilter] = useState<"all" | "attention">("all");
+	const visibleItems = useMemo(
+		() =>
+			healthFilter === "attention"
+				? aggregate.items.filter((it) => it.siblings.some((s) => s.trackerHealth))
+				: aggregate.items,
+		[aggregate.items, healthFilter],
+	);
+
+	// Bridge to qui for remediation (siblings are read-only here per D7). qui has
+	// no stable per-torrent URL, so this lands on the qui web UI — same pattern
+	// as the library torrent drawer's "Open in qui".
+	const { data: services } = useServicesQuery();
+	const quiOpenUrl = (() => {
+		if (!isAvailable) return null;
+		const inst = services?.find((s) => s.id === isAvailable.quiInstanceId);
+		return inst?.externalUrl ?? inst?.baseUrl ?? null;
+	})();
 
 	const quiInstanceLabel =
 		discovery.data?.pages[0]?.quiInstanceLabel ?? isAvailable?.quiInstanceLabel ?? "";
@@ -160,9 +193,9 @@ export const CrossSeedClient = () => {
 		<>
 			<Header
 				quiInstanceLabel={quiInstanceLabel}
-				scanCandidates={isAvailable?.scanCandidates}
 				onRefresh={() => discovery.refetch()}
 				isRefreshing={discovery.isFetching}
+				quiOpenUrl={quiOpenUrl}
 			/>
 
 			<GlassmorphicCard padding="md" className="mb-6">
@@ -186,6 +219,32 @@ export const CrossSeedClient = () => {
 							</div>
 							<div className="text-xl font-semibold">{aggregate.found.toLocaleString()}</div>
 						</div>
+						{/* Primary signal — items with an unhealthy cross-seed sibling.
+						    Clickable: jumps straight to the attention filter. */}
+						{aggregate.itemsNeedingAttention > 0 ? (
+							<button
+								type="button"
+								onClick={() => setHealthFilter("attention")}
+								className="text-left"
+								title="Show only items with an unregistered or down tracker"
+							>
+								<div className="flex items-center gap-1 text-amber-400 text-xs uppercase tracking-wide">
+									<ShieldAlert className="h-3 w-3" aria-hidden />
+									Needs attention
+								</div>
+								<div className="text-xl font-semibold text-amber-400">
+									{aggregate.itemsNeedingAttention.toLocaleString()}
+								</div>
+							</button>
+						) : aggregate.found > 0 ? (
+							<div>
+								<div className="flex items-center gap-1 text-emerald-400/90 text-xs uppercase tracking-wide">
+									<CheckCircle2 className="h-3 w-3" aria-hidden />
+									Healthy
+								</div>
+								<div className="text-xl font-semibold text-emerald-400/90">All</div>
+							</div>
+						) : null}
 						{aggregate.siblingFetchErrors > 0 ? (
 							<div>
 								<div className="text-muted-foreground text-xs uppercase tracking-wide">
@@ -249,6 +308,29 @@ export const CrossSeedClient = () => {
 				/>
 			) : (
 				<>
+					{/* Health filter — lead with problems. "Needs attention" disabled
+					    when nothing is unhealthy so the control never lies about
+					    having results behind it. */}
+					<div className="mb-3 flex items-center gap-1.5">
+						<Button
+							variant={healthFilter === "all" ? "primary" : "ghost"}
+							size="sm"
+							onClick={() => setHealthFilter("all")}
+							className="h-8 text-xs"
+						>
+							All ({aggregate.items.length})
+						</Button>
+						<Button
+							variant={healthFilter === "attention" ? "primary" : "ghost"}
+							size="sm"
+							onClick={() => setHealthFilter("attention")}
+							disabled={aggregate.itemsNeedingAttention === 0}
+							className="h-8 text-xs"
+						>
+							Needs attention ({aggregate.itemsNeedingAttention})
+						</Button>
+					</div>
+
 					{/* Selection-mode toggle. Selection mode shows checkboxes on each
 					    card AND surfaces a sticky bulk-action toolbar at the bottom.
 					    The toggle button label flips to reflect mode + count so the
@@ -283,7 +365,7 @@ export const CrossSeedClient = () => {
 									// the full universe, so the user is never surprised by
 									// off-screen selections.
 									const next = new Set<string>();
-									for (const item of aggregate.items) {
+									for (const item of visibleItems) {
 										if (item.primary) next.add(item.libraryCacheId);
 									}
 									setSelectedIds(next);
@@ -297,7 +379,7 @@ export const CrossSeedClient = () => {
 					</div>
 
 					<div className="space-y-3">
-						{aggregate.items.map((item, idx) => (
+						{visibleItems.map((item, idx) => (
 							<CrossSeedItemCard
 								key={item.libraryCacheId}
 								item={item}
@@ -339,32 +421,46 @@ export const CrossSeedClient = () => {
 
 interface HeaderProps {
 	quiInstanceLabel?: string;
-	scanCandidates?: number;
 	onRefresh?: () => void;
 	isRefreshing?: boolean;
+	/** qui web-UI URL for the "Open in qui" bridge; null when not resolvable. */
+	quiOpenUrl?: string | null;
 }
 
-const Header = ({ quiInstanceLabel, scanCandidates, onRefresh, isRefreshing }: HeaderProps) => {
+const Header = ({ quiInstanceLabel, onRefresh, isRefreshing, quiOpenUrl }: HeaderProps) => {
 	const description = quiInstanceLabel
-		? `Scanning ${scanCandidates?.toLocaleString() ?? "?"} correlated library items via ${quiInstanceLabel} for cross-seed siblings.`
-		: "Surface qui's cross-seed sibling graph across your library.";
+		? `Cross-seed siblings across your library via ${quiInstanceLabel}, with tracker-health problems surfaced first. Remediate in qui — siblings are read-only here.`
+		: "Surface qui's cross-seed sibling graph across your library and flag tracker-health problems.";
 
 	return (
 		<PremiumPageHeader
 			label="qui Integration"
 			labelIcon={Network}
-			title="Cross-Seed Discovery"
+			title="Cross-Seed Health"
 			gradientTitle
 			description={description}
 			actions={
-				onRefresh ? (
-					<Button variant="secondary" onClick={onRefresh} disabled={isRefreshing}>
-						<RefreshCw
-							className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
-							aria-hidden
-						/>
-						Rescan
-					</Button>
+				onRefresh || quiOpenUrl ? (
+					<div className="flex items-center gap-2">
+						{quiOpenUrl ? (
+							<Button
+								variant="ghost"
+								onClick={() => window.open(quiOpenUrl, "_blank", "noopener,noreferrer")}
+							>
+								<ExternalLink className="mr-2 h-4 w-4" aria-hidden />
+								Open in qui
+							</Button>
+						) : null}
+						{onRefresh ? (
+							<Button variant="secondary" onClick={onRefresh} disabled={isRefreshing}>
+								<RefreshCw
+									className={`mr-2 h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+									aria-hidden
+								/>
+								Rescan
+							</Button>
+						) : null}
+					</div>
 				) : undefined
 			}
 		/>

--- a/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
@@ -19,7 +19,11 @@ import {
 	PremiumPageLoading,
 } from "../../../components/layout";
 import { Alert, AlertDescription, Button } from "../../../components/ui";
-import { useCrossSeedAvailability, useCrossSeedDiscovery } from "../../../hooks/api/useQui";
+import {
+	useCrossSeedAvailability,
+	useCrossSeedDiscovery,
+	useTrackerIcons,
+} from "../../../hooks/api/useQui";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { CrossSeedBulkToolbar } from "./cross-seed-bulk-toolbar";
 import { CrossSeedItemCard } from "./cross-seed-item-card";
@@ -62,6 +66,10 @@ export const CrossSeedClient = () => {
 		availability.data?.available === true ? availability.data : null;
 
 	const discovery = useCrossSeedDiscovery(Boolean(isAvailable), SCAN_BATCH_SIZE);
+
+	// Same tracker-identity registry the library grid uses. Soft-fails to
+	// undefined (the card then renders the bare hostname per sibling).
+	const trackerIcons = useTrackerIcons().data?.trackers;
 
 	const aggregate = useMemo(() => {
 		if (!discovery.data) return { items: [], scanned: 0, found: 0, siblingFetchErrors: 0 };
@@ -293,6 +301,7 @@ export const CrossSeedClient = () => {
 							<CrossSeedItemCard
 								key={item.libraryCacheId}
 								item={item}
+								trackerIcons={trackerIcons}
 								animationDelay={Math.min(idx, 12) * 30}
 								isSelected={selectedIds.has(item.libraryCacheId)}
 								onToggleSelect={

--- a/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
@@ -24,6 +24,14 @@ interface CrossSeedItemCardProps {
 	 * visible but is not selectable.
 	 */
 	selectDisabled?: boolean;
+	/**
+	 * qui's tracker-meta map (hostname → {iconUrl, name}) — the same registry
+	 * the library grid uses as the single source of truth for tracker
+	 * identity. Resolves each sibling's hostname to a brand icon + friendly
+	 * name. Undefined until the icons query resolves; falls back to the bare
+	 * hostname per-entry.
+	 */
+	trackerIcons?: Record<string, { iconUrl?: string; name?: string }>;
 }
 
 const MATCH_TYPE_COPY: Record<QuiCrossSeedMatch["matchType"], { label: string; tone: string }> = {
@@ -38,6 +46,7 @@ export const CrossSeedItemCard = ({
 	isSelected = false,
 	onToggleSelect,
 	selectDisabled = false,
+	trackerIcons,
 }: CrossSeedItemCardProps) => {
 	const [incognito] = useIncognitoMode();
 
@@ -109,9 +118,14 @@ export const CrossSeedItemCard = ({
 						<ul className="space-y-1.5">
 							{item.siblings.map((sibling) => {
 								const matchCopy = MATCH_TYPE_COPY[sibling.matchType];
+								// Resolve tracker identity through qui's registry (icon +
+								// friendly name), the same way the library grid does. In
+								// incognito we deliberately skip the registry so neither the
+								// brand name nor its icon leaks — `getLinuxIndexer` masks it.
+								const trackerMeta = incognito ? undefined : trackerIcons?.[sibling.tracker];
 								const trackerLabel = incognito
 									? getLinuxIndexer(sibling.tracker)
-									: sibling.tracker || "unknown tracker";
+									: (trackerMeta?.name ?? sibling.tracker) || "unknown tracker";
 								const siblingInstance = incognito
 									? getLinuxInstanceName(sibling.instanceName)
 									: sibling.instanceName;
@@ -123,7 +137,17 @@ export const CrossSeedItemCard = ({
 											"border border-border/30 bg-card/20 px-2.5 py-1.5",
 										)}
 									>
-										<span className="font-medium text-foreground/90">{trackerLabel}</span>
+										<span className="flex items-center gap-1.5 font-medium text-foreground/90">
+											{trackerMeta?.iconUrl ? (
+												<img
+													src={trackerMeta.iconUrl}
+													alt=""
+													aria-hidden
+													className="h-3.5 w-3.5 rounded-sm object-contain"
+												/>
+											) : null}
+											{trackerLabel}
+										</span>
 										<span className="text-muted-foreground/70">·</span>
 										<span className="text-muted-foreground">{siblingInstance}</span>
 										<span className="text-muted-foreground/70">·</span>

--- a/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
@@ -34,10 +34,39 @@ interface CrossSeedItemCardProps {
 	trackerIcons?: Record<string, { iconUrl?: string; name?: string }>;
 }
 
-const MATCH_TYPE_COPY: Record<QuiCrossSeedMatch["matchType"], { label: string; tone: string }> = {
-	release: { label: "release-name match", tone: "text-emerald-300" },
-	content_path: { label: "content-path match", tone: "text-sky-300" },
-	name: { label: "torrent-name match", tone: "text-amber-300" },
+// Match type is *how* qui correlated the sibling — useful provenance, but low
+// signal day-to-day (most matches are `name`). Demoted to a quiet chip; the
+// tone-coded labels were misreading as warnings (amber `name` looked alarming
+// when it's the normal case). Kept with an explanatory tooltip instead.
+const MATCH_TYPE_LABEL: Record<QuiCrossSeedMatch["matchType"], string> = {
+	release: "release match",
+	content_path: "content-path match",
+	name: "name match",
+};
+
+const MATCH_TYPE_HINT: Record<QuiCrossSeedMatch["matchType"], string> = {
+	release: "qui matched these by release name — highest confidence.",
+	content_path: "qui matched these by on-disk content path — the copies share a location.",
+	name: "qui matched these by torrent name. Common when cross-seeds live at different paths.",
+};
+
+// Tracker health is the page's primary signal — surfaced as a prominent badge.
+// `unregistered` is actionable (dead cross-seed); `tracker_down` is usually
+// transient. Remediation happens in qui (siblings are read-only here per D7).
+const HEALTH_COPY: Record<
+	NonNullable<QuiCrossSeedMatch["trackerHealth"]>,
+	{ label: string; className: string; hint: string }
+> = {
+	unregistered: {
+		label: "Unregistered",
+		className: "bg-red-500/15 text-red-300 border-red-500/30",
+		hint: "The tracker no longer recognizes this torrent — likely a dead cross-seed. Remove it from qui to reclaim the entry (your library files stay; they belong to the primary torrent).",
+	},
+	tracker_down: {
+		label: "Tracker down",
+		className: "bg-amber-500/15 text-amber-300 border-amber-500/30",
+		hint: "The tracker is currently unreachable. Usually transient — no action needed unless it persists.",
+	},
 };
 
 export const CrossSeedItemCard = ({
@@ -58,8 +87,15 @@ export const CrossSeedItemCard = ({
 		? getLinuxInstanceName(item.primary?.qbitInstanceName ?? "")
 		: item.primary?.qbitInstanceName;
 
+	const attentionCount = item.siblings.filter((s) => s.trackerHealth).length;
+	const needsAttention = attentionCount > 0;
+
 	return (
-		<GlassmorphicCard padding="md" animationDelay={animationDelay}>
+		<GlassmorphicCard
+			padding="md"
+			animationDelay={animationDelay}
+			className={cn(needsAttention && "ring-1 ring-amber-500/40")}
+		>
 			<div className="flex items-start gap-3">
 				{onToggleSelect ? (
 					// Selection mode (Phase 4.2). The checkbox sits in the icon
@@ -97,6 +133,14 @@ export const CrossSeedItemCard = ({
 						</h3>
 						<ServiceBadge service={item.arrService} />
 						<span className="text-xs text-muted-foreground">{displayInstance}</span>
+						{needsAttention ? (
+							<span
+								className="rounded-full border border-amber-500/30 bg-amber-500/15 px-2 py-0.5 text-[10px] font-semibold text-amber-300"
+								title={`${attentionCount} cross-seed sibling${attentionCount === 1 ? "" : "s"} need attention`}
+							>
+								Needs attention
+							</span>
+						) : null}
 					</div>
 
 					{item.primary ? (
@@ -117,7 +161,6 @@ export const CrossSeedItemCard = ({
 						</div>
 						<ul className="space-y-1.5">
 							{item.siblings.map((sibling) => {
-								const matchCopy = MATCH_TYPE_COPY[sibling.matchType];
 								// Resolve tracker identity through qui's registry (icon +
 								// friendly name), the same way the library grid does. In
 								// incognito we deliberately skip the registry so neither the
@@ -129,12 +172,13 @@ export const CrossSeedItemCard = ({
 								const siblingInstance = incognito
 									? getLinuxInstanceName(sibling.instanceName)
 									: sibling.instanceName;
+								const health = sibling.trackerHealth ? HEALTH_COPY[sibling.trackerHealth] : null;
 								return (
 									<li
 										key={`${sibling.instanceId}-${sibling.hash}`}
 										className={cn(
-											"flex items-center gap-2 text-xs rounded-lg",
-											"border border-border/30 bg-card/20 px-2.5 py-1.5",
+											"flex items-center gap-2 text-xs rounded-lg px-2.5 py-1.5 border",
+											health ? "border-amber-500/30 bg-amber-500/5" : "border-border/30 bg-card/20",
 										)}
 									>
 										<span className="flex items-center gap-1.5 font-medium text-foreground/90">
@@ -150,14 +194,25 @@ export const CrossSeedItemCard = ({
 										</span>
 										<span className="text-muted-foreground/70">·</span>
 										<span className="text-muted-foreground">{siblingInstance}</span>
-										<span className="text-muted-foreground/70">·</span>
-										<span className={cn("font-medium", matchCopy.tone)}>{matchCopy.label}</span>
-										{sibling.trackerHealth ? (
-											<>
-												<span className="text-muted-foreground/70">·</span>
-												<span className="text-red-300/90">{sibling.trackerHealth}</span>
-											</>
+										{health ? (
+											<span
+												className={cn(
+													"rounded border px-1.5 py-0.5 text-[10px] font-semibold",
+													health.className,
+												)}
+												title={health.hint}
+											>
+												{health.label}
+											</span>
 										) : null}
+										{/* Match type is provenance, not a signal — demoted to a
+										    quiet chip pushed to the row's end, tooltip on hover. */}
+										<span
+											className="ml-auto rounded bg-card/40 px-1.5 py-0.5 text-[10px] text-muted-foreground/60"
+											title={MATCH_TYPE_HINT[sibling.matchType]}
+										>
+											{MATCH_TYPE_LABEL[sibling.matchType]}
+										</span>
 									</li>
 								);
 							})}
@@ -165,11 +220,10 @@ export const CrossSeedItemCard = ({
 					</div>
 				</div>
 				{/*
-				 * Deep-link to qui omitted in v1 — qui doesn't expose a stable
-				 * per-torrent URL we can construct without knowing the
-				 * operator's qui webroot. Add the affordance when we resolve a
-				 * canonical deep-link shape (currently tracked in arc doc as
-				 * Phase 6 polish).
+				 * No per-row "Open in qui": qui exposes no stable per-torrent URL,
+				 * so every link would resolve to the same qui home page. The bridge
+				 * to qui lives once in the page header (CrossSeedClient) instead —
+				 * honest about the grain we actually have.
 				 */}
 			</div>
 		</GlassmorphicCard>

--- a/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
@@ -9,6 +9,7 @@ import {
 	getLinuxIsoName,
 	useIncognitoMode,
 } from "../../../lib/incognito";
+import { resolveHostnameBrand } from "../../../lib/tracker-brand";
 import { cn } from "../../../lib/utils";
 
 interface CrossSeedItemCardProps {
@@ -161,14 +162,17 @@ export const CrossSeedItemCard = ({
 						</div>
 						<ul className="space-y-1.5">
 							{item.siblings.map((sibling) => {
-								// Resolve tracker identity through qui's registry (icon +
-								// friendly name), the same way the library grid does. In
-								// incognito we deliberately skip the registry so neither the
-								// brand name nor its icon leaks — `getLinuxIndexer` masks it.
-								const trackerMeta = incognito ? undefined : trackerIcons?.[sibling.tracker];
+								// Resolve tracker identity through the canonical helper so apex-
+								// domain customizations (e.g. `beyond-hd.me`) still match a sibling
+								// whose announce host is `tracker.beyond-hd.me`. In incognito we
+								// deliberately skip the registry so neither the brand name nor its
+								// icon leaks — `getLinuxIndexer` masks it.
+								const trackerBrand = incognito
+									? null
+									: resolveHostnameBrand(sibling.tracker, trackerIcons);
 								const trackerLabel = incognito
 									? getLinuxIndexer(sibling.tracker)
-									: (trackerMeta?.name ?? sibling.tracker) || "unknown tracker";
+									: trackerBrand?.name || "unknown tracker";
 								const siblingInstance = incognito
 									? getLinuxInstanceName(sibling.instanceName)
 									: sibling.instanceName;
@@ -182,9 +186,9 @@ export const CrossSeedItemCard = ({
 										)}
 									>
 										<span className="flex items-center gap-1.5 font-medium text-foreground/90">
-											{trackerMeta?.iconUrl ? (
+											{trackerBrand?.iconUrl ? (
 												<img
-													src={trackerMeta.iconUrl}
+													src={trackerBrand.iconUrl}
 													alt=""
 													aria-hidden
 													className="h-3.5 w-3.5 rounded-sm object-contain"

--- a/packages/shared/src/types/qui.ts
+++ b/packages/shared/src/types/qui.ts
@@ -333,6 +333,12 @@ export const quiCrossSeedMatchSchema = z.object({
 	category: z.string().default(""),
 	savePath: z.string(),
 	contentPath: z.string(),
+	/**
+	 * Tracker *hostname* only (e.g. `tracker.example.com`). The backend strips
+	 * the path/query from qBittorrent's raw announce URL before sending this,
+	 * because that URL embeds the user's private passkey. Never carries a
+	 * secret; `""` when the host couldn't be derived.
+	 */
 	tracker: z.string(),
 	trackerHealth: z.enum(["unregistered", "tracker_down"]).optional(),
 	matchType: quiCrossSeedMatchTypeSchema,


### PR DESCRIPTION
## Summary

Reframes the cross-seed page as an **integrity lens** — what qBittorrent thinks about the cross-seeds *arr already knows about — and hardens the tracker-passkey privacy boundary in passing. Three commits:

- **`a1f07b9e fix(cross-seed): strip tracker passkeys from sibling display`** — moves `extractHostnameSafe` into `lib/qui/client-helpers.ts` as the canonical helper (re-exported from `qui-shared.ts` for route compatibility) and applies it inside `wireCrossSeedMatchSchema.transform` so every cross-seed consumer inherits the strip at the validation boundary, never the raw qBit announce URL. Documents the `tracker` field as hostname-only on the shared schema. Adds unit tests for `extractHostnameSafe` covering passkey-in-path, passkey-in-query, basic-auth userinfo, UDP trackers, and unparseable input (fail-closed to `""`). Adds a defense-in-depth `JSON.stringify(matches).not.toContain(SECRET)` assertion at the client layer.
- **`5bd75f91 feat(cross-seed): reframe page as a cross-seed integrity lens`** — UI refactor of `cross-seed-client.tsx` + `cross-seed-item-card.tsx` on top of the strip. Demotes match-type from a tone-coded warning chip (the amber `name`-match was misreading as a problem when it's the normal case) to a quiet provenance chip with hover hint. Surfaces `trackerHealth` as the primary signal. Adds an "Open in qui" header bridge (no per-row link — qui has no stable per-torrent URL, so every row would resolve to the same home page). Skips the tracker-icon registry in incognito so neither brand name nor icon leaks.
- **`65e98916 fix(cross-seed): use canonical brand resolver + pin passkey contract`** — review-driven fixup. Swaps an ad-hoc `trackerIcons?.[sibling.tracker]` lookup for `resolveHostnameBrand` so apex-domain customizations (`beyond-hd.me`) match siblings whose announce host is `tracker.beyond-hd.me`. Pins the passkey-leak contract at two layers: a render test on `<CrossSeedItemCard>` asserting the DOM contains no `/announce`/`passkey=`/40-hex substring, and a response-body assertion in `qui-routes.test.ts` for the cross-seed route. Tightens the mock to the post-wire-transform shape (hostname-only `tracker`) so a future "fix" feeding pre-transform data trips the assertion.

## Out of scope (filed separately)

- **#491 — `/qui/instances/:id/qbit/:instanceId/torrents/:hash/trackers` returns raw passkey-bearing URLs.** Pre-existing on `main`; same threat model as this branch's privacy fix but lives in a different route. Surfaced by code review during the post-fix multi-agent pass on this branch.

## Test plan

- [x] `pnpm run typecheck` — 3/3 turbo tasks green
- [x] `pnpm run test` — 2017 tests pass (no failures)
- [x] `pnpm run lint` — 0 errors
- [x] Multi-agent review pass (code-reviewer + security + test-analyzer) on the post-fixup branch — security verdict: safe to merge; one apex-domain UX bug found + fixed in `65e98916`; defense-in-depth gaps closed by `65e98916`'s two test pins
- [ ] Manual walkthrough of the integrity-lens UI against a live cross-seed setup (recommended before tagging a release; the render test exercises the rendering path but not the visual hierarchy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)