### PR TITLE
security(qui): strip raw passkey from trackers route response (#491)

### DIFF
--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -234,9 +234,32 @@ describe("GET /qui/instances/:id/torrents/by-hash/:hash", () => {
 });
 
 describe("GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/trackers", () => {
-	it("returns trackers filtered to real trackers only", async () => {
+	it("returns trackers filtered to real trackers only, with passkey URLs stripped to hostnames (#491)", async () => {
+		// Mock the INTERNAL shape `getTrackers` resolves to (carries the raw
+		// announce URL with passkey embedded). The route is responsible for
+		// stripping it before serializing — this test pins that contract end
+		// to end so any future regression to a passthrough trips it.
 		mockQuiClient.getTrackers.mockResolvedValue([
-			{ url: "http://tracker.example:6969/announce", status: 1, health: "healthy" },
+			{
+				url: "https://tracker.example.org/abcdef0123456789abcdef0123456789abcdef01/announce",
+				status: 2,
+				health: "working",
+				msg: "",
+				numSeeds: 1,
+				numLeeches: 0,
+				numPeers: 1,
+				tier: 0,
+			},
+			// Pseudo-tracker (DHT/PeX/LSD) — must be filtered out.
+			{
+				url: "** [DHT] **",
+				status: 0,
+				health: "working",
+				msg: "",
+				numSeeds: 0,
+				numLeeches: 0,
+				numPeers: 0,
+			},
 		]);
 		const res = await injectAuthenticated(
 			"GET",
@@ -245,6 +268,19 @@ describe("GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/trackers", () =
 		expect(res.statusCode).toBe(200);
 		const body = JSON.parse(res.payload);
 		expect(body.trackers).toHaveLength(1);
+
+		// Positive contract: the route exposes hostname, never the raw URL.
+		expect(body.trackers[0].hostname).toBe("tracker.example.org");
+		expect(body.trackers[0]).not.toHaveProperty("url");
+
+		// Defense-in-depth on the whole payload: no URL form, no `/announce`,
+		// no `passkey=` anywhere — catches a regression that re-introduces the
+		// raw URL via a sibling field, error path, or future extension.
+		expect(res.payload).not.toMatch(/https?:\/\//i);
+		expect(res.payload).not.toMatch(/\/announce/);
+		expect(res.payload).not.toMatch(/passkey/i);
+		// The passkey itself (40-hex from the mock) must not appear anywhere.
+		expect(res.payload).not.toContain("abcdef0123456789abcdef0123456789abcdef01");
 	});
 
 	it("returns 400 for invalid hash", async () => {

--- a/apps/api/src/routes/qui/torrent-routes.ts
+++ b/apps/api/src/routes/qui/torrent-routes.ts
@@ -41,8 +41,16 @@ export function registerTorrentRoutes(app: FastifyInstance): void {
 			const instance = await requireQuiInstance(app, userId, id);
 			const client = createQuiClient(app, instance);
 			const trackers = await client.getTrackers(qbitInstanceId, hash);
-			// Filter pseudo-trackers (DHT/PeX/LSD) from the visible list.
-			const realTrackers = trackers.filter((t) => !t.url.startsWith("** "));
+			// Filter pseudo-trackers (DHT/PeX/LSD) from the visible list, then
+			// strip the raw announce URL — it embeds the user's tracker passkey,
+			// which is effectively a credential and an ejection-worthy leak on
+			// most private trackers (#491). Replace with the hostname so the
+			// response is safe to render, screenshot, or capture in a HAR.
+			// Mutation routes (add/remove/edit) re-fetch the original URL
+			// server-side when qBit needs it, so the wire never carries it.
+			const realTrackers = trackers
+				.filter((t) => !t.url.startsWith("** "))
+				.map(({ url, ...rest }) => ({ ...rest, hostname: extractHostnameSafe(url) }));
 			return reply.send({ trackers: realTrackers });
 		},
 	);

--- a/packages/shared/src/types/qui.ts
+++ b/packages/shared/src/types/qui.ts
@@ -300,9 +300,14 @@ export const quiTransferInfoSchema = z.object({
 export type QuiTransferInfo = z.infer<typeof quiTransferInfoSchema>;
 
 /**
- * Tracker entry for a torrent. `status` is the raw qBit int (kept for diagnostics);
- * `health` is the friendly mapping the UI renders. `tier` is optional because
- * qui omits it for pseudo-trackers like DHT/PeX/LSD.
+ * Tracker entry for a torrent — INTERNAL backend shape. `url` is the raw qBit
+ * announce URL with the user's tracker passkey embedded; the backend keeps it
+ * so the remove/edit mutations can match by exact URL. **Do NOT expose this
+ * shape to the wire as-is** — the GET `/torrents/:hash/trackers` route maps
+ * it to a hostname-only response shape (see torrent-routes.ts) so the passkey
+ * never leaks. `status` is the raw qBit int (kept for diagnostics); `health`
+ * is the friendly mapping the UI renders. `tier` is optional because qui
+ * omits it for pseudo-trackers like DHT/PeX/LSD.
  */
 export const quiTrackerSchema = z.object({
 	url: z.string(),


### PR DESCRIPTION
## Summary

Fixes #491. The `GET /qui/instances/:id/qbit/:instanceId/torrents/:hash/trackers` endpoint returned the raw qBittorrent announce URL — including the user's tracker passkey — in each tracker entry's `url` field. The route is auth-gated, but the secret still lands in browser devtools, HAR captures, and proxy logs — surfaces incognito mode cannot mask in API bodies. On most private trackers, passkey leakage is an ejection-worthy offense.

## Approach

Route-level mapping, not schema-level removal. `QuiTracker` (with `url`) is kept as the internal backend shape because the **remove and edit mutations match qBit by exact URL** and need the original to do their work (`torrent-routes.ts:262-263`, `308-312`). The leaking GET route now projects `{url, ...rest}` → `{hostname: extractHostnameSafe(url), ...rest}` before sending. A doc-comment on `quiTrackerSchema` marks it INTERNAL-only so a future frontend consumer doesn't import it expecting the wire shape.

No frontend changes required — verified by grep that `apps/web/src/lib/api-client/qui.ts` has no `fetchQuiTrackers`-style consumer of this endpoint. The mutation routes (`/trackers/add|remove|edit`) already operate by hostname client-side.

## Test plan

- [x] `pnpm run typecheck` — 3/3 turbo tasks green
- [x] `pnpm run test` — 2017 tests pass (no failures)
- [x] `pnpm run lint` — 0 errors
- [x] Existing trackers route test extended with the full internal `QuiTracker` mock shape (including a `** [DHT] **` pseudo-tracker to pin the pre-existing filter) and **four response-body regression assertions**: hostname is present, `url` is absent, no `https?://` / `/announce` / `passkey` substring in the payload, and the 40-hex mock passkey itself never appears in `res.payload`.
- [x] **Manual `curl` against a live setup verified post-merge** — exercised against a real qui instance with a real qBit (10,593 torrents indexed). Response had `hostname` (non-empty), zero `url` field, zero `https?://`, zero `/announce`, zero `passkey`, zero 40-hex tokens. See verification comment below.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)
