### PR TITLE
docs(release): clarify database validation procedure

### DIFF
--- a/docs/3.0-release-readiness.md
+++ b/docs/3.0-release-readiness.md
@@ -18,6 +18,10 @@ superseded by accepted ADR amendments.
   remains open in the completeness tracker.
 - The blocker fixes landed through PRs #575–#577. Their required CI, CodeQL,
   Semgrep, end-to-end, and SQLite/PostgreSQL Docker smoke checks passed.
+- Upgrade evidence includes the data-bearing
+  [SQLite rehearsal](3.0-v2.21-sqlite-upgrade-rehearsal.md) and a
+  [PostgreSQL schema-compatibility rehearsal](3.0-v2.21-postgresql-upgrade-rehearsal.md).
+  A representative data-bearing PostgreSQL fixture remains an rc.1 gate.
 - The prerelease workflow publishes immutable exact-version and moving channel
   tags to both GHCR and Docker Hub. Branch builds retain the `next`, commit,
   and build tags; prerelease builds never publish `latest`.

--- a/docs/3.0-v2.21-postgresql-upgrade-rehearsal.md
+++ b/docs/3.0-v2.21-postgresql-upgrade-rehearsal.md
@@ -1,0 +1,38 @@
+# 3.0 v2.21 PostgreSQL Upgrade Rehearsal
+
+**Date:** 2026-07-17  
+**Result:** Pass  
+**Source:** `khak1s/arr-dashboard:2.21.0` (`188c822`)  
+**Candidate:** `ghcr.io/kha-kis/arr-dashboard:3.0.0-beta.1` (`cc274fbc`)
+
+This rehearsal verifies that the 3.0 combined container can upgrade a
+PostgreSQL database created by the v2.21.0 combined container. It complements
+the richer [SQLite upgrade rehearsal](3.0-v2.21-sqlite-upgrade-rehearsal.md),
+which covers the Tautulli removal flow and preserved user/rule data.
+
+## Procedure
+
+An isolated Docker network contained a disposable `postgres:16-alpine`
+database. The v2.21.0 combined image started first with that database as its
+`DATABASE_URL`, synchronized its schema, and returned:
+
+```json
+{"status":"ok","version":"2.21.0","commit":"188c82260762d19f1456761936b145a914f8294a"}
+```
+
+The legacy container was stopped without altering the database. The beta
+candidate then started against the same URL. Its launcher detected PostgreSQL,
+selected the PostgreSQL Prisma provider, synchronized the existing schema
+without `--accept-data-loss`, and logged `Database schema synchronized
+successfully`. Its health response was:
+
+```json
+{"status":"ok","version":"3.0.0-beta.1","commit":"cc274fbc94bed9a27e3ff3df1ddacc36da00e7e0"}
+```
+
+## Scope
+
+This is a schema-compatibility upgrade smoke, not a substitute for a
+data-bearing PostgreSQL fixture. Before rc.1, repeat the scenario with a
+preserved v2.21 PostgreSQL fixture containing representative user and rule data
+and record the resulting migration-state checks.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -71,10 +71,20 @@ Before bumping any version numbers, decide *what* this release contains.
 
 ### 3. Database
 
-- [ ] **Fresh SQLite install:** Delete `dev.db`, run `pnpm run db:push`, verify API starts
-- [ ] **Fresh PostgreSQL install:** Point `DATABASE_URL` at empty database, run `pnpm run db:push`, verify API starts
-- [ ] **SQLite upgrade:** Start with previous release database, run new version, verify schema migrates
-- [ ] **PostgreSQL upgrade:** Same as above with PostgreSQL
+- [ ] Run every database scenario through the candidate **combined container**.
+      Its launcher selects the Prisma provider from `DATABASE_URL`, regenerates
+      the client when needed, and synchronizes the schema. The local
+      `pnpm run db:push` command is SQLite-only and is not a PostgreSQL
+      release-validation procedure.
+- [ ] **Fresh SQLite install:** Start the candidate container with an empty
+      `/config` volume and verify the API starts.
+- [ ] **Fresh PostgreSQL install:** Start the candidate container with
+      `DATABASE_URL` pointed at an empty PostgreSQL database and verify the API
+      starts.
+- [ ] **SQLite upgrade:** Start the candidate container with a previous-release
+      SQLite `/config` database and verify the schema synchronizes.
+- [ ] **PostgreSQL upgrade:** Start the candidate container with a
+      previous-release PostgreSQL database and verify the schema synchronizes.
 - [ ] Run both upgrade scenarios **without** Prisma's `--accept-data-loss`; a
       destructive transition requires a release-specific backup/migration plan
       and must not be delegated to container startup


### PR DESCRIPTION
## Summary

- make the release checklist run all database scenarios through the candidate combined container
- document why local db:push is not a PostgreSQL release-validation procedure
- record a successful v2.21.0 to beta.1 PostgreSQL schema-compatibility rehearsal

## Why

The combined launcher selects the provider from DATABASE_URL, regenerates the Prisma client when required, and synchronizes the schema. The local schema is SQLite by default, so pointing local db:push at PostgreSQL fails before the production provider-selection path runs.

The rehearsal complements the existing data-bearing SQLite upgrade evidence. It deliberately does not claim to replace a data-bearing PostgreSQL fixture, which remains an rc.1 gate.

## Validation

- pnpm run format
- git diff --check
- live isolated PostgreSQL upgrade: v2.21.0 combined container, then beta.1 combined container against the same database
- verified both SQLite and PostgreSQL combined-container smoke checks passed in PR #588