### PR TITLE
fix(plex): accept null player access tokens

### DIFF
--- a/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
@@ -249,6 +249,39 @@ describe("POST /oauth/servers", () => {
 		expect(body.servers[0].name).toBe("My Server");
 	});
 
+	it("ignores player resources with a null access token", async () => {
+		const tokenRef = await getTokenRef();
+		const plexResources = [
+			{
+				name: "My Server",
+				clientIdentifier: "server-1",
+				provides: "server",
+				owned: true,
+				accessToken: "server-token",
+				connections: [],
+			},
+			{
+				name: "Living room",
+				clientIdentifier: "player-1",
+				provides: "player,pubsub-player",
+				owned: true,
+				accessToken: null,
+				connections: [],
+			},
+		];
+
+		mockFetch.mockResolvedValueOnce(jsonResponse(plexResources));
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.servers).toHaveLength(1);
+		expect(body.servers[0].name).toBe("My Server");
+	});
+
 	it("returns 400 when plex.tv returns 401 (expired token)", async () => {
 		const tokenRef = await getTokenRef();
 		mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));

--- a/apps/api/src/routes/plex/oauth-routes.ts
+++ b/apps/api/src/routes/plex/oauth-routes.ts
@@ -68,7 +68,7 @@ const plexTvResourceSchema = z.object({
 	provides: z.string(),
 	owned: z.boolean().optional(),
 	connections: z.array(plexTvResourceConnectionSchema).optional(),
-	accessToken: z.string().optional(),
+	accessToken: z.string().nullable().optional(),
 	productVersion: z.string().optional(),
 	platform: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- accept the explicit `null` access tokens Plex returns for player-only resources
- keep filtering discovery results to owned Plex servers
- cover an account containing both a server and a player with a null token

## Root cause

The Plex resources schema accepted only string or omitted access tokens. Plex returns `accessToken: null` for player devices, so one player caused validation of the entire resources response to fail before the existing server filter ran.

## Validation

- reproduced the reported mixed server/player payload as a failing regression test (502 before the fix)
- focused Plex OAuth tests: 17 passed
- format passed
- shared build passed
- turbo typecheck passed
- full tests: 2,867 passed, 41 skipped
- lint passed

A live affected Plex account was not available, so external verification is represented by the reporter's exact response shape in the regression test.

Closes #631