### PR TITLE
fix(statistics): pre-2.21.0 review fixes for the disk-rollup filter (#495 follow-up)

### DIFF
--- a/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
+++ b/apps/api/src/lib/statistics/__tests__/combine-disk-stats.test.ts
@@ -175,6 +175,7 @@ describe("combineDiskStats", () => {
 				diskUsagePercent: combined.usagePercent,
 				diskCount: combined.diskCount,
 				instanceCount: combined.instanceCount,
+				disks: combined.disks,
 			},
 		};
 
@@ -183,6 +184,32 @@ describe("combineDiskStats", () => {
 		expect(parsed.combinedDisk?.diskTotal).toBe(120 * TB); // not the 240 TB naive sum
 		expect(parsed.combinedDisk?.diskCount).toBe(1);
 		expect(parsed.combinedDisk?.instanceCount).toBe(2);
+		// The breakdown survives the parse: both contributors' entries are
+		// present (1 counted + 1 deduplicated), each with its reason intact.
+		expect(parsed.combinedDisk?.disks).toHaveLength(2);
+		expect(parsed.combinedDisk?.disks?.map((d) => d.reason)).toEqual(["media", "deduplicated"]);
+	});
+
+	it("defaults disks to [] when an older payload omits the field", () => {
+		// `combinedDiskStatsSchema` declares `disks` with `.default([])` — pin
+		// that contract so a future schema edit can't silently drop the field
+		// and break the frontend's `combinedDisk.disks ?? []` consumers.
+		const parsed = dashboardStatisticsResponseSchema.parse({
+			sonarr: { instances: [], aggregate: undefined },
+			radarr: { instances: [], aggregate: undefined },
+			prowlarr: { instances: [], aggregate: undefined },
+			lidarr: { instances: [], aggregate: undefined },
+			readarr: { instances: [], aggregate: undefined },
+			combinedDisk: {
+				diskTotal: 1,
+				diskFree: 1,
+				diskUsed: 0,
+				diskUsagePercent: 0,
+				// disks intentionally omitted — legacy shape
+			},
+		});
+
+		expect(parsed.combinedDisk?.disks).toEqual([]);
 	});
 });
 
