### PR TITLE
feat(composer): v1-serving automation read API (Composer PR-1, §5.1)

### DIFF
--- a/apps/api/src/lib/automation/collect-rules.ts
+++ b/apps/api/src/lib/automation/collect-rules.ts
@@ -1,0 +1,115 @@
+/**
+ * Automation rule aggregation — the composer's read surface (charter §5.1).
+ *
+ * Loads every domain's stored rules (owned by `userId`) and normalizes each to
+ * the v1 grammar so the API serves only v1 and the frontend carries zero legacy
+ * knowledge. All v0→v1 conversion is delegated to the existing mappers — the
+ * SAME ones the live evaluators use (`cleanup-adapter`), so the viewer shows
+ * exactly what the engine evaluates.
+ *
+ * Surfaces with user-authored rule documents: library-cleanup, auto-tag,
+ * notifications. Queue-cleaner and hunting register as contexts but have no
+ * user-authored documents (empty kind sets), so they contribute nothing here.
+ *
+ * Robustness mirrors the engine's discipline: a structurally unparseable row is
+ * surfaced honestly (`unparseable: true`, `document: null`) rather than dropped
+ * or 500'd — the operator sees the rule exists and needs attention.
+ */
+
+import type { AutomationRuleSummary, RuleContextId, RuleDocument } from "@arr/shared";
+import { CONTEXT_KINDS } from "@arr/shared";
+import type { PrismaClient } from "../prisma.js";
+import { listUnavailableKinds, normalizeDocument } from "../rules/engine.js";
+import { mapCriteriaV0ToDocument, mapNotificationsV0ToDocument } from "../rules/v0-mappers.js";
+
+/** Fields both criteria tables (library-cleanup, auto-tag) share. */
+const criteriaSelect = {
+	id: true,
+	name: true,
+	enabled: true,
+	ruleType: true,
+	parameters: true,
+	operator: true,
+	conditions: true,
+} as const;
+
+interface RuleBase {
+	id: string;
+	name: string;
+	enabled: boolean;
+}
+
+/**
+ * Build a summary by running `build()` (the v0→v1 mapper) under the context's
+ * legal-kind set. A throw from the mapper (or JSON.parse) → unparseable.
+ */
+function summarize(
+	context: RuleContextId,
+	base: RuleBase,
+	build: () => RuleDocument,
+): AutomationRuleSummary {
+	const legalKinds = CONTEXT_KINDS[context];
+	try {
+		const doc = build();
+		return {
+			id: base.id,
+			name: base.name,
+			enabled: base.enabled,
+			context,
+			document: normalizeDocument(doc, legalKinds),
+			unavailableKinds: listUnavailableKinds(doc, legalKinds),
+			unparseable: false,
+		};
+	} catch {
+		return {
+			id: base.id,
+			name: base.name,
+			enabled: base.enabled,
+			context,
+			document: null,
+			unavailableKinds: [],
+			unparseable: true,
+		};
+	}
+}
+
+export async function collectAutomationRules(
+	prisma: PrismaClient,
+	userId: string,
+): Promise<AutomationRuleSummary[]> {
+	const [cleanupRules, autoTagRules, notificationRules] = await Promise.all([
+		// Cleanup rules are owned through their config (no direct userId column).
+		prisma.libraryCleanupRule.findMany({
+			where: { config: { userId } },
+			select: criteriaSelect,
+			orderBy: { name: "asc" },
+		}),
+		prisma.autoTagRule.findMany({
+			where: { userId },
+			select: criteriaSelect,
+			orderBy: { name: "asc" },
+		}),
+		prisma.notificationRule.findMany({
+			where: { userId },
+			select: { id: true, name: true, enabled: true, conditions: true },
+			orderBy: { name: "asc" },
+		}),
+	]);
+
+	const summaries: AutomationRuleSummary[] = [];
+
+	for (const r of cleanupRules) {
+		summaries.push(summarize("library-cleanup", r, () => mapCriteriaV0ToDocument(r)));
+	}
+	for (const r of autoTagRules) {
+		summaries.push(summarize("auto-tag", r, () => mapCriteriaV0ToDocument(r)));
+	}
+	for (const r of notificationRules) {
+		// conditions is a JSON array string; JSON.parse may throw → unparseable.
+		summaries.push(
+			summarize("notifications", r, () => mapNotificationsV0ToDocument(JSON.parse(r.conditions))),
+		);
+	}
+
+	return summaries;
+}

