### PR TITLE
feat(trash-guides): add deployment safety primitives

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
@@ -1,0 +1,426 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveActiveDeploymentOwnership } from "../deployment-active-ownership.js";
+
+function state(overrides: Record<string, unknown> = {}) {
+	return JSON.stringify({
+		schemaVersion: 2,
+		endpointKey: "endpoint",
+		connectionStateToken: "connection",
+		customFormats: [],
+		customFormatDeployments: [],
+		managedCustomFormats: [],
+		managedCustomFormatsCaptured: true,
+		qualityProfileDeployment: {
+			beforeProfile: null,
+			status: "not_started",
+			action: "created",
+			profileId: null,
+			profileName: "Profile",
+			postStateToken: null,
+			intendedPostStateToken: null,
+		},
+		namingDeployment: null,
+		...overrides,
+	});
+}
+
+describe("active deployment ownership", () => {
+	it("rejects a superseded rollback target", async () => {
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						templateId: "template-1",
+						backupId: "new",
+						status: "SUCCESS",
+						deployedAt: new Date("2026-01-02"),
+						backup: { backupData: state() },
+					},
+					{
+						templateId: "template-1",
+						backupId: "old",
+						status: "SUCCESS",
+						deployedAt: new Date("2026-01-01"),
+						backup: { backupData: state() },
+					},
+				]),
+			},
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "old",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("newer deployment");
+	});
+
+	it("fails closed when one template has active backups with tied timestamps", async () => {
+		const tiedAt = new Date("2026-01-02");
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						templateId: "template-1",
+						backupId: "target",
+						status: "SUCCESS",
+						deployedAt: tiedAt,
+						backup: { backupData: state() },
+					},
+					{
+						templateId: "template-1",
+						backupId: "tied",
+						status: "SUCCESS",
+						deployedAt: tiedAt,
+						backup: { backupData: state() },
+					},
+				]),
+			},
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("same deployment time");
+	});
+
+	it("combines exact identities from managed and per-write ledgers", async () => {
+		const target = {
+			templateId: "template-1",
+			backupId: "target",
+			status: "SUCCESS",
+			deployedAt: new Date("2026-01-02"),
+			backup: { backupData: state() },
+		};
+		const other = {
+			templateId: "template-2",
+			backupId: "other",
+			status: "PARTIAL_SUCCESS",
+			deployedAt: new Date("2026-01-03"),
+			backup: {
+				backupData: state({
+					managedCustomFormats: [
+						{
+							trashId: "managed",
+							name: "Managed",
+							resourceId: 7,
+							stateToken: "format",
+							profileId: 3,
+							appliedScore: 100,
+						},
+					],
+					customFormatDeployments: [
+						{
+							beforeFormat: null,
+							action: "created",
+							resourceId: 8,
+							name: "Created",
+							status: "applied",
+							postStateToken: "post",
+							intendedPostStateToken: null,
+						},
+					],
+					qualityProfileDeployment: {
+						beforeProfile: { id: 3 },
+						status: "applied",
+						action: "updated",
+						profileId: 3,
+						profileName: "Profile",
+						postStateToken: "profile",
+						intendedPostStateToken: "profile",
+					},
+					namingDeployment: {
+						beforeConfig: {},
+						status: "applied",
+						postStateToken: "naming",
+						intendedPostStateToken: "naming",
+					},
+				}),
+			},
+		};
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([target, other]) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "template-1",
+		});
+
+		expect([...result.sharedCustomFormatIds]).toEqual([7, 8]);
+		expect([...result.sharedQualityProfileIds]).toEqual([3]);
+		expect(result.namingOwnedByAnotherDeployment).toBe(true);
+		expect([...result.sharedCustomFormatStateTokens.get(7)!]).toEqual(["format"]);
+		expect([...result.sharedCustomFormatStateTokens.get(8)!]).toEqual(["post"]);
+		expect([...result.sharedQualityProfileStateTokens.get(3)!]).toEqual(["profile"]);
+		expect([...result.sharedNamingStateTokens]).toEqual(["naming"]);
+	});
+
+	it("keeps the newest surviving owner state when multiple templates touched one resource", async () => {
+		const managedState = (token: string) =>
+			state({
+				managedCustomFormats: [
+					{
+						trashId: "shared",
+						name: "Shared",
+						resourceId: 7,
+						stateToken: token,
+						profileId: 3,
+						appliedScore: 100,
+					},
+				],
+			});
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-04"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "older-survivor",
+				backupId: "older",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: managedState("older-state") },
+			},
+			{
+				templateId: "newer-survivor",
+				backupId: "newer",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-03"),
+				backup: { backupData: managedState("newer-state") },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect([...result.sharedCustomFormatStateTokens.get(7)!]).toEqual(["newer-state"]);
+	});
+
+	it("marks a target resource as non-restorable when a newer survivor touched it", async () => {
+		const managedState = (token: string) =>
+			state({
+				managedCustomFormats: [
+					{
+						trashId: "shared",
+						name: "Shared",
+						resourceId: 7,
+						stateToken: token,
+						profileId: 3,
+						appliedScore: 100,
+					},
+				],
+			});
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: managedState("target-state") },
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: managedState("survivor-state") },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect(result.sharedCustomFormatIds).toContain(7);
+		expect(result.restorableSharedCustomFormatIds).not.toContain(7);
+	});
+
+	it("fails closed when a target and survivor touched a resource at the same time", async () => {
+		const managedState = (token: string) =>
+			state({
+				managedCustomFormats: [
+					{
+						trashId: "shared",
+						name: "Shared",
+						resourceId: 7,
+						stateToken: token,
+						profileId: 3,
+						appliedScore: 100,
+					},
+				],
+			});
+		const tiedAt = new Date("2026-01-02");
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: tiedAt,
+				backup: { backupData: managedState("target-state") },
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: tiedAt,
+				backup: { backupData: managedState("survivor-state") },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "target-template",
+			}),
+		).rejects.toThrow("same deployment time");
+	});
+
+	it("fails closed when surviving owners of one resource have tied timestamps", async () => {
+		const managedState = (token: string) =>
+			state({
+				managedCustomFormats: [
+					{
+						trashId: "shared",
+						name: "Shared",
+						resourceId: 7,
+						stateToken: token,
+						profileId: 3,
+						appliedScore: 100,
+					},
+				],
+			});
+		const tiedAt = new Date("2026-01-03");
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-04"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "survivor-a",
+				backupId: "survivor-a",
+				status: "SUCCESS",
+				deployedAt: tiedAt,
+				backup: { backupData: managedState("state-a") },
+			},
+			{
+				templateId: "survivor-b",
+				backupId: "survivor-b",
+				status: "SUCCESS",
+				deployedAt: tiedAt,
+				backup: { backupData: managedState("state-b") },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "target-template",
+			}),
+		).rejects.toThrow("same deployment time");
+	});
+
+	it("fails closed when a competing deployment has no verified survivor state", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-2",
+				backupId: "other",
+				status: "PARTIAL_SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: {
+					backupData: state({
+						customFormatDeployments: [
+							{
+								beforeFormat: null,
+								action: "created",
+								resourceId: 8,
+								name: "Created",
+								status: "pending",
+								postStateToken: null,
+								intendedPostStateToken: "intended",
+							},
+						],
+					}),
+				},
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("verified Custom Format state");
+	});
+
+	it("fails closed when a competing deployment never captured ownership", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-2",
+				backupId: "other",
+				status: "PARTIAL_SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: state({ managedCustomFormatsCaptured: false }) },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("incomplete Custom Format ownership");
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
@@ -423,4 +423,346 @@ describe("active deployment ownership", () => {
 			}),
 		).rejects.toThrow("incomplete Custom Format ownership");
 	});
+
+	it("fails closed when an unrolled deployment lost its backup relation", async () => {
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						templateId: "template-1",
+						backupId: "target",
+						status: "SUCCESS",
+						deployedAt: new Date("2026-01-01"),
+						backup: null,
+					},
+				]),
+			},
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("ownership relation is missing");
+	});
+
+	it("fails closed when an unrolled sync lost its template relation", async () => {
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						templateId: null,
+						backupId: "target",
+						status: "SUCCESS",
+						startedAt: new Date("2026-01-01"),
+						backup: { backupData: state() },
+					},
+				]),
+			},
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("ownership relation is missing");
+	});
+
+	it("fails closed when a backup ID points to a missing backup row", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-2",
+				backupId: "missing",
+				status: "PARTIAL_SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: null,
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("ownership relation is missing");
+	});
+
+	it("treats malformed failed history as ambiguous active ownership", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-2",
+				backupId: "failed",
+				status: "FAILED",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: "not-json" },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("invalid ownership metadata");
+	});
+
+	it("allows shared restoration only across a matching before-state and survivor post-state chain", async () => {
+		const targetState = state({
+			customFormatDeployments: [
+				{
+					beforeFormat: { id: 7, name: "Shared" },
+					action: "updated",
+					resourceId: 7,
+					name: "Shared",
+					status: "applied",
+					postStateToken: "target-format-post",
+				},
+			],
+			qualityProfileDeployment: {
+				beforeProfile: { id: 3, name: "Profile", formatItems: [] },
+				status: "applied",
+				action: "updated",
+				profileId: 3,
+				profileName: "Profile",
+				postStateToken: "target-profile-post",
+			},
+			namingDeployment: {
+				beforeConfig: { renameMovies: false },
+				status: "applied",
+				postStateToken: "target-naming-post",
+			},
+		});
+		const survivorState = state({
+			customFormatDeployments: [
+				{
+					beforeFormat: null,
+					action: "created",
+					resourceId: 7,
+					name: "Shared",
+					status: "applied",
+					postStateToken: "373729921fc51c4805d22de8b04d62e412d8a76396f102b9af586211d75ff5d1",
+				},
+			],
+			qualityProfileDeployment: {
+				beforeProfile: { id: 3 },
+				status: "applied",
+				action: "updated",
+				profileId: 3,
+				profileName: "Profile",
+				postStateToken: "13316e449d497aebe9728f2df57001f3627a676826faf463fe6c4861fa74d825",
+			},
+			namingDeployment: {
+				beforeConfig: { renameMovies: true },
+				status: "applied",
+				postStateToken: "e790ec8f4fc6decf93f45ffbd3467dcde5f204ab1562bf4d6f9537e9c0a5b235",
+			},
+		});
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-03"),
+				backup: { backupData: targetState },
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: survivorState },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect(result.restorableSharedCustomFormatIds).toContain(7);
+		expect(result.restorableSharedQualityProfileIds).toContain(3);
+		expect(result.sharedNamingRestorationAllowed).toBe(true);
+	});
+
+	it("does not restore a shared Custom Format after manual drift broke the ownership chain", async () => {
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-03"),
+				backup: {
+					backupData: state({
+						customFormatDeployments: [
+							{
+								beforeFormat: { id: 7, name: "Manually drifted" },
+								action: "updated",
+								resourceId: 7,
+								name: "Shared",
+								status: "applied",
+								postStateToken: "target-post",
+							},
+						],
+					}),
+				},
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: {
+					backupData: state({
+						customFormatDeployments: [
+							{
+								beforeFormat: null,
+								action: "created",
+								resourceId: 7,
+								name: "Shared",
+								status: "applied",
+								postStateToken: "373729921fc51c4805d22de8b04d62e412d8a76396f102b9af586211d75ff5d1",
+							},
+						],
+					}),
+				},
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect(result.restorableSharedCustomFormatIds).not.toContain(7);
+	});
+
+	it("does not restore a shared quality profile after manual drift broke the ownership chain", async () => {
+		const profileState = (beforeProfile: Record<string, unknown> | null, postStateToken: string) =>
+			state({
+				qualityProfileDeployment: {
+					beforeProfile,
+					status: "applied",
+					action: "updated",
+					profileId: 3,
+					profileName: "Profile",
+					postStateToken,
+				},
+			});
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-03"),
+				backup: {
+					backupData: profileState(
+						{ id: 3, name: "Profile", formatItems: [{ format: 7, score: 25 }] },
+						"target-post",
+					),
+				},
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: {
+					backupData: profileState(
+						{ id: 3 },
+						"13316e449d497aebe9728f2df57001f3627a676826faf463fe6c4861fa74d825",
+					),
+				},
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect(result.restorableSharedQualityProfileIds).not.toContain(3);
+	});
+
+	it("does not restore shared naming after manual drift broke the ownership chain", async () => {
+		const namingState = (beforeConfig: Record<string, unknown>, postStateToken: string) =>
+			state({
+				namingDeployment: {
+					beforeConfig,
+					status: "applied",
+					postStateToken,
+				},
+			});
+		const rows = [
+			{
+				templateId: "target-template",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-03"),
+				backup: {
+					backupData: namingState({ renameMovies: true }, "target-post"),
+				},
+			},
+			{
+				templateId: "survivor-template",
+				backupId: "survivor",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: {
+					backupData: namingState(
+						{ renameMovies: false },
+						"e790ec8f4fc6decf93f45ffbd3467dcde5f204ab1562bf4d6f9537e9c0a5b235",
+					),
+				},
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		const result = await resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+			backupId: "target",
+			templateId: "target-template",
+		});
+
+		expect(result.sharedNamingRestorationAllowed).toBe(false);
+	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -65,4 +65,38 @@ describe("parseDeploymentBackupState", () => {
 		backup.qualityProfileDeployment.status = "unknown" as never;
 		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow();
 	});
+
+	it("rejects an applied Custom Format whose upstream ID was not captured", () => {
+		const backup = validBackup();
+		backup.customFormatDeployments = [
+			{
+				beforeFormat: null,
+				action: "created",
+				resourceId: null,
+				name: "Foo",
+				status: "applied",
+				postStateToken: "token",
+			},
+		] as never;
+
+		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow(
+			"Applied CF state requires a resource ID",
+		);
+	});
+
+	it("rejects an applied quality profile whose upstream ID was not captured", () => {
+		const backup = validBackup();
+		backup.qualityProfileDeployment = {
+			beforeProfile: null,
+			action: "created",
+			profileId: null,
+			profileName: "Any",
+			status: "applied",
+			postStateToken: "token",
+		} as never;
+
+		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow(
+			"Applied profile state requires a profile ID",
+		);
+	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { parseDeploymentBackupState } from "../deployment-backup-state.js";
+
+function validBackup() {
+	return {
+		schemaVersion: 2,
+		endpointKey: "user:RADARR:http://radarr/",
+		connectionStateToken: "connection-token",
+		customFormats: [],
+		customFormatDeployments: [],
+		managedCustomFormats: [],
+		managedCustomFormatsCaptured: false,
+		qualityProfileDeployment: {
+			beforeProfile: null,
+			status: "not_started",
+			action: "updated",
+			profileId: null,
+			postStateToken: null,
+		},
+		namingDeployment: null,
+	};
+}
+
+describe("parseDeploymentBackupState", () => {
+	it("accepts the current identity-bound schema", () => {
+		expect(parseDeploymentBackupState(JSON.stringify(validBackup())).schemaVersion).toBe(2);
+	});
+
+	it("preserves an intended post-write token used to reconcile a timed-out update", () => {
+		const backup = validBackup();
+		backup.customFormatDeployments = [
+			{
+				beforeFormat: { id: 7, name: "Foo" },
+				action: "updated",
+				resourceId: 7,
+				name: "Foo",
+				status: "pending",
+				postStateToken: null,
+				intendedPostStateToken: "intended-token",
+			},
+		] as never;
+
+		expect(
+			parseDeploymentBackupState(JSON.stringify(backup)).customFormatDeployments[0],
+		).toMatchObject({ intendedPostStateToken: "intended-token" });
+	});
+
+	it.each([0, -1, 7.5, "7"])("rejects invalid resource ID %s", (resourceId) => {
+		const backup = validBackup();
+		backup.customFormatDeployments = [
+			{
+				beforeFormat: null,
+				action: "created",
+				resourceId,
+				name: "Foo",
+				status: "applied",
+				postStateToken: "token",
+			},
+		] as never;
+		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow();
+	});
+
+	it("rejects unknown phase statuses", () => {
+		const backup = validBackup();
+		backup.qualityProfileDeployment.status = "unknown" as never;
+		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow();
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
@@ -1,85 +1,224 @@
 import { describe, expect, it, vi } from "vitest";
 import { rebindLegacyDeploymentConnectionState } from "../deployment-legacy-rebind.js";
+import { createDeploymentConnectionBinding } from "../deployment-target.js";
+
+const reviewedMapping = {
+	id: "mapping-1",
+	templateId: "template-1",
+	instanceId: "instance-1",
+	qualityProfileId: 4,
+	qualityProfileName: "HD-1080p",
+	connectionGeneration: 0,
+	connectionStateToken: null,
+};
+
+const currentInstance = {
+	id: "instance-1",
+	userId: "user-1",
+	service: "RADARR",
+	baseUrl: "http://radarr",
+	encryptedApiKey: "encrypted-key",
+	encryptionIv: "key-iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 3,
+};
+
+const legacyOverride = {
+	id: "override-1",
+	userId: "user-1",
+	instanceId: "instance-1",
+	qualityProfileId: 4,
+	customFormatId: 7,
+	score: 100,
+	status: "APPLIED",
+	intentOperation: null,
+	intendedScore: null,
+	connectionGeneration: 0,
+	connectionStateToken: null,
+};
+
+function createPrisma(
+	options: {
+		mappings?: (typeof reviewedMapping)[];
+		instances?: (typeof currentInstance)[];
+		templates?: Array<{ id: string }>;
+		overrides?: (typeof legacyOverride)[];
+		mappingUpdateCount?: number;
+		overrideUpdateCount?: number;
+		remainingLegacyOverrides?: number;
+	} = {},
+) {
+	const mappingUpdateMany = vi.fn().mockResolvedValue({ count: options.mappingUpdateCount ?? 1 });
+	const overrideUpdateMany = vi.fn().mockResolvedValue({ count: options.overrideUpdateCount ?? 1 });
+	const overrideCount = vi.fn().mockResolvedValue(options.remainingLegacyOverrides ?? 0);
+	const transaction = vi.fn(async (callback) =>
+		callback({
+			templateQualityProfileMapping: {
+				findMany: vi.fn().mockResolvedValue(options.mappings ?? [reviewedMapping]),
+				updateMany: mappingUpdateMany,
+			},
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue(options.instances ?? [currentInstance]),
+			},
+			trashTemplate: {
+				findMany: vi.fn().mockResolvedValue(options.templates ?? [{ id: "template-1" }]),
+			},
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue(options.overrides ?? [legacyOverride]),
+				updateMany: overrideUpdateMany,
+				count: overrideCount,
+			},
+		}),
+	);
+	return {
+		prisma: { $transaction: transaction },
+		mappingUpdateMany,
+		overrideUpdateMany,
+		overrideCount,
+	};
+}
 
 describe("legacy deployment connection rebind", () => {
-	it("compare-and-sets the mapping and preserves score overrides while binding them", async () => {
-		const mappingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
-		const overrideUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
-		const transaction = vi.fn(async (callback) =>
-			callback({
-				templateQualityProfileMapping: { updateMany: mappingUpdateMany },
-				instanceQualityProfileOverride: { updateMany: overrideUpdateMany },
-			}),
-		);
+	it("re-reads ownership and compare-and-sets every reviewed mapping and override identity", async () => {
+		const { prisma, mappingUpdateMany, overrideUpdateMany, overrideCount } = createPrisma();
+		const binding = createDeploymentConnectionBinding(currentInstance);
 
-		await rebindLegacyDeploymentConnectionState(
-			{ $transaction: transaction } as never,
-			"user-1",
-			[{ id: "mapping-1", instanceId: "instance-1", qualityProfileId: 4 }],
-			4,
-			[
-				{
-					instanceId: "instance-1",
-					connectionGeneration: 3,
-					connectionStateToken: "current-connection",
-				},
-			],
-		);
+		await rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+			binding,
+		]);
 
 		expect(mappingUpdateMany).toHaveBeenCalledWith({
 			where: {
 				id: "mapping-1",
+				templateId: "template-1",
+				instanceId: "instance-1",
+				qualityProfileId: 4,
+				qualityProfileName: "HD-1080p",
 				connectionGeneration: 0,
 				connectionStateToken: null,
 			},
 			data: {
 				connectionGeneration: 3,
-				connectionStateToken: "current-connection",
+				connectionStateToken: binding.connectionStateToken,
 				updatedAt: expect.any(Date),
 			},
 		});
 		expect(overrideUpdateMany).toHaveBeenCalledWith({
 			where: {
+				id: "override-1",
 				userId: "user-1",
 				instanceId: "instance-1",
 				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 100,
+				status: "APPLIED",
+				intentOperation: null,
+				intendedScore: null,
 				connectionGeneration: 0,
 				connectionStateToken: null,
 			},
 			data: {
 				connectionGeneration: 3,
-				connectionStateToken: "current-connection",
+				connectionStateToken: binding.connectionStateToken,
 			},
 		});
+		expect(overrideCount).toHaveBeenCalledOnce();
 		expect(overrideUpdateMany.mock.calls[0]?.[0].data).not.toHaveProperty("score");
 	});
 
-	it("fails the transaction when the reviewed legacy mapping changed", async () => {
-		const overrideUpdateMany = vi.fn();
-		const transaction = vi.fn(async (callback) =>
-			callback({
-				templateQualityProfileMapping: {
-					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
-				},
-				instanceQualityProfileOverride: { updateMany: overrideUpdateMany },
-			}),
-		);
+	it.each([
+		{ relation: "instance", options: { instances: [] } },
+		{ relation: "template", options: { templates: [] } },
+	])("rejects a reviewed mapping whose $relation is owned by another user", async ({ options }) => {
+		const { prisma, mappingUpdateMany } = createPrisma(options);
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(
-				{ $transaction: transaction } as never,
-				"user-1",
-				[{ id: "mapping-1", instanceId: "instance-1", qualityProfileId: 4 }],
-				4,
-				[
-					{
-						instanceId: "instance-1",
-						connectionGeneration: 3,
-						connectionStateToken: "current-connection",
-					},
-				],
-			),
-		).rejects.toThrow("changed after preview");
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+			]),
+		).rejects.toThrow("no longer authorized");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects a rebind when live credentials changed after review", async () => {
+		const reviewedBinding = createDeploymentConnectionBinding(currentInstance);
+		const { prisma, mappingUpdateMany } = createPrisma({
+			instances: [{ ...currentInstance, encryptedApiKey: "rotated-key" }],
+		});
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				reviewedBinding,
+			]),
+		).rejects.toThrow("connection changed after preview");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects a user-owned binding that no longer represents the reviewed physical endpoint", async () => {
+		const unrelatedInstance = {
+			...currentInstance,
+			id: "instance-2",
+			baseUrl: "http://other-radarr",
+		};
+		const { prisma, mappingUpdateMany } = createPrisma({
+			instances: [currentInstance, unrelatedInstance],
+		});
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+				createDeploymentConnectionBinding(unrelatedInstance),
+			]),
+		).rejects.toThrow("no longer belongs to one ARR endpoint");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ field: "ID", liveMapping: { ...reviewedMapping, qualityProfileId: 5 } },
+		{
+			field: "name",
+			liveMapping: { ...reviewedMapping, qualityProfileName: "Reused profile" },
+		},
+	])("rejects a mapping whose reviewed quality-profile $field changed", async ({ liveMapping }) => {
+		const { prisma, mappingUpdateMany } = createPrisma({ mappings: [liveMapping] });
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+			]),
+		).rejects.toThrow("mapping changed after preview");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("fails the transaction when a mapping changes during its compare-and-set", async () => {
+		const { prisma, overrideUpdateMany } = createPrisma({ mappingUpdateCount: 0 });
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+			]),
+		).rejects.toThrow("mapping changed after preview");
 		expect(overrideUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("fails the transaction when an override changes during its compare-and-set", async () => {
+		const { prisma } = createPrisma({ overrideUpdateCount: 0 });
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+			]),
+		).rejects.toThrow("score overrides changed");
+	});
+
+	it("rejects a concurrent override upsert that was not part of the reviewed set", async () => {
+		const { prisma } = createPrisma({ remainingLegacyOverrides: 1 });
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
+				createDeploymentConnectionBinding(currentInstance),
+			]),
+		).rejects.toThrow("score overrides changed");
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from "vitest";
+import { rebindLegacyDeploymentConnectionState } from "../deployment-legacy-rebind.js";
+
+describe("legacy deployment connection rebind", () => {
+	it("compare-and-sets the mapping and preserves score overrides while binding them", async () => {
+		const mappingUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const overrideUpdateMany = vi.fn().mockResolvedValue({ count: 2 });
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				templateQualityProfileMapping: { updateMany: mappingUpdateMany },
+				instanceQualityProfileOverride: { updateMany: overrideUpdateMany },
+			}),
+		);
+
+		await rebindLegacyDeploymentConnectionState(
+			{ $transaction: transaction } as never,
+			"user-1",
+			[{ id: "mapping-1", instanceId: "instance-1", qualityProfileId: 4 }],
+			4,
+			[
+				{
+					instanceId: "instance-1",
+					connectionGeneration: 3,
+					connectionStateToken: "current-connection",
+				},
+			],
+		);
+
+		expect(mappingUpdateMany).toHaveBeenCalledWith({
+			where: {
+				id: "mapping-1",
+				connectionGeneration: 0,
+				connectionStateToken: null,
+			},
+			data: {
+				connectionGeneration: 3,
+				connectionStateToken: "current-connection",
+				updatedAt: expect.any(Date),
+			},
+		});
+		expect(overrideUpdateMany).toHaveBeenCalledWith({
+			where: {
+				userId: "user-1",
+				instanceId: "instance-1",
+				qualityProfileId: 4,
+				connectionGeneration: 0,
+				connectionStateToken: null,
+			},
+			data: {
+				connectionGeneration: 3,
+				connectionStateToken: "current-connection",
+			},
+		});
+		expect(overrideUpdateMany.mock.calls[0]?.[0].data).not.toHaveProperty("score");
+	});
+
+	it("fails the transaction when the reviewed legacy mapping changed", async () => {
+		const overrideUpdateMany = vi.fn();
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				templateQualityProfileMapping: {
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+				},
+				instanceQualityProfileOverride: { updateMany: overrideUpdateMany },
+			}),
+		);
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(
+				{ $transaction: transaction } as never,
+				"user-1",
+				[{ id: "mapping-1", instanceId: "instance-1", qualityProfileId: 4 }],
+				4,
+				[
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "current-connection",
+					},
+				],
+			),
+		).rejects.toThrow("changed after preview");
+		expect(overrideUpdateMany).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
@@ -170,11 +170,11 @@ describe("legacy deployment connection rebind", () => {
 		expect(mappingUpdateMany).not.toHaveBeenCalled();
 	});
 
