### PR TITLE
fix(library-cleanup): verify retained Radarr variants

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -60,7 +60,14 @@ function radarrSafetySnapshot(
 ) {
 	return serializeExecutableSafetyPlan(
 		file
-			? { kind: "verified_radarr", target: radarrTargetIdentity, file }
+			? {
+					kind: "verified_radarr",
+					target: radarrTargetIdentity,
+					file,
+					peers: [],
+					ownership: [],
+					targetDeleteNotifications: [],
+				}
 			: { kind: "verified_radarr_empty", target: radarrTargetIdentity },
 	);
 }
@@ -365,6 +372,93 @@ function makeDeps(options: TestOptions = {}) {
 			targetMovie.tmdbId = tmdbId;
 			targetMovie.path = path;
 		},
+	};
+}
+
+function configureVerifiedRadarrPeer(
+	fixture: ReturnType<typeof makeDeps>,
+	overrides: {
+		filePath?: string;
+		fileSize?: number;
+		mapFrom?: string;
+		mapTo?: string;
+		movieTags?: number[];
+		notificationTags?: number[];
+		notificationEnable?: boolean;
+		updateLibrary?: boolean;
+	} = {},
+) {
+	const peerInstance = {
+		...fixture.targetInstance,
+		id: "radarr-hd",
+		label: "HD Radarr",
+		baseUrl: "http://radarr-hd.internal:7878",
+		encryptedApiKey: "encrypted-radarr-hd-key",
+		encryptionIv: "radarr-hd-iv",
+	};
+	const peerMovie = {
+		id: 202,
+		tmdbId: 42,
+		title: "Example Movie",
+		tags: overrides.movieTags ?? [],
+		hasFile: true,
+		movieFileId: 2002,
+		path: "/downloads-hd/Example Movie (2024)",
+		rootFolderPath: "/downloads-hd",
+	};
+	const peerMovieFile = {
+		id: 2002,
+		path: overrides.filePath ?? "/downloads-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+		relativePath: "Example.Movie.1080p.mkv",
+		size: overrides.fileSize ?? 1_000,
+	};
+	const deletePeerMovie = vi.fn();
+	const deletePeerMovieFile = vi.fn();
+	const peerClient = {
+		movie: {
+			getAll: vi.fn().mockResolvedValue([peerMovie]),
+			getById: vi.fn().mockResolvedValue(peerMovie),
+			delete: deletePeerMovie,
+			update: vi.fn(),
+		},
+		movieFile: {
+			getById: vi.fn().mockResolvedValue(peerMovieFile),
+			delete: deletePeerMovieFile,
+		},
+		notification: {
+			getAll: vi.fn().mockResolvedValue([
+				{
+					enable: overrides.notificationEnable,
+					implementation: "PlexServer",
+					configContract: "PlexServerSettings",
+					onMovieDelete: true,
+					onMovieFileDelete: true,
+					tags: overrides.notificationTags ?? [],
+					fields: notificationFields({
+						mapFrom: overrides.mapFrom ?? "/downloads-hd",
+						mapTo: overrides.mapTo ?? "/plex/movies-hd",
+						updateLibrary: overrides.updateLibrary,
+					}),
+				},
+			]),
+		},
+	};
+	vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+		(args) =>
+			(args?.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance])
+				: Promise.resolve([fixture.targetInstance, peerInstance])) as never,
+	);
+	vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+		(instance) => (instance.id === peerInstance.id ? peerClient : fixture.targetClient) as never,
+	);
+	return {
+		peerInstance,
+		peerMovie,
+		peerMovieFile,
+		peerClient,
+		deletePeerMovie,
+		deletePeerMovieFile,
 	};
 }
 
@@ -987,7 +1081,464 @@ describe("shared Plex deletion safety", () => {
 				service: { in: ["RADARR", "SONARR"] },
 			},
 		});
