### PR TITLE
test(auth): cover the Authentik linked-account lifecycle

### DIFF
--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -110,6 +110,22 @@ export const passwordSchemaStrict = z.string()
   providers also expose their link status and a **Link Account** or **Test
   Account** action in Settings.
 
+### Linking OIDC to an Existing Administrator
+
+OIDC identities are never matched to an existing administrator by username or
+email. To add OIDC after password setup:
+
+1. Sign in with the existing administrator account.
+2. Open **Settings → Auth** and choose **Configure OIDC**.
+3. Enter the provider settings and select **Create & Link Account**.
+4. Complete the provider login while the initiating dashboard session remains
+   active.
+
+An existing provider that has not been linked shows **Link Account** instead.
+After linking, **Test Account** verifies the configured identity without
+changing the link. Do not sign out or remove the password until the linked
+OIDC login has been tested successfully.
+
 ## Passkey Authentication
 
 **Library**: @simplewebauthn/server v13+

--- a/e2e/authentik-test/authentik-oidc.spec.ts
+++ b/e2e/authentik-test/authentik-oidc.spec.ts
@@ -1,191 +1,168 @@
 /**
- * Authentik OIDC Integration Test
+ * Real Authentik OIDC regression coverage.
  *
- * Validates the fix for GitHub Issue #208: OIDC issuer URL trailing slash normalization
+ * Covers the trailing-slash issuer fix from #208 and the explicit account
+ * linking, repeat login, and guarded provider deletion lifecycle from #650.
  *
- * Authentik includes a trailing slash in its canonical issuer URL, which caused
- * oauth4webapi to fail with "issuer property does not match" when we stripped it.
- *
- * This test:
- * 1. Reads OIDC credentials from bootstrap .env.test file
- * 2. Verifies Authentik discovery endpoint returns issuer WITH trailing slash
- * 3. Configures arr-dashboard OIDC via the setup page
- * 4. Verifies the stored issuer matches Authentik's canonical value
- * 5. Completes the full OIDC login flow (redirect → Authentik login → callback)
- *
- * Prerequisites:
- *   cd e2e/authentik-test
- *   docker compose up -d
- *   bash bootstrap.sh
- *   # arr-dashboard must be running on localhost:3000 (fresh, no user created)
+ * Run:
+ *   pnpm e2e:authentik:up
+ *   pnpm e2e:authentik
+ *   pnpm e2e:authentik:down
  */
 
-import { test, expect } from "@playwright/test";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-
-// ---------------------------------------------------------------------------
-// Load test config from bootstrap output
-// ---------------------------------------------------------------------------
+import { expect, type Page, test } from "@playwright/test";
 
 function loadTestEnv(): Record<string, string> {
 	const envPath = resolve(__dirname, ".env.test");
 	try {
 		const content = readFileSync(envPath, "utf-8");
-		const env: Record<string, string> = {};
-		for (const line of content.split("\n")) {
-			const [key, ...rest] = line.split("=");
-			if (key && rest.length > 0) {
-				env[key.trim()] = rest.join("=").trim();
-			}
-		}
-		return env;
-	} catch {
-		throw new Error(
-			`Missing .env.test — run bootstrap.sh first.\n` +
-				`  cd e2e/authentik-test && docker compose up -d && bash bootstrap.sh`,
+		return Object.fromEntries(
+			content
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => {
+					const separator = line.indexOf("=");
+					return [line.slice(0, separator), line.slice(separator + 1)];
+				}),
 		);
+	} catch {
+		throw new Error("Missing e2e/authentik-test/.env.test. Run `pnpm e2e:authentik:up` first.");
 	}
 }
 
 const ENV = loadTestEnv();
-const AUTHENTIK_URL = ENV.AUTHENTIK_URL || "http://localhost:9000";
-const ARR_DASHBOARD_URL = ENV.ARR_DASHBOARD_URL || "http://localhost:3000";
-const ISSUER_URL = ENV.AUTHENTIK_ISSUER_URL!;
-const CLIENT_ID = ENV.AUTHENTIK_CLIENT_ID!;
-const CLIENT_SECRET = ENV.AUTHENTIK_CLIENT_SECRET!;
-const ADMIN_USERNAME = ENV.AUTHENTIK_ADMIN_USERNAME || "akadmin";
-const ADMIN_PASSWORD = ENV.AUTHENTIK_ADMIN_PASSWORD || "TestPassword123!";
+const AUTHENTIK_URL = ENV.AUTHENTIK_URL;
+const ARR_DASHBOARD_URL = ENV.ARR_DASHBOARD_URL;
+const ISSUER_URL = ENV.AUTHENTIK_ISSUER_URL;
+const CLIENT_ID = ENV.AUTHENTIK_CLIENT_ID;
+const CLIENT_SECRET = ENV.AUTHENTIK_CLIENT_SECRET;
+const ADMIN_USERNAME = ENV.AUTHENTIK_ADMIN_USERNAME;
+const ADMIN_PASSWORD = ENV.AUTHENTIK_ADMIN_PASSWORD;
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
+const DASHBOARD_USERNAME = "admin";
+const DASHBOARD_PASSWORD = "DashboardTest123!";
+const FALLBACK_PASSWORD = "FallbackTest123!";
+const PROVIDER_NAME = "Authentik E2E";
 
