### PR TITLE
feat(setup): add media discovery foundation

### DIFF
--- a/apps/api/src/lib/setup-discovery/__tests__/fixtures/emby-response.json
+++ b/apps/api/src/lib/setup-discovery/__tests__/fixtures/emby-response.json
@@ -1,0 +1,1 @@
+{"Address":"https://10.0.0.50:8920/emby","Id":"emby-server-123","Name":"Cinema Emby"}

--- a/apps/api/src/lib/setup-discovery/__tests__/fixtures/jellyfin-response.json
+++ b/apps/api/src/lib/setup-discovery/__tests__/fixtures/jellyfin-response.json
@@ -1,0 +1,1 @@
+{"Address":"http://10.0.0.40:8096","Id":"jellyfin-server-123","Name":"Cinema Jellyfin"}

--- a/apps/api/src/lib/setup-discovery/__tests__/fixtures/plex-gdm-response.txt
+++ b/apps/api/src/lib/setup-discovery/__tests__/fixtures/plex-gdm-response.txt
@@ -1,0 +1,6 @@
+HTTP/1.0 200 OK
+Content-Type: plex/media-server
+Name: Cinema Plex
+Port: 32400
+Resource-Identifier: plex-server-123
+Version: 1.41.0

--- a/apps/api/src/lib/setup-discovery/__tests__/parsers.test.ts
+++ b/apps/api/src/lib/setup-discovery/__tests__/parsers.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parseMediaBrowserUdpResponse, parsePlexGdmResponse } from "../parsers";
+
+const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const fixture = (name: string) => readFileSync(join(fixtures, name));
+
+describe("setup discovery datagram parsers", () => {
+	it("parses a recorded Plex GDM response using the packet source address", () => {
+		expect(
+			parsePlexGdmResponse(fixture("plex-gdm-response.txt"), { address: "192.168.1.20" }),
+		).toEqual({
+			service: "plex",
+			name: "Cinema Plex",
+			baseUrl: "http://192.168.1.20:32400",
+			serverId: "plex-server-123",
+			protocol: "plex-gdm",
+		});
+	});
+
+	it("parses Jellyfin and Emby JSON while replacing advertised hosts with packet sources", () => {
+		expect(
+			parseMediaBrowserUdpResponse("jellyfin", fixture("jellyfin-response.json"), {
+				address: "192.168.1.40",
+			}),
+		).toMatchObject({
+			service: "jellyfin",
+			baseUrl: "http://192.168.1.40:8096",
+			protocol: "jellyfin-udp",
+		});
+		expect(
+			parseMediaBrowserUdpResponse("emby", fixture("emby-response.json"), {
+				address: "192.168.1.50",
+			}),
+		).toMatchObject({
+			service: "emby",
+			baseUrl: "https://192.168.1.50:8920/emby",
+			protocol: "emby-udp",
+		});
+	});
+
+	it("rejects malformed, unrelated, and non-HTTP responses", () => {
+		expect(parsePlexGdmResponse("HTTP/1.0 404 Nope", { address: "192.168.1.2" })).toBeNull();
+		expect(
+			parseMediaBrowserUdpResponse(
+				"jellyfin",
+				'{"Address":"ftp://192.168.1.2/media","Name":"Bad"}',
+				{ address: "192.168.1.2" },
+			),
+		).toBeNull();
+		expect(parseMediaBrowserUdpResponse("emby", "not-json", { address: "192.168.1.2" })).toBeNull();
+	});
+
+	it("strips credentials and tracking data from advertised addresses", () => {
+		expect(
+			parseMediaBrowserUdpResponse(
+				"jellyfin",
+				'{"Address":"http://user:secret@10.0.0.2:8096/jellyfin?token=secret#fragment","Name":"Jellyfin"}',
+				{ address: "192.168.1.2" },
+			),
+		).toMatchObject({ baseUrl: "http://192.168.1.2:8096/jellyfin" });
+	});
+});