-	it("accepts reviewed aliases with different URLs when their credential identity matches", async () => {
+	it("accepts reviewed aliases with the same normalized URL and credential identity", async () => {
 		const alias = {
 			...currentInstance,
 			id: "instance-2",
-			baseUrl: "https://radarr.example.com",
+			baseUrl: "HTTP://RADARR:80/",
 			encryptedApiKey: "separately-encrypted-key",
 			encryptionIv: "separate-iv",
 		};
@@ -196,6 +196,34 @@ describe("legacy deployment connection rebind", () => {
 			),
 		).resolves.toBeUndefined();
 		expect(mappingUpdateMany).toHaveBeenCalledOnce();
+	});
+
+	it("rejects reviewed aliases on different URLs even when credentials match", async () => {
+		const otherEndpoint = {
+			...currentInstance,
+			id: "instance-2",
+			baseUrl: "https://other-radarr.example.com",
+			encryptedApiKey: "separately-encrypted-key",
+			encryptionIv: "separate-iv",
+		};
+		const { prisma, mappingUpdateMany } = createPrisma({
+			instances: [currentInstance, otherEndpoint],
+		});
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[
+					createDeploymentConnectionBinding(currentInstance, "same-credentials"),
+					createDeploymentConnectionBinding(otherEndpoint, "same-credentials"),
+				],
+			),
+		).rejects.toThrow("cannot be proven to belong to one ARR endpoint");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
 	});
 
 	it("rejects a user-owned binding that no longer represents the reviewed physical endpoint", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-legacy-rebind.test.ts
@@ -84,9 +84,14 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma, mappingUpdateMany, overrideUpdateMany, overrideCount } = createPrisma();
 		const binding = createDeploymentConnectionBinding(currentInstance);
 
-		await rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-			binding,
-		]);
+		await rebindLegacyDeploymentConnectionState(
+			prisma as never,
+			"user-1",
+			[reviewedMapping],
+			4,
+			[legacyOverride],
+			[binding],
+		);
 
 		expect(mappingUpdateMany).toHaveBeenCalledWith({
 			where: {
@@ -134,9 +139,14 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma, mappingUpdateMany } = createPrisma(options);
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
 		).rejects.toThrow("no longer authorized");
 		expect(mappingUpdateMany).not.toHaveBeenCalled();
 	});
@@ -148,11 +158,44 @@ describe("legacy deployment connection rebind", () => {
 		});
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				reviewedBinding,
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[reviewedBinding],
+			),
 		).rejects.toThrow("connection changed after preview");
 		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("accepts reviewed aliases with different URLs when their credential identity matches", async () => {
+		const alias = {
+			...currentInstance,
+			id: "instance-2",
+			baseUrl: "https://radarr.example.com",
+			encryptedApiKey: "separately-encrypted-key",
+			encryptionIv: "separate-iv",
+		};
+		const { prisma, mappingUpdateMany } = createPrisma({
+			instances: [currentInstance, alias],
+		});
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[
+					createDeploymentConnectionBinding(currentInstance, "same-credentials"),
+					createDeploymentConnectionBinding(alias, "same-credentials"),
+				],
+			),
+		).resolves.toBeUndefined();
+		expect(mappingUpdateMany).toHaveBeenCalledOnce();
 	});
 
 	it("rejects a user-owned binding that no longer represents the reviewed physical endpoint", async () => {
@@ -166,11 +209,18 @@ describe("legacy deployment connection rebind", () => {
 		});
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-				createDeploymentConnectionBinding(unrelatedInstance),
-			]),
-		).rejects.toThrow("no longer belongs to one ARR endpoint");
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[
+					createDeploymentConnectionBinding(currentInstance),
+					createDeploymentConnectionBinding(unrelatedInstance),
+				],
+			),
+		).rejects.toThrow("cannot be proven to belong to one ARR endpoint");
 		expect(mappingUpdateMany).not.toHaveBeenCalled();
 	});
 
@@ -184,10 +234,33 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma, mappingUpdateMany } = createPrisma({ mappings: [liveMapping] });
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
 		).rejects.toThrow("mapping changed after preview");
+		expect(mappingUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects a score override whose reviewed value changed before the transaction", async () => {
+		const { prisma, mappingUpdateMany } = createPrisma({
+			overrides: [{ ...legacyOverride, score: 200 }],
+		});
+
+		await expect(
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
+		).rejects.toThrow("score overrides changed after preview");
 		expect(mappingUpdateMany).not.toHaveBeenCalled();
 	});
 
@@ -195,9 +268,14 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma, overrideUpdateMany } = createPrisma({ mappingUpdateCount: 0 });
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
 		).rejects.toThrow("mapping changed after preview");
 		expect(overrideUpdateMany).not.toHaveBeenCalled();
 	});
@@ -206,9 +284,14 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma } = createPrisma({ overrideUpdateCount: 0 });
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
 		).rejects.toThrow("score overrides changed");
 	});
 
@@ -216,9 +299,14 @@ describe("legacy deployment connection rebind", () => {
 		const { prisma } = createPrisma({ remainingLegacyOverrides: 1 });
 
 		await expect(
-			rebindLegacyDeploymentConnectionState(prisma as never, "user-1", [reviewedMapping], 4, [
-				createDeploymentConnectionBinding(currentInstance),
-			]),
+			rebindLegacyDeploymentConnectionState(
+				prisma as never,
+				"user-1",
+				[reviewedMapping],
+				4,
+				[legacyOverride],
+				[createDeploymentConnectionBinding(currentInstance)],
+			),
 		).rejects.toThrow("score overrides changed");
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -1,0 +1,525 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	assertNoActiveDeploymentOwnership,
+	assertNoPendingDeploymentOperation,
+	reconcileInterruptedDeploymentHistories,
+} from "../deployment-operation-gate.js";
+
+function backup(status: "pending" | "applied") {
+	return {
+		id: "backup-1",
+		backupData: JSON.stringify({
+			schemaVersion: 2,
+			endpointKey: "endpoint",
+			connectionStateToken: "connection",
+			customFormats: [],
+			customFormatDeployments: [
+				{
+					beforeFormat: { id: 7, name: "Foo" },
+					action: "updated",
+					resourceId: 7,
+					name: "Foo",
+					status,
+					postStateToken: status === "applied" ? "post" : null,
+				},
+			],
+			managedCustomFormats: [],
+			managedCustomFormatsCaptured: false,
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "not_started",
+				action: "updated",
+				profileId: null,
+				postStateToken: null,
+			},
+			namingDeployment: null,
+		}),
+	};
+}
+
+function fullyAppliedBackup() {
+	return {
+		id: "backup-1",
+		backupData: JSON.stringify({
+			schemaVersion: 2,
+			endpointKey: "endpoint",
+			connectionStateToken: "connection",
+			customFormats: [],
+			customFormatDeployments: [
+				{
+					beforeFormat: null,
+					action: "created",
+					resourceId: 7,
+					name: "Created CF",
+					status: "applied",
+					postStateToken: "created-post",
+				},
+				{
+					beforeFormat: { id: 8, name: "Updated CF" },
+					action: "updated",
+					resourceId: 8,
+					name: "Updated CF",
+					status: "applied",
+					postStateToken: "updated-post",
+				},
+			],
+			managedCustomFormats: [],
+			managedCustomFormatsCaptured: true,
+			qualityProfileDeployment: {
+				beforeProfile: { id: 9, name: "HD-1080p" },
+				status: "applied",
+				action: "updated",
+				profileId: 9,
+				profileName: "HD-1080p",
+				postStateToken: "profile-post",
+			},
+			namingDeployment: {
+				beforeConfig: { renameEpisodes: false },
+				status: "applied",
+				postStateToken: "naming-post",
+			},
+		}),
+	};
+}
+
+describe("assertNoPendingDeploymentOperation", () => {
+	it("blocks endpoint mutations while a rollback is partial and retryable", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ rollbackStatus: "PARTIAL", backup: fullyAppliedBackup() }]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("unfinished rollback");
+	});
+
+	it("blocks endpoint mutations while an undeploy is partial and retryable", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						status: "SUCCESS",
+						undeployStatus: "PARTIAL",
+						backup: fullyAppliedBackup(),
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("unfinished undeploy");
+	});
+
+	it("blocks a new mutation when a durable pending state exists", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([{ backup: backup("pending") }]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("uncertain upstream result");
+	});
+
+	it("allows a fully verified operation", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([{ backup: backup("applied") }]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).resolves.toBeUndefined();
+	});
+
+	it("fails closed when a current backup ledger is malformed", async () => {
+		const malformed = backup("pending");
+		malformed.backupData = JSON.stringify({ schemaVersion: 2, customFormatDeployments: [] });
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([{ backup: malformed }]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("invalid deployment ledger");
+	});
+
+	it("does not treat a legacy array backup as a pending ledger", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ backup: { id: "legacy", backupData: JSON.stringify([]) } }]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks unrelated mutations while a score write is uncertain", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([{ qualityProfileId: 4, customFormatId: 7 }]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("score write has an uncertain upstream result");
+	});
+
+	it("allows an exact score-write retry to reconcile uncertain intent", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						qualityProfileId: 4,
+						customFormatId: 7,
+						intentOperation: "RESET_SCORE",
+						intendedScore: 100,
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"], {
+				qualityProfileId: 4,
+				operation: "RESET_SCORE",
+				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it.each([
+		{
+			name: "operation",
+			retry: {
+				qualityProfileId: 4,
+				operation: "SET_SCORE" as const,
+				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+			},
+		},
+		{
+			name: "intended score",
+			retry: {
+				qualityProfileId: 4,
+				operation: "RESET_SCORE" as const,
+				scoreUpdates: [{ customFormatId: 7, score: 200 }],
+			},
+		},
+		{
+			name: "Custom Format set",
+			retry: {
+				qualityProfileId: 4,
+				operation: "RESET_SCORE" as const,
+				scoreUpdates: [{ customFormatId: 8, score: 100 }],
+			},
+		},
+	])("blocks a retry whose $name does not match the durable intent", async ({ retry }) => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						qualityProfileId: 4,
+						customFormatId: 7,
+						intentOperation: "RESET_SCORE",
+						intendedScore: 100,
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"], retry),
+		).rejects.toThrow("exact score update");
+	});
+});
+
+describe("assertNoActiveDeploymentOwnership", () => {
+	it("blocks a connection change that would strand an applied deployment", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi.fn().mockResolvedValue([{ backup: fullyAppliedBackup() }]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoActiveDeploymentOwnership(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("active deployment ownership");
+	});
+
+	it("allows a connection change after all deployment ledgers are rolled back", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoActiveDeploymentOwnership(prisma as never, "user-1", ["instance-1"]),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("reconcileInterruptedDeploymentHistories", () => {
+	it("marks an interrupted undeploy partial without rewriting deployment status", async () => {
+		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const findMany = vi.fn().mockResolvedValue([
+			{
+				id: "deployment-undeploy",
+				backupId: "backup-1",
+				backup: fullyAppliedBackup(),
+				status: "SUCCESS",
+				undeployStatus: "IN_PROGRESS",
+			},
+		]);
+		const prisma = {
+			templateDeploymentHistory: { findMany, update: deploymentUpdate },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { OR: [{ status: "IN_PROGRESS" }, { undeployStatus: "IN_PROGRESS" }] },
+			}),
+		);
+		expect(deploymentUpdate).toHaveBeenCalledWith({
+			where: { id: "deployment-undeploy" },
+			data: { undeployStatus: "PARTIAL" },
+		});
+	});
+
+	it("marks an interrupted rollback partial without rewriting deployment status", async () => {
+		const syncUpdate = vi.fn().mockResolvedValue({});
+		const findMany = vi.fn().mockResolvedValue([
+			{
+				id: "sync-rollback",
+				backupId: "backup-1",
+				backup: fullyAppliedBackup(),
+				rollbackStatus: "IN_PROGRESS",
+			},
+		]);
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: { findMany, update: syncUpdate },
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					OR: [{ status: { in: ["IN_PROGRESS", "RUNNING"] } }, { rollbackStatus: "IN_PROGRESS" }],
+				},
+			}),
+		);
+		expect(syncUpdate).toHaveBeenCalledWith({
+			where: { id: "sync-rollback" },
+			data: { rollbackStatus: "PARTIAL" },
+		});
+	});
+
+	it("atomically marks paired histories failed while preserving a pending safety gate", async () => {
+		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				templateDeploymentHistory: { update: deploymentUpdate },
+				trashSyncHistory: { updateMany: syncUpdateMany },
+			}),
+		);
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "deployment-1", backupId: "backup-1", backup: backup("pending") },
+					]),
+			},
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: backup("pending") }]),
+			},
+			$transaction: transaction,
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(transaction).toHaveBeenCalledTimes(1);
+		expect(deploymentUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ status: "FAILED" }) }),
+		);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "FAILED",
+					errorLog: expect.stringContaining("uncertain"),
+				}),
+			}),
+		);
+	});
+
+	it("reconciles an orphan sync history even when no template history was created", async () => {
+		const syncUpdate = vi.fn().mockResolvedValue({});
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: backup("applied") }]),
+				update: syncUpdate,
+			},
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(syncUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "sync-1" },
+				data: expect.objectContaining({
+					status: "PARTIAL_SUCCESS",
+					configsApplied: 1,
+					configsFailed: 1,
+					appliedConfigs: JSON.stringify([{ name: "Foo", action: "updated" }]),
+				}),
+			}),
+		);
+	});
+
+	it("reconstructs applied counters and details from a durable ledger", async () => {
+		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				templateDeploymentHistory: { update: deploymentUpdate },
+				trashSyncHistory: { updateMany: syncUpdateMany },
+			}),
+		);
+		const durableBackup = fullyAppliedBackup();
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "deployment-1", backupId: "backup-1", backup: durableBackup }]),
+			},
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: durableBackup }]),
+			},
+			$transaction: transaction,
+		};
+		const appliedConfigs = [
+			{ name: "Created CF", action: "created" },
+			{ name: "Updated CF", action: "updated" },
+			{
+				name: "HD-1080p",
+				action: "updated",
+				type: "quality_profile",
+				id: 9,
+			},
+			{ name: "Naming configuration", action: "updated" },
+		];
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(deploymentUpdate).toHaveBeenCalledWith({
+			where: { id: "deployment-1" },
+			data: expect.objectContaining({
+				status: "PARTIAL_SUCCESS",
+				appliedCFs: 2,
+				appliedConfigs: JSON.stringify(appliedConfigs),
+			}),
+		});
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: {
+				backupId: "backup-1",
+				status: { in: ["IN_PROGRESS", "RUNNING"] },
+			},
+			data: expect.objectContaining({
+				status: "PARTIAL_SUCCESS",
+				configsApplied: 4,
+				configsFailed: 1,
+				appliedConfigs: JSON.stringify(appliedConfigs),
+			}),
+		});
+	});
+
+	it("reconciles a RUNNING sync without a deployment backup", async () => {
+		const syncUpdate = vi.fn().mockResolvedValue({});
+		const findMany = vi
+			.fn()
+			.mockResolvedValue([{ id: "sync-running", backupId: null, backup: null }]);
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: { findMany, update: syncUpdate },
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					OR: [{ status: { in: ["IN_PROGRESS", "RUNNING"] } }, { rollbackStatus: "IN_PROGRESS" }],
+				},
+			}),
+		);
+		expect(syncUpdate).toHaveBeenCalledWith({
+			where: { id: "sync-running" },
+			data: expect.objectContaining({
+				status: "FAILED",
+				completedAt: expect.any(Date),
+				errorLog: expect.stringContaining("restarted"),
+			}),
+		});
+	});
+
+	it("uses a non-claiming failure when applied profile details are incomplete", async () => {
+		const syncUpdate = vi.fn().mockResolvedValue({});
+		const incomplete = fullyAppliedBackup();
+		const backupData = JSON.parse(incomplete.backupData);
+		backupData.customFormatDeployments = [];
+		backupData.namingDeployment = null;
+		backupData.qualityProfileDeployment.profileId = null;
+		incomplete.backupData = JSON.stringify(backupData);
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: incomplete }]),
+				update: syncUpdate,
+			},
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(syncUpdate).toHaveBeenCalledWith({
+			where: { id: "sync-1" },
+			data: expect.not.objectContaining({
+				configsApplied: expect.anything(),
+				appliedConfigs: expect.anything(),
+			}),
+		});
+		expect(syncUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ status: "FAILED" }) }),
+		);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -96,6 +96,20 @@ function mixedAppliedAndPendingBackup() {
 	return { ...result, backupData: JSON.stringify(state) };
 }
 
+function mixedPendingAndIncompleteAppliedProfileBackup() {
+	const result = mixedAppliedAndPendingBackup();
+	const state = JSON.parse(result.backupData);
+	state.qualityProfileDeployment = {
+		beforeProfile: { id: 9, name: "HD-1080p" },
+		status: "applied",
+		action: "updated",
+		profileId: 9,
+		profileName: null,
+		postStateToken: "profile-post",
+	};
+	return { ...result, backupData: JSON.stringify(state) };
+}
+
 describe("assertNoPendingDeploymentOperation", () => {
 	it("blocks endpoint mutations while a rollback is partial and retryable", async () => {
 		const prisma = {
@@ -766,6 +780,51 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 					status: "UNCERTAIN",
 					configsApplied: 1,
 					configsFailed: 0,
+					appliedConfigs: JSON.stringify(appliedConfigs),
+				}),
+			}),
+		);
+	});
+
+	it("lets pending state dominate incomplete applied-profile audit metadata", async () => {
+		const interruptedBackup = mixedPendingAndIncompleteAppliedProfileBackup();
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{ id: "deployment-1", backupId: "backup-1", backup: interruptedBackup },
+				]),
+			},
+			trashSyncHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{ id: "sync-1", backupId: "backup-1", backup: interruptedBackup },
+				]),
+			},
+			$transaction: vi.fn(async (callback) =>
+				callback({
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+					trashSyncHistory: { updateMany: syncUpdateMany },
+				}),
+			),
+		};
+		const appliedConfigs = [{ name: "Applied CF", action: "updated" }];
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(deploymentUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					appliedCFs: 1,
+					appliedConfigs: JSON.stringify(appliedConfigs),
+				}),
+			}),
+		);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					configsApplied: 1,
 					appliedConfigs: JSON.stringify(appliedConfigs),
 				}),
 			}),

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -165,6 +165,83 @@ describe("assertNoPendingDeploymentOperation", () => {
 		).resolves.toBeUndefined();
 	});
 
