### PR TITLE
test(cleanup): cover IMDb ratings from Radarr sync

### DIFF
--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -16,7 +16,7 @@ import type { PrismaClient, ServiceType } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
 import { createArrServiceFingerprint } from "../../arr/service-fingerprint.js";
 import type { Encryptor } from "../../auth/encryption.js";
-import { extractRating } from "../../library-cleanup/rule-evaluators.js";
+import { evaluateSingleCondition, extractRating } from "../../library-cleanup/rule-evaluators.js";
 import type { CacheItemForEval } from "../../library-cleanup/types.js";
 import { type LibraryStreamFn, type SyncExecutorDeps, syncInstance } from "../sync-executor.js";
 
@@ -379,7 +379,7 @@ describe("syncInstance", () => {
 			};
 		}
 
-		it("preserves Radarr source provenance without arbitrary fallback", async () => {
+		it("preserves Radarr source provenance and matches IMDb cleanup from cached data", async () => {
 			const { data, cacheItem } = await syncRating("RADARR", {
 				imdb: { value: 7.4, votes: 100 },
 				tmdb: { value: 8.6, votes: 200 },
@@ -391,6 +391,14 @@ describe("syncInstance", () => {
 				metacritic: { value: 84, votes: 20 },
 			});
 			expect(extractRating(cacheItem)).toBe(8.6);
+			expect(
+				evaluateSingleCondition(
+					cacheItem,
+					"imdb_rating",
+					{ operator: "less_than", score: 10 },
+					{ now: new Date("2026-07-30T00:00:00Z") },
+				),
+			).toBe("IMDb rating: 7.4 (threshold: < 10)");
 		});
 
 		it("keeps Sonarr's flat score separate from IMDb", async () => {


### PR DESCRIPTION
## Summary

- lock the reported Radarr IMDb cleanup path into the library-sync regression suite
- verify a real Radarr-style `ratings.imdb.value` survives normalization and cache serialization
- verify the cached item matches an `IMDb rating less than 10` cleanup condition

## Root cause and resolution

In v2.23.0, Radarr ratings were omitted from the normalized library item, so the cleanup evaluator had no IMDb value and returned no match. PR #668 added source-aware rating normalization and cleanup evaluation. This PR proves the reporter's exact threshold scenario across the normalization/cache/evaluation boundary so it cannot silently regress.

## Validation

- reproduced on `v2.23.0`: normalized IMDb rating absent and cleanup match `null`
- verified on current `main`: IMDb `7.4` preserved and `less than 10` matched
- focused sync executor suite: 34 passed
- shared build passed
- root typecheck passed
- root test suite passed: 3,872 tests
- root lint passed
- changed file passes Biome formatting and `git diff --check`

The root format command still reports four pre-existing OIDC formatting failures already present on `origin/main`; this PR does not touch those files.

Closes #660
