### PR TITLE
fix(library-cleanup): align next coordination safeguards

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	acquireCleanupRunLease,
+	CleanupPolicyMutationConflictError,
 	CleanupTopologyMutationConflictError,
 	releaseCleanupRunLease,
 	renewCleanupRunLease,
 	withCleanupTopologyMutationLease,
+	withCleanupPolicyMutationLease,
 } from "../cleanup-executor.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
@@ -226,5 +228,27 @@ describe("library cleanup database run lease", () => {
 			where: { id: "config-1", userId: "user-1", runClaimToken: expect.any(String) },
 			data: { runClaimToken: null, runClaimedAt: null },
 		});
+	});
+
+	it("rejects cleanup policy writes while a run owns the existing config lease", async () => {
+		const mutate = vi.fn();
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn(),
+				updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = {
+			warn: vi.fn(),
+			error: vi.fn(),
+		} as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupPolicyMutationLease({ prisma, log }, "user-1", mutate, {
+				configId: "config-1",
+			}),
+		).rejects.toBeInstanceOf(CleanupPolicyMutationConflictError);
+		expect(prisma.libraryCleanupConfig.upsert).not.toHaveBeenCalled();
+		expect(mutate).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2354,7 +2354,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -2394,7 +2394,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -2678,7 +2678,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -2725,7 +2725,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem] as never,
 			1,
@@ -2950,7 +2950,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -3021,7 +3021,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -3667,6 +3667,50 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovieFile).toHaveBeenCalledOnce();
 		expect(deleteMovie).toHaveBeenCalledTimes(2);
 	});
