### PR TITLE
chore: restore 2.x quality baseline

### DIFF
--- a/apps/api/src/lib/__tests__/test-prisma.ts
+++ b/apps/api/src/lib/__tests__/test-prisma.ts
@@ -21,7 +21,9 @@ function isPostgresUrl(url: string): boolean {
  * @param databaseUrl - Optional database URL (defaults to in-memory SQLite)
  * @returns Configured PrismaClient instance
  */
-export function createTestPrismaClient(databaseUrl = ":memory:"): InstanceType<typeof PrismaClient> {
+export function createTestPrismaClient(
+	databaseUrl = ":memory:",
+): InstanceType<typeof PrismaClient> {
 	const adapter = new PrismaBetterSqlite3({ url: databaseUrl });
 	return new PrismaClient({ adapter });
 }

--- a/apps/api/src/lib/arr/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/arr/__tests__/client-factory.test.ts
@@ -16,7 +16,16 @@ import {
 	isNotFoundError,
 	type ClientInstanceData,
 } from "../client-factory.js";
-import { SonarrClient, RadarrClient, ProwlarrClient, NotFoundError, UnauthorizedError, ValidationError, TimeoutError, NetworkError } from "arr-sdk";
+import {
+	SonarrClient,
+	RadarrClient,
+	ProwlarrClient,
+	NotFoundError,
+	UnauthorizedError,
+	ValidationError,
+	TimeoutError,
+	NetworkError,
+} from "arr-sdk";
 import type { Encryptor } from "../../auth/encryption.js";
 
 // Mock the arr-sdk module to match actual SDK signatures
@@ -48,7 +57,10 @@ vi.mock("arr-sdk", () => {
 
 	class MockValidationError extends MockArrError {
 		readonly validationErrors: Array<{ propertyName: string; errorMessage: string }>;
-		constructor(message: string, validationErrors: Array<{ propertyName: string; errorMessage: string }>) {
+		constructor(
+			message: string,
+			validationErrors: Array<{ propertyName: string; errorMessage: string }>,
+		) {
 			super(message, 400, validationErrors);
 			this.name = "ValidationError";
 			this.validationErrors = validationErrors;
@@ -98,14 +110,15 @@ vi.mock("arr-sdk", () => {
 });
 
 // Create mock encryptor (cast to Encryptor since we only mock the methods we need)
-const createMockEncryptor = () => ({
-	encrypt: vi.fn((value: string) => ({
-		value: `encrypted-${value}`,
-		iv: "test-iv",
-	})),
-	decrypt: vi.fn((_: { value: string; iv: string }) => `decrypted-api-key`),
-	safeCompare: vi.fn((a: string, b: string) => a === b),
-}) as unknown as Encryptor;
+const createMockEncryptor = () =>
+	({
+		encrypt: vi.fn((value: string) => ({
+			value: `encrypted-${value}`,
+			iv: "test-iv",
+		})),
+		decrypt: vi.fn((_: { value: string; iv: string }) => `decrypted-api-key`),
+		safeCompare: vi.fn((a: string, b: string) => a === b),
+	}) as unknown as Encryptor;
 
 // Create mock instance data
 const createMockInstance = (
@@ -300,7 +313,8 @@ describe("ArrClientFactory - Options and Callbacks", () => {
 		const onRequest = vi.fn();
 
 		const client = factory.create(instance, { onRequest });
-		const config = (client as unknown as { config: { onRequest?: (config: unknown) => void } }).config;
+		const config = (client as unknown as { config: { onRequest?: (config: unknown) => void } })
+			.config;
 
 		expect(config.onRequest).toBeDefined();
 	});

--- a/apps/api/src/lib/auth/oidc-provider.ts
+++ b/apps/api/src/lib/auth/oidc-provider.ts
@@ -185,14 +185,11 @@ export class OIDCProvider {
 				// Fetch the discovery doc, extract the canonical issuer, and retry.
 				if (processMsg.includes("OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED")) {
 					try {
-						const res = await discoveryResponse.clone().json() as { issuer?: string };
+						const res = (await discoveryResponse.clone().json()) as { issuer?: string };
 						if (res.issuer && res.issuer !== this.config.issuer) {
 							issuerUrl = new URL(res.issuer);
 							discoveryResponse = await oauth.discoveryRequest(issuerUrl, insecureOpts);
-							const authServer = await oauth.processDiscoveryResponse(
-								issuerUrl,
-								discoveryResponse,
-							);
+							const authServer = await oauth.processDiscoveryResponse(issuerUrl, discoveryResponse);
 							this.authServer = authServer;
 							return authServer;
 						}

--- a/apps/api/src/lib/auth/user-agent-parser.ts
+++ b/apps/api/src/lib/auth/user-agent-parser.ts
@@ -151,4 +151,3 @@ function detectDevice(ua: string): "desktop" | "mobile" | "tablet" | "unknown" {
 
 	return "unknown";
 }
-

--- a/apps/api/src/lib/dashboard/calendar-utils.ts
+++ b/apps/api/src/lib/dashboard/calendar-utils.ts
@@ -201,8 +201,11 @@ export const normalizeCalendarItem = (item: unknown, service: CalendarService): 
 
 	// Extract poster from series/movie/artist/author images
 	const imageSource =
-		anyItem.series?.images ?? anyItem.movie?.images ?? anyItem.images ??
-		anyItem.artist?.images ?? anyItem.author?.images;
+		anyItem.series?.images ??
+		anyItem.movie?.images ??
+		anyItem.images ??
+		anyItem.artist?.images ??
+		anyItem.author?.images;
 	const { poster: posterUrl } = normalizeImages(imageSource);
 
 	return {

--- a/apps/api/src/lib/hunting/__tests__/scheduler-batch-update.test.ts
+++ b/apps/api/src/lib/hunting/__tests__/scheduler-batch-update.test.ts
@@ -72,9 +72,7 @@ describe("HuntingScheduler - API Counter Reset", () => {
 
 		// First findMany: find expired configs for reset
 		// Second findMany: get all enabled configs for scheduling
-		mockPrisma.huntConfig.findMany
-			.mockResolvedValueOnce(expiredConfigs)
-			.mockResolvedValueOnce([]);
+		mockPrisma.huntConfig.findMany.mockResolvedValueOnce(expiredConfigs).mockResolvedValueOnce([]);
 
 		const scheduler = getHuntingScheduler() as any;
 		await scheduler.processScheduledHunts();

--- a/apps/api/src/lib/hunting/hunt-executor.ts
+++ b/apps/api/src/lib/hunting/hunt-executor.ts
@@ -1053,7 +1053,7 @@ async function executeRadarrHuntWithSdk(
 						streamingDeps.log,
 					)) {
 						const slim = projectMovie(raw);
-						if (slim && slim.monitored && slim.hasFile) {
+						if (slim?.monitored && slim.hasFile) {
 							monitoredMovies.push(slim);
 						}
 					}
@@ -1061,7 +1061,7 @@ async function executeRadarrHuntWithSdk(
 					const allMovies = await client.movie.getAll();
 					for (const raw of allMovies) {
 						const slim = projectMovie(raw as unknown as Record<string, unknown>);
-						if (slim && slim.monitored && slim.hasFile) {
+						if (slim?.monitored && slim.hasFile) {
 							monitoredMovies.push(slim);
 						}
 					}
@@ -1293,7 +1293,7 @@ async function executeLidarrHuntWithSdk(
 						{ path: "/api/v1/album" },
 					)) {
 						const slim = projectAlbum(raw);
-						if (slim && slim.monitored && slim.trackFileCount > 0) {
+						if (slim?.monitored && slim.trackFileCount > 0) {
 							monitoredAlbums.push(slim);
 						}
 					}
@@ -1301,7 +1301,7 @@ async function executeLidarrHuntWithSdk(
 					const allAlbums = await client.album.getAll();
 					for (const raw of allAlbums) {
 						const slim = projectAlbum(raw as unknown as Record<string, unknown>);
-						if (slim && slim.monitored && slim.trackFileCount > 0) {
+						if (slim?.monitored && slim.trackFileCount > 0) {
 							monitoredAlbums.push(slim);
 						}
 					}
@@ -1539,7 +1539,7 @@ async function executeReadarrHuntWithSdk(
 						{ path: "/api/v1/book" },
 					)) {
 						const slim = projectBook(raw);
-						if (slim && slim.monitored && slim.bookFileCount > 0) {
+						if (slim?.monitored && slim.bookFileCount > 0) {
 							monitoredBooks.push(slim);
 						}
 					}
@@ -1547,7 +1547,7 @@ async function executeReadarrHuntWithSdk(
 					const allBooks = await client.book.getAll();
 					for (const raw of allBooks) {
 						const slim = projectBook(raw as unknown as Record<string, unknown>);
-						if (slim && slim.monitored && slim.bookFileCount > 0) {
+						if (slim?.monitored && slim.bookFileCount > 0) {
 							monitoredBooks.push(slim);
 						}
 					}

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -8,7 +8,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 import { refreshJellyfinCache } from "../jellyfin-cache-refresher.js";
-import type { JellyfinClient, JellyfinItem, JellyfinLibrary, JellyfinUser } from "../jellyfin-client.js";
+import type {
+	JellyfinClient,
+	JellyfinItem,
+	JellyfinLibrary,
+	JellyfinUser,
+} from "../jellyfin-client.js";
 import type { FastifyBaseLogger } from "fastify";
 
 // ---------------------------------------------------------------------------
@@ -41,7 +46,9 @@ function makeSeriesItem(overrides: Partial<JellyfinItem> = {}): JellyfinItem {
 }
 
 const oneUser: JellyfinUser[] = [{ id: "user-1", name: "Alice" }];
-const oneLibrary: JellyfinLibrary[] = [{ id: "lib-1", name: "TV Shows", collectionType: "tvshows" }];
+const oneLibrary: JellyfinLibrary[] = [
+	{ id: "lib-1", name: "TV Shows", collectionType: "tvshows" },
+];
 
 /**
  * Build a minimal mock JellyfinClient that serves the given library items.
@@ -110,7 +117,8 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
 
 		expect(upserts).toHaveLength(1);
-		const payload = (upserts[0] as { create: { lastWatchedAt: Date | null; watchCount: number } }).create;
+		const payload = (upserts[0] as { create: { lastWatchedAt: Date | null; watchCount: number } })
+			.create;
 		// lastWatchedAt must be set so the episode-cache refresher picks up this series
 		expect(payload.lastWatchedAt).toEqual(new Date("2024-06-15T18:30:00Z"));
 		// watchCount stays 0 — the series wasn't fully watched
@@ -148,7 +156,8 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 			getUsers: vi.fn().mockResolvedValue(twoUsers),
 			getLibraries: vi.fn().mockResolvedValue(oneLibrary),
 			// First call (Alice) returns older, second call (Bob) returns newer
-			getLibraryItems: vi.fn()
+			getLibraryItems: vi
+				.fn()
 				.mockResolvedValueOnce([olderItem])
 				.mockResolvedValueOnce([newerItem]),
 			getResumeItems: vi.fn().mockResolvedValue([]),

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -118,7 +118,7 @@ export async function refreshJellyfinCache(
 								userRating: null,
 								collections: [],
 								addedAt: item.dateCreated ? new Date(item.dateCreated) : null,
-								thumb: item.imageTags?.["Primary"] ? `/Items/${item.id}/Images/Primary` : null,
+								thumb: item.imageTags?.Primary ? `/Items/${item.id}/Images/Primary` : null,
 							};
 							aggregations.set(key, agg);
 						}

--- a/apps/api/src/lib/jellyfin/jellyfin-client.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-client.ts
@@ -483,7 +483,7 @@ function mapItem(item: {
 	ImageTags?: Record<string, string>;
 }): JellyfinItem {
 	const providerIds = item.ProviderIds ?? {};
-	const tmdbStr = providerIds["Tmdb"] ?? providerIds["tmdb"];
+	const tmdbStr = providerIds.Tmdb ?? providerIds.tmdb;
 	const tmdbId = tmdbStr ? Number.parseInt(tmdbStr, 10) : undefined;
 
 	return {
@@ -496,7 +496,7 @@ function mapItem(item: {
 		seasonNumber: item.ParentIndexNumber,
 		year: item.ProductionYear,
 		tmdbId: tmdbId && !Number.isNaN(tmdbId) ? tmdbId : undefined,
-		imdbId: providerIds["Imdb"] ?? providerIds["imdb"],
+		imdbId: providerIds.Imdb ?? providerIds.imdb,
 		played: item.UserData?.Played ?? false,
 		playCount: item.UserData?.PlayCount ?? 0,
 		lastPlayedDate: item.UserData?.LastPlayedDate ?? null,

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
@@ -751,14 +751,24 @@ describe("golden test — multi-rule priority evaluation", () => {
 	];
 
 	it("first matching rule wins (declined request takes priority)", () => {
-		const result = evaluateItemAgainstRules(declinedRequest, rules as LibraryCleanupRule[], "RADARR", ctx);
+		const result = evaluateItemAgainstRules(
+			declinedRequest,
+			rules as LibraryCleanupRule[],
+			"RADARR",
+			ctx,
+		);
 		expect(result).not.toBeNull();
 		expect(result!.ruleId).toBe("r-declined");
 		expect(result!.action).toBe("delete");
 	});
 
 	it("composite AND rule matches old low-rated item", () => {
-		const result = evaluateItemAgainstRules(oldLowRated, rules as LibraryCleanupRule[], "RADARR", ctx);
+		const result = evaluateItemAgainstRules(
+			oldLowRated,
+			rules as LibraryCleanupRule[],
+			"RADARR",
+			ctx,
+		);
 		// oldLowRated has no seerr request (tmdbId 12345 has declined request, but this item
 		// also has tmdbId 12345 in its data — it WILL match r-declined first)
 		expect(result).not.toBeNull();
@@ -773,7 +783,12 @@ describe("golden test — multi-rule priority evaluation", () => {
 		//   "never" with null watch → "Never watched (per Plex)"... wait
 		//   Actually: watch is null (not in plexMap), so returns null for "never"
 		//   because the function only returns match when watch exists but lastWatchedAt is null
-		const result = evaluateItemAgainstRules(recentHighRated, rules as LibraryCleanupRule[], "RADARR", ctx);
+		const result = evaluateItemAgainstRules(
+			recentHighRated,
+			rules as LibraryCleanupRule[],
+			"RADARR",
+			ctx,
+		);
 		// plex_last_watched with "never": if watch is null (no plex entry), the function returns null
 		// (you need to be IN plex with null lastWatchedAt to match)
 		// But wait — looking at the code: `if (!watch || watch.lastWatchedAt === null)` — so null watch
@@ -787,7 +802,12 @@ describe("golden test — multi-rule priority evaluation", () => {
 		// protectedByGenre has rating 2.0, is old (90 days) — matches r-low-rating conditions
 		// BUT has excludeTitles pattern "Protected" which matches "Protected Film"
 		// So r-low-rating skips. Check if r-never-watched catches it.
-		const result = evaluateItemAgainstRules(protectedByGenre, rules as LibraryCleanupRule[], "RADARR", ctx);
+		const result = evaluateItemAgainstRules(
+			protectedByGenre,
+			rules as LibraryCleanupRule[],
+			"RADARR",
+			ctx,
+		);
 		// protectedByGenre has tmdbId 12345 → seerr has declined request → r-declined matches
 		expect(result).not.toBeNull();
 		expect(result!.ruleId).toBe("r-declined");
@@ -805,7 +825,12 @@ describe("golden test — multi-rule priority evaluation", () => {
 			}),
 		});
 
-		const result = evaluateItemAgainstRules(noSeerrItem, rules as LibraryCleanupRule[], "RADARR", ctx);
+		const result = evaluateItemAgainstRules(
+			noSeerrItem,
+			rules as LibraryCleanupRule[],
+			"RADARR",
+			ctx,
+		);
 		// r-declined: no seerr data → skip
 		// r-low-rating: rating 2.5 < 5 AND age ~90 days > 60 → MATCH
 		expect(result).not.toBeNull();

--- a/apps/api/src/lib/library-sync/__tests__/infohash-backfill-by-inode.integration.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/infohash-backfill-by-inode.integration.test.ts
@@ -240,7 +240,9 @@ describe.skipIf(!isPosix)("inode backfill — real filesystem", () => {
 		// THE PROOF: index contains the file's inode (so library lookup
 		// will hit), NOT the folder's inode.
 		expect(index.byFileId.size).toBe(1);
-		expect(index.byFileId.get(`${fileStat.dev}:${fileStat.ino}`)).toEqual(new Set(["folder-wrapped-hash"]));
+		expect(index.byFileId.get(`${fileStat.dev}:${fileStat.ino}`)).toEqual(
+			new Set(["folder-wrapped-hash"]),
+		);
 		expect(index.byFileId.get(`${folderStat.dev}:${folderStat.ino}`)).toBeUndefined();
 
 		const match = await matchLibraryByFileId(libraryPath, index);
@@ -289,8 +291,14 @@ describe.skipIf(!isPosix)("inode backfill — real filesystem", () => {
 		const e1Stat = statSync(e1Torrent);
 		const e2Stat = statSync(e2Torrent);
 		const e3Stat = statSync(e3Torrent);
-		expect(index.byFileId.get(`${e1Stat.dev}:${e1Stat.ino}`)).toEqual(new Set(["season-pack-hash"]));
-		expect(index.byFileId.get(`${e2Stat.dev}:${e2Stat.ino}`)).toEqual(new Set(["season-pack-hash"]));
-		expect(index.byFileId.get(`${e3Stat.dev}:${e3Stat.ino}`)).toEqual(new Set(["season-pack-hash"]));
+		expect(index.byFileId.get(`${e1Stat.dev}:${e1Stat.ino}`)).toEqual(
+			new Set(["season-pack-hash"]),
+		);
+		expect(index.byFileId.get(`${e2Stat.dev}:${e2Stat.ino}`)).toEqual(
+			new Set(["season-pack-hash"]),
+		);
+		expect(index.byFileId.get(`${e3Stat.dev}:${e3Stat.ino}`)).toEqual(
+			new Set(["season-pack-hash"]),
+		);
 	});
 });

--- a/apps/api/src/lib/library-sync/__tests__/infohash-backfill.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/infohash-backfill.test.ts
@@ -61,7 +61,6 @@ function makeApp(historyResponse: { ok: boolean; records?: unknown[] }) {
 				count: vi.fn().mockResolvedValue(0),
 			},
 		},
-		// biome-ignore lint/suspicious/noExplicitAny: test shim
 	} as any;
 }
 

--- a/apps/api/src/lib/library-sync/infohash-backfill-by-inode.ts
+++ b/apps/api/src/lib/library-sync/infohash-backfill-by-inode.ts
@@ -550,7 +550,7 @@ async function indexDirectoryFiles(
 		// (Dockerfile uses node:22-alpine3.21), so no fallback needed.
 		const filePath = `${entry.parentPath}/${entry.name}`;
 		const info = await statSafe(filePath);
-		if (!info || info.kind !== "file") continue;
+		if (info?.kind !== "file") continue;
 		if (info.nlink < 2) {
 			skippedNoLinks++;
 			continue;
@@ -578,7 +578,7 @@ export async function matchLibraryByFileId(
 	index: FileIdIndex,
 ): Promise<InodeMatchResult | null> {
 	const info = await statSafe(libraryPath);
-	if (!info || info.kind !== "file") return null;
+	if (info?.kind !== "file") return null;
 	if (info.nlink < 2) return null;
 	const hashes = index.byFileId.get(`${info.dev}:${info.ino}`);
 	if (!hashes || hashes.size === 0) return null;
@@ -610,7 +610,7 @@ export async function getAllHashesForFileId(
 	index: FileIdIndex,
 ): Promise<string[]> {
 	const info = await statSafe(libraryPath);
-	if (!info || info.kind !== "file") return [];
+	if (info?.kind !== "file") return [];
 	if (info.nlink < 2) return [];
 	const hashes = index.byFileId.get(`${info.dev}:${info.ino}`);
 	if (!hashes) return [];

--- a/apps/api/src/lib/library/artist-normalizer.ts
+++ b/apps/api/src/lib/library/artist-normalizer.ts
@@ -72,7 +72,10 @@ export const buildArtistItem = (
 			trackFileCount,
 			totalTrackCount: toNumber(stats?.totalTrackCount),
 			// Use trackCount (monitored albums only) for missing calculation; fall back to totalTrackCount
-			missingTrackCount: Math.max((toNumber(stats?.trackCount) ?? toNumber(stats?.totalTrackCount) ?? 0) - trackFileCount, 0),
+			missingTrackCount: Math.max(
+				(toNumber(stats?.trackCount) ?? toNumber(stats?.totalTrackCount) ?? 0) - trackFileCount,
+				0,
+			),
 		},
 	} as LibraryItem;
 };

--- a/apps/api/src/lib/notifications/__tests__/aggregation-buffer.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/aggregation-buffer.test.ts
@@ -96,7 +96,10 @@ describe("AggregationBuffer", () => {
 
 		buffer.push(makePayload(), config);
 		buffer.push(
-			makePayload({ eventType: "BACKUP_COMPLETED" as NotificationPayload["eventType"], title: "Backup done" }),
+			makePayload({
+				eventType: "BACKUP_COMPLETED" as NotificationPayload["eventType"],
+				title: "Backup done",
+			}),
 			configB,
 		);
 

--- a/apps/api/src/lib/notifications/__tests__/log-retention.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/log-retention.test.ts
@@ -7,10 +7,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { purgeOldLogs, purgeOldLogsBatched } from "../log-retention.js";
 
-function createMockPrisma(
-	deleteCount: number,
-	findBatches?: Array<Array<{ id: string }>>,
-) {
+function createMockPrisma(deleteCount: number, findBatches?: Array<Array<{ id: string }>>) {
 	const findManyFn = vi.fn();
 	if (findBatches) {
 		for (const batch of findBatches) {

--- a/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/retry-handler.test.ts
@@ -17,8 +17,19 @@ const mockLogger = {
 	debug: vi.fn(),
 };
 
-type SendFnType = (type: NotificationChannelType, config: Record<string, unknown>, payload: NotificationPayload) => Promise<SendResult>;
-type LogFnType = (channelId: string, channelType: NotificationChannelType, payload: NotificationPayload, status: "sent" | "failed" | "dead_letter", error?: string, retryCount?: number) => Promise<void>;
+type SendFnType = (
+	type: NotificationChannelType,
+	config: Record<string, unknown>,
+	payload: NotificationPayload,
+) => Promise<SendResult>;
+type LogFnType = (
+	channelId: string,
+	channelType: NotificationChannelType,
+	payload: NotificationPayload,
+	status: "sent" | "failed" | "dead_letter",
+	error?: string,
+	retryCount?: number,
+) => Promise<void>;
 
 let sendFn: ReturnType<typeof vi.fn<SendFnType>>;
 let logDeliveryFn: ReturnType<typeof vi.fn<LogFnType>>;
@@ -73,7 +84,11 @@ describe("RetryHandler", () => {
 	});
 
 	it("dead-letters after max retries (3) are exhausted", async () => {
-		sendFn.mockResolvedValue({ success: false, retryable: true, error: "server error" } satisfies SendResult);
+		sendFn.mockResolvedValue({
+			success: false,
+			retryable: true,
+			error: "server error",
+		} satisfies SendResult);
 		handler = new RetryHandler(sendFn, logDeliveryFn, mockLogger);
 
 		handler.enqueue({

--- a/apps/api/src/lib/notifications/__tests__/statistics.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/statistics.test.ts
@@ -57,10 +57,34 @@ describe("getDeliveryStatistics", () => {
 	it("correctly counts sent/failed/dead_letter totals", async () => {
 		const now = new Date();
 		const prisma = createMockPrisma([
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_FAILED", status: "failed", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "BACKUP_COMPLETED", status: "dead_letter", sentAt: now },
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_FAILED",
+				status: "failed",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "BACKUP_COMPLETED",
+				status: "dead_letter",
+				sentAt: now,
+			},
 		]);
 
 		const result = await getDeliveryStatistics(prisma, ["ch-1"], 7);
@@ -117,12 +141,48 @@ describe("getDeliveryStatistics", () => {
 	it("aggregates per-event-type counts sorted by frequency", async () => {
 		const now = new Date();
 		const prisma = createMockPrisma([
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "BACKUP_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "BACKUP_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "BACKUP_COMPLETED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_FAILED", status: "sent", sentAt: now },
-			{ channelId: "ch-1", channelType: "discord", eventType: "HUNT_FAILED", status: "sent", sentAt: now },
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "BACKUP_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "BACKUP_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "BACKUP_COMPLETED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_FAILED",
+				status: "sent",
+				sentAt: now,
+			},
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "HUNT_FAILED",
+				status: "sent",
+				sentAt: now,
+			},
 		]);
 
 		const result = await getDeliveryStatistics(prisma, ["ch-1"], 7);
@@ -145,7 +205,13 @@ describe("getDeliveryStatistics", () => {
 		const prisma = createMockPrisma([
 			{ channelId: "ch-1", channelType: "discord", eventType: "E1", status: "sent", sentAt: day3 },
 			{ channelId: "ch-1", channelType: "discord", eventType: "E1", status: "sent", sentAt: day1 },
-			{ channelId: "ch-1", channelType: "discord", eventType: "E1", status: "failed", sentAt: day1 },
+			{
+				channelId: "ch-1",
+				channelType: "discord",
+				eventType: "E1",
+				status: "failed",
+				sentAt: day1,
+			},
 			{ channelId: "ch-1", channelType: "discord", eventType: "E1", status: "sent", sentAt: day2 },
 		]);
 

--- a/apps/api/src/lib/notifications/aggregation-buffer.ts
+++ b/apps/api/src/lib/notifications/aggregation-buffer.ts
@@ -78,7 +78,10 @@ export class AggregationBuffer {
 
 		const digest = this.buildDigest(bucket.items, key);
 		this.flushCallback(digest).catch((err) => {
-			loggers.notifications.warn({ err }, "Aggregation flush failed — batched notifications may be lost");
+			loggers.notifications.warn(
+				{ err },
+				"Aggregation flush failed — batched notifications may be lost",
+			);
 		});
 	}
 

--- a/apps/api/src/lib/notifications/channels/__tests__/gotify-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/gotify-sender.test.ts
@@ -154,7 +154,9 @@ describe("gotifySender", () => {
 
 		const call = mockFetch.mock.calls[0]!;
 		const body = JSON.parse(call[1].body);
-		expect(body.extras["client::notification"]).toEqual({ click: { url: "https://example.com/details" } });
+		expect(body.extras["client::notification"]).toEqual({
+			click: { url: "https://example.com/details" },
+		});
 	});
 
 	it("returns retryable on 429", async () => {

--- a/apps/api/src/lib/notifications/channels/__tests__/ntfy-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/ntfy-sender.test.ts
@@ -45,10 +45,7 @@ describe("ntfySender", () => {
 	it("sends to correct URL (serverUrl/topic)", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await ntfySender.send(
-			{ serverUrl: "https://ntfy.sh", topic: "test" },
-			makePayload(),
-		);
+		await ntfySender.send({ serverUrl: "https://ntfy.sh", topic: "test" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		expect(call[0]).toBe("https://ntfy.sh/test");
@@ -71,10 +68,7 @@ describe("ntfySender", () => {
 	it("includes X-Priority header", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await ntfySender.send(
-			{ serverUrl: "https://ntfy.sh", topic: "test" },
-			makePayload(),
-		);
+		await ntfySender.send({ serverUrl: "https://ntfy.sh", topic: "test" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const headers: Record<string, string> = call[1].headers;
@@ -86,10 +80,7 @@ describe("ntfySender", () => {
 	it("includes X-Tags header", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await ntfySender.send(
-			{ serverUrl: "https://ntfy.sh", topic: "test" },
-			makePayload(),
-		);
+		await ntfySender.send({ serverUrl: "https://ntfy.sh", topic: "test" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const headers: Record<string, string> = call[1].headers;
@@ -115,10 +106,7 @@ describe("ntfySender", () => {
 	it("does not include Authorization when no token", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await ntfySender.send(
-			{ serverUrl: "https://ntfy.sh", topic: "test" },
-			makePayload(),
-		);
+		await ntfySender.send({ serverUrl: "https://ntfy.sh", topic: "test" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const headers: Record<string, string> = call[1].headers;

--- a/apps/api/src/lib/notifications/channels/__tests__/pushbullet-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/pushbullet-sender.test.ts
@@ -33,10 +33,7 @@ describe("pushbulletSender", () => {
 	it("returns success on 200", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		const result = await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		const result = await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		expect(result).toEqual({ success: true, retryable: false });
 		expect(mockFetch).toHaveBeenCalledOnce();
@@ -45,10 +42,7 @@ describe("pushbulletSender", () => {
 	it("sends correct URL to Pushbullet API", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		expect(call[0]).toBe("https://api.pushbullet.com/v2/pushes");
@@ -57,10 +51,7 @@ describe("pushbulletSender", () => {
 	it("includes Access-Token header", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const headers: Record<string, string> = call[1].headers;
@@ -84,10 +75,7 @@ describe("pushbulletSender", () => {
 	it("sends 'note' type when payload has no url", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const body = JSON.parse(call[1].body);
@@ -113,10 +101,7 @@ describe("pushbulletSender", () => {
 			new Response("rate limited", { status: 429, statusText: "Too Many Requests" }),
 		);
 
-		const result = await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		const result = await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -128,10 +113,7 @@ describe("pushbulletSender", () => {
 			new Response("Internal Server Error", { status: 500, statusText: "Internal Server Error" }),
 		);
 
-		const result = await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		const result = await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -143,10 +125,7 @@ describe("pushbulletSender", () => {
 			new Response("bad request", { status: 400, statusText: "Bad Request" }),
 		);
 
-		const result = await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		const result = await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(false);
@@ -156,10 +135,7 @@ describe("pushbulletSender", () => {
 	it("returns retryable on network error", async () => {
 		mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
 
-		const result = await pushbulletSender.send(
-			{ apiToken: "o.abc123" },
-			makePayload(),
-		);
+		const result = await pushbulletSender.send({ apiToken: "o.abc123" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);

--- a/apps/api/src/lib/notifications/channels/__tests__/pushover-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/pushover-sender.test.ts
@@ -45,10 +45,7 @@ describe("pushoverSender", () => {
 	it("sends to correct Pushover API URL", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushoverSender.send(
-			{ userKey: "ukey123", apiToken: "atoken456" },
-			makePayload(),
-		);
+		await pushoverSender.send({ userKey: "ukey123", apiToken: "atoken456" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		expect(call[0]).toBe("https://api.pushover.net/1/messages.json");
@@ -57,10 +54,7 @@ describe("pushoverSender", () => {
 	it("includes token and user in body", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushoverSender.send(
-			{ userKey: "ukey123", apiToken: "atoken456" },
-			makePayload(),
-		);
+		await pushoverSender.send({ userKey: "ukey123", apiToken: "atoken456" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const body = JSON.parse(call[1].body);
@@ -71,10 +65,7 @@ describe("pushoverSender", () => {
 	it("sets html: 1 in body", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await pushoverSender.send(
-			{ userKey: "ukey123", apiToken: "atoken456" },
-			makePayload(),
-		);
+		await pushoverSender.send({ userKey: "ukey123", apiToken: "atoken456" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const body = JSON.parse(call[1].body);

--- a/apps/api/src/lib/notifications/channels/__tests__/telegram-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/telegram-sender.test.ts
@@ -36,10 +36,7 @@ describe("telegramSender", () => {
 	it("returns success on 2xx response", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		const result = await telegramSender.send(
-			{ botToken: "123:ABC", chatId: "456" },
-			makePayload(),
-		);
+		const result = await telegramSender.send({ botToken: "123:ABC", chatId: "456" }, makePayload());
 
 		expect(result).toEqual({ success: true, retryable: false });
 		expect(mockFetch).toHaveBeenCalledWith(
@@ -69,10 +66,7 @@ describe("telegramSender", () => {
 			),
 		);
 
-		const result = await telegramSender.send(
-			{ botToken: "123:ABC", chatId: "456" },
-			makePayload(),
-		);
+		const result = await telegramSender.send({ botToken: "123:ABC", chatId: "456" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -87,7 +81,7 @@ describe("telegramSender", () => {
 			{ botToken: "123:ABC", chatId: "456" },
 			makePayload({
 				title: '<script>alert("xss")</script>',
-				body: 'Tom & Jerry <> "quotes" \'apos\'',
+				body: "Tom & Jerry <> \"quotes\" 'apos'",
 			}),
 		);
 
@@ -125,10 +119,7 @@ describe("telegramSender", () => {
 			new Response(JSON.stringify({ ok: false }), { status: 502, statusText: "Bad Gateway" }),
 		);
 
-		const result = await telegramSender.send(
-			{ botToken: "123:ABC", chatId: "456" },
-			makePayload(),
-		);
+		const result = await telegramSender.send({ botToken: "123:ABC", chatId: "456" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -136,16 +127,12 @@ describe("telegramSender", () => {
 
 	it("returns non-retryable on 4xx (not 429)", async () => {
 		mockFetch.mockResolvedValue(
-			new Response(
-				JSON.stringify({ ok: false, description: "Bad Request: chat not found" }),
-				{ status: 400 },
-			),
+			new Response(JSON.stringify({ ok: false, description: "Bad Request: chat not found" }), {
+				status: 400,
+			}),
 		);
 
-		const result = await telegramSender.send(
-			{ botToken: "123:ABC", chatId: "456" },
-			makePayload(),
-		);
+		const result = await telegramSender.send({ botToken: "123:ABC", chatId: "456" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(false);

--- a/apps/api/src/lib/notifications/channels/__tests__/webhook-sender.test.ts
+++ b/apps/api/src/lib/notifications/channels/__tests__/webhook-sender.test.ts
@@ -33,10 +33,7 @@ describe("webhookSender", () => {
 	it("returns success on 200 response", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		const result = await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		const result = await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		expect(result).toEqual({ success: true, retryable: false });
 		expect(mockFetch).toHaveBeenCalledOnce();
@@ -45,10 +42,7 @@ describe("webhookSender", () => {
 	it("sends correct JSON payload structure", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload("My Title"),
-		);
+		await webhookSender.send({ url: "https://example.com/webhook" }, makePayload("My Title"));
 
 		const call = mockFetch.mock.calls[0]!;
 		const body = JSON.parse(call[1].body);
@@ -80,10 +74,7 @@ describe("webhookSender", () => {
 	it("does not include signature headers when no secret", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		const headers: Record<string, string> = call[1].headers;
@@ -102,10 +93,7 @@ describe("webhookSender", () => {
 			headers: responseHeaders,
 		});
 
-		const result = await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		const result = await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -120,10 +108,7 @@ describe("webhookSender", () => {
 			headers: new Headers(),
 		});
 
-		const result = await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		const result = await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -138,10 +123,7 @@ describe("webhookSender", () => {
 			headers: new Headers(),
 		});
 
-		const result = await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		const result = await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(false);
@@ -151,10 +133,7 @@ describe("webhookSender", () => {
 	it("returns retryable on network error", async () => {
 		mockFetch.mockRejectedValue(new Error("Network connection refused"));
 
-		const result = await webhookSender.send(
-			{ url: "https://example.com/webhook" },
-			makePayload(),
-		);
+		const result = await webhookSender.send({ url: "https://example.com/webhook" }, makePayload());
 
 		expect(result.success).toBe(false);
 		expect(result.retryable).toBe(true);
@@ -164,10 +143,7 @@ describe("webhookSender", () => {
 	it("uses configured HTTP method", async () => {
 		mockFetch.mockResolvedValue(okResponse());
 
-		await webhookSender.send(
-			{ url: "https://example.com/webhook", method: "PUT" },
-			makePayload(),
-		);
+		await webhookSender.send({ url: "https://example.com/webhook", method: "PUT" }, makePayload());
 
 		const call = mockFetch.mock.calls[0]!;
 		expect(call[1].method).toBe("PUT");

--- a/apps/api/src/lib/notifications/rule-engine.ts
+++ b/apps/api/src/lib/notifications/rule-engine.ts
@@ -160,12 +160,22 @@ function isWithinQuietHours(start: string, end: string, timezone: string | null)
 		const endH = endParts[0];
 		const endM = endParts[1];
 		if (
-			startH === undefined || startM === undefined ||
-			endH === undefined || endM === undefined ||
-			!Number.isFinite(startH) || !Number.isFinite(startM) ||
-			!Number.isFinite(endH) || !Number.isFinite(endM) ||
-			startH < 0 || startH > 23 || startM < 0 || startM > 59 ||
-			endH < 0 || endH > 23 || endM < 0 || endM > 59
+			startH === undefined ||
+			startM === undefined ||
+			endH === undefined ||
+			endM === undefined ||
+			!Number.isFinite(startH) ||
+			!Number.isFinite(startM) ||
+			!Number.isFinite(endH) ||
+			!Number.isFinite(endM) ||
+			startH < 0 ||
+			startH > 23 ||
+			startM < 0 ||
+			startM > 59 ||
+			endH < 0 ||
+			endH > 23 ||
+			endM < 0 ||
+			endM > 59
 		) {
 			return true; // Malformed time config — fail closed
 		}
@@ -195,7 +205,12 @@ function computeDeferUntil(endTime: string, timezone: string | null): string {
 		const endParts = endTime.split(":").map(Number);
 		const endH = endParts[0];
 		const endM = endParts[1];
-		if (endH === undefined || endM === undefined || !Number.isFinite(endH) || !Number.isFinite(endM)) {
+		if (
+			endH === undefined ||
+			endM === undefined ||
+			!Number.isFinite(endH) ||
+			!Number.isFinite(endM)
+		) {
 			return new Date(Date.now() + 8 * 60 * 60_000).toISOString();
 		}
 
@@ -234,7 +249,9 @@ function computeDeferUntil(endTime: string, timezone: string | null): string {
 		const utcNow = now.getTime();
 		const localDate = new Date(localYear, localMonth - 1, localDay + dayOffset, endH, endM, 0, 0);
 		const localTimestamp = localDate.getTime();
-		const offset = utcNow - new Date(localYear, localMonth - 1, localDay, localHour, localMinute, 0, 0).getTime();
+		const offset =
+			utcNow -
+			new Date(localYear, localMonth - 1, localDay, localHour, localMinute, 0, 0).getTime();
 
 		return new Date(localTimestamp + offset).toISOString();
 	} catch {

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -138,9 +138,7 @@ describe("evictStaleRows", () => {
 
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
-			getLibrarySections: vi
-				.fn()
-				.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
 			getLibraryItems: vi.fn().mockResolvedValue(libraryItems),
 			getHistory: vi.fn().mockResolvedValue([]),
 			getOnDeck: vi.fn().mockResolvedValue([]),
@@ -150,10 +148,7 @@ describe("evictStaleRows", () => {
 		// a large stale tail — enough that the old `notIn: upsertedIds` path
 		// would have been >999 params and tripped P2029.
 		const upsertedIds: string[] = [];
-		const existingIds: string[] = Array.from(
-			{ length: STALE_COUNT },
-			(_, i) => `stale-${i}`,
-		);
+		const existingIds: string[] = Array.from({ length: STALE_COUNT }, (_, i) => `stale-${i}`);
 
 		const deleteCalls: Array<{ idsInFilter: string[] }> = [];
 
@@ -169,18 +164,16 @@ describe("evictStaleRows", () => {
 					// freshly-upserted rows. Eviction should keep the fresh set.
 					[...existingIds, ...upsertedIds].map((id) => ({ id })),
 				),
-				deleteMany: vi.fn(
-					async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
-						const inList = args.where.id?.in;
-						if (!inList) {
-							throw new Error(
-								"Regression: DELETE used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
-							);
-						}
-						deleteCalls.push({ idsInFilter: inList });
-						return { count: inList.length };
-					},
-				),
+				deleteMany: vi.fn(async (args: { where: { id?: { in?: string[]; notIn?: string[] } } }) => {
+					const inList = args.where.id?.in;
+					if (!inList) {
+						throw new Error(
+							"Regression: DELETE used something other than `id: { in: [...] }` — likely a reintroduced notIn.",
+						);
+					}
+					deleteCalls.push({ idsInFilter: inList });
+					return { count: inList.length };
+				}),
 			},
 			$transaction: vi.fn(async (ops: Promise<unknown>[] | unknown[]) => {
 				const results: unknown[] = [];

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -315,25 +315,36 @@ export async function refreshPlexCache(
 								},
 							},
 							create: {
-								instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType,
-								sectionId: agg.sectionId, sectionTitle: agg.sectionTitle,
-								title: agg.title, ratingKey: agg.ratingKey,
-								lastWatchedAt: agg.lastWatchedAt, watchCount: agg.watchCount,
-								watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
-								onDeck: agg.onDeck, userRating: agg.userRating,
-								collections: JSON.stringify(agg.collections),
-								labels: JSON.stringify(agg.labels),
-								addedAt: agg.addedAt, thumb: agg.thumb,
-							},
-							update: {
-								sectionTitle: agg.sectionTitle, title: agg.title,
-								ratingKey: agg.ratingKey, lastWatchedAt: agg.lastWatchedAt,
+								instanceId,
+								tmdbId: agg.tmdbId,
+								mediaType: agg.mediaType,
+								sectionId: agg.sectionId,
+								sectionTitle: agg.sectionTitle,
+								title: agg.title,
+								ratingKey: agg.ratingKey,
+								lastWatchedAt: agg.lastWatchedAt,
 								watchCount: agg.watchCount,
 								watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
-								onDeck: agg.onDeck, userRating: agg.userRating,
+								onDeck: agg.onDeck,
+								userRating: agg.userRating,
 								collections: JSON.stringify(agg.collections),
 								labels: JSON.stringify(agg.labels),
-								addedAt: agg.addedAt, thumb: agg.thumb,
+								addedAt: agg.addedAt,
+								thumb: agg.thumb,
+							},
+							update: {
+								sectionTitle: agg.sectionTitle,
+								title: agg.title,
+								ratingKey: agg.ratingKey,
+								lastWatchedAt: agg.lastWatchedAt,
+								watchCount: agg.watchCount,
+								watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
+								onDeck: agg.onDeck,
+								userRating: agg.userRating,
+								collections: JSON.stringify(agg.collections),
+								labels: JSON.stringify(agg.labels),
+								addedAt: agg.addedAt,
+								thumb: agg.thumb,
 							},
 						});
 						upsertedIds.push(row.id);
@@ -342,7 +353,10 @@ export async function refreshPlexCache(
 						const msg = `Failed to upsert ${agg.mediaType} tmdb:${agg.tmdbId}: ${getErrorMessage(itemError)}`;
 						errors++;
 						errorMessages.push(msg);
-						log.warn({ err: itemError, instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType }, msg);
+						log.warn(
+							{ err: itemError, instanceId, tmdbId: agg.tmdbId, mediaType: agg.mediaType },
+							msg,
+						);
 					}
 				}
 			}

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -151,7 +151,9 @@ export async function refreshPlexEpisodeCache(
 						);
 					}
 					if (errorMessages.length < 5) {
-						errorMessages.push(`Failed to upsert S${episode.seasonNumber}E${episode.episodeNumber}: ${getErrorMessage(err)}`);
+						errorMessages.push(
+							`Failed to upsert S${episode.seasonNumber}E${episode.episodeNumber}: ${getErrorMessage(err)}`,
+						);
 					}
 				}
 			}
@@ -159,7 +161,9 @@ export async function refreshPlexEpisodeCache(
 			errors++;
 			log.warn({ err, instanceId, tmdbId, showRatingKey }, "Failed to fetch episodes for show");
 			if (errorMessages.length < 5) {
-				errorMessages.push(`Failed to fetch episodes for show tmdb:${tmdbId}: ${getErrorMessage(err)}`);
+				errorMessages.push(
+					`Failed to fetch episodes for show tmdb:${tmdbId}: ${getErrorMessage(err)}`,
+				);
 			}
 		}
 	}

--- a/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-arr.test.ts
@@ -26,13 +26,15 @@ const mockLog = {
 	child: () => mockLog,
 } as unknown as FastifyBaseLogger;
 
-function makeInstance(overrides: Partial<{
-	id: string;
-	label: string;
-	service: string;
-	baseUrl: string;
-	storageGroupId: string | null;
-}> = {}) {
+function makeInstance(
+	overrides: Partial<{
+		id: string;
+		label: string;
+		service: string;
+		baseUrl: string;
+		storageGroupId: string | null;
+	}> = {},
+) {
 	return {
 		id: "inst-lidarr-1",
 		label: "Lidarr",
@@ -76,18 +78,22 @@ function makeLidarrClient(overrides: {
 			: vi.fn().mockResolvedValue(overrides.healthResult ?? []),
 	};
 	(client as unknown as Record<string, unknown>).diskSpace = {
-		get: vi.fn().mockResolvedValue(overrides.diskResult ?? [
-			{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 },
-		]),
+		get: vi
+			.fn()
+			.mockResolvedValue(
+				overrides.diskResult ?? [{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 }],
+			),
 	};
 	return client;
 }
 
-function makeSonarrClient(overrides: {
-	healthResult?: Array<{ type: string; message: string; source?: string }>;
-	healthError?: boolean;
-	diskResult?: Array<{ totalSpace: number; freeSpace: number }>;
-} = {}): SonarrClient {
+function makeSonarrClient(
+	overrides: {
+		healthResult?: Array<{ type: string; message: string; source?: string }>;
+		healthError?: boolean;
+		diskResult?: Array<{ totalSpace: number; freeSpace: number }>;
+	} = {},
+): SonarrClient {
 	const client = Object.create(SonarrClient.prototype) as SonarrClient;
 	(client as unknown as Record<string, unknown>).health = {
 		getAll: overrides.healthError
@@ -95,9 +101,11 @@ function makeSonarrClient(overrides: {
 			: vi.fn().mockResolvedValue(overrides.healthResult ?? []),
 	};
 	(client as unknown as Record<string, unknown>).diskSpace = {
-		getAll: vi.fn().mockResolvedValue(overrides.diskResult ?? [
-			{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 },
-		]),
+		getAll: vi
+			.fn()
+			.mockResolvedValue(
+				overrides.diskResult ?? [{ totalSpace: 1_000_000_000_000, freeSpace: 500_000_000_000 }],
+			),
 	};
 	return client;
 }
@@ -133,14 +141,20 @@ describe("collectArrSignals — Lidarr", () => {
 		const client = makeLidarrClient({
 			healthResult: [
 				{ type: "error", message: "Indexer unavailable", source: "IndexerLongTermStatusCheck" },
-				{ type: "warning", message: "No download client configured", source: "DownloadClientCheck" },
+				{
+					type: "warning",
+					message: "No download client configured",
+					source: "DownloadClientCheck",
+				},
 			],
 		});
 		const app = makeMockApp(makeInstance({ label: "My Lidarr" }), client);
 
 		const items = await collectArrSignals(app, "user-1", mockLog);
 
-		const healthItems = items.filter((i) => i.category === "health" && !i.id.startsWith("arr-unreachable-"));
+		const healthItems = items.filter(
+			(i) => i.category === "health" && !i.id.startsWith("arr-unreachable-"),
+		);
 		expect(healthItems).toHaveLength(2);
 
 		const errorItem = healthItems.find((i) => i.severity === "critical");
@@ -156,7 +170,8 @@ describe("collectArrSignals — Lidarr", () => {
 
 		await collectArrSignals(app, "user-1", mockLog);
 
-		const healthGet = (client as unknown as { health: { get: ReturnType<typeof vi.fn> } }).health.get;
+		const healthGet = (client as unknown as { health: { get: ReturnType<typeof vi.fn> } }).health
+			.get;
 		expect(healthGet).toHaveBeenCalledOnce();
 	});
 });
@@ -168,7 +183,10 @@ describe("collectArrSignals — Lidarr", () => {
 describe("collectArrSignals — Sonarr", () => {
 	it("does NOT emit unreachable signal when Sonarr is healthy", async () => {
 		const client = makeSonarrClient({ healthResult: [] });
-		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+		const app = makeMockApp(
+			makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }),
+			client,
+		);
 
 		const items = await collectArrSignals(app, "user-1", mockLog);
 
@@ -178,7 +196,10 @@ describe("collectArrSignals — Sonarr", () => {
 
 	it("emits unreachable signal when Sonarr health.getAll() throws", async () => {
 		const client = makeSonarrClient({ healthError: true });
-		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr Main", service: "SONARR" }), client);
+		const app = makeMockApp(
+			makeInstance({ id: "inst-sonarr-1", label: "Sonarr Main", service: "SONARR" }),
+			client,
+		);
 
 		const items = await collectArrSignals(app, "user-1", mockLog);
 
@@ -191,7 +212,10 @@ describe("collectArrSignals — Sonarr", () => {
 		const client = makeSonarrClient({
 			healthResult: [{ type: "error", message: "Root folder missing" }],
 		});
-		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+		const app = makeMockApp(
+			makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }),
+			client,
+		);
 
 		const items = await collectArrSignals(app, "user-1", mockLog);
 
@@ -203,11 +227,15 @@ describe("collectArrSignals — Sonarr", () => {
 
 	it("calls health.getAll() — not health.get() — on SonarrClient", async () => {
 		const client = makeSonarrClient({ healthResult: [] });
-		const app = makeMockApp(makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }), client);
+		const app = makeMockApp(
+			makeInstance({ id: "inst-sonarr-1", label: "Sonarr", service: "SONARR" }),
+			client,
+		);
 
 		await collectArrSignals(app, "user-1", mockLog);
 
-		const healthGetAll = (client as unknown as { health: { getAll: ReturnType<typeof vi.fn> } }).health.getAll;
+		const healthGetAll = (client as unknown as { health: { getAll: ReturnType<typeof vi.fn> } })
+			.health.getAll;
 		expect(healthGetAll).toHaveBeenCalledOnce();
 	});
 });

--- a/apps/api/src/lib/queue-cleaner/auto-import-integration.test.ts
+++ b/apps/api/src/lib/queue-cleaner/auto-import-integration.test.ts
@@ -166,7 +166,7 @@ describe("Auto-Import Integration", () => {
 				action: "remove",
 				autoImportEligible: !neverMatch && !!safeMatch,
 				autoImportReason:
-					!neverMatch && !!safeMatch
+					!neverMatch && safeMatch
 						? "Eligible for auto-import"
 						: neverMatch
 							? `Cannot auto-import: ${neverMatch}`

--- a/apps/api/src/lib/qui/__tests__/action-service.test.ts
+++ b/apps/api/src/lib/qui/__tests__/action-service.test.ts
@@ -56,7 +56,6 @@ function makeApp(opts: { txReturn?: { id: string }[] } = {}) {
 		__create: create,
 		__updateMany: updateMany,
 		__transaction: $transaction,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/qui/__tests__/activity-log.test.ts
+++ b/apps/api/src/lib/qui/__tests__/activity-log.test.ts
@@ -26,7 +26,6 @@ function makeApp() {
 		__create: create,
 		__findFirst: findFirst,
 		__deleteMany: deleteMany,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 
@@ -69,7 +68,6 @@ describe("logQuiActivity", () => {
 			userId: "user-1",
 			eventType: "qui_sync_complete",
 			details: {},
-			// biome-ignore lint/suspicious/noExplicitAny: testing the deprecated alias
 			status: "warn" as any,
 		});
 		// The alias should map to the canonical `severity` Prisma field.

--- a/apps/api/src/lib/qui/__tests__/cross-seed-discovery.test.ts
+++ b/apps/api/src/lib/qui/__tests__/cross-seed-discovery.test.ts
@@ -36,7 +36,6 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 			},
 		},
 		...overrides,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -46,7 +46,6 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 		__findMany: serviceInstanceFindMany,
 		__libraryCacheFindMany: libraryCacheFindMany,
 		...overrides,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/seerr/__tests__/seerr-circuit-breaker.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-circuit-breaker.test.ts
@@ -3,10 +3,7 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-	CircuitBreakerOpenError,
-	SeerrCircuitBreaker,
-} from "../seerr-circuit-breaker.js";
+import { CircuitBreakerOpenError, SeerrCircuitBreaker } from "../seerr-circuit-breaker.js";
 
 let breaker: SeerrCircuitBreaker;
 

--- a/apps/api/src/lib/seerr/__tests__/seerr-retry.test.ts
+++ b/apps/api/src/lib/seerr/__tests__/seerr-retry.test.ts
@@ -25,22 +25,18 @@ describe("withSeerrRetry", () => {
 	});
 
 	it("does NOT retry on 404 (non-retryable)", async () => {
-		const fn = vi
-			.fn()
-			.mockRejectedValue(new SeerrApiError("404", { seerrStatus: 404 }));
-		await expect(
-			withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 }),
-		).rejects.toThrow(SeerrApiError);
+		const fn = vi.fn().mockRejectedValue(new SeerrApiError("404", { seerrStatus: 404 }));
+		await expect(withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 })).rejects.toThrow(
+			SeerrApiError,
+		);
 		expect(fn).toHaveBeenCalledTimes(1);
 	});
 
 	it("exhausts max attempts then throws", async () => {
-		const fn = vi
-			.fn()
-			.mockRejectedValue(new SeerrApiError("500", { seerrStatus: 500 }));
-		await expect(
-			withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 }),
-		).rejects.toThrow(SeerrApiError);
+		const fn = vi.fn().mockRejectedValue(new SeerrApiError("500", { seerrStatus: 500 }));
+		await expect(withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 })).rejects.toThrow(
+			SeerrApiError,
+		);
 		expect(fn).toHaveBeenCalledTimes(3);
 	});
 
@@ -49,10 +45,7 @@ describe("withSeerrRetry", () => {
 			seerrStatus: 429,
 			retryAfterMs: 50, // 50ms
 		});
-		const fn = vi
-			.fn()
-			.mockRejectedValueOnce(err429)
-			.mockResolvedValue("ok");
+		const fn = vi.fn().mockRejectedValueOnce(err429).mockResolvedValue("ok");
 
 		const start = Date.now();
 		const result = await withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 });
@@ -64,10 +57,7 @@ describe("withSeerrRetry", () => {
 
 	it("retries on network errors", async () => {
 		const networkErr = new Error("fetch failed: ECONNREFUSED");
-		const fn = vi
-			.fn()
-			.mockRejectedValueOnce(networkErr)
-			.mockResolvedValue("ok");
+		const fn = vi.fn().mockRejectedValueOnce(networkErr).mockResolvedValue("ok");
 		const result = await withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 });
 		expect(result).toBe("ok");
 		expect(fn).toHaveBeenCalledTimes(2);
@@ -75,9 +65,9 @@ describe("withSeerrRetry", () => {
 
 	it("does not retry non-retryable non-SeerrApiError", async () => {
 		const fn = vi.fn().mockRejectedValue(new Error("something unrelated"));
-		await expect(
-			withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 }),
-		).rejects.toThrow("something unrelated");
+		await expect(withSeerrRetry(fn, { maxAttempts: 3, baseDelayMs: 1 })).rejects.toThrow(
+			"something unrelated",
+		);
 		expect(fn).toHaveBeenCalledTimes(1);
 	});
 

--- a/apps/api/src/lib/services/connection-tester.ts
+++ b/apps/api/src/lib/services/connection-tester.ts
@@ -589,7 +589,7 @@ async function testJellyfinConnection(
 				details: "Invalid API key. Generate one in Jellyfin Dashboard > API Keys.",
 			};
 		}
-	} catch (authErr) {
+	} catch {
 		return {
 			success: false,
 			error: "API key validation failed",

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -136,7 +136,9 @@ export async function refreshTautulliCache(
 				errors++;
 				log.warn({ err: error, ratingKey }, "Tautulli cache: failed to fetch metadata for item");
 				if (errorMessages.length < 5) {
-					errorMessages.push(`Failed to fetch metadata for ratingKey ${ratingKey}: ${getErrorMessage(error)}`);
+					errorMessages.push(
+						`Failed to fetch metadata for ratingKey ${ratingKey}: ${getErrorMessage(error)}`,
+					);
 				}
 			}
 		}
@@ -179,7 +181,9 @@ export async function refreshTautulliCache(
 					"Tautulli cache: failed to upsert item",
 				);
 				if (errorMessages.length < 5) {
-					errorMessages.push(`Failed to upsert tmdb:${guid.tmdbId} (${guid.mediaType}): ${getErrorMessage(error)}`);
+					errorMessages.push(
+						`Failed to upsert tmdb:${guid.tmdbId} (${guid.mediaType}): ${getErrorMessage(error)}`,
+					);
 				}
 			}
 		}

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -17,7 +17,7 @@ type SdkSpecification = NonNullable<SdkCustomFormat["specifications"]>[number];
 // Helper to create a specification with array-format fields (SDK format)
 const createSpecWithArrayFields = (
 	name: string,
-	fields: Array<{ name: string; value: unknown }>
+	fields: Array<{ name: string; value: unknown }>,
 ): SdkSpecification => ({
 	name,
 	implementation: "test",
@@ -29,7 +29,7 @@ const createSpecWithArrayFields = (
 // Helper to create a specification with object-format fields (TRaSH format, cast for testing)
 const createSpecWithObjectFields = (
 	name: string,
-	fields: Record<string, unknown>
+	fields: Record<string, unknown>,
 ): SdkSpecification => ({
 	name,
 	implementation: "test",
@@ -40,7 +40,6 @@ const createSpecWithObjectFields = (
 });
 
 describe("extractTrashId", () => {
-
 	it("should extract trash_id from array format fields", () => {
 		const cf: SdkCustomFormat = {
 			id: 1,
@@ -78,9 +77,7 @@ describe("extractTrashId", () => {
 			id: 1,
 			name: "Test CF Without Trash ID",
 			specifications: [
-				createSpecWithArrayFields("test", [
-					{ name: "other_field", value: "other_value" },
-				]),
+				createSpecWithArrayFields("test", [{ name: "other_field", value: "other_value" }]),
 			],
 		};
 
@@ -142,15 +139,9 @@ describe("extractTrashId", () => {
 			id: 1,
 			name: "Test CF",
 			specifications: [
-				createSpecWithArrayFields("test1", [
-					{ name: "other_field", value: "value" },
-				]),
-				createSpecWithArrayFields("test2", [
-					{ name: "trash_id", value: "first-uuid" },
-				]),
-				createSpecWithArrayFields("test3", [
-					{ name: "trash_id", value: "second-uuid" },
-				]),
+				createSpecWithArrayFields("test1", [{ name: "other_field", value: "value" }]),
+				createSpecWithArrayFields("test2", [{ name: "trash_id", value: "first-uuid" }]),
+				createSpecWithArrayFields("test3", [{ name: "trash_id", value: "second-uuid" }]),
 			],
 		};
 
@@ -162,11 +153,7 @@ describe("extractTrashId", () => {
 		const cf: SdkCustomFormat = {
 			id: 1,
 			name: "Test CF",
-			specifications: [
-				createSpecWithArrayFields("test", [
-					{ name: "trash_id", value: 12345 },
-				]),
-			],
+			specifications: [createSpecWithArrayFields("test", [{ name: "trash_id", value: 12345 }])],
 		};
 
 		const trashId = extractTrashId(cf);
@@ -179,11 +166,7 @@ describe("extractTrashId", () => {
 		const cfWithoutId: SdkCustomFormat = {
 			id: 1,
 			name: "My Custom Format",
-			specifications: [
-				createSpecWithArrayFields("test", [
-					{ name: "some_field", value: "value" },
-				]),
-			],
+			specifications: [createSpecWithArrayFields("test", [{ name: "some_field", value: "value" }])],
 		};
 
 		const trashId = extractTrashId(cfWithoutId);
@@ -232,35 +215,19 @@ describe("Quality Format Reversal (TRaSH Guides PR #2590)", () => {
 
 		it("should reverse items for API compatibility (PR #2590 merged)", () => {
 			// TRaSH NEW format: low→high (Unknown → Remux)
-			const items = [
-				{ name: "Unknown" },
-				{ name: "DVD" },
-				{ name: "Remux" },
-			];
+			const items = [{ name: "Unknown" }, { name: "DVD" }, { name: "Remux" }];
 			const result = reverseQualityItemsIfNeeded(items);
 
 			// Reversed for API: high→low (Remux → Unknown)
 			expect(result).not.toBe(items);
-			expect(result).toEqual([
-				{ name: "Remux" },
-				{ name: "DVD" },
-				{ name: "Unknown" },
-			]);
+			expect(result).toEqual([{ name: "Remux" }, { name: "DVD" }, { name: "Unknown" }]);
 		});
 
 		it("should reverse items and create a new array", () => {
-			const newFormatItems = [
-				{ name: "Unknown" },
-				{ name: "DVD" },
-				{ name: "Remux" },
-			];
+			const newFormatItems = [{ name: "Unknown" }, { name: "DVD" }, { name: "Remux" }];
 			const result = reverseQualityItemsIfNeeded(newFormatItems);
 
-			expect(result).toEqual([
-				{ name: "Remux" },
-				{ name: "DVD" },
-				{ name: "Unknown" },
-			]);
+			expect(result).toEqual([{ name: "Remux" }, { name: "DVD" }, { name: "Unknown" }]);
 			// New array created, original untouched
 			expect(result).not.toBe(newFormatItems);
 		});
@@ -308,9 +275,7 @@ describe("DeploymentExecutorService - ID-based vs name-based matching", () => {
 			id: 1,
 			name: "CF With ID",
 			specifications: [
-				createSpecWithArrayFields("test", [
-					{ name: "trash_id", value: "uuid-123" },
-				]),
+				createSpecWithArrayFields("test", [{ name: "trash_id", value: "uuid-123" }]),
 			],
 		};
 
@@ -319,9 +284,7 @@ describe("DeploymentExecutorService - ID-based vs name-based matching", () => {
 			id: 2,
 			name: "CF Without ID",
 			specifications: [
-				createSpecWithArrayFields("test", [
-					{ name: "other_field", value: "value" },
-				]),
+				createSpecWithArrayFields("test", [{ name: "other_field", value: "value" }]),
 			],
 		};
 
@@ -329,9 +292,7 @@ describe("DeploymentExecutorService - ID-based vs name-based matching", () => {
 		const mockExtractTrashId = (cf: SdkCustomFormat): string | null => {
 			for (const spec of cf.specifications || []) {
 				if (spec.fields && Array.isArray(spec.fields)) {
-					const trashIdField = spec.fields.find(
-						(f) => f.name === "trash_id"
-					);
+					const trashIdField = spec.fields.find((f) => f.name === "trash_id");
 					if (trashIdField) {
 						return String(trashIdField.value);
 					}

--- a/apps/api/src/lib/trash-guides/__tests__/naming-deployer.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/naming-deployer.test.ts
@@ -55,7 +55,9 @@ const SONARR_NAMING: TrashSonarrNaming = {
 };
 
 // Helpers to build full preset objects (all fields required as string | null)
-function radarrPresets(overrides: Partial<Omit<RadarrSelectedPresets, "serviceType">> = {}): RadarrSelectedPresets {
+function radarrPresets(
+	overrides: Partial<Omit<RadarrSelectedPresets, "serviceType">> = {},
+): RadarrSelectedPresets {
 	return {
 		serviceType: "RADARR",
 		filePreset: null,
@@ -64,7 +66,9 @@ function radarrPresets(overrides: Partial<Omit<RadarrSelectedPresets, "serviceTy
 	};
 }
 
-function sonarrPresets(overrides: Partial<Omit<SonarrSelectedPresets, "serviceType">> = {}): SonarrSelectedPresets {
+function sonarrPresets(
+	overrides: Partial<Omit<SonarrSelectedPresets, "serviceType">> = {},
+): SonarrSelectedPresets {
 	return {
 		serviceType: "SONARR",
 		standardEpisodePreset: null,

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine.test.ts
@@ -11,14 +11,16 @@ import type { ArrClientFactory } from "../../arr/client-factory.js";
 import { SyncEngine, type SyncOptions } from "../sync-engine.js";
 
 // Create mock template
-const createMockTemplate = (overrides: Partial<{
-	id: string;
-	userId: string;
-	serviceType: string;
-	hasUserModifications: boolean;
-	configData: string;
-	deletedAt: Date | null;
-}> = {}) => ({
+const createMockTemplate = (
+	overrides: Partial<{
+		id: string;
+		userId: string;
+		serviceType: string;
+		hasUserModifications: boolean;
+		configData: string;
+		deletedAt: Date | null;
+	}> = {},
+) => ({
 	id: "template-123",
 	userId: "user-123",
 	serviceType: "RADARR",
@@ -33,15 +35,17 @@ const createMockTemplate = (overrides: Partial<{
 });
 
 // Create mock instance
-const createMockInstance = (overrides: Partial<{
-	id: string;
-	userId: string;
-	service: string;
-	label: string;
-	baseUrl: string;
-	encryptedApiKey: string;
-	encryptionIv: string;
-}> = {}) => ({
+const createMockInstance = (
+	overrides: Partial<{
+		id: string;
+		userId: string;
+		service: string;
+		label: string;
+		baseUrl: string;
+		encryptedApiKey: string;
+		encryptionIv: string;
+	}> = {},
+) => ({
 	id: "instance-123",
 	userId: "user-123",
 	service: "RADARR",
@@ -56,11 +60,13 @@ const createMockInstance = (overrides: Partial<{
 });
 
 // Create mock quality profile mapping
-const createMockMapping = (overrides: Partial<{
-	templateId: string;
-	instanceId: string;
-	qualityProfileId: number;
-}> = {}) => ({
+const createMockMapping = (
+	overrides: Partial<{
+		templateId: string;
+		instanceId: string;
+		qualityProfileId: number;
+	}> = {},
+) => ({
 	id: "mapping-123",
 	templateId: "template-123",
 	instanceId: "instance-123",
@@ -70,23 +76,28 @@ const createMockMapping = (overrides: Partial<{
 });
 
 // Create mock Prisma client
-const createMockPrisma = (overrides: {
-	template?: ReturnType<typeof createMockTemplate> | null;
-	instance?: ReturnType<typeof createMockInstance> | null;
-	mappings?: ReturnType<typeof createMockMapping>[];
-	cache?: { configData: string; lastModified: Date; updatedAt: Date } | null;
-} = {}): PrismaClient => {
+const createMockPrisma = (
+	overrides: {
+		template?: ReturnType<typeof createMockTemplate> | null;
+		instance?: ReturnType<typeof createMockInstance> | null;
+		mappings?: ReturnType<typeof createMockMapping>[];
+		cache?: { configData: string; lastModified: Date; updatedAt: Date } | null;
+	} = {},
+): PrismaClient => {
 	// Use "in" check to properly handle null values being passed explicitly
 	const template = "template" in overrides ? overrides.template : createMockTemplate();
 	const instance = "instance" in overrides ? overrides.instance : createMockInstance();
 	const mappings = overrides.mappings ?? [createMockMapping()];
-	const cache = "cache" in overrides ? overrides.cache : {
-		configData: JSON.stringify({
-			customFormats: [{ trashId: "cf-1", name: "Test CF" }],
-		}),
-		lastModified: new Date(),
-		updatedAt: new Date(),
-	};
+	const cache =
+		"cache" in overrides
+			? overrides.cache
+			: {
+					configData: JSON.stringify({
+						customFormats: [{ trashId: "cf-1", name: "Test CF" }],
+					}),
+					lastModified: new Date(),
+					updatedAt: new Date(),
+				};
 
 	return {
 		trashTemplate: {
@@ -105,12 +116,14 @@ const createMockPrisma = (overrides: {
 };
 
 // Create mock ARR client factory
-const createMockClientFactory = (overrides: {
-	status?: { version: string };
-	profiles?: Array<{ id: number; name: string }>;
-	connectError?: Error;
-	profileError?: Error;
-} = {}): ArrClientFactory => {
+const createMockClientFactory = (
+	overrides: {
+		status?: { version: string };
+		profiles?: Array<{ id: number; name: string }>;
+		connectError?: Error;
+		profileError?: Error;
+	} = {},
+): ArrClientFactory => {
 	const mockClient = {
 		system: {
 			// Note: SDK uses get() not getStatus()
@@ -298,9 +311,7 @@ describe("SyncEngine - validate()", () => {
 			});
 			const engine = new SyncEngine(prisma);
 
-			const result = await engine.validate(
-				createSyncOptions({ syncType: "SCHEDULED" }),
-			);
+			const result = await engine.validate(createSyncOptions({ syncType: "SCHEDULED" }));
 
 			expect(result.valid).toBe(false);
 			expect(result.errors[0]).toContain("Auto-sync is blocked");
@@ -314,9 +325,7 @@ describe("SyncEngine - validate()", () => {
 			const factory = createMockClientFactory();
 			const engine = new SyncEngine(prisma, undefined, undefined, factory);
 
-			const result = await engine.validate(
-				createSyncOptions({ syncType: "MANUAL" }),
-			);
+			const result = await engine.validate(createSyncOptions({ syncType: "MANUAL" }));
 
 			// Should not have the auto-sync blocking error
 			expect(result.errors.filter((e) => e.includes("Auto-sync is blocked"))).toHaveLength(0);
@@ -331,9 +340,7 @@ describe("SyncEngine - validate()", () => {
 			const factory = createMockClientFactory();
 			const engine = new SyncEngine(prisma, undefined, undefined, factory);
 
-			const result = await engine.validate(
-				createSyncOptions({ syncType: "SCHEDULED" }),
-			);
+			const result = await engine.validate(createSyncOptions({ syncType: "SCHEDULED" }));
 
 			// Should not have modification-related errors
 			expect(result.errors.filter((e) => e.includes("modifications"))).toHaveLength(0);
@@ -364,7 +371,9 @@ describe("SyncEngine - validate()", () => {
 
 			const result = await engine.validate(createSyncOptions());
 
-			expect(result.warnings.some((w) => w.includes("reachable") && w.includes("v4.5.0"))).toBe(true);
+			expect(result.warnings.some((w) => w.includes("reachable") && w.includes("v4.5.0"))).toBe(
+				true,
+			);
 		});
 
 		it("should skip connectivity check when factory is not provided", async () => {
@@ -386,7 +395,9 @@ describe("SyncEngine - validate()", () => {
 
 			const result = await engine.validate(createSyncOptions());
 
-			expect(result.warnings.some((w) => w.includes("Could not fetch quality profiles"))).toBe(true);
+			expect(result.warnings.some((w) => w.includes("Could not fetch quality profiles"))).toBe(
+				true,
+			);
 			// Should still be valid if other checks pass
 		});
 	});
@@ -401,7 +412,9 @@ describe("SyncEngine - validate()", () => {
 
 			const result = await engine.validate(createSyncOptions());
 
-			expect(result.warnings.some((w) => w.includes("older version") && w.includes("v3.2.1"))).toBe(true);
+			expect(result.warnings.some((w) => w.includes("older version") && w.includes("v3.2.1"))).toBe(
+				true,
+			);
 		});
 
 		it("should not warn when instance version is v4 or higher", async () => {
@@ -428,7 +441,9 @@ describe("SyncEngine - validate()", () => {
 			const result = await engine.validate(createSyncOptions());
 
 			expect(result.valid).toBe(false);
-			expect(result.errors.some((e) => e.includes("corrupted") || e.includes("Unexpected token"))).toBe(true);
+			expect(
+				result.errors.some((e) => e.includes("corrupted") || e.includes("Unexpected token")),
+			).toBe(true);
 		});
 
 		it("should return error when configData is missing customFormats", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/user-cf-resolver.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/user-cf-resolver.test.ts
@@ -45,9 +45,17 @@ function createUserCF(overrides: {
 		name: overrides.name,
 		userId: overrides.userId ?? "test-user",
 		serviceType: "RADARR" as const,
-		specifications: overrides.specifications ?? JSON.stringify([
-			{ name: "TestSpec", implementation: "ReleaseTitleSpecification", negate: false, required: false, fields: { value: "test" } },
-		]),
+		specifications:
+			overrides.specifications ??
+			JSON.stringify([
+				{
+					name: "TestSpec",
+					implementation: "ReleaseTitleSpecification",
+					negate: false,
+					required: false,
+					fields: { value: "test" },
+				},
+			]),
 		defaultScore: overrides.defaultScore ?? 100,
 		includeCustomFormatWhenRenaming: overrides.includeCustomFormatWhenRenaming ?? false,
 		createdAt: new Date(),
@@ -56,7 +64,11 @@ function createUserCF(overrides: {
 }
 
 /** Create a selection map entry */
-function sel(selected: boolean, scoreOverride?: number, conditionsEnabled: Record<string, boolean> = {}): CFSelection {
+function sel(
+	selected: boolean,
+	scoreOverride?: number,
+	conditionsEnabled: Record<string, boolean> = {},
+): CFSelection {
 	return { selected, scoreOverride, conditionsEnabled };
 }
 
@@ -259,10 +271,26 @@ describe("resolveUserCustomFormats", () => {
 	describe("specifications parsing", () => {
 		it("parses valid JSON array specifications", async () => {
 			const specs = [
-				{ name: "Spec1", implementation: "ReleaseTitleSpecification", negate: false, required: false, fields: { value: "test" } },
-				{ name: "Spec2", implementation: "SizeSpecification", negate: true, required: true, fields: { min: 0, max: 100 } },
+				{
+					name: "Spec1",
+					implementation: "ReleaseTitleSpecification",
+					negate: false,
+					required: false,
+					fields: { value: "test" },
+				},
+				{
+					name: "Spec2",
+					implementation: "SizeSpecification",
+					negate: true,
+					required: true,
+					fields: { min: 0, max: 100 },
+				},
 			];
-			const userCF = createUserCF({ id: "cf1", name: "My CF", specifications: JSON.stringify(specs) });
+			const userCF = createUserCF({
+				id: "cf1",
+				name: "My CF",
+				specifications: JSON.stringify(specs),
+			});
 			mockPrisma = createMockPrisma([userCF]);
 
 			const result = await resolveUserCustomFormats(
@@ -279,7 +307,11 @@ describe("resolveUserCustomFormats", () => {
 		});
 
 		it("skips CF with malformed JSON and logs warning", async () => {
-			const userCF = createUserCF({ id: "cf1", name: "Bad JSON", specifications: "not-valid-json" });
+			const userCF = createUserCF({
+				id: "cf1",
+				name: "Bad JSON",
+				specifications: "not-valid-json",
+			});
 			mockPrisma = createMockPrisma([userCF]);
 
 			const result = await resolveUserCustomFormats(
@@ -297,7 +329,11 @@ describe("resolveUserCustomFormats", () => {
 		});
 
 		it("skips CF when JSON is an object instead of array", async () => {
-			const userCF = createUserCF({ id: "cf1", name: "Object Specs", specifications: '{"key": "value"}' });
+			const userCF = createUserCF({
+				id: "cf1",
+				name: "Object Specs",
+				specifications: '{"key": "value"}',
+			});
 			mockPrisma = createMockPrisma([userCF]);
 
 			const result = await resolveUserCustomFormats(
@@ -315,7 +351,11 @@ describe("resolveUserCustomFormats", () => {
 		});
 
 		it("skips CF when JSON is a primitive string", async () => {
-			const userCF = createUserCF({ id: "cf1", name: "String Specs", specifications: '"just a string"' });
+			const userCF = createUserCF({
+				id: "cf1",
+				name: "String Specs",
+				specifications: '"just a string"',
+			});
 			mockPrisma = createMockPrisma([userCF]);
 
 			const result = await resolveUserCustomFormats(
@@ -350,13 +390,29 @@ describe("resolveUserCustomFormats", () => {
 
 		it("filters out array elements that don't match specification shape and logs warning", async () => {
 			const mixedSpecs = [
-				{ name: "Valid", implementation: "ReleaseTitleSpecification", negate: false, required: false, fields: {} },
+				{
+					name: "Valid",
+					implementation: "ReleaseTitleSpecification",
+					negate: false,
+					required: false,
+					fields: {},
+				},
 				"not an object",
 				42,
 				null,
-				{ name: "Also Valid", implementation: "SizeSpecification", negate: true, required: true, fields: {} },
+				{
+					name: "Also Valid",
+					implementation: "SizeSpecification",
+					negate: true,
+					required: true,
+					fields: {},
+				},
 			];
-			const userCF = createUserCF({ id: "cf1", name: "Mixed", specifications: JSON.stringify(mixedSpecs) });
+			const userCF = createUserCF({
+				id: "cf1",
+				name: "Mixed",
+				specifications: JSON.stringify(mixedSpecs),
+			});
 			mockPrisma = createMockPrisma([userCF]);
 
 			const result = await resolveUserCustomFormats(
@@ -446,12 +502,14 @@ describe("resolveUserCustomFormats", () => {
 			);
 
 			expect(result[0]!.name).toBe("Premium CF");
-			expect(result[0]!.originalConfig).toEqual(expect.objectContaining({
-				trash_id: "user-cf1",
-				name: "Premium CF",
-				includeCustomFormatWhenRenaming: true,
-				trash_scores: { default: 500 },
-			}));
+			expect(result[0]!.originalConfig).toEqual(
+				expect.objectContaining({
+					trash_id: "user-cf1",
+					name: "Premium CF",
+					includeCustomFormatWhenRenaming: true,
+					trash_scores: { default: 500 },
+				}),
+			);
 		});
 
 		it("uses the synthetic trash_id (user-{id}) in both trashId and originalConfig", async () => {

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -28,7 +28,6 @@ const log = loggers.trashGuides;
 // SDK type aliases
 type SdkCustomFormat = Awaited<ReturnType<SonarrClient["customFormat"]["getAll"]>>[number];
 
-
 // ============================================================================
 // Bulk Score Manager Class
 // ============================================================================

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -352,12 +352,10 @@ export class DeploymentExecutorService {
 				}
 
 				if (existingCF?.id) {
-					const specifications = (templateCF.originalConfig?.specifications || []).map(
-						(spec) => ({
-							...spec,
-							fields: transformFieldsToArray(spec.fields),
-						}),
-					);
+					const specifications = (templateCF.originalConfig?.specifications || []).map((spec) => ({
+						...spec,
+						fields: transformFieldsToArray(spec.fields),
+					}));
 
 					const updatedCF = {
 						...existingCF,
@@ -372,12 +370,10 @@ export class DeploymentExecutorService {
 					updated++;
 					details.updated.push(templateCF.name);
 				} else {
-					const specifications = (templateCF.originalConfig?.specifications || []).map(
-						(spec) => ({
-							...spec,
-							fields: transformFieldsToArray(spec.fields),
-						}),
-					);
+					const specifications = (templateCF.originalConfig?.specifications || []).map((spec) => ({
+						...spec,
+						fields: transformFieldsToArray(spec.fields),
+					}));
 
 					const newCF = {
 						name: templateCF.name,
@@ -1049,7 +1045,10 @@ export class DeploymentExecutorService {
 					}
 				}
 			} catch (conflictCheckError) {
-				log.debug({ err: conflictCheckError }, "CF conflict check skipped — data may not be cached");
+				log.debug(
+					{ err: conflictCheckError },
+					"CF conflict check skipped — data may not be cached",
+				);
 			}
 
 			cfResult.details.orphaned = profileResult.orphanedCFs;

--- a/apps/api/src/lib/trash-guides/sync-metrics.ts
+++ b/apps/api/src/lib/trash-guides/sync-metrics.ts
@@ -258,4 +258,3 @@ export function getSyncMetrics(): SyncMetricsService {
 	}
 	return metricsInstance;
 }
-

--- a/apps/api/src/lib/trash-guides/utils.ts
+++ b/apps/api/src/lib/trash-guides/utils.ts
@@ -102,4 +102,3 @@ export function parseInstanceOverrides(
 		return {};
 	}
 }
-

--- a/apps/api/src/lib/validation/__tests__/client-health-recording.test.ts
+++ b/apps/api/src/lib/validation/__tests__/client-health-recording.test.ts
@@ -76,7 +76,11 @@ describe("Client health recording pattern", () => {
 
 			const health = integrationHealth.getByIntegration("plex");
 			expect(health).toBeDefined();
-			expect(health!.categories["/library/sections"]).toEqual({ total: 1, validated: 1, rejected: 0 });
+			expect(health!.categories["/library/sections"]).toEqual({
+				total: 1,
+				validated: 1,
+				rejected: 0,
+			});
 		});
 
 		it("records failure on invalid Plex response", () => {
@@ -87,7 +91,11 @@ describe("Client health recording pattern", () => {
 			).toThrow();
 
 			const health = integrationHealth.getByIntegration("plex");
-			expect(health!.categories["/library/sections"]).toEqual({ total: 1, validated: 0, rejected: 1 });
+			expect(health!.categories["/library/sections"]).toEqual({
+				total: 1,
+				validated: 0,
+				rejected: 1,
+			});
 		});
 	});
 
@@ -118,7 +126,10 @@ describe("Client health recording pattern", () => {
 			const raw = { version: "2.0.0", commitTag: "abc123" };
 
 			const result = parseAndRecord<{ version: string; commitTag: string }>(
-				raw, seerrStatusSchema, "seerr", "getStatus",
+				raw,
+				seerrStatusSchema,
+				"seerr",
+				"getStatus",
 			);
 
 			expect(result.version).toBe("2.0.0");
@@ -144,7 +155,11 @@ describe("Client health recording pattern", () => {
 
 			parseAndRecord(valid, seerrStatusSchema, "seerr", "getStatus");
 			parseAndRecord(valid, seerrStatusSchema, "seerr", "getStatus");
-			try { parseAndRecord(invalid, seerrStatusSchema, "seerr", "getStatus"); } catch { /* expected */ }
+			try {
+				parseAndRecord(invalid, seerrStatusSchema, "seerr", "getStatus");
+			} catch {
+				/* expected */
+			}
 
 			const health = integrationHealth.getByIntegration("seerr");
 			expect(health!.categories.getStatus).toEqual({ total: 3, validated: 2, rejected: 1 });
@@ -155,7 +170,11 @@ describe("Client health recording pattern", () => {
 	describe("Cross-integration aggregation", () => {
 		it("getAll() aggregates health from all three clients", () => {
 			// Simulate typical operation: all three clients reporting health
-			integrationHealth.record("plex", "/library/sections", { total: 1, validated: 1, rejected: 0 });
+			integrationHealth.record("plex", "/library/sections", {
+				total: 1,
+				validated: 1,
+				rejected: 0,
+			});
 			integrationHealth.record("tautulli", "get_history", { total: 5, validated: 5, rejected: 0 });
 			integrationHealth.record("seerr", "getRequests", { total: 3, validated: 2, rejected: 1 });
 

--- a/apps/api/src/lib/validation/__tests__/github-fetcher-validation.test.ts
+++ b/apps/api/src/lib/validation/__tests__/github-fetcher-validation.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, expect, it } from "vitest";
 import { z } from "zod";
-import { githubDirectoryEntrySchema, trashMetadataSchema } from "../../trash-guides/github-fetcher.js";
+import {
+	githubDirectoryEntrySchema,
+	trashMetadataSchema,
+} from "../../trash-guides/github-fetcher.js";
 import { parseUpstreamOrThrow, UpstreamValidationError } from "../parse-upstream.js";
 
 describe("GitHub directory listing validation", () => {

--- a/apps/api/src/lib/validation/__tests__/integration-health.test.ts
+++ b/apps/api/src/lib/validation/__tests__/integration-health.test.ts
@@ -11,7 +11,11 @@ describe("IntegrationHealthRegistry", () => {
 
 		const health = integrationHealth.getByIntegration("plex");
 		expect(health).toBeDefined();
-		expect(health!.categories["/library/sections"]).toEqual({ total: 1, validated: 1, rejected: 0 });
+		expect(health!.categories["/library/sections"]).toEqual({
+			total: 1,
+			validated: 1,
+			rejected: 0,
+		});
 		expect(health!.totals).toEqual({ total: 1, validated: 1, rejected: 0 });
 		expect(health!.lastRefreshAt).toBeDefined();
 	});

--- a/apps/api/src/lib/validation/__tests__/parse-upstream.test.ts
+++ b/apps/api/src/lib/validation/__tests__/parse-upstream.test.ts
@@ -1,11 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { z } from "zod";
 import { integrationHealth } from "../integration-health.js";
-import {
-	UpstreamValidationError,
-	parseUpstream,
-	parseUpstreamOrThrow,
-} from "../parse-upstream.js";
+import { UpstreamValidationError, parseUpstream, parseUpstreamOrThrow } from "../parse-upstream.js";
 
 const schema = z.looseObject({
 	id: z.number(),

--- a/apps/api/src/lib/validation/__tests__/schema-fingerprint.test.ts
+++ b/apps/api/src/lib/validation/__tests__/schema-fingerprint.test.ts
@@ -180,7 +180,9 @@ describe("SchemaFingerprintRegistry", () => {
 	it("logs warning for new fields immediately", () => {
 		const warnings: string[] = [];
 		const logSpy = {
-			warn: (msg: string | object) => { warnings.push(String(msg)); },
+			warn: (msg: string | object) => {
+				warnings.push(String(msg));
+			},
 			error: () => {},
 		};
 
@@ -195,7 +197,9 @@ describe("SchemaFingerprintRegistry", () => {
 	it("logs warning for missing fields only after threshold", () => {
 		const warnings: string[] = [];
 		const logSpy = {
-			warn: (msg: string | object) => { warnings.push(String(msg)); },
+			warn: (msg: string | object) => {
+				warnings.push(String(msg));
+			},
 			error: () => {},
 		};
 

--- a/apps/api/src/lib/validation/__tests__/upstream-fixtures.test.ts
+++ b/apps/api/src/lib/validation/__tests__/upstream-fixtures.test.ts
@@ -177,16 +177,9 @@ const PLEX_LIBRARY_ITEMS_RESPONSE = {
 				year: 2014,
 				userRating: 9.5,
 				addedAt: 1600000000,
-				Guid: [
-					{ id: "imdb://tt0816692" },
-					{ id: "tmdb://157336" },
-				],
-				Collection: [
-					{ tag: "Christopher Nolan" },
-				],
-				Label: [
-					{ tag: "4K" },
-				],
+				Guid: [{ id: "imdb://tt0816692" }, { id: "tmdb://157336" }],
+				Collection: [{ tag: "Christopher Nolan" }],
+				Label: [{ tag: "4K" }],
 				// Extra fields
 				summary: "A team of explorers travel through a wormhole...",
 				contentRating: "PG-13",
@@ -560,10 +553,14 @@ describe("Upstream fixture regression tests", () => {
 		});
 
 		it("accepts get_home_stats rows missing total_plays/total_duration (defaults to 0)", () => {
-			const result = parseUpstream(TAUTULLI_HOME_STATS_MISSING_DURATION, z.array(tautulliHomeStatSchema), {
-				integration: "tautulli",
-				category: "get_home_stats",
-			});
+			const result = parseUpstream(
+				TAUTULLI_HOME_STATS_MISSING_DURATION,
+				z.array(tautulliHomeStatSchema),
+				{
+					integration: "tautulli",
+					category: "get_home_stats",
+				},
+			);
 			expect(result.success).toBe(true);
 			if (result.success) {
 				const row = result.data[0]!.rows[0]!;
@@ -593,17 +590,21 @@ describe("Upstream fixture regression tests", () => {
 		it("accumulates correct stats across multiple fixture validations", () => {
 			// Run several validations
 			parseUpstream(PLEX_IDENTITY_RESPONSE, plexIdentityResponseSchema, {
-				integration: "plex", category: "/identity",
+				integration: "plex",
+				category: "/identity",
 			});
 			parseUpstream(PLEX_SECTIONS_RESPONSE, plexSectionsResponseSchema, {
-				integration: "plex", category: "/library/sections",
+				integration: "plex",
+				category: "/library/sections",
 			});
 			parseUpstream(TAUTULLI_HISTORY_DATA, tautulliHistoryDataSchema, {
-				integration: "tautulli", category: "get_history",
+				integration: "tautulli",
+				category: "get_history",
 			});
 			// One failure
 			parseUpstream({ broken: true }, plexIdentityResponseSchema, {
-				integration: "plex", category: "/identity",
+				integration: "plex",
+				category: "/identity",
 			});
 
 			const all = integrationHealth.getAll();
@@ -622,7 +623,8 @@ describe("Upstream fixture regression tests", () => {
 	describe("Extra field tolerance (z.looseObject)", () => {
 		it("preserves extra fields in parsed output", () => {
 			const result = parseUpstream(PLEX_IDENTITY_RESPONSE, plexIdentityResponseSchema, {
-				integration: "plex", category: "/identity",
+				integration: "plex",
+				category: "/identity",
 			});
 			expect(result.success).toBe(true);
 			if (result.success) {
@@ -634,15 +636,20 @@ describe("Upstream fixture regression tests", () => {
 		});
 
 		it("would fail with z.object().strict() — confirms looseObject is needed", () => {
-			const strictSchema = z.object({
-				MediaContainer: z.object({
-					machineIdentifier: z.string(),
-					version: z.string(),
-				}).strict(),
-			}).strict();
+			const strictSchema = z
+				.object({
+					MediaContainer: z
+						.object({
+							machineIdentifier: z.string(),
+							version: z.string(),
+						})
+						.strict(),
+				})
+				.strict();
 
 			const result = parseUpstream(PLEX_IDENTITY_RESPONSE, strictSchema, {
-				integration: "test", category: "strict-test",
+				integration: "test",
+				category: "strict-test",
 			});
 			// Should fail because fixture has extra fields
 			expect(result.success).toBe(false);

--- a/apps/api/src/lib/validation/__tests__/validation-modes.test.ts
+++ b/apps/api/src/lib/validation/__tests__/validation-modes.test.ts
@@ -45,9 +45,9 @@ describe("Validation Modes", () => {
 				{ name: "invalid" }, // missing score
 			];
 
-			expect(() =>
-				validateAndCollect(data, schema, "test", mockLog, { mode: "strict" }),
-			).toThrow(ValidationError);
+			expect(() => validateAndCollect(data, schema, "test", mockLog, { mode: "strict" })).toThrow(
+				ValidationError,
+			);
 		});
 
 		it("returns all items when all are valid", () => {
@@ -66,7 +66,12 @@ describe("Validation Modes", () => {
 	describe("log-only", () => {
 		it("passes all items through but logs validation issues", () => {
 			const warnings: string[] = [];
-			const log = { warn: (msg: string | object) => { warnings.push(String(msg)); }, error: () => {} };
+			const log = {
+				warn: (msg: string | object) => {
+					warnings.push(String(msg));
+				},
+				error: () => {},
+			};
 
 			const data = [
 				{ name: "valid", score: 10 },
@@ -84,11 +89,7 @@ describe("Validation Modes", () => {
 
 	describe("disabled", () => {
 		it("returns all items without validation", () => {
-			const data = [
-				"not-an-object",
-				42,
-				null,
-			];
+			const data = ["not-an-object", 42, null];
 
 			const result = validateAndCollect(data, schema, "test", mockLog, { mode: "disabled" });
 

--- a/apps/api/src/lib/validation/index.ts
+++ b/apps/api/src/lib/validation/index.ts
@@ -85,4 +85,3 @@ export const KNOWN_INTEGRATIONS = [
 	"trash-guides",
 	"queue-cleaner",
 ] as const;
-

--- a/apps/api/src/plugins/arr-client.ts
+++ b/apps/api/src/plugins/arr-client.ts
@@ -19,4 +19,3 @@ export const arrClientPlugin = fp(
 		dependencies: ["prisma", "security"], // Ensure encryptor is available
 	},
 );
-

--- a/apps/api/src/plugins/prisma.ts
+++ b/apps/api/src/plugins/prisma.ts
@@ -79,4 +79,3 @@ export const prismaPlugin = fp(
 		name: "prisma",
 	},
 );
-

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -6,7 +6,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 
 const { mockSessionService } = vi.hoisted(() => ({
 	mockSessionService: {
-		createSession: vi.fn().mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSession: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -16,9 +18,11 @@ const { mockSessionService } = vi.hoisted(() => ({
 
 // Mock OIDCProvider class — avoid real discovery/HTTP calls
 const { MockOIDCProvider } = vi.hoisted(() => {
-	const mockGetAuthorizationUrl = vi.fn().mockResolvedValue(
-		"https://provider.example.com/authorize?client_id=test&state=mock-state&code_challenge=mock-challenge",
-	);
+	const mockGetAuthorizationUrl = vi
+		.fn()
+		.mockResolvedValue(
+			"https://provider.example.com/authorize?client_id=test&state=mock-state&code_challenge=mock-challenge",
+		);
 	class MockOIDCProvider {
 		config: Record<string, unknown>;
 		static mockGetAuthorizationUrl = mockGetAuthorizationUrl;

--- a/apps/api/src/routes/__tests__/library-torrent-state-filter.test.ts
+++ b/apps/api/src/routes/__tests__/library-torrent-state-filter.test.ts
@@ -67,7 +67,6 @@ afterAll(async () => {
 	await app?.close();
 });
 
-// biome-ignore lint/suspicious/noExplicitAny: typed access into vi.fn().mock.calls would obscure intent
 function findManyCallWhere(call: number = 0): any {
 	const calls = mockPrisma.libraryCache.findMany.mock.calls;
 	if (call >= calls.length)
@@ -175,7 +174,6 @@ describe("GET /library — torrentStateCounts response field", () => {
 	});
 });
 
-// biome-ignore lint/suspicious/noExplicitAny: typed access into vi.fn().mock.calls would obscure intent
 function groupByCallArg(call: number): any {
 	const calls = mockPrisma.libraryCache.groupBy.mock.calls;
 	if (call >= calls.length)

--- a/apps/api/src/routes/__tests__/notifications.test.ts
+++ b/apps/api/src/routes/__tests__/notifications.test.ts
@@ -7,7 +7,9 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 const { mockNotificationService, mockGetDeliveryStatistics } = vi.hoisted(() => ({
 	mockNotificationService: {
 		testChannel: vi.fn().mockResolvedValue(undefined),
-		getDecryptedConfig: vi.fn().mockResolvedValue({ webhookUrl: "https://discord.com/api/webhooks/123" }),
+		getDecryptedConfig: vi
+			.fn()
+			.mockResolvedValue({ webhookUrl: "https://discord.com/api/webhooks/123" }),
 		getChannelTypes: vi.fn().mockReturnValue([]),
 	},
 	mockGetDeliveryStatistics: vi.fn().mockResolvedValue({ total: 0, sent: 0, failed: 0 }),
@@ -23,7 +25,12 @@ vi.mock("../../lib/notifications/statistics.js", () => ({
 
 import Fastify from "fastify";
 import { registerNotificationRoutes } from "../notifications.js";
-import { setupAuthInjection, createInjectAuthenticated, createMockEncryptor, registerTestErrorHandler } from "./test-helpers.js";
+import {
+	setupAuthInjection,
+	createInjectAuthenticated,
+	createMockEncryptor,
+	registerTestErrorHandler,
+} from "./test-helpers.js";
 
 // ---------------------------------------------------------------------------
 // Test data factories
@@ -59,7 +66,9 @@ function makeRule(overrides: Record<string, unknown> = {}) {
 		enabled: true,
 		priority: 0,
 		action: "suppress",
-		conditions: JSON.stringify([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]),
+		conditions: JSON.stringify([
+			{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+		]),
 		targetChannelIds: null,
 		throttleMinutes: null,
 		createdAt: now,
@@ -152,9 +161,12 @@ beforeEach(async () => {
 	app = Fastify();
 
 	app.decorate("prisma", mockPrisma);
-	app.decorate("encryptor", createMockEncryptor(
-		JSON.stringify({ webhookUrl: "https://discord.com/api/webhooks/original" }),
-	));
+	app.decorate(
+		"encryptor",
+		createMockEncryptor(
+			JSON.stringify({ webhookUrl: "https://discord.com/api/webhooks/original" }),
+		),
+	);
 	app.decorate("notificationService", mockNotificationService);
 
 	setupAuthInjection(app);
@@ -342,14 +354,18 @@ describe("POST /rules", () => {
 		const body = JSON.parse(res.payload);
 		expect(body.name).toBe("Suppress Hunt Noise");
 		expect(body.action).toBe("suppress");
-		expect(body.conditions).toEqual([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]);
+		expect(body.conditions).toEqual([
+			{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+		]);
 
 		// Conditions should be stored as JSON string in DB
 		expect(mockPrisma.notificationRule.create).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
 					userId: "user-1",
-					conditions: JSON.stringify([{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" }]),
+					conditions: JSON.stringify([
+						{ field: "eventType", operator: "equals", value: "HUNT_COMPLETED" },
+					]),
 				}),
 			}),
 		);
@@ -392,7 +408,9 @@ describe("GET /channels/:id/config", () => {
 	});
 
 	it("returns 404 when channel not found", async () => {
-		mockNotificationService.getDecryptedConfig.mockRejectedValueOnce(new Error("Channel not found"));
+		mockNotificationService.getDecryptedConfig.mockRejectedValueOnce(
+			new Error("Channel not found"),
+		);
 
 		const res = await injectAuthenticated("GET", "/channels/ch-999/config");
 

--- a/apps/api/src/routes/__tests__/pulse-collector-error.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-collector-error.test.ts
@@ -47,9 +47,7 @@ describe("GET /pulse — collector failure detail wording", () => {
 		expect(res.statusCode).toBe(200);
 
 		const body = JSON.parse(res.payload);
-		const errorItem = body.items.find((i: { id: string }) =>
-			i.id.startsWith("collector-error-"),
-		);
+		const errorItem = body.items.find((i: { id: string }) => i.id.startsWith("collector-error-"));
 
 		expect(errorItem).toBeDefined();
 

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -76,7 +76,7 @@ describe("POST /webhooks/qui", () => {
 	it("returns 401 when the secret does not match any user", async () => {
 		const res = await app.inject({
 			method: "POST",
-			url: "/webhooks/qui?secret=" + "z".repeat(43),
+			url: `/webhooks/qui?secret=${"z".repeat(43)}`,
 			payload: { type: "torrent_added", payload: {} },
 		});
 		expect(res.statusCode).toBe(401);

--- a/apps/api/src/routes/auto-tag.ts
+++ b/apps/api/src/routes/auto-tag.ts
@@ -470,7 +470,7 @@ export async function registerAutoTagRoutes(app: FastifyInstance, _opts: Fastify
 		// the same fast-path check the inbound Connect webhook handler uses,
 		// just inverted (we have plaintext + hash, want to confirm match).
 		const user = await app.prisma.user.findUnique({ where: { id: userId } });
-		if (!user || !user.hashedWebhookSecret) {
+		if (!user?.hashedWebhookSecret) {
 			return reply
 				.status(412)
 				.send({ error: "Webhook secret not configured. Generate one first." });

--- a/apps/api/src/routes/jellyfin/image-proxy-routes.ts
+++ b/apps/api/src/routes/jellyfin/image-proxy-routes.ts
@@ -16,9 +16,24 @@ const thumbParams = z.object({
 });
 
 const thumbQuery = z.object({
-	itemId: z.string().min(1).refine((v) => !v.includes("..") && !v.includes("/"), "Invalid item ID"),
+	itemId: z
+		.string()
+		.min(1)
+		.refine((v) => !v.includes("..") && !v.includes("/"), "Invalid item ID"),
 	imageType: z
-		.enum(["Primary", "Backdrop", "Thumb", "Logo", "Banner", "Art", "Disc", "Box", "Screenshot", "Chapter", "Profile"])
+		.enum([
+			"Primary",
+			"Backdrop",
+			"Thumb",
+			"Logo",
+			"Banner",
+			"Art",
+			"Disc",
+			"Box",
+			"Screenshot",
+			"Chapter",
+			"Profile",
+		])
 		.optional()
 		.default("Primary"),
 	maxWidth: z

--- a/apps/api/src/routes/jellyfin/now-playing-routes.ts
+++ b/apps/api/src/routes/jellyfin/now-playing-routes.ts
@@ -35,19 +35,15 @@ export async function registerNowPlayingRoutes(app: FastifyInstance, _opts: Fast
 					state: s.isPaused ? "paused" : "playing",
 					viewOffset: s.positionMs,
 					duration: s.durationMs,
-					videoDecision: isTranscoding ? "Transcode" : s.playMethod ?? "DirectPlay",
+					videoDecision: isTranscoding ? "Transcode" : (s.playMethod ?? "DirectPlay"),
 					audioDecision:
-						s.transcodingInfo && !s.transcodingInfo.isAudioDirect
-							? "Transcode"
-							: "Direct",
+						s.transcodingInfo && !s.transcodingInfo.isAudioDirect ? "Transcode" : "Direct",
 					bandwidth: s.transcodingInfo?.bitrate
 						? Math.round(s.transcodingInfo.bitrate / 1000)
 						: undefined,
 					videoCodec: s.transcodingInfo?.videoCodec,
 					audioCodec: s.transcodingInfo?.audioCodec,
-					thumb: item?.imageTags?.["Primary"]
-						? `/Items/${item.id}/Images/Primary`
-						: undefined,
+					thumb: item?.imageTags?.Primary ? `/Items/${item.id}/Images/Primary` : undefined,
 					instanceId: instance.id,
 					instanceName: instance.label,
 				};

--- a/apps/api/src/routes/library/__tests__/queryraw-migration.test.ts
+++ b/apps/api/src/routes/library/__tests__/queryraw-migration.test.ts
@@ -20,10 +20,7 @@ const RUN_DB_TESTS = process.env.TEST_DB === "true";
 const PG_URL = process.env.TEST_PG_URL;
 
 // Use the pre-initialized test database with full schema
-const TEST_DB_PATH = path.resolve(
-	import.meta.dirname,
-	"../../../../prisma/test-integration.db",
-);
+const TEST_DB_PATH = path.resolve(import.meta.dirname, "../../../../prisma/test-integration.db");
 
 /** Shared test data setup */
 async function seedTestData(prisma: PrismaClient) {
@@ -166,53 +163,45 @@ function defineQueryRawTests(
 
 // ─── SQLite Suite ───────────────────────────────────────────────────────────
 
-(RUN_DB_TESTS ? describe : describe.skip)(
-	"$queryRaw migration: SQLite (json_extract)",
-	() => {
-		let prisma: PrismaClient;
+(RUN_DB_TESTS ? describe : describe.skip)("$queryRaw migration: SQLite (json_extract)", () => {
+	let prisma: PrismaClient;
 
-		beforeEach(async () => {
-			prisma = createTestPrismaClient(TEST_DB_PATH);
-			await seedTestData(prisma);
-		});
+	beforeEach(async () => {
+		prisma = createTestPrismaClient(TEST_DB_PATH);
+		await seedTestData(prisma);
+	});
 
-		afterEach(async () => {
-			await cleanupTestData(prisma);
-			await prisma.$disconnect();
-		});
+	afterEach(async () => {
+		await cleanupTestData(prisma);
+		await prisma.$disconnect();
+	});
 
-		defineQueryRawTests(
-			() => prisma,
-			(tmdbId) =>
-				Prisma.sql`CAST(json_extract(data, '$.remoteIds.tmdbId') AS INTEGER) = ${tmdbId}`,
-		);
-	},
-);
+	defineQueryRawTests(
+		() => prisma,
+		(tmdbId) => Prisma.sql`CAST(json_extract(data, '$.remoteIds.tmdbId') AS INTEGER) = ${tmdbId}`,
+	);
+});
 
 // ─── PostgreSQL Suite ───────────────────────────────────────────────────────
 
-(PG_URL ? describe : describe.skip)(
-	"$queryRaw migration: PostgreSQL (JSON ->> operator)",
-	() => {
-		let prisma: PrismaClient;
-		let cleanup: () => Promise<void>;
+(PG_URL ? describe : describe.skip)("$queryRaw migration: PostgreSQL (JSON ->> operator)", () => {
+	let prisma: PrismaClient;
+	let cleanup: () => Promise<void>;
 
-		beforeEach(async () => {
-			const pg = await createTestPgClient(PG_URL!);
-			prisma = pg.prisma;
-			cleanup = pg.cleanup;
-			await seedTestData(prisma);
-		});
+	beforeEach(async () => {
+		const pg = await createTestPgClient(PG_URL!);
+		prisma = pg.prisma;
+		cleanup = pg.cleanup;
+		await seedTestData(prisma);
+	});
 
-		afterEach(async () => {
-			await cleanupTestData(prisma);
-			await cleanup();
-		});
+	afterEach(async () => {
+		await cleanupTestData(prisma);
+		await cleanup();
+	});
 
-		defineQueryRawTests(
-			() => prisma,
-			(tmdbId) =>
-				Prisma.sql`CAST("data"::json->'remoteIds'->>'tmdbId' AS INTEGER) = ${tmdbId}`,
-		);
-	},
-);
+	defineQueryRawTests(
+		() => prisma,
+		(tmdbId) => Prisma.sql`CAST("data"::json->'remoteIds'->>'tmdbId' AS INTEGER) = ${tmdbId}`,
+	);
+});

--- a/apps/api/src/routes/library/insights-routes.ts
+++ b/apps/api/src/routes/library/insights-routes.ts
@@ -219,7 +219,10 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		const instanceIds = userInstances.map((i) => i.id);
 
 		if (instanceIds.length === 0) {
-			return reply.send({ success: true, data: { items: [], hasPlexData: false, hasWatchData: false } });
+			return reply.send({
+				success: true,
+				data: { items: [], hasPlexData: false, hasWatchData: false },
+			});
 		}
 
 		// Get media server instances — Plex + Jellyfin/Emby
@@ -235,7 +238,10 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		]);
 
 		if (plexInstances.length === 0 && jellyfinInstances.length === 0) {
-			return reply.send({ success: true, data: { items: [], hasPlexData: false, hasWatchData: false } });
+			return reply.send({
+				success: true,
+				data: { items: [], hasPlexData: false, hasWatchData: false },
+			});
 		}
 
 		// Build watch data map: mediaType:tmdbId → { watchCount, lastWatchedAt }
@@ -364,7 +370,10 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		});
 
 		if (!seerrInstance) {
-			return reply.send({ success: true, data: { items: [], hasSeerrData: false, hasPlexData: false, hasWatchData: false } });
+			return reply.send({
+				success: true,
+				data: { items: [], hasSeerrData: false, hasPlexData: false, hasWatchData: false },
+			});
 		}
 
 		// Get media server watch data — Plex + Jellyfin/Emby
@@ -435,14 +444,24 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			);
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: false, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
+				data: {
+					items: [],
+					hasSeerrData: false,
+					hasPlexData: plexInstances.length > 0,
+					hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
+				},
 			});
 		}
 
 		if (seerrRequests.length === 0) {
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
+				data: {
+					items: [],
+					hasSeerrData: true,
+					hasPlexData: plexInstances.length > 0,
+					hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
+				},
 			});
 		}
 
@@ -466,7 +485,12 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		if (instanceIds.length === 0) {
 			return reply.send({
 				success: true,
-				data: { items: [], hasSeerrData: true, hasPlexData: plexInstances.length > 0, hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0 },
+				data: {
+					items: [],
+					hasSeerrData: true,
+					hasPlexData: plexInstances.length > 0,
+					hasWatchData: plexInstances.length > 0 || jellyfinInstances.length > 0,
+				},
 			});
 		}
 

--- a/apps/api/src/routes/library/sync-routes.ts
+++ b/apps/api/src/routes/library/sync-routes.ts
@@ -157,4 +157,3 @@ export const registerSyncRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 	done();
 };
-

--- a/apps/api/src/routes/plex/__tests__/account-helpers.test.ts
+++ b/apps/api/src/routes/plex/__tests__/account-helpers.test.ts
@@ -22,7 +22,15 @@ describe("deduplicateAccounts", () => {
 	});
 
 	it("filters out non-string values from aggregated array", () => {
-		const result = deduplicateAccounts(["alice", 42, null, undefined, true, "bob", { name: "eve" }]);
+		const result = deduplicateAccounts([
+			"alice",
+			42,
+			null,
+			undefined,
+			true,
+			"bob",
+			{ name: "eve" },
+		]);
 		expect(result).toEqual(["alice", "bob"]);
 	});
 

--- a/apps/api/src/routes/plex/__tests__/bandwidth-analytics.test.ts
+++ b/apps/api/src/routes/plex/__tests__/bandwidth-analytics.test.ts
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
-import { aggregateBandwidthAnalytics, type SnapshotForBandwidth } from "../lib/bandwidth-analytics-helpers.js";
+import {
+	aggregateBandwidthAnalytics,
+	type SnapshotForBandwidth,
+} from "../lib/bandwidth-analytics-helpers.js";
 
-function snapshot(date: string, concurrent: number, total: number, lan: number, wan: number): SnapshotForBandwidth {
-	return { capturedAt: new Date(`${date}T12:00:00Z`), concurrentStreams: concurrent, totalBandwidth: total, lanBandwidth: lan, wanBandwidth: wan };
+function snapshot(
+	date: string,
+	concurrent: number,
+	total: number,
+	lan: number,
+	wan: number,
+): SnapshotForBandwidth {
+	return {
+		capturedAt: new Date(`${date}T12:00:00Z`),
+		concurrentStreams: concurrent,
+		totalBandwidth: total,
+		lanBandwidth: lan,
+		wanBandwidth: wan,
+	};
 }
 
 describe("aggregateBandwidthAnalytics", () => {
@@ -19,9 +34,21 @@ describe("aggregateBandwidthAnalytics", () => {
 		expect(result.avgBandwidth).toBe(Math.round(3500 / 3));
 		expect(result.timeSeries).toHaveLength(2);
 		// Day 1: peak concurrent=5, avg bandwidth=1500, avg lan=900, avg wan=600
-		expect(result.timeSeries[0]).toEqual({ date: "2025-01-01", concurrent: 5, bandwidth: 1500, lanBandwidth: 900, wanBandwidth: 600 });
+		expect(result.timeSeries[0]).toEqual({
+			date: "2025-01-01",
+			concurrent: 5,
+			bandwidth: 1500,
+			lanBandwidth: 900,
+			wanBandwidth: 600,
+		});
 		// Day 2: single snapshot
-		expect(result.timeSeries[1]).toEqual({ date: "2025-01-02", concurrent: 2, bandwidth: 500, lanBandwidth: 300, wanBandwidth: 200 });
+		expect(result.timeSeries[1]).toEqual({
+			date: "2025-01-02",
+			concurrent: 2,
+			bandwidth: 500,
+			lanBandwidth: 300,
+			wanBandwidth: 200,
+		});
 		expect(result.parseFailures).toBe(0);
 		expect(result.totalSnapshots).toBe(3);
 	});

--- a/apps/api/src/routes/plex/__tests__/cache-health.test.ts
+++ b/apps/api/src/routes/plex/__tests__/cache-health.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { sanitizeErrorMessage, buildCacheHealthItems, type CacheRefreshStatusRow } from "../lib/cache-health-helpers.js";
+import {
+	sanitizeErrorMessage,
+	buildCacheHealthItems,
+	type CacheRefreshStatusRow,
+} from "../lib/cache-health-helpers.js";
 
 describe("sanitizeErrorMessage", () => {
 	it("returns null for null input", () => {

--- a/apps/api/src/routes/plex/__tests__/forecast.test.ts
+++ b/apps/api/src/routes/plex/__tests__/forecast.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { computeForecast, linearRegression, type SnapshotForForecast } from "../lib/forecast-helpers.js";
+import {
+	computeForecast,
+	linearRegression,
+	type SnapshotForForecast,
+} from "../lib/forecast-helpers.js";
 
 function snapshot(capturedAt: string, bandwidth: number, concurrent = 1): SnapshotForForecast {
 	return {

--- a/apps/api/src/routes/plex/__tests__/now-playing-helpers.test.ts
+++ b/apps/api/src/routes/plex/__tests__/now-playing-helpers.test.ts
@@ -3,28 +3,17 @@ import { computeTotalBandwidth } from "../lib/now-playing-helpers.js";
 
 describe("computeTotalBandwidth", () => {
 	it("sums bandwidth across sessions", () => {
-		const sessions = [
-			{ bandwidth: 5000 },
-			{ bandwidth: 12000 },
-			{ bandwidth: 3000 },
-		];
+		const sessions = [{ bandwidth: 5000 }, { bandwidth: 12000 }, { bandwidth: 3000 }];
 		expect(computeTotalBandwidth(sessions)).toBe(20000);
 	});
 
 	it("treats null bandwidth as 0", () => {
-		const sessions = [
-			{ bandwidth: 5000 },
-			{ bandwidth: null },
-			{ bandwidth: 8000 },
-		];
+		const sessions = [{ bandwidth: 5000 }, { bandwidth: null }, { bandwidth: 8000 }];
 		expect(computeTotalBandwidth(sessions as any)).toBe(13000);
 	});
 
 	it("treats undefined bandwidth as 0", () => {
-		const sessions = [
-			{ bandwidth: undefined },
-			{ bandwidth: 4000 },
-		];
+		const sessions = [{ bandwidth: undefined }, { bandwidth: 4000 }];
 		expect(computeTotalBandwidth(sessions as any)).toBe(4000);
 	});
 

--- a/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
@@ -115,10 +115,7 @@ describe("GET /oauth/pin/:pinId", () => {
 	it("returns null tokenRef when not yet approved", async () => {
 		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: null }));
 
-		const res = await injectAuthenticated(
-			"GET",
-			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
-		);
+		const res = await injectAuthenticated("GET", `/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`);
 
 		expect(res.statusCode).toBe(200);
 		expect(res.json()).toEqual({ tokenRef: null });
@@ -127,10 +124,7 @@ describe("GET /oauth/pin/:pinId", () => {
 	it("returns tokenRef when approved", async () => {
 		mockFetch.mockResolvedValueOnce(jsonResponse({ authToken: "plex-token-123" }));
 
-		const res = await injectAuthenticated(
-			"GET",
-			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
-		);
+		const res = await injectAuthenticated("GET", `/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`);
 
 		expect(res.statusCode).toBe(200);
 		const body = res.json();
@@ -143,10 +137,7 @@ describe("GET /oauth/pin/:pinId", () => {
 	it("returns 502 when plex.tv returns an error", async () => {
 		mockFetch.mockResolvedValueOnce(jsonResponse({}, 500));
 
-		const res = await injectAuthenticated(
-			"GET",
-			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
-		);
+		const res = await injectAuthenticated("GET", `/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`);
 
 		expect(res.statusCode).toBe(502);
 	});
@@ -154,10 +145,7 @@ describe("GET /oauth/pin/:pinId", () => {
 	it("returns 502 on network error", async () => {
 		mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
-		const res = await injectAuthenticated(
-			"GET",
-			`/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`,
-		);
+		const res = await injectAuthenticated("GET", `/oauth/pin/12345?clientId=${VALID_CLIENT_ID}`);
 
 		expect(res.statusCode).toBe(502);
 		expect(res.json().error).toBe("Could not reach plex.tv");
@@ -190,8 +178,22 @@ describe("POST /oauth/servers", () => {
 				platform: "Linux",
 				productVersion: "1.32.0",
 				connections: [
-					{ protocol: "https", address: "192.168.1.10", port: 32400, uri: "https://192.168.1.10:32400", local: true, relay: false },
-					{ protocol: "https", address: "203.0.113.10", port: 32400, uri: "https://203.0.113.10:32400", local: false, relay: false },
+					{
+						protocol: "https",
+						address: "192.168.1.10",
+						port: 32400,
+						uri: "https://192.168.1.10:32400",
+						local: true,
+						relay: false,
+					},
+					{
+						protocol: "https",
+						address: "203.0.113.10",
+						port: 32400,
+						uri: "https://203.0.113.10:32400",
+						local: false,
+						relay: false,
+					},
 				],
 			},
 		];

--- a/apps/api/src/routes/plex/__tests__/recently-added-helpers.test.ts
+++ b/apps/api/src/routes/plex/__tests__/recently-added-helpers.test.ts
@@ -8,7 +8,10 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { mapToRecentlyAddedItems, type PlexCacheRecentEntry } from "../lib/recently-added-helpers.js";
+import {
+	mapToRecentlyAddedItems,
+	type PlexCacheRecentEntry,
+} from "../lib/recently-added-helpers.js";
 
 describe("mapToRecentlyAddedItems", () => {
 	it("maps cache entries to correct response shape", () => {

--- a/apps/api/src/routes/plex/__tests__/transcode-analytics.test.ts
+++ b/apps/api/src/routes/plex/__tests__/transcode-analytics.test.ts
@@ -1,8 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { aggregateTranscodeAnalytics, type SnapshotForTranscode } from "../lib/transcode-analytics-helpers.js";
+import {
+	aggregateTranscodeAnalytics,
+	type SnapshotForTranscode,
+} from "../lib/transcode-analytics-helpers.js";
 
-function snapshot(date: string, directPlay: number, transcode: number, directStream: number): SnapshotForTranscode {
-	return { capturedAt: new Date(`${date}T12:00:00Z`), directPlayCount: directPlay, transcodeCount: transcode, directStreamCount: directStream };
+function snapshot(
+	date: string,
+	directPlay: number,
+	transcode: number,
+	directStream: number,
+): SnapshotForTranscode {
+	return {
+		capturedAt: new Date(`${date}T12:00:00Z`),
+		directPlayCount: directPlay,
+		transcodeCount: transcode,
+		directStreamCount: directStream,
+	};
 }
 
 describe("aggregateTranscodeAnalytics", () => {
@@ -19,8 +32,18 @@ describe("aggregateTranscodeAnalytics", () => {
 		expect(result.directStream).toBe(3);
 		expect(result.totalSessions).toBe(15);
 		expect(result.dailyBreakdown).toHaveLength(2);
-		expect(result.dailyBreakdown[0]).toEqual({ date: "2025-01-01", directPlay: 4, transcode: 3, directStream: 2 });
-		expect(result.dailyBreakdown[1]).toEqual({ date: "2025-01-02", directPlay: 5, transcode: 0, directStream: 1 });
+		expect(result.dailyBreakdown[0]).toEqual({
+			date: "2025-01-01",
+			directPlay: 4,
+			transcode: 3,
+			directStream: 2,
+		});
+		expect(result.dailyBreakdown[1]).toEqual({
+			date: "2025-01-02",
+			directPlay: 5,
+			transcode: 0,
+			directStream: 1,
+		});
 		expect(result.parseFailures).toBe(0);
 		expect(result.totalSnapshots).toBe(3);
 	});
@@ -36,14 +59,16 @@ describe("aggregateTranscodeAnalytics", () => {
 	});
 
 	it("produces a single daily entry for one day", () => {
-		const snapshots = [
-			snapshot("2025-06-15", 10, 5, 3),
-			snapshot("2025-06-15", 2, 1, 0),
-		];
+		const snapshots = [snapshot("2025-06-15", 10, 5, 3), snapshot("2025-06-15", 2, 1, 0)];
 
 		const result = aggregateTranscodeAnalytics(snapshots);
 		expect(result.dailyBreakdown).toHaveLength(1);
-		expect(result.dailyBreakdown[0]).toEqual({ date: "2025-06-15", directPlay: 12, transcode: 6, directStream: 3 });
+		expect(result.dailyBreakdown[0]).toEqual({
+			date: "2025-06-15",
+			directPlay: 12,
+			transcode: 6,
+			directStream: 3,
+		});
 		expect(result.totalSessions).toBe(21);
 	});
 

--- a/apps/api/src/routes/plex/__tests__/user-episode-completion.test.ts
+++ b/apps/api/src/routes/plex/__tests__/user-episode-completion.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { aggregateUserEpisodeCompletion, type EpisodeCacheEntry } from "../lib/user-episode-helpers.js";
+import {
+	aggregateUserEpisodeCompletion,
+	type EpisodeCacheEntry,
+} from "../lib/user-episode-helpers.js";
 
 function episode(overrides: Partial<EpisodeCacheEntry> = {}): EpisodeCacheEntry {
 	return {

--- a/apps/api/src/routes/plex/__tests__/watch-enrichment.test.ts
+++ b/apps/api/src/routes/plex/__tests__/watch-enrichment.test.ts
@@ -50,7 +50,9 @@ function tautulliEntry(overrides: Partial<TautulliCacheEntry> = {}): TautulliCac
 	};
 }
 
-function makeKeys(...pairs: [string, number][]): Map<string, { tmdbId: number; mediaType: string }> {
+function makeKeys(
+	...pairs: [string, number][]
+): Map<string, { tmdbId: number; mediaType: string }> {
 	const map = new Map<string, { tmdbId: number; mediaType: string }>();
 	for (const [mediaType, tmdbId] of pairs) {
 		map.set(`${mediaType}:${tmdbId}`, { tmdbId, mediaType });
@@ -120,7 +122,12 @@ describe("aggregateWatchEnrichment", () => {
 			keys,
 			[
 				plexEntry({ instanceId: "plex-1", watchCount: 2, watchedByUsers: '["alice"]' }),
-				plexEntry({ instanceId: "plex-2", watchCount: 4, ratingKey: null, watchedByUsers: '["bob"]' }),
+				plexEntry({
+					instanceId: "plex-2",
+					watchCount: 4,
+					ratingKey: null,
+					watchedByUsers: '["bob"]',
+				}),
 			],
 			[],
 			undefined,

--- a/apps/api/src/routes/plex/cache-routes.ts
+++ b/apps/api/src/routes/plex/cache-routes.ts
@@ -69,13 +69,19 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 							cacheType: "plex",
 							lastRefreshedAt: new Date(),
 							lastResult: result.errors > 0 ? "error" : "success",
-							lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
+							lastErrorMessage:
+								result.errorMessages.length > 0
+									? result.errorMessages.slice(0, 3).join("; ").slice(0, 200)
+									: null,
 							itemCount: result.upserted,
 						},
 						update: {
 							lastRefreshedAt: new Date(),
 							lastResult: result.errors > 0 ? "error" : "success",
-							lastErrorMessage: result.errorMessages.length > 0 ? result.errorMessages.slice(0, 3).join("; ").slice(0, 200) : null,
+							lastErrorMessage:
+								result.errorMessages.length > 0
+									? result.errorMessages.slice(0, 3).join("; ").slice(0, 200)
+									: null,
 							itemCount: result.upserted,
 						},
 					})

--- a/apps/api/src/routes/tautulli/__tests__/stats-aggregation.test.ts
+++ b/apps/api/src/routes/tautulli/__tests__/stats-aggregation.test.ts
@@ -16,12 +16,25 @@ import { tautulliHomeStatSchema } from "../../../lib/tautulli/tautulli-schemas.j
  * Simulate the aggregation logic from stats-routes.ts lines 69-92.
  * Extracted here so we can test it in isolation against real parsed data.
  */
-function aggregateHomeStats(
-	homeStats: z.infer<typeof tautulliHomeStatSchema>[],
-): Map<string, { statTitle: string; rows: Map<string, { title: string; totalPlays: number; totalDuration: number; platform?: string }> }> {
+function aggregateHomeStats(homeStats: z.infer<typeof tautulliHomeStatSchema>[]): Map<
+	string,
+	{
+		statTitle: string;
+		rows: Map<
+			string,
+			{ title: string; totalPlays: number; totalDuration: number; platform?: string }
+		>;
+	}
+> {
 	const homeStatsMap = new Map<
 		string,
-		{ statTitle: string; rows: Map<string, { title: string; totalPlays: number; totalDuration: number; platform?: string }> }
+		{
+			statTitle: string;
+			rows: Map<
+				string,
+				{ title: string; totalPlays: number; totalDuration: number; platform?: string }
+			>;
+		}
 	>();
 
 	for (const stat of homeStats) {
@@ -105,9 +118,7 @@ describe("Tautulli stats aggregation (#233)", () => {
 			{
 				stat_id: "top_users",
 				stat_title: "Top Users",
-				rows: [
-					{ title: "admin", friendly_name: "Admin", total_plays: 10, total_duration: 72000 },
-				],
+				rows: [{ title: "admin", friendly_name: "Admin", total_plays: 10, total_duration: 72000 }],
 			},
 		];
 		// Instance 2: missing duration (like some Tautulli configurations)
@@ -115,9 +126,7 @@ describe("Tautulli stats aggregation (#233)", () => {
 			{
 				stat_id: "top_users",
 				stat_title: "Top Users",
-				rows: [
-					{ title: "admin", friendly_name: "Admin" },
-				],
+				rows: [{ title: "admin", friendly_name: "Admin" }],
 			},
 		];
 

--- a/apps/api/src/routes/trash-guides/__tests__/naming-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/naming-routes.test.ts
@@ -224,9 +224,7 @@ describe("POST /preview", () => {
 	});
 
 	it("returns 502 on invalid ARR response (missing required fields)", async () => {
-		mockRawRequest.mockResolvedValueOnce(
-			makeJsonResponse({ notAValidConfig: true }),
-		);
+		mockRawRequest.mockResolvedValueOnce(makeJsonResponse({ notAValidConfig: true }));
 
 		const res = await app.inject({
 			method: "POST",
@@ -268,7 +266,9 @@ describe("POST /apply", () => {
 	it("applies naming presets and creates history", async () => {
 		mockRawRequest
 			.mockResolvedValueOnce(makeJsonResponse(VALID_ARR_NAMING_CONFIG)) // GET
-			.mockResolvedValueOnce(makeJsonResponse({ ...VALID_ARR_NAMING_CONFIG, standardMovieFormat: "new" })); // PUT
+			.mockResolvedValueOnce(
+				makeJsonResponse({ ...VALID_ARR_NAMING_CONFIG, standardMovieFormat: "new" }),
+			); // PUT
 
 		const res = await app.inject({
 			method: "POST",
@@ -329,7 +329,9 @@ describe("POST /apply", () => {
 		mockRawRequest
 			.mockResolvedValueOnce(makeJsonResponse(VALID_ARR_NAMING_CONFIG)) // GET
 			.mockRejectedValueOnce(new Error("ECONNRESET")) // First PUT fails
-			.mockResolvedValueOnce(makeJsonResponse({ ...VALID_ARR_NAMING_CONFIG, standardMovieFormat: "new" })); // Retry succeeds
+			.mockResolvedValueOnce(
+				makeJsonResponse({ ...VALID_ARR_NAMING_CONFIG, standardMovieFormat: "new" }),
+			); // Retry succeeds
 
 		const res = await app.inject({
 			method: "POST",
@@ -379,9 +381,7 @@ describe("POST /apply", () => {
 		expect(res.statusCode).toBe(200);
 
 		// Check that the PUT body includes renameMovies
-		const putCall = mockRawRequest.mock.calls.find(
-			(call: any[]) => call[2]?.method === "PUT",
-		);
+		const putCall = mockRawRequest.mock.calls.find((call: any[]) => call[2]?.method === "PUT");
 		expect(putCall).toBeDefined();
 		expect(putCall![2].body.renameMovies).toBe(true);
 	});
@@ -717,9 +717,7 @@ describe("GET /history", () => {
 
 describe("ARR response validation", () => {
 	it("rejects non-JSON response with 502", async () => {
-		mockRawRequest.mockResolvedValueOnce(
-			new Response("This is not JSON", { status: 200 }),
-		);
+		mockRawRequest.mockResolvedValueOnce(new Response("This is not JSON", { status: 200 }));
 
 		const res = await app.inject({
 			method: "POST",

--- a/apps/api/src/routes/trash-guides/bulk-score-routes.ts
+++ b/apps/api/src/routes/trash-guides/bulk-score-routes.ts
@@ -172,7 +172,10 @@ const bulkScoreRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 */
 	app.post("/export", async (request, reply) => {
 		const userId = request.currentUser!.id; // preHandler guarantees authentication
-		const { templateIds, serviceType } = validateRequest(bulkScoreExportRequestSchema, request.body);
+		const { templateIds, serviceType } = validateRequest(
+			bulkScoreExportRequestSchema,
+			request.body,
+		);
 
 		const bulkScoreManager = createBulkScoreManager(app.prisma, app.arrClientFactory);
 		const exportData = await bulkScoreManager.exportScores(userId, templateIds, serviceType);

--- a/apps/api/src/routes/trash-guides/quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/quality-profile-routes.ts
@@ -273,10 +273,9 @@ export async function registerQualityProfileRoutes(
 		}
 
 		// Get CF Groups from cache
-		const cfGroups = (await cacheManager.get(
-			serviceType as "RADARR" | "SONARR",
-			"CF_GROUPS",
-		)) as TrashCustomFormatGroup[] | null;
+		const cfGroups = (await cacheManager.get(serviceType as "RADARR" | "SONARR", "CF_GROUPS")) as
+			| TrashCustomFormatGroup[]
+			| null;
 
 		// Get Custom Formats from cache
 		const customFormats = (await cacheManager.get(
@@ -472,7 +471,9 @@ export async function registerQualityProfileRoutes(
 		}
 
 		// Get Custom Formats referenced in the quality profile
-		const customFormats = (await cacheManager.get(serviceType, "CUSTOM_FORMATS")) as TrashCustomFormat[] | null;
+		const customFormats = (await cacheManager.get(serviceType, "CUSTOM_FORMATS")) as
+			| TrashCustomFormat[]
+			| null;
 
 		if (!customFormats) {
 			return reply.status(400).send({
@@ -505,7 +506,9 @@ export async function registerQualityProfileRoutes(
 		};
 
 		// Get CF Groups for reference storage
-		const cfGroups = (await cacheManager.get(serviceType, "CF_GROUPS")) as TrashCustomFormatGroup[] | null;
+		const cfGroups = (await cacheManager.get(serviceType, "CF_GROUPS")) as
+			| TrashCustomFormatGroup[]
+			| null;
 
 		// Add selected CF Groups
 		if (cfGroups) {
@@ -617,7 +620,9 @@ export async function registerQualityProfileRoutes(
 		}
 
 		// Get Custom Formats from cache
-		const customFormats = (await cacheManager.get(serviceType, "CUSTOM_FORMATS")) as TrashCustomFormat[] | null;
+		const customFormats = (await cacheManager.get(serviceType, "CUSTOM_FORMATS")) as
+			| TrashCustomFormat[]
+			| null;
 
 		if (!customFormats) {
 			return reply.status(400).send({
@@ -646,7 +651,9 @@ export async function registerQualityProfileRoutes(
 		};
 
 		// Get CF Groups for reference storage
-		const cfGroups = (await cacheManager.get(serviceType, "CF_GROUPS")) as TrashCustomFormatGroup[] | null;
+		const cfGroups = (await cacheManager.get(serviceType, "CF_GROUPS")) as
+			| TrashCustomFormatGroup[]
+			| null;
 
 		// Build lookup maps from existing template data for fallback
 		const existingGroupMap = new Map(

--- a/apps/api/src/routes/trash-guides/user-custom-format-routes.ts
+++ b/apps/api/src/routes/trash-guides/user-custom-format-routes.ts
@@ -432,9 +432,9 @@ export async function registerUserCustomFormatRoutes(
 				// Transform fields from object to array format for the ARR API
 				const transformedSpecs = specs.map((spec) => ({
 					...spec,
-					fields: Object.entries(
-						(spec.fields as Record<string, unknown>) || {},
-					).map(([name, value]) => ({ name, value })),
+					fields: Object.entries((spec.fields as Record<string, unknown>) || {}).map(
+						([name, value]) => ({ name, value }),
+					),
 				}));
 
 				const existing = existingByName.get(userCF.name);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-@config '../tailwind.config.ts';
+@config "../tailwind.config.ts";
 
 /*
   The default border color has changed to `currentcolor` in Tailwind CSS v4,
@@ -3377,9 +3377,9 @@
 	   - Gradient text (elements with background-clip: text)
 	   Using :not() with :where() for broader exclusions */
 	[data-theme="qbittorrent"]
-		[style*="gradient"]:where(
-			:not(.pointer-events-none):not(.fixed):not([data-appearance-settings] *)
-		):not([style*="background-clip"]):not([style*="BackgroundClip"]) {
+	[style*="gradient"]:where(
+		:not(.pointer-events-none):not(.fixed):not([data-appearance-settings] *)
+	):not([style*="background-clip"]):not([style*="BackgroundClip"]) {
 		background: transparent !important;
 	}
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -9,7 +9,15 @@ import globals from "globals";
 /** @type {import('eslint').Linter.Config[]} */
 const eslintConfig = [
 	{
-		ignores: ["node_modules/**", ".next/**", "out/**", "build/**", "coverage/**", "next-env.d.ts", "server.js"],
+		ignores: [
+			"node_modules/**",
+			".next/**",
+			"out/**",
+			"build/**",
+			"coverage/**",
+			"next-env.d.ts",
+			"server.js",
+		],
 	},
 	{
 		files: ["**/*.{js,jsx,ts,tsx}"],

--- a/apps/web/src/components/layout/premium-containers.tsx
+++ b/apps/web/src/components/layout/premium-containers.tsx
@@ -233,7 +233,9 @@ export const InstanceCard = ({
 				<div className="flex items-start justify-between mb-3">
 					<div>
 						<div className="flex items-center gap-2 mb-1">
-							<h3 className="font-semibold text-foreground">{incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}</h3>
+							<h3 className="font-semibold text-foreground">
+								{incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}
+							</h3>
 							<ServiceBadge service={service} />
 						</div>
 						{status}

--- a/apps/web/src/components/layout/topbar.tsx
+++ b/apps/web/src/components/layout/topbar.tsx
@@ -58,11 +58,15 @@ export const TopBar = () => {
 
 							<div className="relative h-9 w-9 rounded-full bg-linear-to-br from-primary to-accent text-white flex items-center justify-center shadow-md ring-1 ring-white/10">
 								<span className="text-sm font-semibold">
-									{(incognitoMode ? getLinuxUsername(user.username) : user.username)[0]?.toUpperCase() ?? "U"}
+									{(incognitoMode
+										? getLinuxUsername(user.username)
+										: user.username)[0]?.toUpperCase() ?? "U"}
 								</span>
 							</div>
 							<div className="text-right relative">
-								<p className="text-sm font-medium text-foreground">{incognitoMode ? getLinuxUsername(user.username) : user.username}</p>
+								<p className="text-sm font-medium text-foreground">
+									{incognitoMode ? getLinuxUsername(user.username) : user.username}
+								</p>
 							</div>
 						</div>
 						<Button

--- a/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
@@ -239,7 +239,7 @@ const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | nul
 					</h4>
 					<p className="text-xs text-muted-foreground mt-0.5">
 						Push the webhook config above to your Sonarr/Radarr instances in one click — no manual
-						copy/paste in each *arr's Connect settings.
+						copy/paste in each *arr’s Connect settings.
 					</p>
 				</div>
 				<div className="flex gap-1 shrink-0">

--- a/apps/web/src/features/calendar/components/calendar-client.tsx
+++ b/apps/web/src/features/calendar/components/calendar-client.tsx
@@ -39,10 +39,7 @@ export const CalendarClient = () => {
 	const { eventsByDate, serviceMap, instanceOptions, filteredEvents } = calendarData;
 
 	// Plex deep links — only fetched when Plex is configured
-	const hasPlex = useMemo(
-		() => services?.some((s) => s.service === "plex") ?? false,
-		[services],
-	);
+	const hasPlex = useMemo(() => services?.some((s) => s.service === "plex") ?? false, [services]);
 	const plexUrlMap = useCalendarPlexLinks(filteredEvents, hasPlex);
 
 	const handleOpenExternal = useCallback((href: string) => {
@@ -60,22 +57,13 @@ export const CalendarClient = () => {
 				{/* Header skeleton */}
 				<div className="flex items-center gap-5">
 					<PremiumSkeleton className="h-7 w-24 rounded-lg" />
-					<PremiumSkeleton
-						className="h-5 w-px"
-						style={{ animationDelay: "30ms" }}
-					/>
-					<PremiumSkeleton
-						className="h-7 w-44 rounded-lg"
-						style={{ animationDelay: "50ms" }}
-					/>
+					<PremiumSkeleton className="h-5 w-px" style={{ animationDelay: "30ms" }} />
+					<PremiumSkeleton className="h-7 w-44 rounded-lg" style={{ animationDelay: "50ms" }} />
 				</div>
 
 				{/* Filter skeleton */}
 				<div className="flex gap-2">
-					<PremiumSkeleton
-						className="h-9 w-60 rounded-xl"
-						style={{ animationDelay: "80ms" }}
-					/>
+					<PremiumSkeleton className="h-9 w-60 rounded-xl" style={{ animationDelay: "80ms" }} />
 					<PremiumSkeleton
 						className="h-8 w-[140px] rounded-xl"
 						style={{ animationDelay: "100ms" }}
@@ -113,10 +101,7 @@ export const CalendarClient = () => {
 					{/* Panel skeleton */}
 					<div className="mt-6 xl:mt-0 xl:w-[380px] xl:shrink-0">
 						<div className="rounded-2xl border border-border/10 overflow-hidden">
-							<PremiumSkeleton
-								className="h-16"
-								style={{ animationDelay: "520ms" }}
-							/>
+							<PremiumSkeleton className="h-16" style={{ animationDelay: "520ms" }} />
 							<div className="p-4 space-y-2.5">
 								{Array.from({ length: 3 }).map((_, i) => (
 									<PremiumSkeleton
@@ -165,8 +150,7 @@ export const CalendarClient = () => {
 			{error && (
 				<Alert variant="danger">
 					<AlertDescription>
-						Unable to load calendar data. Please refresh and try
-						again.
+						Unable to load calendar data. Please refresh and try again.
 					</AlertDescription>
 				</Alert>
 			)}

--- a/apps/web/src/features/calendar/components/calendar-event-card.tsx
+++ b/apps/web/src/features/calendar/components/calendar-event-card.tsx
@@ -92,9 +92,7 @@ const MetaChip = ({
 }) => (
 	<span
 		className={`inline-flex items-center gap-1 text-[11px] ${
-			variant === "muted"
-				? "text-muted-foreground/30"
-				: "text-muted-foreground/50"
+			variant === "muted" ? "text-muted-foreground/30" : "text-muted-foreground/50"
 		}`}
 	>
 		{Icon && <Icon className="h-3 w-3 shrink-0" />}
@@ -122,9 +120,7 @@ export const CalendarEventCard = ({
 	// Plex deep link — lookup by "type:tmdbId" key
 	const plexUrl =
 		event.tmdbId != null && (event.service === "sonarr" || event.service === "radarr")
-			? plexUrlMap.get(
-					`${event.service === "radarr" ? "movie" : "series"}:${event.tmdbId}`,
-				)
+			? plexUrlMap.get(`${event.service === "radarr" ? "movie" : "series"}:${event.tmdbId}`)
 			: undefined;
 
 	const episodeCode =
@@ -134,12 +130,12 @@ export const CalendarEventCard = ({
 
 	const hasMultipleInstances = event.allInstances.length > 1;
 	const instancesDisplay = incognitoMode
-		? (hasMultipleInstances
+		? hasMultipleInstances
 			? event.allInstances.map((inst) => getLinuxInstanceName(inst.instanceName)).join(", ")
-			: getLinuxInstanceName(event.instanceName))
-		: (hasMultipleInstances
+			: getLinuxInstanceName(event.instanceName)
+		: hasMultipleInstances
 			? event.allInstances.map((inst) => inst.instanceName).join(", ")
-			: event.instanceName);
+			: event.instanceName;
 
 	const hasPoster = !incognitoMode && !!event.posterUrl;
 
@@ -206,10 +202,7 @@ export const CalendarEventCard = ({
 							>
 								{instancesDisplay}
 								{hasMultipleInstances && (
-									<span
-										className="ml-1 font-bold"
-										style={{ color: serviceGradient.from }}
-									>
+									<span className="ml-1 font-bold" style={{ color: serviceGradient.from }}>
 										({event.allInstances.length})
 									</span>
 								)}
@@ -225,11 +218,7 @@ export const CalendarEventCard = ({
 
 							{/* Time */}
 							<MetaChip icon={Clock}>
-								{formatTime(
-									event.airDateUtc ??
-										event.airDate ??
-										event.releaseDate,
-								)}
+								{formatTime(event.airDateUtc ?? event.airDate ?? event.releaseDate)}
 							</MetaChip>
 						</div>
 
@@ -257,11 +246,7 @@ export const CalendarEventCard = ({
 								}}
 							>
 								{/* eslint-disable-next-line @next/next/no-img-element -- Remote poster from arr instance */}
-								<img
-									src={event.posterUrl}
-									alt=""
-									className="h-full w-full object-cover"
-								/>
+								<img src={event.posterUrl} alt="" className="h-full w-full object-cover" />
 							</div>
 						)}
 						<div className="flex-1 min-w-0">
@@ -291,21 +276,13 @@ export const CalendarEventCard = ({
 
 					{/* Metadata row */}
 					<div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2">
-						{details.runtime && (
-							<MetaChip icon={Clock}>{details.runtime} min</MetaChip>
-						)}
+						{details.runtime && <MetaChip icon={Clock}>{details.runtime} min</MetaChip>}
 						{details.network && !incognitoMode && <MetaChip>{details.network}</MetaChip>}
 						{details.status && <MetaChip>{details.status}</MetaChip>}
 						{details.monitoring !== undefined && (
 							<MetaChip
-								icon={
-									details.monitoring === "Monitored" ? Eye : EyeOff
-								}
-								variant={
-									details.monitoring === "Monitored"
-										? "default"
-										: "muted"
-								}
+								icon={details.monitoring === "Monitored" ? Eye : EyeOff}
+								variant={details.monitoring === "Monitored" ? "default" : "muted"}
 							>
 								{details.monitoring}
 							</MetaChip>
@@ -313,19 +290,13 @@ export const CalendarEventCard = ({
 						{details.library !== undefined && (
 							<MetaChip
 								icon={HardDrive}
-								variant={
-									details.library === "In library"
-										? "default"
-										: "muted"
-								}
+								variant={details.library === "In library" ? "default" : "muted"}
 							>
 								{details.library}
 							</MetaChip>
 						)}
 						{details.genres && <MetaChip>{details.genres}</MetaChip>}
-						{details.albumType && (
-							<MetaChip>{details.albumType}</MetaChip>
-						)}
+						{details.albumType && <MetaChip>{details.albumType}</MetaChip>}
 					</div>
 
 					{/* External links */}

--- a/apps/web/src/features/calendar/components/calendar-event-list.tsx
+++ b/apps/web/src/features/calendar/components/calendar-event-list.tsx
@@ -36,17 +36,12 @@ export const CalendarEventList = ({
 							background: `linear-gradient(135deg, ${themeGradient.from}15, ${themeGradient.to}08)`,
 						}}
 					>
-						<CalendarDays
-							className="h-4 w-4"
-							style={{ color: themeGradient.from }}
-						/>
+						<CalendarDays className="h-4 w-4" style={{ color: themeGradient.from }} />
 					</div>
 
 					<div className="min-w-0 flex-1">
 						<h2 className="text-sm font-semibold text-foreground truncate">
-							{selectedDate
-								? formatLongDate(selectedDate)
-								: "Select a date"}
+							{selectedDate ? formatLongDate(selectedDate) : "Select a date"}
 						</h2>
 						{selectedEvents.length > 0 && (
 							<span className="text-[10px] text-muted-foreground/35 font-medium">
@@ -81,15 +76,10 @@ export const CalendarEventList = ({
 								background: `linear-gradient(135deg, ${themeGradient.from}08, ${themeGradient.to}04)`,
 							}}
 						>
-							<CalendarDays
-								className="h-6 w-6"
-								style={{ color: `${themeGradient.from}25` }}
-							/>
+							<CalendarDays className="h-6 w-6" style={{ color: `${themeGradient.from}25` }} />
 						</div>
 						<p className="text-xs text-muted-foreground/25 font-medium">
-							{selectedDate
-								? "No scheduled items for this date"
-								: "Select a date to view events"}
+							{selectedDate ? "No scheduled items for this date" : "Select a date to view events"}
 						</p>
 					</div>
 				) : (

--- a/apps/web/src/features/calendar/components/calendar-filters.tsx
+++ b/apps/web/src/features/calendar/components/calendar-filters.tsx
@@ -58,9 +58,7 @@ export const CalendarFilters = ({
 				{SERVICE_TABS.map((tab) => {
 					const isActive = serviceFilter === tab.value;
 					const serviceColor =
-						tab.value !== "all"
-							? getServiceGradient(tab.value).from
-							: themeGradient.from;
+						tab.value !== "all" ? getServiceGradient(tab.value).from : themeGradient.from;
 
 					return (
 						<button
@@ -69,13 +67,9 @@ export const CalendarFilters = ({
 							onClick={() => onServiceFilterChange(tab.value)}
 							className="relative rounded-lg px-2.5 py-1.5 text-[11px] font-semibold tracking-wide transition-all"
 							style={{
-								backgroundColor: isActive
-									? `${serviceColor}12`
-									: "transparent",
+								backgroundColor: isActive ? `${serviceColor}12` : "transparent",
 								color: isActive ? serviceColor : undefined,
-								boxShadow: isActive
-									? `0 0 12px ${serviceColor}08`
-									: "none",
+								boxShadow: isActive ? `0 0 12px ${serviceColor}08` : "none",
 							}}
 						>
 							{tab.label}
@@ -123,9 +117,7 @@ export const CalendarFilters = ({
 					placeholder="Search…"
 					className="h-8 w-[160px] rounded-xl border border-border/10 bg-card/[0.04] pl-7 pr-7 text-[12px] text-foreground placeholder:text-muted-foreground/20 focus:outline-none transition-all"
 					style={{
-						borderColor: searchTerm
-							? `${themeGradient.from}25`
-							: undefined,
+						borderColor: searchTerm ? `${themeGradient.from}25` : undefined,
 						boxShadow: searchTerm
 							? `0 0 0 1px ${themeGradient.from}10, 0 0 12px ${themeGradient.from}06`
 							: undefined,
@@ -152,16 +144,10 @@ export const CalendarFilters = ({
 				className="flex items-center gap-1.5 rounded-xl px-2.5 py-1.5 text-[11px] font-medium transition-all hover:bg-white/[0.04]"
 				style={{
 					color: includeUnmonitored ? themeGradient.from : undefined,
-					boxShadow: includeUnmonitored
-						? `0 0 10px ${themeGradient.from}0c`
-						: undefined,
+					boxShadow: includeUnmonitored ? `0 0 10px ${themeGradient.from}0c` : undefined,
 				}}
 			>
-				{includeUnmonitored ? (
-					<Eye className="h-3 w-3" />
-				) : (
-					<EyeOff className="h-3 w-3" />
-				)}
+				{includeUnmonitored ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
 				Unmonitored
 			</button>
 

--- a/apps/web/src/features/calendar/components/calendar-grid.tsx
+++ b/apps/web/src/features/calendar/components/calendar-grid.tsx
@@ -48,16 +48,13 @@ const isSameDay = (a: Date | null, b: Date): boolean => {
 };
 
 const isSameMonth = (a: Date, b: Date): boolean =>
-	a.getUTCFullYear() === b.getUTCFullYear() &&
-	a.getUTCMonth() === b.getUTCMonth();
+	a.getUTCFullYear() === b.getUTCFullYear() && a.getUTCMonth() === b.getUTCMonth();
 
 const formatDayNumber = (date: Date): string =>
 	new Intl.DateTimeFormat(undefined, { day: "numeric", timeZone: "UTC" }).format(date);
 
 /** Extract unique service colors from a day's events */
-const getUniqueServiceColors = (
-	events: DeduplicatedCalendarItem[],
-): string[] => {
+const getUniqueServiceColors = (events: DeduplicatedCalendarItem[]): string[] => {
 	const seen = new Set<string>();
 	const colors: string[] = [];
 	for (const e of events) {
@@ -168,10 +165,7 @@ export const CalendarGrid = ({
 	const { gradient: themeGradient } = useThemeGradient();
 	const todayKey = formatDateOnly(new Date());
 
-	const rotatedLabels = [
-		...WEEKDAY_LABELS.slice(weekStart),
-		...WEEKDAY_LABELS.slice(0, weekStart),
-	];
+	const rotatedLabels = [...WEEKDAY_LABELS.slice(weekStart), ...WEEKDAY_LABELS.slice(0, weekStart)];
 	// Weekend column indices after rotation
 	const satIndex = (6 - weekStart + 7) % 7;
 	const sunIndex = (0 - weekStart + 7) % 7;
@@ -211,16 +205,11 @@ export const CalendarGrid = ({
 					const hasEvents = events.length > 0;
 					const isPast = key < todayKey;
 
-					const serviceColors = hasEvents
-						? getUniqueServiceColors(events)
-						: [];
-					const dominantColor =
-						serviceColors[0] ?? themeGradient.from;
+					const serviceColors = hasEvents ? getUniqueServiceColors(events) : [];
+					const dominantColor = serviceColors[0] ?? themeGradient.from;
 
 					// Density-based opacity for heatmap effect (1.5% per event, max 7%)
-					const densityOpacity = hasEvents
-						? Math.min(events.length * 0.015, 0.07)
-						: 0;
+					const densityOpacity = hasEvents ? Math.min(events.length * 0.015, 0.07) : 0;
 
 					// Cell selection/glow style
 					const cellStyle: React.CSSProperties = {};
@@ -337,19 +326,12 @@ export const CalendarGrid = ({
 
 							{/* Event chips */}
 							<div className="flex-1 px-1.5 pb-1.5 space-y-px relative z-10 overflow-y-auto [&::-webkit-scrollbar]:w-0.5 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-white/10">
-								{events
-									.slice(0, MAX_VISIBLE_CHIPS)
-									.map((event) => (
-										<EventChip
-											key={`${key}:${String(event.id)}`}
-											event={event}
-										/>
-									))}
+								{events.slice(0, MAX_VISIBLE_CHIPS).map((event) => (
+									<EventChip key={`${key}:${String(event.id)}`} event={event} />
+								))}
 								{events.length > MAX_VISIBLE_CHIPS && (
 									<MoreIndicator
-										hiddenEvents={events.slice(
-											MAX_VISIBLE_CHIPS,
-										)}
+										hiddenEvents={events.slice(MAX_VISIBLE_CHIPS)}
 										dominantColor={dominantColor}
 									/>
 								)}

--- a/apps/web/src/features/calendar/hooks/use-calendar-plex-links.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-plex-links.ts
@@ -26,10 +26,7 @@ export const useCalendarPlexLinks = (
 		const types: string[] = [];
 
 		for (const event of events) {
-			if (
-				event.tmdbId != null &&
-				(event.service === "sonarr" || event.service === "radarr")
-			) {
+			if (event.tmdbId != null && (event.service === "sonarr" || event.service === "radarr")) {
 				const mediaType = event.service === "radarr" ? "movie" : "series";
 				const key = `${mediaType}:${event.tmdbId}`;
 				if (!seen.has(key)) {

--- a/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
@@ -187,6 +187,7 @@ export const CrossSeedItemCard = ({
 									>
 										<span className="flex items-center gap-1.5 font-medium text-foreground/90">
 											{trackerBrand?.iconUrl ? (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													src={trackerBrand.iconUrl}
 													alt=""

--- a/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/needs-attention-panel.test.tsx
@@ -86,9 +86,7 @@ describe("<NeedsAttentionPanel />", () => {
 
 		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
 
-		expect(
-			screen.getByTestId("needs-attention-panel-loading"),
-		).toBeInTheDocument();
+		expect(screen.getByTestId("needs-attention-panel-loading")).toBeInTheDocument();
 		// The loading state must NOT claim "all clear" or show any item rows.
 		expect(screen.queryByText(/No actionable items right now/i)).not.toBeInTheDocument();
 	});
@@ -160,17 +158,15 @@ describe("<NeedsAttentionPanel />", () => {
 		// Action links land on the exact actionUrl from the item, and respect
 		// actionLabel when provided (else "Resolve" default).
 		const openService = screen.getByRole("link", { name: /Open service/i });
-		expect(openService).toHaveAttribute(
-			"href",
-			"/settings/services?instance=sonarr-1",
-		);
+		expect(openService).toHaveAttribute("href", "/settings/services?instance=sonarr-1");
 		const resolve = screen.getByRole("link", { name: /Resolve/i });
 		expect(resolve).toHaveAttribute("href", "/queue-cleaner");
 
 		// Header shows a "View all in Pulse" link regardless.
-		expect(
-			screen.getByRole("link", { name: /View all in Pulse/i }),
-		).toHaveAttribute("href", "/pulse");
+		expect(screen.getByRole("link", { name: /View all in Pulse/i })).toHaveAttribute(
+			"href",
+			"/pulse",
+		);
 	});
 
 	it("shows the critical (error) header accent when any visible item is critical", () => {
@@ -212,9 +208,7 @@ describe("<NeedsAttentionPanel />", () => {
 
 		const panel = screen.getByTestId("needs-attention-panel");
 		// Warning triangle present, no critical x-circle in the header.
-		expect(
-			panel.querySelector(".lucide-alert-triangle, .lucide-triangle-alert"),
-		).not.toBeNull();
+		expect(panel.querySelector(".lucide-alert-triangle, .lucide-triangle-alert")).not.toBeNull();
 	});
 
 	// ---------------------------------------------------------------------
@@ -337,9 +331,6 @@ describe("<NeedsAttentionPanel />", () => {
 
 		render(<NeedsAttentionPanel />, { wrapper: createWrapper() });
 		const link = screen.getByRole("link", { name: /View in Pulse/i });
-		expect(link).toHaveAttribute(
-			"href",
-			"/pulse#scheduler-failing-queue-cleaner",
-		);
+		expect(link).toHaveAttribute("href", "/pulse#scheduler-failing-queue-cleaner");
 	});
 });

--- a/apps/web/src/features/dashboard/components/dashboard-client.tsx
+++ b/apps/web/src/features/dashboard/components/dashboard-client.tsx
@@ -371,16 +371,30 @@ export const DashboardClient = () => {
 		[services],
 	);
 	const hasJellyfinInstances = useMemo(
-		() => services.some((s) => (s.service.toLowerCase() === "jellyfin" || s.service.toLowerCase() === "emby") && s.enabled),
+		() =>
+			services.some(
+				(s) =>
+					(s.service.toLowerCase() === "jellyfin" || s.service.toLowerCase() === "emby") &&
+					s.enabled,
+			),
 		[services],
 	);
 	const hasMediaServer = hasPlexInstances || hasTautulliInstances || hasJellyfinInstances;
 
 	// Session count for Activity tab badge
 	const isMediaTab = activeTab === "overview" || activeTab === "activity";
-	const plexNowPlaying = useNowPlaying(hasPlexInstances, isMediaTab ? POLLING_REALTIME : POLLING_STANDARD);
-	const tautulliActivity = useTautulliActivity(hasTautulliInstances, isMediaTab ? POLLING_REALTIME : POLLING_STANDARD);
-	const jellyfinNowPlaying = useJellyfinNowPlaying(hasJellyfinInstances, isMediaTab ? POLLING_REALTIME : POLLING_STANDARD);
+	const plexNowPlaying = useNowPlaying(
+		hasPlexInstances,
+		isMediaTab ? POLLING_REALTIME : POLLING_STANDARD,
+	);
+	const tautulliActivity = useTautulliActivity(
+		hasTautulliInstances,
+		isMediaTab ? POLLING_REALTIME : POLLING_STANDARD,
+	);
+	const jellyfinNowPlaying = useJellyfinNowPlaying(
+		hasJellyfinInstances,
+		isMediaTab ? POLLING_REALTIME : POLLING_STANDARD,
+	);
 	const sessionCount = useMemo(() => {
 		if (!hasMediaServer) return undefined;
 		const plexCount = plexNowPlaying.data?.sessions?.length ?? 0;
@@ -692,7 +706,13 @@ export const DashboardClient = () => {
 											description={description}
 											subtitle={subtitle}
 											warningLine={warningLine}
-											healthWarning={healthWarning ? (incognitoMode ? anonymizeHealthMessage(healthWarning) : healthWarning) : undefined}
+											healthWarning={
+												healthWarning
+													? incognitoMode
+														? anonymizeHealthMessage(healthWarning)
+														: healthWarning
+													: undefined
+											}
 											detail={instanceNote}
 											onClick={cardOnClick}
 											animationDelay={100 + index * 50}
@@ -741,8 +761,16 @@ export const DashboardClient = () => {
 						)}
 
 						{/* Full-width media carousels */}
-						<OnDeckWidget hasPlexInstances={hasPlexInstances} hasJellyfinInstances={hasJellyfinInstances} animationDelay={500} />
-						<RecentlyAddedWidget hasPlexInstances={hasPlexInstances} hasJellyfinInstances={hasJellyfinInstances} animationDelay={525} />
+						<OnDeckWidget
+							hasPlexInstances={hasPlexInstances}
+							hasJellyfinInstances={hasJellyfinInstances}
+							animationDelay={500}
+						/>
+						<RecentlyAddedWidget
+							hasPlexInstances={hasPlexInstances}
+							hasJellyfinInstances={hasJellyfinInstances}
+							animationDelay={525}
+						/>
 
 						{/* Configured Instances Section — collapsible */}
 						<div
@@ -980,7 +1008,11 @@ export const DashboardClient = () => {
 							hasJellyfinInstances={hasJellyfinInstances}
 							variant="full"
 						/>
-						<OnDeckWidget hasPlexInstances={hasPlexInstances} hasJellyfinInstances={hasJellyfinInstances} animationDelay={100} />
+						<OnDeckWidget
+							hasPlexInstances={hasPlexInstances}
+							hasJellyfinInstances={hasJellyfinInstances}
+							animationDelay={100}
+						/>
 						<WatchHistorySection enabled={hasTautulliInstances} />
 					</div>
 				)}

--- a/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
+++ b/apps/web/src/features/dashboard/components/needs-attention-panel.tsx
@@ -82,10 +82,7 @@ function PanelShell({
 		<section
 			data-testid={testId}
 			aria-label={ariaLabel}
-			className={cn(
-				"overflow-hidden rounded-xl border border-border/30 bg-muted/10",
-				className,
-			)}
+			className={cn("overflow-hidden rounded-xl border border-border/30 bg-muted/10", className)}
 		>
 			{children}
 		</section>
@@ -144,13 +141,7 @@ function PanelHeader({
 // AttentionRow — one row per item. No severity logic beyond "pick the visual
 // for critical vs warning". Severity comes from the item verbatim.
 // ---------------------------------------------------------------------------
-function AttentionRow({
-	item,
-	incognito,
-}: {
-	item: PulseItem;
-	incognito: boolean;
-}) {
+function AttentionRow({ item, incognito }: { item: PulseItem; incognito: boolean }) {
 	const visual =
 		item.severity === "critical" || item.severity === "warning"
 			? SEVERITY_VISUAL[item.severity]
@@ -164,8 +155,7 @@ function AttentionRow({
 	// Pass `item.source` so system-sourced titles (scheduler jobs, cache health)
 	// aren't mis-anonymized as ARR instance labels by the " is "-split branch.
 	const title = incognito ? anonymizePulseText(item.title, item.source) : item.title;
-	const detail =
-		incognito && item.detail ? anonymizeHealthMessage(item.detail) : item.detail;
+	const detail = incognito && item.detail ? anonymizeHealthMessage(item.detail) : item.detail;
 
 	return (
 		<li className="flex items-start gap-3 border-b border-border/30 px-6 py-3 last:border-b-0">
@@ -183,9 +173,7 @@ function AttentionRow({
 			</div>
 			<div className="min-w-0 flex-1">
 				<p className="truncate text-sm font-medium text-foreground">{title}</p>
-				{detail && (
-					<p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>
-				)}
+				{detail && <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">{detail}</p>}
 			</div>
 			{item.action && <PulseActionButton signalId={item.id} action={item.action} />}
 			{item.actionUrl && (
@@ -218,10 +206,7 @@ export function NeedsAttentionPanel() {
 	// State: loading (no cached data yet).
 	if (isLoading) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-loading"
-				ariaLabel="Needs Attention — loading"
-			>
+			<PanelShell testId="needs-attention-panel-loading" ariaLabel="Needs Attention — loading">
 				<div className="flex items-center gap-3 border-b border-border/50 px-6 py-4">
 					<div className="h-8 w-8 animate-pulse rounded-lg bg-muted/30" />
 					<div className="flex-1 space-y-1.5">
@@ -241,10 +226,7 @@ export function NeedsAttentionPanel() {
 	// State: error with no cached data — NEVER imply "all clear" here.
 	if (isError && !data) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-error"
-				ariaLabel="Needs Attention — unavailable"
-			>
+			<PanelShell testId="needs-attention-panel-error" ariaLabel="Needs Attention — unavailable">
 				<div className="flex items-start gap-3 px-6 py-4">
 					<XCircle
 						className="mt-0.5 h-5 w-5 shrink-0"
@@ -255,8 +237,8 @@ export function NeedsAttentionPanel() {
 							Couldn&apos;t load attention items
 						</h3>
 						<p className="mt-0.5 text-xs text-muted-foreground">
-							The attention feed is unavailable right now — other dashboard signals may
-							still be accurate.{" "}
+							The attention feed is unavailable right now — other dashboard signals may still be
+							accurate.{" "}
 							<Link
 								href="/pulse"
 								className="underline underline-offset-2 transition-colors hover:text-foreground"
@@ -278,19 +260,14 @@ export function NeedsAttentionPanel() {
 	// State: empty — only shown when fetch succeeded.
 	if (visible.length === 0) {
 		return (
-			<PanelShell
-				testId="needs-attention-panel-empty"
-				ariaLabel="Needs Attention — all clear"
-			>
+			<PanelShell testId="needs-attention-panel-empty" ariaLabel="Needs Attention — all clear">
 				<div className="flex items-start gap-3 px-6 py-4">
 					<CheckCircle2
 						className="mt-0.5 h-5 w-5 shrink-0"
 						style={{ color: SEMANTIC_COLORS.success.text }}
 					/>
 					<div className="min-w-0 flex-1">
-						<h3 className="text-sm font-semibold text-foreground">
-							No actionable items right now
-						</h3>
+						<h3 className="text-sm font-semibold text-foreground">No actionable items right now</h3>
 						<p className="mt-0.5 text-xs text-muted-foreground">
 							Open Pulse to view the full signal list.
 						</p>

--- a/apps/web/src/features/dashboard/components/now-playing-widget.tsx
+++ b/apps/web/src/features/dashboard/components/now-playing-widget.tsx
@@ -392,7 +392,9 @@ export const NowPlayingWidget = ({
 		hasTautulliInstances && tautulliQuery.isError,
 		hasJellyfinInstances && jellyfinQuery.isError,
 	].filter(Boolean).length;
-	const enabledSources = [hasPlexInstances, hasTautulliInstances, hasJellyfinInstances].filter(Boolean).length;
+	const enabledSources = [hasPlexInstances, hasTautulliInstances, hasJellyfinInstances].filter(
+		Boolean,
+	).length;
 	const hasError = enabledSources > 0 && enabledErrors === enabledSources;
 
 	if (isLoading && sessions.length === 0) return null;

--- a/apps/web/src/features/dashboard/components/on-deck-widget.tsx
+++ b/apps/web/src/features/dashboard/components/on-deck-widget.tsx
@@ -36,7 +36,11 @@ interface OnDeckWidgetProps {
 	animationDelay?: number;
 }
 
-export const OnDeckWidget = ({ hasPlexInstances, hasJellyfinInstances, animationDelay = 0 }: OnDeckWidgetProps) => {
+export const OnDeckWidget = ({
+	hasPlexInstances,
+	hasJellyfinInstances,
+	animationDelay = 0,
+}: OnDeckWidgetProps) => {
 	const enabled = hasPlexInstances || hasJellyfinInstances;
 	const [incognitoMode] = useIncognitoMode();
 	const plexQuery = useOnDeck(hasPlexInstances);
@@ -71,7 +75,10 @@ export const OnDeckWidget = ({ hasPlexInstances, hasJellyfinInstances, animation
 
 	const isLoading = plexQuery.isLoading || jellyfinQuery.isLoading;
 	// Only error if all enabled sources failed
-	const enabledErrors = [hasPlexInstances && plexQuery.isError, hasJellyfinInstances && jellyfinQuery.isError].filter(Boolean).length;
+	const enabledErrors = [
+		hasPlexInstances && plexQuery.isError,
+		hasJellyfinInstances && jellyfinQuery.isError,
+	].filter(Boolean).length;
 	const enabledCount = [hasPlexInstances, hasJellyfinInstances].filter(Boolean).length;
 	const isError = enabledCount > 0 && enabledErrors === enabledCount;
 	const [failedThumbs, setFailedThumbs] = useState<Set<string>>(new Set());
@@ -153,7 +160,10 @@ export const OnDeckWidget = ({ hasPlexInstances, hasJellyfinInstances, animation
 								const hasThumb = item.thumbUrl && !failedThumbs.has(thumbKey);
 								const libraryHref = item.tmdbId ? `/library?tmdbId=${item.tmdbId}` : "/library";
 								const displayTitle = incognitoMode ? getLinuxIsoName(item.title) : item.title;
-								const displaySection = incognitoMode && item.sectionTitle ? getLinuxSectionName(item.sectionTitle) : item.sectionTitle;
+								const displaySection =
+									incognitoMode && item.sectionTitle
+										? getLinuxSectionName(item.sectionTitle)
+										: item.sectionTitle;
 
 								return (
 									<Link
@@ -180,7 +190,7 @@ export const OnDeckWidget = ({ hasPlexInstances, hasJellyfinInstances, animation
 													height={210}
 													className="absolute inset-0 w-full h-full object-cover"
 													onError={() => setFailedThumbs((prev) => new Set(prev).add(thumbKey))}
-											unoptimized
+													unoptimized
 												/>
 											) : (
 												<MediaIcon className="absolute inset-0 m-auto h-10 w-10 text-white/30" />

--- a/apps/web/src/features/dashboard/components/plex-server-info-widget.tsx
+++ b/apps/web/src/features/dashboard/components/plex-server-info-widget.tsx
@@ -85,7 +85,10 @@ export const PlexServerInfoWidget = ({
 	}, [plexQuery.data, jellyfinQuery.data]);
 
 	const isLoading = plexQuery.isLoading || jellyfinQuery.isLoading;
-	const enabledErrors = [hasPlexInstances && plexQuery.isError, hasJellyfinInstances && jellyfinQuery.isError].filter(Boolean).length;
+	const enabledErrors = [
+		hasPlexInstances && plexQuery.isError,
+		hasJellyfinInstances && jellyfinQuery.isError,
+	].filter(Boolean).length;
 	const enabledCount = [hasPlexInstances, hasJellyfinInstances].filter(Boolean).length;
 	const isError = enabledCount > 0 && enabledErrors === enabledCount;
 
@@ -188,7 +191,9 @@ export const PlexServerInfoWidget = ({
 									{server.platform && ` · ${server.platform}`}
 								</p>
 							</div>
-							<span className="text-[10px] text-muted-foreground/60 capitalize">{server.source}</span>
+							<span className="text-[10px] text-muted-foreground/60 capitalize">
+								{server.source}
+							</span>
 							<span className="text-xs text-muted-foreground font-mono">
 								{incognitoMode ? "••••••••" : server.identifier.slice(0, 8)}
 							</span>

--- a/apps/web/src/features/dashboard/components/recently-added-widget.tsx
+++ b/apps/web/src/features/dashboard/components/recently-added-widget.tsx
@@ -47,7 +47,11 @@ interface RecentlyAddedWidgetProps {
 	animationDelay?: number;
 }
 
-export const RecentlyAddedWidget = ({ hasPlexInstances, hasJellyfinInstances, animationDelay = 0 }: RecentlyAddedWidgetProps) => {
+export const RecentlyAddedWidget = ({
+	hasPlexInstances,
+	hasJellyfinInstances,
+	animationDelay = 0,
+}: RecentlyAddedWidgetProps) => {
 	const enabled = hasPlexInstances || hasJellyfinInstances;
 	const [incognitoMode] = useIncognitoMode();
 	const plexQuery = useRecentlyAdded(20, hasPlexInstances);
@@ -89,7 +93,10 @@ export const RecentlyAddedWidget = ({ hasPlexInstances, hasJellyfinInstances, an
 	}, [plexQuery.data, jellyfinQuery.data]);
 
 	const isLoading = plexQuery.isLoading || jellyfinQuery.isLoading;
-	const enabledErrors = [hasPlexInstances && plexQuery.isError, hasJellyfinInstances && jellyfinQuery.isError].filter(Boolean).length;
+	const enabledErrors = [
+		hasPlexInstances && plexQuery.isError,
+		hasJellyfinInstances && jellyfinQuery.isError,
+	].filter(Boolean).length;
 	const enabledCount = [hasPlexInstances, hasJellyfinInstances].filter(Boolean).length;
 	const isError = enabledCount > 0 && enabledErrors === enabledCount;
 	const [failedThumbs, setFailedThumbs] = useState<Set<string>>(new Set());
@@ -169,7 +176,10 @@ export const RecentlyAddedWidget = ({ hasPlexInstances, hasJellyfinInstances, an
 								const hasThumb = item.thumbUrl && !failedThumbs.has(thumbKey);
 								const libraryHref = item.tmdbId ? `/library?tmdbId=${item.tmdbId}` : "/library";
 								const displayTitle = incognitoMode ? getLinuxIsoName(item.title) : item.title;
-								const displaySection = incognitoMode && item.sectionTitle ? getLinuxSectionName(item.sectionTitle) : item.sectionTitle;
+								const displaySection =
+									incognitoMode && item.sectionTitle
+										? getLinuxSectionName(item.sectionTitle)
+										: item.sectionTitle;
 
 								return (
 									<Link
@@ -196,7 +206,7 @@ export const RecentlyAddedWidget = ({ hasPlexInstances, hasJellyfinInstances, an
 													height={210}
 													className="absolute inset-0 w-full h-full object-cover"
 													onError={() => setFailedThumbs((prev) => new Set(prev).add(thumbKey))}
-											unoptimized
+													unoptimized
 												/>
 											) : (
 												<MediaIcon className="absolute inset-0 m-auto h-10 w-10 text-white/30" />

--- a/apps/web/src/features/dashboard/components/seerr-requests-widget.tsx
+++ b/apps/web/src/features/dashboard/components/seerr-requests-widget.tsx
@@ -96,7 +96,12 @@ export const SeerrRequestsWidget = ({
 
 	const statusStats = [
 		{ icon: Clock, label: "Pending", value: counts.pending, color: SEMANTIC_COLORS.warning.text },
-		{ icon: Loader2, label: "Processing", value: counts.processing, color: SEMANTIC_COLORS.warning.text },
+		{
+			icon: Loader2,
+			label: "Processing",
+			value: counts.processing,
+			color: SEMANTIC_COLORS.warning.text,
+		},
 		{ icon: Check, label: "Approved", value: counts.approved, color: SEMANTIC_COLORS.success.text },
 		{ icon: X, label: "Declined", value: counts.declined, color: SEMANTIC_COLORS.error.text },
 	];
@@ -123,7 +128,9 @@ export const SeerrRequestsWidget = ({
 				tabIndex={0}
 				className="block cursor-pointer"
 				onClick={() => router.push("/requests")}
-				onKeyDown={(e) => { if (e.key === "Enter") router.push("/requests"); }}
+				onKeyDown={(e) => {
+					if (e.key === "Enter") router.push("/requests");
+				}}
 			>
 				<div className="overflow-hidden rounded-xl border border-border/30 bg-muted/10 group transition-all hover:border-border/80">
 					{/* Accent line */}
@@ -237,13 +244,7 @@ function NeedsAttentionSection({
 	);
 }
 
-function AttentionItemRow({
-	item,
-	instanceId,
-}: {
-	item: SeerrAttentionItem;
-	instanceId: string;
-}) {
+function AttentionItemRow({ item, instanceId }: { item: SeerrAttentionItem; instanceId: string }) {
 	const [incognitoMode] = useIncognitoMode();
 	const retryMutation = useRetrySeerrRequest();
 	const [isRetrying, setIsRetrying] = useState(false);

--- a/apps/web/src/features/dashboard/components/watch-history-section.tsx
+++ b/apps/web/src/features/dashboard/components/watch-history-section.tsx
@@ -40,9 +40,7 @@ const plexGradient = SERVICE_GRADIENTS.plex;
 const HistoryRow = ({ item, index }: { item: TautulliWatchHistoryItem; index: number }) => {
 	const [incognitoMode] = useIncognitoMode();
 	const Icon = MEDIA_ICONS[item.mediaType] ?? Film;
-	const rawTitle = item.grandparentTitle
-		? `${item.grandparentTitle} — ${item.title}`
-		: item.title;
+	const rawTitle = item.grandparentTitle ? `${item.grandparentTitle} — ${item.title}` : item.title;
 	const displayTitle = incognitoMode ? getLinuxIsoName(rawTitle) : rawTitle;
 
 	return (

--- a/apps/web/src/features/discover/components/discover-detail-modal.tsx
+++ b/apps/web/src/features/discover/components/discover-detail-modal.tsx
@@ -63,8 +63,12 @@ export const DiscoverDetailModal: React.FC<DiscoverDetailModalProps> = ({
 						(details as NonNullable<typeof tvQuery.data>)?.firstAirDate ?? item.firstAirDate,
 				},
 	);
-	const backdropUrl = incognitoMode ? null : getSeerrImageUrl(details?.backdropPath ?? item.backdropPath, "w1280");
-	const posterUrl = incognitoMode ? null : getSeerrImageUrl(details?.posterPath ?? item.posterPath, "w342");
+	const backdropUrl = incognitoMode
+		? null
+		: getSeerrImageUrl(details?.backdropPath ?? item.backdropPath, "w1280");
+	const posterUrl = incognitoMode
+		? null
+		: getSeerrImageUrl(details?.posterPath ?? item.posterPath, "w342");
 
 	const mediaStatus = details?.mediaInfo?.status ?? item.mediaInfo?.status;
 	const statusInfo = getMediaStatusInfo(mediaStatus);

--- a/apps/web/src/features/discover/components/discover-request-dialog.tsx
+++ b/apps/web/src/features/discover/components/discover-request-dialog.tsx
@@ -266,16 +266,12 @@ export const DiscoverRequestDialog: React.FC<DiscoverRequestDialogProps> = ({
 								icon={User}
 								label="Request As"
 								value={selectedUserId?.toString() ?? USE_DEFAULT}
-								onChange={(v) =>
-									setSelectedUserId(v === USE_DEFAULT ? undefined : Number(v))
-								}
+								onChange={(v) => setSelectedUserId(v === USE_DEFAULT ? undefined : Number(v))}
 								options={[
 									{ value: USE_DEFAULT, label: "Default request user" },
 									...seerrUsers.map((u) => ({
 										value: u.id.toString(),
-										label: incognitoMode
-											? getLinuxUsername(u.displayName)
-											: u.displayName,
+										label: incognitoMode ? getLinuxUsername(u.displayName) : u.displayName,
 									})),
 								]}
 								themeFrom={themeGradient.from}
@@ -379,20 +375,14 @@ export const DiscoverRequestDialog: React.FC<DiscoverRequestDialogProps> = ({
 														}
 														className="rounded-md border px-2.5 py-1 text-xs font-medium transition-all duration-150"
 														style={{
-															borderColor: isSelected
-																? `${themeGradient.from}60`
-																: "var(--border)",
+															borderColor: isSelected ? `${themeGradient.from}60` : "var(--border)",
 															backgroundColor: isSelected
 																? `${themeGradient.from}12`
 																: "transparent",
-															color: isSelected
-																? themeGradient.from
-																: "var(--muted-foreground)",
+															color: isSelected ? themeGradient.from : "var(--muted-foreground)",
 														}}
 													>
-														{incognitoMode
-															? getLinuxUsername(tag.label)
-															: tag.label}
+														{incognitoMode ? getLinuxUsername(tag.label) : tag.label}
 													</button>
 												);
 											})}

--- a/apps/web/src/features/discover/components/media-detail-sections.tsx
+++ b/apps/web/src/features/discover/components/media-detail-sections.tsx
@@ -307,28 +307,42 @@ export const ExternalLinksSection: React.FC<ExternalLinksSectionProps> = ({
 						TVDB
 					</button>
 				)}
-				{plexUrl && (() => {
-					const watchColors = watchLabel === "Jellyfin"
-						? { bg: "rgba(0, 164, 220, 0.1)", border: "rgba(0, 164, 220, 0.3)", text: "#00a4dc" }
-						: watchLabel === "Emby"
-							? { bg: "rgba(82, 181, 75, 0.1)", border: "rgba(82, 181, 75, 0.3)", text: "#52b54b" }
-							: { bg: "rgba(229, 160, 13, 0.1)", border: "rgba(229, 160, 13, 0.3)", text: "#e5a00d" };
-					return (
-						<button
-							type="button"
-							className={btnClass}
-							style={{
-								backgroundColor: watchColors.bg,
-								border: `1px solid ${watchColors.border}`,
-								color: watchColors.text,
-							}}
-							onClick={() => safeOpenUrl(plexUrl)}
-						>
-							<ExternalLink className="h-3.5 w-3.5" />
-							Watch in {watchLabel}
-						</button>
-					);
-				})()}
+				{plexUrl &&
+					(() => {
+						const watchColors =
+							watchLabel === "Jellyfin"
+								? {
+										bg: "rgba(0, 164, 220, 0.1)",
+										border: "rgba(0, 164, 220, 0.3)",
+										text: "#00a4dc",
+									}
+								: watchLabel === "Emby"
+									? {
+											bg: "rgba(82, 181, 75, 0.1)",
+											border: "rgba(82, 181, 75, 0.3)",
+											text: "#52b54b",
+										}
+									: {
+											bg: "rgba(229, 160, 13, 0.1)",
+											border: "rgba(229, 160, 13, 0.3)",
+											text: "#e5a00d",
+										};
+						return (
+							<button
+								type="button"
+								className={btnClass}
+								style={{
+									backgroundColor: watchColors.bg,
+									border: `1px solid ${watchColors.border}`,
+									color: watchColors.text,
+								}}
+								onClick={() => safeOpenUrl(plexUrl)}
+							>
+								<ExternalLink className="h-3.5 w-3.5" />
+								Watch in {watchLabel}
+							</button>
+						);
+					})()}
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/history/components/history-timeline.tsx
+++ b/apps/web/src/features/history/components/history-timeline.tsx
@@ -167,15 +167,21 @@ const HistoryTimelineCard = ({
 		>
 			<div
 				className="absolute inset-0 pointer-events-none"
-				style={{ background: `linear-gradient(135deg, ${serviceGradient.from}04, transparent 60%)` }}
+				style={{
+					background: `linear-gradient(135deg, ${serviceGradient.from}04, transparent 60%)`,
+				}}
 			/>
 			<div
 				className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-				style={{ background: `radial-gradient(ellipse at top left, ${serviceGradient.from}06, transparent 50%)` }}
+				style={{
+					background: `radial-gradient(ellipse at top left, ${serviceGradient.from}06, transparent 50%)`,
+				}}
 			/>
 			<div
 				className="absolute left-0 top-0 bottom-0 w-[3px]"
-				style={{ background: `linear-gradient(180deg, ${serviceGradient.from}, ${serviceGradient.to}70)` }}
+				style={{
+					background: `linear-gradient(180deg, ${serviceGradient.from}, ${serviceGradient.to}70)`,
+				}}
 			/>
 			<div className="relative p-4 space-y-2">
 				{/* Header: Title + Relative Time */}

--- a/apps/web/src/features/hunting/components/hunting-activity.tsx
+++ b/apps/web/src/features/hunting/components/hunting-activity.tsx
@@ -25,7 +25,12 @@ import {
 	StatusBadge,
 } from "../../../components/layout";
 import { Pagination } from "../../../components/ui";
-import { getLinuxIndexer, getLinuxInstanceName, getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
+import {
+	getLinuxIndexer,
+	getLinuxInstanceName,
+	getLinuxIsoName,
+	useIncognitoMode,
+} from "../../../lib/incognito";
 import { getServiceGradient, SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { useHuntingLogs } from "../hooks/useHuntingLogs";
 import type { HuntLog } from "../lib/hunting-types";
@@ -291,10 +296,7 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 					<div className="flex items-center gap-3">
 						{isRunning ? (
 							<div className="flex items-center gap-1">
-								<Loader2
-									className="h-3 w-3 animate-spin"
-									style={{ color: serviceGradient.from }}
-								/>
+								<Loader2 className="h-3 w-3 animate-spin" style={{ color: serviceGradient.from }} />
 								<span>Searching...</span>
 							</div>
 						) : (
@@ -305,11 +307,7 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 								</span>
 								<span
 									className={`inline-flex items-center gap-1 text-[11px] ${log.itemsGrabbed > 0 ? "" : "text-muted-foreground/50"}`}
-									style={
-										log.itemsGrabbed > 0
-											? { color: SEMANTIC_COLORS.success.text }
-											: undefined
-									}
+									style={log.itemsGrabbed > 0 ? { color: SEMANTIC_COLORS.success.text } : undefined}
 								>
 									<Download className="h-3 w-3 shrink-0" />
 									{log.itemsGrabbed} grabbed
@@ -339,9 +337,7 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 			{expanded && (
 				<div className="relative px-5 py-4 border-t border-border/20 text-sm space-y-4">
 					{/* Message */}
-					{log.message && (
-						<p className="text-[11.5px] text-muted-foreground/50">{log.message}</p>
-					)}
+					{log.message && <p className="text-[11.5px] text-muted-foreground/50">{log.message}</p>}
 
 					{/* Metadata */}
 					<div className="flex flex-wrap gap-4 text-xs text-muted-foreground/40">
@@ -377,12 +373,14 @@ const ActivityLogEntry = ({ log, animationDelay = 0 }: ActivityLogEntryProps) =>
 											border: `1px solid ${SEMANTIC_COLORS.success.border}`,
 										}}
 									>
-										<span className="font-medium text-foreground flex-1">{incognitoMode ? getLinuxIsoName(item.title) : item.title}</span>
-										{item.quality && (
-											<StatusBadge status="success">{item.quality}</StatusBadge>
-										)}
+										<span className="font-medium text-foreground flex-1">
+											{incognitoMode ? getLinuxIsoName(item.title) : item.title}
+										</span>
+										{item.quality && <StatusBadge status="success">{item.quality}</StatusBadge>}
 										{item.indexer && (
-											<span className="text-muted-foreground">{incognitoMode ? getLinuxIndexer(item.indexer) : item.indexer}</span>
+											<span className="text-muted-foreground">
+												{incognitoMode ? getLinuxIndexer(item.indexer) : item.indexer}
+											</span>
 										)}
 										{item.size && (
 											<span className="text-muted-foreground flex items-center gap-1">

--- a/apps/web/src/features/hunting/components/hunting-client.tsx
+++ b/apps/web/src/features/hunting/components/hunting-client.tsx
@@ -103,7 +103,13 @@ export const HuntingClient = () => {
 				className="animate-in fade-in slide-in-from-bottom-4 duration-500"
 				style={{ animationDelay: "200ms", animationFillMode: "backwards" }}
 			>
-				{activeTab === "overview" && <HuntingOverview status={status} onRefresh={refetch} onConfigure={() => setActiveTab("config")} />}
+				{activeTab === "overview" && (
+					<HuntingOverview
+						status={status}
+						onRefresh={refetch}
+						onConfigure={() => setActiveTab("config")}
+					/>
+				)}
 				{activeTab === "activity" && <HuntingActivity />}
 				{activeTab === "config" && <HuntingConfig />}
 			</div>

--- a/apps/web/src/features/hunting/components/hunting-config.tsx
+++ b/apps/web/src/features/hunting/components/hunting-config.tsx
@@ -142,7 +142,9 @@ export const HuntingConfig = () => {
 	return (
 		<div className="flex flex-col gap-8">
 			{/* Global Automation Control */}
-			<div className={`overflow-hidden rounded-xl border border-border/30 bg-muted/10 ${schedulerRunning ? "border-green-500/30" : ""}`}>
+			<div
+				className={`overflow-hidden rounded-xl border border-border/30 bg-muted/10 ${schedulerRunning ? "border-green-500/30" : ""}`}
+			>
 				{/* Status accent line */}
 				<div
 					className="h-1 rounded-t-2xl"
@@ -406,7 +408,9 @@ const InstanceConfigCard = ({ config, onSaved, animationDelay = 0 }: InstanceCon
 					</div>
 					<div>
 						<div className="flex items-center gap-2">
-							<h3 className="font-semibold">{incognitoMode ? getLinuxInstanceName(config.instanceName) : config.instanceName}</h3>
+							<h3 className="font-semibold">
+								{incognitoMode ? getLinuxInstanceName(config.instanceName) : config.instanceName}
+							</h3>
 							<ServiceBadge service={config.service} />
 						</div>
 						<p className="text-sm text-muted-foreground">
@@ -633,7 +637,12 @@ const InstanceConfigCard = ({ config, onSaved, animationDelay = 0 }: InstanceCon
 								</DialogTitle>
 								<DialogDescription>
 									Are you sure you want to clear the search history for{" "}
-									<span className="font-medium text-foreground">{incognitoMode ? getLinuxInstanceName(config.instanceName) : config.instanceName}</span>?
+									<span className="font-medium text-foreground">
+										{incognitoMode
+											? getLinuxInstanceName(config.instanceName)
+											: config.instanceName}
+									</span>
+									?
 								</DialogDescription>
 							</DialogHeader>
 							<div className="rounded-lg border border-border/50 bg-muted/30 p-3 text-sm text-muted-foreground">
@@ -763,12 +772,12 @@ const UnconfiguredInstanceCard = ({
 					</span>
 					<div>
 						<div className="flex items-center gap-2">
-							<span className="font-semibold text-[14px] text-foreground">{incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}</span>
+							<span className="font-semibold text-[14px] text-foreground">
+								{incognitoMode ? getLinuxInstanceName(instanceName) : instanceName}
+							</span>
 							<ServiceBadge service={service} />
 						</div>
-						<p className="text-[11px] text-muted-foreground/40 mt-0.5">
-							Click to enable hunting
-						</p>
+						<p className="text-[11px] text-muted-foreground/40 mt-0.5">Click to enable hunting</p>
 					</div>
 				</div>
 				<Button

--- a/apps/web/src/features/hunting/components/hunting-overview.tsx
+++ b/apps/web/src/features/hunting/components/hunting-overview.tsx
@@ -60,7 +60,11 @@ export const HuntingOverview = ({ status, onRefresh, onConfigure }: HuntingOverv
 				description="Configure hunting for your Sonarr, Radarr, Lidarr, and Readarr instances to start finding missing and upgrade content."
 				action={
 					onConfigure ? (
-						<Button variant="secondary" className="gap-2 border-border/50 bg-card/50" onClick={onConfigure}>
+						<Button
+							variant="secondary"
+							className="gap-2 border-border/50 bg-card/50"
+							onClick={onConfigure}
+						>
 							Go to Configuration
 						</Button>
 					) : undefined

--- a/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
+++ b/apps/web/src/features/indexers/components/indexer-configuration-fields.tsx
@@ -51,7 +51,9 @@ const FieldRow = ({
 				{/* Value */}
 				<div className="flex-1 min-w-0 flex items-center gap-2">
 					{sensitive && <Lock className="h-3 w-3 text-muted-foreground/45 shrink-0" />}
-					<p className={`text-[13px] font-medium leading-tight min-w-0 ${masked ? "select-none" : ""}`}>
+					<p
+						className={`text-[13px] font-medium leading-tight min-w-0 ${masked ? "select-none" : ""}`}
+					>
 						{masked ? (
 							<span className="text-muted-foreground/45 tracking-[0.2em] font-mono text-xs">
 								{"●".repeat(Math.min(displayValue.length, 20))}
@@ -67,11 +69,7 @@ const FieldRow = ({
 							className="shrink-0 rounded-md p-1 text-muted-foreground/45 hover:text-foreground hover:bg-card/60 transition-all opacity-0 group-hover:opacity-100"
 							title={copied ? "Copied!" : "Copy value"}
 						>
-							{copied ? (
-								<Check className="h-3 w-3 text-green-500" />
-							) : (
-								<Copy className="h-3 w-3" />
-							)}
+							{copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
 						</button>
 					)}
 				</div>
@@ -159,13 +157,7 @@ export const IndexerConfigurationFields = ({ fields }: { fields: ProwlarrIndexer
 			{normalFields.length > 0 && (
 				<div className="divide-y divide-border/10">
 					{normalFields.map((field, index) => (
-						<FieldRow
-							key={field.name}
-							field={field}
-							index={index}
-							sensitive={false}
-							revealed
-						/>
+						<FieldRow key={field.name} field={field} index={index} sensitive={false} revealed />
 					))}
 				</div>
 			)}

--- a/apps/web/src/features/indexers/components/indexer-details-info.tsx
+++ b/apps/web/src/features/indexers/components/indexer-details-info.tsx
@@ -80,7 +80,10 @@ const SuccessGauge = ({ rate }: { rate?: number }) => {
 	if (rate === undefined) {
 		return (
 			<div className="flex flex-col items-center gap-2">
-				<div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+				<div
+					className="relative flex items-center justify-center"
+					style={{ width: size, height: size }}
+				>
 					<svg viewBox={viewBox} width={size} height={size} className="-rotate-90">
 						<circle
 							cx={cx}
@@ -113,7 +116,10 @@ const SuccessGauge = ({ rate }: { rate?: number }) => {
 
 	return (
 		<div className="flex flex-col items-center gap-2">
-			<div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+			<div
+				className="relative flex items-center justify-center"
+				style={{ width: size, height: size }}
+			>
 				{/* Glow backdrop */}
 				<div
 					className="absolute inset-2 rounded-full"
@@ -149,7 +155,10 @@ const SuccessGauge = ({ rate }: { rate?: number }) => {
 					/>
 				</svg>
 				<div className="absolute flex flex-col items-center">
-					<span className="text-lg font-bold tabular-nums leading-none" style={{ color: gaugeColor }}>
+					<span
+						className="text-lg font-bold tabular-nums leading-none"
+						style={{ color: gaugeColor }}
+					>
 						{pct}
 					</span>
 					<span className="text-[9px] font-medium text-muted-foreground/40 mt-0.5">%</span>
@@ -235,8 +244,7 @@ export const IndexerDetailsInfo = ({
 	const categories = detail.categories ?? [];
 	const protocol = detail.protocol ?? indexer.protocol;
 
-	const protocolColor =
-		protocol === "torrent" ? PROTOCOL_COLORS.torrent : PROTOCOL_COLORS.usenet;
+	const protocolColor = protocol === "torrent" ? PROTOCOL_COLORS.torrent : PROTOCOL_COLORS.usenet;
 
 	return (
 		<div className="space-y-0">
@@ -274,22 +282,12 @@ export const IndexerDetailsInfo = ({
 						icon={Folder}
 						label="App Profile"
 						value={
-							typeof detail.appProfileId === "number"
-								? detail.appProfileId.toString()
-								: "Default"
+							typeof detail.appProfileId === "number" ? detail.appProfileId.toString() : "Default"
 						}
 						mono
 					/>
-					<StatTile
-						icon={Shield}
-						label="Privacy"
-						value={detail.privacy ?? undefined}
-					/>
-					<StatTile
-						icon={Globe}
-						label="Language"
-						value={detail.language ?? undefined}
-					/>
+					<StatTile icon={Shield} label="Privacy" value={detail.privacy ?? undefined} />
+					<StatTile icon={Globe} label="Language" value={detail.language ?? undefined} />
 				</div>
 			</div>
 
@@ -318,20 +316,12 @@ export const IndexerDetailsInfo = ({
 								value={formatResponseTime(stats.averageResponseTime)}
 								color={themeGradient.from}
 							/>
-							<PerfMetric
-								icon={Clock}
-								label="Last Check"
-								value={formatDateTime(stats.lastCheck)}
-							/>
+							<PerfMetric icon={Clock} label="Last Check" value={formatDateTime(stats.lastCheck)} />
 							<PerfMetric
 								icon={AlertTriangle}
 								label="Last Failure"
 								value={formatDateTime(stats.lastFailure)}
-								color={
-									stats.lastFailure
-										? SEMANTIC_COLORS.error.from
-										: undefined
-								}
+								color={stats.lastFailure ? SEMANTIC_COLORS.error.from : undefined}
 							/>
 							{typeof stats.grabs === "number" && (
 								<PerfMetric
@@ -374,9 +364,7 @@ export const IndexerDetailsInfo = ({
 
 					{categories.length > 0 && (
 						<>
-							{capabilities.length > 0 && (
-								<span className="w-px h-4 bg-border/20 mx-1.5" />
-							)}
+							{capabilities.length > 0 && <span className="w-px h-4 bg-border/20 mx-1.5" />}
 							<span className="text-[10px] font-semibold text-muted-foreground/40 mr-1 shrink-0">
 								Categories
 							</span>

--- a/apps/web/src/features/indexers/components/indexer-details-panel.tsx
+++ b/apps/web/src/features/indexers/components/indexer-details-panel.tsx
@@ -1,15 +1,7 @@
 "use client";
 
 import type { ProwlarrIndexer, ProwlarrIndexerDetails } from "@arr/shared";
-import {
-	AlertCircle,
-	ChevronDown,
-	Loader2,
-	Pencil,
-	RefreshCw,
-	Save,
-	X,
-} from "lucide-react";
+import { AlertCircle, ChevronDown, Loader2, Pencil, RefreshCw, Save, X } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { PremiumSkeleton } from "../../../components/layout/premium-components";
 import { useIndexerDetailsQuery } from "../../../hooks/api/useSearch";
@@ -183,8 +175,16 @@ export const IndexerDetailsPanel = ({
 					<div className="space-y-3 py-2">
 						<div className="flex items-center gap-3">
 							<PremiumSkeleton variant="line" className="h-4 w-28" />
-							<PremiumSkeleton variant="line" className="h-4 w-20" style={{ animationDelay: "60ms" }} />
-							<PremiumSkeleton variant="line" className="h-4 w-16" style={{ animationDelay: "120ms" }} />
+							<PremiumSkeleton
+								variant="line"
+								className="h-4 w-20"
+								style={{ animationDelay: "60ms" }}
+							/>
+							<PremiumSkeleton
+								variant="line"
+								className="h-4 w-16"
+								style={{ animationDelay: "120ms" }}
+							/>
 						</div>
 						<div className="grid gap-3 sm:grid-cols-3">
 							{["s1", "s2", "s3"].map((id, i) => (
@@ -197,10 +197,22 @@ export const IndexerDetailsPanel = ({
 							))}
 						</div>
 						<div className="flex gap-3">
-							<PremiumSkeleton variant="line" className="h-20 w-20 rounded-full" style={{ animationDelay: "300ms" }} />
+							<PremiumSkeleton
+								variant="line"
+								className="h-20 w-20 rounded-full"
+								style={{ animationDelay: "300ms" }}
+							/>
 							<div className="flex-1 space-y-2">
-								<PremiumSkeleton variant="line" className="h-4 w-3/4" style={{ animationDelay: "360ms" }} />
-								<PremiumSkeleton variant="line" className="h-4 w-1/2" style={{ animationDelay: "420ms" }} />
+								<PremiumSkeleton
+									variant="line"
+									className="h-4 w-3/4"
+									style={{ animationDelay: "360ms" }}
+								/>
+								<PremiumSkeleton
+									variant="line"
+									className="h-4 w-1/2"
+									style={{ animationDelay: "420ms" }}
+								/>
 							</div>
 						</div>
 					</div>
@@ -218,7 +230,10 @@ export const IndexerDetailsPanel = ({
 								className="h-4 w-4 shrink-0"
 								style={{ color: SEMANTIC_COLORS.error.from }}
 							/>
-							<p className="text-sm font-medium flex-1" style={{ color: SEMANTIC_COLORS.error.text }}>
+							<p
+								className="text-sm font-medium flex-1"
+								style={{ color: SEMANTIC_COLORS.error.text }}
+							>
 								{detailError}
 							</p>
 							<button

--- a/apps/web/src/features/indexers/components/indexer-edit-form.tsx
+++ b/apps/web/src/features/indexers/components/indexer-edit-form.tsx
@@ -126,10 +126,7 @@ const EditableField = ({
 	if (fieldType === "select" && field.selectOptions && field.selectOptions.length > 0) {
 		return (
 			<div className="space-y-1.5">
-				<label
-					htmlFor={fieldId}
-					className="text-[11px] font-medium text-muted-foreground/60 block"
-				>
+				<label htmlFor={fieldId} className="text-[11px] font-medium text-muted-foreground/60 block">
 					{fieldLabel}
 				</label>
 				<select
@@ -163,10 +160,7 @@ const EditableField = ({
 	if (fieldType === "number" || (typeof value === "number" && fieldType !== "textbox")) {
 		return (
 			<div className="space-y-1.5">
-				<label
-					htmlFor={fieldId}
-					className="text-[11px] font-medium text-muted-foreground/60 block"
-				>
+				<label htmlFor={fieldId} className="text-[11px] font-medium text-muted-foreground/60 block">
 					{fieldLabel}
 				</label>
 				<Input
@@ -196,10 +190,7 @@ const EditableField = ({
 	// Default: text input
 	return (
 		<div className="space-y-1.5">
-			<label
-				htmlFor={fieldId}
-				className="text-[11px] font-medium text-muted-foreground/60 block"
-			>
+			<label htmlFor={fieldId} className="text-[11px] font-medium text-muted-foreground/60 block">
 				{fieldLabel}
 			</label>
 			<Input
@@ -303,9 +294,7 @@ export const IndexerEditForm = ({
 				{/* Priority */}
 				<div className="flex items-center gap-2.5">
 					<Hash className="h-3.5 w-3.5 text-muted-foreground/40" />
-					<span className="text-[11px] font-medium text-muted-foreground/50">
-						Priority
-					</span>
+					<span className="text-[11px] font-medium text-muted-foreground/50">Priority</span>
 					<Input
 						type="number"
 						value={formPriority === undefined ? "" : formPriority.toString()}

--- a/apps/web/src/features/indexers/components/indexer-row.tsx
+++ b/apps/web/src/features/indexers/components/indexer-row.tsx
@@ -52,8 +52,7 @@ const relativeTime = (iso: string | undefined): string | null => {
  * Protocol pill — compact colored indicator
  */
 const ProtocolPill = ({ protocol }: { protocol: ProwlarrIndexer["protocol"] }) => {
-	const color =
-		protocol === "torrent" ? PROTOCOL_COLORS.torrent : PROTOCOL_COLORS.usenet;
+	const color = protocol === "torrent" ? PROTOCOL_COLORS.torrent : PROTOCOL_COLORS.usenet;
 	const Icon = protocol === "torrent" ? Download : Wifi;
 
 	return (
@@ -249,9 +248,7 @@ export const IndexerRow = ({
 							backgroundColor: indexer.enable
 								? SEMANTIC_COLORS.success.from
 								: "rgba(var(--border), 0.5)",
-							boxShadow: indexer.enable
-								? `0 0 4px ${SEMANTIC_COLORS.success.from}40`
-								: "none",
+							boxShadow: indexer.enable ? `0 0 4px ${SEMANTIC_COLORS.success.from}40` : "none",
 						}}
 						title={indexer.enable ? "Enabled" : "Disabled"}
 					/>

--- a/apps/web/src/features/indexers/components/indexer-stats-grid.tsx
+++ b/apps/web/src/features/indexers/components/indexer-stats-grid.tsx
@@ -137,19 +137,28 @@ const HealthBar = ({
 			</div>
 			<div className="flex items-center gap-2 text-[10px] font-medium shrink-0">
 				{healthy > 0 && (
-					<span className="inline-flex items-center gap-1" style={{ color: SEMANTIC_COLORS.success.from }}>
+					<span
+						className="inline-flex items-center gap-1"
+						style={{ color: SEMANTIC_COLORS.success.from }}
+					>
 						<HeartPulse className="h-3 w-3" />
 						{healthy}
 					</span>
 				)}
 				{degraded > 0 && (
-					<span className="inline-flex items-center gap-1" style={{ color: SEMANTIC_COLORS.warning.from }}>
+					<span
+						className="inline-flex items-center gap-1"
+						style={{ color: SEMANTIC_COLORS.warning.from }}
+					>
 						<AlertTriangle className="h-3 w-3" />
 						{degraded}
 					</span>
 				)}
 				{failing > 0 && (
-					<span className="inline-flex items-center gap-1" style={{ color: SEMANTIC_COLORS.error.from }}>
+					<span
+						className="inline-flex items-center gap-1"
+						style={{ color: SEMANTIC_COLORS.error.from }}
+					>
 						<XCircle className="h-3 w-3" />
 						{failing}
 					</span>

--- a/apps/web/src/features/indexers/components/indexers-client.tsx
+++ b/apps/web/src/features/indexers/components/indexers-client.tsx
@@ -336,22 +336,10 @@ export const IndexersClient = () => {
 			<section className="space-y-6 animate-in fade-in duration-300">
 				<div className="space-y-3">
 					<PremiumSkeleton variant="line" className="h-8 w-48" />
-					<PremiumSkeleton
-						variant="line"
-						className="h-4 w-80"
-						style={{ animationDelay: "50ms" }}
-					/>
+					<PremiumSkeleton variant="line" className="h-4 w-80" style={{ animationDelay: "50ms" }} />
 				</div>
-				<PremiumSkeleton
-					variant="card"
-					className="h-14"
-					style={{ animationDelay: "100ms" }}
-				/>
-				<PremiumSkeleton
-					variant="card"
-					className="h-12"
-					style={{ animationDelay: "150ms" }}
-				/>
+				<PremiumSkeleton variant="card" className="h-14" style={{ animationDelay: "100ms" }} />
+				<PremiumSkeleton variant="card" className="h-12" style={{ animationDelay: "150ms" }} />
 				<div className="space-y-1">
 					{["a", "b", "c", "d", "e"].map((id, i) => (
 						<PremiumSkeleton
@@ -420,7 +408,10 @@ export const IndexersClient = () => {
 					}}
 				>
 					<div className="flex items-center gap-3">
-						<AlertCircle className="h-4 w-4 shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
+						<AlertCircle
+							className="h-4 w-4 shrink-0"
+							style={{ color: SEMANTIC_COLORS.error.from }}
+						/>
 						<p className="text-sm font-medium" style={{ color: SEMANTIC_COLORS.error.text }}>
 							Unable to load indexers. Check your Prowlarr settings.
 						</p>

--- a/apps/web/src/features/label-sync/components/rule-dialog.tsx
+++ b/apps/web/src/features/label-sync/components/rule-dialog.tsx
@@ -305,7 +305,7 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 						/>
 						<p className="text-xs text-muted-foreground">
 							The tag/label to apply on the destination service. Created automatically on
-							Sonarr/Radarr if it doesn't already exist.
+							Sonarr/Radarr if it doesn’t already exist.
 						</p>
 					</div>
 

--- a/apps/web/src/features/library-cleanup/lib/__tests__/condition-params.test.ts
+++ b/apps/web/src/features/library-cleanup/lib/__tests__/condition-params.test.ts
@@ -121,12 +121,12 @@ describe("getDefaultConditionParams", () => {
 			["user_retention", { operator: "watched_by_none", source: "plex" }],
 			["staleness_score", { operator: "greater_than", threshold: 70 }],
 			["recently_active", { protectionDays: 30, requireActivity: true }],
-		] as [
-			CleanupRuleType,
-			Record<string, unknown>,
-		][])("%s → returns correct defaults", (ruleType, expected) => {
-			expect(getDefaultConditionParams(ruleType)).toEqual(expected);
-		});
+		] as [CleanupRuleType, Record<string, unknown>][])(
+			"%s → returns correct defaults",
+			(ruleType, expected) => {
+				expect(getDefaultConditionParams(ruleType)).toEqual(expected);
+			},
+		);
 	});
 
 	// Document the intentional default divergence between getDefaultConditionParams

--- a/apps/web/src/features/library-cleanup/lib/__tests__/rule-dialog-logic.test.ts
+++ b/apps/web/src/features/library-cleanup/lib/__tests__/rule-dialog-logic.test.ts
@@ -289,9 +289,7 @@ describe("buildParams", () => {
 		});
 
 		it("rating: non-unrated includes score", () => {
-			const result = buildParams(
-				makeState({ ruleType: "rating", scoreOp: "less_than", score: 7 }),
-			);
+			const result = buildParams(makeState({ ruleType: "rating", scoreOp: "less_than", score: 7 }));
 			expect(result).toEqual({ source: "tmdb", operator: "less_than", score: 7 });
 		});
 
@@ -315,9 +313,7 @@ describe("buildParams", () => {
 		});
 
 		it("imdb_rating: unrated omits score", () => {
-			const result = buildParams(
-				makeState({ ruleType: "imdb_rating", imdbRatingOp: "unrated" }),
-			);
+			const result = buildParams(makeState({ ruleType: "imdb_rating", imdbRatingOp: "unrated" }));
 			expect(result).toEqual({ operator: "unrated" });
 			expect(result).not.toHaveProperty("score");
 		});
@@ -446,9 +442,7 @@ describe("buildParams", () => {
 
 		it("runtime", () => {
 			expect(
-				buildParams(
-					makeState({ ruleType: "runtime", runtimeOp: "less_than", runtimeMinutes: 90 }),
-				),
+				buildParams(makeState({ ruleType: "runtime", runtimeOp: "less_than", runtimeMinutes: 90 })),
 			).toEqual({ operator: "less_than", minutes: 90 });
 		});
 
@@ -520,23 +514,23 @@ describe("buildParams", () => {
 
 		it("user_retention: returns behaviorParams as-is", () => {
 			const bp = { operator: "watched_by_none", source: "plex" };
-			expect(
-				buildParams(makeState({ ruleType: "user_retention", behaviorParams: bp })),
-			).toEqual(bp);
+			expect(buildParams(makeState({ ruleType: "user_retention", behaviorParams: bp }))).toEqual(
+				bp,
+			);
 		});
 
 		it("staleness_score: returns behaviorParams as-is", () => {
 			const bp = { operator: "greater_than", threshold: 70 };
-			expect(
-				buildParams(makeState({ ruleType: "staleness_score", behaviorParams: bp })),
-			).toEqual(bp);
+			expect(buildParams(makeState({ ruleType: "staleness_score", behaviorParams: bp }))).toEqual(
+				bp,
+			);
 		});
 
 		it("recently_active: returns behaviorParams as-is", () => {
 			const bp = { protectionDays: 30, requireActivity: true };
-			expect(
-				buildParams(makeState({ ruleType: "recently_active", behaviorParams: bp })),
-			).toEqual(bp);
+			expect(buildParams(makeState({ ruleType: "recently_active", behaviorParams: bp }))).toEqual(
+				bp,
+			);
 		});
 	});
 

--- a/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/season-episode-list-error.test.tsx
@@ -32,20 +32,14 @@ function wrapper({ children }: { children: ReactNode }) {
 
 describe("<SeasonEpisodeList /> error state microcopy", () => {
 	it("renders the neutral error message pointing at Pulse as the live source", () => {
-		render(
-			<SeasonEpisodeList instanceId="inst-1" seriesId={1} seasonNumber={1} />,
-			{ wrapper },
-		);
+		render(<SeasonEpisodeList instanceId="inst-1" seriesId={1} seasonNumber={1} />, { wrapper });
 		expect(
 			screen.getByText(/Failed to load episodes\. Try again, or check Pulse/i),
 		).toBeInTheDocument();
 	});
 
 	it("does NOT render the old speculative 'may be unreachable' copy", () => {
-		render(
-			<SeasonEpisodeList instanceId="inst-1" seriesId={1} seasonNumber={1} />,
-			{ wrapper },
-		);
+		render(<SeasonEpisodeList instanceId="inst-1" seriesId={1} seasonNumber={1} />, { wrapper });
 		// The component has no way to diagnose the actual cause of a fetch
 		// failure — guessing "may be unreachable" competes with Pulse's
 		// canonical reachability signal. Never bring it back.

--- a/apps/web/src/features/library/components/__tests__/torrent-detail-drawer-capabilities.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/torrent-detail-drawer-capabilities.test.tsx
@@ -36,6 +36,9 @@ vi.mock("../../../../hooks/api/useQui", async () => {
 	return {
 		...actual,
 		useQuiCapabilities: (args: unknown) => mockUseQuiCapabilities(args),
+		useQuiTorrentProperties: () => ({ data: undefined }),
+		useQuiCategories: () => ({ data: { categories: [] } }),
+		useQuiTags: () => ({ data: { tags: [] } }),
 	};
 });
 
@@ -102,9 +105,9 @@ describe("TorrentDetailDrawer — capability banner", () => {
 	it("does NOT render the banner while the capability query is in-flight (no caps yet)", () => {
 		mockUseQuiCapabilities.mockReturnValue({ data: undefined });
 		renderDrawer(makeCopy());
-		// The unsupported banner specifically mentions "doesn't support" —
+		// The unsupported banner specifically mentions "doesn’t support" —
 		// it should not appear until caps is loaded.
-		expect(screen.queryByText(/doesn't support/i)).toBeNull();
+		expect(screen.queryByText(/doesn’t support/i)).toBeNull();
 	});
 
 	it("does NOT render the banner when all supported capabilities are true", () => {
@@ -117,7 +120,7 @@ describe("TorrentDetailDrawer — capability banner", () => {
 			},
 		});
 		renderDrawer(makeCopy());
-		expect(screen.queryByText(/doesn't support/i)).toBeNull();
+		expect(screen.queryByText(/doesn’t support/i)).toBeNull();
 	});
 
 	it("renders banner naming 'tracker editing' when supportsTrackerEditing is false", () => {
@@ -130,7 +133,7 @@ describe("TorrentDetailDrawer — capability banner", () => {
 			},
 		});
 		renderDrawer(makeCopy());
-		const banner = screen.getByText(/doesn't support/i);
+		const banner = screen.getByText(/doesn’t support/i);
 		expect(banner.textContent).toMatch(/tracker editing/i);
 		expect(banner.textContent).not.toMatch(/share \/ seeding limits/i);
 	});
@@ -145,7 +148,7 @@ describe("TorrentDetailDrawer — capability banner", () => {
 			},
 		});
 		renderDrawer(makeCopy());
-		const banner = screen.getByText(/doesn't support/i);
+		const banner = screen.getByText(/doesn’t support/i);
 		expect(banner.textContent).toMatch(/share \/ seeding limits/i);
 		expect(banner.textContent).not.toMatch(/tracker editing/i);
 	});
@@ -160,7 +163,7 @@ describe("TorrentDetailDrawer — capability banner", () => {
 			},
 		});
 		renderDrawer(makeCopy());
-		const banner = screen.getByText(/doesn't support/i);
+		const banner = screen.getByText(/doesn’t support/i);
 		expect(banner.textContent).toMatch(/tracker editing/i);
 		expect(banner.textContent).toMatch(/share \/ seeding limits/i);
 		// The joiner is " or " between the two items.

--- a/apps/web/src/features/library/components/album-breakdown-modal.tsx
+++ b/apps/web/src/features/library/components/album-breakdown-modal.tsx
@@ -205,7 +205,9 @@ export const AlbumBreakdownModal = ({
 								{item.title}
 							</h2>
 							<div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-muted-foreground">
-								<span>{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}</span>
+								<span>
+									{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}
+								</span>
 								<span>•</span>
 								<span className="flex items-center gap-1">
 									<Disc3 className="h-3.5 w-3.5" />

--- a/apps/web/src/features/library/components/book-breakdown-modal.tsx
+++ b/apps/web/src/features/library/components/book-breakdown-modal.tsx
@@ -176,7 +176,9 @@ export const BookBreakdownModal = ({
 								{item.title}
 							</h2>
 							<div className="flex flex-wrap items-center gap-3 mt-1 text-sm text-muted-foreground">
-								<span>{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}</span>
+								<span>
+									{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}
+								</span>
 								<span>•</span>
 								<span className="flex items-center gap-1">
 									<BookOpen className="h-3.5 w-3.5" />

--- a/apps/web/src/features/library/components/disk-waste-panel.tsx
+++ b/apps/web/src/features/library/components/disk-waste-panel.tsx
@@ -6,10 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ServiceBadge } from "../../../components/layout";
 import { useLibraryMonitorMutation } from "../../../hooks/api/useLibrary";
-import {
-	type DiskWasteItem,
-	useDiskWasteInsights,
-} from "../../../hooks/api/useDiskWasteInsights";
+import { type DiskWasteItem, useDiskWasteInsights } from "../../../hooks/api/useDiskWasteInsights";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { getLinuxInstanceName, getLinuxIsoName, useIncognitoMode } from "../../../lib/incognito";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
@@ -84,7 +81,10 @@ export function DiskWastePanel({
 	if (isLoading || items.length === 0 || !hasWatchData) return null;
 
 	return (
-		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
+		<div
+			ref={panelRef}
+			className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden"
+		>
 			{/* Header — always visible */}
 			<button
 				type="button"
@@ -106,7 +106,9 @@ export function DiskWastePanel({
 							{formatSize(totalWasted)}
 						</span>
 						{!hasWatchData && (
-							<span className="text-xs text-muted-foreground ml-2">(no media server connected)</span>
+							<span className="text-xs text-muted-foreground ml-2">
+								(no media server connected)
+							</span>
 						)}
 					</div>
 				</div>
@@ -122,7 +124,8 @@ export function DiskWastePanel({
 			{expanded && (
 				<div className="border-t border-border/20 px-4 py-3 space-y-2">
 					<p className="text-xs text-muted-foreground mb-3">
-						Largest library items ({">"}1 GB) added over 30 days ago that have never been watched. Sorted by size.
+						Largest library items ({">"}1 GB) added over 30 days ago that have never been watched.
+						Sorted by size.
 					</p>
 					{items.map((item) => (
 						<DiskWasteRow
@@ -155,19 +158,14 @@ function DiskWasteRow({
 }) {
 	return (
 		<div className="group flex items-center gap-3 rounded-lg px-3 py-2 bg-muted/5 border border-border/10">
-			<HardDrive
-				className="h-3.5 w-3.5 shrink-0"
-				style={{ color: SEMANTIC_COLORS.warning.from }}
-			/>
+			<HardDrive className="h-3.5 w-3.5 shrink-0" style={{ color: SEMANTIC_COLORS.warning.from }} />
 			<div className="flex-1 min-w-0">
 				<span className="text-sm font-medium text-foreground truncate block">
 					{incognitoMode ? getLinuxIsoName(item.title) : item.title}
 					{item.year ? ` (${item.year})` : ""}
 				</span>
 				<span className="text-xs text-muted-foreground">
-					{incognitoMode
-						? getLinuxInstanceName(item.instanceName)
-						: item.instanceName}
+					{incognitoMode ? getLinuxInstanceName(item.instanceName) : item.instanceName}
 					{" · "}Added {item.addedDaysAgo}d ago
 				</span>
 			</div>

--- a/apps/web/src/features/library/components/library-card.tsx
+++ b/apps/web/src/features/library/components/library-card.tsx
@@ -576,6 +576,7 @@ export const LibraryCard = memo(function LibraryCard({
 										const name = meta?.name ?? host;
 										if (meta?.iconUrl) {
 											return (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													key={host}
 													src={meta.iconUrl}

--- a/apps/web/src/features/library/components/library-content.tsx
+++ b/apps/web/src/features/library/components/library-content.tsx
@@ -247,7 +247,10 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 		return { state: item.torrentState, ratio: item.torrentRatio };
 	};
 
-	const allItems = [...grouped.movies, ...grouped.series, ...grouped.artists, ...grouped.authors];
+	const allItems = useMemo(
+		() => [...grouped.movies, ...grouped.series, ...grouped.artists, ...grouped.authors],
+		[grouped.movies, grouped.series, grouped.artists, grouped.authors],
+	);
 
 	// Per-card tracker strip data. The hook batches one request for the
 	// entire visible page; the React Query key is stable on the sorted

--- a/apps/web/src/features/library/components/library-insights-section.tsx
+++ b/apps/web/src/features/library/components/library-insights-section.tsx
@@ -30,10 +30,15 @@ export function LibraryInsightsSection() {
 	const diskWasteCount = diskWaste.data?.data?.items?.length ?? 0;
 	const watchedMonitoredCount = watchedMonitored.data?.data?.items?.length ?? 0;
 	const requestedUnwatchedCount = requestedUnwatched.data?.data?.items?.length ?? 0;
-	const hasWatchData = watchedMonitored.data?.data?.hasWatchData ?? watchedMonitored.data?.data?.hasPlexData ?? false;
+	const hasWatchData =
+		watchedMonitored.data?.data?.hasWatchData ?? watchedMonitored.data?.data?.hasPlexData ?? false;
 	const hasSeerrData = requestedUnwatched.data?.data?.hasSeerrData ?? false;
-	const hasRequestedWatchData = requestedUnwatched.data?.data?.hasWatchData ?? requestedUnwatched.data?.data?.hasPlexData ?? false;
-	const isLoading = diskWaste.isLoading || watchedMonitored.isLoading || requestedUnwatched.isLoading;
+	const hasRequestedWatchData =
+		requestedUnwatched.data?.data?.hasWatchData ??
+		requestedUnwatched.data?.data?.hasPlexData ??
+		false;
+	const isLoading =
+		diskWaste.isLoading || watchedMonitored.isLoading || requestedUnwatched.isLoading;
 
 	// Don't render the section if all panels are empty and done loading
 	const hasContent =
@@ -45,7 +50,8 @@ export function LibraryInsightsSection() {
 
 	// Effective counts — only count signals where the required services are configured
 	const effectiveWatchedCount = hasWatchData ? watchedMonitoredCount : 0;
-	const effectiveRequestedCount = hasSeerrData && hasRequestedWatchData ? requestedUnwatchedCount : 0;
+	const effectiveRequestedCount =
+		hasSeerrData && hasRequestedWatchData ? requestedUnwatchedCount : 0;
 	const totalCount = diskWasteCount + effectiveWatchedCount + effectiveRequestedCount;
 
 	// Build breakdown segments (only non-zero)
@@ -75,9 +81,7 @@ export function LibraryInsightsSection() {
 					{totalCount} item{totalCount !== 1 ? "s" : ""} need attention
 				</span>
 				{segments.length > 1 && (
-					<span className="text-xs text-muted-foreground/60">
-						— {segments.join(" · ")}
-					</span>
+					<span className="text-xs text-muted-foreground/60">— {segments.join(" · ")}</span>
 				)}
 			</div>
 			{priorityCue && (
@@ -86,9 +90,21 @@ export function LibraryInsightsSection() {
 
 			{/* Panels — ordered by priority: requests > monitoring > storage */}
 			<div className="space-y-2">
-				<RequestedUnwatchedPanel autoExpand={insightParam === "requested-unwatched"} isDismissed={isDismissed} onDismiss={dismiss} />
-				<WatchedMonitoredPanel autoExpand={insightParam === "watched-monitored"} isDismissed={isDismissed} onDismiss={dismiss} />
-				<DiskWastePanel autoExpand={insightParam === "disk-waste"} isDismissed={isDismissed} onDismiss={dismiss} />
+				<RequestedUnwatchedPanel
+					autoExpand={insightParam === "requested-unwatched"}
+					isDismissed={isDismissed}
+					onDismiss={dismiss}
+				/>
+				<WatchedMonitoredPanel
+					autoExpand={insightParam === "watched-monitored"}
+					isDismissed={isDismissed}
+					onDismiss={dismiss}
+				/>
+				<DiskWastePanel
+					autoExpand={insightParam === "disk-waste"}
+					isDismissed={isDismissed}
+					onDismiss={dismiss}
+				/>
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/library/components/requested-unwatched-panel.tsx
+++ b/apps/web/src/features/library/components/requested-unwatched-panel.tsx
@@ -7,7 +7,12 @@ import {
 	type RequestedUnwatchedItem,
 	useRequestedUnwatchedInsights,
 } from "../../../hooks/api/useRequestedUnwatchedInsights";
-import { getLinuxInstanceName, getLinuxIsoName, getLinuxUsername, useIncognitoMode } from "../../../lib/incognito";
+import {
+	getLinuxInstanceName,
+	getLinuxIsoName,
+	getLinuxUsername,
+	useIncognitoMode,
+} from "../../../lib/incognito";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { cn } from "../../../lib/utils";
 
@@ -52,7 +57,10 @@ export function RequestedUnwatchedPanel({
 	if (isLoading || items.length === 0 || !hasSeerrData || !hasWatchData) return null;
 
 	return (
-		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
+		<div
+			ref={panelRef}
+			className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden"
+		>
 			<button
 				type="button"
 				onClick={() => setExpanded(!expanded)}
@@ -102,13 +110,14 @@ function RequestedRow({
 	item,
 	incognitoMode,
 	onDismiss,
-}: { item: RequestedUnwatchedItem; incognitoMode: boolean; onDismiss?: () => void }) {
+}: {
+	item: RequestedUnwatchedItem;
+	incognitoMode: boolean;
+	onDismiss?: () => void;
+}) {
 	return (
 		<div className="group flex items-center gap-3 rounded-lg px-3 py-2 bg-muted/5 border border-border/10">
-			<Inbox
-				className="h-3.5 w-3.5 shrink-0"
-				style={{ color: SEMANTIC_COLORS.error.from }}
-			/>
+			<Inbox className="h-3.5 w-3.5 shrink-0" style={{ color: SEMANTIC_COLORS.error.from }} />
 			<div className="flex-1 min-w-0">
 				<span className="text-sm font-medium text-foreground truncate block">
 					{incognitoMode ? getLinuxIsoName(item.title) : item.title}

--- a/apps/web/src/features/library/components/series-torrents-panel.tsx
+++ b/apps/web/src/features/library/components/series-torrents-panel.tsx
@@ -780,6 +780,7 @@ const ClusterCard: React.FC<{
 									<TooltipTrigger asChild>
 										<span className="inline-flex items-center gap-1 rounded bg-card/70 px-1.5 py-0.5 font-mono text-[10px] text-foreground/80">
 											{brand.iconUrl ? (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													src={brand.iconUrl}
 													alt={brand.name}
@@ -876,6 +877,7 @@ const CopyRow: React.FC<{
 					<TooltipTrigger asChild>
 						<span className="inline-flex items-center gap-1 rounded bg-card/60 px-1.5 py-0.5 font-mono text-[10px] text-foreground/90">
 							{brand.iconUrl ? (
+								// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 								<img
 									src={brand.iconUrl}
 									alt={brand.name}
@@ -988,6 +990,7 @@ const CopyRow: React.FC<{
 										}`}
 									>
 										{brand.iconUrl ? (
+											// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 											<img
 												src={brand.iconUrl}
 												alt={brand.name}

--- a/apps/web/src/features/library/components/torrent-detail-drawer.tsx
+++ b/apps/web/src/features/library/components/torrent-detail-drawer.tsx
@@ -146,7 +146,7 @@ const DrawerBody: React.FC<{
 
 			{unsupported.length > 0 && (
 				<div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-200">
-					This qBittorrent version doesn't support {unsupported.join(" or ")} — those controls are
+					This qBittorrent version doesn’t support {unsupported.join(" or ")} — those controls are
 					disabled below.
 				</div>
 			)}

--- a/apps/web/src/features/library/components/torrent-drawer/files-section.tsx
+++ b/apps/web/src/features/library/components/torrent-drawer/files-section.tsx
@@ -127,7 +127,7 @@ const FileMediaInfo: React.FC<{
 	if (query.isError || !query.data) {
 		return (
 			<div className="ml-2 text-[10px] italic text-muted-foreground">
-				MediaInfo unavailable — qui needs local filesystem access to the torrent's files.
+				MediaInfo unavailable — qui needs local filesystem access to the torrent’s files.
 			</div>
 		);
 	}

--- a/apps/web/src/features/library/components/watched-monitored-panel.tsx
+++ b/apps/web/src/features/library/components/watched-monitored-panel.tsx
@@ -73,7 +73,10 @@ export function WatchedMonitoredPanel({
 	if (isLoading || items.length === 0 || !hasWatchData) return null;
 
 	return (
-		<div ref={panelRef} className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden">
+		<div
+			ref={panelRef}
+			className="rounded-xl border border-border/30 bg-card/30 backdrop-blur-sm overflow-hidden"
+		>
 			<button
 				type="button"
 				onClick={() => setExpanded(!expanded)}
@@ -103,7 +106,8 @@ export function WatchedMonitoredPanel({
 			{expanded && (
 				<div className="border-t border-border/20 px-4 py-3 space-y-2">
 					<p className="text-xs text-muted-foreground mb-3">
-						Movies and ended series with watch history that are still monitored. Continuing series are excluded. Sorted by watch count.
+						Movies and ended series with watch history that are still monitored. Continuing series
+						are excluded. Sorted by watch count.
 					</p>
 					{items.map((item) => (
 						<WatchedRow
@@ -136,10 +140,7 @@ function WatchedRow({
 }) {
 	return (
 		<div className="group flex items-center gap-3 rounded-lg px-3 py-2 bg-muted/5 border border-border/10">
-			<Eye
-				className="h-3.5 w-3.5 shrink-0"
-				style={{ color: SEMANTIC_COLORS.info.from }}
-			/>
+			<Eye className="h-3.5 w-3.5 shrink-0" style={{ color: SEMANTIC_COLORS.info.from }} />
 			<div className="flex-1 min-w-0">
 				<span className="text-sm font-medium text-foreground truncate block">
 					{incognitoMode ? getLinuxIsoName(item.title) : item.title}

--- a/apps/web/src/features/notifications/components/channel-form.tsx
+++ b/apps/web/src/features/notifications/components/channel-form.tsx
@@ -185,11 +185,7 @@ export function ChannelForm({ channelId, onSave, onCancel }: ChannelFormProps) {
 			)}
 
 			<div className="flex items-center justify-between pt-2">
-				<ToggleSwitch
-					label="Enabled"
-					checked={enabled}
-					onChange={(v) => setEnabled(v)}
-				/>
+				<ToggleSwitch label="Enabled" checked={enabled} onChange={(v) => setEnabled(v)} />
 
 				<button
 					type="submit"

--- a/apps/web/src/features/queue-cleaner/components/dry-run-preview.tsx
+++ b/apps/web/src/features/queue-cleaner/components/dry-run-preview.tsx
@@ -203,7 +203,11 @@ export const EnhancedDryRunPreview = ({
 						</div>
 						<div>
 							<div className="flex items-center gap-2">
-								<h3 className="font-semibold text-foreground">{incognitoMode ? getLinuxInstanceName(result.instanceLabel) : result.instanceLabel}</h3>
+								<h3 className="font-semibold text-foreground">
+									{incognitoMode
+										? getLinuxInstanceName(result.instanceLabel)
+										: result.instanceLabel}
+								</h3>
 								<ServiceBadge service={result.instanceService} />
 								{result.instanceReachable ? (
 									<span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 text-[10px] font-medium text-green-500">
@@ -518,7 +522,9 @@ const PreviewItemRow = ({
 					)}
 					<div className="flex-1 min-w-0">
 						<div className="flex items-center gap-2 mb-1">
-							<p className="text-sm font-medium text-foreground truncate">{incognitoMode ? getLinuxIsoName(item.title) : item.title}</p>
+							<p className="text-sm font-medium text-foreground truncate">
+								{incognitoMode ? getLinuxIsoName(item.title) : item.title}
+							</p>
 							<span
 								className="inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[9px] font-medium"
 								style={{
@@ -620,7 +626,9 @@ const GroupedItemRow = ({
 						<div className="flex items-center gap-2 mb-1">
 							<Package className="h-4 w-4 text-muted-foreground shrink-0" />
 							<p className="text-sm font-medium text-foreground truncate">
-								{incognitoMode ? getLinuxIsoName(commonPrefix || "Download Pack") : (commonPrefix || "Download Pack")}
+								{incognitoMode
+									? getLinuxIsoName(commonPrefix || "Download Pack")
+									: commonPrefix || "Download Pack"}
 							</p>
 							<span
 								className="inline-flex shrink-0 items-center rounded-full px-1.5 py-0.5 text-[9px] font-medium"
@@ -775,4 +783,3 @@ const ItemSection = ({
 		</div>
 	);
 };
-

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-config-ui.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-config-ui.tsx
@@ -58,9 +58,7 @@ export const RuleSection = ({
 				<div
 					className="flex h-7 w-7 items-center justify-center rounded-lg shrink-0 transition-colors duration-200"
 					style={{
-						backgroundColor: enabled
-							? "rgba(74, 222, 128, 0.1)"
-							: "rgba(148, 163, 184, 0.08)",
+						backgroundColor: enabled ? "rgba(74, 222, 128, 0.1)" : "rgba(148, 163, 184, 0.08)",
 						border: enabled
 							? "1px solid rgba(74, 222, 128, 0.15)"
 							: "1px solid rgba(148, 163, 184, 0.1)",

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-config.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-config.tsx
@@ -608,11 +608,11 @@ const InstanceConfigCard = ({
 					onToggle={(v) => updateField("quiAwareMode", v)}
 				>
 					<div className="text-[11px] text-muted-foreground/70 p-2.5 rounded-lg bg-card/20 border border-border/15">
-						When a queue item's torrent is in <span className="font-medium">paused</span> or{" "}
+						When a queue item’s torrent is in <span className="font-medium">paused</span> or{" "}
 						<span className="font-medium">error</span> state in qui, this gate suppresses the strike
 						and surfaces the item as skipped with a qui-aware reason. Useful when qui automations
 						are already acting on the torrent (e.g., rule-based pause after seed goal). No-op if you
-						haven't added a qui instance.
+						haven’t added a qui instance.
 					</div>
 				</RuleSection>
 
@@ -620,13 +620,13 @@ const InstanceConfigCard = ({
 				<RuleSection
 					icon={ShieldCheck}
 					title="Last-seed protection"
-					description="Skip strikes when *arr's library still references the torrent (default on)"
+					description="Skip strikes when *arr’s library still references the torrent (default on)"
 					enabled={formData.lastSeedProtection ?? true}
 					onToggle={(v) => updateField("lastSeedProtection", v)}
 				>
 					<div className="text-[11px] text-muted-foreground/70 p-2.5 rounded-lg bg-card/20 border border-border/15">
-						Protects against accidentally striking a torrent that's still backing an active *arr
-						file. The gate matches a strike candidate's info-hash against{" "}
+						Protects against accidentally striking a torrent that’s still backing an active *arr
+						file. The gate matches a strike candidate’s info-hash against{" "}
 						<span className="font-medium">LibraryCache</span> (movies/artists) and{" "}
 						<span className="font-medium">EpisodeFileCache</span> (series) across all your *arr
 						instances; if any row still references the hash, the strike is skipped with a last-seed

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-overview.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-overview.tsx
@@ -206,7 +206,9 @@ const InstanceStatusCard = ({ instance, onRefresh, animationDelay }: InstanceSta
 							<div>
 								<div className="flex items-center gap-2">
 									<h4 className="font-semibold text-[14px] text-foreground leading-snug">
-										{incognitoMode ? getLinuxInstanceName(instance.instanceName) : instance.instanceName}
+										{incognitoMode
+											? getLinuxInstanceName(instance.instanceName)
+											: instance.instanceName}
 									</h4>
 									<ServiceBadge service={instance.service} />
 									{instance.dryRunMode && instance.hasConfig && (
@@ -233,9 +235,7 @@ const InstanceStatusCard = ({ instance, onRefresh, animationDelay }: InstanceSta
 							}}
 						>
 							<div className="text-[10px] text-muted-foreground/50">Cleaned</div>
-							<div className="text-lg font-semibold text-foreground">
-								{instance.cleanedToday}
-							</div>
+							<div className="text-lg font-semibold text-foreground">{instance.cleanedToday}</div>
 						</div>
 						<div
 							className="rounded-lg p-2.5 text-center"
@@ -245,9 +245,7 @@ const InstanceStatusCard = ({ instance, onRefresh, animationDelay }: InstanceSta
 							}}
 						>
 							<div className="text-[10px] text-muted-foreground/50">Skipped</div>
-							<div className="text-lg font-semibold text-foreground">
-								{instance.skippedToday}
-							</div>
+							<div className="text-lg font-semibold text-foreground">{instance.skippedToday}</div>
 						</div>
 						<div
 							className="rounded-lg p-2.5 text-center"

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-statistics.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-statistics.tsx
@@ -161,7 +161,10 @@ export const QueueCleanerStatistics = () => {
 					icon={Trash2}
 					animationDelay={300}
 				>
-					<InstanceBreakdownList instances={statistics.instanceBreakdown} incognitoMode={incognitoMode} />
+					<InstanceBreakdownList
+						instances={statistics.instanceBreakdown}
+						incognitoMode={incognitoMode}
+					/>
 				</PremiumSection>
 
 				{/* Recent Activity */}
@@ -171,7 +174,10 @@ export const QueueCleanerStatistics = () => {
 					icon={Clock}
 					animationDelay={350}
 				>
-					<RecentActivityList activities={statistics.recentActivity} incognitoMode={incognitoMode} />
+					<RecentActivityList
+						activities={statistics.recentActivity}
+						incognitoMode={incognitoMode}
+					/>
 				</PremiumSection>
 			</div>
 		</div>
@@ -288,7 +294,13 @@ const DailyTrendChart = ({
 };
 
 // Instance Breakdown List
-const InstanceBreakdownList = ({ instances, incognitoMode }: { instances: InstanceBreakdown[]; incognitoMode: boolean }) => {
+const InstanceBreakdownList = ({
+	instances,
+	incognitoMode,
+}: {
+	instances: InstanceBreakdown[];
+	incognitoMode: boolean;
+}) => {
 	if (instances.length === 0) {
 		return (
 			<div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
@@ -342,14 +354,14 @@ const InstanceBreakdownList = ({ instances, incognitoMode }: { instances: Instan
 									{instance.totalRuns} runs
 								</span>
 								<span className="text-[14px] font-semibold text-foreground leading-snug">
-									{incognitoMode ? getLinuxInstanceName(instance.instanceName) : instance.instanceName}
+									{incognitoMode
+										? getLinuxInstanceName(instance.instanceName)
+										: instance.instanceName}
 								</span>
 								<ServiceBadge service={instance.service} />
 							</div>
 							<div className="text-right">
-								<div className="text-lg font-semibold text-foreground">
-									{instance.itemsCleaned}
-								</div>
+								<div className="text-lg font-semibold text-foreground">{instance.itemsCleaned}</div>
 								<div className="text-[10px] text-muted-foreground/40">items cleaned</div>
 							</div>
 						</div>
@@ -361,7 +373,13 @@ const InstanceBreakdownList = ({ instances, incognitoMode }: { instances: Instan
 };
 
 // Recent Activity List
-const RecentActivityList = ({ activities, incognitoMode }: { activities: RecentActivity[]; incognitoMode: boolean }) => {
+const RecentActivityList = ({
+	activities,
+	incognitoMode,
+}: {
+	activities: RecentActivity[];
+	incognitoMode: boolean;
+}) => {
 	if (activities.length === 0) {
 		return (
 			<div className="flex items-center justify-center py-8 text-muted-foreground text-sm">
@@ -411,7 +429,9 @@ const RecentActivityList = ({ activities, incognitoMode }: { activities: RecentA
 						<div className="relative flex items-center justify-between py-3 pl-5 pr-4">
 							<div className="flex items-center gap-2">
 								<span className="text-[14px] font-semibold text-foreground leading-snug">
-									{incognitoMode ? getLinuxInstanceName(activity.instanceName) : activity.instanceName}
+									{incognitoMode
+										? getLinuxInstanceName(activity.instanceName)
+										: activity.instanceName}
 								</span>
 								<span className="text-[11px] text-muted-foreground/40">
 									{date.toLocaleString(undefined, {

--- a/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
@@ -197,7 +197,7 @@ export const QuiWebhookConfigPanel = () => {
 				<div className="flex justify-between items-center pt-1">
 					<p className="text-xs text-muted-foreground">
 						qui → Settings → Notifications → Targets → URL + Method POST. arr-dashboard
-						authenticates the inbound webhook via the <code>?secret=</code> param (qui's
+						authenticates the inbound webhook via the <code>?secret=</code> param (qui’s
 						<code> ApiKeyQuery </code>scheme).
 					</p>
 					<Button
@@ -295,7 +295,7 @@ const AutoRegisterSection = ({
 					Auto-register in qui
 				</h4>
 				<p className="text-xs text-muted-foreground mt-0.5">
-					Push the URL + secret to a qui instance in one click — no manual paste in qui's Settings
+					Push the URL + secret to a qui instance in one click — no manual paste in qui’s Settings
 					UI. Available immediately after rotation; the plaintext secret is held in memory only.
 				</p>
 			</div>
@@ -304,7 +304,7 @@ const AutoRegisterSection = ({
 				<div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
 					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
 					<span>
-						Click <strong>Rotate secret</strong> above to generate the value. arr-dashboard doesn't
+						Click <strong>Rotate secret</strong> above to generate the value. arr-dashboard doesn’t
 						store plaintext, so registration needs a fresh rotation.
 					</span>
 				</div>
@@ -312,7 +312,7 @@ const AutoRegisterSection = ({
 				<div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
 					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
 					<span>
-						A secret exists but isn't visible right now. Click <strong>Rotate secret</strong> to
+						A secret exists but isn’t visible right now. Click <strong>Rotate secret</strong> to
 						display a new one (the old URL stops working when you rotate).
 					</span>
 				</div>
@@ -408,7 +408,7 @@ const RecentEventsStrip = ({ recentEvents, isIncognito, isError }: RecentEventsS
 			<div className="border-t border-border/40 pt-3">
 				<h4 className="text-sm font-semibold mb-1">Recent events</h4>
 				<p className="text-xs text-amber-300/80">
-					Couldn't load recent events — the event-log endpoint returned an error. Webhook delivery
+					Couldn’t load recent events — the event-log endpoint returned an error. Webhook delivery
 					may still be working; this is a display-side problem. Refresh the page or check the server
 					logs.
 				</p>

--- a/apps/web/src/features/search/components/search-results-table.tsx
+++ b/apps/web/src/features/search/components/search-results-table.tsx
@@ -86,8 +86,7 @@ const getQualityLabel = (quality: SearchResult["quality"]): string | null => {
 	if (maybeNested && typeof maybeNested === "object") {
 		const nested = maybeNested as Record<string, unknown>;
 		const name = typeof nested.name === "string" ? nested.name : undefined;
-		const resolution =
-			typeof nested.resolution === "number" ? nested.resolution : undefined;
+		const resolution = typeof nested.resolution === "number" ? nested.resolution : undefined;
 		if (name || resolution) {
 			if (name && resolution && !name.includes(`${resolution}p`)) {
 				return `${name} ${resolution}p`;

--- a/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
@@ -50,6 +50,7 @@ vi.mock("next/image", () => ({
 	default: (props: Record<string, unknown>) => {
 		// next/image passes non-standard props; just render essential ones
 		const { src, alt, fill: _fill, priority: _priority, ...rest } = props;
+		// eslint-disable-next-line @next/next/no-img-element -- Native img is intentional in the next/image test double.
 		return <img src={src as string} alt={alt as string} {...rest} />;
 	},
 }));

--- a/apps/web/src/features/seerr/components/__tests__/request-status-timeline.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/request-status-timeline.test.tsx
@@ -84,9 +84,7 @@ function getStageLabels(container: HTMLElement): string[] {
 describe("RequestStatusTimeline — compact", () => {
 	it("shows pending flow: Requested → Pending → Processing → Available", () => {
 		const request = makeRequest({ status: 1 });
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Pending", "Processing", "Available"]);
 	});
@@ -118,9 +116,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 3, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Available"]);
 	});
@@ -130,9 +126,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 5, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Available"]);
 	});
@@ -142,9 +136,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 4, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Partial"]);
 	});
@@ -172,9 +164,7 @@ describe("RequestStatusTimeline — compact", () => {
 
 	it("shows failed: Requested → Failed", () => {
 		const request = makeRequest({ status: 4 });
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Failed"]);
 	});
@@ -184,9 +174,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 6, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Blocklisted"]);
 	});
@@ -196,9 +184,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 7, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Deleted"]);
 	});
@@ -208,9 +194,7 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 5,
 			media: { id: 1, tmdbId: 123, status: 1, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Available"]);
 	});
@@ -220,18 +204,14 @@ describe("RequestStatusTimeline — compact", () => {
 			status: 2,
 			media: { id: 1, tmdbId: 123, status: 2, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const labels = getStageLabels(container);
 		expect(labels).toEqual(["Requested", "Approved", "Processing", "Available"]);
 	});
 
 	it("has role='img' with synthesized aria-label on compact timeline wrapper", () => {
 		const request = makeRequest({ status: 1 });
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="compact" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="compact" />);
 		const wrapper = container.querySelector('[role="img"]');
 		expect(wrapper).toBeTruthy();
 		expect(wrapper?.getAttribute("aria-label")).toBe(
@@ -290,9 +270,7 @@ describe("RequestStatusTimeline — expanded", () => {
 			},
 			media: { id: 1, tmdbId: 123, status: 1, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		render(
-			<RequestStatusTimeline request={request} variant="expanded" modifierName="Admin" />,
-		);
+		render(<RequestStatusTimeline request={request} variant="expanded" modifierName="Admin" />);
 		expect(screen.getByText("by Admin")).toBeTruthy();
 	});
 
@@ -302,9 +280,7 @@ describe("RequestStatusTimeline — expanded", () => {
 			updatedAt: "2024-06-05T12:00:00Z",
 			media: { id: 1, tmdbId: 123, status: 3, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="expanded" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="expanded" />);
 		// The expanded timeline renders timestamps with Clock icon + formatRelativeTime
 		// There should only be 1 timestamp (for "Requested"), not 2
 		const clockIcons = container.querySelectorAll(".h-2\\.5.w-2\\.5");
@@ -317,9 +293,7 @@ describe("RequestStatusTimeline — expanded", () => {
 			updatedAt: "2024-06-05T12:00:00Z",
 			media: { id: 1, tmdbId: 123, status: 1, createdAt: "2024-06-01", updatedAt: "2024-06-01" },
 		});
-		const { container } = render(
-			<RequestStatusTimeline request={request} variant="expanded" />,
-		);
+		const { container } = render(<RequestStatusTimeline request={request} variant="expanded" />);
 		// Should have 2 timestamps (Requested + Approved)
 		const clockIcons = container.querySelectorAll(".h-2\\.5.w-2\\.5");
 		expect(clockIcons.length).toBe(2);

--- a/apps/web/src/features/seerr/components/__tests__/requester-profile-popover.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/requester-profile-popover.test.tsx
@@ -64,7 +64,9 @@ function createWrapper() {
 	);
 }
 
-function renderPopover(overrides: Partial<React.ComponentProps<typeof RequesterProfilePopover>> = {}) {
+function renderPopover(
+	overrides: Partial<React.ComponentProps<typeof RequesterProfilePopover>> = {},
+) {
 	return render(
 		<RequesterProfilePopover
 			seerrUser={sampleUser}

--- a/apps/web/src/features/seerr/components/issues-tab.tsx
+++ b/apps/web/src/features/seerr/components/issues-tab.tsx
@@ -278,7 +278,10 @@ export const IssuesTab = ({ instanceId }: IssuesTabProps) => {
 												</span>
 											)}
 											<span className="text-[11px] text-muted-foreground/40">
-												by {incognitoMode ? getLinuxUsername(issue.createdBy.displayName) : issue.createdBy.displayName}
+												by{" "}
+												{incognitoMode
+													? getLinuxUsername(issue.createdBy.displayName)
+													: issue.createdBy.displayName}
 											</span>
 											<span className="text-[11px] text-muted-foreground/40">
 												{formatRelativeTime(issue.createdAt)}
@@ -294,7 +297,9 @@ export const IssuesTab = ({ instanceId }: IssuesTabProps) => {
 										{/* Title + status */}
 										<div className="flex items-center gap-2 flex-wrap">
 											<h3 className="truncate text-[14px] font-semibold text-foreground leading-snug">
-												{incognitoMode ? getLinuxIsoName(issue.media.title ?? `Issue #${issue.id}`) : (issue.media.title ?? `Issue #${issue.id}`)}
+												{incognitoMode
+													? getLinuxIsoName(issue.media.title ?? `Issue #${issue.id}`)
+													: (issue.media.title ?? `Issue #${issue.id}`)}
 											</h3>
 											<StatusBadge status={getIssueStatusVariant(issue.status)}>
 												{getIssueStatusLabel(issue.status)}
@@ -307,7 +312,9 @@ export const IssuesTab = ({ instanceId }: IssuesTabProps) => {
 												{issue.comments.map((comment) => (
 													<div key={comment.id} className="text-xs">
 														<span className="font-medium text-foreground">
-															{incognitoMode ? getLinuxUsername(comment.user.displayName) : comment.user.displayName}
+															{incognitoMode
+																? getLinuxUsername(comment.user.displayName)
+																: comment.user.displayName}
 														</span>
 														<span className="ml-1.5 text-muted-foreground/40">
 															{formatRelativeTime(comment.createdAt)}
@@ -336,9 +343,7 @@ export const IssuesTab = ({ instanceId }: IssuesTabProps) => {
 												<button
 													type="button"
 													onClick={() => handleSubmitComment(issue.id)}
-													disabled={
-														!commentInput[issue.id]?.trim() || addCommentMutation.isPending
-													}
+													disabled={!commentInput[issue.id]?.trim() || addCommentMutation.isPending}
 													className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md border border-border/30 bg-white/[0.03] text-muted-foreground/40 transition-colors hover:bg-white/[0.06] hover:text-foreground disabled:opacity-40 disabled:pointer-events-none"
 													title="Send comment"
 												>

--- a/apps/web/src/features/seerr/components/notifications-tab.tsx
+++ b/apps/web/src/features/seerr/components/notifications-tab.tsx
@@ -4,11 +4,7 @@ import type { SeerrNotificationAgent } from "@arr/shared";
 import { AlertCircle, Bell, Send, Settings, ToggleLeft, ToggleRight } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import {
-	GradientButton,
-	PremiumEmptyState,
-	PremiumSkeleton,
-} from "../../../components/layout";
+import { GradientButton, PremiumEmptyState, PremiumSkeleton } from "../../../components/layout";
 import { Button } from "../../../components/ui";
 import {
 	useSeerrNotifications,
@@ -69,7 +65,9 @@ export const NotificationsTab = ({ instanceId }: NotificationsTabProps) => {
 				{agents.map((agent, index) => {
 					const ToggleIcon = agent.enabled ? ToggleRight : ToggleLeft;
 					const hasFields = !!AGENT_FIELDS[agent.id];
-					const accent = agent.enabled ? SEMANTIC_COLORS.success : { from: "#6b7280", to: "#9ca3af" };
+					const accent = agent.enabled
+						? SEMANTIC_COLORS.success
+						: { from: "#6b7280", to: "#9ca3af" };
 
 					return (
 						<div
@@ -121,9 +119,7 @@ export const NotificationsTab = ({ instanceId }: NotificationsTabProps) => {
 										<span
 											className="h-[5px] w-[5px] rounded-full shrink-0"
 											style={{
-												backgroundColor: agent.enabled
-													? SEMANTIC_COLORS.success.text
-													: "#6b7280",
+												backgroundColor: agent.enabled ? SEMANTIC_COLORS.success.text : "#6b7280",
 											}}
 										/>
 										<span className="text-[11px] text-muted-foreground/40">

--- a/apps/web/src/features/seerr/components/request-card.tsx
+++ b/apps/web/src/features/seerr/components/request-card.tsx
@@ -41,13 +41,25 @@ const SEERR_GRADIENT = SERVICE_GRADIENTS.seerr;
 function getStatusAccentColor(status: number): { from: string; to: string; glow: string } {
 	switch (status) {
 		case SEERR_REQUEST_STATUS.PENDING:
-			return { from: SEMANTIC_COLORS.warning.from, to: SEMANTIC_COLORS.warning.to, glow: SEMANTIC_COLORS.warning.glow };
+			return {
+				from: SEMANTIC_COLORS.warning.from,
+				to: SEMANTIC_COLORS.warning.to,
+				glow: SEMANTIC_COLORS.warning.glow,
+			};
 		case SEERR_REQUEST_STATUS.APPROVED:
 		case SEERR_REQUEST_STATUS.COMPLETED:
-			return { from: SEMANTIC_COLORS.success.from, to: SEMANTIC_COLORS.success.to, glow: SEMANTIC_COLORS.success.glow };
+			return {
+				from: SEMANTIC_COLORS.success.from,
+				to: SEMANTIC_COLORS.success.to,
+				glow: SEMANTIC_COLORS.success.glow,
+			};
 		case SEERR_REQUEST_STATUS.DECLINED:
 		case SEERR_REQUEST_STATUS.FAILED:
-			return { from: SEMANTIC_COLORS.error.from, to: SEMANTIC_COLORS.error.to, glow: SEMANTIC_COLORS.error.glow };
+			return {
+				from: SEMANTIC_COLORS.error.from,
+				to: SEMANTIC_COLORS.error.to,
+				glow: SEMANTIC_COLORS.error.glow,
+			};
 		default:
 			return { from: SEERR_GRADIENT.from, to: SEERR_GRADIENT.to, glow: SEERR_GRADIENT.glow };
 	}
@@ -129,7 +141,13 @@ const MetaChip = ({
 // Component
 // ============================================================================
 
-export const RequestCard = ({ request, instanceId, actions, index = 0, onClick }: RequestCardProps) => {
+export const RequestCard = ({
+	request,
+	instanceId,
+	actions,
+	index = 0,
+	onClick,
+}: RequestCardProps) => {
 	const [incognitoMode] = useIncognitoMode();
 	const posterUrl = getPosterUrl(request.media.posterPath);
 	const TypeIcon = request.type === "movie" ? Film : Tv;
@@ -234,7 +252,11 @@ export const RequestCard = ({ request, instanceId, actions, index = 0, onClick }
 							{instanceId ? (
 								<RequesterProfilePopover
 									seerrUser={request.requestedBy}
-									displayName={incognitoMode ? getLinuxUsername(request.requestedBy.displayName) : request.requestedBy.displayName}
+									displayName={
+										incognitoMode
+											? getLinuxUsername(request.requestedBy.displayName)
+											: request.requestedBy.displayName
+									}
 									instanceId={instanceId}
 									isIncognito={incognitoMode}
 								>
@@ -246,11 +268,17 @@ export const RequestCard = ({ request, instanceId, actions, index = 0, onClick }
 										onKeyDown={(e) => e.stopPropagation()}
 									>
 										<User className="h-3 w-3 shrink-0" aria-hidden="true" />
-										{incognitoMode ? getLinuxUsername(request.requestedBy.displayName) : request.requestedBy.displayName}
+										{incognitoMode
+											? getLinuxUsername(request.requestedBy.displayName)
+											: request.requestedBy.displayName}
 									</button>
 								</RequesterProfilePopover>
 							) : (
-								<MetaChip icon={User}>{incognitoMode ? getLinuxUsername(request.requestedBy.displayName) : request.requestedBy.displayName}</MetaChip>
+								<MetaChip icon={User}>
+									{incognitoMode
+										? getLinuxUsername(request.requestedBy.displayName)
+										: request.requestedBy.displayName}
+								</MetaChip>
 							)}
 
 							{/* Separator dot */}

--- a/apps/web/src/features/seerr/components/request-status-timeline.tsx
+++ b/apps/web/src/features/seerr/components/request-status-timeline.tsx
@@ -134,8 +134,7 @@ function deriveStages(request: SeerrRequest, modifierName?: string): TimelineSta
 
 	// Terminal media states (blocklisted, deleted) — short-circuit
 	const isTerminalMedia =
-		media.status === SEERR_MEDIA_STATUS.BLOCKLISTED ||
-		media.status === SEERR_MEDIA_STATUS.DELETED;
+		media.status === SEERR_MEDIA_STATUS.BLOCKLISTED || media.status === SEERR_MEDIA_STATUS.DELETED;
 
 	if (isTerminalMedia) {
 		stages.push({ label: "Processing", status: "completed" });
@@ -189,24 +188,47 @@ function StageIcon({ status, size }: { status: StageStatus; size: number }) {
 	const iconSize = size - 2;
 
 	if (status === "completed") {
-		return <Check className="shrink-0" aria-hidden="true" style={{ color: color.dot, width: iconSize, height: iconSize }} />;
+		return (
+			<Check
+				className="shrink-0"
+				aria-hidden="true"
+				style={{ color: color.dot, width: iconSize, height: iconSize }}
+			/>
+		);
 	}
 	if (status === "failed") {
-		return <X className="shrink-0" aria-hidden="true" style={{ color: color.dot, width: iconSize, height: iconSize }} />;
+		return (
+			<X
+				className="shrink-0"
+				aria-hidden="true"
+				style={{ color: color.dot, width: iconSize, height: iconSize }}
+			/>
+		);
 	}
 	if (status === "active") {
 		return (
-			<span className="relative shrink-0 flex items-center justify-center" style={{ width: size, height: size }}>
+			<span
+				className="relative shrink-0 flex items-center justify-center"
+				style={{ width: size, height: size }}
+			>
 				<span
 					className="absolute inset-0 rounded-full motion-safe:animate-ping"
 					style={{ backgroundColor: color.dot, opacity: 0.3 }}
 				/>
-				<Circle className="fill-current" aria-hidden="true" style={{ color: color.dot, width: iconSize, height: iconSize }} />
+				<Circle
+					className="fill-current"
+					aria-hidden="true"
+					style={{ color: color.dot, width: iconSize, height: iconSize }}
+				/>
 			</span>
 		);
 	}
 	return (
-		<Circle className="shrink-0" aria-hidden="true" style={{ color: color.dot, width: iconSize - 2, height: iconSize - 2 }} />
+		<Circle
+			className="shrink-0"
+			aria-hidden="true"
+			style={{ color: color.dot, width: iconSize - 2, height: iconSize - 2 }}
+		/>
 	);
 }
 
@@ -223,11 +245,7 @@ function CompactTimeline({ stages }: { stages: TimelineStage[] }) {
 		.join(" → ");
 
 	return (
-		<div
-			className="flex items-center gap-0.5"
-			role="img"
-			aria-label={`Status: ${summary}`}
-		>
+		<div className="flex items-center gap-0.5" role="img" aria-label={`Status: ${summary}`}>
 			{stages.map((stage, i) => {
 				const color = STAGE_COLORS[stage.status];
 				const isLast = i === stages.length - 1;

--- a/apps/web/src/features/seerr/components/requester-profile-popover.tsx
+++ b/apps/web/src/features/seerr/components/requester-profile-popover.tsx
@@ -94,10 +94,11 @@ export const RequesterProfilePopover = ({
 	const [isOpen, setIsOpen] = useState(false);
 
 	// Fetch quota only when popover is open
-	const { data: quota, isLoading: quotaLoading, isError: quotaError } = useSeerrUserQuota(
-		isOpen ? instanceId : "",
-		seerrUser.id,
-	);
+	const {
+		data: quota,
+		isLoading: quotaLoading,
+		isError: quotaError,
+	} = useSeerrUserQuota(isOpen ? instanceId : "", seerrUser.id);
 
 	const hasMovieQuota = quota?.movie.restricted;
 	const hasTvQuota = quota?.tv.restricted;
@@ -137,8 +138,15 @@ export const RequesterProfilePopover = ({
 				{/* Quota section */}
 				<div className="p-3 space-y-2.5">
 					{quotaLoading && (
-						<div role="status" aria-label="Loading quota" className="flex items-center justify-center py-1">
-							<Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" aria-hidden="true" />
+						<div
+							role="status"
+							aria-label="Loading quota"
+							className="flex items-center justify-center py-1"
+						>
+							<Loader2
+								className="h-3.5 w-3.5 animate-spin text-muted-foreground"
+								aria-hidden="true"
+							/>
 						</div>
 					)}
 					{quotaError && (
@@ -167,7 +175,9 @@ export const RequesterProfilePopover = ({
 						</>
 					)}
 					{quota && !hasAnyQuota && (
-						<p className="text-[11px] text-muted-foreground/60 text-center">No quota restrictions</p>
+						<p className="text-[11px] text-muted-foreground/60 text-center">
+							No quota restrictions
+						</p>
 					)}
 
 					{/* Deep-link action */}

--- a/apps/web/src/features/seerr/components/requests-history-tab.tsx
+++ b/apps/web/src/features/seerr/components/requests-history-tab.tsx
@@ -53,7 +53,11 @@ interface RequestsHistoryTabProps {
 	initialUserFilter?: string;
 }
 
-export const RequestsHistoryTab = ({ instanceId, onSelectRequest, initialUserFilter }: RequestsHistoryTabProps) => {
+export const RequestsHistoryTab = ({
+	instanceId,
+	onSelectRequest,
+	initialUserFilter,
+}: RequestsHistoryTabProps) => {
 	const [incognitoMode] = useIncognitoMode();
 	const [statusFilter, setStatusFilter] = useState<RequestFilter>("all");
 	const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
@@ -103,7 +107,9 @@ export const RequestsHistoryTab = ({ instanceId, onSelectRequest, initialUserFil
 		for (const user of usersData.results) {
 			base.push({
 				value: String(user.id),
-				label: incognitoMode ? getLinuxUsername(user.displayName || user.email || `User #${user.id}`) : (user.displayName || user.email || `User #${user.id}`),
+				label: incognitoMode
+					? getLinuxUsername(user.displayName || user.email || `User #${user.id}`)
+					: user.displayName || user.email || `User #${user.id}`,
 			});
 		}
 		return base;

--- a/apps/web/src/features/seerr/components/user-settings-dialog.tsx
+++ b/apps/web/src/features/seerr/components/user-settings-dialog.tsx
@@ -80,10 +80,15 @@ export const UserSettingsDialog = ({
 			{ instanceId, seerrUserId: user.id, data: draft },
 			{
 				onSuccess: () => {
-					toast.success(`Updated quota settings for ${incognitoMode ? getLinuxUsername(user.displayName) : user.displayName}`);
+					toast.success(
+						`Updated quota settings for ${incognitoMode ? getLinuxUsername(user.displayName) : user.displayName}`,
+					);
 					onOpenChange(false);
 				},
-				onError: () => toast.error(`Failed to update quota for ${incognitoMode ? getLinuxUsername(user.displayName) : user.displayName}`),
+				onError: () =>
+					toast.error(
+						`Failed to update quota for ${incognitoMode ? getLinuxUsername(user.displayName) : user.displayName}`,
+					),
 			},
 		);
 	};

--- a/apps/web/src/features/settings/components/__tests__/plex-oauth-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/plex-oauth-section.test.tsx
@@ -70,10 +70,21 @@ function createWrapper() {
 	);
 }
 
-function renderSection(onServerSelected = vi.fn(), mode: "add" | "edit" = "add", onTestConnection = vi.fn()) {
-	return render(<PlexOAuthSection onServerSelected={onServerSelected} onTestConnection={onTestConnection} mode={mode} />, {
-		wrapper: createWrapper(),
-	});
+function renderSection(
+	onServerSelected = vi.fn(),
+	mode: "add" | "edit" = "add",
+	onTestConnection = vi.fn(),
+) {
+	return render(
+		<PlexOAuthSection
+			onServerSelected={onServerSelected}
+			onTestConnection={onTestConnection}
+			mode={mode}
+		/>,
+		{
+			wrapper: createWrapper(),
+		},
+	);
 }
 
 const sampleServers: PlexDiscoveredServer[] = [

--- a/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -237,7 +237,9 @@ describe("SeerrAutoSetupSection", () => {
 		});
 
 		// Clean up: resolve the pending promise
-		resolvePromise({ apiKey: "key", version: "1.0" });
+		await act(async () => {
+			resolvePromise({ apiKey: "key", version: "1.0" });
+		});
 	});
 
 	// ================================================================

--- a/apps/web/src/features/settings/components/appearance-tab.tsx
+++ b/apps/web/src/features/settings/components/appearance-tab.tsx
@@ -299,10 +299,10 @@ export function AppearanceTab() {
 									</div>
 
 									<div className="flex items-center gap-1 p-1 rounded-lg bg-muted/50">
-										{([
+										{[
 											{ value: 0 as WeekStart, label: "Sun" },
 											{ value: 1 as WeekStart, label: "Mon" },
-										]).map(({ value, label }) => (
+										].map(({ value, label }) => (
 											<button
 												key={value}
 												type="button"

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -16,11 +16,7 @@ import {
 	X,
 } from "lucide-react";
 import { useState } from "react";
-import {
-	PremiumEmptyState,
-	PremiumSection,
-	PremiumSkeleton,
-} from "../../../components/layout";
+import { PremiumEmptyState, PremiumSection, PremiumSkeleton } from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import {
@@ -324,12 +320,12 @@ export const OIDCProviderSection = () => {
 									</div>
 
 									<div className="sm:col-span-2">
-									<ToggleSwitch
-										label="Enable provider"
-										checked={formData.enabled}
-										onChange={(v) => setFormData({ ...formData, enabled: v })}
-									/>
-								</div>
+										<ToggleSwitch
+											label="Enable provider"
+											checked={formData.enabled}
+											onChange={(v) => setFormData({ ...formData, enabled: v })}
+										/>
+									</div>
 								</div>
 
 								<div className="flex gap-3">
@@ -474,12 +470,12 @@ export const OIDCProviderSection = () => {
 									</div>
 
 									<div className="sm:col-span-2">
-									<ToggleSwitch
-										label="Enable provider"
-										checked={editData.enabled}
-										onChange={(v) => setEditData({ ...editData, enabled: v })}
-									/>
-								</div>
+										<ToggleSwitch
+											label="Enable provider"
+											checked={editData.enabled}
+											onChange={(v) => setEditData({ ...editData, enabled: v })}
+										/>
+									</div>
 								</div>
 
 								<div className="flex gap-3">

--- a/apps/web/src/features/settings/components/passkey-section.tsx
+++ b/apps/web/src/features/settings/components/passkey-section.tsx
@@ -14,11 +14,7 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
-import {
-	PremiumEmptyState,
-	PremiumSection,
-	PremiumSkeleton,
-} from "../../../components/layout";
+import { PremiumEmptyState, PremiumSection, PremiumSkeleton } from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";

--- a/apps/web/src/features/settings/components/sessions-section.tsx
+++ b/apps/web/src/features/settings/components/sessions-section.tsx
@@ -15,11 +15,7 @@ import {
 	X,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import {
-	PremiumEmptyState,
-	PremiumSection,
-	PremiumSkeleton,
-} from "../../../components/layout";
+import { PremiumEmptyState, PremiumSection, PremiumSkeleton } from "../../../components/layout";
 import { Button } from "../../../components/ui/button";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import {

--- a/apps/web/src/features/settings/components/validation-health-section.tsx
+++ b/apps/web/src/features/settings/components/validation-health-section.tsx
@@ -11,7 +11,7 @@ import {
 	Trash2,
 	XCircle,
 } from "lucide-react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { DomainStatusBadge, PremiumSection } from "../../../components/layout";
 import { Tooltip } from "../../../components/layout/config-primitives";
 import type { DomainStatus } from "../../../components/layout/domain-status";
@@ -319,9 +319,8 @@ export function ValidationHealthSection({
 										const isExpanded = expandedIntegrations.has(name);
 
 										return (
-											<>
+											<Fragment key={name}>
 												<tr
-													key={name}
 													className={`border-b border-border/30 last:border-b-0 transition-colors animate-in fade-in slide-in-from-bottom-1 duration-200 ${isExpandable ? "cursor-pointer hover:bg-card/50" : "hover:bg-card/50"}`}
 													style={{
 														animationDelay: `${i * 30}ms`,
@@ -451,7 +450,7 @@ export function ValidationHealthSection({
 															<td className="p-2" />
 														</tr>
 													))}
-											</>
+											</Fragment>
 										);
 									})}
 								</tbody>

--- a/apps/web/src/features/setup/components/passkey-setup.tsx
+++ b/apps/web/src/features/setup/components/passkey-setup.tsx
@@ -79,12 +79,15 @@ export const PasskeySetup = () => {
 			userCreated = true;
 
 			// Step 2: Get passkey registration options
-			const options = await apiRequest<Parameters<typeof startRegistration>[0]>("/auth/passkey/register/options", {
-				method: "POST",
-				json: {
-					friendlyName: formState.passkeyName.trim() || `${formState.username}'s passkey`,
+			const options = await apiRequest<Parameters<typeof startRegistration>[0]>(
+				"/auth/passkey/register/options",
+				{
+					method: "POST",
+					json: {
+						friendlyName: formState.passkeyName.trim() || `${formState.username}'s passkey`,
+					},
 				},
-			});
+			);
 
 			// Step 3: Trigger WebAuthn registration
 			const registrationResponse = await startRegistration(options);

--- a/apps/web/src/features/statistics/components/arr-service-tab.tsx
+++ b/apps/web/src/features/statistics/components/arr-service-tab.tsx
@@ -37,6 +37,7 @@ export type ArrServiceType = "sonarr" | "radarr" | "lidarr" | "readarr";
 // (e.g. t.totalSeries, r.downloadedEpisodes) is compile-time checked.
 // The `any` default is necessary because TypeScript's strict function parameter
 // contravariance prevents narrower parameter types from widening to a union.
+/* eslint-disable @typescript-eslint/no-explicit-any -- Strategy boundary intentionally erases concrete service types. */
 // biome-ignore lint/suspicious/noExplicitAny: Strategy pattern requires type erasure at the component boundary
 interface ServiceVariant<TTotals = any, TRow = any> {
 	/** Primary stat grid: 4 cards across the top */
@@ -61,6 +62,7 @@ interface ServiceVariant<TTotals = any, TRow = any> {
 	/** Primary count field for progress column */
 	progressField: "downloadedPercentage";
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const SONARR_VARIANT: ServiceVariant<SonarrTotals, SonarrRow> = {
 	primaryStats: (t) => [

--- a/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
+++ b/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
@@ -55,7 +55,7 @@ export const DiskBreakdownPanel = ({ disks }: DiskBreakdownPanelProps) => {
 				<h3 className="text-sm font-medium text-foreground">Storage Breakdown</h3>
 				<p className="mt-0.5 text-xs text-muted-foreground">
 					Disks included in the rollup hold at least one configured *arr root folder. Disks marked
-					excluded carry config, container OS, or system data that isn't media.
+					excluded carry config, container OS, or system data that isn’t media.
 				</p>
 			</div>
 			<ul className="divide-y divide-border/50">

--- a/apps/web/src/features/trash-guides/components/cache-status-section.tsx
+++ b/apps/web/src/features/trash-guides/components/cache-status-section.tsx
@@ -66,75 +66,79 @@ const CacheStatusCard = ({
 			/>
 			<div
 				className="absolute inset-0 pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-200"
-				style={{ background: `radial-gradient(ellipse at top left, ${cardColor}06, transparent 50%)` }}
+				style={{
+					background: `radial-gradient(ellipse at top left, ${cardColor}06, transparent 50%)`,
+				}}
 			/>
 			<div
 				className="absolute left-0 top-0 bottom-0 w-[3px]"
-				style={{ background: isStale
-					? `linear-gradient(180deg, ${SEMANTIC_COLORS.warning.from}, ${SEMANTIC_COLORS.warning.from}70)`
-					: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`
+				style={{
+					background: isStale
+						? `linear-gradient(180deg, ${SEMANTIC_COLORS.warning.from}, ${SEMANTIC_COLORS.warning.from}70)`
+						: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
 				}}
 			/>
 			<div className="relative p-5">
-			<div className="flex items-start justify-between mb-4">
-				<div className="flex items-center gap-3">
-					<div
-						className="flex h-10 w-10 items-center justify-center rounded-xl"
-						style={{
-							background: isStale
-								? `${SEMANTIC_COLORS.warning.from}20`
-								: `linear-gradient(135deg, ${themeGradient.from}20, ${themeGradient.to}20)`,
-							border: isStale
-								? `1px solid ${SEMANTIC_COLORS.warning.border}`
-								: `1px solid ${themeGradient.from}30`,
-						}}
-					>
-						<Package
-							className="h-5 w-5"
-							style={{ color: isStale ? SEMANTIC_COLORS.warning.from : themeGradient.from }}
-						/>
+				<div className="flex items-start justify-between mb-4">
+					<div className="flex items-center gap-3">
+						<div
+							className="flex h-10 w-10 items-center justify-center rounded-xl"
+							style={{
+								background: isStale
+									? `${SEMANTIC_COLORS.warning.from}20`
+									: `linear-gradient(135deg, ${themeGradient.from}20, ${themeGradient.to}20)`,
+								border: isStale
+									? `1px solid ${SEMANTIC_COLORS.warning.border}`
+									: `1px solid ${themeGradient.from}30`,
+							}}
+						>
+							<Package
+								className="h-5 w-5"
+								style={{ color: isStale ? SEMANTIC_COLORS.warning.from : themeGradient.from }}
+							/>
+						</div>
+						<div>
+							<h3 className="font-semibold text-foreground">{configTypeLabel}</h3>
+							<p className="text-xs text-muted-foreground">Version {version}</p>
+						</div>
 					</div>
-					<div>
-						<h3 className="font-semibold text-foreground">{configTypeLabel}</h3>
-						<p className="text-xs text-muted-foreground">Version {version}</p>
-					</div>
+					{isStale && (
+						<span
+							className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
+							style={{
+								backgroundColor: SEMANTIC_COLORS.warning.bg,
+								border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
+								color: SEMANTIC_COLORS.warning.text,
+							}}
+						>
+							<AlertTriangle className="h-3 w-3" />
+							Stale
+						</span>
+					)}
 				</div>
-				{isStale && (
-					<span
-						className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium"
-						style={{
-							backgroundColor: SEMANTIC_COLORS.warning.bg,
-							border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
-							color: SEMANTIC_COLORS.warning.text,
-						}}
-					>
-						<AlertTriangle className="h-3 w-3" />
-						Stale
-					</span>
-				)}
-			</div>
 
-			<div className="space-y-2.5">
-				<div className="flex items-center gap-2.5 text-sm">
-					<Database className="h-4 w-4 text-muted-foreground" />
-					<span className="text-muted-foreground">
-						<span className="font-medium text-foreground">{itemCount}</span> items cached
-						{sourceBreakdown && (
-							<span className="ml-1">
-								({sourceBreakdown.official} official,{" "}
-								<span style={{ color: themeGradient.from }}>{sourceBreakdown.custom} custom</span>)
-							</span>
-						)}
-					</span>
+				<div className="space-y-2.5">
+					<div className="flex items-center gap-2.5 text-sm">
+						<Database className="h-4 w-4 text-muted-foreground" />
+						<span className="text-muted-foreground">
+							<span className="font-medium text-foreground">{itemCount}</span> items cached
+							{sourceBreakdown && (
+								<span className="ml-1">
+									({sourceBreakdown.official} official,{" "}
+									<span style={{ color: themeGradient.from }}>{sourceBreakdown.custom} custom</span>
+									)
+								</span>
+							)}
+						</span>
+					</div>
+					<div className="flex items-center gap-2.5 text-sm">
+						<Clock className="h-4 w-4 text-muted-foreground" />
+						<span className="text-muted-foreground">
+							Last fetched:{" "}
+							<span className="text-foreground">{new Date(lastFetched).toLocaleString()}</span>
+						</span>
+					</div>
 				</div>
-				<div className="flex items-center gap-2.5 text-sm">
-					<Clock className="h-4 w-4 text-muted-foreground" />
-					<span className="text-muted-foreground">
-						Last fetched:{" "}
-						<span className="text-foreground">{new Date(lastFetched).toLocaleString()}</span>
-					</span>
-				</div>
-			</div>
 			</div>
 		</article>
 	);

--- a/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-progress-modal.tsx
@@ -215,7 +215,8 @@ export const SyncProgressModal = ({
 								</h2>
 								<p id="sync-progress-description" className="mt-1 text-sm text-muted-foreground">
 									Template: <span className="font-medium text-foreground">{templateName}</span> →
-									Instance: <span className="font-medium text-foreground">{displayInstanceName}</span>
+									Instance:{" "}
+									<span className="font-medium text-foreground">{displayInstanceName}</span>
 								</p>
 							</div>
 						</div>

--- a/apps/web/src/features/trash-guides/components/template-stats.tsx
+++ b/apps/web/src/features/trash-guides/components/template-stats.tsx
@@ -338,7 +338,9 @@ export const TemplateStats = ({
 											{/* Top: Instance name + strategy badge */}
 											<div className="flex items-center justify-center gap-2">
 												<span className="text-sm font-medium text-foreground">
-													{incognitoMode ? getLinuxInstanceName(instance.instanceName) : instance.instanceName}
+													{incognitoMode
+														? getLinuxInstanceName(instance.instanceName)
+														: instance.instanceName}
 												</span>
 												<Badge
 													variant={strategyInfo.variant}

--- a/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
+++ b/apps/web/src/features/trash-guides/components/trash-guides-client.tsx
@@ -139,36 +139,43 @@ function CacheValidationHealthSection() {
 
 			<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
 				{categories.map(([category, stats]) => {
-					const cardColor = stats.rejected > 0 ? SEMANTIC_COLORS.warning.from : SEMANTIC_COLORS.success.from;
+					const cardColor =
+						stats.rejected > 0 ? SEMANTIC_COLORS.warning.from : SEMANTIC_COLORS.success.from;
 					return (
-					<div
-						key={category}
-						className="rounded-xl p-4 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-lg hover:shadow-black/10"
-						style={{
-							backgroundColor: `${cardColor}05`,
-							border: `1px solid ${cardColor}12`,
-						}}
-					>
-						<div className="flex items-center justify-between mb-2">
-							<span className="text-sm font-medium text-foreground capitalize">
-								{category.replace(/([A-Z])/g, " $1").trim()}
-							</span>
-							{stats.rejected > 0 ? (
-								<AlertCircle className="h-4 w-4" style={{ color: SEMANTIC_COLORS.warning.from }} />
-							) : (
-								<CheckCircle2 className="h-4 w-4" style={{ color: SEMANTIC_COLORS.success.from }} />
+						<div
+							key={category}
+							className="rounded-xl p-4 transition-all duration-200 hover:-translate-y-[1px] hover:shadow-lg hover:shadow-black/10"
+							style={{
+								backgroundColor: `${cardColor}05`,
+								border: `1px solid ${cardColor}12`,
+							}}
+						>
+							<div className="flex items-center justify-between mb-2">
+								<span className="text-sm font-medium text-foreground capitalize">
+									{category.replace(/([A-Z])/g, " $1").trim()}
+								</span>
+								{stats.rejected > 0 ? (
+									<AlertCircle
+										className="h-4 w-4"
+										style={{ color: SEMANTIC_COLORS.warning.from }}
+									/>
+								) : (
+									<CheckCircle2
+										className="h-4 w-4"
+										style={{ color: SEMANTIC_COLORS.success.from }}
+									/>
+								)}
+							</div>
+							<div className="flex items-baseline gap-1">
+								<span className="text-2xl font-bold text-foreground">{stats.validated}</span>
+								<span className="text-sm text-muted-foreground">/ {stats.total}</span>
+							</div>
+							{stats.rejected > 0 && (
+								<p className="text-xs mt-1" style={{ color: SEMANTIC_COLORS.warning.text }}>
+									{stats.rejected} rejected
+								</p>
 							)}
 						</div>
-						<div className="flex items-baseline gap-1">
-							<span className="text-2xl font-bold text-foreground">{stats.validated}</span>
-							<span className="text-sm text-muted-foreground">/ {stats.total}</span>
-						</div>
-						{stats.rejected > 0 && (
-							<p className="text-xs mt-1" style={{ color: SEMANTIC_COLORS.warning.text }}>
-								{stats.rejected} rejected
-							</p>
-						)}
-					</div>
 					);
 				})}
 			</div>
@@ -253,11 +260,15 @@ export function TrashGuidesClient() {
 						>
 							<div
 								className="absolute inset-0 pointer-events-none"
-								style={{ background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)` }}
+								style={{
+									background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)`,
+								}}
 							/>
 							<div
 								className="absolute left-0 top-0 bottom-0 w-[3px]"
-								style={{ background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})` }}
+								style={{
+									background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
+								}}
 							/>
 							<div className="relative p-6">
 								<div className="flex items-start gap-4">
@@ -274,7 +285,10 @@ export function TrashGuidesClient() {
 										<div className="flex items-center gap-2 mb-1">
 											<span
 												className="inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider"
-												style={{ backgroundColor: `${themeGradient.from}12`, color: themeGradient.from }}
+												style={{
+													backgroundColor: `${themeGradient.from}12`,
+													color: themeGradient.from,
+												}}
 											>
 												<History className="h-2.5 w-2.5" />
 												History
@@ -309,11 +323,15 @@ export function TrashGuidesClient() {
 					>
 						<div
 							className="absolute inset-0 pointer-events-none"
-							style={{ background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)` }}
+							style={{
+								background: `linear-gradient(135deg, ${themeGradient.from}04, transparent 60%)`,
+							}}
 						/>
 						<div
 							className="absolute left-0 top-0 bottom-0 w-[3px]"
-							style={{ background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})` }}
+							style={{
+								background: `linear-gradient(180deg, ${themeGradient.from}, ${themeGradient.fromLight})`,
+							}}
 						/>
 						<div className="relative p-6 space-y-4">
 							<span
@@ -327,7 +345,10 @@ export function TrashGuidesClient() {
 								<div className="flex items-center justify-center py-12">
 									<div
 										className="h-8 w-8 animate-spin rounded-full border-2 border-t-transparent"
-										style={{ borderColor: `${themeGradient.from}40`, borderTopColor: "transparent" }}
+										style={{
+											borderColor: `${themeGradient.from}40`,
+											borderTopColor: "transparent",
+										}}
 									/>
 								</div>
 							) : currentUser?.id ? (

--- a/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
+++ b/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
@@ -300,7 +300,8 @@ function JsonImportTab({
 					customFormats: cfs.map((cf) => ({
 						name: cf.name,
 						includeCustomFormatWhenRenaming: cf.includeCustomFormatWhenRenaming,
-						specifications: cf.specifications as ImportUserCFFromJsonRequest["customFormats"][number]["specifications"],
+						specifications:
+							cf.specifications as ImportUserCFFromJsonRequest["customFormats"][number]["specifications"],
 					})),
 					defaultScore,
 				},

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration-catalog.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration-catalog.tsx
@@ -10,10 +10,7 @@ import {
 import type { ThemeGradient } from "../../../../lib/theme-gradients";
 import { SanitizedHtml } from "../sanitized-html";
 import type { CFSelectionState } from "./cf-configuration-types";
-import type {
-	WizardCFConfigurationResult,
-	ResolveScoreFn,
-} from "../../types/wizard-types";
+import type { WizardCFConfigurationResult, ResolveScoreFn } from "../../types/wizard-types";
 
 interface CatalogSectionProps {
 	/** The full CF configuration data from the hook */
@@ -189,7 +186,12 @@ export const BrowseCFCatalog = ({
 }: BrowseCFCatalogProps) => {
 	if (!data.availableFormats || data.availableFormats.length === 0) return null;
 
-	const filterCF = (cf: { trash_id: string; name?: string; displayName?: string; description?: string }) => {
+	const filterCF = (cf: {
+		trash_id: string;
+		name?: string;
+		displayName?: string;
+		description?: string;
+	}) => {
 		// Hide formats already in template (mandatory or in groups)
 		const isInMandatory = data.mandatoryCFs?.some(
 			(mandatoryCF) => mandatoryCF.trash_id === cf.trash_id,
@@ -199,8 +201,7 @@ export const BrowseCFCatalog = ({
 		// Hide formats in CF groups
 		const isInGroups = data.cfGroups?.some((group) =>
 			group.custom_formats?.some(
-				(groupCF) =>
-					(typeof groupCF === "string" ? groupCF : groupCF.trash_id) === cf.trash_id,
+				(groupCF) => (typeof groupCF === "string" ? groupCF : groupCF.trash_id) === cf.trash_id,
 			),
 		);
 		if (isInGroups) return false;

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration-edit.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration-edit.tsx
@@ -196,7 +196,8 @@ export const CFConfigurationEdit = ({
 					(c) => (typeof c === "string" ? c : c.trash_id) === trashId,
 				);
 				if (foundCF) {
-					const cfObj = typeof foundCF === "string" ? { trash_id: foundCF, name: foundCF } : foundCF;
+					const cfObj =
+						typeof foundCF === "string" ? { trash_id: foundCF, name: foundCF } : foundCF;
 					return {
 						trash_id: cfObj.trash_id,
 						name: cfObj.name,
@@ -227,7 +228,15 @@ export const CFConfigurationEdit = ({
 				}
 			}
 
-			return { trash_id: trashId, name: trashId, displayName: trashId, description: "", defaultScore: 0, source: "trash", locked: false };
+			return {
+				trash_id: trashId,
+				name: trashId,
+				displayName: trashId,
+				description: "",
+				defaultScore: 0,
+				source: "trash",
+				locked: false,
+			};
 		});
 
 	return (
@@ -491,7 +500,9 @@ export const CFConfigurationEdit = ({
 					const selection = selections[conditionEditorFormat.trashId];
 
 					const format = conditionEditorFormat.format;
-					const specs = (format.originalConfig?.specifications || format.specifications || []) as ConditionSpec[];
+					const specs = (format.originalConfig?.specifications ||
+						format.specifications ||
+						[]) as ConditionSpec[];
 
 					const specificationsWithEnabled = specs.map((spec) => ({
 						...spec,

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
@@ -36,11 +36,7 @@ import { CFConfigurationCloned } from "./cf-configuration-cloned";
 import { CFConfigurationEdit } from "./cf-configuration-edit";
 import type { CFSelectionState, ConditionEditorTarget } from "./cf-configuration-types";
 import type { ResolvedCF } from "./cf-resolution";
-import type {
-	WizardEditingTemplate,
-	ResolveScoreFn,
-} from "../../types/wizard-types";
-
+import type { WizardEditingTemplate, ResolveScoreFn } from "../../types/wizard-types";
 
 /**
  * Wizard-specific profile type that allows undefined trashId for edit mode.
@@ -409,7 +405,9 @@ export const CFConfiguration = ({
 	const resolveScore: ResolveScoreFn = (cf, fallback?) => {
 		const cfRecord = cf as Record<string, unknown>;
 		const originalConfig = cfRecord.originalConfig as Record<string, unknown> | undefined;
-		const trashScores = (originalConfig?.trash_scores ?? cfRecord.trash_scores) as Record<string, number> | undefined;
+		const trashScores = (originalConfig?.trash_scores ?? cfRecord.trash_scores) as
+			| Record<string, number>
+			| undefined;
 		return trashScores?.[scoreSet] ?? trashScores?.default ?? fallback ?? 0;
 	};
 
@@ -432,7 +430,9 @@ export const CFConfiguration = ({
 						default: cf.default,
 						defaultChecked: cf.defaultChecked,
 						source: undefined as string | undefined,
-						includeCustomFormatWhenRenaming: cfRecord.includeCustomFormatWhenRenaming as boolean | undefined,
+						includeCustomFormatWhenRenaming: cfRecord.includeCustomFormatWhenRenaming as
+							| boolean
+							| undefined,
 						specifications: cfRecord.specifications as unknown[] | undefined,
 					};
 				}),
@@ -532,10 +532,7 @@ export const CFConfiguration = ({
 						<AlertDescription>
 							Found{" "}
 							{filteredMandatoryCFs.length +
-								filteredGroupedCFs.reduce(
-									(acc, g) => acc + g.customFormats.length,
-									0,
-								)}{" "}
+								filteredGroupedCFs.reduce((acc, g) => acc + g.customFormats.length, 0)}{" "}
 							custom formats matching &quot;{searchQuery}&quot;
 						</AlertDescription>
 					</Alert>
@@ -967,25 +964,29 @@ export const CFConfiguration = ({
 			)}
 
 			{/* Additional Custom Formats - Selected from Browse */}
-			{data && <AdditionalCFSection
-				data={data}
-				selections={selections}
-				onToggleCF={(trashId) => toggleCF(trashId)}
-				onUpdateSelection={updateSelection}
-				resolveScore={resolveScore}
-			/>}
+			{data && (
+				<AdditionalCFSection
+					data={data}
+					selections={selections}
+					onToggleCF={(trashId) => toggleCF(trashId)}
+					onUpdateSelection={updateSelection}
+					resolveScore={resolveScore}
+				/>
+			)}
 
 			{/* Browse All Custom Formats */}
-			{data && <BrowseCFCatalog
-				data={data}
-				selections={selections}
-				onToggleCF={(trashId) => toggleCF(trashId)}
-				onUpdateSelection={updateSelection}
-				resolveScore={resolveScore}
-				searchQuery={searchQuery}
-				isClonedProfile={isClonedProfile}
-				themeGradient={themeGradient}
-			/>}
+			{data && (
+				<BrowseCFCatalog
+					data={data}
+					selections={selections}
+					onToggleCF={(trashId) => toggleCF(trashId)}
+					onUpdateSelection={updateSelection}
+					resolveScore={resolveScore}
+					searchQuery={searchQuery}
+					isClonedProfile={isClonedProfile}
+					themeGradient={themeGradient}
+				/>
+			)}
 
 			{/* Navigation */}
 			<div

--- a/apps/web/src/features/trash-guides/components/wizard-steps/quality-configuration.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/quality-configuration.tsx
@@ -225,36 +225,38 @@ export const QualityConfiguration = ({
 		}
 
 		// Convert qualityItems to CustomQualityConfig format
-		const items = data.qualityItems.map((item: { name: string; allowed?: boolean; items?: string[] }, index: number) => {
-			const id = `q-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 7)}`;
+		const items = data.qualityItems.map(
+			(item: { name: string; allowed?: boolean; items?: string[] }, index: number) => {
+				const id = `q-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 7)}`;
 
-			// Check if this is a quality group (has nested items)
-			if (item.items && Array.isArray(item.items) && item.items.length > 0) {
+				// Check if this is a quality group (has nested items)
+				if (item.items && Array.isArray(item.items) && item.items.length > 0) {
+					return {
+						type: "group" as const,
+						group: {
+							id,
+							name: item.name,
+							allowed: item.allowed ?? true,
+							qualities: item.items.map((qualityName: string, qIndex: number) => ({
+								id: `q-${Date.now()}-${index}-${qIndex}-${Math.random().toString(36).slice(2, 7)}`,
+								name: qualityName,
+								allowed: true,
+							})),
+						},
+					};
+				}
+
+				// Single quality item
 				return {
-					type: "group" as const,
-					group: {
+					type: "quality" as const,
+					item: {
 						id,
 						name: item.name,
 						allowed: item.allowed ?? true,
-						qualities: item.items.map((qualityName: string, qIndex: number) => ({
-							id: `q-${Date.now()}-${index}-${qIndex}-${Math.random().toString(36).slice(2, 7)}`,
-							name: qualityName,
-							allowed: true,
-						})),
 					},
 				};
-			}
-
-			// Single quality item
-			return {
-				type: "quality" as const,
-				item: {
-					id,
-					name: item.name,
-					allowed: item.allowed ?? true,
-				},
-			};
-		});
+			},
+		);
 
 		// Find cutoffId
 		let cutoffId: string | undefined;

--- a/apps/web/src/hooks/api/__tests__/usePulseActionMutation-incognito.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/usePulseActionMutation-incognito.test.tsx
@@ -95,9 +95,7 @@ describe("usePulseActionMutation — incognito-mode error toast sanitization", (
 
 	it("strips a hostname URL from a backend error message in incognito mode", async () => {
 		localStorage.setItem(INCOGNITO_STORAGE_KEY, "true");
-		await fireMutationWithError(
-			"fetch failed: http://sonarr.local:8989/api/v3/queue/42",
-		);
+		await fireMutationWithError("fetch failed: http://sonarr.local:8989/api/v3/queue/42");
 
 		const text = toastErrorCalls[0]!;
 		expect(text).not.toContain("sonarr.local");

--- a/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
@@ -1,5 +1,6 @@
 import type {
 	LibraryEnrichmentResponse,
+	LibraryItem,
 	SeerrPageResult,
 	SeerrRequest,
 	SeerrRequestCount,
@@ -508,12 +509,13 @@ describe("useLibraryEnrichment", () => {
 		};
 		vi.mocked(seerrApi.fetchLibraryEnrichment).mockResolvedValue(enrichmentResponse);
 
-		const items = [
+		const items: LibraryItem[] = [
 			{
 				id: "lib-1",
 				title: "Test Movie",
 				service: "radarr" as const,
 				instanceId: "i-1",
+				instanceName: "Radarr",
 				type: "movie" as const,
 				remoteIds: { tmdbId: 100, imdbId: "tt123" },
 				monitored: true,
@@ -526,6 +528,7 @@ describe("useLibraryEnrichment", () => {
 				title: "Test Series",
 				service: "sonarr" as const,
 				instanceId: "i-2",
+				instanceName: "Sonarr",
 				type: "series" as const,
 				remoteIds: { tmdbId: 200, tvdbId: 999 },
 				monitored: true,
@@ -536,7 +539,7 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(() => useLibraryEnrichment("seerr-inst", items as any), {
+		const { result } = renderHook(() => useLibraryEnrichment("seerr-inst", items), {
 			wrapper,
 		});
 
@@ -551,12 +554,13 @@ describe("useLibraryEnrichment", () => {
 	});
 
 	it("is disabled when seerr instanceId is null", () => {
-		const items = [
+		const items: LibraryItem[] = [
 			{
 				id: "lib-1",
 				title: "Movie",
 				service: "radarr" as const,
 				instanceId: "i-1",
+				instanceName: "Radarr",
 				type: "movie" as const,
 				remoteIds: { tmdbId: 100 },
 				monitored: true,
@@ -567,7 +571,7 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(() => useLibraryEnrichment(null, items as any), { wrapper });
+		const { result } = renderHook(() => useLibraryEnrichment(null, items), { wrapper });
 
 		expect(result.current.fetchStatus).toBe("idle");
 		expect(seerrApi.fetchLibraryEnrichment).not.toHaveBeenCalled();

--- a/apps/web/src/hooks/api/useCFConfiguration.ts
+++ b/apps/web/src/hooks/api/useCFConfiguration.ts
@@ -223,9 +223,9 @@ async function fetchCFDescriptionMap(serviceType: string): Promise<{
 	const bySlug = new Map<string, DescEntry>();
 	const byDisplayName = new Map<string, DescEntry>();
 	try {
-		const res = await apiRequest<Record<string, Array<{ cfName: string; description: string; displayName?: string }>>>(
-			`/api/trash-guides/cache/cf-descriptions/list?serviceType=${serviceType}`,
-		);
+		const res = await apiRequest<
+			Record<string, Array<{ cfName: string; description: string; displayName?: string }>>
+		>(`/api/trash-guides/cache/cf-descriptions/list?serviceType=${serviceType}`);
 		const serviceKey = serviceType.toLowerCase();
 		const descriptions = res?.[serviceKey] || [];
 		for (const desc of descriptions) {
@@ -263,7 +263,13 @@ function cfNameToSlug(name: string): string {
  * Mirrors the 4-strategy approach from custom-formats-browser.tsx.
  */
 function enrichWithDescription(
-	cf: { name?: string; originalConfig?: Record<string, unknown>; trash_description?: string; description?: string; displayName?: string },
+	cf: {
+		name?: string;
+		originalConfig?: Record<string, unknown>;
+		trash_description?: string;
+		description?: string;
+		displayName?: string;
+	},
 	descMaps: { bySlug: Map<string, DescEntry>; byDisplayName: Map<string, DescEntry> },
 ): { description: string; displayName: string } {
 	const name = cf.name || (cf.originalConfig?.name as string) || "";
@@ -491,7 +497,10 @@ async function fetchClonedProfileData(trashId: string) {
 	};
 }
 
-async function fetchNormalModeData(serviceType: string, trashId: string): Promise<WizardCFConfigurationResult> {
+async function fetchNormalModeData(
+	serviceType: string,
+	trashId: string,
+): Promise<WizardCFConfigurationResult> {
 	const profileData = await apiRequest<Record<string, unknown>>(
 		`/api/trash-guides/quality-profiles/${serviceType}/${trashId}`,
 	);
@@ -499,16 +508,15 @@ async function fetchNormalModeData(serviceType: string, trashId: string): Promis
 	// Check for error response (quality profile route returns { statusCode, error, message } on error)
 	if (profileData.statusCode || profileData.error) {
 		throw new Error(
-			((profileData.message || profileData.error) as string) || "Failed to fetch quality profile details",
+			((profileData.message || profileData.error) as string) ||
+				"Failed to fetch quality profile details",
 		);
 	}
 
 	const availableFormats = await fetchAvailableFormats(serviceType);
 
 	// Extract quality items from profile for QualityGroupEditor
-	const qualityItems = extractQualityItems(
-		(profileData.profile as Record<string, unknown>) || {},
-	);
+	const qualityItems = extractQualityItems((profileData.profile as Record<string, unknown>) || {});
 
 	// The quality profile endpoint returns cfGroups, mandatoryCFs, stats, profile, etc.
 	// Spread them and add our computed fields

--- a/apps/web/src/hooks/api/useTautulli.ts
+++ b/apps/web/src/hooks/api/useTautulli.ts
@@ -18,7 +18,11 @@ import {
 	fetchWatchHistory,
 } from "../../lib/api-client/tautulli";
 import { tautulliKeys } from "../../lib/query-keys";
-import { POLLING_BACKGROUND, POLLING_REALTIME, POLLING_STANDARD } from "../../lib/polling-intervals";
+import {
+	POLLING_BACKGROUND,
+	POLLING_REALTIME,
+	POLLING_STANDARD,
+} from "../../lib/polling-intervals";
 
 // ============================================================================
 // Activity (F5)

--- a/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
+++ b/apps/web/src/hooks/api/useWatchedMonitoredInsights.ts
@@ -23,19 +23,14 @@ interface WatchedMonitoredResponse {
 	};
 }
 
-function fetchWatchedMonitored(params: {
-	limit?: number;
-}): Promise<WatchedMonitoredResponse> {
+function fetchWatchedMonitored(params: { limit?: number }): Promise<WatchedMonitoredResponse> {
 	const search = new URLSearchParams();
 	if (params.limit !== undefined) search.set("limit", String(params.limit));
 	const qs = search.toString();
 	return apiRequest(`/api/library/insights/watched-monitored${qs ? `?${qs}` : ""}`);
 }
 
-export function useWatchedMonitoredInsights(params?: {
-	limit?: number;
-	enabled?: boolean;
-}) {
+export function useWatchedMonitoredInsights(params?: { limit?: number; enabled?: boolean }) {
 	return useQuery<WatchedMonitoredResponse>({
 		queryKey: ["library", "insights", "watched-monitored", params],
 		queryFn: () => fetchWatchedMonitored({ limit: params?.limit }),

--- a/apps/web/src/hooks/useEnrichableItems.ts
+++ b/apps/web/src/hooks/useEnrichableItems.ts
@@ -39,9 +39,7 @@ export function useEnrichableItems<M extends string, S extends string>(
 	items: LibraryItem[],
 	typeMapping: EnrichableTypeMapping<M, S>,
 ): EnrichableResult<M | S>;
-export function useEnrichableItems(
-	items: LibraryItem[],
-): EnrichableResult<"movie" | "tv">;
+export function useEnrichableItems(items: LibraryItem[]): EnrichableResult<"movie" | "tv">;
 export function useEnrichableItems<M extends string = "movie", S extends string = "tv">(
 	items: LibraryItem[],
 	typeMapping: EnrichableTypeMapping<M, S> = DEFAULT_TYPE_MAPPING as EnrichableTypeMapping<M, S>,

--- a/apps/web/src/hooks/useFocusTrap.ts
+++ b/apps/web/src/hooks/useFocusTrap.ts
@@ -109,4 +109,3 @@ export function useFocusTrap<T extends HTMLElement>(isActive: boolean, onEscape?
 
 	return containerRef;
 }
-

--- a/apps/web/src/lib/api-client/auth/index.ts
+++ b/apps/web/src/lib/api-client/auth/index.ts
@@ -137,7 +137,9 @@ export async function getPasskeyCredentials(): Promise<PasskeyCredential[]> {
 	return data.credentials;
 }
 
-export async function getPasskeyRegistrationOptions(friendlyName?: string): Promise<WebAuthnOptions> {
+export async function getPasskeyRegistrationOptions(
+	friendlyName?: string,
+): Promise<WebAuthnOptions> {
 	return apiRequest("/auth/passkey/register/options", {
 		method: "POST",
 		json: { friendlyName },
@@ -154,13 +156,19 @@ export async function verifyPasskeyRegistration(
 	});
 }
 
-export async function getPasskeyLoginOptions(): Promise<{ options: WebAuthnOptions; sessionId: string }> {
+export async function getPasskeyLoginOptions(): Promise<{
+	options: WebAuthnOptions;
+	sessionId: string;
+}> {
 	return apiRequest("/auth/passkey/login/options", {
 		method: "POST",
 	});
 }
 
-export async function verifyPasskeyLogin(response: WebAuthnCredentialJSON, sessionId: string): Promise<CurrentUser> {
+export async function verifyPasskeyLogin(
+	response: WebAuthnCredentialJSON,
+	sessionId: string,
+): Promise<CurrentUser> {
 	const data = await apiRequest<CurrentUserResponse>("/auth/passkey/login/verify", {
 		method: "POST",
 		json: { response, sessionId },

--- a/apps/web/src/lib/api-client/oidc-providers.ts
+++ b/apps/web/src/lib/api-client/oidc-providers.ts
@@ -20,7 +20,6 @@ export async function getOIDCProvider(): Promise<OIDCProviderResponse> {
 	});
 }
 
-
 /**
  * Create a new OIDC provider (admin only)
  */

--- a/apps/web/src/lib/api-client/pulse.ts
+++ b/apps/web/src/lib/api-client/pulse.ts
@@ -27,8 +27,7 @@ export async function dispatchPulseAction(
 	signalId: string,
 	action: PulseAction,
 ): Promise<PulseActionResponse> {
-	return apiRequest<PulseActionResponse>(
-		`/api/pulse/${encodeURIComponent(signalId)}/action`,
-		{ json: action },
-	);
+	return apiRequest<PulseActionResponse>(`/api/pulse/${encodeURIComponent(signalId)}/action`, {
+		json: action,
+	});
 }

--- a/apps/web/src/lib/api-client/trash-guides/custom-formats.ts
+++ b/apps/web/src/lib/api-client/trash-guides/custom-formats.ts
@@ -46,7 +46,6 @@ export interface DeployMultipleCustomFormatsRequest {
 	serviceType: "RADARR" | "SONARR";
 }
 
-
 export interface DeployMultipleCustomFormatsResponse {
 	success: boolean;
 	created: string[];
@@ -199,7 +198,6 @@ export async function createUserCustomFormat(
 		json: request,
 	});
 }
-
 
 /**
  * Delete a user custom format

--- a/apps/web/src/providers/color-theme-provider.tsx
+++ b/apps/web/src/providers/color-theme-provider.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { createContext, type ReactNode, useCallback, useMemo, useContext, useEffect, useState } from "react";
+import {
+	createContext,
+	type ReactNode,
+	useCallback,
+	useMemo,
+	useContext,
+	useEffect,
+	useState,
+} from "react";
 
 /**
  * Color Theme Provider

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,10 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
+	"css": {
+		"parser": {
+			"tailwindDirectives": true
+		}
+	},
 	"formatter": {
 		"enabled": true,
 		"lineWidth": 100
@@ -27,6 +32,7 @@
 			"includes": [
 				"apps/api/src/index.ts",
 				"apps/api/src/launcher.ts",
+				"apps/api/src/lib/backup/__tests__/backup-heap.test.ts",
 				"apps/api/src/lib/queue-cleaner/test-*.ts",
 				"apps/api/src/lib/queue-cleaner/analyze-*.ts"
 			],
@@ -51,6 +57,12 @@
 	],
 	"assist": { "actions": { "source": { "organizeImports": "on" } } },
 	"files": {
-		"includes": ["**", "!**/node_modules/**", "!**/dist/**", "!**/generated/**"]
+		"includes": [
+			"**",
+			"!**/node_modules/**",
+			"!**/.next/**",
+			"!**/dist/**",
+			"!**/generated/**"
+		]
 	}
 }

--- a/packages/shared/src/types/__tests__/trash-guides.test.ts
+++ b/packages/shared/src/types/__tests__/trash-guides.test.ts
@@ -6,10 +6,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import {
-	isCFGroupApplicableToProfile,
-	type TrashCustomFormatGroup,
-} from "../trash-guides.js";
+import { isCFGroupApplicableToProfile, type TrashCustomFormatGroup } from "../trash-guides.js";
 
 // ============================================================================
 // Helper factories for test data
@@ -160,10 +157,10 @@ describe("isCFGroupApplicableToProfile", () => {
 				custom_formats: [],
 				quality_profiles: {
 					include: {
-						"included": PROFILE_HD_BLURAY,
+						included: PROFILE_HD_BLURAY,
 					},
 					exclude: {
-						"excluded": PROFILE_HD_BLURAY, // Same profile in both!
+						excluded: PROFILE_HD_BLURAY, // Same profile in both!
 					},
 				},
 			};
@@ -216,7 +213,7 @@ describe("isCFGroupApplicableToProfile", () => {
 
 		it("should be case-sensitive for profile IDs", () => {
 			const group = createGroupWithInclude("group-1", {
-				"included": "Profile-ID",
+				included: "Profile-ID",
 			});
 
 			expect(isCFGroupApplicableToProfile(group, "Profile-ID")).toBe(true);

--- a/packages/shared/src/types/pulse.ts
+++ b/packages/shared/src/types/pulse.ts
@@ -25,11 +25,7 @@ export type PulseCategory = z.infer<typeof pulseCategorySchema>;
 // boundary. New kinds land by extending this union — schema drift between
 // client and server surfaces as a Zod parse failure, not a silent no-op.
 
-export const pulseActionKindSchema = z.enum([
-	"scheduler.enable",
-	"cache.refresh",
-	"queue.retry",
-]);
+export const pulseActionKindSchema = z.enum(["scheduler.enable", "cache.refresh", "queue.retry"]);
 export type PulseActionKind = z.infer<typeof pulseActionKindSchema>;
 
 // Canonical scheduler job ids — match `JOB_ID` in


### PR DESCRIPTION
## Summary

- restore an idempotent Biome 2.5 formatting baseline across the 2.x tree
- enable Tailwind directive parsing and exclude generated Next.js output from formatting
- resolve all API Biome and web ESLint diagnostics with focused code fixes or narrowly documented exceptions
- stabilize React tests by supplying complete query mocks, awaiting async updates, and keying mapped fragments

## Review notes

Most of this PR is deterministic formatter output. The non-format changes are limited to lint-equivalent optional chains and property access, one memoized library item array, scoped external tracker-icon image exceptions, test typing/mocks, and the validation table fragment key.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm audit` (no known vulnerabilities)
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (2,615 passing; 41 skipped)
- `pnpm run lint` (zero diagnostics)
- `pnpm run build`
- focused warning-regression tests (25 passing with clean stderr)