### PR TITLE
ci: publish immutable prerelease images

### DIFF
--- a/.github/workflows/docker-combined.yml
+++ b/.github/workflows/docker-combined.yml
@@ -3,11 +3,9 @@ name: Build and Push Release Docker Image
 on:
   push:
     tags:
-      # Stable release tags only. Prerelease tags (v3.0.0-alpha.1 etc.)
-      # are cut from `next` and must never publish :latest — the
-      # validate-tag ancestry guard below already blocks them, but
-      # excluding them here avoids a red failed run on every prerelease
-      # tag. Preview images ship via docker-next.yml (:next channel).
+      # Stable release tags only. Prerelease tags are handled by
+      # docker-next.yml, which publishes immutable + moving preview tags
+      # without ever touching :latest.
       - 'v*'
       - '!v*-*'
   workflow_dispatch:

--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -1,9 +1,13 @@
-name: Build and Push Next Docker Image
+name: Build and Push Preview Docker Image
 
 on:
   push:
     branches:
       - "next"
+    tags:
+      - "v*-alpha.*"
+      - "v*-beta.*"
+      - "v*-rc.*"
   workflow_dispatch:
 
 # Cancel in-progress runs when a new push arrives
@@ -16,10 +20,37 @@ env:
   DOCKERHUB_IMAGE: khak1s/arr-dashboard
 
 jobs:
