### PR TITLE
chore: add Codex-native maintainer workflows

### DIFF
--- a/.agents/skills/arr-fix-issue/SKILL.md
+++ b/.agents/skills/arr-fix-issue/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: arr-fix-issue
+description: Diagnose and fix an arr-dashboard GitHub issue with exact reproduction, release-line selection, regression coverage, and safe issue-linking. Use when Codex is asked to investigate, fix, or implement a reported issue.
+---
+
+# Fix an arr-dashboard issue
+
+1. Read `AGENTS.md`, `CLAUDE.md`, the issue, and all relevant comments.
+2. Record the reported version, deployment, database, integrations, expected
+   behavior, actual behavior, and evidence.
+3. Resolve the release line:
+   - stable 2.x user impact targets `main`;
+   - 3.0 beta work targets `next`;
+   - reproduce both when both may be affected, fixing stable first and
+     forward-porting separately.
+4. Fetch the intended base and create a focused branch. Preserve unrelated
+   worktree changes.
+5. Reproduce the reporter's actual scenario. Trace the real data and mutation
+   path instead of fixing a plausible symptom.
+6. Add a regression test that fails before the fix, then implement the smallest
+   coherent correction.
+7. For destructive or upstream mutation paths, delegate an independent review
+   to the `data_safety_reviewer` project agent before declaring readiness.
+8. Use `$arr-validate` for the final checks and live-verify user-visible fixes.
+9. Report the root cause, behavior changed, files, risks, validation, and any
+   forward-port or patch-release requirement.
+
+Do not commit, push, open a PR, comment, or close an issue unless requested.
+Default to `Related to #N`; use standalone `Closes #N` only after exact
+reproduction and verification. Sanitize commit messages independently.

--- a/.agents/skills/arr-fix-issue/agents/openai.yaml
+++ b/.agents/skills/arr-fix-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix arr-dashboard issue"
+  short_description: "Reproduce and fix a GitHub issue safely"
+  default_prompt: "Use $arr-fix-issue to diagnose and fix this arr-dashboard issue."

--- a/.agents/skills/arr-integration-change/SKILL.md
+++ b/.agents/skills/arr-integration-change/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: arr-integration-change
+description: Add, modify, or audit arr-dashboard integrations with Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Jellyfin, Emby, Seerr, Tautulli, Tracearr, or qui. Use for service clients, schemas, normalization, routes, webhooks, and integration UI.
+---
+
+# Change an arr-dashboard integration
+
+1. Resolve the target branch before copying patterns. Tautulli is supported on
+   stable 2.x; Tracearr replaces it on 3.0. Do not blindly port either contract.
+2. Read the closest integration end to end: shared schema, Prisma service type,
+   encrypted credentials, backend client/factory, normalizer, route, API
+   client, query hook, UI, and tests.
+3. Preserve these contracts:
+   - encrypt credentials and store value plus IV;
+   - scope user-owned resources with `request.currentUser!.id`;
+   - parse bodies with `validateRequest()`;
+   - normalize unstable upstream payloads at the boundary;
+   - use route-manifest registration and `docs/API-ROUTES.md`;
+   - structure identifiable response fields so incognito mode can mask them;
+   - use centralized query keys and polling constants.
+4. Treat absent optional services, timeouts, malformed payloads, pagination,
+   rate limits, retries, partial upstream success, and multiple instances
+   sharing a media library as normal cases.
+5. For service mutations or webhook installation, delegate a review to
+   `data_safety_reviewer`.
+6. Add focused contract and failure-path tests. Rebuild `@arr/shared` when its
+   exports change, then use `$arr-validate`.
+
+Do not refactor unrelated integrations.

--- a/.agents/skills/arr-integration-change/agents/openai.yaml
+++ b/.agents/skills/arr-integration-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Change an integration"
+  short_description: "Safely modify external service integrations"
+  default_prompt: "Use $arr-integration-change to implement this external service integration change."

--- a/.agents/skills/arr-prepare-pr/SKILL.md
+++ b/.agents/skills/arr-prepare-pr/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: arr-prepare-pr
+description: Assess arr-dashboard pull-request readiness and draft an accurate title and body from the real branch diff. Use when Codex is asked to prepare, open, refresh, or review a PR.
+---
+
+# Prepare an arr-dashboard pull request
+
+1. Resolve the actual base from an existing PR or branch intent. Stable 2.x
+   maintenance targets `main`; 3.0 work targets `next`.
+2. Inspect commits, the triple-dot diff, working-tree changes, linked issues,
+   and CI state. Surface unrelated or uncommitted work.
+3. Use `$arr-review-change`, then `$arr-validate`. A validation failure remains
+   visible even if it predates the branch.
+4. Draft:
+   - a conventional title under 70 characters describing the outcome;
+   - a concise summary and domain-specific change sections;
+   - an honest test plan using checks actually performed;
+   - files changed when it helps reviewers;
+   - risks, compatibility, and forward-port notes when applicable.
+5. Default issue references to `Related to #N`. Upgrade to a standalone
+   `Closes #N` line only after reproducing the exact reporter scenario before
+   the fix and verifying it afterward. Check commit messages for auto-close
+   language separately.
+6. Never `@`-mention people. Refer to `Kha-kis` in backticks or prose.
+
+Preparing text does not authorize committing, pushing, opening, updating, or
+merging a PR. Perform those actions only when the user explicitly requests
+them.

--- a/.agents/skills/arr-prepare-pr/agents/openai.yaml
+++ b/.agents/skills/arr-prepare-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare arr-dashboard PR"
+  short_description: "Prepare a focused and evidence-backed PR"
+  default_prompt: "Use $arr-prepare-pr to assess readiness and draft this pull request."

--- a/.agents/skills/arr-release/SKILL.md
+++ b/.agents/skills/arr-release/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: arr-release
+description: Prepare and verify arr-dashboard stable releases and 3.0 prereleases, including readiness, changelog, version surfaces, tagging, registries, GitHub Releases, and issue follow-up. Use for release planning or execution.
+---
+
+# Release arr-dashboard
+
+1. Read `docs/RELEASING.md`; it is authoritative. Resolve whether this is:
+   - a stable 2.x release from `main`; or
+   - a 3.0 alpha/beta/RC from an exact reviewed `next` SHA.
+2. Audit scope and blockers with `$arr-review-change` and `$arr-validate`.
+   Include `pnpm run build`.
+3. Prepare user-facing release notes from the actual commit range. Update every
+   version surface required by `docs/RELEASING.md`, including the wiki when
+   specified.
+4. Before publishing, confirm ancestry, clean state, reviewed SHA, CI, target
+   registries, tag type, and stable-versus-prerelease GitHub metadata.
+5. Use annotated tags. After publication, verify Docker Hub and GHCR artifacts,
+   container `/health` version/commit metadata, and the human-facing GitHub
+   Release. A successful image workflow does not create that release.
+6. Close only reproduced and resolved issues, with an explanatory release
+   comment. Keep unrelated or partially addressed issues open.
+
+Release planning and preparation do not authorize tagging, pushing, publishing,
+marking Latest, or closing issues. Perform each external action only when the
+user explicitly includes it in scope.

--- a/.agents/skills/arr-release/agents/openai.yaml
+++ b/.agents/skills/arr-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release arr-dashboard"
+  short_description: "Prepare stable and prerelease releases safely"
+  default_prompt: "Use $arr-release to prepare and verify this arr-dashboard release."

--- a/.agents/skills/arr-review-change/SKILL.md
+++ b/.agents/skills/arr-review-change/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: arr-review-change
+description: Review arr-dashboard branches and diffs for correctness, regressions, privacy, authorization, production data-shape failures, and mutation safety. Use for code review, merge-readiness, stabilization, trust checks, or regression audits.
+---
+
+# Review an arr-dashboard change
+
+1. Read `AGENTS.md` and `CLAUDE.md`.
+2. Resolve the actual PR base (`main` or `next`). Inspect the triple-dot branch
+   diff, commits, and uncommitted changes; never assume `main`.
+3. For substantial code changes, delegate a separate read-only pass to the
+   `regression_reviewer` project agent. For destructive or upstream mutations,
+   also delegate to `data_safety_reviewer`. Do not delegate trivial docs-only
+   reviews.
+4. Trace changed behavior through callers, shared contracts, API routes,
+   persistence, caches, and UI consumers. Test assumptions against populated,
+   paginated, multi-instance, null/fractional, and partial-failure data where
+   applicable.
+5. Check:
+   - authorization and `userId` scoping;
+   - validation, encryption, incognito masking, error redaction, and logging;
+   - centralized query keys, invalidation, polling, and durable status labels;
+   - route-manifest/API documentation contracts;
+   - dry-run parity, fail-closed behavior, idempotency, and honest partial
+     failure state for mutations;
+   - regression tests at the real failure boundary.
+6. Use `$arr-validate` when the user asks for readiness or when changes were
+   implemented in the same task.
+
+For review-only requests, do not implement fixes. Report concrete findings
+first, ordered by severity, with file/line references and failure scenarios.
+If none qualify, state that and list residual risks or validation gaps.

--- a/.agents/skills/arr-review-change/agents/openai.yaml
+++ b/.agents/skills/arr-review-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review arr-dashboard change"
+  short_description: "Review changes for regressions and safety"
+  default_prompt: "Use $arr-review-change to assess this branch for correctness and merge risk."

