### PR TITLE
fix(cleanup): verify shared Sonarr Plex ownership

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { PlexSeriesNotFoundError } from "../../plex/plex-client.js";
 import {
 	executeApprovedItems,
 	executeDirectRemoval,
@@ -13,6 +14,7 @@ import {
 	createSharedPlexSafetyContext,
 	findSharedPlexDeleteBlocks,
 	serializeExecutableSafetyPlan,
+	type VerifiedSonarrTargetDeleteNotification,
 } from "../shared-plex-safety.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
@@ -285,6 +287,7 @@ function addSonarrPeer(
 	options: {
 		episodeFiles?: Array<{ id: number; path: string; relativePath?: string; size: number }>;
 		seriesPath?: string;
+		tvdbId?: number | null;
 		notification?: Record<string, unknown>;
 	} = {},
 ) {
@@ -309,6 +312,7 @@ function addSonarrPeer(
 		...fixture.series,
 		id: 202,
 		path: seriesPath,
+		...(options.tvdbId === null ? { tvdbId: undefined } : { tvdbId: options.tvdbId ?? 123 }),
 	};
 	const peerNotification = options.notification ?? fixture.notification;
 	const peerClient = {
@@ -476,6 +480,7 @@ describe("shared Plex deletion safety for Sonarr", () => {
 			],
 		});
 		expect(peer.peerClient.episodeFile.getBySeries).not.toHaveBeenCalled();
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
 	});
 
 	it("applies the retained Sonarr peer's own Plex path mapping", async () => {
@@ -579,6 +584,301 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		);
 	});
 
+	it.each([
+		["a different TVDB ID", 999],
+		["no TVDB ID", null],
+	])("blocks a peer that tracks the target file under %s", async (_label, tvdbId) => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId,
+			seriesPath: fixture.series.path,
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("allows an alternate-TVDB peer whose physical series path is unrelated", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, { tvdbId: 999 });
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+	});
+
+	it("bounds concurrent episode-file reads while checking every untracked peer series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, { tvdbId: 998 });
+		const allSeries = Array.from({ length: 12 }, (_, index) => ({
+			...peer.peerSeries,
+			id: 202 + index,
+			tvdbId: 998 + index,
+			path: `/tv-alt/Series ${index + 1}`,
+		}));
+		peer.peerClient.series.getAll.mockResolvedValue(allSeries);
+		let activeReads = 0;
+		let maximumActiveReads = 0;
+		peer.peerClient.episodeFile.getBySeries.mockImplementation(async (seriesId) => {
+			activeReads += 1;
+			maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			activeReads -= 1;
+			return [
+				{
+					id: 4_000 + seriesId,
+					seriesId,
+					path: `/tv-alt/Series ${seriesId - 201}/Season 01/Episode.mkv`,
+					relativePath: "Season 01/Episode.mkv",
+					size: 1_000 + seriesId,
+				},
+			];
+		});
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalledTimes(allSeries.length * 2);
+		expect(maximumActiveReads).toBeGreaterThan(1);
+		expect(maximumActiveReads).toBeLessThanOrEqual(8);
+	});
+
+	it("reuses one stable peer inventory across a batch of target series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, { tvdbId: 998 });
+		const secondTarget = { ...target, arrItemId: 202 };
+
+		await expect(
+			findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target, secondTarget]),
+		).resolves.toEqual(new Map());
+
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalledTimes(2);
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+	});
+
+	it("blocks an alternate-TVDB peer through its own Plex path mapping", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: "/tv-alt/Example Series",
+			episodeFiles: [
+				{
+					id: 4001,
+					path: "/tv-alt/Example Series/Season 01/Example.S01E01.2160p.mkv",
+					relativePath: "Season 01/Example.S01E01.2160p.mkv",
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+			notification: {
+				...fixture.notification,
+				fields: notificationFields({
+					mapFrom: "/tv-alt",
+					mapTo: "/tv-4k",
+				}),
+			},
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("fails closed when an alternate-TVDB peer has files but no target-Plex correlation", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			notification: {
+				...fixture.notification,
+				fields: [
+					{ name: "host", value: "different-plex.internal" },
+					{ name: "port", value: 32400 },
+					{ name: "useSsl", value: false },
+					{ name: "urlBase", value: "" },
+					{ name: "updateLibrary", value: true },
+				],
+			},
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("blocks an alternate-TVDB peer that claims the target path with a stale size", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: fixture.series.path,
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size! + 1,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("checks alternate-TVDB episode files even when the current series root is unrelated", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: "/tv-new/Example Series",
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("refetches the peer catalog after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll
+			.mockResolvedValueOnce([])
+			.mockResolvedValue([{ ...peer.peerSeries, tvdbId: 999, path: fixture.series.path }]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				id: 4001,
+				seriesId: peer.peerSeries.id,
+				path: fixture.episodeFiles[0]!.path!,
+				relativePath: fixture.episodeFiles[0]!.relativePath!,
+				size: fixture.episodeFiles[0]!.size!,
+			},
+		]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(fixture.getSeriesEpisodeMediaPartsByTvdbId).toHaveBeenCalledWith(123);
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("revalidates a tracked peer's path mapping after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, {
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!.replace("/tv-4k", "/tv-hd"),
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: 1_001,
+				},
+			],
+		});
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		peer.peerClient.notification.getAll
+			.mockResolvedValueOnce([fixture.notification])
+			.mockResolvedValue([
+				{
+					...fixture.notification,
+					fields: notificationFields({
+						mapFrom: "/tv-hd",
+						mapTo: "/tv-4k",
+					}),
+				},
+			]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("revalidates the target delete notification after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		fixture.targetClient.notification.getAll
+			.mockResolvedValueOnce([fixture.notification])
+			.mockResolvedValue([
+				{
+					...fixture.notification,
+					onEpisodeFileDelete: false,
+				},
+			]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(fixture.getSeriesEpisodeMediaPartsByTvdbId).toHaveBeenCalledWith(123);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"could not verify the live Sonarr series and Plex media state",
+		);
+	});
+
+	it("revalidates the target delete notification after the terminal peer scan", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		peer.peerClient.series.getAll
+			.mockResolvedValueOnce([peer.peerSeries])
+			.mockImplementation(async () => {
+				fixture.targetClient.notification.getAll.mockResolvedValue([
+					{
+						...fixture.notification,
+						onEpisodeFileDelete: false,
+					},
+				]);
+				return [peer.peerSeries];
+			});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"could not verify the live Sonarr series and Plex media state",
+		);
+	});
+
 	it("revalidates retained peer files after the target episode files are gone", async () => {
 		const fixture = makeSonarrDeps();
 		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
@@ -600,6 +900,96 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		await expect(
 			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
 		).resolves.toBeUndefined();
+	});
+
+	it("accepts a vanished Plex show after deletion when no peer parts were retained", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan.ownership).toEqual([expect.objectContaining({ retained: [] })]);
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockRejectedValue(new PlexSeriesNotFoundError(123));
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).resolves.toBeUndefined();
+	});
+
+	it("accepts a legacy series-only notification snapshot after target files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan.targetDeleteNotifications).toEqual([
+			expect.objectContaining({
+				onSeriesDelete: false,
+				onEpisodeFileDelete: true,
+			}),
+		]);
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, {
+				...plan,
+				targetDeleteNotifications: [],
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks a new alternate-TVDB peer claim after target files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		peer.peerClient.series.getAll.mockResolvedValue([
+			{ ...peer.peerSeries, tvdbId: 999, path: fixture.series.path },
+		]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				id: 4001,
+				seriesId: peer.peerSeries.id,
+				path: fixture.episodeFiles[0]!.path!,
+				relativePath: fixture.episodeFiles[0]!.relativePath!,
+				size: fixture.episodeFiles[0]!.size!,
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("another configured Sonarr instance");
+	});
+
+	it("rejects a vanished Plex show when peer parts were retained", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockRejectedValue(new PlexSeriesNotFoundError(123));
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("no series item for TVDB 123");
 	});
 
 	it("blocks record deletion when a retained peer episode file changes", async () => {
@@ -628,7 +1018,7 @@ describe("shared Plex deletion safety for Sonarr", () => {
 
 		await expect(
 			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
-		).rejects.toThrow("Sonarr episode files changed");
+		).rejects.toThrow("another configured Sonarr instance");
 	});
 
 	it("blocks record deletion when Plex gains an unowned part after file deletion", async () => {
@@ -667,7 +1057,7 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		).rejects.toThrow("another configured Sonarr instance");
 	});
 
