### PR TITLE
feat(composer): v1→v0 rule serializer — the down-convert write foundation (PR-3a)

### DIFF
--- a/apps/api/src/lib/rules/__tests__/v1-serializer-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/v1-serializer-parity.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Round-trip parity between the v0→v1 mappers (read side) and the v1→v0
+ * serializers (write side). This is the correctness contract for the
+ * composer's down-convert-on-save: an authored document must serialize to a
+ * v0 payload that maps back to the identical document, and a stored v0 rule
+ * must map to a document that serializes back to the identical payload.
+ *
+ * The serializer emits the API PAYLOAD shape (params/conditions as objects);
+ * the mapper consumes the STORAGE shape (stringified). The tiny `toRow`/
+ * `toConditionsJson` helpers bridge the two exactly as the routes do.
+ */
+
+import {
+	type CriteriaV0Payload,
+	type RuleDocument,
+	serializeCriteriaDocumentToV0,
+	serializeNotificationsDocumentToV0,
+} from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import {
+	type CriteriaV0Row,
+	mapCriteriaV0ToDocument,
+	mapNotificationsV0ToDocument,
+} from "../v0-mappers.js";
+
+/** Bridge a criteria payload (objects) to the storage row (strings). */
+function toRow(p: CriteriaV0Payload): CriteriaV0Row {
+	return {
+		ruleType: p.ruleType,
+		parameters: JSON.stringify(p.parameters),
+		operator: p.operator,
+		conditions: p.conditions ? JSON.stringify(p.conditions) : null,
+	};
+}
+
+describe("criteria round-trip: v1 → serialize → map → v1", () => {
+	const documents: Array<[string, RuleDocument]> = [
+		[
+			"single predicate",
+			{
+				version: 1,
+				root: { kind: "age", params: { field: "arrAddedAt", operator: "older_than", days: 30 } },
+			},
+		],
+		[
+			"AND composite",
+			{
+				version: 1,
+				root: {
+					all: [
+						{ kind: "age", params: { days: 30 } },
+						{ kind: "no_file", params: {} },
+					],
+				},
+			},
+		],
+		[
+			"OR composite",
+			{
+				version: 1,
+				root: {
+					any: [
+						{ kind: "size", params: { gb: 10 } },
+						{ kind: "rating", params: { max: 5 } },
+					],
+				},
+			},
+		],
+	];
+
+	it.each(documents)("%s survives the round trip unchanged", (_label, doc) => {
+		const payload = serializeCriteriaDocumentToV0(doc);
+		const remapped = mapCriteriaV0ToDocument(toRow(payload));
+		expect(remapped).toEqual(doc);
+	});
+});
+
+describe("criteria round-trip: v0 → map → serialize → v0", () => {
+	const rows: Array<[string, CriteriaV0Row]> = [
+		[
+			"single",
+			{
+				ruleType: "age",
+				parameters: JSON.stringify({ days: 30 }),
+				operator: null,
+				conditions: null,
+			},
+		],
+		[
+			"composite",
+			{
+				ruleType: "composite",
+				parameters: "{}",
+				operator: "AND",
+				conditions: JSON.stringify([
+					{ ruleType: "age", parameters: { days: 30 } },
+					{ ruleType: "no_file", parameters: {} },
+				]),
+			},
+		],
+	];
+
+	it.each(rows)("%s survives the round trip unchanged", (_label, row) => {
+		const doc = mapCriteriaV0ToDocument(row);
+		const payload = serializeCriteriaDocumentToV0(doc);
+		// Compare against the row's canonical object form.
+		expect(payload).toEqual({
+			ruleType: row.ruleType,
+			parameters: JSON.parse(row.parameters),
+			operator: row.operator,
+			conditions: row.conditions ? JSON.parse(row.conditions) : null,
+		});
+	});
+});
+
+describe("notifications round-trip", () => {
+	it("v1 → serialize → map → v1 is unchanged", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{
+						kind: "field_match",
+						params: { field: "eventType", operator: "equals", value: "GRAB" },
+					},
+					{ kind: "field_match", params: { field: "title", operator: "contains", value: "4K" } },
+				],
+			},
+		};
+		const conditions = serializeNotificationsDocumentToV0(doc);
+		expect(mapNotificationsV0ToDocument(conditions)).toEqual(doc);
+	});
+
+	it("empty conditions (matches every event) round-trips", () => {
+		const doc: RuleDocument = { version: 1, root: { all: [] } };
+		expect(mapNotificationsV0ToDocument(serializeNotificationsDocumentToV0(doc))).toEqual(doc);
+	});
+});

