### PR TITLE
feat(setup): add Operator Console walkthrough

### DIFF
--- a/apps/web/app/setup/__tests__/page.test.tsx
+++ b/apps/web/app/setup/__tests__/page.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	replace: vi.fn(),
+	stage: "console",
+	setupRequired: { data: { required: false }, isLoading: false },
+	currentUser: {
+		data: { id: "user-1", username: "admin" } as { id: string; username: string } | undefined,
+		isLoading: false,
+	},
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ replace: mocks.replace }),
+	useSearchParams: () => new URLSearchParams({ stage: mocks.stage }),
+}));
+
+vi.mock("../../../src/hooks/api/useAuth", () => ({
+	useSetupRequired: () => mocks.setupRequired,
+	useCurrentUser: () => mocks.currentUser,
+}));
+
+vi.mock("../../../src/features/setup/components/setup-client", () => ({
+	SetupClient: ({ stage }: { stage: string }) => <div>Setup stage: {stage}</div>,
+}));
+
+vi.mock("../../../src/components/ui", () => ({
+	Skeleton: () => <div>Loading setup</div>,
+}));
+
+import SetupPage from "../page";
+
+describe("SetupPage authenticated stages", () => {
+	beforeEach(() => {
+		mocks.replace.mockReset();
+		mocks.stage = "console";
+		mocks.setupRequired = { data: { required: false }, isLoading: false };
+		mocks.currentUser = {
+			data: { id: "user-1", username: "admin" },
+			isLoading: false,
+		};
+	});
+
+	it("renders the requested Console orientation for an authenticated user", () => {
+		render(<SetupPage />);
+
+		expect(screen.getByText("Setup stage: console")).toBeInTheDocument();
+		expect(mocks.replace).not.toHaveBeenCalled();
+	});
+
+	it("preserves the Console stage when redirecting an expired session to login", async () => {
+		mocks.currentUser = { data: undefined, isLoading: false };
+
+		render(<SetupPage />);
+
+		await waitFor(() => {
+			expect(mocks.replace).toHaveBeenCalledWith("/login?redirectTo=%2Fsetup%3Fstage%3Dconsole");
+		});
+	});
+});

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -15,25 +15,29 @@ const SetupLoading = () => (
 const SetupPageContent = () => {
 	const router = useRouter();
 	const searchParams = useSearchParams();
-	const requestedServicesStage = searchParams.get("stage") === "services";
+	const requestedStage = searchParams.get("stage");
+	const requestedAuthenticatedStage = requestedStage === "services" || requestedStage === "console";
+	const requestedSetupPath =
+		requestedStage === "console" ? "/setup?stage=console" : "/setup?stage=services";
 	const { data: setupRequired, isLoading } = useSetupRequired();
-	const shouldVerifySession = setupRequired?.required === false && requestedServicesStage;
+	const shouldVerifySession = setupRequired?.required === false && requestedAuthenticatedStage;
 	const { data: user, isLoading: userLoading } = useCurrentUser(shouldVerifySession);
 
 	useEffect(() => {
 		if (isLoading || userLoading) return;
 
-		if (setupRequired?.required === false && !requestedServicesStage) {
+		if (setupRequired?.required === false && !requestedAuthenticatedStage) {
 			router.replace("/login");
 			return;
 		}
 
 		if (shouldVerifySession && !user) {
-			router.replace("/login?redirectTo=%2Fsetup%3Fstage%3Dservices");
+			router.replace(`/login?redirectTo=${encodeURIComponent(requestedSetupPath)}`);
 		}
 	}, [
 		isLoading,
-		requestedServicesStage,
+		requestedAuthenticatedStage,
+		requestedSetupPath,
 		router,
 		setupRequired,
 		shouldVerifySession,
@@ -47,7 +51,7 @@ const SetupPageContent = () => {
 	}
 
 	// If setup is complete, don't render (will redirect)
-	if (setupRequired?.required === false && (!requestedServicesStage || !user)) {
+	if (setupRequired?.required === false && (!requestedAuthenticatedStage || !user)) {
 		return null;
 	}
 
@@ -55,8 +59,8 @@ const SetupPageContent = () => {
 		<main className="flex min-h-screen items-center justify-center bg-background px-4">
 			<SetupClient
 				stage={
-					requestedServicesStage && setupRequired?.required === false && user
-						? "services"
+					requestedAuthenticatedStage && setupRequired?.required === false && user
+						? requestedStage
 						: "account"
 				}
 			/>

--- a/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	push: vi.fn(),
+	incognito: false,
+	services: [
+		{
+			id: "service-1",
+			service: "jellyfin",
+			label: "Living Room Jellyfin",
+			baseUrl: "http://192.168.1.25:8096",
+			enabled: true,
+			isDefault: true,
+		},
+	],
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({ data: mocks.services, isLoading: false }),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "blue", to: "purple", glow: "blue" },
+	}),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [mocks.incognito, vi.fn()],
+	getLinuxServerName: () => "linux-server",
+}));
+
+import { ConsoleWalkthrough } from "../console-walkthrough";
+
+describe("ConsoleWalkthrough", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.incognito = false;
+	});
+
+	it("reviews connected services and walks through both Console surfaces", () => {
+		render(<ConsoleWalkthrough />);
+
+		expect(screen.getByText("Living Room Jellyfin")).toBeInTheDocument();
+		expect(screen.getByText("Orientation 1 of 3")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("Domain health")).toBeInTheDocument();
+		expect(screen.getByText("Needs Attention")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(screen.getByText("One rule view, explicit lifecycle")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Open Operator Console" }));
+		expect(mocks.push).toHaveBeenCalledWith("/console");
+	});
+
+	it("supports returning to services and masks instance labels in incognito mode", () => {
+		mocks.incognito = true;
+		render(<ConsoleWalkthrough />);
+
+		expect(screen.queryByText("Living Room Jellyfin")).not.toBeInTheDocument();
+		expect(screen.getByText("linux-server")).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Back to services" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=services");
+	});
+
+	it("allows the walkthrough to be skipped", () => {
+		render(<ConsoleWalkthrough />);
+		fireEvent.click(screen.getByRole("button", { name: "Skip walkthrough" }));
+		expect(mocks.push).toHaveBeenCalledWith("/console");
+	});
+});

