### PR TITLE
ci: extend CI to next + repurpose beta channel as :next preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, "release/**"]
+    branches: [main, next, "release/**"]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -10,7 +10,7 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
-    branches: [main, "release/**"]
+    branches: [main, next, "release/**"]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -10,7 +10,7 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
-    branches: [main]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -1,9 +1,9 @@
-name: Build and Push Beta Docker Image
+name: Build and Push Next Docker Image
 
 on:
   push:
     branches:
-      - "feat/v2.9"
+      - "next"
   workflow_dispatch:
 
 # Cancel in-progress runs when a new push arrives
@@ -75,7 +75,7 @@ jobs:
         run: |
           echo "short_sha=${FULL_SHA::7}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-          echo "version=2.9.0-beta.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "version=3.0.0-next.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
           echo "platform_slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest (GHCR)
@@ -95,8 +95,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
           outputs: type=image,name=${{ env.GHCR_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache-beta-${{ steps.meta.outputs.platform_slug }}
-          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache-beta-${{ steps.meta.outputs.platform_slug }},mode=max
+          cache-from: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache-next-${{ steps.meta.outputs.platform_slug }}
+          cache-to: type=registry,ref=${{ env.GHCR_IMAGE }}:buildcache-next-${{ steps.meta.outputs.platform_slug }},mode=max
 
       - name: Export GHCR digest
         env:
@@ -144,8 +144,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.build_date }}
           outputs: type=image,name=${{ env.DOCKERHUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:buildcache-beta-${{ steps.meta.outputs.platform_slug }}
-          cache-to: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:buildcache-beta-${{ steps.meta.outputs.platform_slug }},mode=max
+          cache-from: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:buildcache-next-${{ steps.meta.outputs.platform_slug }}
+          cache-to: type=registry,ref=${{ env.DOCKERHUB_IMAGE }}:buildcache-next-${{ steps.meta.outputs.platform_slug }},mode=max
 
       - name: Export DockerHub digest
         if: steps.dockerhub-check.outputs.available == 'true'
@@ -225,8 +225,7 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           TAGS=(
-            "-t" "${GHCR_IMAGE}:v2.9-beta"
-            "-t" "${GHCR_IMAGE}:feat-v2.9"
+            "-t" "${GHCR_IMAGE}:next"
             "-t" "${GHCR_IMAGE}:sha-${SHORT_SHA}"
             "-t" "${GHCR_IMAGE}:build-${RUN_NUMBER}"
           )
@@ -250,8 +249,7 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           TAGS=(
-            "-t" "${DOCKERHUB_IMAGE}:v2.9-beta"
-            "-t" "${DOCKERHUB_IMAGE}:feat-v2.9"
+            "-t" "${DOCKERHUB_IMAGE}:next"
             "-t" "${DOCKERHUB_IMAGE}:sha-${SHORT_SHA}"
             "-t" "${DOCKERHUB_IMAGE}:build-${RUN_NUMBER}"
           )
@@ -275,17 +273,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull beta image
-        run: docker pull "${GHCR_IMAGE}:v2.9-beta"
+      - name: Pull next image
+        run: docker pull "${GHCR_IMAGE}:next"
 
       - name: Start container
         run: |
           docker run -d \
-            --name beta-verify \
+            --name next-verify \
             -p 3001:3001 \
             -e PUID=1000 \
             -e PGID=1000 \
-            "${GHCR_IMAGE}:v2.9-beta"
+            "${GHCR_IMAGE}:next"
 
       - name: Wait for /health and validate
         run: |
@@ -327,13 +325,13 @@ jobs:
           done
 
           echo "::error::Health check did not pass within 90 seconds"
-          docker logs beta-verify 2>&1 || true
+          docker logs next-verify 2>&1 || true
           exit 1
 
       - name: Dump container logs on failure
         if: failure()
-        run: docker logs beta-verify 2>&1
+        run: docker logs next-verify 2>&1
 
       - name: Cleanup
         if: always()
-        run: docker rm -f beta-verify 2>/dev/null || true
+        run: docker rm -f next-verify 2>/dev/null || true

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -2,7 +2,7 @@ name: Docker Smoke Test
 
 on:
   pull_request:
-    branches: [main, "feat/v2.9"]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -10,7 +10,7 @@ on:
       - "LICENSE"
       - ".gitignore"
   push:
-    branches: [main, "feat/v2.9"]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -2,7 +2,7 @@ name: Semgrep
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -10,7 +10,7 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
-    branches: [main]
+    branches: [main, next]
     paths-ignore:
       - "**.md"
       - "docs/**"


### PR DESCRIPTION
## Summary
First infrastructure PR of the 3.0 cycle, implementing charter §8.2:

- **CI on `next`**: `ci.yml`, `codeql.yml`, `semgrep.yml`, `docker-smoke.yml` now trigger on pushes to `next` and PRs targeting `next` — 3.0 work gets the same gate as 2.x maintenance
- **`arr-dashboard:next` preview channel**: `docker-beta.yml` (the v2.9 cycle's preview channel, dead since `feat/v2.9` merged) is repurposed as `docker-next.yml` — every push to `next` publishes `:next` to GHCR + Docker Hub (amd64+arm64), with `sha-`/`build-` pin tags, `/health` smoke verification, and `3.0.0-next.<run>` version stamps
- Drops the stale `feat/v2.9` reference from `docker-smoke.yml` in the same pass

## Deliberate deferral
**No required status checks on `next` yet.** ADR PRs (next up) are docs-only and CI's `paths-ignore` skips `docs/**`/`**.md` — requiring checks now would deadlock them (known failure mode: paths-ignore + required check = permanently pending). Revisit when Bucket A code PRs begin.

## Validation
- [x] All 5 workflow files parse as valid YAML
- [x] Zero stale `feat/v2.9` / `v2.9-beta` references remain (checked twice — the verify job's image pulls hid two)
- [x] No new untrusted-input interpolations introduced (branch/tag literals only; existing env-var patterns untouched)

## Effects after merge
1. This merge itself pushes to `next` → first `docker-next` run → `arr-dashboard:next` goes live for early adopters
2. Every subsequent PR against `next` that touches code gets the full check suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)