--- a/.agents/skills/arr-validate/SKILL.md
+++ b/.agents/skills/arr-validate/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: arr-validate
+description: Run and report the arr-dashboard verification gauntlet. Use when Codex is asked to validate, test, check, stabilize, or assess readiness of a change, and before preparing a pull request.
+---
+
+# Validate arr-dashboard
+
+1. Read `AGENTS.md` and resolve the change scope with `git status` and the diff
+   against the actual base branch.
+2. Run:
+
+   ```bash
+   pnpm run format
+   pnpm --filter @arr/shared build   # only when packages/shared changed
+   pnpm run typecheck
+   pnpm run test
+   pnpm run lint
+   ```
+
+3. Run `pnpm run build` for release-sensitive, dependency, Docker, routing, or
+   substantial frontend changes.
+4. Live-verify user-visible behavior in a real browser. Use populated fixtures
+   for data-dependent behavior.
+5. When a gate fails, determine whether the failure exists on the untouched
+   base. Do not bypass it or attribute it to the branch without evidence.
+6. Report `Check | Status | Details`, including skipped checks and why they were
+   not applicable.
+
+Validation-only requests authorize diagnosis, not unrelated fixes.

--- a/.agents/skills/arr-validate/agents/openai.yaml
+++ b/.agents/skills/arr-validate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate arr-dashboard"
+  short_description: "Run the repository verification gauntlet"
+  default_prompt: "Use $arr-validate to run and report the appropriate verification checks."

--- a/.claude/agents/data-safety-reviewer.md
+++ b/.claude/agents/data-safety-reviewer.md
@@ -1,0 +1,54 @@
+---
+name: data-safety-reviewer
+description: Review deletion, cleanup, restore, schema, and upstream mutation changes for target drift, unsafe fallback behavior, partial-failure dishonesty, and production data-loss risks
+model: inherit
+color: red
+---
+
+You are the independent data-safety reviewer for arr-dashboard. Review the
+specified diff or, by default, the current branch against its actual PR base.
+Read `AGENTS.md` and `CLAUDE.md` before reviewing. Do not implement fixes during
+the review.
+
+## Review method
+
+1. Resolve the real base branch from the open PR. If there is no PR, determine
+   whether the work targets stable `main` or 3.0 `next`; stop if ambiguous.
+2. Trace the complete mutation path from user/scheduler input through target
+   selection, preview/dry-run, authorization, upstream calls, database/cache
+   updates, audit logs, notifications, and retries.
+3. Construct adversarial production scenarios, including multiple service
+   instances sharing one media library, same-title collisions, stale caches,
+   missing optional integrations, upstream timeout after partial success,
+   concurrent execution, and retry after restart.
+4. Inspect tests and state whether they exercise the real failure boundary or
+   only mocked happy-path orchestration.
+
+## Required invariants
+
+- Dry-run and preview perform no mutation and select the same targets/actions as
+  execution.
+- Ownership and target identity are re-established at execution time.
+- Unknown correlation, ownership, upstream state, or safety dependency fails
+  closed.
+- A failed safety check cannot fall back to a more destructive action.
+- Upstream success precedes local success state. Partial failure is visible,
+  retryable, and does not double-apply completed work.
+- Confirmation, audit logs, notifications, and summaries describe the action
+  actually executed.
+- Logs and errors contain actionable identifiers without credentials, API
+  keys, webhook secrets, or internal URLs.
+- Existing stable API/configuration behavior is preserved unless a documented
+  breaking change is explicitly in scope.
+
+## Output
+
+Report only concrete findings. Use:
+
+`Severity | Confidence | Location | Invariant | Failure scenario | Required fix`
+
+Severity is `critical`, `high`, or `medium`; confidence is 0–100. Report
+critical/high findings at confidence 80 or above, plus medium findings only
+when they represent realistic data loss or an incorrect operator audit trail.
+If no findings qualify, say so and list the mutation paths and adversarial
+scenarios reviewed.

