### PR TITLE
feat(tracearr): Statistics history + users + violations panels (C2b)

### DIFF
--- a/apps/api/src/routes/__tests__/tracearr-analytics-routes.test.ts
+++ b/apps/api/src/routes/__tests__/tracearr-analytics-routes.test.ts
@@ -19,10 +19,20 @@ vi.mock("../../lib/tracearr/instance-helpers.js", () => ({
 	listTracearrInstances: vi.fn().mockResolvedValue([]),
 }));
 
-const { mockGetStats, mockGetStatsToday, mockGetActivity } = vi.hoisted(() => ({
+const {
+	mockGetStats,
+	mockGetStatsToday,
+	mockGetActivity,
+	mockGetHistory,
+	mockGetUsers,
+	mockGetViolations,
+} = vi.hoisted(() => ({
 	mockGetStats: vi.fn(),
 	mockGetStatsToday: vi.fn(),
 	mockGetActivity: vi.fn(),
+	mockGetHistory: vi.fn(),
+	mockGetUsers: vi.fn(),
+	mockGetViolations: vi.fn(),
 }));
 
 vi.mock("../../lib/tracearr/client-factory.js", () => ({
@@ -30,8 +40,13 @@ vi.mock("../../lib/tracearr/client-factory.js", () => ({
 		getStats: mockGetStats,
 		getStatsToday: mockGetStatsToday,
 		getActivity: mockGetActivity,
+		getHistory: mockGetHistory,
+		getUsers: mockGetUsers,
+		getViolations: mockGetViolations,
 	})),
 }));
+
+const emptyPage = { data: [], meta: { total: 0, page: 1, pageSize: 25 } };
 
 import Fastify, { type FastifyInstance } from "fastify";
 import { InstanceNotFoundError } from "../../lib/errors.js";
@@ -99,6 +114,9 @@ beforeEach(async () => {
 			transcodePercent: 0,
 		},
 	});
+	mockGetHistory.mockResolvedValue(emptyPage);
+	mockGetUsers.mockResolvedValue(emptyPage);
+	mockGetViolations.mockResolvedValue(emptyPage);
 
 	app = Fastify();
 	app.decorate("prisma", {} as never);
@@ -155,5 +173,54 @@ describe("GET /tracearr/activity", () => {
 		const res = await injectAuthenticated("GET", "/tracearr/activity?period=decade");
 		expect(res.statusCode).toBe(400);
 		expect(mockGetActivity).not.toHaveBeenCalled();
+	});
+});
+
+describe("GET /tracearr/history", () => {
+	it("wraps the paginated history with the source instance", async () => {
+		const res = await injectAuthenticated("GET", "/tracearr/history?page=2");
+		expect(res.statusCode).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.instanceId).toBe("trr-1");
+		expect(body.history.meta).toBeDefined();
+		expect(mockGetHistory).toHaveBeenCalledWith({
+			page: 2,
+			pageSize: undefined,
+			mediaType: undefined,
+		});
+	});
+
+	it("passes pageSize + mediaType filters through", async () => {
+		await injectAuthenticated("GET", "/tracearr/history?page=1&pageSize=25&mediaType=movie");
+		expect(mockGetHistory).toHaveBeenCalledWith({ page: 1, pageSize: 25, mediaType: "movie" });
+	});
+});
+
+describe("GET /tracearr/users", () => {
+	it("wraps the paginated users with the source instance", async () => {
+		const res = await injectAuthenticated("GET", "/tracearr/users");
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload).users.meta).toBeDefined();
+		expect(mockGetUsers).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("GET /tracearr/violations", () => {
+	it("forwards severity + acknowledged filters", async () => {
+		await injectAuthenticated("GET", "/tracearr/violations?severity=high&acknowledged=false");
+		// acknowledged=false must parse to boolean false, NOT true.
+		expect(mockGetViolations).toHaveBeenCalledWith({
+			page: undefined,
+			pageSize: undefined,
+			severity: "high",
+			acknowledged: false,
+		});
+	});
+
+	it("404s when no Tracearr instance exists", async () => {
+		mockResolveTracearrInstance.mockRejectedValue(new InstanceNotFoundError("tracearr"));
+		const res = await injectAuthenticated("GET", "/tracearr/violations");
+		expect(res.statusCode).toBe(404);
+		expect(mockGetViolations).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/tracearr/analytics-routes.ts
+++ b/apps/api/src/routes/tracearr/analytics-routes.ts
@@ -1,4 +1,9 @@
-import type { TracearrStatsBundle } from "@arr/shared";
+import type {
+	TracearrHistoryBundle,
+	TracearrStatsBundle,
+	TracearrUsersBundle,
+	TracearrViolationsBundle,
+} from "@arr/shared";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { createTracearrClient } from "../../lib/tracearr/client-factory.js";
@@ -13,6 +18,35 @@ const ACTIVITY_QUERY = z.object({
 	instanceId: z.string().min(1).optional(),
 	period: z.enum(["week", "month", "year"]).optional(),
 	timezone: z.string().min(1).max(64).optional(),
+});
+
+const page = z.coerce.number().int().min(1).optional();
+const pageSize = z.coerce.number().int().min(1).max(100).optional();
+
+const HISTORY_QUERY = z.object({
+	instanceId: z.string().min(1).optional(),
+	page,
+	pageSize,
+	mediaType: z.enum(["movie", "episode", "track", "live", "photo", "unknown"]).optional(),
+});
+
+const USERS_QUERY = z.object({
+	instanceId: z.string().min(1).optional(),
+	page,
+	pageSize,
+});
+
+const VIOLATIONS_QUERY = z.object({
+	instanceId: z.string().min(1).optional(),
+	page,
+	pageSize,
+	severity: z.enum(["low", "warning", "high"]).optional(),
+	// Query strings are text — z.coerce.boolean() would turn "false" into true
+	// (Boolean("false") === true), so parse the literal instead.
+	acknowledged: z
+		.enum(["true", "false"])
+		.transform((v) => v === "true")
+		.optional(),
 });
 
 /**
@@ -52,5 +86,53 @@ export function registerTracearrAnalyticsRoutes(app: FastifyInstance): void {
 
 		const activity = await client.getActivity({ period, timezone });
 		return reply.send({ instanceId: instance.id, instanceLabel: instance.label, activity });
+	});
+
+	app.get("/tracearr/history", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const { instanceId, page, pageSize, mediaType } = validateRequest(HISTORY_QUERY, request.query);
+		const instance = await resolveTracearrInstance(app, userId, instanceId);
+		const client = createTracearrClient(app, instance);
+
+		const history = await client.getHistory({ page, pageSize, mediaType });
+		const bundle: TracearrHistoryBundle = {
+			instanceId: instance.id,
+			instanceLabel: instance.label,
+			history,
+		};
+		return reply.send(bundle);
+	});
+
+	app.get("/tracearr/users", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const { instanceId, page, pageSize } = validateRequest(USERS_QUERY, request.query);
+		const instance = await resolveTracearrInstance(app, userId, instanceId);
+		const client = createTracearrClient(app, instance);
+
+		const users = await client.getUsers({ page, pageSize });
+		const bundle: TracearrUsersBundle = {
+			instanceId: instance.id,
+			instanceLabel: instance.label,
+			users,
+		};
+		return reply.send(bundle);
+	});
+
+	app.get("/tracearr/violations", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const { instanceId, page, pageSize, severity, acknowledged } = validateRequest(
+			VIOLATIONS_QUERY,
+			request.query,
+		);
+		const instance = await resolveTracearrInstance(app, userId, instanceId);
+		const client = createTracearrClient(app, instance);
+
+		const violations = await client.getViolations({ page, pageSize, severity, acknowledged });
+		const bundle: TracearrViolationsBundle = {
+			instanceId: instance.id,
+			instanceLabel: instance.label,
+			violations,
+		};
+		return reply.send(bundle);
 	});
 }

--- a/apps/web/src/features/statistics/components/__tests__/tracearr-panels.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/tracearr-panels.test.tsx
@@ -1,0 +1,188 @@
+import type {
+	TracearrHistoryBundle,
+	TracearrUsersBundle,
+	TracearrViolationsBundle,
+} from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
+
+const INCOGNITO_STORAGE_KEY = "arr-dashboard-incognito-mode";
+
+const mockHistory = vi.fn();
+const mockUsers = vi.fn();
+const mockViolations = vi.fn();
+vi.mock("../../../../hooks/api/useTracearr", () => ({
+	useTracearrHistory: () => mockHistory(),
+	useTracearrUsers: () => mockUsers(),
+	useTracearrViolations: () => mockViolations(),
+}));
+
+import {
+	TracearrHistoryPanel,
+	TracearrUsersPanel,
+	TracearrViolationsPanel,
+} from "../tracearr-panels";
+
+function createWrapper() {
+	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={qc}>
+			<ColorThemeProvider>
+				<IncognitoProvider>{children}</IncognitoProvider>
+			</ColorThemeProvider>
+		</QueryClientProvider>
+	);
+}
+
+function historyBundle(): TracearrHistoryBundle {
+	return {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		history: {
+			data: [
+				{
+					id: "h1",
+					instanceId: "trr-1",
+					mediaTitle: "Blade Runner 2049",
+					username: "alice",
+					serverName: "Johns Home Plex",
+					startedAt: "2026-07-01T00:00:00.000Z",
+					mediaType: "movie",
+				} as never,
+			],
+			meta: { total: 1, page: 1, pageSize: 25 },
+		},
+	};
+}
+
+function usersBundle(): TracearrUsersBundle {
+	return {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		users: {
+			data: [
+				{ id: "u1", username: "bob", role: "member", trustScore: 82, totalViolations: 1 } as never,
+			],
+			meta: { total: 1, page: 1, pageSize: 25 },
+		},
+	};
+}
+
+function violationsBundle(): TracearrViolationsBundle {
+	return {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		violations: {
+			data: [
+				{
+					id: "v1",
+					severity: "high",
+					acknowledged: false,
+					rule: { name: "Concurrent locations" },
+					user: { username: "carol" },
+					createdAt: "2026-07-01T00:00:00.000Z",
+				} as never,
+			],
+			meta: { total: 1, page: 1, pageSize: 25 },
+		},
+	};
+}
+
+beforeEach(() => {
+	mockHistory.mockReset();
+	mockUsers.mockReset();
+	mockViolations.mockReset();
+	mockHistory.mockReturnValue({ data: historyBundle(), isFetching: false });
+	mockUsers.mockReturnValue({ data: usersBundle(), isFetching: false });
+	mockViolations.mockReturnValue({ data: violationsBundle(), isFetching: false });
+	localStorage.removeItem(INCOGNITO_STORAGE_KEY);
+});
+
+describe("<TracearrHistoryPanel />", () => {
+	it("renders history rows with title, user, and server", () => {
+		render(<TracearrHistoryPanel />, { wrapper: createWrapper() });
+		const rows = screen.getByTestId("tracearr-history-rows");
+		expect(rows).toHaveTextContent("Blade Runner 2049");
+		expect(rows).toHaveTextContent("alice");
+		expect(rows).toHaveTextContent("Johns Home Plex");
+	});
+
+	it("masks title, user, and server in incognito", async () => {
+		localStorage.setItem(INCOGNITO_STORAGE_KEY, "true");
+		render(<TracearrHistoryPanel />, { wrapper: createWrapper() });
+		await waitFor(() => expect(screen.queryByText("Blade Runner 2049")).not.toBeInTheDocument());
+		expect(screen.queryByText("alice")).not.toBeInTheDocument();
+		expect(screen.queryByText(/Johns Home Plex/)).not.toBeInTheDocument();
+		expect(screen.getByTestId("tracearr-history-rows")).toBeInTheDocument();
+	});
+
+	it("derives the pager from the server's pageSize, not a client constant", () => {
+		// Server clamps to pageSize 10 with 30 total → 3 pages. A client that
+		// assumed pageSize 25 would compute 2 pages and hide the tail.
+		mockHistory.mockReturnValue({
+			data: {
+				instanceId: "trr-1",
+				instanceLabel: "X",
+				history: {
+					data: [historyBundle().history.data[0]],
+					meta: { total: 30, page: 1, pageSize: 10 },
+				},
+			},
+			isFetching: false,
+		});
+		render(<TracearrHistoryPanel />, { wrapper: createWrapper() });
+		expect(screen.getByText(/Page 1 of 3/)).toBeInTheDocument();
+	});
+
+	it("shows an honest empty state when there is no history", () => {
+		mockHistory.mockReturnValue({
+			data: {
+				instanceId: "trr-1",
+				instanceLabel: "X",
+				history: { data: [], meta: { total: 0, page: 1, pageSize: 25 } },
+			},
+			isFetching: false,
+		});
+		render(<TracearrHistoryPanel />, { wrapper: createWrapper() });
+		expect(screen.queryByTestId("tracearr-history-rows")).not.toBeInTheDocument();
+		expect(screen.getByText(/No watch history recorded yet/i)).toBeInTheDocument();
+	});
+});
+
+describe("<TracearrUsersPanel />", () => {
+	it("renders users with role, trust score, and violation count", () => {
+		render(<TracearrUsersPanel />, { wrapper: createWrapper() });
+		const rows = screen.getByTestId("tracearr-users-rows");
+		expect(rows).toHaveTextContent("bob");
+		expect(rows).toHaveTextContent("82"); // trust score
+		expect(rows).toHaveTextContent(/1 violation/i);
+	});
+
+	it("masks the username in incognito", async () => {
+		localStorage.setItem(INCOGNITO_STORAGE_KEY, "true");
+		render(<TracearrUsersPanel />, { wrapper: createWrapper() });
+		await waitFor(() => expect(screen.queryByText("bob")).not.toBeInTheDocument());
+		expect(screen.getByTestId("tracearr-users-rows")).toBeInTheDocument();
+	});
+});
+
+describe("<TracearrViolationsPanel />", () => {
+	it("renders violations with severity, rule, and user", () => {
+		render(<TracearrViolationsPanel />, { wrapper: createWrapper() });
+		const rows = screen.getByTestId("tracearr-violations-rows");
+		expect(rows).toHaveTextContent(/high/i);
+		expect(rows).toHaveTextContent("Concurrent locations");
+		expect(rows).toHaveTextContent("carol");
+	});
+
+	it("masks the violating user in incognito", async () => {
+		localStorage.setItem(INCOGNITO_STORAGE_KEY, "true");
+		render(<TracearrViolationsPanel />, { wrapper: createWrapper() });
+		await waitFor(() => expect(screen.queryByText("carol")).not.toBeInTheDocument());
+		expect(screen.getByTestId("tracearr-violations-rows")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/statistics/components/__tests__/tracearr-tab.test.tsx
+++ b/apps/web/src/features/statistics/components/__tests__/tracearr-tab.test.tsx
@@ -3,13 +3,27 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
 import { ColorThemeProvider } from "../../../../providers/color-theme-provider";
 
 const mockUseTracearrStats = vi.fn();
 const mockUseTracearrActivity = vi.fn();
+// The tab renders the C2b detail panels too; stub their hooks with empty
+// paginated pages so those panels render their empty states without erroring.
+const emptyPage = (key: "history" | "users" | "violations") => ({
+	data: {
+		instanceId: "trr-1",
+		instanceLabel: "Dev Tracearr",
+		[key]: { data: [], meta: { total: 0, page: 1, pageSize: 25 } },
+	},
+	isFetching: false,
+});
 vi.mock("../../../../hooks/api/useTracearr", () => ({
 	useTracearrStats: () => mockUseTracearrStats(),
 	useTracearrActivity: (period: string) => mockUseTracearrActivity(period),
+	useTracearrHistory: () => emptyPage("history"),
+	useTracearrUsers: () => emptyPage("users"),
+	useTracearrViolations: () => emptyPage("violations"),
 }));
 
 import { TracearrTab } from "../tracearr-tab";
@@ -18,7 +32,9 @@ function createWrapper() {
 	const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
 	return ({ children }: { children: ReactNode }) => (
 		<QueryClientProvider client={qc}>
-			<ColorThemeProvider>{children}</ColorThemeProvider>
+			<ColorThemeProvider>
+				<IncognitoProvider>{children}</IncognitoProvider>
+			</ColorThemeProvider>
 		</QueryClientProvider>
 	);
 }

--- a/apps/web/src/features/statistics/components/tracearr-panels.tsx
+++ b/apps/web/src/features/statistics/components/tracearr-panels.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+/**
+ * Statistics — Tracearr detail panels (charter C2b).
+ *
+ * Watch history, users (trust scores), and account-sharing violations from
+ * Tracearr — the deep, cross-server dimensions SessionSnapshot can't provide.
+ * Each is a paginated table over a single Tracearr hub instance.
+ *
+ * INCOGNITO: these panels render media titles, usernames, and server names —
+ * all masked via the shared Linux-ISO helpers when incognito is on.
+ */
+
+import type {
+	TracearrPaginationMeta,
+	TracearrSessionHistory,
+	TracearrUser,
+	TracearrViolation,
+} from "@arr/shared";
+import { ChevronLeft, ChevronRight, ShieldAlert, TrendingUp, Users } from "lucide-react";
+import { useState } from "react";
+import { AsyncStateView, formatRelativeTime } from "../../../components/layout";
+import {
+	useTracearrHistory,
+	useTracearrUsers,
+	useTracearrViolations,
+} from "../../../hooks/api/useTracearr";
+import {
+	getLinuxInstanceName,
+	getLinuxIsoName,
+	getLinuxUsername,
+	useIncognitoMode,
+} from "../../../lib/incognito";
+import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
+
+const PAGE_SIZE = 25;
+
+function PanelCard({
+	title,
+	subtitle,
+	children,
+}: {
+	title: string;
+	subtitle?: string;
+	children: React.ReactNode;
+}) {
+	return (
+		<div className="rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+			<div className="mb-3">
+				<h3 className="text-sm font-medium text-foreground">{title}</h3>
+				{subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+			</div>
+			{children}
+		</div>
+	);
+}
+
+/** Prev/next pager. `meta` is the server's { total, page, pageSize }. */
+function Pagination({
+	meta,
+	page,
+	onChange,
+	isFetching,
+}: {
+	meta?: TracearrPaginationMeta;
+	page: number;
+	onChange: (page: number) => void;
+	isFetching: boolean;
+}) {
+	// Trust the server's page size, not our requested constant — if Tracearr
+	// clamps to a smaller page, computing lastPage from PAGE_SIZE would disable
+	// Next early and silently hide rows (a signal-accuracy violation).
+	const size = meta?.pageSize || PAGE_SIZE;
+	const total = meta?.total ?? 0;
+	const lastPage = Math.max(1, Math.ceil(total / size));
+	if (total <= size) return null;
+	return (
+		<div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+			<span>
+				Page {page} of {lastPage} · {total} total
+			</span>
+			<div className="flex items-center gap-1">
+				<button
+					type="button"
+					onClick={() => onChange(page - 1)}
+					disabled={page <= 1 || isFetching}
+					className="flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 disabled:opacity-40"
+					aria-label="Previous page"
+				>
+					<ChevronLeft className="h-3.5 w-3.5" />
+				</button>
+				<button
+					type="button"
+					onClick={() => onChange(page + 1)}
+					disabled={page >= lastPage || isFetching}
+					className="flex items-center gap-1 rounded-md border border-border/50 px-2 py-1 disabled:opacity-40"
+					aria-label="Next page"
+				>
+					<ChevronRight className="h-3.5 w-3.5" />
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function EmptyRow({ label }: { label: string }) {
+	return <p className="text-xs text-muted-foreground">{label}</p>;
+}
+
+// ── Watch history ───────────────────────────────────────────────────
+
+export function TracearrHistoryPanel() {
+	const [incognito] = useIncognitoMode();
+	const [page, setPage] = useState(1);
+	const query = useTracearrHistory(page);
+	const rows = query.data?.history.data ?? [];
+
+	const mask = (s: TracearrSessionHistory) => {
+		const rawTitle = s.mediaTitle || s.showTitle || "Untitled";
+		const rawUser = s.username || s.user?.username || "Unknown user";
+		const rawServer = s.serverName || "";
+		return {
+			title: incognito ? getLinuxIsoName(rawTitle) : rawTitle,
+			user: incognito ? getLinuxUsername(rawUser) : rawUser,
+			server: rawServer ? (incognito ? getLinuxInstanceName(rawServer) : rawServer) : "",
+		};
+	};
+
+	return (
+		<PanelCard title="Watch history" subtitle="Complete history across all Tracearr servers">
+			<AsyncStateView
+				isLoading={query.isLoading}
+				isError={query.isError}
+				error={query.error}
+				onRetry={() => void query.refetch()}
+				errorTitle="Couldn't load history"
+				loadingFallback={<div className="h-40 animate-pulse rounded-lg bg-muted/10" />}
+				emptyState={{ icon: TrendingUp, title: "No history", description: "" }}
+			>
+				{rows.length === 0 ? (
+					<EmptyRow label="No watch history recorded yet." />
+				) : (
+					<ul className="space-y-2" data-testid="tracearr-history-rows">
+						{rows.map((row) => {
+							const m = mask(row);
+							const when = row.stoppedAt || row.startedAt;
+							const isTranscode = row.isTranscode || row.videoDecision === "transcode";
+							return (
+								<li
+									key={row.id}
+									className="flex items-center gap-3 rounded-lg border border-border/40 bg-card/40 p-2.5"
+								>
+									<div className="min-w-0 flex-1">
+										<p className="truncate text-sm text-foreground">{m.title}</p>
+										<p className="truncate text-xs text-muted-foreground">
+											{m.user}
+											{m.server ? ` · ${m.server}` : ""}
+										</p>
+									</div>
+									{isTranscode && (
+										<span className="shrink-0 text-xs text-muted-foreground">Transcode</span>
+									)}
+									{when && (
+										<span className="shrink-0 text-xs text-muted-foreground">
+											{formatRelativeTime(new Date(when).getTime())}
+										</span>
+									)}
+								</li>
+							);
+						})}
+					</ul>
+				)}
+				<Pagination
+					meta={query.data?.history.meta}
+					page={page}
+					onChange={setPage}
+					isFetching={query.isFetching}
+				/>
+			</AsyncStateView>
+		</PanelCard>
+	);
+}
+
+// ── Users + trust scores ────────────────────────────────────────────
+
+function trustColor(score?: number): string {
+	if (score === undefined) return SEMANTIC_COLORS.neutral.text;
+	if (score >= 70) return SEMANTIC_COLORS.success.text;
+	if (score >= 40) return SEMANTIC_COLORS.warning.text;
+	return SEMANTIC_COLORS.error.text;
+}
+
+export function TracearrUsersPanel() {
+	const [incognito] = useIncognitoMode();
+	const [page, setPage] = useState(1);
+	const query = useTracearrUsers(page);
+	const rows = query.data?.users.data ?? [];
+
+	const maskUser = (u: TracearrUser) => {
+		const raw = u.displayName || u.username || "Unknown user";
+		return incognito ? getLinuxUsername(raw) : raw;
+	};
+
+	return (
+		<PanelCard title="Users" subtitle="Trust scores + violation counts">
+			<AsyncStateView
+				isLoading={query.isLoading}
+				isError={query.isError}
+				error={query.error}
+				onRetry={() => void query.refetch()}
+				errorTitle="Couldn't load users"
+				loadingFallback={<div className="h-40 animate-pulse rounded-lg bg-muted/10" />}
+				emptyState={{ icon: Users, title: "No users", description: "" }}
+			>
+				{rows.length === 0 ? (
+					<EmptyRow label="No users tracked yet." />
+				) : (
+					<ul className="space-y-2" data-testid="tracearr-users-rows">
+						{rows.map((user) => (
+							<li
+								key={user.id}
+								className="flex items-center gap-3 rounded-lg border border-border/40 bg-card/40 p-2.5"
+							>
+								<div className="min-w-0 flex-1">
+									<p className="truncate text-sm text-foreground">{maskUser(user)}</p>
+									<p className="truncate text-xs text-muted-foreground">
+										{user.role ?? "member"}
+										{user.lastActivityAt
+											? ` · active ${formatRelativeTime(new Date(user.lastActivityAt).getTime())}`
+											: ""}
+									</p>
+								</div>
+								{user.totalViolations !== undefined && user.totalViolations > 0 && (
+									<span className="shrink-0 text-xs text-muted-foreground">
+										{user.totalViolations} violation{user.totalViolations === 1 ? "" : "s"}
+									</span>
+								)}
+								{user.trustScore !== undefined && (
+									<span
+										className="shrink-0 text-xs font-medium tabular-nums"
+										style={{ color: trustColor(user.trustScore) }}
+										title="Trust score"
+									>
+										{user.trustScore}
+									</span>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
+				<Pagination
+					meta={query.data?.users.meta}
+					page={page}
+					onChange={setPage}
+					isFetching={query.isFetching}
+				/>
+			</AsyncStateView>
+		</PanelCard>
+	);
+}
+
+// ── Violations (account-sharing) ────────────────────────────────────
+
+const SEVERITY_COLOR: Record<string, string> = {
+	low: SEMANTIC_COLORS.neutral.text,
+	warning: SEMANTIC_COLORS.warning.text,
+	high: SEMANTIC_COLORS.error.text,
+};
+
+export function TracearrViolationsPanel() {
+	const [incognito] = useIncognitoMode();
+	const [page, setPage] = useState(1);
+	const query = useTracearrViolations(page);
+	const rows = query.data?.violations.data ?? [];
+
+	const maskUser = (v: TracearrViolation) => {
+		const raw = v.user?.username || "Unknown user";
+		return incognito ? getLinuxUsername(raw) : raw;
+	};
+
+	return (
+		<PanelCard title="Account-sharing violations" subtitle="Flagged by Tracearr">
+			<AsyncStateView
+				isLoading={query.isLoading}
+				isError={query.isError}
+				error={query.error}
+				onRetry={() => void query.refetch()}
+				errorTitle="Couldn't load violations"
+				loadingFallback={<div className="h-40 animate-pulse rounded-lg bg-muted/10" />}
+				emptyState={{ icon: ShieldAlert, title: "No violations", description: "" }}
+			>
+				{rows.length === 0 ? (
+					<EmptyRow label="No violations detected — nothing to review." />
+				) : (
+					<ul className="space-y-2" data-testid="tracearr-violations-rows">
+						{rows.map((v) => (
+							<li
+								key={v.id}
+								className="flex items-center gap-3 rounded-lg border border-border/40 bg-card/40 p-2.5"
+							>
+								<span
+									className="shrink-0 text-xs font-medium capitalize"
+									style={{ color: SEVERITY_COLOR[v.severity ?? "warning"] }}
+								>
+									{v.severity ?? "warning"}
+								</span>
+								<div className="min-w-0 flex-1">
+									{/* rule.name is an operator-authored rule template (e.g. "Concurrent
+									    locations"), not user PII — left unmasked deliberately, since
+									    masking would garble legitimate generic names. The violating
+									    user (below) IS masked. */}
+									<p className="truncate text-sm text-foreground">
+										{v.rule?.name ?? "Account sharing"}
+									</p>
+									<p className="truncate text-xs text-muted-foreground">
+										{maskUser(v)}
+										{v.createdAt ? ` · ${formatRelativeTime(new Date(v.createdAt).getTime())}` : ""}
+									</p>
+								</div>
+								{v.acknowledged && (
+									<span className="shrink-0 text-xs text-muted-foreground">Acknowledged</span>
+								)}
+							</li>
+						))}
+					</ul>
+				)}
+				<Pagination
+					meta={query.data?.violations.meta}
+					page={page}
+					onChange={setPage}
+					isFetching={query.isFetching}
+				/>
+			</AsyncStateView>
+		</PanelCard>
+	);
+}

--- a/apps/web/src/features/statistics/components/tracearr-tab.tsx
+++ b/apps/web/src/features/statistics/components/tracearr-tab.tsx
@@ -20,6 +20,11 @@ import { AsyncStateView } from "../../../components/layout";
 import { useTracearrActivity, useTracearrStats } from "../../../hooks/api/useTracearr";
 import { SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 import { MiniStatCard, Sparkline } from "./chart-primitives";
+import {
+	TracearrHistoryPanel,
+	TracearrUsersPanel,
+	TracearrViolationsPanel,
+} from "./tracearr-panels";
 
 const PERIODS = ["week", "month", "year"] as const;
 type Period = (typeof PERIODS)[number];
@@ -223,6 +228,16 @@ export const TracearrTab = () => {
 					</div>
 				)}
 			</AsyncStateView>
+
+			{/* Detail panels (C2b): the deep dimensions SessionSnapshot can't give —
+			    complete watch history, per-user trust, account-sharing violations. */}
+			<div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+				<div className="lg:col-span-2">
+					<TracearrHistoryPanel />
+				</div>
+				<TracearrUsersPanel />
+				<TracearrViolationsPanel />
+			</div>
 
 			{stats && (
 				<p className="text-xs text-muted-foreground">Source: Tracearr · {stats.instanceLabel}</p>

--- a/apps/web/src/hooks/api/useTracearr.ts
+++ b/apps/web/src/hooks/api/useTracearr.ts
@@ -2,16 +2,22 @@
 
 import type {
 	TracearrActivityBundle,
+	TracearrHistoryBundle,
 	TracearrLiveSessionsResponse,
 	TracearrStatsBundle,
 	TracearrTerminateResponse,
+	TracearrUsersBundle,
+	TracearrViolationsBundle,
 } from "@arr/shared";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
 	fetchTracearrActivity,
+	fetchTracearrHistory,
 	fetchTracearrLiveSessions,
 	fetchTracearrStats,
+	fetchTracearrUsers,
+	fetchTracearrViolations,
 	terminateTracearrSession,
 } from "../../lib/api-client/tracearr";
 import { getErrorMessage } from "../../lib/error-utils";
@@ -101,4 +107,37 @@ export const useTracearrActivity = (
 		queryFn: () => fetchTracearrActivity(period),
 		enabled: options.enabled ?? true,
 		staleTime: POLLING_STATS,
+	});
+
+/**
+ * Paginated watch history for the Tracearr tab (C2b). `keepPreviousData`
+ * keeps the current page on screen while the next loads (no flicker/jump).
+ */
+export const useTracearrHistory = (page: number, options: TracearrAnalyticsOptions = {}) =>
+	useQuery<TracearrHistoryBundle>({
+		queryKey: tracearrKeys.history(page),
+		queryFn: () => fetchTracearrHistory(page),
+		enabled: options.enabled ?? true,
+		staleTime: POLLING_STATS,
+		placeholderData: keepPreviousData,
+	});
+
+/** Paginated Tracearr users (trust scores + violation counts) — C2b. */
+export const useTracearrUsers = (page: number, options: TracearrAnalyticsOptions = {}) =>
+	useQuery<TracearrUsersBundle>({
+		queryKey: tracearrKeys.users(page),
+		queryFn: () => fetchTracearrUsers(page),
+		enabled: options.enabled ?? true,
+		staleTime: POLLING_STATS,
+		placeholderData: keepPreviousData,
+	});
+
+/** Paginated account-sharing violations — C2b. */
+export const useTracearrViolations = (page: number, options: TracearrAnalyticsOptions = {}) =>
+	useQuery<TracearrViolationsBundle>({
+		queryKey: tracearrKeys.violations(page),
+		queryFn: () => fetchTracearrViolations(page),
+		enabled: options.enabled ?? true,
+		staleTime: POLLING_STATS,
+		placeholderData: keepPreviousData,
 	});

--- a/apps/web/src/lib/api-client/tracearr.ts
+++ b/apps/web/src/lib/api-client/tracearr.ts
@@ -7,9 +7,12 @@
 
 import type {
 	TracearrActivityBundle,
+	TracearrHistoryBundle,
 	TracearrLiveSessionsResponse,
 	TracearrStatsBundle,
 	TracearrTerminateResponse,
+	TracearrUsersBundle,
+	TracearrViolationsBundle,
 } from "@arr/shared";
 import { apiRequest } from "./base";
 
@@ -54,4 +57,19 @@ export async function fetchTracearrActivity(
 	period: ActivityPeriod,
 ): Promise<TracearrActivityBundle> {
 	return apiRequest(`/api/tracearr/activity?period=${encodeURIComponent(period)}`);
+}
+
+/** Paginated watch history (C2b). Fixed pageSize; `page` is 1-based. */
+export async function fetchTracearrHistory(page: number): Promise<TracearrHistoryBundle> {
+	return apiRequest(`/api/tracearr/history?page=${page}&pageSize=25`);
+}
+
+/** Paginated Tracearr users with trust scores + violation counts (C2b). */
+export async function fetchTracearrUsers(page: number): Promise<TracearrUsersBundle> {
+	return apiRequest(`/api/tracearr/users?page=${page}&pageSize=25`);
+}
+
+/** Paginated account-sharing violations (C2b). */
+export async function fetchTracearrViolations(page: number): Promise<TracearrViolationsBundle> {
+	return apiRequest(`/api/tracearr/violations?page=${page}&pageSize=25`);
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -351,6 +351,9 @@ export const tracearrKeys = {
 	liveSessions: () => ["tracearr", "live-sessions"] as const,
 	stats: () => ["tracearr", "stats"] as const,
 	activity: (period: string) => ["tracearr", "activity", period] as const,
+	history: (page: number) => ["tracearr", "history", page] as const,
+	users: (page: number) => ["tracearr", "users", page] as const,
+	violations: (page: number) => ["tracearr", "violations", page] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -13,8 +13,8 @@ progress · ⛔ blocked · ⬜ not started.
 |---|---|---|
 | 2.1 Operator Console — shell / feed / tiles / actions | ✅ | #534 #535 #537 #538 |
 | 2.1 — embedded rule composer | 🚧 | backend v1 substrate merged (#518–#521); UI + v1-serving API pending |
-| 2.1 — Tracearr live-session count + kill-session action | 🚧 | unblocked by 2.2 foundation; live-session tiles (Tracearr-2) + kill-session (Tracearr-3) pending |
-| 2.2 Tracearr integration | 🚧 | foundation shipped — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; instance addable via Settings → Services (live-verified against a running instance). Streams / terminate / C2 Statistics-on-Tracearr follow. |
+| 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
+| 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
 | 2.3 Setup rewrite (auto-discovery) | ⬜ | pulled from 3.1; lowest priority |
 
 ## Bucket A — breaking changes: ✅ complete
@@ -31,7 +31,7 @@ A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #
 | B6 useIncognitoMode | ✅ | #525 #526 + e2e gate #533 |
 
 ## Bucket C — arcs
-C1 qui→stable ✅ (#513 graduation) · C2 Statistics-on-Tracearr ⛔ (blocked) ·
+C1 qui→stable ✅ (#513 graduation) · C2 Statistics-on-Tracearr ✅ (stats/activity #558 + history/users/violations C2b — reframed as additive, since SessionSnapshot already covers post-Tautulli analytics) ·
 C3 auto-tagger sub-arc 4 ✅ (#529) · C4 pulse labels ✅ (#524).
 
 ## ADRs (§5): ✅ 0005–0008 (#509, amended #514/#515).
@@ -85,5 +85,9 @@ qui-home. The remaining polling surfaces are correctly excluded:
 
 ## Remaining work (in recommended order)
 1. **Operator Console composer** (2.1) — unblocked flagship; multi-PR, its own loop.
-2. **Tracearr (2.2) + C2 Statistics-on-Tracearr + 2.1 live-session/kill-session** — foundation shipped (service type + typed client + connection/health route). Remaining: Tracearr-2 (streams → console live-session tiles), Tracearr-3 (terminate → kill-session action), C2 (Statistics re-point onto /history + /stats).
-3. **Setup rewrite (2.3)** — lowest priority (pulled from 3.1).
+2. **Setup rewrite (2.3)** — lowest priority (pulled from 3.1).
+
+**Tracearr arc (2.2) COMPLETE** — foundation (#555), live-session card (#556),
+kill-session (#557), Statistics stats/activity (#558) + history/users/violations
+(C2b). C2 was reframed from a "rewrite" to *additive* analytics after ground
+truth showed SessionSnapshot already covers post-Tautulli Statistics.

--- a/packages/shared/src/types/tracearr.ts
+++ b/packages/shared/src/types/tracearr.ts
@@ -523,6 +523,32 @@ export const tracearrHistoryResponseSchema = z.object({
 });
 export type TracearrHistoryResponse = z.infer<typeof tracearrHistoryResponseSchema>;
 
+// ── OUR-API bundles for the Statistics tab (C2b) ────────────────────
+// Each wraps a paginated Tracearr response with the source instance, so the
+// tab can disclose which Tracearr hub backs the figures (statistics target a
+// single instance, not an aggregate).
+
+export const tracearrHistoryBundleSchema = z.object({
+	instanceId: z.string(),
+	instanceLabel: z.string(),
+	history: tracearrHistoryResponseSchema,
+});
+export type TracearrHistoryBundle = z.infer<typeof tracearrHistoryBundleSchema>;
+
+export const tracearrUsersBundleSchema = z.object({
+	instanceId: z.string(),
+	instanceLabel: z.string(),
+	users: tracearrUsersResponseSchema,
+});
+export type TracearrUsersBundle = z.infer<typeof tracearrUsersBundleSchema>;
+
+export const tracearrViolationsBundleSchema = z.object({
+	instanceId: z.string(),
+	instanceLabel: z.string(),
+	violations: tracearrViolationsResponseSchema,
+});
+export type TracearrViolationsBundle = z.infer<typeof tracearrViolationsBundleSchema>;
+
 // ── Query-param option bags (for typed client methods) ──────────────
 //
 // Each carries an index signature so it's assignable to the request


### PR DESCRIPTION
## Summary

Final slice of charter **C2** — completes the Tracearr Statistics surface (C2a #558 shipped stats + activity). Adds three paginated detail panels to the Tracearr tab: the deep, cross-server dimensions SessionSnapshot can't provide. **This closes the Tracearr integration arc (§2.2).**

## What's in this PR

- **Backend**: `GET /api/tracearr/{history,users,violations}` — paginated (page/pageSize), single-instance via `resolveTracearrInstance` (same ownership model as C2a). `history` takes an optional `mediaType` filter; `violations` take `severity` + `acknowledged` filters. Each wrapped in a bundle type disclosing the source instance.
- **Shared**: `TracearrHistoryBundle` / `TracearrUsersBundle` / `TracearrViolationsBundle`.
- **Frontend**: api-client (3 fns) + `useTracearr{History,Users,Violations}` hooks (`keepPreviousData` for smooth pagination) + `tracearrKeys.{history,users,violations}`; `tracearr-panels.tsx` with three panels (incognito-masked rows, `AsyncStateView` states, a shared `Pagination` pager) wired into the tab.

## Incognito

Media titles, usernames, and server names are all masked via the shared Linux-ISO helpers on every render path. `rule.name` is left unmasked **deliberately** — it's an operator-authored rule template ("Concurrent locations"), not user PII; masking would garble legitimate generic names. The violating user **is** masked.

## Query-parsing note

`acknowledged` uses `z.enum(["true","false"]).transform()` not `z.coerce.boolean()` — `Boolean("false") === true` would misfilter.

## Validation

- `turbo typecheck` green (3 packages); full suite green (2190 API + web; **13 new tests** — 5 route + 8 panel incl. incognito masking on all three panels + the pagination fix below); lint 0 errors.
- **Live-verified end-to-end** against a running Tracearr container: all 3 endpoints return correct bundle shapes; all 3 panels render honest empty states; 0 console errors.
- Code-review agent: one material trust issue found + fixed — the pager derived `lastPage` from a hardcoded `PAGE_SIZE` instead of the server's `meta.pageSize`, which would silently hide rows if Tracearr clamps to a smaller page (a case the empty dev dataset couldn't surface). Now trusts `meta.pageSize` + pinned by a test.

Also marks **C2 complete** in `docs/3.0-completeness-status.md` (reframed as *additive* analytics, since SessionSnapshot already covers post-Tautulli Statistics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)