### PR TITLE
ci: run health checks after manifest creation

### DIFF
--- a/.github/workflows/docker-next.yml
+++ b/.github/workflows/docker-next.yml
@@ -326,6 +326,9 @@ jobs:
     name: Verify /health (${{ matrix.registry }})
     runs-on: ubuntu-latest
     needs: merge
+    # Like merge above, branch runs have a skipped tag-validation ancestor.
+    # Run only after manifest creation succeeds, including on branch builds.
+    if: always() && needs.merge.result == 'success'
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
## Summary

- explicitly run the two-registry health matrix after successful manifest creation
- retain blocking behavior when manifest creation fails or is cancelled

## Root cause

PR #579 fixed the first transitive skipped-ancestor edge and live run 29455766573 proved both multi-architecture manifests now publish. GitHub then applied the same implicit `success()` behavior to the next downstream job because branch runs intentionally skip `Validate Prerelease Tag`, so the health matrix was skipped. This adds the explicit result gate to the final dependency edge.

## Validation

- actionlint 1.7.7
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- live failure mode reproduced in Actions run 29455766573