### PR TITLE
feat(notifications): per-event-type metadata schema registry (Operator Console PR 1)

### DIFF
--- a/apps/api/src/lib/notifications/__tests__/metadata-registry-conformance.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/metadata-registry-conformance.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Emitter ↔ registry conformance suite.
+ *
+ * Every notification emit site in apps/api/src passes a metadata object
+ * (or none); the per-event-type schema registry in @arr/shared
+ * (notification-metadata.ts) documents those shapes. These fixtures mirror
+ * the EXACT metadata literals at each emit site (verified 2026-06-10) so
+ * that drift in either direction — an emitter adding a key without a
+ * registry entry, or a registry edit that no emitter satisfies — fails
+ * here instead of warn-spamming production logs.
+ *
+ * When this test fails after you changed an emitter: update the registry
+ * AND the fixture together. The registry documents the wire, not the ideal.
+ *
+ * qui torrent-state events are validated through the real payload builder
+ * (buildNotificationPayloads) instead of hand-copied fixtures.
+ */
+
+import { eventMetadataSchemaMap, type NotificationEventType } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import { buildNotificationPayloads } from "../../qui/torrent-state-notifier.js";
+
+/** One fixture per emit-site shape: [description, eventType, metadata]. */
+const EMIT_SITE_FIXTURES: Array<[string, NotificationEventType, Record<string, unknown>]> = [
+	// apps/api/src/index.ts — startup notification
+	[
+		"index.ts startup",
+		"SYSTEM_STARTUP",
+		{
+			version: "3.0.0-alpha.2",
+			nodeVersion: "v22.11.0",
+			database: "sqlite",
+			host: "0.0.0.0",
+			port: 3001,
+		},
+	],
+	// apps/api/src/routes/auth.ts
+	[
+		"auth.ts lockout",
+		"ACCOUNT_LOCKED",
+		{ username: "admin", ip: "203.0.113.7", failedAttempts: 5, lockedMinutes: 15 },
+	],
+	[
+		"auth.ts failed login",
+		"LOGIN_FAILED",
+		{ username: "admin", ip: "203.0.113.7", failedAttempts: 3, maxAttempts: 5 },
+	],
+	// apps/api/src/routes/services.ts — connection test failure
+	[
+		"services.ts connection test",
+		"SERVICE_CONNECTION_FAILED",
+		{ service: "sonarr", baseUrl: "http://sonarr.example:8989" },
+	],
+	// apps/api/src/routes/trash-guides/deployment-routes.ts — two shapes
+	[
+		"deployment-routes.ts single deploy",
+		"TRASH_DEPLOY_FAILED",
+		{ instance: "Sonarr Main", templateId: "tpl-1080p" },
+	],
+	[
+		"deployment-routes.ts bulk deploy",
+		"TRASH_DEPLOY_FAILED",
+		{ totalInstances: 3, failedInstances: 1, templateId: "tpl-1080p" },
+	],
+	// apps/api/src/lib/backup/backup-scheduler.ts
+	[
+		"backup-scheduler.ts completed",
+		"BACKUP_COMPLETED",
+		{ nextRunAt: "2026-06-11T03:00:00.000Z", intervalType: "daily", retentionCount: 7 },
+	],
+	// apps/api/src/lib/library-cleanup/cleanup-scheduler.ts — two outcomes
+	[
+		"cleanup-scheduler.ts actions taken",
+		"CLEANUP_ITEMS_REMOVED",
+		{ itemsRemoved: 2, itemsUnmonitored: 1, itemsFilesDeleted: 1 },
+	],
+	["cleanup-scheduler.ts flag-only", "CLEANUP_ITEMS_FLAGGED", { itemsFlagged: 4 }],
+	// apps/api/src/lib/library-sync/sync-scheduler.ts
+	[
+		"library-sync new downloads",
+		"LIBRARY_NEW_CONTENT",
+		{ instance: "Sonarr Main", service: "sonarr", itemCount: 2, items: ["Show A", "Show B"] },
+	],
+	// apps/api/src/lib/hunting/scheduler.ts — shared huntMeta (success paths
+	// and the returned-error path) + the reduced thrown-error shape
+	[
+		"hunting full huntMeta (content found)",
+		"HUNT_CONTENT_FOUND",
+		{
+			instance: "Radarr Main",
+			service: "radarr",
+			huntType: "missing",
+			itemsSearched: 10,
+			itemsGrabbed: 2,
+			apiCalls: 12,
+			durationMs: 5400,
+			grabbedItems: ["Movie A", "Movie B"],
+		},
+	],
+	[
+		"hunting full huntMeta (completed, nothing grabbed)",
+		"HUNT_COMPLETED",
+		{
+			instance: "Radarr Main",
+			service: "radarr",
+			huntType: "upgrade",
+			itemsSearched: 10,
+			itemsGrabbed: 0,
+			apiCalls: 11,
+			durationMs: 4100,
+			grabbedItems: [],
+		},
+	],
+	[
+		"hunting returned-error result (full huntMeta)",
+		"HUNT_FAILED",
+		{
+			instance: "Radarr Main",
+			service: "radarr",
+			huntType: "missing",
+			itemsSearched: 0,
+			itemsGrabbed: 0,
+			apiCalls: 1,
+			durationMs: 300,
+			grabbedItems: [],
+		},
+	],
+	[
+		"hunting thrown-error path (reduced shape)",
+		"HUNT_FAILED",
+		{ instance: "Radarr Main", service: "radarr", huntType: "missing", durationMs: 300 },
+	],
+	// apps/api/src/lib/queue-cleaner/scheduler.ts
+	[
+		"queue-cleaner removals",
+		"QUEUE_ITEMS_REMOVED",
+		{
+			instance: "Sonarr Main",
+			service: "sonarr",
+			itemsCleaned: 3,
+			itemsSkipped: 1,
+			durationMs: 800,
+			cleanedItems: ["Show A (stalled)", "Show B (failed_import)"],
+		},
+	],
+	[
+		"queue-cleaner strikes",
+		"QUEUE_STRIKES_ISSUED",
+		{
+			instance: "Sonarr Main",
+			service: "sonarr",
+			itemsWarned: 2,
+			warnedItems: ["Show A (slow)", "Show B (stalled)"],
+		},
+	],
+	[
+		"queue-cleaner failure",
+		"QUEUE_CLEANER_FAILED",
+		{ instance: "Sonarr Main", service: "sonarr", durationMs: 120 },
+	],
+	// apps/api/src/lib/trash-guides/sync-scheduler.ts — three metadata shapes
+	[
+		"trash sync-scheduler validation failure",
+		"TRASH_SYNC_ERROR",
+		{ templateId: "tpl-1080p", instanceId: "inst-1", reason: "validation_failed" },
+	],
+	[
+		"trash sync-scheduler sync failure",
+		"TRASH_SYNC_ERROR",
+		{ templateId: "tpl-1080p", instanceId: "inst-1" },
+	],
+	[
+		"trash sync-scheduler scheduled sync success",
+		"TRASH_PROFILE_UPDATED",
+		{ templateId: "tpl-1080p", instanceId: "inst-1", syncId: "sync-42" },
+	],
+	// apps/api/src/lib/trash-guides/update-scheduler.ts — rollup shape
+	[
+		"trash update-scheduler rollup",
+		"TRASH_PROFILE_UPDATED",
+		{ templatesAutoSynced: 2, templatesNeedingAttention: 1, qualitySizeAutoSynced: 3 },
+	],
+	// apps/api/src/lib/validation/integration-health.ts — note the
+	// stringified failureCount; the registry documents the wire reality.
+	[
+		"integration-health degradation",
+		"VALIDATION_HEALTH_DEGRADED",
+		{ integration: "plex", failureCount: "3", affectedCategories: "sessions, library" },
+	],
+	// apps/api/src/lib/notifications/insights-digest.ts
+	[
+		"insights-digest requested-unwatched",
+		"LIBRARY_INSIGHT_REQUESTED_UNWATCHED",
+		{ count: 3, signal: "requested_unwatched" },
+	],
+	[
+		"insights-digest watched-monitored",
+		"LIBRARY_INSIGHT_WATCHED_MONITORED",
+		{ count: 2, signal: "watched_monitored" },
+	],
+];
+
+describe("emit-site metadata conforms to the registry schemas", () => {
+	it.each(EMIT_SITE_FIXTURES)("%s", (_description, eventType, metadata) => {
+		const result = eventMetadataSchemaMap[eventType].safeParse(metadata);
+		expect(result.success, JSON.stringify(result.success ? null : result.error.issues)).toBe(true);
+	});
+
+	it("qui torrent-state payloads (real builder, individual variant)", () => {
+		const payloads = buildNotificationPayloads([
+			{
+				kind: "errored",
+				infoHash: "abc123",
+				title: "Some Show S01E01",
+				instanceLabel: "qui main",
+				oldState: null,
+				newState: "error",
+			},
+		]);
+		expect(payloads).toHaveLength(1);
+		for (const payload of payloads) {
+			const result = eventMetadataSchemaMap[payload.eventType].safeParse(payload.metadata);
+			expect(result.success, JSON.stringify(result.success ? null : result.error.issues)).toBe(
+				true,
+			);
+		}
+	});
+
+	it("qui torrent-state payloads (real builder, aggregate variant)", () => {
+		const transitions = Array.from({ length: 8 }, (_, i) => ({
+			kind: "stalled" as const,
+			infoHash: `hash-${i}`,
+			title: `Torrent ${i}`,
+			instanceLabel: "qui main",
+			oldState: "downloading",
+			newState: "stalled_dl",
+		}));
+		const payloads = buildNotificationPayloads(transitions);
+		expect(payloads).toHaveLength(1); // storm rollup
+		for (const payload of payloads) {
+			const result = eventMetadataSchemaMap[payload.eventType].safeParse(payload.metadata);
+			expect(result.success, JSON.stringify(result.success ? null : result.error.issues)).toBe(
+				true,
+			);
+		}
+	});
+});

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -1,4 +1,4 @@
-import type { NotificationChannelType } from "@arr/shared";
+import { eventMetadataSchemaMap, type NotificationChannelType } from "@arr/shared";
 
 const REDACTED_PLACEHOLDER = "••••••••";
 const SECRET_FIELD_NAMES = new Set([
@@ -20,14 +20,14 @@ function redactSecretFields(config: Record<string, unknown>): Record<string, unk
 		]),
 	);
 }
