### PR TITLE
Forward-port bodyless POST normalization to next

### DIFF
--- a/apps/web/src/lib/api-client/base.test.ts
+++ b/apps/web/src/lib/api-client/base.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { apiRequest } from "./base";
+
+const jsonResponse = (body: unknown) =>
+	new Response(JSON.stringify(body), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+
+describe("apiRequest", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("sends body-less POST actions as explicit empty JSON", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ running: true }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await apiRequest("/api/hunting/scheduler/toggle", { method: "POST" });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/hunting/scheduler/toggle",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					Accept: "application/json",
+					"Content-Type": "application/json",
+				},
+				body: "{}",
+			}),
+		);
+	});
+
+	it("leaves payload-free GET requests body-less", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await apiRequest("/api/status");
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/status",
+			expect.objectContaining({
+				method: "GET",
+				headers: { Accept: "application/json" },
+				body: undefined,
+			}),
+		);
+	});
+
+	it("preserves caller-provided request bodies", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }));
+		vi.stubGlobal("fetch", fetchMock);
+		const body = new FormData();
+		body.append("file", "contents");
+
+		await apiRequest("/api/import", { method: "POST", body });
+
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/import",
+			expect.objectContaining({
+				method: "POST",
+				headers: { Accept: "application/json" },
+				body,
+			}),
+		);
+	});
+});

--- a/apps/web/src/lib/api-client/base.ts
+++ b/apps/web/src/lib/api-client/base.ts
@@ -47,19 +47,27 @@ const resolveUrl = (path: string): string => {
 };
 
 export async function apiRequest<T>(path: string, options: RequestOptions = {}): Promise<T> {
-	const { json, headers, ...rest } = options;
+	const { json, headers, body, method: requestedMethod, ...rest } = options;
+	const method = requestedMethod ?? (json !== undefined ? "POST" : "GET");
+	// Next.js may forward a body-less POST with chunked transfer encoding. Fastify
+	// then sees a request body without a media type and rejects it before the route
+	// handler runs. Give no-payload POST actions an explicit JSON representation.
+	const sendsEmptyJson =
+		method.toUpperCase() === "POST" && json === undefined && body === undefined;
+	const sendsJson = json !== undefined || sendsEmptyJson;
+	const jsonPayload = json !== undefined ? json : {};
 
 	let response: Response;
 	try {
 		response = await fetch(resolveUrl(path), {
-			method: options.method ?? (json ? "POST" : "GET"),
+			method,
 			credentials: "include",
 			headers: {
 				Accept: "application/json",
-				...(json ? { "Content-Type": "application/json" } : {}),
+				...(sendsJson ? { "Content-Type": "application/json" } : {}),
 				...headers,
 			},
-			body: json ? JSON.stringify(json) : options.body,
+			body: sendsJson ? JSON.stringify(jsonPayload) : body,
 			...rest,
 		});
 	} catch (error) {


### PR DESCRIPTION
## Summary

- forward-port the validated no-payload POST normalization from PR #638
- preserve the newer `next` unauthorized-session event behavior
- carry the focused regression coverage for POST, GET, and caller-provided body handling

## Why

Issue #626 exposed a transport-level failure where a bodyless POST forwarded with chunked transfer encoding reached Fastify without a media type and was rejected before the route handler ran. The stable fix sends an explicit `{}` JSON payload for POST requests that do not otherwise provide a body.

This keeps `next` aligned with `main` and protects Hunting, Queue Cleaner, and the other existing no-payload POST actions without changing GET requests or caller-provided bodies.

## Validation

- focused API-client regression tests — 3 passed
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — 3,283 passed, 41 skipped
- `pnpm run lint`

Forward-port of #638.