### PR TITLE
docs(adr): ADRs 0005–0008 — 3.0 foundations

### DIFF
--- a/docs/adr/0005-tier-discipline.md
+++ b/docs/adr/0005-tier-discipline.md
@@ -1,0 +1,131 @@
+# ADR 0005: Tier Discipline
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** Backend maintainers
+- **Supersedes:** — (amends ADR-0004)
+- **Charter:** [3.0 charter](../3.0-charter.md) §5.1, Bucket A1
+
+## Context
+
+ADR-0004 introduced the route-manifest maturity tiers (`stable` /
+`operator` / `internal` / `experimental`) but deliberately left
+promotion and demotion criteria undefined — at the time, `experimental`
+was empty and every group's tier was assigned once, by judgment.
+
+Two years of 2.x development drifted tiers away from reality. The 3.0
+domain inventory (40 domains, six parallel audits) found:
+
+- **Auto-Tagger and Label Sync sit at `experimental`** despite having
+  zero debt signals, full `validateRequest` coverage, and the cleanest
+  backend architecture in the codebase.
+- **Hunting and Queue Cleaner sit at `internal`** despite being
+  operator-facing scheduler surfaces that operators script against.
+- **qui sits at `experimental`** despite passkey-hardening, extensive
+  test coverage, and shipping as the headline feature of v2.20.
+- **Tautulli sits at `stable`** while the project's direction (ADR-0007)
+  removes it entirely.
+
+Tier labels that disagree with maturity are worse than no labels: a
+reviewer who learns that `experimental` sometimes means "cleanest code
+in the repo" stops trusting every tier. ADR-0004 predicted exactly this
+("the cost of a tier no one understands is high").
+
+## Decision
+
+### 1. Promotion criteria
+
+A route group may be promoted one tier (experimental → internal →
+operator → stable, skipping allowed when criteria for the target tier
+are met) when **all** of:
+
+1. **Zero validation bypasses** — every mutation handler parses its body
+   via `validateRequest()`; no inline `Body:` generics without it.
+2. **Test coverage exists** at the route or service layer (not
+   necessarily exhaustive — present and meaningful).
+3. **Shape stability** — the request/response shape survived the last
+   two minor releases without breaking change, or the group is new and
+   its shape was reviewed against the target tier's discipline.
+4. **Docs parity** — the group's row in `docs/API-ROUTES.md` is accurate
+   (enforced by the existing manifest contract test).
+
+### 2. Demotion / removal criteria
+
+- Demotion (any tier → `experimental`) requires a release-notes entry
+  and a one-line rationale in the manifest summary.
+- **Removal requires a deprecation path decided in an ADR** (see
+  ADR-0007 for the Tautulli case), including the user-migration story.
+  "Stable" is a promise; breaking it silently is not an option.
+
+### 3. The 3.0 reshuffle
+
+Applied as part of Bucket A (one PR, manifest + docs + release notes):
+
+| Group | 2.x tier | 3.0 tier | Basis |
+|---|---|---|---|
+| Auto-Tagger | experimental | operator | criteria 1–4 met; sub-arcs 1–4 shipped |
+| Label Sync | experimental | operator | criteria 1–4 met; any-to-any arc complete |
+| Hunting | internal | operator | operator-facing scheduler; criteria met |
+| Queue Cleaner | internal | operator | operator-facing scheduler; criteria met |
+| TRaSH Guides | internal | operator | flagship feature set; criteria met after the Bucket A `validateRequest` migration of deployment routes |
+| qui | experimental | stable | hardened, tested, shipped headline in v2.20 |
+| Cross-seed (rides `/api/qui`) | experimental | stable | graduates with qui |
+| Tautulli | stable | **removed** | ADR-0007 |
+
+TRaSH Guides' promotion is **conditional on** the `Body:` →
+`validateRequest` migration (charter Bucket A6) landing first — it
+currently fails criterion 1.
+
+## Why this shape
+
+1. **Criteria are mechanically checkable.** Three of the four promotion
+   criteria can be verified by grep/test-run, which means tier debates
+   in PR review become evidence questions, not taste questions.
+2. **Removal goes through an ADR, not a PR description.** The single
+   place a "stable" promise can be withdrawn is a document with a
+   migration story — which is what makes the promise worth anything.
+3. **The reshuffle is one atomic PR.** Trickling tier changes across the
+   cycle would leave the manifest internally inconsistent for months.
+
+## Why not …
+
+- **Automatic tier scoring in CI.** Criteria 1–2 could be computed, but
+  criterion 3 (shape stability) needs release history and criterion 4
+  needs human judgment about doc accuracy. A half-automated score would
+  be trusted as if fully automated. Keep it a review-time checklist.
+- **A `deprecated` tier for Tautulli.** Considered (ADR-0004 reserved
+  the idea). Rejected because 3.0 removes Tautulli outright rather than
+  deprecating it across a window — a tier that exists for one group for
+  one release is ceremony. If a future removal needs a long window,
+  revisit.
+- **Re-grading everything from scratch.** The inventory found the other
+  ~19 groups' tiers accurate. Only mismatches move; stability of the
+  vocabulary is the point.
+
+## Consequences
+
+### Positive
+
+- Tier labels regain their meaning before 3.0 ships them to a larger
+  audience (the `:next` preview channel).
+- "Why is this experimental?" has a checkable answer, and the path out
+  of `experimental` is documented for future features (Tracearr will
+  enter at `experimental` and graduate by these criteria).
+
+### Negative / trade-offs
+
+- The reshuffle widens the `stable`+`operator` surface, which raises the
+  bar for future changes to those groups (CHANGELOG discipline). That is
+  the intended cost of honesty.
+- Criterion 3 ("two minor releases") is awkward during the 3.0 cycle
+  itself, when there are no 3.x minors yet. For the cycle, "two preview
+  milestones (alpha/beta)" substitutes.
+
+## Follow-ups
+
+- Apply the reshuffle in Bucket A; verify the manifest contract test
+  still passes with the new tiers.
+- Tracearr's route group (ADR-0007) enters at `experimental`; schedule
+  its graduation review at 3.0-rc.
+- When the first 3.x minor ships, retire the preview-milestone
+  substitution for criterion 3.