+
+	it.each([0, 101])(
+		"fails closed when the persisted direct cleanup cap is invalid (%i)",
+		async (maxRemovalsPerRun) => {
+			const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
+			const flaggedItem = {
+				cacheItem: {
+					instanceId: "radarr-4k",
+					arrItemId: 101,
+					itemType: "movie",
+					title: "Example Movie",
+					year: 2024,
+					...radarrCachedFileIdentity,
+					sizeOnDisk: 2_000n,
+				},
+				match: {
+					ruleId: "rule-1",
+					ruleName: "Large movie cleanup",
+					reason: "Matched size rule",
+					action: "delete",
+				},
+				rating: 8,
+			} as never;
+
+			const result = await executeDirectRemoval(
+				deps,
+				{ id: "config-1", maxRemovalsPerRun, rules: [] } as never,
+				"user-1",
+				[flaggedItem],
+				1,
+				1,
+				Date.now(),
+			);
+
+			expect(result).toMatchObject({
+				itemsFlagged: 0,
+				itemsRemoved: 0,
+				itemsFilesDeleted: 0,
+				itemsSkipped: 1,
+			});
+			expect(deleteMovieFile).not.toHaveBeenCalled();
+			expect(deleteMovie).not.toHaveBeenCalled();
+		},
+	);
 
 	it("returns a partially completed approval to pending with accurate file state", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
@@ -4705,7 +4749,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,
@@ -4749,7 +4793,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			flaggedItems,
 			2,
@@ -4818,7 +4862,7 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeDirectRemoval(
 			deps,
-			{ id: "config-1", rules: [] } as never,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
 			"user-1",
 			[flaggedItem],
 			1,

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -3702,10 +3702,12 @@ describe("shared Plex deletion safety", () => {
 			);
 
 			expect(result).toMatchObject({
+				status: "partial",
 				itemsFlagged: 0,
 				itemsRemoved: 0,
 				itemsFilesDeleted: 0,
 				itemsSkipped: 1,
+				warnings: [expect.stringContaining("whole number from 1 through 100")],
 			});
 			expect(deleteMovieFile).not.toHaveBeenCalled();
 			expect(deleteMovie).not.toHaveBeenCalled();

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1308,7 +1308,7 @@ describe("verified Sonarr mutation handoff", () => {
 			},
 			rating: 8,
 		} as never;
-		const config = { id: "config-1", rules: [] } as never;
+		const config = { id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never;
 
 		const firstResult = await executeDirectRemoval(
 			deps,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -125,6 +125,15 @@ export class CleanupTopologyMutationConflictError extends Error {
 	}
 }
 
+export class CleanupPolicyMutationConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor() {
+		super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
+		this.name = "CleanupPolicyMutationConflictError";
+	}
+}
+
 class CleanupExemptionAuthorityError extends Error {
 	constructor() {
 		super("Skipped for safety: current deployed cleanup exemption policy covers this ARR target.");
@@ -181,25 +190,28 @@ export async function renewCleanupRunLease(
 	return renewal.count === 1;
 }
 
-export async function withCleanupTopologyMutationLease<T>(
+async function withCleanupMutationLease<T>(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
 	mutate: () => Promise<T>,
-	options: { leaseRowMayBeDeleted?: boolean } = {},
+	conflictError: () => Error,
+	options: { configId?: string; leaseRowMayBeDeleted?: boolean } = {},
 ): Promise<T> {
 	return await withCleanupOperationGuard(async () => {
 		const { prisma, log } = deps;
-		// Ensure the per-user coordination row exists even when the cleanup UI has
-		// never been opened. This closes the config-initialization race between a
-		// service topology write and the first cleanup run.
-		const config = await prisma.libraryCleanupConfig.upsert({
-			where: { userId },
-			update: {},
-			create: { userId },
-			select: { id: true },
-		});
+		// Ensure the per-user coordination row exists when the caller does not
+		// already have its ID. This closes the initialization race between a
+		// cleanup-sensitive write and the first cleanup run.
+		const config = options.configId
+			? { id: options.configId }
+			: await prisma.libraryCleanupConfig.upsert({
+					where: { userId },
+					update: {},
+					create: { userId },
+					select: { id: true },
+				});
 		const runClaimToken = await acquireCleanupRunLease(prisma, userId, config.id);
-		if (!runClaimToken) throw new CleanupTopologyMutationConflictError();
+		if (!runClaimToken) throw conflictError();
 
 		try {
 			return await mutate();
@@ -221,6 +233,36 @@ export async function withCleanupTopologyMutationLease<T>(
 				});
 		}
 	});
+}
+
+export async function withCleanupTopologyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { leaseRowMayBeDeleted?: boolean } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupTopologyMutationConflictError(),
+		options,
+	);
+}
+
+export async function withCleanupPolicyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { configId?: string } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupPolicyMutationConflictError(),
+		options,
+	);
 }
 
 async function startCleanupRunLease(
@@ -3564,9 +3606,11 @@ export async function executeDirectRemoval(
 	const selectedDirectRetryTargetKeys = new Set<string>();
 	const inFlightDirectRetryTargetKeys = new Set<string>();
 	const configuredRunLimit =
-		Number.isSafeInteger(config.maxRemovalsPerRun) && config.maxRemovalsPerRun > 0
+		Number.isSafeInteger(config.maxRemovalsPerRun) &&
+		config.maxRemovalsPerRun > 0 &&
+		config.maxRemovalsPerRun <= 100
 			? config.maxRemovalsPerRun
-			: Number.MAX_SAFE_INTEGER;
+			: 0;
 
 	let directRetries: Awaited<ReturnType<typeof prisma.libraryCleanupApproval.findMany>> = [];
 	let fairnessDeferredRetries: typeof directRetries = [];

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -3605,12 +3605,11 @@ export async function executeDirectRemoval(
 	const directRetryTargetKeys = new Set<string>();
 	const selectedDirectRetryTargetKeys = new Set<string>();
 	const inFlightDirectRetryTargetKeys = new Set<string>();
-	const configuredRunLimit =
+	const configuredRunLimitIsValid =
 		Number.isSafeInteger(config.maxRemovalsPerRun) &&
 		config.maxRemovalsPerRun > 0 &&
-		config.maxRemovalsPerRun <= 100
-			? config.maxRemovalsPerRun
-			: 0;
+		config.maxRemovalsPerRun <= 100;
+	const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
 
 	let directRetries: Awaited<ReturnType<typeof prisma.libraryCleanupApproval.findMany>> = [];
 	let fairnessDeferredRetries: typeof directRetries = [];
@@ -4359,6 +4358,11 @@ export async function executeDirectRemoval(
 	}
 
 	const allWarnings = withSharedPlexWarning([...(warnings ?? [])], runtimeSafetyBlocks);
+	if (!configuredRunLimitIsValid) {
+		allWarnings.push(
+			"Cleanup did not mutate any items because the stored per-run removal limit is invalid. Set it to a whole number from 1 through 100.",
+		);
+	}
 	if (exemptionPolicyBlocks > 0) {
 		allWarnings.push(
 			`${exemptionPolicyBlocks} cleanup ${

--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -3,6 +3,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const executorMocks = vi.hoisted(() => ({
 	buildEvalContext: vi.fn(),
+	CleanupPolicyMutationConflictError: class CleanupPolicyMutationConflictError extends Error {
+		constructor() {
+			super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
+		}
+	},
 	CleanupRunAlreadyInProgressError: class CleanupRunAlreadyInProgressError extends Error {
 		constructor() {
 			super("A cleanup operation is already in progress");
@@ -14,10 +19,17 @@ const executorMocks = vi.hoisted(() => ({
 	executeRetryItems: vi
 		.fn()
 		.mockResolvedValue({ removed: 0, reconciled: 1, failed: 0, errors: [] }),
+	withCleanupPolicyMutationLease: vi.fn(
+		async (_deps: unknown, _userId: string, mutate: () => Promise<unknown>) => await mutate(),
+	),
 }));
 
 vi.mock("../../lib/library-cleanup/cleanup-executor.js", () => executorMocks);
 
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupMaintenanceGuard,
+} from "../../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import {
 	createInjectAuthenticated,
@@ -112,6 +124,28 @@ describe("library cleanup approval compare-and-set routes", () => {
 
 		expect(response.statusCode).toBe(409);
 		expect(response.json()).toEqual({ error: "A cleanup operation is already in progress" });
+	});
+
+	it("does not transition an approval while backup restore owns maintenance", async () => {
+		let finishMaintenance!: () => void;
+		const maintenanceBlocked = new Promise<void>((resolve) => {
+			finishMaintenance = resolve;
+		});
+		const maintenance = withCleanupMaintenanceGuard(() => maintenanceBlocked);
+
+		try {
+			const response = await createInjectAuthenticated(app)(
+				"POST",
+				"/library-cleanup/approval-queue/approval-1/approve",
+			);
+
+			expect(response.statusCode).toBe(409);
+			expect(updateMany).not.toHaveBeenCalled();
+			expect(executorMocks.executeApprovedItems).not.toHaveBeenCalled();
+		} finally {
+			finishMaintenance();
+			await maintenance;
+		}
 	});
 
 	it("does not transition expired approvals during bulk approval", async () => {
@@ -220,6 +254,24 @@ describe("library cleanup approval compare-and-set routes", () => {
 
 		expect(response.statusCode).toBe(409);
 		expect(response.json()).toEqual({ error: "A cleanup operation is already in progress" });
+	});
+
+	it("returns a retryable conflict when maintenance blocks manual cleanup", async () => {
+		let finishMaintenance!: () => void;
+		const maintenanceBlocked = new Promise<void>((resolve) => {
+			finishMaintenance = resolve;
+		});
+		const maintenance = withCleanupMaintenanceGuard(() => maintenanceBlocked);
+		executorMocks.executeCleanupRun.mockRejectedValueOnce(new CleanupMaintenanceConflictError());
+
+		try {
+			const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/execute");
+
+			expect(response.statusCode).toBe(409);
+		} finally {
+			finishMaintenance();
+			await maintenance;
+		}
 	});
 
 	it("warns when preview details were capped before reaching the route", async () => {

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -18,12 +18,18 @@ import type { FastifyPluginCallback } from "fastify";
 import { randomUUID } from "node:crypto";
 import {
 	buildEvalContext,
+	CleanupPolicyMutationConflictError,
 	CleanupRunAlreadyInProgressError,
 	executeApprovedItems,
 	executeCleanupPreview,
 	executeCleanupRun,
 	executeRetryItems,
+	withCleanupPolicyMutationLease,
 } from "../lib/library-cleanup/cleanup-executor.js";
+import {
+	CleanupMaintenanceConflictError,
+	withCleanupOperationGuard,
+} from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { explainItemAgainstRulesViaEngine } from "../lib/rules/cleanup-adapter.js";
 import type { CacheItemForEval } from "../lib/library-cleanup/types.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
@@ -37,6 +43,19 @@ const EXECUTE_RATE_LIMIT = { max: 3, timeWindow: "1 minute" };
 
 // In-memory guard against concurrent execute/preview overlap (single-admin app)
 let cleanupRunInProgress = false;
+
+function isCleanupConflict(
+	error: unknown,
+): error is
+	| CleanupRunAlreadyInProgressError
+	| CleanupMaintenanceConflictError
+	| CleanupPolicyMutationConflictError {
+	return (
+		error instanceof CleanupRunAlreadyInProgressError ||
+		error instanceof CleanupMaintenanceConflictError ||
+		error instanceof CleanupPolicyMutationConflictError
+	);
+}
 
 // ============================================================================
 // Serialization helpers
@@ -381,11 +400,20 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		});
 
 		if (!config) {
-			// Auto-create default config
-			config = await app.prisma.libraryCleanupConfig.create({
-				data: { userId },
-				include: { rules: { orderBy: { priority: "asc" } } },
-			});
+			// Auto-create the coordination row while restore and cleanup-sensitive
+			// writes are excluded.
+			config = await withCleanupPolicyMutationLease(
+				{ prisma: app.prisma, log: request.log },
+				userId,
+				async () => {
+					const initialized = await app.prisma.libraryCleanupConfig.findUnique({
+						where: { userId },
+						include: { rules: { orderBy: { priority: "asc" } } },
+					});
+					if (!initialized) throw new Error("Cleanup configuration could not be initialized");
+					return initialized;
+				},
+			);
 		}
 
 		return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
@@ -396,24 +424,30 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const data = validateRequest(updateCleanupConfigSchema, request.body);
 
-		const config = await app.prisma.libraryCleanupConfig.upsert({
-			where: { userId },
-			update: data,
-			create: { userId, ...data },
-			include: { rules: { orderBy: { priority: "asc" } } },
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const config = await app.prisma.libraryCleanupConfig.upsert({
+					where: { userId },
+					update: data,
+					create: { userId, ...data },
+					include: { rules: { orderBy: { priority: "asc" } } },
+				});
 
-		// Recalculate nextRunAt when enabled or intervalHours changes
-		if (config.enabled && (!config.nextRunAt || data.intervalHours != null)) {
-			const newNextRun = new Date(Date.now() + config.intervalHours * 60 * 60 * 1000);
-			await app.prisma.libraryCleanupConfig.update({
-				where: { id: config.id },
-				data: { nextRunAt: newNextRun },
-			});
-			(config as Record<string, unknown>).nextRunAt = newNextRun;
-		}
+				// Recalculate nextRunAt when enabled or intervalHours changes
+				if (config.enabled && (!config.nextRunAt || data.intervalHours != null)) {
+					const newNextRun = new Date(Date.now() + config.intervalHours * 60 * 60 * 1000);
+					await app.prisma.libraryCleanupConfig.update({
+						where: { id: config.id },
+						data: { nextRunAt: newNextRun },
+					});
+					(config as Record<string, unknown>).nextRunAt = newNextRun;
+				}
 
-		return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
+				return reply.send(serializeConfig(config as unknown as Record<string, unknown>));
+			},
+		);
 	});
 
 	// ─── Rules CRUD ───────────────────────────────────────────────────
@@ -440,34 +474,44 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			return reply.status(404).send({ error: "Config not found. Initialize config first." });
 		}
 
-		const rule = await app.prisma.libraryCleanupRule.create({
-			data: {
-				configId: config.id,
-				name: data.name,
-				enabled: data.enabled,
-				priority: data.priority,
-				ruleType: data.ruleType,
-				parameters: JSON.stringify(data.parameters),
-				serviceFilter: data.serviceFilter ? JSON.stringify(data.serviceFilter) : null,
-				instanceFilter: data.instanceFilter ? JSON.stringify(data.instanceFilter) : null,
-				excludeTags: data.excludeTags ? JSON.stringify(data.excludeTags) : null,
-				excludeTitles: data.excludeTitles ? JSON.stringify(data.excludeTitles) : null,
-				plexLibraryFilter: data.plexLibraryFilter ? JSON.stringify(data.plexLibraryFilter) : null,
-				action: data.action ?? "delete",
-				operator: data.operator ?? null,
-				conditions: data.conditions ? JSON.stringify(data.conditions) : null,
-				retentionMode: data.retentionMode ?? false,
-				useGlobalRejectionMemory: data.useGlobalRejectionMemory ?? true,
-				// `?? 0` would collapse a deliberate `null` (forever) to `0` (off),
-				// silently downgrading "Forever" → "Off" on rule creation. The
-				// encoding contract is null=forever, 0=off, N>0=days — so only
-				// substitute the default for `undefined`. PUT path on rule update
-				// uses the same `!== undefined` discipline; keep them symmetric.
-				rejectionMemoryDays: data.rejectionMemoryDays === undefined ? 0 : data.rejectionMemoryDays,
-			},
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const rule = await app.prisma.libraryCleanupRule.create({
+					data: {
+						configId: config.id,
+						name: data.name,
+						enabled: data.enabled,
+						priority: data.priority,
+						ruleType: data.ruleType,
+						parameters: JSON.stringify(data.parameters),
+						serviceFilter: data.serviceFilter ? JSON.stringify(data.serviceFilter) : null,
+						instanceFilter: data.instanceFilter ? JSON.stringify(data.instanceFilter) : null,
+						excludeTags: data.excludeTags ? JSON.stringify(data.excludeTags) : null,
+						excludeTitles: data.excludeTitles ? JSON.stringify(data.excludeTitles) : null,
+						plexLibraryFilter: data.plexLibraryFilter
+							? JSON.stringify(data.plexLibraryFilter)
+							: null,
+						action: data.action ?? "delete",
+						operator: data.operator ?? null,
+						conditions: data.conditions ? JSON.stringify(data.conditions) : null,
+						retentionMode: data.retentionMode ?? false,
+						useGlobalRejectionMemory: data.useGlobalRejectionMemory ?? true,
+						// `?? 0` would collapse a deliberate `null` (forever) to `0` (off),
+						// silently downgrading "Forever" → "Off" on rule creation. The
+						// encoding contract is null=forever, 0=off, N>0=days — so only
+						// substitute the default for `undefined`. PUT path on rule update
+						// uses the same `!== undefined` discipline; keep them symmetric.
+						rejectionMemoryDays:
+							data.rejectionMemoryDays === undefined ? 0 : data.rejectionMemoryDays,
+					},
+				});
 
-		return reply.status(201).send(serializeRule(rule as unknown as Record<string, unknown>));
+				return reply.status(201).send(serializeRule(rule as unknown as Record<string, unknown>));
+			},
+			{ configId: config.id },
+		);
 	});
 
 	/** PUT /api/library-cleanup/rules/reorder */
@@ -475,42 +519,57 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const { ruleIds } = validateRequest(reorderRulesSchema, request.body);
 
-		const config = await app.prisma.libraryCleanupConfig.findUnique({
+		const configRef = await app.prisma.libraryCleanupConfig.findUnique({
 			where: { userId },
-			include: { rules: { select: { id: true } } },
+			select: { id: true },
 		});
-		if (!config) {
+		if (!configRef) {
 			return reply.status(404).send({ error: "Config not found" });
 		}
 
-		// Verify all IDs belong to this config and all rules are included
-		const existingIds = new Set(config.rules.map((r) => r.id));
-		if (ruleIds.length !== existingIds.size) {
-			return reply.status(400).send({
-				error: `Expected ${existingIds.size} rule IDs but received ${ruleIds.length}`,
-			});
-		}
-		for (const id of ruleIds) {
-			if (!existingIds.has(id)) {
-				return reply.status(400).send({ error: `Rule ${id} not found in config` });
-			}
-		}
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const config = await app.prisma.libraryCleanupConfig.findUnique({
+					where: { userId },
+					include: { rules: { select: { id: true } } },
+				});
+				if (!config) {
+					return reply.status(404).send({ error: "Config not found" });
+				}
 
-		// Assign sequential priorities in a transaction
-		await app.prisma.$transaction(
-			ruleIds.map((id, index) =>
-				app.prisma.libraryCleanupRule.update({
-					where: { id },
-					data: { priority: index },
-				}),
-			),
+				// Verify all IDs belong to this config and all rules are included
+				const existingIds = new Set(config.rules.map((r) => r.id));
+				if (ruleIds.length !== existingIds.size) {
+					return reply.status(400).send({
+						error: `Expected ${existingIds.size} rule IDs but received ${ruleIds.length}`,
+					});
+				}
+				for (const id of ruleIds) {
+					if (!existingIds.has(id)) {
+						return reply.status(400).send({ error: `Rule ${id} not found in config` });
+					}
+				}
+
+				// Assign sequential priorities in a transaction
+				await app.prisma.$transaction(
+					ruleIds.map((id, index) =>
+						app.prisma.libraryCleanupRule.update({
+							where: { id },
+							data: { priority: index },
+						}),
+					),
+				);
+
+				const updated = await app.prisma.libraryCleanupConfig.findUnique({
+					where: { userId },
+					include: { rules: { orderBy: { priority: "asc" } } },
+				});
+				return reply.send(serializeConfig(updated as unknown as Record<string, unknown>));
+			},
+			{ configId: configRef.id },
 		);
-
-		const updated = await app.prisma.libraryCleanupConfig.findUnique({
-			where: { userId },
-			include: { rules: { orderBy: { priority: "asc" } } },
-		});
-		return reply.send(serializeConfig(updated as unknown as Record<string, unknown>));
 	});
 
 	/** PUT /api/library-cleanup/rules/:id */
@@ -581,12 +640,19 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		if (data.rejectionMemoryDays !== undefined)
 			updateData.rejectionMemoryDays = data.rejectionMemoryDays;
 
-		const rule = await app.prisma.libraryCleanupRule.update({
-			where: { id },
-			data: updateData,
-		});
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const rule = await app.prisma.libraryCleanupRule.update({
+					where: { id },
+					data: updateData,
+				});
 
-		return reply.send(serializeRule(rule as unknown as Record<string, unknown>));
+				return reply.send(serializeRule(rule as unknown as Record<string, unknown>));
+			},
+			{ configId: existing.configId },
+		);
 	});
 
 	/** DELETE /api/library-cleanup/rules/:id */
@@ -601,8 +667,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			return reply.status(404).send({ error: "Rule not found" });
 		}
 
-		await app.prisma.libraryCleanupRule.delete({ where: { id } });
-		return reply.status(204).send();
+		return await withCleanupPolicyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				await app.prisma.libraryCleanupRule.delete({ where: { id } });
+				return reply.status(204).send();
+			},
+			{ configId: existing.configId },
+		);
 	});
 
 	// ─── Preview & Execute ────────────────────────────────────────────
@@ -768,7 +841,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 
 				return reply.send(result);
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				request.log.error({ err: error }, "Cleanup execution failed");
@@ -849,46 +922,46 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			const { id } = request.params;
 			const approvalRequestToken = randomUUID();
 
-			const transition = await app.prisma.libraryCleanupApproval.updateMany({
-				where: {
-					id,
-					config: { userId },
-					status: "pending",
-					expiresAt: { gt: new Date() },
-				},
-				data: {
-					status: "approved",
-					executionToken: approvalRequestToken,
-					reviewedAt: new Date(),
-				},
-			});
-			if (transition.count !== 1) {
-				return reply.status(404).send({ error: "Approval not found or not pending" });
-			}
-
-			// Execute immediately
-			let result: Awaited<ReturnType<typeof executeApprovedItems>>;
 			try {
-				result = await executeApprovedItems(
-					{
-						prisma: app.prisma,
-						arrClientFactory: app.arrClientFactory,
-						encryptor: app.encryptor,
-						log: request.log,
-					},
-					userId,
-					[id],
-					approvalRequestToken,
-				);
+				return await withCleanupOperationGuard(async () => {
+					const transition = await app.prisma.libraryCleanupApproval.updateMany({
+						where: {
+							id,
+							config: { userId },
+							status: "pending",
+							expiresAt: { gt: new Date() },
+						},
+						data: {
+							status: "approved",
+							executionToken: approvalRequestToken,
+							reviewedAt: new Date(),
+						},
+					});
+					if (transition.count !== 1) {
+						return reply.status(404).send({ error: "Approval not found or not pending" });
+					}
+
+					const result = await executeApprovedItems(
+						{
+							prisma: app.prisma,
+							arrClientFactory: app.arrClientFactory,
+							encryptor: app.encryptor,
+							log: request.log,
+						},
+						userId,
+						[id],
+						approvalRequestToken,
+					);
+
+					// nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Fastify JSON response
+					return reply.send(result);
+				});
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				throw error;
 			}
-
-			// nosemgrep: javascript.express.security.audit.xss.direct-response-write.direct-response-write -- Fastify JSON response
-			return reply.send(result);
 		},
 	);
 
@@ -912,7 +985,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				);
 				return reply.send(result);
 			} catch (error) {
-				if (error instanceof CleanupRunAlreadyInProgressError) {
+				if (isCleanupConflict(error)) {
 					return reply.status(409).send({ error: error.message });
 				}
 				throw error;
@@ -927,15 +1000,24 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			const userId = request.currentUser!.id;
 			const { id } = request.params;
 
-			const transition = await app.prisma.libraryCleanupApproval.updateMany({
-				where: { id, config: { userId }, status: "pending" },
-				data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
-			});
-			if (transition.count !== 1) {
-				return reply.status(404).send({ error: "Approval not found or not pending" });
-			}
+			try {
+				return await withCleanupOperationGuard(async () => {
+					const transition = await app.prisma.libraryCleanupApproval.updateMany({
+						where: { id, config: { userId }, status: "pending" },
+						data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
+					});
+					if (transition.count !== 1) {
+						return reply.status(404).send({ error: "Approval not found or not pending" });
+					}
 
-			return reply.status(204).send();
+					return reply.status(204).send();
+				});
+			} catch (error) {
+				if (isCleanupConflict(error)) {
+					return reply.status(409).send({ error: error.message });
+				}
+				throw error;
+			}
 		},
 	);
 
@@ -944,51 +1026,53 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const userId = request.currentUser!.id;
 		const { ids, action } = validateRequest(bulkApprovalSchema, request.body);
 
-		if (action === "rejected") {
-			const result = await app.prisma.libraryCleanupApproval.updateMany({
-				where: { id: { in: ids }, config: { userId }, status: "pending" },
-				data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
-			});
-			return reply.send({ updated: result.count });
-		}
-
-		// Approve and execute
-		const approvalRequestToken = randomUUID();
-		await app.prisma.libraryCleanupApproval.updateMany({
-			where: {
-				id: { in: ids },
-				config: { userId },
-				status: "pending",
-				expiresAt: { gt: new Date() },
-			},
-			data: {
-				status: "approved",
-				executionToken: approvalRequestToken,
-				reviewedAt: new Date(),
-			},
-		});
-
-		let result: Awaited<ReturnType<typeof executeApprovedItems>>;
 		try {
-			result = await executeApprovedItems(
-				{
-					prisma: app.prisma,
-					arrClientFactory: app.arrClientFactory,
-					encryptor: app.encryptor,
-					log: request.log,
-				},
-				userId,
-				ids,
-				approvalRequestToken,
-			);
+			return await withCleanupOperationGuard(async () => {
+				if (action === "rejected") {
+					const result = await app.prisma.libraryCleanupApproval.updateMany({
+						where: { id: { in: ids }, config: { userId }, status: "pending" },
+						data: { status: "rejected", executionToken: null, reviewedAt: new Date() },
+					});
+					return reply.send({ updated: result.count });
+				}
+
+				// Approve and execute under one guard so restore cannot observe
+				// an intermediate approved state.
+				const approvalRequestToken = randomUUID();
+				await app.prisma.libraryCleanupApproval.updateMany({
+					where: {
+						id: { in: ids },
+						config: { userId },
+						status: "pending",
+						expiresAt: { gt: new Date() },
+					},
+					data: {
+						status: "approved",
+						executionToken: approvalRequestToken,
+						reviewedAt: new Date(),
+					},
+				});
+
+				const result = await executeApprovedItems(
+					{
+						prisma: app.prisma,
+						arrClientFactory: app.arrClientFactory,
+						encryptor: app.encryptor,
+						log: request.log,
+					},
+					userId,
+					ids,
+					approvalRequestToken,
+				);
+
+				return reply.send(result);
+			});
 		} catch (error) {
-			if (error instanceof CleanupRunAlreadyInProgressError) {
+			if (isCleanupConflict(error)) {
 				return reply.status(409).send({ error: error.message });
 			}
 			throw error;
 		}
-
-		return reply.send(result);
 	});
 
 	// ─── Logs ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This is the focused `next` parity follow-up to #634. It forward-ports only the final coordination safeguards discovered during the 2.x review, while preserving 3.0's rule engine, deployed exemption checks, and other next-only behavior.

- coordinates cleanup config and rule writes with backup maintenance and the cleanup database lease
- guards approval, rejection, and bulk transitions across the complete transition/execution boundary
- treats cleanup maintenance and policy conflicts as retryable HTTP 409 responses
- fails closed when a persisted direct removal limit is outside the supported `1–100` range

## Verification

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 3,279 passed, 41 skipped
- `pnpm run lint`
- `pnpm run build`
- focused safety tests — 195 passed
- independent regression and deletion-safety reviews — both clear

No live destructive multi-Radarr/Plex test was run because this environment does not have a representative topology. The affected boundaries are covered by coordination, invalid-cap, approval-transition, and mutation-safety regressions.

Related to #616