### PR TITLE
fix(api): migrate inline Body: validation bypasses to validateRequest (Bucket A6)

### DIFF
--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -10,10 +10,10 @@ import {
 	updateBackupSettingsRequestSchema,
 } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
+import { z } from "zod";
 import { BackupService } from "../lib/backup/backup-service.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
-import { z } from "zod";
 import { validateRequest } from "../lib/utils/validate.js";
 import { getAppVersion } from "../lib/utils/version.js";
 
@@ -399,18 +399,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * PUT /backup/password
 	 * Set or update the backup password
 	 */
-	app.put<{
-		Body: { password: string };
-	}>("/password", async (request, reply) => {
-		const { password } = request.body;
+	const backupPasswordSchema = z.object({
+		password: z
+			.string({ message: "Password is required" })
+			.min(8, "Password must be at least 8 characters"),
+	});
 
-		if (!password || typeof password !== "string") {
-			return reply.status(400).send({ error: "Password is required" });
-		}
-
-		if (password.length < 8) {
-			return reply.status(400).send({ error: "Password must be at least 8 characters" });
-		}
+	app.put("/password", async (request, reply) => {
+		const { password } = validateRequest(backupPasswordSchema, request.body);
 
 		try {
 			const backupService = getBackupService();

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -2,21 +2,79 @@ import { createReadStream, existsSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { basename, join, resolve } from "node:path";
 import type { FastifyPluginCallback } from "fastify";
+import { z } from "zod";
 import { LOG_DIR, LOG_LEVEL, LOG_MAX_FILES, LOG_MAX_SIZE } from "../lib/logger.js";
 import { evaluateSecurityPosture } from "../lib/security/security-posture.js";
+import { validateRequest } from "../lib/utils/validate.js";
 import { getAppVersionInfo } from "../lib/utils/version.js";
 import { KNOWN_INTEGRATIONS } from "../lib/validation/index.js";
 import { integrationHealth } from "../lib/validation/integration-health.js";
 import { schemaFingerprints } from "../lib/validation/schema-fingerprint.js";
-import {
-	getAllValidationModes,
-	setValidationMode,
-	type ValidationMode,
-} from "../lib/validation/validate-batch.js";
+import { getAllValidationModes, setValidationMode } from "../lib/validation/validate-batch.js";
 import { validationQuarantine } from "../lib/validation/validation-quarantine.js";
 
 const RESTART_RATE_LIMIT = { max: 2, timeWindow: "5 minutes" };
 const LOGS_RATE_LIMIT = { max: 30, timeWindow: "1 minute" };
+
+const portSchema = (label: string) =>
+	z
+		.number({ message: `${label} must be a valid port number (1-65535)` })
+		.int(`${label} must be a valid port number (1-65535)`)
+		.min(1, `${label} must be a valid port number (1-65535)`)
+		.max(65535, `${label} must be a valid port number (1-65535)`);
+
+// Field-shape validation for PUT /system/settings. Cross-field rules (port
+// conflicts, the secure-cookies-without-proxy lockout guard) stay in the
+// handler — they need env defaults and a DB read, which is not Zod's job.
+const systemSettingsSchema = z.object({
+	apiPort: portSchema("API Port").optional(),
+	webPort: portSchema("Web Port").optional(),
+	listenAddress: z
+		.string()
+		.refine(
+			(addr) =>
+				["0.0.0.0", "127.0.0.1", "localhost", "::"].includes(addr) ||
+				/^(\d{1,3}\.){3}\d{1,3}$/.test(addr),
+			"Listen address must be a valid IP address (e.g., 0.0.0.0, 127.0.0.1)",
+		)
+		.optional(),
+	appName: z.string().optional(),
+	externalUrl: z
+		.string()
+		.nullable()
+		.optional()
+		.superRefine((value, ctx) => {
+			if (value === undefined || value === null || value === "") return;
+			try {
+				const url = new URL(value);
+				if (!["http:", "https:"].includes(url.protocol)) {
+					ctx.addIssue({
+						code: "custom",
+						message: "External URL must use http or https protocol",
+					});
+				}
+			} catch {
+				ctx.addIssue({
+					code: "custom",
+					message: "External URL must be a valid URL (e.g., https://arr.example.com)",
+				});
+			}
+		}),
+	trustProxy: z.boolean({ message: "trustProxy must be a boolean" }).optional(),
+	secureCookies: z
+		.boolean({ message: "secureCookies must be a boolean or null" })
+		.nullable()
+		.optional(),
+});
+
+const validationModeSchema = z.object({
+	integration: z.enum(KNOWN_INTEGRATIONS, {
+		message: `Unknown integration. Valid integrations: ${KNOWN_INTEGRATIONS.join(", ")}`,
+	}),
+	mode: z.enum(["strict", "tolerant", "log-only", "disabled"], {
+		message: "Invalid mode. Must be one of: strict, tolerant, log-only, disabled",
+	}),
+});
 
 /**
  * Extract a safe display identifier for the database connection.
@@ -97,79 +155,17 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Update system-wide settings
 	 * Note: Port and listen address changes require container restart to take effect
 	 */
-	app.put<{
-		Body: {
-			apiPort?: number;
-			webPort?: number;
-			listenAddress?: string;
-			appName?: string;
-			externalUrl?: string | null;
-			trustProxy?: boolean;
-			secureCookies?: boolean | null;
-		};
-	}>("/settings", async (request, reply) => {
+	app.put("/settings", async (request, reply) => {
 		const { apiPort, webPort, listenAddress, appName, externalUrl, trustProxy, secureCookies } =
-			request.body;
+			validateRequest(systemSettingsSchema, request.body);
 
-		// Validate port numbers if provided
-		if (apiPort !== undefined) {
-			if (!Number.isInteger(apiPort) || apiPort < 1 || apiPort > 65535) {
-				return reply.status(400).send({
-					success: false,
-					error: "API Port must be a valid port number (1-65535)",
-				});
-			}
-		}
-
-		if (webPort !== undefined) {
-			if (!Number.isInteger(webPort) || webPort < 1 || webPort > 65535) {
-				return reply.status(400).send({
-					success: false,
-					error: "Web Port must be a valid port number (1-65535)",
-				});
-			}
-		}
-
-		// Check for port conflicts
+		// Check for port conflicts (cross-field — stays out of the Zod schema)
 		const effectiveApiPort = apiPort ?? (Number(process.env.API_PORT) || 3001);
 		const effectiveWebPort = webPort ?? (Number(process.env.PORT) || 3000);
 		if (effectiveApiPort === effectiveWebPort) {
 			return reply.status(400).send({
 				success: false,
 				error: "API Port and Web Port cannot be the same",
-			});
-		}
-
-		// Validate listen address if provided
-		if (listenAddress !== undefined) {
-			// Must be a valid IP address or 0.0.0.0 or localhost
-			const validAddresses = ["0.0.0.0", "127.0.0.1", "localhost", "::"];
-			const ipv4Regex = /^(\d{1,3}\.){3}\d{1,3}$/;
-			const isValidIp = validAddresses.includes(listenAddress) || ipv4Regex.test(listenAddress);
-
-			if (!isValidIp) {
-				return reply.status(400).send({
-					success: false,
-					error: "Listen address must be a valid IP address (e.g., 0.0.0.0, 127.0.0.1)",
-				});
-			}
-		}
-
-		// Validate security settings
-		if (trustProxy !== undefined && typeof trustProxy !== "boolean") {
-			return reply.status(400).send({
-				success: false,
-				error: "trustProxy must be a boolean",
-			});
-		}
-		if (
-			secureCookies !== undefined &&
-			secureCookies !== null &&
-			typeof secureCookies !== "boolean"
-		) {
-			return reply.status(400).send({
-				success: false,
-				error: "secureCookies must be a boolean or null",
 			});
 		}
 
@@ -194,26 +190,8 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			});
 		}
 
-		// Validate external URL if provided (not null - null means clear)
-		if (externalUrl !== undefined && externalUrl !== null && externalUrl !== "") {
-			try {
-				const url = new URL(externalUrl);
-				// Must be http or https
-				if (!["http:", "https:"].includes(url.protocol)) {
-					return reply.status(400).send({
-						success: false,
-						error: "External URL must use http or https protocol",
-					});
-				}
-			} catch {
-				return reply.status(400).send({
-					success: false,
-					error: "External URL must be a valid URL (e.g., https://arr.example.com)",
-				});
-			}
-		}
-
-		// Normalize external URL (empty string becomes null)
+		// URL shape is validated by the schema; only normalize here
+		// (empty string becomes null = "clear the external URL")
 		const normalizedExternalUrl = externalUrl === "" ? null : externalUrl;
 
 		// Update or create settings
@@ -464,29 +442,10 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * PUT /system/validation-modes
 	 * Update validation mode for a specific integration.
 	 */
-	app.put<{
-		Body: { integration: string; mode: string };
-	}>("/validation-modes", async (request, reply) => {
-		const { integration, mode } = request.body;
+	app.put("/validation-modes", async (request, reply) => {
+		const { integration, mode } = validateRequest(validationModeSchema, request.body);
 
-		if (!integration || typeof integration !== "string") {
-			return reply.status(400).send({ error: "integration is required and must be a string" });
-		}
-
-		if (!KNOWN_INTEGRATIONS.includes(integration as (typeof KNOWN_INTEGRATIONS)[number])) {
-			return reply.status(400).send({
-				error: `Unknown integration "${integration}". Valid integrations: ${KNOWN_INTEGRATIONS.join(", ")}`,
-			});
-		}
-
-		const validModes: ValidationMode[] = ["strict", "tolerant", "log-only", "disabled"];
-		if (!validModes.includes(mode as ValidationMode)) {
-			return reply.status(400).send({
-				error: `Invalid mode "${mode}". Must be one of: ${validModes.join(", ")}`,
-			});
-		}
-
-		setValidationMode(integration, mode as ValidationMode);
+		setValidationMode(integration, mode);
 
 		request.log.info({ integration, mode }, "Validation mode updated");
 

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -7,7 +7,47 @@
  */
 
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+const syncStrategyEnum = z.enum(["auto", "manual", "notify"]);
+
+const previewSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+});
+
+const executeSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+	syncStrategy: syncStrategyEnum.optional(),
+	// Map of trashId → resolution
+	conflictResolutions: z.record(z.string(), z.enum(["use_template", "keep_existing"])).optional(),
+});
+
+const syncStrategySchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+	syncStrategy: syncStrategyEnum,
+});
+
+const syncStrategyBulkSchema = z.object({
+	templateId: z.string().min(1),
+	syncStrategy: syncStrategyEnum,
+});
+
+const unlinkSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+});
+
+const executeBulkSchema = z.object({
+	templateId: z.string().min(1),
+	instanceIds: z.array(z.string().min(1)).min(1),
+	syncStrategy: syncStrategyEnum.optional(),
+	instanceSyncStrategies: z.record(z.string(), syncStrategyEnum).optional(),
+});
 
 export async function deploymentRoutes(app: FastifyInstance) {
 	const { prisma, deploymentExecutor } = app;
@@ -17,21 +57,9 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * POST /api/trash-guides/deployment/preview
 	 * Generate deployment preview showing what would change
 	 */
-	app.post<{
-		Body: {
-			templateId: string;
-			instanceId: string;
-		};
-	}>("/preview", async (request, reply) => {
-		const { templateId, instanceId } = request.body;
+	app.post("/preview", async (request, reply) => {
+		const { templateId, instanceId } = validateRequest(previewSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		const preview = await deploymentPreview.generatePreview(templateId, instanceId, userId);
 
@@ -64,23 +92,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * POST /api/trash-guides/deployment/execute
 	 * Execute deployment to instance
 	 */
-	app.post<{
-		Body: {
-			templateId: string;
-			instanceId: string;
-			syncStrategy?: "auto" | "manual" | "notify";
-			conflictResolutions?: Record<string, "use_template" | "keep_existing">; // Map of trashId → resolution
-		};
-	}>("/execute", async (request, reply) => {
-		const { templateId, instanceId, syncStrategy, conflictResolutions } = request.body;
+	app.post("/execute", async (request, reply) => {
+		const { templateId, instanceId, syncStrategy, conflictResolutions } = validateRequest(
+			executeSchema,
+			request.body,
+		);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		// Execute deployment with conflict resolutions
 		const result = await deploymentExecutor.deploySingleInstance(
@@ -126,30 +143,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * PATCH /api/trash-guides/deployment/sync-strategy
 	 * Update sync strategy for an existing deployment (template-instance mapping)
 	 */
-	app.patch<{
-		Body: {
-			templateId: string;
-			instanceId: string;
-			syncStrategy: "auto" | "manual" | "notify";
-		};
-	}>("/sync-strategy", async (request, reply) => {
+	app.patch("/sync-strategy", async (request, reply) => {
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-		const { templateId, instanceId, syncStrategy } = request.body;
-
-		if (!templateId || !instanceId || !syncStrategy) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId, instanceId, and syncStrategy are required",
-			});
-		}
-
-		// Validate syncStrategy value
-		if (!["auto", "manual", "notify"].includes(syncStrategy)) {
-			return reply.status(400).send({
-				success: false,
-				error: "syncStrategy must be 'auto', 'manual', or 'notify'",
-			});
-		}
+		const { templateId, instanceId, syncStrategy } = validateRequest(
+			syncStrategySchema,
+			request.body,
+		);
 
 		// Find the mapping and verify ownership
 		const mapping = await prisma.templateQualityProfileMapping.findFirst({
@@ -208,29 +207,9 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * PATCH /api/trash-guides/deployment/sync-strategy-bulk
 	 * Update sync strategy for all instances of a template at once
 	 */
-	app.patch<{
-		Body: {
-			templateId: string;
-			syncStrategy: "auto" | "manual" | "notify";
-		};
-	}>("/sync-strategy-bulk", async (request, reply) => {
+	app.patch("/sync-strategy-bulk", async (request, reply) => {
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-		const { templateId, syncStrategy } = request.body;
-
-		if (!templateId || !syncStrategy) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and syncStrategy are required",
-			});
-		}
-
-		// Validate syncStrategy value
-		if (!["auto", "manual", "notify"].includes(syncStrategy)) {
-			return reply.status(400).send({
-				success: false,
-				error: "syncStrategy must be 'auto', 'manual', or 'notify'",
-			});
-		}
+		const { templateId, syncStrategy } = validateRequest(syncStrategyBulkSchema, request.body);
 
 		// Verify template belongs to user
 		const template = await prisma.trashTemplate.findFirst({
@@ -281,21 +260,9 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * Remove a template from a single instance (unlink without deleting the template)
 	 * This removes the TemplateQualityProfileMapping but keeps Custom Formats on the instance
 	 */
-	app.delete<{
-		Body: {
-			templateId: string;
-			instanceId: string;
-		};
-	}>("/unlink", async (request, reply) => {
-		const { templateId, instanceId } = request.body;
+	app.delete("/unlink", async (request, reply) => {
+		const { templateId, instanceId } = validateRequest(unlinkSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		// Find the mapping
 		const mapping = await prisma.templateQualityProfileMapping.findFirst({
@@ -369,23 +336,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 	 * Execute deployment to multiple instances
 	 * Supports per-instance sync strategies via instanceSyncStrategies map
 	 */
-	app.post<{
-		Body: {
-			templateId: string;
-			instanceIds: string[];
-			syncStrategy?: "auto" | "manual" | "notify";
-			instanceSyncStrategies?: Record<string, "auto" | "manual" | "notify">;
-		};
-	}>("/execute-bulk", async (request, reply) => {
-		const { templateId, instanceIds, syncStrategy, instanceSyncStrategies } = request.body;
+	app.post("/execute-bulk", async (request, reply) => {
+		const { templateId, instanceIds, syncStrategy, instanceSyncStrategies } = validateRequest(
+			executeBulkSchema,
+			request.body,
+		);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceIds || instanceIds.length === 0) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceIds are required",
-			});
-		}
 
 		// Execute bulk deployment with per-instance strategies support
 		const result = await deploymentExecutor.deployBulkInstances(


### PR DESCRIPTION
## Summary
**First code PR of Bucket A.** Closes the validation-bypass class the 3.0 inventory found: three route files destructured `request.body` from concretely-typed `Body:` generics — compile-time trust of runtime data, with hand-rolled checks drifting per handler. This is also the explicit prerequisite for TRaSH Guides' tier promotion in the A1 reshuffle (ADR-0005 §3).

## Migrated (−229 lines of hand-rolled checks, +140 of schemas)
| File | Endpoints | Notes |
|---|---|---|
| `trash-guides/deployment-routes.ts` | all 6 mutations (preview, execute, sync-strategy ×2, unlink, execute-bulk) | the ADR-0005 blocker |
| `system.ts` | PUT `/settings`, PUT `/validation-modes` | shape checks → schema **with original error messages preserved**; cross-field rules (port conflict, secure-cookies lockout guard) stay in the handler — they need env defaults + a DB read |
| `backup.ts` | PUT `/password` | min-8 rule → schema |

## Audited, intentionally unchanged
- **qui routes** use `Body: { field?: unknown }` + immediate `validateRequest` — `unknown` *forces* validation; this is the correct pattern and the shape the future L1 lint should encode (flag concrete-typed `Body:` generics, allow `unknown`-typed ones)
- **naming-routes `safeParse`** calls validate stored DB JSON / upstream responses, not request bodies — non-throwing is correct there
- **deployment-history-routes** parses no bodies

## Behavior change
Malformed requests get the central handler's structured 400 (`{ error, details }`) instead of per-handler ad-hoc messages. Field-level messages preserved inside `details`. Repo grep confirms **zero** concrete-typed `Body:` generics remain outside the safe qui pattern.

## Validation
- [x] `tsc --noEmit` clean (api)
- [x] Full suite: 2039 passed / 0 failed — **identical to pre-change baseline** (verified via stash A/B run)
- [x] `git grep` sweep: no remaining bypass sites

## Follow-up (not this PR)
- Route-level 400-contract tests for deployment routes (they have no test harness today — flagged in the inventory; building one belongs with the L1 lint work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)