-test.describe("Authentik OIDC Integration (#208)", () => {
-	test.describe.configure({ mode: "serial" });
+function isPrivateIpv4(hostname: string): boolean {
+	const octets = hostname.split(".").map(Number);
+	if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet))) {
+		return false;
+	}
+	return (
+		octets[0] === 10 ||
+		(octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+		(octets[0] === 192 && octets[1] === 168)
+	);
+}
 
-	test("Authentik discovery endpoint returns issuer WITH trailing slash", async ({
-		request,
-	}) => {
-		const discoveryUrl = ISSUER_URL.endsWith("/")
-			? `${ISSUER_URL}.well-known/openid-configuration`
-			: `${ISSUER_URL}/.well-known/openid-configuration`;
+for (const [name, value] of Object.entries({
+	AUTHENTIK_URL,
+	ARR_DASHBOARD_URL,
+	ISSUER_URL,
+	CLIENT_ID,
+	CLIENT_SECRET,
+	ADMIN_USERNAME,
+	ADMIN_PASSWORD,
+})) {
+	if (!value) {
+		throw new Error(`Missing ${name} in e2e/authentik-test/.env.test`);
+	}
+}
 
-		const response = await request.get(discoveryUrl);
+const dashboardUrl = new URL(ARR_DASHBOARD_URL);
+if (!["localhost", "127.0.0.1"].includes(dashboardUrl.hostname)) {
+	throw new Error(`Refusing to run destructive E2E test against ${ARR_DASHBOARD_URL}`);
+}
+
+const authentikUrl = new URL(AUTHENTIK_URL);
+if (!isPrivateIpv4(authentikUrl.hostname)) {
+	throw new Error(`Refusing to bootstrap non-private Authentik URL ${AUTHENTIK_URL}`);
+}
+if (new URL(ISSUER_URL).origin !== authentikUrl.origin) {
+	throw new Error("Authentik issuer and API URL must use the same isolated origin");
+}
+
+async function signInToAuthentik(page: Page): Promise<void> {
+	const authentikHost = new URL(AUTHENTIK_URL).host;
+	await page.waitForURL((url) => url.host === authentikHost);
+
+	const username = page.getByRole("textbox", { name: "Email or Username" });
+	await expect(username).toBeVisible();
+	await username.fill(ADMIN_USERNAME);
+	await page.getByRole("button", { name: "Log in" }).click();
+
+	const password = page.getByRole("textbox", {
+		name: /password/i,
+	});
+	await expect(password).toBeVisible();
+	await password.fill(ADMIN_PASSWORD);
+	await page.getByRole("button", { name: /continue|log in/i }).click();
+}
+
+test.describe("Authentik OIDC account lifecycle (#208, #650)", () => {
+	test("discovery preserves Authentik's canonical trailing-slash issuer", async ({ request }) => {
+		const response = await request.get(`${ISSUER_URL}.well-known/openid-configuration`);
 		expect(response.ok()).toBeTruthy();
 
-		const doc = await response.json();
-		expect(doc.issuer).toBeDefined();
-		// Authentik's canonical issuer includes trailing slash
-		expect(doc.issuer).toMatch(/\/$/);
-		console.log(`Discovery issuer: ${doc.issuer}`);
+		const discovery = await response.json();
+		expect(discovery.issuer).toBe(ISSUER_URL);
+		expect(discovery.issuer).toMatch(/\/$/);
+		expect(discovery.token_endpoint_auth_methods_supported).toContain("client_secret_basic");
 	});
 
-	test("arr-dashboard OIDC setup accepts Authentik issuer with trailing slash", async ({
-		page,
-	}) => {
-		// Navigate to setup page (assumes fresh instance with no users)
+	test("links the admin, signs in again, then safely deletes OIDC", async ({ page }) => {
 		await page.goto(`${ARR_DASHBOARD_URL}/setup`);
-		await page.waitForTimeout(2000);
+		await expect(page.getByRole("heading", { name: "Welcome to your dashboard" })).toBeVisible();
 
-		// Check if we're on the setup page or already set up
-		const pageText = await page.textContent("body");
-		if (!pageText?.includes("setup") && !pageText?.includes("Setup")) {
-			test.skip(true, "App already has a user — cannot test first-run OIDC setup");
-			return;
-		}
+		await page.getByRole("button", { name: "Password", exact: true }).click();
+		await page.getByRole("textbox", { name: "admin" }).fill(DASHBOARD_USERNAME);
+		await page.getByRole("textbox", { name: "At least 8 characters" }).fill(DASHBOARD_PASSWORD);
+		await page.getByRole("textbox", { name: "Re-enter password" }).fill(DASHBOARD_PASSWORD);
+		await page.getByRole("button", { name: "Create Admin Account" }).click();
+		await expect(page).toHaveURL(/\/dashboard$/);
 
-		// Select OIDC authentication method
-		const oidcButton = page.locator("button, [role=button]").filter({
-			hasText: /OIDC|OpenID|Single Sign/i,
-		});
-		if ((await oidcButton.count()) > 0) {
-			await oidcButton.first().click();
-			await page.waitForTimeout(1000);
-		}
+		await page.goto(`${ARR_DASHBOARD_URL}/settings`);
+		await page.getByRole("button", { name: "Auth", exact: true }).click();
+		await page.getByRole("button", { name: "Configure OIDC" }).click();
+		await page.getByRole("textbox", { name: "e.g., Authentik SSO" }).fill(PROVIDER_NAME);
+		await page.getByRole("textbox", { name: "https://auth.example.com" }).fill(ISSUER_URL);
+		await page.getByRole("textbox", { name: "OAuth client ID" }).fill(CLIENT_ID);
+		await page.getByRole("textbox", { name: "OAuth client secret" }).fill(CLIENT_SECRET);
+		await page.getByRole("button", { name: "Create & Link Account" }).click();
 
-		// Fill OIDC configuration
-		// The issuer URL intentionally has a trailing slash (Authentik format)
-		const issuerInput = page.locator(
-			'input[name="issuer"], input[placeholder*="issuer" i], input[placeholder*="URL" i]',
-		).first();
-		await issuerInput.fill(ISSUER_URL);
+		await signInToAuthentik(page);
+		await expect(page).toHaveURL(
+			(url) => url.pathname === "/settings" && url.hash === "#authentication",
+			{ timeout: 15_000 },
+		);
+		await expect(page.getByText("Linked", { exact: true })).toBeVisible();
 
-		const clientIdInput = page.locator(
-			'input[name="clientId"], input[placeholder*="client" i]',
-		).first();
-		await clientIdInput.fill(CLIENT_ID);
-
-		const clientSecretInput = page.locator(
-			'input[name="clientSecret"], input[type="password"]',
-		).first();
-		await clientSecretInput.fill(CLIENT_SECRET);
-
-		// Submit the OIDC setup
-		const submitButton = page.locator("button[type=submit], button").filter({
-			hasText: /continue|setup|save|submit/i,
-		});
-		await submitButton.first().click();
-		await page.waitForTimeout(3000);
-
-		// Verify no error about issuer mismatch
-		const bodyText = await page.textContent("body");
-		expect(bodyText).not.toContain("issuer");
-		expect(bodyText).not.toContain("OAUTH_JSON_ATTRIBUTE_COMPARISON_FAILED");
-
-		console.log("OIDC setup completed without issuer mismatch error");
-	});
-
-	test("OIDC login redirects to Authentik and completes flow", async ({ page }) => {
-		// Navigate to login page
+		await page.getByRole("button", { name: "Sign out" }).click();
+		await expect(page).toHaveURL((url) => url.pathname === "/login");
 		await page.goto(`${ARR_DASHBOARD_URL}/login`);
-		await page.waitForTimeout(2000);
+		await page.getByRole("button", { name: `Sign in with ${PROVIDER_NAME}` }).click();
+		await expect(page).toHaveURL(/\/dashboard$/, { timeout: 15_000 });
 
-		// Click OIDC login button
-		const oidcLoginButton = page.locator("button, a").filter({
-			hasText: /OIDC|OpenID|Sign in with|SSO/i,
-		});
+		await page.goto(`${ARR_DASHBOARD_URL}/settings`);
+		await page.getByRole("button", { name: "Auth", exact: true }).click();
+		await page.getByRole("button", { name: "Delete", exact: true }).click();
+		await page.getByRole("textbox", { name: "Current password" }).fill(DASHBOARD_PASSWORD);
+		await page
+			.getByRole("textbox", { name: "Fallback password", exact: true })
+			.fill(FALLBACK_PASSWORD);
+		await page.getByRole("textbox", { name: "Confirm fallback password" }).fill(FALLBACK_PASSWORD);
+		await page.getByRole("button", { name: "Delete and sign out" }).click();
 
-		if ((await oidcLoginButton.count()) === 0) {
-			test.skip(true, "No OIDC login button found — OIDC may not be configured");
-			return;
-		}
-
-		await oidcLoginButton.first().click();
-
-		// Should redirect to Authentik login page
-		await page.waitForURL(/localhost:9000|localhost:9443/, { timeout: 10000 });
-		console.log(`Redirected to Authentik: ${page.url()}`);
-
-		// Fill Authentik login form
-		const usernameInput = page.locator('input[name="uidField"], input[type="text"]').first();
-		await usernameInput.fill(ADMIN_USERNAME);
-
-		// Authentik may have a two-step login (username first, then password)
-		const nextButton = page.locator("button[type=submit]").first();
-		await nextButton.click();
-		await page.waitForTimeout(1000);
-
-		const passwordInput = page.locator('input[name="password"], input[type="password"]').first();
-		if (await passwordInput.isVisible()) {
-			await passwordInput.fill(ADMIN_PASSWORD);
-			const loginButton = page.locator("button[type=submit]").first();
-			await loginButton.click();
-		}
-
-		// Authentik may show a consent screen — accept it
-		await page.waitForTimeout(2000);
-		const consentButton = page.locator("button").filter({ hasText: /continue|allow|accept|consent/i });
-		if ((await consentButton.count()) > 0) {
-			await consentButton.first().click();
-		}
-
-		// Should redirect back to arr-dashboard
-		await page.waitForURL(/localhost:3000/, { timeout: 15000 });
-		console.log(`Redirected back to dashboard: ${page.url()}`);
-
-		// Verify we're logged in (not on login page)
-		expect(page.url()).not.toContain("/login");
-		console.log("OIDC login flow completed successfully!");
+		await expect(page).toHaveURL((url) => url.pathname === "/login");
+		await expect(page.getByRole("button", { name: `Sign in with ${PROVIDER_NAME}` })).toHaveCount(
+			0,
+		);
+		await page.getByRole("textbox", { name: "Username" }).fill(DASHBOARD_USERNAME);
+		await page.getByRole("textbox", { name: "Password" }).fill(FALLBACK_PASSWORD);
+		await page.getByRole("button", { name: "Sign in with password" }).click();
+		await expect(page).toHaveURL(/\/dashboard$/);
 	});
 });

--- a/e2e/authentik-test/bootstrap.sh
+++ b/e2e/authentik-test/bootstrap.sh
@@ -1,142 +1,229 @@
-#!/bin/bash
-# Bootstrap Authentik OIDC provider for arr-dashboard testing
+#!/usr/bin/env bash
+# Bootstrap a real Authentik provider for the OIDC account-linking E2E test.
 #
-# This script:
-# 1. Waits for Authentik to be healthy
-# 2. Completes initial admin setup via Playwright
-# 3. Creates an OIDC provider and application via the API
-# 4. Writes credentials to .env.test for the Playwright spec
+# Run through `pnpm e2e:authentik:up`, which pins the isolated Compose
+# project name before this script makes any API changes.
 #
-# Prerequisites: docker compose up -d
-# Usage: bash bootstrap.sh
+# The issuer uses Authentik's container IP so both the host-run Playwright
+# browser and the arr-dashboard container can resolve the same canonical URL.
+# This harness is intended for Linux hosts and Linux CI runners.
 
 set -euo pipefail
 
-AUTHENTIK_URL="${AUTHENTIK_URL:-http://localhost:9000}"
-ARR_DASHBOARD_URL="${ARR_DASHBOARD_URL:-http://localhost:3000}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${SCRIPT_DIR}/.env.test"
+
+COMPOSE_PROJECT="arr-dashboard-authentik-e2e"
+AUTHENTIK_CONTAINER="authentik-test-server"
+AUTHENTIK_TOKEN="e2e-test-api-token"
+ARR_DASHBOARD_URL="http://localhost:${DASHBOARD_PORT:-3000}"
+ADMIN_USERNAME="akadmin"
 ADMIN_PASSWORD="TestPassword123!"
-ADMIN_EMAIL="admin@test.local"
 APP_SLUG="arr-dashboard-test"
 CLIENT_ID="arr-dashboard-e2e-test"
-CLIENT_SECRET="e2e-test-secret-value-$(openssl rand -hex 8)"
+CLIENT_SECRET="e2e-test-secret-value"
 
-echo "🔧 Bootstrapping Authentik OIDC for arr-dashboard testing..."
+log() {
+	echo "[authentik-bootstrap] $*"
+}
 
-# Wait for Authentik
-echo "⏳ Waiting for Authentik..."
-for i in $(seq 1 60); do
-  if curl -sf "$AUTHENTIK_URL/-/health/ready/" > /dev/null 2>&1; then
-    echo "✅ Authentik is ready"
-    break
-  fi
-  [ "$i" -eq 60 ] && echo "❌ Timeout" && exit 1
-  sleep 5
+fail() {
+	echo "[authentik-bootstrap] ERROR: $*" >&2
+	exit 1
+}
+
+require_value() {
+	local label="$1"
+	local value="$2"
+	[ -n "$value" ] || fail "Could not resolve ${label}"
+}
+
+urlencode() {
+	jq -rn --arg value "$1" '$value | @uri'
+}
+
+CONTAINER_METADATA="$(docker inspect "$AUTHENTIK_CONTAINER")"
+ACTUAL_PROJECT="$(
+	jq -er '.[0].Config.Labels["com.docker.compose.project"]' <<<"$CONTAINER_METADATA"
+)"
+ACTUAL_SERVICE="$(
+	jq -er '.[0].Config.Labels["com.docker.compose.service"]' <<<"$CONTAINER_METADATA"
+)"
+
+[ "$ACTUAL_PROJECT" = "$COMPOSE_PROJECT" ] ||
+	fail "${AUTHENTIK_CONTAINER} belongs to Compose project ${ACTUAL_PROJECT}, not ${COMPOSE_PROJECT}"
+[ "$ACTUAL_SERVICE" = "authentik-server" ] ||
+	fail "${AUTHENTIK_CONTAINER} is service ${ACTUAL_SERVICE}, not authentik-server"
+
+AUTHENTIK_IP="$(
+	jq -er '.[0].NetworkSettings.Networks | to_entries[0].value.IPAddress' \
+		<<<"$CONTAINER_METADATA"
+)"
+AUTHENTIK_URL="http://${AUTHENTIK_IP}:9000"
+
+api() {
+	local path="$1"
+	shift
+	curl -fsS \
+		-H "Authorization: Bearer ${AUTHENTIK_TOKEN}" \
+		-H "Content-Type: application/json" \
+		"$@" \
+		"${AUTHENTIK_URL}${path}"
+}
+
+log "Waiting for Authentik at ${AUTHENTIK_URL}"
+for attempt in $(seq 1 60); do
+	if curl -fsS "${AUTHENTIK_URL}/-/health/ready/" >/dev/null 2>&1; then
+		break
+	fi
+	[ "$attempt" -lt 60 ] || fail "Authentik did not become ready"
+	sleep 2
 done
 
-# Step 1: Complete initial setup via Playwright
-echo "🔧 Completing initial admin setup..."
-npx playwright-cli open "$AUTHENTIK_URL/if/flow/initial-setup/" 2>/dev/null
+log "Waiting for arr-dashboard at ${ARR_DASHBOARD_URL}"
+for attempt in $(seq 1 60); do
+	if curl -fsS "${ARR_DASHBOARD_URL}/health" >/dev/null 2>&1; then
+		break
+	fi
+	[ "$attempt" -lt 60 ] || fail "arr-dashboard did not become ready"
+	sleep 2
+done
 
-sleep 3
+log "Resolving Authentik OAuth defaults"
+FLOWS="$(api "/api/v3/flows/instances/?pagination=false")"
+AUTHORIZATION_FLOW="$(
+	jq -er '.results[] | select(.slug == "default-provider-authorization-implicit-consent") | .pk' \
+		<<<"$FLOWS"
+)"
+INVALIDATION_FLOW="$(
+	jq -er '.results[] | select(.slug == "default-provider-invalidation-flow") | .pk' \
+		<<<"$FLOWS"
+)"
+SIGNING_KEY="$(
+	api "/api/v3/crypto/certificatekeypairs/?pagination=false" |
+		jq -er '.results[0].pk'
+)"
+PROPERTY_MAPPINGS="$(
+	api "/api/v3/propertymappings/all/?pagination=false" |
+		jq -cer '
+			[
+				.results[]
+				| select(
+					.managed == "goauthentik.io/providers/oauth2/scope-openid"
+					or .managed == "goauthentik.io/providers/oauth2/scope-email"
+					or .managed == "goauthentik.io/providers/oauth2/scope-profile"
+				)
+				| .pk
+			]
+			| if length == 3 then . else error("missing default OIDC scope mappings") end
+		'
+)"
 
