### PR TITLE
chore: restore next quality baseline

### DIFF
--- a/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
+++ b/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
@@ -21,6 +21,7 @@ function rule(overrides: Partial<LibraryCleanupRule>): LibraryCleanupRule {
 		parameters: "{}",
 		operator: null,
 		conditions: null,
+		...overrides,
 	} as unknown as LibraryCleanupRule;
 	// minimal stub; only fields the collector reads
 }

--- a/apps/api/src/lib/library-sync/__tests__/infohash-backfill.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/infohash-backfill.test.ts
@@ -61,7 +61,6 @@ function makeApp(historyResponse: { ok: boolean; records?: unknown[] }) {
 				count: vi.fn().mockResolvedValue(0),
 			},
 		},
-		// biome-ignore lint/suspicious/noExplicitAny: test shim
 	} as any;
 }
 

--- a/apps/api/src/lib/qui/__tests__/action-service.test.ts
+++ b/apps/api/src/lib/qui/__tests__/action-service.test.ts
@@ -56,7 +56,6 @@ function makeApp(opts: { txReturn?: { id: string }[] } = {}) {
 		__create: create,
 		__updateMany: updateMany,
 		__transaction: $transaction,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/qui/__tests__/activity-log.test.ts
+++ b/apps/api/src/lib/qui/__tests__/activity-log.test.ts
@@ -26,7 +26,6 @@ function makeApp() {
 		__create: create,
 		__findFirst: findFirst,
 		__deleteMany: deleteMany,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 
@@ -69,7 +68,6 @@ describe("logQuiActivity", () => {
 			userId: "user-1",
 			eventType: "qui_sync_complete",
 			details: {},
-			// biome-ignore lint/suspicious/noExplicitAny: testing the deprecated alias
 			status: "warn" as any,
 		});
 		// The alias should map to the canonical `severity` Prisma field.

--- a/apps/api/src/lib/qui/__tests__/cross-seed-discovery.test.ts
+++ b/apps/api/src/lib/qui/__tests__/cross-seed-discovery.test.ts
@@ -36,7 +36,6 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 			},
 		},
 		...overrides,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
+++ b/apps/api/src/lib/qui/__tests__/torrent-state-sync.test.ts
@@ -46,7 +46,6 @@ function makeApp(overrides: Record<string, unknown> = {}) {
 		__findMany: serviceInstanceFindMany,
 		__libraryCacheFindMany: libraryCacheFindMany,
 		...overrides,
-		// biome-ignore lint/suspicious/noExplicitAny: test-shim
 	} as any;
 }
 

--- a/apps/api/src/lib/rules-migration/__tests__/tautulli-pass.test.ts
+++ b/apps/api/src/lib/rules-migration/__tests__/tautulli-pass.test.ts
@@ -23,7 +23,6 @@ const silentLog = {
 	info: vi.fn(),
 	warn: vi.fn(),
 	error: vi.fn(),
-	// biome-ignore lint/suspicious/noExplicitAny: minimal logger stub
 } as any;
 
 function rule(overrides: Partial<Parameters<typeof planRuleTransform>[0]> = {}) {

--- a/apps/api/src/routes/__tests__/library-torrent-state-filter.test.ts
+++ b/apps/api/src/routes/__tests__/library-torrent-state-filter.test.ts
@@ -67,7 +67,6 @@ afterAll(async () => {
 	await app?.close();
 });
 
-// biome-ignore lint/suspicious/noExplicitAny: typed access into vi.fn().mock.calls would obscure intent
 function findManyCallWhere(call: number = 0): any {
 	const calls = mockPrisma.libraryCache.findMany.mock.calls;
 	if (call >= calls.length)
@@ -175,7 +174,6 @@ describe("GET /library — torrentStateCounts response field", () => {
 	});
 });
 
