### PR TITLE
fix: repair qUI webhook registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ The `/config` volume contains critical data that must be preserved:
 | File | Purpose |
 |------|---------|
 | `prod.db` | SQLite database with all your settings, users, and configurations |
-| `secrets.json` | Auto-generated encryption keys for API credentials |
+| `secrets.json` | Auto-generated encryption keys and local installation identity |
 | `backups/` | Automated database backups (when enabled) |
 
 > **Important:** If `secrets.json` is lost, encrypted API keys cannot be decrypted. You would need to re-enter all service API keys. Always preserve your entire `/config` volume when upgrading or migrating.

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -1,6 +1,7 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { inspect } from "node:util";
 import { afterEach, describe, expect, it } from "vitest";
 import { readSecrets, writeSecrets } from "../../backup/backup-file-utils.js";
 import { Encryptor } from "../encryption.js";
@@ -152,11 +153,70 @@ describe("SecretManager installation identity", () => {
 			sessionCookieSecret: "e".repeat(32),
 		};
 
-		const first = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(overrides);
-		const second = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(overrides);
+		const firstManager = new SecretManager(secretsPath);
+		const secondManager = new SecretManager(secretsPath);
+		const first = firstManager.getOrCreateEnvironmentSecrets(overrides);
+		const second = secondManager.getOrCreateEnvironmentSecrets(overrides);
 
 		expect(first).toEqual(second);
 		expect(first).toMatchObject(overrides);
 		expect(first.installationId).toMatch(/^[a-f0-9]{32}$/);
+		expect(firstManager.secretsSynchronized).toBe(false);
+		expect(secondManager.secretsSynchronized).toBe(false);
+	});
+
+	it("does not expose a partially managed secret when persistence fails", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
+		tempDirectories.push(directory);
+		const pathBlocker = join(directory, "not-a-directory");
+		await writeFile(pathBlocker, "block directory creation");
+		const environmentEncryptionKey = "d".repeat(32);
+
+		let thrown: unknown;
+		try {
+			new SecretManager(join(pathBlocker, "secrets.json")).getOrCreateSecrets({
+				encryptionKey: environmentEncryptionKey,
+			});
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(Error);
+		expect(inspect(thrown)).not.toContain(environmentEncryptionKey);
+		expect(JSON.stringify(thrown)).not.toContain(environmentEncryptionKey);
+	});
+
+	it("marks stale readable secrets as unsynchronized when environment keys cannot be written", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
+		tempDirectories.push(directory);
+		const secretsPath = join(directory, "secrets.json");
+		await writeFile(
+			secretsPath,
+			JSON.stringify({
+				encryptionKey: "a".repeat(64),
+				sessionCookieSecret: "b".repeat(64),
+				installationId: "c".repeat(32),
+			}),
+		);
+		await chmod(directory, 0o555);
+
+		try {
+			const manager = new SecretManager(secretsPath);
+			const active = manager.getOrCreateEnvironmentSecrets({
+				encryptionKey: "d".repeat(32),
+				sessionCookieSecret: "e".repeat(32),
+			});
+
+			expect(active.encryptionKey).toBe("d".repeat(32));
+			expect(active.sessionCookieSecret).toBe("e".repeat(32));
+			expect(active.installationId).toBe("c".repeat(32));
+			expect(manager.secretsSynchronized).toBe(false);
+			expect(JSON.parse(await readFile(secretsPath, "utf8"))).toMatchObject({
+				encryptionKey: "a".repeat(64),
+				sessionCookieSecret: "b".repeat(64),
+			});
+		} finally {
+			await chmod(directory, 0o755);
+		}
 	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -140,4 +140,23 @@ describe("SecretManager installation identity", () => {
 		).toThrow("ENCRYPTION_KEY must decode to 32 bytes");
 		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual(persisted);
 	});
