### PR TITLE
fix(trash-guides): bind execution to reviewed state

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/cf-field-utils.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/cf-field-utils.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { buildCustomFormatIdentityIndex, extractTrashId } from "../cf-field-utils.js";
+
+describe("extractTrashId", () => {
+	it("uses the trailing TRaSH UUID identity when ARR does not persist metadata fields", () => {
+		expect(
+			extractTrashId({
+				id: 42,
+				name: "Streaming Services [A1B2C3D4-E5F6-47A8-9B0C-1D2E3F4A5B6C]",
+				specifications: [],
+			} as never),
+		).toBe("a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c");
+	});
+
+	it("accepts the canonical UUID shape without imposing UUID version bits", () => {
+		expect(
+			extractTrashId({
+				name: "TRaSH format [a1b2c3d4-e5f6-f7a8-7b0c-1d2e3f4a5b6c]",
+				specifications: [],
+			} as never),
+		).toBe("a1b2c3d4-e5f6-f7a8-7b0c-1d2e3f4a5b6c");
+	});
+
+	it("prefers an explicit specification identity over the display-name suffix", () => {
+		expect(
+			extractTrashId({
+				name: "Streaming Services [a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c]",
+				specifications: [
+					{
+						fields: [{ name: "trash_id", value: "11111111-2222-4333-8444-555555555555" }],
+					},
+				],
+			} as never),
+		).toBe("11111111-2222-4333-8444-555555555555");
+	});
+});
+
+describe("buildCustomFormatIdentityIndex", () => {
+	it("reports duplicate extracted identities and fallback names instead of choosing a row", () => {
+		const duplicateIdentity = "a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c";
+		const result = buildCustomFormatIdentityIndex([
+			{ id: 1, name: `First [${duplicateIdentity}]`, specifications: [] },
+			{ id: 2, name: `Second [${duplicateIdentity}]`, specifications: [] },
+			{ id: 3, name: "Same name", specifications: [] },
+			{ id: 4, name: "Same name", specifications: [] },
+		] as never);
+
+		expect(result.collisions).toEqual([`TRaSH identity ${duplicateIdentity}`, 'name "Same name"']);
+		expect(result.byTrashId.has(duplicateIdentity)).toBe(false);
+		expect(result.byName.has("Same name")).toBe(false);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 import {
 	createDeploymentConnectionStateToken,
+	createDeploymentMappingAuthorityState,
 	createDeploymentStateToken,
 } from "../deployment-target.js";
 
@@ -43,6 +44,29 @@ function currentMapping(overrides: Record<string, unknown> = {}) {
 		managedCustomFormatsCaptured: true,
 		...overrides,
 	};
+}
+
+function reviewedExecutionToken(mappingState: ReturnType<typeof currentMapping>) {
+	return createDeploymentStateToken({
+		template: {
+			id: template.id,
+			name: template.name,
+			configData: template.configData,
+			instanceOverrides: template.instanceOverrides,
+			sourceQualityProfileName: template.sourceQualityProfileName,
+		},
+		instanceId: instance.id,
+		connection: {
+			service: instance.service,
+			baseUrl: instance.baseUrl,
+			credentialIdentity: "encrypted-key:iv::",
+		},
+		target: { profile, profileName: "Any", matchedBy: "mapping_id" },
+		customFormats: [],
+		mappingAuthority: createDeploymentMappingAuthorityState([mappingState]),
+		savedScoreOverrides: [],
+		orphanedFormatScoreChanges: [],
+	});
 }
 
 function createFixture(
@@ -127,6 +151,27 @@ describe("deployment execution authority", () => {
 		expect(createBackup).not.toHaveBeenCalled();
 	});
 
+	it("invalidates a reviewed token when deployment authority changes", async () => {
+		const reviewedMapping = currentMapping({ updatedAt: new Date("2026-08-09T10:00:00.000Z") });
+		const changedMapping = currentMapping({
+			updatedAt: new Date("2026-08-09T10:01:00.000Z"),
+			syncStrategy: "notify",
+		});
+		const { executor, createBackup } = createFixture([changedMapping]);
+
+		await expect(
+			executor.deploySingleInstance(
+				"template-1",
+				"instance-1",
+				"user-1",
+				undefined,
+				undefined,
+				reviewedExecutionToken(reviewedMapping),
+			),
+		).rejects.toThrow("changed after this preview");
+		expect(createBackup).not.toHaveBeenCalled();
+	});
+
 	it("rejects ambiguous Custom Format identities before backup or upstream mutation", async () => {
 		const duplicateTrashId = "a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c";
 		const { executor, createBackup } = createFixture(
@@ -157,25 +202,7 @@ describe("deployment execution authority", () => {
 			syncStrategy: "notify",
 		});
 		const { executor, createBackup, transaction } = createFixture([legacyMapping]);
-		const executionToken = createDeploymentStateToken({
-			template: {
-				id: template.id,
-				name: template.name,
-				configData: template.configData,
-				instanceOverrides: template.instanceOverrides,
-				sourceQualityProfileName: template.sourceQualityProfileName,
-			},
-			instanceId: instance.id,
-			connection: {
-				service: instance.service,
-				baseUrl: instance.baseUrl,
-				credentialIdentity: "encrypted-key:iv::",
-			},
-			target: { profile, profileName: "Any", matchedBy: "mapping_id" },
-			customFormats: [],
-			savedScoreOverrides: [],
-			orphanedFormatScoreChanges: [],
-		});
+		const executionToken = reviewedExecutionToken(legacyMapping);
 
 		await expect(
 			executor.deploySingleInstance(
@@ -207,7 +234,7 @@ describe("deployment execution authority", () => {
 
 		await expect(
 			executor.deploySingleInstanceFromAutomation("template-1", "instance-1", "user-1"),
-		).rejects.toThrow(/Automatic deployment|older connection/);
+		).rejects.toThrow(/Automatic deployment|older connection|conflicting deployment authority/);
 		expect(createBackup).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeploymentExecutorService } from "../deployment-executor.js";
+import {
+	createDeploymentConnectionStateToken,
+	createDeploymentStateToken,
+} from "../deployment-target.js";
+
+const instance = {
+	id: "instance-1",
+	userId: "user-1",
+	label: "Radarr",
+	service: "RADARR",
+	baseUrl: "http://radarr:7878",
+	encryptedApiKey: "encrypted-key",
+	encryptionIv: "iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 2,
+};
+
+const template = {
+	id: "template-1",
+	name: "Any",
+	serviceType: "RADARR",
+	configData: '{"customFormats":[]}',
+	instanceOverrides: null,
+	sourceQualityProfileName: "Any",
+};
+
+const profile = { id: 4, name: "Any", formatItems: [] };
+
+function currentMapping(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "mapping-1",
+		templateId: "template-1",
+		instanceId: "instance-1",
+		qualityProfileId: 4,
+		qualityProfileName: "Any",
+		connectionGeneration: 2,
+		connectionStateToken: createDeploymentConnectionStateToken(instance),
+		syncStrategy: "auto",
+		managedCustomFormats: "[]",
+		managedCustomFormatsCaptured: true,
+		...overrides,
+	};
+}
+
+function createFixture(
+	mappings: Array<ReturnType<typeof currentMapping>>,
+	customFormats: Array<Record<string, unknown>> = [],
+) {
+	const transaction = vi.fn();
+	const prisma = {
+		libraryCleanupConfig: {
+			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
+		serviceInstance: {
+			findFirst: vi.fn().mockResolvedValue(instance),
+			findMany: vi.fn().mockResolvedValue([instance]),
+		},
+		templateQualityProfileMapping: {
+			findMany: vi.fn().mockResolvedValue(mappings),
+			deleteMany: vi.fn(),
+			upsert: vi.fn(),
+		},
+		instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+		trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		$transaction: transaction,
+	};
+	const client = {
+		system: { get: vi.fn().mockResolvedValue({ version: "5.0.0" }) },
+		customFormat: { getAll: vi.fn().mockResolvedValue(customFormats) },
+		qualityProfile: {
+			getAll: vi.fn().mockResolvedValue([profile]),
+			getById: vi.fn().mockResolvedValue(profile),
+		},
+	};
+	const executor = new DeploymentExecutorService(
+		prisma as never,
+		{ create: vi.fn().mockReturnValue(client) } as never,
+	);
+	const privateExecutor = executor as unknown as {
+		validateAndPrepareDeployment: (...args: unknown[]) => Promise<unknown>;
+		createBackupAndHistory: (...args: unknown[]) => Promise<unknown>;
+	};
+	vi.spyOn(privateExecutor, "validateAndPrepareDeployment").mockResolvedValue({
+		template,
+		instance,
+		templateConfig: { customFormats: [] },
+		templateCFs: [],
+		overridesForInstance: {},
+		effectiveQualityConfig: undefined,
+		usingQualityOverride: false,
+	} as never);
+	const createBackup = vi
+		.spyOn(privateExecutor, "createBackupAndHistory")
+		.mockRejectedValue(new Error("authority accepted"));
+	return { executor, prisma, client, createBackup, transaction };
+}
+
+describe("deployment execution authority", () => {
+	it("rejects tokenless user execution before reading deployment state", async () => {
+		const { executor, prisma, client } = createFixture([]);
+
+		await expect(
+			executor.deploySingleInstance("template-1", "instance-1", "user-1"),
+		).rejects.toThrow("preview token is required");
+		expect(prisma.serviceInstance.findFirst).not.toHaveBeenCalled();
+		expect(client.customFormat.getAll).not.toHaveBeenCalled();
+	});
+
+	it("rejects a stale preview token before backup or upstream mutation", async () => {
+		const { executor, createBackup } = createFixture([]);
+
+		await expect(
+			executor.deploySingleInstance(
+				"template-1",
+				"instance-1",
+				"user-1",
+				"notify",
+				undefined,
+				"stale-preview-token",
+			),
+		).rejects.toThrow("changed after this preview");
+		expect(createBackup).not.toHaveBeenCalled();
+	});
+
+	it("rejects ambiguous Custom Format identities before backup or upstream mutation", async () => {
+		const duplicateTrashId = "a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c";
+		const { executor, createBackup } = createFixture(
+			[],
+			[
+				{ id: 42, name: `First [${duplicateTrashId}]`, specifications: [] },
+				{ id: 43, name: `Second [${duplicateTrashId}]`, specifications: [] },
+			],
+		);
+
+		await expect(
+			executor.deploySingleInstance(
+				"template-1",
+				"instance-1",
+				"user-1",
+				"notify",
+				undefined,
+				"review-token",
+			),
+		).rejects.toThrow("ambiguous Custom Format identities");
+		expect(createBackup).not.toHaveBeenCalled();
+	});
+
+	it("does not rebind a legacy mapping before backup succeeds", async () => {
+		const legacyMapping = currentMapping({
+			connectionGeneration: 0,
+			connectionStateToken: null,
+			syncStrategy: "notify",
+		});
+		const { executor, createBackup, transaction } = createFixture([legacyMapping]);
+		const executionToken = createDeploymentStateToken({
+			template: {
+				id: template.id,
+				name: template.name,
+				configData: template.configData,
+				instanceOverrides: template.instanceOverrides,
+				sourceQualityProfileName: template.sourceQualityProfileName,
+			},
+			instanceId: instance.id,
+			connection: {
+				service: instance.service,
+				baseUrl: instance.baseUrl,
+				credentialIdentity: "encrypted-key:iv::",
+			},
+			target: { profile, profileName: "Any", matchedBy: "mapping_id" },
+			customFormats: [],
+			savedScoreOverrides: [],
+			orphanedFormatScoreChanges: [],
+		});
+
+		await expect(
+			executor.deploySingleInstance(
+				"template-1",
+				"instance-1",
+				"user-1",
+				undefined,
+				undefined,
+				executionToken,
+			),
+		).resolves.toMatchObject({ success: false, errors: ["authority accepted"] });
+		expect(createBackup).toHaveBeenCalledOnce();
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["missing mapping", []],
+		["non-auto mapping", [currentMapping({ syncStrategy: "notify" })]],
+		["legacy mapping", [currentMapping({ connectionGeneration: 0, connectionStateToken: null })]],
+		["stale connection mapping", [currentMapping({ connectionGeneration: 1 })]],
+		[
+			"changed alias strategy",
+			[currentMapping(), currentMapping({ id: "mapping-2", syncStrategy: "notify" })],
+		],
+	])("blocks automation with a %s", async (_case, mappings) => {
+		const { executor, createBackup } = createFixture(
+			mappings as ReturnType<typeof currentMapping>[],
+		);
+
+		await expect(
+			executor.deploySingleInstanceFromAutomation("template-1", "instance-1", "user-1"),
+		).rejects.toThrow(/Automatic deployment|older connection/);
+		expect(createBackup).not.toHaveBeenCalled();
+	});
+
+	it("accepts only a current auto mapping inside the mutation lease", async () => {
+		const { executor, createBackup } = createFixture([currentMapping()]);
+
+		await expect(
+			executor.deploySingleInstanceFromAutomation("template-1", "instance-1", "user-1"),
+		).resolves.toMatchObject({ success: false, errors: ["authority accepted"] });
+		expect(createBackup).toHaveBeenCalledOnce();
+	});
+
+	it("rejects repeated bulk targets before acquiring deployment state", async () => {
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+
+		await expect(
+			executor.deployBulkInstances(
+				"template-1",
+				["instance-1", "instance-1"],
+				"user-1",
+				undefined,
+				undefined,
+				{ "instance-1": "review-token" },
+			),
+		).rejects.toThrow("same service instance more than once");
+	});
+
+	it("rejects equivalent endpoint aliases under the topology lease before any deployment", async () => {
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+			trashTemplate: { findUnique: vi.fn().mockResolvedValue(template) },
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([
+					{ id: "instance-1", service: "RADARR", baseUrl: "http://radarr/" },
+					{ id: "instance-alias", service: "radarr", baseUrl: "HTTP://RADARR:80" },
+				]),
+			},
+		};
+		const executor = new DeploymentExecutorService(prisma as never, {} as never);
+		const privateExecutor = executor as unknown as {
+			executeSingleDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		const executeSingle = vi.spyOn(privateExecutor, "executeSingleDeployment");
+
+		await expect(
+			executor.deployBulkInstances(
+				"template-1",
+				["instance-1", "instance-alias"],
+				"user-1",
+				undefined,
+				undefined,
+				{ "instance-1": "token-1", "instance-alias": "token-2" },
+			),
+		).rejects.toThrow("multiple service records for the same ARR endpoint");
+		expect(executeSingle).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { ConflictError } from "../../errors.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
-import { createQualityProfileStateToken } from "../deployment-target.js";
+import {
+	createDeploymentStateToken,
+	createQualityProfileStateToken,
+} from "../deployment-target.js";
 
 describe("DeploymentExecutorService Task 4A result propagation", () => {
 	it("returns an explicit uncertain result when a conflict follows a possible upstream write", async () => {
@@ -110,7 +113,7 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 		const createBackup = vi.spyOn(privateExecutor, "createBackupAndHistory");
 
 		await expect(
-			executor.deploySingleInstance("template-1", "instance-1", "user-1"),
+			executor.deploySingleInstanceFromAutomation("template-1", "instance-1", "user-1"),
 		).resolves.toMatchObject({
 			success: false,
 			errors: [expect.stringContaining("uncertain upstream result")],
@@ -207,6 +210,7 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			validateAndPrepareDeployment: (...args: unknown[]) => Promise<unknown>;
 			createBackupAndHistory: (...args: unknown[]) => Promise<unknown>;
 			deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			executeSingleDeployment: (...args: unknown[]) => Promise<unknown>;
 		};
 		vi.spyOn(privateExecutor, "validateAndPrepareDeployment").mockResolvedValue({
 			template: {
@@ -275,7 +279,34 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			errors: [],
 		} as never);
 
-		const result = await executor.deploySingleInstance("template-1", "instance-1", "user-1");
+		const executionToken = createDeploymentStateToken({
+			template: {
+				id: "template-1",
+				name: "Any",
+				configData: "{}",
+				instanceOverrides: null,
+				sourceQualityProfileName: null,
+			},
+			instanceId: "instance-1",
+			connection: {
+				service: "RADARR",
+				baseUrl: "http://radarr:7878",
+				credentialIdentity: "encrypted-key:iv::",
+			},
+			target: { profile: undefined, profileName: "Any", matchedBy: "new" },
+			customFormats: [{ id: 42, name: "Managed CF" }],
+			savedScoreOverrides: [],
+			orphanedFormatScoreChanges: [],
+		});
+		const result = await privateExecutor.executeSingleDeployment(
+			"template-1",
+			"instance-1",
+			"user-1",
+			undefined,
+			undefined,
+			executionToken,
+			"user-1:RADARR:http://radarr:7878/",
+		);
 
 		const appliedProfile = {
 			name: "Any",
@@ -325,8 +356,19 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 
 	it("preserves applied details and profile evidence when a bulk target conflicts", async () => {
 		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
 			trashTemplate: {
 				findUnique: vi.fn().mockResolvedValue({ id: "template-1", name: "Radarr - Any" }),
+			},
+			serviceInstance: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "instance-1", service: "RADARR", baseUrl: "http://radarr:7878" },
+					]),
 			},
 		};
 		const executor = new DeploymentExecutorService(prisma as never, {} as never);
@@ -350,9 +392,19 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 				},
 			},
 		});
-		vi.spyOn(executor, "deploySingleInstance").mockRejectedValue(conflict);
+		const privateExecutor = executor as unknown as {
+			executeSingleDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		vi.spyOn(privateExecutor, "executeSingleDeployment").mockRejectedValue(conflict);
 
-		const result = await executor.deployBulkInstances("template-1", ["instance-1"], "user-1");
+		const result = await executor.deployBulkInstances(
+			"template-1",
+			["instance-1"],
+			"user-1",
+			undefined,
+			undefined,
+			{ "instance-1": "review-token" },
+		);
 
 		expect(result.results[0]).toMatchObject({
 			instanceId: "instance-1",

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -425,17 +425,38 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 
 	it("counts an unverified bulk write as uncertain instead of failed", async () => {
 		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
 			trashTemplate: {
 				findUnique: vi.fn().mockResolvedValue({ id: "template-1", name: "Any" }),
+			},
+			serviceInstance: {
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "instance-1", service: "RADARR", baseUrl: "http://radarr:7878" },
+					]),
 			},
 		};
 		const executor = new DeploymentExecutorService(prisma as never, {} as never);
 		const uncertain = Object.assign(new ConflictError("ARR write result is uncertain"), {
 			deploymentResultUncertain: true,
 		});
-		vi.spyOn(executor, "deploySingleInstance").mockRejectedValue(uncertain);
+		const privateExecutor = executor as unknown as {
+			executeSingleDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		vi.spyOn(privateExecutor, "executeSingleDeployment").mockRejectedValue(uncertain);
 
-		const result = await executor.deployBulkInstances("template-1", ["instance-1"], "user-1");
+		const result = await executor.deployBulkInstances(
+			"template-1",
+			["instance-1"],
+			"user-1",
+			undefined,
+			undefined,
+			{ "instance-1": "review-token" },
+		);
 
 		expect(result).toMatchObject({
 			successfulInstances: 0,

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { ConflictError } from "../../errors.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 import {
+	createDeploymentConnectionStateToken,
 	createDeploymentStateToken,
 	createQualityProfileStateToken,
 } from "../deployment-target.js";
@@ -465,6 +466,158 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			uncertainInstances: 1,
 			results: [{ status: "UNCERTAIN", success: false }],
 		});
+	});
+
+	it("marks applied work uncertain when managed history finalization rolls back", async () => {
+		const instance = {
+			id: "instance-1",
+			userId: "user-1",
+			label: "Radarr",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			connectionGeneration: 1,
+		};
+		const profile = { id: 1, name: "Any", formatItems: [], items: [], cutoff: 1 };
+		const mapping = {
+			id: "mapping-1",
+			templateId: "template-1",
+			instanceId: "instance-1",
+			qualityProfileId: 1,
+			qualityProfileName: "Any",
+			connectionGeneration: 1,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			syncStrategy: "auto",
+			managedCustomFormatsCaptured: true,
+			managedCustomFormats: "[]",
+			updatedAt: new Date("2026-08-09T00:00:00.000Z"),
+		};
+		const syncHistoryUpdate = vi.fn().mockResolvedValue({});
+		const deploymentHistoryUpdate = vi.fn().mockResolvedValue({});
+		const mappingUpdate = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("managed mapping transaction failed"));
+		const transactionClient = {
+			trashSyncHistory: { update: syncHistoryUpdate },
+			templateDeploymentHistory: { update: deploymentHistoryUpdate },
+			templateQualityProfileMapping: { updateMany: mappingUpdate },
+		};
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			trashSyncHistory: {
+				findMany: vi.fn().mockResolvedValue([]),
+				update: syncHistoryUpdate,
+			},
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue([]),
+				create: vi.fn().mockResolvedValue({ id: "deployment-history-1" }),
+				update: deploymentHistoryUpdate,
+			},
+			templateQualityProfileMapping: {
+				findMany: vi.fn().mockResolvedValue([mapping]),
+				updateMany: mappingUpdate,
+			},
+			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			trashBackup: { update: vi.fn().mockResolvedValue({}) },
+			$transaction: vi.fn(async (work: (database: typeof transactionClient) => Promise<void>) =>
+				work(transactionClient),
+			),
+		};
+		const client = {
+			system: { get: vi.fn().mockResolvedValue({ version: "5.0.0" }) },
+			customFormat: { getAll: vi.fn().mockResolvedValue([]) },
+			qualityProfile: {
+				getAll: vi.fn().mockResolvedValue([profile]),
+				getById: vi.fn().mockResolvedValue(profile),
+			},
+		};
+		const executor = new DeploymentExecutorService(
+			prisma as never,
+			{ create: vi.fn().mockReturnValue(client) } as never,
+		);
+		const privateExecutor = executor as unknown as {
+			validateAndPrepareDeployment: (...args: unknown[]) => Promise<unknown>;
+			createBackupAndHistory: (...args: unknown[]) => Promise<unknown>;
+			deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			syncQualityProfile: (...args: unknown[]) => Promise<unknown>;
+			executeSingleDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		vi.spyOn(privateExecutor, "validateAndPrepareDeployment").mockResolvedValue({
+			template: {
+				id: "template-1",
+				name: "Any",
+				serviceType: "RADARR",
+				configData: "{}",
+				instanceOverrides: null,
+				sourceQualityProfileName: null,
+			},
+			instance,
+			templateConfig: {},
+			templateCFs: [],
+			effectiveQualityConfig: undefined,
+		} as never);
+		vi.spyOn(privateExecutor, "createBackupAndHistory").mockResolvedValue({
+			backup: {
+				id: "backup-1",
+				retentionExpiresAt: null,
+				data: {
+					schemaVersion: 2,
+					endpointKey: "endpoint",
+					connectionStateToken: "connection",
+					customFormats: [],
+					customFormatDeployments: [],
+					managedCustomFormats: [],
+					managedCustomFormatsCaptured: false,
+					qualityProfileDeployment: {
+						beforeProfile: profile,
+						status: "not_started",
+						action: "updated",
+						profileId: 1,
+						profileName: "Any",
+						postStateToken: null,
+						intendedPostStateToken: null,
+					},
+					namingDeployment: null,
+				},
+			},
+			historyId: "sync-history-1",
+		} as never);
+		vi.spyOn(privateExecutor, "deployCustomFormats").mockResolvedValue({
+			created: 0,
+			updated: 0,
+			skipped: 0,
+			resolvedResourceIds: new Map(),
+			details: { created: [], updated: [], failed: [], orphaned: [] },
+			errors: [],
+		} as never);
+		vi.spyOn(privateExecutor, "syncQualityProfile").mockResolvedValue({
+			errors: [],
+			orphanedCFs: [],
+		} as never);
+
+		await expect(
+			privateExecutor.executeSingleDeployment("template-1", "instance-1", "user-1"),
+		).resolves.toMatchObject({
+			success: false,
+			status: "UNCERTAIN",
+			errors: [expect.stringContaining("managed deployment state could not be finalized")],
+		});
+		expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+		expect(syncHistoryUpdate).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				where: { id: "sync-history-1" },
+				data: expect.objectContaining({ status: "UNCERTAIN" }),
+			}),
+		);
+		expect(deploymentHistoryUpdate).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				where: { id: "deployment-history-1" },
+				data: expect.objectContaining({ status: "UNCERTAIN" }),
+			}),
+		);
 	});
 
 	it("serializes deployment and rollback work across equivalent endpoint records", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -295,6 +295,7 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			},
 			target: { profile: undefined, profileName: "Any", matchedBy: "new" },
 			customFormats: [{ id: 42, name: "Managed CF" }],
+			mappingAuthority: [],
 			savedScoreOverrides: [],
 			orphanedFormatScoreChanges: [],
 		});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -249,7 +249,7 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			retentionExpiresAt: null,
 			data: {
 				schemaVersion: 2,
-				endpointKey: "user-1:RADARR:http://radarr:7878",
+				endpointKey: "user-1:RADARR:credential-1",
 				connectionStateToken: "connection",
 				customFormats: [],
 				customFormatDeployments: [],
@@ -305,7 +305,7 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			undefined,
 			undefined,
 			executionToken,
-			"user-1:RADARR:http://radarr:7878/",
+			"user-1:RADARR:credential-1",
 		);
 
 		const appliedProfile = {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-partial-results.test.ts
@@ -3,6 +3,7 @@ import { ConflictError } from "../../errors.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 import {
 	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
 	createDeploymentStateToken,
 	createQualityProfileStateToken,
 } from "../deployment-target.js";
@@ -250,7 +251,11 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			retentionExpiresAt: null,
 			data: {
 				schemaVersion: 2,
-				endpointKey: "user-1:RADARR:credential-1",
+				endpointKey: createDeploymentEndpointKey("user-1", {
+					service: "RADARR",
+					baseUrl: "http://radarr:7878",
+					credentialIdentity: "credential-1",
+				}),
 				connectionStateToken: "connection",
 				customFormats: [],
 				customFormatDeployments: [],
@@ -307,7 +312,11 @@ describe("DeploymentExecutorService Task 4A result propagation", () => {
 			undefined,
 			undefined,
 			executionToken,
-			"user-1:RADARR:credential-1",
+			createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				baseUrl: "http://radarr:7878",
+				credentialIdentity: "credential-1",
+			}),
 		);
 
 		const appliedProfile = {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -236,6 +236,37 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 		expect(update).not.toHaveBeenCalled();
 	});
 
+	it("revalidates a kept format before retaining its managed identity", async () => {
+		const existing = { id: 1, name: "Test CF", specifications: [] } as SdkCustomFormat;
+		const client = {
+			customFormat: {
+				getById: vi.fn().mockResolvedValue({
+					...existing,
+					name: "Changed after review",
+				}),
+				update: vi.fn(),
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[{ trashId: "cf-1", name: "Test CF", originalConfig: { specifications: [] } }],
+				new Map([["cf-1", existing]]),
+				new Map([["Test CF", existing]]),
+				{ "cf-1": "keep_existing" },
+			),
+		).rejects.toThrow("changed during deployment");
+		expect(client.customFormat.getById).toHaveBeenCalledWith(1);
+		expect(client.customFormat.update).not.toHaveBeenCalled();
+	});
+
 	it("aborts instead of creating a duplicate format that appeared after preview", async () => {
 		const create = vi.fn();
 		const client = {
@@ -1627,6 +1658,108 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		expect(deleteMany).not.toHaveBeenCalled();
 		expect(transaction).not.toHaveBeenCalled();
 		expect(upsert).not.toHaveBeenCalled();
+	});
+
+	it("finalizes mapping and saved-score authority for every equivalent alias", async () => {
+		const deleteMappings = vi.fn().mockResolvedValue({ count: 2 });
+		const upsertMapping = vi.fn().mockResolvedValue({});
+		const deleteOverrides = vi.fn().mockResolvedValue({ count: 0 });
+		const createOverride = vi.fn().mockResolvedValue({});
+		const database = {
+			templateQualityProfileMapping: {
+				deleteMany: deleteMappings,
+				upsert: upsertMapping,
+			},
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: "instance-primary",
+						qualityProfileId: 7,
+						customFormatId: 42,
+						score: 100,
+						status: "APPLIED",
+						connectionGeneration: 2,
+						connectionStateToken: "primary-token",
+					},
+					{
+						instanceId: "instance-alias",
+						qualityProfileId: 7,
+						customFormatId: 42,
+						score: 100,
+						status: "APPLIED",
+						connectionGeneration: 3,
+						connectionStateToken: "alias-token",
+					},
+				]),
+				deleteMany: deleteOverrides,
+				create: createOverride,
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never) as unknown as {
+			finalizeQualityProfileMappingState: (
+				database: unknown,
+				finalization: Record<string, unknown>,
+			) => Promise<void>;
+		};
+		const connectionBindings = [
+			{
+				instanceId: "instance-primary",
+				connectionGeneration: 2,
+				connectionStateToken: "primary-token",
+			},
+			{
+				instanceId: "instance-alias",
+				connectionGeneration: 3,
+				connectionStateToken: "alias-token",
+			},
+		];
+
+		await executor.finalizeQualityProfileMappingState(database, {
+			userId: "user-1",
+			templateId: "template-1",
+			instanceId: "instance-primary",
+			equivalentInstanceIds: ["instance-primary", "instance-alias"],
+			connectionBindings,
+			connectionReadBindings: connectionBindings,
+			savedScoreOverrides: [[42, 100]],
+			qualityProfileId: 7,
+			qualityProfileName: "HD-1080p",
+			connectionGeneration: 2,
+			connectionStateToken: "primary-token",
+			syncStrategy: "auto",
+		});
+
+		expect(deleteMappings).toHaveBeenCalledWith({
+			where: {
+				templateId: "template-1",
+				instanceId: { in: ["instance-primary", "instance-alias"] },
+			},
+		});
+		expect(upsertMapping).toHaveBeenCalledTimes(2);
+		expect(upsertMapping).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					instanceId_qualityProfileId: {
+						instanceId: "instance-alias",
+						qualityProfileId: 7,
+					},
+				},
+				create: expect.objectContaining({
+					instanceId: "instance-alias",
+					connectionGeneration: 3,
+					connectionStateToken: "alias-token",
+				}),
+			}),
+		);
+		expect(createOverride).toHaveBeenCalledTimes(2);
+		expect(createOverride).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				instanceId: "instance-alias",
+				customFormatId: 42,
+				connectionGeneration: 3,
+				connectionStateToken: "alias-token",
+			}),
+		});
 	});
 
 	it("resets an orphaned managed score and defers override cleanup until finalization", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -10,6 +10,7 @@ import { ConflictError } from "../../errors.js";
 import { extractTrashId } from "../cf-field-utils.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 import {
+	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 } from "../deployment-target.js";
@@ -542,7 +543,11 @@ describe("DeploymentExecutorService - backup parity", () => {
 
 		const backupData = JSON.parse(createBackup.mock.calls[0]![0].data.backupData);
 		expect(backupData).toMatchObject({
-			endpointKey: "user-1:RADARR:http://radarr:7878/:credential-1",
+			endpointKey: createDeploymentEndpointKey("user-1", {
+				service: "RADARR",
+				baseUrl: "http://radarr:7878",
+				credentialIdentity: "credential-1",
+			}),
 			connectionStateToken: expect.any(String),
 			customFormats: [{ id: 5, name: "CF" }],
 			customFormatDeployments: [],

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -4,8 +4,8 @@
  * Tests extractTrashId function and ID-based vs name-based matching behavior
  */
 
-import { describe, expect, it, vi } from "vitest";
 import type { SonarrClient } from "arr-sdk";
+import { describe, expect, it, vi } from "vitest";
 import { ConflictError } from "../../errors.js";
 import { extractTrashId } from "../cf-field-utils.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
@@ -958,6 +958,7 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 					appliedScore: 10,
 				},
 			],
+			new Map([["managed-trash-id", 42]]),
 		);
 		expect(result).toMatchObject({ errors: [] });
 
@@ -1041,6 +1042,7 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 						appliedScore: 5,
 					},
 				],
+				new Map([["managed-trash-id", 42]]),
 			),
 		).resolves.toMatchObject({ errors: [] });
 
@@ -1052,6 +1054,7 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 
 	it("blocks profile creation when the reviewed name appears before POST", async () => {
 		const client = {
+			customFormat: { getAll: vi.fn().mockResolvedValue([]) },
 			qualityProfile: {
 				getAll: vi.fn().mockResolvedValue([{ id: 9, name: "Any", formatItems: [] }]),
 			},
@@ -1093,16 +1096,12 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		};
 		const persistProfileState = vi.fn().mockResolvedValue(undefined);
 		const client = {
+			customFormat: { getAll: vi.fn().mockResolvedValue([]) },
 			qualityProfile: {
 				getAll: vi.fn().mockResolvedValue([]),
 				getSchema: vi.fn().mockResolvedValue({ items: [], formatItems: [] }),
 				create: vi.fn().mockResolvedValue(createdProfile),
-			},
-			customFormat: {
-				getAll: vi
-					.fn()
-					.mockResolvedValueOnce([])
-					.mockRejectedValueOnce(new Error("later custom format read failed")),
+				getById: vi.fn().mockRejectedValue(new Error("later profile read failed")),
 			},
 		};
 		const executor = new DeploymentExecutorService({} as never, {} as never);
@@ -1250,6 +1249,10 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 				["instance-1"],
 				undefined,
 				persistProfileState,
+				undefined,
+				undefined,
+				[],
+				new Map([["managed-cf", 7]]),
 			);
 		} catch (caughtError) {
 			error = caughtError;
@@ -1320,6 +1323,10 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 			["instance-1"],
 			undefined,
 			persistProfileState,
+			undefined,
+			undefined,
+			[],
+			new Map([["managed-cf", 42]]),
 		);
 		expect(result).toMatchObject({
 			errors: [],
@@ -1469,6 +1476,10 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 				["instance-1"],
 				undefined,
 				persistProfileState,
+				undefined,
+				undefined,
+				[],
+				new Map([["managed-cf", 42]]),
 			),
 		).rejects.toThrow("did not match the intended post-write state");
 		expect(persistProfileState).toHaveBeenCalledOnce();
@@ -1547,7 +1558,7 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		);
 	});
 
-	it("defers selected-instance mapping finalization without changing an alias", async () => {
+	it("defers mapping finalization while retaining every equivalent alias", async () => {
 		const profile = { id: 2, name: "Any", formatItems: [] };
 		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
 		const upsert = vi.fn().mockResolvedValue({});
@@ -1597,7 +1608,7 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 			mappingFinalization: {
 				templateId: "template-1",
 				instanceId: "instance-alias",
-				equivalentInstanceIds: ["instance-alias"],
+				equivalentInstanceIds: ["instance-primary", "instance-alias"],
 				qualityProfileId: 2,
 			},
 		});
@@ -1625,9 +1636,15 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		};
 		const prisma = {
 			instanceQualityProfileOverride: {
-				findMany: vi
-					.fn()
-					.mockResolvedValue([{ customFormatId: 42, score: -10_000, instanceId: "instance-1" }]),
+				findMany: vi.fn().mockResolvedValue([
+					{
+						customFormatId: 42,
+						score: -10_000,
+						instanceId: "instance-1",
+						connectionGeneration: 0,
+						connectionStateToken: "",
+					},
+				]),
 				deleteMany: deleteManyOverrides,
 			},
 			templateQualityProfileMapping: {
@@ -1689,9 +1706,15 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		};
 		const prisma = {
 			instanceQualityProfileOverride: {
-				findMany: vi
-					.fn()
-					.mockResolvedValue([{ customFormatId: 42, score: 0, instanceId: "instance-1" }]),
+				findMany: vi.fn().mockResolvedValue([
+					{
+						customFormatId: 42,
+						score: 0,
+						instanceId: "instance-1",
+						connectionGeneration: 0,
+						connectionStateToken: "",
+					},
+				]),
 			},
 		};
 		const executor = new DeploymentExecutorService(prisma as never, {} as never);
@@ -1747,8 +1770,20 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		const prisma = {
 			instanceQualityProfileOverride: {
 				findMany: vi.fn().mockResolvedValue([
-					{ customFormatId: 7, score: 200, instanceId: "instance-1" },
-					{ customFormatId: 42, score: 100, instanceId: "instance-1" },
+					{
+						customFormatId: 7,
+						score: 200,
+						instanceId: "instance-1",
+						connectionGeneration: 0,
+						connectionStateToken: "",
+					},
+					{
+						customFormatId: 42,
+						score: 100,
+						instanceId: "instance-1",
+						connectionGeneration: 0,
+						connectionStateToken: "",
+					},
 				]),
 			},
 		};
@@ -1789,9 +1824,143 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 					[7, 200],
 				]),
 				["instance-1"],
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				new Map([
+					["first", 42],
+					["second", 7],
+				]),
 			),
 		).resolves.toMatchObject({ errors: [] });
 		expect(update).toHaveBeenCalledOnce();