-npx playwright-cli run-code "async (page) => {
-  await page.waitForTimeout(2000);
-  const emailInput = page.getByRole('textbox', { name: 'Admin email' });
-  if (await emailInput.count() > 0) {
-    await emailInput.fill('$ADMIN_EMAIL');
-    await page.getByRole('textbox', { name: 'Password', exact: true }).fill('$ADMIN_PASSWORD');
-    await page.getByRole('textbox', { name: 'Password (repeat)' }).fill('$ADMIN_PASSWORD');
-    await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(3000);
-    return 'Setup completed';
-  }
-  return 'Already set up';
-}" 2>/dev/null
+require_value "authorization flow" "$AUTHORIZATION_FLOW"
+require_value "invalidation flow" "$INVALIDATION_FLOW"
+require_value "signing key" "$SIGNING_KEY"
+require_value "OIDC property mappings" "$PROPERTY_MAPPINGS"
 
-# Step 2: Create OIDC provider via API (using Playwright session)
-echo "🔧 Creating OIDC provider and application..."
-RESULT=$(npx playwright-cli run-code "async (page) => {
-  // Log in if needed
-  if (page.url().includes('flow')) {
-    await page.getByRole('textbox', { name: 'Email or Username' }).fill('akadmin');
-    await page.getByRole('button', { name: 'Log in' }).click();
-    await page.waitForTimeout(1000);
-    await page.getByRole('textbox', { name: 'Please enter your password' }).fill('$ADMIN_PASSWORD');
-    await page.getByRole('button', { name: 'Continue' }).click();
-    await page.waitForTimeout(3000);
-  }
+log "Removing an existing test application, if present"
+ENCODED_APP_SLUG="$(urlencode "$APP_SLUG")"
+APPLICATIONS="$(api "/api/v3/core/applications/?slug=${ENCODED_APP_SLUG}")"
+EXACT_APPLICATIONS="$(
+	jq -c --arg slug "$APP_SLUG" '[.results[] | select(.slug == $slug)]' \
+		<<<"$APPLICATIONS"
+)"
+APPLICATION_COUNT="$(jq -r 'length' <<<"$EXACT_APPLICATIONS")"
+[ "$APPLICATION_COUNT" -le 1 ] ||
+	fail "Found ${APPLICATION_COUNT} applications with exact slug ${APP_SLUG}"
+if [ "$APPLICATION_COUNT" -eq 1 ]; then
+	EXISTING_APP="$(jq -er '.[0].slug' <<<"$EXACT_APPLICATIONS")"
+	api "/api/v3/core/applications/$(urlencode "$EXISTING_APP")/" -X DELETE >/dev/null
+fi
 
