### PR TITLE
fix(library-cleanup): complete cleanup coordination

### DIFF
--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -11,6 +11,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "../../../lib/prisma.js";
 import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../../library-cleanup/cleanup-maintenance-gate.js";
 import { generateBackupId } from "../backup-file-utils.js";
 import { BackupService, estimateBackupBytes } from "../backup-service.js";
 import {
@@ -300,6 +304,42 @@ describe("BackupService - Backup Validation (Unit)", () => {
 		expect(() => validateBackup(invalidBackup)).toThrow(
 			"Invalid backup format: missing or invalid version",
 		);
+	});
+});
+
+describe("BackupService - cleanup maintenance exclusion", () => {
+	it("rejects a validated restore before changing secrets or database state", async () => {
+		let releaseCleanup!: () => void;
+		const cleanupBlocked = new Promise<void>((resolve) => {
+			releaseCleanup = resolve;
+		});
+		const cleanup = withCleanupOperationGuard(() => cleanupBlocked);
+		const backupService = new BackupService({} as PrismaClient, "/unused/secrets.json");
+		const backup = {
+			version: "1.0",
+			appVersion: "2.23.0",
+			timestamp: new Date().toISOString(),
+			data: {
+				users: [],
+				sessions: [],
+				serviceInstances: [],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+			},
+			secrets: {
+				encryptionKey: "test-encryption-key-32-bytes-hex",
+				sessionCookieSecret: "test-session-cookie-secret",
+			},
+		};
+
+		await expect(backupService.restoreBackup(JSON.stringify(backup))).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		releaseCleanup();
+		await cleanup;
 	});
 });
 

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -28,6 +28,7 @@ import type {
 } from "@arr/shared";
 import type { PrismaClient } from "../../lib/prisma.js";
 import type { Encryptor } from "../auth/encryption.js";
+import { withCleanupMaintenanceGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { decryptBackupData, encryptBackupData } from "./backup-crypto.js";
@@ -708,7 +709,15 @@ export class BackupService {
 		// 1. Validate backup structure (parsed now contains the backup object)
 		const backup = parsed as BackupData;
 		validateBackup(backup);
+		// A successful restore replaces credentials and scheduler state that are
+		// only reloaded on process start. Keep cleanup-sensitive mutations
+		// blocked until the required restart; failures release the guard.
+		return await withCleanupMaintenanceGuard(() => this.restoreValidatedBackup(backup), {
+			holdAfterSuccess: true,
+		});
+	}
 
+	private async restoreValidatedBackup(backup: BackupData): Promise<BackupMetadata> {
 		// 2. Perform atomic restore with two-phase commit pattern to prevent partial restore
 		const secretsBackupPath = `${this.secretsPath}.restore-backup`;
 		let secretsBackedUp = false;

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-maintenance-gate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+	withCleanupOperationGuard,
+} from "../cleanup-maintenance-gate.js";
+
+describe.sequential("cleanup maintenance gate", () => {
+	it("rejects restore while a cleanup-sensitive operation is active", async () => {
+		let releaseOperation!: () => void;
+		const operationBlocked = new Promise<void>((resolve) => {
+			releaseOperation = resolve;
+		});
+		const operation = withCleanupOperationGuard(() => operationBlocked);
+
+		await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		releaseOperation();
+		await operation;
+		await expect(withCleanupMaintenanceGuard(async () => "restored")).resolves.toBe("restored");
+	});
+
+	it("rejects cleanup and topology writes throughout restore", async () => {
+		let releaseRestore!: () => void;
+		const restoreBlocked = new Promise<void>((resolve) => {
+			releaseRestore = resolve;
+		});
+		const restore = withCleanupMaintenanceGuard(() => restoreBlocked);
+
+		await expect(withCleanupOperationGuard(async () => undefined)).rejects.toBeInstanceOf(
+			CleanupMaintenanceConflictError,
+		);
+
+		releaseRestore();
+		await restore;
+		await expect(withCleanupOperationGuard(async () => "changed")).resolves.toBe("changed");
+	});
+
+	it("releases the exclusive guard after restore fails", async () => {
+		await expect(
+			withCleanupMaintenanceGuard(async () => {
+				throw new Error("restore failed");
+			}),
+		).rejects.toThrow("restore failed");
+
+		await expect(withCleanupOperationGuard(async () => "available")).resolves.toBe("available");
+	});
+});

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	acquireCleanupRunLease,
+	CleanupPolicyMutationConflictError,
+	CleanupTopologyMutationConflictError,
 	releaseCleanupRunLease,
 	renewCleanupRunLease,
+	withCleanupTopologyMutationLease,
+	withCleanupPolicyMutationLease,
 } from "../cleanup-executor.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
@@ -151,5 +155,100 @@ describe("library cleanup database run lease", () => {
 				"owner-2",
 			),
 		).resolves.toBeNull();