+	it("allows a terminal legacy history with no pending marker to start a reviewed deployment", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ status: "FAILED", rollbackStatus: null, backupId: null, backup: null },
+					]),
+			},
+			templateDeploymentHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ status: "SUCCESS", undeployStatus: null, backupId: null, backup: null },
+					]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks a transient sync whose backup relation is missing", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ status: "RUNNING", rollbackStatus: null, backupId: null, backup: null },
+					]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("uncertain upstream result");
+	});
+
+	it("blocks a transient deployment whose backup relation is missing", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						status: "IN_PROGRESS",
+						undeployStatus: null,
+						backupId: null,
+						backup: null,
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("uncertain upstream result");
+	});
+
+	it("blocks a partial history whose backup relation disappeared", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ status: "PARTIAL_SUCCESS", rollbackStatus: null, backupId: "missing", backup: null },
+					]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("uncertain upstream result");
+	});
+
 	it("blocks unrelated mutations while a score write is uncertain", async () => {
 		const prisma = {
 			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
@@ -186,10 +263,13 @@ describe("assertNoPendingDeploymentOperation", () => {
 			instanceQualityProfileOverride: {
 				findMany: vi.fn().mockResolvedValue([
 					{
+						instanceId: "instance-1",
 						qualityProfileId: 4,
 						customFormatId: 7,
 						intentOperation: "RESET_SCORE",
 						intendedScore: 100,
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
 					},
 				]),
 			},
@@ -200,8 +280,143 @@ describe("assertNoPendingDeploymentOperation", () => {
 				qualityProfileId: 4,
 				operation: "RESET_SCORE",
 				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				],
 			}),
 		).resolves.toBeUndefined();
+	});
+
+	it("does not let an exact retry for one profile bypass another uncertain profile", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: "instance-1",
+						qualityProfileId: 4,
+						customFormatId: 7,
+						intentOperation: "RESET_SCORE",
+						intendedScore: 100,
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+					{
+						instanceId: "instance-1",
+						qualityProfileId: 5,
+						customFormatId: 8,
+						intentOperation: "SET_SCORE",
+						intendedScore: 200,
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"], {
+				qualityProfileId: 4,
+				operation: "RESET_SCORE",
+				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				],
+			}),
+		).rejects.toThrow("exact score update");
+	});
+
+	it("allows one exact retry across duplicate records for the same physical endpoint", async () => {
+		const uncertain = (instanceId: string, token: string) => ({
+			instanceId,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			intentOperation: "RESET_SCORE",
+			intendedScore: 100,
+			connectionGeneration: 3,
+			connectionStateToken: token,
+		});
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						uncertain("instance-1", "connection-1"),
+						uncertain("instance-alias", "connection-alias"),
+					]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(
+				prisma as never,
+				"user-1",
+				["instance-1", "instance-alias"],
+				{
+					qualityProfileId: 4,
+					operation: "RESET_SCORE",
+					scoreUpdates: [{ customFormatId: 7, score: 100 }],
+					connectionBindings: [
+						{
+							instanceId: "instance-1",
+							connectionGeneration: 3,
+							connectionStateToken: "connection-1",
+						},
+						{
+							instanceId: "instance-alias",
+							connectionGeneration: 3,
+							connectionStateToken: "connection-alias",
+						},
+					],
+				},
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks a retry bound to stale connection state", async () => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: "instance-1",
+						qualityProfileId: 4,
+						customFormatId: 7,
+						intentOperation: "RESET_SCORE",
+						intendedScore: 100,
+						connectionGeneration: 2,
+						connectionStateToken: "stale-connection",
+					},
+				]),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"], {
+				qualityProfileId: 4,
+				operation: "RESET_SCORE",
+				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "current-connection",
+					},
+				],
+			}),
+		).rejects.toThrow("exact score update");
 	});
 
 	it.each([
@@ -211,6 +426,13 @@ describe("assertNoPendingDeploymentOperation", () => {
 				qualityProfileId: 4,
 				operation: "SET_SCORE" as const,
 				scoreUpdates: [{ customFormatId: 7, score: 100 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				],
 			},
 		},
 		{
@@ -219,6 +441,13 @@ describe("assertNoPendingDeploymentOperation", () => {
 				qualityProfileId: 4,
 				operation: "RESET_SCORE" as const,
 				scoreUpdates: [{ customFormatId: 7, score: 200 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				],
 			},
 		},
 		{
@@ -227,6 +456,13 @@ describe("assertNoPendingDeploymentOperation", () => {
 				qualityProfileId: 4,
 				operation: "RESET_SCORE" as const,
 				scoreUpdates: [{ customFormatId: 8, score: 100 }],
+				connectionBindings: [
+					{
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
+					},
+				],
 			},
 		},
 	])("blocks a retry whose $name does not match the durable intent", async ({ retry }) => {
@@ -240,6 +476,9 @@ describe("assertNoPendingDeploymentOperation", () => {
 						customFormatId: 7,
 						intentOperation: "RESET_SCORE",
 						intendedScore: 100,
+						instanceId: "instance-1",
+						connectionGeneration: 3,
+						connectionStateToken: "connection-1",
 					},
 				]),
 			},
@@ -275,11 +514,26 @@ describe("assertNoActiveDeploymentOwnership", () => {
 			assertNoActiveDeploymentOwnership(prisma as never, "user-1", ["instance-1"]),
 		).resolves.toBeUndefined();
 	});
+
+	it("blocks connection replacement when an unrolled history lost its backup relation", async () => {
+		const prisma = {
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ status: "SUCCESS", backupId: "missing", backup: null }]),
+			},
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			assertNoActiveDeploymentOwnership(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("active deployment ownership");
+	});
 });
 
 describe("reconcileInterruptedDeploymentHistories", () => {
 	it("marks an interrupted undeploy partial without rewriting deployment status", async () => {
-		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const findMany = vi.fn().mockResolvedValue([
 			{
 				id: "deployment-undeploy",
@@ -290,7 +544,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 			},
 		]);
 		const prisma = {
-			templateDeploymentHistory: { findMany, update: deploymentUpdate },
+			templateDeploymentHistory: { findMany, updateMany: deploymentUpdateMany },
 			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
 			$transaction: vi.fn(),
 		};
@@ -301,14 +555,14 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				where: { OR: [{ status: "IN_PROGRESS" }, { undeployStatus: "IN_PROGRESS" }] },
 			}),
 		);
-		expect(deploymentUpdate).toHaveBeenCalledWith({
-			where: { id: "deployment-undeploy" },
+		expect(deploymentUpdateMany).toHaveBeenCalledWith({
+			where: { id: "deployment-undeploy", undeployStatus: "IN_PROGRESS" },
 			data: { undeployStatus: "PARTIAL" },
 		});
 	});
 
 	it("marks an interrupted rollback partial without rewriting deployment status", async () => {
-		const syncUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const findMany = vi.fn().mockResolvedValue([
 			{
 				id: "sync-rollback",
@@ -319,7 +573,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		]);
 		const prisma = {
 			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			trashSyncHistory: { findMany, update: syncUpdate },
+			trashSyncHistory: { findMany, updateMany: syncUpdateMany },
 			$transaction: vi.fn(),
 		};
 
@@ -331,18 +585,18 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				},
 			}),
 		);
-		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { id: "sync-rollback" },
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: { id: "sync-rollback", rollbackStatus: "IN_PROGRESS" },
 			data: { rollbackStatus: "PARTIAL" },
 		});
 	});
 
 	it("atomically marks paired histories failed while preserving a pending safety gate", async () => {
-		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const transaction = vi.fn(async (callback) =>
 			callback({
-				templateDeploymentHistory: { update: deploymentUpdate },
+				templateDeploymentHistory: { updateMany: deploymentUpdateMany },
 				trashSyncHistory: { updateMany: syncUpdateMany },
 			}),
 		);
@@ -364,8 +618,11 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
 		expect(transaction).toHaveBeenCalledTimes(1);
-		expect(deploymentUpdate).toHaveBeenCalledWith(
-			expect.objectContaining({ data: expect.objectContaining({ status: "FAILED" }) }),
+		expect(deploymentUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "deployment-1", status: "IN_PROGRESS" },
+				data: expect.objectContaining({ status: "FAILED" }),
+			}),
 		);
 		expect(syncUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
@@ -378,22 +635,22 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 	});
 
 	it("reconciles an orphan sync history even when no template history was created", async () => {
-		const syncUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const prisma = {
 			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
 			trashSyncHistory: {
 				findMany: vi
 					.fn()
 					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: backup("applied") }]),
-				update: syncUpdate,
+				updateMany: syncUpdateMany,
 			},
 			$transaction: vi.fn(),
 		};
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
-		expect(syncUpdate).toHaveBeenCalledWith(
+		expect(syncUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "sync-1" },
+				where: { id: "sync-1", status: { in: ["IN_PROGRESS", "RUNNING"] } },
 				data: expect.objectContaining({
 					status: "PARTIAL_SUCCESS",
 					configsApplied: 1,
@@ -405,11 +662,11 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 	});
 
 	it("reconstructs applied counters and details from a durable ledger", async () => {
-		const deploymentUpdate = vi.fn().mockResolvedValue({});
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const transaction = vi.fn(async (callback) =>
 			callback({
-				templateDeploymentHistory: { update: deploymentUpdate },
+				templateDeploymentHistory: { updateMany: deploymentUpdateMany },
 				trashSyncHistory: { updateMany: syncUpdateMany },
 			}),
 		);
@@ -440,8 +697,8 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		];
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
-		expect(deploymentUpdate).toHaveBeenCalledWith({
-			where: { id: "deployment-1" },
+		expect(deploymentUpdateMany).toHaveBeenCalledWith({
+			where: { id: "deployment-1", status: "IN_PROGRESS" },
 			data: expect.objectContaining({
 				status: "PARTIAL_SUCCESS",
 				appliedCFs: 2,
@@ -463,13 +720,13 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 	});
 
 	it("reconciles a RUNNING sync without a deployment backup", async () => {
-		const syncUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const findMany = vi
 			.fn()
 			.mockResolvedValue([{ id: "sync-running", backupId: null, backup: null }]);
 		const prisma = {
 			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
-			trashSyncHistory: { findMany, update: syncUpdate },
+			trashSyncHistory: { findMany, updateMany: syncUpdateMany },
 			$transaction: vi.fn(),
 		};
 
@@ -481,8 +738,8 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				},
 			}),
 		);
-		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { id: "sync-running" },
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: { id: "sync-running", status: { in: ["IN_PROGRESS", "RUNNING"] } },
 			data: expect.objectContaining({
 				status: "FAILED",
 				completedAt: expect.any(Date),
@@ -492,7 +749,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 	});
 
 	it("uses a non-claiming failure when applied profile details are incomplete", async () => {
-		const syncUpdate = vi.fn().mockResolvedValue({});
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const incomplete = fullyAppliedBackup();
 		const backupData = JSON.parse(incomplete.backupData);
 		backupData.customFormatDeployments = [];
@@ -505,21 +762,132 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				findMany: vi
 					.fn()
 					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: incomplete }]),
-				update: syncUpdate,
+				updateMany: syncUpdateMany,
 			},
 			$transaction: vi.fn(),
 		};
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
-		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { id: "sync-1" },
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: { id: "sync-1", status: { in: ["IN_PROGRESS", "RUNNING"] } },
 			data: expect.not.objectContaining({
 				configsApplied: expect.anything(),
 				appliedConfigs: expect.anything(),
 			}),
 		});
-		expect(syncUpdate).toHaveBeenCalledWith(
+		expect(syncUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({ data: expect.objectContaining({ status: "FAILED" }) }),
+		);
+	});
+
+	it("does not overwrite a deployment that became terminal before reconciliation", async () => {
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const pairedSyncUpdateMany = vi.fn();
+		const transaction = vi.fn(async (callback) =>
+			callback({
+				templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				trashSyncHistory: { updateMany: pairedSyncUpdateMany },
+			}),
+		);
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "deployment-race", backupId: "backup-1", backup: backup("pending") },
+					]),
+			},
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "sync-pair", backupId: "backup-1", backup: backup("pending") },
+					]),
+				updateMany: pairedSyncUpdateMany,
+			},
+			$transaction: transaction,
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(0);
+		expect(deploymentUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "deployment-race", status: "IN_PROGRESS" },
+			}),
+		);
+		expect(pairedSyncUpdateMany).not.toHaveBeenCalled();
+	});
+
+	it("does not overwrite an undeploy that became terminal before reconciliation", async () => {
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						id: "undeploy-race",
+						backupId: "backup-1",
+						status: "SUCCESS",
+						undeployStatus: "IN_PROGRESS",
+						backup: fullyAppliedBackup(),
+					},
+				]),
+				updateMany: deploymentUpdateMany,
+			},
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(0);
+		expect(deploymentUpdateMany).toHaveBeenCalledWith({
+			where: { id: "undeploy-race", undeployStatus: "IN_PROGRESS" },
+			data: { undeployStatus: "PARTIAL" },
+		});
+	});
+
+	it("does not overwrite a rollback that became terminal before reconciliation", async () => {
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						id: "rollback-race",
+						backupId: "backup-1",
+						rollbackStatus: "IN_PROGRESS",
+						backup: fullyAppliedBackup(),
+					},
+				]),
+				updateMany: syncUpdateMany,
+			},
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(0);
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: { id: "rollback-race", rollbackStatus: "IN_PROGRESS" },
+			data: { rollbackStatus: "PARTIAL" },
+		});
+	});
+
+	it("does not overwrite an orphan sync that became terminal before reconciliation", async () => {
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 0 });
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "sync-race", backupId: "backup-1", backup: backup("applied") },
+					]),
+				updateMany: syncUpdateMany,
+			},
+			$transaction: vi.fn(),
+		};
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(0);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "sync-race", status: { in: ["IN_PROGRESS", "RUNNING"] } },
+			}),
 		);
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -532,6 +532,75 @@ describe("assertNoActiveDeploymentOwnership", () => {
 });
 
 describe("reconcileInterruptedDeploymentHistories", () => {
+	it.each([
+		{ label: "missing", backup: null },
+		{ label: "invalid", backup: { id: "backup-invalid", backupData: "not-json" } },
+	])(
+		"keeps a restarted $label-ledger operation blocked after reconciliation",
+		async ({ backup: interruptedBackup }) => {
+			const deploymentRow = {
+				id: "deployment-uncertain",
+				status: "IN_PROGRESS",
+				undeployStatus: null,
+				backupId: interruptedBackup?.id ?? null,
+				backup: interruptedBackup,
+			};
+			const syncRow = {
+				id: "sync-uncertain",
+				status: "RUNNING",
+				rollbackStatus: null,
+				backupId: interruptedBackup?.id ?? null,
+				backup: interruptedBackup,
+			};
+			const updateDeployment = vi.fn(async ({ where, data }) => {
+				if (deploymentRow.id !== where.id || deploymentRow.status !== where.status) {
+					return { count: 0 };
+				}
+				Object.assign(deploymentRow, data);
+				return { count: 1 };
+			});
+			const updateSync = vi.fn(async ({ where, data }) => {
+				const statusMatches = Array.isArray(where.status?.in)
+					? where.status.in.includes(syncRow.status)
+					: syncRow.status === where.status;
+				if (
+					(where.id !== undefined && syncRow.id !== where.id) ||
+					(where.backupId !== undefined && syncRow.backupId !== where.backupId) ||
+					!statusMatches
+				) {
+					return { count: 0 };
+				}
+				Object.assign(syncRow, data);
+				return { count: 1 };
+			});
+			const prisma = {
+				templateDeploymentHistory: {
+					findMany: vi.fn().mockResolvedValue([deploymentRow]),
+					updateMany: updateDeployment,
+				},
+				trashSyncHistory: {
+					findMany: vi.fn().mockResolvedValue([syncRow]),
+					updateMany: updateSync,
+				},
+				$transaction: vi.fn(async (callback) =>
+					callback({
+						templateDeploymentHistory: { updateMany: updateDeployment },
+						trashSyncHistory: { updateMany: updateSync },
+					}),
+				),
+			};
+
+			await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(
+				interruptedBackup ? 1 : 2,
+			);
+			expect(deploymentRow.status).toBe("UNCERTAIN");
+			expect(syncRow.status).toBe("UNCERTAIN");
+			await expect(
+				assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+			).rejects.toThrow("uncertain upstream result");
+		},
+	);
+
 	it("marks an interrupted undeploy partial without rewriting deployment status", async () => {
 		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const findMany = vi.fn().mockResolvedValue([
@@ -741,9 +810,9 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		expect(syncUpdateMany).toHaveBeenCalledWith({
 			where: { id: "sync-running", status: { in: ["IN_PROGRESS", "RUNNING"] } },
 			data: expect.objectContaining({
-				status: "FAILED",
+				status: "UNCERTAIN",
 				completedAt: expect.any(Date),
-				errorLog: expect.stringContaining("restarted"),
+				errorLog: expect.stringContaining("uncertain"),
 			}),
 		});
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -82,6 +82,20 @@ function fullyAppliedBackup() {
 	};
 }
 
+function mixedAppliedAndPendingBackup() {
+	const result = backup("pending");
+	const state = JSON.parse(result.backupData);
+	state.customFormatDeployments.unshift({
+		beforeFormat: { id: 8, name: "Applied CF" },
+		action: "updated",
+		resourceId: 8,
+		name: "Applied CF",
+		status: "applied",
+		postStateToken: "applied-post",
+	});
+	return { ...result, backupData: JSON.stringify(state) };
+}
+
 describe("assertNoPendingDeploymentOperation", () => {
 	it("blocks endpoint mutations while a rollback is partial and retryable", async () => {
 		const prisma = {
@@ -660,7 +674,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		});
 	});
 
-	it("atomically marks paired histories failed while preserving a pending safety gate", async () => {
+	it("atomically marks paired pending histories uncertain while preserving the safety gate", async () => {
 		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const transaction = vi.fn(async (callback) =>
@@ -690,14 +704,69 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		expect(deploymentUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				where: { id: "deployment-1", status: "IN_PROGRESS" },
-				data: expect.objectContaining({ status: "FAILED" }),
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					appliedCFs: 0,
+					appliedConfigs: "[]",
+				}),
 			}),
 		);
 		expect(syncUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
-					status: "FAILED",
+					status: "UNCERTAIN",
+					configsApplied: 0,
+					configsFailed: 0,
+					appliedConfigs: "[]",
 					errorLog: expect.stringContaining("uncertain"),
+				}),
+			}),
+		);
+	});
+
+	it("keeps mixed applied and pending histories uncertain while preserving proven audit", async () => {
+		const interruptedBackup = mixedAppliedAndPendingBackup();
+		const deploymentUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const prisma = {
+			templateDeploymentHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "deployment-1", backupId: "backup-1", backup: interruptedBackup },
+					]),
+			},
+			trashSyncHistory: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: interruptedBackup }]),
+			},
+			$transaction: vi.fn(async (callback) =>
+				callback({
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+					trashSyncHistory: { updateMany: syncUpdateMany },
+				}),
+			),
+		};
+		const appliedConfigs = [{ name: "Applied CF", action: "updated" }];
+
+		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
+		expect(deploymentUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					appliedCFs: 1,
+					appliedConfigs: JSON.stringify(appliedConfigs),
+				}),
+			}),
+		);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					configsApplied: 1,
+					configsFailed: 0,
+					appliedConfigs: JSON.stringify(appliedConfigs),
 				}),
 			}),
 		);

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -817,7 +817,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		});
 	});
 
-	it("uses a non-claiming failure when applied profile details are incomplete", async () => {
+	it("marks recovery uncertain when applied profile details are incomplete", async () => {
 		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const incomplete = fullyAppliedBackup();
 		const backupData = JSON.parse(incomplete.backupData);
@@ -845,7 +845,12 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 			}),
 		});
 		expect(syncUpdateMany).toHaveBeenCalledWith(
-			expect.objectContaining({ data: expect.objectContaining({ status: "FAILED" }) }),
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					errorLog: expect.stringContaining("upstream result is uncertain"),
+				}),
+			}),
 		);
 	});
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -12,6 +12,7 @@ import {
 	createQualityProfileStateToken,
 	getEquivalentServiceInstanceIds,
 	resolveDeploymentTarget,
+	type DeploymentProfileMapping,
 } from "../deployment-target.js";
 
 const profiles = [
@@ -98,7 +99,12 @@ describe("resolveDeploymentTarget", () => {
 		expect(() =>
 			resolveDeploymentTarget({
 				profiles,
-				mapping: { qualityProfileId: 99, qualityProfileName: "Deleted profile" },
+				mapping: {
+					qualityProfileId: 99,
+					qualityProfileName: "Deleted profile",
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
 				sourceProfileName: "Any",
 				templateName: "Radarr - Any",
 			}),
@@ -140,6 +146,8 @@ describe("resolveDeploymentTarget", () => {
 						templateId: "template-2",
 						qualityProfileId: 1,
 						qualityProfileName: "Any",
+						connectionGeneration: 0,
+						connectionStateToken: null,
 					},
 				],
 			}),
@@ -161,6 +169,8 @@ describe("resolveDeploymentTarget", () => {
 						templateId: "template-1",
 						qualityProfileId: 1,
 						qualityProfileName: "Any",
+						connectionGeneration: 0,
+						connectionStateToken: null,
 					},
 				],
 			}),
@@ -175,8 +185,20 @@ describe("resolveDeploymentTarget", () => {
 				target,
 				templateId: "template-1",
 				existingMappings: [
-					{ templateId: "template-1", qualityProfileId: 1, qualityProfileName: "Any" },
-					{ templateId: "template-2", qualityProfileId: 99, qualityProfileName: "Any" },
+					{
+						templateId: "template-1",
+						qualityProfileId: 1,
+						qualityProfileName: "Any",
+						connectionGeneration: 0,
+						connectionStateToken: null,
+					},
+					{
+						templateId: "template-2",
+						qualityProfileId: 99,
+						qualityProfileName: "Any",
+						connectionGeneration: 0,
+						connectionStateToken: null,
+					},
 				],
 			}),
 		).toThrow(ConflictError);
