### PR TITLE
feat(lint): hex-color gate for apps/web (B2 follow-up)

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,7 +9,15 @@ import globals from "globals";
 /** @type {import('eslint').Linter.Config[]} */
 const eslintConfig = [
 	{
-		ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "coverage/**", "next-env.d.ts", "server.js"],
+		ignores: [
+			"node_modules/**",
+			".next/**",
+			"out/**",
+			"build/**",
+			"coverage/**",
+			"next-env.d.ts",
+			"server.js",
+		],
 	},
 	{
 		files: ["**/*.{js,jsx,ts,tsx}"],
@@ -60,6 +68,26 @@ const eslintConfig = [
 			// Console usage — use structured error handling, not console.log
 			"no-console": ["warn", { allow: ["warn", "error"] }],
 
+			// Hardcoded hex colors — use SEMANTIC_COLORS / BRAND_COLORS /
+			// useThemeGradient() from lib/theme-gradients.ts instead (B2 sweep
+			// follow-up). AST-based so issue numbers in comments (#474) never
+			// false-positive. Palette-definition files are exempted below;
+			// genuine one-offs need an eslint-disable with a reason.
+			"no-restricted-syntax": [
+				"error",
+				{
+					selector: "Literal[value=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]",
+					message:
+						"Hardcoded hex color. Use SEMANTIC_COLORS / BRAND_COLORS or useThemeGradient() from lib/theme-gradients.ts. If this is a genuine carve-out, add an eslint-disable comment with the reason.",
+				},
+				{
+					selector:
+						"TemplateElement[value.raw=/#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})\\b/]",
+					message:
+						"Hardcoded hex color in template literal. Use SEMANTIC_COLORS / BRAND_COLORS or useThemeGradient() from lib/theme-gradients.ts. If this is a genuine carve-out, add an eslint-disable comment with the reason.",
+				},
+			],
+
 			// Unused imports - auto-fixable
 			"unused-imports/no-unused-imports": "warn",
 			"unused-imports/no-unused-vars": [
@@ -74,6 +102,27 @@ const eslintConfig = [
 				},
 			],
 			"@typescript-eslint/no-unused-vars": "off", // Handled by unused-imports
+		},
+	},
+	{
+		// Palette-definition files — these ARE the places hex colors belong:
+		// theme-gradients is the token source itself; color-theme-provider
+		// defines the theme palettes; queue-cleaner constants is a categorical
+		// chart palette (9 distinct hues — semantic tokens would lose
+		// distinguishability); appearance-preview fakes browser chrome
+		// (charter carve-out).
+		files: [
+			"tailwind.config.ts",
+			"src/lib/theme-gradients.ts",
+			"src/providers/color-theme-provider.tsx",
+			"src/features/queue-cleaner/lib/constants.ts",
+			"src/features/settings/components/appearance-preview.tsx",
+			// Tests stub theme-gradient objects with literal colors
+			"**/__tests__/**",
+			"**/*.test.{ts,tsx}",
+		],
+		rules: {
+			"no-restricted-syntax": "off",
 		},
 	},
 ];

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -360,6 +360,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 							>
 								<Smartphone
 									className="h-4 w-4"
+									// eslint-disable-next-line no-restricted-syntax -- OLED mode forces pure white over theme color
 									style={{ color: isOLED && isDarkMode ? "#fff" : themeGradient.from }}
 								/>
 							</div>