--- a/apps/api/src/lib/automation/collect-rules.ts
+++ b/apps/api/src/lib/automation/collect-rules.ts
@@ -18,6 +18,7 @@
 
 import type { AutomationRuleSummary, RuleContextId, RuleDocument } from "@arr/shared";
 import { CONTEXT_KINDS } from "@arr/shared";
+import type { FastifyBaseLogger } from "fastify";
 import type { PrismaClient } from "../prisma.js";
 import { listUnavailableKinds, normalizeDocument } from "../rules/engine.js";
 import { mapCriteriaV0ToDocument, mapNotificationsV0ToDocument } from "../rules/v0-mappers.js";
@@ -47,6 +48,7 @@ function summarize(
 	context: RuleContextId,
 	base: RuleBase,
 	build: () => RuleDocument,
+	log: FastifyBaseLogger,
 ): AutomationRuleSummary {
 	const legalKinds = CONTEXT_KINDS[context];
 	try {
@@ -60,7 +62,11 @@ function summarize(
 			unavailableKinds: listUnavailableKinds(doc, legalKinds),
 			unparseable: false,
 		};
-	} catch {
+	} catch (err) {
+		// The `unparseable` flag is the operator-facing signal; log the
+		// underlying error too so "why is this rule broken?" is diagnosable
+		// server-side (the row is surfaced, never silently dropped).
+		log.warn({ err, ruleId: base.id, context }, "automation: rule could not be parsed to v1");
 		return {
 			id: base.id,
 			name: base.name,
@@ -76,6 +82,7 @@ function summarize(
 export async function collectAutomationRules(
 	prisma: PrismaClient,
 	userId: string,
+	log: FastifyBaseLogger,
 ): Promise<AutomationRuleSummary[]> {
 	const [cleanupRules, autoTagRules, notificationRules] = await Promise.all([
 		// Cleanup rules are owned through their config (no direct userId column).
@@ -99,15 +106,20 @@ export async function collectAutomationRules(
 	const summaries: AutomationRuleSummary[] = [];
 
 	for (const r of cleanupRules) {
-		summaries.push(summarize("library-cleanup", r, () => mapCriteriaV0ToDocument(r)));
+		summaries.push(summarize("library-cleanup", r, () => mapCriteriaV0ToDocument(r), log));
 	}
 	for (const r of autoTagRules) {
-		summaries.push(summarize("auto-tag", r, () => mapCriteriaV0ToDocument(r)));
+		summaries.push(summarize("auto-tag", r, () => mapCriteriaV0ToDocument(r), log));
 	}
 	for (const r of notificationRules) {
 		// conditions is a JSON array string; JSON.parse may throw → unparseable.
 		summaries.push(
-			summarize("notifications", r, () => mapNotificationsV0ToDocument(JSON.parse(r.conditions))),
+			summarize(
+				"notifications",
+				r,
+				() => mapNotificationsV0ToDocument(JSON.parse(r.conditions)),
+				log,
+			),
 		);
 	}
 

--- a/apps/api/src/routes/__tests__/automation-rules.test.ts
+++ b/apps/api/src/routes/__tests__/automation-rules.test.ts
@@ -1,0 +1,258 @@
+/**
+ * GET /api/automation/rules — the composer's v1 read surface (charter §5.1).
+ *
+ * Asserts the boundary contract: every domain's stored (v0) rules are served
+ * normalized to v1, retired/unknown kinds are annotated (not dropped), and an
+ * unparseable row is surfaced honestly rather than 500'd. Ownership scoping is
+ * exercised through the stubbed Prisma `where` clauses.
+ */
+
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { registerAutomationRoutes } from "../automation.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+type CriteriaRow = {
+	id: string;
+	name: string;
+	enabled: boolean;
+	ruleType: string;
+	parameters: string;
+	operator: string | null;
+	conditions: string | null;
+};
+type NotificationRow = {
+	id: string;
+	name: string;
+	enabled: boolean;
+	conditions: string;
+};
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let userCounter = 0;
+
+let cleanupRules: CriteriaRow[];
+let autoTagRules: CriteriaRow[];
+let notificationRules: NotificationRow[];
+// Records the `where` each surface was queried with, to assert ownership scoping.
+let queriedWith: Record<string, unknown>;
+
+beforeEach(async () => {
+	userCounter += 1;
+	cleanupRules = [];
+	autoTagRules = [];
+	notificationRules = [];
+	queriedWith = {};
+
+	app = Fastify({ logger: false });
+	setupAuthInjection(app, { id: `user-automation-${userCounter}`, username: "admin" });
+	app.decorate("prisma", {
+		libraryCleanupRule: {
+			findMany: async (args: { where: unknown }) => {
+				queriedWith.cleanup = args.where;
+				return cleanupRules;
+			},
+		},
+		autoTagRule: {
+			findMany: async (args: { where: unknown }) => {
+				queriedWith.autoTag = args.where;
+				return autoTagRules;
+			},
+		},
+		notificationRule: {
+			findMany: async (args: { where: unknown }) => {
+				queriedWith.notification = args.where;
+				return notificationRules;
+			},
+		},
+	} as unknown as never);
+	await app.register(registerAutomationRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+async function getRules() {
+	const res = await injectAuthenticated("GET", "/automation/rules");
+	expect(res.statusCode).toBe(200);
+	return JSON.parse(res.payload).rules as Array<Record<string, unknown>>;
+}
+
+describe("GET /api/automation/rules", () => {
+	it("scopes each surface to the current user (cleanup via config.userId)", async () => {
+		const expectedUser = `user-automation-${userCounter}`;
+		await getRules();
+		expect(queriedWith.cleanup).toEqual({ config: { userId: expectedUser } });
+		expect(queriedWith.autoTag).toEqual({ userId: expectedUser });
+		expect(queriedWith.notification).toEqual({ userId: expectedUser });
+	});
+
+	it("maps a single criteria rule to a v1 predicate document", async () => {
+		cleanupRules = [
+			{
+				id: "c1",
+				name: "Old movies",
+				enabled: true,
+				ruleType: "age",
+				parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+				operator: null,
+				conditions: null,
+			},
+		];
+
+		const rule = (await getRules())[0]!;
+		expect(rule).toMatchObject({
+			id: "c1",
+			context: "library-cleanup",
+			unparseable: false,
+			unavailableKinds: [],
+			document: {
+				version: 1,
+				root: { kind: "age", params: { operator: "older_than", days: 30 } },
+			},
+		});
+	});
+
+	it("maps a composite criteria rule to an all/any group", async () => {
+		autoTagRules = [
+			{
+				id: "a1",
+				name: "Action 2020+",
+				enabled: true,
+				ruleType: "composite",
+				parameters: "{}",
+				operator: "AND",
+				conditions: JSON.stringify([
+					{ ruleType: "genre", parameters: { genres: ["Action"] } },
+					{ ruleType: "year_range", parameters: { from: 2020, to: 2024 } },
+				]),
+			},
+		];
+
+		const rule = (await getRules())[0]!;
+		expect(rule.context).toBe("auto-tag");
+		expect(rule.document).toMatchObject({
+			version: 1,
+			root: {
+				all: [
+					{ kind: "genre", params: { genres: ["Action"] } },
+					{ kind: "year_range", params: { from: 2020, to: 2024 } },
+				],
+			},
+		});
+	});
+
+	it("maps a notifications rule to field_match predicates", async () => {
+		notificationRules = [
+			{
+				id: "n1",
+				name: "Hunt done",
+				enabled: false,
+				conditions: JSON.stringify([
+					{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+				]),
+			},
+		];
+
+		const rule = (await getRules())[0]!;
+		expect(rule).toMatchObject({
+			id: "n1",
+			enabled: false,
+			context: "notifications",
+			unparseable: false,
+			document: {
+				version: 1,
+				root: {
+					all: [
+						{
+							kind: "field_match",
+							params: { field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+						},
+					],
+				},
+			},
+		});
+	});
+
+	it("annotates retired/unknown kinds without dropping the rule", async () => {
+		cleanupRules = [
+			{
+				id: "c-retired",
+				name: "Legacy rule",
+				enabled: true,
+				ruleType: "totally_unknown_kind",
+				parameters: "{}",
+				operator: null,
+				conditions: null,
+			},
+		];
+
+		const rule = (await getRules())[0]!;
+		expect(rule.unparseable).toBe(false);
+		expect(rule.unavailableKinds).toEqual(["totally_unknown_kind"]);
+		expect(rule.document).toMatchObject({
+			root: { kind: "totally_unknown_kind", unavailableKind: true },
+		});
+	});
+
+	it("surfaces an unparseable rule honestly (document null, flagged)", async () => {
+		cleanupRules = [
+			{
+				id: "c-bad",
+				name: "Broken rule",
+				enabled: true,
+				ruleType: "age",
+				parameters: "not valid json {",
+				operator: null,
+				conditions: null,
+			},
+		];
+
+		const rule = (await getRules())[0]!;
+		expect(rule).toMatchObject({
+			id: "c-bad",
+			name: "Broken rule",
+			unparseable: true,
+			document: null,
+			unavailableKinds: [],
+		});
+	});
+
+	it("returns rules from all three surfaces together", async () => {
+		cleanupRules = [
+			{
+				id: "c1",
+				name: "c",
+				enabled: true,
+				ruleType: "age",
+				parameters: "{}",
+				operator: null,
+				conditions: null,
+			},
+		];
+		autoTagRules = [
+			{
+				id: "a1",
+				name: "a",
+				enabled: true,
+				ruleType: "genre",
+				parameters: "{}",
+				operator: null,
+				conditions: null,
+			},
+		];
+		notificationRules = [{ id: "n1", name: "n", enabled: true, conditions: "[]" }];
+
+		const rules = await getRules();
+		expect(rules.map((r) => r.context).sort()).toEqual([
+			"auto-tag",
+			"library-cleanup",
+			"notifications",
+		]);
+	});
+});

--- a/apps/api/src/routes/automation.ts
+++ b/apps/api/src/routes/automation.ts
@@ -14,7 +14,7 @@ import { collectAutomationRules } from "../lib/automation/collect-rules.js";
 export const registerAutomationRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	app.get("/automation/rules", async (request) => {
 		const userId = request.currentUser!.id;
-		const rules = await collectAutomationRules(app.prisma, userId);
+		const rules = await collectAutomationRules(app.prisma, userId, request.log);
 		return { rules } satisfies AutomationRulesResponse;
 	});
 

--- a/apps/api/src/routes/automation.ts
+++ b/apps/api/src/routes/automation.ts
@@ -1,0 +1,22 @@
+/**
+ * Unified Automation Engine — composer read surface.
+ *
+ * GET /api/automation/rules returns every domain's stored rules normalized to
+ * the v1 grammar (charter §5.1: "the API serves only v1"). This is the read
+ * half of the Operator Console rule composer; authoring + cross-domain rules
+ * land in later PRs.
+ */
+
+import type { AutomationRulesResponse } from "@arr/shared";
+import type { FastifyPluginCallback } from "fastify";
+import { collectAutomationRules } from "../lib/automation/collect-rules.js";
+
+export const registerAutomationRoutes: FastifyPluginCallback = (app, _opts, done) => {
+	app.get("/automation/rules", async (request) => {
+		const userId = request.currentUser!.id;
+		const rules = await collectAutomationRules(app.prisma, userId);
+		return { rules } satisfies AutomationRulesResponse;
+	});
+
+	done();
+};

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -22,6 +22,7 @@ import { registerAuthOidcRoutes } from "./auth-oidc.js";
 import { registerAuthPasskeyRoutes } from "./auth-passkey.js";
 import { registerAutoTagRoutes } from "./auto-tag.js";
 import { registerAutoTagWebhookRoutes } from "./auto-tag-webhook.js";
+import { registerAutomationRoutes } from "./automation.js";
 import { registerBackupRoutes } from "./backup.js";
 import { registerDashboardRoutes } from "./dashboard.js";
 import { registerHealthRoutes } from "./health.js";
@@ -272,6 +273,14 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		register: registerPulseRoutes,
 		maturity: "internal",
 		summary: "System Pulse health signals + attention items",
+	},
+	{
+		path: "/api/automation",
+		prefix: "/api",
+		register: registerAutomationRoutes,
+		maturity: "experimental",
+		summary:
+			"Unified Automation Engine — composer read surface: every domain's stored rules (library-cleanup / auto-tag / notifications) normalized to the v1 grammar (charter §5.1). Read-only in this phase; authoring + cross-domain rules follow.",
 	},
 	{
 		path: "/api/qui",

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -55,6 +55,7 @@ for the full rationale.
 | `/api/auto-tag` | operator | Criteria-based auto-tagger — applies tags to LibraryCache items matching the rule's criteria DSL (genre, year, codec, watch state, …). Companion to Label Sync. Webhook config (secret read/rotate) lives here under session auth. |
 | `/api/auto-tag/webhook` | operator | Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. **Public route** (no session cookie); authenticates via per-user Bearer token (SHA-256 hash of the user's webhook secret). |
 | `/api/pulse` | internal | System Pulse health signals + attention items |
+| `/api/automation` | experimental | Unified Automation Engine — composer read surface: every domain's stored rules (library-cleanup / auto-tag / notifications) normalized to the v1 grammar (charter §5.1). Read-only in this phase; authoring + cross-domain rules follow. |
 | `/api/qui` | stable | Federated peer integration with autobrr/qui (qBittorrent UI) — torrent state, trackers, cross-seed siblings, and capability-aware torrent mutations; powers the Torrent Health panel and detail drawer. |
 | `/api/webhooks/qui` | stable | Inbound qui webhook receiver (Phase 5.1). **Public route** (no session cookie); authenticates via per-user `?secret=…` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in `QuiEventLog` and publishes to the in-process event bus for SSE fan-out. |
 | `/api/seerr` | stable | Request management, discovery, library enrichment |

--- a/packages/shared/src/types/automation.ts
+++ b/packages/shared/src/types/automation.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { RULE_CONTEXT_IDS } from "../rules/contexts.js";
+import { ruleDocumentSchema } from "../rules/grammar.js";
+
+/**
+ * Automation rule — read surface for the Operator Console composer.
+ *
+ * The composer reads every domain's stored rule normalized to the v1 grammar
+ * (charter §5.1: "the API serves only v1"). Each domain's rows are parsed and
+ * mapped to a {@link RuleDocument} server-side via the v0 mappers; the frontend
+ * carries zero legacy knowledge. Retired / drifted kinds are annotated
+ * (`unavailableKinds`) rather than dropped, and a rule whose stored shape can't
+ * be parsed is surfaced honestly (`unparseable`) rather than hidden or 500'd.
+ */
+export const automationRuleSummarySchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	enabled: z.boolean(),
+	/** Which engine surface owns the rule (its legal-kind context). */
+	context: z.enum(RULE_CONTEXT_IDS),
+	/** Normalized v1 document, or null when the stored rule is unparseable. */
+	document: ruleDocumentSchema.nullable(),
+	/**
+	 * Kinds in the document not legal for the context — retired (`tautulli_*`)
+	 * or vocabulary drift. The UI badges these; evaluation no-matches them.
+	 */
+	unavailableKinds: z.array(z.string()),
+	/** The stored rule could not be parsed into a v1 document. */
+	unparseable: z.boolean(),
+});
+export type AutomationRuleSummary = z.infer<typeof automationRuleSummarySchema>;
+
+export const automationRulesResponseSchema = z.object({
+	rules: z.array(automationRuleSummarySchema),
+});
+export type AutomationRulesResponse = z.infer<typeof automationRulesResponseSchema>;

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from "./api";
 export * from "./arr";
 export * from "./auto-tag";
+export * from "./automation";
 export * from "./backup";
 export * from "./dashboard";
 export * from "./jellyfin";


### PR DESCRIPTION
## Summary

First slice of the Operator Console **rule composer** (charter §2.1 / §5.2) — the load-bearing **"API serves only v1"** read boundary (§5.1) that every later composer slice depends on.

`GET /api/automation/rules` aggregates every domain's stored rules and serves each **normalized to the v1 grammar**:
- **library-cleanup** (scoped via `config.userId`), **auto-tag** + **notifications** (via `userId`)
- v0→v1 through the **same mappers the live evaluators use** (`cleanup-adapter`), so the read surface shows exactly what the engine evaluates
- retired/unknown kinds **annotated** (`unavailableKind` + `unavailableKinds[]`), never dropped
- an unparseable stored row is **surfaced honestly** (`unparseable: true`, `document: null`), never hidden or 500'd

The backend substrate (grammar, v0-mappers, `normalizeDocument`/`listUnavailableKinds`) was already merged (A4, #518–#521); this PR wires the aggregation + boundary on top.

## Scope boundary (deliberate, thin slice)
`AutomationRuleSummary` carries identity + the normalized **condition document** — the unified grammar is the *condition* half (ADR-0006). Per-domain **actions** (tagName / delete-vs-retention / notification routing) are heterogeneous and ride with the viewer/authoring work; the type can grow an `action` field without breaking. **No UI yet** — the Automation tab + read-only viewer is PR-2.

## Best-order sequencing
PR-1 (this): backend v1 boundary · PR-2: Automation tab + read-only cross-domain viewer · PR-3: single-context authoring (write v1) · PR-4: cross-domain storage + dry-run + deploy.

## Validation
- `turbo typecheck` clean; full API suite green (**2165**) + **7 new route tests** (ownership scoping, v0→v1 across all 3 surfaces, unavailable-kind annotation, unparseable handling); lint 0 errors.
- **Live-verified against the real stack**: seeded a cleanup rule, confirmed the real Prisma `config: { userId }` relation query (which the stubbed tests can't exercise) returns it normalized to v1.

New surface registered `experimental` (ADR-0005) + documented in `API-ROUTES.md` (manifest test enforces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)