### PR TITLE
fix(pulse): stabilize ARR health dismissal IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cached user and returns protected pages to login.
 - Fixed the combined container's failed-start diagnostic so its timed foreground
   retry runs as the configured user and reports the real API error.
+- ARR health Pulse dismissals now use an entity-keyed source/URL identity, so
+  changing upstream error text no longer causes a dismissed signal to reappear.
+  Existing message-derived ARR-health dismissals are swept once after upgrade so
+  the active issue resurfaces with its new stable identity.
 
 ## [3.0.0-beta.1] - 2026-07-16 — Trust layer beta
 

--- a/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { LidarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
-import { collectArrSignals } from "../collectors.js";
+import { arrHealthSignalId, collectArrSignals } from "../collectors.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -225,6 +225,38 @@ describe("collectArrSignals — Sonarr", () => {
 		expect(healthItems[0]?.severity).toBe("critical");
 	});
 
+	it("keeps an ARR health signal ID stable when its message changes", async () => {
+		const instance = makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" });
+		const firstIssue = {
+			type: "warning" as const,
+			message: "Indexer is unavailable at https://old.example",
+			source: "IndexerLongTermStatusCheck",
+		};
+		const changedMessageIssue = {
+			...firstIssue,
+			message: "Indexer is unavailable at https://new.example after 3 retries",
+		};
+
+		const first = await collectArrSignals(
+			makeMockApp(instance, makeSonarrClient({ healthResult: [firstIssue] })),
+			"user-1",
+			mockLog,
+		);
+		const changed = await collectArrSignals(
+			makeMockApp(instance, makeSonarrClient({ healthResult: [changedMessageIssue] })),
+			"user-1",
+			mockLog,
+		);
+
+		expect(first[0]?.id).toBe(changed[0]?.id);
+		expect(first[0]?.id).toBe(
+			arrHealthSignalId(instance.id, {
+				type: "warning",
+				source: "IndexerLongTermStatusCheck",
+			}),
+		);
+	});
+
 	it("calls health.getAll() — not health.get() — on SonarrClient", async () => {
 		const client = makeSonarrClient({ healthResult: [] });
 		const app = makeMockApp(
@@ -245,6 +277,19 @@ describe("collectArrSignals — Sonarr", () => {
 // ---------------------------------------------------------------------------
 
 describe("collectArrSignals — edge cases", () => {
+	it("uses a stable fallback when an upstream health row omits source", () => {
+		expect(
+			arrHealthSignalId("inst-1", {
+				type: "warning",
+				wikiUrl: "https://wiki.example/health-check",
+			}),
+		).toBe("arr-health-inst-1-wiki%3Ahttps%3A%2F%2Fwiki.example%2Fhealth-check");
+
+		expect(arrHealthSignalId("inst-1", { type: "warning" })).toBe(
+			"arr-health-inst-1-type%3Awarning",
+		);
+	});
+
 	it("returns empty array when no ARR instances are configured", async () => {
 		const app = {
 			prisma: {

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -34,6 +34,7 @@ import { createQuiClient } from "../qui/client-factory.js";
 import { listQuiInstances } from "../qui/instance-helpers.js";
 import {
 	calculateDiskTotals,
+	type HealthIssue,
 	type InstanceInfo,
 	processHealthIssues,
 	safeRequest,
@@ -56,6 +57,29 @@ type Collector = (
 	userId: string,
 	log: FastifyBaseLogger,
 ) => Promise<PulseItem[]>;
+
+/**
+ * Build a dismissal-safe identity for an ARR health issue.
+ *
+ * Health messages often include changing upstream details (a hostname, count,
+ * or connection text), so they are presentation rather than identity. ARR's
+ * `source` is the stable check/entity key. Older or incomplete upstream
+ * responses may omit it; use their stable wiki URL when available and only
+ * then fall back to severity. Prefixing the key type prevents collisions
+ * between otherwise identical source and URL values.
+ */
+export function arrHealthSignalId(
+	instanceId: string,
+	issue: Pick<HealthIssue, "source" | "wikiUrl" | "type">,
+): string {
+	const source = issue.source?.trim();
+	const identity = source
+		? `source:${source}`
+		: issue.wikiUrl
+			? `wiki:${issue.wikiUrl}`
+			: `type:${issue.type}`;
+	return `arr-health-${instanceId}-${encodeURIComponent(identity)}`;
+}
 
 // ============================================================================
 // 1 & 2. ARR Health Issues + Disk Space (merged — shares client creation)
@@ -147,7 +171,7 @@ const collectArrSignals: Collector = async (app, userId, log) => {
 
 				for (const issue of healthIssues) {
 					items.push({
-						id: `arr-health-${instance.id}-${issue.message.slice(0, 30)}`,
+						id: arrHealthSignalId(instance.id, issue),
 						severity: issue.type === "error" ? "critical" : "warning",
 						category: "health",
 						title: `${instance.label}: ${issue.message}`,

--- a/apps/api/src/routes/__tests__/pulse-dismiss.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-dismiss.test.ts
@@ -131,6 +131,32 @@ describe("dismiss-until-recovery", () => {
 		expect(after.summary).toEqual({ critical: 0, warning: 1, info: 0 });
 	});
 
+	it("keeps a dismissal when an ARR health message changes but its stable ID remains", async () => {
+		const signalId = "arr-health-inst-1-source%3ADownloadClientCheck";
+		items = [
+			makeItem({
+				id: signalId,
+				title: "Sonarr: Download client has no connection",
+			}),
+		];
+		await injectAuthenticated("POST", `/pulse/${encodeURIComponent(signalId)}/dismiss`);
+
+		items = [
+			makeItem({
+				id: signalId,
+				title: "Sonarr: Download client timed out after 3 retries",
+			}),
+		];
+		// Bust the per-user cache; the new collector output retains the same
+		// entity-keyed ID, so the dismissal must stay active.
+		await injectAuthenticated("DELETE", "/pulse/unrelated/dismiss");
+
+		const afterMessageChange = await getPulse();
+		expect(afterMessageChange.items).toEqual([]);
+		expect(afterMessageChange.dismissedCount).toBe(1);
+		expect(tombstones).toEqual([{ userId: `user-dismiss-${userCounter}`, signalId }]);
+	});
+
 	it("never suppresses a signal currently firing as critical (breakthrough)", async () => {
 		items = [makeItem({ id: "sig-1", severity: "critical" })];
 

--- a/docs/3.0-release-readiness.md
+++ b/docs/3.0-release-readiness.md
@@ -67,9 +67,10 @@ named stage.
 - Review Tracearr's `experimental` route tier against ADR-0005 graduation
   criteria, as required by ADR-0007. Promote it or explicitly record why it
   remains experimental in the release notes.
-- Fix the Pulse dismissal identity that embeds
-  `issue.message.slice(0, 30)` in an `arr-health` signal id. It fails safe, but
-  dismiss-until-recovery is not durable when the message changes.
+- ARR health Pulse dismissal IDs are entity-keyed from the instance and upstream
+  health source (with wiki URL/severity fallbacks), so changing error text does
+  not discard an active dismissal. Existing message-derived tombstones are swept
+  once after upgrade because their prior external identity cannot be recovered.
 - Resolve the release promotion mechanics: merge `next` to `main`, tag the
   exact promoted commit, and confirm the stable workflow's main-ancestry guard.
   The current stable checklist documents tagging but not the `next` → `main`


### PR DESCRIPTION
## Summary

- derive ARR health Pulse identities from the instance and upstream health source, with stable wiki URL/severity fallbacks
- preserve dismiss-until-recovery when upstream health message text changes
- document the one-time sweep of legacy message-keyed tombstones after upgrade

## Root cause

The ARR health collector used the first 30 characters of the display message as a signal identity. Upstream error text can change while the underlying health check remains active, causing a dismissed signal to reappear.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- focused collector and authenticated dismissal-route regressions