-		expect(targetClient.notification.getAll).not.toHaveBeenCalled();
+		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
+	});
+
+	it("allows a merged Plex movie when another Radarr instance verifies the retained part", async () => {
+		const fixture = makeDeps();
+		const { peerInstance, peerClient } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+
+		expect(blocks).toEqual(new Map());
+		expect(peerClient.movie.getAll).toHaveBeenCalledWith({ tmdbId: 42 });
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_radarr",
+			file: { movieFileId: 1001 },
+			peers: [
+				{
+					instanceId: peerInstance.id,
+					arrItemId: 202,
+					file: {
+						movieFileId: 2002,
+						fullPath: {
+							value: "/downloads-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+						},
+						size: 1_000,
+					},
+				},
+			],
+			ownership: [
+				{
+					plexServerUrl: "http://plex.internal:32400",
+					target: {
+						ratingKey: "plex-movie-42",
+						fullPath: {
+							value: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						},
+						size: 2_000,
+					},
+					retained: [
+						{
+							instanceId: peerInstance.id,
+							ratingKey: "plex-movie-42",
+							fullPath: {
+								value: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							},
+							size: 1_000,
+							mapping: {
+								from: { value: "/downloads-hd" },
+								to: { value: "/plex/movies-hd" },
+							},
+						},
+					],
+				},
+			],
+		});
+	});
+
+	it("deletes only the selected Radarr file after rechecking the retained peer", async () => {
+		const fixture = makeDeps();
+		const { peerClient, deletePeerMovie, deletePeerMovieFile } =
+			configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (
+			!plan ||
+			(plan.kind !== "verified_radarr" &&
+				plan.kind !== "verified_radarr_empty" &&
+				plan.kind !== "verified_arr_target" &&
+				plan.kind !== "verified_sonarr")
+		) {
+			throw new Error("Expected an executable safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).toHaveBeenCalledWith(101, {
+			deleteFiles: false,
+			addImportExclusion: false,
+		});
+		expect(peerClient.movie.getById).toHaveBeenCalledWith(202);
+		expect(deletePeerMovieFile).not.toHaveBeenCalled();
+		expect(deletePeerMovie).not.toHaveBeenCalled();
+	});
+
+	it("keeps the live peer witness while comparing a direct cleanup to cached target data", async () => {
+		const fixture = makeDeps({ onMovieDelete: true, onMovieFileDelete: true });
+		const { deletePeerMovie, deletePeerMovieFile } = configureVerifiedRadarrPeer(fixture);
+		configureRetryStore(fixture.deps);
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Remove 4K duplicate",
+				reason: "Matched 4K cleanup rule",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ itemsRemoved: 1, itemsSkipped: 0 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(deletePeerMovieFile).not.toHaveBeenCalled();
+		expect(deletePeerMovie).not.toHaveBeenCalled();
+	});
+
+	it("blocks a merged Plex movie when an extra part has no verified Radarr owner", async () => {
+		const fixture = makeDeps({
+			plexItems: [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+						{
+							file: "/plex/movies-remux/Example Movie (2024)/Example.Movie.Remux.mkv",
+							size: 3_000,
+						},
+					],
+				},
+			],
+		});
+		configureVerifiedRadarrPeer(fixture);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain("Plex has multiple files merged");
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+	});
+
+	it("blocks when the peer Radarr resolves to the selected Plex part", async () => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture, {
+			filePath: "/downloads-hd/Example Movie (2024)/Example.Movie.2160p.mkv",
+			fileSize: 2_000,
+			mapTo: "/movies-4k",
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Radarr instance may access the same storage",
+		);
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["disabled", { notificationEnable: false }],
+		["tag-inapplicable", { movieTags: [], notificationTags: [9] }],
+	])(
+		"does not authorize a raw peer path through a %s mapped notification",
+		async (_label, peer) => {
+			const fixture = makeDeps();
+			configureVerifiedRadarrPeer(fixture, {
+				...peer,
+				filePath: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+				mapFrom: "/stale-peer-root",
+				mapTo: "/stale-plex-root",
+			});
+
+			const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+			expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+				"could not match the exact Radarr movie file",
+			);
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		},
+	);
+
+	it("snapshots an unrelated Radarr peer as absent without blocking the retained variant", async () => {
+		const fixture = makeDeps();
+		const { peerInstance, peerClient } = configureVerifiedRadarrPeer(fixture);
+		const unrelatedInstance = {
+			...fixture.targetInstance,
+			id: "radarr-anime",
+			label: "Anime Radarr",
+			baseUrl: "http://radarr-anime.internal:7878",
+			encryptedApiKey: "encrypted-radarr-anime-key",
+			encryptionIv: "radarr-anime-iv",
+		};
+		const unrelatedClient = {
+			movie: {
+				getAll: vi.fn().mockResolvedValue([]),
+				getById: vi.fn(),
+				delete: vi.fn(),
+				update: vi.fn(),
+			},
+			movieFile: {
+				getById: vi.fn(),
+				delete: vi.fn(),
+			},
+			notification: {
+				getAll: vi.fn(),
+			},
+		};
+		vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+			(args) =>
+				(args?.where?.service === "PLEX"
+					? Promise.resolve([fixture.plexInstance])
+					: Promise.resolve([fixture.targetInstance, peerInstance, unrelatedInstance])) as never,
+		);
+		vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+			(instance) =>
+				(instance.id === peerInstance.id
+					? peerClient
+					: instance.id === unrelatedInstance.id
+						? unrelatedClient
+						: fixture.targetClient) as never,
+		);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		expect(plan.peers).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					instanceId: unrelatedInstance.id,
+					externalId: 42,
+					arrItemId: null,
+					mediaPath: null,
+					file: null,
+				}),
+			]),
+		);
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+
+		await expect(
+			executeApprovedItems(fixture.deps, "user-1", ["approval-1"]),
+		).resolves.toMatchObject({ removed: 1, failed: 0 });
+		expect(unrelatedClient.movie.getAll.mock.calls.length).toBeGreaterThanOrEqual(4);
+		expect(unrelatedClient.movie.getById).not.toHaveBeenCalled();
+	});
+
+	it("blocks at the mutation boundary when the retained Radarr peer changes", async () => {
+		const fixture = makeDeps();
+		const { peerClient, peerMovie } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		peerClient.movie.getById.mockResolvedValue({
+			...peerMovie,
+			movieFileId: 2999,
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(result.errors[0]).toContain("Radarr movie file changed");
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("blocks at the mutation boundary when the retained Plex binding changes", async () => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const safeItems = [
+			{
+				ratingKey: "plex-movie-42",
+				parts: [
+					{
+						file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+						size: 1_000,
+					},
+					{
+						file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						size: 2_000,
+					},
+				],
+			},
+		];
+		fixture.getMovieMediaPartsByTmdbId.mockResolvedValueOnce(safeItems).mockResolvedValueOnce([
+			{
+				ratingKey: "plex-movie-42",
+				parts: [
+					{
+						file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						size: 2_000,
+					},
+				],
+			},
+		]);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(result.errors[0]).toContain("ownership changed at the mutation boundary");
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("retains the target record when the peer disappears after exact file deletion", async () => {
+		const fixture = makeDeps();
+		const { peerClient } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			peerClient.movie.getAll.mockResolvedValue([]);
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(result.errors[0]).toContain("Partial cleanup");
+	});
+
+	it("retains the target record when its Plex notification changes after exact file deletion", async () => {
+		const fixture = makeDeps({ onMovieDelete: true, onMovieFileDelete: true });
+		configureVerifiedRadarrPeer(fixture);
+		const originalNotifications = await fixture.targetClient.notification.getAll();
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		expect(plan.targetDeleteNotifications).toHaveLength(1);
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.targetClient.notification.getAll.mockResolvedValue(
+				originalNotifications.map((notification: Record<string, unknown>) => ({
+					...notification,
+					fields: notificationFields({
+						mapFrom: "/movies-4k",
+						mapTo: "/changed-plex-root",
+					}),
+				})),
+			);
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(result.errors[0]).toContain("Partial cleanup");
+	});
+
+	it("retains the target record when a replacement file appears during the final Plex proof", async () => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+				fixture.setLiveMovieFileId(3003);
+				return [
+					{
+						ratingKey: "plex-movie-42",
+						parts: [
+							{
+								file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+								size: 1_000,
+							},
+						],
+					},
+				];
+			});
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(result.errors[0]).toContain("Partial cleanup");
 	});
 
 	it("renders only preview items that can receive live safety inspection", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1541,6 +1541,113 @@ describe("shared Plex deletion safety", () => {
 		expect(result.errors[0]).toContain("Partial cleanup");
 	});
 
+	it("retains the target record when a new unowned Plex part appears after exact file deletion", async () => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockResolvedValue([
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/plex/movies-remux/Example Movie (2024)/Example.Movie.Remux.mkv",
+							size: 3_000,
+						},
+					],
+				},
+			]);
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(result.errors[0]).toContain("Partial cleanup");
+	});
+
+	it("allows the deleted target Plex item to disappear when the retained peer has its own item", async () => {
+		const fixture = makeDeps({
+			plexItems: [
+				{
+					ratingKey: "plex-movie-4k",
+					parts: [
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+				{
+					ratingKey: "plex-movie-hd",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+					],
+				},
+			],
+		});
+		configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockResolvedValue([
+				{
+					ratingKey: "plex-movie-hd",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+					],
+				},
+			]);
+		});
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).toHaveBeenCalledWith(101, {
+			deleteFiles: false,
+			addImportExclusion: false,
+		});
+	});
+
 	it("renders only preview items that can receive live safety inspection", () => {
 		const flagged = Array.from({ length: 201 }, (_, index) => ({
 			cacheItem: { arrItemId: index + 1 },

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -10,26 +10,28 @@
  * Supports three actions per rule: delete, unmonitor, delete_files.
  */
 
+import { createHash, randomUUID } from "node:crypto";
 import { type DataSourceDependency, ruleDataSourceMap } from "@arr/shared";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
-import { createHash, randomUUID } from "node:crypto";
 import type { Prisma } from "../../generated/prisma/client.js";
 import { isNotFoundError } from "../arr/client-factory.js";
 import type { LibraryCleanupConfig, LibraryCleanupRule, ServiceInstance } from "../prisma.js";
 import { SeerrClient } from "../seerr/seerr-client.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
+import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 import { applyQuiSeedingFilter } from "./qui-filter.js";
 import { evaluateItemAgainstRules, extractRating } from "./rule-evaluators.js";
 import {
 	ArrCrossInstanceOwnershipChangedDuringSafetyCheckError,
 	ArrFileChangedDuringSafetyCheckError,
 	ArrMutationAuthorityChangedDuringSafetyCheckError,
+	ArrTargetChangedDuringSafetyCheckError,
 	assertVerifiedArrTargetUnchanged,
 	assertVerifiedRadarrEmptyUnchanged,
 	assertVerifiedRadarrFileUnchanged,
+	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
-	ArrTargetChangedDuringSafetyCheckError,
 	buildCacheTargetSafetyPlan,
 	buildRadarrCacheSafetyPlan,
 	buildSonarrCacheSafetyPlan,
@@ -42,9 +44,9 @@ import {
 	findSharedPlexDeleteBlocks,
 	parseExecutableSafetyPlan,
 	RadarrFileChangedDuringSafetyCheckError,
-	serializeExecutableSafetyPlan,
 	type SharedMediaSafetyPlan,
 	SonarrFilesChangedDuringSafetyCheckError,
+	serializeExecutableSafetyPlan,
 	type VerifiedRadarrFileIdentity,
 	type VerifiedSonarrFileIdentity,
 } from "./shared-plex-safety.js";
@@ -65,7 +67,6 @@ import type {
 	SeerrRequestMap,
 	TautulliWatchMap,
 } from "./types.js";
-import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 
 // Default approval expiry: 7 days
 const APPROVAL_EXPIRY_DAYS = 7;
@@ -601,21 +602,93 @@ async function loadCurrentMutationInstance(
 	) {
 		throw new ArrTargetChangedDuringSafetyCheckError();
 	}
-	const verifiedFileCount =
-		executablePlan.kind === "verified_radarr"
-			? 1
-			: executablePlan.kind === "verified_sonarr"
-				? executablePlan.files.episodeFiles.length
-				: 0;
-	if (
-		verifiedFileCount > 0 &&
+	if (executablePlan.kind === "verified_radarr") {
+		const peerInstances = instances.filter(
+			(candidate) => candidate.id !== instance.id && candidate.service === "RADARR",
+		);
+		const peerIds = new Set(executablePlan.peers.map((peer) => peer.instanceId));
+		if (
+			peerInstances.length !== peerIds.size ||
+			peerInstances.some((peerInstance) => !peerIds.has(peerInstance.id))
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		for (const peer of executablePlan.peers) {
+			const peerInstance = peerInstances.find((candidate) => candidate.id === peer.instanceId);
+			if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			const peerClient = deps.arrClientFactory.create(peerInstance) as InstanceType<
+				typeof RadarrClient
+			>;
+			const peerMovies = (await peerClient.movie.getAll({ tmdbId: peer.externalId })).filter(
+				(movie) => movie.tmdbId === peer.externalId,
+			);
+			if (peer.arrItemId === null) {
+				if (peerMovies.length !== 0) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+				continue;
+			}
+			if (
+				peerMovies.length !== 1 ||
+				peerMovies[0]?.id !== peer.arrItemId ||
+				peer.mediaPath === null
+			) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			const peerTarget = {
+				serviceFingerprint: peer.serviceFingerprint,
+				externalId: peer.externalId,
+				mediaPath: peer.mediaPath,
+			};
+			if (peer.file) {
+				await assertVerifiedRadarrFileUnchanged(peerClient, peer.arrItemId, peerTarget, peer.file);
+			} else {
+				await assertVerifiedRadarrEmptyUnchanged(peerClient, peer.arrItemId, peerTarget);
+			}
+		}
+	} else if (
+		executablePlan.kind === "verified_sonarr" &&
+		executablePlan.files.episodeFiles.length > 0 &&
 		instances.some(
 			(candidate) => candidate.id !== instance.id && candidate.service === instance.service,
 		)
 	) {
-		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError(instance.service);
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
 	}
 	return instance;
+}
+
+function withRadarrPeerOwnershipRevalidation(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	target: CleanupDeleteTarget,
+	safetyPlan: SharedMediaSafetyPlan,
+	assertMutationAuthority?: () => Promise<void>,
+): () => Promise<void> {
+	let ownershipRevalidationCount = 0;
+	return async () => {
+		await assertMutationAuthority?.();
+		if (safetyPlan.kind !== "verified_radarr" || safetyPlan.peers.length === 0) {
+			return;
+		}
+		if (ownershipRevalidationCount === 0) {
+			const context = createSharedPlexSafetyContext();
+			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+			const targetKey = cleanupDeleteTargetKey(target);
+			const livePlan = asExecutableSafetyPlan(context.plans.get(targetKey));
+			if (blocks.has(targetKey) || !livePlan || !executableSafetyPlansEqual(safetyPlan, livePlan)) {
+				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+					"Skipped for safety: the verified Radarr-to-Plex ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+				);
+			}
+		} else {
+			await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
+		}
+		ownershipRevalidationCount++;
+		await assertMutationAuthority?.();
+	};
 }
 
 async function persistAndClaimDirectMutationIntent(
@@ -706,7 +779,15 @@ async function buildEvaluatedCacheSafetyPlan(
 		return buildCacheTargetSafetyPlan(data, item.itemType, livePlan.target);
 	}
 	if (livePlan.kind === "verified_radarr" || livePlan.kind === "verified_radarr_empty") {
-		return buildRadarrCacheSafetyPlan(data, item.hasFile, livePlan.target);
+		const cachePlan = buildRadarrCacheSafetyPlan(data, item.hasFile, livePlan.target);
+		return cachePlan?.kind === "verified_radarr" && livePlan.kind === "verified_radarr"
+			? {
+					...cachePlan,
+					peers: livePlan.peers,
+					ownership: livePlan.ownership,
+					targetDeleteNotifications: livePlan.targetDeleteNotifications,
+				}
+			: cachePlan;
 	}
 	const seriesPath =
 		data && typeof data === "object" && "path" in data
@@ -1716,10 +1797,22 @@ async function executeQueuedCleanupItems(
 					approval.instanceId,
 					safetyPlan!,
 				);
-				const assertMutationAuthority = async () => {
+				const assertExecutionAuthority = async () => {
 					await options.assertExecutionAllowed?.();
 					mutationBudgetConsumedIds.add(approval.id);
 				};
+				const assertMutationAuthority = withRadarrPeerOwnershipRevalidation(
+					deps,
+					userId,
+					{
+						instanceId: approval.instanceId,
+						arrItemId: approval.arrItemId,
+						itemType: approval.itemType,
+						action,
+					},
+					safetyPlan!,
+					assertExecutionAuthority,
+				);
 
 				if (retryTargetAlreadyAbsent) {
 					executionCompleted = true;
@@ -3570,6 +3663,18 @@ export async function executeDirectRemoval(
 				instance.id,
 				safetyPlan!,
 			);
+			const assertMutationAuthority = withRadarrPeerOwnershipRevalidation(
+				deps,
+				userId,
+				{
+					instanceId: item.cacheItem.instanceId,
+					arrItemId: item.cacheItem.arrItemId,
+					itemType: item.cacheItem.itemType,
+					action: ruleAction,
+				},
+				safetyPlan!,
+				assertRunLease,
+			);
 
 			if (ruleAction === "unmonitor") {
 				await unmonitorInArr(
@@ -3577,7 +3682,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
-					assertRunLease,
+					assertMutationAuthority,
 				);
 				try {
 					await prisma.libraryCache.updateMany({
@@ -3607,7 +3712,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
-					assertRunLease,
+					assertMutationAuthority,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,
@@ -3654,7 +3759,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
-					assertRunLease,
+					assertMutationAuthority,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -2095,6 +2095,12 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 		for (const plexInstance of matchingPlexInstances) {
 			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
 			const mediaItems = await plex.getMovieMediaPartsByTmdbId(plan.target.externalId);
+			const targetItems = mediaItems.filter(
+				(item) => item.ratingKey === ownership.target.ratingKey,
+			);
+			if (targetItems.length > 1) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
 			for (const expected of ownership.retained) {
 				const peer = livePeers.get(expected.instanceId);
 				if (!peer) {
@@ -2107,6 +2113,30 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 					match.part.size !== expected.size ||
 					!pathsEqual(normalizeMediaPath(match.part.file), expected.fullPath) ||
 					JSON.stringify(match.mapping) !== JSON.stringify(expected.mapping)
+				) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+			}
+			const currentTargetItem = targetItems[0];
+			if (currentTargetItem) {
+				const allowedTargetItemParts = new Set([
+					plexPartKey({
+						file: ownership.target.fullPath.value,
+						size: ownership.target.size,
+					}),
+					...ownership.retained
+						.filter((expected) => expected.ratingKey === ownership.target.ratingKey)
+						.map((expected) =>
+							plexPartKey({
+								file: expected.fullPath.value,
+								size: expected.size,
+							}),
+						),
+				]);
+				const currentTargetItemPartKeys = currentTargetItem.parts.map(plexPartKey);
+				if (
+					new Set(currentTargetItemPartKeys).size !== currentTargetItemPartKeys.length ||
+					currentTargetItemPartKeys.some((partKey) => !allowedTargetItemParts.has(partKey))
 				) {
 					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
 				}

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -1,14 +1,14 @@
 import type {
 	Movie,
 	MovieFile,
-	Notification as RadarrNotification,
 	RadarrClient,
+	Notification as RadarrNotification,
 } from "arr-sdk/radarr";
 import type {
 	EpisodeFile,
-	Notification as SonarrNotification,
 	Series,
 	SonarrClient,
+	Notification as SonarrNotification,
 } from "arr-sdk/sonarr";
 import {
 	createPlexClient,
@@ -17,7 +17,9 @@ import {
 	type PlexSeriesMediaItem,
 } from "../plex/plex-client.js";
 import type { ServiceInstance } from "../prisma.js";
+
 export { createArrServiceFingerprint } from "../arr/service-fingerprint.js";
+
 import { createArrServiceFingerprint } from "../arr/service-fingerprint.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import type { CleanupExecutorDeps } from "./types.js";
@@ -88,6 +90,37 @@ export interface VerifiedArrTargetIdentity {
 	mediaPath: NormalizedMediaPath;
 }
 
+export interface VerifiedRadarrPeerIdentity {
+	instanceId: string;
+	serviceFingerprint: string;
+	externalId: number;
+	arrItemId: number | null;
+	mediaPath: NormalizedMediaPath | null;
+	file: VerifiedRadarrFileIdentity | null;
+}
+
+export interface VerifiedRadarrPlexOwnership {
+	plexServerUrl: string;
+	target: {
+		ratingKey: string;
+		fullPath: NormalizedMediaPath;
+		size: number;
+	};
+	retained: Array<{
+		instanceId: string;
+		ratingKey: string;
+		fullPath: NormalizedMediaPath;
+		size: number;
+		mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+	}>;
+}
+
+export interface VerifiedRadarrTargetDeleteNotification {
+	plexServerUrl: string;
+	onMovieFileDelete: boolean;
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}
+
 export type VerifiedCleanupFileIdentity =
 	| { service: "RADARR"; file: VerifiedRadarrFileIdentity }
 	| { service: "SONARR"; files: VerifiedSonarrFileIdentity };
@@ -101,6 +134,9 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_radarr";
 			target: VerifiedArrTargetIdentity;
 			file: VerifiedRadarrFileIdentity;
+			peers: VerifiedRadarrPeerIdentity[];
+			ownership: VerifiedRadarrPlexOwnership[];
+			targetDeleteNotifications: VerifiedRadarrTargetDeleteNotification[];
 	  }
 	| {
 			kind: "verified_sonarr";
@@ -148,6 +184,165 @@ function canonicalTargetIdentity(value: unknown): VerifiedArrTargetIdentity {
 	};
 }
 
+function canonicalRadarrFileIdentity(value: unknown): VerifiedRadarrFileIdentity {
+	if (!value || typeof value !== "object") {
+		throw new FileMatchVerificationError("Radarr file identity is invalid");
+	}
+	const file = value as Record<string, unknown>;
+	return {
+		movieFileId: requiredPositiveSafeInteger(file.movieFileId, "Radarr movie file ID"),
+		fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
+		size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
+	};
+}
+
+function canonicalRadarrPeers(value: unknown): VerifiedRadarrPeerIdentity[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr peer safety snapshot is invalid");
+	}
+	const peers = value
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Radarr peer safety snapshot is invalid");
+			}
+			const peer = entry as Record<string, unknown>;
+			const serviceFingerprint = requiredNonEmptyString(
+				peer.serviceFingerprint,
+				"Radarr peer service fingerprint",
+			);
+			if (!/^[a-f0-9]{64}$/.test(serviceFingerprint)) {
+				throw new FileMatchVerificationError("Radarr peer service fingerprint is invalid");
+			}
+			const arrItemId =
+				peer.arrItemId === null
+					? null
+					: requiredPositiveSafeInteger(peer.arrItemId, "Radarr peer movie ID");
+			const mediaPath =
+				peer.mediaPath === null
+					? null
+					: normalizeMediaPath((peer.mediaPath as Record<string, unknown> | undefined)?.value);
+			const file = peer.file === null ? null : canonicalRadarrFileIdentity(peer.file);
+			if (arrItemId === null ? mediaPath !== null || file !== null : mediaPath === null) {
+				throw new FileMatchVerificationError("Radarr peer movie snapshot is inconsistent");
+			}
+			return {
+				instanceId: requiredNonEmptyString(peer.instanceId, "Radarr peer instance ID"),
+				serviceFingerprint,
+				externalId: requiredPositiveSafeInteger(peer.externalId, "Radarr peer external media ID"),
+				arrItemId,
+				mediaPath,
+				file,
+			};
+		})
+		.sort((left, right) => left.instanceId.localeCompare(right.instanceId));
+	if (new Set(peers.map((peer) => peer.instanceId)).size !== peers.length) {
+		throw new FileMatchVerificationError(
+			"Radarr peer safety snapshot contains duplicate instances",
+		);
+	}
+	return peers;
+}
+
+function canonicalRadarrOwnership(value: unknown): VerifiedRadarrPlexOwnership[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+	}
+	const ownership = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+		}
+		const witness = entry as Record<string, unknown>;
+		const target = witness.target as Record<string, unknown> | undefined;
+		if (!target || !Array.isArray(witness.retained)) {
+			throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+		}
+		const retained = witness.retained
+			.map((retainedEntry) => {
+				if (!retainedEntry || typeof retainedEntry !== "object") {
+					throw new FileMatchVerificationError("Radarr retained-part snapshot is invalid");
+				}
+				const part = retainedEntry as Record<string, unknown>;
+				const mapping = part.mapping as Record<string, unknown> | null | undefined;
+				return {
+					instanceId: requiredNonEmptyString(part.instanceId, "Radarr retained-part instance ID"),
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Radarr retained Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Radarr retained Plex part size"),
+					mapping:
+						mapping === null
+							? null
+							: {
+									from: normalizeMediaPath(
+										(mapping?.from as Record<string, unknown> | undefined)?.value,
+									),
+									to: normalizeMediaPath(
+										(mapping?.to as Record<string, unknown> | undefined)?.value,
+									),
+								},
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		return {
+			plexServerUrl: requiredNonEmptyString(witness.plexServerUrl, "Radarr ownership Plex URL"),
+			target: {
+				ratingKey: requiredNonEmptyString(target.ratingKey, "Radarr target Plex rating key"),
+				fullPath: normalizeMediaPath(
+					(target.fullPath as Record<string, unknown> | undefined)?.value,
+				),
+				size: requiredPositiveSafeInteger(target.size, "Radarr target Plex part size"),
+			},
+			retained,
+		};
+	});
+	const unique = new Map(ownership.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
+function canonicalRadarrTargetDeleteNotifications(
+	value: unknown,
+): VerifiedRadarrTargetDeleteNotification[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr target notification snapshot is invalid");
+	}
+	const notifications = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Radarr target notification snapshot is invalid");
+		}
+		const notification = entry as Record<string, unknown>;
+		const normalizedUrl = normalizedServerUrl(
+			requiredNonEmptyString(notification.plexServerUrl, "Radarr target notification Plex URL"),
+		);
+		if (!normalizedUrl) {
+			throw new FileMatchVerificationError("Radarr target notification Plex URL is invalid");
+		}
+		const mapping = notification.mapping as Record<string, unknown> | null | undefined;
+		return {
+			plexServerUrl: normalizedUrl,
+			onMovieFileDelete: notification.onMovieFileDelete === true,
+			mapping:
+				mapping === null
+					? null
+					: {
+							from: normalizeMediaPath(
+								(mapping?.from as Record<string, unknown> | undefined)?.value,
+							),
+							to: normalizeMediaPath((mapping?.to as Record<string, unknown> | undefined)?.value),
+						},
+		};
+	});
+	const unique = new Map(notifications.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
 function buildTargetIdentity(
 	instance: ServiceInstance,
 	externalId: unknown,
@@ -178,16 +373,15 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 		};
 	}
 	if (candidate.kind === "verified_radarr") {
-		const file = candidate.file as Record<string, unknown> | undefined;
-		if (!file) throw new FileMatchVerificationError("Radarr safety snapshot is invalid");
 		return {
 			kind: "verified_radarr",
 			target: canonicalTargetIdentity(candidate.target),
-			file: {
-				movieFileId: requiredPositiveSafeInteger(file.movieFileId, "Radarr movie file ID"),
-				fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
-				size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
-			},
+			file: canonicalRadarrFileIdentity(candidate.file),
+			peers: canonicalRadarrPeers(candidate.peers),
+			ownership: canonicalRadarrOwnership(candidate.ownership),
+			targetDeleteNotifications: canonicalRadarrTargetDeleteNotifications(
+				candidate.targetDeleteNotifications,
+			),
 		};
 	}
 	if (candidate.kind === "verified_sonarr") {
@@ -282,6 +476,9 @@ export function buildRadarrCacheSafetyPlan(
 				fullPath: { value: pathValue },
 				size: movieFile.size,
 			},
+			peers: [],
+			ownership: [],
+			targetDeleteNotifications: [],
 		});
 	} catch {
 		return null;
@@ -378,6 +575,7 @@ export class SonarrFilesChangedDuringSafetyCheckError extends ArrFileChangedDuri
 }
 
 interface NotificationLike {
+	enable?: boolean | null;
 	implementation?: string | null;
 	implementationName?: string | null;
 	configContract?: string | null;
@@ -712,7 +910,7 @@ function matchingPlexItems(
 	items: PlexMovieMediaItem[],
 	notification: NotificationLike,
 	service: "RADARR" | "SONARR",
-): PlexMovieMediaItem[] {
+): Array<{ item: PlexMovieMediaItem; part: { file: string; size: number } }> {
 	return targets.map((target) => {
 		const mappedTarget = {
 			...target,
@@ -730,7 +928,7 @@ function matchingPlexItems(
 					: `Multiple Plex media parts matched the ${serviceLabel(service)} file path and size`,
 			);
 		}
-		return matches[0]!.item;
+		return matches[0]!;
 	});
 }
 
@@ -869,6 +1067,7 @@ function radarrNotificationApplies(
 	action: string,
 ): boolean {
 	if (
+		(notification as NotificationLike).enable === false ||
 		mediaServerNotificationKind(notification) === null ||
 		!notificationMutatesLibrary(notification)
 	) {
@@ -956,6 +1155,54 @@ function normalizedServerUrl(value: string): string | null {
 	}
 }
 
+function notificationPathMapping(
+	notification: NotificationLike,
+	label: string,
+): { from: NormalizedMediaPath; to: NormalizedMediaPath } | null {
+	const rawMapFrom = fieldValue(notification, "mapFrom");
+	const rawMapTo = fieldValue(notification, "mapTo");
+	const hasMapFrom = typeof rawMapFrom === "string" && rawMapFrom.trim() !== "";
+	const hasMapTo = typeof rawMapTo === "string" && rawMapTo.trim() !== "";
+	if (hasMapFrom !== hasMapTo) {
+		throw new FileMatchVerificationError(`${label} Plex path mapping is incomplete`);
+	}
+	return hasMapFrom && hasMapTo
+		? {
+				from: normalizeMediaPath(rawMapFrom),
+				to: normalizeMediaPath(rawMapTo),
+			}
+		: null;
+}
+
+function radarrTargetDeleteNotificationWitnesses(
+	notifications: RadarrNotification[],
+	movie: Movie,
+): VerifiedRadarrTargetDeleteNotification[] {
+	const witnesses = notifications
+		.filter(
+			(notification) =>
+				radarrNotificationApplies(notification, movie, "delete") &&
+				notification.onMovieDelete === true,
+		)
+		.map((notification) => {
+			if (mediaServerNotificationKind(notification) !== "plex") {
+				throw new FileMatchVerificationError(
+					"Radarr target has an unsupported movie-delete notification",
+				);
+			}
+			const plexServerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+			if (!plexServerUrl) {
+				throw new FileMatchVerificationError("Radarr target movie-delete Plex URL is invalid");
+			}
+			return {
+				plexServerUrl,
+				onMovieFileDelete: notification.onMovieFileDelete === true,
+				mapping: notificationPathMapping(notification, "Radarr target"),
+			};
+		});
+	return canonicalRadarrTargetDeleteNotifications(witnesses);
+}
+
 function plexConnectionFingerprint(instance: ServiceInstance): string {
 	return JSON.stringify([
 		instance.id,
@@ -1013,6 +1260,111 @@ interface PlexVerificationInput {
 	notifications: PlexNotification[];
 	externalId: number;
 	files: MediaFileIdentity[];
+	radarrPeers?: Array<{
+		identity: VerifiedRadarrPeerIdentity;
+		movieTags: number[];
+		notifications: RadarrNotification[];
+	}>;
+}
+
+interface PlexVerificationResult {
+	block?: string;
+	ownership: VerifiedRadarrPlexOwnership[];
+}
+
+function matchingPeerPlexPart(
+	peer: NonNullable<PlexVerificationInput["radarrPeers"]>[number],
+	items: PlexMovieMediaItem[],
+	notificationUrl: string,
+): {
+	item: PlexMovieMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+} | null {
+	if (!peer.identity.file) return null;
+	const file = comparableFile(peer.identity.file);
+	const serverNotifications: RadarrNotification[] = [];
+	for (const notification of peer.notifications) {
+		if (mediaServerNotificationKind(notification) !== "plex") continue;
+		let peerUrl: string | null = null;
+		try {
+			peerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+		} catch {
+			continue;
+		}
+		if (peerUrl === notificationUrl) serverNotifications.push(notification);
+	}
+	const matchingNotifications = serverNotifications.filter(
+		(notification) =>
+			(notification as NotificationLike).enable !== false &&
+			notificationMutatesLibrary(notification) &&
+			notificationTagsApply(notification, peer.movieTags),
+	);
+	const unusableConfiguredMapping = serverNotifications.some((notification) => {
+		const rawMapFrom = fieldValue(notification, "mapFrom");
+		const rawMapTo = fieldValue(notification, "mapTo");
+		return (
+			!matchingNotifications.includes(notification) &&
+			((typeof rawMapFrom === "string" && rawMapFrom.trim() !== "") ||
+				(typeof rawMapTo === "string" && rawMapTo.trim() !== ""))
+		);
+	});
+	if (matchingNotifications.length === 0 && unusableConfiguredMapping) {
+		throw new FileMatchVerificationError("Radarr peer has only non-applicable Plex path mappings");
+	}
+
+	const pathCandidates = new Map<
+		string,
+		{
+			fullPath: NormalizedMediaPath;
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>();
+	if (matchingNotifications.length === 0) {
+		pathCandidates.set(JSON.stringify([file.fullPath, null]), {
+			fullPath: file.fullPath,
+			mapping: null,
+		});
+	}
+	for (const notification of matchingNotifications) {
+		const mapping = notificationPathMapping(notification, "Radarr peer");
+		const fullPath = mapping
+			? mappedArrPathForNotification(file, notification, "RADARR")
+			: file.fullPath;
+		pathCandidates.set(JSON.stringify([fullPath, mapping]), { fullPath, mapping });
+	}
+	if (pathCandidates.size !== 1) {
+		throw new FileMatchVerificationError("Radarr peer Plex path mappings conflict");
+	}
+	const pathCandidate = [...pathCandidates.values()][0]!;
+	const matches = new Map<
+		string,
+		{
+			item: PlexMovieMediaItem;
+			part: { file: string; size: number };
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>();
+	const mappedFile = { ...file, fullPath: pathCandidate.fullPath };
+	for (const item of items) {
+		for (const part of item.parts) {
+			if (mediaPartMatchesTarget(mappedFile, part)) {
+				matches.set(`${item.ratingKey}:${plexPartKey(part)}`, {
+					item,
+					part,
+					mapping: pathCandidate.mapping,
+				});
+			}
+		}
+	}
+	if (matches.size !== 1) {
+		throw new FileMatchVerificationError(
+			matches.size === 0
+				? "No Plex media part matched the retained Radarr peer file"
+				: "Multiple Plex media parts matched the retained Radarr peer file",
+		);
+	}
+	return [...matches.values()][0]!;
 }
 
 async function verifyPlexMediaState(
@@ -1023,8 +1375,9 @@ async function verifyPlexMediaState(
 	movieLookups: Map<SafetyPlexClient, Map<number, Promise<PlexMovieMediaItem[]>>>,
 	seriesLookups: Map<SafetyPlexClient, Map<number, Promise<PlexSeriesMediaItem[]>>>,
 	input: PlexVerificationInput,
-): Promise<string | undefined> {
-	if (input.files.length === 0) return undefined;
+): Promise<PlexVerificationResult> {
+	const ownership: VerifiedRadarrPlexOwnership[] = [];
+	if (input.files.length === 0) return { ownership };
 
 	for (const notification of input.notifications) {
 		const notificationUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
@@ -1062,14 +1415,62 @@ async function verifyPlexMediaState(
 						mediaPartsPromise = plex.getMovieMediaPartsByTmdbId(input.externalId);
 						clientLookups.set(input.externalId, mediaPartsPromise);
 					}
-					const matchedItems = matchingPlexItems(
+					const mediaItems = await mediaPartsPromise;
+					const targetMatches = matchingPlexItems(
 						input.files,
-						await mediaPartsPromise,
+						mediaItems,
 						notification,
 						input.service,
 					);
-					if (matchedItems.some((item) => item.parts.length > 1)) {
-						return mergedItemReason(input.service);
+					for (const targetMatch of targetMatches) {
+						const targetPartKey = plexPartKey(targetMatch.part);
+						const retainedPartKeys = new Set<string>();
+						const retained: VerifiedRadarrPlexOwnership["retained"] = [];
+						if (input.radarrPeers?.length && notificationUrl) {
+							for (const peer of input.radarrPeers) {
+								const peerMatch = matchingPeerPlexPart(peer, mediaItems, notificationUrl);
+								if (!peerMatch) continue;
+								const peerPartKey = plexPartKey(peerMatch.part);
+								if (peerPartKey === targetPartKey) {
+									return {
+										block: crossInstanceOwnershipReason("RADARR"),
+										ownership,
+									};
+								}
+								retained.push({
+									instanceId: peer.identity.instanceId,
+									ratingKey: peerMatch.item.ratingKey,
+									fullPath: normalizeMediaPath(peerMatch.part.file),
+									size: peerMatch.part.size,
+									mapping: peerMatch.mapping,
+								});
+								if (peerMatch.item.ratingKey === targetMatch.item.ratingKey) {
+									retainedPartKeys.add(peerPartKey);
+								}
+							}
+						}
+						if (input.radarrPeers?.length && notificationUrl) {
+							ownership.push({
+								plexServerUrl: notificationUrl,
+								target: {
+									ratingKey: targetMatch.item.ratingKey,
+									fullPath: normalizeMediaPath(targetMatch.part.file),
+									size: targetMatch.part.size,
+								},
+								retained,
+							});
+						}
+						if (targetMatch.item.parts.length <= 1) continue;
+						if (!input.radarrPeers?.length || !notificationUrl) {
+							return { block: mergedItemReason(input.service), ownership };
+						}
+						const unownedParts = targetMatch.item.parts.filter((part) => {
+							const partKey = plexPartKey(part);
+							return partKey !== targetPartKey && !retainedPartKeys.has(partKey);
+						});
+						if (retainedPartKeys.size === 0 || unownedParts.length > 0) {
+							return { block: mergedItemReason(input.service), ownership };
+						}
 					}
 				} else {
 					let clientLookups = seriesLookups.get(plex);
@@ -1086,7 +1487,7 @@ async function verifyPlexMediaState(
 						matchingPlexSeriesShows(input.files, await mediaPartsPromise, notification);
 					} catch (error) {
 						if (error instanceof SharedPlexItemError) {
-							return mergedItemReason(input.service);
+							return { block: mergedItemReason(input.service), ownership };
 						}
 						throw error;
 					}
@@ -1110,13 +1511,15 @@ async function verifyPlexMediaState(
 			throw new Error("No matching Plex credential could verify owner-visible media state");
 		}
 	}
-	return undefined;
+	return { ownership };
 }
 
 /**
  * Fail-closed preflight for shared Plex library deletions initiated through
  * either Radarr or Sonarr. The live ARR file set is correlated to exact Plex
- * media parts after applying the target ARR connection's path mapping.
+ * media parts after applying the target ARR connection's path mapping. A
+ * multi-part Radarr movie is allowed only when every retained Plex part is
+ * backed by a peer Radarr witness and every configured peer is snapshotted.
  */
 export async function findSharedPlexDeleteBlocks(
 	deps: CleanupExecutorDeps,
@@ -1162,6 +1565,7 @@ export async function findSharedPlexDeleteBlocks(
 	const instancesById = new Map(instances.map((instance) => [instance.id, instance]));
 	const radarrClients = new Map<string, InstanceType<typeof RadarrClient>>();
 	const sonarrClients = new Map<string, InstanceType<typeof SonarrClient>>();
+	const radarrMovies = new Map<string, Promise<Movie[]>>();
 	const radarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
 	const sonarrNotifications = new Map<string, Promise<SonarrNotification[]>>();
 	const plexOwnerChecks = new Map<string, Promise<void>>();
@@ -1199,6 +1603,20 @@ export async function findSharedPlexDeleteBlocks(
 			radarrNotifications.set(instance.id, notifications);
 		}
 		return notifications;
+	};
+
+	const getRadarrMovies = (
+		instance: ServiceInstance,
+		client: InstanceType<typeof RadarrClient>,
+		tmdbId: number,
+	): Promise<Movie[]> => {
+		const lookupKey = `${instance.id}:${tmdbId}`;
+		let movies = radarrMovies.get(lookupKey);
+		if (!movies) {
+			movies = client.movie.getAll({ tmdbId });
+			radarrMovies.set(lookupKey, movies);
+		}
+		return movies;
 	};
 
 	const getSonarrNotifications = (
@@ -1294,21 +1712,24 @@ export async function findSharedPlexDeleteBlocks(
 							await radarr.movieFile.getById(movieFileId),
 							movieFileId,
 						),
+						peers: [],
+						ownership: [],
+						targetDeleteNotifications: [],
 					};
-				}
-				if (
-					verifiedPlan.kind === "verified_radarr" &&
-					otherInstanceMayOwnFile(targetInstance, service, 1)
-				) {
-					const reason = crossInstanceOwnershipReason(service);
-					blocks.set(targetKey, reason);
-					context.plans.set(targetKey, { kind: "blocked", reason });
-					continue;
 				}
 				const notifications = (await getRadarrNotifications(targetInstance, radarr)).filter(
 					(notification) => radarrNotificationApplies(notification, movie, action),
 				);
 				if (notifications.length === 0) {
+					if (
+						verifiedPlan.kind === "verified_radarr" &&
+						otherInstanceMayOwnFile(targetInstance, service, 1)
+					) {
+						const reason = crossInstanceOwnershipReason(service);
+						blocks.set(targetKey, reason);
+						context.plans.set(targetKey, { kind: "blocked", reason });
+						continue;
+					}
 					if (verifiedPlan.kind === "verified_radarr") {
 						context.verifiedRadarrFiles.set(targetKey, verifiedPlan.file);
 					}
@@ -1353,8 +1774,66 @@ export async function findSharedPlexDeleteBlocks(
 					context.plans.set(targetKey, verifiedPlan);
 					continue;
 				}
+				const peerInstances = instances.filter(
+					(candidate) => candidate.id !== targetInstance.id && candidate.service === "RADARR",
+				);
+				const radarrPeers: NonNullable<PlexVerificationInput["radarrPeers"]> = [];
+				for (const peerInstance of peerInstances) {
+					const peerClient = getRadarrClient(peerInstance);
+					const peerMovies = (await getRadarrMovies(peerInstance, peerClient, tmdbId)).filter(
+						(candidate) => candidate.tmdbId === tmdbId,
+					);
+					if (peerMovies.length > 1) {
+						throw new FileMatchVerificationError("Radarr peer returned multiple matching movies");
+					}
+					if (peerMovies.length === 0) {
+						radarrPeers.push({
+							identity: {
+								instanceId: peerInstance.id,
+								serviceFingerprint: createArrServiceFingerprint(peerInstance),
+								externalId: tmdbId,
+								arrItemId: null,
+								mediaPath: null,
+								file: null,
+							},
+							movieTags: [],
+							notifications: [],
+						});
+						continue;
+					}
+					const peerMovie = peerMovies[0]!;
+					const peerMovieId = requiredPositiveSafeInteger(peerMovie.id, "Radarr peer movie ID");
+					const peerMovieFileId = peerMovie.movieFileId;
+					let peerFile: VerifiedRadarrFileIdentity | null = null;
+					if (
+						peerMovie.hasFile !== false ||
+						(typeof peerMovieFileId === "number" && peerMovieFileId > 0)
+					) {
+						const verifiedPeerFileId = requiredPositiveSafeInteger(
+							peerMovieFileId,
+							"Radarr peer movie file ID",
+						);
+						peerFile = radarrFileIdentity(
+							peerMovie,
+							await peerClient.movieFile.getById(verifiedPeerFileId),
+							verifiedPeerFileId,
+						);
+					}
+					radarrPeers.push({
+						identity: {
+							instanceId: peerInstance.id,
+							serviceFingerprint: createArrServiceFingerprint(peerInstance),
+							externalId: tmdbId,
+							arrItemId: peerMovieId,
+							mediaPath: normalizeMediaPath(peerMovie.path),
+							file: peerFile,
+						},
+						movieTags: peerMovie.tags ?? [],
+						notifications: await getRadarrNotifications(peerInstance, peerClient),
+					});
+				}
 				const targetFile = verifiedPlan.file;
-				const block = await verifyPlexMediaState(
+				const verification = await verifyPlexMediaState(
 					deps,
 					context,
 					plexOwnerChecks,
@@ -1367,17 +1846,24 @@ export async function findSharedPlexDeleteBlocks(
 						notifications: plexNotifications,
 						externalId: tmdbId,
 						files: [comparableFile(targetFile)],
+						radarrPeers,
 					},
 				);
-				if (block) {
-					blocks.set(targetKey, block);
-					context.plans.set(targetKey, { kind: "blocked", reason: block });
+				if (verification.block) {
+					blocks.set(targetKey, verification.block);
+					context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 				} else {
 					context.verifiedRadarrFiles.set(targetKey, targetFile);
 					context.plans.set(targetKey, {
 						kind: "verified_radarr",
 						target: targetIdentity,
 						file: targetFile,
+						peers: radarrPeers.map((peer) => peer.identity),
+						ownership: verification.ownership,
+						targetDeleteNotifications: radarrTargetDeleteNotificationWitnesses(
+							plexNotifications,
+							movie,
+						),
 					});
 				}
 				continue;
@@ -1458,7 +1944,7 @@ export async function findSharedPlexDeleteBlocks(
 				context.plans.set(targetKey, { kind: "blocked", reason });
 				continue;
 			}
-			const block = await verifyPlexMediaState(
+			const verification = await verifyPlexMediaState(
 				deps,
 				context,
 				plexOwnerChecks,
@@ -1473,9 +1959,9 @@ export async function findSharedPlexDeleteBlocks(
 					files: verifiedFiles.episodeFiles.map(comparableFile),
 				},
 			);
-			if (block) {
-				blocks.set(targetKey, block);
-				context.plans.set(targetKey, { kind: "blocked", reason: block });
+			if (verification.block) {
+				blocks.set(targetKey, verification.block);
+				context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 			} else {
 				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
 				context.plans.set(targetKey, {
@@ -1504,4 +1990,128 @@ export async function findSharedPlexDeleteBlocks(
 	}
 
 	return blocks;
+}
+
+/**
+ * Revalidate the retained side of a verified multi-Radarr ownership proof after
+ * the selected target file is gone. This is intentionally independent of the
+ * target Plex part so it can run immediately before deleting the now-fileless
+ * Radarr record and triggering its final notification.
+ */
+export async function assertVerifiedRadarrPeerOwnershipRetained(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	targetArrItemId: number,
+	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
+): Promise<void> {
+	const [arrInstances, plexInstances] = await Promise.all([
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["RADARR", "SONARR"] } },
+		}),
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX" },
+		}),
+	]);
+	const peerInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "RADARR" &&
+			createArrServiceFingerprint(instance) !== plan.target.serviceFingerprint,
+	);
+	const targetInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "RADARR" &&
+			createArrServiceFingerprint(instance) === plan.target.serviceFingerprint,
+	);
+	const peerIds = new Set(plan.peers.map((peer) => peer.instanceId));
+	if (
+		targetInstances.length !== 1 ||
+		peerInstances.length !== peerIds.size ||
+		peerInstances.some((instance) => !peerIds.has(instance.id))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+	const targetClient = deps.arrClientFactory.create(targetInstances[0]!) as InstanceType<
+		typeof RadarrClient
+	>;
+	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
+	const currentTargetMovie = await targetClient.movie.getById(targetArrItemId);
+	const currentTargetDeleteNotifications = radarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		currentTargetMovie,
+	);
+	if (
+		JSON.stringify(currentTargetDeleteNotifications) !==
+		JSON.stringify(plan.targetDeleteNotifications)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+
+	const livePeers = new Map<string, NonNullable<PlexVerificationInput["radarrPeers"]>[number]>();
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof RadarrClient>;
+		const movies = (await client.movie.getAll({ tmdbId: peer.externalId })).filter(
+			(movie) => movie.tmdbId === peer.externalId,
+		);
+		if (peer.arrItemId === null) {
+			if (movies.length !== 0) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			continue;
+		}
+		const movie = movies[0];
+		if (movies.length !== 1 || !movie || movie.id !== peer.arrItemId || peer.mediaPath === null) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		const target: VerifiedArrTargetIdentity = {
+			serviceFingerprint: peer.serviceFingerprint,
+			externalId: peer.externalId,
+			mediaPath: peer.mediaPath,
+		};
+		if (peer.file) {
+			await assertVerifiedRadarrFileUnchanged(client, peer.arrItemId, target, peer.file);
+		} else {
+			await assertVerifiedRadarrEmptyUnchanged(client, peer.arrItemId, target);
+		}
+		livePeers.set(peer.instanceId, {
+			identity: peer,
+			movieTags: movie.tags ?? [],
+			notifications: await client.notification.getAll(),
+		});
+	}
+
+	const context = createSharedPlexSafetyContext();
+	const ownerChecks = new Map<string, Promise<void>>();
+	for (const ownership of plan.ownership) {
+		const matchingPlexInstances = plexInstances.filter(
+			(instance) => normalizedServerUrl(instance.baseUrl) === ownership.plexServerUrl,
+		);
+		if (matchingPlexInstances.length === 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		for (const plexInstance of matchingPlexInstances) {
+			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
+			const mediaItems = await plex.getMovieMediaPartsByTmdbId(plan.target.externalId);
+			for (const expected of ownership.retained) {
+				const peer = livePeers.get(expected.instanceId);
+				if (!peer) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+				const match = matchingPeerPlexPart(peer, mediaItems, ownership.plexServerUrl);
+				if (
+					!match ||
+					match.item.ratingKey !== expected.ratingKey ||
+					match.part.size !== expected.size ||
+					!pathsEqual(normalizeMediaPath(match.part.file), expected.fullPath) ||
+					JSON.stringify(match.mapping) !== JSON.stringify(expected.mapping)
+				) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+			}
+		}
+	}
+	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
 }


### PR DESCRIPTION
﻿## Summary

- Allow removal of one Radarr variant from a merged Plex movie only when every retained Plex part is proven to belong to another configured Radarr instance.
- Snapshot every Radarr peer, exact ARR/Plex file identity, path mapping, and the target movie-delete notification configuration.
- Revalidate the full ownership plan before file deletion and revalidate retained ownership, target notifications, and target filelessness before deleting the Radarr record.
- Keep peer Radarr instances read-only and leave Sonarr's fail-closed behavior unchanged.

## Validation

- Focused Radarr and Sonarr safety suites: 167 passed
- Full API suite: 2,477 passed, 41 expected skipped
- API typecheck
- Repository lint
- Production build
- Biome formatting/check and `git diff --check`
- Independent data-safety review: clean
- Independent regression review: clean

Refs #616
