### PR TITLE
feat(tracearr): Statistics tab — stats + activity analytics (C2a)

### DIFF
--- a/apps/api/src/lib/tracearr/instance-helpers.ts
+++ b/apps/api/src/lib/tracearr/instance-helpers.ts
@@ -36,3 +36,27 @@ export async function listTracearrInstances(
 		orderBy: { createdAt: "asc" },
 	});
 }
+
+/**
+ * Resolve the single Tracearr instance a statistics query should target.
+ * Unlike the live-session aggregate (which fans out across instances),
+ * paginated analytics (history / activity / stats) don't merge cleanly, so
+ * these surfaces run against ONE hub instance: the caller-specified
+ * `instanceId` when given (ownership-checked), otherwise the user's first
+ * enabled Tracearr. Throws InstanceNotFoundError (→ 404) when none exists —
+ * the frontend gates the tab on configuration, so that's a defensive path.
+ */
+export async function resolveTracearrInstance(
+	app: FastifyInstance,
+	userId: string,
+	instanceId?: string,
+): Promise<ServiceInstance> {
+	if (instanceId) {
+		return requireTracearrInstance(app, userId, instanceId);
+	}
+	const [first] = await listTracearrInstances(app, userId);
+	if (!first) {
+		throw new InstanceNotFoundError("tracearr");
+	}
+	return first;
+}

