### PR TITLE
chore(routes): apply the 3.0 tier reshuffle (Bucket A1, ADR-0005 §3)

### DIFF
--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -125,7 +125,7 @@ export const PUBLIC_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/auto-tag/webhook",
 		prefix: "/api/auto-tag/webhook",
 		register: registerAutoTagWebhookRoutes,
-		maturity: "experimental",
+		maturity: "operator",
 		summary:
 			"Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. Authenticates via per-user Bearer token (user's hashed webhookSecret). Public route — no session cookie required.",
 	},
@@ -133,7 +133,7 @@ export const PUBLIC_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/webhooks/qui",
 		prefix: "/api",
 		register: registerQuiWebhookRoutes,
-		maturity: "experimental",
+		maturity: "stable",
 		summary:
 			"Inbound qui webhook receiver (Phase 5.1). Authenticates via per-user `?secret=...` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in QuiEventLog and publishes to the in-process event bus for SSE fan-out.",
 	},
@@ -218,14 +218,14 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/hunting",
 		prefix: "/api",
 		register: registerHuntingRoutes,
-		maturity: "internal",
+		maturity: "operator",
 		summary: "Auto-search configuration and execution",
 	},
 	{
 		path: "/api/queue-cleaner",
 		prefix: "/api",
 		register: registerQueueCleanerRoutes,
-		maturity: "internal",
+		maturity: "operator",
 		summary: "Queue cleanup rules, strikes, dry-run preview",
 	},
 	{
@@ -262,7 +262,7 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/label-sync",
 		prefix: "/api/label-sync",
 		register: registerLabelSyncRoutes,
-		maturity: "experimental",
+		maturity: "operator",
 		summary:
 			"Generic any-to-any media-service tag/label sync rules (issue #384). Sub-arc 1: Sonarr/Radarr → Plex.",
 	},
@@ -270,7 +270,7 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/auto-tag",
 		prefix: "/api/auto-tag",
 		register: registerAutoTagRoutes,
-		maturity: "experimental",
+		maturity: "operator",
 		summary:
 			"Criteria-based auto-tagger rules — applies tags to LibraryCache items matching the rule's criteria DSL (genre, year, codec, watch state, …). Companion to Label Sync. Webhook config (secret read/rotate) lives here under session auth; the inbound webhook itself is in PUBLIC_ROUTE_GROUPS at /api/auto-tag/webhook so Connect can reach it without a session cookie.",
 	},
@@ -285,9 +285,9 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/qui",
 		prefix: "/api",
 		register: registerQuiRoutes,
-		maturity: "experimental",
+		maturity: "stable",
 		summary:
-			"Federated peer integration with autobrr/qui (qBittorrent UI) — read-only torrent state, trackers, cross-seed siblings; powers the Torrent Health panel on library item detail pages.",
+			"Federated peer integration with autobrr/qui (qBittorrent UI) — torrent state, trackers, cross-seed siblings, and capability-aware torrent mutations (pause/resume, limits, trackers, tags); powers the Torrent Health panel and detail drawer on library item pages.",
 	},
 
 	// --- External integrations (Seerr / TRaSH Guides) ---
@@ -302,7 +302,7 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		path: "/api/trash-guides",
 		prefix: "/api/trash-guides",
 		register: registerTrashGuidesRoutes,
-		maturity: "internal",
+		maturity: "operator",
 		summary: "TRaSH cache, templates, deployment, profiles",
 	},
 ];

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -46,20 +46,20 @@ for the full rationale.
 | `/api/library` | stable | Movies/series listing, episodes, monitor, search |
 | `/api/search` | stable | Prowlarr indexer search + grab |
 | `/api/manual-import` | stable | Manual import candidates and submission |
-| `/api/hunting` | internal | Auto-search configuration and execution |
-| `/api/queue-cleaner` | internal | Queue cleanup rules, strikes, dry-run preview |
+| `/api/hunting` | operator | Auto-search configuration and execution |
+| `/api/queue-cleaner` | operator | Queue cleanup rules, strikes, dry-run preview |
 | `/api/library-cleanup` | internal | Library cleanup rules, approvals, execution |
 | `/api/plex` | stable | Now playing, on-deck, history, analytics, forecasts |
 | `/api/jellyfin` | stable | Jellyfin activity and library data |
 | `/api/tautulli` | stable | Activity, watch history enrichment, statistics |
