### PR TITLE
docs: introduce 3.0 charter — trust-layer / operator console release plan

### DIFF
--- a/docs/3.0-charter.md
+++ b/docs/3.0-charter.md
@@ -273,11 +273,12 @@ How we know 3.0 shipped well:
 
 ## 10. Stale Memory to Prune (Charter Ratification Housekeeping)
 
-These memory files diverged from repo state during 2.x and should be closed or archived as part of charter ratification:
+The auto-memory layer drifted from repo state during 2.x. The pruning happens against `~/.claude/projects/-home-khak1s-arr-dashboard/memory/`, not against the repo.
 
-- `v2.9-feature-plan.md` — all 3 features shipped (Zod for TRaSH GitHub, naming deployment, profile groups UI); archive as `v2.9-retrospective.md`
-- `qui-integration-arc.md` — qui landed on `main` as #475 in v2.20; rewrite as `qui-integration-history.md` or close
-- `auto-tagger-arc.md` — sub-arc 4 partly landed (#403, #399); update to reflect actual status or close
+- **`MEMORY.md` — "v2.9 Feature Plan" inline section.** Refers to a `v2.9-feature-plan.md` file that no longer exists; the inline bullets list features that all shipped in v2.9+ (Zod for TRaSH GitHub data, naming deployment, profile groups UI). Remove the section from the index entirely.
+- **`qui-integration-arc.md`.** Body still says "no merge to `main` until the entire qui feature is built" and treats Phase 1.1 as the latest merge. qui actually landed on `main` as #475 in v2.20. Add a STATUS notice at the top recording the merge + tagged release; update MEMORY.md description accordingly.
+- **`tautulli-deprecation-plan.md`.** Superseded by this charter (Tautulli is now outright-removed in 3.0, not phased-deprecated). Add a STATUS notice pointing readers at `docs/3.0-charter.md` §6.1; update MEMORY.md description accordingly.
+- **`MEMORY.md` — Auto-Tagger arc description (line 121).** Says sub-arc 4 "is fully designed but not implemented"; the arc file itself correctly says it shipped via #403 in 2.18.0. The index is the stale layer; update the MEMORY.md description, leave the arc body alone.
 
 ---
 

--- a/docs/3.0-charter.md
+++ b/docs/3.0-charter.md
@@ -1,0 +1,312 @@
+# arr-dashboard 3.0 Charter
+
+**Status:** DRAFT v0
+**Date:** 2026-06-04
+**Owner:** @khak1s
+**Branch:** `next` (cut from `main` at ratification)
+**Target window:** 6–12 months from ratification; continuous preview tags
+
+---
+
+## 1. Thesis
+
+arr-dashboard 3.0 is the release where the app stops being a viewer over *arr APIs and becomes the **trust layer and operator console** for self-hosted media stacks.
+
+The 2.x line built the pieces — domain status taxonomy, data freshness, route surface governance, scheduler reliability, validation health, Pulse, qui integration, cross-seed integrity lens, statistics accuracy hardening. These are not disconnected features. They are consistent investments in **signal accuracy** and **operator workflows**. 3.0 names the trajectory, makes the patterns universal, removes the legacy parts that resist it, and ships two named surfaces (Operator Console and Tracearr) that make the thesis literal.
+
+**Scope-debate shorthand:** *"does this strengthen the trust layer?"* If yes, scope. If no, defer to 3.1+.
+
+**What 3.0 demotes:** cosmetic-only UI features, social/sharing features, "more integrations for breadth's sake," any work that doesn't strengthen signal accuracy or operator control.
+
+**What 3.0 promotes:** signal accuracy, observability primitives applied universally, operator-facing automation the user can trust to do the right thing without watching it.
+
+---
+
+## 2. Flagships
+
+Two named surfaces. Plus one major rewrite as a "supporting feature."
+
+### 2.1 Operator Console (with embedded rule composer)
+
+A new top-level page that makes the trust-layer thesis literal. One canonical view of every domain's health + freshness + next-scheduled-action, with one-click operator actions and an embedded composer for the Unified Automation Engine (§5.2).
+
+**Surfaces in 3.0:**
+- Per-domain health badge (`DomainStatusBadge`) + freshness (`DataFreshness`) + next-scheduled-action
+- Pulse needs-attention rollup as the action feed
+- Tracearr live sessions count + recent activity
+- One-click operator actions: refresh sync, retry failed item, dismiss notification, kill session
+- Embedded rule composer for the Unified Automation Engine (cross-domain rules, dry-run preview, deploy)
+
+**Design constraint:** Console hosts both live-status and composer surfaces, so plan for tabs or split-panels from the start — not a one-screen dashboard.
+
+### 2.2 Tracearr integration (full read + write parity)
+
+Tracearr replaces Tautulli as the canonical analytics integration. Plex / Jellyfin / Emby continue to provide live-session data via native APIs; Tracearr provides historical analytics, leaderboards, account-sharing detection, and operator actions.
+
+**Surfaces in 3.0:**
+- Backend client (`apps/api/src/lib/tracearr/`)
+- Routes (`apps/api/src/routes/tracearr/`)
+- `Service.type = TRACEARR` enum addition (Prisma)
+- Connection tester, settings UI, validation health entry
+- Read: sessions, history, leaderboards, transcode analytics, trust scores
+- Write: stream termination, bulk actions on Tracearr-side users/rules, trust-score actions
+- Statistics rewritten on Tracearr (overview-tab + all `useTautulliStats` / `useTautulliPlaysByDate` consumers)
+- SessionSnapshot helpers in (renamed) `media-stats/` adapted to Tracearr-shaped data
+
+### 2.3 Setup rewrite (supporting feature, pulled in from 3.1)
+
+First-impression product surface, rewritten end-to-end to match the trust-layer thesis.
+
+**Surfaces in 3.0:**
+- Full guided first-time UX with progressive disclosure
+- Service auto-detection for media servers (Plex / Jellyfin / Emby / Tracearr) via SSDP / GDM / mDNS
+- *arr services remain manual entry (no canonical service-discovery protocol — port-scanning is out of scope)
+- Opinionated TRaSH Guides defaults applied at setup
+- Sample notifications + Auto-Tag + Label Sync rules pre-seeded as starting points
+- Walkthrough of the Operator Console for new users
+- Tautulli first-boot wizard (§6.1) shares the same component family
+
+---
+
+## 3. What 3.0 Commits To — The Three Buckets
+
+Ordered by irreversibility. Bucket A lands first on `next` as a self-contained early phase; B and C interleave afterward.
+
+### Bucket A — Breaking-changes bundle
+
+Bundle, do not trickle. All breaking changes land together so users absorb the disruption once.
+
+| # | Change | Rationale |
+|---|---|---|
+| A1 | **Route-manifest tier reshuffle.** Auto-Tagger / Label Sync / Hunting / Queue Cleaner / TRaSH Guides promote per ADR-0005. Tautulli removed entirely. qui (and Cross-seed) promote `experimental` → `stable`. | Tiers diverged from maturity; honest tiers make tier-based decisions safe. |
+| A2 | **Tautulli removal.** All `routes/tautulli/`, `lib/tautulli/`, hooks, schemas, settings UI, env vars, and `Service.type === TAUTULLI` Prisma handling deleted. First-boot wizard migrates remaining DB instances (§6.1). | Inventory confirms Tautulli is the least-used media-server integration (6 sub-routes vs Plex's 33, Jellyfin's 14). Tracearr provides full coverage replacement. |
+| A3 | **Rename `apps/api/src/routes/plex/lib/` → `apps/api/src/lib/media-stats/`.** | Directory name lies about its purpose — Jellyfin already imports `aggregateTopMedia` etc. from `plex/lib/`. One importer, one codemod. |
+| A4 | **Unified Automation Engine.** All five rule/predicate engines (Notifications, library-cleanup, Queue Cleaner, Hunting filters, Auto-Tagger transitively) unified on one rule grammar. Stored-rule migrations for each surface ship together. See ADR-0006. | Inventory found 5 parallel DSLs across operations workflows. Notifications is `stable` tier so any unification is breaking; bundle for 3.0 or never. |
+| A5 | **Drop dev scripts from `apps/api/src/lib/queue-cleaner/`.** Removes `analyze-status-patterns.ts`, `test-arr-integration.ts`, `test-lidarr-integration.ts`, `test-live-import.ts`. | Production lib tree should not ship dev scripts; accounts for 26 of the codebase's `console.*` instances. |
+| A6 | **Inline `Body:` typing → `validateRequest`.** Migrate 6 TRaSH deployment routes (`deployment-routes.ts:26,75,137,218,290,380`), `system.ts` PUT `/settings`, and the backup download endpoint. | Validation bypass via inline `Body:` generic typing is the same trust hole as `as Type`, different syntax. Forced migration closes the gap. |
+
+**Not in this bucket:** broad Prisma schema renames, env-var defaults reshuffle, URL/IA reshuffle. None surfaced as load-bearing in the inventory.
+
+### Bucket B — Coherence sweep
+
+Six PRs retroactively applying formalized primitives across all relevant surfaces. Each sweep is independently mergeable; ordering is by leverage (most domains touched per PR first).
+
+| # | Sweep | Primitive | Surface count |
+|---|---|---|---|
+| B1 | Centralized query-keys migration | `apps/web/src/lib/query-keys.ts` | ~12 hooks |
+| B2 | SEMANTIC_COLORS replacing hex | `apps/web/src/lib/theme-gradients.ts` | ~70 hits |
+| B3 | premium-components on TRaSH ecosystem | `apps/web/src/components/layout/premium-components.tsx` | 45+ components |
+| B4 | `DataFreshness` adoption across polling surfaces | `apps/web/src/components/layout/data-freshness.tsx` | ~15 surfaces |
+| B5 | `DomainStatusBadge` adoption across status-bearing surfaces | `apps/web/src/components/layout/domain-status.tsx` | ~12 surfaces |
+| B6 | `useIncognitoMode` sweep — anchor: Manual Import (0/9 today) | `apps/web/src/contexts/IncognitoContext.tsx` | ~10 surfaces |
+
+**Carve-out:** `appearance-preview.tsx` is exempt from sweep B2 — its 44 inline hex values fake browser chrome (window borders, address bars) and SEMANTIC_COLORS doesn't fit. Mark with an inline comment + ESLint-disable.
+
+### Bucket C — Arcs to close
+
+| # | Arc | Status |
+|---|---|---|
+| C1 | qui Phase 6: detail-drawer rename + tracker CRUD completion → graduate to `stable` | Cross-seed graduates alongside. |
+| C2 | Statistics rewrite on Tracearr | Last `useTautulliStats` / `useTautulliPlaysByDate` consumers re-targeted; SessionSnapshot helpers adapted to Tracearr-shaped data. |
+| C3 | Auto-Tagger sub-arc 4 closeout | List-membership runtime shipped (#403). Finish UI surfaces; close `auto-tagger-arc.md`. |
+| C4 | Pulse collector labels | Add `COLLECTOR_LABELS` entries for `collectMediaServerReachability` and `collectArrQueueFailures` (pulse.ts:57–69). |
+
+---
+
+## 4. What 3.0 Explicitly Does NOT Commit To
+
+Saying "no" in writing is what makes scope hold. Requests for any of these during the 3.0 cycle: **"out of scope, queued for 3.1+."**
+
+- Plex Labels Phase E (webhooks) — latency concern, not direction
+- Lidarr label sync support
+- Super-seed support in qui (upstream qui gap)
+- *arr service auto-detection (no canonical discovery protocol; out of scope for Setup rewrite)
+- Tracearr-side rule editing (use Tracearr UI directly for rule management)
+- Unified URL / IA reshuffle of `/calendar`, `/hunting`, etc.
+- Library Cleanup decomposition à la backup-service split — 3.1 work
+- New media-server integrations
+- New *arr integrations
+- Multi-user / multi-tenant (project remains single-admin self-hosted by design)
+
+---
+
+## 5. Architecture Decisions (ADRs)
+
+Four new ADRs ratify in 3.0 alongside the charter.
+
+### 5.1 ADR-0005 — Tier Discipline
+Documents what `stable` / `operator` / `internal` / `experimental` tiers commit to operationally and the criteria for promotion/demotion. Companion to ADR-0004 (route surface governance).
+
+### 5.2 ADR-0006 — Unified Rule Engine + Migration Policy
+Defines the unified rule grammar consumed by Notifications, library-cleanup, Queue Cleaner, Hunting filters, and Auto-Tagger. Specifies the migration policy: each surface's stored rules get a backup file written to `/config/rules-pre-3.0/<surface>.json` before mutation, with a dry-run preview surfaced through the Operator Console's composer.
+
+### 5.3 ADR-0007 — Tracearr Replaces Tautulli
+Records the decision to remove Tautulli outright in 3.0, the data-migration path (Tracearr's built-in Tautulli history import), and the first-boot wizard contract (§6.1).
+
+### 5.4 ADR-0008 — Setup Auto-Discovery Scope
+Records the decision that Setup auto-detection covers media servers (Plex / Jellyfin / Emby / Tracearr via SSDP / GDM / mDNS) only. *arr services remain manual entry. Rationale: port-scanning is privacy-loud and slow; no canonical *arr service-discovery protocol exists.
+
+---
+
+## 6. Migration Story
+
+Single-admin self-hosted means users don't read changelogs. Every breaking change ships with its migration in the same PR.
+
+### 6.1 Tautulli removal — first-boot blocking wizard
+
+No 2.21 warning banner ships. The 3.0 first-boot wizard absorbs the entire migration:
+
+**Trigger:** Any `Service` row where `type = TAUTULLI` exists in the DB at 3.0 boot.
+
+**Behavior:** App boots into a **blocking modal** — dashboard is unavailable until the user picks a path. The modal is not dismissible.
+
+**Three paths:**
+1. **Set up Tracearr (with Tautulli import).** Walks through Tracearr connection, runs Tracearr's built-in Tautulli history import against the user's existing Tautulli instance, then deletes the Tautulli `Service` rows. Recommended path.
+2. **Remove Tautulli config and continue without historical analytics.** Deletes Tautulli `Service` rows. Live-session data from Plex / Jellyfin / Emby continues to work. Statistics tabs surface "historical analytics unavailable — set up Tracearr in Settings" where Tautulli data used to live.
+3. **Cancel and stay on 2.x.** Closes the app cleanly. User can roll back to 2.x via Docker tag pinning.
+
+**No silent data loss.** Tautulli instance records are only deleted via explicit user choice.
+
+### 6.2 Unified Rule Engine — plural stored-rule migrations
+
+Five surfaces have stored rules that need migration: Notifications, library-cleanup, Queue Cleaner, Hunting filters, Auto-Tagger.
+
+**Per-surface contract** (per ADR-0006):
+1. On first 3.0 boot, write a backup file to `/config/rules-pre-3.0/<surface>.json`
+2. Migrate the surface's stored rules into the unified grammar
+3. Surface a one-time "Rules migrated — review in Operator Console" notification with a dry-run preview link
+4. Rollback path: stop 3.0, restore `<surface>.json` to the original location, downgrade Docker tag to last 2.x
+5. Document the per-surface migration table in `CHANGELOG.md`
+
+### 6.3 Other breaking changes
+
+| Change | Migration |
+|---|---|
+| Tier reshuffle | Automatic — manifest read at boot; no user action |
+| `plex/lib/` → `media-stats/` | Internal-only refactor; no user-visible change |
+| Dev scripts dropped | No user-visible change |
+| `Body:` → `validateRequest` | No user-visible behavior change. Previously-broken requests get 400 with validation details instead of 500. |
+
+---
+
+## 7. Lint Rules / Governance
+
+Four lint rules become CI gates in 3.0. They are the durable enforcement layer that prevents regression to the current state.
+
+### L1 — `no-inline-Body-without-validateRequest`
+Any Fastify route declaring `Body:` in its generic must call `validateRequest()` somewhere in the handler before destructuring `request.body`. Catches the validation bypass that doesn't use `as Type` syntax.
+
+### L2 — `require-collector-label-entry`
+Any collector registered in `apps/api/src/lib/pulse/collectors.ts` must have a matching entry in `COLLECTOR_LABELS` in `apps/api/src/routes/pulse.ts`. Promotes the existing `feedback_pulse_collector_labels` memory rule to CI enforcement.
+
+### L3 — `require-incognito-on-sensitive-text-props`
+JSX rendering titles / paths / instance names / URLs without `useIncognitoMode()` anonymization fails review. Implemented as a heuristic ESLint rule against a curated prop-name allowlist; false positives suppressed with an inline `// eslint-disable-next-line` that **requires a reason** in the comment.
+
+### L4 — `no-arbitrary-z-index`
+Inline `z-[NN]` is forbidden outside an explicit allowlist (the dashboard widget overlay arrows at `z-[1]` / `z-[2]`). Forces semantic z-index classes.
+
+**Additional lint considered for 3.1+:** `require-migration-on-rule-schema-change` — any change to a unified-rule-engine schema must include a corresponding migration entry. Deferred until the rule engine stabilizes.
+
+---
+
+## 8. Branch Strategy & Cadence
+
+### 8.1 Branches
+- **`next`** — long-lived 3.0 branch cut from `main` at charter ratification. Protected. PR-only merges.
+- **`main`** — continues to ship 2.x patches as needed (security fixes, regressions). No new features land on `main` during the 3.0 cycle.
+
+### 8.2 Preview tags
+- Nightly Docker tag `arr-dashboard:next` built from the `next` branch
+- Milestone tags as buckets land:
+  - `3.0-alpha.1` — Bucket A complete (all breaking changes landed and migrations tested)
+  - `3.0-alpha.2..N` — Bucket B sweep PRs land progressively
+  - `3.0-beta.1..N` — Flagships (Operator Console, Tracearr full parity, Setup rewrite) land
+  - `3.0-rc.1..N` — All buckets complete; bug-fixing window
+  - `3.0.0` — Release
+- Early-adopter testing happens against the preview tags; feedback rolls in throughout the cycle rather than concentrating at release
+
+### 8.3 Bucket sequencing
+1. **Bucket A (breaking) lands first** as a self-contained early phase. Rationale: if a breaking change has to be reverted, do it before sweep work piles on top of the broken foundation.
+2. **Bucket B (coherence sweep) follows**, one PR per primitive, each independently mergeable. Sweeps don't depend on each other.
+3. **Bucket C (arcs) interleaves with B** as appropriate. qui Phase 6 can land any time; Statistics rewrite waits for Tracearr to land.
+4. **Flagship surfaces (Operator Console, Tracearr, Setup) develop on parallel tracks** through the cycle. They don't depend on each other and can land in any order.
+
+### 8.4 Cutover criteria for 3.0.0
+- Zero open A/B/C items
+- All four lint rules green in CI, no waivers
+- Manual smoke test: fresh install + migration from latest 2.x with each path through the Tautulli wizard
+- All five unified-rule-engine migrations tested with realistic stored-rule fixtures
+- `arr-dashboard:next` Docker tag has run for ≥2 weeks with no major regressions reported
+
+---
+
+## 9. Success Criteria
+
+How we know 3.0 shipped well:
+
+### 9.1 Pattern adoption rates (from inventory baseline to target)
+- `DataFreshness` ≥ **90%** of polling surfaces (baseline ~15%)
+- `DomainStatusBadge` ≥ **90%** of status-bearing surfaces (baseline ~15%)
+- Centralized query-keys ≥ **95%** of hooks (baseline ~50%)
+- `useIncognitoMode` ≥ **95%** of sensitive-text-rendering components (baseline ~70%)
+- `SEMANTIC_COLORS` for all hex outside `appearance-preview` carve-out
+
+### 9.2 Trust-layer integrity
+- **Zero** routes bypassing `validateRequest` via inline `Body:` typing
+- **Zero** Pulse collectors without `COLLECTOR_LABELS` entries
+- All four lint rules green in CI for ≥ 4 weeks before release
+
+### 9.3 Migration integrity
+- Tautulli wizard produces **zero** support reports about lost data for 4 weeks post-release
+- All five unified-rule-engine migrations produce zero support reports about lost rules for 4 weeks post-release
+- Each surface's `/config/rules-pre-3.0/<surface>.json` backup file is verified present in post-migration support diagnostics
+
+### 9.4 Tier discipline
+- No domain ships at a tier mismatched to its maturity per ADR-0005 criteria
+- The route-manifest is the single source of truth; CI enforces manifest ↔ docs parity
+
+### 9.5 Release narrative
+- 3.0 release notes lead with **two named flagships** (Operator Console with composer, Tracearr) and **one rewrite** (Setup)
+- "Trust layer / operator console" appears as the thesis line in the release notes, README, DOCKERHUB, and the v3.0 wiki page
+
+---
+
+## 10. Stale Memory to Prune (Charter Ratification Housekeeping)
+
+These memory files diverged from repo state during 2.x and should be closed or archived as part of charter ratification:
+
+- `v2.9-feature-plan.md` — all 3 features shipped (Zod for TRaSH GitHub, naming deployment, profile groups UI); archive as `v2.9-retrospective.md`
+- `qui-integration-arc.md` — qui landed on `main` as #475 in v2.20; rewrite as `qui-integration-history.md` or close
+- `auto-tagger-arc.md` — sub-arc 4 partly landed (#403, #399); update to reflect actual status or close
+
+---
+
+## 11. Open Follow-ups (flagged during planning, not blocking ratification)
+
+These are known unknowns that should be answered during the cycle but don't block charter sign-off:
+
+- **Service auto-detection scope refinement** — what specific protocols (SSDP / GDM / mDNS / Bonjour) the Setup detector implements; UX for "we found these candidates, confirm?"
+- **Tracearr permission model mapping** — how arr-dashboard's single-admin model maps to Tracearr's API-key + per-action authorization
+- **Unified rule grammar specification** — the actual schema for the unified-rule-engine; needs design pass during Bucket A work
+- **Operator Console layout** — tabs / split-panels / accordion; needs UX design pass when the surface starts taking shape
+- **Sample-data seeding scope** — which Notifications, Auto-Tag, Label Sync rules pre-seed at first-time setup; the line between "helpful starting point" and "opinionated default"
+
+---
+
+## 12. Decision Log
+
+For traceability — the eleven load-bearing decisions ratified during charter drafting:
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Thesis | Trust layer / operator console |
+| 2 | Tautulli | Outright removal in 3.0 |
+| 3 | 2.21 warning banner | Skip entirely |
+| 4 | First-boot wizard behavior | Blocking modal |
+| 5 | No-analytics opt-out path | Included |
+| 6 | Tracearr API scope | Full read + write parity |
+| 7 | Rule-engine unification scope | All five engines (Unified Automation Engine) |
+| 8 | qui graduation | Full to `stable` |
+| 9 | Operator Console scope | Read + actions + rule composer (fuses with UAE) |
+| 10 | Setup rewrite scope | Auto-detection + full guided UX + sample data + opinionated defaults |
+| 11 | Release flow | Continuous `next` with preview tags |


### PR DESCRIPTION
## Summary
- Introduces `docs/3.0-charter.md` codifying the 11 ratified decisions from the 3.0 planning pass
- Output of a multi-agent domain inventory across 40 domains, a synthesis verdict table, and iterative decision-locking with the user
- Scopes the cycle around two named flagships (Operator Console with embedded rule composer, Tracearr integration) plus a Setup rewrite

## What's in the charter
- **§1 Thesis** — trust layer / operator console
- **§2 Flagships** — Operator Console (read + actions + composer), Tracearr (full read+write parity), Setup rewrite (auto-detection + guided UX)
- **§3 Three Buckets** — Bucket A (6 breaking changes incl. Tautulli removal + Unified Automation Engine), Bucket B (6 coherence sweeps), Bucket C (4 in-flight arcs to land)
- **§4 Non-commitments** — what 3.0 explicitly defers to 3.1+
- **§5 ADRs** — 0005 Tier Discipline, 0006 Unified Rule Engine + Migration Policy, 0007 Tracearr Replaces Tautulli, 0008 Setup Auto-Discovery Scope (stubbed; full docs land on `next` post-ratification)
- **§6 Migration Story** — blocking 3.0 first-boot wizard for Tautulli users; plural stored-rule migrations for the Unified Automation Engine
- **§7 Lint Rules** — four CI gates as the durable enforcement layer
- **§8 Branch Strategy & Cadence** — continuous `next` with preview tags (3.0-alpha → 3.0-beta → 3.0-rc → 3.0.0)
- **§9 Success Criteria** — quantitative targets for pattern adoption, trust-layer integrity, migration integrity, tier discipline
- **§10 Stale Memory** — three memory files identified for pruning as charter ratification housekeeping
- **§11 Open Follow-ups** — parking lot for known unknowns that need design passes during the cycle
- **§12 Decision Log** — traceability table for all 11 ratified decisions

## What happens after this merges
1. Cut `next` branch from `main` (this is the formal ratification step)
2. Author ADR-0005, 0006, 0007, 0008 as separate PRs onto `next`
3. Prune the three stale memory files (`v2.9-feature-plan.md`, `qui-integration-arc.md`, `auto-tagger-arc.md`)
4. Begin Bucket A breaking-changes work on `next`

## Review checklist
- [ ] Thesis (§1) accurately reflects what 3.0 should be
- [ ] Flagship surfaces (§2) sized appropriately for the cycle
- [ ] Bucket A breaking changes (§3) match what's worth the disruption budget
- [ ] Bucket B coherence sweeps (§3) cover the right primitives at the right surface counts
- [ ] Bucket C arcs (§3) match what's actually close to closeable
- [ ] What 3.0 does NOT commit to (§4) is the right "no" list
- [ ] Migration story (§6) covers all breaking-change paths with no silent data loss
- [ ] Lint rules (§7) are enforceable and worth the cost
- [ ] Success criteria (§9) are measurable and honest
- [ ] Decision log (§12) accurately captures the 11 ratified choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)