--- a/.claude/commands/db-change.md
+++ b/.claude/commands/db-change.md
@@ -38,9 +38,9 @@ Only pause for confirmation if the change is destructive (dropping columns/model
 3. Derive TypeScript types via `z.infer<typeof schema>`
 4. Define response types that omit sensitive fields (encrypted keys → `hasApiKey: boolean`)
 5. Export from the barrel `packages/shared/src/types/index.ts` if new file
-6. Type-check both consumers — shared type changes affect both packages:
-   - `pnpm --filter @arr/api exec tsc --noEmit`
-   - `pnpm --filter @arr/web exec tsc --noEmit`
+6. Rebuild shared and run the CI-equivalent typecheck:
+   - `pnpm --filter @arr/shared build`
+   - `pnpm run typecheck`
 
 ---
 
@@ -56,8 +56,9 @@ Only pause for confirmation if the change is destructive (dropping columns/model
 3. For modified fields:
    - Update any Prisma `select` or `include` clauses
    - Update response formatting functions
-4. Register new route files in `apps/api/src/server.ts` if needed
-5. Run `pnpm --filter @arr/api exec tsc --noEmit` to verify
+4. Register new route groups in `apps/api/src/routes/route-manifest.ts` and add
+   the contract row to `docs/API-ROUTES.md`
+5. Run `pnpm run typecheck` to verify the complete workspace
 
 ---
 
@@ -77,7 +78,7 @@ Only pause for confirmation if the change is destructive (dropping columns/model
    - Only update components that render the changed fields
    - If new fields display sensitive data: apply `useIncognitoMode()` + anonymizer
 
-4. Run `pnpm --filter @arr/web exec tsc --noEmit` to verify frontend compiles
+4. Run `pnpm run typecheck` to verify frontend and shared consumers together
 
 ---
 
@@ -93,7 +94,7 @@ Only pause for confirmation if the change is destructive (dropping columns/model
    - Validation failure (invalid input → 400)
    - Ownership enforcement (wrong userId → 404)
    - New fields are included in responses
-3. Run `pnpm run test` to verify all tests pass
+3. Run focused tests, then `/validate`
 
 ---
 
@@ -110,9 +111,14 @@ Summarize:
 
 ## Rules
 
-- Never skip the `db:push` step — the Prisma client must be regenerated before any TypeScript imports will resolve
+- Never run a destructive `db:push` against production data. Inspect the
+  proposed transition first; destructive or transform-requiring changes need a
+  release-specific backup/migration plan.
+- Regenerate the Prisma client after schema changes before TypeScript checks
 - Never create migration files — this project uses `db push` for SQLite/PostgreSQL dual support
-- Always type-check BOTH `@arr/api` and `@arr/web` — shared type changes affect both
+- Use the root Turbo typecheck; per-package `tsc` can hide shared-output drift
 - If removing a field, search for all usages first (grep across the repo)
 - If adding an encrypted field, always add both `encryptedX` and `encryptionIv` columns
 - Do not modify unrelated models or routes as part of this change
+- Run the `data-safety-reviewer` agent for destructive schema changes, restore
+  behavior, or data transformations

--- a/.claude/commands/e2e-test.md
+++ b/.claude/commands/e2e-test.md
@@ -131,4 +131,7 @@ After running tests, report:
 - Do not modify `e2e/auth.setup.ts` unless the auth flow itself changed
 - Do not add `test.only` — the CI config (`forbidOnly: true`) will reject it
 - Workers are forced to 1 to prevent session race conditions — do not change this
-- When writing tests for new features, check if the feature has service-availability gating (Plex, Seerr, Tautulli) — tests may need to handle the "service not configured" state
+- When writing tests for new features, check branch-specific
+  service-availability gating (for example Plex/Seerr/Tautulli on 2.x or
+  Plex/Seerr/Tracearr/qui on 3.0) — tests must handle the "service not
+  configured" state

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,12 +1,30 @@
 Fix GitHub issue $ARGUMENTS
 
-1. Read the issue with `gh issue view $ARGUMENTS`
-2. Understand the root cause — trace the code, don't guess
-3. Create a fix on the current branch (never edit main directly)
-4. Write or update tests that validate the fix
-5. Run `pnpm --filter @arr/web exec tsc --noEmit` and `pnpm --filter @arr/api exec tsc --noEmit`
-6. Run `pnpm run test`
-7. Commit with message: `fix: Description (#ISSUE_NUMBER)`
-8. Comment on the issue with what was fixed and how
+1. Read the issue and its comments with `gh issue view $ARGUMENTS`.
+2. Record the reported version, deployment, database, connected services,
+   exact expected behavior, actual behavior, and supplied evidence.
+3. Determine the release line before editing:
+   - stable 2.x maintenance targets `main`;
+   - 3.0 beta work targets `next`;
+   - if both are affected, reproduce both and plan a stable fix plus a separate
+     forward-port.
+4. Fetch the intended base. Confirm the working tree and current branch contain
+   no unrelated work. Create a focused task branch from the intended base when
+   necessary; never edit `main` or `next` directly.
+5. Reproduce the reporter's actual scenario. If it cannot be reproduced,
+   continue diagnosis and describe the missing evidence; do not claim a fix.
+6. Trace the root cause through the real data and mutation path. Do not patch a
+   plausible symptom without proving why it occurs.
+7. Write a regression test that fails for the reported scenario, then implement
+   the smallest coherent fix.
+8. If the issue touches deletion, file removal, unmonitoring, restore, cleanup,
+   schema changes, or an upstream write, run the `data-safety-reviewer` agent.
+9. Run focused tests while iterating, then `/validate`. Live-verify
+   user-visible behavior in a browser when applicable.
+10. Report the diff, risks, validation, and whether a forward-port or patch
+    release is required.
 
-If the issue is unclear, ask for clarification before implementing.
+Do not commit, push, open a PR, close the issue, or post an issue comment unless
+the user asks for that action. A future PR may use standalone `Closes #N` only
+after the exact reported scenario was reproduced and verified; otherwise use
+`Related to #N`.

--- a/.claude/commands/incognito-audit.md
+++ b/.claude/commands/incognito-audit.md
@@ -1,6 +1,8 @@
 Audit incognito/privacy coverage for: $ARGUMENTS
 
-If no target specified, audit files changed on the current branch (`git diff --name-only origin/main..HEAD`).
+If no target is specified, resolve the branch's actual PR base (`main` or
+`next`) and audit `git diff --name-only origin/<base>...HEAD`. Stop if the base
+is ambiguous rather than defaulting to `main`.
 
 ---
 

--- a/.claude/commands/integration-change.md
+++ b/.claude/commands/integration-change.md
@@ -7,10 +7,18 @@ Add or modify an external service integration: $ARGUMENTS
 Before writing any code, read an existing integration that is structurally closest to the target service:
 
 - **Arr services** (Sonarr, Radarr, Lidarr, Readarr): read `apps/api/src/routes/services.ts` and one normalizer in `apps/api/src/lib/library/`
-- **Media server** (Plex): read `apps/web/src/lib/api-client/plex.ts`, `apps/web/src/hooks/api/usePlex.ts`
-- **Enrichment service** (Seerr, Tautulli): read `apps/web/src/lib/api-client/seerr.ts` or `tautulli.ts`
+- **Media server** (Plex/Jellyfin/Emby): read the matching API client, domain
+  hook, backend client, and normalizer
+- **Enrichment/analytics service**: read Seerr on either line; Tautulli is a
+  2.x-only product integration, while Tracearr is the 3.0 replacement
+- **Torrent layer**: read the existing qui client factory, routes, capability
+  gates, and webhook handling
 
 Note the patterns used: how the service is registered, how its API key is stored, how raw data is normalized, and how the frontend consumes it.
+
+Resolve the target release line before changing anything. Do not port a
+Tautulli or Tracearr pattern across `main`/`next` without checking the
+branch-specific product contract.
 
 ---
 
@@ -22,9 +30,9 @@ Note the patterns used: how the service is registered, how its API key is stored
    - `INTEGRATION_SERVICES` for enrichment/media services
    - Update `ARR_SERVICES_UPPER` if the new service is an *arr type
 3. **Prisma push**: Run `pnpm --filter @arr/api run db:push` to sync schema and regenerate client
-4. **Type-check both packages** after shared type changes:
-   - `pnpm --filter @arr/api exec tsc --noEmit`
-   - `pnpm --filter @arr/web exec tsc --noEmit`
+4. **Rebuild shared and run the root typecheck** after shared type changes:
+   - `pnpm --filter @arr/shared build`
+   - `pnpm run typecheck`
 
 If the service uses an API key, confirm that the existing `ServiceInstance` model's `encryptedApiKey`/`encryptionIv` fields are sufficient. If additional credentials are needed, add paired `encryptedX String` + `encryptionIv String` columns.
 
@@ -62,9 +70,10 @@ If the service returns content items that need to appear in the unified library:
    - `app.encryptor.encrypt()` for any new secrets before storage
    - `request.log.info()` for mutation logging
    - Proper status codes: 201 create, 200 update, 204 delete
-3. Register new route files in `apps/api/src/server.ts`
+3. Register new route groups in `apps/api/src/routes/route-manifest.ts` and add
+   the contract row to `docs/API-ROUTES.md`
 4. **Response shaping for privacy**: Keep identifiable data (instance names, URLs, usernames) in separate response fields, not embedded in free-text strings. The frontend needs to be able to anonymize each part independently for incognito mode.
-5. Run `pnpm --filter @arr/api exec tsc --noEmit`
+5. Run `pnpm run typecheck`
 
 ---
 
@@ -94,7 +103,7 @@ If the service returns content items that need to appear in the unified library:
    - Use `POLLING_*` constants from `lib/polling-intervals.ts` for `refetchInterval`
    - Invalidate correct query keys in mutation `onSuccess`
 
-4. Run `pnpm --filter @arr/web exec tsc --noEmit`
+4. Run `pnpm run typecheck`
 
 ---
 
@@ -120,8 +129,9 @@ If the service returns content items that need to appear in the unified library:
 ## Step 10: Validate and report
 
 1. Run the full check:
-   - `pnpm --filter @arr/api exec tsc --noEmit`
-   - `pnpm --filter @arr/web exec tsc --noEmit`
+   - `pnpm run format`
+   - `pnpm --filter @arr/shared build` if shared changed
+   - `pnpm run typecheck`
    - `pnpm run test`
    - `pnpm run lint`
 
@@ -141,5 +151,6 @@ If the service returns content items that need to appear in the unified library:
 - Every request body must go through `validateRequest()` — no `as Type` casts
 - Every API key must be encrypted before storage — store both `value` and `iv`
 - Every user-facing response with identifiable data must be structured for anonymization — no embedded names in free-text fields
-- Shared type changes require type-checking both `@arr/api` and `@arr/web`
+- Shared type changes require rebuilding shared and running the root Turbo
+  typecheck
 - Do not modify unrelated integrations or routes as part of this change

--- a/.claude/commands/pr-prep.md
+++ b/.claude/commands/pr-prep.md
@@ -6,11 +6,17 @@ If `$ARGUMENTS` is a PR number, refresh that PR's description to match current b
 
 ## Step 1: Gather context
 
+Resolve the base first:
+- If the branch already has a PR, use its `baseRefName`.
+- Otherwise determine whether the task is stable 2.x maintenance (`main`) or
+  3.0 work (`next`) from the branch point and task intent.
+- Stop if ambiguous. Never default to `main`.
+
 Run these in parallel:
 - `git branch --show-current` — confirm branch name
-- `git log --oneline origin/main..HEAD` — all commits since divergence
-- `git diff --stat origin/main..HEAD` — file change summary
-- `git diff origin/main..HEAD` — full diff for analysis
+- `git log --oneline origin/<base>..HEAD` — all commits since divergence
+- `git diff --stat origin/<base>...HEAD` — file change summary
+- `git diff origin/<base>...HEAD` — full diff for analysis
 - `gh pr list --head $(git branch --show-current) --json number,title,body,url --limit 1` — check if PR already exists
 
 Note whether this is a **new PR** or a **refresh** of an existing one.
@@ -57,7 +63,7 @@ See pr-writer skill for section naming guidance.]
 ## Test plan
 - [ ] Verification steps as checkboxes
 
-Closes #NNN (if applicable)
+Related to #NNN
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
@@ -73,7 +79,7 @@ Closes #NNN (if applicable)
 ## Test plan
 - [ ] Steps to verify the fix
 
-Closes #NNN
+Related to #NNN
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
@@ -121,7 +127,13 @@ Closes #NNN
 
 - Scan commit messages for `#NNN` references
 - Check branch name for issue numbers (e.g., `feat/222-request-as`)
-- If found, include `Closes #NNN` at the bottom of the body
+- Read any linked issue and its comments.
+- Include standalone `Closes #NNN` only when the exact reporter scenario was
+  reproduced before the fix and verified afterward.
+- If the change addresses a plausible cause, partial scenario, or
+  independently discovered problem, use `Related to #NNN`.
+- Check commit messages separately for auto-close language and remove it when
+  the reproduction requirement was not met.
 
 ## Step 6: Handle scope drift (refresh mode)
 
@@ -140,6 +152,9 @@ Surface these as guidance before offering to create/update. Not hard blockers �
 - **Branch pushed?** `git log origin/$(git branch --show-current)..HEAD 2>/dev/null` — note if local commits need pushing
 - **CI status?** `gh pr checks` or `gh run list --branch $(git branch --show-current) --limit 1` — report if known
 - **Trust check needed?** If changed files include new pages (`app/*/page.tsx`), new API routes (`routes/*.ts`), or new feature panels (`features/*/components/*`), suggest running `/trust-check` first
+- **Data-safety review needed?** If the diff mutates or deletes upstream,
+  filesystem, schema, backup, queue, or library state, require the
+  `data-safety-reviewer` agent before PR creation
 
 Format as a short checklist:
 ```

--- a/.claude/commands/prepare-changelog.md
+++ b/.claude/commands/prepare-changelog.md
@@ -1,26 +1,29 @@
 Generate polished changelog/release notes for the current branch's changes.
 
-1. **Gather changes**: `git log --oneline origin/main..HEAD`
+1. **Resolve the release base**: stable 2.x uses `origin/main`; 3.0 prereleases
+   use `origin/next`. Stop if the intended release line is ambiguous.
 
-2. **Categorize** each change into exactly one group:
+2. **Gather changes**: `git log --oneline origin/<base>..HEAD`
+
+3. **Categorize** each change into exactly one group:
    - **Fixed** — bug fixes with issue numbers
    - **Changed** — behavior changes, architecture improvements, refactors
    - **Added** — new features, new test infrastructure, new documentation
    - **Dependencies** — package updates, overrides, CI changes
 
-3. **Write in the repo's changelog style** (see existing entries in `CHANGELOG.md`):
+4. **Write in the repo's changelog style** (see existing entries in `CHANGELOG.md`):
    - Lead each item with a bold short title
    - Follow with a one-sentence description of what changed and why
    - Include issue numbers where applicable (#NNN)
    - Group dependency updates into a compact list
 
-4. **Rules**:
+5. **Rules**:
    - No hype words ("amazing", "powerful", "comprehensive")
    - No vague descriptions ("various improvements", "minor fixes")
    - No duplicated information across categories
    - Each item should be understandable without reading the code
    - User-facing fixes come first, architecture changes second
 
-5. **Output**: The formatted changelog section ready to paste into `CHANGELOG.md`, starting with `## [VERSION] - DATE`
+6. **Output**: The formatted changelog section ready to paste into `CHANGELOG.md`, starting with `## [VERSION] - DATE`
 
 Do NOT update CHANGELOG.md directly — output the text for review first.

--- a/.claude/commands/release-patch.md
+++ b/.claude/commands/release-patch.md
@@ -1,5 +1,10 @@
 Prepare a patch release from the current branch.
 
+This command is for stable 2.x patches targeting `main`. Confirm the current
+branch is based on the latest `origin/main`; for a 3.0 prerelease, use
+the readiness tracker present on `next` and the prerelease workflow in
+`docs/RELEASING.md`.
+
 1. **Review scope**: Run `git log --oneline origin/main..HEAD` to see all changes. Categorize each commit as:
    - User-facing fix (bug fix, behavior change)
    - Maintenance (dependency update, CI change)

--- a/.claude/commands/release-prep.md
+++ b/.claude/commands/release-prep.md
@@ -1,6 +1,8 @@
 Prepare release v$ARGUMENTS
 
-This is the mechanical execution step. Run `/release-patch` first for readiness assessment.
+This is the mechanical execution step for a stable release from `main`. Run
+`/release-patch` first for readiness assessment. For a 3.0 prerelease from
+`next`, use the prerelease section of `docs/RELEASING.md` instead.
 
 Follow the release checklist exactly:
 
@@ -12,9 +14,11 @@ Follow the release checklist exactly:
 6. **Wiki**: Update version in `Home.md` and `Troubleshooting.md` (clone from `arr-dashboard.wiki.git` if not at `/tmp/arr-wiki`)
 
 Then validate (or run `/validate`):
-- `pnpm --filter @arr/web exec tsc --noEmit`
-- `pnpm --filter @arr/api exec tsc --noEmit`
+- `pnpm run format`
+- `pnpm --filter @arr/shared build` if shared changed
+- `pnpm run typecheck`
 - `pnpm run test`
+- `pnpm run lint`
 - `pnpm run build`
 
 Commit as: `chore: v$ARGUMENTS release — changelog and version bump`

--- a/.claude/commands/security-pass.md
+++ b/.claude/commands/security-pass.md
@@ -1,9 +1,12 @@
 Perform a focused security audit on: $ARGUMENTS
 
-If no target specified, audit the most recently changed files (`git diff --name-only origin/main..HEAD`).
+If no target is specified, resolve the branch's actual PR base (`main` or
+`next`) and audit `git diff --name-only origin/<base>...HEAD`. Stop if the base
+is ambiguous rather than defaulting to `main`.
 
 1. **Auth & authorization**:
-   - Are all routes properly protected with preHandler auth check?
+   - Are protected route groups registered through the route manifest and the
+     single protected scope?
    - Is `userId: request.currentUser!.id` included in all Prisma queries for user-owned resources?
    - Are there any routes that should be protected but aren't?
 

--- a/.claude/commands/stabilize-branch.md
+++ b/.claude/commands/stabilize-branch.md
@@ -1,36 +1,50 @@
 Assess the current branch for merge/release readiness.
 
-1. **Branch overview**:
-   - `git log --oneline origin/main..HEAD` — list all commits
-   - `git diff --stat origin/main..HEAD` — file change summary
-   - `git branch --show-current` — confirm branch name
+1. **Resolve the base branch**:
+   - Check the current branch and any open PR.
+   - If a PR exists, use its `baseRefName`.
+   - Without a PR, determine whether the task is stable 2.x maintenance
+     (`main`) or 3.0 work (`next`) from the branch point and task intent.
+   - If both bases are plausible, stop and ask. Never silently default to
+     `main`.
 
-2. **Regression risk**:
+2. **Branch overview**:
+   - Fetch the resolved base.
+   - Run `git log --oneline origin/<base>..HEAD`.
+   - Run `git diff --stat origin/<base>...HEAD` and inspect the full diff.
+   - Surface pre-existing commits and unrelated working-tree changes.
+
+3. **Regression risk**:
    - Identify files with the most changes — these are highest regression risk
    - Check if changed files have corresponding tests
    - Look for changes to shared utilities, hooks, or types that affect multiple consumers
+   - Load the `regression-hunter` skill and apply its current checklist
+   - For safety-critical mutations, run the `data-safety-reviewer` agent
 
-3. **Validation**:
-   - Run typecheck, lint, test, build (same as `/validate`)
+4. **Validation**:
+   - Run `/validate`
    - Report any failures with root cause
 
-4. **Merge risk**:
-   - `git fetch origin main && git diff origin/main...HEAD --stat` — check for conflicts
+5. **Merge risk**:
+   - Compare with the current `origin/<base>` and report divergence/conflicts
    - Are there changes to `package.json`, `pnpm-lock.yaml`, or `schema.prisma` that could conflict?
    - Are there Dependabot PRs that should be merged first or after?
 
-5. **Cleanup check**:
+6. **Cleanup check**:
    - Are there debug `console.log` statements?
    - Are there commented-out code blocks?
    - Are there TODO comments introduced in this branch?
    - Are there uncommitted changes that should be staged?
+   - Are generated artifacts, credentials, snapshots, or local runtime data in
+     the diff?
 
-6. **Trust check** (if applicable):
+7. **Trust check** (if applicable):
    - Check if changed files include new pages (`app/*/page.tsx`), new API routes, or new feature panels
    - If yes: run `/trust-check` on the affected files (privacy, ownership, signal accuracy, service gating, action links, overlap)
    - If no: skip — not needed for bug fixes, dependency updates, or refactors
 
-7. **Recommendation**:
+8. **Recommendation**:
    - Safe to merge? Yes/No with reasoning
    - If no: list specific blockers
-   - If yes: recommended merge strategy (squash vs merge) and any post-merge actions needed
+   - If yes: recommend squash merge and list any forward-port, release, issue,
+     or live-monitoring action

--- a/.claude/commands/trust-check.md
+++ b/.claude/commands/trust-check.md
@@ -1,6 +1,9 @@
 Perform a trust and UX correctness audit on: $ARGUMENTS
 
-If no target specified, audit files changed on the current branch (`git diff --name-only origin/main..HEAD`).
+If no target is specified, resolve the current branch's actual PR base (`main`
+or `next`) and audit files changed in
+`git diff --name-only origin/<base>...HEAD`. If the base is ambiguous, stop and
+ask rather than defaulting to `main`.
 
 This audit focuses on issues that are NOT security vulnerabilities but erode user trust: misleading data, missing privacy masking, overclaiming signals, or broken navigation. These are the issues that make users doubt whether the feature is working correctly.
 