--- a/apps/api/src/routes/__tests__/tracearr-analytics-routes.test.ts
+++ b/apps/api/src/routes/__tests__/tracearr-analytics-routes.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tracearr analytics routes (C2a): GET /tracearr/stats + /tracearr/activity.
+ *
+ * These back the Statistics "Tracearr" tab. Unlike the live-session aggregate,
+ * they target a SINGLE instance via resolveTracearrInstance (caller-specified
+ * or first enabled). Covers the stats bundle, the activity period passthrough,
+ * the 404 when no instance exists, and instanceId forwarding.
+ */
+
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockResolveTracearrInstance } = vi.hoisted(() => ({
+	mockResolveTracearrInstance: vi.fn(),
+}));
+
+vi.mock("../../lib/tracearr/instance-helpers.js", () => ({
+	resolveTracearrInstance: (...args: unknown[]) => mockResolveTracearrInstance(...args),
+	requireTracearrInstance: vi.fn(),
+	listTracearrInstances: vi.fn().mockResolvedValue([]),
+}));
+
+const { mockGetStats, mockGetStatsToday, mockGetActivity } = vi.hoisted(() => ({
+	mockGetStats: vi.fn(),
+	mockGetStatsToday: vi.fn(),
+	mockGetActivity: vi.fn(),
+}));
+
+vi.mock("../../lib/tracearr/client-factory.js", () => ({
+	createTracearrClient: vi.fn(() => ({
+		getStats: mockGetStats,
+		getStatsToday: mockGetStatsToday,
+		getActivity: mockGetActivity,
+	})),
+}));
+
+import Fastify, { type FastifyInstance } from "fastify";
+import { InstanceNotFoundError } from "../../lib/errors.js";
+import { registerTracearrRoutes } from "../tracearr.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "./test-helpers.js";
+
+function makeInstance(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "trr-1",
+		userId: "user-1",
+		service: "TRACEARR",
+		label: "Dev Tracearr",
+		baseUrl: "http://tracearr.test",
+		encryptedApiKey: "enc",
+		encryptionIv: "iv",
+		externalUrl: null,
+		isDefault: false,
+		enabled: true,
+		storageGroupId: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	};
+}
+
+let app: FastifyInstance;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	mockResolveTracearrInstance.mockResolvedValue(makeInstance());
+	mockGetStats.mockResolvedValue({
+		activeStreams: 1,
+		totalUsers: 5,
+		totalSessions: 200,
+		recentViolations: 2,
+		timestamp: "2026-07-02T00:00:00.000Z",
+	});
+	mockGetStatsToday.mockResolvedValue({
+		activeStreams: 1,
+		todayPlays: 12,
+		watchTimeHours: 8,
+		alertsLast24h: 0,
+		activeUsersToday: 3,
+	});
+	mockGetActivity.mockResolvedValue({
+		period: "month",
+		range: { start: "2026-06-01T00:00:00.000Z", end: "2026-07-01T00:00:00.000Z" },
+		plays: [],
+		concurrent: [],
+		byDayOfWeek: [],
+		byHourOfDay: [],
+		platforms: [],
+		quality: {
+			directPlay: 0,
+			directStream: 0,
+			transcode: 0,
+			total: 0,
+			directPlayPercent: 0,
+			directStreamPercent: 0,
+			transcodePercent: 0,
+		},
+	});
+
+	app = Fastify();
+	app.decorate("prisma", {} as never);
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+
+	await app.register(registerTracearrRoutes);
+	await app.ready();
+
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("GET /tracearr/stats", () => {
+	it("bundles the all-time + today counters with the source instance", async () => {
+		const res = await injectAuthenticated("GET", "/tracearr/stats");
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.instanceId).toBe("trr-1");
+		expect(body.instanceLabel).toBe("Dev Tracearr");
+		expect(body.stats.totalUsers).toBe(5);
+		expect(body.today.todayPlays).toBe(12);
+		expect(mockGetStats).toHaveBeenCalledTimes(1);
+		expect(mockGetStatsToday).toHaveBeenCalledTimes(1);
+	});
+
+	it("returns 404 when the user has no Tracearr instance", async () => {
+		mockResolveTracearrInstance.mockRejectedValue(new InstanceNotFoundError("tracearr"));
+		const res = await injectAuthenticated("GET", "/tracearr/stats");
+		expect(res.statusCode).toBe(404);
+		expect(mockGetStats).not.toHaveBeenCalled();
+	});
+
+	it("forwards a caller-specified instanceId to the resolver", async () => {
+		await injectAuthenticated("GET", "/tracearr/stats?instanceId=trr-2");
+		expect(mockResolveTracearrInstance).toHaveBeenCalledWith(expect.anything(), "user-1", "trr-2");
+	});
+});
+
+describe("GET /tracearr/activity", () => {
+	it("returns the time-series for the requested period", async () => {
+		const res = await injectAuthenticated("GET", "/tracearr/activity?period=week");
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.instanceId).toBe("trr-1");
+		expect(body.activity).toBeDefined();
+		expect(mockGetActivity).toHaveBeenCalledWith({ period: "week", timezone: undefined });
+	});
+
+	it("rejects an invalid period", async () => {
+		const res = await injectAuthenticated("GET", "/tracearr/activity?period=decade");
+		expect(res.statusCode).toBe(400);
+		expect(mockGetActivity).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/tracearr.ts
+++ b/apps/api/src/routes/tracearr.ts
@@ -1,4 +1,5 @@
 import type { FastifyPluginCallback } from "fastify";
+import { registerTracearrAnalyticsRoutes } from "./tracearr/analytics-routes.js";
 import { registerTracearrInstanceRoutes } from "./tracearr/instance-routes.js";
 import { registerTracearrSessionRoutes } from "./tracearr/session-routes.js";
 import { registerTracearrStreamsRoutes } from "./tracearr/streams-routes.js";
@@ -22,6 +23,7 @@ const tracearrRoute: FastifyPluginCallback = (app, _opts, done) => {
 	registerTracearrInstanceRoutes(app);
 	registerTracearrStreamsRoutes(app);
 	registerTracearrSessionRoutes(app);
+	registerTracearrAnalyticsRoutes(app);
 	done();
 };
 

--- a/apps/api/src/routes/tracearr/analytics-routes.ts
+++ b/apps/api/src/routes/tracearr/analytics-routes.ts
@@ -1,0 +1,56 @@
+import type { TracearrStatsBundle } from "@arr/shared";
+import type { FastifyInstance } from "fastify";
+import { z } from "zod";
+import { createTracearrClient } from "../../lib/tracearr/client-factory.js";
+import { resolveTracearrInstance } from "../../lib/tracearr/instance-helpers.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+const STATS_QUERY = z.object({
+	instanceId: z.string().min(1).optional(),
+});
+
+const ACTIVITY_QUERY = z.object({
+	instanceId: z.string().min(1).optional(),
+	period: z.enum(["week", "month", "year"]).optional(),
+	timezone: z.string().min(1).max(64).optional(),
+});
+
+/**
+ * Tracearr analytics routes for the Statistics "Tracearr" tab (charter C2).
+ *
+ * These surface Tracearr's deep, cross-server watch analytics — complementary
+ * to the SessionSnapshot-backed per-server Plex/Jellyfin tabs (which already
+ * work post-Tautulli). Unlike the live-session aggregate, analytics target a
+ * SINGLE Tracearr instance (paginated/time-series data doesn't merge across
+ * instances): the caller may pass `?instanceId=`, else the user's first
+ * enabled Tracearr is used (resolveTracearrInstance, ownership-checked).
+ */
+export function registerTracearrAnalyticsRoutes(app: FastifyInstance): void {
+	app.get("/tracearr/stats", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const { instanceId } = validateRequest(STATS_QUERY, request.query);
+		const instance = await resolveTracearrInstance(app, userId, instanceId);
+		const client = createTracearrClient(app, instance);
+
+		// Both counters come from the same instance; fetch concurrently.
+		const [stats, today] = await Promise.all([client.getStats(), client.getStatsToday()]);
+
+		const bundle: TracearrStatsBundle = {
+			instanceId: instance.id,
+			instanceLabel: instance.label,
+			stats,
+			today,
+		};
+		return reply.send(bundle);
+	});
+
+	app.get("/tracearr/activity", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const { instanceId, period, timezone } = validateRequest(ACTIVITY_QUERY, request.query);
+		const instance = await resolveTracearrInstance(app, userId, instanceId);
+		const client = createTracearrClient(app, instance);
+
+		const activity = await client.getActivity({ period, timezone });
+		return reply.send({ instanceId: instance.id, instanceLabel: instance.label, activity });
+	});
+}

