### PR TITLE
chore(pulse): label the two unlabeled collectors + completeness guard (C4)

### DIFF
--- a/apps/api/src/routes/__tests__/pulse-collector-label.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-collector-label.test.ts
@@ -7,12 +7,15 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { labelForCollector } from "../pulse.js";
+import { pulseCollectors } from "../../lib/pulse/collectors.js";
+import { COLLECTOR_LABELS, labelForCollector } from "../pulse.js";
 
 describe("labelForCollector", () => {
 	it("returns the operator label for every known collector", () => {
 		const knownPairs: Array<[string, string]> = [
 			["collectArrSignals", "ARR health and disk space"],
+			["collectMediaServerReachability", "media server reachability"],
+			["collectArrQueueFailures", "queue failures"],
 			["collectSeerrCircuitBreaker", "Seerr circuit breaker"],
 			["collectCacheStaleness", "cache freshness"],
 			["collectValidationHealth", "validation health"],
@@ -26,6 +29,16 @@ describe("labelForCollector", () => {
 		for (const [name, expected] of knownPairs) {
 			expect(labelForCollector(name)).toBe(expected);
 		}
+	});
+
+	it("every registered collector has an EXPLICIT label entry (completeness guard)", () => {
+		// The humanize fallback is a safety net, not a labeling strategy —
+		// new collectors must register explicit operator copy (charter C4;
+		// this guard turns that review rule into a permanent gate).
+		const missing = pulseCollectors
+			.map((c) => c.name)
+			.filter((name) => !(name in COLLECTOR_LABELS));
+		expect(missing).toEqual([]);
 	});
 
 	it("humanizes unknown camelCase names instead of leaking them", () => {

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -54,8 +54,10 @@ const SEVERITY_ORDER: Record<string, number> = {
 // refreshes. That name is jargon to operators, so we translate it to a plain
 // label for the visible `detail` string. Unknown names fall back to a
 // humanized camelCase form so a future collector never leaks raw source names.
-const COLLECTOR_LABELS: Record<string, string> = {
+export const COLLECTOR_LABELS: Record<string, string> = {
 	collectArrSignals: "ARR health and disk space",
+	collectMediaServerReachability: "media server reachability",
+	collectArrQueueFailures: "queue failures",
 	collectSeerrCircuitBreaker: "Seerr circuit breaker",
 	collectCacheStaleness: "cache freshness",
 	collectValidationHealth: "validation health",


### PR DESCRIPTION
Charter Bucket C4 (verified outstanding before work began): `collectMediaServerReachability` and `collectArrQueueFailures` lacked `COLLECTOR_LABELS` entries — their operator-facing failure copy relied on the humanize fallback, which is a safety net, not a labeling strategy.

Beyond the two entries, the label test now asserts **every** collector in `pulseCollectors` has an explicit label — the PR #332 review rule made into a permanent gate, so this gap class can't recur. The guard passing confirms these two were the only misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)