### PR TITLE
fix: resolve notification beta blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Arr Dashboard will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- New Radarr and Sonarr downloads are now detected when an item is added and
+  imported entirely between library polls, and the resulting notification is
+  dispatched only through channels owned by the instance's user.
+- The notification Rules page no longer enters a render loop while aggregation
+  configuration is unavailable.
+
 ## [3.0.0-alpha.2] - 2026-06-10 — Bucket B: the coherence sweep
 
 Second 3.0 preview. Every formalized UI/data primitive is now applied

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -684,7 +684,7 @@ describe("syncInstance", () => {
 
 	// --- New download detection ---------------------------------------------
 
-	describe("New download detection (hasFile false->true)", () => {
+	describe("New download detection", () => {
 		it("Sonarr: detects when hasFile transitions from false to true", async () => {
 			const rawItems = [
 				makeRawItem({
@@ -736,6 +736,63 @@ describe("syncInstance", () => {
 				title: "Downloaded Book",
 				itemType: "author",
 			});
+		});
+
+		it("detects an item added and imported entirely between completed syncs", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Between-polls Movie",
+					hasFile: true,
+					added: "2026-07-15T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: new Date("2026-07-15T11:00:00Z"),
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([{ title: "Between-polls Movie", itemType: "movie" }]);
+		});
+
+		it("does not report existing downloaded items during the first baseline sync", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Existing Movie",
+					hasFile: true,
+					added: "2026-07-15T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: null,
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([]);
+		});
+
+		it("does not report a stale downloaded item that merely reappears", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Old Movie",
+					hasFile: true,
+					added: "2026-07-14T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: new Date("2026-07-15T11:00:00Z"),
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([]);
 		});
 	});
 

--- a/apps/api/src/lib/library-sync/__tests__/sync-scheduler.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-scheduler.test.ts
@@ -23,8 +23,10 @@
 
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationDispatcher } from "../../notifications/notification-dispatcher.js";
+import { NotificationService } from "../../notifications/notification-service.js";
 
-import { LibrarySyncScheduler } from "../sync-scheduler.js";
+import { LibrarySyncScheduler, sendNewDownloadNotification } from "../sync-scheduler.js";
 
 // Match the constants in sync-scheduler.ts. If those change, these test
 // thresholds should too — but keep them in sync intentionally so a change
@@ -239,6 +241,96 @@ describe("LibrarySyncScheduler.activeSyncItemCounts lifecycle", () => {
 		expect(callEffectiveMaxConcurrent(sched, 100)).toBe(1);
 		map.delete("inst-1");
 		expect(callEffectiveMaxConcurrent(sched, 100)).toBe(2);
+	});
+});
+
+// ============================================================================
+// New-download producer → Telegram sender (issue #543)
+// ============================================================================
+
+describe("sendNewDownloadNotification", () => {
+	it("scopes the event to the owner and reaches the real Telegram sender", async () => {
+		const notificationSubscriptionFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "sub-1",
+				channelId: "telegram-1",
+				eventType: "LIBRARY_NEW_CONTENT",
+				channel: {
+					id: "telegram-1",
+					userId: "user-1",
+					name: "Telegram",
+					type: "TELEGRAM",
+					enabled: true,
+					encryptedConfig: "encrypted-config",
+					configIv: "config-iv",
+				},
+			},
+		]);
+		const notificationLogCreate = vi.fn().mockResolvedValue({});
+		const notificationChannelUpdate = vi.fn().mockResolvedValue({});
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		const service = new NotificationService(
+			{
+				notificationSubscription: { findMany: notificationSubscriptionFindMany },
+				notificationLog: { create: notificationLogCreate },
+				notificationChannel: { update: notificationChannelUpdate },
+			} as never,
+			{
+				decrypt: vi
+					.fn()
+					.mockReturnValue(JSON.stringify({ botToken: "telegram-token", chatId: "chat-123" })),
+			} as never,
+			new NotificationDispatcher(),
+			{ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+			{ isDuplicate: vi.fn().mockReturnValue(false) } as never,
+			{ enqueue: vi.fn() } as never,
+			"https://dashboard.example.test",
+		);
+
+		try {
+			await sendNewDownloadNotification(
+				service,
+				{
+					newDownloads: [
+						{ title: "Movie <One>", itemType: "movie" },
+						{ title: "Movie Two", itemType: "movie" },
+					],
+				},
+				{ label: "Radarr", service: "RADARR", userId: "user-1" },
+			);
+
+			expect(notificationSubscriptionFindMany).toHaveBeenCalledWith({
+				where: {
+					eventType: "LIBRARY_NEW_CONTENT",
+					channel: { userId: "user-1" },
+				},
+				include: { channel: true },
+			});
+			expect(fetchSpy).toHaveBeenCalledWith(
+				"https://api.telegram.org/bottelegram-token/sendMessage",
+				expect.objectContaining({
+					method: "POST",
+					body: expect.stringContaining("2 new download(s) on Radarr"),
+				}),
+			);
+			const request = fetchSpy.mock.calls[0]?.[1];
+			const body = JSON.parse(String(request?.body)) as { text: string };
+			expect(body.text).toContain("Movie &lt;One&gt;, Movie Two");
+			expect(body.text).toContain("https://dashboard.example.test/library");
+			expect(notificationLogCreate).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					channelId: "telegram-1",
+					channelType: "TELEGRAM",
+					eventType: "LIBRARY_NEW_CONTENT",
+					status: "sent",
+				}),
+			});
+		} finally {
+			service.dispose();
+			fetchSpy.mockRestore();
+		}
 	});
 });
 

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -244,7 +244,7 @@ export async function syncInstance(
 	};
 
 	try {
-		await prisma.librarySyncStatus.upsert({
+		const syncStatus = await prisma.librarySyncStatus.upsert({
 			where: { instanceId: instance.id },
 			create: {
 				instanceId: instance.id,
@@ -255,6 +255,7 @@ export async function syncInstance(
 				lastError: null,
 			},
 		});
+		const previousFullSync = syncStatus.lastFullSync;
 
 		const client = arrClientFactory.create(instance);
 		const service = instance.service.toLowerCase() as LibraryService;
@@ -450,6 +451,21 @@ export async function syncInstance(
 							data: buildCacheCreate(instance.id, item),
 						});
 						result.itemsAdded++;
+
+						// A complete add + import can happen between polling ticks. In that
+						// case there is no cached hasFile=false row to transition from, so
+						// recognize a newly added ARR item that already has a file. Require a
+						// completed baseline sync and an ARR added timestamp newer than that
+						// baseline; this prevents first-sync floods and stale-row reappearance
+						// from masquerading as new downloads.
+						if (
+							fields.hasFile &&
+							previousFullSync &&
+							fields.arrAddedAt &&
+							fields.arrAddedAt > previousFullSync
+						) {
+							result.newDownloads.push({ title: item.title, itemType: item.type });
+						}
 					}
 					result.itemsProcessed++;
 				}

--- a/apps/api/src/lib/library-sync/sync-scheduler.ts
+++ b/apps/api/src/lib/library-sync/sync-scheduler.ts
@@ -8,6 +8,7 @@
 import { LIBRARY_SERVICES_UPPER } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../logger.js";
+import type { NotificationService } from "../notifications/notification-service.js";
 import {
 	passthroughTickWrapper,
 	type TickWrapper,
@@ -360,6 +361,7 @@ export class LibrarySyncScheduler {
 	 */
 	private async runSync(instance: {
 		id: string;
+		userId: string;
 		label: string;
 		service: string;
 		baseUrl: string;
@@ -390,30 +392,16 @@ export class LibrarySyncScheduler {
 				"Library sync completed",
 			);
 
-			// Notify about newly downloaded content (hasFile: false → true transitions)
+			// Notify about newly downloaded content detected by the sync executor.
 			if (result.success && result.newDownloads.length > 0) {
-				const titles = result.newDownloads.slice(0, 5).map((d) => d.title);
-				const remaining = result.newDownloads.length - titles.length;
-
-				this.app.notificationService
-					?.notify({
-						eventType: "LIBRARY_NEW_CONTENT",
-						title: `${result.newDownloads.length} new download(s) on ${instance.label}`,
-						body: remaining > 0 ? `${titles.join(", ")} and ${remaining} more` : titles.join(", "),
-						url: "/library",
-						metadata: {
-							instance: instance.label,
-							service: instance.service,
-							itemCount: result.newDownloads.length,
-							items: titles,
-						},
-					})
-					.catch((err) => {
+				void sendNewDownloadNotification(this.app.notificationService, result, instance).catch(
+					(err) => {
 						log.warn(
 							{ err, instanceLabel: instance.label },
 							"New content notification dispatch failed",
 						);
-					});
+					},
+				);
 			}
 
 			return result;
@@ -436,6 +424,36 @@ export class LibrarySyncScheduler {
 	isInstanceSyncing(instanceId: string): boolean {
 		return this.activeSyncs.has(instanceId);
 	}
+}
+
+/**
+ * Dispatch the library-sync delta through the owning user's notification
+ * pipeline. Exported so the producer-to-channel contract can be tested with
+ * the real notification service and sender registry.
+ */
+export async function sendNewDownloadNotification(
+	notificationService: Pick<NotificationService, "notify">,
+	result: Pick<SyncResult, "newDownloads">,
+	instance: { label: string; service: string; userId: string },
+): Promise<void> {
+	const titles = result.newDownloads.slice(0, 5).map((download) => download.title);
+	const remaining = result.newDownloads.length - titles.length;
+
+	await notificationService.notify(
+		{
+			eventType: "LIBRARY_NEW_CONTENT",
+			title: `${result.newDownloads.length} new download(s) on ${instance.label}`,
+			body: remaining > 0 ? `${titles.join(", ")} and ${remaining} more` : titles.join(", "),
+			url: "/library",
+			metadata: {
+				instance: instance.label,
+				service: instance.service,
+				itemCount: result.newDownloads.length,
+				items: titles,
+			},
+		},
+		{ userId: instance.userId },
+	);
 }
 
 // ============================================================================

--- a/apps/web/src/features/notifications/components/__tests__/aggregation-config.test.tsx
+++ b/apps/web/src/features/notifications/components/__tests__/aggregation-config.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseAggregationConfigs = vi.fn();
+const mockUpdate = { mutate: vi.fn(), isPending: false };
+
+vi.mock("../../../../hooks/api/useNotifications", () => ({
+	useAggregationConfigs: () => mockUseAggregationConfigs(),
+	useUpdateAggregationConfigs: () => mockUpdate,
+}));
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "rgb(1, 2, 3)" },
+	}),
+}));
+
+import { AggregationConfig } from "../aggregation-config";
+
+describe("AggregationConfig", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("renders a stable empty configuration while the query has no data", () => {
+		mockUseAggregationConfigs.mockReturnValue({ data: undefined, isLoading: false });
+
+		render(<AggregationConfig />);
+
+		expect(screen.getByText("Event Aggregation")).toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/notifications/components/aggregation-config.tsx
+++ b/apps/web/src/features/notifications/components/aggregation-config.tsx
@@ -65,6 +65,8 @@ const AGGREGATABLE_EVENTS: NotificationEventType[] = [
 	"JELLYFIN_NEW_DEVICE",
 ];
 
+const EMPTY_AGGREGATION_CONFIGS: never[] = [];
+
 interface LocalConfig {
 	eventType: NotificationEventType;
 	windowSeconds: number;
@@ -74,7 +76,7 @@ interface LocalConfig {
 
 export function AggregationConfig() {
 	const { gradient } = useThemeGradient();
-	const { data: configs = [], isLoading } = useAggregationConfigs();
+	const { data: configs = EMPTY_AGGREGATION_CONFIGS, isLoading } = useAggregationConfigs();
 	const updateConfigs = useUpdateAggregationConfigs();
 	const [localConfigs, setLocalConfigs] = useState<LocalConfig[]>([]);
 	const [isDirty, setIsDirty] = useState(false);


### PR DESCRIPTION
## Summary

- stop the notification Rules view from entering a maximum-update-depth loop while aggregation data is unresolved
- detect Radarr/Sonarr items that are added and imported entirely between library polling ticks
- scope library download notifications to the service instance owner
- exercise the producer through the real Telegram sender with a captured HTTP boundary

## Root causes

The Rules component created a fresh fallback array on every unresolved query render, and an effect copied that unstable value into local state.

Library sync only recognized cached `hasFile: false → true` transitions. An item added and imported between two polls first appeared in cache with `hasFile: true`, so no event was produced. The new path requires both a completed baseline and an ARR-added timestamp newer than the previous full sync, preventing first-sync floods and stale-row reappearance.

This addresses the reproducible between-poll failure path relevant to #543. The issue should remain open until the reporter confirms the fix against their Telegram setup.

## Validation

- API: 196 test files passed, 2,228 tests passed
- Web: 56 test files passed, 627 tests passed
- `pnpm run typecheck`
- `pnpm run lint` (existing warnings only)
- real Chromium session on Settings → Notifications → Rules; no render-depth or console errors
- changed files pass Biome formatting and `git diff --check`

The repository-wide `pnpm run format` still reports the previously audited 89-file API formatting baseline; that cleanup is isolated to the next beta-readiness increment.