### PR TITLE
fix: show executed cleanup approvals in approved tab on next

### DIFF
--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -59,28 +59,30 @@ describe("library cleanup approval compare-and-set routes", () => {
 		app.decorate("prisma", {
 			libraryCleanupApproval: {
 				updateMany,
-				findMany: vi.fn(async ({ where }: { where: { status: string } }) => [
-					{
-						id: "retry-1",
-						instanceId: "radarr-1",
-						arrItemId: 101,
-						itemType: "movie",
-						title: "Example Movie",
-						matchedRuleId: "rule-1",
-						matchedRuleName: "Cleanup",
-						reason: "Matched",
-						action: "delete",
-						sizeOnDisk: 1000n,
-						year: 2024,
-						rating: 8,
-						status: where.status,
-						lastExecutionError: "Radarr is unavailable",
-						reviewedAt: new Date(),
-						executedAt: null,
-						createdAt: new Date(),
-						expiresAt: new Date(Date.now() + 60_000),
-					},
-				]),
+				findMany: vi.fn(
+					async ({ where }: { where: { status?: string; OR?: Array<{ status: string }> } }) => [
+						{
+							id: "retry-1",
+							instanceId: "radarr-1",
+							arrItemId: 101,
+							itemType: "movie",
+							title: "Example Movie",
+							matchedRuleId: "rule-1",
+							matchedRuleName: "Cleanup",
+							reason: "Matched",
+							action: "delete",
+							sizeOnDisk: 1000n,
+							year: 2024,
+							rating: 8,
+							status: where.status ?? "executed",
+							lastExecutionError: "Radarr is unavailable",
+							reviewedAt: new Date(),
+							executedAt: null,
+							createdAt: new Date(),
+							expiresAt: new Date(Date.now() + 60_000),
+						},
+					],
+				),
 				count: vi.fn().mockResolvedValue(1),
 			},
 			serviceInstance: {
@@ -225,6 +227,44 @@ describe("library cleanup approval compare-and-set routes", () => {
 			});
 		},
 	);
+
+	it("shows operator-approved executed rows in the Approved tab query", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/library-cleanup/approval-queue?status=approved",
+		);
+
+		expect(response.statusCode).toBe(200);
+		expect(app.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					config: { userId: "user-1" },
+					OR: [
+						{ status: "approved" },
+						{ status: "executed", id: { not: { startsWith: "mutation-intent:" } } },
+					],
+				},
+			}),
+		);
+		expect(app.prisma.libraryCleanupApproval.count).toHaveBeenCalledWith({
+			where: {
+				config: { userId: "user-1" },
+				OR: [
+					{ status: "approved" },
+					{ status: "executed", id: { not: { startsWith: "mutation-intent:" } } },
+				],
+			},
+		});
+		expect(response.json()).toMatchObject({
+			items: [
+				{
+					status: "executed",
+					instanceLabel: "Radarr",
+				},
+			],
+			total: 1,
+		});
+	});
 
 	it("explicitly resumes a durable retry independently of cleanup mode", async () => {
 		const response = await createInjectAuthenticated(app)(

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -871,12 +871,21 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		];
 		const rawStatus = (request.query as Record<string, string>).status || "pending";
 		const statusFilter = validStatuses.includes(rawStatus) ? rawStatus : "pending";
+		const statusWhere =
+			statusFilter === "approved"
+				? {
+						OR: [
+							{ status: "approved" },
+							{ status: "executed", id: { not: { startsWith: "mutation-intent:" } } },
+						],
+					}
+				: { status: statusFilter };
 
 		const [approvals, total] = await Promise.all([
 			app.prisma.libraryCleanupApproval.findMany({
 				where: {
 					config: { userId },
-					status: statusFilter,
+					...statusWhere,
 				},
 				orderBy: { createdAt: "desc" },
 				skip: (page - 1) * pageSize,
@@ -885,7 +894,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			app.prisma.libraryCleanupApproval.count({
 				where: {
 					config: { userId },
-					status: statusFilter,
+					...statusWhere,
 				},
 			}),
 		]);


### PR DESCRIPTION
﻿## Summary
- forward-port #617 Approved tab fix from `main` to `next`
- include completed operator-approved `executed` approvals when the Approved tab requests approved items
- keep literal `approved` rows included for any in-flight or legacy approval state
- exclude automatic cleanup mutation intents (`mutation-intent:` rows) so automatic deletions do not appear as user approvals

## Root Cause
Approving a cleanup item transitions it through `approved` and immediately executes it. Successful manual approvals are persisted as `executed`, but the Approved tab queried only `status=approved`, so successfully approved items disappeared from that tab.

Automatic cleanup runs also persist executed mutation intents in the same table. The fix therefore filters by approval provenance: `approved` rows are shown, and `executed` rows are shown only when they are not direct `mutation-intent:` rows.

## Validation
- `pnpm install --frozen-lockfile` with Node 20.19.6
- `pnpm exec biome format --write apps/api/src/routes/library-cleanup.ts apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts`
- `pnpm --filter @arr/api lint -- src/routes/library-cleanup.ts src/routes/__tests__/library-cleanup-approval-cas.test.ts`
- `pnpm --filter @arr/api typecheck`
- `pnpm --filter @arr/api test -- src/routes/__tests__/library-cleanup-approval-cas.test.ts` (repo script ran API suite: 215 files, 2534 tests passed)
- `git diff --check`

Forward-port of #642 for #617.
