### PR TITLE
feat(trash-guides): capture deployment state

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseDeploymentBackupState } from "../deployment-backup-state.js";
+import {
+	parseDeploymentBackupState,
+	shouldRetainDeploymentBackup,
+} from "../deployment-backup-state.js";
 
 function validBackup() {
 	return {
@@ -98,5 +101,40 @@ describe("parseDeploymentBackupState", () => {
 		expect(() => parseDeploymentBackupState(JSON.stringify(backup))).toThrow(
 			"Applied profile state requires a profile ID",
 		);
+	});
+});
+
+describe("shouldRetainDeploymentBackup", () => {
+	it("retains a relationless applied v2 deployment ledger", () => {
+		const backup = validBackup();
+		backup.customFormatDeployments = [
+			{
+				beforeFormat: { id: 7, name: "Foo", specifications: [] },
+				action: "updated",
+				resourceId: 7,
+				name: "Foo",
+				status: "applied",
+				postStateToken: "post-token",
+			},
+		] as never;
+
+		expect(shouldRetainDeploymentBackup(JSON.stringify(backup))).toBe(true);
+	});
+
+	it.each([
+		["invalid JSON", "not-json"],
+		["missing schema version", JSON.stringify({ endpointKey: "current-like" })],
+		["string schema version", JSON.stringify({ schemaVersion: "2" })],
+		["malformed current schema", JSON.stringify({ schemaVersion: 2 })],
+		["future schema version", JSON.stringify({ schemaVersion: 3 })],
+	] as const)("retains %s", (_label, backupData) => {
+		expect(shouldRetainDeploymentBackup(backupData)).toBe(true);
+	});
+
+	it.each([
+		["raw Custom Format array", JSON.stringify([])],
+		["object snapshot", JSON.stringify({ customFormats: [], qualityProfile: null })],
+	] as const)("allows positively identified legacy %s cleanup", (_label, backupData) => {
+		expect(shouldRetainDeploymentBackup(backupData)).toBe(false);
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -135,6 +135,16 @@ describe("shouldRetainDeploymentBackup", () => {
 
 	it.each([
 		["raw Custom Format array", JSON.stringify([])],
+		[
+			"legacy Custom Format without include-on-rename",
+			JSON.stringify([
+				{
+					id: 7,
+					name: "Legacy CF",
+					specifications: [],
+				},
+			]),
+		],
 		["object snapshot", JSON.stringify({ customFormats: [], qualityProfile: null })],
 		[
 			"object snapshot with Unknown quality",

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -136,6 +136,31 @@ describe("shouldRetainDeploymentBackup", () => {
 	it.each([
 		["raw Custom Format array", JSON.stringify([])],
 		["object snapshot", JSON.stringify({ customFormats: [], qualityProfile: null })],
+		[
+			"object snapshot with Unknown quality",
+			JSON.stringify({
+				customFormats: [],
+				qualityProfile: {
+					id: 4,
+					name: "Legacy",
+					upgradeAllowed: true,
+					cutoff: 0,
+					items: [
+						{
+							id: 0,
+							name: "Unknown",
+							allowed: false,
+							quality: { id: 0, name: "Unknown" },
+							items: [],
+						},
+					],
+					minFormatScore: 0,
+					cutoffFormatScore: 0,
+					minUpgradeFormatScore: 0,
+					formatItems: [],
+				},
+			}),
+		],
 	] as const)("allows positively identified legacy %s cleanup", (_label, backupData) => {
 		expect(shouldRetainDeploymentBackup(backupData)).toBe(false);
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-backup-state.test.ts
@@ -127,6 +127,8 @@ describe("shouldRetainDeploymentBackup", () => {
 		["string schema version", JSON.stringify({ schemaVersion: "2" })],
 		["malformed current schema", JSON.stringify({ schemaVersion: 2 })],
 		["future schema version", JSON.stringify({ schemaVersion: 3 })],
+		["malformed legacy profile", JSON.stringify({ customFormats: [], qualityProfile: {} })],
+		["malformed legacy Custom Format", JSON.stringify([{ id: 7, name: "Incomplete" }])],
 	] as const)("retains %s", (_label, backupData) => {
 		expect(shouldRetainDeploymentBackup(backupData)).toBe(true);
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	type CustomFormatRollbackState,
+	rollbackCustomFormatDeployment,
+} from "../deployment-custom-format-state.js";
+import { createUpstreamResourceStateToken } from "../deployment-target.js";
+
+const appliedState = (
+	overrides: Partial<CustomFormatRollbackState> = {},
+): CustomFormatRollbackState => ({
+	beforeFormat: null,
+	action: "created",
+	resourceId: 7,
+	name: "Created CF",
+	status: "applied",
+	postStateToken: createUpstreamResourceStateToken({
+		id: 7,
+		name: "Created CF",
+		specifications: [],
+	}),
+	intendedPostStateToken: null,
+	...overrides,
+});
+
+describe("rollbackCustomFormatDeployment", () => {
+	it("deletes only the exact unchanged Custom Format created by deployment", async () => {
+		const deployed = { id: 7, name: "Created CF", specifications: [] };
+		const remove = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				delete: remove,
+			},
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).resolves.toBe(
+			"deleted",
+		);
+		expect(remove).toHaveBeenCalledWith(7);
+	});
+
+	it("refuses to delete a created Custom Format that changed after deployment", async () => {
+		const changed = { id: 7, name: "Operator CF", specifications: [] };
+		const remove = vi.fn();
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([changed]),
+				getById: vi.fn().mockResolvedValue(changed),
+				delete: remove,
+			},
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"changed after deployment",
+		);
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("refuses to delete an unchanged created Custom Format reused by a live profile", async () => {
+		const deployed = { id: 7, name: "Created CF", specifications: [] };
+		const remove = vi.fn();
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				delete: remove,
+			},
+			qualityProfile: {
+				getAll: vi
+					.fn()
+					.mockResolvedValue([{ id: 3, name: "Manually reused", formatItems: [{ format: 7 }] }]),
+			},
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"referenced by quality profile",
+		);
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("restores an updated Custom Format only from its exact post-write state", async () => {
+		const before = { id: 4, name: "Existing CF", specifications: [{ name: "old" }] };
+		const deployed = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				update,
+			},
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 4,
+					name: "Existing CF",
+					postStateToken: createUpstreamResourceStateToken(deployed),
+				}),
+			),
+		).resolves.toBe("restored");
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
+	it("treats a pending update still at its before-state as an idempotent no-op", async () => {
+		const before = { id: 4, name: "Existing CF", specifications: [] };
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([before]),
+				getById: vi.fn().mockResolvedValue(before),
+			},
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 4,
+					name: "Existing CF",
+					status: "pending",
+					postStateToken: null,
+				}),
+			),
+		).resolves.toBe("noop");
+	});
+
+	it("fails closed when a pending write left an unknown current state", async () => {
+		const before = { id: 4, name: "Existing CF", specifications: [] };
+		const changed = { ...before, specifications: [{ name: "unknown" }] };
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([changed]),
+				getById: vi.fn().mockResolvedValue(changed),
+			},
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 4,
+					name: "Existing CF",
+					status: "pending",
+					postStateToken: null,
+				}),
+			),
+		).rejects.toThrow("unverified deployment state");
+	});
+
+	it("restores a pending update when the upstream state matches the recorded intent", async () => {
+		const before = { id: 4, name: "Existing CF", specifications: [{ name: "old" }] };
+		const intended = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([intended]),
+				getById: vi.fn().mockResolvedValue(intended),
+				update,
+			},
+		};
+		const state = {
+			...appliedState({
+				beforeFormat: before,
+				action: "updated",
+				resourceId: 4,
+				name: "Existing CF",
+				status: "pending",
+				postStateToken: null,
+			}),
+			intendedPostStateToken: createUpstreamResourceStateToken(intended),
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, state)).resolves.toBe("restored");
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
+	it("deletes a pending create when its exact returned state was durably recorded", async () => {
+		const created = { id: 7, name: "Created CF", specifications: [] };
+		const remove = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([created]),
+				getById: vi.fn().mockResolvedValue(created),
+				delete: remove,
+			},
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					status: "pending",
+					postStateToken: createUpstreamResourceStateToken(created),
+				}),
+			),
+		).resolves.toBe("deleted");
+		expect(remove).toHaveBeenCalledWith(7);
+	});
+
+	it("reconciles a pending create after the unknown resource is manually removed", async () => {
+		const client = { customFormat: { getAll: vi.fn().mockResolvedValue([]) } };
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					action: "created",
+					resourceId: null,
+					name: "Created CF",
+					status: "pending",
+					postStateToken: null,
+				}),
+			),
+		).resolves.toBe("noop");
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
@@ -22,6 +22,16 @@ const appliedState = (
 	...overrides,
 });
 
