### PR TITLE
feat(setup): add optional disabled starter drafts

### DIFF
--- a/apps/api/src/routes/__tests__/setup-starters.test.ts
+++ b/apps/api/src/routes/__tests__/setup-starters.test.ts
@@ -1,0 +1,151 @@
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerSetupRoutes } from "../setup";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "./test-helpers";
+
+const prisma = {
+	serviceInstance: { findMany: vi.fn() },
+	notificationRule: { findFirst: vi.fn(), create: vi.fn() },
+	autoTagRule: { findFirst: vi.fn(), create: vi.fn() },
+	labelSyncRule: { findFirst: vi.fn(), create: vi.fn() },
+	$transaction: vi.fn(async (operations: Promise<unknown>[]) => Promise.all(operations)),
+};
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	prisma.serviceInstance.findMany.mockResolvedValue([
+		{
+			id: "sonarr-1",
+			service: "SONARR",
+			label: "Primary Sonarr",
+			isDefault: true,
+			createdAt: new Date("2026-01-01"),
+		},
+		{
+			id: "plex-1",
+			service: "PLEX",
+			label: "Primary Plex",
+			isDefault: true,
+			createdAt: new Date("2026-01-01"),
+		},
+	]);
+	prisma.notificationRule.findFirst.mockResolvedValue(null);
+	prisma.autoTagRule.findFirst.mockResolvedValue(null);
+	prisma.labelSyncRule.findFirst.mockResolvedValue(null);
+	prisma.notificationRule.create.mockResolvedValue({ id: "notification-1" });
+	prisma.autoTagRule.create.mockResolvedValue({ id: "auto-tag-1" });
+	prisma.labelSyncRule.create.mockResolvedValue({ id: "label-sync-1" });
+
+	app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	app.decorate("prisma", prisma as any);
+	registerTestErrorHandler(app);
+	await app.register(registerSetupRoutes);
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterEach(async () => app.close());
+
+describe("Setup starter configuration", () => {
+	it("previews starter availability using only the current user's services and rules", async () => {
+		const response = await injectAuthenticated("GET", "/setup/starters");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			starters: [
+				{ id: "notification-throttle", available: true, existing: false },
+				{
+					id: "auto-tag-recent",
+					available: true,
+					source: { id: "sonarr-1", service: "sonarr" },
+				},
+				{
+					id: "label-sync-recent",
+					available: true,
+					destination: { id: "plex-1", service: "plex" },
+				},
+			],
+		});
+		expect(prisma.serviceInstance.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ where: expect.objectContaining({ userId: "user-1" }) }),
+		);
+		expect(prisma.notificationRule.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({ where: expect.objectContaining({ userId: "user-1" }) }),
+		);
+	});
+
+	it("atomically creates only selected starters in a disabled state", async () => {
+		const response = await injectAuthenticated("POST", "/setup/starters", {
+			body: {
+				starterIds: ["notification-throttle", "auto-tag-recent", "label-sync-recent"],
+			},
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(JSON.parse(response.payload)).toEqual({
+			created: ["notification-throttle", "auto-tag-recent", "label-sync-recent"],
+			existing: [],
+		});
+		expect(prisma.notificationRule.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ userId: "user-1", enabled: false }),
+			}),
+		);
+		expect(prisma.autoTagRule.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					userId: "user-1",
+					enabled: false,
+					instanceFilter: '["sonarr-1"]',
+				}),
+			}),
+		);
+		expect(prisma.labelSyncRule.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					userId: "user-1",
+					enabled: false,
+					sourceInstanceId: "sonarr-1",
+					destInstanceId: "plex-1",
+				}),
+			}),
+		);
+		expect(prisma.$transaction).toHaveBeenCalledOnce();
+	});
+
+	it("treats matching starters as existing instead of duplicating them", async () => {
+		prisma.notificationRule.findFirst.mockResolvedValue({ id: "existing-1" });
+
+		const response = await injectAuthenticated("POST", "/setup/starters", {
+			body: { starterIds: ["notification-throttle"] },
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(JSON.parse(response.payload)).toEqual({
+			created: [],
+			existing: ["notification-throttle"],
+		});
+		expect(prisma.notificationRule.create).not.toHaveBeenCalled();
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+	});
+
+	it("rejects topology-dependent starters when their services are unavailable", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([]);
+
+		const response = await injectAuthenticated("POST", "/setup/starters", {
+			body: { starterIds: ["label-sync-recent"] },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(JSON.parse(response.payload)).toMatchObject({ error: "Starter unavailable" });
+		expect(prisma.labelSyncRule.create).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -191,7 +191,7 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		prefix: "/api",
 		register: registerSetupRoutes,
 		maturity: "experimental",
-		summary: "Guided setup media-server discovery",
+		summary: "Guided setup discovery and disabled starter-rule drafts",
 	},
 	{
 		path: "/api/dashboard",

--- a/apps/api/src/routes/setup.ts
+++ b/apps/api/src/routes/setup.ts
@@ -1,9 +1,118 @@
-import type { SetupDiscoveryResponse } from "@arr/shared";
-import type { FastifyPluginCallback } from "fastify";
+import {
+	type ApplySetupStartersResponse,
+	applySetupStartersRequestSchema,
+	type SetupDiscoveryResponse,
+	type SetupStarterDefinition,
+	type SetupStarterId,
+} from "@arr/shared";
+import type { FastifyInstance, FastifyPluginCallback } from "fastify";
 import { discoverMediaServers } from "../lib/setup-discovery/udp-discovery.js";
+import { validateRequest } from "../lib/utils/validate.js";
 
 let activeDiscovery: Promise<SetupDiscoveryResponse> | null = null;
 const DISCOVERY_RATE_LIMIT = { max: 5, timeWindow: "1 minute" };
+
+const STARTER_NAMES: Record<SetupStarterId, string> = {
+	"notification-throttle": "Starter: throttle repeated hunt matches",
+	"auto-tag-recent": "Starter: tag recently added media",
+	"label-sync-recent": "Starter: sync recently added label",
+};
+
+type StarterService = NonNullable<SetupStarterDefinition["source"]>;
+
+const toStarterService = (service: {
+	id: string;
+	service: string;
+	label: string;
+}): StarterService => ({
+	id: service.id,
+	service: service.service.toLowerCase() as StarterService["service"],
+	label: service.label,
+});
+
+async function getStarterCatalog(
+	app: FastifyInstance,
+	userId: string,
+): Promise<SetupStarterDefinition[]> {
+	const [services, notificationRule, autoTagRule, labelSyncRule] = await Promise.all([
+		app.prisma.serviceInstance.findMany({
+			where: {
+				userId,
+				enabled: true,
+				service: { in: ["SONARR", "RADARR", "PLEX", "JELLYFIN", "EMBY"] },
+			},
+			select: { id: true, service: true, label: true, isDefault: true, createdAt: true },
+			orderBy: [{ isDefault: "desc" }, { createdAt: "asc" }],
+		}),
+		app.prisma.notificationRule.findFirst({
+			where: { userId, name: STARTER_NAMES["notification-throttle"] },
+			select: { id: true },
+		}),
+		app.prisma.autoTagRule.findFirst({
+			where: { userId, name: STARTER_NAMES["auto-tag-recent"] },
+			select: { id: true },
+		}),
+		app.prisma.labelSyncRule.findFirst({
+			where: { userId, name: STARTER_NAMES["label-sync-recent"] },
+			select: { id: true },
+		}),
+	]);
+
+	const sourceRow = services.find(
+		(service) => service.service === "SONARR" || service.service === "RADARR",
+	);
+	const destinationRow = services.find(
+		(service) =>
+			service.service === "PLEX" || service.service === "JELLYFIN" || service.service === "EMBY",
+	);
+	const source = sourceRow ? toStarterService(sourceRow) : null;
+	const destination = destinationRow ? toStarterService(destinationRow) : null;
+
+	return [
+		{
+			id: "notification-throttle",
+			kind: "notifications",
+			title: "Throttle repeated hunt matches",
+			description: "A starting point for grouping repeated content-found notifications.",
+			effect:
+				"Creates a disabled 30-minute throttle rule. It sends nothing until you review and enable it.",
+			available: true,
+			unavailableReason: null,
+			existing: Boolean(notificationRule),
+			source: null,
+			destination: null,
+		},
+		{
+			id: "auto-tag-recent",
+			kind: "auto-tag",
+			title: "Tag recently added media",
+			description: "A reusable draft for media added to Sonarr or Radarr in the last 30 days.",
+			effect:
+				"Creates a disabled rule that would apply the arr-dashboard-recent tag after you enable it.",
+			available: Boolean(source),
+			unavailableReason: source ? null : "Connect Sonarr or Radarr to use this starter.",
+			existing: Boolean(autoTagRule),
+			source,
+			destination: null,
+		},
+		{
+			id: "label-sync-recent",
+			kind: "label-sync",
+			title: "Sync the recently added label",
+			description: "A draft bridge from an *arr tag to your primary media server.",
+			effect:
+				"Creates a disabled mapping for arr-dashboard-recent. No labels are written until you enable it.",
+			available: Boolean(source && destination),
+			unavailableReason:
+				source && destination
+					? null
+					: "Connect Sonarr or Radarr plus Plex, Jellyfin, or Emby to use this starter.",
+			existing: Boolean(labelSyncRule),
+			source,
+			destination,
+		},
+	];
+}
 
 export const registerSetupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	app.post("/setup/discovery", { config: { rateLimit: DISCOVERY_RATE_LIMIT } }, async (request) => {
@@ -13,6 +122,81 @@ export const registerSetupRoutes: FastifyPluginCallback = (app, _opts, done) => 
 			});
 		}
 		return activeDiscovery;
+	});
+
+	app.get("/setup/starters", async (request) => {
+		const userId = request.currentUser!.id;
+		return { starters: await getStarterCatalog(app, userId) };
+	});
+
+	app.post("/setup/starters", async (request, reply) => {
+		const userId = request.currentUser!.id;
+		const body = validateRequest(applySetupStartersRequestSchema, request.body);
+		const catalog = await getStarterCatalog(app, userId);
+		const definitions = new Map(catalog.map((starter) => [starter.id, starter]));
+		const selected = body.starterIds.map((id) => definitions.get(id)!);
+		const unavailable = selected.find((starter) => !starter.available);
+		if (unavailable) {
+			return reply.status(400).send({
+				error: "Starter unavailable",
+				message: unavailable.unavailableReason,
+			});
+		}
+
+		const existing = selected.filter((starter) => starter.existing).map((starter) => starter.id);
+		const pending = selected.filter((starter) => !starter.existing);
+		const operations = pending.map((starter) => {
+			if (starter.id === "notification-throttle") {
+				return app.prisma.notificationRule.create({
+					data: {
+						userId,
+						name: STARTER_NAMES[starter.id],
+						enabled: false,
+						priority: 100,
+						action: "throttle",
+						conditions: JSON.stringify([
+							{ field: "eventType", operator: "equals", value: "HUNT_CONTENT_FOUND" },
+						]),
+						throttleMinutes: 30,
+					},
+				});
+			}
+			if (starter.id === "auto-tag-recent") {
+				return app.prisma.autoTagRule.create({
+					data: {
+						userId,
+						name: STARTER_NAMES[starter.id],
+						enabled: false,
+						ruleType: "age",
+						parameters: JSON.stringify({ field: "arrAddedAt", operator: "newer_than", days: 30 }),
+						serviceFilter: JSON.stringify([starter.source!.service]),
+						instanceFilter: JSON.stringify([starter.source!.id]),
+						tagName: "arr-dashboard-recent",
+					},
+				});
+			}
+			return app.prisma.labelSyncRule.create({
+				data: {
+					userId,
+					name: STARTER_NAMES[starter.id],
+					enabled: false,
+					sourceService: starter.source!.service,
+					sourceInstanceId: starter.source!.id,
+					sourceTagName: "arr-dashboard-recent",
+					destService: starter.destination!.service,
+					destInstanceId: starter.destination!.id,
+					destTagName: "arr-dashboard-recent",
+				},
+			});
+		});
+
+		if (operations.length > 0) await app.prisma.$transaction(operations);
+		const response: ApplySetupStartersResponse = {
+			created: pending.map((starter) => starter.id),
+			existing,
+		};
+		request.log.info({ userId, created: response.created }, "Applied disabled Setup starter rules");
+		return reply.status(201).send(response);
 	});
 
 	done();

--- a/apps/web/app/setup/__tests__/page.test.tsx
+++ b/apps/web/app/setup/__tests__/page.test.tsx
@@ -49,6 +49,14 @@ describe("SetupPage authenticated stages", () => {
 		expect(mocks.replace).not.toHaveBeenCalled();
 	});
 
+	it("renders the starter configuration stage for an authenticated user", () => {
+		mocks.stage = "starters";
+		render(<SetupPage />);
+
+		expect(screen.getByText("Setup stage: starters")).toBeInTheDocument();
+		expect(mocks.replace).not.toHaveBeenCalled();
+	});
+
 	it("preserves the Console stage when redirecting an expired session to login", async () => {
 		mocks.currentUser = { data: undefined, isLoading: false };
 

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -16,9 +16,14 @@ const SetupPageContent = () => {
 	const router = useRouter();
 	const searchParams = useSearchParams();
 	const requestedStage = searchParams.get("stage");
-	const requestedAuthenticatedStage = requestedStage === "services" || requestedStage === "console";
+	const requestedAuthenticatedStage =
+		requestedStage === "services" || requestedStage === "starters" || requestedStage === "console";
 	const requestedSetupPath =
-		requestedStage === "console" ? "/setup?stage=console" : "/setup?stage=services";
+		requestedStage === "console"
+			? "/setup?stage=console"
+			: requestedStage === "starters"
+				? "/setup?stage=starters"
+				: "/setup?stage=services";
 	const { data: setupRequired, isLoading } = useSetupRequired();
 	const shouldVerifySession = setupRequired?.required === false && requestedAuthenticatedStage;
 	const { data: user, isLoading: userLoading } = useCurrentUser(shouldVerifySession);

--- a/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
@@ -65,8 +65,8 @@ describe("ConsoleWalkthrough", () => {
 
 		expect(screen.queryByText("Living Room Jellyfin")).not.toBeInTheDocument();
 		expect(screen.getByText("linux-server")).toBeInTheDocument();
-		fireEvent.click(screen.getByRole("button", { name: "Back to services" }));
-		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=services");
+		fireEvent.click(screen.getByRole("button", { name: "Back to starters" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=starters");
 	});
 
 	it("allows the walkthrough to be skipped", () => {

--- a/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
@@ -119,6 +119,6 @@ describe("ServiceOnboarding", () => {
 	it("continues to the Console walkthrough without requiring a service", () => {
 		render(<ServiceOnboarding />);
 		fireEvent.click(screen.getByRole("button", { name: "Continue without services" }));
-		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=console");
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=starters");
 	});
 });

--- a/apps/web/src/features/setup/components/__tests__/starter-configuration.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/starter-configuration.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	push: vi.fn(),
+	mutateAsync: vi.fn(),
+	incognito: false,
+	starters: [
+		{
+			id: "notification-throttle" as const,
+			kind: "notifications" as const,
+			title: "Throttle repeated hunt matches",
+			description: "Notification starter",
+			effect: "Creates a disabled throttle rule.",
+			available: true,
+			unavailableReason: null,
+			existing: false,
+			source: null,
+			destination: null,
+		},
+		{
+			id: "auto-tag-recent" as const,
+			kind: "auto-tag" as const,
+			title: "Tag recently added media",
+			description: "Auto-Tag starter",
+			effect: "Creates a disabled tag rule.",
+			available: true,
+			unavailableReason: null,
+			existing: false,
+			source: { id: "sonarr-1", service: "sonarr" as const, label: "Family Sonarr" },
+			destination: null,
+		},
+		{
+			id: "label-sync-recent" as const,
+			kind: "label-sync" as const,
+			title: "Sync the recently added label",
+			description: "Label Sync starter",
+			effect: "Creates a disabled label mapping.",
+			available: true,
+			unavailableReason: null,
+			existing: false,
+			source: { id: "sonarr-1", service: "sonarr" as const, label: "Family Sonarr" },
+			destination: { id: "plex-1", service: "plex" as const, label: "Family Plex" },
+		},
+	],
+}));
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("../../../../hooks/api/useSetupStarters", () => ({
+	useSetupStarters: () => ({ data: { starters: mocks.starters }, isLoading: false, error: null }),
+	useApplySetupStarters: () => ({
+		mutateAsync: mocks.mutateAsync,
+		isPending: false,
+		error: null,
+	}),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({ gradient: { from: "blue", to: "purple", glow: "blue" } }),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [mocks.incognito, vi.fn()],
+	getLinuxServerName: () => "linux-server",
+}));
+
+import { StarterConfiguration } from "../starter-configuration";
+
+describe("StarterConfiguration", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.incognito = false;
+		mocks.mutateAsync.mockResolvedValue({ created: ["notification-throttle"], existing: [] });
+	});
+
+	it("creates only explicitly selected starters as disabled drafts", async () => {
+		render(<StarterConfiguration />);
+
+		expect(screen.queryByRole("button", { name: /Create/ })).not.toBeInTheDocument();
+		fireEvent.click(screen.getByRole("checkbox", { name: /Throttle repeated hunt matches/ }));
+		fireEvent.click(screen.getByRole("button", { name: "Create 1 disabled draft" }));
+
+		await waitFor(() => {
+			expect(mocks.mutateAsync).toHaveBeenCalledWith({
+				starterIds: ["notification-throttle"],
+			});
+		});
+		expect(screen.getByText(/Created 1 disabled draft/)).toBeInTheDocument();
+	});
+
+	it("masks service labels and supports safe navigation without applying", () => {
+		mocks.incognito = true;
+		render(<StarterConfiguration />);
+
+		expect(screen.queryByText("Family Sonarr", { exact: false })).not.toBeInTheDocument();
+		expect(screen.getAllByText(/linux-server/).length).toBeGreaterThan(0);
+		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=console");
+		expect(mocks.mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("returns to service setup", () => {
+		render(<StarterConfiguration />);
+		fireEvent.click(screen.getByRole("button", { name: "Back to services" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=services");
+	});
+});

--- a/apps/web/src/features/setup/components/console-walkthrough.tsx
+++ b/apps/web/src/features/setup/components/console-walkthrough.tsx
@@ -51,7 +51,7 @@ export const ConsoleWalkthrough = () => {
 	return (
 		<div className="w-full max-w-3xl space-y-6 py-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 3 of 3</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 4 of 4</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{
@@ -162,11 +162,11 @@ export const ConsoleWalkthrough = () => {
 					variant="ghost"
 					onClick={() =>
 						step === 0
-							? router.push("/setup?stage=services")
+							? router.push("/setup?stage=starters")
 							: setStep((currentStep) => currentStep - 1)
 					}
 				>
-					<ArrowLeft className="h-4 w-4" /> {step === 0 ? "Back to services" : "Back"}
+					<ArrowLeft className="h-4 w-4" /> {step === 0 ? "Back to starters" : "Back"}
 				</Button>
 				<Button
 					type="button"

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -120,7 +120,7 @@ export const ServiceOnboarding = () => {
 	return (
 		<div className="w-full max-w-4xl space-y-6 py-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 3</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 4</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{
@@ -329,7 +329,7 @@ export const ServiceOnboarding = () => {
 			</Card>
 
 			<div className="flex justify-end">
-				<Button type="button" size="lg" onClick={() => router.push("/setup?stage=console")}>
+				<Button type="button" size="lg" onClick={() => router.push("/setup?stage=starters")}>
 					{services.length > 0 ? "Review and continue" : "Continue without services"}
 					<ArrowRight className="h-4 w-4" />
 				</Button>

--- a/apps/web/src/features/setup/components/setup-client.tsx
+++ b/apps/web/src/features/setup/components/setup-client.tsx
@@ -18,11 +18,12 @@ import { OIDCSetup } from "./oidc-setup";
 import { PasskeySetup } from "./passkey-setup";
 import { PasswordSetup } from "./password-setup";
 import { ServiceOnboarding } from "./service-onboarding";
+import { StarterConfiguration } from "./starter-configuration";
 
 type SetupMethod = "password" | "oidc" | "passkey";
 
 interface SetupClientProps {
-	stage: "account" | "services" | "console";
+	stage: "account" | "services" | "starters" | "console";
 }
 
 export const SetupClient = ({ stage }: SetupClientProps) => {
@@ -36,6 +37,9 @@ export const SetupClient = ({ stage }: SetupClientProps) => {
 
 	if (stage === "services") {
 		return <ServiceOnboarding />;
+	}
+	if (stage === "starters") {
+		return <StarterConfiguration />;
 	}
 	if (stage === "console") {
 		return <ConsoleWalkthrough />;

--- a/apps/web/src/features/setup/components/starter-configuration.tsx
+++ b/apps/web/src/features/setup/components/starter-configuration.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import type { SetupStarterId, SetupStarterKind, SetupStarterService } from "@arr/shared";
+import { ArrowLeft, ArrowRight, Bell, Loader2, ShieldCheck, Tags, Workflow } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import {
+	Alert,
+	AlertDescription,
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	Checkbox,
+} from "../../../components/ui";
+import { useApplySetupStarters, useSetupStarters } from "../../../hooks/api/useSetupStarters";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { getErrorMessage } from "../../../lib/error-utils";
+import { getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
+
+const STARTER_ICONS: Record<SetupStarterKind, typeof Bell> = {
+	notifications: Bell,
+	"auto-tag": Tags,
+	"label-sync": Workflow,
+};
+
+const serviceName = (service: SetupStarterService, incognitoMode: boolean) =>
+	incognitoMode ? getLinuxServerName(service.label) : service.label;
+
+export const StarterConfiguration = () => {
+	const router = useRouter();
+	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
+	const { data, isLoading, error } = useSetupStarters();
+	const applyStarters = useApplySetupStarters();
+	const [selected, setSelected] = useState<Set<SetupStarterId>>(new Set());
+	const [appliedCount, setAppliedCount] = useState(0);
+
+	const toggleStarter = (id: SetupStarterId, checked: boolean) => {
+		setSelected((current) => {
+			const next = new Set(current);
+			if (checked) next.add(id);
+			else next.delete(id);
+			return next;
+		});
+	};
+
+	const handleApply = async () => {
+		if (selected.size === 0) return;
+		const result = await applyStarters.mutateAsync({ starterIds: [...selected] });
+		setAppliedCount(result.created.length);
+		setSelected(new Set());
+	};
+
+	return (
+		<div className="w-full max-w-4xl space-y-6 pb-24 pt-8">
+			<div className="space-y-3 text-center">
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 3 of 4</p>
+				<h1
+					className="text-3xl font-bold tracking-tight"
+					style={{
+						background: `linear-gradient(135deg, ${gradient.from}, ${gradient.to})`,
+						WebkitBackgroundClip: "text",
+						WebkitTextFillColor: "transparent",
+					}}
+				>
+					Choose a safe starting point
+				</h1>
+				<p className="mx-auto max-w-2xl text-muted-foreground">
+					Starter rules are optional and always created disabled. Review them later in the Operator
+					Console before enabling anything.
+				</p>
+			</div>
+
+			{appliedCount > 0 && (
+				<Alert>
+					<ShieldCheck className="h-4 w-4" />
+					<AlertDescription>
+						Created {appliedCount} disabled {appliedCount === 1 ? "draft" : "drafts"}. No automation
+						has run.
+					</AlertDescription>
+				</Alert>
+			)}
+
+			<Card className="border-border/50 bg-card/80">
+				<CardHeader>
+					<CardTitle>Optional starter drafts</CardTitle>
+					<CardDescription>
+						Select only the examples you want to keep and customize.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					{isLoading && (
+						<div className="flex items-center gap-2 py-8 text-sm text-muted-foreground">
+							<Loader2 className="h-4 w-4 animate-spin" /> Loading available starters…
+						</div>
+					)}
+					{error && (
+						<Alert variant="destructive">
+							<AlertDescription>{getErrorMessage(error)}</AlertDescription>
+						</Alert>
+					)}
+					{data?.starters.map((starter) => {
+						const Icon = STARTER_ICONS[starter.kind];
+						const disabled = !starter.available || starter.existing || applyStarters.isPending;
+						return (
+							<label
+								key={starter.id}
+								htmlFor={`starter-${starter.id}`}
+								className="flex cursor-pointer items-start gap-3 rounded-xl border border-border/60 p-4 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-60"
+							>
+								<Checkbox
+									id={`starter-${starter.id}`}
+									checked={selected.has(starter.id)}
+									disabled={disabled}
+									onCheckedChange={(checked) => toggleStarter(starter.id, checked === true)}
+									className="mt-1"
+								/>
+								<div className="min-w-0 flex-1 space-y-2">
+									<div className="flex flex-wrap items-center gap-2">
+										<Icon className="h-4 w-4" style={{ color: gradient.from }} />
+										<span className="font-medium">{starter.title}</span>
+										<Badge variant="outline" className="capitalize">
+											{starter.kind.replace("-", " ")}
+										</Badge>
+										{starter.existing && <Badge variant="secondary">Already exists</Badge>}
+									</div>
+									<p className="text-sm text-muted-foreground">{starter.description}</p>
+									<p className="text-sm">{starter.effect}</p>
+									{starter.source && (
+										<p className="text-xs text-muted-foreground">
+											Source: {serviceName(starter.source, incognitoMode)}
+											{starter.destination && (
+												<>
+													{" → "}
+													{serviceName(starter.destination, incognitoMode)}
+												</>
+											)}
+										</p>
+									)}
+									{starter.unavailableReason && (
+										<p className="text-xs text-muted-foreground">{starter.unavailableReason}</p>
+									)}
+								</div>
+							</label>
+						);
+					})}
+				</CardContent>
+			</Card>
+
+			<Card className="border-border/50 bg-card/80">
+				<CardContent className="flex items-start gap-3 p-4">
+					<ShieldCheck className="mt-0.5 h-5 w-5" style={{ color: gradient.to }} />
+					<div>
+						<p className="font-medium">TRaSH quality profiles require a deployment preview</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Setup will not guess a quality profile or change Sonarr/Radarr settings. TRaSH Guides
+							remains available after setup with a full before-and-after review.
+						</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			{applyStarters.error && (
+				<Alert variant="destructive">
+					<AlertDescription>{getErrorMessage(applyStarters.error)}</AlertDescription>
+				</Alert>
+			)}
+
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<Button type="button" variant="ghost" onClick={() => router.push("/setup?stage=services")}>
+					<ArrowLeft className="h-4 w-4" /> Back to services
+				</Button>
+				<div className="flex flex-wrap gap-2">
+					{selected.size > 0 && (
+						<Button
+							type="button"
+							variant="outline"
+							onClick={handleApply}
+							disabled={applyStarters.isPending}
+						>
+							{applyStarters.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+							Create {selected.size} disabled {selected.size === 1 ? "draft" : "drafts"}
+						</Button>
+					)}
+					<Button type="button" size="lg" onClick={() => router.push("/setup?stage=console")}>
+						{selected.size > 0 ? "Continue without creating" : "Continue"}
+						<ArrowRight className="h-4 w-4" />
+					</Button>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/apps/web/src/hooks/api/useSetupStarters.ts
+++ b/apps/web/src/hooks/api/useSetupStarters.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import type { ApplySetupStartersRequest, SetupStarterPreviewResponse } from "@arr/shared";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { applySetupStarters, fetchSetupStarters } from "../../lib/api-client/setup";
+import { autoTagKeys, labelSyncKeys, notificationKeys, setupKeys } from "../../lib/query-keys";
+
+export const useSetupStarters = () =>
+	useQuery<SetupStarterPreviewResponse, Error>({
+		queryKey: setupKeys.starters,
+		queryFn: fetchSetupStarters,
+		refetchOnWindowFocus: false,
+		retry: false,
+	});
+
+export const useApplySetupStarters = () => {
+	const queryClient = useQueryClient();
+	return useMutation({
+		mutationFn: (payload: ApplySetupStartersRequest) => applySetupStarters(payload),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: setupKeys.starters });
+			queryClient.invalidateQueries({ queryKey: notificationKeys.rules });
+			queryClient.invalidateQueries({ queryKey: autoTagKeys.all });
+			queryClient.invalidateQueries({ queryKey: labelSyncKeys.all });
+		},
+	});
+};

--- a/apps/web/src/lib/api-client/setup.ts
+++ b/apps/web/src/lib/api-client/setup.ts
@@ -1,4 +1,12 @@
-import { setupDiscoveryResponseSchema, type SetupDiscoveryResponse } from "@arr/shared";
+import {
+	type ApplySetupStartersRequest,
+	type ApplySetupStartersResponse,
+	applySetupStartersResponseSchema,
+	type SetupDiscoveryResponse,
+	type SetupStarterPreviewResponse,
+	setupDiscoveryResponseSchema,
+	setupStarterPreviewResponseSchema,
+} from "@arr/shared";
 import { apiRequest } from "./base";
 
 export async function discoverSetupCandidates(): Promise<SetupDiscoveryResponse> {
@@ -6,4 +14,19 @@ export async function discoverSetupCandidates(): Promise<SetupDiscoveryResponse>
 		method: "POST",
 	});
 	return setupDiscoveryResponseSchema.parse(response);
+}
+
+export async function fetchSetupStarters(): Promise<SetupStarterPreviewResponse> {
+	const response = await apiRequest<SetupStarterPreviewResponse>("/api/setup/starters");
+	return setupStarterPreviewResponseSchema.parse(response);
+}
+
+export async function applySetupStarters(
+	payload: ApplySetupStartersRequest,
+): Promise<ApplySetupStartersResponse> {
+	const response = await apiRequest<ApplySetupStartersResponse>("/api/setup/starters", {
+		method: "POST",
+		json: payload,
+	});
+	return applySetupStartersResponseSchema.parse(response);
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -36,6 +36,7 @@ export const authKeys = {
 
 export const setupKeys = {
 	discovery: ["setup", "discovery"] as const,
+	starters: ["setup", "starters"] as const,
 };
 
 /* -------------------------------------------------------------------------- */

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback; Operator Console walkthrough |
+| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback; Operator Console walkthrough (#571); explicit disabled starter-rule drafts |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -42,7 +42,7 @@ for the full rationale.
 | `/api/backup` | operator | Create, download, restore, scheduled backups |
 | `/api/notifications` | stable | Channels, subscriptions, rules, delivery aggregation |
 | `/api/services` | stable | ARR instance CRUD + connection testing |
-| `/api/setup` | experimental | Guided Setup support — bounded, credential-free media-server discovery. Candidates require explicit operator confirmation and are never connected automatically. |
+| `/api/setup` | experimental | Guided Setup support — bounded media-server discovery plus explicitly selected starter-rule drafts. Candidates are never connected automatically and starter automation is always created disabled. |
 | `/api/dashboard` | stable | Queue, history, calendar, statistics aggregates |
 | `/api/library` | stable | Movies/series listing, episodes, monitor, search |
 | `/api/search` | stable | Prowlarr indexer search + grab |
@@ -74,6 +74,8 @@ for the full rationale.
 | Method | Route | Auth | Purpose |
 |--------|-------|------|---------|
 | POST | `/api/setup/discovery` | Yes | Discover Plex, Jellyfin, and Emby candidates without saving or connecting them |
+| GET | `/api/setup/starters` | Yes | Preview available, disabled starter automation drafts and existing matches |
+| POST | `/api/setup/starters` | Yes | Idempotently create explicitly selected starter drafts in a disabled state |
 
 ## Authentication Routes (`/auth`)
 

--- a/packages/shared/src/types/__tests__/setup-starters.test.ts
+++ b/packages/shared/src/types/__tests__/setup-starters.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+	applySetupStartersRequestSchema,
+	setupStarterPreviewResponseSchema,
+} from "../setup-starters";
+
+describe("Setup starter contracts", () => {
+	it("accepts an explicit unique starter selection", () => {
+		expect(
+			applySetupStartersRequestSchema.parse({
+				starterIds: ["notification-throttle", "auto-tag-recent"],
+			}),
+		).toEqual({ starterIds: ["notification-throttle", "auto-tag-recent"] });
+	});
+
+	it("rejects duplicate starter IDs", () => {
+		expect(() =>
+			applySetupStartersRequestSchema.parse({
+				starterIds: ["notification-throttle", "notification-throttle"],
+			}),
+		).toThrow("Starter IDs must be unique");
+	});
+
+	it("pins service labels and availability in the preview shape", () => {
+		const preview = setupStarterPreviewResponseSchema.parse({
+			starters: [
+				{
+					id: "auto-tag-recent",
+					kind: "auto-tag",
+					title: "Tag recently added media",
+					description: "Starter draft",
+					effect: "Disabled until reviewed",
+					available: true,
+					unavailableReason: null,
+					existing: false,
+					source: { id: "sonarr-1", service: "sonarr", label: "Primary Sonarr" },
+					destination: null,
+				},
+			],
+		});
+
+		expect(preview.starters[0]?.source?.service).toBe("sonarr");
+	});
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -23,6 +23,7 @@ export * from "./rule-criteria";
 export * from "./search";
 export * from "./seerr";
 export * from "./setup-discovery";
+export * from "./setup-starters";
 export * from "./template-sharing";
 export * from "./tracearr";
 export * from "./trash-guides";

--- a/packages/shared/src/types/setup-starters.ts
+++ b/packages/shared/src/types/setup-starters.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const setupStarterIdSchema = z.enum([
+	"notification-throttle",
+	"auto-tag-recent",
+	"label-sync-recent",
+]);
+export type SetupStarterId = z.infer<typeof setupStarterIdSchema>;
+
+export const setupStarterKindSchema = z.enum(["notifications", "auto-tag", "label-sync"]);
+export type SetupStarterKind = z.infer<typeof setupStarterKindSchema>;
+
+export const setupStarterServiceSchema = z.object({
+	id: z.string(),
+	service: z.enum(["sonarr", "radarr", "plex", "jellyfin", "emby"]),
+	label: z.string(),
+});
+export type SetupStarterService = z.infer<typeof setupStarterServiceSchema>;
+
+export const setupStarterDefinitionSchema = z.object({
+	id: setupStarterIdSchema,
+	kind: setupStarterKindSchema,
+	title: z.string(),
+	description: z.string(),
+	effect: z.string(),
+	available: z.boolean(),
+	unavailableReason: z.string().nullable(),
+	existing: z.boolean(),
+	source: setupStarterServiceSchema.nullable(),
+	destination: setupStarterServiceSchema.nullable(),
+});
+export type SetupStarterDefinition = z.infer<typeof setupStarterDefinitionSchema>;
+
+export const setupStarterPreviewResponseSchema = z.object({
+	starters: z.array(setupStarterDefinitionSchema),
+});
+export type SetupStarterPreviewResponse = z.infer<typeof setupStarterPreviewResponseSchema>;
+
+export const applySetupStartersRequestSchema = z.object({
+	starterIds: z
+		.array(setupStarterIdSchema)
+		.min(1)
+		.max(3)
+		.refine((ids) => new Set(ids).size === ids.length, "Starter IDs must be unique"),
+});
+export type ApplySetupStartersRequest = z.infer<typeof applySetupStartersRequestSchema>;
+
+export const applySetupStartersResponseSchema = z.object({
+	created: z.array(setupStarterIdSchema),
+	existing: z.array(setupStarterIdSchema),
+});
+export type ApplySetupStartersResponse = z.infer<typeof applySetupStartersResponseSchema>;


### PR DESCRIPTION
## Summary

- add a fourth guided Setup stage for optional notification, Auto-Tag, and Label Sync starter drafts
- derive starter availability from the signed-in operator's connected service topology
- create only explicitly selected starters, always with `enabled: false`
- make starter application transactional and repeat-safe for matching starter names
- preserve Setup-stage redirects, incognito-mask service labels, and document the new routes

## Safety boundary

This slice does not deploy TRaSH profiles or mutate Sonarr/Radarr. Those external changes require an explicit quality-profile choice and the existing before-and-after deployment preview, so Setup explains that boundary instead of guessing.

## Validation

- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,943 passed, 41 skipped
- `pnpm run lint` — passes with the existing 10 API and 27 web warnings
- focused Biome checks on all changed TypeScript/TSX files
- fresh-install Chromium flow at 1440px and 390px
- live SQLite verification: selected notification starter persisted disabled with the intended throttle; unselected Auto-Tag and Label Sync tables remained empty

`pnpm run format` remains blocked by the existing 89 formatting errors in untouched API files. Every file changed by this PR is formatted.