@@ -20,8 +23,12 @@ This audit focuses on issues that are NOT security vulnerabilities but erode use
    - Check: does every signal have a clear "why now" (time-sensitive or state-change) rather than "always true"?
 
 4. **Service-availability gating**:
-   - For each signal/insight that depends on optional services (Plex, Seerr, Tautulli): is there a guard that prevents misleading items when the service isn't configured?
-   - Check: would a user with only Sonarr see any items about Plex/Seerr/Tautulli?
+   - For each signal/insight that depends on optional services configured on
+     the target branch (for example Plex, Seerr, Tautulli on 2.x, or Tracearr
+     and qui on 3.0): is there a guard that prevents misleading items when the
+     service isn't configured?
+   - Check the minimal configured-service case: would a user with only Sonarr
+     see claims about an integration they do not have?
 
 5. **Action link correctness**:
    - List every action link, deep link, or navigation target in the feature

--- a/.claude/commands/validate.md
+++ b/.claude/commands/validate.md
@@ -1,26 +1,38 @@
 Run the full validation suite and report results.
 
-1. TypeScript type check (both packages):
+1. Format:
    ```
-   pnpm --filter @arr/web exec tsc --noEmit
-   pnpm --filter @arr/api exec tsc --noEmit
+   pnpm run format
+   ```
+   Report any files changed by formatting.
+
+2. If `packages/shared` changed, rebuild it before type checking or testing:
+   ```
+   pnpm --filter @arr/shared build
    ```
 
-2. Lint:
+3. Run the CI-equivalent root typecheck. Never substitute per-package `tsc`;
+   it can resolve stale shared-package output and miss CI failures:
    ```
+   pnpm run typecheck
+   ```
+
+4. Tests and lint:
+   ```
+   pnpm run test
    pnpm run lint
    ```
 
-3. Tests:
-   ```
-   pnpm run test
-   ```
-
-4. Build:
+5. Production build:
    ```
    pnpm run build
    ```
+   The build is required for release-sensitive, dependency, Docker, routing, or
+   substantial frontend changes. For a documentation-only change, explicitly
+   mark it not applicable rather than pretending it ran.
 
 Report results as a table: Check | Status | Details
 
-If any check fails, diagnose the root cause and suggest a fix.
+If a check fails, diagnose the root cause. Do not bypass, disable, or quietly
+reclassify a failure. Distinguish pre-existing failures from changes introduced
+by the current branch with evidence.

--- a/.claude/commands/work.md
+++ b/.claude/commands/work.md
@@ -24,7 +24,9 @@ Inspect the task description, current branch, and git state to determine the wor
 - Route based on the user's answer.
 
 For other ambiguous tasks, check:
