### PR TITLE
feat(setup): add guided service onboarding

### DIFF
--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -6,7 +6,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 
 const { mockSessionService } = vi.hoisted(() => ({
 	mockSessionService: {
-		createSession: vi.fn().mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSession: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -16,9 +18,11 @@ const { mockSessionService } = vi.hoisted(() => ({
 
 // Mock OIDCProvider class — avoid real discovery/HTTP calls
 const { MockOIDCProvider } = vi.hoisted(() => {
-	const mockGetAuthorizationUrl = vi.fn().mockResolvedValue(
-		"https://provider.example.com/authorize?client_id=test&state=mock-state&code_challenge=mock-challenge",
-	);
+	const mockGetAuthorizationUrl = vi
+		.fn()
+		.mockResolvedValue(
+			"https://provider.example.com/authorize?client_id=test&state=mock-state&code_challenge=mock-challenge",
+		);
 	class MockOIDCProvider {
 		config: Record<string, unknown>;
 		static mockGetAuthorizationUrl = mockGetAuthorizationUrl;
@@ -26,6 +30,15 @@ const { MockOIDCProvider } = vi.hoisted(() => {
 			this.config = config;
 		}
 		getAuthorizationUrl = mockGetAuthorizationUrl;
+		exchangeCode = vi.fn().mockResolvedValue({
+			access_token: "mock-access-token",
+			id_token: "mock-id-token",
+		});
+		extractIdTokenClaims = vi.fn().mockReturnValue({ sub: "provider-user-1" });
+		getUserInfo = vi.fn().mockResolvedValue({
+			sub: "provider-user-1",
+			preferred_username: "oidc-admin",
+		});
 	}
 	return { MockOIDCProvider };
 });
@@ -88,6 +101,10 @@ function makeOidcProvider(overrides: Record<string, unknown> = {}) {
 function createMockPrisma() {
 	const userMock = {
 		count: vi.fn().mockResolvedValue(0),
+		create: vi.fn().mockResolvedValue({
+			id: "user-1",
+			username: "oidc-admin",
+		}),
 	};
 
 	const oidcProviderMock = {
@@ -108,7 +125,8 @@ function createMockPrisma() {
 		user: userMock,
 		oIDCProvider: oidcProviderMock,
 		oIDCAccount: {
-			findFirst: vi.fn().mockResolvedValue(null),
+			findUnique: vi.fn().mockResolvedValue(null),
+			create: vi.fn(),
 		},
 		$transaction: vi.fn().mockImplementation(async (fn: any) => {
 			return fn({
@@ -130,8 +148,9 @@ beforeEach(async () => {
 	vi.clearAllMocks();
 
 	// Reset the OIDCProvider mock
-	MockOIDCProvider.mockGetAuthorizationUrl.mockResolvedValue(
-		"https://provider.example.com/authorize?client_id=test&state=mock-state",
+	MockOIDCProvider.mockGetAuthorizationUrl.mockImplementation(
+		(state: string) =>
+			`https://provider.example.com/authorize?client_id=test&state=${encodeURIComponent(state)}`,
 	);
 
 	mockPrisma = createMockPrisma();
@@ -294,6 +313,45 @@ describe("POST /auth/oidc/login", () => {
 // ===========================================================================
 
 describe("GET /auth/oidc/callback", () => {
+	it("continues initial OIDC setup into service onboarding", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		const login = await app.inject({ method: "POST", url: "/auth/oidc/login" });
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const res = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(res.statusCode).toBe(302);
+		expect(res.headers.location).toBe("/setup?stage=services");
+		expect(mockSessionService.createSession).toHaveBeenCalledWith(
+			"user-1",
+			true,
+			expect.any(Object),
+		);
+	});
+
+	it("keeps normal OIDC logins on the existing root redirect", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "existing-user", username: "existing-admin" },
+		});
+		const login = await app.inject({ method: "POST", url: "/auth/oidc/login" });
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const res = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(res.statusCode).toBe(302);
+		expect(res.headers.location).toBe("/");
+	});
+
 	it("returns 400 with invalid state (CSRF protection)", async () => {
 		const res = await app.inject({
 			method: "GET",

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -361,6 +361,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		});
 
 		try {
+			let createdInitialUser = false;
 			// Convert query object to URLSearchParams for oauth4webapi
 			const queryParams = new URLSearchParams();
 			for (const [key, value] of Object.entries(request.query as Record<string, string>)) {
@@ -466,6 +467,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 						});
 
 						user = newUser;
+						createdInitialUser = true;
 					} catch (error) {
 						if (error instanceof Error && error.message === "SETUP_COMPLETE") {
 							// Setup already completed by concurrent request
@@ -489,12 +491,12 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				request.log.debug({ err }, "Connection warm-up wrapper error (non-critical)");
 			});
 
-			// Redirect to root - Next.js middleware will redirect to dashboard if authenticated
+			const redirectPath = createdInitialUser ? "/setup?stage=services" : "/";
 			request.log.info(
-				{ userId: user.id, username: user.username },
-				"OIDC authentication successful, redirecting to root",
+				{ userId: user.id, username: user.username, redirectPath },
+				"OIDC authentication successful",
 			);
-			return reply.redirect("/", 302);
+			return reply.redirect(redirectPath, 302);
 		} catch (error: unknown) {
 			const errMsg = getErrorMessage(error);
 			const errStack = error instanceof Error ? error.stack : undefined;

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -1,41 +1,73 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
 import { Skeleton } from "../../src/components/ui";
 import { SetupClient } from "../../src/features/setup/components/setup-client";
-import { useSetupRequired } from "../../src/hooks/api/useAuth";
+import { useCurrentUser, useSetupRequired } from "../../src/hooks/api/useAuth";
 
-const SetupPage = () => {
+const SetupLoading = () => (
+	<main className="flex min-h-screen items-center justify-center bg-background px-4">
+		<Skeleton className="h-10 w-10 rounded-full" />
+	</main>
+);
+
+const SetupPageContent = () => {
 	const router = useRouter();
+	const searchParams = useSearchParams();
+	const requestedServicesStage = searchParams.get("stage") === "services";
 	const { data: setupRequired, isLoading } = useSetupRequired();
+	const shouldVerifySession = setupRequired?.required === false && requestedServicesStage;
+	const { data: user, isLoading: userLoading } = useCurrentUser(shouldVerifySession);
 
 	useEffect(() => {
-		// If setup is complete, redirect to login
-		if (!isLoading && setupRequired?.required === false) {
+		if (isLoading || userLoading) return;
+
+		if (setupRequired?.required === false && !requestedServicesStage) {
 			router.replace("/login");
+			return;
 		}
-	}, [isLoading, setupRequired, router]);
+
+		if (shouldVerifySession && !user) {
+			router.replace("/login?redirectTo=%2Fsetup%3Fstage%3Dservices");
+		}
+	}, [
+		isLoading,
+		requestedServicesStage,
+		router,
+		setupRequired,
+		shouldVerifySession,
+		user,
+		userLoading,
+	]);
 
 	// Show loading while checking
-	if (isLoading) {
-		return (
-			<main className="flex min-h-screen items-center justify-center bg-background px-4">
-				<Skeleton className="h-10 w-10 rounded-full" />
-			</main>
-		);
+	if (isLoading || (shouldVerifySession && userLoading)) {
+		return <SetupLoading />;
 	}
 
 	// If setup is complete, don't render (will redirect)
-	if (setupRequired?.required === false) {
+	if (setupRequired?.required === false && (!requestedServicesStage || !user)) {
 		return null;
 	}
 
 	return (
 		<main className="flex min-h-screen items-center justify-center bg-background px-4">
-			<SetupClient />
+			<SetupClient
+				stage={
+					requestedServicesStage && setupRequired?.required === false && user
+						? "services"
+						: "account"
+				}
+			/>
 		</main>
 	);
 };
+
+const SetupPage = () => (
+	<Suspense fallback={<SetupLoading />}>
+		<SetupPageContent />
+	</Suspense>
+);
 
 export default SetupPage;

--- a/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
@@ -1,0 +1,113 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	refetchDiscovery: vi.fn(),
+	testConnection: vi.fn(),
+	createService: vi.fn(),
+}));
+
+vi.mock("../../../../hooks/api/useSetupDiscovery", () => ({
+	useSetupDiscovery: () => ({
+		refetch: mocks.refetchDiscovery,
+		isFetching: false,
+		isLoading: false,
+		isError: false,
+		error: null,
+		data: {
+			candidates: [
+				{
+					service: "jellyfin",
+					name: "Living Room Jellyfin",
+					baseUrl: "http://192.168.1.25:8096",
+					serverId: "server-1",
+					protocol: "jellyfin-udp",
+				},
+			],
+			scannedProtocols: ["jellyfin-udp"],
+			durationMs: 1200,
+		},
+	}),
+}));
+
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({ data: [], isLoading: false }),
+}));
+
+vi.mock("../../../../hooks/api/useServiceMutations", () => ({
+	useTestConnectionBeforeAdd: () => ({
+		mutateAsync: mocks.testConnection,
+		isPending: false,
+	}),
+	useCreateServiceMutation: () => ({
+		mutateAsync: mocks.createService,
+		isPending: false,
+	}),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "blue", to: "purple", glow: "blue" },
+	}),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [false, vi.fn()],
+	getLinuxServerName: () => "linux-server",
+	getLinuxUrl: () => "http://localhost",
+}));
+
+import { ServiceOnboarding } from "../service-onboarding";
+
+describe("ServiceOnboarding", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.testConnection.mockResolvedValue({ success: true, version: "10.9.0" });
+		mocks.createService.mockResolvedValue({ id: "service-1" });
+	});
+
+	it("loads discovery automatically and pre-fills a candidate", () => {
+		render(<ServiceOnboarding />);
+
+		expect(screen.getByText("Living Room Jellyfin")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Scan again" }));
+		expect(mocks.refetchDiscovery).toHaveBeenCalledOnce();
+		fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+
+		expect(screen.getByLabelText("Label")).toHaveValue("Living Room Jellyfin");
+		expect(screen.getByLabelText("Base URL")).toHaveValue("http://192.168.1.25:8096");
+	});
+
+	it("tests the connection before persisting a service", async () => {
+		render(<ServiceOnboarding />);
+		fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+		fireEvent.change(screen.getByLabelText("API key"), { target: { value: "valid-api-key" } });
+		fireEvent.click(screen.getByRole("button", { name: "Test and add" }));
+
+		await waitFor(() => expect(mocks.createService).toHaveBeenCalledOnce());
+		expect(mocks.testConnection).toHaveBeenCalledWith({
+			service: "jellyfin",
+			label: "Living Room Jellyfin",
+			baseUrl: "http://192.168.1.25:8096",
+			apiKey: "valid-api-key",
+		});
+		expect(mocks.testConnection.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.createService.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it("does not persist a service when verification fails", async () => {
+		mocks.testConnection.mockResolvedValue({
+			success: false,
+			error: "Unauthorized",
+			details: "Check the API key",
+		});
+		render(<ServiceOnboarding />);
+		fireEvent.click(screen.getByRole("button", { name: "Configure" }));
+		fireEvent.change(screen.getByLabelText("API key"), { target: { value: "invalid-key" } });
+		fireEvent.click(screen.getByRole("button", { name: "Test and add" }));
+
+		expect(await screen.findByText("Check the API key")).toBeInTheDocument();
+		expect(mocks.createService).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/setup/components/passkey-setup.tsx
+++ b/apps/web/src/features/setup/components/passkey-setup.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import type { CurrentUser } from "@arr/shared";
+import type { CurrentUser, PasswordPolicy } from "@arr/shared";
 import { startRegistration } from "@simplewebauthn/browser";
 import { KeyRound, Loader2 } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Alert, AlertDescription } from "../../../components/ui";
 import { Button } from "../../../components/ui/button";
@@ -11,15 +10,22 @@ import { Input } from "../../../components/ui/input";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { apiRequest } from "../../../lib/api-client/base";
 import { getErrorMessage } from "../../../lib/error-utils";
+import { validatePassword } from "../../settings/lib/settings-utils";
 
 interface RegisterResponse {
 	user: CurrentUser;
 }
 
-export const PasskeySetup = () => {
-	const { gradient: themeGradient } = useThemeGradient();
+interface PasskeySetupProps {
+	onAccountCreated: () => void;
+	passwordPolicy?: PasswordPolicy;
+}
 
-	const router = useRouter();
+export const PasskeySetup = ({
+	onAccountCreated,
+	passwordPolicy = "strict",
+}: PasskeySetupProps) => {
+	const { gradient: themeGradient } = useThemeGradient();
 	const [formState, setFormState] = useState({
 		username: "",
 		password: "",
@@ -38,24 +44,9 @@ export const PasskeySetup = () => {
 			setError("Username and password are required");
 			return;
 		}
-		if (formState.password.length < 8) {
-			setError("Password must be at least 8 characters");
-			return;
-		}
-		if (!/[a-z]/.test(formState.password)) {
-			setError("Password must contain at least one lowercase letter");
-			return;
-		}
-		if (!/[A-Z]/.test(formState.password)) {
-			setError("Password must contain at least one uppercase letter");
-			return;
-		}
-		if (!/[0-9]/.test(formState.password)) {
-			setError("Password must contain at least one number");
-			return;
-		}
-		if (!/[^a-zA-Z0-9]/.test(formState.password)) {
-			setError("Password must contain at least one special character");
+		const passwordValidation = validatePassword(formState.password, passwordPolicy);
+		if (!passwordValidation.valid) {
+			setError(passwordValidation.message ?? "Password validation failed");
 			return;
 		}
 		if (formState.password !== formState.confirmPassword) {
@@ -79,12 +70,15 @@ export const PasskeySetup = () => {
 			userCreated = true;
 
 			// Step 2: Get passkey registration options
-			const options = await apiRequest<Parameters<typeof startRegistration>[0]>("/auth/passkey/register/options", {
-				method: "POST",
-				json: {
-					friendlyName: formState.passkeyName.trim() || `${formState.username}'s passkey`,
+			const options = await apiRequest<Parameters<typeof startRegistration>[0]>(
+				"/auth/passkey/register/options",
+				{
+					method: "POST",
+					json: {
+						friendlyName: formState.passkeyName.trim() || `${formState.username}'s passkey`,
+					},
 				},
-			});
+			);
 
 			// Step 3: Trigger WebAuthn registration
 			const registrationResponse = await startRegistration(options);
@@ -98,8 +92,7 @@ export const PasskeySetup = () => {
 				},
 			});
 
-			// Registration successful, redirect to dashboard
-			router.push("/dashboard");
+			onAccountCreated();
 		} catch (err: unknown) {
 			// If user was created but passkey registration failed, delete the incomplete account
 			if (userCreated) {
@@ -156,8 +149,9 @@ export const PasskeySetup = () => {
 					className="rounded-xl"
 				/>
 				<p className="text-xs text-muted-foreground">
-					Required as a backup login method. Must include uppercase, lowercase, number, and special
-					character.
+					{passwordPolicy === "relaxed"
+						? "Required as a backup login method. Must be at least 8 characters."
+						: "Required as a backup login method. Must include uppercase, lowercase, number, and special character."}
 				</p>
 			</div>
 			<div className="space-y-2">

--- a/apps/web/src/features/setup/components/password-setup.tsx
+++ b/apps/web/src/features/setup/components/password-setup.tsx
@@ -2,7 +2,6 @@
 
 import type { CurrentUser } from "@arr/shared";
 import { Loader2, Lock } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { Alert, AlertDescription } from "../../../components/ui";
 import { Button } from "../../../components/ui/button";
@@ -20,12 +19,14 @@ interface RegisterResponse {
 
 interface PasswordSetupProps {
 	passwordPolicy?: PasswordPolicy;
+	onAccountCreated: () => void;
 }
 
-export const PasswordSetup = ({ passwordPolicy = "strict" }: PasswordSetupProps) => {
+export const PasswordSetup = ({
+	passwordPolicy = "strict",
+	onAccountCreated,
+}: PasswordSetupProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
-
-	const router = useRouter();
 	const [formState, setFormState] = useState({
 		username: "",
 		password: "",
@@ -66,8 +67,7 @@ export const PasswordSetup = ({ passwordPolicy = "strict" }: PasswordSetupProps)
 				},
 			});
 
-			// Registration successful, redirect to dashboard
-			router.push("/dashboard");
+			onAccountCreated();
 		} catch (err: unknown) {
 			setError(getErrorMessage(err, "Failed to create admin account"));
 			setIsSubmitting(false);

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -1,0 +1,340 @@
+"use client";
+
+import type { SetupDiscoveryCandidate } from "@arr/shared";
+import { Check, Loader2, Radar, Server, SkipForward } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	Alert,
+	AlertDescription,
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Input,
+} from "../../../components/ui";
+import {
+	useCreateServiceMutation,
+	useTestConnectionBeforeAdd,
+} from "../../../hooks/api/useServiceMutations";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
+import { useSetupDiscovery } from "../../../hooks/api/useSetupDiscovery";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getErrorMessage } from "../../../lib/error-utils";
+import { getLinuxServerName, getLinuxUrl, useIncognitoMode } from "../../../lib/incognito";
+import { SERVICE_TYPES, type ServiceType } from "../../settings/lib/settings-constants";
+import { getServicePlaceholders } from "../../settings/lib/settings-utils";
+
+interface ServiceDraft {
+	service: ServiceType;
+	label: string;
+	baseUrl: string;
+	apiKey: string;
+}
+
+const emptyDraft = (service: ServiceType = "sonarr"): ServiceDraft => {
+	const placeholders = getServicePlaceholders(service);
+	return { service, label: placeholders.label, baseUrl: "", apiKey: "" };
+};
+
+const candidateDraft = (candidate: SetupDiscoveryCandidate): ServiceDraft => ({
+	service: candidate.service,
+	label: candidate.name,
+	baseUrl: candidate.baseUrl,
+	apiKey: "",
+});
+
+export const ServiceOnboarding = () => {
+	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
+	const discovery = useSetupDiscovery();
+	const createService = useCreateServiceMutation();
+	const testConnection = useTestConnectionBeforeAdd();
+	const { data: services = [], isLoading: servicesLoading } = useServicesQuery();
+	const [draft, setDraft] = useState<ServiceDraft | null>(null);
+	const [result, setResult] = useState<{ success: boolean; message: string } | null>(null);
+
+	const candidates = useMemo(
+		() =>
+			(discovery.data?.candidates ?? []).filter(
+				(candidate) =>
+					!services.some(
+						(service) =>
+							service.service === candidate.service && service.baseUrl === candidate.baseUrl,
+					),
+			),
+		[discovery.data?.candidates, services],
+	);
+
+	const selectService = (service: ServiceType) => {
+		setDraft(emptyDraft(service));
+		setResult(null);
+	};
+
+	const handleSave = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!draft) return;
+
+		const payload = {
+			service: draft.service,
+			label: draft.label.trim(),
+			baseUrl: draft.baseUrl.trim(),
+			apiKey: draft.apiKey.trim(),
+		};
+		if (!payload.label || !payload.baseUrl || payload.apiKey.length < 8) {
+			setResult({
+				success: false,
+				message: "Enter a label, a full URL, and an API key of at least 8 characters.",
+			});
+			return;
+		}
+
+		setResult(null);
+		try {
+			const connection = await testConnection.mutateAsync(payload);
+			if (!connection.success) {
+				setResult({
+					success: false,
+					message: connection.details ?? connection.error ?? "Connection could not be verified.",
+				});
+				return;
+			}
+
+			await createService.mutateAsync({
+				...payload,
+				enabled: true,
+				isDefault: !services.some((service) => service.service === payload.service),
+			});
+			setDraft(null);
+			setResult({ success: true, message: "Service connected successfully." });
+		} catch (error) {
+			setResult({ success: false, message: getErrorMessage(error, "Failed to add service") });
+		}
+	};
+
+	const isSaving = testConnection.isPending || createService.isPending;
+
+	return (
+		<div className="w-full max-w-4xl space-y-6 py-8">
+			<div className="space-y-3 text-center">
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 2</p>
+				<h1
+					className="text-3xl font-bold tracking-tight"
+					style={{
+						background: `linear-gradient(135deg, ${gradient.from}, ${gradient.to})`,
+						WebkitBackgroundClip: "text",
+						WebkitTextFillColor: "transparent",
+					}}
+				>
+					Connect your media stack
+				</h1>
+				<p className="mx-auto max-w-2xl text-muted-foreground">
+					We scan only supported media-server discovery protocols. Sonarr, Radarr, and other
+					services stay manual because they do not advertise a discovery protocol.
+				</p>
+			</div>
+
+			<Card className="border-border/50 bg-card/80">
+				<CardHeader>
+					<div className="flex flex-wrap items-center justify-between gap-3">
+						<div>
+							<CardTitle className="flex items-center gap-2">
+								<Radar className="h-5 w-5" /> Discovered media servers
+							</CardTitle>
+							<CardDescription>Review each candidate before connecting it.</CardDescription>
+						</div>
+						<Button
+							type="button"
+							variant="secondary"
+							onClick={() => discovery.refetch()}
+							disabled={discovery.isFetching}
+						>
+							{discovery.isFetching ? (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							) : (
+								<Radar className="h-4 w-4" />
+							)}
+							Scan again
+						</Button>
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					{discovery.isLoading ? (
+						<p className="text-sm text-muted-foreground">Scanning the local network…</p>
+					) : candidates.length > 0 ? (
+						<div className="grid gap-3 sm:grid-cols-2">
+							{candidates.map((candidate) => (
+								<div
+									key={`${candidate.service}:${candidate.serverId ?? candidate.baseUrl}`}
+									className="rounded-xl border border-border/60 p-4"
+								>
+									<p className="font-medium capitalize">{candidate.service}</p>
+									<p className="text-sm text-foreground">
+										{incognitoMode ? getLinuxServerName(candidate.name) : candidate.name}
+									</p>
+									<p className="truncate text-xs text-muted-foreground">
+										{incognitoMode ? getLinuxUrl(candidate.baseUrl) : candidate.baseUrl}
+									</p>
+									<Button
+										className="mt-3"
+										size="sm"
+										onClick={() => {
+											setDraft(candidateDraft(candidate));
+											setResult(null);
+										}}
+									>
+										Configure
+									</Button>
+								</div>
+							))}
+						</div>
+					) : (
+						<p className="text-sm text-muted-foreground">
+							No unconfigured media servers answered this scan. Discovery may not cross Docker
+							bridges, VLANs, or subnets; manual setup works in every network layout.
+						</p>
+					)}
+					{discovery.isError && (
+						<Alert variant="danger">
+							<AlertDescription>
+								{getErrorMessage(discovery.error, "Discovery failed")}
+							</AlertDescription>
+						</Alert>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card className="border-border/50 bg-card/80">
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Server className="h-5 w-5" /> Add a service
+					</CardTitle>
+					<CardDescription>
+						Choose a discovered candidate above or enter any supported service manually.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-4">
+					<div className="flex flex-wrap gap-2">
+						{SERVICE_TYPES.map((service) => (
+							<Button
+								key={service}
+								type="button"
+								size="sm"
+								variant={draft?.service === service ? "default" : "outline"}
+								onClick={() => selectService(service)}
+								className="capitalize"
+							>
+								{service}
+							</Button>
+						))}
+					</div>
+
+					{draft && (
+						<form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSave} autoComplete="off">
+							<label className="space-y-2 text-sm">
+								Label
+								<Input
+									value={draft.label}
+									onChange={(event) =>
+										setDraft((current) =>
+											current ? { ...current, label: event.target.value } : current,
+										)
+									}
+									required
+									maxLength={120}
+								/>
+							</label>
+							<label className="space-y-2 text-sm">
+								Base URL
+								<Input
+									type="url"
+									value={draft.baseUrl}
+									onChange={(event) =>
+										setDraft((current) =>
+											current ? { ...current, baseUrl: event.target.value } : current,
+										)
+									}
+									placeholder={getServicePlaceholders(draft.service).baseUrl}
+									required
+									data-1p-ignore
+								/>
+							</label>
+							<label className="space-y-2 text-sm sm:col-span-2">
+								API key
+								<Input
+									type="password"
+									value={draft.apiKey}
+									onChange={(event) =>
+										setDraft((current) =>
+											current ? { ...current, apiKey: event.target.value } : current,
+										)
+									}
+									required
+									minLength={8}
+									autoComplete="off"
+									data-1p-ignore
+								/>
+							</label>
+							<div className="flex gap-2 sm:col-span-2">
+								<Button type="submit" disabled={isSaving}>
+									{isSaving && <Loader2 className="h-4 w-4 animate-spin" />} Test and add
+								</Button>
+								<Button
+									type="button"
+									variant="ghost"
+									onClick={() => {
+										setDraft(null);
+										setResult(null);
+									}}
+								>
+									Cancel
+								</Button>
+							</div>
+						</form>
+					)}
+
+					{result && (
+						<Alert variant={result.success ? "success" : "danger"}>
+							<AlertDescription>{result.message}</AlertDescription>
+						</Alert>
+					)}
+
+					<div className="space-y-2 border-t border-border/50 pt-4">
+						<p className="text-sm font-medium">Connected during setup</p>
+						{servicesLoading ? (
+							<p className="text-sm text-muted-foreground">Loading services…</p>
+						) : services.length > 0 ? (
+							<ul className="space-y-2">
+								{services.map((service) => (
+									<li key={service.id} className="flex items-center gap-2 text-sm">
+										<Check className="h-4 w-4" />
+										<span className="capitalize">{service.service}</span>
+										<span>{incognitoMode ? getLinuxServerName(service.label) : service.label}</span>
+									</li>
+								))}
+							</ul>
+						) : (
+							<p className="text-sm text-muted-foreground">
+								None yet. You can also add services later in Settings.
+							</p>
+						)}
+					</div>
+				</CardContent>
+			</Card>
+
+			<div className="flex justify-end">
+				<Button
+					type="button"
+					size="lg"
+					onClick={() => {
+						window.location.href = "/console";
+					}}
+				>
+					<SkipForward className="h-4 w-4" />{" "}
+					{services.length > 0 ? "Finish setup" : "Skip for now"}
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/setup/components/setup-client.tsx
+++ b/apps/web/src/features/setup/components/setup-client.tsx
@@ -16,14 +16,26 @@ import { cn } from "../../../lib/utils";
 import { OIDCSetup } from "./oidc-setup";
 import { PasskeySetup } from "./passkey-setup";
 import { PasswordSetup } from "./password-setup";
+import { ServiceOnboarding } from "./service-onboarding";
 
 type SetupMethod = "password" | "oidc" | "passkey";
 
-export const SetupClient = () => {
+interface SetupClientProps {
+	stage: "account" | "services";
+}
+
+export const SetupClient = ({ stage }: SetupClientProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const { data: setupData } = useSetupRequired();
 	const [activeMethod, setActiveMethod] = useState<SetupMethod>("passkey");
 	const passwordPolicy = setupData?.passwordPolicy ?? "strict";
+	const continueToServices = () => {
+		window.location.href = "/setup?stage=services";
+	};
+
+	if (stage === "services") {
+		return <ServiceOnboarding />;
+	}
 
 	const methods = [
 		{ id: "passkey" as const, label: "Passkey", icon: KeyRound },
@@ -98,8 +110,12 @@ export const SetupClient = () => {
 					</div>
 
 					{/* Method-specific forms */}
-					{activeMethod === "passkey" && <PasskeySetup />}
-					{activeMethod === "password" && <PasswordSetup passwordPolicy={passwordPolicy} />}
+					{activeMethod === "passkey" && (
+						<PasskeySetup onAccountCreated={continueToServices} passwordPolicy={passwordPolicy} />
+					)}
+					{activeMethod === "password" && (
+						<PasswordSetup passwordPolicy={passwordPolicy} onAccountCreated={continueToServices} />
+					)}
 					{activeMethod === "oidc" && <OIDCSetup />}
 				</CardContent>
 			</Card>

--- a/apps/web/src/hooks/api/useSetupDiscovery.ts
+++ b/apps/web/src/hooks/api/useSetupDiscovery.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import type { SetupDiscoveryResponse } from "@arr/shared";
+import { useQuery } from "@tanstack/react-query";
+import { discoverSetupCandidates } from "../../lib/api-client/setup";
+import { setupKeys } from "../../lib/query-keys";
+
+export const useSetupDiscovery = () =>
+	useQuery<SetupDiscoveryResponse, Error>({
+		queryKey: setupKeys.discovery,
+		queryFn: discoverSetupCandidates,
+		refetchOnMount: "always",
+		refetchOnWindowFocus: false,
+		retry: false,
+	});

--- a/apps/web/src/lib/api-client/setup.ts
+++ b/apps/web/src/lib/api-client/setup.ts
@@ -1,0 +1,9 @@
+import { setupDiscoveryResponseSchema, type SetupDiscoveryResponse } from "@arr/shared";
+import { apiRequest } from "./base";
+
+export async function discoverSetupCandidates(): Promise<SetupDiscoveryResponse> {
+	const response = await apiRequest<SetupDiscoveryResponse>("/api/setup/discovery", {
+		method: "POST",
+	});
+	return setupDiscoveryResponseSchema.parse(response);
+}

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -34,6 +34,10 @@ export const authKeys = {
 	passkeyCredentials: ["passkey-credentials"] as const,
 };
 
+export const setupKeys = {
+	discovery: ["setup", "discovery"] as const,
+};
+
 /* -------------------------------------------------------------------------- */
 /*  Services                                                                   */
 /* -------------------------------------------------------------------------- */

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry in progress |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569) |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568): typed candidates, recorded protocol fixtures, and bounded Plex/Jellyfin/Emby UDP probes; guided wizard follows |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry in progress |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/adr/0008-setup-auto-discovery-scope.md
+++ b/docs/adr/0008-setup-auto-discovery-scope.md
@@ -116,3 +116,10 @@ bounded, authenticated endpoint. It returns candidates only, coalesces
 overlapping scans, and treats unavailable UDP networking as an empty
 result. SSDP and mDNS remain fallback mechanisms for the guided-wizard
 slice; they do not broaden discovery to the *arr family.
+
+**Guided-wizard note (2026-07-15):** the first wizard slice carries all
+three bootstrap authentication methods into an authenticated service
+onboarding step. Discovery candidates only pre-fill forms; the operator
+must supply credentials, pass a live connection test, and explicitly
+save each service. Manual entry remains available for every supported
+service, and the flow explains why the *arr family is not scanned.


### PR DESCRIPTION
## Summary

- continue password, passkey, and first-user OIDC bootstrap into an authenticated Setup stage
- present bounded media-server discovery candidates for explicit confirmation
- support manual entry for every service while explaining why the *arr family is not scanned
- require a successful live connection test before persisting any service
- hand completed or skipped onboarding into the Operator Console

## Impact

Fresh installs no longer jump directly from account creation to the dashboard. Operators get a progressive service-onboarding step that keeps discovery candidate-only, preserves manual setup for segmented networks, and never saves unverified credentials. Existing OIDC logins retain their original redirect behavior.

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,922 passed, 41 skipped
- `pnpm run lint` — passed with existing warnings
- `pnpm --filter @arr/web build`
- focused onboarding UI and OIDC continuation tests
- isolated fresh-install browser smoke: password registration → authenticated service stage → bounded empty discovery → manual Sonarr prefill → Console handoff
- independent adversarial review; the browser pass caught and drove a fix for a hanging mutation-mode scan
- changed formatter-managed files and `git diff --check` pass

## Formatting note

`pnpm run format` still reports pre-existing repository-wide API formatting drift. This PR adds no formatter drift in its changed files.

## Follow-up

Opinionated TRaSH defaults, sample automation rules, the Console walkthrough, and SSDP/mDNS fallback probes remain later Setup rewrite slices.