### PR TITLE
docs(3.0): ratify B4 + B5 complete-as-scoped + completeness tracker

### DIFF
--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -1,0 +1,89 @@
+# 3.0 Charter — Completeness Status
+
+Living status of every `docs/3.0-charter.md` deliverable, ground-truthed against
+merged code on `next` (PR log + render-site checks). Maintained as the 3.0 cycle
+closes out so apparent "gaps" that are actually complete-as-scoped don't get
+re-discovered and re-worked.
+
+Legend: ✅ shipped · 🟢 complete-as-scoped (ratified) · 🔄 superseded · 🚧 in
+progress · ⛔ blocked · ⬜ not started.
+
+## Flagships (§2)
+| Item | Status | Evidence |
+|---|---|---|
+| 2.1 Operator Console — shell / feed / tiles / actions | ✅ | #534 #535 #537 #538 |
+| 2.1 — embedded rule composer | 🚧 | backend v1 substrate merged (#518–#521); UI + v1-serving API pending |
+| 2.1 — Tracearr live-session count + kill-session action | ⛔ | needs Tracearr (2.2) |
+| 2.2 Tracearr integration | ⛔ | not started — user must deploy a Tracearr instance first |
+| 2.3 Setup rewrite (auto-discovery) | ⬜ | pulled from 3.1; lowest priority |
+
+## Bucket A — breaking changes: ✅ complete
+A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.
+
+## Bucket B — coherence sweeps
+| Sweep | Status | Evidence |
+|---|---|---|
+| B1 query-keys | ✅ | #523 |
+| B2 SEMANTIC_COLORS | ✅ | #527 + hex lint gate #532 |
+| B3 premium-components | ✅ | #530 |
+| B4 DataFreshness | 🟢 ratified | see below |
+| B5 DomainStatusBadge | 🟢 ratified | see below |
+| B6 useIncognitoMode | ✅ | #525 #526 + e2e gate #533 |
+
+## Bucket C — arcs
+C1 qui→stable ✅ (#513 graduation) · C2 Statistics-on-Tracearr ⛔ (blocked) ·
+C3 auto-tagger sub-arc 4 ✅ (#529) · C4 pulse labels ✅ (#524).
+
+## ADRs (§5): ✅ 0005–0008 (#509, amended #514/#515).
+
+## Migration (§6)
+- 6.1 Tautulli first-boot wizard → ✅ shipped as a confirmation dialog (#517, downscoped #514).
+- 6.2 eager per-surface rule migrations + `/config/rules-pre-3.0/*.json` backups → 🔄 **superseded** by ADR-0006 lazy convergence (write-on-edit). Only `rules-migration/tautulli-pass.ts` is needed; the "review migrated rules" dry-run rides with the composer.
+- 6.3 other breaking changes → ✅.
+
+## Governance (§7): ✅ #551 — see `docs/governance-gates.md` for the per-gate mechanism map.
+
+---
+
+## Ratification rationale
+
+These two sweeps look under-target against the charter's surface-count estimates,
+but those estimates counted *every status/polling surface*; the trust-correct
+target is narrower, and it is fully covered. Forcing the primitive onto the
+remaining surfaces would make it **lie about what it means** — the opposite of
+the trust thesis.
+
+### B5 — DomainStatusBadge (🟢 ratified; charter est. ~12)
+`DomainStatusBadge` has one meaning: persistent **service/integration health**
+(healthy / degraded / offline / configured / disabled), deliberately deferring
+live state to Pulse. Adopted on all 5 surfaces where that is the semantic:
+`service-instance-card` (via `services-tab`, covers every arr / media / Seerr /
+qui instance), the console domain tiles, the validation-health section, and the
+two notification-channel surfaces.
+
+Every other status badge in the app is **different semantics** and correctly does
+NOT use it: notification log/rule status, hunting/queue-cleaner *run* status,
+library/cleanup *item* status, `qui-status-badge` (per-torrent deletion safety),
+and `service-form`'s transient connection-test result. Statistics / dashboard /
+plex-oauth / indexers render no ad-hoc service-health badge (the dashboard routes
+service-unreachability through Pulse, by design).
+
+### B4 — DataFreshness (🟢 ratified; charter est. ~15)
+`DataFreshness` is trust-correct on **single-feed primary live-status surfaces**.
+Adopted on 7: calendar, Pulse, statistics, hunting, queue-cleaner, settings/system,
+qui-home. The remaining polling surfaces are correctly excluded:
+- **Multi-feed → would under-report freshness:** the dashboard and the console
+  Overview (the latter documents the exclusion in-code — it is the precedent for
+  the rule).
+- **Already conveys freshness via richer domain cues:** `scheduler-status-dashboard`
+  shows `lastCheckAt` ("5 minutes ago") + `nextCheckAt` + a live pulse dot; a
+  generic freshness badge would be redundant chrome.
+- **Worklist / feed / browse, freshness secondary:** Seerr requests, qui-activity,
+  library browse — item timestamps carry the recency signal.
+
+---
+
+## Remaining work (in recommended order)
+1. **Operator Console composer** (2.1) — unblocked flagship; multi-PR, its own loop.
+2. **Tracearr (2.2) + C2 Statistics-on-Tracearr + 2.1 live-session/kill-session** — blocked on deploying a Tracearr instance.
+3. **Setup rewrite (2.3)** — lowest priority (pulled from 3.1).


### PR DESCRIPTION
## Summary

Closes out the two remaining Bucket B sweeps from the 3.0 completeness audit. Both **look** under-target against the charter's surface-count estimates, but ground-truthing shows those estimates counted *every* status/polling surface — the trust-correct target is narrower and is fully covered. Adopting the primitives onto the remaining surfaces would make them **misrepresent their own meaning**, which is the over-adoption trap the sweep memo + trust-check discipline warn against.

### B5 — DomainStatusBadge (charter est. ~12) → 🟢 ratified
The badge means persistent **service/integration health** (healthy/degraded/offline/configured/disabled), deferring live state to Pulse. Adopted on all 5 service-health surfaces (service-instance-card via services-tab, console tiles, validation-health, notification channels ×2). Every other status badge is **different semantics** — notification log/run status, hunting/queue-cleaner run status, library/cleanup item status, `qui-status-badge` (per-torrent deletion-safety), `service-form` transient connect-test — and correctly doesn't use it.

### B4 — DataFreshness (charter est. ~15) → 🟢 ratified
Trust-correct on **single-feed primary live-status surfaces**; adopted on 7 (calendar, Pulse, statistics, hunting, queue-cleaner, settings/system, qui-home). The rest are correctly excluded:
- **Multi-feed** (would under-report): dashboard + console Overview (the console documents the exclusion in-code — the precedent for the rule).
- **Already fresh via domain cues**: `scheduler-status-dashboard` shows `lastCheckAt`/`nextCheckAt` + a live pulse dot — a generic badge would be redundant.
- **Worklist/feed/browse** (freshness secondary): Seerr requests, qui-activity, library browse.

## What's in the PR
- `docs/3.0-completeness-status.md` — a living status tracker for every charter deliverable (so complete-as-scoped items aren't re-discovered as gaps), with the B4/B5 ratification rationale.

No code change.

## Audit progress
Item 1 (§7 governance gates) shipped in #551. This closes B4/B5. Remaining unblocked: the **Operator Console composer** (flagship, multi-PR). Tracearr (2.2/C2) + Setup (2.3) stay blocked/deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)