--- a/apps/api/src/lib/setup-discovery/__tests__/udp-discovery.test.ts
+++ b/apps/api/src/lib/setup-discovery/__tests__/udp-discovery.test.ts
@@ -1,0 +1,94 @@
+import type { Socket } from "node:dgram";
+import { describe, expect, it } from "vitest";
+import {
+	deduplicateCandidates,
+	discoverMediaServers,
+	SETUP_DISCOVERY_PROTOCOLS,
+} from "../udp-discovery";
+
+type Handler = (...args: never[]) => void;
+
+function respondingSocketFactory(): () => Socket {
+	return () => {
+		const handlers = new Map<string, Handler[]>();
+		const socket = {
+			on(event: string, handler: Handler) {
+				handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+				return socket;
+			},
+			bind(_port: number, _host: string, callback: () => void) {
+				queueMicrotask(callback);
+				return socket;
+			},
+			setBroadcast() {
+				return socket;
+			},
+			setMulticastTTL() {
+				return socket;
+			},
+			send(message: Buffer, _port: number, _host: string, callback: (error: null) => void) {
+				const query = message.toString();
+				const payload = query.includes("M-SEARCH")
+					? "HTTP/1.0 200 OK\r\nContent-Type: plex/media-server\r\nName: Plex\r\nPort: 32400\r\nResource-Identifier: plex-1"
+					: query.includes("Jellyfin")
+						? '{"Address":"http://10.0.0.2:8096","Id":"jelly-1","Name":"Jellyfin"}'
+						: '{"Address":"http://10.0.0.3:8096","Id":"emby-1","Name":"Emby"}';
+				queueMicrotask(() => {
+					for (const handler of handlers.get("message") ?? []) {
+						(handler as (...args: unknown[]) => void)(Buffer.from(payload), {
+							address: query.includes("M-SEARCH") ? "192.168.1.2" : "192.168.1.3",
+							family: "IPv4",
+							port: 7359,
+							size: payload.length,
+						});
+					}
+					callback(null);
+				});
+				return socket;
+			},
+			close() {
+				return socket;
+			},
+		};
+		return socket as unknown as Socket;
+	};
+}
+
+describe("bounded UDP setup discovery", () => {
+	it("runs every supported probe concurrently and returns parsed candidates", async () => {
+		const result = await discoverMediaServers({
+			timeoutMs: 5,
+			socketFactory: respondingSocketFactory(),
+		});
+		expect(result.scannedProtocols).toEqual(SETUP_DISCOVERY_PROTOCOLS);
+		expect(result.candidates.map((candidate) => candidate.service).sort()).toEqual([
+			"emby",
+			"jellyfin",
+			"plex",
+		]);
+	});
+
+	it("deduplicates repeated datagrams by service and stable server identity", () => {
+		const candidate = {
+			service: "plex" as const,
+			name: "Plex",
+			baseUrl: "http://192.168.1.2:32400",
+			serverId: "plex-1",
+			protocol: "plex-gdm" as const,
+		};
+		expect(deduplicateCandidates([candidate, { ...candidate, name: "Duplicate" }])).toEqual([
+			candidate,
+		]);
+	});
+
+	it("fails silent-and-fast when UDP sockets are unavailable", async () => {
+		const result = await discoverMediaServers({
+			socketFactory: () => {
+				throw new Error("UDP disabled");
+			},
+		});
+		expect(result.candidates).toEqual([]);
+		expect(result.scannedProtocols).toEqual(SETUP_DISCOVERY_PROTOCOLS);
+		expect(result.durationMs).toBeLessThan(100);
+	});
+});

--- a/apps/api/src/lib/setup-discovery/parsers.ts
+++ b/apps/api/src/lib/setup-discovery/parsers.ts
@@ -1,0 +1,69 @@
+import type { SetupDiscoveryCandidate } from "@arr/shared";
+
+type RemoteInfo = { address: string };
+
+function localBaseUrl(reportedAddress: string, remote: RemoteInfo): string | null {
+	try {
+		const parsed = new URL(
+			reportedAddress.includes("://") ? reportedAddress : `http://${reportedAddress}`,
+		);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+		parsed.hostname = remote.address;
+		parsed.username = "";
+		parsed.password = "";
+		parsed.search = "";
+		parsed.hash = "";
+		return parsed.toString().replace(/\/$/, "");
+	} catch {
+		return null;
+	}
+}
+
+export function parsePlexGdmResponse(
+	payload: Buffer | string,
+	remote: RemoteInfo,
+): SetupDiscoveryCandidate | null {
+	const lines = payload.toString().split(/\r?\n/);
+	if (!lines[0]?.includes("200 OK")) return null;
+
+	const headers = new Map<string, string>();
+	for (const line of lines.slice(1)) {
+		const separator = line.indexOf(":");
+		if (separator < 1) continue;
+		headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
+	}
+	if (headers.get("content-type") !== "plex/media-server") return null;
+	const port = Number(headers.get("port"));
+	if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+
+	return {
+		service: "plex",
+		name: headers.get("name")?.slice(0, 120) || "Plex Media Server",
+		baseUrl: `http://${remote.address}:${port}`,
+		serverId: headers.get("resource-identifier")?.slice(0, 256) || null,
+		protocol: "plex-gdm",
+	};
+}
+
+export function parseMediaBrowserUdpResponse(
+	service: "jellyfin" | "emby",
+	payload: Buffer | string,
+	remote: RemoteInfo,
+): SetupDiscoveryCandidate | null {
+	try {
+		const parsed = JSON.parse(payload.toString()) as Record<string, unknown>;
+		if (typeof parsed.Address !== "string" || typeof parsed.Name !== "string") return null;
+		const baseUrl = localBaseUrl(parsed.Address, remote);
+		if (!baseUrl || parsed.Name.trim().length === 0) return null;
+		return {
+			service,
+			name: parsed.Name.trim().slice(0, 120),
+			baseUrl,
+			serverId:
+				typeof parsed.Id === "string" && parsed.Id.length > 0 ? parsed.Id.slice(0, 256) : null,
+			protocol: service === "jellyfin" ? "jellyfin-udp" : "emby-udp",
+		};
+	} catch {
+		return null;
+	}
+}

