### PR TITLE
feat(statistics): filter combined-disk rollup to media-only + breakdown UI (#495)

### DIFF
--- a/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
+++ b/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
@@ -17,6 +17,7 @@ import {
 	combineDiskStats,
 	type DiskBearingInstance,
 	type DiskContributor,
+	filterToRootFolderDisks,
 	toDiskMounts,
 } from "../statistics-utils.js";
 
@@ -149,6 +150,7 @@ describe("combineDiskStats", () => {
 			usagePercent: 0,
 			diskCount: 0,
 			instanceCount: 0,
+			disks: [],
 		});
 	});
 
@@ -185,11 +187,13 @@ describe("combineDiskStats", () => {
 });
 
 describe("toDiskMounts", () => {
-	// Pins the exact shape combineDiskStats depends on: path is dropped, and
-	// missing total/free coerce to 0. If the `?? 0` coercion ever regressed to
-	// `undefined`, the fingerprint key would become "120…:undefined" and shared
-	// disks would silently stop merging (re-opening issue #486) with green types.
-	it("drops path and coerces missing total/free to 0", () => {
+	// Pins the shape combineDiskStats depends on: missing total/free coerce to
+	// 0 (so the fingerprint key stays "n:n" instead of "n:undefined" — which
+	// would silently break the dedup that fixes issue #486), and `path` is
+	// PRESERVED on the wire so the #495 root-folder filter can use it. Before
+	// #495 the path was dropped here for privacy reasons; the breakdown UI now
+	// needs it, and the frontend handles anonymization under incognito mode.
+	it("preserves path and coerces missing total/free to 0", () => {
 		const mounts = toDiskMounts([
 			{ path: "/tv", totalSpace: 120 * 1024 ** 4, freeSpace: 105 * 1024 ** 4 },
 			{ path: "/data" }, // missing total/free
@@ -197,12 +201,10 @@ describe("toDiskMounts", () => {
 		] as Array<{ path?: string; totalSpace?: number; freeSpace?: number }>);
 
 		expect(mounts).toEqual([
-			{ totalSpace: 120 * 1024 ** 4, freeSpace: 105 * 1024 ** 4 },
-			{ totalSpace: 0, freeSpace: 0 },
-			{ totalSpace: 2 * 1024 ** 4, freeSpace: 0 },
+			{ path: "/tv", totalSpace: 120 * 1024 ** 4, freeSpace: 105 * 1024 ** 4 },
+			{ path: "/data", totalSpace: 0, freeSpace: 0 },
+			{ path: undefined, totalSpace: 2 * 1024 ** 4, freeSpace: 0 },
 		]);
-		// No `path` key survives.
-		expect(mounts.every((m) => !("path" in m))).toBe(true);
 	});
 });
 
@@ -223,7 +225,9 @@ describe("buildCombinedDiskPayload", () => {
 			readarr: [instanceWithArray()],
 		});
 
-		expect(payload).toEqual({
+		// Use toMatchObject so the breakdown payload added in #495 doesn't tighten
+		// this test's contract: the rollup numbers are what we care about here.
+		expect(payload).toMatchObject({
 			diskTotal: 120 * TB,
 			diskFree: 105 * TB,
 			diskUsed: 15 * TB,
@@ -293,5 +297,222 @@ describe("buildCombinedDiskPayload", () => {
 			// @ts-expect-error — Prowlarr is intentionally not a valid input key
 			prowlarr: [{ data: { diskEntries: [{ totalSpace: 1, freeSpace: 1 }] } }],
 		});
+	});
+});
+
+// ===========================================================================
+// Root-folder filter (#495)
+// ===========================================================================
+
+describe("filterToRootFolderDisks (#495)", () => {
+	it("falls back to keeping everything when no root folders are supplied", () => {
+		// Pre-#495 callers don't pass rootFolderPaths. We must not regress them
+		// to showing 0 disks — preserve current behavior as the safety net.
+		const entries = [
+			{ path: "/", totalSpace: 1.5 * TB, freeSpace: 553.9 * 1024 ** 3 },
+			{ path: "/data", totalSpace: 131 * TB, freeSpace: 37.6 * TB },
+		];
+
+		expect(filterToRootFolderDisks(entries, undefined).included).toEqual(entries);
+		expect(filterToRootFolderDisks(entries, []).included).toEqual(entries);
+		expect(filterToRootFolderDisks(entries, ["   "]).included).toEqual(entries);
+	});
+
+	it("keeps only the disk holding the *arr root folder (longest prefix wins)", () => {
+		// The developer's personal Sonarr setup from issue #495 — three disks
+		// reported, one media root folder configured on /data.
+		const entries = [
+			{ path: "/", totalSpace: 1.5 * TB, freeSpace: 553.9 * 1024 ** 3 },
+			{ path: "/data", totalSpace: 131 * TB, freeSpace: 37.6 * TB },
+			{ path: "/config", totalSpace: 585.5 * 1024 ** 3, freeSpace: 553.9 * 1024 ** 3 },
+		];
+
+		const { included, excluded } = filterToRootFolderDisks(entries, ["/data/tv"]);
+
+		expect(included.map((e) => e.path)).toEqual(["/data"]);
+		expect(excluded.map((e) => e.path)).toEqual(["/", "/config"]);
+	});
+
+	it("keeps the root partition on bare-metal setups with no other disk", () => {
+		// Bare-metal *arr where media lives somewhere under /, with no separate
+		// mount. The only candidate disk is /, and the root folder's path starts
+		// with / — so / wins.
+		const entries = [{ path: "/", totalSpace: 4 * TB, freeSpace: 1 * TB }];
+
+		const { included } = filterToRootFolderDisks(entries, ["/home/user/Media"]);
+
+		expect(included).toEqual(entries);
+	});
+
+	it("respects path-segment boundaries (/data does not match /dataother)", () => {
+		// String-prefix is not enough — /data should NOT be considered the mount
+		// holding a root folder at /dataother/movies. The match needs the next
+		// character after the disk path to be / or end-of-string.
+		const entries = [
+			{ path: "/data", totalSpace: 10 * TB, freeSpace: 5 * TB },
+			{ path: "/dataother", totalSpace: 4 * TB, freeSpace: 1 * TB },
+		];
+
+		const { included } = filterToRootFolderDisks(entries, ["/dataother/movies"]);
+
+		expect(included.map((e) => e.path)).toEqual(["/dataother"]);
+	});
+
+	it("normalizes trailing slashes on both disk paths and root folder paths", () => {
+		const entries = [{ path: "/data/", totalSpace: 10 * TB, freeSpace: 5 * TB }];
+
+		const { included } = filterToRootFolderDisks(entries, ["/data/tv/"]);
+
+		expect(included).toHaveLength(1);
+	});
+
+	it("keeps each unique disk only once even when many root folders share it", () => {
+		// Two root folders, both on the same /data disk. Disk should be kept
+		// once, not twice.
+		const entries = [
+			{ path: "/", totalSpace: 1.5 * TB, freeSpace: 553.9 * 1024 ** 3 },
+			{ path: "/data", totalSpace: 131 * TB, freeSpace: 37.6 * TB },
+		];
+
+		const { included } = filterToRootFolderDisks(entries, ["/data/tv", "/data/movies"]);
+
+		expect(included.map((e) => e.path)).toEqual(["/data"]);
+	});
+
+	it("excludes everything when no disk's path is a prefix of any root folder", () => {
+		// All root folders live on disks the *arr never enumerated (perhaps the
+		// root folders point at unmounted paths). Filter excludes everything;
+		// caller's safety net should handle that case at the layer above.
+		const entries = [
+			{ path: "/", totalSpace: 1.5 * TB, freeSpace: 100 * 1024 ** 3 },
+			{ path: "/tmp", totalSpace: 10 * 1024 ** 3, freeSpace: 8 * 1024 ** 3 },
+		];
+
+		const { included, excluded } = filterToRootFolderDisks(entries, ["/data/tv"]);
+
+		// "/data/tv" starts with "/" — so the / disk matches as the longest
+		// prefix and is kept. /tmp does not match.
+		expect(included.map((e) => e.path)).toEqual(["/"]);
+		expect(excluded.map((e) => e.path)).toEqual(["/tmp"]);
+	});
+});
+
+describe("combineDiskStats with root-folder filter (#495)", () => {
+	const KIB = 1024;
+	const GIB = KIB ** 3;
+	const TIB = KIB ** 4;
+
+	it("produces the right rollup + breakdown for the issue-#495 reporter's case", () => {
+		// Models the developer's own Sonarr disk reading reproduced in #495:
+		// three disks shown by the *arr, only /data is media.
+		const result = combineDiskStats([
+			{
+				instanceName: "Sonarr",
+				rootFolderPaths: ["/data/tv"],
+				diskEntries: [
+					{ path: "/", totalSpace: 1.5 * TIB, freeSpace: 553.9 * GIB },
+					{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB },
+					{ path: "/config", totalSpace: 585.5 * GIB, freeSpace: 553.9 * GIB },
+				],
+			},
+		]);
+
+		// Rollup: only /data is counted.
+		expect(result.total).toBe(131 * TIB);
+		expect(result.free).toBe(37.6 * TIB);
+		expect(result.diskCount).toBe(1);
+		expect(result.instanceCount).toBe(1);
+
+		// Breakdown: every disk is listed with its decision so the UI can show
+		// the "Show all disks" expansion.
+		expect(result.disks).toHaveLength(3);
+
+		const byPath = Object.fromEntries(result.disks.map((d) => [d.path, d]));
+		expect(byPath["/data"]).toMatchObject({ includedInRollup: true, reason: "media" });
+		expect(byPath["/"]).toMatchObject({
+			includedInRollup: false,
+			reason: "no-matching-root-folder",
+		});
+		expect(byPath["/config"]).toMatchObject({
+			includedInRollup: false,
+			reason: "no-matching-root-folder",
+		});
+		// All three carry the instance label for UI attribution.
+		expect(result.disks.every((d) => d.instanceName === "Sonarr")).toBe(true);
+	});
+
+	it("marks group-deduplicated disks with reason 'deduplicated' in the breakdown", () => {
+		// Two instances declared in the same storage group. The first contributes
+		// to the rollup; the second's disks are recorded as duplicates so the UI
+		// can show "Radarr's /data ⊘ already counted via Sonarr".
+		const result = combineDiskStats([
+			{
+				instanceName: "Sonarr",
+				storageGroupId: "nas",
+				rootFolderPaths: ["/data/tv"],
+				diskEntries: [{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB }],
+			},
+			{
+				instanceName: "Radarr",
+				storageGroupId: "nas",
+				rootFolderPaths: ["/data/movies"],
+				diskEntries: [{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB }],
+			},
+		]);
+
+		expect(result.diskCount).toBe(1);
+		expect(result.instanceCount).toBe(2);
+		expect(result.disks).toHaveLength(2);
+		expect(result.disks[0]).toMatchObject({
+			instanceName: "Sonarr",
+			includedInRollup: true,
+			reason: "media",
+		});
+		expect(result.disks[1]).toMatchObject({
+			instanceName: "Radarr",
+			includedInRollup: false,
+			reason: "deduplicated",
+		});
+	});
+
+	it("marks fingerprint-deduplicated media disks as 'deduplicated' in the breakdown", () => {
+		// Two ungrouped *arrs both reporting an identically-sized identically-free
+		// media disk. PR #490's fingerprint dedup catches them; the breakdown
+		// records the second one as deduplicated rather than dropping it silently.
+		const result = combineDiskStats([
+			{
+				instanceName: "Sonarr",
+				rootFolderPaths: ["/data/tv"],
+				diskEntries: [{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB }],
+			},
+			{
+				instanceName: "Radarr",
+				rootFolderPaths: ["/data/movies"],
+				diskEntries: [{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB }],
+			},
+		]);
+
+		expect(result.diskCount).toBe(1);
+		expect(result.disks.map((d) => d.reason)).toEqual(["media", "deduplicated"]);
+	});
+
+	it("falls back to current behavior for contributors that don't supply root folders", () => {
+		// Pre-#495 callers (or contributors whose root-folder fetch failed) don't
+		// pass rootFolderPaths. Those contributors keep all their disks as "media"
+		// — preserving the rollup users see today rather than dropping to 0 TB.
+		const result = combineDiskStats([
+			{
+				instanceName: "Sonarr (legacy)",
+				// rootFolderPaths intentionally absent
+				diskEntries: [
+					{ path: "/", totalSpace: 1.5 * TIB, freeSpace: 553.9 * GIB },
+					{ path: "/data", totalSpace: 131 * TIB, freeSpace: 37.6 * TIB },
+				],
+			},
+		]);
+
+		expect(result.diskCount).toBe(2);
+		expect(result.total).toBe(1.5 * TIB + 131 * TIB);
+		expect(result.disks.every((d) => d.reason === "media")).toBe(true);
 	});
 });

--- a/apps/api/src/lib/statistics/dashboard-statistics.ts
+++ b/apps/api/src/lib/statistics/dashboard-statistics.ts
@@ -253,8 +253,9 @@ export const fetchSonarrStatisticsWithSdk = async (
 	// buffer-then-parse pattern is fine. Series goes through the streaming
 	// path when `options.streamItems` is provided (production) so peak
 	// memory is bounded by the aggregation state, not library size.
-	const [diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
+	const [diskspace, rootFolders, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
+		safeRequest(() => client.rootFolder.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.cutoff({ page: 1, pageSize: 1 })).then(
 			(r) => r ?? { totalRecords: 0 },
@@ -379,6 +380,13 @@ export const fetchSonarrStatisticsWithSdk = async (
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
 		diskEntries: toDiskMounts(diskspace),
+		// Configured *arr root folders — used by the dashboard's combined-disk
+		// rollup to filter to media disks only (issue #495). We extract just the
+		// path string; the rest of the RootFolder shape (accessible, freeSpace,
+		// etc.) isn't needed for the filter.
+		rootFolderPaths: rootFolders
+			.map((r) => r.path)
+			.filter((p): p is string => typeof p === "string" && p.length > 0),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -408,8 +416,9 @@ export const fetchRadarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [diskspace, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
+	const [diskspace, rootFolders, health, cutoffUnmet, qualityProfiles, tags] = await Promise.all([
 		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
+		safeRequest(() => client.rootFolder.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
 		safeRequest(() => client.wanted.cutoff({ page: 1, pageSize: 1 })).then(
 			(r) => r ?? { totalRecords: 0 },
@@ -497,6 +506,13 @@ export const fetchRadarrStatisticsWithSdk = async (
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
 		diskEntries: toDiskMounts(diskspace),
+		// Configured *arr root folders — used by the dashboard's combined-disk
+		// rollup to filter to media disks only (issue #495). We extract just the
+		// path string; the rest of the RootFolder shape (accessible, freeSpace,
+		// etc.) isn't needed for the filter.
+		rootFolderPaths: rootFolders
+			.map((r) => r.path)
+			.filter((p): p is string => typeof p === "string" && p.length > 0),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -630,13 +646,15 @@ export const fetchLidarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.diskSpace.get()).then((r) => r ?? []),
-		safeRequest(() => client.health.get()).then((r) => r ?? []),
-		safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
-		safeRequest(() => client.qualityProfile.getAll()).then((r) => r ?? []),
-		safeRequest(() => client.tag.getAll()).then((r) => r ?? []),
-	]);
+	const [diskspace, rootFolders, health, cutoffUnmetResult, qualityProfiles, tags] =
+		await Promise.all([
+			safeRequest(() => client.diskSpace.get()).then((r) => r ?? []),
+			safeRequest(() => client.rootFolder.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.health.get()).then((r) => r ?? []),
+			safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
+			safeRequest(() => client.qualityProfile.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.tag.getAll()).then((r) => r ?? []),
+		]);
 	const cutoffUnmet = cutoffUnmetResult ?? { totalRecords: 0 };
 
 	const profileIdToName = buildProfileIdToNameMap(qualityProfiles);
@@ -743,6 +761,13 @@ export const fetchLidarrStatisticsWithSdk = async (
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
 		diskEntries: toDiskMounts(diskspace),
+		// Configured *arr root folders — used by the dashboard's combined-disk
+		// rollup to filter to media disks only (issue #495). We extract just the
+		// path string; the rest of the RootFolder shape (accessible, freeSpace,
+		// etc.) isn't needed for the filter.
+		rootFolderPaths: rootFolders
+			.map((r) => r.path)
+			.filter((p): p is string => typeof p === "string" && p.length > 0),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};
@@ -772,13 +797,15 @@ export const fetchReadarrStatisticsWithSdk = async (
 		instanceExternalUrl,
 	};
 
-	const [diskspace, health, cutoffUnmetResult, qualityProfiles, tags] = await Promise.all([
-		safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
-		safeRequest(() => client.health.getAll()).then((r) => r ?? []),
-		safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
-		safeRequest(() => client.qualityProfile.getAll()).then((r) => r ?? []),
-		safeRequest(() => client.tag.getAll()).then((r) => r ?? []),
-	]);
+	const [diskspace, rootFolders, health, cutoffUnmetResult, qualityProfiles, tags] =
+		await Promise.all([
+			safeRequest(() => client.diskSpace.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.rootFolder.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.health.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.wanted.getCutoffUnmet({ page: 1, pageSize: 1 })),
+			safeRequest(() => client.qualityProfile.getAll()).then((r) => r ?? []),
+			safeRequest(() => client.tag.getAll()).then((r) => r ?? []),
+		]);
 	const cutoffUnmet = cutoffUnmetResult ?? { totalRecords: 0 };
 
 	const profileIdToName = buildProfileIdToNameMap(qualityProfiles);
@@ -875,6 +902,13 @@ export const fetchReadarrStatisticsWithSdk = async (
 		diskUsed: diskTotals.used || undefined,
 		diskUsagePercent: diskTotals.usagePercent,
 		diskEntries: toDiskMounts(diskspace),
+		// Configured *arr root folders — used by the dashboard's combined-disk
+		// rollup to filter to media disks only (issue #495). We extract just the
+		// path string; the rest of the RootFolder shape (accessible, freeSpace,
+		// etc.) isn't needed for the filter.
+		rootFolderPaths: rootFolders
+			.map((r) => r.path)
+			.filter((p): p is string => typeof p === "string" && p.length > 0),
 		healthIssues: healthIssuesList.length,
 		healthIssuesList,
 	};

--- a/apps/api/src/lib/statistics/statistics-utils.ts
+++ b/apps/api/src/lib/statistics/statistics-utils.ts
@@ -67,9 +67,16 @@ interface HealthEntry {
 }
 
 /**
- * Generic disk space entry from ARR API
+ * Generic disk space entry from ARR API.
+ *
+ * `path` is optional both because the SDK reports it as nullable and because
+ * pre-#495 call sites carried this shape without it. Newer callers populate
+ * `path` so the root-folder filter (see filterToRootFolderDisks) can decide
+ * which disks belong in the media rollup. Treat `path` as sensitive text on
+ * the wire — the frontend should anonymize it under incognito mode.
  */
 interface DiskSpaceEntry {
+	path?: string | null;
 	totalSpace?: number | null;
 	freeSpace?: number | null;
 }
@@ -249,60 +256,193 @@ export const calculateDiskTotals = <T extends DiskSpaceEntry>(diskspace: T[]): D
 
 /**
  * Normalizes raw *arr diskspace entries into a stable mount shape that can be
- * carried per-instance and later de-duplicated in `combineDiskStats`. Mount
- * `path` is intentionally dropped: it's never used for de-duplication (see
- * combineDiskStats) and shipping raw filesystem paths on the wire would leak
- * the operator's layout, which incognito mode cannot mask in an API body.
+ * carried per-instance and later de-duplicated in `combineDiskStats`.
+ *
+ * `path` is preserved on the wire so the #495 root-folder filter can decide
+ * which disks hold media. Raw mount paths do leak the operator's layout in
+ * principle — the dashboard mitigates this on the frontend by passing `path`
+ * through `useIncognitoMode()`-aware anonymization before render, matching the
+ * pattern used for instance names and titles. Pre-#495 the path was dropped
+ * here to avoid that wire-side leak; the trade-off shifted with the breakdown
+ * UI, which needs to show users what's being included vs excluded by path.
  */
 export const toDiskMounts = <T extends DiskSpaceEntry>(
 	diskspace: T[],
-): Array<{ totalSpace: number; freeSpace: number }> =>
+): Array<{ path?: string; totalSpace: number; freeSpace: number }> =>
 	diskspace.map((entry) => ({
+		path: entry?.path ?? undefined,
 		totalSpace: entry?.totalSpace ?? 0,
 		freeSpace: entry?.freeSpace ?? 0,
 	}));
 
 /**
  * One disk-bearing instance's contribution to the combined disk total.
+ *
+ * `rootFolderPaths` and `instanceName` are optional and additive (issue #495):
+ *   - When `rootFolderPaths` is provided, the contributor's disk entries are
+ *     filtered to those holding media (see filterToRootFolderDisks). When
+ *     absent or empty, the filter degrades to "keep everything" — preserving
+ *     pre-#495 behavior for callers that don't supply root-folder context.
+ *   - `instanceName` is plumbed through the breakdown so the UI can attribute
+ *     each disk row to its source instance. Sensitive text — anonymize under
+ *     incognito mode on the frontend.
  */
 export interface DiskContributor {
 	storageGroupId?: string | null;
 	diskEntries: DiskSpaceEntry[];
+	rootFolderPaths?: readonly string[];
+	instanceName?: string;
 }
 
 /**
- * Combined disk totals plus transparency counts.
+ * Why a disk did or didn't make it into the rollup. Drives the UI breakdown
+ * panel's per-row reason text.
+ *   - `"media"`           — included; holds at least one configured *arr root folder
+ *   - `"no-matching-root-folder"` — excluded; no root folder lives on this disk
+ *   - `"deduplicated"`    — excluded; another contributor already accounted for
+ *                           this disk (via storage-group or fingerprint)
+ */
+export type DiskFilterReason = "media" | "no-matching-root-folder" | "deduplicated";
+
+/**
+ * Per-disk row used by the breakdown UI to explain how the rollup was computed.
+ *
+ * `path` is sensitive text — frontend renderers must use `useIncognitoMode()`
+ * to anonymize it. The wire payload carries it unredacted so a) the breakdown
+ * remains legible when incognito is off, b) the dashboard can compute aggregate
+ * facts without depending on per-request privacy flags.
+ */
+export interface DiskBreakdownEntry {
+	path?: string;
+	totalSpace: number;
+	freeSpace: number;
+	includedInRollup: boolean;
+	reason: DiskFilterReason;
+	instanceName?: string;
+}
+
+/**
+ * Combined disk totals plus transparency counts and the per-disk breakdown
+ * the UI uses for its "Show all disks" expansion.
  */
 export interface CombinedDiskTotals extends DiskTotals {
 	diskCount: number;
 	instanceCount: number;
+	disks: DiskBreakdownEntry[];
 }
 
 /**
+ * Normalize a mount path for prefix comparison: trim whitespace, drop trailing
+ * "/" except when the entire path is "/" (which stays). Keeps "/data" and
+ * "/data/" identical without collapsing the root.
+ */
+const normalizePath = (raw: string): string => {
+	const trimmed = raw.trim();
+	if (trimmed === "" || trimmed === "/") return trimmed;
+	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+};
+
+/**
+ * True when `diskPath` is a path-segment prefix of `rfPath` (or equal). This
+ * is what makes "/data" match "/data/tv" but not "/dataother" — the next char
+ * after the prefix has to be "/" or end-of-string.
+ *
+ * Both paths must already be normalized via `normalizePath`.
+ */
+const isPathPrefix = (rfPath: string, diskPath: string): boolean => {
+	if (diskPath === rfPath) return true;
+	if (diskPath === "/") return rfPath.startsWith("/");
+	if (!rfPath.startsWith(diskPath)) return false;
+	return rfPath.charAt(diskPath.length) === "/";
+};
+
+/**
+ * Partition a contributor's disk entries into ones holding media (kept) and
+ * ones that don't (excluded) using the **longest matching prefix wins** rule:
+ *
+ *   For each root folder, pick the disk whose normalized path is the longest
+ *   prefix of the root folder's path. That disk is "kept"; everything else is
+ *   "excluded". When more than one root folder lives on the same disk, that
+ *   disk is kept once.
+ *
+ * Why "longest prefix wins"? It mirrors how `df` resolves a file to its mount
+ * point and is shape-agnostic across containerized vs bare-metal deployments:
+ *   - Containerized Sonarr with disks `/` and `/data` + root folder `/data/tv`
+ *     → `/data` wins (longer prefix), `/` is excluded.
+ *   - Bare-metal Sonarr with disk `/` only + root folder `/home/user/Media`
+ *     → `/` wins (only candidate), kept.
+ *
+ * **Fallback when no root folders are supplied** (`rootFolderPaths` undefined,
+ * null, or empty after trimming): degrade to current pre-#495 behavior — keep
+ * everything as `"media"`. This means a misconfigured *arr (no root folders
+ * yet) doesn't suddenly report 0 disks.
+ */
+export const filterToRootFolderDisks = (
+	diskEntries: DiskSpaceEntry[],
+	rootFolderPaths: readonly string[] | undefined,
+): { included: DiskSpaceEntry[]; excluded: DiskSpaceEntry[] } => {
+	const validRootFolderPaths = (rootFolderPaths ?? [])
+		.map(normalizePath)
+		.filter((p) => p.length > 0);
+
+	if (validRootFolderPaths.length === 0) {
+		return { included: [...diskEntries], excluded: [] };
+	}
+
+	const normalizedDiskPaths = diskEntries.map((entry) => normalizePath(entry.path ?? ""));
+	const keptIndexes = new Set<number>();
+
+	for (const rfPath of validRootFolderPaths) {
+		let bestIdx = -1;
+		let bestLen = -1;
+		for (let i = 0; i < normalizedDiskPaths.length; i++) {
+			const diskPath = normalizedDiskPaths[i];
+			if (!diskPath) continue;
+			if (isPathPrefix(rfPath, diskPath) && diskPath.length > bestLen) {
+				bestIdx = i;
+				bestLen = diskPath.length;
+			}
+		}
+		if (bestIdx >= 0) keptIndexes.add(bestIdx);
+	}
+
+	const included: DiskSpaceEntry[] = [];
+	const excluded: DiskSpaceEntry[] = [];
+	diskEntries.forEach((entry, i) => {
+		if (keptIndexes.has(i)) included.push(entry);
+		else excluded.push(entry);
+	});
+	return { included, excluded };
+};
+
+/**
  * Combines disk stats across instances while avoiding the classic
- * "one physical array, many *arr instances" over-count.
+ * "one physical array, many *arr instances" over-count, and (issue #495)
+ * filtering out non-media disks (container `/`, config volumes, etc.) when
+ * each contributor supplies its configured root folders.
  *
- * De-duplication uses two signals, in order of trust:
- *   1. Storage group — an explicit operator declaration that instances share
- *      storage. Once a group is represented, later instances in the same group
- *      are skipped entirely (this also absorbs read-timing skew in free space).
- *   2. Disk fingerprint `${totalSpace}:${freeSpace}` — for instances with no
- *      group set. `freeSpace` drifts byte-by-byte as data is written, so an
- *      identical (total, free) pair across two instances is an extremely
- *      reliable "same filesystem" signal. The only realistic collision is
- *      near-empty disks of equal size (free ≈ total), where under-counting is
- *      harmless because the user has abundant space.
+ * Pipeline per contributor (order matters):
+ *   1. Storage-group dedup — if the operator declared `storageGroupId` and we
+ *      already saw it on a prior contributor, mark every disk as
+ *      `"deduplicated"` and skip the rest. (Existing PR #490 behavior.)
+ *   2. Root-folder filter — partition into media/non-media via
+ *      `filterToRootFolderDisks`. Non-media entries are recorded as
+ *      `"no-matching-root-folder"`.
+ *   3. Fingerprint dedup — for each surviving media entry, check
+ *      `${totalSpace}:${freeSpace}` against `seenDisks`. Duplicates are
+ *      recorded as `"deduplicated"`; first-sightings are summed into the
+ *      rollup and marked `"media"`.
  *
- * Mount path is deliberately not consulted: under Docker/Unraid the same array
- * is bind-mounted under different container paths per service (/tv vs /movies),
- * so it can neither confirm nor split a shared disk — hence it isn't carried at
- * all (see toDiskMounts).
+ * The `disks` array in the return value carries every entry observed (in
+ * encounter order across contributors) with its final include-reason — that
+ * powers the UI's "Show all disks" breakdown without the frontend having to
+ * re-derive the decision.
  *
  * `instanceCount` counts every instance that reports storage, regardless of
- * whether its disks were de-duplicated away by either signal, so the UI can
- * honestly say "N disks across M instances" — including for the operator who
- * configured storage groups (the good-citizen path must not read as fewer
- * instances than the un-configured one).
+ * whether its disks were de-duplicated or filtered away — the UI can honestly
+ * say "N disks across M instances" including for operators who configured
+ * storage groups (the good-citizen path must not read as fewer instances than
+ * the un-configured one).
  */
 export const combineDiskStats = (contributors: DiskContributor[]): CombinedDiskTotals => {
 	const seenGroups = new Set<string>();
@@ -311,6 +451,23 @@ export const combineDiskStats = (contributors: DiskContributor[]): CombinedDiskT
 	let free = 0;
 	let diskCount = 0;
 	let instanceCount = 0;
+	const disks: DiskBreakdownEntry[] = [];
+
+	const recordEntry = (
+		entry: DiskSpaceEntry,
+		includedInRollup: boolean,
+		reason: DiskFilterReason,
+		instanceName: string | undefined,
+	): void => {
+		disks.push({
+			path: entry.path ?? undefined,
+			totalSpace: entry.totalSpace ?? 0,
+			freeSpace: entry.freeSpace ?? 0,
+			includedInRollup,
+			reason,
+			instanceName,
+		});
+	};
 
 	for (const contributor of contributors) {
 		const usableEntries = (contributor.diskEntries ?? []).filter(
@@ -319,38 +476,69 @@ export const combineDiskStats = (contributors: DiskContributor[]): CombinedDiskT
 		if (usableEntries.length > 0) instanceCount += 1;
 
 		const group = contributor.storageGroupId?.trim();
-		if (group) {
-			if (seenGroups.has(group)) continue;
-			seenGroups.add(group);
+		const groupDuplicate = group ? seenGroups.has(group) : false;
+		if (group && !groupDuplicate) seenGroups.add(group);
+
+		if (groupDuplicate) {
+			// Whole contributor is a known duplicate by operator declaration —
+			// record every entry as `"deduplicated"` and move on. Don't bother
+			// running the root-folder filter since the operator already told us
+			// these instances share storage.
+			for (const entry of usableEntries) {
+				recordEntry(entry, false, "deduplicated", contributor.instanceName);
+			}
+			continue;
 		}
 
-		for (const entry of usableEntries) {
+		const { included: mediaEntries, excluded: nonMediaEntries } = filterToRootFolderDisks(
+			usableEntries,
+			contributor.rootFolderPaths,
+		);
+
+		for (const entry of nonMediaEntries) {
+			recordEntry(entry, false, "no-matching-root-folder", contributor.instanceName);
+		}
+
+		for (const entry of mediaEntries) {
 			const entryTotal = entry.totalSpace ?? 0;
 			const entryFree = entry.freeSpace ?? 0;
-
 			const key = `${entryTotal}:${entryFree}`;
-			if (seenDisks.has(key)) continue;
-			seenDisks.add(key);
+			const fingerprintDuplicate = seenDisks.has(key);
 
-			total += entryTotal;
-			free += entryFree;
-			diskCount += 1;
+			if (!fingerprintDuplicate) {
+				seenDisks.add(key);
+				total += entryTotal;
+				free += entryFree;
+				diskCount += 1;
+			}
+			recordEntry(
+				entry,
+				!fingerprintDuplicate,
+				fingerprintDuplicate ? "deduplicated" : "media",
+				contributor.instanceName,
+			);
 		}
 	}
 
 	const used = Math.max(0, total - free);
 	const usagePercent = total > 0 ? clampPercentage((used / total) * 100) : 0;
 
-	return { total, free, used, usagePercent, diskCount, instanceCount };
+	return { total, free, used, usagePercent, diskCount, instanceCount, disks };
 };
 
 /**
  * Minimal per-instance shape needed to compute combined disk stats.
  * Structurally compatible with the route's per-service instance arrays.
+ *
+ * `data.rootFolderPaths` and `instanceName` are optional and additive (#495):
+ * when present, they're plumbed through `buildCombinedDiskPayload` into the
+ * underlying `DiskContributor` so the root-folder filter has the signal it
+ * needs and the breakdown can attribute each disk row to its source instance.
  */
 export interface DiskBearingInstance {
 	storageGroupId?: string | null;
-	data: { diskEntries?: DiskSpaceEntry[] };
+	instanceName?: string;
+	data: { diskEntries?: DiskSpaceEntry[]; rootFolderPaths?: readonly string[] };
 }
 
 /**
@@ -368,6 +556,13 @@ export interface DiskBearingServiceInstances {
 
 /**
  * Shape returned to the API response under `combinedDisk`.
+ *
+ * The four legacy `disk*` fields reflect the **filtered** rollup (post-#495):
+ * they sum only disks that hold *arr root folders (when root folders are
+ * configured) and have passed the storage-group / fingerprint dedup. The
+ * `disks` array carries the per-disk breakdown for the UI's "Show all disks"
+ * expansion — including disks that were excluded from the rollup, with a
+ * machine-readable reason.
  */
 export interface CombinedDiskPayload {
 	diskTotal: number;
@@ -376,6 +571,7 @@ export interface CombinedDiskPayload {
 	diskUsagePercent: number;
 	diskCount: number;
 	instanceCount: number;
+	disks: DiskBreakdownEntry[];
 }
 
 /**
@@ -397,6 +593,8 @@ export const buildCombinedDiskPayload = (
 	].map((entry) => ({
 		storageGroupId: entry.storageGroupId,
 		diskEntries: entry.data.diskEntries ?? [],
+		rootFolderPaths: entry.data.rootFolderPaths,
+		instanceName: entry.instanceName,
 	}));
 
 	const combined = combineDiskStats(contributors);
@@ -409,6 +607,7 @@ export const buildCombinedDiskPayload = (
 		diskUsagePercent: combined.usagePercent,
 		diskCount: combined.diskCount,
 		instanceCount: combined.instanceCount,
+		disks: combined.disks,
 	};
 };
 

--- a/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
@@ -30,10 +30,15 @@ function Wrapper({ children }: { children: ReactNode }) {
 
 type Props = ComponentProps<typeof OverviewTab>;
 
-const baseProps = (combinedDisk: Props["combinedDisk"]): Props =>
+const baseProps = (
+	combinedDisk: Omit<Props["combinedDisk"], "disks"> &
+		Partial<Pick<Props["combinedDisk"], "disks">>,
+): Props =>
 	({
 		allHealthIssues: [],
-		combinedDisk,
+		// Default `disks` to [] for fixtures that don't care about the breakdown;
+		// individual cases can still override by supplying it.
+		combinedDisk: { disks: [], ...combinedDisk },
 		sonarrRows: [],
 		radarrRows: [],
 		lidarrRows: [],

--- a/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
+++ b/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+/**
+ * Per-disk breakdown for the dashboard's combined-storage rollup (issue #495).
+ *
+ * The headline storage card answers "how much media space do I have?". This
+ * panel answers "how was that number computed?" — every disk every connected
+ * *arr reported, with a per-row tag explaining whether it was counted in the
+ * rollup, deduplicated by another instance, or excluded as non-media.
+ *
+ * Privacy: raw filesystem paths are sensitive (they leak the operator's
+ * storage layout). When incognito mode is on, paths render as `Disk N`
+ * placeholders. The wire still carries unredacted paths so the UI can be
+ * useful when the user has incognito off; the gating is purely render-side.
+ */
+
+import type { DiskBreakdownEntry } from "@arr/shared";
+import { CheckCircle2, XCircle } from "lucide-react";
+
+import { useIncognitoMode } from "@/contexts/IncognitoContext";
+import { cn } from "@/lib/utils";
+
+import { formatBytes } from "../lib/formatters";
+
+interface DiskBreakdownPanelProps {
+	disks: DiskBreakdownEntry[];
+}
+
+const REASON_LABEL: Record<DiskBreakdownEntry["reason"], string> = {
+	media: "Media",
+	"no-matching-root-folder": "No *arr root folder on this disk",
+	deduplicated: "Already counted via another instance",
+};
+
+const REASON_TONE: Record<DiskBreakdownEntry["reason"], string> = {
+	media: "text-emerald-500 dark:text-emerald-400",
+	"no-matching-root-folder": "text-muted-foreground",
+	deduplicated: "text-muted-foreground",
+};
+
+export const DiskBreakdownPanel = ({ disks }: DiskBreakdownPanelProps) => {
+	const [incognitoMode] = useIncognitoMode();
+
+	if (disks.length === 0) {
+		return (
+			<div className="rounded-xl border border-border/50 bg-card/30 p-6 text-center text-sm text-muted-foreground backdrop-blur-sm">
+				No disks reported by any connected instance.
+			</div>
+		);
+	}
+
+	return (
+		<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm">
+			<div className="border-b border-border/50 px-4 py-3">
+				<h3 className="text-sm font-medium text-foreground">Storage Breakdown</h3>
+				<p className="mt-0.5 text-xs text-muted-foreground">
+					Disks included in the rollup hold at least one configured *arr root folder. Disks marked
+					excluded carry config, container OS, or system data that isn't media.
+				</p>
+			</div>
+			<ul className="divide-y divide-border/50">
+				{disks.map((disk, idx) => {
+					const Icon = disk.includedInRollup ? CheckCircle2 : XCircle;
+					const displayPath = incognitoMode ? `Disk ${idx + 1}` : (disk.path ?? `Disk ${idx + 1}`);
+					const usedSpace = Math.max(0, disk.totalSpace - disk.freeSpace);
+					const usagePercent =
+						disk.totalSpace > 0 ? Math.min(100, (usedSpace / disk.totalSpace) * 100) : 0;
+					const displayInstance = incognitoMode ? "Instance" : (disk.instanceName ?? undefined);
+
+					return (
+						<li key={`${disk.path ?? "no-path"}-${idx}`} className="px-4 py-3">
+							<div className="flex items-start gap-3">
+								<Icon
+									className={cn(
+										"mt-0.5 h-4 w-4 shrink-0",
+										disk.includedInRollup
+											? "text-emerald-500 dark:text-emerald-400"
+											: "text-muted-foreground/60",
+									)}
+								/>
+								<div className="min-w-0 flex-1">
+									<div className="flex items-baseline justify-between gap-3">
+										<code className="truncate font-mono text-sm font-medium text-foreground">
+											{displayPath}
+										</code>
+										<span className="shrink-0 text-xs text-muted-foreground">
+											{formatBytes(disk.freeSpace)} free of {formatBytes(disk.totalSpace)}
+										</span>
+									</div>
+									<div className="mt-1.5 h-1 overflow-hidden rounded-full bg-muted/40">
+										<div
+											className={cn(
+												"h-full rounded-full transition-all",
+												disk.includedInRollup
+													? "bg-emerald-500/70 dark:bg-emerald-400/70"
+													: "bg-muted-foreground/30",
+											)}
+											style={{ width: `${usagePercent}%` }}
+										/>
+									</div>
+									<div className="mt-1.5 flex items-center justify-between gap-3 text-xs">
+										<span className={cn("font-medium", REASON_TONE[disk.reason])}>
+											{REASON_LABEL[disk.reason]}
+										</span>
+										{displayInstance ? (
+											<span className="text-muted-foreground">{displayInstance}</span>
+										) : null}
+									</div>
+								</div>
+							</div>
+						</li>
+					);
+				})}
+			</ul>
+		</div>
+	);
+};

--- a/apps/web/src/features/statistics/components/overview-tab.tsx
+++ b/apps/web/src/features/statistics/components/overview-tab.tsx
@@ -27,6 +27,7 @@ import {
 import { getServiceGradient, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 import type { useStatisticsData } from "../hooks/useStatisticsData";
 import { formatBytes, formatPercent } from "../lib/formatters";
+import { DiskBreakdownPanel } from "./disk-breakdown-panel";
 import { ServiceQuickCard } from "./service-quick-card";
 import type { StatisticsTab } from "./statistics-tabs";
 
@@ -80,16 +81,25 @@ export const OverviewTab = ({
 	const [incognitoMode] = useIncognitoMode();
 	const [healthExpanded, setHealthExpanded] = useState(false);
 
-	// Transparency for the combined storage figure: when more than one instance
-	// feeds the total, show how many unique disks it collapsed to, so a large
-	// number reads as "N disks across M instances" instead of an unexplained sum.
+	// Transparency for the combined storage figure (#495). When the root-folder
+	// filter has trimmed the rollup from all reported disks down to media-only,
+	// surface that as "N of M disks" so the headline number is auditable from
+	// the card itself; the user can then expand the breakdown for the per-disk
+	// detail. When no filtering was needed (single-instance, no excluded disks),
+	// fall back to the pre-#495 "N disks across M instances" line.
+	const breakdownDisks = combinedDisk.disks ?? [];
+	const reportedDiskCount = breakdownDisks.length;
 	const storageDescription = (() => {
 		const base = `of ${formatBytes(combinedDisk.diskTotal)} available`;
 		const { diskCount, instanceCount } = combinedDisk;
+		if (reportedDiskCount > 0 && diskCount && reportedDiskCount > diskCount) {
+			return `${base} · ${diskCount} of ${reportedDiskCount} disks (media only)`;
+		}
 		if (!diskCount || !instanceCount || instanceCount <= 1) return base;
 		const disks = `${diskCount} disk${diskCount === 1 ? "" : "s"}`;
 		return `${base} · ${disks} across ${instanceCount} instances`;
 	})();
+	const [storageBreakdownOpen, setStorageBreakdownOpen] = useState(false);
 
 	// Fetch Plex summary data when Tautulli is available
 	const { data: tautulliStats } = useTautulliStats(30, hasTautulli);
@@ -289,6 +299,32 @@ export const OverviewTab = ({
 					animationDelay={550}
 				/>
 			</div>
+
+			{/* Per-disk breakdown — explains how the combined storage figure was
+			    computed (#495). Hidden by default; toggleable from the small text
+			    affordance below. Skipped entirely if the backend didn't return any
+			    breakdown entries (e.g. no instances reporting storage). */}
+			{breakdownDisks.length > 0 ? (
+				<div
+					className="animate-in fade-in slide-in-from-bottom-4 duration-500"
+					style={{ animationDelay: "600ms", animationFillMode: "backwards" }}
+				>
+					<button
+						type="button"
+						onClick={() => setStorageBreakdownOpen((v) => !v)}
+						className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+					>
+						{storageBreakdownOpen
+							? "Hide storage breakdown ▴"
+							: `Show storage breakdown (${breakdownDisks.length} disks) ▾`}
+					</button>
+					{storageBreakdownOpen ? (
+						<div className="mt-3">
+							<DiskBreakdownPanel disks={breakdownDisks} />
+						</div>
+					) : null}
+				</div>
+			) : null}
 
 			{/* Service Quick Stats */}
 			<div

--- a/apps/web/src/features/statistics/hooks/useStatisticsData.ts
+++ b/apps/web/src/features/statistics/hooks/useStatisticsData.ts
@@ -456,6 +456,10 @@ export const useStatisticsData = () => {
 			diskFree,
 			diskUsed,
 			diskUsagePercent: diskTotal > 0 ? (diskUsed / diskTotal) * 100 : 0,
+			// Fallback path has no breakdown data — backend assembles the disks
+			// array as part of combineDiskStats. Empty here keeps the shape valid
+			// for the UI without inventing entries we don't actually have.
+			disks: [],
 		};
 	}, [data?.combinedDisk, sonarrAggregate, radarrAggregate, lidarrAggregate, readarrAggregate]);
 

--- a/packages/shared/src/types/dashboard.ts
+++ b/packages/shared/src/types/dashboard.ts
@@ -301,15 +301,48 @@ export type TagBreakdown = z.infer<typeof tagBreakdownSchema>;
  * A single mount/disk as reported by an *arr instance's diskspace endpoint.
  * Carried per-instance so the combined disk total can de-duplicate disks that
  * multiple instances report (e.g. several services bind-mounted to one array).
- * Mount path is intentionally omitted — it isn't used for de-duplication and
- * shipping raw filesystem paths would leak the operator's layout.
+ *
+ * `path` is carried so the #495 root-folder filter can decide which disks
+ * hold media. It IS sensitive (raw filesystem layout) — the frontend must
+ * pass it through `useIncognitoMode()` anonymization before rendering, the
+ * same way it does for instance names and titles. The server ships unredacted
+ * data; the UI gates display.
  */
 export const diskMountSchema = z.object({
+	path: z.string().optional(),
 	totalSpace: z.number().optional(),
 	freeSpace: z.number().optional(),
 });
 
 export type DiskMount = z.infer<typeof diskMountSchema>;
+
+/**
+ * Why a disk did or didn't make it into the combined rollup (issue #495).
+ *
+ *   - `"media"`                    — included; holds at least one *arr root folder
+ *   - `"no-matching-root-folder"`  — excluded; no root folder lives on this disk
+ *   - `"deduplicated"`             — excluded; another contributor already counted
+ *                                    this disk (storage-group or fingerprint match)
+ */
+export const diskFilterReasonSchema = z.enum(["media", "no-matching-root-folder", "deduplicated"]);
+
+export type DiskFilterReason = z.infer<typeof diskFilterReasonSchema>;
+
+/**
+ * Per-disk row used by the "Show all disks" breakdown UI. Mirrors the backend
+ * `DiskBreakdownEntry` produced by `combineDiskStats`. `path` carries the same
+ * sensitivity caveat as `diskMountSchema` — anonymize on the frontend.
+ */
+export const diskBreakdownEntrySchema = z.object({
+	path: z.string().optional(),
+	totalSpace: z.number(),
+	freeSpace: z.number(),
+	includedInRollup: z.boolean(),
+	reason: diskFilterReasonSchema,
+	instanceName: z.string().optional(),
+});
+
+export type DiskBreakdownEntry = z.infer<typeof diskBreakdownEntrySchema>;
 
 export const sonarrStatisticsSchema = z.object({
 	totalSeries: z.number(),
@@ -332,6 +365,13 @@ export const sonarrStatisticsSchema = z.object({
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
 	diskEntries: z.array(diskMountSchema).optional(),
+	/**
+	 * Configured *arr root folder paths (#495). Used by the dashboard's
+	 * combined-disk rollup to filter out non-media disks (container `/`,
+	 * config volumes, etc.). Sensitive — frontend renders under incognito
+	 * anonymization.
+	 */
+	rootFolderPaths: z.array(z.string()).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -356,6 +396,13 @@ export const radarrStatisticsSchema = z.object({
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
 	diskEntries: z.array(diskMountSchema).optional(),
+	/**
+	 * Configured *arr root folder paths (#495). Used by the dashboard's
+	 * combined-disk rollup to filter out non-media disks (container `/`,
+	 * config volumes, etc.). Sensitive — frontend renders under incognito
+	 * anonymization.
+	 */
+	rootFolderPaths: z.array(z.string()).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -411,6 +458,13 @@ export const lidarrStatisticsSchema = z.object({
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
 	diskEntries: z.array(diskMountSchema).optional(),
+	/**
+	 * Configured *arr root folder paths (#495). Used by the dashboard's
+	 * combined-disk rollup to filter out non-media disks (container `/`,
+	 * config volumes, etc.). Sensitive — frontend renders under incognito
+	 * anonymization.
+	 */
+	rootFolderPaths: z.array(z.string()).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -437,6 +491,13 @@ export const readarrStatisticsSchema = z.object({
 	diskUsed: z.number().optional(),
 	diskUsagePercent: z.number().optional(),
 	diskEntries: z.array(diskMountSchema).optional(),
+	/**
+	 * Configured *arr root folder paths (#495). Used by the dashboard's
+	 * combined-disk rollup to filter out non-media disks (container `/`,
+	 * config volumes, etc.). Sensitive — frontend renders under incognito
+	 * anonymization.
+	 */
+	rootFolderPaths: z.array(z.string()).optional(),
 	healthIssues: z.number().optional(),
 	healthIssuesList: z.array(healthIssueSchema).optional(),
 });
@@ -457,6 +518,12 @@ export const combinedDiskStatsSchema = z.object({
 	diskCount: z.number().optional(),
 	/** Number of instances that contributed at least one unique disk. */
 	instanceCount: z.number().optional(),
+	/**
+	 * Per-disk breakdown for the "Show all disks" UI (issue #495). Every
+	 * disk observed across contributors appears here with its final
+	 * include/exclude decision and reason. Defaults to `[]` for empty cases.
+	 */
+	disks: z.array(diskBreakdownEntrySchema).default([]),
 });
 
 export type CombinedDiskStats = z.infer<typeof combinedDiskStatsSchema>;


### PR DESCRIPTION
## Summary
- Filters the dashboard's combined-storage rollup to disks that hold *arr root folders — closes #495
- Adds a per-disk breakdown UI ("Show storage breakdown") that explains how the rollup was computed, showing every disk every instance reported and why each was included or excluded
- Shape-agnostic across containerized vs bare-metal *arrs; falls back to current behavior when no root folders are configured (no regression)

## The bug it solves

The #495 reporter sees combined storage that adds up the container's `/`, a `/config` bind-mount, and the actual media disk — yielding "3.3 TB available" when only 2.5 TB is media. PR #490's fingerprint dedup catches *identical* disks across instances but can't tell apart "non-media" disks (their fingerprints are unique).

My own Sonarr (containerized) reads three disks: `/` 1.5 TiB, `/data` 131 TiB, `/config` 585.5 GiB. Today the rollup reports ~133 TiB. After this PR: **131 TiB · 1 of 3 disks (media only)**, with the breakdown panel showing the other two excluded with reasons.

## How the filter works

The rule: **a disk is kept if and only if at least one of the instance's configured *arr root folders has the disk's path as its longest matching prefix.**

- Containerized `/data` + root folder `/data/tv` → `/data` wins over `/` (longer prefix). `/` and `/config` dropped.
- Bare-metal disk-only-`/` + root folder `/home/user/Media` → `/` is the only candidate, kept.
- Path-segment-aware: `/data` matches `/data/tv` but NOT `/dataother/movies`.
- Safety net: when no root folders supplied (first-run, fetch failure, misconfig), the filter keeps everything — no risk of the rollup dropping to 0 TB.

## Backend
- `statistics-utils.ts`: new `DiskBreakdownEntry` + `DiskFilterReason` types; new `filterToRootFolderDisks` helper (longest-prefix-wins, trailing-slash-normalizing, path-segment-aware); `combineDiskStats` refactored to apply the filter and emit the breakdown alongside the totals
- `toDiskMounts` now preserves `path` on the wire (the breakdown UI needs it; incognito gating is render-side)
- `dashboard-statistics.ts`: all four aggregators (Sonarr/Radarr/Lidarr/Readarr) fetch root folders via `client.rootFolder.getAll()` in parallel with `client.diskSpace.getAll()` and emit `rootFolderPaths` in the per-instance payload
- `dedupe` pipeline from PR #490 runs **after** the filter so its semantics are preserved

## Shared types
- `diskMountSchema` gains `path`
- New `diskBreakdownEntrySchema` + `diskFilterReasonSchema` (`"media"` / `"no-matching-root-folder"` / `"deduplicated"`)
- All four *arr statistics schemas gain `rootFolderPaths`
- `combinedDiskStatsSchema` gains `disks` (defaulted to `[]`)

## Frontend
- New `DiskBreakdownPanel` component: per-disk rows with ✓/⊘ icon, reason label, usage bar, instance attribution. Paths render as `Disk N` under incognito mode.
- `overview-tab.tsx`: headline now reads `"1 of 3 disks (media only)"` when the filter trimmed the rollup. A `Show storage breakdown (N disks) ▾` toggle below the StatCards row reveals the panel.
- `useStatisticsData.ts` fallback extended to provide `disks: []` so the shape stays consistent in the no-`combinedDisk` path.

## Test plan
- [x] 11 new statistics-utils tests covering: fallback to keep-all when no root folders supplied, longest-prefix wins, bare-metal `/`-only setups, path-segment boundaries, trailing-slash normalization, multiple root folders per disk, the reporter's exact Sonarr setup, group + fingerprint dedup interaction with the filter
- [x] `toDiskMounts` "preserves path" test updated for the new wire shape
- [x] `overview-tab-storage` test helper extended to default `disks: []`
- [x] `pnpm --filter @arr/api exec tsc --noEmit` — clean
- [x] `pnpm --filter @arr/web exec tsc --noEmit` — clean
- [x] `pnpm run test` — all 4 packages pass

## What changes for users
- The Storage headline number is now honest: it shows media space, not the sum of everything mounted in the container
- The "X of Y disks (media only)" subtitle makes the filter auditable from the card itself
- A new expandable breakdown panel explains the full picture: every disk, in or out, with a reason
- Users with no root folders configured see no change (safety net)

🤖 Generated with [Claude Code](https://claude.com/claude-code)