### PR TITLE
feat(composer): library-cleanup authoring UI — the down-convert write path (PR-3b)

### DIFF
--- a/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
@@ -196,6 +196,12 @@ describe("CleanupRuleComposerDialog — edit", () => {
 			enabled: true,
 			action: "unmonitor",
 			retentionMode: true,
+			// Defaulted fields the composer doesn't edit are ECHOED from the loaded
+			// rule — base.partial() re-injects their defaults, so omitting them would
+			// clobber the stored values (priority reset to 0, useGlobalRejectionMemory
+			// to true). Echoing preserves them.
+			priority: 0,
+			useGlobalRejectionMemory: true,
 			ruleType: "composite",
 			parameters: {},
 			operator: "AND",
@@ -204,9 +210,21 @@ describe("CleanupRuleComposerDialog — edit", () => {
 				{ ruleType: "plex_watch_count", parameters: { operator: "less_than", count: 1 } },
 			],
 		});
-		// Advanced filters are NOT in the payload → route preserves them.
+		// Fields WITHOUT a schema default are omitted → the route's !== undefined
+		// discipline preserves them (no clobber risk).
 		expect(arg.data).not.toHaveProperty("serviceFilter");
 		expect(arg.data).not.toHaveProperty("excludeTitles");
 		expect(arg.data).not.toHaveProperty("rejectionMemoryDays");
+	});
+
+	it("shows a loading state and blocks save until the config join resolves (no default-clobber)", async () => {
+		// automation summary present, but config not yet loaded → editDataReady false.
+		configData = undefined;
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
+		expect(await screen.findByText(/loading rule/i)).toBeTruthy();
+		// The form (and its Save button) isn't rendered yet, so no default-seeded
+		// payload can be submitted.
+		expect(screen.queryByRole("button", { name: /save changes/i })).toBeNull();
+		expect(updateMutate).not.toHaveBeenCalled();
 	});
 });