-  const cookies = await page.context().cookies();
-  const csrf = cookies.find(c => c.name === 'authentik_csrf')?.value;
+PROVIDER_NAME="${APP_SLUG}-provider"
+ENCODED_PROVIDER_NAME="$(urlencode "$PROVIDER_NAME")"
+PROVIDERS="$(api "/api/v3/providers/oauth2/?name=${ENCODED_PROVIDER_NAME}")"
+EXACT_PROVIDERS="$(
+	jq -c --arg name "$PROVIDER_NAME" '[.results[] | select(.name == $name)]' \
+		<<<"$PROVIDERS"
+)"
+PROVIDER_COUNT="$(jq -r 'length' <<<"$EXACT_PROVIDERS")"
+[ "$PROVIDER_COUNT" -le 1 ] ||
+	fail "Found ${PROVIDER_COUNT} providers with exact name ${PROVIDER_NAME}"
+if [ "$PROVIDER_COUNT" -eq 1 ]; then
+	EXISTING_PROVIDER="$(jq -er '.[0].pk' <<<"$EXACT_PROVIDERS")"
+	api "/api/v3/providers/oauth2/${EXISTING_PROVIDER}/" -X DELETE >/dev/null
+fi
 
-  async function api(path, method, body) {
-    return page.evaluate(async ({path, method, body, csrf}) => {
-      const res = await fetch(path, {
-        method,
-        headers: { 'Content-Type': 'application/json', 'X-authentik-CSRF': csrf },
-        body: body ? JSON.stringify(body) : undefined,
-      });
-      return { status: res.status, body: await res.json() };
-    }, {path, method, body, csrf});
-  }
+REDIRECT_URI="${ARR_DASHBOARD_URL}/auth/oidc/callback"
+PROVIDER_PAYLOAD="$(
+	jq -cn \
+		--arg name "$PROVIDER_NAME" \
+		--arg authorization_flow "$AUTHORIZATION_FLOW" \
+		--arg invalidation_flow "$INVALIDATION_FLOW" \
+		--arg client_id "$CLIENT_ID" \
+		--arg client_secret "$CLIENT_SECRET" \
+		--arg redirect_uri "$REDIRECT_URI" \
+		--arg signing_key "$SIGNING_KEY" \
+		--argjson property_mappings "$PROPERTY_MAPPINGS" \
+		'{
+			name: $name,
+			authorization_flow: $authorization_flow,
+			invalidation_flow: $invalidation_flow,
+			client_type: "confidential",
+			grant_types: ["authorization_code", "refresh_token"],
+			client_id: $client_id,
+			client_secret: $client_secret,
+			redirect_uris: [{matching_mode: "strict", url: $redirect_uri}],
+			signing_key: $signing_key,
+			property_mappings: $property_mappings,
+			access_token_validity: "hours=1",
+			sub_mode: "user_username",
+			include_claims_in_id_token: true
+		}'
+)"
 
