### PR TITLE
feat(3.0): cleanup + auto-tag cutover to the unified engine (A4 step 4)

### DIFF
--- a/apps/api/src/lib/auto-tag/execute-rule.ts
+++ b/apps/api/src/lib/auto-tag/execute-rule.ts
@@ -21,6 +21,7 @@ import { evaluateSingleCondition } from "../library-cleanup/rule-evaluators.js";
 import type { CacheItemForEval, EvalContext } from "../library-cleanup/types.js";
 import type { PrismaClient, ServiceInstance } from "../prisma.js";
 import { safeJsonParse } from "../utils/json.js";
+import { autoTagRuleMatchesViaEngine } from "../rules/auto-tag-adapter.js";
 
 export interface AutoTagRuleInput {
 	id: string;
@@ -279,7 +280,7 @@ async function processInstance(args: ProcessInstanceArgs): Promise<ProcessInstan
 			}
 
 			const cacheItem = item as CacheItemForEval;
-			const matches = evaluateAgainstRule(cacheItem, rule, instance.service, evalCtx);
+			const matches = autoTagRuleMatchesViaEngine(cacheItem, rule, instance.service, evalCtx);
 			if (matches) matched.push({ item: cacheItem, existingTags });
 		}
 
@@ -393,7 +394,7 @@ async function processInstance(args: ProcessInstanceArgs): Promise<ProcessInstan
  * logic from library-cleanup but skips the cleanup-specific pre-filter
  * pass (we do excludeTags/excludeTitles ourselves above).
  */
