### PR TITLE
feat(setup): add explicit TRaSH profile preview

### DIFF
--- a/apps/web/app/setup/__tests__/page.test.tsx
+++ b/apps/web/app/setup/__tests__/page.test.tsx
@@ -57,6 +57,14 @@ describe("SetupPage authenticated stages", () => {
 		expect(mocks.replace).not.toHaveBeenCalled();
 	});
 
+	it("renders the TRaSH profile stage for an authenticated user", () => {
+		mocks.stage = "trash";
+		render(<SetupPage />);
+
+		expect(screen.getByText("Setup stage: trash")).toBeInTheDocument();
+		expect(mocks.replace).not.toHaveBeenCalled();
+	});
+
 	it("preserves the Console stage when redirecting an expired session to login", async () => {
 		mocks.currentUser = { data: undefined, isLoading: false };
 

--- a/apps/web/app/setup/page.tsx
+++ b/apps/web/app/setup/page.tsx
@@ -17,13 +17,18 @@ const SetupPageContent = () => {
 	const searchParams = useSearchParams();
 	const requestedStage = searchParams.get("stage");
 	const requestedAuthenticatedStage =
-		requestedStage === "services" || requestedStage === "starters" || requestedStage === "console";
+		requestedStage === "services" ||
+		requestedStage === "starters" ||
+		requestedStage === "trash" ||
+		requestedStage === "console";
 	const requestedSetupPath =
 		requestedStage === "console"
 			? "/setup?stage=console"
-			: requestedStage === "starters"
-				? "/setup?stage=starters"
-				: "/setup?stage=services";
+			: requestedStage === "trash"
+				? "/setup?stage=trash"
+				: requestedStage === "starters"
+					? "/setup?stage=starters"
+					: "/setup?stage=services";
 	const { data: setupRequired, isLoading } = useSetupRequired();
 	const shouldVerifySession = setupRequired?.required === false && requestedAuthenticatedStage;
 	const { data: user, isLoading: userLoading } = useCurrentUser(shouldVerifySession);

--- a/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/console-walkthrough.test.tsx
@@ -65,8 +65,8 @@ describe("ConsoleWalkthrough", () => {
 
 		expect(screen.queryByText("Living Room Jellyfin")).not.toBeInTheDocument();
 		expect(screen.getByText("linux-server")).toBeInTheDocument();
-		fireEvent.click(screen.getByRole("button", { name: "Back to starters" }));
-		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=starters");
+		fireEvent.click(screen.getByRole("button", { name: "Back to TRaSH profile" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=trash");
 	});
 
 	it("allows the walkthrough to be skipped", () => {

--- a/apps/web/src/features/setup/components/__tests__/starter-configuration.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/starter-configuration.test.tsx
@@ -98,7 +98,7 @@ describe("StarterConfiguration", () => {
 		expect(screen.queryByText("Family Sonarr", { exact: false })).not.toBeInTheDocument();
 		expect(screen.getAllByText(/linux-server/).length).toBeGreaterThan(0);
 		fireEvent.click(screen.getByRole("button", { name: "Continue" }));
-		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=console");
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=trash");
 		expect(mocks.mutateAsync).not.toHaveBeenCalled();
 	});
 

--- a/apps/web/src/features/setup/components/__tests__/trash-profile-setup.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/trash-profile-setup.test.tsx
@@ -1,0 +1,167 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	push: vi.fn(),
+	refresh: vi.fn(),
+	importProfile: vi.fn(),
+	incognito: false,
+	catalogReady: false,
+}));
+
+vi.mock("next/navigation", () => ({ useRouter: () => ({ push: mocks.push }) }));
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({ gradient: { from: "blue", to: "purple" } }),
+}));
+vi.mock("../../../../lib/incognito", () => ({
+	useIncognitoMode: () => [mocks.incognito, vi.fn()],
+	getLinuxInstanceName: () => "linux-server",
+}));
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({
+		data: [
+			{
+				id: "sonarr-1",
+				service: "sonarr",
+				label: "Family Sonarr",
+				enabled: true,
+			},
+		],
+		isLoading: false,
+		error: null,
+	}),
+}));
+vi.mock("../../../../hooks/api/useTrashCache", () => ({
+	useRefreshTrashCache: () => ({
+		mutateAsync: async (...args: unknown[]) => {
+			mocks.catalogReady = true;
+			return mocks.refresh(...args);
+		},
+		isPending: false,
+		error: null,
+	}),
+}));
+vi.mock("../../../../hooks/api/useQualityProfiles", () => ({
+	useQualityProfiles: (_serviceType: string, options: { enabled?: boolean }) => ({
+		data: options.enabled
+			? {
+					profiles: [
+						{
+							trashId: "profile-1",
+							name: "WEB-1080p",
+							customFormatCount: 2,
+							qualityCount: 3,
+							cutoff: "Bluray-1080p",
+						},
+					],
+				}
+			: undefined,
+		isLoading: false,
+		error: null,
+	}),
+	useQualityProfileDetails: (_serviceType: string, profileId: string) => ({
+		data: profileId
+			? {
+					profile: {},
+					mandatoryCFs: [{ trash_id: "mandatory" }],
+					cfGroups: [
+						{
+							trash_id: "group-1",
+							defaultEnabled: true,
+							custom_formats: [
+								{ trash_id: "recommended", required: true },
+								{ trash_id: "optional" },
+							],
+						},
+					],
+				}
+			: undefined,
+		isLoading: false,
+		error: null,
+	}),
+	useImportQualityProfile: () => ({
+		mutateAsync: mocks.importProfile,
+		isPending: false,
+		error: null,
+	}),
+}));
+vi.mock("../../../../hooks/api/useTemplates", () => ({
+	useTemplates: () => ({ data: { templates: [] }, error: null }),
+}));
+vi.mock("../../../trash-guides/components/deployment-preview-modal", () => ({
+	DeploymentPreviewModal: ({ open, templateId }: { open: boolean; templateId: string | null }) =>
+		open ? <div>Preview modal for {templateId}</div> : null,
+}));
+
+import { buildSetupProfileSelections, TrashProfileSetup } from "../trash-profile-setup";
+
+describe("TrashProfileSetup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.catalogReady = false;
+		mocks.incognito = false;
+		mocks.refresh.mockResolvedValue({ refreshed: true });
+		mocks.importProfile.mockResolvedValue({ template: { id: "template-1", name: "WEB-1080p" } });
+	});
+
+	it("uses mandatory and upstream-default group formats", () => {
+		expect(
+			buildSetupProfileSelections({
+				profile: {},
+				mandatoryCFs: [{ trash_id: "mandatory" }],
+				cfGroups: [
+					{
+						trash_id: "default-group",
+						defaultEnabled: true,
+						custom_formats: [{ trash_id: "required", required: true }, { trash_id: "optional" }],
+					},
+				],
+			}),
+		).toEqual({
+			selectedCFGroups: ["default-group"],
+			customFormatSelections: {
+				mandatory: { selected: true, conditionsEnabled: {} },
+				required: { selected: true, conditionsEnabled: {} },
+				optional: { selected: false, conditionsEnabled: {} },
+			},
+		});
+	});
+
+	it("requires explicit target and profile choices before opening the existing preview", async () => {
+		render(<TrashProfileSetup />);
+
+		expect(screen.queryByText(/Preview modal/)).not.toBeInTheDocument();
+		fireEvent.change(screen.getByLabelText("Target instance"), { target: { value: "sonarr-1" } });
+		fireEvent.click(screen.getByRole("button", { name: "Load official Sonarr profiles" }));
+
+		await waitFor(() =>
+			expect(mocks.refresh).toHaveBeenCalledWith({ serviceType: "SONARR", force: false }),
+		);
+		fireEvent.change(screen.getByLabelText("Official quality profile"), {
+			target: { value: "profile-1" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Review deployment preview" }));
+
+		await waitFor(() =>
+			expect(screen.getByText("Preview modal for template-1")).toBeInTheDocument(),
+		);
+		expect(mocks.importProfile).toHaveBeenCalledWith(
+			expect.objectContaining({
+				serviceType: "SONARR",
+				trashId: "profile-1",
+				templateName: "WEB-1080p",
+			}),
+		);
+	});
+
+	it("supports skipping without loading the catalog and masks instance names", () => {
+		mocks.incognito = true;
+		render(<TrashProfileSetup />);
+
+		expect(screen.queryByText("Family Sonarr", { exact: false })).not.toBeInTheDocument();
+		expect(screen.getByText(/linux-server/)).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "Continue without deploying" }));
+		expect(mocks.push).toHaveBeenCalledWith("/setup?stage=console");
+		expect(mocks.refresh).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/setup/components/console-walkthrough.tsx
+++ b/apps/web/src/features/setup/components/console-walkthrough.tsx
@@ -51,7 +51,7 @@ export const ConsoleWalkthrough = () => {
 	return (
 		<div className="w-full max-w-3xl space-y-6 py-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 4 of 4</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 5 of 5</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{
@@ -162,11 +162,11 @@ export const ConsoleWalkthrough = () => {
 					variant="ghost"
 					onClick={() =>
 						step === 0
-							? router.push("/setup?stage=starters")
+							? router.push("/setup?stage=trash")
 							: setStep((currentStep) => currentStep - 1)
 					}
 				>
-					<ArrowLeft className="h-4 w-4" /> {step === 0 ? "Back to starters" : "Back"}
+					<ArrowLeft className="h-4 w-4" /> {step === 0 ? "Back to TRaSH profile" : "Back"}
 				</Button>
 				<Button
 					type="button"

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -120,7 +120,7 @@ export const ServiceOnboarding = () => {
 	return (
 		<div className="w-full max-w-4xl space-y-6 py-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 4</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 2 of 5</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{

--- a/apps/web/src/features/setup/components/setup-client.tsx
+++ b/apps/web/src/features/setup/components/setup-client.tsx
@@ -19,11 +19,12 @@ import { PasskeySetup } from "./passkey-setup";
 import { PasswordSetup } from "./password-setup";
 import { ServiceOnboarding } from "./service-onboarding";
 import { StarterConfiguration } from "./starter-configuration";
+import { TrashProfileSetup } from "./trash-profile-setup";
 
 type SetupMethod = "password" | "oidc" | "passkey";
 
 interface SetupClientProps {
-	stage: "account" | "services" | "starters" | "console";
+	stage: "account" | "services" | "starters" | "trash" | "console";
 }
 
 export const SetupClient = ({ stage }: SetupClientProps) => {
@@ -40,6 +41,9 @@ export const SetupClient = ({ stage }: SetupClientProps) => {
 	}
 	if (stage === "starters") {
 		return <StarterConfiguration />;
+	}
+	if (stage === "trash") {
+		return <TrashProfileSetup />;
 	}
 	if (stage === "console") {
 		return <ConsoleWalkthrough />;

--- a/apps/web/src/features/setup/components/starter-configuration.tsx
+++ b/apps/web/src/features/setup/components/starter-configuration.tsx
@@ -58,7 +58,7 @@ export const StarterConfiguration = () => {
 	return (
 		<div className="w-full max-w-4xl space-y-6 pb-24 pt-8">
 			<div className="space-y-3 text-center">
-				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 3 of 4</p>
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 3 of 5</p>
 				<h1
 					className="text-3xl font-bold tracking-tight"
 					style={{
@@ -155,10 +155,10 @@ export const StarterConfiguration = () => {
 				<CardContent className="flex items-start gap-3 p-4">
 					<ShieldCheck className="mt-0.5 h-5 w-5" style={{ color: gradient.to }} />
 					<div>
-						<p className="font-medium">TRaSH quality profiles require a deployment preview</p>
+						<p className="font-medium">TRaSH quality-profile selection is next</p>
 						<p className="mt-1 text-sm text-muted-foreground">
-							Setup will not guess a quality profile or change Sonarr/Radarr settings. TRaSH Guides
-							remains available after setup with a full before-and-after review.
+							Setup will not guess a profile or change Sonarr/Radarr settings. The next optional
+							step lets you choose both, then opens the full deployment preview before any write.
 						</p>
 					</div>
 				</CardContent>
@@ -186,7 +186,7 @@ export const StarterConfiguration = () => {
 							Create {selected.size} disabled {selected.size === 1 ? "draft" : "drafts"}
 						</Button>
 					)}
-					<Button type="button" size="lg" onClick={() => router.push("/setup?stage=console")}>
+					<Button type="button" size="lg" onClick={() => router.push("/setup?stage=trash")}>
 						{selected.size > 0 ? "Continue without creating" : "Continue"}
 						<ArrowRight className="h-4 w-4" />
 					</Button>

--- a/apps/web/src/features/setup/components/trash-profile-setup.tsx
+++ b/apps/web/src/features/setup/components/trash-profile-setup.tsx
@@ -1,0 +1,337 @@
+"use client";
+
+import type { ServiceInstanceSummary, TrashTemplate } from "@arr/shared";
+import { ArrowLeft, ArrowRight, CheckCircle2, Loader2, Package, ShieldCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { lazy, Suspense, useMemo, useState } from "react";
+import {
+	Alert,
+	AlertDescription,
+	Badge,
+	Button,
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+	NativeSelect,
+	SelectOption,
+} from "../../../components/ui";
+import {
+	useImportQualityProfile,
+	useQualityProfileDetails,
+	useQualityProfiles,
+} from "../../../hooks/api/useQualityProfiles";
+import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
+import { useTemplates } from "../../../hooks/api/useTemplates";
+import { useRefreshTrashCache } from "../../../hooks/api/useTrashCache";
+import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import type { QualityProfileDetailsResponse } from "../../../lib/api-client/trash-guides";
+import { getErrorMessage } from "../../../lib/error-utils";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
+
+const DeploymentPreviewModal = lazy(() =>
+	import("../../trash-guides/components/deployment-preview-modal").then((module) => ({
+		default: module.DeploymentPreviewModal,
+	})),
+);
+
+type ServiceType = "RADARR" | "SONARR";
+
+const toServiceType = (service: ServiceInstanceSummary): ServiceType =>
+	service.service === "sonarr" ? "SONARR" : "RADARR";
+
+const isDefault = (value: string | boolean | undefined) => value === true || value === "true";
+
+export const buildSetupProfileSelections = (details: QualityProfileDetailsResponse) => {
+	const customFormatSelections: Record<
+		string,
+		{ selected: boolean; conditionsEnabled: Record<string, boolean> }
+	> = {};
+
+	for (const format of details.mandatoryCFs) {
+		customFormatSelections[format.trash_id] = { selected: true, conditionsEnabled: {} };
+	}
+
+	const selectedCFGroups: string[] = [];
+	for (const group of details.cfGroups) {
+		const groupDefault = group.defaultEnabled === true || isDefault(group.default);
+		let selectedInGroup = false;
+		for (const format of group.custom_formats ?? []) {
+			const trashId = typeof format === "string" ? format : format.trash_id;
+			const selected =
+				groupDefault &&
+				typeof format !== "string" &&
+				(format.required === true || isDefault(format.default) || format.defaultChecked === true);
+			customFormatSelections[trashId] = { selected, conditionsEnabled: {} };
+			selectedInGroup ||= selected;
+		}
+		if (selectedInGroup) selectedCFGroups.push(group.trash_id);
+	}
+
+	return { customFormatSelections, selectedCFGroups };
+};
+
+export const TrashProfileSetup = () => {
+	const router = useRouter();
+	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
+	const {
+		data: services = [],
+		isLoading: servicesLoading,
+		error: servicesError,
+	} = useServicesQuery();
+	const arrServices = useMemo(
+		() =>
+			services.filter(
+				(service) =>
+					service.enabled && (service.service === "sonarr" || service.service === "radarr"),
+			),
+		[services],
+	);
+	const [instanceId, setInstanceId] = useState("");
+	const selectedInstance = arrServices.find((service) => service.id === instanceId) ?? null;
+	const serviceType = selectedInstance ? toServiceType(selectedInstance) : "RADARR";
+	const [catalogReady, setCatalogReady] = useState(false);
+	const [catalogError, setCatalogError] = useState<string | null>(null);
+	const [profileId, setProfileId] = useState("");
+	const [previewTemplate, setPreviewTemplate] = useState<TrashTemplate | null>(null);
+	const [deployed, setDeployed] = useState(false);
+	const refreshCache = useRefreshTrashCache();
+	const profiles = useQualityProfiles(serviceType, { enabled: catalogReady });
+	const profileDetails = useQualityProfileDetails(serviceType, profileId, catalogReady);
+	const templates = useTemplates({ serviceType });
+	const importProfile = useImportQualityProfile();
+	const selectedProfile = profiles.data?.profiles.find((profile) => profile.trashId === profileId);
+	const existingTemplate = templates.data?.templates.find(
+		(template) => template.sourceQualityProfileTrashId === profileId,
+	);
+
+	const handleInstanceChange = (value: string) => {
+		setInstanceId(value);
+		setCatalogReady(false);
+		setCatalogError(null);
+		setProfileId("");
+		setPreviewTemplate(null);
+	};
+
+	const loadCatalog = async () => {
+		if (!selectedInstance) return;
+		setCatalogError(null);
+		try {
+			const result = await refreshCache.mutateAsync({ serviceType, force: false });
+			for (const requiredType of ["QUALITY_PROFILES", "CUSTOM_FORMATS", "CF_GROUPS"] as const) {
+				const status = result.results?.[requiredType] as
+					| { success?: boolean; error?: string }
+					| undefined;
+				if (status?.success === false) {
+					throw new Error(status.error || `Failed to load ${requiredType}`);
+				}
+			}
+			setCatalogReady(true);
+		} catch (loadError) {
+			setCatalogError(getErrorMessage(loadError, "Failed to load the TRaSH profile catalog"));
+		}
+	};
+
+	const preparePreview = async () => {
+		if (!selectedInstance || !selectedProfile || !profileDetails.data) return;
+		if (existingTemplate) {
+			setPreviewTemplate(existingTemplate);
+			return;
+		}
+		const selections = buildSetupProfileSelections(profileDetails.data);
+		const result = await importProfile.mutateAsync({
+			serviceType,
+			trashId: selectedProfile.trashId,
+			templateName: selectedProfile.name,
+			selectedCFGroups: selections.selectedCFGroups,
+			customFormatSelections: selections.customFormatSelections,
+		});
+		setPreviewTemplate(result.template);
+	};
+
+	const error =
+		servicesError ||
+		refreshCache.error ||
+		profiles.error ||
+		profileDetails.error ||
+		importProfile.error;
+	const profileLoading =
+		catalogReady && (profiles.isLoading || (Boolean(profileId) && profileDetails.isLoading));
+
+	return (
+		<div className="w-full max-w-4xl space-y-6 pb-24 pt-8">
+			<div className="space-y-3 text-center">
+				<p className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Step 4 of 5</p>
+				<h1
+					className="text-3xl font-bold tracking-tight"
+					style={{
+						background: `linear-gradient(135deg, ${gradient.from}, ${gradient.to})`,
+						WebkitBackgroundClip: "text",
+						WebkitTextFillColor: "transparent",
+					}}
+				>
+					Choose your TRaSH profile
+				</h1>
+				<p className="mx-auto max-w-2xl text-muted-foreground">
+					Pick the target and official profile yourself. Setup prepares the same detailed preview
+					used by TRaSH Guides before any Sonarr or Radarr settings change.
+				</p>
+			</div>
+
+			{deployed && (
+				<Alert>
+					<CheckCircle2 className="h-4 w-4" />
+					<AlertDescription>The selected profile was deployed after review.</AlertDescription>
+				</Alert>
+			)}
+
+			<Card className="border-border/50 bg-card/80">
+				<CardHeader>
+					<CardTitle>Profile deployment</CardTitle>
+					<CardDescription>
+						This step is optional. No target or profile is preselected.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-5">
+					{servicesLoading ? (
+						<div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
+							<Loader2 className="h-4 w-4 animate-spin" /> Loading connected services…
+						</div>
+					) : arrServices.length === 0 ? (
+						<Alert>
+							<AlertDescription>
+								Connect an enabled Sonarr or Radarr instance to prepare a TRaSH profile deployment.
+							</AlertDescription>
+						</Alert>
+					) : (
+						<>
+							<label className="space-y-2 text-sm" htmlFor="setup-trash-instance">
+								<span className="font-medium">Target instance</span>
+								<NativeSelect
+									id="setup-trash-instance"
+									value={instanceId}
+									onChange={(event) => handleInstanceChange(event.target.value)}
+								>
+									<SelectOption value="">Choose Sonarr or Radarr</SelectOption>
+									{arrServices.map((service) => (
+										<SelectOption key={service.id} value={service.id}>
+											{incognitoMode ? getLinuxInstanceName(service.label) : service.label} (
+											{service.service})
+										</SelectOption>
+									))}
+								</NativeSelect>
+							</label>
+
+							{selectedInstance && !catalogReady && (
+								<Button
+									type="button"
+									variant="outline"
+									onClick={loadCatalog}
+									disabled={refreshCache.isPending}
+								>
+									{refreshCache.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+									Load official {serviceType === "SONARR" ? "Sonarr" : "Radarr"} profiles
+								</Button>
+							)}
+
+							{catalogReady && (
+								<label className="space-y-2 text-sm" htmlFor="setup-trash-profile">
+									<span className="font-medium">Official quality profile</span>
+									<NativeSelect
+										id="setup-trash-profile"
+										value={profileId}
+										onChange={(event) => {
+											setProfileId(event.target.value);
+											setPreviewTemplate(null);
+										}}
+										disabled={profiles.isLoading}
+									>
+										<SelectOption value="">Choose a profile</SelectOption>
+										{profiles.data?.profiles.map((profile) => (
+											<SelectOption key={profile.trashId} value={profile.trashId}>
+												{profile.name}
+											</SelectOption>
+										))}
+									</NativeSelect>
+								</label>
+							)}
+
+							{profileLoading && (
+								<div className="flex items-center gap-2 text-sm text-muted-foreground">
+									<Loader2 className="h-4 w-4 animate-spin" /> Loading profile details…
+								</div>
+							)}
+
+							{selectedProfile && profileDetails.data && (
+								<div className="space-y-3 rounded-xl border border-border/60 p-4">
+									<div className="flex flex-wrap items-center gap-2">
+										<Package className="h-4 w-4" style={{ color: gradient.from }} />
+										<span className="font-medium">{selectedProfile.name}</span>
+										{existingTemplate && <Badge variant="secondary">Template already exists</Badge>}
+									</div>
+									<p className="text-sm text-muted-foreground">
+										{selectedProfile.customFormatCount} profile formats ·{" "}
+										{selectedProfile.qualityCount} quality entries · cutoff {selectedProfile.cutoff}
+									</p>
+									<p className="text-sm">
+										Preparing the preview may create a reusable local template. It does not change
+										the selected instance.
+									</p>
+									<Button type="button" onClick={preparePreview} disabled={importProfile.isPending}>
+										{importProfile.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+										Review deployment preview
+									</Button>
+								</div>
+							)}
+						</>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card className="border-border/50 bg-card/80">
+				<CardContent className="flex items-start gap-3 p-4">
+					<ShieldCheck className="mt-0.5 h-5 w-5" style={{ color: gradient.to }} />
+					<div>
+						<p className="font-medium">External writes remain confirmation-gated</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							Loading profiles and preparing a preview only update arr-dashboard’s local catalog and
+							template. Sonarr or Radarr changes only after you explicitly deploy from the preview.
+						</p>
+					</div>
+				</CardContent>
+			</Card>
+
+			{(catalogError || error) && (
+				<Alert variant="destructive">
+					<AlertDescription>{catalogError || getErrorMessage(error)}</AlertDescription>
+				</Alert>
+			)}
+
+			<div className="flex flex-wrap items-center justify-between gap-3">
+				<Button type="button" variant="ghost" onClick={() => router.push("/setup?stage=starters")}>
+					<ArrowLeft className="h-4 w-4" /> Back to starters
+				</Button>
+				<Button type="button" size="lg" onClick={() => router.push("/setup?stage=console")}>
+					Continue{!deployed && " without deploying"}
+					<ArrowRight className="h-4 w-4" />
+				</Button>
+			</div>
+
+			{previewTemplate && (
+				<Suspense fallback={null}>
+					<DeploymentPreviewModal
+						open
+						onClose={() => setPreviewTemplate(null)}
+						templateId={previewTemplate.id}
+						templateName={previewTemplate.name}
+						instanceId={selectedInstance?.id ?? null}
+						instanceLabel={selectedInstance?.label}
+						onDeploySuccess={() => setDeployed(true)}
+					/>
+				</Suspense>
+			)}
+		</div>
+	);
+};

--- a/apps/web/src/hooks/api/useQualityProfiles.ts
+++ b/apps/web/src/hooks/api/useQualityProfiles.ts
@@ -26,11 +26,15 @@ import { qualityProfileKeys, TEMPLATES_QUERY_KEY } from "../../lib/query-keys";
 /**
  * Hook to fetch TRaSH Guides quality profiles for a service
  */
-export const useQualityProfiles = (serviceType: "RADARR" | "SONARR") =>
+export const useQualityProfiles = (
+	serviceType: "RADARR" | "SONARR",
+	options?: { enabled?: boolean },
+) =>
 	useQuery<QualityProfilesResponse>({
 		queryKey: qualityProfileKeys.list(serviceType),
 		queryFn: () => fetchQualityProfiles(serviceType),
 		staleTime: 10 * 60 * 1000, // 10 minutes
+		enabled: options?.enabled ?? true,
 	});
 
 /**

--- a/apps/web/src/lib/api-client/trash-guides/index.ts
+++ b/apps/web/src/lib/api-client/trash-guides/index.ts
@@ -89,6 +89,7 @@ export type {
 	ProfileMatchResult,
 	PromoteOverridePayload,
 	PromoteOverrideResponse,
+	QualityProfileDetailsResponse,
 	// Profile matching types
 	RecommendedCF,
 	// Score update types
@@ -334,9 +335,9 @@ export type {
 	NamingConfigCreatePayload,
 	NamingConfigDeleteResponse,
 	NamingConfigSaveResponse,
+	NamingPresetsApiResponse,
 	NamingPreviewApiResponse,
 	NamingPreviewPayload,
-	NamingPresetsApiResponse,
 } from "./naming";
 export {
 	applyNaming,

--- a/apps/web/src/lib/api-client/trash-guides/profiles.ts
+++ b/apps/web/src/lib/api-client/trash-guides/profiles.ts
@@ -5,7 +5,7 @@
  * fetching, importing, updating, and profile cloning operations.
  */
 
-import type { NamingSelectedPresets } from "@arr/shared";
+import type { NamingSelectedPresets, TrashTemplate } from "@arr/shared";
 import { apiRequest } from "../base";
 import type {
 	CustomQualityConfig,
@@ -57,9 +57,33 @@ export type UpdateQualityProfileTemplatePayload = {
 };
 
 export type ImportQualityProfileResponse = {
-	template: unknown;
+	template: TrashTemplate;
 	message: string;
 	customFormatsIncluded: number;
+};
+
+export type QualityProfileDetailsResponse = {
+	profile: unknown;
+	mandatoryCFs: Array<{ trash_id: string }>;
+	cfGroups: Array<{
+		trash_id: string;
+		default?: string | boolean;
+		defaultEnabled?: boolean;
+		custom_formats?: Array<
+			| string
+			| {
+					trash_id: string;
+					required?: boolean;
+					default?: string | boolean;
+					defaultChecked?: boolean;
+			  }
+		>;
+	}>;
+	stats?: {
+		mandatoryCount: number;
+		optionalGroupCount: number;
+		totalOptionalCFs: number;
+	};
 };
 
 // ============================================================================
@@ -277,8 +301,8 @@ export async function fetchQualityProfiles(
 export async function fetchQualityProfileDetails(
 	serviceType: ServiceType,
 	trashId: string,
-): Promise<{ profile: unknown }> {
-	return await apiRequest<{ profile: unknown }>(
+): Promise<QualityProfileDetailsResponse> {
+	return await apiRequest<QualityProfileDetailsResponse>(
 		`/api/trash-guides/quality-profiles/${serviceType}/${trashId}`,
 	);
 }

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -15,7 +15,7 @@ progress · ⛔ blocked · ⬜ not started.
 | 2.1 — embedded rule composer | ✅ | v1 read API + viewer (#553/#554); cleanup and auto-tag authoring (#562/#563); notifications authoring (#566); cross-domain rules/executor/dry-run/deploy (#567). Deploy lifecycle ratified 2026-07-15 and recorded in ADR-0006. |
 | 2.1 — Tracearr live-session count + kill-session action | ✅ | live-session card (#556) + per-session rows & kill-session (#557) |
 | 2.2 Tracearr integration | ✅ | foundation (#555) — `TRACEARR` service type + typed Bearer client for all 9 Public API endpoints + connection/health route; live-session card (#556); kill-session (#557); Statistics-on-Tracearr / C2 (#558 + C2b). Live-verified end-to-end against a running instance. |
-| 2.3 Setup rewrite (auto-discovery) | 🚧 | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback; Operator Console walkthrough (#571); explicit disabled starter-rule drafts |
+| 2.3 Setup rewrite (auto-discovery) | ✅ | discovery foundation (#568); guided authentication-to-service onboarding, candidate confirmation, verified persistence, and manual entry (#569); Plex SSDP fallback; Operator Console walkthrough (#571); explicit disabled starter-rule drafts; explicit TRaSH profile selection with the existing deployment preview |
 
 ## Bucket A — breaking changes: ✅ complete
 A1 #513 · A2 #517 (+ #514/#515) · A3 #512 · A4 #518–#521 · A5 #511 · A6 #510.
@@ -84,7 +84,7 @@ qui-home. The remaining polling surfaces are correctly excluded:
 ---
 
 ## Remaining work (in recommended order)
-1. **Setup rewrite (2.3)** — lowest priority (pulled from 3.1).
+No charter deliverables remain open. Next work is the release-readiness audit and prerelease path.
 
 **Tracearr arc (2.2) COMPLETE** — foundation (#555), live-session card (#556),
 kill-session (#557), Statistics stats/activity (#558) + history/users/violations


### PR DESCRIPTION
## Summary

- add a fifth guided Setup stage for explicit Sonarr/Radarr target and official TRaSH quality-profile selection
- refresh the local TRaSH catalog only after operator intent, then create or reuse a local template using the same mandatory and upstream-default selections as the existing wizard
- open the existing deployment preview for all external reads, conflict handling, sync-strategy selection, and final Deploy confirmation
- keep the entire stage optional with no preselected target or profile
- mark the 3.0 charter's Setup rewrite complete

## Safety boundary

Loading the catalog and preparing a preview can write only arr-dashboard's local cache and template records. Sonarr/Radarr is not mutated unless the operator explicitly confirms Deploy from the existing preview. An unreachable instance fails closed with Deploy disabled.

## Validation

- focused Biome checks on all changed TypeScript/TSX files
- `pnpm run typecheck`
- `pnpm run test` — 2,946 passed, 41 skipped
- `pnpm run lint` — passes with the existing 10 API and 27 web warnings
- focused Setup tests — 13 passed
- live Chromium flow at 1440px and 390px against the official Sonarr profile catalog
- live import produced a 48-item deployment preview; an intentionally unreachable Sonarr instance displayed Unreachable and kept Deploy disabled
- verified no horizontal overflow at 390px and removed all temporary user/service/template data

`pnpm run format` remains blocked by the existing 89 formatting errors in untouched API files. Every file changed by this PR is formatted.