### PR TITLE
fix(tautulli): tolerate sparse get_metadata responses (#497)

### DIFF
--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -14,15 +14,15 @@
  * contract so the Tautulli refresher cannot regress into that failure mode.
  */
 
+import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../../prisma.js";
 import {
 	evictStaleRows,
 	refreshTautulliCache,
 	STALE_EVICTION_CHUNK_SIZE,
 } from "../tautulli-cache-refresher.js";
-import type { PrismaClient } from "../../prisma.js";
 import type { TautulliClient } from "../tautulli-client.js";
-import type { FastifyBaseLogger } from "fastify";
 
 // Neutralise the inter-lookup rate-limit delay so the end-to-end test runs fast.
 vi.mock("../../utils/delay.js", () => ({
@@ -49,18 +49,16 @@ function makeMockPrisma(existingIds: string[]) {
 	const stub = {
 		tautulliCache: {
 			findMany: vi.fn(async () => existingIds.map((id) => ({ id }))),
-			deleteMany: vi.fn(
-				async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
-					const inList = args.where.id?.in;
-					if (!inList) {
-						throw new Error(
-							"Regression: DELETE used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
-						);
-					}
-					deleteCalls.push({ idsInFilter: inList });
-					return { count: inList.length };
-				},
-			),
+			deleteMany: vi.fn(async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
+				const inList = args.where.id?.in;
+				if (!inList) {
+					throw new Error(
+						"Regression: DELETE used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
+					);
+				}
+				deleteCalls.push({ idsInFilter: inList });
+				return { count: inList.length };
+			}),
 		},
 	} as unknown as PrismaClient;
 
@@ -186,21 +184,17 @@ describe("refreshTautulliCache (end-to-end)", () => {
 					upsertedIds.push(id);
 					return { id };
 				}),
-				findMany: vi.fn(async () =>
-					[...existingStaleIds, ...upsertedIds].map((id) => ({ id })),
-				),
-				deleteMany: vi.fn(
-					async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
-						const inList = args.where.id?.in;
-						if (!inList) {
-							throw new Error(
-								"Regression: Tautulli eviction used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
-							);
-						}
-						deleteCalls.push({ idsInFilter: inList });
-						return { count: inList.length };
-					},
-				),
+				findMany: vi.fn(async () => [...existingStaleIds, ...upsertedIds].map((id) => ({ id }))),
+				deleteMany: vi.fn(async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
+					const inList = args.where.id?.in;
+					if (!inList) {
+						throw new Error(
+							"Regression: Tautulli eviction used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
+						);
+					}
+					deleteCalls.push({ idsInFilter: inList });
+					return { count: inList.length };
+				}),
 			},
 		} as unknown as PrismaClient;
 