--- a/packages/shared/src/rules/__tests__/v1-serializer.test.ts
+++ b/packages/shared/src/rules/__tests__/v1-serializer.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import type { RuleDocument } from "../grammar.js";
+import {
+	serializeCriteriaDocumentToV0,
+	serializeNotificationsDocumentToV0,
+	V1SerializerError,
+} from "../v1-serializer.js";
+
+describe("serializeCriteriaDocumentToV0", () => {
+	it("down-converts a single-predicate document to a single rule", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "age", params: { field: "arrAddedAt", operator: "older_than", days: 30 } },
+		};
+		expect(serializeCriteriaDocumentToV0(doc)).toEqual({
+			ruleType: "age",
+			parameters: { field: "arrAddedAt", operator: "older_than", days: 30 },
+			operator: null,
+			conditions: null,
+		});
+	});
+
+	it("down-converts an all-group to an AND composite", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "age", params: { days: 30 } },
+					{ kind: "no_file", params: {} },
+				],
+			},
+		};
+		expect(serializeCriteriaDocumentToV0(doc)).toEqual({
+			ruleType: "composite",
+			parameters: {},
+			operator: "AND",
+			conditions: [
+				{ ruleType: "age", parameters: { days: 30 } },
+				{ ruleType: "no_file", parameters: {} },
+			],
+		});
+	});
+
+	it("down-converts an any-group to an OR composite", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { any: [{ kind: "size", params: { gb: 10 } }] },
+		};
+		expect(serializeCriteriaDocumentToV0(doc).operator).toBe("OR");
+	});
+
+	it("rejects an empty composite (no conditions)", () => {
+		const doc: RuleDocument = { version: 1, root: { all: [] } };
+		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(V1SerializerError);
+	});
+
+	it("rejects a nested group (v1 is depth-1)", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { all: [{ any: [{ kind: "age", params: {} }] }] },
+		};
+		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(/depth-1/);
+	});
+});
+
+describe("serializeNotificationsDocumentToV0", () => {
+	it("down-converts an all-group of field_match to a flat conditions array", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{
+						kind: "field_match",
+						params: { field: "eventType", operator: "equals", value: "GRAB" },
+					},
+					{ kind: "field_match", params: { field: "title", operator: "contains", value: "4K" } },
+				],
+			},
+		};
+		expect(serializeNotificationsDocumentToV0(doc)).toEqual([
+			{ field: "eventType", operator: "equals", value: "GRAB" },
+			{ field: "title", operator: "contains", value: "4K" },
+		]);
+	});
+
+	it("maps an empty all-group to [] (matches every event)", () => {
+		const doc: RuleDocument = { version: 1, root: { all: [] } };
+		expect(serializeNotificationsDocumentToV0(doc)).toEqual([]);
+	});
+
+	it("accepts a lone field_match predicate root", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "field_match", params: { field: "body", operator: "contains", value: "x" } },
+		};
+		expect(serializeNotificationsDocumentToV0(doc)).toEqual([
+			{ field: "body", operator: "contains", value: "x" },
+		]);
+	});
+
+	it("rejects an OR (any) group — notifications are implicit-AND only", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				any: [{ kind: "field_match", params: { field: "a", operator: "equals", value: "b" } }],
+			},
+		};
+		expect(() => serializeNotificationsDocumentToV0(doc)).toThrow(/OR/);
+	});
+
+	it("rejects a non-field_match predicate", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { all: [{ kind: "age", params: { days: 30 } }] },
+		};
+		expect(() => serializeNotificationsDocumentToV0(doc)).toThrow(/field_match/);
+	});
+});

