### PR TITLE
docs: audit 3.0 release readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ These cause bugs if ignored:
 1. **API Proxy**: Frontend calls `/api/*` via Next.js rewrites to backend. NEVER use `localhost:3001` directly from frontend code.
 2. **Ownership**: Always include `userId: request.currentUser!.id` in Prisma queries for user-owned resources. Omitting this is a security vulnerability.
 3. **Encryption**: All API keys must be encrypted with `app.encryptor.encrypt()` before storage. Store both `value` and `iv`.
-4. **Auth Check**: Protected routes use preHandler hook checking `request.currentUser?.id`. Every route plugin must add this hook.
+4. **Auth Check**: Protected route groups register through `route-manifest.ts` inside the single protected scope, whose preHandler checks `request.currentUser?.id`. Do not add parallel per-route auth gates.
 5. **Validation**: Use `validateRequest()` from `lib/utils/validate.ts` for request body parsing. Never use `request.body as Type`.
 6. **Incognito Mode**: Any component displaying sensitive data (titles, usernames, URLs, instance names) must use `useIncognitoMode()` hook from `contexts/IncognitoContext.tsx` and anonymize with functions from `lib/incognito.ts`. This includes API response text that embeds instance names (e.g., Pulse titles like `"Label: message"` — split and anonymize both parts). Tests rendering such components need `<IncognitoProvider>` wrapper.
 7. **Query Invalidation**: Always invalidate relevant React Query keys after mutations.
@@ -36,13 +36,13 @@ packages/shared/src/types/ # Shared Zod schemas + TypeScript types
 
 ## Architecture
 
-**Monorepo**: `apps/api` (Fastify 4), `apps/web` (Next.js 16 App Router), `packages/shared` (Zod types). pnpm 10+ with Turbo.
+**Monorepo**: `apps/api` (Fastify 5), `apps/web` (Next.js 16 App Router), `packages/shared` (Zod types). pnpm 10+ with Turbo.
 
-**Stack**: Fastify + Prisma + Zod backend, Next.js + React 18 + TanStack Query frontend, TailwindCSS + shadcn/ui, SQLite default (PostgreSQL supported).
+**Stack**: Fastify + Prisma + Zod backend, Next.js + React 19 + TanStack Query frontend, TailwindCSS + shadcn/ui, SQLite default (PostgreSQL supported).
 
 **Design**: Single-admin, self-hosted. Session-based auth (NOT JWT). Three auth methods: Password, OIDC, Passkeys.
 
-**Services**: Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Tautulli, Seerr (Jellyseerr/Overseerr).
+**Services**: Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Jellyfin, Emby, Seerr (Jellyseerr/Overseerr), qui, and Tracearr. Tautulli is removed in 3.0; its Prisma enum value remains only so legacy rows can reach the consent-gated migration dialog.
 
 **Fastify Decorations** (available in route handlers):
 - `request.currentUser` / `request.sessionToken` — populated by auth preHandler
@@ -73,7 +73,7 @@ packages/shared/src/types/ # Shared Zod schemas + TypeScript types
 
 **New API Route:**
 1. Create `apps/api/src/routes/<domain>.ts`
-2. Register in `apps/api/src/server.ts`
+2. Register in `apps/api/src/routes/route-manifest.ts` and document the group in `docs/API-ROUTES.md`
 3. Add Zod types to `packages/shared/src/types/<domain>.ts`
 4. Add API client to `apps/web/src/lib/api-client/<domain>.ts`
 5. Add React Query hook to `apps/web/src/hooks/api/use<Domain>.ts`
@@ -92,7 +92,7 @@ packages/shared/src/types/ # Shared Zod schemas + TypeScript types
 
 When adding features that surface data to users (pages, panels, signals, notifications), verify:
 
-1. **Service-availability gating**: If a signal depends on optional services (Plex, Seerr, Tautulli), guard it — don't show misleading items when the service isn't configured
+1. **Service-availability gating**: If a signal depends on optional services (Plex, Seerr, Tracearr, qui), guard it — don't show misleading items when the service isn't configured
 2. **Signal accuracy**: Every user-facing count or status must be precise, not a proxy. If you can't compute the exact value cheaply, don't show it — overclaiming erodes trust
 3. **Duplicate surface check**: Before adding a signal, check where the same data already appears. Justify the overlap (cross-system synthesis is good, pure duplication is not)
 4. **Action link verification**: Every action link must point to an existing page that shows the relevant data with any required query params
