### PR TITLE
feat(web): Operator Console shell + live attention feed (Console PR 2)

### DIFF
--- a/apps/web/app/console/page.tsx
+++ b/apps/web/app/console/page.tsx
@@ -1,0 +1,10 @@
+import { PageLayout } from "@arr/web/components/layout";
+import { ConsoleClient } from "@arr/web/features/console/components/console-client";
+
+const ConsolePage = () => (
+	<PageLayout maxWidth="7xl">
+		<ConsoleClient />
+	</PageLayout>
+);
+
+export default ConsolePage;

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -9,6 +9,7 @@ import {
 	ChevronRight,
 	Compass,
 	Eraser,
+	Gauge,
 	Globe,
 	History,
 	Inbox,
@@ -53,6 +54,11 @@ const NAV_GROUPS: NavGroup[] = [
 			// (/ redirects here post-auth) and hosts the Needs Attention panel.
 			// Pulse remains the deep-inspection view below it.
 			{ href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+			// Console is the operator's working surface (3.0 flagship,
+			// charter §2.1): domain health + attention feed + one-click
+			// actions, later the rule composer. Sits between the landing
+			// surface (Dashboard) and the deep-inspection view (Pulse).
+			{ href: "/console", label: "Console", icon: Gauge },
 			{ href: "/pulse", label: "Pulse", icon: Activity },
 			// `/qui` is the at-a-glance entry for the torrent layer — Sonarr/Radarr
 			// equivalent for qui. Belongs in Overview, not Maintenance, because

--- a/apps/web/src/features/console/components/__tests__/console-client.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/console-client.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Behavior-focused tests for <ConsoleClient /> (Operator Console shell).
+ *
+ * Pins the user-visible shell contract:
+ *   - header renders with the console identity
+ *   - the attention feed is mounted and driven by the shared
+ *     NeedsAttentionPanel (its own states are pinned in
+ *     needs-attention-panel.test.tsx — not re-tested here)
+ *   - NO tab bar renders while the console has a single tab (the
+ *     Automation tab registers with the composer; a dead stub tab would
+ *     be a misleading surface)
+ *   - the header refresh action refetches the attention query
+ */
+
+import type { PulseResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+// ---------------------------------------------------------------------------
+// Mock the Pulse query hook. ConsoleClient (header freshness/refresh) and
+// NeedsAttentionPanel (feed) both consume it from the same module.
+// ---------------------------------------------------------------------------
+const mockUsePulseQuery = vi.fn();
+
+vi.mock("../../../../hooks/api/usePulse", () => ({
+	usePulseQuery: (args?: { attentionOnly?: boolean }) => mockUsePulseQuery(args),
+}));
+
+// Stub useThemeGradient so we don't have to wire ColorThemeProvider
+// (same idiom as pulse-client-hash-scroll.test.tsx).
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({ gradient: { from: "#6366f1", to: "#8b5cf6" } }),
+}));
+
+// Import after mocks so the component picks up the mocked hook.
+import { ConsoleClient } from "../console-client";
+
+function createWrapper() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={qc}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>
+	);
+}
+
+function makeResponse(): PulseResponse {
+	return {
+		items: [
+			{
+				id: "hunt-failures-radarr",
+				severity: "warning",
+				category: "operations",
+				title: "Hunt failing on Radarr Main",
+				detail: "2 consecutive failures",
+				actionUrl: "/hunting",
+				actionLabel: "Open Hunting",
+				source: "hunting",
+				timestamp: "2026-06-10T12:00:00.000Z",
+			},
+		],
+		summary: { critical: 0, warning: 1, info: 0 },
+		generatedAt: "2026-06-10T12:00:00.000Z",
+	};
+}
+
+function mockQueryState(overrides: Record<string, unknown> = {}) {
+	mockUsePulseQuery.mockReturnValue({
+		data: makeResponse(),
+		isLoading: false,
+		isError: false,
+		isFetching: false,
+		dataUpdatedAt: Date.now(),
+		refetch: vi.fn(),
+		...overrides,
+	});
+}
+
+beforeEach(() => {
+	mockUsePulseQuery.mockReset();
+	window.localStorage.clear();
+});
+
+describe("ConsoleClient shell", () => {
+	it("renders the console header identity", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		expect(screen.getByText("Operator Console")).toBeInTheDocument();
+		expect(screen.getByRole("heading", { name: "Console" })).toBeInTheDocument();
+	});
+
+	it("mounts the shared attention feed with live items", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		expect(screen.getByTestId("needs-attention-panel")).toBeInTheDocument();
+		expect(screen.getByText("Hunt failing on Radarr Main")).toBeInTheDocument();
+	});
+
+	it("renders NO tab bar while the console has a single tab", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		// The only "Overview" affordance would come from a rendered tab bar —
+		// the header itself never says Overview.
+		expect(screen.queryByRole("button", { name: /overview/i })).not.toBeInTheDocument();
+	});
+
+	it("refetches the attention query from the header refresh action", () => {
+		const refetch = vi.fn();
+		mockQueryState({ refetch });
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+		expect(refetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("requests the attention-only feed, not the full Pulse list", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		// Every consumer on this surface must ask for the curated rollup;
+		// the full list lives on /pulse.
+		for (const call of mockUsePulseQuery.mock.calls) {
+			expect(call[0]).toEqual({ attentionOnly: true });
+		}
+	});
+});