--- a/packages/shared/src/rules/index.ts
+++ b/packages/shared/src/rules/index.ts
@@ -11,3 +11,4 @@ export * from "./contexts.js";
 export * from "./criteria.js";
 export * from "./field-match.js";
 export * from "./grammar.js";
+export * from "./v1-serializer.js";

--- a/packages/shared/src/rules/v1-serializer.ts
+++ b/packages/shared/src/rules/v1-serializer.ts
@@ -1,0 +1,140 @@
+/**
+ * v1 → v0 serializers — the WRITE-side inverse of v0-mappers.ts.
+ *
+ * The composer authors rules as a v1 RuleDocument in memory, but 3.0 stores
+ * them in the EXISTING per-domain v0 columns (docs/design/unified-rule-grammar.md
+ * §3: parse-time versioning, no eager rewrites — v0 storage stays permanently
+ * valid, and the live evaluators keep reading it). So on save the composer
+ * down-converts the document to the v0 payload the existing routes accept, and
+ * these functions are that down-conversion.
+ *
+ * They produce the API PAYLOAD shape (params/conditions as OBJECTS, not the
+ * stringified storage form) — the same shape the per-domain dialogs already
+ * POST. Round-trip parity with the mappers is the correctness contract:
+ * `serialize(map(v0)) === v0` and `map(serialize(v1)) === v1` for every
+ * authorable rule (see __tests__/v1-serializer.test.ts).
+ *
+ * v1 is depth-1 (§2.1), so a composite's children must all be predicates;
+ * a nested group throws. Empty groups also throw: an empty composite is not a
+ * meaningful authored rule and would serialize to a no-op `{kind:"composite"}`
+ * / `{all:[]}` shape — the form must reject it before it reaches here.
+ */
+
+import { FIELD_MATCH_KIND } from "./field-match.js";
+import {
+	groupChildren,
+	isRulePredicate,
+	type RuleDocument,
+	type RulePredicate,
+} from "./grammar.js";
+
+export class V1SerializerError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "V1SerializerError";
+	}
+}
+
+// ── Criteria surface (library-cleanup / auto-tag) ───────────────────
+
+/** The v0 API payload for a cleanup/auto-tag rule's condition half. */
+export interface CriteriaV0Payload {
+	ruleType: string;
+	parameters: Record<string, unknown>;
+	operator: "AND" | "OR" | null;
+	conditions: Array<{ ruleType: string; parameters: Record<string, unknown> }> | null;
+}
+
+/**
+ * Down-convert a criteria (cleanup/auto-tag) document to its v0 payload.
+ * - predicate root → single rule `{ ruleType, parameters, operator:null, conditions:null }`
+ * - group root     → composite `{ ruleType:"composite", parameters:{}, operator, conditions[] }`
+ */
+export function serializeCriteriaDocumentToV0(doc: RuleDocument): CriteriaV0Payload {
+	const root = doc.root;
+
+	if (isRulePredicate(root)) {
+		return {
+			ruleType: root.kind,
+			parameters: root.params,
+			operator: null,
+			conditions: null,
+		};
+	}
+
+	const children = groupChildren(root);
+	if (children.length === 0) {
+		throw new V1SerializerError("composite rule has no conditions");
+	}
+
+	const conditions = children.map((child, i) => {
+		if (!isRulePredicate(child)) {
+			throw new V1SerializerError(
+				`composite condition[${i}] is a nested group — v1 rules are depth-1`,
+			);
+		}
+		return { ruleType: child.kind, parameters: child.params };
+	});
+
+	return {
+		ruleType: "composite",
+		parameters: {},
+		operator: "all" in root ? "AND" : "OR",
+		conditions,
+	};
+}
+
+// ── Notifications surface ───────────────────────────────────────────
+
+/** A v0 notification condition (flat implicit-AND element). */
+export interface NotificationV0Condition {
+	field: string;
+	operator: string;
+	value: unknown;
+}
+
+/**
+ * Down-convert a notifications document to its flat v0 conditions array.
+ *
+ * v0 notifications are an implicit-AND list of `{ field, operator, value }`, so
+ * the document root is expected to be an `all` group of `field_match`
+ * predicates (or a lone `field_match` predicate). An `any` (OR) group has no v0
+ * representation and is rejected — OR isn't authorable for notifications in v1.
+ * An empty `all` group serializes to `[]` (matches every event — the one legal
+ * empty case, preserved from 2.x).
+ */
+export function serializeNotificationsDocumentToV0(doc: RuleDocument): NotificationV0Condition[] {
+	const root = doc.root;
+
+	let predicates: RulePredicate[];
+	if (isRulePredicate(root)) {
+		predicates = [root];
+	} else if ("all" in root) {
+		predicates = root.all.map((child, i) => {
+			if (!isRulePredicate(child)) {
+				throw new V1SerializerError(
+					`notification condition[${i}] is a nested group — not representable in v0`,
+				);
+			}
+			return child;
+		});
+	} else {
+		throw new V1SerializerError(
+			"notification rules use implicit AND; an 'any' (OR) group is not representable in v0",
+		);
+	}
+
+	return predicates.map((p, i) => {
+		if (p.kind !== FIELD_MATCH_KIND) {
+			throw new V1SerializerError(
+				`notification condition[${i}] must be a ${FIELD_MATCH_KIND} predicate, got "${p.kind}"`,
+			);
+		}
+		const field = p.params.field;
+		const operator = p.params.operator;
+		if (typeof field !== "string" || typeof operator !== "string") {
+			throw new V1SerializerError(`notification condition[${i}] missing field/operator`);
+		}
+		return { field, operator, value: p.params.value };
+	});
+}