+	});
+
+	it("holds the cleanup lease across a service topology mutation", async () => {
+		const calls: string[] = [];
+		const updateMany = vi.fn(async ({ data }: { data: { runClaimToken: string | null } }) => {
+			calls.push(data.runClaimToken === null ? "release" : "acquire");
+			return { count: 1 };
+		});
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn(async () => {
+					calls.push("upsert");
+					return { id: "config-1" };
+				}),
+				updateMany,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = {
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupTopologyMutationLease({ prisma, log }, "user-1", async () => {
+				calls.push("mutate");
+				return "created";
+			}),
+		).resolves.toBe("created");
+		expect(calls).toEqual(["upsert", "acquire", "mutate", "release"]);
+	});
+
+	it("rejects a service topology mutation while cleanup owns the lease", async () => {
+		const mutate = vi.fn();
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "config-1" }),
+				updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = {
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupTopologyMutationLease({ prisma, log }, "user-1", mutate),
+		).rejects.toBeInstanceOf(CleanupTopologyMutationConflictError);
+		expect(mutate).not.toHaveBeenCalled();
+	});
+
+	it("releases the topology lease when the service mutation fails", async () => {
+		const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "config-1" }),
+				updateMany,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = {
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupTopologyMutationLease({ prisma, log }, "user-1", async () => {
+				throw new Error("write failed");
+			}),
+		).rejects.toThrow("write failed");
+		expect(updateMany).toHaveBeenCalledTimes(2);
+		expect(updateMany.mock.calls[1]![0]).toMatchObject({
+			where: { id: "config-1", userId: "user-1", runClaimToken: expect.any(String) },
+			data: { runClaimToken: null, runClaimedAt: null },
+		});
+	});
+
+	it("rejects cleanup policy writes while a run owns the existing config lease", async () => {
+		const mutate = vi.fn();
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn(),
+				updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = {
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupPolicyMutationLease({ prisma, log }, "user-1", mutate, {
+				configId: "config-1",
+			}),
+		).rejects.toBeInstanceOf(CleanupPolicyMutationConflictError);
+		expect(prisma.libraryCleanupConfig.upsert).not.toHaveBeenCalled();
+		expect(mutate).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CleanupScheduler } from "../cleanup-scheduler.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+} from "../cleanup-maintenance-gate.js";
 
 describe("library cleanup scheduler recovery", () => {
 	afterEach(() => {
@@ -104,5 +108,89 @@ describe("library cleanup scheduler recovery", () => {
 			approvalUpdateMany.mock.calls.find(([args]) => args.where.status === "executing")?.[0].where
 				.config,
 		).toBeDefined();
+	});
+
+	it("does not run recovery writes while database maintenance is active", async () => {
+		const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const findFirst = vi.fn().mockResolvedValue(null);
+		const log = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		const scheduler = new CleanupScheduler(
+			{
+				libraryCleanupApproval: { updateMany },
+				libraryCleanupConfig: { findFirst },
+			} as never,
+			{} as never,
+			{} as never,
+			log as never,
+		);
+		let finishMaintenance!: () => void;
+		const maintenanceBlocked = new Promise<void>((resolve) => {
+			finishMaintenance = resolve;
+		});
+		const maintenance = withCleanupMaintenanceGuard(() => maintenanceBlocked);
+
+		try {
+			await (
+				scheduler as unknown as {
+					checkAndRun: () => Promise<void>;
+				}
+			).checkAndRun();
+
+			expect(updateMany).not.toHaveBeenCalled();
+			expect(findFirst).not.toHaveBeenCalled();
+			expect(log.debug).toHaveBeenCalledWith(
+				"Database maintenance owns the library-cleanup operation guard",
+			);
+		} finally {
+			finishMaintenance();
+			await maintenance;
+		}
+	});
+
+	it("keeps error notification work guarded against backup restore", async () => {
+		const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const findFirst = vi.fn().mockRejectedValue(new Error("config read failed"));
+		const log = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		let finishNotification!: () => void;
+		const notificationBlocked = new Promise<void>((resolve) => {
+			finishNotification = resolve;
+		});
+		const notify = vi.fn(() => notificationBlocked);
+		const scheduler = new CleanupScheduler(
+			{
+				libraryCleanupApproval: { updateMany },
+				libraryCleanupConfig: { findFirst },
+			} as never,
+			{} as never,
+			{} as never,
+			log as never,
+			notify,
+		);
+
+		const tick = (
+			scheduler as unknown as {
+				checkAndRun: () => Promise<void>;
+			}
+		).checkAndRun();
+
+		try {
+			await vi.waitFor(() => expect(notify).toHaveBeenCalledOnce());
+			await expect(withCleanupMaintenanceGuard(async () => undefined)).rejects.toBeInstanceOf(
+				CleanupMaintenanceConflictError,
+			);
+		} finally {
+			finishNotification();
+			await tick;
+		}
 	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -323,6 +323,7 @@ function makeDeps(options: TestOptions = {}) {
 			libraryCleanupApproval: {
 				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 				findMany: vi.fn().mockResolvedValue([]),
+				findFirst: vi.fn().mockResolvedValue(null),
 				count: vi.fn().mockResolvedValue(0),
 				create: vi.fn().mockResolvedValue({}),
 				update: vi.fn().mockResolvedValue({}),
@@ -333,6 +334,7 @@ function makeDeps(options: TestOptions = {}) {
 				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 			},
 			libraryCleanupLog: {
+				findFirst: vi.fn().mockResolvedValue(null),
 				create: vi.fn().mockResolvedValue({}),
 			},
 		} as unknown as CleanupExecutorDeps["prisma"],
@@ -370,16 +372,20 @@ function configureRetryStore(deps: CleanupExecutorDeps) {
 	const retries: Array<Record<string, unknown>> = [];
 	vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
 		where,
+		select,
+		take,
 	}: {
-		where: { status?: string };
+		where: { status?: string | { in: string[] } };
+		select?: Record<string, boolean>;
+		take?: number;
 	}) => {
-		if (where.status === "retry_pending") {
-			return retries.filter((retry) => retry.status === "retry_pending");
-		}
-		if (where.status === "retry_executing") {
-			return retries.filter((retry) => retry.status === "retry_executing");
-		}
-		return [];
+		const statuses = typeof where.status === "string" ? [where.status] : (where.status?.in ?? []);
+		const matching = retries.filter((retry) => statuses.includes(retry.status as string));
+		const limited = take === undefined ? matching : matching.slice(0, take);
+		if (!select) return limited;
+		return limited.map((retry) =>
+			Object.fromEntries(Object.keys(select).map((field) => [field, retry[field]])),
+		);
 	}) as never);
 	vi.mocked(deps.prisma.libraryCleanupApproval.updateMany).mockImplementation((async ({
 		where,
@@ -499,6 +505,7 @@ function dryRunConfig(maxRemovalsPerRun = 10) {
 		requireApproval: false,
 		maxRemovalsPerRun,
 		respectQuiSeeding: false,
+		rejectionMemoryDays: 0,
 		rules: [
 			{
 				id: "rule-1",
@@ -517,10 +524,33 @@ function dryRunConfig(maxRemovalsPerRun = 10) {
 				conditions: null,
 				configId: "config-1",
 				retentionMode: false,
+				useGlobalRejectionMemory: true,
+				rejectionMemoryDays: 0,
 				createdAt: new Date("2026-07-27T12:00:00.000Z"),
 				updatedAt: new Date("2026-07-27T12:00:00.000Z"),
 			},
 		],
+	};
+}
+
+function matchingDryRunCacheItem(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "cache-fresh",
+		instanceId: "radarr-4k",
+		arrItemId: 202,
+		itemType: "movie",
+		title: "Fresh rule match",
+		year: 2020,
+		monitored: true,
+		hasFile: true,
+		status: "released",
+		qualityProfileId: 1,
+		qualityProfileName: "4K",
+		sizeOnDisk: 1_000n,
+		arrAddedAt: new Date("2020-01-01T00:00:00.000Z"),
+		cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+		data: radarrCachedFileIdentity.data,
+		...overrides,
 	};
 }
 
@@ -548,6 +578,200 @@ describe("shared Plex deletion safety", () => {
 		});
 		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
 		expect(deps.prisma.libraryCleanupLog.create).toHaveBeenCalledOnce();
+	});
+
+	it.each(["retry_pending", "retry_executing"])(
+		"filters %s targets before applying the approval run limit",
+		async (retryStatus) => {
+			const { deps, targetClient } = makeDeps({ mediaPartCount: 1 });
+			vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+				...dryRunConfig(1),
+				dryRunMode: false,
+				requireApproval: true,
+			} as never);
+			vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+				matchingDryRunCacheItem({
+					id: "cache-retry",
+					arrItemId: 101,
+					title: "Existing durable retry",
+				}),
+				matchingDryRunCacheItem({
+					id: "cache-fresh",
+					arrItemId: 202,
+					title: "Fresh approval candidate",
+				}),
+			] as never);
+			const retryTarget = approvalRecord({ status: retryStatus }) as Record<string, unknown>;
+			vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+				where,
+				select,
+			}: {
+				where: { status?: string | { in: string[] } };
+				select?: Record<string, boolean>;
+			}) => {
+				const statuses =
+					typeof where.status === "string" ? [where.status] : (where.status?.in ?? []);
+				if (!statuses.includes(retryStatus)) return [];
+				if (!select) return [retryTarget];
+				return [
+					Object.fromEntries(Object.keys(select).map((field) => [field, retryTarget[field]])),
+				];
+			}) as never);
+			vi.mocked(targetClient.movie.getById).mockResolvedValue({
+				id: 202,
+				tmdbId: 42,
+				title: "Fresh approval candidate",
+				tags: [],
+				hasFile: true,
+				movieFileId: 1001,
+				path: "/movies-4k/Example Movie (2024)",
+				rootFolderPath: "/movies-4k",
+				movieFile: {
+					id: 1001,
+					path: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+					relativePath: "Example.Movie.2160p.mkv",
+					size: 2_000,
+				},
+			} as never);
+
+			const result = await executeCleanupRun(deps, "user-1");
+
+			expect(deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledOnce();
+			expect(deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					arrItemId: 202,
+					status: "pending",
+				}),
+			});
+			expect(result).toMatchObject({
+				itemsFlagged: 1,
+				itemsSkipped: 1,
+			});
+		},
+	);
+
+	it.each([
+		{ status: "pending", rejectionMemoryDays: 0 },
+		{ status: "rejected", rejectionMemoryDays: 30 },
+	])(
+		"filters an existing $status approval before applying the approval run limit",
+		async ({ status, rejectionMemoryDays }) => {
+			const { deps, targetClient } = makeDeps({ mediaPartCount: 1 });
+			vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+				...dryRunConfig(1),
+				dryRunMode: false,
+				requireApproval: true,
+				rejectionMemoryDays,
+			} as never);
+			vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+				matchingDryRunCacheItem({
+					id: "cache-existing",
+					arrItemId: 101,
+					title: "Existing approval",
+				}),
+				matchingDryRunCacheItem({
+					id: "cache-fresh",
+					arrItemId: 202,
+					title: "Fresh approval candidate",
+				}),
+			] as never);
+			vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+				where,
+			}: {
+				where: {
+					status?: string | { in: string[] };
+					OR?: Array<{ status: string }>;
+				};
+			}) => {
+				if (where.status) return [];
+				return [
+					{
+						instanceId: "radarr-4k",
+						arrItemId: 101,
+						itemType: "movie",
+						status,
+						reviewedAt: new Date(),
+					},
+				];
+			}) as never);
+			vi.mocked(deps.prisma.libraryCleanupApproval.findFirst).mockImplementation((async ({
+				where,
+			}: {
+				where: { arrItemId: number };
+			}) =>
+				where.arrItemId === 101
+					? {
+							...approvalRecord(),
+							status,
+							reviewedAt: new Date(),
+						}
+					: null) as never);
+			vi.mocked(targetClient.movie.getById).mockResolvedValue({
+				id: 202,
+				tmdbId: 42,
+				title: "Fresh approval candidate",
+				tags: [],
+				hasFile: true,
+				movieFileId: 1001,
+				path: "/movies-4k/Example Movie (2024)",
+				rootFolderPath: "/movies-4k",
+				movieFile: {
+					id: 1001,
+					path: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+					relativePath: "Example.Movie.2160p.mkv",
+					size: 2_000,
+				},
+			} as never);
+
+			const result = await executeCleanupRun(deps, "user-1");
+
+			expect(deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledOnce();
+			expect(deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					arrItemId: 202,
+					status: "pending",
+				}),
+			});
+			expect(result).toMatchObject({
+				status: "completed",
+				itemsFlagged: 1,
+				itemsSkipped: 1,
+			});
+		},
+	);
+
+	it("reports an approval queue write failure as partial and skipped", async () => {
+		const { deps } = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...dryRunConfig(1),
+			dryRunMode: false,
+			requireApproval: true,
+		} as never);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({
+				id: "cache-approval",
+				arrItemId: 101,
+				title: "Approval candidate",
+			}),
+		] as never);
+		vi.mocked(deps.prisma.libraryCleanupApproval.create).mockRejectedValue(
+			new Error("database unavailable"),
+		);
+
+		const result = await executeCleanupRun(deps, "user-1");
+
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsFlagged: 0,
+			itemsSkipped: 1,
+		});
+		expect(result.details).toEqual([
+			expect.objectContaining({
+				title: "Approval candidate",
+				action: "skipped",
+				reason: "Failed to queue: database unavailable",
+			}),
+		]);
 	});
 
 	it("budgets durable retries before fresh matches in a configured dry run", async () => {
@@ -615,6 +839,60 @@ describe("shared Plex deletion safety", () => {
 		);
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
 		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("does not recount a pending retry beyond the configured dry-run detail budget", async () => {
+		const { deps } = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			dryRunConfig(1) as never,
+		);
+		const selectedRetry = approvalRecord({
+			id: "retry-selected",
+			status: "retry_pending",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Old media",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+		const deferredRetry = approvalRecord({
+			id: "retry-deferred",
+			arrItemId: 202,
+			status: "retry_pending",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Old media",
+			sizeOnDisk: 1_000n,
+			year: 2020,
+			createdAt: new Date("2026-07-27T12:01:00.000Z"),
+		});
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+			select,
+		}: {
+			where: { status?: string };
+			select?: Record<string, boolean>;
+		}) => {
+			if (where.status !== "retry_pending") return [];
+			return select ? [selectedRetry, deferredRetry] : [selectedRetry];
+		}) as never);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({
+				id: "cache-retry-deferred",
+				arrItemId: 202,
+				title: "Deferred retry target",
+			}),
+		] as never);
+
+		const result = await executeCleanupRun(deps, "user-1");
+
+		expect(result).toMatchObject({
+			itemsEvaluated: 1,
+			itemsFlagged: 1,
+			pendingRetryCount: 2,
+			itemsSkipped: 0,
+		});
+		expect(result.details).toHaveLength(1);
+		expect(result.details[0]?.arrItemId).toBe(101);
 	});
 
 	it("defers an in-flight retry target in a configured dry run", async () => {
@@ -765,6 +1043,48 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
 		expect(targetClient.movie.update).not.toHaveBeenCalled();
+	});
+
+	it("does not count a rule match twice when a durable retry already represents its target", async () => {
+		const { deps } = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			dryRunConfig() as never,
+		);
+		const retry = {
+			...approvalRecord({
+				status: "retry_pending",
+				lastExecutionError: "Radarr was unavailable",
+			}),
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Cleanup",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+		};
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+		}: {
+			where: { status?: string };
+		}) => (where.status === "retry_pending" ? [retry] : [])) as never);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({
+				id: "cache-retry",
+				arrItemId: 101,
+				title: "Example Movie",
+			}),
+		] as never);
+
+		const result = await executeCleanupPreview(deps, "user-1");
+
+		expect(result).toMatchObject({
+			itemsEvaluated: 1,
+			itemsFlagged: 0,
+			pendingRetryCount: 1,
+		});
+		expect(result.details).toHaveLength(1);
+		expect(result.details[0]).toMatchObject({
+			arrItemId: 101,
+			reason: expect.stringContaining("Durable retry pending"),
+		});
 	});
 
 	it("loads Radarr notifications once per instance across multiple safety targets", async () => {
@@ -1560,7 +1880,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -1600,7 +1920,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -1884,7 +2204,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -1931,7 +2251,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -2156,7 +2476,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -2227,7 +2547,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -2450,6 +2770,360 @@ describe("shared Plex deletion safety", () => {
 		expect(deferredResult.warnings).not.toContainEqual(expect.stringContaining("remains pending"));
 		expect(deleteMovieFile).toHaveBeenCalledOnce();
 		expect(deleteMovie).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not let a safety-blocked retry consume the fresh mutation budget", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
+		const retries = configureRetryStore(deps);
+		retries.push({
+			...approvalRecord(),
+			configId: "config-1",
+			status: "retry_pending",
+			executionToken: null,
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Prior delete",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+		const freshItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 102,
+				itemType: "movie",
+				title: "Fresh Movie",
+				year: 2024,
+				monitored: true,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-2",
+				ruleName: "Fresh unmonitor",
+				reason: "Matched fresh rule",
+				action: "unmonitor",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[freshItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(retries[0]).toMatchObject({ status: "retry_pending" });
+		expect(deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith({
+			where: {
+				configId: "config-1",
+				config: { userId: "user-1" },
+				status: "retry_pending",
+			},
+			orderBy: [{ reviewedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
+			take: 1,
+		});
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).toHaveBeenCalledWith(
+			102,
+			expect.objectContaining({ monitored: false }),
+		);
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsFlagged: 2,
+			itemsUnmonitored: 1,
+			itemsSkipped: 1,
+		});
+		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
+	});
+
+	it("fills a freed retry slot from candidates beyond the initial run limit", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
+		const config = {
+			...dryRunConfig(1),
+			dryRunMode: false,
+			rules: [{ ...dryRunConfig(1).rules[0]!, action: "unmonitor" }],
+		};
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(config as never);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({
+				id: "cache-retry-target",
+				arrItemId: 101,
+				title: "Retry target",
+			}),
+			matchingDryRunCacheItem({
+				id: "cache-fresh-target",
+				arrItemId: 102,
+				title: "Fresh target",
+			}),
+		] as never);
+		const retries = configureRetryStore(deps);
+		retries.push({
+			...approvalRecord(),
+			configId: "config-1",
+			status: "retry_pending",
+			executionToken: null,
+			matchedRuleId: "rule-previous",
+			matchedRuleName: "Prior delete",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+
+		const result = await executeCleanupRun(deps, "user-1");
+
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).toHaveBeenCalledWith(
+			102,
+			expect.objectContaining({ monitored: false }),
+		);
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsFlagged: 2,
+			itemsUnmonitored: 1,
+		});
+		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
+	});
+
+	it("does not execute a fresh duplicate of a pending retry outside the run limit", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
+		const retries = configureRetryStore(deps);
+		retries.push(
+			{
+				...approvalRecord(),
+				configId: "config-1",
+				status: "retry_pending",
+				executionToken: null,
+				matchedRuleId: "rule-1",
+				matchedRuleName: "Selected retry",
+				sizeOnDisk: 2_000n,
+				year: 2024,
+				createdAt: new Date("2026-07-27T12:00:00.000Z"),
+			},
+			{
+				...approvalRecord({
+					id: "approval-2",
+					arrItemId: 102,
+					title: "Older pending target",
+				}),
+				configId: "config-1",
+				status: "retry_pending",
+				executionToken: null,
+				matchedRuleId: "rule-2",
+				matchedRuleName: "Unselected retry",
+				sizeOnDisk: 2_000n,
+				year: 2024,
+				createdAt: new Date("2026-07-27T12:01:00.000Z"),
+			},
+		);
+		const pendingTarget = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 102,
+				itemType: "movie",
+				title: "Older pending target",
+				year: 2024,
+				monitored: true,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-2",
+				ruleName: "Fresh unmonitor",
+				reason: "Matched fresh rule",
+				action: "unmonitor",
+			},
+			rating: 8,
+		};
+		const distinctFreshTarget = {
+			...pendingTarget,
+			cacheItem: {
+				...pendingTarget.cacheItem,
+				arrItemId: 103,
+				title: "Distinct fresh target",
+			},
+		};
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[pendingTarget, distinctFreshTarget] as never,
+			2,
+			2,
+			Date.now(),
+		);
+
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).toHaveBeenCalledTimes(1);
+		expect(targetClient.movie.update).toHaveBeenCalledWith(
+			103,
+			expect.objectContaining({ monitored: false }),
+		);
+		expect(retries[1]).toMatchObject({ id: "approval-2", status: "retry_pending" });
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsUnmonitored: 1,
+		});
+	});
+
+	it("counts a partially completed retry against the fresh mutation budget", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+			mediaPartCount: 1,
+		});
+		const retries = configureRetryStore(deps);
+		retries.push({
+			...approvalRecord(),
+			configId: "config-1",
+			status: "retry_pending",
+			executionToken: null,
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Prior delete",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+		deleteMovie.mockRejectedValue(new Error("Radarr movie delete unavailable"));
+		const freshItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 102,
+				itemType: "movie",
+				title: "Fresh Movie",
+				year: 2024,
+				monitored: true,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-2",
+				ruleName: "Fresh unmonitor",
+				reason: "Matched fresh rule",
+				action: "unmonitor",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[freshItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(deleteMovieFile).toHaveBeenCalledOnce();
+		expect(deleteMovie).toHaveBeenCalledTimes(2);
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
+		expect(retries[0]).toMatchObject({
+			status: "retry_pending",
+			safetySnapshot: radarrSafetySnapshot(null),
+		});
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsFlagged: 1,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 1,
+			itemsSkipped: 2,
+		});
+		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
+	});
+
+	it("defers a dispatched failed retry for one run so fresh work can make progress safely", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+			mediaPartCount: 1,
+		});
+		const retries = configureRetryStore(deps);
+		retries.push({
+			...approvalRecord(),
+			configId: "config-1",
+			status: "retry_pending",
+			executionToken: null,
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Prior delete",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+		deleteMovieFile.mockRejectedValue(new Error("Radarr movie-file delete unavailable"));
+		const freshItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 102,
+				itemType: "movie",
+				title: "Fresh Movie",
+				year: 2024,
+				monitored: true,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-2",
+				ruleName: "Fresh unmonitor",
+				reason: "Matched fresh rule",
+				action: "unmonitor",
+			},
+			rating: 8,
+		} as never;
+
+		const firstResult = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[freshItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(deleteMovieFile).toHaveBeenCalledOnce();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
+		expect(firstResult).toMatchObject({
+			status: "partial",
+			itemsFlagged: 1,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 2,
+		});
+		expect(firstResult.warnings).toContainEqual(expect.stringContaining("retry remains"));
+
+		const reviewedAt = retries[0]!.reviewedAt as Date;
+		vi.mocked(deps.prisma.libraryCleanupLog.findFirst).mockResolvedValue({
+			startedAt: new Date(reviewedAt.getTime() - 1),
+		} as never);
+		const secondResult = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[freshItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(deleteMovieFile).toHaveBeenCalledOnce();
+		expect(targetClient.movie.update).toHaveBeenCalledWith(
+			102,
+			expect.objectContaining({ monitored: false }),
+		);
+		expect(retries[0]).toMatchObject({ status: "retry_pending" });
+		expect(secondResult).toMatchObject({
+			status: "partial",
+			itemsFlagged: 2,
+			itemsUnmonitored: 1,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 1,
+		});
+		expect(secondResult.warnings).toContainEqual(expect.stringContaining("deferred for one run"));
 	});
 
 	it("accounts for a durable retry whose post-claim read fails", async () => {
@@ -2871,6 +3545,101 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovie).not.toHaveBeenCalled();
 		expect(storedApproval).toMatchObject({ status: "expired", executionToken: null });
 	});