+	});
+});
+
+describe("DeploymentExecutorService - legacy override finalization", () => {
+	async function prepareLegacyFinalization() {
+		const profile = { id: 1, name: "Any", formatItems: [{ format: 42, score: 100 }] };
+		const legacyOverride = {
+			id: "override-legacy",
+			userId: "user-1",
+			instanceId: "instance-1",
+			qualityProfileId: 1,
+			customFormatId: 42,
+			score: 100,
+			status: "APPLIED",
+			connectionGeneration: 0,
+			connectionStateToken: null,
+		};
+		const prisma = {
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([legacyOverride]),
+			},
+		};
+		const client = {
+			qualityProfile: {
+				getById: vi.fn().mockResolvedValue(profile),
+				update: vi.fn().mockResolvedValue(profile),
+			},
+		};
+		const executor = new DeploymentExecutorService(prisma as never, {} as never);
+		const privateExecutor = executor as unknown as {
+			syncQualityProfile: (...args: unknown[]) => Promise<{
+				mappingFinalization?: Record<string, unknown>;
+			}>;
+			finalizeSavedScoreOverrideState: (
+				database: unknown,
+				finalization: Record<string, unknown>,
+			) => Promise<void>;
+		};
+		const currentBinding = {
+			instanceId: "instance-1",
+			connectionGeneration: 2,
+			connectionStateToken: "current-connection",
+		};
+		const result = await privateExecutor.syncQualityProfile(
+			client,
+			{},
+			[],
+			"template-1",
+			"instance-1",
+			"user-1",
+			"notify",
+			undefined,
+			"Any",
+			profile,
+			undefined,
+			[],
+			new Map([[42, 100]]),
+			["instance-1"],
+			undefined,
+			undefined,
+			[currentBinding],
+			[
+				currentBinding,
+				{
+					instanceId: "instance-1",
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+			],
+			[],
+			new Map(),
+		);
+		if (!result.mappingFinalization) throw new Error("Expected mapping finalization state");
+		return { executor: privateExecutor, finalization: result.mappingFinalization, legacyOverride };
+	}
+
+	it("carries reviewed legacy APPLIED intent into canonical finalization", async () => {
+		const { executor, finalization, legacyOverride } = await prepareLegacyFinalization();
+		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
+		const create = vi.fn().mockResolvedValue({});
+		const database = {
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([legacyOverride]),
+				deleteMany,
+				create,
+			},
+		};
+
+		await executor.finalizeSavedScoreOverrideState(database, finalization);
+
+		expect(deleteMany).toHaveBeenCalledWith({
+			where: {
+				userId: "user-1",
+				instanceId: { in: ["instance-1"] },
+				qualityProfileId: 1,
+			},
+		});
+		expect(create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				instanceId: "instance-1",
+				customFormatId: 42,
+				score: 100,
+				connectionGeneration: 2,
+				connectionStateToken: "current-connection",
+			}),
+		});
+	});
+
+	it("preserves legacy intent when finalization authority changed", async () => {
+		const { executor, finalization, legacyOverride } = await prepareLegacyFinalization();
+		const deleteMany = vi.fn();
+		const create = vi.fn();
+		const database = {
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([{ ...legacyOverride, score: 200 }]),
+				deleteMany,
+				create,
+			},
+		};
+
+		await expect(executor.finalizeSavedScoreOverrideState(database, finalization)).rejects.toThrow(
+			"changed before deployment state could be finalized",
+		);
+		expect(deleteMany).not.toHaveBeenCalled();
+		expect(create).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -1846,6 +1846,49 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 });
 
 describe("DeploymentExecutorService - legacy override finalization", () => {
+	async function loadLegacyOverrideScore(recordedScore: number, liveScore: number) {
+		const prisma = {
+			instanceQualityProfileOverride: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: "instance-1",
+						qualityProfileId: 1,
+						customFormatId: 42,
+						score: recordedScore,
+						status: "APPLIED",
+						connectionGeneration: 0,
+						connectionStateToken: null,
+					},
+				]),
+			},
+		};
+		const executor = new DeploymentExecutorService(prisma as never, {} as never) as unknown as {
+			loadEquivalentInstanceOverrideScores: (...args: unknown[]) => Promise<Map<number, number>>;
+		};
+		return executor.loadEquivalentInstanceOverrideScores(
+			"user-1",
+			[
+				{
+					instanceId: "instance-1",
+					connectionGeneration: 2,
+					connectionStateToken: "current-connection",
+				},
+			],
+			1,
+			{ id: 1, name: "Any", formatItems: [{ format: 42, score: liveScore }] },
+		);
+	}
+
+	it("loads legacy override intent when its exact score remains live", async () => {
+		await expect(loadLegacyOverrideScore(100, 100)).resolves.toEqual(new Map([[42, 100]]));
+	});
+
+	it("rejects legacy override intent after its live score drifts", async () => {
+		await expect(loadLegacyOverrideScore(100, 200)).rejects.toThrow(
+			"unverified saved score override",
+		);
+	});
+
 	async function prepareLegacyFinalization() {
 		const profile = { id: 1, name: "Any", formatItems: [{ format: 42, score: 100 }] };
 		const legacyOverride = {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -1549,6 +1549,12 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 				[],
 				new Map(),
 				["instance-1"],
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				new Map([["managed-trash-id", 42]]),
 			),
 		).resolves.toMatchObject({ errors: [] });
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-history-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-history-manager.test.ts
@@ -237,6 +237,54 @@ describe("finalizeDeploymentHistoryWithPartialFailure", () => {
 		);
 	});
 