### PR DESCRIPTION
## Summary

First slice of the Operator Console composer's **authoring** (PR-3, charter §5.2). The composer will author rules as v1 `RuleDocument`s in memory but store them in the **existing per-domain v0 columns** (design §3: parse-time versioning, no eager rewrites — v0 storage stays permanently valid and the live evaluators keep reading it unchanged). This PR adds the missing piece for that down-convert: the **write-side inverse of the v0→v1 mappers**.

## What's in this PR

`packages/shared/src/rules/v1-serializer.ts` (frontend-importable, pure):
- `serializeCriteriaDocumentToV0(doc)` → cleanup/auto-tag v0 payload (predicate root → single rule; group root → AND/OR composite).
- `serializeNotificationsDocumentToV0(doc)` → flat `field_match[]` (v0's implicit-AND array); rejects OR groups (no v0 representation) + non-`field_match` kinds.
- Both reject nested groups (v1 is depth-1) and empty composites (which would serialize to a no-op `{kind:"composite"}` / `{all:[]}` — the form must reject them first; this is the last-line guard). `V1SerializerError`.

## Why it matters (blast radius)

The flagship's real danger is a composer-authored rule producing a *subtly different* v0 row than the live media-deletion evaluator expects — silently deleting media the old path would keep. The contract that prevents this is **round-trip parity with the mappers**, tested here in isolation **before any UI**:
- `v1 → serialize → map → v1` (identity) for single / AND / OR shapes.
- `v0 → map → serialize → v0` (identity) for single / composite.
- notifications incl. the empty "matches every event" case.

So the composer can only ever produce rows the engine already evaluates identically.

## Validation

- `turbo typecheck` green (3 packages); full suite green (2197 API + shared; **17 new tests** — 10 serializer unit + 7 round-trip parity vs the mappers); lint 0 errors.

No consumer yet — the composer authoring UI (dialog + per-context action fields + wiring to the existing routes) builds on this foundation next. Design settled with the maintainer: down-convert to v0 / engine untouched, all 3 contexts (cleanup/auto-tag/notifications), edit + create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)