### PR TITLE
fix(auth): decouple OIDC presence from password/passkey gates (#498)

### DIFF
--- a/apps/api/src/routes/__tests__/auth-passkey.test.ts
+++ b/apps/api/src/routes/__tests__/auth-passkey.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -6,7 +6,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 
 const { mockSessionService } = vi.hoisted(() => ({
 	mockSessionService: {
-		createSession: vi.fn().mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSession: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -65,7 +67,7 @@ vi.mock("../../lib/auth/session-metadata.js", () => ({
 
 import Fastify from "fastify";
 import { registerAuthPasskeyRoutes } from "../auth-passkey.js";
-import { setupAuthInjection, createInjectAuthenticated } from "./test-helpers.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Test data
@@ -178,15 +180,19 @@ describe("POST /auth/passkey/register/options", () => {
 		expect(mockPasskeyService.generateRegistrationOptions).not.toHaveBeenCalled();
 	});
 
-	it("returns 403 when OIDC provider is enabled", async () => {
+	it("allows passkey registration even when an OIDC provider is enabled (#498)", async () => {
+		// Regression: the global "any enabled OIDC provider → other auth disabled"
+		// gate also blocked passkey registration, so a user setting up MFA with
+		// passkeys after configuring OIDC was rejected. Passkey registration must
+		// still work for users with a password set, regardless of OIDC.
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({ id: 1, enabled: true });
 
 		const res = await injectAuthenticated("POST", "/auth/passkey/register/options", {
 			body: {},
 		});
 
-		expect(res.statusCode).toBe(403);
-		expect(JSON.parse(res.payload).error).toContain("OIDC");
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload).challenge).toBe("mock-challenge-base64url");
 	});
 
 	it("returns 403 when user has no password set", async () => {
@@ -206,6 +212,21 @@ describe("POST /auth/passkey/register/options", () => {
 // ===========================================================================
 
 describe("POST /auth/passkey/login/verify", () => {
+	it("issues passkey login options even when an OIDC provider is enabled (#498)", async () => {
+		// Regression: the same OIDC gate blocked /passkey/login/options, locking
+		// passkey users out if OIDC was misconfigured. Login options must still
+		// be issued regardless of OIDC presence.
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({ id: 1, enabled: true });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/passkey/login/options",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload).sessionId).toBeDefined();
+	});
+
 	it("returns 200 with user and session on valid credential", async () => {
 		// First: get login options to populate the challenge store
 		const optionsRes = await app.inject({
@@ -223,7 +244,12 @@ describe("POST /auth/passkey/login/verify", () => {
 			method: "POST",
 			url: "/auth/passkey/login/verify",
 			payload: {
-				response: { id: "cred-1", rawId: "cred-1", type: "public-key", response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" } },
+				response: {
+					id: "cred-1",
+					rawId: "cred-1",
+					type: "public-key",
+					response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" },
+				},
 				sessionId,
 			},
 		});
@@ -247,7 +273,12 @@ describe("POST /auth/passkey/login/verify", () => {
 			method: "POST",
 			url: "/auth/passkey/login/verify",
 			payload: {
-				response: { id: "cred-1", rawId: "cred-1", type: "public-key", response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" } },
+				response: {
+					id: "cred-1",
+					rawId: "cred-1",
+					type: "public-key",
+					response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" },
+				},
 				sessionId: "nonexistent-session-id",
 			},
 		});
@@ -274,7 +305,12 @@ describe("POST /auth/passkey/login/verify", () => {
 			method: "POST",
 			url: "/auth/passkey/login/verify",
 			payload: {
-				response: { id: "cred-1", rawId: "cred-1", type: "public-key", response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" } },
+				response: {
+					id: "cred-1",
+					rawId: "cred-1",
+					type: "public-key",
+					response: { clientDataJSON: "test", authenticatorData: "test", signature: "test" },
+				},
 				sessionId,
 			},
 		});

--- a/apps/api/src/routes/__tests__/auth.test.ts
+++ b/apps/api/src/routes/__tests__/auth.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks — vi.hoisted for references before vi.mock
@@ -6,7 +6,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 
 const { mockSessionService } = vi.hoisted(() => ({
 	mockSessionService: {
-		createSession: vi.fn().mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSession: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -42,9 +44,13 @@ vi.mock("../../lib/auth/session-metadata.js", () => ({
 // ---------------------------------------------------------------------------
 
 import Fastify from "fastify";
-import { registerAuthRoutes } from "../auth.js";
 import { hashPassword, verifyPassword } from "../../lib/auth/password.js";
-import { setupAuthInjection, createInjectAuthenticated, createMockEncryptor } from "./test-helpers.js";
+import { registerAuthRoutes } from "../auth.js";
+import {
+	createInjectAuthenticated,
+	createMockEncryptor,
+	setupAuthInjection,
+} from "./test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Test data factories
@@ -226,7 +232,10 @@ describe("POST /auth/register", () => {
 		expect(mockSessionService.createSession).not.toHaveBeenCalled();
 	});
 
-	it("returns 403 when OIDC provider is enabled", async () => {
+	it("allows initial-setup registration even when an OIDC provider is enabled (#498)", async () => {
+		// Regression: adding an OIDC provider used to disable password registration
+		// globally, which locked admins out if the OIDC config was wrong. Password
+		// registration during initial setup must still succeed regardless of OIDC.
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({ id: 1, enabled: true });
 
 		const res = await app.inject({
@@ -235,8 +244,9 @@ describe("POST /auth/register", () => {
 			payload: { username: "admin", password: "StrongPass1!" },
 		});
 
-		expect(res.statusCode).toBe(403);
-		expect(JSON.parse(res.payload).error).toContain("OIDC");
+		expect(res.statusCode).toBe(201);
+		expect(JSON.parse(res.payload).user.username).toBe("admin");
+		expect(mockSessionService.createSession).toHaveBeenCalled();
 	});
 });
 
@@ -318,7 +328,12 @@ describe("POST /auth/login", () => {
 		expect(mockSessionService.createSession).not.toHaveBeenCalled();
 	});
 
-	it("returns 403 when OIDC provider is enabled", async () => {
+	it("allows password login even when an OIDC provider is enabled (#498)", async () => {
+		// Regression: the global "any enabled OIDC provider → password disabled"
+		// gate locked admins out if their OIDC config was wrong. Password login
+		// must still work for users with hashedPassword set, regardless of OIDC.
+		mockPrisma.user.findFirst.mockResolvedValue(makeUser());
+		vi.mocked(verifyPassword).mockResolvedValue(true);
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({ id: 1, enabled: true });
 
 		const res = await app.inject({
@@ -327,8 +342,9 @@ describe("POST /auth/login", () => {
 			payload: { username: "admin", password: "correctpassword" },
 		});
 
-		expect(res.statusCode).toBe(403);
-		expect(JSON.parse(res.payload).error).toContain("OIDC");
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload).user.username).toBe("admin");
+		expect(mockSessionService.createSession).toHaveBeenCalled();
 	});
 });
 
@@ -428,5 +444,21 @@ describe("PATCH /auth/account", () => {
 		});
 
 		expect(res.statusCode).toBe(401);
+	});
+
+	it("allows password change even when an OIDC provider is enabled (#498)", async () => {
+		// Regression: the same global OIDC gate blocked authenticated password
+		// changes, so a user who set up OIDC and then noticed their password was
+		// out of date had no way to update it. Password change must still work.
+		mockPrisma.user.findUnique.mockResolvedValue(makeUser());
+		vi.mocked(verifyPassword).mockResolvedValue(true);
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({ id: 1, enabled: true });
+
+		const res = await injectAuthenticated("PATCH", "/auth/account", {
+			body: { currentPassword: "oldpassword1", newPassword: "NewPass123!" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(hashPassword).toHaveBeenCalledWith("NewPass123!");
 	});
 });

--- a/apps/api/src/routes/auth-passkey.ts
+++ b/apps/api/src/routes/auth-passkey.ts
@@ -79,17 +79,6 @@ const authPasskeyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				return reply.status(401).send({ error: "Unauthorized" });
 			}
 
-			// Check if OIDC provider is enabled - if so, passkey registration is disabled
-			const oidcProvider = await app.prisma.oIDCProvider.findFirst({
-				where: { enabled: true },
-			});
-
-			if (oidcProvider) {
-				return reply.status(403).send({
-					error: "Passkey authentication is disabled. Please use OIDC authentication.",
-				});
-			}
-
 			// Check if user has a password - passkeys require password authentication
 			const user = await app.prisma.user.findUnique({
 				where: { id: request.currentUser.id },
@@ -185,17 +174,6 @@ const authPasskeyRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		"/passkey/login/options",
 		{ config: { rateLimit: PASSKEY_LOGIN_RATE_LIMIT } },
 		async (request, reply) => {
-			// Check if OIDC provider is enabled - if so, passkey login is disabled
-			const oidcProvider = await app.prisma.oIDCProvider.findFirst({
-				where: { enabled: true },
-			});
-
-			if (oidcProvider) {
-				return reply.status(403).send({
-					error: "Passkey authentication is disabled. Please use OIDC authentication.",
-				});
-			}
-
 			const options = await passkeyService.generateAuthenticationOptions();
 
 			// Generate temporary session ID for challenge storage

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -50,17 +50,6 @@ const authRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	});
 
 	app.post("/register", { config: { rateLimit: REGISTER_RATE_LIMIT } }, async (request, reply) => {
-		// Check if OIDC provider is enabled - if so, password registration is disabled
-		const oidcProvider = await app.prisma.oIDCProvider.findFirst({
-			where: { enabled: true },
-		});
-
-		if (oidcProvider) {
-			return reply.status(403).send({
-				error: "Password registration is disabled. Please use OIDC authentication.",
-			});
-		}
-
 		const parsed = validateRequest(registerSchema, request.body);
 
 		const username = parsed.username.trim();
@@ -141,17 +130,6 @@ const authRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	});
 
 	app.post("/login", { config: { rateLimit: LOGIN_RATE_LIMIT } }, async (request, reply) => {
-		// Check if OIDC provider is enabled - if so, password auth is disabled
-		const oidcProvider = await app.prisma.oIDCProvider.findFirst({
-			where: { enabled: true },
-		});
-
-		if (oidcProvider) {
-			return reply.status(403).send({
-				error: "Password authentication is disabled. Please sign in with OIDC.",
-			});
-		}
-
 		const parsed = validateRequest(loginSchema, request.body);
 
 		const username = parsed.username.trim();
@@ -427,20 +405,6 @@ const authRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		const { username, currentPassword, newPassword, tmdbApiKey, traktAccessToken } =
 			validateRequest(updateAccountSchema, request.body);
-
-		// Check if OIDC provider is enabled - if so, password changes are disabled
-		if (newPassword) {
-			const oidcProvider = await app.prisma.oIDCProvider.findFirst({
-				where: { enabled: true },
-			});
-
-			if (oidcProvider) {
-				return reply.status(403).send({
-					error:
-						"Password authentication is disabled. Cannot add or change password while OIDC is enabled.",
-				});
-			}
-		}
 
 		// Check if at least one field is being updated
 		if (!username && !newPassword && tmdbApiKey === undefined && traktAccessToken === undefined) {


### PR DESCRIPTION
## Summary
- Adding an OIDC provider silently disabled **password auth, password registration, password change, passkey registration, and passkey login** via five identical `oIDCProvider.findFirst({where:{enabled:true}})` gates
- If the OIDC config was wrong, the admin was locked out with no recovery path through the API — closes #498
- Removed all five gates; the existing per-user `!user.hashedPassword` check at `auth.ts:182` is the correct granular gate and stays

## Root cause

Five identical short-circuits across `auth.ts` and `auth-passkey.ts` returned 403 if **any** enabled OIDC provider existed in the DB, before doing any other work:

| Route | Old behavior |
|---|---|
| `POST /auth/register` | 403 "Password registration is disabled. Please use OIDC authentication." |
| `POST /auth/login` | 403 "Password authentication is disabled. Please sign in with OIDC." |
| `PATCH /auth/account` (password change) | 403 "Password authentication is disabled. Cannot add or change password while OIDC is enabled." |
| `POST /auth/passkey/register/options` | 403 "Passkey authentication is disabled. Please use OIDC authentication." |
| `POST /auth/passkey/login/options` | 403 "Passkey authentication is disabled. Please use OIDC authentication." |

Reporter's scenario: added an OIDC provider with the wrong redirect URI → OIDC sign-in fails → tried to fall back to password login → 403 "Password authentication is disabled" → **locked out**.

## Fix
- Deleted all five OIDC-presence gates
- Kept the per-user `if (!user.hashedPassword)` check at `auth.ts:182`, which correctly returns "This account uses passwordless authentication" for OIDC-only users without blocking password users
- Frontend was already correct — the login form renders the OIDC button as an additional method alongside the password form, not a replacement, so no web-side changes are needed

## Note: the "remove password" feature already exists (preserved)

This PR removes the *implicit* OIDC-presence gates, but the codebase already has an *explicit* path for users who want to deliberately disable password authentication: the password-removal endpoint at `apps/api/src/routes/auth.ts:540-598`, exposed in the UI under Settings → Password section (`apps/web/src/features/settings/components/password-section.tsx`).

The explicit path requires:
1. Verified current password (proof of identity)
2. At least one linked OIDC account
3. The OIDC provider is currently enabled

Only then does it null out `hashedPassword`. After password removal, the per-user `if (!user.hashedPassword)` check at the login route returns `"passwordless authentication"` — the user is now OIDC-only.

The gates this PR removes were doing the same thing *implicitly* and *unsafely* (no current-password proof, no linked-OIDC verification, no recovery path). The explicit endpoint is the safe replacement and it already exists.

## Test plan
- [x] Inverted `auth.test.ts` test "returns 403 when OIDC provider is enabled" for `/register` → now asserts 201 with OIDC enabled (initial setup)
- [x] Inverted same test for `/login` → now asserts 200 with OIDC enabled + valid password
- [x] Added new test for `PATCH /account` password change with OIDC enabled → 200
- [x] Inverted `auth-passkey.test.ts` test for `/passkey/register/options` with OIDC enabled → 200
- [x] Added new test for `/passkey/login/options` with OIDC enabled → 200
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] Full test suite: 2017 passed, 41 skipped, 0 failed

## Recovery path for users already locked out on 2.20

For users hit by this on v2.20 before this patch ships, the workaround is direct SQLite DB access:

```bash
docker exec -it arr-dashboard sqlite3 /config/prod.db
sqlite> UPDATE OIDCProvider SET enabled = 0;
sqlite> .exit
```

After disabling the broken OIDC provider, password login works normally. Once upgraded to the patched version, this is no longer needed — password and OIDC coexist by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