--- a/apps/web/src/features/statistics/components/__tests__/tracearr-tab.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/tracearr-tab.test.tsx
@@ -1,0 +1,122 @@
+import type { TracearrActivityBundle, TracearrStatsBundle } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+
+const mockUseTracearrStats = vi.fn();
+const mockUseTracearrActivity = vi.fn();
+vi.mock("../../../../hooks/api/useTracearr", () => ({
+	useTracearrStats: () => mockUseTracearrStats(),
+	useTracearrActivity: (period: string) => mockUseTracearrActivity(period),
+}));
+
+import { TracearrTab } from "../tracearr-tab";
+
+function createWrapper() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={qc}>
+			<ColorThemeProvider>{children}</ColorThemeProvider>
+		</QueryClientProvider>
+	);
+}
+
+function statsBundle(): TracearrStatsBundle {
+	return {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		stats: {
+			activeStreams: 1,
+			totalUsers: 5,
+			totalSessions: 200,
+			recentViolations: 2,
+			timestamp: "2026-07-02T00:00:00.000Z",
+		},
+		today: {
+			activeStreams: 1,
+			todayPlays: 12,
+			// Deliberately fractional — the card must round this for display.
+			watchTimeHours: 8.3333333,
+			alertsLast24h: 0,
+			activeUsersToday: 3,
+		},
+	};
+}
+
+function activityBundle(): TracearrActivityBundle {
+	return {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		activity: {
+			period: "month",
+			range: { start: "2026-06-01T00:00:00.000Z", end: "2026-07-01T00:00:00.000Z" },
+			plays: [
+				{ date: "2026-06-01", count: 3 },
+				{ date: "2026-06-02", count: 7 },
+			],
+			concurrent: [],
+			byDayOfWeek: [{ day: 1, name: "Mon", count: 4 }],
+			byHourOfDay: [],
+			platforms: [{ platform: "Chrome", count: 9 }],
+			quality: {
+				directPlay: 6,
+				directStream: 2,
+				transcode: 4,
+				total: 12,
+				directPlayPercent: 50,
+				directStreamPercent: 17,
+				transcodePercent: 33,
+			},
+		},
+	};
+}
+
+beforeEach(() => {
+	mockUseTracearrStats.mockReset();
+	mockUseTracearrActivity.mockReset();
+	mockUseTracearrStats.mockReturnValue({ data: statsBundle() });
+	mockUseTracearrActivity.mockReturnValue({ data: activityBundle() });
+});
+
+describe("<TracearrTab />", () => {
+	it("renders the all-time + today summary cards", () => {
+		render(<TracearrTab />, { wrapper: createWrapper() });
+		const cards = screen.getByTestId("tracearr-stats-cards");
+		expect(cards).toHaveTextContent("12"); // plays today
+		expect(cards).toHaveTextContent("5"); // total users
+		expect(cards).toHaveTextContent("200"); // total sessions
+		expect(cards).toHaveTextContent(/Recent violations/i);
+		// watchTimeHours is fractional — it must render rounded, not as a long float.
+		expect(cards).toHaveTextContent("8.3");
+		expect(cards).not.toHaveTextContent("8.3333333");
+	});
+
+	it("renders the activity breakdowns (quality + platforms)", () => {
+		render(<TracearrTab />, { wrapper: createWrapper() });
+		const activity = screen.getByTestId("tracearr-activity");
+		expect(activity).toHaveTextContent(/Transcode/i);
+		expect(activity).toHaveTextContent("Chrome");
+		expect(activity).toHaveTextContent("Mon");
+	});
+
+	it("discloses the source instance", () => {
+		render(<TracearrTab />, { wrapper: createWrapper() });
+		expect(screen.getByText(/Source: Tracearr · Dev Tracearr/i)).toBeInTheDocument();
+	});
+
+	it("shows a loading skeleton while stats load (no cards yet)", () => {
+		mockUseTracearrStats.mockReturnValue({ isLoading: true });
+		mockUseTracearrActivity.mockReturnValue({ isLoading: true });
+		render(<TracearrTab />, { wrapper: createWrapper() });
+		expect(screen.queryByTestId("tracearr-stats-cards")).not.toBeInTheDocument();
+	});
+
+	it("lets the operator switch the activity period", () => {
+		render(<TracearrTab />, { wrapper: createWrapper() });
+		// Default period is month; switching to year should re-query.
+		fireEvent.click(screen.getByRole("button", { name: /^year$/i }));
+		expect(mockUseTracearrActivity).toHaveBeenCalledWith("year");
+	});
+});