+  validate-prerelease:
+    name: Validate Prerelease Tag
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Checkout repository (full history for ancestry check)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag format and next ancestry
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ ! "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
+            echo "::error::Prerelease tag '$REF_NAME' must match vX.Y.Z-(alpha|beta|rc).N."
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/next; then
+            echo "::error::Tagged commit $GITHUB_SHA is not reachable from origin/next."
+            echo "::error::Prerelease tags must be cut from the next branch."
+            exit 1
+          fi
+          echo "Prerelease tag is valid and reachable from next (${GITHUB_SHA::7})."
+
   # ── Build each platform in parallel ────────────────────────────────
   build:
     name: Build (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    needs: validate-prerelease
+    if: always() && (needs.validate-prerelease.result == 'success' || needs.validate-prerelease.result == 'skipped')
     permissions:
       contents: read
       packages: write
@@ -71,11 +102,17 @@ jobs:
         env:
           FULL_SHA: ${{ github.sha }}
           PLATFORM: ${{ matrix.platform }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
           echo "short_sha=${FULL_SHA::7}" >> "$GITHUB_OUTPUT"
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-          echo "version=3.0.0-next.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=3.0.0-next.${RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+          fi
           echo "platform_slug=${PLATFORM//\//-}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push by digest (GHCR)
@@ -221,16 +258,28 @@ jobs:
       - name: Create and push GHCR manifest
         working-directory: /tmp/digests-ghcr
         env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
           SHORT_SHA: ${{ steps.tags.outputs.short_sha }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
-          TAGS=(
-            "-t" "${GHCR_IMAGE}:next"
-            "-t" "${GHCR_IMAGE}:sha-${SHORT_SHA}"
-            "-t" "${GHCR_IMAGE}:build-${RUN_NUMBER}"
-          )
-          docker buildx imagetools create "${TAGS[@]}" \
-            $(printf "${GHCR_IMAGE}@sha256:%s " *)
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            version="${REF_NAME#v}"
+            prerelease="${version#*-}"
+            channel="${prerelease%%.*}"
+            TAGS=("-t" "${GHCR_IMAGE}:${version}" "-t" "${GHCR_IMAGE}:${channel}")
+          else
+            TAGS=(
+              "-t" "${GHCR_IMAGE}:next"
+              "-t" "${GHCR_IMAGE}:sha-${SHORT_SHA}"
+              "-t" "${GHCR_IMAGE}:build-${RUN_NUMBER}"
+            )
+          fi
+          SOURCES=()
+          for digest in *; do
+            SOURCES+=("${GHCR_IMAGE}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${TAGS[@]}" "${SOURCES[@]}"
 
       # ── DockerHub manifest (optional) ──
       - name: Download DockerHub digests
@@ -245,47 +294,97 @@ jobs:
         if: steps.dockerhub-check.outputs.available == 'true'
         working-directory: /tmp/digests-dockerhub
         env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
           SHORT_SHA: ${{ steps.tags.outputs.short_sha }}
           RUN_NUMBER: ${{ github.run_number }}
         run: |
-          TAGS=(
-            "-t" "${DOCKERHUB_IMAGE}:next"
-            "-t" "${DOCKERHUB_IMAGE}:sha-${SHORT_SHA}"
-            "-t" "${DOCKERHUB_IMAGE}:build-${RUN_NUMBER}"
-          )
-          docker buildx imagetools create "${TAGS[@]}" \
-            $(printf "${DOCKERHUB_IMAGE}@sha256:%s " *)
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            version="${REF_NAME#v}"
+            prerelease="${version#*-}"
+            channel="${prerelease%%.*}"
+            TAGS=("-t" "${DOCKERHUB_IMAGE}:${version}" "-t" "${DOCKERHUB_IMAGE}:${channel}")
+          else
+            TAGS=(
+              "-t" "${DOCKERHUB_IMAGE}:next"
+              "-t" "${DOCKERHUB_IMAGE}:sha-${SHORT_SHA}"
+              "-t" "${DOCKERHUB_IMAGE}:build-${RUN_NUMBER}"
+            )
+          fi
+          SOURCES=()
+          for digest in *; do
+            SOURCES+=("${DOCKERHUB_IMAGE}@sha256:${digest}")
+          done
+          docker buildx imagetools create "${TAGS[@]}" "${SOURCES[@]}"
 
   # ── Smoke verification (amd64 only) ───────────────────────────────
   verify:
-    name: Verify /health
+    name: Verify /health (${{ matrix.registry }})
     runs-on: ubuntu-latest
     needs: merge
     permissions:
       contents: read
       packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - registry: ghcr
+            image: ghcr.io/kha-kis/arr-dashboard
+          - registry: dockerhub
+            image: khak1s/arr-dashboard
 
     steps:
+      - name: Select verification tag
+        id: verify-tag
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [[ "$REF_TYPE" == "tag" ]]; then
+            echo "tag=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+            echo "expected_version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=next" >> "$GITHUB_OUTPUT"
+            echo "expected_version=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Log in to GitHub Container Registry
+        if: matrix.registry == 'ghcr'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull next image
-        run: docker pull "${GHCR_IMAGE}:next"
+      - name: Log in to Docker Hub
+        if: matrix.registry == 'dockerhub'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Pull preview image
+        env:
+          VERIFY_IMAGE: ${{ matrix.image }}
+          VERIFY_TAG: ${{ steps.verify-tag.outputs.tag }}
+        run: docker pull "${VERIFY_IMAGE}:${VERIFY_TAG}"
 
       - name: Start container
+        env:
+          VERIFY_IMAGE: ${{ matrix.image }}
+          VERIFY_TAG: ${{ steps.verify-tag.outputs.tag }}
         run: |
           docker run -d \
-            --name next-verify \
+            --name preview-verify \
             -p 3001:3001 \
             -e PUID=1000 \
             -e PGID=1000 \
-            "${GHCR_IMAGE}:next"
+            "${VERIFY_IMAGE}:${VERIFY_TAG}"
 
       - name: Wait for /health and validate
+        env:
+          EXPECTED_VERSION: ${{ steps.verify-tag.outputs.expected_version }}
         run: |
           echo "Polling /health on port 3001 (timeout: 90s)..."
           elapsed=0
@@ -313,6 +412,11 @@ jobs:
                   exit 1
                 fi
 
+                if [ -n "$EXPECTED_VERSION" ] && [ "$version" != "$EXPECTED_VERSION" ]; then
+                  echo "::error::version is '${version}', expected '${EXPECTED_VERSION}'"
+                  exit 1
+                fi
+
                 echo ""
                 echo "=== Verification PASSED ==="
                 echo "version=${version}  commit=${commit}"
@@ -325,13 +429,13 @@ jobs:
           done
 
           echo "::error::Health check did not pass within 90 seconds"
-          docker logs next-verify 2>&1 || true
+          docker logs preview-verify 2>&1 || true
           exit 1
 
       - name: Dump container logs on failure
         if: failure()
-        run: docker logs next-verify 2>&1
+        run: docker logs preview-verify 2>&1
 
       - name: Cleanup
         if: always()
-        run: docker rm -f next-verify 2>/dev/null || true
+        run: docker rm -f preview-verify 2>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
 # ===== BUILD STAGE =====
 FROM build-base AS builder
 WORKDIR /app
+ARG VERSION
 ARG COMMIT_SHA=unknown
 
 # Copy dependencies and source code
@@ -51,7 +52,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     cd /app/deploy-api && \
     cp -r /app/apps/api/dist ./dist && \
     cp -r /app/apps/api/prisma ./prisma && \
-    node -e "const p=require('/app/package.json'); console.log(JSON.stringify({version:p.version,name:p.name,commitSha:process.env.COMMIT_SHA||'unknown'}))" > ./version.json && \
+    node -e "const p=require('/app/package.json'); console.log(JSON.stringify({version:process.env.VERSION||p.version,name:p.name,commitSha:process.env.COMMIT_SHA||'unknown'}))" > ./version.json && \
     # Remove non-Linux native module prebuilds to reduce image size (~1MB)
     find node_modules -type d -name "prebuilds" -exec sh -c 'cd "{}" && rm -rf darwin-* win32-* freebsd-*' \; 2>/dev/null || true
 

--- a/apps/api/src/lib/utils/__tests__/docker-version-contract.test.ts
+++ b/apps/api/src/lib/utils/__tests__/docker-version-contract.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Docker runtime version contract", () => {
+	it("writes the VERSION build argument into the deployed version.json", () => {
+		const dockerfile = readFileSync(resolve(process.cwd(), "../../Dockerfile"), "utf8");
+
+		expect(dockerfile).toContain("ARG VERSION");
+		expect(dockerfile).toContain("version:process.env.VERSION||p.version");
+	});
+});

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -4,9 +4,27 @@ Step-by-step checklist for publishing a new version of Arr Dashboard.
 
 > **3.0 cycle:** Use the
 > [3.0 release-readiness audit](3.0-release-readiness.md) for beta/RC entry
-> gates and the `next` → `main` promotion checklist. This document remains the
-> stable-tag checklist; the current Docker workflows do not yet publish
-> immutable images for prerelease tags.
+> gates and the `next` → `main` promotion checklist. Prereleases are cut from
+> `next` using the process below; the remainder of this document is the
+> stable-tag checklist.
+
+## Prerelease Tags (3.0 alpha/beta/RC)
+
+Prerelease tags must match `vX.Y.Z-(alpha|beta|rc).N` and point to a commit
+reachable from `next`.
+
+```bash
+git switch next
+git pull --ff-only origin next
+git tag -a v3.0.0-beta.1 -m "v3.0.0-beta.1"
+git push origin v3.0.0-beta.1
+```
+
+`docker-next.yml` publishes the exact version and moving prerelease channel to
+both registries—for example, `3.0.0-beta.1` and `beta`. It verifies each
+registry's image through `/health`, including the exact version metadata.
+Prereleases never publish `latest`, major, or minor tags; those remain
+exclusive to the stable workflow.
 
 ## Pre-Release
 


### PR DESCRIPTION
## Summary

- accept validated `vX.Y.Z-(alpha|beta|rc).N` tags in the existing preview image workflow
- require prerelease commits to be reachable from `next`
- publish the exact version plus the moving `alpha`, `beta`, or `rc` channel to GHCR and Docker Hub
- wire the `VERSION` build argument into the deployed `version.json`
- verify the exact tagged version through `/health` from both registries
- document the prerelease tagging process and keep prereleases out of the stable `latest` workflow

Branch pushes still publish the existing `next`, SHA, and build-number tags. Stable tags remain exclusively handled by `docker-combined.yml`.

## Root cause found during rehearsal

The Docker runner labels consumed `VERSION`, but the builder generated `version.json` directly from the root package version. A beta image therefore still reported `3.0.0-alpha.2` at `/health`. The builder now writes the supplied version with a package-version fallback for local builds, and a contract test protects that wiring.

## Validation

- Actionlint 1.7.7 passes for `docker-next.yml`
- both workflow files parse as YAML
- shell simulations accept alpha/beta/RC tag forms, derive the expected exact/channel tags, and reject stable or malformed tags
- Docker version contract regression test passes
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint` (existing warnings only)
- `git diff --check`

The repository-wide formatting baseline is isolated to PR #577.