@@ -188,7 +210,13 @@ describe("resolveDeploymentTarget", () => {
 				target: { profile: undefined, profileName: "Any", matchedBy: "new" },
 				templateId: "template-1",
 				existingMappings: [
-					{ templateId: "template-2", qualityProfileId: 99, qualityProfileName: "Any" },
+					{
+						templateId: "template-2",
+						qualityProfileId: 99,
+						qualityProfileName: "Any",
+						connectionGeneration: 0,
+						connectionStateToken: null,
+					},
 				],
 			}),
 		).toThrow(ConflictError);
@@ -225,10 +253,34 @@ describe("legacy deployment connection mappings", () => {
 		).toThrow("predates connection identity verification");
 	});
 
+	it("fails closed when persisted connection fields are omitted", () => {
+		const mapping = {
+			qualityProfileId: 1,
+			qualityProfileName: "Any",
+		} as unknown as DeploymentProfileMapping;
+
+		expect(() => assertNoLegacyDeploymentConnectionMappings([mapping])).toThrow(
+			"predates connection identity verification",
+		);
+	});
+
+	it.each([
+		{ connectionGeneration: 4, connectionStateToken: null },
+		{ connectionGeneration: 4, connectionStateToken: "" },
+		{ connectionGeneration: 4, connectionStateToken: "   " },
+		{ connectionGeneration: 0, connectionStateToken: "bound-token" },
+		{ connectionGeneration: -1, connectionStateToken: "bound-token" },
+		{ connectionGeneration: 1.5, connectionStateToken: "bound-token" },
+	])("fails closed for malformed persisted connection identity %#", (mapping) => {
+		expect(() => assertNoLegacyDeploymentConnectionMappings([mapping])).toThrow(
+			"predates connection identity verification",
+		);
+	});
+
 	it("accepts mappings bound to an exact connection state", () => {
 		expect(() =>
 			assertNoLegacyDeploymentConnectionMappings([
-				{ connectionGeneration: 0, connectionStateToken: "exact-token" },
+				{ connectionGeneration: 1, connectionStateToken: "exact-token" },
 			]),
 		).not.toThrow();
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -268,13 +268,20 @@ describe("legacy deployment connection mappings", () => {
 		{ connectionGeneration: 4, connectionStateToken: null },
 		{ connectionGeneration: 4, connectionStateToken: "" },
 		{ connectionGeneration: 4, connectionStateToken: "   " },
-		{ connectionGeneration: 0, connectionStateToken: "bound-token" },
 		{ connectionGeneration: -1, connectionStateToken: "bound-token" },
 		{ connectionGeneration: 1.5, connectionStateToken: "bound-token" },
 	])("fails closed for malformed persisted connection identity %#", (mapping) => {
 		expect(() => assertNoLegacyDeploymentConnectionMappings([mapping])).toThrow(
 			"predates connection identity verification",
 		);
+	});
+
+	it("accepts a generation-zero mapping with an exact connection token", () => {
+		expect(() =>
+			assertNoLegacyDeploymentConnectionMappings([
+				{ connectionGeneration: 0, connectionStateToken: "exact-token" },
+			]),
+		).not.toThrow();
 	});
 
 	it("accepts mappings bound to an exact connection state", () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -440,7 +440,7 @@ describe("createDeploymentStateToken", () => {
 });
 
 describe("getEquivalentServiceInstanceIds", () => {
-	it("groups aliases by service and credential identity across different URLs", () => {
+	it("groups aliases only when service, normalized URL, and credentials match", () => {
 		const target = {
 			id: "radarr-1",
 			service: "RADARR",
@@ -479,29 +479,46 @@ describe("getEquivalentServiceInstanceIds", () => {
 				],
 				target,
 			),
-		).toEqual(["radarr-1", "radarr-2", "radarr-other"]);
+		).toEqual(["radarr-1", "radarr-2"]);
 	});
 
-	it("uses the same lock identity for credential aliases with different URLs", () => {
+	it("binds lock identity to the normalized URL as well as credentials", () => {
 		expect(
 			createDeploymentEndpointKey("user-1", {
 				service: "RADARR",
+				baseUrl: "HTTP://RADARR:80/",
 				credentialIdentity: "same-credentials",
 			}),
 		).toBe(
 			createDeploymentEndpointKey("user-1", {
 				service: "radarr",
+				baseUrl: "http://radarr",
 				credentialIdentity: "same-credentials",
 			}),
 		);
 		expect(
 			createDeploymentEndpointKey("user-1", {
 				service: "RADARR",
+				baseUrl: "http://radarr",
 				credentialIdentity: "other-credentials",
 			}),
 		).not.toBe(
 			createDeploymentEndpointKey("user-1", {
 				service: "RADARR",
+				baseUrl: "http://radarr",
+				credentialIdentity: "same-credentials",
+			}),
+		);
+		expect(
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				baseUrl: "https://other-radarr.example.com",
+				credentialIdentity: "same-credentials",
+			}),
+		).not.toBe(
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				baseUrl: "http://radarr",
 				credentialIdentity: "same-credentials",
 			}),
 		);

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -440,7 +440,7 @@ describe("createDeploymentStateToken", () => {
 });
 
 describe("getEquivalentServiceInstanceIds", () => {
-	it("groups duplicate local records for the same normalized ARR endpoint across credentials", () => {
+	it("groups aliases by service and credential identity across different URLs", () => {
 		const target = {
 			id: "radarr-1",
 			service: "RADARR",
@@ -464,24 +464,45 @@ describe("getEquivalentServiceInstanceIds", () => {
 						baseUrl: "http://radarr",
 						credentialIdentity: "other-credentials",
 					},
-					{ id: "sonarr-1", service: "SONARR", baseUrl: "http://radarr" },
-					{ id: "radarr-other", service: "RADARR", baseUrl: "http://other" },
+					{
+						id: "sonarr-1",
+						service: "SONARR",
+						baseUrl: "http://radarr",
+						credentialIdentity: "same-credentials",
+					},
+					{
+						id: "radarr-other",
+						service: "RADARR",
+						baseUrl: "https://radarr.example.com",
+						credentialIdentity: "same-credentials",
+					},
 				],
 				target,
 			),
-		).toEqual(["radarr-1", "radarr-2", "radarr-other-credentials"]);
+		).toEqual(["radarr-1", "radarr-2", "radarr-other"]);
 	});
 
-	it("uses the same lock identity for normalized duplicate records", () => {
+	it("uses the same lock identity for credential aliases with different URLs", () => {
 		expect(
 			createDeploymentEndpointKey("user-1", {
 				service: "RADARR",
-				baseUrl: "HTTP://RADARR:80/",
+				credentialIdentity: "same-credentials",
 			}),
 		).toBe(
 			createDeploymentEndpointKey("user-1", {
 				service: "radarr",
-				baseUrl: "http://radarr",
+				credentialIdentity: "same-credentials",
+			}),
+		);
+		expect(
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				credentialIdentity: "other-credentials",
+			}),
+		).not.toBe(
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				credentialIdentity: "same-credentials",
 			}),
 		);
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -23,7 +23,12 @@ describe("resolveDeploymentTarget", () => {
 	it("uses a stored mapping as the authoritative identity", () => {
 		const result = resolveDeploymentTarget({
 			profiles,
-			mapping: { qualityProfileId: 2, qualityProfileName: "Old name" },
+			mapping: {
+				qualityProfileId: 2,
+				qualityProfileName: "Unrelated",
+				connectionGeneration: 3,
+				connectionStateToken: "bound-connection",
+			},
 			sourceProfileName: "Any",
 			templateName: "Renamed template",
 		});
@@ -47,13 +52,46 @@ describe("resolveDeploymentTarget", () => {
 	it("recovers a stale mapping only by its last known name", () => {
 		const result = resolveDeploymentTarget({
 			profiles,
-			mapping: { qualityProfileId: 99, qualityProfileName: "Unrelated" },
+			mapping: {
+				qualityProfileId: 99,
+				qualityProfileName: "Unrelated",
+				connectionGeneration: 0,
+				connectionStateToken: null,
+			},
 			sourceProfileName: "Any",
 			templateName: "Renamed template",
 		});
 
 		expect(result.profile?.id).toBe(2);
 		expect(result.matchedBy).toBe("mapping_name");
+	});
+
+	it("fails closed when a bound mapping ID is reused by a differently named profile", () => {
+		expect(() =>
+			resolveDeploymentTarget({
+				profiles,
+				mapping: {
+					qualityProfileId: 2,
+					qualityProfileName: "Any",
+					connectionGeneration: 3,
+					connectionStateToken: "bound-connection",
+				},
+			}),
+		).toThrow("identity no longer matches");
+	});
+
+	it("fails closed when a bound mapping ID was deleted and its name was recreated", () => {
+		expect(() =>
+			resolveDeploymentTarget({
+				profiles: [{ id: 99, name: "Any", formatItems: [] }],
+				mapping: {
+					qualityProfileId: 1,
+					qualityProfileName: "Any",
+					connectionGeneration: 3,
+					connectionStateToken: "bound-connection",
+				},
+			}),
+		).toThrow(ConflictError);
 	});
 
 	it("fails closed when neither a stale mapping ID nor its recorded name exists", () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -1,0 +1,508 @@
+import { describe, expect, it } from "vitest";
+import { ConflictError } from "../../errors.js";
+import {
+	assertDeploymentTargetOwnership,
+	assertNoLegacyDeploymentConnectionMappings,
+	createDeploymentConnectionBinding,
+	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+	createDeploymentStateToken,
+	createLegacyDeploymentConnectionBindings,
+	createQualityProfileStateToken,
+	getEquivalentServiceInstanceIds,
+	resolveDeploymentTarget,
+} from "../deployment-target.js";
+
+const profiles = [
+	{ id: 1, name: "Any", formatItems: [{ format: 42, score: -10_000 }] },
+	{ id: 2, name: "Unrelated", formatItems: [] },
+];
+
+describe("resolveDeploymentTarget", () => {
+	it("uses a stored mapping as the authoritative identity", () => {
+		const result = resolveDeploymentTarget({
+			profiles,
+			mapping: { qualityProfileId: 2, qualityProfileName: "Old name" },
+			sourceProfileName: "Any",
+			templateName: "Renamed template",
+		});
+
+		expect(result.profile?.id).toBe(2);
+		expect(result.matchedBy).toBe("mapping_id");
+	});
+
+	it("targets the cloned source profile when the template was renamed", () => {
+		const result = resolveDeploymentTarget({
+			profiles,
+			sourceProfileName: "Any",
+			templateName: "Radarr - Any",
+		});
+
+		expect(result.profile?.id).toBe(1);
+		expect(result.profileName).toBe("Any");
+		expect(result.matchedBy).toBe("source_name");
+	});
+
+	it("recovers a stale mapping only by its last known name", () => {
+		const result = resolveDeploymentTarget({
+			profiles,
+			mapping: { qualityProfileId: 99, qualityProfileName: "Unrelated" },
+			sourceProfileName: "Any",
+			templateName: "Renamed template",
+		});
+
+		expect(result.profile?.id).toBe(2);
+		expect(result.matchedBy).toBe("mapping_name");
+	});
+
+	it("fails closed when neither a stale mapping ID nor its recorded name exists", () => {
+		expect(() =>
+			resolveDeploymentTarget({
+				profiles,
+				mapping: { qualityProfileId: 99, qualityProfileName: "Deleted profile" },
+				sourceProfileName: "Any",
+				templateName: "Radarr - Any",
+			}),
+		).toThrow(ConflictError);
+	});
+
+	it("uses the authoritative profile ID when deploying back to the source instance", () => {
+		const result = resolveDeploymentTarget({
+			profiles,
+			sourceProfileId: 1,
+			isSourceInstance: true,
+			sourceProfileName: "Any",
+			templateName: "Radarr - Any",
+		});
+
+		expect(result.profile?.id).toBe(1);
+		expect(result.matchedBy).toBe("source_id");
+	});
+
+	it("fails closed when a name fallback is ambiguous", () => {
+		expect(() =>
+			resolveDeploymentTarget({
+				profiles: [...profiles, { id: 3, name: "Any", formatItems: [] }],
+				sourceProfileName: "Any",
+				templateName: "Radarr - Any",
+			}),
+		).toThrow(ConflictError);
+	});
+
+	it("rejects taking ownership of a profile managed by another template", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+
+		expect(() =>
+			assertDeploymentTargetOwnership({
+				target,
+				templateId: "template-1",
+				existingMappings: [
+					{
+						templateId: "template-2",
+						qualityProfileId: 1,
+						qualityProfileName: "Any",
+					},
+				],
+			}),
+		).toThrow(ConflictError);
+	});
+
+	it("treats another template's stale same-name mapping as ownership", () => {
+		const target = resolveDeploymentTarget({
+			profiles: [{ id: 9, name: "Any", formatItems: [] }],
+			sourceProfileName: "Any",
+		});
+
+		expect(() =>
+			assertDeploymentTargetOwnership({
+				target,
+				templateId: "template-2",
+				existingMappings: [
+					{
+						templateId: "template-1",
+						qualityProfileId: 1,
+						qualityProfileName: "Any",
+					},
+				],
+			}),
+		).toThrow(ConflictError);
+	});
+
+	it("rejects another owner even when the requesting template mapping is listed first", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+
+		expect(() =>
+			assertDeploymentTargetOwnership({
+				target,
+				templateId: "template-1",
+				existingMappings: [
+					{ templateId: "template-1", qualityProfileId: 1, qualityProfileName: "Any" },
+					{ templateId: "template-2", qualityProfileId: 99, qualityProfileName: "Any" },
+				],
+			}),
+		).toThrow(ConflictError);
+	});
+
+	it("rejects creation under a profile name claimed by another template", () => {
+		expect(() =>
+			assertDeploymentTargetOwnership({
+				target: { profile: undefined, profileName: "Any", matchedBy: "new" },
+				templateId: "template-1",
+				existingMappings: [
+					{ templateId: "template-2", qualityProfileId: 99, qualityProfileName: "Any" },
+				],
+			}),
+		).toThrow(ConflictError);
+	});
+});
+
+describe("legacy deployment connection mappings", () => {
+	it("rejects a legacy mapping when its numeric ID was reused by a differently named profile", () => {
+		expect(() =>
+			resolveDeploymentTarget({
+				profiles,
+				mapping: {
+					qualityProfileId: 2,
+					qualityProfileName: "Any",
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+			}),
+		).toThrow("identity no longer matches");
+	});
+
+	it("queries legacy generation-zero mappings only as a conflict signal", () => {
+		expect(createLegacyDeploymentConnectionBindings(["instance-1", "instance-alias"])).toEqual([
+			{ instanceId: "instance-1", connectionGeneration: 0, connectionStateToken: null },
+			{ instanceId: "instance-alias", connectionGeneration: 0, connectionStateToken: null },
+		]);
+	});
+
+	it("fails closed instead of treating an unbound legacy mapping as ownership", () => {
+		expect(() =>
+			assertNoLegacyDeploymentConnectionMappings([
+				{ connectionGeneration: 0, connectionStateToken: null },
+			]),
+		).toThrow("predates connection identity verification");
+	});
+
+	it("accepts mappings bound to an exact connection state", () => {
+		expect(() =>
+			assertNoLegacyDeploymentConnectionMappings([
+				{ connectionGeneration: 0, connectionStateToken: "exact-token" },
+			]),
+		).not.toThrow();
+	});
+});
+
+describe("createDeploymentStateToken", () => {
+	const template = {
+		id: "template-1",
+		name: "Radarr - Any",
+		configData: '{"customFormats":[]}',
+		sourceQualityProfileName: "Any",
+	};
+	const connection = {
+		service: "RADARR",
+		baseUrl: "http://radarr",
+		credentialIdentity: "encrypted:iv",
+	};
+
+	it("is stable when object key order differs", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const first = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [{ id: 42, name: "CF" }],
+		});
+		const second = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [{ name: "CF", id: 42 }],
+		});
+
+		expect(first).toBe(second);
+	});
+
+	it("changes when the reviewed upstream score changes", () => {
+		const originalTarget = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const changedTarget = resolveDeploymentTarget({
+			profiles: [{ id: 1, name: "Any", formatItems: [{ format: 42, score: 0 }] }, profiles[1]!],
+			sourceProfileName: "Any",
+		});
+
+		expect(
+			createDeploymentStateToken({
+				template,
+				instanceId: "instance-1",
+				connection,
+				target: originalTarget,
+				customFormats: [],
+			}),
+		).not.toBe(
+			createDeploymentStateToken({
+				template,
+				instanceId: "instance-1",
+				connection,
+				target: changedTarget,
+				customFormats: [],
+			}),
+		);
+	});
+
+	it("changes when the reviewed service connection changes", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const original = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [],
+		});
+		const changed = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection: { ...connection, baseUrl: "http://different-radarr" },
+			target,
+			customFormats: [],
+		});
+
+		expect(changed).not.toBe(original);
+	});
+
+	it("normalizes equivalent connection URLs", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const first = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection: { ...connection, baseUrl: "HTTP://RADARR:80/" },
+			target,
+			customFormats: [],
+		});
+		const second = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection: { ...connection, baseUrl: "http://radarr/" },
+			target,
+			customFormats: [],
+		});
+
+		expect(first).toBe(second);
+	});
+
+	it("changes when the resolved naming payload changes", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const original = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [],
+			namingConfig: { id: 1, standardMovieFormat: "Current" },
+			namingPayload: { id: 1, standardMovieFormat: "First payload" },
+		});
+		const changed = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [],
+			namingConfig: { id: 1, standardMovieFormat: "Current" },
+			namingPayload: { id: 1, standardMovieFormat: "Changed payload" },
+		});
+
+		expect(changed).not.toBe(original);
+	});
+
+	it("changes when saved instance score overrides change", () => {
+		const target = resolveDeploymentTarget({ profiles, sourceProfileName: "Any" });
+		const original = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [],
+			savedScoreOverrides: [[42, -10_000]],
+		});
+		const changed = createDeploymentStateToken({
+			template,
+			instanceId: "instance-1",
+			connection,
+			target,
+			customFormats: [],
+			savedScoreOverrides: [[42, 0]],
+		});
+
+		expect(changed).not.toBe(original);
+	});
+});
+
+describe("getEquivalentServiceInstanceIds", () => {
+	it("groups duplicate local records for the same normalized ARR endpoint across credentials", () => {
+		const target = {
+			id: "radarr-1",
+			service: "RADARR",
+			baseUrl: "HTTP://RADARR:80/",
+			credentialIdentity: "same-credentials",
+		};
+
+		expect(
+			getEquivalentServiceInstanceIds(
+				[
+					target,
+					{
+						id: "radarr-2",
+						service: "radarr",
+						baseUrl: "http://radarr",
+						credentialIdentity: "same-credentials",
+					},
+					{
+						id: "radarr-other-credentials",
+						service: "radarr",
+						baseUrl: "http://radarr",
+						credentialIdentity: "other-credentials",
+					},
+					{ id: "sonarr-1", service: "SONARR", baseUrl: "http://radarr" },
+					{ id: "radarr-other", service: "RADARR", baseUrl: "http://other" },
+				],
+				target,
+			),
+		).toEqual(["radarr-1", "radarr-2", "radarr-other-credentials"]);
+	});
+
+	it("uses the same lock identity for normalized duplicate records", () => {
+		expect(
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				baseUrl: "HTTP://RADARR:80/",
+			}),
+		).toBe(
+			createDeploymentEndpointKey("user-1", {
+				service: "radarr",
+				baseUrl: "http://radarr",
+			}),
+		);
+	});
+
+	it("binds rollback identity to normalized endpoint and credentials", () => {
+		const connection = {
+			service: "RADARR",
+			baseUrl: "HTTP://RADARR:80/",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+		};
+		expect(createDeploymentConnectionStateToken(connection)).toBe(
+			createDeploymentConnectionStateToken({
+				...connection,
+				service: "radarr",
+				baseUrl: "http://radarr",
+			}),
+		);
+		expect(createDeploymentConnectionStateToken(connection)).not.toBe(
+			createDeploymentConnectionStateToken({
+				...connection,
+				encryptedApiKey: "rotated-key",
+			}),
+		);
+	});
+
+	it("requires an exact token even on a generation-zero connection", () => {
+		const connection = {
+			id: "radarr-1",
+			service: "RADARR",
+			baseUrl: "http://radarr",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+			connectionGeneration: 0,
+		};
+
+		expect(createDeploymentConnectionBindingCandidates(connection)).toEqual([
+			createDeploymentConnectionBinding(connection),
+		]);
+	});
+
+	it("does not target a reused numeric ID from an unbound mapping after an upgraded endpoint was repointed", () => {
+		const connection = {
+			id: "radarr-1",
+			service: "RADARR",
+			baseUrl: "http://replacement-radarr",
+			encryptedApiKey: "replacement-key",
+			encryptionIv: "replacement-iv",
+			connectionGeneration: 0,
+		};
+		const legacyMapping = {
+			templateId: "template-1",
+			instanceId: "radarr-1",
+			connectionGeneration: 0,
+			connectionStateToken: null,
+			qualityProfileId: 2,
+			qualityProfileName: "Old endpoint profile",
+		};
+		const eligibleMapping = createDeploymentConnectionBindingCandidates(connection).some(
+			(binding) =>
+				binding.instanceId === legacyMapping.instanceId &&
+				binding.connectionGeneration === legacyMapping.connectionGeneration &&
+				binding.connectionStateToken === legacyMapping.connectionStateToken,
+		)
+			? legacyMapping
+			: undefined;
+
+		const result = resolveDeploymentTarget({
+			profiles: [
+				{ id: 2, name: "Unrelated replacement profile" },
+				{ id: 3, name: "Intended profile" },
+			],
+			mapping: eligibleMapping,
+			sourceProfileName: "Intended profile",
+		});
+
+		expect(result.profile?.id).toBe(3);
+		expect(result.matchedBy).toBe("source_name");
+	});
+
+	it("does not recognize a legacy binding after the connection generation changes", () => {
+		const connection = {
+			id: "radarr-1",
+			service: "RADARR",
+			baseUrl: "http://radarr",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+			connectionGeneration: 1,
+		};
+
+		expect(createDeploymentConnectionBindingCandidates(connection)).toEqual([
+			createDeploymentConnectionBinding(connection),
+		]);
+	});
+});
+
+describe("createQualityProfileStateToken", () => {
+	it("detects score and quality-setting drift before a full-profile PUT", () => {
+		const original = createQualityProfileStateToken({
+			id: 1,
+			name: "Any",
+			cutoff: 1,
+			formatItems: [{ format: 42, score: -10_000 }],
+		});
+		const changedScore = createQualityProfileStateToken({
+			id: 1,
+			name: "Any",
+			cutoff: 1,
+			formatItems: [{ format: 42, score: 0 }],
+		});
+		const changedCutoff = createQualityProfileStateToken({
+			id: 1,
+			name: "Any",
+			cutoff: 2,
+			formatItems: [{ format: 42, score: -10_000 }],
+		});
+
+		expect(changedScore).not.toBe(original);
+		expect(changedCutoff).not.toBe(original);
+	});
+});