--- a/apps/web/src/features/statistics/components/statistics-client.tsx
+++ b/apps/web/src/features/statistics/components/statistics-client.tsx
@@ -1,7 +1,16 @@
 "use client";
 
-import { Activity, BarChart3, BookOpen, Film, Globe, Music, RefreshCw, Tv } from "lucide-react";
-import { POLLING_STATS } from "../../../lib/polling-intervals";
+import {
+	Activity,
+	BarChart3,
+	BookOpen,
+	Film,
+	Globe,
+	Music,
+	RefreshCw,
+	TrendingUp,
+	Tv,
+} from "lucide-react";
 import { useMemo, useState } from "react";
 import { DataFreshness, PremiumSkeleton } from "../../../components/layout";
 import { Alert, AlertDescription } from "../../../components/ui";
@@ -9,6 +18,7 @@ import { Button } from "../../../components/ui/button";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { useRefreshState } from "../../../hooks/useRefreshState";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { POLLING_STATS } from "../../../lib/polling-intervals";
 import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
 import { useStatisticsData } from "../hooks/useStatisticsData";
@@ -18,6 +28,7 @@ import { OverviewTab } from "./overview-tab";
 import { PlexTab } from "./plex-tab";
 import { ProwlarrTab } from "./prowlarr-tab";
 import type { StatisticsTab } from "./statistics-tabs";
+import { TracearrTab } from "./tracearr-tab";
 
 export const StatisticsClient = () => {
 	const [activeTab, setActiveTab] = useState<StatisticsTab>("overview");
@@ -37,6 +48,10 @@ export const StatisticsClient = () => {
 				const svc = s.service.toLowerCase();
 				return (svc === "jellyfin" || svc === "emby") && s.enabled;
 			}),
+		[services],
+	);
+	const hasTracearr = useMemo(
+		() => services.some((s) => s.service.toLowerCase() === "tracearr" && s.enabled),
 		[services],
 	);
 
@@ -122,6 +137,16 @@ export const StatisticsClient = () => {
 						label: "Jellyfin",
 						icon: Activity,
 						gradient: SERVICE_GRADIENTS.jellyfin,
+					},
+				]
+			: []),
+		...(hasTracearr
+			? [
+					{
+						id: "tracearr" as const,
+						label: "Tracearr",
+						icon: TrendingUp,
+						gradient: SERVICE_GRADIENTS.tracearr,
 					},
 				]
 			: []),
@@ -353,6 +378,8 @@ export const StatisticsClient = () => {
 			{activeTab === "plex" && <PlexTab />}
 
 			{activeTab === "jellyfin" && <JellyfinTab />}
+
+			{activeTab === "tracearr" && hasTracearr && <TracearrTab />}
 		</>
 	);
 };