-  const flows = await api('/api/v3/flows/instances/', 'GET');
-  const authFlow = flows.body.results?.find(f => f.slug === 'default-authentication-flow')?.pk;
-  const invalidFlow = flows.body.results?.find(f => f.slug.includes('invalidation'))?.pk || authFlow;
-  const keys = await api('/api/v3/crypto/certificatekeypairs/', 'GET');
-  const keyUuid = keys.body.results?.[0]?.pk;
+log "Creating OAuth2/OpenID provider"
+PROVIDER="$(
+	api "/api/v3/providers/oauth2/" \
+		-X POST \
+		--data "$PROVIDER_PAYLOAD"
+)"
+PROVIDER_PK="$(jq -er '.pk' <<<"$PROVIDER")"
 
-  const provider = await api('/api/v3/providers/oauth2/', 'POST', {
-    name: '$APP_SLUG-provider',
-    authorization_flow: authFlow,
-    invalidation_flow: invalidFlow,
-    client_type: 'confidential',
-    client_id: '$CLIENT_ID',
-    client_secret: '$CLIENT_SECRET',
-    redirect_uris: [{ matching_mode: 'strict', url: '$ARR_DASHBOARD_URL/auth/oidc/callback' }],
-    signing_key: keyUuid,
-    access_token_validity: 'hours=1',
-    sub_mode: 'user_username',
-    include_claims_in_id_token: true,
-  });
+log "Creating Authentik application"
+APPLICATION_PAYLOAD="$(
+	jq -cn \
+		--arg name "$APP_SLUG" \
+		--arg slug "$APP_SLUG" \
+		--argjson provider "$PROVIDER_PK" \
+		'{name: $name, slug: $slug, provider: $provider}'
+)"
+api "/api/v3/core/applications/" \
+	-X POST \
+	--data "$APPLICATION_PAYLOAD" >/dev/null
 