--- a/apps/api/src/lib/setup-discovery/udp-discovery.ts
+++ b/apps/api/src/lib/setup-discovery/udp-discovery.ts
@@ -1,0 +1,152 @@
+import type {
+	SetupDiscoveryCandidate,
+	SetupDiscoveryProtocol,
+	SetupDiscoveryResponse,
+} from "@arr/shared";
+import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
+import { parseMediaBrowserUdpResponse, parsePlexGdmResponse } from "./parsers.js";
+
+const DEFAULT_TIMEOUT_MS = 1_200;
+export const SETUP_DISCOVERY_PROTOCOLS = [
+	"plex-gdm",
+	"jellyfin-udp",
+	"emby-udp",
+] as const satisfies readonly SetupDiscoveryProtocol[];
+
+interface Probe {
+	protocol: SetupDiscoveryProtocol;
+	message: string;
+	host: string;
+	port: number;
+	broadcast: boolean;
+	parse(payload: Buffer, remote: RemoteInfo): SetupDiscoveryCandidate | null;
+}
+
+const PROBES: readonly Probe[] = [
+	{
+		protocol: "plex-gdm",
+		message: "M-SEARCH * HTTP/1.0",
+		host: "239.0.0.250",
+		port: 32414,
+		broadcast: false,
+		parse: parsePlexGdmResponse,
+	},
+	{
+		protocol: "jellyfin-udp",
+		message: "who is JellyfinServer?",
+		host: "255.255.255.255",
+		port: 7359,
+		broadcast: true,
+		parse: (payload, remote) => parseMediaBrowserUdpResponse("jellyfin", payload, remote),
+	},
+	{
+		protocol: "emby-udp",
+		message: "who is EmbyServer?",
+		host: "255.255.255.255",
+		port: 7359,
+		broadcast: true,
+		parse: (payload, remote) => parseMediaBrowserUdpResponse("emby", payload, remote),
+	},
+];
+
+export interface DiscoveryLogger {
+	debug(bindings: Record<string, unknown>, message: string): void;
+}
+
+type SocketFactory = () => Socket;
+
+export async function discoverMediaServers(options?: {
+	timeoutMs?: number;
+	log?: DiscoveryLogger;
+	socketFactory?: SocketFactory;
+}): Promise<SetupDiscoveryResponse> {
+	const startedAt = Date.now();
+	const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const socketFactory = options?.socketFactory ?? (() => createSocket("udp4"));
+	const results = await Promise.all(
+		PROBES.map((probe) => runProbe(probe, timeoutMs, socketFactory, options?.log)),
+	);
+	const candidates = deduplicateCandidates(results.flat());
+	return {
+		candidates,
+		scannedProtocols: [...SETUP_DISCOVERY_PROTOCOLS],
+		durationMs: Date.now() - startedAt,
+	};
+}
+
+function runProbe(
+	probe: Probe,
+	timeoutMs: number,
+	socketFactory: SocketFactory,
+	log?: DiscoveryLogger,
+): Promise<SetupDiscoveryCandidate[]> {
+	return new Promise((resolve) => {
+		const candidates: SetupDiscoveryCandidate[] = [];
+		let socket: Socket;
+		try {
+			socket = socketFactory();
+		} catch (error) {
+			log?.debug({ err: error, protocol: probe.protocol }, "Setup discovery socket unavailable");
+			resolve([]);
+			return;
+		}
+		let finished = false;
+		const finish = () => {
+			if (finished) return;
+			finished = true;
+			clearTimeout(timer);
+			try {
+				socket.close();
+			} catch {
+				// A socket that failed before binding may already be closed.
+			}
+			resolve(candidates);
+		};
+		const timer = setTimeout(finish, timeoutMs);
+
+		socket.on("message", (payload, remote) => {
+			if (finished) return;
+			const candidate = probe.parse(payload, remote);
+			if (candidate) candidates.push(candidate);
+		});
+		socket.on("error", (error) => {
+			log?.debug({ err: error, protocol: probe.protocol }, "Setup discovery probe unavailable");
+			finish();
+		});
+		try {
+			socket.bind(0, "0.0.0.0", () => {
+				try {
+					if (probe.broadcast) socket.setBroadcast(true);
+					else socket.setMulticastTTL(1);
+					socket.send(Buffer.from(probe.message), probe.port, probe.host, (error) => {
+						if (error) {
+							log?.debug(
+								{ err: error, protocol: probe.protocol },
+								"Setup discovery probe send failed",
+							);
+							finish();
+						}
+					});
+				} catch (error) {
+					log?.debug({ err: error, protocol: probe.protocol }, "Setup discovery probe failed");
+					finish();
+				}
+			});
+		} catch (error) {
+			log?.debug({ err: error, protocol: probe.protocol }, "Setup discovery bind failed");
+			finish();
+		}
+	});
+}
+
+export function deduplicateCandidates(
+	candidates: SetupDiscoveryCandidate[],
+): SetupDiscoveryCandidate[] {
+	const seen = new Set<string>();
+	return candidates.filter((candidate) => {
+		const key = `${candidate.service}:${candidate.serverId ?? candidate.baseUrl}`;
+		if (seen.has(key)) return false;
+		seen.add(key);
+		return true;
+	});
+}

