### PR TITLE
fix: support Sonarr flat ratings in cleanup rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Library Cleanup rating rules now read Sonarr's flat SkyHook rating format,
+  while IMDb-specific rules continue to require an explicitly sourced IMDb
+  value.
 - New Radarr and Sonarr downloads are now detected when an item is added and
   imported entirely between library polls, and the resulting notification is
   dispatched only through channels owned by the instance's user.

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
@@ -8,14 +8,14 @@
  */
 
 import { describe, expect, it } from "vitest";
-import type { CacheItemForEval, EvalContext, PlexWatchInfo, SeerrRequestInfo } from "./types.js";
+import type { LibraryCleanupRule } from "../prisma.js";
 import {
 	evaluateItemAgainstRules,
 	evaluateRule,
 	evaluateSingleCondition,
 	extractRating,
 } from "./rule-evaluators.js";
-import type { LibraryCleanupRule } from "../prisma.js";
+import type { CacheItemForEval, EvalContext, PlexWatchInfo, SeerrRequestInfo } from "./types.js";
 
 // ---------------------------------------------------------------------------
 // Type stub for Prisma-generated LibraryCleanupRule (avoids prisma generate)
@@ -206,7 +206,7 @@ describe("size rule", () => {
 });
 
 // ---------------------------------------------------------------------------
