### PR TITLE
feat(3.0): rule engine core + differential parity suite (A4 steps 2–3)

### DIFF
--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -1788,14 +1788,14 @@ export function extractRating(item: CacheItemForEval): number | null {
 /**
  * Parse rule parameters JSON string into a typed object.
  */
-function parseParams(rule: LibraryCleanupRule): Record<string, unknown> | null {
+export function parseParams(rule: LibraryCleanupRule): Record<string, unknown> | null {
 	return safeJsonParse(rule.parameters) as Record<string, unknown> | null;
 }
 
 /**
  * Check if item's service type passes the rule's service filter.
  */
-function passesServiceFilter(instanceService: string, serviceFilter: string | null): boolean {
+export function passesServiceFilter(instanceService: string, serviceFilter: string | null): boolean {
 	if (!serviceFilter) return true;
 	const filter = safeJsonParse(serviceFilter) as string[] | null;
 	if (!filter || filter.length === 0) return true;
@@ -1805,7 +1805,7 @@ function passesServiceFilter(instanceService: string, serviceFilter: string | nu
 /**
  * Check if item's instance passes the rule's instance filter.
  */
-function passesInstanceFilter(instanceId: string, instanceFilter: string | null): boolean {
+export function passesInstanceFilter(instanceId: string, instanceFilter: string | null): boolean {
 	if (!instanceFilter) return true;
 	const filter = safeJsonParse(instanceFilter) as string[] | null;
 	if (!filter || filter.length === 0) return true;
@@ -1815,7 +1815,7 @@ function passesInstanceFilter(instanceId: string, instanceFilter: string | null)
 /**
  * Check if item should be excluded by tag filter.
  */
-function passesTagExclusion(item: CacheItemForEval, excludeTags: string | null): boolean {
+export function passesTagExclusion(item: CacheItemForEval, excludeTags: string | null): boolean {
 	if (!excludeTags) return true;
 	const tagIds = safeJsonParse(excludeTags) as number[] | null;
 	if (!tagIds || tagIds.length === 0) return true;
@@ -1840,7 +1840,7 @@ function passesTagExclusion(item: CacheItemForEval, excludeTags: string | null):
 /**
  * Check if item should be excluded by title regex patterns.
  */
-function passesTitleExclusion(title: string, excludeTitles: string | null): boolean {
+export function passesTitleExclusion(title: string, excludeTitles: string | null): boolean {
 	if (!excludeTitles) return true;
 	const patterns = safeJsonParse(excludeTitles) as string[] | null;
 	if (!patterns || patterns.length === 0) return true;

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -1,0 +1,322 @@
+/**
+ * Differential parity suite — legacy `evaluateRule` vs the engine-backed
+ * `evaluateRuleViaEngine` (unified-rule-grammar §4 step 3).
+ *
+ * THE cutover gate: every fixture asserts the two paths return deep-equal
+ * results (same RuleMatch incl. composed reason strings, or both null).
+ * Fixtures are author-shaped rules (template/dialog-derived — §4.3 as
+ * amended) plus the §1.3/§6.5 preserved-semantics edges: permissive
+ * null, never-watched inference, case-insensitivity, retired-kind
+ * no-match, the source:"tautulli" fail-safe, and the legacy domain
+ * quirks (empty composite, unparseable JSON).
+ */
+
+import { describe, expect, it } from "vitest";
+import { evaluateRule } from "../../library-cleanup/rule-evaluators.js";
+import type { CacheItemForEval, EvalContext, PlexWatchInfo } from "../../library-cleanup/types.js";
+import type { LibraryCleanupRule } from "../../prisma.js";
+import { evaluateRuleViaEngine } from "../cleanup-adapter.js";
+
+// ---------------------------------------------------------------------------
+// Factories (shapes mirror rule-evaluators.test.ts)
+// ---------------------------------------------------------------------------
+
+const NOW = new Date("2026-03-01T12:00:00Z");
+
+const DEFAULT_DATA = {
+	genres: ["Action", "Sci-Fi"],
+	ratings: { tmdb: { value: 7.5 }, imdb: { value: 7.2 } },
+	remoteIds: { tmdbId: 12345 },
+	movieFile: {
+		mediaInfo: {
+			videoCodec: "h265",
+			audioCodec: "eac3",
+			resolution: "1920x1080",
+			videoDynamicRange: "HDR",
+			audioChannels: 5.1,
+		},
+		quality: { quality: { name: "Bluray-1080p" } },
+		customFormatScore: 85,
+		releaseGroup: "SPARKS",
+		runtime: 142,
+		path: "/movies/Test Movie (2020)/Test.Movie.2020.1080p.BluRay.mkv",
+	},
+	tags: [1, 3],
+};
+
+function makeCacheItem(overrides: Partial<CacheItemForEval> = {}): CacheItemForEval {
+	return {
+		id: "cache-1",
+		instanceId: "instance-1",
+		arrItemId: 100,
+		itemType: "movie",
+		title: "Test Movie 2020",
+		year: 2020,
+		monitored: true,
+		hasFile: true,
+		status: "released",
+		qualityProfileId: 1,
+		qualityProfileName: "HD-1080p",
+		sizeOnDisk: BigInt(5 * 1024 * 1024 * 1024),
+		arrAddedAt: new Date("2025-12-01T00:00:00Z"),
+		data: JSON.stringify(DEFAULT_DATA),
+		...overrides,
+	};
+}
+
+function makeRule(overrides: Partial<LibraryCleanupRule> = {}): LibraryCleanupRule {
+	return {
+		id: "rule-1",
+		name: "Parity Rule",
+		enabled: true,
+		priority: 1,
+		ruleType: "age",
+		parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+		serviceFilter: null,
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		action: "delete",
+		operator: null,
+		conditions: null,
+		configId: "config-1",
+		retentionMode: false,
+		createdAt: NOW,
+		updatedAt: NOW,
+		...overrides,
+	} as unknown as LibraryCleanupRule; // cast keeps the suite Prisma-generate-free, matching the legacy tests
+}
+
+function makePlexInfo(overrides: Partial<PlexWatchInfo> = {}): PlexWatchInfo {
+	return {
+		lastWatchedAt: new Date("2025-10-01T00:00:00Z"),
+		watchCount: 3,
+		watchedByUsers: ["alice", "bob"],
+		onDeck: false,
+		userRating: null,
+		collections: [],
+		labels: [],
+		addedAt: new Date("2025-09-01T00:00:00Z"),
+		sections: [],
+		...overrides,
+	} as PlexWatchInfo;
+}
+
+function baseCtx(overrides: Partial<EvalContext> = {}): EvalContext {
+	return { now: NOW, ...overrides };
+}
+
+/** The parity assertion — both paths, deep-equal. */
+function assertParity(
+	rule: LibraryCleanupRule,
+	item: CacheItemForEval = makeCacheItem(),
+	ctx: EvalContext = baseCtx(),
+	instanceService = "RADARR",
+) {
+	const legacy = evaluateRule(item, rule, instanceService, ctx);
+	const engine = evaluateRuleViaEngine(item, rule, instanceService, ctx);
+	expect(engine).toEqual(legacy);
+	return { legacy, engine };
+}
+
+// ---------------------------------------------------------------------------
+// Single rules
+// ---------------------------------------------------------------------------
+
+describe("parity — single rules", () => {
+	it("age match (reason strings identical)", () => {
+		const { legacy } = assertParity(makeRule());
+		expect(legacy).not.toBeNull(); // both matched, not both-null
+	});
+
+	it("age no-match", () => {
+		const { legacy } = assertParity(
+			makeRule(),
+			makeCacheItem({ arrAddedAt: new Date("2026-02-28T00:00:00Z") }),
+		);
+		expect(legacy).toBeNull();
+	});
+
+	it("permissive null — age with null arrAddedAt", () => {
+		assertParity(makeRule(), makeCacheItem({ arrAddedAt: null }));
+	});
+
+	it("size greater_than", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "size",
+				parameters: JSON.stringify({ operator: "greater_than", sizeGb: 2 }),
+			}),
+		);
+		expect(legacy).not.toBeNull();
+	});
+
+	it("genre case-insensitivity (§1.3.5)", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "genre",
+				parameters: JSON.stringify({ operator: "includes_any", genres: ["aCtIoN"] }),
+			}),
+		);
+		expect(legacy).not.toBeNull();
+	});
+
+	it("plex_last_watched with watch data", () => {
+		const ctx = baseCtx({ plexMap: new Map([["movie:12345", makePlexInfo()]]) });
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "plex_last_watched",
+				parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+			}),
+			makeCacheItem(),
+			ctx,
+		);
+		expect(legacy).not.toBeNull();
+	});
+
+	it("permissive null — plex_last_watched with item absent from the watch map", () => {
+		assertParity(
+			makeRule({
+				ruleType: "plex_last_watched",
+				parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+			}),
+			makeCacheItem(),
+			baseCtx({ plexMap: new Map() }),
+		);
+	});
+
+	it("never-watched inference — plex_watch_count less_than on map-absent item (§1.3.2)", () => {
+		// Inference requires a NON-empty plexMap (proof Plex is configured)
+		// with this item absent from it — an empty map means "no Plex data
+		// at all" and stays permissive-null.
+		const ctx = baseCtx({ plexMap: new Map([["movie:99999", makePlexInfo()]]) });
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "plex_watch_count",
+				parameters: JSON.stringify({ operator: "less_than", count: 1 }),
+			}),
+			makeCacheItem(), // hasFile, added ~90d before NOW → inference applies
+			ctx,
+		);
+		expect(legacy).not.toBeNull();
+	});
+
+	it("user_retention source plex / either / tautulli (fail-safe, §6.5)", () => {
+		for (const source of ["plex", "either", "tautulli"]) {
+			assertParity(
+				makeRule({
+					ruleType: "user_retention",
+					parameters: JSON.stringify({ operator: "watched_by_none", source }),
+				}),
+				makeCacheItem(),
+				baseCtx({ plexMap: new Map() }),
+			);
+		}
+	});
+
+	it("retired kind — disabled-then-re-enabled tautulli rule no-matches on both paths", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "tautulli_last_watched",
+				parameters: JSON.stringify({ operator: "older_than", days: 90 }),
+			}),
+		);
+		expect(legacy).toBeNull();
+	});
+
+	it("legacy quirk — unparseable parameters JSON no-matches", () => {
+		assertParity(makeRule({ parameters: "not-json{{{" }));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Composites
+// ---------------------------------------------------------------------------
+
+describe("parity — composites", () => {
+	const ageCond = { ruleType: "age", parameters: { operator: "older_than", days: 30 } };
+	const sizeCond = { ruleType: "size", parameters: { operator: "greater_than", sizeGb: 2 } };
+	const noMatchCond = { ruleType: "size", parameters: { operator: "greater_than", sizeGb: 500 } };
+	const retiredCond = { ruleType: "tautulli_watched_by", parameters: { userNames: ["x"] } };
+
+	it("AND — multi-reason ' AND ' join is byte-identical", () => {
+		const { legacy, engine } = assertParity(
+			makeRule({
+				ruleType: "composite",
+				operator: "AND",
+				conditions: JSON.stringify([ageCond, sizeCond]),
+			}),
+		);
+		expect(legacy?.reason).toContain(" AND ");
+		expect(engine?.reason).toBe(legacy?.reason);
+	});
+
+	it("AND — one failing condition fails the rule", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "composite",
+				operator: "AND",
+				conditions: JSON.stringify([ageCond, noMatchCond]),
+			}),
+		);
+		expect(legacy).toBeNull();
+	});
+
+	it("OR — first matching reason only, in declaration order", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "composite",
+				operator: "OR",
+				conditions: JSON.stringify([noMatchCond, ageCond, sizeCond]),
+			}),
+		);
+		expect(legacy?.reason).not.toContain(" AND ");
+	});
+
+	it("OR — retired-kind sibling no-matches but does not poison the rule", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "composite",
+				operator: "OR",
+				conditions: JSON.stringify([retiredCond, ageCond]),
+			}),
+		);
+		expect(legacy).not.toBeNull(); // age sibling still matches on both paths
+	});
+
+	it("legacy quirk — empty composite conditions no-match (NOT vacuous true)", () => {
+		assertParity(makeRule({ ruleType: "composite", operator: "AND", conditions: "[]" }));
+	});
+
+	it("legacy quirk — unparseable composite conditions no-match", () => {
+		assertParity(makeRule({ ruleType: "composite", operator: "AND", conditions: "not-json{{{" }));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Pre-filters + rule state
+// ---------------------------------------------------------------------------
+
+describe("parity — pre-filters and rule state", () => {
+	it("disabled rule", () => {
+		assertParity(makeRule({ enabled: false }));
+	});
+
+	it("service filter mismatch", () => {
+		assertParity(makeRule({ serviceFilter: JSON.stringify(["SONARR"]) }));
+	});
+
+	it("title exclusion", () => {
+		assertParity(makeRule({ excludeTitles: JSON.stringify(["Test Movie 2020"]) }));
+	});
+
+	it("instance filter mismatch", () => {
+		assertParity(makeRule({ instanceFilter: JSON.stringify(["other-instance"]) }));
+	});
+
+	it("action passthrough — unmonitor", () => {
+		const { legacy } = assertParity(makeRule({ action: "unmonitor" }));
+		expect(legacy?.action).toBe("unmonitor");
+	});
+});

--- a/apps/api/src/lib/rules/__tests__/engine.test.ts
+++ b/apps/api/src/lib/rules/__tests__/engine.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Engine composition tests (unified-rule-grammar §4 step 2).
+ *
+ * Pins the legacy-exact reason semantics the cutover depends on:
+ * `all` joins every reason with " AND " (cleanup's AND path), `any`
+ * returns the FIRST matching reason only (cleanup's OR path). Also
+ * pins the tier-2/tier-3 split: the engine never inspects kinds —
+ * permissive null is the injected evaluator's job; annotation is
+ * normalizeDocument's.
+ */
+
+import type { RuleDocument, RulePredicate } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import {
+	evaluateDocument,
+	evaluateNode,
+	listUnavailableKinds,
+	normalizeDocument,
+	type PredicateEvaluator,
+} from "../engine.js";
+
+/** Evaluator stub: kind "match_*" matches with its suffix as reason. */
+const stubEvaluator: PredicateEvaluator = (p: RulePredicate) =>
+	p.kind.startsWith("match_") ? `reason:${p.kind.slice("match_".length)}` : null;
+
+const doc = (root: RuleDocument["root"]): RuleDocument => ({ version: 1, root });
+
+describe("evaluateNode — predicates", () => {
+	it("returns the evaluator's reason on match", () => {
+		expect(evaluateNode({ kind: "match_a", params: {} }, stubEvaluator)).toEqual({
+			matched: true,
+			reason: "reason:a",
+		});
+	});
+
+	it("returns no-match when the evaluator returns null (tier-3 permissive null)", () => {
+		expect(evaluateNode({ kind: "tautulli_last_watched", params: {} }, stubEvaluator)).toEqual({
+			matched: false,
+		});
+	});
+});
+
+describe("evaluateNode — all groups (legacy AND semantics)", () => {
+	it("joins every child reason with ' AND ' in order", () => {
+		const result = evaluateNode(
+			{
+				all: [
+					{ kind: "match_a", params: {} },
+					{ kind: "match_b", params: {} },
+				],
+			},
+			stubEvaluator,
+		);
+		expect(result).toEqual({ matched: true, reason: "reason:a AND reason:b" });
+	});
+
+	it("fails when ANY child fails", () => {
+		const result = evaluateNode(
+			{
+				all: [
+					{ kind: "match_a", params: {} },
+					{ kind: "no_match", params: {} },
+				],
+			},
+			stubEvaluator,
+		);
+		expect(result).toEqual({ matched: false });
+	});
+
+	it("empty all-group is vacuously true (notifications' match-all semantics)", () => {
+		expect(evaluateNode({ all: [] }, stubEvaluator)).toEqual({ matched: true, reason: "" });
+	});
+});
+
+describe("evaluateNode — any groups (legacy OR semantics)", () => {
+	it("returns the FIRST matching reason only", () => {
+		const result = evaluateNode(
+			{
+				any: [
+					{ kind: "no_match", params: {} },
+					{ kind: "match_b", params: {} },
+					{ kind: "match_c", params: {} },
+				],
+			},
+			stubEvaluator,
+		);
+		expect(result).toEqual({ matched: true, reason: "reason:b" });
+	});
+
+	it("fails when no child matches", () => {
+		expect(evaluateNode({ any: [{ kind: "no_match", params: {} }] }, stubEvaluator)).toEqual({
+			matched: false,
+		});
+	});
+
+	it("empty any-group is false (standard existential on empty set)", () => {
+		expect(evaluateNode({ any: [] }, stubEvaluator)).toEqual({ matched: false });
+	});
+});
+
+describe("evaluateDocument — recursion ready", () => {
+	it("evaluates nested groups correctly even though v1 writes are depth-1", () => {
+		// The engine handles depth the grammar permits structurally; the
+		// depth-1 restriction is a write-path policy, not an engine limit.
+		const result = evaluateDocument(
+			doc({
+				all: [
+					{ kind: "match_a", params: {} },
+					{
+						any: [
+							{ kind: "no_match", params: {} },
+							{ kind: "match_b", params: {} },
+						],
+					},
+				],
+			}),
+			stubEvaluator,
+		);
+		expect(result).toEqual({ matched: true, reason: "reason:a AND reason:b" });
+	});
+});
+
+describe("normalizeDocument (tier-2 annotation)", () => {
+	const legal = new Set(["age", "size"]);
+
+	it("annotates predicates whose kind is not legal for the context", () => {
+		const normalized = normalizeDocument(
+			doc({
+				all: [
+					{ kind: "age", params: {} },
+					{ kind: "tautulli_last_watched", params: {} },
+				],
+			}),
+			legal,
+		);
+		expect(normalized.root).toEqual({
+			all: [
+				{ kind: "age", params: {} },
+				{ kind: "tautulli_last_watched", params: {}, unavailableKind: true },
+			],
+		});
+	});
+
+	it("never mutates the input document", () => {
+		const input = doc({ kind: "tautulli_last_watched", params: {} });
+		const before = JSON.parse(JSON.stringify(input));
+		normalizeDocument(input, legal);
+		expect(input).toEqual(before);
+	});
+
+	it("strips stale stored annotations — availability is computed, never trusted", () => {
+		const normalized = normalizeDocument(
+			doc({ kind: "age", params: {}, unavailableKind: true }),
+			legal,
+		);
+		expect(normalized.root).toEqual({ kind: "age", params: {} });
+	});
+});
+
+describe("listUnavailableKinds", () => {
+	it("collects unique illegal kinds across the tree", () => {
+		const kinds = listUnavailableKinds(
+			doc({
+				all: [
+					{ kind: "age", params: {} },
+					{ kind: "tautulli_watch_count", params: {} },
+					{ any: [{ kind: "tautulli_watch_count", params: {} }] },
+				],
+			}),
+			new Set(["age"]),
+		);
+		expect(kinds).toEqual(["tautulli_watch_count"]);
+	});
+});

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -1,0 +1,92 @@
+/**
+ * Cleanup/auto-tag → engine adapter
+ * (docs/design/unified-rule-grammar.md §4 step 4, strangler shape).
+ *
+ * Reproduces `evaluateRule`'s exact decision surface on top of the
+ * unified engine: same pre-filters (imported, never duplicated), same
+ * composite reason semantics (engine pins them), same domain quirks —
+ * all reproduced deliberately and parity-tested:
+ *
+ *   - empty/unparseable composite conditions → no-match (legacy guard
+ *     `if (!conditions?.length) return null`)
+ *   - unparseable single-rule parameters → no-match (legacy
+ *     `parseParams` returning null)
+ *   - retired/unknown kinds → no-match via the injected dispatch's
+ *     `default: return null` (tier-3 permissive null, §2.2)
+ *
+ * One documented, intentional delta: structurally unrepresentable rows
+ * (a composite condition without `ruleType`, parameters that aren't an
+ * object) map to no-match here, where the legacy path could THROW from
+ * inside an evaluator mid-run. Such rows cannot be produced by any
+ * write path; no-match is strictly safer than an aborted cleanup run.
+ *
+ * Cutover = swapping `evaluateRule` call sites to
+ * `evaluateRuleViaEngine` once the differential parity suite is green.
+ */
+
+import type { RuleDocument } from "@arr/shared";
+import {
+	evaluateSingleCondition,
+	passesInstanceFilter,
+	passesServiceFilter,
+	passesTagExclusion,
+	passesTitleExclusion,
+} from "../library-cleanup/rule-evaluators.js";
+import type {
+	CacheItemForEval,
+	EvalContext,
+	RuleAction,
+	RuleMatch,
+} from "../library-cleanup/types.js";
+import type { LibraryCleanupRule } from "../prisma.js";
+import { safeJsonParse } from "../utils/json.js";
+import { evaluateDocument, type PredicateEvaluator } from "./engine.js";
+import { mapCriteriaV0ToDocument } from "./v0-mappers.js";
+
+/**
+ * Engine-backed equivalent of `evaluateRule` (rule-evaluators.ts).
+ * Identical inputs, identical outputs — proven by the parity suite.
+ */
+export function evaluateRuleViaEngine(
+	item: CacheItemForEval,
+	rule: LibraryCleanupRule,
+	instanceService: string,
+	ctx: EvalContext,
+): RuleMatch | null {
+	if (!rule.enabled) return null;
+
+	// Pre-filters — the legacy functions, not copies.
+	if (!passesServiceFilter(instanceService, rule.serviceFilter)) return null;
+	if (!passesInstanceFilter(item.instanceId, rule.instanceFilter)) return null;
+	if (!passesTagExclusion(item, rule.excludeTags)) return null;
+	if (!passesTitleExclusion(item.title, rule.excludeTitles)) return null;
+
+	const plexLibFilter = safeJsonParse(rule.plexLibraryFilter) as string[] | null;
+	const action = (rule.action ?? "delete") as RuleAction;
+
+	// Domain quirk guards (rule-level policy, deliberately NOT in the
+	// engine — see engine.ts header on empty-group semantics).
+	if (rule.operator && rule.conditions) {
+		const conditions = safeJsonParse(rule.conditions) as unknown[] | null;
+		if (!conditions?.length) return null;
+	} else {
+		const params = safeJsonParse(rule.parameters) as Record<string, unknown> | null;
+		if (!params) return null;
+	}
+
+	let doc: RuleDocument;
+	try {
+		doc = mapCriteriaV0ToDocument(rule);
+	} catch {
+		// Unrepresentable row (see header) — no-match, never a thrown run.
+		return null;
+	}
+
+	const evalPredicate: PredicateEvaluator = (predicate) =>
+		evaluateSingleCondition(item, predicate.kind, predicate.params, ctx, plexLibFilter);
+
+	const result = evaluateDocument(doc, evalPredicate);
+	return result.matched
+		? { ruleId: rule.id, ruleName: rule.name, reason: result.reason, action }
+		: null;
+}

--- a/apps/api/src/lib/rules/engine.ts
+++ b/apps/api/src/lib/rules/engine.ts
@@ -1,0 +1,140 @@
+/**
+ * Unified rule engine — composition core
+ * (docs/design/unified-rule-grammar.md §4 step 2, as refined at the
+ * implementation checkpoint).
+ *
+ * The engine is PURE COMPOSITION over grammar nodes; per-kind predicate
+ * evaluation is injected. This is the strangler shape: the existing
+ * 79 KB `rule-evaluators.ts` is not copied or decomposed — its
+ * `evaluateSingleCondition` dispatch IS the injected evaluator for the
+ * cleanup/auto-tag context, wrapped at cutover (§4 step 4). The
+ * decomposition the design doc sketched becomes optional polish, not a
+ * migration step.
+ *
+ * Reason-string semantics mirror the legacy composite path EXACTLY
+ * (parity-tested):
+ *   - `all`: every child must match; reasons joined with " AND "
+ *   - `any`: FIRST matching child's reason only
+ *
+ * Empty-group semantics are deliberately standard logic here
+ * (`all: []` → vacuous true, `any: []` → false) because the surfaces
+ * disagree: notifications' empty condition list matches every event
+ * (Array.every on []), while cleanup rejects empty composites BEFORE
+ * evaluation (`if (!conditions?.length) return null`). That cleanup
+ * guard is rule-level domain policy and lives in the cleanup adapter,
+ * never in the engine.
+ *
+ * Kind-legality tier 3 (permissive null) lives in the INJECTED
+ * evaluators — the legacy dispatch's `default: return null` and the
+ * `source:"tautulli"` fail-safe ride along unchanged. The engine never
+ * inspects kinds; tier-2 annotation is `normalizeDocument` below.
+ */
+
+import {
+	groupChildren,
+	isRulePredicate,
+	type RuleDocument,
+	type RuleGroup,
+	type RuleNode,
+	type RulePredicate,
+} from "@arr/shared";
+
+// ============================================================================
+// Evaluation
+// ============================================================================
+
+/**
+ * A predicate evaluator returns the human-readable match reason, or
+ * null for no-match. Unknown/retired kinds and stale params MUST return
+ * null (tier-3 permissive null), never throw.
+ */
+export type PredicateEvaluator = (predicate: RulePredicate) => string | null;
+
+export type EvalResult = { matched: true; reason: string } | { matched: false };
+
+const NO_MATCH: EvalResult = { matched: false };
+
+export function evaluateNode(node: RuleNode, evalPredicate: PredicateEvaluator): EvalResult {
+	if (isRulePredicate(node)) {
+		const reason = evalPredicate(node);
+		return reason === null ? NO_MATCH : { matched: true, reason };
+	}
+	return evaluateGroup(node, evalPredicate);
+}
+
+function evaluateGroup(group: RuleGroup, evalPredicate: PredicateEvaluator): EvalResult {
+	const children = groupChildren(group);
+
+	if ("all" in group) {
+		// Vacuous truth on []: notifications' "no conditions = match all
+		// events". Cleanup never reaches here with [] (adapter guard).
+		const reasons: string[] = [];
+		for (const child of children) {
+			const result = evaluateNode(child, evalPredicate);
+			if (!result.matched) return NO_MATCH;
+			reasons.push(result.reason);
+		}
+		return { matched: true, reason: reasons.join(" AND ") };
+	}
+
+	// any: first matching child's reason only (legacy OR semantics)
+	for (const child of children) {
+		const result = evaluateNode(child, evalPredicate);
+		if (result.matched) return result;
+	}
+	return NO_MATCH;
+}
+
+export function evaluateDocument(doc: RuleDocument, evalPredicate: PredicateEvaluator): EvalResult {
+	return evaluateNode(doc.root, evalPredicate);
+}
+
+// ============================================================================
+// Normalization annotation (tier 2)
+// ============================================================================
+
+/**
+ * Return a copy of the document with `unavailableKind: true` set on
+ * every predicate whose kind is not in the context's legal set —
+ * retired kinds (tautulli_*) or vocabulary drift. Never mutates the
+ * input; never rejects (stored documents legally contain retired
+ * kinds — §2.2 as amended). API rule GET endpoints serve this so the
+ * UI can badge unavailable conditions instead of silently no-matching.
+ */
+export function normalizeDocument(
+	doc: RuleDocument,
+	legalKinds: ReadonlySet<string>,
+): RuleDocument {
+	return { version: 1, root: annotateNode(doc.root, legalKinds) };
+}
+
+function annotateNode(node: RuleNode, legalKinds: ReadonlySet<string>): RuleNode {
+	if (isRulePredicate(node)) {
+		if (legalKinds.has(node.kind)) {
+			// Strip any stale stored annotation — availability is computed,
+			// never trusted from input.
+			if (node.unavailableKind === undefined) return node;
+			const { unavailableKind: _stale, ...rest } = node;
+			return rest;
+		}
+		return { ...node, unavailableKind: true };
+	}
+	if ("all" in node) {
+		return { all: node.all.map((child) => annotateNode(child, legalKinds)) };
+	}
+	return { any: node.any.map((child) => annotateNode(child, legalKinds)) };
+}
+
+/** List the kinds in a document that are not legal for the context. */
+export function listUnavailableKinds(doc: RuleDocument, legalKinds: ReadonlySet<string>): string[] {
+	const found = new Set<string>();
+	const walk = (node: RuleNode): void => {
+		if (isRulePredicate(node)) {
+			if (!legalKinds.has(node.kind)) found.add(node.kind);
+			return;
+		}
+		for (const child of groupChildren(node)) walk(child);
+	};
+	walk(doc.root);
+	return [...found];
+}


### PR DESCRIPTION
## Summary

Steps 2–3 of Bucket A4 (`docs/design/unified-rule-grammar.md` §4). No behavior change anywhere — no call site is swapped yet; this lands the engine and the gate that authorizes the swap.

### Engine core — refined at the implementation checkpoint
The design sketched "seed from `rule-evaluators.ts`; decompose the 82KB file as part of the lift." The implementation found a lower-risk shape: **pure composition with injected predicate evaluators**. The legacy `evaluateSingleCondition` dispatch *is* the injected evaluator — nothing is copied, so the decomposition becomes optional polish instead of a migration step, and tier-3 permissive null (default-null dispatch + the `source:"tautulli"` fail-safe) rides along unchanged.

- `evaluateNode/evaluateDocument` — legacy-exact reason semantics: `all` joins with `" AND "`, `any` returns the **first** match only
- Empty-group semantics stay domain-owned: notifications' `[]` is match-all (vacuous truth), cleanup's `[]` is no-match (its adapter guard) — the engine does standard logic and the disagreement lives where it belongs
- `normalizeDocument` — tier-2 `unavailableKind` annotation (computed, never trusted from input; non-mutating) for the API-boundary serve path

### Cleanup adapter (the cutover artifact)
`evaluateRuleViaEngine` reproduces `evaluateRule`'s full decision surface — imported (never duplicated) pre-filters, both legacy quirks (empty composite → no-match, unparseable params → no-match), identical `RuleMatch` composition. One documented intentional delta: structurally unrepresentable rows no-match instead of potentially throwing mid-run.

### Differential parity suite — THE cutover gate
22 fixtures assert `legacy === engine` deep-equal (including byte-identical composed reason strings): single rules, AND/OR composites, pre-filters, permissive null, **never-watched inference** (fixture documents that it requires a *non-empty* plexMap as proof Plex is configured), genre case-insensitivity, retired tautulli kinds, and the `source:"tautulli"` fail-safe.

`rule-evaluators.ts` diff is 5 `export` keywords — no logic touched.

Next PR: A4 step 4 — swap cleanup call sites to the adapter behind this green gate, then auto-tag.

## Validation
71 lib/rules tests green (22 parity, 13 engine, 22 mapper, 14 pass-migration); 2078 API tests; turbo typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)