### PR TITLE
feat(web): DataFreshness adoption — four trust-correct surfaces (Bucket B4)

### DIFF
--- a/apps/web/src/features/calendar/components/calendar-client.tsx
+++ b/apps/web/src/features/calendar/components/calendar-client.tsx
@@ -31,7 +31,8 @@ export const CalendarClient = () => {
 		[calendarStart, calendarEnd, filters.includeUnmonitored],
 	);
 
-	const { data, isLoading, error, refetch } = useMultiInstanceCalendarQuery(queryParams);
+	const { data, isLoading, error, refetch, dataUpdatedAt, isFetching, isError } =
+		useMultiInstanceCalendarQuery(queryParams);
 
 	const { data: services } = useServicesQuery();
 
@@ -141,6 +142,9 @@ export const CalendarClient = () => {
 			<CalendarHeader
 				monthStart={monthStart}
 				isLoading={isLoading}
+				dataUpdatedAt={dataUpdatedAt}
+				isFetching={isFetching}
+				isError={isError}
 				onPreviousMonth={calendarState.handlePreviousMonth}
 				onNextMonth={calendarState.handleNextMonth}
 				onGoToday={calendarState.handleGoToday}

--- a/apps/web/src/features/calendar/components/calendar-header.tsx
+++ b/apps/web/src/features/calendar/components/calendar-header.tsx
@@ -1,11 +1,16 @@
 "use client";
 
 import { ChevronLeft, ChevronRight, Dot, RefreshCw } from "lucide-react";
+import { DataFreshness } from "../../../components/layout";
+import { POLLING_STANDARD } from "../../../lib/polling-intervals";
 import { useRefreshState } from "../../../hooks/useRefreshState";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { formatMonthLabel } from "../lib/calendar-formatters";
 
 interface CalendarHeaderProps {
+	dataUpdatedAt?: number;
+	isFetching?: boolean;
+	isError?: boolean;
 	monthStart: Date;
 	isLoading: boolean;
 	onPreviousMonth: () => void;
@@ -15,6 +20,9 @@ interface CalendarHeaderProps {
 }
 
 export const CalendarHeader = ({
+	dataUpdatedAt,
+	isFetching,
+	isError,
 	monthStart,
 	isLoading,
 	onPreviousMonth,
@@ -88,7 +96,14 @@ export const CalendarHeader = ({
 				</div>
 
 				{/* Right: Actions */}
-				<div className="flex items-center gap-1">
+				<div className="flex items-center gap-3">
+					{/* Calendar feed freshness (single polled query drives the grid) */}
+					<DataFreshness
+						dataUpdatedAt={dataUpdatedAt}
+						isFetching={isFetching}
+						isError={isError}
+						pollIntervalMs={POLLING_STANDARD}
+					/>
 					<button
 						type="button"
 						onClick={onGoToday}

--- a/apps/web/src/features/hunting/components/hunting-client.tsx
+++ b/apps/web/src/features/hunting/components/hunting-client.tsx
@@ -1,13 +1,9 @@
 "use client";
 
 import { Activity, RefreshCw, Settings, Target } from "lucide-react";
+import { POLLING_ACTIVE } from "../../../lib/polling-intervals";
 import { useState } from "react";
-import {
-	PremiumPageHeader,
-	PremiumPageLoading,
-	type PremiumTab,
-	PremiumTabs,
-} from "../../../components/layout";
+import { DataFreshness, PremiumPageHeader, PremiumPageLoading, PremiumTabs, type PremiumTab } from "../../../components/layout";
 import { Alert, AlertDescription, Button } from "../../../components/ui";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { useHuntingStatus } from "../hooks/useHuntingStatus";
@@ -29,7 +25,8 @@ export const HuntingClient = () => {
 	const { gradient: _themeGradient } = useThemeGradient();
 
 	const [activeTab, setActiveTab] = useState<HuntingTab>("overview");
-	const { status, isLoading, error, refetch } = useHuntingStatus();
+	const { status, isLoading, error, refetch, dataUpdatedAt, isFetching, isError } =
+		useHuntingStatus();
 
 	// Tab configuration with gradient styling
 	const tabs: PremiumTab[] = [
@@ -75,7 +72,18 @@ export const HuntingClient = () => {
 				gradientTitle
 				description="Automatically search for missing content and quality upgrades across your Sonarr and Radarr instances"
 				actions={
-					<Button
+					<div className="flex items-center gap-3">
+						{/* Status feed freshness — only honest on the overview tab;
+						    Activity/Config render different (or no) polled data. */}
+						{activeTab === "overview" && (
+							<DataFreshness
+								dataUpdatedAt={dataUpdatedAt}
+								isFetching={isFetching}
+								isError={isError}
+								pollIntervalMs={POLLING_ACTIVE}
+							/>
+						)}
+						<Button
 						variant="secondary"
 						onClick={() => void refetch()}
 						className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
@@ -83,6 +91,7 @@ export const HuntingClient = () => {
 						<RefreshCw className="h-4 w-4" />
 						Refresh
 					</Button>
+					</div>
 				}
 			/>
 

--- a/apps/web/src/features/hunting/hooks/useHuntingStatus.ts
+++ b/apps/web/src/features/hunting/hooks/useHuntingStatus.ts
@@ -34,5 +34,9 @@ export function useHuntingStatus() {
 		isLoading: query.isLoading,
 		error: query.error,
 		refetch: query.refetch,
+		// Freshness inputs for <DataFreshness> (B4)
+		dataUpdatedAt: query.dataUpdatedAt,
+		isFetching: query.isFetching,
+		isError: query.isError,
 	};
 }

--- a/apps/web/src/features/qui-home/components/qui-home-client.tsx
+++ b/apps/web/src/features/qui-home/components/qui-home-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { POLLING_STANDARD } from "../../../lib/polling-intervals";
 import {
 	AlertCircle,
 	ArrowRight,
@@ -19,12 +20,7 @@ import {
 import Link from "next/link";
 import { useState } from "react";
 import { toast } from "sonner";
-import {
-	GlassmorphicCard,
-	PremiumEmptyState,
-	PremiumPageHeader,
-	PremiumPageLoading,
-} from "../../../components/layout";
+import { DataFreshness, GlassmorphicCard, PremiumEmptyState, PremiumPageHeader, PremiumPageLoading } from "../../../components/layout";
 import { Alert, AlertDescription, Button } from "../../../components/ui";
 import { useIncognitoMode } from "../../../contexts/IncognitoContext";
 import { useQuiAttention, useQuiSummary } from "../../../hooks/api/useQui";
@@ -92,7 +88,11 @@ export const QuiHomeClient = () => {
 
 	return (
 		<>
-			<Header />
+			<Header
+				dataUpdatedAt={summary.dataUpdatedAt}
+				isFetching={summary.isFetching}
+				isError={summary.isError}
+			/>
 			<KpiStrip data={data} />
 			<CorrelationBackfillCard />
 			<AttentionSection
@@ -107,13 +107,30 @@ export const QuiHomeClient = () => {
 	);
 };
 
-const Header = () => (
+const Header = ({
+	dataUpdatedAt,
+	isFetching,
+	isError,
+}: {
+	dataUpdatedAt?: number;
+	isFetching?: boolean;
+	isError?: boolean;
+}) => (
 	<PremiumPageHeader
 		label="qui Integration"
 		labelIcon={Network}
 		title="qui — Torrent Layer"
 		gradientTitle
 		description="Your torrents across every qBittorrent backend qui manages, joined with the *arr library context so you can see at a glance which movies and shows need attention."
+		actions={
+			// Summary feed freshness — the page's panels all derive from it (B4)
+			<DataFreshness
+				dataUpdatedAt={dataUpdatedAt}
+				isFetching={isFetching}
+				isError={isError}
+				pollIntervalMs={POLLING_STANDARD}
+			/>
+		}
 	/>
 );
 

--- a/apps/web/src/features/statistics/components/statistics-client.tsx
+++ b/apps/web/src/features/statistics/components/statistics-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Activity, BarChart3, BookOpen, Film, Globe, Music, RefreshCw, Tv } from "lucide-react";
+import { POLLING_STATS } from "../../../lib/polling-intervals";
 import { useMemo, useState } from "react";
-import { PremiumSkeleton } from "../../../components/layout";
+import { DataFreshness, PremiumSkeleton } from "../../../components/layout";
 import { Alert, AlertDescription } from "../../../components/ui";
 import { Button } from "../../../components/ui/button";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
@@ -56,6 +57,8 @@ export const StatisticsClient = () => {
 		readarrTotals,
 		combinedDisk,
 		allHealthIssues,
+		dataUpdatedAt,
+		isError,
 	} = useStatisticsData();
 	const [isRefreshing, handleRefresh] = useRefreshState(refetch);
 
@@ -187,6 +190,17 @@ export const StatisticsClient = () => {
 						</p>
 					</div>
 
+					{/* Freshness of the aggregated statistics feed. Hidden on the
+					    Plex/Jellyfin tabs — their analytics come from separate
+					    non-polled queries, so this timestamp would mislead there. */}
+					{activeTab !== "plex" && activeTab !== "jellyfin" && (
+						<DataFreshness
+							dataUpdatedAt={dataUpdatedAt}
+							isFetching={isFetching}
+							isError={isError}
+							pollIntervalMs={POLLING_STATS}
+						/>
+					)}
 					<Button
 						variant="secondary"
 						onClick={() => void handleRefresh()}

--- a/apps/web/src/features/statistics/hooks/useStatisticsData.ts
+++ b/apps/web/src/features/statistics/hooks/useStatisticsData.ts
@@ -115,7 +115,8 @@ const buildReadarrRows = (
  * @returns Aggregated statistics and table rows for all service types
  */
 export const useStatisticsData = () => {
-	const { data, isLoading, isFetching, error, refetch } = useDashboardStatisticsQuery();
+	const { data, isLoading, isFetching, error, refetch, dataUpdatedAt, isError } =
+		useDashboardStatisticsQuery();
 
 	// Memoize instance arrays to prevent dependency changes on every render
 	const sonarrInstances = useMemo(() => data?.sonarr.instances ?? [], [data?.sonarr.instances]);
@@ -469,6 +470,8 @@ export const useStatisticsData = () => {
 		isFetching,
 		error,
 		refetch,
+		dataUpdatedAt,
+		isError,
 
 		// Table rows
 		sonarrRows,


### PR DESCRIPTION
## Summary

Charter B4, re-grounded: the survey's "~15 polling surfaces" collapses to **4 honest adoptions** under the trust rule — a freshness timestamp is only truthful where one polled query clearly *is* the page's data.

### The trust analysis (the real work of this sweep)
| Page | Verdict |
|---|---|
| statistics | ✅ **tab-gated** — overview + arr tabs share the one polled query; **hidden on Plex/Jellyfin tabs** whose analytics are separate non-polled queries |
| calendar | ✅ single query drives everything |
| hunting | ✅ **overview-gated** (+2-line hook extension to expose query state) |
| qui-home | ✅ via `PremiumPageHeader`'s `actions` slot, happy path only |
| dashboard, library-cleanup, qui-activity, requests | ❌ multi-feed — one timestamp would misrepresent whichever feed the user is reading |
| indexers, cross-seed, seerr tabs | ❌ not actively polled (staleTime/pagination ≠ polling) |

### Live-verified
- statistics: `Updated 5s ago` on Overview → **gone** after switching to the Plex tab
- hunting: 0 indicators on Configuration tab, present on Overview (round-trip)
- calendar: renders in the header action bar

The tab-gating is the point: every place the indicator *appears* it describes exactly the data on screen, and every place it would lie, it doesn't render.

## Validation
498 web tests, turbo typecheck + lint green, three-surface live verification with gate round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)