### PR TITLE
refactor(web): centralized query-keys sweep (Bucket B1)

### DIFF
--- a/apps/web/src/features/hunting/hooks/useManualHunt.ts
+++ b/apps/web/src/features/hunting/hooks/useManualHunt.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { huntingKeys } from "../../../lib/query-keys";
 import { ApiError, apiRequest } from "../../../lib/api-client/base";
 
 interface TriggerHuntResponse {
@@ -39,7 +40,7 @@ export function useManualHunt() {
 		mutationFn: ({ instanceId, type }: { instanceId: string; type: "missing" | "upgrade" }) =>
 			triggerHunt(instanceId, type),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["hunting"] });
+			void queryClient.invalidateQueries({ queryKey: huntingKeys.all });
 		},
 	});
 

--- a/apps/web/src/features/settings/components/password-section.tsx
+++ b/apps/web/src/features/settings/components/password-section.tsx
@@ -2,6 +2,7 @@
 
 import type { CurrentUser } from "@arr/shared";
 import { useQuery } from "@tanstack/react-query";
+import { authKeys } from "../../../lib/query-keys";
 import { AlertTriangle, Check, Key, Loader2, Lock, Shield, Trash2, X } from "lucide-react";
 import { useState } from "react";
 import { PremiumSection } from "../../../components/layout";