+
+	it("rechecks the run lease immediately before a fresh direct ARR mutation", async () => {
+		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
+		const retries = configureRetryStore(deps);
+		const assertRunLease = vi
+			.fn()
+			.mockResolvedValueOnce(undefined)
+			.mockRejectedValueOnce(new CleanupRunLeaseLostError());
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Large movie cleanup",
+				reason: "Matched size rule",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		await expect(
+			executeDirectRemoval(
+				deps,
+				{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+				"user-1",
+				[flaggedItem],
+				1,
+				1,
+				Date.now(),
+				undefined,
+				undefined,
+				new Map(),
+				assertRunLease,
+			),
+		).rejects.toBeInstanceOf(CleanupRunLeaseLostError);
+
+		expect(assertRunLease).toHaveBeenCalledTimes(2);
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(retries[0]).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: expect.stringContaining("run lease was lost"),
+		});
+	});
+
+	it.each([0, 101])(
+		"fails closed when the persisted direct cleanup cap is invalid (%i)",
+		async (maxRemovalsPerRun) => {
+			const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
+			const flaggedItem = {
+				cacheItem: {
+					instanceId: "radarr-4k",
+					arrItemId: 101,
+					itemType: "movie",
+					title: "Example Movie",
+					year: 2024,
+					...radarrCachedFileIdentity,
+					sizeOnDisk: 2_000n,
+				},
+				match: {
+					ruleId: "rule-1",
+					ruleName: "Large movie cleanup",
+					reason: "Matched size rule",
+					action: "delete",
+				},
+				rating: 8,
+			} as never;
+
+			const result = await executeDirectRemoval(
+				deps,
+				{ id: "config-1", maxRemovalsPerRun, rules: [] } as never,
+				"user-1",
+				[flaggedItem],
+				1,
+				1,
+				Date.now(),
+			);
+
+			expect(result).toMatchObject({
+				itemsFlagged: 0,
+				itemsRemoved: 0,
+				itemsFilesDeleted: 0,
+				itemsSkipped: 1,
+			});
+			expect(deleteMovieFile).not.toHaveBeenCalled();
+			expect(deleteMovie).not.toHaveBeenCalled();
+		},
+	);
 
 	it("uses a persisted Radarr repoint instead of the instance loaded by the caller", async () => {
 		const { deps, targetInstance, plexInstance, deleteMovie, deleteMovieFile } = makeDeps({
@@ -3369,7 +4138,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -3413,7 +4182,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			flaggedItems,
 			2,
@@ -3482,7 +4251,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1249,7 +1249,7 @@ describe("verified Sonarr mutation handoff", () => {
 			},
 			rating: 8,
 		} as never;
-		const config = { id: "config-1", rules: [] } as never;
+		const config = { id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never;
 
 		const firstResult = await executeDirectRemoval(
 			deps,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -65,6 +65,7 @@ import type {
 	SeerrRequestMap,
 	TautulliWatchMap,
 } from "./types.js";
+import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 
 // Default approval expiry: 7 days
 const APPROVAL_EXPIRY_DAYS = 7;
@@ -96,6 +97,24 @@ export class CleanupRunLeaseLostError extends Error {
 	constructor() {
 		super("The cleanup run lost its database execution lease");
 		this.name = "CleanupRunLeaseLostError";
+	}
+}
+
+export class CleanupTopologyMutationConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor() {
+		super("Service instances cannot be changed while a library cleanup operation is in progress");
+		this.name = "CleanupTopologyMutationConflictError";
+	}
+}
+
+export class CleanupPolicyMutationConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor() {
+		super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
+		this.name = "CleanupPolicyMutationConflictError";
 	}
 }
 
@@ -146,6 +165,81 @@ export async function renewCleanupRunLease(
 		data: { runClaimedAt: now },
 	});
 	return renewal.count === 1;
+}
+
+async function withCleanupMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	conflictError: () => Error,
+	options: { configId?: string; leaseRowMayBeDeleted?: boolean } = {},
+): Promise<T> {
+	return await withCleanupOperationGuard(async () => {
+		const { prisma, log } = deps;
+		// Ensure the per-user coordination row exists when the caller does not
+		// already have its ID. This closes the initialization race between a
+		// cleanup-sensitive write and the first cleanup run.
+		const config = options.configId
+			? { id: options.configId }
+			: await prisma.libraryCleanupConfig.upsert({
+					where: { userId },
+					update: {},
+					create: { userId },
+					select: { id: true },
+				});
+		const runClaimToken = await acquireCleanupRunLease(prisma, userId, config.id);
+		if (!runClaimToken) throw conflictError();
+
+		try {
+			return await mutate();
+		} finally {
+			await releaseCleanupRunLease(prisma, userId, config.id, runClaimToken)
+				.then((released) => {
+					if (!released && !options.leaseRowMayBeDeleted) {
+						log.warn(
+							{ configId: config.id },
+							"Service topology mutation finished after its cleanup lease ownership changed",
+						);
+					}
+				})
+				.catch((error) => {
+					log.error(
+						{ err: error, configId: config.id },
+						"Service topology mutation finished but its cleanup lease could not be released",
+					);
+				});
+		}
+	});
+}
+
+export async function withCleanupTopologyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { leaseRowMayBeDeleted?: boolean } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupTopologyMutationConflictError(),
+		options,
+	);
+}
+
+export async function withCleanupPolicyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { configId?: string } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupPolicyMutationConflictError(),
+		options,
+	);
 }
 
 async function startCleanupRunLease(
@@ -741,13 +835,16 @@ async function loadDurableRetryPreview(
 			config: { userId },
 			status: "retry_executing",
 		} as const;
-		const [retries, count, inFlightRetries] = await Promise.all([
+		const [retries, pendingRetryTargets, inFlightRetries] = await Promise.all([
 			deps.prisma.libraryCleanupApproval.findMany({
 				where: pendingWhere,
 				orderBy: { createdAt: "asc" },
 				take,
 			}),
-			deps.prisma.libraryCleanupApproval.count({ where: pendingWhere }),
+			deps.prisma.libraryCleanupApproval.findMany({
+				where: pendingWhere,
+				select: { instanceId: true, arrItemId: true, itemType: true },
+			}),
 			deps.prisma.libraryCleanupApproval.findMany({
 				where: executingWhere,
 				orderBy: { createdAt: "asc" },
@@ -773,7 +870,10 @@ async function loadDurableRetryPreview(
 				"Deferred: another cleanup run is already executing this durable retry.",
 			),
 		);
-		const total = Math.max(count, retryDetails.length);
+		const total = Math.max(pendingRetryTargets.length, retryDetails.length);
+		const targetKeys = new Set(
+			[...pendingRetryTargets, ...inFlightRetries].map((retry) => cleanupDeleteTargetKey(retry)),
+		);
 		const warningParts = [];
 		if (total > 0) {
 			warningParts.push(
@@ -790,6 +890,7 @@ async function loadDurableRetryPreview(
 		return {
 			retries,
 			inFlightRetries,
+			targetKeys,
 			details: [...inFlightDetails, ...retryDetails],
 			total,
 			loaded: true,
@@ -803,6 +904,7 @@ async function loadDurableRetryPreview(
 		return {
 			retries: [],
 			inFlightRetries: [],
+			targetKeys: new Set<string>(),
 			details: [],
 			total: 0,
 			loaded: false,
@@ -833,6 +935,7 @@ export async function executeCleanupPreview(
 			status: "completed",
 			itemsEvaluated: 0,
 			itemsFlagged: 0,
+			previewItemCount: 0,
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
@@ -850,6 +953,7 @@ export async function executeCleanupPreview(
 			itemsEvaluated: 0,
 			itemsFlagged: 0,
 			pendingRetryCount: retryPreview.total,
+			previewItemCount: retryPreview.targetKeys.size,
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
@@ -865,13 +969,8 @@ export async function executeCleanupPreview(
 		config,
 		config.rules,
 	);
-	const retryTargetKeys = new Set(
-		[...retryPreview.retries, ...retryPreview.inFlightRetries].map((retry) =>
-			cleanupDeleteTargetKey(retry),
-		),
-	);
 	const freshCandidates = flagged.filter(
-		(item) => !retryTargetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
+		(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
 	);
 	const retryDetails = retryPreview.details.slice(0, PREVIEW_SAFETY_INSPECTION_LIMIT);
 	const inspected = selectInspectableCleanupPreviewItems(
@@ -903,7 +1002,8 @@ export async function executeCleanupPreview(
 	log.info(
 		{
 			totalEvaluated,
-			totalFlagged: flagged.length,
+			totalRuleMatches: flagged.length,
+			totalFlagged: freshCandidates.length,
 			pendingRetryCount: retryPreview.total,
 			sharedPlexBlocks: sharedPlexBlocks.size,
 			hasWarnings,
@@ -915,8 +1015,9 @@ export async function executeCleanupPreview(
 		isDryRun: true,
 		status: hasWarnings ? ("partial" as const) : ("completed" as const),
 		itemsEvaluated: totalEvaluated,
-		itemsFlagged: flagged.length,
+		itemsFlagged: freshCandidates.length,
 		pendingRetryCount: retryPreview.total,
+		previewItemCount: retryPreview.targetKeys.size + freshCandidates.length,
 		itemsRemoved: 0,
 		itemsUnmonitored: 0,
 		itemsFilesDeleted: 0,
@@ -939,6 +1040,13 @@ export async function executeCleanupPreview(
  * - Otherwise: Execute actions directly on ARR instances
  */
 export async function executeCleanupRun(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<CleanupRunResult> {
+	return await withCleanupOperationGuard(() => executeCleanupRunGuarded(deps, userId));
+}
+
+async function executeCleanupRunGuarded(
 	deps: CleanupExecutorDeps,
 	userId: string,
 ): Promise<CleanupRunResult> {
@@ -976,13 +1084,8 @@ export async function executeCleanupRun(
 				? config.maxRemovalsPerRun
 				: Number.MAX_SAFE_INTEGER;
 		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id, configuredRunLimit);
-		const retryTargetKeys = new Set(
-			[...retryPreview.retries, ...retryPreview.inFlightRetries].map((retry) =>
-				cleanupDeleteTargetKey(retry),
-			),
-		);
 		const freshCandidates = flagged.filter(
-			(item) => !retryTargetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
+			(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
 		);
 		const freshBudget = retryPreview.loaded
 			? Math.max(0, configuredRunLimit - retryPreview.retries.length)
@@ -1042,10 +1145,34 @@ export async function executeCleanupRun(
 			config,
 			config.rules,
 		);
-		const limited = flagged.slice(0, config.maxRemovalsPerRun);
-
 		// Real execution
 		if (config.requireApproval) {
+			const nonterminalRetryTargets = await prisma.libraryCleanupApproval.findMany({
+				where: {
+					configId: config.id,
+					config: { userId },
+					status: { in: ["retry_pending", "retry_executing"] },
+				},
+				select: {
+					instanceId: true,
+					arrItemId: true,
+					itemType: true,
+				},
+			});
+			const retryTargetKeys = new Set(
+				nonterminalRetryTargets.map((retry) => cleanupDeleteTargetKey(retry)),
+			);
+			const freshCandidates = flagged.filter(
+				(item) => !retryTargetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
+			);
+			const approvalSelection = await selectApprovalCandidatesBeforeLimit(
+				deps,
+				config,
+				userId,
+				freshCandidates,
+				config.maxRemovalsPerRun,
+			);
+			const limited = approvalSelection.selected;
 			const safetyContext = createSharedPlexSafetyContext();
 			const sharedPlexBlocks = await findSharedPlexDeleteBlocks(
 				deps,
@@ -1072,6 +1199,7 @@ export async function executeCleanupRun(
 				allWarnings,
 				sharedPlexBlocks,
 				safetyContext.plans,
+				approvalSelection.skippedDetails,
 			);
 		}
 
@@ -1079,7 +1207,7 @@ export async function executeCleanupRun(
 			deps,
 			config,
 			userId,
-			limited,
+			flagged,
 			totalEvaluated,
 			flagged.length,
 			startTime,
@@ -1098,6 +1226,17 @@ export async function executeCleanupRun(
  * Dispatches on the stored action (delete, unmonitor, delete_files).
  */
 export async function executeApprovedItems(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	approvalIds: string[],
+	approvalRequestToken?: string,
+): Promise<{ removed: number; failed: number; errors: string[] }> {
+	return await withCleanupOperationGuard(() =>
+		executeApprovedItemsGuarded(deps, userId, approvalIds, approvalRequestToken),
+	);
+}
+
+async function executeApprovedItemsGuarded(
 	deps: CleanupExecutorDeps,
 	userId: string,
 	approvalIds: string[],
@@ -1176,6 +1315,14 @@ export async function executeRetryItems(
 	userId: string,
 	retryIds: string[],
 ): Promise<{ removed: number; reconciled: number; failed: number; errors: string[] }> {
+	return await withCleanupOperationGuard(() => executeRetryItemsGuarded(deps, userId, retryIds));
+}
+
+async function executeRetryItemsGuarded(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	retryIds: string[],
+): Promise<{ removed: number; reconciled: number; failed: number; errors: string[] }> {
 	const config = await deps.prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
 		select: { id: true },
@@ -1220,6 +1367,8 @@ interface QueuedCleanupExecutionResult {
 	recordingFailureIds: string[];
 	reconciledIds: string[];
 	unclaimedIds: string[];
+	mutationBudgetConsumedIds: string[];
+	confirmedPartialFileDeletionIds: string[];
 }
 
 async function retryTargetRecordIsAbsent(
@@ -1278,6 +1427,8 @@ async function executeQueuedCleanupItems(
 	const claimedApprovalIds: string[] = [];
 	const claimedApprovalTokens = new Map<string, string>();
 	const mutationAttemptedApprovalIds = new Set<string>();
+	const mutationBudgetConsumedIds = new Set<string>();
+	const confirmedPartialFileDeletionIds = new Set<string>();
 	const unclaimedIds: string[] = [];
 	const claimErrors: string[] = [];
 	for (const approvalId of [...new Set(approvalIds)]) {
@@ -1311,6 +1462,8 @@ async function executeQueuedCleanupItems(
 			recordingFailureIds: [],
 			reconciledIds: [],
 			unclaimedIds,
+			mutationBudgetConsumedIds: [],
+			confirmedPartialFileDeletionIds: [],
 		};
 	}
 
@@ -1563,6 +1716,10 @@ async function executeQueuedCleanupItems(
 					approval.instanceId,
 					safetyPlan!,
 				);
+				const assertMutationAuthority = async () => {
+					await options.assertExecutionAllowed?.();
+					mutationBudgetConsumedIds.add(approval.id);
+				};
 
 				if (retryTargetAlreadyAbsent) {
 					executionCompleted = true;
@@ -1583,7 +1740,13 @@ async function executeQueuedCleanupItems(
 							);
 						});
 				} else if (action === "unmonitor") {
-					await unmonitorInArr(arrClientFactory, mutationInstance, approval.arrItemId, safetyPlan!);
+					await unmonitorInArr(
+						arrClientFactory,
+						mutationInstance,
+						approval.arrItemId,
+						safetyPlan!,
+						assertMutationAuthority,
+					);
 					executionCompleted = true;
 					await prisma.libraryCache
 						.updateMany({
@@ -1606,6 +1769,7 @@ async function executeQueuedCleanupItems(
 						mutationInstance,
 						approval.arrItemId,
 						safetyPlan!,
+						assertMutationAuthority,
 					);
 					executionCompleted = true;
 					reconciledWithoutMutation = !deletedFiles;
@@ -1626,7 +1790,13 @@ async function executeQueuedCleanupItems(
 							);
 						});
 				} else {
-					await deleteFromArr(arrClientFactory, mutationInstance, approval.arrItemId, safetyPlan!);
+					await deleteFromArr(
+						arrClientFactory,
+						mutationInstance,
+						approval.arrItemId,
+						safetyPlan!,
+						assertMutationAuthority,
+					);
 					executionCompleted = true;
 					await reconcileSonarrEpisodeFileCache(prisma, mutationInstance, approval.arrItemId, log);
 					await prisma.libraryCache
@@ -1742,6 +1912,9 @@ async function executeQueuedCleanupItems(
 					error instanceof ArrDeletePartialError
 						? buildPostPartialRetrySnapshot(safetyPlan, error)
 						: undefined;
+				if (error instanceof ArrDeletePartialError && error.deletedFileIds.length > 0) {
+					confirmedPartialFileDeletionIds.add(approval.id);
+				}
 				log.error(
 					{ err: error, title: approval.title, instanceId: approval.instanceId },
 					"Failed to execute approved cleanup item",
@@ -1812,6 +1985,8 @@ async function executeQueuedCleanupItems(
 			recordingFailureIds,
 			reconciledIds,
 			unclaimedIds,
+			mutationBudgetConsumedIds: [...mutationBudgetConsumedIds],
+			confirmedPartialFileDeletionIds: [...confirmedPartialFileDeletionIds],
 		};
 	} finally {
 		for (const [approvalId, executionToken] of claimedApprovalTokens) {
@@ -2679,6 +2854,107 @@ function getRuleDataSources(rule: LibraryCleanupRule): Set<DataSourceDependency>
 	return sources;
 }
 
+function buildApprovalDedupSkipReason(
+	status: string,
+	memWindow: RejectionMemoryWindow,
+): string | undefined {
+	if (status !== "rejected") return undefined;
+	if (memWindow.mode === "forever") {
+		return "Previously rejected — rejection memory: forever";
+	}
+	if (memWindow.mode === "days") {
+		return `Previously rejected — rejection memory: ${memWindow.days} day${memWindow.days === 1 ? "" : "s"}`;
+	}
+	return undefined;
+}
+
+async function selectApprovalCandidatesBeforeLimit(
+	deps: CleanupExecutorDeps,
+	config: LibraryCleanupConfig & { rules: LibraryCleanupRule[] },
+	userId: string,
+	flagged: FlaggedItem[],
+	limit: number,
+): Promise<{
+	selected: FlaggedItem[];
+	skippedDetails: CleanupRunResult["details"];
+}> {
+	const memoryByRuleId = new Map<string, RejectionMemoryWindow>();
+	for (const rule of config.rules) {
+		memoryByRuleId.set(rule.id, resolveRejectionMemoryWindow(rule, config));
+	}
+
+	const remembersForever = [...memoryByRuleId.values()].some((window) => window.mode === "forever");
+	const maxRememberedDays = Math.max(
+		0,
+		...[...memoryByRuleId.values()]
+			.filter((window): window is Extract<RejectionMemoryWindow, { mode: "days" }> => {
+				return window.mode === "days";
+			})
+			.map((window) => window.days),
+	);
+	const now = new Date();
+	const approvalDedupRows = await deps.prisma.libraryCleanupApproval.findMany({
+		where: {
+			configId: config.id,
+			config: { userId },
+			OR: [
+				{ status: "pending" },
+				...(remembersForever
+					? [{ status: "rejected" }]
+					: maxRememberedDays > 0
+						? [
+								{
+									status: "rejected",
+									reviewedAt: {
+										gt: new Date(now.getTime() - maxRememberedDays * 24 * 60 * 60 * 1000),
+									},
+								},
+							]
+						: []),
+			],
+		},
+		select: {
+			instanceId: true,
+			arrItemId: true,
+			itemType: true,
+			status: true,
+			reviewedAt: true,
+		},
+	});
+	const approvalDedupRowsByTarget = new Map<string, typeof approvalDedupRows>();
+	for (const row of approvalDedupRows) {
+		const targetKey = cleanupDeleteTargetKey(row);
+		const rows = approvalDedupRowsByTarget.get(targetKey);
+		if (rows) rows.push(row);
+		else approvalDedupRowsByTarget.set(targetKey, [row]);
+	}
+
+	const selected: FlaggedItem[] = [];
+	const skippedDetails: CleanupRunResult["details"] = [];
+	for (const item of flagged) {
+		if (selected.length >= limit) break;
+		const memWindow = memoryByRuleId.get(item.match.ruleId) ?? { mode: "off" as const };
+		const targetRows = approvalDedupRowsByTarget.get(cleanupDeleteTargetKey(item.cacheItem)) ?? [];
+		const existing = targetRows.find((row) => {
+			if (row.status === "pending") return true;
+			if (row.status !== "rejected") return false;
+			if (memWindow.mode === "forever") return true;
+			if (memWindow.mode === "days" && row.reviewedAt) {
+				return row.reviewedAt > new Date(now.getTime() - memWindow.days * 24 * 60 * 60 * 1000);
+			}
+			return false;
+		});
+		if (existing) {
+			skippedDetails.push(
+				buildDetail(item, "skipped", buildApprovalDedupSkipReason(existing.status, memWindow)),
+			);
+			continue;
+		}
+		selected.push(item);
+	}
+	return { selected, skippedDetails };
+}
+
 /**
  * Create approval queue entries for flagged items.
  * Stores the action from each rule match on the approval record.
@@ -2694,13 +2970,16 @@ async function executeWithApproval(
 	warnings?: string[],
 	sharedPlexBlocks: Map<string, string> = new Map(),
 	safetyPlans: Map<string, SharedMediaSafetyPlan> = new Map(),
+	preSkippedDetails: CleanupRunResult["details"] = [],
 ): Promise<CleanupRunResult> {
 	const { prisma, log } = deps;
 	const now = new Date();
 	const expiresAt = new Date(now.getTime() + APPROVAL_EXPIRY_DAYS * 24 * 60 * 60 * 1000);
 
-	const details: CleanupRunResult["details"] = [];
+	const details: CleanupRunResult["details"] = [...preSkippedDetails];
 	let queued = 0;
+	let approvalDedupSkipped = 0;
+	let approvalQueueFailures = 0;
 
 	// Precompute rejection-memory window per rule once. The window is the same
 	// for every flagged item that matched the same rule, so resolving once
@@ -2732,6 +3011,7 @@ async function executeWithApproval(
 			const existing = await prisma.libraryCleanupApproval.findFirst({
 				where: {
 					configId: config.id,
+					config: { userId: config.userId },
 					instanceId: item.cacheItem.instanceId,
 					arrItemId: item.cacheItem.arrItemId,
 					itemType: item.cacheItem.itemType,
@@ -2740,15 +3020,10 @@ async function executeWithApproval(
 			});
 
 			if (existing) {
-				const skipReason =
-					existing.status === "rejected"
-						? memWindow.mode === "forever"
-							? "Previously rejected — rejection memory: forever"
-							: memWindow.mode === "days"
-								? `Previously rejected — rejection memory: ${memWindow.days} day${memWindow.days === 1 ? "" : "s"}`
-								: undefined
-						: undefined;
-				details.push(buildDetail(item, "skipped", skipReason));
+				details.push(
+					buildDetail(item, "skipped", buildApprovalDedupSkipReason(existing.status, memWindow)),
+				);
+				approvalDedupSkipped++;
 				continue;
 			}
 
@@ -2785,19 +3060,25 @@ async function executeWithApproval(
 				"Failed to create cleanup approval entry",
 			);
 			details.push(buildDetail(item, "skipped", `Failed to queue: ${getErrorMessage(error)}`));
+			approvalQueueFailures++;
 		}
 	}
 
 	const hasFailedPrefetch = warnings && warnings.length > 0;
 	const result: CleanupRunResult = {
 		isDryRun: false,
-		status: hasFailedPrefetch ? "partial" : "completed",
+		status: hasFailedPrefetch || approvalQueueFailures > 0 ? "partial" : "completed",
 		itemsEvaluated: totalEvaluated,
 		itemsFlagged: queued,
 		itemsRemoved: 0,
 		itemsUnmonitored: 0,
 		itemsFilesDeleted: 0,
-		itemsSkipped: totalFlaggedBeforeLimit - flagged.length + sharedPlexBlocks.size,
+		itemsSkipped:
+			totalFlaggedBeforeLimit -
+			flagged.length +
+			sharedPlexBlocks.size +
+			approvalDedupSkipped +
+			approvalQueueFailures,
 		details,
 		durationMs: Date.now() - startTime,
 		prefetchHealth,
@@ -2846,28 +3127,63 @@ export async function executeDirectRemoval(
 	let directRetryExecutionFailures = 0;
 	let directRetryPersistenceFailures = 0;
 	let directRetryReconciled = 0;
+	let directRetryFairnessDeferred = 0;
 	let retriedRemoved = 0;
 	let retriedUnmonitored = 0;
 	let retriedFilesDeleted = 0;
 	let directRetryCount = 0;
+	let directRetryMutationBudgetConsumed = 0;
 	const sharedPlexSafetyContext = createSharedPlexSafetyContext();
 	const directRetryTargetKeys = new Set<string>();
 	const selectedDirectRetryTargetKeys = new Set<string>();
 	const inFlightDirectRetryTargetKeys = new Set<string>();
 	const configuredRunLimit =
-		Number.isSafeInteger(config.maxRemovalsPerRun) && config.maxRemovalsPerRun > 0
+		Number.isSafeInteger(config.maxRemovalsPerRun) &&
+		config.maxRemovalsPerRun > 0 &&
+		config.maxRemovalsPerRun <= 100
 			? config.maxRemovalsPerRun
-			: Number.MAX_SAFE_INTEGER;
+			: 0;
 
 	let directRetries: Awaited<ReturnType<typeof prisma.libraryCleanupApproval.findMany>> = [];
+	let fairnessDeferredRetries: typeof directRetries = [];
+	let previousRunStartedAt: Date | undefined;
 	try {
+		const previousRun = await prisma.libraryCleanupLog.findFirst({
+			where: {
+				configId: config.id,
+				isDryRun: false,
+				completedAt: { not: null },
+			},
+			orderBy: { startedAt: "desc" },
+			select: { startedAt: true },
+		});
+		previousRunStartedAt = previousRun?.startedAt;
+	} catch (error) {
+		log.warn(
+			{ err: error, configId: config.id },
+			"Cleanup could not load its prior run boundary for retry fairness",
+		);
+	}
+	try {
+		const nonterminalRetryTargets = await prisma.libraryCleanupApproval.findMany({
+			where: {
+				configId: config.id,
+				config: { userId },
+				status: { in: ["retry_pending", "retry_executing"] },
+			},
+			select: {
+				instanceId: true,
+				arrItemId: true,
+				itemType: true,
+			},
+		});
 		const loadedDirectRetries = await prisma.libraryCleanupApproval.findMany({
 			where: {
 				configId: config.id,
 				config: { userId },
 				status: "retry_pending",
 			},
-			orderBy: { createdAt: "asc" },
+			orderBy: [{ reviewedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
 			take: configuredRunLimit,
 		});
 		const executingDirectRetries = await prisma.libraryCleanupApproval.findMany({
@@ -2882,16 +3198,41 @@ export async function executeDirectRemoval(
 			directRetryTargetKeys.add(targetKey);
 			inFlightDirectRetryTargetKeys.add(targetKey);
 		}
-		directRetries = loadedDirectRetries;
-		directRetryCount = directRetries.length;
+		for (const retry of loadedDirectRetries) {
+			directRetryTargetKeys.add(cleanupDeleteTargetKey(retry));
+		}
+		for (const retryTarget of nonterminalRetryTargets) {
+			directRetryTargetKeys.add(cleanupDeleteTargetKey(retryTarget));
+		}
+		const hasDistinctFreshCandidate = flagged.some(
+			(item) => !directRetryTargetKeys.has(cleanupDeleteTargetKey(item.cacheItem)),
+		);
+		if (previousRunStartedAt && hasDistinctFreshCandidate) {
+			fairnessDeferredRetries = loadedDirectRetries.filter(
+				(retry) => retry.reviewedAt && retry.reviewedAt >= previousRunStartedAt,
+			);
+		}
+		const fairnessDeferredIds = new Set(fairnessDeferredRetries.map((retry) => retry.id));
+		directRetries = loadedDirectRetries.filter((retry) => !fairnessDeferredIds.has(retry.id));
+		directRetryFairnessDeferred = fairnessDeferredRetries.length;
+		directRetryCount = loadedDirectRetries.length;
 	} catch (error) {
 		directRetryLoadFailures++;
 		log.error({ err: error, configId: config.id }, "Cleanup could not load durable ARR retries");
 	}
 
+	for (const retry of fairnessDeferredRetries) {
+		details.push(
+			buildRetryDetail(
+				retry,
+				"skipped",
+				"Deferred for one run after its previous attempt so fresh cleanup work can make progress",
+			),
+		);
+	}
+
 	for (const retry of directRetries) {
 		const targetKey = cleanupDeleteTargetKey(retry);
-		directRetryTargetKeys.add(targetKey);
 		selectedDirectRetryTargetKeys.add(targetKey);
 		try {
 			const retryResult = await executeQueuedCleanupItems(deps, userId, [retry.id], {
@@ -2901,6 +3242,9 @@ export async function executeDirectRemoval(
 				enforceExpiry: false,
 				assertExecutionAllowed: assertRunLease,
 			});
+			if (retryResult.mutationBudgetConsumedIds.includes(retry.id)) {
+				directRetryMutationBudgetConsumed++;
+			}
 			if (retryResult.unclaimedIds.includes(retry.id)) {
 				directRetryConcurrent++;
 				details.push(
@@ -2972,6 +3316,18 @@ export async function executeDirectRemoval(
 					retriedRemoved++;
 					details.push(buildRetryDetail(retry, "removed", recordingFailureReason));
 				}
+			} else if (retryResult.confirmedPartialFileDeletionIds.includes(retry.id)) {
+				directRetryFailures++;
+				filesDeleted++;
+				retriedFilesDeleted++;
+				details.push(
+					buildRetryDetail(
+						retry,
+						"files_deleted",
+						retryResult.errors[0] ??
+							"Verified ARR files were deleted, but the remaining cleanup mutation is still pending.",
+					),
+				);
 			} else {
 				directRetryFailures++;
 				details.push(
@@ -3019,7 +3375,11 @@ export async function executeDirectRemoval(
 			),
 		);
 	}
-	const freshBudget = Math.max(0, configuredRunLimit - directRetryCount);
+	// Only retries that reached an ARR write consume the current run budget.
+	// Successful, partial, and indeterminate writes all count because ARR may
+	// have changed. reviewedAt plus the prior run boundary defers a just-tried
+	// retry for one later run when distinct fresh work exists.
+	const freshBudget = Math.max(0, configuredRunLimit - directRetryMutationBudgetConsumed);
 	const freshItems = freshCandidates.slice(0, freshBudget);
 	const budgetDeferredItems = freshCandidates.length - freshItems.length;
 
@@ -3217,6 +3577,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
+					assertRunLease,
 				);
 				try {
 					await prisma.libraryCache.updateMany({
@@ -3246,6 +3607,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
+					assertRunLease,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,
@@ -3292,6 +3654,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
+					assertRunLease,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,
@@ -3533,6 +3896,13 @@ export async function executeDirectRemoval(
 			} deferred because another cleanup run claimed it first.`,
 		);
 	}
+	if (directRetryFairnessDeferred > 0) {
+		allWarnings.push(
+			`${directRetryFairnessDeferred} durable record-only cleanup ${
+				directRetryFairnessDeferred === 1 ? "retry was" : "retries were"
+			} deferred for one run so distinct fresh cleanup work could make progress.`,
+		);
+	}
 	if (directIntentConcurrent > 0) {
 		allWarnings.push(
 			`${directIntentConcurrent} fresh cleanup ${
@@ -3601,6 +3971,7 @@ export async function executeDirectRemoval(
 			flagged.length +
 			budgetDeferredItems +
 			inFlightDeferredItems.length +
+			directRetryFairnessDeferred +
 			(directlyEvaluated - directRemoved - directUnmonitored - directFilesDeleted) +
 			accountedUnsuccessfulRetries +
 			directRetryReconciled,
@@ -3682,10 +4053,12 @@ async function deleteVerifiedRadarrFile(
 	arrItemId: number,
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>["target"],
 	expected: VerifiedRadarrFileIdentity,
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<void> {
 	await assertVerifiedRadarrFileUnchanged(radarr, arrItemId, expectedTarget, expected);
 	let deleteError: unknown;
 	try {
+		await assertMutationAuthority?.();
 		await radarr.movieFile.delete(expected.movieFileId);
 	} catch (error) {
 		deleteError = error;
@@ -3730,6 +4103,7 @@ async function deleteRadarrRecordWithoutFiles(
 		{ kind: "verified_radarr_empty" }
 	>["target"],
 	deletedFileIds: number[],
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<void> {
 	let lastDeleteError: unknown;
 	for (let attempt = 0; attempt < 2; attempt++) {
@@ -3758,12 +4132,24 @@ async function deleteRadarrRecordWithoutFiles(
 		}
 
 		try {
+			await assertMutationAuthority?.();
 			await radarr.movie.delete(arrItemId, {
 				deleteFiles: false,
 				addImportExclusion: false,
 			});
 			return;
 		} catch (error) {
+			if (error instanceof CleanupRunLeaseLostError) {
+				if (deletedFileIds.length === 0) throw error;
+				throw new ArrDeletePartialError({
+					cause: error,
+					service: "RADARR",
+					deletedFileIds,
+					hasRemainingFiles: false,
+					message:
+						"Partial cleanup: the verified Radarr movie file was deleted, but execution authority was lost before the movie record could be removed.",
+				});
+			}
 			lastDeleteError = error;
 			try {
 				await radarr.movie.getById(arrItemId);
@@ -3795,6 +4181,7 @@ async function deleteVerifiedSonarrFiles(
 	arrItemId: number,
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>["target"],
 	expected: VerifiedSonarrFileIdentity,
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<number[]> {
 	await assertVerifiedSonarrFilesUnchanged(sonarr, arrItemId, expectedTarget, expected);
 	const expectedIds = expected.episodeFiles.map((file) => file.episodeFileId);
@@ -3802,6 +4189,7 @@ async function deleteVerifiedSonarrFiles(
 
 	let bulkError: unknown;
 	try {
+		await assertMutationAuthority?.();
 		await sonarr.episodeFile.bulkDelete(expectedIds);
 	} catch (error) {
 		bulkError = error;
@@ -3864,6 +4252,7 @@ async function deleteSonarrRecordWithoutFiles(
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>["target"],
 	expected: VerifiedSonarrFileIdentity,
 	deletedFileIds: number[],
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<void> {
 	let lastDeleteError: unknown;
 	const emptyExpected: VerifiedSonarrFileIdentity = {
@@ -3906,12 +4295,24 @@ async function deleteSonarrRecordWithoutFiles(
 		}
 
 		try {
+			await assertMutationAuthority?.();
 			await sonarr.series.delete(arrItemId, {
 				deleteFiles: false,
 				addImportListExclusion: false,
 			});
 			return;
 		} catch (error) {
+			if (error instanceof CleanupRunLeaseLostError) {
+				if (deletedFileIds.length === 0) throw error;
+				throw new ArrDeletePartialError({
+					cause: error,
+					service: "SONARR",
+					deletedFileIds,
+					hasRemainingFiles: false,
+					message:
+						"Partial cleanup: the verified Sonarr episode files were deleted, but execution authority was lost before the series record could be removed.",
+				});
+			}
 			lastDeleteError = error;
 			try {
 				await sonarr.series.getById(arrItemId);
@@ -4013,6 +4414,7 @@ async function deleteFromArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<void> {
 	const client = arrClientFactory.create(instance);
 
@@ -4024,12 +4426,28 @@ async function deleteFromArr(
 				throw new Error("Sonarr safety plan cannot authorize a Radarr mutation");
 			}
 			if (safetyPlan.kind === "verified_radarr") {
-				await deleteVerifiedRadarrFile(radarr, arrItemId, safetyPlan.target, safetyPlan.file);
-				await deleteRadarrRecordWithoutFiles(radarr, arrItemId, safetyPlan.target, [
-					safetyPlan.file.movieFileId,
-				]);
+				await deleteVerifiedRadarrFile(
+					radarr,
+					arrItemId,
+					safetyPlan.target,
+					safetyPlan.file,
+					assertMutationAuthority,
+				);
+				await deleteRadarrRecordWithoutFiles(
+					radarr,
+					arrItemId,
+					safetyPlan.target,
+					[safetyPlan.file.movieFileId],
+					assertMutationAuthority,
+				);
 			} else if (safetyPlan.kind === "verified_radarr_empty") {
-				await deleteRadarrRecordWithoutFiles(radarr, arrItemId, safetyPlan.target, []);
+				await deleteRadarrRecordWithoutFiles(
+					radarr,
+					arrItemId,
+					safetyPlan.target,
+					[],
+					assertMutationAuthority,
+				);
 			} else if (safetyPlan.kind === "not_required" || safetyPlan.kind === "verified_arr_target") {
 				throw new Error("A verified Radarr file identity is required for deletion");
 			} else {
@@ -4050,6 +4468,7 @@ async function deleteFromArr(
 					arrItemId,
 					safetyPlan.target,
 					safetyPlan.files,
+					assertMutationAuthority,
 				);
 				await deleteSonarrRecordWithoutFiles(
 					sonarr,
@@ -4057,6 +4476,7 @@ async function deleteFromArr(
 					safetyPlan.target,
 					safetyPlan.files,
 					deletedFileIds,
+					assertMutationAuthority,
 				);
 			} else if (safetyPlan.kind === "not_required" || safetyPlan.kind === "verified_arr_target") {
 				throw new Error("A verified Sonarr file identity is required for deletion");
@@ -4080,6 +4500,7 @@ async function unmonitorInArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<void> {
 	if (safetyPlan.kind !== "verified_arr_target") {
 		throw new Error("A verified ARR target identity is required before unmonitoring");
@@ -4091,6 +4512,7 @@ async function unmonitorInArr(
 			const radarr = client as InstanceType<typeof RadarrClient>;
 			const movie = await radarr.movie.getById(arrItemId);
 			assertVerifiedArrTargetUnchanged(instance, movie.tmdbId, movie.path, safetyPlan.target);
+			await assertMutationAuthority?.();
 			await radarr.movie.update(arrItemId, { ...movie, id: arrItemId, monitored: false });
 			break;
 		}
@@ -4098,6 +4520,7 @@ async function unmonitorInArr(
 			const sonarr = client as InstanceType<typeof SonarrClient>;
 			const series = await sonarr.series.getById(arrItemId);
 			assertVerifiedArrTargetUnchanged(instance, series.tvdbId, series.path, safetyPlan.target);
+			await assertMutationAuthority?.();
 			await sonarr.series.update(arrItemId, {
 				...series,
 				id: arrItemId,
@@ -4119,6 +4542,7 @@ async function deleteFilesFromArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
+	assertMutationAuthority?: () => Promise<void>,
 ): Promise<boolean> {
 	const client = arrClientFactory.create(instance);
 
@@ -4130,7 +4554,13 @@ async function deleteFilesFromArr(
 				throw new Error("Sonarr safety plan cannot authorize a Radarr mutation");
 			}
 			if (safetyPlan.kind === "verified_radarr") {
-				await deleteVerifiedRadarrFile(radarr, arrItemId, safetyPlan.target, safetyPlan.file);
+				await deleteVerifiedRadarrFile(
+					radarr,
+					arrItemId,
+					safetyPlan.target,
+					safetyPlan.file,
+					assertMutationAuthority,
+				);
 				return true;
 			}
 			if (safetyPlan.kind === "verified_radarr_empty") {
@@ -4150,7 +4580,13 @@ async function deleteFilesFromArr(
 				throw new Error("Radarr safety plan cannot authorize a Sonarr mutation");
 			}
 			if (safetyPlan.kind === "verified_sonarr") {
-				await deleteVerifiedSonarrFiles(sonarr, arrItemId, safetyPlan.target, safetyPlan.files);
+				await deleteVerifiedSonarrFiles(
+					sonarr,
+					arrItemId,
+					safetyPlan.target,
+					safetyPlan.files,
+					assertMutationAuthority,
+				);
 				return safetyPlan.files.episodeFiles.length > 0;
 			}
 			if (safetyPlan.kind === "not_required" || safetyPlan.kind === "verified_arr_target") {

--- a/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-maintenance-gate.ts
@@ -1,0 +1,54 @@
+/**
+ * In-process reader/writer gate around cleanup-sensitive mutations.
+ *
+ * The API runtime lease guarantees one live API process per database. That
+ * lets this gate live outside the application tables that backup restore
+ * replaces: cleanup runs and topology writes are shared readers, while a
+ * database restore is the exclusive writer.
+ */
+
+let activeCleanupOperations = 0;
+let maintenanceActive = false;
+
+export class CleanupMaintenanceConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor(message = "Database maintenance cannot overlap a library cleanup operation") {
+		super(message);
+		this.name = "CleanupMaintenanceConflictError";
+	}
+}
+
+export async function withCleanupOperationGuard<T>(operation: () => Promise<T>): Promise<T> {
+	if (maintenanceActive) {
+		throw new CleanupMaintenanceConflictError(
+			"Library cleanup and service changes are unavailable while database maintenance is running",
+		);
+	}
+	activeCleanupOperations += 1;
+	try {
+		return await operation();
+	} finally {
+		activeCleanupOperations -= 1;
+	}
+}
+
+export async function withCleanupMaintenanceGuard<T>(
+	maintenance: () => Promise<T>,
+	options: { holdAfterSuccess?: boolean } = {},
+): Promise<T> {
+	if (maintenanceActive || activeCleanupOperations > 0) {
+		throw new CleanupMaintenanceConflictError();
+	}
+	maintenanceActive = true;
+	let completed = false;
+	try {
+		const result = await maintenance();
+		completed = true;
+		return result;
+	} finally {
+		if (!completed || !options.holdAfterSuccess) {
+			maintenanceActive = false;
+		}
+	}
+}

--- a/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
@@ -24,6 +24,10 @@ import {
 	executeCleanupRun,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
 } from "./cleanup-executor.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "./cleanup-maintenance-gate.js";
 import type { CleanupRunResult } from "./types.js";
 
 const CHECK_INTERVAL_MS = 60 * 1000; // Check every minute
@@ -139,6 +143,22 @@ export class CleanupScheduler {
 		}
 	}
 
+	private async sendNotification(
+		payload: NotificationPayload,
+		failureMessage: string,
+	): Promise<void> {
+		if (!this.notifyFn) return;
+		try {
+			await withCleanupOperationGuard(() => this.notifyFn!(payload));
+		} catch (error) {
+			if (error instanceof CleanupMaintenanceConflictError) {
+				this.logger.debug("Database maintenance skipped a library-cleanup notification");
+				return;
+			}
+			this.logger.warn({ err: error }, failureMessage);
+		}
+	}
+
 	/**
 	 * Check if a cleanup run should execute and run it.
 	 */
@@ -149,181 +169,186 @@ export class CleanupScheduler {
 		}
 
 		try {
-			// Expire stale pending approvals
-			await this.prisma.libraryCleanupApproval
-				.updateMany({
-					where: { status: "pending", expiresAt: { lt: new Date() } },
-					data: { status: "expired" },
-				})
-				.catch((err) => {
-					this.logger.warn({ err }, "Failed to expire stale approvals");
-				});
+			await withCleanupOperationGuard(async () => {
+				// Expire stale pending approvals
+				await this.prisma.libraryCleanupApproval
+					.updateMany({
+						where: { status: "pending", expiresAt: { lt: new Date() } },
+						data: { status: "expired" },
+					})
+					.catch((err) => {
+						this.logger.warn({ err }, "Failed to expire stale approvals");
+					});
 
-			// Recover stuck "executing" items (crash recovery: >1 hour since approval).
-			// The persisted safety snapshot is reconciled against the live file
-			// remainder when the operator approves it again.
-			const stuckThreshold = new Date(Date.now() - 60 * 60 * 1000);
-			const staleRunLeaseThreshold = new Date(Date.now() - CLEANUP_RUN_LEASE_MS);
-			await this.prisma.libraryCleanupApproval
-				.updateMany({
-					where: {
-						status: "approved",
-						reviewedAt: { lt: stuckThreshold },
-						config: {
-							OR: [
-								{ runClaimToken: null },
-								{ runClaimedAt: null },
-								{ runClaimedAt: { lt: staleRunLeaseThreshold } },
-							],
+				// Recover stuck "executing" items (crash recovery: >1 hour since approval).
+				// The persisted safety snapshot is reconciled against the live file
+				// remainder when the operator approves it again.
+				const stuckThreshold = new Date(Date.now() - 60 * 60 * 1000);
+				const staleRunLeaseThreshold = new Date(Date.now() - CLEANUP_RUN_LEASE_MS);
+				await this.prisma.libraryCleanupApproval
+					.updateMany({
+						where: {
+							status: "approved",
+							reviewedAt: { lt: stuckThreshold },
+							config: {
+								OR: [
+									{ runClaimToken: null },
+									{ runClaimedAt: null },
+									{ runClaimedAt: { lt: staleRunLeaseThreshold } },
+								],
+							},
 						},
-					},
-					data: {
-						status: "pending",
-						executionToken: null,
-						lastExecutionError:
-							"Recovered an interrupted approval request. Review and approve again.",
-					},
-				})
-				.then((result) => {
-					if (result.count > 0) {
-						this.logger.warn(
-							{ recoveredCount: result.count },
-							"Recovered stuck approved cleanup items — returned them to pending review",
-						);
-					}
-				})
-				.catch((err) => {
-					this.logger.warn({ err }, "Failed to recover stuck approved cleanup items");
-				});
-			await this.prisma.libraryCleanupApproval
-				.updateMany({
-					where: {
-						status: "executing",
-						reviewedAt: { lt: stuckThreshold },
-						config: {
-							OR: [
-								{ runClaimToken: null },
-								{ runClaimedAt: null },
-								{ runClaimedAt: { lt: staleRunLeaseThreshold } },
-							],
+						data: {
+							status: "pending",
+							executionToken: null,
+							lastExecutionError:
+								"Recovered an interrupted approval request. Review and approve again.",
 						},
-					},
-					data: {
-						status: "pending",
-						executionToken: null,
-						lastExecutionError: INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
-					},
-				})
-				.then((result) => {
-					if (result.count > 0) {
-						this.logger.warn(
-							{ recoveredCount: result.count },
-							"Recovered stuck executing approval items — returned them to pending review",
-						);
-					}
-				})
-				.catch((err) => {
-					this.logger.warn({ err }, "Failed to recover stuck executing approvals");
-				});
-			await this.prisma.libraryCleanupApproval
-				.updateMany({
-					where: {
-						status: "retry_executing",
-						reviewedAt: { lt: stuckThreshold },
-						config: {
-							OR: [
-								{ runClaimToken: null },
-								{ runClaimedAt: null },
-								{ runClaimedAt: { lt: staleRunLeaseThreshold } },
-							],
+					})
+					.then((result) => {
+						if (result.count > 0) {
+							this.logger.warn(
+								{ recoveredCount: result.count },
+								"Recovered stuck approved cleanup items — returned them to pending review",
+							);
+						}
+					})
+					.catch((err) => {
+						this.logger.warn({ err }, "Failed to recover stuck approved cleanup items");
+					});
+				await this.prisma.libraryCleanupApproval
+					.updateMany({
+						where: {
+							status: "executing",
+							reviewedAt: { lt: stuckThreshold },
+							config: {
+								OR: [
+									{ runClaimToken: null },
+									{ runClaimedAt: null },
+									{ runClaimedAt: { lt: staleRunLeaseThreshold } },
+								],
+							},
 						},
-					},
-					data: { status: "retry_pending", executionToken: null },
-				})
-				.then((result) => {
-					if (result.count > 0) {
-						this.logger.warn(
-							{ recoveredCount: result.count },
-							"Recovered stuck record-only cleanup retries — returned them to retry pending",
-						);
-					}
-				})
-				.catch((err) => {
-					this.logger.warn({ err }, "Failed to recover stuck record-only cleanup retries");
+						data: {
+							status: "pending",
+							executionToken: null,
+							lastExecutionError: INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+						},
+					})
+					.then((result) => {
+						if (result.count > 0) {
+							this.logger.warn(
+								{ recoveredCount: result.count },
+								"Recovered stuck executing approval items — returned them to pending review",
+							);
+						}
+					})
+					.catch((err) => {
+						this.logger.warn({ err }, "Failed to recover stuck executing approvals");
+					});
+				await this.prisma.libraryCleanupApproval
+					.updateMany({
+						where: {
+							status: "retry_executing",
+							reviewedAt: { lt: stuckThreshold },
+							config: {
+								OR: [
+									{ runClaimToken: null },
+									{ runClaimedAt: null },
+									{ runClaimedAt: { lt: staleRunLeaseThreshold } },
+								],
+							},
+						},
+						data: { status: "retry_pending", executionToken: null },
+					})
+					.then((result) => {
+						if (result.count > 0) {
+							this.logger.warn(
+								{ recoveredCount: result.count },
+								"Recovered stuck record-only cleanup retries — returned them to retry pending",
+							);
+						}
+					})
+					.catch((err) => {
+						this.logger.warn({ err }, "Failed to recover stuck record-only cleanup retries");
+					});
+
+				// Find any user's config that is enabled and due for a run.
+				// (Single-admin app, so there's at most one config.)
+				const config = await this.prisma.libraryCleanupConfig.findFirst({
+					where: { enabled: true },
 				});
 
-			// Find any user's config that is enabled and due for a run.
-			// (Single-admin app, so there's at most one config.)
-			const config = await this.prisma.libraryCleanupConfig.findFirst({
-				where: { enabled: true },
-			});
+				if (!config) return;
 
-			if (!config) return;
+				const now = new Date();
+				if (!config.nextRunAt || config.nextRunAt > now) return;
 
-			const now = new Date();
-			if (!config.nextRunAt || config.nextRunAt > now) return;
-
-			this._isRunning = true;
-
-			this.logger.info(
-				{ intervalHours: config.intervalHours, dryRunMode: config.dryRunMode },
-				"Running scheduled library cleanup",
-			);
-
-			try {
-				const result = await executeCleanupRun(
-					{
-						prisma: this.prisma,
-						arrClientFactory: this.arrClientFactory,
-						encryptor: this.encryptor,
-						log: this.logger,
-					},
-					config.userId,
-				);
-
-				// Calculate next run time
-				const nextRunAt = new Date(now.getTime() + config.intervalHours * 60 * 60 * 1000);
-
-				await this.prisma.libraryCleanupConfig.update({
-					where: { id: config.id },
-					data: { lastRunAt: now, nextRunAt },
-				});
+				this._isRunning = true;
 
 				this.logger.info(
-					{
-						itemsEvaluated: result.itemsEvaluated,
-						itemsFlagged: result.itemsFlagged,
-						itemsRemoved: result.itemsRemoved,
-						nextRunAt: nextRunAt.toISOString(),
-					},
-					"Scheduled library cleanup completed",
+					{ intervalHours: config.intervalHours, dryRunMode: config.dryRunMode },
+					"Running scheduled library cleanup",
 				);
 
-				const notification = buildCleanupNotification(result);
-				if (notification) {
-					this.notifyFn?.(notification).catch((err) => {
-						this.logger.warn({ err }, "Failed to send cleanup notification");
+				try {
+					const result = await executeCleanupRun(
+						{
+							prisma: this.prisma,
+							arrClientFactory: this.arrClientFactory,
+							encryptor: this.encryptor,
+							log: this.logger,
+						},
+						config.userId,
+					);
+
+					// Calculate next run time
+					const nextRunAt = new Date(now.getTime() + config.intervalHours * 60 * 60 * 1000);
+
+					await this.prisma.libraryCleanupConfig.update({
+						where: { id: config.id },
+						data: { lastRunAt: now, nextRunAt },
 					});
+
+					this.logger.info(
+						{
+							itemsEvaluated: result.itemsEvaluated,
+							itemsFlagged: result.itemsFlagged,
+							itemsRemoved: result.itemsRemoved,
+							nextRunAt: nextRunAt.toISOString(),
+						},
+						"Scheduled library cleanup completed",
+					);
+
+					const notification = buildCleanupNotification(result);
+					if (notification) {
+						await this.sendNotification(notification, "Failed to send cleanup notification");
+					}
+				} finally {
+					this._isRunning = false;
 				}
-			} finally {
-				this._isRunning = false;
-			}
+			});
 		} catch (error) {
 			this._isRunning = false;
+			if (error instanceof CleanupMaintenanceConflictError) {
+				this.logger.debug("Database maintenance owns the library-cleanup operation guard");
+				return;
+			}
 			if (error instanceof CleanupRunAlreadyInProgressError) {
 				this.logger.debug("Another app process owns the library-cleanup run lease");
 				return;
 			}
 			this.logger.error({ err: error }, "Error checking/running scheduled cleanup");
 
-			this.notifyFn?.({
-				eventType: "SYSTEM_ERROR",
-				title: "Library cleanup failed",
-				body: getErrorMessage(error),
-				url: "/library",
-			}).catch((err) => {
-				this.logger.warn({ err }, "Failed to send cleanup error notification");
-			});
+			await this.sendNotification(
+				{
+					eventType: "SYSTEM_ERROR",
+					title: "Library cleanup failed",
+					body: getErrorMessage(error),
+					url: "/library",
+				},
+				"Failed to send cleanup error notification",
+			);
 		}
 	}
 }

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -222,6 +222,8 @@ export interface CleanupRunResult {
 	itemsFlagged: number;
 	/** Durable retries shown alongside current rule matches in preview responses. */
 	pendingRetryCount?: number;
+	/** Distinct retry and fresh-candidate targets available to an interactive preview. */
+	previewItemCount?: number;
 	itemsRemoved: number;
 	itemsUnmonitored: number;
 	itemsFilesDeleted: number;

--- a/apps/api/src/routes/__tests__/auth.test.ts
+++ b/apps/api/src/routes/__tests__/auth.test.ts
@@ -94,10 +94,21 @@ function createMockPrisma() {
 			mustChangePassword: data.mustChangePassword ?? false,
 			createdAt: new Date("2024-01-01T00:00:00Z"),
 		})),
+		delete: vi.fn().mockResolvedValue(undefined),
 	};
 
 	return {
 		user: userMock,
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
+		oIDCAccount: {
+			count: vi.fn().mockResolvedValue(0),
+		},
+		webAuthnCredential: {
+			count: vi.fn().mockResolvedValue(0),
+		},
 		oIDCProvider: {
 			findFirst: vi.fn().mockResolvedValue(null),
 			findUnique: vi.fn().mockResolvedValue(null),
@@ -460,5 +471,27 @@ describe("PATCH /auth/account", () => {
 
 		expect(res.statusCode).toBe(200);
 		expect(hashPassword).toHaveBeenCalledWith("NewPass123!");
+	});
+});
+
+describe("DELETE /auth/account", () => {
+	it("holds the cleanup topology lease while cascading user data", async () => {
+		mockPrisma.user.findUnique.mockResolvedValue(makeUser({ hashedPassword: null }));
+
+		const res = await injectAuthenticated("DELETE", "/auth/account");
+
+		expect(res.statusCode).toBe(200);
+		expect(mockPrisma.user.delete).toHaveBeenCalledWith({ where: { id: "user-1" } });
+		expect(mockPrisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
+	});
+
+	it("returns 409 without deleting the account while cleanup owns the lease", async () => {
+		mockPrisma.user.findUnique.mockResolvedValue(makeUser({ hashedPassword: null }));
+		mockPrisma.libraryCleanupConfig.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const res = await injectAuthenticated("DELETE", "/auth/account");
+
+		expect(res.statusCode).toBe(409);
+		expect(mockPrisma.user.delete).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const executorMocks = vi.hoisted(() => ({
 	buildEvalContext: vi.fn(),
+	CleanupPolicyMutationConflictError: class CleanupPolicyMutationConflictError extends Error {
+		constructor() {
+			super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
+		}
+	},
 	CleanupRunAlreadyInProgressError: class CleanupRunAlreadyInProgressError extends Error {
 		constructor() {
 			super("A cleanup operation is already in progress");
@@ -14,10 +19,17 @@ const executorMocks = vi.hoisted(() => ({
 	executeRetryItems: vi
 		.fn()
 		.mockResolvedValue({ removed: 0, reconciled: 1, failed: 0, errors: [] }),
+	withCleanupPolicyMutationLease: vi.fn(
+		async (_deps: unknown, _userId: string, mutate: () => Promise<unknown>) => await mutate(),
+	),
 }));
 
 vi.mock("../../lib/library-cleanup/cleanup-executor.js", () => executorMocks);
 
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+} from "../../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import {
 	createInjectAuthenticated,
@@ -112,6 +124,28 @@ describe("library cleanup approval compare-and-set routes", () => {
 
 		expect(response.statusCode).toBe(409);
 		expect(response.json()).toEqual({ error: "A cleanup operation is already in progress" });
+	});
+
+	it("does not transition an approval while backup restore owns maintenance", async () => {
+		let finishMaintenance!: () => void;
+		const maintenanceBlocked = new Promise<void>((resolve) => {
+			finishMaintenance = resolve;
+		});
+		const maintenance = withCleanupMaintenanceGuard(() => maintenanceBlocked);
+
+		try {
+			const response = await createInjectAuthenticated(app)(
+				"POST",
+				"/library-cleanup/approval-queue/approval-1/approve",
+			);
+
+			expect(response.statusCode).toBe(409);
+			expect(updateMany).not.toHaveBeenCalled();
+			expect(executorMocks.executeApprovedItems).not.toHaveBeenCalled();
+		} finally {
+			finishMaintenance();
+			await maintenance;
+		}
 	});
 
 	it("does not transition expired approvals during bulk approval", async () => {
@@ -222,6 +256,24 @@ describe("library cleanup approval compare-and-set routes", () => {
 		expect(response.json()).toEqual({ error: "A cleanup operation is already in progress" });
 	});
 
+	it("returns a retryable conflict when maintenance blocks manual cleanup", async () => {
+		let finishMaintenance!: () => void;
+		const maintenanceBlocked = new Promise<void>((resolve) => {
+			finishMaintenance = resolve;
+		});
+		const maintenance = withCleanupMaintenanceGuard(() => maintenanceBlocked);
+		executorMocks.executeCleanupRun.mockRejectedValueOnce(new CleanupMaintenanceConflictError());
+
+		try {
+			const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/execute");
+
+			expect(response.statusCode).toBe(409);
+		} finally {
+			finishMaintenance();
+			await maintenance;
+		}
+	});
+
 	it("warns when preview details were capped before reaching the route", async () => {
 		const details = Array.from({ length: 200 }, (_, index) => ({
 			instanceId: "radarr-1",
@@ -255,6 +307,86 @@ describe("library cleanup approval compare-and-set routes", () => {
 		expect(response.json()).toMatchObject({
 			totalFlagged: 201,
 			warnings: ["Existing warning", "Showing 200 of 201 preview items"],
+		});
+		expect(response.json().items).toHaveLength(200);
+	});
+
+	it("does not warn when one retry is the only distinct preview row", async () => {
+		executorMocks.executeCleanupPreview.mockResolvedValueOnce({
+			isDryRun: true,
+			status: "partial",
+			itemsEvaluated: 1,
+			itemsFlagged: 0,
+			pendingRetryCount: 1,
+			previewItemCount: 1,
+			itemsRemoved: 0,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 0,
+			details: [
+				{
+					instanceId: "radarr-1",
+					arrItemId: 101,
+					itemType: "movie",
+					title: "Example Movie",
+					ruleId: "rule-1",
+					rule: "Cleanup",
+					reason: "Durable retry pending resume",
+					action: "delete",
+					sizeOnDisk: "1000",
+					year: 2024,
+					rating: 8,
+				},
+			],
+			durationMs: 1,
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/preview");
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({
+			totalFlagged: 0,
+			pendingRetryCount: 1,
+			warnings: [],
+		});
+		expect(response.json().items).toHaveLength(1);
+	});
+
+	it("warns when executing retries exceed the rendered preview cap", async () => {
+		const details = Array.from({ length: 200 }, (_, index) => ({
+			instanceId: "radarr-1",
+			arrItemId: index + 1,
+			itemType: "movie",
+			title: `Movie ${index + 1}`,
+			ruleId: "rule-1",
+			rule: "Cleanup",
+			reason: "Durable retry is already executing",
+			action: "skipped" as const,
+			sizeOnDisk: "1000",
+			year: 2024,
+			rating: 8,
+		}));
+		executorMocks.executeCleanupPreview.mockResolvedValueOnce({
+			isDryRun: true,
+			status: "partial",
+			itemsEvaluated: 0,
+			itemsFlagged: 0,
+			pendingRetryCount: 0,
+			previewItemCount: 201,
+			itemsRemoved: 0,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 201,
+			details,
+			durationMs: 1,
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/preview");
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({
+			pendingRetryCount: 0,
+			warnings: ["Showing 200 of 201 preview items"],
 		});
 		expect(response.json().items).toHaveLength(200);
 	});

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -116,6 +116,10 @@ function createPrismaStub() {
 
 	return {
 		_instances: instances,
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
 		serviceInstance,
 		serviceTag: {
 			findMany: vi.fn().mockResolvedValue([]),

--- a/apps/api/src/routes/__tests__/services-qui-cleanup.test.ts
+++ b/apps/api/src/routes/__tests__/services-qui-cleanup.test.ts
@@ -123,6 +123,10 @@ function makeSonarrInstance(overrides: Record<string, unknown> = {}) {
 
 function createMockPrisma() {
 	return {
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
 		serviceInstance: {
 			findMany: vi.fn().mockResolvedValue([]),
 			findFirst: vi.fn().mockResolvedValue(null),

--- a/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
+++ b/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
@@ -99,6 +99,10 @@ beforeEach(async () => {
 	vi.clearAllMocks();
 
 	mockPrisma = {
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
 		serviceInstance: {
 			findMany: vi
 				.fn()

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -95,6 +95,10 @@ function makeInstance(overrides: Record<string, unknown> = {}) {
 
 function createMockPrisma() {
 	return {
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
 		serviceInstance: {
 			findMany: vi.fn().mockResolvedValue([]),
 			findFirst: vi.fn().mockResolvedValue(null),
@@ -230,6 +234,25 @@ describe("POST /services", () => {
 
 		expect(mockPrisma.serviceInstance.updateMany).not.toHaveBeenCalled();
 	});
+
+	it("returns 409 without changing topology while cleanup owns the lease", async () => {
+		mockPrisma.libraryCleanupConfig.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const res = await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Concurrent Sonarr",
+				baseUrl: "http://sonarr:8989",
+				apiKey: "my-secret-api-key",
+				service: "sonarr",
+			},
+		});
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).message).toContain(
+			"cannot be changed while a library cleanup operation is in progress",
+		);
+		expect(mockPrisma.serviceInstance.create).not.toHaveBeenCalled();
+	});
 });
 
 // ===========================================================================
@@ -261,6 +284,7 @@ describe("PUT /services/:id", () => {
 			expect.objectContaining({ label: "Updated Label" }),
 			expect.objectContaining({ encrypt: expect.any(Function) }),
 		);
+		expect(mockPrisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
 	});
 
 	it("returns 404 for non-owned instance via requireInstance", async () => {
@@ -288,6 +312,7 @@ describe("DELETE /services/:id", () => {
 		expect(mockPrisma.serviceInstance.delete).toHaveBeenCalledWith({
 			where: { id: "inst-1", userId: "user-1" },
 		});
+		expect(mockPrisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
 	});
 
 	it("returns 404 for non-owned instance", async () => {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { getPasswordSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
+import { withCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-executor.js";
 import { warmConnectionsForUser } from "../lib/arr/connection-warmer.js";
 import { hashPassword, verifyPassword } from "../lib/auth/password.js";
 import { getSessionMetadata } from "../lib/auth/session-metadata.js";
@@ -614,51 +615,60 @@ const authRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		const userId = request.currentUser.id;
 
-		// Check for any authentication methods
-		const user = await app.prisma.user.findUnique({
-			where: { id: userId },
-		});
+		return await withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				// Check for any authentication methods while cleanup and database
+				// restore are excluded, so the decision cannot go stale before
+				// the cascading topology deletion.
+				const user = await app.prisma.user.findUnique({
+					where: { id: userId },
+				});
 
-		if (!user) {
-			return reply.status(404).send({ error: "User not found" });
-		}
+				if (!user) {
+					return reply.status(404).send({ error: "User not found" });
+				}
 
-		const oidcAccounts = await app.prisma.oIDCAccount.count({
-			where: { userId },
-		});
+				const oidcAccounts = await app.prisma.oIDCAccount.count({
+					where: { userId },
+				});
 
-		const passkeys = await app.prisma.webAuthnCredential.count({
-			where: { userId },
-		});
+				const passkeys = await app.prisma.webAuthnCredential.count({
+					where: { userId },
+				});
 
-		const hasPassword = !!user.hashedPassword;
+				const hasPassword = !!user.hashedPassword;
 
-		// Only allow deletion if user has NO authentication methods
-		if (hasPassword || oidcAccounts > 0 || passkeys > 0) {
-			return reply.status(400).send({
-				error:
-					"Cannot delete account with existing authentication methods. Please remove password, OIDC accounts, and passkeys first.",
-			});
-		}
+				// Only allow deletion if user has NO authentication methods
+				if (hasPassword || oidcAccounts > 0 || passkeys > 0) {
+					return reply.status(400).send({
+						error:
+							"Cannot delete account with existing authentication methods. Please remove password, OIDC accounts, and passkeys first.",
+					});
+				}
 
-		// Log BEFORE deletion since the user record will be gone after
-		request.log.info({ username: request.currentUser!.username }, "Account deleted");
+				// Log BEFORE deletion since the user record will be gone after
+				request.log.info({ username: request.currentUser!.username }, "Account deleted");
 
-		// Delete all user data (cascade will handle related records)
-		await app.prisma.user.delete({
-			where: { id: userId },
-		});
+				// Delete all user data (cascade will handle related records)
+				await app.prisma.user.delete({
+					where: { id: userId },
+				});
 
-		// Invalidate session and clear cookie
-		if (request.sessionToken) {
-			await app.sessionService.invalidateSession(request.sessionToken);
-		}
-		app.sessionService.clearCookie(reply);
+				// Invalidate session and clear cookie
+				if (request.sessionToken) {
+					await app.sessionService.invalidateSession(request.sessionToken);
+				}
+				app.sessionService.clearCookie(reply);
 
-		return reply.send({
-			success: true,
-			message: "Account deleted successfully.",
-		});
+				return reply.send({
+					success: true,
+					message: "Account deleted successfully.",
+				});
+			},
+			{ leaseRowMayBeDeleted: true },
+		);
 	});
 
 	done();

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -11,6 +11,7 @@ import {
 } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { BackupService } from "../lib/backup/backup-service.js";
+import { CleanupMaintenanceConflictError } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
 import { z } from "zod";
@@ -145,8 +146,12 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				await app.lifecycle.restart("backup-restore");
 			}
 		} catch (error) {
-			request.log.error({ err: error }, "Failed to restore backup");
+			if (error instanceof CleanupMaintenanceConflictError) {
+				request.log.warn({ err: error }, "Backup restore blocked by active cleanup maintenance");
+				return reply.status(409).send({ error: error.message });
+			}
 
+			request.log.error({ err: error }, "Failed to restore backup");
 			const errorMessage = getErrorMessage(error);
 
 			// Check for specific error types
@@ -200,8 +205,15 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					await app.lifecycle.restart("backup-restore");
 				}
 			} catch (error) {
-				request.log.error({ err: error }, "Failed to restore backup from file");
+				if (error instanceof CleanupMaintenanceConflictError) {
+					request.log.warn(
+						{ err: error },
+						"Backup restore from file blocked by active cleanup maintenance",
+					);
+					return reply.status(409).send({ error: error.message });
+				}
 
+				request.log.error({ err: error }, "Failed to restore backup from file");
 				const errorMessage = getErrorMessage(error);
 
 				// Check for specific error types

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -17,12 +17,18 @@ import type { FastifyPluginCallback } from "fastify";
 import { randomUUID } from "node:crypto";
 import {
 	buildEvalContext,
+	CleanupPolicyMutationConflictError,
 	CleanupRunAlreadyInProgressError,
 	executeApprovedItems,
 	executeCleanupPreview,
 	executeCleanupRun,
 	executeRetryItems,
+	withCleanupPolicyMutationLease,
 } from "../lib/library-cleanup/cleanup-executor.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { explainItemAgainstRules } from "../lib/library-cleanup/rule-evaluators.js";
 import type { CacheItemForEval } from "../lib/library-cleanup/types.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
@@ -36,6 +42,19 @@ const EXECUTE_RATE_LIMIT = { max: 3, timeWindow: "1 minute" };
 
 // In-memory guard against concurrent execute/preview overlap (single-admin app)
 let cleanupRunInProgress = false;
+
+function isCleanupConflict(
+	error: unknown,
+): error is
+	| CleanupRunAlreadyInProgressError
+	| CleanupMaintenanceConflictError
+	| CleanupPolicyMutationConflictError {
+	return (
+		error instanceof CleanupRunAlreadyInProgressError ||
+		error instanceof CleanupMaintenanceConflictError ||
+		error instanceof CleanupPolicyMutationConflictError
+	);
+}
 
 // ============================================================================
 // Serialization helpers
@@ -406,11 +425,20 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		});
 
 		if (!config) {
-			// Auto-create default config
-			config = await app.prisma.libraryCleanupConfig.create({
-				data: { userId },
-				include: { rules: { orderBy: { priority: "asc" } } },
-			});
+			// Auto-create the coordination row while restore and cleanup-sensitive
+			// writes are excluded.
+			config = await withCleanupPolicyMutationLease(
+				{ prisma: app.prisma, log: request.log },
+				userId,
+				async () => {
+					const initialized = await app.prisma.libraryCleanupConfig.findUnique({
+						where: { userId },
+						include: { rules: { orderBy: { priority: "asc" } } },
+					});
+					if (!initialized) throw new Error("Cleanup configuration could not be initialized");
+					return initialized;
+				},
+			);
 		}
 
 		return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
@@ -421,24 +449,30 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const data = validateRequest(updateCleanupConfigSchema, request.body);
 
-		const config = await app.prisma.libraryCleanupConfig.upsert({
-			where: { userId },
-			update: data,
-			create: { userId, ...data },
-			include: { rules: { orderBy: { priority: "asc" } } },
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const config = await app.prisma.libraryCleanupConfig.upsert({
+					where: { userId },
+					update: data,
+					create: { userId, ...data },
+					include: { rules: { orderBy: { priority: "asc" } } },
+				});
 
-		// Recalculate nextRunAt when enabled or intervalHours changes
-		if (config.enabled && (!config.nextRunAt || data.intervalHours != null)) {
-			const newNextRun = new Date(Date.now() + config.intervalHours * 60 * 60 * 1000);
-			await app.prisma.libraryCleanupConfig.update({
-				where: { id: config.id },
-				data: { nextRunAt: newNextRun },
-			});
-			(config as Record<string, unknown>).nextRunAt = newNextRun;
-		}
+				// Recalculate nextRunAt when enabled or intervalHours changes
+				if (config.enabled && (!config.nextRunAt || data.intervalHours != null)) {
+					const newNextRun = new Date(Date.now() + config.intervalHours * 60 * 60 * 1000);
+					await app.prisma.libraryCleanupConfig.update({
+						where: { id: config.id },
+						data: { nextRunAt: newNextRun },
+					});
+					(config as Record<string, unknown>).nextRunAt = newNextRun;
+				}
 
-		return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
+				return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
+			},
+		);
 	});
 
 	// ─── Rules CRUD ───────────────────────────────────────────────────
@@ -465,34 +499,44 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			return reply.status(404).send({ error: "Config not found. Initialize config first." });
 		}
 
-		const rule = await app.prisma.libraryCleanupRule.create({
-			data: {
-				configId: config.id,
-				name: data.name,
-				enabled: data.enabled,
-				priority: data.priority,
-				ruleType: data.ruleType,
-				parameters: JSON.stringify(data.parameters),
-				serviceFilter: data.serviceFilter ? JSON.stringify(data.serviceFilter) : null,
-				instanceFilter: data.instanceFilter ? JSON.stringify(data.instanceFilter) : null,
-				excludeTags: data.excludeTags ? JSON.stringify(data.excludeTags) : null,
-				excludeTitles: data.excludeTitles ? JSON.stringify(data.excludeTitles) : null,
-				plexLibraryFilter: data.plexLibraryFilter ? JSON.stringify(data.plexLibraryFilter) : null,
-				action: data.action ?? "delete",
-				operator: data.operator ?? null,
-				conditions: data.conditions ? JSON.stringify(data.conditions) : null,
-				retentionMode: data.retentionMode ?? false,
-				useGlobalRejectionMemory: data.useGlobalRejectionMemory ?? true,
-				// `?? 0` would collapse a deliberate `null` (forever) to `0` (off),
-				// silently downgrading "Forever" → "Off" on rule creation. The
-				// encoding contract is null=forever, 0=off, N>0=days — so only
-				// substitute the default for `undefined`. PUT path on rule update
-				// uses the same `!== undefined` discipline; keep them symmetric.
-				rejectionMemoryDays: data.rejectionMemoryDays === undefined ? 0 : data.rejectionMemoryDays,
-			},
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const rule = await app.prisma.libraryCleanupRule.create({
+					data: {
+						configId: config.id,
+						name: data.name,
+						enabled: data.enabled,
+						priority: data.priority,
+						ruleType: data.ruleType,
+						parameters: JSON.stringify(data.parameters),
+						serviceFilter: data.serviceFilter ? JSON.stringify(data.serviceFilter) : null,
+						instanceFilter: data.instanceFilter ? JSON.stringify(data.instanceFilter) : null,
+						excludeTags: data.excludeTags ? JSON.stringify(data.excludeTags) : null,
+						excludeTitles: data.excludeTitles ? JSON.stringify(data.excludeTitles) : null,
+						plexLibraryFilter: data.plexLibraryFilter
+							? JSON.stringify(data.plexLibraryFilter)
+							: null,
+						action: data.action ?? "delete",
+						operator: data.operator ?? null,
+						conditions: data.conditions ? JSON.stringify(data.conditions) : null,
+						retentionMode: data.retentionMode ?? false,
+						useGlobalRejectionMemory: data.useGlobalRejectionMemory ?? true,
+						// `?? 0` would collapse a deliberate `null` (forever) to `0` (off),
+						// silently downgrading "Forever" → "Off" on rule creation. The
+						// encoding contract is null=forever, 0=off, N>0=days — so only
+						// substitute the default for `undefined`. PUT path on rule update
+						// uses the same `!== undefined` discipline; keep them symmetric.
+						rejectionMemoryDays:
+							data.rejectionMemoryDays === undefined ? 0 : data.rejectionMemoryDays,
+					},
+				});
 
-		return reply.status(201).send(serializeRule(rule as unknown as Record<string, unknown>));
+				return reply.status(201).send(serializeRule(rule as unknown as Record<string, unknown>));
+			},
+			{ configId: config.id },
+		);
 	});
 
 	/** PUT /api/library-cleanup/rules/reorder */
@@ -500,42 +544,57 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const { ruleIds } = validateRequest(reorderRulesSchema, request.body);
 
-		const config = await app.prisma.libraryCleanupConfig.findUnique({
+		const configRef = await app.prisma.libraryCleanupConfig.findUnique({
 			where: { userId },
-			include: { rules: { select: { id: true } } },
+			select: { id: true },
 		});
-		if (!config) {
+		if (!configRef) {
 			return reply.status(404).send({ error: "Config not found" });
 		}
 
-		// Verify all IDs belong to this config and all rules are included
-		const existingIds = new Set(config.rules.map((r) => r.id));
-		if (ruleIds.length !== existingIds.size) {
-			return reply.status(400).send({
-				error: `Expected ${existingIds.size} rule IDs but received ${ruleIds.length}`,
-			});
-		}
-		for (const id of ruleIds) {
-			if (!existingIds.has(id)) {
-				return reply.status(400).send({ error: `Rule ${id} not found in config` });
-			}
-		}
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const config = await app.prisma.libraryCleanupConfig.findUnique({
+					where: { userId },
+					include: { rules: { select: { id: true } } },
+				});
+				if (!config) {
+					return reply.status(404).send({ error: "Config not found" });
+				}
 
-		// Assign sequential priorities in a transaction
-		await app.prisma.$transaction(
-			ruleIds.map((id, index) =>
-				app.prisma.libraryCleanupRule.update({
-					where: { id },
-					data: { priority: index },
-				}),
-			),
+				// Verify all IDs belong to this config and all rules are included
+				const existingIds = new Set(config.rules.map((r) => r.id));
+				if (ruleIds.length !== existingIds.size) {
+					return reply.status(400).send({
+						error: `Expected ${existingIds.size} rule IDs but received ${ruleIds.length}`,
+					});
+				}
+				for (const id of ruleIds) {
+					if (!existingIds.has(id)) {
+						return reply.status(400).send({ error: `Rule ${id} not found in config` });
+					}
+				}
+
+				// Assign sequential priorities in a transaction
+				await app.prisma.$transaction(
+					ruleIds.map((id, index) =>
+						app.prisma.libraryCleanupRule.update({
+							where: { id },
+							data: { priority: index },
+						}),
+					),
+				);
+
+				const updated = await app.prisma.libraryCleanupConfig.findUnique({
+					where: { userId },
+					include: { rules: { orderBy: { priority: "asc" } } },
+				});
+				return reply.send(serializeConfig(updated as unknown as Record<string, unknown>));
+			},
+			{ configId: configRef.id },
 		);
-
-		const updated = await app.prisma.libraryCleanupConfig.findUnique({
-			where: { userId },
-			include: { rules: { orderBy: { priority: "asc" } } },
-		});
-		return reply.send(serializeConfig(updated as unknown as Record<string, unknown>));
 	});
 
 	/** PUT /api/library-cleanup/rules/:id */
@@ -606,12 +665,19 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		if (data.rejectionMemoryDays !== undefined)
 			updateData.rejectionMemoryDays = data.rejectionMemoryDays;
 
-		const rule = await app.prisma.libraryCleanupRule.update({
-			where: { id },
-			data: updateData,
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const rule = await app.prisma.libraryCleanupRule.update({
+					where: { id },
+					data: updateData,
+				});
 
-		return reply.send(serializeRule(rule as unknown as Record<string, unknown>));
+				return reply.send(serializeRule(rule as unknown as Record<string, unknown>));
+			},
+			{ configId: existing.configId },
+		);
 	});
 
 	/** DELETE /api/library-cleanup/rules/:id */
@@ -626,8 +692,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			return reply.status(404).send({ error: "Rule not found" });
 		}
 
-		await app.prisma.libraryCleanupRule.delete({ where: { id } });
-		return reply.status(204).send();
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				await app.prisma.libraryCleanupRule.delete({ where: { id } });
+				return reply.status(204).send();
+			},
+			{ configId: existing.configId },
+		);
 	});
 
 	// ─── Preview & Execute ────────────────────────────────────────────
@@ -669,10 +742,9 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				}
 
 				const MAX_PREVIEW_ITEMS = 200;
-				const totalPreviewItems = Math.max(
-					result.itemsFlagged + (result.pendingRetryCount ?? 0),
-					result.details.length,
-				);
+				const totalPreviewItems =
+					result.previewItemCount ??
+					Math.max(result.itemsFlagged + (result.pendingRetryCount ?? 0), result.details.length);
 				const previewDetails = result.details.slice(0, MAX_PREVIEW_ITEMS);
 				const truncated = totalPreviewItems > previewDetails.length;
 
@@ -794,7 +866,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 
 				return reply.send(result);
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				request.log.error({ err: error }, "Cleanup execution failed");
@@ -875,46 +947,46 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			const { id } = request.params;
 			const approvalRequestToken = randomUUID();
 
-			const transition = await app.prisma.libraryCleanupApproval.updateMany({
-				where: {
-					id,
-					config: { userId },
-					status: "pending",
-					expiresAt: { gt: new Date() },
-				},
-				data: {
-					status: "approved",
-					executionToken: approvalRequestToken,
-					reviewedAt: new Date(),
-				},
-			});
-			if (transition.count !== 1) {
-				return reply.status(404).send({ error: "Approval not found or not pending" });
-			}
-
-			// Execute immediately
-			let result: Awaited<ReturnType<typeof executeApprovedItems>>;
 			try {
-				result = await executeApprovedItems(
-					{
-						prisma: app.prisma,
-						arrClientFactory: app.arrClientFactory,
-						encryptor: app.encryptor,
-						log: request.log,
-					},
-					userId,
-					[id],
-					approvalRequestToken,
-				);
+				return await withCleanupOperationGuard(async () => {
+					const transition = await app.prisma.libraryCleanupApproval.updateMany({
+						where: {
+							id,
+							config: { userId },
+							status: "pending",
+							expiresAt: { gt: new Date() },
+						},
+						data: {
+							status: "approved",
+							executionToken: approvalRequestToken,
+							reviewedAt: new Date(),
+						},
+					});
+					if (transition.count !== 1) {
+						return reply.status(404).send({ error: "Approval not found or not pending" });
+					}
+
+					const result = await executeApprovedItems(
+						{
+							prisma: app.prisma,
+							arrClientFactory: app.arrClientFactory,
+							encryptor: app.encryptor,
+							log: request.log,
+						},
+						userId,
+						[id],
+						approvalRequestToken,
+					);
+
+					// nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Fastify JSON response
+					return reply.send(result);
+				});
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				throw error;
 			}
-
-			// nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Fastify JSON response
-			return reply.send(result);
 		},
 	);
 
@@ -938,7 +1010,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				);
 				return reply.send(result);
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				throw error;
@@ -953,15 +1025,24 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			const userId = request.currentUser!.id;
 			const { id } = request.params;
 
-			const transition = await app.prisma.libraryCleanupApproval.updateMany({
-				where: { id, config: { userId }, status: "pending" },
-				data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
-			});
-			if (transition.count !== 1) {
-				return reply.status(404).send({ error: "Approval not found or not pending" });
-			}
+			try {
+				return await withCleanupOperationGuard(async () => {
+					const transition = await app.prisma.libraryCleanupApproval.updateMany({
+						where: { id, config: { userId }, status: "pending" },
+						data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
+					});
+					if (transition.count !== 1) {
+						return reply.status(404).send({ error: "Approval not found or not pending" });
+					}
 
-			return reply.status(204).send();
+					return reply.status(204).send();
+				});
+			} catch (error) {
+				if (isCleanupConflict(error)) {
+					return reply.status(409).send({ error: error.message });
+				}
+				throw error;
+			}
 		},
 	);
 
@@ -970,51 +1051,53 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const { ids, action } = validateRequest(bulkApprovalSchema, request.body);
 
-		if (action === "rejected") {
-			const result = await app.prisma.libraryCleanupApproval.updateMany({
-				where: { id: { in: ids }, config: { userId }, status: "pending" },
-				data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
-			});
-			return reply.send({ updated: result.count });
-		}
-
-		// Approve and execute
-		const approvalRequestToken = randomUUID();
-		await app.prisma.libraryCleanupApproval.updateMany({
-			where: {
-				id: { in: ids },
-				config: { userId },
-				status: "pending",
-				expiresAt: { gt: new Date() },
-			},
-			data: {
-				status: "approved",
-				executionToken: approvalRequestToken,
-				reviewedAt: new Date(),
-			},
-		});
-
-		let result: Awaited<ReturnType<typeof executeApprovedItems>>;
 		try {
-			result = await executeApprovedItems(
-				{
-					prisma: app.prisma,
-					arrClientFactory: app.arrClientFactory,
-					encryptor: app.encryptor,
-					log: request.log,
-				},
-				userId,
-				ids,
-				approvalRequestToken,
-			);
+			return await withCleanupOperationGuard(async () => {
+				if (action === "rejected") {
+					const result = await app.prisma.libraryCleanupApproval.updateMany({
+						where: { id: { in: ids }, config: { userId }, status: "pending" },
+						data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
+					});
+					return reply.send({ updated: result.count });
+				}
+
+				// Approve and execute under one guard so restore cannot observe
+				// an intermediate approved state.
+				const approvalRequestToken = randomUUID();
+				await app.prisma.libraryCleanupApproval.updateMany({
+					where: {
+						id: { in: ids },
+						config: { userId },
+						status: "pending",
+						expiresAt: { gt: new Date() },
+					},
+					data: {
+						status: "approved",
+						executionToken: approvalRequestToken,
+						reviewedAt: new Date(),
+					},
+				});
+
+				const result = await executeApprovedItems(
+					{
+						prisma: app.prisma,
+						arrClientFactory: app.arrClientFactory,
+						encryptor: app.encryptor,
+						log: request.log,
+					},
+					userId,
+					ids,
+					approvalRequestToken,
+				);
+
+				return reply.send(result);
+			});
 		} catch (error) {
-			if (error instanceof CleanupRunAlreadyInProgressError) {
+			if (isCleanupConflict(error)) {
 				return reply.status(409).send({ error: error.message });
 			}
 			throw error;
 		}
-
-		return reply.send(result);
 	});
 
 	// ─── Logs ─────────────────────────────────────────────────────────

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -2,6 +2,7 @@ import { ALL_SERVICES, arrServiceTypeSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { requireInstance } from "../lib/arr/instance-helpers.js";
+import { withCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-executor.js";
 import { clearFileIdIndexCache } from "../lib/library-sync/infohash-backfill-by-inode.js";
 import type { ServiceType } from "../lib/prisma.js";
 import { invalidateTorrentListCache } from "../lib/qui/torrent-list-cache.js";
@@ -101,146 +102,166 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 		const encryptedHttpAuth = httpAuth ? encryptHttpAuthCredentials(app.encryptor, httpAuth) : {};
 
 		const serviceEnum = service.toUpperCase() as ServiceType;
+		const userId = request.currentUser!.id;
 
-		if (isDefault) {
-			await app.prisma.serviceInstance.updateMany({
-				where: { service: serviceEnum, userId: request.currentUser!.id },
-				data: { isDefault: false },
-			});
-		}
+		return await withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				if (isDefault) {
+					await app.prisma.serviceInstance.updateMany({
+						where: { service: serviceEnum, userId },
+						data: { isDefault: false },
+					});
+				}
 
-		const tagRecords = await upsertTags(app.prisma, tags);
+				const tagRecords = await upsertTags(app.prisma, tags);
 
-		const created = await app.prisma.serviceInstance.create({
-			data: {
-				userId: request.currentUser!.id, // preHandler guarantees auth
-				service: serviceEnum,
-				encryptedApiKey: encrypted.value,
-				encryptionIv: encrypted.iv,
-				...encryptedHttpAuth,
-				isDefault,
-				...rest,
-				tags: {
-					create: tagRecords,
-				},
-			},
-			include: {
-				tags: {
-					include: {
-						tag: true,
+				const created = await app.prisma.serviceInstance.create({
+					data: {
+						userId, // preHandler guarantees auth
+						service: serviceEnum,
+						encryptedApiKey: encrypted.value,
+						encryptionIv: encrypted.iv,
+						...encryptedHttpAuth,
+						isDefault,
+						...rest,
+						tags: {
+							create: tagRecords,
+						},
 					},
-				},
+					include: {
+						tags: {
+							include: {
+								tag: true,
+							},
+						},
+					},
+				});
+
+				request.log.info({ service, label: rest.label }, "Service instance added");
+
+				return reply.status(201).send({
+					service: formatServiceInstance(created),
+				});
 			},
-		});
-
-		request.log.info({ service, label: rest.label }, "Service instance added");
-
-		return reply.status(201).send({
-			service: formatServiceInstance(created),
-		});
+		);
 	});
 
 	app.put("/services/:id", async (request, reply) => {
 		const { id } = validateRequest(idParams, request.params);
 		const payload = validateRequest(serviceUpdateSchema, request.body);
 		const userId = request.currentUser!.id;
-		const existing = await requireInstance(app, userId, id);
-		const targetService = payload.service ?? existing.service.toLowerCase();
-		const keepsExistingHttpAuth =
-			payload.httpAuth === undefined && Boolean(existing.encryptedHttpAuthCredentials);
-		const httpAuthConflict =
-			payload.httpAuth || keepsExistingHttpAuth ? getHttpAuthConflict(targetService) : null;
-		if (httpAuthConflict) {
-			return reply.status(400).send({
-				error: `HTTP Basic Auth is not supported for ${targetService}`,
-				details: `${httpAuthConflict} Remove HTTP Basic Auth or configure a proxy bypass.`,
-			});
-		}
 
-		const updateData = buildUpdateData(payload, app.encryptor);
+		return await withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const existing = await requireInstance(app, userId, id);
+				const targetService = payload.service ?? existing.service.toLowerCase();
+				const keepsExistingHttpAuth =
+					payload.httpAuth === undefined && Boolean(existing.encryptedHttpAuthCredentials);
+				const httpAuthConflict =
+					payload.httpAuth || keepsExistingHttpAuth ? getHttpAuthConflict(targetService) : null;
+				if (httpAuthConflict) {
+					return reply.status(400).send({
+						error: `HTTP Basic Auth is not supported for ${targetService}`,
+						details: `${httpAuthConflict} Remove HTTP Basic Auth or configure a proxy bypass.`,
+					});
+				}
 
-		if (payload.isDefault === true || payload.service) {
-			const targetService = (
-				payload.service ?? existing.service.toLowerCase()
-			).toUpperCase() as ServiceType;
-			await app.prisma.serviceInstance.updateMany({
-				where: { service: targetService, userId, NOT: { id } },
-				data: { isDefault: false },
-			});
-		}
+				const updateData = buildUpdateData(payload, app.encryptor);
 
-		await app.prisma.serviceInstance.updateMany({
-			where: { id, userId },
-			data: updateData,
-		});
+				if (payload.isDefault === true || payload.service) {
+					const targetService = (
+						payload.service ?? existing.service.toLowerCase()
+					).toUpperCase() as ServiceType;
+					await app.prisma.serviceInstance.updateMany({
+						where: { service: targetService, userId, NOT: { id } },
+						data: { isDefault: false },
+					});
+				}
 
-		if (payload.tags) {
-			await updateInstanceTags(app.prisma, id, payload.tags);
-		}
+				await app.prisma.serviceInstance.updateMany({
+					where: { id, userId },
+					data: updateData,
+				});
 
-		// Drop process-local qui caches when a qui instance becomes
-		// unreachable from this app's perspective — either disabled
-		// (enabled: true → false) or its service type changed away from
-		// QUI. Mirrors the DELETE handler's invalidation but for the
-		// "kept but inert" case. Without this, a disabled instance's
-		// inode index + torrent list would sit in memory for the rest
-		// of the process lifetime (TTL is read-only; nothing reads a
-		// disabled instance, so no self-healing). No-op for non-qui
-		// services because the keys won't be in those caches.
-		const wasQui = existing.service === "QUI";
-		const nowDisabled = payload.enabled === false && existing.enabled === true;
-		const switchedAwayFromQui =
-			payload.service !== undefined && payload.service.toLowerCase() !== "qui";
-		if (wasQui && (nowDisabled || switchedAwayFromQui)) {
-			invalidateTorrentListCache(id);
-			clearFileIdIndexCache(id);
-			request.log.info(
-				{ instanceId: id, reason: nowDisabled ? "disabled" : "service-changed" },
-				"qui caches dropped after instance update",
-			);
-		}
+				if (payload.tags) {
+					await updateInstanceTags(app.prisma, id, payload.tags);
+				}
 
-		// Fetch updated instance - include userId to ensure we only get owned instances
-		const fresh = await app.prisma.serviceInstance.findFirst({
-			where: {
-				id,
-				userId,
+				// Drop process-local qui caches when a qui instance becomes
+				// unreachable from this app's perspective — either disabled
+				// (enabled: true → false) or its service type changed away from
+				// QUI. Mirrors the DELETE handler's invalidation but for the
+				// "kept but inert" case. Without this, a disabled instance's
+				// inode index + torrent list would sit in memory for the rest
+				// of the process lifetime (TTL is read-only; nothing reads a
+				// disabled instance, so no self-healing). No-op for non-qui
+				// services because the keys won't be in those caches.
+				const wasQui = existing.service === "QUI";
+				const nowDisabled = payload.enabled === false && existing.enabled === true;
+				const switchedAwayFromQui =
+					payload.service !== undefined && payload.service.toLowerCase() !== "qui";
+				if (wasQui && (nowDisabled || switchedAwayFromQui)) {
+					invalidateTorrentListCache(id);
+					clearFileIdIndexCache(id);
+					request.log.info(
+						{ instanceId: id, reason: nowDisabled ? "disabled" : "service-changed" },
+						"qui caches dropped after instance update",
+					);
+				}
+
+				// Fetch updated instance - include userId to ensure we only get owned instances
+				const fresh = await app.prisma.serviceInstance.findFirst({
+					where: {
+						id,
+						userId,
+					},
+					include: { tags: { include: { tag: true } } },
+				});
+
+				if (!fresh) {
+					return reply.status(404).send({ error: "Service instance not found" });
+				}
+
+				request.log.info(
+					{ service: fresh.service, label: fresh.label, instanceId: id },
+					"Service instance updated",
+				);
+
+				return reply.send({
+					service: formatServiceInstance(fresh),
+				});
 			},
-			include: { tags: { include: { tag: true } } },
-		});
-
-		if (!fresh) {
-			return reply.status(404).send({ error: "Service instance not found" });
-		}
-
-		request.log.info(
-			{ service: fresh.service, label: fresh.label, instanceId: id },
-			"Service instance updated",
 		);
-
-		return reply.send({
-			service: formatServiceInstance(fresh),
-		});
 	});
 
 	app.delete("/services/:id", async (request, reply) => {
 		const { id } = validateRequest(idParams, request.params);
 		const userId = request.currentUser!.id; // preHandler guarantees authentication
 
-		await requireInstance(app, userId, id);
-		await app.prisma.serviceInstance.delete({ where: { id, userId } });
+		return await withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				await requireInstance(app, userId, id);
+				await app.prisma.serviceInstance.delete({ where: { id, userId } });
 
-		// Free any process-local qui caches keyed to this instance. Both
-		// the torrent-list cache and the inode index retain heavy entries
-		// (TTL-checked on read only — a stale entry self-heals, but a
-		// deleted instance is never read again, so its entry would linger
-		// for the whole process life). No-op for non-qui services: the id
-		// simply isn't a key in those caches.
-		invalidateTorrentListCache(id);
-		clearFileIdIndexCache(id);
+				// Free any process-local qui caches keyed to this instance. Both
+				// the torrent-list cache and the inode index retain heavy entries
+				// (TTL-checked on read only — a stale entry self-heals, but a
+				// deleted instance is never read again, so its entry would linger
+				// for the whole process life). No-op for non-qui services: the id
+				// simply isn't a key in those caches.
+				invalidateTorrentListCache(id);
+				clearFileIdIndexCache(id);
 
-		request.log.info({ instanceId: id }, "Service instance deleted");
-		return reply.status(204).send();
+				request.log.info({ instanceId: id }, "Service instance deleted");
+				return reply.status(204).send();
+			},
+		);
 	});
 
 	app.get("/tags", async (_request, reply) => {


### PR DESCRIPTION
## Summary

This is the focused 2.x companion to #633. It carries over the review-proven cleanup safety fixes that also apply to `main`, while leaving all 3.0-only automation and cross-domain work on `next`.

- coordinates cleanup runs with backup restore, service/account topology changes, cleanup config/rule writes, approval transitions, and scheduler work
- rechecks the cleanup lease immediately before each Radarr or Sonarr mutation
- preserves retry fairness, filters retries out of approval execution, and tracks the exact destructive mutation budget
- fails closed when a stored per-run limit is outside the supported `1–100` range
- reports distinct preview totals instead of counting duplicate rule matches
- returns conflict responses when cleanup or maintenance already owns the operation boundary

## Verification

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,866 passed, 41 skipped
- `pnpm run lint`
- `pnpm run build`
- two independent focused review passes, both clear

A live destructive smoke test was not run because this environment does not have a representative Radarr/Sonarr/Plex topology. The mutation paths are covered by mocked last-moment lease-loss and coordination regressions.

Related to #616