### PR TITLE
feat(cleanup): list-membership kinds + executor prefetch — auto-tagger arc closeout (C3)

### DIFF
--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1043,6 +1043,17 @@ async function evaluateAllItems(
 		? await prefetchJellyfinEpisodeData(deps, config.userId)
 		: undefined;
 
+	// Prefetch TMDb/Trakt list memberships when list-membership kinds are
+	// active (C3 closeout). Without this, the evaluator's permissive-null
+	// would make list rules silently never match in cleanup runs — the
+	// same maps auto-tag's executor builds for its own runs.
+	const tmdbListMemberships = activeTypes.has("tmdb_list_member")
+		? await prefetchCleanupListMemberships(deps, config.userId, rules, "tmdb")
+		: undefined;
+	const traktListMemberships = activeTypes.has("trakt_list_member")
+		? await prefetchCleanupListMemberships(deps, config.userId, rules, "trakt")
+		: undefined;
+
 	// Build prefetch health status
 	const prefetchHealth: PrefetchResults = {
 		seerr: hasSeerrRules ? (seerrMap ? "ok" : "failed") : "skipped",
@@ -1082,6 +1093,8 @@ async function evaluateAllItems(
 		plexEpisodeMap,
 		jellyfinMap,
 		jellyfinEpisodeMap,
+		tmdbListMemberships,
+		traktListMemberships,
 	};
 
 	const flagged: FlaggedItem[] = [];
@@ -1645,4 +1658,62 @@ async function createRunLog(
 			"Failed to write cleanup run log — run result is still valid",
 		);
 	}
+}
+
+/**
+ * Collect the list identifiers referenced by cleanup rules (top-level
+ * params and composite sub-conditions) and load their cached memberships
+ * as Map<identifier, Set<tmdbId>> — the shape the shared evaluator's
+ * tmdb_list_member / trakt_list_member cases consume. Mirrors the
+ * auto-tag executor's per-rule prefetch, generalized to a rule set.
+ */
+export async function prefetchCleanupListMemberships(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	rules: LibraryCleanupRule[],
+	cacheKind: "tmdb" | "trakt",
+): Promise<Map<string, Set<number>>> {
+	const targetType = cacheKind === "tmdb" ? "tmdb_list_member" : "trakt_list_member";
+	const identifierKey = cacheKind === "tmdb" ? "listId" : "listSlug";
+
+	const identifiers = new Set<string>();
+	const collectFromParams = (ruleType: string, params: unknown) => {
+		if (ruleType !== targetType) return;
+		if (params === null || typeof params !== "object") return;
+		const value = (params as Record<string, unknown>)[identifierKey];
+		if (typeof value === "string" && value.length > 0) identifiers.add(value);
+	};
+	for (const rule of rules) {
+		collectFromParams(rule.ruleType, safeJsonParse(rule.parameters));
+		const conditions = safeJsonParse(rule.conditions ?? "") as Array<{
+			ruleType: string;
+			parameters: unknown;
+		}> | null;
+		if (Array.isArray(conditions)) {
+			for (const cond of conditions) collectFromParams(cond?.ruleType, cond?.parameters);
+		}
+	}
+	if (identifiers.size === 0) return new Map();
+
+	const out = new Map<string, Set<number>>();
+	if (cacheKind === "tmdb") {
+		const rows = await deps.prisma.tmdbListCache.findMany({
+			where: { userId, listId: { in: [...identifiers] } },
+			select: { listId: true, tmdbId: true },
+		});
+		for (const row of rows) {
+			(out.get(row.listId) ?? out.set(row.listId, new Set()).get(row.listId))!.add(row.tmdbId);
+		}
+	} else {
+		const rows = await deps.prisma.traktListCache.findMany({
+			where: { userId, listSlug: { in: [...identifiers] } },
+			select: { listSlug: true, tmdbId: true },
+		});
+		for (const row of rows) {
+			(out.get(row.listSlug) ?? out.set(row.listSlug, new Set()).get(row.listSlug))!.add(
+				row.tmdbId,
+			);
+		}
+	}
+	return out;
 }