-  if (provider.status !== 201) return 'ERROR:Provider:' + JSON.stringify(provider.body);
+DISCOVERY_URL="${AUTHENTIK_URL}/application/o/${APP_SLUG}/.well-known/openid-configuration"
+DISCOVERY="$(curl -fsS "$DISCOVERY_URL")"
+ISSUER_URL="$(jq -er '.issuer' <<<"$DISCOVERY")"
+EXPECTED_ISSUER="${AUTHENTIK_URL}/application/o/${APP_SLUG}/"
 
-  const app = await api('/api/v3/core/applications/', 'POST', {
-    name: '$APP_SLUG',
-    slug: '$APP_SLUG',
-    provider: provider.body.pk,
-  });
+[ "$ISSUER_URL" = "$EXPECTED_ISSUER" ] ||
+	fail "Discovery issuer ${ISSUER_URL} did not match ${EXPECTED_ISSUER}"
 
-  if (app.status !== 201) return 'ERROR:App:' + JSON.stringify(app.body);
+jq -e '
+	.token_endpoint_auth_methods_supported
+	| index("client_secret_basic") != null
+' <<<"$DISCOVERY" >/dev/null ||
+	fail "Authentik discovery does not advertise client_secret_basic"
 
-  const disc = await page.evaluate(async () => {
-    const res = await fetch('/application/o/$APP_SLUG/.well-known/openid-configuration');
-    return res.ok ? await res.json() : null;
-  });
-
-  return JSON.stringify({ issuer: disc?.issuer });
-}" 2>/dev/null | grep -o '{.*}')
-
-npx playwright-cli close 2>/dev/null
-
-ISSUER_URL=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['issuer'])")
-
-echo ""
-echo "✅ Authentik OIDC setup complete!"
-echo "============================================"
-echo "ISSUER_URL=$ISSUER_URL"
-echo "CLIENT_ID=$CLIENT_ID"
-echo "CLIENT_SECRET=$CLIENT_SECRET"
-echo "============================================"
-
-cat > "$(dirname "$0")/.env.test" << EOF
+cat >"$ENV_FILE" <<EOF
 AUTHENTIK_ISSUER_URL=$ISSUER_URL
 AUTHENTIK_CLIENT_ID=$CLIENT_ID
 AUTHENTIK_CLIENT_SECRET=$CLIENT_SECRET