--- a/apps/api/src/routes/__tests__/setup-discovery.test.ts
+++ b/apps/api/src/routes/__tests__/setup-discovery.test.ts
@@ -1,0 +1,81 @@
+import fastifyRateLimit from "@fastify/rate-limit";
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers";
+
+const { discoverMediaServers } = vi.hoisted(() => ({ discoverMediaServers: vi.fn() }));
+vi.mock("../../lib/setup-discovery/udp-discovery.js", () => ({ discoverMediaServers }));
+
+import { registerSetupRoutes } from "../setup";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	discoverMediaServers.mockReset();
+	discoverMediaServers.mockResolvedValue({
+		candidates: [
+			{
+				service: "plex",
+				name: "Plex",
+				baseUrl: "http://192.168.1.2:32400",
+				serverId: "plex-1",
+				protocol: "plex-gdm",
+			},
+		],
+		scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+		durationMs: 1200,
+	});
+	app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	await app.register(fastifyRateLimit, { max: 100, timeWindow: "1 minute" });
+	await app.register(registerSetupRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => app.close());
+
+describe("POST /setup/discovery", () => {
+	it("returns credential-free candidates without persisting or connecting them", async () => {
+		const response = await injectAuthenticated("POST", "/setup/discovery");
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			candidates: [{ service: "plex", serverId: "plex-1" }],
+		});
+		expect(discoverMediaServers).toHaveBeenCalledOnce();
+	});
+
+	it("coalesces overlapping scans instead of multiplying network broadcasts", async () => {
+		let resolveScan!: (value: {
+			candidates: never[];
+			scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"];
+			durationMs: number;
+		}) => void;
+		discoverMediaServers.mockReturnValueOnce(
+			new Promise((resolve) => {
+				resolveScan = resolve;
+			}),
+		);
+
+		const first = injectAuthenticated("POST", "/setup/discovery");
+		const second = injectAuthenticated("POST", "/setup/discovery");
+		await vi.waitFor(() => expect(discoverMediaServers).toHaveBeenCalledOnce());
+		resolveScan({
+			candidates: [],
+			scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+			durationMs: 1,
+		});
+
+		expect((await first).statusCode).toBe(200);
+		expect((await second).statusCode).toBe(200);
+		expect(discoverMediaServers).toHaveBeenCalledOnce();
+	});
+
+	it("limits repeated scans to avoid noisy local-network broadcasts", async () => {
+		for (let request = 0; request < 5; request++) {
+			expect((await injectAuthenticated("POST", "/setup/discovery")).statusCode).toBe(200);
+		}
+		expect((await injectAuthenticated("POST", "/setup/discovery")).statusCode).toBe(429);
+	});
+});

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -42,6 +42,7 @@ import { registerQuiWebhookRoutes } from "./qui-webhook.js";
 import { registerSearchRoutes } from "./search.js";
 import { registerSeerrRoutes } from "./seerr/index.js";
 import { registerServiceRoutes } from "./services.js";
