### PR TITLE
fix(web): use semantic layer for command palette

### DIFF
--- a/apps/web/src/components/layout/command-palette.tsx
+++ b/apps/web/src/components/layout/command-palette.tsx
@@ -115,8 +115,7 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
 	// Use portal to render at document.body level, escaping all stacking contexts
 	return createPortal(
 		<div
-			className="fixed inset-0 flex items-start justify-center pt-[20vh] animate-in fade-in duration-150"
-			style={{ zIndex: 9999 }}
+			className="fixed inset-0 z-modal flex items-start justify-center pt-[20vh] animate-in fade-in duration-150"
 			onClick={() => onOpenChange(false)}
 		>
 			{/* Backdrop */}


### PR DESCRIPTION
## Summary
- replace the command palette’s inline z-index with the existing semantic modal layer
- preserve its portal and interaction behavior

## Validation
- pnpm run format
- pnpm run typecheck
- pnpm run test
- pnpm run lint