-- `git log --oneline origin/main..HEAD` — if there are unreleased commits, lean toward **stabilize**
+- Resolve the intended base (`main` for stable 2.x maintenance, `next` for 3.0)
+  from an existing PR or the task/branch point; never assume `main`
+- `git log --oneline origin/<base>..HEAD` — if there are unreleased commits, lean toward **stabilize**
 - `git branch --show-current` — if branch name contains `fix/`, `feat/`, `release/`, use that hint
 - `gh issue list --assignee @me --state open --limit 3` — if the task loosely matches an open issue, treat as **issue**
 
@@ -37,7 +39,8 @@ State your classification and reasoning in one line, then proceed.
 ### Issue workflow
 1. Run `/fix-issue {issue_number}`
 2. Run `/validate`
-3. If on a feature branch with multiple commits, run `/stabilize-branch`
+3. If on a task branch with multiple commits or a safety-critical mutation,
+   run `/stabilize-branch`
 
 ### PR review workflow (incoming — reviewing a PR)
 1. Run `/review-pr {pr_number}`
@@ -59,10 +62,15 @@ State your classification and reasoning in one line, then proceed.
 6. **Trust gate**: Check if changed files include new pages (`app/*/page.tsx`), new API routes (`routes/*.ts`), new feature panels (`features/*/components/*`), or notification event types. If yes, run `/trust-check` on the affected files before declaring the work done.
 
 ### Release workflow
-1. Run `/release-patch` — assess readiness
-2. If ready: run `/prepare-changelog`
-3. Present changelog for review
-4. If approved: run `/release-prep {version}`
+1. Resolve the release line.
+2. For a stable 2.x patch from `main`, run `/release-patch`.
+3. For a 3.0 alpha/beta/RC from `next`, follow its living readiness tracker and
+   the prerelease section of `docs/RELEASING.md`; do not route it through the
+   stable patch workflow.
+4. If ready, run `/prepare-changelog` with the resolved release base.
+5. Present changelog for review.
+6. If approved, use `/release-prep {version}` only for stable releases; prepare
+   prereleases from the exact reviewed `next` SHA.
 
 ### Stabilize workflow
 1. Run `/stabilize-branch`

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -11,9 +11,12 @@ Skills are loaded when Claude needs specialized knowledge that would bloat CLAUD
 |-------|-------------|
 | `frontend-architecture` | Working on hooks, query infrastructure, component patterns, state management |
 | `release-engineer` | Preparing releases, writing changelogs, assessing release scope |
-| `integration-auditor` | Working with *arr service APIs, normalizers, Plex/Tautulli/Seerr data |
+| `integration-auditor` | Working with branch-specific *arr, media, Seerr, qui, Tautulli, or Tracearr APIs and normalizers |
 | `auth-reviewer` | Reviewing auth changes, OIDC flows, session management, encryption |
 | `regression-hunter` | Reviewing diffs, stabilizing branches, assessing merge safety |
+
+The `data-safety-reviewer` under `.claude/agents/` is a mandatory independent
+reviewer for deletion, cleanup, restore, schema, and upstream mutation changes.
 
 ## How skills relate to commands
 

--- a/.claude/skills/frontend-architecture.md
+++ b/.claude/skills/frontend-architecture.md
@@ -10,20 +10,24 @@ Load this skill when working on React hooks, data fetching, component structure,
 
 ## Query Infrastructure
 
-**Query keys** are centralized in `apps/web/src/lib/query-keys.ts` (407 lines). Every domain has a key factory:
-- `dashboardKeys`, `libraryKeys`, `plexKeys`, `tautulliKeys`, `seerrKeys`, `huntingKeys`, `queueCleanerKeys`, `libraryCleanupKeys`, `notificationKeys`, `validationKeys`, `authKeys`, `backupKeys`, etc.
+**Query keys** are centralized in `apps/web/src/lib/query-keys.ts`. Every domain has a key factory:
+- Examples include `dashboardKeys`, `libraryKeys`, `plexKeys`, `seerrKeys`,
+  `huntingKeys`, `queueCleanerKeys`, `libraryCleanupKeys`, `notificationKeys`,
+  `validationKeys`, `authKeys`, and `backupKeys`. Tautulli keys are 2.x-only;
+  Tracearr keys are 3.0-only.
 - Key factories return `as const` tuples for type safety
 - Mutations must invalidate using these factories, never raw string arrays
 - Prefix-based invalidation works: invalidating `["seerr"]` clears all seerr queries
 
 **Polling intervals** are in `apps/web/src/lib/polling-intervals.ts`:
 - POLLING_FAST (5s), POLLING_REALTIME (15s), POLLING_ACTIVE (30s), POLLING_STANDARD (60s), POLLING_STATS (120s), POLLING_BACKGROUND (5min)
-- Some hooks accept `refetchInterval` as a parameter (usePlex, useTautulli) — change the call site, not the hook default
+- Some hooks accept `refetchInterval` as a parameter — inspect all call sites
+  before changing the hook default
 
 ## Hook Organization
 
 Two tiers of hooks:
-1. **Domain hooks** (`hooks/api/use*.ts`) — 33 files, each wrapping an API domain's queries and mutations. These are the primary data layer.
+1. **Domain hooks** (`hooks/api/use*.ts`) — each wraps an API domain's queries and mutations. These are the primary data layer.
 2. **Feature hooks** (`features/*/hooks/use*.ts`) — per-feature state management, filter state, derived data. These consume domain hooks.
 
 **Pattern**: API client module → domain hook → feature hook → component. Components should never call `useQuery` or `useMutation` directly.

--- a/.claude/skills/integration-auditor.md
+++ b/.claude/skills/integration-auditor.md
@@ -1,12 +1,24 @@
 ---
 name: integration-auditor
-description: Specialized knowledge for reviewing *arr service integrations — API patterns, normalization, monitoring field semantics, and common drift issues
+description: Specialized knowledge for reviewing *arr and adjacent service integrations — API patterns, normalization, version-line differences, monitoring semantics, and common drift issues
 type: skill
 ---
 
 # Integration Auditor Knowledge
 
-Load this skill when working with Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Tautulli, or Seerr integrations.
+Load this skill when working with Sonarr, Radarr, Prowlarr, Lidarr,
+Readarr, Plex, Jellyfin, Emby, Tautulli, Seerr, qui, or Tracearr integrations.
+
+## Resolve the release line first
+
+- On stable 2.x (`main`), Tautulli remains a supported integration. Tracearr is
+  not part of the stable contract.
+- On 3.0 (`next`), Tautulli is removed from the product surface; its enum value
+  remains only for migration compatibility. Tracearr is its analytics
+  replacement, and qui is a stable integration.
+- Never forward-port integration code mechanically. Re-evaluate service
+  availability, route maturity, stored rows, migrations, and UI consumers on
+  the target branch.
 
 ## Service Architecture
 
@@ -37,12 +49,17 @@ Each *arr service has different API shapes. The normalizers map them to a unifie
 - Lidarr: `foreignArtistId` (MusicBrainz)
 - Plex: `ratingKey` for items, `machineId` for servers
 
-## Plex/Tautulli Integration
+## Media analytics integrations
 
 - Plex provides: library data, now playing sessions, on-deck, recently added
-- Tautulli enriches: watch history, user analytics, bandwidth stats
-- Session merging: Tautulli sessions are preferred over Plex when both report the same stream (richer data)
-- Cache: `PlexCache`, `TautulliCache`, `SessionSnapshot` models — these are regenerated, not critical data
+- Jellyfin and Emby provide parallel library and playback data through their
+  branch-specific clients and caches.
+- In 2.x, Tautulli enriches watch history, user analytics, and bandwidth
+  statistics.
+- In 3.0, Tracearr provides the replacement analytics surface and live-session
+  actions; do not reintroduce Tautulli consumers.
+- Cache rows are regenerated, but actions derived from cache data are not
+  automatically safe. Re-establish the owned upstream target before mutation.
 
 ## Seerr Integration
 