--- a/apps/web/src/features/dashboard/components/on-deck-widget.tsx
+++ b/apps/web/src/features/dashboard/components/on-deck-widget.tsx
@@ -148,8 +148,10 @@ export const OnDeckWidget = ({ hasPlexInstances, hasJellyfinInstances, animation
 								const bgGradient =
 									item.mediaType === "movie"
 										? // Decorative poster-placeholder art, categorical not semantic (B2 carve-out)
+											// eslint-disable-next-line no-restricted-syntax -- decorative categorical art
 											"linear-gradient(160deg, #92400e 0%, #f59e0b 100%)"
-										: "linear-gradient(160deg, #164e63 0%, #06b6d4 100%)";
+										: // eslint-disable-next-line no-restricted-syntax -- decorative categorical art
+											"linear-gradient(160deg, #164e63 0%, #06b6d4 100%)";
 								const thumbKey = item.key;
 								const hasThumb = item.thumbUrl && !failedThumbs.has(thumbKey);
 								const libraryHref = item.tmdbId ? `/library?tmdbId=${item.tmdbId}` : "/library";

--- a/apps/web/src/features/dashboard/components/recently-added-widget.tsx
+++ b/apps/web/src/features/dashboard/components/recently-added-widget.tsx
@@ -164,8 +164,10 @@ export const RecentlyAddedWidget = ({ hasPlexInstances, hasJellyfinInstances, an
 								const bgGradient =
 									item.mediaType === "movie"
 										? // Decorative poster-placeholder art, categorical not semantic (B2 carve-out)
+											// eslint-disable-next-line no-restricted-syntax -- decorative categorical art
 											"linear-gradient(160deg, #92400e 0%, #f59e0b 100%)"
-										: "linear-gradient(160deg, #164e63 0%, #06b6d4 100%)";
+										: // eslint-disable-next-line no-restricted-syntax -- decorative categorical art
+											"linear-gradient(160deg, #164e63 0%, #06b6d4 100%)";
 								const thumbKey = item.key;
 								const hasThumb = item.thumbUrl && !failedThumbs.has(thumbKey);
 								const libraryHref = item.tmdbId ? `/library?tmdbId=${item.tmdbId}` : "/library";

--- a/apps/web/src/features/discover/components/discover-genre-filter.tsx
+++ b/apps/web/src/features/discover/components/discover-genre-filter.tsx
@@ -147,6 +147,7 @@ const GenrePill: React.FC<GenrePillProps> = ({
 				? {
 						background: `linear-gradient(135deg, ${themeFrom}, ${themeTo})`,
 						borderColor: "transparent",
+						// eslint-disable-next-line no-restricted-syntax -- white-on-accent chip text (not semantic)
 						color: "#fff",
 						boxShadow: `0 2px 8px -2px ${themeFrom}60`,
 					}

--- a/apps/web/src/features/discover/lib/seerr-image-utils.ts
+++ b/apps/web/src/features/discover/lib/seerr-image-utils.ts
@@ -57,6 +57,7 @@ export function getMediaStatusInfo(status: SeerrMediaStatus | undefined): MediaS
 				label: "Processing",
 				bg: "rgba(234, 179, 8, 0.1)",
 				border: "rgba(234, 179, 8, 0.3)",
+				// eslint-disable-next-line no-restricted-syntax -- categorical yellow, deliberately distinct from warning amber
 				text: "#facc15",
 			};
 		case SEERR_MEDIA_STATUS.PARTIALLY_AVAILABLE:

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -1750,7 +1750,8 @@ export function CleanupRuleDialog({
 													? {
 															borderColor: svcGradient.from,
 															backgroundColor: svcGradient.from,
-															color: "#ffffff", // white-on-accent chip text (B2 carve-out: not semantic)
+															// eslint-disable-next-line no-restricted-syntax -- white-on-accent chip text (B2 carve-out: not semantic)
+															color: "#ffffff",
 														}
 													: {
 															borderColor: `${svcGradient.from}40`,

--- a/apps/web/src/features/library/components/album-breakdown-modal.tsx
+++ b/apps/web/src/features/library/components/album-breakdown-modal.tsx
@@ -51,6 +51,7 @@ const ALBUM_TYPE_COLORS: Record<string, { bg: string; border: string; text: stri
 	EP: SEMANTIC_COLORS.info,
 	// Categorical format-badge color (B2 carve-out): album types are a data
 	// palette, not semantic status — purple has no SEMANTIC_COLORS meaning.
+	// eslint-disable-next-line no-restricted-syntax -- categorical data palette (B2 carve-out)
 	Single: { bg: "rgba(168, 85, 247, 0.1)", border: "rgba(168, 85, 247, 0.3)", text: "#a855f7" },
 };
 

--- a/apps/web/src/features/settings/components/appearance-tab.tsx
+++ b/apps/web/src/features/settings/components/appearance-tab.tsx
@@ -221,6 +221,7 @@ export function AppearanceTab() {
 											>
 												<Smartphone
 													className="h-5 w-5 transition-colors duration-300"
+													// eslint-disable-next-line no-restricted-syntax -- OLED mode forces pure white over theme color
 													style={{ color: isOLED ? "#fff" : activeGradient.from }}
 												/>
 											</div>
@@ -391,6 +392,7 @@ export function AppearanceTab() {
 											className="inline-block h-1.5 w-1.5 rounded-full"
 											style={{
 												// Decorative section-header dot, not a theme/semantic color (B2 carve-out)
+												// eslint-disable-next-line no-restricted-syntax -- gradient-picker preview swatch
 												background: "linear-gradient(135deg, #ff00ff, #00ffff)",
 											}}
 										/>
@@ -472,6 +474,7 @@ export function AppearanceTab() {
 											className="inline-block h-1.5 w-1.5 rounded-full"
 											style={{
 												// Decorative section-header dot, not a theme/semantic color (B2 carve-out)
+												// eslint-disable-next-line no-restricted-syntax -- gradient-picker preview swatch
 												background: "linear-gradient(135deg, #ffd700, #ff8c00)",
 											}}
 										/>

--- a/apps/web/src/features/statistics/components/overview-tab.tsx
+++ b/apps/web/src/features/statistics/components/overview-tab.tsx
@@ -153,6 +153,7 @@ export const OverviewTab = ({
 						<div
 							className="flex h-8 w-8 items-center justify-center rounded-lg shrink-0"
 							style={{
+								// eslint-disable-next-line no-restricted-syntax -- decorative tile gradient; amber-600 pair has no token
 								background: "linear-gradient(135deg, #f59e0b20, #d9770620)",
 							}}
 						>
@@ -236,6 +237,7 @@ export const OverviewTab = ({
 					<div
 						className="flex h-8 w-8 items-center justify-center rounded-lg shrink-0"
 						style={{
+							// eslint-disable-next-line no-restricted-syntax -- decorative tile gradient; emerald has no token
 							background: "linear-gradient(135deg, #10b98120, #05966920)",
 						}}
 					>


### PR DESCRIPTION
## Summary

B2 follow-up (ex-session-task #64): an ESLint gate preventing new hardcoded hex colors in `apps/web`, so the SEMANTIC_COLORS sweep doesn't erode.

### Design

- **AST-based** `no-restricted-syntax` selectors on `Literal` + `TemplateElement` — issue numbers in comments (`#474` is valid hex!) can never false-positive; a regex grep would have flagged 35 of them
- **Error severity** — ESLint exits non-zero only on errors, so this is a real CI gate (warnings don't fail CI)
- **Two-tier exemptions**:
  - *Config-level* for palette-definition files — the places hex belongs: `tailwind.config.ts`, `theme-gradients.ts` (token source), `color-theme-provider.tsx` (theme palettes), queue-cleaner `constants.ts` (categorical 9-hue chart palette — semantic tokens would lose distinguishability), `appearance-preview.tsx` (charter carve-out), test fixtures
  - *Inline disables with reasons* for 12 genuine one-offs (OLED forced-white, gradient-picker swatches, decorative categorical art — several already carried B2 carve-out comments and just needed the mechanical marker)

### Verification

- Gate negative-tested with probe files — fires on both string literals and template literals, then probes removed
- Zero rendered-output changes (every edit is a comment or config)
- turbo typecheck ✅ · 500/500 web tests ✅ · lint 0 errors (26 pre-existing warnings unchanged) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)