### PR TITLE
fix: limit seerr attention to failed requests

### DIFF
--- a/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
+++ b/apps/api/src/routes/seerr/__tests__/request-routes.test.ts
@@ -185,6 +185,77 @@ describe("GET /:instanceId/count", () => {
 });
 
 // ===========================================================================
+// GET /:instanceId/attention — Requests needing admin intervention
+// ===========================================================================
+
+describe("GET /:instanceId/attention", () => {
+	it("returns failed requests as attention items", async () => {
+		const failedRequest = {
+			...sampleRequest,
+			id: 99,
+			status: 4,
+			updatedAt: "2024-01-01T00:00:00.000Z",
+			media: { ...sampleRequest.media, title: "Failed Movie" },
+		};
+		const failedResult = {
+			pageInfo: { pages: 1, pageSize: 10, results: 1, page: 1 },
+			results: [failedRequest],
+		};
+		const enrichedResult = {
+			...failedResult,
+			results: [{ ...failedRequest, media: { ...failedRequest.media, title: "Enriched Movie" } }],
+		};
+
+		mockClient.getRequests.mockResolvedValueOnce(failedResult);
+		mockClient.enrichRequestsWithMedia.mockResolvedValueOnce(enrichedResult);
+
+		const res = await app.inject({
+			method: "GET",
+			url: "/api/seerr/requests/inst-1/attention",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.getRequests).toHaveBeenCalledTimes(1);
+		expect(mockClient.getRequests).toHaveBeenCalledWith({
+			filter: "failed",
+			take: 10,
+			sort: "modified",
+		});
+
+		const body = JSON.parse(res.payload);
+		expect(body.total).toBe(1);
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0]).toEqual(
+			expect.objectContaining({
+				reason: "failed",
+				request: enrichedResult.results[0],
+			}),
+		);
+		expect(body.items[0].ageMs).toBeGreaterThan(0);
+	});
+
+	it("does not classify approved processing requests as stuck attention items", async () => {
+		mockClient.getRequests.mockResolvedValueOnce({
+			pageInfo: { pages: 1, pageSize: 10, results: 0, page: 1 },
+			results: [],
+		});
+
+		const res = await app.inject({
+			method: "GET",
+			url: "/api/seerr/requests/inst-1/attention",
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockClient.getRequests).toHaveBeenCalledTimes(1);
+		expect(mockClient.getRequests).not.toHaveBeenCalledWith(
+			expect.objectContaining({ filter: "processing" }),
+		);
+		expect(mockClient.enrichRequestsWithMedia).not.toHaveBeenCalled();
+		expect(JSON.parse(res.payload)).toEqual({ items: [], total: 0 });
+	});
+});
+
+// ===========================================================================
 // GET /:instanceId/:requestId — Single request (enriched)
 // ===========================================================================
 

--- a/apps/api/src/routes/seerr/request-routes.ts
+++ b/apps/api/src/routes/seerr/request-routes.ts
@@ -5,7 +5,6 @@
  */
 
 import type { SeerrAttentionItem, SeerrUpdateRequestPayload } from "@arr/shared";
-import { SEERR_MEDIA_STATUS, SEERR_REQUEST_STATUS } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import { logSeerrAction } from "../../lib/seerr/seerr-action-logger.js";
@@ -13,8 +12,6 @@ import { requireSeerrClient } from "../../lib/seerr/seerr-client.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
-/** Requests approved but still processing after this threshold are flagged as stuck */
-const STUCK_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 hours
 /** Maximum attention items returned (dashboard signal, not a list page) */
 const ATTENTION_LIMIT = 10;
 
@@ -83,38 +80,21 @@ export async function registerRequestRoutes(app: FastifyInstance, _opts: Fastify
 		const client = await requireSeerrClient(app, request.currentUser!.id, instanceId);
 		const now = Date.now();
 
-		// Fetch failed and processing requests in parallel (graceful degradation)
-		const [failedResult, processingResult] = await Promise.allSettled([
-			client.getRequests({ filter: "failed", take: ATTENTION_LIMIT, sort: "modified" }),
-			client.getRequests({ filter: "processing", take: 50, sort: "modified" }),
-		]);
+		const failedResult = await client.getRequests({
+			filter: "failed",
+			take: ATTENTION_LIMIT,
+			sort: "modified",
+		});
 
 		const allItems: SeerrAttentionItem[] = [];
 
 		// All failed requests need attention
-		if (failedResult.status === "fulfilled") {
-			for (const req of failedResult.value.results) {
-				allItems.push({
-					request: req,
-					reason: "failed",
-					ageMs: now - new Date(req.updatedAt).getTime(),
-				});
-			}
-		}
-
-		// Processing requests are only "stuck" if approved + still processing + older than threshold
-		if (processingResult.status === "fulfilled") {
-			for (const req of processingResult.value.results) {
-				if (
-					req.status === SEERR_REQUEST_STATUS.APPROVED &&
-					req.media.status === SEERR_MEDIA_STATUS.PROCESSING
-				) {
-					const ageMs = now - new Date(req.updatedAt).getTime();
-					if (ageMs >= STUCK_THRESHOLD_MS) {
-						allItems.push({ request: req, reason: "stuck", ageMs });
-					}
-				}
-			}
+		for (const req of failedResult.results) {
+			allItems.push({
+				request: req,
+				reason: "failed",
+				ageMs: now - new Date(req.updatedAt).getTime(),
+			});
 		}
 
 		const total = allItems.length;


### PR DESCRIPTION
## Summary

- limit the Seerr attention endpoint to failed requests
- stop fetching processing requests for the attention widget
- add route tests that keep approved/processing requests out of needs-attention

## Root cause

The attention endpoint treated approved requests with processing media as stuck after 48 hours. In Seerr, approved/processing can be the normal waiting-for-release/download lifecycle, so age alone produced false positives.

## Validation

- pnpm exec biome format --write apps/api/src/routes/seerr/request-routes.ts apps/api/src/routes/seerr/__tests__/request-routes.test.ts
- pnpm --filter @arr/api lint -- src/routes/seerr/request-routes.ts src/routes/seerr/__tests__/request-routes.test.ts
- pnpm --filter @arr/api typecheck
- pnpm --filter @arr/api test -- src/routes/seerr/__tests__/request-routes.test.ts
- git diff --check

Fixes #620