--- a/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Rendered tests for the composer's cleanup create/edit dialog — the flagship
+ * WRITE path. These cover the populated-data paths an empty-dev-DB live-verify
+ * is blind to (feedback_review_catches_data_dependent_bugs):
+ *   - create → the exact merged v0 payload POSTed (core action + serialized
+ *     condition quartet)
+ *   - edit → a real two-condition composite prefilled from the read API's v1
+ *     document, then saved as a PARTIAL update (advanced filters omitted →
+ *     preserved by the route's !== undefined discipline)
+ */
+
+import type { AutomationRulesResponse, CleanupConfigResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+// jsdom polyfills for Radix Dialog
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+
+// ── Mocks ───────────────────────────────────────────────────────────
+
+const createMutate = vi.fn().mockResolvedValue({});
+const updateMutate = vi.fn().mockResolvedValue({});
+
+let automationData: AutomationRulesResponse = { rules: [] };
+let configData: CleanupConfigResponse | undefined;
+
+vi.mock("@/hooks/api/useLibraryCleanup", () => ({
+	useCleanupFieldOptions: () => ({ data: { hasPlex: false }, isLoading: false }),
+	useCleanupConfig: () => ({ data: configData }),
+	useCreateCleanupRule: () => ({ mutateAsync: createMutate, isPending: false }),
+	useUpdateCleanupRule: () => ({ mutateAsync: updateMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/api/useAutomation", () => ({
+	useAutomationRules: () => ({ data: automationData }),
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "#3b82f6", to: "#8b5cf6", fromLight: "#3b82f610", fromMuted: "#3b82f630" },
+	}),
+}));
+
+vi.mock("@/lib/theme-input-styles", () => ({
+	getInputStyles: () => ({ base: "test-input", applyFocus: vi.fn(), removeFocus: vi.fn() }),
+}));
+
+// Import after mocks
+import { CleanupRuleComposerDialog } from "../cleanup-rule-composer-dialog";
+
+function wrapper(ui: ReactNode) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<IncognitoProvider>{ui}</IncognitoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	createMutate.mockClear();
+	updateMutate.mockClear();
+	automationData = { rules: [] };
+	configData = undefined;
+});
+
+describe("CleanupRuleComposerDialog — create", () => {
+	it("POSTs the merged core-action + serialized single-condition payload", async () => {
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} />);
+
+		fireEvent.change(screen.getByPlaceholderText(/old low-rated movies/i), {
+			target: { value: "My rule" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+
+		await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+		expect(createMutate).toHaveBeenCalledWith({
+			name: "My rule",
+			enabled: true,
+			action: "delete",
+			retentionMode: false,
+			// Default seed condition is age; single → operator/conditions null.
+			ruleType: "age",
+			parameters: { operator: "older_than", days: 30 },
+			operator: null,
+			conditions: null,
+		});
+	});
+
+	it("blocks save on a whitespace-only name (native `required` passes it, the trim guard catches it)", async () => {
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} />);
+		fireEvent.change(screen.getByPlaceholderText(/old low-rated movies/i), {
+			target: { value: "   " },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+		await screen.findByText(/give the rule a name/i);
+		expect(createMutate).not.toHaveBeenCalled();
+	});
+});
+
+describe("CleanupRuleComposerDialog — edit", () => {
+	beforeEach(() => {
+		// A real two-condition AND composite, as the read API would serve it (v1).
+		automationData = {
+			rules: [
+				{
+					id: "rule-1",
+					name: "Old unwatched",
+					enabled: true,
+					context: "library-cleanup",
+					document: {
+						version: 1,
+						root: {
+							all: [
+								{ kind: "age", params: { operator: "older_than", days: 90 } },
+								{ kind: "plex_watch_count", params: { operator: "less_than", count: 1 } },
+							],
+						},
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+			],
+		};
+		configData = {
+			id: "cfg",
+			enabled: true,
+			intervalHours: 24,
+			lastRunAt: null,
+			nextRunAt: null,
+			dryRunMode: false,
+			maxRemovalsPerRun: 10,
+			requireApproval: true,
+			respectQuiSeeding: false,
+			rejectionMemoryDays: 0,
+			rules: [
+				{
+					id: "rule-1",
+					name: "Old unwatched",
+					enabled: true,
+					priority: 0,
+					ruleType: "composite",
+					parameters: {},
+					serviceFilter: ["sonarr"],
+					instanceFilter: null,
+					excludeTags: null,
+					excludeTitles: ["Keep me"],
+					plexLibraryFilter: null,
+					action: "unmonitor",
+					operator: "AND",
+					conditions: [
+						{ ruleType: "age", parameters: { operator: "older_than", days: 90 } },
+						{ ruleType: "plex_watch_count", parameters: { operator: "less_than", count: 1 } },
+					],
+					retentionMode: true,
+					useGlobalRejectionMemory: true,
+					rejectionMemoryDays: null,
+					createdAt: "2026-01-01T00:00:00Z",
+					updatedAt: "2026-01-01T00:00:00Z",
+				},
+			],
+		};
+	});
+
+	it("prefills name + action + both composite conditions from the joined sources", async () => {
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
+
+		expect(await screen.findByDisplayValue("Old unwatched")).toBeTruthy();
+		// Two condition rows rendered (composite prefill).
+		expect(screen.getByText(/condition 1/i)).toBeTruthy();
+		expect(screen.getByText(/condition 2/i)).toBeTruthy();
+	});
+
+	it("saves a PARTIAL update — composer-owned fields only, advanced filters omitted (preserved)", async () => {
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
+		await screen.findByDisplayValue("Old unwatched");
+
+		fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+		const arg = updateMutate.mock.calls[0]?.[0];
+		expect(arg.id).toBe("rule-1");
+		expect(arg.data).toEqual({
+			name: "Old unwatched",
+			enabled: true,
+			action: "unmonitor",
+			retentionMode: true,
+			ruleType: "composite",
+			parameters: {},
+			operator: "AND",
+			conditions: [
+				{ ruleType: "age", parameters: { operator: "older_than", days: 90 } },
+				{ ruleType: "plex_watch_count", parameters: { operator: "less_than", count: 1 } },
+			],
+		});
+		// Advanced filters are NOT in the payload → route preserves them.
+		expect(arg.data).not.toHaveProperty("serviceFilter");
+		expect(arg.data).not.toHaveProperty("excludeTitles");
+		expect(arg.data).not.toHaveProperty("rejectionMemoryDays");
+	});
+});

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -171,7 +171,15 @@ export function AutomationPanel() {
 										rule={rule}
 										incognito={incognito}
 										onEdit={
-											rule.context === "library-cleanup" ? () => openEdit(rule.id) : undefined
+											// Composer-editable only for library-cleanup rules whose kinds
+											// are ALL still available. A rule referencing a retired kind
+											// (unavailableKinds non-empty) is parseable but the composer's
+											// kind picker can't represent it — editing would be a dead-end
+											// (picker shows a wrong kind, save is blocked). Route those to
+											// the Library Cleanup surface to repair instead.
+											rule.context === "library-cleanup" && rule.unavailableKinds.length === 0
+												? () => openEdit(rule.id)
+												: undefined
 										}
 									/>
 								))}

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -1,26 +1,34 @@
 "use client";
 
 /**
- * Operator Console — Automation tab (read-only cross-domain rule viewer).
+ * Operator Console — Automation tab (cross-domain rule composer).
  *
- * The read half of the Unified Automation Engine composer (charter §2.1 /
- * §5.2): every domain's rules in one place, normalized to v1 and rendered with
- * {@link RuleDocumentView}. Authoring lands in a later PR; this surface is
- * deliberately read-only.
+ * The unified rule surface (charter §2.1 / §5.2): every domain's rules in one
+ * place, normalized to v1 and rendered with {@link RuleDocumentView}. Authoring
+ * lands in slices by context — library-cleanup first (create + edit via the
+ * down-convert write path, PR-3b). Auto-tag and notifications authoring follow.
  *
- * Incognito: rule NAMES (the operator's own labels) stay visible so the view is
- * usable; sensitive param VALUES are masked inside RuleDocumentView. Retired
- * kinds badge as unavailable; an unparseable stored rule is shown honestly
- * rather than hidden.
+ * Incognito: rule NAMES stay visible (ratified 2026-07-07 — consistent with the
+ * rest of the app; usable in a screenshare); sensitive param VALUES are masked
+ * inside RuleDocumentView. Retired kinds badge as unavailable; an unparseable
+ * stored rule is shown honestly and is NOT offered for composer edit (it routes
+ * to its own surface to repair).
  */
 
 import type { AutomationRuleSummary, RuleContextId } from "@arr/shared";
-import { AlertTriangle, Workflow } from "lucide-react";
+import { AlertTriangle, Pencil, Plus, Workflow } from "lucide-react";
+import { lazy, Suspense, useState } from "react";
 import { AsyncStateView, GlassmorphicCard } from "../../../components/layout";
 import { useIncognitoMode } from "../../../contexts/IncognitoContext";
 import { useAutomationRules } from "../../../hooks/api/useAutomation";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { RuleDocumentView } from "./rule-document-view";
+
+const CleanupRuleComposerDialog = lazy(() =>
+	import("./cleanup-rule-composer-dialog").then((m) => ({
+		default: m.CleanupRuleComposerDialog,
+	})),
+);
 
 const CONTEXT_LABELS: Record<RuleContextId, string> = {
 	"library-cleanup": "Library Cleanup",
@@ -51,16 +59,43 @@ function EnabledBadge({ enabled }: { enabled: boolean }) {
 	);
 }
 
-function RuleCard({ rule, incognito }: { rule: AutomationRuleSummary; incognito: boolean }) {
+function RuleCard({
+	rule,
+	incognito,
+	onEdit,
+}: {
+	rule: AutomationRuleSummary;
+	incognito: boolean;
+	/** Provided only for rules this slice can author (parseable cleanup rules). */
+	onEdit?: () => void;
+}) {
+	// Keyed on `document` (not a derived `broken` const) so the else branch
+	// narrows document to non-null for RuleDocumentView.
+	const document = rule.unparseable ? null : rule.document;
 	return (
 		<GlassmorphicCard className="space-y-2 p-4">
 			<div className="flex items-start justify-between gap-2">
 				{/* Rule name = the operator's own label; shown even in incognito so the
 				    viewer stays usable. Sensitive values live in the params, masked below. */}
 				<span className="font-medium text-foreground">{rule.name}</span>
-				<EnabledBadge enabled={rule.enabled} />
+				<div className="flex shrink-0 items-center gap-2">
+					{onEdit && document && (
+						<button
+							type="button"
+							onClick={onEdit}
+							className="inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+							aria-label={`Edit ${rule.name}`}
+						>
+							<Pencil className="h-3 w-3" aria-hidden="true" />
+							Edit
+						</button>
+					)}
+					<EnabledBadge enabled={rule.enabled} />
+				</div>
 			</div>
-			{rule.unparseable || rule.document === null ? (
+			{document ? (
+				<RuleDocumentView document={document} context={rule.context} incognito={incognito} />
+			) : (
 				<p
 					className="flex items-center gap-1.5 text-sm"
 					style={{ color: SEMANTIC_COLORS.warning.text }}
@@ -68,8 +103,6 @@ function RuleCard({ rule, incognito }: { rule: AutomationRuleSummary; incognito:
 					<AlertTriangle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
 					This rule could not be read from its stored definition — open its surface to repair it.
 				</p>
-			) : (
-				<RuleDocumentView document={rule.document} context={rule.context} incognito={incognito} />
 			)}
 		</GlassmorphicCard>
 	);
@@ -78,6 +111,11 @@ function RuleCard({ rule, incognito }: { rule: AutomationRuleSummary; incognito:
 export function AutomationPanel() {
 	const { data, isLoading, isError, error, refetch } = useAutomationRules();
 	const [incognito] = useIncognitoMode();
+	// { open, editRuleId } — editRuleId null = create mode.
+	const [composer, setComposer] = useState<{ open: boolean; editRuleId: string | null }>({
+		open: false,
+		editRuleId: null,
+	});
 
 	const rules = data?.rules ?? [];
 	const groups = CONTEXT_ORDER.map((context) => ({
@@ -85,38 +123,73 @@ export function AutomationPanel() {
 		rules: rules.filter((rule) => rule.context === context),
 	})).filter((group) => group.rules.length > 0);
 
+	const openCreate = () => setComposer({ open: true, editRuleId: null });
+	const openEdit = (id: string) => setComposer({ open: true, editRuleId: id });
+
 	return (
-		<AsyncStateView
-			isLoading={isLoading}
-			isError={isError}
-			error={error}
-			isEmpty={rules.length === 0}
-			onRetry={() => void refetch()}
-			errorTitle="Couldn't load automation rules"
-			emptyState={{
-				icon: Workflow,
-				title: "No automation rules yet",
-				description:
-					"Rules you create in Library Cleanup, Auto-Tag, and Notifications appear here, unified.",
-			}}
-		>
-			<div className="space-y-6">
-				{groups.map((group) => (
-					<section key={group.context} className="space-y-2">
-						<h3 className="flex items-center gap-2 text-sm font-semibold text-foreground">
-							{CONTEXT_LABELS[group.context]}
-							<span className="rounded-full bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
-								{group.rules.length}
-							</span>
-						</h3>
-						<div className="space-y-3">
-							{group.rules.map((rule) => (
-								<RuleCard key={`${rule.context}-${rule.id}`} rule={rule} incognito={incognito} />
-							))}
-						</div>
-					</section>
-				))}
+		<div className="space-y-4">
+			{/* Authoring entry point. Scoped to library-cleanup this slice; the
+			    button grows a context selector as auto-tag / notifications land. */}
+			<div className="flex items-center justify-end">
+				<button
+					type="button"
+					onClick={openCreate}
+					className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 bg-card/50 px-3 py-1.5 text-sm font-medium backdrop-blur-xs transition-colors hover:bg-card/80"
+				>
+					<Plus className="h-4 w-4" aria-hidden="true" />
+					New cleanup rule
+				</button>
 			</div>
-		</AsyncStateView>
+
+			<AsyncStateView
+				isLoading={isLoading}
+				isError={isError}
+				error={error}
+				isEmpty={rules.length === 0}
+				onRetry={() => void refetch()}
+				errorTitle="Couldn't load automation rules"
+				emptyState={{
+					icon: Workflow,
+					title: "No automation rules yet",
+					description:
+						"Create a cleanup rule here, or add rules in Auto-Tag and Notifications — they all appear here, unified.",
+				}}
+			>
+				<div className="space-y-6">
+					{groups.map((group) => (
+						<section key={group.context} className="space-y-2">
+							<h3 className="flex items-center gap-2 text-sm font-semibold text-foreground">
+								{CONTEXT_LABELS[group.context]}
+								<span className="rounded-full bg-muted/40 px-2 py-0.5 text-xs font-medium text-muted-foreground">
+									{group.rules.length}
+								</span>
+							</h3>
+							<div className="space-y-3">
+								{group.rules.map((rule) => (
+									<RuleCard
+										key={`${rule.context}-${rule.id}`}
+										rule={rule}
+										incognito={incognito}
+										onEdit={
+											rule.context === "library-cleanup" ? () => openEdit(rule.id) : undefined
+										}
+									/>
+								))}
+							</div>
+						</section>
+					))}
+				</div>
+			</AsyncStateView>
+
+			{composer.open && (
+				<Suspense>
+					<CleanupRuleComposerDialog
+						open={composer.open}
+						onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
+						editRuleId={composer.editRuleId}
+					/>
+				</Suspense>
+			)}
+		</div>
 	);
 }

--- a/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+/**
+ * Composer — create/edit dialog for a library-cleanup rule (charter §5.2, the
+ * flagship WRITE path — it authors live media-deletion rules).
+ *
+ * Flow: author the CONDITION half as a v1 document ({@link CriteriaConditionEditor})
+ * plus the core action fields, then on save validate strictly, down-convert the
+ * document to the v0 payload the EXISTING route accepts (`serializeCriteria
+ * DocumentToV0`), and POST/PUT via the existing cleanup api-client. The live
+ * evaluator keeps reading v0 — the composer writes the SAME rows the per-domain
+ * dialog would (round-trip parity, PR-3a).
+ *
+ * Action scope (ratified 2026-07-07): core action only — action + retentionMode
+ * + name + enabled. Advanced filters (service/instance/tag/title/plex-library)
+ * and rejection-memory are managed in the full Library Cleanup surface; the PUT
+ * route's `!== undefined` discipline PRESERVES them across a composer edit, and
+ * create defaults them. Hence the note + deep link below.
+ */
+
+import type { CleanupAction, CreateCleanupRule, UpdateCleanupRule } from "@arr/shared";
+import { CONTEXT_KINDS } from "@arr/shared";
+import { useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Loader2, Save, ShieldOff } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import {
+	useCleanupConfig,
+	useCleanupFieldOptions,
+	useCreateCleanupRule,
+	useUpdateCleanupRule,
+} from "@/hooks/api/useLibraryCleanup";
+import { useThemeGradient } from "@/hooks/useThemeGradient";
+import { getErrorMessage } from "@/lib/error-utils";
+import { automationKeys } from "@/lib/query-keys";
+import { getInputStyles } from "@/lib/theme-input-styles";
+import { useAutomationRules } from "../../../hooks/api/useAutomation";
+import { getDefaultConditionParams } from "../../rule-criteria/components/condition-params-fields";
+import {
+	type CriteriaEditorState,
+	decomposeCriteriaDocument,
+	toCriteriaV0Payload,
+} from "../lib/rule-document-editor";
+import { CriteriaConditionEditor } from "./criteria-condition-editor";
+
+interface CleanupRuleComposerDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Rule id to edit; omit/null for create mode. */
+	editRuleId?: string | null;
+}
+
+const ACTIONS: Array<{ value: CleanupAction; label: string; hint: string }> = [
+	{ value: "delete", label: "Delete", hint: "Remove the item entirely from the ARR instance." },
+	{
+		value: "unmonitor",
+		label: "Unmonitor",
+		hint: "Set the item unmonitored (keeps files and data).",
+	},
+	{
+		value: "delete_files",
+		label: "Delete Files",
+		hint: "Delete files but keep the item in the library.",
+	},
+];
+
+function freshEditorState(): CriteriaEditorState {
+	return {
+		mode: "single",
+		operator: "all",
+		conditions: [{ id: "seed-0", kind: "age", params: getDefaultConditionParams("age") }],
+	};
+}
+
+export function CleanupRuleComposerDialog({
+	open,
+	onOpenChange,
+	editRuleId,
+}: CleanupRuleComposerDialogProps) {
+	const { gradient } = useThemeGradient();
+	const queryClient = useQueryClient();
+	const isEdit = !!editRuleId;
+
+	const { data: automation } = useAutomationRules();
+	const { data: config } = useCleanupConfig();
+	const { data: fieldOptions, isLoading: fieldOptionsLoading } = useCleanupFieldOptions();
+	const createRule = useCreateCleanupRule();
+	const updateRule = useUpdateCleanupRule();
+
+	// The two edit data sources, joined by id: the automation read API supplies
+	// the normalized v1 document (conditions); the cleanup config supplies the
+	// action half the read API deliberately omits (name/enabled come from either).
+	const summary = useMemo(
+		() =>
+			editRuleId
+				? automation?.rules.find((r) => r.context === "library-cleanup" && r.id === editRuleId)
+				: undefined,
+		[automation, editRuleId],
+	);
+	const configRule = useMemo(
+		() => (editRuleId ? config?.rules.find((r) => r.id === editRuleId) : undefined),
+		[config, editRuleId],
+	);
+
+	const [name, setName] = useState("");
+	const [enabled, setEnabled] = useState(true);
+	const [action, setAction] = useState<CleanupAction>("delete");
+	const [retentionMode, setRetentionMode] = useState(false);
+	const [editorState, setEditorState] = useState<CriteriaEditorState>(freshEditorState);
+	const [error, setError] = useState<string | null>(null);
+
+	const legalKinds = useMemo(() => [...CONTEXT_KINDS["library-cleanup"]], []);
+
+	// Prefill on open. In edit mode this re-runs when the joined rule resolves.
+	useEffect(() => {
+		if (!open) return;
+		setError(null);
+		if (isEdit) {
+			setName(summary?.name ?? configRule?.name ?? "");
+			setEnabled(summary?.enabled ?? configRule?.enabled ?? true);
+			setAction((configRule?.action as CleanupAction) ?? "delete");
+			setRetentionMode(configRule?.retentionMode ?? false);
+			// The document is the v1 source of truth for conditions; if the stored
+			// rule was unparseable (document null) we fall back to a fresh editor so
+			// the operator can re-author rather than see a broken form.
+			setEditorState(
+				summary?.document ? decomposeCriteriaDocument(summary.document) : freshEditorState(),
+			);
+		} else {
+			setName("");
+			setEnabled(true);
+			setAction("delete");
+			setRetentionMode(false);
+			setEditorState(freshEditorState());
+		}
+	}, [open, isEdit, summary, configRule]);
+
+	const inputStyles = getInputStyles(gradient);
+	const inputClass = `${inputStyles.base} focus:outline-hidden`;
+	const labelClass = "mb-1 block text-xs text-muted-foreground";
+
+	const isSaving = createRule.isPending || updateRule.isPending;
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (isSaving) return;
+
+		if (!name.trim()) {
+			setError("Give the rule a name.");
+			return;
+		}
+
+		// Validate + down-convert the v1 document to the v0 route payload. The
+		// full condition quartet (ruleType/parameters/operator/conditions) is
+		// ALWAYS sent together so switching single↔composite clears any stale
+		// operator/conditions the engine's composite discriminator would honor.
+		// Not destructured: reading `.error`/`.payload` off the result preserves
+		// the discriminated-union narrowing (payload is defined after the guard).
+		const result = toCriteriaV0Payload(editorState, "library-cleanup");
+		if (!result.payload) {
+			setError(result.error ?? "This rule isn't valid yet.");
+			return;
+		}
+		const payload = result.payload;
+		setError(null);
+
+		// The composer owns name/enabled/action/retentionMode + the full condition
+		// quartet from the serializer. Every OTHER cleanup field is omitted: create
+		// applies the schema defaults, and the PUT route's `!== undefined`
+		// discipline PRESERVES the stored advanced filters + rejection-memory.
+		// Cast mirrors the per-domain dialog (cleanup-rule-dialog.tsx): the
+		// serializer types ruleType/conditions as `string` (v0 payload shape) and
+		// the schema output type demands its defaulted fields — validation already
+		// proved the kind legal, so the cast is sound.
+		const domainBase = {
+			name: name.trim(),
+			enabled,
+			action,
+			retentionMode,
+			ruleType: payload.ruleType,
+			parameters: payload.parameters,
+			operator: payload.operator,
+			conditions: payload.conditions,
+		};
+
+		try {
+			if (isEdit && editRuleId) {
+				await updateRule.mutateAsync({ id: editRuleId, data: domainBase as UpdateCleanupRule });
+			} else {
+				await createRule.mutateAsync(domainBase as CreateCleanupRule);
+			}
+			// The mutation hooks invalidate the cleanup config; the Automation tab
+			// reads its own key, so refresh it too.
+			await queryClient.invalidateQueries({ queryKey: automationKeys.all });
+			onOpenChange(false);
+		} catch (err) {
+			setError(getErrorMessage(err, "Could not save the rule."));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>{isEdit ? "Edit Cleanup Rule" : "New Cleanup Rule"}</DialogTitle>
+					<DialogDescription>
+						Author the matching conditions and action. This writes a real Library Cleanup rule.
+					</DialogDescription>
+				</DialogHeader>
+
+				<form
+					onSubmit={handleSubmit}
+					className="mt-2 space-y-5"
+					onFocus={(e) => {
+						const t = e.target;
+						if (
+							(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+							t instanceof HTMLSelectElement
+						) {
+							inputStyles.applyFocus(t);
+						}
+					}}
+					onBlur={(e) => {
+						const t = e.target;
+						if (
+							(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+							t instanceof HTMLSelectElement
+						) {
+							inputStyles.removeFocus(t);
+						}
+					}}
+				>
+					{/* Name */}
+					<label className="block">
+						<span className={labelClass}>Rule name</span>
+						<input
+							type="text"
+							value={name}
+							onChange={(e) => setName(e.target.value)}
+							placeholder="e.g., Old low-rated movies"
+							required
+							className={inputClass}
+						/>
+					</label>
+
+					{/* Enabled */}
+					<div className="flex items-center justify-between">
+						<span className="text-sm font-medium">Enabled</span>
+						<Switch
+							checked={enabled}
+							onCheckedChange={setEnabled}
+							style={enabled ? { backgroundColor: gradient.from } : undefined}
+						/>
+					</div>
+
+					{/* Retention mode */}
+					<div className="flex items-center justify-between">
+						<div className="flex items-center gap-2">
+							<ShieldOff className="h-4 w-4 text-emerald-400" />
+							<div>
+								<span className="text-sm font-medium">Retention rule</span>
+								<p className="text-xs text-muted-foreground">
+									Protects matching items from other rules
+								</p>
+							</div>
+						</div>
+						<Switch
+							checked={retentionMode}
+							onCheckedChange={setRetentionMode}
+							style={retentionMode ? { backgroundColor: "rgb(16 185 129)" } : undefined}
+						/>
+					</div>
+
+					{/* Action */}
+					<div>
+						<span className={labelClass}>Action when matched</span>
+						<div className="mt-1.5 flex gap-2">
+							{ACTIONS.map((a) => (
+								<button
+									key={a.value}
+									type="button"
+									onClick={() => setAction(a.value)}
+									className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+									style={
+										action === a.value
+											? {
+													borderColor: gradient.from,
+													backgroundColor: gradient.fromLight,
+													color: gradient.from,
+												}
+											: { borderColor: "var(--color-border)" }
+									}
+								>
+									{a.label}
+								</button>
+							))}
+						</div>
+						<p className="mt-1 text-xs text-muted-foreground">
+							{ACTIONS.find((a) => a.value === action)?.hint}
+						</p>
+					</div>
+
+					{/* Conditions */}
+					<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+						<span className="text-sm font-medium">Conditions</span>
+						<CriteriaConditionEditor
+							state={editorState}
+							onChange={setEditorState}
+							legalKinds={legalKinds}
+							fieldOptions={fieldOptions}
+							fieldOptionsLoading={fieldOptionsLoading}
+							inputClass={inputClass}
+							labelClass={labelClass}
+						/>
+					</div>
+
+					{/* Advanced-filters disclosure (they live in the full surface) */}
+					<Link
+						href="/library-cleanup"
+						className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+					>
+						<ExternalLink className="h-3 w-3" aria-hidden="true" />
+						Advanced filters (services, instances, tags, titles, Plex libraries) and rejection
+						memory are managed in Library Cleanup
+					</Link>
+
+					{error && (
+						<div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+							{error}
+						</div>
+					)}
+
+					<div className="flex justify-end gap-2">
+						<button
+							type="button"
+							onClick={() => onOpenChange(false)}
+							className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							disabled={isSaving}
+							className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-60"
+							style={{ background: `linear-gradient(to right, ${gradient.from}, ${gradient.to})` }}
+						>
+							{isSaving ? (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							) : (
+								<Save className="h-4 w-4" />
+							)}
+							{isEdit ? "Save changes" : "Create rule"}
+						</button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
@@ -110,6 +110,14 @@ export function CleanupRuleComposerDialog({
 		[config, editRuleId],
 	);
 
+	// Edit mode needs BOTH joined sources before the form is meaningful: the
+	// automation summary (conditions) AND the config rule (action + the defaulted
+	// fields we must echo back — see the save comment). Initializing or saving
+	// before configRule resolves would prefill composer DEFAULTS (action:"delete",
+	// retentionMode:false) and write them over the stored values — on a media-
+	// deletion rule, silently flipping e.g. "unmonitor" → "delete". So we gate.
+	const editDataReady = !isEdit || (Boolean(summary) && Boolean(configRule));
+
 	const [name, setName] = useState("");
 	const [enabled, setEnabled] = useState(true);
 	const [action, setAction] = useState<CleanupAction>("delete");
@@ -119,9 +127,13 @@ export function CleanupRuleComposerDialog({
 
 	const legalKinds = useMemo(() => [...CONTEXT_KINDS["library-cleanup"]], []);
 
-	// Prefill on open. In edit mode this re-runs when the joined rule resolves.
+	// Prefill on open. In edit mode this runs once the joined rule resolves
+	// (editDataReady) — never with partial data, so it can't seed defaults that a
+	// later save would persist, and can't wipe in-progress edits on late load
+	// (the form isn't shown until ready).
 	useEffect(() => {
 		if (!open) return;
+		if (isEdit && !editDataReady) return;
 		setError(null);
 		if (isEdit) {
 			setName(summary?.name ?? configRule?.name ?? "");
@@ -141,7 +153,7 @@ export function CleanupRuleComposerDialog({
 			setRetentionMode(false);
 			setEditorState(freshEditorState());
 		}
-	}, [open, isEdit, summary, configRule]);
+	}, [open, isEdit, editDataReady, summary, configRule]);
 
 	const inputStyles = getInputStyles(gradient);
 	const inputClass = `${inputStyles.base} focus:outline-hidden`;
@@ -173,18 +185,23 @@ export function CleanupRuleComposerDialog({
 		setError(null);
 
 		// The composer owns name/enabled/action/retentionMode + the full condition
-		// quartet from the serializer. Every OTHER cleanup field is omitted: create
-		// applies the schema defaults, and the PUT route's `!== undefined`
-		// discipline PRESERVES the stored advanced filters + rejection-memory.
-		// Cast mirrors the per-domain dialog (cleanup-rule-dialog.tsx): the
-		// serializer types ruleType/conditions as `string` (v0 payload shape) and
-		// the schema output type demands its defaulted fields — validation already
-		// proved the kind legal, so the cast is sound.
-		const domainBase = {
-			name: name.trim(),
-			enabled,
-			action,
-			retentionMode,
+		// quartet from the serializer.
+		//
+		// Preservation of the fields the composer does NOT edit is subtle:
+		//  - Fields WITHOUT a schema default (serviceFilter, instanceFilter,
+		//    excludeTags, excludeTitles, plexLibraryFilter, rejectionMemoryDays)
+		//    can be omitted — the PUT route's `!== undefined` discipline keeps the
+		//    stored value.
+		//  - Fields WITH a `.default()` CANNOT simply be omitted: updateCleanup-
+		//    RuleSchema = base.partial(), and `.partial()` does NOT strip
+		//    `.default()`, so an absent `priority` (default 0) or
+		//    `useGlobalRejectionMemory` (default true) is RE-INJECTED by Zod and
+		//    would overwrite the stored value. So on edit we echo those two back
+		//    from the loaded rule (editDataReady guarantees it's present).
+		// Cast mirrors the per-domain dialog: the serializer types ruleType/
+		// conditions as `string` (v0 payload shape) and the schema output type
+		// demands its defaulted fields — validation proved the kind legal.
+		const conditionHalf = {
 			ruleType: payload.ruleType,
 			parameters: payload.parameters,
 			operator: payload.operator,
@@ -192,10 +209,28 @@ export function CleanupRuleComposerDialog({
 		};
 
 		try {
-			if (isEdit && editRuleId) {
-				await updateRule.mutateAsync({ id: editRuleId, data: domainBase as UpdateCleanupRule });
+			if (isEdit && editRuleId && configRule) {
+				const update = {
+					name: name.trim(),
+					enabled,
+					action,
+					retentionMode,
+					// Echo back the defaulted fields the composer doesn't edit, so
+					// base.partial()'s re-injected defaults can't clobber them.
+					priority: configRule.priority,
+					useGlobalRejectionMemory: configRule.useGlobalRejectionMemory,
+					...conditionHalf,
+				};
+				await updateRule.mutateAsync({ id: editRuleId, data: update as UpdateCleanupRule });
 			} else {
-				await createRule.mutateAsync(domainBase as CreateCleanupRule);
+				const create = {
+					name: name.trim(),
+					enabled,
+					action,
+					retentionMode,
+					...conditionHalf,
+				};
+				await createRule.mutateAsync(create as CreateCleanupRule);
 			}
 			// The mutation hooks invalidate the cleanup config; the Automation tab
 			// reads its own key, so refresh it too.
@@ -216,151 +251,162 @@ export function CleanupRuleComposerDialog({
 					</DialogDescription>
 				</DialogHeader>
 
-				<form
-					onSubmit={handleSubmit}
-					className="mt-2 space-y-5"
-					onFocus={(e) => {
-						const t = e.target;
-						if (
-							(t instanceof HTMLInputElement && t.type !== "checkbox") ||
-							t instanceof HTMLSelectElement
-						) {
-							inputStyles.applyFocus(t);
-						}
-					}}
-					onBlur={(e) => {
-						const t = e.target;
-						if (
-							(t instanceof HTMLInputElement && t.type !== "checkbox") ||
-							t instanceof HTMLSelectElement
-						) {
-							inputStyles.removeFocus(t);
-						}
-					}}
-				>
-					{/* Name */}
-					<label className="block">
-						<span className={labelClass}>Rule name</span>
-						<input
-							type="text"
-							value={name}
-							onChange={(e) => setName(e.target.value)}
-							placeholder="e.g., Old low-rated movies"
-							required
-							className={inputClass}
-						/>
-					</label>
-
-					{/* Enabled */}
-					<div className="flex items-center justify-between">
-						<span className="text-sm font-medium">Enabled</span>
-						<Switch
-							checked={enabled}
-							onCheckedChange={setEnabled}
-							style={enabled ? { backgroundColor: gradient.from } : undefined}
-						/>
+				{isEdit && !editDataReady ? (
+					// Don't render the form until the joined rule data has loaded —
+					// otherwise the fields would show composer defaults, not the rule.
+					<div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+						Loading rule…
 					</div>
-
-					{/* Retention mode */}
-					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-2">
-							<ShieldOff className="h-4 w-4 text-emerald-400" />
-							<div>
-								<span className="text-sm font-medium">Retention rule</span>
-								<p className="text-xs text-muted-foreground">
-									Protects matching items from other rules
-								</p>
-							</div>
-						</div>
-						<Switch
-							checked={retentionMode}
-							onCheckedChange={setRetentionMode}
-							style={retentionMode ? { backgroundColor: "rgb(16 185 129)" } : undefined}
-						/>
-					</div>
-
-					{/* Action */}
-					<div>
-						<span className={labelClass}>Action when matched</span>
-						<div className="mt-1.5 flex gap-2">
-							{ACTIONS.map((a) => (
-								<button
-									key={a.value}
-									type="button"
-									onClick={() => setAction(a.value)}
-									className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
-									style={
-										action === a.value
-											? {
-													borderColor: gradient.from,
-													backgroundColor: gradient.fromLight,
-													color: gradient.from,
-												}
-											: { borderColor: "var(--color-border)" }
-									}
-								>
-									{a.label}
-								</button>
-							))}
-						</div>
-						<p className="mt-1 text-xs text-muted-foreground">
-							{ACTIONS.find((a) => a.value === action)?.hint}
-						</p>
-					</div>
-
-					{/* Conditions */}
-					<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
-						<span className="text-sm font-medium">Conditions</span>
-						<CriteriaConditionEditor
-							state={editorState}
-							onChange={setEditorState}
-							legalKinds={legalKinds}
-							fieldOptions={fieldOptions}
-							fieldOptionsLoading={fieldOptionsLoading}
-							inputClass={inputClass}
-							labelClass={labelClass}
-						/>
-					</div>
-
-					{/* Advanced-filters disclosure (they live in the full surface) */}
-					<Link
-						href="/library-cleanup"
-						className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+				) : (
+					<form
+						onSubmit={handleSubmit}
+						className="mt-2 space-y-5"
+						onFocus={(e) => {
+							const t = e.target;
+							if (
+								(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+								t instanceof HTMLSelectElement
+							) {
+								inputStyles.applyFocus(t);
+							}
+						}}
+						onBlur={(e) => {
+							const t = e.target;
+							if (
+								(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+								t instanceof HTMLSelectElement
+							) {
+								inputStyles.removeFocus(t);
+							}
+						}}
 					>
-						<ExternalLink className="h-3 w-3" aria-hidden="true" />
-						Advanced filters (services, instances, tags, titles, Plex libraries) and rejection
-						memory are managed in Library Cleanup
-					</Link>
+						{/* Name */}
+						<label className="block">
+							<span className={labelClass}>Rule name</span>
+							<input
+								type="text"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder="e.g., Old low-rated movies"
+								required
+								className={inputClass}
+							/>
+						</label>
 
-					{error && (
-						<div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
-							{error}
+						{/* Enabled */}
+						<div className="flex items-center justify-between">
+							<span className="text-sm font-medium">Enabled</span>
+							<Switch
+								checked={enabled}
+								onCheckedChange={setEnabled}
+								style={enabled ? { backgroundColor: gradient.from } : undefined}
+							/>
 						</div>
-					)}
 
-					<div className="flex justify-end gap-2">
-						<button
-							type="button"
-							onClick={() => onOpenChange(false)}
-							className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+						{/* Retention mode */}
+						<div className="flex items-center justify-between">
+							<div className="flex items-center gap-2">
+								<ShieldOff className="h-4 w-4 text-emerald-400" />
+								<div>
+									<span className="text-sm font-medium">Retention rule</span>
+									<p className="text-xs text-muted-foreground">
+										Protects matching items from other rules
+									</p>
+								</div>
+							</div>
+							<Switch
+								checked={retentionMode}
+								onCheckedChange={setRetentionMode}
+								style={retentionMode ? { backgroundColor: "rgb(16 185 129)" } : undefined}
+							/>
+						</div>
+
+						{/* Action */}
+						<div>
+							<span className={labelClass}>Action when matched</span>
+							<div className="mt-1.5 flex gap-2">
+								{ACTIONS.map((a) => (
+									<button
+										key={a.value}
+										type="button"
+										onClick={() => setAction(a.value)}
+										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+										style={
+											action === a.value
+												? {
+														borderColor: gradient.from,
+														backgroundColor: gradient.fromLight,
+														color: gradient.from,
+													}
+												: { borderColor: "var(--color-border)" }
+										}
+									>
+										{a.label}
+									</button>
+								))}
+							</div>
+							<p className="mt-1 text-xs text-muted-foreground">
+								{ACTIONS.find((a) => a.value === action)?.hint}
+							</p>
+						</div>
+
+						{/* Conditions */}
+						<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+							<span className="text-sm font-medium">Conditions</span>
+							<CriteriaConditionEditor
+								state={editorState}
+								onChange={setEditorState}
+								legalKinds={legalKinds}
+								fieldOptions={fieldOptions}
+								fieldOptionsLoading={fieldOptionsLoading}
+								inputClass={inputClass}
+								labelClass={labelClass}
+							/>
+						</div>
+
+						{/* Advanced-filters disclosure (they live in the full surface) */}
+						<Link
+							href="/library-cleanup"
+							className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
 						>
-							Cancel
-						</button>
-						<button
-							type="submit"
-							disabled={isSaving}
-							className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-60"
-							style={{ background: `linear-gradient(to right, ${gradient.from}, ${gradient.to})` }}
-						>
-							{isSaving ? (
-								<Loader2 className="h-4 w-4 animate-spin" />
-							) : (
-								<Save className="h-4 w-4" />
-							)}
-							{isEdit ? "Save changes" : "Create rule"}
-						</button>
-					</div>
-				</form>
+							<ExternalLink className="h-3 w-3" aria-hidden="true" />
+							Advanced filters (services, instances, tags, titles, Plex libraries) and rejection
+							memory are managed in Library Cleanup
+						</Link>
+
+						{error && (
+							<div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+								{error}
+							</div>
+						)}
+
+						<div className="flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								disabled={isSaving}
+								className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-60"
+								style={{
+									background: `linear-gradient(to right, ${gradient.from}, ${gradient.to})`,
+								}}
+							>
+								{isSaving ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Save className="h-4 w-4" />
+								)}
+								{isEdit ? "Save changes" : "Create rule"}
+							</button>
+						</div>
+					</form>
+				)}
 			</DialogContent>
 		</Dialog>
 	);

--- a/apps/web/src/features/console/components/criteria-condition-editor.tsx
+++ b/apps/web/src/features/console/components/criteria-condition-editor.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * Composer — criteria condition editor (library-cleanup / auto-tag).
+ *
+ * The authoring counterpart of {@link RuleDocumentView}: it edits the CONDITION
+ * half of a criteria rule as a {@link CriteriaEditorState}, which the dialog
+ * down-converts to a v0 payload on save. It generalizes the existing cleanup
+ * dialog's composite builder (single OR all/any group) and reuses the SAME
+ * per-kind param editor (`ConditionParamsFields` + `getDefaultConditionParams`)
+ * so the composer's field UX is identical to the per-domain dialog's — no
+ * second, drifting editor.
+ *
+ * Notifications author `field_match` predicates, not criteria kinds, so that
+ * surface gets its own editor in a later slice; this component is criteria-only.
+ */
+
+import type { CleanupFieldOptionsResponse, CleanupRuleType } from "@arr/shared";
+import { useRef } from "react";
+import { useThemeGradient } from "@/hooks/useThemeGradient";
+import {
+	ConditionParamsFields,
+	getDefaultConditionParams,
+} from "../../rule-criteria/components/condition-params-fields";
+import { humanizeKind } from "../lib/describe-predicate";
+import type { CriteriaEditorState, EditorCondition } from "../lib/rule-document-editor";
+
+interface CriteriaConditionEditorProps {
+	state: CriteriaEditorState;
+	onChange: (next: CriteriaEditorState) => void;
+	/** Kind ids legal for the rule's context (from CONTEXT_KINDS). */
+	legalKinds: readonly string[];
+	fieldOptions: CleanupFieldOptionsResponse | undefined;
+	fieldOptionsLoading: boolean;
+	inputClass: string;
+	labelClass: string;
+}
+
+const DEFAULT_KIND = "age";
+
+export function CriteriaConditionEditor({
+	state,
+	onChange,
+	legalKinds,
+	fieldOptions,
+	fieldOptionsLoading,
+	inputClass,
+	labelClass,
+}: CriteriaConditionEditorProps) {
+	const { gradient } = useThemeGradient();
+	// Monotonic id source for new rows — stable React keys without Date.now.
+	const nextId = useRef(0);
+	const makeCondition = (kind: string = DEFAULT_KIND): EditorCondition => ({
+		id: `new-${nextId.current++}`,
+		kind,
+		params: getDefaultConditionParams(kind as CleanupRuleType),
+	});
+
+	// Kind picker options, context-driven + humanized (no duplicated 52-entry
+	// label map — the read viewer humanizes the same way).
+	const kindOptions = [...legalKinds]
+		.map((kind) => ({ value: kind, label: humanizeKind(kind) }))
+		.sort((a, b) => a.label.localeCompare(b.label));
+
+	const setMode = (mode: CriteriaEditorState["mode"]) => {
+		if (mode === state.mode) return;
+		if (mode === "single") {
+			// Collapse to the first condition (seed one if somehow empty).
+			onChange({ ...state, mode, conditions: [state.conditions[0] ?? makeCondition()] });
+		} else {
+			// Promote the current single condition into the group's first row.
+			onChange({
+				...state,
+				mode,
+				conditions: state.conditions.length ? state.conditions : [makeCondition()],
+			});
+		}
+	};
+
+	const updateCondition = (id: string, patch: Partial<EditorCondition>) => {
+		onChange({
+			...state,
+			conditions: state.conditions.map((c) => (c.id === id ? { ...c, ...patch } : c)),
+		});
+	};
+
+	const changeKind = (id: string, kind: string) => {
+		// New kind → seed its defaults (stale params from the old kind would fail
+		// the new kind's schema).
+		updateCondition(id, { kind, params: getDefaultConditionParams(kind as CleanupRuleType) });
+	};
+
+	const addCondition = () => {
+		onChange({ ...state, conditions: [...state.conditions, makeCondition()] });
+	};
+
+	const removeCondition = (id: string) => {
+		onChange({ ...state, conditions: state.conditions.filter((c) => c.id !== id) });
+	};
+
+	const toggleStyle = (active: boolean) =>
+		active
+			? { borderColor: gradient.from, backgroundColor: gradient.fromLight, color: gradient.from }
+			: { borderColor: "var(--color-border)" };
+
+	const renderRow = (cond: EditorCondition, index: number, removable: boolean) => (
+		<div key={cond.id} className="space-y-2 rounded-lg border border-border/50 bg-card/20 p-3">
+			<div className="flex items-center justify-between">
+				<span className="text-xs font-medium text-muted-foreground">
+					{state.mode === "composite" ? `Condition ${index + 1}` : "Condition"}
+				</span>
+				{removable && (
+					<button
+						type="button"
+						onClick={() => removeCondition(cond.id)}
+						className="text-xs text-muted-foreground transition-colors hover:text-destructive"
+					>
+						Remove
+					</button>
+				)}
+			</div>
+			<select
+				value={cond.kind}
+				onChange={(e) => changeKind(cond.id, e.target.value)}
+				className={inputClass}
+			>
+				{kindOptions.map((opt) => (
+					<option key={opt.value} value={opt.value}>
+						{opt.label}
+					</option>
+				))}
+			</select>
+			<ConditionParamsFields
+				ruleType={cond.kind as CleanupRuleType}
+				params={cond.params}
+				onParamsChange={(params) => updateCondition(cond.id, { params })}
+				fieldOptions={fieldOptions}
+				fieldOptionsLoading={fieldOptionsLoading}
+				inputClass={inputClass}
+				labelClass={labelClass}
+			/>
+		</div>
+	);
+
+	return (
+		<div className="space-y-3">
+			{/* Mode toggle */}
+			<div>
+				<span className={labelClass}>Match</span>
+				<div className="mt-1.5 flex gap-2">
+					<button
+						type="button"
+						onClick={() => setMode("single")}
+						className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+						style={toggleStyle(state.mode === "single")}
+					>
+						Single condition
+					</button>
+					<button
+						type="button"
+						onClick={() => setMode("composite")}
+						className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+						style={toggleStyle(state.mode === "composite")}
+					>
+						Multiple conditions
+					</button>
+				</div>
+			</div>
+
+			{/* all/any operator (composite only) */}
+			{state.mode === "composite" && (
+				<div>
+					<span className={labelClass}>Require</span>
+					<div className="mt-1.5 flex gap-2">
+						{(["all", "any"] as const).map((op) => (
+							<button
+								key={op}
+								type="button"
+								onClick={() => onChange({ ...state, operator: op })}
+								className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+								style={toggleStyle(state.operator === op)}
+							>
+								{op === "all" ? "All conditions (AND)" : "Any condition (OR)"}
+							</button>
+						))}
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{state.operator === "all"
+							? "The item must match every condition below."
+							: "The item matches if any condition below matches."}
+					</p>
+				</div>
+			)}
+
+			{/* Condition rows */}
+			<div className="space-y-2">
+				{state.mode === "single"
+					? state.conditions[0] && renderRow(state.conditions[0], 0, false)
+					: state.conditions.map((cond, i) => renderRow(cond, i, state.conditions.length > 1))}
+			</div>
+
+			{state.mode === "composite" && (
+				<button
+					type="button"
+					onClick={addCondition}
+					className="w-full rounded-lg border border-dashed border-border/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+				>
+					+ Add condition
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/features/console/lib/__tests__/describe-predicate.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/describe-predicate.test.ts
@@ -25,6 +25,35 @@ describe("describePredicate — generic kinds", () => {
 		);
 		expect(result.summary).toBe("Action, Drama");
 	});
+
+	// Fix (a): multi-value kinds get keyed summaries to remove ambiguity.
+	it("keys each value when a kind has more than one value-bearing param", () => {
+		const result = describePredicate(
+			{ kind: "year_range", params: { operator: "between", yearFrom: 2020, yearTo: 2024 } },
+			false,
+		);
+		// Not the ambiguous bare "2020 · 2024".
+		expect(result.summary).toBe("between · year from 2020 · year to 2024");
+	});
+
+	it("keeps the clean value-only form for single-value kinds", () => {
+		const result = describePredicate(
+			{ kind: "year_range", params: { operator: "before", year: 2020 } },
+			false,
+		);
+		expect(result.summary).toBe("before · 2020");
+	});
+
+	it("keys still show in incognito while values stay masked", () => {
+		const result = describePredicate(
+			{ kind: "file_path", params: { operator: "matches", pattern: "/mnt/x", field: "path" } },
+			true,
+		);
+		// Two string values → keyed; keys structural (shown), values masked.
+		expect(result.summary).toContain("pattern •••");
+		expect(result.summary).toContain("field •••");
+		expect(result.summary).not.toContain("/mnt/x");
+	});
 });
 
 describe("describePredicate — field_match (notifications)", () => {

--- a/apps/web/src/features/console/lib/__tests__/rule-document-editor.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/rule-document-editor.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Unit tests for the composer's pure authoring layer — the editor-state ↔
+ * RuleDocument transforms and the strict write-time validation choke point.
+ *
+ * These exercise the populated-data paths a live-verify on an empty dev DB is
+ * blind to (feedback_review_catches_data_dependent_bugs): a composite with two
+ * real conditions, populated array params, an illegal kind, a retired-kind
+ * prefill, and the v0 down-convert parity the live evaluator depends on.
+ */
+
+import type { RuleDocument } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import {
+	buildCriteriaDocument,
+	type CriteriaEditorState,
+	decomposeCriteriaDocument,
+	toCriteriaV0Payload,
+	validateCriteriaEditor,
+} from "../rule-document-editor";
+
+function singleState(kind: string, params: Record<string, unknown>): CriteriaEditorState {
+	return { mode: "single", operator: "all", conditions: [{ id: "c0", kind, params }] };
+}
+
+describe("buildCriteriaDocument", () => {
+	it("single mode → a bare predicate root", () => {
+		const doc = buildCriteriaDocument(singleState("age", { operator: "older_than", days: 30 }));
+		expect(doc).toEqual({
+			version: 1,
+			root: { kind: "age", params: { operator: "older_than", days: 30 } },
+		});
+	});
+
+	it("composite mode → an all/any group of predicates", () => {
+		const state: CriteriaEditorState = {
+			mode: "composite",
+			operator: "any",
+			conditions: [
+				{ id: "a", kind: "age", params: { operator: "older_than", days: 30 } },
+				{ id: "b", kind: "size", params: { operator: "greater_than", sizeGb: 50 } },
+			],
+		};
+		expect(buildCriteriaDocument(state)).toEqual({
+			version: 1,
+			root: {
+				any: [
+					{ kind: "age", params: { operator: "older_than", days: 30 } },
+					{ kind: "size", params: { operator: "greater_than", sizeGb: 50 } },
+				],
+			},
+		});
+	});
+});
+
+describe("decomposeCriteriaDocument", () => {
+	it("predicate root → single mode with one condition", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { kind: "plex_watched_by", params: { operator: "includes_any", userNames: ["bob"] } },
+		};
+		expect(decomposeCriteriaDocument(doc)).toEqual({
+			mode: "single",
+			operator: "all",
+			conditions: [
+				{
+					id: "cond-0",
+					kind: "plex_watched_by",
+					params: { operator: "includes_any", userNames: ["bob"] },
+				},
+			],
+		});
+	});
+
+	it("all group → composite mode, operator all, child predicates", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "age", params: { operator: "older_than", days: 90 } },
+					{ kind: "genre", params: { operator: "includes_any", genres: ["Horror"] } },
+				],
+			},
+		};
+		expect(decomposeCriteriaDocument(doc)).toEqual({
+			mode: "composite",
+			operator: "all",
+			conditions: [
+				{ id: "cond-0", kind: "age", params: { operator: "older_than", days: 90 } },
+				{ id: "cond-1", kind: "genre", params: { operator: "includes_any", genres: ["Horror"] } },
+			],
+		});
+	});
+
+	it("preserves a retired (unavailableKind) predicate verbatim so edit doesn't drop it", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				kind: "tautulli_last_watched",
+				params: { operator: "older_than", days: 30 },
+				unavailableKind: true,
+			},
+		};
+		const state = decomposeCriteriaDocument(doc);
+		expect(state.conditions[0]?.kind).toBe("tautulli_last_watched");
+		// ...and validation then refuses to save it (illegal for the context).
+		expect(validateCriteriaEditor(state, "library-cleanup")).toMatch(/not available/i);
+	});
+
+	it("round-trips build∘decompose for a composite (ignoring row ids)", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				any: [
+					{ kind: "size", params: { operator: "greater_than", sizeGb: 20 } },
+					{ kind: "no_file", params: {} },
+				],
+			},
+		};
+		expect(buildCriteriaDocument(decomposeCriteriaDocument(doc))).toEqual(doc);
+	});
+});
+
+describe("validateCriteriaEditor", () => {
+	it("accepts a valid single condition", () => {
+		expect(
+			validateCriteriaEditor(
+				singleState("age", { operator: "older_than", days: 30 }),
+				"library-cleanup",
+			),
+		).toBeNull();
+	});
+
+	it("accepts a valid two-condition composite", () => {
+		const state: CriteriaEditorState = {
+			mode: "composite",
+			operator: "all",
+			conditions: [
+				{ id: "a", kind: "age", params: { operator: "older_than", days: 90 } },
+				{ id: "b", kind: "plex_watch_count", params: { operator: "less_than", count: 1 } },
+			],
+		};
+		expect(validateCriteriaEditor(state, "library-cleanup")).toBeNull();
+	});
+
+	it("rejects an empty composite at the form (fix c — before the serializer's last-line guard)", () => {
+		const state: CriteriaEditorState = { mode: "composite", operator: "all", conditions: [] };
+		expect(validateCriteriaEditor(state, "library-cleanup")).toMatch(/at least one condition/i);
+	});
+
+	it("rejects a single condition with no chosen kind", () => {
+		const state: CriteriaEditorState = {
+			mode: "single",
+			operator: "all",
+			conditions: [{ id: "c", kind: "", params: {} }],
+		};
+		expect(validateCriteriaEditor(state, "library-cleanup")).toMatch(/choose a condition/i);
+	});
+
+	it("rejects a kind not legal for the context (field_match belongs to notifications)", () => {
+		const state = singleState("field_match", {
+			field: "eventType",
+			operator: "equals",
+			value: "X",
+		});
+		expect(validateCriteriaEditor(state, "library-cleanup")).toMatch(/not available/i);
+	});
+
+	it("rejects params that fail the kind's schema", () => {
+		// age requires a positive integer `days`; -5 fails the schema.
+		const state = singleState("age", { operator: "older_than", days: -5 });
+		expect(validateCriteriaEditor(state, "library-cleanup")).toMatch(/age/i);
+	});
+});
+
+describe("toCriteriaV0Payload", () => {
+	it("down-converts a valid single condition to the v0 route payload", () => {
+		const result = toCriteriaV0Payload(
+			singleState("age", { operator: "older_than", days: 30 }),
+			"library-cleanup",
+		);
+		expect(result.error).toBeUndefined();
+		expect(result.payload).toEqual({
+			ruleType: "age",
+			parameters: { operator: "older_than", days: 30 },
+			operator: null,
+			conditions: null,
+		});
+	});
+
+	it("down-converts a composite to the v0 composite payload (AND/OR mapped)", () => {
+		const state: CriteriaEditorState = {
+			mode: "composite",
+			operator: "any",
+			conditions: [
+				{ id: "a", kind: "age", params: { operator: "older_than", days: 90 } },
+				{ id: "b", kind: "size", params: { operator: "greater_than", sizeGb: 50 } },
+			],
+		};
+		const result = toCriteriaV0Payload(state, "library-cleanup");
+		expect(result.payload).toEqual({
+			ruleType: "composite",
+			parameters: {},
+			operator: "OR",
+			conditions: [
+				{ ruleType: "age", parameters: { operator: "older_than", days: 90 } },
+				{ ruleType: "size", parameters: { operator: "greater_than", sizeGb: 50 } },
+			],
+		});
+	});
+
+	it("returns the validation error instead of a payload when invalid", () => {
+		const result = toCriteriaV0Payload(
+			{ mode: "composite", operator: "all", conditions: [] },
+			"library-cleanup",
+		);
+		expect(result.payload).toBeUndefined();
+		expect(result.error).toMatch(/at least one condition/i);
+	});
+});

--- a/apps/web/src/features/console/lib/describe-predicate.ts
+++ b/apps/web/src/features/console/lib/describe-predicate.ts
@@ -29,6 +29,14 @@ function humanizeToken(token: string): string {
 	return token.replace(/_/g, " ");
 }
 
+/** Param key → readable label: "yearFrom" → "year from", "size_gb" → "size gb". */
+function humanizeKey(key: string): string {
+	return key
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.replace(/_/g, " ")
+		.toLowerCase();
+}
+
 function formatValue(value: unknown, incognito: boolean): string {
 	if (value === null || value === undefined) return "";
 	if (typeof value === "number") return String(value);
@@ -74,11 +82,22 @@ export function describePredicate(
 	}
 
 	// Generic: operator first (structural, always shown), then the rest.
+	//
+	// Fix (a): when a kind carries more than ONE value-bearing param, prefix each
+	// with its humanized key so the summary is unambiguous — "before · 2020" is
+	// clear, but a bare "2020 · 2024" (year_range between) or "10 · 0"
+	// (episode_completion percentage/minSeason) is not. Single-value kinds keep
+	// the clean value-only form. Keys are structural, so they show in incognito;
+	// only VALUES are masked.
 	const operator = typeof params.operator === "string" ? humanizeToken(params.operator) : null;
-	const rest = Object.entries(params)
+	const valued = Object.entries(params)
 		.filter(([key]) => key !== "operator")
-		.map(([, value]) => formatValue(value, incognito))
-		.filter((part) => part.length > 0);
+		.map(([key, value]) => ({ key, text: formatValue(value, incognito) }))
+		.filter((entry) => entry.text.length > 0);
+	const keyed = valued.length > 1;
+	const rest = valued.map((entry) =>
+		keyed ? `${humanizeKey(entry.key)} ${entry.text}` : entry.text,
+	);
 
 	return {
 		label: humanizeKind(kind),

--- a/apps/web/src/features/console/lib/rule-document-editor.ts
+++ b/apps/web/src/features/console/lib/rule-document-editor.ts
@@ -1,0 +1,180 @@
+/**
+ * Composer authoring — the pure state layer for editing a criteria (library-
+ * cleanup / auto-tag) rule's CONDITION half as a v1 {@link RuleDocument}.
+ *
+ * The composer edits an in-memory v1 document, then down-converts to the v0
+ * payload the existing per-domain routes accept (docs/design/unified-rule-
+ * grammar.md §3; serializer = packages/shared/src/rules/v1-serializer.ts). This
+ * module owns the ergonomic middle: a flat editor state the UI binds to, the
+ * two transforms between it and a RuleDocument, and the strict write-time
+ * validation choke point.
+ *
+ * Validation is the FIRST line of the write path (the serializer is the last):
+ * depth ≤ 1, every predicate kind legal for the context, params satisfy the
+ * kind's schema, and — fix (c) — an empty composite is rejected here at the
+ * form so the write path never emits a no-op `{kind:"composite"}` / `{all:[]}`.
+ *
+ * Deliberately React-free so it unit-tests without a DOM. `getDefaultCondition
+ * Params` (the per-kind seed) lives in the UI layer; this module never seeds.
+ */
+
+import {
+	type CriteriaV0Payload,
+	isKindLegalForContext,
+	isRulePredicate,
+	type RuleContextId,
+	type RuleDocument,
+	type RuleNode,
+	ruleParamSchemaMap,
+	serializeCriteriaDocumentToV0,
+	validateV1Depth,
+} from "@arr/shared";
+import { humanizeKind } from "./describe-predicate";
+
+// ── Editor state ────────────────────────────────────────────────────
+
+/** One authored predicate row. `id` is a stable React key, never serialized. */
+export interface EditorCondition {
+	id: string;
+	kind: string;
+	params: Record<string, unknown>;
+}
+
+/**
+ * Single = a lone predicate (v0 `operator`/`conditions` are null). Composite =
+ * an all/any group. Mirrors the existing cleanup dialog's isComposite +
+ * compositeOperator + conditions[] shape, so the reused ConditionParamsFields
+ * binds unchanged.
+ */
+export type EditorMode = "single" | "composite";
+
+export interface CriteriaEditorState {
+	mode: EditorMode;
+	/** all = AND, any = OR. Only meaningful in composite mode. */
+	operator: "all" | "any";
+	conditions: EditorCondition[];
+}
+
+// ── Transforms ──────────────────────────────────────────────────────
+
+/**
+ * Editor state → v1 document. Single mode uses the first condition as the root
+ * predicate; composite wraps the conditions in an all/any group. Callers must
+ * validate first ({@link validateCriteriaEditor}); this assumes a well-formed
+ * state (single has ≥1 condition).
+ */
+export function buildCriteriaDocument(state: CriteriaEditorState): RuleDocument {
+	if (state.mode === "single") {
+		const first = state.conditions[0];
+		return {
+			version: 1,
+			root: { kind: first?.kind ?? "", params: first?.params ?? {} },
+		};
+	}
+
+	const children: RuleNode[] = state.conditions.map((c) => ({ kind: c.kind, params: c.params }));
+	return {
+		version: 1,
+		root: state.operator === "all" ? { all: children } : { any: children },
+	};
+}
+
+/**
+ * v1 document → editor state (edit prefill). A predicate root is single mode; a
+ * group is composite with operator + child predicates. Retired-kind predicates
+ * (annotated `unavailableKind` by the read API) are KEPT verbatim so the edit
+ * preserves them — validation later forces the operator to fix them before save
+ * rather than silently dropping a condition.
+ */
+export function decomposeCriteriaDocument(doc: RuleDocument): CriteriaEditorState {
+	const root = doc.root;
+	if (isRulePredicate(root)) {
+		return {
+			mode: "single",
+			operator: "all",
+			conditions: [{ id: "cond-0", kind: root.kind, params: root.params }],
+		};
+	}
+
+	const isAll = "all" in root;
+	const children = isAll ? root.all : root.any;
+	return {
+		mode: "composite",
+		operator: isAll ? "all" : "any",
+		conditions: children.map((child, i) => ({
+			id: `cond-${i}`,
+			// Depth-1: children are predicates. A stray nested group (shouldn't
+			// occur from the read API) collapses to an empty predicate row that
+			// validation then flags.
+			kind: isRulePredicate(child) ? child.kind : "",
+			params: isRulePredicate(child) ? child.params : {},
+		})),
+	};
+}
+
+// ── Validation (the write-path first line) ──────────────────────────
+
+/**
+ * Strict pre-serialize validation for a criteria editor state under its
+ * context. Returns the first human-readable error, or null when the state is a
+ * legal, serializable rule.
+ *
+ * Order: structural (condition counts / empty composite = fix c) → depth →
+ * per-predicate kind legality (tier-1 write-strict, §2.2) → per-predicate param
+ * schema. Mirrors the server's own write-time checks (defense in depth).
+ */
+export function validateCriteriaEditor(
+	state: CriteriaEditorState,
+	context: RuleContextId,
+): string | null {
+	// Structural — an authored rule must actually match something.
+	if (state.mode === "single") {
+		const first = state.conditions[0];
+		if (!first || !first.kind) return "Choose a condition type.";
+	} else if (state.conditions.length === 0) {
+		// Fix (c): reject the empty composite at the form, before the serializer's
+		// last-line guard. An empty group serializes to a no-op that never matches.
+		return "Add at least one condition, or switch to a single condition.";
+	}
+
+	const doc = buildCriteriaDocument(state);
+
+	const depthError = validateV1Depth(doc);
+	if (depthError) return depthError;
+
+	// Per-predicate legality + params.
+	const nodes: EditorCondition[] = state.conditions;
+	for (const cond of nodes) {
+		const label = cond.kind ? humanizeKind(cond.kind) : "This condition";
+		if (!cond.kind) return "Choose a type for every condition.";
+		if (!isKindLegalForContext(context, cond.kind)) {
+			return `"${label}" is not available for this rule type — remove or replace it.`;
+		}
+		const schema = ruleParamSchemaMap[cond.kind];
+		if (schema) {
+			const result = schema.safeParse(cond.params);
+			if (!result.success) {
+				const issue = result.error.issues[0];
+				const where = issue?.path.length ? ` (${issue.path.join(".")})` : "";
+				const message = issue?.message ?? "invalid parameters";
+				return `${label}: ${message}${where}.`;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Convenience for the save path: validate, then down-convert to the v0 payload
+ * the per-domain create/update routes accept. Returns either the payload or the
+ * first validation error — never both.
+ */
+export function toCriteriaV0Payload(
+	state: CriteriaEditorState,
+	context: RuleContextId,
+): { payload: CriteriaV0Payload; error?: undefined } | { payload?: undefined; error: string } {
+	const error = validateCriteriaEditor(state, context);
+	if (error) return { error };
+	return { payload: serializeCriteriaDocumentToV0(buildCriteriaDocument(state)) };
+}


### PR DESCRIPTION
## What & why

The Operator Console **Automation tab** gains **create + edit of library-cleanup rules** — the composer arc's flagship WRITE path (charter §5.2). It authors the condition half as an in-memory **v1 `RuleDocument`** (reusing the shared `ConditionParamsFields` editor + an all/any composite toggle), then on save validates strictly, **down-converts v1→v0** via `serializeCriteriaDocumentToV0` (PR-3a, #561), and POST/PUTs through the **existing** cleanup api-client. The live evaluator keeps reading v0 — the composer writes the **same rows the per-domain dialog would** (round-trip parity).

This is the first authoring slice; auto-tag and notifications follow (each its own PR).

## Design decisions (ratified 2026-07-07)
- **Storage** = down-convert v1→v0, engine untouched (design doc §3).
- **Action scope** = core action only (name / enabled / action / retentionMode + conditions). Advanced filters (service / instance / tag / title / plex-library) and rejection-memory are managed in Library Cleanup; a note + deep link points there.
- **Incognito** = rule NAMES stay visible (consistent with the app); param VALUES stay masked in the read viewer.

## What's in it
- `lib/rule-document-editor.ts` — pure editor-state ↔ `RuleDocument` transforms + the write-time validation choke point (depth ≤ 1, `isKindLegalForContext`, `ruleParamSchemaMap.safeParse`). Reuses `@arr/shared` schemas so form validation can't drift from what the API accepts.
- `components/criteria-condition-editor.tsx` — reusable single/composite condition builder; reuses `ConditionParamsFields` + `getDefaultConditionParams` (no second, drifting editor).
- `components/cleanup-rule-composer-dialog.tsx` — the create/edit dialog.
- `automation-panel.tsx` — New / Edit affordances + lazy dialog.

## Deferred fixes landed
- **(a)** `describe-predicate`: keyed summary for multi-value kinds (`year_range` now reads `between · year from 2020 · year to 2024`, no longer the ambiguous `2020 · 2024`).
- **(c)** empty composite rejected at **form** validation (the serializer was the last line; the form is now the first).

## Verification
- **turbo typecheck** clean (3/3); **596 web tests** pass; **lint** 0 errors.
- **24 new tests**, incl. a rendered dialog test with a populated two-condition composite fixture.
- **Live-verified** (forged session, seeded rule): authored a composite in the composer → confirmed it lands as the exact v0 `ruleType:"composite"` row a per-domain dialog writes → confirmed it round-trips back into the composer for edit.

## Review + live-verify caught two real bugs (fixed in the 2nd commit)
1. **Partial-PUT default-clobber** (live-verify): `updateCleanupRuleSchema = base.partial()`, and `z.partial()` doesn't strip `.default()`, so an omitted `priority`/`useGlobalRejectionMemory` was re-injected and overwrote the stored value; and the edit form could submit composer defaults before the async config join resolved (silently flipping a live `unmonitor` rule to `delete`). Fixed with an edit-readiness gate + echoing the defaulted fields back on save. Live-verified: editing only the name preserves action, retentionMode, priority, and all advanced filters.
2. **Retired-kind edit dead-end** (review agent): a rule with an unavailable kind is parseable but not representable in the composer's picker — Edit is now offered only when `unavailableKinds` is empty; repair routes to Library Cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)