-AUTHENTIK_ADMIN_USERNAME=akadmin
+AUTHENTIK_ADMIN_USERNAME=$ADMIN_USERNAME
 AUTHENTIK_ADMIN_PASSWORD=$ADMIN_PASSWORD
 AUTHENTIK_URL=$AUTHENTIK_URL
 ARR_DASHBOARD_URL=$ARR_DASHBOARD_URL
 EOF
-echo "📄 Wrote credentials to .env.test"
+
+log "OIDC provider ready; wrote ${ENV_FILE}"

--- a/e2e/authentik-test/docker-compose.yml
+++ b/e2e/authentik-test/docker-compose.yml
@@ -1,9 +1,10 @@
-# Docker Compose for Authentik OIDC integration testing
-# Validates fix for GitHub Issue #208: OIDC issuer URL trailing slash normalization
+# Docker Compose for real Authentik OIDC integration testing.
+# Covers canonical issuer handling (#208) and the linked-admin lifecycle (#650).
 #
 # Usage:
-#   docker compose up -d
-#   # Wait for health checks, then run: npx playwright test authentik-oidc.spec.ts
+#   pnpm e2e:authentik:up
+#   pnpm e2e:authentik
+#   pnpm e2e:authentik:down
 
 services:
   postgresql:
@@ -35,7 +36,7 @@ services:
       - authentik-net
 
   authentik-server:
