### PR TITLE
ci: run manifests after skipped tag validation

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -206,6 +206,10 @@ jobs:
     name: Create Multi-Arch Manifests
     runs-on: ubuntu-latest
     needs: build
+    # Branch runs intentionally skip validate-prerelease. Override GitHub's
+    # transitive implicit success() gate so a successful build matrix still
+    # reaches manifest creation; failed or cancelled builds remain blocked.
+    if: always() && needs.build.result == 'success'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- explicitly run manifest creation when the architecture build matrix succeeds
- retain blocking behavior when a build fails or is cancelled

## Root cause

The first live branch run after PR #576 built and pushed both architectures successfully, but GitHub skipped `Create Multi-Arch Manifests` and both registry health checks. Branch runs intentionally skip `Validate Prerelease Tag`; GitHub's implicit downstream `success()` condition propagated that skipped ancestor through the build job. The merge job therefore needed an explicit condition based on `needs.build.result`.

## Validation

- actionlint 1.7.7
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- live failure mode reproduced in Actions run 29453801342