+
 import type { Encryptor } from "../auth/encryption.js";
 import type { PrismaClient } from "../prisma.js";
 import type { AggregationBuffer, AggregationConfig } from "./aggregation-buffer.js";
 import type { DedupGate } from "./dedup-gate.js";
 import type { NotificationDispatcher } from "./notification-dispatcher.js";
 import type { RetryHandler } from "./retry-handler.js";
-import type { RuleEngine } from "./rule-engine.js";
-import type { NotificationRule } from "./rule-engine.js";
+import type { NotificationRule, RuleEngine } from "./rule-engine.js";
 import type { ChannelFormField, NotificationLogger, NotificationPayload } from "./types.js";
 
 /**
@@ -140,6 +140,30 @@ export class NotificationService {
 	 * Failures on individual channels are logged but do not throw.
 	 */
 	async notify(payload: NotificationPayload, options?: { skipRules?: boolean }): Promise<void> {
+		// Conformance check against the per-event-type metadata schema
+		// registry (@arr/shared notification-metadata). Warn-only: a mismatch
+		// means an emitter and the registry drifted apart — that's a bug to
+		// fix in code, never a reason to drop a user's notification. Skipped
+		// for deferred re-delivery (skipRules), which already validated on
+		// first entry. The lookup is guarded even though the registry Record
+		// is compile-time exhaustive: a non-enum eventType sneaking in at
+		// runtime must not turn this advisory check into a delivery failure.
+		const registrySchema = payload.metadata ? eventMetadataSchemaMap[payload.eventType] : undefined;
+		if (registrySchema && payload.metadata && !options?.skipRules) {
+			const conformance = registrySchema.safeParse(payload.metadata);
+			if (!conformance.success) {
+				this.logger.warn(
+					{
+						eventType: payload.eventType,
+						issues: conformance.error.issues.map(
+							(issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`,
+						),
+					},
+					"Notification metadata does not match the registry schema (registry drift)",
+				);
+			}
+		}
+
 		// Dedup: skip if an identical payload was dispatched within the TTL window
 		if (this.dedupGate.isDuplicate(payload)) {
 			this.logger.debug({ eventType: payload.eventType }, "Duplicate notification suppressed");

--- a/packages/shared/src/types/__tests__/notification-metadata.test.ts
+++ b/packages/shared/src/types/__tests__/notification-metadata.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+	describeEventMetadata,
+	eventMetadataSchemaMap,
+	NOTIFICATION_EVENT_METADATA,
+} from "../notification-metadata";
+import { notificationEventTypeSchema } from "../notifications";
+
+describe("NOTIFICATION_EVENT_METADATA registry", () => {
+	it("has an entry for every notification event type", () => {
+		// The Record type already enforces this at compile time; this pins it
+		// at runtime too so a future type-level loosening can't slip through.
+		for (const eventType of notificationEventTypeSchema.options) {
+			expect(NOTIFICATION_EVENT_METADATA[eventType]).toBeDefined();
+		}
+		expect(Object.keys(NOTIFICATION_EVENT_METADATA).sort()).toEqual(
+			[...notificationEventTypeSchema.options].sort(),
+		);
+	});
+
+	it("declares unique keys per event type", () => {
+		for (const eventType of notificationEventTypeSchema.options) {
+			const keys = NOTIFICATION_EVENT_METADATA[eventType].map((f) => f.key);
+			expect(new Set(keys).size).toBe(keys.length);
+		}
+	});
+
+	it("gives every field a non-empty description (composer field-picker copy)", () => {
+		for (const eventType of notificationEventTypeSchema.options) {
+			for (const field of NOTIFICATION_EVENT_METADATA[eventType]) {
+				expect(field.description.length, `${eventType}.${field.key}`).toBeGreaterThan(0);
+			}
+		}
+	});
+});
+
+describe("eventMetadataSchemaMap (derived schemas)", () => {
+	it("rejects keys not declared in the registry (drift detection)", () => {
+		const result = eventMetadataSchemaMap.ACCOUNT_LOCKED.safeParse({
+			username: "admin",
+			ip: "10.0.0.1",
+			failedAttempts: 5,
+			lockedMinutes: 15,
+			smuggled: "nope",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects wrong value types", () => {
+		const result = eventMetadataSchemaMap.CLEANUP_ITEMS_FLAGGED.safeParse({
+			itemsFlagged: "four",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("rejects missing required keys", () => {
+		const result = eventMetadataSchemaMap.SERVICE_CONNECTION_FAILED.safeParse({
+			service: "sonarr",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("honors optional fields (variant shapes parse without them)", () => {
+		const minimalHuntFailure = eventMetadataSchemaMap.HUNT_FAILED.safeParse({
+			instance: "Sonarr Main",
+			service: "sonarr",
+			huntType: "missing",
+			durationMs: 1200,
+		});
+		expect(minimalHuntFailure.success).toBe(true);
+	});
+
+	it("honors nullable fields (qui oldState is null on first sight)", () => {
+		const result = eventMetadataSchemaMap.QUI_TORRENT_ERRORED.safeParse({
+			aggregate: false,
+			kind: "errored",
+			infoHash: "abc123",
+			torrentTitle: "Some Show S01E01",
+			instanceLabel: "qui main",
+			oldState: null,
+			newState: "error",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts an empty object for no-metadata event types", () => {
+		expect(eventMetadataSchemaMap.CACHE_REFRESH_STALE.safeParse({}).success).toBe(true);
+		expect(eventMetadataSchemaMap.PLEX_CONCURRENT_PEAK.safeParse({ anything: 1 }).success).toBe(
+			false,
+		);
+	});
+});
+
+describe("describeEventMetadata", () => {
+	it("returns the registry entry for the event type", () => {
+		expect(describeEventMetadata("BACKUP_FAILED")).toEqual([]);
+		expect(describeEventMetadata("LOGIN_FAILED").map((f) => f.key)).toEqual([
+			"username",
+			"ip",
+			"failedAttempts",
+			"maxAttempts",
+		]);
+	});
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -8,6 +8,7 @@ export * from "./label-sync";
 export * from "./library";
 export * from "./library-cleanup";
 export * from "./manual-import";
+export * from "./notification-metadata";
 export * from "./notifications";
 export * from "./oidc-provider";
 export * from "./password";

--- a/packages/shared/src/types/notification-metadata.ts
+++ b/packages/shared/src/types/notification-metadata.ts
@@ -1,0 +1,417 @@
+import { z } from "zod";
+import type { NotificationEventType } from "./notifications";
+
+// ============================================================================
+// Per-event-type metadata schema registry
+// ============================================================================
+//
+// Notification event metadata was historically free-form
+// (`Record<string, unknown>`) populated ad-hoc by each emitter. This registry
+// is the single source of truth for which metadata keys each event type
+// actually carries on the wire — verified against every emit site in
+// apps/api/src (2026-06-10).
+//
+// Consumers:
+// - The rule composer (Operator Console) enumerates these descriptors to
+//   offer `metadata.*` condition fields per event type instead of
+//   guess-the-key free text (design doc §5.2).
+// - NotificationService validates outgoing payloads against the derived
+//   Zod schemas (warn-only — a mismatch is registry drift to fix, never a
+//   reason to drop a notification).
+//
+// Registry rules:
+// - Descriptors document the ACTUAL wire shape, not the ideal one (e.g.
+//   VALIDATION_HEALTH_DEGRADED stringifies failureCount — recorded as
+//   "string", not "number").
+// - `optional: true` means the key is absent on at least one emit path.
+//   This matters to rule authors: an absent field fails EVERY operator,
+//   including `not_equals` (see apps/api/src/lib/notifications/
+//   condition-matcher.ts) — the composer surfaces that caveat from this
+//   flag.
+// - The Record over NotificationEventType is the exhaustiveness gate: a
+//   new event type does not compile until it declares its metadata here
+//   (an empty array is a valid declaration meaning "no metadata").
+
+/** Wire type of one metadata value. */
+export type NotificationMetadataFieldType = "string" | "number" | "boolean" | "string_array";
+
+/** Describes one metadata key an event type may carry. */
+export interface NotificationMetadataField {
+	key: string;
+	type: NotificationMetadataFieldType;
+	/** Key is absent on at least one emit path (variant shapes, conditional emitters). */
+	optional?: boolean;
+	/** Value may be null when the key is present. */
+	nullable?: boolean;
+	/** Human-readable description, shown in the composer's field picker. */
+	description: string;
+}
+
+// Shared descriptor fragments for emitters that stamp instance context.
+const INSTANCE_FIELDS: readonly NotificationMetadataField[] = [
+	{ key: "instance", type: "string", description: "Instance label the event originated from" },
+	{
+		key: "service",
+		type: "string",
+		description: "Service type of the instance (e.g. sonarr, radarr)",
+	},
+];
+
+// Hunting emits one shared meta object on success paths; the thrown-error
+// path emits a reduced shape (instance/service/huntType/durationMs only).
+const HUNT_BASE_FIELDS: readonly NotificationMetadataField[] = [
+	...INSTANCE_FIELDS,
+	{ key: "huntType", type: "string", description: 'Hunt type: "missing" or "upgrade"' },
+	{ key: "durationMs", type: "number", description: "Hunt run duration in milliseconds" },
+];
+
+const HUNT_RESULT_FIELDS: readonly NotificationMetadataField[] = [
+	{ key: "itemsSearched", type: "number", description: "Items the hunt searched" },
+	{ key: "itemsGrabbed", type: "number", description: "Items the hunt grabbed" },
+	{ key: "apiCalls", type: "number", description: "*arr API calls the hunt made" },
+	{
+		key: "grabbedItems",
+		type: "string_array",
+		description: "Titles of grabbed items (first 5; empty array when nothing grabbed)",
+	},
+];
+
+// qui torrent-state events share one builder with two variants discriminated
+// by `aggregate` (storm rollup vs individual transition) — see
+// apps/api/src/lib/qui/torrent-state-notifier.ts.
+const QUI_TORRENT_FIELDS: readonly NotificationMetadataField[] = [
+	{
+		key: "aggregate",
+		type: "boolean",
+		description: "true = storm rollup of many transitions; false = single torrent",
+	},
+	{
+		key: "kind",
+		type: "string",
+		description: 'Transition kind: "errored", "stalled" or "completed"',
+	},
+	{
+		key: "count",
+		type: "number",
+		optional: true,
+		description: "Number of torrents in the rollup (aggregate notifications only)",
+	},
+	{
+		key: "sampleTitles",
+		type: "string_array",
+		optional: true,
+		description: "Sample torrent titles (first 5; aggregate notifications only)",
+	},
+	{
+		key: "infoHash",
+		type: "string",
+		optional: true,
+		description: "Torrent info-hash (individual notifications only)",
+	},
+	{
+		key: "torrentTitle",
+		type: "string",
+		optional: true,
+		description: "*arr library title of the torrent (individual notifications only)",
+	},
+	{
+		key: "instanceLabel",
+		type: "string",
+		optional: true,
+		description: "qui instance label (individual notifications only)",
+	},
+	{
+		key: "oldState",
+		type: "string",
+		optional: true,
+		nullable: true,
+		description: "Previous torrent state; null when first seen (individual notifications only)",
+	},
+	{
+		key: "newState",
+		type: "string",
+		optional: true,
+		description: "New torrent state (individual notifications only)",
+	},
+];
+
+const LIBRARY_INSIGHT_FIELDS = (signal: string): readonly NotificationMetadataField[] => [
+	{ key: "count", type: "number", description: "Number of items matching the insight" },
+	{ key: "signal", type: "string", description: `Insight signal identifier (always "${signal}")` },
+];
+
+/**
+ * The registry. One entry per notification event type; an empty array means
+ * the event carries no metadata. Keep this in sync with the emit sites —
+ * the api-side conformance test pins each emitter's shape against it.
+ */
+export const NOTIFICATION_EVENT_METADATA: Record<
+	NotificationEventType,
+	readonly NotificationMetadataField[]
+> = {
+	// Hunting — apps/api/src/lib/hunting/scheduler.ts
+	HUNT_CONTENT_FOUND: [...HUNT_BASE_FIELDS, ...HUNT_RESULT_FIELDS],
+	HUNT_COMPLETED: [...HUNT_BASE_FIELDS, ...HUNT_RESULT_FIELDS],
+	HUNT_FAILED: [
+		...HUNT_BASE_FIELDS,
+		// Absent on the thrown-error path, present when a hunt returns an
+		// error result after running.
+		...HUNT_RESULT_FIELDS.map((f) => ({ ...f, optional: true })),
+	],
+
+	// Queue Cleaner — apps/api/src/lib/queue-cleaner/scheduler.ts
+	QUEUE_ITEMS_REMOVED: [
+		...INSTANCE_FIELDS,
+		{ key: "itemsCleaned", type: "number", description: "Items removed from the queue" },
+		{ key: "itemsSkipped", type: "number", description: "Items evaluated but skipped" },
+		{ key: "durationMs", type: "number", description: "Cleaner run duration in milliseconds" },
+		{
+			key: "cleanedItems",
+			type: "string_array",
+			description: 'Removed items as "Title (rule)" strings (first 5)',
+		},
+	],
+	QUEUE_STRIKES_ISSUED: [
+		...INSTANCE_FIELDS,
+		{ key: "itemsWarned", type: "number", description: "Items that received strikes" },
+		{
+			key: "warnedItems",
+			type: "string_array",
+			description: 'Warned items as "Title (rule)" strings (first 5)',
+		},
+	],
+	QUEUE_CLEANER_FAILED: [
+		...INSTANCE_FIELDS,
+		{
+			key: "durationMs",
+			type: "number",
+			description: "Run duration before failure in milliseconds",
+		},
+	],
+
+	// qui torrent layer — apps/api/src/lib/qui/torrent-state-notifier.ts
+	QUI_TORRENT_ERRORED: QUI_TORRENT_FIELDS,
+	QUI_DOWNLOAD_STALLED: QUI_TORRENT_FIELDS,
+	QUI_TORRENT_COMPLETED: QUI_TORRENT_FIELDS,
+
+	// TRaSH Guides — two emitters with disjoint shapes:
+	// scheduled per-template sync (sync-scheduler.ts) vs update-check rollup
+	// (update-scheduler.ts). All keys optional; descriptions say which.
+	TRASH_PROFILE_UPDATED: [
+		{
+			key: "templateId",
+			type: "string",
+			optional: true,
+			description: "Synced template id (scheduled per-template sync only)",
+		},
+		{
+			key: "instanceId",
+			type: "string",
+			optional: true,
+			description: "Target instance id (scheduled per-template sync only)",
+		},
+		{
+			key: "syncId",
+			type: "string",
+			optional: true,
+			description: "Sync history id (scheduled per-template sync only)",
+		},
+		{
+			key: "templatesAutoSynced",
+			type: "number",
+			optional: true,
+			description: "Templates auto-synced (update-check rollup only)",
+		},
+		{
+			key: "templatesNeedingAttention",
+			type: "number",
+			optional: true,
+			description: "Templates needing attention (update-check rollup only)",
+		},
+		{
+			key: "qualitySizeAutoSynced",
+			type: "number",
+			optional: true,
+			description: "Quality-size definitions auto-synced (update-check rollup only)",
+		},
+	],
+	TRASH_SYNC_ERROR: [
+		// Four emit paths; two carry no metadata at all.
+		{
+			key: "templateId",
+			type: "string",
+			optional: true,
+			description: "Template id (scheduled-sync failures only)",
+		},
+		{
+			key: "instanceId",
+			type: "string",
+			optional: true,
+			description: "Instance id (scheduled-sync failures only)",
+		},
+		{
+			key: "reason",
+			type: "string",
+			optional: true,
+			description: 'Failure reason code (e.g. "validation_failed"; validation failures only)',
+		},
+	],
+	TRASH_DEPLOY_FAILED: [
+		{ key: "templateId", type: "string", description: "Template that failed to deploy" },
+		{
+			key: "instance",
+			type: "string",
+			optional: true,
+			description: "Instance label (single-instance deployments only)",
+		},
+		{
+			key: "totalInstances",
+			type: "number",
+			optional: true,
+			description: "Instances attempted (bulk deployments only)",
+		},
+		{
+			key: "failedInstances",
+			type: "number",
+			optional: true,
+			description: "Instances that failed (bulk deployments only)",
+		},
+	],
+
+	// Backup — apps/api/src/lib/backup/backup-scheduler.ts
+	BACKUP_COMPLETED: [
+		{ key: "nextRunAt", type: "string", description: "Next scheduled backup (ISO timestamp)" },
+		{ key: "intervalType", type: "string", description: "Backup interval setting" },
+		{ key: "retentionCount", type: "number", description: "Number of backups retained" },
+	],
+	BACKUP_FAILED: [],
+
+	// Library — sync-scheduler.ts / cleanup-scheduler.ts
+	LIBRARY_NEW_CONTENT: [
+		...INSTANCE_FIELDS,
+		{ key: "itemCount", type: "number", description: "Newly downloaded items" },
+		{ key: "items", type: "string_array", description: "Titles of new downloads (first 5)" },
+	],
+	CLEANUP_ITEMS_FLAGGED: [
+		{ key: "itemsFlagged", type: "number", description: "Items flagged for review" },
+	],
+	CLEANUP_ITEMS_REMOVED: [
+		{ key: "itemsRemoved", type: "number", description: "Items removed from the library" },
+		{ key: "itemsUnmonitored", type: "number", description: "Items unmonitored" },
+		{ key: "itemsFilesDeleted", type: "number", description: "Files deleted from disk" },
+	],
+
+	// Security — apps/api/src/routes/auth.ts
+	ACCOUNT_LOCKED: [
+		{ key: "username", type: "string", description: "Account that was locked" },
+		{ key: "ip", type: "string", description: "Source IP of the failed attempts" },
+		{ key: "failedAttempts", type: "number", description: "Consecutive failed attempts" },
+		{ key: "lockedMinutes", type: "number", description: "Lockout duration in minutes" },
+	],
+	LOGIN_FAILED: [
+		{ key: "username", type: "string", description: "Username of the failed attempt" },
+		{ key: "ip", type: "string", description: "Source IP of the attempt" },
+		{ key: "failedAttempts", type: "number", description: "Failed attempts so far" },
+		{ key: "maxAttempts", type: "number", description: "Attempts before lockout" },
+	],
+
+	// Services — apps/api/src/routes/services.ts
+	SERVICE_CONNECTION_FAILED: [
+		{ key: "service", type: "string", description: "Service type that failed the connection test" },
+		{ key: "baseUrl", type: "string", description: "Base URL that was tested" },
+	],
+
+	// Cache — plex-cache-scheduler.ts / plex-episode-cache-scheduler.ts
+	CACHE_REFRESH_STALE: [],
+
+	// Plex / Jellyfin analytics — session-snapshot-scheduler.ts (no metadata)
+	PLEX_CONCURRENT_PEAK: [],
+	PLEX_TRANSCODE_HEAVY: [],
+	PLEX_NEW_DEVICE: [],
+	JELLYFIN_CONCURRENT_PEAK: [],
+	JELLYFIN_TRANSCODE_HEAVY: [],
+	JELLYFIN_NEW_DEVICE: [],
+
+	// System — apps/api/src/index.ts (channel test-senders emit this event
+	// type with no metadata object at all, which is always legal).
+	SYSTEM_STARTUP: [
+		{ key: "version", type: "string", description: "arr-dashboard version" },
+		{ key: "nodeVersion", type: "string", description: "Node.js runtime version" },
+		{ key: "database", type: "string", description: "Database provider in use" },
+		{ key: "host", type: "string", description: "API bind host" },
+		{ key: "port", type: "number", description: "API port" },
+	],
+	SYSTEM_ERROR: [],
+	VALIDATION_HEALTH_DEGRADED: [
+		{ key: "integration", type: "string", description: "Integration whose validation degraded" },
+		{
+			key: "failureCount",
+			type: "string",
+			// Documents the wire reality: the emitter stringifies the number.
+			description: "Consecutive validation failures (stringified number)",
+		},
+		{
+			key: "affectedCategories",
+			type: "string",
+			description: 'Comma-joined affected categories, or "unknown"',
+		},
+	],
+
+	// Library Insights — apps/api/src/lib/notifications/insights-digest.ts
+	LIBRARY_INSIGHT_REQUESTED_UNWATCHED: LIBRARY_INSIGHT_FIELDS("requested_unwatched"),
+	LIBRARY_INSIGHT_WATCHED_MONITORED: LIBRARY_INSIGHT_FIELDS("watched_monitored"),
+};
+
+// ============================================================================
+// Derived Zod schemas (for emitter conformance validation)
+// ============================================================================
+
+function fieldToZodType(field: NotificationMetadataField): z.ZodType {
+	let base: z.ZodType;
+	switch (field.type) {
+		case "string":
+			base = z.string();
+			break;
+		case "number":
+			base = z.number();
+			break;
+		case "boolean":
+			base = z.boolean();
+			break;
+		case "string_array":
+			base = z.array(z.string());
+			break;
+	}
+	if (field.nullable) base = base.nullable();
+	if (field.optional) base = base.optional();
+	return base;
+}
+
+function buildEventMetadataSchema(fields: readonly NotificationMetadataField[]): z.ZodType {
+	// strictObject so unknown keys fail — that failure IS the registry-drift
+	// signal the warn-only validation in NotificationService exists to catch.
+	return z.strictObject(Object.fromEntries(fields.map((f) => [f.key, fieldToZodType(f)])));
+}
+
+/**
+ * Per-event-type metadata schemas derived from the registry. Strict: keys
+ * not declared in the registry fail validation. Intended for warn-only
+ * conformance checks — never to block a notification.
+ */
+export const eventMetadataSchemaMap: Record<NotificationEventType, z.ZodType> = Object.fromEntries(
+	(Object.keys(NOTIFICATION_EVENT_METADATA) as NotificationEventType[]).map((eventType) => [
+		eventType,
+		buildEventMetadataSchema(NOTIFICATION_EVENT_METADATA[eventType]),
+	]),
+) as Record<NotificationEventType, z.ZodType>;
+
+/**
+ * Composer-facing accessor: the metadata fields a given event type may
+ * carry. An empty array means the event has no metadata — the composer
+ * should offer no `metadata.*` conditions for it.
+ */
+export function describeEventMetadata(
+	eventType: NotificationEventType,
+): readonly NotificationMetadataField[] {
+	return NOTIFICATION_EVENT_METADATA[eventType];
+}


### PR DESCRIPTION
## Summary

**Operator Console arc PR 1** (charter §2.1; unified-rule-grammar design doc §5.2 — beta flagship phase opener).

Notification event metadata has been free-form `Record<string, unknown>` populated ad-hoc by 18 emitter files. The Operator Console's embedded rule composer needs to expose `metadata.*` condition fields per event type — without a registry that would be a guess-the-key footgun (design doc §5.2). This PR builds that registry, verified against **every emit site** on `next` (35 sites across 18 files, all read directly — not surveyed).

## What

- **`packages/shared/src/types/notification-metadata.ts`** — `NOTIFICATION_EVENT_METADATA`: field descriptors (`key`/`type`/`optional`/`nullable`/`description`) for all **32** event types. The `Record<NotificationEventType, …>` annotation makes it compile-time exhaustive — event type #33 won't build without an entry (same enforcement idea as the planned L2 collector-labels lint, at zero CI cost).
- **Derived strict Zod schemas** (`eventMetadataSchemaMap`) — unknown keys fail, which is the registry-drift signal.
- **`describeEventMetadata()`** — the composer-facing accessor the field picker will consume.
- **`NotificationService.notify()`** — warn-only conformance check. Drift surfaces in logs; never blocks delivery. Runtime-guarded map lookup so a non-enum eventType can't turn the advisory check into a delivery failure.
- **Tests**: 10 shared registry tests + 26 api conformance tests; qui events validated through the real `buildNotificationPayloads` builder rather than copied fixtures.

## Registry fidelity notes (the traps)

- Documents the **wire** shape, not the ideal one: `VALIDATION_HEALTH_DEGRADED.failureCount` is a *stringified* number — recorded as `string`.
- Variant shapes flattened to optional keys with per-variant descriptions: `HUNT_FAILED` (full huntMeta vs reduced thrown-error shape), `TRASH_PROFILE_UPDATED` (scheduled-sync vs update-check rollup — **two disjoint emitters**), `TRASH_SYNC_ERROR` (3 shapes across 4 sites), `QUI_*` (aggregate vs individual, `oldState` nullable).
- `optional: true` doubles as the composer's future absent-field warning feed — an absent field fails **every** operator including `not_equals` (`condition-matcher.ts` documented edge).
- Channel test-senders emit `SYSTEM_STARTUP` with no metadata at all — absent metadata is always legal; validation only applies when a metadata object is present.

## Validation

- Turbo typecheck green (3/3 packages)
- Full test suite green — 2,700 tests, 36 new
- Lint green (10 pre-existing warnings, none in touched files)
- No user-visible surface — live browser verify n/a
- Pre-existing biome format drift in `shared/src/types/arr.ts` + `trash-guides.test.ts` left untouched (format isn't in CI's gate set; separate cleanup candidate)

## Sequencing context

Console-first ordering confirmed with `Kha-kis` (Tracearr instance not yet deployed; Tracearr arc starts after, unblocking C2 then). Next console PRs: console shell (tabs/split-panels IA per ratified charter §2.1), per-domain tiles, Pulse rollup feed, composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