-// 3. Rating rule (TMDB from data blob)
+// 3. Rating rule (available *arr rating from data blob)
 // ---------------------------------------------------------------------------
 
 describe("rating rule", () => {
@@ -222,7 +222,26 @@ describe("rating rule", () => {
 		expect(rating).toBeNull();
 	});
 
-	it("matches item with rating below threshold", () => {
+	it("extractRating handles Sonarr's flat rating format", () => {
+		const item = makeCacheItem({
+			data: JSON.stringify({ ratings: { value: 7.4, votes: 142958 } }),
+		});
+		expect(extractRating(item)).toBe(7.4);
+	});
+
+	it("extractRating prefers Radarr's TMDB rating over a flat rating", () => {
+		const item = makeCacheItem({
+			data: JSON.stringify({
+				ratings: {
+					value: 7.4,
+					tmdb: { value: 8.2 },
+				},
+			}),
+		});
+		expect(extractRating(item)).toBe(8.2);
+	});
+
+	it("matches a Radarr item with a rating below the threshold", () => {
 		const item = makeCacheItem({
 			data: JSON.stringify({ ...DEFAULT_DATA, ratings: { tmdb: { value: 3.2 } } }),
 		});
@@ -235,10 +254,36 @@ describe("rating rule", () => {
 		expect(result).toContain("TMDB rating: 3.2");
 	});
 
+	it("matches a Sonarr item with a flat rating below the threshold", () => {
+		const item = makeCacheItem({
+			data: JSON.stringify({ ratings: { value: 4.5, votes: 10000 } }),
+		});
+		const result = evaluateSingleCondition(
+			item,
+			"rating",
+			{ operator: "less_than", score: 5 },
+			ctx,
+		);
+		expect(result).toContain("Sonarr rating: 4.5");
+	});
+
+	it("does not treat Sonarr's source-less flat rating as an IMDb rating", () => {
+		const item = makeCacheItem({
+			data: JSON.stringify({ ratings: { value: 6.8, votes: 50000 } }),
+		});
+		const result = evaluateSingleCondition(
+			item,
+			"imdb_rating",
+			{ operator: "less_than", score: 7 },
+			ctx,
+		);
+		expect(result).toBeNull();
+	});
+
 	it("matches unrated items", () => {
 		const item = makeCacheItem({ data: JSON.stringify({ genres: ["Drama"] }) });
 		const result = evaluateSingleCondition(item, "rating", { operator: "unrated" }, ctx);
-		expect(result).toBe("No TMDB rating");
+		expect(result).toBe("No rating");
 	});
 
 	it("does not flag rated item as unrated", () => {

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -116,23 +116,28 @@ function evaluateSizeRule(item: CacheItemForEval, params: SizeRuleParams): strin
 	return null;
 }
 
+interface ExtractedRating {
+	value: number;
+	label: "TMDB rating" | "Sonarr rating" | "Rating";
+}
+
 /**
- * Rating rule: flag items based on TMDB rating from the data blob.
+ * Rating rule: flag items based on the available *arr rating in the data blob.
  */
 function evaluateRatingRule(item: CacheItemForEval, params: RatingRuleParams): string | null {
-	const rating = extractRating(item);
+	const rating = extractRatingDetails(item);
 
 	if (params.operator === "unrated") {
-		return rating === null ? "No TMDB rating" : null;
+		return rating === null ? "No rating" : null;
 	}
 
 	if (rating === null || params.score === undefined) return null;
 
-	if (params.operator === "less_than" && rating < params.score) {
-		return `TMDB rating: ${rating.toFixed(1)} (threshold: < ${params.score})`;
+	if (params.operator === "less_than" && rating.value < params.score) {
+		return `${rating.label}: ${rating.value.toFixed(1)} (threshold: < ${params.score})`;
 	}
-	if (params.operator === "greater_than" && rating > params.score) {
-		return `TMDB rating: ${rating.toFixed(1)} (threshold: > ${params.score})`;
+	if (params.operator === "greater_than" && rating.value > params.score) {
+		return `${rating.label}: ${rating.value.toFixed(1)} (threshold: > ${params.score})`;
 	}
 
 	return null;
@@ -1821,11 +1826,11 @@ function evaluateStalenessScore(
 		userRatingScore = Math.max(0, 100 - plex.userRating * 10);
 	}
 
-	// 5. Low TMDB rating
-	let tmdbRatingScore = 100;
-	const tmdbRating = extractRating(item);
-	if (tmdbRating !== null) {
-		tmdbRatingScore = Math.max(0, 100 - tmdbRating * 10);
+	// 5. Low available *arr rating
+	let arrRatingScore = 100;
+	const arrRating = extractRating(item);
+	if (arrRating !== null) {
+		arrRatingScore = Math.max(0, 100 - arrRating * 10);
 	}
 
 	// 6. Size on disk (normalized: 50GB+ = 100)
@@ -1840,7 +1845,7 @@ function evaluateStalenessScore(
 		watchCountScore * w.inverseWatchCount +
 		onDeckScore * w.notOnDeck +
 		userRatingScore * w.lowUserRating +
-		tmdbRatingScore * w.lowTmdbRating +
+		arrRatingScore * w.lowTmdbRating +
 		sizeScore * w.sizeOnDisk;
 
 	// Normalize by sum of weights to handle incomplete weights
@@ -1854,7 +1859,7 @@ function evaluateStalenessScore(
 	const score = weightSum > 0 ? total / weightSum : 0;
 
 	if (params.operator === "greater_than" && score > params.threshold) {
-		return `Staleness score ${score.toFixed(1)} > ${params.threshold} (watch: ${daysSinceScore.toFixed(0)}, plays: ${watchCountScore.toFixed(0)}, tmdb: ${tmdbRatingScore.toFixed(0)})`;
+		return `Staleness score ${score.toFixed(1)} > ${params.threshold} (watch: ${daysSinceScore.toFixed(0)}, plays: ${watchCountScore.toFixed(0)}, rating: ${arrRatingScore.toFixed(0)})`;
 	}
 
 	return null;
@@ -1898,33 +1903,44 @@ function evaluateRecentlyActive(
 // ============================================================================
 
 /**
- * Extract TMDB rating from the item's JSON data blob.
- * The data field contains a serialized LibraryItem which may have ratings info
- * from Sonarr/Radarr's API response (stored in the `ratings` or `certification` fields).
+ * Extract the preferred available rating from a serialized Sonarr/Radarr item.
+ * Radarr exposes source-keyed ratings and Sonarr exposes a flat `{ value, votes }`
+ * object populated from SkyHook. Prefer Radarr's TMDB value when it is present.
  */
-export function extractRating(item: CacheItemForEval): number | null {
+function extractRatingDetails(item: CacheItemForEval): ExtractedRating | null {
 	const parsed = safeJsonParse(item.data);
 	if (!parsed) return null;
 
 	const data = parsed as Record<string, unknown>;
 
-	// Radarr stores ratings as { tmdb: { value: 7.5 }, imdb: { value: 7.2 } }
 	if (typeof data.ratings === "object" && data.ratings !== null) {
 		const ratings = data.ratings as Record<string, unknown>;
 		const tmdb = ratings.tmdb as Record<string, unknown> | undefined;
 		if (tmdb && typeof tmdb.value === "number") {
-			return tmdb.value;
+			return { value: tmdb.value, label: "TMDB rating" };
 		}
+
+		// Sonarr stores its SkyHook rating directly as { value, votes }.
+		if (typeof ratings.value === "number") {
+			return { value: ratings.value, label: "Sonarr rating" };
+		}
+
 		// Fallback to any available rating
 		for (const source of Object.values(ratings)) {
 			if (typeof source === "object" && source !== null) {
 				const val = (source as Record<string, unknown>).value;
-				if (typeof val === "number" && val > 0) return val;
+				if (typeof val === "number" && val > 0) {
+					return { value: val, label: "Rating" };
+				}
 			}
 		}
 	}
 
 	return null;
+}
+
+export function extractRating(item: CacheItemForEval): number | null {
+	return extractRatingDetails(item)?.value ?? null;
 }
 
 /**

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -194,7 +194,7 @@ export interface RuleMatch {
 export interface FlaggedItem {
 	cacheItem: CacheItemForEval;
 	match: RuleMatch;
-	/** TMDB rating if available from the data blob */
+	/** Preferred available *arr rating from the data blob */
 	rating: number | null;
 }
 

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -54,7 +54,11 @@ import {
 const RULE_TYPES: Array<{ value: CleanupRuleType; label: string; desc: string }> = [
 	{ value: "age", label: "Age", desc: "Flag items by age (older/newer than N days)" },
 	{ value: "size", label: "Size", desc: "Flag items based on disk size" },
-	{ value: "rating", label: "Rating", desc: "Flag items by TMDB rating" },
+	{
+		value: "rating",
+		label: "Rating",
+		desc: "Flag items by the available Radarr or Sonarr rating",
+	},
 	{ value: "status", label: "Status", desc: "Flag items with specific statuses" },
 	{ value: "unmonitored", label: "Unmonitored", desc: "Flag unmonitored items" },
 	{ value: "genre", label: "Genre", desc: "Flag items by genre" },


### PR DESCRIPTION
## Summary

- read Sonarr's flat `ratings: { value, votes }` shape in Library Cleanup rating rules
- keep Radarr's nested TMDb rating preferred when both shapes are present
- label matched values according to their actual source
- keep IMDb-specific rules strict: Sonarr's source-less SkyHook value is not treated as IMDb
- update the Rating rule description and changelog

The flat-format coverage was prompted by PR #596 from `josmase`. Its generic-rating cases were adapted here alongside the missing implementation; the IMDb-flat expectation was intentionally not adopted because Sonarr maps its source-less SkyHook rating into this field.

## Verification

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 2,068 passed / 41 skipped; web 506 passed; shared 45 passed)
- `pnpm run lint`
- focused rating evaluator suites: 150 passed