-	it("loads Sonarr notifications once per instance across multiple safety targets", async () => {
+	it("caches initial Sonarr notifications and revalidates each target after Plex", async () => {
 		const { deps, targetClient } = makeSonarrDeps();
 		const context = createSharedPlexSafetyContext();
 
@@ -678,8 +1068,8 @@ describe("shared Plex deletion safety for Sonarr", () => {
 			context,
 		);
 
-		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
-		expect(targetClient.series.getById).toHaveBeenCalledTimes(2);
+		expect(targetClient.notification.getAll).toHaveBeenCalledTimes(3);
+		expect(targetClient.series.getById).toHaveBeenCalledTimes(4);
 	});
 
 	it("refetches Sonarr notifications across separate safety checks", async () => {
@@ -1003,6 +1393,14 @@ describe("verified Sonarr mutation handoff", () => {
 				size: 2_002,
 			},
 		],
+		targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[] = [
+			{
+				plexServerUrl: "http://plex.internal:32400",
+				onSeriesDelete: false,
+				onEpisodeFileDelete: true,
+				mapping: null,
+			},
+		],
 	) {
 		return {
 			id: "approval-1",
@@ -1036,7 +1434,7 @@ describe("verified Sonarr mutation handoff", () => {
 				},
 				peers: [],
 				ownership: [],
-				targetDeleteNotifications: [],
+				targetDeleteNotifications,
 			}),
 		};
 	}
@@ -1136,7 +1534,9 @@ describe("verified Sonarr mutation handoff", () => {
 		const { deps, targetClient, episodeFiles, bulkDelete, deleteSeries } = makeSonarrDeps({
 			notificationKind: "none",
 		});
-		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approval("delete", undefined, []),
+		] as never);
 		targetClient.episodeFile.getBySeries
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
@@ -1240,10 +1640,8 @@ describe("verified Sonarr mutation handoff", () => {
 			safetySnapshot: serializeExecutableSafetyPlan(plan),
 		} as unknown as Record<string, unknown>;
 		configureApprovalStore(fixture.deps, storedApproval);
-		let peerFileReadCount = 0;
 		peer.peerClient.episodeFile.getBySeries.mockImplementation(async () => {
-			peerFileReadCount++;
-			return peerFileReadCount < 4
+			return fixture.bulkDelete.mock.calls.length === 0
 				? peer.episodeFiles
 				: [{ ...peer.episodeFiles[0]!, size: peer.episodeFiles[0]!.size + 1 }];
 		});
@@ -1847,7 +2245,7 @@ describe("verified Sonarr mutation handoff", () => {
 			});
 			const peer = addSonarrPeer(fixture);
 			vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-				approval(action, []),
+				approval(action, [], []),
 			] as never);
 
 			await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -7,6 +7,7 @@ import {
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
 } from "../cleanup-executor.js";
 import {
+	assertVerifiedSonarrPeerOwnershipRetained,
 	cleanupDeleteTargetKey,
 	createArrServiceFingerprint,
 	createSharedPlexSafetyContext,
@@ -256,8 +257,10 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 	return {
 		deps,
 		targetInstance,
+		plexInstance,
 		targetClient,
 		series,
+		notification,
 		episodeFiles,
 		bulkDelete,
 		deleteSeries,
@@ -276,6 +279,61 @@ const target = {
 	itemType: "series",
 	action: "delete",
 };
+
+function addSonarrPeer(
+	fixture: ReturnType<typeof makeSonarrDeps>,
+	options: {
+		episodeFiles?: Array<{ id: number; path: string; relativePath?: string; size: number }>;
+		seriesPath?: string;
+		notification?: Record<string, unknown>;
+	} = {},
+) {
+	const seriesPath = options.seriesPath ?? "/tv-hd/Example Series";
+	const episodeFiles = options.episodeFiles ?? [
+		{
+			id: 4003,
+			path: `${seriesPath}/Season 01/Example.S01E03.1080p.mkv`,
+			relativePath: "Season 01/Example.S01E03.1080p.mkv",
+			size: 1_003,
+		},
+	];
+	const peerInstance = {
+		...fixture.targetInstance,
+		id: "sonarr-hd",
+		label: "HD Sonarr",
+		baseUrl: "http://sonarr-hd.internal:8989",
+		encryptedApiKey: "encrypted-sonarr-hd-key",
+		encryptionIv: "sonarr-hd-iv",
+	};
+	const peerSeries = {
+		...fixture.series,
+		id: 202,
+		path: seriesPath,
+	};
+	const peerNotification = options.notification ?? fixture.notification;
+	const peerClient = {
+		series: {
+			getAll: vi.fn().mockResolvedValue([peerSeries]),
+			getById: vi.fn().mockResolvedValue(peerSeries),
+		},
+		episodeFile: {
+			getBySeries: vi.fn().mockResolvedValue(episodeFiles),
+		},
+		notification: {
+			getAll: vi.fn().mockResolvedValue([peerNotification]),
+		},
+	};
+	vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+		(args) =>
+			(args?.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance])
+				: Promise.resolve([fixture.targetInstance, peerInstance])) as never,
+	);
+	vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+		(instance) => (instance.id === peerInstance.id ? peerClient : fixture.targetClient) as never,
+	);
+	return { peerInstance, peerSeries, peerClient, episodeFiles };
+}
 
 describe("shared Plex deletion safety for Sonarr", () => {
 	it("blocks at scale when another Sonarr may mount the same storage under a different path", async () => {
@@ -313,7 +371,7 @@ describe("shared Plex deletion safety for Sonarr", () => {
 				service: { in: ["RADARR", "SONARR"] },
 			},
 		});
-		expect(targetClient.notification.getAll).not.toHaveBeenCalled();
+		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
 	});
 
 	it("verifies the complete exact episode-file set for a single-source Plex show", async () => {
@@ -326,6 +384,287 @@ describe("shared Plex deletion safety for Sonarr", () => {
 			kind: "verified_sonarr",
 			files: { episodeFiles: [{ episodeFileId: 3001 }, { episodeFileId: 3002 }] },
 		});
+	});
+
+	it("allows a shared Plex show when every retained part has an exact peer Sonarr file", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peerFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			peers: [
+				{
+					instanceId: "sonarr-hd",
+					arrItemId: 202,
+					files: { episodeFiles: [{ episodeFileId: 4003 }] },
+				},
+			],
+			ownership: [
+				{
+					target: expect.arrayContaining([
+						expect.objectContaining({ ratingKey: "show-123", size: 2_001 }),
+						expect.objectContaining({ ratingKey: "show-123", size: 2_002 }),
+					]),
+					retained: [
+						expect.objectContaining({
+							instanceId: "sonarr-hd",
+							ratingKey: "show-123",
+							size: 1_003,
+						}),
+					],
+				},
+			],
+		});
+	});
+
+	it("allows separate Plex show items when each one maps completely to a Sonarr instance", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-4k",
+				episodes: fixture.episodeFiles.map((file, index) => ({
+					ratingKey: `target-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+			{
+				ratingKey: "show-hd",
+				episodes: peerFiles.map((file, index) => ({
+					ratingKey: `peer-${index + 1}`,
+					parts: [{ file: file.path, size: file.size }],
+				})),
+			},
+		]);
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+	});
+
+	it("snapshots a configured Sonarr peer that does not contain the TVDB series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			peers: [
+				{
+					instanceId: "sonarr-hd",
+					arrItemId: null,
+					mediaPath: null,
+					files: null,
+				},
+			],
+		});
+		expect(peer.peerClient.episodeFile.getBySeries).not.toHaveBeenCalled();
+	});
+
+	it("applies the retained Sonarr peer's own Plex path mapping", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, {
+			notification: {
+				...fixture.notification,
+				fields: notificationFields({
+					mapFrom: "/tv-hd",
+					mapTo: "/media/tv-hd",
+				}),
+			},
+		});
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [
+					...fixture.episodeFiles.map((file, index) => ({
+						ratingKey: `target-${index + 1}`,
+						parts: [{ file: file.path!, size: file.size! }],
+					})),
+					{
+						ratingKey: "peer-1",
+						parts: [
+							{
+								file: peer.episodeFiles[0]!.path.replace("/tv-hd", "/media/tv-hd"),
+								size: peer.episodeFiles[0]!.size,
+							},
+						],
+					},
+				],
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			ownership: [
+				{
+					retained: [
+						expect.objectContaining({
+							mapping: {
+								from: expect.objectContaining({ value: "/tv-hd" }),
+								to: expect.objectContaining({ value: "/media/tv-hd" }),
+							},
+						}),
+					],
+				},
+			],
+		});
+	});
+
+	it("blocks a shared Plex show when any retained part lacks a peer Sonarr file", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [
+					...fixture.episodeFiles.map((file, index) => ({
+						ratingKey: `target-${index + 1}`,
+						parts: [{ file: file.path!, size: file.size! }],
+					})),
+					{
+						ratingKey: "peer-1",
+						parts: [{ file: peerFiles[0]!.path, size: peerFiles[0]!.size }],
+					},
+					{
+						ratingKey: "unowned-1",
+						parts: [{ file: "/tv-other/Example.S01E04.mkv", size: 1_004 }],
+					},
+				],
+			},
+		]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain("Plex has multiple files merged");
+	});
+
+	it("blocks when target and peer Sonarr instances claim the same Plex part", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("revalidates retained peer files after the target episode files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peerFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks record deletion when a retained peer episode file changes", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				...peer.episodeFiles[0]!,
+				size: peer.episodeFiles[0]!.size + 1,
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("Sonarr episode files changed");
+	});
+
+	it("blocks record deletion when Plex gains an unowned part after file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		const initialPlexSeries = [
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		];
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue(initialPlexSeries);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				...initialPlexSeries[0]!,
+				episodes: [
+					...initialPlexSeries[0]!.episodes,
+					{
+						ratingKey: "episode-new",
+						parts: [{ file: "/tv-other/Example.S01E04.mkv", size: 1_004 }],
+					},
+				],
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("another configured Sonarr instance");
 	});
 
 	it("loads Sonarr notifications once per instance across multiple safety targets", async () => {
@@ -695,6 +1034,9 @@ describe("verified Sonarr mutation handoff", () => {
 						size: file.size!,
 					})),
 				},
+				peers: [],
+				ownership: [],
+				targetDeleteNotifications: [],
 			}),
 		};
 	}
@@ -840,6 +1182,78 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(episodeFileCacheDeleteMany).toHaveBeenCalledWith({
 			where: { instanceId: "sonarr-4k", arrSeriesId: 201 },
 		});
+	});
+
+	it("deletes only the target Sonarr files after revalidating shared Plex ownership", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalled();
+		expect(fixture.deleteSeries).toHaveBeenCalledWith(201, {
+			deleteFiles: false,
+			addImportListExclusion: false,
+		});
+	});
+
+	it("retains the series when peer ownership changes after target file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		let peerFileReadCount = 0;
+		peer.peerClient.episodeFile.getBySeries.mockImplementation(async () => {
+			peerFileReadCount++;
+			return peerFileReadCount < 4
+				? peer.episodeFiles
+				: [{ ...peer.episodeFiles[0]!, size: peer.episodeFiles[0]!.size + 1 }];
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+		expect(storedApproval).toMatchObject({ status: "pending" });
 	});
 
 	it("blocks when the Sonarr file set changes after Plex verification", async () => {
@@ -1060,6 +1474,55 @@ describe("verified Sonarr mutation handoff", () => {
 		});
 	});
 
+	it("retries a shared Sonarr series-delete notification after target files were removed", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: fixture.episodeFiles.map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		fixture.deleteSeries
+			.mockRejectedValueOnce(new Error("series delete unavailable"))
+			.mockRejectedValueOnce(new Error("series delete unavailable"));
+
+		const firstResult = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(firstResult).toMatchObject({ removed: 0, failed: 1 });
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [expect.objectContaining({ instanceId: "sonarr-hd", arrItemId: null })],
+			ownership: [expect.objectContaining({ retained: [] })],
+		});
+
+		storedApproval.status = "approved";
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
+		expect(fixture.deleteSeries).toHaveBeenCalledTimes(3);
+	});
+
 	it("reconciles an interrupted approved Sonarr mutation to the unchanged file remainder", async () => {
 		const remainingFile = {
 			id: 3002,
@@ -1090,6 +1553,52 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(approvalUpdate.mock.invocationCallOrder[0]).toBeLessThan(
 			bulkDelete.mock.invocationCallOrder[0]!,
 		);
+	});
+
+	it("recovers a shared Sonarr crash after files were deleted but before the snapshot changed", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.bulkDelete.mockClear();
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+			lastExecutionError: INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).toHaveBeenCalledOnce();
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			ownership: [
+				expect.objectContaining({
+					retained: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+				}),
+			],
+		});
 	});
 
 	it("reconciles an interrupted Sonarr file-delete retry when no episode files remain", async () => {
@@ -1217,8 +1726,22 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(storedApproval).toMatchObject({ status: "expired", executionToken: null });
 	});
 
-	it("durably retries a direct Sonarr record deletion after exact file removal", async () => {
-		const { deps, episodeFiles, bulkDelete, deleteSeries } = makeSonarrDeps();
+	it("durably retries direct shared-Sonarr record deletion after exact file removal", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const { deps, episodeFiles, bulkDelete, deleteSeries } = fixture;
 		const retries = configureRetryStore(deps);
 		deleteSeries
 			.mockRejectedValueOnce(new Error("series delete unavailable"))
@@ -1270,7 +1793,17 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(retries).toHaveLength(1);
 		expect(retries[0]).toMatchObject({
 			status: "executed",
-			safetySnapshot: approval("delete", []).safetySnapshot,
+			safetySnapshot: expect.any(String),
+		});
+		expect(JSON.parse(retries[0]!.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+			ownership: [
+				expect.objectContaining({
+					retained: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+				}),
+			],
 		});
 		expect(retryResult).toMatchObject({
 			status: "completed",
@@ -1303,6 +1836,30 @@ describe("verified Sonarr mutation handoff", () => {
 			addImportListExclusion: false,
 		});
 	});
+
+	it.each(["delete", "delete_files"] as const)(
+		"allows %s for a fileless no-notification series when a sibling Sonarr exists",
+		async (action) => {
+			const fixture = makeSonarrDeps({
+				action,
+				notificationKind: "none",
+				episodeFiles: [],
+			});
+			const peer = addSonarrPeer(fixture);
+			vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+				approval(action, []),
+			] as never);
+
+			await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+				removed: action === "delete" ? 1 : 0,
+				failed: 0,
+				errors: [],
+			});
+			expect(fixture.bulkDelete).not.toHaveBeenCalled();
+			expect(fixture.deleteSeries).toHaveBeenCalledTimes(action === "delete" ? 1 : 0);
+			expect(peer.peerClient.series.getAll).not.toHaveBeenCalled();
+		},
+	);
 
 	it("accepts a lost Sonarr record-delete response after a not-found readback", async () => {
 		const { deps, targetClient, episodeFiles, deleteSeries, setLiveSeriesExists } =

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -32,6 +32,7 @@ import {
 	assertVerifiedRadarrFileUnchanged,
 	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
+	assertVerifiedSonarrPeerInventoryUnchanged,
 	assertVerifiedSonarrPeerOwnershipRetained,
 	buildCacheTargetSafetyPlan,
 	buildRadarrCacheSafetyPlan,
@@ -694,29 +695,13 @@ async function loadCurrentMutationInstance(
 			const peerClient = deps.arrClientFactory.create(peerInstance) as InstanceType<
 				typeof SonarrClient
 			>;
-			const peerSeries = (await peerClient.series.getAll({ tvdbId: peer.externalId })).filter(
-				(series) => series.tvdbId === peer.externalId,
+			const peerSeriesCatalog = await peerClient.series.getAll();
+			await assertVerifiedSonarrPeerInventoryUnchanged(
+				peerClient,
+				peer,
+				executablePlan.ownership,
+				peerSeriesCatalog,
 			);
-			if (peer.arrItemId === null) {
-				if (peerSeries.length !== 0) {
-					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
-				}
-				continue;
-			}
-			if (
-				peerSeries.length !== 1 ||
-				peerSeries[0]?.id !== peer.arrItemId ||
-				peer.mediaPath === null ||
-				peer.files === null
-			) {
-				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
-			}
-			const peerTarget = {
-				serviceFingerprint: peer.serviceFingerprint,
-				externalId: peer.externalId,
-				mediaPath: peer.mediaPath,
-			};
-			await assertVerifiedSonarrFilesUnchanged(peerClient, peer.arrItemId, peerTarget, peer.files);
 		}
 	}
 	return instance;

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -32,6 +32,7 @@ import {
 	assertVerifiedRadarrFileUnchanged,
 	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
+	assertVerifiedSonarrPeerOwnershipRetained,
 	buildCacheTargetSafetyPlan,
 	buildRadarrCacheSafetyPlan,
 	buildSonarrCacheSafetyPlan,
@@ -359,6 +360,7 @@ async function updateClaimedCleanupApproval(
 function buildPostPartialRetrySnapshot(
 	safetyPlan: SharedMediaSafetyPlan | undefined,
 	error: ArrDeletePartialError,
+	action: RuleAction,
 ): string | undefined {
 	if (error.hasRemainingFiles || error.deletedFileIds.length === 0) return undefined;
 
@@ -393,6 +395,9 @@ function buildPostPartialRetrySnapshot(
 			seriesPath: safetyPlan.files.seriesPath,
 			episodeFiles: [],
 		},
+		peers: safetyPlan.peers,
+		ownership: action === "delete" ? safetyPlan.ownership : [],
+		targetDeleteNotifications: safetyPlan.targetDeleteNotifications,
 	});
 }
 
@@ -436,6 +441,25 @@ function isVerifiedFileRemainder(
 	return livePlan.files.episodeFiles.every(
 		(file) => approvedFiles.get(file.episodeFileId) === JSON.stringify(file),
 	);
+}
+
+function hasVerifiedSonarrOwnershipProof(
+	action: string,
+	plan: ExecutableSharedMediaSafetyPlan | null,
+): plan is Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }> {
+	return (
+		action === "delete" &&
+		plan?.kind === "verified_sonarr" &&
+		plan.peers.length > 0 &&
+		plan.ownership.length > 0
+	);
+}
+
+function isVerifiedSonarrRecordOnlyRetry(
+	action: string,
+	plan: ExecutableSharedMediaSafetyPlan | null,
+): plan is Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }> {
+	return hasVerifiedSonarrOwnershipProof(action, plan) && plan.files.episodeFiles.length === 0;
 }
 
 const SHARED_PLEX_WARNING =
@@ -650,17 +674,55 @@ async function loadCurrentMutationInstance(
 		}
 	} else if (
 		executablePlan.kind === "verified_sonarr" &&
-		executablePlan.files.episodeFiles.length > 0 &&
-		instances.some(
-			(candidate) => candidate.id !== instance.id && candidate.service === instance.service,
-		)
+		(executablePlan.files.episodeFiles.length > 0 || executablePlan.peers.length > 0)
 	) {
-		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		const peerInstances = instances.filter(
+			(candidate) => candidate.id !== instance.id && candidate.service === "SONARR",
+		);
+		const peerIds = new Set(executablePlan.peers.map((peer) => peer.instanceId));
+		if (
+			peerInstances.length !== peerIds.size ||
+			peerInstances.some((peerInstance) => !peerIds.has(peerInstance.id))
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		for (const peer of executablePlan.peers) {
+			const peerInstance = peerInstances.find((candidate) => candidate.id === peer.instanceId);
+			if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+			const peerClient = deps.arrClientFactory.create(peerInstance) as InstanceType<
+				typeof SonarrClient
+			>;
+			const peerSeries = (await peerClient.series.getAll({ tvdbId: peer.externalId })).filter(
+				(series) => series.tvdbId === peer.externalId,
+			);
+			if (peer.arrItemId === null) {
+				if (peerSeries.length !== 0) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+				}
+				continue;
+			}
+			if (
+				peerSeries.length !== 1 ||
+				peerSeries[0]?.id !== peer.arrItemId ||
+				peer.mediaPath === null ||
+				peer.files === null
+			) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+			const peerTarget = {
+				serviceFingerprint: peer.serviceFingerprint,
+				externalId: peer.externalId,
+				mediaPath: peer.mediaPath,
+			};
+			await assertVerifiedSonarrFilesUnchanged(peerClient, peer.arrItemId, peerTarget, peer.files);
+		}
 	}
 	return instance;
 }
 
-function withRadarrPeerOwnershipRevalidation(
+function withSharedPlexOwnershipRevalidation(
 	deps: CleanupExecutorDeps,
 	userId: string,
 	target: CleanupDeleteTarget,
@@ -670,21 +732,35 @@ function withRadarrPeerOwnershipRevalidation(
 	let ownershipRevalidationCount = 0;
 	return async () => {
 		await assertMutationAuthority?.();
-		if (safetyPlan.kind !== "verified_radarr" || safetyPlan.peers.length === 0) {
+		if (
+			(safetyPlan.kind !== "verified_radarr" && safetyPlan.kind !== "verified_sonarr") ||
+			safetyPlan.peers.length === 0
+		) {
 			return;
 		}
 		if (ownershipRevalidationCount === 0) {
-			const context = createSharedPlexSafetyContext();
-			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
-			const targetKey = cleanupDeleteTargetKey(target);
-			const livePlan = asExecutableSafetyPlan(context.plans.get(targetKey));
-			if (blocks.has(targetKey) || !livePlan || !executableSafetyPlansEqual(safetyPlan, livePlan)) {
-				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
-					"Skipped for safety: the verified Radarr-to-Plex ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
-				);
+			if (isVerifiedSonarrRecordOnlyRetry(target.action ?? "delete", safetyPlan)) {
+				await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
+			} else {
+				const context = createSharedPlexSafetyContext();
+				const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+				const targetKey = cleanupDeleteTargetKey(target);
+				const livePlan = asExecutableSafetyPlan(context.plans.get(targetKey));
+				if (
+					blocks.has(targetKey) ||
+					!livePlan ||
+					!executableSafetyPlansEqual(safetyPlan, livePlan)
+				) {
+					const service = safetyPlan.kind === "verified_radarr" ? "Radarr" : "Sonarr";
+					throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+						`Skipped for safety: the verified ${service}-to-Plex ownership changed at the mutation boundary. Run cleanup again before deleting the file.`,
+					);
+				}
 			}
-		} else {
+		} else if (safetyPlan.kind === "verified_radarr") {
 			await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
+		} else {
+			await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
 		}
 		ownershipRevalidationCount++;
 		await assertMutationAuthority?.();
@@ -806,13 +882,21 @@ async function buildEvaluatedCacheSafetyPlan(
 		where: { instanceId: item.instanceId, arrSeriesId: item.arrItemId },
 		select: { arrEpisodeFileId: true, path: true, size: true },
 	});
-	return buildSonarrCacheSafetyPlan(
+	const cachePlan = buildSonarrCacheSafetyPlan(
 		seriesPath,
 		tvdbId,
 		item.hasFile,
 		episodeFiles,
 		livePlan.target,
 	);
+	return cachePlan?.kind === "verified_sonarr"
+		? {
+				...cachePlan,
+				peers: livePlan.peers,
+				ownership: livePlan.ownership,
+				targetDeleteNotifications: livePlan.targetDeleteNotifications,
+			}
+		: cachePlan;
 }
 
 async function blockPlansThatDifferFromEvaluatedCache(
@@ -1640,7 +1724,7 @@ async function executeQueuedCleanupItems(
 
 			let sharedPlexBlock: string | undefined;
 			let approvalIdentityChanged = false;
-			const approvedPlan = parseExecutableSafetyPlan(approval.safetySnapshot);
+			let approvedPlan = parseExecutableSafetyPlan(approval.safetySnapshot);
 			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
 			const recoveringInterruptedMutation =
 				options.claimStatus === "retry_pending" ||
@@ -1669,71 +1753,138 @@ async function executeQueuedCleanupItems(
 					);
 				}
 			}
-			if (!sharedPlexBlock && !retryTargetAlreadyAbsent) {
+			if (
+				!sharedPlexBlock &&
+				!retryTargetAlreadyAbsent &&
+				recoveringInterruptedMutation &&
+				hasVerifiedSonarrOwnershipProof(action, approvedPlan) &&
+				approvedPlan.files.episodeFiles.length > 0
+			) {
 				try {
-					const targetKey = cleanupDeleteTargetKey(approval);
-					const blocks = await findSharedPlexDeleteBlocks(
+					await assertVerifiedSonarrPeerOwnershipRetained(
 						deps,
 						userId,
-						[
-							{
-								instanceId: approval.instanceId,
-								arrItemId: approval.arrItemId,
-								itemType: approval.itemType,
-								action,
-							},
-						],
-						sharedPlexSafetyContext,
+						approval.arrItemId,
+						approvedPlan,
 					);
-					sharedPlexBlock = blocks.get(targetKey);
-					safetyPlan = sharedPlexSafetyContext.plans.get(targetKey);
+					const reconciledPlan: Extract<
+						ExecutableSharedMediaSafetyPlan,
+						{ kind: "verified_sonarr" }
+					> = {
+						...approvedPlan,
+						files: {
+							seriesPath: approvedPlan.files.seriesPath,
+							episodeFiles: [],
+						},
+					};
+					await updateClaimedCleanupApproval(
+						prisma,
+						userId,
+						approval.id,
+						options.executeStatus,
+						claimedExecutionToken,
+						{
+							safetySnapshot: serializeExecutableSafetyPlan(reconciledPlan),
+							lastExecutionError:
+								"Recovered a persisted Sonarr mutation after verifying that its target files were already removed.",
+						},
+					);
+					approvedPlan = reconciledPlan;
+					safetyPlan = reconciledPlan;
 				} catch (error) {
-					log.error(
+					log.info(
 						{ err: error, approvalId: approval.id },
-						"Approved cleanup item safety preflight failed closed",
+						"Interrupted Sonarr cleanup was not a verified record-only recovery",
 					);
-					sharedPlexBlock =
-						"Skipped for safety: arr-dashboard could not complete the live ARR and media-server preflight.";
 				}
-				if (!sharedPlexBlock && !safetyPlan) {
-					sharedPlexBlock =
-						"Skipped for safety: arr-dashboard did not produce an explicit ARR mutation safety plan.";
-				}
-				if (!sharedPlexBlock) {
-					const livePlan = asExecutableSafetyPlan(safetyPlan);
-					const exactPlanMatch =
-						approvedPlan && livePlan && executableSafetyPlansEqual(approvedPlan, livePlan);
-					const recoverableFileRemainder =
-						recoveringInterruptedMutation &&
-						(action === "delete" || action === "delete_files") &&
-						approvedPlan &&
-						livePlan &&
-						isVerifiedFileRemainder(approvedPlan, livePlan);
-					if (!exactPlanMatch && !recoverableFileRemainder) {
-						approvalIdentityChanged = true;
+			}
+			const sonarrRecordOnlyRetryPlan = isVerifiedSonarrRecordOnlyRetry(action, approvedPlan)
+				? approvedPlan
+				: null;
+			if (!sharedPlexBlock && !retryTargetAlreadyAbsent) {
+				if (sonarrRecordOnlyRetryPlan) {
+					try {
+						await assertVerifiedSonarrPeerOwnershipRetained(
+							deps,
+							userId,
+							approval.arrItemId,
+							sonarrRecordOnlyRetryPlan,
+						);
+						safetyPlan = sonarrRecordOnlyRetryPlan;
+					} catch (error) {
+						log.error(
+							{ err: error, approvalId: approval.id },
+							"Approved Sonarr record-only retry ownership revalidation failed closed",
+						);
 						sharedPlexBlock =
-							"Skipped for safety: the ARR target or file identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
-					} else if (recoverableFileRemainder && !exactPlanMatch) {
-						try {
-							await updateClaimedCleanupApproval(
-								prisma,
-								userId,
-								approval.id,
-								options.executeStatus,
-								claimedExecutionToken,
+							"Skipped for safety: the retained Sonarr-to-Plex ownership changed before the series record could be retried.";
+					}
+				} else {
+					try {
+						const targetKey = cleanupDeleteTargetKey(approval);
+						const blocks = await findSharedPlexDeleteBlocks(
+							deps,
+							userId,
+							[
 								{
-									safetySnapshot: serializeExecutableSafetyPlan(livePlan),
-									lastExecutionError:
-										"Recovered a persisted cleanup mutation after verifying the remaining ARR file set.",
+									instanceId: approval.instanceId,
+									arrItemId: approval.arrItemId,
+									itemType: approval.itemType,
+									action,
 								},
-							);
-						} catch (error) {
-							log.error(
-								{ err: error, approvalId: approval.id },
-								"Cleanup could not persist its reconciled crash-recovery snapshot",
-							);
+							],
+							sharedPlexSafetyContext,
+						);
+						sharedPlexBlock = blocks.get(targetKey);
+						safetyPlan = sharedPlexSafetyContext.plans.get(targetKey);
+					} catch (error) {
+						log.error(
+							{ err: error, approvalId: approval.id },
+							"Approved cleanup item safety preflight failed closed",
+						);
+						sharedPlexBlock =
+							"Skipped for safety: arr-dashboard could not complete the live ARR and media-server preflight.";
+					}
+					if (!sharedPlexBlock && !safetyPlan) {
+						sharedPlexBlock =
+							"Skipped for safety: arr-dashboard did not produce an explicit ARR mutation safety plan.";
+					}
+					if (!sharedPlexBlock) {
+						const livePlan = asExecutableSafetyPlan(safetyPlan);
+						const exactPlanMatch =
+							approvedPlan && livePlan && executableSafetyPlansEqual(approvedPlan, livePlan);
+						const recoverableFileRemainder =
+							recoveringInterruptedMutation &&
+							(action === "delete" || action === "delete_files") &&
+							approvedPlan &&
+							livePlan &&
+							isVerifiedFileRemainder(approvedPlan, livePlan);
+						if (!exactPlanMatch && !recoverableFileRemainder) {
+							approvalIdentityChanged = true;
 							sharedPlexBlock =
-								"Skipped for safety: arr-dashboard could not persist the verified crash-recovery state before continuing.";
+								"Skipped for safety: the ARR target or file identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
+						} else if (recoverableFileRemainder && !exactPlanMatch) {
+							try {
+								await updateClaimedCleanupApproval(
+									prisma,
+									userId,
+									approval.id,
+									options.executeStatus,
+									claimedExecutionToken,
+									{
+										safetySnapshot: serializeExecutableSafetyPlan(livePlan),
+										lastExecutionError:
+											"Recovered a persisted cleanup mutation after verifying the remaining ARR file set.",
+									},
+								);
+							} catch (error) {
+								log.error(
+									{ err: error, approvalId: approval.id },
+									"Cleanup could not persist its reconciled crash-recovery snapshot",
+								);
+								sharedPlexBlock =
+									"Skipped for safety: arr-dashboard could not persist the verified crash-recovery state before continuing.";
+							}
 						}
 					}
 				}
@@ -1801,7 +1952,7 @@ async function executeQueuedCleanupItems(
 					await options.assertExecutionAllowed?.();
 					mutationBudgetConsumedIds.add(approval.id);
 				};
-				const assertMutationAuthority = withRadarrPeerOwnershipRevalidation(
+				const assertMutationAuthority = withSharedPlexOwnershipRevalidation(
 					deps,
 					userId,
 					{
@@ -2003,7 +2154,7 @@ async function executeQueuedCleanupItems(
 				failed++;
 				const postPartialRetrySnapshot =
 					error instanceof ArrDeletePartialError
-						? buildPostPartialRetrySnapshot(safetyPlan, error)
+						? buildPostPartialRetrySnapshot(safetyPlan, error, action)
 						: undefined;
 				if (error instanceof ArrDeletePartialError && error.deletedFileIds.length > 0) {
 					confirmedPartialFileDeletionIds.add(approval.id);
@@ -3663,7 +3814,7 @@ export async function executeDirectRemoval(
 				instance.id,
 				safetyPlan!,
 			);
-			const assertMutationAuthority = withRadarrPeerOwnershipRevalidation(
+			const assertMutationAuthority = withSharedPlexOwnershipRevalidation(
 				deps,
 				userId,
 				{
@@ -3837,7 +3988,11 @@ export async function executeDirectRemoval(
 				partialArrDeletes++;
 				const deletedAnyVerifiedFiles = error.deletedFileIds.length > 0;
 				if (deletedAnyVerifiedFiles) filesDeleted++;
-				const postPartialRetrySnapshot = buildPostPartialRetrySnapshot(safetyPlan, error);
+				const postPartialRetrySnapshot = buildPostPartialRetrySnapshot(
+					safetyPlan,
+					error,
+					item.match.action,
+				);
 				let retryPersistenceSucceeded = true;
 				try {
 					await updateClaimedCleanupApproval(

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -15,6 +15,7 @@ import {
 	type PlexClient,
 	type PlexMovieMediaItem,
 	type PlexSeriesMediaItem,
+	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
 import type { ServiceInstance } from "../prisma.js";
 
@@ -112,6 +113,7 @@ export interface VerifiedSonarrPlexOwnership {
 
 export interface VerifiedSonarrTargetDeleteNotification {
 	plexServerUrl: string;
+	onSeriesDelete: boolean;
 	onEpisodeFileDelete: boolean;
 	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
 }
@@ -404,6 +406,8 @@ function canonicalSonarrTargetDeleteNotifications(
 		const mapping = notification.mapping as Record<string, unknown> | null | undefined;
 		return {
 			plexServerUrl: normalizedUrl,
+			onSeriesDelete:
+				notification.onSeriesDelete === undefined ? true : notification.onSeriesDelete === true,
 			onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
 			mapping:
 				mapping === null
@@ -1083,11 +1087,19 @@ function mappedArrPathForNotification(
 	notification: NotificationLike,
 	service: "RADARR" | "SONARR",
 ): NormalizedMediaPath {
+	return mappedMediaPathForNotification(target.fullPath, notification, service);
+}
+
+function mappedMediaPathForNotification(
+	fullPath: NormalizedMediaPath,
+	notification: NotificationLike,
+	service: "RADARR" | "SONARR",
+): NormalizedMediaPath {
 	const rawMapFrom = fieldValue(notification, "mapFrom");
 	const rawMapTo = fieldValue(notification, "mapTo");
 	const hasMapFrom = typeof rawMapFrom === "string" && rawMapFrom.trim() !== "";
 	const hasMapTo = typeof rawMapTo === "string" && rawMapTo.trim() !== "";
-	if (!hasMapFrom && !hasMapTo) return target.fullPath;
+	if (!hasMapFrom && !hasMapTo) return fullPath;
 	if (!hasMapFrom || !hasMapTo) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} Plex path mapping is incomplete`,
@@ -1096,21 +1108,22 @@ function mappedArrPathForNotification(
 
 	const mapFrom = normalizeMediaPath(rawMapFrom);
 	const mapTo = normalizeMediaPath(rawMapTo);
-	if (mapFrom.windows !== target.fullPath.windows) {
+	if (mapFrom.windows !== fullPath.windows) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} Plex source mapping uses a different path type`,
 		);
 	}
-	const caseInsensitive = target.fullPath.windows;
-	const targetPath = comparablePath(target.fullPath, caseInsensitive);
+	const caseInsensitive = fullPath.windows;
+	const targetPath = comparablePath(fullPath, caseInsensitive);
 	const sourceValue = mapFrom.value.replace(/\/+$/, "");
 	const sourcePrefix = comparablePath({ ...mapFrom, value: sourceValue }, caseInsensitive);
-	if (!targetPath.startsWith(`${sourcePrefix}/`)) {
+	if (targetPath !== sourcePrefix && !targetPath.startsWith(`${sourcePrefix}/`)) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} path is outside its Plex source mapping`,
 		);
 	}
-	const relativePath = target.fullPath.value.slice(sourceValue.length + 1);
+	if (targetPath === sourcePrefix) return mapTo;
+	const relativePath = fullPath.value.slice(sourceValue.length + 1);
 	return normalizeMediaPath(`${mapTo.value.replace(/\/+$/, "")}/${relativePath}`);
 }
 
@@ -1406,12 +1419,14 @@ function radarrTargetDeleteNotificationWitnesses(
 function sonarrTargetDeleteNotificationWitnesses(
 	notifications: SonarrNotification[],
 	series: Series,
+	action: string,
+	seriesDeleteOnly = false,
 ): VerifiedSonarrTargetDeleteNotification[] {
 	const witnesses = notifications
 		.filter(
 			(notification) =>
-				sonarrNotificationApplies(notification, series, "delete") &&
-				notification.onSeriesDelete === true,
+				sonarrNotificationApplies(notification, series, action) &&
+				(!seriesDeleteOnly || notification.onSeriesDelete === true),
 		)
 		.map((notification) => {
 			if (mediaServerNotificationKind(notification) !== "plex") {
@@ -1425,6 +1440,7 @@ function sonarrTargetDeleteNotificationWitnesses(
 			}
 			return {
 				plexServerUrl,
+				onSeriesDelete: notification.onSeriesDelete === true,
 				onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
 				mapping: notificationPathMapping(notification, "Sonarr target"),
 			};
@@ -1602,18 +1618,18 @@ function matchingPeerPlexPart(
 	return [...matches.values()][0]!;
 }
 
-function matchingSonarrPeerPlexParts(
-	peer: NonNullable<PlexVerificationInput["sonarrPeers"]>[number],
-	items: PlexSeriesMediaItem[],
+function mappedSonarrPeerFileCandidate(
+	files: MediaFileIdentity[],
+	seriesTags: number[],
+	notifications: SonarrNotification[],
 	notificationUrl: string,
-): Array<{
-	show: PlexSeriesMediaItem;
-	part: { file: string; size: number };
+): {
 	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
-}> {
-	if (!peer.identity.files) return [];
+	files: MediaFileIdentity[];
+	hasExplicitServerCorrelation: boolean;
+} {
 	const serverNotifications: SonarrNotification[] = [];
-	for (const notification of peer.notifications) {
+	for (const notification of notifications) {
 		if (mediaServerNotificationKind(notification) !== "plex") continue;
 		let peerUrl: string | null = null;
 		try {
@@ -1627,7 +1643,7 @@ function matchingSonarrPeerPlexParts(
 		(notification) =>
 			(notification as NotificationLike).enable !== false &&
 			notificationMutatesLibrary(notification) &&
-			notificationTagsApply(notification, peer.seriesTags),
+			notificationTagsApply(notification, seriesTags),
 	);
 	const unusableConfiguredMapping = serverNotifications.some((notification) => {
 		const rawMapFrom = fieldValue(notification, "mapFrom");
@@ -1649,30 +1665,50 @@ function matchingSonarrPeerPlexParts(
 			files: MediaFileIdentity[];
 		}
 	>();
-	const peerFiles = peer.identity.files.episodeFiles.map(comparableFile);
 	if (matchingNotifications.length === 0) {
-		pathCandidates.set(JSON.stringify([null, peerFiles.map((file) => file.fullPath)]), {
+		pathCandidates.set(JSON.stringify([null, files.map((file) => file.fullPath)]), {
 			mapping: null,
-			files: peerFiles,
+			files,
 		});
 	}
 	for (const notification of matchingNotifications) {
 		const mapping = notificationPathMapping(notification, "Sonarr peer");
-		const files = peerFiles.map((file) => ({
+		const mappedFiles = files.map((file) => ({
 			...file,
 			fullPath: mapping
 				? mappedArrPathForNotification(file, notification, "SONARR")
 				: file.fullPath,
 		}));
-		pathCandidates.set(JSON.stringify([mapping, files.map((file) => file.fullPath)]), {
+		pathCandidates.set(JSON.stringify([mapping, mappedFiles.map((file) => file.fullPath)]), {
 			mapping,
-			files,
+			files: mappedFiles,
 		});
 	}
 	if (pathCandidates.size !== 1) {
 		throw new FileMatchVerificationError("Sonarr peer Plex path mappings conflict");
 	}
-	const pathCandidate = [...pathCandidates.values()][0]!;
+	return {
+		...[...pathCandidates.values()][0]!,
+		hasExplicitServerCorrelation: matchingNotifications.length > 0,
+	};
+}
+
+function matchingSonarrPeerPlexParts(
+	peer: NonNullable<PlexVerificationInput["sonarrPeers"]>[number],
+	items: PlexSeriesMediaItem[],
+	notificationUrl: string,
+): Array<{
+	show: PlexSeriesMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}> {
+	if (!peer.identity.files) return [];
+	const pathCandidate = mappedSonarrPeerFileCandidate(
+		peer.identity.files.episodeFiles.map(comparableFile),
+		peer.seriesTags,
+		peer.notifications,
+		notificationUrl,
+	);
 
 	return pathCandidate.files.map((file) => {
 		const matches = new Map<
@@ -1697,6 +1733,268 @@ function matchingSonarrPeerPlexParts(
 		}
 		return { ...[...matches.values()][0]!, mapping: pathCandidate.mapping };
 	});
+}
+
+function assertVerifiedSonarrTrackedPeerMappingUnchanged(
+	peer: VerifiedSonarrPeerIdentity,
+	series: Series | null,
+	notifications: SonarrNotification[],
+	ownership: VerifiedSonarrPlexOwnership[],
+): void {
+	for (const witness of ownership) {
+		const expected = witness.retained
+			.filter((part) => part.instanceId === peer.instanceId)
+			.map((part) => ({
+				fullPath: part.fullPath,
+				size: part.size,
+				mapping: part.mapping,
+			}))
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		if (peer.files === null) {
+			if (expected.length !== 0) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+			continue;
+		}
+		if (!series) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const mappedCandidate = mappedSonarrPeerFileCandidate(
+			peer.files.episodeFiles.map(comparableFile),
+			series.tags ?? [],
+			notifications,
+			witness.plexServerUrl,
+		);
+		if (
+			mappedCandidate.files.some((file) =>
+				witness.target.some((part) => pathsEqual(file.fullPath, part.fullPath)),
+			)
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const current = mappedCandidate.files
+			.map((file) => ({
+				fullPath: file.fullPath,
+				size: file.size,
+				mapping: mappedCandidate.mapping,
+			}))
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		if (JSON.stringify(current) !== JSON.stringify(expected)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+	}
+}
+
+/**
+ * A TVDB lookup is not a complete ownership boundary: another Sonarr may have
+ * imported the same physical file under a different or missing external ID.
+ * Inspect every untracked peer series whose mapped root can contain a target
+ * Plex part and fail closed if one of its exact episode files matches.
+ */
+const SONARR_PEER_FILE_READ_CONCURRENCY = 8;
+
+interface StableSonarrPeerInventory {
+	seriesCatalog: Series[];
+	notifications: SonarrNotification[];
+	filesBySeries: Map<number, VerifiedSonarrEpisodeFileIdentity[]>;
+}
+
+function sonarrPeerSeriesCatalogWitness(seriesCatalog: Series[]): string {
+	return JSON.stringify(
+		seriesCatalog
+			.map((series) => ({
+				id: requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID"),
+				tvdbId: series.tvdbId ?? null,
+				path: normalizeMediaPath(series.path),
+				tags: [...(series.tags ?? [])].sort((left, right) => left - right),
+				episodeFileCount: series.statistics?.episodeFileCount ?? null,
+				sizeOnDisk: series.statistics?.sizeOnDisk ?? null,
+			}))
+			.sort((left, right) => left.id - right.id),
+	);
+}
+
+function sonarrPeerNotificationCatalogWitness(notifications: SonarrNotification[]): string {
+	return JSON.stringify(notifications.map((notification) => JSON.stringify(notification)).sort());
+}
+
+function sonarrPeerFileCatalogWitness(
+	filesBySeries: ReadonlyMap<number, VerifiedSonarrEpisodeFileIdentity[]>,
+): string {
+	return JSON.stringify(
+		[...filesBySeries]
+			.map(([seriesId, files]) => ({
+				seriesId,
+				files: files
+					.map((file) => [
+						file.episodeFileId,
+						file.fullPath.windows,
+						comparablePath(file.fullPath, file.fullPath.windows),
+						file.size,
+					])
+					.sort((left, right) => Number(left[0]) - Number(right[0])),
+			}))
+			.sort((left, right) => left.seriesId - right.seriesId),
+	);
+}
+
+async function readSonarrPeerFilesBySeries(
+	sonarr: InstanceType<typeof SonarrClient>,
+	seriesCatalog: Series[],
+): Promise<Map<number, VerifiedSonarrEpisodeFileIdentity[]>> {
+	const seriesById = new Map<number, Series>();
+	for (const series of seriesCatalog) {
+		const seriesId = requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID");
+		if (seriesById.has(seriesId)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		seriesById.set(seriesId, series);
+	}
+	const filesBySeries = new Map<number, VerifiedSonarrEpisodeFileIdentity[]>();
+	const allSeries = [...seriesById.entries()];
+	let nextSeriesIndex = 0;
+	await Promise.all(
+		Array.from(
+			{
+				length: Math.min(SONARR_PEER_FILE_READ_CONCURRENCY, allSeries.length),
+			},
+			async () => {
+				while (nextSeriesIndex < allSeries.length) {
+					const [seriesId, series] = allSeries[nextSeriesIndex++]!;
+					const files = (await sonarr.episodeFile.getBySeries(seriesId)).map((file) => {
+						if (
+							requiredPositiveSafeInteger(
+								file.seriesId ?? seriesId,
+								"Unverified Sonarr episode file series ID",
+							) !== seriesId
+						) {
+							throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+						}
+						return sonarrEpisodeFileIdentity(series, file);
+					});
+					filesBySeries.set(seriesId, files);
+				}
+			},
+		),
+	);
+	return filesBySeries;
+}
+
+async function readStableSonarrPeerInventory(
+	sonarr: InstanceType<typeof SonarrClient>,
+	initialSeriesCatalog?: Series[],
+	initialNotifications?: SonarrNotification[],
+): Promise<StableSonarrPeerInventory> {
+	const seriesCatalog = initialSeriesCatalog ?? (await sonarr.series.getAll());
+	const notifications = initialNotifications ?? (await sonarr.notification.getAll());
+	const firstFilesBySeries = await readSonarrPeerFilesBySeries(sonarr, seriesCatalog);
+	const finalFilesBySeries = await readSonarrPeerFilesBySeries(sonarr, seriesCatalog);
+	const [finalSeriesCatalog, finalNotifications] = await Promise.all([
+		sonarr.series.getAll(),
+		sonarr.notification.getAll(),
+	]);
+	if (
+		sonarrPeerSeriesCatalogWitness(finalSeriesCatalog) !==
+			sonarrPeerSeriesCatalogWitness(seriesCatalog) ||
+		sonarrPeerNotificationCatalogWitness(finalNotifications) !==
+			sonarrPeerNotificationCatalogWitness(notifications) ||
+		sonarrPeerFileCatalogWitness(finalFilesBySeries) !==
+			sonarrPeerFileCatalogWitness(firstFilesBySeries)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	return {
+		seriesCatalog: finalSeriesCatalog,
+		notifications: finalNotifications,
+		filesBySeries: finalFilesBySeries,
+	};
+}
+
+function assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+	trackedSeriesIds: ReadonlySet<number>,
+	ownership: VerifiedSonarrPlexOwnership[],
+	inventory: StableSonarrPeerInventory,
+): void {
+	for (const series of inventory.seriesCatalog) {
+		const seriesId = requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID");
+		if (trackedSeriesIds.has(seriesId)) continue;
+		const peerFiles = (inventory.filesBySeries.get(seriesId) ?? []).map(comparableFile);
+		for (const witness of ownership) {
+			if (peerFiles.length === 0) continue;
+			const mappedCandidate = mappedSonarrPeerFileCandidate(
+				peerFiles,
+				series.tags ?? [],
+				inventory.notifications,
+				witness.plexServerUrl,
+			);
+			if (
+				!mappedCandidate.hasExplicitServerCorrelation ||
+				mappedCandidate.files.some((file) =>
+					witness.target.some((part) => pathsEqual(file.fullPath, part.fullPath)),
+				)
+			) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+		}
+	}
+}
+
+function assertVerifiedSonarrPeerIdentityFromInventory(
+	peer: VerifiedSonarrPeerIdentity,
+	inventory: StableSonarrPeerInventory,
+): Series | null {
+	const matchingSeries = inventory.seriesCatalog.filter(
+		(series) => series.tvdbId === peer.externalId,
+	);
+	if (peer.arrItemId === null) {
+		if (matchingSeries.length !== 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		return null;
+	}
+	const series = matchingSeries[0];
+	if (
+		matchingSeries.length !== 1 ||
+		!series ||
+		series.id !== peer.arrItemId ||
+		peer.mediaPath === null ||
+		peer.files === null ||
+		!pathsEqual(normalizeMediaPath(series.path), peer.mediaPath) ||
+		sonarrPeerFileCatalogWitness(
+			new Map([[peer.arrItemId, inventory.filesBySeries.get(peer.arrItemId) ?? []]]),
+		) !== sonarrPeerFileCatalogWitness(new Map([[peer.arrItemId, peer.files.episodeFiles]]))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	return series;
+}
+
+export async function assertVerifiedSonarrPeerInventoryUnchanged(
+	sonarr: InstanceType<typeof SonarrClient>,
+	peer: VerifiedSonarrPeerIdentity,
+	ownership: VerifiedSonarrPlexOwnership[],
+	seriesCatalog?: Series[],
+	notifications?: SonarrNotification[],
+): Promise<{ series: Series | null; notifications: SonarrNotification[] }> {
+	try {
+		const inventory = await readStableSonarrPeerInventory(sonarr, seriesCatalog, notifications);
+		const series = assertVerifiedSonarrPeerIdentityFromInventory(peer, inventory);
+		assertVerifiedSonarrTrackedPeerMappingUnchanged(
+			peer,
+			series,
+			inventory.notifications,
+			ownership,
+		);
+		assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+			new Set(peer.arrItemId === null ? [] : [peer.arrItemId]),
+			ownership,
+			inventory,
+		);
+		return { series, notifications: inventory.notifications };
+	} catch (error) {
+		if (error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError) throw error;
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
 }
 
 async function verifyPlexMediaState(
@@ -1983,6 +2281,21 @@ export async function findSharedPlexDeleteBlocks(
 		SafetyPlexClient,
 		Map<number, Promise<PlexSeriesMediaItem[]>>
 	>();
+	const pendingSonarrPlans: Array<{
+		target: CleanupDeleteTarget;
+		targetKey: string;
+		client: InstanceType<typeof SonarrClient>;
+		action: string;
+		targetIdentity: VerifiedArrTargetIdentity;
+		verifiedFiles: VerifiedSonarrFileIdentity;
+		peers: NonNullable<PlexVerificationInput["sonarrPeers"]>;
+		peerCatalogs: Array<{
+			client: InstanceType<typeof SonarrClient>;
+			peer: VerifiedSonarrPeerIdentity;
+		}>;
+		ownership: VerifiedSonarrPlexOwnership[];
+		targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
+	}> = [];
 
 	const getRadarrClient = (instance: ServiceInstance): InstanceType<typeof RadarrClient> => {
 		let client = radarrClients.get(instance.id);
@@ -2043,13 +2356,11 @@ export async function findSharedPlexDeleteBlocks(
 	const getSonarrSeries = (
 		instance: ServiceInstance,
 		client: InstanceType<typeof SonarrClient>,
-		tvdbId: number,
 	): Promise<Series[]> => {
-		const lookupKey = `${instance.id}:${tvdbId}`;
-		let series = sonarrSeries.get(lookupKey);
+		let series = sonarrSeries.get(instance.id);
 		if (!series) {
-			series = client.series.getAll({ tvdbId });
-			sonarrSeries.set(lookupKey, series);
+			series = client.series.getAll();
+			sonarrSeries.set(instance.id, series);
 		}
 		return series;
 	};
@@ -2374,24 +2685,32 @@ export async function findSharedPlexDeleteBlocks(
 				(candidate) => candidate.id !== targetInstance.id && candidate.service === "SONARR",
 			);
 			const sonarrPeers: NonNullable<PlexVerificationInput["sonarrPeers"]> = [];
+			const sonarrPeerCatalogs: Array<{
+				client: InstanceType<typeof SonarrClient>;
+				peer: VerifiedSonarrPeerIdentity;
+			}> = [];
 			for (const peerInstance of peerInstances) {
 				const peerClient = getSonarrClient(peerInstance);
-				const peerSeriesItems = (await getSonarrSeries(peerInstance, peerClient, tvdbId)).filter(
+				const peerSeriesCatalog = await getSonarrSeries(peerInstance, peerClient);
+				const peerSeriesItems = peerSeriesCatalog.filter(
 					(candidate) => candidate.tvdbId === tvdbId,
 				);
+				const peerNotifications = await getSonarrNotifications(peerInstance, peerClient);
 				if (peerSeriesItems.length > 1) {
 					throw new FileMatchVerificationError("Sonarr peer returned multiple matching series");
 				}
 				if (peerSeriesItems.length === 0) {
+					const peerIdentity: VerifiedSonarrPeerIdentity = {
+						instanceId: peerInstance.id,
+						serviceFingerprint: createArrServiceFingerprint(peerInstance),
+						externalId: tvdbId,
+						arrItemId: null,
+						mediaPath: null,
+						files: null,
+					};
+					sonarrPeerCatalogs.push({ client: peerClient, peer: peerIdentity });
 					sonarrPeers.push({
-						identity: {
-							instanceId: peerInstance.id,
-							serviceFingerprint: createArrServiceFingerprint(peerInstance),
-							externalId: tvdbId,
-							arrItemId: null,
-							mediaPath: null,
-							files: null,
-						},
+						identity: peerIdentity,
 						seriesTags: [],
 						notifications: [],
 					});
@@ -2405,22 +2724,26 @@ export async function findSharedPlexDeleteBlocks(
 						sonarrEpisodeFileIdentity(peerSeries, file),
 					),
 				};
+				const peerIdentity: VerifiedSonarrPeerIdentity = {
+					instanceId: peerInstance.id,
+					serviceFingerprint: createArrServiceFingerprint(peerInstance),
+					externalId: tvdbId,
+					arrItemId: peerSeriesId,
+					mediaPath: normalizeMediaPath(peerSeries.path),
+					files: peerFiles,
+				};
+				sonarrPeerCatalogs.push({ client: peerClient, peer: peerIdentity });
 				sonarrPeers.push({
-					identity: {
-						instanceId: peerInstance.id,
-						serviceFingerprint: createArrServiceFingerprint(peerInstance),
-						externalId: tvdbId,
-						arrItemId: peerSeriesId,
-						mediaPath: normalizeMediaPath(peerSeries.path),
-						files: peerFiles,
-					},
+					identity: peerIdentity,
 					seriesTags: peerSeries.tags ?? [],
-					notifications:
-						peerFiles.episodeFiles.length === 0
-							? []
-							: await getSonarrNotifications(peerInstance, peerClient),
+					notifications: peerFiles.episodeFiles.length === 0 ? [] : peerNotifications,
 				});
 			}
+			const targetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+				plexNotifications,
+				series,
+				action,
+			);
 			const verification = await verifyPlexMediaState(
 				deps,
 				context,
@@ -2441,24 +2764,26 @@ export async function findSharedPlexDeleteBlocks(
 				blocks.set(targetKey, verification.block);
 				context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 			} else {
-				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
-				context.plans.set(targetKey, {
-					kind: "verified_sonarr",
-					target: targetIdentity,
-					files: verifiedFiles,
-					peers: sonarrPeers.map((peer) => peer.identity),
+				pendingSonarrPlans.push({
+					target,
+					targetKey,
+					client: sonarr,
+					action,
+					targetIdentity,
+					verifiedFiles,
+					peers: sonarrPeers,
+					peerCatalogs: sonarrPeerCatalogs,
 					ownership: verification.sonarrOwnership,
-					targetDeleteNotifications: sonarrTargetDeleteNotificationWitnesses(
-						plexNotifications,
-						series,
-					),
+					targetDeleteNotifications,
 				});
 			}
 		} catch (error) {
 			const reason =
-				error instanceof FileMatchVerificationError
-					? fileMatchFailedReason(service)
-					: verificationFailedReason(service);
+				error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError
+					? error.message
+					: error instanceof FileMatchVerificationError
+						? fileMatchFailedReason(service)
+						: verificationFailedReason(service);
 			blocks.set(targetKey, reason);
 			context.plans.set(targetKey, { kind: "blocked", reason });
 			deps.log.warn(
@@ -2467,6 +2792,74 @@ export async function findSharedPlexDeleteBlocks(
 					instanceId: target.instanceId,
 					arrItemId: target.arrItemId,
 					service,
+				},
+				"Cleanup shared-Plex safety check failed closed",
+			);
+		}
+	}
+
+	const sonarrPeerInventories = new Map<string, Promise<StableSonarrPeerInventory>>();
+	for (const pending of pendingSonarrPlans) {
+		try {
+			for (const peerCatalog of pending.peerCatalogs) {
+				const inventoryKey = `${peerCatalog.peer.instanceId}:${peerCatalog.peer.serviceFingerprint}`;
+				let inventoryPromise = sonarrPeerInventories.get(inventoryKey);
+				if (!inventoryPromise) {
+					inventoryPromise = readStableSonarrPeerInventory(peerCatalog.client);
+					sonarrPeerInventories.set(inventoryKey, inventoryPromise);
+				}
+				const inventory = await inventoryPromise;
+				const freshPeerSeries = assertVerifiedSonarrPeerIdentityFromInventory(
+					peerCatalog.peer,
+					inventory,
+				);
+				assertVerifiedSonarrTrackedPeerMappingUnchanged(
+					peerCatalog.peer,
+					freshPeerSeries,
+					inventory.notifications,
+					pending.ownership,
+				);
+				assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+					new Set(peerCatalog.peer.arrItemId === null ? [] : [peerCatalog.peer.arrItemId]),
+					pending.ownership,
+					inventory,
+				);
+			}
+			const freshTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+				await pending.client.notification.getAll(),
+				await pending.client.series.getById(pending.target.arrItemId),
+				pending.action,
+			);
+			if (
+				JSON.stringify(freshTargetDeleteNotifications) !==
+				JSON.stringify(pending.targetDeleteNotifications)
+			) {
+				throw new ArrTargetChangedDuringSafetyCheckError();
+			}
+			context.verifiedSonarrFiles.set(pending.targetKey, pending.verifiedFiles);
+			context.plans.set(pending.targetKey, {
+				kind: "verified_sonarr",
+				target: pending.targetIdentity,
+				files: pending.verifiedFiles,
+				peers: pending.peers.map((peer) => peer.identity),
+				ownership: pending.ownership,
+				targetDeleteNotifications: pending.targetDeleteNotifications,
+			});
+		} catch (error) {
+			const reason =
+				error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError
+					? error.message
+					: error instanceof FileMatchVerificationError
+						? fileMatchFailedReason("SONARR")
+						: verificationFailedReason("SONARR");
+			blocks.set(pending.targetKey, reason);
+			context.plans.set(pending.targetKey, { kind: "blocked", reason });
+			deps.log.warn(
+				{
+					err: getErrorMessage(error),
+					instanceId: pending.target.instanceId,
+					arrItemId: pending.target.arrItemId,
+					service: "SONARR",
 				},
 				"Cleanup shared-Plex safety check failed closed",
 			);
@@ -2674,6 +3067,9 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 		seriesPath: plan.files.seriesPath,
 		episodeFiles: [],
 	};
+	const expectedTargetSeriesDeleteNotifications = plan.targetDeleteNotifications.filter(
+		(notification) => notification.onSeriesDelete,
+	);
 	await assertVerifiedSonarrFilesUnchanged(
 		targetClient,
 		targetArrItemId,
@@ -2684,10 +3080,12 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 	const currentTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
 		await targetClient.notification.getAll(),
 		currentTargetSeries,
+		"delete",
+		true,
 	);
 	if (
 		JSON.stringify(currentTargetDeleteNotifications) !==
-		JSON.stringify(plan.targetDeleteNotifications)
+		JSON.stringify(expectedTargetSeriesDeleteNotifications)
 	) {
 		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
 	}
@@ -2699,35 +3097,20 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
 		}
 		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof SonarrClient>;
-		const seriesItems = (await client.series.getAll({ tvdbId: peer.externalId })).filter(
-			(series) => series.tvdbId === peer.externalId,
+		const seriesCatalog = await client.series.getAll();
+		const peerNotifications = await client.notification.getAll();
+		const verifiedPeer = await assertVerifiedSonarrPeerInventoryUnchanged(
+			client,
+			peer,
+			plan.ownership,
+			seriesCatalog,
+			peerNotifications,
 		);
-		if (peer.arrItemId === null) {
-			if (seriesItems.length !== 0) {
-				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
-			}
-			continue;
-		}
-		const series = seriesItems[0];
-		if (
-			seriesItems.length !== 1 ||
-			!series ||
-			series.id !== peer.arrItemId ||
-			peer.mediaPath === null ||
-			peer.files === null
-		) {
-			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
-		}
-		const peerTarget: VerifiedArrTargetIdentity = {
-			serviceFingerprint: peer.serviceFingerprint,
-			externalId: peer.externalId,
-			mediaPath: peer.mediaPath,
-		};
-		await assertVerifiedSonarrFilesUnchanged(client, peer.arrItemId, peerTarget, peer.files);
+		if (peer.arrItemId === null || peer.files === null || verifiedPeer.series === null) continue;
 		livePeers.set(peer.instanceId, {
 			identity: peer,
-			seriesTags: series.tags ?? [],
-			notifications: peer.files.episodeFiles.length ? await client.notification.getAll() : [],
+			seriesTags: verifiedPeer.series.tags ?? [],
+			notifications: peer.files.episodeFiles.length ? verifiedPeer.notifications : [],
 		});
 	}
 
@@ -2742,7 +3125,16 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 		}
 		for (const plexInstance of matchingPlexInstances) {
 			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
-			const mediaItems = await plex.getSeriesEpisodeMediaPartsByTvdbId(plan.target.externalId);
+			let mediaItems: PlexSeriesMediaItem[];
+			try {
+				mediaItems = await plex.getSeriesEpisodeMediaPartsByTvdbId(plan.target.externalId);
+			} catch (error) {
+				if (error instanceof PlexSeriesNotFoundError && ownership.retained.length === 0) {
+					mediaItems = [];
+				} else {
+					throw error;
+				}
+			}
 			const liveRetained: VerifiedSonarrPlexOwnership["retained"] = [];
 			for (const expectedPeer of plan.peers) {
 				const peer = livePeers.get(expectedPeer.instanceId);
@@ -2789,6 +3181,34 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 				}
 			}
 		}
+	}
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof SonarrClient>;
+		const seriesCatalog = await client.series.getAll();
+		const currentPeerNotifications = await client.notification.getAll();
+		await assertVerifiedSonarrPeerInventoryUnchanged(
+			client,
+			peer,
+			plan.ownership,
+			seriesCatalog,
+			currentPeerNotifications,
+		);
+	}
+	const finalTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		await targetClient.series.getById(targetArrItemId),
+		"delete",
+		true,
+	);
+	if (
+		JSON.stringify(finalTargetDeleteNotifications) !==
+		JSON.stringify(expectedTargetSeriesDeleteNotifications)
+	) {
+		throw new ArrTargetChangedDuringSafetyCheckError();
 	}
 	await assertVerifiedSonarrFilesUnchanged(
 		targetClient,

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -84,6 +84,38 @@ export interface VerifiedSonarrFileIdentity {
 	episodeFiles: VerifiedSonarrEpisodeFileIdentity[];
 }
 
+export interface VerifiedSonarrPeerIdentity {
+	instanceId: string;
+	serviceFingerprint: string;
+	externalId: number;
+	arrItemId: number | null;
+	mediaPath: NormalizedMediaPath | null;
+	files: VerifiedSonarrFileIdentity | null;
+}
+
+interface VerifiedSonarrPlexPart {
+	ratingKey: string;
+	fullPath: NormalizedMediaPath;
+	size: number;
+}
+
+export interface VerifiedSonarrPlexOwnership {
+	plexServerUrl: string;
+	target: VerifiedSonarrPlexPart[];
+	retained: Array<
+		VerifiedSonarrPlexPart & {
+			instanceId: string;
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>;
+}
+
+export interface VerifiedSonarrTargetDeleteNotification {
+	plexServerUrl: string;
+	onEpisodeFileDelete: boolean;
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}
+
 export interface VerifiedArrTargetIdentity {
 	serviceFingerprint: string;
 	externalId: number;
@@ -142,6 +174,9 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_sonarr";
 			target: VerifiedArrTargetIdentity;
 			files: VerifiedSonarrFileIdentity;
+			peers: VerifiedSonarrPeerIdentity[];
+			ownership: VerifiedSonarrPlexOwnership[];
+			targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
 	  };
 
 export type ExecutableSharedMediaSafetyPlan = Extract<
@@ -194,6 +229,197 @@ function canonicalRadarrFileIdentity(value: unknown): VerifiedRadarrFileIdentity
 		fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
 		size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
 	};
+}
+
+function canonicalSonarrFiles(value: unknown): VerifiedSonarrFileIdentity {
+	if (!value || typeof value !== "object") {
+		throw new FileMatchVerificationError("Sonarr file safety snapshot is invalid");
+	}
+	const files = value as Record<string, unknown>;
+	if (!Array.isArray(files.episodeFiles)) {
+		throw new FileMatchVerificationError("Sonarr file safety snapshot is invalid");
+	}
+	const episodeFiles = files.episodeFiles
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Sonarr episode-file snapshot is invalid");
+			}
+			const file = entry as Record<string, unknown>;
+			return {
+				episodeFileId: requiredPositiveSafeInteger(file.episodeFileId, "Sonarr episode file ID"),
+				fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
+				size: requiredPositiveSafeInteger(file.size, "Sonarr episode file size"),
+			};
+		})
+		.sort((left, right) => left.episodeFileId - right.episodeFileId);
+	if (new Set(episodeFiles.map((file) => file.episodeFileId)).size !== episodeFiles.length) {
+		throw new FileMatchVerificationError("Sonarr safety snapshot contains duplicate file IDs");
+	}
+	return {
+		seriesPath: normalizeMediaPath(
+			(files.seriesPath as Record<string, unknown> | undefined)?.value,
+		),
+		episodeFiles,
+	};
+}
+
+function canonicalSonarrPeers(value: unknown): VerifiedSonarrPeerIdentity[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr peer safety snapshot is invalid");
+	}
+	const peers = value
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Sonarr peer safety snapshot is invalid");
+			}
+			const peer = entry as Record<string, unknown>;
+			const serviceFingerprint = requiredNonEmptyString(
+				peer.serviceFingerprint,
+				"Sonarr peer service fingerprint",
+			);
+			if (!/^[a-f0-9]{64}$/.test(serviceFingerprint)) {
+				throw new FileMatchVerificationError("Sonarr peer service fingerprint is invalid");
+			}
+			const arrItemId =
+				peer.arrItemId === null
+					? null
+					: requiredPositiveSafeInteger(peer.arrItemId, "Sonarr peer series ID");
+			const mediaPath =
+				peer.mediaPath === null
+					? null
+					: normalizeMediaPath((peer.mediaPath as Record<string, unknown> | undefined)?.value);
+			const files = peer.files === null ? null : canonicalSonarrFiles(peer.files);
+			if (
+				arrItemId === null
+					? mediaPath !== null || files !== null
+					: mediaPath === null || files === null || !pathsEqual(files.seriesPath, mediaPath)
+			) {
+				throw new FileMatchVerificationError("Sonarr peer series snapshot is inconsistent");
+			}
+			return {
+				instanceId: requiredNonEmptyString(peer.instanceId, "Sonarr peer instance ID"),
+				serviceFingerprint,
+				externalId: requiredPositiveSafeInteger(peer.externalId, "Sonarr peer external media ID"),
+				arrItemId,
+				mediaPath,
+				files,
+			};
+		})
+		.sort((left, right) => left.instanceId.localeCompare(right.instanceId));
+	if (new Set(peers.map((peer) => peer.instanceId)).size !== peers.length) {
+		throw new FileMatchVerificationError(
+			"Sonarr peer safety snapshot contains duplicate instances",
+		);
+	}
+	return peers;
+}
+
+function canonicalSonarrOwnership(value: unknown): VerifiedSonarrPlexOwnership[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+	}
+	const ownership = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+		}
+		const witness = entry as Record<string, unknown>;
+		if (!Array.isArray(witness.target) || !Array.isArray(witness.retained)) {
+			throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+		}
+		const target = witness.target
+			.map((targetEntry) => {
+				if (!targetEntry || typeof targetEntry !== "object") {
+					throw new FileMatchVerificationError("Sonarr target-part snapshot is invalid");
+				}
+				const part = targetEntry as Record<string, unknown>;
+				return {
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Sonarr target Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Sonarr target Plex part size"),
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		const retained = witness.retained
+			.map((retainedEntry) => {
+				if (!retainedEntry || typeof retainedEntry !== "object") {
+					throw new FileMatchVerificationError("Sonarr retained-part snapshot is invalid");
+				}
+				const part = retainedEntry as Record<string, unknown>;
+				const mapping = part.mapping as Record<string, unknown> | null | undefined;
+				return {
+					instanceId: requiredNonEmptyString(part.instanceId, "Sonarr retained-part instance ID"),
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Sonarr retained Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Sonarr retained Plex part size"),
+					mapping:
+						mapping === null
+							? null
+							: {
+									from: normalizeMediaPath(
+										(mapping?.from as Record<string, unknown> | undefined)?.value,
+									),
+									to: normalizeMediaPath(
+										(mapping?.to as Record<string, unknown> | undefined)?.value,
+									),
+								},
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		return {
+			plexServerUrl: requiredNonEmptyString(witness.plexServerUrl, "Sonarr ownership Plex URL"),
+			target,
+			retained,
+		};
+	});
+	const unique = new Map(ownership.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
+function canonicalSonarrTargetDeleteNotifications(
+	value: unknown,
+): VerifiedSonarrTargetDeleteNotification[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr target notification snapshot is invalid");
+	}
+	const notifications = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Sonarr target notification snapshot is invalid");
+		}
+		const notification = entry as Record<string, unknown>;
+		const normalizedUrl = normalizedServerUrl(
+			requiredNonEmptyString(notification.plexServerUrl, "Sonarr target notification Plex URL"),
+		);
+		if (!normalizedUrl) {
+			throw new FileMatchVerificationError("Sonarr target notification Plex URL is invalid");
+		}
+		const mapping = notification.mapping as Record<string, unknown> | null | undefined;
+		return {
+			plexServerUrl: normalizedUrl,
+			onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
+			mapping:
+				mapping === null
+					? null
+					: {
+							from: normalizeMediaPath(
+								(mapping?.from as Record<string, unknown> | undefined)?.value,
+							),
+							to: normalizeMediaPath((mapping?.to as Record<string, unknown> | undefined)?.value),
+						},
+		};
+	});
+	const unique = new Map(notifications.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
 }
 
 function canonicalRadarrPeers(value: unknown): VerifiedRadarrPeerIdentity[] {
@@ -385,35 +611,15 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 		};
 	}
 	if (candidate.kind === "verified_sonarr") {
-		const files = candidate.files as Record<string, unknown> | undefined;
-		if (!files || !Array.isArray(files.episodeFiles)) {
-			throw new FileMatchVerificationError("Sonarr safety snapshot is invalid");
-		}
-		const episodeFiles = files.episodeFiles
-			.map((entry) => {
-				const file = entry as Record<string, unknown>;
-				return {
-					episodeFileId: requiredPositiveSafeInteger(file.episodeFileId, "Sonarr episode file ID"),
-					fullPath: normalizeMediaPath(
-						(file.fullPath as Record<string, unknown> | undefined)?.value,
-					),
-					size: requiredPositiveSafeInteger(file.size, "Sonarr episode file size"),
-				};
-			})
-			.sort((left, right) => left.episodeFileId - right.episodeFileId);
-		const uniqueIds = new Set(episodeFiles.map((file) => file.episodeFileId));
-		if (uniqueIds.size !== episodeFiles.length) {
-			throw new FileMatchVerificationError("Sonarr safety snapshot contains duplicate file IDs");
-		}
 		return {
 			kind: "verified_sonarr",
 			target: canonicalTargetIdentity(candidate.target),
-			files: {
-				seriesPath: normalizeMediaPath(
-					(files.seriesPath as Record<string, unknown> | undefined)?.value,
-				),
-				episodeFiles,
-			},
+			files: canonicalSonarrFiles(candidate.files),
+			peers: canonicalSonarrPeers(candidate.peers),
+			ownership: canonicalSonarrOwnership(candidate.ownership),
+			targetDeleteNotifications: canonicalSonarrTargetDeleteNotifications(
+				candidate.targetDeleteNotifications,
+			),
 		};
 	}
 	throw new FileMatchVerificationError("Cleanup safety snapshot is not executable");
@@ -510,6 +716,9 @@ export function buildSonarrCacheSafetyPlan(
 					size: Number(file.size),
 				})),
 			},
+			peers: [],
+			ownership: [],
+			targetDeleteNotifications: [],
 		});
 	} catch {
 		return null;
@@ -937,16 +1146,22 @@ function plexPartKey(part: { file: string; size: number }): string {
 	return JSON.stringify([path.windows, comparablePath(path, path.windows), part.size]);
 }
 
-function matchingPlexSeriesShows(
+function matchingPlexSeriesParts(
 	targets: MediaFileIdentity[],
 	seriesItems: PlexSeriesMediaItem[],
 	notification: NotificationLike,
-): PlexSeriesMediaItem[] {
+): Array<{
+	show: PlexSeriesMediaItem;
+	part: { file: string; size: number };
+}> {
 	const mappedTargets = targets.map((target) => ({
 		...target,
 		fullPath: mappedArrPathForNotification(target, notification, "SONARR"),
 	}));
-	const matchedShows = new Map<string, PlexSeriesMediaItem>();
+	const matches: Array<{
+		show: PlexSeriesMediaItem;
+		part: { file: string; size: number };
+	}> = [];
 
 	for (const target of mappedTargets) {
 		const physicalMatches = new Map<
@@ -971,26 +1186,10 @@ function matchingPlexSeriesShows(
 			);
 		}
 		const match = [...physicalMatches.values()][0]!;
-		matchedShows.set(match.show.ratingKey, match.show);
+		matches.push(match);
 	}
-
-	const targetKeys = new Set(
-		mappedTargets.map((target) => plexPartKey({ file: target.fullPath.value, size: target.size })),
-	);
-	for (const show of matchedShows.values()) {
-		const showPartKeys = new Set(
-			show.episodes.flatMap((episode) => episode.parts.map((part) => plexPartKey(part))),
-		);
-		for (const partKey of showPartKeys) {
-			if (!targetKeys.has(partKey)) {
-				throw new SharedPlexItemError();
-			}
-		}
-	}
-	return [...matchedShows.values()];
+	return matches;
 }
-
-class SharedPlexItemError extends Error {}
 
 export function cleanupDeleteTargetKey(
 	target: Pick<CleanupDeleteTarget, "instanceId" | "arrItemId" | "itemType">,
@@ -1086,6 +1285,7 @@ function sonarrNotificationApplies(
 	action: string,
 ): boolean {
 	if (
+		(notification as NotificationLike).enable === false ||
 		mediaServerNotificationKind(notification) === null ||
 		!notificationMutatesLibrary(notification)
 	) {
@@ -1203,6 +1403,35 @@ function radarrTargetDeleteNotificationWitnesses(
 	return canonicalRadarrTargetDeleteNotifications(witnesses);
 }
 
+function sonarrTargetDeleteNotificationWitnesses(
+	notifications: SonarrNotification[],
+	series: Series,
+): VerifiedSonarrTargetDeleteNotification[] {
+	const witnesses = notifications
+		.filter(
+			(notification) =>
+				sonarrNotificationApplies(notification, series, "delete") &&
+				notification.onSeriesDelete === true,
+		)
+		.map((notification) => {
+			if (mediaServerNotificationKind(notification) !== "plex") {
+				throw new FileMatchVerificationError(
+					"Sonarr target has an unsupported series-delete notification",
+				);
+			}
+			const plexServerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+			if (!plexServerUrl) {
+				throw new FileMatchVerificationError("Sonarr target series-delete Plex URL is invalid");
+			}
+			return {
+				plexServerUrl,
+				onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
+				mapping: notificationPathMapping(notification, "Sonarr target"),
+			};
+		});
+	return canonicalSonarrTargetDeleteNotifications(witnesses);
+}
+
 function plexConnectionFingerprint(instance: ServiceInstance): string {
 	return JSON.stringify([
 		instance.id,
@@ -1265,11 +1494,17 @@ interface PlexVerificationInput {
 		movieTags: number[];
 		notifications: RadarrNotification[];
 	}>;
+	sonarrPeers?: Array<{
+		identity: VerifiedSonarrPeerIdentity;
+		seriesTags: number[];
+		notifications: SonarrNotification[];
+	}>;
 }
 
 interface PlexVerificationResult {
 	block?: string;
 	ownership: VerifiedRadarrPlexOwnership[];
+	sonarrOwnership: VerifiedSonarrPlexOwnership[];
 }
 
 function matchingPeerPlexPart(
@@ -1367,6 +1602,103 @@ function matchingPeerPlexPart(
 	return [...matches.values()][0]!;
 }
 
+function matchingSonarrPeerPlexParts(
+	peer: NonNullable<PlexVerificationInput["sonarrPeers"]>[number],
+	items: PlexSeriesMediaItem[],
+	notificationUrl: string,
+): Array<{
+	show: PlexSeriesMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}> {
+	if (!peer.identity.files) return [];
+	const serverNotifications: SonarrNotification[] = [];
+	for (const notification of peer.notifications) {
+		if (mediaServerNotificationKind(notification) !== "plex") continue;
+		let peerUrl: string | null = null;
+		try {
+			peerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+		} catch {
+			continue;
+		}
+		if (peerUrl === notificationUrl) serverNotifications.push(notification);
+	}
+	const matchingNotifications = serverNotifications.filter(
+		(notification) =>
+			(notification as NotificationLike).enable !== false &&
+			notificationMutatesLibrary(notification) &&
+			notificationTagsApply(notification, peer.seriesTags),
+	);
+	const unusableConfiguredMapping = serverNotifications.some((notification) => {
+		const rawMapFrom = fieldValue(notification, "mapFrom");
+		const rawMapTo = fieldValue(notification, "mapTo");
+		return (
+			!matchingNotifications.includes(notification) &&
+			((typeof rawMapFrom === "string" && rawMapFrom.trim() !== "") ||
+				(typeof rawMapTo === "string" && rawMapTo.trim() !== ""))
+		);
+	});
+	if (matchingNotifications.length === 0 && unusableConfiguredMapping) {
+		throw new FileMatchVerificationError("Sonarr peer has only non-applicable Plex path mappings");
+	}
+
+	const pathCandidates = new Map<
+		string,
+		{
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+			files: MediaFileIdentity[];
+		}
+	>();
+	const peerFiles = peer.identity.files.episodeFiles.map(comparableFile);
+	if (matchingNotifications.length === 0) {
+		pathCandidates.set(JSON.stringify([null, peerFiles.map((file) => file.fullPath)]), {
+			mapping: null,
+			files: peerFiles,
+		});
+	}
+	for (const notification of matchingNotifications) {
+		const mapping = notificationPathMapping(notification, "Sonarr peer");
+		const files = peerFiles.map((file) => ({
+			...file,
+			fullPath: mapping
+				? mappedArrPathForNotification(file, notification, "SONARR")
+				: file.fullPath,
+		}));
+		pathCandidates.set(JSON.stringify([mapping, files.map((file) => file.fullPath)]), {
+			mapping,
+			files,
+		});
+	}
+	if (pathCandidates.size !== 1) {
+		throw new FileMatchVerificationError("Sonarr peer Plex path mappings conflict");
+	}
+	const pathCandidate = [...pathCandidates.values()][0]!;
+
+	return pathCandidate.files.map((file) => {
+		const matches = new Map<
+			string,
+			{ show: PlexSeriesMediaItem; part: { file: string; size: number } }
+		>();
+		for (const show of items) {
+			for (const episode of show.episodes) {
+				for (const part of episode.parts) {
+					if (mediaPartMatchesTarget(file, part)) {
+						matches.set(`${show.ratingKey}:${plexPartKey(part)}`, { show, part });
+					}
+				}
+			}
+		}
+		if (matches.size !== 1) {
+			throw new FileMatchVerificationError(
+				matches.size === 0
+					? "No Plex media part matched a retained Sonarr peer file"
+					: "Multiple Plex show items matched a retained Sonarr peer file",
+			);
+		}
+		return { ...[...matches.values()][0]!, mapping: pathCandidate.mapping };
+	});
+}
+
 async function verifyPlexMediaState(
 	deps: CleanupExecutorDeps,
 	context: SharedPlexSafetyContext,
@@ -1377,7 +1709,8 @@ async function verifyPlexMediaState(
 	input: PlexVerificationInput,
 ): Promise<PlexVerificationResult> {
 	const ownership: VerifiedRadarrPlexOwnership[] = [];
-	if (input.files.length === 0) return { ownership };
+	const sonarrOwnership: VerifiedSonarrPlexOwnership[] = [];
+	if (input.files.length === 0) return { ownership, sonarrOwnership };
 
 	for (const notification of input.notifications) {
 		const notificationUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
@@ -1435,6 +1768,7 @@ async function verifyPlexMediaState(
 									return {
 										block: crossInstanceOwnershipReason("RADARR"),
 										ownership,
+										sonarrOwnership,
 									};
 								}
 								retained.push({
@@ -1462,14 +1796,14 @@ async function verifyPlexMediaState(
 						}
 						if (targetMatch.item.parts.length <= 1) continue;
 						if (!input.radarrPeers?.length || !notificationUrl) {
-							return { block: mergedItemReason(input.service), ownership };
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
 						}
 						const unownedParts = targetMatch.item.parts.filter((part) => {
 							const partKey = plexPartKey(part);
 							return partKey !== targetPartKey && !retainedPartKeys.has(partKey);
 						});
 						if (retainedPartKeys.size === 0 || unownedParts.length > 0) {
-							return { block: mergedItemReason(input.service), ownership };
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
 						}
 					}
 				} else {
@@ -1483,13 +1817,86 @@ async function verifyPlexMediaState(
 						mediaPartsPromise = plex.getSeriesEpisodeMediaPartsByTvdbId(input.externalId);
 						clientLookups.set(input.externalId, mediaPartsPromise);
 					}
-					try {
-						matchingPlexSeriesShows(input.files, await mediaPartsPromise, notification);
-					} catch (error) {
-						if (error instanceof SharedPlexItemError) {
-							return { block: mergedItemReason(input.service), ownership };
+					const mediaItems = await mediaPartsPromise;
+					const targetMatches = matchingPlexSeriesParts(input.files, mediaItems, notification);
+					const targetPhysicalKeys = new Set(
+						targetMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+					);
+					if (targetPhysicalKeys.size !== targetMatches.length) {
+						throw new FileMatchVerificationError(
+							"Multiple Sonarr episode files matched the same Plex media part",
+						);
+					}
+					const targetPartKeys = new Set(targetMatches.map((match) => plexPartKey(match.part)));
+					const retainedMatches: Array<{
+						instanceId: string;
+						show: PlexSeriesMediaItem;
+						part: { file: string; size: number };
+						mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+					}> = [];
+					const retainedPartOwners = new Map<string, string>();
+					for (const peer of input.sonarrPeers ?? []) {
+						for (const match of matchingSonarrPeerPlexParts(peer, mediaItems, notificationUrl)) {
+							const partKey = plexPartKey(match.part);
+							if (targetPartKeys.has(partKey)) {
+								return {
+									block: crossInstanceOwnershipReason("SONARR"),
+									ownership,
+									sonarrOwnership,
+								};
+							}
+							const existingOwner = retainedPartOwners.get(partKey);
+							if (existingOwner) {
+								if (existingOwner !== peer.identity.instanceId) {
+									return {
+										block: crossInstanceOwnershipReason("SONARR"),
+										ownership,
+										sonarrOwnership,
+									};
+								}
+								throw new FileMatchVerificationError(
+									"Multiple Sonarr peer files matched the same Plex media part",
+								);
+							}
+							retainedPartOwners.set(partKey, peer.identity.instanceId);
+							retainedMatches.push({
+								instanceId: peer.identity.instanceId,
+								...match,
+							});
 						}
-						throw error;
+					}
+					if (input.sonarrPeers?.length) {
+						sonarrOwnership.push({
+							plexServerUrl: notificationUrl,
+							target: targetMatches.map((match) => ({
+								ratingKey: match.show.ratingKey,
+								fullPath: normalizeMediaPath(match.part.file),
+								size: match.part.size,
+							})),
+							retained: retainedMatches.map((match) => ({
+								instanceId: match.instanceId,
+								ratingKey: match.show.ratingKey,
+								fullPath: normalizeMediaPath(match.part.file),
+								size: match.part.size,
+								mapping: match.mapping,
+							})),
+						});
+					}
+					const allowedPartKeys = new Set([
+						...targetMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+						...retainedMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+					]);
+					for (const show of mediaItems) {
+						const showPartKeys = new Set(
+							show.episodes.flatMap((episode) => episode.parts.map(plexPartKey)),
+						);
+						if (
+							[...showPartKeys].some(
+								(partKey) => !allowedPartKeys.has(`${show.ratingKey}:${partKey}`),
+							)
+						) {
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
+						}
 					}
 				}
 			} catch (error) {
@@ -1511,15 +1918,16 @@ async function verifyPlexMediaState(
 			throw new Error("No matching Plex credential could verify owner-visible media state");
 		}
 	}
-	return { ownership };
+	return { ownership, sonarrOwnership };
 }
 
 /**
  * Fail-closed preflight for shared Plex library deletions initiated through
  * either Radarr or Sonarr. The live ARR file set is correlated to exact Plex
  * media parts after applying the target ARR connection's path mapping. A
- * multi-part Radarr movie is allowed only when every retained Plex part is
- * backed by a peer Radarr witness and every configured peer is snapshotted.
+ * shared Radarr movies and Sonarr shows are allowed only when every retained
+ * Plex part is backed by an exact peer ARR file and every configured peer is
+ * snapshotted.
  */
 export async function findSharedPlexDeleteBlocks(
 	deps: CleanupExecutorDeps,
@@ -1567,6 +1975,7 @@ export async function findSharedPlexDeleteBlocks(
 	const sonarrClients = new Map<string, InstanceType<typeof SonarrClient>>();
 	const radarrMovies = new Map<string, Promise<Movie[]>>();
 	const radarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
+	const sonarrSeries = new Map<string, Promise<Series[]>>();
 	const sonarrNotifications = new Map<string, Promise<SonarrNotification[]>>();
 	const plexOwnerChecks = new Map<string, Promise<void>>();
 	const plexMovieLookups = new Map<SafetyPlexClient, Map<number, Promise<PlexMovieMediaItem[]>>>();
@@ -1629,6 +2038,20 @@ export async function findSharedPlexDeleteBlocks(
 			sonarrNotifications.set(instance.id, notifications);
 		}
 		return notifications;
+	};
+
+	const getSonarrSeries = (
+		instance: ServiceInstance,
+		client: InstanceType<typeof SonarrClient>,
+		tvdbId: number,
+	): Promise<Series[]> => {
+		const lookupKey = `${instance.id}:${tvdbId}`;
+		let series = sonarrSeries.get(lookupKey);
+		if (!series) {
+			series = client.series.getAll({ tvdbId });
+			sonarrSeries.set(lookupKey, series);
+		}
+		return series;
 	};
 
 	const otherInstanceMayOwnFile = (
@@ -1892,21 +2315,24 @@ export async function findSharedPlexDeleteBlocks(
 					sonarrEpisodeFileIdentity(series, file),
 				),
 			};
-			if (otherInstanceMayOwnFile(targetInstance, service, verifiedFiles.episodeFiles.length)) {
-				const reason = crossInstanceOwnershipReason(service);
-				blocks.set(targetKey, reason);
-				context.plans.set(targetKey, { kind: "blocked", reason });
-				continue;
-			}
 			const notifications = (await getSonarrNotifications(targetInstance, sonarr)).filter(
 				(notification) => sonarrNotificationApplies(notification, series, action),
 			);
 			if (notifications.length === 0) {
+				if (otherInstanceMayOwnFile(targetInstance, service, verifiedFiles.episodeFiles.length)) {
+					const reason = crossInstanceOwnershipReason(service);
+					blocks.set(targetKey, reason);
+					context.plans.set(targetKey, { kind: "blocked", reason });
+					continue;
+				}
 				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
 				context.plans.set(targetKey, {
 					kind: "verified_sonarr",
 					target: targetIdentity,
 					files: verifiedFiles,
+					peers: [],
+					ownership: [],
+					targetDeleteNotifications: [],
 				});
 				continue;
 			}
@@ -1944,6 +2370,57 @@ export async function findSharedPlexDeleteBlocks(
 				context.plans.set(targetKey, { kind: "blocked", reason });
 				continue;
 			}
+			const peerInstances = instances.filter(
+				(candidate) => candidate.id !== targetInstance.id && candidate.service === "SONARR",
+			);
+			const sonarrPeers: NonNullable<PlexVerificationInput["sonarrPeers"]> = [];
+			for (const peerInstance of peerInstances) {
+				const peerClient = getSonarrClient(peerInstance);
+				const peerSeriesItems = (await getSonarrSeries(peerInstance, peerClient, tvdbId)).filter(
+					(candidate) => candidate.tvdbId === tvdbId,
+				);
+				if (peerSeriesItems.length > 1) {
+					throw new FileMatchVerificationError("Sonarr peer returned multiple matching series");
+				}
+				if (peerSeriesItems.length === 0) {
+					sonarrPeers.push({
+						identity: {
+							instanceId: peerInstance.id,
+							serviceFingerprint: createArrServiceFingerprint(peerInstance),
+							externalId: tvdbId,
+							arrItemId: null,
+							mediaPath: null,
+							files: null,
+						},
+						seriesTags: [],
+						notifications: [],
+					});
+					continue;
+				}
+				const peerSeries = peerSeriesItems[0]!;
+				const peerSeriesId = requiredPositiveSafeInteger(peerSeries.id, "Sonarr peer series ID");
+				const peerFiles: VerifiedSonarrFileIdentity = {
+					seriesPath: normalizeMediaPath(peerSeries.path),
+					episodeFiles: (await peerClient.episodeFile.getBySeries(peerSeriesId)).map((file) =>
+						sonarrEpisodeFileIdentity(peerSeries, file),
+					),
+				};
+				sonarrPeers.push({
+					identity: {
+						instanceId: peerInstance.id,
+						serviceFingerprint: createArrServiceFingerprint(peerInstance),
+						externalId: tvdbId,
+						arrItemId: peerSeriesId,
+						mediaPath: normalizeMediaPath(peerSeries.path),
+						files: peerFiles,
+					},
+					seriesTags: peerSeries.tags ?? [],
+					notifications:
+						peerFiles.episodeFiles.length === 0
+							? []
+							: await getSonarrNotifications(peerInstance, peerClient),
+				});
+			}
 			const verification = await verifyPlexMediaState(
 				deps,
 				context,
@@ -1957,6 +2434,7 @@ export async function findSharedPlexDeleteBlocks(
 					notifications: plexNotifications,
 					externalId: tvdbId,
 					files: verifiedFiles.episodeFiles.map(comparableFile),
+					sonarrPeers,
 				},
 			);
 			if (verification.block) {
@@ -1968,6 +2446,12 @@ export async function findSharedPlexDeleteBlocks(
 					kind: "verified_sonarr",
 					target: targetIdentity,
 					files: verifiedFiles,
+					peers: sonarrPeers.map((peer) => peer.identity),
+					ownership: verification.sonarrOwnership,
+					targetDeleteNotifications: sonarrTargetDeleteNotificationWitnesses(
+						plexNotifications,
+						series,
+					),
 				});
 			}
 		} catch (error) {
@@ -2144,4 +2628,172 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 		}
 	}
 	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
+}
+
+/**
+ * Revalidate every retained Sonarr episode-file witness after the selected
+ * target files are gone and immediately before the fileless series record is
+ * deleted. The final target-file read is deliberately last.
+ */
+export async function assertVerifiedSonarrPeerOwnershipRetained(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	targetArrItemId: number,
+	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
+): Promise<void> {
+	const [arrInstances, plexInstances] = await Promise.all([
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["RADARR", "SONARR"] } },
+		}),
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX" },
+		}),
+	]);
+	const peerInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "SONARR" &&
+			createArrServiceFingerprint(instance) !== plan.target.serviceFingerprint,
+	);
+	const targetInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "SONARR" &&
+			createArrServiceFingerprint(instance) === plan.target.serviceFingerprint,
+	);
+	const peerIds = new Set(plan.peers.map((peer) => peer.instanceId));
+	if (
+		targetInstances.length !== 1 ||
+		peerInstances.length !== peerIds.size ||
+		peerInstances.some((instance) => !peerIds.has(instance.id))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	const targetClient = deps.arrClientFactory.create(targetInstances[0]!) as InstanceType<
+		typeof SonarrClient
+	>;
+	const emptyTargetFiles: VerifiedSonarrFileIdentity = {
+		seriesPath: plan.files.seriesPath,
+		episodeFiles: [],
+	};
+	await assertVerifiedSonarrFilesUnchanged(
+		targetClient,
+		targetArrItemId,
+		plan.target,
+		emptyTargetFiles,
+	);
+	const currentTargetSeries = await targetClient.series.getById(targetArrItemId);
+	const currentTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		currentTargetSeries,
+	);
+	if (
+		JSON.stringify(currentTargetDeleteNotifications) !==
+		JSON.stringify(plan.targetDeleteNotifications)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+
+	const livePeers = new Map<string, NonNullable<PlexVerificationInput["sonarrPeers"]>[number]>();
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof SonarrClient>;
+		const seriesItems = (await client.series.getAll({ tvdbId: peer.externalId })).filter(
+			(series) => series.tvdbId === peer.externalId,
+		);
+		if (peer.arrItemId === null) {
+			if (seriesItems.length !== 0) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+			continue;
+		}
+		const series = seriesItems[0];
+		if (
+			seriesItems.length !== 1 ||
+			!series ||
+			series.id !== peer.arrItemId ||
+			peer.mediaPath === null ||
+			peer.files === null
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const peerTarget: VerifiedArrTargetIdentity = {
+			serviceFingerprint: peer.serviceFingerprint,
+			externalId: peer.externalId,
+			mediaPath: peer.mediaPath,
+		};
+		await assertVerifiedSonarrFilesUnchanged(client, peer.arrItemId, peerTarget, peer.files);
+		livePeers.set(peer.instanceId, {
+			identity: peer,
+			seriesTags: series.tags ?? [],
+			notifications: peer.files.episodeFiles.length ? await client.notification.getAll() : [],
+		});
+	}
+
+	const context = createSharedPlexSafetyContext();
+	const ownerChecks = new Map<string, Promise<void>>();
+	for (const ownership of plan.ownership) {
+		const matchingPlexInstances = plexInstances.filter(
+			(instance) => normalizedServerUrl(instance.baseUrl) === ownership.plexServerUrl,
+		);
+		if (matchingPlexInstances.length === 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		for (const plexInstance of matchingPlexInstances) {
+			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
+			const mediaItems = await plex.getSeriesEpisodeMediaPartsByTvdbId(plan.target.externalId);
+			const liveRetained: VerifiedSonarrPlexOwnership["retained"] = [];
+			for (const expectedPeer of plan.peers) {
+				const peer = livePeers.get(expectedPeer.instanceId);
+				if (!peer) continue;
+				for (const match of matchingSonarrPeerPlexParts(
+					peer,
+					mediaItems,
+					ownership.plexServerUrl,
+				)) {
+					liveRetained.push({
+						instanceId: expectedPeer.instanceId,
+						ratingKey: match.show.ratingKey,
+						fullPath: normalizeMediaPath(match.part.file),
+						size: match.part.size,
+						mapping: match.mapping,
+					});
+				}
+			}
+			const expectedRetained = [...ownership.retained].sort((left, right) =>
+				JSON.stringify(left).localeCompare(JSON.stringify(right)),
+			);
+			liveRetained.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+			if (JSON.stringify(liveRetained) !== JSON.stringify(expectedRetained)) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+
+			const allowedPartKeys = new Set([
+				...ownership.target.map(
+					(part) =>
+						`${part.ratingKey}:${plexPartKey({ file: part.fullPath.value, size: part.size })}`,
+				),
+				...ownership.retained.map(
+					(part) =>
+						`${part.ratingKey}:${plexPartKey({ file: part.fullPath.value, size: part.size })}`,
+				),
+			]);
+			for (const show of mediaItems) {
+				for (const partKey of new Set(
+					show.episodes.flatMap((episode) => episode.parts.map(plexPartKey)),
+				)) {
+					if (!allowedPartKeys.has(`${show.ratingKey}:${partKey}`)) {
+						throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+					}
+				}
+			}
+		}
+	}
+	await assertVerifiedSonarrFilesUnchanged(
+		targetClient,
+		targetArrItemId,
+		plan.target,
+		emptyTargetFiles,
+	);
 }

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -77,6 +77,13 @@ export interface PlexSeriesMediaItem {
 	episodes: PlexEpisodeMediaItem[];
 }
 
+export class PlexSeriesNotFoundError extends Error {
+	constructor(tvdbId: number) {
+		super(`Plex returned no series item for TVDB ${tvdbId}`);
+		this.name = "PlexSeriesNotFoundError";
+	}
+}
+
 export interface PlexHistoryItem {
 	ratingKey: string;
 	parentRatingKey?: string;
@@ -349,7 +356,7 @@ export class PlexClient {
 			(item) => item.type === "show" && item.Guid?.some((guid) => guid.id === `tvdb://${tvdbId}`),
 		);
 		if (exactShows.length === 0) {
-			throw new Error(`Plex returned no series item for TVDB ${tvdbId}`);
+			throw new PlexSeriesNotFoundError(tvdbId);
 		}
 
 		const seriesItems = await Promise.all(


### PR DESCRIPTION
## Summary

- verify exact Plex media ownership across every configured Sonarr instance before shared-library cleanup
- persist peer, Plex ownership, and Sonarr notification witnesses and revalidate them at both destructive boundaries
- preserve safe retry and crash recovery with execution-token-scoped snapshot transitions

## Safety and compatibility

- supports same-show and separate-show Plex variants, peer-specific path mappings, and alternate or missing TVDB identities
- blocks overlapping claims, unowned Plex parts, and peer, notification, catalog, or Plex topology races
- builds one API-compatible, bounded, exact two-pass peer inventory per preview batch and fresh inventories at mutation boundaries
- keeps existing Radarr behavior unchanged and reads older Sonarr snapshots without the new witness fields
- deletes the Sonarr series record with `deleteFiles: false` only after the verified files are gone and retained ownership is rechecked

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test` (2,494 API tests passed with 41 expected skips; 527 web tests; 54 shared tests)
- focused shared-Plex safety suites (69 Sonarr tests, 132 Radarr tests, and 8 Plex client tests; 209 total)
- `git diff --check`
- changed files pass Biome formatting checks
- independent data-safety and regression reviews found no remaining actionable issues

The repository-wide `pnpm run format` check still reports four untouched OIDC files already present on `origin/main`; this branch does not modify them. Browser testing is not applicable because this is backend deletion-safety logic. The destructive Sonarr/Plex boundaries are covered with populated multi-instance mocks, including retries, interrupted execution, alternate identities, notification races, and batched peer inventories.

Related to #657
