### PR TITLE
chore: 3.0.0-alpha.1 prep — version, changelog, release-safety guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,11 @@ on:
       - "LICENSE"
       - ".gitignore"
   pull_request:
+    # No paths-ignore here (push keeps its filter): a required status
+    # check that never reports blocks docs-only PRs forever ("Expected —
+    # waiting"). Running CI on docs PRs costs a few runner minutes;
+    # admin-merging around a deadlocked required check costs more.
     branches: [main, next, "release/**"]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".vscode/**"
-      - "LICENSE"
-      - ".gitignore"
 
 # Cancel in-progress runs when a new push arrives (saves runner minutes)
 concurrency:

--- a/.github/workflows/docker-combined.yml
+++ b/.github/workflows/docker-combined.yml
@@ -3,7 +3,13 @@ name: Build and Push Release Docker Image
 on:
   push:
     tags:
+      # Stable release tags only. Prerelease tags (v3.0.0-alpha.1 etc.)
+      # are cut from `next` and must never publish :latest — the
+      # validate-tag ancestry guard below already blocks them, but
+      # excluding them here avoids a red failed run on every prerelease
+      # tag. Preview images ship via docker-next.yml (:next channel).
       - 'v*'
+      - '!v*-*'
   workflow_dispatch:
 
 # Cancel in-progress runs when a new run is triggered

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -2,13 +2,8 @@ name: Docker Smoke Test
 
 on:
   pull_request:
+    # No paths-ignore (see ci.yml note): required checks must always report.
     branches: [main, next]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - ".vscode/**"
-      - "LICENSE"
-      - ".gitignore"
   push:
     branches: [main, next]
     paths-ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0-alpha.1] - 2026-06-10 — Bucket A: the breaking-changes bundle
+
+First 3.0 preview. All breaking changes land together (charter §3) so
+upgraders absorb the disruption once. Ships on the `:next` Docker
+channel; this tag marks the Bucket-A-complete snapshot.
+
+### BREAKING — Tautulli removed (ADR-0007)
+
+- All Tautulli routes, schedulers, settings, and rule kinds are gone.
+  Plex statistics now come directly from session snapshots; Tracearr
+  arrives later in the 3.0 cycle as the analytics successor.
+- **Migration is automatic and consent-gated**: on first boot a
+  blocking dialog discloses exactly what changes (lingering instances,
+  affected cleanup/auto-tag rules) and deletes Tautulli data only when
+  you click through. Rules that depended on Tautulli are disabled —
+  never deleted — with originals backed up to
+  `<config>/rules-pre-3.0/`.
+- **Rollback**: the 2.21.0 image runs against the same database.
+  Re-add your Tautulli instance manually; re-enable any disabled rules.
+
+### Changed
+
+- **Unified rule engine (ADR-0006)**: library-cleanup, auto-tag, and
+  notification rules all evaluate through one grammar-based engine.
+  Behavior-preserving by 48-fixture differential parity against the
+  legacy evaluators; stored rules are NOT rewritten (parse-time
+  versioning — your rows convert in memory and only write the new
+  format when you edit them).
+- Rule writes now reject unknown/retired condition kinds with a clear
+  error instead of silently accepting them.
+- Route-manifest tiers reshuffled per ADR-0005 (Auto-Tagger, Label
+  Sync, Hunting, Queue Cleaner, TRaSH Guides promoted; qui and
+  Cross-Seed `experimental` → `stable`).
+- Internal: `routes/plex/lib/` → `lib/media-stats/` (the helpers were
+  never Plex-only); queue-cleaner dev scripts removed; remaining
+  inline `Body:` typings migrated to `validateRequest`.
+
+### Known issues
+
+- Settings → Notifications → Rules can log a "Maximum update depth
+  exceeded" warning on mount (pre-existing in 2.x, not a regression).
+
 ## [2.21.0] - 2026-06-09 — Media-only Storage & Auth Resilience
 
 The storage rollup now tells the truth about *media* space, and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,4 +180,4 @@ For deep dives, see these files (create as needed):
 
 ---
 
-**Version:** 2.21.0 | **Node:** 22+ | **pnpm:** 10+
+**Version:** 3.0.0-alpha.1 | **Node:** 22+ | **pnpm:** 10+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.21.0",
+	"version": "3.0.0-alpha.1",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
Pre-tag mechanics for `v3.0.0-alpha.1` (Bucket A complete, charter §8.2). Ultrathink findings driving each change:

1. **`docker-combined` negative tag pattern (`!v*-*`)** — the validate-tag ancestry guard already blocks prerelease tags from publishing `:latest`, but the failed run would leave a red ✗ on every prerelease tag. Now they don't trigger it at all. Preview images keep shipping via `:next`.
2. **`paths-ignore` removed from PR triggers** (ci + docker-smoke; push keeps filters) — required checks on `next` would otherwise deadlock every docs-only PR ("Expected — waiting" forever), the exact blocker documented on `main`, on a cycle full of ADR/memo PRs. A docs PR now costs ~5 runner-minutes instead.
3. **Version self-identification** — `package.json`/`CLAUDE.md` → `3.0.0-alpha.1`; `/health` and alpha bug reports stop claiming 2.21.0.
4. **CHANGELOG** — alpha entry with the consent-gated migration + rollback story, parity-preserving engine note, known issues. README/DOCKERHUB/wiki deliberately stay on the 2.x stable story.

After merge: required checks on `next` (mirroring main's `Lint, Type Check & Test`), annotated `v3.0.0-alpha.1` tag, GitHub prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)