### PR TITLE
docs(design): unified rule grammar — survey synthesis + v1 spec (gates A4)

### DIFF
--- a/docs/adr/0006-unified-rule-engine.md
+++ b/docs/adr/0006-unified-rule-engine.md
@@ -140,6 +140,34 @@ Tautulli removal rides this migration framework instead of duplicating
 it. The migration report per surface must count and list rules whose
 conditions referenced Tautulli data so the A2 dialog can disclose them.
 
+**Amendment note 2 (2026-06-09) — eager migration eliminated; 5-point
+contract rescoped; A2 re-unblocked:** the grammar design pass
+(`docs/design/unified-rule-grammar.md`) found that format unification
+needs **no eager row rewrites**: documents version-detect at parse time
+(legacy v0 → tiny mapper; `version: 1` → direct), and rules are written
+in v1 only on create/edit. Three consequences supersede parts of this
+ADR and of amendment 1:
+
+1. **Notifications' stable-tier promise survives unification** — its
+   stored rows are untouched until the user edits a rule. The "bundle
+   into 3.0 or never" forcing premise in Context no longer applies
+   (the unification still ships in 3.0 as planned).
+2. **The 5-point migration contract applies to semantic passes only** —
+   passes that change what stored rules *mean*. In 3.0 that is exactly
+   one pass: the Tautulli-condition retirement. Format conversion needs
+   no backup file; untouched rows are the backup.
+3. **Bucket A sequencing reverts to A2 → A4** (superseding amendment
+   1's ordering): the Tautulli pass operates on v0 documents directly
+   and does not need the engine. It establishes the migration-pass
+   pattern in miniature; its v0-parsing utilities are reused by A4's
+   lazy mappers. Each ordering decision was made on the best evidence
+   available at the time; this trail is the record.
+
+A4's acceptance gate is **differential parity testing**: the engine
+must produce identical decisions to the legacy evaluators on identical
+inputs (fixtures harvested from real rule rows + synthetic edge cases)
+before each surface cuts over.
+
 ## Follow-ups
 
 - Bucket A design pass: grammar schema (typed fields, operators,

--- a/docs/adr/0007-tracearr-replaces-tautulli.md
+++ b/docs/adr/0007-tracearr-replaces-tautulli.md
@@ -162,11 +162,14 @@ Auto-Tagger, which reuses the same evaluators), and the `TautulliCache`
 table feeds the cleanup executor plus the Plex AND Jellyfin
 watch-enrichment routes. Removing Tautulli therefore orphans stored
 user rules — a stored-rule migration, which is exactly what ADR-0006's
-5-point contract exists for. Rather than building one-off migration
-machinery in A2 and rebuilding it properly in A4 (two migration events
-for users), **A2 lands after A4's unified engine + migration framework,
-and the Tautulli rule-type removal ships as one case inside the unified
-migration**. The first-boot dialog additionally discloses how many of
+5-point contract exists for. ~~A2 lands after A4's unified engine +
+migration framework~~ **Superseded by ADR-0006 amendment 2
+(2026-06-09): eager format migration was eliminated from A4 entirely
+(parse-time versioning), so the Tautulli pass is self-contained over
+the existing stored-document format and A2 is again independent — and
+sequenced FIRST. The pass still runs under the full 5-point contract
+(it is the one semantic migration in 3.0), and its rule-count report
+feeds this dialog's disclosure.** The first-boot dialog additionally discloses how many of
 the user's stored rules referenced Tautulli watch data. Watch-enrichment
 re-pointing (Plex/Jellyfin enrichment reads of TautulliCache → Tracearr
 or SessionSnapshot equivalents) is scoped into A2 alongside the

--- a/docs/design/unified-rule-grammar.md
+++ b/docs/design/unified-rule-grammar.md
@@ -143,52 +143,106 @@ type RuleContext = {
 - **Queue-cleaner / hunting storage** — config columns stay; their UIs
   stay; only the evaluation internals route through the engine.
 
-## 3. Per-surface migration mapping (ADR-0006 5-point contract)
+## 3. Migration strategy: parse-time versioning, no eager rewrites
 
-| Surface | Transform | Risk |
+**Format unification does not rewrite stored rows.** The parser
+version-detects each document at load time:
+
+- JSON with top-level `ruleType` (cleanup/auto-tag) or a bare
+  conditions array (notifications) → **legacy v0**; a small mapper
+  converts to grammar nodes in memory.
+- JSON with `version: 1` → parsed directly.
+
+Rules are written in v1 **only when created or edited** (lazy
+convergence). The v0 mappers live in one quarantined module with
+fixture tests against real 2.x rows.
+
+| Surface | Load path | Eager rewrite? |
 |---|---|---|
-| Library Cleanup | Near-identity: `{ruleType, parameters}` → `{version:1, root:{kind, params}}`; composites → `{all:[…]}`/`{any:[…]}` | Low — shape-preserving envelope |
-| Auto-Tagger | Same as cleanup | Low |
-| Notifications | Each `{field,operator,value}` → `{kind:"field_match", params:{…}}`; array → `{all:[…]}` | Low — lossless and mechanical |
-| Queue Cleaner | **None** (config unchanged; adapter internal) | n/a |
-| Hunting | **None** (config unchanged; adapter internal) | n/a |
+| Library Cleanup | v0 mapper (near-identity) | **No** |
+| Auto-Tagger | same v0 mapper | **No** |
+| Notifications | v0 mapper (`{field,operator,value}` → `field_match`) | **No** |
+| Queue Cleaner | config adapter (not a document) | **No** |
+| Hunting | config adapter (not a document) | **No** |
 
-### 3.1 The Tautulli test case (ADR-0006/0007 amendments)
+Consequences:
 
-During the cleanup/auto-tag migration, conditions with kinds
-`tautulli_last_watched`, `tautulli_watch_count`, `tautulli_watched_by`:
+1. **Notifications' stable-tier promise survives unification** — its
+   stored rows are untouched until the user edits a rule. The breaking
+   change ADR-0006 assumed ("bundle into 3.0 or never") does not exist.
+2. **ADR-0006's 5-point contract is rescoped to semantic changes
+   only** — passes that alter what rules *mean* (the Tautulli
+   retirement, §3.1). Format conversion needs no backup file because
+   the original rows are never touched; the untouched rows ARE the
+   backup.
+3. Mixed v0/v1 documents coexist in the DB indefinitely. Accepted:
+   write-on-edit converges naturally; an optional "migrate all now"
+   maintenance action can be added if mixed-format debugging ever
+   becomes a real cost.
+4. Future format changes add a v1→v2 mapper — the `version` field makes
+   every document self-describing.
 
-1. Are counted and listed per rule in the migration report (feeds the
-   A2 dialog's disclosure: "N of your rules referenced Tautulli watch
-   data").
+### 3.1 The Tautulli pass — the only eager (semantic) migration
+
+Retiring `tautulli_last_watched` / `tautulli_watch_count` /
+`tautulli_watched_by` changes what stored rules *mean*, so it runs as
+an eager pass under the full ADR-0006 5-point contract — and it
+operates on **v0 documents directly** (read JSON, find tautulli kinds,
+transform, write back, report). It does not require the unified engine,
+which restores A2's independence from A4 (see §4).
+
+1. Conditions are counted and listed per rule in the migration report
+   (feeds the A2 dialog's disclosure: "N of your rules referenced
+   Tautulli watch data").
 2. Composite handling: if removing the Tautulli condition leaves the
    composite empty → the rule is **disabled** (not deleted), flagged
    `migration: tautulli-orphaned`. If siblings remain → the condition
    is removed and the rule stays active, flagged
    `migration: tautulli-condition-dropped`.
 3. The backup file (`/config/rules-pre-3.0/<surface>.json`) preserves
-   the original documents regardless.
+   the original documents (warranted here — this pass DOES rewrite
+   rows).
 4. Post-A2 (Tracearr-era), users can re-express watch conditions with
-   the Plex/Jellyfin kinds or future Tracearr kinds; the migration does
-   NOT auto-rewrite `tautulli_*` → `plex_*` (different data sources;
+   the Plex/Jellyfin kinds or future Tracearr kinds; the pass does NOT
+   auto-rewrite `tautulli_*` → `plex_*` (different data sources;
    silent semantic swaps violate the trust thesis).
 
-## 4. Implementation order (A4)
+The v0-parsing utilities this pass builds are reused by A4's lazy
+mappers — nothing here is throwaway.
 
-1. `packages/shared` (or `apps/api/src/lib/rules/`): grammar types +
-   Zod schemas + per-kind param schemas lifted from
-   `ruleParamSchemaMap` (cleanup's existing per-kind validation).
-2. Engine core: parse → validate-against-context → evaluate. Seeded
-   from cleanup's `rule-evaluators.ts` (per ADR-0006); decompose the
+## 4. Implementation order
+
+**Resequencing note (2026-06-09):** with eager format migration
+eliminated (§3), A2 no longer depends on A4 — its Tautulli pass is
+self-contained over v0 documents. **A2 lands first** (it is fully
+specified; ADR-0007), establishing the migration-pass pattern
+(backup / transactional / report / dry-run) in miniature. A4 follows.
+
+A4 itself, gated by **differential parity testing** — the engine's
+acceptance criterion is "identical decisions to the legacy evaluator on
+identical inputs," proven per surface before cutover (strangler
+pattern, not big-bang):
+
+1. `packages/shared`: grammar types + Zod schemas + per-kind param
+   schemas lifted from `ruleParamSchemaMap`, plus the v0 mappers.
+2. Engine core: version-detect → parse → validate-against-context →
+   evaluate. Seeded from cleanup's `rule-evaluators.ts`; decompose the
    82 KB file along kind-category lines as part of the lift.
-3. Cleanup + auto-tag re-pointed at the engine (their evaluators ARE
-   the engine; this step is mostly file moves + context wiring).
-4. Notifications adapter + document migration (the only behavioral
-   risk; ship with fixture tests against real 2.x rule rows).
-5. Queue-cleaner + hunting adapters (internal; can trail).
-6. Migrations per the 5-point contract; Tautulli counting wired for A2.
-7. Composer UI (Operator Console) — after the engine stabilizes;
-   seeded from `features/rule-criteria/`.
+3. **Parity suite**: legacy evaluator vs engine on identical eval
+   contexts — fixtures harvested from real rule rows (the dev DB has
+   live cleanup/auto-tag rules) plus synthetic edge cases (null
+   handling, never-watched inference, case sensitivity). Green parity
+   gates each cutover.
+4. Cleanup cut over → auto-tag cut over (shared evaluators make this
+   nearly one step).
+5. Notifications: v0 mapper + adapter at load; **no storage change**.
+   Parity-tested against its 5 operators and first-match-wins
+   semantics.
+6. Queue-cleaner + hunting adapters (internal; can trail indefinitely
+   without blocking anything).
+7. Composer UI (Operator Console flagship) — after the engine
+   stabilizes; seeded from `features/rule-criteria/`. Writes v1 on
+   save, which is what converges stored documents over time.
 
 ## 5. Open questions for review
 
@@ -196,9 +250,9 @@ During the cleanup/auto-tag migration, conditions with kinds
    composer needs the types + Zod for validation) vs `apps/api/lib`
    (keeps grammar server-private)? Leaning `packages/shared` since the
    composer must validate client-side.
-2. **Version field**: `version: 1` on every document vs schema-level
-   versioning per surface? Leaning per-document — it makes the next
-   migration self-describing.
+2. ~~Version field placement~~ — **resolved by the migration strategy**:
+   per-document `version` is load-bearing for parse-time
+   version-detection (§3); not optional.
 3. **Notifications metadata fields**: the engine supports
    `metadata.*` but the UI never exposed it. Keep API-only in v1, or
    surface it in the composer? Leaning keep API-only (no user demand

--- a/docs/design/unified-rule-grammar.md
+++ b/docs/design/unified-rule-grammar.md
@@ -244,20 +244,59 @@ pattern, not big-bang):
    stabilizes; seeded from `features/rule-criteria/`. Writes v1 on
    save, which is what converges stored documents over time.
 
-## 5. Open questions for review
+## 5. Decisions (formerly open questions; resolved 2026-06-09)
 
-1. **Where do the shared schemas live** — `packages/shared` (frontend
-   composer needs the types + Zod for validation) vs `apps/api/lib`
-   (keeps grammar server-private)? Leaning `packages/shared` since the
-   composer must validate client-side.
-2. ~~Version field placement~~ — **resolved by the migration strategy**:
-   per-document `version` is load-bearing for parse-time
-   version-detection (§3); not optional.
-3. **Notifications metadata fields**: the engine supports
-   `metadata.*` but the UI never exposed it. Keep API-only in v1, or
-   surface it in the composer? Leaning keep API-only (no user demand
-   signal yet).
-4. **Queue-cleaner/hunting in the composer**: v1 keeps them
-   adapter-only (their config UIs stay). Does the Operator Console
-   eventually edit them through the composer (v1.5/v2), or are flat
-   config UIs the right permanent shape for config-class surfaces?
+### 5.1 Schema placement: data in `packages/shared`, behavior in api
+
+`packages/shared/src/rules/` holds the **data**: grammar types, per-kind
+Zod param schemas, kind metadata (labels, categories), and the
+domain→legal-kinds map — subsuming the existing
+`packages/shared/src/types/rule-criteria.ts` rather than paralleling
+it. `apps/api/src/lib/rules/` holds the **behavior**: evaluators,
+eval-input builders, the v0 mappers, and the Tautulli migration pass.
+
+Load-bearing refinement: **the API normalizes documents to v1 at the
+boundary.** Rule GET endpoints parse stored v0/v1 server-side and serve
+only v1; the composer saves v1. The frontend therefore carries zero
+legacy knowledge, and the mappers stay api-private.
+
+Known costs (pre-existing, managed): rebuild `@arr/shared` dist before
+vitest; turbo typecheck (not per-package tsc) for cross-package changes.
+
+Rejected: api-private schemas — would force a duplicated frontend
+vocabulary for the composer's palette/forms, recreating the drift this
+unification exists to kill. The monorepo ships one image, so the usual
+deploy-coupling argument against shared schemas does not apply.
+
+### 5.2 `metadata.*` conditions: API-only in v1, prerequisite built now
+
+Composer exposure is deferred — but because it is a **schema problem,
+not a UI problem**: event metadata is free-form
+`Record<string, unknown>` populated ad-hoc by six schedulers, so a
+composer field would be a guess-the-key footgun. During the
+notifications adapter work (§4 step 5), event payloads gain a
+**per-event-type metadata schema registry** (built opportunistically;
+valuable for type-safety regardless). With the registry in place,
+composer exposure becomes a small demand-gated UI task.
+
+Documented sharp edge (preserved, per §1.3): a missing field coerces
+via `String(undefined)` → the literal `"undefined"`, so
+`equals "undefined"` can match absent metadata. v1 `field_match`
+replicates this exactly (parity-tested). Fixing it is a semantic change
+reserved for a future document-version bump, considered only if/when
+UI exposure happens.
+
+### 5.3 Queue-cleaner/hunting: flat config UIs are permanent; composer is a non-goal
+
+These surfaces are **settings, not rules**: fixed behavior sets with
+enable/threshold params and no open-ended authoring. Condition trees
+are the right interface for user-authored logic; dedicated controls are
+the right interface for closed behavior sets — replacing purpose-built
+toggles with a generic tree editor is a downgrade dressed as
+consistency.
+
+The adapters keep the interesting future open *additively*: if demand
+materializes for arbitrary user rules on these domains ("remove when
+indexer = X AND age > Y"), the path is a new rule-document table on
+that domain — same engine, same composer — added **alongside** the
+config, never migrating it. No advance commitment; demand decides.

--- a/docs/design/unified-rule-grammar.md
+++ b/docs/design/unified-rule-grammar.md
@@ -1,0 +1,209 @@
+# Unified Rule Grammar — Design
+
+- **Status:** DRAFT for review (gates ADR-0006 / Bucket A4 implementation)
+- **Date:** 2026-06-09
+- **Inputs:** code survey of all five rule systems on `next` @ `ada897be`
+- **Charter:** §5.2, Bucket A4; ADR-0006 (incl. 2026-06-09 amendment)
+
+## 1. What the survey found (and what it corrects)
+
+Five systems were surveyed. They fall into **two storage classes**, which
+corrects ADR-0006's premise that all five store rules:
+
+| Surface | Storage | Stored rule documents? | Migration class |
+|---|---|---|---|
+| Library Cleanup | `LibraryCleanupRule` — `ruleType` + `parameters` JSON + optional `operator`/`conditions` composite | **Yes** (47 condition kinds) | Document migration |
+| Auto-Tagger | `AutoTagRule` — mirrors LibraryCleanupRule | **Yes** (same kinds + list-membership) | Document migration |
+| Notifications | `NotificationRule` — `conditions` JSON (flat array of `{field, operator, value}`) + action columns | **Yes** (generic field-match conditions) | Document migration |
+| Queue Cleaner | `QueueCleanerConfig` — flat typed columns + JSON-string arrays; evaluation order hardcoded | **No** | Adapter only — no storage migration |
+| Hunting | `HuntConfig` — flat typed columns + include/exclude lists + AND/OR toggle | **No** | Adapter only — no storage migration |
+
+**Consequence:** the unified migration (ADR-0006 §2) applies to **three**
+surfaces, not five. Queue Cleaner and Hunting keep their config schemas;
+their evaluators are re-expressed against the unified engine internally
+(an adapter translating config → grammar at evaluation time), with zero
+user-visible storage change. This shrinks A4's riskiest dimension by
+40%.
+
+### 1.1 The two condition styles that must unify
+
+- **Kind+params style** (cleanup / auto-tag): a condition is
+  `{ ruleType: "plex_last_watched", parameters: { operator: "older_than", days: 14 } }`.
+  Operators are **per-kind enums** (e.g. `older_than|never` for watch
+  ages, `includes_any|excludes_all` for user lists). 47 kinds, grouped
+  by data source (basic ×9, file-metadata ×7, Seerr ×10, Tautulli ×3,
+  Plex ×8, Jellyfin ×7, misc ×8 incl. tmdb/trakt list membership).
+- **Field-match style** (notifications): a condition is
+  `{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }`
+  with five universal operators
+  (`equals|not_equals|contains|greater_than|in`) over payload fields
+  (`eventType`, `title`, `body`, `metadata.*`).
+
+### 1.2 Composition reality
+
+- Cleanup/auto-tag: **one-level** AND/OR composite (`operator` +
+  `conditions[]`); no NOT; no nesting.
+- Notifications: **flat implicit AND** across the conditions array;
+  first-matching-rule-wins across rules (priority-ordered).
+- Nobody nests. Nobody has rule-level NOT.
+
+### 1.3 Semantics that must be preserved exactly
+
+1. **Permissive null** (cleanup family): missing data → condition does
+   not match; never an error. (E.g. item absent from the Plex watch map
+   → `plex_last_watched` returns no-match.) Changing this silently
+   changes which items cleanup rules flag.
+2. **"Never watched" inference** (cleanup family): `plex_watch_count`
+   with `less_than` infers 0 plays for items with a file, added N+ days
+   ago, absent from the watch map.
+3. **First-match-wins + priority** (notifications): exactly one rule's
+   action fires per event.
+4. **Action↔field coupling** (notifications): `throttle`/`route`/
+   `quiet_hours` carry extra columns. **Actions are out of grammar
+   scope** — the grammar unifies predicates only; actions remain
+   domain-owned columns.
+5. **Case-insensitive string matching** throughout the cleanup family;
+   notifications' `equals` is case-sensitive but `contains` is not.
+   The grammar must not "harmonize" this — each kind keeps its
+   documented semantics.
+
+## 2. The grammar
+
+### 2.1 Shape (serialization v1)
+
+```ts
+// One predicate. The kind+params style is the base form.
+type Condition = {
+  kind: string;                       // e.g. "plex_last_watched", "field_match"
+  params: Record<string, unknown>;    // validated by the kind's Zod schema
+};
+
+// Composite. Schema permits recursion; v1 UI and validators restrict
+// depth to 1 (matching every existing rule). Depth is a future unlock,
+// not a migration burden.
+type ConditionGroup =
+  | { all: ConditionNode[] }          // AND
+  | { any: ConditionNode[] };         // OR
+
+type ConditionNode = Condition | ConditionGroup;
+
+// The stored document envelope (per rule row, in the existing JSON columns)
+type RuleDocument = {
+  version: 1;
+  root: ConditionNode;
+};
+```
+
+Notifications' field-match style becomes **one kind in the unified
+vocabulary** rather than a parallel grammar:
+
+```ts
+// kind: "field_match"
+params: {
+  field: "eventType" | "title" | "body" | `metadata.${string}`;
+  operator: "equals" | "not_equals" | "contains" | "greater_than" | "in";
+  value: string | number | string[];
+}
+```
+
+### 2.2 Context registry
+
+Each domain registers an **evaluation context**: the set of kinds legal
+in that domain plus the data the evaluator needs.
+
+```ts
+type RuleContext = {
+  id: "library-cleanup" | "auto-tag" | "notifications"
+    | "queue-cleaner" | "hunting";
+  kinds: Set<string>;                  // legal condition kinds
+  buildEvalInput: (...domainArgs) => EvalInput;  // domain-owned
+};
+```
+
+- `library-cleanup` and `auto-tag` share the 47-kind vocabulary (the
+  existing shared-evaluator relationship, formalized). Auto-tag
+  additionally registers the list-membership maps in its eval input.
+- `notifications` registers `field_match` (and gains nothing else in
+  v1 — its vocabulary is intentionally tiny and event-shaped).
+- `queue-cleaner` / `hunting` register internal kinds for their config
+  semantics (`stalled`, `tag_membership`, `status_hierarchy`, …) used
+  only by their adapters; not exposed in the composer in v1.
+- The engine validates at parse time that every kind in a document is
+  legal for the context — a cleanup rule cannot smuggle a
+  `field_match` on a notification payload and vice versa.
+
+### 2.3 What deliberately does NOT unify
+
+- **Actions** (notifications' suppress/throttle/route/quiet_hours;
+  cleanup's flag-for-review; auto-tag's tag writes) — domain-owned.
+- **Trigger model** (event-driven vs scheduled) — domain-owned.
+- **Operator vocabulary across kinds** — per-kind enums stay. A global
+  operator set would force semantic changes (see §1.3.5) for zero user
+  value.
+- **Queue-cleaner / hunting storage** — config columns stay; their UIs
+  stay; only the evaluation internals route through the engine.
+
+## 3. Per-surface migration mapping (ADR-0006 5-point contract)
+
+| Surface | Transform | Risk |
+|---|---|---|
+| Library Cleanup | Near-identity: `{ruleType, parameters}` → `{version:1, root:{kind, params}}`; composites → `{all:[…]}`/`{any:[…]}` | Low — shape-preserving envelope |
+| Auto-Tagger | Same as cleanup | Low |
+| Notifications | Each `{field,operator,value}` → `{kind:"field_match", params:{…}}`; array → `{all:[…]}` | Low — lossless and mechanical |
+| Queue Cleaner | **None** (config unchanged; adapter internal) | n/a |
+| Hunting | **None** (config unchanged; adapter internal) | n/a |
+
+### 3.1 The Tautulli test case (ADR-0006/0007 amendments)
+
+During the cleanup/auto-tag migration, conditions with kinds
+`tautulli_last_watched`, `tautulli_watch_count`, `tautulli_watched_by`:
+
+1. Are counted and listed per rule in the migration report (feeds the
+   A2 dialog's disclosure: "N of your rules referenced Tautulli watch
+   data").
+2. Composite handling: if removing the Tautulli condition leaves the
+   composite empty → the rule is **disabled** (not deleted), flagged
+   `migration: tautulli-orphaned`. If siblings remain → the condition
+   is removed and the rule stays active, flagged
+   `migration: tautulli-condition-dropped`.
+3. The backup file (`/config/rules-pre-3.0/<surface>.json`) preserves
+   the original documents regardless.
+4. Post-A2 (Tracearr-era), users can re-express watch conditions with
+   the Plex/Jellyfin kinds or future Tracearr kinds; the migration does
+   NOT auto-rewrite `tautulli_*` → `plex_*` (different data sources;
+   silent semantic swaps violate the trust thesis).
+
+## 4. Implementation order (A4)
+
+1. `packages/shared` (or `apps/api/src/lib/rules/`): grammar types +
+   Zod schemas + per-kind param schemas lifted from
+   `ruleParamSchemaMap` (cleanup's existing per-kind validation).
+2. Engine core: parse → validate-against-context → evaluate. Seeded
+   from cleanup's `rule-evaluators.ts` (per ADR-0006); decompose the
+   82 KB file along kind-category lines as part of the lift.
+3. Cleanup + auto-tag re-pointed at the engine (their evaluators ARE
+   the engine; this step is mostly file moves + context wiring).
+4. Notifications adapter + document migration (the only behavioral
+   risk; ship with fixture tests against real 2.x rule rows).
+5. Queue-cleaner + hunting adapters (internal; can trail).
+6. Migrations per the 5-point contract; Tautulli counting wired for A2.
+7. Composer UI (Operator Console) — after the engine stabilizes;
+   seeded from `features/rule-criteria/`.
+
+## 5. Open questions for review
+
+1. **Where do the shared schemas live** — `packages/shared` (frontend
+   composer needs the types + Zod for validation) vs `apps/api/lib`
+   (keeps grammar server-private)? Leaning `packages/shared` since the
+   composer must validate client-side.
+2. **Version field**: `version: 1` on every document vs schema-level
+   versioning per surface? Leaning per-document — it makes the next
+   migration self-describing.
+3. **Notifications metadata fields**: the engine supports
+   `metadata.*` but the UI never exposed it. Keep API-only in v1, or
+   surface it in the composer? Leaning keep API-only (no user demand
+   signal yet).
+4. **Queue-cleaner/hunting in the composer**: v1 keeps them
+   adapter-only (their config UIs stay). Does the Operator Console
+   eventually edit them through the composer (v1.5/v2), or are flat
+   config UIs the right permanent shape for config-class surfaces?


### PR DESCRIPTION
## Summary
The grammar design doc ADR-0006 requires before any A4 engine code. Built from a three-agent survey of all five rule systems on `next`.

## Headline finding — ADR-0006's premise corrected
Only **3 of 5** surfaces store rule documents:

| Surface | Stored documents? | Migration |
|---|---|---|
| Library Cleanup (47 kinds) | ✅ | Near-identity envelope |
| Auto-Tagger (mirrors cleanup) | ✅ | Same |
| Notifications (field/operator/value) | ✅ | Lossless mechanical wrap |
| Queue Cleaner | ❌ flat config columns | **None** — internal adapter |
| Hunting | ❌ flat config columns | **None** — internal adapter |

The unified migration shrinks from 5 surfaces to 3 — A4's riskiest dimension down 40%.

## Grammar v1 in one paragraph
`{kind, params}` conditions (cleanup's existing shape) as the base; notifications' style becomes a `field_match` kind; `{all:[…]}`/`{any:[…]}` composition restricted to depth 1 in v1 (nobody nests today — schema permits recursion as a future unlock); per-domain **context registry** gates which kinds are legal where. Deliberately NOT unified: actions, trigger models, per-kind operator enums, queue-cleaner/hunting storage.

## Also specified
- The 5 semantics that must survive migration exactly (permissive null, never-watched inference, first-match-wins, action↔field coupling, per-kind case sensitivity)
- Full Tautulli-condition migration contract (count + disclose for the A2 dialog; disable-if-orphaned / drop-if-siblings; **no silent `tautulli_*`→`plex_*` rewrites**)
- Implementation order (7 steps, engine seeded from cleanup's evaluators)

## Review focus — 4 open questions (§5)
1. Shared schemas in `packages/shared` vs api-private? (lean: shared — composer validates client-side)
2. Per-document `version: 1` vs schema-level versioning? (lean: per-document)
3. `metadata.*` conditions: keep API-only or expose in composer? (lean: API-only)
4. Queue-cleaner/hunting in the composer eventually, or flat config UIs permanently?

🤖 Generated with [Claude Code](https://claude.com/claude-code)