@@ -124,7 +124,7 @@ When adding features that surface data to users (pages, panels, signals, notific
 
 **Data fetching**: API client module -> `useQuery`/`useMutation` hook -> component. All API requests use `credentials: "include"`. Server state must live in shared domain hooks (`hooks/api/`), never inline in components. Components should only render and handle user interaction — keep data transformation and business logic in hooks or utilities.
 
-**Route protection**: No Next.js middleware is used. Auth gating relies on API calls returning 401 for unauthenticated requests — the frontend redirects to `/login` on auth failure. API proxying is handled by Next.js rewrites in `next.config.mjs`.
+**Route protection**: `proxy.ts` performs the frontend redirect preflight, while the API's protected manifest scope is the authoritative auth gate and returns 401 for unauthenticated requests. API proxying is handled by Next.js rewrites in `next.config.mjs`.
 
 **Lazy modals**: Use `React.lazy` + `Suspense` for modals behind `{stateVar && <Modal />}`. Named exports need adapter: `lazy(() => import("./file").then(m => ({ default: m.NamedExport })))`.
 
@@ -153,7 +153,7 @@ pnpm --filter @arr/api exec tsc --noEmit         # Type check backend
 
 ## Patterns & Gotchas
 
-- **API Proxy**: Frontend uses `/api/*` paths via Next.js rewrites in `next.config.mjs`. No middleware exists — auth gating relies on API 401 responses
+- **API Proxy**: Frontend uses `/api/*` paths via Next.js rewrites in `next.config.mjs`; `proxy.ts` only assists navigation, and API 401 responses remain authoritative
 - **Server Components**: Default in Next.js App Router. Add `"use client"` when needed
 - **Docker vs Dev**: Different env vars and paths (`/config/` vs `./`)
 - **Secrets auto-generated**: `ENCRYPTION_KEY` and `SESSION_COOKIE_SECRET` are auto-generated to `secrets.json` if not provided

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,16 +20,17 @@ The main development reference is [`CLAUDE.md`](CLAUDE.md) — it covers:
 
 ## Submitting Changes
 
-1. **Fork** the repo and create a branch from `main`
+1. **Fork** the repo and choose the correct base: `next` for 3.0 work, or `main` only for 2.x maintenance
 2. **Follow existing patterns** — check `CLAUDE.md` for conventions
 3. **Test your changes**:
    ```bash
-   pnpm run lint        # Biome (API) + ESLint (Web)
-   pnpm run typecheck   # TypeScript strict mode
+   pnpm run format      # Biome format check
+   pnpm run typecheck   # Turbo TypeScript check (matches CI)
    pnpm run test        # Vitest unit tests
-   pnpm run build       # Production build
+   pnpm run lint        # Biome (API) + ESLint (Web)
+   pnpm run build       # Production build for release-sensitive changes
    ```
-4. **Open a PR** against `main` with a clear description
+4. **Open a PR** against the branch you based the work on (`next` for 3.0; `main` for 2.x maintenance) with a clear description
 
 ## What Makes a Good PR
 

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -305,7 +305,7 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		register: registerTracearrRoutes,
 		maturity: "experimental",
 		summary:
-			"Tracearr integration (charter §2.2 / ADR-0007) — self-hosted media-analytics peer replacing Tautulli in 3.0. Typed reads against Tracearr's Public API (health, live streams + aggregate for the console card, watch history, stats, users, violations) plus the kill-session operator action (POST terminate). Instance CRUD + connection testing runs through /api/services; Statistics-on-Tracearr (C2) follows.",
+			"Tracearr integration (charter §2.2 / ADR-0007) — typed Public API reads for health, streams, history, stats, activity, users, and violations, plus stream termination. Powers the Console live-session card and Statistics analytics; instance CRUD and connection testing run through /api/services.",
 	},
 
 	// --- External integrations (Seerr / TRaSH Guides) ---

