### PR TITLE
security: fail closed on destructive schema sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and Lodash advisories.
 - Pinned all third-party GitHub Actions to reviewed commit SHAs and hardened
   dependency updates with release-age, provenance, and registry-source policy.
+- Container startup now rejects destructive Prisma schema changes instead of
+  silently approving data loss, and schema-sync failures no longer echo any
+  portion of the database connection URL.
 
 ## [2.21.0] - 2026-06-09 — Media-only Storage & Auth Resilience
 

--- a/apps/api/src/lib/utils/__tests__/docker-schema-sync-contract.test.ts
+++ b/apps/api/src/lib/utils/__tests__/docker-schema-sync-contract.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Docker schema synchronization contract", () => {
+	const startupScript = readFileSync(
+		resolve(process.cwd(), "../../docker/start-combined.sh"),
+		"utf8",
+	);
+
+	it("synchronizes the runtime schema without approving data loss", () => {
+		const schemaSyncCommand = startupScript
+			.split("\n")
+			.find((line) => line.includes("prisma db push"));
+
+		expect(schemaSyncCommand).toContain("prisma db push --schema prisma/schema.prisma");
+		expect(schemaSyncCommand).not.toContain("--accept-data-loss");
+	});
+
+	it("keeps an actionable fail-closed message for destructive changes", () => {
+		expect(startupScript).toContain(
+			"Destructive schema changes are intentionally rejected at startup",
+		);
+		expect(startupScript).toContain("consult the release notes for an explicit upgrade path");
+	});
+
+	it("does not echo any portion of DATABASE_URL on synchronization failure", () => {
+		expect(startupScript).not.toContain("Current DATABASE_URL");
+		expect(startupScript).not.toContain("DATABASE_URL%%");
+		expect(startupScript).toContain("Detected database provider: $DB_PROVIDER");
+	});
+});

--- a/docker/README.md
+++ b/docker/README.md
@@ -67,6 +67,13 @@ docker run -d \
 
 Both `postgresql://` and `postgres://` URL schemes are supported.
 
+At startup, the container synchronizes the Prisma schema for the selected
+provider. Schema additions and other non-destructive changes are applied
+automatically. Destructive changes are rejected: the launcher never passes
+Prisma's `--accept-data-loss` option. If an upgrade requires a destructive
+transition, keep the previous image running and follow that release's explicit
+backup and migration instructions before retrying the upgrade.
+
 ## Environment Variables
 
 ### Core

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -275,19 +275,23 @@ fi
 
 echo ""
 echo "Synchronizing database schema..."
-# Use 'db push' instead of 'migrate deploy' to support multi-provider (SQLite/PostgreSQL)
-# Prisma migrations are provider-specific SQL, but db push generates correct SQL for any provider
-# --accept-data-loss allows dropping unused columns during schema updates (e.g., removed urlBase)
+# Use 'db push' instead of 'migrate deploy' to support multi-provider (SQLite/PostgreSQL).
+# Prisma migrations are provider-specific SQL, but db push generates correct SQL for any provider.
+# Deliberately do NOT pass --accept-data-loss here. A release that needs a destructive
+# schema transition must ship an explicit, reviewed migration/backup path instead of
+# silently discarding operator data merely because a new container started.
 # Note: Prisma 7 removed --skip-generate flag (db push no longer regenerates by default)
-if ! run_as_user ./node_modules/.bin/prisma db push --schema prisma/schema.prisma --accept-data-loss; then
+if ! run_as_user ./node_modules/.bin/prisma db push --schema prisma/schema.prisma; then
     echo "ERROR: Database schema synchronization failed" >&2
     if [ "$ROOTLESS" = true ]; then
         echo "  - In rootless mode, ensure the database file is readable/writable by UID:$PUID" >&2
         echo "  - If switching from root to rootless, run: chown $PUID:$PGID /path/to/config/prod.db" >&2
     fi
+    echo "  - Destructive schema changes are intentionally rejected at startup" >&2
+    echo "  - Restore the previous image and consult the release notes for an explicit upgrade path" >&2
     echo "  - Ensure DATABASE_URL is correct and the database is accessible" >&2
     echo "  - For PostgreSQL: Check that the database exists and user has permissions" >&2
-    echo "  - Current DATABASE_URL: ${DATABASE_URL%%@*}@[REDACTED]" >&2
+    echo "  - Detected database provider: $DB_PROVIDER" >&2
     exit 1
 fi
 echo "  - Database schema synchronized successfully"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -51,6 +51,9 @@ Before bumping any version numbers, decide *what* this release contains.
 - [ ] **Fresh PostgreSQL install:** Point `DATABASE_URL` at empty database, run `pnpm run db:push`, verify API starts
 - [ ] **SQLite upgrade:** Start with previous release database, run new version, verify schema migrates
 - [ ] **PostgreSQL upgrade:** Same as above with PostgreSQL
+- [ ] Run both upgrade scenarios **without** Prisma's `--accept-data-loss`; a
+      destructive transition requires a release-specific backup/migration plan
+      and must not be delegated to container startup
 - [ ] New Prisma models (if any) are documented in CHANGELOG
 
 ### 4. Docker Build


### PR DESCRIPTION
## Summary

- remove unconditional Prisma `--accept-data-loss` approval from 2.x container startup
- fail closed with actionable recovery guidance when a schema transition would be destructive
- avoid logging any portion of `DATABASE_URL` after schema-sync failure
- document the operator contract and add a regression test for the launcher

## Why

The 2.x launcher should never silently discard operator data merely because a newer container started. Additive schema upgrades continue automatically; a destructive transition now requires an explicit reviewed backup/migration path.

## Verification

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 2,071 passed / 41 skipped; web 506 passed; shared 45 passed)
- `pnpm run lint`
- `bash -n docker/start-combined.sh`
- built the exact branch image
- SQLite container upgrade from v2.21.0 passed without `--accept-data-loss`; existing login preserved
- PostgreSQL container upgrade from v2.21.0 passed without `--accept-data-loss`; existing login preserved and both HTTP-auth columns present
- independent security/code review tightened the regression test so it rejects the destructive flag regardless of argument ordering

This is a focused backport of the established `next` behavior.