### PR TITLE
feat(web): establish unified UX shell foundations

### DIFF
--- a/apps/web/app/library-cleanup/page.tsx
+++ b/apps/web/app/library-cleanup/page.tsx
@@ -1,5 +1,10 @@
+import { PageLayout } from "@arr/web/components/layout";
 import { LibraryCleanupClient } from "../../src/features/library-cleanup/components/library-cleanup-client";
 
 export default function LibraryCleanupPage() {
-	return <LibraryCleanupClient />;
+	return (
+		<PageLayout maxWidth="7xl">
+			<LibraryCleanupClient />
+		</PageLayout>
+	);
 }

--- a/apps/web/app/qui/page.tsx
+++ b/apps/web/app/qui/page.tsx
@@ -1,3 +1,4 @@
+import { PageLayout } from "../../src/components/layout";
 import { QuiHomeClient } from "../../src/features/qui-home/components/qui-home-client";
 
 export const metadata = {
@@ -5,5 +6,9 @@ export const metadata = {
 };
 
 export default function QuiHomePage() {
-	return <QuiHomeClient />;
+	return (
+		<PageLayout maxWidth="7xl">
+			<QuiHomeClient />
+		</PageLayout>
+	);
 }

--- a/apps/web/src/components/layout/__tests__/navigation.test.ts
+++ b/apps/web/src/components/layout/__tests__/navigation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { NAVIGATION_GROUPS, NAVIGATION_ITEMS } from "../navigation";
+
+const AUTHENTICATED_ROUTES = [
+	"/auto-tag",
+	"/calendar",
+	"/console",
+	"/cross-seed",
+	"/dashboard",
+	"/discover",
+	"/history",
+	"/hunting",
+	"/indexers",
+	"/label-sync",
+	"/library-cleanup",
+	"/library",
+	"/pulse",
+	"/queue-cleaner",
+	"/qui-activity",
+	"/qui",
+	"/requests",
+	"/search",
+	"/settings",
+	"/statistics",
+	"/trash-guides",
+];
+
+describe("authenticated navigation inventory", () => {
+	it("gives every authenticated route exactly one navigation home", () => {
+		const hrefs = NAVIGATION_ITEMS.map((item) => item.href).sort();
+
+		expect(hrefs).toEqual([...AUTHENTICATED_ROUTES].sort());
+		expect(new Set(hrefs)).toHaveLength(hrefs.length);
+	});
+
+	it("keeps media planning with the rest of the media workflow", () => {
+		const media = NAVIGATION_GROUPS.find((group) => group.id === "media");
+
+		expect(media?.items.map((item) => item.href)).toContain("/calendar");
+		expect(media?.items.map((item) => item.href)).toContain("/history");
+	});
+
+	it("gives every destination a concise orientation cue for the shared shell", () => {
+		expect(NAVIGATION_ITEMS.every((item) => item.description.trim().length > 0)).toBe(true);
+	});
+});

--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -4,25 +4,15 @@ import { useQueryClient } from "@tanstack/react-query";
 import { THEME_GRADIENT_VALUES } from "../../lib/theme-gradients";
 import { Command } from "cmdk";
 import {
-	BarChart3,
-	Calendar,
-	Compass,
 	FileText,
-	Globe,
-	History,
-	LayoutDashboard,
-	Library,
 	LogOut,
 	Monitor,
 	Moon,
 	Palette,
 	RefreshCw,
 	Search,
-	Settings,
 	Smartphone,
-	Sparkles,
 	Sun,
-	Target,
 	User,
 	Zap,
 } from "lucide-react";
@@ -35,63 +25,7 @@ import { useThemeGradient } from "../../hooks/useThemeGradient";
 import { logout } from "../../lib/api-client/auth";
 import { cn } from "../../lib/utils";
 import { type ColorTheme, useColorTheme } from "../../providers/color-theme-provider";
-
-/**
- * Navigation items matching sidebar
- */
-const NAV_ITEMS = [
-	{
-		href: "/dashboard",
-		label: "Dashboard",
-		icon: LayoutDashboard,
-		keywords: ["home", "overview", "queue"],
-	},
-	{
-		href: "/discover",
-		label: "Discover",
-		icon: Compass,
-		keywords: ["tmdb", "trending", "popular", "movies", "shows"],
-	},
-	{
-		href: "/library",
-		label: "Library",
-		icon: Library,
-		keywords: ["movies", "series", "collection"],
-	},
-	{ href: "/search", label: "Search", icon: Search, keywords: ["find", "prowlarr", "indexers"] },
-	{
-		href: "/indexers",
-		label: "Indexers",
-		icon: Globe,
-		keywords: ["prowlarr", "torrent", "usenet"],
-	},
-	{
-		href: "/calendar",
-		label: "Calendar",
-		icon: Calendar,
-		keywords: ["upcoming", "releases", "schedule"],
-	},
-	{
-		href: "/statistics",
-		label: "Statistics",
-		icon: BarChart3,
-		keywords: ["stats", "analytics", "graphs"],
-	},
-	{ href: "/hunting", label: "Hunting", icon: Target, keywords: ["missing", "upgrade", "auto"] },
-	{ href: "/history", label: "History", icon: History, keywords: ["downloads", "log", "activity"] },
-	{
-		href: "/trash-guides",
-		label: "TRaSH Guides",
-		icon: Sparkles,
-		keywords: ["quality", "profiles", "custom formats"],
-	},
-	{
-		href: "/settings",
-		label: "Settings",
-		icon: Settings,
-		keywords: ["config", "preferences", "account"],
-	},
-];
+import { NAVIGATION_ITEMS } from "./navigation";
 
 /**
  * Theme color options with actual hex values for previews
@@ -239,7 +173,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 						}
 						className="mb-2"
 					>
-						{NAV_ITEMS.map((item) => {
+						{NAVIGATION_ITEMS.map((item) => {
 							const Icon = item.icon;
 							return (
 								<Command.Item

--- a/apps/web/src/components/layout/layout-wrapper.tsx
+++ b/apps/web/src/components/layout/layout-wrapper.tsx
@@ -37,7 +37,7 @@ export const LayoutWrapper = ({ children }: LayoutWrapperProps) => {
 	}
 
 	return (
-		<div className="flex min-h-screen bg-background relative">
+		<div className="relative flex min-h-screen bg-background">
 			{/* 3.0 one-shot migration gate — blocks until lingering Tautulli
 			    instances are acknowledged and removed (ADR-0007) */}
 			<TautulliMigrationDialog />