+	it("preserves applied naming evidence when finalization becomes uncertain", async () => {
+		const trashSyncUpdate = vi.fn().mockResolvedValue({});
+		const templateDeploymentUpdate = vi.fn().mockResolvedValue({});
+		const prisma = {
+			trashSyncHistory: { update: trashSyncUpdate },
+			templateDeploymentHistory: { update: templateDeploymentUpdate },
+		};
+		const error = Object.assign(new Error("Managed state could not be finalized"), {
+			deploymentResultUncertain: true,
+		});
+
+		await finalizeDeploymentHistoryWithPartialFailure(
+			prisma as never,
+			"sync-1",
+			"deployment-1",
+			new Date(),
+			{ created: [], updated: [], failed: [], orphaned: [] },
+			{ created: 0, updated: 0, skipped: 0 },
+			error,
+			undefined,
+			[],
+			3,
+		);
+
+		const appliedConfigs = JSON.stringify([
+			{
+				name: "Naming configuration",
+				action: "updated",
+				type: "naming",
+				fields: 3,
+			},
+		]);
+		expect(trashSyncUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "UNCERTAIN",
+					configsApplied: 1,
+					appliedConfigs,
+				}),
+			}),
+		);
+		expect(templateDeploymentUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ status: "UNCERTAIN", appliedConfigs }),
+			}),
+		);
+	});
+
 	it("records a created quality profile in both histories when a later phase is blocked", async () => {
 		const trashSyncUpdate = vi.fn().mockResolvedValue({});
 		const templateDeploymentUpdate = vi.fn().mockResolvedValue({});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-naming-finalization.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-naming-finalization.test.ts
@@ -13,6 +13,7 @@ vi.mock("../deployment-naming-state.js", async (importOriginal) => {
 });
 
 import { DeploymentExecutorService } from "../deployment-executor.js";
+import { createDeploymentConnectionStateToken } from "../deployment-target.js";
 
 describe("DeploymentExecutorService naming finalization", () => {
 	it("returns UNCERTAIN when the applied naming ledger cannot be finalized", async () => {
@@ -64,7 +65,22 @@ describe("DeploymentExecutorService naming finalization", () => {
 			.mockRejectedValueOnce(new Error("database unavailable"));
 		const prisma = {
 			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
-			templateQualityProfileMapping: { findMany: vi.fn().mockResolvedValue([]) },
+			templateQualityProfileMapping: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						id: "mapping-1",
+						templateId: "template-1",
+						instanceId: "instance-1",
+						qualityProfileId: 4,
+						qualityProfileName: "Any",
+						connectionGeneration: 1,
+						connectionStateToken: createDeploymentConnectionStateToken(instance),
+						syncStrategy: "auto",
+						managedCustomFormats: "[]",
+						managedCustomFormatsCaptured: true,
+					},
+				]),
+			},
 			instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
 			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
 			templateDeploymentHistory: {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -761,6 +761,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 	it.each([
 		{ label: "missing", backup: null },
 		{ label: "invalid", backup: { id: "backup-invalid", backupData: "not-json" } },
+		{ label: "terminal", backup: fullyAppliedBackup() },
 	])(
 		"keeps a restarted $label-ledger operation blocked after reconciliation",
 		async ({ backup: interruptedBackup }) => {
@@ -1051,9 +1052,9 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 			expect.objectContaining({
 				where: { id: "sync-1", status: { in: ["IN_PROGRESS", "RUNNING"] } },
 				data: expect.objectContaining({
-					status: "PARTIAL_SUCCESS",
+					status: "UNCERTAIN",
 					configsApplied: 1,
-					configsFailed: 1,
+					configsFailed: 0,
 					appliedConfigs: JSON.stringify([
 						{ name: "Foo", action: "updated", type: "custom_format" },
 					]),
@@ -1127,7 +1128,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		expect(deploymentUpdateMany).toHaveBeenCalledWith({
 			where: { id: "deployment-1", status: "IN_PROGRESS" },
 			data: expect.objectContaining({
-				status: "PARTIAL_SUCCESS",
+				status: "UNCERTAIN",
 				appliedCFs: 2,
 				appliedConfigs: JSON.stringify(appliedConfigs),
 			}),
@@ -1138,9 +1139,9 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				status: { in: ["IN_PROGRESS", "RUNNING"] },
 			},
 			data: expect.objectContaining({
-				status: "PARTIAL_SUCCESS",
+				status: "UNCERTAIN",
 				configsApplied: 4,
-				configsFailed: 1,
+				configsFailed: 0,
 				appliedConfigs: JSON.stringify(appliedConfigs),
 			}),
 		});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -165,6 +165,44 @@ describe("assertNoPendingDeploymentOperation", () => {
 		).resolves.toBeUndefined();
 	});
 
+	it.each([
+		{
+			label: "sync",
+			syncRows: [
+				{
+					status: "RUNNING",
+					rollbackStatus: null,
+					backupId: "backup-1",
+					backup: fullyAppliedBackup(),
+				},
+			],
+			deploymentRows: [],
+		},
+		{
+			label: "deployment",
+			syncRows: [],
+			deploymentRows: [
+				{
+					status: "IN_PROGRESS",
+					undeployStatus: null,
+					backupId: "backup-1",
+					backup: fullyAppliedBackup(),
+				},
+			],
+		},
+	])("blocks a transient $label history even when its ledger is terminal", async (rows) => {
+		const prisma = {
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue(rows.syncRows) },
+			templateDeploymentHistory: {
+				findMany: vi.fn().mockResolvedValue(rows.deploymentRows),
+			},
+		};
+
+		await expect(
+			assertNoPendingDeploymentOperation(prisma as never, "user-1", ["instance-1"]),
+		).rejects.toThrow("uncertain upstream result");
+	});
+
 	it("fails closed when a current backup ledger is malformed", async () => {
 		const malformed = backup("pending");
 		malformed.backupData = JSON.stringify({ schemaVersion: 2, customFormatDeployments: [] });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts
@@ -961,9 +961,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				}),
 			),
 		};
-		const appliedConfigs = [
-			{ name: "Applied CF", action: "updated", type: "custom_format" },
-		];
+		const appliedConfigs = [{ name: "Applied CF", action: "updated", type: "custom_format" }];
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
 		expect(deploymentUpdateMany).toHaveBeenCalledWith(
@@ -993,14 +991,16 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 		const syncUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
 		const prisma = {
 			templateDeploymentHistory: {
-				findMany: vi.fn().mockResolvedValue([
-					{ id: "deployment-1", backupId: "backup-1", backup: interruptedBackup },
-				]),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						{ id: "deployment-1", backupId: "backup-1", backup: interruptedBackup },
+					]),
 			},
 			trashSyncHistory: {
-				findMany: vi.fn().mockResolvedValue([
-					{ id: "sync-1", backupId: "backup-1", backup: interruptedBackup },
-				]),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([{ id: "sync-1", backupId: "backup-1", backup: interruptedBackup }]),
 			},
 			$transaction: vi.fn(async (callback) =>
 				callback({
@@ -1009,9 +1009,7 @@ describe("reconcileInterruptedDeploymentHistories", () => {
 				}),
 			),
 		};
-		const appliedConfigs = [
-			{ name: "Applied CF", action: "updated", type: "custom_format" },
-		];
+		const appliedConfigs = [{ name: "Applied CF", action: "updated", type: "custom_format" }];
 
 		await expect(reconcileInterruptedDeploymentHistories(prisma as never)).resolves.toBe(1);
 		expect(deploymentUpdateMany).toHaveBeenCalledWith(

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import { DeploymentPreviewService } from "../deployment-preview.js";
+
+const trashId = "a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c";
+const instance = {
+	id: "instance-1",
+	userId: "user-1",
+	label: "Radarr",
+	service: "RADARR",
+	baseUrl: "http://radarr:7878",
+	encryptedApiKey: "encrypted-key",
+	encryptionIv: "iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 2,
+};
+const template = {
+	id: "template-1",
+	userId: "user-1",
+	name: "Any",
+	serviceType: "RADARR",
+	configData: JSON.stringify({
+		customFormats: [
+			{
+				trashId,
+				name: "Template display name",
+				originalConfig: { specifications: [], trash_scores: { default: 100 } },
+			},
+		],
+	}),
+	instanceOverrides: null,
+	sourceQualityProfileName: "Any",
+};
+
+function createService(
+	options: {
+		unreachable?: boolean;
+		customFormats?: Array<{ id: number; name: string; specifications: unknown[] }>;
+		mappings?: Array<Record<string, unknown>>;
+		instances?: (typeof instance)[];
+	} = {},
+) {
+	const existingFormat = {
+		id: 42,
+		name: `Different ARR name [${trashId.toUpperCase()}]`,
+		specifications: [],
+	};
+	const profile = { id: 4, name: "Any", formatItems: [{ format: 42, score: 100 }] };
+	const prisma = {
+		trashTemplate: { findUnique: vi.fn().mockResolvedValue(template) },
+		serviceInstance: {
+			findFirst: vi.fn().mockResolvedValue(instance),
+			findMany: vi.fn().mockResolvedValue(options.instances ?? [instance]),
+		},
+		templateQualityProfileMapping: {
+			findMany: vi.fn().mockResolvedValue(options.mappings ?? []),
+		},
+		instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+		trashCache: { findFirst: vi.fn().mockResolvedValue(null) },
+	};
+	const client = {
+		system: {
+			get: options.unreachable
+				? vi.fn().mockRejectedValue(new Error("offline"))
+				: vi.fn().mockResolvedValue({ version: "5.0.0" }),
+		},
+		customFormat: {
+			getAll: vi.fn().mockResolvedValue(options.customFormats ?? [existingFormat]),
+		},
+		qualityProfile: {
+			getAll: vi.fn().mockResolvedValue([profile]),
+			getById: vi.fn().mockResolvedValue(profile),
+		},
+	};
+	const logger = { warn: vi.fn(), error: vi.fn() };
+	return new DeploymentPreviewService(
+		prisma as never,
+		{ create: vi.fn().mockReturnValue(client) } as never,
+		logger as never,
+	);
+}
+
+describe("deployment preview authority", () => {
+	it("matches a differently named ARR Custom Format by the shared trailing UUID", async () => {
+		const preview = await createService().generatePreview("template-1", "instance-1", "user-1");
+
+		expect(preview.customFormats[0]).toMatchObject({ action: "update", trashId });
+		expect(preview.summary.newCustomFormats).toBe(0);
+		expect(preview.summary.updatedCustomFormats).toBe(1);
+		expect(preview.executionToken).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("returns the same execution token for the same reviewed state", async () => {
+		const service = createService();
+		const first = await service.generatePreview("template-1", "instance-1", "user-1");
+		const second = await service.generatePreview("template-1", "instance-1", "user-1");
+
+		expect(second.executionToken).toBe(first.executionToken);
+	});
+
+	it("never issues an executable token when the instance is unreachable", async () => {
+		const preview = await createService({ unreachable: true }).generatePreview(
+			"template-1",
+			"instance-1",
+			"user-1",
+		);
+
+		expect(preview.canDeploy).toBe(false);
+		expect(preview.executionToken).toBe("");
+	});
+
+	it("fails closed when ARR returns duplicate Custom Format identities", async () => {
+		const duplicateFormats = [
+			{ id: 42, name: `First [${trashId}]`, specifications: [] },
+			{ id: 43, name: `Second [${trashId}]`, specifications: [] },
+		];
+
+		await expect(
+			createService({ customFormats: duplicateFormats }).generatePreview(
+				"template-1",
+				"instance-1",
+				"user-1",
+			),
+		).rejects.toThrow("ambiguous Custom Format identities");
+	});
+
+	it("fails closed when an equivalent alias carries a stale mapping", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		const staleMapping = {
+			id: "mapping-alias",
+			templateId: "template-1",
+			instanceId: alias.id,
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: alias.connectionGeneration + 1,
+			connectionStateToken: "stale-token",
+			syncStrategy: "auto",
+		};
+
+		await expect(
+			createService({ instances: [instance, alias], mappings: [staleMapping] }).generatePreview(
+				"template-1",
+				"instance-1",
+				"user-1",
+			),
+		).rejects.toThrow("older connection");
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -38,6 +38,7 @@ function createService(
 		customFormats?: Array<{ id: number; name: string; specifications: unknown[] }>;
 		mappings?: Array<Record<string, unknown>>;
 		instances?: (typeof instance)[];
+		savedOverrides?: Array<Record<string, unknown>>;
 	} = {},
 ) {
 	const existingFormat = {
@@ -55,7 +56,9 @@ function createService(
 		templateQualityProfileMapping: {
 			findMany: vi.fn().mockResolvedValue(options.mappings ?? []),
 		},
-		instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+		instanceQualityProfileOverride: {
+			findMany: vi.fn().mockResolvedValue(options.savedOverrides ?? []),
+		},
 		trashCache: { findFirst: vi.fn().mockResolvedValue(null) },
 	};
 	const client = {
@@ -107,6 +110,42 @@ describe("deployment preview authority", () => {
 
 		expect(preview.canDeploy).toBe(false);
 		expect(preview.executionToken).toBe("");
+	});
+
+	it("accepts a legacy saved override only when ARR still has its exact score", async () => {
+		const preview = await createService({
+			savedOverrides: [
+				{
+					instanceId: instance.id,
+					qualityProfileId: 4,
+					customFormatId: 42,
+					score: 100,
+					status: "APPLIED",
+					connectionGeneration: 0,
+					connectionStateToken: null,
+				},
+			],
+		}).generatePreview("template-1", "instance-1", "user-1");
+
+		expect(preview.executionToken).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("rejects a legacy saved override when ARR no longer has its recorded score", async () => {
+		await expect(
+			createService({
+				savedOverrides: [
+					{
+						instanceId: instance.id,
+						qualityProfileId: 4,
+						customFormatId: 42,
+						score: 200,
+						status: "APPLIED",
+						connectionGeneration: 0,
+						connectionStateToken: null,
+					},
+				],
+			}).generatePreview("template-1", "instance-1", "user-1"),
+		).rejects.toThrow("unverified saved score override");
 	});
 
 	it("fails closed when ARR returns duplicate Custom Format identities", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { DeploymentPreviewService } from "../deployment-preview.js";
+import { createDeploymentConnectionStateToken } from "../deployment-target.js";
 
 const trashId = "a1b2c3d4-e5f6-47a8-9b0c-1d2e3f4a5b6c";
 const instance = {
@@ -183,5 +184,38 @@ describe("deployment preview authority", () => {
 				"user-1",
 			),
 		).rejects.toThrow("older connection");
+	});
+
+	it("fails closed when equivalent aliases disagree about their managed-format snapshot", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		const sharedMapping = {
+			templateId: "template-1",
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			syncStrategy: "auto",
+			managedCustomFormatsCaptured: true,
+		};
+
+		await expect(
+			createService({
+				instances: [instance, alias],
+				mappings: [
+					{
+						...sharedMapping,
+						id: "mapping-primary",
+						instanceId: instance.id,
+						managedCustomFormats: '[{"resourceId":42}]',
+					},
+					{
+						...sharedMapping,
+						id: "mapping-alias",
+						instanceId: alias.id,
+						managedCustomFormats: '[{"resourceId":43}]',
+					},
+				],
+			}).generatePreview("template-1", "instance-1", "user-1"),
+		).rejects.toThrow("conflicting deployment authority");
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -11,6 +11,7 @@ import {
 	createLegacyDeploymentConnectionBindings,
 	createQualityProfileStateToken,
 	getEquivalentServiceInstanceIds,
+	isDeploymentBackupEndpointIdentityCurrent,
 	resolveDeploymentTarget,
 	type DeploymentProfileMapping,
 } from "../deployment-target.js";
@@ -544,6 +545,33 @@ describe("getEquivalentServiceInstanceIds", () => {
 				encryptedApiKey: "rotated-key",
 			}),
 		);
+	});
+
+	it("accepts a legacy endpoint key only with the exact URL-bound connection token", () => {
+		const instance = {
+			id: "radarr-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+			connectionGeneration: 2,
+		};
+		const backupConnectionStateToken = createDeploymentConnectionStateToken(instance);
+		const identity = {
+			userId: "user-1",
+			backupEndpointKey: "user-1:RADARR:credential-1",
+			backupConnectionStateToken,
+			instance,
+			credentialIdentity: "credential-1",
+		};
+
+		expect(isDeploymentBackupEndpointIdentityCurrent(identity)).toBe(true);
+		expect(
+			isDeploymentBackupEndpointIdentityCurrent({
+				...identity,
+				instance: { ...instance, baseUrl: "http://other-radarr:7878" },
+			}),
+		).toBe(false);
 	});
 
 	it("requires an exact token even on a generation-zero connection", () => {

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
@@ -124,7 +124,9 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			{ deploySingleInstance: vi.fn().mockRejectedValue(partialConflict) } as never,
 		);
 
-		await expect(engine.execute(createSyncOptions(), undefined)).resolves.toMatchObject({
+		await expect(
+			engine.execute(createSyncOptions(), undefined, "review-token"),
+		).resolves.toMatchObject({
 			success: false,
 			status: "PARTIAL_SUCCESS",
 			configsApplied: 1,
@@ -171,7 +173,9 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 		const progress = vi.fn();
 		engine.onProgress("sync-1", progress);
 
-		await expect(engine.execute(createSyncOptions(), undefined)).resolves.toMatchObject({
+		await expect(
+			engine.execute(createSyncOptions(), undefined, "review-token"),
+		).resolves.toMatchObject({
 			success: false,
 			status: "PARTIAL_SUCCESS",
 			configsApplied: 2,
@@ -229,7 +233,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			{ deploySingleInstance: vi.fn().mockRejectedValue(conflict) } as never,
 		);
 
-		const result = await engine.execute(createSyncOptions(), undefined);
+		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
 		expect(result).toMatchObject({
 			success: false,
@@ -268,7 +272,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 		const progress = vi.fn();
 		engine.onProgress("sync-1", progress);
 
-		const result = await engine.execute(createSyncOptions(), undefined);
+		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
 		expect(result).toMatchObject({
 			success: true,
@@ -314,7 +318,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			} as never,
 		);
 
-		const result = await engine.execute(createSyncOptions(), undefined);
+		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
 		expect(result).toMatchObject({
 			success: true,
@@ -366,7 +370,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			{ deploySingleInstance } as never,
 		);
 
-		const result = await engine.execute(createSyncOptions(), undefined);
+		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
 		expect(result).toMatchObject({
 			success: false,

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
@@ -388,6 +388,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			"user-123",
 			undefined,
 			undefined,
+			"review-token",
 			"sync-1",
 		);
 	});

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
@@ -371,6 +371,8 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			{ syncTemplate: vi.fn().mockResolvedValue({ success: true, errors: [] }) } as never,
 			{ deploySingleInstance } as never,
 		);
+		const progress = vi.fn();
+		engine.onProgress("sync-1", progress);
 
 		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
@@ -383,6 +385,14 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 		expect(result.warnings).toEqual([
 			"ARR changes may be present, but the local audit record is incomplete.",
 		]);
+		expect(progress).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				status: "FAILED",
+				progress: 100,
+				appliedConfigs: 2,
+				failedConfigs: 1,
+			}),
+		);
 		expect(prisma.trashSyncHistory.update).toHaveBeenCalledTimes(1);
 		expect(deploySingleInstance).toHaveBeenCalledWith(
 			"template-123",
@@ -392,6 +402,47 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			undefined,
 			"review-token",
 			"sync-1",
+		);
+	});
+
+	it("keeps scheduled refresh before automation deployment without a review token", async () => {
+		const syncTemplate = vi.fn().mockResolvedValue({ success: true, errors: [] });
+		const deploySingleInstanceFromAutomation = vi.fn().mockResolvedValue({
+			instanceId: "instance-123",
+			instanceLabel: "Test Radarr",
+			success: true,
+			status: "SUCCESS",
+			customFormatsCreated: 1,
+			customFormatsUpdated: 0,
+			customFormatsSkipped: 0,
+			errors: [],
+			details: { created: ["Created CF"], updated: [], failed: [] },
+		});
+		const prisma = {
+			trashSyncHistory: {
+				create: vi.fn().mockResolvedValue({ id: "sync-1" }),
+				update: vi.fn().mockResolvedValue({}),
+			},
+		};
+		const engine = new SyncEngine(
+			prisma as never,
+			{ syncTemplate } as never,
+			{ deploySingleInstanceFromAutomation } as never,
+		);
+
+		const result = await engine.execute(createSyncOptions({ syncType: "SCHEDULED" }));
+
+		expect(result).toMatchObject({ success: true, status: "SUCCESS", configsApplied: 1 });
+		expect(syncTemplate).toHaveBeenCalledWith("template-123", undefined, "user-123");
+		expect(deploySingleInstanceFromAutomation).toHaveBeenCalledWith(
+			"template-123",
+			"instance-123",
+			"user-123",
+			undefined,
+			"sync-1",
+		);
+		expect(syncTemplate.mock.invocationCallOrder[0]).toBeLessThan(
+			deploySingleInstanceFromAutomation.mock.invocationCallOrder[0]!,
 		);
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
@@ -83,7 +83,7 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 			} as never,
 		);
 
-		const result = await engine.execute(createSyncOptions(), undefined);
+		const result = await engine.execute(createSyncOptions(), undefined, "review-token");
 
 		expect(result).toMatchObject({
 			success: false,

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine-partial-results.test.ts
@@ -36,7 +36,9 @@ describe("SyncEngine Task 4A partial result consumption", () => {
 		const progress = vi.fn();
 		engine.onProgress("sync-1", progress);
 
-		await expect(engine.execute(createSyncOptions(), undefined)).resolves.toMatchObject({
+		await expect(
+			engine.execute(createSyncOptions(), undefined, "review-token"),
+		).resolves.toMatchObject({
 			success: false,
 			status: "UNCERTAIN",
 			configsApplied: 1,

--- a/apps/api/src/lib/trash-guides/__tests__/sync-engine.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/sync-engine.test.ts
@@ -5,9 +5,10 @@
  * are properly configured before sync operations.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
+import { createDeploymentConnectionStateToken } from "../deployment-target.js";
 import { SyncEngine, type SyncOptions } from "../sync-engine.js";
 
 // Create mock template
@@ -44,6 +45,7 @@ const createMockInstance = (
 		baseUrl: string;
 		encryptedApiKey: string;
 		encryptionIv: string;
+		connectionGeneration: number;
 	}> = {},
 ) => ({
 	id: "instance-123",
@@ -53,6 +55,9 @@ const createMockInstance = (
 	baseUrl: "http://localhost:7878",
 	encryptedApiKey: "encrypted-key",
 	encryptionIv: "iv-123",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 0,
 	enabled: true,
 	createdAt: new Date(),
 	updatedAt: new Date(),
@@ -65,12 +70,20 @@ const createMockMapping = (
 		templateId: string;
 		instanceId: string;
 		qualityProfileId: number;
+		qualityProfileName: string;
+		connectionGeneration: number;
+		connectionStateToken: string | null;
+		syncStrategy: "auto" | "manual" | "notify";
 	}> = {},
 ) => ({
 	id: "mapping-123",
 	templateId: "template-123",
 	instanceId: "instance-123",
 	qualityProfileId: 1,
+	qualityProfileName: "HD-1080p",
+	connectionGeneration: 0,
+	connectionStateToken: createDeploymentConnectionStateToken(createMockInstance()),
+	syncStrategy: "auto",
 	createdAt: new Date(),
 	...overrides,
 });
@@ -80,6 +93,7 @@ const createMockPrisma = (
 	overrides: {
 		template?: ReturnType<typeof createMockTemplate> | null;
 		instance?: ReturnType<typeof createMockInstance> | null;
+		instances?: ReturnType<typeof createMockInstance>[];
 		mappings?: ReturnType<typeof createMockMapping>[];
 		cache?: { configData: string; lastModified: Date; updatedAt: Date } | null;
 	} = {},
@@ -105,6 +119,7 @@ const createMockPrisma = (
 		},
 		serviceInstance: {
 			findFirst: vi.fn().mockResolvedValue(instance),
+			findMany: vi.fn().mockResolvedValue(overrides.instances ?? (instance ? [instance] : [])),
 		},
 		templateQualityProfileMapping: {
 			findMany: vi.fn().mockResolvedValue(mappings),
@@ -287,6 +302,44 @@ describe("SyncEngine - validate()", () => {
 			const result = await engine.validate(createSyncOptions());
 
 			expect(result.errors.filter((e) => e.includes("mappings"))).toHaveLength(0);
+		});
+
+		it("blocks scheduled sync when an equivalent mapping no longer allows auto", async () => {
+			const prisma = createMockPrisma({
+				mappings: [createMockMapping({ syncStrategy: "notify" })],
+			});
+			const engine = new SyncEngine(prisma);
+
+			const result = await engine.validate(createSyncOptions({ syncType: "SCHEDULED" }));
+
+			expect(result.valid).toBe(false);
+			expect(result.errors).toContainEqual(expect.stringContaining("auto enabled"));
+		});
+
+		it("blocks sync when an equivalent alias has a mapping from an older connection", async () => {
+			const primary = createMockInstance();
+			const alias = createMockInstance({ id: "instance-alias" });
+			const prisma = createMockPrisma({
+				instance: primary,
+				instances: [primary, alias],
+				mappings: [
+					createMockMapping(),
+					createMockMapping({
+						instanceId: alias.id,
+						connectionGeneration: alias.connectionGeneration + 1,
+						connectionStateToken: createDeploymentConnectionStateToken(alias),
+					}),
+				],
+			});
+			const engine = new SyncEngine(prisma);
+
+			const result = await engine.validate(createSyncOptions());
+
+			expect(result.valid).toBe(false);
+			expect(result.errors).toContainEqual(expect.stringContaining("older connection"));
+			expect(prisma.templateQualityProfileMapping.findMany).toHaveBeenCalledWith({
+				where: { instanceId: { in: expect.arrayContaining([primary.id, alias.id]) } },
+			});
 		});
 
 		it("should warn when mapped quality profiles no longer exist in instance", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -30,13 +30,19 @@ function mapping(target: ReturnType<typeof instance>, overrides: Record<string, 
 		connectionGeneration: target.connectionGeneration,
 		connectionStateToken: createDeploymentConnectionStateToken(target),
 		instance: target,
+		managedCustomFormatsCaptured: true,
+		managedCustomFormats: "[]",
 		...overrides,
 	};
 }
 
 function createUpdater(
 	mappings: Array<ReturnType<typeof mapping>>,
-	deploymentResult: { success: boolean; errors: string[] } = { success: true, errors: [] },
+	deploymentResult: {
+		success: boolean;
+		errors: string[];
+		status?: "SUCCESS" | "FAILED" | "UNCERTAIN";
+	} = { success: true, errors: [], status: "SUCCESS" },
 ) {
 	const deploySingleInstanceFromAutomation = vi.fn().mockResolvedValue({
 		...deploymentResult,
@@ -65,6 +71,7 @@ function createUpdater(
 				instanceId: string;
 				instanceLabel: string;
 				success: boolean;
+				status: "SUCCESS" | "FAILED" | "UNCERTAIN";
 				errors: string[];
 			}>
 		>;
@@ -153,6 +160,26 @@ describe("TemplateUpdater automation authority", () => {
 		]);
 	});
 
+	it("blocks equivalent aliases with different managed-format snapshots", async () => {
+		const primary = instance("a-primary", "http://radarr/");
+		const alias = instance("z-alias", "HTTP://RADARR:80");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+			mapping(primary, { managedCustomFormats: '[{"resourceId":42}]' }),
+			mapping(alias, { managedCustomFormats: '[{"resourceId":43}]' }),
+		]);
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				instanceId: primary.id,
+				status: "FAILED",
+				errors: [expect.stringContaining("conflicting deployment authority")],
+			}),
+		]);
+	});
+
 	it("reports a resolved executor failure as an endpoint failure", async () => {
 		const target = instance("instance-1", "http://radarr:7878");
 		const { privateUpdater } = createUpdater([mapping(target)], {
@@ -231,6 +258,116 @@ describe("TemplateUpdater automation authority", () => {
 				success: false,
 				errors: [expect.stringContaining("ARR rejected the deployment")],
 			}),
+		]);
+	});
+
+	it("preserves an uncertain auto-deployment as needing review", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { updater } = createUpdater([mapping(target)], {
+			success: false,
+			status: "UNCERTAIN",
+			errors: ["ARR write could not be verified"],
+		});
+		vi.spyOn(updater, "checkForUpdates").mockResolvedValue({
+			templatesWithUpdates: [
+				{
+					templateId: template.id,
+					templateName: template.name,
+					currentCommit: "old",
+					latestCommit: "new",
+					hasUserModifications: false,
+					autoSyncInstanceCount: 1,
+					canAutoSync: true,
+					serviceType: "RADARR",
+				},
+			],
+			latestCommit: {
+				commitHash: "new",
+				commitDate: "2026-08-09",
+				commitMessage: "update",
+				commitUrl: "https://example.com/commit/new",
+			},
+			totalTemplates: 1,
+			outdatedTemplates: 1,
+		});
+		vi.spyOn(updater, "syncTemplate").mockResolvedValue({
+			success: true,
+			templateId: template.id,
+			previousCommit: "old",
+			newCommit: "new",
+		});
+
+		const result = await updater.processAutoUpdates(template.userId);
+
+		expect(result).toMatchObject({ processed: 1, successful: 0, failed: 0, uncertain: 1 });
+		expect(result.results).toEqual([
+			expect.objectContaining({
+				templateId: template.id,
+				success: false,
+				errors: [expect.stringContaining("needs review")],
+			}),
+		]);
+	});
+
+	it("preserves uncertainty when another endpoint also fails", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { updater, privateUpdater } = createUpdater([mapping(target)]);
+		vi.spyOn(privateUpdater, "deployToMappedInstances").mockResolvedValue([
+			{
+				endpointKey: "failed-endpoint",
+				instanceId: "failed-instance",
+				instanceLabel: "Failed Radarr",
+				success: false,
+				status: "FAILED",
+				errors: ["ARR rejected the deployment"],
+			},
+			{
+				endpointKey: "uncertain-endpoint",
+				instanceId: "uncertain-instance",
+				instanceLabel: "Uncertain Radarr",
+				success: false,
+				status: "UNCERTAIN",
+				errors: ["ARR write could not be verified"],
+			},
+		]);
+		vi.spyOn(updater, "checkForUpdates").mockResolvedValue({
+			templatesWithUpdates: [
+				{
+					templateId: template.id,
+					templateName: template.name,
+					currentCommit: "old",
+					latestCommit: "new",
+					hasUserModifications: false,
+					autoSyncInstanceCount: 2,
+					canAutoSync: true,
+					serviceType: "RADARR",
+				},
+			],
+			latestCommit: {
+				commitHash: "new",
+				commitDate: "2026-08-09",
+				commitMessage: "update",
+				commitUrl: "https://example.com/commit/new",
+			},
+			totalTemplates: 1,
+			outdatedTemplates: 1,
+		});
+		vi.spyOn(updater, "syncTemplate").mockResolvedValue({
+			success: true,
+			templateId: template.id,
+			previousCommit: "old",
+			newCommit: "new",
+		});
+
+		const result = await updater.processAutoUpdates(template.userId);
+
+		expect(result).toMatchObject({ processed: 1, successful: 0, failed: 1, uncertain: 1 });
+		expect(result.uncertainDeployments).toEqual([
+			expect.objectContaining({ instanceId: "uncertain-instance", status: "UNCERTAIN" }),
+		]);
+		expect(result.results[0]?.errors).toEqual([
+			expect.stringContaining("ARR rejected"),
+			expect.stringContaining("could not be verified"),
 		]);
 	});
 

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import { createDeploymentConnectionStateToken } from "../deployment-target.js";
+import { TemplateUpdater } from "../template-updater.js";
+
+const template = { id: "template-1", userId: "user-1", name: "Any" };
+
+function instance(id: string, baseUrl: string) {
+	return {
+		id,
+		userId: "user-1",
+		label: id,
+		service: "RADARR",
+		baseUrl,
+		encryptedApiKey: "encrypted-key",
+		encryptionIv: "iv",
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
+		connectionGeneration: 2,
+	};
+}
+
+function mapping(target: ReturnType<typeof instance>, overrides: Record<string, unknown> = {}) {
+	return {
+		id: `mapping-${target.id}`,
+		templateId: template.id,
+		instanceId: target.id,
+		qualityProfileId: 4,
+		qualityProfileName: "Any",
+		syncStrategy: "auto",
+		connectionGeneration: target.connectionGeneration,
+		connectionStateToken: createDeploymentConnectionStateToken(target),
+		instance: target,
+		...overrides,
+	};
+}
+
+function createUpdater(
+	mappings: Array<ReturnType<typeof mapping>>,
+	deploymentResult: { success: boolean; errors: string[] } = { success: true, errors: [] },
+) {
+	const deploySingleInstanceFromAutomation = vi.fn().mockResolvedValue({
+		...deploymentResult,
+	});
+	const prisma = {
+		trashTemplate: { findUnique: vi.fn().mockResolvedValue(template) },
+		templateQualityProfileMapping: { findMany: vi.fn().mockResolvedValue(mappings) },
+	};
+	const updater = new TemplateUpdater(
+		prisma as never,
+		{} as never,
+		{} as never,
+		{} as never,
+		{ deploySingleInstanceFromAutomation } as never,
+	);
+	const privateUpdater = updater as unknown as {
+		deployToMappedInstances: (templateId: string) => Promise<
+			Array<{
+				endpointKey: string;
+				instanceId: string;
+				instanceLabel: string;
+				success: boolean;
+				errors: string[];
+			}>
+		>;
+	};
+	return { updater, privateUpdater, deploySingleInstanceFromAutomation };
+}
+
+describe("TemplateUpdater automation authority", () => {
+	it("does not invoke automation for a stale connection binding", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+			mapping(target, { connectionGeneration: 1 }),
+		]);
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				instanceId: target.id,
+				success: false,
+				errors: [expect.stringContaining("stale or legacy")],
+			}),
+		]);
+	});
+
+	it("blocks an entire endpoint when one equivalent alias has a stale binding", async () => {
+		const primary = instance("a-primary", "http://radarr/");
+		const staleAlias = instance("z-stale-alias", "HTTP://RADARR:80");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+			mapping(primary),
+			mapping(staleAlias, { connectionGeneration: 1 }),
+		]);
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				endpointKey: "user-1:RADARR:http://radarr/",
+				instanceId: primary.id,
+				success: false,
+				errors: [expect.stringContaining("stale or legacy")],
+			}),
+		]);
+	});
+
+	it("deduplicates equivalent aliases to one deterministic automation call", async () => {
+		const primary = instance("a-primary", "http://radarr/");
+		const alias = instance("z-alias", "HTTP://RADARR:80");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+			mapping(alias),
+			mapping(primary),
+		]);
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(deploySingleInstanceFromAutomation).toHaveBeenCalledOnce();
+		expect(deploySingleInstanceFromAutomation).toHaveBeenCalledWith(
+			template.id,
+			primary.id,
+			template.userId,
+		);
+		expect(outcomes).toEqual([
+			expect.objectContaining({ instanceId: primary.id, success: true, errors: [] }),
+		]);
+	});
+
+	it("blocks conflicting profile mappings for equivalent aliases", async () => {
+		const primary = instance("a-primary", "http://radarr/");
+		const alias = instance("z-alias", "HTTP://RADARR:80");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+			mapping(primary),
+			mapping(alias, { qualityProfileId: 5 }),
+		]);
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				instanceId: primary.id,
+				success: false,
+				errors: [expect.stringContaining("conflicting quality profile")],
+			}),
+		]);
+	});
+
+	it("reports a resolved executor failure as an endpoint failure", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { privateUpdater } = createUpdater([mapping(target)], {
+			success: false,
+			errors: ["ARR rejected the deployment"],
+		});
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				instanceId: target.id,
+				success: false,
+				errors: [expect.stringContaining("ARR rejected the deployment")],
+			}),
+		]);
+	});
+
+	it("reports a thrown executor failure as an endpoint failure", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([mapping(target)]);
+		deploySingleInstanceFromAutomation.mockRejectedValueOnce(new Error("ARR unavailable"));
+
+		const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				instanceId: target.id,
+				success: false,
+				errors: [expect.stringContaining("ARR unavailable")],
+			}),
+		]);
+	});
+
+	it("marks a synced template failed when any endpoint deployment fails", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { updater } = createUpdater([mapping(target)], {
+			success: false,
+			errors: ["ARR rejected the deployment"],
+		});
+		vi.spyOn(updater, "checkForUpdates").mockResolvedValue({
+			templatesWithUpdates: [
+				{
+					templateId: template.id,
+					templateName: template.name,
+					currentCommit: "old",
+					latestCommit: "new",
+					hasUserModifications: false,
+					autoSyncInstanceCount: 1,
+					canAutoSync: true,
+					serviceType: "RADARR",
+				},
+			],
+			latestCommit: {
+				commitHash: "new",
+				commitDate: "2026-08-09",
+				commitMessage: "update",
+				commitUrl: "https://example.com/commit/new",
+			},
+			totalTemplates: 1,
+			outdatedTemplates: 1,
+		});
+		vi.spyOn(updater, "syncTemplate").mockResolvedValue({
+			success: true,
+			templateId: template.id,
+			previousCommit: "old",
+			newCommit: "new",
+		});
+
+		const result = await updater.processAutoUpdates(template.userId);
+
+		expect(result).toMatchObject({ processed: 1, successful: 0, failed: 1 });
+		expect(result.results).toEqual([
+			expect.objectContaining({
+				templateId: template.id,
+				success: false,
+				errors: [expect.stringContaining("ARR rejected the deployment")],
+			}),
+		]);
+	});
+
+	it("keeps a refreshed template successful when it has no auto mappings", async () => {
+		const { updater } = createUpdater([]);
+		vi.spyOn(updater, "checkForUpdates").mockResolvedValue({
+			templatesWithUpdates: [
+				{
+					templateId: template.id,
+					templateName: template.name,
+					currentCommit: "old",
+					latestCommit: "new",
+					hasUserModifications: false,
+					autoSyncInstanceCount: 1,
+					canAutoSync: true,
+					serviceType: "RADARR",
+				},
+			],
+			latestCommit: {
+				commitHash: "new",
+				commitDate: "2026-08-09",
+				commitMessage: "update",
+				commitUrl: "https://example.com/commit/new",
+			},
+			totalTemplates: 1,
+			outdatedTemplates: 1,
+		});
+		vi.spyOn(updater, "syncTemplate").mockResolvedValue({
+			success: true,
+			templateId: template.id,
+			previousCommit: "old",
+			newCommit: "new",
+		});
+
+		const result = await updater.processAutoUpdates(template.userId);
+
+		expect(result).toMatchObject({ processed: 1, successful: 1, failed: 0 });
+		expect(result.results).toEqual([expect.objectContaining({ success: true })]);
+		expect(result.results[0]).not.toHaveProperty("errors");
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import { createDeploymentConnectionStateToken } from "../deployment-target.js";
 import { TemplateUpdater } from "../template-updater.js";
 
-const template = { id: "template-1", userId: "user-1", name: "Any" };
+const template = {
+	id: "template-1",
+	userId: "user-1",
+	name: "Any",
+	instanceOverrides: null as string | null,
+};
 
 function instance(id: string, baseUrl: string) {
 	return {
@@ -178,6 +183,35 @@ describe("TemplateUpdater automation authority", () => {
 				errors: [expect.stringContaining("conflicting deployment authority")],
 			}),
 		]);
+	});
+
+	it("blocks equivalent aliases with different instance overrides", async () => {
+		const primary = instance("a-primary", "http://radarr/");
+		const alias = instance("z-alias", "HTTP://RADARR:80");
+		const previousOverrides = template.instanceOverrides;
+		template.instanceOverrides = JSON.stringify({
+			[primary.id]: { cfScoreOverrides: { "trash-cf": 100 } },
+			[alias.id]: { cfScoreOverrides: { "trash-cf": 200 } },
+		});
+		try {
+			const { privateUpdater, deploySingleInstanceFromAutomation } = createUpdater([
+				mapping(primary),
+				mapping(alias),
+			]);
+
+			const outcomes = await privateUpdater.deployToMappedInstances(template.id);
+
+			expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
+			expect(outcomes).toEqual([
+				expect.objectContaining({
+					instanceId: primary.id,
+					status: "FAILED",
+					errors: [expect.stringContaining("conflicting instance overrides")],
+				}),
+			]);
+		} finally {
+			template.instanceOverrides = previousOverrides;
+		}
 	});
 
 	it("reports a resolved executor failure as an endpoint failure", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -41,6 +41,12 @@ function createUpdater(
 	const deploySingleInstanceFromAutomation = vi.fn().mockResolvedValue({
 		...deploymentResult,
 	});
+	const createEndpointMutationKey = vi
+		.fn()
+		.mockImplementation(
+			(userId: string, target: ReturnType<typeof instance>) =>
+				`${userId}:${target.service}:credential-1`,
+		);
 	const prisma = {
 		trashTemplate: { findUnique: vi.fn().mockResolvedValue(template) },
 		templateQualityProfileMapping: { findMany: vi.fn().mockResolvedValue(mappings) },
@@ -50,7 +56,7 @@ function createUpdater(
 		{} as never,
 		{} as never,
 		{} as never,
-		{ deploySingleInstanceFromAutomation } as never,
+		{ deploySingleInstanceFromAutomation, createEndpointMutationKey } as never,
 	);
 	const privateUpdater = updater as unknown as {
 		deployToMappedInstances: (templateId: string) => Promise<
@@ -98,7 +104,7 @@ describe("TemplateUpdater automation authority", () => {
 		expect(deploySingleInstanceFromAutomation).not.toHaveBeenCalled();
 		expect(outcomes).toEqual([
 			expect.objectContaining({
-				endpointKey: "user-1:RADARR:http://radarr/",
+				endpointKey: "user-1:RADARR:credential-1",
 				instanceId: primary.id,
 				success: false,
 				errors: [expect.stringContaining("stale or legacy")],

--- a/apps/api/src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { UpdateScheduler } from "../update-scheduler.js";
+
+describe("TRaSH update scheduler uncertain automation", () => {
+	it("counts and notifies an uncertain deployment without treating it as failed", async () => {
+		const uncertainOutcome = {
+			endpointKey: "user-1:RADARR:credential-1",
+			instanceId: "instance-1",
+			instanceLabel: "Radarr",
+			status: "UNCERTAIN" as const,
+			success: false,
+			errors: ["ARR write could not be verified"],
+		};
+		const templateUpdater = {
+			refreshAllCaches: vi.fn().mockResolvedValue({ refreshed: 0, failed: 0, errors: [] }),
+			checkForUpdates: vi.fn().mockResolvedValue({
+				totalTemplates: 1,
+				outdatedTemplates: 1,
+				templatesWithUpdates: [],
+			}),
+			processAutoUpdates: vi.fn().mockResolvedValue({
+				processed: 1,
+				successful: 0,
+				failed: 0,
+				uncertain: 1,
+				skippedForApproval: 0,
+				templatesWithScoreConflicts: 0,
+				uncertainDeployments: [uncertainOutcome],
+				results: [
+					{
+						templateId: "template-1",
+						success: false,
+						errors: uncertainOutcome.errors,
+					},
+				],
+			}),
+			getTemplatesNeedingAttention: vi.fn().mockResolvedValue([]),
+		};
+		const prisma = {
+			trashTemplate: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([{ userId: "user-1" }]),
+			},
+		};
+		const logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		};
+		const notify = vi.fn().mockResolvedValue(undefined);
+		const scheduler = new UpdateScheduler(
+			{ enabled: true, intervalHours: 12 },
+			templateUpdater as never,
+			{
+				getLatestCommit: vi.fn().mockResolvedValue({ commitHash: "new", commitDate: "today" }),
+			} as never,
+			prisma as never,
+			logger,
+			undefined,
+			{ notifyFn: notify },
+		);
+		const privateScheduler = scheduler as unknown as {
+			processQualitySizeSync: () => Promise<unknown>;
+			processNamingSync: () => Promise<unknown>;
+		};
+		vi.spyOn(privateScheduler, "processQualitySizeSync").mockResolvedValue({
+			autoSynced: 0,
+			updatesPending: 0,
+			errors: [],
+		});
+		vi.spyOn(privateScheduler, "processNamingSync").mockResolvedValue({
+			autoSynced: 0,
+			updatesPending: 0,
+			errors: [],
+		});
+
+		await scheduler.triggerCheck();
+
+		expect(scheduler.getStats().lastCheckResult).toMatchObject({
+			templatesAutoSynced: 0,
+			templatesWithUncertainDeployments: 1,
+			errors: [],
+		});
+		expect(notify).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "TRASH_DEPLOY_UNCERTAIN",
+				title: expect.stringContaining("needs review"),
+				metadata: expect.objectContaining({ reason: "uncertain_result" }),
+			}),
+			{ userId: "user-1", fallbackEventTypes: ["TRASH_SYNC_ERROR"] },
+		);
+	});
+});

--- a/apps/api/src/lib/trash-guides/cf-field-utils.ts
+++ b/apps/api/src/lib/trash-guides/cf-field-utils.ts
@@ -50,5 +50,59 @@ export function extractTrashId(cf: SdkCustomFormat): string | null {
 			}
 		}
 	}
+	if (cf.name) {
+		const trailingIdentity = cf.name.match(
+			/\[([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})\]$/i,
+		);
+		if (trailingIdentity?.[1]) {
+			return trailingIdentity[1].toLowerCase();
+		}
+	}
 	return null;
+}
+
+/**
+ * Index ARR Custom Formats only when each mutation identity resolves to one row.
+ * Ambiguous identities are removed from the indexes so callers cannot
+ * accidentally authorize whichever duplicate happened to be returned last.
+ */
+export function buildCustomFormatIdentityIndex(customFormats: SdkCustomFormat[]): {
+	byTrashId: Map<string, SdkCustomFormat>;
+	byName: Map<string, SdkCustomFormat>;
+	collisions: string[];
+} {
+	const byTrashId = new Map<string, SdkCustomFormat>();
+	const byName = new Map<string, SdkCustomFormat>();
+	const duplicateTrashIds = new Set<string>();
+	const duplicateNames = new Set<string>();
+
+	for (const customFormat of customFormats) {
+		const trashId = extractTrashId(customFormat);
+		if (trashId) {
+			if (duplicateTrashIds.has(trashId) || byTrashId.has(trashId)) {
+				duplicateTrashIds.add(trashId);
+				byTrashId.delete(trashId);
+			} else {
+				byTrashId.set(trashId, customFormat);
+			}
+		}
+
+		if (customFormat.name) {
+			if (duplicateNames.has(customFormat.name) || byName.has(customFormat.name)) {
+				duplicateNames.add(customFormat.name);
+				byName.delete(customFormat.name);
+			} else {
+				byName.set(customFormat.name, customFormat);
+			}
+		}
+	}
+
+	return {
+		byTrashId,
+		byName,
+		collisions: [
+			...[...duplicateTrashIds].sort().map((trashId) => `TRaSH identity ${trashId}`),
+			...[...duplicateNames].sort().map((name) => `name "${name}"`),
+		],
+	};
 }

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -54,9 +54,11 @@ import {
 import { assertNoPendingDeploymentOperation } from "./deployment-operation-gate.js";
 import {
 	assertDeploymentTargetOwnership,
+	assertEquivalentDeploymentMappingAuthority,
 	createDeploymentConnectionBindingCandidates,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
+	createDeploymentMappingAuthorityState,
 	createDeploymentStateToken,
 	createLegacyDeploymentConnectionBindings,
 	createQualityProfileStateToken,
@@ -1755,6 +1757,7 @@ export class DeploymentExecutorService {
 					"This template has conflicting quality-profile mappings for duplicate records of the same ARR instance. Unlink the stale deployment before continuing.",
 				);
 			}
+			assertEquivalentDeploymentMappingAuthority(templateMappings);
 			const qualityProfileMapping =
 				templateMappings.find((mapping) => mapping.instanceId === instanceId) ??
 				templateMappings[0];
@@ -1893,6 +1896,7 @@ export class DeploymentExecutorService {
 					customFormats: existingCFs,
 					namingConfig: namingState?.currentConfig,
 					namingPayload: namingState?.mergedConfig,
+					mappingAuthority: createDeploymentMappingAuthorityState(templateMappings),
 					savedScoreOverrides: [...instanceOverrideScores.entries()].sort(
 						([left], [right]) => left - right,
 					),

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -1656,6 +1656,7 @@ export class DeploymentExecutorService {
 		const warnings: string[] = [];
 		let appliedProfileMutation: QualityProfileMutation | undefined;
 		let instanceLabel = "Unknown";
+		let managedFinalizationUncertain = false;
 		let namingFieldsApplied = 0;
 		let deploymentPhase: "before_cf" | "custom_formats" | "quality_profile" | "post_profile" =
 			"before_cf";
@@ -2251,9 +2252,37 @@ export class DeploymentExecutorService {
 					"Deployment succeeded but history finalization failed",
 				);
 				if (requiresManagedFinalization) {
-					allErrors.push(
-						"ARR changes were applied, but managed deployment state could not be finalized. The prior mapping and saved score overrides were preserved; retry this deployment or roll it back before making further changes.",
-					);
+					managedFinalizationUncertain = true;
+					const finalizationMessage =
+						"ARR changes were applied, but managed deployment state could not be finalized. The prior mapping and saved score overrides were preserved; resolve or roll back this deployment before making further changes.";
+					const uncertaintyError = Object.assign(new ConflictError(finalizationMessage), {
+						deploymentResultUncertain: true,
+					});
+					const priorErrors = [...allErrors];
+					allErrors.push(finalizationMessage);
+					try {
+						await finalizeDeploymentHistoryWithPartialFailure(
+							this.prisma,
+							historyId,
+							deploymentHistoryId,
+							startTime,
+							cfResult.details,
+							{
+								created: cfResult.created,
+								updated: cfResult.updated,
+								skipped: cfResult.skipped,
+							},
+							uncertaintyError,
+							appliedProfileMutation,
+							priorErrors,
+							namingFieldsApplied,
+						);
+					} catch (uncertainHistoryError) {
+						log.error(
+							{ err: uncertainHistoryError, templateId, instanceId },
+							"Failed to mark deployment history uncertain after managed finalization failed",
+						);
+					}
 				} else {
 					warnings.push(
 						"Deployment completed, but its history record could not be finalized. Check the server logs.",
@@ -2272,7 +2301,12 @@ export class DeploymentExecutorService {
 				instanceId,
 				instanceLabel: instance.label,
 				success: allErrors.length === 0,
-				status: allErrors.length === 0 ? "SUCCESS" : "FAILED",
+				status:
+					allErrors.length === 0
+						? "SUCCESS"
+						: managedFinalizationUncertain
+							? "UNCERTAIN"
+							: "FAILED",
 				customFormatsCreated: cfResult.created,
 				customFormatsUpdated: cfResult.updated,
 				customFormatsSkipped: cfResult.skipped,

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -386,6 +386,10 @@ export class DeploymentExecutorService {
 		});
 	}
 
+	createEndpointMutationKey(userId: string, instance: EndpointCredentialSource): string {
+		return this.createEndpointKey(userId, instance);
+	}
+
 	// ============================================================================
 	// Private Helper Methods
 	// ============================================================================
@@ -1209,14 +1213,15 @@ export class DeploymentExecutorService {
 				if (targetProfile.id === undefined) {
 					throw new Error("Quality profile ID is missing");
 				}
-				const [latestTargetProfile, latestOverrideScores] = await Promise.all([
-					client.qualityProfile.getById(targetProfile.id) as Promise<SdkQualityProfile>,
-					this.loadEquivalentInstanceOverrideScores(
-						userId,
-						connectionReadBindings,
-						targetProfile.id,
-					),
-				]);
+				const latestTargetProfile = (await client.qualityProfile.getById(
+					targetProfile.id,
+				)) as SdkQualityProfile;
+				const latestOverrideScores = await this.loadEquivalentInstanceOverrideScores(
+					userId,
+					connectionReadBindings,
+					targetProfile.id,
+					latestTargetProfile,
+				);
 				if (
 					createQualityProfileStateToken(latestTargetProfile) !==
 						createQualityProfileStateToken(targetProfile) ||
@@ -1337,6 +1342,7 @@ export class DeploymentExecutorService {
 		userId: string,
 		connectionBindings: DeploymentConnectionReadBinding[],
 		qualityProfileId: number,
+		liveProfile: SdkQualityProfile,
 	): Promise<Map<number, number>> {
 		const instanceIds = [...new Set(connectionBindings.map((binding) => binding.instanceId))];
 		const overrides = await this.prisma.instanceQualityProfileOverride.findMany({
@@ -1349,9 +1355,15 @@ export class DeploymentExecutorService {
 		});
 		const scores = new Map<number, number>();
 		for (const override of overrides) {
-			if (!isCurrentDeploymentConnectionMapping(override, connectionBindings)) {
+			const currentOverride = isCurrentDeploymentConnectionMapping(override, connectionBindings);
+			const liveScore = liveProfile.formatItems?.find(
+				(item) => item.format === override.customFormatId,
+			)?.score;
+			const verifiedLegacyOverride =
+				isLegacyDeploymentConnectionMapping(override) && liveScore === override.score;
+			if (!currentOverride && !verifiedLegacyOverride) {
 				throw new ConflictError(
-					"This ARR endpoint has a saved score override bound to an older connection. Reconcile the stale override before deploying.",
+					"This ARR endpoint has an unverified saved score override. Restore its recorded score on the current profile or remove the override before deploying.",
 				);
 			}
 			const existingScore = scores.get(override.customFormatId);
@@ -1380,7 +1392,8 @@ export class DeploymentExecutorService {
 		for (const override of liveOverrides) {
 			if (
 				override.status !== "APPLIED" ||
-				!isCurrentDeploymentConnectionMapping(override, finalization.connectionReadBindings)
+				(!isCurrentDeploymentConnectionMapping(override, finalization.connectionReadBindings) &&
+					!isLegacyDeploymentConnectionMapping(override))
 			) {
 				throw new ConflictError(
 					"Saved score override authority changed before deployment state could be finalized.",
@@ -1823,6 +1836,7 @@ export class DeploymentExecutorService {
 							userId,
 							overrideReadBindings,
 							authorizedTarget.profile.id,
+							authorizedTarget.profile,
 						)
 					: new Map<number, number>();
 			let previousManagedFormats: ManagedCustomFormatIdentity[] = [];
@@ -2372,7 +2386,16 @@ export class DeploymentExecutorService {
 
 			const selectedInstances = await this.prisma.serviceInstance.findMany({
 				where: { id: { in: instanceIds }, userId },
-				select: { id: true, service: true, baseUrl: true },
+				select: {
+					id: true,
+					service: true,
+					baseUrl: true,
+					encryptedApiKey: true,
+					encryptionIv: true,
+					encryptedHttpAuthCredentials: true,
+					httpAuthEncryptionIv: true,
+					connectionGeneration: true,
+				},
 			});
 			if (selectedInstances.length !== instanceIds.length) {
 				throw new AppValidationError(
@@ -2383,7 +2406,7 @@ export class DeploymentExecutorService {
 			const endpointOwners = new Map<string, string>();
 			for (const instanceId of instanceIds) {
 				const instance = selectedById.get(instanceId)!;
-				const endpointKey = createDeploymentEndpointKey(userId, instance);
+				const endpointKey = this.createEndpointKey(userId, instance);
 				const existingInstanceId = endpointOwners.get(endpointKey);
 				if (existingInstanceId && existingInstanceId !== instance.id) {
 					throw new AppValidationError(

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -2459,13 +2459,13 @@ export class DeploymentExecutorService {
 
 			return {
 				templateId,
-					templateName: template.name,
-					totalInstances: instanceIds.length,
-					successfulInstances: results.filter((result) => result.status === "SUCCESS").length,
-					failedInstances: results.filter((result) => result.status === "FAILED").length,
-					uncertainInstances: results.filter((result) => result.status === "UNCERTAIN").length,
-					results,
-				};
-			});
+				templateName: template.name,
+				totalInstances: instanceIds.length,
+				successfulInstances: results.filter((result) => result.status === "SUCCESS").length,
+				failedInstances: results.filter((result) => result.status === "FAILED").length,
+				uncertainInstances: results.filter((result) => result.status === "UNCERTAIN").length,
+				results,
+			};
+		});
 	}
 }

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -26,7 +26,11 @@ import { withCleanupTopologyMutationLease } from "../library-cleanup/cleanup-exe
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { createCacheManager } from "./cache-manager.js";
-import { extractTrashId, transformFieldsToArray } from "./cf-field-utils.js";
+import {
+	buildCustomFormatIdentityIndex,
+	extractTrashId,
+	transformFieldsToArray,
+} from "./cf-field-utils.js";
 import { checkMutualExclusions } from "./conflict-checker.js";
 import { shouldRetainDeploymentBackup } from "./deployment-backup-state.js";
 import type { CustomFormatRollbackState } from "./deployment-custom-format-state.js";
@@ -36,7 +40,6 @@ import {
 	finalizeDeploymentHistoryWithPartialFailure,
 	isDeploymentResultUncertain,
 } from "./deployment-history-manager.js";
-import { assertNoPendingDeploymentOperation } from "./deployment-operation-gate.js";
 import {
 	captureManagedCustomFormatIdentities,
 	type ManagedCustomFormatIdentity,
@@ -48,13 +51,20 @@ import {
 	type PreparedNamingDeployment,
 	prepareNamingDeployment,
 } from "./deployment-naming-state.js";
+import { assertNoPendingDeploymentOperation } from "./deployment-operation-gate.js";
 import {
+	assertDeploymentTargetOwnership,
 	createDeploymentConnectionBindingCandidates,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
+	createDeploymentStateToken,
+	createLegacyDeploymentConnectionBindings,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
+	isCurrentDeploymentConnectionMapping,
+	isLegacyDeploymentConnectionMapping,
+	resolveDeploymentTarget,
 } from "./deployment-target.js";
 import { createQualityProfileFromSchema } from "./profile-creation-strategies.js";
 import {
@@ -301,6 +311,7 @@ interface DeployCustomFormatsResult {
 	skipped: number;
 	details: DeploymentDetails;
 	errors: string[];
+	resolvedResourceIds: Map<string, number>;
 }
 
 interface SyncQualityProfileResult {
@@ -314,9 +325,13 @@ interface SyncQualityProfileResult {
 		connectionReadBindings: DeploymentConnectionReadBinding[];
 	};
 	mappingFinalization?: {
+		userId: string;
 		templateId: string;
 		instanceId: string;
 		equivalentInstanceIds: string[];
+		connectionBindings: DeploymentConnectionBinding[];
+		connectionReadBindings: DeploymentConnectionReadBinding[];
+		savedScoreOverrides: Array<[number, number]>;
 		qualityProfileId: number;
 		qualityProfileName: string;
 		connectionGeneration: number;
@@ -622,6 +637,7 @@ export class DeploymentExecutorService {
 		let created = 0;
 		let updated = 0;
 		let skipped = 0;
+		const resolvedResourceIds = new Map<string, number>();
 		const throwWithPartialDeployment = (error: ConflictError): never => {
 			Object.assign(error, {
 				partialDeployment: {
@@ -646,11 +662,15 @@ export class DeploymentExecutorService {
 				const cfResolution =
 					conflictResolutions?.[templateCF.trashId] ?? conflictResolutions?.[templateCF.name];
 				if (existingCF && cfResolution === "keep_existing") {
+					if (existingCF.id !== undefined) {
+						resolvedResourceIds.set(templateCF.trashId, existingCF.id);
+					}
 					skipped++;
 					continue;
 				}
 
 				if (existingCF?.id) {
+					resolvedResourceIds.set(templateCF.trashId, existingCF.id);
 					const freshExistingCF = await client.customFormat.getById(existingCF.id);
 					if (
 						createUpstreamResourceStateToken(freshExistingCF) !==
@@ -748,9 +768,10 @@ export class DeploymentExecutorService {
 					);
 					mutationState.status = "applied";
 					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
+					await persistMutationState(mutationState, false);
+					resolvedResourceIds.set(templateCF.trashId, createdFormat.id);
 					created++;
 					details.created.push(templateCF.name);
-					await persistMutationState(mutationState, false);
 				}
 			} catch (error) {
 				if (upstreamMutationStarted) {
@@ -775,7 +796,7 @@ export class DeploymentExecutorService {
 			}
 		}
 
-		return { created, updated, skipped, details, errors };
+		return { created, updated, skipped, details, errors, resolvedResourceIds };
 	}
 
 	private async syncQualityProfile(
@@ -803,6 +824,7 @@ export class DeploymentExecutorService {
 		})),
 		connectionReadBindings: DeploymentConnectionReadBinding[] = connectionBindings,
 		previousManagedFormats: ManagedCustomFormatIdentity[] = [],
+		resolvedCustomFormatIds: ReadonlyMap<string, number> = new Map(),
 	): Promise<SyncQualityProfileResult> {
 		const errors: string[] = [];
 		const orphanedCFs: string[] = [];
@@ -890,9 +912,6 @@ export class DeploymentExecutorService {
 			}
 
 			if (targetProfile) {
-				const allCFs = await client.customFormat.getAll();
-				const cfMap = new Map(allCFs.map((cf) => [cf.name, cf]));
-
 				const formatItems: Array<{ format: number; score: number }> = [];
 				const scoreSet = templateConfig.qualityProfile?.trash_score_set;
 
@@ -904,29 +923,29 @@ export class DeploymentExecutorService {
 				}
 
 				for (const templateCF of templateCFs) {
-					const cf = cfMap.get(templateCF.name);
-					if (cf?.id) {
+					const customFormatId = resolvedCustomFormatIds.get(templateCF.trashId);
+					if (customFormatId !== undefined) {
 						const conflictResolution = conflictResolutions?.[templateCF.trashId];
 						if (conflictResolution === "keep_existing") {
-							const existingScore = existingScoreMap.get(cf.id);
+							const existingScore = existingScoreMap.get(customFormatId);
 							if (existingScore !== undefined) {
-								formatItems.push({ format: cf.id, score: existingScore });
+								formatItems.push({ format: customFormatId, score: existingScore });
 								continue;
 							}
 						}
 
-						const instanceOverrideScore = instanceOverrideScores.get(cf.id);
+						const instanceOverrideScore = instanceOverrideScores.get(customFormatId);
 						const { score: templateScore } = calculateScoreAndSource(
 							templateCF,
 							scoreSet,
 							instanceOverrideScore,
 						);
 
-						const existingScore = existingScoreMap.get(cf.id);
+						const existingScore = existingScoreMap.get(customFormatId);
 						const previousManagedFormat = previousManagedFormats.find(
 							(previous) =>
 								previous.trashId === templateCF.trashId &&
-								previous.resourceId === cf.id &&
+								previous.resourceId === customFormatId &&
 								previous.profileId === targetProfile.id,
 						);
 						const manuallyDriftedAfterDeployment =
@@ -935,16 +954,16 @@ export class DeploymentExecutorService {
 						if (
 							existingScore !== undefined &&
 							existingScore !== templateScore &&
-							!instanceOverrideScores.has(cf.id) &&
+							!instanceOverrideScores.has(customFormatId) &&
 							templateCF.scoreOverride === undefined &&
 							conflictResolution !== "use_template" &&
 							(previousManagedFormat === undefined || manuallyDriftedAfterDeployment)
 						) {
 							// Preserve genuine manual Radarr/Sonarr drift, but do not mistake
 							// the score applied by the previous deployment for user intent.
-							formatItems.push({ format: cf.id, score: existingScore });
+							formatItems.push({ format: customFormatId, score: existingScore });
 						} else {
-							formatItems.push({ format: cf.id, score: templateScore });
+							formatItems.push({ format: customFormatId, score: templateScore });
 						}
 					}
 				}
@@ -1258,10 +1277,13 @@ export class DeploymentExecutorService {
 				// Mapping replacement is committed only with successful history
 				// finalization. Until then, the previous mapping remains authoritative.
 				mappingFinalization = {
+					userId,
 					templateId,
 					instanceId,
-					// Alias consolidation requires Task 4B's in-lock authority checks.
-					equivalentInstanceIds: [instanceId],
+					equivalentInstanceIds,
+					connectionBindings,
+					connectionReadBindings,
+					savedScoreOverrides: getSortedOverrideScoreEntries(instanceOverrideScores),
 					qualityProfileId: targetProfile.id,
 					qualityProfileName: targetProfile.name ?? profileName,
 					connectionGeneration: connectionBinding.connectionGeneration,
@@ -1316,16 +1338,22 @@ export class DeploymentExecutorService {
 		connectionBindings: DeploymentConnectionReadBinding[],
 		qualityProfileId: number,
 	): Promise<Map<number, number>> {
+		const instanceIds = [...new Set(connectionBindings.map((binding) => binding.instanceId))];
 		const overrides = await this.prisma.instanceQualityProfileOverride.findMany({
 			where: {
 				userId,
 				status: "APPLIED",
 				qualityProfileId,
-				OR: connectionBindings,
+				instanceId: { in: instanceIds },
 			},
 		});
 		const scores = new Map<number, number>();
 		for (const override of overrides) {
+			if (!isCurrentDeploymentConnectionMapping(override, connectionBindings)) {
+				throw new ConflictError(
+					"This ARR endpoint has a saved score override bound to an older connection. Reconcile the stale override before deploying.",
+				);
+			}
 			const existingScore = scores.get(override.customFormatId);
 			if (existingScore !== undefined && existingScore !== override.score) {
 				throw new ConflictError(
@@ -1335,6 +1363,67 @@ export class DeploymentExecutorService {
 			scores.set(override.customFormatId, override.score);
 		}
 		return scores;
+	}
+
+	private async finalizeSavedScoreOverrideState(
+		database: PrismaClient,
+		finalization: NonNullable<SyncQualityProfileResult["mappingFinalization"]>,
+	): Promise<void> {
+		const liveOverrides = await database.instanceQualityProfileOverride.findMany({
+			where: {
+				userId: finalization.userId,
+				instanceId: { in: finalization.equivalentInstanceIds },
+				qualityProfileId: finalization.qualityProfileId,
+			},
+		});
+		const liveOverrideScores = new Map<number, number>();
+		for (const override of liveOverrides) {
+			if (
+				override.status !== "APPLIED" ||
+				!isCurrentDeploymentConnectionMapping(override, finalization.connectionReadBindings)
+			) {
+				throw new ConflictError(
+					"Saved score override authority changed before deployment state could be finalized.",
+				);
+			}
+			const existingScore = liveOverrideScores.get(override.customFormatId);
+			if (existingScore !== undefined && existingScore !== override.score) {
+				throw new ConflictError(
+					"Saved score overrides changed before deployment state could be finalized.",
+				);
+			}
+			liveOverrideScores.set(override.customFormatId, override.score);
+		}
+		if (
+			createUpstreamResourceStateToken(getSortedOverrideScoreEntries(liveOverrideScores)) !==
+			createUpstreamResourceStateToken(finalization.savedScoreOverrides)
+		) {
+			throw new ConflictError(
+				"Saved score overrides changed before deployment state could be finalized.",
+			);
+		}
+
+		await database.instanceQualityProfileOverride.deleteMany({
+			where: {
+				userId: finalization.userId,
+				instanceId: { in: finalization.equivalentInstanceIds },
+				qualityProfileId: finalization.qualityProfileId,
+			},
+		});
+		for (const [customFormatId, score] of finalization.savedScoreOverrides) {
+			await database.instanceQualityProfileOverride.create({
+				data: {
+					userId: finalization.userId,
+					instanceId: finalization.instanceId,
+					qualityProfileId: finalization.qualityProfileId,
+					customFormatId,
+					score,
+					status: "APPLIED",
+					connectionGeneration: finalization.connectionGeneration,
+					connectionStateToken: finalization.connectionStateToken,
+				},
+			});
+		}
 	}
 
 	// ============================================================================
@@ -1368,6 +1457,50 @@ export class DeploymentExecutorService {
 		userId: string,
 		syncStrategy?: "auto" | "manual" | "notify",
 		conflictResolutions?: Record<string, "use_template" | "keep_existing">,
+		executionToken?: string,
+		parentSyncHistoryId?: string,
+	): Promise<DeploymentResult> {
+		if (!executionToken) {
+			throw new AppValidationError(
+				"A fresh deployment preview token is required for user-triggered execution.",
+			);
+		}
+		return this.deploySingleInstanceWithCapability(
+			templateId,
+			instanceId,
+			userId,
+			syncStrategy,
+			conflictResolutions,
+			executionToken,
+			parentSyncHistoryId,
+		);
+	}
+
+	async deploySingleInstanceFromAutomation(
+		templateId: string,
+		instanceId: string,
+		userId: string,
+		conflictResolutions?: Record<string, "use_template" | "keep_existing">,
+		parentSyncHistoryId?: string,
+	): Promise<DeploymentResult> {
+		return this.deploySingleInstanceWithCapability(
+			templateId,
+			instanceId,
+			userId,
+			"auto",
+			conflictResolutions,
+			undefined,
+			parentSyncHistoryId,
+		);
+	}
+
+	private async deploySingleInstanceWithCapability(
+		templateId: string,
+		instanceId: string,
+		userId: string,
+		syncStrategy: "auto" | "manual" | "notify" | undefined,
+		conflictResolutions: Record<string, "use_template" | "keep_existing"> | undefined,
+		executionToken: string | undefined,
 		parentSyncHistoryId?: string,
 	): Promise<DeploymentResult> {
 		const lockInstance = await this.prisma.serviceInstance.findFirst({
@@ -1394,6 +1527,7 @@ export class DeploymentExecutorService {
 					userId,
 					syncStrategy,
 					conflictResolutions,
+					executionToken,
 					endpointKey,
 					parentSyncHistoryId,
 				),
@@ -1496,6 +1630,7 @@ export class DeploymentExecutorService {
 		userId: string,
 		syncStrategy?: "auto" | "manual" | "notify",
 		conflictResolutions?: Record<string, "use_template" | "keep_existing">,
+		executionToken?: string,
 		expectedEndpointKey?: string,
 		parentSyncHistoryId?: string,
 	): Promise<DeploymentResult> {
@@ -1530,8 +1665,7 @@ export class DeploymentExecutorService {
 				throw new Error(`Instance unreachable: ${getErrorMessage(error, "Unknown error")}`);
 			}
 
-			// Resolve equivalent endpoint records for serialization and durable state capture.
-			// Preview tokens, automation capabilities, and legacy rebinding are integrated by Task 4B.
+			// Resolve and authorize the exact upstream target before any write or history mutation.
 			const serviceAliases = await this.prisma.serviceInstance.findMany({
 				where: { userId, service: instance.service },
 				select: {
@@ -1578,39 +1712,125 @@ export class DeploymentExecutorService {
 				client.customFormat.getAll(),
 				client.qualityProfile.getAll(),
 				this.prisma.templateQualityProfileMapping.findMany({
-					where: { templateId, instanceId },
+					where: { instanceId: { in: equivalentInstanceIds } },
 					orderBy: { updatedAt: "desc" },
 				}),
 			]);
-			const profileName = template.name || "TRaSH Guides HD/UHD";
-			const listedProfile = (fetchedProfiles as SdkQualityProfile[]).find(
-				(profile) => profile.name === profileName,
-			);
-			const preDeploymentQP =
-				listedProfile?.id !== undefined
-					? ((await client.qualityProfile.getById(listedProfile.id)) as SdkQualityProfile)
-					: null;
-			if (preDeploymentQP && preDeploymentQP.id !== listedProfile?.id) {
+			const customFormatIndex = buildCustomFormatIdentityIndex(existingCFs);
+			if (customFormatIndex.collisions.length > 0) {
 				throw new ConflictError(
-					"The target quality profile identity changed before its rollback snapshot was captured.",
+					`ARR returned ambiguous Custom Format identities (${customFormatIndex.collisions.join(", ")}). Resolve the duplicates before deploying.`,
 				);
 			}
+			if (
+				qualityProfileMappings.some(
+					(mapping) =>
+						!isLegacyDeploymentConnectionMapping(mapping) &&
+						!isCurrentDeploymentConnectionMapping(mapping, connectionBindings),
+				)
+			) {
+				throw new ConflictError(
+					"This ARR endpoint has a deployment mapping bound to an older connection. Unlink or reconcile the stale mapping before deploying.",
+				);
+			}
+			const allProfiles = fetchedProfiles as SdkQualityProfile[];
+			const templateMappings = qualityProfileMappings.filter(
+				(mapping) => mapping.templateId === templateId,
+			);
+			if (new Set(templateMappings.map((mapping) => mapping.qualityProfileId)).size > 1) {
+				throw new ConflictError(
+					"This template has conflicting quality-profile mappings for duplicate records of the same ARR instance. Unlink the stale deployment before continuing.",
+				);
+			}
+			const qualityProfileMapping =
+				templateMappings.find((mapping) => mapping.instanceId === instanceId) ??
+				templateMappings[0];
+			const selectedMappingIsLegacy = Boolean(
+				qualityProfileMapping && isLegacyDeploymentConnectionMapping(qualityProfileMapping),
+			);
+			if (!executionToken) {
+				const eligibleAutomationMappings = templateMappings.filter(
+					(mapping) =>
+						mapping.syncStrategy === "auto" &&
+						!isLegacyDeploymentConnectionMapping(mapping) &&
+						isCurrentDeploymentConnectionMapping(mapping, connectionBindings),
+				);
+				if (eligibleAutomationMappings.length === 0) {
+					throw new ConflictError(
+						"Automatic deployment is no longer authorized for this ARR endpoint. Review the mapping, sync strategy, and connection before retrying.",
+					);
+				}
+				if (
+					templateMappings.some(
+						(mapping) =>
+							mapping.syncStrategy !== "auto" ||
+							isLegacyDeploymentConnectionMapping(mapping) ||
+							!isCurrentDeploymentConnectionMapping(mapping, connectionBindings),
+					)
+				) {
+					throw new ConflictError(
+						"Automatic deployment is blocked by a changed, stale, or legacy alias mapping for this ARR endpoint. Review and consolidate the deployment mappings first.",
+					);
+				}
+			}
+			const resolvedTarget = resolveDeploymentTarget({
+				profiles: allProfiles,
+				mapping: qualityProfileMapping,
+				sourceProfileId: templateConfig.completeQualityProfile?.sourceProfileId,
+				isSourceInstance: equivalentInstanceIds.includes(
+					templateConfig.completeQualityProfile?.sourceInstanceId ?? "",
+				),
+				sourceProfileName: template.sourceQualityProfileName,
+				templateName: template.name,
+			});
+			if (resolvedTarget.matchedBy === "mapping_name" && !executionToken) {
+				throw new ConflictError(
+					"The mapped quality profile was recreated. Review a fresh deployment preview before relinking it.",
+				);
+			}
+			assertDeploymentTargetOwnership({
+				target: resolvedTarget,
+				templateId,
+				existingMappings: qualityProfileMappings,
+			});
+			const preDeploymentQP =
+				resolvedTarget.profile?.id !== undefined
+					? ((await client.qualityProfile.getById(resolvedTarget.profile.id)) as SdkQualityProfile)
+					: null;
+			if (preDeploymentQP?.id !== resolvedTarget.profile?.id) {
+				throw new ConflictError(
+					"The target quality profile identity changed before its full rollback snapshot was captured.",
+				);
+			}
+			const authorizedTarget = { ...resolvedTarget, profile: preDeploymentQP ?? undefined };
+			const profileName = resolvedTarget.profileName;
+			const reviewedTargetProfileToken = executionToken
+				? createQualityProfileStateToken(authorizedTarget.profile ?? null)
+				: undefined;
 			const namingSelection = templateConfig.namingSelection as NamingSelectedPresets | undefined;
 			const namingState = namingSelection
 				? await prepareNamingDeployment(this.prisma, this.clientFactory, instance, namingSelection)
 				: undefined;
+			const overrideReadBindings = selectedMappingIsLegacy
+				? [
+						...connectionReadBindings,
+						...createLegacyDeploymentConnectionBindings(equivalentInstanceIds),
+					]
+				: connectionReadBindings;
 			const instanceOverrideScores =
-				preDeploymentQP?.id !== undefined
+				authorizedTarget.profile?.id !== undefined
 					? await this.loadEquivalentInstanceOverrideScores(
 							userId,
-							connectionReadBindings,
-							preDeploymentQP.id,
+							overrideReadBindings,
+							authorizedTarget.profile.id,
 						)
 					: new Map<number, number>();
-			const qualityProfileMapping = qualityProfileMappings[0];
 			let previousManagedFormats: ManagedCustomFormatIdentity[] = [];
 			try {
-				previousManagedFormats = readPersistedManagedCustomFormatIdentities(qualityProfileMapping);
+				previousManagedFormats =
+					selectedMappingIsLegacy && !qualityProfileMapping?.managedCustomFormatsCaptured
+						? []
+						: readPersistedManagedCustomFormatIdentities(qualityProfileMapping);
 			} catch (parseError) {
 				throw new ConflictError(
 					`The previous deployment's Custom Format identity metadata is unavailable or invalid: ${getErrorMessage(parseError)}`,
@@ -1620,9 +1840,56 @@ export class DeploymentExecutorService {
 				client,
 				templateCFs,
 				previousManagedFormats,
-				preDeploymentQP ?? undefined,
+				authorizedTarget.profile,
 			);
 			warnings.push(...orphanResolution.warnings);
+			const currentProfileScores = new Map(
+				(authorizedTarget.profile?.formatItems ?? []).map((item) => [item.format, item.score]),
+			);
+			const orphanedFormatScoreChanges = orphanResolution.formats.map((format) => ({
+				instanceId: format.resourceId,
+				name: format.name,
+				score:
+					currentProfileScores.get(format.resourceId) ??
+					instanceOverrideScores.get(format.resourceId) ??
+					0,
+			}));
+
+			if (executionToken) {
+				const currentToken = createDeploymentStateToken({
+					template: {
+						id: template.id,
+						name: template.name,
+						configData: template.configData,
+						instanceOverrides: template.instanceOverrides,
+						sourceQualityProfileName: template.sourceQualityProfileName,
+					},
+					instanceId,
+					connection: {
+						service: instance.service,
+						baseUrl: instance.baseUrl,
+						credentialIdentity: [
+							instance.encryptedApiKey,
+							instance.encryptionIv,
+							instance.encryptedHttpAuthCredentials,
+							instance.httpAuthEncryptionIv,
+						].join(":"),
+					},
+					target: authorizedTarget,
+					customFormats: existingCFs,
+					namingConfig: namingState?.currentConfig,
+					namingPayload: namingState?.mergedConfig,
+					savedScoreOverrides: [...instanceOverrideScores.entries()].sort(
+						([left], [right]) => left - right,
+					),
+					orphanedFormatScoreChanges,
+				});
+				if (currentToken !== executionToken) {
+					throw new ConflictError(
+						"The template or instance changed after this preview. Refresh the preview and review the deployment again.",
+					);
+				}
+			}
 
 			const { backup, historyId: syncHistoryId } = await this.createBackupAndHistory(
 				instance,
@@ -1644,17 +1911,8 @@ export class DeploymentExecutorService {
 				});
 			};
 			historyId = syncHistoryId;
-			const existingCFMap = new Map<string, SdkCustomFormat>();
-			const existingCFByName = new Map<string, SdkCustomFormat>();
-			for (const cf of existingCFs) {
-				const trashId = extractTrashId(cf);
-				if (trashId) {
-					existingCFMap.set(trashId, cf);
-				}
-				if (cf.name) {
-					existingCFByName.set(cf.name, cf);
-				}
-			}
+			const existingCFMap = customFormatIndex.byTrashId;
+			const existingCFByName = customFormatIndex.byName;
 
 			const deploymentHistory = await this.prisma.templateDeploymentHistory.create({
 				data: {
@@ -1698,6 +1956,11 @@ export class DeploymentExecutorService {
 			partialCFResult = cfResult;
 			deploymentPhase = "quality_profile";
 
+			const retainedSyncStrategy = ["auto", "manual", "notify"].includes(
+				qualityProfileMapping?.syncStrategy ?? "",
+			)
+				? (qualityProfileMapping?.syncStrategy as "auto" | "manual" | "notify")
+				: undefined;
 			const profileResult = await this.syncQualityProfile(
 				client,
 				templateConfig,
@@ -1705,11 +1968,11 @@ export class DeploymentExecutorService {
 				templateId,
 				instanceId,
 				userId,
-				syncStrategy,
+				syncStrategy ?? retainedSyncStrategy ?? "notify",
 				conflictResolutions,
 				profileName,
-				preDeploymentQP ?? undefined,
-				undefined,
+				authorizedTarget.profile,
+				reviewedTargetProfileToken,
 				orphanResolution.formats,
 				instanceOverrideScores,
 				equivalentInstanceIds,
@@ -1719,8 +1982,9 @@ export class DeploymentExecutorService {
 					await persistBackupLedger();
 				},
 				connectionBindings,
-				connectionReadBindings,
+				overrideReadBindings,
 				previousManagedFormats,
+				cfResult.resolvedResourceIds ?? new Map(),
 			);
 			appliedProfileMutation = profileResult.mutation;
 			let deferredManagedMappingUpdate:
@@ -1743,6 +2007,7 @@ export class DeploymentExecutorService {
 					client,
 					templateCFs,
 					managedProfile,
+					cfResult.resolvedResourceIds,
 				);
 				backup.data.managedCustomFormats = managedCustomFormats;
 				backup.data.managedCustomFormatsCaptured = true;
@@ -1858,11 +2123,51 @@ export class DeploymentExecutorService {
 					mappingFinalization || orphanedOverrideCleanup || managedMappingUpdate
 						? async (database) => {
 								if (mappingFinalization) {
+									const liveInstances = await database.serviceInstance.findMany({
+										where: {
+											id: { in: mappingFinalization.equivalentInstanceIds },
+											userId: mappingFinalization.userId,
+										},
+										select: {
+											id: true,
+											service: true,
+											baseUrl: true,
+											encryptedApiKey: true,
+											encryptionIv: true,
+											encryptedHttpAuthCredentials: true,
+											httpAuthEncryptionIv: true,
+											connectionGeneration: true,
+										},
+									});
+									const expectedBindingByInstanceId = new Map(
+										mappingFinalization.connectionBindings.map((binding) => [
+											binding.instanceId,
+											binding,
+										]),
+									);
+									if (
+										liveInstances.length !== expectedBindingByInstanceId.size ||
+										liveInstances.some((liveInstance) => {
+											const expected = expectedBindingByInstanceId.get(liveInstance.id);
+											return (
+												!expected ||
+												expected.connectionGeneration !== liveInstance.connectionGeneration ||
+												expected.connectionStateToken !==
+													createDeploymentConnectionStateToken(liveInstance)
+											);
+										})
+									) {
+										throw new ConflictError(
+											"The ARR service connection changed before deployment state could be finalized.",
+										);
+									}
+
+									await this.finalizeSavedScoreOverrideState(database, mappingFinalization);
+
 									await database.templateQualityProfileMapping.deleteMany({
 										where: {
 											templateId: mappingFinalization.templateId,
 											instanceId: { in: mappingFinalization.equivalentInstanceIds },
-											qualityProfileId: { not: mappingFinalization.qualityProfileId },
 										},
 									});
 									await database.templateQualityProfileMapping.upsert({
@@ -2043,49 +2348,101 @@ export class DeploymentExecutorService {
 		userId: string,
 		syncStrategy?: "auto" | "manual" | "notify",
 		instanceSyncStrategies?: Record<string, "auto" | "manual" | "notify">,
+		executionTokens: Record<string, string> = {},
 	): Promise<BulkDeploymentResult> {
-		const template = await this.prisma.trashTemplate.findUnique({
-			where: { id: templateId, userId },
-		});
-		if (!template) {
-			throw new TemplateNotFoundError(templateId);
+		if (new Set(instanceIds).size !== instanceIds.length) {
+			throw new AppValidationError(
+				"Bulk deployment contains the same service instance more than once.",
+			);
 		}
-
-		// The topology lease is per user, so bulk targets run sequentially.
-		const results: DeploymentResult[] = [];
-		for (let index = 0; index < instanceIds.length; index++) {
-			const instanceId = instanceIds[index]!;
-			try {
-				const strategy = instanceSyncStrategies?.[instanceId] ?? syncStrategy;
-				results.push(await this.deploySingleInstance(templateId, instanceId, userId, strategy));
-			} catch (error) {
-				const partialDeployment = getPartialDeploymentResult(error);
-				results.push({
-					instanceId,
-					instanceLabel: `Instance ${index + 1}`,
-					success: false,
-					status: isDeploymentResultUncertain(error) ? "UNCERTAIN" : "FAILED",
-					customFormatsCreated: partialDeployment?.created ?? 0,
-					customFormatsUpdated: partialDeployment?.updated ?? 0,
-					customFormatsSkipped: partialDeployment?.skipped ?? 0,
-					errors: [
-						...(partialDeployment?.errors ?? []),
-						getErrorMessage(error, "Deployment failed"),
-					],
-					qualityProfileApplied: toPublicQualityProfileMutation(partialDeployment?.qualityProfile),
-					details: partialDeployment?.details,
-				});
+		for (const instanceId of instanceIds) {
+			if (!executionTokens[instanceId]) {
+				throw new AppValidationError(
+					"A fresh deployment preview token is required for every user-triggered bulk target.",
+				);
 			}
 		}
+		return withCleanupTopologyMutationLease({ prisma: this.prisma, log }, userId, async () => {
+			const template = await this.prisma.trashTemplate.findUnique({
+				where: { id: templateId, userId },
+			});
+			if (!template) {
+				throw new TemplateNotFoundError(templateId);
+			}
 
-		return {
-			templateId,
-			templateName: template.name,
-			totalInstances: instanceIds.length,
-			successfulInstances: results.filter((result) => result.status === "SUCCESS").length,
-			failedInstances: results.filter((result) => result.status === "FAILED").length,
-			uncertainInstances: results.filter((result) => result.status === "UNCERTAIN").length,
-			results,
-		};
+			const selectedInstances = await this.prisma.serviceInstance.findMany({
+				where: { id: { in: instanceIds }, userId },
+				select: { id: true, service: true, baseUrl: true },
+			});
+			if (selectedInstances.length !== instanceIds.length) {
+				throw new AppValidationError(
+					"One or more selected service instances no longer exist or are not authorized.",
+				);
+			}
+			const selectedById = new Map(selectedInstances.map((instance) => [instance.id, instance]));
+			const endpointOwners = new Map<string, string>();
+			for (const instanceId of instanceIds) {
+				const instance = selectedById.get(instanceId)!;
+				const endpointKey = createDeploymentEndpointKey(userId, instance);
+				const existingInstanceId = endpointOwners.get(endpointKey);
+				if (existingInstanceId && existingInstanceId !== instance.id) {
+					throw new AppValidationError(
+						"Bulk deployment includes multiple service records for the same ARR endpoint. Select only one record for each endpoint.",
+					);
+				}
+				endpointOwners.set(endpointKey, instance.id);
+			}
+
+			const results: DeploymentResult[] = [];
+			for (let index = 0; index < instanceIds.length; index++) {
+				const instanceId = instanceIds[index]!;
+				const instance = selectedById.get(instanceId)!;
+				try {
+					const strategy = instanceSyncStrategies?.[instanceId] ?? syncStrategy;
+					results.push(
+						await this.runWithEndpointMutation(userId, instance, "Deployment", (endpointKey) =>
+							this.executeSingleDeployment(
+								templateId,
+								instanceId,
+								userId,
+								strategy,
+								undefined,
+								executionTokens[instanceId],
+								endpointKey,
+							),
+						),
+					);
+				} catch (error) {
+					const partialDeployment = getPartialDeploymentResult(error);
+					results.push({
+						instanceId,
+						instanceLabel: `Instance ${index + 1}`,
+						success: false,
+						status: isDeploymentResultUncertain(error) ? "UNCERTAIN" : "FAILED",
+						customFormatsCreated: partialDeployment?.created ?? 0,
+						customFormatsUpdated: partialDeployment?.updated ?? 0,
+						customFormatsSkipped: partialDeployment?.skipped ?? 0,
+						errors: [
+							...(partialDeployment?.errors ?? []),
+							getErrorMessage(error, "Deployment failed"),
+						],
+						qualityProfileApplied: toPublicQualityProfileMutation(
+							partialDeployment?.qualityProfile,
+						),
+						details: partialDeployment?.details,
+					});
+				}
+			}
+
+			return {
+				templateId,
+					templateName: template.name,
+					totalInstances: instanceIds.length,
+					successfulInstances: results.filter((result) => result.status === "SUCCESS").length,
+					failedInstances: results.filter((result) => result.status === "FAILED").length,
+					uncertainInstances: results.filter((result) => result.status === "UNCERTAIN").length,
+					results,
+				};
+			});
 	}
 }

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -668,9 +668,21 @@ export class DeploymentExecutorService {
 				const cfResolution =
 					conflictResolutions?.[templateCF.trashId] ?? conflictResolutions?.[templateCF.name];
 				if (existingCF && cfResolution === "keep_existing") {
-					if (existingCF.id !== undefined) {
-						resolvedResourceIds.set(templateCF.trashId, existingCF.id);
+					if (existingCF.id === undefined) {
+						throw new ConflictError(
+							`Custom Format "${templateCF.name}" has no stable ARR identity. Refresh the preview and try again.`,
+						);
 					}
+					const freshExistingCF = await client.customFormat.getById(existingCF.id);
+					if (
+						createUpstreamResourceStateToken(freshExistingCF) !==
+						createUpstreamResourceStateToken(existingCF)
+					) {
+						throw new ConflictError(
+							`Custom Format "${templateCF.name}" changed during deployment. Refresh the preview and review the deployment again.`,
+						);
+					}
+					resolvedResourceIds.set(templateCF.trashId, existingCF.id);
 					skipped++;
 					continue;
 				}
@@ -774,10 +786,10 @@ export class DeploymentExecutorService {
 					);
 					mutationState.status = "applied";
 					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
-					await persistMutationState(mutationState, false);
-					resolvedResourceIds.set(templateCF.trashId, createdFormat.id);
 					created++;
 					details.created.push(templateCF.name);
+					await persistMutationState(mutationState, false);
+					resolvedResourceIds.set(templateCF.trashId, createdFormat.id);
 				}
 			} catch (error) {
 				if (upstreamMutationStarted) {
@@ -1383,6 +1395,17 @@ export class DeploymentExecutorService {
 		database: PrismaClient,
 		finalization: NonNullable<SyncQualityProfileResult["mappingFinalization"]>,
 	): Promise<void> {
+		const bindingByInstanceId = new Map(
+			finalization.connectionBindings.map((binding) => [binding.instanceId, binding]),
+		);
+		if (
+			bindingByInstanceId.size !== finalization.equivalentInstanceIds.length ||
+			finalization.equivalentInstanceIds.some((instanceId) => !bindingByInstanceId.has(instanceId))
+		) {
+			throw new ConflictError(
+				"Equivalent ARR alias connection authority is incomplete and cannot be finalized safely.",
+			);
+		}
 		const liveOverrides = await database.instanceQualityProfileOverride.findMany({
 			where: {
 				userId: finalization.userId,
@@ -1425,17 +1448,73 @@ export class DeploymentExecutorService {
 				qualityProfileId: finalization.qualityProfileId,
 			},
 		});
-		for (const [customFormatId, score] of finalization.savedScoreOverrides) {
-			await database.instanceQualityProfileOverride.create({
-				data: {
-					userId: finalization.userId,
-					instanceId: finalization.instanceId,
+		for (const binding of bindingByInstanceId.values()) {
+			for (const [customFormatId, score] of finalization.savedScoreOverrides) {
+				await database.instanceQualityProfileOverride.create({
+					data: {
+						userId: finalization.userId,
+						instanceId: binding.instanceId,
+						qualityProfileId: finalization.qualityProfileId,
+						customFormatId,
+						score,
+						status: "APPLIED",
+						connectionGeneration: binding.connectionGeneration,
+						connectionStateToken: binding.connectionStateToken,
+					},
+				});
+			}
+		}
+	}
+
+	private async finalizeQualityProfileMappingState(
+		database: PrismaClient,
+		finalization: NonNullable<SyncQualityProfileResult["mappingFinalization"]>,
+	): Promise<void> {
+		await this.finalizeSavedScoreOverrideState(database, finalization);
+		const bindingByInstanceId = new Map(
+			finalization.connectionBindings.map((binding) => [binding.instanceId, binding]),
+		);
+		if (
+			bindingByInstanceId.size !== finalization.equivalentInstanceIds.length ||
+			finalization.equivalentInstanceIds.some((instanceId) => !bindingByInstanceId.has(instanceId))
+		) {
+			throw new ConflictError(
+				"Equivalent ARR alias connection authority is incomplete and cannot be finalized safely.",
+			);
+		}
+
+		await database.templateQualityProfileMapping.deleteMany({
+			where: {
+				templateId: finalization.templateId,
+				instanceId: { in: finalization.equivalentInstanceIds },
+			},
+		});
+		for (const binding of bindingByInstanceId.values()) {
+			await database.templateQualityProfileMapping.upsert({
+				where: {
+					instanceId_qualityProfileId: {
+						instanceId: binding.instanceId,
+						qualityProfileId: finalization.qualityProfileId,
+					},
+				},
+				create: {
+					templateId: finalization.templateId,
+					instanceId: binding.instanceId,
 					qualityProfileId: finalization.qualityProfileId,
-					customFormatId,
-					score,
-					status: "APPLIED",
-					connectionGeneration: finalization.connectionGeneration,
-					connectionStateToken: finalization.connectionStateToken,
+					qualityProfileName: finalization.qualityProfileName,
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+					syncStrategy: finalization.syncStrategy || "notify",
+					lastSyncedAt: new Date(),
+				},
+				update: {
+					templateId: finalization.templateId,
+					qualityProfileName: finalization.qualityProfileName,
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+					...(finalization.syncStrategy && { syncStrategy: finalization.syncStrategy }),
+					lastSyncedAt: new Date(),
+					updatedAt: new Date(),
 				},
 			});
 		}
@@ -2181,49 +2260,13 @@ export class DeploymentExecutorService {
 										);
 									}
 
-									await this.finalizeSavedScoreOverrideState(database, mappingFinalization);
-
-									await database.templateQualityProfileMapping.deleteMany({
-										where: {
-											templateId: mappingFinalization.templateId,
-											instanceId: { in: mappingFinalization.equivalentInstanceIds },
-										},
-									});
-									await database.templateQualityProfileMapping.upsert({
-										where: {
-											instanceId_qualityProfileId: {
-												instanceId: mappingFinalization.instanceId,
-												qualityProfileId: mappingFinalization.qualityProfileId,
-											},
-										},
-										create: {
-											templateId: mappingFinalization.templateId,
-											instanceId: mappingFinalization.instanceId,
-											qualityProfileId: mappingFinalization.qualityProfileId,
-											qualityProfileName: mappingFinalization.qualityProfileName,
-											connectionGeneration: mappingFinalization.connectionGeneration,
-											connectionStateToken: mappingFinalization.connectionStateToken,
-											syncStrategy: mappingFinalization.syncStrategy || "notify",
-											lastSyncedAt: new Date(),
-										},
-										update: {
-											templateId: mappingFinalization.templateId,
-											qualityProfileName: mappingFinalization.qualityProfileName,
-											connectionGeneration: mappingFinalization.connectionGeneration,
-											connectionStateToken: mappingFinalization.connectionStateToken,
-											...(mappingFinalization.syncStrategy && {
-												syncStrategy: mappingFinalization.syncStrategy,
-											}),
-											lastSyncedAt: new Date(),
-											updatedAt: new Date(),
-										},
-									});
+									await this.finalizeQualityProfileMappingState(database, mappingFinalization);
 								}
 								if (managedMappingUpdate) {
 									await database.templateQualityProfileMapping.updateMany({
 										where: {
 											templateId,
-											instanceId,
+											instanceId: { in: equivalentInstanceIds },
 											qualityProfileId: managedMappingUpdate.managedProfileId,
 										},
 										data: {

--- a/apps/api/src/lib/trash-guides/deployment-history-manager.ts
+++ b/apps/api/src/lib/trash-guides/deployment-history-manager.ts
@@ -209,6 +209,15 @@ export async function finalizeDeploymentHistoryWithPartialFailure(
 	const appliedCFCount = counts.created + counts.updated;
 	const appliedCount =
 		appliedCFCount + (qualityProfile ? 1 : 0) + (namingFieldsApplied > 0 ? 1 : 0);
+	const uncertain = isDeploymentResultUncertain(error);
+	const status = uncertain ? "UNCERTAIN" : appliedCount > 0 ? "PARTIAL_SUCCESS" : "FAILED";
+	const failedConfigs = [
+		...details.failed.map((name, index) => ({
+			name,
+			error: priorErrors[index] ?? "Custom Format deployment failed",
+		})),
+		...(uncertain ? [] : [{ name: "Deployment phase", error: errorMessage }]),
+	];
 	const appliedConfigs = [
 		...getAppliedConfigs(details, qualityProfile),
 		...(namingFieldsApplied > 0
@@ -221,15 +230,6 @@ export async function finalizeDeploymentHistoryWithPartialFailure(
 					},
 				]
 			: []),
-	];
-	const uncertain = isDeploymentResultUncertain(error);
-	const status = uncertain ? "UNCERTAIN" : appliedCount > 0 ? "PARTIAL_SUCCESS" : "FAILED";
-	const failedConfigs = [
-		...details.failed.map((name, index) => ({
-			name,
-			error: priorErrors[index] ?? "Custom Format deployment failed",
-		})),
-		...(uncertain ? [] : [{ name: "Deployment phase", error: errorMessage }]),
 	];
 	await withHistoryTransaction(prisma, async (database) => {
 		if (historyId) {

--- a/apps/api/src/lib/trash-guides/deployment-managed-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-managed-format-state.ts
@@ -27,6 +27,7 @@ export async function captureManagedCustomFormatIdentities(
 	client: ArrClient,
 	templateCFs: Array<Pick<TemplateCF, "trashId" | "name">>,
 	profile: ManagedProfile,
+	resolvedResourceIds?: ReadonlyMap<string, number>,
 ): Promise<ManagedCustomFormatIdentity[]> {
 	if (profile.id === undefined) {
 		throw new Error("The managed quality profile ID is unavailable");
@@ -37,26 +38,30 @@ export async function captureManagedCustomFormatIdentities(
 			appliedScores.set(item.format, item.score);
 		}
 	}
-	const listed = await client.customFormat.getAll();
-	const byName = new Map(
-		listed.filter((format) => format.name).map((format) => [format.name!, format]),
-	);
+	const byName = resolvedResourceIds
+		? undefined
+		: new Map(
+				(await client.customFormat.getAll())
+					.filter((format) => format.name)
+					.map((format) => [format.name!, format]),
+			);
 	const identities: ManagedCustomFormatIdentity[] = [];
 	for (const templateCF of templateCFs) {
-		const match = byName.get(templateCF.name);
-		if (match?.id === undefined) {
+		const resourceId =
+			resolvedResourceIds?.get(templateCF.trashId) ?? byName?.get(templateCF.name)?.id;
+		if (resourceId === undefined) {
 			throw new Error(
 				`The deployed Custom Format identity for "${templateCF.name}" could not be captured.`,
 			);
 		}
-		const full = await client.customFormat.getById(match.id);
+		const full = await client.customFormat.getById(resourceId);
 		identities.push({
 			trashId: templateCF.trashId,
 			name: templateCF.name,
-			resourceId: match.id,
+			resourceId,
 			stateToken: createUpstreamResourceStateToken(full),
 			profileId: profile.id,
-			appliedScore: appliedScores.get(match.id) ?? 0,
+			appliedScore: appliedScores.get(resourceId) ?? 0,
 		});
 	}
 	return identities;

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -139,13 +139,12 @@ export async function assertNoPendingDeploymentOperation(
 	if (
 		syncRows.some(
 			(row) =>
-				!row.backup &&
-				(row.status === "IN_PROGRESS" ||
-					row.status === "RUNNING" ||
-					row.status === "PARTIAL_SUCCESS"),
+				row.status === "IN_PROGRESS" ||
+				row.status === "RUNNING" ||
+				(!row.backup && row.status === "PARTIAL_SUCCESS"),
 		) ||
 		deploymentRows.some(
-			(row) => !row.backup && (row.status === "IN_PROGRESS" || row.status === "PARTIAL_SUCCESS"),
+			(row) => row.status === "IN_PROGRESS" || (!row.backup && row.status === "PARTIAL_SUCCESS"),
 		)
 	) {
 		throw new AppValidationError(

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -283,7 +283,7 @@ export async function reconcileInterruptedDeploymentHistories(
 			: [];
 
 	type Reconciliation = {
-		status: "FAILED" | "UNCERTAIN" | "PARTIAL_SUCCESS";
+		status: "FAILED" | "UNCERTAIN";
 		message: string;
 		appliedCFCount?: number;
 		appliedConfigs?: Array<Record<string, unknown>>;
@@ -369,8 +369,9 @@ export async function reconcileInterruptedDeploymentHistories(
 			return { status: "FAILED", message };
 		}
 		return {
-			status: "PARTIAL_SUCCESS",
-			message,
+			status: "UNCERTAIN",
+			message:
+				"The application restarted after upstream changes were applied but before deployment authority could be finalized. Resolve or roll back this deployment before making further changes.",
 			appliedCFCount: appliedCustomFormats.length,
 			appliedConfigs,
 		};

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -503,7 +503,12 @@ export class DeploymentPreviewService {
 		if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
 		const connectionBindings = aliases
 			.filter((alias) => equivalentInstanceIds.includes(alias.id))
-			.flatMap(createDeploymentConnectionBindingCandidates);
+			.flatMap((alias) =>
+				createDeploymentConnectionBindingCandidates(
+					alias,
+					createCredentialIdentity(this.clientFactory, alias),
+				),
+			);
 		const qualityProfileMappings = await this.prisma.templateQualityProfileMapping.findMany({
 			where: { instanceId: { in: equivalentInstanceIds } },
 			orderBy: { updatedAt: "desc" },
@@ -574,12 +579,14 @@ export class DeploymentPreviewService {
 			});
 			for (const override of savedOverrides) {
 				const currentOverride = isCurrentDeploymentConnectionMapping(override, connectionBindings);
-				if (
-					!currentOverride &&
-					!(selectedMappingIsLegacy && isLegacyDeploymentConnectionMapping(override))
-				) {
+				const liveScore = targetProfile.formatItems?.find(
+					(item: { format?: number; score?: number }) => item.format === override.customFormatId,
+				)?.score;
+				const verifiedLegacyOverride =
+					isLegacyDeploymentConnectionMapping(override) && liveScore === override.score;
+				if (!currentOverride && !verifiedLegacyOverride) {
 					throw new AppValidationError(
-						"This ARR endpoint has a saved score override bound to an older connection. Reconcile the stale override before deploying.",
+						"This ARR endpoint has an unverified saved score override. Restore its recorded score on the current profile or remove the override before deploying.",
 					);
 				}
 				const existingScore = savedScoreOverrides.get(override.customFormatId);

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -33,8 +33,10 @@ import {
 import { prepareNamingDeployment } from "./deployment-naming-state.js";
 import {
 	assertDeploymentTargetOwnership,
+	assertEquivalentDeploymentMappingAuthority,
 	createDeploymentConnectionBindingCandidates,
 	createDeploymentConnectionStateToken,
+	createDeploymentMappingAuthorityState,
 	createDeploymentStateToken,
 	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
@@ -532,6 +534,7 @@ export class DeploymentPreviewService {
 				"This template has conflicting quality-profile mappings for duplicate records of the same ARR instance. Unlink the stale deployment before continuing.",
 			);
 		}
+		assertEquivalentDeploymentMappingAuthority(templateMappings);
 		const qualityProfileMapping =
 			templateMappings.find((mapping) => mapping.instanceId === instanceId) ?? templateMappings[0];
 		const selectedMappingIsLegacy = Boolean(
@@ -860,6 +863,7 @@ export class DeploymentPreviewService {
 				customFormats: instanceCustomFormats,
 				namingConfig: namingState?.currentConfig,
 				namingPayload: namingState?.mergedConfig,
+				mappingAuthority: createDeploymentMappingAuthorityState(templateMappings),
 				savedScoreOverrides: [...savedScoreOverrides.entries()].sort(
 					([left], [right]) => left - right,
 				),

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -11,8 +11,9 @@ import type {
 	CustomFormatSpecification,
 	DeploymentAction,
 	DeploymentPreview,
-	TrashConflictGroup,
+	NamingSelectedPresets,
 	TemplateCustomFormat,
+	TrashConflictGroup,
 	UnmatchedCustomFormat,
 } from "@arr/shared";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
@@ -22,7 +23,33 @@ import type { PrismaClient } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import { AppValidationError, InstanceNotFoundError, TemplateNotFoundError } from "../errors.js";
 import { createCacheManager } from "./cache-manager.js";
+import { buildCustomFormatIdentityIndex } from "./cf-field-utils.js";
 import { checkMutualExclusions } from "./conflict-checker.js";
+import {
+	type ManagedCustomFormatIdentity,
+	readPersistedManagedCustomFormatIdentities,
+	resolveOrphanedManagedCustomFormats,
+} from "./deployment-managed-format-state.js";
+import { prepareNamingDeployment } from "./deployment-naming-state.js";
+import {
+	assertDeploymentTargetOwnership,
+	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionStateToken,
+	createDeploymentStateToken,
+	getEquivalentServiceInstanceIds,
+	isCurrentDeploymentConnectionMapping,
+	isLegacyDeploymentConnectionMapping,
+	resolveDeploymentTarget,
+} from "./deployment-target.js";
+
+function createCredentialIdentity(
+	factory: ArrClientFactory,
+	instance: Parameters<ArrClientFactory["createConnectionCredentialIdentity"]>[0],
+): string {
+	return typeof factory.createConnectionCredentialIdentity === "function"
+		? factory.createConnectionCredentialIdentity(instance)
+		: createDeploymentConnectionStateToken(instance);
+}
 
 // SDK type aliases
 type SdkCustomFormat = Awaited<ReturnType<SonarrClient["customFormat"]["getAll"]>>[number];
@@ -59,9 +86,14 @@ interface InstanceOverridesMap {
  */
 interface ParsedTemplateConfig {
 	customFormats?: TemplateCustomFormat[];
+	completeQualityProfile?: {
+		sourceInstanceId?: string;
+		sourceProfileId?: number;
+	};
 	qualityProfile?: {
 		trash_score_set?: string;
 	};
+	namingSelection?: NamingSelectedPresets;
 }
 
 // ============================================================================
@@ -372,83 +404,243 @@ export class DeploymentPreviewService {
 					scoreOverride: effectiveScore,
 				};
 			});
+		const warnings: string[] = [];
+
+		if (!instanceReachable) {
+			const deploymentItems: CustomFormatDeploymentItem[] = templateCFs.map((cf) => ({
+				trashId: cf.trashId,
+				name: cf.name,
+				action: "skip",
+				defaultScore: cf.defaultScore,
+				instanceOverrideScore: cf.instanceOverrideScore,
+				scoreOverride: cf.scoreOverride,
+				templateData: cf.originalConfig,
+				conflicts: [],
+				hasConflicts: false,
+			}));
+			return {
+				templateId,
+				templateName: template.name,
+				instanceId,
+				instanceLabel: instance.label,
+				instanceServiceType: instance.service.toUpperCase() as "RADARR" | "SONARR",
+				summary: {
+					totalItems: deploymentItems.length,
+					newCustomFormats: 0,
+					updatedCustomFormats: 0,
+					deletedCustomFormats: 0,
+					skippedCustomFormats: skipCount + deploymentItems.length,
+					totalConflicts: 0,
+					unresolvedConflicts: 0,
+					unmatchedCustomFormats: 0,
+					orphanedCustomFormats: 0,
+				},
+				customFormats: deploymentItems,
+				unmatchedCustomFormats: [],
+				orphanedCustomFormats: [],
+				canDeploy: false,
+				requiresConflictResolution: false,
+				instanceReachable: false,
+				instanceVersion,
+				executionToken: "",
+				warnings: ["Instance is unreachable. Verify the service connection before deploying."],
+			};
+		}
+
+		const namingState = templateConfig.namingSelection
+			? await prepareNamingDeployment(
+					this.prisma,
+					this.clientFactory,
+					instance,
+					templateConfig.namingSelection,
+				)
+			: undefined;
+		if (namingState?.changedFields.length) {
+			warnings.push(`Naming settings will update: ${namingState.changedFields.join(", ")}.`);
+		}
 
 		// Build instance CF maps for matching
 		// We need both trashId-based matching (ideal) and name-based matching (fallback)
 		// since Radarr doesn't natively store trash_id
-		const instanceCFByTrashId = new Map<string, SdkCustomFormat>();
-		const instanceCFByName = new Map<string, SdkCustomFormat>();
-
-		for (const instanceCF of instanceCustomFormats) {
-			// Try to extract trash_id from specifications (rare - Radarr doesn't store this)
-			const trashId = this.extractTrashIdFromSpecs(instanceCF);
-			if (trashId) {
-				instanceCFByTrashId.set(trashId, instanceCF);
-			}
-			// Always map by name for fallback matching
-			if (instanceCF.name) {
-				instanceCFByName.set(instanceCF.name, instanceCF);
-			}
+		const customFormatIndex = buildCustomFormatIdentityIndex(instanceCustomFormats);
+		if (customFormatIndex.collisions.length > 0) {
+			throw new AppValidationError(
+				`ARR returned ambiguous Custom Format identities (${customFormatIndex.collisions.join(", ")}). Resolve the duplicates before previewing this deployment.`,
+			);
 		}
-
-		// Initialize warnings array early so we can add warnings during profile matching
-		const warnings: string[] = [];
+		const instanceCFByTrashId = customFormatIndex.byTrashId;
+		const instanceCFByName = customFormatIndex.byName;
 
 		// Build map of CF scores from the target quality profile in the instance
 		// This allows us to detect score conflicts (when instance score differs from template)
 		// Prefer matching by quality profile ID from mapping, fall back to name-based matching
 		const instanceCFScoreMap = new Map<number, number>(); // CF ID -> score
 		let targetProfile: (typeof instanceQualityProfiles)[0] | undefined;
-
-		// Strategy 1: Try to find quality profile by ID from TemplateQualityProfileMapping
-		// This is the most reliable method as it uses the actual instance profile ID
-		const qualityProfileMapping = await this.prisma.templateQualityProfileMapping.findFirst({
-			where: {
-				templateId,
-				instanceId,
+		const serviceAliases = await this.prisma.serviceInstance.findMany({
+			where: { userId, service: instance.service },
+			select: {
+				id: true,
+				service: true,
+				baseUrl: true,
+				encryptedApiKey: true,
+				encryptionIv: true,
+				encryptedHttpAuthCredentials: true,
+				httpAuthEncryptionIv: true,
+				connectionGeneration: true,
 			},
+		});
+		const aliases = serviceAliases.some((alias) => alias.id === instance.id)
+			? serviceAliases
+			: [...serviceAliases, instance];
+		const credentialIdentity = createCredentialIdentity(this.clientFactory, instance);
+		const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+			aliases.map((alias) => ({
+				...alias,
+				credentialIdentity: createCredentialIdentity(this.clientFactory, alias),
+			})),
+			{ ...instance, credentialIdentity },
+		);
+		if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
+		const connectionBindings = aliases
+			.filter((alias) => equivalentInstanceIds.includes(alias.id))
+			.flatMap(createDeploymentConnectionBindingCandidates);
+		const qualityProfileMappings = await this.prisma.templateQualityProfileMapping.findMany({
+			where: { instanceId: { in: equivalentInstanceIds } },
 			orderBy: { updatedAt: "desc" },
 		});
-
-		if (qualityProfileMapping) {
-			targetProfile = instanceQualityProfiles.find(
-				(p) => p.id === qualityProfileMapping.qualityProfileId,
+		if (
+			qualityProfileMappings.some(
+				(mapping) =>
+					!isLegacyDeploymentConnectionMapping(mapping) &&
+					!isCurrentDeploymentConnectionMapping(mapping, connectionBindings),
+			)
+		) {
+			throw new AppValidationError(
+				"This ARR endpoint has a deployment mapping bound to an older connection. Unlink or reconcile the stale mapping before previewing another deployment.",
 			);
-			if (targetProfile) {
-				// Successfully matched by ID - this is the preferred method
-				for (const formatItem of targetProfile.formatItems || []) {
-					instanceCFScoreMap.set(formatItem.format, formatItem.score);
-				}
-			}
 		}
-
-		// Strategy 2: Fall back to name-based matching if ID-based matching failed
-		if (!targetProfile) {
-			// Try sourceQualityProfileName first (more reliable than template.name)
-			const profileNameToMatch =
-				template.sourceQualityProfileName || template.name || "TRaSH Guides HD/UHD";
-			targetProfile = instanceQualityProfiles.find((p) => p.name === profileNameToMatch);
-
-			if (targetProfile) {
-				// Profile recovered by name — ID changed (e.g., profile was recreated)
-				if (qualityProfileMapping) {
-					warnings.push(
-						`Quality profile "${qualityProfileMapping.qualityProfileName}" (ID: ${qualityProfileMapping.qualityProfileId}) was recreated in the instance (now ID: ${targetProfile.id}). The stored mapping will be updated on deploy.`,
-					);
-				} else {
-					warnings.push(
-						`Quality profile matched by name ("${profileNameToMatch}") rather than stored ID. Score conflict detection is based on name match.`,
-					);
-				}
-				for (const formatItem of targetProfile.formatItems || []) {
-					instanceCFScoreMap.set(formatItem.format, formatItem.score);
-				}
-			} else {
-				// No profile found at all — deployment will create the profile
-				warnings.push(
-					`Quality profile "${profileNameToMatch}" not found in instance. Deploying will create it with the template's quality settings and Custom Format scores.`,
+		const templateMappings = qualityProfileMappings.filter(
+			(mapping) => mapping.templateId === templateId,
+		);
+		if (new Set(templateMappings.map((mapping) => mapping.qualityProfileId)).size > 1) {
+			throw new AppValidationError(
+				"This template has conflicting quality-profile mappings for duplicate records of the same ARR instance. Unlink the stale deployment before continuing.",
+			);
+		}
+		const qualityProfileMapping =
+			templateMappings.find((mapping) => mapping.instanceId === instanceId) ?? templateMappings[0];
+		const selectedMappingIsLegacy = Boolean(
+			qualityProfileMapping && isLegacyDeploymentConnectionMapping(qualityProfileMapping),
+		);
+		if (selectedMappingIsLegacy) {
+			warnings.push(
+				"This 2.x deployment mapping is not yet bound to a verified ARR connection. Executing this exact preview will bind it to the current connection only after the reviewed deployment succeeds.",
+			);
+		}
+		const resolvedTarget = resolveDeploymentTarget({
+			profiles: instanceQualityProfiles,
+			mapping: qualityProfileMapping,
+			sourceProfileId: templateConfig.completeQualityProfile?.sourceProfileId,
+			isSourceInstance: equivalentInstanceIds.includes(
+				templateConfig.completeQualityProfile?.sourceInstanceId ?? "",
+			),
+			sourceProfileName: template.sourceQualityProfileName,
+			templateName: template.name,
+		});
+		assertDeploymentTargetOwnership({
+			target: resolvedTarget,
+			templateId,
+			existingMappings: qualityProfileMappings,
+		});
+		if (resolvedTarget.profile?.id !== undefined) {
+			const fullProfile = await client.qualityProfile.getById(resolvedTarget.profile.id);
+			if (fullProfile.id !== resolvedTarget.profile.id) {
+				throw new AppValidationError(
+					"The target quality profile identity changed while the preview was loading.",
 				);
 			}
+			resolvedTarget.profile = fullProfile;
+		}
+		targetProfile = resolvedTarget.profile;
+		const savedScoreOverrides = new Map<number, number>();
+		if (targetProfile?.id !== undefined) {
+			const savedOverrides = await this.prisma.instanceQualityProfileOverride.findMany({
+				where: {
+					userId,
+					status: "APPLIED",
+					qualityProfileId: targetProfile.id,
+					instanceId: { in: equivalentInstanceIds },
+				},
+			});
+			for (const override of savedOverrides) {
+				const currentOverride = isCurrentDeploymentConnectionMapping(override, connectionBindings);
+				if (
+					!currentOverride &&
+					!(selectedMappingIsLegacy && isLegacyDeploymentConnectionMapping(override))
+				) {
+					throw new AppValidationError(
+						"This ARR endpoint has a saved score override bound to an older connection. Reconcile the stale override before deploying.",
+					);
+				}
+				const existingScore = savedScoreOverrides.get(override.customFormatId);
+				if (existingScore !== undefined && existingScore !== override.score) {
+					throw new AppValidationError(
+						"Duplicate records for this ARR instance have conflicting saved Custom Format score overrides. Resolve the duplicate instance settings before deploying.",
+					);
+				}
+				savedScoreOverrides.set(override.customFormatId, override.score);
+			}
+		}
+		let previousManagedFormats: ManagedCustomFormatIdentity[];
+		try {
+			previousManagedFormats =
+				selectedMappingIsLegacy && !qualityProfileMapping?.managedCustomFormatsCaptured
+					? []
+					: readPersistedManagedCustomFormatIdentities(qualityProfileMapping);
+		} catch {
+			throw new AppValidationError(
+				"The previous deployment has invalid Custom Format identity metadata and cannot be previewed safely.",
+			);
+		}
+		const orphanResolution = await resolveOrphanedManagedCustomFormats(
+			client,
+			templateCFs,
+			previousManagedFormats,
+			resolvedTarget.profile,
+		);
+		warnings.push(...orphanResolution.warnings);
+		const currentProfileScores = new Map<number, number>(
+			(targetProfile?.formatItems ?? []).flatMap(
+				(item: { format?: number; score?: number }): Array<[number, number]> =>
+					typeof item.format === "number" && typeof item.score === "number"
+						? [[item.format, item.score]]
+						: [],
+			),
+		);
+		const orphanedCustomFormats = orphanResolution.formats.map((format) => ({
+			instanceId: format.resourceId,
+			name: format.name,
+			score:
+				currentProfileScores.get(format.resourceId) ??
+				savedScoreOverrides.get(format.resourceId) ??
+				0,
+		}));
+
+		if (targetProfile) {
+			if (resolvedTarget.matchedBy !== "mapping_id") {
+				warnings.push(
+					qualityProfileMapping
+						? `Quality profile "${qualityProfileMapping.qualityProfileName}" (ID: ${qualityProfileMapping.qualityProfileId}) was recovered as "${resolvedTarget.profileName}" (ID: ${targetProfile.id}). The stored mapping will be updated on deploy.`
+						: `Quality profile matched by name ("${resolvedTarget.profileName}") rather than stored ID. Score conflict detection is based on name match.`,
+				);
+			}
+			for (const formatItem of targetProfile.formatItems || []) {
+				instanceCFScoreMap.set(formatItem.format, formatItem.score);
+			}
+		} else {
+			warnings.push(
+				`Quality profile "${resolvedTarget.profileName}" not found in instance. Deploying will create it with the template's quality settings and Custom Format scores.`,
+			);
 		}
 
 		// Track which instance CFs are matched by template CFs
@@ -510,7 +702,10 @@ export class DeploymentPreviewService {
 				// score for this CF than what the template expects
 				if (instanceCF.id !== undefined && targetProfile) {
 					const instanceScore = instanceCFScoreMap.get(instanceCF.id);
-					const expectedScore = calculateExpectedScore(templateCF, scoreSet);
+					const expectedScore =
+						savedScoreOverrides.get(instanceCF.id) ??
+						templateCF.instanceOverrideScore ??
+						calculateExpectedScore(templateCF, scoreSet);
 
 					// Only flag as conflict if instance has a score AND it differs from template
 					// (instanceScore of 0 is valid and should be compared)
@@ -540,8 +735,14 @@ export class DeploymentPreviewService {
 				name: templateCF.name,
 				action,
 				defaultScore: templateCF.defaultScore,
-				instanceOverrideScore: templateCF.instanceOverrideScore,
-				scoreOverride: templateCF.scoreOverride ?? 0,
+				instanceOverrideScore:
+					instanceCF?.id !== undefined
+						? (savedScoreOverrides.get(instanceCF.id) ?? templateCF.instanceOverrideScore)
+						: templateCF.instanceOverrideScore,
+				scoreOverride:
+					instanceCF?.id !== undefined
+						? (savedScoreOverrides.get(instanceCF.id) ?? templateCF.scoreOverride ?? 0)
+						: (templateCF.scoreOverride ?? 0),
 				templateData: templateCF.originalConfig,
 				instanceData: instanceCF,
 				conflicts,
@@ -610,7 +811,7 @@ export class DeploymentPreviewService {
 			instanceServiceType: instance.service.toUpperCase() as "RADARR" | "SONARR",
 
 			summary: {
-				totalItems: deploymentItems.length,
+				totalItems: deploymentItems.length + orphanedCustomFormats.length,
 				newCustomFormats: newCount,
 				updatedCustomFormats: updateCount,
 				deletedCustomFormats: 0, // Not implementing deletion for safety
@@ -618,57 +819,53 @@ export class DeploymentPreviewService {
 				totalConflicts,
 				unresolvedConflicts,
 				unmatchedCustomFormats: unmatchedCFs.length,
+				orphanedCustomFormats: orphanedCustomFormats.length,
 			},
 
 			customFormats: deploymentItems,
 			unmatchedCustomFormats: unmatchedCFs,
+			orphanedCustomFormats,
 
 			canDeploy,
 			requiresConflictResolution,
 			instanceReachable,
 			instanceVersion,
+			executionToken: createDeploymentStateToken({
+				template: {
+					id: template.id,
+					name: template.name,
+					configData: template.configData,
+					instanceOverrides: template.instanceOverrides,
+					sourceQualityProfileName: template.sourceQualityProfileName,
+				},
+				instanceId,
+				connection: {
+					service: instance.service,
+					baseUrl: instance.baseUrl,
+					credentialIdentity: [
+						instance.encryptedApiKey,
+						instance.encryptionIv,
+						instance.encryptedHttpAuthCredentials,
+						instance.httpAuthEncryptionIv,
+					].join(":"),
+				},
+				target: resolvedTarget,
+				customFormats: instanceCustomFormats,
+				namingConfig: namingState?.currentConfig,
+				namingPayload: namingState?.mergedConfig,
+				savedScoreOverrides: [...savedScoreOverrides.entries()].sort(
+					([left], [right]) => left - right,
+				),
+				orphanedFormatScoreChanges: orphanedCustomFormats,
+			}),
+			namingChanges: namingState?.changedFields,
+			existingSyncStrategy: qualityProfileMapping?.syncStrategy as
+				| "auto"
+				| "manual"
+				| "notify"
+				| undefined,
 			warnings,
 		};
-	}
-
-	/**
-	 * Extract trash_id from Custom Format specifications only
-	 * Returns null if no trash_id found (Radarr doesn't natively store trash_id)
-	 * Name-based matching is handled separately in generatePreview
-	 */
-	private extractTrashIdFromSpecs(cf: SdkCustomFormat): string | null {
-		// Strategy 1: Check specifications for trash_id in fields
-		// TRaSH Guides may store metadata in specification fields (rare)
-		for (const spec of cf.specifications || []) {
-			if (spec.fields) {
-				// Handle both array format (Radarr API) and object format
-				if (Array.isArray(spec.fields)) {
-					const trashIdField = spec.fields.find((f) => f.name === "trash_id");
-					if (trashIdField) {
-						return String(trashIdField.value).toLowerCase();
-					}
-				} else if (typeof spec.fields === "object") {
-					// Check common field patterns for trash_id
-					const fields = spec.fields as Record<string, unknown>;
-					const trashIdValue = fields.trash_id || fields.trashId;
-					if (typeof trashIdValue === "string" && trashIdValue.length > 0) {
-						return trashIdValue.toLowerCase();
-					}
-				}
-			}
-		}
-
-		// Strategy 2: Check for TRaSH ID pattern in CF name
-		// TRaSH Guides CFs may have format: "CF Name [trash_id]" or similar
-		if (cf.name) {
-			const trashIdMatch = cf.name.match(/\[([a-f0-9-]{36})\]$/i);
-			if (trashIdMatch?.[1]) {
-				return trashIdMatch[1].toLowerCase();
-			}
-		}
-
-		// No trash_id found - name-based matching is handled separately
-		return null;
 	}
 }
 

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -265,6 +265,26 @@ export function createDeploymentEndpointKey(
 	return `${userId}:${instance.service.toUpperCase()}:${normalizeDeploymentBaseUrl(instance.baseUrl)}:${instance.credentialIdentity}`;
 }
 
+/** Accept pre-URL endpoint keys only when the exact connection token still matches. */
+export function isDeploymentBackupEndpointIdentityCurrent(args: {
+	userId: string;
+	backupEndpointKey: string;
+	backupConnectionStateToken: string;
+	instance: DeploymentConnectionInstance;
+	credentialIdentity: string;
+}): boolean {
+	if (args.backupConnectionStateToken !== createDeploymentConnectionStateToken(args.instance)) {
+		return false;
+	}
+	const currentKey = createDeploymentEndpointKey(args.userId, {
+		service: args.instance.service,
+		baseUrl: args.instance.baseUrl,
+		credentialIdentity: args.credentialIdentity,
+	});
+	const legacyKey = `${args.userId}:${args.instance.service.toUpperCase()}:${args.credentialIdentity}`;
+	return args.backupEndpointKey === currentKey || args.backupEndpointKey === legacyKey;
+}
+
 /** Bind rollback metadata to both the normalized endpoint and configured credentials. */
 export function createDeploymentConnectionStateToken(instance: {
 	service: string;

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -320,6 +320,19 @@ export function isLegacyDeploymentConnectionMapping(mapping: DeploymentConnectio
 	);
 }
 
+/** True only when a persisted mapping matches one freshly resolved connection binding. */
+export function isCurrentDeploymentConnectionMapping(
+	mapping: DeploymentConnectionMapping & { instanceId: string },
+	bindings: DeploymentConnectionBinding[],
+): boolean {
+	return bindings.some(
+		(binding) =>
+			binding.instanceId === mapping.instanceId &&
+			binding.connectionGeneration === mapping.connectionGeneration &&
+			binding.connectionStateToken === mapping.connectionStateToken,
+	);
+}
+
 export function assertNoLegacyDeploymentConnectionMappings(
 	mappings: DeploymentConnectionMapping[],
 ): void {

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -14,6 +14,17 @@ export interface DeploymentProfileMapping {
 	connectionStateToken: string | null;
 }
 
+interface DeploymentMappingAuthorityInput {
+	id?: string;
+	instanceId?: string;
+	qualityProfileId: number;
+	qualityProfileName: string;
+	syncStrategy?: string | null;
+	managedCustomFormatsCaptured?: boolean | null;
+	managedCustomFormats?: string | null;
+	updatedAt?: Date | string | null;
+}
+
 export interface DeploymentServiceInstance {
 	id: string;
 	service: string;
@@ -343,6 +354,56 @@ export function assertNoLegacyDeploymentConnectionMappings(
 	}
 }
 
+function deploymentMappingAuthorityValue(mapping: DeploymentMappingAuthorityInput) {
+	return {
+		qualityProfileId: mapping.qualityProfileId,
+		qualityProfileName: mapping.qualityProfileName,
+		syncStrategy: mapping.syncStrategy ?? null,
+		managedCustomFormatsCaptured: mapping.managedCustomFormatsCaptured ?? false,
+		managedCustomFormats: mapping.managedCustomFormats ?? null,
+	};
+}
+
+/** Fail closed when aliases disagree about the resources one template owns. */
+export function assertEquivalentDeploymentMappingAuthority(
+	mappings: DeploymentMappingAuthorityInput[],
+): void {
+	const expected = mappings[0];
+	if (!expected) return;
+	const expectedAuthority = JSON.stringify(stableValue(deploymentMappingAuthorityValue(expected)));
+	if (
+		mappings.some(
+			(mapping) =>
+				JSON.stringify(stableValue(deploymentMappingAuthorityValue(mapping))) !== expectedAuthority,
+		)
+	) {
+		throw new ConflictError(
+			"Equivalent ARR aliases have conflicting deployment authority. Reconcile the quality profile, sync strategy, and managed Custom Format snapshot before continuing.",
+		);
+	}
+}
+
+/** Canonical mapping state included in preview tokens to detect replacement or revocation. */
+export function createDeploymentMappingAuthorityState(
+	mappings: DeploymentMappingAuthorityInput[],
+): unknown[] {
+	return mappings
+		.map((mapping) => ({
+			id: mapping.id ?? null,
+			instanceId: mapping.instanceId ?? null,
+			...deploymentMappingAuthorityValue(mapping),
+			updatedAt:
+				mapping.updatedAt instanceof Date
+					? mapping.updatedAt.toISOString()
+					: (mapping.updatedAt ?? null),
+		}))
+		.sort((left, right) =>
+			`${left.instanceId ?? ""}:${left.id ?? ""}`.localeCompare(
+				`${right.instanceId ?? ""}:${right.id ?? ""}`,
+			),
+		);
+}
+
 /** Create an opaque fingerprint for the exact upstream state shown in preview. */
 export function createDeploymentStateToken(args: {
 	template: {
@@ -362,6 +423,7 @@ export function createDeploymentStateToken(args: {
 	customFormats: unknown[];
 	namingConfig?: unknown;
 	namingPayload?: unknown;
+	mappingAuthority?: unknown;
 	savedScoreOverrides?: unknown;
 	orphanedFormatScoreChanges?: unknown;
 }): string {
@@ -380,6 +442,7 @@ export function createDeploymentStateToken(args: {
 		customFormats: args.customFormats,
 		namingConfig: args.namingConfig ?? null,
 		namingPayload: args.namingPayload ?? null,
+		mappingAuthority: args.mappingAuthority ?? null,
 		savedScoreOverrides: args.savedScoreOverrides ?? null,
 		orphanedFormatScoreChanges: args.orphanedFormatScoreChanges ?? null,
 	});

--- a/apps/api/src/lib/trash-guides/sync-engine.ts
+++ b/apps/api/src/lib/trash-guides/sync-engine.ts
@@ -7,11 +7,17 @@
 import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { PrismaClient } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
-import { ConflictError } from "../errors.js";
+import { AppValidationError, ConflictError } from "../errors.js";
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
 import { isDeploymentResultUncertain } from "./deployment-history-manager.js";
+import {
+	createDeploymentConnectionBindingCandidates,
+	getEquivalentServiceInstanceIds,
+	isCurrentDeploymentConnectionMapping,
+	isLegacyDeploymentConnectionMapping,
+} from "./deployment-target.js";
 import { getSyncMetrics } from "./sync-metrics.js";
 import type { TemplateUpdater } from "./template-updater.js";
 import { USER_CF_PREFIX } from "./user-cf-resolver.js";
@@ -184,17 +190,66 @@ export class SyncEngine {
 			return { valid: false, conflicts, errors, warnings };
 		}
 
-		// Check for quality profile mappings
-		const qualityProfileMappings = await this.prisma.templateQualityProfileMapping.findMany({
-			where: {
-				templateId: options.templateId,
-				instanceId: options.instanceId,
+		const serviceAliases = await this.prisma.serviceInstance.findMany({
+			where: { userId: options.userId, service: instance.service },
+			select: {
+				id: true,
+				service: true,
+				baseUrl: true,
+				encryptedApiKey: true,
+				encryptionIv: true,
+				encryptedHttpAuthCredentials: true,
+				httpAuthEncryptionIv: true,
+				connectionGeneration: true,
 			},
 		});
+		const aliases = serviceAliases.some((alias) => alias.id === instance.id)
+			? serviceAliases
+			: [...serviceAliases, instance];
+		const equivalentInstanceIds = getEquivalentServiceInstanceIds(aliases, instance);
+		if (!equivalentInstanceIds.includes(instance.id)) equivalentInstanceIds.push(instance.id);
+		const connectionBindings = aliases
+			.filter((alias) => equivalentInstanceIds.includes(alias.id))
+			.flatMap(createDeploymentConnectionBindingCandidates);
+		const allQualityProfileMappings = await this.prisma.templateQualityProfileMapping.findMany({
+			where: { instanceId: { in: equivalentInstanceIds } },
+		});
+		const staleMappings = allQualityProfileMappings.filter(
+			(mapping) =>
+				!isLegacyDeploymentConnectionMapping(mapping) &&
+				!isCurrentDeploymentConnectionMapping(mapping, connectionBindings),
+		);
+		if (staleMappings.length > 0) {
+			errors.push(
+				"Sync is blocked because this ARR endpoint has a deployment mapping bound to an older connection. Unlink or reconcile the stale mapping before continuing.",
+			);
+			return { valid: false, conflicts, errors, warnings };
+		}
+		const legacyMappings = allQualityProfileMappings.filter(isLegacyDeploymentConnectionMapping);
+		if (options.syncType === "SCHEDULED" && legacyMappings.length > 0) {
+			errors.push(
+				"Auto-sync is blocked because this ARR endpoint has a legacy deployment mapping. Run a manual sync to review and rebind it before enabling scheduled sync.",
+			);
+			return { valid: false, conflicts, errors, warnings };
+		}
+		const qualityProfileMappings = allQualityProfileMappings.filter(
+			(mapping) =>
+				mapping.templateId === options.templateId &&
+				(options.syncType === "MANUAL" || !isLegacyDeploymentConnectionMapping(mapping)),
+		);
 
 		if (qualityProfileMappings.length === 0) {
 			errors.push(
 				"No quality profile mappings found. Please deploy this template to the instance first.",
+			);
+			return { valid: false, conflicts, errors, warnings };
+		}
+		if (
+			options.syncType === "SCHEDULED" &&
+			qualityProfileMappings.some((mapping) => mapping.syncStrategy !== "auto")
+		) {
+			errors.push(
+				"Auto-sync is blocked because this ARR endpoint no longer has auto enabled on every equivalent deployment mapping. Review and consolidate the deployment mappings first.",
 			);
 			return { valid: false, conflicts, errors, warnings };
 		}
@@ -420,7 +475,13 @@ export class SyncEngine {
 	async execute(
 		options: SyncOptions,
 		conflictResolutions?: Map<string, "REPLACE" | "SKIP">,
+		executionToken?: string,
 	): Promise<SyncResult> {
+		if (options.syncType === "MANUAL" && !executionToken) {
+			throw new AppValidationError(
+				"Manual sync requires a fresh validation token. Validate the sync again before executing.",
+			);
+		}
 		const startTime = Date.now();
 		const metrics = getSyncMetrics();
 		const completeMetrics = metrics.startOperation("sync");
@@ -454,18 +515,24 @@ export class SyncEngine {
 				errors: [],
 			});
 
-			if (!this.templateUpdater) {
-				throw new Error(
-					"Template sync cannot proceed: templateUpdater dependency is not configured. " +
-						"Ensure SyncEngine is instantiated with a TemplateUpdater instance.",
-				);
-			}
+			if (options.syncType === "SCHEDULED") {
+				if (!this.templateUpdater) {
+					throw new Error(
+						"Template sync cannot proceed: templateUpdater dependency is not configured. " +
+							"Ensure SyncEngine is instantiated with a TemplateUpdater instance.",
+					);
+				}
 
-			const syncResult = await this.templateUpdater.syncTemplate(options.templateId);
-			if (!syncResult.success) {
-				throw new Error(
-					`Template sync failed: ${syncResult.errors?.join(", ") || "Unknown error"}`,
+				const syncResult = await this.templateUpdater.syncTemplate(
+					options.templateId,
+					undefined,
+					options.userId,
 				);
+				if (!syncResult.success) {
+					throw new Error(
+						`Template sync failed: ${syncResult.errors?.join(", ") || "Unknown error"}`,
+					);
+				}
 			}
 
 			// Step 2: Deploy to instance using deployment executor
@@ -498,14 +565,24 @@ export class SyncEngine {
 				: undefined;
 
 			deploymentAttempted = true;
-			const deployResult = await this.deploymentExecutor.deploySingleInstance(
-				options.templateId,
-				options.instanceId,
-				options.userId,
-				undefined, // syncStrategy - not used in sync engine
-				deploymentConflictResolutions,
-				syncId,
-			);
+			const deployResult =
+				options.syncType === "SCHEDULED"
+					? await this.deploymentExecutor.deploySingleInstanceFromAutomation(
+							options.templateId,
+							options.instanceId,
+							options.userId,
+							deploymentConflictResolutions,
+							syncId,
+						)
+					: await this.deploymentExecutor.deploySingleInstance(
+							options.templateId,
+							options.instanceId,
+							options.userId,
+							undefined,
+							deploymentConflictResolutions,
+							executionToken,
+							syncId,
+						);
 
 			// Calculate duration and status
 			const duration = Math.floor((Date.now() - startTime) / 1000);

--- a/apps/api/src/lib/trash-guides/sync-engine.ts
+++ b/apps/api/src/lib/trash-guides/sync-engine.ts
@@ -14,6 +14,7 @@ import type { DeploymentExecutorService } from "./deployment-executor.js";
 import { isDeploymentResultUncertain } from "./deployment-history-manager.js";
 import {
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionStateToken,
 	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
 	isLegacyDeploymentConnectionMapping,
@@ -206,11 +207,29 @@ export class SyncEngine {
 		const aliases = serviceAliases.some((alias) => alias.id === instance.id)
 			? serviceAliases
 			: [...serviceAliases, instance];
-		const equivalentInstanceIds = getEquivalentServiceInstanceIds(aliases, instance);
+		const aliasesWithCredentials = aliases.map((alias) => ({
+			...alias,
+			credentialIdentity:
+				typeof this.arrClientFactory?.createConnectionCredentialIdentity === "function"
+					? this.arrClientFactory.createConnectionCredentialIdentity(alias)
+					: createDeploymentConnectionStateToken(alias),
+		}));
+		const instanceWithCredential = aliasesWithCredentials.find(
+			(alias) => alias.id === instance.id,
+		) ?? {
+			...instance,
+			credentialIdentity: createDeploymentConnectionStateToken(instance),
+		};
+		const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+			aliasesWithCredentials,
+			instanceWithCredential,
+		);
 		if (!equivalentInstanceIds.includes(instance.id)) equivalentInstanceIds.push(instance.id);
-		const connectionBindings = aliases
+		const connectionBindings = aliasesWithCredentials
 			.filter((alias) => equivalentInstanceIds.includes(alias.id))
-			.flatMap(createDeploymentConnectionBindingCandidates);
+			.flatMap((alias) =>
+				createDeploymentConnectionBindingCandidates(alias, alias.credentialIdentity),
+			);
 		const allQualityProfileMappings = await this.prisma.templateQualityProfileMapping.findMany({
 			where: { instanceId: { in: equivalentInstanceIds } },
 		});

--- a/apps/api/src/lib/trash-guides/sync-engine.ts
+++ b/apps/api/src/lib/trash-guides/sync-engine.ts
@@ -690,7 +690,8 @@ export class SyncEngine {
 			// Emit completion
 			this.emitProgress({
 				syncId,
-				status: status === "UNCERTAIN" ? "UNCERTAIN" : "COMPLETED",
+				status:
+					status === "SUCCESS" ? "COMPLETED" : status === "UNCERTAIN" ? "UNCERTAIN" : "FAILED",
 				currentStep: resultSuccess
 					? warnings.length
 						? "Sync completed with warnings"

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -27,7 +27,10 @@ import { TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
 import { CacheCorruptionError, type TrashCacheManager } from "./cache-manager.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
-import { createDeploymentConnectionBindingCandidates } from "./deployment-target.js";
+import {
+	assertEquivalentDeploymentMappingAuthority,
+	createDeploymentConnectionBindingCandidates,
+} from "./deployment-target.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
 import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
 
@@ -63,6 +66,7 @@ interface AutomationDeploymentOutcome {
 	instanceId: string;
 	instanceLabel: string;
 	success: boolean;
+	status: "SUCCESS" | "FAILED" | "UNCERTAIN";
 	errors: string[];
 }
 
@@ -751,6 +755,8 @@ export class TemplateUpdater {
 		processed: number;
 		successful: number;
 		failed: number;
+		uncertain: number;
+		uncertainDeployments: AutomationDeploymentOutcome[];
 		results: SyncResult[];
 		skippedForApproval: number;
 		templatesWithScoreConflicts: number;
@@ -766,6 +772,8 @@ export class TemplateUpdater {
 		const results: SyncResult[] = [];
 		let successful = 0;
 		let failed = 0;
+		let uncertain = 0;
+		const uncertainDeployments: AutomationDeploymentOutcome[] = [];
 		let templatesWithScoreConflicts = 0;
 
 		for (const template of autoSyncTemplates) {
@@ -788,7 +796,16 @@ export class TemplateUpdater {
 
 				try {
 					const deploymentOutcomes = await this.deployToMappedInstances(template.templateId);
-					const failedDeployments = deploymentOutcomes.filter((outcome) => !outcome.success);
+					const failedDeployments = deploymentOutcomes.filter(
+						(outcome) => outcome.status === "FAILED",
+					);
+					const uncertainOutcomes = deploymentOutcomes.filter(
+						(outcome) => outcome.status === "UNCERTAIN",
+					);
+					if (uncertainOutcomes.length > 0) {
+						uncertain++;
+						uncertainDeployments.push(...uncertainOutcomes);
+					}
 					if (failedDeployments.length > 0) {
 						const deploymentErrors = failedDeployments.flatMap((outcome) =>
 							outcome.errors.length > 0
@@ -796,8 +813,18 @@ export class TemplateUpdater {
 								: [`Auto-deploy to "${outcome.instanceLabel}" failed without an error message.`],
 						);
 						result.success = false;
-						result.errors = [...(result.errors ?? []), ...deploymentErrors];
+						result.errors = [
+							...(result.errors ?? []),
+							...deploymentErrors,
+							...uncertainOutcomes.flatMap((outcome) => outcome.errors),
+						];
 						failed++;
+					} else if (uncertainOutcomes.length > 0) {
+						result.success = false;
+						result.errors = [
+							...(result.errors ?? []),
+							...uncertainOutcomes.flatMap((outcome) => outcome.errors),
+						];
 					} else {
 						successful++;
 					}
@@ -822,6 +849,8 @@ export class TemplateUpdater {
 			processed: autoSyncTemplates.length,
 			successful,
 			failed,
+			uncertain,
+			uncertainDeployments,
 			results,
 			skippedForApproval,
 			templatesWithScoreConflicts,
@@ -905,7 +934,7 @@ export class TemplateUpdater {
 					},
 					"Auto-deploy blocked for endpoint with a stale or legacy ARR mapping",
 				);
-				outcomes.push({ ...outcomeTarget, success: false, errors: [error] });
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [error] });
 				continue;
 			}
 			if (new Set(endpointGroup.map((mapping) => mapping.qualityProfileId)).size > 1) {
@@ -918,7 +947,18 @@ export class TemplateUpdater {
 					},
 					"Auto-deploy blocked by conflicting alias mappings for one ARR endpoint",
 				);
-				outcomes.push({ ...outcomeTarget, success: false, errors: [error] });
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [error] });
+				continue;
+			}
+			try {
+				assertEquivalentDeploymentMappingAuthority(endpointGroup);
+			} catch (error) {
+				const message = `Auto-deploy to "${mapping.instance.label}" blocked: ${getErrorMessage(error)}`;
+				log.error(
+					{ err: error, templateId, endpointKey },
+					"Auto-deploy blocked by conflicting alias deployment authority",
+				);
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [message] });
 				continue;
 			}
 			if (endpointGroup.length > 1) {
@@ -938,7 +978,21 @@ export class TemplateUpdater {
 					template.userId,
 				);
 
-				if (!result.success) {
+				if (result.status === "UNCERTAIN") {
+					const errors =
+						result.errors.length > 0
+							? result.errors.map(
+									(error) => `Auto-deploy to "${mapping.instance.label}" needs review: ${error}`,
+								)
+							: [
+									`Auto-deploy to "${mapping.instance.label}" needs review because ARR may have applied changes that could not be verified.`,
+								];
+					log.warn(
+						{ templateId, instanceLabel: mapping.instance.label, errors: result.errors },
+						"Auto-deploy result is uncertain and requires reconciliation",
+					);
+					outcomes.push({ ...outcomeTarget, success: false, status: "UNCERTAIN", errors });
+				} else if (!result.success) {
 					const errors =
 						result.errors.length > 0
 							? result.errors.map(
@@ -954,9 +1008,9 @@ export class TemplateUpdater {
 						},
 						"Failed to auto-deploy template to instance",
 					);
-					outcomes.push({ ...outcomeTarget, success: false, errors });
+					outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors });
 				} else {
-					outcomes.push({ ...outcomeTarget, success: true, errors: [] });
+					outcomes.push({ ...outcomeTarget, success: true, status: "SUCCESS", errors: [] });
 				}
 			} catch (error) {
 				const message = `Auto-deploy to "${mapping.instance.label}" failed: ${getErrorMessage(error)}`;
@@ -964,7 +1018,7 @@ export class TemplateUpdater {
 					{ err: error, templateId, templateName: template.name, instanceId: mapping.instanceId },
 					"Error auto-deploying template to instance",
 				);
-				outcomes.push({ ...outcomeTarget, success: false, errors: [message] });
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [message] });
 			}
 		}
 

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -27,10 +27,7 @@ import { TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
 import { CacheCorruptionError, type TrashCacheManager } from "./cache-manager.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
-import {
-	createDeploymentConnectionBindingCandidates,
-	createDeploymentEndpointKey,
-} from "./deployment-target.js";
+import { createDeploymentConnectionBindingCandidates } from "./deployment-target.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
 import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
 
@@ -867,7 +864,10 @@ export class TemplateUpdater {
 
 		const endpointMappings = new Map<string, typeof candidateMappings>();
 		for (const mapping of candidateMappings) {
-			const endpointKey = createDeploymentEndpointKey(template.userId, mapping.instance);
+			const endpointKey = this.deploymentExecutor.createEndpointMutationKey(
+				template.userId,
+				mapping.instance,
+			);
 			const grouped = endpointMappings.get(endpointKey) ?? [];
 			grouped.push(mapping);
 			endpointMappings.set(endpointKey, grouped);

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -30,6 +30,7 @@ import type { DeploymentExecutorService } from "./deployment-executor.js";
 import {
 	assertEquivalentDeploymentMappingAuthority,
 	createDeploymentConnectionBindingCandidates,
+	createUpstreamResourceStateToken,
 } from "./deployment-target.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
 import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
@@ -870,7 +871,7 @@ export class TemplateUpdater {
 
 		const template = await this.prisma.trashTemplate.findUnique({
 			where: { id: templateId },
-			select: { userId: true, name: true },
+			select: { userId: true, name: true, instanceOverrides: true },
 		});
 
 		if (!template) {
@@ -889,6 +890,19 @@ export class TemplateUpdater {
 		});
 		if (candidateMappings.length === 0) {
 			return [];
+		}
+
+		let instanceOverrides: Record<string, unknown> = {};
+		let instanceOverridesError: string | undefined;
+		try {
+			const parsed = template.instanceOverrides ? JSON.parse(template.instanceOverrides) : {};
+			if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+				throw new Error("instance overrides must be an object");
+			}
+			instanceOverrides = parsed as Record<string, unknown>;
+		} catch (error) {
+			instanceOverridesError = `Automatic deployment blocked because the template's instance overrides could not be validated: ${getErrorMessage(error)}`;
+			log.error({ err: error, templateId }, "Auto-deploy blocked by invalid instance overrides");
 		}
 
 		const endpointMappings = new Map<string, typeof candidateMappings>();
@@ -914,6 +928,15 @@ export class TemplateUpdater {
 				instanceId: mapping.instanceId,
 				instanceLabel: mapping.instance.label,
 			};
+			if (instanceOverridesError) {
+				outcomes.push({
+					...outcomeTarget,
+					success: false,
+					status: "FAILED",
+					errors: [instanceOverridesError],
+				});
+				continue;
+			}
 			const staleMappings = endpointGroup.filter(
 				(candidate) =>
 					!createDeploymentConnectionBindingCandidates(candidate.instance).some(
@@ -946,6 +969,38 @@ export class TemplateUpdater {
 						mappingIds: endpointGroup.map((mapping) => mapping.id),
 					},
 					"Auto-deploy blocked by conflicting alias mappings for one ARR endpoint",
+				);
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [error] });
+				continue;
+			}
+			const invalidOverrideMapping = endpointGroup.find((candidate) => {
+				const value = instanceOverrides[candidate.instanceId];
+				return (
+					value !== undefined &&
+					value !== null &&
+					(typeof value !== "object" || Array.isArray(value))
+				);
+			});
+			if (invalidOverrideMapping) {
+				const error = `Auto-deploy to "${mapping.instance.label}" blocked: instance overrides for ARR alias "${invalidOverrideMapping.instance.label}" are invalid. Review and save the template overrides before continuing.`;
+				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [error] });
+				continue;
+			}
+			const aliasOverrides = endpointGroup.map(
+				(candidate) => instanceOverrides[candidate.instanceId] ?? {},
+			);
+			const overrideStates = new Set(
+				aliasOverrides.map((value) => createUpstreamResourceStateToken(value)),
+			);
+			if (overrideStates.size > 1) {
+				const error = `Auto-deploy to "${mapping.instance.label}" blocked: equivalent ARR aliases have conflicting instance overrides. Reconcile the per-instance Custom Format and quality settings before continuing.`;
+				log.error(
+					{
+						templateId,
+						endpointKey,
+						mappingIds: endpointGroup.map((candidate) => candidate.id),
+					},
+					"Auto-deploy blocked by conflicting alias instance overrides",
 				);
 				outcomes.push({ ...outcomeTarget, success: false, status: "FAILED", errors: [error] });
 				continue;

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -27,6 +27,10 @@ import { TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
 import { CacheCorruptionError, type TrashCacheManager } from "./cache-manager.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
+import {
+	createDeploymentConnectionBindingCandidates,
+	createDeploymentEndpointKey,
+} from "./deployment-target.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
 import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
 
@@ -56,6 +60,14 @@ import type {
 	TemplateUpdateInfo,
 	UpdateCheckResult,
 } from "./template-updater-types.js";
+
+interface AutomationDeploymentOutcome {
+	endpointKey: string;
+	instanceId: string;
+	instanceLabel: string;
+	success: boolean;
+	errors: string[];
+}
 
 // ============================================================================
 // Template Updater Class
@@ -773,23 +785,36 @@ export class TemplateUpdater {
 			results.push(result);
 
 			if (result.success) {
-				successful++;
-
 				if (result.scoreConflicts && result.scoreConflicts.length > 0) {
 					templatesWithScoreConflicts++;
 				}
 
 				try {
-					await this.deployToMappedInstances(template.templateId);
+					const deploymentOutcomes = await this.deployToMappedInstances(template.templateId);
+					const failedDeployments = deploymentOutcomes.filter((outcome) => !outcome.success);
+					if (failedDeployments.length > 0) {
+						const deploymentErrors = failedDeployments.flatMap((outcome) =>
+							outcome.errors.length > 0
+								? outcome.errors
+								: [`Auto-deploy to "${outcome.instanceLabel}" failed without an error message.`],
+						);
+						result.success = false;
+						result.errors = [...(result.errors ?? []), ...deploymentErrors];
+						failed++;
+					} else {
+						successful++;
+					}
 				} catch (error) {
 					log.error(
 						{ err: error, templateId: template.templateId },
 						"Auto-deploy failed for template",
 					);
-					if (!result.errors) {
-						result.errors = [];
-					}
-					result.errors.push(`Auto-deploy failed: ${getErrorMessage(error)}`);
+					result.success = false;
+					result.errors = [
+						...(result.errors ?? []),
+						`Auto-deploy failed before endpoint execution: ${getErrorMessage(error)}`,
+					];
+					failed++;
 				}
 			} else {
 				failed++;
@@ -810,9 +835,11 @@ export class TemplateUpdater {
 	 * Deploy template to all mapped instances
 	 * @private
 	 */
-	private async deployToMappedInstances(templateId: string): Promise<void> {
+	private async deployToMappedInstances(
+		templateId: string,
+	): Promise<AutomationDeploymentOutcome[]> {
 		if (!this.deploymentExecutor) {
-			return;
+			return [];
 		}
 
 		const template = await this.prisma.trashTemplate.findUnique({
@@ -822,10 +849,10 @@ export class TemplateUpdater {
 
 		if (!template) {
 			log.error({ templateId }, "Cannot auto-deploy: template not found");
-			return;
+			return [];
 		}
 
-		const mappings = await this.prisma.templateQualityProfileMapping.findMany({
+		const candidateMappings = await this.prisma.templateQualityProfileMapping.findMany({
 			where: {
 				templateId,
 				syncStrategy: "auto",
@@ -834,20 +861,90 @@ export class TemplateUpdater {
 				instance: true,
 			},
 		});
-
-		if (mappings.length === 0) {
-			return;
+		if (candidateMappings.length === 0) {
+			return [];
 		}
 
-		for (const mapping of mappings) {
+		const endpointMappings = new Map<string, typeof candidateMappings>();
+		for (const mapping of candidateMappings) {
+			const endpointKey = createDeploymentEndpointKey(template.userId, mapping.instance);
+			const grouped = endpointMappings.get(endpointKey) ?? [];
+			grouped.push(mapping);
+			endpointMappings.set(endpointKey, grouped);
+		}
+
+		const outcomes: AutomationDeploymentOutcome[] = [];
+		for (const [endpointKey, endpointGroup] of [...endpointMappings.entries()].sort(
+			([left], [right]) => left.localeCompare(right),
+		)) {
+			const mapping = [...endpointGroup].sort((left, right) =>
+				left.instanceId.localeCompare(right.instanceId),
+			)[0]!;
+			const outcomeTarget = {
+				endpointKey,
+				instanceId: mapping.instanceId,
+				instanceLabel: mapping.instance.label,
+			};
+			const staleMappings = endpointGroup.filter(
+				(candidate) =>
+					!createDeploymentConnectionBindingCandidates(candidate.instance).some(
+						(binding) =>
+							binding.instanceId === candidate.instanceId &&
+							binding.connectionGeneration === candidate.connectionGeneration &&
+							binding.connectionStateToken === candidate.connectionStateToken,
+					),
+			);
+			if (staleMappings.length > 0) {
+				const error = `Auto-deploy to "${mapping.instance.label}" blocked: one or more mappings use a stale or legacy ARR connection binding. Unlink the stale deployment mapping and review a fresh preview.`;
+				log.warn(
+					{
+						templateId,
+						endpointKey,
+						mappingIds: endpointGroup.map((candidate) => candidate.id),
+						staleMappingIds: staleMappings.map((candidate) => candidate.id),
+					},
+					"Auto-deploy blocked for endpoint with a stale or legacy ARR mapping",
+				);
+				outcomes.push({ ...outcomeTarget, success: false, errors: [error] });
+				continue;
+			}
+			if (new Set(endpointGroup.map((mapping) => mapping.qualityProfileId)).size > 1) {
+				const error = `Auto-deploy to "${mapping.instance.label}" blocked: equivalent ARR aliases have conflicting quality profile mappings. Unlink the conflicting deployment mapping and review a fresh preview.`;
+				log.error(
+					{
+						templateId,
+						endpointKey,
+						mappingIds: endpointGroup.map((mapping) => mapping.id),
+					},
+					"Auto-deploy blocked by conflicting alias mappings for one ARR endpoint",
+				);
+				outcomes.push({ ...outcomeTarget, success: false, errors: [error] });
+				continue;
+			}
+			if (endpointGroup.length > 1) {
+				log.info(
+					{
+						templateId,
+						instanceId: mapping.instanceId,
+						deduplicatedMappingIds: endpointGroup.map((candidate) => candidate.id),
+					},
+					"Auto-deploy consolidated equivalent ARR instance mappings",
+				);
+			}
 			try {
-				const result = await this.deploymentExecutor.deploySingleInstance(
+				const result = await this.deploymentExecutor.deploySingleInstanceFromAutomation(
 					templateId,
 					mapping.instanceId,
 					template.userId,
 				);
 
 				if (!result.success) {
+					const errors =
+						result.errors.length > 0
+							? result.errors.map(
+									(error) => `Auto-deploy to "${mapping.instance.label}" failed: ${error}`,
+								)
+							: [`Auto-deploy to "${mapping.instance.label}" failed without an error message.`];
 					log.error(
 						{
 							templateId,
@@ -857,15 +954,21 @@ export class TemplateUpdater {
 						},
 						"Failed to auto-deploy template to instance",
 					);
+					outcomes.push({ ...outcomeTarget, success: false, errors });
+				} else {
+					outcomes.push({ ...outcomeTarget, success: true, errors: [] });
 				}
 			} catch (error) {
+				const message = `Auto-deploy to "${mapping.instance.label}" failed: ${getErrorMessage(error)}`;
 				log.error(
 					{ err: error, templateId, templateName: template.name, instanceId: mapping.instanceId },
 					"Error auto-deploying template to instance",
 				);
-				throw error;
+				outcomes.push({ ...outcomeTarget, success: false, errors: [message] });
 			}
 		}
+
+		return outcomes;
 	}
 
 	/**

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -8,6 +8,7 @@
 import { createHash } from "node:crypto";
 import {
 	type NamingSelectedPresets,
+	type NotificationEventType,
 	TRASH_CONFIG_TYPES,
 	type TrashNamingData,
 	type TrashQualitySize,
@@ -62,6 +63,7 @@ export interface SchedulerStats {
 		templatesNeedingAttention: number;
 		templatesNeedingApproval: number; // Templates with CF Group additions needing user approval
 		templatesWithScoreConflicts: number; // Templates where score updates were skipped due to user overrides
+		templatesWithUncertainDeployments: number;
 		cachesRefreshed: number;
 		cachesFailed: number;
 		qualitySizeAutoSynced: number;
@@ -100,6 +102,7 @@ export class UpdateScheduler {
 	private deploymentExecutor?: import("./deployment-executor.js").DeploymentExecutorService;
 	private notifyFn?: (
 		payload: import("../notifications/types.js").NotificationPayload,
+		options?: { userId?: string; fallbackEventTypes?: NotificationEventType[] },
 	) => Promise<void>;
 	private trackTick: import("../scheduler-registry/scheduler-registry.js").TickWrapper;
 
@@ -115,6 +118,7 @@ export class UpdateScheduler {
 			deploymentExecutor?: import("./deployment-executor.js").DeploymentExecutorService;
 			notifyFn?: (
 				payload: import("../notifications/types.js").NotificationPayload,
+				options?: { userId?: string; fallbackEventTypes?: NotificationEventType[] },
 			) => Promise<void>;
 			trackTick?: import("../scheduler-registry/scheduler-registry.js").TickWrapper;
 		},
@@ -267,6 +271,7 @@ export class UpdateScheduler {
 		let templatesNeedingAttention = 0;
 		let templatesNeedingApproval = 0;
 		let templatesWithScoreConflicts = 0;
+		let templatesWithUncertainDeployments = 0;
 		let qualitySizeAutoSynced = 0;
 		let qualitySizeUpdatesPending = 0;
 		let namingAutoSynced = 0;
@@ -371,6 +376,25 @@ export class UpdateScheduler {
 					templatesAutoSynced += autoSyncResult.successful;
 					templatesNeedingApproval += autoSyncResult.skippedForApproval;
 					templatesWithScoreConflicts += autoSyncResult.templatesWithScoreConflicts;
+					templatesWithUncertainDeployments += autoSyncResult.uncertain;
+					for (const outcome of autoSyncResult.uncertainDeployments) {
+						this.notifyFn?.(
+							{
+								eventType: "TRASH_DEPLOY_UNCERTAIN",
+								title: `Automatic TRaSH deployment needs review on ${outcome.instanceLabel}`,
+								body: outcome.errors.join("; "),
+								url: "/trash-guides",
+								metadata: {
+									instanceId: outcome.instanceId,
+									endpointKey: outcome.endpointKey,
+									reason: "uncertain_result",
+								},
+							},
+							{ userId: user.id, fallbackEventTypes: ["TRASH_SYNC_ERROR"] },
+						).catch((err) => {
+							this.logger.debug({ err }, "Automatic deployment review notification failed");
+						});
+					}
 
 					if (autoSyncResult.failed > 0) {
 						const failedResults = autoSyncResult.results.filter((r: SyncResult) => !r.success);
@@ -418,6 +442,7 @@ export class UpdateScheduler {
 					templatesNeedingAttention: 0,
 					templatesNeedingApproval: 0,
 					templatesWithScoreConflicts: 0,
+					templatesWithUncertainDeployments: 0,
 					cachesRefreshed: totalCachesRefreshed,
 					cachesFailed: totalCacheFailed,
 					qualitySizeAutoSynced,
@@ -450,6 +475,7 @@ export class UpdateScheduler {
 				templatesNeedingAttention,
 				templatesNeedingApproval,
 				templatesWithScoreConflicts,
+				templatesWithUncertainDeployments,
 				cachesRefreshed: totalCachesRefreshed,
 				cachesFailed: totalCacheFailed,
 				qualitySizeAutoSynced,
@@ -500,6 +526,7 @@ export class UpdateScheduler {
 				templatesNeedingAttention: 0,
 				templatesNeedingApproval: 0,
 				templatesWithScoreConflicts: 0,
+				templatesWithUncertainDeployments: 0,
 				cachesRefreshed: 0,
 				cachesFailed: 0,
 				qualitySizeAutoSynced: 0,
@@ -984,7 +1011,10 @@ export function createUpdateScheduler(
 	options?: {
 		repoConfigResolver?: RepoConfigResolver;
 		deploymentExecutor?: import("./deployment-executor.js").DeploymentExecutorService;
-		notifyFn?: (payload: import("../notifications/types.js").NotificationPayload) => Promise<void>;
+		notifyFn?: (
+			payload: import("../notifications/types.js").NotificationPayload,
+			options?: { userId?: string; fallbackEventTypes?: NotificationEventType[] },
+		) => Promise<void>;
 		trackTick?: import("../scheduler-registry/scheduler-registry.js").TickWrapper;
 	},
 ): UpdateScheduler {

--- a/apps/api/src/plugins/trash-update-scheduler.ts
+++ b/apps/api/src/plugins/trash-update-scheduler.ts
@@ -86,7 +86,7 @@ const trashUpdateSchedulerPlugin = fastifyPlugin(
 						{
 							repoConfigResolver,
 							deploymentExecutor: app.deploymentExecutor,
-							notifyFn: (payload) => app.notificationService.notify(payload),
+							notifyFn: (payload, options) => app.notificationService.notify(payload, options),
 							trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.trashUpdate, fn),
 						},
 					);

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
@@ -1,0 +1,177 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+import { deploymentRoutes } from "../deployment-routes.js";
+
+function deferred() {
+	let resolve!: () => void;
+	const promise = new Promise<void>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+function createSerializedExecutor() {
+	let tail: Promise<void> = Promise.resolve();
+	const runWithEndpointMutation = vi.fn(
+		async <T>(
+			_userId: string,
+			_instance: unknown,
+			_operation: string,
+			action: () => Promise<T>,
+		) => {
+			const previous = tail;
+			const turn = deferred();
+			tail = previous.then(() => turn.promise);
+			await previous;
+			try {
+				return await action();
+			} finally {
+				turn.resolve();
+			}
+		},
+	);
+	return {
+		createEndpointMutationKey: vi.fn().mockReturnValue("user-1:RADARR:credential-1"),
+		runWithEndpointMutation,
+		deploySingleInstance: vi.fn(),
+		deployBulkInstances: vi.fn(),
+	};
+}
+
+const instance = {
+	id: "instance-1",
+	userId: "user-1",
+	label: "Radarr",
+	service: "RADARR",
+	baseUrl: "http://radarr:7878",
+	encryptedApiKey: "encrypted-key",
+	encryptionIv: "iv",
+	connectionGeneration: 2,
+};
+const mapping = {
+	id: "mapping-1",
+	templateId: "template-1",
+	instanceId: instance.id,
+	qualityProfileId: 4,
+	updatedAt: new Date("2026-08-09T10:00:00.000Z"),
+	instance,
+	template: { name: "Any", userId: "user-1" },
+};
+
+async function createApp(prisma: unknown, deploymentExecutor: unknown) {
+	const app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	app.decorate("prisma", prisma as never);
+	app.decorate("arrClientFactory", {} as never);
+	app.decorate("deploymentExecutor", deploymentExecutor as never);
+	await app.register(deploymentRoutes);
+	await app.ready();
+	return app;
+}
+
+describe("deployment authority writer locking", () => {
+	let app: FastifyInstance | undefined;
+
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it("changes sync strategy under the endpoint lock before automation can write", async () => {
+		const mutationStarted = deferred();
+		const releaseMutation = deferred();
+		let syncStrategy = "auto";
+		let upstreamWrites = 0;
+		const updateMany = vi.fn().mockImplementation(async () => {
+			syncStrategy = "notify";
+			mutationStarted.resolve();
+			await releaseMutation.promise;
+			return { count: 1 };
+		});
+		const prisma = {
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				updateMany,
+			},
+		};
+		const executor = createSerializedExecutor();
+		app = await createApp(prisma, executor);
+
+		const responsePromise = createInjectAuthenticated(app)("PATCH", "/sync-strategy", {
+			body: {
+				templateId: mapping.templateId,
+				instanceId: mapping.instanceId,
+				syncStrategy: "notify",
+			},
+		});
+		await mutationStarted.promise;
+		const automationPromise = executor.runWithEndpointMutation(
+			"user-1",
+			instance,
+			"Automatic deployment",
+			async () => {
+				if (syncStrategy === "auto") upstreamWrites += 1;
+			},
+		);
+
+		await vi.waitFor(() => expect(updateMany).toHaveBeenCalledOnce());
+		expect(upstreamWrites).toBe(0);
+		releaseMutation.resolve();
+
+		const response = await responsePromise;
+		await automationPromise;
+		expect(response.statusCode).toBe(200);
+		expect(upstreamWrites).toBe(0);
+	});
+
+	it("unlinks under the endpoint lock before automation can write", async () => {
+		const mutationStarted = deferred();
+		const releaseMutation = deferred();
+		let linked = true;
+		let upstreamWrites = 0;
+		const transaction = {
+			templateQualityProfileMapping: {
+				deleteMany: vi.fn().mockImplementation(async () => {
+					linked = false;
+					mutationStarted.resolve();
+					await releaseMutation.promise;
+					return { count: 1 };
+				}),
+			},
+			instanceQualityProfileOverride: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+		};
+		const prisma = {
+			templateQualityProfileMapping: { findFirst: vi.fn().mockResolvedValue(mapping) },
+			$transaction: vi.fn().mockImplementation((action) => action(transaction)),
+		};
+		const executor = createSerializedExecutor();
+		app = await createApp(prisma, executor);
+
+		const responsePromise = createInjectAuthenticated(app)("DELETE", "/unlink", {
+			body: { templateId: mapping.templateId, instanceId: mapping.instanceId },
+		});
+		await mutationStarted.promise;
+		const automationPromise = executor.runWithEndpointMutation(
+			"user-1",
+			instance,
+			"Automatic deployment",
+			async () => {
+				if (linked) upstreamWrites += 1;
+			},
+		);
+
+		expect(upstreamWrites).toBe(0);
+		releaseMutation.resolve();
+
+		const response = await responsePromise;
+		await automationPromise;
+		expect(response.statusCode).toBe(200);
+		expect(upstreamWrites).toBe(0);
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
@@ -58,12 +58,21 @@ const mapping = {
 	templateId: "template-1",
 	instanceId: instance.id,
 	qualityProfileId: 4,
+	qualityProfileName: "Any",
+	syncStrategy: "auto",
+	managedCustomFormatsCaptured: true,
+	managedCustomFormats: "[]",
 	updatedAt: new Date("2026-08-09T10:00:00.000Z"),
 	instance,
 	template: { name: "Any", userId: "user-1" },
 };
 
 async function createApp(prisma: unknown, deploymentExecutor: unknown) {
+	const database = prisma as Record<string, unknown>;
+	database.libraryCleanupConfig ??= {
+		upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+		updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+	};
 	const app = Fastify({ logger: false });
 	setupAuthInjection(app);
 	registerTestErrorHandler(app);
@@ -95,8 +104,10 @@ describe("deployment authority writer locking", () => {
 			return { count: 1 };
 		});
 		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
 			templateQualityProfileMapping: {
 				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping]),
 				updateMany,
 			},
 		};
@@ -147,7 +158,11 @@ describe("deployment authority writer locking", () => {
 			instanceQualityProfileOverride: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 		};
 		const prisma = {
-			templateQualityProfileMapping: { findFirst: vi.fn().mockResolvedValue(mapping) },
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping]),
+			},
 			$transaction: vi.fn().mockImplementation((action) => action(transaction)),
 		};
 		const executor = createSerializedExecutor();
@@ -174,4 +189,141 @@ describe("deployment authority writer locking", () => {
 		expect(response.statusCode).toBe(200);
 		expect(upstreamWrites).toBe(0);
 	});
+
+	it("changes sync strategy for every equivalent alias", async () => {
+		const aliasInstance = { ...instance, id: "instance-alias", label: "Radarr alias" };
+		const aliasMapping = {
+			...mapping,
+			id: "mapping-alias",
+			instanceId: aliasInstance.id,
+			instance: aliasInstance,
+		};
+		const updateMany = vi.fn().mockResolvedValue({ count: 2 });
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance, aliasInstance]) },
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping, aliasMapping]),
+				updateMany,
+			},
+		};
+		const executor = createSerializedExecutor();
+		app = await createApp(prisma, executor);
+
+		const response = await createInjectAuthenticated(app)("PATCH", "/sync-strategy", {
+			body: {
+				templateId: mapping.templateId,
+				instanceId: mapping.instanceId,
+				syncStrategy: "notify",
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({ id: mapping.id }),
+						expect.objectContaining({ id: aliasMapping.id }),
+					]),
+				}),
+				data: expect.objectContaining({ syncStrategy: "notify" }),
+			}),
+		);
+	});
+
+	it("unlinks every equivalent alias and its matching score overrides", async () => {
+		const aliasInstance = { ...instance, id: "instance-alias", label: "Radarr alias" };
+		const aliasMapping = {
+			...mapping,
+			id: "mapping-alias",
+			instanceId: aliasInstance.id,
+			instance: aliasInstance,
+		};
+		const deleteMappings = vi.fn().mockResolvedValue({ count: 2 });
+		const deleteOverrides = vi.fn().mockResolvedValue({ count: 2 });
+		const transaction = {
+			templateQualityProfileMapping: { deleteMany: deleteMappings },
+			instanceQualityProfileOverride: { deleteMany: deleteOverrides },
+		};
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance, aliasInstance]) },
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping, aliasMapping]),
+			},
+			$transaction: vi.fn().mockImplementation((action) => action(transaction)),
+		};
+		const executor = createSerializedExecutor();
+		app = await createApp(prisma, executor);
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/unlink", {
+			body: { templateId: mapping.templateId, instanceId: mapping.instanceId },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(deleteMappings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({ id: mapping.id }),
+						expect.objectContaining({ id: aliasMapping.id }),
+					]),
+				}),
+			}),
+		);
+		expect(deleteOverrides).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({ instanceId: instance.id, qualityProfileId: 4 }),
+						expect.objectContaining({ instanceId: aliasInstance.id, qualityProfileId: 4 }),
+					]),
+				}),
+			}),
+		);
+	});
+
+	it.each([
+		["sync strategy", "PATCH", "/sync-strategy"],
+		["unlink", "DELETE", "/unlink"],
+	] as const)(
+		"blocks a cross-process %s change while another mutation owns the database lease",
+		async (_case, method, path) => {
+			const updateMappings = vi.fn();
+			const deleteMappings = vi.fn();
+			const prisma = {
+				libraryCleanupConfig: {
+					upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+					updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+				},
+				serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+				templateQualityProfileMapping: {
+					findFirst: vi.fn().mockResolvedValue(mapping),
+					findMany: vi.fn().mockResolvedValue([mapping]),
+					updateMany: updateMappings,
+				},
+				$transaction: vi.fn().mockImplementation(async (action) =>
+					action({
+						templateQualityProfileMapping: { deleteMany: deleteMappings },
+						instanceQualityProfileOverride: { deleteMany: vi.fn() },
+					}),
+				),
+			};
+			const executor = createSerializedExecutor();
+			app = await createApp(prisma, executor);
+
+			const response = await createInjectAuthenticated(app)(method, path, {
+				body: {
+					templateId: mapping.templateId,
+					instanceId: mapping.instanceId,
+					...(method === "PATCH" ? { syncStrategy: "notify" } : {}),
+				},
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(updateMappings).not.toHaveBeenCalled();
+			expect(deleteMappings).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
@@ -232,6 +232,51 @@ describe("deployment authority writer locking", () => {
 		);
 	});
 
+	it("repairs divergent alias strategies while preserving exact ownership authority", async () => {
+		const aliasInstance = { ...instance, id: "instance-alias", label: "Radarr alias" };
+		const aliasMapping = {
+			...mapping,
+			id: "mapping-alias",
+			instanceId: aliasInstance.id,
+			syncStrategy: "manual",
+			instance: aliasInstance,
+		};
+		const updateMany = vi.fn().mockResolvedValue({ count: 2 });
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance, aliasInstance]) },
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping, aliasMapping]),
+				updateMany,
+			},
+		};
+		app = await createApp(prisma, createSerializedExecutor());
+
+		const response = await createInjectAuthenticated(app)("PATCH", "/sync-strategy", {
+			body: {
+				templateId: mapping.templateId,
+				instanceId: mapping.instanceId,
+				syncStrategy: "notify",
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({ id: mapping.id, updatedAt: mapping.updatedAt }),
+						expect.objectContaining({
+							id: aliasMapping.id,
+							updatedAt: aliasMapping.updatedAt,
+						}),
+					]),
+				}),
+				data: expect.objectContaining({ syncStrategy: "notify" }),
+			}),
+		);
+	});
+
 	it("unlinks every equivalent alias and its matching score overrides", async () => {
 		const aliasInstance = { ...instance, id: "instance-alias", label: "Radarr alias" };
 		const aliasMapping = {

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
@@ -329,6 +329,41 @@ describe("deployment authority writer locking", () => {
 		);
 	});
 
+	it("refuses to unlink aliases with conflicting deployment ownership", async () => {
+		const aliasInstance = { ...instance, id: "instance-alias", label: "Radarr alias" };
+		const aliasMapping = {
+			...mapping,
+			id: "mapping-alias",
+			instanceId: aliasInstance.id,
+			qualityProfileId: 5,
+			instance: aliasInstance,
+		};
+		const deleteMappings = vi.fn();
+		const deleteOverrides = vi.fn();
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance, aliasInstance]) },
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(mapping),
+				findMany: vi.fn().mockResolvedValue([mapping, aliasMapping]),
+			},
+			$transaction: vi.fn().mockImplementation((action) =>
+				action({
+					templateQualityProfileMapping: { deleteMany: deleteMappings },
+					instanceQualityProfileOverride: { deleteMany: deleteOverrides },
+				}),
+			),
+		};
+		app = await createApp(prisma, createSerializedExecutor());
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/unlink", {
+			body: { templateId: mapping.templateId, instanceId: mapping.instanceId },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(deleteMappings).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
 	it.each([
 		["sync strategy", "PATCH", "/sync-strategy"],
 		["unlink", "DELETE", "/unlink"],

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-routes-uncertain.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-routes-uncertain.test.ts
@@ -81,7 +81,11 @@ describe("deployment route uncertain outcomes", () => {
 		});
 
 		const response = await createInjectAuthenticated(app)("POST", "/execute", {
-			body: { templateId: "template-1", instanceId: "instance-1" },
+			body: {
+				templateId: "template-1",
+				instanceId: "instance-1",
+				executionToken: "a".repeat(64),
+			},
 		});
 
 		expect(response.statusCode).toBe(200);

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-routes-uncertain.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-routes-uncertain.test.ts
@@ -46,7 +46,11 @@ describe("deployment route uncertain outcomes", () => {
 		});
 
 		const response = await createInjectAuthenticated(app)("POST", "/execute", {
-			body: { templateId: "template-1", instanceId: "instance-1" },
+			body: {
+				templateId: "template-1",
+				instanceId: "instance-1",
+				executionToken: "a".repeat(64),
+			},
 		});
 
 		expect(response.statusCode).toBe(200);
@@ -110,6 +114,10 @@ describe("deployment route uncertain outcomes", () => {
 			body: {
 				templateId: "template-1",
 				instanceIds: ["failed", "uncertain"],
+				executionTokens: {
+					failed: "a".repeat(64),
+					uncertain: "b".repeat(64),
+				},
 			},
 		});
 

--- a/apps/api/src/routes/trash-guides/__tests__/execution-token-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/execution-token-routes.test.ts
@@ -1,0 +1,136 @@
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from "fastify";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+import { deploymentRoutes } from "../deployment-routes.js";
+import { registerSyncRoutes } from "../sync-routes.js";
+import { registerTemplateRoutes } from "../template-routes.js";
+
+const templateId = "cdef0123456789abcdef01234";
+const instanceId = "cdef0123456789abcdef01235";
+const executionToken = "a".repeat(64);
+
+async function createApp(
+	registerRoutes: FastifyPluginAsync,
+	prisma: unknown = {},
+	deploymentExecutor: unknown = {},
+) {
+	const app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	app.decorate("prisma", prisma as never);
+	app.decorate("arrClientFactory", {} as never);
+	app.decorate("deploymentExecutor", deploymentExecutor as never);
+	await app.register(registerRoutes);
+	await app.ready();
+	return app;
+}
+
+describe("user-triggered deployment token enforcement", () => {
+	let app: FastifyInstance | undefined;
+
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it("rejects tokenless execution on both deployment route surfaces", async () => {
+		for (const [routes, path] of [
+			[deploymentRoutes, "/execute"],
+			[registerTemplateRoutes, "/deployment/execute"],
+		] as const) {
+			app = await createApp(routes);
+			const response = await createInjectAuthenticated(app)("POST", path, {
+				body: { templateId, instanceId },
+			});
+			expect(response.statusCode).toBe(400);
+			expect(response.json().message).toBe("Invalid payload");
+			await app.close();
+			app = undefined;
+		}
+	});
+
+	it("forwards the exact reviewed token to the deployment executor", async () => {
+		const deploySingleInstance = vi.fn().mockResolvedValue({
+			instanceId,
+			instanceLabel: "Radarr",
+			success: true,
+			customFormatsCreated: 0,
+			customFormatsUpdated: 0,
+			customFormatsSkipped: 0,
+			errors: [],
+		});
+		app = await createApp(deploymentRoutes, {}, { deploySingleInstance });
+
+		const response = await createInjectAuthenticated(app)("POST", "/execute", {
+			body: { templateId, instanceId, executionToken },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(deploySingleInstance).toHaveBeenCalledWith(
+			templateId,
+			instanceId,
+			"user-1",
+			undefined,
+			undefined,
+			executionToken,
+		);
+	});
+
+	it.each([
+		[deploymentRoutes, "/execute-bulk"],
+		[registerTemplateRoutes, "/deployment/bulk"],
+	] as const)("rejects missing and extra bulk tokens on %s", async (routes, path) => {
+		app = await createApp(routes);
+		const secondInstanceId = "cdef0123456789abcdef01236";
+
+		const missing = await createInjectAuthenticated(app)("POST", path, {
+			body: {
+				templateId,
+				instanceIds: [instanceId, secondInstanceId],
+				executionTokens: { [instanceId]: executionToken },
+			},
+		});
+		const extra = await createInjectAuthenticated(app)("POST", path, {
+			body: {
+				templateId,
+				instanceIds: [instanceId],
+				executionTokens: {
+					[instanceId]: executionToken,
+					"unselected-instance": "b".repeat(64),
+				},
+			},
+		});
+
+		expect(missing.statusCode).toBe(400);
+		expect(extra.statusCode).toBe(400);
+	});
+
+	it("does not let an API caller claim scheduled-sync authority", async () => {
+		app = await createApp(registerSyncRoutes);
+		const response = await createInjectAuthenticated(app)("POST", "/execute", {
+			body: { templateId, instanceId, syncType: "SCHEDULED", executionToken },
+		});
+
+		expect(response.statusCode).toBe(400);
+	});
+
+	it("rejects an unowned sync target before creating history", async () => {
+		const historyCreate = vi.fn();
+		app = await createApp(registerSyncRoutes, {
+			trashTemplate: { findFirst: vi.fn().mockResolvedValue(null) },
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(null) },
+			trashSyncHistory: { create: historyCreate },
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/execute", {
+			body: { templateId, instanceId, executionToken },
+		});
+
+		expect(response.statusCode).toBe(404);
+		expect(historyCreate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/sync-validation-route.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/sync-validation-route.test.ts
@@ -64,6 +64,7 @@ describe("manual sync review authority", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mocks.syncTemplate.mockResolvedValue({ success: true, errors: [] });
 		mocks.validate.mockResolvedValue({ valid: true, conflicts: [], errors: [], warnings: [] });
 		mocks.generatePreview.mockResolvedValue({
 			templateId,
@@ -92,14 +93,20 @@ describe("manual sync review authority", () => {
 		app = undefined;
 	});
 
-	it("returns the exact deployment plan without refreshing the template", async () => {
+	it("refreshes persisted template data before validating and issuing the reviewed plan", async () => {
 		app = await createApp();
 		const response = await createInjectAuthenticated(app)("POST", "/validate", {
 			body: { templateId, instanceId },
 		});
 
 		expect(response.statusCode).toBe(200);
-		expect(mocks.syncTemplate).not.toHaveBeenCalled();
+		expect(mocks.syncTemplate).toHaveBeenCalledWith(templateId, undefined, "user-1");
+		expect(mocks.syncTemplate.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.validate.mock.invocationCallOrder[0]!,
+		);
+		expect(mocks.validate.mock.invocationCallOrder[0]).toBeLessThan(
+			mocks.generatePreview.mock.invocationCallOrder[0]!,
+		);
 		expect(response.json()).toMatchObject({
 			valid: true,
 			executionToken,
@@ -109,6 +116,28 @@ describe("manual sync review authority", () => {
 				namingChanges: ["movieFolderFormat"],
 			},
 		});
+	});
+
+	it("does not issue a review token when the template refresh fails", async () => {
+		mocks.syncTemplate.mockResolvedValueOnce({
+			success: false,
+			errors: ["GitHub unavailable"],
+		});
+		app = await createApp();
+
+		const response = await createInjectAuthenticated(app)("POST", "/validate", {
+			body: { templateId, instanceId },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			valid: false,
+			conflicts: [],
+			errors: ["Template sync failed: GitHub unavailable"],
+			warnings: [],
+		});
+		expect(mocks.validate).not.toHaveBeenCalled();
+		expect(mocks.generatePreview).not.toHaveBeenCalled();
 	});
 
 	it("executes only as manual and forwards the reviewed token", async () => {
@@ -123,5 +152,35 @@ describe("manual sync review authority", () => {
 			undefined,
 			executionToken,
 		);
+		expect(mocks.syncTemplate).not.toHaveBeenCalled();
+	});
+
+	it("exposes partial success as non-success terminal progress", async () => {
+		mocks.execute.mockResolvedValueOnce({
+			syncId: "sync-partial",
+			success: false,
+			status: "PARTIAL_SUCCESS",
+			configsApplied: 2,
+			configsFailed: 1,
+			configsSkipped: 0,
+			errors: [{ configName: "HDR", error: "Update failed", retryable: true }],
+			warnings: [],
+		});
+		app = await createApp();
+
+		const executeResponse = await createInjectAuthenticated(app)("POST", "/execute", {
+			body: { templateId, instanceId, executionToken },
+		});
+		const progressResponse = await createInjectAuthenticated(app)("GET", "/sync-partial/progress");
+
+		expect(executeResponse.statusCode).toBe(200);
+		expect(progressResponse.statusCode).toBe(200);
+		expect(progressResponse.json()).toMatchObject({
+			syncId: "sync-partial",
+			status: "FAILED",
+			progress: 100,
+			appliedConfigs: 2,
+			failedConfigs: 1,
+		});
 	});
 });

--- a/apps/api/src/routes/trash-guides/__tests__/sync-validation-route.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/sync-validation-route.test.ts
@@ -1,0 +1,127 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+	validate: vi.fn(),
+	execute: vi.fn(),
+	syncTemplate: vi.fn(),
+	generatePreview: vi.fn(),
+}));
+
+vi.mock("../../../lib/trash-guides/cache-manager.js", () => ({
+	createCacheManager: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/github-fetcher.js", () => ({
+	createTrashFetcher: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/repo-config.js", () => ({
+	getRepoConfig: vi.fn(async () => ({})),
+}));
+vi.mock("../../../lib/trash-guides/version-tracker.js", () => ({
+	createVersionTracker: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/template-updater.js", () => ({
+	createTemplateUpdater: vi.fn(() => ({ syncTemplate: mocks.syncTemplate })),
+}));
+vi.mock("../../../lib/trash-guides/sync-engine.js", () => ({
+	createSyncEngine: vi.fn(() => ({
+		validate: mocks.validate,
+		execute: mocks.execute,
+	})),
+}));
+vi.mock("../../../lib/trash-guides/deployment-preview.js", () => ({
+	createDeploymentPreviewService: vi.fn(() => ({ generatePreview: mocks.generatePreview })),
+}));
+
+import { registerSyncRoutes } from "../sync-routes.js";
+
+const templateId = "cdef0123456789abcdef01234";
+const instanceId = "cdef0123456789abcdef01235";
+const executionToken = "a".repeat(64);
+
+async function createApp(): Promise<FastifyInstance> {
+	const app = Fastify({ logger: false });
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	app.decorate("prisma", {
+		trashTemplate: { findFirst: vi.fn().mockResolvedValue({ id: templateId }) },
+		serviceInstance: { findFirst: vi.fn().mockResolvedValue({ id: instanceId }) },
+	} as never);
+	app.decorate("arrClientFactory", {} as never);
+	app.decorate("deploymentExecutor", {} as never);
+	await app.register(registerSyncRoutes);
+	await app.ready();
+	return app;
+}
+
+describe("manual sync review authority", () => {
+	let app: FastifyInstance | undefined;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.validate.mockResolvedValue({ valid: true, conflicts: [], errors: [], warnings: [] });
+		mocks.generatePreview.mockResolvedValue({
+			templateId,
+			instanceId,
+			canDeploy: true,
+			executionToken,
+			summary: { updatedCustomFormats: 1, orphanedCustomFormats: 1 },
+			customFormats: [{ name: "HDR", action: "update", scoreOverride: 500 }],
+			orphanedCustomFormats: [{ name: "Old format", score: 100 }],
+			namingChanges: ["movieFolderFormat"],
+			warnings: ["A legacy mapping will be rebound during execution."],
+		});
+		mocks.execute.mockResolvedValue({
+			syncId: "sync-1",
+			status: "SUCCESS",
+			configsApplied: 1,
+			configsFailed: 0,
+			configsSkipped: 0,
+			errors: [],
+			warnings: [],
+		});
+	});
+
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it("returns the exact deployment plan without refreshing the template", async () => {
+		app = await createApp();
+		const response = await createInjectAuthenticated(app)("POST", "/validate", {
+			body: { templateId, instanceId },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(mocks.syncTemplate).not.toHaveBeenCalled();
+		expect(response.json()).toMatchObject({
+			valid: true,
+			executionToken,
+			preview: {
+				summary: { updatedCustomFormats: 1, orphanedCustomFormats: 1 },
+				customFormats: [{ name: "HDR", action: "update", scoreOverride: 500 }],
+				namingChanges: ["movieFolderFormat"],
+			},
+		});
+	});
+
+	it("executes only as manual and forwards the reviewed token", async () => {
+		app = await createApp();
+		const response = await createInjectAuthenticated(app)("POST", "/execute", {
+			body: { templateId, instanceId, executionToken },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(mocks.execute).toHaveBeenCalledWith(
+			{ templateId, instanceId, userId: "user-1", syncType: "MANUAL" },
+			undefined,
+			executionToken,
+		);
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/update-routes-uncertain.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/update-routes-uncertain.test.ts
@@ -1,0 +1,79 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+	processAutoUpdates: vi.fn(),
+}));
+
+vi.mock("../../../lib/trash-guides/cache-manager.js", () => ({
+	createCacheManager: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/github-fetcher.js", () => ({
+	createTrashFetcher: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/repo-config.js", () => ({
+	getRepoConfig: vi.fn(async () => ({})),
+}));
+vi.mock("../../../lib/trash-guides/version-tracker.js", () => ({
+	createVersionTracker: vi.fn(() => ({})),
+}));
+vi.mock("../../../lib/trash-guides/template-updater.js", () => ({
+	createTemplateUpdater: vi.fn(() => ({ processAutoUpdates: mocks.processAutoUpdates })),
+}));
+
+import { registerUpdateRoutes } from "../update-routes.js";
+
+describe("manual automatic-update uncertainty", () => {
+	let app: FastifyInstance | undefined;
+	const notify = vi.fn();
+
+	beforeEach(async () => {
+		vi.clearAllMocks();
+		mocks.processAutoUpdates.mockResolvedValue({
+			processed: 1,
+			successful: 0,
+			failed: 0,
+			uncertain: 1,
+			uncertainDeployments: [
+				{
+					endpointKey: "user-1:RADARR:credential-1",
+					instanceId: "instance-1",
+					instanceLabel: "Radarr",
+					errors: ["ARR write could not be verified"],
+				},
+			],
+			results: [{ templateId: "template-1", success: false }],
+		});
+		app = Fastify({ logger: false });
+		setupAuthInjection(app);
+		registerTestErrorHandler(app);
+		app.decorate("prisma", {} as never);
+		app.decorate("deploymentExecutor", {} as never);
+		app.decorate("notificationService", { notify } as never);
+		await app.register(registerUpdateRoutes);
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		await app?.close();
+		app = undefined;
+	});
+
+	it("returns the uncertain automation result when notification delivery fails", async () => {
+		notify.mockRejectedValue(new Error("notification database unavailable"));
+
+		const response = await createInjectAuthenticated(app!)("POST", "/process-auto");
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toMatchObject({
+			success: true,
+			data: { summary: { processed: 1, failed: 0, uncertain: 1 } },
+		});
+		expect(notify).toHaveBeenCalledOnce();
+	});
+});

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -23,11 +23,11 @@ import { rollbackCustomFormatDeployment } from "../../lib/trash-guides/deploymen
 import { restoreNamingDeployment } from "../../lib/trash-guides/deployment-naming-state.js";
 import { rollbackQualityProfileDeployment } from "../../lib/trash-guides/deployment-profile-state.js";
 import {
-	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
+	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 
@@ -588,9 +588,13 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 						});
 					}
 					if (
-						backupState.endpointKey !== endpointKey ||
-						backupState.connectionStateToken !==
-							createDeploymentConnectionStateToken(currentInstance)
+						!isDeploymentBackupEndpointIdentityCurrent({
+							userId,
+							backupEndpointKey: backupState.endpointKey,
+							backupConnectionStateToken: backupState.connectionStateToken,
+							instance: currentInstance,
+							credentialIdentity: currentCredentialIdentity!,
+						})
 					) {
 						return stopClaimedUndeploy(409, {
 							success: false,

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -8,6 +8,7 @@
 
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
+import { ConflictError } from "../../lib/errors.js";
 import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
@@ -49,9 +50,47 @@ const executeBulkDeploymentSchema = z
 		}
 	});
 
+const syncStrategySchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+	syncStrategy: z.enum(["auto", "manual", "notify"]),
+});
+
+const bulkSyncStrategySchema = z.object({
+	templateId: z.string().min(1),
+	syncStrategy: z.enum(["auto", "manual", "notify"]),
+});
+
+const unlinkDeploymentSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+});
+
 export async function deploymentRoutes(app: FastifyInstance) {
 	const { prisma, deploymentExecutor } = app;
 	const deploymentPreview = createDeploymentPreviewService(prisma, app.arrClientFactory, app.log);
+	const runWithEndpointLocks = async <T>(
+		userId: string,
+		instances: Array<Parameters<typeof deploymentExecutor.createEndpointMutationKey>[1]>,
+		operation: string,
+		action: () => Promise<T>,
+	): Promise<T> => {
+		const targets = new Map<string, (typeof instances)[number]>();
+		for (const instance of instances) {
+			targets.set(deploymentExecutor.createEndpointMutationKey(userId, instance), instance);
+		}
+		const orderedTargets = [...targets.entries()].sort(([left], [right]) =>
+			left.localeCompare(right),
+		);
+		const acquire = async (index: number): Promise<T> => {
+			const target = orderedTargets[index];
+			if (!target) return action();
+			return deploymentExecutor.runWithEndpointMutation(userId, target[1], operation, () =>
+				acquire(index + 1),
+			);
+		};
+		return acquire(0);
+	};
 	const notifyUncertainDeployment = async (
 		userId: string,
 		title: string,
@@ -81,15 +120,8 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			instanceId: string;
 		};
 	}>("/preview", async (request, reply) => {
-		const { templateId, instanceId } = request.body;
+		const { templateId, instanceId } = validateRequest(unlinkDeploymentSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		const preview = await deploymentPreview.generatePreview(templateId, instanceId, userId);
 
@@ -203,22 +235,10 @@ export async function deploymentRoutes(app: FastifyInstance) {
 		};
 	}>("/sync-strategy", async (request, reply) => {
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-		const { templateId, instanceId, syncStrategy } = request.body;
-
-		if (!templateId || !instanceId || !syncStrategy) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId, instanceId, and syncStrategy are required",
-			});
-		}
-
-		// Validate syncStrategy value
-		if (!["auto", "manual", "notify"].includes(syncStrategy)) {
-			return reply.status(400).send({
-				success: false,
-				error: "syncStrategy must be 'auto', 'manual', or 'notify'",
-			});
-		}
+		const { templateId, instanceId, syncStrategy } = validateRequest(
+			syncStrategySchema,
+			request.body,
+		);
 
 		// Find the mapping and verify ownership
 		const mapping = await prisma.templateQualityProfileMapping.findFirst({
@@ -228,6 +248,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			},
 			orderBy: { updatedAt: "desc" },
 			include: {
+				instance: true,
 				template: {
 					select: { userId: true },
 				},
@@ -251,14 +272,28 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			});
 		}
 
-		// Update the sync strategy (single instance)
-		const updated = await prisma.templateQualityProfileMapping.update({
-			where: { id: mapping.id },
-			data: {
-				syncStrategy,
-				updatedAt: new Date(),
+		await runWithEndpointLocks(
+			userId,
+			[mapping.instance],
+			"Deployment authority update",
+			async () => {
+				const updated = await prisma.templateQualityProfileMapping.updateMany({
+					where: {
+						id: mapping.id,
+						templateId,
+						instanceId,
+						updatedAt: mapping.updatedAt,
+						template: { userId },
+					},
+					data: { syncStrategy, updatedAt: new Date() },
+				});
+				if (updated.count !== 1) {
+					throw new ConflictError(
+						"Deployment authority changed while the sync strategy was being updated",
+					);
+				}
 			},
-		});
+		);
 
 		request.log.info({ templateId, instanceId, syncStrategy }, "Sync strategy updated");
 
@@ -268,7 +303,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			data: {
 				templateId,
 				instanceId,
-				syncStrategy: updated.syncStrategy,
+				syncStrategy,
 			},
 		});
 	});
@@ -284,22 +319,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 		};
 	}>("/sync-strategy-bulk", async (request, reply) => {
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-		const { templateId, syncStrategy } = request.body;
-
-		if (!templateId || !syncStrategy) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and syncStrategy are required",
-			});
-		}
-
-		// Validate syncStrategy value
-		if (!["auto", "manual", "notify"].includes(syncStrategy)) {
-			return reply.status(400).send({
-				success: false,
-				error: "syncStrategy must be 'auto', 'manual', or 'notify'",
-			});
-		}
+		const { templateId, syncStrategy } = validateRequest(bulkSyncStrategySchema, request.body);
 
 		// Verify template belongs to user
 		const template = await prisma.trashTemplate.findFirst({
@@ -316,31 +336,45 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			});
 		}
 
-		// Update all mappings for this template
-		const result = await prisma.templateQualityProfileMapping.updateMany({
-			where: {
-				templateId,
-			},
-			data: {
-				syncStrategy,
-				updatedAt: new Date(),
-			},
+		const mappings = await prisma.templateQualityProfileMapping.findMany({
+			where: { templateId, template: { userId } },
+			include: { instance: true },
 		});
-
-		if (result.count === 0) {
+		if (mappings.length === 0) {
 			return reply.status(404).send({
 				success: false,
 				error: "No deployment mappings found for this template",
 			});
 		}
 
+		await runWithEndpointLocks(
+			userId,
+			mappings.map((mapping) => mapping.instance),
+			"Bulk deployment authority update",
+			async () => {
+				const result = await prisma.templateQualityProfileMapping.updateMany({
+					where: {
+						templateId,
+						template: { userId },
+						OR: mappings.map((mapping) => ({ id: mapping.id, updatedAt: mapping.updatedAt })),
+					},
+					data: { syncStrategy, updatedAt: new Date() },
+				});
+				if (result.count !== mappings.length) {
+					throw new ConflictError(
+						"Deployment authority changed while the bulk sync strategy was being updated",
+					);
+				}
+			},
+		);
+
 		return reply.send({
 			success: true,
-			message: `Updated ${result.count} instance(s) to '${syncStrategy}' sync strategy`,
+			message: `Updated ${mappings.length} instance(s) to '${syncStrategy}' sync strategy`,
 			data: {
 				templateId,
 				syncStrategy,
-				updatedCount: result.count,
+				updatedCount: mappings.length,
 			},
 		});
 	});
@@ -356,15 +390,8 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			instanceId: string;
 		};
 	}>("/unlink", async (request, reply) => {
-		const { templateId, instanceId } = request.body;
+		const { templateId, instanceId } = validateRequest(unlinkDeploymentSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		// Find the mapping
 		const mapping = await prisma.templateQualityProfileMapping.findFirst({
@@ -374,11 +401,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			},
 			orderBy: { updatedAt: "desc" },
 			include: {
-				instance: {
-					select: {
-						label: true,
-					},
-				},
+				instance: true,
 				template: {
 					select: {
 						name: true,
@@ -403,18 +426,32 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			});
 		}
 
-		// Delete the mapping
-		await prisma.templateQualityProfileMapping.delete({
-			where: { id: mapping.id },
-		});
-
-		// Also delete any instance-level overrides for this template+instance
-		await prisma.instanceQualityProfileOverride.deleteMany({
-			where: {
-				instanceId,
-				qualityProfileId: mapping.qualityProfileId,
+		await runWithEndpointLocks(
+			userId,
+			[mapping.instance],
+			"Deployment authority unlink",
+			async () => {
+				await prisma.$transaction(async (transaction) => {
+					const deleted = await transaction.templateQualityProfileMapping.deleteMany({
+						where: {
+							id: mapping.id,
+							templateId,
+							instanceId,
+							updatedAt: mapping.updatedAt,
+							template: { userId },
+						},
+					});
+					if (deleted.count !== 1) {
+						throw new ConflictError(
+							"Deployment authority changed while the template was being unlinked",
+						);
+					}
+					await transaction.instanceQualityProfileOverride.deleteMany({
+						where: { userId, instanceId, qualityProfileId: mapping.qualityProfileId },
+					});
+				});
 			},
-		});
+		);
 
 		request.log.info(
 			{ templateId, instanceId, mappingId: mapping.id },

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -317,7 +317,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 						"Deployment authority changed while the sync strategy was being updated",
 					);
 				}
-				assertEquivalentDeploymentMappingAuthority(equivalentMappings);
+				// A strategy write is also the repair path for aliases left with divergent
+				// strategies by older single-row writers. Every other ownership field must
+				// still agree before replacing that one field across the endpoint.
+				assertEquivalentDeploymentMappingAuthority(
+					equivalentMappings.map((candidate) => ({ ...candidate, syncStrategy: null })),
+				);
 				const updated = await prisma.templateQualityProfileMapping.updateMany({
 					where: {
 						templateId,

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -9,7 +9,9 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { ConflictError } from "../../lib/errors.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
 import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
+import { assertEquivalentDeploymentMappingAuthority } from "../../lib/trash-guides/deployment-target.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 const executeDeploymentSchema = z.object({
@@ -89,7 +91,35 @@ export async function deploymentRoutes(app: FastifyInstance) {
 				acquire(index + 1),
 			);
 		};
-		return acquire(0);
+		return withCleanupTopologyMutationLease({ prisma, log: app.log }, userId, () => acquire(0));
+	};
+	const loadEquivalentEndpointMappings = async (
+		userId: string,
+		templateId: string,
+		targetInstance: Parameters<typeof deploymentExecutor.createEndpointMutationKey>[1],
+	) => {
+		const endpointKey = deploymentExecutor.createEndpointMutationKey(userId, targetInstance);
+		const configuredInstances = await prisma.serviceInstance.findMany({
+			where: { userId },
+		});
+		const equivalentInstanceIds = configuredInstances
+			.filter(
+				(instance) =>
+					deploymentExecutor.createEndpointMutationKey(userId, instance) === endpointKey,
+			)
+			.map((instance) => instance.id);
+		if (!equivalentInstanceIds.includes(targetInstance.id)) {
+			equivalentInstanceIds.push(targetInstance.id);
+		}
+		return prisma.templateQualityProfileMapping.findMany({
+			where: {
+				templateId,
+				instanceId: { in: equivalentInstanceIds },
+				template: { userId },
+			},
+			orderBy: { updatedAt: "desc" },
+			include: { instance: true },
+		});
 	};
 	const notifyUncertainDeployment = async (
 		userId: string,
@@ -277,17 +307,29 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			[mapping.instance],
 			"Deployment authority update",
 			async () => {
+				const equivalentMappings = await loadEquivalentEndpointMappings(
+					userId,
+					templateId,
+					mapping.instance,
+				);
+				if (!equivalentMappings.some((candidate) => candidate.id === mapping.id)) {
+					throw new ConflictError(
+						"Deployment authority changed while the sync strategy was being updated",
+					);
+				}
+				assertEquivalentDeploymentMappingAuthority(equivalentMappings);
 				const updated = await prisma.templateQualityProfileMapping.updateMany({
 					where: {
-						id: mapping.id,
 						templateId,
-						instanceId,
-						updatedAt: mapping.updatedAt,
 						template: { userId },
+						OR: equivalentMappings.map((candidate) => ({
+							id: candidate.id,
+							updatedAt: candidate.updatedAt,
+						})),
 					},
 					data: { syncStrategy, updatedAt: new Date() },
 				});
-				if (updated.count !== 1) {
+				if (updated.count !== equivalentMappings.length) {
 					throw new ConflictError(
 						"Deployment authority changed while the sync strategy was being updated",
 					);
@@ -352,6 +394,24 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			mappings.map((mapping) => mapping.instance),
 			"Bulk deployment authority update",
 			async () => {
+				const currentMappings = await prisma.templateQualityProfileMapping.findMany({
+					where: { templateId, template: { userId } },
+					include: { instance: true },
+				});
+				const reviewedMappingState = new Set(
+					mappings.map((mapping) => `${mapping.id}:${mapping.updatedAt.toISOString()}`),
+				);
+				if (
+					currentMappings.length !== mappings.length ||
+					currentMappings.some(
+						(mapping) =>
+							!reviewedMappingState.has(`${mapping.id}:${mapping.updatedAt.toISOString()}`),
+					)
+				) {
+					throw new ConflictError(
+						"Deployment authority changed while the bulk sync strategy was being updated",
+					);
+				}
 				const result = await prisma.templateQualityProfileMapping.updateMany({
 					where: {
 						templateId,
@@ -431,23 +491,40 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			[mapping.instance],
 			"Deployment authority unlink",
 			async () => {
+				const equivalentMappings = await loadEquivalentEndpointMappings(
+					userId,
+					templateId,
+					mapping.instance,
+				);
+				if (!equivalentMappings.some((candidate) => candidate.id === mapping.id)) {
+					throw new ConflictError(
+						"Deployment authority changed while the template was being unlinked",
+					);
+				}
 				await prisma.$transaction(async (transaction) => {
 					const deleted = await transaction.templateQualityProfileMapping.deleteMany({
 						where: {
-							id: mapping.id,
 							templateId,
-							instanceId,
-							updatedAt: mapping.updatedAt,
 							template: { userId },
+							OR: equivalentMappings.map((candidate) => ({
+								id: candidate.id,
+								updatedAt: candidate.updatedAt,
+							})),
 						},
 					});
-					if (deleted.count !== 1) {
+					if (deleted.count !== equivalentMappings.length) {
 						throw new ConflictError(
 							"Deployment authority changed while the template was being unlinked",
 						);
 					}
 					await transaction.instanceQualityProfileOverride.deleteMany({
-						where: { userId, instanceId, qualityProfileId: mapping.qualityProfileId },
+						where: {
+							userId,
+							OR: equivalentMappings.map((candidate) => ({
+								instanceId: candidate.instanceId,
+								qualityProfileId: candidate.qualityProfileId,
+							})),
+						},
 					});
 				});
 			},

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -506,6 +506,14 @@ export async function deploymentRoutes(app: FastifyInstance) {
 						"Deployment authority changed while the template was being unlinked",
 					);
 				}
+				assertEquivalentDeploymentMappingAuthority(
+					equivalentMappings.map((candidate) => ({
+						...candidate,
+						// Unlink is allowed to repair strategy-only drift, but not disagreement
+						// about the profile or Custom Formats that this template owns.
+						syncStrategy: null,
+					})),
+				);
 				await prisma.$transaction(async (transaction) => {
 					const deleted = await transaction.templateQualityProfileMapping.deleteMany({
 						where: {

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -7,7 +7,47 @@
  */
 
 import type { FastifyInstance } from "fastify";
+import { z } from "zod";
 import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+const executeDeploymentSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+	syncStrategy: z.enum(["auto", "manual", "notify"]).optional(),
+	conflictResolutions: z.record(z.string(), z.enum(["use_template", "keep_existing"])).optional(),
+	executionToken: z.string().length(64),
+});
+
+const executeBulkDeploymentSchema = z
+	.object({
+		templateId: z.string().min(1),
+		instanceIds: z.array(z.string().min(1)).min(1),
+		syncStrategy: z.enum(["auto", "manual", "notify"]).optional(),
+		instanceSyncStrategies: z.record(z.string(), z.enum(["auto", "manual", "notify"])).optional(),
+		executionTokens: z.record(z.string(), z.string().length(64)),
+	})
+	.superRefine((body, context) => {
+		const selectedInstanceIds = new Set(body.instanceIds);
+		for (const instanceId of body.instanceIds) {
+			if (!body.executionTokens[instanceId]) {
+				context.addIssue({
+					code: "custom",
+					path: ["executionTokens", instanceId],
+					message: "A fresh execution token is required for every selected instance",
+				});
+			}
+		}
+		for (const instanceId of Object.keys(body.executionTokens)) {
+			if (!selectedInstanceIds.has(instanceId)) {
+				context.addIssue({
+					code: "custom",
+					path: ["executionTokens", instanceId],
+					message: "Execution tokens may only be provided for selected instances",
+				});
+			}
+		}
+	});
 
 export async function deploymentRoutes(app: FastifyInstance) {
 	const { prisma, deploymentExecutor } = app;
@@ -53,28 +93,9 @@ export async function deploymentRoutes(app: FastifyInstance) {
 
 		const preview = await deploymentPreview.generatePreview(templateId, instanceId, userId);
 
-		// Check for existing deployment to get current sync strategy
-		// Find the mapping by templateId and instanceId
-		const existingMapping = await prisma.templateQualityProfileMapping.findFirst({
-			where: {
-				templateId,
-				instanceId,
-			},
-			orderBy: { updatedAt: "desc" },
-			select: { syncStrategy: true },
-		});
-
 		return reply.send({
 			success: true,
-			data: {
-				...preview,
-				// Include existing sync strategy if this instance was previously deployed
-				existingSyncStrategy: existingMapping?.syncStrategy as
-					| "auto"
-					| "manual"
-					| "notify"
-					| undefined,
-			},
+			data: preview,
 		});
 	});
 
@@ -88,17 +109,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			instanceId: string;
 			syncStrategy?: "auto" | "manual" | "notify";
 			conflictResolutions?: Record<string, "use_template" | "keep_existing">; // Map of trashId → resolution
+			executionToken: string;
 		};
 	}>("/execute", async (request, reply) => {
-		const { templateId, instanceId, syncStrategy, conflictResolutions } = request.body;
+		const { templateId, instanceId, syncStrategy, conflictResolutions, executionToken } =
+			validateRequest(executeDeploymentSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceId are required",
-			});
-		}
 
 		// Execute deployment with conflict resolutions
 		const result = await deploymentExecutor.deploySingleInstance(
@@ -107,6 +123,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			userId,
 			syncStrategy,
 			conflictResolutions,
+			executionToken,
 		);
 
 		request.log.info({ templateId, instanceId, success: result.success }, "Deployment executed");
@@ -167,7 +184,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 				request.log.warn({ err }, "Deployment failed notification dispatch failed");
 			});
 
-		return reply.status(400).send({
+		return reply.send({
 			success: false,
 			error: "Deployment failed",
 			result: result,
@@ -427,17 +444,12 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			instanceIds: string[];
 			syncStrategy?: "auto" | "manual" | "notify";
 			instanceSyncStrategies?: Record<string, "auto" | "manual" | "notify">;
+			executionTokens: Record<string, string>;
 		};
 	}>("/execute-bulk", async (request, reply) => {
-		const { templateId, instanceIds, syncStrategy, instanceSyncStrategies } = request.body;
+		const { templateId, instanceIds, syncStrategy, instanceSyncStrategies, executionTokens } =
+			validateRequest(executeBulkDeploymentSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
-
-		if (!templateId || !instanceIds || instanceIds.length === 0) {
-			return reply.status(400).send({
-				success: false,
-				error: "templateId and instanceIds are required",
-			});
-		}
 
 		// Execute bulk deployment with per-instance strategies support
 		const result = await deploymentExecutor.deployBulkInstances(
@@ -446,6 +458,7 @@ export async function deploymentRoutes(app: FastifyInstance) {
 			userId,
 			syncStrategy,
 			instanceSyncStrategies,
+			executionTokens,
 		);
 
 		request.log.info({ templateId, instanceCount: instanceIds.length }, "Bulk deployment executed");

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -244,7 +244,16 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 			});
 		}
 
-		const { syncEngine } = await getServices(userId);
+		const { syncEngine, templateUpdater } = await getServices(userId);
+		const templateSync = await templateUpdater.syncTemplate(body.templateId, undefined, userId);
+		if (!templateSync.success) {
+			return reply.send({
+				valid: false,
+				conflicts: [],
+				errors: [`Template sync failed: ${templateSync.errors?.join(", ") || "Unknown error"}`],
+				warnings: [],
+			});
+		}
 		const validation = await syncEngine.validate({
 			templateId: body.templateId,
 			instanceId: body.instanceId,
@@ -303,19 +312,21 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 		const finalProgress: SyncProgress = {
 			syncId: result.syncId,
 			status:
-				result.status === "UNCERTAIN"
-					? "UNCERTAIN"
-					: result.status === "FAILED"
-						? "FAILED"
-						: "COMPLETED",
+				result.status === "SUCCESS"
+					? "COMPLETED"
+					: result.status === "UNCERTAIN"
+						? "UNCERTAIN"
+						: "FAILED",
 			currentStep:
 				result.status === "UNCERTAIN"
 					? "Sync result is uncertain; resolve or roll back before retrying"
-					: result.status !== "FAILED"
+					: result.status === "SUCCESS"
 						? result.warnings?.length
 							? `Sync completed with warnings: ${result.warnings.join("; ")}`
 							: `Sync completed: ${result.configsApplied} applied, ${result.configsFailed} failed`
-						: "Sync failed",
+						: result.status === "PARTIAL_SUCCESS"
+							? `Sync completed with errors: ${result.configsApplied} applied, ${result.configsFailed} failed`
+							: "Sync failed",
 			progress: 100,
 			totalConfigs: result.configsApplied + result.configsFailed + result.configsSkipped,
 			appliedConfigs: result.configsApplied,

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -28,11 +28,11 @@ import {
 	rollbackQualityProfileDeployment,
 } from "../../lib/trash-guides/deployment-profile-state.js";
 import {
-	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
+	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
 import { createTrashFetcher } from "../../lib/trash-guides/github-fetcher.js";
 import { getRepoConfig } from "../../lib/trash-guides/repo-config.js";
@@ -805,8 +805,13 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 								});
 							}
 							if (
-								backupEndpointKey !== endpointKey ||
-								backupConnectionStateToken !== createDeploymentConnectionStateToken(currentInstance)
+								!isDeploymentBackupEndpointIdentityCurrent({
+									userId,
+									backupEndpointKey,
+									backupConnectionStateToken,
+									instance: currentInstance,
+									credentialIdentity: leasedCredentialIdentity!,
+								})
 							) {
 								return stopClaimedRollback(409, {
 									error: "ROLLBACK_TARGET_CHANGED",

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -22,6 +22,7 @@ import {
 	rollbackCustomFormatDeployment,
 } from "../../lib/trash-guides/deployment-custom-format-state.js";
 import { restoreNamingDeployment } from "../../lib/trash-guides/deployment-naming-state.js";
+import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
 import {
 	type QualityProfileRollbackState,
 	rollbackQualityProfileDeployment,
@@ -56,8 +57,9 @@ const validateSyncSchema = z.object({
 const executeSyncSchema = z.object({
 	templateId: z.string().cuid(),
 	instanceId: z.string().cuid(),
-	syncType: z.enum(["MANUAL", "SCHEDULED"]),
+	syncType: z.literal("MANUAL").optional(),
 	conflictResolutions: z.record(z.string(), z.enum(["REPLACE", "SKIP"])).optional(),
+	executionToken: z.string().length(64),
 });
 
 const syncHistoryQuerySchema = z.object({
@@ -192,6 +194,19 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 	// Shared services (repo-independent)
 	const cacheManager = createCacheManager(app.prisma);
 	const { deploymentExecutor } = app;
+	async function ownsSyncTarget(userId: string, templateId: string, instanceId: string) {
+		const [template, instance] = await Promise.all([
+			app.prisma.trashTemplate.findFirst({
+				where: { id: templateId, userId, deletedAt: null },
+				select: { id: true },
+			}),
+			app.prisma.serviceInstance.findFirst({
+				where: { id: instanceId, userId },
+				select: { id: true },
+			}),
+		]);
+		return Boolean(template && instance);
+	}
 
 	/** Create repo-aware services configured for the current user's repo settings */
 	async function getServices(userId: string) {
@@ -221,6 +236,13 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.post("/validate", async (request: FastifyRequest, reply) => {
 		const body = validateRequest(validateSyncSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
+		if (!(await ownsSyncTarget(userId, body.templateId, body.instanceId))) {
+			return reply.status(404).send({
+				statusCode: 404,
+				error: "NotFound",
+				message: "Sync target not found",
+			});
+		}
 
 		const { syncEngine } = await getServices(userId);
 		const validation = await syncEngine.validate({
@@ -230,7 +252,17 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 			syncType: "MANUAL",
 		});
 
-		return reply.send(validation);
+		if (!validation.valid) return reply.send(validation);
+		const preview = await createDeploymentPreviewService(
+			app.prisma,
+			app.arrClientFactory,
+			app.log,
+		).generatePreview(body.templateId, body.instanceId, userId);
+		return reply.send({
+			...validation,
+			executionToken: preview.executionToken,
+			preview,
+		});
 	});
 
 	/**
@@ -240,6 +272,13 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 	app.post("/execute", async (request: FastifyRequest, reply) => {
 		const body = validateRequest(executeSyncSchema, request.body);
 		const userId = request.currentUser!.id; // preHandler guarantees auth
+		if (!(await ownsSyncTarget(userId, body.templateId, body.instanceId))) {
+			return reply.status(404).send({
+				statusCode: 404,
+				error: "NotFound",
+				message: "Sync target not found",
+			});
+		}
 
 		// Convert conflictResolutions object to Map
 		const resolutionsMap = body.conflictResolutions
@@ -253,21 +292,30 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 				templateId: body.templateId,
 				instanceId: body.instanceId,
 				userId,
-				syncType: body.syncType,
+				syncType: "MANUAL",
 			},
 			resolutionsMap,
+			body.executionToken,
 		);
 
 		// By the time we get here, sync is complete. Store final state in progress store
 		// so that polling endpoints can retrieve it
 		const finalProgress: SyncProgress = {
 			syncId: result.syncId,
-			status: result.status === "UNCERTAIN" ? "UNCERTAIN" : result.success ? "COMPLETED" : "FAILED",
-			currentStep: result.success
-				? `Sync completed: ${result.configsApplied} applied, ${result.configsFailed} failed`
-				: result.status === "UNCERTAIN"
+			status:
+				result.status === "UNCERTAIN"
+					? "UNCERTAIN"
+					: result.status === "FAILED"
+						? "FAILED"
+						: "COMPLETED",
+			currentStep:
+				result.status === "UNCERTAIN"
 					? "Sync result is uncertain; resolve or roll back before retrying"
-					: "Sync failed",
+					: result.status !== "FAILED"
+						? result.warnings?.length
+							? `Sync completed with warnings: ${result.warnings.join("; ")}`
+							: `Sync completed: ${result.configsApplied} applied, ${result.configsFailed} failed`
+						: "Sync failed",
 			progress: 100,
 			totalConfigs: result.configsApplied + result.configsFailed + result.configsSkipped,
 			appliedConfigs: result.configsApplied,

--- a/apps/api/src/routes/trash-guides/template-routes.ts
+++ b/apps/api/src/routes/trash-guides/template-routes.ts
@@ -17,6 +17,40 @@ import { validateRequest } from "../../lib/utils/validate.js";
 // Request Schemas
 // ============================================================================
 
+const executeTemplateDeploymentSchema = z.object({
+	templateId: z.string().min(1),
+	instanceId: z.string().min(1),
+	executionToken: z.string().length(64),
+});
+
+const executeTemplateBulkDeploymentSchema = z
+	.object({
+		templateId: z.string().min(1),
+		instanceIds: z.array(z.string().min(1)).min(1),
+		executionTokens: z.record(z.string(), z.string().length(64)),
+	})
+	.superRefine((body, context) => {
+		const selected = new Set(body.instanceIds);
+		for (const instanceId of body.instanceIds) {
+			if (!body.executionTokens[instanceId]) {
+				context.addIssue({
+					code: "custom",
+					path: ["executionTokens", instanceId],
+					message: "A fresh execution token is required for every selected instance",
+				});
+			}
+		}
+		for (const instanceId of Object.keys(body.executionTokens)) {
+			if (!selected.has(instanceId)) {
+				context.addIssue({
+					code: "custom",
+					path: ["executionTokens", instanceId],
+					message: "Execution tokens may only be provided for selected instances",
+				});
+			}
+		}
+	});
+
 // Custom Format Specification schema (validates TRaSH CF structure)
 const customFormatSpecificationSchema = z.object({
 	name: z.string(),
@@ -638,17 +672,13 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 		Body: {
 			templateId: string;
 			instanceId: string;
+			executionToken: string;
 		};
 	}>("/deployment/execute", async (request, reply) => {
-		const { templateId, instanceId } = request.body;
-
-		if (!templateId || !instanceId) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "templateId and instanceId are required",
-			});
-		}
+		const { templateId, instanceId, executionToken } = validateRequest(
+			executeTemplateDeploymentSchema,
+			request.body,
+		);
 
 		await requireTemplate(app.prisma, request.currentUser!.id, templateId);
 		await requireInstance(app, request.currentUser!.id, instanceId);
@@ -658,6 +688,9 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 			templateId,
 			instanceId,
 			request.currentUser!.id,
+			undefined,
+			undefined,
+			executionToken,
 		);
 
 		return reply.send({
@@ -674,25 +707,13 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 		Body: {
 			templateId: string;
 			instanceIds: string[];
+			executionTokens: Record<string, string>;
 		};
 	}>("/deployment/bulk", async (request, reply) => {
-		const { templateId, instanceIds } = request.body;
-
-		if (!templateId || !instanceIds || !Array.isArray(instanceIds)) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "templateId and instanceIds array are required",
-			});
-		}
-
-		if (instanceIds.length === 0) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "At least one instance ID is required",
-			});
-		}
+		const { templateId, instanceIds, executionTokens } = validateRequest(
+			executeTemplateBulkDeploymentSchema,
+			request.body,
+		);
 
 		await requireTemplate(app.prisma, request.currentUser!.id, templateId);
 
@@ -717,6 +738,9 @@ export async function registerTemplateRoutes(app: FastifyInstance, _opts: Fastif
 			templateId,
 			instanceIds,
 			request.currentUser!.id,
+			undefined,
+			undefined,
+			executionTokens,
 		);
 
 		return reply.send({

--- a/apps/api/src/routes/trash-guides/update-routes.ts
+++ b/apps/api/src/routes/trash-guides/update-routes.ts
@@ -157,23 +157,30 @@ export async function registerUpdateRoutes(app: FastifyInstance, _opts: FastifyP
 		const { templateUpdater } = await getServices(request.currentUser!.id);
 		const result = await templateUpdater.processAutoUpdates(request.currentUser!.id);
 		for (const outcome of result.uncertainDeployments) {
-			await app.notificationService.notify(
-				{
-					eventType: "TRASH_DEPLOY_UNCERTAIN",
-					title: `Automatic TRaSH deployment needs review on ${outcome.instanceLabel}`,
-					body: outcome.errors.join("; "),
-					url: "/trash-guides",
-					metadata: {
-						instanceId: outcome.instanceId,
-						endpointKey: outcome.endpointKey,
-						reason: "uncertain_result",
+			try {
+				await app.notificationService.notify(
+					{
+						eventType: "TRASH_DEPLOY_UNCERTAIN",
+						title: `Automatic TRaSH deployment needs review on ${outcome.instanceLabel}`,
+						body: outcome.errors.join("; "),
+						url: "/trash-guides",
+						metadata: {
+							instanceId: outcome.instanceId,
+							endpointKey: outcome.endpointKey,
+							reason: "uncertain_result",
+						},
 					},
-				},
-				{
-					userId: request.currentUser!.id,
-					fallbackEventTypes: ["TRASH_SYNC_ERROR"],
-				},
-			);
+					{
+						userId: request.currentUser!.id,
+						fallbackEventTypes: ["TRASH_SYNC_ERROR"],
+					},
+				);
+			} catch (error) {
+				request.log.warn(
+					{ err: error, instanceId: outcome.instanceId, endpointKey: outcome.endpointKey },
+					"Automatic deployment review notification failed",
+				);
+			}
 		}
 
 		return reply.send({

--- a/apps/api/src/routes/trash-guides/update-routes.ts
+++ b/apps/api/src/routes/trash-guides/update-routes.ts
@@ -156,6 +156,25 @@ export async function registerUpdateRoutes(app: FastifyInstance, _opts: FastifyP
 	app.post("/process-auto", async (request, reply) => {
 		const { templateUpdater } = await getServices(request.currentUser!.id);
 		const result = await templateUpdater.processAutoUpdates(request.currentUser!.id);
+		for (const outcome of result.uncertainDeployments) {
+			await app.notificationService.notify(
+				{
+					eventType: "TRASH_DEPLOY_UNCERTAIN",
+					title: `Automatic TRaSH deployment needs review on ${outcome.instanceLabel}`,
+					body: outcome.errors.join("; "),
+					url: "/trash-guides",
+					metadata: {
+						instanceId: outcome.instanceId,
+						endpointKey: outcome.endpointKey,
+						reason: "uncertain_result",
+					},
+				},
+				{
+					userId: request.currentUser!.id,
+					fallbackEventTypes: ["TRASH_SYNC_ERROR"],
+				},
+			);
+		}
 
 		return reply.send({
 			success: true,
@@ -164,6 +183,7 @@ export async function registerUpdateRoutes(app: FastifyInstance, _opts: FastifyP
 					processed: result.processed,
 					successful: result.successful,
 					failed: result.failed,
+					uncertain: result.uncertain,
 				},
 				results: result.results,
 			},

--- a/apps/web/src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { DeploymentPreview } from "@arr/shared";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { BulkDeploymentModal } from "../bulk-deployment-modal";
+import { DeploymentPreviewModal } from "../deployment-preview-modal";
+
+const hookMocks = vi.hoisted(() => ({
+	useDeploymentPreview: vi.fn(),
+	useExecuteDeployment: vi.fn(),
+	useBulkDeploymentPreviews: vi.fn(),
+	useExecuteBulkDeployment: vi.fn(),
+}));
+
+vi.mock("../../../../hooks/api/useDeploymentPreview", () => hookMocks);
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#6366f1",
+			to: "#8b5cf6",
+			glow: "rgba(99, 102, 241, 0.3)",
+			fromLight: "rgba(99, 102, 241, 0.1)",
+			fromMuted: "rgba(99, 102, 241, 0.3)",
+		},
+	}),
+}));
+
+const makePreview = (instanceId: string, executionToken: string): DeploymentPreview => ({
+	templateId: "template-1",
+	templateName: "Test Template",
+	instanceId,
+	instanceLabel: `Instance ${instanceId}`,
+	instanceServiceType: "RADARR" as const,
+	executionToken,
+	summary: {
+		totalItems: 1,
+		newCustomFormats: 1,
+		updatedCustomFormats: 0,
+		deletedCustomFormats: 0,
+		skippedCustomFormats: 0,
+		totalConflicts: 0,
+		unresolvedConflicts: 0,
+		unmatchedCustomFormats: 0,
+		orphanedCustomFormats: 0,
+	},
+	customFormats: [],
+	unmatchedCustomFormats: [],
+	orphanedCustomFormats: [],
+	canDeploy: true,
+	requiresConflictResolution: false,
+	instanceReachable: true,
+	warnings: [],
+});
+
+const renderWithQueryClient = (children: ReactNode) => {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+};
+
+describe("deployment execution tokens", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("passes the exact preview token to single-instance execution", async () => {
+		const executionToken = "a".repeat(64);
+		const mutate = vi.fn();
+		hookMocks.useDeploymentPreview.mockReturnValue({
+			data: { success: true, data: makePreview("instance-1", executionToken) },
+			isLoading: false,
+			error: null,
+		});
+		hookMocks.useExecuteDeployment.mockReturnValue({
+			mutate,
+			isError: false,
+			isPending: false,
+			data: undefined,
+		});
+
+		renderWithQueryClient(
+			<DeploymentPreviewModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				instanceId="instance-1"
+			/>,
+		);
+
+		fireEvent.click(await screen.findByRole("button", { name: "Deploy to Instance" }));
+
+		expect(mutate).toHaveBeenCalledWith(
+			expect.objectContaining({ executionToken }),
+			expect.any(Object),
+		);
+	});
+
+	it("passes each selected instance's exact preview token to bulk execution", async () => {
+		const executionTokens = {
+			"instance-1": "b".repeat(64),
+			"instance-2": "c".repeat(64),
+		};
+		const mutate = vi.fn();
+		hookMocks.useBulkDeploymentPreviews.mockReturnValue({
+			results: Object.entries(executionTokens).map(([instanceId, executionToken]) => ({
+				instanceId,
+				isLoading: false,
+				isError: false,
+				error: null,
+				data: { success: true, data: makePreview(instanceId, executionToken) },
+			})),
+			isLoading: false,
+			hasErrors: false,
+		});
+		hookMocks.useExecuteBulkDeployment.mockReturnValue({
+			mutate,
+			reset: vi.fn(),
+			isError: false,
+			isPending: false,
+			isSuccess: false,
+			data: undefined,
+		});
+
+		renderWithQueryClient(
+			<BulkDeploymentModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				instances={[
+					{ instanceId: "instance-1", instanceLabel: "One", instanceType: "RADARR" },
+					{ instanceId: "instance-2", instanceLabel: "Two", instanceType: "RADARR" },
+				]}
+			/>,
+		);
+
+		const deployButton = await screen.findByRole("button", { name: "Deploy to 2 Instances" });
+		await waitFor(() => expect(deployButton).toBeEnabled());
+		fireEvent.click(deployButton);
+
+		expect(mutate).toHaveBeenCalledWith(
+			expect.objectContaining({ executionTokens }),
+			expect.any(Object),
+		);
+	});
+});

--- a/apps/web/src/features/trash-guides/components/__tests__/manual-sync-authority-and-orphans.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/manual-sync-authority-and-orphans.test.tsx
@@ -1,0 +1,239 @@
+import type { DeploymentPreview } from "@arr/shared";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SyncExecuteRequest } from "../../../../lib/api-client/trash-guides";
+import { DeploymentPreviewModal } from "../deployment-preview-modal";
+import { TemplateList } from "../template-list";
+
+const executionToken = "a".repeat(64);
+
+const hookMocks = vi.hoisted(() => ({
+	executeSync: vi.fn(),
+	useDeploymentPreview: vi.fn(),
+	useExecuteDeployment: vi.fn(),
+}));
+
+const validationResult = {
+	valid: true,
+	conflicts: [],
+	errors: [],
+	warnings: [],
+	executionToken,
+	preview: {
+		templateId: "template-1",
+		templateName: "Test Template",
+		instanceId: "instance-1",
+		instanceLabel: "Test Instance",
+		instanceServiceType: "RADARR" as const,
+		executionToken,
+		summary: {
+			totalItems: 0,
+			newCustomFormats: 0,
+			updatedCustomFormats: 0,
+			deletedCustomFormats: 0,
+			skippedCustomFormats: 0,
+			totalConflicts: 0,
+			unresolvedConflicts: 0,
+			unmatchedCustomFormats: 0,
+			orphanedCustomFormats: 2,
+		},
+		customFormats: [],
+		unmatchedCustomFormats: [],
+		orphanedCustomFormats: [
+			{ instanceId: 10, name: "Orphan One", score: 125 },
+			{ instanceId: 11, name: "Orphan Two", score: -50 },
+		],
+		canDeploy: true,
+		requiresConflictResolution: false,
+		instanceReachable: true,
+		warnings: [],
+	},
+};
+
+vi.mock("../../../../hooks/api/useSync", () => ({
+	useExecuteSync: () => ({ mutateAsync: hookMocks.executeSync }),
+	useValidateSync: (options?: { onSuccess?: (data: typeof validationResult) => void }) => ({
+		mutate: (
+			_request: unknown,
+			callbacks?: { onSuccess?: (data: typeof validationResult) => void },
+		) => {
+			options?.onSuccess?.(validationResult);
+			callbacks?.onSuccess?.(validationResult);
+		},
+		isPending: false,
+		isError: false,
+		isSuccess: true,
+		error: null,
+		cancelRetry: vi.fn(),
+	}),
+}));
+
+vi.mock("../../../../hooks/api/useDeploymentPreview", () => ({
+	useDeploymentPreview: hookMocks.useDeploymentPreview,
+	useExecuteDeployment: hookMocks.useExecuteDeployment,
+	useUnlinkTemplateFromInstance: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({ data: [] }),
+}));
+
+vi.mock("../../../../hooks/api/useTemplates", () => ({
+	TEMPLATES_QUERY_KEY: ["trash-guides", "templates"],
+	useDeleteTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useDuplicateTemplate: () => ({ mutateAsync: vi.fn(), isPending: false }),
+	useTemplates: () => ({ data: { templates: [] }, isLoading: false, error: null }),
+}));
+
+vi.mock("../../../../hooks/api/useTemplateUpdates", () => ({
+	useTemplateUpdates: () => ({ data: undefined }),
+}));
+
+vi.mock("../../hooks/use-template-list-modals", () => ({
+	useTemplateListModals: () => [
+		{
+			deleteConfirm: null,
+			duplicateName: "",
+			duplicatingId: null,
+			instanceSelectorTemplate: null,
+			validationModal: {
+				templateId: "template-1",
+				templateName: "Test Template",
+				instanceId: "instance-1",
+				instanceName: "Test Instance",
+			},
+			progressModal: null,
+			deploymentModal: null,
+			exportModal: null,
+			importModal: false,
+			unlinkConfirm: null,
+			bulkDeployModal: null,
+		},
+		vi.fn(),
+	],
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#6366f1",
+			to: "#8b5cf6",
+			glow: "rgba(99, 102, 241, 0.3)",
+			fromLight: "rgba(99, 102, 241, 0.1)",
+			fromMedium: "rgba(99, 102, 241, 0.2)",
+			fromMuted: "rgba(99, 102, 241, 0.3)",
+		},
+	}),
+}));
+
+vi.mock("../../../../lib/incognito", () => ({
+	getLinuxInstanceName: (name: string) => name,
+	useIncognitoMode: () => [false],
+}));
+
+function renderWithQueryClient(children: ReactNode) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+}
+
+describe("manual sync authority", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		hookMocks.executeSync.mockResolvedValue({ syncId: "sync-1" });
+	});
+
+	it("passes the exact validation token through the modal to sync execution", async () => {
+		renderWithQueryClient(
+			<TemplateList
+				onCreateNew={vi.fn()}
+				onEdit={vi.fn()}
+				onImport={vi.fn()}
+				onBrowseQualityProfiles={vi.fn()}
+			/>,
+		);
+
+		const startSyncButton = await screen.findByRole("button", { name: "Start Sync" });
+		await waitFor(() => expect(startSyncButton).toBeEnabled());
+		fireEvent.click(startSyncButton);
+
+		await waitFor(() =>
+			expect(hookMocks.executeSync).toHaveBeenCalledWith({
+				templateId: "template-1",
+				instanceId: "instance-1",
+				syncType: "MANUAL",
+				executionToken,
+				conflictResolutions: {},
+			}),
+		);
+	});
+
+	it("does not expose scheduled authority in the browser request type", () => {
+		const manualRequest: SyncExecuteRequest = {
+			templateId: "template-1",
+			instanceId: "instance-1",
+			syncType: "MANUAL",
+			executionToken,
+		};
+
+		expect(manualRequest.syncType).toBe("MANUAL");
+
+		// @ts-expect-error Browser callers cannot claim scheduler authority.
+		const scheduledRequest: SyncExecuteRequest = { ...manualRequest, syncType: "SCHEDULED" };
+		expect(scheduledRequest.syncType).toBe("SCHEDULED");
+	});
+});
+
+describe("orphan review visibility", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("shows every orphan score reset in manual sync validation", async () => {
+		renderWithQueryClient(
+			<TemplateList
+				onCreateNew={vi.fn()}
+				onEdit={vi.fn()}
+				onImport={vi.fn()}
+				onBrowseQualityProfiles={vi.fn()}
+			/>,
+		);
+
+		expect(await screen.findByText("Orphan One")).toBeInTheDocument();
+		expect(screen.getByText("125 → 0")).toBeInTheDocument();
+		expect(screen.getByText("Orphan Two")).toBeInTheDocument();
+		expect(screen.getByText("-50 → 0")).toBeInTheDocument();
+	});
+
+	it("shows every orphan score reset in deployment preview", async () => {
+		hookMocks.useDeploymentPreview.mockReturnValue({
+			data: { success: true, data: validationResult.preview as DeploymentPreview },
+			isLoading: false,
+			error: null,
+		});
+		hookMocks.useExecuteDeployment.mockReturnValue({
+			mutate: vi.fn(),
+			isError: false,
+			isPending: false,
+			data: undefined,
+		});
+
+		renderWithQueryClient(
+			<DeploymentPreviewModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				instanceId="instance-1"
+			/>,
+		);
+
+		expect(await screen.findByText("Orphan One")).toBeInTheDocument();
+		expect(screen.getByText("125 → 0")).toBeInTheDocument();
+		expect(screen.getByText("Orphan Two")).toBeInTheDocument();
+		expect(screen.getByText("-50 → 0")).toBeInTheDocument();
+		expect(screen.queryByText("Instance is up to date")).not.toBeInTheDocument();
+	});
+});

--- a/apps/web/src/features/trash-guides/components/__tests__/manual-sync-authority-and-orphans.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/manual-sync-authority-and-orphans.test.tsx
@@ -3,8 +3,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { SyncExecuteRequest } from "../../../../lib/api-client/trash-guides";
+import type { SyncExecuteRequest, ValidationResult } from "../../../../lib/api-client/trash-guides";
 import { DeploymentPreviewModal } from "../deployment-preview-modal";
+import { SyncValidationModal } from "../sync-validation-modal";
 import { TemplateList } from "../template-list";
 
 const executionToken = "a".repeat(64);
@@ -15,7 +16,7 @@ const hookMocks = vi.hoisted(() => ({
 	useExecuteDeployment: vi.fn(),
 }));
 
-const validationResult = {
+const validationResult: ValidationResult = {
 	valid: true,
 	conflicts: [],
 	errors: [],
@@ -52,15 +53,14 @@ const validationResult = {
 	},
 };
 
+let activeValidationResult = validationResult;
+
 vi.mock("../../../../hooks/api/useSync", () => ({
 	useExecuteSync: () => ({ mutateAsync: hookMocks.executeSync }),
-	useValidateSync: (options?: { onSuccess?: (data: typeof validationResult) => void }) => ({
-		mutate: (
-			_request: unknown,
-			callbacks?: { onSuccess?: (data: typeof validationResult) => void },
-		) => {
-			options?.onSuccess?.(validationResult);
-			callbacks?.onSuccess?.(validationResult);
+	useValidateSync: (options?: { onSuccess?: (data: ValidationResult) => void }) => ({
+		mutate: (_request: unknown, callbacks?: { onSuccess?: (data: ValidationResult) => void }) => {
+			options?.onSuccess?.(activeValidationResult);
+			callbacks?.onSuccess?.(activeValidationResult);
 		},
 		isPending: false,
 		isError: false,
@@ -143,6 +143,7 @@ function renderWithQueryClient(children: ReactNode) {
 describe("manual sync authority", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		activeValidationResult = validationResult;
 		hookMocks.executeSync.mockResolvedValue({ syncId: "sync-1" });
 	});
 
@@ -190,6 +191,7 @@ describe("manual sync authority", () => {
 describe("orphan review visibility", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		activeValidationResult = validationResult;
 	});
 
 	it("shows every orphan score reset in manual sync validation", async () => {
@@ -235,5 +237,121 @@ describe("orphan review visibility", () => {
 		expect(screen.getByText("Orphan Two")).toBeInTheDocument();
 		expect(screen.getByText("-50 → 0")).toBeInTheDocument();
 		expect(screen.queryByText("Instance is up to date")).not.toBeInTheDocument();
+	});
+});
+
+describe("manual sync reviewed preview", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		activeValidationResult = {
+			...validationResult,
+			conflicts: [],
+			warnings: ["Validation warning shown to the reviewer."],
+			preview: {
+				...validationResult.preview!,
+				summary: {
+					...validationResult.preview!.summary,
+					totalItems: 2,
+					newCustomFormats: 1,
+					updatedCustomFormats: 1,
+					totalConflicts: 1,
+					unresolvedConflicts: 1,
+				},
+				customFormats: [
+					{
+						trashId: "created-format",
+						name: "Created Format",
+						action: "create",
+						defaultScore: 25,
+						scoreOverride: 25,
+						templateData: {},
+						conflicts: [],
+						hasConflicts: false,
+					},
+					{
+						trashId: "updated-format",
+						name: "Updated Format",
+						action: "update",
+						defaultScore: 500,
+						scoreOverride: 500,
+						templateData: { score: 500 },
+						instanceData: { score: 100 },
+						hasConflicts: true,
+						conflicts: [
+							{
+								cfTrashId: "updated-format",
+								cfName: "Updated Format",
+								conflictType: "score_mismatch",
+								templateValue: 500,
+								instanceValue: 100,
+								suggestedResolution: "use_template",
+							},
+						],
+					},
+				],
+				namingChanges: ["movieFolderFormat", "standardMovieFormat"],
+				warnings: ["Preview warning bound to this execution token."],
+				requiresConflictResolution: true,
+				canDeploy: false,
+			},
+		};
+	});
+
+	it("renders every token-bound reviewed change and warning", async () => {
+		renderWithQueryClient(
+			<SyncValidationModal
+				templateId="template-1"
+				templateName="Test Template"
+				instanceId="instance-1"
+				instanceName="Test Instance"
+				onConfirm={vi.fn()}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		expect(await screen.findByText("Custom Format Changes (2)")).toBeInTheDocument();
+		expect(screen.getByText("Created Format")).toBeInTheDocument();
+		expect(screen.getByText("Create")).toBeInTheDocument();
+		expect(screen.getByText("Updated Format")).toBeInTheDocument();
+		expect(screen.getByText("Update")).toBeInTheDocument();
+		expect(screen.getByText("Score mismatch")).toBeInTheDocument();
+		expect(screen.getByText("Template: 500")).toBeInTheDocument();
+		expect(screen.getByText("Instance: 100")).toBeInTheDocument();
+		expect(screen.getByText("Naming Changes (2)")).toBeInTheDocument();
+		expect(screen.getByText("movieFolderFormat")).toBeInTheDocument();
+		expect(screen.getByText("standardMovieFormat")).toBeInTheDocument();
+		expect(screen.getByText("Orphan One")).toBeInTheDocument();
+		expect(screen.getByText("Orphan Two")).toBeInTheDocument();
+		expect(screen.getByText(/Validation warning shown to the reviewer\./)).toBeInTheDocument();
+		expect(screen.getByText(/Preview warning bound to this execution token\./)).toBeInTheDocument();
+	});
+
+	it("requires an explicit resolution for preview conflicts before confirmation", async () => {
+		const onConfirm = vi.fn();
+		renderWithQueryClient(
+			<SyncValidationModal
+				templateId="template-1"
+				templateName="Test Template"
+				instanceId="instance-1"
+				instanceName="Test Instance"
+				onConfirm={onConfirm}
+				onCancel={vi.fn()}
+			/>,
+		);
+
+		const confirmButton = await screen.findByRole("button", {
+			name: "Resolve all conflicts to continue",
+		});
+		expect(confirmButton).toBeDisabled();
+		fireEvent.click(confirmButton);
+		expect(onConfirm).not.toHaveBeenCalled();
+
+		fireEvent.click(screen.getByRole("button", { name: "Keep existing Updated Format" }));
+		expect(confirmButton).toBeEnabled();
+		fireEvent.click(confirmButton);
+
+		expect(onConfirm).toHaveBeenCalledWith(executionToken, {
+			"updated-format": "SKIP",
+		});
 	});
 });

--- a/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-deployment-modal.tsx
@@ -65,6 +65,7 @@ interface InstancePreview {
 		updatedCustomFormats: number;
 		conflicts: number;
 		canDeploy: boolean;
+		executionToken: string;
 	};
 	loading: boolean;
 	error?: Error;
@@ -213,6 +214,7 @@ export const BulkDeploymentModal = ({
 							updatedCustomFormats: preview.summary.updatedCustomFormats,
 							conflicts: preview.summary.totalConflicts,
 							canDeploy: preview.canDeploy,
+							executionToken: preview.executionToken,
 						}
 					: undefined,
 			};
@@ -291,14 +293,18 @@ export const BulkDeploymentModal = ({
 
 		// Build per-instance sync strategies map
 		const instanceSyncStrategies: Record<string, SyncStrategy> = {};
+		const executionTokens: Record<string, string> = {};
 		for (const inst of deployableInstances) {
+			if (!inst.preview?.executionToken) return;
 			instanceSyncStrategies[inst.instanceId] = inst.syncStrategy;
+			executionTokens[inst.instanceId] = inst.preview.executionToken;
 		}
 
 		bulkDeployMutation.mutate(
 			{
 				templateId,
 				instanceIds: deployableInstances.map((inst) => inst.instanceId),
+				executionTokens,
 				instanceSyncStrategies,
 			},
 			{

--- a/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
@@ -192,12 +192,13 @@ export const DeploymentPreviewModal = ({
 	const deploymentMutation = useExecuteDeployment();
 
 	const handleDeploy = () => {
-		if (!templateId || !instanceId) return;
+		if (!templateId || !instanceId || !data?.data.executionToken) return;
 
 		deploymentMutation.mutate(
 			{
 				templateId,
 				instanceId,
+				executionToken: data.data.executionToken,
 				syncStrategy,
 				conflictResolutions:
 					Object.keys(conflictResolutions).length > 0 ? conflictResolutions : undefined,
@@ -695,8 +696,43 @@ export const DeploymentPreviewModal = ({
 							</div>
 						)}
 
+						{/* Previously Managed Custom Formats */}
+						{data.data.orphanedCustomFormats.length > 0 && (
+							<div className="space-y-3">
+								<h3 className="text-sm font-medium text-foreground">
+									Managed Custom Formats Reset to Zero ({data.data.orphanedCustomFormats.length})
+								</h3>
+								<p className="text-xs text-muted-foreground">
+									These formats are no longer in the template. Deployment will reset their scores to
+									0.
+								</p>
+								<div className="max-h-48 space-y-2 overflow-y-auto">
+									{data.data.orphanedCustomFormats.map((orphan) => (
+										<div
+											key={orphan.instanceId}
+											className="flex items-center justify-between gap-4 rounded-xl border p-3"
+											style={{
+												backgroundColor: SEMANTIC_COLORS.warning.bg,
+												borderColor: SEMANTIC_COLORS.warning.border,
+											}}
+										>
+											<span className="min-w-0 truncate text-sm font-medium text-foreground">
+												{orphan.name}
+											</span>
+											<span
+												className="shrink-0 font-mono text-sm"
+												style={{ color: SEMANTIC_COLORS.warning.text }}
+											>
+												{orphan.score} → 0
+											</span>
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+
 						{/* No Changes Message */}
-						{data.data.summary.totalItems === 0 && (
+						{data.data.summary.totalItems === 0 && data.data.orphanedCustomFormats.length === 0 && (
 							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-8 text-center">
 								<CheckCircle2
 									className="h-12 w-12 mx-auto mb-3"

--- a/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
@@ -504,9 +504,9 @@ export const SyncValidationModal = ({
 																	{item.conflicts.length !== 1 ? "s" : ""} Detected
 																</p>
 																<div className="mt-2 space-y-2">
-													{item.conflicts.map((conflict) => (
-														<div
-															key={`${item.trashId}-${conflict.cfTrashId}-${conflict.conflictType}`}
+																	{item.conflicts.map((conflict) => (
+																		<div
+																			key={`${item.trashId}-${conflict.cfTrashId}-${conflict.conflictType}`}
 																			className="rounded-lg border border-border/50 bg-muted/20 p-2 text-xs"
 																		>
 																			<p className="font-medium text-foreground">

--- a/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
@@ -19,6 +19,7 @@ import { Button } from "../../../components/ui";
 import { useValidateSync } from "../../../hooks/api/useSync";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import type { ValidationResult } from "../../../lib/api-client/trash-guides";
+import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import {
 	detectErrorTypes,
 	type ErrorType,
@@ -42,7 +43,7 @@ interface SyncValidationModalProps {
 	templateName: string;
 	instanceId: string;
 	instanceName: string;
-	onConfirm: (resolutions: Record<string, "REPLACE" | "SKIP">) => void;
+	onConfirm: (executionToken: string, resolutions: Record<string, "REPLACE" | "SKIP">) => void;
 	onCancel: () => void;
 	/** Optional callback to navigate to deployment workflow */
 	onNavigateToDeploy?: () => void;
@@ -264,14 +265,16 @@ export const SyncValidationModal = ({
 	};
 
 	const handleConfirm = () => {
-		onConfirm(resolutions);
+		if (!validation?.executionToken) return;
+		onConfirm(validation.executionToken, resolutions);
 	};
 
 	const isValidating = validateMutation.isPending;
 	const hasErrors = Array.isArray(validation?.errors) && validation.errors.length > 0;
 	const _hasWarnings = Array.isArray(validation?.warnings) && validation.warnings.length > 0;
 	const hasConflicts = Array.isArray(validation?.conflicts) && validation.conflicts.length > 0;
-	const canProceed = validation && validation.valid && !hasErrors;
+	const canProceed = !!validation?.executionToken && validation.valid && !hasErrors;
+	const orphanedCustomFormats = validation?.preview?.orphanedCustomFormats ?? [];
 
 	const hasSilentFailure = validation && !validation.valid && !hasErrors;
 
@@ -424,6 +427,50 @@ export const SyncValidationModal = ({
 													<li key={index}>• {info}</li>
 												))}
 											</ul>
+										</div>
+									</div>
+								</div>
+							)}
+
+							{orphanedCustomFormats.length > 0 && (
+								<div
+									className="rounded-xl p-4"
+									style={{
+										backgroundColor: SEMANTIC_COLORS.warning.bg,
+										border: `1px solid ${SEMANTIC_COLORS.warning.border}`,
+									}}
+								>
+									<div className="flex items-start gap-3">
+										<Info
+											className="h-5 w-5 shrink-0"
+											style={{ color: SEMANTIC_COLORS.warning.from }}
+										/>
+										<div className="min-w-0 flex-1">
+											<h3 className="font-medium" style={{ color: SEMANTIC_COLORS.warning.text }}>
+												Managed Custom Formats Reset to Zero ({orphanedCustomFormats.length})
+											</h3>
+											<p className="mt-1 text-sm text-muted-foreground">
+												These formats are no longer in the template. Sync will reset their scores to
+												0.
+											</p>
+											<div className="mt-3 space-y-2">
+												{orphanedCustomFormats.map((orphan) => (
+													<div
+														key={orphan.instanceId}
+														className="flex items-center justify-between gap-4 rounded-lg border border-border/50 bg-card/30 px-3 py-2"
+													>
+														<span className="min-w-0 truncate text-sm font-medium text-foreground">
+															{orphan.name}
+														</span>
+														<span
+															className="shrink-0 font-mono text-sm"
+															style={{ color: SEMANTIC_COLORS.warning.text }}
+														>
+															{orphan.score} → 0
+														</span>
+													</div>
+												))}
+											</div>
 										</div>
 									</div>
 								</div>

--- a/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
@@ -13,12 +13,12 @@
  */
 
 import { Info, Loader2, RefreshCw, X } from "lucide-react";
-import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { useEffect, useRef, useState } from "react";
 import { Button } from "../../../components/ui";
 import { useValidateSync } from "../../../hooks/api/useSync";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
 import type { ValidationResult } from "../../../lib/api-client/trash-guides";
+import { getLinuxInstanceName, useIncognitoMode } from "../../../lib/incognito";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import {
 	detectErrorTypes,
@@ -37,6 +37,21 @@ import {
 
 // Check if we're in development mode
 const isDevelopment = process.env.NODE_ENV === "development";
+
+const ACTION_LABELS = {
+	create: "Create",
+	update: "Update",
+	delete: "Delete",
+	skip: "Skip",
+} as const;
+
+const formatConflictType = (conflictType: string) => {
+	const label = conflictType.replaceAll("_", " ");
+	return `${label.charAt(0).toUpperCase()}${label.slice(1)}`;
+};
+
+const formatConflictValue = (value: unknown) =>
+	typeof value === "object" && value !== null ? JSON.stringify(value) : String(value);
 
 interface SyncValidationModalProps {
 	templateId: string;
@@ -223,15 +238,7 @@ export const SyncValidationModal = ({
 			{
 				onSuccess: (data) => {
 					setValidation(data);
-					if (data && Array.isArray(data.conflicts) && data.conflicts.length > 0) {
-						const defaultResolutions: Record<string, "REPLACE" | "SKIP"> = {};
-						data.conflicts.forEach((conflict) => {
-							defaultResolutions[conflict.configName] = "REPLACE";
-						});
-						setResolutions(defaultResolutions);
-					} else {
-						setResolutions({});
-					}
+					setResolutions({});
 				},
 			},
 		);
@@ -264,26 +271,46 @@ export const SyncValidationModal = ({
 		}));
 	};
 
-	const handleConfirm = () => {
-		if (!validation?.executionToken) return;
-		onConfirm(validation.executionToken, resolutions);
-	};
-
 	const isValidating = validateMutation.isPending;
 	const hasErrors = Array.isArray(validation?.errors) && validation.errors.length > 0;
-	const _hasWarnings = Array.isArray(validation?.warnings) && validation.warnings.length > 0;
-	const hasConflicts = Array.isArray(validation?.conflicts) && validation.conflicts.length > 0;
 	const canProceed = !!validation?.executionToken && validation.valid && !hasErrors;
-	const orphanedCustomFormats = validation?.preview?.orphanedCustomFormats ?? [];
+	const preview = validation?.preview;
+	const customFormats = preview?.customFormats ?? [];
+	const namingChanges = preview?.namingChanges ?? [];
+	const unmatchedCustomFormats = preview?.unmatchedCustomFormats ?? [];
+	const orphanedCustomFormats = preview?.orphanedCustomFormats ?? [];
+	const previewConflictItems = customFormats.filter(
+		(item) => item.hasConflicts || item.conflicts.length > 0,
+	);
+	const previewConflictNames = new Set(previewConflictItems.map((item) => item.name));
+	const legacyConflicts = (validation?.conflicts ?? []).filter(
+		(conflict) => !previewConflictNames.has(conflict.configName),
+	);
+	const conflictKeys = [
+		...previewConflictItems.map((item) => item.trashId),
+		...legacyConflicts.map((conflict) => conflict.configName),
+	];
+	const previewHasUnrenderableConflicts = Boolean(
+		preview &&
+			(preview.requiresConflictResolution || preview.summary.unresolvedConflicts > 0) &&
+			conflictKeys.length === 0,
+	);
+	const hasConflicts = conflictKeys.length > 0 || previewHasUnrenderableConflicts;
+	const hasUnresolvedConflicts =
+		previewHasUnrenderableConflicts || conflictKeys.some((key) => !resolutions[key]);
+	const canConfirm = canProceed && !hasUnresolvedConflicts;
 
 	const hasSilentFailure = validation && !validation.valid && !hasErrors;
 
 	const errorTypes = hasErrors ? detectErrorTypes(validation.errors) : new Set<ErrorType>();
 
-	const informationalWarnings = (validation?.warnings || []).filter(
+	const warnings = Array.from(
+		new Set([...(validation?.warnings ?? []), ...(preview?.warnings ?? [])]),
+	);
+	const informationalWarnings = warnings.filter(
 		(w) => w.includes("is reachable") || w.includes("Validation passed"),
 	);
-	const actualWarnings = (validation?.warnings || []).filter(
+	const actualWarnings = warnings.filter(
 		(w) => !w.includes("is reachable") && !w.includes("Validation passed"),
 	);
 	const hasActualWarnings = actualWarnings.length > 0;
@@ -291,6 +318,11 @@ export const SyncValidationModal = ({
 	const _isAutoRetrying = retryProgress !== null && retryProgress.isWaiting;
 
 	const displayError = localError ?? validateMutation.error ?? null;
+
+	const handleConfirm = () => {
+		if (!validation?.executionToken || !canConfirm) return;
+		onConfirm(validation.executionToken, resolutions);
+	};
 
 	// Shared retry props for extracted panels
 	const retryProps = {
@@ -432,6 +464,132 @@ export const SyncValidationModal = ({
 								</div>
 							)}
 
+							{customFormats.length > 0 && (
+								<section className="space-y-3" aria-labelledby="sync-custom-format-changes">
+									<h3
+										id="sync-custom-format-changes"
+										className="text-sm font-medium text-foreground"
+									>
+										Custom Format Changes ({customFormats.length})
+									</h3>
+									<div className="space-y-2">
+										{customFormats.map((item) => {
+											const hasItemConflicts = item.hasConflicts || item.conflicts.length > 0;
+											const resolution = resolutions[item.trashId];
+
+											return (
+												<div
+													key={item.trashId}
+													className="rounded-xl border border-border/50 bg-card/30 p-3"
+												>
+													<div className="flex items-start justify-between gap-3">
+														<div className="min-w-0">
+															<p className="truncate text-sm font-medium text-foreground">
+																{item.name}
+															</p>
+															<p className="mt-1 text-xs text-muted-foreground">
+																Score: {item.scoreOverride}
+															</p>
+														</div>
+														<span className="shrink-0 rounded-full border border-border/50 bg-muted/50 px-2 py-0.5 text-xs font-medium text-foreground">
+															{ACTION_LABELS[item.action]}
+														</span>
+													</div>
+
+													{hasItemConflicts && (
+														<div className="mt-3 space-y-3 border-t border-border/50 pt-3">
+															<div>
+																<p className="text-xs font-medium text-foreground">
+																	{item.conflicts.length} Conflict
+																	{item.conflicts.length !== 1 ? "s" : ""} Detected
+																</p>
+																<div className="mt-2 space-y-2">
+													{item.conflicts.map((conflict) => (
+														<div
+															key={`${item.trashId}-${conflict.cfTrashId}-${conflict.conflictType}`}
+																			className="rounded-lg border border-border/50 bg-muted/20 p-2 text-xs"
+																		>
+																			<p className="font-medium text-foreground">
+																				{formatConflictType(conflict.conflictType)}
+																			</p>
+																			<p className="mt-1 break-words text-muted-foreground">
+																				Template: {formatConflictValue(conflict.templateValue)}
+																			</p>
+																			<p className="mt-1 break-words text-muted-foreground">
+																				Instance: {formatConflictValue(conflict.instanceValue)}
+																			</p>
+																		</div>
+																	))}
+																</div>
+															</div>
+															<div className="flex flex-wrap gap-2">
+																<Button
+																	size="sm"
+																	variant={resolution === "REPLACE" ? "default" : "outline"}
+																	aria-label={`Use template version of ${item.name}`}
+																	aria-pressed={resolution === "REPLACE"}
+																	onClick={() => handleResolutionChange(item.trashId, "REPLACE")}
+																	className="rounded-xl"
+																>
+																	Use template
+																</Button>
+																<Button
+																	size="sm"
+																	variant={resolution === "SKIP" ? "default" : "outline"}
+																	aria-label={`Keep existing ${item.name}`}
+																	aria-pressed={resolution === "SKIP"}
+																	onClick={() => handleResolutionChange(item.trashId, "SKIP")}
+																	className="rounded-xl"
+																>
+																	Keep existing
+																</Button>
+															</div>
+														</div>
+													)}
+												</div>
+											);
+										})}
+									</div>
+								</section>
+							)}
+
+							{namingChanges.length > 0 && (
+								<section className="space-y-3" aria-labelledby="sync-naming-changes">
+									<h3 id="sync-naming-changes" className="text-sm font-medium text-foreground">
+										Naming Changes ({namingChanges.length})
+									</h3>
+									<div className="space-y-2">
+										{namingChanges.map((field) => (
+											<div
+												key={field}
+												className="rounded-lg border border-border/50 bg-card/30 px-3 py-2 text-sm text-foreground"
+											>
+												{field}
+											</div>
+										))}
+									</div>
+								</section>
+							)}
+
+							{unmatchedCustomFormats.length > 0 && (
+								<section className="space-y-3" aria-labelledby="sync-unmatched-formats">
+									<h3 id="sync-unmatched-formats" className="text-sm font-medium text-foreground">
+										Unmatched Custom Formats ({unmatchedCustomFormats.length})
+									</h3>
+									<div className="space-y-2">
+										{unmatchedCustomFormats.map((item) => (
+											<div
+												key={item.instanceId}
+												className="rounded-lg border border-border/50 bg-card/30 px-3 py-2"
+											>
+												<p className="text-sm font-medium text-foreground">{item.name}</p>
+												<p className="mt-1 text-xs text-muted-foreground">{item.reason}</p>
+											</div>
+										))}
+									</div>
+								</section>
+							)}
+
 							{orphanedCustomFormats.length > 0 && (
 								<div
 									className="rounded-xl p-4"
@@ -476,22 +634,22 @@ export const SyncValidationModal = ({
 								</div>
 							)}
 
-							{/* Conflicts */}
-							{hasConflicts && validation.conflicts && (
+							{/* Legacy validation conflicts that are not represented in the preview. */}
+							{legacyConflicts.length > 0 && (
 								<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 									<div className="flex items-start gap-3">
 										<Info className="h-5 w-5 shrink-0" style={{ color: themeGradient.from }} />
 										<div className="flex-1">
 											<h3 className="font-medium text-foreground">
-												{validation.conflicts.length} Conflict
-												{validation.conflicts.length !== 1 ? "s" : ""} Detected
+												{legacyConflicts.length} Additional Conflict
+												{legacyConflicts.length !== 1 ? "s" : ""} Detected
 											</h3>
 											<p className="mt-1 text-sm text-muted-foreground">
 												Choose how to handle existing Custom Formats with the same name
 											</p>
 
 											<div className="mt-4 space-y-3">
-												{validation.conflicts.map((conflict) => (
+												{legacyConflicts.map((conflict) => (
 													<div
 														key={conflict.configName}
 														className="rounded-xl border border-border/50 bg-card/30 p-3"
@@ -515,6 +673,8 @@ export const SyncValidationModal = ({
 																	onClick={() =>
 																		handleResolutionChange(conflict.configName, "REPLACE")
 																	}
+																	aria-label={`Replace ${conflict.configName} with template version`}
+																	aria-pressed={resolutions[conflict.configName] === "REPLACE"}
 																	className="rounded-xl"
 																	style={
 																		resolutions[conflict.configName] === "REPLACE"
@@ -536,6 +696,8 @@ export const SyncValidationModal = ({
 																	onClick={() =>
 																		handleResolutionChange(conflict.configName, "SKIP")
 																	}
+																	aria-label={`Keep existing ${conflict.configName}`}
+																	aria-pressed={resolutions[conflict.configName] === "SKIP"}
 																	className="rounded-xl"
 																	style={
 																		resolutions[conflict.configName] === "SKIP"
@@ -554,6 +716,21 @@ export const SyncValidationModal = ({
 											</div>
 										</div>
 									</div>
+								</div>
+							)}
+
+							{previewHasUnrenderableConflicts && (
+								<div
+									className="rounded-xl p-4"
+									style={{
+										backgroundColor: SEMANTIC_COLORS.error.bg,
+										border: `1px solid ${SEMANTIC_COLORS.error.border}`,
+									}}
+								>
+									<p className="text-sm font-medium" style={{ color: SEMANTIC_COLORS.error.text }}>
+										The reviewed preview reports unresolved conflicts but did not include their
+										details. Validate again before syncing.
+									</p>
 								</div>
 							)}
 
@@ -596,10 +773,10 @@ export const SyncValidationModal = ({
 					</Button>
 					<Button
 						onClick={handleConfirm}
-						disabled={!canProceed || isValidating}
+						disabled={!canConfirm || isValidating}
 						className="gap-2 rounded-xl font-medium"
 						style={
-							canProceed && !isValidating
+							canConfirm && !isValidating
 								? {
 										background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
 										boxShadow: `0 4px 12px -4px ${themeGradient.glow}`,
@@ -607,7 +784,11 @@ export const SyncValidationModal = ({
 								: undefined
 						}
 					>
-						{hasConflicts ? "Proceed with Resolutions" : "Start Sync"}
+						{hasUnresolvedConflicts
+							? "Resolve all conflicts to continue"
+							: hasConflicts
+								? "Proceed with Resolutions"
+								: "Start Sync"}
 					</Button>
 				</div>
 			</div>

--- a/apps/web/src/features/trash-guides/components/template-list.tsx
+++ b/apps/web/src/features/trash-guides/components/template-list.tsx
@@ -147,7 +147,10 @@ export const TemplateList = ({
 		}
 	};
 
-	const handleSyncValidationComplete = async (resolutions: Record<string, "REPLACE" | "SKIP">) => {
+	const handleSyncValidationComplete = async (
+		executionToken: string,
+		resolutions: Record<string, "REPLACE" | "SKIP">,
+	) => {
 		if (!modals.validationModal) return;
 
 		try {
@@ -155,6 +158,7 @@ export const TemplateList = ({
 				templateId: modals.validationModal.templateId,
 				instanceId: modals.validationModal.instanceId,
 				syncType: "MANUAL",
+				executionToken,
 				conflictResolutions: resolutions,
 			});
 

--- a/apps/web/src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { trashGuidesKeys } from "../../../lib/query-keys";
+
+const apiMocks = vi.hoisted(() => ({
+	executeDeployment: vi.fn(),
+	executeBulkDeployment: vi.fn(),
+}));
+
+vi.mock("../../../lib/api-client/trash-guides", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../lib/api-client/trash-guides")>();
+	return {
+		...actual,
+		executeDeployment: apiMocks.executeDeployment,
+		executeBulkDeployment: apiMocks.executeBulkDeployment,
+	};
+});
+
+import { useExecuteBulkDeployment, useExecuteDeployment } from "../useDeploymentPreview";
+
+function createWrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+	};
+}
+
+describe("deployment preview authority recovery", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("invalidates the rejected single-instance preview after execution fails", async () => {
+		apiMocks.executeDeployment.mockRejectedValue(new Error("stale preview"));
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useExecuteDeployment(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await act(async () => {
+			await result.current
+				.mutateAsync({
+					templateId: "template-1",
+					instanceId: "instance-1",
+					executionToken: "a".repeat(64),
+				})
+				.catch(() => undefined);
+		});
+
+		await waitFor(() =>
+			expect(invalidate).toHaveBeenCalledWith({
+				queryKey: trashGuidesKeys.deployment.preview("template-1", "instance-1"),
+			}),
+		);
+	});
+
+	it("invalidates all reviewed previews after bulk execution fails", async () => {
+		apiMocks.executeBulkDeployment.mockRejectedValue(new Error("stale bulk preview"));
+		const queryClient = new QueryClient({
+			defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+		});
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useExecuteBulkDeployment(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await act(async () => {
+			await result.current
+				.mutateAsync({
+					templateId: "template-1",
+					instanceIds: ["instance-1"],
+					executionTokens: { "instance-1": "a".repeat(64) },
+				})
+				.catch(() => undefined);
+		});
+
+		await waitFor(() =>
+			expect(invalidate).toHaveBeenCalledWith({ queryKey: trashGuidesKeys.deployment.all }),
+		);
+	});
+});

--- a/apps/web/src/hooks/api/useDeploymentPreview.ts
+++ b/apps/web/src/hooks/api/useDeploymentPreview.ts
@@ -50,6 +50,11 @@ export function useExecuteDeployment() {
 
 	return useMutation<ExecuteDeploymentResponse, Error, ExecuteDeploymentPayload>({
 		mutationFn: (payload) => executeDeployment(payload),
+		onError: (_error, payload) => {
+			queryClient.invalidateQueries({
+				queryKey: trashGuidesKeys.deployment.preview(payload.templateId, payload.instanceId),
+			});
+		},
 		onSuccess: () => {
 			// Invalidate relevant queries
 			queryClient.invalidateQueries({
@@ -76,6 +81,11 @@ export function useExecuteBulkDeployment() {
 
 	return useMutation<ExecuteBulkDeploymentResponse, Error, ExecuteBulkDeploymentPayload>({
 		mutationFn: (payload) => executeBulkDeployment(payload),
+		onError: () => {
+			queryClient.invalidateQueries({
+				queryKey: trashGuidesKeys.deployment.all,
+			});
+		},
 		onSuccess: () => {
 			// Invalidate relevant queries
 			queryClient.invalidateQueries({

--- a/apps/web/src/lib/api-client/trash-guides/deployment.ts
+++ b/apps/web/src/lib/api-client/trash-guides/deployment.ts
@@ -108,6 +108,7 @@ export type BulkDeploymentResult = {
 export type ExecuteDeploymentPayload = {
 	templateId: string;
 	instanceId: string;
+	executionToken: string;
 	syncStrategy?: SyncStrategy;
 	/** Conflict resolutions: trashId -> resolution (use_template, keep_existing) */
 	conflictResolutions?: Record<string, ConflictResolution>;
@@ -121,6 +122,7 @@ export type ExecuteDeploymentResponse = {
 export type ExecuteBulkDeploymentPayload = {
 	templateId: string;
 	instanceIds: string[];
+	executionTokens: Record<string, string>;
 	syncStrategy?: SyncStrategy;
 	/** Per-instance sync strategies - overrides global syncStrategy for specific instances */
 	instanceSyncStrategies?: Record<string, SyncStrategy>;

--- a/apps/web/src/lib/api-client/trash-guides/sync.ts
+++ b/apps/web/src/lib/api-client/trash-guides/sync.ts
@@ -5,6 +5,7 @@
  */
 
 import { apiRequest } from "../base";
+import type { DeploymentPreview } from "./types";
 
 // ============================================================================
 // Types
@@ -27,12 +28,15 @@ export interface ValidationResult {
 	conflicts: ConflictInfo[];
 	errors: string[];
 	warnings: string[];
+	executionToken?: string;
+	preview?: DeploymentPreview;
 }
 
 export interface SyncExecuteRequest {
 	templateId: string;
 	instanceId: string;
-	syncType: "MANUAL" | "SCHEDULED";
+	syncType: "MANUAL";
+	executionToken: string;
 	conflictResolutions?: Record<string, "REPLACE" | "SKIP">;
 }
 

--- a/packages/shared/src/types/trash-guides.ts
+++ b/packages/shared/src/types/trash-guides.ts
@@ -1485,6 +1485,8 @@ export interface DeploymentPreview {
 	instanceId: string;
 	instanceLabel: string;
 	instanceServiceType: "RADARR" | "SONARR";
+	/** Opaque 64-character token binding execution to this exact preview state. */
+	executionToken: string;
 
 	// Deployment statistics
 	summary: {
@@ -1496,6 +1498,7 @@ export interface DeploymentPreview {
 		totalConflicts: number;
 		unresolvedConflicts: number;
 		unmatchedCustomFormats: number; // CFs in instance that couldn't be matched to a trash_id
+		orphanedCustomFormats: number;
 	};
 
 	// Deployment items
@@ -1503,6 +1506,16 @@ export interface DeploymentPreview {
 
 	// Unmatched CFs in instance (couldn't extract trash_id)
 	unmatchedCustomFormats: UnmatchedCustomFormat[];
+
+	// Previously managed CFs no longer present in the template
+	orphanedCustomFormats: Array<{
+		instanceId: number;
+		name: string;
+		score: number;
+	}>;
+
+	// Naming fields whose deployed values differ from the instance
+	namingChanges?: string[];
 
 	// Instance state
 	canDeploy: boolean; // False if instance unreachable or conflicts unresolved


### PR DESCRIPTION
## Summary

- make every user-triggered TRaSH deployment require the exact opaque token returned by its preview
- recompute template, connection, target profile, Custom Format, naming, saved-score, and orphan-cleanup state before backup or upstream mutation
- keep scheduled automation on a separate tokenless capability that requires current `auto` mappings for the complete equivalent endpoint

## Authority and mutation safety

- reject ambiguous Custom Format names or TRaSH identities before preview or execution, then use exact resolved ARR resource IDs for scoring and managed-state capture
- query every equivalent service-instance record and fail closed on stale mappings, conflicting profile ownership, conflicting saved scores, pending recovery, or changed preview state
- defer legacy mapping and saved-score rebinding until successful transactional history finalization
- consolidate equivalent alias mappings and reviewed APPLIED score intent onto one current canonical instance only after live authority is revalidated
- preserve prior mappings and override intent when backup, execution, authority revalidation, or finalization fails
- reject duplicate bulk IDs and multiple selected records for the same physical endpoint before the first target executes

## Routes and UI

- require exact single and per-instance bulk execution tokens and reject missing or extra token entries
- prevent browser callers from claiming scheduled sync authority
- pass manual-sync validation tokens through the confirmation modal to execution
- show every managed orphan score reset as `current score -> 0` in deployment and sync review
- invalidate stale preview queries after failed execution so the next attempt loads a fresh plan
- report automated deployment failures in result status and counters instead of counting them as successful template updates

## Validation

- shared package build, root typecheck, lint, production build, and full tests passed on the final stacked commit
- full tests: API 3,598 passed / 43 skipped; web 593 passed; shared 89 passed
- live deployment and rollback paths passed against isolated Radarr and Sonarr instances

The repository-wide formatter still reports the same four unrelated OIDC files already present on the base branch. Every file changed by this stack passes formatting.

Stacked on #679.