--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -84,7 +84,10 @@ qui-home. The remaining polling surfaces are correctly excluded:
 ---
 
 ## Remaining work (in recommended order)
-No charter deliverables remain open. Next work is the release-readiness audit and prerelease path.
+No charter deliverables remain open. The release-readiness audit is recorded in
+[`docs/3.0-release-readiness.md`](3.0-release-readiness.md). Its beta-entry
+blockers are now the authoritative next-work queue; charter items should not be
+re-opened to represent release operations.
 
 **Tracearr arc (2.2) COMPLETE** — foundation (#555), live-session card (#556),
 kill-session (#557), Statistics stats/activity (#558) + history/users/violations

--- a/docs/3.0-release-readiness.md
+++ b/docs/3.0-release-readiness.md
@@ -1,0 +1,131 @@
+# 3.0 Release Readiness
+
+**Audit date:** 2026-07-15<br>
+**Audited commit:** `45f3c6b` (`next`)<br>
+**Verdict:** Charter-complete, but **not ready to cut beta.1 yet**.
+
+This is the operational bridge between the completed
+[3.0 charter](3.0-charter.md), its
+[completeness tracker](3.0-completeness-status.md), and the stable
+[release checklist](RELEASING.md). It records evidence, separates beta entry
+work from stable-release work, and resolves charter criteria that were
+superseded by accepted ADR amendments.
+
+## Evidence snapshot
+
+- All charter deliverables are complete on `next`; no A/B/C or flagship row
+  remains open in the completeness tracker.
+- GitHub has no open feature PRs. The four open issues are #565, #543, #487,
+  and #427.
+- At the audited commit, CI, CodeQL, Semgrep, and the SQLite/PostgreSQL Docker
+  smoke workflow are green. The `:next` multi-architecture publish was still
+  running when this snapshot was taken; it must finish successfully before a
+  beta tag is cut.
+- The Tautulli semantic migration has realistic unit and route fixtures in
+  `rules-migration/__tests__/tautulli-pass.test.ts` and
+  `routes/__tests__/system-migrations-tautulli.test.ts`. Unified-engine
+  behavior is covered by cleanup, auto-tag, notifications, and serializer
+  parity suites.
+- The repository's prescribed format gate is red: Biome reports 89 files in
+  `apps/api` that would be reformatted. This is pre-existing drift, but a
+  release gate cannot be considered green while it remains the baseline.
+- The last published prerelease is `v3.0.0-alpha.2` from 2026-06-10. Root
+  package metadata still reports `3.0.0-alpha.2`, despite the completed
+  flagship work that followed it.
+
+## Beta.1 entry blockers
+
+| ID | Blocker | Exit evidence |
+|---|---|---|
+| B1 | Settings → Notifications → Rules enters a React update loop. The root cause is now localized: `AggregationConfig` destructures unresolved query data as `configs = []`; that creates a new array every render, its `[configs]` effect sets local state, and the render/effect cycle repeats. | Focused regression test, fix, and browser verification with the Rules tab mounted before and after query resolution. |
+| B2 | Issue #543 reports that `LIBRARY_NEW_CONTENT` does not reach Telegram. Static inspection confirms the event producer and transition detector exist, but there is no scheduler-to-dispatch regression test and the reporter's real scenario has not been reproduced. | Reproduce against Telegram or an equivalent captured sender boundary; fix or document an evidence-backed disposition. Do not close the issue from static inference. |
+| B3 | The prerelease artifact contract is incomplete. `docker-combined.yml` intentionally ignores `v*-*`, while `docker-next.yml` publishes only mutable `:next` tags with `3.0.0-next.<run>` metadata. A GitHub beta tag therefore does not produce a pin-able beta Docker image. | Ratify and implement immutable prerelease tags (recommended: `3.0.0-beta.1` plus a moving `beta` tag, never `latest`) for both registries, with `/health` verification. |
+| B4 | `pnpm run format` fails on 89 existing API files. | A mechanical, reviewable formatting-only PR makes the documented gauntlet green without mixing semantic changes. |
+| B5 | No recorded end-to-end upgrade smoke exists for a realistic v2.21.0 SQLite database at the feature-complete commit. This is the highest-risk user path because it exercises schema push, the Tautulli rules pass, and the consent dialog together. | Preserve a copy of a 2.21.0 fixture, boot the beta candidate against it, exercise the migration dialog, verify disabled-rule disclosures/backups, restart, and confirm idempotence. Record commands and outcomes. |
+
+Beta.1 may be cut when B1–B5 are complete and the candidate SHA has green CI,
+security scans, Docker smoke, and multi-architecture `:next` publication.
+
+## RC and 3.0.0 gates
+
+These are not reasons to delay beta testing, but they block promotion to the
+named stage.
+
+### Before rc.1
+
+- Run and record all four database scenarios from `RELEASING.md`: fresh and
+  upgrade for SQLite and PostgreSQL. CI currently covers fresh container boots;
+  it does not replace realistic upgrade fixtures.
+- Run the live Radarr/Sonarr write-path integration test, the full production
+  build/e2e suite, Docker PUID/PGID smoke, backup create/download, and password,
+  OIDC, and passkey authentication smokes.
+- Review Tracearr's `experimental` route tier against ADR-0005 graduation
+  criteria, as required by ADR-0007. Promote it or explicitly record why it
+  remains experimental in the release notes.
+- Fix the Pulse dismissal identity that embeds
+  `issue.message.slice(0, 30)` in an `arr-health` signal id. It fails safe, but
+  dismiss-until-recovery is not durable when the message changes.
+- Resolve the release promotion mechanics: merge `next` to `main`, tag the
+  exact promoted commit, and confirm the stable workflow's main-ancestry guard.
+  The current stable checklist documents tagging but not the `next` → `main`
+  promotion step.
+
+### Before 3.0.0
+
+- Complete a two-week soak of the **feature-complete** `:next`/beta candidate
+  with no major regressions. The meaningful clock starts 2026-07-15, making
+  2026-07-29 the earliest evidence date; prior `:next` uptime did not contain
+  the completed Setup and composer flagships.
+- Keep all four governance gates green for four weeks. The final gate landed
+  2026-06-29, making 2026-07-27 the earliest evidence date.
+- Rewrite README, Docker Hub copy, and the wiki for 3.0. They currently present
+  2.21.0, list Tautulli as supported, and omit the Operator Console, composer,
+  Tracearr, and rewritten Setup experience. The final narrative must lead with
+  the trust-layer thesis and the two flagships plus Setup rewrite.
+- Prepare the version bump and complete changelog from alpha.2 onward, create
+  the stable GitHub release, verify both registry images, and monitor the issue
+  tracker for 24–48 hours.
+- Close #487 only when the integration is actually available in the released
+  3.0 image, with an issue-specific explanatory comment. Keep #427 open for
+  monitoring unless release evidence supports a different decision. #565 is a
+  feature request and is not 3.0 release scope.
+
+## Superseded charter criteria
+
+The charter remains the historical contract, but later ADR amendments are the
+ratified implementation truth:
+
+- "Each path through the Tautulli wizard" now means the single consent-gated
+  removal path that shipped. ADR-0007 downscoped the wizard to a confirmation
+  dialog, then recorded the one-action implementation.
+- "All five unified-rule-engine migrations" and five backup files no longer
+  apply. ADR-0006 amendment 2 replaced eager format rewrites with parse-time v0
+  mapping and write-on-edit convergence. The only semantic migration is the
+  Tautulli-condition retirement, which retains the backup/report contract.
+- The five rule domains do not all persist v1 documents in one new store.
+  Existing domain rows remain authoritative for legacy authoring; cross-domain
+  automation uses its own versioned draft/deployment snapshot lifecycle per
+  ADR-0006 amendment 3.
+
+These amendments reduce migration risk; they do not remove the need for the
+realistic v2.21.0 upgrade smoke in B5.
+
+## Non-blocking debt after beta
+
+- Repair or retire `apps/api/scripts/seed-admin.ts`; its password-helper import
+  is broken and the supported first-user path is `/setup`.
+- Decide whether the release-label bucketing process applies to the long-lived
+  3.0 promotion. The 3.0 PRs have no `release:*` labels because charter scope,
+  not the 2.x patch queue, governed them.
+- Continue normal triage of #565 and monitoring of #427 without pulling either
+  into the 3.0 critical path absent new evidence.
+
+## Recommended execution order
+
+1. Fix B1 and add the missing scheduler-to-notification regression coverage
+   while investigating B2.
+2. Add immutable prerelease Docker publication (B3).
+3. Land the formatting-only baseline cleanup (B4).
+4. Run and record the realistic SQLite upgrade rehearsal (B5).
+5. Prepare and cut `v3.0.0-beta.1`, then begin the feature-complete soak and
+   public documentation rewrite in parallel.

--- a/docs/3.0-release-readiness.md
+++ b/docs/3.0-release-readiness.md
@@ -18,9 +18,9 @@ superseded by accepted ADR amendments.
 - GitHub has no open feature PRs. The four open issues are #565, #543, #487,
   and #427.
 - At the audited commit, CI, CodeQL, Semgrep, and the SQLite/PostgreSQL Docker
-  smoke workflow are green. The `:next` multi-architecture publish was still
-  running when this snapshot was taken; it must finish successfully before a
-  beta tag is cut.
+  smoke workflow are green. The `:next` workflow also published both
+  architectures, created the multi-architecture manifests, and passed its
+  `/health` verification.
 - The Tautulli semantic migration has realistic unit and route fixtures in
   `rules-migration/__tests__/tautulli-pass.test.ts` and
   `routes/__tests__/system-migrations-tautulli.test.ts`. Unified-engine

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -59,7 +59,7 @@ for the full rationale.
 | `/api/automation` | experimental | Unified Automation Engine composer — normalized domain-rule reads plus cross-domain draft CRUD, mutation-free dry-run, atomic deploy, and scheduled execution. |
 | `/api/qui` | stable | Federated peer integration with autobrr/qui (qBittorrent UI) — torrent state, trackers, cross-seed siblings, and capability-aware torrent mutations; powers the Torrent Health panel and detail drawer. |
 | `/api/webhooks/qui` | stable | Inbound qui webhook receiver (Phase 5.1). **Public route** (no session cookie); authenticates via per-user `?secret=…` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in `QuiEventLog` and publishes to the in-process event bus for SSE fan-out. |
-| `/api/tracearr` | experimental | Tracearr integration (charter §2.2 / ADR-0007) — self-hosted media-analytics peer replacing Tautulli in 3.0. Foundation phase: typed reads against Tracearr's Public API (health, live streams, watch history, stats, users, violations). Instance CRUD + connection testing runs through `/api/services`; live-session tiles, kill-session, and Statistics-on-Tracearr follow. |
+| `/api/tracearr` | experimental | Tracearr integration (charter §2.2 / ADR-0007) — typed Public API reads for health, streams, history, stats, activity, users, and violations, plus stream termination. Powers the Console live-session card and Statistics analytics; instance CRUD and connection testing run through `/api/services`. |
 | `/api/seerr` | stable | Request management, discovery, library enrichment |
 | `/api/trash-guides` | operator | TRaSH cache, templates, deployment, profiles |
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,6 +2,12 @@
 
 Step-by-step checklist for publishing a new version of Arr Dashboard.
 
+> **3.0 cycle:** Use the
+> [3.0 release-readiness audit](3.0-release-readiness.md) for beta/RC entry
+> gates and the `next` → `main` promotion checklist. This document remains the
+> stable-tag checklist; the current Docker workflows do not yet publish
+> immutable images for prerelease tags.
+
 ## Pre-Release
 
 ### 0. Determine Release Scope

--- a/docs/domains/README.md
+++ b/docs/domains/README.md
@@ -12,7 +12,7 @@ deep dives (`docs/AUTH.md`, `docs/API-ROUTES.md`) and ADRs
 |---|---|
 | [Auth](auth.md) | touching login, sessions, encryption, OIDC, passkeys, or anything that decides who a request belongs to |
 | [Schedulers](schedulers.md) | adding or modifying a background job, or wiring something into `/system/jobs` |
-| [Services](services.md) | adding or modifying a Sonarr / Radarr / Plex / Tautulli / Jellyfin / Seerr integration |
+| [Services](services.md) | adding or modifying an *arr / media server / Seerr / qui / Tracearr integration |
 | [System](system.md) | adding a `/system/*` endpoint or a section to the System tab in Settings |
 
 For when to update these docs vs. when to write an ADR, see the

--- a/docs/domains/services.md
+++ b/docs/domains/services.md
@@ -1,8 +1,8 @@
 # Domain: Services
 
 Operating manual for external integrations: Sonarr, Radarr, Prowlarr,
-Lidarr, Readarr, Plex, Tautulli, Jellyfin/Emby, Seerr (Jellyseerr /
-Overseerr).
+Lidarr, Readarr, Plex, Jellyfin/Emby, Seerr (Jellyseerr / Overseerr),
+qui, and Tracearr.
 
 ## Purpose
 
@@ -17,12 +17,15 @@ and the UI deal in normalized, typed shapes.
 | Shape | Services | Client style |
 |---|---|---|
 | ARR | Sonarr, Radarr, Prowlarr, Lidarr, Readarr | shared `ArrClientFactory` over `arr-sdk` |
-| Media server | Plex, Jellyfin, Emby, Tautulli | per-service hand-written client (different auth headers) |
+| Media server | Plex, Jellyfin, Emby | per-service hand-written client (different auth headers) |
 | Request | Seerr (Jellyseerr / Overseerr) | hand-written client over `ArrClientFactory.rawRequest()` with retry + circuit breaker |
+| Torrent peer | qui | typed client factory plus capability-aware action service |
+| Analytics | Tracearr | typed Bearer client for its Public API |
 
-All three categories share the same Prisma model (`ServiceInstance`) and
-the same lookup helper (`requireInstance`). The split is in *how to talk
-to them*, not in *how we own them*.
+All categories share the same Prisma model (`ServiceInstance`) and ownership
+invariant. ID-based routes normally use `requireInstance`; aggregate/singleton
+surfaces may use a domain resolver that scopes its query by `userId`. The split
+is in *how to talk to them*, not in *how we own them*.
 
 ## Key files
 
@@ -31,8 +34,10 @@ to them*, not in *how we own them*.
 | CRUD + connection test for any service | `apps/api/src/routes/services.ts` |
 | Ownership-checked instance lookup | `apps/api/src/lib/arr/instance-helpers.ts` (`requireInstance`, `requireEnabledInstance`) |
 | ARR client factory + error types | `apps/api/src/lib/arr/client-factory.ts` |
-| Plex / Tautulli / Jellyfin clients | `apps/api/src/lib/plex/plex-client.ts`, `apps/api/src/lib/tautulli/tautulli-client.ts`, `apps/api/src/lib/jellyfin/*` |
+| Plex / Jellyfin / Emby clients | `apps/api/src/lib/plex/plex-client.ts`, `apps/api/src/lib/jellyfin/*` |
 | Seerr client (resilient) | `apps/api/src/lib/seerr/seerr-client.ts` |
+| qui client + actions | `apps/api/src/lib/qui/client-factory.ts`, `apps/api/src/lib/qui/action-service.ts` |
+| Tracearr client | `apps/api/src/lib/tracearr/client-factory.ts` |
 | Encrypted update helper | `apps/api/src/lib/services/update-builder.ts` |
 | Library/search normalizers | `apps/api/src/lib/library/*-normalizer.ts`, `apps/api/src/lib/search/normalizers.ts` |
 | Centralized error mapping | `apps/api/src/server.ts` (error handler) + `apps/api/src/lib/errors.ts` |
@@ -42,9 +47,11 @@ to them*, not in *how we own them*.
 
 These are the rules every contributor must hold. Most are not type-checkable.
 
-1. **Every instance lookup goes through `requireInstance(app, userId, id)`.**
-   Never query `serviceInstance.findFirst({ where: { id } })` directly —
-   that elides the `userId` filter and creates a cross-tenant read.
+1. **Every instance lookup is ownership-scoped.** Prefer
+   `requireInstance(app, userId, id)` for ID-based reads. A domain resolver
+   may query directly when it aggregates or selects a singleton, but its
+   Prisma `where` must include `userId`; `{ id }` alone creates a cross-tenant
+   read.
 2. **Credentials are encrypted on write through `app.encryptor.encrypt()`,
    stored as `{ encryptedApiKey, encryptionIv }`, and decrypted only at
    the moment of use.** No plaintext on the wire to the DB, no caching
@@ -72,8 +79,9 @@ These are the rules every contributor must hold. Most are not type-checkable.
 - **Validation health** — every external integration emits validation
   stats consumed by `/system/validation-health` (see
   [`docs/domains/system.md`](system.md)).
-- **Centralized error handler** — `ArrError` / `SeerrApiError` /
-  `InstanceNotFoundError` all collapse into clean HTTP responses there.
+- **Centralized error handler** — `ArrError`, `SeerrApiError`,
+  `QuiApiError`, `TracearrApiError`, and `InstanceNotFoundError` all collapse
+  into clean HTTP responses there.
 
 ## Common failure modes / operational notes
 
@@ -87,9 +95,9 @@ These are the rules every contributor must hold. Most are not type-checkable.
   Prowlarr API revisions, Plex schema additions. Absorb in a normalizer
   with defensive type converters (`toNumber`, `toString`, `toBoolean`),
   not in the route or the UI.
-- **Token leakage in logs** — Tautulli's `apikey=…` query param is the
-  most common offender. Sanitize before any `app.log` call. Same rule
-  for Plex's `X-Plex-Token`.
+- **Token leakage in logs** — sanitize Plex's `X-Plex-Token`, Tracearr's
+  Bearer token, qui credentials, and webhook secrets before any `app.log`
+  call. Do not put credentials into URLs.
 - **Seerr/Jellyseerr 5xx storms** — handled by retry + circuit breaker
   in `seerr-client.ts`. Do not add ad-hoc retries on top of that in
   routes.
@@ -111,10 +119,10 @@ A new media or request service (more common):
    regenerate the Prisma client.
 2. `apps/api/src/lib/<service>/<service>-client.ts` — mirror an existing
    peer rather than inventing a signature: `plex-client.ts` for simple
-   token-header auth, `tautulli-client.ts` for query-param API keys,
-   `seerr-client.ts` for resilient (retry + circuit breaker) clients
-   over `ArrClientFactory.rawRequest()`. Sanitize tokens before logging
-   in all cases.
+   token-header auth, Tracearr's `client-factory.ts` for a typed Bearer
+   client, or `seerr-client.ts` for resilient (retry + circuit breaker)
+   clients over `ArrClientFactory.rawRequest()`. Sanitize tokens before
+   logging in all cases.
 3. Routes:
    - if it slots into the generic CRUD shape → reuse `routes/services.ts`
      and only add a connection-test branch.


### PR DESCRIPTION
## Summary

- add an evidence-backed 3.0 release-readiness audit with beta, RC, stable, and non-blocking work separated
- reconcile superseded charter migration criteria with ADR-0006 and ADR-0007 amendments
- correct stale contributor, architecture, services, Tracearr route, and release guidance

## Key findings

The charter is complete, but beta.1 has five entry blockers: the root-caused Notifications Rules render loop, investigation of issue #543, immutable prerelease Docker artifacts, the 89-file format baseline, and a realistic v2.21.0 SQLite upgrade rehearsal.

## Validation

- `pnpm run typecheck`
- `pnpm run test` — 2,947 passed, 41 skipped
- `pnpm run lint` — passes with the existing 10 API and 27 web warnings
- `pnpm --filter @arr/api exec biome check src/routes/route-manifest.ts`
- `pnpm --filter @arr/api exec vitest run src/routes/__tests__/route-manifest.test.ts`
- `git diff --check`

`pnpm run format` remains red on the pre-existing 89-file API baseline; the audit records that as beta blocker B4.