### PR TITLE
feat(composer): notifications authoring slice (PR-3d)

### DIFF
--- a/apps/api/src/routes/__tests__/notifications.test.ts
+++ b/apps/api/src/routes/__tests__/notifications.test.ts
@@ -1,4 +1,4 @@
-import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // Module-level mocks
@@ -7,7 +7,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 const { mockNotificationService, mockGetDeliveryStatistics } = vi.hoisted(() => ({
 	mockNotificationService: {
 		testChannel: vi.fn().mockResolvedValue(undefined),
-		getDecryptedConfig: vi.fn().mockResolvedValue({ webhookUrl: "https://discord.com/api/webhooks/123" }),
+		getDecryptedConfig: vi
+			.fn()
+			.mockResolvedValue({ webhookUrl: "https://discord.com/api/webhooks/123" }),
 		getChannelTypes: vi.fn().mockReturnValue([]),
 	},
 	mockGetDeliveryStatistics: vi.fn().mockResolvedValue({ total: 0, sent: 0, failed: 0 }),
@@ -23,7 +25,12 @@ vi.mock("../../lib/notifications/statistics.js", () => ({
 
 import Fastify from "fastify";
 import { registerNotificationRoutes } from "../notifications.js";
-import { setupAuthInjection, createInjectAuthenticated, createMockEncryptor, registerTestErrorHandler } from "./test-helpers.js";
+import {
+	createInjectAuthenticated,
+	createMockEncryptor,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "./test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Test data factories
@@ -59,7 +66,9 @@ function makeRule(overrides: Record<string, unknown> = {}) {
 		enabled: true,
 		priority: 0,
 		action: "suppress",
-		conditions: JSON.stringify([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]),
+		conditions: JSON.stringify([
+			{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+		]),
 		targetChannelIds: null,
 		throttleMinutes: null,
 		createdAt: now,
@@ -152,9 +161,12 @@ beforeEach(async () => {
 	app = Fastify();
 
 	app.decorate("prisma", mockPrisma);
-	app.decorate("encryptor", createMockEncryptor(
-		JSON.stringify({ webhookUrl: "https://discord.com/api/webhooks/original" }),
-	));
+	app.decorate(
+		"encryptor",
+		createMockEncryptor(
+			JSON.stringify({ webhookUrl: "https://discord.com/api/webhooks/original" }),
+		),
+	);
 	app.decorate("notificationService", mockNotificationService);
 
 	setupAuthInjection(app);
@@ -342,17 +354,59 @@ describe("POST /rules", () => {
 		const body = JSON.parse(res.payload);
 		expect(body.name).toBe("Suppress Hunt Noise");
 		expect(body.action).toBe("suppress");
-		expect(body.conditions).toEqual([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]);
+		expect(body.conditions).toEqual([
+			{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+		]);
 
 		// Conditions should be stored as JSON string in DB
 		expect(mockPrisma.notificationRule.create).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
 					userId: "user-1",
-					conditions: JSON.stringify([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]),
+					conditions: JSON.stringify([
+						{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+					]),
 				}),
 			}),
 		);
+	});
+
+	it("rejects fields outside the unified field-match vocabulary", async () => {
+		const res = await injectAuthenticated("POST", "/rules", {
+			body: {
+				name: "Bad field",
+				action: "suppress",
+				conditions: [{ field: "instanceName", operator: "equals", value: "Sonarr" }],
+			},
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(mockPrisma.notificationRule.create).not.toHaveBeenCalled();
+	});
+});
+
+describe("PUT /rules/:id", () => {
+	it("updates an owned rule with the composer-echoed defaulted fields", async () => {
+		mockPrisma.notificationRule.findFirst.mockResolvedValue(
+			makeRule({ enabled: false, priority: 17 }),
+		);
+
+		const res = await injectAuthenticated("PUT", "/rules/rule-1", {
+			body: {
+				name: "Route failures",
+				enabled: false,
+				priority: 17,
+				action: "route",
+				conditions: [{ field: "eventType", operator: "equals", value: "HUNT_FAILED" }],
+				targetChannelIds: ["channel-1"],
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockPrisma.notificationRule.update).toHaveBeenCalledWith({
+			where: { id: "rule-1" },
+			data: expect.objectContaining({ enabled: false, priority: 17 }),
+		});
 	});
 });
 
@@ -392,7 +446,9 @@ describe("GET /channels/:id/config", () => {
 	});
 
 	it("returns 404 when channel not found", async () => {
-		mockNotificationService.getDecryptedConfig.mockRejectedValueOnce(new Error("Channel not found"));
+		mockNotificationService.getDecryptedConfig.mockRejectedValueOnce(
+			new Error("Channel not found"),
+		);
 
 		const res = await injectAuthenticated("GET", "/channels/ch-999/config");
 

--- a/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
@@ -102,6 +102,8 @@ describe("<AutomationPanel />", () => {
 		expect(screen.getByText("Hunt notifier")).toBeInTheDocument();
 		expect(screen.getByText("Enabled")).toBeInTheDocument();
 		expect(screen.getByText("Disabled")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /new notification rule/i })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: /edit hunt notifier/i })).toBeInTheDocument();
 	});
 
 	it("surfaces an unparseable rule with a warning instead of a document", () => {

--- a/apps/web/src/features/console/components/__tests__/notification-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/notification-rule-composer-dialog.test.tsx
@@ -1,0 +1,223 @@
+import type { AutomationRulesResponse, NotificationRuleResponse } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+class ResizeObserverStub {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub as unknown as typeof ResizeObserver;
+if (!Element.prototype.hasPointerCapture) Element.prototype.hasPointerCapture = () => false;
+if (!Element.prototype.setPointerCapture) Element.prototype.setPointerCapture = () => {};
+if (!Element.prototype.releasePointerCapture) Element.prototype.releasePointerCapture = () => {};
+
+const createMutate = vi.fn().mockResolvedValue({});
+const updateMutate = vi.fn().mockResolvedValue({});
+let automationData: AutomationRulesResponse = { rules: [] };
+let notificationRules: NotificationRuleResponse[] = [];
+
+vi.mock("@/hooks/api/useNotifications", () => ({
+	useNotificationRules: () => ({ data: notificationRules }),
+	useNotificationChannels: () => ({
+		data: [
+			{ id: "channel-1", name: "Discord", type: "DISCORD", enabled: true },
+			{ id: "channel-2", name: "Telegram", type: "TELEGRAM", enabled: true },
+		],
+	}),
+	useCreateRule: () => ({ mutateAsync: createMutate, isPending: false }),
+	useUpdateRule: () => ({ mutateAsync: updateMutate, isPending: false }),
+}));
+
+vi.mock("@/hooks/api/useAutomation", () => ({
+	useAutomationRules: () => ({ data: automationData }),
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "#3b82f6", to: "#8b5cf6", fromLight: "#3b82f610" },
+	}),
+}));
+
+vi.mock("@/lib/theme-input-styles", () => ({
+	getInputStyles: () => ({ base: "test-input", applyFocus: vi.fn(), removeFocus: vi.fn() }),
+}));
+
+import { NotificationRuleComposerDialog } from "../notification-rule-composer-dialog";
+
+function wrapper(ui: ReactNode) {
+	const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+	return render(
+		<QueryClientProvider client={client}>
+			<IncognitoProvider>{ui}</IncognitoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+function notificationRule(
+	overrides: Partial<NotificationRuleResponse> = {},
+): NotificationRuleResponse {
+	return {
+		id: "notification-1",
+		name: "Route failures",
+		enabled: false,
+		priority: 17,
+		action: "route",
+		conditions: [],
+		targetChannelIds: ["channel-2"],
+		throttleMinutes: null,
+		quietHoursStart: null,
+		quietHoursEnd: null,
+		quietHoursTimezone: null,
+		createdAt: "2026-07-01T00:00:00.000Z",
+		updatedAt: "2026-07-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	createMutate.mockClear();
+	updateMutate.mockClear();
+	automationData = { rules: [] };
+	notificationRules = [];
+});
+
+describe("NotificationRuleComposerDialog — create", () => {
+	it("creates a throttle rule through the flat field-match write path", async () => {
+		wrapper(<NotificationRuleComposerDialog open onOpenChange={() => {}} />);
+
+		fireEvent.change(screen.getByPlaceholderText(/route failed hunts/i), {
+			target: { value: "Throttle hunt completions" },
+		});
+		fireEvent.change(screen.getByLabelText("Condition 1 value"), {
+			target: { value: "HUNT_COMPLETED" },
+		});
+		fireEvent.change(screen.getByLabelText("Action"), { target: { value: "throttle" } });
+		fireEvent.change(screen.getByLabelText(/minimum minutes/i), { target: { value: "45" } });
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+
+		await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+		expect(createMutate).toHaveBeenCalledWith({
+			name: "Throttle hunt completions",
+			enabled: true,
+			priority: 0,
+			action: "throttle",
+			conditions: [{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }],
+			throttleMinutes: 45,
+		});
+	});
+
+	it("creates quiet hours with the complete time-window action payload", async () => {
+		wrapper(<NotificationRuleComposerDialog open onOpenChange={() => {}} />);
+
+		fireEvent.change(screen.getByPlaceholderText(/route failed hunts/i), {
+			target: { value: "Overnight quiet hours" },
+		});
+		fireEvent.change(screen.getByLabelText("Condition 1 value"), {
+			target: { value: "SYSTEM_STARTUP" },
+		});
+		fireEvent.change(screen.getByLabelText("Action"), { target: { value: "quiet_hours" } });
+		fireEvent.change(screen.getByLabelText("Start"), { target: { value: "23:15" } });
+		fireEvent.change(screen.getByLabelText("End"), { target: { value: "06:45" } });
+		fireEvent.change(screen.getByLabelText("Timezone"), {
+			target: { value: "America/Chicago" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: /create rule/i }));
+
+		await waitFor(() => expect(createMutate).toHaveBeenCalledTimes(1));
+		expect(createMutate).toHaveBeenCalledWith({
+			name: "Overnight quiet hours",
+			enabled: true,
+			priority: 0,
+			action: "quiet_hours",
+			conditions: [{ field: "eventType", operator: "equals", value: "SYSTEM_STARTUP" }],
+			quietHoursStart: "23:15",
+			quietHoursEnd: "06:45",
+			quietHoursTimezone: "America/Chicago",
+		});
+	});
+});
+
+describe("NotificationRuleComposerDialog — edit", () => {
+	beforeEach(() => {
+		automationData = {
+			rules: [
+				{
+					id: "notification-1",
+					name: "Route failures",
+					enabled: false,
+					context: "notifications",
+					document: {
+						version: 1,
+						root: {
+							all: [
+								{
+									kind: "field_match",
+									params: {
+										field: "eventType",
+										operator: "in",
+										value: ["HUNT_FAILED", "TRASH_DEPLOY_FAILED"],
+									},
+								},
+								{
+									kind: "field_match",
+									params: { field: "title", operator: "contains", value: "failed" },
+								},
+							],
+						},
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+			],
+		};
+		notificationRules = [notificationRule()];
+	});
+
+	it("prefills both joined halves and echoes defaulted enabled/priority fields on PUT", async () => {
+		wrapper(
+			<NotificationRuleComposerDialog open onOpenChange={() => {}} editRuleId="notification-1" />,
+		);
+
+		expect(await screen.findByDisplayValue("Route failures")).toBeTruthy();
+		expect(screen.getByDisplayValue("17")).toBeTruthy();
+		expect(screen.getByDisplayValue("HUNT_FAILED, TRASH_DEPLOY_FAILED")).toBeTruthy();
+		expect(screen.getByDisplayValue("failed")).toBeTruthy();
+		expect(screen.getByLabelText("Telegram")).toBeChecked();
+
+		fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+		await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+		expect(updateMutate).toHaveBeenCalledWith({
+			id: "notification-1",
+			data: {
+				name: "Route failures",
+				enabled: false,
+				priority: 17,
+				action: "route",
+				conditions: [
+					{
+						field: "eventType",
+						operator: "in",
+						value: ["HUNT_FAILED", "TRASH_DEPLOY_FAILED"],
+					},
+					{ field: "title", operator: "contains", value: "failed" },
+				],
+				targetChannelIds: ["channel-2"],
+			},
+		});
+	});
+
+	it("blocks the form until both edit sources resolve", async () => {
+		notificationRules = [];
+		wrapper(
+			<NotificationRuleComposerDialog open onOpenChange={() => {}} editRuleId="notification-1" />,
+		);
+		expect(await screen.findByText(/loading rule/i)).toBeTruthy();
+		expect(screen.queryByRole("button", { name: /save changes/i })).toBeNull();
+		expect(updateMutate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -5,8 +5,8 @@
  *
  * The unified rule surface (charter §2.1 / §5.2): every domain's rules in one
  * place, normalized to v1 and rendered with {@link RuleDocumentView}. Authoring
- * lands in slices by context — library-cleanup first (create + edit via the
- * down-convert write path, PR-3b). Auto-tag and notifications authoring follow.
+ * lands in slices by context — library-cleanup, auto-tag, and notifications now
+ * create/edit through their existing domain write paths.
  *
  * Incognito: rule NAMES stay visible (ratified 2026-07-07 — consistent with the
  * rest of the app; usable in a screenshare); sensitive param VALUES are masked
@@ -36,8 +36,14 @@ const AutoTagRuleComposerDialog = lazy(() =>
 	})),
 );
 
+const NotificationRuleComposerDialog = lazy(() =>
+	import("./notification-rule-composer-dialog").then((m) => ({
+		default: m.NotificationRuleComposerDialog,
+	})),
+);
+
 /** Contexts this composer can author (grows as slices land). */
-type AuthorableContext = "library-cleanup" | "auto-tag";
+type AuthorableContext = "library-cleanup" | "auto-tag" | "notifications";
 
 const CONTEXT_LABELS: Record<RuleContextId, string> = {
 	"library-cleanup": "Library Cleanup",
@@ -75,7 +81,7 @@ function RuleCard({
 }: {
 	rule: AutomationRuleSummary;
 	incognito: boolean;
-	/** Provided only for rules this slice can author (parseable cleanup rules). */
+	/** Provided only for parseable rules whose context this composer can author. */
 	onEdit?: () => void;
 }) {
 	// Keyed on `document` (not a derived `broken` const) so the else branch
@@ -141,7 +147,9 @@ export function AutomationPanel() {
 
 	// Only these contexts have a composer authoring dialog in this slice.
 	const editableContext = (context: RuleContextId): AuthorableContext | null =>
-		context === "library-cleanup" || context === "auto-tag" ? context : null;
+		context === "library-cleanup" || context === "auto-tag" || context === "notifications"
+			? context
+			: null;
 
 	return (
 		<div className="space-y-4">
@@ -164,6 +172,14 @@ export function AutomationPanel() {
 					<Plus className="h-4 w-4" aria-hidden="true" />
 					New auto-tag rule
 				</button>
+				<button
+					type="button"
+					onClick={() => openCreate("notifications")}
+					className="inline-flex items-center gap-1.5 rounded-lg border border-border/50 bg-card/50 px-3 py-1.5 text-sm font-medium backdrop-blur-xs transition-colors hover:bg-card/80"
+				>
+					<Plus className="h-4 w-4" aria-hidden="true" />
+					New notification rule
+				</button>
 			</div>
 
 			<AsyncStateView
@@ -177,7 +193,7 @@ export function AutomationPanel() {
 					icon: Workflow,
 					title: "No automation rules yet",
 					description:
-						"Create a cleanup or auto-tag rule here, or add notification rules — they all appear here, unified.",
+						"Create cleanup, auto-tag, and notification rules here — they all appear in one unified view.",
 				}}
 			>
 				<div className="space-y-6">
@@ -223,8 +239,14 @@ export function AutomationPanel() {
 							onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
 							editRuleId={composer.editRuleId}
 						/>
-					) : (
+					) : composer.context === "auto-tag" ? (
 						<AutoTagRuleComposerDialog
+							open={composer.open}
+							onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
+							editRuleId={composer.editRuleId}
+						/>
+					) : (
+						<NotificationRuleComposerDialog
 							open={composer.open}
 							onOpenChange={(open) => setComposer((prev) => ({ ...prev, open }))}
 							editRuleId={composer.editRuleId}

--- a/apps/web/src/features/console/components/field-match-condition-editor.tsx
+++ b/apps/web/src/features/console/components/field-match-condition-editor.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/** Notification-only condition editor: flat `field_match` rows joined by AND. */
+
+import { useRef } from "react";
+import type {
+	NotificationEditorCondition,
+	NotificationEditorState,
+} from "../lib/notification-rule-editor";
+
+const FIELD_OPTIONS = [
+	{ value: "eventType", label: "Event type" },
+	{ value: "title", label: "Title" },
+	{ value: "body", label: "Body" },
+] as const;
+
+const OPERATOR_OPTIONS = [
+	{ value: "equals", label: "Equals" },
+	{ value: "not_equals", label: "Does not equal" },
+	{ value: "contains", label: "Contains" },
+	{ value: "greater_than", label: "Greater than" },
+	{ value: "in", label: "Is one of" },
+] as const;
+
+interface FieldMatchConditionEditorProps {
+	state: NotificationEditorState;
+	onChange: (next: NotificationEditorState) => void;
+	inputClass: string;
+	labelClass: string;
+}
+
+function seedCondition(id: string): NotificationEditorCondition {
+	return { id, field: "eventType", operator: "equals", value: "" };
+}
+
+export function FieldMatchConditionEditor({
+	state,
+	onChange,
+	inputClass,
+	labelClass,
+}: FieldMatchConditionEditorProps) {
+	const nextId = useRef(0);
+
+	const updateCondition = (id: string, patch: Partial<NotificationEditorCondition>) => {
+		onChange({
+			conditions: state.conditions.map((condition) =>
+				condition.id === id ? { ...condition, ...patch } : condition,
+			),
+		});
+	};
+
+	const changeOperator = (condition: NotificationEditorCondition, operator: string) => {
+		const value = operator === "in" ? [] : operator === "greater_than" ? 0 : "";
+		updateCondition(condition.id, { operator, value });
+	};
+
+	const addCondition = () => {
+		onChange({
+			conditions: [...state.conditions, seedCondition(`new-${nextId.current++}`)],
+		});
+	};
+
+	const removeCondition = (id: string) => {
+		onChange({ conditions: state.conditions.filter((condition) => condition.id !== id) });
+	};
+
+	return (
+		<div className="space-y-3">
+			<p className="text-xs text-muted-foreground">
+				Every condition must match. Notification rules use implicit AND ordering.
+			</p>
+			<div className="space-y-2">
+				{state.conditions.map((condition, index) => (
+					<div
+						key={condition.id}
+						className="space-y-3 rounded-lg border border-border/50 bg-card/20 p-3"
+					>
+						<div className="flex items-center justify-between">
+							<span className="text-xs font-medium text-muted-foreground">
+								Condition {index + 1}
+							</span>
+							{state.conditions.length > 1 && (
+								<button
+									type="button"
+									onClick={() => removeCondition(condition.id)}
+									className="text-xs text-muted-foreground transition-colors hover:text-destructive"
+								>
+									Remove
+								</button>
+							)}
+						</div>
+
+						<div className="grid gap-3 sm:grid-cols-2">
+							<label>
+								<span className={labelClass}>Field</span>
+								<select
+									aria-label={`Condition ${index + 1} field`}
+									value={condition.field}
+									onChange={(event) => updateCondition(condition.id, { field: event.target.value })}
+									className={inputClass}
+								>
+									{!FIELD_OPTIONS.some((option) => option.value === condition.field) && (
+										<option value={condition.field}>{condition.field} (existing field)</option>
+									)}
+									{FIELD_OPTIONS.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</select>
+							</label>
+							<label>
+								<span className={labelClass}>Operator</span>
+								<select
+									aria-label={`Condition ${index + 1} operator`}
+									value={condition.operator}
+									onChange={(event) => changeOperator(condition, event.target.value)}
+									className={inputClass}
+								>
+									{OPERATOR_OPTIONS.map((option) => (
+										<option key={option.value} value={option.value}>
+											{option.label}
+										</option>
+									))}
+								</select>
+							</label>
+						</div>
+
+						<label>
+							<span className={labelClass}>
+								{condition.operator === "in" ? "Values (comma-separated)" : "Value"}
+							</span>
+							<input
+								aria-label={`Condition ${index + 1} value`}
+								type={condition.operator === "greater_than" ? "number" : "text"}
+								value={
+									Array.isArray(condition.value)
+										? condition.value.join(", ")
+										: String(condition.value)
+								}
+								onChange={(event) => {
+									const value =
+										condition.operator === "in"
+											? event.target.value
+													.split(",")
+													.map((entry) => entry.trim())
+													.filter(Boolean)
+											: condition.operator === "greater_than"
+												? event.target.valueAsNumber
+												: event.target.value;
+									updateCondition(condition.id, { value });
+								}}
+								className={inputClass}
+							/>
+						</label>
+					</div>
+				))}
+			</div>
+
+			<button
+				type="button"
+				onClick={addCondition}
+				className="w-full rounded-lg border border-dashed border-border/50 px-3 py-2 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
+			>
+				+ Add condition
+			</button>
+		</div>
+	);
+}

--- a/apps/web/src/features/console/components/notification-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/notification-rule-composer-dialog.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+/**
+ * Composer create/edit dialog for notification rules (PR-3d).
+ *
+ * The condition half is edited as v1 `field_match` predicates and serialized
+ * back to the existing flat v0 route contract. Edit mode joins the Automation
+ * summary with the domain rule before initializing so action data and the
+ * defaulted `enabled`/`priority` fields can never be overwritten by form seeds.
+ */
+
+import type { CreateNotificationRule, NotificationRuleResponse } from "@arr/shared";
+import { useQueryClient } from "@tanstack/react-query";
+import { Loader2, Save } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Switch } from "@/components/ui/switch";
+import { useIncognitoMode } from "@/contexts/IncognitoContext";
+import {
+	useCreateRule,
+	useNotificationChannels,
+	useNotificationRules,
+	useUpdateRule,
+} from "@/hooks/api/useNotifications";
+import { useThemeGradient } from "@/hooks/useThemeGradient";
+import { getErrorMessage } from "@/lib/error-utils";
+import { automationKeys } from "@/lib/query-keys";
+import { SEMANTIC_COLORS } from "@/lib/theme-gradients";
+import { getInputStyles } from "@/lib/theme-input-styles";
+import { useAutomationRules } from "../../../hooks/api/useAutomation";
+import {
+	decomposeNotificationDocument,
+	type NotificationEditorState,
+	toNotificationsV0Conditions,
+} from "../lib/notification-rule-editor";
+import { FieldMatchConditionEditor } from "./field-match-condition-editor";
+
+interface NotificationRuleComposerDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	editRuleId?: string | null;
+}
+
+type NotificationAction = NotificationRuleResponse["action"];
+
+function localTimezone(): string {
+	return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+}
+
+function freshEditorState(): NotificationEditorState {
+	return {
+		conditions: [{ id: "condition-0", field: "eventType", operator: "equals", value: "" }],
+	};
+}
+
+export function NotificationRuleComposerDialog({
+	open,
+	onOpenChange,
+	editRuleId,
+}: NotificationRuleComposerDialogProps) {
+	const { gradient } = useThemeGradient();
+	const [incognito] = useIncognitoMode();
+	const queryClient = useQueryClient();
+	const isEdit = Boolean(editRuleId);
+
+	const { data: automation } = useAutomationRules();
+	const { data: notificationRules } = useNotificationRules();
+	const { data: channels = [] } = useNotificationChannels();
+	const createRule = useCreateRule();
+	const updateRule = useUpdateRule();
+
+	const summary = useMemo(
+		() =>
+			editRuleId
+				? automation?.rules.find(
+						(rule) => rule.context === "notifications" && rule.id === editRuleId,
+					)
+				: undefined,
+		[automation, editRuleId],
+	);
+	const rule = useMemo(
+		() =>
+			editRuleId ? notificationRules?.find((candidate) => candidate.id === editRuleId) : undefined,
+		[notificationRules, editRuleId],
+	);
+
+	const editDataReady = !isEdit || (Boolean(summary) && Boolean(rule));
+
+	const [name, setName] = useState("");
+	const [enabled, setEnabled] = useState(true);
+	const [priority, setPriority] = useState(0);
+	const [action, setAction] = useState<NotificationAction>("suppress");
+	const [throttleMinutes, setThrottleMinutes] = useState(60);
+	const [targetChannelIds, setTargetChannelIds] = useState<string[]>([]);
+	const [quietHoursStart, setQuietHoursStart] = useState("22:00");
+	const [quietHoursEnd, setQuietHoursEnd] = useState("08:00");
+	const [quietHoursTimezone, setQuietHoursTimezone] = useState(localTimezone);
+	const [editorState, setEditorState] = useState<NotificationEditorState>(freshEditorState);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (!open || (isEdit && !editDataReady)) return;
+		setError(null);
+		if (isEdit && summary && rule) {
+			setName(rule.name);
+			setEnabled(rule.enabled);
+			setPriority(rule.priority);
+			setAction(rule.action);
+			setThrottleMinutes(rule.throttleMinutes ?? 60);
+			setTargetChannelIds(rule.targetChannelIds ?? []);
+			setQuietHoursStart(rule.quietHoursStart ?? "22:00");
+			setQuietHoursEnd(rule.quietHoursEnd ?? "08:00");
+			setQuietHoursTimezone(rule.quietHoursTimezone ?? localTimezone());
+			setEditorState(
+				summary.document ? decomposeNotificationDocument(summary.document) : freshEditorState(),
+			);
+			return;
+		}
+
+		setName("");
+		setEnabled(true);
+		setPriority(0);
+		setAction("suppress");
+		setThrottleMinutes(60);
+		setTargetChannelIds([]);
+		setQuietHoursStart("22:00");
+		setQuietHoursEnd("08:00");
+		setQuietHoursTimezone(localTimezone());
+		setEditorState(freshEditorState());
+	}, [open, isEdit, editDataReady, summary, rule]);
+
+	const inputStyles = getInputStyles(gradient);
+	const inputClass = `${inputStyles.base} focus:outline-hidden`;
+	const labelClass = "mb-1 block text-xs text-muted-foreground";
+	const isSaving = createRule.isPending || updateRule.isPending;
+
+	const toggleChannel = (id: string) => {
+		setTargetChannelIds((current) =>
+			current.includes(id) ? current.filter((candidate) => candidate !== id) : [...current, id],
+		);
+	};
+
+	const handleSubmit = async (event: React.FormEvent) => {
+		event.preventDefault();
+		if (isSaving || (isEdit && !editDataReady)) return;
+		if (!name.trim()) {
+			setError("Give the rule a name.");
+			return;
+		}
+		if (!Number.isInteger(priority) || priority < 0 || priority > 1000) {
+			setError("Priority must be a whole number from 0 to 1000.");
+			return;
+		}
+		if (
+			action === "throttle" &&
+			(!Number.isInteger(throttleMinutes) || throttleMinutes < 1 || throttleMinutes > 1440)
+		) {
+			setError("Throttle minutes must be a whole number from 1 to 1440.");
+			return;
+		}
+		if (action === "route" && targetChannelIds.length === 0) {
+			setError("Choose at least one target channel.");
+			return;
+		}
+		if (action === "quiet_hours" && (!quietHoursStart || !quietHoursEnd)) {
+			setError("Enter both quiet-hours times.");
+			return;
+		}
+
+		const result = toNotificationsV0Conditions(editorState);
+		if (!result.conditions) {
+			setError(result.error ?? "This rule isn't valid yet.");
+			return;
+		}
+
+		const payload: CreateNotificationRule = {
+			name: name.trim(),
+			enabled,
+			priority,
+			action,
+			conditions: result.conditions,
+			...(action === "throttle" ? { throttleMinutes } : {}),
+			...(action === "route" ? { targetChannelIds } : {}),
+			...(action === "quiet_hours" ? { quietHoursStart, quietHoursEnd, quietHoursTimezone } : {}),
+		};
+
+		try {
+			if (isEdit && editRuleId) {
+				await updateRule.mutateAsync({ id: editRuleId, data: payload });
+			} else {
+				await createRule.mutateAsync(payload);
+			}
+			await queryClient.invalidateQueries({ queryKey: automationKeys.all });
+			onOpenChange(false);
+		} catch (err) {
+			setError(getErrorMessage(err, "Could not save the rule."));
+		}
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[85vh] max-w-2xl overflow-y-auto">
+				<DialogHeader>
+					<DialogTitle>{isEdit ? "Edit Notification Rule" : "New Notification Rule"}</DialogTitle>
+					<DialogDescription>
+						Match notification fields, then suppress, throttle, route, or defer the event.
+					</DialogDescription>
+				</DialogHeader>
+
+				{isEdit && !editDataReady ? (
+					<div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+						Loading rule…
+					</div>
+				) : (
+					<form
+						onSubmit={handleSubmit}
+						className="mt-2 space-y-5"
+						onFocus={(event) => {
+							const target = event.target;
+							if (
+								(target instanceof HTMLInputElement && target.type !== "checkbox") ||
+								target instanceof HTMLSelectElement
+							) {
+								inputStyles.applyFocus(target);
+							}
+						}}
+						onBlur={(event) => {
+							const target = event.target;
+							if (
+								(target instanceof HTMLInputElement && target.type !== "checkbox") ||
+								target instanceof HTMLSelectElement
+							) {
+								inputStyles.removeFocus(target);
+							}
+						}}
+					>
+						<div className="grid gap-4 sm:grid-cols-[1fr_9rem]">
+							<label>
+								<span className={labelClass}>Rule name</span>
+								<input
+									type="text"
+									value={name}
+									onChange={(event) => setName(event.target.value)}
+									placeholder="e.g., Route failed hunts"
+									required
+									className={inputClass}
+								/>
+							</label>
+							<label>
+								<span className={labelClass}>Priority (0 first)</span>
+								<input
+									type="number"
+									min={0}
+									max={1000}
+									value={priority}
+									onChange={(event) => setPriority(event.target.valueAsNumber)}
+									className={inputClass}
+								/>
+							</label>
+						</div>
+
+						<div className="flex items-center justify-between">
+							<span className="text-sm font-medium">Enabled</span>
+							<Switch
+								aria-label="Enabled"
+								checked={enabled}
+								onCheckedChange={setEnabled}
+								style={enabled ? { backgroundColor: gradient.from } : undefined}
+							/>
+						</div>
+
+						<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+							<span className="text-sm font-medium">Conditions</span>
+							<FieldMatchConditionEditor
+								state={editorState}
+								onChange={setEditorState}
+								inputClass={inputClass}
+								labelClass={labelClass}
+							/>
+						</div>
+
+						<div className="space-y-3 rounded-xl border border-border/50 bg-card/30 p-4 backdrop-blur-sm">
+							<label>
+								<span className={labelClass}>Action</span>
+								<select
+									value={action}
+									onChange={(event) => setAction(event.target.value as NotificationAction)}
+									className={inputClass}
+								>
+									<option value="suppress">Suppress notification</option>
+									<option value="throttle">Throttle matching notifications</option>
+									<option value="route">Route to selected channels</option>
+									<option value="quiet_hours">Quiet hours</option>
+								</select>
+							</label>
+
+							{action === "throttle" && (
+								<label>
+									<span className={labelClass}>Minimum minutes between notifications</span>
+									<input
+										type="number"
+										min={1}
+										max={1440}
+										value={throttleMinutes}
+										onChange={(event) => setThrottleMinutes(event.target.valueAsNumber)}
+										className={inputClass}
+									/>
+								</label>
+							)}
+
+							{action === "route" && (
+								<div>
+									<span className={labelClass}>Target channels</span>
+									{channels.length === 0 ? (
+										<p className="text-xs text-muted-foreground">
+											Create a notification channel in Settings before authoring a route rule.
+										</p>
+									) : (
+										<div className="grid gap-2 sm:grid-cols-2">
+											{channels.map((channel, index) => (
+												<label
+													key={channel.id}
+													className="flex items-center gap-2 rounded-lg border border-border/50 px-3 py-2 text-sm"
+												>
+													<input
+														type="checkbox"
+														checked={targetChannelIds.includes(channel.id)}
+														onChange={() => toggleChannel(channel.id)}
+													/>
+													<span>{incognito ? `Channel ${index + 1}` : channel.name}</span>
+												</label>
+											))}
+										</div>
+									)}
+								</div>
+							)}
+
+							{action === "quiet_hours" && (
+								<div className="grid gap-3 sm:grid-cols-3">
+									<label>
+										<span className={labelClass}>Start</span>
+										<input
+											type="time"
+											value={quietHoursStart}
+											onChange={(event) => setQuietHoursStart(event.target.value)}
+											className={inputClass}
+										/>
+									</label>
+									<label>
+										<span className={labelClass}>End</span>
+										<input
+											type="time"
+											value={quietHoursEnd}
+											onChange={(event) => setQuietHoursEnd(event.target.value)}
+											className={inputClass}
+										/>
+									</label>
+									<label>
+										<span className={labelClass}>Timezone</span>
+										<input
+											type="text"
+											value={quietHoursTimezone}
+											onChange={(event) => setQuietHoursTimezone(event.target.value)}
+											className={inputClass}
+										/>
+									</label>
+								</div>
+							)}
+						</div>
+
+						{error && (
+							<div
+								className="rounded-md border px-3 py-2 text-xs"
+								style={{
+									borderColor: SEMANTIC_COLORS.error.border,
+									backgroundColor: SEMANTIC_COLORS.error.bg,
+									color: SEMANTIC_COLORS.error.text,
+								}}
+							>
+								{error}
+							</div>
+						)}
+
+						<div className="flex justify-end gap-2">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Cancel
+							</button>
+							<button
+								type="submit"
+								disabled={isSaving}
+								className="flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white transition-opacity disabled:opacity-60"
+								style={{
+									background: `linear-gradient(to right, ${gradient.from}, ${gradient.to})`,
+								}}
+							>
+								{isSaving ? (
+									<Loader2 className="h-4 w-4 animate-spin" />
+								) : (
+									<Save className="h-4 w-4" />
+								)}
+								{isEdit ? "Save changes" : "Create rule"}
+							</button>
+						</div>
+					</form>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/features/console/lib/__tests__/notification-rule-editor.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/notification-rule-editor.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildNotificationDocument,
+	decomposeNotificationDocument,
+	toNotificationsV0Conditions,
+	validateNotificationEditor,
+} from "../notification-rule-editor";
+
+describe("notification rule editor", () => {
+	it("decomposes and round-trips a non-trivial implicit-AND document", () => {
+		const document = {
+			version: 1 as const,
+			root: {
+				all: [
+					{
+						kind: "field_match",
+						params: {
+							field: "eventType",
+							operator: "in",
+							value: ["HUNT_COMPLETED", "HUNT_FAILED"],
+						},
+					},
+					{
+						kind: "field_match",
+						params: { field: "title", operator: "contains", value: "Radarr" },
+					},
+				],
+			},
+		};
+
+		const state = decomposeNotificationDocument(document);
+		expect(buildNotificationDocument(state)).toEqual(document);
+		expect(toNotificationsV0Conditions(state)).toEqual({
+			conditions: [
+				{ field: "eventType", operator: "in", value: ["HUNT_COMPLETED", "HUNT_FAILED"] },
+				{ field: "title", operator: "contains", value: "Radarr" },
+			],
+		});
+	});
+
+	it("rejects empty conditions, unknown fields, and empty values", () => {
+		expect(validateNotificationEditor({ conditions: [] })).toMatch(/at least one/i);
+		expect(
+			validateNotificationEditor({
+				conditions: [{ id: "one", field: "instanceName", operator: "equals", value: "Sonarr" }],
+			}),
+		).toMatch(/eventType, title, body, or metadata/i);
+		expect(
+			validateNotificationEditor({
+				conditions: [{ id: "one", field: "body", operator: "contains", value: "  " }],
+			}),
+		).toMatch(/enter a value/i);
+	});
+
+	it("preserves a lone predicate document when preparing edit state", () => {
+		const state = decomposeNotificationDocument({
+			version: 1,
+			root: {
+				kind: "field_match",
+				params: { field: "body", operator: "greater_than", value: 12 },
+			},
+		});
+		expect(state.conditions).toEqual([
+			{ id: "condition-0", field: "body", operator: "greater_than", value: 12 },
+		]);
+	});
+});

--- a/apps/web/src/features/console/lib/notification-rule-editor.ts
+++ b/apps/web/src/features/console/lib/notification-rule-editor.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure notification composer state and v1↔editor↔v0 transforms. Notification
+ * storage is a flat implicit-AND list, so the editor deliberately exposes no OR
+ * mode and rejects empty documents under the current route contract.
+ */
+
+import {
+	FIELD_MATCH_KIND,
+	fieldMatchParamsSchema,
+	isKindLegalForContext,
+	isRulePredicate,
+	type RuleCondition,
+	type RuleDocument,
+	serializeNotificationsDocumentToV0,
+	validateV1Depth,
+} from "@arr/shared";
+
+export interface NotificationEditorCondition {
+	id: string;
+	field: string;
+	operator: string;
+	value: unknown;
+}
+
+export interface NotificationEditorState {
+	conditions: NotificationEditorCondition[];
+}
+
+export function buildNotificationDocument(state: NotificationEditorState): RuleDocument {
+	return {
+		version: 1,
+		root: {
+			all: state.conditions.map(({ field, operator, value }) => ({
+				kind: FIELD_MATCH_KIND,
+				params: { field, operator, value },
+			})),
+		},
+	};
+}
+
+export function decomposeNotificationDocument(doc: RuleDocument): NotificationEditorState {
+	const root = doc.root;
+	const nodes = isRulePredicate(root) ? [root] : "all" in root ? root.all : root.any;
+
+	return {
+		conditions: nodes.map((node, index) => ({
+			id: `condition-${index}`,
+			field: isRulePredicate(node) ? String(node.params.field ?? "") : "",
+			operator: isRulePredicate(node) ? String(node.params.operator ?? "") : "",
+			value: isRulePredicate(node) ? node.params.value : "",
+		})),
+	};
+}
+
+export function validateNotificationEditor(state: NotificationEditorState): string | null {
+	if (state.conditions.length === 0) return "Add at least one condition.";
+
+	const doc = buildNotificationDocument(state);
+	const depthError = validateV1Depth(doc);
+	if (depthError) return depthError;
+
+	if (!isKindLegalForContext("notifications", FIELD_MATCH_KIND)) {
+		return "Notification conditions are not available in this rule context.";
+	}
+
+	for (const [index, condition] of state.conditions.entries()) {
+		const parsed = fieldMatchParamsSchema.safeParse(condition);
+		if (!parsed.success) {
+			const issue = parsed.error.issues[0];
+			return `Condition ${index + 1}: ${issue?.message ?? "invalid field match"}.`;
+		}
+		if (typeof parsed.data.value === "string" && !parsed.data.value.trim()) {
+			return `Condition ${index + 1}: enter a value.`;
+		}
+		if (Array.isArray(parsed.data.value) && parsed.data.value.length === 0) {
+			return `Condition ${index + 1}: enter at least one value.`;
+		}
+	}
+
+	return null;
+}
+
+export function toNotificationsV0Conditions(
+	state: NotificationEditorState,
+): { conditions: RuleCondition[]; error?: undefined } | { conditions?: undefined; error: string } {
+	const error = validateNotificationEditor(state);
+	if (error) return { error };
+	return {
+		conditions: serializeNotificationsDocumentToV0(buildNotificationDocument(state)).map(
+			(condition) => fieldMatchParamsSchema.parse(condition),
+		),
+	};
+}

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -12,7 +12,7 @@ progress · ⛔ blocked · ⬜ not started.
 | Item | Status | Evidence |
 |---|---|---|
 | 2.1 Operator Console — shell / feed / tiles / actions | ✅ | #534 #535 #537 #538 |
-| 2.1 — embedded rule composer | 🚧 | backend v1 substrate merged (#518–#521); UI + v1-serving API pending |
+| 2.1 — embedded rule composer | 🚧 | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring in PR-3d; cross-domain rules/executor/deploy remain |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
 | 2.3 Setup rewrite (auto-discovery) | ⬜ | pulled from 3.1; lowest priority |
@@ -84,7 +84,7 @@ qui-home. The remaining polling surfaces are correctly excluded:
 ---
 
 ## Remaining work (in recommended order)
-1. **Operator Console composer** (2.1) — unblocked flagship; multi-PR, its own loop.
+1. **Operator Console composer** (2.1) — finish PR-3d notifications authoring, then PR-4 cross-domain rules/executor/deploy (define “deploy” with the owner before design).
 2. **Setup rewrite (2.3)** — lowest priority (pulled from 3.1).
 
 **Tracearr arc (2.2) COMPLETE** — foundation (#555), live-session card (#556),

--- a/packages/shared/src/types/notifications.ts
+++ b/packages/shared/src/types/notifications.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { fieldMatchParamsSchema } from "../rules/field-match.js";
 
 // ============================================================================
 // Validation Helpers
@@ -259,11 +260,7 @@ export type PushSubscription = z.infer<typeof pushSubscriptionSchema>;
 // Notification Rules
 // ============================================================================
 
-export const ruleConditionSchema = z.object({
-	field: z.string().min(1), // "eventType", "title", "body", "metadata.*"
-	operator: z.enum(["equals", "not_equals", "contains", "greater_than", "in"]),
-	value: z.union([z.string(), z.number(), z.array(z.string())]),
-});
+export const ruleConditionSchema = fieldMatchParamsSchema;
 
 const timeFormatRegex = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
 


### PR DESCRIPTION
## Summary

- add notification-specific field-match authoring to the Operator Console
- support suppress, throttle, route, and quiet-hours action configuration
- preserve edit data across the automation/domain async join and echo defaulted update fields
- centralize notification condition validation on the unified field-match schema
- keep existing metadata fields representable while deferring new metadata-field authoring
- update the 3.0 completeness tracker to reflect shipped composer slices

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 86 shared, 608 web, and 2,199 API tests passed
- `pnpm run lint` — passes with pre-existing warnings
- targeted PR-3d editor/dialog/route tests
- live Chromium verification: create returned 201, edit returned 200, joined action data persisted, incognito masked predicate values, and no console errors/update-depth loop occurred

`pnpm run format` currently reports pre-existing repository drift (89 API and 105 web files). Every file changed by this PR was formatted and passes `biome check`; the broad baseline cleanup is intentionally not mixed into this feature PR.