### PR TITLE
docs(adr): Tautulli is a stored-rule surface — A2 sequenced after A4

### DIFF
--- a/docs/adr/0006-unified-rule-engine.md
+++ b/docs/adr/0006-unified-rule-engine.md
@@ -130,11 +130,22 @@ engine.
   rewrite. That is acceptable — the contract is about storage and
   grammar, not internal call paths.
 
+**Amendment note (2026-06-09):** the unified migration gains an explicit
+case from ADR-0007's second amendment — **Tautulli-typed conditions**
+(`tautulli_last_watched`, `tautulli_watch_count`, `tautulli_watched_by`)
+in Library Cleanup (and Auto-Tagger via the shared evaluators) are
+removed/retargeted as part of the unified migration rather than in an
+ad-hoc A2 pass. Consequence: **Bucket A sequencing is A4 → A2** — the
+Tautulli removal rides this migration framework instead of duplicating
+it. The migration report per surface must count and list rules whose
+conditions referenced Tautulli data so the A2 dialog can disclose them.
+
 ## Follow-ups
 
 - Bucket A design pass: grammar schema (typed fields, operators,
   serialization) — review against all five domains' existing rules
-  before freezing.
+  before freezing. The Tautulli-typed condition kinds are an explicit
+  test case for the migration design.
 - A `require-migration-on-rule-schema-change` lint (charter §7) once the
   engine stabilizes.
 - Dry-run preview infrastructure is shared with the Tautulli wizard's

--- a/docs/adr/0007-tracearr-replaces-tautulli.md
+++ b/docs/adr/0007-tracearr-replaces-tautulli.md
@@ -153,11 +153,35 @@ successor — are fully preserved in the dialog.
 - AGPL-3.0: arr-dashboard consumes Tracearr's HTTP API only — a normal
   client relationship, no code linkage. No license obligation arises.
 
+**Amendment note 2 (2026-06-09) — A2 is sequenced AFTER A4:** the
+removal inventory found that Tautulli is a *data source*, not just an
+integration: Library Cleanup's rule grammar has three Tautulli-typed
+condition kinds (`tautulli_last_watched`, `tautulli_watch_count`,
+`tautulli_watched_by`) stored in user rules (and reachable from
+Auto-Tagger, which reuses the same evaluators), and the `TautulliCache`
+table feeds the cleanup executor plus the Plex AND Jellyfin
+watch-enrichment routes. Removing Tautulli therefore orphans stored
+user rules — a stored-rule migration, which is exactly what ADR-0006's
+5-point contract exists for. Rather than building one-off migration
+machinery in A2 and rebuilding it properly in A4 (two migration events
+for users), **A2 lands after A4's unified engine + migration framework,
+and the Tautulli rule-type removal ships as one case inside the unified
+migration**. The first-boot dialog additionally discloses how many of
+the user's stored rules referenced Tautulli watch data. Watch-enrichment
+re-pointing (Plex/Jellyfin enrichment reads of TautulliCache → Tracearr
+or SessionSnapshot equivalents) is scoped into A2 alongside the
+Statistics overview-tab migration.
+
 ## Follow-ups
 
 - Bucket C2 (Statistics rewrite on Tracearr) starts only after the
   Tracearr client + routes land.
 - Dialog ships in the same PR as the Tautulli removal — the removal
   must never exist on `next` without its migration path.
+- The `ServiceType.TAUTULLI` Prisma enum value is RETAINED (with a
+  deprecation comment) until 4.0 — removing it would make pre-dialog
+  rows undeserializable and crash boot before the dialog could render.
+  The dialog is the only deleter of rows; the enum value goes when no
+  supported upgrade path can still carry such rows.
 - Schedule Tracearr's `experimental` → graduation review at 3.0-rc
   (per ADR-0005).


### PR DESCRIPTION
## Summary
The A2 removal inventory surfaced a dependency ADR-0007 missed: **Tautulli is a data source with stored-rule consumers**, not just an integration.

- Library Cleanup's grammar has 3 Tautulli-typed condition kinds (`tautulli_last_watched` / `tautulli_watch_count` / `tautulli_watched_by`) **stored in user rules**, reachable from Auto-Tagger via the shared evaluators
- `TautulliCache` feeds the cleanup executor + **both** Plex and Jellyfin watch-enrichment routes

## Decision (amendments to 0006 + 0007)
- **Bucket A sequencing: A4 → A2.** The Tautulli rule-type removal ships as one case inside A4's unified migration (5-point contract) instead of ad-hoc machinery in A2 that A4 would rebuild — one migration event for users, not two
- A2's dialog additionally discloses how many stored rules referenced Tautulli data
- `ServiceType.TAUTULLI` Prisma enum value **retained until 4.0** — removing it would make pre-dialog rows undeserializable and crash boot before the dialog could render
- Watch-enrichment re-pointing scoped into A2

🤖 Generated with [Claude Code](https://claude.com/claude-code)