### PR TITLE
fix(trash-guides): preserve cloned profile target

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
@@ -195,6 +195,49 @@ describe("deployment execution authority", () => {
 		expect(createBackup).not.toHaveBeenCalled();
 	});
 
+	it("rejects a repointed cloned source before execution can use an original alias", async () => {
+		const selectedAlias = { ...instance, id: "instance-alias" };
+		const repointedSource = { ...instance, baseUrl: "http://other-radarr:7878" };
+		const clonedTemplate = {
+			...template,
+			configData: JSON.stringify({
+				customFormats: [],
+				completeQualityProfile: {
+					sourceInstanceId: instance.id,
+					sourceConnectionStateToken: createDeploymentConnectionStateToken(instance),
+					sourceProfileId: profile.id,
+				},
+			}),
+		};
+		const { executor, prisma, createBackup } = createFixture([]);
+		prisma.serviceInstance.findFirst.mockResolvedValue(selectedAlias);
+		prisma.serviceInstance.findMany.mockResolvedValue([repointedSource, selectedAlias]);
+		const privateExecutor = executor as unknown as {
+			validateAndPrepareDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		vi.mocked(privateExecutor.validateAndPrepareDeployment).mockResolvedValue({
+			template: clonedTemplate,
+			instance: selectedAlias,
+			templateConfig: JSON.parse(clonedTemplate.configData),
+			templateCFs: [],
+			overridesForInstance: {},
+			effectiveQualityConfig: undefined,
+			usingQualityOverride: false,
+		} as never);
+
+		await expect(
+			executor.deploySingleInstance(
+				clonedTemplate.id,
+				selectedAlias.id,
+				"user-1",
+				"notify",
+				undefined,
+				"review-token",
+			),
+		).rejects.toThrow("source ARR connection changed");
+		expect(createBackup).not.toHaveBeenCalled();
+	});
+
 	it("does not rebind a legacy mapping before backup succeeds", async () => {
 		const legacyMapping = currentMapping({
 			connectionGeneration: 0,

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
@@ -238,6 +238,65 @@ describe("deployment execution authority", () => {
 		expect(createBackup).not.toHaveBeenCalled();
 	});
 
+	it("uses a current mapped target after the original cloned source record was removed", async () => {
+		const clonedTemplate = {
+			...template,
+			configData: JSON.stringify({
+				customFormats: [],
+				completeQualityProfile: {
+					sourceInstanceId: "removed-source",
+					sourceConnectionStateToken: "removed-source-token",
+					sourceProfileId: 99,
+				},
+			}),
+		};
+		const mapping = currentMapping({ syncStrategy: "notify" });
+		const { executor, createBackup } = createFixture([mapping]);
+		const privateExecutor = executor as unknown as {
+			validateAndPrepareDeployment: (...args: unknown[]) => Promise<unknown>;
+		};
+		vi.mocked(privateExecutor.validateAndPrepareDeployment).mockResolvedValue({
+			template: clonedTemplate,
+			instance,
+			templateConfig: JSON.parse(clonedTemplate.configData),
+			templateCFs: [],
+			overridesForInstance: {},
+			effectiveQualityConfig: undefined,
+			usingQualityOverride: false,
+		} as never);
+		const executionToken = createDeploymentStateToken({
+			template: {
+				id: clonedTemplate.id,
+				name: clonedTemplate.name,
+				configData: clonedTemplate.configData,
+				instanceOverrides: clonedTemplate.instanceOverrides,
+				sourceQualityProfileName: clonedTemplate.sourceQualityProfileName,
+			},
+			instanceId: instance.id,
+			connection: {
+				service: instance.service,
+				baseUrl: instance.baseUrl,
+				credentialIdentity: "encrypted-key:iv::",
+			},
+			target: { profile, profileName: "Any", matchedBy: "mapping_id" },
+			customFormats: [],
+			savedScoreOverrides: [],
+			orphanedFormatScoreChanges: [],
+		});
+
+		await expect(
+			executor.deploySingleInstance(
+				clonedTemplate.id,
+				instance.id,
+				"user-1",
+				"notify",
+				undefined,
+				executionToken,
+			),
+		).resolves.toMatchObject({ success: false, errors: ["authority accepted"] });
+		expect(createBackup).toHaveBeenCalledOnce();
+	});
+
 	it("does not rebind a legacy mapping before backup succeeds", async () => {
 		const legacyMapping = currentMapping({
 			connectionGeneration: 0,

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-authority.test.ts
@@ -280,6 +280,7 @@ describe("deployment execution authority", () => {
 			},
 			target: { profile, profileName: "Any", matchedBy: "mapping_id" },
 			customFormats: [],
+			mappingAuthority: createDeploymentMappingAuthorityState([mapping]),
 			savedScoreOverrides: [],
 			orphanedFormatScoreChanges: [],
 		});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -1122,6 +1122,89 @@ describe("DeploymentExecutorService - saved override concurrency", () => {
 		).rejects.toThrow("appeared during deployment");
 	});
 
+	it.each(["RADARR", "SONARR"] as const)(
+		"updates the cloned source profile instead of creating the renamed template for %s",
+		async (serviceType) => {
+			const profile = {
+				id: 7,
+				name: "Any",
+				upgradeAllowed: true,
+				cutoff: 1,
+				minFormatScore: 0,
+				formatItems: [],
+				items: [],
+			};
+			const postWriteProfile = {
+				...profile,
+				formatItems: [{ format: 42, score: 20 }],
+			};
+			const create = vi.fn();
+			const update = vi.fn().mockResolvedValue(postWriteProfile);
+			const client = {
+				serviceType,
+				customFormat: { getAll: vi.fn().mockResolvedValue([]) },
+				qualityProfile: {
+					create,
+					getById: vi
+						.fn()
+						.mockResolvedValueOnce(profile)
+						.mockResolvedValueOnce(profile)
+						.mockResolvedValueOnce(postWriteProfile),
+					update,
+				},
+			};
+			const prisma = {
+				instanceQualityProfileOverride: { findMany: vi.fn().mockResolvedValue([]) },
+			};
+			const executor = new DeploymentExecutorService(prisma as never, {} as never);
+			const syncQualityProfile = (
+				executor as unknown as {
+					syncQualityProfile: (...args: unknown[]) => Promise<{ errors: string[] }>;
+				}
+			).syncQualityProfile.bind(executor);
+
+			const result = await syncQualityProfile(
+				client,
+				{ qualityProfile: { trash_score_set: "default" } },
+				[
+					{
+						trashId: "managed-cf",
+						name: "Managed CF",
+						originalConfig: { trash_scores: { default: 20 } },
+					},
+				],
+				"template-1",
+				"instance-1",
+				"user-1",
+				undefined,
+				undefined,
+				"Any",
+				profile,
+				createQualityProfileStateToken(profile),
+				[],
+				new Map(),
+				["instance-1"],
+				undefined,
+				undefined,
+				undefined,
+				undefined,
+				[],
+				new Map([["managed-cf", 42]]),
+			);
+
+			expect(result.errors).toEqual([]);
+			expect(update).toHaveBeenCalledWith(
+				7,
+				expect.objectContaining({
+					id: 7,
+					name: "Any",
+					formatItems: [{ format: 42, score: 20 }],
+				}),
+			);
+			expect(create).not.toHaveBeenCalled();
+		},
+	);
+
 	it("persists the exact created profile state before later preparation can fail", async () => {
 		const createdProfile = {
 			id: 9,

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -123,6 +123,35 @@ describe("deployment preview authority", () => {
 		).rejects.toThrow("source ARR connection changed");
 	});
 
+	it("uses a current mapped target after the original cloned source record was removed", async () => {
+		const mappedInstance = {
+			...instance,
+			id: "mapped-instance",
+			baseUrl: "http://mapped-radarr:7878",
+		};
+		const mapping = {
+			id: "mapping-1",
+			templateId: template.id,
+			instanceId: mappedInstance.id,
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: mappedInstance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(mappedInstance),
+			syncStrategy: "notify",
+			managedCustomFormats: "[]",
+			managedCustomFormatsCaptured: true,
+		};
+
+		const preview = await createService({
+			instance: mappedInstance,
+			instances: [mappedInstance],
+			mappings: [mapping],
+		}).generatePreview(template.id, mappedInstance.id, "user-1");
+
+		expect(preview.warnings).not.toContainEqual(expect.stringContaining("cloned source"));
+		expect(preview.executionToken).toMatch(/^[a-f0-9]{64}$/);
+	});
+
 	it("matches a differently named ARR Custom Format by the shared trailing UUID", async () => {
 		const preview = await createService().generatePreview("template-1", "instance-1", "user-1");
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -111,6 +111,18 @@ describe("deployment preview authority", () => {
 		).rejects.toThrow("source ARR connection changed");
 	});
 
+	it("blocks a repointed source alias before falling back through an original alias", async () => {
+		const selectedAlias = { ...instance, id: "instance-alias" };
+		const repointedSource = { ...instance, baseUrl: "http://other-radarr:7878" };
+
+		await expect(
+			createService({
+				instance: selectedAlias,
+				instances: [repointedSource, selectedAlias],
+			}).generatePreview("template-1", selectedAlias.id, "user-1"),
+		).rejects.toThrow("source ARR connection changed");
+	});
+
 	it("matches a differently named ARR Custom Format by the shared trailing UUID", async () => {
 		const preview = await createService().generatePreview("template-1", "instance-1", "user-1");
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-preview-authority.test.ts
@@ -18,9 +18,14 @@ const instance = {
 const template = {
 	id: "template-1",
 	userId: "user-1",
-	name: "Any",
+	name: "Radarr - Any",
 	serviceType: "RADARR",
 	configData: JSON.stringify({
+		completeQualityProfile: {
+			sourceInstanceId: "instance-1",
+			sourceConnectionStateToken: createDeploymentConnectionStateToken(instance),
+			sourceProfileId: 4,
+		},
 		customFormats: [
 			{
 				trashId,
@@ -38,10 +43,12 @@ function createService(
 		unreachable?: boolean;
 		customFormats?: Array<{ id: number; name: string; specifications: unknown[] }>;
 		mappings?: Array<Record<string, unknown>>;
+		instance?: typeof instance;
 		instances?: (typeof instance)[];
 		savedOverrides?: Array<Record<string, unknown>>;
 	} = {},
 ) {
+	const selectedInstance = options.instance ?? instance;
 	const existingFormat = {
 		id: 42,
 		name: `Different ARR name [${trashId.toUpperCase()}]`,
@@ -51,8 +58,8 @@ function createService(
 	const prisma = {
 		trashTemplate: { findUnique: vi.fn().mockResolvedValue(template) },
 		serviceInstance: {
-			findFirst: vi.fn().mockResolvedValue(instance),
-			findMany: vi.fn().mockResolvedValue(options.instances ?? [instance]),
+			findFirst: vi.fn().mockResolvedValue(selectedInstance),
+			findMany: vi.fn().mockResolvedValue(options.instances ?? [selectedInstance]),
 		},
 		templateQualityProfileMapping: {
 			findMany: vi.fn().mockResolvedValue(options.mappings ?? []),
@@ -85,6 +92,25 @@ function createService(
 }
 
 describe("deployment preview authority", () => {
+	it("targets the cloned source profile when the template was renamed", async () => {
+		const preview = await createService().generatePreview("template-1", "instance-1", "user-1");
+
+		expect(preview.warnings).toContain(
+			'Quality profile matched by cloned source ID ("Any", ID: 4) rather than a stored deployment mapping.',
+		);
+		expect(preview.warnings).not.toContain(
+			'Quality profile "Radarr - Any" not found in instance. Deploying will create it with the template\'s quality settings and Custom Format scores.',
+		);
+	});
+
+	it("blocks a cloned source deployment after the ARR connection changes", async () => {
+		await expect(
+			createService({
+				instance: { ...instance, encryptedApiKey: "changed-key" },
+			}).generatePreview("template-1", "instance-1", "user-1"),
+		).rejects.toThrow("source ARR connection changed");
+	});
+
 	it("matches a differently named ARR Custom Format by the shared trailing UUID", async () => {
 		const preview = await createService().generatePreview("template-1", "instance-1", "user-1");
 

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -12,6 +12,7 @@ import {
 	createQualityProfileStateToken,
 	getEquivalentServiceInstanceIds,
 	isDeploymentBackupEndpointIdentityCurrent,
+	isVerifiedClonedProfileSourceConnection,
 	resolveDeploymentTarget,
 	type DeploymentProfileMapping,
 } from "../deployment-target.js";
@@ -22,6 +23,51 @@ const profiles = [
 ];
 
 describe("resolveDeploymentTarget", () => {
+	it("uses a cloned source ID only while its reviewed ARR connection still matches", () => {
+		const sourceInstance = {
+			id: "instance-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+			encryptedApiKey: "encrypted-key",
+			encryptionIv: "iv",
+			connectionGeneration: 2,
+		};
+		const sourceConnectionStateToken = createDeploymentConnectionStateToken(sourceInstance);
+
+		expect(
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: "instance-1",
+				sourceConnectionStateToken,
+				equivalentInstanceIds: ["instance-1"],
+				instance: sourceInstance,
+			}),
+		).toBe(true);
+		expect(
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: "instance-1",
+				sourceConnectionStateToken: undefined,
+				equivalentInstanceIds: ["instance-1"],
+				instance: sourceInstance,
+			}),
+		).toBe(false);
+		expect(
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: "other-instance",
+				sourceConnectionStateToken,
+				equivalentInstanceIds: ["instance-1"],
+				instance: sourceInstance,
+			}),
+		).toBe(false);
+		expect(() =>
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: "instance-1",
+				sourceConnectionStateToken,
+				equivalentInstanceIds: ["instance-1"],
+				instance: { ...sourceInstance, encryptedApiKey: "changed-key" },
+			}),
+		).toThrow("source ARR connection changed");
+	});
+
 	it("uses a stored mapping as the authoritative identity", () => {
 		const result = resolveDeploymentTarget({
 			profiles,

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -39,23 +39,23 @@ describe("resolveDeploymentTarget", () => {
 				sourceInstanceId: "instance-1",
 				sourceConnectionStateToken,
 				equivalentInstanceIds: ["instance-1"],
-				instance: sourceInstance,
+				sourceInstance,
 			}),
 		).toBe(true);
-		expect(
+		expect(() =>
 			isVerifiedClonedProfileSourceConnection({
 				sourceInstanceId: "instance-1",
 				sourceConnectionStateToken: undefined,
 				equivalentInstanceIds: ["instance-1"],
-				instance: sourceInstance,
+				sourceInstance,
 			}),
-		).toBe(false);
+		).toThrow("predates verified source-connection binding");
 		expect(
 			isVerifiedClonedProfileSourceConnection({
 				sourceInstanceId: "other-instance",
 				sourceConnectionStateToken,
 				equivalentInstanceIds: ["instance-1"],
-				instance: sourceInstance,
+				sourceInstance: { ...sourceInstance, id: "other-instance" },
 			}),
 		).toBe(false);
 		expect(() =>
@@ -63,7 +63,30 @@ describe("resolveDeploymentTarget", () => {
 				sourceInstanceId: "instance-1",
 				sourceConnectionStateToken,
 				equivalentInstanceIds: ["instance-1"],
-				instance: { ...sourceInstance, encryptedApiKey: "changed-key" },
+				sourceInstance: { ...sourceInstance, encryptedApiKey: "changed-key" },
+			}),
+		).toThrow("source ARR connection changed");
+
+		const selectedAlias = {
+			...sourceInstance,
+			id: "instance-alias",
+			encryptedApiKey: "separately-encrypted-key",
+			encryptionIv: "different-iv",
+		};
+		expect(
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: sourceInstance.id,
+				sourceConnectionStateToken,
+				equivalentInstanceIds: [sourceInstance.id, selectedAlias.id],
+				sourceInstance,
+			}),
+		).toBe(true);
+		expect(() =>
+			isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: sourceInstance.id,
+				sourceConnectionStateToken,
+				equivalentInstanceIds: [selectedAlias.id],
+				sourceInstance: { ...sourceInstance, baseUrl: "http://repointed-radarr:7878" },
 			}),
 		).toThrow("source ARR connection changed");
 	});

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -1875,7 +1875,9 @@ export class DeploymentExecutorService {
 				sourceConnectionStateToken:
 					templateConfig.completeQualityProfile?.sourceConnectionStateToken,
 				equivalentInstanceIds,
-				instance,
+				sourceInstance: serviceAliases.find(
+					(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
+				),
 			});
 			const resolvedTarget = resolveDeploymentTarget({
 				profiles: allProfiles,

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -1870,15 +1870,17 @@ export class DeploymentExecutorService {
 					);
 				}
 			}
-			const isVerifiedSourceInstance = isVerifiedClonedProfileSourceConnection({
-				sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
-				sourceConnectionStateToken:
-					templateConfig.completeQualityProfile?.sourceConnectionStateToken,
-				equivalentInstanceIds,
-				sourceInstance: serviceAliases.find(
-					(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
-				),
-			});
+			const isVerifiedSourceInstance = qualityProfileMapping
+				? false
+				: isVerifiedClonedProfileSourceConnection({
+						sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
+						sourceConnectionStateToken:
+							templateConfig.completeQualityProfile?.sourceConnectionStateToken,
+						equivalentInstanceIds,
+						sourceInstance: serviceAliases.find(
+							(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
+						),
+					});
 			const resolvedTarget = resolveDeploymentTarget({
 				profiles: allProfiles,
 				mapping: qualityProfileMapping,

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -66,6 +66,7 @@ import {
 	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
 	isLegacyDeploymentConnectionMapping,
+	isVerifiedClonedProfileSourceConnection,
 	resolveDeploymentTarget,
 } from "./deployment-target.js";
 import { createQualityProfileFromSchema } from "./profile-creation-strategies.js";
@@ -1869,13 +1870,18 @@ export class DeploymentExecutorService {
 					);
 				}
 			}
+			const isVerifiedSourceInstance = isVerifiedClonedProfileSourceConnection({
+				sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
+				sourceConnectionStateToken:
+					templateConfig.completeQualityProfile?.sourceConnectionStateToken,
+				equivalentInstanceIds,
+				instance,
+			});
 			const resolvedTarget = resolveDeploymentTarget({
 				profiles: allProfiles,
 				mapping: qualityProfileMapping,
 				sourceProfileId: templateConfig.completeQualityProfile?.sourceProfileId,
-				isSourceInstance: equivalentInstanceIds.includes(
-					templateConfig.completeQualityProfile?.sourceInstanceId ?? "",
-				),
+				isSourceInstance: isVerifiedSourceInstance,
 				sourceProfileName: template.sourceQualityProfileName,
 				templateName: template.name,
 			});

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -547,14 +547,17 @@ export class DeploymentPreviewService {
 				"This 2.x deployment mapping is not yet bound to a verified ARR connection. Executing this exact preview will bind it to the current connection only after the reviewed deployment succeeds.",
 			);
 		}
-		const isVerifiedSourceInstance = isVerifiedClonedProfileSourceConnection({
-			sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
-			sourceConnectionStateToken: templateConfig.completeQualityProfile?.sourceConnectionStateToken,
-			equivalentInstanceIds,
-			sourceInstance: aliases.find(
-				(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
-			),
-		});
+		const isVerifiedSourceInstance = qualityProfileMapping
+			? false
+			: isVerifiedClonedProfileSourceConnection({
+					sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
+					sourceConnectionStateToken:
+						templateConfig.completeQualityProfile?.sourceConnectionStateToken,
+					equivalentInstanceIds,
+					sourceInstance: aliases.find(
+						(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
+					),
+				});
 		const resolvedTarget = resolveDeploymentTarget({
 			profiles: instanceQualityProfiles,
 			mapping: qualityProfileMapping,

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -41,6 +41,7 @@ import {
 	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
 	isLegacyDeploymentConnectionMapping,
+	isVerifiedClonedProfileSourceConnection,
 	resolveDeploymentTarget,
 } from "./deployment-target.js";
 
@@ -90,6 +91,7 @@ interface ParsedTemplateConfig {
 	customFormats?: TemplateCustomFormat[];
 	completeQualityProfile?: {
 		sourceInstanceId?: string;
+		sourceConnectionStateToken?: string;
 		sourceProfileId?: number;
 	};
 	qualityProfile?: {
@@ -545,13 +547,17 @@ export class DeploymentPreviewService {
 				"This 2.x deployment mapping is not yet bound to a verified ARR connection. Executing this exact preview will bind it to the current connection only after the reviewed deployment succeeds.",
 			);
 		}
+		const isVerifiedSourceInstance = isVerifiedClonedProfileSourceConnection({
+			sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
+			sourceConnectionStateToken: templateConfig.completeQualityProfile?.sourceConnectionStateToken,
+			equivalentInstanceIds,
+			instance,
+		});
 		const resolvedTarget = resolveDeploymentTarget({
 			profiles: instanceQualityProfiles,
 			mapping: qualityProfileMapping,
 			sourceProfileId: templateConfig.completeQualityProfile?.sourceProfileId,
-			isSourceInstance: equivalentInstanceIds.includes(
-				templateConfig.completeQualityProfile?.sourceInstanceId ?? "",
-			),
+			isSourceInstance: isVerifiedSourceInstance,
 			sourceProfileName: template.sourceQualityProfileName,
 			templateName: template.name,
 		});
@@ -641,7 +647,9 @@ export class DeploymentPreviewService {
 				warnings.push(
 					qualityProfileMapping
 						? `Quality profile "${qualityProfileMapping.qualityProfileName}" (ID: ${qualityProfileMapping.qualityProfileId}) was recovered as "${resolvedTarget.profileName}" (ID: ${targetProfile.id}). The stored mapping will be updated on deploy.`
-						: `Quality profile matched by name ("${resolvedTarget.profileName}") rather than stored ID. Score conflict detection is based on name match.`,
+						: resolvedTarget.matchedBy === "source_id"
+							? `Quality profile matched by cloned source ID ("${resolvedTarget.profileName}", ID: ${targetProfile.id}) rather than a stored deployment mapping.`
+							: `Quality profile matched by name ("${resolvedTarget.profileName}") rather than stored ID. Score conflict detection is based on name match.`,
 				);
 			}
 			for (const formatItem of targetProfile.formatItems || []) {

--- a/apps/api/src/lib/trash-guides/deployment-preview.ts
+++ b/apps/api/src/lib/trash-guides/deployment-preview.ts
@@ -551,7 +551,9 @@ export class DeploymentPreviewService {
 			sourceInstanceId: templateConfig.completeQualityProfile?.sourceInstanceId,
 			sourceConnectionStateToken: templateConfig.completeQualityProfile?.sourceConnectionStateToken,
 			equivalentInstanceIds,
-			instance,
+			sourceInstance: aliases.find(
+				(alias) => alias.id === templateConfig.completeQualityProfile?.sourceInstanceId,
+			),
 		});
 		const resolvedTarget = resolveDeploymentTarget({
 			profiles: instanceQualityProfiles,

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -328,20 +328,29 @@ export function isVerifiedClonedProfileSourceConnection(args: {
 	sourceInstanceId?: string | null;
 	sourceConnectionStateToken?: string | null;
 	equivalentInstanceIds: string[];
-	instance: DeploymentConnectionInstance;
+	sourceInstance?: DeploymentConnectionInstance | null;
 }): boolean {
-	if (!args.sourceInstanceId || !args.equivalentInstanceIds.includes(args.sourceInstanceId)) {
+	if (!args.sourceInstanceId) {
 		return false;
 	}
 	if (!args.sourceConnectionStateToken) {
-		return false;
+		throw new ConflictError(
+			"This cloned profile predates verified source-connection binding. Recreate the template from the current source profile before deploying it back to that ARR endpoint.",
+		);
 	}
-	if (createDeploymentConnectionStateToken(args.instance) !== args.sourceConnectionStateToken) {
+	if (!args.sourceInstance || args.sourceInstance.id !== args.sourceInstanceId) {
+		throw new ConflictError(
+			"The cloned profile's recorded source ARR instance is unavailable. Recreate the template from the current source profile before deploying it back to that endpoint.",
+		);
+	}
+	if (
+		createDeploymentConnectionStateToken(args.sourceInstance) !== args.sourceConnectionStateToken
+	) {
 		throw new ConflictError(
 			"The cloned profile's source ARR connection changed after the template was created. Recreate the template from the current connection before deploying it back to that source instance.",
 		);
 	}
-	return true;
+	return args.equivalentInstanceIds.includes(args.sourceInstanceId);
 }
 
 /** Bind database ownership records to the exact configured ARR connection. */

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -313,13 +313,18 @@ export function createClonedProfileSourceStateToken(args: {
 	userId: string;
 	instance: DeploymentConnectionInstance;
 	profile: unknown;
+	customFormats: unknown[];
 }): string {
+	const customFormats = args.customFormats
+		.map((customFormat) => stableValue(customFormat))
+		.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
 	return createUpstreamResourceStateToken({
 		userId: args.userId,
 		instanceId: args.instance.id,
 		connectionGeneration: args.instance.connectionGeneration ?? 0,
 		connectionStateToken: createDeploymentConnectionStateToken(args.instance),
 		profileStateToken: createQualityProfileStateToken(args.profile),
+		customFormats,
 	});
 }
 

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -308,6 +308,42 @@ export function createDeploymentConnectionStateToken(instance: {
 	});
 }
 
+/** Bind cloned-profile creation to the exact reviewed owner, connection, and ARR profile state. */
+export function createClonedProfileSourceStateToken(args: {
+	userId: string;
+	instance: DeploymentConnectionInstance;
+	profile: unknown;
+}): string {
+	return createUpstreamResourceStateToken({
+		userId: args.userId,
+		instanceId: args.instance.id,
+		connectionGeneration: args.instance.connectionGeneration ?? 0,
+		connectionStateToken: createDeploymentConnectionStateToken(args.instance),
+		profileStateToken: createQualityProfileStateToken(args.profile),
+	});
+}
+
+/** Authorize numeric cloned-profile targeting only on the reviewed source ARR connection. */
+export function isVerifiedClonedProfileSourceConnection(args: {
+	sourceInstanceId?: string | null;
+	sourceConnectionStateToken?: string | null;
+	equivalentInstanceIds: string[];
+	instance: DeploymentConnectionInstance;
+}): boolean {
+	if (!args.sourceInstanceId || !args.equivalentInstanceIds.includes(args.sourceInstanceId)) {
+		return false;
+	}
+	if (!args.sourceConnectionStateToken) {
+		return false;
+	}
+	if (createDeploymentConnectionStateToken(args.instance) !== args.sourceConnectionStateToken) {
+		throw new ConflictError(
+			"The cloned profile's source ARR connection changed after the template was created. Recreate the template from the current connection before deploying it back to that source instance.",
+		);
+	}
+	return true;
+}
+
 /** Bind database ownership records to the exact configured ARR connection. */
 export function createDeploymentConnectionBinding(
 	instance: DeploymentConnectionInstance,

--- a/apps/api/src/lib/trash-guides/profile-matcher.ts
+++ b/apps/api/src/lib/trash-guides/profile-matcher.ts
@@ -325,6 +325,7 @@ export function buildCompleteQualityProfile(
 	sourceInfo: {
 		sourceInstanceId: string;
 		sourceInstanceLabel: string;
+		sourceConnectionStateToken?: string;
 		sourceProfileId: number;
 		sourceProfileName: string;
 	},
@@ -338,6 +339,7 @@ export function buildCompleteQualityProfile(
 		// Source information
 		sourceInstanceId: sourceInfo.sourceInstanceId,
 		sourceInstanceLabel: sourceInfo.sourceInstanceLabel,
+		sourceConnectionStateToken: sourceInfo.sourceConnectionStateToken,
 		sourceProfileId: sourceInfo.sourceProfileId,
 		sourceProfileName: sourceInfo.sourceProfileName,
 		importedAt: new Date().toISOString(),

--- a/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
@@ -1,0 +1,244 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+
+const mocks = vi.hoisted(() => ({
+	cacheGet: vi.fn(),
+	createTemplate: vi.fn(),
+	getCommitHash: vi.fn(),
+}));
+
+const clients = vi.hoisted(() => {
+	class MockRadarrClient {}
+	class MockSonarrClient {}
+	return { MockRadarrClient, MockSonarrClient };
+});
+
+vi.mock("arr-sdk", () => ({
+	RadarrClient: clients.MockRadarrClient,
+	SonarrClient: clients.MockSonarrClient,
+}));
+
+vi.mock("../../../lib/trash-guides/cache-manager.js", () => ({
+	createCacheManager: () => ({
+		get: mocks.cacheGet,
+		getCommitHash: mocks.getCommitHash,
+	}),
+}));
+
+vi.mock("../../../lib/trash-guides/template-service.js", () => ({
+	createTemplateService: () => ({ createTemplate: mocks.createTemplate }),
+}));
+
+import profileCloneRoutes from "../profile-clone-routes.js";
+
+let upstreamProfileId = 7;
+let upstreamProfileName: string | null | undefined = "Any";
+let instanceService: "RADARR" | "SONARR" = "RADARR";
+let instanceEncryptedApiKey = "encrypted-key-a";
+
+function createClient() {
+	const Client = instanceService === "RADARR" ? clients.MockRadarrClient : clients.MockSonarrClient;
+	return Object.assign(new Client(), {
+		qualityProfile: {
+			getById: vi.fn().mockResolvedValue({
+				id: upstreamProfileId,
+				name: upstreamProfileName,
+				upgradeAllowed: true,
+				cutoff: 1,
+				minFormatScore: 0,
+				cutoffFormatScore: 0,
+				formatItems: [],
+				items: [],
+			}),
+		},
+		customFormat: {
+			getAll: vi.fn().mockResolvedValue([]),
+		},
+	});
+}
+
+function requestBody(serviceType = instanceService, sourceStateToken?: string) {
+	return {
+		serviceType,
+		trashId: "cloned-instance-1-7",
+		templateName: "Radarr - Any",
+		customFormatSelections: {},
+		sourceInstanceId: "instance-1",
+		sourceProfileId: 7,
+		sourceProfileName: "Stale browser profile name",
+		sourceInstanceLabel: "Stale browser instance label",
+		...(sourceStateToken ? { sourceStateToken } : {}),
+		profileConfig: {
+			upgradeAllowed: true,
+			cutoff: 1,
+			minFormatScore: 0,
+			cutoffFormatScore: 0,
+			items: [],
+		},
+	};
+}
+
+describe("profile clone source authority", () => {
+	let app: FastifyInstance;
+
+	beforeEach(async () => {
+		upstreamProfileId = 7;
+		upstreamProfileName = "Any";
+		instanceService = "RADARR";
+		instanceEncryptedApiKey = "encrypted-key-a";
+		mocks.cacheGet.mockResolvedValue([]);
+		mocks.getCommitHash.mockResolvedValue("commit-1");
+		mocks.createTemplate.mockResolvedValue({ id: "template-1" });
+
+		app = Fastify({ logger: false });
+		setupAuthInjection(app);
+		registerTestErrorHandler(app);
+		app.decorate("prisma", {
+			serviceInstance: {
+				findFirst: vi.fn().mockImplementation(async () => ({
+					id: "instance-1",
+					userId: "user-1",
+					service: instanceService,
+					label: "Production Radarr",
+					baseUrl: "http://radarr:7878",
+					encryptedApiKey: instanceEncryptedApiKey,
+					encryptionIv: "iv",
+					encryptedHttpAuthCredentials: null,
+					httpAuthEncryptionIv: null,
+					connectionGeneration: 2,
+				})),
+			},
+		} as never);
+		app.decorate("arrClientFactory", { create: vi.fn(() => createClient()) } as never);
+		app.decorate("dbProvider", "sqlite");
+		await app.register(profileCloneRoutes);
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		await app.close();
+		vi.clearAllMocks();
+	});
+
+	async function getSourceStateToken(): Promise<string> {
+		const response = await createInjectAuthenticated(app)("GET", "/profile-details/instance-1/7");
+		expect(response.statusCode).toBe(200);
+		const token = response.json().data?.sourceStateToken;
+		expect(token).toMatch(/^[a-f0-9]{64}$/);
+		return token;
+	}
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"persists the re-fetched %s source identity when the template is renamed",
+		async (serviceType) => {
+			instanceService = serviceType;
+			const sourceStateToken = await getSourceStateToken();
+			const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+				body: requestBody(serviceType, sourceStateToken),
+			});
+
+			expect(response.statusCode).toBe(201);
+			expect(mocks.createTemplate).toHaveBeenCalledWith(
+				"user-1",
+				expect.objectContaining({
+					name: "Radarr - Any",
+					sourceQualityProfileName: "Any",
+					description: "Cloned from Production Radarr: Any",
+					config: expect.objectContaining({
+						completeQualityProfile: expect.objectContaining({
+							sourceInstanceId: "instance-1",
+							sourceInstanceLabel: "Production Radarr",
+							sourceConnectionStateToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+							sourceProfileId: 7,
+							sourceProfileName: "Any",
+						}),
+					}),
+				}),
+			);
+		},
+	);
+
+	it("rejects a client service type that does not match the stored source instance", async () => {
+		const sourceStateToken = await getSourceStateToken();
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("SONARR", sourceStateToken),
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json()).toEqual(
+			expect.objectContaining({
+				error: expect.stringContaining("Service type mismatch"),
+			}),
+		);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when ARR returns a different profile identity than requested", async () => {
+		const sourceStateToken = await getSourceStateToken();
+		upstreamProfileId = 8;
+
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("RADARR", sourceStateToken),
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toEqual(
+			expect.objectContaining({
+				message: expect.stringContaining("identity changed"),
+			}),
+		);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it.each([null, undefined, "", "   "])(
+		"fails closed when ARR returns a missing source profile name (%s)",
+		async (profileName) => {
+			upstreamProfileName = profileName;
+
+			const response = await createInjectAuthenticated(app)("GET", "/profile-details/instance-1/7");
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toEqual(
+				expect.objectContaining({ message: expect.stringContaining("name is missing") }),
+			);
+		},
+	);
+
+	it("rejects creation when the reviewed source connection changed", async () => {
+		const sourceStateToken = await getSourceStateToken();
+		instanceEncryptedApiKey = "encrypted-key-b";
+
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("RADARR", sourceStateToken),
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toEqual(
+			expect.objectContaining({ message: expect.stringContaining("reviewed source") }),
+		);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it("rejects an invalid source review token", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("RADARR", "0".repeat(64)),
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it("requires a source review token", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody(),
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
@@ -40,6 +40,8 @@ let upstreamProfileId = 7;
 let upstreamProfileName: string | null | undefined = "Any";
 let instanceService: "RADARR" | "SONARR" = "RADARR";
 let instanceEncryptedApiKey = "encrypted-key-a";
+let upstreamCustomFormatName = "Reviewed CF";
+let upstreamCustomFormatSpecifications: unknown[] = [{ name: "Source", value: "WEB-DL" }];
 
 function createClient() {
 	const Client = instanceService === "RADARR" ? clients.MockRadarrClient : clients.MockSonarrClient;
@@ -52,12 +54,19 @@ function createClient() {
 				cutoff: 1,
 				minFormatScore: 0,
 				cutoffFormatScore: 0,
-				formatItems: [],
+				formatItems: [{ format: 42, score: 100 }],
 				items: [],
 			}),
 		},
 		customFormat: {
-			getAll: vi.fn().mockResolvedValue([]),
+			getAll: vi.fn().mockImplementation(async () => [
+				{
+					id: 42,
+					name: upstreamCustomFormatName,
+					specifications: upstreamCustomFormatSpecifications,
+					includeCustomFormatWhenRenaming: false,
+				},
+			]),
 		},
 	});
 }
@@ -91,6 +100,8 @@ describe("profile clone source authority", () => {
 		upstreamProfileName = "Any";
 		instanceService = "RADARR";
 		instanceEncryptedApiKey = "encrypted-key-a";
+		upstreamCustomFormatName = "Reviewed CF";
+		upstreamCustomFormatSpecifications = [{ name: "Source", value: "WEB-DL" }];
 		mocks.cacheGet.mockResolvedValue([]);
 		mocks.getCommitHash.mockResolvedValue("commit-1");
 		mocks.createTemplate.mockResolvedValue({ id: "template-1" });
@@ -212,6 +223,34 @@ describe("profile clone source authority", () => {
 	it("rejects creation when the reviewed source connection changed", async () => {
 		const sourceStateToken = await getSourceStateToken();
 		instanceEncryptedApiKey = "encrypted-key-b";
+
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("RADARR", sourceStateToken),
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toEqual(
+			expect.objectContaining({ message: expect.stringContaining("reviewed source") }),
+		);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		[
+			"name",
+			() => {
+				upstreamCustomFormatName = "Changed CF";
+			},
+		],
+		[
+			"specifications",
+			() => {
+				upstreamCustomFormatSpecifications = [{ name: "Source", value: "Bluray" }];
+			},
+		],
+	] as const)("rejects creation when reviewed Custom Format %s changed", async (_field, mutate) => {
+		const sourceStateToken = await getSourceStateToken();
+		mutate();
 
 		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
 			body: requestBody("RADARR", sourceStateToken),

--- a/apps/api/src/routes/trash-guides/profile-clone-routes.ts
+++ b/apps/api/src/routes/trash-guides/profile-clone-routes.ts
@@ -14,8 +14,13 @@ import type {
 import { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginCallback } from "fastify";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
+import { ConflictError } from "../../lib/errors.js";
 import { createCacheManager } from "../../lib/trash-guides/cache-manager.js";
 import { createCFMatcher, type InstanceCustomFormat } from "../../lib/trash-guides/cf-matcher.js";
+import {
+	createClonedProfileSourceStateToken,
+	createDeploymentConnectionStateToken,
+} from "../../lib/trash-guides/deployment-target.js";
 import { createProfileCloner } from "../../lib/trash-guides/profile-cloner.js";
 import {
 	type ArrQualityProfileResponse,
@@ -102,7 +107,17 @@ const createTemplateSchema = z.object({
 	}),
 	matchedTrashProfileId: z.string().optional(),
 	matchedScoreSet: z.string().optional(),
+	sourceStateToken: z.string().regex(/^[a-f0-9]{64}$/i),
 });
+
+function requireSourceProfileName(profile: { name?: string | null }): string {
+	if (typeof profile.name !== "string" || profile.name.trim().length === 0) {
+		throw new ConflictError(
+			"The cloned source quality profile name is missing. Refresh the profile and try again.",
+		);
+	}
+	return profile.name;
+}
 
 // ============================================================================
 // Routes
@@ -275,6 +290,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			client.qualityProfile.getById(profileId),
 			client.customFormat.getAll(),
 		]);
+		requireSourceProfileName(profile);
+		const sourceStateToken = createClonedProfileSourceStateToken({
+			userId: request.currentUser!.id,
+			instance,
+			profile,
+		});
 
 		// Get the CFs used in this profile (from formatItems)
 		const profileCFIds = new Set(
@@ -309,6 +330,7 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		return reply.status(200).send({
 			success: true,
 			data: {
+				sourceStateToken,
 				profile: {
 					id: profile.id,
 					name: profile.name,
@@ -532,8 +554,7 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			customFormatSelections,
 			sourceInstanceId,
 			sourceProfileId,
-			sourceProfileName,
-			sourceInstanceLabel,
+			sourceStateToken,
 			profileConfig,
 			matchedTrashProfileId,
 			matchedScoreSet,
@@ -558,6 +579,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		}
 
 		const instance = await requireInstance(app, userId, sourceInstanceId);
+		if (instance.service.toUpperCase() !== serviceType) {
+			return reply.status(400).send({
+				success: false,
+				error: `Service type mismatch: instance is ${instance.service}, request is ${serviceType}`,
+			});
+		}
 
 		// Create SDK client
 		const client = app.arrClientFactory.create(instance);
@@ -575,6 +602,22 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			client.qualityProfile.getById(sourceProfileId) as Promise<ArrQualityProfileResponse>,
 			client.customFormat.getAll(),
 		]);
+		if (fullProfile.id !== sourceProfileId) {
+			throw new ConflictError(
+				"The cloned source quality profile identity changed while the template was being created. Refresh the profile and try again.",
+			);
+		}
+		const sourceProfileName = requireSourceProfileName(fullProfile);
+		const currentSourceStateToken = createClonedProfileSourceStateToken({
+			userId,
+			instance,
+			profile: fullProfile,
+		});
+		if (currentSourceStateToken !== sourceStateToken.toLowerCase()) {
+			throw new ConflictError(
+				"The reviewed source profile or ARR connection changed while the template was being created. Refresh the profile and review it again.",
+			);
+		}
 
 		// Build a lookup map for instance CFs (filter out CFs with undefined id or name)
 		const cfLookup = new Map<number, { id: number; name: string; specifications?: unknown[] }>();
@@ -614,8 +657,9 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		const completeQualityProfile = buildCompleteQualityProfile(fullProfile, profileConfig, {
 			sourceInstanceId,
-			sourceInstanceLabel,
-			sourceProfileId,
+			sourceInstanceLabel: instance.label,
+			sourceConnectionStateToken: createDeploymentConnectionStateToken(instance),
+			sourceProfileId: fullProfile.id,
 			sourceProfileName,
 		});
 
@@ -648,8 +692,7 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 		const templateService = createTemplateService(app.prisma, app.dbProvider);
 		const template = await templateService.createTemplate(userId, {
 			name: templateName,
-			description:
-				templateDescription || `Cloned from ${sourceInstanceLabel}: ${sourceProfileName}`,
+			description: templateDescription || `Cloned from ${instance.label}: ${sourceProfileName}`,
 			serviceType,
 			config: templateConfig,
 			sourceQualityProfileTrashId: safeMatchedTrashProfileId || trashId,

--- a/apps/api/src/routes/trash-guides/profile-clone-routes.ts
+++ b/apps/api/src/routes/trash-guides/profile-clone-routes.ts
@@ -291,12 +291,6 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			client.customFormat.getAll(),
 		]);
 		requireSourceProfileName(profile);
-		const sourceStateToken = createClonedProfileSourceStateToken({
-			userId: request.currentUser!.id,
-			instance,
-			profile,
-		});
-
 		// Get the CFs used in this profile (from formatItems)
 		const profileCFIds = new Set(
 			((profile as ArrQualityProfileResponse).formatItems || []).map(
@@ -310,6 +304,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			(cf): cf is typeof cf & { id: number; name: string } =>
 				cf.id !== undefined && cf.name !== undefined && cf.name !== null,
 		);
+		const sourceStateToken = createClonedProfileSourceStateToken({
+			userId: request.currentUser!.id,
+			instance,
+			profile,
+			customFormats: validCustomFormats,
+		});
 
 		const profileCustomFormats = validCustomFormats
 			.filter((cf) => profileCFIds.has(cf.id))
@@ -608,10 +608,15 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			);
 		}
 		const sourceProfileName = requireSourceProfileName(fullProfile);
+		const validCustomFormats = allCustomFormats.filter(
+			(cf): cf is typeof cf & { id: number; name: string } =>
+				cf.id !== undefined && cf.name !== undefined && cf.name !== null,
+		);
 		const currentSourceStateToken = createClonedProfileSourceStateToken({
 			userId,
 			instance,
 			profile: fullProfile,
+			customFormats: validCustomFormats,
 		});
 		if (currentSourceStateToken !== sourceStateToken.toLowerCase()) {
 			throw new ConflictError(
@@ -621,14 +626,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		// Build a lookup map for instance CFs (filter out CFs with undefined id or name)
 		const cfLookup = new Map<number, { id: number; name: string; specifications?: unknown[] }>();
-		for (const cf of allCustomFormats) {
-			if (cf.id !== undefined && cf.name !== undefined && cf.name !== null) {
-				cfLookup.set(cf.id, {
-					id: cf.id,
-					name: cf.name,
-					specifications: cf.specifications ?? undefined,
-				});
-			}
+		for (const cf of validCustomFormats) {
+			cfLookup.set(cf.id, {
+				id: cf.id,
+				name: cf.name,
+				specifications: cf.specifications ?? undefined,
+			});
 		}
 
 		// Get TRaSH cache for matching

--- a/apps/web/src/features/trash-guides/components/quality-profile-wizard.tsx
+++ b/apps/web/src/features/trash-guides/components/quality-profile-wizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { CustomQualityConfig, NamingSelectedPresets, TrashTemplate } from "@arr/shared";
-import type { WizardEditingTemplate } from "../types/wizard-types";
+import type { WizardClonedSourceReview, WizardEditingTemplate } from "../types/wizard-types";
 import { X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
@@ -131,6 +131,8 @@ interface WizardState {
 	customQualityConfig?: CustomQualityConfig;
 	/** Optional naming presets to deploy with this template */
 	namingSelection?: NamingSelectedPresets;
+	/** Exact cloned ARR snapshot reviewed during Custom Format configuration. */
+	clonedSourceReview?: WizardClonedSourceReview;
 }
 
 // Standard step order for TRaSH Guides profiles: quality config before CF config
@@ -292,6 +294,7 @@ export const QualityProfileWizard = ({
 			currentStep: nextStep,
 			selectedProfile: profile,
 			customFormatSelections: {},
+			clonedSourceReview: undefined,
 			templateName: profile.name,
 			templateDescription: profile.description
 				? htmlToPlainText(profile.description)
@@ -317,12 +320,14 @@ export const QualityProfileWizard = ({
 				conditionsEnabled: Record<string, boolean>;
 			}
 		>,
+		clonedSourceReview?: WizardClonedSourceReview,
 	) => {
 		// Go to summary - template naming happens in the Review step
 		setWizardState((prev) => ({
 			...prev,
 			currentStep: "summary",
 			customFormatSelections: selections,
+			clonedSourceReview,
 		}));
 	};
 
@@ -536,6 +541,7 @@ export const QualityProfileWizard = ({
 								templateDescription: wizardState.templateDescription,
 								customQualityConfig: wizardState.customQualityConfig,
 								namingSelection: wizardState.namingSelection,
+								clonedSourceReview: wizardState.clonedSourceReview,
 							}}
 							templateId={wizardState.templateId} // Pass template ID for update
 							isEditMode={isEditMode}

--- a/apps/web/src/features/trash-guides/components/wizard-steps/__tests__/template-creation.test.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/__tests__/template-creation.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TemplateCreation } from "../template-creation";
+
+const mocks = vi.hoisted(() => ({
+	useQuery: vi.fn(),
+	importMutation: {
+		mutateAsync: vi.fn(),
+		isPending: false,
+		isError: false,
+		isSuccess: false,
+		error: null,
+	},
+	updateMutation: {
+		mutateAsync: vi.fn(),
+		isPending: false,
+		isError: false,
+		isSuccess: false,
+		error: null,
+	},
+	clonedMutation: {
+		mutateAsync: vi.fn(),
+		isPending: false,
+		isError: false,
+		isSuccess: false,
+		error: null,
+	},
+}));
+
+vi.mock("@tanstack/react-query", () => ({ useQuery: mocks.useQuery }));
+
+vi.mock("../../../../../hooks/api/useQualityProfiles", () => ({
+	useImportQualityProfileWizard: () => mocks.importMutation,
+	useUpdateQualityProfileTemplate: () => mocks.updateMutation,
+	useCreateClonedProfileTemplate: () => mocks.clonedMutation,
+}));
+
+vi.mock("../../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: { fromMuted: "transparent", fromLight: "transparent" },
+	}),
+}));
+
+describe("TemplateCreation cloned source review", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.useQuery
+			.mockReturnValueOnce({
+				data: undefined,
+				isLoading: false,
+				error: new Error("ARR source profile is unavailable"),
+			})
+			.mockReturnValueOnce({ data: [], isLoading: false, error: null })
+			.mockReturnValueOnce({ data: undefined, isLoading: false, error: null });
+	});
+
+	it("shows the source-review failure and disables cloned template creation", () => {
+		render(
+			<TemplateCreation
+				serviceType="RADARR"
+				wizardState={{
+					selectedProfile: {
+						trashId: "cloned-instance-1-4-1700000000000-abc123",
+						name: "Any",
+						description: "Cloned from Radarr",
+					} as never,
+					customFormatSelections: {
+						"trash-1": { selected: true, conditionsEnabled: {} },
+					},
+					templateName: "My cloned profile",
+					templateDescription: "",
+				}}
+				onComplete={vi.fn()}
+				onBack={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByText("ARR source profile is unavailable")).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "Create Template" })).toBeDisabled();
+		expect(mocks.clonedMutation.mutateAsync).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/features/trash-guides/components/wizard-steps/__tests__/template-creation.test.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/__tests__/template-creation.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { TemplateCreation } from "../template-creation";
 
@@ -44,6 +44,7 @@ vi.mock("../../../../../hooks/useThemeGradient", () => ({
 describe("TemplateCreation cloned source review", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mocks.clonedMutation.mutateAsync.mockResolvedValue({});
 		mocks.useQuery
 			.mockReturnValueOnce({
 				data: undefined,
@@ -75,8 +76,53 @@ describe("TemplateCreation cloned source review", () => {
 			/>,
 		);
 
-		expect(screen.getByText("ARR source profile is unavailable")).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				"The cloned profile review is unavailable. Go back and review the Custom Formats again.",
+			),
+		).toBeInTheDocument();
 		expect(screen.getByRole("button", { name: "Create Template" })).toBeDisabled();
 		expect(mocks.clonedMutation.mutateAsync).not.toHaveBeenCalled();
+	});
+
+	it("creates from the exact source snapshot carried from configuration", async () => {
+		render(
+			<TemplateCreation
+				serviceType="RADARR"
+				wizardState={{
+					selectedProfile: {
+						trashId: "cloned-instance-1-4-1700000000000-abc123",
+						name: "Any",
+						description: "Cloned from Radarr",
+					} as never,
+					customFormatSelections: {
+						"instance-42": { selected: true, conditionsEnabled: {} },
+					},
+					templateName: "My cloned profile",
+					templateDescription: "",
+					clonedSourceReview: {
+						sourceStateToken: "a".repeat(64),
+						profile: {
+							name: "Any",
+							upgradeAllowed: true,
+							cutoff: 1,
+							minFormatScore: 0,
+							items: [],
+						},
+						mandatoryCFTrashIds: ["instance-42"],
+					},
+				}}
+				onComplete={vi.fn()}
+				onBack={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Create Template" }));
+
+		await waitFor(() =>
+			expect(mocks.clonedMutation.mutateAsync).toHaveBeenCalledWith(
+				expect.objectContaining({ sourceStateToken: "a".repeat(64) }),
+			),
+		);
 	});
 });

--- a/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/cf-configuration.tsx
@@ -36,7 +36,11 @@ import { CFConfigurationCloned } from "./cf-configuration-cloned";
 import { CFConfigurationEdit } from "./cf-configuration-edit";
 import type { CFSelectionState, ConditionEditorTarget } from "./cf-configuration-types";
 import type { ResolvedCF } from "./cf-resolution";
-import type { WizardEditingTemplate, ResolveScoreFn } from "../../types/wizard-types";
+import type {
+	ResolveScoreFn,
+	WizardClonedSourceReview,
+	WizardEditingTemplate,
+} from "../../types/wizard-types";
 
 /**
  * Wizard-specific profile type that allows undefined trashId for edit mode.
@@ -50,7 +54,10 @@ interface CFConfigurationProps {
 	serviceType: "RADARR" | "SONARR";
 	qualityProfile: WizardSelectedProfile;
 	initialSelections: Record<string, CFSelectionState>;
-	onNext: (selections: Record<string, CFSelectionState>) => void;
+	onNext: (
+		selections: Record<string, CFSelectionState>,
+		clonedSourceReview?: WizardClonedSourceReview,
+	) => void;
 	onBack?: () => void; // Optional - undefined means hide back button
 	isEditMode?: boolean; // Edit mode flag to skip API call
 	editingTemplate?: WizardEditingTemplate; // Template being edited (contains all CF data)
@@ -288,11 +295,10 @@ export const CFConfiguration = ({
 	const handleNext = () => {
 		// Pass selections to the next step (Summary/Review)
 		// Template naming is now handled in the Review step
-		onNext(selections);
+		onNext(selections, data?.clonedSourceReview);
 	};
 
-	// For cloned profile mode, skip loading state (we have cfResolutions)
-	if (!isClonedProfileMode && isLoading) {
+	if (isLoading) {
 		return (
 			<div className="space-y-6 animate-in fade-in duration-300">
 				{/* Header Skeleton */}
@@ -360,13 +366,18 @@ export const CFConfiguration = ({
 		);
 	}
 
-	if (!isClonedProfileMode && error) {
+	if (error || (isClonedProfileMode && !data?.clonedSourceReview)) {
 		return (
 			<div className="animate-in fade-in duration-300">
 				<Alert variant="danger">
 					<AlertCircle className="h-4 w-4" />
 					<AlertDescription>
-						{getErrorMessage(error, "Failed to load quality profile details")}
+						{getErrorMessage(
+							error,
+							isClonedProfileMode
+								? "The cloned profile review is unavailable. Refresh and try again."
+								: "Failed to load quality profile details",
+						)}
 					</AlertDescription>
 				</Alert>
 			</div>

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -25,6 +25,7 @@ import {
 import { useThemeGradient } from "../../../../hooks/useThemeGradient";
 import { apiRequest } from "../../../../lib/api-client/base";
 import type { QualityProfileSummary } from "../../../../lib/api-client/trash-guides";
+import { qualityProfileKeys } from "../../../../lib/query-keys";
 import type { WizardCFGroup } from "../../types/wizard-types";
 
 /** Response from profile details endpoints */
@@ -32,6 +33,7 @@ interface ProfileDetailsResponse {
 	success?: boolean;
 	error?: string;
 	data?: {
+		sourceStateToken?: string;
 		profile?: {
 			upgradeAllowed?: boolean;
 			cutoff?: number;
@@ -212,7 +214,7 @@ export const TemplateCreation = ({
 	const hasTrashId = !!wizardState.selectedProfile.trashId;
 	const { data, isLoading } = useQuery({
 		queryKey: isCloned
-			? ["cloned-profile-details", wizardState.selectedProfile.trashId]
+			? qualityProfileKeys.clone.sourceReview(wizardState.selectedProfile.trashId ?? "")
 			: ["quality-profile-details", serviceType, wizardState.selectedProfile.trashId],
 		queryFn: async () => {
 			if (isCloned && clonedProfileInfo) {
@@ -320,6 +322,12 @@ export const TemplateCreation = ({
 
 				// Extract profile config from the data we fetched
 				const profileData = data?.data?.profile || data?.profile;
+				const sourceStateToken = data?.data?.sourceStateToken;
+				if (!sourceStateToken) {
+					throw new Error(
+						"Cannot create template: the cloned profile review expired. Refresh the profile and try again.",
+					);
+				}
 				const instanceLabel =
 					wizardState.selectedProfile.description?.replace("Cloned from ", "") ||
 					"Unknown Instance";
@@ -332,6 +340,7 @@ export const TemplateCreation = ({
 					customFormatSelections: wizardState.customFormatSelections,
 					sourceInstanceId: clonedProfileInfo.instanceId,
 					sourceProfileId: clonedProfileInfo.profileId,
+					sourceStateToken,
 					sourceProfileName: wizardState.selectedProfile.name,
 					sourceInstanceLabel: instanceLabel,
 					profileConfig: {

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -212,7 +212,11 @@ export const TemplateCreation = ({
 	// In edit mode, trashId is undefined and we don't need profile data from TRaSH Guides
 	// For cloned profiles, we fetch from the instance, not TRaSH cache
 	const hasTrashId = !!wizardState.selectedProfile.trashId;
-	const { data, isLoading } = useQuery({
+	const {
+		data,
+		isLoading,
+		error: profileDetailsError,
+	} = useQuery({
 		queryKey: isCloned
 			? qualityProfileKeys.clone.sourceReview(wizardState.selectedProfile.trashId ?? "")
 			: ["quality-profile-details", serviceType, wizardState.selectedProfile.trashId],
@@ -231,6 +235,9 @@ export const TemplateCreation = ({
 		// Skip fetch in edit mode (no trashId) - we already have all data from the template
 		enabled: hasTrashId && !isEditMode,
 	});
+	const clonedSourceStateToken = isCloned ? data?.data?.sourceStateToken : undefined;
+	const clonedSourceReviewUnavailable =
+		isCloned && !isEditMode && !isLoading && !clonedSourceStateToken;
 
 	// Fetch CF Groups from cache for edit mode categorization
 	// This helps determine which CFs belong to which groups even when template data is incomplete
@@ -322,7 +329,7 @@ export const TemplateCreation = ({
 
 				// Extract profile config from the data we fetched
 				const profileData = data?.data?.profile || data?.profile;
-				const sourceStateToken = data?.data?.sourceStateToken;
+				const sourceStateToken = clonedSourceStateToken;
 				if (!sourceStateToken) {
 					throw new Error(
 						"Cannot create template: the cloned profile review expired. Refresh the profile and try again.",
@@ -791,20 +798,27 @@ export const TemplateCreation = ({
 			</div>
 
 			{/* Error/Success Messages */}
-			{(importMutation.isError || updateMutation.isError || clonedMutation.isError) && (
+			{(importMutation.isError ||
+				updateMutation.isError ||
+				clonedMutation.isError ||
+				clonedSourceReviewUnavailable) && (
 				<Alert variant="danger">
 					<AlertDescription>
-						{importMutation.error instanceof Error
-							? importMutation.error.message
-							: updateMutation.error instanceof Error
-								? updateMutation.error.message
-								: clonedMutation.error instanceof Error
-									? clonedMutation.error.message
-									: isEditMode
-										? "Failed to update template"
-										: isCloned
-											? "Failed to create template from cloned profile"
-											: "Failed to import quality profile"}
+						{clonedSourceReviewUnavailable
+							? profileDetailsError instanceof Error
+								? profileDetailsError.message
+								: "The cloned profile review is unavailable. Refresh or go back and select the source profile again."
+							: importMutation.error instanceof Error
+								? importMutation.error.message
+								: updateMutation.error instanceof Error
+									? updateMutation.error.message
+									: clonedMutation.error instanceof Error
+										? clonedMutation.error.message
+										: isEditMode
+											? "Failed to update template"
+											: isCloned
+												? "Failed to create template from cloned profile"
+												: "Failed to import quality profile"}
 					</AlertDescription>
 				</Alert>
 			)}
@@ -845,6 +859,7 @@ export const TemplateCreation = ({
 						disabled={
 							!templateName.trim() ||
 							selectedCFs.length === 0 ||
+							clonedSourceReviewUnavailable ||
 							importMutation.isPending ||
 							updateMutation.isPending ||
 							clonedMutation.isPending

--- a/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
+++ b/apps/web/src/features/trash-guides/components/wizard-steps/template-creation.tsx
@@ -25,8 +25,7 @@ import {
 import { useThemeGradient } from "../../../../hooks/useThemeGradient";
 import { apiRequest } from "../../../../lib/api-client/base";
 import type { QualityProfileSummary } from "../../../../lib/api-client/trash-guides";
-import { qualityProfileKeys } from "../../../../lib/query-keys";
-import type { WizardCFGroup } from "../../types/wizard-types";
+import type { WizardCFGroup, WizardClonedSourceReview } from "../../types/wizard-types";
 
 /** Response from profile details endpoints */
 interface ProfileDetailsResponse {
@@ -172,6 +171,7 @@ interface TemplateCreationProps {
 		templateDescription: string;
 		customQualityConfig?: CustomQualityConfig;
 		namingSelection?: NamingSelectedPresets;
+		clonedSourceReview?: WizardClonedSourceReview;
 	};
 	templateId?: string; // For editing existing templates
 	isEditMode?: boolean;
@@ -212,32 +212,22 @@ export const TemplateCreation = ({
 	// In edit mode, trashId is undefined and we don't need profile data from TRaSH Guides
 	// For cloned profiles, we fetch from the instance, not TRaSH cache
 	const hasTrashId = !!wizardState.selectedProfile.trashId;
-	const {
-		data,
-		isLoading,
-		error: profileDetailsError,
-	} = useQuery({
-		queryKey: isCloned
-			? qualityProfileKeys.clone.sourceReview(wizardState.selectedProfile.trashId ?? "")
-			: ["quality-profile-details", serviceType, wizardState.selectedProfile.trashId],
+	const { data: fetchedData, isLoading } = useQuery({
+		queryKey: ["quality-profile-details", serviceType, wizardState.selectedProfile.trashId],
 		queryFn: async () => {
-			if (isCloned && clonedProfileInfo) {
-				// Fetch from cloned profile endpoint
-				return await apiRequest<ProfileDetailsResponse>(
-					`/api/trash-guides/profile-clone/profile-details/${clonedProfileInfo.instanceId}/${clonedProfileInfo.profileId}`,
-				);
-			}
 			// Fetch from TRaSH Guides cache
 			return await apiRequest<ProfileDetailsResponse>(
 				`/api/trash-guides/quality-profiles/${serviceType}/${wizardState.selectedProfile.trashId}`,
 			);
 		},
 		// Skip fetch in edit mode (no trashId) - we already have all data from the template
-		enabled: hasTrashId && !isEditMode,
+		enabled: hasTrashId && !isEditMode && !isCloned,
 	});
-	const clonedSourceStateToken = isCloned ? data?.data?.sourceStateToken : undefined;
-	const clonedSourceReviewUnavailable =
-		isCloned && !isEditMode && !isLoading && !clonedSourceStateToken;
+	const data = fetchedData;
+	const clonedSourceStateToken = isCloned
+		? wizardState.clonedSourceReview?.sourceStateToken
+		: undefined;
+	const clonedSourceReviewUnavailable = isCloned && !isEditMode && !wizardState.clonedSourceReview;
 
 	// Fetch CF Groups from cache for edit mode categorization
 	// This helps determine which CFs belong to which groups even when template data is incomplete
@@ -328,7 +318,7 @@ export const TemplateCreation = ({
 				}
 
 				// Extract profile config from the data we fetched
-				const profileData = data?.data?.profile || data?.profile;
+				const profileData = wizardState.clonedSourceReview?.profile;
 				const sourceStateToken = clonedSourceStateToken;
 				if (!sourceStateToken) {
 					throw new Error(
@@ -399,15 +389,18 @@ export const TemplateCreation = ({
 	// Build list of selected CF Groups for display (groups with at least one selected CF)
 	// In edit mode, prefer cfGroupsCache from TRaSH cache, fallback to template's stored groups
 	// This ensures proper categorization even for templates with incomplete group data
-	const cfGroups: WizardCFGroup[] = isEditMode
-		? cfGroupsCache ||
-			editingTemplate?.config.customFormatGroups.map((g) => ({
-				trash_id: g.trashId,
-				name: g.name || "",
-				custom_formats: (g.originalConfig?.custom_formats as WizardCFGroup["custom_formats"]) || [],
-			})) ||
-			[]
-		: data?.cfGroups || [];
+	const cfGroups: WizardCFGroup[] = isCloned
+		? []
+		: isEditMode
+			? cfGroupsCache ||
+				editingTemplate?.config.customFormatGroups.map((g) => ({
+					trash_id: g.trashId,
+					name: g.name || "",
+					custom_formats:
+						(g.originalConfig?.custom_formats as WizardCFGroup["custom_formats"]) || [],
+				})) ||
+				[]
+			: data?.cfGroups || [];
 
 	const selectedCFTrashIds = new Set(
 		Object.entries(wizardState.customFormatSelections)
@@ -430,9 +423,13 @@ export const TemplateCreation = ({
 	// Categorize CFs by their properties
 	// In edit mode, use the source profile data to determine mandatory CFs
 	// This requires the template to have sourceQualityProfileTrashId set
-	const mandatoryCFs = isEditMode
-		? sourceProfileData?.mandatoryCFs || []
-		: data?.mandatoryCFs || [];
+	const mandatoryCFs = isCloned
+		? (wizardState.clonedSourceReview?.mandatoryCFTrashIds ?? []).map((trash_id) => ({
+				trash_id,
+			}))
+		: isEditMode
+			? sourceProfileData?.mandatoryCFs || []
+			: data?.mandatoryCFs || [];
 	const mandatoryCFIds = new Set(mandatoryCFs.map((cf) => cf.trash_id));
 
 	// CFs from groups that have at least one selected CF
@@ -805,9 +802,7 @@ export const TemplateCreation = ({
 				<Alert variant="danger">
 					<AlertDescription>
 						{clonedSourceReviewUnavailable
-							? profileDetailsError instanceof Error
-								? profileDetailsError.message
-								: "The cloned profile review is unavailable. Refresh or go back and select the source profile again."
+							? "The cloned profile review is unavailable. Go back and review the Custom Formats again."
 							: importMutation.error instanceof Error
 								? importMutation.error.message
 								: updateMutation.error instanceof Error

--- a/apps/web/src/features/trash-guides/types/wizard-types.ts
+++ b/apps/web/src/features/trash-guides/types/wizard-types.ts
@@ -112,6 +112,21 @@ export interface WizardProfileSummary {
 	minUpgradeFormatScore?: number;
 }
 
+/** Exact ARR source snapshot reviewed before creating a cloned template. */
+export interface WizardClonedSourceReview {
+	sourceStateToken: string;
+	profile: {
+		name: string;
+		upgradeAllowed?: boolean;
+		cutoff?: number;
+		minFormatScore?: number;
+		cutoffFormatScore?: number;
+		items?: unknown[];
+		language?: unknown;
+	};
+	mandatoryCFTrashIds: string[];
+}
+
 /**
  * The full result returned by useCFConfiguration's queryFn.
  * This is the union of all three modes (edit, cloned, normal).
@@ -126,6 +141,8 @@ export interface WizardCFConfigurationResult {
 	profile?: WizardProfileSummary;
 	/** Present in cloned mode */
 	isClonedProfile?: boolean;
+	/** Present in cloned mode and carried unchanged through final creation. */
+	clonedSourceReview?: WizardClonedSourceReview;
 	/** Present in normal mode — TRaSH-specific fields */
 	trashScoreSet?: string;
 	cfDescriptions?: Record<string, { description: string; displayName: string }>;

--- a/apps/web/src/hooks/api/useCFConfiguration.ts
+++ b/apps/web/src/hooks/api/useCFConfiguration.ts
@@ -4,6 +4,7 @@ import type { QualityProfileSummary } from "../../lib/api-client/trash-guides";
 import { qualityProfileKeys } from "../../lib/query-keys";
 import type {
 	WizardAvailableFormat,
+	WizardClonedSourceReview,
 	WizardCFConfigurationResult,
 	WizardCFGroup,
 	WizardCustomFormat,
@@ -399,12 +400,14 @@ async function fetchClonedProfileData(trashId: string) {
 		upgradeAllowed?: boolean;
 		cutoff?: number;
 		minFormatScore?: number;
+		cutoffFormatScore?: number;
 		items?: Array<{
 			name?: string;
 			allowed?: boolean;
 			quality?: { name?: string; source?: string; resolution?: number };
 			items?: Array<string | { name?: string; quality?: { name?: string } }>;
 		}>;
+		language?: unknown;
 	}
 
 	// Fetch profile details from the source instance
@@ -412,6 +415,7 @@ async function fetchClonedProfileData(trashId: string) {
 		success: boolean;
 		error?: string;
 		data?: {
+			sourceStateToken: string;
 			profile: InstanceProfile;
 			customFormats: InstanceCF[];
 			allCustomFormats: InstanceCF[];
@@ -423,7 +427,10 @@ async function fetchClonedProfileData(trashId: string) {
 		throw new Error(response.error || "Failed to fetch profile details from instance");
 	}
 
-	const { profile, customFormats, allCustomFormats } = response.data;
+	const { sourceStateToken, profile, customFormats, allCustomFormats } = response.data;
+	if (!sourceStateToken) {
+		throw new Error("The cloned profile source review is unavailable. Refresh and try again.");
+	}
 
 	// Detect service type from instance for description enrichment
 	// Instance response may include serviceType; fall back to inferring from trashId
@@ -478,6 +485,20 @@ async function fetchClonedProfileData(trashId: string) {
 			items: item.items?.map((q) => (typeof q === "string" ? q : q.name || q.quality?.name || "")),
 		})) || [];
 
+	const clonedSourceReview: WizardClonedSourceReview = {
+		sourceStateToken,
+		profile: {
+			name: profile.name,
+			upgradeAllowed: profile.upgradeAllowed,
+			cutoff: profile.cutoff,
+			minFormatScore: profile.minFormatScore,
+			cutoffFormatScore: profile.cutoffFormatScore,
+			items: profile.items,
+			language: profile.language,
+		},
+		mandatoryCFTrashIds: customFormats.map((cf) => cf.trash_id),
+	};
+
 	return {
 		cfGroups: [], // Cloned profiles don't have CF groups
 		mandatoryCFs,
@@ -494,6 +515,7 @@ async function fetchClonedProfileData(trashId: string) {
 			totalOptionalCFs: allCustomFormats.length,
 		},
 		isClonedProfile: true,
+		clonedSourceReview,
 		qualityItems,
 	};
 }

--- a/apps/web/src/hooks/api/useCFConfiguration.ts
+++ b/apps/web/src/hooks/api/useCFConfiguration.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiRequest } from "../../lib/api-client/base";
 import type { QualityProfileSummary } from "../../lib/api-client/trash-guides";
+import { qualityProfileKeys } from "../../lib/query-keys";
 import type {
 	WizardAvailableFormat,
 	WizardCFConfigurationResult,
@@ -116,7 +117,7 @@ export function useCFConfiguration({
 		queryKey: isEditMode
 			? ["template-edit-data", editingTemplate?.id]
 			: isCloned
-				? ["cloned-profile-details", qualityProfile.trashId]
+				? qualityProfileKeys.clone.configuration(qualityProfile.trashId ?? "")
 				: ["quality-profile-details", serviceType, qualityProfile.trashId],
 		queryFn: async () => {
 			if (isEditMode && editingTemplate) {

--- a/apps/web/src/lib/api-client/trash-guides/profiles.ts
+++ b/apps/web/src/lib/api-client/trash-guides/profiles.ts
@@ -149,6 +149,7 @@ export type CreateClonedTemplatePayload = {
 	>;
 	sourceInstanceId: string;
 	sourceProfileId: number;
+	sourceStateToken: string;
 	sourceProfileName: string;
 	sourceInstanceLabel: string;
 	profileConfig: {

--- a/apps/web/src/lib/query-keys.test.ts
+++ b/apps/web/src/lib/query-keys.test.ts
@@ -1,0 +1,17 @@
+import { QueryClient } from "@tanstack/react-query";
+import { describe, expect, it } from "vitest";
+import { qualityProfileKeys } from "./query-keys";
+
+describe("cloned profile query keys", () => {
+	it("keeps transformed configuration data out of the source-review token cache", () => {
+		const queryClient = new QueryClient();
+		const trashId = "cloned-instance-1-7";
+		queryClient.setQueryData(qualityProfileKeys.clone.configuration(trashId), {
+			profile: { name: "Any" },
+		});
+
+		expect(
+			queryClient.getQueryData(qualityProfileKeys.clone.sourceReview(trashId)),
+		).toBeUndefined();
+	});
+});

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -139,6 +139,10 @@ export const qualityProfileKeys = {
 		["profile-match", profileName, serviceType] as const,
 	clone: {
 		profiles: (instanceId: string) => ["profile-clone", "profiles", instanceId] as const,
+		configuration: (trashId: string) =>
+			["cloned-profile-details", "configuration", trashId] as const,
+		sourceReview: (trashId: string) =>
+			["cloned-profile-details", "source-review", trashId] as const,
 	},
 };
 

--- a/packages/shared/src/types/trash-guides.ts
+++ b/packages/shared/src/types/trash-guides.ts
@@ -758,6 +758,7 @@ export interface CompleteQualityProfile {
 	// Source information
 	sourceInstanceId: string; // Instance this was imported from
 	sourceInstanceLabel?: string; // Friendly name of source instance
+	sourceConnectionStateToken?: string; // Exact ARR connection reviewed during cloning
 	sourceProfileId: number; // *arr quality profile ID
 	sourceProfileName: string; // Original profile name
 	importedAt: string; // When it was imported


### PR DESCRIPTION
## Summary

- bind cloned-template creation to the exact reviewed owner, ARR connection, and profile state
- persist the reviewed source connection and use the numeric source profile ID only while that connection still matches
- fail closed for legacy clones without a source token and for changed, missing, or repointed source records before alias correlation or name fallback
- keep renamed templates targeting the original profile while allowing verified deployments to a genuinely different endpoint to use unique-name matching
- show source-review failures in the wizard and disable template creation until the source can be reviewed again
- isolate transformed wizard data from the raw source-review token cache

## Live verification

The candidate was tested in Chromium against an isolated real Radarr instance:

- selected a template renamed to `LC E2E 665 Renamed Radarr Any`
- preview matched cloned source profile ID `1` (`Any`) instead of relying on the stored name
- deployed the update successfully with no browser console or page errors
- Radarr retained exactly six profiles, profile ID `1` remained `Any`, and no profile with the renamed template title was created
- the intended profile score changed from `-10000` to `-9999`
- deployment history recorded `SUCCESS`

## Validation

- shared package build, root typecheck, lint, production build, and full tests passed
- full tests: API 3,514 passed / 43 skipped; web 585 passed; shared 89 passed (4,188 passed total)
- focused source-binding, alias-repoint, preview, executor, and wizard regressions passed
- independent project data-safety review: CLEAN
- independent project regression review: CLEAN

The repository-wide formatter still reports only the four inherited OIDC formatting discrepancies already present on the base branch. Every changed file passes formatting.

Stacked on #680.

Related to #665