### PR TITLE
fix(incognito): mask release titles in *arr queue Pulse rows

### DIFF
--- a/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
+++ b/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
@@ -26,15 +26,15 @@
 import type { PulseItem, PulseSeverity } from "@arr/shared";
 import { AlertTriangle, CheckCircle2, ChevronRight, XCircle } from "lucide-react";
 import Link from "next/link";
+import { usePulseQuery } from "../../../hooks/api/usePulse";
 import {
 	anonymizeHealthMessage,
-	anonymizePulseText,
+	anonymizePulseItemContent,
 	useIncognitoMode,
 } from "../../../lib/incognito";
-import { usePulseQuery } from "../../../hooks/api/usePulse";
-import { PulseActionButton } from "../../pulse/components/pulse-action-button";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
+import { PulseActionButton } from "../../pulse/components/pulse-action-button";
 
 const MAX_VISIBLE_ITEMS = 10;
 
@@ -82,10 +82,7 @@ function PanelShell({
 		<section
 			data-testid={testId}
 			aria-label={ariaLabel}
-			className={cn(
-				"overflow-hidden rounded-xl border border-border/30 bg-muted/10",
-				className,
-			)}
+			className={cn("overflow-hidden rounded-xl border border-border/30 bg-muted/10", className)}
 		>
 			{children}
 		</section>
@@ -144,13 +141,7 @@ function PanelHeader({
 // AttentionRow — one row per item. No severity logic beyond "pick the visual
 // for critical vs warning". Severity comes from the item verbatim.
 // ---------------------------------------------------------------------------
-function AttentionRow({
-	item,
-	incognito,
-}: {
-	item: PulseItem;
-	incognito: boolean;
-}) {
+function AttentionRow({ item, incognito }: { item: PulseItem; incognito: boolean }) {
 	const visual =
 		item.severity === "critical" || item.severity === "warning"
 			? SEVERITY_VISUAL[item.severity]
@@ -161,11 +152,13 @@ function AttentionRow({
 	if (!visual) return null;
 
 	const Icon = visual.icon;
-	// Pass `item.source` so system-sourced titles (scheduler jobs, cache health)
-	// aren't mis-anonymized as ARR instance labels by the " is "-split branch.
-	const title = incognito ? anonymizePulseText(item.title, item.source) : item.title;
-	const detail =
-		incognito && item.detail ? anonymizeHealthMessage(item.detail) : item.detail;
+	// Anonymize title+detail as a pair: `item.source` keeps system-sourced
+	// titles from being mis-anonymized as ARR instance labels, and `item.id`
+	// lets *arr queue rows mask their embedded RELEASE TITLE — which the
+	// health-message patterns can't catch (see anonymizePulseItemContent).
+	const { title, detail } = incognito
+		? anonymizePulseItemContent(item)
+		: { title: item.title, detail: item.detail };
 
 	return (
 		<li className="flex items-start gap-3 border-b border-border/30 px-6 py-3 last:border-b-0">
@@ -183,9 +176,7 @@ function AttentionRow({
 			</div>
 			<div className="min-w-0 flex-1">
 				<p className="truncate text-sm font-medium text-foreground">{title}</p>
-				{detail && (
-					<p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>
-				)}
+				{detail && <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>}
 			</div>
 			{item.action && <PulseActionButton signalId={item.id} action={item.action} />}
 			{item.actionUrl && (
@@ -218,10 +209,7 @@ export function NeedsAttentionPanel() {
 	// State: loading (no cached data yet).
 	if (isLoading) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-loading"
-				ariaLabel="Needs Attention — loading"
-			>
+			<PanelShell testId="needs-attention-panel-loading" ariaLabel="Needs Attention — loading">
 				<div className="flex items-center gap-3 border-b border-border/50 px-6 py-4">
 					<div className="h-8 w-8 animate-pulse rounded-lg bg-muted/30" />
 					<div className="flex-1 space-y-1.5">
@@ -241,10 +229,7 @@ export function NeedsAttentionPanel() {
 	// State: error with no cached data — NEVER imply "all clear" here.
 	if (isError && !data) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-error"
-				ariaLabel="Needs Attention — unavailable"
-			>
+			<PanelShell testId="needs-attention-panel-error" ariaLabel="Needs Attention — unavailable">
 				<div className="flex items-start gap-3 px-6 py-4">
 					<XCircle
 						className="mt-0.5 h-5 w-5 shrink-0"
@@ -255,8 +240,8 @@ export function NeedsAttentionPanel() {
 							Couldn&apos;t load attention items
 						</h3>
 						<p className="mt-0.5 text-xs text-muted-foreground">
-							The attention feed is unavailable right now — other dashboard signals may
-							still be accurate.{" "}
+							The attention feed is unavailable right now — other dashboard signals may still be
+							accurate.{" "}
 							<Link
 								href="/pulse"
 								className="underline underline-offset-2 transition-colors hover:text-foreground"
@@ -278,19 +263,14 @@ export function NeedsAttentionPanel() {
 	// State: empty — only shown when fetch succeeded.
 	if (visible.length === 0) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-empty"
-				ariaLabel="Needs Attention — all clear"
-			>
+			<PanelShell testId="needs-attention-panel-empty" ariaLabel="Needs Attention — all clear">
 				<div className="flex items-start gap-3 px-6 py-4">
 					<CheckCircle2
 						className="mt-0.5 h-5 w-5 shrink-0"
 						style={{ color: SEMANTIC_COLORS.success.text }}
 					/>
 					<div className="min-w-0 flex-1">
-						<h3 className="text-sm font-semibold text-foreground">
-							No actionable items right now
-						</h3>
+						<h3 className="text-sm font-semibold text-foreground">No actionable items right now</h3>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							Open Pulse to view the full signal list.
 						</p>

--- a/apps/web/src/features/pulse/components/pulse-client.tsx
+++ b/apps/web/src/features/pulse/components/pulse-client.tsx
@@ -23,16 +23,12 @@ import {
 	PremiumEmptyState,
 } from "../../../components/layout/premium-components";
 import { usePulseQuery } from "../../../hooks/api/usePulse";
-import { PulseActionButton } from "./pulse-action-button";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
-import {
-	anonymizeHealthMessage,
-	anonymizePulseText,
-	useIncognitoMode,
-} from "../../../lib/incognito";
+import { anonymizePulseItemContent, useIncognitoMode } from "../../../lib/incognito";
 import { POLLING_STATS } from "../../../lib/polling-intervals";
 import { getServiceGradient, SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
+import { PulseActionButton } from "./pulse-action-button";
 
 // ============================================================================
 // Severity config
@@ -90,10 +86,13 @@ function PulseItemRow({
 }) {
 	const serviceGradient = getServiceGradient(item.source);
 	const CategoryIcon = CATEGORY_ICONS[item.category] ?? Activity;
-	// Pass `item.source` so system-sourced titles (scheduler jobs, cache health)
-	// aren't mis-anonymized as ARR instance labels by the " is "-split branch.
-	const title = incognito ? anonymizePulseText(item.title, item.source) : item.title;
-	const detail = incognito && item.detail ? anonymizeHealthMessage(item.detail) : item.detail;
+	// Anonymize title+detail as a pair: `item.source` keeps system-sourced
+	// titles from being mis-anonymized as ARR instance labels, and `item.id`
+	// lets *arr queue rows mask their embedded RELEASE TITLE — which the
+	// health-message patterns can't catch (see anonymizePulseItemContent).
+	const { title, detail } = incognito
+		? anonymizePulseItemContent(item)
+		: { title: item.title, detail: item.detail };
 
 	return (
 		// `id={item.id}` anchors deep-links from curated surfaces (e.g. the

--- a/apps/web/src/lib/__tests__/incognito.test.ts
+++ b/apps/web/src/lib/__tests__/incognito.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { anonymizeHealthMessage, anonymizePulseText } from "../incognito";
+import {
+	anonymizeHealthMessage,
+	anonymizePulseItemContent,
+	anonymizePulseText,
+} from "../incognito";
 
 describe("anonymizePulseText — source-aware masking", () => {
 	it("leaves system-sourced titles un-split (no instance-label substitution)", () => {
@@ -102,5 +106,102 @@ describe("anonymizeHealthMessage — URL and IP stripping", () => {
 		expect(out).toContain("http://linux-host");
 		expect(out).not.toContain("MyIndexer");
 		expect(out).not.toContain("proxy.local");
+	});
+});
+
+describe("anonymizePulseItemContent — *arr queue rows mask release titles", () => {
+	// The leak this pins (found 2026-06-11 during the Operator Console
+	// live-verify): queue-failure rows embed a bare media release title,
+	// which none of the health-message patterns catch. Shape comes from
+	// collectArrQueueFailures: title `"Label: Release (failed|warning)"`,
+	// stable id `queue-failed-*` / `queue-stuck-*`, detail = *arr error
+	// message that often embeds the same release name.
+
+	it("masks the release title in a queue-failed row, preserving the state suffix", () => {
+		const { title } = anonymizePulseItemContent({
+			id: "queue-failed-inst1-42",
+			source: "lidarr",
+			title: "Primary Lidarr: Jimmy Eat World - 2001 - Bleed American [2008 Remaster] (failed)",
+		});
+		expect(title).not.toContain("Jimmy Eat World");
+		expect(title).not.toContain("Bleed American");
+		expect(title).not.toContain("Primary Lidarr");
+		expect(title).toMatch(/ \(failed\)$/);
+	});
+
+	it("masks queue-stuck rows with the (warning) suffix", () => {
+		const { title } = anonymizePulseItemContent({
+			id: "queue-stuck-inst1-7",
+			source: "sonarr",
+			title: "Sonarr Prod: Some.Show.S01E01.1080p.WEB-GROUP (warning)",
+		});
+		expect(title).not.toContain("Some.Show");
+		expect(title).toMatch(/ \(warning\)$/);
+	});
+
+	it("excises the release name embedded in the detail (error message)", () => {
+		const { detail } = anonymizePulseItemContent({
+			id: "queue-failed-inst1-42",
+			source: "lidarr",
+			title: "Primary Lidarr: Jimmy Eat World - Bleed American (failed)",
+			detail:
+				"No files eligible for import in Jimmy Eat World - Bleed American, manual import required",
+		});
+		expect(detail).not.toContain("Jimmy Eat World");
+		expect(detail).not.toContain("Bleed American");
+		expect(detail).toContain("manual import required");
+	});
+
+	it("excises the FULL name from detail when the row title was server-truncated", () => {
+		// collectors.ts shortens long titles with a trailing "…"; the detail
+		// keeps the full name. Excision must match from the prefix onward.
+		const { detail } = anonymizePulseItemContent({
+			id: "queue-failed-inst1-42",
+			source: "lidarr",
+			title: "Primary Lidarr: Jimmy Eat World - 2001 - Bleed Ameri… (failed)",
+			detail:
+				"Stalled in queue: Jimmy Eat World - 2001 - Bleed American [2008 Remastered Deluxe Edition]",
+		});
+		expect(detail).not.toContain("Jimmy Eat World");
+		expect(detail).not.toContain("Remastered Deluxe");
+		expect(detail).toContain("Stalled in queue:");
+	});
+
+	it("handles regex-special characters in release titles without throwing", () => {
+		const { title, detail } = anonymizePulseItemContent({
+			id: "queue-failed-inst1-9",
+			source: "radarr",
+			title: "Radarr 4K: Movie (2024) [Remux-2160p] {Edition} (failed)",
+			detail: "Download Movie (2024) [Remux-2160p] {Edition} failed",
+		});
+		expect(title).not.toContain("Remux-2160p");
+		expect(detail).not.toContain("Remux-2160p");
+	});
+
+	it("delegates non-queue rows to the existing source-aware behavior", () => {
+		const system = anonymizePulseItemContent({
+			id: "scheduler-disabled-hunting",
+			source: "system",
+			title: "Library Sync is disabled",
+			detail: "Enable it in settings",
+		});
+		expect(system.title).toBe("Library Sync is disabled");
+		expect(system.detail).toBe("Enable it in settings");
+
+		const instance = anonymizePulseItemContent({
+			id: "arr-health-inst1",
+			source: "sonarr",
+			title: "Sonarr Prod: Indexer X failed",
+		});
+		expect(instance.title).not.toContain("Sonarr Prod");
+	});
+
+	it("leaves detail undefined when the item has none", () => {
+		const { detail } = anonymizePulseItemContent({
+			id: "queue-failed-inst1-1",
+			source: "sonarr",
+			title: "Sonarr Prod: Show Name (failed)",
+		});
+		expect(detail).toBeUndefined();
 	});
 });

--- a/apps/web/src/lib/incognito.ts
+++ b/apps/web/src/lib/incognito.ts
@@ -297,6 +297,83 @@ export function anonymizePulseText(text: string, source?: string): string {
 	return anonymizeHealthMessage(text);
 }
 
+// *arr queue rows (collectArrQueueFailures) — the only Pulse rows whose
+// title embeds a MEDIA RELEASE TITLE rather than a health message. Their
+// stable ids are part of the Pulse contract (used for /pulse hash-scroll).
+const QUEUE_ROW_ID_PREFIXES = ["queue-failed-", "queue-stuck-"] as const;
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Anonymize a Pulse item's title and detail as a pair.
+ *
+ * Most Pulse rows carry health messages, which `anonymizePulseText` /
+ * `anonymizeHealthMessage` already handle. *arr queue rows are different:
+ * their title is `"InstanceLabel: Release.Title (failed|warning)"` and
+ * their detail is the raw *arr error message, which frequently embeds the
+ * same release title. Health-message patterns can't catch a bare release
+ * name (no tvdbid suffix, no quotes, no URL), so with incognito on those
+ * rows leaked media titles on /pulse, the dashboard attention panel, and
+ * the Operator Console feed (found 2026-06-11).
+ *
+ * This helper detects queue rows by their stable id prefix, swaps the
+ * release title for a Linux ISO placeholder (keeping the instance mask and
+ * the "(failed)"/"(warning)" state suffix), and excises the release name
+ * from the detail before the standard health-message pass. The row title
+ * may be server-truncated with a trailing "…", in which case the detail
+ * holds the FULL name — excision therefore matches from the truncated
+ * prefix through the rest of the embedded name.
+ */
+export function anonymizePulseItemContent(item: {
+	id: string;
+	source?: string;
+	title: string;
+	detail?: string;
+}): { title: string; detail?: string } {
+	const isQueueRow = QUEUE_ROW_ID_PREFIXES.some((prefix) => item.id.startsWith(prefix));
+	if (!isQueueRow) {
+		return {
+			title: anonymizePulseText(item.title, item.source),
+			detail: item.detail ? anonymizeHealthMessage(item.detail) : item.detail,
+		};
+	}
+
+	let releaseTitle: string | null = null;
+	let title: string;
+	const colonIdx = item.title.indexOf(": ");
+	if (colonIdx > 0) {
+		const label = item.title.slice(0, colonIdx);
+		const message = item.title.slice(colonIdx + 2);
+		const suffixMatch = message.match(/ \((failed|warning)\)$/);
+		releaseTitle = suffixMatch ? message.slice(0, suffixMatch.index) : message;
+		const suffix = suffixMatch ? message.slice(suffixMatch.index) : "";
+		title = `${getLinuxInstanceName(label)}: ${getLinuxIsoName(releaseTitle)}${suffix}`;
+	} else {
+		// Unexpected shape for a queue row — fall back to the generic path
+		// rather than render it raw.
+		title = anonymizePulseText(item.title, item.source);
+	}
+
+	let detail = item.detail;
+	if (detail) {
+		// Strip the server-side truncation marker so a shortened row title
+		// still matches the full name embedded in the error message, then
+		// consume the rest of the embedded name up to a natural delimiter.
+		const prefix = releaseTitle?.replace(/…$/, "") ?? "";
+		if (prefix.length >= 3) {
+			detail = detail.replace(
+				new RegExp(`${escapeRegExp(prefix)}[^,\n]*`, "g"),
+				getLinuxIsoName(prefix),
+			);
+		}
+		detail = anonymizeHealthMessage(detail);
+	}
+
+	return { title, detail };
+}
+
 // Anonymize queue status/error messages
 export function anonymizeStatusMessage(message: string): string {
 	let anonymized = message;


### PR DESCRIPTION
## Summary

Trust-bucket fix for the incognito leak found during the Console shell live-verify (#535): with incognito ON, `collectArrQueueFailures` rows rendered media release titles in clear text — on `/pulse`, the dashboard Needs Attention panel, and the new Operator Console feed. `anonymizeHealthMessage` catches `(tvdbid N)` patterns, quoted names, URLs, IPs, and indexer lists — a bare release name sailed through all of them. CLAUDE.md rule 6 lists titles as sensitive.

## What

- **`anonymizePulseItemContent({id, source, title, detail})`** — anonymizes a Pulse item's title+detail as a pair. Queue rows are detected by their stable id prefixes (`queue-failed-`/`queue-stuck-`, already part of the `/pulse` hash-scroll contract):
  - Title: instance mask + Linux ISO placeholder, preserving the `(failed)`/`(warning)` state suffix
  - Detail: the release name is **excised** from the *arr error message (which frequently embeds it) before the standard health-message pass — including when the server shortened the row title with a trailing `…` (prefix regex matches the full embedded name; regex-special chars escaped)
  - Non-queue rows delegate to the existing source-aware behavior unchanged
- Both row renderers (`pulse-client.tsx`, `needs-attention-panel.tsx`) switch to the pair helper — **one seam, three surfaces healed** (the console inherits via the shared panel)
- 7 new tests pin the masking, excision, shortened-title case, special chars, and non-queue delegation

## Live verification (anti-vacuous ON/OFF pairing)

- Incognito **ON**: zero title leaks on `/pulse` (10 queue rows, all rendering as `linuxmint-22-cinnamon-64bit.iso (failed)`-style placeholders) and on `/console`
- Incognito **OFF**: real titles render — display-only invariant intact, no over-anonymization

## Validation

Turbo typecheck 3/3 · full suite green · lint green · existing needs-attention-panel and incognito suites pass unchanged (non-queue behavior identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)