@@ -222,5 +216,126 @@ describe("refreshTautulliCache (end-to-end)", () => {
 		const deletedIds = deleteCalls.flatMap((c) => c.idsInFilter);
 		expect(deletedIds.length).toBe(STALE_TAIL);
 		expect(new Set(deletedIds)).toEqual(new Set(existingStaleIds));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Sparse metadata regression (#497)
+// ---------------------------------------------------------------------------
+//
+// Tautulli's get_metadata can return a "success" envelope with empty/sparse
+// data when the rating_key isn't in its database (e.g., item deleted from
+// Plex but still in watch history). Before the schema fix, the missing
+// rating_key field caused UpstreamValidationError on every such response,
+// flooding Pulse/Dashboard with false-positive warnings. With the schema
+// tolerant of empty data, the refresher silently skips items whose metadata
+// can't be resolved — without logging warnings for the expected "not found"
+// case — while still surfacing real failures.
+
+describe("refreshTautulliCache — sparse metadata handling (#497)", () => {
+	it("silently skips items returning sparse metadata, without counting errors", async () => {
+		const libraries = [
+			{ section_id: "1", section_name: "Movies", section_type: "movie", count: "3" },
+		];
+		const history = [
+			{
+				rating_key: "rk-found",
+				parent_rating_key: "",
+				grandparent_rating_key: "",
+				title: "Found Movie",
+				grandparent_title: "",
+				media_type: "movie",
+				user: "alice",
+				date: 1_700_000_000,
+				play_count: 1,
+			},
+			{
+				rating_key: "rk-missing",
+				parent_rating_key: "",
+				grandparent_rating_key: "",
+				title: "Deleted Movie",
+				grandparent_title: "",
+				media_type: "movie",
+				user: "alice",
+				date: 1_700_000_001,
+				play_count: 1,
+			},
+			{
+				rating_key: "rk-error",
+				parent_rating_key: "",
+				grandparent_rating_key: "",
+				title: "Network-Failed Movie",
+				grandparent_title: "",
+				media_type: "movie",
+				user: "alice",
+				date: 1_700_000_002,
+				play_count: 1,
+			},
+		];
+
+		const mockClient = {
+			getLibraries: vi.fn().mockResolvedValue(libraries),
+			getHistory: vi.fn().mockResolvedValue({
+				data: history,
+				recordsFiltered: history.length,
+				recordsTotal: history.length,
+			}),
+			getMetadata: vi.fn(async (ratingKey: string) => {
+				if (ratingKey === "rk-found") {
+					return {
+						guids: ["tmdb://12345"],
+						media_type: "movie",
+						title: "Found Movie",
+						rating_key: "rk-found",
+					};
+				}
+				if (ratingKey === "rk-missing") {
+					// Tautulli's "rating_key not in DB" shape: success envelope with
+					// empty data, normalised by the schema's preprocess defaults.
+					return {
+						guids: [],
+						media_type: "unknown",
+						title: "",
+						// rating_key omitted entirely
+					};
+				}
+				// rk-error: real upstream failure path (network, HTTP 500, etc.)
+				throw new Error("ECONNREFUSED");
+			}),
+		} as unknown as TautulliClient;
+
+		const mockPrisma = {
+			tautulliCache: {
+				upsert: vi.fn(async () => ({ id: "fresh-1" })),
+				findMany: vi.fn(async () => [{ id: "fresh-1" }]),
+				deleteMany: vi.fn(async () => ({ count: 0 })),
+			},
+		} as unknown as PrismaClient;
+
+		const log = { warn: vi.fn(), info: vi.fn(), error: vi.fn() } as unknown as FastifyBaseLogger;
+
+		const result = await refreshTautulliCache(mockClient, mockPrisma, "inst-1", log);
+
+		// Only the rk-found item upserts; rk-missing is silently skipped (no guid),
+		// rk-error throws and is caught + counted as a real error.
+		expect(result.upserted).toBe(1);
+		expect(result.errors).toBe(1);
+		expect(result.errorMessages).toHaveLength(1);
+		expect(result.errorMessages[0]).toContain("rk-error");
+
+		// The crucial regression assertion: the empty-metadata item must NOT
+		// produce a "failed to fetch metadata for item" warning. Before the fix,
+		// it would — one warning per missing rating_key, flooding the operator
+		// dashboards. With the schema tolerant of sparse responses, only the
+		// genuine ECONNREFUSED logs a warning.
+		const metadataWarnings = (
+			log.warn as unknown as { mock: { calls: unknown[][] } }
+		).mock.calls.filter((call) => {
+			const msg = call[1];
+			return typeof msg === "string" && msg.includes("failed to fetch metadata");
+		});
+		expect(metadataWarnings).toHaveLength(1);
+		const errCallArg = metadataWarnings[0]?.[0] as { ratingKey?: string } | undefined;
+		expect(errCallArg?.ratingKey).toBe("rk-error");
 	});
 });

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-schemas.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-schemas.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for Tautulli Zod schemas.
+ *
+ * Particular focus on the get_metadata schema's tolerance of missing fields —
+ * Tautulli's get_metadata API returns a "success" envelope with sparse data
+ * when the rating_key isn't in its database (item deleted from Plex but still
+ * in watch history). See issue #497.
+ */
+import { describe, expect, it } from "vitest";
+import { tautulliMetadataSchema } from "../tautulli-schemas.js";
+
+describe("tautulliMetadataSchema", () => {
+	it("parses a full metadata response with all fields present", () => {
+		const input = {
+			guids: ["tmdb://12345", "imdb://tt1234567"],
+			media_type: "movie",
+			title: "The Matrix",
+			rating_key: "118702",
+		};
+		const result = tautulliMetadataSchema.parse(input);
+		expect(result.guids).toEqual(["tmdb://12345", "imdb://tt1234567"]);
+		expect(result.media_type).toBe("movie");
+		expect(result.title).toBe("The Matrix");
+		expect(result.rating_key).toBe("118702");
+	});
+
+	it("accepts an empty {} response without throwing (#497 regression)", () => {
+		// Tautulli's get_metadata sometimes returns `{response: {result: "success", data: {}}}`
+		// when the rating_key isn't found in its DB (e.g., Plex item deleted).
+		// Before the fix, this threw `UpstreamValidationError` for missing rating_key,
+		// flooding Pulse/Dashboard with false-positive warnings. The schema now
+		// tolerates empty data — callers use the local rating_key arg, not the
+		// echoed one in the response.
+		const result = tautulliMetadataSchema.parse({});
+		expect(result.guids).toEqual([]);
+		expect(result.media_type).toBe("unknown");
+		expect(result.title).toBe("");
+		expect(result.rating_key).toBeUndefined();
+	});
+
+	it("accepts partial responses with only some fields present", () => {
+		// Real-world Tautulli responses can include some fields and omit others
+		// depending on the metadata source. Each field should default
+		// independently.
+		const result = tautulliMetadataSchema.parse({
+			title: "Partial Item",
+			// guids, media_type, rating_key all missing
+		});
+		expect(result.guids).toEqual([]);
+		expect(result.media_type).toBe("unknown");
+		expect(result.title).toBe("Partial Item");
+		expect(result.rating_key).toBeUndefined();
+	});
+
+	it("coerces numeric rating_key to string (Tautulli returns it as a number)", () => {
+		const result = tautulliMetadataSchema.parse({
+			guids: [],
+			media_type: "movie",
+			title: "Numeric Key Movie",
+			rating_key: 118702,
+		});
+		expect(result.rating_key).toBe("118702");
+	});
+
+	it("preserves unknown extra fields (looseObject)", () => {
+		// The schema uses z.looseObject, so unknown fields pass through —
+		// important because Tautulli's API surface evolves and we should not
+		// strip fields callers might want to read directly.
+		const result = tautulliMetadataSchema.parse({
+			guids: [],
+			media_type: "movie",
+			title: "X",
+			rating_key: "1",
+			year: 1999,
+			summary: "A movie",
+		}) as Record<string, unknown>;
+		expect(result.year).toBe(1999);
+		expect(result.summary).toBe("A movie");
+	});
+
+	it("treats null fields the same as missing (preprocess defaults)", () => {
+		// Tautulli occasionally returns explicit nulls for fields it doesn't
+		// know about. The preprocess wrappers normalize null and undefined.
+		const result = tautulliMetadataSchema.parse({
+			guids: null,
+			media_type: null,
+			title: null,
+		});
+		expect(result.guids).toEqual([]);
+		expect(result.media_type).toBe("unknown");
+		expect(result.title).toBe("");
+	});
+});

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -37,7 +37,10 @@ export interface TautulliMetadata {
 	guids: string[]; // e.g. ["tmdb://12345", "imdb://tt1234567"]
 	media_type: string;
 	title: string;
-	rating_key: string;
+	// Optional — Tautulli omits this when the rating_key isn't in its database
+	// (e.g., item deleted from Plex). Callers already have the rating_key as
+	// the request arg, so the response copy is informational only.
+	rating_key?: string;
 }
 
 export interface TautulliSessionItem {

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -122,10 +122,17 @@ export const tautulliUserWatchTimeStatsSchema = z.looseObject({
 	total_duration: z.number(),
 });
 
-/** get_metadata — inner data */
+/** get_metadata — inner data
+ *
+ * NOTE: All fields are tolerant of missing/null upstream values. Tautulli's
+ * get_metadata can return a "success" envelope with sparse or empty data when
+ * the rating_key isn't in its database (e.g., item deleted from Plex but still
+ * in watch history). Treat every field as best-effort: callers should not rely
+ * on rating_key being present here — they already have it as the request arg.
+ */
 export const tautulliMetadataSchema = z.looseObject({
-	guids: z.preprocess(v => v ?? [], z.array(z.string())),
-	media_type: z.preprocess(v => v ?? "unknown", z.string()),
-	title: z.preprocess(v => v ?? "", z.string()),
-	rating_key: z.coerce.string(),
+	guids: z.preprocess((v) => v ?? [], z.array(z.string())),
+	media_type: z.preprocess((v) => v ?? "unknown", z.string()),
+	title: z.preprocess((v) => v ?? "", z.string()),
+	rating_key: z.coerce.string().optional(),
 });


### PR DESCRIPTION
## Summary
- Tautulli's `get_metadata` endpoint returns a "success" envelope with empty/sparse data when the rating_key isn't found in its database (item deleted from Plex but still in watch history)
- The Zod schema required `rating_key`, so every such response threw `UpstreamValidationError` and flooded Pulse/Dashboard with `warn` logs that looked like real failures — closes #497
- The cache refresh itself was already correct end-to-end (per-item errors caught + continue); the bug was purely the spurious warning flood

## Root cause

`apps/api/src/lib/tautulli/tautulli-schemas.ts` — the `tautulliMetadataSchema` had four fields, three with tolerant `z.preprocess(v => v ?? <default>)` patterns and one that wasn't:

```ts
export const tautulliMetadataSchema = z.looseObject({
    guids: z.preprocess(v => v ?? [], z.array(z.string())),       // tolerant
    media_type: z.preprocess(v => v ?? "unknown", z.string()),    // tolerant
    title: z.preprocess(v => v ?? "", z.string()),                // tolerant
    rating_key: z.coerce.string(),                                // ← strict — the bug
});
```

When Tautulli returned a response like `{ response: { result: "success", data: {} } }` (its "not found" shape), the first three fields silently defaulted but `rating_key` threw, producing:

```
UpstreamValidationError: Upstream validation failed [tautulli/get_metadata]:
  rating_key: Invalid input: expected nonoptional, received undefined
```

The reporter saw 10+ of these per refresh cycle on their Dashboard / Pulse page.

## Why the fix is small

`metadata.rating_key` is never actually read downstream. The cache refresher already has the rating_key as the local arg it passed to `client.getMetadata(ratingKey)`:

```ts
const metadata = await client.getMetadata(ratingKey);  // ← rating_key already known
const guid = parseTmdbGuid(metadata.guids);            // ← only field actually used
```

So making `rating_key` optional in both the schema and the `TautulliMetadata` interface has zero callsite impact. After the fix, sparse Tautulli responses validate cleanly → `guids` defaults to `[]` → `parseTmdbGuid([])` returns null → item silently skipped (correct behavior, no warning logged).

## What real failures still surface

The refresher's `try/catch` around `client.getMetadata(ratingKey)` still catches and logs all other failure modes:

- Network errors (ECONNREFUSED, timeout)
- HTTP non-2xx responses
- Malformed JSON
- Wrapper validation failures (envelope shape wrong)
- Tautulli `result: "error"` responses

Only the "Tautulli intentionally returned empty data because the item isn't in its DB" case becomes silent — which is the correct behavior.

## Test plan
- [x] New `tautulli-schemas.test.ts` — covers empty `{}` / partial / null-field / numeric-coercion / loose-object cases against `tautulliMetadataSchema`
- [x] New regression test in `tautulli-cache-refresher.test.ts` — three-way contract: full metadata → upsert; sparse metadata → silent skip with no warning; real upstream error → caught + counted
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] Full test suite: 2024 passed, 41 skipped, 0 failed (7 new tests vs pre-fix baseline)

## What changes for users

- The `Tautulli cache: failed to fetch metadata for item` warning flood on Dashboard / Pulse disappears for the expected "item not in Tautulli DB" case
- Cache refresh behavior is unchanged — items that can't be resolved were already being skipped; this PR just silences the false-alarm logs that accompanied the skip
- Genuine Tautulli connectivity issues still surface as warnings (preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)