### PR TITLE
fix(2.x): restore new-library Telegram notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   startup. Jellyfin requires a proxy bypass because its API authentication
   already uses the `Authorization` header.
 
+### Fixed
+
+- New Radarr and Sonarr downloads are now detected when an item is added and
+  imported entirely between library polls, and the resulting notification is
+  dispatched only through channels owned by the instance's user.
+
 ## [2.21.0] - 2026-06-09 — Media-only Storage & Auth Resilience
 
 The storage rollup now tells the truth about *media* space, and a

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -686,7 +686,7 @@ describe("syncInstance", () => {
 
 	// --- New download detection ---------------------------------------------
 
-	describe("New download detection (hasFile false->true)", () => {
+	describe("New download detection", () => {
 		it("Sonarr: detects when hasFile transitions from false to true", async () => {
 			const rawItems = [
 				makeRawItem({
@@ -738,6 +738,63 @@ describe("syncInstance", () => {
 				title: "Downloaded Book",
 				itemType: "author",
 			});
+		});
+
+		it("detects an item added and imported entirely between completed syncs", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Between-polls Movie",
+					hasFile: true,
+					added: "2026-07-15T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: new Date("2026-07-15T11:00:00Z"),
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([{ title: "Between-polls Movie", itemType: "movie" }]);
+		});
+
+		it("does not report existing downloaded items during the first baseline sync", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Existing Movie",
+					hasFile: true,
+					added: "2026-07-15T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: null,
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([]);
+		});
+
+		it("does not report a stale downloaded item that merely reappears", async () => {
+			const rawItems = [
+				makeRawItem({
+					id: 7,
+					title: "Old Movie",
+					hasFile: true,
+					added: "2026-07-14T12:00:00Z",
+				}),
+			];
+			const { deps, instance, mockPrisma } = setupSync("RADARR", rawItems, []);
+			(mockPrisma.librarySyncStatus.upsert as ReturnType<typeof vi.fn>).mockResolvedValue({
+				lastFullSync: new Date("2026-07-15T11:00:00Z"),
+			});
+
+			const result = await syncInstance(deps, instance);
+
+			expect(result.newDownloads).toEqual([]);
 		});
 	});
 

--- a/apps/api/src/lib/library-sync/__tests__/sync-scheduler.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-scheduler.test.ts
@@ -23,8 +23,10 @@
 
 import type { FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NotificationDispatcher } from "../../notifications/notification-dispatcher.js";
+import { NotificationService } from "../../notifications/notification-service.js";
 
-import { LibrarySyncScheduler } from "../sync-scheduler.js";
+import { LibrarySyncScheduler, sendNewDownloadNotification } from "../sync-scheduler.js";
 
 // Match the constants in sync-scheduler.ts. If those change, these test
 // thresholds should too — but keep them in sync intentionally so a change
@@ -239,6 +241,96 @@ describe("LibrarySyncScheduler.activeSyncItemCounts lifecycle", () => {
 		expect(callEffectiveMaxConcurrent(sched, 100)).toBe(1);
 		map.delete("inst-1");
 		expect(callEffectiveMaxConcurrent(sched, 100)).toBe(2);
+	});
+});
+
+// ============================================================================
+// New-download producer → Telegram sender (issue #543)
+// ============================================================================
+
+describe("sendNewDownloadNotification", () => {
+	it("scopes the event to the owner and reaches the real Telegram sender", async () => {
+		const notificationSubscriptionFindMany = vi.fn().mockResolvedValue([
+			{
+				id: "sub-1",
+				channelId: "telegram-1",
+				eventType: "LIBRARY_NEW_CONTENT",
+				channel: {
+					id: "telegram-1",
+					userId: "user-1",
+					name: "Telegram",
+					type: "TELEGRAM",
+					enabled: true,
+					encryptedConfig: "encrypted-config",
+					configIv: "config-iv",
+				},
+			},
+		]);
+		const notificationLogCreate = vi.fn().mockResolvedValue({});
+		const notificationChannelUpdate = vi.fn().mockResolvedValue({});
+		const fetchSpy = vi
+			.spyOn(globalThis, "fetch")
+			.mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+		const service = new NotificationService(
+			{
+				notificationSubscription: { findMany: notificationSubscriptionFindMany },
+				notificationLog: { create: notificationLogCreate },
+				notificationChannel: { update: notificationChannelUpdate },
+			} as never,
+			{
+				decrypt: vi
+					.fn()
+					.mockReturnValue(JSON.stringify({ botToken: "telegram-token", chatId: "chat-123" })),
+			} as never,
+			new NotificationDispatcher(),
+			{ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+			{ isDuplicate: vi.fn().mockReturnValue(false) } as never,
+			{ enqueue: vi.fn() } as never,
+			"https://dashboard.example.test",
+		);
+
+		try {
+			await sendNewDownloadNotification(
+				service,
+				{
+					newDownloads: [
+						{ title: "Movie <One>", itemType: "movie" },
+						{ title: "Movie Two", itemType: "movie" },
+					],
+				},
+				{ label: "Radarr", service: "RADARR", userId: "user-1" },
+			);
+
+			expect(notificationSubscriptionFindMany).toHaveBeenCalledWith({
+				where: {
+					eventType: "LIBRARY_NEW_CONTENT",
+					channel: { userId: "user-1" },
+				},
+				include: { channel: true },
+			});
+			expect(fetchSpy).toHaveBeenCalledWith(
+				"https://api.telegram.org/bottelegram-token/sendMessage",
+				expect.objectContaining({
+					method: "POST",
+					body: expect.stringContaining("2 new download(s) on Radarr"),
+				}),
+			);
+			const request = fetchSpy.mock.calls[0]?.[1];
+			const body = JSON.parse(String(request?.body)) as { text: string };
+			expect(body.text).toContain("Movie &lt;One&gt;, Movie Two");
+			expect(body.text).toContain("https://dashboard.example.test/library");
+			expect(notificationLogCreate).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					channelId: "telegram-1",
+					channelType: "TELEGRAM",
+					eventType: "LIBRARY_NEW_CONTENT",
+					status: "sent",
+				}),
+			});
+		} finally {
+			service.dispose();
+			fetchSpy.mockRestore();
+		}
 	});
 });
 

