### PR TITLE
feat(composer): Automation tab — read-only cross-domain rule viewer (PR-2)

### DIFF
--- a/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
@@ -1,0 +1,125 @@
+import type { AutomationRulesResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+
+const INCOGNITO_STORAGE_KEY = "arr-dashboard-incognito-mode";
+
+const mockUseAutomationRules = vi.fn();
+vi.mock("../../../../hooks/api/useAutomation", () => ({
+	useAutomationRules: () => mockUseAutomationRules(),
+}));
+
+import { AutomationPanel } from "../automation-panel";
+
+function createWrapper() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={qc}>
+			<ColorThemeProvider>
+				<IncognitoProvider>{children}</IncognitoProvider>
+			</ColorThemeProvider>
+		</QueryClientProvider>
+	);
+}
+
+function response(rules: AutomationRulesResponse["rules"]): AutomationRulesResponse {
+	return { rules };
+}
+
+beforeEach(() => {
+	mockUseAutomationRules.mockReset();
+	localStorage.removeItem(INCOGNITO_STORAGE_KEY);
+});
+
+describe("<AutomationPanel />", () => {
+	it("shows a loading state while fetching", () => {
+		mockUseAutomationRules.mockReturnValue({ isLoading: true });
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+		expect(screen.queryByText(/No automation rules yet/i)).not.toBeInTheDocument();
+	});
+
+	it("shows an honest error state (not empty) on failure", () => {
+		mockUseAutomationRules.mockReturnValue({
+			isError: true,
+			error: new Error("boom"),
+		});
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+		expect(screen.getByText(/Couldn't load automation rules/i)).toBeInTheDocument();
+		expect(screen.queryByText(/No automation rules yet/i)).not.toBeInTheDocument();
+	});
+
+	it("shows the empty state only when the fetch succeeded with no rules", () => {
+		mockUseAutomationRules.mockReturnValue({ data: response([]) });
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+		expect(screen.getByText(/No automation rules yet/i)).toBeInTheDocument();
+	});
+
+	it("groups rules by domain and renders names + documents", () => {
+		mockUseAutomationRules.mockReturnValue({
+			data: response([
+				{
+					id: "c1",
+					name: "Old movies",
+					enabled: true,
+					context: "library-cleanup",
+					document: {
+						version: 1,
+						root: { kind: "age", params: { operator: "older_than", days: 30 } },
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+				{
+					id: "n1",
+					name: "Hunt notifier",
+					enabled: false,
+					context: "notifications",
+					document: {
+						version: 1,
+						root: {
+							all: [
+								{
+									kind: "field_match",
+									params: { field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+								},
+							],
+						},
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+			]),
+		});
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+
+		expect(screen.getByText("Library Cleanup")).toBeInTheDocument();
+		expect(screen.getByText("Notifications")).toBeInTheDocument();
+		expect(screen.getByText("Old movies")).toBeInTheDocument();
+		expect(screen.getByText("Hunt notifier")).toBeInTheDocument();
+		expect(screen.getByText("Enabled")).toBeInTheDocument();
+		expect(screen.getByText("Disabled")).toBeInTheDocument();
+	});
+
+	it("surfaces an unparseable rule with a warning instead of a document", () => {
+		mockUseAutomationRules.mockReturnValue({
+			data: response([
+				{
+					id: "bad",
+					name: "Broken rule",
+					enabled: true,
+					context: "auto-tag",
+					document: null,
+					unavailableKinds: [],
+					unparseable: true,
+				},
+			]),
+		});
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+		expect(screen.getByText("Broken rule")).toBeInTheDocument();
+		expect(screen.getByText(/could not be read/i)).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/console/components/__tests__/console-client.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/console-client.test.tsx
@@ -6,9 +6,9 @@
  *   - the attention feed is mounted and driven by the shared
  *     NeedsAttentionPanel (its own states are pinned in
  *     needs-attention-panel.test.tsx — not re-tested here)
- *   - NO tab bar renders while the console has a single tab (the
- *     Automation tab registers with the composer; a dead stub tab would
- *     be a misleading surface)
+ *   - the tab bar renders now that the Automation tab is registered
+ *     (Overview + Automation = >1 tab; the Automation tab shows real
+ *     normalized rules, not a dead stub)
  *   - the header refresh action refetches the attention query
  */
 
@@ -156,13 +156,14 @@ describe("ConsoleClient shell", () => {
 		expect(screen.getByText("Hunt failing on Radarr Main")).toBeInTheDocument();
 	});
 
-	it("renders NO tab bar while the console has a single tab", () => {
+	it("renders the tab bar now that the Automation tab is registered", () => {
 		mockQueryState();
 		render(<ConsoleClient />, { wrapper: createWrapper() });
 
-		// The only "Overview" affordance would come from a rendered tab bar —
-		// the header itself never says Overview.
-		expect(screen.queryByRole("button", { name: /overview/i })).not.toBeInTheDocument();
+		// Two tabs (Overview + Automation) → PremiumTabs renders (the >1-tab rule).
+		// Both tab affordances appear; Overview is the default active tab.
+		expect(screen.getByRole("button", { name: /overview/i })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /automation/i })).toBeInTheDocument();
 	});
 
 	it("refreshes BOTH overview feeds from the header refresh action", () => {

--- a/apps/web/src/features/console/components/__tests__/rule-document-view.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/rule-document-view.test.tsx
@@ -1,0 +1,72 @@
+import type { RuleDocument } from "@arr/shared";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { RuleDocumentView } from "../rule-document-view";
+
+describe("<RuleDocumentView />", () => {
+	it("renders a single predicate root", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "age", params: { operator: "older_than", days: 30 } },
+		};
+		render(<RuleDocumentView document={doc} context="library-cleanup" incognito={false} />);
+		expect(screen.getByText("Age")).toBeInTheDocument();
+		expect(screen.getByText("older than · 30")).toBeInTheDocument();
+	});
+
+	it("renders an ALL group with its children", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "genre", params: { genres: ["Action"] } },
+					{ kind: "year_range", params: { from: 2020, to: 2024 } },
+				],
+			},
+		};
+		render(<RuleDocumentView document={doc} context="auto-tag" incognito={false} />);
+		expect(screen.getByText("All of")).toBeInTheDocument();
+		expect(screen.getByText("Genre")).toBeInTheDocument();
+		expect(screen.getByText("Year range")).toBeInTheDocument();
+	});
+
+	it("renders an ANY group label", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { any: [{ kind: "genre", params: { genres: ["Action"] } }] },
+		};
+		render(<RuleDocumentView document={doc} context="auto-tag" incognito={false} />);
+		expect(screen.getByText("Any of")).toBeInTheDocument();
+	});
+
+	it("annotates an empty group as 'matches every event' for notifications", () => {
+		const doc: RuleDocument = { version: 1, root: { all: [] } };
+		render(<RuleDocumentView document={doc} context="notifications" incognito={false} />);
+		expect(screen.getByText(/matches every event/i)).toBeInTheDocument();
+	});
+
+	it("annotates an empty group as 'never matches' for cleanup/auto-tag", () => {
+		const doc: RuleDocument = { version: 1, root: { all: [] } };
+		render(<RuleDocumentView document={doc} context="library-cleanup" incognito={false} />);
+		expect(screen.getByText(/never matches/i)).toBeInTheDocument();
+	});
+
+	it("badges an unavailable (retired) kind", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "tautulli_last_watched", params: {}, unavailableKind: true },
+		};
+		render(<RuleDocumentView document={doc} context="library-cleanup" incognito={false} />);
+		expect(screen.getByText("unavailable")).toBeInTheDocument();
+	});
+
+	it("masks string param values in incognito but keeps the operator", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "plex_label", params: { operator: "any_of", labels: ["Favorites"] } },
+		};
+		render(<RuleDocumentView document={doc} context="library-cleanup" incognito={true} />);
+		expect(screen.queryByText(/Favorites/)).not.toBeInTheDocument();
+		expect(screen.getByText(/•••/)).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * Operator Console — Automation tab (read-only cross-domain rule viewer).
+ *
+ * The read half of the Unified Automation Engine composer (charter §2.1 /
+ * §5.2): every domain's rules in one place, normalized to v1 and rendered with
+ * {@link RuleDocumentView}. Authoring lands in a later PR; this surface is
+ * deliberately read-only.
+ *
+ * Incognito: rule NAMES (the operator's own labels) stay visible so the view is
+ * usable; sensitive param VALUES are masked inside RuleDocumentView. Retired
+ * kinds badge as unavailable; an unparseable stored rule is shown honestly
+ * rather than hidden.
+ */
+
+import type { AutomationRuleSummary, RuleContextId } from "@arr/shared";
+import { AlertTriangle, Workflow } from "lucide-react";
+import { AsyncStateView, GlassmorphicCard } from "../../../components/layout";
+import { useIncognitoMode } from "../../../contexts/IncognitoContext";
+import { useAutomationRules } from "../../../hooks/api/useAutomation";
+import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
+import { RuleDocumentView } from "./rule-document-view";
+
+const CONTEXT_LABELS: Record<RuleContextId, string> = {
+	"library-cleanup": "Library Cleanup",
+	"auto-tag": "Auto-Tag",
+	notifications: "Notifications",
+	"queue-cleaner": "Queue Cleaner",
+	hunting: "Hunting",
+};
+
+// Display order — the three surfaces with user-authored documents first.
+const CONTEXT_ORDER: RuleContextId[] = [
+	"library-cleanup",
+	"auto-tag",
+	"notifications",
+	"queue-cleaner",
+	"hunting",
+];
+
+function EnabledBadge({ enabled }: { enabled: boolean }) {
+	const tone = enabled ? SEMANTIC_COLORS.success : SEMANTIC_COLORS.neutral;
+	return (
+		<span
+			className="shrink-0 rounded px-2 py-0.5 text-[11px] font-medium"
+			style={{ backgroundColor: tone.bg, color: tone.text, border: `1px solid ${tone.border}` }}
+		>
+			{enabled ? "Enabled" : "Disabled"}
+		</span>
+	);
+}
+
+function RuleCard({ rule, incognito }: { rule: AutomationRuleSummary; incognito: boolean }) {
+	return (
+		<GlassmorphicCard className="space-y-2 p-4">
+			<div className="flex items-start justify-between gap-2">
+				{/* Rule name = the operator's own label; shown even in incognito so the
+				    viewer stays usable. Sensitive values live in the params, masked below. */}
+				<span className="font-medium text-foreground">{rule.name}</span>
+				<EnabledBadge enabled={rule.enabled} />
+			</div>
+			{rule.unparseable || rule.document === null ? (
+				<p
+					className="flex items-center gap-1.5 text-sm"
+					style={{ color: SEMANTIC_COLORS.warning.text }}
+				>
+					<AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+					This rule could not be read from its stored definition — open its surface to repair it.
+				</p>
+			) : (
+				<RuleDocumentView document={rule.document} context={rule.context} incognito={incognito} />
+			)}
+		</GlassmorphicCard>
+	);
+}
+
+export function AutomationPanel() {
+	const { data, isLoading, isError, error, refetch } = useAutomationRules();
+	const [incognito] = useIncognitoMode();
+
+	const rules = data?.rules ?? [];
+	const groups = CONTEXT_ORDER.map((context) => ({
+		context,
+		rules: rules.filter((rule) => rule.context === context),
+	})).filter((group) => group.rules.length > 0);
+
+	return (
+		<AsyncStateView
+			isLoading={isLoading}
+			isError={isError}
+			error={error}
+			isEmpty={rules.length === 0}
+			onRetry={() => void refetch()}
+			errorTitle="Couldn't load automation rules"
+			emptyState={{
+				icon: Workflow,
+				title: "No automation rules yet",
+				description:
+					"Rules you create in Library Cleanup, Auto-Tag, and Notifications appear here, unified.",
+			}}
+		>
+			<div className="space-y-6">
+				{groups.map((group) => (
+					<section key={group.context} className="space-y-2">
+						<h3 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+							{CONTEXT_LABELS[group.context]}
+							<span className="rounded-full bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+								{group.rules.length}
+							</span>
+						</h3>
+						<div className="space-y-3">
+							{group.rules.map((rule) => (
+								<RuleCard key={`${rule.context}-${rule.id}`} rule={rule} incognito={incognito} />
+							))}
+						</div>
+					</section>
+				))}
+			</div>
+		</AsyncStateView>
+	);
+}

--- a/apps/web/src/features/console/components/console-client.tsx
+++ b/apps/web/src/features/console/components/console-client.tsx
@@ -11,10 +11,9 @@
  * Layout (ratified with the charter, refined 2026-06-10): PremiumTabs as
  * primary navigation; the Overview tab becomes a two-column split (domain
  * tiles left, attention feed right) once the tiles land. Console arc:
- *   PR 2 (this) — shell + live attention feed
- *   PR 3 — per-domain tiles (Overview becomes the split)
- *   PR 4 — Pulse rollup refinements / operator actions
- *   PR 6 — rule composer (registers the Automation tab)
+ *   shell + live attention feed (#535) · per-domain tiles (#537) ·
+ *   operator actions (#538) · composer read surface = the Automation tab
+ *   (this; authoring follows in later composer PRs).
  *
  * The attention feed is the SAME component the dashboard renders
  * (NeedsAttentionPanel) — charter §2.1 names the rollup as the console's
@@ -23,22 +22,26 @@
  * in one place instead of forking them.
  */
 
-import { Gauge, RefreshCw } from "lucide-react";
+import { Gauge, RefreshCw, Workflow } from "lucide-react";
 import { useState } from "react";
 import { PremiumPageHeader, type PremiumTab, PremiumTabs } from "../../../components/layout";
 import { Button } from "../../../components/ui";
 import { usePulseQuery } from "../../../hooks/api/usePulse";
 import { useSystemJobs } from "../../../hooks/api/useSystem";
 import { NeedsAttentionPanel } from "../../dashboard/components/needs-attention-panel";
+import { AutomationPanel } from "./automation-panel";
 import { DomainTileGrid } from "./domain-tile-grid";
 
-export type ConsoleTabId = "overview";
+export type ConsoleTabId = "overview" | "automation";
 
-// The Automation tab registers here when the rule composer lands.
-// PremiumTabs renders only when there is more than one tab: a lone tab is
-// chrome without a choice, and shipping a dead "Automation" stub before
-// the composer exists would violate the no-misleading-surfaces trust rule.
-const CONSOLE_TABS: PremiumTab[] = [{ id: "overview", label: "Overview", icon: Gauge }];
+// The Automation tab hosts the rule composer's read surface (PR-2: cross-domain
+// viewer). PremiumTabs renders only at >1 tab, so adding this is what surfaces
+// the tab bar — and the tab is real (it shows your normalized rules), not a
+// dead stub, satisfying the no-misleading-surfaces trust rule.
+const CONSOLE_TABS: PremiumTab[] = [
+	{ id: "overview", label: "Overview", icon: Gauge },
+	{ id: "automation", label: "Automation", icon: Workflow },
+];
 
 export const ConsoleClient = () => {
 	const [activeTab, setActiveTab] = useState<ConsoleTabId>("overview");
@@ -101,6 +104,8 @@ export const ConsoleClient = () => {
 						<NeedsAttentionPanel />
 					</div>
 				)}
+
+				{activeTab === "automation" && <AutomationPanel />}
 			</div>
 		</>
 	);

--- a/apps/web/src/features/console/components/rule-document-view.tsx
+++ b/apps/web/src/features/console/components/rule-document-view.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * Read-only renderer for a v1 {@link RuleDocument} (charter §5.1 read surface).
+ *
+ * Walks the document tree with the grammar helpers and renders each predicate
+ * as a humanized row. Depth is v1-limited to 1 (one group level), so the tree
+ * is a root predicate OR a single all/any group of predicates.
+ *
+ * Empty-group honesty: the three domains' live evaluators disagree on an empty
+ * group, so the annotation is context-aware — cleanup and auto-tag no-match an
+ * empty composite (guard / unknown "composite" kind), while notifications
+ * matches every event (vacuous-true is the real 2.x behavior).
+ */
+
+import type { RuleContextId, RuleDocument, RuleNode } from "@arr/shared";
+import { groupChildren, isRulePredicate } from "@arr/shared";
+import { AlertTriangle } from "lucide-react";
+import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
+import { describePredicate } from "../lib/describe-predicate";
+
+function PredicateRow({
+	node,
+	incognito,
+}: {
+	node: Extract<RuleNode, { kind: string }>;
+	incognito: boolean;
+}) {
+	const { label, summary } = describePredicate(node, incognito);
+	const unavailable = node.unavailableKind === true;
+
+	return (
+		<div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-border/30 bg-card/20 px-3 py-1.5 text-sm">
+			<span className="font-medium text-foreground">{label}</span>
+			{summary && <span className="text-muted-foreground">{summary}</span>}
+			{unavailable && (
+				<span
+					className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium"
+					style={{
+						backgroundColor: SEMANTIC_COLORS.warning.bg,
+						color: SEMANTIC_COLORS.warning.text,
+						border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
+					}}
+					title="This condition's kind is retired or unavailable — it no longer matches anything."
+				>
+					<AlertTriangle className="h-2.5 w-2.5" aria-hidden="true" />
+					unavailable
+				</span>
+			)}
+		</div>
+	);
+}
+
+function emptyGroupNote(context: RuleContextId): string {
+	// Notifications' empty condition list matches every event (vacuous-true is
+	// the live 2.x behavior). Cleanup and auto-tag both no-match an empty
+	// composite (cleanup via its pre-eval guard, auto-tag via the unknown
+	// "composite" kind). Other contexts don't author documents here.
+	return context === "notifications"
+		? "No conditions — matches every event."
+		: "No conditions — this rule never matches.";
+}
+
+export function RuleDocumentView({
+	document,
+	context,
+	incognito,
+}: {
+	document: RuleDocument;
+	context: RuleContextId;
+	incognito: boolean;
+}) {
+	const root = document.root;
+
+	if (isRulePredicate(root)) {
+		return <PredicateRow node={root} incognito={incognito} />;
+	}
+
+	const children = groupChildren(root);
+	if (children.length === 0) {
+		return <p className="text-sm italic text-muted-foreground">{emptyGroupNote(context)}</p>;
+	}
+
+	const joiner = "all" in root ? "All of" : "Any of";
+
+	return (
+		<div className="space-y-1.5">
+			<span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+				{joiner}
+			</span>
+			<div className="space-y-1">
+				{children.map((child, index) =>
+					isRulePredicate(child) ? (
+						// Stable enough: v1 depth-1 means children are a flat predicate
+						// list rendered in document order.
+						// biome-ignore lint/suspicious/noArrayIndexKey: predicates have no id; order is stable
+						<PredicateRow key={index} node={child} incognito={incognito} />
+					) : null,
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/features/console/lib/__tests__/describe-predicate.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/describe-predicate.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { describePredicate, humanizeKind } from "../describe-predicate";
+
+describe("humanizeKind", () => {
+	it("turns a snake_case kind into a readable label", () => {
+		expect(humanizeKind("plex_last_watched")).toBe("Plex last watched");
+		expect(humanizeKind("age")).toBe("Age");
+	});
+});
+
+describe("describePredicate — generic kinds", () => {
+	it("shows the operator first, then the values", () => {
+		const result = describePredicate(
+			{ kind: "age", params: { operator: "older_than", days: 30 } },
+			false,
+		);
+		expect(result.label).toBe("Age");
+		expect(result.summary).toBe("older than · 30");
+	});
+
+	it("joins array values when not incognito", () => {
+		const result = describePredicate(
+			{ kind: "genre", params: { genres: ["Action", "Drama"] } },
+			false,
+		);
+		expect(result.summary).toBe("Action, Drama");
+	});
+});
+
+describe("describePredicate — field_match (notifications)", () => {
+	it("uses the matched field as the label", () => {
+		const result = describePredicate(
+			{
+				kind: "field_match",
+				params: { field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+			},
+			false,
+		);
+		expect(result.label).toBe("eventType");
+		expect(result.summary).toBe("equals HUNT_COMPLETED");
+	});
+});
+
+describe("describePredicate — incognito masking", () => {
+	it("masks string values but keeps numbers and the operator", () => {
+		const result = describePredicate(
+			{ kind: "plex_label", params: { operator: "any_of", labels: ["Favorites"] } },
+			true,
+		);
+		// operator shown (structural), label array masked
+		expect(result.summary).toContain("any of");
+		expect(result.summary).toContain("•••");
+		expect(result.summary).not.toContain("Favorites");
+	});
+
+	it("keeps numeric thresholds visible in incognito (structure, not data)", () => {
+		const result = describePredicate(
+			{ kind: "age", params: { operator: "older_than", days: 30 } },
+			true,
+		);
+		expect(result.summary).toBe("older than · 30");
+	});
+
+	it("masks a free-text field_match value in incognito", () => {
+		const result = describePredicate(
+			{ kind: "field_match", params: { field: "username", operator: "equals", value: "alice" } },
+			true,
+		);
+		expect(result.summary).toContain("equals");
+		expect(result.summary).not.toContain("alice");
+		expect(result.summary).toContain("•••");
+	});
+});

--- a/apps/web/src/features/console/lib/describe-predicate.ts
+++ b/apps/web/src/features/console/lib/describe-predicate.ts
@@ -1,0 +1,87 @@
+/**
+ * Human-readable summaries of v1 rule predicates for the read-only composer
+ * viewer. Pure + incognito-aware.
+ *
+ * No per-kind label map is maintained (52+ kinds): `humanizeKind` derives a
+ * label from the kind id, which is stable and good enough for a read surface.
+ *
+ * Incognito discipline (CLAUDE.md rule 6): a predicate's param VALUES can carry
+ * sensitive free text — Plex labels, usernames (`*_watched_by`,
+ * `seerr_requested_by`), title/path patterns. On a screenshare those must not
+ * leak. So in incognito we mask string values (and string arrays) but keep the
+ * rule's STRUCTURE visible — numbers, booleans, and the `operator` are
+ * non-sensitive and shown verbatim. Conservative (may mask a benign genre), but
+ * always safe-direction.
+ */
+
+export const PREDICATE_FIELD_MATCH_KIND = "field_match";
+const MASK = "•••";
+
+/** "plex_last_watched" → "Plex last watched". */
+export function humanizeKind(kind: string): string {
+	const spaced = kind.replace(/_/g, " ").trim();
+	if (!spaced) return kind;
+	return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** Snake/enum token → readable: "older_than" → "older than". */
+function humanizeToken(token: string): string {
+	return token.replace(/_/g, " ");
+}
+
+function formatValue(value: unknown, incognito: boolean): string {
+	if (value === null || value === undefined) return "";
+	if (typeof value === "number") return String(value);
+	if (typeof value === "boolean") return value ? "yes" : "no";
+	if (Array.isArray(value)) {
+		return incognito
+			? MASK
+			: value
+					.map((v) => formatValue(v, false))
+					.filter(Boolean)
+					.join(", ");
+	}
+	if (typeof value === "string") {
+		// Free-text string value — shown verbatim (it's data: an exact event
+		// type, label, title, …), masked in incognito. Only the `operator` key
+		// is humanized, and it's handled separately.
+		return incognito ? MASK : value;
+	}
+	return incognito ? MASK : JSON.stringify(value);
+}
+
+export interface PredicateDescription {
+	/** Human label — the kind, or the matched field for `field_match`. */
+	label: string;
+	/** Operator + values summary (e.g. "older than · 30"). May be empty. */
+	summary: string;
+}
+
+export function describePredicate(
+	predicate: { kind: string; params: Record<string, unknown> },
+	incognito: boolean,
+): PredicateDescription {
+	const { kind, params } = predicate;
+
+	// Notifications: the predicate's subject is the matched event field.
+	if (kind === PREDICATE_FIELD_MATCH_KIND && typeof params.field === "string") {
+		const op = typeof params.operator === "string" ? humanizeToken(params.operator) : "";
+		const val = formatValue(params.value, incognito);
+		return {
+			label: params.field,
+			summary: [op, val].filter(Boolean).join(" "),
+		};
+	}
+
+	// Generic: operator first (structural, always shown), then the rest.
+	const operator = typeof params.operator === "string" ? humanizeToken(params.operator) : null;
+	const rest = Object.entries(params)
+		.filter(([key]) => key !== "operator")
+		.map(([, value]) => formatValue(value, incognito))
+		.filter((part) => part.length > 0);
+
+	return {
+		label: humanizeKind(kind),
+		summary: [operator, ...rest].filter(Boolean).join(" · "),
+	};
+}

--- a/apps/web/src/hooks/api/useAutomation.ts
+++ b/apps/web/src/hooks/api/useAutomation.ts
@@ -1,0 +1,14 @@
+import type { AutomationRulesResponse } from "@arr/shared";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAutomationRules } from "../../lib/api-client/automation";
+import { automationKeys } from "../../lib/query-keys";
+
+/**
+ * Every domain's automation rules, normalized to v1 (charter §5.1).
+ * Powers the Operator Console Automation tab's read-only viewer.
+ */
+export const useAutomationRules = () =>
+	useQuery<AutomationRulesResponse>({
+		queryKey: automationKeys.rules(),
+		queryFn: fetchAutomationRules,
+	});

--- a/apps/web/src/lib/api-client/automation.ts
+++ b/apps/web/src/lib/api-client/automation.ts
@@ -1,0 +1,10 @@
+import type { AutomationRulesResponse } from "@arr/shared";
+import { apiRequest } from "./base";
+
+/**
+ * Fetch every domain's automation rules, normalized to the v1 grammar
+ * (charter §5.1). Read surface for the Operator Console composer.
+ */
+export async function fetchAutomationRules(): Promise<AutomationRulesResponse> {
+	return apiRequest<AutomationRulesResponse>("/api/automation/rules");
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -533,6 +533,11 @@ export const pulseKeys = {
 	attention: () => ["pulse", "attentionOnly"] as const,
 };
 
+export const automationKeys = {
+	all: ["automation"] as const,
+	rules: () => ["automation", "rules"] as const,
+};
+
 export const quiKeys = {
 	all: ["qui"] as const,
 	// Per-series aggregate (episode counts + distinct torrents). Powers


### PR DESCRIPTION
## Summary

Composer PR-2 — debuts the Operator Console **Automation tab**, consuming PR-1's v1 read API (#553). One place to see every domain's automation rules, normalized to the v1 grammar.

- **Tab wiring:** `ConsoleTabId` gains `"automation"`; one `CONSOLE_TABS` entry surfaces the tab bar (the shell's >1-tab rule). The tab is **real** (shows your normalized rules), not the dead stub the no-misleading-surfaces rule forbids.
- **`RuleDocumentView`:** walks the v1 tree with the grammar helpers — a root predicate, or an `all`/`any` group of predicate rows. **Empty-group annotation is context-aware:** cleanup/auto-tag render "never matches", but notifications render "matches every event" — the three live evaluators genuinely disagree on `{all:[]}`, so the same shape gets three honest annotations.
- **`describePredicate`:** humanizes any kind (no 52-entry map) + a generic param summary. **Incognito masks free-text string values** (labels, usernames, titles, paths) while keeping structure visible — numbers, booleans, operators. `field_match` uses the matched field as the label.
- **`AutomationPanel`:** `AsyncStateView` (honest loading/error/empty states), grouped by domain; an unparseable row is surfaced with a repair hint, not hidden.

## Validation
- `turbo typecheck` clean; web suite green (**551**); lint **0 errors**; 19 new tests (helper masking, tree all/any/empty/unavailable, panel states).
- **Live-verified in the browser:** tab bar renders, rules group by domain (Library Cleanup `Age · older than · 45`; Notifications `All of: eventType equals HUNT_COMPLETED`); toggling incognito masks the value to `•••` while keeping the operator + numeric thresholds; 0 console errors. Seeded rules cleaned up via the app's own DELETE endpoints.

## Known PR-1 follow-up (rare edge)
Auto-tag **empty composites** map to `{all:[]}` in PR-1's aggregation (it reuses the cleanup mapper) vs the live auto-tag evaluator's `{kind:"composite"}` → no-match. Same user-visible outcome here (the "never matches" annotation), but the API document shape differs. Tracked for a small follow-up; empty composites are rare legacy rows (write-validation rejects new ones).

## Composer arc
PR-1 (#553) v1 read API ✓ · **PR-2 (this) Automation tab + viewer** · PR-3 single-context authoring · PR-4 cross-domain storage + dry-run + deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)