--- a/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
+++ b/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
@@ -4,6 +4,10 @@ import {
 	type DeploymentBackupState,
 	parseDeploymentBackupState,
 } from "./deployment-backup-state.js";
+import {
+	createQualityProfileStateToken,
+	createUpstreamResourceStateToken,
+} from "./deployment-target.js";
 
 const ACTIVE_STATUSES = new Set([
 	"SUCCESS",
@@ -42,6 +46,7 @@ interface ResourceStateOwner {
 function targetCanRestoreSharedResource(
 	target: OwnershipCandidate,
 	survivor: ResourceStateOwner | undefined,
+	targetBeforeStateToken: string | undefined,
 	resourceLabel: string,
 ): boolean {
 	if (!survivor) return false;
@@ -51,7 +56,7 @@ function targetCanRestoreSharedResource(
 			`The target and a surviving deployment changed ${resourceLabel} at the same deployment time, so it was not changed.`,
 		);
 	}
-	return timeDifference > 0;
+	return timeDifference > 0 && targetBeforeStateToken === survivor.token;
 }
 
 /** Prevent an older deployment snapshot from overwriting a newer survivor. */
@@ -165,7 +170,6 @@ export async function resolveActiveDeploymentOwnership(
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
 			},
 			select: {
 				templateId: true,
@@ -180,8 +184,6 @@ export async function resolveActiveDeploymentOwnership(
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
-				templateId: { not: null },
 			},
 			select: {
 				templateId: true,
@@ -198,7 +200,11 @@ export async function resolveActiveDeploymentOwnership(
 		...deploymentRows.map((item) => ({ ...item, startedAt: item.deployedAt })),
 		...syncRows,
 	]) {
-		if (!row.backupId || !row.templateId || !row.backup) continue;
+		if (!row.backupId || !row.templateId || !row.backup) {
+			throw new ConflictError(
+				"An unrolled deployment ownership relation is missing, so this operation was stopped.",
+			);
+		}
 		const existing = byBackup.get(row.backupId);
 		if (existing && existing.templateId !== row.templateId) {
 			throw new ConflictError(
@@ -210,7 +216,9 @@ export async function resolveActiveDeploymentOwnership(
 			try {
 				state = parseDeploymentBackupState(row.backup.backupData);
 			} catch {
-				state = null;
+				throw new ConflictError(
+					"An unrolled deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+				);
 			}
 		}
 		const active =
@@ -364,10 +372,17 @@ export async function resolveActiveDeploymentOwnership(
 	]);
 	const restorableSharedCustomFormatIds = new Set<number>();
 	for (const resourceId of targetCustomFormatIds) {
+		const targetMutation = latestTarget.state.customFormatDeployments.find(
+			(mutation) => mutation.resourceId === resourceId,
+		);
+		const targetBeforeStateToken = targetMutation?.beforeFormat
+			? createUpstreamResourceStateToken(targetMutation.beforeFormat)
+			: undefined;
 		if (
 			targetCanRestoreSharedResource(
 				latestTarget,
 				customFormatOwners.get(resourceId),
+				targetBeforeStateToken,
 				`Custom Format ${resourceId}`,
 			)
 		) {
@@ -377,10 +392,14 @@ export async function resolveActiveDeploymentOwnership(
 	const targetProfile = latestTarget.state.qualityProfileDeployment;
 	const restorableSharedQualityProfileIds = new Set<number>();
 	if (targetProfile.status !== "not_started" && targetProfile.profileId !== null) {
+		const targetBeforeStateToken = targetProfile.beforeProfile
+			? createQualityProfileStateToken(targetProfile.beforeProfile)
+			: undefined;
 		if (
 			targetCanRestoreSharedResource(
 				latestTarget,
 				qualityProfileOwners.get(targetProfile.profileId),
+				targetBeforeStateToken,
 				`quality profile ${targetProfile.profileId}`,
 			)
 		) {
@@ -392,9 +411,13 @@ export async function resolveActiveDeploymentOwnership(
 		latestTarget.state.namingDeployment &&
 		latestTarget.state.namingDeployment.status !== "not_started"
 	) {
+		const targetBeforeStateToken = createUpstreamResourceStateToken(
+			latestTarget.state.namingDeployment.beforeConfig,
+		);
 		sharedNamingRestorationAllowed = targetCanRestoreSharedResource(
 			latestTarget,
 			namingOwners.get("naming"),
+			targetBeforeStateToken,
 			"naming configuration",
 		);
 	}

--- a/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
+++ b/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
@@ -1,0 +1,413 @@
+import { ConflictError } from "../errors.js";
+import type { PrismaClient } from "../prisma.js";
+import {
+	type DeploymentBackupState,
+	parseDeploymentBackupState,
+} from "./deployment-backup-state.js";
+
+const ACTIVE_STATUSES = new Set([
+	"SUCCESS",
+	"PARTIAL_SUCCESS",
+	"PARTIAL_UNDEPLOY",
+	"IN_PROGRESS",
+	"RUNNING",
+]);
+
+interface OwnershipCandidate {
+	backupId: string;
+	templateId: string;
+	startedAt: Date;
+	active: boolean;
+	state: DeploymentBackupState | null;
+}
+
+export interface ActiveDeploymentOwnership {
+	sharedCustomFormatIds: Set<number>;
+	sharedQualityProfileIds: Set<number>;
+	namingOwnedByAnotherDeployment: boolean;
+	restorableSharedCustomFormatIds: Set<number>;
+	restorableSharedQualityProfileIds: Set<number>;
+	sharedNamingRestorationAllowed: boolean;
+	sharedCustomFormatStateTokens: Map<number, Set<string>>;
+	sharedQualityProfileStateTokens: Map<number, Set<string>>;
+	sharedNamingStateTokens: Set<string>;
+}
+
+interface ResourceStateOwner {
+	backupId: string;
+	startedAt: Date;
+	token: string;
+}
+
+function targetCanRestoreSharedResource(
+	target: OwnershipCandidate,
+	survivor: ResourceStateOwner | undefined,
+	resourceLabel: string,
+): boolean {
+	if (!survivor) return false;
+	const timeDifference = target.startedAt.getTime() - survivor.startedAt.getTime();
+	if (timeDifference === 0) {
+		throw new ConflictError(
+			`The target and a surviving deployment changed ${resourceLabel} at the same deployment time, so it was not changed.`,
+		);
+	}
+	return timeDifference > 0;
+}
+
+/** Prevent an older deployment snapshot from overwriting a newer survivor. */
+export function assertSharedDeploymentRestorationAllowed(
+	isAllowed: boolean,
+	resourceLabel: string,
+): void {
+	if (!isAllowed) {
+		throw new ConflictError(
+			`A newer surviving deployment changed ${resourceLabel}, so the older target cannot restore it safely.`,
+		);
+	}
+}
+
+function retainNewestResourceOwner<K>(
+	owners: Map<K, ResourceStateOwner>,
+	resourceId: K,
+	candidate: OwnershipCandidate,
+	token: string,
+	resourceLabel: string,
+): void {
+	const existing = owners.get(resourceId);
+	if (!existing) {
+		owners.set(resourceId, {
+			backupId: candidate.backupId,
+			startedAt: candidate.startedAt,
+			token,
+		});
+		return;
+	}
+	if (existing.backupId === candidate.backupId) {
+		if (existing.token !== token) {
+			throw new ConflictError(
+				`One surviving deployment recorded conflicting states for ${resourceLabel}, so it was not changed.`,
+			);
+		}
+		return;
+	}
+	const timeDifference = candidate.startedAt.getTime() - existing.startedAt.getTime();
+	if (timeDifference === 0) {
+		throw new ConflictError(
+			`Multiple surviving deployments changed ${resourceLabel} at the same deployment time, so it was not changed.`,
+		);
+	}
+	if (timeDifference > 0) {
+		owners.set(resourceId, {
+			backupId: candidate.backupId,
+			startedAt: candidate.startedAt,
+			token,
+		});
+	}
+}
+
+/** Prove that a skipped shared resource still matches every surviving owner. */
+export function assertSharedDeploymentState(
+	expectedStateTokens: ReadonlySet<string> | undefined,
+	currentStateToken: string,
+	resourceLabel: string,
+): void {
+	const expectedStateToken = getExpectedSharedDeploymentStateToken(
+		expectedStateTokens,
+		resourceLabel,
+	);
+	if (expectedStateToken !== currentStateToken) {
+		throw new ConflictError(
+			`The current ${resourceLabel} does not match the surviving deployment state, so it was not changed.`,
+		);
+	}
+}
+
+/** Resolve the one state all surviving owners agree must remain active. */
+export function getExpectedSharedDeploymentStateToken(
+	expectedStateTokens: ReadonlySet<string> | undefined,
+	resourceLabel: string,
+): string {
+	if (!expectedStateTokens || expectedStateTokens.size === 0) {
+		throw new ConflictError(
+			`The surviving deployment state for ${resourceLabel} is unavailable, so it was not changed.`,
+		);
+	}
+	if (expectedStateTokens.size !== 1) {
+		throw new ConflictError(
+			`Surviving deployments disagree about the expected state of ${resourceLabel}, so it was not changed.`,
+		);
+	}
+	return expectedStateTokens.values().next().value!;
+}
+
+function ledgerHasMutation(state: DeploymentBackupState): boolean {
+	return (
+		state.customFormatDeployments.length > 0 ||
+		state.qualityProfileDeployment.status !== "not_started" ||
+		state.namingDeployment?.status !== "not_started" ||
+		state.managedCustomFormatsCaptured
+	);
+}
+
+/**
+ * Resolve the latest active deployment per template on one physical ARR endpoint.
+ * Any incomplete competing ledger blocks rollback/undeploy before an upstream write.
+ */
+export async function resolveActiveDeploymentOwnership(
+	prisma: PrismaClient,
+	userId: string,
+	instanceIds: string[],
+	target: { backupId: string; templateId: string },
+): Promise<ActiveDeploymentOwnership> {
+	const [deploymentRows, syncRows] = await Promise.all([
+		prisma.templateDeploymentHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+			},
+			select: {
+				templateId: true,
+				backupId: true,
+				status: true,
+				deployedAt: true,
+				backup: { select: { backupData: true } },
+			},
+		}),
+		prisma.trashSyncHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+				templateId: { not: null },
+			},
+			select: {
+				templateId: true,
+				backupId: true,
+				status: true,
+				startedAt: true,
+				backup: { select: { backupData: true } },
+			},
+		}),
+	]);
+
+	const byBackup = new Map<string, OwnershipCandidate>();
+	for (const row of [
+		...deploymentRows.map((item) => ({ ...item, startedAt: item.deployedAt })),
+		...syncRows,
+	]) {
+		if (!row.backupId || !row.templateId || !row.backup) continue;
+		const existing = byBackup.get(row.backupId);
+		if (existing && existing.templateId !== row.templateId) {
+			throw new ConflictError(
+				"Deployment ownership metadata is inconsistent across paired history records.",
+			);
+		}
+		let state = existing?.state ?? null;
+		if (!state) {
+			try {
+				state = parseDeploymentBackupState(row.backup.backupData);
+			} catch {
+				state = null;
+			}
+		}
+		const active =
+			Boolean(existing?.active) ||
+			ACTIVE_STATUSES.has(row.status) ||
+			Boolean(state && ledgerHasMutation(state)) ||
+			row.backupId === target.backupId;
+		byBackup.set(row.backupId, {
+			backupId: row.backupId,
+			templateId: row.templateId,
+			startedAt:
+				existing && existing.startedAt > row.startedAt ? existing.startedAt : row.startedAt,
+			active,
+			state,
+		});
+	}
+
+	const latestByTemplate = new Map<string, OwnershipCandidate>();
+	for (const candidate of byBackup.values()) {
+		if (!candidate.active) continue;
+		const previous = latestByTemplate.get(candidate.templateId);
+		if (
+			previous &&
+			previous.backupId !== candidate.backupId &&
+			previous.startedAt.getTime() === candidate.startedAt.getTime()
+		) {
+			throw new ConflictError(
+				"Multiple active deployments of one template have the same deployment time, so ownership is ambiguous and nothing was changed.",
+			);
+		}
+		if (!previous || candidate.startedAt > previous.startedAt) {
+			latestByTemplate.set(candidate.templateId, candidate);
+		}
+	}
+	const latestTarget = latestByTemplate.get(target.templateId);
+	if (!latestTarget || latestTarget.backupId !== target.backupId) {
+		throw new ConflictError(
+			"A newer deployment of this template exists on the ARR endpoint. Roll back the latest deployment instead.",
+		);
+	}
+
+	const sharedCustomFormatIds = new Set<number>();
+	const sharedQualityProfileIds = new Set<number>();
+	const customFormatOwners = new Map<number, ResourceStateOwner>();
+	const qualityProfileOwners = new Map<number, ResourceStateOwner>();
+	const namingOwners = new Map<"naming", ResourceStateOwner>();
+	let namingOwnedByAnotherDeployment = false;
+	for (const candidate of latestByTemplate.values()) {
+		if (candidate.backupId === target.backupId) continue;
+		if (!candidate.state) {
+			throw new ConflictError(
+				"Another active deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+			);
+		}
+		if (!candidate.state.managedCustomFormatsCaptured) {
+			throw new ConflictError(
+				"Another active deployment has incomplete Custom Format ownership metadata, so this operation was stopped.",
+			);
+		}
+		for (const format of candidate.state.managedCustomFormats) {
+			sharedCustomFormatIds.add(format.resourceId);
+			retainNewestResourceOwner(
+				customFormatOwners,
+				format.resourceId,
+				candidate,
+				format.stateToken,
+				`Custom Format ${format.resourceId}`,
+			);
+		}
+		for (const mutation of candidate.state.customFormatDeployments) {
+			if (mutation.resourceId === null) {
+				throw new ConflictError(
+					"Another active deployment may have created a Custom Format with an unknown identity, so this operation was stopped.",
+				);
+			}
+			if (mutation.status !== "applied" || !mutation.postStateToken) {
+				throw new ConflictError(
+					"Another active deployment has no verified Custom Format state, so this operation was stopped.",
+				);
+			}
+			sharedCustomFormatIds.add(mutation.resourceId);
+			retainNewestResourceOwner(
+				customFormatOwners,
+				mutation.resourceId,
+				candidate,
+				mutation.postStateToken,
+				`Custom Format ${mutation.resourceId}`,
+			);
+		}
+		const profile = candidate.state.qualityProfileDeployment;
+		if (profile.status !== "not_started") {
+			if (profile.profileId === null) {
+				throw new ConflictError(
+					"Another active deployment may have created a quality profile with an unknown identity, so this operation was stopped.",
+				);
+			}
+			if (profile.status !== "applied" || !profile.postStateToken) {
+				throw new ConflictError(
+					"Another active deployment has no verified quality-profile state, so this operation was stopped.",
+				);
+			}
+			sharedQualityProfileIds.add(profile.profileId);
+			retainNewestResourceOwner(
+				qualityProfileOwners,
+				profile.profileId,
+				candidate,
+				profile.postStateToken,
+				`quality profile ${profile.profileId}`,
+			);
+		}
+		if (
+			candidate.state.namingDeployment &&
+			candidate.state.namingDeployment.status !== "not_started"
+		) {
+			if (
+				candidate.state.namingDeployment.status !== "applied" ||
+				!candidate.state.namingDeployment.postStateToken
+			) {
+				throw new ConflictError(
+					"Another active deployment has no verified naming state, so this operation was stopped.",
+				);
+			}
+			namingOwnedByAnotherDeployment = true;
+			retainNewestResourceOwner(
+				namingOwners,
+				"naming",
+				candidate,
+				candidate.state.namingDeployment.postStateToken,
+				"naming configuration",
+			);
+		}
+	}
+	const sharedCustomFormatStateTokens = new Map(
+		[...customFormatOwners].map(([resourceId, owner]) => [resourceId, new Set([owner.token])]),
+	);
+	const sharedQualityProfileStateTokens = new Map(
+		[...qualityProfileOwners].map(([resourceId, owner]) => [resourceId, new Set([owner.token])]),
+	);
+	const sharedNamingStateTokens = new Set([...namingOwners.values()].map((owner) => owner.token));
+
+	if (!latestTarget.state) {
+		throw new ConflictError(
+			"The target deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+		);
+	}
+	const targetCustomFormatIds = new Set([
+		...latestTarget.state.managedCustomFormats.map((format) => format.resourceId),
+		...latestTarget.state.customFormatDeployments.flatMap((mutation) =>
+			mutation.resourceId === null ? [] : [mutation.resourceId],
+		),
+	]);
+	const restorableSharedCustomFormatIds = new Set<number>();
+	for (const resourceId of targetCustomFormatIds) {
+		if (
+			targetCanRestoreSharedResource(
+				latestTarget,
+				customFormatOwners.get(resourceId),
+				`Custom Format ${resourceId}`,
+			)
+		) {
+			restorableSharedCustomFormatIds.add(resourceId);
+		}
+	}
+	const targetProfile = latestTarget.state.qualityProfileDeployment;
+	const restorableSharedQualityProfileIds = new Set<number>();
+	if (targetProfile.status !== "not_started" && targetProfile.profileId !== null) {
+		if (
+			targetCanRestoreSharedResource(
+				latestTarget,
+				qualityProfileOwners.get(targetProfile.profileId),
+				`quality profile ${targetProfile.profileId}`,
+			)
+		) {
+			restorableSharedQualityProfileIds.add(targetProfile.profileId);
+		}
+	}
+	let sharedNamingRestorationAllowed = false;
+	if (
+		latestTarget.state.namingDeployment &&
+		latestTarget.state.namingDeployment.status !== "not_started"
+	) {
+		sharedNamingRestorationAllowed = targetCanRestoreSharedResource(
+			latestTarget,
+			namingOwners.get("naming"),
+			"naming configuration",
+		);
+	}
+
+	return {
+		sharedCustomFormatIds,
+		sharedQualityProfileIds,
+		namingOwnedByAnotherDeployment,
+		restorableSharedCustomFormatIds,
+		restorableSharedQualityProfileIds,
+		sharedNamingRestorationAllowed,
+		sharedCustomFormatStateTokens,
+		sharedQualityProfileStateTokens,
+		sharedNamingStateTokens,
+	};
+}

--- a/apps/api/src/lib/trash-guides/deployment-backup-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-backup-state.ts
@@ -21,6 +21,9 @@ const customFormatStateSchema = z
 		if (state.status === "applied" && !state.postStateToken) {
 			ctx.addIssue({ code: "custom", message: "Applied CF state requires a post token" });
 		}
+		if (state.status === "applied" && state.resourceId === null) {
+			ctx.addIssue({ code: "custom", message: "Applied CF state requires a resource ID" });
+		}
 	});
 
 const qualityProfileStateSchema = z
@@ -39,6 +42,9 @@ const qualityProfileStateSchema = z
 		}
 		if (state.status === "applied" && !state.postStateToken) {
 			ctx.addIssue({ code: "custom", message: "Applied profile state requires a post token" });
+		}
+		if (state.status === "applied" && state.profileId === null) {
+			ctx.addIssue({ code: "custom", message: "Applied profile state requires a profile ID" });
 		}
 	});
 

--- a/apps/api/src/lib/trash-guides/deployment-backup-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-backup-state.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+const positiveResourceId = z.number().int().positive().safe();
+const stateToken = z.string().min(1);
+const recordState = z.record(z.string(), z.unknown());
+
+const customFormatStateSchema = z
+	.object({
+		beforeFormat: recordState.nullable(),
+		action: z.enum(["created", "updated"]),
+		resourceId: positiveResourceId.nullable(),
+		name: z.string().min(1),
+		status: z.enum(["pending", "applied"]),
+		postStateToken: stateToken.nullable(),
+		intendedPostStateToken: stateToken.nullable().optional().default(null),
+	})
+	.superRefine((state, ctx) => {
+		if (state.action === "updated" && !state.beforeFormat) {
+			ctx.addIssue({ code: "custom", message: "Updated CF state requires beforeFormat" });
+		}
+		if (state.status === "applied" && !state.postStateToken) {
+			ctx.addIssue({ code: "custom", message: "Applied CF state requires a post token" });
+		}
+	});
+
+const qualityProfileStateSchema = z
+	.object({
+		beforeProfile: recordState.nullable(),
+		status: z.enum(["not_started", "pending", "applied"]),
+		action: z.enum(["created", "updated"]),
+		profileId: positiveResourceId.nullable(),
+		profileName: z.string().min(1).nullable().optional().default(null),
+		postStateToken: stateToken.nullable(),
+		intendedPostStateToken: stateToken.nullable().optional().default(null),
+	})
+	.superRefine((state, ctx) => {
+		if (state.status !== "not_started" && state.action === "updated" && !state.beforeProfile) {
+			ctx.addIssue({ code: "custom", message: "Updated profile state requires beforeProfile" });
+		}
+		if (state.status === "applied" && !state.postStateToken) {
+			ctx.addIssue({ code: "custom", message: "Applied profile state requires a post token" });
+		}
+	});
+
+const namingStateSchema = z
+	.object({
+		beforeConfig: recordState,
+		status: z.enum(["not_started", "pending", "applied"]),
+		postStateToken: stateToken.nullable(),
+		intendedPostStateToken: stateToken.nullable().optional().default(null),
+	})
+	.superRefine((state, ctx) => {
+		if (state.status === "applied" && !state.postStateToken) {
+			ctx.addIssue({ code: "custom", message: "Applied naming state requires a post token" });
+		}
+	});
+
+const managedFormatSchema = z.object({
+	trashId: z.string().min(1),
+	name: z.string().min(1),
+	resourceId: positiveResourceId,
+	stateToken,
+	profileId: positiveResourceId,
+	appliedScore: z.number().int().safe(),
+});
+
+export const deploymentBackupStateSchema = z.object({
+	schemaVersion: z.literal(2),
+	endpointKey: z.string().min(1),
+	connectionStateToken: stateToken,
+	customFormats: z.array(recordState),
+	customFormatDeployments: z.array(customFormatStateSchema),
+	managedCustomFormats: z.array(managedFormatSchema),
+	managedCustomFormatsCaptured: z.boolean(),
+	qualityProfileDeployment: qualityProfileStateSchema,
+	namingDeployment: namingStateSchema.nullable(),
+});
+
+export type DeploymentBackupState = z.infer<typeof deploymentBackupStateSchema>;
+
+export function parseDeploymentBackupState(value: string): DeploymentBackupState {
+	return deploymentBackupStateSchema.parse(JSON.parse(value));
+}
+
+export function hasPendingDeploymentMutation(state: DeploymentBackupState): boolean {
+	return (
+		state.customFormatDeployments.some((item) => item.status === "pending") ||
+		state.qualityProfileDeployment.status === "pending" ||
+		state.namingDeployment?.status === "pending"
+	);
+}
+
+/** Fail closed when cleanup cannot prove a current deployment ledger is terminal. */
+export function shouldRetainDeploymentBackup(value: string): boolean {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return true;
+	}
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		Array.isArray(parsed) ||
+		!("schemaVersion" in parsed) ||
+		parsed.schemaVersion !== 2
+	) {
+		return false;
+	}
+	try {
+		return hasPendingDeploymentMutation(deploymentBackupStateSchema.parse(parsed));
+	} catch {
+		return true;
+	}
+}

