### PR TITLE
fix: align security posture with External URL

### DIFF
--- a/apps/api/src/lib/auth/__tests__/oidc-redirect-uri.test.ts
+++ b/apps/api/src/lib/auth/__tests__/oidc-redirect-uri.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { buildOidcRedirectUriFromAppUrl } from "../oidc-redirect-uri.js";
+
+describe("buildOidcRedirectUriFromAppUrl", () => {
+	it.each([
+		["https://arr.example.com", "https://arr.example.com/auth/oidc/callback"],
+		["https://arr.example.com/", "https://arr.example.com/auth/oidc/callback"],
+		["https://arr.example.com/arr", "https://arr.example.com/arr/auth/oidc/callback"],
+		["https://arr.example.com/arr/", "https://arr.example.com/arr/auth/oidc/callback"],
+	])("builds a canonical callback for %s", (appUrl, expected) => {
+		expect(buildOidcRedirectUriFromAppUrl(appUrl)).toBe(expected);
+	});
+
+	it.each([
+		"https://admin:secret@arr.example.com/",
+		"ftp://arr.example.com/",
+		"mailto:admin@example.com",
+		"https://arr.example.com/arr?tenant=home",
+		"https://arr.example.com/arr#fragment",
+		"https://arr.example.com/arr//nested",
+	])("rejects an unsafe application URL: %s", (appUrl) => {
+		expect(buildOidcRedirectUriFromAppUrl(appUrl)).toBeNull();
+	});
+});

--- a/apps/api/src/lib/auth/oidc-redirect-uri.ts
+++ b/apps/api/src/lib/auth/oidc-redirect-uri.ts
@@ -2,9 +2,19 @@ import { oidcRedirectUriSchema } from "@arr/shared";
 
 export function buildOidcRedirectUriFromAppUrl(appUrl: string): string | null {
 	try {
-		const result = oidcRedirectUriSchema.safeParse(
-			new URL("/auth/oidc/callback", appUrl).toString(),
-		);
+		const baseUrl = new URL(appUrl);
+		if (
+			!["http:", "https:"].includes(baseUrl.protocol) ||
+			baseUrl.username ||
+			baseUrl.password ||
+			appUrl.includes("?") ||
+			appUrl.includes("#")
+		) {
+			return null;
+		}
+
+		baseUrl.pathname = `${baseUrl.pathname.replace(/\/+$/, "")}/auth/oidc/callback`;
+		const result = oidcRedirectUriSchema.safeParse(baseUrl.toString());
 		return result.success ? result.data : null;
 	} catch {
 		return null;

--- a/apps/api/src/lib/auth/oidc-redirect-uri.ts
+++ b/apps/api/src/lib/auth/oidc-redirect-uri.ts
@@ -1,0 +1,12 @@
+import { oidcRedirectUriSchema } from "@arr/shared";
+
+export function buildOidcRedirectUriFromAppUrl(appUrl: string): string | null {
+	try {
+		const result = oidcRedirectUriSchema.safeParse(
+			new URL("/auth/oidc/callback", appUrl).toString(),
+		);
+		return result.success ? result.data : null;
+	} catch {
+		return null;
+	}
+}

--- a/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
+++ b/apps/api/src/lib/notifications/__tests__/notification-service.test.ts
@@ -115,6 +115,22 @@ describe("NotificationService", () => {
 		});
 	});
 
