### PR TITLE
fix(auth): forward-port secure OIDC admin linking

### DIFF
--- a/apps/api/src/lib/auth/__tests__/session-validation.test.ts
+++ b/apps/api/src/lib/auth/__tests__/session-validation.test.ts
@@ -200,6 +200,17 @@ describe("SessionService.validateRequest", () => {
 		expect(rememberedTtlMs).toBeGreaterThan(standardTtlMs * 10);
 	});
 
+	it("can attach a rotated cookie for only the session's remaining lifetime", () => {
+		const setCookie = vi.fn();
+		const expiresAt = new Date(Date.now() + 60 * 60 * 1000);
+
+		service.attachCookie({ setCookie } as never, "replacement-token", true, expiresAt);
+
+		const options = setCookie.mock.calls[0]![2];
+		expect(options.maxAge).toBeGreaterThanOrEqual(3599);
+		expect(options.maxAge).toBeLessThanOrEqual(3600);
+	});
+
 	it("atomically rotates only a still-active session and runs the authorized mutation", async () => {
 		const current = await service.createSession("user-1");
 		const onRotate = vi.fn().mockResolvedValue(undefined);
@@ -207,12 +218,12 @@ describe("SessionService.validateRequest", () => {
 		const replacement = await service.rotateActiveSession(
 			current.token,
 			"user-1",
-			true,
 			{ userAgent: "vitest" },
 			{ onRotate },
 		);
 
 		expect(replacement).not.toBeNull();
+		expect(replacement!.expiresAt).toEqual(current.expiresAt);
 		expect(onRotate).toHaveBeenCalledTimes(1);
 		await expect(
 			service.validateRequest(makeRequest("signed-cookie", { valid: true, value: current.token })),
@@ -230,7 +241,7 @@ describe("SessionService.validateRequest", () => {
 		const onRotate = vi.fn().mockResolvedValue(undefined);
 
 		await expect(
-			service.rotateActiveSession(current.token, "user-1", true, undefined, { onRotate }),
+			service.rotateActiveSession(current.token, "user-1", undefined, { onRotate }),
 		).resolves.toBeNull();
 		expect(onRotate).not.toHaveBeenCalled();
 	});
@@ -245,13 +256,10 @@ describe("SessionService.validateRequest", () => {
 			expect(prisma._sessions.size).toBe(2);
 		});
 
-		const replacement = await service.rotateActiveSession(
-			current.token,
-			"user-1",
-			true,
-			undefined,
-			{ onRotate, revokeOtherSessions: true },
-		);
+		const replacement = await service.rotateActiveSession(current.token, "user-1", undefined, {
+			onRotate,
+			revokeOtherSessions: true,
+		});
 
 		expect(replacement).not.toBeNull();
 		await expect(

--- a/apps/api/src/lib/auth/__tests__/session-validation.test.ts
+++ b/apps/api/src/lib/auth/__tests__/session-validation.test.ts
@@ -50,7 +50,7 @@ function createPrismaStub() {
 		}
 	>();
 
-	return {
+	const prisma = {
 		_sessions: sessions,
 		session: {
 			create: vi.fn(async ({ data }: any) => {
@@ -84,7 +84,23 @@ function createPrismaStub() {
 				sessions.delete(where.id);
 				return row;
 			}),
-			deleteMany: vi.fn(async () => ({ count: 0 })),
+			deleteMany: vi.fn(async ({ where }: any) => {
+				let count = 0;
+				for (const [id, row] of sessions.entries()) {
+					const matchesId =
+						where?.id === undefined ||
+						where.id === id ||
+						(typeof where.id === "object" && where.id.not !== id);
+					const matchesUser = where?.userId === undefined || where.userId === row.userId;
+					const matchesExpiry =
+						where?.expiresAt?.gt === undefined || row.expiresAt > where.expiresAt.gt;
+					if (matchesId && matchesUser && matchesExpiry) {
+						sessions.delete(id);
+						count += 1;
+					}
+				}
+				return { count };
+			}),
 			update: vi.fn(async ({ where, data }: any) => {
 				const row = sessions.get(where.id);
 				if (row) Object.assign(row, data);
@@ -92,6 +108,11 @@ function createPrismaStub() {
 			}),
 			count: vi.fn(async () => sessions.size),
 		},
+	};
+
+	return {
+		...prisma,
+		$transaction: vi.fn(async (fn: (tx: typeof prisma) => unknown) => fn(prisma)),
 	};
 }
 
@@ -177,6 +198,41 @@ describe("SessionService.validateRequest", () => {
 		const standardTtlMs = standard.expiresAt.getTime() - Date.now();
 		const rememberedTtlMs = remembered.expiresAt.getTime() - Date.now();
 		expect(rememberedTtlMs).toBeGreaterThan(standardTtlMs * 10);
+	});
+
+	it("atomically rotates only a still-active session and runs the authorized mutation", async () => {
+		const current = await service.createSession("user-1");
+		const onRotate = vi.fn().mockResolvedValue(undefined);
+
+		const replacement = await service.rotateActiveSession(
+			current.token,
+			"user-1",
+			true,
+			{ userAgent: "vitest" },
+			onRotate,
+		);
+
+		expect(replacement).not.toBeNull();
+		expect(onRotate).toHaveBeenCalledTimes(1);
+		await expect(
+			service.validateRequest(makeRequest("signed-cookie", { valid: true, value: current.token })),
+		).resolves.toBeNull();
+		await expect(
+			service.validateRequest(
+				makeRequest("signed-cookie", { valid: true, value: replacement!.token }),
+			),
+		).resolves.not.toBeNull();
+	});
+
+	it("does not rotate or mutate after the initiating session is revoked", async () => {
+		const current = await service.createSession("user-1");
+		await service.invalidateSession(current.token);
+		const onRotate = vi.fn().mockResolvedValue(undefined);
+
+		await expect(
+			service.rotateActiveSession(current.token, "user-1", true, undefined, onRotate),
+		).resolves.toBeNull();
+		expect(onRotate).not.toHaveBeenCalled();
 	});
 
 	it("invalidateAllUserSessions(userId, exceptToken) hashes the exceptToken before scoping the delete", async () => {

--- a/apps/api/src/lib/auth/__tests__/session-validation.test.ts
+++ b/apps/api/src/lib/auth/__tests__/session-validation.test.ts
@@ -209,7 +209,7 @@ describe("SessionService.validateRequest", () => {
 			"user-1",
 			true,
 			{ userAgent: "vitest" },
-			onRotate,
+			{ onRotate },
 		);
 
 		expect(replacement).not.toBeNull();
@@ -230,9 +230,64 @@ describe("SessionService.validateRequest", () => {
 		const onRotate = vi.fn().mockResolvedValue(undefined);
 
 		await expect(
-			service.rotateActiveSession(current.token, "user-1", true, undefined, onRotate),
+			service.rotateActiveSession(current.token, "user-1", true, undefined, { onRotate }),
 		).resolves.toBeNull();
 		expect(onRotate).not.toHaveBeenCalled();
+	});
+
+	it("revokes every other user session before creating the rotated replacement", async () => {
+		const current = await service.createSession("user-1");
+		const otherSession = await service.createSession("user-1");
+		const otherUserSession = await service.createSession("user-2");
+		const onRotate = vi.fn(async () => {
+			// The initiating session is consumed first, while revocation runs
+			// after the credential mutation callback.
+			expect(prisma._sessions.size).toBe(2);
+		});
+
+		const replacement = await service.rotateActiveSession(
+			current.token,
+			"user-1",
+			true,
+			undefined,
+			{ onRotate, revokeOtherSessions: true },
+		);
+
+		expect(replacement).not.toBeNull();
+		await expect(
+			service.validateRequest(
+				makeRequest("signed-cookie", { valid: true, value: otherSession.token }),
+			),
+		).resolves.toBeNull();
+		await expect(
+			service.validateRequest(
+				makeRequest("signed-cookie", { valid: true, value: otherUserSession.token }),
+			),
+		).resolves.not.toBeNull();
+		await expect(
+			service.validateRequest(
+				makeRequest("signed-cookie", { valid: true, value: replacement!.token }),
+			),
+		).resolves.not.toBeNull();
+	});
+
+	it("creates a session only when the transactional authorization check succeeds", async () => {
+		const authorized = await service.createSessionIfAuthorized(
+			"user-1",
+			true,
+			undefined,
+			async () => true,
+		);
+		const denied = await service.createSessionIfAuthorized(
+			"user-1",
+			true,
+			undefined,
+			async () => false,
+		);
+
+		expect(authorized).not.toBeNull();
+		expect(denied).toBeNull();
+		expect(prisma._sessions.size).toBe(1);
 	});
 
 	it("invalidateAllUserSessions(userId, exceptToken) hashes the exceptToken before scoping the delete", async () => {

--- a/apps/api/src/lib/auth/session.ts
+++ b/apps/api/src/lib/auth/session.ts
@@ -40,6 +40,11 @@ export interface SessionMetadata {
 	ipAddress?: string;
 }
 
+interface SessionRotationOptions {
+	onRotate?: (tx: Prisma.TransactionClient) => Promise<void>;
+	revokeOtherSessions?: boolean;
+}
+
 export class SessionService {
 	constructor(
 		private readonly prisma: PrismaClient,
@@ -99,7 +104,7 @@ export class SessionService {
 		userId: string,
 		rememberMe = false,
 		metadata?: SessionMetadata,
-		onRotate?: (tx: Prisma.TransactionClient) => Promise<void>,
+		options?: SessionRotationOptions,
 	) {
 		const currentSessionId = hashToken(token);
 		const replacementToken = generateSessionToken();
@@ -123,7 +128,12 @@ export class SessionService {
 				return null;
 			}
 
-			await onRotate?.(tx);
+			await options?.onRotate?.(tx);
+			if (options?.revokeOtherSessions) {
+				await tx.session.deleteMany({
+					where: { userId },
+				});
+			}
 			await tx.session.create({
 				data: {
 					id: replacementSessionId,
@@ -135,6 +145,43 @@ export class SessionService {
 			});
 
 			return { token: replacementToken, expiresAt };
+		});
+	}
+
+	/**
+	 * Create a session only when an authorization check succeeds inside the
+	 * same transaction. The check may take a write lock on the credential row
+	 * so a concurrent credential replacement can revoke the resulting session.
+	 */
+	async createSessionIfAuthorized(
+		userId: string,
+		rememberMe: boolean,
+		metadata: SessionMetadata | undefined,
+		authorize: (tx: Prisma.TransactionClient) => Promise<boolean>,
+	) {
+		const token = generateSessionToken();
+		const hashedToken = hashToken(token);
+		const ttlMs = rememberMe
+			? REMEMBER_ME_TTL_DAYS * 24 * 60 * 60 * 1000
+			: this.env.SESSION_TTL_HOURS * 60 * 60 * 1000;
+		const expiresAt = new Date(Date.now() + ttlMs);
+
+		return this.prisma.$transaction(async (tx) => {
+			if (!(await authorize(tx))) {
+				return null;
+			}
+
+			await tx.session.create({
+				data: {
+					id: hashedToken,
+					userId,
+					expiresAt,
+					userAgent: metadata?.userAgent,
+					ipAddress: metadata?.ipAddress,
+				},
+			});
+
+			return { token, expiresAt };
 		});
 	}
 

--- a/apps/api/src/lib/auth/session.ts
+++ b/apps/api/src/lib/auth/session.ts
@@ -102,20 +102,26 @@ export class SessionService {
 	async rotateActiveSession(
 		token: string,
 		userId: string,
-		rememberMe = false,
 		metadata?: SessionMetadata,
 		options?: SessionRotationOptions,
 	) {
 		const currentSessionId = hashToken(token);
 		const replacementToken = generateSessionToken();
 		const replacementSessionId = hashToken(replacementToken);
-		const ttlMs = rememberMe
-			? REMEMBER_ME_TTL_DAYS * 24 * 60 * 60 * 1000
-			: this.env.SESSION_TTL_HOURS * 60 * 60 * 1000;
-		const expiresAt = new Date(Date.now() + ttlMs);
-		const now = new Date();
 
 		return this.prisma.$transaction(async (tx) => {
+			const currentSession = await tx.session.findUnique({
+				where: { id: currentSessionId },
+				select: {
+					userId: true,
+					expiresAt: true,
+				},
+			});
+			const now = new Date();
+			if (!currentSession || currentSession.userId !== userId || currentSession.expiresAt <= now) {
+				return null;
+			}
+
 			const consumed = await tx.session.deleteMany({
 				where: {
 					id: currentSessionId,
@@ -138,13 +144,13 @@ export class SessionService {
 				data: {
 					id: replacementSessionId,
 					userId,
-					expiresAt,
+					expiresAt: currentSession.expiresAt,
 					userAgent: metadata?.userAgent,
 					ipAddress: metadata?.ipAddress,
 				},
 			});
 
-			return { token: replacementToken, expiresAt };
+			return { token: replacementToken, expiresAt: currentSession.expiresAt };
 		});
 	}
 
@@ -269,10 +275,12 @@ export class SessionService {
 		return true;
 	}
 
-	attachCookie(reply: FastifyReply, token: string, rememberMe = false) {
-		const maxAgeSeconds = rememberMe
-			? REMEMBER_ME_TTL_DAYS * 24 * 60 * 60
-			: this.env.SESSION_TTL_HOURS * 60 * 60;
+	attachCookie(reply: FastifyReply, token: string, rememberMe = false, expiresAt?: Date) {
+		const maxAgeSeconds = expiresAt
+			? Math.max(0, Math.ceil((expiresAt.getTime() - Date.now()) / 1000))
+			: rememberMe
+				? REMEMBER_ME_TTL_DAYS * 24 * 60 * 60
+				: this.env.SESSION_TTL_HOURS * 60 * 60;
 
 		const options = BASE_COOKIE_OPTIONS(this.env, maxAgeSeconds);
 		reply.setCookie(this.env.SESSION_COOKIE_NAME, token, {

--- a/apps/api/src/lib/auth/session.ts
+++ b/apps/api/src/lib/auth/session.ts
@@ -1,7 +1,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import type { FastifyBaseLogger, FastifyReply, FastifyRequest } from "fastify";
 import type { ApiEnv } from "../../config/env.js";
-import type { PrismaClient } from "../../lib/prisma.js";
+import type { Prisma, PrismaClient } from "../../lib/prisma.js";
 
 /**
  * Base cookie options for session management.
@@ -84,6 +84,58 @@ export class SessionService {
 				// The cookie is still cleared client-side, and the session expires via TTL.
 				this.logger?.debug({ err }, "Best-effort session deletion failed during logout");
 			});
+	}
+
+	/**
+	 * Atomically replace an active session and optionally perform an authorized
+	 * database mutation in the same transaction.
+	 *
+	 * Consuming the current session makes revocation and rotation race safely:
+	 * whichever transaction removes the session first wins. The callback only
+	 * runs when the exact session still belongs to the user and is unexpired.
+	 */
+	async rotateActiveSession(
+		token: string,
+		userId: string,
+		rememberMe = false,
+		metadata?: SessionMetadata,
+		onRotate?: (tx: Prisma.TransactionClient) => Promise<void>,
+	) {
+		const currentSessionId = hashToken(token);
+		const replacementToken = generateSessionToken();
+		const replacementSessionId = hashToken(replacementToken);
+		const ttlMs = rememberMe
+			? REMEMBER_ME_TTL_DAYS * 24 * 60 * 60 * 1000
+			: this.env.SESSION_TTL_HOURS * 60 * 60 * 1000;
+		const expiresAt = new Date(Date.now() + ttlMs);
+		const now = new Date();
+
+		return this.prisma.$transaction(async (tx) => {
+			const consumed = await tx.session.deleteMany({
+				where: {
+					id: currentSessionId,
+					userId,
+					expiresAt: { gt: now },
+				},
+			});
+
+			if (consumed.count !== 1) {
+				return null;
+			}
+
+			await onRotate?.(tx);
+			await tx.session.create({
+				data: {
+					id: replacementSessionId,
+					userId,
+					expiresAt,
+					userAgent: metadata?.userAgent,
+					ipAddress: metadata?.ipAddress,
+				},
+			});
+
+			return { token: replacementToken, expiresAt };
+		});
 	}
 
 	async invalidateAllUserSessions(userId: string, exceptToken?: string) {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -103,6 +103,8 @@ function makeOidcProvider(overrides: Record<string, unknown> = {}) {
 		redirectUri: "http://localhost:3000/auth/oidc/callback",
 		scopes: "openid,email,profile",
 		enabled: true,
+		createdAt: new Date("2026-07-29T00:00:00.000Z"),
+		updatedAt: new Date("2026-07-29T00:00:00.000Z"),
 		...overrides,
 	};
 }
@@ -128,6 +130,7 @@ function createMockPrisma() {
 			id: 1,
 			...data,
 		})),
+		updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 	};
 
 	return {
@@ -417,6 +420,19 @@ describe("GET /auth/oidc/callback", () => {
 
 		expect(callback.statusCode).toBe(302);
 		expect(callback.headers.location).toBe("/settings#authentication");
+		expect(mockPrisma.oIDCProvider.updateMany).toHaveBeenCalledWith({
+			where: {
+				id: 1,
+				enabled: true,
+				clientId: "test-client-id",
+				encryptedClientSecret: "encrypted-secret",
+				clientSecretIv: "mock-iv",
+				issuer: "https://provider.example.com",
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+				scopes: "openid,email,profile",
+			},
+			data: { updatedAt: expect.any(Date) },
+		});
 		expect(mockPrisma.oIDCAccount.deleteMany).toHaveBeenCalledWith({
 			where: { userId: "admin-user" },
 		});
@@ -435,6 +451,32 @@ describe("GET /auth/oidc/callback", () => {
 				revokeOtherSessions: true,
 			},
 		);
+	});
+
+	it("does not recreate an OIDC link after the provider changes or is deleted", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCProvider.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "link" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
+		});
+
+		expect(callback.statusCode).toBe(409);
+		expect(JSON.parse(callback.payload).error).toContain("provider changed");
+		expect(mockPrisma.oIDCAccount.deleteMany).not.toHaveBeenCalled();
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
 	});
 
 	it("invalidates a pending account link when the initiating session is no longer active", async () => {
@@ -577,6 +619,19 @@ describe("GET /auth/oidc/callback", () => {
 			},
 			data: { updatedAt: expect.any(Date) },
 		});
+		expect(mockPrisma.oIDCProvider.updateMany).toHaveBeenCalledWith({
+			where: {
+				id: 1,
+				enabled: true,
+				clientId: "test-client-id",
+				encryptedClientSecret: "encrypted-secret",
+				clientSecretIv: "mock-iv",
+				issuer: "https://provider.example.com",
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+				scopes: "openid,email,profile",
+			},
+			data: { updatedAt: expect.any(Date) },
+		});
 		expect(mockSessionService.createSessionIfAuthorized).toHaveBeenCalledWith(
 			"admin-user",
 			true,
@@ -609,6 +664,73 @@ describe("GET /auth/oidc/callback", () => {
 		expect(JSON.parse(callback.payload).error).toContain("no longer linked");
 		expect(mockSessionService.createSession).not.toHaveBeenCalled();
 		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
+	});
+
+	it("does not mint an ordinary login session after the provider configuration changes", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+		mockPrisma.oIDCProvider.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain("no longer linked");
+		expect(mockPrisma.oIDCAccount.updateMany).not.toHaveBeenCalled();
+		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
+	});
+
+	it("allows simultaneous callbacks from the same unchanged provider snapshot", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+
+		const firstLogin = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const secondLogin = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const firstState = new URL(JSON.parse(firstLogin.payload).authorizationUrl).searchParams.get(
+			"state",
+		);
+		const secondState = new URL(JSON.parse(secondLogin.payload).authorizationUrl).searchParams.get(
+			"state",
+		);
+
+		const [firstCallback, secondCallback] = await Promise.all([
+			app.inject({
+				method: "GET",
+				url: `/auth/oidc/callback?code=first-code&state=${encodeURIComponent(firstState ?? "")}`,
+			}),
+			app.inject({
+				method: "GET",
+				url: `/auth/oidc/callback?code=second-code&state=${encodeURIComponent(secondState ?? "")}`,
+			}),
+		]);
+
+		expect(firstCallback.statusCode).toBe(302);
+		expect(secondCallback.statusCode).toBe(302);
+		expect(mockPrisma.oIDCProvider.updateMany).toHaveBeenCalledTimes(2);
+		for (const [call] of mockPrisma.oIDCProvider.updateMany.mock.calls) {
+			expect(call.where).not.toHaveProperty("updatedAt");
+		}
 	});
 
 	it("still refuses an unlinked OIDC identity when no authenticated admin initiated the flow", async () => {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -181,6 +181,7 @@ beforeEach(async () => {
 				createdAt: new Date(),
 				updatedAt: new Date(),
 			};
+			request.sessionToken = "admin-session-token";
 		}
 	});
 
@@ -374,6 +375,7 @@ describe("GET /auth/oidc/callback", () => {
 			method: "POST",
 			url: "/auth/oidc/login",
 			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "link" },
 		});
 		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
 		const state = authorizationUrl.searchParams.get("state");
@@ -381,6 +383,7 @@ describe("GET /auth/oidc/callback", () => {
 		const callback = await app.inject({
 			method: "GET",
 			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
 		});
 
 		expect(callback.statusCode).toBe(302);
@@ -392,6 +395,85 @@ describe("GET /auth/oidc/callback", () => {
 			},
 			include: { user: true },
 		});
+		expect(mockSessionService.createSession).toHaveBeenCalledWith(
+			"admin-user",
+			true,
+			expect.any(Object),
+		);
+	});
+
+	it("invalidates a pending account link when the initiating session is no longer active", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "link" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain("session is no longer active");
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+		expect(mockSessionService.createSession).not.toHaveBeenCalled();
+	});
+
+	it("tests only an OIDC identity already linked to the authenticated admin", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "test" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain("not linked");
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+		expect(mockSessionService.createSession).not.toHaveBeenCalled();
+	});
+
+	it("successfully tests an OIDC identity already linked to the authenticated admin", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "test" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
+		});
+
+		expect(callback.statusCode).toBe(302);
+		expect(callback.headers.location).toBe("/settings#authentication");
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
 		expect(mockSessionService.createSession).toHaveBeenCalledWith(
 			"admin-user",
 			true,
@@ -433,6 +515,7 @@ describe("GET /auth/oidc/callback", () => {
 			method: "POST",
 			url: "/auth/oidc/login",
 			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "link" },
 		});
 		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
 		const state = authorizationUrl.searchParams.get("state");
@@ -440,6 +523,7 @@ describe("GET /auth/oidc/callback", () => {
 		const callback = await app.inject({
 			method: "GET",
 			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
 		});
 
 		expect(callback.statusCode).toBe(409);

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -582,14 +582,55 @@ describe("GET /auth/oidc/callback", () => {
 			"admin-session-token",
 			"admin-user",
 			expect.any(Object),
-			undefined,
+			{ onRotate: expect.any(Function) },
 		);
+		expect(mockPrisma.oIDCProvider.updateMany).toHaveBeenCalledWith({
+			where: {
+				id: 1,
+				enabled: true,
+				clientId: "test-client-id",
+				encryptedClientSecret: "encrypted-secret",
+				clientSecretIv: "mock-iv",
+				issuer: "https://provider.example.com",
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+				scopes: "openid,email,profile",
+			},
+			data: { updatedAt: expect.any(Date) },
+		});
 		expect(mockSessionService.attachCookie).toHaveBeenCalledWith(
 			expect.anything(),
 			"mock-session-token",
 			true,
 			new Date("2026-07-30T00:00:00.000Z"),
 		);
+	});
+
+	it("does not report a successful account test after the provider changes", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+		mockPrisma.oIDCProvider.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "test" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
+		});
+
+		expect(callback.statusCode).toBe(409);
+		expect(JSON.parse(callback.payload).error).toContain("provider changed");
+		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
 	});
 
 	it("revalidates an ordinary OIDC login in the session-creation transaction", async () => {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -6,15 +6,18 @@ import { vi, describe, it, expect, beforeEach, afterAll } from "vitest";
 
 const { mockSessionService } = vi.hoisted(() => ({
 	mockSessionService: {
-		createSession: vi
-			.fn()
-			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
-		createSessionIfAuthorized: vi
-			.fn()
-			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
-		rotateActiveSession: vi
-			.fn()
-			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSession: vi.fn().mockResolvedValue({
+			token: "mock-session-token",
+			expiresAt: new Date("2026-07-30T00:00:00.000Z"),
+		}),
+		createSessionIfAuthorized: vi.fn().mockResolvedValue({
+			token: "mock-session-token",
+			expiresAt: new Date("2026-07-30T00:00:00.000Z"),
+		}),
+		rotateActiveSession: vi.fn().mockResolvedValue({
+			token: "mock-session-token",
+			expiresAt: new Date("2026-07-30T00:00:00.000Z"),
+		}),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -163,14 +166,22 @@ beforeEach(async () => {
 
 	mockPrisma = createMockPrisma();
 	mockSessionService.rotateActiveSession.mockImplementation(
-		async (_token, _userId, _rememberMe, _metadata, options) => {
+		async (_token, _userId, _metadata, options) => {
 			await options?.onRotate?.(mockPrisma);
-			return { token: "mock-session-token", id: "mock-session-id" };
+			return {
+				token: "mock-session-token",
+				expiresAt: new Date("2026-07-30T00:00:00.000Z"),
+			};
 		},
 	);
 	mockSessionService.createSessionIfAuthorized.mockImplementation(
 		async (_userId, _rememberMe, _metadata, authorize) =>
-			(await authorize(mockPrisma)) ? { token: "mock-session-token", id: "mock-session-id" } : null,
+			(await authorize(mockPrisma))
+				? {
+						token: "mock-session-token",
+						expiresAt: new Date("2026-07-30T00:00:00.000Z"),
+					}
+				: null,
 	);
 
 	app = Fastify();
@@ -418,7 +429,6 @@ describe("GET /auth/oidc/callback", () => {
 		expect(mockSessionService.rotateActiveSession).toHaveBeenCalledWith(
 			"admin-session-token",
 			"admin-user",
-			true,
 			expect.any(Object),
 			{
 				onRotate: expect.any(Function),
@@ -529,9 +539,14 @@ describe("GET /auth/oidc/callback", () => {
 		expect(mockSessionService.rotateActiveSession).toHaveBeenCalledWith(
 			"admin-session-token",
 			"admin-user",
-			true,
 			expect.any(Object),
 			undefined,
+		);
+		expect(mockSessionService.attachCookie).toHaveBeenCalledWith(
+			expect.anything(),
+			"mock-session-token",
+			true,
+			new Date("2026-07-30T00:00:00.000Z"),
 		);
 	});
 

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -9,6 +9,9 @@ const { mockSessionService } = vi.hoisted(() => ({
 		createSession: vi
 			.fn()
 			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		createSessionIfAuthorized: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		rotateActiveSession: vi
 			.fn()
 			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
@@ -131,6 +134,7 @@ function createMockPrisma() {
 			findUnique: vi.fn().mockResolvedValue(null),
 			create: vi.fn(),
 			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 		},
 		$transaction: vi.fn().mockImplementation(async (fn: any) => {
 			return fn({
@@ -159,10 +163,14 @@ beforeEach(async () => {
 
 	mockPrisma = createMockPrisma();
 	mockSessionService.rotateActiveSession.mockImplementation(
-		async (_token, _userId, _rememberMe, _metadata, onRotate) => {
-			await onRotate?.(mockPrisma);
+		async (_token, _userId, _rememberMe, _metadata, options) => {
+			await options?.onRotate?.(mockPrisma);
 			return { token: "mock-session-token", id: "mock-session-id" };
 		},
+	);
+	mockSessionService.createSessionIfAuthorized.mockImplementation(
+		async (_userId, _rememberMe, _metadata, authorize) =>
+			(await authorize(mockPrisma)) ? { token: "mock-session-token", id: "mock-session-id" } : null,
 	);
 
 	app = Fastify();
@@ -412,7 +420,10 @@ describe("GET /auth/oidc/callback", () => {
 			"admin-user",
 			true,
 			expect.any(Object),
-			expect.any(Function),
+			{
+				onRotate: expect.any(Function),
+				revokeOtherSessions: true,
+			},
 		);
 	});
 
@@ -522,6 +533,67 @@ describe("GET /auth/oidc/callback", () => {
 			expect.any(Object),
 			undefined,
 		);
+	});
+
+	it("revalidates an ordinary OIDC login in the session-creation transaction", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(302);
+		expect(mockPrisma.oIDCAccount.updateMany).toHaveBeenCalledWith({
+			where: {
+				providerUserId: "provider-user-1",
+				userId: "admin-user",
+			},
+			data: { updatedAt: expect.any(Date) },
+		});
+		expect(mockSessionService.createSessionIfAuthorized).toHaveBeenCalledWith(
+			"admin-user",
+			true,
+			expect.any(Object),
+			expect.any(Function),
+		);
+	});
+
+	it("does not mint an ordinary login session after Relink removes the old identity", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+		mockPrisma.oIDCAccount.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain("no longer linked");
+		expect(mockSessionService.createSession).not.toHaveBeenCalled();
+		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
 	});
 
 	it("still refuses an unlinked OIDC identity when no authenticated admin initiated the flow", async () => {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -75,7 +75,7 @@ vi.mock("../../lib/auth/session-metadata.js", () => ({
 // Imports (after mocks)
 // ---------------------------------------------------------------------------
 
-import Fastify from "fastify";
+import Fastify, { type FastifyRequest } from "fastify";
 import { registerAuthOidcRoutes } from "../auth-oidc.js";
 import { resolveCanonicalIssuer } from "../../lib/auth/oidc-utils.js";
 
@@ -172,6 +172,17 @@ beforeEach(async () => {
 	// Request decorations
 	app.decorateRequest("currentUser", null);
 	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (request: FastifyRequest) => {
+		if (request.headers["x-test-current-user"] === "admin-user") {
+			request.currentUser = {
+				id: "admin-user",
+				username: "admin",
+				mustChangePassword: false,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			};
+		}
+	});
 
 	// Register OIDC routes
 	await app.register(registerAuthOidcRoutes, { prefix: "/auth" });
@@ -350,6 +361,91 @@ describe("GET /auth/oidc/callback", () => {
 
 		expect(res.statusCode).toBe(302);
 		expect(res.headers.location).toBe("/");
+	});
+
+	it("links the OIDC identity to the authenticated admin who initiated the flow", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.create.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "admin-user", username: "admin" },
+		});
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(302);
+		expect(callback.headers.location).toBe("/settings#authentication");
+		expect(mockPrisma.oIDCAccount.create).toHaveBeenCalledWith({
+			data: {
+				providerUserId: "provider-user-1",
+				userId: "admin-user",
+			},
+			include: { user: true },
+		});
+		expect(mockSessionService.createSession).toHaveBeenCalledWith(
+			"admin-user",
+			true,
+			expect.any(Object),
+		);
+	});
+
+	it("still refuses an unlinked OIDC identity when no authenticated admin initiated the flow", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.user.count.mockResolvedValue(1);
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain(
+			"Cannot sign in with an unlinked OIDC account",
+		);
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+	});
+
+	it("refuses to relink an OIDC identity owned by a different account", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockPrisma.oIDCAccount.findUnique.mockResolvedValue({
+			providerUserId: "provider-user-1",
+			user: { id: "different-user", username: "different-admin" },
+		});
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+		});
+
+		expect(callback.statusCode).toBe(409);
+		expect(JSON.parse(callback.payload).error).toContain("already linked");
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+		expect(mockSessionService.createSession).not.toHaveBeenCalled();
 	});
 
 	it("returns 400 with invalid state (CSRF protection)", async () => {

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -9,6 +9,9 @@ const { mockSessionService } = vi.hoisted(() => ({
 		createSession: vi
 			.fn()
 			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
+		rotateActiveSession: vi
+			.fn()
+			.mockResolvedValue({ token: "mock-session-token", id: "mock-session-id" }),
 		attachCookie: vi.fn(),
 		invalidateSession: vi.fn().mockResolvedValue(undefined),
 		clearCookie: vi.fn(),
@@ -127,6 +130,7 @@ function createMockPrisma() {
 		oIDCAccount: {
 			findUnique: vi.fn().mockResolvedValue(null),
 			create: vi.fn(),
+			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 		},
 		$transaction: vi.fn().mockImplementation(async (fn: any) => {
 			return fn({
@@ -154,6 +158,12 @@ beforeEach(async () => {
 	);
 
 	mockPrisma = createMockPrisma();
+	mockSessionService.rotateActiveSession.mockImplementation(
+		async (_token, _userId, _rememberMe, _metadata, onRotate) => {
+			await onRotate?.(mockPrisma);
+			return { token: "mock-session-token", id: "mock-session-id" };
+		},
+	);
 
 	app = Fastify();
 
@@ -388,17 +398,21 @@ describe("GET /auth/oidc/callback", () => {
 
 		expect(callback.statusCode).toBe(302);
 		expect(callback.headers.location).toBe("/settings#authentication");
+		expect(mockPrisma.oIDCAccount.deleteMany).toHaveBeenCalledWith({
+			where: { userId: "admin-user" },
+		});
 		expect(mockPrisma.oIDCAccount.create).toHaveBeenCalledWith({
 			data: {
 				providerUserId: "provider-user-1",
 				userId: "admin-user",
 			},
-			include: { user: true },
 		});
-		expect(mockSessionService.createSession).toHaveBeenCalledWith(
+		expect(mockSessionService.rotateActiveSession).toHaveBeenCalledWith(
+			"admin-session-token",
 			"admin-user",
 			true,
 			expect.any(Object),
+			expect.any(Function),
 		);
 	});
 
@@ -423,6 +437,33 @@ describe("GET /auth/oidc/callback", () => {
 		expect(JSON.parse(callback.payload).error).toContain("session is no longer active");
 		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
 		expect(mockSessionService.createSession).not.toHaveBeenCalled();
+	});
+
+	it("does not link or mint a session when the initiating session is revoked during the OIDC exchange", async () => {
+		mockPrisma.oIDCProvider.findFirst.mockResolvedValue(makeOidcProvider());
+		mockSessionService.rotateActiveSession.mockResolvedValueOnce(null);
+
+		const login = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/login",
+			headers: { "x-test-current-user": "admin-user" },
+			payload: { intent: "link" },
+		});
+		const authorizationUrl = new URL(JSON.parse(login.payload).authorizationUrl);
+		const state = authorizationUrl.searchParams.get("state");
+
+		const callback = await app.inject({
+			method: "GET",
+			url: `/auth/oidc/callback?code=mock-auth-code&state=${encodeURIComponent(state ?? "")}`,
+			headers: { "x-test-current-user": "admin-user" },
+		});
+
+		expect(callback.statusCode).toBe(401);
+		expect(JSON.parse(callback.payload).error).toContain("session is no longer active");
+		expect(mockPrisma.oIDCAccount.deleteMany).not.toHaveBeenCalled();
+		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
+		expect(mockSessionService.createSession).not.toHaveBeenCalled();
+		expect(mockSessionService.attachCookie).not.toHaveBeenCalled();
 	});
 
 	it("tests only an OIDC identity already linked to the authenticated admin", async () => {
@@ -474,10 +515,12 @@ describe("GET /auth/oidc/callback", () => {
 		expect(callback.statusCode).toBe(302);
 		expect(callback.headers.location).toBe("/settings#authentication");
 		expect(mockPrisma.oIDCAccount.create).not.toHaveBeenCalled();
-		expect(mockSessionService.createSession).toHaveBeenCalledWith(
+		expect(mockSessionService.rotateActiveSession).toHaveBeenCalledWith(
+			"admin-session-token",
 			"admin-user",
 			true,
 			expect.any(Object),
+			undefined,
 		);
 	});
 

--- a/apps/api/src/routes/__tests__/auth.test.ts
+++ b/apps/api/src/routes/__tests__/auth.test.ts
@@ -94,7 +94,18 @@ function createMockPrisma() {
 			mustChangePassword: data.mustChangePassword ?? false,
 			createdAt: new Date("2024-01-01T00:00:00Z"),
 		})),
+		updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 		delete: vi.fn().mockResolvedValue(undefined),
+	};
+
+	const oidcAccountMock = {
+		count: vi.fn().mockResolvedValue(0),
+		updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+	};
+	const oidcProviderMock = {
+		findFirst: vi.fn().mockResolvedValue(null),
+		findUnique: vi.fn().mockResolvedValue(null),
+		updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 	};
 
 	return {
@@ -103,23 +114,21 @@ function createMockPrisma() {
 			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
 			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 		},
-		oIDCAccount: {
-			count: vi.fn().mockResolvedValue(0),
-		},
+		oIDCAccount: oidcAccountMock,
 		webAuthnCredential: {
 			count: vi.fn().mockResolvedValue(0),
 		},
-		oIDCProvider: {
-			findFirst: vi.fn().mockResolvedValue(null),
-			findUnique: vi.fn().mockResolvedValue(null),
-		},
+		oIDCProvider: oidcProviderMock,
 		session: {
 			findMany: vi.fn().mockResolvedValue([]),
 		},
 		// $transaction: execute the callback with the same prisma mock as `tx`
 		$transaction: vi.fn().mockImplementation(async (fn: (tx: any) => Promise<any>) => {
-			// The tx object exposes the same user methods
-			return fn({ user: userMock });
+			return fn({
+				user: userMock,
+				oIDCAccount: oidcAccountMock,
+				oIDCProvider: oidcProviderMock,
+			});
 		}),
 	};
 }
@@ -471,6 +480,65 @@ describe("PATCH /auth/account", () => {
 
 		expect(res.statusCode).toBe(200);
 		expect(hashPassword).toHaveBeenCalledWith("NewPass123!");
+	});
+});
+
+describe("DELETE /auth/password", () => {
+	const oidcProvider = {
+		id: 1,
+		enabled: true,
+		clientId: "arr-dashboard",
+		encryptedClientSecret: "encrypted-secret",
+		clientSecretIv: "secret-iv",
+		issuer: "https://auth.example.com",
+		redirectUri: "https://arr.example.com/auth/oidc/callback",
+		scopes: "openid,email,profile",
+	};
+
+	beforeEach(() => {
+		mockPrisma.user.findUnique.mockResolvedValue(makeUser());
+		mockPrisma.oIDCAccount.count.mockResolvedValue(1);
+		mockPrisma.oIDCProvider.findUnique.mockResolvedValue(oidcProvider);
+	});
+
+	it("revalidates the provider, link, and password in one transaction", async () => {
+		const res = await injectAuthenticated("DELETE", "/auth/password", {
+			body: { currentPassword: "oldpassword1" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockPrisma.oIDCProvider.updateMany).toHaveBeenCalledWith({
+			where: {
+				...oidcProvider,
+				enabled: true,
+			},
+			data: { updatedAt: expect.any(Date) },
+		});
+		expect(mockPrisma.oIDCAccount.updateMany).toHaveBeenCalledWith({
+			where: { userId: "user-1" },
+			data: { updatedAt: expect.any(Date) },
+		});
+		expect(mockPrisma.user.updateMany).toHaveBeenCalledWith({
+			where: {
+				id: "user-1",
+				hashedPassword: "$argon2id$existing-hash",
+			},
+			data: { hashedPassword: null },
+		});
+	});
+
+	it("does not remove the replacement password after provider deletion wins the race", async () => {
+		mockPrisma.oIDCProvider.updateMany.mockResolvedValueOnce({ count: 0 });
+
+		const res = await injectAuthenticated("DELETE", "/auth/password", {
+			body: { currentPassword: "oldpassword1" },
+		});
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).error).toContain("Authentication settings changed");
+		expect(mockPrisma.oIDCAccount.updateMany).not.toHaveBeenCalled();
+		expect(mockPrisma.user.updateMany).not.toHaveBeenCalled();
+		expect(mockSessionService.invalidateAllUserSessions).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -19,16 +19,54 @@ const provider = {
 let app: ReturnType<typeof Fastify>;
 const findProvider = vi.fn();
 const findLinkedAccount = vi.fn();
+const findUniqueProvider = vi.fn();
+const deleteProvider = vi.fn();
+const deleteOidcAccounts = vi.fn();
+const findOidcOnlyUsers = vi.fn();
+const updateUser = vi.fn();
+const runTransaction = vi.fn();
+const deleteSessions = vi.fn();
+const clearCookie = vi.fn();
 
 beforeEach(async () => {
 	findProvider.mockReset();
 	findLinkedAccount.mockReset();
+	findUniqueProvider.mockReset();
+	deleteProvider.mockReset();
+	deleteOidcAccounts.mockReset();
+	findOidcOnlyUsers.mockReset();
+	updateUser.mockReset();
+	runTransaction.mockReset();
+	deleteSessions.mockReset();
+	clearCookie.mockReset();
+
+	findUniqueProvider.mockResolvedValue(provider);
+	deleteProvider.mockResolvedValue({ count: 1 });
+	deleteOidcAccounts.mockResolvedValue({ count: 1 });
+	findOidcOnlyUsers.mockResolvedValue([{ id: "admin-user" }]);
+	updateUser.mockResolvedValue({ id: "admin-user" });
+	deleteSessions.mockResolvedValue({ count: 1 });
+	runTransaction.mockImplementation(async (callback) =>
+		callback({
+			oIDCProvider: { deleteMany: deleteProvider },
+			oIDCAccount: { deleteMany: deleteOidcAccounts },
+			user: { findMany: findOidcOnlyUsers, update: updateUser },
+			session: { deleteMany: deleteSessions },
+		}),
+	);
 
 	app = Fastify();
 	app.decorate("prisma", {
-		oIDCProvider: { findFirst: findProvider },
+		oIDCProvider: {
+			findFirst: findProvider,
+			findUnique: findUniqueProvider,
+		},
 		oIDCAccount: { findFirst: findLinkedAccount },
+		user: { findMany: findOidcOnlyUsers },
+		session: { deleteMany: deleteSessions },
+		$transaction: runTransaction,
 	});
+	app.decorate("sessionService", { clearCookie });
 	app.decorateRequest("currentUser", null);
 	app.decorateRequest("sessionToken", null);
 	app.addHook("preHandler", async (request: FastifyRequest) => {
@@ -39,6 +77,7 @@ beforeEach(async () => {
 			createdAt: new Date(),
 			updatedAt: new Date(),
 		};
+		request.sessionToken = "admin-session-token";
 	});
 	await app.register(oidcProvidersRoutes);
 	await app.ready();
@@ -74,5 +113,80 @@ describe("GET /api/oidc-providers", () => {
 		expect(response.statusCode).toBe(200);
 		expect(JSON.parse(response.payload)).toEqual({ provider: null, linked: false });
 		expect(findLinkedAccount).not.toHaveBeenCalled();
+	});
+});
+
+describe("DELETE /api/oidc-providers", () => {
+	it("deletes the exact provider and its links in one transaction", async () => {
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(204);
+		expect(deleteProvider).toHaveBeenCalledWith({
+			where: {
+				id: provider.id,
+				enabled: true,
+				clientId: provider.clientId,
+				encryptedClientSecret: provider.encryptedClientSecret,
+				clientSecretIv: provider.clientSecretIv,
+				issuer: provider.issuer,
+				redirectUri: provider.redirectUri,
+				scopes: provider.scopes,
+			},
+		});
+		expect(deleteOidcAccounts).toHaveBeenCalledWith({});
+		expect(findOidcOnlyUsers).toHaveBeenCalledWith({
+			where: { oidcAccounts: { some: {} } },
+			select: { id: true },
+		});
+		expect(updateUser).toHaveBeenCalledWith({
+			where: { id: "admin-user" },
+			data: {
+				hashedPassword: expect.any(String),
+				mustChangePassword: false,
+			},
+		});
+		expect(deleteSessions).toHaveBeenCalledWith({});
+		expect(deleteProvider.mock.invocationCallOrder[0]).toBeLessThan(
+			deleteOidcAccounts.mock.invocationCallOrder[0]!,
+		);
+		expect(clearCookie).toHaveBeenCalledWith(expect.anything());
+	});
+
+	it("does not remove links when the provider changed before deletion acquired it", async () => {
+		deleteProvider.mockResolvedValueOnce({ count: 0 });
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(JSON.parse(response.payload).error).toContain("provider changed");
+		expect(deleteOidcAccounts).not.toHaveBeenCalled();
+		expect(deleteSessions).not.toHaveBeenCalled();
+		expect(clearCookie).not.toHaveBeenCalled();
+	});
+
+	it("keeps provider cleanup and session revocation in one transaction", async () => {
+		deleteSessions.mockRejectedValueOnce(new Error("database cleanup failed"));
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(500);
+		expect(runTransaction).toHaveBeenCalledTimes(1);
+		expect(deleteProvider).toHaveBeenCalled();
+		expect(updateUser).toHaveBeenCalled();
+		expect(deleteOidcAccounts).toHaveBeenCalled();
+		expect(deleteSessions).toHaveBeenCalledWith({});
+		expect(clearCookie).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -1,0 +1,78 @@
+import Fastify, { type FastifyRequest } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import oidcProvidersRoutes from "../oidc-providers.js";
+
+const provider = {
+	id: 1,
+	displayName: "Authentik",
+	clientId: "arr-dashboard",
+	encryptedClientSecret: "encrypted",
+	clientSecretIv: "iv",
+	issuer: "https://auth.example.com/application/o/arr-dashboard/",
+	redirectUri: "https://arr.example.com/auth/oidc/callback",
+	scopes: "openid,email,profile",
+	enabled: true,
+	createdAt: new Date("2026-07-29T00:00:00.000Z"),
+	updatedAt: new Date("2026-07-29T00:00:00.000Z"),
+};
+
+let app: ReturnType<typeof Fastify>;
+const findProvider = vi.fn();
+const findLinkedAccount = vi.fn();
+
+beforeEach(async () => {
+	findProvider.mockReset();
+	findLinkedAccount.mockReset();
+
+	app = Fastify();
+	app.decorate("prisma", {
+		oIDCProvider: { findFirst: findProvider },
+		oIDCAccount: { findFirst: findLinkedAccount },
+	});
+	app.decorateRequest("currentUser", null);
+	app.decorateRequest("sessionToken", null);
+	app.addHook("preHandler", async (request: FastifyRequest) => {
+		request.currentUser = {
+			id: "admin-user",
+			username: "admin",
+			mustChangePassword: false,
+			createdAt: new Date(),
+			updatedAt: new Date(),
+		};
+	});
+	await app.register(oidcProvidersRoutes);
+	await app.ready();
+});
+
+afterEach(async () => {
+	await app?.close();
+});
+
+describe("GET /api/oidc-providers", () => {
+	it("reports whether the current admin has linked the configured provider", async () => {
+		findProvider.mockResolvedValue(provider);
+		findLinkedAccount.mockResolvedValue({ id: "oidc-account-1" });
+
+		const response = await app.inject({ method: "GET", url: "/api/oidc-providers" });
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			provider: { displayName: "Authentik" },
+			linked: true,
+		});
+		expect(findLinkedAccount).toHaveBeenCalledWith({
+			where: { userId: "admin-user" },
+			select: { id: true },
+		});
+	});
+
+	it("returns an unlinked state when no provider is configured", async () => {
+		findProvider.mockResolvedValue(null);
+
+		const response = await app.inject({ method: "GET", url: "/api/oidc-providers" });
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toEqual({ provider: null, linked: false });
+		expect(findLinkedAccount).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -43,7 +43,7 @@ beforeEach(async () => {
 	findUniqueProvider.mockResolvedValue(provider);
 	deleteProvider.mockResolvedValue({ count: 1 });
 	deleteOidcAccounts.mockResolvedValue({ count: 1 });
-	findOidcOnlyUsers.mockResolvedValue([{ id: "admin-user" }]);
+	findOidcOnlyUsers.mockResolvedValue([{ id: "admin-user", hashedPassword: null }]);
 	updateUser.mockResolvedValue({ id: "admin-user" });
 	deleteSessions.mockResolvedValue({ count: 1 });
 	runTransaction.mockImplementation(async (callback) =>
@@ -125,6 +125,13 @@ describe("DELETE /api/oidc-providers", () => {
 		});
 
 		expect(response.statusCode).toBe(204);
+		expect(deleteSessions).toHaveBeenNthCalledWith(1, {
+			where: {
+				id: expect.any(String),
+				userId: "admin-user",
+				expiresAt: { gt: expect.any(Date) },
+			},
+		});
 		expect(deleteProvider).toHaveBeenCalledWith({
 			where: {
 				id: provider.id,
@@ -140,7 +147,7 @@ describe("DELETE /api/oidc-providers", () => {
 		expect(deleteOidcAccounts).toHaveBeenCalledWith({});
 		expect(findOidcOnlyUsers).toHaveBeenCalledWith({
 			where: { oidcAccounts: { some: {} } },
-			select: { id: true },
+			select: { id: true, hashedPassword: true },
 		});
 		expect(updateUser).toHaveBeenCalledWith({
 			where: { id: "admin-user" },
@@ -149,11 +156,29 @@ describe("DELETE /api/oidc-providers", () => {
 				mustChangePassword: false,
 			},
 		});
-		expect(deleteSessions).toHaveBeenCalledWith({});
+		expect(deleteSessions).toHaveBeenLastCalledWith({});
 		expect(deleteProvider.mock.invocationCallOrder[0]).toBeLessThan(
 			deleteOidcAccounts.mock.invocationCallOrder[0]!,
 		);
 		expect(clearCookie).toHaveBeenCalledWith(expect.anything());
+	});
+
+	it("preserves an existing password while deleting OIDC", async () => {
+		findOidcOnlyUsers.mockResolvedValueOnce([
+			{ id: "admin-user", hashedPassword: "$argon2id$existing-password" },
+		]);
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(204);
+		expect(updateUser).not.toHaveBeenCalled();
+		expect(deleteProvider).toHaveBeenCalled();
+		expect(deleteOidcAccounts).toHaveBeenCalled();
+		expect(deleteSessions).toHaveBeenLastCalledWith({});
 	});
 
 	it("does not remove links when the provider changed before deletion acquired it", async () => {
@@ -168,12 +193,31 @@ describe("DELETE /api/oidc-providers", () => {
 		expect(response.statusCode).toBe(409);
 		expect(JSON.parse(response.payload).error).toContain("provider changed");
 		expect(deleteOidcAccounts).not.toHaveBeenCalled();
-		expect(deleteSessions).not.toHaveBeenCalled();
+		expect(deleteSessions).toHaveBeenCalledTimes(1);
+		expect(clearCookie).not.toHaveBeenCalled();
+	});
+
+	it("does not delete OIDC after the initiating session is revoked", async () => {
+		deleteSessions.mockResolvedValueOnce({ count: 0 });
+
+		const response = await app.inject({
+			method: "DELETE",
+			url: "/api/oidc-providers",
+			payload: { replacementPassword: "Safe-Replacement1!" },
+		});
+
+		expect(response.statusCode).toBe(401);
+		expect(JSON.parse(response.payload).error).toContain("session is no longer active");
+		expect(deleteProvider).not.toHaveBeenCalled();
+		expect(updateUser).not.toHaveBeenCalled();
+		expect(deleteOidcAccounts).not.toHaveBeenCalled();
 		expect(clearCookie).not.toHaveBeenCalled();
 	});
 
 	it("keeps provider cleanup and session revocation in one transaction", async () => {
-		deleteSessions.mockRejectedValueOnce(new Error("database cleanup failed"));
+		deleteSessions
+			.mockResolvedValueOnce({ count: 1 })
+			.mockRejectedValueOnce(new Error("database cleanup failed"));
 
 		const response = await app.inject({
 			method: "DELETE",

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -459,6 +459,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 			let user: { id: string; username: string };
 			let replaceOidcLink = false;
+			let revalidateOidcLink = false;
 
 			if (storedState.intent === "link") {
 				if (oidcAccount && oidcAccount.user.id !== storedState.linkUserId) {
@@ -482,6 +483,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			} else if (oidcAccount) {
 				// Existing OIDC account - log them in
 				user = oidcAccount.user;
+				revalidateOidcLink = true;
 			} else {
 				// User is not authenticated - check if this is initial setup
 				// Use transaction to atomically check user count and create user
@@ -534,25 +536,45 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 						true,
 						metadata,
 						replaceOidcLink
-							? async (tx) => {
-									await tx.oIDCAccount.deleteMany({
-										where: { userId: user.id },
-									});
-									await tx.oIDCAccount.create({
-										data: {
-											providerUserId: userInfo.sub,
-											userId: user.id,
-										},
-									});
+							? {
+									onRotate: async (tx) => {
+										await tx.oIDCAccount.deleteMany({
+											where: { userId: user.id },
+										});
+										await tx.oIDCAccount.create({
+											data: {
+												providerUserId: userInfo.sub,
+												userId: user.id,
+											},
+										});
+									},
+									revokeOtherSessions: true,
 								}
 							: undefined,
 					)
-				: await app.sessionService.createSession(user.id, true, metadata);
+				: revalidateOidcLink
+					? await app.sessionService.createSessionIfAuthorized(
+							user.id,
+							true,
+							metadata,
+							async (tx) => {
+								const linked = await tx.oIDCAccount.updateMany({
+									where: {
+										providerUserId: userInfo.sub,
+										userId: user.id,
+									},
+									data: { updatedAt: new Date() },
+								});
+								return linked.count === 1;
+							},
+						)
+					: await app.sessionService.createSession(user.id, true, metadata);
 
 			if (!session) {
 				return reply.status(401).send({
-					error:
-						"The OIDC account action expired because the initiating session is no longer active. Sign in and try again.",
+					error: isAccountAction
+						? "The OIDC account action expired because the initiating session is no longer active. Sign in and try again."
+						: "This OIDC identity is no longer linked. Sign in with another method and try again.",
 				});
 			}
 			app.sessionService.attachCookie(reply, session.token, true);

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import type { FastifyPluginCallback } from "fastify";
 import * as oauth from "oauth4webapi";
 import { z } from "zod";
@@ -16,12 +16,13 @@ interface OIDCStateData {
 	nonce: string;
 	codeVerifier: string;
 	expiresAt: number;
+	intent: "login" | "link" | "test";
 	/**
 	 * The authenticated admin who explicitly initiated an account-link flow.
-	 * This is server-side state, so the callback does not need to rely on the
-	 * browser session cookie surviving the round trip through the provider.
+	 * The session digest binds the callback to the same still-active session.
 	 */
 	linkUserId?: string;
+	linkSessionDigest?: string;
 }
 
 const oidcStateStore = new Map<string, OIDCStateData>();
@@ -50,6 +51,10 @@ function sanitizeOIDCError(value: unknown, maxLength = 200): string {
 const oidcCallbackSchema = z.object({
 	code: z.string(),
 	state: z.string(),
+});
+
+const oidcLoginSchema = z.object({
+	intent: z.enum(["login", "link", "test"]).default("login"),
 });
 
 const oidcSetupSchema = z.object({
@@ -218,6 +223,15 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		"/oidc/login",
 		{ config: { rateLimit: OIDC_LOGIN_RATE_LIMIT } },
 		async (request, reply) => {
+			const { intent } = validateRequest(oidcLoginSchema, request.body ?? {});
+			const isAccountAction = intent === "link" || intent === "test";
+
+			if (isAccountAction && (!request.currentUser || !request.sessionToken)) {
+				return reply.status(401).send({
+					error: "Authentication is required to link or test an OIDC account.",
+				});
+			}
+
 			// Get OIDC configuration from database
 			const dbProvider = await app.prisma.oIDCProvider.findFirst({
 				where: { enabled: true },
@@ -260,7 +274,11 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				nonce,
 				codeVerifier,
 				expiresAt: Date.now() + 15 * 60 * 1000,
-				linkUserId: request.currentUser?.id,
+				intent,
+				linkUserId: isAccountAction ? request.currentUser!.id : undefined,
+				linkSessionDigest: isAccountAction
+					? createHash("sha256").update(request.sessionToken!).digest("base64url")
+					: undefined,
 			});
 
 			try {
@@ -342,6 +360,21 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		// Remove state to prevent replay attacks
 		oidcStateStore.delete(state);
 
+		if (storedState.intent === "link" || storedState.intent === "test") {
+			const callbackSessionDigest = request.sessionToken
+				? createHash("sha256").update(request.sessionToken).digest("base64url")
+				: undefined;
+			if (
+				request.currentUser?.id !== storedState.linkUserId ||
+				callbackSessionDigest !== storedState.linkSessionDigest
+			) {
+				return reply.status(401).send({
+					error:
+						"The OIDC account action expired because the initiating session is no longer active. Sign in and try again.",
+				});
+			}
+		}
+
 		request.log.info({ hasCode: !!code }, "Processing OIDC callback");
 
 		// Get OIDC configuration from database
@@ -369,7 +402,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		try {
 			let createdInitialUser = false;
-			let linkedExistingUser = false;
+			const isAccountAction = storedState.intent === "link" || storedState.intent === "test";
 			// Convert query object to URLSearchParams for oauth4webapi
 			const queryParams = new URLSearchParams();
 			for (const [key, value] of Object.entries(request.query as Record<string, string>)) {
@@ -427,33 +460,29 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			let user: { id: string; username: string };
 
 			if (oidcAccount) {
-				if (storedState.linkUserId && oidcAccount.user.id !== storedState.linkUserId) {
+				if (isAccountAction && oidcAccount.user.id !== storedState.linkUserId) {
 					return reply.status(409).send({
 						error: "This OIDC identity is already linked to another account.",
 					});
 				}
 				// Existing OIDC account - log them in
 				user = oidcAccount.user;
-				linkedExistingUser = storedState.linkUserId !== undefined;
 			} else {
-				// New OIDC account - check if user is authenticated or if this is setup
-
-				// Prefer the authenticated admin captured when the flow started.
-				// Falling back to the callback session preserves existing behavior
-				// for flows initiated before this linking intent was introduced.
-				const linkUserId = storedState.linkUserId ?? request.currentUser?.id;
-
-				if (linkUserId) {
+				if (storedState.intent === "link") {
 					// Link the provider identity to the admin who initiated the flow.
 					oidcAccount = await app.prisma.oIDCAccount.create({
 						data: {
 							providerUserId: userInfo.sub,
-							userId: linkUserId,
+							userId: storedState.linkUserId!,
 						},
 						include: { user: true },
 					});
 					user = oidcAccount.user;
-					linkedExistingUser = true;
+				} else if (storedState.intent === "test") {
+					return reply.status(401).send({
+						error:
+							"This OIDC identity is not linked to the admin account. Use Link Account to add it explicitly.",
+					});
 				} else {
 					// User is not authenticated - check if this is initial setup
 					// Use transaction to atomically check user count and create user
@@ -490,7 +519,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							// Setup already completed by concurrent request
 							return reply.status(401).send({
 								error:
-									"Cannot sign in with an unlinked OIDC account. Sign in with your password, then use Link or Test Account in Settings > Authentication.",
+									"Cannot sign in with an unlinked OIDC account. Sign in with your password, then use Link Account in Settings > Authentication.",
 							});
 						}
 						throw error;
@@ -510,7 +539,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 			const redirectPath = createdInitialUser
 				? "/setup?stage=services"
-				: linkedExistingUser
+				: isAccountAction
 					? "/settings#authentication"
 					: "/";
 			request.log.info(

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -16,6 +16,12 @@ interface OIDCStateData {
 	nonce: string;
 	codeVerifier: string;
 	expiresAt: number;
+	/**
+	 * The authenticated admin who explicitly initiated an account-link flow.
+	 * This is server-side state, so the callback does not need to rely on the
+	 * browser session cookie surviving the round trip through the provider.
+	 */
+	linkUserId?: string;
 }
 
 const oidcStateStore = new Map<string, OIDCStateData>();
@@ -254,6 +260,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				nonce,
 				codeVerifier,
 				expiresAt: Date.now() + 15 * 60 * 1000,
+				linkUserId: request.currentUser?.id,
 			});
 
 			try {
@@ -362,6 +369,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		try {
 			let createdInitialUser = false;
+			let linkedExistingUser = false;
 			// Convert query object to URLSearchParams for oauth4webapi
 			const queryParams = new URLSearchParams();
 			for (const [key, value] of Object.entries(request.query as Record<string, string>)) {
@@ -419,24 +427,33 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			let user: { id: string; username: string };
 
 			if (oidcAccount) {
+				if (storedState.linkUserId && oidcAccount.user.id !== storedState.linkUserId) {
+					return reply.status(409).send({
+						error: "This OIDC identity is already linked to another account.",
+					});
+				}
 				// Existing OIDC account - log them in
 				user = oidcAccount.user;
+				linkedExistingUser = storedState.linkUserId !== undefined;
 			} else {
 				// New OIDC account - check if user is authenticated or if this is setup
 
-				// Check if user is currently authenticated (has active session)
-				const currentUser = request.currentUser;
+				// Prefer the authenticated admin captured when the flow started.
+				// Falling back to the callback session preserves existing behavior
+				// for flows initiated before this linking intent was introduced.
+				const linkUserId = storedState.linkUserId ?? request.currentUser?.id;
 
-				if (currentUser) {
-					// User is logged in - link OIDC to their account
+				if (linkUserId) {
+					// Link the provider identity to the admin who initiated the flow.
 					oidcAccount = await app.prisma.oIDCAccount.create({
 						data: {
 							providerUserId: userInfo.sub,
-							userId: currentUser.id,
+							userId: linkUserId,
 						},
 						include: { user: true },
 					});
 					user = oidcAccount.user;
+					linkedExistingUser = true;
 				} else {
 					// User is not authenticated - check if this is initial setup
 					// Use transaction to atomically check user count and create user
@@ -473,7 +490,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							// Setup already completed by concurrent request
 							return reply.status(401).send({
 								error:
-									"Cannot link OIDC account without authentication. Please log in first and add OIDC from settings.",
+									"Cannot sign in with an unlinked OIDC account. Sign in with your password, then use Link or Test Account in Settings > Authentication.",
 							});
 						}
 						throw error;
@@ -491,7 +508,11 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				request.log.debug({ err }, "Connection warm-up wrapper error (non-critical)");
 			});
 
-			const redirectPath = createdInitialUser ? "/setup?stage=services" : "/";
+			const redirectPath = createdInitialUser
+				? "/setup?stage=services"
+				: linkedExistingUser
+					? "/settings#authentication"
+					: "/";
 			request.log.info(
 				{ userId: user.id, username: user.username, redirectPath },
 				"OIDC authentication successful",

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -68,6 +68,7 @@ const oidcSetupSchema = z.object({
 
 const OIDC_SETUP_RATE_LIMIT = { max: 5, timeWindow: "1 minute" };
 const OIDC_LOGIN_RATE_LIMIT = { max: 10, timeWindow: "1 minute" };
+const OIDC_PROVIDER_CHANGED = "OIDC_PROVIDER_CHANGED";
 
 const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 	/**
@@ -386,6 +387,17 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			return reply.status(500).send({ error: "OIDC provider configuration error" });
 		}
 
+		const providerAuthVersion = {
+			id: dbProvider.id,
+			enabled: true,
+			clientId: dbProvider.clientId,
+			encryptedClientSecret: dbProvider.encryptedClientSecret,
+			clientSecretIv: dbProvider.clientSecretIv,
+			issuer: dbProvider.issuer,
+			redirectUri: dbProvider.redirectUri,
+			scopes: dbProvider.scopes,
+		};
+
 		// Decrypt client secret
 		const clientSecret = app.encryptor.decrypt({
 			value: dbProvider.encryptedClientSecret,
@@ -537,6 +549,13 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 						replaceOidcLink
 							? {
 									onRotate: async (tx) => {
+										const providerStillCurrent = await tx.oIDCProvider.updateMany({
+											where: providerAuthVersion,
+											data: { updatedAt: new Date() },
+										});
+										if (providerStillCurrent.count !== 1) {
+											throw new Error(OIDC_PROVIDER_CHANGED);
+										}
 										await tx.oIDCAccount.deleteMany({
 											where: { userId: user.id },
 										});
@@ -557,6 +576,13 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 							true,
 							metadata,
 							async (tx) => {
+								const providerStillCurrent = await tx.oIDCProvider.updateMany({
+									where: providerAuthVersion,
+									data: { updatedAt: new Date() },
+								});
+								if (providerStillCurrent.count !== 1) {
+									return false;
+								}
 								const linked = await tx.oIDCAccount.updateMany({
 									where: {
 										providerUserId: userInfo.sub,
@@ -599,6 +625,17 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			);
 			return reply.redirect(redirectPath, 302);
 		} catch (error: unknown) {
+			if (error instanceof Error && error.message === OIDC_PROVIDER_CHANGED) {
+				request.log.warn(
+					{ providerId: dbProvider.id },
+					"OIDC provider changed while an account link was in progress",
+				);
+				return reply.status(409).send({
+					error:
+						"The OIDC provider changed while the account link was in progress. Start Link Account again with the current provider configuration.",
+				});
+			}
+
 			const errMsg = getErrorMessage(error);
 			const errStack = error instanceof Error ? error.stack : undefined;
 			request.log.error(

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -568,7 +568,17 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 									},
 									revokeOtherSessions: true,
 								}
-							: undefined,
+							: {
+									onRotate: async (tx) => {
+										const providerStillCurrent = await tx.oIDCProvider.updateMany({
+											where: providerAuthVersion,
+											data: { updatedAt: new Date() },
+										});
+										if (providerStillCurrent.count !== 1) {
+											throw new Error(OIDC_PROVIDER_CHANGED);
+										}
+									},
+								},
 					)
 				: revalidateOidcLink
 					? await app.sessionService.createSessionIfAuthorized(
@@ -632,7 +642,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				);
 				return reply.status(409).send({
 					error:
-						"The OIDC provider changed while the account link was in progress. Start Link Account again with the current provider configuration.",
+						"The OIDC provider changed while the account action was in progress. Start the action again with the current provider configuration.",
 				});
 			}
 

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -533,7 +533,6 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				? await app.sessionService.rotateActiveSession(
 						request.sessionToken!,
 						user.id,
-						true,
 						metadata,
 						replaceOidcLink
 							? {
@@ -577,7 +576,12 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 						: "This OIDC identity is no longer linked. Sign in with another method and try again.",
 				});
 			}
-			app.sessionService.attachCookie(reply, session.token, true);
+			app.sessionService.attachCookie(
+				reply,
+				session.token,
+				true,
+				isAccountAction ? session.expiresAt : undefined,
+			);
 
 			// Pre-warm connections to ARR instances in background (don't await)
 			warmConnectionsForUser(app, user.id).catch((err) => {

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -450,7 +450,7 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			request.log.info({ sub: userInfo.sub }, "Retrieved user info from OIDC provider");
 
 			// Find existing OIDC account
-			let oidcAccount = await app.prisma.oIDCAccount.findUnique({
+			const oidcAccount = await app.prisma.oIDCAccount.findUnique({
 				where: {
 					providerUserId: userInfo.sub,
 				},
@@ -458,78 +458,103 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			});
 
 			let user: { id: string; username: string };
+			let replaceOidcLink = false;
 
-			if (oidcAccount) {
-				if (isAccountAction && oidcAccount.user.id !== storedState.linkUserId) {
+			if (storedState.intent === "link") {
+				if (oidcAccount && oidcAccount.user.id !== storedState.linkUserId) {
 					return reply.status(409).send({
 						error: "This OIDC identity is already linked to another account.",
 					});
 				}
-				// Existing OIDC account - log them in
-				user = oidcAccount.user;
-			} else {
-				if (storedState.intent === "link") {
-					// Link the provider identity to the admin who initiated the flow.
-					oidcAccount = await app.prisma.oIDCAccount.create({
-						data: {
-							providerUserId: userInfo.sub,
-							userId: storedState.linkUserId!,
-						},
-						include: { user: true },
-					});
-					user = oidcAccount.user;
-				} else if (storedState.intent === "test") {
+				user = {
+					id: storedState.linkUserId!,
+					username: request.currentUser!.username,
+				};
+				replaceOidcLink = true;
+			} else if (storedState.intent === "test") {
+				if (!oidcAccount || oidcAccount.user.id !== storedState.linkUserId) {
 					return reply.status(401).send({
 						error:
 							"This OIDC identity is not linked to the admin account. Use Link Account to add it explicitly.",
 					});
-				} else {
-					// User is not authenticated - check if this is initial setup
-					// Use transaction to atomically check user count and create user
-					// This prevents race condition where two concurrent callbacks both create admin accounts
-					try {
-						const newUser = await app.prisma.$transaction(async (tx) => {
-							// Check if any users exist (must be inside transaction for atomicity)
-							const userCount = await tx.user.count();
+				}
+				user = oidcAccount.user;
+			} else if (oidcAccount) {
+				// Existing OIDC account - log them in
+				user = oidcAccount.user;
+			} else {
+				// User is not authenticated - check if this is initial setup
+				// Use transaction to atomically check user count and create user
+				// This prevents race condition where two concurrent callbacks both create admin accounts
+				try {
+					const newUser = await app.prisma.$transaction(async (tx) => {
+						// Check if any users exist (must be inside transaction for atomicity)
+						const userCount = await tx.user.count();
 
-							if (userCount > 0) {
-								throw new Error("SETUP_COMPLETE");
-							}
+						if (userCount > 0) {
+							throw new Error("SETUP_COMPLETE");
+						}
 
-							// Initial setup - create admin account atomically
-							const username = userInfo.preferred_username ?? `user_${userInfo.sub}`;
+						// Initial setup - create admin account atomically
+						const username = userInfo.preferred_username ?? `user_${userInfo.sub}`;
 
-							return await tx.user.create({
-								data: {
-									username,
-									hashedPassword: null, // OIDC-only user (no password)
-									oidcAccounts: {
-										create: {
-											providerUserId: userInfo.sub,
-										},
+						return await tx.user.create({
+							data: {
+								username,
+								hashedPassword: null, // OIDC-only user (no password)
+								oidcAccounts: {
+									create: {
+										providerUserId: userInfo.sub,
 									},
 								},
-							});
+							},
 						});
+					});
 
-						user = newUser;
-						createdInitialUser = true;
-					} catch (error) {
-						if (error instanceof Error && error.message === "SETUP_COMPLETE") {
-							// Setup already completed by concurrent request
-							return reply.status(401).send({
-								error:
-									"Cannot sign in with an unlinked OIDC account. Sign in with your password, then use Link Account in Settings > Authentication.",
-							});
-						}
-						throw error;
+					user = newUser;
+					createdInitialUser = true;
+				} catch (error) {
+					if (error instanceof Error && error.message === "SETUP_COMPLETE") {
+						// Setup already completed by concurrent request
+						return reply.status(401).send({
+							error:
+								"Cannot sign in with an unlinked OIDC account. Sign in with your password, then use Link Account in Settings > Authentication.",
+						});
 					}
+					throw error;
 				}
 			}
 
 			// Create session with metadata
 			const metadata = getSessionMetadata(request);
-			const session = await app.sessionService.createSession(user.id, true, metadata);
+			const session = isAccountAction
+				? await app.sessionService.rotateActiveSession(
+						request.sessionToken!,
+						user.id,
+						true,
+						metadata,
+						replaceOidcLink
+							? async (tx) => {
+									await tx.oIDCAccount.deleteMany({
+										where: { userId: user.id },
+									});
+									await tx.oIDCAccount.create({
+										data: {
+											providerUserId: userInfo.sub,
+											userId: user.id,
+										},
+									});
+								}
+							: undefined,
+					)
+				: await app.sessionService.createSession(user.id, true, metadata);
+
+			if (!session) {
+				return reply.status(401).send({
+					error:
+						"The OIDC account action expired because the initiating session is no longer active. Sign in and try again.",
+				});
+			}
 			app.sessionService.attachCookie(reply, session.token, true);
 
 			// Pre-warm connections to ARR instances in background (don't await)

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -578,11 +578,51 @@ const authRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			});
 		}
 
-		// Remove password
-		await app.prisma.user.update({
-			where: { id: request.currentUser.id },
-			data: { hashedPassword: null },
+		const passwordRemoved = await app.prisma.$transaction(async (tx) => {
+			// Take the same provider write boundary used by OIDC callbacks and
+			// provider deletion. Matching auth fields instead of updatedAt allows
+			// simultaneous valid logins while rejecting a real configuration change.
+			const providerStillCurrent = await tx.oIDCProvider.updateMany({
+				where: {
+					id: oidcProvider.id,
+					enabled: true,
+					clientId: oidcProvider.clientId,
+					encryptedClientSecret: oidcProvider.encryptedClientSecret,
+					clientSecretIv: oidcProvider.clientSecretIv,
+					issuer: oidcProvider.issuer,
+					redirectUri: oidcProvider.redirectUri,
+					scopes: oidcProvider.scopes,
+				},
+				data: { updatedAt: new Date() },
+			});
+			if (providerStillCurrent.count !== 1) {
+				return false;
+			}
+
+			const linkedAccount = await tx.oIDCAccount.updateMany({
+				where: { userId: request.currentUser!.id },
+				data: { updatedAt: new Date() },
+			});
+			if (linkedAccount.count === 0) {
+				return false;
+			}
+
+			const removed = await tx.user.updateMany({
+				where: {
+					id: request.currentUser!.id,
+					hashedPassword: user.hashedPassword,
+				},
+				data: { hashedPassword: null },
+			});
+			return removed.count === 1;
 		});
+
+		if (!passwordRemoved) {
+			return reply.status(409).send({
+				error:
+					"Authentication settings changed while the password was being removed. Review the current sign-in methods and try again.",
+			});
+		}
 
 		request.log.info("Password removed");
 

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -13,6 +13,8 @@ import type { Prisma, OIDCProvider as PrismaOIDCProvider } from "../lib/prisma.j
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
+const OIDC_PROVIDER_CHANGED = "OIDC_PROVIDER_CHANGED";
+
 /**
  * Transform a Prisma OIDCProvider model to the public DTO shape
  * Strips encrypted client secret and IVs from response
@@ -286,72 +288,73 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 				return reply.status(404).send({ error: "OIDC provider not found" });
 			}
 
-			// Check if any users would be locked out (users with OIDC-only and no password/passkeys)
-			const usersWithOidcOnly = await app.prisma.user.findMany({
-				where: {
-					hashedPassword: null, // No password
-					oidcAccounts: {
-						some: {}, // Has OIDC linked
-					},
-				},
-				include: {
-					webauthnCredentials: true,
-				},
-			});
+			// Deleting OIDC is an explicit switch to password authentication. Always
+			// prepare the supplied replacement so a concurrent passkey/password change
+			// cannot leave a linked account without a sign-in method.
+			const hashedPassword = await hashPassword(replacementPassword);
+			const providerAuthVersion = {
+				id: existing.id,
+				enabled: existing.enabled,
+				clientId: existing.clientId,
+				encryptedClientSecret: existing.encryptedClientSecret,
+				clientSecretIv: existing.clientSecretIv,
+				issuer: existing.issuer,
+				redirectUri: existing.redirectUri,
+				scopes: existing.scopes,
+			};
 
-			const lockedOutUsers = usersWithOidcOnly.filter(
-				(user) => user.webauthnCredentials.length === 0,
-			);
+			try {
+				const replacedUsers = await app.prisma.$transaction(async (tx) => {
+					// Delete the exact provider version first. This serializes deletion with an
+					// in-flight Link Account callback before either side changes OIDC links.
+					const deletedProvider = await tx.oIDCProvider.deleteMany({
+						where: providerAuthVersion,
+					});
+					if (deletedProvider.count !== 1) {
+						throw new Error(OIDC_PROVIDER_CHANGED);
+					}
 
-			if (lockedOutUsers.length > 0) {
-				// Hash the replacement password
-				const hashedPassword = await hashPassword(replacementPassword);
-
-				// Set password for all OIDC-only users to prevent lockout
-				await app.prisma.$transaction(
-					lockedOutUsers.map((user) =>
-						app.prisma.user.update({
+					// The provider lock prevents new links from being created while this
+					// snapshot is installed with a replacement password.
+					const linkedUsers = await tx.user.findMany({
+						where: { oidcAccounts: { some: {} } },
+						select: { id: true },
+					});
+					for (const user of linkedUsers) {
+						await tx.user.update({
 							where: { id: user.id },
 							data: {
 								hashedPassword,
-								mustChangePassword: user.id !== request.currentUser!.id, // Force password change for other users
+								mustChangePassword: user.id !== request.currentUser!.id,
 							},
-						}),
-					),
-				);
+						});
+					}
+
+					// OIDCAccount has no provider relation, so remove links explicitly.
+					await tx.oIDCAccount.deleteMany({});
+
+					// Credential removal and session revocation must commit or roll back
+					// together; otherwise a cleanup failure can preserve authenticated sessions.
+					await tx.session.deleteMany({});
+					return linkedUsers.length;
+				});
 
 				request.log.info(
-					{ userCount: lockedOutUsers.length },
-					"Set replacement password for OIDC-only users",
+					{ replacedUsers },
+					"Installed replacement passwords for OIDC-linked users",
 				);
-			}
-
-			request.log.info({ lockedOutUsers: lockedOutUsers.length }, "Deleting OIDC provider");
-
-			// Delete all OIDC account links (cascade will handle this, but explicit for clarity)
-			await app.prisma.oIDCAccount.deleteMany({});
-
-			// Delete provider (singleton with id=1)
-			await app.prisma.oIDCProvider.delete({
-				where: { id: 1 },
-			});
-
-			// Invalidate all sessions to force re-authentication with new method
-			if (request.sessionToken) {
-				// Preserve current session while invalidating all others
-				await app.sessionService.invalidateAllUserSessions(
-					request.currentUser!.id,
-					request.sessionToken,
-				);
-				// Also invalidate sessions for other users (single-admin architecture)
-				await app.prisma.session.deleteMany({
-					where: { userId: { not: request.currentUser!.id } },
-				});
-			} else {
-				await app.prisma.session.deleteMany({});
+			} catch (error) {
+				if (error instanceof Error && error.message === OIDC_PROVIDER_CHANGED) {
+					return reply.status(409).send({
+						error:
+							"The OIDC provider changed while deletion was in progress. Review the current configuration and try again.",
+					});
+				}
+				throw error;
 			}
 
 			request.log.info("OIDC provider deleted");
+			app.sessionService.clearCookie(reply);
 			return reply.status(204).send(undefined);
 		},
 	);

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -38,16 +38,22 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 	 */
 	app.get<{ Reply: OIDCProviderResponse | ErrorResponse }>(
 		"/api/oidc-providers",
-		async (_request, reply) => {
+		async (request, reply) => {
 			const provider = await app.prisma.oIDCProvider.findFirst();
 
 			if (!provider) {
-				return reply.send({ provider: null });
+				return reply.send({ provider: null, linked: false });
 			}
+
+			const linkedAccount = await app.prisma.oIDCAccount.findFirst({
+				where: { userId: request.currentUser!.id },
+				select: { id: true },
+			});
 
 			// Return provider without exposing client secret
 			return reply.send({
 				provider: toPublicProvider(provider),
+				linked: linkedAccount !== null,
 			});
 		},
 	);

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
 	createOidcProviderSchema,
 	deleteOidcProviderSchema,
@@ -14,6 +15,7 @@ import { getErrorMessage } from "../lib/utils/error-message.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
 const OIDC_PROVIDER_CHANGED = "OIDC_PROVIDER_CHANGED";
+const OIDC_SESSION_INACTIVE = "OIDC_SESSION_INACTIVE";
 
 /**
  * Transform a Prisma OIDCProvider model to the public DTO shape
@@ -292,6 +294,12 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 			// prepare the supplied replacement so a concurrent passkey/password change
 			// cannot leave a linked account without a sign-in method.
 			const hashedPassword = await hashPassword(replacementPassword);
+			if (!request.sessionToken) {
+				return reply.status(401).send({
+					error: "The initiating session is no longer active. Sign in and try again.",
+				});
+			}
+			const initiatingSessionId = createHash("sha256").update(request.sessionToken).digest("hex");
 			const providerAuthVersion = {
 				id: existing.id,
 				enabled: existing.enabled,
@@ -305,6 +313,18 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 
 			try {
 				const replacedUsers = await app.prisma.$transaction(async (tx) => {
+					const now = new Date();
+					const consumedSession = await tx.session.deleteMany({
+						where: {
+							id: initiatingSessionId,
+							userId: request.currentUser!.id,
+							expiresAt: { gt: now },
+						},
+					});
+					if (consumedSession.count !== 1) {
+						throw new Error(OIDC_SESSION_INACTIVE);
+					}
+
 					// Delete the exact provider version first. This serializes deletion with an
 					// in-flight Link Account callback before either side changes OIDC links.
 					const deletedProvider = await tx.oIDCProvider.deleteMany({
@@ -318,16 +338,20 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 					// snapshot is installed with a replacement password.
 					const linkedUsers = await tx.user.findMany({
 						where: { oidcAccounts: { some: {} } },
-						select: { id: true },
+						select: { id: true, hashedPassword: true },
 					});
+					let replacedUsers = 0;
 					for (const user of linkedUsers) {
-						await tx.user.update({
-							where: { id: user.id },
-							data: {
-								hashedPassword,
-								mustChangePassword: user.id !== request.currentUser!.id,
-							},
-						});
+						if (!user.hashedPassword) {
+							await tx.user.update({
+								where: { id: user.id },
+								data: {
+									hashedPassword,
+									mustChangePassword: user.id !== request.currentUser!.id,
+								},
+							});
+							replacedUsers += 1;
+						}
 					}
 
 					// OIDCAccount has no provider relation, so remove links explicitly.
@@ -336,7 +360,7 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 					// Credential removal and session revocation must commit or roll back
 					// together; otherwise a cleanup failure can preserve authenticated sessions.
 					await tx.session.deleteMany({});
-					return linkedUsers.length;
+					return replacedUsers;
 				});
 
 				request.log.info(
@@ -344,6 +368,11 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 					"Installed replacement passwords for OIDC-linked users",
 				);
 			} catch (error) {
+				if (error instanceof Error && error.message === OIDC_SESSION_INACTIVE) {
+					return reply.status(401).send({
+						error: "The initiating session is no longer active. Sign in and try again.",
+					});
+				}
 				if (error instanceof Error && error.message === OIDC_PROVIDER_CHANGED) {
 					return reply.status(409).send({
 						error:

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { initiateOIDCLogin } = vi.hoisted(() => ({
+const { initiateOIDCLogin, oidcState } = vi.hoisted(() => ({
 	initiateOIDCLogin: vi.fn(),
+	oidcState: { linked: false },
 }));
 
 vi.mock("../../../../hooks/api/useOIDCProviders", () => ({
@@ -19,6 +20,7 @@ vi.mock("../../../../hooks/api/useOIDCProviders", () => ({
 				createdAt: "2026-07-29T00:00:00.000Z",
 				updatedAt: "2026-07-29T00:00:00.000Z",
 			},
+			linked: oidcState.linked,
 		},
 		isLoading: false,
 	}),
@@ -42,15 +44,26 @@ import { OIDCProviderSection } from "../oidc-provider-section";
 describe("OIDCProviderSection account linking", () => {
 	beforeEach(() => {
 		initiateOIDCLogin.mockReset();
+		oidcState.linked = false;
 	});
 
 	it("offers existing installations an explicit admin-link action", async () => {
 		initiateOIDCLogin.mockRejectedValueOnce(new Error("provider unavailable"));
 		render(<OIDCProviderSection />);
 
-		fireEvent.click(screen.getByRole("button", { name: /link or test account/i }));
+		expect(screen.getByText("Not linked")).toBeDefined();
+		fireEvent.click(screen.getByRole("button", { name: /link account/i }));
 
 		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledOnce());
 		expect(await screen.findByText("provider unavailable")).toBeDefined();
+	});
+
+	it("shows a linked identity as ready to test", () => {
+		oidcState.linked = true;
+
+		render(<OIDCProviderSection />);
+
+		expect(screen.getByText("Linked")).toBeDefined();
+		expect(screen.getByRole("button", { name: /test account/i })).toBeDefined();
 	});
 });

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { initiateOIDCLogin } = vi.hoisted(() => ({
+	initiateOIDCLogin: vi.fn(),
+}));
+
+vi.mock("../../../../hooks/api/useOIDCProviders", () => ({
+	useOIDCProvider: () => ({
+		data: {
+			provider: {
+				id: 1,
+				displayName: "Authentik",
+				clientId: "arr-dashboard",
+				issuer: "https://auth.example.com/application/o/arr-dashboard/",
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+				scopes: "openid,email,profile",
+				enabled: true,
+				createdAt: "2026-07-29T00:00:00.000Z",
+				updatedAt: "2026-07-29T00:00:00.000Z",
+			},
+		},
+		isLoading: false,
+	}),
+	useCreateOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useUpdateOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDeleteOIDCProvider: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { from: "#111111", to: "#222222", glow: "#333333" },
+	}),
+}));
+
+vi.mock("../../../../lib/api-client/auth", () => ({
+	initiateOIDCLogin,
+}));
+
+import { OIDCProviderSection } from "../oidc-provider-section";
+
+describe("OIDCProviderSection account linking", () => {
+	beforeEach(() => {
+		initiateOIDCLogin.mockReset();
+	});
+
+	it("offers existing installations an explicit admin-link action", async () => {
+		initiateOIDCLogin.mockRejectedValueOnce(new Error("provider unavailable"));
+		render(<OIDCProviderSection />);
+
+		fireEvent.click(screen.getByRole("button", { name: /link or test account/i }));
+
+		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledOnce());
+		expect(await screen.findByText("provider unavailable")).toBeDefined();
+	});
+});

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -54,16 +54,19 @@ describe("OIDCProviderSection account linking", () => {
 		expect(screen.getByText("Not linked")).toBeDefined();
 		fireEvent.click(screen.getByRole("button", { name: /link account/i }));
 
-		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledOnce());
+		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledWith("link"));
 		expect(await screen.findByText("provider unavailable")).toBeDefined();
 	});
 
-	it("shows a linked identity as ready to test", () => {
+	it("tests a linked identity without starting another link flow", async () => {
 		oidcState.linked = true;
+		initiateOIDCLogin.mockRejectedValueOnce(new Error("provider unavailable"));
 
 		render(<OIDCProviderSection />);
 
 		expect(screen.getByText("Linked")).toBeDefined();
-		expect(screen.getByRole("button", { name: /test account/i })).toBeDefined();
+		fireEvent.click(screen.getByRole("button", { name: /test account/i }));
+
+		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledWith("test"));
 	});
 });

--- a/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
+++ b/apps/web/src/features/settings/components/__tests__/oidc-provider-section.test.tsx
@@ -58,15 +58,27 @@ describe("OIDCProviderSection account linking", () => {
 		expect(await screen.findByText("provider unavailable")).toBeDefined();
 	});
 
-	it("tests a linked identity without starting another link flow", async () => {
+	it("offers linked installations both test and relink recovery actions", async () => {
 		oidcState.linked = true;
 		initiateOIDCLogin.mockRejectedValueOnce(new Error("provider unavailable"));
 
 		render(<OIDCProviderSection />);
 
 		expect(screen.getByText("Linked")).toBeDefined();
+		expect(screen.getByRole("button", { name: /relink account/i })).toBeDefined();
 		fireEvent.click(screen.getByRole("button", { name: /test account/i }));
 
 		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledWith("test"));
+	});
+
+	it("starts a new link flow when the stored identity is stale", async () => {
+		oidcState.linked = true;
+		initiateOIDCLogin.mockRejectedValueOnce(new Error("provider unavailable"));
+
+		render(<OIDCProviderSection />);
+
+		fireEvent.click(screen.getByRole("button", { name: /relink account/i }));
+
+		await waitFor(() => expect(initiateOIDCLogin).toHaveBeenCalledWith("link"));
 	});
 });

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -26,6 +26,7 @@ import {
 	useUpdateOIDCProvider,
 } from "../../../hooks/api/useOIDCProviders";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import { initiateOIDCLogin } from "../../../lib/api-client/auth";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { ToggleSwitch } from "../../../components/layout/config-primitives";
@@ -51,6 +52,7 @@ export const OIDCProviderSection = () => {
 
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
+	const [isLinking, setIsLinking] = useState(false);
 
 	// Form state for creating new provider
 	const [showCreateForm, setShowCreateForm] = useState(false);
@@ -88,7 +90,6 @@ export const OIDCProviderSection = () => {
 			};
 
 			await createMutation.mutateAsync(payload);
-			setSuccess("OIDC provider created successfully!");
 			setShowCreateForm(false);
 			setFormData({
 				displayName: "",
@@ -99,8 +100,41 @@ export const OIDCProviderSection = () => {
 				scopes: "openid,email,profile",
 				enabled: true,
 			});
+
+			if (payload.enabled) {
+				setSuccess("OIDC provider created. Redirecting you to link the admin account...");
+				setIsLinking(true);
+				try {
+					const authorizationUrl = await initiateOIDCLogin();
+					window.location.href = authorizationUrl;
+				} catch (linkError) {
+					setIsLinking(false);
+					setError(
+						getErrorMessage(
+							linkError,
+							"Provider was created, but the admin account could not be linked. Use the link button below to try again.",
+						),
+					);
+				}
+			} else {
+				setSuccess("OIDC provider created successfully!");
+			}
 		} catch (err) {
 			setError(getErrorMessage(err, "Failed to create OIDC provider"));
+		}
+	};
+
+	const handleLinkAccount = async () => {
+		setError(null);
+		setSuccess(null);
+		setIsLinking(true);
+
+		try {
+			const authorizationUrl = await initiateOIDCLogin();
+			window.location.href = authorizationUrl;
+		} catch (err) {
+			setError(getErrorMessage(err, "Failed to start OIDC account linking"));
+			setIsLinking(false);
 		}
 	};
 
@@ -346,7 +380,7 @@ export const OIDCProviderSection = () => {
 										) : (
 											<>
 												<Plus className="h-4 w-4" />
-												Create Provider
+												{formData.enabled ? "Create & Link Account" : "Create Provider"}
 											</>
 										)}
 									</Button>
@@ -604,6 +638,33 @@ export const OIDCProviderSection = () => {
 											<p className="text-foreground">{provider.scopes}</p>
 										</div>
 									</div>
+								</div>
+
+								<div className="flex flex-col gap-3 rounded-lg border border-border/50 bg-card/30 p-4 sm:flex-row sm:items-center sm:justify-between">
+									<div>
+										<p className="text-sm font-medium text-foreground">Admin account linking</p>
+										<p className="text-xs text-muted-foreground">
+											Complete this once before signing out so this OIDC identity can access the
+											dashboard.
+										</p>
+									</div>
+									<Button
+										onClick={handleLinkAccount}
+										disabled={!provider.enabled || isLinking}
+										className="gap-2 sm:shrink-0"
+									>
+										{isLinking ? (
+											<>
+												<Loader2 className="h-4 w-4 animate-spin" />
+												Redirecting...
+											</>
+										) : (
+											<>
+												<Link className="h-4 w-4" />
+												Link or Test Account
+											</>
+										)}
+									</Button>
 								</div>
 							</div>
 						)}

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -106,7 +106,7 @@ export const OIDCProviderSection = () => {
 				setSuccess("OIDC provider created. Redirecting you to link the admin account...");
 				setIsLinking(true);
 				try {
-					const authorizationUrl = await initiateOIDCLogin();
+					const authorizationUrl = await initiateOIDCLogin("link");
 					window.location.href = authorizationUrl;
 				} catch (linkError) {
 					setIsLinking(false);
@@ -131,7 +131,7 @@ export const OIDCProviderSection = () => {
 		setIsLinking(true);
 
 		try {
-			const authorizationUrl = await initiateOIDCLogin();
+			const authorizationUrl = await initiateOIDCLogin(isLinked ? "test" : "link");
 			window.location.href = authorizationUrl;
 		} catch (err) {
 			setError(getErrorMessage(err, "Failed to start OIDC account linking"));

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { PremiumEmptyState, PremiumSection, PremiumSkeleton } from "../../../components/layout";
+import { ToggleSwitch } from "../../../components/layout/config-primitives";
 import { Button } from "../../../components/ui/button";
 import { Input } from "../../../components/ui/input";
 import {
@@ -29,7 +30,6 @@ import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import { initiateOIDCLogin } from "../../../lib/api-client/auth";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
-import { ToggleSwitch } from "../../../components/layout/config-primitives";
 
 /**
  * Premium OIDC Provider Section
@@ -53,7 +53,8 @@ export const OIDCProviderSection = () => {
 
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
-	const [isLinking, setIsLinking] = useState(false);
+	const [accountAction, setAccountAction] = useState<"link" | "test" | null>(null);
+	const isLinking = accountAction !== null;
 
 	// Form state for creating new provider
 	const [showCreateForm, setShowCreateForm] = useState(false);
@@ -104,12 +105,12 @@ export const OIDCProviderSection = () => {
 
 			if (payload.enabled) {
 				setSuccess("OIDC provider created. Redirecting you to link the admin account...");
-				setIsLinking(true);
+				setAccountAction("link");
 				try {
 					const authorizationUrl = await initiateOIDCLogin("link");
 					window.location.href = authorizationUrl;
 				} catch (linkError) {
-					setIsLinking(false);
+					setAccountAction(null);
 					setError(
 						getErrorMessage(
 							linkError,
@@ -125,17 +126,24 @@ export const OIDCProviderSection = () => {
 		}
 	};
 
-	const handleLinkAccount = async () => {
+	const handleAccountAction = async (intent: "link" | "test") => {
 		setError(null);
 		setSuccess(null);
-		setIsLinking(true);
+		setAccountAction(intent);
 
 		try {
-			const authorizationUrl = await initiateOIDCLogin(isLinked ? "test" : "link");
+			const authorizationUrl = await initiateOIDCLogin(intent);
 			window.location.href = authorizationUrl;
 		} catch (err) {
-			setError(getErrorMessage(err, "Failed to start OIDC account linking"));
-			setIsLinking(false);
+			setError(
+				getErrorMessage(
+					err,
+					intent === "link"
+						? "Failed to start OIDC account linking"
+						: "Failed to start OIDC account test",
+				),
+			);
+			setAccountAction(null);
 		}
 	};
 
@@ -661,27 +669,49 @@ export const OIDCProviderSection = () => {
 										</p>
 										<p className="text-xs text-muted-foreground">
 											{isLinked
-												? "This OIDC identity can access the dashboard. Test it before removing another sign-in method."
+												? "This OIDC identity can access the dashboard. Test it before removing another sign-in method. Relinking replaces the current identity."
 												: "Link this OIDC identity before signing out so it can access the dashboard."}
 										</p>
 									</div>
-									<Button
-										onClick={handleLinkAccount}
-										disabled={!provider.enabled || isLinking}
-										className="gap-2 sm:shrink-0"
-									>
-										{isLinking ? (
-											<>
-												<Loader2 className="h-4 w-4 animate-spin" />
-												Redirecting...
-											</>
-										) : (
-											<>
-												<Link className="h-4 w-4" />
-												{isLinked ? "Test Account" : "Link Account"}
-											</>
+									<div className="flex flex-col gap-2 sm:shrink-0 sm:flex-row">
+										{isLinked && (
+											<Button
+												variant="outline"
+												onClick={() => handleAccountAction("link")}
+												disabled={!provider.enabled || isLinking}
+												className="gap-2"
+											>
+												{accountAction === "link" ? (
+													<>
+														<Loader2 className="h-4 w-4 animate-spin" />
+														Redirecting...
+													</>
+												) : (
+													<>
+														<Link className="h-4 w-4" />
+														Relink Account
+													</>
+												)}
+											</Button>
 										)}
-									</Button>
+										<Button
+											onClick={() => handleAccountAction(isLinked ? "test" : "link")}
+											disabled={!provider.enabled || isLinking}
+											className="gap-2"
+										>
+											{accountAction === (isLinked ? "test" : "link") ? (
+												<>
+													<Loader2 className="h-4 w-4 animate-spin" />
+													Redirecting...
+												</>
+											) : (
+												<>
+													<Link className="h-4 w-4" />
+													{isLinked ? "Test Account" : "Link Account"}
+												</>
+											)}
+										</Button>
+									</div>
 								</div>
 							</div>
 						)}

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -669,7 +669,7 @@ export const OIDCProviderSection = () => {
 										</p>
 										<p className="text-xs text-muted-foreground">
 											{isLinked
-												? "This OIDC identity can access the dashboard. Test it before removing another sign-in method. Relinking replaces the current identity."
+												? "An OIDC identity is linked. Test it before relying on this sign-in method. Relinking replaces the current identity."
 												: "Link this OIDC identity before signing out so it can access the dashboard."}
 										</p>
 									</div>

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -49,6 +49,7 @@ export const OIDCProviderSection = () => {
 	const deleteMutation = useDeleteOIDCProvider();
 
 	const provider = providerData?.provider;
+	const isLinked = providerData?.linked ?? false;
 
 	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
@@ -642,10 +643,26 @@ export const OIDCProviderSection = () => {
 
 								<div className="flex flex-col gap-3 rounded-lg border border-border/50 bg-card/30 p-4 sm:flex-row sm:items-center sm:justify-between">
 									<div>
-										<p className="text-sm font-medium text-foreground">Admin account linking</p>
+										<p className="flex items-center gap-2 text-sm font-medium text-foreground">
+											Admin account
+											<span
+												className="rounded-full px-2 py-0.5 text-xs"
+												style={{
+													backgroundColor: isLinked
+														? SEMANTIC_COLORS.success.bg
+														: SEMANTIC_COLORS.warning.bg,
+													color: isLinked
+														? SEMANTIC_COLORS.success.text
+														: SEMANTIC_COLORS.warning.text,
+												}}
+											>
+												{isLinked ? "Linked" : "Not linked"}
+											</span>
+										</p>
 										<p className="text-xs text-muted-foreground">
-											Complete this once before signing out so this OIDC identity can access the
-											dashboard.
+											{isLinked
+												? "This OIDC identity can access the dashboard. Test it before removing another sign-in method."
+												: "Link this OIDC identity before signing out so it can access the dashboard."}
 										</p>
 									</div>
 									<Button
@@ -661,7 +678,7 @@ export const OIDCProviderSection = () => {
 										) : (
 											<>
 												<Link className="h-4 w-4" />
-												Link or Test Account
+												{isLinked ? "Test Account" : "Link Account"}
 											</>
 										)}
 									</Button>

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -669,7 +669,7 @@ export const OIDCProviderSection = () => {
 										</p>
 										<p className="text-xs text-muted-foreground">
 											{isLinked
-												? "An OIDC identity is linked. Test it before relying on this sign-in method. Relinking replaces the current identity."
+												? "An OIDC identity is linked. Test it before relying on this sign-in method. Relinking replaces the current identity and signs out other sessions."
 												: "Link this OIDC identity before signing out so it can access the dashboard."}
 										</p>
 									</div>

--- a/apps/web/src/lib/api-client/auth/index.ts
+++ b/apps/web/src/lib/api-client/auth/index.ts
@@ -120,12 +120,15 @@ export async function getOIDCProvider(): Promise<{ displayName: string; enabled:
 }
 
 /**
- * Initiate OIDC login flow
+ * Initiate an OIDC login, account-link, or linked-account test flow
  * @returns Authorization URL to redirect user to
  */
-export async function initiateOIDCLogin(): Promise<string> {
+export async function initiateOIDCLogin(
+	intent: "login" | "link" | "test" = "login",
+): Promise<string> {
 	const data = await apiRequest<OIDCLoginResponse>("/auth/oidc/login", {
 		method: "POST",
+		json: { intent },
 	});
 	return data.authorizationUrl;
 }

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -103,7 +103,8 @@ export const passwordSchemaStrict = z.string()
 - Client secret encrypted at rest
 - Auto-generated redirect URI
 - Creating an enabled provider starts account linking immediately; configured
-  providers also expose a **Link or Test Account** action in Settings.
+  providers also expose their link status and a **Link Account** or **Test
+  Account** action in Settings.
 
 ## Passkey Authentication
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -80,21 +80,30 @@ export const passwordSchemaStrict = z.string()
 
 **Flow:**
 1. `POST /auth/oidc/login` -> Generate state, nonce, PKCE verifier
+   - When an authenticated admin starts the flow from Settings, the
+     server-side state also records that admin's user ID as a linking intent.
 2. Redirect to provider authorization URL
 3. `GET /auth/oidc/callback` -> Validate state, exchange code
 4. Verify ID token nonce, get user info
 5. Create/link OIDCAccount, create session
+   - With no users, the first OIDC identity creates the initial admin.
+   - With an existing admin, a new OIDC identity is linked only from an
+     authenticated, one-time Settings flow. Ordinary unlinked logins are rejected.
 
 **Security:**
 - PKCE (Proof Key for Code Exchange)
 - State parameter (CSRF protection)
 - Nonce validation (replay attack prevention)
 - Subject claim consistency check
+- Existing-admin linking is bound to expiring, single-use server-side state;
+  usernames and email claims are never used to claim the admin account.
 
 **Configuration** (`apps/api/src/routes/oidc-providers.ts`):
 - Singleton pattern (only one provider)
 - Client secret encrypted at rest
 - Auto-generated redirect URI
+- Creating an enabled provider starts account linking immediately; configured
+  providers also expose a **Link or Test Account** action in Settings.
 
 ## Passkey Authentication
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -88,7 +88,11 @@ export const passwordSchemaStrict = z.string()
 5. Create/link OIDCAccount, create session
    - With no users, the first OIDC identity creates the initial admin.
    - With an existing admin, a new OIDC identity is linked only from an
-     authenticated, one-time Settings flow. Ordinary unlinked logins are rejected.
+     authenticated, one-time Settings flow bound to the initiating session.
+     Logging out or revoking that session invalidates the pending link.
+   - **Test Account** only verifies an identity that is already linked; it never
+     creates a new link.
+   - Ordinary unlinked logins are rejected.
 
 **Security:**
 - PKCE (Proof Key for Code Exchange)

--- a/packages/shared/src/types/oidc-provider.ts
+++ b/packages/shared/src/types/oidc-provider.ts
@@ -51,6 +51,7 @@ export type UpdateOIDCProvider = z.infer<typeof updateOidcProviderSchema>;
  */
 export const oidcProviderResponseSchema = z.object({
 	provider: oidcProviderSchema.nullable(),
+	linked: z.boolean(),
 });
 
 export type OIDCProviderResponse = z.infer<typeof oidcProviderResponseSchema>;


### PR DESCRIPTION
## Summary

- forward-port the secure OIDC administrator-linking workflow from main
- preserve next setup and routing behavior while adding Link Account, Test Account, Relink Account, and linked status
- replace stale stored identities and require the exact initiating administrator session for every account action
- coordinate callbacks and credential changes with the exact active provider configuration
- retain the single-admin rule: unknown OIDC identities cannot create another user after setup

## Security properties

- one-time link/test state expires after 15 minutes and is bound to both administrator ID and session-token digest
- callback completion atomically consumes the initiating session, replaces the OIDC link when requested, and preserves the session's original expiration
- relinking revokes every other administrator session
- ordinary login, relink, provider deletion, and password removal share an exact provider-configuration write boundary
- concurrent callbacks for an unchanged provider remain valid, while a real provider change or deletion makes stale callbacks fail closed
- provider deletion first consumes the exact active initiating session, then installs a replacement password only for OIDC-only linked accounts while preserving existing passwords, removes links, revokes sessions, and clears the cookie only after commit
- password removal revalidates the provider, link, and current password hash transactionally
- Test Account validates the exact provider snapshot during session rotation and never creates or changes an OIDC account link

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- pnpm run build
- next: 2,616 API tests, 659 web tests, and 97 shared tests passed
- branch parity preserved, including the next initial-setup redirect
- independent concurrency/security regression review completed with no remaining findings
- real-provider compatibility verified with Authentik 2025.2.4, Keycloak 26.7.0, and Authelia 4.39.20

Related to #650