--- a/apps/api/src/lib/library-sync/sync-executor.ts
+++ b/apps/api/src/lib/library-sync/sync-executor.ts
@@ -244,7 +244,7 @@ export async function syncInstance(
 	};
 
 	try {
-		await prisma.librarySyncStatus.upsert({
+		const syncStatus = await prisma.librarySyncStatus.upsert({
 			where: { instanceId: instance.id },
 			create: {
 				instanceId: instance.id,
@@ -255,6 +255,7 @@ export async function syncInstance(
 				lastError: null,
 			},
 		});
+		const previousFullSync = syncStatus.lastFullSync;
 
 		const client = arrClientFactory.create(instance);
 		const service = instance.service.toLowerCase() as LibraryService;
@@ -450,6 +451,21 @@ export async function syncInstance(
 							data: buildCacheCreate(instance.id, item),
 						});
 						result.itemsAdded++;
+
+						// A complete add + import can happen between polling ticks. In that
+						// case there is no cached hasFile=false row to transition from, so
+						// recognize a newly added ARR item that already has a file. Require a
+						// completed baseline sync and an ARR added timestamp newer than that
+						// baseline; this prevents first-sync floods and stale-row reappearance
+						// from masquerading as new downloads.
+						if (
+							fields.hasFile &&
+							previousFullSync &&
+							fields.arrAddedAt &&
+							fields.arrAddedAt > previousFullSync
+						) {
+							result.newDownloads.push({ title: item.title, itemType: item.type });
+						}
 					}
 					result.itemsProcessed++;
 				}

--- a/apps/api/src/lib/library-sync/sync-scheduler.ts
+++ b/apps/api/src/lib/library-sync/sync-scheduler.ts
@@ -8,6 +8,7 @@
 import { LIBRARY_SERVICES_UPPER } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
 import { createLogger } from "../logger.js";
+import type { NotificationService } from "../notifications/notification-service.js";
 import {
 	passthroughTickWrapper,
 	type TickWrapper,
@@ -360,6 +361,7 @@ export class LibrarySyncScheduler {
 	 */
 	private async runSync(instance: {
 		id: string;
+		userId: string;
 		label: string;
 		service: string;
 		baseUrl: string;
@@ -390,30 +392,16 @@ export class LibrarySyncScheduler {
 				"Library sync completed",
 			);
 
-			// Notify about newly downloaded content (hasFile: false → true transitions)
+			// Notify about newly downloaded content detected by the sync executor.
 			if (result.success && result.newDownloads.length > 0) {
-				const titles = result.newDownloads.slice(0, 5).map((d) => d.title);
-				const remaining = result.newDownloads.length - titles.length;
-
-				this.app.notificationService
-					?.notify({
-						eventType: "LIBRARY_NEW_CONTENT",
-						title: `${result.newDownloads.length} new download(s) on ${instance.label}`,
-						body: remaining > 0 ? `${titles.join(", ")} and ${remaining} more` : titles.join(", "),
-						url: "/library",
-						metadata: {
-							instance: instance.label,
-							service: instance.service,
-							itemCount: result.newDownloads.length,
-							items: titles,
-						},
-					})
-					.catch((err) => {
+				void sendNewDownloadNotification(this.app.notificationService, result, instance).catch(
+					(err) => {
 						log.warn(
 							{ err, instanceLabel: instance.label },
 							"New content notification dispatch failed",
 						);
-					});
+					},
+				);
 			}
 
 			return result;
@@ -436,6 +424,36 @@ export class LibrarySyncScheduler {
 	isInstanceSyncing(instanceId: string): boolean {
 		return this.activeSyncs.has(instanceId);
 	}
+}
+
+/**
+ * Dispatch the library-sync delta through the owning user's notification
+ * pipeline. Exported so the producer-to-channel contract can be tested with
+ * the real notification service and sender registry.
+ */
+export async function sendNewDownloadNotification(
+	notificationService: Pick<NotificationService, "notify">,
+	result: Pick<SyncResult, "newDownloads">,
+	instance: { label: string; service: string; userId: string },
+): Promise<void> {
+	const titles = result.newDownloads.slice(0, 5).map((download) => download.title);
+	const remaining = result.newDownloads.length - titles.length;
+
+	await notificationService.notify(
+		{
+			eventType: "LIBRARY_NEW_CONTENT",
+			title: `${result.newDownloads.length} new download(s) on ${instance.label}`,
+			body: remaining > 0 ? `${titles.join(", ")} and ${remaining} more` : titles.join(", "),
+			url: "/library",
+			metadata: {
+				instance: instance.label,
+				service: instance.service,
+				itemCount: result.newDownloads.length,
+				items: titles,
+			},
+		},
+		{ userId: instance.userId },
+	);
 }
 
 // ============================================================================

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -44,7 +44,11 @@ export class NotificationService {
 	private ruleEngine: RuleEngine | null;
 	private aggregationBuffer: AggregationBuffer | null;
 	private baseUrl: string;
-	private deferredQueue: Array<{ payload: NotificationPayload; deliverAt: number }> = [];
+	private deferredQueue: Array<{
+		payload: NotificationPayload;
+		deliverAt: number;
+		userId?: string;
+	}> = [];
 	private deferFlushTimer: ReturnType<typeof setInterval> | null = null;
 	private static readonly MAX_DEFERRED_QUEUE_SIZE = 200;
 
@@ -86,6 +90,7 @@ export class NotificationService {
 		payload: NotificationPayload,
 		deferUntil: string,
 		ruleId: string,
+		userId?: string,
 	): void {
 		// Cap queue to prevent unbounded growth
 		if (this.deferredQueue.length >= NotificationService.MAX_DEFERRED_QUEUE_SIZE) {
@@ -96,7 +101,7 @@ export class NotificationService {
 			this.deferredQueue.shift();
 		}
 		const deliverAt = new Date(deferUntil).getTime();
-		this.deferredQueue.push({ payload, deliverAt });
+		this.deferredQueue.push({ payload, deliverAt, userId });
 		this.logger.info(
 			{ eventType: payload.eventType, ruleId, deferUntil, queueSize: this.deferredQueue.length },
 			"Notification deferred until quiet hours end",
@@ -125,7 +130,7 @@ export class NotificationService {
 		const deliveryOptions = { skipRules: true };
 		for (const item of ready) {
 			try {
-				await this.notify(item.payload, deliveryOptions);
+				await this.notify(item.payload, { ...deliveryOptions, userId: item.userId });
 			} catch (err: unknown) {
 				this.logger.warn(
 					{ err, eventType: item.payload.eventType },
@@ -139,7 +144,10 @@ export class NotificationService {
 	 * Send a notification to all channels subscribed to the given event type.
 	 * Failures on individual channels are logged but do not throw.
 	 */
-	async notify(payload: NotificationPayload, options?: { skipRules?: boolean }): Promise<void> {
+	async notify(
+		payload: NotificationPayload,
+		options?: { skipRules?: boolean; userId?: string },
+	): Promise<void> {
 		// Dedup: skip if an identical payload was dispatched within the TTL window
 		if (this.dedupGate.isDuplicate(payload)) {
 			this.logger.debug({ eventType: payload.eventType }, "Duplicate notification suppressed");
@@ -147,7 +155,10 @@ export class NotificationService {
 		}
 
 		const subscriptions = await this.prisma.notificationSubscription.findMany({
-			where: { eventType: payload.eventType },
+			where: {
+				eventType: payload.eventType,
+				...(options?.userId ? { channel: { userId: options.userId } } : {}),
+			},
 			include: {
 				channel: true,
 			},
@@ -166,7 +177,7 @@ export class NotificationService {
 
 		// Rule engine: evaluate user-defined rules for suppression, throttling, routing
 		// Deferred notifications skip rules to prevent infinite re-deferral loops
-		const userId = enabledSubs[0]?.channel?.userId;
+		const userId = options?.userId ?? enabledSubs[0]?.channel?.userId;
 		if (userId && this.ruleEngine && !options?.skipRules) {
 			const rules = await this.loadRules(userId);
 			const ruleResult = this.ruleEngine.evaluate(payload, rules);
@@ -179,7 +190,7 @@ export class NotificationService {
 					return;
 				}
 				if (ruleResult.action === "defer" && ruleResult.deferUntil) {
-					this.deferNotification(payload, ruleResult.deferUntil, ruleResult.ruleId);
+					this.deferNotification(payload, ruleResult.deferUntil, ruleResult.ruleId, userId);
 					return;
 				}
 				if (ruleResult.action === "throttle" && ruleResult.throttleMinutes) {


### PR DESCRIPTION
## Summary

- backport the confirmed between-poll import detection from PR #575 to the 2.x line
- detect Radarr/Sonarr items first seen with a file after a completed baseline sync
- suppress first-sync floods and stale-row reappearance
- scope library-new-content notifications to the service instance owner
- preserve owner scope when a notification is deferred
- exercise the producer through the real Telegram sender and captured HTTP request

## Root cause

Library sync only recognized cached `hasFile: false → true` transitions. When an item was added and fully imported between two polling ticks, its first cache row already had `hasFile: true`, so no `LIBRARY_NEW_CONTENT` event was emitted.

The 2.x notification service also lacked the owner-scoped notify option already present on `next`; the backport adds that option so this event cannot route through another user's channels.

## Validation

- focused library-sync/Telegram regression suite: 46 tests
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- touched files pass Biome formatting
- `git diff --check`

The repository-wide format command still reports the existing 2.21 formatting baseline drift in unrelated files.

Closes #543