--- a/apps/web/src/features/statistics/components/statistics-tabs.tsx
+++ b/apps/web/src/features/statistics/components/statistics-tabs.tsx
@@ -6,4 +6,5 @@ export type StatisticsTab =
 	| "lidarr"
 	| "readarr"
 	| "plex"
-	| "jellyfin";
+	| "jellyfin"
+	| "tracearr";

--- a/apps/web/src/features/statistics/components/tracearr-tab.tsx
+++ b/apps/web/src/features/statistics/components/tracearr-tab.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+/**
+ * Statistics — Tracearr tab (charter C2).
+ *
+ * Deep, cross-server watch analytics from Tracearr, complementary to the
+ * SessionSnapshot-backed per-server Plex/Jellyfin tabs (which already cover
+ * post-Tautulli analytics). This tab surfaces what SessionSnapshot can't:
+ * unified play/quality/platform time-series across every media server, plus
+ * all-time rollups. (History + users + violations panels land in C2b.)
+ *
+ * No incognito surface here: the stats + activity data are counts, dates,
+ * and platform names — no media titles or usernames. Those arrive with the
+ * history/users panels (C2b), which will mask.
+ */
+
+import { AudioLines, Clock, Play, ShieldAlert, TrendingUp, Users } from "lucide-react";
+import { useState } from "react";
+import { AsyncStateView } from "../../../components/layout";
+import { useTracearrActivity, useTracearrStats } from "../../../hooks/api/useTracearr";
+import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
+import { MiniStatCard, Sparkline } from "./chart-primitives";
+
+const PERIODS = ["week", "month", "year"] as const;
+type Period = (typeof PERIODS)[number];
+
+const ACCENT = SERVICE_GRADIENTS.tracearr;
+
+function Card({
+	title,
+	children,
+	subtitle,
+}: {
+	title: string;
+	subtitle?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+			<div className="mb-3">
+				<h3 className="text-sm font-medium text-foreground">{title}</h3>
+				{subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+/** Labeled horizontal bars for a breakdown (platforms, day-of-week, …). */
+function BarList({
+	items,
+	emptyLabel,
+}: {
+	items: Array<{ label: string; value: number }>;
+	emptyLabel: string;
+}) {
+	const max = Math.max(...items.map((i) => i.value), 1);
+	if (items.length === 0 || items.every((i) => i.value === 0)) {
+		return <p className="text-xs text-muted-foreground">{emptyLabel}</p>;
+	}
+	return (
+		<ul className="space-y-2">
+			{items.map((item) => (
+				<li key={item.label} className="flex items-center gap-3">
+					<span className="w-24 shrink-0 truncate text-xs text-muted-foreground" title={item.label}>
+						{item.label}
+					</span>
+					<div className="h-2 flex-1 overflow-hidden rounded-full bg-muted/20">
+						<div
+							className="h-full rounded-full"
+							style={{
+								width: `${(item.value / max) * 100}%`,
+								background: `linear-gradient(90deg, ${ACCENT.from}, ${ACCENT.to})`,
+							}}
+						/>
+					</div>
+					<span className="w-10 shrink-0 text-right text-xs tabular-nums text-foreground">
+						{item.value}
+					</span>
+				</li>
+			))}
+		</ul>
+	);
+}
+
+export const TracearrTab = () => {
+	const [period, setPeriod] = useState<Period>("month");
+	const statsQuery = useTracearrStats();
+	const activityQuery = useTracearrActivity(period);
+
+	const stats = statsQuery.data;
+	const activity = activityQuery.data?.activity;
+
+	return (
+		<div className="flex flex-col gap-6">
+			{/* Summary cards — all-time + today's rollups. */}
+			<AsyncStateView
+				isLoading={statsQuery.isLoading}
+				isError={statsQuery.isError}
+				error={statsQuery.error}
+				onRetry={() => void statsQuery.refetch()}
+				errorTitle="Couldn't load Tracearr stats"
+				loadingFallback={<div className="h-24 animate-pulse rounded-xl bg-muted/10" />}
+				emptyState={{ icon: TrendingUp, title: "No stats", description: "" }}
+			>
+				{stats && (
+					<div
+						className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6"
+						data-testid="tracearr-stats-cards"
+					>
+						<MiniStatCard
+							icon={Play}
+							label="Plays today"
+							value={stats.today.todayPlays}
+							color={ACCENT.from}
+						/>
+						<MiniStatCard
+							icon={Clock}
+							label="Watch hours today"
+							// watchTimeHours is the one non-integer stat — round for display so
+							// a value like 0.8333h doesn't render as a 16-digit float.
+							value={stats.today.watchTimeHours.toFixed(1)}
+							color={ACCENT.from}
+						/>
+						<MiniStatCard
+							icon={Users}
+							label="Active users today"
+							value={stats.today.activeUsersToday}
+							color={ACCENT.from}
+						/>
+						<MiniStatCard
+							icon={Users}
+							label="Total users"
+							value={stats.stats.totalUsers}
+							color={ACCENT.to}
+						/>
+						<MiniStatCard
+							icon={AudioLines}
+							label="Total sessions"
+							value={stats.stats.totalSessions}
+							color={ACCENT.to}
+						/>
+						<MiniStatCard
+							icon={ShieldAlert}
+							label="Recent violations"
+							value={stats.stats.recentViolations}
+							color={ACCENT.to}
+						/>
+					</div>
+				)}
+			</AsyncStateView>
+
+			{/* Period selector for the activity series. */}
+			<div className="flex items-center gap-2">
+				<span className="text-xs text-muted-foreground">Period:</span>
+				{PERIODS.map((p) => (
+					<button
+						key={p}
+						type="button"
+						onClick={() => setPeriod(p)}
+						className={`rounded-md border px-2.5 py-1 text-xs capitalize transition-colors ${
+							period === p
+								? "border-border bg-card text-foreground"
+								: "border-border/50 text-muted-foreground hover:text-foreground"
+						}`}
+					>
+						{p}
+					</button>
+				))}
+			</div>
+
+			<AsyncStateView
+				isLoading={activityQuery.isLoading}
+				isError={activityQuery.isError}
+				error={activityQuery.error}
+				onRetry={() => void activityQuery.refetch()}
+				errorTitle="Couldn't load Tracearr activity"
+				loadingFallback={<div className="h-64 animate-pulse rounded-xl bg-muted/10" />}
+				emptyState={{ icon: TrendingUp, title: "No activity", description: "" }}
+			>
+				{activity && (
+					<div className="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="tracearr-activity">
+						<Card title="Plays over time" subtitle={`Per day, this ${period}`}>
+							{activity.plays.length >= 2 ? (
+								<Sparkline
+									data={activity.plays.map((p) => p.count)}
+									width={320}
+									height={72}
+									color={ACCENT.from}
+									fillColor={ACCENT.from}
+								/>
+							) : (
+								<p className="text-xs text-muted-foreground">Not enough data yet.</p>
+							)}
+						</Card>
+
+						<Card title="Playback quality" subtitle="Direct vs. transcode">
+							<BarList
+								emptyLabel="No playback recorded yet."
+								items={[
+									{ label: "Direct play", value: activity.quality.directPlay },
+									{ label: "Direct stream", value: activity.quality.directStream },
+									{ label: "Transcode", value: activity.quality.transcode },
+								]}
+							/>
+						</Card>
+
+						<Card title="By day of week">
+							<BarList
+								emptyLabel="No plays recorded yet."
+								items={activity.byDayOfWeek.map((d) => ({ label: d.name, value: d.count }))}
+							/>
+						</Card>
+
+						<Card title="Top platforms">
+							<BarList
+								emptyLabel="No platforms recorded yet."
+								items={activity.platforms
+									.slice(0, 8)
+									.map((p) => ({ label: p.platform, value: p.count }))}
+							/>
+						</Card>
+					</div>
+				)}
+			</AsyncStateView>
+
+			{stats && (
+				<p className="text-xs text-muted-foreground">Source: Tracearr · {stats.instanceLabel}</p>
+			)}
+		</div>
+	);
+};

--- a/apps/web/src/hooks/api/useTracearr.ts
+++ b/apps/web/src/hooks/api/useTracearr.ts
@@ -1,13 +1,25 @@
 "use client";
 
-import type { TracearrLiveSessionsResponse, TracearrTerminateResponse } from "@arr/shared";
+import type {
+	TracearrActivityBundle,
+	TracearrLiveSessionsResponse,
+	TracearrStatsBundle,
+	TracearrTerminateResponse,
+} from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { fetchTracearrLiveSessions, terminateTracearrSession } from "../../lib/api-client/tracearr";
+import {
+	fetchTracearrActivity,
+	fetchTracearrLiveSessions,
+	fetchTracearrStats,
+	terminateTracearrSession,
+} from "../../lib/api-client/tracearr";
 import { getErrorMessage } from "../../lib/error-utils";
 import { anonymizeHealthMessage, useIncognitoMode } from "../../lib/incognito";
-import { POLLING_REALTIME } from "../../lib/polling-intervals";
+import { POLLING_REALTIME, POLLING_STATS } from "../../lib/polling-intervals";
 import { tracearrKeys } from "../../lib/query-keys";
+
+type ActivityPeriod = "week" | "month" | "year";
 
 interface TracearrLiveSessionsOptions {
 	/**
@@ -60,3 +72,33 @@ export const useTerminateSession = () => {
 		},
 	});
 };
+
+interface TracearrAnalyticsOptions {
+	/** Gate on Tracearr being configured (resolved from the services query). */
+	enabled?: boolean;
+}
+
+/**
+ * All-time + today's rollup counters for the Statistics "Tracearr" tab. This
+ * is historical analytics, not live data, so it polls at the slow "stats"
+ * cadence (2 min) rather than the live-session realtime rate.
+ */
+export const useTracearrStats = (options: TracearrAnalyticsOptions = {}) =>
+	useQuery<TracearrStatsBundle>({
+		queryKey: tracearrKeys.stats(),
+		queryFn: fetchTracearrStats,
+		enabled: options.enabled ?? true,
+		staleTime: POLLING_STATS,
+	});
+
+/** Aggregated play/quality/platform time-series for the given period. */
+export const useTracearrActivity = (
+	period: ActivityPeriod,
+	options: TracearrAnalyticsOptions = {},
+) =>
+	useQuery<TracearrActivityBundle>({
+		queryKey: tracearrKeys.activity(period),
+		queryFn: () => fetchTracearrActivity(period),
+		enabled: options.enabled ?? true,
+		staleTime: POLLING_STATS,
+	});

--- a/apps/web/src/lib/api-client/tracearr.ts
+++ b/apps/web/src/lib/api-client/tracearr.ts
@@ -5,8 +5,15 @@
  * All requests are proxied through Next.js rewrites → Fastify backend.
  */
 
-import type { TracearrLiveSessionsResponse, TracearrTerminateResponse } from "@arr/shared";
+import type {
+	TracearrActivityBundle,
+	TracearrLiveSessionsResponse,
+	TracearrStatsBundle,
+	TracearrTerminateResponse,
+} from "@arr/shared";
 import { apiRequest } from "./base";
+
+type ActivityPeriod = "week" | "month" | "year";
 
 /**
  * Aggregate live-session view for the Console "Live Sessions" card. Sums the
@@ -32,4 +39,19 @@ export async function terminateTracearrSession(args: {
 		`/api/tracearr/instances/${encodeURIComponent(instanceId)}/streams/${encodeURIComponent(streamId)}/terminate`,
 		{ method: "POST", json: reason ? { reason } : {} },
 	);
+}
+
+/**
+ * All-time + today's rollup counters from the user's Tracearr hub instance
+ * (charter C2 Statistics tab).
+ */
+export async function fetchTracearrStats(): Promise<TracearrStatsBundle> {
+	return apiRequest("/api/tracearr/stats");
+}
+
+/** Aggregated play/quality/platform time-series for the given period. */
+export async function fetchTracearrActivity(
+	period: ActivityPeriod,
+): Promise<TracearrActivityBundle> {
+	return apiRequest(`/api/tracearr/activity?period=${encodeURIComponent(period)}`);
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -349,6 +349,8 @@ export const plexKeys = {
 export const tracearrKeys = {
 	all: ["tracearr"] as const,
 	liveSessions: () => ["tracearr", "live-sessions"] as const,
+	stats: () => ["tracearr", "stats"] as const,
+	activity: (period: string) => ["tracearr", "activity", period] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/packages/shared/src/types/tracearr.ts
+++ b/packages/shared/src/types/tracearr.ts
@@ -90,6 +90,20 @@ export const tracearrStatsTodaySchema = z.object({
 });
 export type TracearrStatsToday = z.infer<typeof tracearrStatsTodaySchema>;
 
+/**
+ * `GET /api/tracearr/stats` — OUR API bundles the all-time rollup and today's
+ * counters in one response so the Statistics tab's summary cards need a
+ * single fetch. `instanceId`/`instanceLabel` disclose which Tracearr backs
+ * the figures (statistics target a single hub instance, not an aggregate).
+ */
+export const tracearrStatsBundleSchema = z.object({
+	instanceId: z.string(),
+	instanceLabel: z.string(),
+	stats: tracearrStatsSchema,
+	today: tracearrStatsTodaySchema,
+});
+export type TracearrStatsBundle = z.infer<typeof tracearrStatsBundleSchema>;
+
 // ── /activity ───────────────────────────────────────────────────────
 
 export const tracearrQualityBreakdownSchema = z.object({
@@ -125,6 +139,17 @@ export const tracearrActivitySchema = z.object({
 	quality: tracearrQualityBreakdownSchema,
 });
 export type TracearrActivity = z.infer<typeof tracearrActivitySchema>;
+
+/**
+ * `GET /api/tracearr/activity` — OUR API wraps the time-series with the
+ * source instance so the Statistics tab can disclose which Tracearr backs it.
+ */
+export const tracearrActivityBundleSchema = z.object({
+	instanceId: z.string(),
+	instanceLabel: z.string(),
+	activity: tracearrActivitySchema,
+});
+export type TracearrActivityBundle = z.infer<typeof tracearrActivityBundleSchema>;
 
 // ── Shared media-detail sub-objects (Stream + SessionHistory) ───────
 // Partial by nature; every field optional. Shared between live streams and


### PR DESCRIPTION
## Summary

First slice of charter **C2 ("Statistics on Tracearr")**. Adds a service-gated **Tracearr** tab to the Statistics page surfacing Tracearr's cross-server watch analytics.

### Charter reframe (confirmed with the maintainer)

C2's premise turned out to be **stale**: removing Tautulli (#517) did *not* leave Statistics broken — every panel was re-pointed to **`SessionSnapshot`** (arr-dashboard's own 5-min session capture) and works today. So this PR is **not a fix** — it's *additive* value: what SessionSnapshot can't give — **unified play/quality/platform time-series across all media servers at once**, plus all-time rollups. (History / users / violations panels follow in **C2b**.)

## What's in this PR

- **Backend**: `GET /api/tracearr/stats` (bundles `getStats` + `getStatsToday`) and `GET /api/tracearr/activity?period=` (`getActivity`). Both target a **single** Tracearr instance via a new `resolveTracearrInstance(app, userId, instanceId?)` — caller-specified (ownership-checked) or the user's first enabled; `InstanceNotFoundError`→404 if none. Deliberately **not** the cross-instance aggregate the live-session card uses: paginated/time-series data doesn't merge across instances, so statistics run against one hub instance (disclosed in the UI).
- **Shared**: strict `TracearrStatsBundle` + `TracearrActivityBundle` (OUR-API types).
- **Frontend**: api-client + `useTracearrStats`/`useTracearrActivity` (slow `POLLING_STATS` cadence, gated) + `tracearrKeys.{stats,activity}`; a `TracearrTab` (period selector, `MiniStatCard` summary, `Sparkline` plays-over-time, `BarList` quality / day-of-week / platform breakdowns), wired into `statistics-client` service-gated on `hasTracearr` and disclosing its source instance.

## Trust / scope

- **No incognito surface**: only counts, dates, platform names, and the instance label are rendered (no media titles/usernames — those arrive with the history/users panels in C2b).
- **Complementary to** (not a replacement for) the SessionSnapshot-backed Plex/Jellyfin tabs; the `Source: Tracearr · <instance>` line frames the overlap honestly.

## Validation

- `turbo typecheck` green (3 packages); full suite green (2185 API + 565 web; **10 new tests** — 5 route + 5 tab, incl. gating / period-switch / rounding); lint 0 errors.
- **Live-verified end-to-end** against a running Tracearr container: both endpoints return real (zero) data, the tab renders all 6 stat cards + 4 activity panels with honest empty states, and the tab is correctly **omitted** when Tracearr is removed (anti-vacuous gating), 0 console errors.
- Code-review agent: one material issue found + fixed — `watchTimeHours` is the one non-integer stat and would render as a 16-digit float with real data (the dev container's `0` hid it); now `.toFixed(1)` + pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)