### PR TITLE
feat(web): premium-components on TRaSH ecosystem (Bucket B3)

### DIFF
--- a/apps/web/src/components/layout/premium-data-display.tsx
+++ b/apps/web/src/components/layout/premium-data-display.tsx
@@ -44,12 +44,15 @@ interface PremiumTableRowProps {
 	children: ReactNode;
 	className?: string;
 	isHoverable?: boolean;
+	/** Inline style passthrough (e.g. staggered animationDelay) */
+	style?: React.CSSProperties;
 }
 
 export const PremiumTableRow = ({
 	children,
 	className,
 	isHoverable = true,
+	style,
 }: PremiumTableRowProps) => {
 	return (
 		<tr
@@ -58,6 +61,7 @@ export const PremiumTableRow = ({
 				isHoverable && "hover:bg-muted/20 transition-colors",
 				className,
 			)}
+			style={style}
 		>
 			{children}
 		</tr>

--- a/apps/web/src/features/trash-guides/components/deployment-history-table.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-history-table.tsx
@@ -24,10 +24,18 @@ import {
 	Eye,
 	History,
 	Loader2,
+	type LucideIcon,
 	Trash2,
 	Undo2,
 	XCircle,
 } from "lucide-react";
+import {
+	PremiumEmptyState,
+	PremiumTable,
+	PremiumTableHeader,
+	PremiumTableRow,
+	StatusBadge,
+} from "../../../components/layout";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 
@@ -38,64 +46,35 @@ interface DeploymentHistoryTableProps {
 }
 
 /**
- * Premium Status Badge Component
+ * Deployment status → shared StatusBadge mapping
  */
-const StatusBadge = ({ status }: { status: string }) => {
-	const statusConfig: Record<
-		string,
-		{
-			label: string;
-			icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
-			color: { bg: string; border: string; text: string; from: string };
-		}
-	> = {
-		SUCCESS: {
-			label: "Success",
-			icon: CheckCircle2,
-			color: SEMANTIC_COLORS.success,
-		},
-		PARTIAL_SUCCESS: {
-			label: "Partial",
-			icon: AlertTriangle,
-			color: SEMANTIC_COLORS.warning,
-		},
-		FAILED: {
-			label: "Failed",
-			icon: XCircle,
-			color: SEMANTIC_COLORS.error,
-		},
-		IN_PROGRESS: {
-			label: "In Progress",
-			icon: Clock,
-			color: SEMANTIC_COLORS.info,
-		},
-	};
+const DEPLOYMENT_STATUS_CONFIG: Record<
+	string,
+	{
+		label: string;
+		icon: LucideIcon;
+		variant: "success" | "warning" | "error" | "info";
+	}
+> = {
+	SUCCESS: { label: "Success", icon: CheckCircle2, variant: "success" },
+	PARTIAL_SUCCESS: { label: "Partial", icon: AlertTriangle, variant: "warning" },
+	FAILED: { label: "Failed", icon: XCircle, variant: "error" },
+	IN_PROGRESS: { label: "In Progress", icon: Clock, variant: "info" },
+};
 
-	const config = statusConfig[status] || {
-		label: status,
-		icon: Clock,
-		color: {
-			bg: "rgba(100, 116, 139, 0.1)",
-			border: "rgba(100, 116, 139, 0.2)",
-			text: "rgb(148, 163, 184)",
-			from: "rgb(148, 163, 184)",
-		},
-	};
-
-	const Icon = config.icon;
-
+const DeploymentStatusBadge = ({ status }: { status: string }) => {
+	const config = DEPLOYMENT_STATUS_CONFIG[status];
+	if (!config) {
+		return (
+			<StatusBadge status="default" icon={Clock}>
+				{status}
+			</StatusBadge>
+		);
+	}
 	return (
-		<span
-			className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
-			style={{
-				backgroundColor: config.color.bg,
-				border: `1px solid ${config.color.border}`,
-				color: config.color.text,
-			}}
-		>
-			<Icon className="h-3 w-3" />
+		<StatusBadge status={config.variant} icon={config.icon}>
 			{config.label}
-		</span>
+		</StatusBadge>
 	);
 };
 
@@ -164,13 +143,11 @@ export function DeploymentHistoryTable({
 	// Empty State
 	if (!data?.data?.history || data.data.history.length === 0) {
 		return (
-			<div className="rounded-2xl border border-dashed border-border/30 bg-muted/10 p-12 text-center">
-				<History className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-				<p className="text-lg font-medium text-foreground mb-2">No deployment history</p>
-				<p className="text-sm text-muted-foreground">
-					Deployments will appear here once you deploy templates to instances
-				</p>
-			</div>
+			<PremiumEmptyState
+				icon={History}
+				title="No deployment history"
+				description="Deployments will appear here once you deploy templates to instances"
+			/>
 		);
 	}
 
@@ -189,193 +166,139 @@ export function DeploymentHistoryTable({
 	return (
 		<div className="space-y-4 animate-in fade-in duration-300">
 			{/* Table Container */}
-			<div className="overflow-hidden rounded-2xl border border-border/30 bg-muted/10">
-				<div className="overflow-x-auto">
-					<table className="w-full">
-						<thead>
-							<tr className="border-b border-border/50">
+			<PremiumTable>
+				<table className="w-full">
+					<PremiumTableHeader>
+						<tr>
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								Timestamp
+							</th>
+							{!templateId && !instanceId && (
 								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									Timestamp
+									Template
 								</th>
+							)}
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								{templateId ? "Instance" : instanceId ? "Template" : "Instance"}
+							</th>
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								Status
+							</th>
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								Duration
+							</th>
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								Results
+							</th>
+							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+								Actions
+							</th>
+						</tr>
+					</PremiumTableHeader>
+					<tbody>
+						{history.map((entry, index) => (
+							<PremiumTableRow
+								key={entry.id}
+								className="animate-in fade-in"
+								style={{
+									animationDelay: `${index * 30}ms`,
+									animationFillMode: "backwards",
+								}}
+							>
+								<td className="px-6 py-4 text-sm">
+									<div className="flex flex-col">
+										<span className="font-medium text-foreground">
+											{format(new Date(entry.deployedAt), "MMM d, yyyy")}
+										</span>
+										<span className="text-xs text-muted-foreground">
+											{format(new Date(entry.deployedAt), "h:mm a")}
+										</span>
+									</div>
+								</td>
 								{!templateId && !instanceId && (
-									<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-										Template
-									</th>
-								)}
-								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									{templateId ? "Instance" : instanceId ? "Template" : "Instance"}
-								</th>
-								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									Status
-								</th>
-								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									Duration
-								</th>
-								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									Results
-								</th>
-								<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-									Actions
-								</th>
-							</tr>
-						</thead>
-						<tbody className="divide-y divide-border/30">
-							{history.map((entry, index) => (
-								<tr
-									key={entry.id}
-									className="transition-colors hover:bg-card/50 animate-in fade-in"
-									style={{
-										animationDelay: `${index * 30}ms`,
-										animationFillMode: "backwards",
-									}}
-								>
 									<td className="px-6 py-4 text-sm">
 										<div className="flex flex-col">
 											<span className="font-medium text-foreground">
-												{format(new Date(entry.deployedAt), "MMM d, yyyy")}
+												{entry.template?.name || "Unknown"}
 											</span>
 											<span className="text-xs text-muted-foreground">
-												{format(new Date(entry.deployedAt), "h:mm a")}
+												{entry.template?.serviceType}
 											</span>
 										</div>
 									</td>
-									{!templateId && !instanceId && (
-										<td className="px-6 py-4 text-sm">
-											<div className="flex flex-col">
-												<span className="font-medium text-foreground">
-													{entry.template?.name || "Unknown"}
-												</span>
-												<span className="text-xs text-muted-foreground">
-													{entry.template?.serviceType}
-												</span>
-											</div>
-										</td>
+								)}
+								<td className="px-6 py-4 text-sm">
+									{templateId || !instanceId ? (
+										<div className="flex flex-col">
+											<span className="font-medium text-foreground">
+												{entry.instance?.label || "Unknown"}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{entry.instance?.service}
+											</span>
+										</div>
+									) : (
+										<div className="flex flex-col">
+											<span className="font-medium text-foreground">
+												{entry.template?.name || "Unknown"}
+											</span>
+											<span className="text-xs text-muted-foreground">
+												{entry.template?.serviceType}
+											</span>
+										</div>
 									)}
-									<td className="px-6 py-4 text-sm">
-										{templateId || !instanceId ? (
-											<div className="flex flex-col">
-												<span className="font-medium text-foreground">
-													{entry.instance?.label || "Unknown"}
-												</span>
-												<span className="text-xs text-muted-foreground">
-													{entry.instance?.service}
-												</span>
-											</div>
-										) : (
-											<div className="flex flex-col">
-												<span className="font-medium text-foreground">
-													{entry.template?.name || "Unknown"}
-												</span>
-												<span className="text-xs text-muted-foreground">
-													{entry.template?.serviceType}
-												</span>
-											</div>
-										)}
-									</td>
-									<td className="px-6 py-4">
-										<StatusBadge status={entry.status} />
-									</td>
-									<td className="px-6 py-4 text-sm text-muted-foreground">
-										{entry.duration ? `${entry.duration}s` : "-"}
-									</td>
-									<td className="px-6 py-4 text-sm">
-										<div className="flex items-center gap-3">
+								</td>
+								<td className="px-6 py-4">
+									<DeploymentStatusBadge status={entry.status} />
+								</td>
+								<td className="px-6 py-4 text-sm text-muted-foreground">
+									{entry.duration ? `${entry.duration}s` : "-"}
+								</td>
+								<td className="px-6 py-4 text-sm">
+									<div className="flex items-center gap-3">
+										<span
+											className="flex items-center gap-1"
+											style={{ color: SEMANTIC_COLORS.success.from }}
+										>
+											<CheckCircle2 className="h-3.5 w-3.5" />
+											{entry.appliedCFs}
+										</span>
+										{entry.failedCFs > 0 && (
 											<span
 												className="flex items-center gap-1"
-												style={{ color: SEMANTIC_COLORS.success.from }}
+												style={{ color: SEMANTIC_COLORS.error.from }}
 											>
-												<CheckCircle2 className="h-3.5 w-3.5" />
-												{entry.appliedCFs}
+												<XCircle className="h-3.5 w-3.5" />
+												{entry.failedCFs}
 											</span>
-											{entry.failedCFs > 0 && (
-												<span
-													className="flex items-center gap-1"
-													style={{ color: SEMANTIC_COLORS.error.from }}
-												>
-													<XCircle className="h-3.5 w-3.5" />
-													{entry.failedCFs}
-												</span>
-											)}
-										</div>
-									</td>
-									<td className="px-6 py-4">
-										<div className="flex items-center gap-2">
-											{/* View Details Button */}
-											<button
-												type="button"
-												onClick={() => setSelectedHistoryId(entry.id)}
-												className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors hover:bg-card/80"
-												style={{ color: themeGradient.from }}
-											>
-												<Eye className="h-3.5 w-3.5" />
-												Details
-											</button>
+										)}
+									</div>
+								</td>
+								<td className="px-6 py-4">
+									<div className="flex items-center gap-2">
+										{/* View Details Button */}
+										<button
+											type="button"
+											onClick={() => setSelectedHistoryId(entry.id)}
+											className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors hover:bg-card/80"
+											style={{ color: themeGradient.from }}
+										>
+											<Eye className="h-3.5 w-3.5" />
+											Details
+										</button>
 
-											{/* Undeploy Button */}
-											{!entry.rolledBack &&
-												(undeployConfirmId === entry.id ? (
-													<div className="flex items-center gap-1">
-														<button
-															type="button"
-															onClick={() => {
-																undeployMutation.mutate(entry.id, {
-																	onSuccess: () => setUndeployConfirmId(null),
-																});
-															}}
-															disabled={undeployMutation.isPending}
-															className="rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors"
-															style={{
-																backgroundColor: SEMANTIC_COLORS.error.bg,
-																border: `1px solid ${SEMANTIC_COLORS.error.border}`,
-																color: SEMANTIC_COLORS.error.text,
-															}}
-														>
-															{undeployMutation.isPending ? (
-																<Loader2 className="h-3.5 w-3.5 animate-spin" />
-															) : (
-																"Confirm"
-															)}
-														</button>
-														<button
-															type="button"
-															onClick={() => setUndeployConfirmId(null)}
-															disabled={undeployMutation.isPending}
-															className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
-														>
-															Cancel
-														</button>
-													</div>
-												) : (
-													<button
-														type="button"
-														onClick={() => setUndeployConfirmId(entry.id)}
-														className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors hover:bg-card/80"
-														style={{ color: SEMANTIC_COLORS.warning.from }}
-														title="Remove Custom Formats deployed by this template"
-													>
-														<Undo2 className="h-3.5 w-3.5" />
-														Undeploy
-													</button>
-												))}
-
-											{/* Undeployed Badge */}
-											{entry.rolledBack && (
-												<span className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium bg-muted/20 text-muted-foreground">
-													Undeployed
-												</span>
-											)}
-
-											{/* Delete Button */}
-											{deleteConfirmId === entry.id ? (
+										{/* Undeploy Button */}
+										{!entry.rolledBack &&
+											(undeployConfirmId === entry.id ? (
 												<div className="flex items-center gap-1">
 													<button
 														type="button"
 														onClick={() => {
-															deleteMutation.mutate(entry.id, {
-																onSuccess: () => setDeleteConfirmId(null),
+															undeployMutation.mutate(entry.id, {
+																onSuccess: () => setUndeployConfirmId(null),
 															});
 														}}
-														disabled={deleteMutation.isPending}
+														disabled={undeployMutation.isPending}
 														className="rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors"
 														style={{
 															backgroundColor: SEMANTIC_COLORS.error.bg,
@@ -383,7 +306,7 @@ export function DeploymentHistoryTable({
 															color: SEMANTIC_COLORS.error.text,
 														}}
 													>
-														{deleteMutation.isPending ? (
+														{undeployMutation.isPending ? (
 															<Loader2 className="h-3.5 w-3.5 animate-spin" />
 														) : (
 															"Confirm"
@@ -391,8 +314,8 @@ export function DeploymentHistoryTable({
 													</button>
 													<button
 														type="button"
-														onClick={() => setDeleteConfirmId(null)}
-														disabled={deleteMutation.isPending}
+														onClick={() => setUndeployConfirmId(null)}
+														disabled={undeployMutation.isPending}
 														className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
 													>
 														Cancel
@@ -401,21 +324,72 @@ export function DeploymentHistoryTable({
 											) : (
 												<button
 													type="button"
-													onClick={() => setDeleteConfirmId(entry.id)}
-													className="rounded-lg p-1.5 text-muted-foreground hover:text-foreground transition-colors hover:bg-card/80"
+													onClick={() => setUndeployConfirmId(entry.id)}
+													className="inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium transition-colors hover:bg-card/80"
+													style={{ color: SEMANTIC_COLORS.warning.from }}
+													title="Remove Custom Formats deployed by this template"
 												>
-													<Trash2 className="h-3.5 w-3.5" />
+													<Undo2 className="h-3.5 w-3.5" />
+													Undeploy
 												</button>
-											)}
-										</div>
-									</td>
-								</tr>
-							))}
-						</tbody>
-					</table>
-				</div>
-			</div>
+											))}
 
+										{/* Undeployed Badge */}
+										{entry.rolledBack && (
+											<span className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium bg-muted/20 text-muted-foreground">
+												Undeployed
+											</span>
+										)}
+
+										{/* Delete Button */}
+										{deleteConfirmId === entry.id ? (
+											<div className="flex items-center gap-1">
+												<button
+													type="button"
+													onClick={() => {
+														deleteMutation.mutate(entry.id, {
+															onSuccess: () => setDeleteConfirmId(null),
+														});
+													}}
+													disabled={deleteMutation.isPending}
+													className="rounded-lg px-2.5 py-1.5 text-xs font-medium transition-colors"
+													style={{
+														backgroundColor: SEMANTIC_COLORS.error.bg,
+														border: `1px solid ${SEMANTIC_COLORS.error.border}`,
+														color: SEMANTIC_COLORS.error.text,
+													}}
+												>
+													{deleteMutation.isPending ? (
+														<Loader2 className="h-3.5 w-3.5 animate-spin" />
+													) : (
+														"Confirm"
+													)}
+												</button>
+												<button
+													type="button"
+													onClick={() => setDeleteConfirmId(null)}
+													disabled={deleteMutation.isPending}
+													className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+												>
+													Cancel
+												</button>
+											</div>
+										) : (
+											<button
+												type="button"
+												onClick={() => setDeleteConfirmId(entry.id)}
+												className="rounded-lg p-1.5 text-muted-foreground hover:text-foreground transition-colors hover:bg-card/80"
+											>
+												<Trash2 className="h-3.5 w-3.5" />
+											</button>
+										)}
+									</div>
+								</td>
+							</PremiumTableRow>
+						))}
+					</tbody>
+				</table>
+			</PremiumTable>
 			{/* Pagination */}
 			<div className="flex items-center justify-between">
 				<p className="text-sm text-muted-foreground">
@@ -444,7 +418,6 @@ export function DeploymentHistoryTable({
 					</button>
 				</div>
 			</div>
-
 			{/* Details Modal (lazy-loaded) */}
 			{selectedHistoryId && (
 				<Suspense>

--- a/apps/web/src/features/trash-guides/components/naming-history-table.tsx
+++ b/apps/web/src/features/trash-guides/components/naming-history-table.tsx
@@ -13,6 +13,13 @@ import {
 	XCircle,
 } from "lucide-react";
 import { useState } from "react";
+import {
+	PremiumEmptyState,
+	PremiumTable,
+	PremiumTableHeader,
+	PremiumTableRow,
+	StatusBadge,
+} from "../../../components/layout";
 import { useNamingHistory, useRollbackNaming } from "../../../hooks/api/useNaming";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
@@ -22,29 +29,21 @@ import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 // ============================================================================
 
 const STATUS_CONFIG = {
-	PENDING: { label: "Pending", Icon: Clock, color: SEMANTIC_COLORS.warning },
-	SUCCESS: { label: "Success", Icon: CheckCircle2, color: SEMANTIC_COLORS.success },
-	FAILED: { label: "Failed", Icon: XCircle, color: SEMANTIC_COLORS.error },
-	ROLLED_BACK: { label: "Rolled Back", Icon: Undo2, color: SEMANTIC_COLORS.info },
+	PENDING: { label: "Pending", Icon: Clock, variant: "warning" },
+	SUCCESS: { label: "Success", Icon: CheckCircle2, variant: "success" },
+	FAILED: { label: "Failed", Icon: XCircle, variant: "error" },
+	ROLLED_BACK: { label: "Rolled Back", Icon: Undo2, variant: "info" },
 } as const;
 
 function NamingStatusBadge({ status }: { status: keyof typeof STATUS_CONFIG }) {
 	const config = STATUS_CONFIG[status];
 	if (!config) return <span className="text-xs text-muted-foreground">{status}</span>;
 
-	const { label, Icon, color } = config;
+	const { label, Icon, variant } = config;
 	return (
-		<span
-			className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
-			style={{
-				backgroundColor: color.bg,
-				borderColor: color.border,
-				color: color.text,
-			}}
-		>
-			<Icon className="h-3.5 w-3.5" />
+		<StatusBadge status={variant} icon={Icon}>
 			{label}
-		</span>
+		</StatusBadge>
 	);
 }
 
@@ -129,21 +128,21 @@ export function NamingHistoryTable({ instanceId }: NamingHistoryTableProps) {
 	// ── Empty ────────────────────────────────────────────────────────────
 	if (history.length === 0) {
 		return (
-			<div className="rounded-2xl border border-dashed border-border/30 bg-muted/10 p-12 text-center">
-				<History className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-				<p className="text-lg font-medium text-foreground mb-2">No deployment history</p>
-				<p className="text-sm text-muted-foreground">Deploy naming presets to see history here</p>
-			</div>
+			<PremiumEmptyState
+				icon={History}
+				title="No deployment history"
+				description="Deploy naming presets to see history here"
+			/>
 		);
 	}
 
 	// ── Table ────────────────────────────────────────────────────────────
 	return (
 		<div className="space-y-4 animate-in fade-in duration-300">
-			<div className="rounded-2xl border border-border/30 bg-muted/10 overflow-hidden">
+			<PremiumTable>
 				<table className="w-full">
-					<thead>
-						<tr className="border-b border-border/50">
+					<PremiumTableHeader>
+						<tr>
 							<th className="px-6 py-4 text-left text-xs font-semibold uppercase tracking-wider text-muted-foreground">
 								Timestamp
 							</th>
@@ -160,12 +159,12 @@ export function NamingHistoryTable({ instanceId }: NamingHistoryTableProps) {
 								Actions
 							</th>
 						</tr>
-					</thead>
+					</PremiumTableHeader>
 					<tbody>
 						{history.map((entry, index) => (
-							<tr
+							<PremiumTableRow
 								key={entry.id}
-								className="border-b border-border/30 last:border-0 transition-colors hover:bg-card/50 animate-in fade-in"
+								className="animate-in fade-in"
 								style={{
 									animationDelay: `${index * 30}ms`,
 									animationFillMode: "backwards",
@@ -261,11 +260,11 @@ export function NamingHistoryTable({ instanceId }: NamingHistoryTableProps) {
 										</span>
 									) : null}
 								</td>
-							</tr>
+							</PremiumTableRow>
 						))}
 					</tbody>
 				</table>
-			</div>
+			</PremiumTable>
 
 			{/* Rollback error banner */}
 			{rollbackMutation.isError && (

--- a/apps/web/src/features/trash-guides/components/naming-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/naming-manager.tsx
@@ -15,7 +15,13 @@ import {
 	Trash2,
 } from "lucide-react";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
-import { ServiceBadge } from "../../../components/layout/premium-components";
+import {
+	GradientButton,
+	PremiumTable,
+	PremiumTableHeader,
+	PremiumTableRow,
+	ServiceBadge,
+} from "../../../components/layout/premium-components";
 import {
 	useApplyNaming,
 	useDeleteNamingConfig,
@@ -187,67 +193,66 @@ function PreviewTable({
 	themeGradient: ReturnType<typeof useThemeGradient>["gradient"];
 }) {
 	return (
-		<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10">
-			<div className="overflow-x-auto">
-				<table className="w-full text-sm">
-					<thead>
-						<tr className="border-b border-border/50">
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">Field</th>
-							<th className="px-4 py-3 text-left font-medium text-muted-foreground">Current</th>
-							<th className="px-4 py-3 text-left font-medium" style={{ color: themeGradient.from }}>
-								TRaSH Preset
-							</th>
-							<th className="px-4 py-3 text-center font-medium text-muted-foreground">Status</th>
-						</tr>
-					</thead>
-					<tbody>
-						{comparisons.map((row, idx) => (
-							<tr
-								key={row.arrApiField}
-								className="border-b border-border/30 last:border-0 animate-in fade-in duration-200"
-								style={{
-									animationDelay: `${idx * 30}ms`,
-									animationFillMode: "backwards",
-								}}
-							>
-								<td className="px-4 py-2.5">
-									<div>
-										<div className="font-medium">{row.fieldGroup}</div>
-										<div className="text-xs text-muted-foreground">{row.presetName}</div>
-									</div>
-								</td>
-								<td className="px-4 py-2.5">
-									<code className="text-xs text-muted-foreground break-all">
-										{row.currentValue || "—"}
-									</code>
-								</td>
-								<td className="px-4 py-2.5">
-									<code
-										className="text-xs break-all font-medium"
-										style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
-									>
-										{row.presetValue}
-									</code>
-								</td>
-								<td className="px-4 py-2.5 text-center">
-									{row.changed ? (
-										<AlertTriangle
-											className="h-4 w-4 mx-auto"
-											style={{ color: SEMANTIC_COLORS.warning.text }}
-										/>
-									) : (
-										<CheckCircle2
-											className="h-4 w-4 mx-auto"
-											style={{ color: SEMANTIC_COLORS.success.text }}
-										/>
-									)}
-								</td>
-							</tr>
-						))}
-					</tbody>
-				</table>
-			</div>
-		</div>
+		<PremiumTable>
+			<table className="w-full text-sm">
+				<PremiumTableHeader>
+					<tr>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">Field</th>
+						<th className="px-4 py-3 text-left font-medium text-muted-foreground">Current</th>
+						<th className="px-4 py-3 text-left font-medium" style={{ color: themeGradient.from }}>
+							TRaSH Preset
+						</th>
+						<th className="px-4 py-3 text-center font-medium text-muted-foreground">Status</th>
+					</tr>
+				</PremiumTableHeader>
+				<tbody>
+					{comparisons.map((row, idx) => (
+						<PremiumTableRow
+							key={row.arrApiField}
+							isHoverable={false}
+							className="animate-in fade-in duration-200"
+							style={{
+								animationDelay: `${idx * 30}ms`,
+								animationFillMode: "backwards",
+							}}
+						>
+							<td className="px-4 py-2.5">
+								<div>
+									<div className="font-medium">{row.fieldGroup}</div>
+									<div className="text-xs text-muted-foreground">{row.presetName}</div>
+								</div>
+							</td>
+							<td className="px-4 py-2.5">
+								<code className="text-xs text-muted-foreground break-all">
+									{row.currentValue || "—"}
+								</code>
+							</td>
+							<td className="px-4 py-2.5">
+								<code
+									className="text-xs break-all font-medium"
+									style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
+								>
+									{row.presetValue}
+								</code>
+							</td>
+							<td className="px-4 py-2.5 text-center">
+								{row.changed ? (
+									<AlertTriangle
+										className="h-4 w-4 mx-auto"
+										style={{ color: SEMANTIC_COLORS.warning.text }}
+									/>
+								) : (
+									<CheckCircle2
+										className="h-4 w-4 mx-auto"
+										style={{ color: SEMANTIC_COLORS.success.text }}
+									/>
+								)}
+							</td>
+						</PremiumTableRow>
+					))}
+				</tbody>
+			</table>
+		</PremiumTable>
 	);
 }
 
@@ -548,7 +553,9 @@ export function NamingManager() {
 										/>
 										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-2">
-												<span className="text-sm font-medium truncate">{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}</span>
+												<span className="text-sm font-medium truncate">
+													{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}
+												</span>
 												<ServiceBadge service={instance.service} />
 											</div>
 											{hasSavedConfig && (
@@ -700,19 +707,15 @@ export function NamingManager() {
 							<div className="space-y-3">
 								<div className="flex items-center gap-4">
 									{!showConfirmApply ? (
-										<button
-											type="button"
+										<GradientButton
 											onClick={() => setShowConfirmApply(true)}
 											disabled={
 												applyMutation.isPending || previewMutation.data.preview.changedCount === 0
 											}
-											className="rounded-xl px-6 py-2.5 text-sm font-medium text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110"
-											style={{
-												background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-											}}
+											className="px-6 py-2.5"
 										>
 											{`Apply to ${selectedInstance?.label ?? "Instance"}`}
-										</button>
+										</GradientButton>
 									) : (
 										<div
 											className="flex items-center gap-3 rounded-xl border px-4 py-3 animate-in fade-in duration-200"
@@ -727,8 +730,13 @@ export function NamingManager() {
 											/>
 											<span className="text-sm">
 												Apply {previewMutation.data.preview.changedCount} naming change(s) to{" "}
-												<strong>{selectedInstance && (incognitoMode ? getLinuxInstanceName(selectedInstance.label) : selectedInstance.label)}</strong>? This will overwrite the current
-												naming config.
+												<strong>
+													{selectedInstance &&
+														(incognitoMode
+															? getLinuxInstanceName(selectedInstance.label)
+															: selectedInstance.label)}
+												</strong>
+												? This will overwrite the current naming config.
 											</span>
 											<button
 												type="button"
@@ -737,14 +745,11 @@ export function NamingManager() {
 											>
 												Cancel
 											</button>
-											<button
-												type="button"
+											<GradientButton
 												onClick={handleApply}
 												disabled={applyMutation.isPending}
-												className="rounded-lg px-3 py-1.5 text-xs font-medium text-white transition-all hover:brightness-110 disabled:opacity-50"
-												style={{
-													background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-												}}
+												size="sm"
+												className="text-xs"
 											>
 												{applyMutation.isPending ? (
 													<span className="flex items-center gap-1">
@@ -754,7 +759,7 @@ export function NamingManager() {
 												) : (
 													"Confirm Apply"
 												)}
-											</button>
+											</GradientButton>
 										</div>
 									)}
 									{previewMutation.data.preview.changedCount === 0 && (

--- a/apps/web/src/features/trash-guides/components/quality-size-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-size-manager.tsx
@@ -13,7 +13,13 @@ import {
 	Server,
 } from "lucide-react";
 import { useState } from "react";
-import { ServiceBadge } from "../../../components/layout/premium-components";
+import {
+	GradientButton,
+	PremiumTable,
+	PremiumTableHeader,
+	PremiumTableRow,
+	ServiceBadge,
+} from "../../../components/layout/premium-components";
 import {
 	useApplyQualitySize,
 	useQualitySizeMapping,
@@ -219,7 +225,9 @@ export function QualitySizeManager() {
 										/>
 										<div className="min-w-0 flex-1">
 											<div className="flex items-center gap-2">
-												<span className="text-sm font-medium truncate">{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}</span>
+												<span className="text-sm font-medium truncate">
+													{incognitoMode ? getLinuxInstanceName(instance.label) : instance.label}
+												</span>
 												<ServiceBadge service={instance.service} />
 											</div>
 										</div>
@@ -341,22 +349,23 @@ export function QualitySizeManager() {
 								<p className="text-sm font-medium">Reset to Factory Defaults</p>
 								<p className="text-sm text-muted-foreground mt-1">
 									This will restore all quality size definitions on{" "}
-									<span className="font-medium text-foreground">{selectedInstance && (incognitoMode ? getLinuxInstanceName(selectedInstance.label) : selectedInstance.label)}</span> to
-									the original values set by{" "}
+									<span className="font-medium text-foreground">
+										{selectedInstance &&
+											(incognitoMode
+												? getLinuxInstanceName(selectedInstance.label)
+												: selectedInstance.label)}
+									</span>{" "}
+									to the original values set by{" "}
 									{selectedInstance?.service === "sonarr" ? "Sonarr" : "Radarr"}. Any previously
 									applied TRaSH preset will be removed.
 								</p>
 							</div>
 						</div>
 					</div>
-					<button
-						type="button"
+					<GradientButton
 						onClick={handleApply}
 						disabled={applyMutation.isPending}
-						className="rounded-xl px-6 py-2.5 text-sm font-medium text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110"
-						style={{
-							background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-						}}
+						className="px-6 py-2.5"
 					>
 						{applyMutation.isPending ? (
 							<span className="flex items-center gap-2">
@@ -366,7 +375,7 @@ export function QualitySizeManager() {
 						) : (
 							`Reset ${selectedInstance?.label ?? "Instance"} to Defaults`
 						)}
-					</button>
+					</GradientButton>
 					{applyMutation.isError && (
 						<ErrorBanner message={`Reset failed: ${applyMutation.error.message}`} />
 					)}
@@ -435,115 +444,113 @@ export function QualitySizeManager() {
 							Comparing quality definitions...
 						</div>
 					) : previewData?.comparisons ? (
-						<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10">
-							<div className="overflow-x-auto">
-								<table className="w-full text-sm">
-									<thead>
-										<tr className="border-b border-border/50">
-											<th className="px-4 py-3 text-left font-medium text-muted-foreground">
-												Quality
-											</th>
-											<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-												Current Min
-											</th>
-											<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-												Current Preferred
-											</th>
-											<th className="px-4 py-3 text-right font-medium text-muted-foreground">
-												Current Max
-											</th>
-											<th
-												className="px-4 py-3 text-right font-medium"
-												style={{ color: themeGradient.from }}
+						<PremiumTable>
+							<table className="w-full text-sm">
+								<PremiumTableHeader>
+									<tr>
+										<th className="px-4 py-3 text-left font-medium text-muted-foreground">
+											Quality
+										</th>
+										<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+											Current Min
+										</th>
+										<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+											Current Preferred
+										</th>
+										<th className="px-4 py-3 text-right font-medium text-muted-foreground">
+											Current Max
+										</th>
+										<th
+											className="px-4 py-3 text-right font-medium"
+											style={{ color: themeGradient.from }}
+										>
+											TRaSH Min
+										</th>
+										<th
+											className="px-4 py-3 text-right font-medium"
+											style={{ color: themeGradient.from }}
+										>
+											TRaSH Preferred
+										</th>
+										<th
+											className="px-4 py-3 text-right font-medium"
+											style={{ color: themeGradient.from }}
+										>
+											TRaSH Max
+										</th>
+										<th className="px-4 py-3 text-center font-medium text-muted-foreground">
+											Status
+										</th>
+									</tr>
+								</PremiumTableHeader>
+								<tbody>
+									{previewData.comparisons.map((row, idx) => (
+										<PremiumTableRow
+											key={row.qualityName}
+											isHoverable={false}
+											className="animate-in fade-in duration-200"
+											style={{
+												animationDelay: `${idx * 20}ms`,
+												animationFillMode: "backwards",
+											}}
+										>
+											<td className="px-4 py-2.5 font-medium">
+												{row.instanceTitle ?? row.qualityName}
+											</td>
+											<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+												{row.current?.min ?? "—"}
+											</td>
+											<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+												{row.current?.preferred ?? "—"}
+											</td>
+											<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
+												{row.current?.max ?? "—"}
+											</td>
+											<td
+												className="px-4 py-2.5 text-right tabular-nums font-medium"
+												style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
 											>
-												TRaSH Min
-											</th>
-											<th
-												className="px-4 py-3 text-right font-medium"
-												style={{ color: themeGradient.from }}
+												{row.trash.min}
+											</td>
+											<td
+												className="px-4 py-2.5 text-right tabular-nums font-medium"
+												style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
 											>
-												TRaSH Preferred
-											</th>
-											<th
-												className="px-4 py-3 text-right font-medium"
-												style={{ color: themeGradient.from }}
+												{row.trash.preferred}
+											</td>
+											<td
+												className="px-4 py-2.5 text-right tabular-nums font-medium"
+												style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
 											>
-												TRaSH Max
-											</th>
-											<th className="px-4 py-3 text-center font-medium text-muted-foreground">
-												Status
-											</th>
-										</tr>
-									</thead>
-									<tbody>
-										{previewData.comparisons.map((row, idx) => (
-											<tr
-												key={row.qualityName}
-												className="border-b border-border/30 last:border-0 animate-in fade-in duration-200"
-												style={{
-													animationDelay: `${idx * 20}ms`,
-													animationFillMode: "backwards",
-												}}
-											>
-												<td className="px-4 py-2.5 font-medium">
-													{row.instanceTitle ?? row.qualityName}
-												</td>
-												<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
-													{row.current?.min ?? "—"}
-												</td>
-												<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
-													{row.current?.preferred ?? "—"}
-												</td>
-												<td className="px-4 py-2.5 text-right tabular-nums text-muted-foreground">
-													{row.current?.max ?? "—"}
-												</td>
-												<td
-													className="px-4 py-2.5 text-right tabular-nums font-medium"
-													style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
-												>
-													{row.trash.min}
-												</td>
-												<td
-													className="px-4 py-2.5 text-right tabular-nums font-medium"
-													style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
-												>
-													{row.trash.preferred}
-												</td>
-												<td
-													className="px-4 py-2.5 text-right tabular-nums font-medium"
-													style={row.changed ? { color: SEMANTIC_COLORS.warning.text } : undefined}
-												>
-													{row.trash.max}
-												</td>
-												<td className="px-4 py-2.5 text-center">
-													{!row.matched ? (
-														<MinusCircle className="h-4 w-4 mx-auto text-muted-foreground" />
-													) : row.changed ? (
-														<AlertTriangle
-															className="h-4 w-4 mx-auto"
-															style={{ color: SEMANTIC_COLORS.warning.text }}
-														/>
-													) : (
-														<CheckCircle2
-															className="h-4 w-4 mx-auto"
-															style={{ color: SEMANTIC_COLORS.success.text }}
-														/>
-													)}
-												</td>
-											</tr>
-										))}
-									</tbody>
-								</table>
-							</div>
-						</div>
+												{row.trash.max}
+											</td>
+											<td className="px-4 py-2.5 text-center">
+												{!row.matched ? (
+													<MinusCircle className="h-4 w-4 mx-auto text-muted-foreground" />
+												) : row.changed ? (
+													<AlertTriangle
+														className="h-4 w-4 mx-auto"
+														style={{ color: SEMANTIC_COLORS.warning.text }}
+													/>
+												) : (
+													<CheckCircle2
+														className="h-4 w-4 mx-auto"
+														style={{ color: SEMANTIC_COLORS.success.text }}
+													/>
+												)}
+											</td>
+										</PremiumTableRow>
+									))}
+								</tbody>
+							</table>
+						</PremiumTable>
 					) : null}
 
 					{/* Apply Button */}
 					{previewData && (
 						<div className="space-y-3">
 							<div className="flex items-center gap-4">
-								<button
-									type="button"
+								<GradientButton
 									onClick={handleApply}
 									disabled={
 										applyMutation.isPending ||
@@ -551,10 +558,7 @@ export function QualitySizeManager() {
 										(previewData.summary.changed === 0 &&
 											existingMapping?.presetTrashId === selectedPresetId)
 									}
-									className="rounded-xl px-6 py-2.5 text-sm font-medium text-white transition-all disabled:opacity-50 disabled:cursor-not-allowed hover:brightness-110"
-									style={{
-										background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-									}}
+									className="px-6 py-2.5"
 								>
 									{applyMutation.isPending ? (
 										<span className="flex items-center gap-2">
@@ -564,7 +568,7 @@ export function QualitySizeManager() {
 									) : (
 										`Apply to ${selectedInstance?.label ?? "Instance"}`
 									)}
-								</button>
+								</GradientButton>
 								{previewData.summary.changed === 0 && previewData.summary.matched > 0 && (
 									<span className="text-sm text-muted-foreground">
 										{existingMapping?.presetTrashId === selectedPresetId

--- a/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
@@ -2,6 +2,7 @@
 
 import { AlertCircle, CheckCircle2, Loader2, RefreshCw, XCircle } from "lucide-react";
 import { useCallback, useEffect, useRef } from "react";
+import { PremiumProgress } from "../../../components/layout";
 import { Button } from "../../../components/ui";
 import { useSyncProgress } from "../../../hooks/api/useSync";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
@@ -215,7 +216,8 @@ export const SyncProgressModal = ({
 								</h2>
 								<p id="sync-progress-description" className="mt-1 text-sm text-muted-foreground">
 									Template: <span className="font-medium text-foreground">{templateName}</span> →
-									Instance: <span className="font-medium text-foreground">{displayInstanceName}</span>
+									Instance:{" "}
+									<span className="font-medium text-foreground">{displayInstanceName}</span>
 								</p>
 							</div>
 						</div>
@@ -342,19 +344,11 @@ export const SyncProgressModal = ({
 									<span className="font-medium text-foreground">{progress.currentStep}</span>
 									<span className="text-muted-foreground">{Math.round(progress.progress)}%</span>
 								</div>
-								<div className="h-3 overflow-hidden rounded-full bg-muted/30">
-									<div
-										className="h-full transition-all duration-500 rounded-full"
-										style={{
-											width: `${progress.progress}%`,
-											background: isFailed
-												? `linear-gradient(90deg, ${SEMANTIC_COLORS.error.from}, ${SEMANTIC_COLORS.error.to})`
-												: isCompleted
-													? `linear-gradient(90deg, ${SEMANTIC_COLORS.success.from}, ${SEMANTIC_COLORS.success.to})`
-													: `linear-gradient(90deg, ${themeGradient.from}, ${themeGradient.to})`,
-										}}
-									/>
-								</div>
+								<PremiumProgress
+									value={progress.progress}
+									size="lg"
+									variant={isFailed ? "danger" : isCompleted ? "success" : "default"}
+								/>
 							</div>
 
 							{/* Statistics */}

--- a/apps/web/src/features/trash-guides/components/template-list.tsx
+++ b/apps/web/src/features/trash-guides/components/template-list.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { toast } from "sonner";
-import { PremiumEmptyState } from "../../../components/layout";
+import { GradientButton, PremiumEmptyState } from "../../../components/layout";
 import { useUnlinkTemplateFromInstance } from "../../../hooks/api/useDeploymentPreview";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { useExecuteSync } from "../../../hooks/api/useSync";
@@ -430,17 +430,12 @@ export const TemplateList = ({
 											autoFocus
 										/>
 										<div className="flex gap-2">
-											<button
-												type="button"
+											<GradientButton
 												onClick={() => handleDuplicate(template.id)}
 												disabled={duplicateMutation.isPending || !modals.duplicateName.trim()}
-												className="rounded-xl px-4 py-2 text-sm font-medium transition-all disabled:opacity-50"
-												style={{
-													background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
-												}}
 											>
 												{duplicateMutation.isPending ? "Creating..." : "Create"}
-											</button>
+											</GradientButton>
 											<button
 												type="button"
 												onClick={() => dispatch({ type: "CLOSE_DUPLICATE" })}

--- a/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
+++ b/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
@@ -40,7 +40,7 @@ import { TemplateImportDialog } from "./template-import-dialog";
 import { TemplateList } from "./template-list";
 import { TrashGuidesTabs } from "./trash-guides-tabs";
 
-function PremiumSkeleton() {
+function TrashGuidesPageSkeleton() {
 	const { gradient: themeGradient } = useThemeGradient();
 
 	return (
@@ -139,36 +139,43 @@ function CacheValidationHealthSection() {
 
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 				{categories.map(([category, stats]) => {
-					const cardColor = stats.rejected > 0 ? SEMANTIC_COLORS.warning.from : SEMANTIC_COLORS.success.from;
+					const cardColor =
+						stats.rejected > 0 ? SEMANTIC_COLORS.warning.from : SEMANTIC_COLORS.success.from;
 					return (
-					<div
-						key={category}
-						className="rounded-xl p-4 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-lg hover:shadow-black/10"
-						style={{
-							backgroundColor: `${cardColor}05`,
-							border: `1px solid ${cardColor}12`,
-						}}
-					>
-						<div className="flex items-center justify-between mb-2">
-							<span className="text-sm font-medium text-foreground capitalize">
-								{category.replace(/([A-Z])/g, " $1").trim()}
-							</span>
-							{stats.rejected > 0 ? (
-								<AlertCircle className="h-4 w-4" style={{ color: SEMANTIC_COLORS.warning.from }} />
-							) : (
-								<CheckCircle2 className="h-4 w-4" style={{ color: SEMANTIC_COLORS.success.from }} />
+						<div
+							key={category}
+							className="rounded-xl p-4 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-lg hover:shadow-black/10"
+							style={{
+								backgroundColor: `${cardColor}05`,
+								border: `1px solid ${cardColor}12`,
+							}}
+						>
+							<div className="flex items-center justify-between mb-2">
+								<span className="text-sm font-medium text-foreground capitalize">
+									{category.replace(/([A-Z])/g, " $1").trim()}
+								</span>
+								{stats.rejected > 0 ? (
+									<AlertCircle
+										className="h-4 w-4"
+										style={{ color: SEMANTIC_COLORS.warning.from }}
+									/>
+								) : (
+									<CheckCircle2
+										className="h-4 w-4"
+										style={{ color: SEMANTIC_COLORS.success.from }}
+									/>
+								)}
+							</div>
+							<div className="flex items-baseline gap-1">
+								<span className="text-2xl font-bold text-foreground">{stats.validated}</span>
+								<span className="text-sm text-muted-foreground">/ {stats.total}</span>
+							</div>
+							{stats.rejected > 0 && (
+								<p className="text-xs mt-1" style={{ color: SEMANTIC_COLORS.warning.text }}>
+									{stats.rejected} rejected
+								</p>
 							)}
 						</div>
-						<div className="flex items-baseline gap-1">
-							<span className="text-2xl font-bold text-foreground">{stats.validated}</span>
-							<span className="text-sm text-muted-foreground">/ {stats.total}</span>
-						</div>
-						{stats.rejected > 0 && (
-							<p className="text-xs mt-1" style={{ color: SEMANTIC_COLORS.warning.text }}>
-								{stats.rejected} rejected
-							</p>
-						)}
-					</div>
 					);
 				})}
 			</div>
@@ -253,11 +260,15 @@ export function TrashGuidesClient() {
 						>
 							<div
 								className="absolute inset-0 pointer-events-none"
-								style={{ background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)` }}
+								style={{
+									background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)`,
+								}}
 							/>
 							<div
 								className="absolute left-0 top-0 bottom-0 w-[3px]"
-								style={{ background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})` }}
+								style={{
+									background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
+								}}
 							/>
 							<div className="relative p-6">
 								<div className="flex items-start gap-4">
@@ -274,7 +285,10 @@ export function TrashGuidesClient() {
 										<div className="flex items-center gap-2 mb-1">
 											<span
 												className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider"
-												style={{ backgroundColor: `${themeGradient.from}12`, color: themeGradient.from }}
+												style={{
+													backgroundColor: `${themeGradient.from}12`,
+													color: themeGradient.from,
+												}}
 											>
 												<History className="h-2.5 w-2.5" />
 												History
@@ -309,11 +323,15 @@ export function TrashGuidesClient() {
 					>
 						<div
 							className="absolute inset-0 pointer-events-none"
-							style={{ background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)` }}
+							style={{
+								background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)`,
+							}}
 						/>
 						<div
 							className="absolute left-0 top-0 bottom-0 w-[3px]"
-							style={{ background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})` }}
+							style={{
+								background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
+							}}
 						/>
 						<div className="relative p-6 space-y-4">
 							<span
@@ -327,7 +345,10 @@ export function TrashGuidesClient() {
 								<div className="flex items-center justify-center py-12">
 									<div
 										className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"
-										style={{ borderColor: `${themeGradient.from}40`, borderTopColor: "transparent" }}
+										style={{
+											borderColor: `${themeGradient.from}40`,
+											borderTopColor: "transparent",
+										}}
 									/>
 								</div>
 							) : currentUser?.id ? (
@@ -369,7 +390,7 @@ export function TrashGuidesClient() {
 	}
 
 	if (isLoading) {
-		return <PremiumSkeleton />;
+		return <TrashGuidesPageSkeleton />;
 	}
 
 	if (error) {


### PR DESCRIPTION
## Summary

Charter §3 **Bucket B3** — the last Bucket B sweep. The checkpoint re-inventory shrank the charter's "45+ components" to an honest **7 files / ~15 sites**; everything else is exempt by design, not omission (full taxonomy below).

### Conversions

| File | Conversion |
|---|---|
| `premium-data-display.tsx` | `PremiumTableRow` gains additive `style?` passthrough (staggered `animationDelay`) |
| `deployment-history-table.tsx` | local 60-line `StatusBadge` clone → shared `StatusBadge`; raw table → `PremiumTable/Header/Row`; empty state → `PremiumEmptyState` |
| `naming-history-table.tsx` | same three conversions |
| `quality-size-manager.tsx` | comparison table → `PremiumTable` family (`isHoverable={false}` preserves non-hover rows); 2 gradient submit buttons → `GradientButton` |
| `naming-manager.tsx` | preset preview table → `PremiumTable` family; apply/confirm buttons → `GradientButton` |
| `sync-progress-modal.tsx` | hand-rolled progress bar → `PremiumProgress` (failed→`danger`, completed→`success`, else theme) |
| `template-list.tsx` | duplicate-confirm button → `GradientButton` |
| `trash-guides-client.tsx` | local component **named `PremiumSkeleton`** shadowed the shared primitive's name → renamed `TrashGuidesPageSkeleton` (zero visual change; rest of diff is biome whitespace) |

### Declared normalizations (each visually verified)

- Table wrappers `bg-muted/10 border-border/30 rounded-2xl` → `bg-card/30 border-border/50 rounded-xl` + `muted/30` header band — aligns with History / Search / Backups / Audit-log tables app-wide
- Badges `rounded-lg px-2.5 py-1` → `rounded-md px-2 py-0.5`; naming badge gains its previously-missing border (`borderColor` was set with no border width — a latent bug)
- Buttons hover `brightness-110` → scale+shadow; `IN_PROGRESS` badge `SEMANTIC.info` → theme-aware info
- Empty states gain gradient icon tile + dashed `border-2`

### EXEMPT taxonomy (why "45+" became 7)

- **46 glassmorphic divs** — CLAUDE.md blesses the raw pattern; `GlassmorphicCard` would add entrance animations + radius change inside modals (downgrade dressed as consistency)
- **Underline tab nav** — matches the dashboard's own nav; pill-style `PremiumTabs` would diverge
- **21 wizard/editor files** — styling encodes domain state (amber=instance vs green=TRaSH, confidence levels)
- **bulk-score-manager table** — sticky first column requires opaque `bg-card/95`; glassy header breaks it
- **12 raw selects** — more styled than `FilterSelect` (custom chevrons, theme rings); conversion = downgrade
- **Service-gradient buttons** — `GradientButton` is theme-gradient-only

### Visual verification (before → after)

| Surface | Before | After |
|---|---|---|
| History table (20 live rows) | `b3-before-history.png` | `b3-after-history.png` |
| Quality Size preview + apply | `b3-before-quality-size-preview.png` | `b3-after-quality-size-preview.png` |
| Naming preview table | `b3-before-naming-preview-table.png` | `b3-after-naming-preview-table.png` |
| Naming history empty state | `b3-before-naming-history.png` | `b3-after-naming-history.png` |
| Duplicate dialog button | `b3-before-duplicate-dialog.png` | `b3-after-duplicate-dialog.png` |

Zero console errors on every surface. **Not live-triggered:** `sync-progress-modal` (requires a real template deployment against live instances) — its `PremiumProgress` equivalence is code-level only.

### Validation

- turbo `typecheck` green; **500/500** web tests; lint **0 errors** (26 pre-existing warnings in untouched files); biome format clean on touched files
- No data flowing to saves/payloads touched; row stagger + non-hoverable semantics preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)