### PR TITLE
fix(plex): accept null player access tokens on next

### DIFF
--- a/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/oauth-routes.test.ts
@@ -249,6 +249,39 @@ describe("POST /oauth/servers", () => {
 		expect(body.servers[0].name).toBe("My Server");
 	});
 
+	it("ignores player resources with a null access token", async () => {
+		const tokenRef = await getTokenRef();
+		const plexResources = [
+			{
+				name: "My Server",
+				clientIdentifier: "server-1",
+				provides: "server",
+				owned: true,
+				accessToken: "server-token",
+				connections: [],
+			},
+			{
+				name: "Living room",
+				clientIdentifier: "player-1",
+				provides: "player,pubsub-player",
+				owned: true,
+				accessToken: null,
+				connections: [],
+			},
+		];
+
+		mockFetch.mockResolvedValueOnce(jsonResponse(plexResources));
+
+		const res = await injectAuthenticated("POST", "/oauth/servers", {
+			body: { tokenRef, clientId: VALID_CLIENT_ID },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const body = res.json();
+		expect(body.servers).toHaveLength(1);
+		expect(body.servers[0].name).toBe("My Server");
+	});
+
 	it("returns 400 when plex.tv returns 401 (expired token)", async () => {
 		const tokenRef = await getTokenRef();
 		mockFetch.mockResolvedValueOnce(jsonResponse({}, 401));

--- a/apps/api/src/routes/plex/oauth-routes.ts
+++ b/apps/api/src/routes/plex/oauth-routes.ts
@@ -68,7 +68,7 @@ const plexTvResourceSchema = z.object({
 	provides: z.string(),
 	owned: z.boolean().optional(),
 	connections: z.array(plexTvResourceConnectionSchema).optional(),
-	accessToken: z.string().optional(),
+	accessToken: z.string().nullable().optional(),
 	productVersion: z.string().optional(),
 	platform: z.string().optional(),
 });


### PR DESCRIPTION
## Summary

- carry the Plex player-resource schema fix from `main` to `next`
- accept the explicit `null` access tokens Plex returns for player-only resources
- retain owned-server filtering and cover the mixed server/player response shape

## Root cause

The 3.0 Plex resources schema had the same `string | undefined` assumption as 2.x. An explicit null token on any player invalidated the entire resource array before server filtering.

## Validation

- focused Plex OAuth tests: 17 passed
- format passed
- shared build passed
- turbo typecheck passed
- full tests: 3,280 passed, 41 skipped
- lint passed

The production change and regression payload match the reviewed 2.x fix in #636. A live affected Plex account was not available.

Related to #631