--- a/apps/web/src/features/console/components/console-client.tsx
+++ b/apps/web/src/features/console/components/console-client.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Operator Console — the 3.0 flagship surface (charter §2.1).
+ *
+ * One canonical operator view: per-domain health + freshness +
+ * next-scheduled-action tiles, the Pulse needs-attention rollup as the
+ * action feed, and (later) the embedded rule composer for the Unified
+ * Automation Engine.
+ *
+ * Layout (ratified with the charter, refined 2026-06-10): PremiumTabs as
+ * primary navigation; the Overview tab becomes a two-column split (domain
+ * tiles left, attention feed right) once the tiles land. Console arc:
+ *   PR 2 (this) — shell + live attention feed
+ *   PR 3 — per-domain tiles (Overview becomes the split)
+ *   PR 4 — Pulse rollup refinements / operator actions
+ *   PR 6 — rule composer (registers the Automation tab)
+ *
+ * The attention feed is the SAME component the dashboard renders
+ * (NeedsAttentionPanel) — charter §2.1 names the rollup as the console's
+ * action feed, and sharing the component keeps its trust rules (honest
+ * error state, incognito anonymization, no client-side re-classification)
+ * in one place instead of forking them.
+ */
+
+import { Gauge, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import {
+	DataFreshness,
+	PremiumPageHeader,
+	type PremiumTab,
+	PremiumTabs,
+} from "../../../components/layout";
+import { Button } from "../../../components/ui";
+import { usePulseQuery } from "../../../hooks/api/usePulse";
+import { POLLING_STATS } from "../../../lib/polling-intervals";
+import { NeedsAttentionPanel } from "../../dashboard/components/needs-attention-panel";
+
+export type ConsoleTabId = "overview";
+
+// The Automation tab registers here when the rule composer lands.
+// PremiumTabs renders only when there is more than one tab: a lone tab is
+// chrome without a choice, and shipping a dead "Automation" stub before
+// the composer exists would violate the no-misleading-surfaces trust rule.
+const CONSOLE_TABS: PremiumTab[] = [{ id: "overview", label: "Overview", icon: Gauge }];
+
+export const ConsoleClient = () => {
+	const [activeTab, setActiveTab] = useState<ConsoleTabId>("overview");
+
+	// Same query key as NeedsAttentionPanel's internal hook — React Query
+	// dedupes, so this adds no extra fetch; it only feeds the header's
+	// freshness indicator and refresh action.
+	const { refetch, dataUpdatedAt, isFetching, isError } = usePulseQuery({
+		attentionOnly: true,
+	});
+
+	return (
+		<>
+			<PremiumPageHeader
+				label="Operator Console"
+				labelIcon={Gauge}
+				title="Console"
+				gradientTitle
+				description="One view of every domain's health and what needs your attention — with one-click operator actions"
+				actions={
+					<div className="flex items-center gap-3">
+						{/* Freshness of the attention feed — the only polled data on
+						    this surface until the domain tiles land (console PR 3). */}
+						{activeTab === "overview" && (
+							<DataFreshness
+								dataUpdatedAt={dataUpdatedAt}
+								isFetching={isFetching}
+								isError={isError}
+								pollIntervalMs={POLLING_STATS}
+							/>
+						)}
+						<Button
+							variant="secondary"
+							onClick={() => void refetch()}
+							className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
+						>
+							<RefreshCw className="h-4 w-4" />
+							Refresh
+						</Button>
+					</div>
+				}
+			/>
+
+			{CONSOLE_TABS.length > 1 && (
+				<div
+					className="animate-in fade-in slide-in-from-bottom-4 duration-500"
+					style={{ animationDelay: "100ms", animationFillMode: "backwards" }}
+				>
+					<PremiumTabs
+						tabs={CONSOLE_TABS}
+						activeTab={activeTab}
+						onTabChange={(tabId) => setActiveTab(tabId as ConsoleTabId)}
+					/>
+				</div>
+			)}
+
+			<div
+				className="animate-in fade-in slide-in-from-bottom-4 duration-500"
+				style={{ animationDelay: "200ms", animationFillMode: "backwards" }}
+			>
+				{activeTab === "overview" && (
+					// PR 3 turns this into the two-column split:
+					// grid lg:grid-cols-[2fr_1fr] — domain tiles left, feed right.
+					<NeedsAttentionPanel />
+				)}
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
## Summary

**Operator Console arc PR 2** (charter §2.1) — the flagship surface goes live at `/console`.

Layout direction settled with `Kha-kis` within the ratified constraint: **tabs as primary navigation**, with the Overview tab becoming a two-column split (domain tiles left, attention feed right) when tiles land in PR 3. Until the composer exists, no tab bar renders — the `CONSOLE_TABS` registry only mounts `PremiumTabs` at >1 tab, so the preview tag never shows a dead "Automation" stub.

## What

- **`/console` page** + sidebar entry (Gauge icon) between Dashboard (landing surface) and Pulse (deep inspection) in the Overview group
- **`ConsoleClient`**: `PremiumPageHeader` with `DataFreshness` on the attention query + Refresh action; tab-ready architecture; staggered entrance animations per house idiom
- **Action feed = `NeedsAttentionPanel` reused verbatim** from the dashboard. The charter names the Pulse needs-attention rollup as the console's action feed; sharing the component keeps its trust rules (honest error state, incognito anonymization with `item.source` disambiguation, no client-side re-classification) in one place. Duplicate-surface check: ratified overlap, one implementation.
- **5 behavior-pinning tests** (header identity, live feed mounted, *no tab bar at single tab*, refresh→refetch, attention-only query contract)

## Live verification (dev DB, forged session)

- `/console` renders 13 real attention items with working action links; sidebar active-state correct; freshness ticking; **0 console errors** — `console-shell-v1-live.png`
- Incognito ON: instance names anonymized — `console-shell-v1-incognito.png`

## Pre-existing issue surfaced (NOT introduced here)

The incognito pass exposed that **release titles in queue-failure Pulse items bypass anonymization** (e.g. an album title renders in clear text with incognito on). Confirmed byte-identical on `/pulse` — the gap lives in the shared `anonymizePulseText`/`anonymizeHealthMessage` helpers, upstream of this PR. Queued as a surgical follow-up; one fix heals `/pulse`, dashboard, and console simultaneously.

## Next in the arc

PR 3 — per-domain health/freshness/next-action tiles (Overview becomes the split; needs next-run derivation since `JobStatus` exposes `lastStartedAt`+`intervalMs`, not `nextExecution`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

