### PR TITLE
feat(web): incognito sweep — deploy flows + username selects (Bucket B6b)

### DIFF
--- a/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CrossSeedDiscoveryAvailability } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	ArrowRight,
 	CheckCircle2,
@@ -428,8 +429,11 @@ interface HeaderProps {
 }
 
 const Header = ({ quiInstanceLabel, onRefresh, isRefreshing, quiOpenUrl }: HeaderProps) => {
-	const description = quiInstanceLabel
-		? `Cross-seed siblings across your library via ${quiInstanceLabel}, with tracker-health problems surfaced first. Remediate in qui — siblings are read-only here.`
+	const [incognitoMode] = useIncognitoMode();
+	const displayLabel =
+		quiInstanceLabel && incognitoMode ? getLinuxInstanceName(quiInstanceLabel) : quiInstanceLabel;
+	const description = displayLabel
+		? `Cross-seed siblings across your library via ${displayLabel}, with tracker-health problems surfaced first. Remediate in qui — siblings are read-only here.`
 		: "Surface qui's cross-seed sibling graph across your library and flag tracker-health problems.";
 
 	return (

--- a/apps/web/src/features/hunting/components/hunting-overview.tsx
+++ b/apps/web/src/features/hunting/components/hunting-overview.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	Play,
 	Search,
@@ -255,10 +256,13 @@ const InstanceStatusCard = ({
 	};
 
 	const isCurrentlyTriggering = isTriggering && triggeringType !== null;
+	const [incognitoMode] = useIncognitoMode();
 
 	return (
 		<InstanceCard
-			instanceName={instance.instanceName}
+			instanceName={
+				incognitoMode ? getLinuxInstanceName(instance.instanceName) : instance.instanceName
+			}
 			service={instance.service}
 			animationDelay={animationDelay}
 			status={

--- a/apps/web/src/features/indexers/components/indexers-client.tsx
+++ b/apps/web/src/features/indexers/components/indexers-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ProwlarrIndexer, ProwlarrIndexerDetails } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	AlertCircle,
 	CheckCircle2,
@@ -145,16 +146,20 @@ export const IndexersClient = () => {
 
 	// Data
 	const aggregated = useMemo(() => data?.aggregated ?? [], [data?.aggregated]);
+	const [incognitoMode] = useIncognitoMode();
 	const instances = useMemo(() => data?.instances ?? [], [data?.instances]);
 	const noInstances = !isLoading && instances.length === 0;
 
 	const instanceOptions = useMemo(() => {
 		const opts = [{ value: "all", label: "All instances" }];
 		for (const inst of instances) {
-			opts.push({ value: inst.instanceId, label: inst.instanceName });
+			opts.push({
+				value: inst.instanceId,
+				label: incognitoMode ? getLinuxInstanceName(inst.instanceName) : inst.instanceName,
+			});
 		}
 		return opts;
-	}, [instances]);
+	}, [instances, incognitoMode]);
 
 	// Filter + sort
 	const filtered = useMemo(() => {

--- a/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
@@ -1,4 +1,5 @@
 import type { CleanupRuleResponse, CreateCleanupRule } from "@arr/shared";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -96,7 +97,9 @@ function createWrapper() {
 		defaultOptions: { queries: { retry: false, gcTime: 0 } },
 	});
 	return ({ children }: { children: ReactNode }) => (
-		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		<QueryClientProvider client={queryClient}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>
 	);
 }
 

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -7,6 +7,7 @@ import type {
 	CreateCleanupRule,
 } from "@arr/shared";
 import type { LucideIcon } from "lucide-react";
+import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
 import {
 	Brain,
 	ChevronDown,
@@ -2028,6 +2029,7 @@ interface ParamsFieldsProps {
 }
 
 function ParamsFields(props: ParamsFieldsProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const {
 		ruleType,
 		days,
@@ -2856,6 +2858,7 @@ function ParamsFields(props: ParamsFieldsProps) {
 					<MultiSelectField
 						label="Plex Users"
 						options={fieldOptions?.plexUsers ?? []}
+						displayValue={incognitoMode ? getLinuxUsername : undefined}
 						selected={selectedPlexUsers}
 						onChange={setSelectedPlexUsers}
 						loading={fieldOptionsLoading}
@@ -3239,6 +3242,7 @@ function ParamsFields(props: ParamsFieldsProps) {
 					<MultiSelectField
 						label="Jellyfin Users"
 						options={fieldOptions?.jellyfinUsers ?? []}
+						displayValue={incognitoMode ? getLinuxUsername : undefined}
 						selected={selectedJellyfinUsers}
 						onChange={setSelectedJellyfinUsers}
 						loading={fieldOptionsLoading}

--- a/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
@@ -15,6 +15,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
 
 // Mock the episodes hook to simulate an error state.
 vi.mock("../../../../hooks/api/useLibrary", () => ({
@@ -27,7 +28,11 @@ import { SeasonEpisodeList } from "../season-episode-list";
 
 function wrapper({ children }: { children: ReactNode }) {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-	return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+	return (
+		<QueryClientProvider client={qc}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>
+	);
 }
 
 describe("<SeasonEpisodeList /> error state microcopy", () => {

--- a/apps/web/src/features/library/components/season-episode-list.tsx
+++ b/apps/web/src/features/library/components/season-episode-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Film, HardDrive, Loader2, PauseCircle, PlayCircle, Search } from "lucide-react";
+import { getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { useState } from "react";
 import { Button, toast } from "../../../components/ui";
 import {
@@ -37,6 +38,7 @@ export const SeasonEpisodeList = ({
 	seriesId,
 	seasonNumber,
 }: SeasonEpisodeListProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { data, isLoading, isError } = useEpisodesQuery({
 		instanceId,
 		seriesId,
@@ -122,7 +124,7 @@ export const SeasonEpisodeList = ({
 							<div className="flex-1 min-w-0">
 								<div className="flex items-center gap-2">
 									<span className="font-medium text-foreground">E{episode.episodeNumber}</span>
-									<span className="text-muted-foreground truncate">{episode.title || "TBA"}</span>
+									<span className="text-muted-foreground truncate">{incognitoMode ? getLinuxIsoName(episode.title || "TBA") : episode.title || "TBA"}</span>
 									{episode.finaleType && (
 										<span className="text-[10px] uppercase tracking-wider text-amber-400/70 font-medium">
 											{episode.finaleType}

--- a/apps/web/src/features/library/components/torrent-drawer/actions-section.tsx
+++ b/apps/web/src/features/library/components/torrent-drawer/actions-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { QuiAction } from "@arr/shared";
+import { getLinuxIsoName, useIncognitoMode } from "../../../../lib/incognito";
 import { ExternalLink } from "lucide-react";
 import { Button } from "../../../../components/ui/button";
 import { toast } from "../../../../components/ui/toast";
@@ -26,6 +27,7 @@ export const ActionsSection: React.FC<{ copy: SeriesTorrentCopy; canAct: boolean
 	// the priority controls on incompleteness so they never clutter the
 	// drawer for a seeding torrent (an all-seeding library never sees them).
 	const isDownloading = typeof copy.progress === "number" && copy.progress < 1;
+	const [incognitoMode] = useIncognitoMode();
 	const run = (action: QuiAction, verb: string) => {
 		if (!canAct) return;
 		actionMutation.mutate(
@@ -38,7 +40,13 @@ export const ActionsSection: React.FC<{ copy: SeriesTorrentCopy; canAct: boolean
 			},
 			{
 				onSuccess: () =>
-					toast.success(`${verb}: ${copy.name ?? copy.infoHash.slice(0, 12)}`, {
+					toast.success(
+					`${verb}: ${
+						incognitoMode
+							? getLinuxIsoName(copy.name ?? copy.infoHash.slice(0, 12))
+							: (copy.name ?? copy.infoHash.slice(0, 12))
+					}`,
+					{
 						action:
 							action === "pause"
 								? { label: "Undo", onClick: () => run("resume", "Resumed") }

--- a/apps/web/src/features/manual-import/components/candidate-card.tsx
+++ b/apps/web/src/features/manual-import/components/candidate-card.tsx
@@ -1,4 +1,5 @@
 import { Button } from "../../../components/ui/button";
+import { getLinuxIsoName, getLinuxSavePath, useIncognitoMode } from "../../../lib/incognito";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { cn } from "../../../lib/utils";
 import {
@@ -47,6 +48,7 @@ export const CandidateCard = ({
 	onClearEpisodes,
 	disabled = false,
 }: CandidateCardProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const key = candidateKey(candidate);
 	const rejection = describeRejections(candidate);
@@ -131,9 +133,15 @@ export const CandidateCard = ({
 					/>
 					<div className="min-w-0 space-y-2">
 						<div className="space-y-1">
-							<p className="font-medium text-foreground">{describeCandidate(candidate)}</p>
+							<p className="font-medium text-foreground">
+								{incognitoMode
+									? getLinuxIsoName(describeCandidate(candidate))
+									: describeCandidate(candidate)}
+							</p>
 							<p className="wrap-break-word text-xs text-muted-foreground">
-								{candidateDisplayPath(candidate)}
+								{incognitoMode
+									? getLinuxSavePath(candidateDisplayPath(candidate))
+									: candidateDisplayPath(candidate)}
 							</p>
 						</div>
 						{chips.length > 0 && (
@@ -155,10 +163,10 @@ export const CandidateCard = ({
 						<p className="text-xs uppercase text-muted-foreground">Mapping</p>
 						<p>{mappingSummary}</p>
 						{isLidarrCandidate(candidate) && candidate.album?.title && (
-							<p className="text-xs text-muted-foreground/70">{candidate.album.title}</p>
+							<p className="text-xs text-muted-foreground/70">{incognitoMode ? getLinuxIsoName(candidate.album.title) : candidate.album.title}</p>
 						)}
 						{isReadarrCandidate(candidate) && candidate.book?.title && (
-							<p className="text-xs text-muted-foreground/70">{candidate.book.title}</p>
+							<p className="text-xs text-muted-foreground/70">{incognitoMode ? getLinuxIsoName(candidate.book.title) : candidate.book.title}</p>
 						)}
 					</div>
 					{isSonarrCandidate(candidate) && episodes.length > 0 && (
@@ -211,7 +219,11 @@ export const CandidateCard = ({
 												disabled={disabled || !selected}
 											/>
 											<span className="truncate text-xs">
-												{describeEpisode(episode as Parameters<typeof describeEpisode>[0])}
+												{incognitoMode
+													? getLinuxIsoName(
+															describeEpisode(episode as Parameters<typeof describeEpisode>[0]),
+														)
+													: describeEpisode(episode as Parameters<typeof describeEpisode>[0])}
 											</span>
 										</label>
 									);

--- a/apps/web/src/features/manual-import/components/manual-import-modal.tsx
+++ b/apps/web/src/features/manual-import/components/manual-import-modal.tsx
@@ -10,6 +10,7 @@ import {
 	X,
 	XSquare,
 } from "lucide-react";
+import { getLinuxInstanceName, getLinuxSavePath, useIncognitoMode } from "../../../lib/incognito";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useShallow } from "zustand/shallow";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
@@ -63,6 +64,7 @@ export const ManualImportModal = ({
 	onOpenChange,
 	onCompleted,
 }: ManualImportModalProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const serviceColor = SERVICE_COLORS[service] ?? themeGradient.from;
 	const { selections, toggleSelection, clear } = useManualImportStore(
@@ -254,13 +256,13 @@ export const ManualImportModal = ({
 						</div>
 						<div>
 							<h2 id="manual-import-title" className="text-xl font-bold text-foreground">
-								Manual Import - {instanceName}
+								Manual Import - {incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}
 							</h2>
 							<p className="text-sm text-muted-foreground">
 								{downloadId
 									? `Download: ${downloadId}`
 									: folder
-										? `Folder: ${folder}`
+										? `Folder: ${incognitoMode ? getLinuxSavePath(folder) : folder}`
 										: "Interactive manual import"}
 							</p>
 						</div>

--- a/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
+++ b/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CleanupFieldOptionsResponse, CleanupRuleType } from "@arr/shared";
+import { getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
 import { ToggleSwitch } from "@/components/layout/config-primitives";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
 import { MultiSelectField } from "./multi-select-field";
@@ -128,6 +129,7 @@ export function ConditionParamsFields({
 	inputClass,
 	labelClass,
 }: ConditionParamsFieldsProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient } = useThemeGradient();
 	const get = <T,>(key: string, def: T): T => (params[key] as T) ?? def;
 	const set = (key: string, val: unknown) => onParamsChange({ ...params, [key]: val });
@@ -906,6 +908,7 @@ export function ConditionParamsFields({
 					<MultiSelectField
 						label="Plex Users"
 						options={fieldOptions?.plexUsers ?? []}
+						displayValue={incognitoMode ? getLinuxUsername : undefined}
 						selected={get("userNames", []) as string[]}
 						onChange={(v) => set("userNames", v)}
 						loading={fieldOptionsLoading}

--- a/apps/web/src/features/rule-criteria/components/multi-select-field.tsx
+++ b/apps/web/src/features/rule-criteria/components/multi-select-field.tsx
@@ -16,6 +16,13 @@ interface MultiSelectFieldProps {
 	loading?: boolean;
 	inputClass: string;
 	labelClass: string;
+	/**
+	 * Optional display transform (e.g. incognito anonymization). Applied to
+	 * the rendered option text ONLY — selection, filtering, select-all and
+	 * the stored values all operate on the real values. Incognito is a
+	 * screenshot mode; filtering still matches the real (hidden) value.
+	 */
+	displayValue?: (value: string) => string;
 }
 
 // ============================================================================
@@ -30,6 +37,7 @@ export function MultiSelectField({
 	loading,
 	inputClass,
 	labelClass,
+	displayValue,
 }: MultiSelectFieldProps) {
 	const { gradient } = useThemeGradient();
 	const [filter, setFilter] = useState("");
@@ -159,7 +167,7 @@ export function MultiSelectField({
 											onChange={() => toggle(value)}
 											className="sr-only"
 										/>
-										<span className="truncate">{value}</span>
+										<span className="truncate">{displayValue ? displayValue(value) : value}</span>
 									</label>
 								);
 							})

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -10,6 +10,7 @@
  */
 
 import type { SeerrRequest, SeerrServerWithDetails } from "@arr/shared";
+import { getLinuxSavePath, getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
 import { Loader2 } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -53,6 +54,7 @@ export const ApproveWithOptionsDialog = ({
 	open,
 	onOpenChange,
 }: ApproveWithOptionsDialogProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const profileFieldId = useId();
 	const folderFieldId = useId();
 	const serverFieldId = useId();
@@ -198,7 +200,7 @@ export const ApproveWithOptionsDialog = ({
 								>
 									{filteredServers.map((s) => (
 										<SelectOption key={s.server.id} value={s.server.id}>
-											{s.server.name}
+											{incognitoMode ? getLinuxServerName(s.server.name) : s.server.name}
 											{s.server.isDefault ? " (default)" : ""}
 										</SelectOption>
 									))}
@@ -241,7 +243,7 @@ export const ApproveWithOptionsDialog = ({
 							>
 								{selectedServer.rootFolders.map((f) => (
 									<SelectOption key={f.id} value={f.path}>
-										{f.path}
+										{incognitoMode ? getLinuxSavePath(f.path) : f.path}
 										{f.path === selectedServer.server.activeDirectory ? " (server default)" : ""}
 									</SelectOption>
 								))}

--- a/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
@@ -10,6 +10,7 @@
  */
 
 import { useState, useEffect, useMemo } from "react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { trashGuidesKeys } from "../../../lib/query-keys";
 import { useQueryClient } from "@tanstack/react-query";
 import {
@@ -172,6 +173,7 @@ export const BulkDeploymentModal = ({
 }: BulkDeploymentModalProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const queryClient = useQueryClient();
+	const [incognitoMode] = useIncognitoMode();
 	// Track selection state and sync strategies per instance
 	const [selectedInstances, setSelectedInstances] = useState<Set<string>>(new Set());
 	const [syncStrategies, setSyncStrategies] = useState<Record<string, SyncStrategy>>({});
@@ -420,7 +422,7 @@ export const BulkDeploymentModal = ({
 								{/* Instance info */}
 								<Server className="h-4 w-4 text-muted-foreground shrink-0" />
 								<span className="text-sm font-medium text-foreground flex-1 min-w-0 truncate">
-									{inst.instanceLabel}
+									{incognitoMode ? getLinuxInstanceName(inst.instanceLabel) : inst.instanceLabel}
 								</span>
 
 								{/* Quality config override indicator/button */}

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -12,6 +12,7 @@
 "use client";
 
 import type { CustomFormatScoreEntry } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useQueryClient } from "@tanstack/react-query";
 import { bulkScoreKeys } from "../../../lib/query-keys";
 import {
@@ -61,6 +62,7 @@ interface BulkScoreManagerProps {
 }
 
 export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkScoreManagerProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const queryClient = useQueryClient();
 
@@ -479,7 +481,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 								)
 								.map((instance) => (
 									<option key={instance.id} value={instance.id}>
-										{instance.label} ({instance.service.toUpperCase()})
+										{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label} ({instance.service.toUpperCase()})
 									</option>
 								))}
 						</select>

--- a/apps/web/src/features/trash-guides/components/deploy-cf-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deploy-cf-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertCircle, ChevronDown, Download, Loader2, X } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 
@@ -31,6 +32,7 @@ const DeployCFModal = ({
 	onClose,
 	isPending,
 }: DeployCFModalProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 
 	return (
@@ -141,7 +143,7 @@ const DeployCFModal = ({
 									<option value="">Choose an instance...</option>
 									{availableInstances.map((instance) => (
 										<option key={instance.id} value={instance.id}>
-											{instance.label} ({instance.service})
+											{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label} ({instance.service})
 										</option>
 									))}
 								</select>

--- a/apps/web/src/features/trash-guides/components/deployment-history-details-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-history-details-modal.tsx
@@ -2,6 +2,7 @@
 
 import { format } from "date-fns";
 import { AlertCircle, CheckCircle2, History, XCircle } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
 import {
 	Button,
@@ -27,6 +28,7 @@ export function DeploymentHistoryDetailsModal({
 	onClose,
 	onUndeploy,
 }: DeploymentHistoryDetailsModalProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const { data, isLoading, error } = useDeploymentHistoryDetail(historyId);
 
@@ -116,7 +118,7 @@ export function DeploymentHistoryDetailsModal({
 							<div className="grid grid-cols-2 gap-4">
 								{data.data.instance && (
 									<>
-										<InfoField label="Instance" value={data.data.instance.label} />
+										<InfoField label="Instance" value={incognitoMode ? getLinuxInstanceName(data.data.instance.label) : data.data.instance.label} />
 										<InfoField label="Instance Service" value={data.data.instance.service} />
 									</>
 								)}

--- a/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
@@ -16,6 +16,7 @@ import {
 	Settings,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
 import {
 	Button,
@@ -57,6 +58,7 @@ export const DeploymentPreviewModal = ({
 	instanceLabel,
 	onDeploySuccess,
 }: DeploymentPreviewModalProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const { data, isLoading, error } = useDeploymentPreview(templateId, instanceId);
 	const [expandedConflicts, setExpandedConflicts] = useState<Set<string>>(new Set());
@@ -283,7 +285,7 @@ export const DeploymentPreviewModal = ({
 								<div className="flex-1">
 									<h3 className="text-sm font-medium text-foreground">Target Instance</h3>
 									<p className="text-xs text-muted-foreground">
-										{data.data.instanceLabel} ({data.data.instanceServiceType})
+										{incognitoMode ? getLinuxInstanceName(data.data.instanceLabel) : data.data.instanceLabel} ({data.data.instanceServiceType})
 									</p>
 								</div>
 								<div className="flex items-center gap-2">

--- a/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
+++ b/apps/web/src/features/trash-guides/components/instance-override-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertCircle, RotateCcw, Save, Settings, Trash2 } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
@@ -53,6 +54,7 @@ export const InstanceOverrideEditor = ({
 	instanceLabel,
 	customFormats,
 }: InstanceOverrideEditorProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const { data, isLoading, error, refetch } = useInstanceOverrides(templateId, instanceId);
 	const updateMutation = useUpdateInstanceOverrides();
 	const deleteMutation = useDeleteInstanceOverrides();
@@ -230,7 +232,7 @@ export const InstanceOverrideEditor = ({
 				<LegacyDialogDescription>
 					Customize Custom Format scores and enable/disable CFs for this instance
 					{templateName && ` - Template: "${templateName}"`}
-					{instanceLabel && ` → Instance: "${instanceLabel}"`}
+					{instanceLabel && ` → Instance: "${incognitoMode ? getLinuxInstanceName(instanceLabel) : instanceLabel}"`}
 				</LegacyDialogDescription>
 			</LegacyDialogHeader>
 

--- a/apps/web/src/features/trash-guides/components/instance-overrides-panel.tsx
+++ b/apps/web/src/features/trash-guides/components/instance-overrides-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { CustomQualityConfig, TemplateInstanceOverride, TrashTemplate } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	AlertTriangle,
 	Check,
@@ -48,6 +49,7 @@ export const InstanceOverridesPanel = ({
 	instances,
 	onOverrideChanged,
 }: InstanceOverridesPanelProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const [isExpanded, setIsExpanded] = useState(false);
 	const [editingInstance, setEditingInstance] = useState<ServiceInstance | null>(null);
 
@@ -192,7 +194,7 @@ export const InstanceOverridesPanel = ({
 										<Server className="h-4 w-4 text-muted-foreground shrink-0" />
 										<div className="min-w-0">
 											<div className="text-sm font-medium text-foreground truncate">
-												{status.instanceLabel}
+												{incognitoMode ? getLinuxInstanceName(status.instanceLabel) : status.instanceLabel}
 											</div>
 											{status.hasQualityOverride && status.qualityOverride ? (
 												<div className="flex items-center gap-2 text-xs text-muted-foreground">

--- a/apps/web/src/features/trash-guides/components/instance-quality-override-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/instance-quality-override-modal.tsx
@@ -2,6 +2,7 @@
 
 import type { CustomQualityConfig } from "@arr/shared";
 import { AlertCircle, Check, Info, Loader2, RotateCcw, Save, Server, Sliders } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "../../../components/ui";
 import {
@@ -48,6 +49,7 @@ export const InstanceQualityOverrideModal = ({
 	templateDefaultConfig,
 	onSaved,
 }: InstanceQualityOverrideModalProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	// State
 	const [config, setConfig] = useState<CustomQualityConfig>({
 		useCustomQualities: false,
@@ -187,11 +189,11 @@ export const InstanceQualityOverrideModal = ({
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
 						<Server className="h-5 w-5 text-purple-500" />
-						Quality Settings for {instanceLabel}
+						Quality Settings for {incognitoMode ? getLinuxInstanceName(instanceLabel) : instanceLabel}
 					</DialogTitle>
 					<DialogDescription>
 						Customize quality settings for{" "}
-						<strong className="text-foreground">{instanceLabel}</strong> only. Other instances using
+						<strong className="text-foreground">{incognitoMode ? getLinuxInstanceName(instanceLabel) : instanceLabel}</strong> only. Other instances using
 						&ldquo;{templateName}&rdquo; will not be affected.
 					</DialogDescription>
 				</DialogHeader>
@@ -322,7 +324,7 @@ export const InstanceQualityOverrideModal = ({
 												</span>
 											</div>
 											<p className="text-xs text-muted-foreground pl-7">
-												Different settings just for {instanceLabel}.
+												Different settings just for {incognitoMode ? getLinuxInstanceName(instanceLabel) : instanceLabel}.
 											</p>
 										</button>
 									</div>

--- a/apps/web/src/features/trash-guides/components/naming-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/naming-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ServiceInstanceSummary } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import type { NamingFieldComparison, NamingPresetsResponse } from "@arr/shared";
 import {
 	AlertCircle,
@@ -255,6 +256,7 @@ function PreviewTable({
 // ============================================================================
 
 export function NamingManager() {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const { data: services, isLoading: servicesLoading, error: servicesError } = useServicesQuery();
 
@@ -546,7 +548,7 @@ export function NamingManager() {
 										/>
 										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-2">
-												<span className="text-sm font-medium truncate">{instance.label}</span>
+												<span className="text-sm font-medium truncate">{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}</span>
 												<ServiceBadge service={instance.service} />
 											</div>
 											{hasSavedConfig && (
@@ -725,7 +727,7 @@ export function NamingManager() {
 											/>
 											<span className="text-sm">
 												Apply {previewMutation.data.preview.changedCount} naming change(s) to{" "}
-												<strong>{selectedInstance?.label}</strong>? This will overwrite the current
+												<strong>{selectedInstance && (incognitoMode ? getLinuxInstanceName(selectedInstance.label) : selectedInstance.label)}</strong>? This will overwrite the current
 												naming config.
 											</span>
 											<button

--- a/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-importer.tsx
@@ -11,6 +11,7 @@
 
 import type { CompleteQualityProfile } from "@arr/shared";
 import { AlertCircle, CheckCircle, ChevronRight, Download, Info } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useState } from "react";
 import {
 	Alert,
@@ -34,6 +35,7 @@ export function QualityProfileImporter({
 	onImportComplete,
 	onClose,
 }: QualityProfileImporterProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
 	const [selectedProfileId, setSelectedProfileId] = useState<number | null>(null);
 	const [importedProfile, setImportedProfile] = useState<CompleteQualityProfile | null>(null);
@@ -119,7 +121,7 @@ export function QualityProfileImporter({
 					<SelectOption value="">Select an instance...</SelectOption>
 					{instances?.map((instance) => (
 						<SelectOption key={instance.id} value={instance.id}>
-							{instance.label} ({instance.service})
+							{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label} ({instance.service})
 						</SelectOption>
 					))}
 				</NativeSelect>
@@ -210,7 +212,7 @@ export function QualityProfileImporter({
 							</div>
 							<div>
 								<span className="text-muted-foreground">Source Instance:</span>
-								<div className="font-medium text-foreground">{selectedInstance?.label}</div>
+								<div className="font-medium text-foreground">{selectedInstance && (incognitoMode ? getLinuxInstanceName(selectedInstance.label) : selectedInstance.label)}</div>
 							</div>
 							<div>
 								<span className="text-muted-foreground">Upgrade Allowed:</span>

--- a/apps/web/src/features/trash-guides/components/quality-size-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-size-manager.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ServiceInstanceSummary } from "@arr/shared";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import {
 	AlertCircle,
 	AlertTriangle,
@@ -64,6 +65,7 @@ function ErrorBanner({ message }: { message: string }) {
 // ============================================================================
 
 export function QualitySizeManager() {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
 	const { data: services, isLoading: servicesLoading, error: servicesError } = useServicesQuery();
 
@@ -217,7 +219,7 @@ export function QualitySizeManager() {
 										/>
 										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-2">
-												<span className="text-sm font-medium truncate">{instance.label}</span>
+												<span className="text-sm font-medium truncate">{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}</span>
 												<ServiceBadge service={instance.service} />
 											</div>
 										</div>
@@ -339,7 +341,7 @@ export function QualitySizeManager() {
 								<p className="text-sm font-medium">Reset to Factory Defaults</p>
 								<p className="text-sm text-muted-foreground mt-1">
 									This will restore all quality size definitions on{" "}
-									<span className="font-medium text-foreground">{selectedInstance?.label}</span> to
+									<span className="font-medium text-foreground">{selectedInstance && (incognitoMode ? getLinuxInstanceName(selectedInstance.label) : selectedInstance.label)}</span> to
 									the original values set by{" "}
 									{selectedInstance?.service === "sonarr" ? "Sonarr" : "Radarr"}. Any previously
 									applied TRaSH preset will be removed.

--- a/apps/web/src/features/trash-guides/components/template-instance-selector.tsx
+++ b/apps/web/src/features/trash-guides/components/template-instance-selector.tsx
@@ -8,6 +8,7 @@
  */
 
 import { AlertCircle, Layers, Rocket, X } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 
 interface TemplateInstanceSelectorProps {
 	templateName: string;
@@ -25,7 +26,9 @@ export const TemplateInstanceSelector = ({
 	onSelectInstance,
 	onBulkDeploy,
 	onClose,
-}: TemplateInstanceSelectorProps) => (
+}: TemplateInstanceSelectorProps) => {
+	const [incognitoMode] = useIncognitoMode();
+	return (
 	<div
 		className="fixed inset-0 bg-black/80 backdrop-blur-xs flex items-center justify-center z-modal p-4 animate-in fade-in duration-200"
 		role="dialog"
@@ -97,7 +100,7 @@ export const TemplateInstanceSelector = ({
 							>
 								<div>
 									<div className="font-medium text-foreground group-hover:text-foreground transition-colors">
-										{instance.label}
+										{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}
 									</div>
 									<div className="text-sm text-muted-foreground mt-1">{instance.service}</div>
 								</div>
@@ -132,3 +135,4 @@ export const TemplateInstanceSelector = ({
 		</div>
 	</div>
 );
+};

--- a/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
+++ b/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertCircle, Check, FileJson, Loader2, Plus, Server, Upload } from "lucide-react";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useCallback, useState } from "react";
 import { PremiumTabs } from "../../../components/layout/premium-components";
 import { Button } from "../../../components/ui";
@@ -49,6 +50,7 @@ export function UserCFImportDialog({
 	onOpenChange,
 	defaultServiceType = "RADARR",
 }: UserCFImportDialogProps) {
+	const [incognitoMode] = useIncognitoMode();
 	const { gradient } = useThemeGradient();
 	const [activeTab, setActiveTab] = useState("create");
 
@@ -456,6 +458,7 @@ function InstanceImportTab({
 	onSuccess: () => void;
 	gradient: { from: string; fromLight: string };
 }) {
+	const [incognitoMode] = useIncognitoMode();
 	const [selectedInstanceId, setSelectedInstanceId] = useState("");
 	const [instanceCFs, setInstanceCFs] = useState<
 		Array<{ id: number; name: string; checked: boolean }>
@@ -550,7 +553,7 @@ function InstanceImportTab({
 						<option value="">Choose an instance...</option>
 						{arrInstances.map((instance) => (
 							<option key={instance.id} value={instance.id}>
-								{instance.label} ({instance.service})
+								{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label} ({instance.service})
 							</option>
 						))}
 					</select>


### PR DESCRIPTION
## Summary

Completes charter B6 (with #525). **16 files**: 13 trash-guides deploy-flow surfaces wrap every visible instance-label render; the shared `MultiSelectField` gains a `displayValue` transform so the rule dialogs' Plex/Jellyfin user options anonymize in incognito.

### Display-vs-data invariant, enforced three ways
- `displayValue` applies to rendered option text **only** — selection, filtering, select-all, and stored values all operate on real values (structurally incapable of corrupting saves)
- Prop pass-throughs stay raw; children anonymize their own renders
- **Seerr username text inputs deliberately excluded**: they're read-write — anonymizing an input value would round-trip fake usernames into saved rules. The classifier suggested them; the checkpoint review rejected them (same trap class as B6a's indexer-details false-IN)

### Live-verified (incognito on, dev stack)
- Plex Users multi-select renders only fakes (`root/penguin/maintainer/admin`) — **zero real-username leaks** in the full page body, checked against all 9 known users
- Quality Size instance buttons render `Radarr 4K`/`Sonarr Main`, `hasPrimary: false`

### Scope notes
Public TRaSH guide data (template/CF names, scores) deliberately untouched — not in CLAUDE.md rule 6's sensitive classes. `cleanup-rule-dialog` tests gain the `IncognitoProvider` wrapper.

**Charter B6 is complete with this PR.**

## Validation
498 web tests, turbo typecheck + lint green, two-surface live verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)