### PR TITLE
Fix bodyless POST requests rejected by Fastify

### DIFF
--- a/apps/web/src/lib/api-client/base.test.ts
+++ b/apps/web/src/lib/api-client/base.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiRequest } from "./base";
+
+const jsonResponse = (body: unknown) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+
+describe("apiRequest", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("sends body-less POST actions as explicit empty JSON", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ running: true }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await apiRequest("/api/hunting/scheduler/toggle", { method: "POST" });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/hunting/scheduler/toggle",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
+				body: "{}",
+			}),
+		);
+	});
+
+	it("leaves payload-free GET requests body-less", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await apiRequest("/api/status");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/status",
+			expect.objectContaining({
+				method: "GET",
+				headers: { Accept: "application/json" },
+				body: undefined,
+			}),
+		);
+	});
+
+	it("preserves caller-provided request bodies", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+		vi.stubGlobal("fetch", fetchMock);
+		const body = new FormData();
+		body.append("file", "contents");
+
+		await apiRequest("/api/import", { method: "POST", body });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/import",
+			expect.objectContaining({
+				method: "POST",
+				headers: { Accept: "application/json" },
+				body,
+			}),
+		);
+	});
+});

--- a/apps/web/src/lib/api-client/base.ts
+++ b/apps/web/src/lib/api-client/base.ts
@@ -45,19 +45,27 @@ const resolveUrl = (path: string): string => {
 };
 
 export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
-	const { json, headers, ...rest } = options;
+	const { json, headers, body, method: requestedMethod, ...rest } = options;
+	const method = requestedMethod ?? (json !== undefined ? "POST" : "GET");
+	// Next.js may forward a body-less POST with chunked transfer encoding. Fastify
+	// then sees a request body without a media type and rejects it before the route
+	// handler runs. Give no-payload POST actions an explicit JSON representation.
+	const sendsEmptyJson =
+		method.toUpperCase() === "POST" && json === undefined && body === undefined;
+	const sendsJson = json !== undefined || sendsEmptyJson;
+	const jsonPayload = json !== undefined ? json : {};
 
 	let response: Response;
 	try {
 		response = await fetch(resolveUrl(path), {
-			method: options.method ?? (json ? "POST" : "GET"),
+			method,
 			credentials: "include",
 			headers: {
 				Accept: "application/json",
-				...(json ? { "Content-Type": "application/json" } : {}),
+				...(sendsJson ? { "Content-Type": "application/json" } : {}),
 				...headers,
 			},
-			body: json ? JSON.stringify(json) : options.body,
+			body: sendsJson ? JSON.stringify(jsonPayload) : body,
 			...rest,
 		});
 	} catch (error) {


### PR DESCRIPTION
## Summary

- encode no-payload POST requests as an explicit empty JSON object in the shared web API client
- preserve payload-free GET requests and caller-provided request bodies
- add focused regression coverage for the request transport behavior

## Root cause

A bodyless POST can be forwarded through the Next.js rewrite using chunked transfer encoding without a `Content-Type` header. Fastify then sees a request body with no registered media type and returns `FST_ERR_CTP_INVALID_MEDIA_TYPE` before the route handler runs. JSON-bearing mutations do not hit this failure mode.

The shared request helper now sends `{}` with `Content-Type: application/json` for POST requests that do not otherwise provide a payload. This fixes Hunting and protects the other existing no-payload POST actions, including Queue Cleaner, without changing GETs, form bodies, or other caller-provided payloads.

## Validation

- reproduced HTTP 415 on `/api/hunting/scheduler/toggle` with the reporter's bodyless/chunked transport shape
- production Next.js build browser verification: Hunting toggle returned 200 with JSON `{}`
- production Next.js build browser verification: Queue Cleaner toggle returned 200 with JSON `{}`
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 2,870 passed, 41 skipped
- `pnpm run lint`

Closes #626