-| `/api/label-sync` | experimental | Generic any-to-any media-service tag/label sync rules (issue #384). Sub-arc 1 ships Sonarr/Radarr → Plex. |
-| `/api/auto-tag` | experimental | Criteria-based auto-tagger — applies tags to LibraryCache items matching the rule's criteria DSL (genre, year, codec, watch state, …). Companion to Label Sync. Webhook config (secret read/rotate) lives here under session auth. |
-| `/api/auto-tag/webhook` | experimental | Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. **Public route** (no session cookie); authenticates via per-user Bearer token (SHA-256 hash of the user's webhook secret). |
+| `/api/label-sync` | operator | Generic any-to-any media-service tag/label sync rules (issue #384). Sub-arc 1 ships Sonarr/Radarr → Plex. |
+| `/api/auto-tag` | operator | Criteria-based auto-tagger — applies tags to LibraryCache items matching the rule's criteria DSL (genre, year, codec, watch state, …). Companion to Label Sync. Webhook config (secret read/rotate) lives here under session auth. |
+| `/api/auto-tag/webhook` | operator | Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. **Public route** (no session cookie); authenticates via per-user Bearer token (SHA-256 hash of the user's webhook secret). |
 | `/api/pulse` | internal | System Pulse health signals + attention items |
-| `/api/qui` | experimental | Federated peer integration with autobrr/qui (qBittorrent UI) — read-only torrent state, trackers, cross-seed siblings; powers the Torrent Health panel. |
-| `/api/webhooks/qui` | experimental | Inbound qui webhook receiver (Phase 5.1). **Public route** (no session cookie); authenticates via per-user `?secret=…` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in `QuiEventLog` and publishes to the in-process event bus for SSE fan-out. |
+| `/api/qui` | stable | Federated peer integration with autobrr/qui (qBittorrent UI) — torrent state, trackers, cross-seed siblings, and capability-aware torrent mutations; powers the Torrent Health panel and detail drawer. |
+| `/api/webhooks/qui` | stable | Inbound qui webhook receiver (Phase 5.1). **Public route** (no session cookie); authenticates via per-user `?secret=…` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in `QuiEventLog` and publishes to the in-process event bus for SSE fan-out. |
 | `/api/seerr` | stable | Request management, discovery, library enrichment |
-| `/api/trash-guides` | internal | TRaSH cache, templates, deployment, profiles |
+| `/api/trash-guides` | operator | TRaSH cache, templates, deployment, profiles |
 
 > When you add a new route group, add a manifest entry **and** a row above.
 > A contract test (`apps/api/src/routes/__tests__/route-manifest.test.ts`)


### PR DESCRIPTION
## Summary
Bucket A1: applies ADR-0005 §3's reshuffle — 8 route groups move to tiers matching their measured maturity. The two public webhook receivers travel with their parent features (leaving them `experimental` while the feature is `operator`/`stable` would be incoherent; flagged since the ADR table didn't list them separately).

| Group | From | To |
|---|---|---|
| `/api/auto-tag` (+ webhook) | experimental | operator |
| `/api/label-sync` | experimental | operator |
| `/api/hunting` | internal | operator |
| `/api/queue-cleaner` | internal | operator |
| `/api/trash-guides` | internal | operator — unblocked by A6 (#510) |
| `/api/qui` (+ webhook) | experimental | **stable** |

`/api/tautulli` deliberately stays `stable` until A2 removes it (ADR-0007) — demoting first would be ceremony.

## Honesty fix bundled
The qui summary (manifest + doc) still said "read-only" — false since the Phase 4 mutation routes. A `stable` row must be accurate (ADR-0005 criterion 4), so both updated to describe the capability-aware mutations.

## Validation
- [x] manifest↔doc contract test green
- [x] tsc clean; suite identical (2039 passed / 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)