### PR TITLE
Add Plex SSDP setup discovery fallback

### DIFF
--- a/apps/api/src/lib/setup-discovery/__tests__/fixtures/plex-ssdp-response.txt
+++ b/apps/api/src/lib/setup-discovery/__tests__/fixtures/plex-ssdp-response.txt
@@ -1,0 +1,7 @@
+HTTP/1.1 200 OK
+CACHE-CONTROL: max-age=1800
+EXT:
+LOCATION: http://10.0.0.20:32469/DeviceDescription.xml
+SERVER: Linux/6.8 UPnP/1.0 DLNADOC/1.50
+ST: urn:schemas-upnp-org:device:MediaServer:1
+USN: uuid:2b95f4f3-0e2d-4ee4-a05d-3c7eaf30d990::urn:schemas-upnp-org:device:MediaServer:1

--- a/apps/api/src/lib/setup-discovery/__tests__/parsers.test.ts
+++ b/apps/api/src/lib/setup-discovery/__tests__/parsers.test.ts
@@ -2,7 +2,11 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
-import { parseMediaBrowserUdpResponse, parsePlexGdmResponse } from "../parsers";
+import {
+	parseMediaBrowserUdpResponse,
+	parsePlexGdmResponse,
+	parsePlexSsdpResponse,
+} from "../parsers";
 
 const fixtures = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
 const fixture = (name: string) => readFileSync(join(fixtures, name));
@@ -17,6 +21,18 @@ describe("setup discovery datagram parsers", () => {
 			baseUrl: "http://192.168.1.20:32400",
 			serverId: "plex-server-123",
 			protocol: "plex-gdm",
+		});
+	});
+
+	it("parses a Plex SSDP response into the Plex HTTP endpoint", () => {
+		expect(
+			parsePlexSsdpResponse(fixture("plex-ssdp-response.txt"), { address: "192.168.1.20" }),
+		).toEqual({
+			service: "plex",
+			name: "Plex Media Server",
+			baseUrl: "http://192.168.1.20:32400",
+			serverId: "2b95f4f3-0e2d-4ee4-a05d-3c7eaf30d990",
+			protocol: "plex-ssdp",
 		});
 	});
 
