### PR TITLE
feat(web): incognito sweep — high-exposure surfaces (Bucket B6a)

### DIFF
--- a/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CrossSeedDiscoveryAvailability } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	ArrowRight,
 	CheckCircle2,
@@ -428,8 +429,11 @@ interface HeaderProps {
 }
 
 const Header = ({ quiInstanceLabel, onRefresh, isRefreshing, quiOpenUrl }: HeaderProps) => {
-	const description = quiInstanceLabel
-		? `Cross-seed siblings across your library via ${quiInstanceLabel}, with tracker-health problems surfaced first. Remediate in qui — siblings are read-only here.`
+	const [incognitoMode] = useIncognitoMode();
+	const displayLabel =
+		quiInstanceLabel && incognitoMode ? getLinuxInstanceName(quiInstanceLabel) : quiInstanceLabel;
+	const description = displayLabel
+		? `Cross-seed siblings across your library via ${displayLabel}, with tracker-health problems surfaced first. Remediate in qui — siblings are read-only here.`
 		: "Surface qui's cross-seed sibling graph across your library and flag tracker-health problems.";
 
 	return (

--- a/apps/web/src/features/hunting/components/hunting-overview.tsx
+++ b/apps/web/src/features/hunting/components/hunting-overview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	Play,
 	Search,
@@ -255,10 +256,13 @@ const InstanceStatusCard = ({
 	};
 
 	const isCurrentlyTriggering = isTriggering && triggeringType !== null;
+	const [incognitoMode] = useIncognitoMode();
 
 	return (
 		<InstanceCard
-			instanceName={instance.instanceName}
+			instanceName={
+				incognitoMode ? getLinuxInstanceName(instance.instanceName) : instance.instanceName
+			}
 			service={instance.service}
 			animationDelay={animationDelay}
 			status={

--- a/apps/web/src/features/indexers/components/indexers-client.tsx
+++ b/apps/web/src/features/indexers/components/indexers-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ProwlarrIndexer, ProwlarrIndexerDetails } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	AlertCircle,
 	CheckCircle2,
@@ -145,16 +146,20 @@ export const IndexersClient = () => {
 
 	// Data
 	const aggregated = useMemo(() => data?.aggregated ?? [], [data?.aggregated]);
+	const [incognitoMode] = useIncognitoMode();
 	const instances = useMemo(() => data?.instances ?? [], [data?.instances]);
 	const noInstances = !isLoading && instances.length === 0;
 
 	const instanceOptions = useMemo(() => {
 		const opts = [{ value: "all", label: "All instances" }];
 		for (const inst of instances) {
-			opts.push({ value: inst.instanceId, label: inst.instanceName });
+			opts.push({
+				value: inst.instanceId,
+				label: incognitoMode ? getLinuxInstanceName(inst.instanceName) : inst.instanceName,
+			});
 		}
 		return opts;
-	}, [instances]);
+	}, [instances, incognitoMode]);
 
 	// Filter + sort
 	const filtered = useMemo(() => {

--- a/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
 
 // Mock the episodes hook to simulate an error state.
 vi.mock("../../../../hooks/api/useLibrary", () => ({
@@ -27,7 +28,11 @@ import { SeasonEpisodeList } from "../season-episode-list";
 
 function wrapper({ children }: { children: ReactNode }) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+	return (
+		<QueryClientProvider client={qc}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>
+	);
 }
 
 describe("<SeasonEpisodeList /> error state microcopy", () => {

--- a/apps/web/src/features/library/components/season-episode-list.tsx
+++ b/apps/web/src/features/library/components/season-episode-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Film, HardDrive, Loader2, PauseCircle, PlayCircle, Search } from "lucide-react";
+import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { useState } from "react";
 import { Button, toast } from "../../../components/ui";
 import {
@@ -37,6 +38,7 @@ export const SeasonEpisodeList = ({
 	seriesId,
 	seasonNumber,
 }: SeasonEpisodeListProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { data, isLoading, isError } = useEpisodesQuery({
 		instanceId,
 		seriesId,
@@ -122,7 +124,7 @@ export const SeasonEpisodeList = ({
 							<div className="flex-1 min-w-0">
 								<div className="flex items-center gap-2">
 									<span className="font-medium text-foreground">E{episode.episodeNumber}</span>
-									<span className="text-muted-foreground truncate">{episode.title || "TBA"}</span>
+									<span className="text-muted-foreground truncate">{incognitoMode ? getLinuxIsoName(episode.title || "TBA") : episode.title || "TBA"}</span>
 									{episode.finaleType && (
 										<span className="text-[10px] uppercase tracking-wider text-amber-400/70 font-medium">
 											{episode.finaleType}

--- a/apps/web/src/features/library/components/torrent-drawer/actions-section.tsx
+++ b/apps/web/src/features/library/components/torrent-drawer/actions-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { QuiAction } from "@arr/shared";
+import { getLinuxIsoName, useIncognitoMode } from "../../../../lib/incognito";
 import { ExternalLink } from "lucide-react";
 import { Button } from "../../../../components/ui/button";
 import { toast } from "../../../../components/ui/toast";
@@ -26,6 +27,7 @@ export const ActionsSection: React.FC<{ copy: SeriesTorrentCopy; canAct: boolean
 	// the priority controls on incompleteness so they never clutter the
 	// drawer for a seeding torrent (an all-seeding library never sees them).
 	const isDownloading = typeof copy.progress === "number" && copy.progress < 1;
+	const [incognitoMode] = useIncognitoMode();
 	const run = (action: QuiAction, verb: string) => {
 		if (!canAct) return;
 		actionMutation.mutate(
@@ -38,7 +40,13 @@ export const ActionsSection: React.FC<{ copy: SeriesTorrentCopy; canAct: boolean
 			},
 			{
 				onSuccess: () =>
-					toast.success(`${verb}: ${copy.name ?? copy.infoHash.slice(0, 12)}`, {
+					toast.success(
+					`${verb}: ${
+						incognitoMode
+							? getLinuxIsoName(copy.name ?? copy.infoHash.slice(0, 12))
+							: (copy.name ?? copy.infoHash.slice(0, 12))
+					}`,
+					{
 						action:
 							action === "pause"
 								? { label: "Undo", onClick: () => run("resume", "Resumed") }

--- a/apps/web/src/features/manual-import/components/candidate-card.tsx
+++ b/apps/web/src/features/manual-import/components/candidate-card.tsx
@@ -1,4 +1,5 @@
 import { Button } from "../../../components/ui/button";
+import { getLinuxIsoName, getLinuxSavePath, useIncognitoMode } from "../../../lib/incognito";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { cn } from "../../../lib/utils";
 import {
@@ -47,6 +48,7 @@ export const CandidateCard = ({
 	onClearEpisodes,
 	disabled = false,
 }: CandidateCardProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const key = candidateKey(candidate);
 	const rejection = describeRejections(candidate);
@@ -131,9 +133,15 @@ export const CandidateCard = ({
 					/>
 					<div className="min-w-0 space-y-2">
 						<div className="space-y-1">
-							<p className="font-medium text-foreground">{describeCandidate(candidate)}</p>
+							<p className="font-medium text-foreground">
+								{incognitoMode
+									? getLinuxIsoName(describeCandidate(candidate))
+									: describeCandidate(candidate)}
+							</p>
 							<p className="wrap-break-word text-xs text-muted-foreground">
-								{candidateDisplayPath(candidate)}
+								{incognitoMode
+									? getLinuxSavePath(candidateDisplayPath(candidate))
+									: candidateDisplayPath(candidate)}
 							</p>
 						</div>
 						{chips.length > 0 && (
@@ -155,10 +163,10 @@ export const CandidateCard = ({
 						<p className="text-xs uppercase text-muted-foreground">Mapping</p>
 						<p>{mappingSummary}</p>
 						{isLidarrCandidate(candidate) && candidate.album?.title && (
-							<p className="text-xs text-muted-foreground/70">{candidate.album.title}</p>
+							<p className="text-xs text-muted-foreground/70">{incognitoMode ? getLinuxIsoName(candidate.album.title) : candidate.album.title}</p>
 						)}
 						{isReadarrCandidate(candidate) && candidate.book?.title && (
-							<p className="text-xs text-muted-foreground/70">{candidate.book.title}</p>
+							<p className="text-xs text-muted-foreground/70">{incognitoMode ? getLinuxIsoName(candidate.book.title) : candidate.book.title}</p>
 						)}
 					</div>
 					{isSonarrCandidate(candidate) && episodes.length > 0 && (
@@ -211,7 +219,11 @@ export const CandidateCard = ({
 												disabled={disabled || !selected}
 											/>
 											<span className="truncate text-xs">
-												{describeEpisode(episode as Parameters<typeof describeEpisode>[0])}
+												{incognitoMode
+													? getLinuxIsoName(
+															describeEpisode(episode as Parameters<typeof describeEpisode>[0]),
+														)
+													: describeEpisode(episode as Parameters<typeof describeEpisode>[0])}
 											</span>
 										</label>
 									);

--- a/apps/web/src/features/manual-import/components/manual-import-modal.tsx
+++ b/apps/web/src/features/manual-import/components/manual-import-modal.tsx
@@ -10,6 +10,7 @@ import {
 	X,
 	XSquare,
 } from "lucide-react";
+import { getLinuxInstanceName, getLinuxSavePath, useIncognitoMode } from "../../../lib/incognito";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
@@ -63,6 +64,7 @@ export const ManualImportModal = ({
 	onOpenChange,
 	onCompleted,
 }: ManualImportModalProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const serviceColor = SERVICE_COLORS[service] ?? themeGradient.from;
 	const { selections, toggleSelection, clear } = useManualImportStore(
@@ -254,13 +256,13 @@ export const ManualImportModal = ({
 						</div>
 						<div>
 							<h2 id="manual-import-title" className="text-xl font-bold text-foreground">
-								Manual Import - {instanceName}
+								Manual Import - {incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}
 							</h2>
 							<p className="text-sm text-muted-foreground">
 								{downloadId
 									? `Download: ${downloadId}`
 									: folder
-										? `Folder: ${folder}`
+										? `Folder: ${incognitoMode ? getLinuxSavePath(folder) : folder}`
 										: "Interactive manual import"}
 							</p>
 						</div>

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { SeerrRequest, SeerrServerWithDetails } from "@arr/shared";
+import { getLinuxSavePath, getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
 import { Loader2 } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -53,6 +54,7 @@ export const ApproveWithOptionsDialog = ({
 	open,
 	onOpenChange,
 }: ApproveWithOptionsDialogProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const profileFieldId = useId();
 	const folderFieldId = useId();
 	const serverFieldId = useId();
@@ -198,7 +200,7 @@ export const ApproveWithOptionsDialog = ({
 								>
 									{filteredServers.map((s) => (
 										<SelectOption key={s.server.id} value={s.server.id}>
-											{s.server.name}
+											{incognitoMode ? getLinuxServerName(s.server.name) : s.server.name}
 											{s.server.isDefault ? " (default)" : ""}
 										</SelectOption>
 									))}
@@ -241,7 +243,7 @@ export const ApproveWithOptionsDialog = ({
 							>
 								{selectedServer.rootFolders.map((f) => (
 									<SelectOption key={f.id} value={f.path}>
-										{f.path}
+										{incognitoMode ? getLinuxSavePath(f.path) : f.path}
 										{f.path === selectedServer.server.activeDirectory ? " (server default)" : ""}
 									</SelectOption>
 								))}


### PR DESCRIPTION
## Summary

First half of charter B6 (`useIncognitoMode` sweep; anchor: Manual Import). **8 surfaces** gain incognito coverage at their render sites — display-only, stored/submitted values never touched.

### The checkpoint review earned its keep again
A 3-agent classification fan-out over 35 candidate files was **spot-verified before implementation** — and 4 verdicts flipped:
- 3 false-OUTs rescued by reading the actual render sites: cross-seed's header renders the qui instance label, the Seerr approve dialog renders server names + root-folder paths, season-episode-list renders episode titles
- 1 false-IN reversed: `indexer-details-panel`'s `instanceName` flows only into the **save payload** — anonymizing it there would have *persisted fake data*

### Surfaces covered
| Surface | Sensitive class |
|---|---|
| Manual Import (anchor — candidate card + modal) | titles (movie/album/book/episode), file paths, instance name, folder |
| Hunting overview | instance card labels |
| Indexers | instance filter option labels |
| Cross-Seed header | qui instance label |
| Seerr approve dialog | server names + root-folder paths (option *display* only — values stay real) |
| Library episode list | episode titles |
| Torrent drawer toasts | torrent names (toasts are screenshot-visible) |

### Live-verified
Toggling the topbar control: hunting cards anonymize ("Primary Radarr" → "Radarr 4K"); the indexers page renders with **zero real instance names** (`hasPrimary: false` across the full body).

### Not in this PR (B6b follow-up)
13 trash-guides deploy-flow modals (instance labels) + the rule-dialog username options, which need `MultiSelectField` display-vs-value support — structurally different work.

## Validation
498 web tests green (episode-list test gains the `IncognitoProvider` wrapper per CLAUDE.md rule 6); turbo typecheck + lint clean; live toggle verification on two surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)