+function completeSpecification(name: string) {
+	return {
+		name,
+		implementation: "ReleaseTitleSpecification",
+		negate: false,
+		required: false,
+		fields: [{ name: "value", type: "textbox", value: name }],
+	};
+}
+
 describe("rollbackCustomFormatDeployment", () => {
 	it("retains an unchanged created Custom Format when deletion has no conditional boundary", async () => {
 		const deployed = { id: 7, name: "Created CF", specifications: [] };
@@ -153,7 +163,7 @@ describe("rollbackCustomFormatDeployment", () => {
 		const before = {
 			id: 4,
 			name: "Existing CF",
-			specifications: [{ name: "old" }],
+			specifications: [completeSpecification("old")],
 			includeCustomFormatWhenRenaming: false,
 		};
 		const deployed = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
@@ -183,6 +193,15 @@ describe("rollbackCustomFormatDeployment", () => {
 
 	it.each([
 		["incomplete", { id: 4, name: "Existing CF" }],
+		[
+			"malformed nested specification",
+			{
+				id: 4,
+				name: "Existing CF",
+				specifications: [{}],
+				includeCustomFormatWhenRenaming: false,
+			},
+		],
 		[
 			"cross-wired",
 			{
@@ -281,7 +300,7 @@ describe("rollbackCustomFormatDeployment", () => {
 		const before = {
 			id: 4,
 			name: "Existing CF",
-			specifications: [{ name: "old" }],
+			specifications: [completeSpecification("old")],
 			includeCustomFormatWhenRenaming: false,
 		};
 		const intended = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
@@ -23,7 +23,7 @@ const appliedState = (
 });
 
 describe("rollbackCustomFormatDeployment", () => {
-	it("deletes only the exact unchanged Custom Format created by deployment", async () => {
+	it("retains an unchanged created Custom Format when deletion has no conditional boundary", async () => {
 		const deployed = { id: 7, name: "Created CF", specifications: [] };
 		const remove = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -35,10 +35,10 @@ describe("rollbackCustomFormatDeployment", () => {
 			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
 		};
 
-		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).resolves.toBe(
-			"deleted",
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"cannot be deleted safely",
 		);
-		expect(remove).toHaveBeenCalledWith(7);
+		expect(remove).not.toHaveBeenCalled();
 	});
 
 	it("refuses to delete a created Custom Format that changed after deployment", async () => {
@@ -80,8 +80,82 @@ describe("rollbackCustomFormatDeployment", () => {
 		expect(remove).not.toHaveBeenCalled();
 	});
 
+	it("fetches a complete profile when a partial listing omits formatItems", async () => {
+		const deployed = { id: 7, name: "Created CF", specifications: [] };
+		const remove = vi.fn();
+		const getProfileById = vi.fn().mockResolvedValue({
+			id: 3,
+			name: "Manually reused",
+			formatItems: [{ format: 7, score: 100 }],
+		});
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				delete: remove,
+			},
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([{ id: 3, name: "Manually reused" }]),
+				getById: getProfileById,
+			},
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"referenced by quality profile",
+		);
+		expect(getProfileById).toHaveBeenCalledWith(3);
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when a full profile still has no complete Custom Format reference list", async () => {
+		const deployed = { id: 7, name: "Created CF", specifications: [] };
+		const remove = vi.fn();
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				delete: remove,
+			},
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([{ id: 3, name: "Incomplete" }]),
+				getById: vi.fn().mockResolvedValue({ id: 3, name: "Incomplete", formatItems: null }),
+			},
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"reference list could not be established",
+		);
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("re-checks exact Custom Format identity after profile reference checks", async () => {
+		const deployed = { id: 7, name: "Created CF", specifications: [] };
+		const changed = { id: 7, name: "Created CF", specifications: [{ name: "operator edit" }] };
+		const remove = vi.fn();
+		const getById = vi.fn().mockResolvedValueOnce(deployed).mockResolvedValueOnce(changed);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById,
+				delete: remove,
+			},
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(rollbackCustomFormatDeployment(client as never, appliedState())).rejects.toThrow(
+			"changed after deployment",
+		);
+		expect(getById).toHaveBeenCalledTimes(2);
+		expect(remove).not.toHaveBeenCalled();
+	});
+
 	it("restores an updated Custom Format only from its exact post-write state", async () => {
-		const before = { id: 4, name: "Existing CF", specifications: [{ name: "old" }] };
+		const before = {
+			id: 4,
+			name: "Existing CF",
+			specifications: [{ name: "old" }],
+			includeCustomFormatWhenRenaming: false,
+		};
 		const deployed = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
 		const update = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -107,8 +181,50 @@ describe("rollbackCustomFormatDeployment", () => {
 		expect(update).toHaveBeenCalledWith(4, before);
 	});
 
+	it.each([
+		["incomplete", { id: 4, name: "Existing CF" }],
+		[
+			"cross-wired",
+			{
+				id: 9,
+				name: "Existing CF",
+				specifications: [],
+				includeCustomFormatWhenRenaming: false,
+			},
+		],
+	] as const)("rejects a %s persisted Custom Format snapshot", async (_label, beforeFormat) => {
+		const deployed = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
+		const update = vi.fn();
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				update,
+			},
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					beforeFormat,
+					action: "updated",
+					resourceId: 4,
+					name: "Existing CF",
+					postStateToken: createUpstreamResourceStateToken(deployed),
+				}),
+			),
+		).rejects.toThrow("pre-deployment state");
+		expect(update).not.toHaveBeenCalled();
+	});
+
 	it("treats a pending update still at its before-state as an idempotent no-op", async () => {
-		const before = { id: 4, name: "Existing CF", specifications: [] };
+		const before = {
+			id: 4,
+			name: "Existing CF",
+			specifications: [],
+			includeCustomFormatWhenRenaming: false,
+		};
 		const client = {
 			customFormat: {
 				getAll: vi.fn().mockResolvedValue([before]),
@@ -132,7 +248,12 @@ describe("rollbackCustomFormatDeployment", () => {
 	});
 
 	it("fails closed when a pending write left an unknown current state", async () => {
-		const before = { id: 4, name: "Existing CF", specifications: [] };
+		const before = {
+			id: 4,
+			name: "Existing CF",
+			specifications: [],
+			includeCustomFormatWhenRenaming: false,
+		};
 		const changed = { ...before, specifications: [{ name: "unknown" }] };
 		const client = {
 			customFormat: {
@@ -157,7 +278,12 @@ describe("rollbackCustomFormatDeployment", () => {
 	});
 
 	it("restores a pending update when the upstream state matches the recorded intent", async () => {
-		const before = { id: 4, name: "Existing CF", specifications: [{ name: "old" }] };
+		const before = {
+			id: 4,
+			name: "Existing CF",
+			specifications: [{ name: "old" }],
+			includeCustomFormatWhenRenaming: false,
+		};
 		const intended = { id: 4, name: "Existing CF", specifications: [{ name: "new" }] };
 		const update = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -183,7 +309,7 @@ describe("rollbackCustomFormatDeployment", () => {
 		expect(update).toHaveBeenCalledWith(4, before);
 	});
 
-	it("deletes a pending create when its exact returned state was durably recorded", async () => {
+	it("retains a pending create when its exact returned state cannot be conditionally deleted", async () => {
 		const created = { id: 7, name: "Created CF", specifications: [] };
 		const remove = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -203,12 +329,16 @@ describe("rollbackCustomFormatDeployment", () => {
 					postStateToken: createUpstreamResourceStateToken(created),
 				}),
 			),
-		).resolves.toBe("deleted");
-		expect(remove).toHaveBeenCalledWith(7);
+		).rejects.toThrow("cannot be deleted safely");
+		expect(remove).not.toHaveBeenCalled();
 	});
 
-	it("reconciles a pending create after the unknown resource is manually removed", async () => {
-		const client = { customFormat: { getAll: vi.fn().mockResolvedValue([]) } };
+	it("keeps an unknown-ID create unresolved when the resource may have been renamed", async () => {
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([{ id: 12, name: "Renamed after create" }]),
+			},
+		};
 
 		await expect(
 			rollbackCustomFormatDeployment(
@@ -221,6 +351,6 @@ describe("rollbackCustomFormatDeployment", () => {
 					postStateToken: null,
 				}),
 			),
-		).resolves.toBe("noop");
+		).rejects.toThrow("ID is unknown");
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
@@ -159,7 +159,7 @@ describe("rollbackCustomFormatDeployment", () => {
 		expect(remove).not.toHaveBeenCalled();
 	});
 
-	it("restores an updated Custom Format only from its exact post-write state", async () => {
+	it("retains an updated Custom Format when restoration has no conditional boundary", async () => {
 		const before = {
 			id: 4,
 			name: "Existing CF",
@@ -187,8 +187,8 @@ describe("rollbackCustomFormatDeployment", () => {
 					postStateToken: createUpstreamResourceStateToken(deployed),
 				}),
 			),
-		).resolves.toBe("restored");
-		expect(update).toHaveBeenCalledWith(4, before);
+		).rejects.toThrow("cannot be restored safely");
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it.each([
@@ -296,7 +296,7 @@ describe("rollbackCustomFormatDeployment", () => {
 		).rejects.toThrow("unverified deployment state");
 	});
 
-	it("restores a pending update when the upstream state matches the recorded intent", async () => {
+	it("retains a pending update when restoration has no conditional boundary", async () => {
 		const before = {
 			id: 4,
 			name: "Existing CF",
@@ -324,8 +324,10 @@ describe("rollbackCustomFormatDeployment", () => {
 			intendedPostStateToken: createUpstreamResourceStateToken(intended),
 		};
 
-		await expect(rollbackCustomFormatDeployment(client as never, state)).resolves.toBe("restored");
-		expect(update).toHaveBeenCalledWith(4, before);
+		await expect(rollbackCustomFormatDeployment(client as never, state)).rejects.toThrow(
+			"cannot be restored safely",
+		);
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it("retains a pending create when its exact returned state cannot be conditionally deleted", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-managed-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-managed-format-state.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	captureManagedCustomFormatIdentities,
+	parseManagedCustomFormatIdentities,
+	readPersistedManagedCustomFormatIdentities,
+	resolveOrphanedManagedCustomFormats,
+} from "../deployment-managed-format-state.js";
+
+const templateFormat = { trashId: "trash-1", name: "Foo" } as never;
+
+describe("managed Custom Format identities", () => {
+	it("captures the exact upstream ID and full-resource state", async () => {
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Foo" }]),
+				getById: vi.fn().mockResolvedValue({ id: 7, name: "Foo", specifications: [] }),
+			},
+		};
+
+		const result = await captureManagedCustomFormatIdentities(client as never, [templateFormat], {
+			id: 3,
+			formatItems: [{ format: 7, score: 100 }],
+		});
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				trashId: "trash-1",
+				name: "Foo",
+				resourceId: 7,
+				profileId: 3,
+				appliedScore: 100,
+			}),
+		]);
+		expect(result[0]?.stateToken).toEqual(expect.any(String));
+	});
+
+	it("fails closed when any deployed template format cannot be captured", async () => {
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([]),
+				getById: vi.fn(),
+			},
+		};
+
+		await expect(
+			captureManagedCustomFormatIdentities(client as never, [templateFormat], {
+				id: 3,
+				formatItems: [],
+			}),
+		).rejects.toThrow("could not be captured");
+	});
+
+	it("resolves an unchanged removed format by ID", async () => {
+		const full = { id: 7, name: "Foo", specifications: [] };
+		const captured = await captureManagedCustomFormatIdentities(
+			{
+				customFormat: {
+					getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Foo" }]),
+					getById: vi.fn().mockResolvedValue(full),
+				},
+			} as never,
+			[templateFormat],
+			{ id: 3, formatItems: [{ format: 7, score: 100 }] },
+		);
+		const result = await resolveOrphanedManagedCustomFormats(
+			{
+				customFormat: {
+					getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Foo" }]),
+					getById: vi.fn().mockResolvedValue(full),
+				},
+			} as never,
+			[],
+			captured,
+			{ id: 3, formatItems: [{ format: 7, score: 100 }] },
+		);
+
+		expect(result).toEqual({
+			formats: [{ trashId: "trash-1", name: "Foo", resourceId: 7 }],
+			warnings: [],
+		});
+	});
+
+	it("refuses a same-name replacement at a different ID", async () => {
+		const result = await resolveOrphanedManagedCustomFormats(
+			{
+				customFormat: {
+					getAll: vi.fn().mockResolvedValue([{ id: 8, name: "Foo" }]),
+					getById: vi.fn(),
+				},
+			} as never,
+			[],
+			[
+				{
+					trashId: "trash-1",
+					name: "Foo",
+					resourceId: 7,
+					stateToken: "token",
+					profileId: 3,
+					appliedScore: 100,
+				},
+			],
+			{ id: 3, formatItems: [{ format: 7, score: 100 }] },
+		);
+
+		expect(result).toEqual({ formats: [], warnings: [] });
+	});
+
+	it("preserves a manually changed upstream score when a format is removed", async () => {
+		const full = { id: 7, name: "Foo", specifications: [] };
+		const result = await resolveOrphanedManagedCustomFormats(
+			{
+				customFormat: {
+					getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Foo" }]),
+					getById: vi.fn().mockResolvedValue(full),
+				},
+			} as never,
+			[],
+			[
+				{
+					trashId: "trash-1",
+					name: "Foo",
+					resourceId: 7,
+					stateToken: "token",
+					profileId: 3,
+					appliedScore: 100,
+				},
+			],
+			{ id: 3, formatItems: [{ format: 7, score: -10000 }] },
+		);
+
+		expect(result.formats).toEqual([]);
+		expect(result.warnings).toEqual([expect.stringContaining("current score was preserved")]);
+		expect(result.warnings[0]).toContain("Foo");
+	});
+
+	it("rejects malformed persisted identities", () => {
+		expect(() =>
+			parseManagedCustomFormatIdentities(
+				JSON.stringify({
+					managedCustomFormats: [
+						{ trashId: "trash-1", name: "Foo", resourceId: 0, stateToken: "token" },
+					],
+				}),
+			),
+		).toThrow("incomplete");
+	});
+
+	it("fails closed when an existing mapping has no durable managed identity snapshot", () => {
+		expect(() =>
+			readPersistedManagedCustomFormatIdentities({
+				managedCustomFormatsCaptured: false,
+				managedCustomFormats: null,
+			}),
+		).toThrow("managed Custom Format identity snapshot is unavailable");
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
@@ -8,6 +8,29 @@ vi.mock("../cache-manager.js", () => ({
 import { prepareNamingDeployment, restoreNamingDeployment } from "../deployment-naming-state.js";
 import { createUpstreamResourceStateToken } from "../deployment-target.js";
 
+function radarrConfig(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 1,
+		renameMovies: false,
+		standardMovieFormat: "Original movie format",
+		movieFolderFormat: "Original movie folder",
+		...overrides,
+	};
+}
+
+function sonarrConfig(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 1,
+		renameEpisodes: false,
+		standardEpisodeFormat: "Original standard format",
+		dailyEpisodeFormat: "Original daily format",
+		animeEpisodeFormat: "Original anime format",
+		seriesFolderFormat: "Original series folder",
+		seasonFolderFormat: "Original season folder",
+		...overrides,
+	};
+}
+
 describe("prepareNamingDeployment", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -21,12 +44,10 @@ describe("prepareNamingDeployment", () => {
 	});
 
 	it("returns the exact current snapshot, merged payload, and changed fields", async () => {
-		const currentConfig = {
-			id: 1,
-			renameMovies: false,
+		const currentConfig = radarrConfig({
 			standardMovieFormat: "Old format",
 			movieFolderFormat: "{Movie Title}",
-		};
+		});
 		const rawRequest = vi.fn().mockResolvedValue({
 			ok: true,
 			status: 200,
@@ -47,12 +68,29 @@ describe("prepareNamingDeployment", () => {
 			standardMovieFormat: "{Movie CleanTitle}",
 		});
 	});
+
+	it("rejects an unknown upstream naming response shape", async () => {
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue({ error: "reverse proxy response" }),
+		});
+
+		await expect(
+			prepareNamingDeployment(
+				{} as never,
+				{ rawRequest } as never,
+				{ service: "RADARR" } as never,
+				{ serviceType: "RADARR", filePreset: "Recommended", folderPreset: "Recommended" },
+			),
+		).rejects.toThrow("invalid naming configuration");
+	});
 });
 
 describe("restoreNamingDeployment", () => {
 	it("restores the exact backed-up naming payload", async () => {
-		const snapshot = { id: 1, standardMovieFormat: "Original" };
-		const deployedConfig = { id: 1, standardMovieFormat: "Deployed" };
+		const snapshot = radarrConfig();
+		const deployedConfig = radarrConfig({ standardMovieFormat: "Deployed" });
 		const rawRequest = vi
 			.fn()
 			.mockResolvedValueOnce({
@@ -81,17 +119,63 @@ describe("restoreNamingDeployment", () => {
 		const rawRequest = vi.fn().mockResolvedValue({
 			ok: true,
 			status: 200,
-			json: vi.fn().mockResolvedValue({ id: 1, standardMovieFormat: "Changed by another action" }),
+			json: vi
+				.fn()
+				.mockResolvedValue(radarrConfig({ standardMovieFormat: "Changed by another action" })),
 		});
 
 		await expect(
 			restoreNamingDeployment(
 				{ rawRequest } as never,
 				{ service: "RADARR" } as never,
-				{ id: 1, standardMovieFormat: "Original" },
-				createUpstreamResourceStateToken({ id: 1, standardMovieFormat: "Deployed" }),
+				radarrConfig(),
+				createUpstreamResourceStateToken(radarrConfig({ standardMovieFormat: "Deployed" })),
 			),
 		).rejects.toThrow("Naming configuration changed after this deployment");
 		expect(rawRequest).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects an incomplete persisted naming snapshot before issuing a PUT", async () => {
+		const deployedConfig = radarrConfig({ standardMovieFormat: "Deployed" });
+		const rawRequest = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(deployedConfig),
+			})
+			.mockResolvedValueOnce({ ok: true, status: 202 });
+
+		await expect(
+			restoreNamingDeployment(
+				{ rawRequest } as never,
+				{ service: "RADARR" } as never,
+				{ id: 1, standardMovieFormat: "Original" },
+				createUpstreamResourceStateToken(deployedConfig),
+			),
+		).rejects.toThrow("snapshot is incomplete");
+		expect(rawRequest).not.toHaveBeenCalled();
+	});
+
+	it("rejects a naming snapshot for a different service", async () => {
+		const deployedConfig = sonarrConfig({ standardEpisodeFormat: "Deployed" });
+		const rawRequest = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(deployedConfig),
+			})
+			.mockResolvedValueOnce({ ok: true, status: 202 });
+
+		await expect(
+			restoreNamingDeployment(
+				{ rawRequest } as never,
+				{ service: "SONARR" } as never,
+				radarrConfig(),
+				createUpstreamResourceStateToken(deployedConfig),
+			),
+		).rejects.toThrow("does not match SONARR");
+		expect(rawRequest).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
@@ -12,6 +12,8 @@ function radarrConfig(overrides: Record<string, unknown> = {}) {
 	return {
 		id: 1,
 		renameMovies: false,
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: "smart",
 		standardMovieFormat: "Original movie format",
 		movieFolderFormat: "Original movie folder",
 		...overrides,
@@ -22,11 +24,16 @@ function sonarrConfig(overrides: Record<string, unknown> = {}) {
 	return {
 		id: 1,
 		renameEpisodes: false,
+		replaceIllegalCharacters: true,
+		colonReplacementFormat: 4,
+		customColonReplacementFormat: null,
+		multiEpisodeStyle: 5,
 		standardEpisodeFormat: "Original standard format",
 		dailyEpisodeFormat: "Original daily format",
 		animeEpisodeFormat: "Original anime format",
 		seriesFolderFormat: "Original series folder",
 		seasonFolderFormat: "Original season folder",
+		specialsFolderFormat: "Original specials folder",
 		...overrides,
 	};
 }
@@ -83,7 +90,25 @@ describe("prepareNamingDeployment", () => {
 				{ service: "RADARR" } as never,
 				{ serviceType: "RADARR", filePreset: "Recommended", folderPreset: "Recommended" },
 			),
-		).rejects.toThrow("invalid naming configuration");
+		).rejects.toThrow("invalid RADARR naming configuration");
+	});
+
+	it("rejects an incomplete service-specific naming response", async () => {
+		const { replaceIllegalCharacters: _missing, ...incomplete } = radarrConfig();
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue(incomplete),
+		});
+
+		await expect(
+			prepareNamingDeployment(
+				{} as never,
+				{ rawRequest } as never,
+				{ service: "RADARR" } as never,
+				{ serviceType: "RADARR", filePreset: "Recommended", folderPreset: "Recommended" },
+			),
+		).rejects.toThrow("invalid RADARR naming configuration");
 	});
 });
 
@@ -152,6 +177,21 @@ describe("restoreNamingDeployment", () => {
 				{ service: "RADARR" } as never,
 				{ id: 1, standardMovieFormat: "Original" },
 				createUpstreamResourceStateToken(deployedConfig),
+			),
+		).rejects.toThrow("snapshot is incomplete");
+		expect(rawRequest).not.toHaveBeenCalled();
+	});
+
+	it("rejects a Sonarr snapshot missing a complete restore field", async () => {
+		const { specialsFolderFormat: _missing, ...incomplete } = sonarrConfig();
+		const rawRequest = vi.fn();
+
+		await expect(
+			restoreNamingDeployment(
+				{ rawRequest } as never,
+				{ service: "SONARR" } as never,
+				incomplete,
+				createUpstreamResourceStateToken(sonarrConfig({ standardEpisodeFormat: "Deployed" })),
 			),
 		).rejects.toThrow("snapshot is incomplete");
 		expect(rawRequest).not.toHaveBeenCalled();

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
@@ -113,7 +113,7 @@ describe("prepareNamingDeployment", () => {
 });
 
 describe("restoreNamingDeployment", () => {
-	it("restores the exact backed-up naming payload", async () => {
+	it("retains exact deployed naming when restoration has no conditional boundary", async () => {
 		const snapshot = radarrConfig();
 		const deployedConfig = radarrConfig({ standardMovieFormat: "Deployed" });
 		const rawRequest = vi
@@ -125,18 +125,20 @@ describe("restoreNamingDeployment", () => {
 			})
 			.mockResolvedValueOnce({ ok: true, status: 202 });
 
-		await restoreNamingDeployment(
-			{ rawRequest } as never,
-			{ service: "RADARR" } as never,
-			snapshot,
-			createUpstreamResourceStateToken(deployedConfig),
-		);
+		await expect(
+			restoreNamingDeployment(
+				{ rawRequest } as never,
+				{ service: "RADARR" } as never,
+				snapshot,
+				createUpstreamResourceStateToken(deployedConfig),
+			),
+		).rejects.toThrow("cannot be restored safely");
 
-		expect(rawRequest).toHaveBeenNthCalledWith(
-			2,
-			expect.objectContaining({ service: "RADARR" }),
+		expect(rawRequest).toHaveBeenCalledTimes(1);
+		expect(rawRequest).not.toHaveBeenCalledWith(
+			expect.anything(),
 			"/api/v3/config/naming",
-			{ method: "PUT", body: snapshot },
+			expect.objectContaining({ method: "PUT" }),
 		);
 	});
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-naming-state.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getCachedNaming = vi.hoisted(() => vi.fn());
+vi.mock("../cache-manager.js", () => ({
+	createCacheManager: () => ({ get: getCachedNaming }),
+}));
+
+import { prepareNamingDeployment, restoreNamingDeployment } from "../deployment-naming-state.js";
+import { createUpstreamResourceStateToken } from "../deployment-target.js";
+
+describe("prepareNamingDeployment", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getCachedNaming.mockResolvedValue([
+			{
+				_service: "RADARR",
+				file: { Recommended: "{Movie CleanTitle}" },
+				folder: { Recommended: "{Movie Title}" },
+			},
+		]);
+	});
+
+	it("returns the exact current snapshot, merged payload, and changed fields", async () => {
+		const currentConfig = {
+			id: 1,
+			renameMovies: false,
+			standardMovieFormat: "Old format",
+			movieFolderFormat: "{Movie Title}",
+		};
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue(currentConfig),
+		});
+
+		const result = await prepareNamingDeployment(
+			{} as never,
+			{ rawRequest } as never,
+			{ service: "RADARR" } as never,
+			{ serviceType: "RADARR", filePreset: "Recommended", folderPreset: "Recommended" },
+		);
+
+		expect(result.currentConfig).toEqual(currentConfig);
+		expect(result.changedFields).toEqual(["standardMovieFormat"]);
+		expect(result.mergedConfig).toEqual({
+			...currentConfig,
+			standardMovieFormat: "{Movie CleanTitle}",
+		});
+	});
+});
+
+describe("restoreNamingDeployment", () => {
+	it("restores the exact backed-up naming payload", async () => {
+		const snapshot = { id: 1, standardMovieFormat: "Original" };
+		const deployedConfig = { id: 1, standardMovieFormat: "Deployed" };
+		const rawRequest = vi
+			.fn()
+			.mockResolvedValueOnce({
+				ok: true,
+				status: 200,
+				json: vi.fn().mockResolvedValue(deployedConfig),
+			})
+			.mockResolvedValueOnce({ ok: true, status: 202 });
+
+		await restoreNamingDeployment(
+			{ rawRequest } as never,
+			{ service: "RADARR" } as never,
+			snapshot,
+			createUpstreamResourceStateToken(deployedConfig),
+		);
+
+		expect(rawRequest).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ service: "RADARR" }),
+			"/api/v3/config/naming",
+			{ method: "PUT", body: snapshot },
+		);
+	});
+
+	it("refuses to overwrite naming configuration changed after deployment", async () => {
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue({ id: 1, standardMovieFormat: "Changed by another action" }),
+		});
+
+		await expect(
+			restoreNamingDeployment(
+				{ rawRequest } as never,
+				{ service: "RADARR" } as never,
+				{ id: 1, standardMovieFormat: "Original" },
+				createUpstreamResourceStateToken({ id: 1, standardMovieFormat: "Deployed" }),
+			),
+		).rejects.toThrow("Naming configuration changed after this deployment");
+		expect(rawRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -18,7 +18,7 @@ function completeProfile(overrides: Record<string, unknown> = {}) {
 }
 
 describe("rollbackQualityProfileDeployment", () => {
-	it("deletes a profile created by the deployment only while it is unchanged", async () => {
+	it("retains an unchanged created profile when deletion has no conditional boundary", async () => {
 		const deployed = { id: 7, name: "Created profile", formatItems: [] };
 		const remove = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -29,18 +29,20 @@ describe("rollbackQualityProfileDeployment", () => {
 			},
 		};
 
-		await rollbackQualityProfileDeployment(client as never, {
-			beforeProfile: null,
-			action: "created",
-			status: "applied",
-			profileId: 7,
-			postStateToken: createQualityProfileStateToken(deployed),
-			intendedPostStateToken: null,
-		});
-		expect(remove).toHaveBeenCalledWith(7);
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: null,
+				action: "created",
+				status: "applied",
+				profileId: 7,
+				postStateToken: createQualityProfileStateToken(deployed),
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("cannot be deleted safely");
+		expect(remove).not.toHaveBeenCalled();
 	});
 
-	it("deletes an unchanged pending create from its verified created-state token", async () => {
+	it("retains an unchanged pending create when deletion has no conditional boundary", async () => {
 		const created = { id: 7, name: "Created profile", formatItems: [] };
 		const remove = vi.fn().mockResolvedValue(undefined);
 		const client = {
@@ -51,16 +53,18 @@ describe("rollbackQualityProfileDeployment", () => {
 			},
 		};
 
-		await rollbackQualityProfileDeployment(client as never, {
-			beforeProfile: null,
-			action: "created",
-			status: "pending",
-			profileId: 7,
-			postStateToken: createQualityProfileStateToken(created),
-			intendedPostStateToken: null,
-		});
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: null,
+				action: "created",
+				status: "pending",
+				profileId: 7,
+				postStateToken: createQualityProfileStateToken(created),
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("cannot be deleted safely");
 
-		expect(remove).toHaveBeenCalledWith(7);
+		expect(remove).not.toHaveBeenCalled();
 	});
 
 	it("refuses to delete a created profile changed after deployment", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it, vi } from "vitest";
 import { rollbackQualityProfileDeployment } from "../deployment-profile-state.js";
 import { createQualityProfileStateToken } from "../deployment-target.js";
 
+function completeProfile(overrides: Record<string, unknown> = {}) {
+	return {
+		id: 4,
+		name: "Existing",
+		upgradeAllowed: true,
+		cutoff: 1,
+		items: [],
+		minFormatScore: 0,
+		cutoffFormatScore: 0,
+		minUpgradeFormatScore: 0,
+		formatItems: [],
+		...overrides,
+	};
+}
+
 describe("rollbackQualityProfileDeployment", () => {
 	it("deletes a profile created by the deployment only while it is unchanged", async () => {
 		const deployed = { id: 7, name: "Created profile", formatItems: [] };
@@ -80,8 +95,8 @@ describe("rollbackQualityProfileDeployment", () => {
 	});
 
 	it("restores an updated profile only from the recorded post-write state", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
-		const deployed = { id: 4, name: "Existing", formatItems: [{ score: 100 }] };
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
+		const deployed = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
 		const update = vi.fn().mockResolvedValue(undefined);
 		const client = {
 			qualityProfile: {
@@ -102,8 +117,35 @@ describe("rollbackQualityProfileDeployment", () => {
 		expect(update).toHaveBeenCalledWith(4, before);
 	});
 
+	it.each([
+		["incomplete", { id: 4, name: "Existing" }],
+		["same-title cross-wired", completeProfile({ id: 9 })],
+	] as const)("rejects a %s persisted quality-profile snapshot", async (_label, beforeProfile) => {
+		const deployed = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };
+		const update = vi.fn();
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				update,
+			},
+		};
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile,
+				action: "updated",
+				status: "applied",
+				profileId: 4,
+				postStateToken: createQualityProfileStateToken(deployed),
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("pre-deployment state");
+		expect(update).not.toHaveBeenCalled();
+	});
+
 	it("treats an already-restored profile as an idempotent retry", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const update = vi.fn();
 		const client = {
 			qualityProfile: {
@@ -120,7 +162,7 @@ describe("rollbackQualityProfileDeployment", () => {
 			profileId: 4,
 			postStateToken: createQualityProfileStateToken({
 				...before,
-				formatItems: [{ score: 100 }],
+				formatItems: [{ format: 7, score: 100 }],
 			}),
 			intendedPostStateToken: null,
 		});
@@ -128,7 +170,7 @@ describe("rollbackQualityProfileDeployment", () => {
 	});
 
 	it("treats a pending update still at its before-state as an idempotent retry", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const client = {
 			qualityProfile: {
 				getAll: vi.fn().mockResolvedValue([before]),
@@ -149,7 +191,7 @@ describe("rollbackQualityProfileDeployment", () => {
 	});
 
 	it("fails closed when a pending update left an unknown current state", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const changed = { ...before, formatItems: [{ score: 50 }] };
 		const client = {
 			qualityProfile: {
@@ -171,8 +213,8 @@ describe("rollbackQualityProfileDeployment", () => {
 	});
 
 	it("restores a pending update when the upstream state matches the recorded intent", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 0 }] };
-		const intended = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
+		const intended = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
 		const update = vi.fn().mockResolvedValue(undefined);
 		const client = {
 			qualityProfile: {
@@ -195,13 +237,11 @@ describe("rollbackQualityProfileDeployment", () => {
 	});
 
 	it("restores a pending update from its verified normalized post-write state", async () => {
-		const before = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 0 }] };
-		const intended = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };
-		const normalized = {
-			id: 4,
-			name: "Existing",
+		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
+		const intended = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
+		const normalized = completeProfile({
 			formatItems: [{ format: 7, score: 100, name: "Normalized by ARR" }],
-		};
+		});
 		const update = vi.fn().mockResolvedValue(undefined);
 		const client = {
 			qualityProfile: {
@@ -223,8 +263,12 @@ describe("rollbackQualityProfileDeployment", () => {
 		expect(update).toHaveBeenCalledWith(4, before);
 	});
 
-	it("reconciles a pending create after the unknown profile is manually removed", async () => {
-		const client = { qualityProfile: { getAll: vi.fn().mockResolvedValue([]) } };
+	it("keeps an unknown-ID create unresolved when the profile may have been renamed", async () => {
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([{ id: 12, name: "Renamed after create" }]),
+			},
+		};
 
 		await expect(
 			rollbackQualityProfileDeployment(client as never, {
@@ -236,6 +280,6 @@ describe("rollbackQualityProfileDeployment", () => {
 				postStateToken: null,
 				intendedPostStateToken: null,
 			}),
-		).resolves.toBeUndefined();
+		).rejects.toThrow("ID is unknown");
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -119,6 +119,7 @@ describe("rollbackQualityProfileDeployment", () => {
 
 	it.each([
 		["incomplete", { id: 4, name: "Existing" }],
+		["malformed nested item", completeProfile({ items: [{}] })],
 		["same-title cross-wired", completeProfile({ id: 9 })],
 	] as const)("rejects a %s persisted quality-profile snapshot", async (_label, beforeProfile) => {
 		const deployed = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -98,7 +98,7 @@ describe("rollbackQualityProfileDeployment", () => {
 		expect(remove).not.toHaveBeenCalled();
 	});
 
-	it("restores an updated profile only from the recorded post-write state", async () => {
+	it("retains an updated profile when restoration has no conditional boundary", async () => {
 		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const deployed = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
 		const update = vi.fn().mockResolvedValue(undefined);
@@ -110,18 +110,20 @@ describe("rollbackQualityProfileDeployment", () => {
 			},
 		};
 
-		await rollbackQualityProfileDeployment(client as never, {
-			beforeProfile: before,
-			action: "updated",
-			status: "applied",
-			profileId: 4,
-			postStateToken: createQualityProfileStateToken(deployed),
-			intendedPostStateToken: null,
-		});
-		expect(update).toHaveBeenCalledWith(4, before);
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: before,
+				action: "updated",
+				status: "applied",
+				profileId: 4,
+				postStateToken: createQualityProfileStateToken(deployed),
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("cannot be restored safely");
+		expect(update).not.toHaveBeenCalled();
 	});
 
-	it("restores a valid profile containing ARR's Unknown quality ID zero", async () => {
+	it("retains a valid profile containing ARR's Unknown quality ID zero", async () => {
 		const before = completeProfile({
 			cutoff: 0,
 			items: [
@@ -153,8 +155,8 @@ describe("rollbackQualityProfileDeployment", () => {
 				postStateToken: createQualityProfileStateToken(deployed),
 				intendedPostStateToken: null,
 			}),
-		).resolves.toBeUndefined();
-		expect(update).toHaveBeenCalledWith(4, before);
+		).rejects.toThrow("cannot be restored safely");
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it.each([
@@ -280,7 +282,7 @@ describe("rollbackQualityProfileDeployment", () => {
 		).rejects.toThrow("unverified deployment state");
 	});
 
-	it("restores a pending update when the upstream state matches the recorded intent", async () => {
+	it("retains a pending update when restoration has no conditional boundary", async () => {
 		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const intended = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
 		const update = vi.fn().mockResolvedValue(undefined);
@@ -300,11 +302,13 @@ describe("rollbackQualityProfileDeployment", () => {
 			intendedPostStateToken: createQualityProfileStateToken(intended),
 		};
 
-		await rollbackQualityProfileDeployment(client as never, state);
-		expect(update).toHaveBeenCalledWith(4, before);
+		await expect(rollbackQualityProfileDeployment(client as never, state)).rejects.toThrow(
+			"cannot be restored safely",
+		);
+		expect(update).not.toHaveBeenCalled();
 	});
 
-	it("restores a pending update from its verified normalized post-write state", async () => {
+	it("retains a pending normalized update when restoration has no conditional boundary", async () => {
 		const before = completeProfile({ formatItems: [{ format: 7, score: 0 }] });
 		const intended = completeProfile({ formatItems: [{ format: 7, score: 100 }] });
 		const normalized = completeProfile({
@@ -319,16 +323,18 @@ describe("rollbackQualityProfileDeployment", () => {
 			},
 		};
 
-		await rollbackQualityProfileDeployment(client as never, {
-			beforeProfile: before,
-			action: "updated",
-			status: "pending",
-			profileId: 4,
-			postStateToken: createQualityProfileStateToken(normalized),
-			intendedPostStateToken: createQualityProfileStateToken(intended),
-		});
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: before,
+				action: "updated",
+				status: "pending",
+				profileId: 4,
+				postStateToken: createQualityProfileStateToken(normalized),
+				intendedPostStateToken: createQualityProfileStateToken(intended),
+			}),
+		).rejects.toThrow("cannot be restored safely");
 
-		expect(update).toHaveBeenCalledWith(4, before);
+		expect(update).not.toHaveBeenCalled();
 	});
 
 	it("keeps an unknown-ID create unresolved when the profile may have been renamed", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -117,9 +117,72 @@ describe("rollbackQualityProfileDeployment", () => {
 		expect(update).toHaveBeenCalledWith(4, before);
 	});
 
+	it("restores a valid profile containing ARR's Unknown quality ID zero", async () => {
+		const before = completeProfile({
+			cutoff: 0,
+			items: [
+				{
+					id: 0,
+					name: "Unknown",
+					allowed: false,
+					quality: { id: 0, name: "Unknown" },
+					items: [],
+				},
+			],
+		});
+		const deployed = { ...before, formatItems: [{ format: 7, score: 100 }] };
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				update,
+			},
+		};
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: before,
+				action: "updated",
+				status: "applied",
+				profileId: 4,
+				postStateToken: createQualityProfileStateToken(deployed),
+				intendedPostStateToken: null,
+			}),
+		).resolves.toBeUndefined();
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
 	it.each([
 		["incomplete", { id: 4, name: "Existing" }],
 		["malformed nested item", completeProfile({ items: [{}] })],
+		[
+			"nested item with null children",
+			completeProfile({
+				items: [
+					{
+						id: 1,
+						name: "HD",
+						allowed: true,
+						quality: { id: 1, name: "HD" },
+						items: null,
+					},
+				],
+			}),
+		],
+		[
+			"nested item with omitted children",
+			completeProfile({
+				items: [
+					{
+						id: 1,
+						name: "HD",
+						allowed: true,
+						quality: { id: 1, name: "HD" },
+					},
+				],
+			}),
+		],
 		["same-title cross-wired", completeProfile({ id: 9 })],
 	] as const)("rejects a %s persisted quality-profile snapshot", async (_label, beforeProfile) => {
 		const deployed = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-profile-state.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, it, vi } from "vitest";
+import { rollbackQualityProfileDeployment } from "../deployment-profile-state.js";
+import { createQualityProfileStateToken } from "../deployment-target.js";
+
+describe("rollbackQualityProfileDeployment", () => {
+	it("deletes a profile created by the deployment only while it is unchanged", async () => {
+		const deployed = { id: 7, name: "Created profile", formatItems: [] };
+		const remove = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				delete: remove,
+			},
+		};
+
+		await rollbackQualityProfileDeployment(client as never, {
+			beforeProfile: null,
+			action: "created",
+			status: "applied",
+			profileId: 7,
+			postStateToken: createQualityProfileStateToken(deployed),
+			intendedPostStateToken: null,
+		});
+		expect(remove).toHaveBeenCalledWith(7);
+	});
+
+	it("deletes an unchanged pending create from its verified created-state token", async () => {
+		const created = { id: 7, name: "Created profile", formatItems: [] };
+		const remove = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([created]),
+				getById: vi.fn().mockResolvedValue(created),
+				delete: remove,
+			},
+		};
+
+		await rollbackQualityProfileDeployment(client as never, {
+			beforeProfile: null,
+			action: "created",
+			status: "pending",
+			profileId: 7,
+			postStateToken: createQualityProfileStateToken(created),
+			intendedPostStateToken: null,
+		});
+
+		expect(remove).toHaveBeenCalledWith(7);
+	});
+
+	it("refuses to delete a created profile changed after deployment", async () => {
+		const remove = vi.fn();
+		const client = {
+			qualityProfile: {
+				getAll: vi
+					.fn()
+					.mockResolvedValue([{ id: 7, name: "Created profile", formatItems: [{ score: 10 }] }]),
+				getById: vi
+					.fn()
+					.mockResolvedValue({ id: 7, name: "Created profile", formatItems: [{ score: 10 }] }),
+				delete: remove,
+			},
+		};
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: null,
+				action: "created",
+				status: "applied",
+				profileId: 7,
+				postStateToken: createQualityProfileStateToken({
+					id: 7,
+					name: "Created profile",
+					formatItems: [],
+				}),
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("changed after deployment");
+		expect(remove).not.toHaveBeenCalled();
+	});
+
+	it("restores an updated profile only from the recorded post-write state", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const deployed = { id: 4, name: "Existing", formatItems: [{ score: 100 }] };
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([deployed]),
+				getById: vi.fn().mockResolvedValue(deployed),
+				update,
+			},
+		};
+
+		await rollbackQualityProfileDeployment(client as never, {
+			beforeProfile: before,
+			action: "updated",
+			status: "applied",
+			profileId: 4,
+			postStateToken: createQualityProfileStateToken(deployed),
+			intendedPostStateToken: null,
+		});
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
+	it("treats an already-restored profile as an idempotent retry", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const update = vi.fn();
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([before]),
+				getById: vi.fn().mockResolvedValue(before),
+				update,
+			},
+		};
+
+		await rollbackQualityProfileDeployment(client as never, {
+			beforeProfile: before,
+			action: "updated",
+			status: "applied",
+			profileId: 4,
+			postStateToken: createQualityProfileStateToken({
+				...before,
+				formatItems: [{ score: 100 }],
+			}),
+			intendedPostStateToken: null,
+		});
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("treats a pending update still at its before-state as an idempotent retry", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([before]),
+				getById: vi.fn().mockResolvedValue(before),
+			},
+		};
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: before,
+				action: "updated",
+				status: "pending",
+				profileId: 4,
+				postStateToken: null,
+				intendedPostStateToken: null,
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("fails closed when a pending update left an unknown current state", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ score: 0 }] };
+		const changed = { ...before, formatItems: [{ score: 50 }] };
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([changed]),
+				getById: vi.fn().mockResolvedValue(changed),
+			},
+		};
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: before,
+				action: "updated",
+				status: "pending",
+				profileId: 4,
+				postStateToken: null,
+				intendedPostStateToken: null,
+			}),
+		).rejects.toThrow("unverified deployment state");
+	});
+
+	it("restores a pending update when the upstream state matches the recorded intent", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 0 }] };
+		const intended = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([intended]),
+				getById: vi.fn().mockResolvedValue(intended),
+				update,
+			},
+		};
+		const state = {
+			beforeProfile: before,
+			action: "updated" as const,
+			status: "pending" as const,
+			profileId: 4,
+			postStateToken: null,
+			intendedPostStateToken: createQualityProfileStateToken(intended),
+		};
+
+		await rollbackQualityProfileDeployment(client as never, state);
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
+	it("restores a pending update from its verified normalized post-write state", async () => {
+		const before = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 0 }] };
+		const intended = { id: 4, name: "Existing", formatItems: [{ format: 7, score: 100 }] };
+		const normalized = {
+			id: 4,
+			name: "Existing",
+			formatItems: [{ format: 7, score: 100, name: "Normalized by ARR" }],
+		};
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([normalized]),
+				getById: vi.fn().mockResolvedValue(normalized),
+				update,
+			},
+		};
+
+		await rollbackQualityProfileDeployment(client as never, {
+			beforeProfile: before,
+			action: "updated",
+			status: "pending",
+			profileId: 4,
+			postStateToken: createQualityProfileStateToken(normalized),
+			intendedPostStateToken: createQualityProfileStateToken(intended),
+		});
+
+		expect(update).toHaveBeenCalledWith(4, before);
+	});
+
+	it("reconciles a pending create after the unknown profile is manually removed", async () => {
+		const client = { qualityProfile: { getAll: vi.fn().mockResolvedValue([]) } };
+
+		await expect(
+			rollbackQualityProfileDeployment(client as never, {
+				beforeProfile: null,
+				action: "created",
+				status: "pending",
+				profileId: null,
+				profileName: "Created profile",
+				postStateToken: null,
+				intendedPostStateToken: null,
+			}),
+		).resolves.toBeUndefined();
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
@@ -1,46 +1,123 @@
 import { describe, expect, it, vi } from "vitest";
 import { TrashBackupCleanupService } from "../trash-backup-cleanup.js";
 
-describe("TrashBackupCleanupService", () => {
-	it("excludes snapshots referenced by nonterminal recovery work from expiry cleanup", async () => {
-		const deleteMany = vi.fn().mockResolvedValue({ count: 0 });
-		const service = new TrashBackupCleanupService(
+function ledger(status: "pending" | "applied") {
+	return JSON.stringify({
+		schemaVersion: 2,
+		endpointKey: "endpoint",
+		connectionStateToken: "connection",
+		customFormats: [],
+		customFormatDeployments: [
 			{
-				trashBackup: {
-					deleteMany,
-					findMany: vi.fn().mockResolvedValue([]),
-				},
-			} as never,
-			{ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+				beforeFormat: { id: 7, name: "Foo" },
+				action: "updated",
+				resourceId: 7,
+				name: "Foo",
+				status,
+				postStateToken: status === "applied" ? "post" : null,
+			},
+		],
+		managedCustomFormats: [],
+		managedCustomFormatsCaptured: false,
+		qualityProfileDeployment: {
+			beforeProfile: null,
+			status: "not_started",
+			action: "created",
+			profileId: null,
+			profileName: "Any",
+			postStateToken: null,
+		},
+		namingDeployment: null,
+	});
+}
+
+describe("TrashBackupCleanupService", () => {
+	it("never deletes an expired pending or malformed current deployment ledger", async () => {
+		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
+		const prisma = {
+			trashBackup: {
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce([
+						{
+							id: "pending",
+							backupData: ledger("pending"),
+							_count: { syncHistory: 1, deploymentHistory: 0 },
+						},
+						{
+							id: "malformed",
+							backupData: JSON.stringify({ schemaVersion: 2 }),
+							_count: { syncHistory: 1, deploymentHistory: 0 },
+						},
+						{
+							id: "terminal",
+							backupData: ledger("applied"),
+							_count: { syncHistory: 1, deploymentHistory: 0 },
+						},
+					])
+					.mockResolvedValueOnce([]),
+				deleteMany,
+			},
+		};
+		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const service = new TrashBackupCleanupService(prisma as never, logger as never);
+
+		await expect(service.runCleanup()).resolves.toEqual({
+			expiredCount: 1,
+			orphanedCount: 0,
+			totalCleaned: 1,
+		});
+		expect(prisma.trashBackup.findMany).toHaveBeenNthCalledWith(1, {
+			where: {
+				expiresAt: { not: null, lte: expect.any(Date) },
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
+			},
+			select: { id: true, backupData: true },
+		});
+		expect(deleteMany).toHaveBeenCalledTimes(1);
+		expect(deleteMany).toHaveBeenCalledWith({
+			where: {
+				expiresAt: { not: null, lte: expect.any(Date) },
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
+				OR: [{ id: "terminal", backupData: ledger("applied") }],
+			},
+		});
+	});
+
+	it("does not delete a backup when an unrolled history claims it after selection", async () => {
+		const deleteMany = vi.fn().mockImplementation(async ({ where }) => ({
+			count:
+				where.syncHistory?.none?.rolledBack === false &&
+				where.deploymentHistory?.none?.rolledBack === false
+					? 0
+					: 1,
+		}));
+		const prisma = {
+			trashBackup: {
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce([{ id: "race", backupData: ledger("applied") }])
+					.mockResolvedValueOnce([]),
+				deleteMany,
+			},
+		};
+		const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const service = new TrashBackupCleanupService(prisma as never, logger as never);
+
+		await expect(service.runCleanup()).resolves.toEqual({
+			expiredCount: 0,
+			orphanedCount: 0,
+			totalCleaned: 0,
+		});
+		expect(deleteMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+				}),
+			}),
 		);
-
-		await service.runCleanup();
-
-		const expiryWhere = deleteMany.mock.calls[0]?.[0]?.where;
-		expect(expiryWhere.syncHistory).toEqual({
-			none: {
-				rolledBack: false,
-				OR: [
-					{
-						rollbackStatus: { not: null },
-						NOT: { rollbackStatus: "COMPLETED" },
-					},
-					{ status: { in: ["IN_PROGRESS", "RUNNING"] } },
-				],
-			},
-		});
-		expect(expiryWhere.deploymentHistory).toEqual({
-			none: {
-				rolledBack: false,
-				OR: [
-					{
-						undeployStatus: { not: null },
-						NOT: { undeployStatus: "COMPLETED" },
-					},
-					{ status: "PARTIAL_UNDEPLOY", undeployStatus: null },
-					{ status: "IN_PROGRESS" },
-				],
-			},
-		});
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
@@ -128,6 +128,94 @@ describe("TrashBackupCleanupService", () => {
 		},
 	);
 
+	it.each(["expired", "orphaned"] as const)(
+		"uses bounded keyset pages and advances past retained %s ledgers",
+		async (phase) => {
+			type CandidateQuery = {
+				where: {
+					expiresAt?: unknown;
+					createdAt?: unknown;
+					id?: { gt: string };
+				};
+				orderBy?: { id: string };
+				take?: number;
+			};
+
+			const retainedPrefix = `${phase}-retained`;
+			let retainedPageLastId = "";
+			let initialPageReads = 0;
+			const findMany = vi.fn(async (query: CandidateQuery) => {
+				const isTargetQuery =
+					phase === "expired"
+						? query.where.expiresAt !== undefined
+						: query.where.createdAt !== undefined;
+				if (!isTargetQuery) return [];
+
+				if (!query.where.id) {
+					initialPageReads++;
+					if (initialPageReads > 1) {
+						throw new Error(`${phase} cleanup did not advance past the retained page`);
+					}
+					const pageSize = query.take ?? 2;
+					const page = Array.from({ length: pageSize }, (_, index) => ({
+						id: `${retainedPrefix}-${String(index).padStart(4, "0")}`,
+						backupData: ledger("pending"),
+						_count: { syncHistory: 0, deploymentHistory: 0 },
+					}));
+					retainedPageLastId = page.at(-1)!.id;
+					return page;
+				}
+
+				if (query.where.id.gt === retainedPageLastId) {
+					return [
+						{
+							id: `${phase}-zz-legacy`,
+							backupData: JSON.stringify([]),
+							_count: { syncHistory: 0, deploymentHistory: 0 },
+						},
+					];
+				}
+
+				throw new Error(`Unexpected ${phase} cleanup cursor: ${query.where.id.gt}`);
+			});
+			const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
+			const prisma = { trashBackup: { findMany, deleteMany } };
+			const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+			const service = new TrashBackupCleanupService(prisma as never, logger as never);
+
+			await expect(service.runCleanup()).resolves.toEqual({
+				expiredCount: phase === "expired" ? 1 : 0,
+				orphanedCount: phase === "orphaned" ? 1 : 0,
+				totalCleaned: 1,
+			});
+
+			const targetQueries = findMany.mock.calls
+				.map(([query]) => query)
+				.filter((query) =>
+					phase === "expired"
+						? query.where.expiresAt !== undefined
+						: query.where.createdAt !== undefined,
+				);
+			expect(targetQueries).toHaveLength(2);
+			expect(targetQueries[0]).toEqual(
+				expect.objectContaining({
+					orderBy: { id: "asc" },
+					take: expect.any(Number),
+				}),
+			);
+			expect(targetQueries[0]!.take).toBeGreaterThan(0);
+			expect(targetQueries[0]!.take).toBeLessThanOrEqual(400);
+			expect(targetQueries[1]).toEqual(
+				expect.objectContaining({
+					where: expect.objectContaining({ id: { gt: retainedPageLastId } }),
+					orderBy: { id: "asc" },
+					take: targetQueries[0]!.take,
+				}),
+			);
+			expect(deleteMany).toHaveBeenCalledTimes(1);
+		},
+	);
+
 	it("never deletes an expired pending or malformed current deployment ledger", async () => {
 		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
 		const prisma = {
@@ -170,6 +258,8 @@ describe("TrashBackupCleanupService", () => {
 				deploymentHistory: { none: { rolledBack: false } },
 			},
 			select: { id: true, backupData: true },
+			orderBy: { id: "asc" },
+			take: 400,
 		});
 		expect(deleteMany).toHaveBeenCalledTimes(1);
 		expect(deleteMany).toHaveBeenCalledWith({

--- a/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
@@ -35,6 +35,31 @@ function ledger(status: "pending" | "applied") {
 	});
 }
 
+function legacyUnknownQualityBackup() {
+	return JSON.stringify({
+		customFormats: [],
+		qualityProfile: {
+			id: 4,
+			name: "Legacy",
+			upgradeAllowed: true,
+			cutoff: 0,
+			items: [
+				{
+					id: 0,
+					name: "Unknown",
+					allowed: false,
+					quality: { id: 0, name: "Unknown" },
+					items: [],
+				},
+			],
+			minFormatScore: 0,
+			cutoffFormatScore: 0,
+			minUpgradeFormatScore: 0,
+			formatItems: [],
+		},
+	});
+}
+
 describe("TrashBackupCleanupService", () => {
 	it.each(["expired", "orphaned"] as const)(
 		"retains uncertain and current ledgers during %s cleanup while deleting known legacy backups",
@@ -59,11 +84,12 @@ describe("TrashBackupCleanupService", () => {
 					id: "legacy-object",
 					backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
 				},
+				{ id: "legacy-unknown-quality", backupData: legacyUnknownQualityBackup() },
 			].map((candidate) => ({
 				...candidate,
 				_count: { syncHistory: 0, deploymentHistory: 0 },
 			}));
-			const deleteMany = vi.fn().mockResolvedValue({ count: 2 });
+			const deleteMany = vi.fn().mockResolvedValue({ count: 3 });
 			const prisma = {
 				trashBackup: {
 					findMany: vi
@@ -77,9 +103,9 @@ describe("TrashBackupCleanupService", () => {
 			const service = new TrashBackupCleanupService(prisma as never, logger as never);
 
 			await expect(service.runCleanup()).resolves.toEqual({
-				expiredCount: phase === "expired" ? 2 : 0,
-				orphanedCount: phase === "orphaned" ? 2 : 0,
-				totalCleaned: 2,
+				expiredCount: phase === "expired" ? 3 : 0,
+				orphanedCount: phase === "orphaned" ? 3 : 0,
+				totalCleaned: 3,
 			});
 			expect(deleteMany).toHaveBeenCalledTimes(1);
 			expect(deleteMany).toHaveBeenCalledWith({
@@ -91,6 +117,10 @@ describe("TrashBackupCleanupService", () => {
 						{
 							id: "legacy-object",
 							backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+						},
+						{
+							id: "legacy-unknown-quality",
+							backupData: legacyUnknownQualityBackup(),
 						},
 					],
 				}),

--- a/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
@@ -1,4 +1,8 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
 import { TrashBackupCleanupService } from "../trash-backup-cleanup.js";
 
 function ledger(status: "pending" | "applied") {
@@ -32,6 +36,60 @@ function ledger(status: "pending" | "applied") {
 }
 
 describe("TrashBackupCleanupService", () => {
+	it.each(["expired", "orphaned"] as const)(
+		"retains uncertain and current ledgers during %s cleanup while deleting known legacy backups",
+		async (phase) => {
+			const candidates = [
+				{ id: "applied-v2", backupData: ledger("applied") },
+				{ id: "pending-v2", backupData: ledger("pending") },
+				{ id: "malformed-v2", backupData: JSON.stringify({ schemaVersion: 2 }) },
+				{ id: "future", backupData: JSON.stringify({ schemaVersion: 3 }) },
+				{ id: "missing-version", backupData: JSON.stringify({ endpointKey: "current-like" }) },
+				{ id: "string-version", backupData: JSON.stringify({ schemaVersion: "2" }) },
+				{ id: "legacy-array", backupData: JSON.stringify([]) },
+				{
+					id: "legacy-object",
+					backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+				},
+			].map((candidate) => ({
+				...candidate,
+				_count: { syncHistory: 0, deploymentHistory: 0 },
+			}));
+			const deleteMany = vi.fn().mockResolvedValue({ count: 2 });
+			const prisma = {
+				trashBackup: {
+					findMany: vi
+						.fn()
+						.mockResolvedValueOnce(phase === "expired" ? candidates : [])
+						.mockResolvedValueOnce(phase === "orphaned" ? candidates : []),
+					deleteMany,
+				},
+			};
+			const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+			const service = new TrashBackupCleanupService(prisma as never, logger as never);
+
+			await expect(service.runCleanup()).resolves.toEqual({
+				expiredCount: phase === "expired" ? 2 : 0,
+				orphanedCount: phase === "orphaned" ? 2 : 0,
+				totalCleaned: 2,
+			});
+			expect(deleteMany).toHaveBeenCalledTimes(1);
+			expect(deleteMany).toHaveBeenCalledWith({
+				where: expect.objectContaining({
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+					OR: [
+						{ id: "legacy-array", backupData: JSON.stringify([]) },
+						{
+							id: "legacy-object",
+							backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+						},
+					],
+				}),
+			});
+		},
+	);
+
 	it("never deletes an expired pending or malformed current deployment ledger", async () => {
 		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
 		const prisma = {
@@ -50,8 +108,8 @@ describe("TrashBackupCleanupService", () => {
 							_count: { syncHistory: 1, deploymentHistory: 0 },
 						},
 						{
-							id: "terminal",
-							backupData: ledger("applied"),
+							id: "legacy",
+							backupData: JSON.stringify([]),
 							_count: { syncHistory: 1, deploymentHistory: 0 },
 						},
 					])
@@ -81,7 +139,7 @@ describe("TrashBackupCleanupService", () => {
 				expiresAt: { not: null, lte: expect.any(Date) },
 				syncHistory: { none: { rolledBack: false } },
 				deploymentHistory: { none: { rolledBack: false } },
-				OR: [{ id: "terminal", backupData: ledger("applied") }],
+				OR: [{ id: "legacy", backupData: JSON.stringify([]) }],
 			},
 		});
 	});
@@ -98,7 +156,7 @@ describe("TrashBackupCleanupService", () => {
 			trashBackup: {
 				findMany: vi
 					.fn()
-					.mockResolvedValueOnce([{ id: "race", backupData: ledger("applied") }])
+					.mockResolvedValueOnce([{ id: "race", backupData: JSON.stringify([]) }])
 					.mockResolvedValueOnce([]),
 				deleteMany,
 			},
@@ -120,4 +178,66 @@ describe("TrashBackupCleanupService", () => {
 			}),
 		);
 	});
+
+	it.each([499, 500])(
+		"deletes %i legacy candidates through bounded real SQLite batches",
+		async (candidateCount) => {
+			const directory = await mkdtemp(join(tmpdir(), "trash-backup-cleanup-"));
+			const databasePath = join(directory, "cleanup.db");
+			const prisma = createTestPrismaClient(databasePath);
+			try {
+				await prisma.$executeRawUnsafe(`
+					CREATE TABLE "trash_backups" (
+						"id" TEXT NOT NULL PRIMARY KEY,
+						"instanceId" TEXT NOT NULL,
+						"userId" TEXT NOT NULL,
+						"backupData" TEXT NOT NULL,
+						"createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+						"expiresAt" DATETIME
+					)
+				`);
+				await prisma.$executeRawUnsafe(`
+					CREATE TABLE "trash_sync_history" (
+						"id" TEXT NOT NULL PRIMARY KEY,
+						"backupId" TEXT,
+						"rolledBack" BOOLEAN NOT NULL DEFAULT false
+					)
+				`);
+				await prisma.$executeRawUnsafe(`
+					CREATE TABLE "template_deployment_history" (
+						"id" TEXT NOT NULL PRIMARY KEY,
+						"backupId" TEXT,
+						"rolledBack" BOOLEAN NOT NULL DEFAULT false
+					)
+				`);
+
+				const records = Array.from({ length: candidateCount }, (_, index) => ({
+					id: `backup-${index}`,
+					instanceId: "instance",
+					userId: "user",
+					backupData: JSON.stringify([]),
+					createdAt: new Date("2026-01-01T00:00:00.000Z"),
+					expiresAt: new Date("2026-01-02T00:00:00.000Z"),
+				}));
+				for (let index = 0; index < records.length; index += 100) {
+					await prisma.trashBackup.createMany({ data: records.slice(index, index + 100) });
+				}
+
+				const deleteMany = vi.spyOn(prisma.trashBackup, "deleteMany");
+				const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+				const service = new TrashBackupCleanupService(prisma, logger as never);
+
+				await expect(service.runCleanup()).resolves.toEqual({
+					expiredCount: candidateCount,
+					orphanedCount: 0,
+					totalCleaned: candidateCount,
+				});
+				expect(deleteMany).toHaveBeenCalledTimes(2);
+				await expect(prisma.trashBackup.count()).resolves.toBe(0);
+			} finally {
+				await prisma.$disconnect();
+				await rm(directory, { recursive: true, force: true });
+			}
+		},
+	);
 });

--- a/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/trash-backup-cleanup.test.ts
@@ -46,6 +46,14 @@ describe("TrashBackupCleanupService", () => {
 				{ id: "future", backupData: JSON.stringify({ schemaVersion: 3 }) },
 				{ id: "missing-version", backupData: JSON.stringify({ endpointKey: "current-like" }) },
 				{ id: "string-version", backupData: JSON.stringify({ schemaVersion: "2" }) },
+				{
+					id: "malformed-legacy-profile",
+					backupData: JSON.stringify({ customFormats: [], qualityProfile: {} }),
+				},
+				{
+					id: "malformed-legacy-cf",
+					backupData: JSON.stringify([{ id: 7, name: "Incomplete" }]),
+				},
 				{ id: "legacy-array", backupData: JSON.stringify([]) },
 				{
 					id: "legacy-object",

--- a/apps/api/src/lib/trash-guides/deployment-backup-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-backup-state.ts
@@ -3,6 +3,16 @@ import { z } from "zod";
 const positiveResourceId = z.number().int().positive().safe();
 const stateToken = z.string().min(1);
 const recordState = z.record(z.string(), z.unknown());
+const legacyCustomFormatSchema = z.looseObject({
+	id: positiveResourceId.optional(),
+	name: z.string().min(1),
+	specifications: z.array(z.unknown()).optional(),
+	includeCustomFormatWhenRenaming: z.boolean().optional(),
+});
+const legacyBackupSchema = z.looseObject({
+	customFormats: z.array(legacyCustomFormatSchema),
+	qualityProfile: recordState.nullable(),
+});
 
 const customFormatStateSchema = z
 	.object({
@@ -104,18 +114,16 @@ export function shouldRetainDeploymentBackup(value: string): boolean {
 	} catch {
 		return true;
 	}
+	if (Array.isArray(parsed)) {
+		return !z.array(legacyCustomFormatSchema).safeParse(parsed).success;
+	}
 	if (
-		typeof parsed !== "object" ||
-		parsed === null ||
-		Array.isArray(parsed) ||
-		!("schemaVersion" in parsed) ||
-		parsed.schemaVersion !== 2
+		typeof parsed === "object" &&
+		parsed !== null &&
+		!("schemaVersion" in parsed) &&
+		legacyBackupSchema.safeParse(parsed).success
 	) {
 		return false;
 	}
-	try {
-		return hasPendingDeploymentMutation(deploymentBackupStateSchema.parse(parsed));
-	} catch {
-		return true;
-	}
+	return true;
 }

--- a/apps/api/src/lib/trash-guides/deployment-backup-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-backup-state.ts
@@ -1,17 +1,13 @@
 import { z } from "zod";
+import { restorableCustomFormatSchema } from "./deployment-custom-format-state.js";
+import { restorableQualityProfileSchema } from "./deployment-profile-state.js";
 
 const positiveResourceId = z.number().int().positive().safe();
 const stateToken = z.string().min(1);
 const recordState = z.record(z.string(), z.unknown());
-const legacyCustomFormatSchema = z.looseObject({
-	id: positiveResourceId.optional(),
-	name: z.string().min(1),
-	specifications: z.array(z.unknown()).optional(),
-	includeCustomFormatWhenRenaming: z.boolean().optional(),
-});
 const legacyBackupSchema = z.looseObject({
-	customFormats: z.array(legacyCustomFormatSchema),
-	qualityProfile: recordState.nullable(),
+	customFormats: z.array(restorableCustomFormatSchema),
+	qualityProfile: restorableQualityProfileSchema.nullable(),
 });
 
 const customFormatStateSchema = z
@@ -115,7 +111,7 @@ export function shouldRetainDeploymentBackup(value: string): boolean {
 		return true;
 	}
 	if (Array.isArray(parsed)) {
-		return !z.array(legacyCustomFormatSchema).safeParse(parsed).success;
+		return !z.array(restorableCustomFormatSchema).safeParse(parsed).success;
 	}
 	if (
 		typeof parsed === "object" &&

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -24,7 +24,7 @@ export const restorableCustomFormatSchema = z.looseObject({
 	id: z.number().int().positive().safe(),
 	name: z.string().min(1),
 	specifications: z.array(restorableCustomFormatSpecificationSchema),
-	includeCustomFormatWhenRenaming: z.boolean().nullable(),
+	includeCustomFormatWhenRenaming: z.boolean().nullable().optional(),
 });
 
 export interface CustomFormatRollbackState {

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -1,7 +1,14 @@
 import type { RadarrClient, SonarrClient } from "arr-sdk";
+import { z } from "zod";
 import { createUpstreamResourceStateToken } from "./deployment-target.js";
 
 type ArrClient = SonarrClient | RadarrClient;
+const restorableCustomFormatSchema = z.looseObject({
+	id: z.number().int().positive().safe(),
+	name: z.string().min(1),
+	specifications: z.array(z.unknown()),
+	includeCustomFormatWhenRenaming: z.boolean().nullable(),
+});
 
 export interface CustomFormatRollbackState {
 	beforeFormat: Record<string, unknown> | null;
@@ -22,11 +29,17 @@ export async function rollbackCustomFormatDeployment(
 	state: CustomFormatRollbackState,
 ): Promise<"noop" | "restored" | "deleted"> {
 	if (state.resourceId === null) {
-		if (state.action === "created" && state.status === "pending") {
-			const listed = await client.customFormat.getAll();
-			if (!listed.some((format) => format.name === state.name)) return "noop";
-		}
 		throw new Error(`Custom Format "${state.name}" may have been created, but its ID is unknown.`);
+	}
+	let beforeFormat: Record<string, unknown> | null = null;
+	if (state.action === "updated") {
+		const parsed = restorableCustomFormatSchema.safeParse(state.beforeFormat);
+		if (!parsed.success || parsed.data.id !== state.resourceId) {
+			throw new Error(
+				`Custom Format "${state.name}" has an incomplete or mismatched pre-deployment state and was not restored.`,
+			);
+		}
+		beforeFormat = parsed.data;
 	}
 
 	const listed = await client.customFormat.getAll();
@@ -42,8 +55,8 @@ export async function rollbackCustomFormatDeployment(
 	if (state.status === "pending") {
 		if (
 			state.action === "updated" &&
-			state.beforeFormat &&
-			currentToken === createUpstreamResourceStateToken(state.beforeFormat)
+			beforeFormat &&
+			currentToken === createUpstreamResourceStateToken(beforeFormat)
 		) {
 			return "noop";
 		}
@@ -68,9 +81,27 @@ export async function rollbackCustomFormatDeployment(
 			);
 		}
 		const profiles = await client.qualityProfile.getAll();
-		const referencingProfiles = profiles.filter((profile) =>
-			profile.formatItems?.some((item) => item.format === state.resourceId),
-		);
+		const referencingProfiles: Array<{ id?: number; name?: string | null }> = [];
+		for (const profile of profiles) {
+			let formatItems = profile.formatItems;
+			if (!Array.isArray(formatItems)) {
+				if (!Number.isSafeInteger(profile.id) || (profile.id ?? 0) <= 0) {
+					throw new Error(
+						`Custom Format "${state.name}" profile references could not be established because a quality profile has no valid ID.`,
+					);
+				}
+				const fullProfile = await client.qualityProfile.getById(profile.id!);
+				formatItems = fullProfile.formatItems;
+				if (!Array.isArray(formatItems)) {
+					throw new Error(
+						`Custom Format "${state.name}" profile reference list could not be established for "${profile.name ?? profile.id}".`,
+					);
+				}
+			}
+			if (formatItems.some((item) => item.format === state.resourceId)) {
+				referencingProfiles.push(profile);
+			}
+		}
 		if (referencingProfiles.length > 0) {
 			throw new Error(
 				`Custom Format "${state.name}" is referenced by quality profile(s) ${referencingProfiles
@@ -78,14 +109,21 @@ export async function rollbackCustomFormatDeployment(
 					.join(", ")} and was not deleted.`,
 			);
 		}
-		await client.customFormat.delete(state.resourceId);
-		return "deleted";
+		const rechecked = await client.customFormat.getById(state.resourceId);
+		if (createUpstreamResourceStateToken(rechecked) !== verifiedPostStateToken) {
+			throw new Error(
+				`Custom Format "${state.name}" changed after deployment and was not deleted.`,
+			);
+		}
+		throw new Error(
+			`Custom Format "${state.name}" cannot be deleted safely because the upstream API has no conditional delete. Verify that it is unused, then remove it manually.`,
+		);
 	}
 
-	if (!state.beforeFormat) {
+	if (!beforeFormat) {
 		throw new Error(`Custom Format "${state.name}" is missing its pre-deployment state.`);
 	}
-	if (currentToken === createUpstreamResourceStateToken(state.beforeFormat)) return "noop";
+	if (currentToken === createUpstreamResourceStateToken(beforeFormat)) return "noop";
 	if (currentToken !== verifiedPostStateToken) {
 		throw new Error(
 			`Custom Format "${state.name}" changed after deployment and was not overwritten.`,
@@ -94,7 +132,7 @@ export async function rollbackCustomFormatDeployment(
 	await client.customFormat.update(
 		state.resourceId,
 		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr Custom Format types are runtime-compatible
-		state.beforeFormat as any,
+		beforeFormat as any,
 	);
 	return "restored";
 }

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -1,0 +1,100 @@
+import type { RadarrClient, SonarrClient } from "arr-sdk";
+import { createUpstreamResourceStateToken } from "./deployment-target.js";
+
+type ArrClient = SonarrClient | RadarrClient;
+
+export interface CustomFormatRollbackState {
+	beforeFormat: Record<string, unknown> | null;
+	action: "created" | "updated";
+	resourceId: number | null;
+	name: string;
+	status: "pending" | "applied";
+	postStateToken: string | null;
+	intendedPostStateToken?: string | null;
+}
+
+/**
+ * Roll back only an exact Custom Format mutation made by this deployment.
+ * Unknown writes fail closed; an already-restored state is an idempotent success.
+ */
+export async function rollbackCustomFormatDeployment(
+	client: ArrClient,
+	state: CustomFormatRollbackState,
+): Promise<"noop" | "restored" | "deleted"> {
+	if (state.resourceId === null) {
+		if (state.action === "created" && state.status === "pending") {
+			const listed = await client.customFormat.getAll();
+			if (!listed.some((format) => format.name === state.name)) return "noop";
+		}
+		throw new Error(`Custom Format "${state.name}" may have been created, but its ID is unknown.`);
+	}
+
+	const listed = await client.customFormat.getAll();
+	const listedCurrent = listed.find((format) => format.id === state.resourceId);
+	if (!listedCurrent) {
+		if (state.action === "created") return "noop";
+		throw new Error(`Custom Format "${state.name}" no longer exists.`);
+	}
+	const current = await client.customFormat.getById(state.resourceId);
+	const currentToken = createUpstreamResourceStateToken(current);
+
+	let verifiedPostStateToken = state.postStateToken;
+	if (state.status === "pending") {
+		if (
+			state.action === "updated" &&
+			state.beforeFormat &&
+			currentToken === createUpstreamResourceStateToken(state.beforeFormat)
+		) {
+			return "noop";
+		}
+		if (state.postStateToken && currentToken === state.postStateToken) {
+			verifiedPostStateToken = state.postStateToken;
+		} else if (state.intendedPostStateToken && currentToken === state.intendedPostStateToken) {
+			verifiedPostStateToken = state.intendedPostStateToken;
+		} else {
+			throw new Error(
+				`Custom Format "${state.name}" has an unverified deployment state and was not changed.`,
+			);
+		}
+	}
+
+	if (!verifiedPostStateToken) {
+		throw new Error(`Custom Format "${state.name}" is missing its verified post-write state.`);
+	}
+	if (state.action === "created") {
+		if (currentToken !== verifiedPostStateToken) {
+			throw new Error(
+				`Custom Format "${state.name}" changed after deployment and was not deleted.`,
+			);
+		}
+		const profiles = await client.qualityProfile.getAll();
+		const referencingProfiles = profiles.filter((profile) =>
+			profile.formatItems?.some((item) => item.format === state.resourceId),
+		);
+		if (referencingProfiles.length > 0) {
+			throw new Error(
+				`Custom Format "${state.name}" is referenced by quality profile(s) ${referencingProfiles
+					.map((profile) => `"${profile.name ?? profile.id ?? "Unknown"}"`)
+					.join(", ")} and was not deleted.`,
+			);
+		}
+		await client.customFormat.delete(state.resourceId);
+		return "deleted";
+	}
+
+	if (!state.beforeFormat) {
+		throw new Error(`Custom Format "${state.name}" is missing its pre-deployment state.`);
+	}
+	if (currentToken === createUpstreamResourceStateToken(state.beforeFormat)) return "noop";
+	if (currentToken !== verifiedPostStateToken) {
+		throw new Error(
+			`Custom Format "${state.name}" changed after deployment and was not overwritten.`,
+		);
+	}
+	await client.customFormat.update(
+		state.resourceId,
+		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr Custom Format types are runtime-compatible
+		state.beforeFormat as any,
+	);
+	return "restored";
+}

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -146,10 +146,7 @@ export async function rollbackCustomFormatDeployment(
 			`Custom Format "${state.name}" changed after deployment and was not overwritten.`,
 		);
 	}
-	await client.customFormat.update(
-		state.resourceId,
-		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr Custom Format types are runtime-compatible
-		beforeFormat as any,
+	throw new Error(
+		`Custom Format "${state.name}" cannot be restored safely because the upstream API has no conditional update. Its current state still matches this deployment; restore the recorded pre-deployment configuration manually.`,
 	);
-	return "restored";
 }

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -3,10 +3,27 @@ import { z } from "zod";
 import { createUpstreamResourceStateToken } from "./deployment-target.js";
 
 type ArrClient = SonarrClient | RadarrClient;
-const restorableCustomFormatSchema = z.looseObject({
+const restorableCustomFormatFieldSchema = z.looseObject({
+	name: z.string().min(1),
+	type: z.string().min(1),
+});
+const restorableCustomFormatSpecificationSchema: z.ZodType = z.lazy(() =>
+	z.looseObject({
+		id: z.number().int().positive().safe().optional(),
+		name: z.string().min(1),
+		implementation: z.string().min(1),
+		implementationName: z.string().min(1).nullable().optional(),
+		infoLink: z.string().nullable().optional(),
+		negate: z.boolean(),
+		required: z.boolean(),
+		fields: z.array(restorableCustomFormatFieldSchema),
+		presets: z.array(restorableCustomFormatSpecificationSchema).nullable().optional(),
+	}),
+);
+export const restorableCustomFormatSchema = z.looseObject({
 	id: z.number().int().positive().safe(),
 	name: z.string().min(1),
-	specifications: z.array(z.unknown()),
+	specifications: z.array(restorableCustomFormatSpecificationSchema),
 	includeCustomFormatWhenRenaming: z.boolean().nullable(),
 });
 

--- a/apps/api/src/lib/trash-guides/deployment-managed-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-managed-format-state.ts
@@ -1,0 +1,166 @@
+import type { RadarrClient, SonarrClient } from "arr-sdk";
+import { createUpstreamResourceStateToken } from "./deployment-target.js";
+import type { TemplateCF } from "./quality-profile-helpers.js";
+
+type ArrClient = SonarrClient | RadarrClient;
+type ManagedProfile = {
+	id?: number;
+	formatItems?: Array<{ format?: number; score?: number }> | null;
+};
+
+export interface ManagedCustomFormatIdentity {
+	trashId: string;
+	name: string;
+	resourceId: number;
+	stateToken: string;
+	profileId: number;
+	appliedScore: number;
+}
+
+export interface OrphanedManagedCustomFormat {
+	trashId: string;
+	name: string;
+	resourceId: number;
+}
+
+export async function captureManagedCustomFormatIdentities(
+	client: ArrClient,
+	templateCFs: Array<Pick<TemplateCF, "trashId" | "name">>,
+	profile: ManagedProfile,
+): Promise<ManagedCustomFormatIdentity[]> {
+	if (profile.id === undefined) {
+		throw new Error("The managed quality profile ID is unavailable");
+	}
+	const appliedScores = new Map<number, number>();
+	for (const item of profile.formatItems ?? []) {
+		if (item.format !== undefined && item.score !== undefined) {
+			appliedScores.set(item.format, item.score);
+		}
+	}
+	const listed = await client.customFormat.getAll();
+	const byName = new Map(
+		listed.filter((format) => format.name).map((format) => [format.name!, format]),
+	);
+	const identities: ManagedCustomFormatIdentity[] = [];
+	for (const templateCF of templateCFs) {
+		const match = byName.get(templateCF.name);
+		if (match?.id === undefined) {
+			throw new Error(
+				`The deployed Custom Format identity for "${templateCF.name}" could not be captured.`,
+			);
+		}
+		const full = await client.customFormat.getById(match.id);
+		identities.push({
+			trashId: templateCF.trashId,
+			name: templateCF.name,
+			resourceId: match.id,
+			stateToken: createUpstreamResourceStateToken(full),
+			profileId: profile.id,
+			appliedScore: appliedScores.get(match.id) ?? 0,
+		});
+	}
+	return identities;
+}
+
+export function parseManagedCustomFormatIdentities(
+	backupData: string | null | undefined,
+): ManagedCustomFormatIdentity[] {
+	if (!backupData) return [];
+	const parsed = JSON.parse(backupData) as unknown;
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+	const value = (parsed as { managedCustomFormats?: unknown }).managedCustomFormats;
+	if (value === undefined) return [];
+	return parseManagedCustomFormatIdentityArray(value);
+}
+
+function parseManagedCustomFormatIdentityArray(value: unknown): ManagedCustomFormatIdentity[] {
+	if (!Array.isArray(value)) throw new Error("Managed Custom Format metadata is invalid");
+	return value.map((entry) => {
+		if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+			throw new Error("Managed Custom Format identity is invalid");
+		}
+		const candidate = entry as Partial<ManagedCustomFormatIdentity>;
+		if (
+			typeof candidate.trashId !== "string" ||
+			candidate.trashId.length === 0 ||
+			typeof candidate.name !== "string" ||
+			candidate.name.length === 0 ||
+			typeof candidate.resourceId !== "number" ||
+			!Number.isInteger(candidate.resourceId) ||
+			candidate.resourceId <= 0 ||
+			typeof candidate.stateToken !== "string" ||
+			candidate.stateToken.length === 0 ||
+			typeof candidate.profileId !== "number" ||
+			!Number.isInteger(candidate.profileId) ||
+			candidate.profileId <= 0 ||
+			typeof candidate.appliedScore !== "number" ||
+			!Number.isSafeInteger(candidate.appliedScore)
+		) {
+			throw new Error("Managed Custom Format identity is incomplete");
+		}
+		return candidate as ManagedCustomFormatIdentity;
+	});
+}
+
+export function readPersistedManagedCustomFormatIdentities(
+	mapping?: {
+		managedCustomFormatsCaptured: boolean;
+		managedCustomFormats: string | null;
+	} | null,
+): ManagedCustomFormatIdentity[] {
+	if (!mapping) return [];
+	if (!mapping.managedCustomFormatsCaptured || !mapping.managedCustomFormats) {
+		throw new Error(
+			"The managed Custom Format identity snapshot is unavailable. Unlink and review a fresh deployment before continuing.",
+		);
+	}
+	return parseManagedCustomFormatIdentityArray(JSON.parse(mapping.managedCustomFormats));
+}
+
+/** Resolve only removed template formats whose exact upstream identity is unchanged. */
+export async function resolveOrphanedManagedCustomFormats(
+	client: ArrClient,
+	currentTemplateCFs: Array<Pick<TemplateCF, "trashId" | "name">>,
+	previousManagedFormats: ManagedCustomFormatIdentity[],
+	currentProfile: ManagedProfile | undefined,
+): Promise<{ formats: OrphanedManagedCustomFormat[]; warnings: string[] }> {
+	const currentTrashIds = new Set(currentTemplateCFs.map((format) => format.trashId));
+	const listed = await client.customFormat.getAll();
+	const listedIds = new Set(
+		listed.flatMap((format) => (format.id === undefined ? [] : [format.id])),
+	);
+	const formats: OrphanedManagedCustomFormat[] = [];
+	const warnings: string[] = [];
+
+	for (const previous of previousManagedFormats) {
+		if (currentTrashIds.has(previous.trashId) || !listedIds.has(previous.resourceId)) continue;
+		if (currentProfile?.id !== previous.profileId) {
+			warnings.push(
+				`The previously managed Custom Format "${previous.name}" is associated with a different quality profile, so its score will not be reset automatically.`,
+			);
+			continue;
+		}
+		const currentScore =
+			currentProfile.formatItems?.find((item) => item.format === previous.resourceId)?.score ?? 0;
+		if (currentScore !== previous.appliedScore) {
+			warnings.push(
+				`The score for previously managed Custom Format "${previous.name}" changed after deployment, so the current score was preserved.`,
+			);
+			continue;
+		}
+		const current = await client.customFormat.getById(previous.resourceId);
+		if (createUpstreamResourceStateToken(current) !== previous.stateToken) {
+			warnings.push(
+				`The previously managed Custom Format "${previous.name}" changed identity, so its profile score will not be reset automatically.`,
+			);
+			continue;
+		}
+		formats.push({
+			trashId: previous.trashId,
+			name: previous.name,
+			resourceId: previous.resourceId,
+		});
+	}
+
+	return { formats, warnings };
+}

--- a/apps/api/src/lib/trash-guides/deployment-naming-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-naming-state.ts
@@ -1,0 +1,86 @@
+import { type NamingSelectedPresets, TRASH_CONFIG_TYPES, type TrashNamingData } from "@arr/shared";
+import type { ArrClientFactory } from "../arr/client-factory.js";
+import { AppValidationError } from "../errors.js";
+import type { PrismaClient } from "../prisma.js";
+import { createCacheManager } from "./cache-manager.js";
+import { createUpstreamResourceStateToken } from "./deployment-target.js";
+import { resolvePayload } from "./naming-deployer.js";
+
+type NamingInstance = Parameters<ArrClientFactory["rawRequest"]>[0];
+
+export interface PreparedNamingDeployment {
+	currentConfig: Record<string, unknown>;
+	mergedConfig: Record<string, unknown>;
+	changedFields: string[];
+}
+
+/** Resolve the exact naming mutation against a fresh upstream snapshot. */
+export async function prepareNamingDeployment(
+	prisma: PrismaClient,
+	clientFactory: ArrClientFactory,
+	instance: NamingInstance,
+	selection: NamingSelectedPresets,
+): Promise<PreparedNamingDeployment> {
+	const serviceType = instance.service.toUpperCase() as "RADARR" | "SONARR";
+	if (selection.serviceType !== serviceType) {
+		throw new AppValidationError(`Naming selection service type mismatch: expected ${serviceType}`);
+	}
+
+	const namingData = await createCacheManager(prisma).get<TrashNamingData[]>(
+		serviceType,
+		TRASH_CONFIG_TYPES.NAMING_PRESETS,
+	);
+	if (!namingData?.length) {
+		throw new AppValidationError(
+			"Naming data is not cached. Refresh TRaSH Guides data before deploying this template.",
+		);
+	}
+
+	const currentResponse = await clientFactory.rawRequest(instance, "/api/v3/config/naming");
+	if (!currentResponse.ok) {
+		throw new AppValidationError(
+			`The current naming configuration could not be read (HTTP ${currentResponse.status}).`,
+		);
+	}
+	const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
+	const patch = resolvePayload(namingData[0]!, selection);
+	const changedFields = Object.keys(patch).filter(
+		(field) => !Object.is(currentConfig[field], patch[field]),
+	);
+
+	return {
+		currentConfig,
+		mergedConfig: { ...currentConfig, ...patch },
+		changedFields,
+	};
+}
+
+/** Restore a naming snapshot captured with a deployment backup. */
+export async function restoreNamingDeployment(
+	clientFactory: ArrClientFactory,
+	instance: NamingInstance,
+	config: Record<string, unknown>,
+	expectedCurrentStateToken: string,
+): Promise<void> {
+	const currentResponse = await clientFactory.rawRequest(instance, "/api/v3/config/naming");
+	if (!currentResponse.ok) {
+		throw new Error(`Failed to read current naming configuration: HTTP ${currentResponse.status}`);
+	}
+	const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
+	const currentStateToken = createUpstreamResourceStateToken(currentConfig);
+	if (currentStateToken === createUpstreamResourceStateToken(config)) {
+		return;
+	}
+	if (currentStateToken !== expectedCurrentStateToken) {
+		throw new Error(
+			"Naming configuration changed after this deployment. Restore it manually or create a fresh backup before retrying.",
+		);
+	}
+	const response = await clientFactory.rawRequest(instance, "/api/v3/config/naming", {
+		method: "PUT",
+		body: config,
+	});
+	if (!response.ok) {
+		throw new Error(`HTTP ${response.status}`);
+	}
+}

--- a/apps/api/src/lib/trash-guides/deployment-naming-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-naming-state.ts
@@ -1,12 +1,46 @@
 import { type NamingSelectedPresets, TRASH_CONFIG_TYPES, type TrashNamingData } from "@arr/shared";
+import { z } from "zod";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import { AppValidationError } from "../errors.js";
 import type { PrismaClient } from "../prisma.js";
 import { createCacheManager } from "./cache-manager.js";
 import { createUpstreamResourceStateToken } from "./deployment-target.js";
+import { arrNamingConfigSchema } from "./github-schemas.js";
 import { resolvePayload } from "./naming-deployer.js";
 
 type NamingInstance = Parameters<ArrClientFactory["rawRequest"]>[0];
+const positiveConfigId = z.number().int().positive().safe();
+const radarrNamingSnapshotSchema = arrNamingConfigSchema.extend({
+	id: positiveConfigId,
+	renameMovies: z.boolean(),
+	standardMovieFormat: z.string(),
+	movieFolderFormat: z.string(),
+});
+const sonarrNamingSnapshotSchema = arrNamingConfigSchema.extend({
+	id: positiveConfigId,
+	renameEpisodes: z.boolean(),
+	standardEpisodeFormat: z.string(),
+	dailyEpisodeFormat: z.string(),
+	animeEpisodeFormat: z.string(),
+	seriesFolderFormat: z.string(),
+	seasonFolderFormat: z.string(),
+});
+
+function getNamingServiceType(instance: NamingInstance): "RADARR" | "SONARR" {
+	const serviceType = instance.service.toUpperCase();
+	if (serviceType !== "RADARR" && serviceType !== "SONARR") {
+		throw new AppValidationError(`Naming deployment is unsupported for ${instance.service}`);
+	}
+	return serviceType;
+}
+
+function parseNamingResponse(value: unknown): Record<string, unknown> {
+	const parsed = arrNamingConfigSchema.safeParse(value);
+	if (!parsed.success) {
+		throw new AppValidationError("The instance returned an invalid naming configuration.");
+	}
+	return parsed.data as Record<string, unknown>;
+}
 
 export interface PreparedNamingDeployment {
 	currentConfig: Record<string, unknown>;
@@ -21,7 +55,7 @@ export async function prepareNamingDeployment(
 	instance: NamingInstance,
 	selection: NamingSelectedPresets,
 ): Promise<PreparedNamingDeployment> {
-	const serviceType = instance.service.toUpperCase() as "RADARR" | "SONARR";
+	const serviceType = getNamingServiceType(instance);
 	if (selection.serviceType !== serviceType) {
 		throw new AppValidationError(`Naming selection service type mismatch: expected ${serviceType}`);
 	}
@@ -42,7 +76,7 @@ export async function prepareNamingDeployment(
 			`The current naming configuration could not be read (HTTP ${currentResponse.status}).`,
 		);
 	}
-	const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
+	const currentConfig = parseNamingResponse(await currentResponse.json());
 	const patch = resolvePayload(namingData[0]!, selection);
 	const changedFields = Object.keys(patch).filter(
 		(field) => !Object.is(currentConfig[field], patch[field]),
@@ -62,13 +96,21 @@ export async function restoreNamingDeployment(
 	config: Record<string, unknown>,
 	expectedCurrentStateToken: string,
 ): Promise<void> {
+	const serviceType = getNamingServiceType(instance);
+	const snapshotResult = (
+		serviceType === "RADARR" ? radarrNamingSnapshotSchema : sonarrNamingSnapshotSchema
+	).safeParse(config);
+	if (!snapshotResult.success) {
+		throw new Error(`Naming snapshot is incomplete or does not match ${serviceType}.`);
+	}
+	const snapshot = snapshotResult.data as Record<string, unknown>;
 	const currentResponse = await clientFactory.rawRequest(instance, "/api/v3/config/naming");
 	if (!currentResponse.ok) {
 		throw new Error(`Failed to read current naming configuration: HTTP ${currentResponse.status}`);
 	}
-	const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
+	const currentConfig = parseNamingResponse(await currentResponse.json());
 	const currentStateToken = createUpstreamResourceStateToken(currentConfig);
-	if (currentStateToken === createUpstreamResourceStateToken(config)) {
+	if (currentStateToken === createUpstreamResourceStateToken(snapshot)) {
 		return;
 	}
 	if (currentStateToken !== expectedCurrentStateToken) {
@@ -78,7 +120,7 @@ export async function restoreNamingDeployment(
 	}
 	const response = await clientFactory.rawRequest(instance, "/api/v3/config/naming", {
 		method: "PUT",
-		body: config,
+		body: snapshot,
 	});
 	if (!response.ok) {
 		throw new Error(`HTTP ${response.status}`);

--- a/apps/api/src/lib/trash-guides/deployment-naming-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-naming-state.ts
@@ -13,17 +13,24 @@ const positiveConfigId = z.number().int().positive().safe();
 const radarrNamingSnapshotSchema = arrNamingConfigSchema.extend({
 	id: positiveConfigId,
 	renameMovies: z.boolean(),
-	standardMovieFormat: z.string(),
-	movieFolderFormat: z.string(),
+	replaceIllegalCharacters: z.boolean(),
+	colonReplacementFormat: z.enum(["delete", "dash", "spaceDash", "spaceDashSpace", "smart"]),
+	standardMovieFormat: z.string().nullable(),
+	movieFolderFormat: z.string().nullable(),
 });
 const sonarrNamingSnapshotSchema = arrNamingConfigSchema.extend({
 	id: positiveConfigId,
 	renameEpisodes: z.boolean(),
-	standardEpisodeFormat: z.string(),
-	dailyEpisodeFormat: z.string(),
-	animeEpisodeFormat: z.string(),
-	seriesFolderFormat: z.string(),
-	seasonFolderFormat: z.string(),
+	replaceIllegalCharacters: z.boolean(),
+	colonReplacementFormat: z.number().int().nonnegative().safe(),
+	customColonReplacementFormat: z.string().nullable(),
+	multiEpisodeStyle: z.number().int().nonnegative().safe(),
+	standardEpisodeFormat: z.string().nullable(),
+	dailyEpisodeFormat: z.string().nullable(),
+	animeEpisodeFormat: z.string().nullable(),
+	seriesFolderFormat: z.string().nullable(),
+	seasonFolderFormat: z.string().nullable(),
+	specialsFolderFormat: z.string().nullable(),
 });
 
 function getNamingServiceType(instance: NamingInstance): "RADARR" | "SONARR" {
@@ -34,10 +41,19 @@ function getNamingServiceType(instance: NamingInstance): "RADARR" | "SONARR" {
 	return serviceType;
 }
 
-function parseNamingResponse(value: unknown): Record<string, unknown> {
-	const parsed = arrNamingConfigSchema.safeParse(value);
+function getNamingSnapshotSchema(serviceType: "RADARR" | "SONARR") {
+	return serviceType === "RADARR" ? radarrNamingSnapshotSchema : sonarrNamingSnapshotSchema;
+}
+
+function parseNamingResponse(
+	value: unknown,
+	serviceType: "RADARR" | "SONARR",
+): Record<string, unknown> {
+	const parsed = getNamingSnapshotSchema(serviceType).safeParse(value);
 	if (!parsed.success) {
-		throw new AppValidationError("The instance returned an invalid naming configuration.");
+		throw new AppValidationError(
+			`The instance returned an invalid ${serviceType} naming configuration.`,
+		);
 	}
 	return parsed.data as Record<string, unknown>;
 }
@@ -76,7 +92,7 @@ export async function prepareNamingDeployment(
 			`The current naming configuration could not be read (HTTP ${currentResponse.status}).`,
 		);
 	}
-	const currentConfig = parseNamingResponse(await currentResponse.json());
+	const currentConfig = parseNamingResponse(await currentResponse.json(), serviceType);
 	const patch = resolvePayload(namingData[0]!, selection);
 	const changedFields = Object.keys(patch).filter(
 		(field) => !Object.is(currentConfig[field], patch[field]),
@@ -97,9 +113,7 @@ export async function restoreNamingDeployment(
 	expectedCurrentStateToken: string,
 ): Promise<void> {
 	const serviceType = getNamingServiceType(instance);
-	const snapshotResult = (
-		serviceType === "RADARR" ? radarrNamingSnapshotSchema : sonarrNamingSnapshotSchema
-	).safeParse(config);
+	const snapshotResult = getNamingSnapshotSchema(serviceType).safeParse(config);
 	if (!snapshotResult.success) {
 		throw new Error(`Naming snapshot is incomplete or does not match ${serviceType}.`);
 	}
@@ -108,7 +122,7 @@ export async function restoreNamingDeployment(
 	if (!currentResponse.ok) {
 		throw new Error(`Failed to read current naming configuration: HTTP ${currentResponse.status}`);
 	}
-	const currentConfig = parseNamingResponse(await currentResponse.json());
+	const currentConfig = parseNamingResponse(await currentResponse.json(), serviceType);
 	const currentStateToken = createUpstreamResourceStateToken(currentConfig);
 	if (currentStateToken === createUpstreamResourceStateToken(snapshot)) {
 		return;

--- a/apps/api/src/lib/trash-guides/deployment-naming-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-naming-state.ts
@@ -132,11 +132,7 @@ export async function restoreNamingDeployment(
 			"Naming configuration changed after this deployment. Restore it manually or create a fresh backup before retrying.",
 		);
 	}
-	const response = await clientFactory.rawRequest(instance, "/api/v3/config/naming", {
-		method: "PUT",
-		body: snapshot,
-	});
-	if (!response.ok) {
-		throw new Error(`HTTP ${response.status}`);
-	}
+	throw new Error(
+		"Naming configuration cannot be restored safely because the upstream API has no conditional update. Its current state still matches this deployment; restore the recorded pre-deployment configuration manually.",
+	);
 }

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -4,23 +4,23 @@ import { createQualityProfileStateToken } from "./deployment-target.js";
 
 type ArrProfileClient = SonarrClient | RadarrClient;
 const restorableQualitySchema = z.looseObject({
-	id: z.number().int().positive().safe(),
+	id: z.number().int().nonnegative().safe(),
 	name: z.string().min(1),
 });
 const restorableQualityProfileItemSchema: z.ZodType = z.lazy(() =>
 	z
 		.looseObject({
-			id: z.number().int().positive().safe(),
+			id: z.number().int().nonnegative().safe(),
 			name: z.string().min(1),
 			allowed: z.boolean(),
 			quality: restorableQualitySchema.optional(),
-			items: z.array(restorableQualityProfileItemSchema).nullable().optional(),
+			items: z.array(restorableQualityProfileItemSchema),
 		})
 		.superRefine((item, ctx) => {
-			if (!item.quality && !Array.isArray(item.items)) {
+			if (!item.quality && item.items.length === 0) {
 				ctx.addIssue({
 					code: "custom",
-					message: "Quality profile item requires a quality or nested items",
+					message: "Quality profile item requires a quality or non-empty nested items",
 				});
 			}
 		}),
@@ -29,7 +29,7 @@ export const restorableQualityProfileSchema = z.looseObject({
 	id: z.number().int().positive().safe(),
 	name: z.string().min(1),
 	upgradeAllowed: z.boolean(),
-	cutoff: z.number().int().positive().safe(),
+	cutoff: z.number().int().nonnegative().safe(),
 	items: z.array(restorableQualityProfileItemSchema),
 	minFormatScore: z.number().int().safe(),
 	cutoffFormatScore: z.number().int().safe(),

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -1,0 +1,90 @@
+import type { RadarrClient, SonarrClient } from "arr-sdk";
+import { createQualityProfileStateToken } from "./deployment-target.js";
+
+type ArrProfileClient = SonarrClient | RadarrClient;
+
+export interface QualityProfileRollbackState {
+	beforeProfile: Record<string, unknown> | null;
+	action: "created" | "updated";
+	profileId: number | null;
+	profileName?: string | null;
+	status: "pending" | "applied";
+	postStateToken: string | null;
+	intendedPostStateToken?: string | null;
+}
+
+/**
+ * Roll back only the exact quality-profile state written by a deployment.
+ * A matching pre-deployment state is treated as an idempotent retry.
+ */
+export async function rollbackQualityProfileDeployment(
+	client: ArrProfileClient,
+	state: QualityProfileRollbackState,
+): Promise<void> {
+	if (state.profileId === null) {
+		if (state.action === "created" && state.status === "pending" && state.profileName) {
+			const currentProfiles = await client.qualityProfile.getAll();
+			if (!currentProfiles.some((profile) => profile.name === state.profileName)) return;
+		}
+		throw new Error("A quality profile may have been created, but its ID is unknown.");
+	}
+	const currentProfiles = await client.qualityProfile.getAll();
+	const currentProfile = currentProfiles.find((profile) => profile.id === state.profileId);
+	let verifiedPostStateToken = state.postStateToken;
+	if (state.status === "pending") {
+		if (!currentProfile) {
+			if (state.action === "created") return;
+			throw new Error("The quality profile to restore no longer exists.");
+		}
+		const fullCurrent = await client.qualityProfile.getById(state.profileId);
+		const currentStateToken = createQualityProfileStateToken(fullCurrent);
+		if (
+			state.action === "updated" &&
+			state.beforeProfile &&
+			currentStateToken === createQualityProfileStateToken(state.beforeProfile)
+		) {
+			return;
+		}
+		if (state.postStateToken && currentStateToken === state.postStateToken) {
+			verifiedPostStateToken = state.postStateToken;
+		} else if (state.intendedPostStateToken && currentStateToken === state.intendedPostStateToken) {
+			verifiedPostStateToken = state.intendedPostStateToken;
+		} else {
+			throw new Error(
+				"The quality profile has an unverified deployment state and was not changed.",
+			);
+		}
+	}
+	if (!verifiedPostStateToken) {
+		throw new Error("The quality profile is missing its verified post-write state.");
+	}
+
+	if (state.action === "created") {
+		if (!currentProfile) {
+			return;
+		}
+		const fullCurrent = await client.qualityProfile.getById(state.profileId);
+		if (createQualityProfileStateToken(fullCurrent) !== verifiedPostStateToken) {
+			throw new Error("The created quality profile changed after deployment and was not deleted.");
+		}
+		await client.qualityProfile.delete(state.profileId);
+		return;
+	}
+
+	if (!currentProfile || !state.beforeProfile) {
+		throw new Error("The quality profile to restore no longer exists.");
+	}
+	const fullCurrent = await client.qualityProfile.getById(state.profileId);
+	const currentStateToken = createQualityProfileStateToken(fullCurrent);
+	if (currentStateToken === createQualityProfileStateToken(state.beforeProfile)) {
+		return;
+	}
+	if (currentStateToken !== verifiedPostStateToken) {
+		throw new Error("The quality profile changed after deployment and was not overwritten.");
+	}
+	await client.qualityProfile.update(
+		state.profileId,
+		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
+		state.beforeProfile as any,
+	);
+}

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -128,9 +128,7 @@ export async function rollbackQualityProfileDeployment(
 	if (currentStateToken !== verifiedPostStateToken) {
 		throw new Error("The quality profile changed after deployment and was not overwritten.");
 	}
-	await client.qualityProfile.update(
-		state.profileId,
-		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
-		beforeProfile as any,
+	throw new Error(
+		"The quality profile cannot be restored safely because the upstream API has no conditional update. Its current state still matches this deployment; restore the recorded pre-deployment configuration manually.",
 	);
 }

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -1,7 +1,24 @@
 import type { RadarrClient, SonarrClient } from "arr-sdk";
+import { z } from "zod";
 import { createQualityProfileStateToken } from "./deployment-target.js";
 
 type ArrProfileClient = SonarrClient | RadarrClient;
+const restorableQualityProfileSchema = z.looseObject({
+	id: z.number().int().positive().safe(),
+	name: z.string().min(1),
+	upgradeAllowed: z.boolean(),
+	cutoff: z.number().int().positive().safe(),
+	items: z.array(z.unknown()),
+	minFormatScore: z.number().int().safe(),
+	cutoffFormatScore: z.number().int().safe(),
+	minUpgradeFormatScore: z.number().int().safe(),
+	formatItems: z.array(
+		z.looseObject({
+			format: z.number().int().positive().safe(),
+			score: z.number().int().safe(),
+		}),
+	),
+});
 
 export interface QualityProfileRollbackState {
 	beforeProfile: Record<string, unknown> | null;
@@ -22,11 +39,17 @@ export async function rollbackQualityProfileDeployment(
 	state: QualityProfileRollbackState,
 ): Promise<void> {
 	if (state.profileId === null) {
-		if (state.action === "created" && state.status === "pending" && state.profileName) {
-			const currentProfiles = await client.qualityProfile.getAll();
-			if (!currentProfiles.some((profile) => profile.name === state.profileName)) return;
-		}
 		throw new Error("A quality profile may have been created, but its ID is unknown.");
+	}
+	let beforeProfile: Record<string, unknown> | null = null;
+	if (state.action === "updated") {
+		const parsed = restorableQualityProfileSchema.safeParse(state.beforeProfile);
+		if (!parsed.success || parsed.data.id !== state.profileId) {
+			throw new Error(
+				"The quality profile has an incomplete or mismatched pre-deployment state and was not restored.",
+			);
+		}
+		beforeProfile = parsed.data;
 	}
 	const currentProfiles = await client.qualityProfile.getAll();
 	const currentProfile = currentProfiles.find((profile) => profile.id === state.profileId);
@@ -40,8 +63,8 @@ export async function rollbackQualityProfileDeployment(
 		const currentStateToken = createQualityProfileStateToken(fullCurrent);
 		if (
 			state.action === "updated" &&
-			state.beforeProfile &&
-			currentStateToken === createQualityProfileStateToken(state.beforeProfile)
+			beforeProfile &&
+			currentStateToken === createQualityProfileStateToken(beforeProfile)
 		) {
 			return;
 		}
@@ -71,12 +94,12 @@ export async function rollbackQualityProfileDeployment(
 		return;
 	}
 
-	if (!currentProfile || !state.beforeProfile) {
+	if (!currentProfile || !beforeProfile) {
 		throw new Error("The quality profile to restore no longer exists.");
 	}
 	const fullCurrent = await client.qualityProfile.getById(state.profileId);
 	const currentStateToken = createQualityProfileStateToken(fullCurrent);
-	if (currentStateToken === createQualityProfileStateToken(state.beforeProfile)) {
+	if (currentStateToken === createQualityProfileStateToken(beforeProfile)) {
 		return;
 	}
 	if (currentStateToken !== verifiedPostStateToken) {
@@ -85,6 +108,6 @@ export async function rollbackQualityProfileDeployment(
 	await client.qualityProfile.update(
 		state.profileId,
 		// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
-		state.beforeProfile as any,
+		beforeProfile as any,
 	);
 }

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -112,8 +112,9 @@ export async function rollbackQualityProfileDeployment(
 		if (createQualityProfileStateToken(fullCurrent) !== verifiedPostStateToken) {
 			throw new Error("The created quality profile changed after deployment and was not deleted.");
 		}
-		await client.qualityProfile.delete(state.profileId);
-		return;
+		throw new Error(
+			"The created quality profile cannot be deleted safely because the upstream API has no conditional delete. Verify that it is unused, then remove it manually.",
+		);
 	}
 
 	if (!currentProfile || !beforeProfile) {

--- a/apps/api/src/lib/trash-guides/deployment-profile-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-profile-state.ts
@@ -3,12 +3,34 @@ import { z } from "zod";
 import { createQualityProfileStateToken } from "./deployment-target.js";
 
 type ArrProfileClient = SonarrClient | RadarrClient;
-const restorableQualityProfileSchema = z.looseObject({
+const restorableQualitySchema = z.looseObject({
+	id: z.number().int().positive().safe(),
+	name: z.string().min(1),
+});
+const restorableQualityProfileItemSchema: z.ZodType = z.lazy(() =>
+	z
+		.looseObject({
+			id: z.number().int().positive().safe(),
+			name: z.string().min(1),
+			allowed: z.boolean(),
+			quality: restorableQualitySchema.optional(),
+			items: z.array(restorableQualityProfileItemSchema).nullable().optional(),
+		})
+		.superRefine((item, ctx) => {
+			if (!item.quality && !Array.isArray(item.items)) {
+				ctx.addIssue({
+					code: "custom",
+					message: "Quality profile item requires a quality or nested items",
+				});
+			}
+		}),
+);
+export const restorableQualityProfileSchema = z.looseObject({
 	id: z.number().int().positive().safe(),
 	name: z.string().min(1),
 	upgradeAllowed: z.boolean(),
 	cutoff: z.number().int().positive().safe(),
-	items: z.array(z.unknown()),
+	items: z.array(restorableQualityProfileItemSchema),
 	minFormatScore: z.number().int().safe(),
 	cutoffFormatScore: z.number().int().safe(),
 	minUpgradeFormatScore: z.number().int().safe(),

--- a/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
+++ b/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
@@ -13,7 +13,7 @@
  */
 
 import type { FastifyBaseLogger } from "fastify";
-import type { PrismaClient } from "../../lib/prisma.js";
+import type { Prisma, PrismaClient } from "../../lib/prisma.js";
 import { withCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import {
 	passthroughTickWrapper,
@@ -23,6 +23,9 @@ import { shouldRetainDeploymentBackup } from "./deployment-backup-state.js";
 
 // Run cleanup every hour
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+// Each candidate contributes two bound values (id + backupData). Keep ample
+// room for the timestamp and relation predicates under SQLite's 999-variable cap.
+const BACKUP_DELETE_BATCH_SIZE = 400;
 
 export interface CleanupStats {
 	expiredCount: number;
@@ -129,6 +132,24 @@ export class TrashBackupCleanupService {
 	/**
 	 * Delete backups that have passed their expiration date
 	 */
+	private async deleteCandidateBatches(
+		candidates: Array<{ id: string; backupData: string }>,
+		where: Prisma.TrashBackupWhereInput,
+	): Promise<number> {
+		let deleted = 0;
+		for (let index = 0; index < candidates.length; index += BACKUP_DELETE_BATCH_SIZE) {
+			const batch = candidates.slice(index, index + BACKUP_DELETE_BATCH_SIZE);
+			const result = await this.prisma.trashBackup.deleteMany({
+				where: {
+					...where,
+					OR: batch.map((backup) => ({ id: backup.id, backupData: backup.backupData })),
+				},
+			});
+			deleted += result.count;
+		}
+		return deleted;
+	}
+
 	private async cleanupExpiredBackups(): Promise<number> {
 		const now = new Date();
 		const expired = await this.prisma.trashBackup.findMany({
@@ -143,22 +164,19 @@ export class TrashBackupCleanupService {
 		});
 		const deletable = expired.filter((backup) => !shouldRetainDeploymentBackup(backup.backupData));
 		if (deletable.length === 0) return 0;
-		const result = await this.prisma.trashBackup.deleteMany({
-			where: {
-				expiresAt: { not: null, lte: now },
-				// Re-check ownership in the mutation itself. A history may have
-				// linked this backup after selection but before deleteMany executes.
-				syncHistory: { none: { rolledBack: false } },
-				deploymentHistory: { none: { rolledBack: false } },
-				OR: deletable.map((backup) => ({ id: backup.id, backupData: backup.backupData })),
-			},
+		const count = await this.deleteCandidateBatches(deletable, {
+			expiresAt: { not: null, lte: now },
+			// Re-check ownership in the mutation itself. A history may have
+			// linked this backup after selection but before deleteMany executes.
+			syncHistory: { none: { rolledBack: false } },
+			deploymentHistory: { none: { rolledBack: false } },
 		});
 
-		if (result.count > 0) {
-			this.logger.debug({ count: result.count }, "Deleted expired trash backups");
+		if (count > 0) {
+			this.logger.debug({ count }, "Deleted expired trash backups");
 		}
 
-		return result.count;
+		return count;
 	}
 
 	/**
@@ -208,19 +226,17 @@ export class TrashBackupCleanupService {
 			return 0;
 		}
 
-		const result = await this.prisma.trashBackup.deleteMany({
-			where: {
-				syncHistory: { none: { rolledBack: false } },
-				deploymentHistory: { none: { rolledBack: false } },
-				OR: orphanIds.map((backup) => ({ id: backup.id, backupData: backup.backupData })),
-			},
+		const count = await this.deleteCandidateBatches(orphanIds, {
+			createdAt: { lte: orphanThreshold },
+			syncHistory: { none: { rolledBack: false } },
+			deploymentHistory: { none: { rolledBack: false } },
 		});
 
-		if (result.count > 0) {
-			this.logger.debug({ count: result.count }, "Deleted orphaned trash backups");
+		if (count > 0) {
+			this.logger.debug({ count }, "Deleted orphaned trash backups");
 		}
 
-		return result.count;
+		return count;
 	}
 
 	/**

--- a/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
+++ b/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
@@ -19,6 +19,7 @@ import {
 	passthroughTickWrapper,
 	type TickWrapper,
 } from "../scheduler-registry/scheduler-registry.js";
+import { shouldRetainDeploymentBackup } from "./deployment-backup-state.js";
 
 // Run cleanup every hour
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
@@ -129,39 +130,27 @@ export class TrashBackupCleanupService {
 	 * Delete backups that have passed their expiration date
 	 */
 	private async cleanupExpiredBackups(): Promise<number> {
+		const now = new Date();
+		const expired = await this.prisma.trashBackup.findMany({
+			where: {
+				expiresAt: { not: null, lte: now },
+				// The backup remains durable ownership and rollback evidence until
+				// every referencing history has been explicitly resolved.
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
+			},
+			select: { id: true, backupData: true },
+		});
+		const deletable = expired.filter((backup) => !shouldRetainDeploymentBackup(backup.backupData));
+		if (deletable.length === 0) return 0;
 		const result = await this.prisma.trashBackup.deleteMany({
 			where: {
-				expiresAt: {
-					not: null,
-					lte: new Date(),
-				},
-				// Legacy snapshots may still have an expiry timestamp even while a
-				// rollback or undeploy is retryable. Keep them until coordination is terminal.
-				syncHistory: {
-					none: {
-						rolledBack: false,
-						OR: [
-							{
-								rollbackStatus: { not: null },
-								NOT: { rollbackStatus: "COMPLETED" },
-							},
-							{ status: { in: ["IN_PROGRESS", "RUNNING"] } },
-						],
-					},
-				},
-				deploymentHistory: {
-					none: {
-						rolledBack: false,
-						OR: [
-							{
-								undeployStatus: { not: null },
-								NOT: { undeployStatus: "COMPLETED" },
-							},
-							{ status: "PARTIAL_UNDEPLOY", undeployStatus: null },
-							{ status: "IN_PROGRESS" },
-						],
-					},
-				},
+				expiresAt: { not: null, lte: now },
+				// Re-check ownership in the mutation itself. A history may have
+				// linked this backup after selection but before deleteMany executes.
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
+				OR: deletable.map((backup) => ({ id: backup.id, backupData: backup.backupData })),
 			},
 		});
 
@@ -192,9 +181,12 @@ export class TrashBackupCleanupService {
 				createdAt: {
 					lte: orphanThreshold,
 				},
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
 			},
 			select: {
 				id: true,
+				backupData: true,
 				_count: {
 					select: {
 						syncHistory: true,
@@ -205,9 +197,12 @@ export class TrashBackupCleanupService {
 		});
 
 		// Filter to only those with no references
-		const orphanIds = potentialOrphans
-			.filter((backup) => backup._count.syncHistory === 0 && backup._count.deploymentHistory === 0)
-			.map((backup) => backup.id);
+		const orphanIds = potentialOrphans.filter(
+			(backup) =>
+				backup._count.syncHistory === 0 &&
+				backup._count.deploymentHistory === 0 &&
+				!shouldRetainDeploymentBackup(backup.backupData),
+		);
 
 		if (orphanIds.length === 0) {
 			return 0;
@@ -215,7 +210,9 @@ export class TrashBackupCleanupService {
 
 		const result = await this.prisma.trashBackup.deleteMany({
 			where: {
-				id: { in: orphanIds },
+				syncHistory: { none: { rolledBack: false } },
+				deploymentHistory: { none: { rolledBack: false } },
+				OR: orphanIds.map((backup) => ({ id: backup.id, backupData: backup.backupData })),
 			},
 		});
 

--- a/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
+++ b/apps/api/src/lib/trash-guides/trash-backup-cleanup.ts
@@ -23,6 +23,8 @@ import { shouldRetainDeploymentBackup } from "./deployment-backup-state.js";
 
 // Run cleanup every hour
 const CLEANUP_INTERVAL_MS = 60 * 60 * 1000;
+// Bound the backup blobs loaded and parsed during each candidate scan.
+const BACKUP_CANDIDATE_PAGE_SIZE = 400;
 // Each candidate contributes two bound values (id + backupData). Keep ample
 // room for the timestamp and relation predicates under SQLite's 999-variable cap.
 const BACKUP_DELETE_BATCH_SIZE = 400;
@@ -152,25 +154,42 @@ export class TrashBackupCleanupService {
 
 	private async cleanupExpiredBackups(): Promise<number> {
 		const now = new Date();
-		const expired = await this.prisma.trashBackup.findMany({
-			where: {
-				expiresAt: { not: null, lte: now },
-				// The backup remains durable ownership and rollback evidence until
-				// every referencing history has been explicitly resolved.
-				syncHistory: { none: { rolledBack: false } },
-				deploymentHistory: { none: { rolledBack: false } },
-			},
-			select: { id: true, backupData: true },
-		});
-		const deletable = expired.filter((backup) => !shouldRetainDeploymentBackup(backup.backupData));
-		if (deletable.length === 0) return 0;
-		const count = await this.deleteCandidateBatches(deletable, {
-			expiresAt: { not: null, lte: now },
-			// Re-check ownership in the mutation itself. A history may have
-			// linked this backup after selection but before deleteMany executes.
-			syncHistory: { none: { rolledBack: false } },
-			deploymentHistory: { none: { rolledBack: false } },
-		});
+		let cursorId: string | undefined;
+		let count = 0;
+
+		for (;;) {
+			const expired = await this.prisma.trashBackup.findMany({
+				where: {
+					expiresAt: { not: null, lte: now },
+					// The backup remains durable ownership and rollback evidence until
+					// every referencing history has been explicitly resolved.
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+					...(cursorId ? { id: { gt: cursorId } } : {}),
+				},
+				select: { id: true, backupData: true },
+				orderBy: { id: "asc" },
+				take: BACKUP_CANDIDATE_PAGE_SIZE,
+			});
+
+			if (expired.length === 0) break;
+			cursorId = expired.at(-1)!.id;
+
+			const deletable = expired.filter(
+				(backup) => !shouldRetainDeploymentBackup(backup.backupData),
+			);
+			if (deletable.length > 0) {
+				count += await this.deleteCandidateBatches(deletable, {
+					expiresAt: { not: null, lte: now },
+					// Re-check ownership in the mutation itself. A history may have
+					// linked this backup after selection but before deleteMany executes.
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+				});
+			}
+
+			if (expired.length < BACKUP_CANDIDATE_PAGE_SIZE) break;
+		}
 
 		if (count > 0) {
 			this.logger.debug({ count }, "Deleted expired trash backups");
@@ -192,45 +211,55 @@ export class TrashBackupCleanupService {
 	private async cleanupOrphanedBackups(): Promise<number> {
 		const orphanThreshold = new Date();
 		orphanThreshold.setDate(orphanThreshold.getDate() - 7);
+		let cursorId: string | undefined;
+		let count = 0;
 
-		// Find backups that might be orphaned (old enough to check)
-		const potentialOrphans = await this.prisma.trashBackup.findMany({
-			where: {
-				createdAt: {
-					lte: orphanThreshold,
+		for (;;) {
+			// Find backups that might be orphaned (old enough to check)
+			const potentialOrphans = await this.prisma.trashBackup.findMany({
+				where: {
+					createdAt: {
+						lte: orphanThreshold,
+					},
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+					...(cursorId ? { id: { gt: cursorId } } : {}),
 				},
-				syncHistory: { none: { rolledBack: false } },
-				deploymentHistory: { none: { rolledBack: false } },
-			},
-			select: {
-				id: true,
-				backupData: true,
-				_count: {
-					select: {
-						syncHistory: true,
-						deploymentHistory: true,
+				select: {
+					id: true,
+					backupData: true,
+					_count: {
+						select: {
+							syncHistory: true,
+							deploymentHistory: true,
+						},
 					},
 				},
-			},
-		});
+				orderBy: { id: "asc" },
+				take: BACKUP_CANDIDATE_PAGE_SIZE,
+			});
 
-		// Filter to only those with no references
-		const orphanIds = potentialOrphans.filter(
-			(backup) =>
-				backup._count.syncHistory === 0 &&
-				backup._count.deploymentHistory === 0 &&
-				!shouldRetainDeploymentBackup(backup.backupData),
-		);
+			if (potentialOrphans.length === 0) break;
+			cursorId = potentialOrphans.at(-1)!.id;
 
-		if (orphanIds.length === 0) {
-			return 0;
+			// Filter to only those with no references
+			const orphanIds = potentialOrphans.filter(
+				(backup) =>
+					backup._count.syncHistory === 0 &&
+					backup._count.deploymentHistory === 0 &&
+					!shouldRetainDeploymentBackup(backup.backupData),
+			);
+
+			if (orphanIds.length > 0) {
+				count += await this.deleteCandidateBatches(orphanIds, {
+					createdAt: { lte: orphanThreshold },
+					syncHistory: { none: { rolledBack: false } },
+					deploymentHistory: { none: { rolledBack: false } },
+				});
+			}
+
+			if (potentialOrphans.length < BACKUP_CANDIDATE_PAGE_SIZE) break;
 		}
-
-		const count = await this.deleteCandidateBatches(orphanIds, {
-			createdAt: { lte: orphanThreshold },
-			syncHistory: { none: { rolledBack: false } },
-			deploymentHistory: { none: { rolledBack: false } },
-		});
 
 		if (count > 0) {
 			this.logger.debug({ count }, "Deleted orphaned trash backups");


### PR DESCRIPTION
## Summary

- add durable state capture and rollback helpers for managed Custom Formats, quality profiles, and naming configuration
- validate complete, exact-ID persisted snapshots before any restore operation, including nested ARR resource shapes and service-specific naming fields
- harden backup cleanup with fail-closed ledger retention, mutation-time relation/payload checks, and bounded SQLite-safe batches

## Safety

- relationless v2 deployment ledgers, malformed/current-like ledgers, and unknown/future versions remain durable recovery evidence
- only positively validated legacy snapshots are eligible for cleanup
- missing or mismatched resource IDs, incomplete nested state, unknown create IDs, partial profile reference data, and post-deployment drift fail closed
- ARR exposes no conditional Custom Format delete, so created formats are retained with actionable manual-cleanup guidance instead of being deleted unsafely
- no route or deployment executor imports these helpers in this PR

## Validation

- 70 focused state and cleanup tests, including real SQLite coverage at 499 and 500 candidates
- `pnpm run typecheck`
- `pnpm run test` — API 3,379 passed / 43 skipped; shared 89 passed; web 575 passed
- `pnpm run lint`
- changed-file Biome and whitespace checks
- final independent data-safety and regression reviews: approved

`pnpm run format` remains red only for four pre-existing, unrelated OIDC formatting violations; every file changed here is formatter-clean.

Related to #672
