### PR TITLE
feat(governance): close charter §7 lint gates (L1 + L4) + enforcement map

### DIFF
--- a/apps/api/src/routes/__tests__/no-inline-body-validation.test.ts
+++ b/apps/api/src/routes/__tests__/no-inline-body-validation.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Charter §7 L1 — `no-inline-Body-without-validateRequest` (CI gate).
+ *
+ * A Fastify route that declares a CONCRETE `Body:` type in its generic and
+ * then trusts `request.body` as that type is the same validation-bypass hole
+ * as `request.body as Type`, just different syntax (CLAUDE.md rule 5). Bucket
+ * A6 (#510) migrated the known offenders to `validateRequest()`; this guard
+ * turns that one-time cleanup into a permanent gate so the bypass can't creep
+ * back in.
+ *
+ * Why a test and not an ESLint rule: `apps/api` is linted by Biome, which has
+ * no custom-AST-rule mechanism (no plugins / no-restricted-syntax). The
+ * codebase already enforces an API-side governance invariant this exact way —
+ * see `pulse-collector-label.test.ts` (charter §7 L2). This mirrors it.
+ *
+ * Granularity: file-level. A route file that declares any non-`unknown`
+ * `Body:` generic must call `validateRequest` somewhere in the file. This is
+ * deliberately coarse (matches L2's pragmatism) — it catches the gross
+ * "type Body concretely and trust it" bypass without a full TS-AST walk.
+ * `Body: unknown` is the safe canonical (unusable without narrowing) and is
+ * exempt. A genuine carve-out can add a `// l1-guard-exempt: <reason>`
+ * comment to the file.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const ROUTES_DIR = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function walkRouteFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const full = join(dir, entry);
+		if (statSync(full).isDirectory()) {
+			if (entry === "__tests__") continue;
+			out.push(...walkRouteFiles(full));
+			continue;
+		}
+		if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) out.push(full);
+	}
+	return out;
+}
+
+// Capture the type text after a `Body:` generic key, up to the next type
+// boundary (`;`, `,`, `}`, `>`, newline). Coarse, but enough to decide the
+// only thing that matters here: is the declared Body `unknown` (safe) or
+// something concrete (must be validated)?
+const BODY_DECL = /Body:\s*([^;\n},>]+)/g;
+
+function declaresConcreteBody(source: string): boolean {
+	for (const match of source.matchAll(BODY_DECL)) {
+		const type = match[1]?.trim();
+		if (type && type !== "unknown") return true;
+	}
+	return false;
+}
+
+describe("charter §7 L1 — no inline Body: typing without validateRequest", () => {
+	const files = walkRouteFiles(ROUTES_DIR);
+
+	it("scans the route tree (sanity: the walker found route files)", () => {
+		expect(files.length).toBeGreaterThan(5);
+	});
+
+	it("every route file with a concrete Body: generic also calls validateRequest", () => {
+		const offenders: string[] = [];
+
+		for (const file of files) {
+			const source = readFileSync(file, "utf8");
+			if (source.includes("l1-guard-exempt")) continue;
+			if (declaresConcreteBody(source) && !source.includes("validateRequest(")) {
+				offenders.push(relative(ROUTES_DIR, file));
+			}
+		}
+
+		expect(
+			offenders,
+			`These route files declare a concrete Body: generic but never call validateRequest() — ` +
+				`parse the body with validateRequest() (lib/utils/validate.ts) instead of trusting the ` +
+				`typed generic, or use 'Body: unknown'. Offending files:\n  ${offenders.join("\n  ")}`,
+		).toEqual([]);
+	});
+});

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -86,6 +86,21 @@ const eslintConfig = [
 					message:
 						"Hardcoded hex color in template literal. Use SEMANTIC_COLORS / BRAND_COLORS or useThemeGradient() from lib/theme-gradients.ts. If this is a genuine carve-out, add an eslint-disable comment with the reason.",
 				},