--- a/docs/adr/0006-unified-rule-engine.md
+++ b/docs/adr/0006-unified-rule-engine.md
@@ -1,0 +1,141 @@
+# ADR 0006: Unified Rule Engine + Migration Policy
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** Backend maintainers
+- **Supersedes:** —
+- **Charter:** [3.0 charter](../3.0-charter.md) §5.2, Bucket A4, §6.2; decision log #7, #9
+
+## Context
+
+Five operations-workflow domains each grew their own rule/predicate
+machinery, at different times, under different pressures:
+
+| Domain | Engine | Shape |
+|---|---|---|
+| Library Cleanup | `lib/library-cleanup/rule-evaluators.ts` (~82 KB) | condition-tree predicate engine |
+| Auto-Tagger | reuses library-cleanup's `evaluateSingleCondition` + shared `features/rule-criteria/` UI | predicate engine (borrowed) |
+| Queue Cleaner | `lib/queue-cleaner/rule-evaluators.ts` | its own predicate DSL over queue items |
+| Notifications | `lib/notifications/rule-engine.ts` | its own `RuleCondition` predicate language |
+| Hunting | `lib/hunting/hunt-filters.ts` | filter abstraction over wanted items |
+
+(Label Sync's `strategy-registry.ts` is adjacent but is a tag
+*transformer*, not a predicate engine — it consumes the unified engine's
+output rather than replacing its own grammar.)
+
+The duplication has real costs: three separate condition-builder UIs,
+three serialization formats in the database, bug fixes that land in one
+evaluator and not its siblings, and no way to express cross-domain
+rules ("when an item matches X, notify AND tag AND exempt from
+cleanup") — which the Operator Console's rule composer (charter §2.1)
+requires.
+
+Notifications is a `stable`-tier surface, so unifying its stored-rule
+format is a breaking change. Per the charter: bundle it into 3.0 or
+never.
+
+## Decision
+
+### 1. One grammar, per-domain contexts
+
+Build a single rule grammar — condition trees with typed field
+references, comparison operators, and AND/OR/NOT composition — consumed
+by every domain above. Each domain contributes an **evaluation
+context** (the field vocabulary its items expose: queue items expose
+`status`/`trackerHealth`, library items expose `genre`/`watchState`,
+etc.). The engine is context-generic; the contexts are domain-owned.
+
+The library-cleanup evaluator is the **seed implementation** — it is the
+largest, the most battle-tested, and already shared with Auto-Tagger.
+The other engines migrate onto it; it does not migrate onto them.
+
+The full grammar schema is a Bucket A design deliverable (charter §11),
+not part of this ADR. This ADR fixes the *direction* and the *migration
+contract*.
+
+### 2. Migration policy (per stored-rule surface)
+
+Five surfaces store rules that must survive the upgrade: Notifications,
+Library Cleanup, Queue Cleaner, Hunting filters, Auto-Tagger. Each
+migration ships with the same contract:
+
+1. **Backup before mutation** — on first 3.0 boot, the pre-migration
+   rules are written to `/config/rules-pre-3.0/<surface>.json` before
+   any row is rewritten.
+2. **Migrate in a transaction** — per-surface, all-or-nothing. A failed
+   migration leaves the surface on its legacy format and surfaces a
+   Pulse item; it must not half-convert.
+3. **One-time review notification** — "Rules migrated — review in
+   Operator Console," linking to a dry-run preview that shows each
+   migrated rule's matches under the new engine.
+4. **Rollback path** — stop 3.0, restore `<surface>.json`, downgrade the
+   Docker tag to the last 2.x. Documented in CHANGELOG per surface.
+5. **CHANGELOG table** — every surface lists its old format, new format,
+   and backup file name.
+
+### 3. Composer
+
+The Operator Console (charter §2.1) embeds one rule composer for the
+unified grammar, replacing the three existing condition-builder UIs.
+`features/rule-criteria/` (already shared by Auto-Tagger and Library
+Cleanup) is the seed for the composer, as the evaluator is for the
+engine.
+
+## Why this shape
+
+1. **Seed-and-migrate beats clean-room.** The library-cleanup evaluator
+   encodes years of edge cases (null handling, *arr field quirks). A
+   from-scratch "elegant" engine would rediscover them in production.
+2. **Contexts keep domains decoupled.** Queue Cleaner doesn't learn
+   about genres; Notifications doesn't learn about tracker health. The
+   grammar is shared; the vocabularies are not forcibly merged.
+3. **The migration contract is uniform on purpose.** Five different
+   migration UXs would each need their own support documentation. One
+   contract means one explanation in the release notes and one shape of
+   bug report.
+
+## Why not …
+
+- **Unify only Notifications + Library Cleanup** (the minimal breaking
+  set). Was the charter draft's recommended option; ratification chose
+  full unification (decision #7) because the Operator Console's
+  cross-domain composer needs all five vocabularies, and doing three
+  now + two later means two migration events for users instead of one.
+- **An off-the-shelf rules engine** (json-rules-engine etc.). The
+  existing evaluator is already written, tested, and tuned to *arr data
+  shapes; a dependency adds a foreign grammar without removing any code
+  we own.
+- **Keep engines, share only the UI.** A shared composer over five
+  serialization formats needs five serializers and five validators —
+  the worst of both worlds.
+
+## Consequences
+
+### Positive
+
+- Cross-domain rules become expressible — the capability the Operator
+  Console flagship is built around.
+- One evaluator to harden, fuzz, and document instead of five.
+- Rule-engine bug fixes apply everywhere at once.
+
+### Negative / trade-offs
+
+- Five stored-rule migrations is the largest user-data risk in 3.0.
+  The uniform contract and per-surface transactions bound it, but
+  3.0-alpha testing must include real 2.x databases with real rules.
+- The seed evaluator (82 KB) needs decomposition as it generalizes —
+  budgeted as part of the engine work, not deferred.
+- Hunting's filters are the furthest in shape from condition trees;
+  its migration may legitimately be a thin adapter rather than a full
+  rewrite. That is acceptable — the contract is about storage and
+  grammar, not internal call paths.
+
+## Follow-ups
+
+- Bucket A design pass: grammar schema (typed fields, operators,
+  serialization) — review against all five domains' existing rules
+  before freezing.
+- A `require-migration-on-rule-schema-change` lint (charter §7) once the
+  engine stabilizes.
+- Dry-run preview infrastructure is shared with the Tautulli wizard's
+  patterns (ADR-0007) where practical.

--- a/docs/adr/0007-tracearr-replaces-tautulli.md
+++ b/docs/adr/0007-tracearr-replaces-tautulli.md
@@ -1,0 +1,139 @@
+# ADR 0007: Tracearr Replaces Tautulli
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** Backend maintainers
+- **Supersedes:** the phased Tautulli-deprecation plan (memory-tracked, pre-charter)
+- **Charter:** [3.0 charter](../3.0-charter.md) §2.2, Bucket A2, §6.1; decision log #2–#6
+
+## Context
+
+Tautulli's role in arr-dashboard has been shrinking for two release
+cycles. The "Option 3" arc (PRs #373–#382) made SessionSnapshot the
+canonical analytics source and gave Jellyfin/Emby parity with Plex by
+moving the aggregation helpers into shared code; Tautulli became an
+optional enrichment source. The 3.0 inventory measured what remains:
+
+- **6 sub-route files** (vs Plex's 33, Jellyfin's 14), 1 test file —
+  the smallest and least-tested media-server integration.
+- One remaining consumer of `useTautulliStats` /
+  `useTautulliPlaysByDate` (the Statistics overview tab).
+
+Meanwhile [Tracearr](https://github.com/connorgallopo/Tracearr)
+(AGPL-3.0, self-hosted) emerged as the community's Tautulli successor:
+one integration covering **Plex + Jellyfin + Emby**, a public REST API
+(Swagger at `/api-docs`, API-key auth), Plex SSE for instant session
+detection, and — decisively — **built-in Tautulli history import**, so
+migrating users keep their watch data. Users asked for it directly
+(issue #487), with parallel requests open across the ecosystem
+(Maintainerr, Seerr).
+
+Maintaining four analytics paths (Tautulli + native Plex + Jellyfin +
+Emby sessions) is the kind of surface-area sprawl the 3.0 charter
+exists to remove.
+
+## Decision
+
+### 1. Tautulli is removed outright in 3.0
+
+All of `routes/tautulli/`, `lib/tautulli/`, `useTautulli*` hooks,
+schemas, settings UI, and `ServiceType.TAUTULLI` handling are deleted
+(charter Bucket A2). No deprecation window, no `deprecated` tier
+(see ADR-0005's "why not"). The 2.x line keeps Tautulli working until
+its end of life.
+
+### 2. Tracearr becomes the analytics backbone, with full read+write parity
+
+- Backend client (`lib/tracearr/`), routes (`routes/tracearr/`),
+  `ServiceType.TRACEARR`, connection tester, settings UI, validation-
+  health entry. Enters the route manifest at `experimental`, graduating
+  by ADR-0005 criteria.
+- **Read**: sessions, history, leaderboards, transcode analytics, trust
+  scores — the Statistics rewrite (Bucket C2) re-targets the last
+  Tautulli consumers here.
+- **Write**: stream termination, bulk actions on Tracearr-side
+  users/rules, trust-score actions (decision #6: full parity, not
+  read-only).
+- Native Plex/Jellyfin/Emby session helpers remain the **live** data
+  source; Tracearr is the **historical/analytics** source. The
+  `routes/plex/lib/` helpers are renamed to reflect their shared role
+  (charter Bucket A3).
+
+### 3. Migration: first-boot blocking wizard, no advance banner
+
+No 2.x warning banner ships (decision #3 — the 2.x line stays quiet).
+Instead, if any `ServiceInstance` row with `service = TAUTULLI` exists
+at first 3.0 boot, the dashboard presents a **blocking, non-dismissible
+wizard** (decision #4) with three paths (decision #5):
+
+1. **Set up Tracearr (recommended)** — walks through connection, points
+   at Tracearr's built-in Tautulli import for history carry-over, then
+   removes the Tautulli rows.
+2. **Continue without historical analytics** — removes the Tautulli
+   rows; live sessions keep working; Statistics shows "historical
+   analytics unavailable — set up Tracearr in Settings."
+3. **Stay on 2.x** — exits cleanly; the operator pins the previous
+   Docker tag.
+
+**No silent data loss**: Tautulli rows are deleted only by explicit
+choice, and the wizard is the only deleter.
+
+## Why this shape
+
+1. **Removal-with-destination beats deprecation-without-one.** The
+   earlier plan deprecated Tautulli with nothing to point users at.
+   Tracearr's Tautulli import turns a takeaway into a swap.
+2. **The blocking wizard concentrates all migration friction into one
+   honest moment.** A dismissible banner gets dismissed; a half-broken
+   Tautulli tab generates support issues for a year.
+3. **Full write parity from day one** keeps the integration from
+   shipping as a second-class read-only viewer that needs a follow-up
+   release to be useful for operators (kill-stream is the single most
+   requested analytics action).
+
+## Why not …
+
+- **Phased deprecation (demote tier in 3.0, remove in 4.0).** The
+  charter draft's option 3. Rejected at ratification: Tautulli usage in
+  this codebase is already vestigial, the maintenance window would span
+  a 6–12 month cycle for an integration with one remaining consumer,
+  and Tracearr's import removes the data-loss argument for going slow.
+- **Keeping both integrations.** Three analytics paths becomes four;
+  contradicts the charter thesis directly.
+- **A 2.x advance-warning banner.** Adds a coordinated 2.x release to
+  the critical path for marginal benefit — users who skip versions
+  would miss it anyway, which is exactly what the first-boot wizard
+  cannot miss.
+- **Auto-deleting Tautulli config on upgrade.** Cheapest to build,
+  silently destroys user configuration. Violates the trust thesis.
+
+## Consequences
+
+### Positive
+
+- Analytics collapses from four maintained paths to two clearly-roled
+  ones (Tracearr historical, native live).
+- ~7,000 lines of the least-tested integration leave the codebase.
+- The wizard pattern (blocking, explicit paths, no silent loss) becomes
+  the template for any future integration removal.
+
+### Negative / trade-offs
+
+- Tracearr is young; its API may churn. Mitigated by the existing
+  upstream-validation infrastructure (Zod schemas, quarantine,
+  validation-health surface) — drift degrades gracefully and visibly.
+- Users who want neither Tracearr nor data loss have no in-place
+  option; path 3 (stay on 2.x) is honest but is still an exit, not an
+  accommodation. Accepted: single-admin self-hosted users control their
+  own upgrade timing.
+- AGPL-3.0: arr-dashboard consumes Tracearr's HTTP API only — a normal
+  client relationship, no code linkage. No license obligation arises.
+
+## Follow-ups
+
+- Bucket C2 (Statistics rewrite on Tracearr) starts only after the
+  Tracearr client + routes land.
+- Wizard ships in the same PR as the Tautulli removal — the removal
+  must never exist on `next` without its migration path.
+- Schedule Tracearr's `experimental` → graduation review at 3.0-rc
+  (per ADR-0005).

--- a/docs/adr/0008-setup-auto-discovery-scope.md
+++ b/docs/adr/0008-setup-auto-discovery-scope.md
@@ -1,0 +1,111 @@
+# ADR 0008: Setup Auto-Discovery Scope
+
+- **Status:** Accepted
+- **Date:** 2026-06-09
+- **Deciders:** Backend maintainers
+- **Supersedes:** —
+- **Charter:** [3.0 charter](../3.0-charter.md) §2.3, §5.4; decision log #10
+
+## Context
+
+The 3.0 Setup rewrite (charter §2.3) includes service auto-detection:
+the first-run flow should find what it can on the local network and
+pre-fill connection forms, because manual URL + API-key entry for six
+services is the worst part of first-run today.
+
+"Detect everything" is not implementable honestly. The services
+arr-dashboard connects to split into two classes:
+
+- **Media servers ship discovery protocols.** Plex answers GDM (UDP
+  broadcast on 32414) and SSDP; Jellyfin and Emby answer a UDP
+  discovery datagram ("Who is JellyfinServer?" on 7359) and mDNS.
+  Discovery is a supported, documented use of these protocols.
+- **The *arr family ships none.** Sonarr, Radarr, Prowlarr, Lidarr, and
+  Readarr have no broadcast/announce mechanism. "Detecting" them means
+  port-scanning the subnet for 8989/7878/9696/8686/8787 and probing
+  HTTP responses — slow, unreliable across VLANs/Docker networks, and
+  indistinguishable from hostile network behavior to IDS/firewall
+  tooling that self-hosters commonly run.
+
+## Decision
+
+Setup auto-detection covers **media servers only**:
+
+| Service | Mechanism |
+|---|---|
+| Plex | GDM broadcast; SSDP fallback |
+| Jellyfin | UDP discovery (port 7359); mDNS fallback |
+| Emby | UDP discovery (shared lineage with Jellyfin); mDNS fallback |
+| Tracearr | manual entry in 3.0; revisit if upstream adds announce/mDNS |
+
+The *arr services (and qui, Seerr) remain **manual entry**, with the
+Setup flow doing what it can honestly: URL validation, reachability
+test, and API-key verification with actionable error messages on each
+attempt.
+
+Detection results are **candidates, never auto-connections**: the flow
+presents "Found Plex at 192.168.x.x — connect?" and the operator
+confirms each one. No credentials are guessed; detection only fills the
+URL field.
+
+## Why this shape
+
+1. **Use protocols as designed, or not at all.** GDM/SSDP/mDNS exist
+   for discovery; answering them is the server opting in. Port-scanning
+   is the absence of an invitation.
+2. **Candidates-not-connections keeps the trust posture.** A first-run
+   flow that silently connects to everything it finds is indistinguishable
+   from malware behavior; one that asks per-service is a convenience.
+3. **The asymmetric outcome matches user reality.** Media-server URLs
+   are the ones users least often know (containers, NAS appliances);
+   *arr users overwhelmingly know their own ports because they
+   configured them.
+
+## Why not …
+
+- **Subnet port-scan for *arr ports.** Slow (seconds-to-minutes per
+  /24), fails across Docker bridge networks and VLANs where most
+  self-hosters actually run, trips IDS/fail2ban, and the charter's
+  scope-debate shorthand ("does this strengthen the trust layer?")
+  answers itself for a feature that behaves like a network attacker.
+- **Asking the host Docker daemon** (inspect containers for known
+  images). Works only when arr-dashboard shares the Docker host and has
+  socket access — a privilege we do not request and should not start
+  requesting for a convenience feature.
+- **mDNS-only for everything.** The *arrs do not announce via mDNS;
+  there is nothing to listen for.
+- **Deferring all detection to 3.1.** Detection of the media servers is
+  low-risk and high-payoff for first-run; deferring it would gut the
+  Setup rewrite's headline improvement.
+
+## Consequences
+
+### Positive
+
+- First-run friction drops for the services where URLs are least known.
+- The detection surface is small, protocol-blessed, and testable with
+  recorded datagrams — no network-shape-dependent heuristics.
+- A clear answer exists for "why didn't it find my Sonarr?" — documented
+  in the Setup flow itself, not just in docs.
+
+### Negative / trade-offs
+
+- The flow is asymmetric (some services found, some manual), which needs
+  copy that explains rather than apologizes. UX design pass required
+  (charter §11 follow-up).
+- Broadcast/mDNS discovery does not cross subnets; users with segmented
+  networks fall back to manual entry for everything. Acceptable — that
+  is also the population most likely to *prefer* manual entry.
+- Docker bridge networks without host networking may block broadcast
+  reception. Detection must fail silent-and-fast (short timeout) into
+  the manual path, never hang the wizard.
+
+## Follow-ups
+
+- Bucket-A-adjacent spike: validate GDM and Jellyfin/Emby UDP discovery
+  from inside a bridge-network container; if reception proves
+  unreliable, document "host network or manual" in the Setup copy.
+- Revisit Tracearr detection when/if upstream ships an announce
+  mechanism.
+- The detection module ships with recorded-datagram fixtures so CI
+  covers parsing without a live network.


### PR DESCRIPTION
## Summary
The four ADRs stubbed in the ratified charter (§5), written out in the house format (ADR-0001…0004). **No new decisions** — these elaborate the charter's §12 decision log into reviewable architecture records.

| ADR | Decision it records | Key content |
|---|---|---|
| **0005 Tier Discipline** | charter §5.1, Bucket A1 | 4 mechanically-checkable promotion criteria; removal requires an ADR; the 3.0 reshuffle table (8 groups; TRaSH promotion conditional on its `validateRequest` migration) |
| **0006 Unified Rule Engine** | §5.2, Bucket A4, §6.2 | One grammar + per-domain evaluation contexts, seeded from the library-cleanup evaluator; uniform 5-point migration contract for all five stored-rule surfaces |
| **0007 Tracearr Replaces Tautulli** | §5.3, Bucket A2, §6.1 | Outright removal + full read/write Tracearr parity; three-path blocking first-boot wizard; records why phased deprecation / advance banners / auto-delete were rejected |
| **0008 Setup Auto-Discovery** | §5.4 | Media servers only via protocols-as-designed (GDM / UDP 7359 / mDNS); *arrs stay manual; candidates-never-auto-connections; bridge-network spike flagged |

## Review focus
- Do the ADRs faithfully expand the charter, or do any sneak in unratified scope?
- 0005's reshuffle table vs the inventory verdicts
- 0006's migration contract — is the 5-point contract complete enough to build against?
- 0007's "why not" section — the strongest objections should be the ones recorded

Docs-only → no CI checks (expected; `paths-ignore` skips `docs/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)