+import { registerSetupRoutes } from "./setup.js";
 import { registerSystemRoutes } from "./system.js";
 import { registerTracearrRoutes } from "./tracearr.js";
 import { registerTrashGuidesRoutes } from "./trash-guides/index.js";
@@ -184,6 +185,13 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		register: registerServiceRoutes,
 		maturity: "stable",
 		summary: "ARR instance CRUD + connection testing",
+	},
+	{
+		path: "/api/setup",
+		prefix: "/api",
+		register: registerSetupRoutes,
+		maturity: "experimental",
+		summary: "Guided setup media-server discovery",
 	},
 	{
 		path: "/api/dashboard",

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -1,0 +1,19 @@
+import type { SetupDiscoveryResponse } from "@arr/shared";
+import type { FastifyPluginCallback } from "fastify";
+import { discoverMediaServers } from "../lib/setup-discovery/udp-discovery.js";
+
+let activeDiscovery: Promise<SetupDiscoveryResponse> | null = null;
+const DISCOVERY_RATE_LIMIT = { max: 5, timeWindow: "1 minute" };
+
+export const registerSetupRoutes: FastifyPluginCallback = (app, _opts, done) => {
+	app.post("/setup/discovery", { config: { rateLimit: DISCOVERY_RATE_LIMIT } }, async (request) => {
+		if (!activeDiscovery) {
+			activeDiscovery = discoverMediaServers({ log: request.log }).finally(() => {
+				activeDiscovery = null;
+			});
+		}
+		return activeDiscovery;
+	});
+
+	done();
+};

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation in progress: typed candidates, recorded protocol fixtures, and bounded Plex/Jellyfin/Emby UDP probes; guided wizard follows |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568): typed candidates, recorded protocol fixtures, and bounded Plex/Jellyfin/Emby UDP probes; guided wizard follows |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | ⬜ | pulled from 3.1; lowest priority |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation in progress: typed candidates, recorded protocol fixtures, and bounded Plex/Jellyfin/Emby UDP probes; guided wizard follows |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -42,6 +42,7 @@ for the full rationale.
 | `/api/backup` | operator | Create, download, restore, scheduled backups |
 | `/api/notifications` | stable | Channels, subscriptions, rules, delivery aggregation |
 | `/api/services` | stable | ARR instance CRUD + connection testing |
+| `/api/setup` | experimental | Guided Setup support — bounded, credential-free media-server discovery. Candidates require explicit operator confirmation and are never connected automatically. |
 | `/api/dashboard` | stable | Queue, history, calendar, statistics aggregates |
 | `/api/library` | stable | Movies/series listing, episodes, monitor, search |
 | `/api/search` | stable | Prowlarr indexer search + grab |
@@ -67,6 +68,12 @@ for the full rationale.
 > will fail loudly if either is missing.
 
 ## Per-group route detail
+
+## Guided Setup Routes (`/api/setup`)
+
+| Method | Route | Auth | Purpose |
+|--------|-------|------|---------|
+| POST | `/api/setup/discovery` | Yes | Discover Plex, Jellyfin, and Emby candidates without saving or connecting them |
 
 ## Authentication Routes (`/auth`)
 

--- a/docs/adr/0008-setup-auto-discovery-scope.md
+++ b/docs/adr/0008-setup-auto-discovery-scope.md
@@ -109,3 +109,10 @@ URL field.
   mechanism.
 - The detection module ships with recorded-datagram fixtures so CI
   covers parsing without a live network.
+
+**Implementation note (2026-07-15):** the first Setup rewrite slice
+implements the primary Plex GDM and Jellyfin/Emby UDP probes behind a
+bounded, authenticated endpoint. It returns candidates only, coalesces
+overlapping scans, and treats unavailable UDP networking as an empty
+result. SSDP and mDNS remain fallback mechanisms for the guided-wizard
+slice; they do not broaden discovery to the *arr family.