+				// Charter §7 L4 — no arbitrary z-index. The semantic z-index scale
+				// (z-dropdown..z-tooltip, 1000–2100 in globals.css) owns all GLOBAL
+				// layering. A Tailwind `z-[100]`+ arbitrary value brute-forces its way
+				// into that territory instead of using a semantic class. Scoped to 3+
+				// digits so benign local stacking (z-[1], z-[2]) stays free.
+				{
+					selector: "Literal[value=/z-\\[\\d{3,}\\]/]",
+					message:
+						"Arbitrary z-index. Use a semantic z-index class (z-modal, z-toast, z-dropdown, …) instead of a hardcoded high value. Low local-stacking values (z-[1], z-[2]) are fine; if this large value is a genuine carve-out, add an eslint-disable comment with the reason.",
+				},
+				{
+					selector: "TemplateElement[value.raw=/z-\\[\\d{3,}\\]/]",
+					message:
+						"Arbitrary z-index in template literal. Use a semantic z-index class (z-modal, z-toast, z-dropdown, …) instead of a hardcoded high value. Low local-stacking values (z-[1], z-[2]) are fine; if this large value is a genuine carve-out, add an eslint-disable comment with the reason.",
+				},
 			],
 
 			// Unused imports - auto-fixable

--- a/docs/3.0-charter.md
+++ b/docs/3.0-charter.md
@@ -207,6 +207,8 @@ Inline `z-[NN]` is forbidden outside an explicit allowlist (the dashboard widget
 
 **Additional lint considered for 3.1+:** `require-migration-on-rule-schema-change` — any change to a unified-rule-engine schema must include a corresponding migration entry. Deferred until the rule engine stabilizes.
 
+**Enforcement map (mechanism per gate):** see `docs/governance-gates.md`. Because `apps/api` / `packages/shared` are Biome-linted (no custom-AST-rule host), L1/L2 ship as vitest CI guards rather than ESLint rules; L3 ships as the `e2e/incognito-gate.spec.ts` leak gate + the B6 sweep; L4 is the ESLint rule. L4 uses a value threshold (flag `z-[100]`+, i.e. the range that collides with the semantic z-index scale) instead of a per-file allowlist — the `z-[1]`/`z-[2]` overlay arrows pass for free.
+
 ---
 
 ## 8. Branch Strategy & Cadence

--- a/docs/governance-gates.md
+++ b/docs/governance-gates.md
@@ -1,0 +1,40 @@
+# Governance Gates (Charter §7) — Enforcement Map
+
+Charter §7 commits 3.0 to four governance gates that "become CI gates." They
+are **not all ESLint rules** — they can't be. `apps/web` is linted by ESLint
+(which hosts custom AST rules via `no-restricted-syntax`), but `apps/api` and
+`packages/shared` are linted by **Biome**, which has no custom-AST-rule
+mechanism. So API-side gates are enforced as **vitest guards** that fail CI the
+same way a lint error would. This document maps each gate to its actual
+mechanism so nobody hunts for an ESLint rule that was never the right tool.
+
+| Gate | Target | Mechanism | Where |
+|---|---|---|---|
+| **L1** `no-inline-Body-without-validateRequest` | `apps/api` routes | vitest guard | `apps/api/src/routes/__tests__/no-inline-body-validation.test.ts` |
+| **L2** `require-collector-label-entry` | `apps/api` Pulse collectors | vitest guard | `apps/api/src/routes/__tests__/pulse-collector-label.test.ts` |
+| **L3** `require-incognito-on-sensitive-text-props` | `apps/web` rendering | e2e leak gate (CI `e2e` job) + the Bucket B6 sweep | `e2e/incognito-gate.spec.ts` (#533) + `useIncognitoMode` adoption |
+| **L4** `no-arbitrary-z-index` | `apps/web` className z-index | ESLint `no-restricted-syntax` | `apps/web/eslint.config.mjs` |
+
+## Notes per gate
+
+- **L1** — File-level: any route file declaring a concrete (non-`unknown`)
+  `Body:` generic must call `validateRequest()`. Coarse by design (matches L2);
+  `Body: unknown` is exempt; genuine carve-outs add `// l1-guard-exempt: <reason>`.
+- **L2** — Every collector in `pulse/collectors.ts` must have an explicit
+  `COLLECTOR_LABELS` entry (the humanize fallback is a safety net, not a
+  labeling strategy). Shipped in C4 (#524).
+- **L3** — Implemented as **behavior** enforcement rather than the charter's
+  originally-sketched heuristic ESLint rule on a prop-name allowlist. The
+  heuristic was explicitly flagged in §7 as false-positive-prone; the e2e leak
+  gate `e2e/incognito-gate.spec.ts` (runs in CI's `e2e` job — asserts no
+  sensitive text renders un-anonymized with incognito on) plus the B6
+  `useIncognitoMode` sweep enforce the same invariant at the layer that
+  actually matters — what the user sees — without the lint noise. Adding the
+  heuristic rule later remains an option if regressions slip the e2e net.
+- **L4** — Scoped to **3+ digit** arbitrary z-index (`z-[100]`+), which is the
+  range that collides with the semantic z-index scale (`z-dropdown`..`z-tooltip`,
+  1000–2100 in `globals.css`). Benign local stacking (`z-[1]`, `z-[2]`) is left
+  alone; large carve-outs use an `eslint-disable` with a reason. This satisfies
+  charter §7 L4's "allowlist the `z-[1]`/`z-[2]` arrows" intent via a value
+  threshold rather than a per-file allowlist — simpler to maintain and it doesn't
+  false-positive on new benign low-stacking values.


### PR DESCRIPTION
## Summary

Closes the charter §7 governance-gate gap found during the 3.0 completeness audit. §7 promised "four lint rules become CI gates," but only the B2 hex gate existed. Ground-truthing surfaced the real shape:

**The four gates target two different linters.** `apps/web` uses ESLint (hosts custom AST rules); `apps/api` + `packages/shared` use **Biome** (no custom-rule mechanism). So L1/L2 can't be ESLint rules — they ship as **vitest CI guards**, exactly how the codebase already enforced L2.

### What landed
- **L4 `no-arbitrary-z-index`** (web/ESLint) — `no-restricted-syntax` selector flagging **3+ digit** arbitrary z-index (`z-[100]`+, the range colliding with the semantic scale `z-dropdown`..`z-tooltip` = 1000–2100 in `globals.css`). Benign local stacking (`z-[1]`/`z-[2]`) passes for free — satisfies the charter's allowlist intent via a value threshold, no per-file list to maintain.
- **L1 `no-inline-Body-without-validateRequest`** (api/Biome) — vitest guard: any route file declaring a concrete (non-`unknown`) `Body:` generic must call `validateRequest`. File-level + coarse by design (matches L2); carve-out via `// l1-guard-exempt: <reason>`. Existing qui/oidc concrete-`Body` routes already validate, so it passes today.
- **L2 + L3** — already enforced; **documented** rather than rebuilt. L2 = the `pulse-collector-label` completeness guard (#524); L3 = `e2e/incognito-gate.spec.ts` (CI `e2e` job, #533) + the B6 `useIncognitoMode` sweep. The charter itself flagged L3's heuristic ESLint rule as false-positive-prone.
- **`docs/governance-gates.md`** maps each gate → mechanism; charter §7 gains a pointer + the Biome-split rationale.

## Proof the gates bite
- Planted `z-[9999]` → ESLint `no-restricted-syntax` error; removed → clean.
- Planted concrete-`Body`-without-`validateRequest` route → L1 guard fails naming the file; removed → green.

## Validation
- `turbo typecheck` clean (forced); full suite green (api **2158** / web 532 / shared 67); lint **0 errors**.

## Audit context
This is the first item closed from the 3.0 charter completeness audit. Remaining unblocked gaps: B5 DomainStatusBadge sweep, B4 DataFreshness verify, and the Operator Console composer (flagship). Tracearr (2.2/C2) + Setup (2.3) stay blocked/deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)