@@ -43,6 +59,12 @@ describe("setup discovery datagram parsers", () => {
 
 	it("rejects malformed, unrelated, and non-HTTP responses", () => {
 		expect(parsePlexGdmResponse("HTTP/1.0 404 Nope", { address: "192.168.1.2" })).toBeNull();
+		expect(
+			parsePlexSsdpResponse(
+				"HTTP/1.1 200 OK\r\nST: urn:schemas-upnp-org:device:MediaServer:1\r\nLOCATION: http://192.168.1.2:8200/description.xml\r\nUSN: uuid:not-plex::urn:schemas-upnp-org:device:MediaServer:1",
+				{ address: "192.168.1.2" },
+			),
+		).toBeNull();
 		expect(
 			parseMediaBrowserUdpResponse(
 				"jellyfin",

--- a/apps/api/src/lib/setup-discovery/__tests__/udp-discovery.test.ts
+++ b/apps/api/src/lib/setup-discovery/__tests__/udp-discovery.test.ts
@@ -8,7 +8,7 @@ import {
 
 type Handler = (...args: never[]) => void;
 
-function respondingSocketFactory(): () => Socket {
+function respondingSocketFactory(options?: { gdm?: boolean }): () => Socket {
 	return () => {
 		const handlers = new Map<string, Handler[]>();
 		const socket = {
@@ -28,12 +28,20 @@ function respondingSocketFactory(): () => Socket {
 			},
 			send(message: Buffer, _port: number, _host: string, callback: (error: null) => void) {
 				const query = message.toString();
-				const payload = query.includes("M-SEARCH")
-					? "HTTP/1.0 200 OK\r\nContent-Type: plex/media-server\r\nName: Plex\r\nPort: 32400\r\nResource-Identifier: plex-1"
-					: query.includes("Jellyfin")
-						? '{"Address":"http://10.0.0.2:8096","Id":"jelly-1","Name":"Jellyfin"}'
-						: '{"Address":"http://10.0.0.3:8096","Id":"emby-1","Name":"Emby"}';
+				const isSsdp = query.includes("239.255.255.250");
+				const isGdm = query.includes("M-SEARCH") && !isSsdp;
+				const payload = isSsdp
+					? "HTTP/1.1 200 OK\r\nST: urn:schemas-upnp-org:device:MediaServer:1\r\nLOCATION: http://192.168.1.2:32469/DeviceDescription.xml\r\nUSN: uuid:ssdp-plex-1::urn:schemas-upnp-org:device:MediaServer:1"
+					: query.includes("M-SEARCH")
+						? "HTTP/1.0 200 OK\r\nContent-Type: plex/media-server\r\nName: Plex\r\nPort: 32400\r\nResource-Identifier: plex-1"
+						: query.includes("Jellyfin")
+							? '{"Address":"http://10.0.0.2:8096","Id":"jelly-1","Name":"Jellyfin"}'
+							: '{"Address":"http://10.0.0.3:8096","Id":"emby-1","Name":"Emby"}';
 				queueMicrotask(() => {
+					if (isGdm && options?.gdm === false) {
+						callback(null);
+						return;
+					}
 					for (const handler of handlers.get("message") ?? []) {
 						(handler as (...args: unknown[]) => void)(Buffer.from(payload), {
 							address: query.includes("M-SEARCH") ? "192.168.1.2" : "192.168.1.3",
@@ -66,6 +74,20 @@ describe("bounded UDP setup discovery", () => {
 			"jellyfin",
 			"plex",
 		]);
+		expect(result.candidates.find((candidate) => candidate.service === "plex")?.protocol).toBe(
+			"plex-gdm",
+		);
+	});
+
+	it("returns the SSDP fallback when Plex does not answer GDM", async () => {
+		const result = await discoverMediaServers({
+			timeoutMs: 5,
+			socketFactory: respondingSocketFactory({ gdm: false }),
+		});
+		expect(result.candidates.find((candidate) => candidate.service === "plex")).toMatchObject({
+			baseUrl: "http://192.168.1.2:32400",
+			protocol: "plex-ssdp",
+		});
 	});
 
 	it("deduplicates repeated datagrams by service and stable server identity", () => {
@@ -79,6 +101,23 @@ describe("bounded UDP setup discovery", () => {
 		expect(deduplicateCandidates([candidate, { ...candidate, name: "Duplicate" }])).toEqual([
 			candidate,
 		]);
+	});
+
+	it("deduplicates fallback responses by service URL while preserving the primary result", () => {
+		const primary = {
+			service: "plex" as const,
+			name: "Cinema Plex",
+			baseUrl: "http://192.168.1.2:32400",
+			serverId: "gdm-identity",
+			protocol: "plex-gdm" as const,
+		};
+		const fallback = {
+			...primary,
+			name: "Plex Media Server",
+			serverId: "ssdp-identity",
+			protocol: "plex-ssdp" as const,
+		};
+		expect(deduplicateCandidates([primary, fallback])).toEqual([primary]);
 	});
 
 	it("fails silent-and-fast when UDP sockets are unavailable", async () => {

--- a/apps/api/src/lib/setup-discovery/parsers.ts
+++ b/apps/api/src/lib/setup-discovery/parsers.ts
@@ -2,6 +2,20 @@ import type { SetupDiscoveryCandidate } from "@arr/shared";
 
 type RemoteInfo = { address: string };
 
+function parseHeaders(payload: Buffer | string): {
+	statusLine: string;
+	headers: Map<string, string>;
+} {
+	const lines = payload.toString().split(/\r?\n/);
+	const headers = new Map<string, string>();
+	for (const line of lines.slice(1)) {
+		const separator = line.indexOf(":");
+		if (separator < 1) continue;
+		headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
+	}
+	return { statusLine: lines[0] ?? "", headers };
+}
+
 function localBaseUrl(reportedAddress: string, remote: RemoteInfo): string | null {
 	try {
 		const parsed = new URL(
@@ -23,15 +37,8 @@ export function parsePlexGdmResponse(
 	payload: Buffer | string,
 	remote: RemoteInfo,
 ): SetupDiscoveryCandidate | null {
-	const lines = payload.toString().split(/\r?\n/);
-	if (!lines[0]?.includes("200 OK")) return null;
-
-	const headers = new Map<string, string>();
-	for (const line of lines.slice(1)) {
-		const separator = line.indexOf(":");
-		if (separator < 1) continue;
-		headers.set(line.slice(0, separator).trim().toLowerCase(), line.slice(separator + 1).trim());
-	}
+	const { statusLine, headers } = parseHeaders(payload);
+	if (!statusLine.includes("200 OK")) return null;
 	if (headers.get("content-type") !== "plex/media-server") return null;
 	const port = Number(headers.get("port"));
 	if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
@@ -42,6 +49,39 @@ export function parsePlexGdmResponse(
 		baseUrl: `http://${remote.address}:${port}`,
 		serverId: headers.get("resource-identifier")?.slice(0, 256) || null,
 		protocol: "plex-gdm",
+	};
+}
+
+const PLEX_DLNA_PORT = 32469;
+const PLEX_HTTP_PORT = 32400;
+const MEDIA_SERVER_ST = "urn:schemas-upnp-org:device:mediaserver:1";
+
+export function parsePlexSsdpResponse(
+	payload: Buffer | string,
+	remote: RemoteInfo,
+): SetupDiscoveryCandidate | null {
+	const { statusLine, headers } = parseHeaders(payload);
+	if (!/^HTTP\/1\.[01] 200(?:\s|$)/i.test(statusLine)) return null;
+	if (headers.get("st")?.toLowerCase() !== MEDIA_SERVER_ST) return null;
+
+	let location: URL;
+	try {
+		location = new URL(headers.get("location") ?? "");
+	} catch {
+		return null;
+	}
+	if (location.protocol !== "http:" || Number(location.port) !== PLEX_DLNA_PORT) return null;
+
+	const usn = headers.get("usn") ?? "";
+	const match = /^uuid:([^:]+)::urn:schemas-upnp-org:device:mediaserver:1$/i.exec(usn);
+	if (!match?.[1]) return null;
+
+	return {
+		service: "plex",
+		name: "Plex Media Server",
+		baseUrl: `http://${remote.address}:${PLEX_HTTP_PORT}`,
+		serverId: match[1].slice(0, 256),
+		protocol: "plex-ssdp",
 	};
 }
 

--- a/apps/api/src/lib/setup-discovery/udp-discovery.ts
+++ b/apps/api/src/lib/setup-discovery/udp-discovery.ts
@@ -4,11 +4,16 @@ import type {
 	SetupDiscoveryResponse,
 } from "@arr/shared";
 import { createSocket, type RemoteInfo, type Socket } from "node:dgram";
-import { parseMediaBrowserUdpResponse, parsePlexGdmResponse } from "./parsers.js";
+import {
+	parseMediaBrowserUdpResponse,
+	parsePlexGdmResponse,
+	parsePlexSsdpResponse,
+} from "./parsers.js";
 
 const DEFAULT_TIMEOUT_MS = 1_200;
 export const SETUP_DISCOVERY_PROTOCOLS = [
 	"plex-gdm",
+	"plex-ssdp",
 	"jellyfin-udp",
 	"emby-udp",
 ] as const satisfies readonly SetupDiscoveryProtocol[];
@@ -30,6 +35,15 @@ const PROBES: readonly Probe[] = [
 		port: 32414,
 		broadcast: false,
 		parse: parsePlexGdmResponse,
+	},
+	{
+		protocol: "plex-ssdp",
+		message:
+			'M-SEARCH * HTTP/1.1\r\nHOST: 239.255.255.250:1900\r\nMAN: "ssdp:discover"\r\nMX: 1\r\nST: urn:schemas-upnp-org:device:MediaServer:1\r\n\r\n',
+		host: "239.255.255.250",
+		port: 1900,
+		broadcast: false,
+		parse: parsePlexSsdpResponse,
 	},
 	{
 		protocol: "jellyfin-udp",
@@ -144,9 +158,11 @@ export function deduplicateCandidates(
 ): SetupDiscoveryCandidate[] {
 	const seen = new Set<string>();
 	return candidates.filter((candidate) => {
-		const key = `${candidate.service}:${candidate.serverId ?? candidate.baseUrl}`;
-		if (seen.has(key)) return false;
-		seen.add(key);
+		const urlKey = `${candidate.service}:url:${candidate.baseUrl}`;
+		const idKey = candidate.serverId ? `${candidate.service}:id:${candidate.serverId}` : null;
+		if (seen.has(urlKey) || (idKey !== null && seen.has(idKey))) return false;
+		seen.add(urlKey);
+		if (idKey !== null) seen.add(idKey);
 		return true;
 	});
 }

--- a/apps/api/src/routes/__tests__/setup-discovery.test.ts
+++ b/apps/api/src/routes/__tests__/setup-discovery.test.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
 				protocol: "plex-gdm",
 			},
 		],
-		scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+		scannedProtocols: ["plex-gdm", "plex-ssdp", "jellyfin-udp", "emby-udp"],
 		durationMs: 1200,
 	});
 	app = Fastify({ logger: false });
@@ -49,7 +49,7 @@ describe("POST /setup/discovery", () => {
 	it("coalesces overlapping scans instead of multiplying network broadcasts", async () => {
 		let resolveScan!: (value: {
 			candidates: never[];
-			scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"];
+			scannedProtocols: ["plex-gdm", "plex-ssdp", "jellyfin-udp", "emby-udp"];
 			durationMs: number;
 		}) => void;
 		discoverMediaServers.mockReturnValueOnce(
@@ -63,7 +63,7 @@ describe("POST /setup/discovery", () => {
 		await vi.waitFor(() => expect(discoverMediaServers).toHaveBeenCalledOnce());
 		resolveScan({
 			candidates: [],
-			scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+			scannedProtocols: ["plex-gdm", "plex-ssdp", "jellyfin-udp", "emby-udp"],
 			durationMs: 1,
 		});
 

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569) |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/adr/0008-setup-auto-discovery-scope.md
+++ b/docs/adr/0008-setup-auto-discovery-scope.md
@@ -17,8 +17,10 @@ services is the worst part of first-run today.
 arr-dashboard connects to split into two classes:
 
 - **Media servers ship discovery protocols.** Plex answers GDM (UDP
-  broadcast on 32414) and SSDP; Jellyfin and Emby answer a UDP
-  discovery datagram ("Who is JellyfinServer?" on 7359) and mDNS.
+  broadcast on 32414) and, when its DLNA server is enabled, SSDP;
+  Jellyfin and Emby answer a UDP discovery datagram ("Who is
+  JellyfinServer?" on 7359). Upstream verification found no built-in
+  Jellyfin or Emby mDNS publisher.
   Discovery is a supported, documented use of these protocols.
 - **The *arr family ships none.** Sonarr, Radarr, Prowlarr, Lidarr, and
   Readarr have no broadcast/announce mechanism. "Detecting" them means
@@ -34,8 +36,8 @@ Setup auto-detection covers **media servers only**:
 | Service | Mechanism |
 |---|---|
 | Plex | GDM broadcast; SSDP fallback |
-| Jellyfin | UDP discovery (port 7359); mDNS fallback |
-| Emby | UDP discovery (shared lineage with Jellyfin); mDNS fallback |
+| Jellyfin | UDP discovery (port 7359) |
+| Emby | UDP discovery (shared lineage with Jellyfin) |
 | Tracearr | manual entry in 3.0; revisit if upstream adds announce/mDNS |
 
 The *arr services (and qui, Seerr) remain **manual entry**, with the
@@ -110,12 +112,14 @@ URL field.
 - The detection module ships with recorded-datagram fixtures so CI
   covers parsing without a live network.
 
-**Implementation note (2026-07-15):** the first Setup rewrite slice
-implements the primary Plex GDM and Jellyfin/Emby UDP probes behind a
-bounded, authenticated endpoint. It returns candidates only, coalesces
-overlapping scans, and treats unavailable UDP networking as an empty
-result. SSDP and mDNS remain fallback mechanisms for the guided-wizard
-slice; they do not broaden discovery to the *arr family.
+**Implementation note (2026-07-15):** the Setup rewrite implements the
+primary Plex GDM and Jellyfin/Emby UDP probes behind a bounded,
+authenticated endpoint, plus a Plex SSDP fallback for installations
+with DLNA enabled. It returns candidates only, coalesces overlapping
+scans, and treats unavailable UDP networking as an empty result.
+Jellyfin and Emby mDNS fallbacks were removed from the plan after their
+current upstream server implementations were verified not to publish
+those services. Discovery does not broaden to the *arr family.
 
 **Guided-wizard note (2026-07-15):** the first wizard slice carries all
 three bootstrap authentication methods into an authenticated service

--- a/packages/shared/src/types/__tests__/setup-discovery.test.ts
+++ b/packages/shared/src/types/__tests__/setup-discovery.test.ts
@@ -14,6 +14,18 @@ describe("setup discovery contracts", () => {
 		).toMatchObject({ service: "plex", protocol: "plex-gdm" });
 	});
 
+	it("accepts Plex SSDP as a discovery fallback", () => {
+		expect(
+			setupDiscoveryCandidateSchema.parse({
+				service: "plex",
+				name: "Plex Media Server",
+				baseUrl: "http://192.168.1.10:32400",
+				serverId: "plex-dlna-id",
+				protocol: "plex-ssdp",
+			}),
+		).toMatchObject({ service: "plex", protocol: "plex-ssdp" });
+	});
+
 	it("rejects unsupported services and non-HTTP URLs", () => {
 		expect(
 			setupDiscoveryCandidateSchema.safeParse({
@@ -42,7 +54,7 @@ describe("setup discovery contracts", () => {
 		expect(
 			setupDiscoveryResponseSchema.parse({
 				candidates: [],
-				scannedProtocols: ["plex-gdm", "jellyfin-udp", "emby-udp"],
+				scannedProtocols: ["plex-gdm", "plex-ssdp", "jellyfin-udp", "emby-udp"],
 				durationMs: 1200,
 			}),
 		).toMatchObject({ candidates: [], durationMs: 1200 });

--- a/packages/shared/src/types/setup-discovery.ts
+++ b/packages/shared/src/types/setup-discovery.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 
-export const setupDiscoveryProtocolSchema = z.enum(["plex-gdm", "jellyfin-udp", "emby-udp"]);
+export const setupDiscoveryProtocolSchema = z.enum([
+	"plex-gdm",
+	"plex-ssdp",
+	"jellyfin-udp",
+	"emby-udp",
+]);
 export type SetupDiscoveryProtocol = z.infer<typeof setupDiscoveryProtocolSchema>;
 
 function isCredentialFreeHttpUrl(value: string): boolean {


### PR DESCRIPTION
## What changed

- add a bounded Plex SSDP probe alongside the existing GDM discovery probe
- parse only Plex's documented DLNA endpoint shape and convert responses to the normal Plex HTTP endpoint
- preserve GDM as the preferred candidate and deduplicate fallback results by service URL or stable identity
- extend the shared discovery contract and add parser, probe, fallback, and deduplication coverage
- correct ADR-0008 after upstream verification showed that current Jellyfin and Emby servers do not publish built-in mDNS services

## Why

The guided Setup flow promised a fallback discovery path for Plex, but the discovery endpoint only ran the primary GDM probe. SSDP provides a real opt-in fallback when Plex's DLNA server is enabled. The handover also proposed Jellyfin and Emby mDNS fallbacks; upstream server code does not implement those publishers, so querying those service names would add network traffic without finding stock installations.

## Impact

Setup can now find a Plex server through SSDP when GDM is unavailable, while keeping scans bounded to the existing 1.2 second window. Discovery still returns candidates only and never connects automatically. Jellyfin and Emby continue to use their supported UDP discovery mechanism.

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,926 passed, 41 skipped
- `pnpm run lint` — passes with the existing warning baseline
- changed files pass Biome format and lint checks
- live UDP smoke test completed all four probes in 1.2 seconds and failed silently to an empty result on a network with no responding media servers

`pnpm run format` still reports the existing 89 unrelated API formatting failures; no changed file is among them.