@@ -377,6 +404,46 @@ describe("filterToRootFolderDisks (#495)", () => {
 		const { included } = filterToRootFolderDisks(entries, ["/data/tv", "/data/movies"]);
 
 		expect(included.map((e) => e.path)).toEqual(["/data"]);
+	});
+
+	it("matches Windows-native *arr paths (backslash separators, drive roots)", () => {
+		// Regression (v2.21.0 pre-release review): isPathPrefix only recognized
+		// "/" as a separator, so a Windows-native Sonarr reporting `C:\` and a
+		// root folder `C:\Media\TV` never matched — the rollup dropped to 0 and
+		// the storage card disappeared entirely. Backslashes are normalized to
+		// forward slashes before comparison, making `C:` a valid path-segment
+		// prefix of `C:/Media/TV`.
+		const entries = [
+			{ path: "C:\\", totalSpace: 1 * TB, freeSpace: 0.2 * TB }, // OS drive
+			{ path: "D:\\", totalSpace: 8 * TB, freeSpace: 3 * TB }, // media drive
+		];
+
+		const { included, excluded } = filterToRootFolderDisks(entries, ["D:\\Media\\TV"]);
+
+		expect(included.map((e) => e.path)).toEqual(["D:\\"]);
+		expect(excluded.map((e) => e.path)).toEqual(["C:\\"]);
+	});
+
+	it("does not let a Windows drive root match a different drive's root folder", () => {
+		// `C:` must not be treated as a prefix of `D:/Media` — the path-segment
+		// rule still applies after slash normalization.
+		const entries = [{ path: "C:\\", totalSpace: 1 * TB, freeSpace: 0.2 * TB }];
+
+		const { included, excluded } = filterToRootFolderDisks(entries, ["D:\\Media"]);
+
+		expect(included).toEqual([]);
+		expect(excluded.map((e) => e.path)).toEqual(["C:\\"]);
+	});
+
+	it("matches UNC paths (\\\\server\\share)", () => {
+		const entries = [
+			{ path: "\\\\nas\\media", totalSpace: 100 * TB, freeSpace: 40 * TB },
+			{ path: "C:\\", totalSpace: 1 * TB, freeSpace: 0.5 * TB },
+		];
+
+		const { included } = filterToRootFolderDisks(entries, ["\\\\nas\\media\\tv"]);
+
+		expect(included.map((e) => e.path)).toEqual(["\\\\nas\\media"]);
 	});
 
 	it("excludes everything when no disk's path is a prefix of any root folder", () => {

--- a/apps/api/src/lib/statistics/statistics-utils.ts
+++ b/apps/api/src/lib/statistics/statistics-utils.ts
@@ -332,12 +332,21 @@ export interface CombinedDiskTotals extends DiskTotals {
 }
 
 /**
- * Normalize a mount path for prefix comparison: trim whitespace, drop trailing
- * "/" except when the entire path is "/" (which stays). Keeps "/data" and
- * "/data/" identical without collapsing the root.
+ * Normalize a mount path for prefix comparison: trim whitespace, convert
+ * Windows backslashes to forward slashes (so `C:\Media\TV` and UNC
+ * `\\server\share` compare uniformly with Unix paths — *arrs running
+ * natively on Windows report `\`-separated paths from both diskspace and
+ * rootfolder endpoints), then drop the trailing "/" except when the entire
+ * path is "/" (which stays). Keeps "/data" and "/data/" identical without
+ * collapsing the root, and turns `C:\` into `C:`.
+ *
+ * Casing is deliberately NOT folded: disk paths and root-folder paths for a
+ * given contributor come from the same *arr instance, so their casing is
+ * internally consistent — and folding would corrupt comparisons on
+ * case-sensitive Linux filesystems.
  */
 const normalizePath = (raw: string): string => {
-	const trimmed = raw.trim();
+	const trimmed = raw.trim().replace(/\\/g, "/");
 	if (trimmed === "" || trimmed === "/") return trimmed;
 	return trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
 };
@@ -345,7 +354,9 @@ const normalizePath = (raw: string): string => {
 /**
  * True when `diskPath` is a path-segment prefix of `rfPath` (or equal). This
  * is what makes "/data" match "/data/tv" but not "/dataother" — the next char
- * after the prefix has to be "/" or end-of-string.
+ * after the prefix has to be "/" or end-of-string. Windows paths arrive here
+ * already slash-normalized (see normalizePath), so `C:` is a valid
+ * path-segment prefix of `C:/Media/TV`.
  *
  * Both paths must already be normalized via `normalizePath`.
  */

--- a/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/overview-tab-storage.test.tsx
@@ -75,6 +75,79 @@ describe("OverviewTab — Storage transparency line", () => {
 		expect(screen.getByText(/1 disk across 4 instances/)).toBeInTheDocument();
 	});
 
+	it("does NOT show '(media only)' for dedup-only breakdowns (v2.21.0 review regression)", () => {
+		// The issue-#486 canonical case: 4 *arrs on 1 shared array, no root-folder
+		// exclusions. The breakdown carries 1 "media" + 3 "deduplicated" entries,
+		// so disks.length (4) > diskCount (1) purely from dedup. The "(media
+		// only)" label must NOT fire — it's gated on at least one
+		// "no-matching-root-folder" exclusion, not on a raw count comparison.
+		const sharedDisk = { path: "/data", totalSpace: 120 * TB, freeSpace: 105 * TB };
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 120 * TB,
+					diskFree: 105 * TB,
+					diskUsed: 15 * TB,
+					diskUsagePercent: 12.5,
+					diskCount: 1,
+					instanceCount: 4,
+					disks: [
+						{ ...sharedDisk, includedInRollup: true, reason: "media" },
+						{ ...sharedDisk, includedInRollup: false, reason: "deduplicated" },
+						{ ...sharedDisk, includedInRollup: false, reason: "deduplicated" },
+						{ ...sharedDisk, includedInRollup: false, reason: "deduplicated" },
+					],
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		expect(screen.queryByText(/media only/)).not.toBeInTheDocument();
+		expect(screen.getByText(/1 disk across 4 instances/)).toBeInTheDocument();
+	});
+
+	it("shows '(media only)' when the root-folder filter excluded non-media disks", () => {
+		// The issue-#495 case: container `/` and `/config` excluded, `/data` kept.
+		render(
+			<OverviewTab
+				{...baseProps({
+					diskTotal: 131 * TB,
+					diskFree: 37 * TB,
+					diskUsed: 94 * TB,
+					diskUsagePercent: 71.8,
+					diskCount: 1,
+					instanceCount: 1,
+					disks: [
+						{
+							path: "/data",
+							totalSpace: 131 * TB,
+							freeSpace: 37 * TB,
+							includedInRollup: true,
+							reason: "media",
+						},
+						{
+							path: "/",
+							totalSpace: 1.5 * TB,
+							freeSpace: 0.5 * TB,
+							includedInRollup: false,
+							reason: "no-matching-root-folder",
+						},
+						{
+							path: "/config",
+							totalSpace: 0.5 * TB,
+							freeSpace: 0.4 * TB,
+							includedInRollup: false,
+							reason: "no-matching-root-folder",
+						},
+					],
+				})}
+			/>,
+			{ wrapper: Wrapper },
+		);
+
+		expect(screen.getByText(/1 of 3 disks \(media only\)/)).toBeInTheDocument();
+	});
+
 	it("pluralizes 'disks' when more than one unique disk is counted", () => {
 		render(
 			<OverviewTab

--- a/apps/web/src/features/statistics/components/overview-tab.tsx
+++ b/apps/web/src/features/statistics/components/overview-tab.tsx
@@ -82,17 +82,23 @@ export const OverviewTab = ({
 	const [healthExpanded, setHealthExpanded] = useState(false);
 
 	// Transparency for the combined storage figure (#495). When the root-folder
-	// filter has trimmed the rollup from all reported disks down to media-only,
-	// surface that as "N of M disks" so the headline number is auditable from
-	// the card itself; the user can then expand the breakdown for the per-disk
-	// detail. When no filtering was needed (single-instance, no excluded disks),
-	// fall back to the pre-#495 "N disks across M instances" line.
+	// filter actually EXCLUDED non-media disks, surface that as "N of M disks
+	// (media only)" so the headline number is auditable from the card itself;
+	// the user can then expand the breakdown for the per-disk detail.
+	//
+	// The gate is "at least one no-matching-root-folder exclusion", NOT a raw
+	// count comparison: the breakdown array also contains `deduplicated`
+	// entries (the issue-#486 shared-array case), and for a 4-instances-on-1-
+	// array user with no root-folder filtering, `disks.length (4) > diskCount
+	// (1)` is true purely from dedup — that user must keep seeing the original
+	// "1 disk across 4 instances" line, not a misleading "(media only)".
 	const breakdownDisks = combinedDisk.disks ?? [];
 	const reportedDiskCount = breakdownDisks.length;
+	const hasNonMediaExclusions = breakdownDisks.some((d) => d.reason === "no-matching-root-folder");
 	const storageDescription = (() => {
 		const base = `of ${formatBytes(combinedDisk.diskTotal)} available`;
 		const { diskCount, instanceCount } = combinedDisk;
-		if (reportedDiskCount > 0 && diskCount && reportedDiskCount > diskCount) {
+		if (reportedDiskCount > 0 && diskCount && hasNonMediaExclusions) {
 			return `${base} · ${diskCount} of ${reportedDiskCount} disks (media only)`;
 		}
 		if (!diskCount || !instanceCount || instanceCount <= 1) return base;


### PR DESCRIPTION
## Summary
Pre-release code review of the `v2.20.0..main` diff (PR #504 merged without a review pass) found **two major bugs** in the #495 root-folder filter. Both fixed + regression-tested + live-verified before tagging v2.21.0.

## Bug 1 — "(media only)" label fired for dedup-only breakdowns (Major)
The headline gate compared `disks.length > diskCount`, but the breakdown array also carries `deduplicated` entries. The canonical issue-#486 user (4 *arrs on 1 shared array, **zero** root-folder exclusions) saw a misleading `"1 of 4 disks (media only)"` instead of the correct `"1 disk across 4 instances"`.

**Fix**: gate on `breakdownDisks.some(d => d.reason === "no-matching-root-folder")` — the label only fires when the filter actually excluded something.

## Bug 2 — Windows-native *arrs lost their storage card entirely (Major)
`isPathPrefix` only recognized `/` as a separator. A Windows-native Sonarr reporting disk `C:\` + root folder `C:\Media\TV` never matched → every disk excluded → rollup 0 → `buildCombinedDiskPayload` returns `undefined` → **storage card disappears**. A regression vs 2.20 for non-Docker Windows deployments.

**Fix**: `normalizePath` converts `\` → `/` before comparison (covers drive roots `C:\` → `C:` and UNC `\\server\share`). Casing deliberately not folded — disk + root-folder paths come from the same instance, so they're internally consistent, and folding would corrupt case-sensitive Linux comparisons.

## Minor — schema round-trip test gap
The response-schema parse test now asserts `disks` survives and that `.default([])` backfills legacy payloads omitting the field.

## Test plan
- [x] 3 new path tests: Windows drive roots, cross-drive non-match, UNC paths
- [x] 2 new overview-tab tests: dedup-only breakdown must NOT show "(media only)"; real exclusions must
- [x] Schema round-trip extended (disks present + reasons intact + legacy default)
- [x] API + Web tsc clean; all 4 packages' tests pass
- [x] **Live-verified against real LAN Sonarr/Radarr/Lidarr**: headline `93.4 TB of 131 TB · 1 of 9 disks (media only)`; breakdown shows all four code paths (filter exclusion, longest-prefix, storage-group dedup, fingerprint dedup) on real data; **incognito mode masks all 9 paths as "Disk N" with zero leaks** (screenshots: `495-breakdown-live-verify.png`, `495-breakdown-incognito-verify.png`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)