+	it("uses an updated normalized base URL for subsequent notification links", async () => {
+		mockPrisma.notificationSubscription.findMany.mockResolvedValue([
+			makeSubscription("ch-1", "discord"),
+		]);
+		mockDispatcher.send.mockResolvedValue({ success: true, retryable: false } satisfies SendResult);
+
+		service.setBaseUrl("  https://arr.example.com/  ");
+		await service.notify(makePayload({ url: "/settings" }));
+
+		expect(mockDispatcher.send).toHaveBeenCalledWith(
+			"discord",
+			{ webhookUrl: "https://example.com" },
+			expect.objectContaining({ url: "https://arr.example.com/settings" }),
+		);
+	});
+
 	it("dedup gate blocks duplicate and returns early", async () => {
 		mockDedupGate.isDuplicate.mockReturnValue(true);
 

--- a/apps/api/src/lib/notifications/notification-service.ts
+++ b/apps/api/src/lib/notifications/notification-service.ts
@@ -69,12 +69,17 @@ export class NotificationService {
 		this.logger = logger;
 		this.dedupGate = dedupGate;
 		this.retryHandler = retryHandler;
-		this.baseUrl = baseUrl.replace(/\/$/, "");
+		this.baseUrl = normalizeBaseUrl(baseUrl);
 		this.ruleEngine = ruleEngine ?? null;
 		this.aggregationBuffer = aggregationBuffer ?? null;
 
 		// Check deferred notifications every minute
 		this.deferFlushTimer = setInterval(() => this.flushDeferredNotifications(), 60_000);
+	}
+
+	/** Update the public URL used to resolve relative notification links. */
+	setBaseUrl(baseUrl: string): void {
+		this.baseUrl = normalizeBaseUrl(baseUrl);
 	}
 
 	/** Clean up timers on shutdown */
@@ -564,4 +569,8 @@ function resolveUrl(url: string, baseUrl: string): string {
 	if (/^https?:\/\//i.test(url)) return url;
 	if (url.startsWith("/")) return `${baseUrl}${url}`;
 	return `${baseUrl}/${url}`;
+}
+
+function normalizeBaseUrl(baseUrl: string): string {
+	return baseUrl.trim().replace(/\/+$/, "");
 }

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -29,6 +29,7 @@ function baseInput(overrides: Overrides = {}): SecurityPostureInput {
 			...overrides.env,
 		},
 		oidcEnabled: overrides.oidcEnabled ?? false,
+		oidcProviderEnabled: overrides.oidcProviderEnabled ?? overrides.oidcEnabled ?? false,
 		oidcRedirectUri: overrides.oidcRedirectUri ?? null,
 		passkeyCount: overrides.passkeyCount ?? 0,
 		passwordUserCount: overrides.passwordUserCount ?? 1,
@@ -165,6 +166,23 @@ describe("evaluateSecurityPosture", () => {
 			expect(check.detail).toContain("3 passkeys");
 		});
 
+		it("warns when the enabled OIDC provider is not linked to the admin", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					oidcEnabled: false,
+					oidcProviderEnabled: true,
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "authentication").severity).toBe("healthy");
+			expect(checkById(result, "oidc-account-link")).toMatchObject({
+				severity: "warning",
+				detail: "The OIDC provider is enabled, but the admin account is not linked.",
+			});
+			expect(result.overall).toBe("warning");
+		});
+
 		it("pluralizes passkeys correctly for a single credential", () => {
 			const result = evaluateSecurityPosture(baseInput({ passkeyCount: 1 }));
 			expect(checkById(result, "authentication").detail).toContain("1 passkey");
@@ -286,6 +304,8 @@ describe("evaluateSecurityPosture", () => {
 			" https://arr.example.com ",
 			"https://admin@arr.example.com",
 			"https://admin:secret@arr.example.com",
+			"https://arr.example.com\\proxy",
+			"https://arr.example.com/\tproxy",
 			"https://arr.example.com?source=proxy",
 			"https://arr.example.com#settings",
 			"https://arr.example.com///",
@@ -360,6 +380,32 @@ describe("evaluateSecurityPosture", () => {
 			});
 			expect(result.checks.find((check) => check.id === "oidc-app-url")).toBeUndefined();
 			expect(result.overall).toBe("healthy");
+		});
+
+		it.each([
+			"https://arr.example.com/auth/oidc/callback#fragment",
+			"https://admin:secret@arr.example.com/auth/oidc/callback",
+			"https://arr.example.com\\auth\\oidc\\callback",
+		])("warns about an invalid HTTPS OIDC callback: %s", (oidcRedirectUri) => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "https://arr.example.com",
+					},
+					oidcEnabled: true,
+					oidcRedirectUri,
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "oidc-app-url")).toMatchObject({
+				severity: "warning",
+				detail: "OIDC Redirect URI is not a valid callback URL.",
+			});
+			expect(result.overall).toBe("warning");
 		});
 
 		it.each([

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -254,7 +254,7 @@ describe("evaluateSecurityPosture", () => {
 
 			expect(checkById(result, "app-url")).toMatchObject({
 				severity: "healthy",
-				detail: "https://arr.example.com",
+				detail: "External URL uses HTTPS.",
 			});
 			expect(result.effective.appUrl).toBe("https://arr.example.com");
 		});
@@ -275,7 +275,7 @@ describe("evaluateSecurityPosture", () => {
 
 			expect(checkById(result, "app-url")).toMatchObject({
 				severity: "warning",
-				detail: "External URL uses http: in production.",
+				detail: "External URL uses HTTP in production.",
 				remediation: expect.stringContaining("External URL in Settings → System"),
 			});
 		});
@@ -297,7 +297,7 @@ describe("evaluateSecurityPosture", () => {
 
 			expect(checkById(result, "app-url")).toMatchObject({
 				severity: "healthy",
-				detail: "https://arr.example.com",
+				detail: "External URL uses HTTPS.",
 			});
 			expect(checkById(result, "oidc-app-url")).toMatchObject({
 				severity: "warning",

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -306,6 +306,7 @@ describe("evaluateSecurityPosture", () => {
 			"https://admin:secret@arr.example.com",
 			"https://arr.example.com\\proxy",
 			"https://arr.example.com/\tproxy",
+			"https://arr.example.com/base path",
 			"https://arr.example.com?source=proxy",
 			"https://arr.example.com#settings",
 			"https://arr.example.com///",
@@ -383,9 +384,12 @@ describe("evaluateSecurityPosture", () => {
 		});
 
 		it.each([
+			"   ",
+			" https://arr.example.com/auth/oidc/callback ",
 			"https://arr.example.com/auth/oidc/callback#fragment",
 			"https://admin:secret@arr.example.com/auth/oidc/callback",
 			"https://arr.example.com\\auth\\oidc\\callback",
+			"https://arr.example.com/auth callback",
 		])("warns about an invalid HTTPS OIDC callback: %s", (oidcRedirectUri) => {
 			const result = evaluateSecurityPosture(
 				baseInput({

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -283,6 +283,7 @@ describe("evaluateSecurityPosture", () => {
 		});
 
 		it.each([
+			" https://arr.example.com ",
 			"https://arr.example.com?source=proxy",
 			"https://arr.example.com#settings",
 			"https://arr.example.com///",
@@ -303,7 +304,7 @@ describe("evaluateSecurityPosture", () => {
 			expect(checkById(result, "app-url")).toMatchObject({
 				severity: "warning",
 				detail: "External URL is not a valid public URL.",
-				remediation: expect.stringContaining("without a query string, fragment"),
+				remediation: expect.stringContaining("without surrounding whitespace"),
 			});
 			expect(result.effective.appUrl).toBe(publicAppUrl);
 		});

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -349,7 +349,11 @@ describe("evaluateSecurityPosture", () => {
 			expect(result.overall).toBe("healthy");
 		});
 
-		it.each(["http://public.example/auth/oidc/callback", "ftp://localhost/auth/oidc/callback"])(
+		it.each([
+			"http://public.example/auth/oidc/callback",
+			"http://127.attacker.invalid/auth/oidc/callback",
+			"ftp://localhost/auth/oidc/callback",
+		])(
 			"warns about a non-HTTPS OIDC callback outside the loopback exception: %s",
 			(oidcRedirectUri) => {
 				const result = evaluateSecurityPosture(

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -389,6 +389,7 @@ describe("evaluateSecurityPosture", () => {
 			"https://arr.example.com/auth/oidc/callback#fragment",
 			"https://admin:secret@arr.example.com/auth/oidc/callback",
 			"https://arr.example.com//auth/oidc/callback",
+			"https://arr.example.com/wrong-callback",
 			"https://arr.example.com\\auth\\oidc\\callback",
 			"https://arr.example.com/auth callback",
 		])("warns about an invalid HTTPS OIDC callback: %s", (oidcRedirectUri) => {

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -32,6 +32,7 @@ function baseInput(overrides: Overrides = {}): SecurityPostureInput {
 		passkeyCount: overrides.passkeyCount ?? 0,
 		passwordUserCount: overrides.passwordUserCount ?? 1,
 		totalUserCount: overrides.totalUserCount ?? 1,
+		publicAppUrl: overrides.publicAppUrl ?? null,
 	};
 }
 
@@ -237,6 +238,48 @@ describe("evaluateSecurityPosture", () => {
 	});
 
 	describe("app URL", () => {
+		it("uses the HTTPS External URL before the APP_URL fallback", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "http://localhost:3000",
+					},
+					publicAppUrl: "https://arr.example.com",
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "app-url")).toMatchObject({
+				severity: "healthy",
+				detail: "https://arr.example.com",
+			});
+			expect(result.effective.appUrl).toBe("https://arr.example.com");
+		});
+
+		it("warns about the External URL when it overrides a secure APP_URL with http", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "https://arr.example.com",
+					},
+					publicAppUrl: "http://proxy.example.com",
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "app-url")).toMatchObject({
+				severity: "warning",
+				detail: "External URL uses http: in production.",
+				remediation: expect.stringContaining("External URL in Settings → System"),
+			});
+		});
+
 		it("warns on non-https APP_URL in production", () => {
 			const result = evaluateSecurityPosture(
 				baseInput({

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -282,6 +282,32 @@ describe("evaluateSecurityPosture", () => {
 			});
 		});
 
+		it.each([
+			"https://arr.example.com?source=proxy",
+			"https://arr.example.com#settings",
+			"https://arr.example.com///",
+		])("warns about an invalid persisted External URL: %s", (publicAppUrl) => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "https://arr.example.com",
+					},
+					publicAppUrl,
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "app-url")).toMatchObject({
+				severity: "warning",
+				detail: "External URL is not a valid public URL.",
+				remediation: expect.stringContaining("without a query string, fragment"),
+			});
+			expect(result.effective.appUrl).toBe(publicAppUrl);
+		});
+
 		it("warns when the enabled OIDC provider uses an HTTP redirect URI", () => {
 			const result = evaluateSecurityPosture(
 				baseInput({

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -280,6 +280,32 @@ describe("evaluateSecurityPosture", () => {
 			});
 		});
 
+		it("keeps an APP_URL warning when OIDC is enabled with an HTTPS External URL", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "http://localhost:3000",
+					},
+					publicAppUrl: "https://arr.example.com",
+					oidcEnabled: true,
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "app-url")).toMatchObject({
+				severity: "healthy",
+				detail: "https://arr.example.com",
+			});
+			expect(checkById(result, "oidc-app-url")).toMatchObject({
+				severity: "warning",
+				detail: expect.stringContaining("OIDC callbacks use APP_URL"),
+				remediation: expect.stringContaining("APP_URL in the container environment"),
+			});
+		});
+
 		it("warns on non-https APP_URL in production", () => {
 			const result = evaluateSecurityPosture(
 				baseInput({

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -388,6 +388,7 @@ describe("evaluateSecurityPosture", () => {
 			" https://arr.example.com/auth/oidc/callback ",
 			"https://arr.example.com/auth/oidc/callback#fragment",
 			"https://admin:secret@arr.example.com/auth/oidc/callback",
+			"https://arr.example.com//auth/oidc/callback",
 			"https://arr.example.com\\auth\\oidc\\callback",
 			"https://arr.example.com/auth callback",
 		])("warns about an invalid HTTPS OIDC callback: %s", (oidcRedirectUri) => {

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -332,17 +332,40 @@ describe("evaluateSecurityPosture", () => {
 			expect(result.overall).toBe("healthy");
 		});
 
-		it("accepts an HTTP OIDC loopback callback in development", () => {
+		it.each([
+			"http://localhost:3000/auth/oidc/callback",
+			"http://dashboard.localhost:3000/auth/oidc/callback",
+			"http://127.0.0.1:3000/auth/oidc/callback",
+			"http://[::1]:3000/auth/oidc/callback",
+		])("accepts an HTTP OIDC loopback callback in development: %s", (oidcRedirectUri) => {
 			const result = evaluateSecurityPosture(
 				baseInput({
 					oidcEnabled: true,
-					oidcRedirectUri: "http://localhost:3000/auth/oidc/callback",
+					oidcRedirectUri,
 				}),
 			);
 
 			expect(result.checks.find((check) => check.id === "oidc-app-url")).toBeUndefined();
 			expect(result.overall).toBe("healthy");
 		});
+
+		it.each(["http://public.example/auth/oidc/callback", "ftp://localhost/auth/oidc/callback"])(
+			"warns about a non-HTTPS OIDC callback outside the loopback exception: %s",
+			(oidcRedirectUri) => {
+				const result = evaluateSecurityPosture(
+					baseInput({
+						oidcEnabled: true,
+						oidcRedirectUri,
+						passkeyCount: 1,
+					}),
+				);
+
+				expect(checkById(result, "oidc-app-url")).toMatchObject({
+					severity: "warning",
+				});
+				expect(result.overall).toBe("warning");
+			},
+		);
 
 		it("warns on non-https APP_URL in production", () => {
 			const result = evaluateSecurityPosture(

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -84,6 +84,7 @@ describe("evaluateSecurityPosture", () => {
 				passwordEnabled: true,
 				passwordUserCount: 1,
 				oidcEnabled: true,
+				oidcProviderEnabled: true,
 				passkeyCount: 0,
 			});
 		});

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -284,6 +284,8 @@ describe("evaluateSecurityPosture", () => {
 
 		it.each([
 			" https://arr.example.com ",
+			"https://admin@arr.example.com",
+			"https://admin:secret@arr.example.com",
 			"https://arr.example.com?source=proxy",
 			"https://arr.example.com#settings",
 			"https://arr.example.com///",
@@ -304,7 +306,7 @@ describe("evaluateSecurityPosture", () => {
 			expect(checkById(result, "app-url")).toMatchObject({
 				severity: "warning",
 				detail: "External URL is not a valid public URL.",
-				remediation: expect.stringContaining("without surrounding whitespace"),
+				remediation: expect.stringContaining("without embedded credentials"),
 			});
 			expect(result.effective.appUrl).toBe(publicAppUrl);
 		});

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -29,6 +29,7 @@ function baseInput(overrides: Overrides = {}): SecurityPostureInput {
 			...overrides.env,
 		},
 		oidcEnabled: overrides.oidcEnabled ?? false,
+		oidcRedirectUri: overrides.oidcRedirectUri ?? null,
 		passkeyCount: overrides.passkeyCount ?? 0,
 		passwordUserCount: overrides.passwordUserCount ?? 1,
 		totalUserCount: overrides.totalUserCount ?? 1,
@@ -280,7 +281,7 @@ describe("evaluateSecurityPosture", () => {
 			});
 		});
 
-		it("keeps an APP_URL warning when OIDC is enabled with an HTTPS External URL", () => {
+		it("warns when the enabled OIDC provider uses an HTTP redirect URI", () => {
 			const result = evaluateSecurityPosture(
 				baseInput({
 					env: {
@@ -291,6 +292,7 @@ describe("evaluateSecurityPosture", () => {
 					},
 					publicAppUrl: "https://arr.example.com",
 					oidcEnabled: true,
+					oidcRedirectUri: "http://localhost:3000/auth/oidc/callback",
 					passkeyCount: 1,
 				}),
 			);
@@ -301,9 +303,33 @@ describe("evaluateSecurityPosture", () => {
 			});
 			expect(checkById(result, "oidc-app-url")).toMatchObject({
 				severity: "warning",
-				detail: expect.stringContaining("OIDC callbacks use APP_URL"),
-				remediation: expect.stringContaining("APP_URL in the container environment"),
+				detail: "OIDC Redirect URI uses HTTP.",
+				remediation: expect.stringContaining("OIDC provider Redirect URI"),
 			});
+		});
+
+		it("accepts an explicit HTTPS OIDC redirect URI when APP_URL remains HTTP", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					env: {
+						NODE_ENV: "production",
+						TRUST_PROXY: true,
+						COOKIE_SECURE: true,
+						APP_URL: "http://localhost:3000",
+					},
+					publicAppUrl: "https://arr.example.com",
+					oidcEnabled: true,
+					oidcRedirectUri: "https://arr.example.com/auth/oidc/callback",
+					passkeyCount: 1,
+				}),
+			);
+
+			expect(checkById(result, "app-url")).toMatchObject({
+				severity: "healthy",
+				detail: "External URL uses HTTPS.",
+			});
+			expect(result.checks.find((check) => check.id === "oidc-app-url")).toBeUndefined();
+			expect(result.overall).toBe("healthy");
 		});
 
 		it("warns on non-https APP_URL in production", () => {

--- a/apps/api/src/lib/security/__tests__/security-posture.test.ts
+++ b/apps/api/src/lib/security/__tests__/security-posture.test.ts
@@ -332,6 +332,18 @@ describe("evaluateSecurityPosture", () => {
 			expect(result.overall).toBe("healthy");
 		});
 
+		it("accepts an HTTP OIDC loopback callback in development", () => {
+			const result = evaluateSecurityPosture(
+				baseInput({
+					oidcEnabled: true,
+					oidcRedirectUri: "http://localhost:3000/auth/oidc/callback",
+				}),
+			);
+
+			expect(result.checks.find((check) => check.id === "oidc-app-url")).toBeUndefined();
+			expect(result.overall).toBe("healthy");
+		});
+
 		it("warns on non-https APP_URL in production", () => {
 			const result = evaluateSecurityPosture(
 				baseInput({

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -108,6 +108,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		? appUrlProtocol.slice(0, -1).toUpperCase()
 		: "an unrecognized protocol";
 	const appUrlIsHttps = appUrlProtocol === "https:";
+	const appUrlIsValidPublicBase = isValidPublicBaseUrl(appUrl);
 	const oidcRedirectUri = input.oidcRedirectUri?.trim() || input.env.APP_URL;
 	const oidcRedirectUriProtocol = safeProtocol(oidcRedirectUri);
 	const oidcRedirectUriProtocolLabel = oidcRedirectUriProtocol
@@ -262,7 +263,17 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	// ──────────────────────────────────────────────────────────────────────
 	// 6. App URL consistency
 	// ──────────────────────────────────────────────────────────────────────
-	if (isProduction && !appUrlIsHttps) {
+	if (!appUrlIsValidPublicBase) {
+		checks.push({
+			id: "app-url",
+			label: "App URL",
+			detail: `${appUrlSource} is not a valid public URL.`,
+			severity: "warning",
+			remediation: configuredPublicAppUrl
+				? "Update External URL in Settings → System to an http(s) URL without a query string, fragment, or repeated trailing slashes."
+				: "Set APP_URL to an http(s) URL without a query string, fragment, or repeated trailing slashes.",
+		});
+	} else if (isProduction && !appUrlIsHttps) {
 		checks.push({
 			id: "app-url",
 			label: "App URL",
@@ -341,6 +352,20 @@ function safeProtocol(url: string): string | null {
 		return new URL(url).protocol;
 	} catch {
 		return null;
+	}
+}
+
+function isValidPublicBaseUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return (
+			(url.protocol === "http:" || url.protocol === "https:") &&
+			!value.includes("?") &&
+			!value.includes("#") &&
+			!/\/{2,}$/.test(value)
+		);
+	} catch {
+		return false;
 	}
 }
 

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -270,8 +270,8 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 			detail: `${appUrlSource} is not a valid public URL.`,
 			severity: "warning",
 			remediation: configuredPublicAppUrl
-				? "Update External URL in Settings → System to an http(s) URL without surrounding whitespace, a query string, fragment, or repeated trailing slashes."
-				: "Set APP_URL to an http(s) URL without surrounding whitespace, a query string, fragment, or repeated trailing slashes.",
+				? "Update External URL in Settings → System to an http(s) URL without embedded credentials, surrounding whitespace, a query string, fragment, or repeated trailing slashes."
+				: "Set APP_URL to an http(s) URL without embedded credentials, surrounding whitespace, a query string, fragment, or repeated trailing slashes.",
 		});
 	} else if (isProduction && !appUrlIsHttps) {
 		checks.push({
@@ -360,6 +360,8 @@ function isValidPublicBaseUrl(value: string): boolean {
 		const url = new URL(value);
 		return (
 			(url.protocol === "http:" || url.protocol === "https:") &&
+			url.username === "" &&
+			url.password === "" &&
 			value === value.trim() &&
 			!value.includes("?") &&
 			!value.includes("#") &&

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -99,8 +99,14 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	const appUrl = configuredPublicAppUrl || input.env.APP_URL;
 	const appUrlSource = configuredPublicAppUrl ? "External URL" : "APP_URL";
 	const appUrlProtocol = safeProtocol(appUrl);
+	const appUrlProtocolLabel = appUrlProtocol
+		? appUrlProtocol.slice(0, -1).toUpperCase()
+		: "an unrecognized protocol";
 	const appUrlIsHttps = appUrlProtocol === "https:";
 	const oidcAppUrlProtocol = safeProtocol(input.env.APP_URL);
+	const oidcAppUrlProtocolLabel = oidcAppUrlProtocol
+		? oidcAppUrlProtocol.slice(0, -1).toUpperCase()
+		: "an unrecognized protocol";
 	const oidcAppUrlIsHttps = oidcAppUrlProtocol === "https:";
 
 	const checks: SecurityCheck[] = [];
@@ -251,7 +257,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		checks.push({
 			id: "app-url",
 			label: "App URL",
-			detail: `${appUrlSource} uses ${appUrlProtocol ?? "an unrecognized protocol"} in production.`,
+			detail: `${appUrlSource} uses ${appUrlProtocolLabel} in production.`,
 			severity: "warning",
 			remediation: configuredPublicAppUrl
 				? "Update External URL in Settings → System to an https:// origin."
@@ -271,7 +277,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		checks.push({
 			id: "app-url",
 			label: "App URL",
-			detail: appUrl,
+			detail: `${appUrlSource} uses ${appUrlProtocolLabel}.`,
 			severity: "healthy",
 		});
 	}
@@ -283,9 +289,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		checks.push({
 			id: "oidc-app-url",
 			label: "OIDC App URL",
-			detail: `OIDC callbacks use APP_URL, which uses ${
-				oidcAppUrlProtocol ?? "an unrecognized protocol"
-			}.`,
+			detail: `OIDC callbacks use APP_URL, which uses ${oidcAppUrlProtocolLabel}.`,
 			severity: "warning",
 			remediation:
 				"Set APP_URL in the container environment to the public https:// origin used by your OIDC provider.",

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -84,6 +84,7 @@ export interface SecurityPostureResult {
 		passwordEnabled: boolean;
 		passwordUserCount: number;
 		oidcEnabled: boolean;
+		oidcProviderEnabled: boolean;
 		passkeyCount: number;
 	};
 }
@@ -321,6 +322,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 			passwordEnabled,
 			passwordUserCount: input.passwordUserCount,
 			oidcEnabled: input.oidcEnabled,
+			oidcProviderEnabled,
 			passkeyCount: input.passkeyCount,
 		},
 	};

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -109,7 +109,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		: "an unrecognized protocol";
 	const appUrlIsHttps = appUrlProtocol === "https:";
 	const appUrlIsValidPublicBase = isValidPublicBaseUrl(appUrl);
-	const oidcRedirectUri = input.oidcRedirectUri?.trim() || input.env.APP_URL;
+	const oidcRedirectUri = input.oidcRedirectUri || input.env.APP_URL;
 	const oidcRedirectUriProtocol = safeProtocol(oidcRedirectUri);
 	const oidcRedirectUriProtocolLabel = oidcRedirectUriProtocol
 		? oidcRedirectUriProtocol.slice(0, -1).toUpperCase()
@@ -408,7 +408,9 @@ function isValidOidcRedirectUri(value: string): boolean {
 function hasUnsafeUrlCharacters(value: string): boolean {
 	for (const character of value) {
 		const codePoint = character.codePointAt(0) ?? 0;
-		if (character === "\\" || codePoint <= 0x1f || codePoint === 0x7f) return true;
+		if (character === "\\" || character.trim() === "" || codePoint <= 0x1f || codePoint === 0x7f) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -52,6 +52,8 @@ export interface SecurityPostureInput {
 	publicAppUrl?: string | null;
 	/** True if at least one OIDC provider is enabled. */
 	oidcEnabled: boolean;
+	/** Stored callback URL for the enabled OIDC provider. */
+	oidcRedirectUri?: string | null;
 	/** Total passkey credentials registered across all users. */
 	passkeyCount: number;
 	/** Count of users with a password set (hashedPassword IS NOT NULL). */
@@ -103,11 +105,12 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		? appUrlProtocol.slice(0, -1).toUpperCase()
 		: "an unrecognized protocol";
 	const appUrlIsHttps = appUrlProtocol === "https:";
-	const oidcAppUrlProtocol = safeProtocol(input.env.APP_URL);
-	const oidcAppUrlProtocolLabel = oidcAppUrlProtocol
-		? oidcAppUrlProtocol.slice(0, -1).toUpperCase()
+	const oidcRedirectUri = input.oidcRedirectUri?.trim() || input.env.APP_URL;
+	const oidcRedirectUriProtocol = safeProtocol(oidcRedirectUri);
+	const oidcRedirectUriProtocolLabel = oidcRedirectUriProtocol
+		? oidcRedirectUriProtocol.slice(0, -1).toUpperCase()
 		: "an unrecognized protocol";
-	const oidcAppUrlIsHttps = oidcAppUrlProtocol === "https:";
+	const oidcRedirectUriIsHttps = oidcRedirectUriProtocol === "https:";
 
 	const checks: SecurityCheck[] = [];
 
@@ -282,17 +285,16 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		});
 	}
 
-	// OIDC still validates and generates redirect URIs from APP_URL. An
-	// External URL can make public links healthy without fixing that separate
-	// callback origin, so keep the OIDC-specific dependency visible.
-	if (input.oidcEnabled && !oidcAppUrlIsHttps) {
+	// OIDC authentication uses the enabled provider's stored redirect URI.
+	// Check that actual callback independently from the public-link URL.
+	if (input.oidcEnabled && !oidcRedirectUriIsHttps) {
 		checks.push({
 			id: "oidc-app-url",
-			label: "OIDC App URL",
-			detail: `OIDC callbacks use APP_URL, which uses ${oidcAppUrlProtocolLabel}.`,
+			label: "OIDC Redirect URI",
+			detail: `OIDC Redirect URI uses ${oidcRedirectUriProtocolLabel}.`,
 			severity: "warning",
 			remediation:
-				"Set APP_URL in the container environment to the public https:// origin used by your OIDC provider.",
+				"Update the enabled OIDC provider Redirect URI to the public https:// callback URL.",
 		});
 	}
 

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -111,6 +111,8 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		? oidcRedirectUriProtocol.slice(0, -1).toUpperCase()
 		: "an unrecognized protocol";
 	const oidcRedirectUriIsHttps = oidcRedirectUriProtocol === "https:";
+	const oidcRedirectUriIsDevelopmentLoopback =
+		input.env.NODE_ENV === "development" && isHttpLoopbackUrl(oidcRedirectUri);
 
 	const checks: SecurityCheck[] = [];
 
@@ -287,7 +289,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 
 	// OIDC authentication uses the enabled provider's stored redirect URI.
 	// Check that actual callback independently from the public-link URL.
-	if (input.oidcEnabled && !oidcRedirectUriIsHttps && (isProduction || effectiveSecureCookies)) {
+	if (input.oidcEnabled && !oidcRedirectUriIsHttps && !oidcRedirectUriIsDevelopmentLoopback) {
 		checks.push({
 			id: "oidc-app-url",
 			label: "OIDC Redirect URI",
@@ -334,5 +336,22 @@ function safeProtocol(url: string): string | null {
 		return new URL(url).protocol;
 	} catch {
 		return null;
+	}
+}
+
+function isHttpLoopbackUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		if (url.protocol !== "http:") return false;
+
+		const hostname = url.hostname.toLowerCase().replace(/\.$/, "");
+		return (
+			hostname === "localhost" ||
+			hostname.endsWith(".localhost") ||
+			hostname.startsWith("127.") ||
+			hostname === "[::1]"
+		);
+	} catch {
+		return false;
 	}
 }

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -398,7 +398,8 @@ function isValidOidcRedirectUri(value: string): boolean {
 			url.password === "" &&
 			value === value.trim() &&
 			!hasUnsafeUrlCharacters(value) &&
-			!value.includes("#")
+			!value.includes("#") &&
+			!url.pathname.includes("//")
 		);
 	} catch {
 		return false;

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -399,7 +399,8 @@ function isValidOidcRedirectUri(value: string): boolean {
 			value === value.trim() &&
 			!hasUnsafeUrlCharacters(value) &&
 			!value.includes("#") &&
-			!url.pathname.includes("//")
+			!url.pathname.includes("//") &&
+			url.pathname.endsWith("/auth/oidc/callback")
 		);
 	} catch {
 		return false;

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -115,6 +115,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		? oidcRedirectUriProtocol.slice(0, -1).toUpperCase()
 		: "an unrecognized protocol";
 	const oidcRedirectUriIsHttps = oidcRedirectUriProtocol === "https:";
+	const oidcRedirectUriIsValid = isValidOidcRedirectUri(oidcRedirectUri);
 	const oidcRedirectUriIsDevelopmentLoopback =
 		input.env.NODE_ENV === "development" && isHttpLoopbackUrl(oidcRedirectUri);
 	const oidcProviderEnabled = input.oidcProviderEnabled ?? input.oidcEnabled;
@@ -213,6 +214,16 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		});
 	}
 
+	if (oidcProviderEnabled && !input.oidcEnabled) {
+		checks.push({
+			id: "oidc-account-link",
+			label: "OIDC Account Link",
+			detail: "The OIDC provider is enabled, but the admin account is not linked.",
+			severity: "warning",
+			remediation: "Link the admin account to the OIDC provider, or disable the provider.",
+		});
+	}
+
 	// ──────────────────────────────────────────────────────────────────────
 	// 4. Password policy (informational — only flagged if relaxed in prod)
 	// ──────────────────────────────────────────────────────────────────────
@@ -304,11 +315,16 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 
 	// OIDC authentication uses the enabled provider's stored redirect URI.
 	// Check that actual callback independently from the public-link URL.
-	if (oidcProviderEnabled && !oidcRedirectUriIsHttps && !oidcRedirectUriIsDevelopmentLoopback) {
+	if (
+		oidcProviderEnabled &&
+		(!oidcRedirectUriIsValid || (!oidcRedirectUriIsHttps && !oidcRedirectUriIsDevelopmentLoopback))
+	) {
 		checks.push({
 			id: "oidc-app-url",
 			label: "OIDC Redirect URI",
-			detail: `OIDC Redirect URI uses ${oidcRedirectUriProtocolLabel}.`,
+			detail: oidcRedirectUriIsValid
+				? `OIDC Redirect URI uses ${oidcRedirectUriProtocolLabel}.`
+				: "OIDC Redirect URI is not a valid callback URL.",
 			severity: "warning",
 			remediation:
 				"Update the enabled OIDC provider Redirect URI to the public https:// callback URL.",
@@ -363,6 +379,7 @@ function isValidPublicBaseUrl(value: string): boolean {
 			url.username === "" &&
 			url.password === "" &&
 			value === value.trim() &&
+			!hasUnsafeUrlCharacters(value) &&
 			!value.includes("?") &&
 			!value.includes("#") &&
 			!/\/{2,}$/.test(value)
@@ -370,6 +387,30 @@ function isValidPublicBaseUrl(value: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+function isValidOidcRedirectUri(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return (
+			(url.protocol === "http:" || url.protocol === "https:") &&
+			url.username === "" &&
+			url.password === "" &&
+			value === value.trim() &&
+			!hasUnsafeUrlCharacters(value) &&
+			!value.includes("#")
+		);
+	} catch {
+		return false;
+	}
+}
+
+function hasUnsafeUrlCharacters(value: string): boolean {
+	for (const character of value) {
+		const codePoint = character.codePointAt(0) ?? 0;
+		if (character === "\\" || codePoint <= 0x1f || codePoint === 0x7f) return true;
+	}
+	return false;
 }
 
 function isHttpLoopbackUrl(value: string): boolean {

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -50,8 +50,10 @@ export interface SecurityPostureInput {
 	};
 	/** Admin-configured public URL. When absent, APP_URL remains the fallback. */
 	publicAppUrl?: string | null;
-	/** True if at least one OIDC provider is enabled. */
+	/** True if an enabled OIDC provider is linked to the current admin. */
 	oidcEnabled: boolean;
+	/** True if an OIDC provider is enabled, even if the current admin is not linked yet. */
+	oidcProviderEnabled?: boolean;
 	/** Stored callback URL for the enabled OIDC provider. */
 	oidcRedirectUri?: string | null;
 	/** Total passkey credentials registered across all users. */
@@ -113,6 +115,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	const oidcRedirectUriIsHttps = oidcRedirectUriProtocol === "https:";
 	const oidcRedirectUriIsDevelopmentLoopback =
 		input.env.NODE_ENV === "development" && isHttpLoopbackUrl(oidcRedirectUri);
+	const oidcProviderEnabled = input.oidcProviderEnabled ?? input.oidcEnabled;
 
 	const checks: SecurityCheck[] = [];
 
@@ -289,7 +292,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 
 	// OIDC authentication uses the enabled provider's stored redirect URI.
 	// Check that actual callback independently from the public-link URL.
-	if (input.oidcEnabled && !oidcRedirectUriIsHttps && !oidcRedirectUriIsDevelopmentLoopback) {
+	if (oidcProviderEnabled && !oidcRedirectUriIsHttps && !oidcRedirectUriIsDevelopmentLoopback) {
 		checks.push({
 			id: "oidc-app-url",
 			label: "OIDC Redirect URI",
@@ -348,7 +351,7 @@ function isHttpLoopbackUrl(value: string): boolean {
 		return (
 			hostname === "localhost" ||
 			hostname.endsWith(".localhost") ||
-			hostname.startsWith("127.") ||
+			/^127(?:\.\d{1,3}){3}$/.test(hostname) ||
 			hostname === "[::1]"
 		);
 	} catch {

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -48,6 +48,8 @@ export interface SecurityPostureInput {
 		PASSWORD_POLICY: "strict" | "relaxed";
 		APP_URL: string;
 	};
+	/** Admin-configured public URL. When absent, APP_URL remains the fallback. */
+	publicAppUrl?: string | null;
 	/** True if at least one OIDC provider is enabled. */
 	oidcEnabled: boolean;
 	/** Total passkey credentials registered across all users. */
@@ -93,7 +95,10 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	const effectiveSecureCookies = input.env.COOKIE_SECURE ?? input.env.TRUST_PROXY;
 	const isProduction = input.env.NODE_ENV === "production";
 	const passwordEnabled = input.passwordUserCount > 0;
-	const appUrlProtocol = safeProtocol(input.env.APP_URL);
+	const configuredPublicAppUrl = input.publicAppUrl?.trim();
+	const appUrl = configuredPublicAppUrl || input.env.APP_URL;
+	const appUrlSource = configuredPublicAppUrl ? "External URL" : "APP_URL";
+	const appUrlProtocol = safeProtocol(appUrl);
 	const appUrlIsHttps = appUrlProtocol === "https:";
 
 	const checks: SecurityCheck[] = [];
@@ -244,23 +249,27 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		checks.push({
 			id: "app-url",
 			label: "App URL",
-			detail: `APP_URL uses ${appUrlProtocol ?? "an unrecognized protocol"} in production.`,
+			detail: `${appUrlSource} uses ${appUrlProtocol ?? "an unrecognized protocol"} in production.`,
 			severity: "warning",
-			remediation: "Set APP_URL to an https:// origin so OIDC redirect URIs and links are secure.",
+			remediation: configuredPublicAppUrl
+				? "Update External URL in Settings → System to an https:// origin."
+				: "Set an https:// External URL in Settings → System, or set APP_URL in the container environment.",
 		});
 	} else if (effectiveSecureCookies && !appUrlIsHttps) {
 		checks.push({
 			id: "app-url",
 			label: "App URL",
-			detail: "Secure cookies are enabled but APP_URL is not https — clients may fail to log in.",
+			detail: `Secure cookies are enabled but ${appUrlSource} is not https — generated public links may be insecure.`,
 			severity: "warning",
-			remediation: "Update APP_URL to match the public https:// origin.",
+			remediation: configuredPublicAppUrl
+				? "Update External URL in Settings → System to match the public https:// origin."
+				: "Set an https:// External URL in Settings → System, or update APP_URL to match the public origin.",
 		});
 	} else {
 		checks.push({
 			id: "app-url",
 			label: "App URL",
-			detail: `${input.env.APP_URL}`,
+			detail: appUrl,
 			severity: "healthy",
 		});
 	}
@@ -272,7 +281,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 		sessionTtlHours: input.env.SESSION_TTL_HOURS,
 		sessionCookieName: input.env.SESSION_COOKIE_NAME,
 		passwordPolicy: input.env.PASSWORD_POLICY,
-		appUrl: input.env.APP_URL,
+		appUrl,
 	};
 
 	return {

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -100,6 +100,8 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	const appUrlSource = configuredPublicAppUrl ? "External URL" : "APP_URL";
 	const appUrlProtocol = safeProtocol(appUrl);
 	const appUrlIsHttps = appUrlProtocol === "https:";
+	const oidcAppUrlProtocol = safeProtocol(input.env.APP_URL);
+	const oidcAppUrlIsHttps = oidcAppUrlProtocol === "https:";
 
 	const checks: SecurityCheck[] = [];
 
@@ -271,6 +273,22 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 			label: "App URL",
 			detail: appUrl,
 			severity: "healthy",
+		});
+	}
+
+	// OIDC still validates and generates redirect URIs from APP_URL. An
+	// External URL can make public links healthy without fixing that separate
+	// callback origin, so keep the OIDC-specific dependency visible.
+	if (input.oidcEnabled && !oidcAppUrlIsHttps) {
+		checks.push({
+			id: "oidc-app-url",
+			label: "OIDC App URL",
+			detail: `OIDC callbacks use APP_URL, which uses ${
+				oidcAppUrlProtocol ?? "an unrecognized protocol"
+			}.`,
+			severity: "warning",
+			remediation:
+				"Set APP_URL in the container environment to the public https:// origin used by your OIDC provider.",
 		});
 	}
 

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -100,7 +100,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 	const effectiveSecureCookies = input.env.COOKIE_SECURE ?? input.env.TRUST_PROXY;
 	const isProduction = input.env.NODE_ENV === "production";
 	const passwordEnabled = input.passwordUserCount > 0;
-	const configuredPublicAppUrl = input.publicAppUrl?.trim();
+	const configuredPublicAppUrl = input.publicAppUrl || undefined;
 	const appUrl = configuredPublicAppUrl || input.env.APP_URL;
 	const appUrlSource = configuredPublicAppUrl ? "External URL" : "APP_URL";
 	const appUrlProtocol = safeProtocol(appUrl);
@@ -270,8 +270,8 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 			detail: `${appUrlSource} is not a valid public URL.`,
 			severity: "warning",
 			remediation: configuredPublicAppUrl
-				? "Update External URL in Settings → System to an http(s) URL without a query string, fragment, or repeated trailing slashes."
-				: "Set APP_URL to an http(s) URL without a query string, fragment, or repeated trailing slashes.",
+				? "Update External URL in Settings → System to an http(s) URL without surrounding whitespace, a query string, fragment, or repeated trailing slashes."
+				: "Set APP_URL to an http(s) URL without surrounding whitespace, a query string, fragment, or repeated trailing slashes.",
 		});
 	} else if (isProduction && !appUrlIsHttps) {
 		checks.push({
@@ -360,6 +360,7 @@ function isValidPublicBaseUrl(value: string): boolean {
 		const url = new URL(value);
 		return (
 			(url.protocol === "http:" || url.protocol === "https:") &&
+			value === value.trim() &&
 			!value.includes("?") &&
 			!value.includes("#") &&
 			!/\/{2,}$/.test(value)

--- a/apps/api/src/lib/security/security-posture.ts
+++ b/apps/api/src/lib/security/security-posture.ts
@@ -287,7 +287,7 @@ export function evaluateSecurityPosture(input: SecurityPostureInput): SecurityPo
 
 	// OIDC authentication uses the enabled provider's stored redirect URI.
 	// Check that actual callback independently from the public-link URL.
-	if (input.oidcEnabled && !oidcRedirectUriIsHttps) {
+	if (input.oidcEnabled && !oidcRedirectUriIsHttps && (isProduction || effectiveSecureCookies)) {
 		checks.push({
 			id: "oidc-app-url",
 			label: "OIDC Redirect URI",

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -256,6 +256,54 @@ describe("POST /auth/oidc/setup", () => {
 		expect(mockPrisma.$transaction).toHaveBeenCalled();
 	});
 
+	it("normalizes a trailing APP_URL slash when generating the callback", async () => {
+		Object.assign(app.config, { APP_URL: "https://arr.example.com/" });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it.each([
+		"https://admin:secret@arr.example.com/",
+		"ftp://arr.example.com/",
+		"mailto:admin@example.com",
+	])(
+		"rejects an unsafe APP_URL when generating the setup callback: %s",
+		async (appUrl) => {
+			Object.assign(app.config, { APP_URL: appUrl });
+
+			const res = await app.inject({
+				method: "POST",
+				url: "/auth/oidc/setup",
+				payload: {
+					displayName: "My OIDC Provider",
+					clientId: "my-client-id",
+					clientSecret: "my-client-secret",
+					issuer: "https://provider.example.com",
+				},
+			});
+
+			expect(res.statusCode).toBe(400);
+			expect(JSON.parse(res.payload).error).toContain("APP_URL");
+			expect(mockPrisma.oIDCProvider.create).not.toHaveBeenCalled();
+		},
+	);
+
 	it("returns 403 when users already exist", async () => {
 		// Make the transaction see existing users
 		mockPrisma.$transaction.mockImplementation(async (fn: any) => {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -257,7 +257,7 @@ describe("POST /auth/oidc/setup", () => {
 	});
 
 	it("normalizes a trailing APP_URL slash when generating the callback", async () => {
-		Object.assign(app.config, { APP_URL: "https://arr.example.com/" });
+		Object.assign(app.config, { APP_URL: "https://arr.example.com/dashboard/" });
 
 		const res = await app.inject({
 			method: "POST",
@@ -273,7 +273,7 @@ describe("POST /auth/oidc/setup", () => {
 		expect(res.statusCode).toBe(201);
 		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
 			data: expect.objectContaining({
-				redirectUri: "https://arr.example.com/auth/oidc/callback",
+				redirectUri: "https://arr.example.com/dashboard/auth/oidc/callback",
 			}),
 		});
 	});

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -195,6 +195,8 @@ describe("DELETE /api/oidc-providers", () => {
 			data: {
 				hashedPassword: expect.any(String),
 				mustChangePassword: false,
+				failedLoginAttempts: 0,
+				lockedUntil: null,
 			},
 		});
 		expect(deleteSessions).toHaveBeenLastCalledWith({});
@@ -221,6 +223,8 @@ describe("DELETE /api/oidc-providers", () => {
 			data: {
 				hashedPassword: expect.any(String),
 				mustChangePassword: false,
+				failedLoginAttempts: 0,
+				lockedUntil: null,
 			},
 		});
 		expect(deleteProvider).toHaveBeenCalled();
@@ -247,6 +251,8 @@ describe("DELETE /api/oidc-providers", () => {
 			data: {
 				hashedPassword: expect.any(String),
 				mustChangePassword: false,
+				failedLoginAttempts: 0,
+				lockedUntil: null,
 			},
 		});
 	});

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -2,6 +2,16 @@ import Fastify, { type FastifyRequest } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import oidcProvidersRoutes from "../oidc-providers.js";
 
+vi.mock("../../lib/auth/password.js", () => ({
+	hashPassword: vi.fn().mockResolvedValue("$argon2id$replacement-password"),
+	verifyPassword: vi
+		.fn()
+		.mockImplementation(
+			async (password: string, hash: string) =>
+				password === "CurrentPassword1!" && hash === "$argon2id$existing-admin-password",
+		),
+}));
+
 vi.mock("../../lib/auth/oidc-utils.js", () => ({
 	resolveCanonicalIssuer: vi.fn().mockResolvedValue({
 		issuer: "https://auth.example.com/application/o/arr-dashboard/",
@@ -30,7 +40,9 @@ const findUniqueProvider = vi.fn();
 const deleteProvider = vi.fn();
 const deleteOidcAccounts = vi.fn();
 const findOidcOnlyUsers = vi.fn();
+const findUniqueUser = vi.fn();
 const updateUser = vi.fn();
+const updateManyUsers = vi.fn();
 const runTransaction = vi.fn();
 const deleteSessions = vi.fn();
 const clearCookie = vi.fn();
@@ -42,7 +54,9 @@ beforeEach(async () => {
 	deleteProvider.mockReset();
 	deleteOidcAccounts.mockReset();
 	findOidcOnlyUsers.mockReset();
+	findUniqueUser.mockReset();
 	updateUser.mockReset();
+	updateManyUsers.mockReset();
 	runTransaction.mockReset();
 	deleteSessions.mockReset();
 	clearCookie.mockReset();
@@ -51,13 +65,20 @@ beforeEach(async () => {
 	deleteProvider.mockResolvedValue({ count: 1 });
 	deleteOidcAccounts.mockResolvedValue({ count: 1 });
 	findOidcOnlyUsers.mockResolvedValue([{ id: "admin-user", hashedPassword: null }]);
+	findUniqueUser.mockResolvedValue({ hashedPassword: null });
 	updateUser.mockResolvedValue({ id: "admin-user" });
+	updateManyUsers.mockResolvedValue({ count: 1 });
 	deleteSessions.mockResolvedValue({ count: 1 });
 	runTransaction.mockImplementation(async (callback) =>
 		callback({
 			oIDCProvider: { deleteMany: deleteProvider },
 			oIDCAccount: { deleteMany: deleteOidcAccounts },
-			user: { findMany: findOidcOnlyUsers, update: updateUser },
+			user: {
+				findMany: findOidcOnlyUsers,
+				findUnique: findUniqueUser,
+				update: updateUser,
+				updateMany: updateManyUsers,
+			},
 			session: { deleteMany: deleteSessions },
 		}),
 	);
@@ -69,7 +90,7 @@ beforeEach(async () => {
 			findUnique: findUniqueProvider,
 		},
 		oIDCAccount: { findFirst: findLinkedAccount },
-		user: { findMany: findOidcOnlyUsers },
+		user: { findMany: findOidcOnlyUsers, findUnique: findUniqueUser },
 		session: { deleteMany: deleteSessions },
 		$transaction: runTransaction,
 	});
@@ -190,8 +211,8 @@ describe("DELETE /api/oidc-providers", () => {
 			},
 			select: { id: true, hashedPassword: true },
 		});
-		expect(updateUser).toHaveBeenCalledWith({
-			where: { id: "admin-user" },
+		expect(updateManyUsers).toHaveBeenCalledWith({
+			where: { id: "admin-user", hashedPassword: null },
 			data: {
 				hashedPassword: expect.any(String),
 				mustChangePassword: false,
@@ -207,19 +228,28 @@ describe("DELETE /api/oidc-providers", () => {
 	});
 
 	it("replaces the current admin password while deleting OIDC", async () => {
+		findUniqueUser.mockResolvedValueOnce({
+			hashedPassword: "$argon2id$existing-admin-password",
+		});
 		findOidcOnlyUsers.mockResolvedValueOnce([
-			{ id: "admin-user", hashedPassword: "$argon2id$existing-password" },
+			{ id: "admin-user", hashedPassword: "$argon2id$existing-admin-password" },
 		]);
 
 		const response = await app.inject({
 			method: "DELETE",
 			url: "/api/oidc-providers",
-			payload: { replacementPassword: "Safe-Replacement1!" },
+			payload: {
+				currentPassword: "CurrentPassword1!",
+				replacementPassword: "Safe-Replacement1!",
+			},
 		});
 
 		expect(response.statusCode).toBe(204);
-		expect(updateUser).toHaveBeenCalledWith({
-			where: { id: "admin-user" },
+		expect(updateManyUsers).toHaveBeenCalledWith({
+			where: {
+				id: "admin-user",
+				hashedPassword: "$argon2id$existing-admin-password",
+			},
 			data: {
 				hashedPassword: expect.any(String),
 				mustChangePassword: false,
@@ -233,6 +263,9 @@ describe("DELETE /api/oidc-providers", () => {
 	});
 
 	it("preserves another linked user's existing password", async () => {
+		findUniqueUser.mockResolvedValueOnce({
+			hashedPassword: "$argon2id$existing-admin-password",
+		});
 		findOidcOnlyUsers.mockResolvedValueOnce([
 			{ id: "admin-user", hashedPassword: "$argon2id$existing-admin-password" },
 			{ id: "other-user", hashedPassword: "$argon2id$existing-password" },
@@ -241,20 +274,70 @@ describe("DELETE /api/oidc-providers", () => {
 		const response = await app.inject({
 			method: "DELETE",
 			url: "/api/oidc-providers",
-			payload: { replacementPassword: "Safe-Replacement1!" },
+			payload: {
+				currentPassword: "CurrentPassword1!",
+				replacementPassword: "Safe-Replacement1!",
+			},
 		});
 
 		expect(response.statusCode).toBe(204);
-		expect(updateUser).toHaveBeenCalledTimes(1);
-		expect(updateUser).toHaveBeenCalledWith({
-			where: { id: "admin-user" },
-			data: {
-				hashedPassword: expect.any(String),
-				mustChangePassword: false,
-				failedLoginAttempts: 0,
-				lockedUntil: null,
+		expect(updateManyUsers).toHaveBeenCalledTimes(1);
+		expect(updateUser).not.toHaveBeenCalled();
+	});
+
+	it("requires the current password before replacing an existing admin password", async () => {
+		findUniqueUser.mockResolvedValueOnce({
+			hashedPassword: "$argon2id$existing-admin-password",
+		});
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(JSON.parse(response.payload).error).toContain("Current password is required");
+		expect(runTransaction).not.toHaveBeenCalled();
+	});
+
+	it("rejects an incorrect current password before deleting OIDC", async () => {
+		findUniqueUser.mockResolvedValueOnce({
+			hashedPassword: "$argon2id$existing-admin-password",
+		});
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: {
+				currentPassword: "WrongPassword1!",
+				replacementPassword: "Safe-Replacement1!",
 			},
 		});
+
+		expect(response.statusCode).toBe(401);
+		expect(JSON.parse(response.payload).error).toContain("Current password is incorrect");
+		expect(runTransaction).not.toHaveBeenCalled();
+	});
+
+	it("rolls back deletion when the verified admin credential changes", async () => {
+		findUniqueUser.mockResolvedValueOnce({
+			hashedPassword: "$argon2id$existing-admin-password",
+		});
+		updateManyUsers.mockResolvedValueOnce({ count: 0 });
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: {
+				currentPassword: "CurrentPassword1!",
+				replacementPassword: "Safe-Replacement1!",
+			},
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(JSON.parse(response.payload).error).toContain("password changed");
+		expect(deleteOidcAccounts).not.toHaveBeenCalled();
 	});
 
 	it("does not remove links when the provider changed before deletion acquired it", async () => {
@@ -304,7 +387,7 @@ describe("DELETE /api/oidc-providers", () => {
 		expect(response.statusCode).toBe(500);
 		expect(runTransaction).toHaveBeenCalledTimes(1);
 		expect(deleteProvider).toHaveBeenCalled();
-		expect(updateUser).toHaveBeenCalled();
+		expect(updateManyUsers).toHaveBeenCalled();
 		expect(deleteOidcAccounts).toHaveBeenCalled();
 		expect(deleteSessions).toHaveBeenCalledWith({});
 		expect(clearCookie).not.toHaveBeenCalled();

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -2,6 +2,13 @@ import Fastify, { type FastifyRequest } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import oidcProvidersRoutes from "../oidc-providers.js";
 
+vi.mock("../../lib/auth/oidc-utils.js", () => ({
+	resolveCanonicalIssuer: vi.fn().mockResolvedValue({
+		issuer: "https://auth.example.com/application/o/arr-dashboard/",
+		source: "discovery",
+	}),
+}));
+
 const provider = {
 	id: 1,
 	displayName: "Authentik",
@@ -67,6 +74,10 @@ beforeEach(async () => {
 		$transaction: runTransaction,
 	});
 	app.decorate("sessionService", { clearCookie });
+	app.decorate("config", { APP_URL: "https://arr.example.com" });
+	app.decorate("encryptor", {
+		encrypt: vi.fn().mockReturnValue({ value: "encrypted", iv: "iv" }),
+	});
 	app.decorateRequest("currentUser", null);
 	app.decorateRequest("sessionToken", null);
 	app.addHook("preHandler", async (request: FastifyRequest) => {
@@ -116,6 +127,34 @@ describe("GET /api/oidc-providers", () => {
 	});
 });
 
+describe("POST /api/oidc-providers", () => {
+	it.each([
+		"https://admin:secret@arr.example.com/",
+		"ftp://arr.example.com/",
+		"mailto:admin@example.com",
+	])(
+		"rejects an unsafe APP_URL when generating the admin callback: %s",
+		async (appUrl) => {
+			Object.assign(app.config, { APP_URL: appUrl });
+
+			const response = await app.inject({
+				method: "POST",
+				url: "/api/oidc-providers",
+				payload: {
+					displayName: "Authentik",
+					clientId: "arr-dashboard",
+					clientSecret: "secret",
+					issuer: "https://auth.example.com",
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(JSON.parse(response.payload).error).toContain("APP_URL");
+			expect(findProvider).not.toHaveBeenCalled();
+		},
+	);
+});
+
 describe("DELETE /api/oidc-providers", () => {
 	it("deletes the exact provider and its links in one transaction", async () => {
 		const response = await app.inject({
@@ -146,7 +185,9 @@ describe("DELETE /api/oidc-providers", () => {
 		});
 		expect(deleteOidcAccounts).toHaveBeenCalledWith({});
 		expect(findOidcOnlyUsers).toHaveBeenCalledWith({
-			where: { oidcAccounts: { some: {} } },
+			where: {
+				OR: [{ id: "admin-user" }, { oidcAccounts: { some: {} } }],
+			},
 			select: { id: true, hashedPassword: true },
 		});
 		expect(updateUser).toHaveBeenCalledWith({
@@ -163,7 +204,7 @@ describe("DELETE /api/oidc-providers", () => {
 		expect(clearCookie).toHaveBeenCalledWith(expect.anything());
 	});
 
-	it("preserves an existing password while deleting OIDC", async () => {
+	it("replaces the current admin password while deleting OIDC", async () => {
 		findOidcOnlyUsers.mockResolvedValueOnce([
 			{ id: "admin-user", hashedPassword: "$argon2id$existing-password" },
 		]);
@@ -175,10 +216,39 @@ describe("DELETE /api/oidc-providers", () => {
 		});
 
 		expect(response.statusCode).toBe(204);
-		expect(updateUser).not.toHaveBeenCalled();
+		expect(updateUser).toHaveBeenCalledWith({
+			where: { id: "admin-user" },
+			data: {
+				hashedPassword: expect.any(String),
+				mustChangePassword: false,
+			},
+		});
 		expect(deleteProvider).toHaveBeenCalled();
 		expect(deleteOidcAccounts).toHaveBeenCalled();
 		expect(deleteSessions).toHaveBeenLastCalledWith({});
+	});
+
+	it("preserves another linked user's existing password", async () => {
+		findOidcOnlyUsers.mockResolvedValueOnce([
+			{ id: "admin-user", hashedPassword: "$argon2id$existing-admin-password" },
+			{ id: "other-user", hashedPassword: "$argon2id$existing-password" },
+		]);
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(204);
+		expect(updateUser).toHaveBeenCalledTimes(1);
+		expect(updateUser).toHaveBeenCalledWith({
+			where: { id: "admin-user" },
+			data: {
+				hashedPassword: expect.any(String),
+				mustChangePassword: false,
+			},
+		});
 	});
 
 	it("does not remove links when the provider changed before deletion acquired it", async () => {

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -99,6 +99,25 @@ describe("PUT /system/settings", () => {
 		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("https://arr.example.com");
 	});
 
+	it.each([
+		["https://arr.example.com\\proxy", "https://arr.example.com/proxy"],
+		["https://arr.example.com/\tproxy", "https://arr.example.com/proxy"],
+	])("persists the parser-canonical External URL: %s", async (externalUrl, expected) => {
+		const res = await injectAuthenticated("PUT", "/system/settings", {
+			body: { externalUrl },
+		});
+
+		expect(res.statusCode, res.payload).toBe(200);
+		expect(JSON.parse(res.payload).data.externalUrl).toBe(expected);
+		expect(mockPrisma.systemSettings.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				update: expect.objectContaining({ externalUrl: expected }),
+				create: expect.objectContaining({ externalUrl: expected }),
+			}),
+		);
+		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith(expected);
+	});
+
 	it("clears a whitespace-only External URL and restores the APP_URL fallback", async () => {
 		const res = await injectAuthenticated("PUT", "/system/settings", {
 			body: { externalUrl: "   " },
@@ -166,6 +185,8 @@ describe("GET /system/security-posture", () => {
 	it.each([
 		" https://arr.example.com ",
 		"https://admin:secret@arr.example.com",
+		"https://arr.example.com\\proxy",
+		"https://arr.example.com/\tproxy",
 		"https://arr.example.com?source=proxy",
 	])(
 		"warns when a legacy persisted External URL is not a valid public base: %s",
@@ -207,7 +228,7 @@ describe("GET /system/security-posture", () => {
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({
 			redirectUri: "https://arr.example.com/auth/oidc/callback",
 		});
-		mockPrisma.webAuthnCredential.count.mockResolvedValue(0);
+		mockPrisma.webAuthnCredential.count.mockResolvedValue(1);
 
 		const res = await injectAuthenticated("GET", "/system/security-posture");
 
@@ -216,12 +237,16 @@ describe("GET /system/security-posture", () => {
 		const authentication = body.data.checks.find(
 			(check: { id: string }) => check.id === "authentication",
 		);
+		const oidcAccountLink = body.data.checks.find(
+			(check: { id: string }) => check.id === "oidc-account-link",
+		);
 		expect(body.data.auth.oidcEnabled).toBe(false);
 		expect(body.data.auth.oidcProviderEnabled).toBe(true);
 		expect(authentication).toMatchObject({
-			severity: "warning",
-			detail: "Password-only authentication is in use.",
+			severity: "healthy",
 		});
+		expect(oidcAccountLink).toMatchObject({ severity: "warning" });
+		expect(body.data.overall).toBe("warning");
 		expect(mockPrisma.oIDCAccount.findFirst).toHaveBeenCalledWith({
 			where: { userId: "user-1" },
 			select: { id: true },

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -69,7 +69,7 @@ describe("GET /system/security-posture", () => {
 
 		expect(appUrlCheck).toMatchObject({
 			severity: "healthy",
-			detail: "https://arr.example.com",
+			detail: "External URL uses HTTPS.",
 		});
 		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
 	});

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -82,21 +82,21 @@ afterAll(async () => {
 });
 
 describe("PUT /system/settings", () => {
-	it("trims External URL and updates the live notification base URL", async () => {
+	it("trims External URL, removes trailing slashes, and updates the live base URL", async () => {
 		const res = await injectAuthenticated("PUT", "/system/settings", {
-			body: { externalUrl: "  https://arr.example.com/  " },
+			body: { externalUrl: "  https://arr.example.com///  " },
 		});
 
 		expect(res.statusCode, res.payload).toBe(200);
 		const body = JSON.parse(res.payload);
-		expect(body.data.externalUrl).toBe("https://arr.example.com/");
+		expect(body.data.externalUrl).toBe("https://arr.example.com");
 		expect(mockPrisma.systemSettings.upsert).toHaveBeenCalledWith(
 			expect.objectContaining({
-				update: expect.objectContaining({ externalUrl: "https://arr.example.com/" }),
-				create: expect.objectContaining({ externalUrl: "https://arr.example.com/" }),
+				update: expect.objectContaining({ externalUrl: "https://arr.example.com" }),
+				create: expect.objectContaining({ externalUrl: "https://arr.example.com" }),
 			}),
 		);
-		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("https://arr.example.com/");
+		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("https://arr.example.com");
 	});
 
 	it("clears a whitespace-only External URL and restores the APP_URL fallback", async () => {

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -1,0 +1,76 @@
+/**
+ * GET /system/security-posture HTTP integration tests.
+ *
+ * The route combines runtime environment values with database-backed system
+ * settings. Keep the reverse-proxy External URL path covered here so the
+ * security diagnostic reports the same public origin configured in Settings.
+ */
+
+import Fastify from "fastify";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerSystemRoutes } from "../system.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+let app: ReturnType<typeof Fastify>;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let mockPrisma: {
+	systemSettings: { findUnique: ReturnType<typeof vi.fn> };
+	oIDCProvider: { findFirst: ReturnType<typeof vi.fn> };
+	webAuthnCredential: { count: ReturnType<typeof vi.fn> };
+	user: { count: ReturnType<typeof vi.fn> };
+};
+
+beforeEach(async () => {
+	mockPrisma = {
+		systemSettings: {
+			findUnique: vi.fn().mockResolvedValue({
+				externalUrl: "https://arr.example.com",
+			}),
+		},
+		oIDCProvider: { findFirst: vi.fn().mockResolvedValue(null) },
+		webAuthnCredential: { count: vi.fn().mockResolvedValue(1) },
+		user: { count: vi.fn().mockResolvedValue(1) },
+	};
+
+	app = Fastify();
+	app.decorate("prisma", mockPrisma as never);
+	app.decorate("config", {
+		NODE_ENV: "production",
+		TRUST_PROXY: true,
+		COOKIE_SECURE: true,
+		SESSION_TTL_HOURS: 24,
+		SESSION_COOKIE_NAME: "arr_session",
+		PASSWORD_POLICY: "strict",
+		APP_URL: "http://localhost:3000",
+	} as never);
+	app.decorate("dbProvider", "sqlite" as never);
+	app.decorate("lifecycle", {
+		getRestartMessage: () => "ok",
+		restart: vi.fn(),
+	} as never);
+
+	setupAuthInjection(app);
+	await app.register(registerSystemRoutes, { prefix: "/system" });
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("GET /system/security-posture", () => {
+	it("uses the configured HTTPS External URL instead of the APP_URL fallback", async () => {
+		const res = await injectAuthenticated("GET", "/system/security-posture");
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		const appUrlCheck = body.data.checks.find((check: { id: string }) => check.id === "app-url");
+
+		expect(appUrlCheck).toMatchObject({
+			severity: "healthy",
+			detail: "https://arr.example.com",
+		});
+		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
+	});
+});

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -150,24 +150,25 @@ describe("GET /system/security-posture", () => {
 		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
 	});
 
-	it("warns when a legacy persisted External URL is not a valid public base", async () => {
-		mockPrisma.systemSettings.findUnique.mockResolvedValue({
-			externalUrl: "https://arr.example.com?source=proxy",
-		});
+	it.each([" https://arr.example.com ", "https://arr.example.com?source=proxy"])(
+		"warns when a legacy persisted External URL is not a valid public base: %s",
+		async (externalUrl) => {
+			mockPrisma.systemSettings.findUnique.mockResolvedValue({ externalUrl });
 
-		const res = await injectAuthenticated("GET", "/system/security-posture");
+			const res = await injectAuthenticated("GET", "/system/security-posture");
 
-		expect(res.statusCode, res.payload).toBe(200);
-		const body = JSON.parse(res.payload);
-		const appUrlCheck = body.data.checks.find((check: { id: string }) => check.id === "app-url");
+			expect(res.statusCode, res.payload).toBe(200);
+			const body = JSON.parse(res.payload);
+			const appUrlCheck = body.data.checks.find((check: { id: string }) => check.id === "app-url");
 
-		expect(appUrlCheck).toMatchObject({
-			severity: "warning",
-			detail: "External URL is not a valid public URL.",
-			remediation: expect.stringContaining("without a query string, fragment"),
-		});
-		expect(body.data.effective.appUrl).toBe("https://arr.example.com?source=proxy");
-	});
+			expect(appUrlCheck).toMatchObject({
+				severity: "warning",
+				detail: "External URL is not a valid public URL.",
+				remediation: expect.stringContaining("without surrounding whitespace"),
+			});
+			expect(body.data.effective.appUrl).toBe(externalUrl);
+		},
+	);
 
 	it("checks the enabled provider's stored redirect URI instead of APP_URL", async () => {
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -73,4 +73,20 @@ describe("GET /system/security-posture", () => {
 		});
 		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
 	});
+
+	it("checks the enabled provider's stored redirect URI instead of APP_URL", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+		});
+
+		const res = await injectAuthenticated("GET", "/system/security-posture");
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.data.checks).not.toContainEqual(expect.objectContaining({ id: "oidc-app-url" }));
+		expect(mockPrisma.oIDCProvider.findFirst).toHaveBeenCalledWith({
+			where: { enabled: true },
+			select: { redirectUri: true },
+		});
+	});
 });

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -107,6 +107,30 @@ describe("PUT /system/settings", () => {
 		expect(body.data.externalUrl).toBeNull();
 		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("http://localhost:3000");
 	});
+	it("rejects a non-string External URL without persisting it", async () => {
+		const res = await injectAuthenticated("PUT", "/system/settings", {
+			body: { externalUrl: 123 },
+		});
+
+		expect(res.statusCode, res.payload).toBe(400);
+		expect(mockPrisma.systemSettings.upsert).not.toHaveBeenCalled();
+		expect(mockNotificationService.setBaseUrl).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		"https://arr.example.com?source=proxy",
+		"https://arr.example.com#settings",
+		"https://arr.example.com?",
+		"https://arr.example.com#",
+	])("rejects an External URL with a query or fragment: %s", async (externalUrl) => {
+		const res = await injectAuthenticated("PUT", "/system/settings", {
+			body: { externalUrl },
+		});
+
+		expect(res.statusCode, res.payload).toBe(400);
+		expect(mockPrisma.systemSettings.upsert).not.toHaveBeenCalled();
+		expect(mockNotificationService.setBaseUrl).not.toHaveBeenCalled();
+	});
 });
 
 describe("GET /system/security-posture", () => {

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -133,6 +133,19 @@ describe("PUT /system/settings", () => {
 		expect(mockPrisma.systemSettings.upsert).not.toHaveBeenCalled();
 		expect(mockNotificationService.setBaseUrl).not.toHaveBeenCalled();
 	});
+
+	it.each(["https://admin@arr.example.com", "https://admin:secret@arr.example.com"])(
+		"rejects an External URL containing credentials: %s",
+		async (externalUrl) => {
+			const res = await injectAuthenticated("PUT", "/system/settings", {
+				body: { externalUrl },
+			});
+
+			expect(res.statusCode, res.payload).toBe(400);
+			expect(mockPrisma.systemSettings.upsert).not.toHaveBeenCalled();
+			expect(mockNotificationService.setBaseUrl).not.toHaveBeenCalled();
+		},
+	);
 });
 
 describe("GET /system/security-posture", () => {
@@ -150,7 +163,11 @@ describe("GET /system/security-posture", () => {
 		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
 	});
 
-	it.each([" https://arr.example.com ", "https://arr.example.com?source=proxy"])(
+	it.each([
+		" https://arr.example.com ",
+		"https://admin:secret@arr.example.com",
+		"https://arr.example.com?source=proxy",
+	])(
 		"warns when a legacy persisted External URL is not a valid public base: %s",
 		async (externalUrl) => {
 			mockPrisma.systemSettings.findUnique.mockResolvedValue({ externalUrl });
@@ -164,7 +181,7 @@ describe("GET /system/security-posture", () => {
 			expect(appUrlCheck).toMatchObject({
 				severity: "warning",
 				detail: "External URL is not a valid public URL.",
-				remediation: expect.stringContaining("without surrounding whitespace"),
+				remediation: expect.stringContaining("without embedded credentials"),
 			});
 			expect(body.data.effective.appUrl).toBe(externalUrl);
 		},

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -19,6 +19,7 @@ let mockPrisma: {
 		upsert: ReturnType<typeof vi.fn>;
 	};
 	oIDCProvider: { findFirst: ReturnType<typeof vi.fn> };
+	oIDCAccount: { findFirst: ReturnType<typeof vi.fn> };
 	webAuthnCredential: { count: ReturnType<typeof vi.fn> };
 	user: { count: ReturnType<typeof vi.fn> };
 };
@@ -46,6 +47,7 @@ beforeEach(async () => {
 			),
 		},
 		oIDCProvider: { findFirst: vi.fn().mockResolvedValue(null) },
+		oIDCAccount: { findFirst: vi.fn().mockResolvedValue(null) },
 		webAuthnCredential: { count: vi.fn().mockResolvedValue(1) },
 		user: { count: vi.fn().mockResolvedValue(1) },
 	};
@@ -162,5 +164,48 @@ describe("GET /system/security-posture", () => {
 			where: { enabled: true },
 			select: { redirectUri: true },
 		});
+	});
+
+	it("does not report OIDC as active until the current admin is linked", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+		});
+		mockPrisma.webAuthnCredential.count.mockResolvedValue(0);
+
+		const res = await injectAuthenticated("GET", "/system/security-posture");
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		const authentication = body.data.checks.find(
+			(check: { id: string }) => check.id === "authentication",
+		);
+		expect(body.data.auth.oidcEnabled).toBe(false);
+		expect(authentication).toMatchObject({
+			severity: "warning",
+			detail: "Password-only authentication is in use.",
+		});
+		expect(mockPrisma.oIDCAccount.findFirst).toHaveBeenCalledWith({
+			where: { userId: "user-1" },
+			select: { id: true },
+		});
+	});
+
+	it("reports OIDC as active when the enabled provider is linked to the current admin", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+		});
+		mockPrisma.oIDCAccount.findFirst.mockResolvedValue({ id: "oidc-account-1" });
+
+		const res = await injectAuthenticated("GET", "/system/security-posture");
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.data.auth.oidcEnabled).toBe(true);
+		expect(body.data.checks).toContainEqual(
+			expect.objectContaining({
+				id: "authentication",
+				detail: expect.stringContaining("OIDC"),
+			}),
+		);
 	});
 });

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -1,9 +1,9 @@
 /**
- * GET /system/security-posture HTTP integration tests.
+ * System External URL and security-posture HTTP integration tests.
  *
  * The route combines runtime environment values with database-backed system
- * settings. Keep the reverse-proxy External URL path covered here so the
- * security diagnostic reports the same public origin configured in Settings.
+ * settings. Keep External URL persistence, live notification updates, and
+ * posture diagnostics aligned with the same public origin.
  */
 
 import Fastify from "fastify";
@@ -14,11 +14,15 @@ import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js
 let app: ReturnType<typeof Fastify>;
 let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
 let mockPrisma: {
-	systemSettings: { findUnique: ReturnType<typeof vi.fn> };
+	systemSettings: {
+		findUnique: ReturnType<typeof vi.fn>;
+		upsert: ReturnType<typeof vi.fn>;
+	};
 	oIDCProvider: { findFirst: ReturnType<typeof vi.fn> };
 	webAuthnCredential: { count: ReturnType<typeof vi.fn> };
 	user: { count: ReturnType<typeof vi.fn> };
 };
+let mockNotificationService: { setBaseUrl: ReturnType<typeof vi.fn> };
 
 beforeEach(async () => {
 	mockPrisma = {
@@ -26,11 +30,26 @@ beforeEach(async () => {
 			findUnique: vi.fn().mockResolvedValue({
 				externalUrl: "https://arr.example.com",
 			}),
+			upsert: vi.fn().mockImplementation(({ update, create }) =>
+				Promise.resolve({
+					apiPort: 3001,
+					webPort: 3000,
+					listenAddress: process.env.HOST || process.env.HOSTNAME || "0.0.0.0",
+					appName: "Arr Dashboard",
+					externalUrl: null,
+					trustProxy: true,
+					secureCookies: true,
+					updatedAt: new Date(),
+					...create,
+					...update,
+				}),
+			),
 		},
 		oIDCProvider: { findFirst: vi.fn().mockResolvedValue(null) },
 		webAuthnCredential: { count: vi.fn().mockResolvedValue(1) },
 		user: { count: vi.fn().mockResolvedValue(1) },
 	};
+	mockNotificationService = { setBaseUrl: vi.fn() };
 
 	app = Fastify();
 	app.decorate("prisma", mockPrisma as never);
@@ -44,6 +63,7 @@ beforeEach(async () => {
 		APP_URL: "http://localhost:3000",
 	} as never);
 	app.decorate("dbProvider", "sqlite" as never);
+	app.decorate("notificationService", mockNotificationService as never);
 	app.decorate("lifecycle", {
 		getRestartMessage: () => "ok",
 		restart: vi.fn(),
@@ -57,6 +77,36 @@ beforeEach(async () => {
 
 afterAll(async () => {
 	await app?.close();
+});
+
+describe("PUT /system/settings", () => {
+	it("trims External URL and updates the live notification base URL", async () => {
+		const res = await injectAuthenticated("PUT", "/system/settings", {
+			body: { externalUrl: "  https://arr.example.com/  " },
+		});
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.data.externalUrl).toBe("https://arr.example.com/");
+		expect(mockPrisma.systemSettings.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				update: expect.objectContaining({ externalUrl: "https://arr.example.com/" }),
+				create: expect.objectContaining({ externalUrl: "https://arr.example.com/" }),
+			}),
+		);
+		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("https://arr.example.com/");
+	});
+
+	it("clears a whitespace-only External URL and restores the APP_URL fallback", async () => {
+		const res = await injectAuthenticated("PUT", "/system/settings", {
+			body: { externalUrl: "   " },
+		});
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		expect(body.data.externalUrl).toBeNull();
+		expect(mockNotificationService.setBaseUrl).toHaveBeenCalledWith("http://localhost:3000");
+	});
 });
 
 describe("GET /system/security-posture", () => {

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -150,6 +150,25 @@ describe("GET /system/security-posture", () => {
 		expect(body.data.effective.appUrl).toBe("https://arr.example.com");
 	});
 
+	it("warns when a legacy persisted External URL is not a valid public base", async () => {
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "https://arr.example.com?source=proxy",
+		});
+
+		const res = await injectAuthenticated("GET", "/system/security-posture");
+
+		expect(res.statusCode, res.payload).toBe(200);
+		const body = JSON.parse(res.payload);
+		const appUrlCheck = body.data.checks.find((check: { id: string }) => check.id === "app-url");
+
+		expect(appUrlCheck).toMatchObject({
+			severity: "warning",
+			detail: "External URL is not a valid public URL.",
+			remediation: expect.stringContaining("without a query string, fragment"),
+		});
+		expect(body.data.effective.appUrl).toBe("https://arr.example.com?source=proxy");
+	});
+
 	it("checks the enabled provider's stored redirect URI instead of APP_URL", async () => {
 		mockPrisma.oIDCProvider.findFirst.mockResolvedValue({
 			redirectUri: "https://arr.example.com/auth/oidc/callback",

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -180,6 +180,7 @@ describe("GET /system/security-posture", () => {
 			(check: { id: string }) => check.id === "authentication",
 		);
 		expect(body.data.auth.oidcEnabled).toBe(false);
+		expect(body.data.auth.oidcProviderEnabled).toBe(true);
 		expect(authentication).toMatchObject({
 			severity: "warning",
 			detail: "Password-only authentication is in use.",
@@ -201,6 +202,7 @@ describe("GET /system/security-posture", () => {
 		expect(res.statusCode, res.payload).toBe(200);
 		const body = JSON.parse(res.payload);
 		expect(body.data.auth.oidcEnabled).toBe(true);
+		expect(body.data.auth.oidcProviderEnabled).toBe(true);
 		expect(body.data.checks).toContainEqual(
 			expect.objectContaining({
 				id: "authentication",

--- a/apps/api/src/routes/__tests__/system-security-posture.test.ts
+++ b/apps/api/src/routes/__tests__/system-security-posture.test.ts
@@ -187,6 +187,7 @@ describe("GET /system/security-posture", () => {
 		"https://admin:secret@arr.example.com",
 		"https://arr.example.com\\proxy",
 		"https://arr.example.com/\tproxy",
+		"https://arr.example.com/base path",
 		"https://arr.example.com?source=proxy",
 	])(
 		"warns when a legacy persisted External URL is not a valid public base: %s",

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import { oidcRedirectUriSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import * as oauth from "oauth4webapi";
 import { z } from "zod";
@@ -62,7 +63,7 @@ const oidcSetupSchema = z.object({
 	clientId: z.string().min(1),
 	clientSecret: z.string().min(1),
 	issuer: z.string().url(),
-	redirectUri: z.string().url().optional(),
+	redirectUri: oidcRedirectUriSchema.optional(),
 	scopes: z.string().default("openid,email,profile"),
 });
 

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -9,6 +9,7 @@ import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
 import { getSessionMetadata } from "../lib/auth/session-metadata.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { validateRequest } from "../lib/utils/validate.js";
+import { buildOidcRedirectUriFromAppUrl } from "../lib/auth/oidc-redirect-uri.js";
 
 /**
  * In-memory storage for OIDC states and nonces (production: use Redis)
@@ -141,7 +142,14 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					});
 				}
 			} else {
-				redirectUri = `${app.config.APP_URL}/auth/oidc/callback`;
+				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(app.config.APP_URL);
+				if (!generatedRedirectUri) {
+					return reply.status(400).send({
+						error:
+							"APP_URL must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
+					});
+				}
+				redirectUri = generatedRedirectUri;
 				request.log.info({ redirectUri }, "Auto-generated redirect URI from APP_URL");
 			}
 

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -362,6 +362,8 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 								data: {
 									hashedPassword,
 									mustChangePassword: !isCurrentAdmin,
+									failedLoginAttempts: 0,
+									lockedUntil: null,
 								},
 							});
 							replacedUsers += 1;

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -8,6 +8,7 @@ import {
 	updateOidcProviderSchema,
 } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
+import { buildOidcRedirectUriFromAppUrl } from "../lib/auth/oidc-redirect-uri.js";
 import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
 import { hashPassword } from "../lib/auth/password.js";
 import type { Prisma, OIDCProvider as PrismaOIDCProvider } from "../lib/prisma.js";
@@ -100,7 +101,14 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 			// Only fall back to request headers when TRUST_PROXY is enabled (headers are validated by Fastify).
 			let redirectUri = data.redirectUri;
 			if (!redirectUri) {
-				redirectUri = `${app.config.APP_URL}/auth/oidc/callback`;
+				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(app.config.APP_URL);
+				if (!generatedRedirectUri) {
+					return reply.status(400).send({
+						error:
+							"APP_URL must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
+					});
+				}
+				redirectUri = generatedRedirectUri;
 				request.log.info({ redirectUri }, "Auto-generated redirect URI from APP_URL");
 			}
 
@@ -336,18 +344,24 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 
 					// The provider lock prevents new links from being created while this
 					// snapshot is installed with a replacement password.
-					const linkedUsers = await tx.user.findMany({
-						where: { oidcAccounts: { some: {} } },
+					const affectedUsers = await tx.user.findMany({
+						where: {
+							OR: [
+								{ id: request.currentUser!.id },
+								{ oidcAccounts: { some: {} } },
+							],
+						},
 						select: { id: true, hashedPassword: true },
 					});
 					let replacedUsers = 0;
-					for (const user of linkedUsers) {
-						if (!user.hashedPassword) {
+					for (const user of affectedUsers) {
+						const isCurrentAdmin = user.id === request.currentUser!.id;
+						if (isCurrentAdmin || !user.hashedPassword) {
 							await tx.user.update({
 								where: { id: user.id },
 								data: {
 									hashedPassword,
-									mustChangePassword: user.id !== request.currentUser!.id,
+									mustChangePassword: !isCurrentAdmin,
 								},
 							});
 							replacedUsers += 1;

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -10,13 +10,14 @@ import {
 import type { FastifyInstance } from "fastify";
 import { buildOidcRedirectUriFromAppUrl } from "../lib/auth/oidc-redirect-uri.js";
 import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
-import { hashPassword } from "../lib/auth/password.js";
+import { hashPassword, verifyPassword } from "../lib/auth/password.js";
 import type { Prisma, OIDCProvider as PrismaOIDCProvider } from "../lib/prisma.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
 const OIDC_PROVIDER_CHANGED = "OIDC_PROVIDER_CHANGED";
 const OIDC_SESSION_INACTIVE = "OIDC_SESSION_INACTIVE";
+const OIDC_ADMIN_AUTH_CHANGED = "OIDC_ADMIN_AUTH_CHANGED";
 
 /**
  * Transform a Prisma OIDCProvider model to the public DTO shape
@@ -287,7 +288,7 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 				});
 			}
 
-			const { replacementPassword } = validation.data;
+			const { replacementPassword, currentPassword } = validation.data;
 
 			// Check if provider exists (singleton with id=1)
 			const existing = await app.prisma.oIDCProvider.findUnique({
@@ -296,6 +297,26 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 
 			if (!existing) {
 				return reply.status(404).send({ error: "OIDC provider not found" });
+			}
+
+			const currentAdmin = await app.prisma.user.findUnique({
+				where: { id: request.currentUser!.id },
+				select: { hashedPassword: true },
+			});
+			if (!currentAdmin) {
+				return reply.status(404).send({ error: "User not found" });
+			}
+			if (currentAdmin.hashedPassword) {
+				if (!currentPassword) {
+					return reply
+						.status(400)
+						.send({ error: "Current password is required to replace your password" });
+				}
+				const valid = await verifyPassword(currentPassword, currentAdmin.hashedPassword);
+				if (!valid) {
+					request.log.warn("OIDC provider deletion failed: invalid current password");
+					return reply.status(401).send({ error: "Current password is incorrect" });
+				}
 			}
 
 			// Deleting OIDC is an explicit switch to password authentication. Always
@@ -342,6 +363,25 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 						throw new Error(OIDC_PROVIDER_CHANGED);
 					}
 
+					// Install the initiating admin's replacement only if the credential
+					// verified above is still current. A concurrent password change aborts
+					// and rolls back the provider deletion.
+					const updatedAdmin = await tx.user.updateMany({
+						where: {
+							id: request.currentUser!.id,
+							hashedPassword: currentAdmin.hashedPassword,
+						},
+						data: {
+							hashedPassword,
+							mustChangePassword: false,
+							failedLoginAttempts: 0,
+							lockedUntil: null,
+						},
+					});
+					if (updatedAdmin.count !== 1) {
+						throw new Error(OIDC_ADMIN_AUTH_CHANGED);
+					}
+
 					// The provider lock prevents new links from being created while this
 					// snapshot is installed with a replacement password.
 					const affectedUsers = await tx.user.findMany({
@@ -353,15 +393,15 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 						},
 						select: { id: true, hashedPassword: true },
 					});
-					let replacedUsers = 0;
+					let replacedUsers = 1;
 					for (const user of affectedUsers) {
 						const isCurrentAdmin = user.id === request.currentUser!.id;
-						if (isCurrentAdmin || !user.hashedPassword) {
+						if (!isCurrentAdmin && !user.hashedPassword) {
 							await tx.user.update({
 								where: { id: user.id },
 								data: {
 									hashedPassword,
-									mustChangePassword: !isCurrentAdmin,
+									mustChangePassword: true,
 									failedLoginAttempts: 0,
 									lockedUntil: null,
 								},
@@ -393,6 +433,12 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 					return reply.status(409).send({
 						error:
 							"The OIDC provider changed while deletion was in progress. Review the current configuration and try again.",
+					});
+				}
+				if (error instanceof Error && error.message === OIDC_ADMIN_AUTH_CHANGED) {
+					return reply.status(409).send({
+						error:
+							"Your password changed while deletion was in progress. Sign in and try again.",
 					});
 				}
 				throw error;

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -558,21 +558,31 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 *
 	 * Security: Requires authentication (single-admin architecture).
 	 */
-	app.get("/security-posture", async (_request, reply) => {
-		const [systemSettings, oidcProvider, passkeyCount, passwordUserCount, totalUserCount] =
-			await Promise.all([
-				app.prisma.systemSettings.findUnique({
-					where: { id: 1 },
-					select: { externalUrl: true },
-				}),
-				app.prisma.oIDCProvider.findFirst({
-					where: { enabled: true },
-					select: { redirectUri: true },
-				}),
-				app.prisma.webAuthnCredential.count(),
-				app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
-				app.prisma.user.count(),
-			]);
+	app.get("/security-posture", async (request, reply) => {
+		const [
+			systemSettings,
+			oidcProvider,
+			linkedOidcAccount,
+			passkeyCount,
+			passwordUserCount,
+			totalUserCount,
+		] = await Promise.all([
+			app.prisma.systemSettings.findUnique({
+				where: { id: 1 },
+				select: { externalUrl: true },
+			}),
+			app.prisma.oIDCProvider.findFirst({
+				where: { enabled: true },
+				select: { redirectUri: true },
+			}),
+			app.prisma.oIDCAccount.findFirst({
+				where: { userId: request.currentUser!.id },
+				select: { id: true },
+			}),
+			app.prisma.webAuthnCredential.count(),
+			app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
+			app.prisma.user.count(),
+		]);
 
 		const result = evaluateSecurityPosture({
 			env: {
@@ -585,7 +595,8 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				APP_URL: app.config.APP_URL,
 			},
 			publicAppUrl: systemSettings?.externalUrl,
-			oidcEnabled: oidcProvider !== null,
+			oidcEnabled: oidcProvider !== null && linkedOidcAccount !== null,
+			oidcProviderEnabled: oidcProvider !== null,
 			oidcRedirectUri: oidcProvider?.redirectUri,
 			passkeyCount,
 			passwordUserCount,

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -203,9 +203,14 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			});
 		}
 
-		// URL shape is validated by the schema; only normalize here
-		// (empty string becomes null = "clear the external URL")
-		const normalizedExternalUrl = externalUrl === "" ? null : externalUrl;
+		// URL shape and whitespace are handled by the schema. Canonicalize the
+		// persisted value so consumers cannot produce double-slash API paths.
+		const normalizedExternalUrl =
+			externalUrl === undefined
+				? undefined
+				: externalUrl === null || externalUrl === ""
+					? null
+					: externalUrl.replace(/\/+$/, "");
 
 		// Update or create settings
 		const settings = await app.prisma.systemSettings.upsert({

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -210,13 +210,13 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		}
 
 		// URL shape and whitespace are handled by the schema. Canonicalize the
-		// persisted value so consumers cannot produce double-slash API paths.
+		// parsed value before persistence so all consumers see the same URL.
 		const normalizedExternalUrl =
 			externalUrl === undefined
 				? undefined
 				: externalUrl === null || externalUrl === ""
 					? null
-					: externalUrl.replace(/\/+$/, "");
+					: new URL(externalUrl).toString().replace(/\/+$/, "");
 
 		// Update or create settings
 		const settings = await app.prisma.systemSettings.upsert({

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -556,7 +556,7 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				}),
 				app.prisma.oIDCProvider.findFirst({
 					where: { enabled: true },
-					select: { id: true },
+					select: { redirectUri: true },
 				}),
 				app.prisma.webAuthnCredential.count(),
 				app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
@@ -575,6 +575,7 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			},
 			publicAppUrl: systemSettings?.externalUrl,
 			oidcEnabled: oidcProvider !== null,
+			oidcRedirectUri: oidcProvider?.redirectUri,
 			passkeyCount,
 			passwordUserCount,
 			totalUserCount,

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -60,6 +60,12 @@ const systemSettingsSchema = z.object({
 						message: "External URL must use http or https protocol",
 					});
 				}
+				if (url.username || url.password) {
+					ctx.addIssue({
+						code: "custom",
+						message: "External URL must not include credentials",
+					});
+				}
 				if (value.includes("?") || value.includes("#")) {
 					ctx.addIssue({
 						code: "custom",

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -541,21 +541,27 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	 * Read-only snapshot of the effective security configuration plus a list
 	 * of derived posture checks (healthy / warning / misconfigured).
 	 *
-	 * Inputs gathered: app.config (effective env), enabled OIDC providers,
-	 * total passkey credentials, count of users with a password set.
+	 * Inputs gathered: app.config (effective env), configured External URL,
+	 * enabled OIDC providers, total passkey credentials, count of users with
+	 * a password set.
 	 *
 	 * Security: Requires authentication (single-admin architecture).
 	 */
 	app.get("/security-posture", async (_request, reply) => {
-		const [oidcProvider, passkeyCount, passwordUserCount, totalUserCount] = await Promise.all([
-			app.prisma.oIDCProvider.findFirst({
-				where: { enabled: true },
-				select: { id: true },
-			}),
-			app.prisma.webAuthnCredential.count(),
-			app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
-			app.prisma.user.count(),
-		]);
+		const [systemSettings, oidcProvider, passkeyCount, passwordUserCount, totalUserCount] =
+			await Promise.all([
+				app.prisma.systemSettings.findUnique({
+					where: { id: 1 },
+					select: { externalUrl: true },
+				}),
+				app.prisma.oIDCProvider.findFirst({
+					where: { enabled: true },
+					select: { id: true },
+				}),
+				app.prisma.webAuthnCredential.count(),
+				app.prisma.user.count({ where: { hashedPassword: { not: null } } }),
+				app.prisma.user.count(),
+			]);
 
 		const result = evaluateSecurityPosture({
 			env: {
@@ -567,6 +573,7 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				PASSWORD_POLICY: app.config.PASSWORD_POLICY,
 				APP_URL: app.config.APP_URL,
 			},
+			publicAppUrl: systemSettings?.externalUrl,
 			oidcEnabled: oidcProvider !== null,
 			passkeyCount,
 			passwordUserCount,

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -47,6 +47,7 @@ const systemSettingsSchema = z.object({
 	appName: z.string().optional(),
 	externalUrl: z
 		.string()
+		.trim()
 		.nullable()
 		.optional()
 		.superRefine((value, ctx) => {
@@ -223,6 +224,10 @@ const systemRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				secureCookies: secureCookies ?? null,
 			},
 		});
+
+		if (externalUrl !== undefined) {
+			app.notificationService.setBaseUrl(settings.externalUrl ?? app.config.APP_URL);
+		}
 
 		// Get currently running values
 		const currentApiPort = Number(process.env.API_PORT) || 3001;

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -60,6 +60,12 @@ const systemSettingsSchema = z.object({
 						message: "External URL must use http or https protocol",
 					});
 				}
+				if (value.includes("?") || value.includes("#")) {
+					ctx.addIssue({
+						code: "custom",
+						message: "External URL must not include a query string or fragment",
+					});
+				}
 			} catch {
 				ctx.addIssue({
 					code: "custom",

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -123,4 +123,32 @@ describe("OIDCProviderSection account linking", () => {
 			}),
 		);
 	});
+
+	it("requires the current password before replacing an existing password", async () => {
+		deleteOIDCProvider.mockRejectedValueOnce(new Error("test stop"));
+		render(<OIDCProviderSection currentUser={{ hasPassword: true }} />);
+
+		fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+		const submit = screen.getByRole("button", { name: /delete and sign out/i });
+
+		fireEvent.change(screen.getByLabelText(/^fallback password$/i), {
+			target: { value: "StrongPassword123!" },
+		});
+		fireEvent.change(screen.getByLabelText(/confirm fallback password/i), {
+			target: { value: "StrongPassword123!" },
+		});
+		expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText(/^current password$/i), {
+			target: { value: "CurrentPassword1!" },
+		});
+		fireEvent.click(submit);
+
+		await waitFor(() =>
+			expect(deleteOIDCProvider).toHaveBeenCalledWith({
+				currentPassword: "CurrentPassword1!",
+				replacementPassword: "StrongPassword123!",
+			}),
+		);
+	});
 });

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -92,14 +92,27 @@ describe("OIDCProviderSection account linking", () => {
 		const submit = screen.getByRole("button", { name: /delete and sign out/i });
 		expect((submit as HTMLButtonElement).disabled).toBe(true);
 
-		fireEvent.change(screen.getByLabelText(/fallback password/i), {
+		fireEvent.change(screen.getByLabelText(/^fallback password$/i), {
+			target: { value: "weak" },
+		});
+		fireEvent.change(screen.getByLabelText(/confirm fallback password/i), {
 			target: { value: "weak" },
 		});
 		fireEvent.click(submit);
 		expect(await screen.findByText("Password must be at least 8 characters")).toBeDefined();
 		expect(deleteOIDCProvider).not.toHaveBeenCalled();
 
-		fireEvent.change(screen.getByLabelText(/fallback password/i), {
+		fireEvent.change(screen.getByLabelText(/^fallback password$/i), {
+			target: { value: "StrongPassword123!" },
+		});
+		fireEvent.change(screen.getByLabelText(/confirm fallback password/i), {
+			target: { value: "StrongPassword123?Typo" },
+		});
+		fireEvent.click(submit);
+		expect(await screen.findByText("Fallback passwords do not match.")).toBeDefined();
+		expect(deleteOIDCProvider).not.toHaveBeenCalled();
+
+		fireEvent.change(screen.getByLabelText(/confirm fallback password/i), {
 			target: { value: "StrongPassword123!" },
 		});
 		fireEvent.click(submit);

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { initiateOIDCLogin, oidcState } = vi.hoisted(() => ({
+const { deleteOIDCProvider, initiateOIDCLogin, oidcState } = vi.hoisted(() => ({
+	deleteOIDCProvider: vi.fn(),
 	initiateOIDCLogin: vi.fn(),
 	oidcState: { linked: false },
 }));
@@ -26,7 +27,7 @@ vi.mock("../../../../hooks/api/useOIDCProviders", () => ({
 	}),
 	useCreateOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
 	useUpdateOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
-	useDeleteOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteOIDCProvider: () => ({ mutateAsync: deleteOIDCProvider, isPending: false }),
 }));
 
 vi.mock("../../../../hooks/useThemeGradient", () => ({
@@ -44,6 +45,7 @@ import { OIDCProviderSection } from "../oidc-provider-section";
 describe("OIDCProviderSection account linking", () => {
 	beforeEach(() => {
 		initiateOIDCLogin.mockReset();
+		deleteOIDCProvider.mockReset();
 		oidcState.linked = false;
 	});
 
@@ -80,5 +82,32 @@ describe("OIDCProviderSection account linking", () => {
 		fireEvent.click(screen.getByRole("button", { name: /relink account/i }));
 
 		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledWith("link"));
+	});
+
+	it("requires and submits a fallback password when deleting the provider", async () => {
+		deleteOIDCProvider.mockRejectedValueOnce(new Error("test stop"));
+		render(<OIDCProviderSection />);
+
+		fireEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+		const submit = screen.getByRole("button", { name: /delete and sign out/i });
+		expect((submit as HTMLButtonElement).disabled).toBe(true);
+
+		fireEvent.change(screen.getByLabelText(/fallback password/i), {
+			target: { value: "weak" },
+		});
+		fireEvent.click(submit);
+		expect(await screen.findByText("Password must be at least 8 characters")).toBeDefined();
+		expect(deleteOIDCProvider).not.toHaveBeenCalled();
+
+		fireEvent.change(screen.getByLabelText(/fallback password/i), {
+			target: { value: "StrongPassword123!" },
+		});
+		fireEvent.click(submit);
+
+		await waitFor(() =>
+			expect(deleteOIDCProvider).toHaveBeenCalledWith({
+				replacementPassword: "StrongPassword123!",
+			}),
+		);
 	});
 });

--- a/apps/web/src/features/settings/components/__tests__/security-posture-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/security-posture-section.test.tsx
@@ -31,6 +31,7 @@ function makePosture(overrides: Partial<SecurityPosture> = {}): SecurityPosture 
 			passwordEnabled: true,
 			passwordUserCount: 1,
 			oidcEnabled: false,
+			oidcProviderEnabled: false,
 			passkeyCount: 0,
 		},
 		effective: {
@@ -123,5 +124,22 @@ describe("SecurityPostureSection", () => {
 		expect(screen.getByText("Password-only authentication is in use.")).toBeInTheDocument();
 		// The "Recommended improvements" banner copy only appears on the loaded path.
 		expect(screen.getByText("Recommended improvements")).toBeInTheDocument();
+	});
+
+	it("distinguishes an enabled but unlinked OIDC provider from no configuration", () => {
+		const posture = makePosture({
+			auth: {
+				passwordEnabled: true,
+				passwordUserCount: 1,
+				oidcEnabled: false,
+				oidcProviderEnabled: true,
+				passkeyCount: 0,
+			},
+		});
+
+		renderWithTheme(<SecurityPostureSection posture={posture} isLoading={false} />);
+
+		expect(screen.getByText("Provider enabled; admin not linked")).toBeInTheDocument();
+		expect(screen.queryByText("Not configured")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -748,8 +748,8 @@ export const OIDCProviderSection = () => {
 						<DialogHeader>
 							<DialogTitle>Delete OIDC provider?</DialogTitle>
 							<DialogDescription>
-								Enter a strong fallback password before removing OIDC. Existing passwords are
-								preserved, and OIDC-only accounts receive this password. You will be signed out
+								Enter a strong fallback password before removing OIDC. This becomes your
+								password, and other OIDC-only accounts receive it. You will be signed out
 								afterward.
 							</DialogDescription>
 						</DialogHeader>

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { deleteOidcProviderSchema, type UpdateOIDCProvider } from "@arr/shared";
+import {
+	type CurrentUser,
+	deleteOidcProviderSchema,
+	type UpdateOIDCProvider,
+} from "@arr/shared";
 import {
 	AlertCircle,
 	Check,
@@ -48,7 +52,11 @@ import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
  * - Premium status feedback
  * - Staggered animations
  */
-export const OIDCProviderSection = () => {
+interface OIDCProviderSectionProps {
+	currentUser?: Pick<CurrentUser, "hasPassword"> | null;
+}
+
+export const OIDCProviderSection = ({ currentUser }: OIDCProviderSectionProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 
 	const { data: providerData, isLoading } = useOIDCProvider();
@@ -63,6 +71,7 @@ export const OIDCProviderSection = () => {
 	const [success, setSuccess] = useState<string | null>(null);
 	const [accountAction, setAccountAction] = useState<"link" | "test" | null>(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [currentPassword, setCurrentPassword] = useState("");
 	const [replacementPassword, setReplacementPassword] = useState("");
 	const [confirmReplacementPassword, setConfirmReplacementPassword] = useState("");
 	const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -186,7 +195,14 @@ export const OIDCProviderSection = () => {
 	const handleDelete = async () => {
 		if (!provider) return;
 
-		const validation = deleteOidcProviderSchema.safeParse({ replacementPassword });
+		if (currentUser?.hasPassword && !currentPassword) {
+			setDeleteError("Current password is required.");
+			return;
+		}
+		const validation = deleteOidcProviderSchema.safeParse({
+			replacementPassword,
+			...(currentUser?.hasPassword ? { currentPassword } : {}),
+		});
 		if (!validation.success) {
 			setDeleteError(validation.error.issues[0]?.message ?? "Enter a valid fallback password.");
 			return;
@@ -209,6 +225,7 @@ export const OIDCProviderSection = () => {
 		if (deleteMutation.isPending) return;
 		setDeleteDialogOpen(open);
 		if (!open) {
+			setCurrentPassword("");
 			setReplacementPassword("");
 			setConfirmReplacementPassword("");
 			setDeleteError(null);
@@ -748,12 +765,30 @@ export const OIDCProviderSection = () => {
 						<DialogHeader>
 							<DialogTitle>Delete OIDC provider?</DialogTitle>
 							<DialogDescription>
-								Enter a strong fallback password before removing OIDC. This becomes your
-								password, and other OIDC-only accounts receive it. You will be signed out
-								afterward.
+								{currentUser?.hasPassword
+									? "Confirm your current password, then choose a strong fallback password before removing OIDC. The fallback replaces your password, and other OIDC-only accounts receive it. You will be signed out afterward."
+									: "Choose a strong fallback password before removing OIDC. This becomes your password, and other OIDC-only accounts receive it. You will be signed out afterward."}
 							</DialogDescription>
 						</DialogHeader>
 						<div className="space-y-2">
+							{currentUser?.hasPassword && (
+								<>
+									<label
+										htmlFor="oidc-current-password"
+										className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+									>
+										Current password
+									</label>
+									<Input
+										id="oidc-current-password"
+										type="password"
+										autoComplete="current-password"
+										value={currentPassword}
+										onChange={(event) => setCurrentPassword(event.target.value)}
+										disabled={deleteMutation.isPending}
+									/>
+								</>
+							)}
 							<label
 								htmlFor="oidc-replacement-password"
 								className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
@@ -800,7 +835,10 @@ export const OIDCProviderSection = () => {
 								variant="destructive"
 								onClick={handleDelete}
 								disabled={
-									!replacementPassword || !confirmReplacementPassword || deleteMutation.isPending
+									(currentUser?.hasPassword && !currentPassword) ||
+									!replacementPassword ||
+									!confirmReplacementPassword ||
+									deleteMutation.isPending
 								}
 							>
 								{deleteMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -64,6 +64,7 @@ export const OIDCProviderSection = () => {
 	const [accountAction, setAccountAction] = useState<"link" | "test" | null>(null);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 	const [replacementPassword, setReplacementPassword] = useState("");
+	const [confirmReplacementPassword, setConfirmReplacementPassword] = useState("");
 	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const isLinking = accountAction !== null;
 
@@ -190,6 +191,10 @@ export const OIDCProviderSection = () => {
 			setDeleteError(validation.error.issues[0]?.message ?? "Enter a valid fallback password.");
 			return;
 		}
+		if (replacementPassword !== confirmReplacementPassword) {
+			setDeleteError("Fallback passwords do not match.");
+			return;
+		}
 
 		setDeleteError(null);
 		try {
@@ -205,6 +210,7 @@ export const OIDCProviderSection = () => {
 		setDeleteDialogOpen(open);
 		if (!open) {
 			setReplacementPassword("");
+			setConfirmReplacementPassword("");
 			setDeleteError(null);
 		}
 	};
@@ -762,6 +768,20 @@ export const OIDCProviderSection = () => {
 								onChange={(event) => setReplacementPassword(event.target.value)}
 								disabled={deleteMutation.isPending}
 							/>
+							<label
+								htmlFor="oidc-confirm-replacement-password"
+								className="block pt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+							>
+								Confirm fallback password
+							</label>
+							<Input
+								id="oidc-confirm-replacement-password"
+								type="password"
+								autoComplete="new-password"
+								value={confirmReplacementPassword}
+								onChange={(event) => setConfirmReplacementPassword(event.target.value)}
+								disabled={deleteMutation.isPending}
+							/>
 							{deleteError && (
 								<p className="text-sm" style={{ color: SEMANTIC_COLORS.error.text }}>
 									{deleteError}
@@ -779,7 +799,9 @@ export const OIDCProviderSection = () => {
 							<Button
 								variant="destructive"
 								onClick={handleDelete}
-								disabled={!replacementPassword || deleteMutation.isPending}
+								disabled={
+									!replacementPassword || !confirmReplacementPassword || deleteMutation.isPending
+								}
 							>
 								{deleteMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
 								Delete and sign out

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { UpdateOIDCProvider } from "@arr/shared";
+import { deleteOidcProviderSchema, type UpdateOIDCProvider } from "@arr/shared";
 import {
 	AlertCircle,
 	Check,
@@ -19,6 +19,14 @@ import { useState } from "react";
 import { PremiumEmptyState, PremiumSection, PremiumSkeleton } from "../../../components/layout";
 import { ToggleSwitch } from "../../../components/layout/config-primitives";
 import { Button } from "../../../components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "../../../components/ui/dialog";
 import { Input } from "../../../components/ui/input";
 import {
 	useCreateOIDCProvider,
@@ -54,6 +62,9 @@ export const OIDCProviderSection = () => {
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
 	const [accountAction, setAccountAction] = useState<"link" | "test" | null>(null);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [replacementPassword, setReplacementPassword] = useState("");
+	const [deleteError, setDeleteError] = useState<string | null>(null);
 	const isLinking = accountAction !== null;
 
 	// Form state for creating new provider
@@ -174,18 +185,27 @@ export const OIDCProviderSection = () => {
 	const handleDelete = async () => {
 		if (!provider) return;
 
-		if (!confirm("Are you sure you want to delete this OIDC provider?")) {
+		const validation = deleteOidcProviderSchema.safeParse({ replacementPassword });
+		if (!validation.success) {
+			setDeleteError(validation.error.issues[0]?.message ?? "Enter a valid fallback password.");
 			return;
 		}
 
-		setError(null);
-		setSuccess(null);
-
+		setDeleteError(null);
 		try {
-			await deleteMutation.mutateAsync();
-			setSuccess("OIDC provider deleted successfully!");
+			await deleteMutation.mutateAsync(validation.data);
+			window.location.href = "/login";
 		} catch (err) {
-			setError(getErrorMessage(err, "Failed to delete OIDC provider"));
+			setDeleteError(getErrorMessage(err, "Failed to delete OIDC provider"));
+		}
+	};
+
+	const handleDeleteDialogChange = (open: boolean) => {
+		if (deleteMutation.isPending) return;
+		setDeleteDialogOpen(open);
+		if (!open) {
+			setReplacementPassword("");
+			setDeleteError(null);
 		}
 	};
 
@@ -603,7 +623,7 @@ export const OIDCProviderSection = () => {
 										<Button
 											size="sm"
 											variant="ghost"
-											onClick={handleDelete}
+											onClick={() => setDeleteDialogOpen(true)}
 											disabled={deleteMutation.isPending}
 											className="gap-1.5"
 											style={{ color: SEMANTIC_COLORS.error.text }}
@@ -717,6 +737,56 @@ export const OIDCProviderSection = () => {
 						)}
 					</div>
 				)}
+				<Dialog open={deleteDialogOpen} onOpenChange={handleDeleteDialogChange}>
+					<DialogContent className="max-w-md">
+						<DialogHeader>
+							<DialogTitle>Delete OIDC provider?</DialogTitle>
+							<DialogDescription>
+								Enter a strong fallback password before removing OIDC. Existing passwords are
+								preserved, and OIDC-only accounts receive this password. You will be signed out
+								afterward.
+							</DialogDescription>
+						</DialogHeader>
+						<div className="space-y-2">
+							<label
+								htmlFor="oidc-replacement-password"
+								className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+							>
+								Fallback password
+							</label>
+							<Input
+								id="oidc-replacement-password"
+								type="password"
+								autoComplete="new-password"
+								value={replacementPassword}
+								onChange={(event) => setReplacementPassword(event.target.value)}
+								disabled={deleteMutation.isPending}
+							/>
+							{deleteError && (
+								<p className="text-sm" style={{ color: SEMANTIC_COLORS.error.text }}>
+									{deleteError}
+								</p>
+							)}
+						</div>
+						<DialogFooter>
+							<Button
+								variant="outline"
+								onClick={() => handleDeleteDialogChange(false)}
+								disabled={deleteMutation.isPending}
+							>
+								Cancel
+							</Button>
+							<Button
+								variant="destructive"
+								onClick={handleDelete}
+								disabled={!replacementPassword || deleteMutation.isPending}
+							>
+								{deleteMutation.isPending && <Loader2 className="h-4 w-4 animate-spin" />}
+								Delete and sign out
+							</Button>
+						</DialogFooter>
+					</DialogContent>
+				</Dialog>
 			</div>
 		</PremiumSection>
 	);

--- a/apps/web/src/features/settings/components/security-posture-section.tsx
+++ b/apps/web/src/features/settings/components/security-posture-section.tsx
@@ -203,7 +203,7 @@ function AuthSummary({ posture }: { posture: SecurityPosture }) {
 			<AuthBadge
 				icon={KeyRound}
 				label="Password auth"
-				active={posture.auth.passwordEnabled}
+				status={posture.auth.passwordEnabled ? "active" : "inactive"}
 				detail={
 					posture.auth.passwordEnabled
 						? `${posture.auth.passwordUserCount} user${
@@ -215,13 +215,25 @@ function AuthSummary({ posture }: { posture: SecurityPosture }) {
 			<AuthBadge
 				icon={UserCheck}
 				label="OIDC"
-				active={posture.auth.oidcEnabled}
-				detail={posture.auth.oidcEnabled ? "Provider enabled" : "Not configured"}
+				status={
+					posture.auth.oidcEnabled
+						? "active"
+						: posture.auth.oidcProviderEnabled
+							? "warning"
+							: "inactive"
+				}
+				detail={
+					posture.auth.oidcEnabled
+						? "Provider linked"
+						: posture.auth.oidcProviderEnabled
+							? "Provider enabled; admin not linked"
+							: "Not configured"
+				}
 			/>
 			<AuthBadge
 				icon={Fingerprint}
 				label="Passkeys"
-				active={posture.auth.passkeyCount > 0}
+				status={posture.auth.passkeyCount > 0 ? "active" : "inactive"}
 				detail={
 					posture.auth.passkeyCount > 0
 						? `${posture.auth.passkeyCount} credential${posture.auth.passkeyCount === 1 ? "" : "s"}`
@@ -235,25 +247,33 @@ function AuthSummary({ posture }: { posture: SecurityPosture }) {
 function AuthBadge({
 	icon: Icon,
 	label,
-	active,
+	status,
 	detail,
 }: {
 	icon: typeof KeyRound;
 	label: string;
-	active: boolean;
+	status: "active" | "warning" | "inactive";
 	detail: string;
 }) {
 	return (
 		<div
 			className={cn(
 				"flex items-start gap-3 rounded-lg border p-3 transition-colors",
-				active ? "border-emerald-500/30 bg-emerald-500/5" : "border-border/40 bg-muted/10",
+				status === "active"
+					? "border-emerald-500/30 bg-emerald-500/5"
+					: status === "warning"
+						? "border-amber-500/30 bg-amber-500/5"
+						: "border-border/40 bg-muted/10",
 			)}
 		>
 			<Icon
 				className={cn(
 					"h-4 w-4 shrink-0 mt-0.5",
-					active ? "text-emerald-500" : "text-muted-foreground",
+					status === "active"
+						? "text-emerald-500"
+						: status === "warning"
+							? "text-amber-500"
+							: "text-muted-foreground",
 				)}
 				aria-hidden="true"
 			/>

--- a/apps/web/src/features/settings/components/settings-client.tsx
+++ b/apps/web/src/features/settings/components/settings-client.tsx
@@ -221,7 +221,7 @@ export const SettingsClient = () => {
 					>
 						<PasswordSection currentUser={currentUser} />
 						<PasskeySection />
-						<OIDCProviderSection />
+						<OIDCProviderSection currentUser={currentUser} />
 						<SessionsSection />
 					</div>
 				)}

--- a/apps/web/src/features/settings/components/system-tab.tsx
+++ b/apps/web/src/features/settings/components/system-tab.tsx
@@ -223,6 +223,10 @@ export function SystemTab() {
 					toast.error("External URL must use http or https protocol");
 					return;
 				}
+				if (externalUrl.includes("?") || externalUrl.includes("#")) {
+					toast.error("External URL must not include a query string or fragment");
+					return;
+				}
 			} catch {
 				toast.error("External URL must be a valid URL (e.g., https://arr.example.com)");
 				return;
@@ -858,7 +862,7 @@ ports:
 						/>
 						<p className="text-xs text-muted-foreground">
 							Leave empty to auto-detect from browser. Set this if you&apos;re behind a reverse
-							proxy.
+							proxy. Use a base URL without a query string or fragment.
 						</p>
 					</div>
 

--- a/apps/web/src/hooks/api/__tests__/useOIDCProviders.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useOIDCProviders.test.tsx
@@ -53,9 +53,12 @@ describe("OIDC provider mutations", () => {
 		await waitFor(() => expect(updateMutation.result.current.isSuccess).toBe(true));
 
 		const deleteMutation = renderHook(() => useDeleteOIDCProvider(), { wrapper });
-		deleteMutation.result.current.mutate();
+		deleteMutation.result.current.mutate({ replacementPassword: "StrongPassword123!" });
 		await waitFor(() => expect(deleteMutation.result.current.isSuccess).toBe(true));
 
+		expect(oidcApi.deleteOIDCProvider).toHaveBeenCalledWith({
+			replacementPassword: "StrongPassword123!",
+		});
 		expect(invalidateQueries).toHaveBeenCalledTimes(6);
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: oidcKeys.provider });
 		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: systemKeys.securityPosture });

--- a/apps/web/src/hooks/api/__tests__/useOIDCProviders.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useOIDCProviders.test.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { oidcKeys, systemKeys } from "../../../lib/query-keys";
+
+vi.mock("../../../lib/api-client/oidc-providers");
+
+import * as oidcApi from "../../../lib/api-client/oidc-providers";
+import {
+	useCreateOIDCProvider,
+	useDeleteOIDCProvider,
+	useUpdateOIDCProvider,
+} from "../useOIDCProviders";
+
+function createWrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+describe("OIDC provider mutations", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("invalidates the provider and security posture after create, update, and delete", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const invalidateQueries = vi.spyOn(client, "invalidateQueries");
+		vi.mocked(oidcApi.createOIDCProvider).mockResolvedValue({} as never);
+		vi.mocked(oidcApi.updateOIDCProvider).mockResolvedValue({} as never);
+		vi.mocked(oidcApi.deleteOIDCProvider).mockResolvedValue(undefined);
+		const wrapper = createWrapper(client);
+
+		const createMutation = renderHook(() => useCreateOIDCProvider(), { wrapper });
+		createMutation.result.current.mutate({
+			displayName: "Example",
+			clientId: "client-id",
+			clientSecret: "secret",
+			issuer: "https://issuer.example.com",
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+			scopes: "openid,email,profile",
+			enabled: true,
+		});
+		await waitFor(() => expect(createMutation.result.current.isSuccess).toBe(true));
+
+		const updateMutation = renderHook(() => useUpdateOIDCProvider(), { wrapper });
+		updateMutation.result.current.mutate({
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+		});
+		await waitFor(() => expect(updateMutation.result.current.isSuccess).toBe(true));
+
+		const deleteMutation = renderHook(() => useDeleteOIDCProvider(), { wrapper });
+		deleteMutation.result.current.mutate();
+		await waitFor(() => expect(deleteMutation.result.current.isSuccess).toBe(true));
+
+		expect(invalidateQueries).toHaveBeenCalledTimes(6);
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: oidcKeys.provider });
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: systemKeys.securityPosture });
+
+		client.clear();
+	});
+});

--- a/apps/web/src/hooks/api/__tests__/useSystem.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useSystem.test.tsx
@@ -1,0 +1,47 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { systemKeys } from "../../../lib/query-keys";
+
+vi.mock("../../../lib/api-client/system");
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import * as systemApi from "../../../lib/api-client/system";
+import { useUpdateSystemSettings } from "../useSystem";
+
+function createWrapper(client: QueryClient) {
+	return ({ children }: { children: ReactNode }) => (
+		<QueryClientProvider client={client}>{children}</QueryClientProvider>
+	);
+}
+
+describe("useUpdateSystemSettings", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("invalidates settings and security posture after a successful save", async () => {
+		const client = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const invalidateQueries = vi.spyOn(client, "invalidateQueries");
+		vi.mocked(systemApi.updateSystemSettings).mockResolvedValue({
+			success: true,
+			message: "Settings saved",
+			data: {},
+		} as never);
+
+		const { result } = renderHook(() => useUpdateSystemSettings(), {
+			wrapper: createWrapper(client),
+		});
+
+		result.current.mutate({ externalUrl: "https://arr.example.com" });
+
+		await waitFor(() => expect(result.current.isSuccess).toBe(true));
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: systemKeys.settings });
+		expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: systemKeys.securityPosture });
+
+		client.clear();
+	});
+});

--- a/apps/web/src/hooks/api/useOIDCProviders.ts
+++ b/apps/web/src/hooks/api/useOIDCProviders.ts
@@ -1,4 +1,4 @@
-import type { CreateOIDCProvider, UpdateOIDCProvider } from "@arr/shared";
+import type { CreateOIDCProvider, DeleteOIDCProvider, UpdateOIDCProvider } from "@arr/shared";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	createOIDCProvider,
@@ -66,7 +66,7 @@ export function useDeleteOIDCProvider() {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: () => deleteOIDCProvider(),
+		mutationFn: (data: DeleteOIDCProvider) => deleteOIDCProvider(data),
 		onSuccess: () => {
 			// Invalidate provider query to refetch
 			queryClient.invalidateQueries({ queryKey: oidcKeys.provider });

--- a/apps/web/src/hooks/api/useOIDCProviders.ts
+++ b/apps/web/src/hooks/api/useOIDCProviders.ts
@@ -6,7 +6,7 @@ import {
 	getOIDCProvider,
 	updateOIDCProvider,
 } from "../../lib/api-client/oidc-providers";
-import { oidcKeys } from "../../lib/query-keys";
+import { oidcKeys, systemKeys } from "../../lib/query-keys";
 
 /**
  * Fetch the configured OIDC provider (admin only)
@@ -38,6 +38,7 @@ export function useCreateOIDCProvider() {
 		onSuccess: () => {
 			// Invalidate provider query to refetch
 			queryClient.invalidateQueries({ queryKey: oidcKeys.provider });
+			queryClient.invalidateQueries({ queryKey: systemKeys.securityPosture });
 		},
 	});
 }
@@ -53,6 +54,7 @@ export function useUpdateOIDCProvider() {
 		onSuccess: () => {
 			// Invalidate provider query to refetch
 			queryClient.invalidateQueries({ queryKey: oidcKeys.provider });
+			queryClient.invalidateQueries({ queryKey: systemKeys.securityPosture });
 		},
 	});
 }
@@ -68,6 +70,7 @@ export function useDeleteOIDCProvider() {
 		onSuccess: () => {
 			// Invalidate provider query to refetch
 			queryClient.invalidateQueries({ queryKey: oidcKeys.provider });
+			queryClient.invalidateQueries({ queryKey: systemKeys.securityPosture });
 		},
 	});
 }

--- a/apps/web/src/hooks/api/useSystem.ts
+++ b/apps/web/src/hooks/api/useSystem.ts
@@ -47,6 +47,7 @@ export function useUpdateSystemSettings() {
 		mutationFn: (data: UpdateSystemSettingsPayload) => updateSystemSettings(data),
 		onSuccess: (response) => {
 			queryClient.invalidateQueries({ queryKey: systemKeys.settings });
+			queryClient.invalidateQueries({ queryKey: systemKeys.securityPosture });
 			toast.success(response.message || "Settings saved");
 		},
 		onError: (error) => {

--- a/apps/web/src/lib/api-client/oidc-providers.ts
+++ b/apps/web/src/lib/api-client/oidc-providers.ts
@@ -1,5 +1,6 @@
 import type {
 	CreateOIDCProvider,
+	DeleteOIDCProvider,
 	OIDCProvider,
 	OIDCProviderResponse,
 	UpdateOIDCProvider,
@@ -43,8 +44,9 @@ export async function updateOIDCProvider(data: UpdateOIDCProvider): Promise<OIDC
 /**
  * Delete the OIDC provider (admin only, singleton)
  */
-export async function deleteOIDCProvider(): Promise<void> {
+export async function deleteOIDCProvider(data: DeleteOIDCProvider): Promise<void> {
 	await apiRequest<void>("/api/oidc-providers", {
 		method: "DELETE",
+		json: data,
 	});
 }

--- a/apps/web/src/lib/api-client/system.ts
+++ b/apps/web/src/lib/api-client/system.ts
@@ -158,6 +158,7 @@ export interface SecurityPosture {
 		passwordEnabled: boolean;
 		passwordUserCount: number;
 		oidcEnabled: boolean;
+		oidcProviderEnabled: boolean;
 		passkeyCount: number;
 	};
 	capturedAt: string;

--- a/docs/adr/0002-security-posture-evaluator.md
+++ b/docs/adr/0002-security-posture-evaluator.md
@@ -53,7 +53,7 @@ decide whether to act. We deliberately separate two kinds of finding:
 | Severity | Meaning | Examples |
 |---|---|---|
 | `misconfigured` | Cannot work / will lock users out / actively harms | Secure cookies + no trust proxy; users exist but no auth methods active |
-| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https effective public URL in production |
+| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https effective public URL; OIDC with non-https `APP_URL` |
 | `healthy` | No issue detected | — |
 
 Hardening warnings must never be promoted to `misconfigured`. Doing so

--- a/docs/adr/0002-security-posture-evaluator.md
+++ b/docs/adr/0002-security-posture-evaluator.md
@@ -37,8 +37,8 @@ a **thin aggregator route** (`GET /system/security-posture`).
 
 `evaluateSecurityPosture(input) → SecurityPostureResult`
 
-- Input is a plain object: env snapshot + OIDC enabled + passkey count
-  + password user count + total user count.
+- Input is a plain object: env snapshot + configured public URL override +
+  OIDC enabled + passkey count + password user count + total user count.
 - Output: per-check severity-tagged list, a worst-case overall severity,
   the `effective` runtime values verbatim, and an `auth` summary.
 - Three severities: `healthy`, `warning`, `misconfigured`.
@@ -53,7 +53,7 @@ decide whether to act. We deliberately separate two kinds of finding:
 | Severity | Meaning | Examples |
 |---|---|---|
 | `misconfigured` | Cannot work / will lock users out / actively harms | Secure cookies + no trust proxy; users exist but no auth methods active |
-| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https `APP_URL` in production |
+| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https effective public URL in production |
 | `healthy` | No issue detected | — |
 
 Hardening warnings must never be promoted to `misconfigured`. Doing so

--- a/docs/adr/0002-security-posture-evaluator.md
+++ b/docs/adr/0002-security-posture-evaluator.md
@@ -38,7 +38,8 @@ a **thin aggregator route** (`GET /system/security-posture`).
 `evaluateSecurityPosture(input) → SecurityPostureResult`
 
 - Input is a plain object: env snapshot + configured public URL override +
-  OIDC enabled + passkey count + password user count + total user count.
+  OIDC enabled and its stored redirect URI + passkey count + password user
+  count + total user count.
 - Output: per-check severity-tagged list, a worst-case overall severity,
   the `effective` runtime values verbatim, and an `auth` summary.
 - Three severities: `healthy`, `warning`, `misconfigured`.
@@ -53,7 +54,7 @@ decide whether to act. We deliberately separate two kinds of finding:
 | Severity | Meaning | Examples |
 |---|---|---|
 | `misconfigured` | Cannot work / will lock users out / actively harms | Secure cookies + no trust proxy; users exist but no auth methods active |
-| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https effective public URL; OIDC with non-https `APP_URL` |
+| `warning` | Works fine; an observable hardening opportunity exists | Password-only auth; relaxed password policy in production; >14-day session TTL in production; non-https effective public URL; OIDC with a non-https stored redirect URI |
 | `healthy` | No issue detected | — |
 
 Hardening warnings must never be promoted to `misconfigured`. Doing so

--- a/packages/shared/src/types/__tests__/oidc-provider.test.ts
+++ b/packages/shared/src/types/__tests__/oidc-provider.test.ts
@@ -22,6 +22,7 @@ describe("oidcRedirectUriSchema", () => {
 		"https://arr.example.com/auth/oidc/callback#",
 		"https://admin@arr.example.com/auth/oidc/callback",
 		"https://admin:secret@arr.example.com/auth/oidc/callback",
+		"https://arr.example.com//auth/oidc/callback",
 		"ftp://arr.example.com/auth/oidc/callback",
 	])("rejects an invalid OAuth callback: %s", (redirectUri) => {
 		expect(oidcRedirectUriSchema.safeParse(redirectUri).success).toBe(false);

--- a/packages/shared/src/types/__tests__/oidc-provider.test.ts
+++ b/packages/shared/src/types/__tests__/oidc-provider.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { oidcRedirectUriSchema } from "../oidc-provider";
+
+describe("oidcRedirectUriSchema", () => {
+	it("accepts HTTP(S) callbacks and preserves query parameters", () => {
+		expect(
+			oidcRedirectUriSchema.parse("https://arr.example.com/auth/oidc/callback?tenant=home"),
+		).toBe("https://arr.example.com/auth/oidc/callback?tenant=home");
+		expect(oidcRedirectUriSchema.parse("http://localhost:3000/auth/oidc/callback")).toBe(
+			"http://localhost:3000/auth/oidc/callback",
+		);
+	});
+
+	it("canonicalizes parser-normalized callback URLs", () => {
+		expect(oidcRedirectUriSchema.parse("https://arr.example.com\\auth\\oidc\\callback")).toBe(
+			"https://arr.example.com/auth/oidc/callback",
+		);
+	});
+
+	it.each([
+		"https://arr.example.com/auth/oidc/callback#fragment",
+		"https://arr.example.com/auth/oidc/callback#",
+		"https://admin@arr.example.com/auth/oidc/callback",
+		"https://admin:secret@arr.example.com/auth/oidc/callback",
+		"ftp://arr.example.com/auth/oidc/callback",
+	])("rejects an invalid OAuth callback: %s", (redirectUri) => {
+		expect(oidcRedirectUriSchema.safeParse(redirectUri).success).toBe(false);
+	});
+});

--- a/packages/shared/src/types/__tests__/oidc-provider.test.ts
+++ b/packages/shared/src/types/__tests__/oidc-provider.test.ts
@@ -23,6 +23,7 @@ describe("oidcRedirectUriSchema", () => {
 		"https://admin@arr.example.com/auth/oidc/callback",
 		"https://admin:secret@arr.example.com/auth/oidc/callback",
 		"https://arr.example.com//auth/oidc/callback",
+		"https://arr.example.com/wrong-callback",
 		"ftp://arr.example.com/auth/oidc/callback",
 	])("rejects an invalid OAuth callback: %s", (redirectUri) => {
 		expect(oidcRedirectUriSchema.safeParse(redirectUri).success).toBe(false);

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -21,6 +21,36 @@ export const oidcProviderSchema = z.object({
 
 export type OIDCProvider = z.infer<typeof oidcProviderSchema>;
 
+export const oidcRedirectUriSchema = z
+	.string()
+	.url()
+	.superRefine((value, ctx) => {
+		try {
+			const url = new URL(value);
+			if (!["http:", "https:"].includes(url.protocol)) {
+				ctx.addIssue({
+					code: "custom",
+					message: "OIDC redirect URI must use http or https protocol",
+				});
+			}
+			if (url.username || url.password) {
+				ctx.addIssue({
+					code: "custom",
+					message: "OIDC redirect URI must not include credentials",
+				});
+			}
+			if (value.includes("#")) {
+				ctx.addIssue({
+					code: "custom",
+					message: "OIDC redirect URI must not include a fragment",
+				});
+			}
+		} catch {
+			// z.string().url() reports the canonical invalid-URL issue.
+		}
+	})
+	.transform((value) => new URL(value).toString());
+
 /**
  * Input schema for creating an OIDC provider
  * Includes clientSecret which will be encrypted on the backend
@@ -30,7 +60,7 @@ export const createOidcProviderSchema = z.object({
 	clientId: z.string().min(1),
 	clientSecret: z.string().min(1),
 	issuer: z.string().url(),
-	redirectUri: z.string().url().optional(),
+	redirectUri: oidcRedirectUriSchema.optional(),
 	scopes: z.string().default("openid,email,profile"),
 	enabled: z.boolean().default(true),
 });

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -45,6 +45,12 @@ export const oidcRedirectUriSchema = z
 					message: "OIDC redirect URI must not include a fragment",
 				});
 			}
+			if (url.pathname.includes("//")) {
+				ctx.addIssue({
+					code: "custom",
+					message: "OIDC redirect URI path must not include repeated slashes",
+				});
+			}
 		} catch {
 			// z.string().url() reports the canonical invalid-URL issue.
 		}

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -51,6 +51,12 @@ export const oidcRedirectUriSchema = z
 					message: "OIDC redirect URI path must not include repeated slashes",
 				});
 			}
+			if (!url.pathname.endsWith("/auth/oidc/callback")) {
+				ctx.addIssue({
+					code: "custom",
+					message: "OIDC redirect URI must end with /auth/oidc/callback",
+				});
+			}
 		} catch {
 			// z.string().url() reports the canonical invalid-URL issue.
 		}

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 // Use strict schema for OIDC disable - security-critical operation
-import { passwordSchemaStrict } from "./password";
+import { passwordSchemaRelaxed, passwordSchemaStrict } from "./password";
 
 /**
  * Public OIDC Provider shape (without client secret)
@@ -104,6 +104,7 @@ export type OIDCProviderResponse = z.infer<typeof oidcProviderResponseSchema>;
  */
 export const deleteOidcProviderSchema = z.object({
 	replacementPassword: passwordSchemaStrict,
+	currentPassword: passwordSchemaRelaxed.optional(),
 });
 
 export type DeleteOIDCProvider = z.infer<typeof deleteOidcProviderSchema>;


### PR DESCRIPTION
## Summary

- forward-port the stable #625 correction to `next`
- use Settings → System External URL as the canonical public URL for Security Posture and notification links, with `APP_URL` as the fallback
- refresh Security Posture immediately after External URL or OIDC configuration changes
- validate External URL as a base URL without a query string or fragment while preserving supported subpaths
- evaluate the enabled OIDC provider's actual redirect URI, allowing HTTP only for real loopback URLs in development
- report OIDC as an active authentication method only when the current administrator is linked, with a separate enabled-but-unlinked UI state
- restore the fallback-password confirmation required when deleting an OIDC provider and sign the administrator out after deletion

## Root cause

Security Posture only evaluated `app.config.APP_URL`. It did not read the database-backed External URL used by reverse-proxied installations, so the default `http://localhost:3000` value produced a warning even when the public application URL was configured as HTTPS.

The final regression review also found two interactions with the recently merged OIDC hardening: the UI did not send the required replacement password when deleting a provider, and an enabled but unlinked provider was being counted as a usable sign-in method. Both are corrected here.

## Validation

- reproduced the report against a fresh local v2 instance with HTTP `APP_URL`
- saved `https://arr.example.com` as External URL and verified the App URL check changed to `External URL uses HTTPS.` with no stale APP_URL warning
- focused API and web regression suites for Security Posture, System settings, OIDC configuration, and provider deletion
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- independent regression review completed with no remaining findings

## Compatibility

- no database schema changes
- installations without an External URL continue to use `APP_URL`
- External URL subpaths remain supported; query strings and fragments are rejected because generated links append paths to this base
- stable implementation is in #648

Related to #625