--- a/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
@@ -5,6 +5,11 @@ const mocks = vi.hoisted(() => ({
 	refetchDiscovery: vi.fn(),
 	testConnection: vi.fn(),
 	createService: vi.fn(),
+	push: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mocks.push }),
 }));
 
 vi.mock("../../../../hooks/api/useSetupDiscovery", () => ({
@@ -109,5 +114,11 @@ describe("ServiceOnboarding", () => {
 
 		expect(await screen.findByText("Check the API key")).toBeInTheDocument();
 		expect(mocks.createService).not.toHaveBeenCalled();
+	});
+
+	it("continues to the Console walkthrough without requiring a service", () => {
+		render(<ServiceOnboarding />);
+		fireEvent.click(screen.getByRole("button", { name: "Continue without services" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=console");
 	});
 });

--- a/apps/web/src/features/setup/components/console-walkthrough.tsx
+++ b/apps/web/src/features/setup/components/console-walkthrough.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { Activity, ArrowLeft, ArrowRight, Check, Gauge, Workflow } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import {
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Progress,
+} from "../../../components/ui";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
+
+const WALKTHROUGH_STEPS = [
+	{
+		title: "Review your connected stack",
+		description:
+			"These verified services will feed the dashboard, health signals, and operator actions.",
+		icon: Check,
+	},
+	{
+		title: "Start with Overview",
+		description:
+			"Domain tiles summarize health and recent work. Needs Attention turns Pulse signals into a focused operator queue.",
+		icon: Gauge,
+	},
+	{
+		title: "Automate deliberately",
+		description:
+			"The Automation tab brings cleanup, tagging, notifications, and cross-domain rules into one reviewable surface.",
+		icon: Workflow,
+	},
+] as const;
+
+export const ConsoleWalkthrough = () => {
+	const router = useRouter();
+	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
+	const { data: services = [], isLoading } = useServicesQuery();
+	const [step, setStep] = useState(0);
+	const current = WALKTHROUGH_STEPS[step]!;
+	const CurrentIcon = current.icon;
+	const isLastStep = step === WALKTHROUGH_STEPS.length - 1;
+
+	return (
+		<div className="w-full max-w-3xl space-y-6 py-8">
+			<div className="space-y-3 text-center">
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 3 of 3</p>
+				<h1
+					className="text-3xl font-bold tracking-tight"
+					style={{
+						background: `linear-gradient(135deg, ${gradient.from}, ${gradient.to})`,
+						WebkitBackgroundClip: "text",
+						WebkitTextFillColor: "transparent",
+					}}
+				>
+					Meet your Operator Console
+				</h1>
+				<p className="mx-auto max-w-2xl text-muted-foreground">
+					A quick orientation before you take control. Nothing is changed or enabled during this
+					walkthrough.
+				</p>
+			</div>
+
+			<Card className="border-border/50 bg-card/80">
+				<CardHeader className="space-y-4">
+					<div className="flex items-center justify-between gap-4 text-xs text-muted-foreground">
+						<span>
+							Orientation {step + 1} of {WALKTHROUGH_STEPS.length}
+						</span>
+						<Button type="button" variant="ghost" size="sm" onClick={() => router.push("/console")}>
+							Skip walkthrough
+						</Button>
+					</div>
+					<Progress value={((step + 1) / WALKTHROUGH_STEPS.length) * 100} />
+					<div className="flex items-start gap-3">
+						<div className="rounded-xl border border-border/60 bg-muted/30 p-2.5">
+							<CurrentIcon className="h-5 w-5" style={{ color: gradient.from }} />
+						</div>
+						<div>
+							<CardTitle>{current.title}</CardTitle>
+							<CardDescription className="mt-1">{current.description}</CardDescription>
+						</div>
+					</div>
+				</CardHeader>
+				<CardContent>
+					{step === 0 && (
+						<div className="space-y-3">
+							{isLoading ? (
+								<p className="text-sm text-muted-foreground">Loading connected services…</p>
+							) : services.length > 0 ? (
+								<ul className="grid gap-2 sm:grid-cols-2">
+									{services.map((service) => (
+										<li
+											key={service.id}
+											className="flex items-center justify-between gap-3 rounded-xl border border-border/60 p-3"
+										>
+											<span className="min-w-0 truncate text-sm font-medium">
+												{incognitoMode ? getLinuxServerName(service.label) : service.label}
+											</span>
+											<Badge variant="outline" className="shrink-0 capitalize">
+												{service.service}
+											</Badge>
+										</li>
+									))}
+								</ul>
+							) : (
+								<div className="rounded-xl border border-border/60 p-4 text-sm text-muted-foreground">
+									No services are connected yet. The Console still opens normally, and Settings
+									remains the place to add services later.
+								</div>
+							)}
+						</div>
+					)}
+
+					{step === 1 && (
+						<div className="grid gap-3 sm:grid-cols-2">
+							<div className="rounded-xl border border-border/60 p-4">
+								<Gauge className="mb-3 h-5 w-5" style={{ color: gradient.from }} />
+								<p className="font-medium">Domain health</p>
+								<p className="mt-1 text-sm text-muted-foreground">
+									Tiles show which parts of the stack are healthy, degraded, disabled, or offline.
+								</p>
+							</div>
+							<div className="rounded-xl border border-border/60 p-4">
+								<Activity className="mb-3 h-5 w-5" style={{ color: gradient.to }} />
+								<p className="font-medium">Needs Attention</p>
+								<p className="mt-1 text-sm text-muted-foreground">
+									Actionable Pulse signals appear here with recovery-aware dismissal and safe
+									actions.
+								</p>
+							</div>
+						</div>
+					)}
+
+					{step === 2 && (
+						<div className="space-y-3">
+							<div className="rounded-xl border border-border/60 p-4">
+								<p className="font-medium">One rule view, explicit lifecycle</p>
+								<p className="mt-1 text-sm text-muted-foreground">
+									Review existing rules together, author supported domains, and dry-run cross-domain
+									rules before deploying them. Drafts do not execute.
+								</p>
+							</div>
+							<p className="text-sm text-muted-foreground">
+								Setup is complete. You can return to Settings at any time to connect more services.
+							</p>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<Button
+					type="button"
+					variant="ghost"
+					onClick={() =>
+						step === 0
+							? router.push("/setup?stage=services")
+							: setStep((currentStep) => currentStep - 1)
+					}
+				>
+					<ArrowLeft className="h-4 w-4" /> {step === 0 ? "Back to services" : "Back"}
+				</Button>
+				<Button
+					type="button"
+					size="lg"
+					onClick={() =>
+						isLastStep ? router.push("/console") : setStep((currentStep) => currentStep + 1)
+					}
+				>
+					{isLastStep ? "Open Operator Console" : "Continue"}
+					<ArrowRight className="h-4 w-4" />
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import type { SetupDiscoveryCandidate } from "@arr/shared";
-import { Check, Loader2, Radar, Server, SkipForward } from "lucide-react";
+import { ArrowRight, Check, Loader2, Radar, Server } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useMemo, useState } from "react";
 import {
 	Alert,
@@ -46,6 +47,7 @@ const candidateDraft = (candidate: SetupDiscoveryCandidate): ServiceDraft => ({
 });
 
 export const ServiceOnboarding = () => {
+	const router = useRouter();
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
 	const discovery = useSetupDiscovery();
@@ -118,7 +120,7 @@ export const ServiceOnboarding = () => {
 	return (
 		<div className="w-full max-w-4xl space-y-6 py-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 2</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 3</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{
@@ -232,9 +234,10 @@ export const ServiceOnboarding = () => {
 
 					{draft && (
 						<form className="grid gap-4 sm:grid-cols-2" onSubmit={handleSave} autoComplete="off">
-							<label className="space-y-2 text-sm">
+							<label htmlFor="setup-service-label" className="space-y-2 text-sm">
 								Label
 								<Input
+									id="setup-service-label"
 									value={draft.label}
 									onChange={(event) =>
 										setDraft((current) =>
@@ -245,9 +248,10 @@ export const ServiceOnboarding = () => {
 									maxLength={120}
 								/>
 							</label>
-							<label className="space-y-2 text-sm">
+							<label htmlFor="setup-service-url" className="space-y-2 text-sm">
 								Base URL
 								<Input
+									id="setup-service-url"
 									type="url"
 									value={draft.baseUrl}
 									onChange={(event) =>
@@ -260,9 +264,10 @@ export const ServiceOnboarding = () => {
 									data-1p-ignore
 								/>
 							</label>
-							<label className="space-y-2 text-sm sm:col-span-2">
+							<label htmlFor="setup-service-api-key" className="space-y-2 text-sm sm:col-span-2">
 								API key
 								<Input
+									id="setup-service-api-key"
 									type="password"
 									value={draft.apiKey}
 									onChange={(event) =>
@@ -324,15 +329,9 @@ export const ServiceOnboarding = () => {
 			</Card>
 
 			<div className="flex justify-end">
-				<Button
-					type="button"
-					size="lg"
-					onClick={() => {
-						window.location.href = "/console";
-					}}
-				>
-					<SkipForward className="h-4 w-4" />{" "}
-					{services.length > 0 ? "Finish setup" : "Skip for now"}
+				<Button type="button" size="lg" onClick={() => router.push("/setup?stage=console")}>
+					{services.length > 0 ? "Review and continue" : "Continue without services"}
+					<ArrowRight className="h-4 w-4" />
 				</Button>
 			</div>
 		</div>

--- a/apps/web/src/features/setup/components/setup-client.tsx
+++ b/apps/web/src/features/setup/components/setup-client.tsx
@@ -13,6 +13,7 @@ import {
 import { useSetupRequired } from "../../../hooks/api/useAuth";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { cn } from "../../../lib/utils";
+import { ConsoleWalkthrough } from "./console-walkthrough";
 import { OIDCSetup } from "./oidc-setup";
 import { PasskeySetup } from "./passkey-setup";
 import { PasswordSetup } from "./password-setup";
@@ -21,7 +22,7 @@ import { ServiceOnboarding } from "./service-onboarding";
 type SetupMethod = "password" | "oidc" | "passkey";
 
 interface SetupClientProps {
-	stage: "account" | "services";
+	stage: "account" | "services" | "console";
 }
 
 export const SetupClient = ({ stage }: SetupClientProps) => {
@@ -35,6 +36,9 @@ export const SetupClient = ({ stage }: SetupClientProps) => {
 
 	if (stage === "services") {
 		return <ServiceOnboarding />;
+	}
+	if (stage === "console") {
+		return <ConsoleWalkthrough />;
 	}
 
 	const methods = [

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback; Operator Console walkthrough |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.


### PR DESCRIPTION
## Summary

- add a third Setup stage that reviews connected services and introduces the Operator Console
- explain Overview, Needs Attention, and the automation lifecycle without creating or enabling anything
- preserve the requested Setup stage across login and route service onboarding into the walkthrough
- keep service names incognito-safe and improve service-form label associations
- update the 3.0 completeness tracker

## Why

First-time users currently leave service onboarding directly for the Console without context. This adds a short, skippable orientation that explains the primary operating surfaces and the safety model before handing over control.

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,932 passed, 41 skipped
- `pnpm run lint` — passes with the existing 10 API and 27 web warnings
- focused Biome checks on every changed TypeScript/TSX file
- Chromium first-run flow from account creation through the walkthrough at 1440px and 390px; no overflow or runtime errors

`pnpm run format` remains blocked by the existing 89 formatting errors in untouched API files. Every file changed by this PR is formatted.