-    image: ghcr.io/goauthentik/server:latest
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_VERSION:-2026.5.6}
     container_name: authentik-test-server
     command: server
     environment:
@@ -58,7 +59,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:9000/-/health/ready/"]
+      test: ["CMD", "ak", "healthcheck"]
       interval: 10s
       timeout: 5s
       retries: 20
@@ -67,7 +68,7 @@ services:
       - authentik-net
 
   authentik-worker:
-    image: ghcr.io/goauthentik/server:latest
+    image: ghcr.io/goauthentik/server:${AUTHENTIK_VERSION:-2026.5.6}
     container_name: authentik-test-worker
     command: worker
     environment:
@@ -84,6 +85,42 @@ services:
         condition: service_healthy
     networks:
       - authentik-net
+
+  arr-dashboard:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+      args:
+        VERSION: e2e-authentik
+        COMMIT_SHA: local
+    container_name: authentik-test-dashboard
+    ports:
+      - "${DASHBOARD_PORT:-3000}:3000"
+      - "${DASHBOARD_API_PORT:-3001}:3001"
+    volumes:
+      - dashboard-config:/config
+    environment:
+      PUID: 1000
+      PGID: 1000
+      PORT: 3000
+      API_PORT: 3001
+      DATABASE_URL: file:/config/prod.db
+      APP_URL: http://localhost:${DASHBOARD_PORT:-3000}
+      API_RATE_LIMIT_MAX: 10000
+    depends_on:
+      authentik-server:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:3000/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+    networks:
+      - authentik-net
+
+volumes:
+  dashboard-config:
 
 networks:
   authentik-net:

--- a/e2e/authentik-test/playwright.config.ts
+++ b/e2e/authentik-test/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+	testDir: ".",
+	testMatch: "authentik-oidc.spec.ts",
+	fullyParallel: false,
+	workers: 1,
+	retries: 0,
+	timeout: 60_000,
+	reporter: [["list"]],
+	use: {
+		...devices["Desktop Chrome"],
+		trace: "retain-on-failure",
+		screenshot: "only-on-failure",
+	},
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
 		"clean": "turbo prune --scope='@arr/*' --docker",
 		"e2e:integration:up": "cd e2e/integration && docker compose up -d --build && bash bootstrap-services.sh",
 		"e2e:integration": "playwright test --config=e2e/integration/playwright.integration.config.ts",
-		"e2e:integration:down": "cd e2e/integration && bash teardown.sh"
+		"e2e:integration:down": "cd e2e/integration && bash teardown.sh",
+		"e2e:authentik:up": "cd e2e/authentik-test && docker compose --project-name arr-dashboard-authentik-e2e down -v --remove-orphans && docker compose --project-name arr-dashboard-authentik-e2e up -d --build && bash bootstrap.sh",
+		"e2e:authentik": "playwright test --config=e2e/authentik-test/playwright.config.ts",
+		"e2e:authentik:down": "cd e2e/authentik-test && docker compose --project-name arr-dashboard-authentik-e2e down -v --remove-orphans"
 	},
 	"pnpm": {
 		"overrides": {


### PR DESCRIPTION
﻿## Summary

- replace the legacy Authentik issuer smoke test with an isolated, repeatable linked-admin lifecycle test
- bootstrap a pinned Authentik 2026.5.6 provider through its API and verify the exact Compose project before any cleanup
- cover password setup, account linking, repeat OIDC login, guarded provider deletion, and fallback-password recovery
- document the explicit Link Account workflow for existing administrators

## Why

The previous Authentik fixture focused on canonical issuer handling and depended on an externally started fresh dashboard. It could skip the important path once an administrator already existed and did not exercise the linked-account or provider-deletion behavior reported in #650.

The new harness owns an isolated dashboard volume and verifies the full administrator lifecycle against a real Authentik provider. Bootstrap cleanup is limited to exact test resources in the fixed Compose project and fails closed when container ownership or target identity is ambiguous.

## Validation

- Authentik 2026.5.6 lifecycle passed twice from clean Compose stacks, 2/2 tests per run
- published `:dev` image provider deletion and fallback login verified manually
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- focused Biome check for the new Playwright files
- `bash -n e2e/authentik-test/bootstrap.sh`
- Docker Compose configuration validation
- `git diff --check`
- independent regression and data-safety reviews completed with no findings

`pnpm run format` currently reports formatting drift in four unchanged files on `origin/main`. The files changed by this PR pass focused formatting checks.

## Compatibility and risk

- the real-provider suite is manual and requires Linux, Docker, Playwright, `curl`, and `jq`; it is not added to CI
- Authentik defaults to version 2026.5.6 and can be overridden with `AUTHENTIK_VERSION`
- teardown resets only the fixed `arr-dashboard-authentik-e2e` Compose project

Related to #650