+
+	it("starts consistently with environment-managed secrets when the secrets path is not writable", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
+		tempDirectories.push(directory);
+		const pathBlocker = join(directory, "not-a-directory");
+		await writeFile(pathBlocker, "block directory creation");
+		const secretsPath = join(pathBlocker, "secrets.json");
+		const overrides = {
+			encryptionKey: "d".repeat(32),
+			sessionCookieSecret: "e".repeat(32),
+		};
+
+		const first = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(overrides);
+		const second = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(overrides);
+
+		expect(first).toEqual(second);
+		expect(first).toMatchObject(overrides);
+		expect(first.installationId).toMatch(/^[a-f0-9]{32}$/);
+	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -163,6 +163,8 @@ describe("SecretManager installation identity", () => {
 		expect(first.installationId).toMatch(/^[a-f0-9]{32}$/);
 		expect(firstManager.secretsSynchronized).toBe(false);
 		expect(secondManager.secretsSynchronized).toBe(false);
+		expect(firstManager.installationIdIsPersistent).toBe(false);
+		expect(secondManager.installationIdIsPersistent).toBe(false);
 	});
 
 	it("keeps read-only environment-managed installation identities deployment-specific", async () => {
@@ -237,6 +239,7 @@ describe("SecretManager installation identity", () => {
 			expect(active.sessionCookieSecret).toBe("e".repeat(32));
 			expect(active.installationId).toBe("c".repeat(32));
 			expect(manager.secretsSynchronized).toBe(false);
+			expect(manager.installationIdIsPersistent).toBe(true);
 			expect(JSON.parse(await readFile(secretsPath, "utf8"))).toMatchObject({
 				encryptionKey: "a".repeat(64),
 				sessionCookieSecret: "b".repeat(64),

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { readSecrets, writeSecrets } from "../../backup/backup-file-utils.js";
+import { Encryptor } from "../encryption.js";
 import { SecretManager } from "../secret-manager.js";
 
 describe("SecretManager installation identity", () => {
@@ -76,6 +77,8 @@ describe("SecretManager installation identity", () => {
 	it("backs up the active environment secrets without dropping local metadata", async () => {
 		const secretsPath = await createSecretsPath();
 		const installationId = "c".repeat(32);
+		const environmentEncryptionKey = "d".repeat(32);
+		const environmentSessionSecret = "e".repeat(32);
 		await writeFile(
 			secretsPath,
 			JSON.stringify({
@@ -85,13 +88,13 @@ describe("SecretManager installation identity", () => {
 		);
 
 		const activeSecrets = new SecretManager(secretsPath).getOrCreateSecrets({
-			encryptionKey: "d".repeat(64),
-			sessionCookieSecret: "e".repeat(64),
+			encryptionKey: environmentEncryptionKey,
+			sessionCookieSecret: environmentSessionSecret,
 		});
 
 		expect(activeSecrets).toMatchObject({
-			encryptionKey: "d".repeat(64),
-			sessionCookieSecret: "e".repeat(64),
+			encryptionKey: environmentEncryptionKey,
+			sessionCookieSecret: environmentSessionSecret,
 			installationId,
 		});
 		const backupSecrets = await readSecrets(secretsPath);
@@ -108,10 +111,16 @@ describe("SecretManager installation identity", () => {
 		const destinationInstallationId = "f".repeat(32);
 		await writeFile(restorePath, JSON.stringify({ installationId: destinationInstallationId }));
 		await writeSecrets(restorePath, backupSecrets);
-		expect(JSON.parse(await readFile(restorePath, "utf8"))).toEqual({
-			encryptionKey: activeSecrets.encryptionKey,
-			sessionCookieSecret: activeSecrets.sessionCookieSecret,
+		const restoredAfterRestart = new SecretManager(restorePath).getOrCreateSecrets();
+		expect(restoredAfterRestart).toEqual({
+			encryptionKey: environmentEncryptionKey,
+			sessionCookieSecret: environmentSessionSecret,
 			installationId: destinationInstallationId,
 		});
+
+		const credential = new Encryptor(environmentEncryptionKey).encrypt("restored-api-key");
+		expect(new Encryptor(restoredAfterRestart.encryptionKey).decrypt(credential)).toBe(
+			"restored-api-key",
+		);
 	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { readSecrets, writeSecrets } from "../../backup/backup-file-utils.js";
+import { SecretManager } from "../secret-manager.js";
+
+describe("SecretManager installation identity", () => {
+	const tempDirectories: string[] = [];
+
+	async function createSecretsPath(): Promise<string> {
+		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
+		tempDirectories.push(directory);
+		return join(directory, "secrets.json");
+	}
+
+	afterEach(async () => {
+		await Promise.all(
+			tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true, force: true })),
+		);
+	});
+
+	it("adds a stable installation ID to an existing secrets file", async () => {
+		const secretsPath = await createSecretsPath();
+		await writeFile(
+			secretsPath,
+			JSON.stringify({
+				encryptionKey: "a".repeat(64),
+				sessionCookieSecret: "b".repeat(64),
+				backupPassword: "local-backup-password",
+			}),
+		);
+
+		const first = new SecretManager(secretsPath).getOrCreateSecrets();
+		const second = new SecretManager(secretsPath).getOrCreateSecrets();
+
+		expect(first.installationId).toMatch(/^[a-f0-9]{32}$/);
+		expect(second.installationId).toBe(first.installationId);
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual({
+			...first,
+			backupPassword: "local-backup-password",
+		});
+	});
+
+	it("keeps the installation ID local when secrets are backed up and restored", async () => {
+		const secretsPath = await createSecretsPath();
+		const installationId = "c".repeat(32);
+		await writeFile(
+			secretsPath,
+			JSON.stringify({
+				encryptionKey: "a".repeat(64),
+				sessionCookieSecret: "b".repeat(64),
+				installationId,
+			}),
+		);
+
+		const backupSecrets = await readSecrets(secretsPath);
+		expect(backupSecrets).toEqual({
+			encryptionKey: "a".repeat(64),
+			sessionCookieSecret: "b".repeat(64),
+		});
+
+		await writeSecrets(secretsPath, {
+			encryptionKey: "d".repeat(64),
+			sessionCookieSecret: "e".repeat(64),
+		});
+
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual({
+			encryptionKey: "d".repeat(64),
+			sessionCookieSecret: "e".repeat(64),
+			installationId,
+		});
+	});
+});

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -155,14 +155,37 @@ describe("SecretManager installation identity", () => {
 
 		const firstManager = new SecretManager(secretsPath);
 		const secondManager = new SecretManager(secretsPath);
-		const first = firstManager.getOrCreateEnvironmentSecrets(overrides);
-		const second = secondManager.getOrCreateEnvironmentSecrets(overrides);
+		const first = firstManager.getOrCreateEnvironmentSecrets(overrides, "deployment-a");
+		const second = secondManager.getOrCreateEnvironmentSecrets(overrides, "deployment-a");
 
 		expect(first).toEqual(second);
 		expect(first).toMatchObject(overrides);
 		expect(first.installationId).toMatch(/^[a-f0-9]{32}$/);
 		expect(firstManager.secretsSynchronized).toBe(false);
 		expect(secondManager.secretsSynchronized).toBe(false);
+	});
+
+	it("keeps read-only environment-managed installation identities deployment-specific", async () => {
+		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
+		tempDirectories.push(directory);
+		const pathBlocker = join(directory, "not-a-directory");
+		await writeFile(pathBlocker, "block directory creation");
+		const secretsPath = join(pathBlocker, "secrets.json");
+		const overrides = {
+			encryptionKey: "d".repeat(32),
+			sessionCookieSecret: "e".repeat(32),
+		};
+
+		const first = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(
+			overrides,
+			"postgresql://deployment-a/app\0https://dashboard-a.test",
+		);
+		const second = new SecretManager(secretsPath).getOrCreateEnvironmentSecrets(
+			overrides,
+			"postgresql://deployment-b/app\0https://dashboard-b.test",
+		);
+
+		expect(first.installationId).not.toBe(second.installationId);
 	});
 
 	it("does not expose a partially managed secret when persistence fails", async () => {
@@ -202,10 +225,13 @@ describe("SecretManager installation identity", () => {
 
 		try {
 			const manager = new SecretManager(secretsPath);
-			const active = manager.getOrCreateEnvironmentSecrets({
-				encryptionKey: "d".repeat(32),
-				sessionCookieSecret: "e".repeat(32),
-			});
+			const active = manager.getOrCreateEnvironmentSecrets(
+				{
+					encryptionKey: "d".repeat(32),
+					sessionCookieSecret: "e".repeat(32),
+				},
+				"deployment-a",
+			);
 
 			expect(active.encryptionKey).toBe("d".repeat(32));
 			expect(active.sessionCookieSecret).toBe("e".repeat(32));

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { inspect } from "node:util";
@@ -223,29 +223,25 @@ describe("SecretManager installation identity", () => {
 				installationId: "c".repeat(32),
 			}),
 		);
-		await chmod(directory, 0o555);
+		await mkdir(`${secretsPath}.tmp`);
 
-		try {
-			const manager = new SecretManager(secretsPath);
-			const active = manager.getOrCreateEnvironmentSecrets(
-				{
-					encryptionKey: "d".repeat(32),
-					sessionCookieSecret: "e".repeat(32),
-				},
-				"deployment-a",
-			);
+		const manager = new SecretManager(secretsPath);
+		const active = manager.getOrCreateEnvironmentSecrets(
+			{
+				encryptionKey: "d".repeat(32),
+				sessionCookieSecret: "e".repeat(32),
+			},
+			"deployment-a",
+		);
 
-			expect(active.encryptionKey).toBe("d".repeat(32));
-			expect(active.sessionCookieSecret).toBe("e".repeat(32));
-			expect(active.installationId).toBe("c".repeat(32));
-			expect(manager.secretsSynchronized).toBe(false);
-			expect(manager.installationIdIsPersistent).toBe(true);
-			expect(JSON.parse(await readFile(secretsPath, "utf8"))).toMatchObject({
-				encryptionKey: "a".repeat(64),
-				sessionCookieSecret: "b".repeat(64),
-			});
-		} finally {
-			await chmod(directory, 0o755);
-		}
+		expect(active.encryptionKey).toBe("d".repeat(32));
+		expect(active.sessionCookieSecret).toBe("e".repeat(32));
+		expect(active.installationId).toBe("c".repeat(32));
+		expect(manager.secretsSynchronized).toBe(false);
+		expect(manager.installationIdIsPersistent).toBe(true);
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toMatchObject({
+			encryptionKey: "a".repeat(64),
+			sessionCookieSecret: "b".repeat(64),
+		});
 	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -123,4 +123,21 @@ describe("SecretManager installation identity", () => {
 			"restored-api-key",
 		);
 	});
+
+	it("rejects an invalid environment key before changing persisted secrets", async () => {
+		const secretsPath = await createSecretsPath();
+		const persisted = {
+			encryptionKey: "a".repeat(64),
+			sessionCookieSecret: "b".repeat(64),
+			installationId: "c".repeat(32),
+		};
+		await writeFile(secretsPath, JSON.stringify(persisted));
+
+		expect(() =>
+			new SecretManager(secretsPath).getOrCreateSecrets({
+				encryptionKey: "x".repeat(33),
+			}),
+		).toThrow("ENCRYPTION_KEY must decode to 32 bytes");
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual(persisted);
+	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -63,12 +63,55 @@ describe("SecretManager installation identity", () => {
 		await writeSecrets(secretsPath, {
 			encryptionKey: "d".repeat(64),
 			sessionCookieSecret: "e".repeat(64),
-		});
+			installationId: "f".repeat(32),
+		} as Parameters<typeof writeSecrets>[1]);
 
 		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual({
 			encryptionKey: "d".repeat(64),
 			sessionCookieSecret: "e".repeat(64),
 			installationId,
+		});
+	});
+
+	it("backs up the active environment secrets without dropping local metadata", async () => {
+		const secretsPath = await createSecretsPath();
+		const installationId = "c".repeat(32);
+		await writeFile(
+			secretsPath,
+			JSON.stringify({
+				installationId,
+				backupPassword: "local-backup-password",
+			}),
+		);
+
+		const activeSecrets = new SecretManager(secretsPath).getOrCreateSecrets({
+			encryptionKey: "d".repeat(64),
+			sessionCookieSecret: "e".repeat(64),
+		});
+
+		expect(activeSecrets).toMatchObject({
+			encryptionKey: "d".repeat(64),
+			sessionCookieSecret: "e".repeat(64),
+			installationId,
+		});
+		const backupSecrets = await readSecrets(secretsPath);
+		expect(backupSecrets).toEqual({
+			encryptionKey: activeSecrets.encryptionKey,
+			sessionCookieSecret: activeSecrets.sessionCookieSecret,
+		});
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toMatchObject({
+			...activeSecrets,
+			backupPassword: "local-backup-password",
+		});
+
+		const restorePath = await createSecretsPath();
+		const destinationInstallationId = "f".repeat(32);
+		await writeFile(restorePath, JSON.stringify({ installationId: destinationInstallationId }));
+		await writeSecrets(restorePath, backupSecrets);
+		expect(JSON.parse(await readFile(restorePath, "utf8"))).toEqual({
+			encryptionKey: activeSecrets.encryptionKey,
+			sessionCookieSecret: activeSecrets.sessionCookieSecret,
+			installationId: destinationInstallationId,
 		});
 	});
 });

--- a/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
+++ b/apps/api/src/lib/auth/__tests__/secret-manager.test.ts
@@ -190,6 +190,25 @@ describe("SecretManager installation identity", () => {
 		expect(first.installationId).not.toBe(second.installationId);
 	});
 
+	it("starts from readable legacy secrets when the installation ID cannot be persisted", async () => {
+		const secretsPath = await createSecretsPath();
+		const persisted = {
+			encryptionKey: "a".repeat(64),
+			sessionCookieSecret: "b".repeat(64),
+		};
+		await writeFile(secretsPath, JSON.stringify(persisted));
+		await mkdir(`${secretsPath}.tmp`);
+
+		const manager = new SecretManager(secretsPath);
+		const active = manager.getOrCreateSecrets();
+
+		expect(active).toMatchObject(persisted);
+		expect(active.installationId).toMatch(/^[a-f0-9]{32}$/);
+		expect(manager.installationIdIsPersistent).toBe(false);
+		expect(manager.secretsSynchronized).toBe(true);
+		expect(JSON.parse(await readFile(secretsPath, "utf8"))).toEqual(persisted);
+	});
+
 	it("does not expose a partially managed secret when persistence fails", async () => {
 		const directory = await mkdtemp(join(tmpdir(), "arr-dashboard-secrets-"));
 		tempDirectories.push(directory);

--- a/apps/api/src/lib/auth/encryption.ts
+++ b/apps/api/src/lib/auth/encryption.ts
@@ -15,27 +15,37 @@ export interface EncryptResult {
 	iv: string;
 }
 
+function decodeEncryptionKey(secret: string): Buffer {
+	// Detect encoding: hex (64 chars), base64 (43-44 chars), or UTF-8.
+	let keyBuffer: Buffer;
+	if (secret.length === 64 && /^[0-9a-f]+$/i.test(secret)) {
+		keyBuffer = Buffer.from(secret, "hex");
+	} else if (secret.length === 44 || secret.length === 43) {
+		keyBuffer = Buffer.from(secret, "base64");
+	} else {
+		keyBuffer = Buffer.from(secret, "utf-8");
+	}
+
+	if (keyBuffer.length !== 32) {
+		throw new Error("ENCRYPTION_KEY must decode to 32 bytes");
+	}
+	return keyBuffer;
+}
+
+export function isValidEncryptionKey(secret: string): boolean {
+	try {
+		decodeEncryptionKey(secret);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export class Encryptor {
 	private readonly key: Buffer;
 
 	constructor(secret: string) {
-		// Detect encoding: hex (64 chars), base64 (44 chars with padding), or utf-8
-		let keyBuffer: Buffer;
-		if (secret.length === 64 && /^[0-9a-f]+$/i.test(secret)) {
-			// Hex encoded (32 bytes = 64 hex chars)
-			keyBuffer = Buffer.from(secret, "hex");
-		} else if (secret.length === 44 || secret.length === 43) {
-			// Base64 encoded (32 bytes = 43-44 chars)
-			keyBuffer = Buffer.from(secret, "base64");
-		} else {
-			// UTF-8 string
-			keyBuffer = Buffer.from(secret, "utf-8");
-		}
-
-		if (keyBuffer.length !== 32) {
-			throw new Error("ENCRYPTION_KEY must decode to 32 bytes");
-		}
-		this.key = keyBuffer;
+		this.key = decodeEncryptionKey(secret);
 	}
 
 	encrypt(plaintext: string): EncryptResult {

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -21,6 +21,8 @@ type StoredSecrets = Omit<Secrets, "installationId"> & {
 	[key: string]: unknown;
 };
 
+type SecretOverrides = Partial<Pick<Secrets, "encryptionKey" | "sessionCookieSecret">>;
+
 /**
  * Known legacy secrets paths from previous versions.
  * When the primary path doesn't exist, these are checked in order
@@ -45,19 +47,25 @@ export class SecretManager {
 	 * Get or create secrets. If secrets file doesn't exist, checks legacy paths
 	 * for migration before generating new secrets.
 	 */
-	getOrCreateSecrets(): Secrets {
+	getOrCreateSecrets(overrides: SecretOverrides = {}): Secrets {
+		let preservedLocalFields: Record<string, unknown> = {};
+
 		// Try to load existing secrets (no existence check to avoid TOCTOU race)
 		try {
 			const content = readFileSync(this.secretsPath, "utf-8");
 			const secrets: unknown = JSON.parse(content);
+			if (secrets && typeof secrets === "object") {
+				preservedLocalFields = secrets as Record<string, unknown>;
+			}
 
 			// Validate loaded secrets
 			if (this.isValidSecrets(secrets)) {
-				return this.ensureInstallationId(secrets);
+				return this.applyOverrides(this.ensureInstallationId(secrets), overrides);
 			}
 
-			// Invalid format, will regenerate below
-			log.warn("Invalid secrets format, regenerating");
+			// Missing or invalid cryptographic fields are resolved below while
+			// preserving parseable deployment-local metadata.
+			log.warn("Secrets file is missing required cryptographic fields");
 		} catch (error) {
 			// ENOENT is expected on first run — only log unexpected errors
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
@@ -70,14 +78,29 @@ export class SecretManager {
 		// secrets were stored at /app/api/data/secrets.json instead of /config/.
 		const migrated = this.tryMigrateLegacySecrets();
 		if (migrated) {
-			return migrated;
+			return this.applyOverrides(migrated, overrides);
 		}
 
 		// Generate new secrets
 		const secrets: Secrets = {
-			encryptionKey: randomBytes(32).toString("hex"),
-			sessionCookieSecret: randomBytes(32).toString("hex"),
-			installationId: randomBytes(16).toString("hex"),
+			...preservedLocalFields,
+			encryptionKey:
+				overrides.encryptionKey ??
+				(typeof preservedLocalFields.encryptionKey === "string" &&
+				preservedLocalFields.encryptionKey.length === 64
+					? preservedLocalFields.encryptionKey
+					: randomBytes(32).toString("hex")),
+			sessionCookieSecret:
+				overrides.sessionCookieSecret ??
+				(typeof preservedLocalFields.sessionCookieSecret === "string" &&
+				preservedLocalFields.sessionCookieSecret.length === 64
+					? preservedLocalFields.sessionCookieSecret
+					: randomBytes(32).toString("hex")),
+			installationId:
+				typeof preservedLocalFields.installationId === "string" &&
+				/^[a-f0-9]{32}$/.test(preservedLocalFields.installationId)
+					? preservedLocalFields.installationId
+					: randomBytes(16).toString("hex"),
 		};
 
 		this.persistSecrets(secrets);
@@ -121,6 +144,24 @@ export class SecretManager {
 		}
 
 		return null;
+	}
+
+	private applyOverrides(secrets: Secrets, overrides: SecretOverrides): Secrets {
+		const resolved: Secrets = {
+			...secrets,
+			...(overrides.encryptionKey ? { encryptionKey: overrides.encryptionKey } : {}),
+			...(overrides.sessionCookieSecret
+				? { sessionCookieSecret: overrides.sessionCookieSecret }
+				: {}),
+		};
+		if (
+			resolved.encryptionKey !== secrets.encryptionKey ||
+			resolved.sessionCookieSecret !== secrets.sessionCookieSecret
+		) {
+			this.persistSecrets(resolved);
+			log.info({ path: this.secretsPath }, "Synchronized active environment secrets");
+		}
+		return resolved;
 	}
 
 	private ensureInstallationId(secrets: StoredSecrets): Secrets {

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { copyFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { loggers } from "../logger.js";
+import { isValidEncryptionKey } from "./encryption.js";
 
 const log = loggers.auth;
 
@@ -87,13 +88,13 @@ export class SecretManager {
 			encryptionKey:
 				overrides.encryptionKey ??
 				(typeof preservedLocalFields.encryptionKey === "string" &&
-				preservedLocalFields.encryptionKey.length === 64
+				isValidEncryptionKey(preservedLocalFields.encryptionKey)
 					? preservedLocalFields.encryptionKey
 					: randomBytes(32).toString("hex")),
 			sessionCookieSecret:
 				overrides.sessionCookieSecret ??
 				(typeof preservedLocalFields.sessionCookieSecret === "string" &&
-				preservedLocalFields.sessionCookieSecret.length === 64
+				preservedLocalFields.sessionCookieSecret.length >= 32
 					? preservedLocalFields.sessionCookieSecret
 					: randomBytes(32).toString("hex")),
 			installationId:
@@ -203,9 +204,9 @@ export class SecretManager {
 		const s = secrets as Record<string, unknown>;
 		return (
 			typeof s.encryptionKey === "string" &&
-			s.encryptionKey.length === 64 && // 32 bytes in hex
+			isValidEncryptionKey(s.encryptionKey) &&
 			typeof s.sessionCookieSecret === "string" &&
-			s.sessionCookieSecret.length === 64
+			s.sessionCookieSecret.length >= 32
 		);
 	}
 }

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -49,6 +49,13 @@ export class SecretManager {
 	 * for migration before generating new secrets.
 	 */
 	getOrCreateSecrets(overrides: SecretOverrides = {}): Secrets {
+		if (overrides.encryptionKey && !isValidEncryptionKey(overrides.encryptionKey)) {
+			throw new Error("ENCRYPTION_KEY must decode to 32 bytes");
+		}
+		if (overrides.sessionCookieSecret && overrides.sessionCookieSecret.length < 32) {
+			throw new Error("SESSION_COOKIE_SECRET must be at least 32 characters");
+		}
+
 		let preservedLocalFields: Record<string, unknown> = {};
 
 		// Try to load existing secrets (no existence check to avoid TOCTOU race)

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -52,6 +52,7 @@ const LEGACY_SECRETS_PATHS = [
 export class SecretManager {
 	private readonly secretsPath: string;
 	private _secretsSynchronized = true;
+	private _installationIdIsPersistent = true;
 
 	constructor(secretsPath: string) {
 		this.secretsPath = secretsPath;
@@ -61,11 +62,17 @@ export class SecretManager {
 		return this._secretsSynchronized;
 	}
 
+	get installationIdIsPersistent(): boolean {
+		return this._installationIdIsPersistent;
+	}
+
 	/**
 	 * Get or create secrets. If secrets file doesn't exist, checks legacy paths
 	 * for migration before generating new secrets.
 	 */
 	getOrCreateSecrets(overrides: SecretOverrides = {}): Secrets {
+		this._secretsSynchronized = true;
+		this._installationIdIsPersistent = true;
 		if (overrides.encryptionKey && !isValidEncryptionKey(overrides.encryptionKey)) {
 			throw new Error("ENCRYPTION_KEY must decode to 32 bytes");
 		}
@@ -160,6 +167,7 @@ export class SecretManager {
 			}
 
 			this._secretsSynchronized = false;
+			this._installationIdIsPersistent = error.installationIdWasPersistent;
 			const installationId = error.installationIdWasPersistent
 				? error.attemptedInstallationId
 				: createHash("sha256")

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -27,7 +27,7 @@ type EnvironmentSecretOverrides = Required<SecretOverrides>;
 
 class SecretsPersistenceError extends Error {
 	constructor(
-		readonly attemptedSecrets: Secrets,
+		readonly attemptedInstallationId: string,
 		readonly installationIdWasPersistent: boolean,
 		options: { cause: unknown },
 	) {
@@ -51,9 +51,14 @@ const LEGACY_SECRETS_PATHS = [
  */
 export class SecretManager {
 	private readonly secretsPath: string;
+	private _secretsSynchronized = true;
 
 	constructor(secretsPath: string) {
 		this.secretsPath = secretsPath;
+	}
+
+	get secretsSynchronized(): boolean {
+		return this._secretsSynchronized;
 	}
 
 	/**
@@ -87,6 +92,9 @@ export class SecretManager {
 			// preserving parseable deployment-local metadata.
 			log.warn("Secrets file is missing required cryptographic fields");
 		} catch (error) {
+			if (error instanceof SecretsPersistenceError) {
+				throw error;
+			}
 			// ENOENT is expected on first run — only log unexpected errors
 			if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
 				log.error({ err: error }, "Failed to load secrets, regenerating");
@@ -148,8 +156,9 @@ export class SecretManager {
 				throw error;
 			}
 
+			this._secretsSynchronized = false;
 			const installationId = error.installationIdWasPersistent
-				? error.attemptedSecrets.installationId
+				? error.attemptedInstallationId
 				: createHash("sha256")
 						.update(
 							`arr-dashboard-environment-installation\0${overrides.encryptionKey}\0${overrides.sessionCookieSecret}`,
@@ -197,7 +206,10 @@ export class SecretManager {
 				copyFileSync(legacyPath, this.secretsPath);
 
 				return this.ensureInstallationId(secrets);
-			} catch {
+			} catch (error) {
+				if (error instanceof SecretsPersistenceError) {
+					throw error;
+				}
 				// File doesn't exist or can't be read — try next legacy path
 			}
 		}
@@ -250,7 +262,9 @@ export class SecretManager {
 			renameSync(tmpPath, this.secretsPath);
 		} catch (error) {
 			log.error({ err: error, path: this.secretsPath }, "Failed to persist secrets");
-			throw new SecretsPersistenceError(secrets, installationIdWasPersistent, { cause: error });
+			throw new SecretsPersistenceError(secrets.installationId, installationIdWasPersistent, {
+				cause: error,
+			});
 		}
 	}
 

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -8,7 +8,18 @@ const log = loggers.auth;
 export interface Secrets {
 	encryptionKey: string;
 	sessionCookieSecret: string;
+	/**
+	 * Identifies this local installation independently of database contents.
+	 * Backups intentionally omit it so restoring a database cannot make two
+	 * live dashboard installations claim the same external resources.
+	 */
+	installationId: string;
 }
+
+type StoredSecrets = Omit<Secrets, "installationId"> & {
+	installationId?: unknown;
+	[key: string]: unknown;
+};
 
 /**
  * Known legacy secrets paths from previous versions.
@@ -38,11 +49,11 @@ export class SecretManager {
 		// Try to load existing secrets (no existence check to avoid TOCTOU race)
 		try {
 			const content = readFileSync(this.secretsPath, "utf-8");
-			const secrets = JSON.parse(content) as Secrets;
+			const secrets: unknown = JSON.parse(content);
 
 			// Validate loaded secrets
 			if (this.isValidSecrets(secrets)) {
-				return secrets;
+				return this.ensureInstallationId(secrets);
 			}
 
 			// Invalid format, will regenerate below
@@ -66,23 +77,11 @@ export class SecretManager {
 		const secrets: Secrets = {
 			encryptionKey: randomBytes(32).toString("hex"),
 			sessionCookieSecret: randomBytes(32).toString("hex"),
+			installationId: randomBytes(16).toString("hex"),
 		};
 
-		// Ensure directory exists (recursive is idempotent)
-		mkdirSync(dirname(this.secretsPath), { recursive: true });
-
-		// Persist to disk atomically (write to temp, then rename)
-		const tmpPath = `${this.secretsPath}.tmp`;
-		try {
-			writeFileSync(tmpPath, JSON.stringify(secrets, null, 2), {
-				mode: 0o600, // Read/write for owner only
-			});
-			renameSync(tmpPath, this.secretsPath);
-			log.info({ path: this.secretsPath }, "Generated new secrets");
-		} catch (error) {
-			log.error({ err: error, path: this.secretsPath }, "Failed to persist secrets");
-			throw new Error("Could not save secrets to disk");
-		}
+		this.persistSecrets(secrets);
+		log.info({ path: this.secretsPath }, "Generated new secrets");
 
 		return secrets;
 	}
@@ -100,7 +99,7 @@ export class SecretManager {
 
 			try {
 				const content = readFileSync(legacyPath, "utf-8");
-				const secrets = JSON.parse(content) as Secrets;
+				const secrets: unknown = JSON.parse(content);
 
 				if (!this.isValidSecrets(secrets)) {
 					log.warn({ legacyPath }, "Found legacy secrets file but format is invalid, skipping");
@@ -115,7 +114,7 @@ export class SecretManager {
 				mkdirSync(dirname(this.secretsPath), { recursive: true });
 				copyFileSync(legacyPath, this.secretsPath);
 
-				return secrets;
+				return this.ensureInstallationId(secrets);
 			} catch {
 				// File doesn't exist or can't be read — try next legacy path
 			}
@@ -124,7 +123,38 @@ export class SecretManager {
 		return null;
 	}
 
-	private isValidSecrets(secrets: unknown): secrets is Secrets {
+	private ensureInstallationId(secrets: StoredSecrets): Secrets {
+		if (
+			typeof secrets.installationId === "string" &&
+			/^[a-f0-9]{32}$/.test(secrets.installationId)
+		) {
+			return secrets as Secrets;
+		}
+
+		const upgraded: Secrets = {
+			...secrets,
+			installationId: randomBytes(16).toString("hex"),
+		};
+		this.persistSecrets(upgraded);
+		log.info({ path: this.secretsPath }, "Added local installation identity");
+		return upgraded;
+	}
+
+	private persistSecrets(secrets: Secrets): void {
+		mkdirSync(dirname(this.secretsPath), { recursive: true });
+		const tmpPath = `${this.secretsPath}.tmp`;
+		try {
+			writeFileSync(tmpPath, JSON.stringify(secrets, null, 2), {
+				mode: 0o600,
+			});
+			renameSync(tmpPath, this.secretsPath);
+		} catch (error) {
+			log.error({ err: error, path: this.secretsPath }, "Failed to persist secrets");
+			throw new Error("Could not save secrets to disk");
+		}
+	}
+
+	private isValidSecrets(secrets: unknown): secrets is StoredSecrets {
 		if (!secrets || typeof secrets !== "object") {
 			return false;
 		}

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { copyFileSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { loggers } from "../logger.js";
@@ -23,6 +23,18 @@ type StoredSecrets = Omit<Secrets, "installationId"> & {
 };
 
 type SecretOverrides = Partial<Pick<Secrets, "encryptionKey" | "sessionCookieSecret">>;
+type EnvironmentSecretOverrides = Required<SecretOverrides>;
+
+class SecretsPersistenceError extends Error {
+	constructor(
+		readonly attemptedSecrets: Secrets,
+		readonly installationIdWasPersistent: boolean,
+		options: { cause: unknown },
+	) {
+		super("Could not save secrets to disk", options);
+		this.name = "SecretsPersistenceError";
+	}
+}
 
 /**
  * Known legacy secrets paths from previous versions.
@@ -111,10 +123,49 @@ export class SecretManager {
 					: randomBytes(16).toString("hex"),
 		};
 
-		this.persistSecrets(secrets);
+		this.persistSecrets(
+			secrets,
+			typeof preservedLocalFields.installationId === "string" &&
+				/^[a-f0-9]{32}$/.test(preservedLocalFields.installationId),
+		);
 		log.info({ path: this.secretsPath }, "Generated new secrets");
 
 		return secrets;
+	}
+
+	/**
+	 * Resolve deployments whose cryptographic secrets are entirely managed by
+	 * the environment. A writable secrets file is still preferred so backups
+	 * contain the active keys and each installation gets a random local ID.
+	 * If the path is read-only, the active secrets are sufficient for startup
+	 * and provide a deterministic identity across container restarts.
+	 */
+	getOrCreateEnvironmentSecrets(overrides: EnvironmentSecretOverrides): Secrets {
+		try {
+			return this.getOrCreateSecrets(overrides);
+		} catch (error) {
+			if (!(error instanceof SecretsPersistenceError)) {
+				throw error;
+			}
+
+			const installationId = error.installationIdWasPersistent
+				? error.attemptedSecrets.installationId
+				: createHash("sha256")
+						.update(
+							`arr-dashboard-environment-installation\0${overrides.encryptionKey}\0${overrides.sessionCookieSecret}`,
+						)
+						.digest("hex")
+						.slice(0, 32);
+			log.warn(
+				{ path: this.secretsPath },
+				"Secrets path is not writable; using environment-managed secrets without local backup synchronization",
+			);
+			return {
+				encryptionKey: overrides.encryptionKey,
+				sessionCookieSecret: overrides.sessionCookieSecret,
+				installationId,
+			};
+		}
 	}
 
 	/**
@@ -166,7 +217,7 @@ export class SecretManager {
 			resolved.encryptionKey !== secrets.encryptionKey ||
 			resolved.sessionCookieSecret !== secrets.sessionCookieSecret
 		) {
-			this.persistSecrets(resolved);
+			this.persistSecrets(resolved, true);
 			log.info({ path: this.secretsPath }, "Synchronized active environment secrets");
 		}
 		return resolved;
@@ -189,17 +240,17 @@ export class SecretManager {
 		return upgraded;
 	}
 
-	private persistSecrets(secrets: Secrets): void {
-		mkdirSync(dirname(this.secretsPath), { recursive: true });
+	private persistSecrets(secrets: Secrets, installationIdWasPersistent = false): void {
 		const tmpPath = `${this.secretsPath}.tmp`;
 		try {
+			mkdirSync(dirname(this.secretsPath), { recursive: true });
 			writeFileSync(tmpPath, JSON.stringify(secrets, null, 2), {
 				mode: 0o600,
 			});
 			renameSync(tmpPath, this.secretsPath);
 		} catch (error) {
 			log.error({ err: error, path: this.secretsPath }, "Failed to persist secrets");
-			throw new Error("Could not save secrets to disk");
+			throw new SecretsPersistenceError(secrets, installationIdWasPersistent, { cause: error });
 		}
 	}
 

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -92,7 +92,31 @@ export class SecretManager {
 
 			// Validate loaded secrets
 			if (this.isValidSecrets(secrets)) {
-				return this.applyOverrides(this.ensureInstallationId(secrets), overrides);
+				try {
+					return this.applyOverrides(this.ensureInstallationId(secrets), overrides);
+				} catch (error) {
+					if (!(error instanceof SecretsPersistenceError)) {
+						throw error;
+					}
+
+					const resolved: Secrets = {
+						...secrets,
+						...(overrides.encryptionKey ? { encryptionKey: overrides.encryptionKey } : {}),
+						...(overrides.sessionCookieSecret
+							? { sessionCookieSecret: overrides.sessionCookieSecret }
+							: {}),
+						installationId: error.attemptedInstallationId,
+					};
+					this._installationIdIsPersistent = error.installationIdWasPersistent;
+					this._secretsSynchronized =
+						resolved.encryptionKey === secrets.encryptionKey &&
+						resolved.sessionCookieSecret === secrets.sessionCookieSecret;
+					log.warn(
+						{ path: this.secretsPath },
+						"Secrets path is not writable; using readable secrets without synchronized local metadata",
+					);
+					return resolved;
+				}
 			}
 
 			// Missing or invalid cryptographic fields are resolved below while

--- a/apps/api/src/lib/auth/secret-manager.ts
+++ b/apps/api/src/lib/auth/secret-manager.ts
@@ -148,7 +148,10 @@ export class SecretManager {
 	 * If the path is read-only, the active secrets are sufficient for startup
 	 * and provide a deterministic identity across container restarts.
 	 */
-	getOrCreateEnvironmentSecrets(overrides: EnvironmentSecretOverrides): Secrets {
+	getOrCreateEnvironmentSecrets(
+		overrides: EnvironmentSecretOverrides,
+		deploymentScope: string,
+	): Secrets {
 		try {
 			return this.getOrCreateSecrets(overrides);
 		} catch (error) {
@@ -161,7 +164,7 @@ export class SecretManager {
 				? error.attemptedInstallationId
 				: createHash("sha256")
 						.update(
-							`arr-dashboard-environment-installation\0${overrides.encryptionKey}\0${overrides.sessionCookieSecret}`,
+							`arr-dashboard-environment-installation\0${deploymentScope}\0${overrides.encryptionKey}\0${overrides.sessionCookieSecret}`,
 						)
 						.digest("hex")
 						.slice(0, 32);

--- a/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
@@ -1,0 +1,31 @@
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../../../lib/prisma.js";
+import { BackupScheduler } from "../backup-scheduler.js";
+
+describe("BackupScheduler secret synchronization", () => {
+	it("rejects the scheduled backup path when active secrets are unsynchronized", async () => {
+		const logger = {
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as FastifyBaseLogger;
+		const scheduler = new BackupScheduler(
+			{} as PrismaClient,
+			logger,
+			"/unused/secrets.json",
+			undefined,
+			{ secretsSynchronized: false },
+		);
+		const runScheduledBackup = (
+			scheduler as unknown as {
+				runScheduledBackup(retentionCount: number): Promise<void>;
+			}
+		).runScheduledBackup.bind(scheduler);
+
+		await expect(runScheduledBackup(3)).rejects.toThrow(
+			"active environment secrets could not be synchronized",
+		);
+	});
+});

--- a/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-scheduler.test.ts
@@ -4,6 +4,29 @@ import type { PrismaClient } from "../../../lib/prisma.js";
 import { BackupScheduler } from "../backup-scheduler.js";
 
 describe("BackupScheduler secret synchronization", () => {
+	it("does not start the minute loop when active secrets are unsynchronized", () => {
+		const logger = {
+			error: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			debug: vi.fn(),
+		} as unknown as FastifyBaseLogger;
+		const scheduler = new BackupScheduler(
+			{} as PrismaClient,
+			logger,
+			"/unused/secrets.json",
+			undefined,
+			{ secretsSynchronized: false },
+		);
+
+		scheduler.start();
+
+		expect(logger.warn).toHaveBeenCalledOnce();
+		expect(logger.warn).toHaveBeenCalledWith(
+			"Backup scheduler disabled because active environment secrets could not be synchronized",
+		);
+	});
+
 	it("rejects the scheduled backup path when active secrets are unsynchronized", async () => {
 		const logger = {
 			error: vi.fn(),

--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -244,6 +244,19 @@ const mockEncryptor = {
 
 // Unit tests - these don't require database access
 describe("BackupService - Backup Validation (Unit)", () => {
+	it("rejects backup creation while active environment secrets are unsynchronized", async () => {
+		const backupService = new BackupService(
+			{} as PrismaClient,
+			"/unused/secrets.json",
+			undefined,
+			false,
+		);
+
+		await expect(backupService.createBackup("2.23.0")).rejects.toThrow(
+			"active environment secrets could not be synchronized",
+		);
+	});
+
 	it("should validate backup structure", () => {
 		const validBackup = {
 			version: "1.0",

--- a/apps/api/src/lib/backup/backup-file-utils.ts
+++ b/apps/api/src/lib/backup/backup-file-utils.ts
@@ -30,7 +30,8 @@ export async function readSecrets(secretsPath: string): Promise<BackupData["secr
 
 /**
  * Write secrets to secrets.json with restrictive permissions (0o600)
- * Merges with existing secrets to preserve additional fields like backupPassword
+ * Merges with existing secrets to preserve deployment-local fields such as
+ * installationId, plus additional fields like backupPassword.
  * Only the owner can read/write the secrets file for enhanced security
  */
 export async function writeSecrets(
@@ -38,7 +39,8 @@ export async function writeSecrets(
 	secrets: BackupData["secrets"],
 ): Promise<void> {
 	try {
-		// Read existing secrets to preserve fields not in backup (e.g., backupPassword)
+		// Preserve fields deliberately omitted from backups (installationId)
+		// as well as other local metadata (for example backupPassword).
 		let existingSecrets: Record<string, unknown> = {};
 		try {
 			const existingContent = await fs.readFile(secretsPath, "utf-8");

--- a/apps/api/src/lib/backup/backup-file-utils.ts
+++ b/apps/api/src/lib/backup/backup-file-utils.ts
@@ -60,9 +60,14 @@ export async function writeSecrets(
 			}
 		}
 
-		// Merge backup secrets with existing ones
-		// Backup secrets take precedence, but existing fields are preserved
-		const mergedSecrets = { ...existingSecrets, ...secrets };
+		// Import only the cryptographic fields defined by the backup contract.
+		// Extra fields in legacy or crafted payloads must never replace local
+		// deployment identity or other destination metadata.
+		const mergedSecrets = {
+			...existingSecrets,
+			encryptionKey: secrets.encryptionKey,
+			sessionCookieSecret: secrets.sessionCookieSecret,
+		};
 
 		const secretsContent = JSON.stringify(mergedSecrets, null, 2);
 		// Write with restrictive permissions (owner read/write only)

--- a/apps/api/src/lib/backup/backup-scheduler.ts
+++ b/apps/api/src/lib/backup/backup-scheduler.ts
@@ -23,9 +23,14 @@ export class BackupScheduler {
 		private logger: FastifyBaseLogger,
 		secretsPath: string,
 		notifyFn?: (payload: NotificationPayload) => Promise<void>,
-		options?: { trackTick?: TickWrapper },
+		options?: { trackTick?: TickWrapper; secretsSynchronized?: boolean },
 	) {
-		this.backupService = new BackupService(prisma, secretsPath);
+		this.backupService = new BackupService(
+			prisma,
+			secretsPath,
+			undefined,
+			options?.secretsSynchronized,
+		);
 		this.notifyFn = notifyFn;
 		this.trackTick = options?.trackTick ?? passthroughTickWrapper;
 	}

--- a/apps/api/src/lib/backup/backup-scheduler.ts
+++ b/apps/api/src/lib/backup/backup-scheduler.ts
@@ -23,7 +23,7 @@ export class BackupScheduler {
 		private logger: FastifyBaseLogger,
 		secretsPath: string,
 		notifyFn?: (payload: NotificationPayload) => Promise<void>,
-		options?: { trackTick?: TickWrapper; secretsSynchronized?: boolean },
+		private options?: { trackTick?: TickWrapper; secretsSynchronized?: boolean },
 	) {
 		this.backupService = new BackupService(
 			prisma,
@@ -32,7 +32,7 @@ export class BackupScheduler {
 			options?.secretsSynchronized,
 		);
 		this.notifyFn = notifyFn;
-		this.trackTick = options?.trackTick ?? passthroughTickWrapper;
+		this.trackTick = this.options?.trackTick ?? passthroughTickWrapper;
 	}
 
 	/**
@@ -41,6 +41,12 @@ export class BackupScheduler {
 	start() {
 		if (this.intervalId) {
 			this.logger.warn("Backup scheduler already running");
+			return;
+		}
+		if (this.options?.secretsSynchronized === false) {
+			this.logger.warn(
+				"Backup scheduler disabled because active environment secrets could not be synchronized",
+			);
 			return;
 		}
 

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -119,6 +119,7 @@ export class BackupService {
 		private prisma: PrismaClient,
 		private secretsPath: string,
 		private encryptor?: Encryptor,
+		private secretsSynchronized = true,
 	) {
 		// Set backups directory next to the database file
 		const dataDir = path.dirname(secretsPath);
@@ -354,6 +355,12 @@ export class BackupService {
 			historyRetentionLimit?: number;
 		} = {},
 	): Promise<BackupFileInfo> {
+		if (!this.secretsSynchronized) {
+			throw new Error(
+				"Backups are unavailable because active environment secrets could not be synchronized to the secrets file",
+			);
+		}
+
 		// 1. Ensure backups directory exists
 		await ensureBackupsDirectory(this.backupsDir);
 

--- a/apps/api/src/lib/qui/__tests__/action-service.test.ts
+++ b/apps/api/src/lib/qui/__tests__/action-service.test.ts
@@ -101,7 +101,7 @@ function makeClient(overrides: Partial<QuiClient> = {}): QuiClient {
 		addTrackers: vi.fn().mockResolvedValue(undefined),
 		removeTrackers: vi.fn().mockResolvedValue(undefined),
 		editTracker: vi.fn().mockResolvedValue(undefined),
-		createNotificationTarget: vi.fn().mockResolvedValue({ id: 1 }),
+		ensureNotificationTarget: vi.fn().mockResolvedValue({ id: 1 }),
 		triggerDirScan: vi.fn().mockResolvedValue({
 			runId: 1,
 			directoryId: 1,

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -779,6 +779,125 @@ describe("createQuiClient", () => {
 			});
 		});
 
+		it("prefers an already-valid newer target during an initial retry", async () => {
+			const stale = { ...target, url: "generic://dashboard.example/stale" };
+			const valid = { ...target, id: 99 };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([stale, valid]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ ...stale, enabled: false }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 99 });
+			expect(String(fetchSpy.mock.calls[1]?.[0])).toBe(
+				"http://qui.test/api/notifications/targets/42",
+			);
+			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
+				enabled: false,
+			});
+		});
+
+		it("recovers a valid newer target after a lost POST response", async () => {
+			const stale = { ...target, url: "generic://dashboard.example/stale" };
+			const valid = { ...target, id: 99 };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "upstream response lost" }), {
+						status: 502,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([stale, valid]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ ...stale, enabled: false }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 99 });
+			expect(fetchSpy).toHaveBeenCalledTimes(4);
+		});
+
+		it("preserves a successful POST when stale-target cleanup cannot finish", async () => {
+			const stale = { ...target, url: "generic://dashboard.example/stale" };
+			const valid = { ...target, id: 99 };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(valid), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([stale, valid]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "cleanup failed" }), {
+						status: 500,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([stale, valid]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 99, cleanupPending: true });
+			expect(fetchSpy).toHaveBeenCalledTimes(5);
+		});
+
 		it("reports canonical success when duplicate cleanup remains pending", async () => {
 			const duplicate = { ...target, id: 99, url: "generic://dashboard.example/stale" };
 			fetchSpy

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -512,6 +512,46 @@ describe("createQuiClient", () => {
 			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
 		});
 
+		it("leaves targets owned by another dashboard instance untouched", async () => {
+			const legacyTarget = { ...target, id: 7, name: "arr-dashboard" };
+			const ownedTarget = { ...target, name: "arr-dashboard-qui-1" };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([legacyTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(ownedTarget), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([legacyTarget, ownedTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: ownedTarget.name,
+					url: ownedTarget.url,
+					eventTypes: ownedTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
+			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
+				name: ownedTarget.name,
+			});
+			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+		});
+
 		it("updates an existing target instead of creating a duplicate", async () => {
 			fetchSpy
 				.mockResolvedValueOnce(

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -471,19 +471,200 @@ describe("createQuiClient", () => {
 		});
 	});
 
-	describe("createNotificationTarget error redaction", () => {
+	describe("ensureNotificationTarget", () => {
+		const target = {
+			id: 42,
+			name: "arr-dashboard",
+			url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current",
+			enabled: true,
+			eventTypes: ["torrent_added"],
+		};
+
+		it("creates the target when qUI's empty list is encoded as null", async () => {
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response("null", {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(target), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
+		});
+
+		it("updates an existing target instead of creating a duplicate", async () => {
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ ...target, url: "generic://dashboard.test/hook" }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			const result = await client.ensureNotificationTarget({
+				name: "arr-dashboard",
+				url: "generic://dashboard.test/hook",
+				eventTypes: ["torrent_added"],
+			});
+
+			expect(result).toEqual({ id: 42 });
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+			expect(String(fetchSpy.mock.calls[1]?.[0])).toBe(
+				"http://qui.test/api/notifications/targets/42",
+			);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
+		});
+
+		it("accepts a committed update when qUI loses the PUT response", async () => {
+			const desiredUrl = "generic://dashboard.test/hook";
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "upstream response lost" }), {
+						status: 502,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([{ ...target, url: desiredUrl }]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: desiredUrl,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+		});
+
+		it("keeps one canonical target and disables enabled duplicates", async () => {
+			const duplicate = { ...target, id: 99, url: "generic://dashboard.example/stale" };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target, duplicate]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ ...duplicate, enabled: false }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			const result = await client.ensureNotificationTarget({
+				name: target.name,
+				url: target.url,
+				eventTypes: target.eventTypes,
+			});
+
+			expect(result).toEqual({ id: 42 });
+			expect(String(fetchSpy.mock.calls[1]?.[0])).toBe(
+				"http://qui.test/api/notifications/targets/99",
+			);
+			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
+				url: duplicate.url,
+				enabled: false,
+			});
+		});
+
+		it("recovers a target created when the POST response is lost", async () => {
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "upstream response lost" }), {
+						status: 502,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+		});
+
 		it("scrubs the callback secret before the shared request helper logs or throws", async () => {
 			const secret = "plaintext-webhook-secret";
 			const targetUrl = `generic://dashboard.example/api/webhooks/qui?template=json&secret=${secret}`;
-			fetchSpy.mockResolvedValueOnce(
-				new Response(JSON.stringify({ error: `invalid notification url: ${targetUrl}` }), {
-					status: 400,
-					headers: { "content-type": "application/json" },
-				}),
-			);
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: `invalid notification url: ${targetUrl}` }), {
+						status: 400,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
 
 			const client = createQuiClient(buildApp(), buildInstance());
-			const rejection = client.createNotificationTarget({
+			const rejection = client.ensureNotificationTarget({
 				name: "arr-dashboard",
 				url: targetUrl,
 			});

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -582,6 +582,50 @@ describe("createQuiClient", () => {
 			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
 		});
 
+		it("renames an owned target after the qUI base URL changes instead of creating a duplicate", async () => {
+			const previousTarget = {
+				...target,
+				name: "arr-dashboard-previous-deployment",
+				url: `${target.url}&owner=owner-1&instanceId=qui-1`,
+			};
+			const desiredTarget = {
+				...previousTarget,
+				name: "arr-dashboard-current-deployment",
+			};
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([previousTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(desiredTarget), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: desiredTarget.name,
+					url: desiredTarget.url,
+					ownerId: "owner-1",
+					eventTypes: desiredTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+			expect(String(fetchSpy.mock.calls[1]?.[0])).toBe(
+				"http://qui.test/api/notifications/targets/42",
+			);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
+			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
+				name: desiredTarget.name,
+			});
+		});
+
 		it("expands an empty requested event list and resets an existing subset", async () => {
 			const allEventTypes = ["torrent_added", "torrent_completed"];
 			fetchSpy

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -542,6 +542,25 @@ describe("createQuiClient", () => {
 			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
 		});
 
+		it("treats an empty requested event list as qUI's all-events setting", async () => {
+			fetchSpy.mockResolvedValueOnce(
+				new Response(JSON.stringify([target]), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+			);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: [],
+				}),
+			).resolves.toEqual({ id: 42 });
+			expect(fetchSpy).toHaveBeenCalledOnce();
+		});
+
 		it("accepts a committed update when qUI loses the PUT response", async () => {
 			const desiredUrl = "generic://dashboard.test/hook";
 			fetchSpy

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -560,21 +560,16 @@ describe("createQuiClient", () => {
 		it("upgrades a matching pre-owner arr-dashboard target in place", async () => {
 			const legacyTarget = {
 				...target,
-				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current",
-			};
-			const otherUserLegacyTarget = {
-				...legacyTarget,
-				id: 7,
-				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=other-user",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=old",
 			};
 			const desiredTarget = {
 				...legacyTarget,
 				name: "arr-dashboard-installation-deployment",
-				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=new&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
 			};
 			fetchSpy
 				.mockResolvedValueOnce(
-					new Response(JSON.stringify([otherUserLegacyTarget, legacyTarget]), {
+					new Response(JSON.stringify([legacyTarget]), {
 						status: 200,
 						headers: { "content-type": "application/json" },
 					}),
@@ -592,6 +587,7 @@ describe("createQuiClient", () => {
 					name: desiredTarget.name,
 					url: desiredTarget.url,
 					ownerId: "owner-1",
+					allowLegacyTargetAdoption: true,
 					eventTypes: desiredTarget.eventTypes,
 				}),
 			).resolves.toEqual({ id: 42 });

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -513,7 +513,12 @@ describe("createQuiClient", () => {
 		});
 
 		it("leaves targets owned by another dashboard instance untouched", async () => {
-			const legacyTarget = { ...target, id: 7, name: "arr-dashboard" };
+			const legacyTarget = {
+				...target,
+				id: 7,
+				name: "arr-dashboard",
+				url: "generic://other-dashboard.example/api/webhooks/qui?template=json&secret=other",
+			};
 			const ownedTarget = { ...target, name: "arr-dashboard-qui-1" };
 			fetchSpy
 				.mockResolvedValueOnce(
@@ -550,6 +555,48 @@ describe("createQuiClient", () => {
 				name: ownedTarget.name,
 			});
 			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+		});
+
+		it("upgrades a matching pre-owner arr-dashboard target in place", async () => {
+			const legacyTarget = {
+				...target,
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=old",
+			};
+			const desiredTarget = {
+				...legacyTarget,
+				name: "arr-dashboard-installation-deployment",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=new&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
+			};
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([legacyTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(desiredTarget), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: desiredTarget.name,
+					url: desiredTarget.url,
+					ownerId: "owner-1",
+					eventTypes: desiredTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
+			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
+				name: desiredTarget.name,
+				url: desiredTarget.url,
+			});
 		});
 
 		it("updates an existing target instead of creating a duplicate", async () => {
@@ -730,6 +777,42 @@ describe("createQuiClient", () => {
 				url: duplicate.url,
 				enabled: false,
 			});
+		});
+
+		it("reports canonical success when duplicate cleanup remains pending", async () => {
+			const duplicate = { ...target, id: 99, url: "generic://dashboard.example/stale" };
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target, duplicate]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ error: "cleanup failed" }), {
+						status: 500,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target, duplicate]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: target.name,
+					url: target.url,
+					eventTypes: target.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42, cleanupPending: true });
+			expect(vi.mocked(fakeLog.warn)).toHaveBeenCalledWith(
+				{ targetId: 99 },
+				expect.stringMatching(/cleanup remains pending/i),
+			);
 		});
 
 		it("recovers a target created when the POST response is lost", async () => {

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -470,4 +470,28 @@ describe("createQuiClient", () => {
 			});
 		});
 	});
+
+	describe("createNotificationTarget error redaction", () => {
+		it("scrubs the callback secret before the shared request helper logs or throws", async () => {
+			const secret = "plaintext-webhook-secret";
+			const targetUrl = `generic://dashboard.example/api/webhooks/qui?template=json&secret=${secret}`;
+			fetchSpy.mockResolvedValueOnce(
+				new Response(JSON.stringify({ error: `invalid notification url: ${targetUrl}` }), {
+					status: 400,
+					headers: { "content-type": "application/json" },
+				}),
+			);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			const rejection = client.createNotificationTarget({
+				name: "arr-dashboard",
+				url: targetUrl,
+			});
+
+			await expect(rejection).rejects.toThrow("secret=***");
+			await expect(rejection).rejects.not.toThrow(secret);
+			expect(JSON.stringify(vi.mocked(fakeLog.warn).mock.calls)).toContain("secret=***");
+			expect(JSON.stringify(vi.mocked(fakeLog.warn).mock.calls)).not.toContain(secret);
+		});
+	});
 });

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -557,13 +557,14 @@ describe("createQuiClient", () => {
 			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
 		});
 
-		it("upgrades a matching pre-owner arr-dashboard target in place", async () => {
+		it("reports manual cleanup when an old-secret legacy target cannot prove ownership", async () => {
 			const legacyTarget = {
 				...target,
 				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=old",
 			};
 			const desiredTarget = {
 				...legacyTarget,
+				id: 99,
 				name: "arr-dashboard-installation-deployment",
 				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=new&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
 			};
@@ -576,6 +577,12 @@ describe("createQuiClient", () => {
 				)
 				.mockResolvedValueOnce(
 					new Response(JSON.stringify(desiredTarget), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([legacyTarget, desiredTarget]), {
 						status: 200,
 						headers: { "content-type": "application/json" },
 					}),
@@ -587,17 +594,15 @@ describe("createQuiClient", () => {
 					name: desiredTarget.name,
 					url: desiredTarget.url,
 					ownerId: "owner-1",
-					legacyTargetAdoption: "callback",
+					legacyTargetAdoption: "secret",
+					reportLegacyCleanupRequired: true,
 					eventTypes: desiredTarget.eventTypes,
 				}),
-			).resolves.toEqual({ id: 42 });
+			).resolves.toEqual({ id: 99, legacyCleanupRequired: true });
 
-			expect(fetchSpy).toHaveBeenCalledTimes(2);
-			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
-			expect(JSON.parse(String(fetchSpy.mock.calls[1]?.[1]?.body))).toMatchObject({
-				name: desiredTarget.name,
-				url: desiredTarget.url,
-			});
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
+			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
 		});
 
 		it("upgrades an exact-secret legacy target when shared deployment adoption requires it", async () => {

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -587,7 +587,7 @@ describe("createQuiClient", () => {
 					name: desiredTarget.name,
 					url: desiredTarget.url,
 					ownerId: "owner-1",
-					allowLegacyTargetAdoption: true,
+					legacyTargetAdoption: "callback",
 					eventTypes: desiredTarget.eventTypes,
 				}),
 			).resolves.toEqual({ id: 42 });
@@ -598,6 +598,45 @@ describe("createQuiClient", () => {
 				name: desiredTarget.name,
 				url: desiredTarget.url,
 			});
+		});
+
+		it("upgrades an exact-secret legacy target when shared deployment adoption requires it", async () => {
+			const legacyTarget = {
+				...target,
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current",
+			};
+			const desiredTarget = {
+				...legacyTarget,
+				name: "arr-dashboard-installation-deployment",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
+			};
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([legacyTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(desiredTarget), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: desiredTarget.name,
+					url: desiredTarget.url,
+					ownerId: "owner-1",
+					legacyTargetAdoption: "secret",
+					eventTypes: desiredTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(2);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
 		});
 
 		it("leaves ambiguous legacy targets at a shared callback untouched", async () => {
@@ -637,6 +676,54 @@ describe("createQuiClient", () => {
 					name: desiredTarget.name,
 					url: desiredTarget.url,
 					ownerId: "owner-1",
+					legacyTargetAdoption: "secret",
+					eventTypes: desiredTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
+			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
+		});
+
+		it("leaves same-secret legacy targets untouched when adoption is denied", async () => {
+			const ambiguousLegacyTarget = {
+				...target,
+				id: 7,
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current",
+			};
+			const desiredTarget = {
+				...target,
+				name: "arr-dashboard-installation-deployment",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current&instanceId=qui-2&deploymentId=deployment-1&owner=owner-2",
+			};
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([ambiguousLegacyTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(desiredTarget), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([ambiguousLegacyTarget, desiredTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: desiredTarget.name,
+					url: desiredTarget.url,
+					ownerId: "owner-2",
+					legacyTargetAdoption: "never",
 					eventTypes: desiredTarget.eventTypes,
 				}),
 			).resolves.toEqual({ id: 42 });

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -560,16 +560,21 @@ describe("createQuiClient", () => {
 		it("upgrades a matching pre-owner arr-dashboard target in place", async () => {
 			const legacyTarget = {
 				...target,
-				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=old",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current",
+			};
+			const otherUserLegacyTarget = {
+				...legacyTarget,
+				id: 7,
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=other-user",
 			};
 			const desiredTarget = {
 				...legacyTarget,
 				name: "arr-dashboard-installation-deployment",
-				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=new&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
 			};
 			fetchSpy
 				.mockResolvedValueOnce(
-					new Response(JSON.stringify([legacyTarget]), {
+					new Response(JSON.stringify([otherUserLegacyTarget, legacyTarget]), {
 						status: 200,
 						headers: { "content-type": "application/json" },
 					}),
@@ -597,6 +602,52 @@ describe("createQuiClient", () => {
 				name: desiredTarget.name,
 				url: desiredTarget.url,
 			});
+		});
+
+		it("leaves ambiguous legacy targets at a shared callback untouched", async () => {
+			const otherUserLegacyTarget = {
+				...target,
+				id: 7,
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=other-user",
+			};
+			const desiredTarget = {
+				...target,
+				name: "arr-dashboard-installation-deployment",
+				url: "generic://dashboard.example/api/webhooks/qui?template=json&secret=current&instanceId=qui-1&deploymentId=deployment-1&owner=owner-1",
+			};
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([otherUserLegacyTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify(desiredTarget), {
+						status: 201,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([otherUserLegacyTarget, desiredTarget]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
+
+			const client = createQuiClient(buildApp(), buildInstance());
+			await expect(
+				client.ensureNotificationTarget({
+					name: desiredTarget.name,
+					url: desiredTarget.url,
+					ownerId: "owner-1",
+					eventTypes: desiredTarget.eventTypes,
+				}),
+			).resolves.toEqual({ id: 42 });
+
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("POST");
+			expect(fetchSpy.mock.calls.some(([, init]) => init?.method === "PUT")).toBe(false);
 		});
 
 		it("updates an existing target instead of creating a duplicate", async () => {

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -542,13 +542,30 @@ describe("createQuiClient", () => {
 			expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe("PUT");
 		});
 
-		it("treats an empty requested event list as qUI's all-events setting", async () => {
-			fetchSpy.mockResolvedValueOnce(
-				new Response(JSON.stringify([target]), {
-					status: 200,
-					headers: { "content-type": "application/json" },
-				}),
-			);
+		it("expands an empty requested event list and resets an existing subset", async () => {
+			const allEventTypes = ["torrent_added", "torrent_completed"];
+			fetchSpy
+				.mockResolvedValueOnce(
+					new Response(
+						JSON.stringify(allEventTypes.map((type) => ({ type, label: type, description: type }))),
+						{
+							status: 200,
+							headers: { "content-type": "application/json" },
+						},
+					),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify([target]), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				)
+				.mockResolvedValueOnce(
+					new Response(JSON.stringify({ ...target, eventTypes: allEventTypes }), {
+						status: 200,
+						headers: { "content-type": "application/json" },
+					}),
+				);
 
 			const client = createQuiClient(buildApp(), buildInstance());
 			await expect(
@@ -558,7 +575,11 @@ describe("createQuiClient", () => {
 					eventTypes: [],
 				}),
 			).resolves.toEqual({ id: 42 });
-			expect(fetchSpy).toHaveBeenCalledOnce();
+			expect(fetchSpy).toHaveBeenCalledTimes(3);
+			expect(String(fetchSpy.mock.calls[0]?.[0])).toBe("http://qui.test/api/notifications/events");
+			expect(JSON.parse(String(fetchSpy.mock.calls[2]?.[1]?.body))).toMatchObject({
+				eventTypes: allEventTypes,
+			});
 		});
 
 		it("accepts a committed update when qUI loses the PUT response", async () => {

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -779,6 +779,13 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				}
 			};
 			const desiredCallbackIdentity = callbackIdentity(url);
+			const desiredSecret = (() => {
+				try {
+					return new URL(url).searchParams.get("secret");
+				} catch {
+					return null;
+				}
+			})();
 			const isOwned = (target: NotificationTarget): boolean => {
 				if (target.name === name) return true;
 				try {
@@ -789,6 +796,8 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					return (
 						target.name === "arr-dashboard" &&
 						!targetUrl.searchParams.has("owner") &&
+						desiredSecret !== null &&
+						targetUrl.searchParams.get("secret") === desiredSecret &&
 						desiredCallbackIdentity !== null &&
 						callbackIdentity(target.url) === desiredCallbackIdentity
 					);

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -180,6 +180,8 @@ export interface QuiClient {
 		url: string;
 		/** Stable local owner marker used to reconcile a renamed target. */
 		ownerId?: string;
+		/** Allow callback-only migration when this is the sole local row for the qUI deployment. */
+		allowLegacyTargetAdoption?: boolean;
 		eventTypes?: string[];
 		enabled?: boolean;
 	}): Promise<{ id: number; cleanupPending?: boolean }>;
@@ -714,7 +716,14 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			});
 		},
 
-		async ensureNotificationTarget({ name, url, ownerId, eventTypes, enabled = true }) {
+		async ensureNotificationTarget({
+			name,
+			url,
+			ownerId,
+			allowLegacyTargetAdoption = false,
+			eventTypes,
+			enabled = true,
+		}) {
 			type NotificationTarget = z.infer<typeof quiNotificationTargetSchema>;
 			const redactSecret = (message: string) => message.replace(/secret=[^&\s"']+/g, "secret=***");
 			const requestOptions = {
@@ -796,8 +805,8 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					return (
 						target.name === "arr-dashboard" &&
 						!targetUrl.searchParams.has("owner") &&
-						desiredSecret !== null &&
-						targetUrl.searchParams.get("secret") === desiredSecret &&
+						(allowLegacyTargetAdoption ||
+							(desiredSecret !== null && targetUrl.searchParams.get("secret") === desiredSecret)) &&
 						desiredCallbackIdentity !== null &&
 						callbackIdentity(target.url) === desiredCallbackIdentity
 					);

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -180,8 +180,8 @@ export interface QuiClient {
 		url: string;
 		/** Stable local owner marker used to reconcile a renamed target. */
 		ownerId?: string;
-		/** Allow callback-only migration when this is the sole local row for the qUI deployment. */
-		allowLegacyTargetAdoption?: boolean;
+		/** Evidence required before migrating a fixed-name, ownerless target. */
+		legacyTargetAdoption?: "callback" | "secret" | "never";
 		eventTypes?: string[];
 		enabled?: boolean;
 	}): Promise<{ id: number; cleanupPending?: boolean }>;
@@ -720,7 +720,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			name,
 			url,
 			ownerId,
-			allowLegacyTargetAdoption = false,
+			legacyTargetAdoption = "never",
 			eventTypes,
 			enabled = true,
 		}) {
@@ -805,8 +805,10 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					return (
 						target.name === "arr-dashboard" &&
 						!targetUrl.searchParams.has("owner") &&
-						(allowLegacyTargetAdoption ||
-							(desiredSecret !== null && targetUrl.searchParams.get("secret") === desiredSecret)) &&
+						(legacyTargetAdoption === "callback" ||
+							(legacyTargetAdoption === "secret" &&
+								desiredSecret !== null &&
+								targetUrl.searchParams.get("secret") === desiredSecret)) &&
 						desiredCallbackIdentity !== null &&
 						callbackIdentity(target.url) === desiredCallbackIdentity
 					);

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -181,10 +181,12 @@ export interface QuiClient {
 		/** Stable local owner marker used to reconcile a renamed target. */
 		ownerId?: string;
 		/** Evidence required before migrating a fixed-name, ownerless target. */
-		legacyTargetAdoption?: "callback" | "secret" | "never";
+		legacyTargetAdoption?: "secret" | "never";
+		/** Report an unowned enabled legacy target so the operator can remove it manually. */
+		reportLegacyCleanupRequired?: boolean;
 		eventTypes?: string[];
 		enabled?: boolean;
-	}): Promise<{ id: number; cleanupPending?: boolean }>;
+	}): Promise<{ id: number; cleanupPending?: boolean; legacyCleanupRequired?: boolean }>;
 	/**
 	 * Trigger a qui dir-scan for a specific path. Maps to qui's
 	 * `POST /api/dirscan/webhook` endpoint, which accepts a simple
@@ -721,6 +723,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			url,
 			ownerId,
 			legacyTargetAdoption = "never",
+			reportLegacyCleanupRequired = false,
 			eventTypes,
 			enabled = true,
 		}) {
@@ -795,6 +798,19 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					return null;
 				}
 			})();
+			const isLegacyCandidate = (target: NotificationTarget): boolean => {
+				if (!target.enabled || target.name !== "arr-dashboard") return false;
+				try {
+					const targetUrl = new URL(target.url);
+					return (
+						!targetUrl.searchParams.has("owner") &&
+						desiredCallbackIdentity !== null &&
+						callbackIdentity(target.url) === desiredCallbackIdentity
+					);
+				} catch {
+					return false;
+				}
+			};
 			const isOwned = (target: NotificationTarget): boolean => {
 				if (target.name === name) return true;
 				try {
@@ -803,14 +819,10 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 						return true;
 					}
 					return (
-						target.name === "arr-dashboard" &&
-						!targetUrl.searchParams.has("owner") &&
-						(legacyTargetAdoption === "callback" ||
-							(legacyTargetAdoption === "secret" &&
-								desiredSecret !== null &&
-								targetUrl.searchParams.get("secret") === desiredSecret)) &&
-						desiredCallbackIdentity !== null &&
-						callbackIdentity(target.url) === desiredCallbackIdentity
+						isLegacyCandidate(target) &&
+						legacyTargetAdoption === "secret" &&
+						desiredSecret !== null &&
+						targetUrl.searchParams.get("secret") === desiredSecret
 					);
 				} catch {
 					return false;
@@ -893,11 +905,20 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				return { target: reconciled, cleanupPending };
 			};
 
-			const existing = await reconcile(await listTargets());
+			const initialTargets = await listTargets();
+			const legacyCleanupRequired =
+				reportLegacyCleanupRequired &&
+				initialTargets.some((target) => isLegacyCandidate(target) && !isOwned(target));
+			const resultStatus = (cleanupPending = false) => ({
+				...(cleanupPending ? { cleanupPending: true as const } : {}),
+				...(legacyCleanupRequired ? { legacyCleanupRequired: true as const } : {}),
+			});
+
+			const existing = await reconcile(initialTargets);
 			if (existing) {
 				return {
 					id: existing.target.id,
-					...(existing.cleanupPending ? { cleanupPending: true } : {}),
+					...resultStatus(existing.cleanupPending),
 				};
 			}
 
@@ -917,7 +938,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					if (recovered) {
 						return {
 							id: recovered.target.id,
-							...(recovered.cleanupPending ? { cleanupPending: true } : {}),
+							...resultStatus(recovered.cleanupPending),
 						};
 					}
 				} catch {
@@ -932,12 +953,12 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			try {
 				afterCreate = await listTargets();
 			} catch {
-				return { id: created.id, cleanupPending: true };
+				return { id: created.id, ...resultStatus(true) };
 			}
 			const reconciled = await reconcile(afterCreate);
 			return {
 				id: reconciled?.target.id ?? created.id,
-				...(reconciled?.cleanupPending ? { cleanupPending: true } : {}),
+				...resultStatus(reconciled?.cleanupPending),
 			};
 		},
 

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -350,6 +350,12 @@ const quiNotificationTargetListSchema = z
 	.nullable()
 	.transform((targets) => targets ?? []);
 
+const quiNotificationEventDefinitionSchema = z
+	.object({
+		type: z.string(),
+	})
+	.passthrough();
+
 /**
  * Build a request-scoped qui client.
  *
@@ -712,7 +718,23 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			const requestOptions = {
 				redactErrorMessage: redactSecret,
 			};
-			const desired = { name, url, eventTypes, enabled };
+			// qUI interprets an explicit [] as "all events" and expands it to
+			// the concrete event list in target responses. Resolve that list
+			// up front so an existing subset cannot be mistaken for all events
+			// and ambiguous PUT responses remain verifiable. Omitted eventTypes
+			// retains qUI's current subscription on update.
+			const desiredEventTypes =
+				eventTypes?.length === 0
+					? (
+							await quiRequest(
+								ctx,
+								"/api/notifications/events",
+								z.array(quiNotificationEventDefinitionSchema),
+								requestOptions,
+							)
+						).map((definition) => definition.type)
+					: eventTypes;
+			const desired = { name, url, eventTypes: desiredEventTypes, enabled };
 
 			const listTargets = () =>
 				quiRequest(
@@ -728,10 +750,8 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					body,
 				});
 			const sameEventTypes = (actual: string[]): boolean => {
-				// qUI treats both an omitted list and [] as "all events"; its
-				// response expands that to every concrete event name.
-				if (eventTypes === undefined || eventTypes.length === 0) return true;
-				const expected = [...new Set(eventTypes)].sort();
+				if (desiredEventTypes === undefined) return true;
+				const expected = [...new Set(desiredEventTypes)].sort();
 				const received = [...new Set(actual)].sort();
 				return (
 					expected.length === received.length &&

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -800,8 +800,8 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			const reconcile = async (
 				targets: NotificationTarget[],
 			): Promise<{ target: NotificationTarget; cleanupPending: boolean } | null> => {
-				const matches = targets.filter(isOwned).sort((left, right) => left.id - right.id);
-				const primary = matches[0];
+				let matches = targets.filter(isOwned).sort((left, right) => left.id - right.id);
+				const primary = matches.find(matchesDesired) ?? matches[0];
 				if (!primary) return null;
 
 				let reconciled = primary;
@@ -814,11 +814,21 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					} catch (updateError) {
 						// A lost response can happen after qui commits the PUT.
 						// Re-read before surfacing a retryable upstream failure.
-						const afterUpdate = (await listTargets()).find((target) => target.id === primary.id);
-						if (!afterUpdate || !matchesDesired(afterUpdate)) {
+						// A concurrent registration may also have created a
+						// different owned target that already satisfies the
+						// desired state; prefer that valid target over a false
+						// total failure and reconcile the stale primary below.
+						matches = (await listTargets())
+							.filter(isOwned)
+							.sort((left, right) => left.id - right.id);
+						const afterUpdate = matches.find((target) => target.id === primary.id);
+						const validTarget =
+							(afterUpdate && matchesDesired(afterUpdate) ? afterUpdate : null) ??
+							matches.find(matchesDesired);
+						if (!validTarget) {
 							throw updateError;
 						}
-						reconciled = afterUpdate;
+						reconciled = validTarget;
 					}
 				}
 
@@ -827,7 +837,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				// every other enabled copy so stale secrets cannot keep firing
 				// rejected callbacks or consume the receiver's rate limit.
 				let cleanupPending = false;
-				for (const duplicate of matches.slice(1)) {
+				for (const duplicate of matches.filter((target) => target.id !== reconciled.id)) {
 					if (!duplicate.enabled) continue;
 					try {
 						const disabled = await updateTarget(duplicate.id, {

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -178,6 +178,8 @@ export interface QuiClient {
 	ensureNotificationTarget(args: {
 		name: string;
 		url: string;
+		/** Stable local owner marker used to reconcile a renamed target. */
+		ownerId?: string;
 		eventTypes?: string[];
 		enabled?: boolean;
 	}): Promise<{ id: number }>;
@@ -712,7 +714,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			});
 		},
 
-		async ensureNotificationTarget({ name, url, eventTypes, enabled = true }) {
+		async ensureNotificationTarget({ name, url, ownerId, eventTypes, enabled = true }) {
 			type NotificationTarget = z.infer<typeof quiNotificationTargetSchema>;
 			const redactSecret = (message: string) => message.replace(/secret=[^&\s"']+/g, "secret=***");
 			const requestOptions = {
@@ -763,13 +765,20 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				target.url === url &&
 				target.enabled === enabled &&
 				sameEventTypes(target.eventTypes);
+			const isOwned = (target: NotificationTarget): boolean => {
+				if (target.name === name) return true;
+				if (!ownerId) return false;
+				try {
+					return new URL(target.url).searchParams.get("owner") === ownerId;
+				} catch {
+					return false;
+				}
+			};
 
 			const reconcile = async (
 				targets: NotificationTarget[],
 			): Promise<NotificationTarget | null> => {
-				const matches = targets
-					.filter((target) => target.name === name)
-					.sort((left, right) => left.id - right.id);
+				const matches = targets.filter(isOwned).sort((left, right) => left.id - right.id);
 				const primary = matches[0];
 				if (!primary) return null;
 

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -697,6 +697,10 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				{
 					method: "POST",
 					body: { name, url, eventTypes, enabled },
+					// qUI includes the rejected target URL in some validation
+					// errors. Scrub the one-time callback credential inside the
+					// shared request boundary, before either logging or throwing.
+					redactErrorMessage: (message) => message.replace(/secret=[^&\s"']+/g, "secret=***"),
 				},
 			);
 		},

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -728,9 +728,11 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 					body,
 				});
 			const sameEventTypes = (actual: string[]): boolean => {
-				if (eventTypes === undefined) return true;
-				const expected = [...eventTypes].sort();
-				const received = [...actual].sort();
+				// qUI treats both an omitted list and [] as "all events"; its
+				// response expands that to every concrete event name.
+				if (eventTypes === undefined || eventTypes.length === 0) return true;
+				const expected = [...new Set(eventTypes)].sort();
+				const received = [...new Set(actual)].sort();
 				return (
 					expected.length === received.length &&
 					expected.every((value, index) => value === received[index])
@@ -755,6 +757,9 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				if (!matchesDesired(primary)) {
 					try {
 						reconciled = await updateTarget(primary.id, desired);
+						if (!matchesDesired(reconciled)) {
+							throw new Error("qUI returned a notification target that does not match the update");
+						}
 					} catch (updateError) {
 						// A lost response can happen after qui commits the PUT.
 						// Re-read before surfacing a retryable upstream failure.
@@ -773,12 +778,15 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				for (const duplicate of matches.slice(1)) {
 					if (!duplicate.enabled) continue;
 					try {
-						await updateTarget(duplicate.id, {
+						const disabled = await updateTarget(duplicate.id, {
 							name: duplicate.name,
 							url: duplicate.url,
 							eventTypes: duplicate.eventTypes,
 							enabled: false,
 						});
+						if (disabled.enabled) {
+							throw new Error("qUI did not disable a duplicate notification target");
+						}
 					} catch (disableError) {
 						const afterDisable = (await listTargets()).find((target) => target.id === duplicate.id);
 						if (afterDisable?.enabled !== false) {

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -182,7 +182,7 @@ export interface QuiClient {
 		ownerId?: string;
 		eventTypes?: string[];
 		enabled?: boolean;
-	}): Promise<{ id: number }>;
+	}): Promise<{ id: number; cleanupPending?: boolean }>;
 	/**
 	 * Trigger a qui dir-scan for a specific path. Maps to qui's
 	 * `POST /api/dirscan/webhook` endpoint, which accepts a simple
@@ -765,11 +765,33 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				target.url === url &&
 				target.enabled === enabled &&
 				sameEventTypes(target.eventTypes);
+			const callbackIdentity = (value: string): string | null => {
+				try {
+					const callback = new URL(value);
+					callback.hash = "";
+					for (const key of ["secret", "instanceId", "deploymentId", "owner"]) {
+						callback.searchParams.delete(key);
+					}
+					callback.searchParams.sort();
+					return callback.toString();
+				} catch {
+					return null;
+				}
+			};
+			const desiredCallbackIdentity = callbackIdentity(url);
 			const isOwned = (target: NotificationTarget): boolean => {
 				if (target.name === name) return true;
-				if (!ownerId) return false;
 				try {
-					return new URL(target.url).searchParams.get("owner") === ownerId;
+					const targetUrl = new URL(target.url);
+					if (ownerId && targetUrl.searchParams.get("owner") === ownerId) {
+						return true;
+					}
+					return (
+						target.name === "arr-dashboard" &&
+						!targetUrl.searchParams.has("owner") &&
+						desiredCallbackIdentity !== null &&
+						callbackIdentity(target.url) === desiredCallbackIdentity
+					);
 				} catch {
 					return false;
 				}
@@ -777,7 +799,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 
 			const reconcile = async (
 				targets: NotificationTarget[],
-			): Promise<NotificationTarget | null> => {
+			): Promise<{ target: NotificationTarget; cleanupPending: boolean } | null> => {
 				const matches = targets.filter(isOwned).sort((left, right) => left.id - right.id);
 				const primary = matches[0];
 				if (!primary) return null;
@@ -804,6 +826,7 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				// Keep the oldest as the canonical registration and disable
 				// every other enabled copy so stale secrets cannot keep firing
 				// rejected callbacks or consume the receiver's rate limit.
+				let cleanupPending = false;
 				for (const duplicate of matches.slice(1)) {
 					if (!duplicate.enabled) continue;
 					try {
@@ -816,19 +839,37 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 						if (disabled.enabled) {
 							throw new Error("qUI did not disable a duplicate notification target");
 						}
-					} catch (disableError) {
-						const afterDisable = (await listTargets()).find((target) => target.id === duplicate.id);
-						if (afterDisable?.enabled !== false) {
-							throw disableError;
+					} catch {
+						let cleanupConfirmed = false;
+						try {
+							const afterDisable = (await listTargets()).find(
+								(target) => target.id === duplicate.id,
+							);
+							cleanupConfirmed = afterDisable?.enabled === false;
+						} catch {
+							// The canonical target is already valid. Preserve
+							// that success and report cleanup as retryable.
+						}
+						if (!cleanupConfirmed) {
+							cleanupPending = true;
+							ctx.log.warn(
+								{ targetId: duplicate.id },
+								"qUI notification target registered but duplicate cleanup remains pending",
+							);
 						}
 					}
 				}
 
-				return reconciled;
+				return { target: reconciled, cleanupPending };
 			};
 
 			const existing = await reconcile(await listTargets());
-			if (existing) return { id: existing.id };
+			if (existing) {
+				return {
+					id: existing.target.id,
+					...(existing.cleanupPending ? { cleanupPending: true } : {}),
+				};
+			}
 
 			let created: NotificationTarget;
 			try {
@@ -843,7 +884,12 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 				// registration failed; the next click must not create another.
 				try {
 					const recovered = await reconcile(await listTargets());
-					if (recovered) return { id: recovered.id };
+					if (recovered) {
+						return {
+							id: recovered.target.id,
+							...(recovered.cleanupPending ? { cleanupPending: true } : {}),
+						};
+					}
 				} catch {
 					// Preserve the original, already-redacted create failure.
 				}
@@ -856,10 +902,13 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			try {
 				afterCreate = await listTargets();
 			} catch {
-				return { id: created.id };
+				return { id: created.id, cleanupPending: true };
 			}
 			const reconciled = await reconcile(afterCreate);
-			return { id: reconciled?.id ?? created.id };
+			return {
+				id: reconciled?.target.id ?? created.id,
+				...(reconciled?.cleanupPending ? { cleanupPending: true } : {}),
+			};
 		},
 
 		async triggerDirScan(path) {

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -170,8 +170,12 @@ export interface QuiClient {
 	 * `PUT /api/instances/:id/torrents/:hash/trackers`.
 	 */
 	editTracker(instanceId: number, hash: string, oldURL: string, newURL: string): Promise<void>;
-	/** Create a notification target inside qui. Phase 5.1 — auto-registers arr-dashboard's webhook URL. */
-	createNotificationTarget(args: {
+	/**
+	 * Create or update arr-dashboard's notification target inside qui.
+	 * Discovers prior registrations by name and reconciles ambiguous create
+	 * responses so retrying registration stays idempotent.
+	 */
+	ensureNotificationTarget(args: {
 		name: string;
 		url: string;
 		eventTypes?: string[];
@@ -328,6 +332,23 @@ const wireCrossSeedMatchSchema = z
 const wireLocalMatchesResponseSchema = z.object({
 	matches: z.array(wireCrossSeedMatchSchema).nullable(),
 });
+
+const quiNotificationTargetSchema = z
+	.object({
+		id: z.number().int(),
+		name: z.string(),
+		url: z.string(),
+		enabled: z.boolean(),
+		eventTypes: z.array(z.string()),
+	})
+	.passthrough();
+
+// qUI's Go store returns a nil slice when no targets exist, which encodes
+// as JSON null rather than []. Normalize both wire shapes at the boundary.
+const quiNotificationTargetListSchema = z
+	.array(quiNotificationTargetSchema)
+	.nullable()
+	.transform((targets) => targets ?? []);
 
 /**
  * Build a request-scoped qui client.
@@ -685,24 +706,123 @@ export function createQuiClient(app: FastifyInstance, instance: ServiceInstance)
 			});
 		},
 
-		async createNotificationTarget({ name, url, eventTypes, enabled = true }) {
-			// qui's `POST /api/notifications/targets` returns the created
-			// target — we only need the id back for arr-dashboard's own
-			// bookkeeping ("we already registered our webhook against this qui").
-			// passthrough() lets future qui fields land without a shared-schema bump.
-			return quiRequest(
-				ctx,
-				"/api/notifications/targets",
-				z.object({ id: z.number().int() }).passthrough(),
-				{
+		async ensureNotificationTarget({ name, url, eventTypes, enabled = true }) {
+			type NotificationTarget = z.infer<typeof quiNotificationTargetSchema>;
+			const redactSecret = (message: string) => message.replace(/secret=[^&\s"']+/g, "secret=***");
+			const requestOptions = {
+				redactErrorMessage: redactSecret,
+			};
+			const desired = { name, url, eventTypes, enabled };
+
+			const listTargets = () =>
+				quiRequest(
+					ctx,
+					"/api/notifications/targets",
+					quiNotificationTargetListSchema,
+					requestOptions,
+				);
+			const updateTarget = (targetId: number, body: typeof desired) =>
+				quiRequest(ctx, `/api/notifications/targets/${targetId}`, quiNotificationTargetSchema, {
+					...requestOptions,
+					method: "PUT",
+					body,
+				});
+			const sameEventTypes = (actual: string[]): boolean => {
+				if (eventTypes === undefined) return true;
+				const expected = [...eventTypes].sort();
+				const received = [...actual].sort();
+				return (
+					expected.length === received.length &&
+					expected.every((value, index) => value === received[index])
+				);
+			};
+			const matchesDesired = (target: NotificationTarget): boolean =>
+				target.name === name &&
+				target.url === url &&
+				target.enabled === enabled &&
+				sameEventTypes(target.eventTypes);
+
+			const reconcile = async (
+				targets: NotificationTarget[],
+			): Promise<NotificationTarget | null> => {
+				const matches = targets
+					.filter((target) => target.name === name)
+					.sort((left, right) => left.id - right.id);
+				const primary = matches[0];
+				if (!primary) return null;
+
+				let reconciled = primary;
+				if (!matchesDesired(primary)) {
+					try {
+						reconciled = await updateTarget(primary.id, desired);
+					} catch (updateError) {
+						// A lost response can happen after qui commits the PUT.
+						// Re-read before surfacing a retryable upstream failure.
+						const afterUpdate = (await listTargets()).find((target) => target.id === primary.id);
+						if (!afterUpdate || !matchesDesired(afterUpdate)) {
+							throw updateError;
+						}
+						reconciled = afterUpdate;
+					}
+				}
+
+				// Old retries may already have created more than one target.
+				// Keep the oldest as the canonical registration and disable
+				// every other enabled copy so stale secrets cannot keep firing
+				// rejected callbacks or consume the receiver's rate limit.
+				for (const duplicate of matches.slice(1)) {
+					if (!duplicate.enabled) continue;
+					try {
+						await updateTarget(duplicate.id, {
+							name: duplicate.name,
+							url: duplicate.url,
+							eventTypes: duplicate.eventTypes,
+							enabled: false,
+						});
+					} catch (disableError) {
+						const afterDisable = (await listTargets()).find((target) => target.id === duplicate.id);
+						if (afterDisable?.enabled !== false) {
+							throw disableError;
+						}
+					}
+				}
+
+				return reconciled;
+			};
+
+			const existing = await reconcile(await listTargets());
+			if (existing) return { id: existing.id };
+
+			let created: NotificationTarget;
+			try {
+				created = await quiRequest(ctx, "/api/notifications/targets", quiNotificationTargetSchema, {
+					...requestOptions,
 					method: "POST",
-					body: { name, url, eventTypes, enabled },
-					// qUI includes the rejected target URL in some validation
-					// errors. Scrub the one-time callback credential inside the
-					// shared request boundary, before either logging or throwing.
-					redactErrorMessage: (message) => message.replace(/secret=[^&\s"']+/g, "secret=***"),
-				},
-			);
+					body: desired,
+				});
+			} catch (createError) {
+				// The POST may have committed even if its response was lost.
+				// Discover and reconcile that target before deciding the
+				// registration failed; the next click must not create another.
+				try {
+					const recovered = await reconcile(await listTargets());
+					if (recovered) return { id: recovered.id };
+				} catch {
+					// Preserve the original, already-redacted create failure.
+				}
+				throw createError;
+			}
+
+			// A concurrent registration can race the initial list. Re-list
+			// after a successful create and collapse any enabled duplicates.
+			let afterCreate: NotificationTarget[];
+			try {
+				afterCreate = await listTargets();
+			} catch {
+				return { id: created.id };
+			}
+			const reconciled = await reconcile(afterCreate);
+			return { id: reconciled?.id ?? created.id };
 		},
 
 		async triggerDirScan(path) {

--- a/apps/api/src/lib/qui/client-helpers.ts
+++ b/apps/api/src/lib/qui/client-helpers.ts
@@ -38,6 +38,12 @@ export async function quiRequest<T>(
 		query?: Record<string, string>;
 		body?: unknown;
 		/**
+		 * Scrub credentials from upstream error text before it is logged or
+		 * wrapped in QuiApiError. Use for calls whose request values may be
+		 * echoed verbatim by qui.
+		 */
+		redactErrorMessage?: (message: string) => string;
+		/**
 		 * Per-call timeout override. Resolves in this order:
 		 *   init.timeoutMs → ctx.timeoutMs → DEFAULT_QUI_TIMEOUT_MS.
 		 * Used by `listAllTorrents` (which paginates and can legitimately
@@ -71,7 +77,8 @@ export async function quiRequest<T>(
 	}
 
 	if (!response.ok) {
-		const message = await readErrorMessage(response);
+		const rawMessage = await readErrorMessage(response);
+		const message = init?.redactErrorMessage?.(rawMessage) ?? rawMessage;
 		ctx.log.warn(
 			{ instanceId: ctx.instanceId, path, status: response.status, message },
 			"qui request failed",

--- a/apps/api/src/lib/qui/webhook-secret.ts
+++ b/apps/api/src/lib/qui/webhook-secret.ts
@@ -2,11 +2,9 @@
  * Per-user qui-webhook secret manager (Phase 5.1).
  *
  * Mirrors the bearer-token pattern in `auto-tag/webhook-handler.ts` but uses
- * a query-param scheme instead of an Authorization header — qui's
- * notification system delivers webhooks via `POST <url>?secret=...` (the
- * `ApiKeyQuery` security scheme in qui's openapi), and inverting that to
- * fit our existing Bearer-header receiver would require a custom shim
- * inside qui (which arr-dashboard doesn't own).
+ * a query-param scheme instead of an Authorization header. qUI's generic
+ * Shoutrrr target forwards the `secret` query parameter to this receiver;
+ * its notification-target API does not expose a per-target header field.
  *
  * Plaintext secret is returned ONLY at generation/rotation time — never
  * stored, only hashed. Operators paste it into qui's notification target

--- a/apps/api/src/plugins/__tests__/backup-scheduler-disabled.test.ts
+++ b/apps/api/src/plugins/__tests__/backup-scheduler-disabled.test.ts
@@ -1,0 +1,43 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import fp from "fastify-plugin";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { JOB_ID } from "../../lib/scheduler-registry/job-definitions.js";
+import backupSchedulerPlugin from "../backup-scheduler.js";
+import schedulerRegistryPlugin from "../scheduler-registry.js";
+
+const stubPrismaPlugin = fp(
+	async (app: FastifyInstance) => {
+		app.decorate("prisma", {} as never);
+	},
+	{ name: "prisma" },
+);
+
+let app: ReturnType<typeof Fastify>;
+
+beforeAll(async () => {
+	app = Fastify({ logger: false });
+	app.decorate("config", { DATABASE_URL: "file:./dev.db" } as never);
+	app.decorate("notificationService", { notify: vi.fn() } as never);
+	app.decorate("secretsSynchronized", false);
+
+	await app.register(stubPrismaPlugin);
+	await app.register(schedulerRegistryPlugin);
+	await app.register(backupSchedulerPlugin);
+	await app.ready();
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("backup scheduler with unsynchronized environment secrets", () => {
+	it("reports the job as disabled instead of idle", () => {
+		const status = app.schedulerRegistry.getStatus(JOB_ID.backup);
+
+		expect(status?.state).toBe("disabled");
+		expect(status?.disabled).toBe(true);
+		expect(status?.disabledReason).toMatch(/environment secrets could not be synchronized/i);
+		expect(status?.totalRuns).toBe(0);
+		expect(app.hasDecorator("backupScheduler")).toBe(false);
+	});
+});

--- a/apps/api/src/plugins/backup-scheduler.ts
+++ b/apps/api/src/plugins/backup-scheduler.ts
@@ -32,7 +32,10 @@ const backupSchedulerPlugin = fastifyPlugin(
 						app.log,
 						secretsPath,
 						(payload) => app.notificationService.notify(payload),
-						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.backup, fn) },
+						{
+							trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.backup, fn),
+							secretsSynchronized: app.secretsSynchronized,
+						},
 					);
 					app.decorate("backupScheduler", scheduler);
 

--- a/apps/api/src/plugins/backup-scheduler.ts
+++ b/apps/api/src/plugins/backup-scheduler.ts
@@ -20,6 +20,14 @@ const backupSchedulerPlugin = fastifyPlugin(
 				JOB_ID.backup,
 				"backup",
 				async () => {
+					if (app.secretsSynchronized === false) {
+						const reason =
+							"Active environment secrets could not be synchronized to the secrets file";
+						app.schedulerRegistry.markDisabled(JOB_ID.backup, reason);
+						app.log.warn({ jobId: JOB_ID.backup, reason }, "Backup scheduler disabled");
+						return;
+					}
+
 					app.log.info("Initializing backup scheduler");
 
 					// Determine secrets path based on DATABASE_URL from app config (canonical source)

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -12,14 +12,18 @@ export const securityPlugin = fp(
 		const databaseUrl = app.config.DATABASE_URL!;
 		const secretsPath = resolveSecretsPath(databaseUrl);
 
-		// Get or generate secrets
+		// Always load the local secrets file because it also carries the
+		// installation identity. Unlike database backups, that identity stays
+		// with this deployment so restored clones cannot claim its resources.
+		const secretManager = new SecretManager(secretsPath);
+		const secrets = secretManager.getOrCreateSecrets();
+
+		// Get or generate cryptographic secrets
 		let encryptionKey = app.config.ENCRYPTION_KEY;
 		let sessionCookieSecret = app.config.SESSION_COOKIE_SECRET;
 
 		if (!encryptionKey || !sessionCookieSecret) {
 			app.log.info("Auto-generating secrets (not provided in environment)");
-			const secretManager = new SecretManager(secretsPath);
-			const secrets = secretManager.getOrCreateSecrets();
 			encryptionKey = encryptionKey || secrets.encryptionKey;
 			sessionCookieSecret = sessionCookieSecret || secrets.sessionCookieSecret;
 		}
@@ -42,6 +46,7 @@ export const securityPlugin = fp(
 
 		app.decorate("encryptor", encryptor);
 		app.decorate("sessionService", sessionService);
+		app.decorate("installationId", secrets.installationId);
 	},
 	{
 		name: "security",

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -52,6 +52,7 @@ export const securityPlugin = fp(
 		app.decorate("encryptor", encryptor);
 		app.decorate("sessionService", sessionService);
 		app.decorate("installationId", secrets.installationId);
+		app.decorate("secretsSynchronized", secretManager.secretsSynchronized);
 	},
 	{
 		name: "security",

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -16,30 +16,29 @@ export const securityPlugin = fp(
 		// installation identity. Unlike database backups, that identity stays
 		// with this deployment so restored clones cannot claim its resources.
 		const secretManager = new SecretManager(secretsPath);
-		const secrets = secretManager.getOrCreateSecrets();
+		const secrets = secretManager.getOrCreateSecrets({
+			...(app.config.ENCRYPTION_KEY ? { encryptionKey: app.config.ENCRYPTION_KEY } : {}),
+			...(app.config.SESSION_COOKIE_SECRET
+				? { sessionCookieSecret: app.config.SESSION_COOKIE_SECRET }
+				: {}),
+		});
 
-		// Get or generate cryptographic secrets
-		let encryptionKey = app.config.ENCRYPTION_KEY;
-		let sessionCookieSecret = app.config.SESSION_COOKIE_SECRET;
-
-		if (!encryptionKey || !sessionCookieSecret) {
+		if (!app.config.ENCRYPTION_KEY || !app.config.SESSION_COOKIE_SECRET) {
 			app.log.info("Auto-generating secrets (not provided in environment)");
-			encryptionKey = encryptionKey || secrets.encryptionKey;
-			sessionCookieSecret = sessionCookieSecret || secrets.sessionCookieSecret;
 		}
 
 		// Register cookie plugin with the secret (auto-generated or from env)
 		await app.register(fastifyCookie, {
-			secret: sessionCookieSecret,
+			secret: secrets.sessionCookieSecret,
 			hook: "onRequest",
 		});
 
-		const encryptor = new Encryptor(encryptionKey);
+		const encryptor = new Encryptor(secrets.encryptionKey);
 		const sessionService = new SessionService(
 			app.prisma,
 			{
 				...app.config,
-				SESSION_COOKIE_SECRET: sessionCookieSecret,
+				SESSION_COOKIE_SECRET: secrets.sessionCookieSecret,
 			},
 			app.log,
 		);

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -55,6 +55,7 @@ export const securityPlugin = fp(
 		app.decorate("encryptor", encryptor);
 		app.decorate("sessionService", sessionService);
 		app.decorate("installationId", secrets.installationId);
+		app.decorate("installationIdIsPersistent", secretManager.installationIdIsPersistent);
 		app.decorate("secretsSynchronized", secretManager.secretsSynchronized);
 	},
 	{

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -16,12 +16,18 @@ export const securityPlugin = fp(
 		// installation identity. Unlike database backups, that identity stays
 		// with this deployment so restored clones cannot claim its resources.
 		const secretManager = new SecretManager(secretsPath);
-		const secrets = secretManager.getOrCreateSecrets({
-			...(app.config.ENCRYPTION_KEY ? { encryptionKey: app.config.ENCRYPTION_KEY } : {}),
-			...(app.config.SESSION_COOKIE_SECRET
-				? { sessionCookieSecret: app.config.SESSION_COOKIE_SECRET }
-				: {}),
-		});
+		const secrets =
+			app.config.ENCRYPTION_KEY && app.config.SESSION_COOKIE_SECRET
+				? secretManager.getOrCreateEnvironmentSecrets({
+						encryptionKey: app.config.ENCRYPTION_KEY,
+						sessionCookieSecret: app.config.SESSION_COOKIE_SECRET,
+					})
+				: secretManager.getOrCreateSecrets({
+						...(app.config.ENCRYPTION_KEY ? { encryptionKey: app.config.ENCRYPTION_KEY } : {}),
+						...(app.config.SESSION_COOKIE_SECRET
+							? { sessionCookieSecret: app.config.SESSION_COOKIE_SECRET }
+							: {}),
+					});
 
 		if (!app.config.ENCRYPTION_KEY || !app.config.SESSION_COOKIE_SECRET) {
 			app.log.info("Auto-generating secrets (not provided in environment)");

--- a/apps/api/src/plugins/security.ts
+++ b/apps/api/src/plugins/security.ts
@@ -18,10 +18,13 @@ export const securityPlugin = fp(
 		const secretManager = new SecretManager(secretsPath);
 		const secrets =
 			app.config.ENCRYPTION_KEY && app.config.SESSION_COOKIE_SECRET
-				? secretManager.getOrCreateEnvironmentSecrets({
-						encryptionKey: app.config.ENCRYPTION_KEY,
-						sessionCookieSecret: app.config.SESSION_COOKIE_SECRET,
-					})
+				? secretManager.getOrCreateEnvironmentSecrets(
+						{
+							encryptionKey: app.config.ENCRYPTION_KEY,
+							sessionCookieSecret: app.config.SESSION_COOKIE_SECRET,
+						},
+						`${databaseUrl}\0${app.config.APP_URL}`,
+					)
 				: secretManager.getOrCreateSecrets({
 						...(app.config.ENCRYPTION_KEY ? { encryptionKey: app.config.ENCRYPTION_KEY } : {}),
 						...(app.config.SESSION_COOKIE_SECRET

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -838,6 +838,17 @@ describe("POST /qui/webhook-config/rotate", () => {
 		// not actually hashing the value before persisting it.
 		expect(persisted).toMatch(/^[a-f0-9]{64}$/);
 	});
+
+	it("does not rotate the secret when the callback URL is invalid", async () => {
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "ftp://dashboard.example",
+		});
+
+		const res = await injectAuthenticated("POST", "/qui/webhook-config/rotate", { body: {} });
+
+		expect(res.statusCode).toBe(500);
+		expect(mockPrisma.user.update).not.toHaveBeenCalled();
+	});
 });
 
 describe("POST /qui/instances/:id/webhook-config/register", () => {

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -853,18 +853,26 @@ describe("POST /qui/webhook-config/rotate", () => {
 
 describe("POST /qui/instances/:id/webhook-config/register", () => {
 	it("keys target ownership by the local installation and upstream qUI deployment", () => {
-		const first = buildQuiNotificationTargetName("installation-a", "user-1", "http://qui.test/");
+		const first = buildQuiNotificationTargetName(
+			"installation-a",
+			"user-1",
+			"qui-1",
+			"http://qui.test/",
+		);
 		expect(first).toBe(
-			buildQuiNotificationTargetName("installation-a", "user-1", "http://QUI.test"),
+			buildQuiNotificationTargetName("installation-a", "user-1", "qui-1", "http://QUI.test"),
 		);
 		expect(first).not.toBe(
-			buildQuiNotificationTargetName("installation-b", "user-1", "http://qui.test"),
+			buildQuiNotificationTargetName("installation-b", "user-1", "qui-1", "http://qui.test"),
 		);
 		expect(first).not.toBe(
-			buildQuiNotificationTargetName("installation-a", "user-2", "http://qui.test"),
+			buildQuiNotificationTargetName("installation-a", "user-2", "qui-1", "http://qui.test"),
 		);
 		expect(first).not.toBe(
-			buildQuiNotificationTargetName("installation-a", "user-1", "http://other-qui.test"),
+			buildQuiNotificationTargetName("installation-a", "user-1", "qui-1", "http://other-qui.test"),
+		);
+		expect(first).not.toBe(
+			buildQuiNotificationTargetName("installation-a", "user-1", "qui-2", "http://qui.test"),
 		);
 	});
 
@@ -925,7 +933,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
 		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
 		expect(call.name).toBe(
-			buildQuiNotificationTargetName("installation-1", "user-1", "http://qui.test"),
+			buildQuiNotificationTargetName("installation-1", "user-1", "qui-1", "http://qui.test"),
 		);
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -177,6 +177,38 @@ afterAll(async () => {
 	await app?.close();
 });
 
+async function injectWebhookConfigWithTrustProxy(options: {
+	remoteAddress: string;
+	forwardedFor: string;
+	forwardedHost: string;
+}) {
+	const proxyApp = Fastify({ trustProxy: true });
+	proxyApp.decorate("prisma", mockPrisma as never);
+	proxyApp.decorate("encryptor", createMockEncryptor("test-api-key") as never);
+	proxyApp.decorate("arrClientFactory", { rawRequest: vi.fn() } as never);
+	proxyApp.decorate("config", { APP_URL: "http://localhost:3000" } as never);
+	setupAuthInjection(proxyApp);
+	registerTestErrorHandler(proxyApp);
+	await proxyApp.register(registerQuiRoutes);
+	await proxyApp.ready();
+
+	try {
+		return await proxyApp.inject({
+			method: "GET",
+			url: "/qui/webhook-config",
+			remoteAddress: options.remoteAddress,
+			headers: {
+				"x-test-auth": "1",
+				host: "localhost:3001",
+				"x-forwarded-for": options.forwardedFor,
+				"x-forwarded-host": options.forwardedHost,
+			},
+		});
+	} finally {
+		await proxyApp.close();
+	}
+}
+
 describe("GET /qui/instances", () => {
 	it("returns empty array when no QUI instances exist", async () => {
 		const res = await injectAuthenticated("GET", "/qui/instances");
@@ -727,6 +759,51 @@ describe("GET /qui/webhook-config", () => {
 		expect(targetUrl.protocol).toBe("generic:");
 		expect(targetUrl.host).toBe("dashboard.example");
 		expect(targetUrl.searchParams.has("disabletls")).toBe(false);
+	});
+
+	it("ignores a forged forwarded host from a non-loopback client", async () => {
+		const res = await app.inject({
+			method: "GET",
+			url: "/qui/webhook-config",
+			remoteAddress: "192.168.1.10",
+			headers: {
+				"x-test-auth": "1",
+				host: "localhost:3001",
+				"x-forwarded-host": "attacker.example",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.host).toBe("localhost:3000");
+		expect(targetUrl.host).not.toBe("attacker.example");
+		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
+	});
+
+	it("uses the direct socket peer when trustProxy rewrites request.ip", async () => {
+		const res = await injectWebhookConfigWithTrustProxy({
+			remoteAddress: "127.0.0.1",
+			forwardedFor: "192.168.1.10",
+			forwardedHost: "192.168.1.50:3000",
+		});
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.host).toBe("192.168.1.50:3000");
+	});
+
+	it("rejects forged loopback X-Forwarded-For from a remote socket", async () => {
+		const res = await injectWebhookConfigWithTrustProxy({
+			remoteAddress: "192.168.1.10",
+			forwardedFor: "127.0.0.1",
+			forwardedHost: "attacker.example",
+		});
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.host).toBe("localhost:3000");
+		expect(targetUrl.host).not.toBe("attacker.example");
 	});
 });
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -69,6 +69,7 @@ import Fastify, { type FastifyRequest } from "fastify";
 import { InstanceNotFoundError } from "../../lib/errors.js";
 import { hashSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiRoutes } from "../qui.js";
+import { buildQuiNotificationTargetName } from "../qui/webhook-routes.js";
 import {
 	createInjectAuthenticated,
 	createMockEncryptor,
@@ -154,6 +155,7 @@ beforeEach(async () => {
 	app = Fastify();
 	app.decorate("prisma", mockPrisma);
 	app.decorate("encryptor", createMockEncryptor("test-api-key"));
+	app.decorate("installationId", "installation-1");
 	app.decorate("arrClientFactory", { rawRequest: vi.fn() });
 	// Phase 5.1 — webhook-config routes resolve the public base URL via
 	// `app.config.APP_URL`. The real plugin wires this from validated env;
@@ -834,6 +836,12 @@ describe("POST /qui/webhook-config/rotate", () => {
 });
 
 describe("POST /qui/instances/:id/webhook-config/register", () => {
+	it("uses different target ownership names for restored database clones", () => {
+		expect(buildQuiNotificationTargetName("installation-a", "qui-1")).not.toBe(
+			buildQuiNotificationTargetName("installation-b", "qui-1"),
+		);
+	});
+
 	it("rejects with 409 when no secret has been generated yet", async () => {
 		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({ hashedQuiWebhookSecret: null });
 		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
@@ -878,7 +886,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
 		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
-		expect(call.name).toBe("arr-dashboard-qui-1");
+		expect(call.name).toBe("arr-dashboard-installation-1-qui-1");
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");
 		expect(targetUrl.host).toBe("arr-dashboard.test:3000");

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -949,7 +949,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		const ownerId = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
 		expect(targetUrl.searchParams.get("owner")).toBe(ownerId);
 		expect(call.ownerId).toBe(ownerId);
-		expect(call.allowLegacyTargetAdoption).toBe(true);
+		expect(call.legacyTargetAdoption).toBe("callback");
 		expect(call.eventTypes).toEqual(["torrent_added"]);
 		expect(call.enabled).toBe(true);
 	});
@@ -978,7 +978,31 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 
 		expect(res.statusCode).toBe(200);
 		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
-			allowLegacyTargetAdoption: false,
+			legacyTargetAdoption: "secret",
+		});
+	});
+
+	it("denies legacy target migration when the same user has another row for the qUI deployment", async () => {
+		const secret = "a".repeat(32);
+		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([
+			makeQuiInstance({
+				id: "qui-2",
+				baseUrl: "http://QUI.test/",
+			}),
+		]);
+		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
+		mockQuiClient.ensureNotificationTarget.mockResolvedValue({ id: 42 });
+
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
+			legacyTargetAdoption: "never",
 		});
 	});
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -70,6 +70,7 @@ import { InstanceNotFoundError } from "../../lib/errors.js";
 import { hashSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiRoutes } from "../qui.js";
 import {
+	buildQuiDeploymentId,
 	buildQuiNotificationTargetName,
 	buildQuiNotificationTargetOwnerId,
 } from "../qui/webhook-routes.js";
@@ -910,6 +911,9 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
 		expect(targetUrl.searchParams.get("secret")).toBe(secret);
 		expect(targetUrl.searchParams.get("instanceId")).toBe("qui-1");
+		expect(targetUrl.searchParams.get("deploymentId")).toBe(
+			buildQuiDeploymentId("user-1", "http://qui.test"),
+		);
 		const ownerId = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
 		expect(targetUrl.searchParams.get("owner")).toBe(ownerId);
 		expect(call.ownerId).toBe(ownerId);

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -836,9 +836,12 @@ describe("POST /qui/webhook-config/rotate", () => {
 });
 
 describe("POST /qui/instances/:id/webhook-config/register", () => {
-	it("uses different target ownership names for restored database clones", () => {
-		expect(buildQuiNotificationTargetName("installation-a", "qui-1")).not.toBe(
-			buildQuiNotificationTargetName("installation-b", "qui-1"),
+	it("keys target ownership by the local installation and upstream qUI deployment", () => {
+		const first = buildQuiNotificationTargetName("installation-a", "http://qui.test/");
+		expect(first).toBe(buildQuiNotificationTargetName("installation-a", "http://QUI.test"));
+		expect(first).not.toBe(buildQuiNotificationTargetName("installation-b", "http://qui.test"));
+		expect(first).not.toBe(
+			buildQuiNotificationTargetName("installation-a", "http://other-qui.test"),
 		);
 	});
 
@@ -886,7 +889,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
 		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
-		expect(call.name).toBe("arr-dashboard-installation-1-qui-1");
+		expect(call.name).toBe(buildQuiNotificationTargetName("installation-1", "http://qui.test"));
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");
 		expect(targetUrl.host).toBe("arr-dashboard.test:3000");

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -949,7 +949,8 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		const ownerId = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
 		expect(targetUrl.searchParams.get("owner")).toBe(ownerId);
 		expect(call.ownerId).toBe(ownerId);
-		expect(call.legacyTargetAdoption).toBe("callback");
+		expect(call.legacyTargetAdoption).toBe("secret");
+		expect(call.reportLegacyCleanupRequired).toBe(true);
 		expect(call.eventTypes).toEqual(["torrent_added"]);
 		expect(call.enabled).toBe(true);
 	});
@@ -979,6 +980,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
 			legacyTargetAdoption: "secret",
+			reportLegacyCleanupRequired: false,
 		});
 	});
 
@@ -1003,6 +1005,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
 			legacyTargetAdoption: "never",
+			reportLegacyCleanupRequired: false,
 		});
 	});
 
@@ -1027,6 +1030,30 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 			quiTargetId: 42,
 			cleanupPending: true,
 			warning: expect.stringMatching(/cleanup remains pending/i),
+		});
+	});
+
+	it("reports manual cleanup when an ownerless legacy target cannot be verified", async () => {
+		const secret = "a".repeat(32);
+		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
+		mockQuiClient.ensureNotificationTarget.mockResolvedValue({
+			id: 42,
+			legacyCleanupRequired: true,
+		});
+
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload)).toMatchObject({
+			ok: true,
+			quiTargetId: 42,
+			cleanupPending: true,
+			warning: expect.stringMatching(/remove the old arr-dashboard target manually/i),
 		});
 	});
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -1005,7 +1005,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
 			legacyTargetAdoption: "never",
-			reportLegacyCleanupRequired: false,
+			reportLegacyCleanupRequired: true,
 		});
 	});
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -926,6 +926,65 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(JSON.stringify(requestWarnSpy.mock.calls)).toContain("secret=***");
 		expect(JSON.stringify(requestWarnSpy.mock.calls)).not.toContain(secret);
 	});
+
+	it("serializes rotation with an in-flight registration so the newest secret wins", async () => {
+		const oldSecret = "o".repeat(32);
+		let currentHash = hashSecret(oldSecret);
+		mockPrisma.user.findUniqueOrThrow.mockImplementation(async () => ({
+			hashedQuiWebhookSecret: currentHash,
+		}));
+		mockPrisma.user.update.mockImplementation(async ({ data }) => {
+			currentHash = data.hashedQuiWebhookSecret;
+			return {};
+		});
+
+		let releaseOldRegistration!: () => void;
+		const oldRegistrationBlocked = new Promise<void>((resolve) => {
+			releaseOldRegistration = resolve;
+		});
+		let oldRegistrationStarted!: () => void;
+		const oldRegistrationEntered = new Promise<void>((resolve) => {
+			oldRegistrationStarted = resolve;
+		});
+		mockQuiClient.ensureNotificationTarget
+			.mockImplementationOnce(async () => {
+				oldRegistrationStarted();
+				await oldRegistrationBlocked;
+				return { id: 41 };
+			})
+			.mockResolvedValueOnce({ id: 42 });
+
+		const oldRegistration = injectAuthenticated(
+			"POST",
+			"/qui/instances/qui-1/webhook-config/register",
+			{ body: { secret: oldSecret } },
+		);
+		await oldRegistrationEntered;
+
+		const rotation = injectAuthenticated("POST", "/qui/webhook-config/rotate", { body: {} });
+		await Promise.resolve();
+		expect(mockPrisma.user.update).not.toHaveBeenCalled();
+
+		releaseOldRegistration();
+		expect((await oldRegistration).statusCode).toBe(200);
+		const rotationResponse = await rotation;
+		expect(rotationResponse.statusCode).toBe(200);
+		const newSecret = JSON.parse(rotationResponse.payload).secret as string;
+		expect(currentHash).toBe(hashSecret(newSecret));
+
+		const newRegistration = await injectAuthenticated(
+			"POST",
+			"/qui/instances/qui-1/webhook-config/register",
+			{ body: { secret: newSecret } },
+		);
+		expect(newRegistration.statusCode).toBe(200);
+		expect(mockQuiClient.ensureNotificationTarget).toHaveBeenCalledTimes(2);
+
+		const oldTarget = new URL(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0].url);
+		const newTarget = new URL(mockQuiClient.ensureNotificationTarget.mock.calls[1]?.[0].url);
+		expect(oldTarget.searchParams.get("secret")).toBe(oldSecret);
+		expect(newTarget.searchParams.get("secret")).toBe(newSecret);
+	});
 });
 
 // ────────────────────────────────────────────────────────────────────────

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -945,6 +945,30 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(call.enabled).toBe(true);
 	});
 
+	it("reports partial success when stale target cleanup remains pending", async () => {
+		const secret = "a".repeat(32);
+		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
+		mockQuiClient.ensureNotificationTarget.mockResolvedValue({
+			id: 42,
+			cleanupPending: true,
+		});
+
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload)).toMatchObject({
+			ok: true,
+			quiTargetId: 42,
+			cleanupPending: true,
+			warning: expect.stringMatching(/cleanup remains pending/i),
+		});
+	});
+
 	it("rejects a stale plaintext secret that does not match the current stored hash", async () => {
 		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
 			hashedQuiWebhookSecret: hashSecret("current-secret-value"),

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -65,8 +65,9 @@ vi.mock("../../lib/library-sync/episode-file-backfill.js", () => ({
 	runEpisodeBackfillSweep: (...args: unknown[]) => mockRunEpisodeBackfillSweep(...args),
 }));
 
-import Fastify from "fastify";
+import Fastify, { type FastifyRequest } from "fastify";
 import { InstanceNotFoundError } from "../../lib/errors.js";
+import { hashSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiRoutes } from "../qui.js";
 import {
 	createInjectAuthenticated,
@@ -141,6 +142,7 @@ const VALID_HASH = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 let app: ReturnType<typeof Fastify>;
 let mockPrisma: ReturnType<typeof createMockPrisma>;
 let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let requestWarnSpy: ReturnType<typeof vi.fn>;
 
 beforeEach(async () => {
 	vi.clearAllMocks();
@@ -159,6 +161,10 @@ beforeEach(async () => {
 	app.decorate("config", { APP_URL: "http://localhost:3000" });
 
 	setupAuthInjection(app);
+	requestWarnSpy = vi.fn();
+	app.addHook("onRequest", async (request: FastifyRequest) => {
+		request.log.warn = requestWarnSpy as unknown as typeof request.log.warn;
+	});
 	registerTestErrorHandler(app);
 
 	await app.register(registerQuiRoutes);
@@ -648,7 +654,13 @@ describe("GET /qui/webhook-config", () => {
 		expect(res.statusCode).toBe(200);
 		const body = JSON.parse(res.payload);
 		expect(body.hasSecret).toBe(false);
-		expect(body.webhookUrl).toMatch(/\/api\/webhooks\/qui$/);
+		const targetUrl = new URL(body.webhookUrl);
+		expect(targetUrl.protocol).toBe("generic:");
+		expect(targetUrl.host).toBe("localhost:3000");
+		expect(targetUrl.pathname).toBe("/api/webhooks/qui");
+		expect(targetUrl.searchParams.get("template")).toBe("json");
+		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
+		expect(targetUrl.searchParams.has("secret")).toBe(false);
 		// CRITICAL — GET never returns the plaintext secret. The plaintext
 		// only exists at rotation time; persisting/echoing it from the DB
 		// would break the "shown once" invariant the operator relies on.
@@ -663,6 +675,58 @@ describe("GET /qui/webhook-config", () => {
 		const body = JSON.parse(res.payload);
 		expect(body.hasSecret).toBe(true);
 		expect(body).not.toHaveProperty("secret");
+	});
+
+	it("preserves an HTTPS external URL without enabling Shoutrrr's HTTP fallback", async () => {
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "https://dashboard.example/",
+		});
+		const res = await injectAuthenticated("GET", "/qui/webhook-config");
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.protocol).toBe("generic:");
+		expect(targetUrl.host).toBe("dashboard.example");
+		expect(targetUrl.pathname).toBe("/api/webhooks/qui");
+		expect(targetUrl.searchParams.get("template")).toBe("json");
+		expect(targetUrl.searchParams.has("disabletls")).toBe(false);
+	});
+
+	it("uses the browser-facing host preserved by Next's production rewrite", async () => {
+		const res = await app.inject({
+			method: "GET",
+			url: "/qui/webhook-config",
+			headers: {
+				"x-test-auth": "1",
+				host: "localhost:3001",
+				"x-forwarded-host": "192.168.1.50:3000",
+			},
+		});
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.protocol).toBe("generic:");
+		expect(targetUrl.host).toBe("192.168.1.50:3000");
+		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
+	});
+
+	it("preserves the forwarded HTTPS protocol for a TLS-terminating proxy", async () => {
+		const res = await app.inject({
+			method: "GET",
+			url: "/qui/webhook-config",
+			headers: {
+				"x-test-auth": "1",
+				host: "localhost:3001",
+				"x-forwarded-host": "dashboard.example",
+				"x-forwarded-proto": "https",
+			},
+		});
+		expect(res.statusCode).toBe(200);
+
+		const targetUrl = new URL(JSON.parse(res.payload).webhookUrl);
+		expect(targetUrl.protocol).toBe("generic:");
+		expect(targetUrl.host).toBe("dashboard.example");
+		expect(targetUrl.searchParams.has("disabletls")).toBe(false);
 	});
 });
 
@@ -721,42 +785,69 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(mockQuiClient.createNotificationTarget).not.toHaveBeenCalled();
 	});
 
-	it("forwards the registration to qui with URL containing the operator-supplied secret", async () => {
+	it("forwards a Shoutrrr generic JSON URL containing the operator-supplied secret", async () => {
+		const secret = "a".repeat(32);
 		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
-			hashedQuiWebhookSecret: "deadbeef".repeat(8),
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "http://arr-dashboard.test:3000",
 		});
 		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
 		mockQuiClient.createNotificationTarget.mockResolvedValue({ id: "target-42" });
 		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
-			body: { secret: "a".repeat(32), eventTypes: ["torrent_added"] },
+			body: { secret, eventTypes: ["torrent_added"] },
 		});
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: "target-42" });
-		// The URL must end with the secret as a query param so qui's
-		// ApiKeyQuery security scheme picks it up. URL-encoding is applied
-		// at the route layer; the secret is hex-clean here so we just check
-		// the substring.
 		const call = mockQuiClient.createNotificationTarget.mock.calls[0]?.[0];
 		expect(call.name).toBe("arr-dashboard");
-		expect(call.url).toContain("/api/webhooks/qui?secret=");
-		expect(call.url).toContain("a".repeat(32));
+		const targetUrl = new URL(call.url);
+		expect(targetUrl.protocol).toBe("generic:");
+		expect(targetUrl.host).toBe("arr-dashboard.test:3000");
+		expect(targetUrl.pathname).toBe("/api/webhooks/qui");
+		expect(targetUrl.searchParams.get("template")).toBe("json");
+		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
+		expect(targetUrl.searchParams.get("secret")).toBe(secret);
 		expect(call.eventTypes).toEqual(["torrent_added"]);
 		expect(call.enabled).toBe(true);
 	});
 
-	it("returns 502 when qui rejects the registration call", async () => {
+	it("rejects a stale plaintext secret that does not match the current stored hash", async () => {
 		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
-			hashedQuiWebhookSecret: "deadbeef".repeat(8),
+			hashedQuiWebhookSecret: hashSecret("current-secret-value"),
 		});
 		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
-		mockQuiClient.createNotificationTarget.mockRejectedValue(new Error("qui refused: 409"));
 		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
-			body: { secret: "a".repeat(32) },
+			body: { secret: "stale-secret-value" },
+		});
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).error).toMatch(/stale/i);
+		expect(mockQuiClient.createNotificationTarget).not.toHaveBeenCalled();
+	});
+
+	it("returns 502 when qui rejects the registration call", async () => {
+		const secret = "a".repeat(32);
+		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
+		mockQuiClient.createNotificationTarget.mockImplementation(({ url }: { url: string }) =>
+			Promise.reject(new Error(`qui refused target ${url}: 409`)),
+		);
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret },
 		});
 		// 502 (bad gateway) rather than 500 — the upstream is the failure
 		// site, not arr-dashboard itself. Frontend renders the qui-side
 		// error message verbatim so the operator can fix the qui config.
 		expect(res.statusCode).toBe(502);
+		const body = JSON.parse(res.payload);
+		expect(body.message).toContain("secret=***");
+		expect(JSON.stringify(body)).not.toContain(secret);
+		expect(JSON.stringify(requestWarnSpy.mock.calls)).toContain("secret=***");
+		expect(JSON.stringify(requestWarnSpy.mock.calls)).not.toContain(secret);
 	});
 });
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -949,8 +949,37 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		const ownerId = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
 		expect(targetUrl.searchParams.get("owner")).toBe(ownerId);
 		expect(call.ownerId).toBe(ownerId);
+		expect(call.allowLegacyTargetAdoption).toBe(true);
 		expect(call.eventTypes).toEqual(["torrent_added"]);
 		expect(call.enabled).toBe(true);
+	});
+
+	it("does not callback-migrate legacy targets when another local row shares the qUI deployment", async () => {
+		const secret = "a".repeat(32);
+		mockPrisma.user.findUniqueOrThrow.mockResolvedValue({
+			hashedQuiWebhookSecret: hashSecret(secret),
+		});
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "http://arr-dashboard.test:3000",
+		});
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([
+			makeQuiInstance({
+				id: "qui-2",
+				userId: "user-2",
+				baseUrl: "http://QUI.test/",
+			}),
+		]);
+		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
+		mockQuiClient.ensureNotificationTarget.mockResolvedValue({ id: 42 });
+
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0]).toMatchObject({
+			allowLegacyTargetAdoption: false,
+		});
 	});
 
 	it("reports partial success when stale target cleanup remains pending", async () => {

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -160,6 +160,7 @@ beforeEach(async () => {
 	app.decorate("prisma", mockPrisma);
 	app.decorate("encryptor", createMockEncryptor("test-api-key"));
 	app.decorate("installationId", "installation-1");
+	app.decorate("installationIdIsPersistent", true);
 	app.decorate("arrClientFactory", { rawRequest: vi.fn() });
 	// Phase 5.1 — webhook-config routes resolve the public base URL via
 	// `app.config.APP_URL`. The real plugin wires this from validated env;
@@ -866,6 +867,18 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		// with the request preconditions. The frontend uses this to prompt
 		// "Rotate first" instead of failing silently.
 		expect(res.statusCode).toBe(409);
+		expect(mockQuiClient.ensureNotificationTarget).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when the installation identity is not persistent", async () => {
+		app.installationIdIsPersistent = false;
+		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
+			body: { secret: "x".repeat(32) },
+		});
+
+		expect(res.statusCode).toBe(503);
+		expect(JSON.parse(res.payload).error).toMatch(/persistent installation identity/i);
+		expect(mockRequireQuiInstance).not.toHaveBeenCalled();
 		expect(mockQuiClient.ensureNotificationTarget).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -69,7 +69,10 @@ import Fastify, { type FastifyRequest } from "fastify";
 import { InstanceNotFoundError } from "../../lib/errors.js";
 import { hashSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiRoutes } from "../qui.js";
-import { buildQuiNotificationTargetName } from "../qui/webhook-routes.js";
+import {
+	buildQuiNotificationTargetName,
+	buildQuiNotificationTargetOwnerId,
+} from "../qui/webhook-routes.js";
 import {
 	createInjectAuthenticated,
 	createMockEncryptor,
@@ -906,6 +909,10 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(targetUrl.searchParams.get("template")).toBe("json");
 		expect(targetUrl.searchParams.get("disabletls")).toBe("yes");
 		expect(targetUrl.searchParams.get("secret")).toBe(secret);
+		expect(targetUrl.searchParams.get("instanceId")).toBe("qui-1");
+		const ownerId = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
+		expect(targetUrl.searchParams.get("owner")).toBe(ownerId);
+		expect(call.ownerId).toBe(ownerId);
 		expect(call.eventTypes).toEqual(["torrent_added"]);
 		expect(call.enabled).toBe(true);
 	});

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -878,7 +878,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
 		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
-		expect(call.name).toBe("arr-dashboard");
+		expect(call.name).toBe("arr-dashboard-qui-1");
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");
 		expect(targetUrl.host).toBe("arr-dashboard.test:3000");

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -36,7 +36,7 @@ const mockQuiClient = vi.hoisted(() => ({
 	addTrackers: vi.fn(),
 	removeTrackers: vi.fn(),
 	editTracker: vi.fn(),
-	createNotificationTarget: vi.fn(),
+	ensureNotificationTarget: vi.fn(),
 	triggerDirScan: vi.fn(),
 }));
 
@@ -844,7 +844,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		// with the request preconditions. The frontend uses this to prompt
 		// "Rotate first" instead of failing silently.
 		expect(res.statusCode).toBe(409);
-		expect(mockQuiClient.createNotificationTarget).not.toHaveBeenCalled();
+		expect(mockQuiClient.ensureNotificationTarget).not.toHaveBeenCalled();
 	});
 
 	it("rejects with 400 when the inline secret is missing or too short", async () => {
@@ -859,7 +859,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		// rejecting at registration prevents the operator from wiring up an
 		// unguessable-yet-truncated value that the receiver would refuse anyway.
 		expect(res.statusCode).toBe(400);
-		expect(mockQuiClient.createNotificationTarget).not.toHaveBeenCalled();
+		expect(mockQuiClient.ensureNotificationTarget).not.toHaveBeenCalled();
 	});
 
 	it("forwards a Shoutrrr generic JSON URL containing the operator-supplied secret", async () => {
@@ -871,13 +871,13 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 			externalUrl: "http://arr-dashboard.test:3000",
 		});
 		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
-		mockQuiClient.createNotificationTarget.mockResolvedValue({ id: "target-42" });
+		mockQuiClient.ensureNotificationTarget.mockResolvedValue({ id: 42 });
 		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {
 			body: { secret, eventTypes: ["torrent_added"] },
 		});
 		expect(res.statusCode).toBe(200);
-		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: "target-42" });
-		const call = mockQuiClient.createNotificationTarget.mock.calls[0]?.[0];
+		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
+		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
 		expect(call.name).toBe("arr-dashboard");
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");
@@ -901,7 +901,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 
 		expect(res.statusCode).toBe(409);
 		expect(JSON.parse(res.payload).error).toMatch(/stale/i);
-		expect(mockQuiClient.createNotificationTarget).not.toHaveBeenCalled();
+		expect(mockQuiClient.ensureNotificationTarget).not.toHaveBeenCalled();
 	});
 
 	it("returns 502 when qui rejects the registration call", async () => {
@@ -910,7 +910,7 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 			hashedQuiWebhookSecret: hashSecret(secret),
 		});
 		mockRequireQuiInstance.mockResolvedValue(makeQuiInstance());
-		mockQuiClient.createNotificationTarget.mockImplementation(({ url }: { url: string }) =>
+		mockQuiClient.ensureNotificationTarget.mockImplementation(({ url }: { url: string }) =>
 			Promise.reject(new Error(`qui refused target ${url}: 409`)),
 		);
 		const res = await injectAuthenticated("POST", "/qui/instances/qui-1/webhook-config/register", {

--- a/apps/api/src/routes/__tests__/qui-routes.test.ts
+++ b/apps/api/src/routes/__tests__/qui-routes.test.ts
@@ -837,11 +837,18 @@ describe("POST /qui/webhook-config/rotate", () => {
 
 describe("POST /qui/instances/:id/webhook-config/register", () => {
 	it("keys target ownership by the local installation and upstream qUI deployment", () => {
-		const first = buildQuiNotificationTargetName("installation-a", "http://qui.test/");
-		expect(first).toBe(buildQuiNotificationTargetName("installation-a", "http://QUI.test"));
-		expect(first).not.toBe(buildQuiNotificationTargetName("installation-b", "http://qui.test"));
+		const first = buildQuiNotificationTargetName("installation-a", "user-1", "http://qui.test/");
+		expect(first).toBe(
+			buildQuiNotificationTargetName("installation-a", "user-1", "http://QUI.test"),
+		);
 		expect(first).not.toBe(
-			buildQuiNotificationTargetName("installation-a", "http://other-qui.test"),
+			buildQuiNotificationTargetName("installation-b", "user-1", "http://qui.test"),
+		);
+		expect(first).not.toBe(
+			buildQuiNotificationTargetName("installation-a", "user-2", "http://qui.test"),
+		);
+		expect(first).not.toBe(
+			buildQuiNotificationTargetName("installation-a", "user-1", "http://other-qui.test"),
 		);
 	});
 
@@ -889,7 +896,9 @@ describe("POST /qui/instances/:id/webhook-config/register", () => {
 		expect(res.statusCode).toBe(200);
 		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, quiTargetId: 42 });
 		const call = mockQuiClient.ensureNotificationTarget.mock.calls[0]?.[0];
-		expect(call.name).toBe(buildQuiNotificationTargetName("installation-1", "http://qui.test"));
+		expect(call.name).toBe(
+			buildQuiNotificationTargetName("installation-1", "user-1", "http://qui.test"),
+		);
 		const targetUrl = new URL(call.url);
 		expect(targetUrl.protocol).toBe("generic:");
 		expect(targetUrl.host).toBe("arr-dashboard.test:3000");

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -120,6 +120,48 @@ describe("POST /webhooks/qui", () => {
 		expect(seen).toHaveLength(1);
 	});
 
+	it("normalizes qUI's Shoutrrr JSON notification body", async () => {
+		const seen: unknown[] = [];
+		quiEventBus.subscribe("user-1", (msg) => seen.push(msg));
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}`,
+			payload: {
+				title: "Torrent added",
+				message: "Instance: qbit-main\nTorrent: Example.Release [aaaaaaaa]\nState: downloading",
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
+		expect(createArgs.data.eventType).toBe("torrent_added");
+		expect(createArgs.data.torrentHash).toBeNull();
+		expect(JSON.parse(createArgs.data.payload)).toEqual({
+			type: "torrent_added",
+			payload: {
+				title: "Torrent added",
+				message: "Instance: qbit-main\nTorrent: Example.Release [aaaaaaaa]\nState: downloading",
+			},
+		});
+		expect(seen).toHaveLength(1);
+	});
+
+	it("keeps unknown qUI notification titles instead of rejecting new event definitions", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}`,
+			payload: {
+				title: "Future qUI event",
+				message: "Instance: qbit-main\nDetail: something changed",
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
+		expect(createArgs.data.eventType).toBe("notification");
+		expect(JSON.parse(createArgs.data.payload).payload.title).toBe("Future qUI event");
+	});
+
 	it("extracts hash from infoHash, torrent.hash, and torrents[0].hash shapes", async () => {
 		const variants = [
 			{ infoHash: "b".repeat(40) },

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -148,6 +148,34 @@ describe("POST /webhooks/qui", () => {
 		expect(createArgs.data.serviceInstanceId).toBe("qui-1");
 	});
 
+	it("preserves the event when its correlated qUI instance is deleted during persistence", async () => {
+		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
+		const owner = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
+		mockPrisma.quiEventLog.create
+			.mockRejectedValueOnce(
+				Object.assign(new Error("Foreign key constraint failed"), { code: "P2003" }),
+			)
+			.mockResolvedValueOnce({
+				id: "evt-row-1",
+				receivedAt: new Date("2026-05-14T10:00:00Z"),
+			});
+
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}&owner=${owner}`,
+			payload: {
+				type: "torrent_added",
+				payload: { hash: "a".repeat(40) },
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(JSON.parse(res.payload)).toMatchObject({ ok: true, eventId: "evt-row-1" });
+		expect(mockPrisma.quiEventLog.create).toHaveBeenCalledTimes(2);
+		expect(mockPrisma.quiEventLog.create.mock.calls[0]?.[0].data.serviceInstanceId).toBe("qui-1");
+		expect(mockPrisma.quiEventLog.create.mock.calls[1]?.[0].data.serviceInstanceId).toBeNull();
+	});
+
 	it("rejects source attribution with a different installation owner", async () => {
 		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
 		const otherOwner = buildQuiNotificationTargetOwnerId("other-installation", "user-1", "qui-1");

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -17,6 +17,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { quiEventBus } from "../../lib/qui/event-bus.js";
 import { generateQuiWebhookSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiWebhookRoutes } from "../qui-webhook.js";
+import { buildQuiDeploymentId } from "../qui/webhook-routes.js";
 import { registerTestErrorHandler } from "./test-helpers.js";
 
 function createMockPrisma(userRow: unknown) {
@@ -25,7 +26,7 @@ function createMockPrisma(userRow: unknown) {
 			findUnique: vi.fn().mockResolvedValue(userRow),
 		},
 		serviceInstance: {
-			findFirst: vi.fn().mockResolvedValue({ id: "qui-1" }),
+			findFirst: vi.fn().mockResolvedValue({ id: "qui-1", baseUrl: "http://qui.test" }),
 		},
 		quiEventLog: {
 			create: vi.fn().mockResolvedValue({
@@ -125,9 +126,10 @@ describe("POST /webhooks/qui", () => {
 	});
 
 	it("authenticates and persists the registered qUI source instance", async () => {
+		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
 		const res = await app.inject({
 			method: "POST",
-			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1`,
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}`,
 			payload: {
 				type: "torrent_added",
 				payload: { hash: "a".repeat(40) },
@@ -137,7 +139,7 @@ describe("POST /webhooks/qui", () => {
 		expect(res.statusCode).toBe(200);
 		expect(mockPrisma.serviceInstance.findFirst).toHaveBeenCalledWith({
 			where: { id: "qui-1", userId: "user-1", service: "QUI" },
-			select: { id: true },
+			select: { id: true, baseUrl: true },
 		});
 		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
 		expect(createArgs.data.serviceInstanceId).toBe("qui-1");
@@ -148,7 +150,21 @@ describe("POST /webhooks/qui", () => {
 
 		const res = await app.inject({
 			method: "POST",
-			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=other-instance`,
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=other-instance&deploymentId=${"a".repeat(24)}`,
+			payload: { type: "torrent_added", payload: {} },
+		});
+
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.payload)).toEqual({ error: "Invalid webhook source" });
+		expect(mockPrisma.quiEventLog.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects attribution from a target bound to the instance's previous deployment", async () => {
+		const previousDeploymentId = buildQuiDeploymentId("user-1", "http://previous-qui.test");
+
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${previousDeploymentId}`,
 			payload: { type: "torrent_added", payload: {} },
 		});
 

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -17,7 +17,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { quiEventBus } from "../../lib/qui/event-bus.js";
 import { generateQuiWebhookSecret } from "../../lib/qui/webhook-secret.js";
 import { registerQuiWebhookRoutes } from "../qui-webhook.js";
-import { buildQuiDeploymentId } from "../qui/webhook-routes.js";
+import { buildQuiDeploymentId, buildQuiNotificationTargetOwnerId } from "../qui/webhook-routes.js";
 import { registerTestErrorHandler } from "./test-helpers.js";
 
 function createMockPrisma(userRow: unknown) {
@@ -56,6 +56,8 @@ beforeEach(async () => {
 
 	app = Fastify();
 	app.decorate("prisma", mockPrisma as never);
+	app.decorate("installationId", "installation-1");
+	app.decorate("installationIdIsPersistent", true);
 	registerTestErrorHandler(app);
 	await app.register(registerQuiWebhookRoutes);
 	await app.ready();
@@ -127,9 +129,10 @@ describe("POST /webhooks/qui", () => {
 
 	it("authenticates and persists the registered qUI source instance", async () => {
 		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
+		const owner = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
 		const res = await app.inject({
 			method: "POST",
-			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}`,
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}&owner=${owner}`,
 			payload: {
 				type: "torrent_added",
 				payload: { hash: "a".repeat(40) },
@@ -143,6 +146,37 @@ describe("POST /webhooks/qui", () => {
 		});
 		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
 		expect(createArgs.data.serviceInstanceId).toBe("qui-1");
+	});
+
+	it("rejects source attribution with a different installation owner", async () => {
+		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
+		const otherOwner = buildQuiNotificationTargetOwnerId("other-installation", "user-1", "qui-1");
+
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}&owner=${otherOwner}`,
+			payload: { type: "torrent_added", payload: {} },
+		});
+
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.payload)).toEqual({ error: "Invalid webhook source" });
+		expect(mockPrisma.quiEventLog.create).not.toHaveBeenCalled();
+	});
+
+	it("rejects source attribution without a persistent installation identity", async () => {
+		app.installationIdIsPersistent = false;
+		const deploymentId = buildQuiDeploymentId("user-1", "http://qui.test");
+		const owner = buildQuiNotificationTargetOwnerId("installation-1", "user-1", "qui-1");
+
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1&deploymentId=${deploymentId}&owner=${owner}`,
+			payload: { type: "torrent_added", payload: {} },
+		});
+
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.payload)).toEqual({ error: "Invalid webhook source" });
+		expect(mockPrisma.quiEventLog.create).not.toHaveBeenCalled();
 	});
 
 	it("rejects a source instance that is not a qUI instance owned by the secret's user", async () => {

--- a/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
+++ b/apps/api/src/routes/__tests__/qui-webhook-route.test.ts
@@ -24,6 +24,9 @@ function createMockPrisma(userRow: unknown) {
 		user: {
 			findUnique: vi.fn().mockResolvedValue(userRow),
 		},
+		serviceInstance: {
+			findFirst: vi.fn().mockResolvedValue({ id: "qui-1" }),
+		},
 		quiEventLog: {
 			create: vi.fn().mockResolvedValue({
 				id: "evt-row-1",
@@ -111,6 +114,7 @@ describe("POST /webhooks/qui", () => {
 		expect(mockPrisma.quiEventLog.create).toHaveBeenCalledOnce();
 		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
 		expect(createArgs.data.userId).toBe("user-1");
+		expect(createArgs.data.serviceInstanceId).toBeNull();
 		expect(createArgs.data.eventType).toBe("torrent_added");
 		// Hash extraction must pull the per-torrent hash out of the
 		// payload — otherwise the My Events tab can't deep-link to the
@@ -118,6 +122,39 @@ describe("POST /webhooks/qui", () => {
 		expect(createArgs.data.torrentHash).toBe("a".repeat(40));
 		// Bus publish hits exactly one subscriber for this user.
 		expect(seen).toHaveLength(1);
+	});
+
+	it("authenticates and persists the registered qUI source instance", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=qui-1`,
+			payload: {
+				type: "torrent_added",
+				payload: { hash: "a".repeat(40) },
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockPrisma.serviceInstance.findFirst).toHaveBeenCalledWith({
+			where: { id: "qui-1", userId: "user-1", service: "QUI" },
+			select: { id: true },
+		});
+		const createArgs = mockPrisma.quiEventLog.create.mock.calls[0]?.[0];
+		expect(createArgs.data.serviceInstanceId).toBe("qui-1");
+	});
+
+	it("rejects a source instance that is not a qUI instance owned by the secret's user", async () => {
+		mockPrisma.serviceInstance.findFirst.mockResolvedValueOnce(null);
+
+		const res = await app.inject({
+			method: "POST",
+			url: `/webhooks/qui?secret=${secret.plaintextSecret}&instanceId=other-instance`,
+			payload: { type: "torrent_added", payload: {} },
+		});
+
+		expect(res.statusCode).toBe(401);
+		expect(JSON.parse(res.payload)).toEqual({ error: "Invalid webhook source" });
+		expect(mockPrisma.quiEventLog.create).not.toHaveBeenCalled();
 	});
 
 	it("normalizes qUI's Shoutrrr JSON notification body", async () => {

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -30,7 +30,7 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		// Use app.config.DATABASE_URL (includes env schema defaults) not process.env
 		const databaseUrl = app.config.DATABASE_URL || "file:./dev.db";
 		const secretsPath = resolveSecretsPath(databaseUrl);
-		return new BackupService(app.prisma, secretsPath, app.encryptor);
+		return new BackupService(app.prisma, secretsPath, app.encryptor, app.secretsSynchronized);
 	};
 
 	/**

--- a/apps/api/src/routes/qui-webhook.ts
+++ b/apps/api/src/routes/qui-webhook.ts
@@ -60,7 +60,7 @@ const QUI_NOTIFICATION_EVENT_TYPES: Readonly<Record<string, string>> = {
 };
 
 const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
-	app.post<{ Querystring: { secret?: string } }>(
+	app.post<{ Querystring: { secret?: string; instanceId?: string } }>(
 		"/webhooks/qui",
 		{
 			// Conservative bounds for an inbound notification body. qui's
@@ -82,6 +82,17 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 				return reply.status(401).send({ error: "Invalid or missing secret" });
 			}
 
+			const instanceId = request.query?.instanceId;
+			const sourceInstance = instanceId
+				? await app.prisma.serviceInstance.findFirst({
+						where: { id: instanceId, userId: user.id, service: "QUI" },
+						select: { id: true },
+					})
+				: null;
+			if (instanceId && !sourceInstance) {
+				return reply.status(401).send({ error: "Invalid webhook source" });
+			}
+
 			const envelope = normalizeQuiWebhookBody(request.body);
 			if (!envelope) {
 				return reply.status(400).send({ error: "Malformed event envelope" });
@@ -97,6 +108,7 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 				const row = await app.prisma.quiEventLog.create({
 					data: {
 						userId: user.id,
+						serviceInstanceId: sourceInstance?.id ?? null,
 						eventType: envelope.type,
 						torrentHash,
 						payload: JSON.stringify(envelope),

--- a/apps/api/src/routes/qui-webhook.ts
+++ b/apps/api/src/routes/qui-webhook.ts
@@ -24,7 +24,7 @@ import { logQuiActivity } from "../lib/qui/activity-log.js";
 import { quiEventBus } from "../lib/qui/event-bus.js";
 import { resolveUserFromQuiSecret } from "../lib/qui/webhook-secret.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
-import { buildQuiDeploymentId } from "./qui/webhook-routes.js";
+import { buildQuiDeploymentId, buildQuiNotificationTargetOwnerId } from "./qui/webhook-routes.js";
 
 const quiShoutrrrNotificationSchema = z
 	.object({
@@ -62,7 +62,12 @@ const QUI_NOTIFICATION_EVENT_TYPES: Readonly<Record<string, string>> = {
 
 const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 	app.post<{
-		Querystring: { secret?: string; instanceId?: string; deploymentId?: string };
+		Querystring: {
+			secret?: string;
+			instanceId?: string;
+			deploymentId?: string;
+			owner?: string;
+		};
 	}>(
 		"/webhooks/qui",
 		{
@@ -87,6 +92,7 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 
 			const instanceId = request.query?.instanceId;
 			const deploymentId = request.query?.deploymentId;
+			const owner = request.query?.owner;
 			const sourceInstance = instanceId
 				? await app.prisma.serviceInstance.findFirst({
 						where: { id: instanceId, userId: user.id, service: "QUI" },
@@ -94,10 +100,13 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 					})
 				: null;
 			const hasValidSource =
+				app.installationIdIsPersistent &&
 				sourceInstance &&
 				deploymentId &&
-				buildQuiDeploymentId(user.id, sourceInstance.baseUrl) === deploymentId;
-			if ((instanceId || deploymentId) && !hasValidSource) {
+				owner &&
+				buildQuiDeploymentId(user.id, sourceInstance.baseUrl) === deploymentId &&
+				buildQuiNotificationTargetOwnerId(app.installationId, user.id, sourceInstance.id) === owner;
+			if ((instanceId || deploymentId || owner) && !hasValidSource) {
 				return reply.status(401).send({ error: "Invalid webhook source" });
 			}
 

--- a/apps/api/src/routes/qui-webhook.ts
+++ b/apps/api/src/routes/qui-webhook.ts
@@ -24,6 +24,7 @@ import { logQuiActivity } from "../lib/qui/activity-log.js";
 import { quiEventBus } from "../lib/qui/event-bus.js";
 import { resolveUserFromQuiSecret } from "../lib/qui/webhook-secret.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
+import { buildQuiDeploymentId } from "./qui/webhook-routes.js";
 
 const quiShoutrrrNotificationSchema = z
 	.object({
@@ -60,7 +61,9 @@ const QUI_NOTIFICATION_EVENT_TYPES: Readonly<Record<string, string>> = {
 };
 
 const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
-	app.post<{ Querystring: { secret?: string; instanceId?: string } }>(
+	app.post<{
+		Querystring: { secret?: string; instanceId?: string; deploymentId?: string };
+	}>(
 		"/webhooks/qui",
 		{
 			// Conservative bounds for an inbound notification body. qui's
@@ -83,13 +86,18 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 			}
 
 			const instanceId = request.query?.instanceId;
+			const deploymentId = request.query?.deploymentId;
 			const sourceInstance = instanceId
 				? await app.prisma.serviceInstance.findFirst({
 						where: { id: instanceId, userId: user.id, service: "QUI" },
-						select: { id: true },
+						select: { id: true, baseUrl: true },
 					})
 				: null;
-			if (instanceId && !sourceInstance) {
+			const hasValidSource =
+				sourceInstance &&
+				deploymentId &&
+				buildQuiDeploymentId(user.id, sourceInstance.baseUrl) === deploymentId;
+			if ((instanceId || deploymentId) && !hasValidSource) {
 				return reply.status(401).send({ error: "Invalid webhook source" });
 			}
 

--- a/apps/api/src/routes/qui-webhook.ts
+++ b/apps/api/src/routes/qui-webhook.ts
@@ -60,6 +60,14 @@ const QUI_NOTIFICATION_EVENT_TYPES: Readonly<Record<string, string>> = {
 	"Automations run failed": "automations_run_failed",
 };
 
+function isForeignKeyConstraintError(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		"code" in error &&
+		(error as Error & { code?: unknown }).code === "P2003"
+	);
+}
+
 const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 	app.post<{
 		Querystring: {
@@ -122,15 +130,32 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 			const torrentHash = extractTorrentHash(envelope.payload);
 
 			try {
-				const row = await app.prisma.quiEventLog.create({
-					data: {
-						userId: user.id,
-						serviceInstanceId: sourceInstance?.id ?? null,
-						eventType: envelope.type,
-						torrentHash,
-						payload: JSON.stringify(envelope),
-					},
-				});
+				const eventData = {
+					userId: user.id,
+					serviceInstanceId: sourceInstance?.id ?? null,
+					eventType: envelope.type,
+					torrentHash,
+					payload: JSON.stringify(envelope),
+				};
+				const row = await (async () => {
+					try {
+						return await app.prisma.quiEventLog.create({ data: eventData });
+					} catch (err) {
+						if (!sourceInstance || !isForeignKeyConstraintError(err)) {
+							throw err;
+						}
+						// The source row can disappear after attribution but before
+						// this insert. Correlation is best-effort, so preserve the
+						// authenticated event without the now-stale foreign key.
+						request.log.warn(
+							{ instanceId: sourceInstance.id },
+							"qUI source instance disappeared during webhook persistence; retrying uncorrelated",
+						);
+						return await app.prisma.quiEventLog.create({
+							data: { ...eventData, serviceInstanceId: null },
+						});
+					}
+				})();
 				// Phase 5.2 — fan the event out to any open SSE connections for
 				// this user. Failures here are non-fatal: the event is already
 				// persisted; SSE is just a freshness optimization. Pass

--- a/apps/api/src/routes/qui-webhook.ts
+++ b/apps/api/src/routes/qui-webhook.ts
@@ -2,11 +2,10 @@
  * Public qui webhook receiver (Phase 5.1).
  *
  * Registered at `/api/webhooks/qui` (no auth prefix — public route).
- * qui POSTs here when an event matching the user's NotificationTarget
- * fires. We authenticate via a per-user `?secret=` query param (matches
- * qui's `ApiKeyQuery` scheme; qui doesn't send a body HMAC) and log the
- * event verbatim into `QuiEventLog` for the My Events surface + SSE
- * fan-out in Phase 5.2.
+ * qui POSTs here through its Shoutrrr generic notification target when a
+ * configured event fires. We authenticate via a per-user `?secret=` query
+ * param and normalize Shoutrrr's `{ title, message }` body into our event
+ * envelope for the My Events surface + SSE fan-out in Phase 5.2.
  *
  * Failure posture:
  *   - Missing/invalid secret → 401, no log row (someone is probing).
@@ -20,10 +19,45 @@
 
 import { quiWebhookEnvelopeSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
+import { z } from "zod";
 import { logQuiActivity } from "../lib/qui/activity-log.js";
 import { quiEventBus } from "../lib/qui/event-bus.js";
 import { resolveUserFromQuiSecret } from "../lib/qui/webhook-secret.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
+
+const quiShoutrrrNotificationSchema = z
+	.object({
+		title: z.string().min(1),
+		message: z.string(),
+	})
+	.passthrough();
+
+/**
+ * qUI v1.23 notification titles are human-readable while its target API stores
+ * machine event keys. Preserve the keys operators see in qUI's event selector.
+ * Unknown/custom titles still land as `notification` instead of being rejected,
+ * which keeps the receiver forward-compatible with new qUI event definitions.
+ */
+const QUI_NOTIFICATION_EVENT_TYPES: Readonly<Record<string, string>> = {
+	"Torrent added": "torrent_added",
+	"Torrent completed": "torrent_completed",
+	"Backup completed": "backup_succeeded",
+	"Backup failed": "backup_failed",
+	"Directory scan completed": "dir_scan_completed",
+	"Directory scan failed": "dir_scan_failed",
+	"Orphan scan completed": "orphan_scan_completed",
+	"Orphan scan failed": "orphan_scan_failed",
+	"Cross-seed RSS automation completed": "cross_seed_automation_succeeded",
+	"Cross-seed RSS automation failed": "cross_seed_automation_failed",
+	"Cross-seed seeded search completed": "cross_seed_search_succeeded",
+	"Cross-seed seeded search failed": "cross_seed_search_failed",
+	"Cross-seed completion search completed": "cross_seed_completion_succeeded",
+	"Cross-seed completion search failed": "cross_seed_completion_failed",
+	"Cross-seed webhook check completed": "cross_seed_webhook_succeeded",
+	"Cross-seed webhook check failed": "cross_seed_webhook_failed",
+	"Automations actions applied": "automations_actions_applied",
+	"Automations run failed": "automations_run_failed",
+};
 
 const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 	app.post<{ Querystring: { secret?: string } }>(
@@ -48,15 +82,10 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 				return reply.status(401).send({ error: "Invalid or missing secret" });
 			}
 
-			// Validate the envelope shape but don't reject on unknown keys — qui
-			// extends NotificationEvent without our schema needing a bump. The
-			// envelope schema uses `z.unknown()` for `payload` so anything
-			// well-formed at the outer layer is accepted.
-			const parsed = quiWebhookEnvelopeSchema.safeParse(request.body);
-			if (!parsed.success) {
+			const envelope = normalizeQuiWebhookBody(request.body);
+			if (!envelope) {
 				return reply.status(400).send({ error: "Malformed event envelope" });
 			}
-			const envelope = parsed.data;
 
 			// Extract a torrent hash if the payload looks like a per-torrent event.
 			// Multiple shapes are tolerated because qui's event payloads aren't
@@ -123,6 +152,30 @@ const quiWebhookRoute: FastifyPluginCallback = (app, _opts, done) => {
 	);
 	done();
 };
+
+function normalizeQuiWebhookBody(
+	body: unknown,
+): { type: string; payload?: unknown; timestamp?: string } | null {
+	// Retain compatibility with the original/raw envelope contract in case an
+	// upstream integration already posts it directly.
+	const envelope = quiWebhookEnvelopeSchema.safeParse(body);
+	if (envelope.success) {
+		return envelope.data;
+	}
+
+	// qUI's notification service formats events for Shoutrrr and the generic
+	// JSON template delivers this exact shape. Keep the original body as the
+	// payload so My Events shows what qUI actually sent.
+	const notification = quiShoutrrrNotificationSchema.safeParse(body);
+	if (!notification.success) {
+		return null;
+	}
+	const { title, message } = notification.data;
+	return {
+		type: QUI_NOTIFICATION_EVENT_TYPES[title.trim()] ?? "notification",
+		payload: { title, message },
+	};
+}
 
 function extractTorrentHash(payload: unknown): string | null {
 	if (!payload || typeof payload !== "object") return null;

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -234,7 +234,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 				try {
 					const created = await client.ensureNotificationTarget({
-						name: "arr-dashboard",
+						name: `arr-dashboard-${instance.id}`,
 						url: targetUrl,
 						eventTypes: body.eventTypes,
 						enabled: true,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -10,6 +10,19 @@ import { validateRequest } from "../../lib/utils/validate.js";
 import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 
 export function registerWebhookRoutes(app: FastifyInstance): void {
+	function isLoopbackAddress(value: string): boolean {
+		const normalized = value
+			.trim()
+			.toLowerCase()
+			.replace(/^\[|\]$/g, "");
+		return (
+			normalized === "localhost" ||
+			normalized === "::1" ||
+			/^127(?:\.\d{1,3}){3}$/.test(normalized) ||
+			/^::ffff:127(?:\.\d{1,3}){3}$/.test(normalized)
+		);
+	}
+
 	// ────────────────────────────────────────────────────────────────────
 	// Phase 5.1 — webhook config (GET + rotate + register-in-qui)
 	// ────────────────────────────────────────────────────────────────────
@@ -33,22 +46,23 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 		const appUrl = app.config.APP_URL.replace(/\/$/, "");
 		const appHost = new URL(appUrl).hostname;
-		const appUrlIsLoopback = ["localhost", "127.0.0.1", "::1"].includes(appHost);
+		const appUrlIsLoopback = isLoopbackAddress(appHost);
 		if (!appUrlIsLoopback) {
 			return appUrl;
 		}
 
 		// Next's production rewrite changes Host to the internal API address,
 		// but always preserves the browser-facing Host in X-Forwarded-Host.
-		// Read that one header explicitly for callback URL discovery even when
-		// Fastify's global trustProxy setting is false. These routes require an
-		// authenticated user, and the submitted secret is verified against the
-		// current user's stored hash before the discovered URL is registered.
+		// Read that header explicitly only when the direct peer is loopback,
+		// which is the trusted in-container Next -> API hop. A remote client
+		// must not be able to forge this header and redirect qUI notifications
+		// (including their callback credential) to an attacker-controlled host.
 		const forwardedHostHeader = request.headers["x-forwarded-host"];
 		const forwardedHost = Array.isArray(forwardedHostHeader)
 			? forwardedHostHeader[0]
 			: forwardedHostHeader?.split(",")[0]?.trim();
-		if (forwardedHost) {
+		const directPeerIsLoopback = isLoopbackAddress(request.raw.socket.remoteAddress ?? "");
+		if (forwardedHost && directPeerIsLoopback) {
 			const forwardedProtoHeader = request.headers["x-forwarded-proto"];
 			const forwardedProtoValue = Array.isArray(forwardedProtoHeader)
 				? forwardedProtoHeader[0]
@@ -60,7 +74,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			try {
 				const forwardedOrigin = new URL(`${forwardedProto}://${forwardedHost}`).origin;
 				const forwardedHostname = new URL(forwardedOrigin).hostname;
-				if (!["localhost", "127.0.0.1", "::1"].includes(forwardedHostname)) {
+				if (!isLoopbackAddress(forwardedHostname)) {
 					return forwardedOrigin;
 				}
 			} catch {
@@ -69,10 +83,17 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			}
 		}
 
+		// With trustProxy enabled, request.host/protocol can also be derived
+		// from forwarded headers. Do not fall through to those values for a
+		// non-local peer after rejecting its forwarded host.
+		if (!directPeerIsLoopback) {
+			return appUrl;
+		}
+
 		// Direct development requests do not pass through Next's rewrite.
 		const requestOrigin = `${request.protocol}://${request.host}`;
 		const requestHost = new URL(requestOrigin).hostname;
-		return ["localhost", "127.0.0.1", "::1"].includes(requestHost) ? appUrl : requestOrigin;
+		return isLoopbackAddress(requestHost) ? appUrl : requestOrigin;
 	}
 
 	/**

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -305,7 +305,8 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 					deploymentPeers.some((otherInstance) => otherInstance.userId === userId)
 						? "never"
 						: "secret";
-				const reportLegacyCleanupRequired = !normalizationUncertain && deploymentPeers.length === 0;
+				const reportLegacyCleanupRequired =
+					legacyTargetAdoption === "never" || deploymentPeers.length === 0;
 				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
 					instanceId: instance.id,
 					deploymentId,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -293,7 +293,17 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 						eventTypes: body.eventTypes,
 						enabled: true,
 					});
-					return reply.send({ ok: true, quiTargetId: created.id });
+					return reply.send({
+						ok: true,
+						quiTargetId: created.id,
+						...(created.cleanupPending
+							? {
+									cleanupPending: true,
+									warning:
+										"Target registered, but stale duplicate cleanup remains pending. Retry registration to reconcile it.",
+								}
+							: {}),
+					});
 				} catch (err) {
 					// qUI/Shoutrrr errors can echo the rejected target URL. Sanitize
 					// before both logging and returning so the one-time plaintext

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -281,6 +281,23 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 				// rotate response and forwards it here.
 				const ownerId = buildQuiNotificationTargetOwnerId(app.installationId, userId, instance.id);
 				const deploymentId = buildQuiDeploymentId(userId, instance.baseUrl);
+				const deploymentKey = buildQuiDeploymentId("", instance.baseUrl);
+				const otherQuiInstances = await app.prisma.serviceInstance.findMany({
+					where: {
+						service: "QUI",
+						id: { not: instance.id },
+					},
+					select: { baseUrl: true },
+				});
+				const allowLegacyTargetAdoption = !otherQuiInstances.some((otherInstance) => {
+					try {
+						return buildQuiDeploymentId("", otherInstance.baseUrl) === deploymentKey;
+					} catch {
+						// Fail closed if legacy data prevents us from proving
+						// that the other qUI row belongs to a different server.
+						return true;
+					}
+				});
 				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
 					instanceId: instance.id,
 					deploymentId,
@@ -297,6 +314,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 						),
 						url: targetUrl,
 						ownerId,
+						allowLegacyTargetAdoption,
 						eventTypes: body.eventTypes,
 						enabled: true,
 					});

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -241,6 +241,12 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			const { id } = validateRequest(QUI_INSTANCE_PARAM, request.params);
 			const body = validateRequest(REGISTER_BODY, request.body ?? {});
 			return withWebhookConfigLock(userId, async () => {
+				if (!app.installationIdIsPersistent) {
+					return reply.status(503).send({
+						error:
+							"qUI registration requires a writable secrets path with a persistent installation identity.",
+					});
+				}
 				const instance = await requireQuiInstance(app, userId, id);
 				const client = createQuiClient(app, instance);
 

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -210,15 +210,16 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 	app.post("/qui/webhook-config/rotate", async (request, reply) => {
 		const userId = request.currentUser!.id;
 		return withWebhookConfigLock(userId, async () => {
+			const baseUrl = await resolvePublicBaseUrl(request);
+			const webhookUrl = buildQuiNotificationTargetUrl(baseUrl);
 			const { plaintextSecret, hashedSecret } = generateQuiWebhookSecret();
 			await app.prisma.user.update({
 				where: { id: userId },
 				data: { hashedQuiWebhookSecret: hashedSecret },
 			});
-			const baseUrl = await resolvePublicBaseUrl(request);
 			return reply.send({
 				hasSecret: true,
-				webhookUrl: buildQuiNotificationTargetUrl(baseUrl),
+				webhookUrl,
 				// Plaintext returned only here — never stored, never re-displayed.
 				// Operators copy it into qui's notification-target URL once.
 				secret: plaintextSecret,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { createQuiClient } from "../../lib/qui/client-factory.js";
@@ -9,11 +10,16 @@ import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 
-export function buildQuiNotificationTargetName(
-	installationId: string,
-	serviceInstanceId: string,
-): string {
-	return `arr-dashboard-${installationId}-${serviceInstanceId}`;
+export function buildQuiNotificationTargetName(installationId: string, quiBaseUrl: string): string {
+	const deploymentUrl = new URL(quiBaseUrl);
+	deploymentUrl.hash = "";
+	deploymentUrl.search = "";
+	deploymentUrl.pathname = deploymentUrl.pathname.replace(/\/+$/, "");
+	const deploymentId = createHash("sha256")
+		.update(deploymentUrl.toString())
+		.digest("hex")
+		.slice(0, 24);
+	return `arr-dashboard-${installationId}-${deploymentId}`;
 }
 
 export function registerWebhookRoutes(app: FastifyInstance): void {
@@ -241,7 +247,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 				try {
 					const created = await client.ensureNotificationTarget({
-						name: buildQuiNotificationTargetName(app.installationId, instance.id),
+						name: buildQuiNotificationTargetName(app.installationId, instance.baseUrl),
 						url: targetUrl,
 						eventTypes: body.eventTypes,
 						enabled: true,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -15,15 +15,18 @@ export function buildQuiNotificationTargetName(
 	userId: string,
 	quiBaseUrl: string,
 ): string {
+	return `arr-dashboard-${installationId}-${buildQuiDeploymentId(userId, quiBaseUrl)}`;
+}
+
+export function buildQuiDeploymentId(userId: string, quiBaseUrl: string): string {
 	const deploymentUrl = new URL(quiBaseUrl);
 	deploymentUrl.hash = "";
 	deploymentUrl.search = "";
 	deploymentUrl.pathname = deploymentUrl.pathname.replace(/\/+$/, "");
-	const deploymentId = createHash("sha256")
+	return createHash("sha256")
 		.update(`${userId}\0${deploymentUrl.toString()}`)
 		.digest("hex")
 		.slice(0, 24);
-	return `arr-dashboard-${installationId}-${deploymentId}`;
 }
 
 export function buildQuiNotificationTargetOwnerId(
@@ -161,7 +164,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 	function buildQuiNotificationTargetUrl(
 		baseUrl: string,
 		secret?: string,
-		source?: { instanceId: string; ownerId: string },
+		source?: { instanceId: string; deploymentId: string; ownerId: string },
 	): string {
 		const callback = new URL(`${baseUrl}/api/webhooks/qui`);
 		const usesPlainHttp = callback.protocol === "http:";
@@ -181,6 +184,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 		}
 		if (source) {
 			target.searchParams.set("instanceId", source.instanceId);
+			target.searchParams.set("deploymentId", source.deploymentId);
 			target.searchParams.set("owner", source.ownerId);
 		}
 		return target.toString();
@@ -267,8 +271,10 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 				// don't have it on the server. The frontend captures it from the
 				// rotate response and forwards it here.
 				const ownerId = buildQuiNotificationTargetOwnerId(app.installationId, userId, instance.id);
+				const deploymentId = buildQuiDeploymentId(userId, instance.baseUrl);
 				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
 					instanceId: instance.id,
+					deploymentId,
 					ownerId,
 				});
 

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -26,6 +26,17 @@ export function buildQuiNotificationTargetName(
 	return `arr-dashboard-${installationId}-${deploymentId}`;
 }
 
+export function buildQuiNotificationTargetOwnerId(
+	installationId: string,
+	userId: string,
+	serviceInstanceId: string,
+): string {
+	return createHash("sha256")
+		.update(`${installationId}\0${userId}\0${serviceInstanceId}`)
+		.digest("hex")
+		.slice(0, 24);
+}
+
 export function registerWebhookRoutes(app: FastifyInstance): void {
 	// The dashboard runs as one Node process, so a per-user in-memory queue
 	// is sufficient to make secret rotation and qUI target registration one
@@ -147,7 +158,11 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 	 * Unknown query keys are forwarded by Shoutrrr, so `secret` reaches
 	 * arr-dashboard without being treated as generic-service configuration.
 	 */
-	function buildQuiNotificationTargetUrl(baseUrl: string, secret?: string): string {
+	function buildQuiNotificationTargetUrl(
+		baseUrl: string,
+		secret?: string,
+		source?: { instanceId: string; ownerId: string },
+	): string {
 		const callback = new URL(`${baseUrl}/api/webhooks/qui`);
 		const usesPlainHttp = callback.protocol === "http:";
 		if (!usesPlainHttp && callback.protocol !== "https:") {
@@ -163,6 +178,10 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 		}
 		if (secret) {
 			target.searchParams.set("secret", secret);
+		}
+		if (source) {
+			target.searchParams.set("instanceId", source.instanceId);
+			target.searchParams.set("owner", source.ownerId);
 		}
 		return target.toString();
 	}
@@ -247,12 +266,17 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 				// The plaintext is supplied per-request in the validated body; we
 				// don't have it on the server. The frontend captures it from the
 				// rotate response and forwards it here.
-				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret);
+				const ownerId = buildQuiNotificationTargetOwnerId(app.installationId, userId, instance.id);
+				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
+					instanceId: instance.id,
+					ownerId,
+				});
 
 				try {
 					const created = await client.ensureNotificationTarget({
 						name: buildQuiNotificationTargetName(app.installationId, userId, instance.baseUrl),
 						url: targetUrl,
+						ownerId,
 						eventTypes: body.eventTypes,
 						enabled: true,
 					});

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -304,9 +304,8 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 					normalizationUncertain ||
 					deploymentPeers.some((otherInstance) => otherInstance.userId === userId)
 						? "never"
-						: deploymentPeers.length > 0
-							? "secret"
-							: "callback";
+						: "secret";
+				const reportLegacyCleanupRequired = !normalizationUncertain && deploymentPeers.length === 0;
 				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
 					instanceId: instance.id,
 					deploymentId,
@@ -324,17 +323,19 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 						url: targetUrl,
 						ownerId,
 						legacyTargetAdoption,
+						reportLegacyCleanupRequired,
 						eventTypes: body.eventTypes,
 						enabled: true,
 					});
 					return reply.send({
 						ok: true,
 						quiTargetId: created.id,
-						...(created.cleanupPending
+						...(created.cleanupPending || created.legacyCleanupRequired
 							? {
 									cleanupPending: true,
-									warning:
-										"Target registered, but stale duplicate cleanup remains pending. Retry registration to reconcile it.",
+									warning: created.legacyCleanupRequired
+										? "Target registered, but an ownerless legacy target could not be verified safely. Remove the old arr-dashboard target manually in qUI."
+										: "Target registered, but stale duplicate cleanup remains pending. Retry registration to reconcile it.",
 								}
 							: {}),
 					});

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -287,17 +287,26 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 						service: "QUI",
 						id: { not: instance.id },
 					},
-					select: { baseUrl: true },
+					select: { baseUrl: true, userId: true },
 				});
-				const allowLegacyTargetAdoption = !otherQuiInstances.some((otherInstance) => {
+				let normalizationUncertain = false;
+				const deploymentPeers = otherQuiInstances.filter((otherInstance) => {
 					try {
 						return buildQuiDeploymentId("", otherInstance.baseUrl) === deploymentKey;
 					} catch {
 						// Fail closed if legacy data prevents us from proving
 						// that the other qUI row belongs to a different server.
-						return true;
+						normalizationUncertain = true;
+						return false;
 					}
 				});
+				const legacyTargetAdoption =
+					normalizationUncertain ||
+					deploymentPeers.some((otherInstance) => otherInstance.userId === userId)
+						? "never"
+						: deploymentPeers.length > 0
+							? "secret"
+							: "callback";
 				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret, {
 					instanceId: instance.id,
 					deploymentId,
@@ -314,7 +323,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 						),
 						url: targetUrl,
 						ownerId,
-						allowLegacyTargetAdoption,
+						legacyTargetAdoption,
 						eventTypes: body.eventTypes,
 						enabled: true,
 					});

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -13,9 +13,11 @@ import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 export function buildQuiNotificationTargetName(
 	installationId: string,
 	userId: string,
+	serviceInstanceId: string,
 	quiBaseUrl: string,
 ): string {
-	return `arr-dashboard-${installationId}-${buildQuiDeploymentId(userId, quiBaseUrl)}`;
+	const ownerId = buildQuiNotificationTargetOwnerId(installationId, userId, serviceInstanceId);
+	return `arr-dashboard-${ownerId}-${buildQuiDeploymentId(userId, quiBaseUrl)}`;
 }
 
 export function buildQuiDeploymentId(userId: string, quiBaseUrl: string): string {
@@ -287,7 +289,12 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 				try {
 					const created = await client.ensureNotificationTarget({
-						name: buildQuiNotificationTargetName(app.installationId, userId, instance.baseUrl),
+						name: buildQuiNotificationTargetName(
+							app.installationId,
+							userId,
+							instance.id,
+							instance.baseUrl,
+						),
 						url: targetUrl,
 						ownerId,
 						eventTypes: body.eventTypes,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -9,6 +9,13 @@ import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 
+export function buildQuiNotificationTargetName(
+	installationId: string,
+	serviceInstanceId: string,
+): string {
+	return `arr-dashboard-${installationId}-${serviceInstanceId}`;
+}
+
 export function registerWebhookRoutes(app: FastifyInstance): void {
 	// The dashboard runs as one Node process, so a per-user in-memory queue
 	// is sufficient to make secret rotation and qUI target registration one
@@ -234,7 +241,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 				try {
 					const created = await client.ensureNotificationTarget({
-						name: `arr-dashboard-${instance.id}`,
+						name: buildQuiNotificationTargetName(app.installationId, instance.id),
 						url: targetUrl,
 						eventTypes: body.eventTypes,
 						enabled: true,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -203,7 +203,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret);
 
 			try {
-				const created = await client.createNotificationTarget({
+				const created = await client.ensureNotificationTarget({
 					name: "arr-dashboard",
 					url: targetUrl,
 					eventTypes: body.eventTypes,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -10,13 +10,17 @@ import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 
-export function buildQuiNotificationTargetName(installationId: string, quiBaseUrl: string): string {
+export function buildQuiNotificationTargetName(
+	installationId: string,
+	userId: string,
+	quiBaseUrl: string,
+): string {
 	const deploymentUrl = new URL(quiBaseUrl);
 	deploymentUrl.hash = "";
 	deploymentUrl.search = "";
 	deploymentUrl.pathname = deploymentUrl.pathname.replace(/\/+$/, "");
 	const deploymentId = createHash("sha256")
-		.update(deploymentUrl.toString())
+		.update(`${userId}\0${deploymentUrl.toString()}`)
 		.digest("hex")
 		.slice(0, 24);
 	return `arr-dashboard-${installationId}-${deploymentId}`;
@@ -247,7 +251,7 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 				try {
 					const created = await client.ensureNotificationTarget({
-						name: buildQuiNotificationTargetName(app.installationId, instance.baseUrl),
+						name: buildQuiNotificationTargetName(app.installationId, userId, instance.baseUrl),
 						url: targetUrl,
 						eventTypes: body.eventTypes,
 						enabled: true,

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -10,6 +10,31 @@ import { validateRequest } from "../../lib/utils/validate.js";
 import { QUI_INSTANCE_PARAM, safeParseJson } from "./qui-shared.js";
 
 export function registerWebhookRoutes(app: FastifyInstance): void {
+	// The dashboard runs as one Node process, so a per-user in-memory queue
+	// is sufficient to make secret rotation and qUI target registration one
+	// critical section. Without this, an older registration can pass its
+	// hash check, pause on qUI I/O, then overwrite a newer rotated secret.
+	const webhookConfigTails = new Map<string, Promise<void>>();
+	async function withWebhookConfigLock<T>(userId: string, operation: () => Promise<T>): Promise<T> {
+		const previous = webhookConfigTails.get(userId) ?? Promise.resolve();
+		let release!: () => void;
+		const current = new Promise<void>((resolve) => {
+			release = resolve;
+		});
+		const tail = previous.catch(() => undefined).then(() => current);
+		webhookConfigTails.set(userId, tail);
+
+		await previous.catch(() => undefined);
+		try {
+			return await operation();
+		} finally {
+			release();
+			if (webhookConfigTails.get(userId) === tail) {
+				webhookConfigTails.delete(userId);
+			}
+		}
+	}
+
 	function isLoopbackAddress(value: string): boolean {
 		const normalized = value
 			.trim()
@@ -144,18 +169,20 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 
 	app.post("/qui/webhook-config/rotate", async (request, reply) => {
 		const userId = request.currentUser!.id;
-		const { plaintextSecret, hashedSecret } = generateQuiWebhookSecret();
-		await app.prisma.user.update({
-			where: { id: userId },
-			data: { hashedQuiWebhookSecret: hashedSecret },
-		});
-		const baseUrl = await resolvePublicBaseUrl(request);
-		return reply.send({
-			hasSecret: true,
-			webhookUrl: buildQuiNotificationTargetUrl(baseUrl),
-			// Plaintext returned only here — never stored, never re-displayed.
-			// Operators copy it into qui's notification-target URL once.
-			secret: plaintextSecret,
+		return withWebhookConfigLock(userId, async () => {
+			const { plaintextSecret, hashedSecret } = generateQuiWebhookSecret();
+			await app.prisma.user.update({
+				where: { id: userId },
+				data: { hashedQuiWebhookSecret: hashedSecret },
+			});
+			const baseUrl = await resolvePublicBaseUrl(request);
+			return reply.send({
+				hasSecret: true,
+				webhookUrl: buildQuiNotificationTargetUrl(baseUrl),
+				// Plaintext returned only here — never stored, never re-displayed.
+				// Operators copy it into qui's notification-target URL once.
+				secret: plaintextSecret,
+			});
 		});
 	});
 
@@ -173,58 +200,62 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			const userId = request.currentUser!.id;
 			const { id } = validateRequest(QUI_INSTANCE_PARAM, request.params);
 			const body = validateRequest(REGISTER_BODY, request.body ?? {});
-			const instance = await requireQuiInstance(app, userId, id);
-			const client = createQuiClient(app, instance);
+			return withWebhookConfigLock(userId, async () => {
+				const instance = await requireQuiInstance(app, userId, id);
+				const client = createQuiClient(app, instance);
 
-			// Operator must rotate the secret first — we don't auto-create
-			// a secret as a side effect of registration, because that would
-			// silently reset any existing wired-up qui targets that depend
-			// on the prior secret.
-			const user = await app.prisma.user.findUniqueOrThrow({
-				where: { id: userId },
-				select: { hashedQuiWebhookSecret: true },
+				// Operator must rotate the secret first — we don't auto-create
+				// a secret as a side effect of registration, because that would
+				// silently reset any existing wired-up qui targets that depend
+				// on the prior secret. This check intentionally happens inside
+				// the rotate/register critical section so a stale request cannot
+				// pass validation and later overwrite the current target.
+				const user = await app.prisma.user.findUniqueOrThrow({
+					where: { id: userId },
+					select: { hashedQuiWebhookSecret: true },
+				});
+				if (!user.hashedQuiWebhookSecret) {
+					return reply.status(409).send({
+						error: "No webhook secret configured. Rotate to generate one first.",
+					});
+				}
+				if (hashSecret(body.secret) !== user.hashedQuiWebhookSecret) {
+					return reply.status(409).send({
+						error:
+							"This webhook secret is stale. Rotate the secret again before registering the target.",
+					});
+				}
+
+				const baseUrl = await resolvePublicBaseUrl(request);
+				// The plaintext is supplied per-request in the validated body; we
+				// don't have it on the server. The frontend captures it from the
+				// rotate response and forwards it here.
+				const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret);
+
+				try {
+					const created = await client.ensureNotificationTarget({
+						name: "arr-dashboard",
+						url: targetUrl,
+						eventTypes: body.eventTypes,
+						enabled: true,
+					});
+					return reply.send({ ok: true, quiTargetId: created.id });
+				} catch (err) {
+					// qUI/Shoutrrr errors can echo the rejected target URL. Sanitize
+					// before both logging and returning so the one-time plaintext
+					// secret never lands in server logs or client-side telemetry.
+					const rawMessage = getErrorMessage(err, "qui registration failed");
+					const safeMessage = rawMessage.replace(/secret=[^&\s"']+/g, "secret=***");
+					request.log.warn(
+						{ error: safeMessage, instanceId: instance.id },
+						"Failed to register webhook target in qui",
+					);
+					return reply.status(502).send({
+						error: "qui rejected the notification target registration",
+						message: safeMessage,
+					});
+				}
 			});
-			if (!user.hashedQuiWebhookSecret) {
-				return reply.status(409).send({
-					error: "No webhook secret configured. Rotate to generate one first.",
-				});
-			}
-			if (hashSecret(body.secret) !== user.hashedQuiWebhookSecret) {
-				return reply.status(409).send({
-					error:
-						"This webhook secret is stale. Rotate the secret again before registering the target.",
-				});
-			}
-
-			const baseUrl = await resolvePublicBaseUrl(request);
-			// The plaintext is supplied per-request in the validated body; we
-			// don't have it on the server. The frontend captures it from the
-			// rotate response and forwards it here.
-			const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret);
-
-			try {
-				const created = await client.ensureNotificationTarget({
-					name: "arr-dashboard",
-					url: targetUrl,
-					eventTypes: body.eventTypes,
-					enabled: true,
-				});
-				return reply.send({ ok: true, quiTargetId: created.id });
-			} catch (err) {
-				// qUI/Shoutrrr errors can echo the rejected target URL. Sanitize
-				// before both logging and returning so the one-time plaintext
-				// secret never lands in server logs or client-side telemetry.
-				const rawMessage = getErrorMessage(err, "qui registration failed");
-				const safeMessage = rawMessage.replace(/secret=[^&\s"']+/g, "secret=***");
-				request.log.warn(
-					{ error: safeMessage, instanceId: instance.id },
-					"Failed to register webhook target in qui",
-				);
-				return reply.status(502).send({
-					error: "qui rejected the notification target registration",
-					message: safeMessage,
-				});
-			}
 		},
 	);
 

--- a/apps/api/src/routes/qui/webhook-routes.ts
+++ b/apps/api/src/routes/qui/webhook-routes.ts
@@ -1,9 +1,9 @@
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { createQuiClient } from "../../lib/qui/client-factory.js";
 import { quiEventBus } from "../../lib/qui/event-bus.js";
 import { requireQuiInstance } from "../../lib/qui/instance-helpers.js";
-import { generateQuiWebhookSecret } from "../../lib/qui/webhook-secret.js";
+import { generateQuiWebhookSecret, hashSecret } from "../../lib/qui/webhook-secret.js";
 import { createSseHandler } from "../../lib/sse/sse-handler.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -25,9 +25,83 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 	 *      typically set when the dashboard sits behind a reverse proxy.
 	 *   2. `app.config.APP_URL` — validated env var (default localhost:3000).
 	 */
-	async function resolvePublicBaseUrl(): Promise<string> {
+	async function resolvePublicBaseUrl(request: FastifyRequest): Promise<string> {
 		const settings = await app.prisma.systemSettings.findUnique({ where: { id: 1 } });
-		return settings?.externalUrl?.replace(/\/$/, "") ?? app.config.APP_URL;
+		if (settings?.externalUrl) {
+			return settings.externalUrl.replace(/\/$/, "");
+		}
+
+		const appUrl = app.config.APP_URL.replace(/\/$/, "");
+		const appHost = new URL(appUrl).hostname;
+		const appUrlIsLoopback = ["localhost", "127.0.0.1", "::1"].includes(appHost);
+		if (!appUrlIsLoopback) {
+			return appUrl;
+		}
+
+		// Next's production rewrite changes Host to the internal API address,
+		// but always preserves the browser-facing Host in X-Forwarded-Host.
+		// Read that one header explicitly for callback URL discovery even when
+		// Fastify's global trustProxy setting is false. These routes require an
+		// authenticated user, and the submitted secret is verified against the
+		// current user's stored hash before the discovered URL is registered.
+		const forwardedHostHeader = request.headers["x-forwarded-host"];
+		const forwardedHost = Array.isArray(forwardedHostHeader)
+			? forwardedHostHeader[0]
+			: forwardedHostHeader?.split(",")[0]?.trim();
+		if (forwardedHost) {
+			const forwardedProtoHeader = request.headers["x-forwarded-proto"];
+			const forwardedProtoValue = Array.isArray(forwardedProtoHeader)
+				? forwardedProtoHeader[0]
+				: forwardedProtoHeader?.split(",")[0]?.trim();
+			const forwardedProto =
+				forwardedProtoValue === "http" || forwardedProtoValue === "https"
+					? forwardedProtoValue
+					: request.protocol;
+			try {
+				const forwardedOrigin = new URL(`${forwardedProto}://${forwardedHost}`).origin;
+				const forwardedHostname = new URL(forwardedOrigin).hostname;
+				if (!["localhost", "127.0.0.1", "::1"].includes(forwardedHostname)) {
+					return forwardedOrigin;
+				}
+			} catch {
+				// Ignore malformed proxy metadata and continue to the direct
+				// request origin / configured APP_URL fallbacks below.
+			}
+		}
+
+		// Direct development requests do not pass through Next's rewrite.
+		const requestOrigin = `${request.protocol}://${request.host}`;
+		const requestHost = new URL(requestOrigin).hostname;
+		return ["localhost", "127.0.0.1", "::1"].includes(requestHost) ? appUrl : requestOrigin;
+	}
+
+	/**
+	 * qui notification targets are Shoutrrr service URLs, not ordinary HTTP
+	 * callback URLs. Its generic service converts `generic://` back to HTTPS
+	 * (or HTTP when `disabletls=yes`) and `template=json` makes the delivered
+	 * body `{ title, message }`, which our public receiver understands.
+	 *
+	 * Unknown query keys are forwarded by Shoutrrr, so `secret` reaches
+	 * arr-dashboard without being treated as generic-service configuration.
+	 */
+	function buildQuiNotificationTargetUrl(baseUrl: string, secret?: string): string {
+		const callback = new URL(`${baseUrl}/api/webhooks/qui`);
+		const usesPlainHttp = callback.protocol === "http:";
+		if (!usesPlainHttp && callback.protocol !== "https:") {
+			throw new TypeError("qui webhook callback must use http or https");
+		}
+		// WHATWG URL objects ignore an assignment that crosses from a special
+		// scheme (`http`) to a non-special one (`generic`). Build a new URL
+		// from the serialized callback instead of mutating `.protocol`.
+		const target = new URL(callback.toString().replace(/^https?:/, "generic:"));
+		target.searchParams.set("template", "json");
+		if (usesPlainHttp) {
+			target.searchParams.set("disabletls", "yes");
+		}
+		if (secret) {
+			target.searchParams.set("secret", secret);
+		}
+		return target.toString();
 	}
 
 	app.get("/qui/webhook-config", async (request, reply) => {
@@ -36,14 +110,14 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			where: { id: userId },
 			select: { hashedQuiWebhookSecret: true },
 		});
-		const baseUrl = await resolvePublicBaseUrl();
+		const baseUrl = await resolvePublicBaseUrl(request);
 		return reply.send({
 			hasSecret: Boolean(user.hashedQuiWebhookSecret),
 			// Public URL the operator pastes into qui's notification target.
 			// The query-param placeholder is intentional — the actual secret
 			// is only returned at rotation time; the operator copies the URL
 			// + secret together on the rotate response.
-			webhookUrl: `${baseUrl}/api/webhooks/qui`,
+			webhookUrl: buildQuiNotificationTargetUrl(baseUrl),
 		});
 	});
 
@@ -54,10 +128,10 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 			where: { id: userId },
 			data: { hashedQuiWebhookSecret: hashedSecret },
 		});
-		const baseUrl = await resolvePublicBaseUrl();
+		const baseUrl = await resolvePublicBaseUrl(request);
 		return reply.send({
 			hasSecret: true,
-			webhookUrl: `${baseUrl}/api/webhooks/qui`,
+			webhookUrl: buildQuiNotificationTargetUrl(baseUrl),
 			// Plaintext returned only here — never stored, never re-displayed.
 			// Operators copy it into qui's notification-target URL once.
 			secret: plaintextSecret,
@@ -94,12 +168,18 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 					error: "No webhook secret configured. Rotate to generate one first.",
 				});
 			}
+			if (hashSecret(body.secret) !== user.hashedQuiWebhookSecret) {
+				return reply.status(409).send({
+					error:
+						"This webhook secret is stale. Rotate the secret again before registering the target.",
+				});
+			}
 
-			const baseUrl = await resolvePublicBaseUrl();
+			const baseUrl = await resolvePublicBaseUrl(request);
 			// The plaintext is supplied per-request in the validated body; we
 			// don't have it on the server. The frontend captures it from the
 			// rotate response and forwards it here.
-			const targetUrl = `${baseUrl}/api/webhooks/qui?secret=${encodeURIComponent(body.secret)}`;
+			const targetUrl = buildQuiNotificationTargetUrl(baseUrl, body.secret);
 
 			try {
 				const created = await client.createNotificationTarget({
@@ -110,16 +190,15 @@ export function registerWebhookRoutes(app: FastifyInstance): void {
 				});
 				return reply.send({ ok: true, quiTargetId: created.id });
 			} catch (err) {
-				request.log.warn(
-					{ err, instanceId: instance.id },
-					"Failed to register webhook target in qui",
-				);
-				// If qui's error message echoes the URL we sent (e.g., a
-				// "couldn't reach <url>" 500), it would leak the plaintext
-				// secret back through the response and into any client-side
-				// logging. Strip `secret=...` defensively before relaying.
+				// qUI/Shoutrrr errors can echo the rejected target URL. Sanitize
+				// before both logging and returning so the one-time plaintext
+				// secret never lands in server logs or client-side telemetry.
 				const rawMessage = getErrorMessage(err, "qui registration failed");
 				const safeMessage = rawMessage.replace(/secret=[^&\s"']+/g, "secret=***");
+				request.log.warn(
+					{ error: safeMessage, instanceId: instance.id },
+					"Failed to register webhook target in qui",
+				);
 				return reply.status(502).send({
 					error: "qui rejected the notification target registration",
 					message: safeMessage,

--- a/apps/api/src/types/fastify.d.ts
+++ b/apps/api/src/types/fastify.d.ts
@@ -20,6 +20,7 @@ declare module "fastify" {
 		encryptor: Encryptor;
 		sessionService: SessionService;
 		installationId: string;
+		installationIdIsPersistent: boolean;
 		secretsSynchronized: boolean;
 		arrClientFactory: ArrClientFactory;
 		deploymentExecutor: DeploymentExecutorService;

--- a/apps/api/src/types/fastify.d.ts
+++ b/apps/api/src/types/fastify.d.ts
@@ -20,6 +20,7 @@ declare module "fastify" {
 		encryptor: Encryptor;
 		sessionService: SessionService;
 		installationId: string;
+		secretsSynchronized: boolean;
 		arrClientFactory: ArrClientFactory;
 		deploymentExecutor: DeploymentExecutorService;
 		secureCookie: boolean;

--- a/apps/api/src/types/fastify.d.ts
+++ b/apps/api/src/types/fastify.d.ts
@@ -19,6 +19,7 @@ declare module "fastify" {
 		dbProvider: "sqlite" | "postgresql";
 		encryptor: Encryptor;
 		sessionService: SessionService;
+		installationId: string;
 		arrClientFactory: ArrClientFactory;
 		deploymentExecutor: DeploymentExecutorService;
 		secureCookie: boolean;

--- a/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
@@ -255,7 +255,11 @@ const AutoRegisterSection = ({
 	const register = useRegisterQuiWebhook();
 	const [selectedInstanceId, setSelectedInstanceId] = useState<string | null>(null);
 	const [resultByInstance, setResultByInstance] = useState<
-		Record<string, { ok: true; targetId?: number } | { ok: false; error: string }>
+		Record<
+			string,
+			| { ok: true; targetId?: number; cleanupPending?: boolean; warning?: string }
+			| { ok: false; error: string }
+		>
 	>({});
 
 	const canRegister = Boolean(plaintextSecret && selectedInstanceId && !register.isPending);
@@ -284,7 +288,12 @@ const AutoRegisterSection = ({
 			});
 			setResultByInstance((prev) => ({
 				...prev,
-				[selectedInstanceId]: { ok: true, targetId: res.quiTargetId },
+				[selectedInstanceId]: {
+					ok: true,
+					targetId: res.quiTargetId,
+					cleanupPending: res.cleanupPending,
+					warning: res.warning,
+				},
 			}));
 		} catch (err) {
 			setResultByInstance((prev) => ({
@@ -350,7 +359,12 @@ const AutoRegisterSection = ({
 							</div>
 							<span className="text-xs">
 								{result ? (
-									result.ok ? (
+									result.ok && result.cleanupPending ? (
+										<span className="text-amber-300 break-words text-left">
+											<AlertCircle className="h-3 w-3 inline mr-1" />
+											{result.warning ?? "Registered; duplicate cleanup remains pending."}
+										</span>
+									) : result.ok ? (
 										<span className="text-emerald-400">
 											<Check className="h-3 w-3 inline mr-1" />
 											{/* qui returns the new target's numeric id; surface it

--- a/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
+++ b/apps/web/src/features/qui-activity/components/webhook-config-panel.tsx
@@ -82,7 +82,9 @@ export const QuiWebhookConfigPanel = () => {
 	};
 
 	const baseUrl = config.data?.webhookUrl ?? "";
-	const fullUrl = plaintextSecret ? `${baseUrl}?secret=${plaintextSecret}` : "";
+	const fullUrl = plaintextSecret
+		? `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}secret=${encodeURIComponent(plaintextSecret)}`
+		: "";
 
 	return (
 		<GlassmorphicCard>
@@ -92,9 +94,13 @@ export const QuiWebhookConfigPanel = () => {
 					<div className="flex-1 space-y-0.5">
 						<h3 className="text-sm font-semibold">qui webhook</h3>
 						<p className="text-xs text-muted-foreground">
-							Register arr-dashboard as a NotificationTarget in qui so torrent state changes push
-							here in real time instead of waiting for the 10-minute scheduled sync. Events flow
-							through SSE to live-invalidate the dashboard.
+							Register arr-dashboard as a NotificationTarget in qui so supported events, including
+							torrent added and completed, push here in real time. The 10-minute sync remains the
+							fallback for other state changes.
+						</p>
+						<p className="text-xs text-muted-foreground">
+							The callback host comes from Settings → System → External URL (or <code>APP_URL</code>
+							) and must be reachable from the qui container.
 						</p>
 					</div>
 				</div>
@@ -102,7 +108,7 @@ export const QuiWebhookConfigPanel = () => {
 				<div className="space-y-2">
 					<div className="space-y-1">
 						<label htmlFor="qui-webhook-url" className="text-xs font-medium text-muted-foreground">
-							Webhook URL (paste into qui → Settings → Notifications → Targets)
+							Shoutrrr target URL (paste into qui → Settings → Notifications → Targets)
 						</label>
 						<div className="flex gap-1">
 							<input
@@ -128,7 +134,7 @@ export const QuiWebhookConfigPanel = () => {
 							htmlFor="qui-webhook-secret"
 							className="text-xs font-medium text-muted-foreground"
 						>
-							Query-param secret (append as <code>?secret=…</code> on the URL above)
+							Query-param secret (append as <code>&amp;secret=…</code> on the URL above)
 						</label>
 						<div className="flex gap-1">
 							<input
@@ -177,7 +183,11 @@ export const QuiWebhookConfigPanel = () => {
 								<input
 									id="qui-webhook-full-url"
 									readOnly
-									value={isIncognito ? `${baseUrl}?secret=${SECRET_MASK}` : fullUrl}
+									value={
+										isIncognito
+											? `${baseUrl}${baseUrl.includes("?") ? "&" : "?"}secret=${SECRET_MASK}`
+											: fullUrl
+									}
 									className="flex-1 rounded-md border border-input bg-background px-3 py-1.5 text-xs font-mono"
 								/>
 								<button
@@ -196,9 +206,9 @@ export const QuiWebhookConfigPanel = () => {
 
 				<div className="flex justify-between items-center pt-1">
 					<p className="text-xs text-muted-foreground">
-						qui → Settings → Notifications → Targets → URL + Method POST. arr-dashboard
-						authenticates the inbound webhook via the <code>?secret=</code> param (qui’s
-						<code> ApiKeyQuery </code>scheme).
+						qui → Settings → Notifications → Targets → URL. The generic Shoutrrr target sends JSON
+						and forwards the <code>secret=</code> query param for arr-dashboard to authenticate the
+						request.
 					</p>
 					<Button
 						type="button"

--- a/apps/web/src/lib/api-client/qui.ts
+++ b/apps/web/src/lib/api-client/qui.ts
@@ -341,16 +341,26 @@ export async function registerQuiWebhook({
 	quiInstanceId,
 	secret,
 	eventTypes,
-}: RegisterQuiWebhookArgs): Promise<{ ok: boolean; quiTargetId?: number }> {
+}: RegisterQuiWebhookArgs): Promise<{
+	ok: boolean;
+	quiTargetId?: number;
+	cleanupPending?: boolean;
+	warning?: string;
+}> {
 	// `quiTargetId` is a number on the wire — qui's openapi declares it as
 	// `integer`, and the backend forwards `created.id` verbatim from qui's
 	// response. An earlier version of this client typed it as `string`,
 	// which caused the Settings panel to call `.slice()` on a number (which
 	// runtime-coerces in JS but is a TypeScript lie).
-	return apiRequest<{ ok: boolean; quiTargetId?: number }>(
-		`/api/qui/instances/${quiInstanceId}/webhook-config/register`,
-		{ method: "POST", json: { secret, eventTypes } },
-	);
+	return apiRequest<{
+		ok: boolean;
+		quiTargetId?: number;
+		cleanupPending?: boolean;
+		warning?: string;
+	}>(`/api/qui/instances/${quiInstanceId}/webhook-config/register`, {
+		method: "POST",
+		json: { secret, eventTypes },
+	});
 }
 
 export interface QuiEventLogParams {

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -57,7 +57,7 @@ for the full rationale.
 | `/api/auto-tag/webhook` | experimental | Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. **Public route** (no session cookie); authenticates via per-user Bearer token (SHA-256 hash of the user's webhook secret). |
 | `/api/pulse` | internal | System Pulse health signals + attention items |
 | `/api/qui` | experimental | Federated peer integration with autobrr/qui (qBittorrent UI) — read-only torrent state, trackers, cross-seed siblings; powers the Torrent Health panel. |
-| `/api/webhooks/qui` | experimental | Inbound qui webhook receiver (Phase 5.1). **Public route** (no session cookie); authenticates via per-user `?secret=…` query param (matches qui's `ApiKeyQuery` scheme). Stores raw events in `QuiEventLog` and publishes to the in-process event bus for SSE fan-out. |
+| `/api/webhooks/qui` | experimental | Inbound qui Shoutrrr notification receiver (Phase 5.1). **Public route** (no session cookie); authenticates via a per-user `?secret=…` query param forwarded by the generic target. Normalizes qUI's `{title, message}` JSON, stores it in `QuiEventLog`, and publishes to the in-process event bus for SSE fan-out. |
 | `/api/seerr` | stable | Request management, discovery, library enrichment |
 | `/api/trash-guides` | internal | TRaSH cache, templates, deployment, profiles |
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -146,6 +146,7 @@ const plaintext = app.encryptor.decrypt({ value, iv });
 - `SESSION_COOKIE_SECRET`: 32 bytes hex
 - `installationId`: local deployment identity (excluded from app backup payloads)
 - Persisted to `/config/secrets.json` (Docker) or `./secrets.json` (dev)
+- Environment-provided cryptographic secrets are synchronized to this file so backups contain the active values.
 
 ### Session Invalidation Pattern
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -144,6 +144,7 @@ const plaintext = app.encryptor.decrypt({ value, iv });
 
 - `ENCRYPTION_KEY`: 32 bytes hex
 - `SESSION_COOKIE_SECRET`: 32 bytes hex
+- `installationId`: local deployment identity (excluded from app backup payloads)
 - Persisted to `/config/secrets.json` (Docker) or `./secrets.json` (dev)
 
 ### Session Invalidation Pattern

--- a/docs/QUI.md
+++ b/docs/QUI.md
@@ -35,8 +35,8 @@ You can monitor both jobs in **Settings → System → Background Jobs**.
 ### qui Activity page — three logs in one surface
 **Activity feed** — observed events emitted by arr-dashboard's own schedulers (sync ticks, gate firings, webhook drops). One row per scheduler tick.
 **My Actions** — tamper-evident audit log of mutations YOU initiated through arr-dashboard. One row per (action, info-hash) pair, including `failed` rows with qui's error message.
-**My Events** — inbound webhook events qui POSTed to arr-dashboard. Empty until you configure the Webhook tab.
-**Webhook** — rotate the secret + auto-register arr-dashboard as a NotificationTarget inside qui (Phase 5.1). When configured, qui pushes state changes to the dashboard within seconds instead of the 10-minute polled sync.
+**My Events** — inbound Shoutrrr notification events qui POSTed to arr-dashboard. Empty until you configure the Webhook tab.
+**Webhook** — rotate the secret + auto-register arr-dashboard as a generic Shoutrrr NotificationTarget inside qui (Phase 5.1). When configured, qui pushes supported notification events (including torrent added/completed) to the dashboard within seconds; the 10-minute sync remains the fallback for other state changes.
 
 ### Pulse (dashboard footer)
 - **Seeding Health domain badge** showing the rollup health of all your qui instances
@@ -90,13 +90,15 @@ By default, arr-dashboard polls qui every 10 minutes for torrent state. If you w
 
 1. **qui Activity → Webhook tab → "Rotate secret"**. The plaintext secret is shown EXACTLY ONCE — copy it or proceed directly to step 2.
 2. Either:
-   - **Auto-register** (single click): pick the qui instance from the list, click "Register selected instance." arr-dashboard POSTs to qui's `/api/notifications/targets` with the full URL + secret.
-   - **Manual**: copy the full URL (with `?secret=...`) into qui's Settings → Notifications → Targets → URL field. Method `POST`.
-3. Trigger an event in qui (pause/resume a torrent) to verify the wire works. The **Recent events** strip on the Webhook tab will show the event within a second, and the qui-activity tabs become push-driven instead of polled.
+   - **Auto-register** (single click): pick the qui instance from the list, click "Register selected instance." arr-dashboard POSTs a `generic://` Shoutrrr JSON target with the full callback URL + secret to qui's `/api/notifications/targets`.
+   - **Manual**: copy the full Shoutrrr target URL (including `template=json` and `secret=...`) into qui's Settings → Notifications → Targets → URL field.
+3. Trigger a configured notification event in qui (for example, add or complete a torrent) to verify the wire works. The **Recent events** strip on the Webhook tab will show the event within a second.
+
+The callback host is generated from **Settings → System → External URL**, falling back to `APP_URL`. It must be reachable from the qui container. If the Webhook tab shows `localhost`, set External URL to the LAN or reverse-proxy address qUI can actually call before registering the target.
 
 **Secret hygiene notes:**
 - The plaintext secret is never persisted — only its SHA-256 hash is stored. Rotating generates a new secret and invalidates the old; you'll need to re-register or update qui's NotificationTarget URL.
-- Query-string secrets land in nginx/Caddy/Cloudflare access logs by default. arr-dashboard's own pino logger redacts `?secret=` from request URLs, but **you should redact the same in your reverse-proxy access logs** if you're worried about log-aggregator access. qui's openapi only supports `ApiKeyQuery` so a header-based scheme isn't available upstream.
+- Query-string secrets land in nginx/Caddy/Cloudflare access logs by default. arr-dashboard's own pino logger redacts `secret=` from request URLs, but **you should redact the same in your reverse-proxy access logs** if you're worried about log-aggregator access. qUI's generic Shoutrrr target forwards the secret in the callback query because its target API does not provide a per-target header field.
 - The hash includes a domain prefix (`qui-webhook-v1:`) so a leak of this secret can't be replayed against the auto-tag webhook (which uses a separate hash domain).
 
 ## Privacy mode (incognito)


### PR DESCRIPTION
## Summary

- register arr-dashboard in qUI with a valid Shoutrrr `generic://` JSON target instead of a plain HTTP URL
- derive a container-reachable callback origin from External URL, APP_URL, or the browser-facing host preserved by Next.js
- accept qUI v1.23 `{ title, message }` notifications while retaining the legacy raw event envelope
- reject stale webhook secrets and redact the one-time secret from upstream errors, logs, and API responses
- update the qUI setup UI and documentation to describe the real registration and delivery contract

## Root cause

qUI validates notification targets as Shoutrrr service URLs, so `http://...` was parsed as an unknown `http` service. Its generic JSON service also delivers `{ title, message }`, while the receiver only accepted `{ type, payload }`. In the default Docker path, Next.js rewrites the API request to an internal localhost host unless the preserved browser-facing host is handled explicitly.

## Validation

- reproduced the qUI v1.23/Shoutrrr validation and delivery contract against the upstream Go code in Docker
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run lint`
- focused qUI client, registration, and receiver suite: 99 tests passed
- full Node 22 suite: 2,883 tests passed, 41 skipped
- `pnpm run build`
- independent regression review: no actionable findings

## Compatibility

The receiver continues to accept the existing `{ type, payload }` envelope. Unknown future qUI notification titles are stored as `notification` events rather than rejected.

Related to #621