--- a/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
+++ b/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
@@ -1,0 +1,87 @@
+/**
+ * C3 closeout — cleanup-side list-membership prefetch.
+ *
+ * Pins the contract that makes tmdb_list_member / trakt_list_member
+ * rules WORK in cleanup runs: identifiers are collected from both
+ * top-level rule params and composite sub-conditions, memberships load
+ * from the per-user cache tables, and absent kinds cost zero queries.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { prefetchCleanupListMemberships } from "./cleanup-executor.js";
+import type { CleanupExecutorDeps } from "./types.js";
+import type { LibraryCleanupRule } from "../prisma.js";
+
+function rule(overrides: Partial<LibraryCleanupRule>): LibraryCleanupRule {
+	return {
+		id: "r1",
+		name: "Rule",
+		enabled: true,
+		ruleType: "age",
+		parameters: "{}",
+		operator: null,
+		conditions: null,
+	} as unknown as LibraryCleanupRule;
+	// minimal stub; only fields the collector reads
+}
+
+function makeDeps(tmdbRows: Array<{ listId: string; tmdbId: number }>) {
+	const findMany = vi.fn().mockResolvedValue(tmdbRows);
+	return {
+		deps: { prisma: { tmdbListCache: { findMany }, traktListCache: { findMany: vi.fn().mockResolvedValue([]) } } } as unknown as CleanupExecutorDeps,
+		findMany,
+	};
+}
+
+describe("prefetchCleanupListMemberships", () => {
+	it("collects identifiers from top-level params AND composite conditions", async () => {
+		const rules = [
+			{ ...rule({}), ruleType: "tmdb_list_member", parameters: JSON.stringify({ listId: "8068", operator: "is_in" }) },
+			{
+				...rule({}),
+				ruleType: "composite",
+				operator: "AND",
+				conditions: JSON.stringify([
+					{ ruleType: "tmdb_list_member", parameters: { listId: "1234", operator: "not_in" } },
+					{ ruleType: "age", parameters: { operator: "older_than", days: 30 } },
+				]),
+			},
+		] as LibraryCleanupRule[];
+		const { deps, findMany } = makeDeps([
+			{ listId: "8068", tmdbId: 100 },
+			{ listId: "8068", tmdbId: 200 },
+			{ listId: "1234", tmdbId: 300 },
+		]);
+
+		const map = await prefetchCleanupListMemberships(deps, "user-1", rules, "tmdb");
+
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { userId: "user-1", listId: { in: expect.arrayContaining(["8068", "1234"]) } },
+			}),
+		);
+		expect(map.get("8068")).toEqual(new Set([100, 200]));
+		expect(map.get("1234")).toEqual(new Set([300]));
+	});
+
+	it("returns an empty map with ZERO queries when no rule references the kind", async () => {
+		const { deps, findMany } = makeDeps([]);
+		const map = await prefetchCleanupListMemberships(
+			deps,
+			"user-1",
+			[rule({})] as LibraryCleanupRule[],
+			"tmdb",
+		);
+		expect(map.size).toBe(0);
+		expect(findMany).not.toHaveBeenCalled();
+	});
+
+	it("unknown/unrefreshed list yields an absent map entry (evaluator no-match, never a throw)", async () => {
+		const rules = [
+			{ ...rule({}), ruleType: "tmdb_list_member", parameters: JSON.stringify({ listId: "999", operator: "is_in" }) },
+		] as LibraryCleanupRule[];
+		const { deps } = makeDeps([]); // cache has nothing for list 999
+		const map = await prefetchCleanupListMemberships(deps, "user-1", rules, "tmdb");
+		expect(map.get("999")).toBeUndefined();
+	});
+});

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -225,6 +225,19 @@ describe("parity — single rules", () => {
 		expect(legacy).toBeNull();
 	});
 
+	it("tmdb_list_member via ctx membership maps (C3) — both paths agree", () => {
+		const ctx = baseCtx({ tmdbListMemberships: new Map([["8068", new Set([12345])]]) });
+		const matchRule = makeRule({
+			ruleType: "tmdb_list_member",
+			parameters: JSON.stringify({ listId: "8068", operator: "is_in" }),
+		});
+		const { legacy } = assertParity(matchRule, makeCacheItem(), ctx);
+		expect(legacy).not.toBeNull(); // item tmdbId 12345 is in the list
+
+		// absent map (kind active but list unrefreshed) → permissive null on both paths
+		assertParity(matchRule, makeCacheItem(), baseCtx());
+	});
+
 	it("legacy quirk — unparseable parameters JSON no-matches", () => {
 		assertParity(makeRule({ parameters: "not-json{{{" }));
 	});

--- a/apps/web/src/features/auto-tag/components/rule-dialog.tsx
+++ b/apps/web/src/features/auto-tag/components/rule-dialog.tsx
@@ -115,10 +115,9 @@ const RULE_TYPE_OPTIONS: Array<{ value: SingleRuleType; label: string; group: st
 	{ value: "plex_watch_count", label: "Plex watch count", group: "Plex" },
 	{ value: "plex_added_at", label: "Plex added (date)", group: "Plex" },
 
-	// Phase 5: external curated lists. Backend foundation only — cache
-	// refresh + evaluator dispatch land in a follow-up PR. Until that
-	// ships, rules using these types will create successfully but match
-	// no items at execution time.
+	// List membership — runtime shipped in #403 (TMDb v3 + Trakt caches,
+	// 4h refresh schedulers, evaluator dispatch). Cleanup gained the same
+	// kinds + executor prefetch in the C3 closeout.
 	{ value: "tmdb_list_member", label: "TMDb list member", group: "Lists" },
 	{ value: "trakt_list_member", label: "Trakt list member", group: "Lists" },
 ];

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -13,6 +13,7 @@ import {
 	ChevronDown,
 	Film,
 	HardDrive,
+	ListChecks,
 	Loader2,
 	MessageSquare,
 	Save,
@@ -254,6 +255,17 @@ const RULE_TYPES: Array<{ value: CleanupRuleType; label: string; desc: string }>
 		label: "Requester Not Watched",
 		desc: "Matches when the Seerr requester has not watched the item (Plex, Emby, or Jellyfin)",
 	},
+	// List membership (auto-tagger sub-arc 4 closeout — C3)
+	{
+		value: "tmdb_list_member",
+		label: "TMDb List Member",
+		desc: "Flag items by membership in a TMDb list",
+	},
+	{
+		value: "trakt_list_member",
+		label: "Trakt List Member",
+		desc: "Flag items by membership in a Trakt list",
+	},
 ];
 
 const RULE_CATEGORIES: Array<{
@@ -332,6 +344,12 @@ const RULE_CATEGORIES: Array<{
 			"plex_added_at",
 		],
 		requires: "plex" as const,
+	},
+	{
+		id: "lists",
+		label: "List Membership",
+		icon: ListChecks,
+		types: ["tmdb_list_member", "trakt_list_member"],
 	},
 	{
 		id: "jellyfin",
@@ -502,6 +520,11 @@ export function CleanupRuleDialog({
 	const [seerrRequestCountVal, setSeerrRequestCountVal] = useState(1);
 	const [audioChannelsOp, setAudioChannelsOp] = useState("less_than");
 	const [audioChannelsVal, setAudioChannelsVal] = useState(6);
+	// List membership params (C3)
+	const [tmdbListId, setTmdbListId] = useState("");
+	const [tmdbListOp, setTmdbListOp] = useState("is_in");
+	const [traktListSlug, setTraktListSlug] = useState("");
+	const [traktListOp, setTraktListOp] = useState("is_in");
 	const [tagMatchOp, setTagMatchOp] = useState("includes_any");
 	const [selectedTagIds, setSelectedTagIds] = useState<number[]>([]);
 
@@ -714,6 +737,14 @@ export function CleanupRuleDialog({
 					setTagMatchOp((p.operator as string) ?? "includes_any");
 					setSelectedTagIds(Array.isArray(p.tagIds) ? (p.tagIds as number[]) : []);
 					break;
+				case "tmdb_list_member":
+					setTmdbListId((p.listId as string) ?? "");
+					setTmdbListOp((p.operator as string) ?? "is_in");
+					break;
+				case "trakt_list_member":
+					setTraktListSlug((p.listSlug as string) ?? "");
+					setTraktListOp((p.operator as string) ?? "is_in");
+					break;
 				// Phase D: Plex collections & labels
 				case "plex_collection":
 					setPlexCollectionOp((p.operator as string) ?? "in");
@@ -854,6 +885,10 @@ export function CleanupRuleDialog({
 			setAudioChannelsOp("less_than");
 			setAudioChannelsVal(6);
 			setTagMatchOp("includes_any");
+			setTmdbListId("");
+			setTmdbListOp("is_in");
+			setTraktListSlug("");
+			setTraktListOp("is_in");
 			setSelectedTagIds([]);
 			setCompositeError(null);
 			// Phase D
@@ -974,6 +1009,10 @@ export function CleanupRuleDialog({
 		audioChannelsVal,
 		tagMatchOp,
 		selectedTagIds,
+		tmdbListId,
+		tmdbListOp,
+		traktListSlug,
+		traktListOp,
 		plexCollectionOp,
 		selectedPlexCollections,
 		plexLabelOp,
@@ -1633,6 +1672,14 @@ export function CleanupRuleDialog({
 								setTagMatchOp={setTagMatchOp}
 								selectedTagIds={selectedTagIds}
 								setSelectedTagIds={setSelectedTagIds}
+								tmdbListId={tmdbListId}
+								setTmdbListId={setTmdbListId}
+								tmdbListOp={tmdbListOp}
+								setTmdbListOp={setTmdbListOp}
+								traktListSlug={traktListSlug}
+								setTraktListSlug={setTraktListSlug}
+								traktListOp={traktListOp}
+								setTraktListOp={setTraktListOp}
 								plexCollectionOp={plexCollectionOp}
 								setPlexCollectionOp={setPlexCollectionOp}
 								selectedPlexCollections={selectedPlexCollections}
@@ -1981,6 +2028,14 @@ interface ParamsFieldsProps {
 	setTagMatchOp: (v: string) => void;
 	selectedTagIds: number[];
 	setSelectedTagIds: (v: number[]) => void;
+	tmdbListId: string;
+	setTmdbListId: (v: string) => void;
+	tmdbListOp: string;
+	setTmdbListOp: (v: string) => void;
+	traktListSlug: string;
+	setTraktListSlug: (v: string) => void;
+	traktListOp: string;
+	setTraktListOp: (v: string) => void;
 	// Phase D
 	plexCollectionOp: string;
 	setPlexCollectionOp: (v: string) => void;
@@ -2150,6 +2205,14 @@ function ParamsFields(props: ParamsFieldsProps) {
 		setTagMatchOp,
 		selectedTagIds,
 		setSelectedTagIds,
+		tmdbListId,
+		setTmdbListId,
+		tmdbListOp,
+		setTmdbListOp,
+		traktListSlug,
+		setTraktListSlug,
+		traktListOp,
+		setTraktListOp,
 		plexCollectionOp,
 		setPlexCollectionOp,
 		selectedPlexCollections,
@@ -3024,6 +3087,68 @@ function ParamsFields(props: ParamsFieldsProps) {
 					inputClass={inputClass}
 					labelClass={labelClass}
 				/>
+			);
+
+		// ── List membership (C3) ────────────────────────────────────
+		case "tmdb_list_member":
+			return (
+				<div className="space-y-2">
+					<label className="block">
+						<span className={labelClass}>Operator</span>
+						<select
+							value={tmdbListOp}
+							onChange={(e) => setTmdbListOp(e.target.value)}
+							className={inputClass}
+						>
+							<option value="is_in">Is in list</option>
+							<option value="not_in">Is not in list</option>
+						</select>
+					</label>
+					<label className="block">
+						<span className={labelClass}>TMDb list ID</span>
+						<input
+							type="text"
+							value={tmdbListId}
+							onChange={(e) => setTmdbListId(e.target.value)}
+							placeholder="8068"
+							className={inputClass}
+						/>
+					</label>
+					<p className="text-xs text-muted-foreground">
+						Numeric TMDb list id. Membership refreshes every 4 hours from your configured TMDb
+						key; an unrefreshed or unknown list matches nothing.
+					</p>
+				</div>
+			);
+		case "trakt_list_member":
+			return (
+				<div className="space-y-2">
+					<label className="block">
+						<span className={labelClass}>Operator</span>
+						<select
+							value={traktListOp}
+							onChange={(e) => setTraktListOp(e.target.value)}
+							className={inputClass}
+						>
+							<option value="is_in">Is in list</option>
+							<option value="not_in">Is not in list</option>
+						</select>
+					</label>
+					<label className="block">
+						<span className={labelClass}>Trakt list slug</span>
+						<input
+							type="text"
+							value={traktListSlug}
+							onChange={(e) => setTraktListSlug(e.target.value)}
+							placeholder="username/oscar-winners"
+							className={inputClass}
+						/>
+					</label>
+					<p className="text-xs text-muted-foreground">
+						Format: username/list-slug. Requires a Trakt access token (Settings → Account);
+						membership refreshes every 4 hours.
+					</p>
+				</div>
 			);
 
 		// ── Phase D: Plex Collections & Labels ───────────────────────

--- a/apps/web/src/features/library-cleanup/lib/__tests__/rule-dialog-logic.test.ts
+++ b/apps/web/src/features/library-cleanup/lib/__tests__/rule-dialog-logic.test.ts
@@ -69,6 +69,10 @@ function makeState(overrides: Partial<BuildParamsState> = {}): BuildParamsState 
 		audioChannelsOp: "less_than",
 		audioChannelsVal: 6,
 		tagMatchOp: "includes_any",
+		tmdbListId: "8068",
+		tmdbListOp: "is_in",
+		traktListSlug: "user/oscar-winners",
+		traktListOp: "is_in",
 		selectedTagIds: [1, 2],
 		plexCollectionOp: "in",
 		selectedPlexCollections: ["Marvel"],
@@ -135,6 +139,22 @@ describe("splitCsv", () => {
 // ============================================================================
 
 describe("buildParams", () => {
+	describe("list membership (C3)", () => {
+		it("tmdb_list_member: trims and passes listId + operator", () => {
+			expect(
+				buildParams(makeState({ ruleType: "tmdb_list_member", tmdbListId: " 8068 " })),
+			).toEqual({ listId: "8068", operator: "is_in" });
+		});
+
+		it("trakt_list_member: trims and passes listSlug + operator", () => {
+			expect(
+				buildParams(
+					makeState({ ruleType: "trakt_list_member", traktListOp: "not_in" }),
+				),
+			).toEqual({ listSlug: "user/oscar-winners", operator: "not_in" });
+		});
+	});
+
 	describe("basic rules", () => {
 		it("age: includes field, operator, and days", () => {
 			expect(buildParams(makeState({ ruleType: "age" }))).toEqual({

--- a/apps/web/src/features/library-cleanup/lib/rule-dialog-logic.ts
+++ b/apps/web/src/features/library-cleanup/lib/rule-dialog-logic.ts
@@ -107,6 +107,11 @@ export interface BuildParamsState {
 	audioChannelsVal: number;
 	// tag_match
 	tagMatchOp: string;
+	// list membership (C3)
+	tmdbListId: string;
+	tmdbListOp: string;
+	traktListSlug: string;
+	traktListOp: string;
 	selectedTagIds: number[];
 	// plex_collection
 	plexCollectionOp: string;
@@ -228,6 +233,10 @@ export function buildParams(state: BuildParamsState): Record<string, unknown> {
 			return { operator: state.audioChannelsOp, channels: state.audioChannelsVal };
 		case "tag_match":
 			return { operator: state.tagMatchOp, tagIds: state.selectedTagIds };
+		case "tmdb_list_member":
+			return { listId: state.tmdbListId.trim(), operator: state.tmdbListOp };
+		case "trakt_list_member":
+			return { listSlug: state.traktListSlug.trim(), operator: state.traktListOp };
 		case "plex_collection":
 			return { operator: state.plexCollectionOp, collections: state.selectedPlexCollections };
 		case "plex_label":


### PR DESCRIPTION
## Summary

Charter C3. The checkpoint read resolved a 40-day-old contradiction: the arc memo said "complete," the charter said "finish UI surfaces" — ground truth showed **both were imprecise**. The list-membership kinds worked only in auto-tag: cleanup's executor never prefetched the membership maps (`EvalContext` had the fields; only auto-tag populated them), and the cleanup dialog never offered the kinds. Since the API already *accepts* them (tier-1 legality), the missing UI was the only guard against authoring cleanup **deletion** rules that silently never match.

### Fixed in dependency order (executor before UI — never ship a rule type that can't fire)
1. **`prefetchCleanupListMemberships`** in the cleanup executor — identifiers collected from top-level params *and* composite sub-conditions, per-user cache queries, `activeTypes`-gated (zero cost when unused)
2. **Cleanup dialog**: TMDb/Trakt entries in `RULE_TYPES` (the composite picker shares the list — both paths covered), a "List Membership" category, full state/load/defaults/buildParams plumbing, field UIs with honest copy
3. **Auto-tag stale comment** corrected (claimed the runtime doesn't exist; it shipped in #403)

### Unlocked
"Flag items **not** in my keep-list" cleanup rules — the composition the arc was designed for.

## Validation
3 prefetch unit tests, an engine-path parity fixture (`legacy === engine` incl. the unrefreshed-list permissive null), 2 buildParams tests. 2107 API + 500 web tests, turbo typecheck + lint green.

**Closes the auto-tagger arc** (memo updated with the closeout record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)