-function evaluateAgainstRule(
+export function evaluateAgainstRule(
 	item: CacheItemForEval,
 	rule: AutoTagRuleInput,
 	instanceService: string,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -18,7 +18,8 @@ import { SeerrClient } from "../seerr/seerr-client.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
 import { applyQuiSeedingFilter } from "./qui-filter.js";
-import { evaluateItemAgainstRules, extractRating } from "./rule-evaluators.js";
+import { evaluateItemAgainstRulesViaEngine } from "../rules/cleanup-adapter.js";
+import { extractRating } from "./rule-evaluators.js";
 import type {
 	CacheItemForEval,
 	CleanupExecutorDeps,
@@ -1131,7 +1132,7 @@ async function evaluateAllItems(
 			const instanceService = instanceServiceMap.get(item.instanceId);
 			if (!instanceService) continue; // Skip orphaned cache items with no matching instance
 
-			const match = evaluateItemAgainstRules(item, rules, instanceService, ctx, failedSources);
+			const match = evaluateItemAgainstRulesViaEngine(item, rules, instanceService, ctx, failedSources);
 			if (match) {
 				flagged.push({
 					cacheItem: item,

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -2252,7 +2252,7 @@ export function explainItemAgainstRules(
  * Check if a rule should be skipped because its data source failed.
  * Examines both the top-level ruleType and composite sub-conditions.
  */
-function shouldSkipForFailedSource(
+export function shouldSkipForFailedSource(
 	rule: LibraryCleanupRule,
 	failedSources?: Set<DataSourceDependency>,
 ): boolean {
@@ -2314,7 +2314,7 @@ function shouldSkipRuleType(
 /**
  * Determine which pre-filter (if any) would block this rule from evaluating the item.
  */
-function getFilterReason(
+export function getFilterReason(
 	item: CacheItemForEval,
 	rule: LibraryCleanupRule,
 	instanceService: string,

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -285,6 +285,35 @@ describe("parity — composites", () => {
 		expect(legacy).not.toBeNull(); // age sibling still matches on both paths
 	});
 
+	it("REVIEW SHAPE — leaf ruleType + operator+conditions: conditions decide, not leaf params", () => {
+		// The empirical probe from the cutover review: ruleType "age"
+		// (which WOULD match) carrying a non-matching size condition.
+		// Legacy evaluates the conditions → null. The engine path must
+		// agree — keying composite on ruleType instead of operator+
+		// conditions made it evaluate the leaf and DELETE.
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "age",
+				parameters: JSON.stringify({ operator: "older_than", days: 30 }), // matches
+				operator: "AND",
+				conditions: JSON.stringify([noMatchCond]), // does not match
+			}),
+		);
+		expect(legacy).toBeNull(); // conditions decide — item is KEPT
+	});
+
+	it("REVIEW SHAPE — leaf ruleType + matching conditions: both paths match via conditions", () => {
+		const { legacy } = assertParity(
+			makeRule({
+				ruleType: "age",
+				parameters: JSON.stringify({ operator: "older_than", days: 99999 }), // would NOT match
+				operator: "OR",
+				conditions: JSON.stringify([sizeCond]), // matches
+			}),
+		);
+		expect(legacy).not.toBeNull(); // conditions decide — matched via size
+	});
+
 	it("legacy quirk — empty composite conditions no-match (NOT vacuous true)", () => {
 		assertParity(makeRule({ ruleType: "composite", operator: "AND", conditions: "[]" }));
 	});

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -320,3 +320,185 @@ describe("parity — pre-filters and rule state", () => {
 		expect(legacy?.action).toBe("unmonitor");
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Loop wrappers — evaluateItemAgainstRules / explainItemAgainstRules
+// ---------------------------------------------------------------------------
+
+import {
+	evaluateItemAgainstRules,
+	explainItemAgainstRules,
+} from "../../library-cleanup/rule-evaluators.js";
+import {
+	evaluateItemAgainstRulesViaEngine,
+	explainItemAgainstRulesViaEngine,
+} from "../cleanup-adapter.js";
+
+describe("parity — evaluateItemAgainstRules (two-phase loop)", () => {
+	const matchingRule = (overrides: Partial<LibraryCleanupRule> = {}) =>
+		makeRule({ id: "m1", name: "Matcher", ...overrides });
+	const retentionRule = makeRule({
+		id: "ret1",
+		name: "Protector",
+		retentionMode: true,
+		ruleType: "size",
+		parameters: JSON.stringify({ operator: "greater_than", sizeGb: 2 }),
+	});
+
+	function assertLoopParity(
+		rules: LibraryCleanupRule[],
+		item: CacheItemForEval = makeCacheItem(),
+		failedSources?: Set<"seerr" | "plex" | "jellyfin" | null>,
+	) {
+		const ctx = baseCtx();
+		const legacy = evaluateItemAgainstRules(item, rules, "RADARR", ctx, failedSources);
+		const engine = evaluateItemAgainstRulesViaEngine(item, rules, "RADARR", ctx, failedSources);
+		expect(engine).toEqual(legacy);
+		return legacy;
+	}
+
+	it("retention rule protects the item (both null) even when a cleanup rule matches", () => {
+		const result = assertLoopParity([retentionRule, matchingRule()]);
+		expect(result).toBeNull();
+	});
+
+	it("priority order — first cleanup match wins in caller-provided order", () => {
+		const result = assertLoopParity([
+			matchingRule({ id: "m1", name: "First" }),
+			matchingRule({ id: "m2", name: "Second" }),
+		]);
+		expect(result?.ruleId).toBe("m1");
+	});
+
+	it("failed-source skip — plex-dependent rule skipped when plex prefetch failed", () => {
+		const plexRule = makeRule({
+			id: "p1",
+			ruleType: "plex_last_watched",
+			parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+		});
+		const result = assertLoopParity([plexRule], makeCacheItem(), new Set(["plex"]));
+		expect(result).toBeNull();
+	});
+});
+
+describe("parity — explainItemAgainstRules", () => {
+	it("identical per-rule breakdown: disabled / filtered / matched rows", () => {
+		const rules = [
+			makeRule({ id: "r1", name: "Disabled", enabled: false }),
+			makeRule({ id: "r2", name: "Filtered", serviceFilter: JSON.stringify(["SONARR"]) }),
+			makeRule({ id: "r3", name: "Match" }),
+			makeRule({
+				id: "r4",
+				name: "NoMatch",
+				parameters: JSON.stringify({ operator: "older_than", days: 9999 }),
+			}),
+		];
+		const item = makeCacheItem();
+		const ctx = baseCtx();
+		const legacy = explainItemAgainstRules(item, rules, "RADARR", ctx);
+		const engine = explainItemAgainstRulesViaEngine(item, rules, "RADARR", ctx);
+		expect(engine).toEqual(legacy);
+		expect(legacy.map((r) => r.filteredBy)).toEqual(["disabled", "service_filter", null, null]);
+		expect(legacy.map((r) => r.matched)).toEqual([false, false, true, false]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Auto-tag adapter parity
+// ---------------------------------------------------------------------------
+
+import { type AutoTagRuleInput, evaluateAgainstRule } from "../../auto-tag/execute-rule.js";
+import { autoTagRuleMatchesViaEngine } from "../auto-tag-adapter.js";
+
+function makeAutoTagRule(overrides: Partial<AutoTagRuleInput> = {}): AutoTagRuleInput {
+	return {
+		id: "at-1",
+		userId: "user-1",
+		name: "Auto-tag parity",
+		ruleType: "age",
+		parameters: { operator: "older_than", days: 30 },
+		operator: null,
+		conditions: null,
+		serviceFilter: null,
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		tagName: "stale",
+		...overrides,
+	};
+}
+
+describe("parity — auto-tag adapter (boolean semantics)", () => {
+	function assertAutoTagParity(
+		rule: AutoTagRuleInput,
+		item: CacheItemForEval = makeCacheItem(),
+		ctx: EvalContext = baseCtx(),
+	) {
+		const legacy = evaluateAgainstRule(item, rule, "RADARR", ctx);
+		const engine = autoTagRuleMatchesViaEngine(item, rule, "RADARR", ctx);
+		expect(engine).toBe(legacy);
+		return legacy;
+	}
+
+	it("single rule match", () => {
+		expect(assertAutoTagParity(makeAutoTagRule())).toBe(true);
+	});
+
+	it("single rule no-match", () => {
+		expect(
+			assertAutoTagParity(
+				makeAutoTagRule({ parameters: { operator: "older_than", days: 9999 } }),
+			),
+		).toBe(false);
+	});
+
+	it("AND composite — all must match", () => {
+		expect(
+			assertAutoTagParity(
+				makeAutoTagRule({
+					ruleType: "composite",
+					operator: "AND",
+					conditions: [
+						{ ruleType: "age", parameters: { operator: "older_than", days: 30 } },
+						{ ruleType: "size", parameters: { operator: "greater_than", sizeGb: 2 } },
+					],
+				}),
+			),
+		).toBe(true);
+	});
+
+	it("OR composite — one suffices", () => {
+		expect(
+			assertAutoTagParity(
+				makeAutoTagRule({
+					ruleType: "composite",
+					operator: "OR",
+					conditions: [
+						{ ruleType: "size", parameters: { operator: "greater_than", sizeGb: 500 } },
+						{ ruleType: "age", parameters: { operator: "older_than", days: 30 } },
+					],
+				}),
+			),
+		).toBe(true);
+	});
+
+	it("legacy quirk — composite with EMPTY conditions falls through to single path (no-match)", () => {
+		expect(
+			assertAutoTagParity(
+				makeAutoTagRule({ ruleType: "composite", operator: "AND", conditions: [] }),
+			),
+		).toBe(false);
+	});
+
+	it("retired kind no-matches on both paths", () => {
+		expect(
+			assertAutoTagParity(
+				makeAutoTagRule({
+					ruleType: "tautulli_watched_by",
+					parameters: { operator: "includes_any", userNames: ["x"] },
+				}),
+			),
+		).toBe(false);
+	});
+});

--- a/apps/api/src/lib/rules/__tests__/v0-mappers.test.ts
+++ b/apps/api/src/lib/rules/__tests__/v0-mappers.test.ts
@@ -133,6 +133,21 @@ describe("mapCriteriaV0ToDocument — composites", () => {
 		expect(doc.root).toEqual({ all: [] });
 	});
 
+	it("leaf ruleType carrying operator+conditions maps as COMPOSITE — conditions win (review shape)", () => {
+		// Legacy evaluateRule keys the composite path on operator+conditions,
+		// ignoring the leaf ruleType/parameters entirely. The mapper must
+		// match, or stored pre-guard rows change meaning (Critical finding).
+		const doc = mapCriteriaV0ToDocument(
+			row({
+				ruleType: "age", // leaf — ignored by legacy when conditions present
+				parameters: JSON.stringify({ operator: "older_than", days: 1 }),
+				operator: "AND",
+				conditions: JSON.stringify([sizeCond]),
+			}),
+		);
+		expect(doc.root).toEqual({ all: [{ kind: "size", params: sizeCond.parameters }] });
+	});
+
 	it("throws on invalid operator", () => {
 		expect(() =>
 			mapCriteriaV0ToDocument(row({ ruleType: "composite", operator: "XOR", conditions: "[]" })),

--- a/apps/api/src/lib/rules/auto-tag-adapter.ts
+++ b/apps/api/src/lib/rules/auto-tag-adapter.ts
@@ -1,0 +1,56 @@
+/**
+ * Auto-tag → engine adapter (unified-rule-grammar §4 step 4 — "shared
+ * evaluators make this nearly one step").
+ *
+ * Reproduces `evaluateAgainstRule` (execute-rule.ts) on the engine:
+ * boolean result, pre-parsed v0 input (auto-tag callers parse JSON
+ * before evaluation), no pre-filter pass here (the executor applies
+ * excludeTags/excludeTitles itself before calling).
+ *
+ * Legacy quirks reproduced deliberately (parity-tested):
+ *   - a composite with NULL or EMPTY conditions falls through to the
+ *     single-condition path, where ruleType "composite" hits the
+ *     dispatch default → no-match (different mechanism from cleanup's
+ *     explicit guard, same outcome)
+ *   - any non-"AND" operator gets OR semantics (the legacy
+ *     `if (operator === "AND") … else OR` shape; the input type
+ *     restricts to "AND" | "OR" but the runtime contract is pinned)
+ */
+
+import type { RuleNode } from "@arr/shared";
+import type { AutoTagRuleInput } from "../auto-tag/execute-rule.js";
+import { evaluateSingleCondition } from "../library-cleanup/rule-evaluators.js";
+import type { CacheItemForEval, EvalContext } from "../library-cleanup/types.js";
+import { evaluateDocument, type PredicateEvaluator } from "./engine.js";
+
+/**
+ * Engine-backed equivalent of auto-tag's `evaluateAgainstRule`.
+ * Identical inputs, identical boolean — proven by the parity suite.
+ */
+export function autoTagRuleMatchesViaEngine(
+	item: CacheItemForEval,
+	rule: AutoTagRuleInput,
+	instanceService: string,
+	ctx: EvalContext,
+): boolean {
+	const plexLibFilter = rule.plexLibraryFilter ?? null;
+
+	let root: RuleNode;
+	if (rule.operator && rule.conditions && rule.conditions.length > 0) {
+		const children: RuleNode[] = rule.conditions.map((c) => ({
+			kind: c.ruleType,
+			params: c.parameters,
+		}));
+		root = rule.operator === "AND" ? { all: children } : { any: children };
+	} else {
+		// Includes the empty-composite fall-through: kind "composite" hits
+		// the dispatch default → no-match, matching legacy behavior.
+		root = { kind: rule.ruleType, params: rule.parameters };
+	}
+
+	const evalPredicate: PredicateEvaluator = (predicate) =>
+		evaluateSingleCondition(item, predicate.kind, predicate.params, ctx, plexLibFilter);
+
+	void instanceService; // reserved for future per-service rule-routing (mirrors legacy)
+	return evaluateDocument({ version: 1, root }, evalPredicate).matched;
+}

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -24,13 +24,15 @@
  * `evaluateRuleViaEngine` once the differential parity suite is green.
  */
 
-import type { RuleDocument } from "@arr/shared";
+import type { DataSourceDependency, RuleDocument } from "@arr/shared";
 import {
 	evaluateSingleCondition,
+	getFilterReason,
 	passesInstanceFilter,
 	passesServiceFilter,
 	passesTagExclusion,
 	passesTitleExclusion,
+	shouldSkipForFailedSource,
 } from "../library-cleanup/rule-evaluators.js";
 import type {
 	CacheItemForEval,
@@ -89,4 +91,105 @@ export function evaluateRuleViaEngine(
 	return result.matched
 		? { ruleId: rule.id, ruleName: rule.name, reason: result.reason, action }
 		: null;
+}
+
+/**
+ * Engine-backed equivalent of `evaluateItemAgainstRules` — the same
+ * two-phase loop (retention rules protect first, then cleanup rules
+ * first-match-wins by caller-provided order) and the same
+ * failed-source skip (the C1 safety fix), delegating per-rule
+ * evaluation to the engine.
+ */
+export function evaluateItemAgainstRulesViaEngine(
+	item: CacheItemForEval,
+	rules: LibraryCleanupRule[],
+	instanceService: string,
+	ctx: EvalContext,
+	failedSources?: Set<DataSourceDependency>,
+): RuleMatch | null {
+	// Phase 1: retention rules — any match protects the item
+	for (const rule of rules) {
+		if (!rule.retentionMode) continue;
+		if (shouldSkipForFailedSource(rule, failedSources)) continue;
+		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
+		if (match) return null;
+	}
+
+	// Phase 2: cleanup rules — first match wins
+	for (const rule of rules) {
+		if (rule.retentionMode) continue;
+		if (shouldSkipForFailedSource(rule, failedSources)) continue;
+		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
+		if (match) return match;
+	}
+	return null;
+}
+
+/** Per-rule breakdown row for the explain endpoint. */
+export interface ExplainRuleResult {
+	ruleId: string;
+	ruleName: string;
+	matched: boolean;
+	reason: string | null;
+	filteredBy:
+		| "service_filter"
+		| "instance_filter"
+		| "tag_exclusion"
+		| "title_exclusion"
+		| "disabled"
+		| null;
+	retentionMode: boolean;
+}
+
+/**
+ * Engine-backed equivalent of `explainItemAgainstRules` — identical
+ * per-rule breakdown (disabled / which pre-filter blocked / match with
+ * reason), delegating evaluation to the engine.
+ */
+export function explainItemAgainstRulesViaEngine(
+	item: CacheItemForEval,
+	rules: LibraryCleanupRule[],
+	instanceService: string,
+	ctx: EvalContext,
+): ExplainRuleResult[] {
+	const results: ExplainRuleResult[] = [];
+
+	for (const rule of rules) {
+		if (!rule.enabled) {
+			results.push({
+				ruleId: rule.id,
+				ruleName: rule.name,
+				matched: false,
+				reason: null,
+				filteredBy: "disabled",
+				retentionMode: rule.retentionMode,
+			});
+			continue;
+		}
+
+		const filteredBy = getFilterReason(item, rule, instanceService);
+		if (filteredBy) {
+			results.push({
+				ruleId: rule.id,
+				ruleName: rule.name,
+				matched: false,
+				reason: null,
+				filteredBy,
+				retentionMode: rule.retentionMode,
+			});
+			continue;
+		}
+
+		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
+		results.push({
+			ruleId: rule.id,
+			ruleName: rule.name,
+			matched: match !== null,
+			reason: match?.reason ?? null,
+			filteredBy: null,
+			retentionMode: rule.retentionMode,
+		});
+	}
+
+	return results;
 }

--- a/apps/api/src/lib/rules/v0-mappers.ts
+++ b/apps/api/src/lib/rules/v0-mappers.ts
@@ -105,7 +105,16 @@ function parseJsonObject(raw: string, what: string): Record<string, unknown> {
  * crashed boot or a 500'd list.
  */
 export function mapCriteriaV0ToDocument(row: CriteriaV0Row): RuleDocument {
-	if (row.ruleType !== "composite") {
+	// Composite-mode discriminator MUST match legacy `evaluateRule`
+	// (`rule.operator && rule.conditions`), NOT `ruleType === "composite"`.
+	// A stored row with a leaf ruleType plus operator+conditions evaluates
+	// its CONDITIONS on the legacy path (the leaf params are ignored);
+	// keying on ruleType here made the engine evaluate the leaf params
+	// instead — a silent divergence that could delete media the legacy
+	// path keeps (review finding, 2026-06-10). Write-time validation now
+	// rejects the mixed shape, but stored rows predating that guard must
+	// keep their legacy meaning forever.
+	if (!(row.operator && row.conditions)) {
 		const doc: RuleDocument = {
 			version: 1,
 			root: {

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -16,7 +16,12 @@ import type {
 	Condition,
 	RuleType,
 } from "@arr/shared";
-import { createAutoTagRuleSchema, ruleParamSchemaMap, updateAutoTagRuleSchema } from "@arr/shared";
+import {
+	createAutoTagRuleSchema,
+	isKindLegalForContext,
+	ruleParamSchemaMap,
+	updateAutoTagRuleSchema,
+} from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { executeAutoTagRule } from "../lib/auto-tag/execute-rule.js";
@@ -123,6 +128,10 @@ function validateRuleParameters(
 		for (let i = 0; i < conditions.length; i++) {
 			const cond = conditions[i];
 			if (!cond) continue;
+			// Tier-1 strict kind legality (unified-rule-grammar §2.2)
+			if (!isKindLegalForContext("auto-tag", cond.ruleType)) {
+				return `Unknown rule type for condition[${i}]: "${cond.ruleType}"`;
+			}
 			const schema = ruleParamSchemaMap[cond.ruleType];
 			if (schema) {
 				const result = schema.safeParse(cond.parameters);
@@ -137,6 +146,9 @@ function validateRuleParameters(
 		return null;
 	}
 
+	if (!isKindLegalForContext("auto-tag", ruleType)) {
+		return `Unknown rule type "${ruleType}"`;
+	}
 	const schema = ruleParamSchemaMap[ruleType];
 	if (schema) {
 		const result = schema.safeParse(parameters);

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -8,6 +8,7 @@ import {
 	bulkApprovalSchema,
 	cleanupExplainRequestSchema,
 	createCleanupRuleSchema,
+	isKindLegalForContext,
 	reorderRulesSchema,
 	ruleParamSchemaMap,
 	updateCleanupConfigSchema,
@@ -20,7 +21,7 @@ import {
 	executeCleanupPreview,
 	executeCleanupRun,
 } from "../lib/library-cleanup/cleanup-executor.js";
-import { explainItemAgainstRules } from "../lib/library-cleanup/rule-evaluators.js";
+import { explainItemAgainstRulesViaEngine } from "../lib/rules/cleanup-adapter.js";
 import type { CacheItemForEval } from "../lib/library-cleanup/types.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { safeJsonParse as utilSafeJsonParse } from "../lib/utils/json.js";
@@ -1059,7 +1060,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			config.rules,
 		);
 
-		const results = explainItemAgainstRules(
+		const results = explainItemAgainstRulesViaEngine(
 			cacheItem as unknown as CacheItemForEval,
 			config.rules,
 			instance.service,
@@ -1223,6 +1224,13 @@ function validateRuleParameters(
 	if (ruleType === "composite" && conditions) {
 		for (let i = 0; i < conditions.length; i++) {
 			const cond = conditions[i]!;
+			// Tier-1 strict kind legality (unified-rule-grammar §2.2): new
+			// writes cannot author retired/unknown kinds. Stored legacy rows
+			// are unaffected — this runs only when the payload carries
+			// ruleType/parameters/conditions.
+			if (!isKindLegalForContext("library-cleanup", cond.ruleType)) {
+				return `Unknown rule type for condition[${i}]: "${cond.ruleType}"`;
+			}
 			const schema = ruleParamSchemaMap[cond.ruleType];
 			if (schema) {
 				const result = schema.safeParse(cond.parameters);
@@ -1237,7 +1245,11 @@ function validateRuleParameters(
 		return null;
 	}
 
-	// For single rules, validate top-level parameters
+	// For single rules, validate top-level parameters (tier-1 strict
+	// kind legality — see composite branch note)
+	if (!isKindLegalForContext("library-cleanup", ruleType)) {
+		return `Unknown rule type "${ruleType}"`;
+	}
 	const schema = ruleParamSchemaMap[ruleType];
 	if (schema) {
 		const result = schema.safeParse(parameters);

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -1220,6 +1220,19 @@ function validateRuleParameters(
 	parameters: Record<string, unknown>,
 	conditions: Array<{ ruleType: string; parameters: Record<string, unknown> }> | null,
 ): string | null {
+	// Reject mode-mismatch: a leaf ruleType carrying operator+conditions
+	// (or ruleType "composite" without them). The evaluator treats any rule
+	// with operator+conditions as composite regardless of ruleType, so a
+	// mixed shape would validate one thing and evaluate another (the same
+	// guard auto-tag.ts has carried; ported per review finding).
+	const compositeByShape = conditions != null && conditions.length > 0;
+	const compositeByRuleType = ruleType === "composite";
+	if (compositeByShape !== compositeByRuleType) {
+		return compositeByShape
+			? 'Composite rules must use ruleType="composite" (got a leaf rule type plus conditions — pick one mode)'
+			: 'Rule type "composite" requires operator + conditions';
+	}
+
 	// For composite rules, validate each condition's parameters
 	if (ruleType === "composite" && conditions) {
 		for (let i = 0; i < conditions.length; i++) {


### PR DESCRIPTION
## Summary

The strangler swap (`docs/design/unified-rule-grammar.md` §4 step 4): library-cleanup and auto-tag evaluation now route through the unified engine, behind the green 35-fixture differential parity gate.

### Call sites cut over (3)
- **cleanup-executor** → `evaluateItemAgainstRulesViaEngine` (same two-phase retention/priority loop + failed-source skip)
- **explain endpoint** → `explainItemAgainstRulesViaEngine` (identical per-rule breakdown)
- **auto-tag execute-rule** → `autoTagRuleMatchesViaEngine` (new adapter: boolean semantics, pre-parsed v0 input, empty-composite fall-through quirk reproduced)

### Tier-1 strict kind legality (§2.2)
Both rule routes now **reject unknown/retired kinds at write time** — upgrading the silent `if (schema)` pass-through. Stored legacy rows are unaffected: validation runs only when the payload carries `ruleType`/`parameters`/`conditions`, so renaming or toggling a legacy rule still works.

### Pre-merge review caught a Critical (fixed in `2f97a0`-series commit)
A code-review agent ran an empirical probe and found the v0 mapper keyed composite-vs-leaf on `ruleType === "composite"` while legacy keys on `operator && conditions`. A leaf-ruleType row carrying operator+conditions (API-reachable, never UI-written) would evaluate its **leaf params** on the engine path but its **conditions** on the legacy path — a silent false-match in the surface that deletes media. Fixed three ways:
1. Mapper discriminator aligned with legacy — stored pre-guard rows keep their meaning forever
2. Cleanup route gains the `compositeByShape !== compositeByRuleType` write rejection auto-tag already had
3. Parity suite pins the probe scenario both directions + a mapper conditions-win fixture

Legacy functions remain exported and parity-pinned — they're the reference implementation until the composer arc retires them.

## Validation
84 lib/rules tests (35 parity), 2091 API total, turbo typecheck + lint green. Review pass: code-reviewer agent (Critical found+fixed; loop wrappers, auto-tag discriminator, reason semantics, and ESM cycle-safety all verified clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)