-// biome-ignore lint/suspicious/noExplicitAny: typed access into vi.fn().mock.calls would obscure intent
 function groupByCallArg(call: number): any {
 	const calls = mockPrisma.libraryCache.groupBy.mock.calls;
 	if (call >= calls.length)

--- a/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/auto-tag/components/webhook-config-panel.tsx
@@ -239,7 +239,7 @@ const AutoInstallSection = ({ plaintextSecret }: { plaintextSecret: string | nul
 					</h4>
 					<p className="text-xs text-muted-foreground mt-0.5">
 						Push the webhook config above to your Sonarr/Radarr instances in one click — no manual
-						copy/paste in each *arr's Connect settings.
+						copy/paste in each *arr’s Connect settings.
 					</p>
 				</div>
 				<div className="flex gap-1 shrink-0">

--- a/apps/web/src/features/console/components/domain-tile-grid.tsx
+++ b/apps/web/src/features/console/components/domain-tile-grid.tsx
@@ -126,7 +126,7 @@ export function DomainTileGrid() {
 			</ul>
 			{servicesQuery.isError && (
 				<p className="mt-3 text-xs text-muted-foreground" data-testid="services-gating-degraded">
-					Couldn't load the service list — tiles for service-linked domains (qui, Requests, Media
+					Couldn’t load the service list — tiles for service-linked domains (qui, Requests, Media
 					Caches) are hidden until it recovers.
 				</p>
 			)}

--- a/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
+++ b/apps/web/src/features/cross-seed/components/cross-seed-item-card.tsx
@@ -187,6 +187,7 @@ export const CrossSeedItemCard = ({
 									>
 										<span className="flex items-center gap-1.5 font-medium text-foreground/90">
 											{trackerBrand?.iconUrl ? (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													src={trackerBrand.iconUrl}
 													alt=""

--- a/apps/web/src/features/label-sync/components/rule-dialog.tsx
+++ b/apps/web/src/features/label-sync/components/rule-dialog.tsx
@@ -305,7 +305,7 @@ export const RuleDialog = ({ rule, onClose }: RuleDialogProps) => {
 						/>
 						<p className="text-xs text-muted-foreground">
 							The tag/label to apply on the destination service. Created automatically on
-							Sonarr/Radarr if it doesn't already exist.
+							Sonarr/Radarr if it doesn’t already exist.
 						</p>
 					</div>
 

--- a/apps/web/src/features/library/components/__tests__/torrent-detail-drawer-capabilities.test.tsx
+++ b/apps/web/src/features/library/components/__tests__/torrent-detail-drawer-capabilities.test.tsx
@@ -36,6 +36,9 @@ vi.mock("../../../../hooks/api/useQui", async () => {
 	return {
 		...actual,
 		useQuiCapabilities: (args: unknown) => mockUseQuiCapabilities(args),
+		useQuiTorrentProperties: () => ({ data: undefined }),
+		useQuiCategories: () => ({ data: { categories: [] } }),
+		useQuiTags: () => ({ data: { tags: [] } }),
 	};
 });
 

--- a/apps/web/src/features/library/components/library-card.tsx
+++ b/apps/web/src/features/library/components/library-card.tsx
@@ -576,6 +576,7 @@ export const LibraryCard = memo(function LibraryCard({
 										const name = meta?.name ?? host;
 										if (meta?.iconUrl) {
 											return (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													key={host}
 													src={meta.iconUrl}

--- a/apps/web/src/features/library/components/library-content.tsx
+++ b/apps/web/src/features/library/components/library-content.tsx
@@ -247,7 +247,10 @@ export const LibraryContent: React.FC<LibraryContentProps> = ({
 		return { state: item.torrentState, ratio: item.torrentRatio };
 	};
 
-	const allItems = [...grouped.movies, ...grouped.series, ...grouped.artists, ...grouped.authors];
+	const allItems = useMemo(
+		() => [...grouped.movies, ...grouped.series, ...grouped.artists, ...grouped.authors],
+		[grouped.movies, grouped.series, grouped.artists, grouped.authors],
+	);
 
 	// Per-card tracker strip data. The hook batches one request for the
 	// entire visible page; the React Query key is stable on the sorted

--- a/apps/web/src/features/library/components/series-torrents-panel.tsx
+++ b/apps/web/src/features/library/components/series-torrents-panel.tsx
@@ -780,6 +780,7 @@ const ClusterCard: React.FC<{
 									<TooltipTrigger asChild>
 										<span className="inline-flex items-center gap-1 rounded bg-card/70 px-1.5 py-0.5 font-mono text-[10px] text-foreground/80">
 											{brand.iconUrl ? (
+												// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 												<img
 													src={brand.iconUrl}
 													alt={brand.name}
@@ -876,6 +877,7 @@ const CopyRow: React.FC<{
 					<TooltipTrigger asChild>
 						<span className="inline-flex items-center gap-1 rounded bg-card/60 px-1.5 py-0.5 font-mono text-[10px] text-foreground/90">
 							{brand.iconUrl ? (
+								// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 								<img
 									src={brand.iconUrl}
 									alt={brand.name}
@@ -988,6 +990,7 @@ const CopyRow: React.FC<{
 										}`}
 									>
 										{brand.iconUrl ? (
+											// eslint-disable-next-line @next/next/no-img-element -- Tracker icons may come from arbitrary user-configured hosts.
 											<img
 												src={brand.iconUrl}
 												alt={brand.name}

--- a/apps/web/src/features/library/components/torrent-detail-drawer.tsx
+++ b/apps/web/src/features/library/components/torrent-detail-drawer.tsx
@@ -146,8 +146,8 @@ const DrawerBody: React.FC<{
 
 			{unsupported.length > 0 && (
 				<div className="rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-200">
-					This qBittorrent version doesn't support {unsupported.join(" or ")} — those controls are
-					disabled below.
+					This qBittorrent version doesn&apos;t support {unsupported.join(" or ")} — those controls
+					are disabled below.
 				</div>
 			)}
 

--- a/apps/web/src/features/library/components/torrent-drawer/files-section.tsx
+++ b/apps/web/src/features/library/components/torrent-drawer/files-section.tsx
@@ -127,7 +127,7 @@ const FileMediaInfo: React.FC<{
 	if (query.isError || !query.data) {
 		return (
 			<div className="ml-2 text-[10px] italic text-muted-foreground">
-				MediaInfo unavailable — qui needs local filesystem access to the torrent's files.
+				MediaInfo unavailable — qui needs local filesystem access to the torrent’s files.
 			</div>
 		);
 	}

--- a/apps/web/src/features/queue-cleaner/components/queue-cleaner-config.tsx
+++ b/apps/web/src/features/queue-cleaner/components/queue-cleaner-config.tsx
@@ -608,11 +608,11 @@ const InstanceConfigCard = ({
 					onToggle={(v) => updateField("quiAwareMode", v)}
 				>
 					<div className="text-[11px] text-muted-foreground/70 p-2.5 rounded-lg bg-card/20 border border-border/15">
-						When a queue item's torrent is in <span className="font-medium">paused</span> or{" "}
+						When a queue item’s torrent is in <span className="font-medium">paused</span> or{" "}
 						<span className="font-medium">error</span> state in qui, this gate suppresses the strike
 						and surfaces the item as skipped with a qui-aware reason. Useful when qui automations
 						are already acting on the torrent (e.g., rule-based pause after seed goal). No-op if you
-						haven't added a qui instance.
+						haven’t added a qui instance.
 					</div>
 				</RuleSection>
 
@@ -620,13 +620,13 @@ const InstanceConfigCard = ({
 				<RuleSection
 					icon={ShieldCheck}
 					title="Last-seed protection"
-					description="Skip strikes when *arr's library still references the torrent (default on)"
+					description="Skip strikes when *arr’s library still references the torrent (default on)"
 					enabled={formData.lastSeedProtection ?? true}
 					onToggle={(v) => updateField("lastSeedProtection", v)}
 				>
 					<div className="text-[11px] text-muted-foreground/70 p-2.5 rounded-lg bg-card/20 border border-border/15">
-						Protects against accidentally striking a torrent that's still backing an active *arr
-						file. The gate matches a strike candidate's info-hash against{" "}
+						Protects against accidentally striking a torrent that’s still backing an active *arr
+						file. The gate matches a strike candidate’s info-hash against{" "}
 						<span className="font-medium">LibraryCache</span> (movies/artists) and{" "}
 						<span className="font-medium">EpisodeFileCache</span> (series) across all your *arr
 						instances; if any row still references the hash, the strike is skipped with a last-seed

--- a/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
@@ -197,7 +197,7 @@ export const QuiWebhookConfigPanel = () => {
 				<div className="flex justify-between items-center pt-1">
 					<p className="text-xs text-muted-foreground">
 						qui → Settings → Notifications → Targets → URL + Method POST. arr-dashboard
-						authenticates the inbound webhook via the <code>?secret=</code> param (qui's
+						authenticates the inbound webhook via the <code>?secret=</code> param (qui’s
 						<code> ApiKeyQuery </code>scheme).
 					</p>
 					<Button
@@ -295,7 +295,7 @@ const AutoRegisterSection = ({
 					Auto-register in qui
 				</h4>
 				<p className="text-xs text-muted-foreground mt-0.5">
-					Push the URL + secret to a qui instance in one click — no manual paste in qui's Settings
+					Push the URL + secret to a qui instance in one click — no manual paste in qui’s Settings
 					UI. Available immediately after rotation; the plaintext secret is held in memory only.
 				</p>
 			</div>
@@ -304,7 +304,7 @@ const AutoRegisterSection = ({
 				<div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
 					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
 					<span>
-						Click <strong>Rotate secret</strong> above to generate the value. arr-dashboard doesn't
+						Click <strong>Rotate secret</strong> above to generate the value. arr-dashboard doesn’t
 						store plaintext, so registration needs a fresh rotation.
 					</span>
 				</div>
@@ -312,7 +312,7 @@ const AutoRegisterSection = ({
 				<div className="flex items-center gap-2 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-300">
 					<AlertCircle className="h-3.5 w-3.5 shrink-0" />
 					<span>
-						A secret exists but isn't visible right now. Click <strong>Rotate secret</strong> to
+						A secret exists but isn’t visible right now. Click <strong>Rotate secret</strong> to
 						display a new one (the old URL stops working when you rotate).
 					</span>
 				</div>
@@ -408,7 +408,7 @@ const RecentEventsStrip = ({ recentEvents, isIncognito, isError }: RecentEventsS
 			<div className="border-t border-border/40 pt-3">
 				<h4 className="text-sm font-semibold mb-1">Recent events</h4>
 				<p className="text-xs text-amber-300/80">
-					Couldn't load recent events — the event-log endpoint returned an error. Webhook delivery
+					Couldn’t load recent events — the event-log endpoint returned an error. Webhook delivery
 					may still be working; this is a display-side problem. Refresh the page or check the server
 					logs.
 				</p>

--- a/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approval-queue-tab.test.tsx
@@ -50,6 +50,7 @@ vi.mock("next/image", () => ({
 	default: (props: Record<string, unknown>) => {
 		// next/image passes non-standard props; just render essential ones
 		const { src, alt, fill: _fill, priority: _priority, ...rest } = props;
+		// eslint-disable-next-line @next/next/no-img-element -- Native img is intentional in the next/image test double.
 		return <img src={src as string} alt={alt as string} {...rest} />;
 	},
 }));

--- a/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/seerr-auto-setup-section.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -237,7 +237,9 @@ describe("SeerrAutoSetupSection", () => {
 		});
 
 		// Clean up: resolve the pending promise
-		resolvePromise({ apiKey: "key", version: "1.0" });
+		await act(async () => {
+			resolvePromise({ apiKey: "key", version: "1.0" });
+		});
 	});
 
 	// ================================================================

--- a/apps/web/src/features/settings/components/validation-health-section.tsx
+++ b/apps/web/src/features/settings/components/validation-health-section.tsx
@@ -11,7 +11,7 @@ import {
 	Trash2,
 	XCircle,
 } from "lucide-react";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { DomainStatusBadge, PremiumSection } from "../../../components/layout";
 import { Tooltip } from "../../../components/layout/config-primitives";
 import type { DomainStatus } from "../../../components/layout/domain-status";
@@ -319,9 +319,8 @@ export function ValidationHealthSection({
 										const isExpanded = expandedIntegrations.has(name);
 
 										return (
-											<>
+											<Fragment key={name}>
 												<tr
-													key={name}
 													className={`border-b border-border/30 last:border-b-0 transition-colors animate-in fade-in slide-in-from-bottom-1 duration-200 ${isExpandable ? "cursor-pointer hover:bg-card/50" : "hover:bg-card/50"}`}
 													style={{
 														animationDelay: `${i * 30}ms`,
@@ -451,7 +450,7 @@ export function ValidationHealthSection({
 															<td className="p-2" />
 														</tr>
 													))}
-											</>
+											</Fragment>
 										);
 									})}
 								</tbody>

--- a/apps/web/src/features/setup/components/__tests__/trash-profile-setup.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/trash-profile-setup.test.tsx
@@ -137,7 +137,7 @@ describe("TrashProfileSetup", () => {
 		await waitFor(() =>
 			expect(mocks.refresh).toHaveBeenCalledWith({ serviceType: "SONARR", force: false }),
 		);
-		fireEvent.change(screen.getByLabelText("Official quality profile"), {
+		fireEvent.change(await screen.findByLabelText("Official quality profile"), {
 			target: { value: "profile-1" },
 		});
 		fireEvent.click(screen.getByRole("button", { name: "Review deployment preview" }));

--- a/apps/web/src/features/statistics/components/arr-service-tab.tsx
+++ b/apps/web/src/features/statistics/components/arr-service-tab.tsx
@@ -37,6 +37,7 @@ export type ArrServiceType = "sonarr" | "radarr" | "lidarr" | "readarr";
 // (e.g. t.totalSeries, r.downloadedEpisodes) is compile-time checked.
 // The `any` default is necessary because TypeScript's strict function parameter
 // contravariance prevents narrower parameter types from widening to a union.
+/* eslint-disable @typescript-eslint/no-explicit-any -- Strategy boundary intentionally erases concrete service types. */
 // biome-ignore lint/suspicious/noExplicitAny: Strategy pattern requires type erasure at the component boundary
 interface ServiceVariant<TTotals = any, TRow = any> {
 	/** Primary stat grid: 4 cards across the top */
@@ -61,6 +62,7 @@ interface ServiceVariant<TTotals = any, TRow = any> {
 	/** Primary count field for progress column */
 	progressField: "downloadedPercentage";
 }
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 const SONARR_VARIANT: ServiceVariant<SonarrTotals, SonarrRow> = {
 	primaryStats: (t) => [

--- a/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
+++ b/apps/web/src/features/statistics/components/disk-breakdown-panel.tsx
@@ -55,7 +55,7 @@ export const DiskBreakdownPanel = ({ disks }: DiskBreakdownPanelProps) => {
 				<h3 className="text-sm font-medium text-foreground">Storage Breakdown</h3>
 				<p className="mt-0.5 text-xs text-muted-foreground">
 					Disks included in the rollup hold at least one configured *arr root folder. Disks marked
-					excluded carry config, container OS, or system data that isn't media.
+					excluded carry config, container OS, or system data that isn’t media.
 				</p>
 			</div>
 			<ul className="divide-y divide-border/50">

--- a/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
+++ b/apps/web/src/features/trash-guides/components/user-cf-import-dialog.tsx
@@ -50,7 +50,6 @@ export function UserCFImportDialog({
 	onOpenChange,
 	defaultServiceType = "RADARR",
 }: UserCFImportDialogProps) {
-	const [incognitoMode] = useIncognitoMode();
 	const { gradient } = useThemeGradient();
 	const [activeTab, setActiveTab] = useState("create");
 

--- a/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useSeerr.test.tsx
@@ -1,5 +1,6 @@
 import type {
 	LibraryEnrichmentResponse,
+	LibraryItem,
 	SeerrPageResult,
 	SeerrRequest,
 	SeerrRequestCount,
@@ -508,12 +509,13 @@ describe("useLibraryEnrichment", () => {
 		};
 		vi.mocked(seerrApi.fetchLibraryEnrichment).mockResolvedValue(enrichmentResponse);
 
-		const items = [
+		const items: LibraryItem[] = [
 			{
 				id: "lib-1",
 				title: "Test Movie",
 				service: "radarr" as const,
 				instanceId: "i-1",
+				instanceName: "Radarr",
 				type: "movie" as const,
 				remoteIds: { tmdbId: 100, imdbId: "tt123" },
 				monitored: true,
@@ -526,6 +528,7 @@ describe("useLibraryEnrichment", () => {
 				title: "Test Series",
 				service: "sonarr" as const,
 				instanceId: "i-2",
+				instanceName: "Sonarr",
 				type: "series" as const,
 				remoteIds: { tmdbId: 200, tvdbId: 999 },
 				monitored: true,
@@ -536,7 +539,7 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(() => useLibraryEnrichment("seerr-inst", items as any), {
+		const { result } = renderHook(() => useLibraryEnrichment("seerr-inst", items), {
 			wrapper,
 		});
 
@@ -551,12 +554,13 @@ describe("useLibraryEnrichment", () => {
 	});
 
 	it("is disabled when seerr instanceId is null", () => {
-		const items = [
+		const items: LibraryItem[] = [
 			{
 				id: "lib-1",
 				title: "Movie",
 				service: "radarr" as const,
 				instanceId: "i-1",
+				instanceName: "Radarr",
 				type: "movie" as const,
 				remoteIds: { tmdbId: 100 },
 				monitored: true,
@@ -567,7 +571,7 @@ describe("useLibraryEnrichment", () => {
 		];
 
 		const { wrapper } = createWrapper();
-		const { result } = renderHook(() => useLibraryEnrichment(null, items as any), { wrapper });
+		const { result } = renderHook(() => useLibraryEnrichment(null, items), { wrapper });
 
 		expect(result.current.fetchStatus).toBe("idle");
 		expect(seerrApi.fetchLibraryEnrichment).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- eliminate the 10 API and 27 web lint warnings present on `next`
- stabilize the aggregated library-item dependency and correct a test helper that discarded overrides
- document intentional native tracker images and strategy-boundary type erasure
- remove stale suppressions and strengthen Seerr test fixtures
- eliminate React act/key and React Query undefined-data warnings from the web test suite

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 3,011 tests passed
- `pnpm run lint` — zero warnings
- targeted warning regression run — 25 tests passed with no React/React Query stderr

## Review notes

This is the focused `next` counterpart to the reviewed 2.x quality baseline. The native `<img>` exceptions remain limited to arbitrary user-configured tracker-icon hosts and the `next/image` test double.