--- a/packages/shared/src/types/__tests__/setup-discovery.test.ts
+++ b/packages/shared/src/types/__tests__/setup-discovery.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { setupDiscoveryCandidateSchema, setupDiscoveryResponseSchema } from "../setup-discovery";
+
+describe("setup discovery contracts", () => {
+	it("accepts a credential-free media-server candidate", () => {
+		expect(
+			setupDiscoveryCandidateSchema.parse({
+				service: "plex",
+				name: "Living Room Plex",
+				baseUrl: "http://192.168.1.10:32400",
+				serverId: "plex-id",
+				protocol: "plex-gdm",
+			}),
+		).toMatchObject({ service: "plex", protocol: "plex-gdm" });
+	});
+
+	it("rejects unsupported services and non-HTTP URLs", () => {
+		expect(
+			setupDiscoveryCandidateSchema.safeParse({
+				service: "sonarr",
+				name: "Sonarr",
+				baseUrl: "not-a-url",
+				serverId: null,
+				protocol: "jellyfin-udp",
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects candidates that leak credentials or tokens through their URL", () => {
+		expect(
+			setupDiscoveryCandidateSchema.safeParse({
+				service: "jellyfin",
+				name: "Jellyfin",
+				baseUrl: "http://user:secret@192.168.1.10:8096?token=secret",
+				serverId: null,
+				protocol: "jellyfin-udp",
+			}).success,
+		).toBe(false);
+	});
+
+	it("pins the response metadata used by the guided setup UI", () => {
+		expect(
+			setupDiscoveryResponseSchema.parse({
+				candidates: [],
+				scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+				durationMs: 1200,
+			}),
+		).toMatchObject({ candidates: [], durationMs: 1200 });
+	});
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -22,6 +22,7 @@ export * from "./regex-safety";
 export * from "./rule-criteria";
 export * from "./search";
 export * from "./seerr";
+export * from "./setup-discovery";
 export * from "./template-sharing";
 export * from "./tracearr";
 export * from "./trash-guides";

--- a/packages/shared/src/types/setup-discovery.ts
+++ b/packages/shared/src/types/setup-discovery.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+export const setupDiscoveryProtocolSchema = z.enum(["plex-gdm", "jellyfin-udp", "emby-udp"]);
+export type SetupDiscoveryProtocol = z.infer<typeof setupDiscoveryProtocolSchema>;
+
+function isCredentialFreeHttpUrl(value: string): boolean {
+	try {
+		const parsed = new URL(value);
+		return (
+			["http:", "https:"].includes(parsed.protocol) &&
+			!parsed.username &&
+			!parsed.password &&
+			!parsed.search &&
+			!parsed.hash
+		);
+	} catch {
+		return false;
+	}
+}
+
+export const setupDiscoveryCandidateSchema = z.object({
+	service: z.enum(["plex", "jellyfin", "emby"]),
+	name: z.string().min(1).max(120),
+	baseUrl: z.string().max(2048).url().refine(isCredentialFreeHttpUrl, {
+		message: "Discovery candidates must use credential-free HTTP or HTTPS URLs",
+	}),
+	serverId: z.string().min(1).max(256).nullable(),
+	protocol: setupDiscoveryProtocolSchema,
+});
+export type SetupDiscoveryCandidate = z.infer<typeof setupDiscoveryCandidateSchema>;
+
+export const setupDiscoveryResponseSchema = z.object({
+	candidates: z.array(setupDiscoveryCandidateSchema),
+	scannedProtocols: z.array(setupDiscoveryProtocolSchema),
+	durationMs: z.number().int().nonnegative(),
+});
+export type SetupDiscoveryResponse = z.infer<typeof setupDiscoveryResponseSchema>;


### PR DESCRIPTION
## Summary

- add shared contracts for credential-free Plex, Jellyfin, and Emby discovery candidates
- add bounded UDP discovery using Plex GDM and Jellyfin/Emby discovery protocols
- expose a protected, rate-limited setup discovery endpoint with overlapping scan coalescing
- document the experimental route and update the Setup rewrite tracker/ADR

## Impact

This is the backend discovery foundation for the guided 3.0 Setup rewrite. It returns candidates only: it does not persist services, test credentials, or connect automatically. SSDP and mDNS remain later fallback work.

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,917 passed, 41 skipped
- `pnpm run lint` — passed with existing warnings
- focused parser, UDP discovery, route, and shared contract tests
- real bounded UDP scan completed in 1.203s with no local responders
- changed formatter-managed files pass Biome; `git diff --check` passes

## Formatting note

`pnpm run format` still reports pre-existing repository-wide drift, including ignored generated `.next` output. This PR does not add formatter drift in its changed source files.