### PR TITLE
feat(web): Operator Console per-domain tiles (Console PR 3)

### DIFF
--- a/apps/web/src/features/console/components/__tests__/console-client.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/console-client.test.tsx
@@ -29,6 +29,17 @@ vi.mock("../../../../hooks/api/usePulse", () => ({
 	usePulseQuery: (args?: { attentionOnly?: boolean }) => mockUsePulseQuery(args),
 }));
 
+// Domain tiles' data sources (system jobs + services for gating).
+const mockUseSystemJobs = vi.fn();
+vi.mock("../../../../hooks/api/useSystem", () => ({
+	useSystemJobs: () => mockUseSystemJobs(),
+}));
+
+const mockUseServicesQuery = vi.fn();
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => mockUseServicesQuery(),
+}));
+
 // Stub useThemeGradient so we don't have to wire ColorThemeProvider
 // (same idiom as pulse-client-hash-scroll.test.tsx).
 vi.mock("../../../../hooks/useThemeGradient", () => ({
@@ -67,6 +78,28 @@ function makeResponse(): PulseResponse {
 	};
 }
 
+function makeJob(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		label: id,
+		description: "",
+		concurrency: "singleton",
+		state: "idle",
+		lastStartedAt: "2026-06-11T12:00:00.000Z",
+		lastFinishedAt: "2026-06-11T12:00:05.000Z",
+		lastSuccessAt: "2026-06-11T12:00:05.000Z",
+		lastFailureAt: null,
+		lastDurationMs: 5000,
+		lastError: null,
+		consecutiveFailures: 0,
+		totalRuns: 10,
+		totalFailures: 0,
+		disabled: false,
+		disabledReason: null,
+		...overrides,
+	};
+}
+
 function mockQueryState(overrides: Record<string, unknown> = {}) {
 	mockUsePulseQuery.mockReturnValue({
 		data: makeResponse(),
@@ -77,10 +110,28 @@ function mockQueryState(overrides: Record<string, unknown> = {}) {
 		refetch: vi.fn(),
 		...overrides,
 	});
+	mockUseSystemJobs.mockReturnValue({
+		data: {
+			jobs: [makeJob("hunting"), makeJob("backup"), makeJob("qui-torrent-state-sync")],
+			count: 3,
+			capturedAt: "2026-06-11T12:00:10.000Z",
+		},
+		isLoading: false,
+		isError: false,
+		error: null,
+		refetch: vi.fn(),
+	});
+	mockUseServicesQuery.mockReturnValue({
+		data: [],
+		isLoading: false,
+		isError: false,
+	});
 }
 
 beforeEach(() => {
 	mockUsePulseQuery.mockReset();
+	mockUseSystemJobs.mockReset();
+	mockUseServicesQuery.mockReset();
 	window.localStorage.clear();
 });
 
@@ -110,13 +161,44 @@ describe("ConsoleClient shell", () => {
 		expect(screen.queryByRole("button", { name: /overview/i })).not.toBeInTheDocument();
 	});
 
-	it("refetches the attention query from the header refresh action", () => {
+	it("refreshes BOTH overview feeds from the header refresh action", () => {
 		const refetch = vi.fn();
 		mockQueryState({ refetch });
+		const jobsRefetch = vi.fn();
+		mockUseSystemJobs.mockReturnValue({
+			data: { jobs: [makeJob("hunting")], count: 1, capturedAt: "2026-06-11T12:00:10.000Z" },
+			isLoading: false,
+			isError: false,
+			error: null,
+			refetch: jobsRefetch,
+		});
 		render(<ConsoleClient />, { wrapper: createWrapper() });
 
 		fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
 		expect(refetch).toHaveBeenCalledTimes(1);
+		expect(jobsRefetch).toHaveBeenCalledTimes(1);
+	});
+
+	it("renders domain tiles for core domains and OMITS service-gated ones", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		const grid = screen.getByTestId("domain-tile-grid");
+		expect(grid).toBeInTheDocument();
+		// hunting + backup jobs are registered → their tiles render.
+		expect(screen.getByText("Hunting")).toBeInTheDocument();
+		expect(screen.getByText("Backup")).toBeInTheDocument();
+		// qui job is registered but NO qui service instance exists → no tile
+		// (service-availability gating by omission, trust rule 1).
+		expect(screen.queryByText("qui")).not.toBeInTheDocument();
+	});
+
+	it("shows honest last-run facts, never a predicted next-run time", () => {
+		mockQueryState();
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		expect(screen.getAllByText(/Last activity /).length).toBeGreaterThan(0);
+		expect(screen.queryByText(/next run/i)).not.toBeInTheDocument();
 	});
 
 	it("requests the attention-only feed, not the full Pulse list", () => {

--- a/apps/web/src/features/console/components/__tests__/console-client.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/console-client.test.tsx
@@ -193,6 +193,21 @@ describe("ConsoleClient shell", () => {
 		expect(screen.queryByText("qui")).not.toBeInTheDocument();
 	});
 
+	it("degrades honestly when the SERVICES feed fails: core tiles render, omission disclosed", () => {
+		// Reviewer-caught trust issue: blocking all tiles on a services
+		// failure rendered a false "No domain schedulers registered" while
+		// the jobs feed was demonstrably fine. Core domains need no service
+		// data; only gated tiles are omitted, and the omission is disclosed.
+		mockQueryState();
+		mockUseServicesQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+		render(<ConsoleClient />, { wrapper: createWrapper() });
+
+		expect(screen.getByText("Hunting")).toBeInTheDocument();
+		expect(screen.getByText("Backup")).toBeInTheDocument();
+		expect(screen.queryByText("No domain schedulers registered")).not.toBeInTheDocument();
+		expect(screen.getByTestId("services-gating-degraded")).toBeInTheDocument();
+	});
+
 	it("shows honest last-run facts, never a predicted next-run time", () => {
 		mockQueryState();
 		render(<ConsoleClient />, { wrapper: createWrapper() });

--- a/apps/web/src/features/console/components/console-client.tsx
+++ b/apps/web/src/features/console/components/console-client.tsx
@@ -25,16 +25,12 @@
 
 import { Gauge, RefreshCw } from "lucide-react";
 import { useState } from "react";
-import {
-	DataFreshness,
-	PremiumPageHeader,
-	type PremiumTab,
-	PremiumTabs,
-} from "../../../components/layout";
+import { PremiumPageHeader, type PremiumTab, PremiumTabs } from "../../../components/layout";
 import { Button } from "../../../components/ui";
 import { usePulseQuery } from "../../../hooks/api/usePulse";
-import { POLLING_STATS } from "../../../lib/polling-intervals";
+import { useSystemJobs } from "../../../hooks/api/useSystem";
 import { NeedsAttentionPanel } from "../../dashboard/components/needs-attention-panel";
+import { DomainTileGrid } from "./domain-tile-grid";
 
 export type ConsoleTabId = "overview";
 
@@ -47,12 +43,17 @@ const CONSOLE_TABS: PremiumTab[] = [{ id: "overview", label: "Overview", icon: G
 export const ConsoleClient = () => {
 	const [activeTab, setActiveTab] = useState<ConsoleTabId>("overview");
 
-	// Same query key as NeedsAttentionPanel's internal hook — React Query
-	// dedupes, so this adds no extra fetch; it only feeds the header's
-	// freshness indicator and refresh action.
-	const { refetch, dataUpdatedAt, isFetching, isError } = usePulseQuery({
-		attentionOnly: true,
-	});
+	// Same query keys as the panels' internal hooks — React Query dedupes,
+	// so these add no extra fetches; they only feed the header's Refresh
+	// action. No header DataFreshness: the Overview is now a multi-feed
+	// surface (jobs + attention), and a single indicator tied to one query
+	// would under-report — the B4 sweep's multi-feed exclusion rule.
+	const attentionQuery = usePulseQuery({ attentionOnly: true });
+	const jobsQuery = useSystemJobs();
+	const refreshAll = () => {
+		void attentionQuery.refetch();
+		void jobsQuery.refetch();
+	};
 
 	return (
 		<>
@@ -63,26 +64,14 @@ export const ConsoleClient = () => {
 				gradientTitle
 				description="One view of every domain's health and what needs your attention — with one-click operator actions"
 				actions={
-					<div className="flex items-center gap-3">
-						{/* Freshness of the attention feed — the only polled data on
-						    this surface until the domain tiles land (console PR 3). */}
-						{activeTab === "overview" && (
-							<DataFreshness
-								dataUpdatedAt={dataUpdatedAt}
-								isFetching={isFetching}
-								isError={isError}
-								pollIntervalMs={POLLING_STATS}
-							/>
-						)}
-						<Button
-							variant="secondary"
-							onClick={() => void refetch()}
-							className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
-						>
-							<RefreshCw className="h-4 w-4" />
-							Refresh
-						</Button>
-					</div>
+					<Button
+						variant="secondary"
+						onClick={refreshAll}
+						className="gap-2 border-border/50 bg-card/50 backdrop-blur-xs hover:bg-card/80"
+					>
+						<RefreshCw className="h-4 w-4" />
+						Refresh
+					</Button>
 				}
 			/>
 
@@ -104,9 +93,13 @@ export const ConsoleClient = () => {
 				style={{ animationDelay: "200ms", animationFillMode: "backwards" }}
 			>
 				{activeTab === "overview" && (
-					// PR 3 turns this into the two-column split:
-					// grid lg:grid-cols-[2fr_1fr] — domain tiles left, feed right.
-					<NeedsAttentionPanel />
+					// The ratified Overview split: domain tiles (status at a
+					// glance) left, the attention feed (what needs me) right.
+					// Stacks on smaller screens, tiles first.
+					<div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+						<DomainTileGrid />
+						<NeedsAttentionPanel />
+					</div>
 				)}
 			</div>
 		</>

--- a/apps/web/src/features/console/components/domain-tile-grid.tsx
+++ b/apps/web/src/features/console/components/domain-tile-grid.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * Operator Console — per-domain tiles (charter §2.1 surface 1).
+ *
+ * One tile per operator domain: health (DomainStatusBadge taxonomy),
+ * last activity (recorded fact), declared tick cadence (registry
+ * constant), and a link to the domain's page. Derivation lives in
+ * ../lib/console-domains.ts (pure, unit-tested); this file only renders.
+ *
+ * Trust rules enforced at render:
+ * - Error state is honest (AsyncStateView) — never an all-healthy grid on
+ *   a failed fetch.
+ * - "Never ran" renders as such, not as a fake timestamp.
+ * - statusDetail tooltips pass through anonymizeHealthMessage in incognito
+ *   (disabledReason strings are plugin-authored free text).
+ */
+
+import { Loader2, ServerCog } from "lucide-react";
+import Link from "next/link";
+import { AsyncStateView, DomainStatusBadge, formatRelativeTime } from "../../../components/layout";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
+import { useSystemJobs } from "../../../hooks/api/useSystem";
+import { anonymizeHealthMessage, useIncognitoMode } from "../../../lib/incognito";
+import { buildDomainTiles, type DomainTileModel } from "../lib/console-domains";
+
+function DomainTile({
+	tile,
+	index,
+	incognito,
+}: {
+	tile: DomainTileModel;
+	index: number;
+	incognito: boolean;
+}) {
+	const { domain } = tile;
+	const Icon = domain.icon;
+	const lastActivity = formatRelativeTime(tile.lastActivityMs ?? undefined);
+	const statusDetail = incognito ? anonymizeHealthMessage(tile.statusDetail) : tile.statusDetail;
+
+	return (
+		<li
+			className="animate-in fade-in slide-in-from-bottom-2"
+			style={{ animationDelay: `${index * 30}ms`, animationFillMode: "backwards" }}
+		>
+			<Link
+				href={domain.href}
+				className="flex h-full flex-col gap-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm transition-colors hover:bg-card/50"
+			>
+				<div className="flex items-center gap-2">
+					<Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+					<span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+						{domain.label}
+					</span>
+					{tile.isRunning && (
+						<span
+							className="flex items-center gap-1 text-xs text-muted-foreground"
+							aria-label={`${domain.label} is running`}
+						>
+							<Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+						</span>
+					)}
+				</div>
+				<DomainStatusBadge status={tile.status} title={statusDetail} />
+				<div className="mt-auto space-y-0.5 text-xs text-muted-foreground">
+					{/* "Last activity", not "Last run": the registry records scheduler
+					    TICKS — a backup tick that decides "not due yet" still counts.
+					    "Last run just now" would misread as "a backup just completed". */}
+					<p>{lastActivity ? `Last activity ${lastActivity}` : "No activity yet"}</p>
+					{tile.cadence && <p>Checks {tile.cadence}</p>}
+				</div>
+			</Link>
+		</li>
+	);
+}
+
+export function DomainTileGrid() {
+	const jobsQuery = useSystemJobs();
+	const servicesQuery = useServicesQuery();
+	const [incognito] = useIncognitoMode();
+
+	const tiles =
+		jobsQuery.data && servicesQuery.data
+			? buildDomainTiles(jobsQuery.data.jobs, servicesQuery.data)
+			: [];
+
+	return (
+		<AsyncStateView
+			isLoading={jobsQuery.isLoading || servicesQuery.isLoading}
+			isError={jobsQuery.isError}
+			error={jobsQuery.error}
+			isEmpty={tiles.length === 0}
+			onRetry={() => void jobsQuery.refetch()}
+			errorTitle="Couldn't load domain status"
+			loadingFallback={
+				<ul className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3" aria-hidden="true">
+					{Array.from({ length: 6 }, (_, i) => (
+						<li
+							// biome-ignore lint/suspicious/noArrayIndexKey: static skeleton list
+							key={i}
+							className="h-28 animate-pulse rounded-xl border border-border/30 bg-muted/10"
+						/>
+					))}
+				</ul>
+			}
+			emptyState={{
+				icon: ServerCog,
+				title: "No domain schedulers registered",
+				description: "Background jobs report here once the API process registers them.",
+			}}
+		>
+			<ul
+				className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3"
+				aria-label="Domain status tiles"
+				data-testid="domain-tile-grid"
+			>
+				{tiles.map((tile, index) => (
+					<DomainTile key={tile.domain.id} tile={tile} index={index} incognito={incognito} />
+				))}
+			</ul>
+		</AsyncStateView>
+	);
+}

--- a/apps/web/src/features/console/components/domain-tile-grid.tsx
+++ b/apps/web/src/features/console/components/domain-tile-grid.tsx
@@ -79,10 +79,16 @@ export function DomainTileGrid() {
 	const servicesQuery = useServicesQuery();
 	const [incognito] = useIncognitoMode();
 
-	const tiles =
-		jobsQuery.data && servicesQuery.data
-			? buildDomainTiles(jobsQuery.data.jobs, servicesQuery.data)
-			: [];
+	// Tiles are built from the JOBS feed alone; the services feed only
+	// drives gating. If services fails, degrade to "no enabled services
+	// known" — core domains still render, gated tiles are omitted (the
+	// same outcome as genuinely having no such service) and the omission
+	// is disclosed below rather than silently swallowed. Blocking ALL
+	// tiles on a services failure would render a false "nothing
+	// registered" empty state while the schedulers are demonstrably fine.
+	const tiles = jobsQuery.data
+		? buildDomainTiles(jobsQuery.data.jobs, servicesQuery.data ?? [])
+		: [];
 
 	return (
 		<AsyncStateView
@@ -118,6 +124,12 @@ export function DomainTileGrid() {
 					<DomainTile key={tile.domain.id} tile={tile} index={index} incognito={incognito} />
 				))}
 			</ul>
+			{servicesQuery.isError && (
+				<p className="mt-3 text-xs text-muted-foreground" data-testid="services-gating-degraded">
+					Couldn't load the service list — tiles for service-linked domains (qui, Requests, Media
+					Caches) are hidden until it recovers.
+				</p>
+			)}
 		</AsyncStateView>
 	);
 }

--- a/apps/web/src/features/console/lib/__tests__/console-domains.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/console-domains.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for the console domain-tile derivation (pure logic).
+ *
+ * Pins the trust-relevant mappings:
+ *   - status taxonomy precedence: disabled > failing (>=2 consecutive,
+ *     mirroring the Pulse collector) > last-run-failed > never-ran > healthy
+ *   - cadence renders ONLY when every member job declares an interval
+ *     (config-driven schedules get no approximate claim)
+ *   - service-gated domains are omitted entirely when no enabled backing
+ *     service exists
+ *   - session-cleanup is not part of any domain (internal hygiene)
+ */
+
+import { describe, expect, it } from "vitest";
+import type { SystemJobStatus } from "../../../../lib/api-client/system";
+import {
+	buildDomainTiles,
+	CONSOLE_DOMAINS,
+	deriveDomainTile,
+	formatCadence,
+} from "../console-domains";
+
+function makeJob(overrides: Partial<SystemJobStatus> & { id: string }): SystemJobStatus {
+	return {
+		label: overrides.id,
+		description: "",
+		concurrency: "singleton",
+		state: "idle",
+		lastStartedAt: "2026-06-11T12:00:00.000Z",
+		lastFinishedAt: "2026-06-11T12:00:05.000Z",
+		lastSuccessAt: "2026-06-11T12:00:05.000Z",
+		lastFailureAt: null,
+		lastDurationMs: 5000,
+		lastError: null,
+		consecutiveFailures: 0,
+		totalRuns: 10,
+		totalFailures: 0,
+		disabled: false,
+		disabledReason: null,
+		...overrides,
+	};
+}
+
+const HUNTING = CONSOLE_DOMAINS.find((d) => d.id === "hunting")!;
+const LIBRARY = CONSOLE_DOMAINS.find((d) => d.id === "library")!;
+const QUI = CONSOLE_DOMAINS.find((d) => d.id === "qui")!;
+
+describe("deriveDomainTile — status precedence", () => {
+	it("healthy when all members ran and none failed", () => {
+		const tile = deriveDomainTile(HUNTING, [makeJob({ id: "hunting" })]);
+		expect(tile?.status).toBe("healthy");
+	});
+
+	it("disabled wins over everything, carrying the reason", () => {
+		const tile = deriveDomainTile(HUNTING, [
+			makeJob({
+				id: "hunting",
+				disabled: true,
+				disabledReason: "suspended after repeated failures",
+				consecutiveFailures: 5,
+			}),
+		]);
+		expect(tile?.status).toBe("disabled");
+		expect(tile?.statusDetail).toContain("suspended after repeated failures");
+	});
+
+	it("degraded at >=2 consecutive failures (Pulse collector parity)", () => {
+		const tile = deriveDomainTile(HUNTING, [makeJob({ id: "hunting", consecutiveFailures: 2 })]);
+		expect(tile?.status).toBe("degraded");
+		expect(tile?.statusDetail).toContain("2 consecutive failures");
+	});
+
+	it("stays healthy at exactly 1 consecutive failure when an earlier success is newer", () => {
+		// One blip below the threshold AND the most recent run succeeded.
+		const tile = deriveDomainTile(HUNTING, [
+			makeJob({
+				id: "hunting",
+				consecutiveFailures: 0,
+				lastFailureAt: "2026-06-11T10:00:00.000Z",
+				lastSuccessAt: "2026-06-11T12:00:05.000Z",
+			}),
+		]);
+		expect(tile?.status).toBe("healthy");
+	});
+
+	it("degraded when the most recent run failed (failure newer than success)", () => {
+		const tile = deriveDomainTile(HUNTING, [
+			makeJob({
+				id: "hunting",
+				consecutiveFailures: 1,
+				lastFailureAt: "2026-06-11T13:00:00.000Z",
+				lastSuccessAt: "2026-06-11T12:00:05.000Z",
+			}),
+		]);
+		expect(tile?.status).toBe("degraded");
+		expect(tile?.statusDetail).toContain("last run failed");
+	});
+
+	it("configured when registered but never ran", () => {
+		const tile = deriveDomainTile(HUNTING, [
+			makeJob({
+				id: "hunting",
+				totalRuns: 0,
+				lastStartedAt: null,
+				lastFinishedAt: null,
+				lastSuccessAt: null,
+			}),
+		]);
+		expect(tile?.status).toBe("configured");
+		expect(tile?.lastActivityMs).toBeNull();
+	});
+
+	it("one unhealthy member degrades a multi-job domain", () => {
+		const tile = deriveDomainTile(LIBRARY, [
+			makeJob({ id: "library-sync" }),
+			makeJob({ id: "library-cleanup", consecutiveFailures: 3 }),
+			makeJob({ id: "insights-digest" }),
+		]);
+		expect(tile?.status).toBe("degraded");
+	});
+
+	it("returns null when no member job is registered", () => {
+		expect(deriveDomainTile(HUNTING, [makeJob({ id: "backup" })])).toBeNull();
+	});
+});
+
+describe("deriveDomainTile — facts, not predictions", () => {
+	it("lastActivityMs is the newest member activity", () => {
+		const tile = deriveDomainTile(LIBRARY, [
+			makeJob({ id: "library-sync", lastFinishedAt: "2026-06-11T12:30:00.000Z" }),
+			makeJob({ id: "library-cleanup", lastFinishedAt: "2026-06-11T11:00:00.000Z" }),
+		]);
+		expect(tile?.lastActivityMs).toBe(Date.parse("2026-06-11T12:30:00.000Z"));
+	});
+
+	it("declares cadence only when EVERY member declares an interval", () => {
+		const allDeclared = deriveDomainTile(QUI, [
+			makeJob({ id: "qui-torrent-state-sync", intervalMs: 10 * 60 * 1000 }),
+			makeJob({ id: "infohash-backfill", intervalMs: 6 * 60 * 60 * 1000 }),
+		]);
+		expect(allDeclared?.cadence).toBe("every 10 min");
+
+		// hunting's schedule is per-instance config — no declared interval, so
+		// no cadence claim at all (never an approximation).
+		const configDriven = deriveDomainTile(HUNTING, [makeJob({ id: "hunting" })]);
+		expect(configDriven?.cadence).toBeNull();
+	});
+
+	it("flags isRunning while any member is mid-run", () => {
+		const tile = deriveDomainTile(LIBRARY, [
+			makeJob({ id: "library-sync", state: "running" }),
+			makeJob({ id: "library-cleanup" }),
+		]);
+		expect(tile?.isRunning).toBe(true);
+	});
+});
+
+describe("formatCadence", () => {
+	it("renders minutes, single hour, and multi-hour", () => {
+		expect(formatCadence(5 * 60 * 1000)).toBe("every 5 min");
+		expect(formatCadence(60 * 60 * 1000)).toBe("every hour");
+		expect(formatCadence(4 * 60 * 60 * 1000)).toBe("every 4 h");
+	});
+});
+
+describe("buildDomainTiles — service gating by omission", () => {
+	const ALL_JOBS = CONSOLE_DOMAINS.flatMap((d) => d.jobIds).map((id) => makeJob({ id }));
+
+	it("omits qui/requests/media-caches tiles when their services are absent", () => {
+		const tiles = buildDomainTiles(ALL_JOBS, []);
+		const ids = tiles.map((t) => t.domain.id);
+		expect(ids).not.toContain("qui");
+		expect(ids).not.toContain("requests");
+		expect(ids).not.toContain("media-caches");
+		// Core domains always render.
+		expect(ids).toEqual(
+			expect.arrayContaining(["backup", "library", "hunting", "queue-cleaner", "trash-guides"]),
+		);
+	});
+
+	it("includes a gated tile when an enabled backing service exists", () => {
+		const tiles = buildDomainTiles(ALL_JOBS, [
+			{ service: "qui", enabled: true },
+			{ service: "plex", enabled: true },
+		]);
+		const ids = tiles.map((t) => t.domain.id);
+		expect(ids).toContain("qui");
+		expect(ids).toContain("media-caches");
+		expect(ids).not.toContain("requests");
+	});
+
+	it("a DISABLED instance does not satisfy the gate", () => {
+		const tiles = buildDomainTiles(ALL_JOBS, [{ service: "seerr", enabled: false }]);
+		expect(tiles.map((t) => t.domain.id)).not.toContain("requests");
+	});
+
+	it("no domain claims session-cleanup (internal hygiene stays internal)", () => {
+		for (const domain of CONSOLE_DOMAINS) {
+			expect(domain.jobIds).not.toContain("session-cleanup");
+		}
+	});
+});

--- a/apps/web/src/features/console/lib/console-domains.ts
+++ b/apps/web/src/features/console/lib/console-domains.ts
@@ -1,0 +1,255 @@
+/**
+ * Operator Console domain tiles — grouping + status derivation.
+ *
+ * The scheduler registry exposes 22 jobs (`GET /api/system/jobs`), many of
+ * them internal plumbing. The console's tiles group them into the operator's
+ * domain vocabulary (the same nouns as the sidebar), so one tile answers
+ * "is this domain running, when did it last act, how often does it act."
+ *
+ * Trust rules applied here:
+ * - NO derived "next run at HH:MM" claims. `JobStatus` records facts
+ *   (last runs, declared cadence) — it has no `nextExecution`, and
+ *   `lastStartedAt + intervalMs` is a proxy, not a promise. Tiles show the
+ *   declared cadence ("every 10 min", exactly true) and last activity
+ *   (recorded fact) instead.
+ * - Service-availability gating by OMISSION: domains whose backing service
+ *   has no enabled instance (qui, Seerr, media servers) render no tile at
+ *   all rather than a misleading "healthy" for a no-op job.
+ * - Status thresholds mirror the Pulse scheduler collector
+ *   (FAILING_THRESHOLD = 2 consecutive failures → degraded) so the tiles
+ *   and the attention feed can never disagree about the same job.
+ * - `session-cleanup` is excluded: internal hygiene with no operator
+ *   action or page to link to.
+ */
+
+import type { ServiceInstanceSummary } from "@arr/shared";
+import type { LucideIcon } from "lucide-react";
+import {
+	Archive,
+	Inbox,
+	Library,
+	MonitorPlay,
+	Network,
+	Sparkles,
+	Tag,
+	Target,
+	Trash2,
+} from "lucide-react";
+import type { DomainStatus } from "../../../components/layout/domain-status";
+import type { SystemJobStatus } from "../../../lib/api-client/system";
+
+export interface ConsoleDomain {
+	id: string;
+	label: string;
+	icon: LucideIcon;
+	/** Action link — must point at an existing page showing the domain's data. */
+	href: string;
+	/** Registry job ids that make up this domain. */
+	jobIds: readonly string[];
+	/**
+	 * Tile renders only when at least one ENABLED instance of one of these
+	 * service types exists. Omitted = always relevant (core domains).
+	 */
+	requiresService?: readonly string[];
+}
+
+// Mirrors the Pulse scheduler collector's FAILING_THRESHOLD — keep in sync
+// with apps/api/src/lib/pulse/collectors.ts.
+const FAILING_THRESHOLD = 2;
+
+export const CONSOLE_DOMAINS: readonly ConsoleDomain[] = [
+	{
+		id: "backup",
+		label: "Backup",
+		icon: Archive,
+		href: "/settings?tab=backups",
+		jobIds: ["backup"],
+	},
+	{
+		id: "library",
+		label: "Library",
+		icon: Library,
+		href: "/library",
+		jobIds: ["library-sync", "library-cleanup", "insights-digest"],
+	},
+	{
+		id: "hunting",
+		label: "Hunting",
+		icon: Target,
+		href: "/hunting",
+		jobIds: ["hunting"],
+	},
+	{
+		id: "queue-cleaner",
+		label: "Queue Cleaner",
+		icon: Trash2,
+		href: "/queue-cleaner",
+		jobIds: ["queue-cleaner"],
+	},
+	{
+		id: "trash-guides",
+		label: "TRaSH Guides",
+		icon: Sparkles,
+		href: "/trash-guides",
+		jobIds: ["trash-update", "trash-sync", "trash-backup-cleanup"],
+	},
+	{
+		id: "media-caches",
+		label: "Media Caches",
+		icon: MonitorPlay,
+		href: "/statistics",
+		jobIds: [
+			"plex-cache",
+			"plex-episode-cache",
+			"jellyfin-cache",
+			"jellyfin-episode-cache",
+			"session-snapshot",
+		],
+		requiresService: ["plex", "jellyfin", "emby"],
+	},
+	{
+		id: "automation",
+		label: "Auto-Tag & Labels",
+		icon: Tag,
+		href: "/auto-tag",
+		jobIds: ["auto-tag", "label-sync", "tmdb-list-cache", "trakt-list-cache"],
+	},
+	{
+		id: "qui",
+		label: "qui",
+		icon: Network,
+		href: "/qui",
+		jobIds: ["qui-torrent-state-sync", "infohash-backfill"],
+		requiresService: ["qui"],
+	},
+	{
+		id: "requests",
+		label: "Requests",
+		icon: Inbox,
+		href: "/requests",
+		jobIds: ["seerr-health"],
+		requiresService: ["seerr"],
+	},
+];
+
+export interface DomainTileModel {
+	domain: ConsoleDomain;
+	status: DomainStatus;
+	/** Hover/tooltip copy explaining the status. */
+	statusDetail: string;
+	/** Epoch ms of the most recent job activity, or null when never ran. */
+	lastActivityMs: number | null;
+	/** Human cadence ("every 10 min") when ALL member jobs declare one… */
+	cadence: string | null;
+	/** …true while any member job is mid-run. */
+	isRunning: boolean;
+}
+
+function toMs(iso: string | null): number | null {
+	if (!iso) return null;
+	const ms = Date.parse(iso);
+	return Number.isFinite(ms) ? ms : null;
+}
+
+export function formatCadence(intervalMs: number): string {
+	const minutes = Math.round(intervalMs / 60_000);
+	if (minutes < 60) return `every ${minutes} min`;
+	const hours = Math.round(minutes / 60);
+	return hours === 1 ? "every hour" : `every ${hours} h`;
+}
+
+/**
+ * Derive one tile's model from the registry jobs. Pure — unit-tested
+ * directly. Returns null when the domain has no registered member jobs
+ * (nothing truthful to show).
+ */
+export function deriveDomainTile(
+	domain: ConsoleDomain,
+	jobs: readonly SystemJobStatus[],
+): DomainTileModel | null {
+	const members = jobs.filter((job) => domain.jobIds.includes(job.id));
+	if (members.length === 0) return null;
+
+	const disabledMember = members.find((job) => job.disabled);
+	const failingMember = members.find((job) => job.consecutiveFailures >= FAILING_THRESHOLD);
+	// "Most recent run failed" — lastFailureAt strictly newer than lastSuccessAt.
+	const lastRunFailedMember = members.find((job) => {
+		const failure = toMs(job.lastFailureAt);
+		const success = toMs(job.lastSuccessAt);
+		return failure !== null && (success === null || failure > success);
+	});
+	const everRan = members.some((job) => job.totalRuns > 0);
+
+	let status: DomainStatus;
+	let statusDetail: string;
+	if (disabledMember) {
+		status = "disabled";
+		statusDetail = disabledMember.disabledReason
+			? `${disabledMember.label}: ${disabledMember.disabledReason}`
+			: `${disabledMember.label} is disabled`;
+	} else if (failingMember) {
+		status = "degraded";
+		statusDetail = `${failingMember.label}: ${failingMember.consecutiveFailures} consecutive failures`;
+	} else if (lastRunFailedMember) {
+		status = "degraded";
+		statusDetail = `${lastRunFailedMember.label}: last run failed`;
+	} else if (!everRan) {
+		status = "configured";
+		statusDetail = "Registered — no runs yet";
+	} else {
+		status = "healthy";
+		statusDetail = "All jobs healthy";
+	}
+
+	const lastActivityMs = members.reduce<number | null>((latest, job) => {
+		const candidate = toMs(job.lastFinishedAt) ?? toMs(job.lastStartedAt);
+		if (candidate === null) return latest;
+		return latest === null ? candidate : Math.max(latest, candidate);
+	}, null);
+
+	// A cadence claim is only exactly true when every member declares one;
+	// config-driven jobs (per-instance schedules) get no cadence line rather
+	// than an approximate one.
+	const intervals = members
+		.map((job) => job.intervalMs)
+		.filter((ms): ms is number => typeof ms === "number" && ms > 0);
+	const cadence =
+		intervals.length === members.length && intervals.length > 0
+			? formatCadence(Math.min(...intervals))
+			: null;
+
+	return {
+		domain,
+		status,
+		statusDetail,
+		lastActivityMs,
+		cadence,
+		isRunning: members.some((job) => job.state === "running"),
+	};
+}
+
+/**
+ * Build the tile list: service-gated domains are OMITTED when no enabled
+ * instance of a backing service exists (trust rule: never show a tile for
+ * a no-op job as if it were doing work).
+ */
+export function buildDomainTiles(
+	jobs: readonly SystemJobStatus[],
+	services: readonly Pick<ServiceInstanceSummary, "service" | "enabled">[],
+): DomainTileModel[] {
+	const enabledServices = new Set(
+		services.filter((s) => s.enabled).map((s) => s.service.toLowerCase()),
+	);
+	const tiles: DomainTileModel[] = [];
+	for (const domain of CONSOLE_DOMAINS) {
+		if (
+			domain.requiresService &&
+			!domain.requiresService.some((service) => enabledServices.has(service))
+		) {
+			continue;
+		}
+		const tile = deriveDomainTile(domain, jobs);
+		if (tile) tiles.push(tile);
+	}
+	return tiles;
+}

--- a/apps/web/src/hooks/api/useSystem.ts
+++ b/apps/web/src/hooks/api/useSystem.ts
@@ -1,11 +1,13 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { UnauthorizedError } from "../../lib/api-client/base";
 import {
 	clearValidationQuarantine,
+	completeTautulliMigration,
 	fetchLogFiles,
 	fetchSecurityPosture,
-	completeTautulliMigration,
 	fetchSystemInfo,
+	fetchSystemJobs,
 	fetchSystemSettings,
 	fetchTautulliMigrationStatus,
 	fetchValidationHealth,
@@ -16,15 +18,15 @@ import {
 	restartSystem,
 	type SecurityPostureResponse,
 	type SystemInfoResponse,
+	type SystemJobsResponse,
 	type SystemSettingsResponse,
 	type TautulliMigrationStatus,
 	type UpdateSystemSettingsPayload,
 	updateSystemSettings,
 	type ValidationHealthResponse,
 } from "../../lib/api-client/system";
-import { UnauthorizedError } from "../../lib/api-client/base";
 import { getErrorMessage } from "../../lib/error-utils";
-import { POLLING_STANDARD } from "../../lib/polling-intervals";
+import { POLLING_STANDARD, POLLING_STATS } from "../../lib/polling-intervals";
 import { pulseKeys, serviceKeys, systemKeys, validationKeys } from "../../lib/query-keys";
 
 // ============================================================================
@@ -62,6 +64,19 @@ export function useSystemInfo() {
 		queryKey: systemKeys.info,
 		queryFn: fetchSystemInfo,
 		refetchInterval: POLLING_STANDARD,
+	});
+}
+
+// ============================================================================
+// Background Jobs (scheduler registry)
+// ============================================================================
+
+export function useSystemJobs() {
+	return useQuery<SystemJobsResponse>({
+		queryKey: systemKeys.jobs,
+		queryFn: fetchSystemJobs,
+		staleTime: 30_000,
+		refetchInterval: POLLING_STATS,
 	});
 }
 

--- a/apps/web/src/lib/api-client/system.ts
+++ b/apps/web/src/lib/api-client/system.ts
@@ -280,3 +280,48 @@ export function completeTautulliMigration(): Promise<{
 }> {
 	return apiRequest("/api/system/migrations/tautulli", { method: "POST" });
 }
+
+// ============================================================================
+// Background Jobs (scheduler registry)
+// ============================================================================
+
+export type SystemJobState = "idle" | "running" | "disabled";
+
+/**
+ * Mirror of the API's `JobStatus` (apps/api/src/lib/scheduler-registry/
+ * scheduler-registry.ts). Read-only runtime telemetry for one registered
+ * background scheduler. Note: there is NO `nextExecution` field — the
+ * registry records facts (last runs, declared cadence), not predictions.
+ */
+export interface SystemJobStatus {
+	id: string;
+	label: string;
+	description: string;
+	concurrency: string;
+	intervalMs?: number;
+	state: SystemJobState;
+	lastStartedAt: string | null;
+	lastFinishedAt: string | null;
+	lastSuccessAt: string | null;
+	lastFailureAt: string | null;
+	lastDurationMs: number | null;
+	lastError: string | null;
+	consecutiveFailures: number;
+	totalRuns: number;
+	totalFailures: number;
+	disabled: boolean;
+	disabledReason: string | null;
+}
+
+export interface SystemJobsResponse {
+	jobs: SystemJobStatus[];
+	count: number;
+	capturedAt: string;
+}
+
+export async function fetchSystemJobs(): Promise<SystemJobsResponse> {
+	const res = await apiRequest<{ success: boolean; data: SystemJobsResponse }>(
+		"/api/system/jobs",
+	);
+	return res.data;
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -408,7 +408,8 @@ export const seerrKeys = {
 	audit: (instanceId: string) => ["seerr", "audit", instanceId] as const,
 	libraryEnrichment: (instanceId: string, tmdbIdKey: string) =>
 		["seerr", "library-enrichment", instanceId, tmdbIdKey] as const,
-	libraryEnrichmentAll: (instanceId: string) => ["seerr", "library-enrichment", instanceId] as const,
+	libraryEnrichmentAll: (instanceId: string) =>
+		["seerr", "library-enrichment", instanceId] as const,
 	discover: {
 		all: ["seerr", "discover"] as const,
 		movies: (instanceId: string) => ["seerr", "discover", "movies", instanceId] as const,
@@ -520,6 +521,7 @@ export const systemKeys = {
 	info: ["system-info"] as const,
 	logs: ["system-logs"] as const,
 	securityPosture: ["system-security-posture"] as const,
+	jobs: ["system-jobs"] as const,
 };
 
 /* -------------------------------------------------------------------------- */
@@ -551,8 +553,7 @@ export const quiKeys = {
 		qbitInstanceId: number | null,
 		hash: string | null,
 		fileIndex: number | null,
-	) =>
-		["qui", "file-mediainfo", quiInstanceId, qbitInstanceId, hash, fileIndex] as const,
+	) => ["qui", "file-mediainfo", quiInstanceId, qbitInstanceId, hash, fileIndex] as const,
 	categories: (quiInstanceId: string | null, qbitInstanceId: number | null) =>
 		["qui", "categories", quiInstanceId, qbitInstanceId] as const,
 	tags: (quiInstanceId: string | null, qbitInstanceId: number | null) =>

--- a/docs/3.0-charter.md
+++ b/docs/3.0-charter.md
@@ -2,7 +2,7 @@
 
 **Status:** RATIFIED v1 — 2026-06-09 (merge into `next` = ratification)
 **Drafted:** 2026-06-04
-**Owner:** @khak1s
+**Owner:** `Kha-kis`
 **Branch:** `next` — cut from `main` at v2.21.0 (`188c8226`) on 2026-06-09
 **Target window:** 6–12 months from ratification; continuous preview tags
 


### PR DESCRIPTION
## Summary

**Operator Console arc PR 3** (charter §2.1 surface 1): per-domain status tiles, completing the ratified Overview split — tiles left, attention feed right.

## What

- **Data layer**: `SystemJobStatus`/`fetchSystemJobs` mirroring the scheduler registry's `JobStatus`, `useSystemJobs` hook (POLLING_STATS), `systemKeys.jobs`
- **Domain model** (`console-domains.ts`, pure + unit-tested): 22 registry jobs → **9 operator domains** in sidebar vocabulary; `session-cleanup` excluded as internal hygiene. Status precedence: `disabled` > `failing` (≥2 consecutive, **Pulse-collector parity** so tiles and the feed can't disagree) > `last-run-failed` > `never-ran` > `healthy`
- **Tile grid**: `DomainStatusBadge` + last activity + tick cadence, `AsyncStateView` for honest error/loading/empty, incognito-safe tooltips
- **Console client**: Overview becomes the split; header `DataFreshness` **removed** (Overview is now multi-feed — applying B4's ratified exclusion rule) and Refresh refetches both feeds
- Rides along: charter `Owner:` line de-mentioned (`@khak1s` → `` `Kha-kis` ``) per the no-live-mentions rule

## Trust decisions (the heart of this PR)

| Decision | Why |
|---|---|
| **No "next run at HH:MM" claims — anywhere** | `JobStatus` has no `nextExecution`; `lastStartedAt + intervalMs` is a proxy, and the trust rules say don't show proxies. Tiles show declared tick cadence ("Checks every 5 min" — a registry constant, exactly true) + last activity (recorded fact). A test pins zero next-run text. |
| **"Last activity," not "Last run"** | The registry records scheduler *ticks* — a backup tick that decides "not due yet" still counts. "Last run just now" on the Backup tile would misread as "a backup just completed." Caught during live cold-read. |
| **Cadence only when every member declares one** | Config-driven schedules (hunting, queue-cleaner per-instance) get no approximate claim. |
| **Service gating by omission** | qui / Requests / Media Caches tiles don't render without an enabled backing service — no "healthy" badge for a no-op job. |

## Validation

- 23 console tests (16 new derivation units + extended client suite); turbo typecheck 3/3; full suite green; lint green
- **Live-verified** (dev DB): 8 tiles render with the **qui tile correctly absent** (no qui instance — the gating path exercised for real); zero next-run claims; cadence only on all-declared domains; 0 console errors; incognito pass clean — screenshots `console-tiles-v1-live.png` / `console-tiles-v1-incognito.png`

## Next in the arc

PR 4 — operator-action refinements on the feed, then the composer (registers the Automation tab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)