### PR TITLE
feat(composer): auto-tag authoring slice — reuse the criteria write path (PR-3c)

### DIFF
--- a/apps/web/src/features/console/components/__tests__/auto-tag-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/auto-tag-rule-composer-dialog.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Rendered tests for the composer's auto-tag create/edit dialog (PR-3c).
+ * Mirrors the cleanup dialog tests, adapted for auto-tag: the action half is a
+ * required `tagName`, update is PATCH `{id, payload}`, and — unlike cleanup —
+ * there are NO defaulted fields to echo (auto-tag's update schema has none), so
+ * the edit payload carries only composer-owned fields.
+ */
+
+import type { AutomationRulesResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+// jsdom polyfills for Radix Dialog
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+
+// ── Mocks ───────────────────────────────────────────────────────────
+
+const createMutate = vi.fn().mockResolvedValue({});
+const updateMutate = vi.fn().mockResolvedValue({});
+
+let automationData: AutomationRulesResponse = { rules: [] };
+let autoTagRules: Array<Record<string, unknown>> = [];
+
+vi.mock("@/hooks/api/useAutoTag", () => ({
+	useAutoTagRules: () => ({ data: autoTagRules }),
+	useCreateAutoTagRule: () => ({ mutateAsync: createMutate, isPending: false }),
+	useUpdateAutoTagRule: () => ({ mutateAsync: updateMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/api/useLibraryCleanup", () => ({
+	useCleanupFieldOptions: () => ({ data: { hasPlex: false }, isLoading: false }),
+}));
+
+vi.mock("@/hooks/api/useAutomation", () => ({
+	useAutomationRules: () => ({ data: automationData }),
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "#3b82f6", to: "#8b5cf6", fromLight: "#3b82f610", fromMuted: "#3b82f630" },
+	}),
+}));
+
+vi.mock("@/lib/theme-input-styles", () => ({
+	getInputStyles: () => ({ base: "test-input", applyFocus: vi.fn(), removeFocus: vi.fn() }),
+}));
+
+// Import after mocks
+import { AutoTagRuleComposerDialog } from "../auto-tag-rule-composer-dialog";
+
+function wrapper(ui: ReactNode) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<IncognitoProvider>{ui}</IncognitoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+beforeEach(() => {
+	createMutate.mockClear();
+	updateMutate.mockClear();
+	automationData = { rules: [] };
+	autoTagRules = [];
+});
+
+describe("AutoTagRuleComposerDialog — create", () => {
+	it("POSTs name + enabled + tagName + the serialized single-condition quartet", async () => {
+		wrapper(<AutoTagRuleComposerDialog open onOpenChange={() => {}} />);
+
+		fireEvent.change(screen.getByPlaceholderText(/tag kids movies/i), {
+			target: { value: "Kids content" },
+		});
+		fireEvent.change(screen.getByPlaceholderText(/^e\.g\., kids$/i), { target: { value: "kids" } });
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+
+		await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+		expect(createMutate).toHaveBeenCalledWith({
+			name: "Kids content",
+			enabled: true,
+			tagName: "kids",
+			ruleType: "age",
+			parameters: { operator: "older_than", days: 30 },
+			operator: null,
+			conditions: null,
+		});
+	});
+
+	it("blocks save on a whitespace-only tag (native `required` passes it, the trim guard catches it)", async () => {
+		wrapper(<AutoTagRuleComposerDialog open onOpenChange={() => {}} />);
+		fireEvent.change(screen.getByPlaceholderText(/tag kids movies/i), {
+			target: { value: "Named but no tag" },
+		});
+		fireEvent.change(screen.getByPlaceholderText(/^e\.g\., kids$/i), { target: { value: "   " } });
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+		await screen.findByText(/enter the tag to apply/i);
+		expect(createMutate).not.toHaveBeenCalled();
+	});
+});
+
+describe("AutoTagRuleComposerDialog — edit", () => {
+	beforeEach(() => {
+		automationData = {
+			rules: [
+				{
+					id: "at-1",
+					name: "Old anime",
+					enabled: true,
+					context: "auto-tag",
+					document: {
+						version: 1,
+						root: {
+							all: [
+								{ kind: "age", params: { operator: "older_than", days: 365 } },
+								{ kind: "genre", params: { operator: "includes_any", genres: ["Anime"] } },
+							],
+						},
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+			],
+		};
+		autoTagRules = [
+			{
+				id: "at-1",
+				name: "Old anime",
+				enabled: true,
+				tagName: "archive",
+				// Scope filters that must survive an omitting PATCH.
+				serviceFilter: ["sonarr"],
+				excludeTitles: ["Keep me"],
+			},
+		];
+	});
+
+	it("prefills name + tagName + both composite conditions from the joined sources", async () => {
+		wrapper(<AutoTagRuleComposerDialog open onOpenChange={() => {}} editRuleId="at-1" />);
+		expect(await screen.findByDisplayValue("Old anime")).toBeTruthy();
+		expect(screen.getByDisplayValue("archive")).toBeTruthy();
+		expect(screen.getByText(/condition 1/i)).toBeTruthy();
+		expect(screen.getByText(/condition 2/i)).toBeTruthy();
+	});
+
+	it("PATCHes {id, payload} with composer-owned fields only; scope filters omitted (preserved)", async () => {
+		wrapper(<AutoTagRuleComposerDialog open onOpenChange={() => {}} editRuleId="at-1" />);
+		await screen.findByDisplayValue("Old anime");
+
+		fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+		const arg = updateMutate.mock.calls[0]?.[0];
+		expect(arg.id).toBe("at-1");
+		expect(arg.payload).toEqual({
+			name: "Old anime",
+			enabled: true,
+			tagName: "archive",
+			ruleType: "composite",
+			parameters: {},
+			operator: "AND",
+			conditions: [
+				{ ruleType: "age", parameters: { operator: "older_than", days: 365 } },
+				{ ruleType: "genre", parameters: { operator: "includes_any", genres: ["Anime"] } },
+			],
+		});
+		// No defaulted fields exist on auto-tag's schema, so none are echoed; scope
+		// filters are omitted → the PATCH route's undefined-preserves them.
+		expect(arg.payload).not.toHaveProperty("serviceFilter");
+		expect(arg.payload).not.toHaveProperty("excludeTitles");
+		expect(arg.payload).not.toHaveProperty("priority");
+	});
+
+	it("shows a loading state until the auto-tag rule join resolves", async () => {
+		autoTagRules = []; // summary present, rule not yet loaded → editDataReady false
+		wrapper(<AutoTagRuleComposerDialog open onOpenChange={() => {}} editRuleId="at-1" />);
+		expect(await screen.findByText(/loading rule/i)).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /save changes/i })).toBeNull();
+		expect(updateMutate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/console/components/auto-tag-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/auto-tag-rule-composer-dialog.tsx
@@ -1,0 +1,329 @@
+"use client";
+
+/**
+ * Composer — create/edit dialog for an auto-tag rule (charter §5.2, second
+ * authoring slice, PR-3c).
+ *
+ * Same shape as the cleanup composer, minus the cleanup-specific action half:
+ * auto-tag's action is a single `tagName`. It reuses the shared criteria editor
+ * ({@link CriteriaConditionEditor}), the pure editor/validation layer, and the
+ * v1→v0 down-convert — auto-tag shares the criteria vocabulary with cleanup, so
+ * `serializeCriteriaDocumentToV0` produces the exact v0 payload the auto-tag
+ * route accepts, and the live evaluator keeps reading v0.
+ *
+ * Two PR-3b lessons carry over; one does NOT:
+ *  - editDataReady gate (async join): still needed — `tagName` lives on the full
+ *    AutoTagRule (useAutoTagRules), joined by id with the automation summary's
+ *    document. Don't render/submit until both load, or a save would seed
+ *    defaults over the real values.
+ *  - retired-kind edit gate: enforced by the panel (see automation-panel).
+ *  - z.partial() default-clobber does NOT apply: auto-tag's update schema has NO
+ *    `.default()` fields, so omitted filters parse to `undefined` and the PATCH
+ *    route preserves them. No defaulted-field echo needed.
+ */
+
+import type { CreateAutoTagRuleRequest, UpdateAutoTagRuleRequest } from "@arr/shared";
+import { CONTEXT_KINDS } from "@arr/shared";
+import { useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Loader2, Save } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import {
+	useAutoTagRules,
+	useCreateAutoTagRule,
+	useUpdateAutoTagRule,
+} from "@/hooks/api/useAutoTag";
+import { useCleanupFieldOptions } from "@/hooks/api/useLibraryCleanup";
+import { useThemeGradient } from "@/hooks/useThemeGradient";
+import { getErrorMessage } from "@/lib/error-utils";
+import { automationKeys } from "@/lib/query-keys";
+import { getInputStyles } from "@/lib/theme-input-styles";
+import { useAutomationRules } from "../../../hooks/api/useAutomation";
+import { getDefaultConditionParams } from "../../rule-criteria/components/condition-params-fields";
+import {
+	type CriteriaEditorState,
+	decomposeCriteriaDocument,
+	toCriteriaV0Payload,
+} from "../lib/rule-document-editor";
+import { CriteriaConditionEditor } from "./criteria-condition-editor";
+
+interface AutoTagRuleComposerDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	/** Rule id to edit; omit/null for create mode. */
+	editRuleId?: string | null;
+}
+
+function freshEditorState(): CriteriaEditorState {
+	return {
+		mode: "single",
+		operator: "all",
+		conditions: [{ id: "seed-0", kind: "age", params: getDefaultConditionParams("age") }],
+	};
+}
+
+export function AutoTagRuleComposerDialog({
+	open,
+	onOpenChange,
+	editRuleId,
+}: AutoTagRuleComposerDialogProps) {
+	const { gradient } = useThemeGradient();
+	const queryClient = useQueryClient();
+	const isEdit = !!editRuleId;
+
+	const { data: automation } = useAutomationRules();
+	const { data: autoTagRules } = useAutoTagRules();
+	const { data: fieldOptions, isLoading: fieldOptionsLoading } = useCleanupFieldOptions();
+	const createRule = useCreateAutoTagRule();
+	const updateRule = useUpdateAutoTagRule();
+
+	// Join by id: automation summary → v1 document (conditions); the auto-tag rule
+	// → the action half (tagName) the read API omits. name/enabled from either.
+	const summary = useMemo(
+		() =>
+			editRuleId
+				? automation?.rules.find((r) => r.context === "auto-tag" && r.id === editRuleId)
+				: undefined,
+		[automation, editRuleId],
+	);
+	const rule = useMemo(
+		() => (editRuleId ? autoTagRules?.find((r) => r.id === editRuleId) : undefined),
+		[autoTagRules, editRuleId],
+	);
+
+	// Edit mode needs BOTH joined sources before the form is meaningful (see the
+	// PR-3b async-join lesson). Initializing/saving before `rule` resolves would
+	// prefill an empty tagName and could clear it on save.
+	const editDataReady = !isEdit || (Boolean(summary) && Boolean(rule));
+
+	const [name, setName] = useState("");
+	const [enabled, setEnabled] = useState(true);
+	const [tagName, setTagName] = useState("");
+	const [editorState, setEditorState] = useState<CriteriaEditorState>(freshEditorState);
+	const [error, setError] = useState<string | null>(null);
+
+	const legalKinds = useMemo(() => [...CONTEXT_KINDS["auto-tag"]], []);
+
+	useEffect(() => {
+		if (!open) return;
+		if (isEdit && !editDataReady) return;
+		setError(null);
+		if (isEdit) {
+			setName(summary?.name ?? rule?.name ?? "");
+			setEnabled(summary?.enabled ?? rule?.enabled ?? true);
+			setTagName(rule?.tagName ?? "");
+			setEditorState(
+				summary?.document ? decomposeCriteriaDocument(summary.document) : freshEditorState(),
+			);
+		} else {
+			setName("");
+			setEnabled(true);
+			setTagName("");
+			setEditorState(freshEditorState());
+		}
+	}, [open, isEdit, editDataReady, summary, rule]);
+
+	const inputStyles = getInputStyles(gradient);
+	const inputClass = `${inputStyles.base} focus:outline-hidden`;
+	const labelClass = "mb-1 block text-xs text-muted-foreground";
+
+	const isSaving = createRule.isPending || updateRule.isPending;
+
+	const handleSubmit = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (isSaving) return;
+
+		if (!name.trim()) {
+			setError("Give the rule a name.");
+			return;
+		}
+		if (!tagName.trim()) {
+			setError("Enter the tag to apply.");
+			return;
+		}
+
+		// Validate + down-convert the v1 document to the v0 route payload. The full
+		// condition quartet is always sent together so switching single↔composite
+		// clears any stale operator/conditions.
+		const result = toCriteriaV0Payload(editorState, "auto-tag");
+		if (!result.payload) {
+			setError(result.error ?? "This rule isn't valid yet.");
+			return;
+		}
+		const payload = result.payload;
+		setError(null);
+
+		// The composer owns name/enabled/tagName + the condition quartet. The scope
+		// filters (serviceFilter/instanceFilter/excludeTags/excludeTitles/
+		// plexLibraryFilter) are omitted; auto-tag's update schema has no defaults,
+		// so the PATCH route preserves them (no echo needed — unlike cleanup).
+		const base = {
+			name: name.trim(),
+			enabled,
+			tagName: tagName.trim(),
+			ruleType: payload.ruleType,
+			parameters: payload.parameters,
+			operator: payload.operator,
+			conditions: payload.conditions,
+		};
+
+		try {
+			if (isEdit && editRuleId) {
+				await updateRule.mutateAsync({ id: editRuleId, payload: base as UpdateAutoTagRuleRequest });
+			} else {
+				await createRule.mutateAsync(base as CreateAutoTagRuleRequest);
+			}
+			// The auto-tag hooks invalidate autoTagKeys.rules; the Automation tab
+			// reads its own key, so refresh it too.
+			await queryClient.invalidateQueries({ queryKey: automationKeys.all });
+			onOpenChange(false);
+		} catch (err) {
+			setError(getErrorMessage(err, "Could not save the rule."));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>{isEdit ? "Edit Auto-Tag Rule" : "New Auto-Tag Rule"}</DialogTitle>
+					<DialogDescription>
+						Author the matching conditions and the tag to apply. This writes a real Auto-Tag rule.
+					</DialogDescription>
+				</DialogHeader>
+
+				{isEdit && !editDataReady ? (
+					<div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+						Loading rule…
+					</div>
+				) : (
+					<form
+						onSubmit={handleSubmit}
+						className="mt-2 space-y-5"
+						onFocus={(e) => {
+							const t = e.target;
+							if (
+								(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+								t instanceof HTMLSelectElement
+							) {
+								inputStyles.applyFocus(t);
+							}
+						}}
+						onBlur={(e) => {
+							const t = e.target;
+							if (
+								(t instanceof HTMLInputElement && t.type !== "checkbox") ||
+								t instanceof HTMLSelectElement
+							) {
+								inputStyles.removeFocus(t);
+							}
+						}}
+					>
+						{/* Name */}
+						<label className="block">
+							<span className={labelClass}>Rule name</span>
+							<input
+								type="text"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder="e.g., Tag kids movies"
+								required
+								className={inputClass}
+							/>
+						</label>
+
+						{/* Enabled */}
+						<div className="flex items-center justify-between">
+							<span className="text-sm font-medium">Enabled</span>
+							<Switch
+								checked={enabled}
+								onCheckedChange={setEnabled}
+								style={enabled ? { backgroundColor: gradient.from } : undefined}
+							/>
+						</div>
+
+						{/* Action = the tag to apply */}
+						<label className="block">
+							<span className={labelClass}>Tag to apply</span>
+							<input
+								type="text"
+								value={tagName}
+								onChange={(e) => setTagName(e.target.value)}
+								placeholder="e.g., kids"
+								required
+								className={inputClass}
+							/>
+							<p className="mt-1 text-xs text-muted-foreground">
+								Applied to every matching item on its source service.
+							</p>
+						</label>
+
+						{/* Conditions */}
+						<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+							<span className="text-sm font-medium">Conditions</span>
+							<CriteriaConditionEditor
+								state={editorState}
+								onChange={setEditorState}
+								legalKinds={legalKinds}
+								fieldOptions={fieldOptions}
+								fieldOptionsLoading={fieldOptionsLoading}
+								inputClass={inputClass}
+								labelClass={labelClass}
+							/>
+						</div>
+
+						{/* Advanced-filters disclosure (managed in the full surface) */}
+						<Link
+							href="/auto-tag"
+							className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+						>
+							<ExternalLink className="h-3 w-3" aria-hidden="true" />
+							Advanced filters (services, instances, tags, titles, Plex libraries) are managed in
+							Auto-Tagger
+						</Link>
+
+						{error && (
+							<div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-xs text-red-400">
+								{error}
+							</div>
+						)}
+
+						<div className="flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								disabled={isSaving}
+								className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-60"
+								style={{
+									background: `linear-gradient(to right, ${gradient.from}, ${gradient.to})`,
+								}}
+							>
+								{isSaving ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Save className="h-4 w-4" />
+								)}
+								{isEdit ? "Save changes" : "Create rule"}
+							</button>
+						</div>
+					</form>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -30,6 +30,15 @@ const CleanupRuleComposerDialog = lazy(() =>
 	})),
 );
 
+const AutoTagRuleComposerDialog = lazy(() =>
+	import("./auto-tag-rule-composer-dialog").then((m) => ({
+		default: m.AutoTagRuleComposerDialog,
+	})),
+);
+
+/** Contexts this composer can author (grows as slices land). */
+type AuthorableContext = "library-cleanup" | "auto-tag";
+
 const CONTEXT_LABELS: Record<RuleContextId, string> = {
 	"library-cleanup": "Library Cleanup",
 	"auto-tag": "Auto-Tag",
@@ -112,10 +121,12 @@ export function AutomationPanel() {
 	const { data, isLoading, isError, error, refetch } = useAutomationRules();
 	const [incognito] = useIncognitoMode();
 	// { open, editRuleId } — editRuleId null = create mode.
-	const [composer, setComposer] = useState<{ open: boolean; editRuleId: string | null }>({
-		open: false,
-		editRuleId: null,
-	});
+	// context selects which per-domain composer dialog opens; editRuleId null = create.
+	const [composer, setComposer] = useState<{
+		open: boolean;
+		context: AuthorableContext;
+		editRuleId: string | null;
+	}>({ open: false, context: "library-cleanup", editRuleId: null });
 
 	const rules = data?.rules ?? [];
 	const groups = CONTEXT_ORDER.map((context) => ({
@@ -123,21 +134,35 @@ export function AutomationPanel() {
 		rules: rules.filter((rule) => rule.context === context),
 	})).filter((group) => group.rules.length > 0);
 
-	const openCreate = () => setComposer({ open: true, editRuleId: null });
-	const openEdit = (id: string) => setComposer({ open: true, editRuleId: id });
+	const openCreate = (context: AuthorableContext) =>
+		setComposer({ open: true, context, editRuleId: null });
+	const openEdit = (context: AuthorableContext, id: string) =>
+		setComposer({ open: true, context, editRuleId: id });
+
+	// Only these contexts have a composer authoring dialog in this slice.
+	const editableContext = (context: RuleContextId): AuthorableContext | null =>
+		context === "library-cleanup" || context === "auto-tag" ? context : null;
 
 	return (
 		<div className="space-y-4">
-			{/* Authoring entry point. Scoped to library-cleanup this slice; the
-			    button grows a context selector as auto-tag / notifications land. */}
-			<div className="flex items-center justify-end">
+			{/* Authoring entry points — one per composer-capable context (grows as
+			    notifications lands). */}
+			<div className="flex flex-wrap items-center justify-end gap-2">
 				<button
 					type="button"
-					onClick={openCreate}
+					onClick={() => openCreate("library-cleanup")}
 					className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 bg-card/50 px-3 py-1.5 text-sm font-medium backdrop-blur-xs transition-colors hover:bg-card/80"
 				>
 					<Plus className="h-4 w-4" aria-hidden="true" />
 					New cleanup rule
+				</button>
+				<button
+					type="button"
+					onClick={() => openCreate("auto-tag")}
+					className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 bg-card/50 px-3 py-1.5 text-sm font-medium backdrop-blur-xs transition-colors hover:bg-card/80"
+				>
+					<Plus className="h-4 w-4" aria-hidden="true" />
+					New auto-tag rule
 				</button>
 			</div>
 
@@ -152,7 +177,7 @@ export function AutomationPanel() {
 					icon: Workflow,
 					title: "No automation rules yet",
 					description:
-						"Create a cleanup rule here, or add rules in Auto-Tag and Notifications — they all appear here, unified.",
+						"Create a cleanup or auto-tag rule here, or add notification rules — they all appear here, unified.",
 				}}
 			>
 				<div className="space-y-6">
@@ -170,17 +195,18 @@ export function AutomationPanel() {
 										key={`${rule.context}-${rule.id}`}
 										rule={rule}
 										incognito={incognito}
-										onEdit={
-											// Composer-editable only for library-cleanup rules whose kinds
-											// are ALL still available. A rule referencing a retired kind
-											// (unavailableKinds non-empty) is parseable but the composer's
-											// kind picker can't represent it — editing would be a dead-end
-											// (picker shows a wrong kind, save is blocked). Route those to
-											// the Library Cleanup surface to repair instead.
-											rule.context === "library-cleanup" && rule.unavailableKinds.length === 0
-												? () => openEdit(rule.id)
-												: undefined
-										}
+										onEdit={(() => {
+											// Composer-editable only for contexts with an authoring dialog
+											// AND rules whose kinds are ALL still available. A rule with a
+											// retired kind (unavailableKinds non-empty) is parseable but the
+											// composer's kind picker can't represent it — editing would be a
+											// dead-end (picker shows a wrong kind, save is blocked). Route
+											// those to the domain surface to repair instead.
+											const ctx = editableContext(rule.context);
+											return ctx && rule.unavailableKinds.length === 0
+												? () => openEdit(ctx, rule.id)
+												: undefined;
+										})()}
 									/>
 								))}
 							</div>
@@ -191,11 +217,19 @@ export function AutomationPanel() {
 
 			{composer.open && (
 				<Suspense>
-					<CleanupRuleComposerDialog
-						open={composer.open}
-						onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
-						editRuleId={composer.editRuleId}
-					/>
+					{composer.context === "library-cleanup" ? (
+						<CleanupRuleComposerDialog
+							open={composer.open}
+							onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
+							editRuleId={composer.editRuleId}
+						/>
+					) : (
+						<AutoTagRuleComposerDialog
+							open={composer.open}
+							onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
+							editRuleId={composer.editRuleId}
+						/>
+					)}
 				</Suspense>
 			)}
 		</div>


### PR DESCRIPTION
## What & why

The Operator Console **Automation tab** now creates + edits **auto-tag rules** — the composer arc's second authoring slice (after library-cleanup, #562). It **reuses the criteria substrate verbatim** (`rule-document-editor` + `CriteriaConditionEditor` from PR-3b) since auto-tag shares the criteria vocabulary with library-cleanup. On save it down-converts v1→v0 via `serializeCriteriaDocumentToV0` and POST/PATCHes through the existing auto-tag api-client; the live evaluator keeps reading v0 (round-trip parity).

## What's in it
- `components/auto-tag-rule-composer-dialog.tsx` — same shape as the cleanup composer, minus the cleanup-specific action half. Auto-tag's action is a single **required `tagName`**; no retention/rejection/priority.
- `automation-panel.tsx` — composer state gains a `context`; **two "New rule" buttons** (cleanup + auto-tag); the Edit affordance now covers both contexts (still gated on `unavailableKinds.length === 0`); the correct lazy dialog renders per context.

## PR-3b lessons applied
- **editDataReady gate** (async join): `tagName` lives on the full `AutoTagRule` (`useAutoTagRules`), joined by id with the automation summary's document — the form doesn't render/submit until both load.
- **`z.partial()` default-clobber does NOT apply here**: auto-tag's update schema has **no `.default()` fields**, so omitted scope filters parse to `undefined` and the PATCH route preserves them — no defaulted-field echo needed (documented inline, confirmed by the review agent).
- **retired-kind edit gate** extended to the auto-tag context.

## Verification
- **turbo typecheck** 3/3, **601 web tests** (5 new), **lint** 0 errors.
- **Live-verified** (forged session): authored a `genre` auto-tag rule → confirmed the exact v0 row (`tagName` + array params) + v1 round-trip → edited the name → confirmed `tagName`, the condition, and both scope filters (`serviceFilter`, `excludeTitles`) all preserved.
- **Review agent**: no high-confidence issues; all six populated-data concerns verified safe (schema-has-no-defaults claim confirmed against source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)