### PR TITLE
docs: record v2.21 SQLite upgrade rehearsal

### DIFF
--- a/docs/3.0-completeness-status.md
+++ b/docs/3.0-completeness-status.md
@@ -83,10 +83,10 @@ qui-home. The remaining polling surfaces are correctly excluded:
 
 ---
 
-## Remaining work (in recommended order)
+## Remaining release work
 No charter deliverables remain open. The release-readiness audit is recorded in
 [`docs/3.0-release-readiness.md`](3.0-release-readiness.md). Its beta-entry
-blockers are now the authoritative next-work queue; charter items should not be
+blockers are resolved; charter items should not be
 re-opened to represent release operations.
 
 **Tracearr arc (2.2) COMPLETE** — foundation (#555), live-session card (#556),

--- a/docs/3.0-release-readiness.md
+++ b/docs/3.0-release-readiness.md
@@ -1,8 +1,9 @@
 # 3.0 Release Readiness
 
 **Audit date:** 2026-07-15<br>
-**Audited commit:** `45f3c6b` (`next`)<br>
-**Verdict:** Charter-complete, but **not ready to cut beta.1 yet**.
+**Evidence baseline:** `4b197b8` (`next`)<br>
+**Verdict:** Charter-complete and **ready to prepare beta.1**. Cutting the tag
+and release remains an explicit release operation.
 
 This is the operational bridge between the completed
 [3.0 charter](3.0-charter.md), its
@@ -15,36 +16,41 @@ superseded by accepted ADR amendments.
 
 - All charter deliverables are complete on `next`; no A/B/C or flagship row
   remains open in the completeness tracker.
-- GitHub has no open feature PRs. The four open issues are #565, #543, #487,
-  and #427.
-- At the audited commit, CI, CodeQL, Semgrep, and the SQLite/PostgreSQL Docker
-  smoke workflow are green. The `:next` workflow also published both
-  architectures, created the multi-architecture manifests, and passed its
-  `/health` verification.
+- The blocker fixes landed through PRs #575–#577. Their required CI, CodeQL,
+  Semgrep, end-to-end, and SQLite/PostgreSQL Docker smoke checks passed.
+- The prerelease workflow publishes immutable exact-version and moving channel
+  tags to both GHCR and Docker Hub. Branch builds retain the `next`, commit,
+  and build tags; prerelease builds never publish `latest`.
 - The Tautulli semantic migration has realistic unit and route fixtures in
   `rules-migration/__tests__/tautulli-pass.test.ts` and
   `routes/__tests__/system-migrations-tautulli.test.ts`. Unified-engine
   behavior is covered by cleanup, auto-tag, notifications, and serializer
   parity suites.
-- The repository's prescribed format gate is red: Biome reports 89 files in
-  `apps/api` that would be reformatted. This is pre-existing drift, but a
-  release gate cannot be considered green while it remains the baseline.
+- The repository's prescribed format gate is green. PR #577 normalized the
+  complete API and web baseline (184 changed files after the full audit, rather
+  than the initially sampled 89 API diagnostics) and enabled Biome's Tailwind
+  directive parsing for `globals.css`.
+- A preserved, realistic v2.21.0 SQLite fixture passed a combined-container
+  schema upgrade, browser consent flow, backup inspection, and idempotent
+  restart. See the
+  [upgrade rehearsal record](3.0-v2.21-sqlite-upgrade-rehearsal.md).
 - The last published prerelease is `v3.0.0-alpha.2` from 2026-06-10. Root
-  package metadata still reports `3.0.0-alpha.2`, despite the completed
-  flagship work that followed it.
+  package metadata still reports `3.0.0-alpha.2`; updating it and creating the
+  beta tag are release-preparation actions, not unresolved product blockers.
 
-## Beta.1 entry blockers
+## Beta.1 entry blockers — resolved
 
-| ID | Blocker | Exit evidence |
+| ID | Status | Exit evidence |
 |---|---|---|
-| B1 | Settings → Notifications → Rules enters a React update loop. The root cause is now localized: `AggregationConfig` destructures unresolved query data as `configs = []`; that creates a new array every render, its `[configs]` effect sets local state, and the render/effect cycle repeats. | Focused regression test, fix, and browser verification with the Rules tab mounted before and after query resolution. |
-| B2 | Issue #543 reports that `LIBRARY_NEW_CONTENT` does not reach Telegram. Static inspection confirms the event producer and transition detector exist, but there is no scheduler-to-dispatch regression test and the reporter's real scenario has not been reproduced. | Reproduce against Telegram or an equivalent captured sender boundary; fix or document an evidence-backed disposition. Do not close the issue from static inference. |
-| B3 | The prerelease artifact contract is incomplete. `docker-combined.yml` intentionally ignores `v*-*`, while `docker-next.yml` publishes only mutable `:next` tags with `3.0.0-next.<run>` metadata. A GitHub beta tag therefore does not produce a pin-able beta Docker image. | Ratify and implement immutable prerelease tags (recommended: `3.0.0-beta.1` plus a moving `beta` tag, never `latest`) for both registries, with `/health` verification. |
-| B4 | `pnpm run format` fails on 89 existing API files. | A mechanical, reviewable formatting-only PR makes the documented gauntlet green without mixing semantic changes. |
-| B5 | No recorded end-to-end upgrade smoke exists for a realistic v2.21.0 SQLite database at the feature-complete commit. This is the highest-risk user path because it exercises schema push, the Tautulli rules pass, and the consent dialog together. | Preserve a copy of a 2.21.0 fixture, boot the beta candidate against it, exercise the migration dialog, verify disabled-rule disclosures/backups, restart, and confirm idempotence. Record commands and outcomes. |
+| B1 | Resolved in PR #575 | Stable empty query data removes the render/effect loop. A focused regression test covers the Rules tab before and after query resolution, and the real page was browser-verified with no console or page errors. |
+| B2 | Resolved in PR #575; issue #543 remains open for reporter confirmation | The download transition detector now handles items first observed after completion while guarding the initial baseline and old downloads. A scheduler-to-dispatch regression test captures the real Telegram HTTP request. The issue was updated with evidence rather than closed without reporter confirmation. |
+| B3 | Resolved in PR #576 | Strict `vX.Y.Z-(alpha\|beta\|rc).N` tags publish an immutable version plus the moving channel to GHCR and Docker Hub, with ancestry validation and exact `/health` version checks from both registries. The same candidate Dockerfile was boot-tested locally during B5. |
+| B4 | Resolved in PR #577 | The mechanical formatting baseline is restored; `pnpm run format` passes across shared, API, and web. An independent review confirmed normalized TypeScript ASTs and structurally equal JSON. |
+| B5 | Resolved | The [v2.21.0 SQLite upgrade rehearsal](3.0-v2.21-sqlite-upgrade-rehearsal.md) records the fixture checksum, commands, disclosures, backups, successful browser consent, data integrity, and byte-identical restart behavior. |
 
-Beta.1 may be cut when B1–B5 are complete and the candidate SHA has green CI,
-security scans, Docker smoke, and multi-architecture `:next` publication.
+B1–B5 are complete. Before creating `v3.0.0-beta.1`, update the package version,
+run the release checklist against that exact candidate SHA, and confirm its CI,
+security scans, Docker smoke, and multi-architecture publication are green.
 
 ## RC and 3.0.0 gates
 
@@ -120,12 +126,9 @@ realistic v2.21.0 upgrade smoke in B5.
 - Continue normal triage of #565 and monitoring of #427 without pulling either
   into the 3.0 critical path absent new evidence.
 
-## Recommended execution order
+## Next release operation
 
-1. Fix B1 and add the missing scheduler-to-notification regression coverage
-   while investigating B2.
-2. Add immutable prerelease Docker publication (B3).
-3. Land the formatting-only baseline cleanup (B4).
-4. Run and record the realistic SQLite upgrade rehearsal (B5).
-5. Prepare and cut `v3.0.0-beta.1`, then begin the feature-complete soak and
-   public documentation rewrite in parallel.
+Prepare the version bump and release notes, run the checklist against the exact
+candidate SHA, and then create `v3.0.0-beta.1`. Once its immutable images pass
+the two-registry health verification, begin the feature-complete soak and the
+public documentation rewrite in parallel.

--- a/docs/3.0-v2.21-sqlite-upgrade-rehearsal.md
+++ b/docs/3.0-v2.21-sqlite-upgrade-rehearsal.md
@@ -1,0 +1,94 @@
+# 3.0 v2.21 SQLite Upgrade Rehearsal
+
+**Date:** 2026-07-15  
+**Result:** Pass  
+**Source fixture:** exact `v2.21.0` schema (`188c822`)  
+**Candidate:** `3.0.0-beta.1` image built from `6540e14` (PR #576)
+
+This records the beta-entry upgrade rehearsal required by the
+[3.0 release-readiness audit](3.0-release-readiness.md). The exercise used a
+preserved SQLite fixture with realistic Tautulli removal state, ran the actual
+combined container and schema synchronization, completed the blocking browser
+dialog, and restarted the container to verify idempotence.
+
+## Preserved fixture
+
+The fixture was created by checking out `v2.21.0` and running its own Prisma
+schema push against a new SQLite database. It was then populated with synthetic
+credentials and configuration only—no production data:
+
+- one user;
+- one disabled Tautulli instance and one disabled Radarr instance;
+- two Library Cleanup rules: one wholly Tautulli-dependent and one composite
+  rule with a surviving age condition;
+- two Auto Tag rules: one with `source: "tautulli"` and one wholly
+  Tautulli-dependent composite.
+
+The pristine fixture is intentionally outside the repository:
+
+```text
+/home/khak1s/arr-dashboard-rehearsal-fixtures/v2.21.0-tautulli/prod.db
+SHA-256 12afda1aff422f2f60c31f168225f1c0279beef91c2a5aa1460388df063af714
+```
+
+Its SQLite `integrity_check` returned `ok` before use. A working copy was used
+for the rehearsal so the preserved source remains unchanged.
+
+## Procedure
+
+The essential operator commands were:
+
+```bash
+# Build the candidate with release metadata.
+docker build \
+  --build-arg VERSION=3.0.0-beta.1 \
+  --build-arg COMMIT_SHA=6540e14181fd1ead280fb5c3ef2fdd890c6c33b8 \
+  -t arr-dashboard:migration-rehearsal .
+
+# Boot against a working copy of the v2.21 fixture. The combined launcher
+# performs the same Prisma schema synchronization used by release images.
+docker run -d --name arr-migration-rehearsal \
+  -p 3100:3000 -p 3101:3001 \
+  -e PUID="$(id -u)" -e PGID="$(id -g)" \
+  -v /tmp/arr-v221-fixture.O2Jbz9:/config \
+  arr-dashboard:migration-rehearsal
+
+curl -fsS http://localhost:3101/health
+```
+
+The browser portion used headless Chromium against `http://localhost:3100`:
+
+1. Sign in with the fixture user.
+2. Confirm the blocking **Tautulli support was removed in 3.0** dialog.
+3. Confirm it lists `Legacy Tautulli`, all four affected rule names, and the
+   `rules-pre-3.0/` backup location.
+4. Select **Remove Tautulli & continue** and wait for the dialog to close.
+5. Confirm no page or console errors occurred.
+
+After consent, the container was restarted and `/health`, migration status,
+rule state, backup hashes, and SQLite integrity were checked again.
+
+## Evidence and outcomes
+
+| Check | Outcome |
+|---|---|
+| Schema synchronization | v2.21 database upgraded successfully by the combined launcher. |
+| Candidate metadata | `/health` returned `version: 3.0.0-beta.1` and commit `6540e14…`. |
+| Pre-consent instance state | One Tautulli and one Radarr instance remained present. |
+| Rules pass | Three wholly Tautulli-dependent rules disabled; one mixed cleanup rule remained enabled with only its age condition. |
+| Disclosure | Browser dialog showed the legacy instance, all four rule names, and backup location. |
+| Backups | `library-cleanup.json`, `auto-tag.json`, and `tautulli-pass-report.json` written; originals retained their enabled state and original conditions. |
+| Consent action | Tautulli instance removed; Radarr instance preserved. Report gained `acknowledgedAt`. |
+| Browser health | Dialog completed with zero page/console errors. |
+| Restart idempotence | Migration status returned `needed: false`; backups were byte-identical; exactly one rules-pass completion was logged. |
+| Data integrity | SQLite `integrity_check` returned `ok` before consent and after restart. |
+
+## Defect found during rehearsal
+
+The first candidate build exposed that the Dockerfile used the root package
+version for `version.json` even when CI supplied a `VERSION` build argument.
+The image therefore reported `3.0.0-alpha.2` instead of the requested beta.
+PR #576 now wires the build argument into `version.json`, adds a contract test,
+and makes the prerelease workflow reject mismatched `/health` metadata. The
+rehearsal was reset to the pristine fixture and repeated with that fix before
+the pass result above was recorded.


### PR DESCRIPTION
## Summary

- record the realistic v2.21.0 SQLite-to-3.0 combined-container upgrade rehearsal
- preserve the fixture checksum, schema/consent/backup checks, and restart-idempotence evidence
- reconcile the release-readiness and completeness documents now that B1–B5 are resolved

## Why

The beta readiness audit required a real upgrade exercise, not only unit and route fixtures. The rehearsal also found the Docker version metadata defect fixed in PR #576, after which the fixture was reset and the full exercise passed.

This leaves the repository ready to prepare beta.1. The package version bump and beta tag remain explicit release operations.

## Validation

- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- real combined-container boot against the preserved v2.21.0 SQLite fixture
- headless Chromium consent flow with zero page/console errors
- post-consent restart, byte-identical backup hashes, and SQLite `integrity_check`