@@ -64,9 +64,9 @@ export const LayoutWrapper = ({ children }: LayoutWrapperProps) => {
 			)}
 
 			<Sidebar />
-			<div className="flex flex-1 flex-col relative z-10 min-w-0">
-				<TopBar />
-				<div className="flex-1 p-6 min-w-0">{children}</div>
+			<div className="relative z-10 flex min-w-0 flex-1 flex-col">
+				<TopBar onOpenCommandPalette={() => setCommandPaletteOpen(true)} />
+				<div className="min-w-0 flex-1 px-4 py-5 sm:px-6 lg:px-8 lg:py-7">{children}</div>
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/layout/navigation.ts
+++ b/apps/web/src/components/layout/navigation.ts
@@ -1,0 +1,222 @@
+import type { LucideIcon } from "lucide-react";
+import {
+	Activity,
+	BarChart3,
+	Calendar,
+	Compass,
+	Eraser,
+	Gauge,
+	Globe,
+	History,
+	Inbox,
+	LayoutDashboard,
+	Library,
+	Network,
+	Search,
+	Settings,
+	Sparkles,
+	Tag,
+	Target,
+	Trash2,
+} from "lucide-react";
+
+export interface NavigationItem {
+	href: string;
+	label: string;
+	description: string;
+	icon: LucideIcon;
+	keywords: string[];
+}
+
+export interface NavigationGroup {
+	id: string;
+	label: string;
+	items: NavigationItem[];
+}
+
+/**
+ * The authenticated product map. Both the sidebar and command palette read
+ * this inventory so a real destination cannot disappear from one navigation
+ * surface while remaining in the other.
+ */
+export const NAVIGATION_GROUPS: NavigationGroup[] = [
+	{
+		id: "monitor",
+		label: "Monitor",
+		items: [
+			{
+				href: "/dashboard",
+				label: "Dashboard",
+				description: "Your media system at a glance",
+				icon: LayoutDashboard,
+				keywords: ["home", "overview"],
+			},
+			{
+				href: "/console",
+				label: "Console",
+				description: "Attention and safe next actions",
+				icon: Gauge,
+				keywords: ["operator", "attention", "actions"],
+			},
+			{
+				href: "/pulse",
+				label: "Pulse",
+				description: "System health and active signals",
+				icon: Activity,
+				keywords: ["health", "signals", "alerts"],
+			},
+			{
+				href: "/statistics",
+				label: "Statistics",
+				description: "Explore media and service trends",
+				icon: BarChart3,
+				keywords: ["analytics", "metrics", "reports"],
+			},
+		],
+	},
+	{
+		id: "media",
+		label: "Media",
+		items: [
+			{
+				href: "/discover",
+				label: "Discover",
+				description: "Find something worth watching",
+				icon: Compass,
+				keywords: ["tmdb", "trending", "popular"],
+			},
+			{
+				href: "/requests",
+				label: "Requests",
+				description: "Review and manage media requests",
+				icon: Inbox,
+				keywords: ["seerr", "approvals"],
+			},
+			{
+				href: "/calendar",
+				label: "Calendar",
+				description: "Plan upcoming releases",
+				icon: Calendar,
+				keywords: ["upcoming", "releases", "schedule"],
+			},
+			{
+				href: "/library",
+				label: "Library",
+				description: "Browse and manage your collection",
+				icon: Library,
+				keywords: ["movies", "series", "collection"],
+			},
+			{
+				href: "/search",
+				label: "Search",
+				description: "Search across your indexers",
+				icon: Search,
+				keywords: ["find", "prowlarr", "indexers"],
+			},
+			{
+				href: "/history",
+				label: "History",
+				description: "Review recent media activity",
+				icon: History,
+				keywords: ["downloads", "activity"],
+			},
+		],
+	},
+	{
+		id: "automations",
+		label: "Automations",
+		items: [
+			{
+				href: "/hunting",
+				label: "Hunting",
+				description: "Find missing and upgraded media",
+				icon: Target,
+				keywords: ["missing", "upgrades", "search"],
+			},
+			{
+				href: "/queue-cleaner",
+				label: "Queue Cleaner",
+				description: "Keep download queues healthy",
+				icon: Trash2,
+				keywords: ["downloads", "failed", "stalled"],
+			},
+			{
+				href: "/library-cleanup",
+				label: "Library Cleanup",
+				description: "Review and automate safe cleanup",
+				icon: Eraser,
+				keywords: ["rules", "removal"],
+			},
+			{
+				href: "/auto-tag",
+				label: "Auto-Tagger",
+				description: "Apply consistent tags with rules",
+				icon: Tag,
+				keywords: ["rules", "tags"],
+			},
+			{
+				href: "/label-sync",
+				label: "Label Sync",
+				description: "Keep labels aligned across services",
+				icon: Tag,
+				keywords: ["tags", "sync"],
+			},
+			{
+				href: "/cross-seed",
+				label: "Cross-Seed",
+				description: "Find compatible torrent matches",
+				icon: Network,
+				keywords: ["torrent", "tracker"],
+			},
+		],
+	},
+	{
+		id: "integrations",
+		label: "Integrations",
+		items: [
+			{
+				href: "/qui",
+				label: "qui",
+				description: "Torrent-layer overview and attention",
+				icon: Network,
+				keywords: ["torrent", "qbit", "activity"],
+			},
+			{
+				href: "/qui-activity",
+				label: "qui Activity",
+				description: "Torrent events, actions, and webhooks",
+				icon: History,
+				keywords: ["webhook", "events", "audit"],
+			},
+			{
+				href: "/indexers",
+				label: "Indexers",
+				description: "Search-source health and configuration",
+				icon: Globe,
+				keywords: ["prowlarr", "torrent", "usenet"],
+			},
+			{
+				href: "/trash-guides",
+				label: "TRaSH Guides",
+				description: "Apply quality-profile guidance",
+				icon: Sparkles,
+				keywords: ["quality", "profiles", "custom formats"],
+			},
+		],
+	},
+	{
+		id: "settings",
+		label: "Settings",
+		items: [
+			{
+				href: "/settings",
+				label: "Settings",
+				description: "Services, security, and preferences",
+				icon: Settings,
+				keywords: ["services", "security", "preferences"],
+			},
+		],
+	},
+];
+
+export const NAVIGATION_ITEMS = NAVIGATION_GROUPS.flatMap((group) => group.items);

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -25,12 +25,23 @@ interface PageHeaderProps {
  */
 export const PageHeader = ({ title, description, actions, className }: PageHeaderProps) => {
 	return (
-		<header className={cn("flex items-start justify-between gap-4", className)}>
-			<div className="space-y-2">
-				<h1 className="text-3xl font-bold text-foreground">{title}</h1>
-				{description && <p className="text-base text-muted-foreground">{description}</p>}
+		<header
+			className={cn(
+				"flex flex-col gap-4 border-b border-border/60 pb-5 sm:flex-row sm:items-start sm:justify-between",
+				className,
+			)}
+		>
+			<div className="min-w-0 space-y-1">
+				<h1 className="font-display text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+					{title}
+				</h1>
+				{description && (
+					<p className="max-w-2xl text-sm leading-6 text-muted-foreground sm:text-base">
+						{description}
+					</p>
+				)}
 			</div>
-			{actions && <div className="flex items-center gap-2">{actions}</div>}
+			{actions && <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div>}
 		</header>
 	);
 };

--- a/apps/web/src/components/layout/page-layout.tsx
+++ b/apps/web/src/components/layout/page-layout.tsx
@@ -6,7 +6,7 @@ interface PageLayoutProps {
 	/** Maximum width constraint for the content */
 	maxWidth?: "4xl" | "6xl" | "7xl";
 	/** Vertical spacing between child elements (default: 8 = 32px) */
-	gap?: "6" | "8" | "10" | "12";
+	gap?: "5" | "6" | "8" | "10" | "12";
 	/** Additional CSS classes */
 	className?: string;
 }
@@ -18,6 +18,7 @@ const MAX_WIDTH_CLASSES = {
 } as const;
 
 const GAP_CLASSES = {
+	"5": "gap-5",
 	"6": "gap-6",
 	"8": "gap-8",
 	"10": "gap-10",
@@ -50,7 +51,7 @@ const GAP_CLASSES = {
 export const PageLayout = ({
 	children,
 	maxWidth = "6xl",
-	gap = "8",
+	gap = "6",
 	className,
 }: PageLayoutProps) => {
 	return (
@@ -60,7 +61,7 @@ export const PageLayout = ({
 				// mx-auto cancels align-items:stretch and main collapses to its intrinsic
 				// content width, so brief loading skeletons or content-width changes cause
 				// visible layout shifts (e.g. calendar narrowing on month nav — issue #272).
-				"mx-auto w-full flex flex-col px-3 py-8 sm:px-4 sm:py-12 md:px-6 md:py-16",
+				"mx-auto flex w-full flex-col px-0 py-1 sm:py-2",
 				MAX_WIDTH_CLASSES[maxWidth],
 				GAP_CLASSES[gap],
 				className,

--- a/apps/web/src/components/layout/sidebar.tsx
+++ b/apps/web/src/components/layout/sidebar.tsx
@@ -1,30 +1,7 @@
 "use client";
 
 import { AnimatePresence, LayoutGroup, motion } from "framer-motion";
-import {
-	Activity,
-	BarChart3,
-	Calendar,
-	ChevronDown,
-	ChevronRight,
-	Compass,
-	Eraser,
-	Gauge,
-	Globe,
-	History,
-	Inbox,
-	LayoutDashboard,
-	Library,
-	Menu,
-	Network,
-	Search,
-	Settings,
-	Sparkles,
-	Tag,
-	Target,
-	Trash2,
-	X,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, LayoutDashboard, Menu, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -32,78 +9,7 @@ import { useThemeGradient } from "../../hooks/useThemeGradient";
 import { cn } from "../../lib/utils";
 import { useColorTheme } from "../../providers/color-theme-provider";
 import { springs } from "../motion";
-
-interface NavItem {
-	href: string;
-	label: string;
-	icon: React.ComponentType<{ className?: string; style?: React.CSSProperties }>;
-}
-
-interface NavGroup {
-	id: string;
-	label: string;
-	items: NavItem[];
-}
-
-const NAV_GROUPS: NavGroup[] = [
-	{
-		id: "overview",
-		label: "Overview",
-		items: [
-			// Dashboard first — it is the product's primary landing surface
-			// (/ redirects here post-auth) and hosts the Needs Attention panel.
-			// Pulse remains the deep-inspection view below it.
-			{ href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
-			// Console is the operator's working surface (3.0 flagship,
-			// charter §2.1): domain health + attention feed + one-click
-			// actions, later the rule composer. Sits between the landing
-			// surface (Dashboard) and the deep-inspection view (Pulse).
-			{ href: "/console", label: "Console", icon: Gauge },
-			{ href: "/pulse", label: "Pulse", icon: Activity },
-			// `/qui` is the at-a-glance entry for the torrent layer — Sonarr/Radarr
-			// equivalent for qui. Belongs in Overview, not Maintenance, because
-			// it answers "what's going on right now" rather than "what do I
-			// need to maintain". The deeper qui-Activity tab and the
-			// Cross-Seed page stay under Maintenance as drill-downs.
-			{ href: "/qui", label: "qui", icon: Network },
-			{ href: "/calendar", label: "Calendar", icon: Calendar },
-			{ href: "/statistics", label: "Statistics", icon: BarChart3 },
-		],
-	},
-	{
-		id: "media",
-		label: "Media",
-		items: [
-			{ href: "/discover", label: "Discover", icon: Compass },
-			{ href: "/library", label: "Library", icon: Library },
-			{ href: "/search", label: "Search", icon: Search },
-			{ href: "/requests", label: "Requests", icon: Inbox },
-		],
-	},
-	{
-		id: "maintenance",
-		label: "Maintenance",
-		items: [
-			{ href: "/hunting", label: "Hunting", icon: Target },
-			{ href: "/queue-cleaner", label: "Queue Cleaner", icon: Trash2 },
-			{ href: "/library-cleanup", label: "Cleanup", icon: Eraser },
-			{ href: "/cross-seed", label: "Cross-Seed", icon: Network },
-			{ href: "/qui-activity", label: "qui Activity", icon: History },
-			{ href: "/auto-tag", label: "Auto-Tagger", icon: Tag },
-			{ href: "/label-sync", label: "Label Sync", icon: Tag },
-			{ href: "/history", label: "History", icon: History },
-		],
-	},
-	{
-		id: "configuration",
-		label: "Configuration",
-		items: [
-			{ href: "/indexers", label: "Indexers", icon: Globe },
-			{ href: "/trash-guides", label: "TRaSH Guides", icon: Sparkles },
-			{ href: "/settings", label: "Settings", icon: Settings },
-		],
-	},
-];
+import { NAVIGATION_GROUPS } from "./navigation";
 
 const STORAGE_KEY = "sidebar-collapsed-groups";
 
@@ -132,7 +38,7 @@ function saveCollapsedGroups(collapsed: Set<string>) {
 
 /** Find which group contains a given pathname */
 function findGroupForPath(pathname: string): string | undefined {
-	for (const group of NAV_GROUPS) {
+	for (const group of NAVIGATION_GROUPS) {
 		if (group.items.some((item) => item.href === pathname)) {
 			return group.id;
 		}
@@ -159,7 +65,7 @@ const NavContent = ({
 }: NavContentProps) => (
 	<>
 		{/* Logo/Brand */}
-		<div className="mb-6 relative z-10">
+		<div className="relative z-10 mb-5 border-b border-border/50 pb-5">
 			<div className="flex items-center gap-3">
 				<div
 					className={cn(
@@ -184,8 +90,8 @@ const NavContent = ({
 				<div>
 					<h1
 						className={cn(
-							"font-bold tracking-tight",
-							useFlatStyling ? "text-sm text-foreground" : "text-lg",
+							"font-display font-semibold tracking-tight",
+							useFlatStyling ? "text-sm text-foreground" : "text-base",
 						)}
 						style={
 							useFlatStyling
@@ -200,8 +106,8 @@ const NavContent = ({
 					>
 						Arr Control
 					</h1>
-					<p className="text-[10px] uppercase tracking-widest text-muted-foreground">
-						Media Server
+					<p className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
+						Media operations
 					</p>
 				</div>
 			</div>
@@ -211,9 +117,9 @@ const NavContent = ({
 		<LayoutGroup>
 			<nav
 				aria-label="Main navigation"
-				className="flex flex-col gap-3 relative z-10 overflow-y-auto flex-1 -mx-2 px-2"
+				className="relative z-10 -mx-2 flex flex-1 flex-col gap-4 overflow-y-auto px-2"
 			>
-				{NAV_GROUPS.map((group) => {
+				{NAVIGATION_GROUPS.map((group) => {
 					const isCollapsed = collapsedGroups.has(group.id);
 					const hasActiveItem = group.items.some((item) => item.href === pathname);
 
@@ -226,7 +132,7 @@ const NavContent = ({
 								aria-expanded={!isCollapsed}
 								aria-controls={`nav-group-${group.id}`}
 								className={cn(
-									"flex w-full items-center gap-2 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider transition-colors duration-200",
+									"flex w-full items-center gap-2 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.14em] transition-colors duration-200",
 									"text-muted-foreground/70 hover:text-muted-foreground",
 									useFlatStyling && "rounded-none",
 								)}
@@ -274,7 +180,7 @@ const NavContent = ({
 														onClick={() => setMobileMenuOpen(false)}
 														aria-current={isActive ? "page" : undefined}
 														className={cn(
-															"group relative flex items-center gap-3 rounded-xl px-3 py-2 min-h-[40px] text-sm font-medium transition-colors duration-200",
+															"group relative flex min-h-10 items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors duration-200",
 															isActive && !useFlatStyling && "text-white",
 															useFlatStyling && "rounded-none",
 															!isActive && "text-muted-foreground hover:text-foreground",
@@ -512,7 +418,7 @@ export const Sidebar = () => {
 			{/* Desktop sidebar */}
 			<aside
 				data-sidebar
-				className="hidden w-64 shrink-0 flex-col border-r border-border/30 bg-background/50 backdrop-blur-xl p-6 lg:flex relative overflow-hidden"
+				className="relative hidden w-64 shrink-0 flex-col overflow-hidden border-r border-border/60 bg-background/65 p-5 backdrop-blur-xl lg:flex"
 			>
 				{/* Decorative gradient orb */}
 				<div

--- a/apps/web/src/components/layout/topbar.tsx
+++ b/apps/web/src/components/layout/topbar.tsx
@@ -1,88 +1,112 @@
 "use client";
 
-import { Eye, EyeOff } from "lucide-react";
+import { Command, Eye, EyeOff, Search } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useCurrentUser, useLogoutMutation } from "../../hooks/api/useAuth";
 import { getLinuxUsername, useIncognitoMode } from "../../lib/incognito";
 import { Button } from "../ui/button";
+import { NAVIGATION_ITEMS } from "./navigation";
 
-export const TopBar = () => {
+interface TopBarProps {
+	readonly onOpenCommandPalette: () => void;
+}
+
+export const TopBar = ({ onOpenCommandPalette }: TopBarProps) => {
 	const { data: user } = useCurrentUser();
 	const pathname = usePathname();
 	const router = useRouter();
 	const logoutMutation = useLogoutMutation();
 	const [incognitoMode, setIncognitoMode] = useIncognitoMode();
+	const context = NAVIGATION_ITEMS.find((item) => item.href === pathname) ?? {
+		label: "Arr Control",
+		description: "Media operations",
+	};
 
-	if (pathname === "/login") {
-		return null;
-	}
-
-	const showLoginCta = !user;
+	if (pathname === "/login") return null;
 
 	const handleLogout = async () => {
 		try {
 			await logoutMutation.mutateAsync();
+		} finally {
 			router.replace("/login");
-		} catch (error) {
-			console.error("Logout failed", error);
 		}
 	};
 
 	return (
-		<header className="flex items-center justify-between border-b border-border/30 bg-background/80 backdrop-blur-xl px-6 py-4 shadow-sm">
-			<div>
-				<h2 className="text-lg font-semibold text-foreground">Arr Control Center</h2>
-				<p className="text-sm text-muted-foreground">
-					Manage Sonarr, Radarr, and Prowlarr from one place.
+		<header className="sticky top-0 z-sticky flex min-h-16 items-center justify-between gap-4 border-b border-border/60 bg-background/85 px-4 py-3 backdrop-blur-xl sm:px-6 lg:px-8">
+			<div className="min-w-0 pl-12 lg:pl-0">
+				<p className="hidden text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground sm:block">
+					Arr Control
+				</p>
+				<h2 className="truncate font-display text-lg font-semibold tracking-tight text-foreground">
+					{context.label}
+				</h2>
+				<p className="hidden truncate text-sm text-muted-foreground md:block">
+					{context.description}
 				</p>
 			</div>
-			<div className="flex items-center gap-3">
-				{showLoginCta ? (
+			<div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					onClick={onOpenCommandPalette}
+					className="hidden min-w-44 justify-between text-muted-foreground md:inline-flex"
+				>
+					<span className="flex items-center gap-2">
+						<Search className="h-4 w-4" />
+						Search or jump to…
+					</span>
+					<kbd className="rounded border border-border/70 bg-muted px-1.5 py-0.5 text-[10px]">
+						⌘K
+					</kbd>
+				</Button>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon-sm"
+					onClick={onOpenCommandPalette}
+					className="md:hidden"
+					aria-label="Search or jump to a page"
+				>
+					<Command className="h-4 w-4" />
+				</Button>
+				{!user ? (
 					<Button asChild variant="secondary">
 						<Link href="/login">Sign in</Link>
 					</Button>
-				) : user ? (
+				) : (
 					<>
 						<Button
 							variant="ghost"
-							size="sm"
+							size="icon-sm"
 							onClick={() => setIncognitoMode(!incognitoMode)}
 							title={incognitoMode ? "Show real data" : "Hide sensitive data"}
-							className="relative h-9 w-9 p-0"
+							aria-label={incognitoMode ? "Show real data" : "Hide sensitive data"}
 						>
 							{incognitoMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
 						</Button>
-						<div className="group relative flex items-center gap-3 px-3 py-2 rounded-lg bg-card/40 backdrop-blur-xs border border-border/50 hover:border-primary/30 transition-all duration-200 cursor-pointer">
-							<div className="absolute inset-0 rounded-lg bg-linear-to-r from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity" />
-
-							<div className="relative h-9 w-9 rounded-full bg-linear-to-br from-primary to-accent text-white flex items-center justify-center shadow-md ring-1 ring-white/10">
-								<span className="text-sm font-semibold">
-									{(incognitoMode
-										? getLinuxUsername(user.username)
-										: user.username)[0]?.toUpperCase() ?? "U"}
-								</span>
+						<div className="hidden items-center gap-2 rounded-lg border border-border/60 bg-card/60 px-2.5 py-1.5 sm:flex">
+							<div className="flex h-7 w-7 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-foreground">
+								{(incognitoMode
+									? getLinuxUsername(user.username)
+									: user.username)[0]?.toUpperCase() ?? "U"}
 							</div>
-							<div className="text-right relative">
-								<p className="text-sm font-medium text-foreground">
-									{incognitoMode ? getLinuxUsername(user.username) : user.username}
-								</p>
-							</div>
+							<span className="max-w-28 truncate text-sm font-medium">
+								{incognitoMode ? getLinuxUsername(user.username) : user.username}
+							</span>
 						</div>
 						<Button
 							variant="ghost"
+							size="sm"
 							onClick={() => void handleLogout()}
 							disabled={logoutMutation.isPending}
 							aria-busy={logoutMutation.isPending}
 						>
-							{logoutMutation.isPending ? "Signing out..." : "Sign out"}
+							{logoutMutation.isPending ? "Signing out…" : "Sign out"}
 						</Button>
 					</>
-				) : (
-					<div className="text-right">
-						<p className="text-sm font-medium text-foreground">Guest</p>
-						<p className="text-xs text-muted-foreground">Not signed in</p>
-					</div>
 				)}
 			</div>
 		</header>

--- a/biome.json
+++ b/biome.json
@@ -56,6 +56,6 @@
 	],
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"files": {
-		"includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/generated/**"]
+		"includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/generated/**", "!**/.next/**"]
 	}
 }

--- a/docs/3.0-ui-ux-audit.md
+++ b/docs/3.0-ui-ux-audit.md
@@ -1,0 +1,77 @@
+# 3.0 UI/UX Audit
+
+This is the working product audit for the 3.0 modernization. It maps the
+existing router to operator jobs rather than treating the current sidebar as
+the information-architecture source of truth.
+
+## Route inventory by user job
+
+| Job | Current routes | Audit finding |
+|---|---|---|
+| Monitor the system | Dashboard, Console, Pulse, Statistics | Three attention/status surfaces have legitimate different depths, but their relationship is not explained by navigation. The redesign must make Dashboard the starting summary, Console the action workspace, and Pulse the signal drill-down. |
+| Manage media | Discover, Requests, Calendar, Library, Search, History | These belong together. Calendar is a media-planning surface; History is media/download context, not a maintenance tool. |
+| Configure automations | Hunting, Queue Cleaner, Library Cleanup, Auto-Tagger, Label Sync, Cross-Seed | These share a lifecycle—define, preview/enable, run, review history—but present it differently. They need a common automation workspace pattern. |
+| Operate integrations | qui, qui Activity, Indexers, TRaSH Guides | `qui` is split between a torrent overview and a four-tab audit/webhook surface. It should become one workspace. Indexers and TRaSH are configuration-heavy integrations, so their placement needs to follow the task, not implementation history. |
+| Configure the application | Settings | Settings currently carries services, identity/security, appearance, backup, and system preferences. It needs clear internal grouping and direct deep links from empty/error states. |
+| Enter the product | Login, Setup | These are outside the authenticated shell but must use the same language, visual hierarchy, and confidence-building state design. |
+
+## Cross-product findings
+
+1. **Navigation is not the same as the command palette.** The palette omits
+   several authenticated destinations, including Console, Pulse, Requests,
+   automation surfaces, and qui. A route registry must drive both.
+2. **Page anatomy is inconsistent.** The application has multiple header,
+   container, card, table, tab, and state primitives. UX-1 must establish one
+   canonical composition before feature-by-feature redesign.
+3. **Feature boundaries leak into navigation.** The qui and qui Activity split
+   is the clearest case, but the same risk exists wherever an overview, history,
+   and configuration surface have accumulated as independent routes.
+4. **Empty states are a navigation system.** Many unconfigured-service states
+   deep-link to Settings. The resulting Settings destinations must be precise,
+   readable, and preserve a route's context on return.
+5. **The user mental model is media-first.** Calendar and History are media
+   work, while health and automation need their own operational vocabulary.
+
+## Page-anatomy inventory
+
+The page audit separates composition defects from feature-specific redesign
+work. A route may own a specialised header or tabs, but it must still enter the
+authenticated shell through the same semantic content boundary.
+
+| Finding | Routes | Decision |
+|---|---|---|
+| Already use the shared page boundary | Dashboard, Console, Pulse, Discover, Requests, Calendar, Library, Search, History, Hunting, Queue Cleaner, Cross-Seed, qui Activity, Indexers, TRaSH Guides, Statistics, Settings | Keep the boundary and converge internal headers, actions, states, and density in their assigned slice. |
+| Own an internal page boundary | Auto-Tagger, Label Sync | Keep their current boundary temporarily; moving it without redesigning their internal loading and error states would create nested semantic landmarks. |
+| Had no shared page boundary | Library Cleanup, qui overview | Corrected in UX-1. Both now use `PageLayout` at the route boundary. |
+| Need route consolidation, not a sidebar relabel | qui and qui Activity | Keep both destinations reachable while UX-2 combines overview, activity, events, actions, and webhook configuration into one qui workspace. Removing the activity link before that content moves would hide a working surface. |
+
+The shared route inventory also owns each route's compact orientation cue. This
+keeps the sidebar, command palette, and top bar in agreement while the
+feature-level headers are progressively consolidated.
+
+## IA hypotheses to validate in the browser
+
+These are hypotheses, not final labels:
+
+| Proposed area | Candidate contents | Validation question |
+|---|---|---|
+| Monitor | Dashboard, Console, Pulse, Statistics | Can an operator move from summary to an actionable signal without guessing which surface owns it? |
+| Media | Discover, Requests, Calendar, Library, Search, History | Does the collection/request/release journey feel like one connected workflow? |
+| Automations | Hunting, Queue Cleaner, Library Cleanup, Auto-Tagger, Label Sync, Cross-Seed | Can an operator distinguish recurring automation from one-off media work, and find its run history? |
+| Integrations | qui workspace, Indexers, TRaSH Guides | Does each integration have one obvious home with overview, activity, and configuration grouped appropriately? |
+| Settings | account/security, services, appearance, backups, system | Do deep links from operational states land at the exact corrective control? |
+
+## Validation method
+
+For every proposed grouping, test both configured and unconfigured states and
+walk these journeys in a browser:
+
+1. identify a problem from Dashboard;
+2. act on it in Console or Pulse;
+3. navigate a request or upcoming release to its media context;
+4. create, preview, enable, and inspect an automation;
+5. configure an integration from an empty state and return to the blocked task;
+6. complete first-run setup and reach a useful first dashboard.
+
+No final navigation or route consolidation is accepted until these journeys are
+implemented and browser-verified at desktop, tablet, and mobile widths.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -58,7 +58,11 @@ async function ensureTestUserExists(): Promise<void> {
 		} else {
 			const errorBody = await registerResponse.text();
 			// If user already exists or registration disabled, that's fine
-			if (errorBody.includes("already") || errorBody.includes("disabled") || registerResponse.status() === 403) {
+			if (
+				errorBody.includes("already") ||
+				errorBody.includes("disabled") ||
+				registerResponse.status() === 403
+			) {
 				console.log("CI: User already exists or registration disabled, will use existing user");
 			} else {
 				console.log(`CI: Registration failed (${registerResponse.status()}): ${errorBody}`);
@@ -109,10 +113,9 @@ setup("authenticate", async ({ page }) => {
 	// Wait for successful login (redirect to dashboard)
 	await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
 
-	// Verify we're logged in by checking for the greeting heading (format: "Hi, username")
-	await expect(
-		page.getByRole("heading", { name: new RegExp(`Hi,?\\s*${TEST_CREDENTIALS.username}`, "i") }),
-	).toBeVisible({ timeout: 5000 });
+	// Verify the authenticated shell is present. Dashboard copy changes independently
+	// of the session contract, while this landmark is guaranteed after login.
+	await expect(page.getByRole("link", { name: "Dashboard" })).toBeVisible({ timeout: 5000 });
 
 	// Save authentication state
 	await page.context().storageState({ path: authFile });

--- a/e2e/dashboard-attention.spec.ts
+++ b/e2e/dashboard-attention.spec.ts
@@ -11,8 +11,10 @@
  * or without any attention-worthy requests — they skip rather than fail.
  */
 
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { ROUTES, TIMEOUTS, waitForLoadingComplete } from "./utils/test-helpers";
+
+const SEERR_WIDGET_DETECTION_TIMEOUT = 5_000;
 
 // ============================================================================
 // Helpers
@@ -22,7 +24,10 @@ import { ROUTES, TIMEOUTS, waitForLoadingComplete } from "./utils/test-helpers";
 async function hasSeerrWidget(page: import("@playwright/test").Page): Promise<boolean> {
 	const widget = page.getByText("Seerr Requests").first();
 	try {
-		await widget.waitFor({ state: "visible", timeout: TIMEOUTS.medium });
+		// A configured widget is rendered once dashboard loading completes. Keep
+		// the optional-instance check short so clean CI databases skip instead of
+		// exhausting the enclosing test timeout.
+		await widget.waitFor({ state: "visible", timeout: SEERR_WIDGET_DETECTION_TIMEOUT });
 		return true;
 	} catch {
 		return false;
@@ -198,7 +203,8 @@ test.describe("Dashboard - Attention Widget Incognito", () => {
 		// Linux distro names (used by getLinuxIsoName) will appear instead
 		// We can't check for specific names without knowing the originals,
 		// but we verify the section is rendered (incognito didn't break rendering)
-		const attentionItems = page.locator('[class*="attention"], [class*="Attention"]')
+		const attentionItems = page
+			.locator('[class*="attention"], [class*="Attention"]')
 			.or(page.getByText(/^failed$/i).or(page.getByText(/^stuck/i)));
 		const itemCount = await attentionItems.count();
 		expect(itemCount).toBeGreaterThan(0);

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -8,14 +8,8 @@
  * - Refresh functionality
  */
 
-import { test, expect } from "@playwright/test";
-import {
-	ROUTES,
-	TIMEOUTS,
-	waitForLoadingComplete,
-	selectTab,
-	SERVICE_TYPES,
-} from "./utils/test-helpers";
+import { expect, test } from "@playwright/test";
+import { ROUTES, SERVICE_TYPES, TIMEOUTS, waitForLoadingComplete } from "./utils/test-helpers";
 
 // CI auto-generates credentials if not provided (must match auth.setup.ts)
 const CI_TEST_USERNAME = "ci-test-user";
@@ -62,14 +56,25 @@ test.describe("Dashboard - Page Load", () => {
 });
 
 test.describe("Dashboard - Overview Tab", () => {
-	test("should display service stat cards", async ({ page }) => {
+	test("should display stat cards for configured service types", async ({ page }) => {
 		await page.goto(ROUTES.dashboard);
 
 		// Wait for loading to complete
 		await waitForLoadingComplete(page);
 
-		// Should have stat cards for each service type
+		// The dashboard only renders a service card for an enabled instance. CI's
+		// clean database has none, while integration tests exercise configured cards.
+		const servicesResponse = await page.request.get("/api/services");
+		expect(servicesResponse.ok()).toBe(true);
+		const { services } = (await servicesResponse.json()) as {
+			services: Array<{ service: string; enabled: boolean }>;
+		};
+
 		for (const service of SERVICE_TYPES) {
+			if (!services.some((instance) => instance.service === service && instance.enabled)) {
+				continue;
+			}
+
 			const statCard = page.getByText(new RegExp(service, "i")).first();
 			await expect(statCard).toBeVisible({ timeout: TIMEOUTS.medium });
 		}
@@ -271,7 +276,6 @@ test.describe("Dashboard - Refresh Functionality", () => {
 		await refreshButton.click();
 
 		// Should show loading state (spinning icon)
-		const spinningIcon = page.locator('[class*="animate-spin"]');
 		// Either shows spinner or completes quickly
 		await page.waitForTimeout(500);
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -20,20 +20,30 @@ test.describe("Navigation - Sidebar", () => {
 	test("should display sidebar with all navigation links", async ({ page }) => {
 		const expectedLinks = [
 			"Dashboard",
+			"Console",
+			"Pulse",
+			"Statistics",
 			"Discover",
+			"Requests",
+			"Calendar",
 			"Library",
 			"Search",
-			"Indexers",
-			"Calendar",
-			"Statistics",
-			"Hunting",
 			"History",
+			"Hunting",
+			"Queue Cleaner",
+			"Library Cleanup",
+			"Auto-Tagger",
+			"Label Sync",
+			"Cross-Seed",
+			"qui",
+			"qui Activity",
+			"Indexers",
 			"TRaSH Guides",
 			"Settings",
 		];
 
 		for (const linkName of expectedLinks) {
-			const link = page.getByRole("link", { name: new RegExp(linkName, "i") });
+			const link = page.getByRole("link", { name: linkName, exact: true });
 			await expect(link).toBeVisible({ timeout: TIMEOUTS.medium });
 		}
 	});
@@ -61,7 +71,7 @@ test.describe("Navigation - Sidebar", () => {
 		// App title should be visible - check header (h2) which is always visible
 		// The sidebar h1 may be hidden on some viewports due to responsive design
 		const header = page.locator("header, [role='banner']");
-		await expect(header.getByText(/arr control center/i).first()).toBeVisible();
+		await expect(header.getByText(/arr control/i).first()).toBeVisible();
 	});
 });
 
@@ -99,11 +109,19 @@ test.describe("Navigation - Route Changes", () => {
 			// Verify page content loaded - look for heading or page identifier text
 			// Some pages may take longer to load content, so use extended timeout
 			const pageContent = page.locator("main");
-			const textVisible = await pageContent.getByText(heading).first().isVisible({ timeout: TIMEOUTS.long }).catch(() => false);
+			const textVisible = await pageContent
+				.getByText(heading)
+				.first()
+				.isVisible({ timeout: TIMEOUTS.long })
+				.catch(() => false);
 
 			// If main content not found, check the whole page (some pages render differently)
 			if (!textVisible) {
-				const pageTextVisible = await page.getByText(heading).first().isVisible({ timeout: 5000 }).catch(() => false);
+				const pageTextVisible = await page
+					.getByText(heading)
+					.first()
+					.isVisible({ timeout: 5000 })
+					.catch(() => false);
 				expect(pageTextVisible).toBe(true);
 			}
 		});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,86 +1,86 @@
-import { defineConfig, devices } from '@playwright/test';
-import path from 'node:path';
-import { config } from 'dotenv';
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+import { config } from "dotenv";
 
 // Load test environment variables
-config({ path: '.env.test' });
+config({ path: ".env.test" });
 
 /**
  * Playwright configuration for arr-dashboard E2E tests.
  * See https://playwright.dev/docs/test-configuration.
  */
 
-const authFile = path.join(__dirname, '.playwright-auth/user.json');
+const authFile = path.join(__dirname, ".playwright-auth/user.json");
 const isCI = !!process.env.CI;
 
 export default defineConfig({
-  testDir: './e2e',
-  /* Run tests in files in parallel - limited workers to prevent session race conditions */
-  fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: isCI,
-  /* Retry on CI only - reduced to 1 retry to speed up CI */
-  retries: isCI ? 1 : 0,
-  /* Force single worker to ensure auth state reliability
-   * Parallel execution causes race conditions with session-based auth */
-  workers: 1,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: isCI ? [['list'], ['html', { open: 'never' }]] : [['html'], ['list']],
-  /* Global timeout for each test - reduced for CI efficiency */
-  timeout: isCI ? 20000 : 60000,
-  /* Shared settings for all the projects below. */
-  use: {
-    /* Base URL to use in actions like `await page.goto('')`. */
-    baseURL: 'http://localhost:3000',
+	testDir: "./e2e",
+	/* Run tests in files in parallel - limited workers to prevent session race conditions */
+	fullyParallel: true,
+	/* Fail the build on CI if you accidentally left test.only in the source code. */
+	forbidOnly: isCI,
+	/* Retry on CI only - reduced to 1 retry to speed up CI */
+	retries: isCI ? 1 : 0,
+	/* Force single worker to ensure auth state reliability
+	 * Parallel execution causes race conditions with session-based auth */
+	workers: 1,
+	/* Reporter to use. See https://playwright.dev/docs/test-reporters */
+	reporter: isCI ? [["list"], ["html", { open: "never" }]] : [["html"], ["list"]],
+	/* Global timeout for each test - reduced for CI efficiency */
+	timeout: isCI ? 20000 : 60000,
+	/* Shared settings for all the projects below. */
+	use: {
+		/* Base URL to use in actions like `await page.goto('')`. */
+		baseURL: process.env.TEST_BASE_URL || "http://localhost:3000",
 
-    /* Collect trace when retrying the failed test. */
-    trace: 'on-first-retry',
+		/* Collect trace when retrying the failed test. */
+		trace: "on-first-retry",
 
-    /* Take screenshot on failure */
-    screenshot: 'only-on-failure',
+		/* Take screenshot on failure */
+		screenshot: "only-on-failure",
 
-    /* Video on failure */
-    video: 'retain-on-failure',
-  },
+		/* Video on failure */
+		video: "retain-on-failure",
+	},
 
-  /* Configure projects for major browsers */
-  projects: [
-    // Setup project - runs authentication
-    {
-      name: 'setup',
-      testMatch: /.*\.setup\.ts/,
-    },
+	/* Configure projects for major browsers */
+	projects: [
+		// Setup project - runs authentication
+		{
+			name: "setup",
+			testMatch: /.*\.setup\.ts/,
+		},
 
-    // Main test project - depends on setup
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        // Use saved auth state
-        storageState: authFile,
-      },
-      dependencies: ['setup'],
-    },
+		// Main test project - depends on setup
+		{
+			name: "chromium",
+			use: {
+				...devices["Desktop Chrome"],
+				// Use saved auth state
+				storageState: authFile,
+			},
+			dependencies: ["setup"],
+		},
 
-    // Firefox (optional - can be enabled for cross-browser testing)
-    // {
-    //   name: 'firefox',
-    //   use: {
-    //     ...devices['Desktop Firefox'],
-    //     storageState: authFile,
-    //   },
-    //   dependencies: ['setup'],
-    // },
-  ],
+		// Firefox (optional - can be enabled for cross-browser testing)
+		// {
+		//   name: 'firefox',
+		//   use: {
+		//     ...devices['Desktop Firefox'],
+		//     storageState: authFile,
+		//   },
+		//   dependencies: ['setup'],
+		// },
+	],
 
-  /* Expect configuration */
-  expect: {
-    /* Maximum time to wait for assertions - reduced for CI */
-    timeout: isCI ? 8000 : 10000,
-  },
+	/* Expect configuration */
+	expect: {
+		/* Maximum time to wait for assertions - reduced for CI */
+		timeout: isCI ? 8000 : 10000,
+	},
 
-  /* Exclude tests that require external services (Docker Compose stacks) */
-  testIgnore: isCI
-    ? ['**/pocket-id-test/**', '**/authentik-test/**', '**/integration/**']
-    : ['**/integration/**'],
+	/* Exclude tests that require external services (Docker Compose stacks) */
+	testIgnore: isCI
+		? ["**/pocket-id-test/**", "**/authentik-test/**", "**/integration/**"]
+		: ["**/integration/**"],
 });


### PR DESCRIPTION
## Summary
- establish one shared 21-route navigation inventory for the sidebar, command palette, and contextual top bar
- organize routes around Monitor, Media, Automations, Integrations, and Settings; Calendar and History are now Media
- normalize page-shell spacing and semantic page boundaries for qui and Library Cleanup
- document the product-wide UX audit and harden the navigation E2E coverage

## Validation
- pnpm run format
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- authenticated Playwright navigation pass in an isolated SQLite preview
- mobile navigation pass: 3/3