--- a/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
+++ b/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
@@ -1,0 +1,70 @@
+import type { PrismaClient } from "../prisma.js";
+import { ConflictError } from "../errors.js";
+import type { DeploymentConnectionBinding } from "./deployment-target.js";
+
+interface LegacyDeploymentMapping {
+	id: string;
+	instanceId: string;
+	qualityProfileId: number;
+}
+
+/**
+ * Bind a user-reviewed 2.x mapping and its saved score intent to the exact
+ * current connection. Every mapping update is compare-and-set so a stale
+ * preview cannot silently re-authorize changed ownership.
+ */
+export async function rebindLegacyDeploymentConnectionState(
+	prisma: PrismaClient,
+	userId: string,
+	mappings: LegacyDeploymentMapping[],
+	qualityProfileId: number,
+	connectionBindings: DeploymentConnectionBinding[],
+): Promise<void> {
+	const bindingByInstanceId = new Map(
+		connectionBindings.map((binding) => [binding.instanceId, binding]),
+	);
+
+	await prisma.$transaction(async (tx) => {
+		for (const mapping of mappings) {
+			const binding = bindingByInstanceId.get(mapping.instanceId);
+			if (!binding) {
+				throw new ConflictError(
+					"The legacy deployment mapping no longer belongs to this ARR endpoint. Unlink it before continuing.",
+				);
+			}
+			const rebound = await tx.templateQualityProfileMapping.updateMany({
+				where: {
+					id: mapping.id,
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+				data: {
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+					updatedAt: new Date(),
+				},
+			});
+			if (rebound.count !== 1) {
+				throw new ConflictError(
+					"The legacy deployment mapping changed after preview. Refresh and review the deployment again.",
+				);
+			}
+		}
+
+		for (const binding of connectionBindings) {
+			await tx.instanceQualityProfileOverride.updateMany({
+				where: {
+					userId,
+					instanceId: binding.instanceId,
+					qualityProfileId,
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+				data: {
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+				},
+			});
+		}
+	});
+}

--- a/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
+++ b/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
@@ -1,17 +1,41 @@
-import type { PrismaClient } from "../prisma.js";
 import { ConflictError } from "../errors.js";
-import type { DeploymentConnectionBinding } from "./deployment-target.js";
+import type { PrismaClient } from "../prisma.js";
+import {
+	createDeploymentConnectionBinding,
+	type DeploymentConnectionBinding,
+	normalizeDeploymentBaseUrl,
+} from "./deployment-target.js";
 
 interface LegacyDeploymentMapping {
 	id: string;
+	templateId: string;
 	instanceId: string;
 	qualityProfileId: number;
+	qualityProfileName: string;
+	connectionGeneration: number;
+	connectionStateToken: string | null;
+}
+
+function mappingMatchesReview(
+	live: LegacyDeploymentMapping | undefined,
+	reviewed: LegacyDeploymentMapping,
+): boolean {
+	return Boolean(
+		live &&
+			live.id === reviewed.id &&
+			live.templateId === reviewed.templateId &&
+			live.instanceId === reviewed.instanceId &&
+			live.qualityProfileId === reviewed.qualityProfileId &&
+			live.qualityProfileName === reviewed.qualityProfileName &&
+			live.connectionGeneration === reviewed.connectionGeneration &&
+			live.connectionStateToken === reviewed.connectionStateToken,
+	);
 }
 
 /**
- * Bind a user-reviewed 2.x mapping and its saved score intent to the exact
- * current connection. Every mapping update is compare-and-set so a stale
- * preview cannot silently re-authorize changed ownership.
+ * Bind user-reviewed 2.x mappings and saved score intent to the exact current
+ * connection. Ownership, connection identity, mappings, and overrides are all
+ * re-read in one serializable transaction before compare-and-set writes.
  */
 export async function rebindLegacyDeploymentConnectionState(
 	prisma: PrismaClient,
@@ -20,51 +44,205 @@ export async function rebindLegacyDeploymentConnectionState(
 	qualityProfileId: number,
 	connectionBindings: DeploymentConnectionBinding[],
 ): Promise<void> {
+	const mappingIds = mappings.map((mapping) => mapping.id);
+	const templateIds = [...new Set(mappings.map((mapping) => mapping.templateId))];
 	const bindingByInstanceId = new Map(
 		connectionBindings.map((binding) => [binding.instanceId, binding]),
 	);
+	if (
+		new Set(mappingIds).size !== mappingIds.length ||
+		bindingByInstanceId.size !== connectionBindings.length
+	) {
+		throw new ConflictError(
+			"The reviewed legacy deployment identities are ambiguous. Refresh and review the deployment again.",
+		);
+	}
 
-	await prisma.$transaction(async (tx) => {
-		for (const mapping of mappings) {
-			const binding = bindingByInstanceId.get(mapping.instanceId);
-			if (!binding) {
+	await prisma.$transaction(
+		async (tx) => {
+			const [liveMappings, liveInstances, ownedTemplates] = await Promise.all([
+				tx.templateQualityProfileMapping.findMany({
+					where: { id: { in: mappingIds } },
+					select: {
+						id: true,
+						templateId: true,
+						instanceId: true,
+						qualityProfileId: true,
+						qualityProfileName: true,
+						connectionGeneration: true,
+						connectionStateToken: true,
+					},
+				}),
+				tx.serviceInstance.findMany({
+					where: { id: { in: [...bindingByInstanceId.keys()] }, userId },
+					select: {
+						id: true,
+						service: true,
+						baseUrl: true,
+						encryptedApiKey: true,
+						encryptionIv: true,
+						encryptedHttpAuthCredentials: true,
+						httpAuthEncryptionIv: true,
+						connectionGeneration: true,
+					},
+				}),
+				tx.trashTemplate.findMany({
+					where: { id: { in: templateIds }, userId, deletedAt: null },
+					select: { id: true },
+				}),
+			]);
+
+			const ownedTemplateIds = new Set(ownedTemplates.map((template) => template.id));
+			if (
+				liveMappings.length !== mappings.length ||
+				liveInstances.length !== bindingByInstanceId.size ||
+				ownedTemplateIds.size !== templateIds.length ||
+				mappings.some(
+					(mapping) =>
+						!ownedTemplateIds.has(mapping.templateId) ||
+						!bindingByInstanceId.has(mapping.instanceId),
+				)
+			) {
 				throw new ConflictError(
-					"The legacy deployment mapping no longer belongs to this ARR endpoint. Unlink it before continuing.",
+					"The reviewed legacy deployment mapping or ARR instance is no longer authorized for this user.",
 				);
 			}
-			const rebound = await tx.templateQualityProfileMapping.updateMany({
-				where: {
-					id: mapping.id,
-					connectionGeneration: 0,
-					connectionStateToken: null,
-				},
-				data: {
-					connectionGeneration: binding.connectionGeneration,
-					connectionStateToken: binding.connectionStateToken,
-					updatedAt: new Date(),
-				},
-			});
-			if (rebound.count !== 1) {
+			const endpointKeys = new Set(
+				liveInstances.map(
+					(instance) =>
+						`${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}`,
+				),
+			);
+			if (endpointKeys.size !== 1) {
+				throw new ConflictError(
+					"The reviewed legacy deployment no longer belongs to one ARR endpoint. Refresh and review the deployment again.",
+				);
+			}
+
+			const liveMappingById = new Map(liveMappings.map((mapping) => [mapping.id, mapping]));
+			if (
+				mappings.some(
+					(mapping) =>
+						mapping.qualityProfileId !== qualityProfileId ||
+						mapping.connectionGeneration !== 0 ||
+						mapping.connectionStateToken !== null ||
+						!mappingMatchesReview(liveMappingById.get(mapping.id), mapping),
+				)
+			) {
 				throw new ConflictError(
 					"The legacy deployment mapping changed after preview. Refresh and review the deployment again.",
 				);
 			}
-		}
 
-		for (const binding of connectionBindings) {
-			await tx.instanceQualityProfileOverride.updateMany({
+			for (const instance of liveInstances) {
+				const reviewedBinding = bindingByInstanceId.get(instance.id)!;
+				const liveBinding = createDeploymentConnectionBinding(instance);
+				if (
+					liveBinding.connectionGeneration !== reviewedBinding.connectionGeneration ||
+					liveBinding.connectionStateToken !== reviewedBinding.connectionStateToken
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed after preview. Refresh and review the deployment again.",
+					);
+				}
+			}
+
+			const legacyOverrides = await tx.instanceQualityProfileOverride.findMany({
 				where: {
 					userId,
-					instanceId: binding.instanceId,
+					instanceId: { in: [...bindingByInstanceId.keys()] },
 					qualityProfileId,
 					connectionGeneration: 0,
 					connectionStateToken: null,
 				},
-				data: {
-					connectionGeneration: binding.connectionGeneration,
-					connectionStateToken: binding.connectionStateToken,
+				select: {
+					id: true,
+					userId: true,
+					instanceId: true,
+					qualityProfileId: true,
+					customFormatId: true,
+					score: true,
+					status: true,
+					intentOperation: true,
+					intendedScore: true,
+					connectionGeneration: true,
+					connectionStateToken: true,
 				},
 			});
-		}
-	});
+
+			for (const mapping of mappings) {
+				const binding = bindingByInstanceId.get(mapping.instanceId)!;
+				const rebound = await tx.templateQualityProfileMapping.updateMany({
+					where: {
+						id: mapping.id,
+						templateId: mapping.templateId,
+						instanceId: mapping.instanceId,
+						qualityProfileId: mapping.qualityProfileId,
+						qualityProfileName: mapping.qualityProfileName,
+						connectionGeneration: mapping.connectionGeneration,
+						connectionStateToken: mapping.connectionStateToken,
+					},
+					data: {
+						connectionGeneration: binding.connectionGeneration,
+						connectionStateToken: binding.connectionStateToken,
+						updatedAt: new Date(),
+					},
+				});
+				if (rebound.count !== 1) {
+					throw new ConflictError(
+						"The legacy deployment mapping changed after preview. Refresh and review the deployment again.",
+					);
+				}
+			}
+
+			for (const override of legacyOverrides) {
+				const binding = bindingByInstanceId.get(override.instanceId);
+				if (!binding) {
+					throw new ConflictError(
+						"The legacy score overrides changed after preview. Refresh and review the deployment again.",
+					);
+				}
+				const rebound = await tx.instanceQualityProfileOverride.updateMany({
+					where: {
+						id: override.id,
+						userId: override.userId,
+						instanceId: override.instanceId,
+						qualityProfileId: override.qualityProfileId,
+						customFormatId: override.customFormatId,
+						score: override.score,
+						status: override.status,
+						intentOperation: override.intentOperation,
+						intendedScore: override.intendedScore,
+						connectionGeneration: override.connectionGeneration,
+						connectionStateToken: override.connectionStateToken,
+					},
+					data: {
+						connectionGeneration: binding.connectionGeneration,
+						connectionStateToken: binding.connectionStateToken,
+					},
+				});
+				if (rebound.count !== 1) {
+					throw new ConflictError(
+						"The legacy score overrides changed after preview. Refresh and review the deployment again.",
+					);
+				}
+			}
+
+			const remainingLegacyOverrides = await tx.instanceQualityProfileOverride.count({
+				where: {
+					userId,
+					instanceId: { in: [...bindingByInstanceId.keys()] },
+					qualityProfileId,
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+			});
+			if (remainingLegacyOverrides !== 0) {
+				throw new ConflictError(
+					"The legacy score overrides changed while they were being rebound. Refresh and review the deployment again.",
+				);
+			}
+		},
+		{ isolationLevel: "Serializable" },
+	);
 }

--- a/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
+++ b/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
@@ -2,6 +2,7 @@ import { ConflictError } from "../errors.js";
 import type { PrismaClient } from "../prisma.js";
 import {
 	createDeploymentConnectionBinding,
+	normalizeDeploymentBaseUrl,
 	type DeploymentConnectionBinding,
 } from "./deployment-target.js";
 
@@ -144,11 +145,15 @@ export async function rebindLegacyDeploymentConnectionState(
 				);
 			}
 			const services = new Set(liveInstances.map((instance) => instance.service.toUpperCase()));
+			const baseUrls = new Set(
+				liveInstances.map((instance) => normalizeDeploymentBaseUrl(instance.baseUrl)),
+			);
 			const reviewedCredentialIdentities = new Set(
 				connectionBindings.map((binding) => binding.credentialIdentity).filter(Boolean),
 			);
 			if (
 				services.size !== 1 ||
+				baseUrls.size !== 1 ||
 				(connectionBindings.length > 1 &&
 					(reviewedCredentialIdentities.size !== 1 ||
 						connectionBindings.some((binding) => !binding.credentialIdentity)))

--- a/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
+++ b/apps/api/src/lib/trash-guides/deployment-legacy-rebind.ts
@@ -3,7 +3,6 @@ import type { PrismaClient } from "../prisma.js";
 import {
 	createDeploymentConnectionBinding,
 	type DeploymentConnectionBinding,
-	normalizeDeploymentBaseUrl,
 } from "./deployment-target.js";
 
 interface LegacyDeploymentMapping {
@@ -12,6 +11,20 @@ interface LegacyDeploymentMapping {
 	instanceId: string;
 	qualityProfileId: number;
 	qualityProfileName: string;
+	connectionGeneration: number;
+	connectionStateToken: string | null;
+}
+
+interface LegacyDeploymentOverride {
+	id: string;
+	userId: string;
+	instanceId: string;
+	qualityProfileId: number;
+	customFormatId: number;
+	score: number;
+	status: string;
+	intentOperation: string | null;
+	intendedScore: number | null;
 	connectionGeneration: number;
 	connectionStateToken: string | null;
 }
@@ -32,6 +45,26 @@ function mappingMatchesReview(
 	);
 }
 
+function overrideMatchesReview(
+	live: LegacyDeploymentOverride | undefined,
+	reviewed: LegacyDeploymentOverride,
+): boolean {
+	return Boolean(
+		live &&
+			live.id === reviewed.id &&
+			live.userId === reviewed.userId &&
+			live.instanceId === reviewed.instanceId &&
+			live.qualityProfileId === reviewed.qualityProfileId &&
+			live.customFormatId === reviewed.customFormatId &&
+			live.score === reviewed.score &&
+			live.status === reviewed.status &&
+			live.intentOperation === reviewed.intentOperation &&
+			live.intendedScore === reviewed.intendedScore &&
+			live.connectionGeneration === reviewed.connectionGeneration &&
+			live.connectionStateToken === reviewed.connectionStateToken,
+	);
+}
+
 /**
  * Bind user-reviewed 2.x mappings and saved score intent to the exact current
  * connection. Ownership, connection identity, mappings, and overrides are all
@@ -42,15 +75,18 @@ export async function rebindLegacyDeploymentConnectionState(
 	userId: string,
 	mappings: LegacyDeploymentMapping[],
 	qualityProfileId: number,
+	overrides: LegacyDeploymentOverride[],
 	connectionBindings: DeploymentConnectionBinding[],
 ): Promise<void> {
 	const mappingIds = mappings.map((mapping) => mapping.id);
+	const overrideIds = overrides.map((override) => override.id);
 	const templateIds = [...new Set(mappings.map((mapping) => mapping.templateId))];
 	const bindingByInstanceId = new Map(
 		connectionBindings.map((binding) => [binding.instanceId, binding]),
 	);
 	if (
 		new Set(mappingIds).size !== mappingIds.length ||
+		new Set(overrideIds).size !== overrideIds.length ||
 		bindingByInstanceId.size !== connectionBindings.length
 	) {
 		throw new ConflictError(
@@ -107,15 +143,18 @@ export async function rebindLegacyDeploymentConnectionState(
 					"The reviewed legacy deployment mapping or ARR instance is no longer authorized for this user.",
 				);
 			}
-			const endpointKeys = new Set(
-				liveInstances.map(
-					(instance) =>
-						`${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}`,
-				),
+			const services = new Set(liveInstances.map((instance) => instance.service.toUpperCase()));
+			const reviewedCredentialIdentities = new Set(
+				connectionBindings.map((binding) => binding.credentialIdentity).filter(Boolean),
 			);
-			if (endpointKeys.size !== 1) {
+			if (
+				services.size !== 1 ||
+				(connectionBindings.length > 1 &&
+					(reviewedCredentialIdentities.size !== 1 ||
+						connectionBindings.some((binding) => !binding.credentialIdentity)))
+			) {
 				throw new ConflictError(
-					"The reviewed legacy deployment no longer belongs to one ARR endpoint. Refresh and review the deployment again.",
+					"The reviewed legacy deployment cannot be proven to belong to one ARR endpoint. Refresh and review the deployment again.",
 				);
 			}
 
@@ -147,7 +186,7 @@ export async function rebindLegacyDeploymentConnectionState(
 				}
 			}
 
-			const legacyOverrides = await tx.instanceQualityProfileOverride.findMany({
+			const liveOverrides = await tx.instanceQualityProfileOverride.findMany({
 				where: {
 					userId,
 					instanceId: { in: [...bindingByInstanceId.keys()] },
@@ -169,6 +208,23 @@ export async function rebindLegacyDeploymentConnectionState(
 					connectionStateToken: true,
 				},
 			});
+			const liveOverrideById = new Map(liveOverrides.map((override) => [override.id, override]));
+			if (
+				liveOverrides.length !== overrides.length ||
+				overrides.some(
+					(override) =>
+						override.userId !== userId ||
+						override.qualityProfileId !== qualityProfileId ||
+						!bindingByInstanceId.has(override.instanceId) ||
+						override.connectionGeneration !== 0 ||
+						override.connectionStateToken !== null ||
+						!overrideMatchesReview(liveOverrideById.get(override.id), override),
+				)
+			) {
+				throw new ConflictError(
+					"The legacy score overrides changed after preview. Refresh and review the deployment again.",
+				);
+			}
 
 			for (const mapping of mappings) {
 				const binding = bindingByInstanceId.get(mapping.instanceId)!;
@@ -195,7 +251,7 @@ export async function rebindLegacyDeploymentConnectionState(
 				}
 			}
 
-			for (const override of legacyOverrides) {
+			for (const override of overrides) {
 				const binding = bindingByInstanceId.get(override.instanceId);
 				if (!binding) {
 					throw new ConflictError(

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -5,6 +5,7 @@ import {
 	hasPendingDeploymentMutation,
 	parseDeploymentBackupState,
 } from "./deployment-backup-state.js";
+import type { DeploymentConnectionBinding } from "./deployment-target.js";
 
 export type ScoreIntentOperation = "SET_SCORE" | "RESET_SCORE";
 
@@ -12,6 +13,7 @@ export interface ScoreIntentRetry {
 	qualityProfileId: number;
 	operation: ScoreIntentOperation;
 	scoreUpdates: Array<{ customFormatId: number; score: number }>;
+	connectionBindings: DeploymentConnectionBinding[];
 }
 
 /** Block new writes while a previous upstream result remains uncertain. */
@@ -27,10 +29,11 @@ export async function assertNoPendingDeploymentOperation(
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
 			},
 			select: {
+				status: true,
 				rollbackStatus: true,
+				backupId: true,
 				backup: { select: { id: true, backupData: true } },
 			},
 		}),
@@ -39,11 +42,11 @@ export async function assertNoPendingDeploymentOperation(
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
 			},
 			select: {
 				status: true,
 				undeployStatus: true,
+				backupId: true,
 				backup: { select: { id: true, backupData: true } },
 			},
 		}),
@@ -55,10 +58,13 @@ export async function assertNoPendingDeploymentOperation(
 						status: { in: ["PENDING", "UNCERTAIN"] },
 					},
 					select: {
+						instanceId: true,
 						qualityProfileId: true,
 						customFormatId: true,
 						intentOperation: true,
 						intendedScore: true,
+						connectionGeneration: true,
+						connectionStateToken: true,
 					},
 				})
 			: [],
@@ -66,21 +72,34 @@ export async function assertNoPendingDeploymentOperation(
 	const retryScores = new Map(
 		overrideRetry?.scoreUpdates.map((update) => [update.customFormatId, update.score]) ?? [],
 	);
-	const retryRows = overrideRetry
-		? uncertainOverrides.filter(
-				(override) => override.qualityProfileId === overrideRetry.qualityProfileId,
-			)
-		: [];
+	const retryBindingByInstanceId = new Map(
+		overrideRetry?.connectionBindings.map((binding) => [binding.instanceId, binding]) ?? [],
+	);
+	const requestedInstanceIds = new Set(instanceIds);
 	const isExactRetry = Boolean(
 		overrideRetry &&
-			retryRows.length > 0 &&
-			retryRows.length === overrideRetry.scoreUpdates.length &&
+			uncertainOverrides.length > 0 &&
 			retryScores.size === overrideRetry.scoreUpdates.length &&
-			retryRows.every(
+			retryBindingByInstanceId.size === overrideRetry.connectionBindings.length &&
+			retryBindingByInstanceId.size === requestedInstanceIds.size &&
+			[...requestedInstanceIds].every((instanceId) => retryBindingByInstanceId.has(instanceId)) &&
+			overrideRetry.scoreUpdates.every((update) =>
+				uncertainOverrides.some(
+					(override) =>
+						override.qualityProfileId === overrideRetry.qualityProfileId &&
+						override.customFormatId === update.customFormatId,
+				),
+			) &&
+			uncertainOverrides.every(
 				(override) =>
+					override.qualityProfileId === overrideRetry.qualityProfileId &&
 					override.intentOperation === overrideRetry.operation &&
 					override.intendedScore !== null &&
-					retryScores.get(override.customFormatId) === override.intendedScore,
+					retryScores.get(override.customFormatId) === override.intendedScore &&
+					retryBindingByInstanceId.get(override.instanceId)?.connectionGeneration ===
+						override.connectionGeneration &&
+					retryBindingByInstanceId.get(override.instanceId)?.connectionStateToken ===
+						override.connectionStateToken,
 			),
 	);
 	if (uncertainOverrides.length > 0 && !isExactRetry) {
@@ -105,6 +124,22 @@ export async function assertNoPendingDeploymentOperation(
 	) {
 		throw new AppValidationError(
 			"A previous TRaSH deployment has an unfinished undeploy. Retry or resolve that undeploy before changing this ARR endpoint.",
+		);
+	}
+	if (
+		syncRows.some(
+			(row) =>
+				!row.backup &&
+				(row.status === "IN_PROGRESS" ||
+					row.status === "RUNNING" ||
+					row.status === "PARTIAL_SUCCESS"),
+		) ||
+		deploymentRows.some(
+			(row) => !row.backup && (row.status === "IN_PROGRESS" || row.status === "PARTIAL_SUCCESS"),
+		)
+	) {
+		throw new AppValidationError(
+			"A previous TRaSH deployment has an uncertain upstream result and no verifiable deployment ledger. Resolve that history before changing this ARR endpoint.",
 		);
 	}
 	const seen = new Set<string>();
@@ -157,23 +192,34 @@ export async function assertNoActiveDeploymentOwnership(
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
 			},
-			select: { backup: { select: { id: true, backupData: true } } },
+			select: {
+				status: true,
+				backupId: true,
+				backup: { select: { id: true, backupData: true } },
+			},
 		}),
 		prisma.templateDeploymentHistory.findMany({
 			where: {
 				userId,
 				instanceId: { in: instanceIds },
 				rolledBack: false,
-				backupId: { not: null },
 			},
-			select: { backup: { select: { id: true, backupData: true } } },
+			select: {
+				status: true,
+				backupId: true,
+				backup: { select: { id: true, backupData: true } },
+			},
 		}),
 	]);
 	const seen = new Set<string>();
 	for (const row of [...syncRows, ...deploymentRows]) {
-		if (!row.backup || seen.has(row.backup.id)) continue;
+		if (!row.backup) {
+			throw new AppValidationError(
+				"This ARR connection has active deployment ownership without verifiable rollback data. Resolve that history before changing the connection.",
+			);
+		}
+		if (seen.has(row.backup.id)) continue;
 		seen.add(row.backup.id);
 		let state: DeploymentBackupState;
 		try {
@@ -300,11 +346,11 @@ export async function reconcileInterruptedDeploymentHistories(
 	const reconciledBackupIds = new Set<string>();
 	for (const history of interruptedDeployments) {
 		if (history.undeployStatus === "IN_PROGRESS") {
-			await prisma.templateDeploymentHistory.update({
-				where: { id: history.id },
+			const result = await prisma.templateDeploymentHistory.updateMany({
+				where: { id: history.id, undeployStatus: "IN_PROGRESS" },
 				data: { undeployStatus: "PARTIAL" },
 			});
-			reconciled++;
+			if (result.count === 1) reconciled++;
 			continue;
 		}
 		const reconciliation = classify(history.backup);
@@ -324,11 +370,12 @@ export async function reconcileInterruptedDeploymentHistories(
 						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
 					}
 				: {};
-		await prisma.$transaction(async (tx) => {
-			await tx.templateDeploymentHistory.update({
-				where: { id: history.id },
+		const primaryReconciled = await prisma.$transaction(async (tx) => {
+			const primary = await tx.templateDeploymentHistory.updateMany({
+				where: { id: history.id, status: "IN_PROGRESS" },
 				data: { status, errors: JSON.stringify([message]), ...appliedAudit },
 			});
+			if (primary.count !== 1) return false;
 			if (history.backupId) {
 				await tx.trashSyncHistory.updateMany({
 					where: {
@@ -343,19 +390,22 @@ export async function reconcileInterruptedDeploymentHistories(
 					},
 				});
 			}
+			return true;
 		});
 		if (history.backupId) reconciledBackupIds.add(history.backupId);
-		reconciled++;
+		if (primaryReconciled) {
+			reconciled++;
+		}
 	}
 
 	for (const history of interruptedSyncs) {
 		if (history.backupId && reconciledBackupIds.has(history.backupId)) continue;
 		if (history.rollbackStatus === "IN_PROGRESS") {
-			await prisma.trashSyncHistory.update({
-				where: { id: history.id },
+			const result = await prisma.trashSyncHistory.updateMany({
+				where: { id: history.id, rollbackStatus: "IN_PROGRESS" },
 				data: { rollbackStatus: "PARTIAL" },
 			});
-			reconciled++;
+			if (result.count === 1) reconciled++;
 			continue;
 		}
 		const reconciliation = classify(history.backup);
@@ -368,11 +418,11 @@ export async function reconcileInterruptedDeploymentHistories(
 						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
 					}
 				: {};
-		await prisma.trashSyncHistory.update({
-			where: { id: history.id },
+		const result = await prisma.trashSyncHistory.updateMany({
+			where: { id: history.id, status: { in: ["IN_PROGRESS", "RUNNING"] } },
 			data: { status, completedAt: new Date(), errorLog: message, ...appliedAudit },
 		});
-		reconciled++;
+		if (result.count === 1) reconciled++;
 	}
 	return reconciled;
 }

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -127,6 +127,14 @@ export async function assertNoPendingDeploymentOperation(
 		);
 	}
 	if (
+		syncRows.some((row) => row.status === "UNCERTAIN") ||
+		deploymentRows.some((row) => row.status === "UNCERTAIN")
+	) {
+		throw new AppValidationError(
+			"A previous TRaSH deployment has an uncertain upstream result. Resolve that history before changing this ARR endpoint.",
+		);
+	}
+	if (
 		syncRows.some(
 			(row) =>
 				!row.backup &&
@@ -273,7 +281,7 @@ export async function reconcileInterruptedDeploymentHistories(
 			: [];
 
 	type Reconciliation =
-		| { status: "FAILED"; message: string }
+		| { status: "FAILED" | "UNCERTAIN"; message: string }
 		| {
 				status: "PARTIAL_SUCCESS";
 				message: string;
@@ -284,9 +292,9 @@ export async function reconcileInterruptedDeploymentHistories(
 		let pending = false;
 		if (!backup) {
 			return {
-				status: "FAILED",
+				status: "UNCERTAIN",
 				message:
-					"The application restarted before deployment history could be finalized. Review the upstream ARR state before retrying.",
+					"The application restarted before deployment history could be finalized, so the upstream result is uncertain. Resolve the upstream ARR state before retrying.",
 			};
 		}
 
@@ -296,9 +304,9 @@ export async function reconcileInterruptedDeploymentHistories(
 			pending = hasPendingDeploymentMutation(state);
 		} catch {
 			return {
-				status: "FAILED",
+				status: "UNCERTAIN",
 				message:
-					"The application restarted with deployment history that could not be reconstructed exactly. Review the upstream ARR state before retrying.",
+					"The application restarted with deployment history that could not be reconstructed exactly, so the upstream result is uncertain. Resolve the upstream ARR state before retrying.",
 			};
 		}
 

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -1,0 +1,378 @@
+import type { PrismaClient } from "../prisma.js";
+import { AppValidationError } from "../errors.js";
+import {
+	type DeploymentBackupState,
+	hasPendingDeploymentMutation,
+	parseDeploymentBackupState,
+} from "./deployment-backup-state.js";
+
+export type ScoreIntentOperation = "SET_SCORE" | "RESET_SCORE";
+
+export interface ScoreIntentRetry {
+	qualityProfileId: number;
+	operation: ScoreIntentOperation;
+	scoreUpdates: Array<{ customFormatId: number; score: number }>;
+}
+
+/** Block new writes while a previous upstream result remains uncertain. */
+export async function assertNoPendingDeploymentOperation(
+	prisma: PrismaClient,
+	userId: string,
+	instanceIds: string[],
+	overrideRetry?: ScoreIntentRetry,
+): Promise<void> {
+	const [syncRows, deploymentRows, uncertainOverrides] = await Promise.all([
+		prisma.trashSyncHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+			},
+			select: {
+				rollbackStatus: true,
+				backup: { select: { id: true, backupData: true } },
+			},
+		}),
+		prisma.templateDeploymentHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+			},
+			select: {
+				status: true,
+				undeployStatus: true,
+				backup: { select: { id: true, backupData: true } },
+			},
+		}),
+		typeof prisma.instanceQualityProfileOverride?.findMany === "function"
+			? prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						userId,
+						instanceId: { in: instanceIds },
+						status: { in: ["PENDING", "UNCERTAIN"] },
+					},
+					select: {
+						qualityProfileId: true,
+						customFormatId: true,
+						intentOperation: true,
+						intendedScore: true,
+					},
+				})
+			: [],
+	]);
+	const retryScores = new Map(
+		overrideRetry?.scoreUpdates.map((update) => [update.customFormatId, update.score]) ?? [],
+	);
+	const retryRows = overrideRetry
+		? uncertainOverrides.filter(
+				(override) => override.qualityProfileId === overrideRetry.qualityProfileId,
+			)
+		: [];
+	const isExactRetry = Boolean(
+		overrideRetry &&
+			retryRows.length > 0 &&
+			retryRows.length === overrideRetry.scoreUpdates.length &&
+			retryScores.size === overrideRetry.scoreUpdates.length &&
+			retryRows.every(
+				(override) =>
+					override.intentOperation === overrideRetry.operation &&
+					override.intendedScore !== null &&
+					retryScores.get(override.customFormatId) === override.intendedScore,
+			),
+	);
+	if (uncertainOverrides.length > 0 && !isExactRetry) {
+		throw new AppValidationError(
+			"A previous quality-profile score write has an uncertain upstream result. Retry that exact score update before changing this ARR endpoint.",
+		);
+	}
+	if (
+		syncRows.some((row) => row.rollbackStatus === "IN_PROGRESS" || row.rollbackStatus === "PARTIAL")
+	) {
+		throw new AppValidationError(
+			"A previous TRaSH deployment has an unfinished rollback. Retry or resolve that rollback before changing this ARR endpoint.",
+		);
+	}
+	if (
+		deploymentRows.some(
+			(row) =>
+				row.undeployStatus === "IN_PROGRESS" ||
+				row.undeployStatus === "PARTIAL" ||
+				row.status === "PARTIAL_UNDEPLOY",
+		)
+	) {
+		throw new AppValidationError(
+			"A previous TRaSH deployment has an unfinished undeploy. Retry or resolve that undeploy before changing this ARR endpoint.",
+		);
+	}
+	const seen = new Set<string>();
+	for (const row of [...syncRows, ...deploymentRows]) {
+		if (!row.backup || seen.has(row.backup.id)) continue;
+		seen.add(row.backup.id);
+		let rawBackup: unknown;
+		try {
+			rawBackup = JSON.parse(row.backup.backupData);
+		} catch {
+			throw new AppValidationError(
+				"A previous TRaSH deployment has an invalid deployment ledger. Resolve or remove that history before changing this ARR endpoint.",
+			);
+		}
+		if (
+			typeof rawBackup !== "object" ||
+			rawBackup === null ||
+			Array.isArray(rawBackup) ||
+			!("schemaVersion" in rawBackup) ||
+			rawBackup.schemaVersion !== 2
+		) {
+			// Legacy backups contain no pending ledger and do not block new work.
+			continue;
+		}
+		let state: DeploymentBackupState;
+		try {
+			state = parseDeploymentBackupState(row.backup.backupData);
+		} catch {
+			throw new AppValidationError(
+				"A previous TRaSH deployment has an invalid deployment ledger. Resolve or remove that history before changing this ARR endpoint.",
+			);
+		}
+		if (hasPendingDeploymentMutation(state)) {
+			throw new AppValidationError(
+				"A previous TRaSH deployment has an uncertain upstream result. Resolve or roll back that operation before changing this ARR endpoint.",
+			);
+		}
+	}
+}
+
+/** Block connection replacement while an exact rollback ledger still owns upstream state. */
+export async function assertNoActiveDeploymentOwnership(
+	prisma: PrismaClient,
+	userId: string,
+	instanceIds: string[],
+): Promise<void> {
+	const [syncRows, deploymentRows] = await Promise.all([
+		prisma.trashSyncHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+			},
+			select: { backup: { select: { id: true, backupData: true } } },
+		}),
+		prisma.templateDeploymentHistory.findMany({
+			where: {
+				userId,
+				instanceId: { in: instanceIds },
+				rolledBack: false,
+				backupId: { not: null },
+			},
+			select: { backup: { select: { id: true, backupData: true } } },
+		}),
+	]);
+	const seen = new Set<string>();
+	for (const row of [...syncRows, ...deploymentRows]) {
+		if (!row.backup || seen.has(row.backup.id)) continue;
+		seen.add(row.backup.id);
+		let state: DeploymentBackupState;
+		try {
+			state = parseDeploymentBackupState(row.backup.backupData);
+		} catch {
+			throw new AppValidationError(
+				"This ARR connection has active deployment ownership with legacy or invalid rollback data. Resolve that history before changing the connection.",
+			);
+		}
+		if (
+			state.customFormatDeployments.length > 0 ||
+			state.qualityProfileDeployment.status !== "not_started" ||
+			(state.namingDeployment && state.namingDeployment.status !== "not_started") ||
+			state.managedCustomFormatsCaptured
+		) {
+			throw new AppValidationError(
+				"This ARR connection has active deployment ownership. Roll back or undeploy it before changing the connection.",
+			);
+		}
+	}
+}
+
+/** Reclassify records left in a transient state by a previous process interruption. */
+export async function reconcileInterruptedDeploymentHistories(
+	prisma: PrismaClient,
+): Promise<number> {
+	if (typeof prisma.templateDeploymentHistory?.findMany !== "function") return 0;
+	const interruptedDeployments = await prisma.templateDeploymentHistory.findMany({
+		where: { OR: [{ status: "IN_PROGRESS" }, { undeployStatus: "IN_PROGRESS" }] },
+		select: {
+			id: true,
+			backupId: true,
+			status: true,
+			undeployStatus: true,
+			backup: { select: { backupData: true } },
+		},
+	});
+	const interruptedSyncs =
+		typeof prisma.trashSyncHistory?.findMany === "function"
+			? await prisma.trashSyncHistory.findMany({
+					where: {
+						OR: [{ status: { in: ["IN_PROGRESS", "RUNNING"] } }, { rollbackStatus: "IN_PROGRESS" }],
+					},
+					select: {
+						id: true,
+						backupId: true,
+						rollbackStatus: true,
+						backup: { select: { backupData: true } },
+					},
+				})
+			: [];
+
+	type Reconciliation =
+		| { status: "FAILED"; message: string }
+		| {
+				status: "PARTIAL_SUCCESS";
+				message: string;
+				appliedCFCount: number;
+				appliedConfigs: Array<Record<string, unknown>>;
+		  };
+	const classify = (backup: { backupData: string } | null): Reconciliation => {
+		let pending = false;
+		if (!backup) {
+			return {
+				status: "FAILED",
+				message:
+					"The application restarted before deployment history could be finalized. Review the upstream ARR state before retrying.",
+			};
+		}
+
+		let state: DeploymentBackupState;
+		try {
+			state = parseDeploymentBackupState(backup.backupData);
+			pending = hasPendingDeploymentMutation(state);
+		} catch {
+			return {
+				status: "FAILED",
+				message:
+					"The application restarted with deployment history that could not be reconstructed exactly. Review the upstream ARR state before retrying.",
+			};
+		}
+
+		const message = pending
+			? "The application restarted while an upstream deployment result was uncertain. Rollback or manual resolution is required before another deployment."
+			: "The application restarted before deployment history could be finalized. Review the upstream ARR state before retrying.";
+		const appliedCustomFormats = state.customFormatDeployments.filter(
+			(item) => item.status === "applied",
+		);
+		const appliedConfigs: Array<Record<string, unknown>> = appliedCustomFormats.map((item) => ({
+			name: item.name,
+			action: item.action,
+		}));
+		const profile = state.qualityProfileDeployment;
+		if (profile.status === "applied") {
+			if (profile.profileId === null || profile.profileName === null) {
+				return {
+					status: "FAILED",
+					message:
+						"The application restarted with applied deployment details that could not be reconstructed exactly. Review the upstream ARR state before retrying.",
+				};
+			}
+			appliedConfigs.push({
+				name: profile.profileName,
+				action: profile.action,
+				type: "quality_profile",
+				id: profile.profileId,
+			});
+		}
+		if (state.namingDeployment?.status === "applied") {
+			appliedConfigs.push({ name: "Naming configuration", action: "updated" });
+		}
+		if (appliedConfigs.length === 0) {
+			return { status: "FAILED", message };
+		}
+		return {
+			status: "PARTIAL_SUCCESS",
+			message,
+			appliedCFCount: appliedCustomFormats.length,
+			appliedConfigs,
+		};
+	};
+
+	let reconciled = 0;
+	const reconciledBackupIds = new Set<string>();
+	for (const history of interruptedDeployments) {
+		if (history.undeployStatus === "IN_PROGRESS") {
+			await prisma.templateDeploymentHistory.update({
+				where: { id: history.id },
+				data: { undeployStatus: "PARTIAL" },
+			});
+			reconciled++;
+			continue;
+		}
+		const reconciliation = classify(history.backup);
+		const { status, message } = reconciliation;
+		const appliedAudit =
+			status === "PARTIAL_SUCCESS"
+				? {
+						appliedCFs: reconciliation.appliedCFCount,
+						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+					}
+				: {};
+		const syncAppliedAudit =
+			status === "PARTIAL_SUCCESS"
+				? {
+						configsApplied: reconciliation.appliedConfigs.length,
+						configsFailed: 1,
+						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+					}
+				: {};
+		await prisma.$transaction(async (tx) => {
+			await tx.templateDeploymentHistory.update({
+				where: { id: history.id },
+				data: { status, errors: JSON.stringify([message]), ...appliedAudit },
+			});
+			if (history.backupId) {
+				await tx.trashSyncHistory.updateMany({
+					where: {
+						backupId: history.backupId,
+						status: { in: ["IN_PROGRESS", "RUNNING"] },
+					},
+					data: {
+						status,
+						completedAt: new Date(),
+						errorLog: message,
+						...syncAppliedAudit,
+					},
+				});
+			}
+		});
+		if (history.backupId) reconciledBackupIds.add(history.backupId);
+		reconciled++;
+	}
+
+	for (const history of interruptedSyncs) {
+		if (history.backupId && reconciledBackupIds.has(history.backupId)) continue;
+		if (history.rollbackStatus === "IN_PROGRESS") {
+			await prisma.trashSyncHistory.update({
+				where: { id: history.id },
+				data: { rollbackStatus: "PARTIAL" },
+			});
+			reconciled++;
+			continue;
+		}
+		const reconciliation = classify(history.backup);
+		const { status, message } = reconciliation;
+		const appliedAudit =
+			status === "PARTIAL_SUCCESS"
+				? {
+						configsApplied: reconciliation.appliedConfigs.length,
+						configsFailed: 1,
+						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+					}
+				: {};
+		await prisma.trashSyncHistory.update({
+			where: { id: history.id },
+			data: { status, completedAt: new Date(), errorLog: message, ...appliedAudit },
+		});
+		reconciled++;
+	}
+	return reconciled;
+}

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -321,18 +321,21 @@ export async function reconcileInterruptedDeploymentHistories(
 		const profile = state.qualityProfileDeployment;
 		if (profile.status === "applied") {
 			if (profile.profileId === null || profile.profileName === null) {
-				return {
-					status: "FAILED",
-					message:
-						"The application restarted with applied deployment details that could not be reconstructed exactly. Review the upstream ARR state before retrying.",
-				};
+				if (!pending) {
+					return {
+						status: "FAILED",
+						message:
+							"The application restarted with applied deployment details that could not be reconstructed exactly. Review the upstream ARR state before retrying.",
+					};
+				}
+			} else {
+				appliedConfigs.push({
+					name: profile.profileName,
+					action: profile.action,
+					type: "quality_profile",
+					id: profile.profileId,
+				});
 			}
-			appliedConfigs.push({
-				name: profile.profileName,
-				action: profile.action,
-				type: "quality_profile",
-				id: profile.profileId,
-			});
 		}
 		if (state.namingDeployment?.status === "applied") {
 			appliedConfigs.push({ name: "Naming configuration", action: "updated" });

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -280,14 +280,12 @@ export async function reconcileInterruptedDeploymentHistories(
 				})
 			: [];
 
-	type Reconciliation =
-		| { status: "FAILED" | "UNCERTAIN"; message: string }
-		| {
-				status: "PARTIAL_SUCCESS";
-				message: string;
-				appliedCFCount: number;
-				appliedConfigs: Array<Record<string, unknown>>;
-		  };
+	type Reconciliation = {
+		status: "FAILED" | "UNCERTAIN" | "PARTIAL_SUCCESS";
+		message: string;
+		appliedCFCount?: number;
+		appliedConfigs?: Array<Record<string, unknown>>;
+	};
 	const classify = (backup: { backupData: string } | null): Reconciliation => {
 		let pending = false;
 		if (!backup) {
@@ -339,6 +337,14 @@ export async function reconcileInterruptedDeploymentHistories(
 		if (state.namingDeployment?.status === "applied") {
 			appliedConfigs.push({ name: "Naming configuration", action: "updated" });
 		}
+		if (pending) {
+			return {
+				status: "UNCERTAIN",
+				message,
+				appliedCFCount: appliedCustomFormats.length,
+				appliedConfigs,
+			};
+		}
 		if (appliedConfigs.length === 0) {
 			return { status: "FAILED", message };
 		}
@@ -363,21 +369,19 @@ export async function reconcileInterruptedDeploymentHistories(
 		}
 		const reconciliation = classify(history.backup);
 		const { status, message } = reconciliation;
-		const appliedAudit =
-			status === "PARTIAL_SUCCESS"
-				? {
-						appliedCFs: reconciliation.appliedCFCount,
-						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
-					}
-				: {};
-		const syncAppliedAudit =
-			status === "PARTIAL_SUCCESS"
-				? {
-						configsApplied: reconciliation.appliedConfigs.length,
-						configsFailed: 1,
-						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
-					}
-				: {};
+		const appliedAudit = reconciliation.appliedConfigs
+			? {
+					appliedCFs: reconciliation.appliedCFCount ?? 0,
+					appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+				}
+			: {};
+		const syncAppliedAudit = reconciliation.appliedConfigs
+			? {
+					configsApplied: reconciliation.appliedConfigs.length,
+					configsFailed: status === "PARTIAL_SUCCESS" ? 1 : 0,
+					appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+				}
+			: {};
 		const primaryReconciled = await prisma.$transaction(async (tx) => {
 			const primary = await tx.templateDeploymentHistory.updateMany({
 				where: { id: history.id, status: "IN_PROGRESS" },
@@ -418,14 +422,13 @@ export async function reconcileInterruptedDeploymentHistories(
 		}
 		const reconciliation = classify(history.backup);
 		const { status, message } = reconciliation;
-		const appliedAudit =
-			status === "PARTIAL_SUCCESS"
-				? {
-						configsApplied: reconciliation.appliedConfigs.length,
-						configsFailed: 1,
-						appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
-					}
-				: {};
+		const appliedAudit = reconciliation.appliedConfigs
+			? {
+					configsApplied: reconciliation.appliedConfigs.length,
+					configsFailed: status === "PARTIAL_SUCCESS" ? 1 : 0,
+					appliedConfigs: JSON.stringify(reconciliation.appliedConfigs),
+				}
+			: {};
 		const result = await prisma.trashSyncHistory.updateMany({
 			where: { id: history.id, status: { in: ["IN_PROGRESS", "RUNNING"] } },
 			data: { status, completedAt: new Date(), errorLog: message, ...appliedAudit },

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -235,10 +235,12 @@ export function getEquivalentServiceInstanceIds(
 	target: DeploymentServiceInstance,
 ): string[] {
 	const targetService = target.service.toUpperCase();
+	const targetBaseUrl = normalizeDeploymentBaseUrl(target.baseUrl);
 	return instances
 		.filter(
 			(instance) =>
 				instance.service.toUpperCase() === targetService &&
+				normalizeDeploymentBaseUrl(instance.baseUrl) === targetBaseUrl &&
 				instance.credentialIdentity === target.credentialIdentity,
 		)
 		.map((instance) => instance.id);
@@ -247,9 +249,9 @@ export function getEquivalentServiceInstanceIds(
 /** Stable in-process lock identity for one user's physical ARR endpoint. */
 export function createDeploymentEndpointKey(
 	userId: string,
-	instance: Pick<DeploymentServiceInstance, "service" | "credentialIdentity">,
+	instance: Pick<DeploymentServiceInstance, "service" | "baseUrl" | "credentialIdentity">,
 ): string {
-	return `${userId}:${instance.service.toUpperCase()}:${instance.credentialIdentity}`;
+	return `${userId}:${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}:${instance.credentialIdentity}`;
 }
 
 /** Bind rollback metadata to both the normalized endpoint and configured credentials. */

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -83,7 +83,8 @@ export function resolveDeploymentTarget<TProfile extends DeploymentQualityProfil
 
 	if (mapping) {
 		const mappedProfile = profiles.find((profile) => profile.id === mapping.qualityProfileId);
-		if (isLegacyDeploymentConnectionMapping(mapping)) {
+		const isLegacyMapping = isLegacyDeploymentConnectionMapping(mapping);
+		if (isLegacyMapping) {
 			const namedProfile = findUniqueProfileByName(profiles, mapping.qualityProfileName);
 			if (!namedProfile) {
 				throw new ConflictError(
@@ -93,6 +94,17 @@ export function resolveDeploymentTarget<TProfile extends DeploymentQualityProfil
 			if (mappedProfile && mappedProfile !== namedProfile) {
 				throw new ConflictError(
 					`The legacy quality profile mapping identity no longer matches "${mapping.qualityProfileName}". The recorded numeric ID now belongs to "${mappedProfile.name ?? "Unknown"}". Unlink the legacy deployment and review a fresh preview.`,
+				);
+			}
+		} else {
+			if (!mappedProfile) {
+				throw new ConflictError(
+					`The bound quality profile "${mapping.qualityProfileName}" no longer exists at its recorded ID. Review a fresh preview before continuing.`,
+				);
+			}
+			if (mappedProfile.name !== mapping.qualityProfileName) {
+				throw new ConflictError(
+					`The bound quality profile identity no longer matches "${mapping.qualityProfileName}". The recorded numeric ID now belongs to "${mappedProfile.name ?? "Unknown"}". Review a fresh preview before continuing.`,
 				);
 			}
 		}

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -309,7 +309,7 @@ export function isLegacyDeploymentConnectionMapping(mapping: DeploymentConnectio
 	return !(
 		typeof mapping.connectionGeneration === "number" &&
 		Number.isSafeInteger(mapping.connectionGeneration) &&
-		mapping.connectionGeneration > 0 &&
+		mapping.connectionGeneration >= 0 &&
 		typeof mapping.connectionStateToken === "string" &&
 		mapping.connectionStateToken.trim().length > 0
 	);

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -10,8 +10,8 @@ export interface DeploymentProfileMapping {
 	templateId?: string;
 	qualityProfileId: number;
 	qualityProfileName: string;
-	connectionGeneration?: number | null;
-	connectionStateToken?: string | null;
+	connectionGeneration: number;
+	connectionStateToken: string | null;
 }
 
 export interface DeploymentServiceInstance {
@@ -306,7 +306,13 @@ export function createLegacyDeploymentConnectionBindings(
 
 /** Never use an unbound 2.x mapping to authorize a mutation after a connection may have changed. */
 export function isLegacyDeploymentConnectionMapping(mapping: DeploymentConnectionMapping): boolean {
-	return (mapping.connectionGeneration ?? 0) === 0 && mapping.connectionStateToken === null;
+	return !(
+		typeof mapping.connectionGeneration === "number" &&
+		Number.isSafeInteger(mapping.connectionGeneration) &&
+		mapping.connectionGeneration > 0 &&
+		typeof mapping.connectionStateToken === "string" &&
+		mapping.connectionStateToken.trim().length > 0
+	);
 }
 
 export function assertNoLegacyDeploymentConnectionMappings(

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -18,13 +18,14 @@ export interface DeploymentServiceInstance {
 	id: string;
 	service: string;
 	baseUrl: string;
-	credentialIdentity?: string;
+	credentialIdentity: string;
 }
 
 export interface DeploymentConnectionBinding {
 	instanceId: string;
 	connectionGeneration: number;
 	connectionStateToken: string | null;
+	credentialIdentity?: string;
 }
 
 interface DeploymentConnectionMapping {
@@ -234,12 +235,11 @@ export function getEquivalentServiceInstanceIds(
 	target: DeploymentServiceInstance,
 ): string[] {
 	const targetService = target.service.toUpperCase();
-	const targetBaseUrl = normalizeDeploymentBaseUrl(target.baseUrl);
 	return instances
 		.filter(
 			(instance) =>
 				instance.service.toUpperCase() === targetService &&
-				normalizeDeploymentBaseUrl(instance.baseUrl) === targetBaseUrl,
+				instance.credentialIdentity === target.credentialIdentity,
 		)
 		.map((instance) => instance.id);
 }
@@ -247,9 +247,9 @@ export function getEquivalentServiceInstanceIds(
 /** Stable in-process lock identity for one user's physical ARR endpoint. */
 export function createDeploymentEndpointKey(
 	userId: string,
-	instance: Pick<DeploymentServiceInstance, "service" | "baseUrl">,
+	instance: Pick<DeploymentServiceInstance, "service" | "credentialIdentity">,
 ): string {
-	return `${userId}:${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}`;
+	return `${userId}:${instance.service.toUpperCase()}:${instance.credentialIdentity}`;
 }
 
 /** Bind rollback metadata to both the normalized endpoint and configured credentials. */
@@ -278,19 +278,22 @@ export function createDeploymentConnectionStateToken(instance: {
 /** Bind database ownership records to the exact configured ARR connection. */
 export function createDeploymentConnectionBinding(
 	instance: DeploymentConnectionInstance,
+	credentialIdentity?: string,
 ): DeploymentConnectionBinding {
 	return {
 		instanceId: instance.id,
 		connectionGeneration: instance.connectionGeneration ?? 0,
 		connectionStateToken: createDeploymentConnectionStateToken(instance),
+		...(credentialIdentity ? { credentialIdentity } : {}),
 	};
 }
 
 /** Resolve mappings bound to the exact configured ARR connection. */
 export function createDeploymentConnectionBindingCandidates(
 	instance: DeploymentConnectionInstance,
+	credentialIdentity?: string,
 ): DeploymentConnectionBinding[] {
-	return [createDeploymentConnectionBinding(instance)];
+	return [createDeploymentConnectionBinding(instance, credentialIdentity)];
 }
 
 /** Locate pre-binding mappings so callers can reject them without trusting them as ownership. */

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -1,0 +1,366 @@
+import { createHash } from "node:crypto";
+import { ConflictError } from "../errors.js";
+
+export interface DeploymentQualityProfile {
+	id?: number;
+	name?: string | null;
+}
+
+export interface DeploymentProfileMapping {
+	templateId?: string;
+	qualityProfileId: number;
+	qualityProfileName: string;
+	connectionGeneration?: number | null;
+	connectionStateToken?: string | null;
+}
+
+export interface DeploymentServiceInstance {
+	id: string;
+	service: string;
+	baseUrl: string;
+	credentialIdentity?: string;
+}
+
+export interface DeploymentConnectionBinding {
+	instanceId: string;
+	connectionGeneration: number;
+	connectionStateToken: string | null;
+}
+
+interface DeploymentConnectionMapping {
+	connectionGeneration?: number | null;
+	connectionStateToken?: string | null;
+}
+
+interface DeploymentConnectionInstance {
+	id: string;
+	service: string;
+	baseUrl: string;
+	encryptedApiKey: string;
+	encryptionIv: string;
+	encryptedHttpAuthCredentials?: string | null;
+	httpAuthEncryptionIv?: string | null;
+	connectionGeneration?: number | null;
+}
+
+export interface ResolvedDeploymentTarget<TProfile extends DeploymentQualityProfile> {
+	profile: TProfile | undefined;
+	profileName: string;
+	matchedBy: "mapping_id" | "mapping_name" | "source_id" | "source_name" | "template_name" | "new";
+}
+
+function findUniqueProfileByName<TProfile extends DeploymentQualityProfile>(
+	profiles: TProfile[],
+	name: string,
+): TProfile | undefined {
+	const matches = profiles.filter((profile) => profile.name === name);
+	if (matches.length > 1) {
+		throw new ConflictError(
+			`Multiple quality profiles named "${name}" exist in the instance. Rename or remove the duplicate before deploying.`,
+		);
+	}
+	return matches[0];
+}
+
+/**
+ * Resolve the one quality profile a deployment is authorized to mutate.
+ *
+ * A stored mapping is authoritative. For a first deployment, cloned templates
+ * retain the source profile identity even when the template itself was renamed.
+ * Every name fallback must be unique so preview and execution fail closed on
+ * ambiguous upstream state.
+ */
+export function resolveDeploymentTarget<TProfile extends DeploymentQualityProfile>(args: {
+	profiles: TProfile[];
+	mapping?: DeploymentProfileMapping | null;
+	sourceProfileId?: number | null;
+	isSourceInstance?: boolean;
+	sourceProfileName?: string | null;
+	templateName?: string | null;
+}): ResolvedDeploymentTarget<TProfile> {
+	const { profiles, mapping, sourceProfileId, isSourceInstance, sourceProfileName, templateName } =
+		args;
+
+	if (mapping) {
+		const mappedProfile = profiles.find((profile) => profile.id === mapping.qualityProfileId);
+		if (isLegacyDeploymentConnectionMapping(mapping)) {
+			const namedProfile = findUniqueProfileByName(profiles, mapping.qualityProfileName);
+			if (!namedProfile) {
+				throw new ConflictError(
+					`The legacy quality profile mapping for "${mapping.qualityProfileName}" cannot be verified because that name no longer exists. Unlink the legacy deployment and review a fresh preview.`,
+				);
+			}
+			if (mappedProfile && mappedProfile !== namedProfile) {
+				throw new ConflictError(
+					`The legacy quality profile mapping identity no longer matches "${mapping.qualityProfileName}". The recorded numeric ID now belongs to "${mappedProfile.name ?? "Unknown"}". Unlink the legacy deployment and review a fresh preview.`,
+				);
+			}
+		}
+		if (mappedProfile) {
+			return {
+				profile: mappedProfile,
+				profileName: mappedProfile.name ?? mapping.qualityProfileName,
+				matchedBy: "mapping_id",
+			};
+		}
+
+		const recoveredProfile = findUniqueProfileByName(profiles, mapping.qualityProfileName);
+		if (recoveredProfile) {
+			return {
+				profile: recoveredProfile,
+				profileName: recoveredProfile.name ?? mapping.qualityProfileName,
+				matchedBy: "mapping_name",
+			};
+		}
+
+		throw new ConflictError(
+			`The mapped quality profile "${mapping.qualityProfileName}" no longer exists in the instance. Unlink this deployment before selecting a different profile.`,
+		);
+	}
+
+	if (isSourceInstance && sourceProfileId !== undefined && sourceProfileId !== null) {
+		const sourceProfile = profiles.find((profile) => profile.id === sourceProfileId);
+		if (!sourceProfile) {
+			throw new ConflictError(
+				`The cloned source quality profile (ID: ${sourceProfileId}) no longer exists in the source instance. Refresh or recreate the template before deploying.`,
+			);
+		}
+		if (sourceProfileName && sourceProfile.name !== sourceProfileName) {
+			throw new ConflictError(
+				`The cloned source quality profile identity changed from "${sourceProfileName}" to "${sourceProfile.name ?? "Unknown"}". Refresh or recreate the template before deploying.`,
+			);
+		}
+		return {
+			profile: sourceProfile,
+			profileName: sourceProfile.name ?? sourceProfileName ?? "TRaSH Guides HD/UHD",
+			matchedBy: "source_id",
+		};
+	}
+
+	const candidates: Array<{
+		name: string | null | undefined;
+		matchedBy: Exclude<
+			ResolvedDeploymentTarget<TProfile>["matchedBy"],
+			"mapping_id" | "mapping_name" | "source_id" | "new"
+		>;
+	}> = [
+		{ name: sourceProfileName, matchedBy: "source_name" },
+		{ name: templateName, matchedBy: "template_name" },
+	];
+
+	const checkedNames = new Set<string>();
+	for (const candidate of candidates) {
+		if (!candidate.name || checkedNames.has(candidate.name)) continue;
+		checkedNames.add(candidate.name);
+		const profile = findUniqueProfileByName(profiles, candidate.name);
+		if (profile) {
+			return {
+				profile,
+				profileName: profile.name ?? candidate.name,
+				matchedBy: candidate.matchedBy,
+			};
+		}
+	}
+
+	return {
+		profile: undefined,
+		profileName: sourceProfileName || templateName || "TRaSH Guides HD/UHD",
+		matchedBy: "new",
+	};
+}
+
+/** Reject a deployment that would take over a profile managed by another template. */
+export function assertDeploymentTargetOwnership(args: {
+	target: ResolvedDeploymentTarget<DeploymentQualityProfile>;
+	templateId: string;
+	existingMappings: DeploymentProfileMapping[];
+}): void {
+	const targetProfileId = args.target.profile?.id;
+	const owner = args.existingMappings
+		.filter((mapping) => mapping.templateId !== args.templateId)
+		.find(
+			(mapping) =>
+				(targetProfileId !== undefined && mapping.qualityProfileId === targetProfileId) ||
+				mapping.qualityProfileName === args.target.profileName,
+		);
+	if (owner?.templateId && owner.templateId !== args.templateId) {
+		throw new ConflictError(
+			`Quality profile "${args.target.profileName}" is already managed by another template. Unlink that deployment before using this profile.`,
+		);
+	}
+}
+
+function stableValue(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(stableValue);
+	}
+	if (value && typeof value === "object") {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, item]) => [key, stableValue(item)]),
+		);
+	}
+	return value;
+}
+
+export function normalizeDeploymentBaseUrl(baseUrl: string): string {
+	try {
+		const url = new URL(baseUrl);
+		url.hash = "";
+		url.search = "";
+		url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+		return url.toString();
+	} catch {
+		return baseUrl.trim().replace(/\/+$/, "");
+	}
+}
+
+/** Resolve every local service record that represents the same upstream ARR endpoint. */
+export function getEquivalentServiceInstanceIds(
+	instances: DeploymentServiceInstance[],
+	target: DeploymentServiceInstance,
+): string[] {
+	const targetService = target.service.toUpperCase();
+	const targetBaseUrl = normalizeDeploymentBaseUrl(target.baseUrl);
+	return instances
+		.filter(
+			(instance) =>
+				instance.service.toUpperCase() === targetService &&
+				normalizeDeploymentBaseUrl(instance.baseUrl) === targetBaseUrl,
+		)
+		.map((instance) => instance.id);
+}
+
+/** Stable in-process lock identity for one user's physical ARR endpoint. */
+export function createDeploymentEndpointKey(
+	userId: string,
+	instance: Pick<DeploymentServiceInstance, "service" | "baseUrl">,
+): string {
+	return `${userId}:${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}`;
+}
+
+/** Bind rollback metadata to both the normalized endpoint and configured credentials. */
+export function createDeploymentConnectionStateToken(instance: {
+	service: string;
+	baseUrl: string;
+	encryptedApiKey: string;
+	encryptionIv: string;
+	encryptedHttpAuthCredentials?: string | null;
+	httpAuthEncryptionIv?: string | null;
+	connectionGeneration?: number | null;
+}): string {
+	return createUpstreamResourceStateToken({
+		service: instance.service.toUpperCase(),
+		baseUrl: normalizeDeploymentBaseUrl(instance.baseUrl),
+		credentials: [
+			instance.encryptedApiKey,
+			instance.encryptionIv,
+			instance.encryptedHttpAuthCredentials ?? null,
+			instance.httpAuthEncryptionIv ?? null,
+		],
+		connectionGeneration: instance.connectionGeneration ?? 0,
+	});
+}
+
+/** Bind database ownership records to the exact configured ARR connection. */
+export function createDeploymentConnectionBinding(
+	instance: DeploymentConnectionInstance,
+): DeploymentConnectionBinding {
+	return {
+		instanceId: instance.id,
+		connectionGeneration: instance.connectionGeneration ?? 0,
+		connectionStateToken: createDeploymentConnectionStateToken(instance),
+	};
+}
+
+/** Resolve mappings bound to the exact configured ARR connection. */
+export function createDeploymentConnectionBindingCandidates(
+	instance: DeploymentConnectionInstance,
+): DeploymentConnectionBinding[] {
+	return [createDeploymentConnectionBinding(instance)];
+}
+
+/** Locate pre-binding mappings so callers can reject them without trusting them as ownership. */
+export function createLegacyDeploymentConnectionBindings(
+	instanceIds: string[],
+): DeploymentConnectionBinding[] {
+	return instanceIds.map((instanceId) => ({
+		instanceId,
+		connectionGeneration: 0,
+		connectionStateToken: null,
+	}));
+}
+
+/** Never use an unbound 2.x mapping to authorize a mutation after a connection may have changed. */
+export function isLegacyDeploymentConnectionMapping(mapping: DeploymentConnectionMapping): boolean {
+	return (mapping.connectionGeneration ?? 0) === 0 && mapping.connectionStateToken === null;
+}
+
+export function assertNoLegacyDeploymentConnectionMappings(
+	mappings: DeploymentConnectionMapping[],
+): void {
+	if (mappings.some(isLegacyDeploymentConnectionMapping)) {
+		throw new ConflictError(
+			"This deployment mapping predates connection identity verification. Unlink the legacy deployment and review a fresh preview before continuing.",
+		);
+	}
+}
+
+/** Create an opaque fingerprint for the exact upstream state shown in preview. */
+export function createDeploymentStateToken(args: {
+	template: {
+		id: string;
+		name: string;
+		configData: string;
+		instanceOverrides?: string | null;
+		sourceQualityProfileName?: string | null;
+	};
+	instanceId: string;
+	connection: {
+		service: string;
+		baseUrl: string;
+		credentialIdentity: string;
+	};
+	target: ResolvedDeploymentTarget<DeploymentQualityProfile>;
+	customFormats: unknown[];
+	namingConfig?: unknown;
+	namingPayload?: unknown;
+	savedScoreOverrides?: unknown;
+	orphanedFormatScoreChanges?: unknown;
+}): string {
+	const state = stableValue({
+		template: args.template,
+		instanceId: args.instanceId,
+		connection: {
+			...args.connection,
+			baseUrl: normalizeDeploymentBaseUrl(args.connection.baseUrl),
+		},
+		target: {
+			matchedBy: args.target.matchedBy,
+			profileName: args.target.profileName,
+			profile: args.target.profile ?? null,
+		},
+		customFormats: args.customFormats,
+		namingConfig: args.namingConfig ?? null,
+		namingPayload: args.namingPayload ?? null,
+		savedScoreOverrides: args.savedScoreOverrides ?? null,
+		orphanedFormatScoreChanges: args.orphanedFormatScoreChanges ?? null,
+	});
+
+	return createHash("sha256").update(JSON.stringify(state)).digest("hex");
+}
+
+/** Fingerprint one upstream resource using stable object-key ordering. */
+export function createUpstreamResourceStateToken(resource: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(stableValue(resource)))
+		.digest("hex");
+}
+
+/** Fingerprint a full upstream profile for a last-moment concurrency check. */
+export function createQualityProfileStateToken(profile: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(stableValue(profile)))
+		.digest("hex");
+}


### PR DESCRIPTION
## Summary

Adds the route-independent deployment safety primitives for the #672 replacement stack:

- authoritative target and connection identity resolution
- exact backup-ledger parsing and conservative retention
- operation serialization and interrupted-history reconciliation
- active shared-resource ownership protection
- compare-and-set rebinding for reviewed legacy mappings

No HTTP routes or user-facing workflow are included.

## Validation

- Focused Vitest: 65 passing tests
- `pnpm run typecheck`
- `pnpm run test` (3,277 passing; 43 skipped)
- `pnpm run lint`

`pnpm run format` remains red only for four pre-existing OIDC files; the identical failure reproduces on base `codex/trash-deploy-state-foundation`.

Related to #672