@@ -56,7 +57,7 @@ export const PasswordSection = ({ currentUser }: PasswordSectionProps) => {
 	const { data: setupData } = useSetupRequired();
 	const passwordPolicy = setupData?.passwordPolicy ?? "strict";
 	const { data: passkeys = [] } = useQuery({
-		queryKey: ["passkey-credentials"],
+		queryKey: authKeys.passkeyCredentials,
 		queryFn: getPasskeyCredentials,
 	});
 

--- a/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useState, useEffect, useMemo } from "react";
+import { trashGuidesKeys } from "../../../lib/query-keys";
 import { useQueryClient } from "@tanstack/react-query";
 import {
 	LegacyDialog,
@@ -676,7 +677,7 @@ export const BulkDeploymentModal = ({
 					onSaved={() => {
 						setEditingQualityOverride(null);
 						queryClient.invalidateQueries({
-							queryKey: ["trash-guides", "deployment", "preview"],
+							queryKey: trashGuidesKeys.deployment.previewAll,
 						});
 					}}
 				/>

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -13,6 +13,7 @@
 
 import type { CustomFormatScoreEntry } from "@arr/shared";
 import { useQueryClient } from "@tanstack/react-query";
+import { bulkScoreKeys } from "../../../lib/query-keys";
 import {
 	AlertCircle,
 	CheckSquare,
@@ -281,7 +282,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 		if (confirm("Are you sure you want to discard all unsaved changes?")) {
 			setModifiedScores(new Map());
-			void queryClient.invalidateQueries({ queryKey: ["bulk-scores"] });
+			void queryClient.invalidateQueries({ queryKey: bulkScoreKeys.all });
 		}
 	};
 

--- a/apps/web/src/features/trash-guides/components/template-list.tsx
+++ b/apps/web/src/features/trash-guides/components/template-list.tsx
@@ -19,11 +19,11 @@ import { useUnlinkTemplateFromInstance } from "../../../hooks/api/useDeploymentP
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { useExecuteSync } from "../../../hooks/api/useSync";
 import {
-	TEMPLATES_QUERY_KEY,
 	useDeleteTemplate,
 	useDuplicateTemplate,
 	useTemplates,
 } from "../../../hooks/api/useTemplates";
+import { TEMPLATES_QUERY_KEY } from "../../../lib/query-keys";
 import { useTemplateUpdates } from "../../../hooks/api/useTemplateUpdates";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -2,6 +2,7 @@
 
 import type { CustomQualityConfig, NamingSelectedPresets, TrashTemplate } from "@arr/shared";
 import { useQuery } from "@tanstack/react-query";
+import { trashGuidesKeys } from "../../../../lib/query-keys";
 import {
 	CheckCircle,
 	ChevronLeft,
@@ -233,7 +234,7 @@ export const TemplateCreation = ({
 	// Fetch CF Groups from cache for edit mode categorization
 	// This helps determine which CFs belong to which groups even when template data is incomplete
 	const { data: cfGroupsCache } = useQuery({
-		queryKey: ["cf-groups-cache", serviceType],
+		queryKey: trashGuidesKeys.wizard.cfGroupsCache(serviceType),
 		queryFn: async () => {
 			// API returns array directly, not wrapped in { entries: [...] }
 			const entries = await apiRequest<CacheEntry[]>(
@@ -251,7 +252,7 @@ export const TemplateCreation = ({
 	// The template stores sourceQualityProfileTrashId which we can use to look up the profile
 	const sourceProfileTrashId = editingTemplate?.sourceQualityProfileTrashId;
 	const { data: sourceProfileData } = useQuery({
-		queryKey: ["source-profile-data", serviceType, sourceProfileTrashId],
+		queryKey: trashGuidesKeys.wizard.sourceProfileData(serviceType, sourceProfileTrashId),
 		queryFn: async () => {
 			return await apiRequest<SourceProfileResponse>(
 				`/api/trash-guides/quality-profiles/${serviceType}/${sourceProfileTrashId}`,

--- a/apps/web/src/hooks/api/useBulkScores.ts
+++ b/apps/web/src/hooks/api/useBulkScores.ts
@@ -2,6 +2,7 @@
 
 import type { BulkScoreFilters, CustomFormatScoreEntry } from "@arr/shared";
 import { useQuery } from "@tanstack/react-query";
+import { bulkScoreKeys } from "../../lib/query-keys";
 
 interface BulkScoresResponse {
 	success: boolean;
@@ -46,7 +47,7 @@ async function fetchBulkScores(filters: BulkScoreFilters): Promise<BulkScoresRes
  */
 export function useBulkScores(filters: UseBulkScoresFilters) {
 	return useQuery<BulkScoresResponse>({
-		queryKey: ["bulk-scores", filters],
+		queryKey: bulkScoreKeys.list(filters),
 		queryFn: () =>
 			fetchBulkScores({
 				instanceId: filters.instanceId,

--- a/apps/web/src/hooks/api/useDeploymentPreview.ts
+++ b/apps/web/src/hooks/api/useDeploymentPreview.ts
@@ -62,7 +62,7 @@ export function useExecuteDeployment() {
 				queryKey: TEMPLATES_QUERY_KEY,
 			});
 			queryClient.invalidateQueries({
-				queryKey: ["template-stats"] as const,
+				queryKey: trashGuidesKeys.templates.statsAll,
 			});
 		},
 	});
@@ -88,7 +88,7 @@ export function useExecuteBulkDeployment() {
 				queryKey: TEMPLATES_QUERY_KEY,
 			});
 			queryClient.invalidateQueries({
-				queryKey: ["template-stats"] as const,
+				queryKey: trashGuidesKeys.templates.statsAll,
 			});
 		},
 	});

--- a/apps/web/src/hooks/api/useDiskWasteInsights.ts
+++ b/apps/web/src/hooks/api/useDiskWasteInsights.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { libraryKeys } from "../../lib/query-keys";
 import { apiRequest } from "../../lib/api-client/base";
 
 export interface DiskWasteItem {
@@ -44,7 +45,7 @@ export function useDiskWasteInsights(params?: {
 	enabled?: boolean;
 }) {
 	return useQuery<DiskWasteResponse>({
-		queryKey: ["library", "insights", "disk-waste", params],
+		queryKey: libraryKeys.insights.diskWaste(params),
 		queryFn: () =>
 			fetchDiskWaste({
 				minSizeGb: params?.minSizeGb,

--- a/apps/web/src/hooks/api/useInstanceOverrides.ts
+++ b/apps/web/src/hooks/api/useInstanceOverrides.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { trashGuidesKeys } from "../../lib/query-keys";
 import {
 	deleteInstanceOverrides,
 	type GetInstanceOverridesResponse,
@@ -12,7 +13,7 @@ import {
  */
 export function useInstanceOverrides(templateId: string | null, instanceId: string | null) {
 	return useQuery<GetInstanceOverridesResponse>({
-		queryKey: ["trash-guides", "instance-overrides", templateId, instanceId],
+		queryKey: trashGuidesKeys.instanceOverrides(templateId, instanceId),
 		queryFn: () => getInstanceOverrides(templateId!, instanceId!),
 		enabled: !!templateId && !!instanceId,
 		staleTime: 5 * 60 * 1000, // 5 minutes

--- a/apps/web/src/hooks/api/useLibrary.ts
+++ b/apps/web/src/hooks/api/useLibrary.ts
@@ -52,7 +52,7 @@ import {
 	updateLibrarySyncSettings,
 } from "../../lib/api-client/library";
 import { POLLING_BACKGROUND, POLLING_STANDARD } from "../../lib/polling-intervals";
-import { QUEUE_QUERY_KEY } from "../../lib/query-keys";
+import { discoverKeys, libraryKeys, QUEUE_QUERY_KEY } from "../../lib/query-keys";
 
 // ============================================================================
 // Library Query Hook (with pagination, search, filters)
@@ -66,7 +66,7 @@ export const useLibraryQuery = (options: UseLibraryQueryOptions = {}) => {
 	const { enabled, ...queryParams } = options;
 
 	return useQuery<PaginatedLibraryResponse>({
-		queryKey: ["library", queryParams],
+		queryKey: libraryKeys.list(queryParams),
 		queryFn: () => fetchLibrary(queryParams),
 		enabled: enabled ?? true,
 		staleTime: 60 * 1000,
@@ -81,7 +81,7 @@ export const useLibraryQuery = (options: UseLibraryQueryOptions = {}) => {
 
 export const useLibrarySyncStatus = (options: { enabled?: boolean } = {}) =>
 	useQuery<LibrarySyncStatusResponse>({
-		queryKey: ["library", "sync", "status"],
+		queryKey: libraryKeys.syncStatus,
 		queryFn: fetchLibrarySyncStatus,
 		enabled: options.enabled ?? true,
 		staleTime: 30 * 1000,
@@ -93,10 +93,10 @@ export const useTriggerLibrarySyncMutation = () => {
 	return useMutation<{ success: boolean; message: string; instanceId: string }, unknown, string>({
 		mutationFn: triggerLibrarySync,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library", "sync", "status"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.syncStatus });
 			// Invalidate library queries after a short delay to allow sync to start
 			setTimeout(() => {
-				void queryClient.invalidateQueries({ queryKey: ["library"] });
+				void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			}, 2000);
 		},
 	});
@@ -111,7 +111,7 @@ export const useUpdateLibrarySyncSettingsMutation = () => {
 	>({
 		mutationFn: ({ instanceId, settings }) => updateLibrarySyncSettings(instanceId, settings),
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library", "sync", "status"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.syncStatus });
 		},
 	});
 };
@@ -125,8 +125,8 @@ export const useLibraryMonitorMutation = () => {
 	return useMutation<void, unknown, LibraryToggleMonitorRequest>({
 		mutationFn: toggleLibraryMonitoring,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["discover", "search"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: discoverKeys.searchAll });
 		},
 	});
 };
@@ -136,7 +136,7 @@ export const useLibrarySeasonSearchMutation = () => {
 	return useMutation<void, unknown, LibrarySeasonSearchRequest>({
 		mutationFn: searchLibrarySeason,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -147,7 +147,7 @@ export const useLibraryMovieSearchMutation = () => {
 	return useMutation<void, unknown, LibraryMovieSearchRequest>({
 		mutationFn: searchLibraryMovie,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -158,7 +158,7 @@ export const useLibrarySeriesSearchMutation = () => {
 	return useMutation<void, unknown, LibrarySeriesSearchRequest>({
 		mutationFn: searchLibrarySeries,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -227,8 +227,8 @@ export const useLibraryEpisodeSearchMutation = () => {
 	return useMutation<void, unknown, LibraryEpisodeSearchRequest>({
 		mutationFn: searchLibraryEpisode,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "episodes"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.episodesAll });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -239,8 +239,8 @@ export const useLibraryEpisodeMonitorMutation = () => {
 	return useMutation<void, unknown, LibraryEpisodeMonitorRequest>({
 		mutationFn: toggleEpisodeMonitoring,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "episodes"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.episodesAll });
 		},
 	});
 };
@@ -252,7 +252,7 @@ export const useLibraryEpisodeMonitorMutation = () => {
 export const useAlbumsQuery = (options: FetchAlbumsParams & { enabled?: boolean }) => {
 	const { enabled, ...params } = options;
 	return useQuery<LibraryAlbumsResponse>({
-		queryKey: ["library", "albums", { instanceId: params.instanceId, artistId: params.artistId }],
+		queryKey: libraryKeys.albums(params.instanceId, params.artistId),
 		queryFn: () => fetchAlbums(params),
 		enabled: enabled ?? true,
 		staleTime: 60 * 1000,
@@ -264,7 +264,7 @@ export const useLibraryArtistSearchMutation = () => {
 	return useMutation<void, unknown, LibraryArtistSearchRequest>({
 		mutationFn: searchLibraryArtist,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -275,8 +275,8 @@ export const useLibraryAlbumSearchMutation = () => {
 	return useMutation<void, unknown, LibraryAlbumSearchRequest>({
 		mutationFn: searchLibraryAlbum,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "albums"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.albumsAll });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -287,8 +287,8 @@ export const useLibraryAlbumMonitorMutation = () => {
 	return useMutation<void, unknown, LibraryAlbumMonitorRequest>({
 		mutationFn: toggleAlbumMonitoring,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "albums"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.albumsAll });
 		},
 	});
 };
@@ -300,7 +300,7 @@ export const useLibraryAlbumMonitorMutation = () => {
 export const useTracksQuery = (options: FetchTracksParams & { enabled?: boolean }) => {
 	const { enabled, ...params } = options;
 	return useQuery<LibraryTracksResponse>({
-		queryKey: ["library", "tracks", { instanceId: params.instanceId, albumId: params.albumId }],
+		queryKey: libraryKeys.tracks(params.instanceId, params.albumId),
 		queryFn: () => fetchTracks(params),
 		enabled: enabled ?? true,
 		staleTime: 60 * 1000,
@@ -314,7 +314,7 @@ export const useTracksQuery = (options: FetchTracksParams & { enabled?: boolean 
 export const useBooksQuery = (options: FetchBooksParams & { enabled?: boolean }) => {
 	const { enabled, ...params } = options;
 	return useQuery<LibraryBooksResponse>({
-		queryKey: ["library", "books", { instanceId: params.instanceId, authorId: params.authorId }],
+		queryKey: libraryKeys.books(params.instanceId, params.authorId),
 		queryFn: () => fetchBooks(params),
 		enabled: enabled ?? true,
 		staleTime: 60 * 1000,
@@ -326,7 +326,7 @@ export const useLibraryAuthorSearchMutation = () => {
 	return useMutation<void, unknown, LibraryAuthorSearchRequest>({
 		mutationFn: searchLibraryAuthor,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -337,8 +337,8 @@ export const useLibraryBookSearchMutation = () => {
 	return useMutation<void, unknown, LibraryBookSearchRequest>({
 		mutationFn: searchLibraryBook,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "books"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.booksAll });
 			void queryClient.invalidateQueries({ queryKey: QUEUE_QUERY_KEY });
 		},
 	});
@@ -349,8 +349,8 @@ export const useLibraryBookMonitorMutation = () => {
 	return useMutation<void, unknown, LibraryBookMonitorRequest>({
 		mutationFn: toggleBookMonitoring,
 		onSuccess: () => {
-			void queryClient.invalidateQueries({ queryKey: ["library"] });
-			void queryClient.invalidateQueries({ queryKey: ["library", "books"] });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.all });
+			void queryClient.invalidateQueries({ queryKey: libraryKeys.booksAll });
 		},
 	});
 };

--- a/apps/web/src/hooks/api/useLibraryCleanup.ts
+++ b/apps/web/src/hooks/api/useLibraryCleanup.ts
@@ -147,9 +147,9 @@ export function useCleanupExecute() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.config });
 			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.status });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-logs"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-approvals"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-statistics"] });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.logsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.approvalsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.statisticsAll });
 		},
 	});
 }
@@ -159,9 +159,9 @@ export function useApproveCleanupItem() {
 	return useMutation({
 		mutationFn: (id: string): Promise<ApprovalExecuteResult> => libraryCleanupApi.approveItem(id),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-approvals"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-logs"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-statistics"] });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.approvalsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.logsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.statisticsAll });
 		},
 	});
 }
@@ -171,9 +171,9 @@ export function useRejectCleanupItem() {
 	return useMutation({
 		mutationFn: (id: string) => libraryCleanupApi.rejectItem(id),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-approvals"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-logs"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-statistics"] });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.approvalsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.logsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.statisticsAll });
 		},
 	});
 }
@@ -184,9 +184,9 @@ export function useBulkCleanupAction() {
 		mutationFn: ({ ids, action }: { ids: string[]; action: "approved" | "rejected" }) =>
 			libraryCleanupApi.bulkAction(ids, action),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-approvals"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-logs"] });
-			queryClient.invalidateQueries({ queryKey: ["library-cleanup-statistics"] });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.approvalsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.logsAll });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.statisticsAll });
 		},
 	});
 }

--- a/apps/web/src/hooks/api/useNaming.ts
+++ b/apps/web/src/hooks/api/useNaming.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { namingKeys } from "../../lib/query-keys";
 import type {
 	NamingApplyApiResponse,
 	NamingApplyPayload,
@@ -29,9 +30,7 @@ import {
 // Query Keys
 // ============================================================================
 
-export const NAMING_PRESETS_KEY = ["naming-presets"] as const;
-export const NAMING_CONFIG_KEY = ["naming-config"] as const;
-export const NAMING_HISTORY_KEY = ["naming-history"] as const;
+
 
 // ============================================================================
 // Query Hooks
@@ -43,7 +42,7 @@ export const NAMING_HISTORY_KEY = ["naming-history"] as const;
  */
 export const useNamingPresets = (serviceType: "RADARR" | "SONARR", enabled = true) =>
 	useQuery<NamingPresetsApiResponse>({
-		queryKey: [...NAMING_PRESETS_KEY, serviceType],
+		queryKey: [...namingKeys.presets, serviceType],
 		queryFn: () => fetchNamingPresets(serviceType),
 		enabled,
 		staleTime: 10 * 60 * 1000, // 10 minutes — presets from TRaSH cache
@@ -54,7 +53,7 @@ export const useNamingPresets = (serviceType: "RADARR" | "SONARR", enabled = tru
  */
 export const useNamingConfig = (instanceId: string | undefined, enabled = true) =>
 	useQuery<NamingConfigApiResponse>({
-		queryKey: [...NAMING_CONFIG_KEY, instanceId],
+		queryKey: [...namingKeys.config, instanceId],
 		queryFn: () => fetchNamingConfig(instanceId!),
 		enabled: enabled && !!instanceId,
 		staleTime: 5 * 60 * 1000,
@@ -68,7 +67,7 @@ export const useNamingHistory = (
 	options?: { limit?: number; offset?: number },
 ) =>
 	useQuery<NamingHistoryApiResponse>({
-		queryKey: [...NAMING_HISTORY_KEY, instanceId, options?.offset ?? 0],
+		queryKey: [...namingKeys.history, instanceId, options?.offset ?? 0],
 		queryFn: () => fetchNamingHistory(instanceId!, options),
 		enabled: !!instanceId,
 		staleTime: 60_000,
@@ -99,10 +98,10 @@ export const useApplyNaming = () => {
 		mutationFn: (payload) => applyNaming(payload),
 		onSuccess: (_data, variables) => {
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_CONFIG_KEY, variables.instanceId],
+				queryKey: [...namingKeys.config, variables.instanceId],
 			});
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_HISTORY_KEY, variables.instanceId],
+				queryKey: [...namingKeys.history, variables.instanceId],
 			});
 		},
 	});
@@ -118,7 +117,7 @@ export const useSaveNamingConfig = () => {
 		mutationFn: (payload) => saveNamingConfig(payload),
 		onSuccess: (_data, variables) => {
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_CONFIG_KEY, variables.instanceId],
+				queryKey: [...namingKeys.config, variables.instanceId],
 			});
 		},
 	});
@@ -134,7 +133,7 @@ export const useDeleteNamingConfig = () => {
 		mutationFn: (instanceId) => deleteNamingConfig(instanceId),
 		onSuccess: (_data, instanceId) => {
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_CONFIG_KEY, instanceId],
+				queryKey: [...namingKeys.config, instanceId],
 			});
 		},
 	});
@@ -151,10 +150,10 @@ export const useRollbackNaming = () => {
 		mutationFn: ({ historyId }) => rollbackNaming(historyId),
 		onSuccess: (_data, variables) => {
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_CONFIG_KEY, variables.instanceId],
+				queryKey: [...namingKeys.config, variables.instanceId],
 			});
 			void queryClient.invalidateQueries({
-				queryKey: [...NAMING_HISTORY_KEY, variables.instanceId],
+				queryKey: [...namingKeys.history, variables.instanceId],
 			});
 		},
 	});

--- a/apps/web/src/hooks/api/useProfileClone.ts
+++ b/apps/web/src/hooks/api/useProfileClone.ts
@@ -4,6 +4,7 @@
 
 import type { CompleteQualityProfile } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { qualityProfileKeys } from "../../lib/query-keys";
 
 // ============================================================================
 // Types
@@ -70,7 +71,7 @@ interface ProfilePreview {
  */
 export function useInstanceProfiles(instanceId: string | null) {
 	return useQuery({
-		queryKey: ["profile-clone", "profiles", instanceId],
+		queryKey: qualityProfileKeys.clone.profiles(instanceId),
 		queryFn: async () => {
 			if (!instanceId) return [];
 
@@ -128,7 +129,7 @@ export function useImportProfile() {
 		onSuccess: (data) => {
 			// Invalidate profile list for the affected instance
 			queryClient.invalidateQueries({
-				queryKey: ["profile-clone", "profiles", data.instanceId],
+				queryKey: qualityProfileKeys.clone.profiles(data.instanceId),
 			});
 		},
 	});
@@ -197,7 +198,7 @@ export function useDeployProfile() {
 		onSuccess: (data) => {
 			// Invalidate profile list for the affected instance
 			queryClient.invalidateQueries({
-				queryKey: ["profile-clone", "profiles", data.instanceId],
+				queryKey: qualityProfileKeys.clone.profiles(data.instanceId),
 			});
 		},
 	});

--- a/apps/web/src/hooks/api/useQualityProfiles.ts
+++ b/apps/web/src/hooks/api/useQualityProfiles.ts
@@ -21,14 +21,14 @@ import {
 	updateQualityProfileTemplate,
 	validateClonedCFs,
 } from "../../lib/api-client/trash-guides";
-import { TEMPLATES_QUERY_KEY } from "./useTemplates";
+import { qualityProfileKeys, TEMPLATES_QUERY_KEY } from "../../lib/query-keys";
 
 /**
  * Hook to fetch TRaSH Guides quality profiles for a service
  */
 export const useQualityProfiles = (serviceType: "RADARR" | "SONARR") =>
 	useQuery<QualityProfilesResponse>({
-		queryKey: ["quality-profiles", serviceType],
+		queryKey: qualityProfileKeys.list(serviceType),
 		queryFn: () => fetchQualityProfiles(serviceType),
 		staleTime: 10 * 60 * 1000, // 10 minutes
 	});
@@ -42,7 +42,7 @@ export const useQualityProfileDetails = (
 	enabled = true,
 ) =>
 	useQuery({
-		queryKey: ["quality-profile-details", serviceType, trashId],
+		queryKey: qualityProfileKeys.details(serviceType, trashId),
 		queryFn: () => fetchQualityProfileDetails(serviceType, trashId),
 		enabled: enabled && !!trashId,
 		staleTime: 10 * 60 * 1000, // 10 minutes
@@ -116,7 +116,7 @@ export const useClonedCFValidation = (
 	enabled = true,
 ) =>
 	useQuery<CFValidationResponse>({
-		queryKey: ["cf-validation", instanceId, profileId, serviceType],
+		queryKey: qualityProfileKeys.cfValidation(instanceId, profileId, serviceType),
 		queryFn: () => validateClonedCFs({ instanceId, profileId, serviceType }),
 		enabled: enabled && !!instanceId && !!profileId,
 		staleTime: 5 * 60 * 1000, // 5 minutes
@@ -142,7 +142,7 @@ export const useProfileMatch = (
 	enabled = true,
 ) =>
 	useQuery<ProfileMatchResult>({
-		queryKey: ["profile-match", profileName, serviceType],
+		queryKey: qualityProfileKeys.profileMatch(profileName, serviceType),
 		queryFn: () => matchProfileToTrash({ profileName, serviceType }),
 		enabled: enabled && !!profileName && !!serviceType,
 		staleTime: 30 * 1000, // 30 seconds - short to pick up TRaSH cache updates

--- a/apps/web/src/hooks/api/useQui.ts
+++ b/apps/web/src/hooks/api/useQui.ts
@@ -246,7 +246,7 @@ export const useQuiFileMediaInfo = (args: {
 }) => {
 	const { quiInstanceId, qbitInstanceId, hash, fileIndex, enabled = true } = args;
 	return useQuery({
-		queryKey: ["qui", "file-mediainfo", quiInstanceId, qbitInstanceId, hash, fileIndex] as const,
+		queryKey: quiKeys.fileMediainfo(quiInstanceId, qbitInstanceId, hash, fileIndex),
 		queryFn: () =>
 			fetchQuiFileMediaInfo({
 				quiInstanceId: quiInstanceId!,
@@ -292,8 +292,8 @@ export const useQuiRenameTorrent = () => {
  * it renders `copy`, a frozen snapshot, so a query refetch can't reach it.
  */
 const invalidateTorrentPanels = (queryClient: ReturnType<typeof useQueryClient>) => {
-	queryClient.invalidateQueries({ queryKey: ["qui", "series-torrents"] });
-	queryClient.invalidateQueries({ queryKey: ["qui", "movie-torrents"] });
+	queryClient.invalidateQueries({ queryKey: quiKeys.seriesTorrentsAll });
+	queryClient.invalidateQueries({ queryKey: quiKeys.movieTorrentsAll });
 };
 
 /** Add tracker URLs to a torrent. */
@@ -352,7 +352,7 @@ export const useQuiCategories = (args: {
 }) => {
 	const { quiInstanceId, qbitInstanceId, enabled = true } = args;
 	return useQuery({
-		queryKey: ["qui", "categories", quiInstanceId, qbitInstanceId] as const,
+		queryKey: quiKeys.categories(quiInstanceId, qbitInstanceId),
 		queryFn: () =>
 			fetchQuiCategories({ quiInstanceId: quiInstanceId!, qbitInstanceId: qbitInstanceId! }),
 		enabled: enabled && quiInstanceId !== null && qbitInstanceId !== null,
@@ -370,7 +370,7 @@ export const useQuiTags = (args: {
 }) => {
 	const { quiInstanceId, qbitInstanceId, enabled = true } = args;
 	return useQuery({
-		queryKey: ["qui", "tags", quiInstanceId, qbitInstanceId] as const,
+		queryKey: quiKeys.tags(quiInstanceId, qbitInstanceId),
 		queryFn: () => fetchQuiTags({ quiInstanceId: quiInstanceId!, qbitInstanceId: qbitInstanceId! }),
 		enabled: enabled && quiInstanceId !== null && qbitInstanceId !== null,
 		staleTime: 5 * 60 * 1000,
@@ -389,7 +389,7 @@ export const useQuiCapabilities = (args: {
 }) => {
 	const { quiInstanceId, qbitInstanceId, enabled = true } = args;
 	return useQuery({
-		queryKey: ["qui", "capabilities", quiInstanceId, qbitInstanceId] as const,
+		queryKey: quiKeys.capabilities(quiInstanceId, qbitInstanceId),
 		queryFn: () =>
 			fetchQuiCapabilities({ quiInstanceId: quiInstanceId!, qbitInstanceId: qbitInstanceId! }),
 		enabled: enabled && quiInstanceId !== null && qbitInstanceId !== null,

--- a/apps/web/src/hooks/api/useRequestedUnwatchedInsights.ts
+++ b/apps/web/src/hooks/api/useRequestedUnwatchedInsights.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { libraryKeys } from "../../lib/query-keys";
 import { apiRequest } from "../../lib/api-client/base";
 
 export interface RequestedUnwatchedItem {
@@ -41,7 +42,7 @@ export function useRequestedUnwatchedInsights(params?: {
 	enabled?: boolean;
 }) {
 	return useQuery<RequestedUnwatchedResponse>({
-		queryKey: ["library", "insights", "requested-unwatched", params],
+		queryKey: libraryKeys.insights.requestedUnwatched(params),
 		queryFn: () =>
 			fetchRequestedUnwatched({
 				minAgeDays: params?.minAgeDays,

--- a/apps/web/src/hooks/api/useSearch.ts
+++ b/apps/web/src/hooks/api/useSearch.ts
@@ -19,11 +19,11 @@ import {
 	testSearchIndexer,
 	updateSearchIndexer,
 } from "../../lib/api-client/search";
-import { QUEUE_QUERY_KEY } from "../../lib/query-keys";
+import { QUEUE_QUERY_KEY, searchKeys } from "../../lib/query-keys";
 
 export const useSearchIndexersQuery = () =>
 	useQuery<SearchIndexersResponse>({
-		queryKey: ["search", "indexers"],
+		queryKey: searchKeys.indexers,
 		queryFn: fetchSearchIndexers,
 		staleTime: 5 * 60 * 1000,
 	});
@@ -56,7 +56,7 @@ export const useIndexerDetailsQuery = (
 	health?: ProwlarrIndexerHealth,
 ) =>
 	useQuery<ProwlarrIndexerDetails>({
-		queryKey: ["search", "indexers", "details", instanceId, indexerId],
+		queryKey: searchKeys.indexerDetails(instanceId, indexerId),
 		queryFn: () => fetchSearchIndexerDetails(instanceId!, indexerId!, health),
 		enabled: Boolean(enabled && instanceId && indexerId !== null),
 		staleTime: 60 * 1000,

--- a/apps/web/src/hooks/api/useSeerr.ts
+++ b/apps/web/src/hooks/api/useSeerr.ts
@@ -121,7 +121,7 @@ export const useApproveSeerrRequest = () => {
 		mutationFn: ({ instanceId, requestId, overrides }) =>
 			approveSeerrRequest(instanceId, requestId, overrides),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.attention(instanceId) });
 		},
@@ -133,7 +133,7 @@ export const useDeclineSeerrRequest = () => {
 	return useMutation<SeerrRequest, Error, { instanceId: string; requestId: number }>({
 		mutationFn: ({ instanceId, requestId }) => declineSeerrRequest(instanceId, requestId),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.attention(instanceId) });
 		},
@@ -145,7 +145,7 @@ export const useDeleteSeerrRequest = () => {
 	return useMutation<void, Error, { instanceId: string; requestId: number }>({
 		mutationFn: ({ instanceId, requestId }) => deleteSeerrRequest(instanceId, requestId),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.attention(instanceId) });
 		},
@@ -162,7 +162,7 @@ export const useBulkSeerrRequestAction = () => {
 		mutationFn: ({ instanceId, action, requestIds }) =>
 			bulkSeerrRequestAction(instanceId, action, requestIds),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.attention(instanceId) });
 		},
@@ -174,7 +174,7 @@ export const useRetrySeerrRequest = () => {
 	return useMutation<SeerrRequest, Error, { instanceId: string; requestId: number }>({
 		mutationFn: ({ instanceId, requestId }) => retrySeerrRequest(instanceId, requestId),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.attention(instanceId) });
 		},
@@ -211,8 +211,8 @@ export const useUpdateSeerrUser = () => {
 		mutationFn: ({ instanceId, seerrUserId, data }) =>
 			updateSeerrUser(instanceId, seerrUserId, data),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "users", instanceId] });
-			queryClient.invalidateQueries({ queryKey: ["seerr", "user-quota", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.usersAll(instanceId) });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.userQuotaAll(instanceId) });
 		},
 	});
 };
@@ -239,7 +239,7 @@ export const useAddSeerrIssueComment = () => {
 		mutationFn: ({ instanceId, issueId, message }) =>
 			addSeerrIssueComment(instanceId, issueId, message),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "issues", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.issuesAll(instanceId) });
 		},
 	});
 };
@@ -254,7 +254,7 @@ export const useUpdateSeerrIssueStatus = () => {
 		mutationFn: ({ instanceId, issueId, status }) =>
 			updateSeerrIssueStatus(instanceId, issueId, status),
 		onSuccess: (_, { instanceId }) => {
-			queryClient.invalidateQueries({ queryKey: ["seerr", "issues", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.issuesAll(instanceId) });
 		},
 	});
 };
@@ -326,8 +326,8 @@ export const useClearSeerrCache = () => {
 		mutationFn: ({ instanceId }) => clearSeerrCache(instanceId),
 		onSuccess: (_, { instanceId }) => {
 			// Invalidate discover queries so they refetch with fresh server-side cache
-			queryClient.invalidateQueries({ queryKey: ["seerr", "discover"] });
-			queryClient.invalidateQueries({ queryKey: ["seerr", "library-enrichment", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.discover.all });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.libraryEnrichmentAll(instanceId) });
 		},
 	});
 };
@@ -469,7 +469,7 @@ export const useCreateSeerrRequest = () => {
 		mutationFn: ({ instanceId, payload }) => createSeerrRequest(instanceId, payload),
 		onSuccess: (_, { instanceId }) => {
 			queryClient.invalidateQueries({ queryKey: seerrKeys.discover.all });
-			queryClient.invalidateQueries({ queryKey: ["seerr", "requests", instanceId] });
+			queryClient.invalidateQueries({ queryKey: seerrKeys.requestsAll(instanceId) });
 			queryClient.invalidateQueries({ queryKey: seerrKeys.requestCount(instanceId) });
 		},
 	});

--- a/apps/web/src/hooks/api/useServiceMutations.ts
+++ b/apps/web/src/hooks/api/useServiceMutations.ts
@@ -2,6 +2,7 @@
 
 import type { ServiceInstanceSummary } from "@arr/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { libraryCleanupKeys, serviceKeys } from "../../lib/query-keys";
 import {
 	type CreateServicePayload,
 	createService,
@@ -10,8 +11,6 @@ import {
 	updateService,
 } from "../../lib/api-client/services";
 
-const SERVICES_QUERY_KEY = ["services"] as const;
-const FIELD_OPTIONS_KEY = ["library-cleanup-field-options"] as const;
 
 type UpdateVariables = {
 	id: string;
@@ -28,8 +27,8 @@ export const useCreateServiceMutation = () => {
 	return useMutation<ServiceInstanceSummary, Error, CreateVariables>({
 		mutationFn: createService,
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: SERVICES_QUERY_KEY });
-			queryClient.invalidateQueries({ queryKey: FIELD_OPTIONS_KEY });
+			queryClient.invalidateQueries({ queryKey: serviceKeys.all });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.fieldOptions });
 		},
 	});
 };
@@ -40,7 +39,7 @@ export const useUpdateServiceMutation = () => {
 	return useMutation<ServiceInstanceSummary, Error, UpdateVariables>({
 		mutationFn: ({ id, payload }) => updateService(id, payload),
 		onSuccess: (updated) => {
-			queryClient.setQueryData<ServiceInstanceSummary[]>(SERVICES_QUERY_KEY, (prev) => {
+			queryClient.setQueryData<ServiceInstanceSummary[]>(serviceKeys.all, (prev) => {
 				if (!prev) {
 					return prev;
 				}
@@ -54,7 +53,7 @@ export const useUpdateServiceMutation = () => {
 					return service;
 				});
 			});
-			queryClient.invalidateQueries({ queryKey: FIELD_OPTIONS_KEY });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.fieldOptions });
 		},
 	});
 };
@@ -65,13 +64,13 @@ export const useDeleteServiceMutation = () => {
 	return useMutation<void, Error, DeleteVariables>({
 		mutationFn: removeService,
 		onSuccess: (_, id) => {
-			queryClient.setQueryData<ServiceInstanceSummary[]>(SERVICES_QUERY_KEY, (prev) => {
+			queryClient.setQueryData<ServiceInstanceSummary[]>(serviceKeys.all, (prev) => {
 				if (!prev) {
 					return prev;
 				}
 				return prev.filter((service) => service.id !== id);
 			});
-			queryClient.invalidateQueries({ queryKey: FIELD_OPTIONS_KEY });
+			queryClient.invalidateQueries({ queryKey: libraryCleanupKeys.fieldOptions });
 		},
 	});
 };

--- a/apps/web/src/hooks/api/useServicesQuery.ts
+++ b/apps/web/src/hooks/api/useServicesQuery.ts
@@ -2,6 +2,7 @@
 
 import type { ServiceInstanceSummary } from "@arr/shared";
 import { useQuery } from "@tanstack/react-query";
+import { serviceKeys } from "../../lib/query-keys";
 import { fetchServices } from "../../lib/api-client/services";
 
 interface ServicesQueryOptions {
@@ -10,7 +11,7 @@ interface ServicesQueryOptions {
 
 export const useServicesQuery = (options: ServicesQueryOptions = {}) =>
 	useQuery<ServiceInstanceSummary[]>({
-		queryKey: ["services"],
+		queryKey: serviceKeys.all,
 		queryFn: fetchServices,
 		staleTime: 30 * 1000, // 30 seconds - services don't change frequently
 		enabled: options.enabled ?? true,

--- a/apps/web/src/hooks/api/useSync.ts
+++ b/apps/web/src/hooks/api/useSync.ts
@@ -371,7 +371,7 @@ export function useRollbackSync() {
 				// Global invalidation when instanceId not available
 				// This may cause cross-instance refetches but ensures data consistency
 				queryClient.invalidateQueries({
-					queryKey: ["sync-history"],
+					queryKey: syncKeys.historyAll,
 				});
 			}
 		},

--- a/apps/web/src/hooks/api/useTags.ts
+++ b/apps/web/src/hooks/api/useTags.ts
@@ -2,9 +2,9 @@
 
 import type { ServiceTagResponse } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { TAGS_QUERY_KEY } from "../../lib/query-keys";
 import { createTag, deleteTag, fetchTags } from "../../lib/api-client/tags";
 
-const TAGS_QUERY_KEY = ["service-tags"] as const;
 
 export const useTagsQuery = () =>
 	useQuery<ServiceTagResponse[]>({

--- a/apps/web/src/hooks/api/useTemplates.ts
+++ b/apps/web/src/hooks/api/useTemplates.ts
@@ -2,6 +2,7 @@
 
 import type { CreateTemplateRequest, UpdateTemplateRequest } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { TEMPLATES_QUERY_KEY, trashGuidesKeys } from "../../lib/query-keys";
 import {
 	createTemplate,
 	deleteTemplate,
@@ -28,7 +29,6 @@ import {
  * Used for invalidation to match all template queries regardless of params.
  * The actual query key is ["trash-guides", "templates", params], so this prefix will match all variations.
  */
-export const TEMPLATES_QUERY_KEY = ["trash-guides", "templates"] as const;
 
 // ============================================================================
 // Query Hooks
@@ -47,7 +47,7 @@ export const useTemplates = (params?: {
 	offset?: number;
 }) =>
 	useQuery<TemplateListResponse>({
-		queryKey: ["trash-guides", "templates", params],
+		queryKey: trashGuidesKeys.templates.list(params),
 		queryFn: () => fetchTemplates(params),
 		staleTime: 2 * 60 * 1000, // 2 minutes
 		refetchOnMount: true,
@@ -58,7 +58,7 @@ export const useTemplates = (params?: {
  */
 export const useTemplate = (templateId: string | null) =>
 	useQuery<TemplateResponse>({
-		queryKey: ["trash-guides", "template", templateId],
+		queryKey: trashGuidesKeys.templates.detail(templateId),
 		queryFn: () => fetchTemplate(templateId!),
 		enabled: !!templateId,
 		staleTime: 5 * 60 * 1000, // 5 minutes
@@ -69,7 +69,7 @@ export const useTemplate = (templateId: string | null) =>
  */
 export const useTemplateStats = (templateId: string | null) =>
 	useQuery<TemplateStatsResponse>({
-		queryKey: ["template-stats", templateId],
+		queryKey: trashGuidesKeys.templates.stats(templateId),
 		queryFn: () => fetchTemplateStats(templateId!),
 		enabled: !!templateId,
 		staleTime: 1 * 60 * 1000, // 1 minute
@@ -105,7 +105,7 @@ export const useUpdateTemplate = () => {
 		onSuccess: (_, variables) => {
 			void queryClient.invalidateQueries({ queryKey: TEMPLATES_QUERY_KEY });
 			void queryClient.invalidateQueries({
-				queryKey: ["trash-guides", "template", variables.templateId],
+				queryKey: trashGuidesKeys.templates.detail(variables.templateId),
 			});
 		},
 	});

--- a/apps/web/src/hooks/api/useTrashCache.ts
+++ b/apps/web/src/hooks/api/useTrashCache.ts
@@ -22,7 +22,7 @@ import {
 	refreshCache,
 } from "../../lib/api-client/trash-guides";
 import { POLLING_STANDARD } from "../../lib/polling-intervals";
-import { trashCacheKeys } from "../../lib/query-keys";
+import { trashCacheKeys, trashGuidesKeys } from "../../lib/query-keys";
 
 /**
  * Hook to fetch TRaSH Guides cache status
@@ -59,7 +59,7 @@ export const useRefreshTrashCache = () => {
 			void queryClient.invalidateQueries({ queryKey: trashCacheKeys.allEntries });
 			// Also invalidate trash-guides related queries for the specific service type
 			void queryClient.invalidateQueries({
-				queryKey: ["trash-guides", variables.serviceType],
+				queryKey: trashGuidesKeys.byService(variables.serviceType),
 			});
 		},
 	});

--- a/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
+++ b/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import { libraryKeys } from "../../lib/query-keys";
 import { apiRequest } from "../../lib/api-client/base";
 
 export interface WatchedMonitoredItem {
@@ -37,7 +38,7 @@ export function useWatchedMonitoredInsights(params?: {
 	enabled?: boolean;
 }) {
 	return useQuery<WatchedMonitoredResponse>({
-		queryKey: ["library", "insights", "watched-monitored", params],
+		queryKey: libraryKeys.insights.watchedMonitored(params),
 		queryFn: () => fetchWatchedMonitored({ limit: params?.limit }),
 		enabled: params?.enabled ?? true,
 		staleTime: 5 * 60 * 1000,

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -53,12 +53,28 @@ export const libraryKeys = {
 	filtering: ["library", "all-for-filtering"] as const,
 	syncStatus: ["library", "sync", "status"] as const,
 	episodes: (params: Record<string, unknown>) => ["library", "episodes", params] as const,
-	albums: (instanceId: string, artistId: number) =>
+	albums: (instanceId: string, artistId: string | number) =>
 		["library", "albums", { instanceId, artistId }] as const,
-	tracks: (instanceId: string, albumId: number) =>
+	tracks: (instanceId: string, albumId: string | number) =>
 		["library", "tracks", { instanceId, albumId }] as const,
-	books: (instanceId: string, authorId: number) =>
+	books: (instanceId: string, authorId: string | number) =>
 		["library", "books", { instanceId, authorId }] as const,
+	// Prefix statics for invalidation — NOT the parameterized factories
+	// called short (that would append a trailing `undefined` slot and
+	// silently break React Query's partial matching).
+	episodesAll: ["library", "episodes"] as const,
+	albumsAll: ["library", "albums"] as const,
+	booksAll: ["library", "books"] as const,
+	insights: {
+		// `object | undefined` (not Record) — consumers pass typed param
+		// objects without index signatures, and some pass undefined; the
+		// produced arrays stay byte-identical to the old literals.
+		diskWaste: (params?: object) => ["library", "insights", "disk-waste", params] as const,
+		requestedUnwatched: (params?: object) =>
+			["library", "insights", "requested-unwatched", params] as const,
+		watchedMonitored: (params?: object) =>
+			["library", "insights", "watched-monitored", params] as const,
+	},
 };
 
 /* -------------------------------------------------------------------------- */
@@ -71,9 +87,10 @@ export const trashGuidesKeys = {
 	// Templates
 	templates: {
 		all: ["trash-guides", "templates"] as const,
-		list: (params: Record<string, unknown>) => ["trash-guides", "templates", params] as const,
-		detail: (templateId: string) => ["trash-guides", "template", templateId] as const,
-		stats: (templateId: string) => ["template-stats", templateId] as const,
+		list: (params?: object) => ["trash-guides", "templates", params] as const,
+		detail: (templateId: string | null) => ["trash-guides", "template", templateId] as const,
+		stats: (templateId: string | null) => ["template-stats", templateId] as const,
+		statsAll: ["template-stats"] as const,
 	},
 
 	// Updates
@@ -87,7 +104,7 @@ export const trashGuidesKeys = {
 	},
 
 	// Instance overrides
-	instanceOverrides: (templateId: string, instanceId: string) =>
+	instanceOverrides: (templateId: string | null, instanceId: string | null) =>
 		["trash-guides", "instance-overrides", templateId, instanceId] as const,
 
 	// Deployment
@@ -95,6 +112,20 @@ export const trashGuidesKeys = {
 		all: ["trash-guides", "deployment"] as const,
 		preview: (templateId: string, instanceId: string) =>
 			["trash-guides", "deployment", "preview", templateId, instanceId] as const,
+		previewAll: ["trash-guides", "deployment", "preview"] as const,
+	},
+
+	// Per-service prefix used by useTrashCache invalidation. NOTE: this
+	// prefix-matches nothing in this file's standard keys (they nest as
+	// ["trash-guides","<group>",...]) — preserved byte-identically by the
+	// B1 sweep; whether it should target a real group is a follow-up.
+	byService: (serviceType: string) => ["trash-guides", serviceType] as const,
+
+	// Template-creation wizard caches
+	wizard: {
+		cfGroupsCache: (serviceType: string) => ["cf-groups-cache", serviceType] as const,
+		sourceProfileData: (serviceType: string, trashId: string | undefined) =>
+			["source-profile-data", serviceType, trashId] as const,
 	},
 
 	// Schedules
@@ -133,12 +164,12 @@ export const qualityProfileKeys = {
 		["quality-profile-details", serviceType, trashId] as const,
 	overrides: (instanceId: string, qualityProfileId: number) =>
 		["quality-profile-overrides", instanceId, qualityProfileId] as const,
-	cfValidation: (instanceId: string, profileId: string, serviceType: string) =>
+	cfValidation: (instanceId: string, profileId: string | number, serviceType: string) =>
 		["cf-validation", instanceId, profileId, serviceType] as const,
 	profileMatch: (profileName: string, serviceType: string) =>
 		["profile-match", profileName, serviceType] as const,
 	clone: {
-		profiles: (instanceId: string) => ["profile-clone", "profiles", instanceId] as const,
+		profiles: (instanceId: string | null) => ["profile-clone", "profiles", instanceId] as const,
 	},
 };
 
@@ -166,6 +197,7 @@ export const syncKeys = {
 	progress: (syncId: string) => ["sync-progress", syncId] as const,
 	history: (instanceId: string, params?: Record<string, unknown>) =>
 		["sync-history", instanceId, params] as const,
+	historyAll: ["sync-history"] as const,
 	detail: (syncId: string) => ["sync-detail", syncId] as const,
 };
 
@@ -202,7 +234,7 @@ export const customFormatKeys = {
 
 export const bulkScoreKeys = {
 	all: ["bulk-scores"] as const,
-	list: (filters: Record<string, unknown>) => ["bulk-scores", filters] as const,
+	list: (filters: object) => ["bulk-scores", filters] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -234,6 +266,7 @@ export const tmdbKeys = {
 export const discoverKeys = {
 	all: ["discover"] as const,
 	search: (query: string, type: string) => ["discover", "search", { query, type }] as const,
+	searchAll: ["discover", "search"] as const,
 	options: (instanceId: string, type: string) =>
 		["discover", "options", { instanceId, type }] as const,
 	testOptions: (request: Record<string, unknown>) => ["discover", "test-options", request] as const,
@@ -250,7 +283,7 @@ export const discoverKeys = {
 export const searchKeys = {
 	all: ["search"] as const,
 	indexers: ["search", "indexers"] as const,
-	indexerDetails: (instanceId: string, indexerId: number) =>
+	indexerDetails: (instanceId: string | null, indexerId: number | null) =>
 		["search", "indexers", "details", instanceId, indexerId] as const,
 };
 
@@ -356,20 +389,26 @@ export const seerrKeys = {
 	all: ["seerr"] as const,
 	requests: (instanceId: string, params?: object) =>
 		["seerr", "requests", instanceId, params] as const,
+	// Invalidation prefixes — see libraryKeys note on trailing-undefined.
+	requestsAll: (instanceId: string) => ["seerr", "requests", instanceId] as const,
 	request: (instanceId: string, requestId: number) =>
 		["seerr", "request", instanceId, requestId] as const,
 	requestCount: (instanceId: string) => ["seerr", "request-count", instanceId] as const,
 	attention: (instanceId: string) => ["seerr", "attention", instanceId] as const,
 	users: (instanceId: string, params?: object) => ["seerr", "users", instanceId, params] as const,
+	usersAll: (instanceId: string) => ["seerr", "users", instanceId] as const,
 	userQuota: (instanceId: string, userId: number) =>
 		["seerr", "user-quota", instanceId, userId] as const,
+	userQuotaAll: (instanceId: string) => ["seerr", "user-quota", instanceId] as const,
 	issues: (instanceId: string, params?: object) => ["seerr", "issues", instanceId, params] as const,
+	issuesAll: (instanceId: string) => ["seerr", "issues", instanceId] as const,
 	notifications: (instanceId: string) => ["seerr", "notifications", instanceId] as const,
 	status: (instanceId: string) => ["seerr", "status", instanceId] as const,
 	health: (instanceId: string) => ["seerr", "health", instanceId] as const,
 	audit: (instanceId: string) => ["seerr", "audit", instanceId] as const,
 	libraryEnrichment: (instanceId: string, tmdbIdKey: string) =>
 		["seerr", "library-enrichment", instanceId, tmdbIdKey] as const,
+	libraryEnrichmentAll: (instanceId: string) => ["seerr", "library-enrichment", instanceId] as const,
 	discover: {
 		all: ["seerr", "discover"] as const,
 		movies: (instanceId: string) => ["seerr", "discover", "movies", instanceId] as const,
@@ -427,10 +466,13 @@ export const libraryCleanupKeys = {
 	config: ["library-cleanup-config"] as const,
 	status: ["library-cleanup-status"] as const,
 	statistics: (days: number) => ["library-cleanup-statistics", days] as const,
+	statisticsAll: ["library-cleanup-statistics"] as const,
 	approvalQueue: (page: number, status?: string) =>
 		["library-cleanup-approvals", page, status] as const,
+	approvalsAll: ["library-cleanup-approvals"] as const,
 	logs: (page: number, filters?: Record<string, string>) =>
 		["library-cleanup-logs", page, filters] as const,
+	logsAll: ["library-cleanup-logs"] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -496,12 +538,27 @@ export const quiKeys = {
 	// when a cross-seed trigger or manual backfill changes correlation.
 	seriesTorrents: (arrInstanceId: string, arrItemId: number) =>
 		["qui", "series-torrents", arrInstanceId, arrItemId] as const,
+	seriesTorrentsAll: ["qui", "series-torrents"] as const,
 	// Per-movie aggregate — single cluster + tracker copies. Same wire shape
 	// as seriesTorrents but the data path queries Radarr/library_cache
 	// instead of episode_file_cache. Distinct key so invalidations don't
 	// collide and React Query can cache each independently.
 	movieTorrents: (arrInstanceId: string, arrItemId: number) =>
 		["qui", "movie-torrents", arrInstanceId, arrItemId] as const,
+	movieTorrentsAll: ["qui", "movie-torrents"] as const,
+	fileMediainfo: (
+		quiInstanceId: string | null,
+		qbitInstanceId: number | null,
+		hash: string | null,
+		fileIndex: number | null,
+	) =>
+		["qui", "file-mediainfo", quiInstanceId, qbitInstanceId, hash, fileIndex] as const,
+	categories: (quiInstanceId: string | null, qbitInstanceId: number | null) =>
+		["qui", "categories", quiInstanceId, qbitInstanceId] as const,
+	tags: (quiInstanceId: string | null, qbitInstanceId: number | null) =>
+		["qui", "tags", quiInstanceId, qbitInstanceId] as const,
+	capabilities: (quiInstanceId: string | null, qbitInstanceId: number | null) =>
+		["qui", "capabilities", quiInstanceId, qbitInstanceId] as const,
 	// qui's tracker-icon registry — single global key (one map per user,
 	// no parameters). Cached server-side for 1h; client also caches via
 	// the long staleTime on the hook.
@@ -555,6 +612,16 @@ export const quiKeys = {
 	// crossSeedDiscovery via React Query's prefix-match invalidation. Used
 	// after bulk mutations that can promote/demote cross-seed siblings.
 	crossSeed: ["qui", "cross-seed"] as const,
+};
+
+/* -------------------------------------------------------------------------- */
+/*  Naming (TRaSH naming presets/config)                                       */
+/* -------------------------------------------------------------------------- */
+
+export const namingKeys = {
+	presets: ["naming-presets"] as const,
+	config: ["naming-config"] as const,
+	history: ["naming-history"] as const,
 };
 
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary

First Bucket B coherence sweep (charter §3). **89 inline `queryKey` literals + 6 stray local key consts across 24 files** migrate to the central factory. Strictly behavior-preserving — every replacement produces a byte-identical key array.

### The one real trap (and how it's handled)
Several factory functions append optional params (`seerrKeys.requests(id, params?)` → 4-slot array ending in `undefined` when called short). That is **not** the 3-element prefix invalidations use — React Query's partial matching treats the `undefined` slot as a real position, so calling parameterized factories short would silently break invalidation (UI stops refreshing after mutations; invisible to tsc and tests). Every such site got an explicit `*All` prefix entry instead.

### Beyond the plan's inventory
The broadened grep gate (`queryKey`/`mutationKey`/`_KEY =`) caught 3 stray local consts the plan missed (`useServiceMutations`, `useTags`) — absorbed too.

### Known follow-up (not fixed here, by design)
`useRefreshTrashCache` invalidates `["trash-guides", serviceType]`, which prefix-matches none of the standard nested keys — it targeted nothing before this sweep and still does (preserved byte-identically, flagged in a factory comment). Fixing it is a semantics change, out of B1 scope.

## Validation
- **Gate:** zero key literals outside the factory + tests (test literals are deliberate behavioral pins)
- **A/B:** 498 web tests = pre-sweep baseline exactly; turbo typecheck + lint clean
- **Review agent** resolved every factory call back to its produced array against the removed literal: *"No key mismatches. No import/symbol issues. Ship-ready."*

Charter §9.1 success criterion (≥95% hooks on centralized keys): now 100% outside tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)