@@ -58,3 +75,15 @@ Each *arr service has different API shapes. The normalizers map them to a unifie
 3. **Missing monitored filtering**: New aggregate calculations must filter by monitored status — this has caused bugs multiple times (#131, #209).
 4. **Inconsistent error handling**: Some API client modules swallow errors (e.g., `services.ts` returns `[]` on 401), others propagate. Prefer propagation.
 5. **Health message anonymization**: The `anonymizeHealthMessage()` and `anonymizeStatusMessage()` functions in `incognito.ts` need regex patterns updated when new services add new message formats (Lidarr music release patterns were missed initially).
+6. **Proxy/auth drift**: Test service URLs behind reverse proxies and optional
+   Basic Auth. A successful connection test must exercise the same
+   authentication and URL resolution path used by real operations.
+7. **Webhook URL formats**: Distinguish a browser HTTP URL from an integration
+   service URL such as Shoutrrr. Preserve secrets while transforming schemes
+   and forwarding query parameters.
+8. **Shared-library identity**: Plex/Jellyfin media identity can aggregate files
+   managed by different *arr instances. A media-server match does not authorize
+   deletion from every backing instance.
+9. **Upstream status semantics**: Do not label normal pending/unreleased content
+   as failed or stuck solely from request age. Require a state transition or
+   evidence that intervention can help.

--- a/.claude/skills/pr-writer.md
+++ b/.claude/skills/pr-writer.md
@@ -32,7 +32,8 @@ type: skill
 5. Files changed
 6. Notes / risks (only if non-trivial)
 7. Test plan
-8. Issue references (`Closes #NNN`)
+8. Issue references (`Closes #NNN` only after exact-scenario reproduction;
+   otherwise `Related to #NNN`)
 9. Footer
 
 ## Writing Patterns

--- a/.claude/skills/regression-hunter.md
+++ b/.claude/skills/regression-hunter.md
@@ -31,6 +31,23 @@ These areas have caused regressions before — extra scrutiny required:
 - Any change to URL normalization can break Authentik (trailing slash) or Keycloak (no trailing slash).
 - The self-healing retry in `discoverAuthServer()` masks stored-issuer mismatches — changing the retry logic can silently break existing setups.
 
+**Safety-critical mutations** (library/queue cleanup, restore, schema sync,
+TRaSH deployment, upstream writes):
+- Preview and dry-run selection must remain identical to execution selection.
+- Re-check ownership and mutable upstream state at execution time.
+- Shared Plex/Jellyfin libraries backed by multiple *arr instances are normal,
+  not an edge case; title/TMDb matches do not prove file or instance identity.
+- Local cache state must not transition to success before the upstream action
+  succeeds.
+- Partial completion, retries, and concurrent scheduler/manual invocation need
+  explicit tests.
+
+**Branch compatibility**:
+- `main` is the stable 2.x contract; avoid breaking route, configuration, or
+  stored-data behavior in a patch.
+- `next` contains 3.0 breaking changes. Confirm whether a fix must be
+  forward-ported, and do not assume identical files imply identical behavior.
+
 ## Silent Breakage Patterns
 
 1. **Query key drift**: A mutation invalidates `["seerr", "requests"]` but the query uses `seerrKeys.requests(id, params)`. The invalidation still works (prefix match) but is fragile. Check that invalidation keys match the centralized key factories.
@@ -43,12 +60,27 @@ These areas have caused regressions before — extra scrutiny required:
 
 5. **Normalizer field access**: Adding a field to a normalizer without checking all callers can produce `undefined` where a value is expected. Always check the `LibraryItem` consumers.
 
-## Test Coverage Gaps to Watch
+6. **Bodyless mutation requests**: Next rewrites/proxies and Fastify content-type
+parsing can disagree on POST/DELETE requests with no body. Verify the real
+browser request and add a route/client regression test rather than assuming
+the proxy is neutral.
 
-- No Lidarr or Readarr-specific tests existed before v2.9.2 — new Lidarr stats tests were added but coverage is still thin
-- Frontend tests only cover 3 files — approval-queue-tab, useSeerr hook, and queue-utils
-- E2E tests run in CI but `authentik-test/` and `pocket-id-test/` are excluded (manual only)
-- Dashboard statistics is the most test-covered backend area (12+ test cases)
+7. **Status-label drift**: A UI filter can become impossible to observe when
+the backend transitions through that status synchronously (for example,
+approved → executing → executed). Verify labels and tabs correspond to durable
+states users can actually inspect.
+
+## Test Evidence to Require
+
+- A regression fixture for the reported data shape, not only an isolated helper
+  test.
+- Populated, paginated, multi-instance, and fractional/null values where the
+  affected domain can produce them.
+- Both failure and success paths at external API boundaries.
+- Real browser verification for user-visible behavior; empty-state rendering
+  alone is insufficient.
+- Manual Authentik/Pocket ID harnesses when their excluded CI paths are
+  affected.
 
 ## Diff Review Checklist
 
@@ -61,3 +93,7 @@ When reviewing a diff, check for:
 6. **New UI data displays** — incognito mode coverage?
 7. **Error handling** — does the catch block log or silently swallow?
 8. **New dependencies** — any known CVEs? Check with `pnpm audit`
+9. **Mutation state** — can the database/cache claim success before upstream
+   success, or can retry double-apply a completed action?
+10. **Preview parity** — do preview and execution share selection logic, or can
+    they drift?

--- a/.claude/skills/release-engineer.md
+++ b/.claude/skills/release-engineer.md
@@ -53,12 +53,19 @@ It should NOT contain:
 
 ## CI Pipeline
 
-After merging to main:
-1. Create tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
-2. Create release: `gh release create vX.Y.Z --title "..." --notes "..."`
-3. The tag push triggers `Build and Push Release Docker Image` workflow
-4. Verify: `gh run list --limit 3` shows the release build succeeded
-5. Close related Dependabot PRs if their changes are included
+Follow `docs/RELEASING.md`; it is the authoritative checklist. In particular:
+
+1. Merge the reviewed release commit to the correct branch and confirm CI.
+2. Create an annotated tag:
+   `git tag -a vX.Y.Z -m "vX.Y.Z — <tagline>"`.
+3. Push the tag and wait for the release Docker workflow.
+4. Verify both registries and `/health` version/commit metadata.
+5. Create the GitHub Release from the exact tag and explicitly mark the newest
+   stable release as Latest (or mark a 3.0 tag as a prerelease).
+6. Confirm `gh release list` shows the tag; a successful Docker workflow does
+   not create the human-facing GitHub Release automatically.
+7. Close only reproduced/resolved issues, each with an explanatory release
+   comment. Close related dependency PRs if their changes are included.
 
 ## Common Mistakes
 
@@ -66,3 +73,6 @@ After merging to main:
 - Writing changelog entries that describe implementation ("changed X to Y") instead of impact ("fixes incorrect missing count for Lidarr")
 - Not closing Dependabot PRs after their changes are included via overrides
 - Creating the tag before CI passes on the merge commit
+- Publishing images but forgetting the GitHub Release, leaving an older version
+  marked Latest
+- Treating prerelease and stable ancestry/tagging rules as interchangeable

--- a/.codex/agents/data-safety-reviewer.toml
+++ b/.codex/agents/data-safety-reviewer.toml
@@ -1,0 +1,28 @@
+name = "data_safety_reviewer"
+description = "Read-only reviewer for deletion, cleanup, restore, schema, deployment, and upstream mutation safety."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and CLAUDE.md. Review the requested diff against its actual PR
+base; do not implement fixes.
+
+Trace the complete mutation path from user or scheduler input through target
+selection, preview or dry-run, authorization, upstream calls, persistence,
+caches, audit logs, notifications, retries, and restart behavior.
+
+Test mentally against multiple service instances sharing a media library,
+same-title collisions, stale previews and caches, missing integrations,
+timeouts after partial upstream success, concurrent execution, and retry after
+restart.
+
+Require preview/execution parity, execution-time ownership and identity,
+fail-closed uncertainty, upstream success before local success, honest
+retryable partial-failure state, idempotency, actionable redacted logs, and
+stable API/config compatibility.
+
+Report only concrete critical/high findings at confidence 80 or above, plus
+medium findings representing realistic data loss or a false operator audit
+trail. Use:
+Severity | Confidence | Location | Invariant | Failure scenario | Required fix
+If none qualify, list the paths and adversarial scenarios reviewed.
+"""

--- a/.codex/agents/regression-reviewer.toml
+++ b/.codex/agents/regression-reviewer.toml
@@ -1,0 +1,23 @@
+name = "regression_reviewer"
+description = "Read-only independent reviewer for correctness, production data shapes, regressions, and missing tests."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and CLAUDE.md. Review the requested diff against its actual PR
+base; do not implement fixes.
+
+Trace changed behavior through callers, shared contracts, routes, persistence,
+caches, hooks, and user-facing consumers. Look for data-dependent failures that
+empty development databases and mocked happy paths miss: pagination,
+multi-instance collisions, null or fractional values, partial results, stale
+cache, bodyless mutation requests, transient statuses, and optional-service
+absence.
+
+Check authorization, validation, encryption, privacy masking, query
+invalidation, upstream API contracts, failure reporting, and regression tests
+at the actual failure boundary.
+
+Report only actionable findings with severity, confidence, file/line,
+production failure scenario, and smallest required correction. If no findings
+qualify, state that and identify residual test or runtime-verification gaps.
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -71,13 +71,15 @@ auth-state.json
 
 # Claude Code
 .claude/*
+!.claude/agents/
 !.claude/commands/
 !.claude/skills/
 # Ignore fetched skill symlinks, keep owned .md files
 .claude/skills/next-best-practices
 .claude/skills/shadcn
 .claude/skills/web-design-guidelines
-.agents/
+.agents/*
+!.agents/skills/
 skills-lock.json
 
 # AI/ML development tool artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,109 @@
+# AGENTS.md — arr-dashboard
+
+Read `CLAUDE.md` for the tracked architecture and pattern reference. If a local
+`HANDOVER.md` exists, read it for machine-specific state and recent project
+history; do not assume it exists in a fresh clone.
+
+Codex-native task workflows live in `.agents/skills/` and are automatically
+discoverable. Use the matching `arr-*` skill for issue fixes, validation,
+reviews, integration changes, PR preparation, and releases. Project reviewers
+live in `.codex/agents/`. `.claude/` files are compatibility material, not the
+canonical Codex workflow.
+
+## Branch and issue discipline
+
+- `main` is stable 2.x maintenance. Limit it to security fixes, data-safety
+  fixes, regressions, and explicitly approved maintenance.
+- `next` is 3.0 development and stabilization. New 3.0 work targets `next`.
+- Fetch the intended base and create a task branch before editing. Do not add
+  work to an unrelated branch merely because it is currently checked out.
+- For a bug affecting both lines, reproduce on both. Fix `main` first when
+  stable users are affected, then forward-port with a separate `next` change;
+  do not merge the branches wholesale.
+- Squash-merge PRs. Keep each PR focused on one coherent concern.
+- Never `@`-mention anyone in PR or issue text. The owner is `Kha-kis`;
+  `khak1s` is an unrelated GitHub user. Attribute with backticks or prose.
+- Use a standalone `Closes #N` PR-body line only after reproducing the
+  reporter's actual scenario and verifying the fix against it. Otherwise use
+  `Related to #N`. Sanitize commit messages as an independent auto-close
+  surface.
+
+## Safety-critical mutations
+
+Deletion, file removal, unmonitoring, queue cleanup, restore, schema change,
+TRaSH deployment, and upstream write paths are safety-critical.
+
+- Dry-run and preview modes must not mutate the database, filesystem, or an
+  upstream service. Previewed targets and actions must be the same targets and
+  actions used by real execution.
+- Fail closed when ownership, service identity, shared-library correlation,
+  file identity, upstream state, or a safety dependency cannot be established.
+  A failed safety check never becomes permission to mutate.
+- Resolve and authorize every target at execution time. Never trust a cached
+  preview, client-supplied owner, title, path, or instance identifier as final
+  authority.
+- Treat multiple service instances pointing at the same media library as a
+  normal production scenario. Test cross-instance and same-title collisions.
+- Record success only after the upstream mutation succeeds. On partial
+  failure, preserve an honest retryable state and an actionable audit trail;
+  never claim completion from a cache-only update.
+- Cover success, expected failure, dependency failure, dry-run, real mutation,
+  partial completion, retry/idempotency, and concurrent invocation as
+  applicable.
+- Run an independent data-safety review before merging deletion-adjacent work.
+  Delegate it to the read-only `data_safety_reviewer` project agent; the
+  implementer must not be the only reviewer of the mutation boundary.
+- Delegate a separate `regression_reviewer` pass for substantial,
+  data-dependent, or deletion-adjacent code changes. Do not spend subagents on
+  trivial documentation-only changes.
+
+## Verification gauntlet
+
+Run the narrowest useful test while iterating. Before every PR:
+
+```bash
+pnpm run format
+pnpm --filter @arr/shared build   # required when packages/shared changed
+pnpm run typecheck                # root Turbo check; per-package tsc is insufficient
+pnpm run test
+pnpm run lint
+```
+
+Use `$arr-validate` to apply and report this gauntlet consistently.
+
+Run `pnpm run build` for release-sensitive, dependency, Docker, routing, or
+substantial frontend changes. Live-verify user-visible behavior in a real
+browser. Use populated fixtures for data-dependent behavior; an empty
+development database is not sufficient evidence.
+
+## Code invariants
+
+1. Frontend calls `/api/*` through Next rewrites, never `localhost:3001`.
+2. Include `userId: request.currentUser!.id` in every Prisma query for
+   user-owned resources.
+3. Encrypt API keys with `app.encryptor.encrypt()` and store both value and IV.
+4. Parse request bodies with `validateRequest()`; never cast
+   `request.body as Type`.
+5. Sensitive titles, usernames, URLs, and instance names require incognito
+   helpers; component tests require `<IncognitoProvider>`.
+6. Use centralized query keys and polling constants; invalidate after
+   mutations.
+7. Use semantic/brand/theme colors and semantic z-index classes.
+8. Radarr/Sonarr updates fetch the full resource with `getById()` and spread it
+   into the PUT payload.
+9. A new route group requires a route-manifest entry and
+   `docs/API-ROUTES.md`; a new Pulse collector requires `COLLECTOR_LABELS` and
+   a stable entity-keyed signal id.
+10. Use `getErrorMessage()` and pino (`request.log`/`app.log`), never production
+    `console.log`.
+
+## Definition of done
+
+- The reported scenario is represented by a regression test where practical.
+- Focused tests and the repository gauntlet pass; failures are reported
+  honestly rather than bypassed.
+- User-visible behavior is live-verified and documented when needed.
+- No secrets, generated artifacts, placeholders, commented-out
+  implementations, or unrelated cleanup enter the diff.
+- The final handoff states behavior changed, files affected, risks, validation,
+  and any required forward-port or release action.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ These cause bugs if ignored:
 1. **API Proxy**: Frontend calls `/api/*` via Next.js rewrites to backend. NEVER use `localhost:3001` directly from frontend code.
 2. **Ownership**: Always include `userId: request.currentUser!.id` in Prisma queries for user-owned resources. Omitting this is a security vulnerability.
 3. **Encryption**: All API keys must be encrypted with `app.encryptor.encrypt()` before storage. Store both `value` and `iv`.
-4. **Auth Check**: Protected routes use preHandler hook checking `request.currentUser?.id`. Every route plugin must add this hook.
+4. **Auth Check**: Protected route groups register through `route-manifest.ts` inside the single protected scope, whose preHandler checks `request.currentUser?.id`. Do not add parallel per-route auth gates.
 5. **Validation**: Use `validateRequest()` from `lib/utils/validate.ts` for request body parsing. Never use `request.body as Type`.
 6. **Incognito Mode**: Any component displaying sensitive data (titles, usernames, URLs, instance names) must use `useIncognitoMode()` hook from `contexts/IncognitoContext.tsx` and anonymize with functions from `lib/incognito.ts`. This includes API response text that embeds instance names (e.g., Pulse titles like `"Label: message"` — split and anonymize both parts). Tests rendering such components need `<IncognitoProvider>` wrapper.
 7. **Query Invalidation**: Always invalidate relevant React Query keys after mutations.
@@ -36,13 +36,13 @@ packages/shared/src/types/ # Shared Zod schemas + TypeScript types
 
 ## Architecture
 
-**Monorepo**: `apps/api` (Fastify 4), `apps/web` (Next.js 16 App Router), `packages/shared` (Zod types). pnpm 10+ with Turbo.
+**Monorepo**: `apps/api` (Fastify 5), `apps/web` (Next.js 16 App Router), `packages/shared` (Zod types). pnpm 10+ with Turbo.
 
-**Stack**: Fastify + Prisma + Zod backend, Next.js + React 18 + TanStack Query frontend, TailwindCSS + shadcn/ui, SQLite default (PostgreSQL supported).
+**Stack**: Fastify + Prisma + Zod backend, Next.js + React 19 + TanStack Query frontend, TailwindCSS + shadcn/ui, SQLite default (PostgreSQL supported).
 
 **Design**: Single-admin, self-hosted. Session-based auth (NOT JWT). Three auth methods: Password, OIDC, Passkeys.
 
-**Services**: Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Tautulli, Seerr (Jellyseerr/Overseerr).
+**Services**: Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Tautulli, Jellyfin, Emby, Seerr (Jellyseerr/Overseerr), and qui.
 
 **Fastify Decorations** (available in route handlers):
 - `request.currentUser` / `request.sessionToken` — populated by auth preHandler
@@ -73,7 +73,7 @@ packages/shared/src/types/ # Shared Zod schemas + TypeScript types
 
 **New API Route:**
 1. Create `apps/api/src/routes/<domain>.ts`
-2. Register in `apps/api/src/server.ts`
+2. Register in `apps/api/src/routes/route-manifest.ts` and document the group in `docs/API-ROUTES.md`
 3. Add Zod types to `packages/shared/src/types/<domain>.ts`
 4. Add API client to `apps/web/src/lib/api-client/<domain>.ts`
 5. Add React Query hook to `apps/web/src/hooks/api/use<Domain>.ts`
@@ -97,6 +97,38 @@ When adding features that surface data to users (pages, panels, signals, notific
 3. **Duplicate surface check**: Before adding a signal, check where the same data already appears. Justify the overlap (cross-system synthesis is good, pure duplication is not)
 4. **Action link verification**: Every action link must point to an existing page that shows the relevant data with any required query params
 5. **Run `/trust-check`** on new user-facing features before marking them ready for review
+
+## Safety-Critical Mutations
+
+Deletion, file removal, unmonitoring, queue cleanup, restore, schema change,
+TRaSH deployment, and upstream write paths require stronger evidence than
+ordinary reads:
+
+1. **Preview parity**: Dry-run and preview code must be side-effect free and
+   select the same targets and actions as real execution.
+2. **Fail closed**: Unknown ownership, instance identity, file correlation,
+   shared-library state, or upstream state means skip/stop with an actionable
+   explanation—not permission to mutate.
+3. **Execution-time authority**: Re-fetch and authorize mutable targets at
+   execution time. Cached previews and client-supplied identifiers are not
+   final authority.
+4. **Honest state transitions**: Persist success only after the upstream action
+   succeeds. Partial failures remain visible and retryable; cache updates do
+   not prove upstream success.
+5. **Production-shaped tests**: Cover shared-library/multi-instance cases,
+   same-title collisions, dependency failure, dry-run, mutation, retry, and
+   concurrency as applicable.
+6. **Independent review**: Delegate deletion-adjacent diffs to Codex's
+   read-only `data_safety_reviewer` project agent before merge, in addition to
+   normal regression and browser verification.
+
+## Codex Workflows
+
+- Repository skills live in `.agents/skills/` and use the `arr-*` namespace.
+- Project reviewers live in `.codex/agents/`; use `regression_reviewer` for
+  substantial changes and `data_safety_reviewer` for mutation boundaries.
+- `AGENTS.md` is the durable instruction entry point. `.claude/` remains only
+  for compatibility with contributors using Claude Code.
 
 ## Database
 
@@ -124,7 +156,7 @@ When adding features that surface data to users (pages, panels, signals, notific
 
 **Data fetching**: API client module -> `useQuery`/`useMutation` hook -> component. All API requests use `credentials: "include"`. Server state must live in shared domain hooks (`hooks/api/`), never inline in components. Components should only render and handle user interaction — keep data transformation and business logic in hooks or utilities.
 
-**Route protection**: No Next.js middleware is used. Auth gating relies on API calls returning 401 for unauthenticated requests — the frontend redirects to `/login` on auth failure. API proxying is handled by Next.js rewrites in `next.config.mjs`.
+**Route protection**: `proxy.ts` performs the frontend redirect preflight, while the API's protected manifest scope is the authoritative auth gate and returns 401 for unauthenticated requests. API proxying is handled by Next.js rewrites in `next.config.mjs`.
 
 **Lazy modals**: Use `React.lazy` + `Suspense` for modals behind `{stateVar && <Modal />}`. Named exports need adapter: `lazy(() => import("./file").then(m => ({ default: m.NamedExport })))`.
 
@@ -135,17 +167,20 @@ When adding features that surface data to users (pages, panels, signals, notific
 ## Testing
 
 ```bash
-pnpm run test                                    # All tests
-pnpm --filter @arr/web exec tsc --noEmit         # Type check frontend
-pnpm --filter @arr/api exec tsc --noEmit         # Type check backend
+pnpm run format
+pnpm --filter @arr/shared build                  # Required after shared changes
+pnpm run typecheck                               # CI-equivalent Turbo typecheck
+pnpm run test
+pnpm run lint
 ```
 
 - Components using `useIncognitoMode()` require `<IncognitoProvider>` wrapper in tests
-- Stale IDE diagnostics can show errors on deleted lines — trust the full `tsc` run
+- Per-package `tsc` runs can hide stale `@arr/shared` output; only the root Turbo
+  typecheck after building shared matches CI
 
 ## Environment & Deployment
 
-**Docker** (single container): Port 3000 exposed, `/config/` volume contains `prod.db` + `secrets.json`. Startup: `docker/start-combined.sh`.
+**Docker** (single container): Port 3000 exposed, `/config/` volume contains `prod.db` + `secrets.json`. Startup: `docker/start-combined.sh`. Production startup acquires a database-backed runtime lease; run exactly one API/container per database. Lease operations are deadline-bound and a process that cannot renew exits fail-closed. Schema sync is fail-closed and never approves destructive changes automatically.
 
 **Key env vars**: `DATABASE_URL`, `API_PORT` (3001), `PORT` (3000), `HOST` (0.0.0.0), `PUID`/`PGID`, `SESSION_TTL_HOURS` (24), `ENCRYPTION_KEY` (auto-generated), `SESSION_COOKIE_SECRET` (auto-generated), `WEBAUTHN_RP_ID`, `WEBAUTHN_ORIGIN`.
 
@@ -153,7 +188,7 @@ pnpm --filter @arr/api exec tsc --noEmit         # Type check backend
 
 ## Patterns & Gotchas
 
-- **API Proxy**: Frontend uses `/api/*` paths via Next.js rewrites in `next.config.mjs`. No middleware exists — auth gating relies on API 401 responses
+- **API Proxy**: Frontend uses `/api/*` paths via Next.js rewrites in `next.config.mjs`; `proxy.ts` only assists navigation, and API 401 responses remain authoritative
 - **Server Components**: Default in Next.js App Router. Add `"use client"` when needed
 - **Docker vs Dev**: Different env vars and paths (`/config/` vs `./`)
 - **Secrets auto-generated**: `ENCRYPTION_KEY` and `SESSION_COOKIE_SECRET` are auto-generated to `secrets.json` if not provided

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,24 +12,31 @@ pnpm install && pnpm run dev  # API (3001) + Web (3000)
 
 ## Development Guide
 
-The main development reference is [`CLAUDE.md`](CLAUDE.md) — it covers:
+Start with [`AGENTS.md`](AGENTS.md) for branch, safety, and verification rules.
+The detailed development reference is [`CLAUDE.md`](CLAUDE.md) — it covers:
 - Architecture (Fastify + Next.js + Prisma monorepo)
 - Code style and conventions (Biome, TypeScript strict mode)
 - Key patterns (auth, encryption, API proxy, theming)
 - How to add features (routes, pages, database changes)
 
+Codex users also get repository-scoped workflows from `.agents/skills/` and
+project reviewers from `.codex/agents/`; no personal installation is required.
+
 ## Submitting Changes
 
-1. **Fork** the repo and create a branch from `main`
+1. **Fork** the repo and choose the correct base: `next` for 3.0 work, or
+   `main` only for stable 2.x maintenance
 2. **Follow existing patterns** — check `CLAUDE.md` for conventions
 3. **Test your changes**:
    ```bash
-   pnpm run lint        # Biome (API) + ESLint (Web)
-   pnpm run typecheck   # TypeScript strict mode
-   pnpm run test        # Vitest unit tests
-   pnpm run build       # Production build
+   pnpm run format
+   pnpm --filter @arr/shared build  # if packages/shared changed
+   pnpm run typecheck               # root Turbo check matching CI
+   pnpm run test
+   pnpm run lint
+   pnpm run build                   # release-sensitive/substantial changes
    ```
-4. **Open a PR** against `main` with a clear description
+4. **Open a PR** against the branch you based the work on
 
 ## What Makes a Good PR
 

--- a/apps/api/src/lib/queue-cleaner/torrent-file-policy.test.ts
+++ b/apps/api/src/lib/queue-cleaner/torrent-file-policy.test.ts
@@ -55,12 +55,16 @@ describe("torrent file policy", () => {
 		});
 	});
 
-	it.each([["not json"], ['{"mkv":true}'], ['["mkv.exe"]'], ['["../mkv"]'], ['[""]'], ["[42]"]])(
-		"rejects unsafe or ambiguous allowlists: %s",
-		(value) => {
-			expect(parseAllowedFileExtensions(value).ok).toBe(false);
-		},
-	);
+	it.each([
+		["not json"],
+		['{"mkv":true}'],
+		['["mkv.exe"]'],
+		['["../mkv"]'],
+		['[""]'],
+		["[42]"],
+	])("rejects unsafe or ambiguous allowlists: %s", (value) => {
+		expect(parseAllowedFileExtensions(value).ok).toBe(false);
+	});
 
 	it("rejects oversized allowlist JSON before parsing it", () => {
 		expect(parseAllowedFileExtensions(`["${"a".repeat(5000)}"]`).ok).toBe(false);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3377,9 +3377,9 @@
 	   - Gradient text (elements with background-clip: text)
 	   Using :not() with :where() for broader exclusions */
 	[data-theme="qbittorrent"]
-	[style*="gradient"]:where(
-		:not(.pointer-events-none):not(.fixed):not([data-appearance-settings] *)
-	):not([style*="background-clip"]):not([style*="BackgroundClip"]) {
+		[style*="gradient"]:where(
+			:not(.pointer-events-none):not(.fixed):not([data-appearance-settings] *)
+		):not([style*="background-clip"]):not([style*="BackgroundClip"]) {
 		background: transparent !important;
 	}
 

--- a/apps/web/src/features/library-cleanup/lib/__tests__/condition-params.test.ts
+++ b/apps/web/src/features/library-cleanup/lib/__tests__/condition-params.test.ts
@@ -121,12 +121,12 @@ describe("getDefaultConditionParams", () => {
 			["user_retention", { operator: "watched_by_none", source: "plex" }],
 			["staleness_score", { operator: "greater_than", threshold: 70 }],
 			["recently_active", { protectionDays: 30, requireActivity: true }],
-		] as [CleanupRuleType, Record<string, unknown>][])(
-			"%s → returns correct defaults",
-			(ruleType, expected) => {
-				expect(getDefaultConditionParams(ruleType)).toEqual(expected);
-			},
-		);
+		] as [
+			CleanupRuleType,
+			Record<string, unknown>,
+		][])("%s → returns correct defaults", (ruleType, expected) => {
+			expect(getDefaultConditionParams(ruleType)).toEqual(expected);
+		});
 	});
 
 	// Document the intentional default divergence between getDefaultConditionParams


### PR DESCRIPTION
## Summary

Add repository-native Codex guidance for maintaining the stable and 3.0 release lines safely, while retaining refreshed Claude Code compatibility material.

## Codex workflow

- Track root `AGENTS.md` as the durable branch, safety, verification, and completion contract.
- Add six repository-scoped `arr-*` skills for issue fixes, validation, change review, integration work, PR preparation, and releases.
- Add read-only `regression_reviewer` and `data_safety_reviewer` project agents for independent review passes.
- Document automatic Codex discovery in the contributor and architecture guidance.

## Maintainer safety

- Make `main` versus `next` selection explicit throughout the workflows.
- Require exact reproduction before using issue auto-close language.
- Add preview parity, fail-closed targeting, execution-time authority, partial-failure honesty, and multi-instance collision checks for mutation paths.
- Refresh stale architecture, service, validation, and release assumptions in the existing Claude Code compatibility workflows.

## Formatter baseline

Apply Biome's formatter-only output to three existing source files so the newly documented verification gauntlet passes on the current stable baseline. These changes do not alter runtime behavior.

## Validation

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run format`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — 2,657 passed; 41 API tests skipped by existing configuration
- [x] `pnpm run lint`
- [x] All six Codex skills passed `quick_validate.py`
- [x] Both project-agent TOML files parsed with required fields
- [x] `codex debug prompt-input` discovered all six repository skills and loaded `AGENTS.md`
- [x] `codex doctor` — 17 passed, 0 warnings, 0 failures

Production build and browser verification are not applicable because the only source changes are formatter-only.