### PR TITLE
fix(trash-guides): harden profile deployment recovery

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+import { BulkScoreManager } from "../bulk-score-manager.js";
+import { createDeploymentConnectionStateToken } from "../deployment-target.js";
+
+const userId = "user-1";
+const primary = {
+	id: "primary",
+	label: "Primary",
+	service: "RADARR",
+	baseUrl: "http://radarr-a:7878",
+	encryptedApiKey: "key-a",
+	encryptionIv: "iv-a",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 2,
+};
+const alias = { ...primary, id: "alias", label: "Alias" };
+const second = {
+	...primary,
+	id: "second",
+	label: "Second",
+	baseUrl: "http://radarr-b:7878",
+	encryptedApiKey: "key-b",
+	encryptionIv: "iv-b",
+};
+
+describe("BulkScoreManager canonical profile identity", () => {
+	it("keeps different scores for same-title profiles on separate instances and finds alias mappings", async () => {
+		const instances = new Map([
+			[primary.id, primary],
+			[alias.id, alias],
+			[second.id, second],
+		]);
+		const findMappings = vi.fn(async ({ where }) => {
+			const bindings = Array.isArray(where.OR) ? where.OR : [];
+			if (bindings.some((binding: { instanceId: string }) => binding.instanceId === alias.id)) {
+				return [
+					{
+						templateId: "template-a",
+						instanceId: alias.id,
+						qualityProfileId: 4,
+						connectionGeneration: alias.connectionGeneration,
+						connectionStateToken: createDeploymentConnectionStateToken(alias),
+					},
+				];
+			}
+			if (bindings.some((binding: { instanceId: string }) => binding.instanceId === second.id)) {
+				return [
+					{
+						templateId: "template-b",
+						instanceId: second.id,
+						qualityProfileId: 4,
+						connectionGeneration: second.connectionGeneration,
+						connectionStateToken: createDeploymentConnectionStateToken(second),
+					},
+				];
+			}
+			return [];
+		});
+		const prisma = {
+			serviceInstance: {
+				findFirst: vi.fn(async ({ where }) =>
+					where.userId === userId ? (instances.get(where.id) ?? null) : null,
+				),
+				findMany: vi.fn(async ({ where }) =>
+					[...instances.values()].filter((instance) => instance.service === where.service),
+				),
+			},
+			templateQualityProfileMapping: { findMany: findMappings },
+			trashTemplate: {
+				findMany: vi.fn(async ({ where }) =>
+					where.id.in.map((id: string) => ({
+						id,
+						configData: JSON.stringify({
+							qualityProfile: { trash_score_set: "default" },
+							customFormats: [
+								{
+									trashId: "trash-reject",
+									name: "Reject",
+									originalConfig: { trash_scores: { default: 0 } },
+								},
+							],
+						}),
+					})),
+				),
+			},
+		};
+		const clientFactory = {
+			create: vi.fn((instance: typeof primary) => ({
+				qualityProfile: {
+					getAll: vi.fn().mockResolvedValue([
+						{
+							id: 4,
+							name: "Any",
+							formatItems: [{ format: 7, score: instance.id === second.id ? 100 : -10_000 }],
+						},
+					]),
+				},
+				customFormat: { getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Reject" }]) },
+			})),
+		};
+		const manager = new BulkScoreManager(prisma as never, clientFactory as never);
+
+		const [primaryScores, secondScores] = await Promise.all([
+			manager.getAllScores(userId, { instanceId: primary.id }),
+			manager.getAllScores(userId, { instanceId: second.id }),
+		]);
+
+		expect(primaryScores[0]?.templateScores[0]).toMatchObject({
+			qualityProfileName: "Any",
+			currentScore: -10_000,
+			isTemplateManaged: true,
+		});
+		expect(secondScores[0]?.templateScores[0]).toMatchObject({
+			qualityProfileName: "Any",
+			currentScore: 100,
+			isTemplateManaged: true,
+		});
+		expect(findMappings).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ template: { userId } }),
+			}),
+		);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -33,6 +33,16 @@ describe("BulkScoreManager canonical profile identity", () => {
 		]);
 		const findMappings = vi.fn(async ({ where }) => {
 			const bindings = Array.isArray(where.OR) ? where.OR : [];
+			const managedCustomFormats = JSON.stringify([
+				{
+					trashId: "trash-reject",
+					name: "Reject",
+					resourceId: 7,
+					stateToken: "resource-state",
+					profileId: 4,
+					appliedScore: -10_000,
+				},
+			]);
 			if (bindings.some((binding: { instanceId: string }) => binding.instanceId === alias.id)) {
 				return [
 					{
@@ -41,6 +51,8 @@ describe("BulkScoreManager canonical profile identity", () => {
 						qualityProfileId: 4,
 						connectionGeneration: alias.connectionGeneration,
 						connectionStateToken: createDeploymentConnectionStateToken(alias),
+						managedCustomFormatsCaptured: true,
+						managedCustomFormats,
 					},
 				];
 			}
@@ -52,6 +64,8 @@ describe("BulkScoreManager canonical profile identity", () => {
 						qualityProfileId: 4,
 						connectionGeneration: second.connectionGeneration,
 						connectionStateToken: createDeploymentConnectionStateToken(second),
+						managedCustomFormatsCaptured: true,
+						managedCustomFormats,
 					},
 				];
 			}
@@ -77,7 +91,7 @@ describe("BulkScoreManager canonical profile identity", () => {
 								{
 									trashId: "trash-reject",
 									name: "Reject",
-									originalConfig: { trash_scores: { default: 0 } },
+									originalConfig: { trash_scores: { default: -10_000 } },
 								},
 							],
 						}),
@@ -86,17 +100,26 @@ describe("BulkScoreManager canonical profile identity", () => {
 			},
 		};
 		const clientFactory = {
+			createConnectionCredentialIdentity: vi.fn().mockReturnValue("credentials"),
 			create: vi.fn((instance: typeof primary) => ({
 				qualityProfile: {
 					getAll: vi.fn().mockResolvedValue([
 						{
 							id: 4,
 							name: "Any",
-							formatItems: [{ format: 7, score: instance.id === second.id ? 100 : -10_000 }],
+							formatItems: [
+								{ format: 7, score: instance.id === second.id ? 100 : -10_000 },
+								{ format: 8, score: 50 },
+							],
 						},
 					]),
 				},
-				customFormat: { getAll: vi.fn().mockResolvedValue([{ id: 7, name: "Reject" }]) },
+				customFormat: {
+					getAll: vi.fn().mockResolvedValue([
+						{ id: 7, name: "Reject" },
+						{ id: 8, name: "Reject" },
+					]),
+				},
 			})),
 		};
 		const manager = new BulkScoreManager(prisma as never, clientFactory as never);
@@ -106,20 +129,75 @@ describe("BulkScoreManager canonical profile identity", () => {
 			manager.getAllScores(userId, { instanceId: second.id }),
 		]);
 
-		expect(primaryScores[0]?.templateScores[0]).toMatchObject({
+		expect(primaryScores).toHaveLength(2);
+		expect(
+			primaryScores.find((score) => score.trashId === "cf-7")?.templateScores[0],
+		).toMatchObject({
 			qualityProfileName: "Any",
 			currentScore: -10_000,
+			defaultScore: -10_000,
 			isTemplateManaged: true,
 		});
-		expect(secondScores[0]?.templateScores[0]).toMatchObject({
-			qualityProfileName: "Any",
-			currentScore: 100,
-			isTemplateManaged: true,
+		expect(
+			primaryScores.find((score) => score.trashId === "cf-8")?.templateScores[0],
+		).toMatchObject({
+			currentScore: 50,
+			defaultScore: 0,
 		});
+		expect(secondScores.find((score) => score.trashId === "cf-7")?.templateScores[0]).toMatchObject(
+			{
+				qualityProfileName: "Any",
+				currentScore: 100,
+				isTemplateManaged: true,
+			},
+		);
 		expect(findMappings).toHaveBeenCalledWith(
 			expect.objectContaining({
 				where: expect.objectContaining({ template: { userId } }),
 			}),
+		);
+
+		findMappings.mockResolvedValueOnce([
+			{
+				templateId: "template-a",
+				instanceId: primary.id,
+				qualityProfileId: 4,
+				connectionGeneration: primary.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(primary),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-reject",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: "resource-7",
+						profileId: 4,
+						appliedScore: -10_000,
+					},
+				]),
+			},
+			{
+				templateId: "template-a",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-reject",
+						name: "Reject",
+						resourceId: 8,
+						stateToken: "resource-8",
+						profileId: 4,
+						appliedScore: 50,
+					},
+				]),
+			},
+		]);
+
+		await expect(manager.getAllScores(userId, { instanceId: primary.id })).rejects.toThrow(
+			"conflicting managed Custom Format snapshots",
 		);
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/profile-matcher.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/profile-matcher.test.ts
@@ -1,0 +1,135 @@
+import type { TrashCustomFormat } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import { AppValidationError, ConflictError } from "../../errors.js";
+import { buildCustomFormatsConfig } from "../profile-matcher.js";
+import { calculateScoreAndSource } from "../template-score-utils.js";
+
+const instanceFormats = new Map([
+	[
+		42,
+		{
+			id: 42,
+			name: "Language: Not English",
+			specifications: [{ name: "Not English" }],
+		},
+	],
+]);
+
+function keepInstanceSelection(scoreOverride?: number) {
+	return {
+		"instance-42": {
+			selected: true,
+			scoreOverride,
+			conditionsEnabled: {},
+		},
+	};
+}
+
+describe("buildCustomFormatsConfig", () => {
+	it("preserves the current source profile score for a Keep Instance selection", () => {
+		const result = buildCustomFormatsConfig(
+			keepInstanceSelection(),
+			instanceFormats,
+			new Map<string, TrashCustomFormat>(),
+			"radarr-1",
+			new Map([[42, -10_000]]),
+		);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				trashId: "instance-42",
+				name: "Language: Not English",
+				scoreOverride: -10_000,
+			}),
+		]);
+		expect(calculateScoreAndSource(result[0]!, undefined)).toEqual({
+			score: -10_000,
+			scoreSource: "template override",
+		});
+	});
+
+	it("keeps an explicit user score of zero instead of replacing it with the source score", () => {
+		const result = buildCustomFormatsConfig(
+			keepInstanceSelection(0),
+			instanceFormats,
+			new Map<string, TrashCustomFormat>(),
+			"sonarr-1",
+			new Map([[42, -10_000]]),
+		);
+
+		expect(result[0]?.scoreOverride).toBe(0);
+	});
+
+	it("fails closed when the source profile no longer contains the selected format score", () => {
+		for (const selection of [keepInstanceSelection(), keepInstanceSelection(500)]) {
+			expect(() =>
+				buildCustomFormatsConfig(
+					selection,
+					instanceFormats,
+					new Map<string, TrashCustomFormat>(),
+					"radarr-1",
+					new Map(),
+				),
+			).toThrow(ConflictError);
+		}
+	});
+
+	it("fails closed when the selected instance format no longer exists", () => {
+		expect(() =>
+			buildCustomFormatsConfig(
+				keepInstanceSelection(),
+				new Map(),
+				new Map<string, TrashCustomFormat>(),
+				"radarr-1",
+				new Map([[42, -10_000]]),
+			),
+		).toThrow(ConflictError);
+	});
+
+	it("fails closed when a selected TRaSH-linked format no longer exists", () => {
+		expect(() =>
+			buildCustomFormatsConfig(
+				{ "trash-missing": { selected: true, conditionsEnabled: {} } },
+				instanceFormats,
+				new Map<string, TrashCustomFormat>(),
+				"radarr-1",
+				new Map([[42, -10_000]]),
+			),
+		).toThrow(ConflictError);
+	});
+
+	it.each(["instance-42-stale", "instance-042", "instance-0", "instance--42"])(
+		"rejects non-canonical instance format key %s",
+		(cfKey) => {
+			expect(() =>
+				buildCustomFormatsConfig(
+					{ [cfKey]: { selected: true, conditionsEnabled: {} } },
+					instanceFormats,
+					new Map<string, TrashCustomFormat>(),
+					"radarr-1",
+					new Map([[42, -10_000]]),
+				),
+			).toThrow(AppValidationError);
+		},
+	);
+
+	it("reserves the instance namespace even if a cached TRaSH ID collides", () => {
+		const collidingTrashFormat = {
+			trash_id: "instance-42",
+			name: "Wrong cached format",
+			specifications: [],
+		} as unknown as TrashCustomFormat;
+
+		const result = buildCustomFormatsConfig(
+			keepInstanceSelection(),
+			instanceFormats,
+			new Map([["instance-42", collidingTrashFormat]]),
+			"radarr-1",
+			new Map([[42, -10_000]]),
+		);
+
+		expect(result[0]).toEqual(
+			expect.objectContaining({ name: "Language: Not English", scoreOverride: -10_000 }),
+		);
+	});
+});

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -22,6 +22,7 @@ import type { ArrClientFactory } from "../arr/client-factory.js";
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
+import { readPersistedManagedCustomFormatIdentities } from "./deployment-managed-format-state.js";
 import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBindingCandidates,
@@ -162,6 +163,8 @@ export class BulkScoreManager {
 				templateId: true,
 				connectionGeneration: true,
 				connectionStateToken: true,
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: true,
 			},
 		});
 		assertNoLegacyDeploymentConnectionMappings(templateMappings);
@@ -176,9 +179,50 @@ export class BulkScoreManager {
 				"Equivalent ARR service records have conflicting template mappings for one quality profile",
 			);
 		}
+		const managedSnapshotsByProfile = new Map<
+			number,
+			{ captured: boolean; snapshot: string | null }
+		>();
+		for (const mapping of templateMappings) {
+			const existing = managedSnapshotsByProfile.get(mapping.qualityProfileId);
+			if (
+				existing &&
+				(existing.captured !== mapping.managedCustomFormatsCaptured ||
+					existing.snapshot !== mapping.managedCustomFormats)
+			) {
+				throw new Error(
+					"Equivalent ARR service records have conflicting managed Custom Format snapshots",
+				);
+			}
+			managedSnapshotsByProfile.set(mapping.qualityProfileId, {
+				captured: mapping.managedCustomFormatsCaptured,
+				snapshot: mapping.managedCustomFormats,
+			});
+		}
 		const templateMappingMap = new Map(
 			templateMappings.map((mapping) => [mapping.qualityProfileId, mapping.templateId]),
 		);
+		const managedTrashIdsByProfile = new Map<number, Map<number, string>>();
+		for (const mapping of templateMappings) {
+			if (!mapping.managedCustomFormatsCaptured) continue;
+			const byResourceId =
+				managedTrashIdsByProfile.get(mapping.qualityProfileId) ?? new Map<number, string>();
+			for (const managed of readPersistedManagedCustomFormatIdentities(mapping)) {
+				if (managed.profileId !== mapping.qualityProfileId) {
+					throw new Error(
+						"A managed Custom Format identity is bound to a different quality profile",
+					);
+				}
+				const existingTrashId = byResourceId.get(managed.resourceId);
+				if (existingTrashId && existingTrashId !== managed.trashId) {
+					throw new Error(
+						"Equivalent ARR service records have conflicting managed Custom Format identities",
+					);
+				}
+				byResourceId.set(managed.resourceId, managed.trashId);
+			}
+			managedTrashIdsByProfile.set(mapping.qualityProfileId, byResourceId);
+		}
 
 		// Fetch templates to get TRaSH default scores
 		const templateIds = [...new Set(templateMappings.map((m) => m.templateId))];
@@ -195,14 +239,13 @@ export class BulkScoreManager {
 					})
 				: [];
 
-		// Build a map of CF name → all available score set scores
-		// Key: CF name, Value: { trashId, scoreSetScores (all available scores by score set) }
+		// Build template-specific score metadata keyed by durable TRaSH identity.
+		// ARR names are display data and are not unique.
 		interface TrashScoreInfo {
-			trashId: string;
 			scoreSetScores: Record<string, number>; // scoreSet → score (e.g., "anime" → 100, "default" → 0)
 			fallbackScore: number; // score from originalConfig.score if no trash_scores
 		}
-		const trashScoreInfoMap = new Map<string, TrashScoreInfo>();
+		const trashScoreInfoByTemplate = new Map<string, Map<string, TrashScoreInfo>>();
 
 		// Build a map of templateId → scoreSet for looking up the correct default per profile
 		const templateScoreSetMap = new Map<string, string>();
@@ -212,6 +255,7 @@ export class BulkScoreManager {
 				const config = JSON.parse(template.configData) as TemplateConfig;
 				const scoreSet = config.qualityProfile?.trash_score_set || "default";
 				templateScoreSetMap.set(template.id, scoreSet);
+				const scoreInfoByTrashId = new Map<string, TrashScoreInfo>();
 
 				for (const cf of config.customFormats || []) {
 					// Get the original config which may have trash_scores
@@ -222,7 +266,7 @@ export class BulkScoreManager {
 						[key: string]: unknown;
 					};
 
-					if (!trashScoreInfoMap.has(cf.name)) {
+					if (!scoreInfoByTrashId.has(cf.trashId)) {
 						const scoreSetScores: Record<string, number> = {};
 						let fallbackScore = 0;
 
@@ -239,21 +283,28 @@ export class BulkScoreManager {
 							fallbackScore = Number(originalConfig.score);
 						}
 
-						trashScoreInfoMap.set(cf.name, {
-							trashId: cf.trashId,
+						scoreInfoByTrashId.set(cf.trashId, {
 							scoreSetScores,
 							fallbackScore,
 						});
 					}
 				}
+				trashScoreInfoByTemplate.set(template.id, scoreInfoByTrashId);
 			} catch (error) {
 				log.error({ err: error, templateId: template.id }, "Failed to parse template config");
 			}
 		}
 
 		// Helper function to calculate the correct default score for a CF given a score set
-		const getDefaultScoreForScoreSet = (cfName: string, scoreSet: string): number => {
-			const scoreInfo = trashScoreInfoMap.get(cfName);
+		const getDefaultScoreForScoreSet = (
+			profileId: number,
+			resourceId: number,
+			scoreSet: string,
+		): number => {
+			const templateId = templateMappingMap.get(profileId);
+			const trashId = managedTrashIdsByProfile.get(profileId)?.get(resourceId);
+			const scoreInfo =
+				templateId && trashId ? trashScoreInfoByTemplate.get(templateId)?.get(trashId) : undefined;
 			if (!scoreInfo) return 0;
 
 			// Priority: scoreSet score > default score > fallbackScore > 0
@@ -349,7 +400,11 @@ export class BulkScoreManager {
 						const profileScoreSet = templateId
 							? templateScoreSetMap.get(templateId) || "default"
 							: "default";
-						const trashDefaultScore = getDefaultScoreForScoreSet(cfName, profileScoreSet);
+						const trashDefaultScore = getDefaultScoreForScoreSet(
+							profileRef.profileId,
+							cf.id,
+							profileScoreSet,
+						);
 
 						const templateScore: TemplateScore = {
 							templateId: `${profileRef.instanceId}-${profileRef.profileId}`,

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -142,13 +142,29 @@ export class BulkScoreManager {
 				connectionGeneration: true,
 			},
 		});
-		const equivalentInstanceIds = new Set(getEquivalentServiceInstanceIds(aliases, instance));
+		const credentialIdentity = this.clientFactory.createConnectionCredentialIdentity(instance);
+		const equivalentInstanceIds = new Set(
+			getEquivalentServiceInstanceIds(
+				aliases.map((alias) => ({
+					...alias,
+					credentialIdentity: this.clientFactory.createConnectionCredentialIdentity(alias),
+				})),
+				{ ...instance, credentialIdentity },
+			),
+		);
 		equivalentInstanceIds.add(instance.id);
 		const connectionBindings = aliases
 			.filter((alias) => equivalentInstanceIds.has(alias.id))
-			.flatMap(createDeploymentConnectionBindingCandidates);
+			.flatMap((alias) =>
+				createDeploymentConnectionBindingCandidates(
+					alias,
+					this.clientFactory.createConnectionCredentialIdentity(alias),
+				),
+			);
 		if (!connectionBindings.some((binding) => binding.instanceId === instance.id)) {
-			connectionBindings.push(...createDeploymentConnectionBindingCandidates(instance));
+			connectionBindings.push(
+				...createDeploymentConnectionBindingCandidates(instance, credentialIdentity),
+			);
 		}
 
 		// Resolve management through every current alias for the physical ARR endpoint.
@@ -317,8 +333,8 @@ export class BulkScoreManager {
 			return scoreInfo.fallbackScore;
 		};
 
-		// Step 2: Collect all unique custom formats across all instances
-		// Key: CF name, Value: CustomFormatScoreEntry
+		// Step 2: Collect exact Custom Format resources from the selected instance.
+		// Names are display data and are not unique in ARR.
 		const cfMap = new Map<string, CustomFormatScoreEntry>();
 
 		for (const instance of instances) {
@@ -377,7 +393,7 @@ export class BulkScoreManager {
 				if (cf.id === undefined || !cf.name) continue;
 
 				const cfName = cf.name;
-				const cfKey = cfName;
+				const cfKey = String(cf.id);
 
 				// Get or create CF entry
 				let cfEntry = cfMap.get(cfKey);

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -22,6 +22,11 @@ import type { ArrClientFactory } from "../arr/client-factory.js";
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
+import {
+	assertNoLegacyDeploymentConnectionMappings,
+	createDeploymentConnectionBindingCandidates,
+	getEquivalentServiceInstanceIds,
+} from "./deployment-target.js";
 
 const log = loggers.trashGuides;
 
@@ -71,6 +76,7 @@ export class BulkScoreManager {
 				encryptionIv: true,
 				encryptedHttpAuthCredentials: true,
 				httpAuthEncryptionIv: true,
+				connectionGeneration: true,
 			},
 		});
 
@@ -122,16 +128,54 @@ export class BulkScoreManager {
 			}
 		}
 
-		// Fetch template mappings for all quality profiles in this instance
-		const templateMappings = await this.prisma.templateQualityProfileMapping.findMany({
-			where: {
-				instanceId: filters.instanceId,
-			},
+		const aliases = await this.prisma.serviceInstance.findMany({
+			where: { userId, service: instance.service },
 			select: {
-				qualityProfileId: true,
-				templateId: true,
+				id: true,
+				service: true,
+				baseUrl: true,
+				encryptedApiKey: true,
+				encryptionIv: true,
+				encryptedHttpAuthCredentials: true,
+				httpAuthEncryptionIv: true,
+				connectionGeneration: true,
 			},
 		});
+		const equivalentInstanceIds = new Set(getEquivalentServiceInstanceIds(aliases, instance));
+		equivalentInstanceIds.add(instance.id);
+		const connectionBindings = aliases
+			.filter((alias) => equivalentInstanceIds.has(alias.id))
+			.flatMap(createDeploymentConnectionBindingCandidates);
+		if (!connectionBindings.some((binding) => binding.instanceId === instance.id)) {
+			connectionBindings.push(...createDeploymentConnectionBindingCandidates(instance));
+		}
+
+		// Resolve management through every current alias for the physical ARR endpoint.
+		const templateMappings = await this.prisma.templateQualityProfileMapping.findMany({
+			where: {
+				OR: connectionBindings,
+				template: { userId },
+			},
+			select: {
+				instanceId: true,
+				qualityProfileId: true,
+				templateId: true,
+				connectionGeneration: true,
+				connectionStateToken: true,
+			},
+		});
+		assertNoLegacyDeploymentConnectionMappings(templateMappings);
+		const templateIdsByProfile = new Map<number, Set<string>>();
+		for (const mapping of templateMappings) {
+			const ids = templateIdsByProfile.get(mapping.qualityProfileId) ?? new Set<string>();
+			ids.add(mapping.templateId);
+			templateIdsByProfile.set(mapping.qualityProfileId, ids);
+		}
+		if ([...templateIdsByProfile.values()].some((templateIds) => templateIds.size > 1)) {
+			throw new Error(
+				"Equivalent ARR service records have conflicting template mappings for one quality profile",
+			);
+		}
 		const templateMappingMap = new Map(
 			templateMappings.map((mapping) => [mapping.qualityProfileId, mapping.templateId]),
 		);

--- a/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
+++ b/apps/api/src/lib/trash-guides/deployment-operation-gate.ts
@@ -1,5 +1,5 @@
 import type { PrismaClient } from "../prisma.js";
-import { AppValidationError } from "../errors.js";
+import { AppValidationError, ConflictError } from "../errors.js";
 import {
 	type DeploymentBackupState,
 	hasPendingDeploymentMutation,
@@ -224,7 +224,7 @@ export async function assertNoActiveDeploymentOwnership(
 	const seen = new Set<string>();
 	for (const row of [...syncRows, ...deploymentRows]) {
 		if (!row.backup) {
-			throw new AppValidationError(
+			throw new ConflictError(
 				"This ARR connection has active deployment ownership without verifiable rollback data. Resolve that history before changing the connection.",
 			);
 		}
@@ -234,7 +234,7 @@ export async function assertNoActiveDeploymentOwnership(
 		try {
 			state = parseDeploymentBackupState(row.backup.backupData);
 		} catch {
-			throw new AppValidationError(
+			throw new ConflictError(
 				"This ARR connection has active deployment ownership with legacy or invalid rollback data. Resolve that history before changing the connection.",
 			);
 		}
@@ -244,7 +244,7 @@ export async function assertNoActiveDeploymentOwnership(
 			(state.namingDeployment && state.namingDeployment.status !== "not_started") ||
 			state.managedCustomFormatsCaptured
 		) {
-			throw new AppValidationError(
+			throw new ConflictError(
 				"This ARR connection has active deployment ownership. Roll back or undeploy it before changing the connection.",
 			);
 		}

--- a/apps/api/src/lib/trash-guides/profile-matcher.ts
+++ b/apps/api/src/lib/trash-guides/profile-matcher.ts
@@ -14,6 +14,7 @@ import {
 	type TrashCustomFormatGroup,
 	type TrashQualityProfile,
 } from "@arr/shared";
+import { AppValidationError, ConflictError } from "../errors.js";
 import { findCutoffQualityName } from "../utils/quality-utils.js";
 import type { TrashCFWithScores } from "./template-score-utils.js";
 
@@ -225,45 +226,75 @@ export function buildCustomFormatsConfig(
 	cfLookup: Map<number, { id: number; name: string; specifications?: unknown[] }>,
 	trashCFLookup: Map<string, TrashCustomFormat>,
 	sourceInstanceId: string,
+	sourceProfileScores: ReadonlyMap<number, number>,
 ): TemplateConfig["customFormats"] {
 	const customFormatsConfig: TemplateConfig["customFormats"] = [];
+	const resolvedInstanceCFIds = new Set<number>();
 
 	for (const [cfKey, selection] of Object.entries(customFormatSelections)) {
 		if (!selection.selected) continue;
 
-		const trashCF = trashCFLookup.get(cfKey);
-
-		if (trashCF) {
-			// TRaSH-linked CF
-			customFormatsConfig.push({
-				trashId: cfKey,
-				name: trashCF.name,
-				scoreOverride: selection.scoreOverride,
-				conditionsEnabled: selection.conditionsEnabled || {},
-				originalConfig: trashCF,
-			});
-		} else if (cfKey.startsWith("instance-")) {
+		if (cfKey.startsWith("instance-")) {
 			// Instance-only CF (not linked to TRaSH)
-			const instanceCFId = Number.parseInt(cfKey.replace("instance-", ""), 10);
+			const match = /^instance-([1-9]\d*)$/.exec(cfKey);
+			if (!match) {
+				throw new AppValidationError(
+					`Invalid instance custom format key (${cfKey}). Refresh the cloned profile and try again.`,
+				);
+			}
+			const instanceCFId = Number(match[1]);
+			if (!Number.isSafeInteger(instanceCFId) || resolvedInstanceCFIds.has(instanceCFId)) {
+				throw new AppValidationError(
+					`Duplicate or invalid instance custom format key (${cfKey}). Refresh the cloned profile and try again.`,
+				);
+			}
+			resolvedInstanceCFIds.add(instanceCFId);
 			const instanceCF = cfLookup.get(instanceCFId);
 
-			if (instanceCF) {
-				customFormatsConfig.push({
-					trashId: cfKey,
-					name: instanceCF.name,
-					scoreOverride: selection.scoreOverride,
-					conditionsEnabled: selection.conditionsEnabled || {},
-					originalConfig: {
-						trash_id: cfKey,
-						name: instanceCF.name,
-						specifications: (instanceCF.specifications ?? []) as CustomFormatSpecification[],
-						_source: "instance",
-						_instanceId: sourceInstanceId,
-						_instanceCFId: instanceCFId,
-					},
-				});
+			if (!instanceCF) {
+				throw new ConflictError(
+					`The selected instance custom format (${cfKey}) no longer exists. Refresh the cloned profile and try again.`,
+				);
 			}
+
+			const sourceScore = sourceProfileScores.get(instanceCFId);
+			if (sourceScore === undefined) {
+				throw new ConflictError(
+					`Custom format "${instanceCF.name}" no longer has a score in the source quality profile. Refresh the cloned profile and try again.`,
+				);
+			}
+
+			customFormatsConfig.push({
+				trashId: cfKey,
+				name: instanceCF.name,
+				scoreOverride: selection.scoreOverride ?? sourceScore,
+				conditionsEnabled: selection.conditionsEnabled || {},
+				originalConfig: {
+					trash_id: cfKey,
+					name: instanceCF.name,
+					specifications: (instanceCF.specifications ?? []) as CustomFormatSpecification[],
+					_source: "instance",
+					_instanceId: sourceInstanceId,
+					_instanceCFId: instanceCFId,
+				},
+			});
+			continue;
 		}
+
+		const trashCF = trashCFLookup.get(cfKey);
+		if (!trashCF) {
+			throw new ConflictError(
+				`The selected TRaSH custom format (${cfKey}) no longer exists in the current cache. Refresh the cloned profile and try again.`,
+			);
+		}
+
+		customFormatsConfig.push({
+			trashId: cfKey,
+			name: trashCF.name,
+			scoreOverride: selection.scoreOverride,
+			conditionsEnabled: selection.conditionsEnabled || {},
+			originalConfig: trashCF,
+		});
 	}
 
 	return customFormatsConfig;

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -35,7 +35,12 @@ vi.mock("../../lib/services/connection-tester.js", () => ({
 	testServiceConnection: (...args: unknown[]) => mockTestConnection(...args),
 }));
 
-import { createDeploymentEndpointKey } from "../../lib/trash-guides/deployment-target.js";
+import {
+	createDeploymentConnectionBinding,
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+	isCurrentDeploymentConnectionMapping,
+} from "../../lib/trash-guides/deployment-target.js";
 import { registerServiceRoutes } from "../services.js";
 import {
 	createInjectAuthenticated,
@@ -60,12 +65,18 @@ const IV_V2 = "iv-v2";
  */
 function createPrismaStub() {
 	const instances = new Map<string, any>();
+	const mappings = new Map<string, any>();
+	const overrides = new Map<string, any>();
 	let nextId = 1;
 
 	const serviceInstance = {
 		findMany: vi.fn(async ({ where }: any) => {
 			return [...instances.values()]
-				.filter((row) => row.userId === where.userId)
+				.filter(
+					(row) =>
+						(!where.userId || row.userId === where.userId) &&
+						(!where.service || row.service === where.service),
+				)
 				.map((row) => ({ ...row, tags: [] }));
 		}),
 		findFirst: vi.fn(async ({ where }: any) => {
@@ -99,7 +110,18 @@ function createPrismaStub() {
 				if (where.userId && row.userId !== where.userId) continue;
 				if (where.NOT?.id && row.id === where.NOT.id) continue;
 				if (where.service && row.service !== where.service) continue;
-				Object.assign(row, data);
+				for (const [key, value] of Object.entries(data)) {
+					if (
+						value &&
+						typeof value === "object" &&
+						"increment" in value &&
+						typeof value.increment === "number"
+					) {
+						row[key] = (row[key] ?? 0) + value.increment;
+					} else {
+						row[key] = value;
+					}
+				}
 				count++;
 			}
 			return { count };
@@ -118,6 +140,8 @@ function createPrismaStub() {
 
 	const prisma = {
 		_instances: instances,
+		_mappings: mappings,
+		_overrides: overrides,
 		libraryCleanupConfig: {
 			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
 			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
@@ -136,10 +160,55 @@ function createPrismaStub() {
 		trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
 		templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
 		templateQualityProfileMapping: {
-			findMany: vi.fn().mockResolvedValue([]),
+			findMany: vi.fn(async ({ where }: any) =>
+				[...mappings.values()].filter((row) => {
+					if (where.instanceId?.in && !where.instanceId.in.includes(row.instanceId)) return false;
+					if (where.instanceId && typeof where.instanceId === "string") {
+						if (row.instanceId !== where.instanceId) return false;
+					}
+					if (where.template?.userId && row.template.userId !== where.template.userId) {
+						return false;
+					}
+					return true;
+				}),
+			),
+			updateMany: vi.fn(async ({ where, data }: any) => {
+				const row = mappings.get(where.id);
+				if (!row || row.instanceId !== where.instanceId) return { count: 0 };
+				Object.assign(row, data);
+				return { count: 1 };
+			}),
+			deleteMany: vi.fn(async ({ where }: any) => {
+				const row = mappings.get(where.id);
+				if (!row || row.instanceId !== where.instanceId) return { count: 0 };
+				mappings.delete(where.id);
+				return { count: 1 };
+			}),
 		},
 		instanceQualityProfileOverride: {
-			findMany: vi.fn().mockResolvedValue([]),
+			findMany: vi.fn(async ({ where }: any) =>
+				[...overrides.values()].filter((row) => {
+					if (where.instanceId?.in && !where.instanceId.in.includes(row.instanceId)) return false;
+					if (where.instanceId && typeof where.instanceId === "string") {
+						if (row.instanceId !== where.instanceId) return false;
+					}
+					if (where.userId && row.userId !== where.userId) return false;
+					if (where.status?.in && !where.status.in.includes(row.status)) return false;
+					return true;
+				}),
+			),
+			updateMany: vi.fn(async ({ where, data }: any) => {
+				const row = overrides.get(where.id);
+				if (!row || row.instanceId !== where.instanceId) return { count: 0 };
+				Object.assign(row, data);
+				return { count: 1 };
+			}),
+			deleteMany: vi.fn(async ({ where }: any) => {
+				const row = overrides.get(where.id);
+				if (!row || row.instanceId !== where.instanceId) return { count: 0 };
+				overrides.delete(where.id);
+				return { count: 1 };
+			}),
 		},
 	};
 	return Object.assign(prisma, {
@@ -154,17 +223,33 @@ function createPrismaStub() {
  * plaintexts, so we can tell whether a rotation actually persisted.
  */
 function createEncryptorStub() {
+	const encryptedValues = new Map<string, string>();
+	const encryptionCounts = new Map<string, number>();
 	return {
 		encrypt: vi.fn((plain: string) => {
-			if (plain === PLAINTEXT_KEY_V1) return { value: ENCRYPTED_V1, iv: IV_V1 };
-			if (plain === PLAINTEXT_KEY_V2) return { value: ENCRYPTED_V2, iv: IV_V2 };
-			return { value: `enc:${plain}`, iv: "iv" };
+			const count = (encryptionCounts.get(plain) ?? 0) + 1;
+			encryptionCounts.set(plain, count);
+			const encrypted =
+				plain === PLAINTEXT_KEY_V1
+					? {
+							value: count === 1 ? ENCRYPTED_V1 : `${ENCRYPTED_V1}-fresh-${count}`,
+							iv: count === 1 ? IV_V1 : `${IV_V1}-fresh-${count}`,
+						}
+					: plain === PLAINTEXT_KEY_V2
+						? {
+								value: count === 1 ? ENCRYPTED_V2 : `${ENCRYPTED_V2}-fresh-${count}`,
+								iv: count === 1 ? IV_V2 : `${IV_V2}-fresh-${count}`,
+							}
+						: {
+								value: count === 1 ? `enc:${plain}` : `enc:${count}:${plain}`,
+								iv: count === 1 ? "iv" : `iv-${count}`,
+							};
+			encryptedValues.set(`${encrypted.value}:${encrypted.iv}`, plain);
+			return encrypted;
 		}),
-		decrypt: vi.fn(({ value }: { value: string }) => {
-			if (value === ENCRYPTED_V1) return PLAINTEXT_KEY_V1;
-			if (value === ENCRYPTED_V2) return PLAINTEXT_KEY_V2;
-			return "unknown";
-		}),
+		decrypt: vi.fn(({ value, iv }: { value: string; iv: string }) =>
+			encryptedValues.get(`${value}:${iv}`),
+		),
 	};
 }
 
@@ -221,14 +306,19 @@ describe("Service instance lifecycle", () => {
 			notify: vi.fn().mockResolvedValue(undefined),
 		} as never);
 		app.decorate("arrClientFactory", {
-			createConnectionCredentialIdentity: vi.fn((instance: any) =>
-				JSON.stringify([
-					instance.encryptedApiKey,
-					instance.encryptionIv,
-					instance.encryptedHttpAuthCredentials ?? null,
-					instance.httpAuthEncryptionIv ?? null,
-				]),
-			),
+			createConnectionCredentialIdentity: vi.fn((instance: any) => {
+				const apiKey = encryptor.decrypt({
+					value: instance.encryptedApiKey,
+					iv: instance.encryptionIv,
+				});
+				const httpAuth = instance.encryptedHttpAuthCredentials
+					? encryptor.decrypt({
+							value: instance.encryptedHttpAuthCredentials,
+							iv: instance.httpAuthEncryptionIv,
+						})
+					: null;
+				return JSON.stringify({ apiKey, httpAuth });
+			}),
 		} as never);
 		app.decorate("deploymentExecutor", {
 			runWithEndpointMutation: vi.fn(async (lockedUserId, target, _operation, callback) =>
@@ -302,6 +392,118 @@ describe("Service instance lifecycle", () => {
 		expect(prisma._instances.get(id).encryptedHttpAuthCredentials).toBeNull();
 		expect(prisma._instances.get(id).httpAuthEncryptionIv).toBeNull();
 	});
+
+	it("keeps ARR ciphertext and saved bindings current when identical credentials are resubmitted", async () => {
+		const httpAuth = { username: "proxy-user", password: "proxy-pass" };
+		const create = await inject("POST", "/services", {
+			body: {
+				label: "Protected Sonarr",
+				baseUrl: "https://sonarr.example.test",
+				apiKey: PLAINTEXT_KEY_V1,
+				service: "sonarr",
+				httpAuth,
+			},
+		});
+		const id = JSON.parse(create.payload).service.id;
+		const storedBefore = { ...prisma._instances.get(id) };
+		const binding = createDeploymentConnectionBinding(storedBefore);
+		const mapping = {
+			id: "mapping-1",
+			templateId: "template-1",
+			instanceId: id,
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: binding.connectionGeneration,
+			connectionStateToken: binding.connectionStateToken,
+			template: { userId: USER_ID },
+			instance: { userId: USER_ID },
+		};
+		prisma._mappings.set(mapping.id, mapping);
+		for (const [index, status] of ["APPLIED", "PENDING", "UNCERTAIN"].entries()) {
+			prisma._overrides.set(`override-${status}`, {
+				id: `override-${status}`,
+				instanceId: id,
+				qualityProfileId: 4,
+				customFormatId: index + 1,
+				score: index,
+				status,
+				intentOperation: status === "APPLIED" ? null : "SET_SCORE",
+				intendedScore: status === "APPLIED" ? null : index,
+				userId: USER_ID,
+				connectionGeneration: binding.connectionGeneration,
+				connectionStateToken: binding.connectionStateToken,
+				instance: { userId: USER_ID },
+			});
+		}
+
+		const response = await inject("PUT", `/services/${id}`, {
+			body: { apiKey: PLAINTEXT_KEY_V1, httpAuth },
+		});
+
+		expect(response.statusCode).toBe(200);
+		const storedAfter = prisma._instances.get(id);
+		expect(storedAfter).toMatchObject({
+			encryptedApiKey: storedBefore.encryptedApiKey,
+			encryptionIv: storedBefore.encryptionIv,
+			encryptedHttpAuthCredentials: storedBefore.encryptedHttpAuthCredentials,
+			httpAuthEncryptionIv: storedBefore.httpAuthEncryptionIv,
+			connectionGeneration: 0,
+		});
+		expect(createDeploymentConnectionStateToken(storedAfter)).toBe(binding.connectionStateToken);
+		expect(prisma.instanceQualityProfileOverride.findMany).not.toHaveBeenCalled();
+
+		const currentBinding = createDeploymentConnectionBinding(storedAfter);
+		expect(isCurrentDeploymentConnectionMapping(mapping, [currentBinding])).toBe(true);
+		for (const status of ["APPLIED", "PENDING", "UNCERTAIN"]) {
+			const row = prisma._overrides.get(`override-${status}`);
+			expect(row.status).toBe(status);
+			expect(isCurrentDeploymentConnectionMapping(row, [currentBinding])).toBe(true);
+		}
+	});
+
+	it.each(["PENDING", "UNCERTAIN"])(
+		"blocks a real credential change while %s score intent is unresolved",
+		async (status) => {
+			const create = await inject("POST", "/services", {
+				body: {
+					label: "Sonarr",
+					baseUrl: "http://sonarr:8989",
+					apiKey: PLAINTEXT_KEY_V1,
+					service: "sonarr",
+				},
+			});
+			const id = JSON.parse(create.payload).service.id;
+			const storedBefore = { ...prisma._instances.get(id) };
+			const binding = createDeploymentConnectionBinding(storedBefore);
+			prisma._overrides.set("override-unresolved", {
+				id: "override-unresolved",
+				instanceId: id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 0,
+				status,
+				intentOperation: "SET_SCORE",
+				intendedScore: 5,
+				userId: USER_ID,
+				connectionGeneration: binding.connectionGeneration,
+				connectionStateToken: binding.connectionStateToken,
+				instance: { userId: USER_ID },
+			});
+
+			const response = await inject("PUT", `/services/${id}`, {
+				body: { apiKey: PLAINTEXT_KEY_V2 },
+			});
+
+			expect(response.statusCode).toBe(409);
+			expect(prisma._instances.get(id)).toMatchObject({
+				encryptedApiKey: storedBefore.encryptedApiKey,
+				encryptionIv: storedBefore.encryptionIv,
+				connectionGeneration: 0,
+			});
+			expect(prisma._overrides.get("override-unresolved").status).toBe(status);
+			expect(prisma.serviceInstance.updateMany).not.toHaveBeenCalled();
+		},
+	);
 
 	it("tests staged HTTP auth with the stored API key without persisting it", async () => {
 		const create = await inject("POST", "/services", {
@@ -441,6 +643,7 @@ describe("Service instance lifecycle", () => {
 		expect(storedAfterUpdate.label).toBe("Sonarr Renamed");
 		expect(storedAfterUpdate.encryptedApiKey).toBe(ENCRYPTED_V2);
 		expect(storedAfterUpdate.encryptionIv).toBe(IV_V2);
+		expect(storedAfterUpdate.connectionGeneration).toBe(1);
 		expect(encryptor.encrypt).toHaveBeenCalledWith(PLAINTEXT_KEY_V2);
 
 		// --- 6. DELETE --------------------------------------------------------
@@ -472,6 +675,75 @@ describe("Service instance lifecycle", () => {
 		// requireInstance must have short-circuited before the raw delete call.
 		expect(prisma.serviceInstance.delete).not.toHaveBeenCalled();
 	});
+
+	it.each(["mapping", "override"] as const)(
+		"fails closed before deleting an ARR alias with mismatched %s ownership",
+		async (stateKind) => {
+			const createSource = await inject("POST", "/services", {
+				body: {
+					label: "Sonarr source",
+					baseUrl: "http://sonarr:8989",
+					apiKey: PLAINTEXT_KEY_V1,
+					service: "sonarr",
+				},
+			});
+			const createSurvivor = await inject("POST", "/services", {
+				body: {
+					label: "Sonarr survivor",
+					baseUrl: "http://sonarr:8989/",
+					apiKey: PLAINTEXT_KEY_V1,
+					service: "sonarr",
+				},
+			});
+			const sourceId = JSON.parse(createSource.payload).service.id;
+			const survivorId = JSON.parse(createSurvivor.payload).service.id;
+			const source = prisma._instances.get(sourceId);
+			const binding = createDeploymentConnectionBinding(source);
+
+			if (stateKind === "mapping") {
+				prisma._mappings.set("mapping-mismatched-owner", {
+					id: "mapping-mismatched-owner",
+					templateId: "other-user-template",
+					instanceId: sourceId,
+					qualityProfileId: 4,
+					qualityProfileName: "Any",
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+					template: { userId: "user-2" },
+					instance: { userId: USER_ID },
+				});
+			} else {
+				prisma._overrides.set("override-mismatched-owner", {
+					id: "override-mismatched-owner",
+					instanceId: sourceId,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 5,
+					status: "APPLIED",
+					userId: "user-2",
+					connectionGeneration: binding.connectionGeneration,
+					connectionStateToken: binding.connectionStateToken,
+					instance: { userId: USER_ID },
+				});
+			}
+
+			const response = await inject("DELETE", `/services/${sourceId}`);
+
+			expect(response.statusCode).toBe(409);
+			expect(prisma._instances.has(sourceId)).toBe(true);
+			expect(prisma._instances.has(survivorId)).toBe(true);
+			if (stateKind === "mapping") {
+				expect(prisma._mappings.get("mapping-mismatched-owner")?.instanceId).toBe(sourceId);
+			} else {
+				expect(prisma._overrides.get("override-mismatched-owner")?.instanceId).toBe(sourceId);
+			}
+			expect(prisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+			expect(prisma.templateQualityProfileMapping.deleteMany).not.toHaveBeenCalled();
+			expect(prisma.instanceQualityProfileOverride.updateMany).not.toHaveBeenCalled();
+			expect(prisma.instanceQualityProfileOverride.deleteMany).not.toHaveBeenCalled();
+			expect(prisma.serviceInstance.delete).not.toHaveBeenCalled();
+		},
+	);
 
 	it("POST /services/:id/test against a non-existent instance returns 404 and never calls the tester", async () => {
 		const res = await inject("POST", "/services/inst-nope/test");

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -35,6 +35,7 @@ vi.mock("../../lib/services/connection-tester.js", () => ({
 	testServiceConnection: (...args: unknown[]) => mockTestConnection(...args),
 }));
 
+import { createDeploymentEndpointKey } from "../../lib/trash-guides/deployment-target.js";
 import { registerServiceRoutes } from "../services.js";
 import {
 	createInjectAuthenticated,
@@ -81,6 +82,7 @@ function createPrismaStub() {
 			const { tags: _tags, ...rest } = data;
 			const row = {
 				id,
+				connectionGeneration: 0,
 				createdAt: new Date("2026-04-13T00:00:00Z"),
 				updatedAt: new Date("2026-04-13T00:00:00Z"),
 				storageGroupId: null,
@@ -114,7 +116,7 @@ function createPrismaStub() {
 		}),
 	};
 
-	return {
+	const prisma = {
 		_instances: instances,
 		libraryCleanupConfig: {
 			upsert: vi.fn().mockResolvedValue({ id: "cleanup-config-1" }),
@@ -133,7 +135,18 @@ function createPrismaStub() {
 		},
 		trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
 		templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		templateQualityProfileMapping: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
+		instanceQualityProfileOverride: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
 	};
+	return Object.assign(prisma, {
+		$transaction: vi.fn(async (callback: (tx: typeof prisma) => Promise<unknown>) =>
+			callback(prisma),
+		),
+	});
 }
 
 /**
@@ -206,6 +219,21 @@ describe("Service instance lifecycle", () => {
 		app.decorate("encryptor", encryptor as any);
 		app.decorate("notificationService", {
 			notify: vi.fn().mockResolvedValue(undefined),
+		} as never);
+		app.decorate("arrClientFactory", {
+			createConnectionCredentialIdentity: vi.fn((instance: any) =>
+				JSON.stringify([
+					instance.encryptedApiKey,
+					instance.encryptionIv,
+					instance.encryptedHttpAuthCredentials ?? null,
+					instance.httpAuthEncryptionIv ?? null,
+				]),
+			),
+		} as never);
+		app.decorate("deploymentExecutor", {
+			runWithEndpointMutation: vi.fn(async (lockedUserId, target, _operation, callback) =>
+				callback(createDeploymentEndpointKey(lockedUserId, target)),
+			),
 		} as never);
 
 		setupAuthInjection(app, { id: USER_ID, username: "admin" });

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -322,7 +322,14 @@ describe("Service instance lifecycle", () => {
 		} as never);
 		app.decorate("deploymentExecutor", {
 			runWithEndpointMutation: vi.fn(async (lockedUserId, target, _operation, callback) =>
-				callback(createDeploymentEndpointKey(lockedUserId, target)),
+				callback(
+					createDeploymentEndpointKey(lockedUserId, {
+						...target,
+						credentialIdentity: (app as any).arrClientFactory.createConnectionCredentialIdentity(
+							target,
+						),
+					}),
+				),
 			),
 		} as never);
 

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -80,6 +80,8 @@ function createPrismaStub() {
 				.map((row) => ({ ...row, tags: [] }));
 		}),
 		findFirst: vi.fn(async ({ where }: any) => {
+			// This lifecycle fake has no durable TRaSH deployment relations.
+			if (where.OR) return null;
 			for (const row of instances.values()) {
 				if (where.id && row.id !== where.id) continue;
 				if (where.userId && row.userId !== where.userId) continue;

--- a/apps/api/src/routes/__tests__/services-qui-cleanup.test.ts
+++ b/apps/api/src/routes/__tests__/services-qui-cleanup.test.ts
@@ -130,6 +130,16 @@ function makeSonarrInstance(overrides: Record<string, unknown> = {}) {
 	});
 }
 
+function makeJellyfinInstance(overrides: Record<string, unknown> = {}) {
+	return makeQuiInstance({
+		id: "jellyfin-instance-1",
+		service: "JELLYFIN",
+		label: "My Jellyfin",
+		baseUrl: "http://jellyfin:8096",
+		...overrides,
+	});
+}
+
 function createMockPrisma() {
 	const prisma = {
 		libraryCleanupConfig: {
@@ -268,7 +278,7 @@ describe("DELETE /services/:id — qui-cache cleanup", () => {
 		// (extra Prisma lookup at delete time), we let the cache functions
 		// no-op when the id isn't a known key. The route stays uniform
 		// across service types; the cache functions handle the no-op.
-		mockRequireInstance.mockResolvedValue(makeSonarrInstance());
+		mockRequireInstance.mockResolvedValue(makeJellyfinInstance());
 		mockPrisma.serviceInstance.delete.mockResolvedValue(undefined);
 
 		const res = await injectAuthenticated("DELETE", "/services/sonarr-instance-1");

--- a/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
+++ b/apps/api/src/routes/__tests__/services-secret-leakage.test.ts
@@ -126,6 +126,9 @@ beforeEach(async () => {
 			delete: vi.fn(),
 		},
 		serviceInstanceTag: { findFirst: vi.fn().mockResolvedValue(null) },
+		instanceQualityProfileOverride: {
+			findMany: vi.fn().mockResolvedValue([]),
+		},
 	};
 
 	mockRequireInstance.mockResolvedValue(makeInstanceRow());
@@ -139,6 +142,16 @@ beforeEach(async () => {
 		decrypt: vi.fn().mockReturnValue(SECRET_KEY),
 	});
 	app.decorate("notificationService", { notify: vi.fn().mockResolvedValue(undefined) } as never);
+	app.decorate("arrClientFactory", {
+		createConnectionCredentialIdentity: vi.fn((instance: any) =>
+			JSON.stringify([
+				instance.encryptedApiKey,
+				instance.encryptionIv,
+				instance.encryptedHttpAuthCredentials ?? null,
+				instance.httpAuthEncryptionIv ?? null,
+			]),
+		),
+	});
 
 	setupAuthInjection(app);
 	registerTestErrorHandler(app);

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -101,6 +101,38 @@ function makeInstance(overrides: Record<string, unknown> = {}) {
 	};
 }
 
+function makeAppliedDeploymentBackup() {
+	return {
+		id: "backup-active",
+		backupData: JSON.stringify({
+			schemaVersion: 2,
+			endpointKey: "endpoint",
+			connectionStateToken: "connection",
+			customFormats: [],
+			customFormatDeployments: [
+				{
+					beforeFormat: null,
+					action: "created",
+					resourceId: 7,
+					name: "Created CF",
+					status: "applied",
+					postStateToken: "created-post",
+				},
+			],
+			managedCustomFormats: [],
+			managedCustomFormatsCaptured: true,
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "not_started",
+				action: "updated",
+				profileId: null,
+				postStateToken: null,
+			},
+			namingDeployment: null,
+		}),
+	};
+}
+
 // ---------------------------------------------------------------------------
 // Mock Prisma client
 // ---------------------------------------------------------------------------
@@ -507,6 +539,31 @@ describe("PUT /services/:id", () => {
 		expect(mockPrisma.serviceInstance.updateMany).not.toHaveBeenCalled();
 	});
 
+	it("blocks an ARR connection replacement while a deployment still owns upstream state", async () => {
+		const existing = makeInstance({
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+		});
+		mockRequireInstance.mockResolvedValue(existing);
+		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://replacement-radarr:7878" });
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([existing]);
+		mockPrisma.templateDeploymentHistory.findMany.mockResolvedValue([
+			{
+				status: "SUCCESS",
+				backupId: "backup-active",
+				backup: makeAppliedDeploymentBackup(),
+			},
+		]);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { baseUrl: "http://replacement-radarr:7878" },
+		});
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).message).toContain("active deployment ownership");
+		expect(mockPrisma.serviceInstance.updateMany).not.toHaveBeenCalled();
+	});
+
 	it("atomically clears Jellyfin cache state after a connection update", async () => {
 		const order: string[] = [];
 		mockRequireInstance.mockResolvedValue(
@@ -900,6 +957,129 @@ describe("DELETE /services/:id", () => {
 		expect(res.statusCode).toBe(204);
 		expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
 		expect(mockPrisma.instanceQualityProfileOverride.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("does not migrate saved ARR state to a distinct endpoint that reuses credentials", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr-a:7878",
+			connectionGeneration: 2,
+		});
+		const distinct = makeInstance({
+			id: "inst-2",
+			service: "RADARR",
+			baseUrl: "http://radarr-b:7878",
+			connectionGeneration: 5,
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, distinct]);
+		mockPrisma.templateQualityProfileMapping.findMany.mockResolvedValue([
+			{
+				id: "mapping-source",
+				instanceId: source.id,
+				templateId: "template-1",
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "notify",
+				managedCustomFormatsCaptured: false,
+				managedCustomFormats: null,
+				connectionGeneration: source.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(source),
+				template: { userId: "user-1" },
+				instance: { userId: "user-1" },
+			},
+		]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(409);
+		expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+		expect(mockPrisma.serviceInstance.delete).not.toHaveBeenCalled();
+	});
+
+	it("rejects alias deletion when duplicate mappings disagree about deployment authority", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "SONARR",
+			baseUrl: "http://sonarr:8989",
+			connectionGeneration: 2,
+		});
+		const survivor = makeInstance({
+			id: "inst-2",
+			service: "SONARR",
+			baseUrl: "http://sonarr:8989/",
+			connectionGeneration: 5,
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, survivor]);
+		mockPrisma.templateQualityProfileMapping.findMany.mockResolvedValue([
+			{
+				id: "mapping-source",
+				instanceId: source.id,
+				templateId: "template-1",
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "auto",
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: '[{"resourceId":7}]',
+				connectionGeneration: source.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(source),
+				template: { userId: "user-1" },
+				instance: { userId: "user-1" },
+			},
+			{
+				id: "mapping-survivor",
+				instanceId: survivor.id,
+				templateId: "template-1",
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "notify",
+				managedCustomFormatsCaptured: false,
+				managedCustomFormats: null,
+				connectionGeneration: survivor.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(survivor),
+				template: { userId: "user-1" },
+				instance: { userId: "user-1" },
+			},
+		]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).message).toContain("conflicting deployment authority");
+		expect(mockPrisma.templateQualityProfileMapping.deleteMany).not.toHaveBeenCalled();
+		expect(mockPrisma.serviceInstance.delete).not.toHaveBeenCalled();
+	});
+
+	it("keeps durable deployment history instead of cascading it during alias deletion", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+		});
+		const survivor = makeInstance({
+			id: "inst-2",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878/",
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, survivor]);
+		mockPrisma.serviceInstance.findFirst.mockResolvedValueOnce(source);
+		mockPrisma.templateDeploymentHistory.findMany.mockResolvedValue([
+			{
+				id: "deployment-1",
+				status: "SUCCESS",
+				rolledBack: false,
+				undeployStatus: null,
+			},
+		]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(409);
+		expect(JSON.parse(res.payload).message).toContain("deployment history");
+		expect(mockPrisma.serviceInstance.delete).not.toHaveBeenCalled();
 	});
 
 	it("never migrates ARR state to another user's equivalent alias", async () => {

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -139,6 +139,7 @@ function createMockPrisma() {
 		plexEpisodeCache: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 		tautulliCache: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 		cacheRefreshStatus: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+		instanceQualityProfileOverride: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 	};
 	return Object.assign(prisma, {
 		$transaction: vi.fn(async (callback: (tx: typeof prisma) => Promise<unknown>) =>
@@ -317,6 +318,31 @@ describe("PUT /services/:id", () => {
 
 		expect(res.statusCode).toBe(404);
 		expect(JSON.parse(res.payload).message).toContain("not found");
+	});
+
+	it("advances an ARR connection generation without erasing saved score intent", async () => {
+		mockRequireInstance.mockResolvedValue(
+			makeInstance({ service: "RADARR", baseUrl: "http://radarr-old:7878" }),
+		);
+		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://radarr-new:7878" });
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
+			makeInstance({
+				service: "RADARR",
+				baseUrl: "http://radarr-new:7878",
+				connectionGeneration: 1,
+			}),
+		);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { baseUrl: "http://radarr-new:7878" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const connectionUpdate = mockPrisma.serviceInstance.updateMany.mock.calls.find(
+			([args]) => args.where.id === "inst-1",
+		)?.[0];
+		expect(connectionUpdate?.data.connectionGeneration).toEqual({ increment: 1 });
+		expect(mockPrisma.instanceQualityProfileOverride.deleteMany).not.toHaveBeenCalled();
 	});
 
 	it("atomically clears Jellyfin cache state after a connection update", async () => {

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -454,27 +454,28 @@ describe("PUT /services/:id", () => {
 		).toBe(false);
 	});
 
-	it("blocks a real ARR connection change while an equivalent alias has unresolved intent", async () => {
+	it("blocks a real ARR credential change while an equivalent alias has unresolved intent", async () => {
 		const primary = makeInstance({
 			id: "inst-1",
 			service: "RADARR",
 			baseUrl: "http://radarr:7878",
+			encryptedApiKey: "old-encrypted-key",
 		});
 		const alias = makeInstance({
 			id: "inst-alias",
 			service: "RADARR",
 			baseUrl: "http://radarr:7878/",
+			encryptedApiKey: "old-encrypted-key",
 		});
 		mockRequireInstance.mockResolvedValue(primary);
-		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://radarr-new:7878" });
-		mockPrisma.serviceInstance.findMany.mockResolvedValue([primary, alias]);
-		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
-			makeInstance({
-				id: "inst-1",
-				service: "RADARR",
-				baseUrl: "http://radarr-new:7878",
-			}),
+		mockBuildUpdateData.mockReturnValue({
+			encryptedApiKey: "new-encrypted-key",
+			encryptionIv: "new-iv",
+		});
+		vi.mocked((app as any).arrClientFactory.createConnectionCredentialIdentity).mockImplementation(
+			(candidate: { encryptedApiKey: string }) => candidate.encryptedApiKey,
 		);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([primary, alias]);
 		mockPrisma.instanceQualityProfileOverride.findMany.mockResolvedValue([
 			{
 				id: "pending-alias-intent",
@@ -487,7 +488,7 @@ describe("PUT /services/:id", () => {
 		]);
 
 		const res = await injectAuthenticated("PUT", "/services/inst-1", {
-			body: { baseUrl: "http://radarr-new:7878" },
+			body: { apiKey: "different-api-key" },
 		});
 
 		expect(res.statusCode).toBe(409);
@@ -762,6 +763,8 @@ describe("DELETE /services/:id", () => {
 				qualityProfileName: "Any",
 				connectionGeneration: source.connectionGeneration,
 				connectionStateToken: createDeploymentConnectionStateToken(source),
+				template: { userId: "user-1" },
+				instance: { userId: "user-1" },
 			},
 		]);
 		mockPrisma.instanceQualityProfileOverride.findMany.mockResolvedValue([
@@ -772,8 +775,10 @@ describe("DELETE /services/:id", () => {
 				customFormatId: 7,
 				score: -10_000,
 				status: "APPLIED",
+				userId: "user-1",
 				connectionGeneration: source.connectionGeneration,
 				connectionStateToken: createDeploymentConnectionStateToken(source),
+				instance: { userId: "user-1" },
 			},
 		]);
 
@@ -827,6 +832,8 @@ describe("DELETE /services/:id", () => {
 					qualityProfileId: 4,
 					customFormatId: 7,
 					status,
+					userId: "user-1",
+					instance: { userId: "user-1" },
 				},
 			]);
 
@@ -857,6 +864,8 @@ describe("DELETE /services/:id", () => {
 				qualityProfileName: "Any",
 				connectionGeneration: source.connectionGeneration,
 				connectionStateToken: createDeploymentConnectionStateToken(source),
+				template: { userId: "user-1" },
+				instance: { userId: "user-1" },
 			},
 		]);
 

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -191,7 +191,12 @@ beforeEach(async () => {
 	});
 	app.decorate("deploymentExecutor", {
 		runWithEndpointMutation: vi.fn(async (lockedUserId, target, _operation, callback) =>
-			callback(createDeploymentEndpointKey(lockedUserId, target)),
+			callback(
+				createDeploymentEndpointKey(lockedUserId, {
+					...target,
+					credentialIdentity: "credential-identity",
+				}),
+			),
 		),
 	});
 

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -64,6 +64,10 @@ vi.mock("../../lib/services/service-formatter.js", () => ({
 import Fastify from "fastify";
 import { InstanceNotFoundError } from "../../lib/errors.js";
 import { acquireCleanupOperationGuard } from "../../lib/library-cleanup/cleanup-maintenance-gate.js";
+import {
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+} from "../../lib/trash-guides/deployment-target.js";
 import { registerServiceRoutes } from "../services.js";
 import {
 	createInjectAuthenticated,
@@ -120,6 +124,11 @@ function createMockPrisma() {
 			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 			delete: vi.fn().mockResolvedValue(undefined),
 		},
+		templateQualityProfileMapping: {
+			findMany: vi.fn().mockResolvedValue([]),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+		},
 		serviceTag: {
 			findMany: vi.fn().mockResolvedValue([]),
 			upsert: vi.fn().mockImplementation(({ create }: any) => ({
@@ -139,7 +148,11 @@ function createMockPrisma() {
 		plexEpisodeCache: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 		tautulliCache: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
 		cacheRefreshStatus: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
-		instanceQualityProfileOverride: { deleteMany: vi.fn().mockResolvedValue({ count: 0 }) },
+		instanceQualityProfileOverride: {
+			findMany: vi.fn().mockResolvedValue([]),
+			updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+		},
 	};
 	return Object.assign(prisma, {
 		$transaction: vi.fn(async (callback: (tx: typeof prisma) => Promise<unknown>) =>
@@ -172,6 +185,14 @@ beforeEach(async () => {
 	app.decorate("encryptor", createMockEncryptor("decrypted-api-key"));
 	app.decorate("notificationService", {
 		notify: vi.fn().mockResolvedValue(undefined),
+	});
+	app.decorate("arrClientFactory", {
+		createConnectionCredentialIdentity: vi.fn().mockReturnValue("credential-identity"),
+	});
+	app.decorate("deploymentExecutor", {
+		runWithEndpointMutation: vi.fn(async (lockedUserId, target, _operation, callback) =>
+			callback(createDeploymentEndpointKey(lockedUserId, target)),
+		),
 	});
 
 	setupAuthInjection(app);
@@ -345,6 +366,141 @@ describe("PUT /services/:id", () => {
 		expect(mockPrisma.instanceQualityProfileOverride.deleteMany).not.toHaveBeenCalled();
 	});
 
+	it("does not advance ARR generation for a normalized equivalent URL", async () => {
+		mockRequireInstance.mockResolvedValue(
+			makeInstance({ service: "RADARR", baseUrl: "http://radarr:7878" }),
+		);
+		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://radarr:7878/" });
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
+			makeInstance({ service: "RADARR", baseUrl: "http://radarr:7878/" }),
+		);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { baseUrl: "http://radarr:7878/" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(
+			mockPrisma.serviceInstance.updateMany.mock.calls.some(
+				([args]) => args.data.connectionGeneration !== undefined,
+			),
+		).toBe(false);
+	});
+
+	it("does not advance ARR generation when credentials resolve to the same identity", async () => {
+		mockRequireInstance.mockResolvedValue(makeInstance({ service: "SONARR" }));
+		mockBuildUpdateData.mockReturnValue({
+			encryptedApiKey: "re-encrypted-same-key",
+			encryptionIv: "new-iv",
+		});
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(makeInstance({ service: "SONARR" }));
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { apiKey: "same-api-key" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(
+			mockPrisma.serviceInstance.updateMany.mock.calls.some(
+				([args]) => args.data.connectionGeneration !== undefined,
+			),
+		).toBe(false);
+	});
+
+	it("advances ARR generation when credential identity changes", async () => {
+		mockRequireInstance.mockResolvedValue(
+			makeInstance({ service: "SONARR", encryptedApiKey: "old-encrypted-key" }),
+		);
+		mockBuildUpdateData.mockReturnValue({
+			encryptedApiKey: "new-encrypted-key",
+			encryptionIv: "new-iv",
+		});
+		vi.mocked((app as any).arrClientFactory.createConnectionCredentialIdentity).mockImplementation(
+			(candidate: { encryptedApiKey: string }) => candidate.encryptedApiKey,
+		);
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
+			makeInstance({ service: "SONARR", encryptedApiKey: "new-encrypted-key" }),
+		);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { apiKey: "different-api-key" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		const connectionUpdate = mockPrisma.serviceInstance.updateMany.mock.calls.find(
+			([args]) => args.where.id === "inst-1",
+		)?.[0];
+		expect(connectionUpdate?.data.connectionGeneration).toEqual({ increment: 1 });
+	});
+
+	it("does not advance generation for a non-ARR connection update", async () => {
+		mockRequireInstance.mockResolvedValue(
+			makeInstance({ service: "JELLYFIN", baseUrl: "http://jellyfin-old:8096" }),
+		);
+		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://jellyfin-new:8096" });
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
+			makeInstance({ service: "JELLYFIN", baseUrl: "http://jellyfin-new:8096" }),
+		);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { baseUrl: "http://jellyfin-new:8096" },
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(
+			mockPrisma.serviceInstance.updateMany.mock.calls.some(
+				([args]) => args.data.connectionGeneration !== undefined,
+			),
+		).toBe(false);
+	});
+
+	it("blocks a real ARR connection change while an equivalent alias has unresolved intent", async () => {
+		const primary = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+		});
+		const alias = makeInstance({
+			id: "inst-alias",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878/",
+		});
+		mockRequireInstance.mockResolvedValue(primary);
+		mockBuildUpdateData.mockReturnValue({ baseUrl: "http://radarr-new:7878" });
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([primary, alias]);
+		mockPrisma.serviceInstance.findFirst.mockResolvedValue(
+			makeInstance({
+				id: "inst-1",
+				service: "RADARR",
+				baseUrl: "http://radarr-new:7878",
+			}),
+		);
+		mockPrisma.instanceQualityProfileOverride.findMany.mockResolvedValue([
+			{
+				id: "pending-alias-intent",
+				userId: "user-1",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				status: "PENDING",
+			},
+		]);
+
+		const res = await injectAuthenticated("PUT", "/services/inst-1", {
+			body: { baseUrl: "http://radarr-new:7878" },
+		});
+
+		expect(res.statusCode).toBe(409);
+		expect(mockPrisma.instanceQualityProfileOverride.findMany).toHaveBeenCalledWith({
+			where: {
+				userId: "user-1",
+				instanceId: { in: expect.arrayContaining(["inst-1", "inst-alias"]) },
+				status: { in: ["PENDING", "UNCERTAIN"] },
+			},
+		});
+		expect(mockPrisma.serviceInstance.updateMany).not.toHaveBeenCalled();
+	});
+
 	it("atomically clears Jellyfin cache state after a connection update", async () => {
 		const order: string[] = [];
 		mockRequireInstance.mockResolvedValue(
@@ -381,7 +537,7 @@ describe("PUT /services/:id", () => {
 		const connectionUpdate = mockPrisma.serviceInstance.updateMany.mock.calls.find(
 			([args]) => args.where.id === "inst-1",
 		)?.[0];
-		expect(connectionUpdate?.data.connectionGeneration).toEqual({ increment: 1 });
+		expect(connectionUpdate?.data.connectionGeneration).toBeUndefined();
 		expect(mockPrisma.cacheRefreshStatus.deleteMany).toHaveBeenCalledWith({
 			where: { instanceId: "inst-1" },
 		});
@@ -467,7 +623,7 @@ describe("PUT /services/:id", () => {
 		["PLEX", "http://plex-old:32400", "http://plex-new:32400"],
 		["TAUTULLI", "http://tautulli-old:8181", "http://tautulli-new:8181"],
 	] as const)(
-		"advances the %s connection generation and clears every provider cache on URL replacement",
+		"keeps %s generation unchanged and clears every provider cache on URL replacement",
 		async (service, oldUrl, newUrl) => {
 			mockRequireInstance.mockResolvedValue(makeInstance({ service, baseUrl: oldUrl }));
 			mockBuildUpdateData.mockReturnValue({ baseUrl: newUrl });
@@ -483,7 +639,7 @@ describe("PUT /services/:id", () => {
 			const connectionUpdate = mockPrisma.serviceInstance.updateMany.mock.calls.find(
 				([args]) => args.where.id === "inst-1",
 			)?.[0];
-			expect(connectionUpdate?.data.connectionGeneration).toEqual({ increment: 1 });
+			expect(connectionUpdate?.data.connectionGeneration).toBeUndefined();
 			expect(mockPrisma.plexCache.deleteMany).toHaveBeenCalledWith({
 				where: { instanceId: "inst-1" },
 			});
@@ -523,6 +679,7 @@ describe("PUT /services/:id", () => {
 
 describe("DELETE /services/:id", () => {
 	it("deletes owned instance and returns 204", async () => {
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([makeInstance()]);
 		const res = await injectAuthenticated("DELETE", "/services/inst-1");
 
 		expect(res.statusCode).toBe(204);
@@ -579,6 +736,181 @@ describe("DELETE /services/:id", () => {
 		} finally {
 			releaseMutation();
 		}
+	});
+
+	it("migrates current mappings and applied overrides to one exact surviving ARR alias", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+			connectionGeneration: 2,
+		});
+		const survivor = makeInstance({
+			id: "inst-2",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878/",
+			connectionGeneration: 5,
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, survivor]);
+		mockPrisma.templateQualityProfileMapping.findMany.mockResolvedValue([
+			{
+				id: "mapping-source",
+				instanceId: source.id,
+				templateId: "template-1",
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				connectionGeneration: source.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(source),
+			},
+		]);
+		mockPrisma.instanceQualityProfileOverride.findMany.mockResolvedValue([
+			{
+				id: "override-source",
+				instanceId: source.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "APPLIED",
+				connectionGeneration: source.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(source),
+			},
+		]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(204);
+		expect(mockPrisma.templateQualityProfileMapping.updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ id: "mapping-source", instanceId: "inst-1" }),
+				data: expect.objectContaining({
+					instanceId: "inst-2",
+					connectionGeneration: 5,
+					connectionStateToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+				}),
+			}),
+		);
+		expect(mockPrisma.instanceQualityProfileOverride.updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ id: "override-source", instanceId: "inst-1" }),
+				data: expect.objectContaining({
+					instanceId: "inst-2",
+					connectionGeneration: 5,
+					connectionStateToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+				}),
+			}),
+		);
+		expect(mockPrisma.serviceInstance.delete).toHaveBeenCalledWith({
+			where: { id: "inst-1", userId: "user-1" },
+		});
+	});
+
+	it.each(["PENDING", "UNCERTAIN"])(
+		"blocks ARR alias deletion while %s score intent exists",
+		async (status) => {
+			const source = makeInstance({
+				id: "inst-1",
+				service: "SONARR",
+				baseUrl: "http://sonarr:8989",
+			});
+			const survivor = makeInstance({
+				id: "inst-2",
+				service: "SONARR",
+				baseUrl: "http://sonarr:8989/",
+			});
+			mockRequireInstance.mockResolvedValue(source);
+			mockPrisma.serviceInstance.findMany.mockResolvedValue([source, survivor]);
+			mockPrisma.instanceQualityProfileOverride.findMany.mockResolvedValue([
+				{
+					id: "intent-1",
+					instanceId: source.id,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					status,
+				},
+			]);
+
+			const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+			expect(res.statusCode).toBe(409);
+			expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+			expect(mockPrisma.instanceQualityProfileOverride.updateMany).not.toHaveBeenCalled();
+			expect(mockPrisma.serviceInstance.delete).not.toHaveBeenCalled();
+		},
+	);
+
+	it("blocks ARR alias deletion when saved state has no exact surviving alias", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+			connectionGeneration: 2,
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source]);
+		mockPrisma.templateQualityProfileMapping.findMany.mockResolvedValue([
+			{
+				id: "mapping-source",
+				instanceId: source.id,
+				templateId: "template-1",
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				connectionGeneration: source.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(source),
+			},
+		]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(409);
+		expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+		expect(mockPrisma.serviceInstance.delete).not.toHaveBeenCalled();
+	});
+
+	it("does not migrate ARR state to a distinct endpoint", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr-a:7878",
+		});
+		const distinct = makeInstance({
+			id: "inst-2",
+			service: "RADARR",
+			baseUrl: "http://radarr-b:7878",
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, distinct]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(204);
+		expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+		expect(mockPrisma.instanceQualityProfileOverride.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("never migrates ARR state to another user's equivalent alias", async () => {
+		const source = makeInstance({
+			id: "inst-1",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878",
+		});
+		const otherUserAlias = makeInstance({
+			id: "other-inst",
+			userId: "user-2",
+			service: "RADARR",
+			baseUrl: "http://radarr:7878/",
+		});
+		mockRequireInstance.mockResolvedValue(source);
+		mockPrisma.serviceInstance.findMany.mockResolvedValue([source, otherUserAlias]);
+
+		const res = await injectAuthenticated("DELETE", "/services/inst-1");
+
+		expect(res.statusCode).toBe(204);
+		expect(mockPrisma.serviceInstance.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ where: { userId: "user-1", service: "RADARR" } }),
+		);
+		expect(mockPrisma.templateQualityProfileMapping.updateMany).not.toHaveBeenCalled();
+		expect(mockPrisma.instanceQualityProfileOverride.updateMany).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -221,15 +221,29 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 					const endpointInstanceIds = endpointAliases.map((alias) => alias.id);
 					const [mappings, overrides] = await Promise.all([
 						tx.templateQualityProfileMapping.findMany({
-							where: {
-								instanceId: { in: endpointInstanceIds },
-								template: { userId },
+							where: { instanceId: { in: endpointInstanceIds } },
+							include: {
+								template: { select: { userId: true } },
+								instance: { select: { userId: true } },
 							},
 						}),
 						tx.instanceQualityProfileOverride.findMany({
-							where: { userId, instanceId: { in: endpointInstanceIds } },
+							where: { instanceId: { in: endpointInstanceIds } },
+							include: { instance: { select: { userId: true } } },
 						}),
 					]);
+					if (
+						mappings.some(
+							(mapping) => mapping.template.userId !== userId || mapping.instance.userId !== userId,
+						) ||
+						overrides.some(
+							(override) => override.userId !== userId || override.instance.userId !== userId,
+						)
+					) {
+						throw new ConflictError(
+							"Saved ARR profile state has inconsistent ownership and cannot be migrated or deleted.",
+						);
+					}
 					if (overrides.some((override) => override.status !== "APPLIED")) {
 						throw new ConflictError(
 							"This ARR endpoint has unresolved score intent. Reconcile it before deleting an alias.",
@@ -523,19 +537,33 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 					...updateData,
 					service: targetService,
 				};
+				const arrConnectionInvolved = isArrService(existing.service) || isArrService(targetService);
+				const arrCredentialFieldsSubmitted =
+					payload.apiKey !== undefined || payload.httpAuth !== undefined;
+				const arrCredentialsChanged =
+					arrConnectionInvolved &&
+					arrCredentialFieldsSubmitted &&
+					app.arrClientFactory.createConnectionCredentialIdentity(existing) !==
+						app.arrClientFactory.createConnectionCredentialIdentity(targetConnection);
+				if (arrConnectionInvolved && arrCredentialFieldsSubmitted && !arrCredentialsChanged) {
+					if (payload.apiKey !== undefined) {
+						delete updateData.encryptedApiKey;
+						delete updateData.encryptionIv;
+					}
+					if (payload.httpAuth !== undefined) {
+						delete updateData.encryptedHttpAuthCredentials;
+						delete updateData.httpAuthEncryptionIv;
+					}
+				}
 				const arrConnectionFieldsSubmitted =
-					serviceTypeChanged ||
-					payload.baseUrl !== undefined ||
-					payload.apiKey !== undefined ||
-					payload.httpAuth !== undefined;
+					serviceTypeChanged || payload.baseUrl !== undefined || arrCredentialFieldsSubmitted;
 				const arrConnectionChanged =
-					(isArrService(existing.service) || isArrService(targetService)) &&
+					arrConnectionInvolved &&
 					arrConnectionFieldsSubmitted &&
 					(serviceTypeChanged ||
 						normalizeDeploymentBaseUrl(existing.baseUrl) !==
 							normalizeDeploymentBaseUrl(targetConnection.baseUrl) ||
-						app.arrClientFactory.createConnectionCredentialIdentity(existing) !==
-							app.arrClientFactory.createConnectionCredentialIdentity(targetConnection));
+						arrCredentialsChanged);
 				if (arrConnectionChanged && isArrService(existing.service)) {
 					const aliases = await app.prisma.serviceInstance.findMany({
 						where: { userId, service: existing.service },

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -25,10 +25,13 @@ import { formatServiceInstance } from "../lib/services/service-formatter.js";
 import { updateInstanceTags, upsertTags } from "../lib/services/tag-manager.js";
 import { buildUpdateData } from "../lib/services/update-builder.js";
 import { assertNoActiveTrashRecoveryForInstance } from "../lib/trash-guides/recovery-evidence.js";
+import { assertNoActiveDeploymentOwnership } from "../lib/trash-guides/deployment-operation-gate.js";
 import {
+	assertEquivalentDeploymentMappingAuthority,
 	createDeploymentConnectionBinding,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
+	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
 	normalizeDeploymentBaseUrl,
 } from "../lib/trash-guides/deployment-target.js";
@@ -211,19 +214,42 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 					const aliases = await tx.serviceInstance.findMany({
 						where: { userId, service: current.service },
 					});
-					const endpointAliases = aliases.filter(
-						(alias) =>
-							alias.userId === userId &&
-							alias.service === current.service &&
-							app.arrClientFactory.createConnectionCredentialIdentity(alias) ===
-								currentCredentialIdentity,
-					);
+					const aliasesWithIdentity = aliases.map((alias) => ({
+						...alias,
+						credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(alias),
+					}));
+					const endpointInstanceIds = getEquivalentServiceInstanceIds(aliasesWithIdentity, {
+						...current,
+						credentialIdentity: currentCredentialIdentity,
+					});
+					const endpointAliases = aliases.filter((alias) => endpointInstanceIds.includes(alias.id));
 					if (!endpointAliases.some((alias) => alias.id === current.id)) {
 						throw new ConflictError(
 							"The ARR alias topology changed before deletion could be authorized.",
 						);
 					}
-					const endpointInstanceIds = endpointAliases.map((alias) => alias.id);
+					const durableDeploymentState = await tx.serviceInstance.findFirst({
+						where: {
+							id: current.id,
+							userId,
+							OR: [
+								{ trashSyncHistory: { some: {} } },
+								{ trashBackups: { some: {} } },
+								{ trashSchedules: { some: {} } },
+								{ deploymentHistory: { some: {} } },
+								{ standaloneCFDeployments: { some: {} } },
+								{ qualitySizeMapping: { isNot: null } },
+								{ namingConfig: { isNot: null } },
+								{ namingDeployHistory: { some: {} } },
+							],
+						},
+						select: { id: true },
+					});
+					if (durableDeploymentState) {
+						throw new ConflictError(
+							"This ARR alias has deployment history or managed configuration that would be lost by deletion. Remove or migrate that state before deleting the service.",
+						);
+					}
 					const [mappings, overrides] = await Promise.all([
 						tx.templateQualityProfileMapping.findMany({
 							where: { instanceId: { in: endpointInstanceIds } },
@@ -260,12 +286,7 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 						(override) => override.instanceId === current.id,
 					);
 					const hasMigratableState = sourceMappings.length > 0 || sourceOverrides.length > 0;
-					const exactSurvivors = endpointAliases.filter(
-						(alias) =>
-							alias.id !== current.id &&
-							app.arrClientFactory.createConnectionCredentialIdentity(alias) ===
-								currentCredentialIdentity,
-					);
+					const exactSurvivors = endpointAliases.filter((alias) => alias.id !== current.id);
 					if (hasMigratableState && exactSurvivors.length !== 1) {
 						throw new ConflictError(
 							"Saved profile state cannot be migrated because no single exact surviving ARR alias exists.",
@@ -319,14 +340,12 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 								(candidate) => candidate.qualityProfileId === mapping.qualityProfileId,
 							);
 							if (target) {
-								if (
-									target.templateId !== mapping.templateId ||
-									target.qualityProfileName !== mapping.qualityProfileName
-								) {
+								if (target.templateId !== mapping.templateId) {
 									throw new ConflictError(
 										"Equivalent ARR aliases have conflicting template mappings.",
 									);
 								}
+								assertEquivalentDeploymentMappingAuthority([mapping, target]);
 								const deleted = await tx.templateQualityProfileMapping.deleteMany({
 									where: {
 										id: mapping.id,
@@ -600,6 +619,7 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 							"This ARR endpoint has unresolved score intent. Reconcile it before changing the connection.",
 						);
 					}
+					await assertNoActiveDeploymentOwnership(app.prisma, userId, equivalentInstanceIds);
 				}
 				const serviceUpdateData = arrConnectionChanged
 					? {

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -82,6 +82,16 @@ const QUI_TOPOLOGY_UPDATE_FIELDS = [
 ] as const;
 const CACHE_PROVIDER_SERVICES = new Set<ServiceType>(["PLEX", "TAUTULLI", "JELLYFIN", "EMBY"]);
 
+function changesServiceConnection(
+	existing: Pick<ServiceInstance, "service" | "baseUrl">,
+	payload: z.infer<typeof serviceUpdateSchema>,
+): boolean {
+	const targetService = (payload.service ?? existing.service.toLowerCase()).toUpperCase();
+	if (payload.service !== undefined && targetService !== existing.service) return true;
+	if (payload.baseUrl !== undefined && payload.baseUrl !== existing.baseUrl) return true;
+	return Object.hasOwn(payload, "apiKey") || Object.hasOwn(payload, "httpAuth");
+}
+
 function changesQuiTopology(
 	existingService: ServiceType,
 	payload: z.infer<typeof serviceUpdateSchema>,
@@ -301,13 +311,15 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 
 				const quiTopologyChanged = changesQuiTopology(existing.service, payload);
 				const providerConnectionChanged = changesCacheProviderConnection(existing, payload);
+				const serviceConnectionChanged = changesServiceConnection(existing, payload);
 				const serviceTypeChanged = targetService !== existing.service;
-				const serviceUpdateData = providerConnectionChanged
-					? {
-							...updateData,
-							connectionGeneration: { increment: 1 },
-						}
-					: updateData;
+				const serviceUpdateData =
+					providerConnectionChanged || serviceConnectionChanged
+						? {
+								...updateData,
+								connectionGeneration: { increment: 1 },
+							}
+						: updateData;
 				if (quiTopologyChanged) {
 					await withQuiObservationTopologyGuard(userId, async () => {
 						await app.prisma.$transaction(async (tx) => {

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -192,8 +192,13 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 			"ARR service alias deletion",
 			async (endpointKey) => {
 				const current = await requireInstance(app, userId, existing.id);
+				const currentCredentialIdentity =
+					app.arrClientFactory.createConnectionCredentialIdentity(current);
 				if (
-					createDeploymentEndpointKey(userId, current) !== endpointKey ||
+					createDeploymentEndpointKey(userId, {
+						...current,
+						credentialIdentity: currentCredentialIdentity,
+					}) !== endpointKey ||
 					createDeploymentConnectionStateToken(current) !==
 						createDeploymentConnectionStateToken(existing)
 				) {
@@ -206,12 +211,12 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 					const aliases = await tx.serviceInstance.findMany({
 						where: { userId, service: current.service },
 					});
-					const normalizedBaseUrl = normalizeDeploymentBaseUrl(current.baseUrl);
 					const endpointAliases = aliases.filter(
 						(alias) =>
 							alias.userId === userId &&
 							alias.service === current.service &&
-							normalizeDeploymentBaseUrl(alias.baseUrl) === normalizedBaseUrl,
+							app.arrClientFactory.createConnectionCredentialIdentity(alias) ===
+								currentCredentialIdentity,
 					);
 					if (!endpointAliases.some((alias) => alias.id === current.id)) {
 						throw new ConflictError(
@@ -255,8 +260,6 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 						(override) => override.instanceId === current.id,
 					);
 					const hasMigratableState = sourceMappings.length > 0 || sourceOverrides.length > 0;
-					const currentCredentialIdentity =
-						app.arrClientFactory.createConnectionCredentialIdentity(current);
 					const exactSurvivors = endpointAliases.filter(
 						(alias) =>
 							alias.id !== current.id &&
@@ -271,8 +274,15 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 
 					const survivor = exactSurvivors[0];
 					if (survivor && hasMigratableState) {
-						const sourceBindings = [createDeploymentConnectionBinding(current)];
-						const survivorBindings = [createDeploymentConnectionBinding(survivor)];
+						const sourceBindings = [
+							createDeploymentConnectionBinding(current, currentCredentialIdentity),
+						];
+						const survivorBindings = [
+							createDeploymentConnectionBinding(
+								survivor,
+								app.arrClientFactory.createConnectionCredentialIdentity(survivor),
+							),
+						];
 						if (
 							sourceMappings.some(
 								(mapping) => !isCurrentDeploymentConnectionMapping(mapping, sourceBindings),

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -2,6 +2,7 @@ import { ALL_SERVICES, arrServiceTypeSchema } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { requireInstance } from "../lib/arr/instance-helpers.js";
+import { ConflictError } from "../lib/errors.js";
 import {
 	withCleanupTopologyMutationLease,
 	withExclusiveCleanupTopologyMutationLease,
@@ -24,6 +25,13 @@ import { formatServiceInstance } from "../lib/services/service-formatter.js";
 import { updateInstanceTags, upsertTags } from "../lib/services/tag-manager.js";
 import { buildUpdateData } from "../lib/services/update-builder.js";
 import { assertNoActiveTrashRecoveryForInstance } from "../lib/trash-guides/recovery-evidence.js";
+import {
+	createDeploymentConnectionBinding,
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+	isCurrentDeploymentConnectionMapping,
+	normalizeDeploymentBaseUrl,
+} from "../lib/trash-guides/deployment-target.js";
 import { validateRequest } from "../lib/utils/validate.js";
 import { invalidatePulseCache } from "./pulse.js";
 
@@ -82,14 +90,8 @@ const QUI_TOPOLOGY_UPDATE_FIELDS = [
 ] as const;
 const CACHE_PROVIDER_SERVICES = new Set<ServiceType>(["PLEX", "TAUTULLI", "JELLYFIN", "EMBY"]);
 
-function changesServiceConnection(
-	existing: Pick<ServiceInstance, "service" | "baseUrl">,
-	payload: z.infer<typeof serviceUpdateSchema>,
-): boolean {
-	const targetService = (payload.service ?? existing.service.toLowerCase()).toUpperCase();
-	if (payload.service !== undefined && targetService !== existing.service) return true;
-	if (payload.baseUrl !== undefined && payload.baseUrl !== existing.baseUrl) return true;
-	return Object.hasOwn(payload, "apiKey") || Object.hasOwn(payload, "httpAuth");
+function isArrService(service: ServiceType): boolean {
+	return service === "RADARR" || service === "SONARR";
 }
 
 function changesQuiTopology(
@@ -180,6 +182,210 @@ async function clearDurableQuiObservations(
 }
 
 const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
+	async function deleteArrAliasWithStateMigration(
+		userId: string,
+		existing: ServiceInstance,
+	): Promise<void> {
+		await app.deploymentExecutor.runWithEndpointMutation(
+			userId,
+			existing,
+			"ARR service alias deletion",
+			async (endpointKey) => {
+				const current = await requireInstance(app, userId, existing.id);
+				if (
+					createDeploymentEndpointKey(userId, current) !== endpointKey ||
+					createDeploymentConnectionStateToken(current) !==
+						createDeploymentConnectionStateToken(existing)
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while alias deletion was starting.",
+					);
+				}
+
+				await app.prisma.$transaction(async (tx) => {
+					const aliases = await tx.serviceInstance.findMany({
+						where: { userId, service: current.service },
+					});
+					const normalizedBaseUrl = normalizeDeploymentBaseUrl(current.baseUrl);
+					const endpointAliases = aliases.filter(
+						(alias) =>
+							alias.userId === userId &&
+							alias.service === current.service &&
+							normalizeDeploymentBaseUrl(alias.baseUrl) === normalizedBaseUrl,
+					);
+					if (!endpointAliases.some((alias) => alias.id === current.id)) {
+						throw new ConflictError(
+							"The ARR alias topology changed before deletion could be authorized.",
+						);
+					}
+					const endpointInstanceIds = endpointAliases.map((alias) => alias.id);
+					const [mappings, overrides] = await Promise.all([
+						tx.templateQualityProfileMapping.findMany({
+							where: {
+								instanceId: { in: endpointInstanceIds },
+								template: { userId },
+							},
+						}),
+						tx.instanceQualityProfileOverride.findMany({
+							where: { userId, instanceId: { in: endpointInstanceIds } },
+						}),
+					]);
+					if (overrides.some((override) => override.status !== "APPLIED")) {
+						throw new ConflictError(
+							"This ARR endpoint has unresolved score intent. Reconcile it before deleting an alias.",
+						);
+					}
+
+					const sourceMappings = mappings.filter((mapping) => mapping.instanceId === current.id);
+					const sourceOverrides = overrides.filter(
+						(override) => override.instanceId === current.id,
+					);
+					const hasMigratableState = sourceMappings.length > 0 || sourceOverrides.length > 0;
+					const currentCredentialIdentity =
+						app.arrClientFactory.createConnectionCredentialIdentity(current);
+					const exactSurvivors = endpointAliases.filter(
+						(alias) =>
+							alias.id !== current.id &&
+							app.arrClientFactory.createConnectionCredentialIdentity(alias) ===
+								currentCredentialIdentity,
+					);
+					if (hasMigratableState && exactSurvivors.length !== 1) {
+						throw new ConflictError(
+							"Saved profile state cannot be migrated because no single exact surviving ARR alias exists.",
+						);
+					}
+
+					const survivor = exactSurvivors[0];
+					if (survivor && hasMigratableState) {
+						const sourceBindings = [createDeploymentConnectionBinding(current)];
+						const survivorBindings = [createDeploymentConnectionBinding(survivor)];
+						if (
+							sourceMappings.some(
+								(mapping) => !isCurrentDeploymentConnectionMapping(mapping, sourceBindings),
+							) ||
+							sourceOverrides.some(
+								(override) => !isCurrentDeploymentConnectionMapping(override, sourceBindings),
+							)
+						) {
+							throw new ConflictError(
+								"The deleting ARR alias has stale saved profile state that requires manual reconciliation.",
+							);
+						}
+						const survivorMappings = mappings.filter(
+							(mapping) => mapping.instanceId === survivor.id,
+						);
+						const survivorOverrides = overrides.filter(
+							(override) => override.instanceId === survivor.id,
+						);
+						if (
+							survivorMappings.some(
+								(mapping) => !isCurrentDeploymentConnectionMapping(mapping, survivorBindings),
+							) ||
+							survivorOverrides.some(
+								(override) => !isCurrentDeploymentConnectionMapping(override, survivorBindings),
+							)
+						) {
+							throw new ConflictError(
+								"The surviving ARR alias has stale saved profile state that requires manual reconciliation.",
+							);
+						}
+
+						for (const mapping of sourceMappings) {
+							const target = survivorMappings.find(
+								(candidate) => candidate.qualityProfileId === mapping.qualityProfileId,
+							);
+							if (target) {
+								if (
+									target.templateId !== mapping.templateId ||
+									target.qualityProfileName !== mapping.qualityProfileName
+								) {
+									throw new ConflictError(
+										"Equivalent ARR aliases have conflicting template mappings.",
+									);
+								}
+								const deleted = await tx.templateQualityProfileMapping.deleteMany({
+									where: {
+										id: mapping.id,
+										instanceId: current.id,
+										connectionGeneration: mapping.connectionGeneration,
+										connectionStateToken: mapping.connectionStateToken,
+									},
+								});
+								if (deleted.count !== 1) {
+									throw new ConflictError("The ARR alias mapping changed during deletion.");
+								}
+								continue;
+							}
+							const migrated = await tx.templateQualityProfileMapping.updateMany({
+								where: {
+									id: mapping.id,
+									instanceId: current.id,
+									connectionGeneration: mapping.connectionGeneration,
+									connectionStateToken: mapping.connectionStateToken,
+								},
+								data: {
+									instanceId: survivor.id,
+									connectionGeneration: survivor.connectionGeneration,
+									connectionStateToken: createDeploymentConnectionStateToken(survivor),
+								},
+							});
+							if (migrated.count !== 1) {
+								throw new ConflictError("The ARR alias mapping changed during migration.");
+							}
+						}
+
+						for (const override of sourceOverrides) {
+							const target = survivorOverrides.find(
+								(candidate) =>
+									candidate.qualityProfileId === override.qualityProfileId &&
+									candidate.customFormatId === override.customFormatId,
+							);
+							if (target) {
+								if (target.status !== "APPLIED" || target.score !== override.score) {
+									throw new ConflictError(
+										"Equivalent ARR aliases have conflicting saved score overrides.",
+									);
+								}
+								const deleted = await tx.instanceQualityProfileOverride.deleteMany({
+									where: {
+										id: override.id,
+										instanceId: current.id,
+										status: "APPLIED",
+										userId,
+									},
+								});
+								if (deleted.count !== 1) {
+									throw new ConflictError("The ARR alias override changed during deletion.");
+								}
+								continue;
+							}
+							const migrated = await tx.instanceQualityProfileOverride.updateMany({
+								where: {
+									id: override.id,
+									instanceId: current.id,
+									status: "APPLIED",
+									userId,
+									connectionGeneration: override.connectionGeneration,
+									connectionStateToken: override.connectionStateToken,
+								},
+								data: {
+									instanceId: survivor.id,
+									connectionGeneration: survivor.connectionGeneration,
+									connectionStateToken: createDeploymentConnectionStateToken(survivor),
+								},
+							});
+							if (migrated.count !== 1) {
+								throw new ConflictError("The ARR alias override changed during migration.");
+							}
+						}
+					}
+
+					await tx.serviceInstance.delete({ where: { id: current.id, userId } });
+				});
+			},
+		);
+	}
+
 	app.get("/services", async (request, reply) => {
 		const instances = await app.prisma.serviceInstance.findMany({
 			where: { userId: request.currentUser!.id },
@@ -311,15 +517,58 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 
 				const quiTopologyChanged = changesQuiTopology(existing.service, payload);
 				const providerConnectionChanged = changesCacheProviderConnection(existing, payload);
-				const serviceConnectionChanged = changesServiceConnection(existing, payload);
 				const serviceTypeChanged = targetService !== existing.service;
-				const serviceUpdateData =
-					providerConnectionChanged || serviceConnectionChanged
-						? {
-								...updateData,
-								connectionGeneration: { increment: 1 },
-							}
-						: updateData;
+				const targetConnection = {
+					...existing,
+					...updateData,
+					service: targetService,
+				};
+				const arrConnectionFieldsSubmitted =
+					serviceTypeChanged ||
+					payload.baseUrl !== undefined ||
+					payload.apiKey !== undefined ||
+					payload.httpAuth !== undefined;
+				const arrConnectionChanged =
+					(isArrService(existing.service) || isArrService(targetService)) &&
+					arrConnectionFieldsSubmitted &&
+					(serviceTypeChanged ||
+						normalizeDeploymentBaseUrl(existing.baseUrl) !==
+							normalizeDeploymentBaseUrl(targetConnection.baseUrl) ||
+						app.arrClientFactory.createConnectionCredentialIdentity(existing) !==
+							app.arrClientFactory.createConnectionCredentialIdentity(targetConnection));
+				if (arrConnectionChanged && isArrService(existing.service)) {
+					const aliases = await app.prisma.serviceInstance.findMany({
+						where: { userId, service: existing.service },
+					});
+					const currentEndpoint = normalizeDeploymentBaseUrl(existing.baseUrl);
+					const equivalentInstanceIds = aliases
+						.filter(
+							(alias) =>
+								alias.userId === userId &&
+								alias.service === existing.service &&
+								normalizeDeploymentBaseUrl(alias.baseUrl) === currentEndpoint,
+						)
+						.map((alias) => alias.id);
+					if (!equivalentInstanceIds.includes(id)) equivalentInstanceIds.push(id);
+					const unresolvedIntents = await app.prisma.instanceQualityProfileOverride.findMany({
+						where: {
+							userId,
+							instanceId: { in: equivalentInstanceIds },
+							status: { in: ["PENDING", "UNCERTAIN"] },
+						},
+					});
+					if (unresolvedIntents.length > 0) {
+						throw new ConflictError(
+							"This ARR endpoint has unresolved score intent. Reconcile it before changing the connection.",
+						);
+					}
+				}
+				const serviceUpdateData = arrConnectionChanged
+					? {
+							...updateData,
+							connectionGeneration: { increment: 1 },
+						}
+					: updateData;
 				if (quiTopologyChanged) {
 					await withQuiObservationTopologyGuard(userId, async () => {
 						await app.prisma.$transaction(async (tx) => {
@@ -427,13 +676,13 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 			{ prisma: app.prisma, log: request.log },
 			userId,
 			async () => {
-				const current = await requireInstance(app, userId, id);
-				if (current.service === "RADARR" || current.service === "SONARR") {
+				const existing = await requireInstance(app, userId, id);
+				if (existing.service === "RADARR" || existing.service === "SONARR") {
 					// Re-check after exclusive ownership is established. This is the
 					// execution-time authority check before the cascading delete.
 					await assertNoActiveTrashRecoveryForInstance(app.prisma, userId, id);
-				}
-				if (current.service === "QUI") {
+					await deleteArrAliasWithStateMigration(userId, existing);
+				} else if (existing.service === "QUI") {
 					await withQuiObservationTopologyGuard(userId, async () => {
 						await app.prisma.$transaction(async (tx) => {
 							await tx.serviceInstance.delete({ where: { id, userId } });

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -39,6 +39,7 @@ describe("instance quality profile score persistence", () => {
 	const findTransactionInstance = vi.fn();
 	const findTransactionMappings = vi.fn();
 	const updateTemplates = vi.fn();
+	const countTemplates = vi.fn();
 	const deleteAliasOverrides = vi.fn();
 	const upsertOverride = vi.fn();
 	const updateOverrides = vi.fn();
@@ -101,6 +102,7 @@ describe("instance quality profile score persistence", () => {
 		findTransactionInstance.mockResolvedValue(instance);
 		findTransactionMappings.mockResolvedValue([]);
 		updateTemplates.mockResolvedValue({ count: 1 });
+		countTemplates.mockResolvedValue(1);
 		deleteAliasOverrides.mockResolvedValue({ count: 0 });
 		upsertOverride.mockResolvedValue({});
 		updateOverrides.mockResolvedValue({ count: 1 });
@@ -132,6 +134,7 @@ describe("instance quality profile score persistence", () => {
 			},
 			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
 			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			trashTemplate: { count: countTemplates },
 			templateQualityProfileMapping: {
 				findMany: findMappings,
 				findUnique: vi.fn().mockResolvedValue(mapping),
@@ -1349,6 +1352,76 @@ describe("instance quality profile score persistence", () => {
 		expect(updateProfile).toHaveBeenCalledOnce();
 		expect(updateOverrides).toHaveBeenCalledWith(
 			expect.objectContaining({ data: { status: "UNCERTAIN" } }),
+		);
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("restores the override when the template score changes before the ARR write", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+			configData: JSON.stringify({
+				customFormats: [{ trashId: "trash-7", scoreOverride: -10_000 }],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		countTemplates.mockResolvedValueOnce(0);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("template changed");
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(updateOverrides).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ id: override.id, status: "PENDING" }),
+				data: expect.objectContaining({ status: "APPLIED" }),
+			}),
 		);
 		expect(deleteOverrides).not.toHaveBeenCalled();
 	});

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
+	createUpstreamResourceStateToken,
 } from "../../../lib/trash-guides/deployment-target.js";
 import {
 	createInjectAuthenticated,
@@ -23,6 +24,8 @@ const instance = {
 	httpAuthEncryptionIv: null,
 	connectionGeneration: 2,
 };
+const liveManagedCustomFormat = { id: 7, name: "Reject", specifications: [] };
+const liveManagedCustomFormatStateToken = createUpstreamResourceStateToken(liveManagedCustomFormat);
 
 describe("instance quality profile score persistence", () => {
 	let app: FastifyInstance;
@@ -43,6 +46,7 @@ describe("instance quality profile score persistence", () => {
 	const getProfile = vi.fn();
 	const updateProfile = vi.fn();
 	const getCustomFormats = vi.fn();
+	const getCustomFormat = vi.fn();
 	const runWithEndpointMutation = vi.fn();
 
 	beforeEach(async () => {
@@ -103,6 +107,7 @@ describe("instance quality profile score persistence", () => {
 		deleteOverrides.mockResolvedValue({ count: 1 });
 		updateProfile.mockResolvedValue(undefined);
 		getCustomFormats.mockResolvedValue([{ id: 7, name: "Reject" }]);
+		getCustomFormat.mockResolvedValue(liveManagedCustomFormat);
 
 		const transactionClient = {
 			serviceInstance: { findFirst: findTransactionInstance },
@@ -144,7 +149,7 @@ describe("instance quality profile score persistence", () => {
 		};
 		const client = {
 			qualityProfile: { getById: getProfile, update: updateProfile },
-			customFormat: { getAll: getCustomFormats },
+			customFormat: { getAll: getCustomFormats, getById: getCustomFormat },
 		};
 
 		app = Fastify({ logger: false });
@@ -985,7 +990,7 @@ describe("instance quality profile score persistence", () => {
 				trashId: "trash-7",
 				name: "Reject",
 				resourceId: 7,
-				stateToken: "format-state",
+				stateToken: liveManagedCustomFormatStateToken,
 				profileId: 4,
 				appliedScore: 100,
 			},
@@ -1029,12 +1034,19 @@ describe("instance quality profile score persistence", () => {
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
 
-	it("resets an instance override to the nested TRaSH profile score set", async () => {
+	it("matches a reset by managed TRaSH identity when instance resource IDs collide", async () => {
 		const template = {
 			id: "template-1",
 			userId,
 			configData: JSON.stringify({
+				completeQualityProfile: { sourceInstanceId: instance.id },
 				customFormats: [
+					{
+						trashId: "instance-only-format",
+						name: "Unmanaged format from the source instance",
+						scoreOverride: 250,
+						originalConfig: { _instanceCFId: 7 },
+					},
 					{
 						trashId: "trash-7",
 						name: "Reject",
@@ -1060,7 +1072,7 @@ describe("instance quality profile score persistence", () => {
 						trashId: "trash-7",
 						name: "Reject",
 						resourceId: 7,
-						stateToken: "format-state",
+						stateToken: liveManagedCustomFormatStateToken,
 						profileId: 4,
 						appliedScore: 100,
 					},
@@ -1125,6 +1137,492 @@ describe("instance quality profile score persistence", () => {
 		);
 	});
 
+	it("fails before saving reset intent when a managed Custom Format identity drifted", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [{ trashId: "trash-7", scoreOverride: -10_000 }],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		getCustomFormat.mockResolvedValue({
+			id: 7,
+			name: "Replacement format",
+			specifications: [],
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("Custom Format identity changed");
+		expect(updateOverrides).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("rechecks managed Custom Format identity before resuming a reset intent", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [{ trashId: "trash-7", scoreOverride: -10_000 }],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		const pendingIntent = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "PENDING",
+			intentOperation: "RESET_SCORE",
+			intendedScore: -10_000,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([pendingIntent])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([pendingIntent]);
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const after = { ...before, formatItems: [{ format: 7, score: -10_000 }] };
+		getProfile
+			.mockReset()
+			.mockResolvedValueOnce(before)
+			.mockResolvedValueOnce(before)
+			.mockResolvedValue(after);
+		getCustomFormat
+			.mockResolvedValueOnce(liveManagedCustomFormat)
+			.mockResolvedValue({ id: 7, name: "Replacement format", specifications: [] });
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("Custom Format identity changed");
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("retains an uncertain reset intent when Custom Format identity changes after the ARR write", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [{ trashId: "trash-7", scoreOverride: -10_000 }],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const after = { ...before, formatItems: [{ format: 7, score: -10_000 }] };
+		getProfile
+			.mockReset()
+			.mockResolvedValueOnce(before)
+			.mockResolvedValueOnce(before)
+			.mockResolvedValue(after);
+		getCustomFormat
+			.mockResolvedValueOnce(liveManagedCustomFormat)
+			.mockResolvedValueOnce(liveManagedCustomFormat)
+			.mockResolvedValue({ id: 7, name: "Replacement format", specifications: [] });
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("Custom Format identity changed");
+		expect(updateProfile).toHaveBeenCalledOnce();
+		expect(updateOverrides).toHaveBeenCalledWith(
+			expect.objectContaining({ data: { status: "UNCERTAIN" } }),
+		);
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("does not reuse source-instance resource IDs on a different ARR endpoint", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				completeQualityProfile: {
+					sourceInstanceId: "source-instance",
+					sourceConnectionStateToken: "source-token",
+				},
+				customFormats: [
+					{
+						trashId: "instance-only-format",
+						scoreOverride: 250,
+						originalConfig: { _instanceCFId: 7 },
+					},
+					{
+						trashId: "managed-format",
+						scoreOverride: -10_000,
+						originalConfig: { _instanceCFId: 9001 },
+					},
+				],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "managed-format",
+						name: "Managed format",
+						resourceId: 9001,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: -10_000,
+					},
+				]),
+				template,
+			},
+		]);
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		findUniqueOverride.mockResolvedValueOnce(override);
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const after = { ...before, formatItems: [{ format: 7, score: 0 }] };
+		getProfile
+			.mockReset()
+			.mockResolvedValueOnce(before)
+			.mockResolvedValueOnce(before)
+			.mockResolvedValue(after);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("Custom Format identity could not be established");
+		expect(updateOverrides).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("retains instance-ID fallback on the verified cloned source connection", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				completeQualityProfile: {
+					sourceInstanceId: instance.id,
+					sourceConnectionStateToken: createDeploymentConnectionStateToken(instance),
+				},
+				customFormats: [
+					{
+						trashId: "instance-only-format",
+						name: "Instance-only format",
+						scoreOverride: 250,
+						originalConfig: {
+							_instanceCFId: 7,
+							name: "Instance-only format",
+							specifications: [],
+						},
+					},
+				],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: "[]",
+				template,
+			},
+		]);
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		findUniqueOverride.mockResolvedValueOnce(override);
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const after = { ...before, formatItems: [{ format: 7, score: 250 }] };
+		getProfile
+			.mockReset()
+			.mockResolvedValueOnce(before)
+			.mockResolvedValueOnce(before)
+			.mockResolvedValue(after);
+		getCustomFormat.mockResolvedValue({
+			id: 7,
+			name: "Instance-only format",
+			specifications: [],
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().revertedScore).toBe(250);
+	});
+
+	it.each([
+		{
+			label: "managed resource IDs",
+			managedCustomFormats: [
+				{ trashId: "trash-a", resourceId: 7 },
+				{ trashId: "trash-b", resourceId: 7 },
+			],
+			customFormats: [{ trashId: "trash-a" }, { trashId: "trash-b" }],
+		},
+		{
+			label: "managed TRaSH identities",
+			managedCustomFormats: [
+				{ trashId: "trash-a", resourceId: 7 },
+				{ trashId: "trash-a", resourceId: 8 },
+			],
+			customFormats: [{ trashId: "trash-a" }],
+		},
+	])("fails closed on duplicate $label", async ({ managedCustomFormats, customFormats }) => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({ customFormats }),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify(
+					managedCustomFormats.map((format) => ({
+						...format,
+						name: "Managed format",
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					})),
+				),
+				template,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("duplicate managed Custom Format authority");
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when a template repeats the managed TRaSH identity", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [
+					{ trashId: "trash-7", scoreOverride: 100 },
+					{ trashId: "trash-7", scoreOverride: 200 },
+				],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Managed format",
+						resourceId: 7,
+						stateToken: liveManagedCustomFormatStateToken,
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("duplicate Custom Format identity");
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
 	it("restores an applied reset intent when the profile changes before the ARR write", async () => {
 		const template = {
 			id: "template-1",
@@ -1155,7 +1653,7 @@ describe("instance quality profile score persistence", () => {
 						trashId: "trash-7",
 						name: "Reject",
 						resourceId: 7,
-						stateToken: "format-state",
+						stateToken: liveManagedCustomFormatStateToken,
 						profileId: 4,
 						appliedScore: 100,
 					},
@@ -1237,7 +1735,7 @@ describe("instance quality profile score persistence", () => {
 					trashId: "trash-7",
 					name: "Reject",
 					resourceId: 7,
-					stateToken: "format-state",
+					stateToken: liveManagedCustomFormatStateToken,
 					profileId: 4,
 					appliedScore: 100,
 				},

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -1,0 +1,571 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+} from "../../../lib/trash-guides/deployment-target.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+import registerInstanceQualityProfileRoutes from "../instance-quality-profile-routes.js";
+
+const userId = "user-1";
+const instance = {
+	id: "instance-1",
+	userId,
+	service: "RADARR",
+	baseUrl: "http://radarr:7878",
+	encryptedApiKey: "encrypted-key",
+	encryptionIv: "iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 2,
+};
+
+describe("instance quality profile score persistence", () => {
+	let app: FastifyInstance;
+	const findServiceInstance = vi.fn();
+	const findServiceInstances = vi.fn();
+	const findMappings = vi.fn();
+	const findOverrides = vi.fn();
+	const findTransactionOverrides = vi.fn();
+	const deleteAliasOverrides = vi.fn();
+	const upsertOverride = vi.fn();
+	const updateOverrides = vi.fn();
+	const deleteOverrides = vi.fn();
+	const getProfile = vi.fn();
+	const updateProfile = vi.fn();
+	const getCustomFormats = vi.fn();
+	const runWithEndpointMutation = vi.fn();
+
+	beforeEach(async () => {
+		vi.resetAllMocks();
+		const beforeProfile = {
+			id: 4,
+			name: "Any",
+			formatItems: [{ format: 7, score: 100 }],
+		};
+		const afterProfile = {
+			...beforeProfile,
+			formatItems: [{ format: 7, score: -10_000 }],
+		};
+		getProfile
+			.mockResolvedValueOnce(beforeProfile)
+			.mockResolvedValueOnce(beforeProfile)
+			.mockResolvedValueOnce(beforeProfile)
+			.mockResolvedValue(afterProfile);
+
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						scoreOverride: 100,
+						originalConfig: { _instanceCFId: 7 },
+					},
+				],
+			}),
+		};
+		const mapping = {
+			id: "mapping-1",
+			templateId: template.id,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			template,
+		};
+
+		findServiceInstance.mockResolvedValue(instance);
+		findServiceInstances.mockResolvedValue([instance]);
+		findMappings.mockResolvedValue([mapping]);
+		findOverrides.mockImplementation(async ({ select }) => (select ? [] : []));
+		findTransactionOverrides.mockResolvedValue([]);
+		deleteAliasOverrides.mockResolvedValue({ count: 0 });
+		upsertOverride.mockResolvedValue({});
+		updateOverrides.mockResolvedValue({ count: 1 });
+		deleteOverrides.mockResolvedValue({ count: 1 });
+		updateProfile.mockResolvedValue(undefined);
+		getCustomFormats.mockResolvedValue([{ id: 7, name: "Reject" }]);
+
+		const transactionClient = {
+			instanceQualityProfileOverride: {
+				findMany: findTransactionOverrides,
+				deleteMany: deleteAliasOverrides,
+				upsert: upsertOverride,
+				updateMany: updateOverrides,
+			},
+		};
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+			serviceInstance: {
+				findFirst: findServiceInstance,
+				findMany: findServiceInstances,
+			},
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			templateQualityProfileMapping: {
+				findMany: findMappings,
+				findUnique: vi.fn().mockResolvedValue(mapping),
+			},
+			instanceQualityProfileOverride: {
+				findMany: findOverrides,
+				findUnique: vi.fn().mockResolvedValue(null),
+				upsert: upsertOverride,
+				updateMany: updateOverrides,
+				deleteMany: deleteOverrides,
+			},
+			$transaction: vi.fn(async (work: (client: typeof transactionClient) => unknown) =>
+				work(transactionClient),
+			),
+		};
+		const client = {
+			qualityProfile: { getById: getProfile, update: updateProfile },
+			customFormat: { getAll: getCustomFormats },
+		};
+
+		app = Fastify({ logger: false });
+		setupAuthInjection(app, { id: userId, username: "admin" });
+		registerTestErrorHandler(app);
+		app.decorate("prisma", prisma as never);
+		app.decorate("arrClientFactory", {
+			create: vi.fn().mockReturnValue(client),
+			createConnectionCredentialIdentity: vi.fn().mockReturnValue("credentials"),
+		} as never);
+		app.decorate("deploymentExecutor", {
+			runWithEndpointMutation: runWithEndpointMutation.mockImplementation(
+				async (_userId, target, _operation, callback) =>
+					callback(createDeploymentEndpointKey(userId, target)),
+			),
+		} as never);
+		await app.register(registerInstanceQualityProfileRoutes);
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		await app.close();
+	});
+
+	it("saves durable intent before the upstream profile update", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(upsertOverride).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					instanceId: "instance-1",
+					score: -10_000,
+					status: "PENDING",
+					intentOperation: "SET_SCORE",
+					intendedScore: -10_000,
+					connectionStateToken: createDeploymentConnectionStateToken(instance),
+				}),
+			}),
+		);
+		expect(upsertOverride.mock.invocationCallOrder[0]).toBeLessThan(
+			updateProfile.mock.invocationCallOrder[0]!,
+		);
+		expect(updateOverrides).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: { status: "APPLIED", intentOperation: null, intendedScore: null },
+			}),
+		);
+	});
+
+	it("retains uncertain intent when the upstream result is unknown", async () => {
+		updateProfile.mockRejectedValueOnce(new Error("request timed out"));
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(500);
+		expect(upsertOverride).toHaveBeenCalledOnce();
+		expect(updateOverrides).toHaveBeenLastCalledWith(
+			expect.objectContaining({ data: { status: "UNCERTAIN" } }),
+		);
+	});
+
+	it("keeps a current mapping stored through an equivalent service alias", async () => {
+		const alias = { ...instance, id: "instance-alias", label: "Renamed alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findMappings.mockResolvedValueOnce([
+			{
+				templateId: "template-1",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().isTemplateManaged).toBe(true);
+		expect(updateOverrides).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: { status: "APPLIED", intentOperation: null, intendedScore: null },
+			}),
+		);
+	});
+
+	it("atomically consolidates an applied override from an equivalent alias", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findTransactionOverrides.mockResolvedValueOnce([
+			{
+				id: "alias-applied",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				status: "APPLIED",
+			},
+		]);
+		deleteAliasOverrides.mockResolvedValueOnce({ count: 1 });
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(deleteAliasOverrides).toHaveBeenCalledWith({
+			where: { id: { in: ["alias-applied"] }, status: "APPLIED", userId },
+		});
+		expect(upsertOverride).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					instanceId_qualityProfileId_customFormatId: {
+						instanceId: instance.id,
+						qualityProfileId: 4,
+						customFormatId: 7,
+					},
+				},
+			}),
+		);
+	});
+
+	it("fails closed if an equivalent override becomes uncertain during consolidation", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findTransactionOverrides.mockResolvedValueOnce([
+			{
+				id: "alias-uncertain",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				status: "UNCERTAIN",
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(upsertOverride).not.toHaveBeenCalled();
+	});
+
+	it("rejects conflicting applied overrides from equivalent aliases transactionally", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findTransactionOverrides.mockResolvedValueOnce([
+			{
+				id: "primary-applied",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 100,
+				status: "APPLIED",
+			},
+			{
+				id: "alias-applied",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 200,
+				status: "APPLIED",
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(deleteAliasOverrides).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects duplicate Custom Format updates before any mutation", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{
+				body: {
+					scoreUpdates: [
+						{ customFormatId: 7, score: 100 },
+						{ customFormatId: 7, score: -10_000 },
+					],
+				},
+			},
+		);
+
+		expect(response.statusCode).toBe(400);
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(upsertOverride).not.toHaveBeenCalled();
+	});
+
+	it("serializes score writes through the canonical endpoint mutation lock", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(runWithEndpointMutation).toHaveBeenCalledWith(
+			userId,
+			expect.objectContaining({ id: "instance-1", baseUrl: "http://radarr:7878" }),
+			"Quality profile score update",
+			expect.any(Function),
+		);
+	});
+
+	it("serializes concurrent saves for equivalent endpoint aliases", async () => {
+		let activeMutation = false;
+		let releaseFirstUpdate!: () => void;
+		let markFirstUpdateStarted!: () => void;
+		const firstUpdateStarted = new Promise<void>((resolve) => {
+			markFirstUpdateStarted = resolve;
+		});
+		const firstUpdateBlocked = new Promise<void>((resolve) => {
+			releaseFirstUpdate = resolve;
+		});
+		updateProfile
+			.mockImplementationOnce(async () => {
+				markFirstUpdateStarted();
+				await firstUpdateBlocked;
+			})
+			.mockResolvedValue(undefined);
+		runWithEndpointMutation.mockImplementation(async (_userId, target, _operation, callback) => {
+			if (activeMutation) {
+				throw Object.assign(new Error("concurrent endpoint mutation"), { statusCode: 409 });
+			}
+			activeMutation = true;
+			try {
+				return await callback(createDeploymentEndpointKey(userId, target));
+			} finally {
+				activeMutation = false;
+			}
+		});
+
+		const first = createInjectAuthenticated(app)("PATCH", "/instance-1/quality-profiles/4/scores", {
+			body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] },
+		});
+		await firstUpdateStarted;
+		const second = createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		releaseFirstUpdate();
+
+		const responses = await Promise.all([first, second]);
+		expect(responses.map((response) => response.statusCode)).toEqual([200, 200]);
+		expect(runWithEndpointMutation).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects an exact retry saved under an older alias connection generation", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findOverrides.mockImplementation(async ({ select }) =>
+			select?.connectionStateToken
+				? [
+						{
+							instanceId: alias.id,
+							qualityProfileId: 4,
+							customFormatId: 7,
+							intentOperation: "SET_SCORE",
+							intendedScore: -10_000,
+							connectionGeneration: 1,
+							connectionStateToken: "stale-token",
+						},
+					]
+				: [],
+		);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(400);
+		expect(upsertOverride).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("marks intent uncertain when database finalization cannot confirm the applied write", async () => {
+		updateOverrides.mockResolvedValueOnce({ count: 0 }).mockResolvedValueOnce({ count: 1 });
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(updateProfile).toHaveBeenCalledOnce();
+		expect(updateOverrides).toHaveBeenLastCalledWith(
+			expect.objectContaining({ data: { status: "UNCERTAIN" } }),
+		);
+	});
+
+	it("scopes all reads to the authenticated user and current connection binding", async () => {
+		findOverrides.mockResolvedValueOnce([]);
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(findServiceInstance).toHaveBeenCalledWith(
+			expect.objectContaining({ where: expect.objectContaining({ id: "instance-1", userId }) }),
+		);
+		expect(findOverrides).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					userId,
+					qualityProfileId: 4,
+					OR: [
+						expect.objectContaining({
+							status: "APPLIED",
+							OR: [
+								expect.objectContaining({
+									instanceId: "instance-1",
+									connectionGeneration: 2,
+									connectionStateToken: createDeploymentConnectionStateToken(instance),
+								}),
+							],
+						}),
+						expect.objectContaining({
+							status: { in: ["PENDING", "UNCERTAIN"] },
+							instanceId: { in: ["instance-1"] },
+						}),
+					],
+				}),
+			}),
+		);
+	});
+
+	it("exposes retryable uncertain intent without treating it as an applied override", async () => {
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "uncertain-1",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "UNCERTAIN",
+				intentOperation: "SET_SCORE",
+				intendedScore: -10_000,
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				updatedAt: new Date("2026-08-09T00:00:00Z"),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json()).toMatchObject({
+			overrides: [],
+			recoveryIntents: [
+				{
+					customFormatId: 7,
+					operation: "SET_SCORE",
+					intendedScore: -10_000,
+					status: "UNCERTAIN",
+					retryAction: { method: "PATCH", score: -10_000 },
+				},
+			],
+		});
+	});
+
+	it("fails closed when equivalent aliases expose conflicting applied scores", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "primary-override",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 100,
+				status: "APPLIED",
+			},
+			{
+				id: "alias-override",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 200,
+				status: "APPLIED",
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode).toBe(409);
+	});
+
+	it("denies cross-user access before reading or mutating profile state", async () => {
+		findServiceInstance.mockResolvedValueOnce(null);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/other-user-instance/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(404);
+		expect(getProfile).not.toHaveBeenCalled();
+		expect(upsertOverride).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -30,7 +30,12 @@ describe("instance quality profile score persistence", () => {
 	const findServiceInstances = vi.fn();
 	const findMappings = vi.fn();
 	const findOverrides = vi.fn();
+	const findUniqueOverride = vi.fn();
 	const findTransactionOverrides = vi.fn();
+	const countTransactionOverrides = vi.fn();
+	const findTransactionInstance = vi.fn();
+	const findTransactionMappings = vi.fn();
+	const updateTemplates = vi.fn();
 	const deleteAliasOverrides = vi.fn();
 	const upsertOverride = vi.fn();
 	const updateOverrides = vi.fn();
@@ -86,7 +91,12 @@ describe("instance quality profile score persistence", () => {
 		findServiceInstances.mockResolvedValue([instance]);
 		findMappings.mockResolvedValue([mapping]);
 		findOverrides.mockImplementation(async ({ select }) => (select ? [] : []));
+		findUniqueOverride.mockResolvedValue(null);
 		findTransactionOverrides.mockResolvedValue([]);
+		countTransactionOverrides.mockResolvedValue(0);
+		findTransactionInstance.mockResolvedValue(instance);
+		findTransactionMappings.mockResolvedValue([]);
+		updateTemplates.mockResolvedValue({ count: 1 });
 		deleteAliasOverrides.mockResolvedValue({ count: 0 });
 		upsertOverride.mockResolvedValue({});
 		updateOverrides.mockResolvedValue({ count: 1 });
@@ -95,8 +105,12 @@ describe("instance quality profile score persistence", () => {
 		getCustomFormats.mockResolvedValue([{ id: 7, name: "Reject" }]);
 
 		const transactionClient = {
+			serviceInstance: { findFirst: findTransactionInstance },
+			templateQualityProfileMapping: { findMany: findTransactionMappings },
+			trashTemplate: { updateMany: updateTemplates },
 			instanceQualityProfileOverride: {
 				findMany: findTransactionOverrides,
+				count: countTransactionOverrides,
 				deleteMany: deleteAliasOverrides,
 				upsert: upsertOverride,
 				updateMany: updateOverrides,
@@ -119,7 +133,7 @@ describe("instance quality profile score persistence", () => {
 			},
 			instanceQualityProfileOverride: {
 				findMany: findOverrides,
-				findUnique: vi.fn().mockResolvedValue(null),
+				findUnique: findUniqueOverride,
 				upsert: upsertOverride,
 				updateMany: updateOverrides,
 				deleteMany: deleteOverrides,
@@ -144,7 +158,12 @@ describe("instance quality profile score persistence", () => {
 		app.decorate("deploymentExecutor", {
 			runWithEndpointMutation: runWithEndpointMutation.mockImplementation(
 				async (_userId, target, _operation, callback) =>
-					callback(createDeploymentEndpointKey(userId, target)),
+					callback(
+						createDeploymentEndpointKey(userId, {
+							...target,
+							credentialIdentity: "credentials",
+						}),
+					),
 			),
 		} as never);
 		await app.register(registerInstanceQualityProfileRoutes);
@@ -582,7 +601,12 @@ describe("instance quality profile score persistence", () => {
 			}
 			activeMutation = true;
 			try {
-				return await callback(createDeploymentEndpointKey(userId, target));
+				return await callback(
+					createDeploymentEndpointKey(userId, {
+						...target,
+						credentialIdentity: "credentials",
+					}),
+				);
 			} finally {
 				activeMutation = false;
 			}
@@ -632,6 +656,98 @@ describe("instance quality profile score persistence", () => {
 
 		expect(response.statusCode).toBe(400);
 		expect(upsertOverride).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a row-level retry that omits part of the saved profile recovery plan", async () => {
+		findOverrides.mockImplementation(async ({ select }) =>
+			select?.connectionStateToken
+				? [
+						{
+							id: "intent-7",
+							instanceId: instance.id,
+							updatedAt: new Date("2026-08-09T00:00:00Z"),
+							qualityProfileId: 4,
+							customFormatId: 7,
+							intentOperation: "SET_SCORE",
+							intendedScore: -10_000,
+							connectionGeneration: instance.connectionGeneration,
+							connectionStateToken: createDeploymentConnectionStateToken(instance),
+						},
+						{
+							id: "intent-8",
+							instanceId: instance.id,
+							updatedAt: new Date("2026-08-09T00:00:00Z"),
+							qualityProfileId: 4,
+							customFormatId: 8,
+							intentOperation: "SET_SCORE",
+							intendedScore: 50,
+							connectionGeneration: instance.connectionGeneration,
+							connectionStateToken: createDeploymentConnectionStateToken(instance),
+						},
+					]
+				: [],
+		);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().message).toContain("exact score update");
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a stale recovery token after another request resolved the intent", async () => {
+		findOverrides.mockResolvedValue([]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{
+				body: {
+					recoveryToken: "a".repeat(64),
+					scoreUpdates: [{ customFormatId: 7, score: -10_000 }],
+				},
+			},
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("no longer exists");
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a recovery token after the saved intent changes", async () => {
+		findOverrides.mockResolvedValue([
+			{
+				id: "intent-7",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				intentOperation: "SET_SCORE",
+				intendedScore: 25,
+				status: "UNCERTAIN",
+				updatedAt: new Date("2026-08-09T01:00:00Z"),
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{
+				body: {
+					recoveryToken: "a".repeat(64),
+					scoreUpdates: [{ customFormatId: 7, score: 25 }],
+				},
+			},
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("plan changed");
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
 
@@ -714,13 +830,22 @@ describe("instance quality profile score persistence", () => {
 		expect(response.statusCode, response.body).toBe(200);
 		expect(response.json()).toMatchObject({
 			overrides: [],
-			recoveryIntents: [
+			recoveryPlans: [
 				{
-					customFormatId: 7,
-					operation: "SET_SCORE",
-					intendedScore: -10_000,
-					status: "UNCERTAIN",
-					retryAction: { method: "PATCH", score: -10_000 },
+					qualityProfileId: 4,
+					entries: [
+						{
+							customFormatId: 7,
+							operation: "SET_SCORE",
+							intendedScore: -10_000,
+							status: "UNCERTAIN",
+						},
+					],
+					retryAction: {
+						method: "PATCH",
+						recoveryToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+						scoreUpdates: [{ customFormatId: 7, score: -10_000 }],
+					},
 				},
 			],
 		});
@@ -762,7 +887,7 @@ describe("instance quality profile score persistence", () => {
 		);
 
 		expect(response.statusCode, response.body).toBe(200);
-		expect(response.json().recoveryIntents).toEqual([
+		expect(response.json().recoveryPlans).toEqual([
 			expect.objectContaining({
 				retryable: false,
 				requiresManualReconciliation: true,
@@ -795,7 +920,7 @@ describe("instance quality profile score persistence", () => {
 		);
 
 		expect(response.statusCode, response.body).toBe(200);
-		expect(response.json().recoveryIntents).toEqual([
+		expect(response.json().recoveryPlans).toEqual([
 			expect.objectContaining({
 				retryable: false,
 				requiresManualReconciliation: true,

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -238,7 +238,10 @@ describe("instance quality profile score persistence", () => {
 				instanceId: alias.id,
 				qualityProfileId: 4,
 				customFormatId: 7,
+				score: 100,
 				status: "APPLIED",
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
 			},
 		]);
 		deleteAliasOverrides.mockResolvedValueOnce({ count: 1 });
@@ -276,6 +279,8 @@ describe("instance quality profile score persistence", () => {
 				qualityProfileId: 4,
 				customFormatId: 7,
 				status: "UNCERTAIN",
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
 			},
 		]);
 
@@ -301,6 +306,8 @@ describe("instance quality profile score persistence", () => {
 				customFormatId: 7,
 				score: 100,
 				status: "APPLIED",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
 			},
 			{
 				id: "alias-applied",
@@ -309,6 +316,8 @@ describe("instance quality profile score persistence", () => {
 				customFormatId: 7,
 				score: 200,
 				status: "APPLIED",
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
 			},
 		]);
 
@@ -320,6 +329,133 @@ describe("instance quality profile score persistence", () => {
 
 		expect(response.statusCode).toBe(409);
 		expect(deleteAliasOverrides).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a stale mapping row from an equivalent alias before saving intent", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-current",
+				templateId: "template-1",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+			},
+			{
+				id: "mapping-stale",
+				templateId: "template-1",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				connectionGeneration: 1,
+				connectionStateToken: "stale-token",
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(upsertOverride).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("rejects a stale applied override row from an equivalent alias before saving intent", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findTransactionOverrides.mockResolvedValueOnce([
+			{
+				id: "alias-applied-stale",
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: 100,
+				status: "APPLIED",
+				connectionGeneration: 1,
+				connectionStateToken: "stale-token",
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(deleteAliasOverrides).not.toHaveBeenCalled();
+		expect(upsertOverride).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it.each(["4junk", "4.5", "0", "-4", "9007199254740992"])(
+		"rejects non-canonical PATCH profile identity %s before lookup",
+		async (profileId) => {
+			const response = await createInjectAuthenticated(app)(
+				"PATCH",
+				`/instance-1/quality-profiles/${profileId}/scores`,
+				{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+			);
+
+			expect(response.statusCode).toBe(400);
+			expect(getProfile).not.toHaveBeenCalled();
+			expect(upsertOverride).not.toHaveBeenCalled();
+			expect(updateProfile).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["4junk", "4.5", "0", "-4", "9007199254740992"])(
+		"rejects non-canonical GET profile identity %s before lookup",
+		async (profileId) => {
+			const response = await createInjectAuthenticated(app)(
+				"GET",
+				`/instance-1/quality-profiles/${profileId}/overrides`,
+			);
+
+			expect(response.statusCode).toBe(400);
+			expect(findOverrides).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([4.5, 0, -4, Number.MAX_SAFE_INTEGER + 1])(
+		"rejects non-positive-safe bulk profile identity %s before lookup",
+		async (profileId) => {
+			const response = await createInjectAuthenticated(app)(
+				"POST",
+				"/instance-1/quality-profiles/bulk-overrides",
+				{ body: { profileIds: [profileId] } },
+			);
+
+			expect(response.statusCode).toBe(400);
+			expect(findOverrides).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		{ id: 5, name: "Any", mismatch: "id" },
+		{ id: 4, name: "Renamed upstream", mismatch: "name" },
+	])("rejects a live profile with mismatched $mismatch authority", async (liveProfile) => {
+		getProfile.mockReset().mockResolvedValue({
+			id: liveProfile.id,
+			name: liveProfile.name,
+			formatItems: [{ format: 7, score: 100 }],
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(upsertOverride).not.toHaveBeenCalled();
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
 
@@ -357,6 +493,72 @@ describe("instance quality profile score persistence", () => {
 			expect.any(Function),
 		);
 	});
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"uses the stateful %s SDK getById/full-resource PUT contract with exact target IDs",
+		async (service) => {
+			const targetInstance = { ...instance, service };
+			findServiceInstance.mockResolvedValue(targetInstance);
+			findServiceInstances.mockResolvedValue([targetInstance]);
+			findMappings.mockResolvedValue([
+				{
+					id: "mapping-1",
+					templateId: "template-1",
+					instanceId: targetInstance.id,
+					qualityProfileId: 4,
+					qualityProfileName: "Any",
+					connectionGeneration: targetInstance.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(targetInstance),
+				},
+			]);
+			let liveProfile = {
+				id: 4,
+				name: "Any",
+				upgradeAllowed: true,
+				cutoff: 1,
+				minFormatScore: 0,
+				cutoffFormatScore: 100,
+				items: [{ quality: { id: 1, name: "HD" }, allowed: true }],
+				language: { id: 1, name: "English" },
+				formatItems: [
+					{ format: 7, score: 100, name: "Reject" },
+					{ format: 8, score: 50, name: "Keep" },
+				],
+			};
+			getProfile.mockReset().mockImplementation(async (profileId: number) => {
+				expect(profileId).toBe(4);
+				return structuredClone(liveProfile);
+			});
+			updateProfile.mockImplementation(async (profileId: number, payload: typeof liveProfile) => {
+				expect(profileId).toBe(4);
+				liveProfile = structuredClone(payload);
+			});
+
+			const response = await createInjectAuthenticated(app)(
+				"PATCH",
+				"/instance-1/quality-profiles/4/scores",
+				{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+			);
+
+			expect(response.statusCode, response.body).toBe(200);
+			expect(getProfile).toHaveBeenCalledTimes(4);
+			expect(getProfile.mock.calls.every(([profileId]) => profileId === 4)).toBe(true);
+			expect(updateProfile).toHaveBeenCalledWith(4, {
+				id: 4,
+				name: "Any",
+				upgradeAllowed: true,
+				cutoff: 1,
+				minFormatScore: 0,
+				cutoffFormatScore: 100,
+				items: [{ quality: { id: 1, name: "HD" }, allowed: true }],
+				language: { id: 1, name: "English" },
+				formatItems: [
+					{ format: 7, score: -10_000, name: "Reject" },
+					{ format: 8, score: 50, name: "Keep" },
+				],
+			});
+		},
+	);
 
 	it("serializes concurrent saves for equivalent endpoint aliases", async () => {
 		let activeMutation = false;
@@ -522,6 +724,83 @@ describe("instance quality profile score persistence", () => {
 				},
 			],
 		});
+	});
+
+	it.each([
+		{
+			label: "stale SET",
+			intentOperation: "SET_SCORE",
+			connectionGeneration: 1,
+			connectionStateToken: "stale-token",
+		},
+		{
+			label: "legacy RESET",
+			intentOperation: "RESET_SCORE",
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+		},
+	])("reports $label intent as manual-only on single reads", async (intent) => {
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "manual-intent",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "UNCERTAIN",
+				intentOperation: intent.intentOperation,
+				intendedScore: -10_000,
+				connectionGeneration: intent.connectionGeneration,
+				connectionStateToken: intent.connectionStateToken,
+				updatedAt: new Date("2026-08-09T00:00:00Z"),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().recoveryIntents).toEqual([
+			expect.objectContaining({
+				retryable: false,
+				requiresManualReconciliation: true,
+				retryAction: null,
+			}),
+		]);
+	});
+
+	it("reports stale intent consistently as manual-only on bulk reads", async () => {
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "stale-intent",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "PENDING",
+				intentOperation: "SET_SCORE",
+				intendedScore: -10_000,
+				connectionGeneration: 1,
+				connectionStateToken: "stale-token",
+				updatedAt: new Date("2026-08-09T00:00:00Z"),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"POST",
+			"/instance-1/quality-profiles/bulk-overrides",
+			{ body: { profileIds: [4] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().recoveryIntents).toEqual([
+			expect.objectContaining({
+				retryable: false,
+				requiresManualReconciliation: true,
+			}),
+		]);
 	});
 
 	it("fails closed when equivalent aliases expose conflicting applied scores", async () => {

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -847,4 +847,352 @@ describe("instance quality profile score persistence", () => {
 		expect(upsertOverride).not.toHaveBeenCalled();
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
+
+	it("rejects reset when equivalent aliases have conflicting mapping authority", async () => {
+		const alias = { ...instance, id: "instance-alias" };
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({ customFormats: [] }),
+		};
+		const managedCustomFormats = JSON.stringify([
+			{
+				trashId: "trash-7",
+				name: "Reject",
+				resourceId: 7,
+				stateToken: "format-state",
+				profileId: 4,
+				appliedScore: 100,
+			},
+		]);
+		findServiceInstances.mockResolvedValueOnce([instance, alias]);
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-primary",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats,
+				template,
+			},
+			{
+				id: "mapping-alias",
+				templateId: template.id,
+				instanceId: alias.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Different profile",
+				syncStrategy: "manual",
+				connectionGeneration: alias.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(alias),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats,
+				template,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
+
+	it("resets an instance override to the nested TRaSH profile score set", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						originalConfig: { trash_scores: { default: 0, "sqp-1-1080p": -10_000 } },
+					},
+				],
+				qualityProfile: { trash_score_set: "sqp-1-1080p" },
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: "format-state",
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([
+				{
+					id: "override-1",
+					userId,
+					instanceId: instance.id,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					intentOperation: null,
+					intendedScore: null,
+					connectionGeneration: instance.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(instance),
+					updatedAt: new Date("2026-08-09T00:00:00Z"),
+				},
+			]);
+		findUniqueOverride.mockResolvedValueOnce({
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+		});
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const after = { ...before, formatItems: [{ format: 7, score: -10_000 }] };
+		getProfile
+			.mockReset()
+			.mockResolvedValueOnce(before)
+			.mockResolvedValueOnce(before)
+			.mockResolvedValue(after);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().revertedScore).toBe(-10_000);
+		expect(updateProfile).toHaveBeenCalledWith(
+			4,
+			expect.objectContaining({
+				formatItems: [expect.objectContaining({ format: 7, score: -10_000 })],
+			}),
+		);
+		expect(updateOverrides.mock.invocationCallOrder[0]).toBeLessThan(
+			updateProfile.mock.invocationCallOrder[0]!,
+		);
+		expect(deleteOverrides.mock.invocationCallOrder[0]).toBeGreaterThan(
+			updateProfile.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it("restores an applied reset intent when the profile changes before the ARR write", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			configData: JSON.stringify({
+				customFormats: [
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						originalConfig: { trash_scores: { default: 0 } },
+					},
+				],
+			}),
+		};
+		findMappings.mockResolvedValueOnce([
+			{
+				id: "mapping-1",
+				templateId: template.id,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				qualityProfileName: "Any",
+				syncStrategy: "manual",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				managedCustomFormatsCaptured: true,
+				managedCustomFormats: JSON.stringify([
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						resourceId: 7,
+						stateToken: "format-state",
+						profileId: 4,
+						appliedScore: 100,
+					},
+				]),
+				template,
+			},
+		]);
+		const originalUpdatedAt = new Date("2026-08-09T00:00:00Z");
+		const override = {
+			id: "override-1",
+			userId,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			intentOperation: null,
+			intendedScore: null,
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			updatedAt: originalUpdatedAt,
+		};
+		findOverrides
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([override]);
+		findUniqueOverride.mockResolvedValueOnce(override);
+		const before = { id: 4, name: "Any", formatItems: [{ format: 7, score: 100 }] };
+		const changed = { ...before, formatItems: [{ format: 7, score: 200 }] };
+		getProfile.mockReset().mockResolvedValueOnce(before).mockResolvedValueOnce(changed);
+
+		const response = await createInjectAuthenticated(app)(
+			"DELETE",
+			"/instance-1/quality-profiles/4/overrides/7",
+		);
+
+		expect(response.statusCode, response.body).toBe(409);
+		expect(updateProfile).not.toHaveBeenCalled();
+		expect(updateOverrides).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ id: override.id, status: "PENDING" }),
+				data: {
+					status: "APPLIED",
+					intentOperation: null,
+					intendedScore: null,
+					updatedAt: originalUpdatedAt,
+				},
+			}),
+		);
+		expect(deleteOverrides).not.toHaveBeenCalled();
+	});
+
+	it("promotes only an applied override bound through managed TRaSH identity", async () => {
+		const template = {
+			id: "template-1",
+			userId,
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+			configData: JSON.stringify({
+				customFormats: [
+					{
+						trashId: "trash-7",
+						name: "Reject",
+						originalConfig: { _instanceCFId: 9001 },
+					},
+				],
+			}),
+		};
+		const mapping = {
+			id: "mapping-1",
+			templateId: template.id,
+			instanceId: instance.id,
+			qualityProfileId: 4,
+			qualityProfileName: "Any",
+			connectionGeneration: instance.connectionGeneration,
+			connectionStateToken: createDeploymentConnectionStateToken(instance),
+			managedCustomFormatsCaptured: true,
+			managedCustomFormats: JSON.stringify([
+				{
+					trashId: "trash-7",
+					name: "Reject",
+					resourceId: 7,
+					stateToken: "format-state",
+					profileId: 4,
+					appliedScore: 100,
+				},
+			]),
+			updatedAt: new Date("2026-08-09T00:00:00Z"),
+			template,
+		};
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "override-1",
+				userId,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "APPLIED",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				updatedAt: new Date("2026-08-09T00:00:00Z"),
+			},
+		]);
+		findMappings.mockResolvedValueOnce([mapping]);
+		findTransactionMappings.mockResolvedValueOnce([mapping]);
+		deleteAliasOverrides.mockResolvedValueOnce({ count: 1 });
+
+		const response = await createInjectAuthenticated(app)(
+			"POST",
+			"/instance-1/quality-profiles/4/promote-override",
+			{ body: { customFormatId: 7, templateId: "template-1" } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(updateTemplates).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					configData: expect.stringContaining('"scoreOverride":-10000'),
+				}),
+			}),
+		);
+	});
+
+	it("refuses to promote an unresolved score intent", async () => {
+		findOverrides.mockResolvedValueOnce([
+			{
+				id: "override-1",
+				userId,
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				score: -10_000,
+				status: "UNCERTAIN",
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken: createDeploymentConnectionStateToken(instance),
+				updatedAt: new Date("2026-08-09T00:00:00Z"),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"POST",
+			"/instance-1/quality-profiles/4/promote-override",
+			{ body: { customFormatId: 7, templateId: "template-1" } },
+		);
+
+		expect(response.statusCode).toBe(409);
+		expect(updateTemplates).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		[
+			"POST",
+			"/instance-1/quality-profiles/4.5/promote-override",
+			{ customFormatId: 7, templateId: "template-1" },
+		],
+		["DELETE", "/instance-1/quality-profiles/4.5/overrides/7", undefined],
+		["DELETE", "/instance-1/quality-profiles/4/overrides/7.5", undefined],
+		["POST", "/instance-1/quality-profiles/4/overrides/bulk-delete", undefined],
+	] as const)("rejects invalid mutation input for %s %s", async (method, url, body) => {
+		const response = await createInjectAuthenticated(app)(method, url, body ? { body } : undefined);
+
+		expect(response.statusCode).toBe(400);
+		expect(updateProfile).not.toHaveBeenCalled();
+	});
 });

--- a/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
@@ -42,6 +42,14 @@ let instanceService: "RADARR" | "SONARR" = "RADARR";
 let instanceEncryptedApiKey = "encrypted-key-a";
 let upstreamCustomFormatName = "Reviewed CF";
 let upstreamCustomFormatSpecifications: unknown[] = [{ name: "Source", value: "WEB-DL" }];
+let upstreamFormatItems: Array<{ format: number; score: number }> = [
+	{ format: 42, score: 100 },
+];
+let upstreamCustomFormats: Array<{
+	id: number;
+	name: string;
+	specifications: unknown[];
+}> | null = null;
 
 function createClient() {
 	const Client = instanceService === "RADARR" ? clients.MockRadarrClient : clients.MockSonarrClient;
@@ -54,19 +62,21 @@ function createClient() {
 				cutoff: 1,
 				minFormatScore: 0,
 				cutoffFormatScore: 0,
-				formatItems: [{ format: 42, score: 100 }],
+				formatItems: upstreamFormatItems,
 				items: [],
 			}),
 		},
 		customFormat: {
-			getAll: vi.fn().mockImplementation(async () => [
-				{
-					id: 42,
-					name: upstreamCustomFormatName,
-					specifications: upstreamCustomFormatSpecifications,
-					includeCustomFormatWhenRenaming: false,
-				},
-			]),
+			getAll: vi.fn().mockImplementation(async () =>
+				upstreamCustomFormats ?? [
+					{
+						id: 42,
+						name: upstreamCustomFormatName,
+						specifications: upstreamCustomFormatSpecifications,
+						includeCustomFormatWhenRenaming: false,
+					},
+				],
+			),
 		},
 	});
 }
@@ -102,6 +112,8 @@ describe("profile clone source authority", () => {
 		instanceEncryptedApiKey = "encrypted-key-a";
 		upstreamCustomFormatName = "Reviewed CF";
 		upstreamCustomFormatSpecifications = [{ name: "Source", value: "WEB-DL" }];
+		upstreamFormatItems = [{ format: 42, score: 100 }];
+		upstreamCustomFormats = null;
 		mocks.cacheGet.mockResolvedValue([]);
 		mocks.getCommitHash.mockResolvedValue("commit-1");
 		mocks.createTemplate.mockResolvedValue({ id: "template-1" });
@@ -168,6 +180,42 @@ describe("profile clone source authority", () => {
 							sourceProfileId: 7,
 							sourceProfileName: "Any",
 						}),
+					}),
+				}),
+			);
+		},
+	);
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"preserves the %s source score for Keep Instance",
+		async (serviceType) => {
+			instanceService = serviceType;
+			upstreamFormatItems = [{ format: 42, score: -10_000 }];
+			upstreamCustomFormats = [
+				{ id: 42, name: "Language: Not English", specifications: [] },
+			];
+			const sourceStateToken = await getSourceStateToken();
+
+			const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+				body: {
+					...requestBody(serviceType, sourceStateToken),
+					customFormatSelections: {
+						"instance-42": { selected: true, conditionsEnabled: {} },
+					},
+				},
+			});
+
+			expect(response.statusCode).toBe(201);
+			expect(mocks.createTemplate).toHaveBeenCalledWith(
+				"user-1",
+				expect.objectContaining({
+					config: expect.objectContaining({
+						customFormats: [
+							expect.objectContaining({
+								trashId: "instance-42",
+								scoreOverride: -10_000,
+							}),
+						],
 					}),
 				}),
 			);

--- a/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
@@ -186,14 +186,17 @@ describe("profile clone source authority", () => {
 		},
 	);
 
-	it.each(["RADARR", "SONARR"] as const)(
-		"preserves the %s source score for Keep Instance",
-		async (serviceType) => {
+	it.each([
+		["RADARR", -10_000],
+		["SONARR", -10_000],
+		["RADARR", 0],
+		["SONARR", 0],
+	] as const)(
+		"preserves the %s source score %s for Keep Instance",
+		async (serviceType, sourceScore) => {
 			instanceService = serviceType;
-			upstreamFormatItems = [{ format: 42, score: -10_000 }];
-			upstreamCustomFormats = [
-				{ id: 42, name: "Language: Not English", specifications: [] },
-			];
+			upstreamFormatItems = [{ format: 42, score: sourceScore }];
+			upstreamCustomFormats = [{ id: 42, name: "Language: Not English", specifications: [] }];
 			const sourceStateToken = await getSourceStateToken();
 
 			const response = await createInjectAuthenticated(app)("POST", "/create-template", {
@@ -213,12 +216,115 @@ describe("profile clone source authority", () => {
 						customFormats: [
 							expect.objectContaining({
 								trashId: "instance-42",
-								scoreOverride: -10_000,
+								scoreOverride: sourceScore,
 							}),
 						],
 					}),
 				}),
 			);
+		},
+	);
+
+	it.each([
+		{
+			label: "name",
+			mutate: () => {
+				upstreamCustomFormats = [
+					{ id: 42, name: "Renamed upstream", specifications: [{ name: "Not English" }] },
+				];
+			},
+		},
+		{
+			label: "specification",
+			mutate: () => {
+				upstreamCustomFormats = [
+					{ id: 42, name: "Language", specifications: [{ name: "Changed specification" }] },
+				];
+			},
+		},
+	])("rejects creation when a reviewed selected CF $label changes", async ({ mutate }) => {
+		upstreamFormatItems = [{ format: 42, score: 0 }];
+		upstreamCustomFormats = [
+			{ id: 42, name: "Language", specifications: [{ name: "Not English" }] },
+		];
+		const sourceStateToken = await getSourceStateToken();
+		mutate();
+
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: {
+				...requestBody("RADARR", sourceStateToken),
+				customFormatSelections: {
+					"instance-42": { selected: true, conditionsEnabled: {} },
+				},
+			},
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ label: "duplicate", formats: [42, 42] },
+		{ label: "fractional", formats: [4.5] },
+		{ label: "zero", formats: [0] },
+		{ label: "negative", formats: [-4] },
+		{ label: "unsafe", formats: [Number.MAX_SAFE_INTEGER + 1] },
+	])("rejects $label upstream Custom Format IDs before template creation", async ({ formats }) => {
+		upstreamFormatItems = [{ format: 42, score: 0 }];
+		upstreamCustomFormats = [{ id: 42, name: "Language", specifications: [] }];
+		const sourceStateToken = await getSourceStateToken();
+		upstreamCustomFormats = formats.map((id, index) => ({
+			id,
+			name: `Format ${index}`,
+			specifications: [],
+		}));
+
+		const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+			body: requestBody("RADARR", sourceStateToken),
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(mocks.createTemplate).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{
+			label: "duplicate",
+			formatItems: [
+				{ format: 42, score: 0 },
+				{ format: 42, score: 100 },
+			],
+		},
+		{ label: "fractional", formatItems: [{ format: 4.5, score: 0 }] },
+		{ label: "zero", formatItems: [{ format: 0, score: 0 }] },
+		{ label: "negative", formatItems: [{ format: -4, score: 0 }] },
+		{ label: "unsafe", formatItems: [{ format: Number.MAX_SAFE_INTEGER + 1, score: 0 }] },
+	])("rejects $label profile format IDs during source review", async ({ formatItems }) => {
+		upstreamFormatItems = formatItems;
+		upstreamCustomFormats = [{ id: 42, name: "Language", specifications: [] }];
+
+		const response = await createInjectAuthenticated(app)("GET", "/profile-details/instance-1/7");
+
+		expect(response.statusCode).toBe(409);
+	});
+
+	it("rejects source review when ARR returns a different profile ID", async () => {
+		upstreamProfileId = 8;
+
+		const response = await createInjectAuthenticated(app)("GET", "/profile-details/instance-1/7");
+
+		expect(response.statusCode).toBe(409);
+	});
+
+	it.each([0, -7, Number.MAX_SAFE_INTEGER + 1])(
+		"rejects invalid requested source profile ID %s before lookup",
+		async (sourceProfileId) => {
+			const response = await createInjectAuthenticated(app)("POST", "/create-template", {
+				body: { ...requestBody("RADARR", "0".repeat(64)), sourceProfileId },
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(mocks.createTemplate).not.toHaveBeenCalled();
 		},
 	);
 

--- a/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/profile-clone-routes.test.ts
@@ -42,9 +42,7 @@ let instanceService: "RADARR" | "SONARR" = "RADARR";
 let instanceEncryptedApiKey = "encrypted-key-a";
 let upstreamCustomFormatName = "Reviewed CF";
 let upstreamCustomFormatSpecifications: unknown[] = [{ name: "Source", value: "WEB-DL" }];
-let upstreamFormatItems: Array<{ format: number; score: number }> = [
-	{ format: 42, score: 100 },
-];
+let upstreamFormatItems: Array<{ format: number; score: number }> = [{ format: 42, score: 100 }];
 let upstreamCustomFormats: Array<{
 	id: number;
 	name: string;
@@ -67,15 +65,16 @@ function createClient() {
 			}),
 		},
 		customFormat: {
-			getAll: vi.fn().mockImplementation(async () =>
-				upstreamCustomFormats ?? [
-					{
-						id: 42,
-						name: upstreamCustomFormatName,
-						specifications: upstreamCustomFormatSpecifications,
-						includeCustomFormatWhenRenaming: false,
-					},
-				],
+			getAll: vi.fn().mockImplementation(
+				async () =>
+					upstreamCustomFormats ?? [
+						{
+							id: 42,
+							name: upstreamCustomFormatName,
+							specifications: upstreamCustomFormatSpecifications,
+							includeCustomFormatWhenRenaming: false,
+						},
+					],
 			),
 		},
 	});

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -218,6 +218,293 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		return { instance, aliases, equivalentInstanceIds, connectionReadBindings };
 	}
 
+	async function resetScoreOverrides(
+		userId: string,
+		instanceId: string,
+		profileId: number,
+		requestedCustomFormatIds: number[],
+	) {
+		const customFormatIds = [...new Set(requestedCustomFormatIds)];
+		if (customFormatIds.length !== requestedCustomFormatIds.length) {
+			throw new AppValidationError("Each Custom Format can only be reset once per request.");
+		}
+		const initialContext = await getEquivalentConnectionContext(userId, instanceId);
+		if (!initialContext) throw new AppValidationError("Instance not found or access denied");
+
+		return runWithCoordinatedEndpointMutation(
+			userId,
+			initialContext.instance,
+			"Quality profile override reset",
+			async (endpointKey) => {
+				const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
+				if (
+					!connectionContext ||
+					createDeploymentEndpointKey(userId, connectionContext.instance) !== endpointKey ||
+					createDeploymentConnectionStateToken(connectionContext.instance) !==
+						createDeploymentConnectionStateToken(initialContext.instance)
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while the override reset was starting.",
+					);
+				}
+				const connectionBindings = connectionContext.connectionReadBindings;
+				const mappings = await app.prisma.templateQualityProfileMapping.findMany({
+					where: {
+						qualityProfileId: profileId,
+						OR: connectionBindings,
+						template: { userId },
+					},
+					include: { template: true },
+					orderBy: { updatedAt: "desc" },
+				});
+				assertNoLegacyDeploymentConnectionMappings(mappings);
+				assertCurrentConnectionRows(mappings, connectionBindings, "template mapping");
+				const templateIds = new Set(mappings.map((mapping) => mapping.templateId));
+				if (mappings.length === 0 || templateIds.size !== 1) {
+					throw new ConflictError(
+						"The quality profile does not have one current template mapping for this ARR connection.",
+					);
+				}
+				const mapping = mappings[0]!;
+				if (
+					mappings.some(
+						(candidate) =>
+							candidate.qualityProfileName !== mapping.qualityProfileName ||
+							candidate.syncStrategy !== mapping.syncStrategy ||
+							candidate.managedCustomFormatsCaptured !== mapping.managedCustomFormatsCaptured ||
+							candidate.managedCustomFormats !== mapping.managedCustomFormats,
+					)
+				) {
+					throw new ConflictError(
+						"Equivalent ARR aliases have conflicting quality-profile mapping authority.",
+					);
+				}
+				const managedFormats = readPersistedManagedCustomFormatIdentities(mapping);
+				const trashIdByResourceId = new Map(
+					managedFormats.map((format) => [format.resourceId, format.trashId]),
+				);
+				let templateConfig: ParsedTemplateConfig;
+				try {
+					templateConfig = JSON.parse(mapping.template.configData) as ParsedTemplateConfig;
+				} catch (error) {
+					throw new AppValidationError(
+						`Template configuration is invalid: ${getErrorMessage(error)}`,
+					);
+				}
+
+				const pendingResetIntents = await app.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						userId,
+						instanceId: { in: connectionContext.equivalentInstanceIds },
+						qualityProfileId: profileId,
+						customFormatId: { in: customFormatIds },
+						status: { in: ["PENDING", "UNCERTAIN"] },
+					},
+					select: {
+						id: true,
+						instanceId: true,
+						connectionGeneration: true,
+						connectionStateToken: true,
+						customFormatId: true,
+						intentOperation: true,
+						intendedScore: true,
+					},
+				});
+				assertCurrentConnectionRows(pendingResetIntents, connectionBindings, "score reset intent");
+				const persistedResetScores = new Map<number, number>();
+				for (const intent of pendingResetIntents) {
+					if (intent.intentOperation !== "RESET_SCORE" || intent.intendedScore === null) {
+						throw new ConflictError(
+							"A different score write is unresolved for this profile. Retry or reconcile it first.",
+						);
+					}
+					const previous = persistedResetScores.get(intent.customFormatId);
+					if (previous !== undefined && previous !== intent.intendedScore) {
+						throw new ConflictError(
+							"Equivalent aliases contain conflicting reset intent for this Custom Format.",
+						);
+					}
+					persistedResetScores.set(intent.customFormatId, intent.intendedScore);
+				}
+				const templateScores = new Map(
+					customFormatIds.map((customFormatId) => [
+						customFormatId,
+						persistedResetScores.has(customFormatId)
+							? { score: persistedResetScores.get(customFormatId)!, inTemplate: true }
+							: getTemplateScore(
+									templateConfig,
+									customFormatId,
+									trashIdByResourceId.get(customFormatId),
+								),
+					]),
+				);
+				await assertNoPendingDeploymentOperation(
+					app.prisma,
+					userId,
+					connectionContext.equivalentInstanceIds,
+					{
+						qualityProfileId: profileId,
+						operation: "RESET_SCORE",
+						scoreUpdates: customFormatIds.map((customFormatId) => ({
+							customFormatId,
+							score: templateScores.get(customFormatId)!.score,
+						})),
+						connectionBindings,
+					},
+				);
+				const overrides = await app.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						userId,
+						qualityProfileId: profileId,
+						customFormatId: { in: customFormatIds },
+						status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
+						OR: connectionBindings,
+					},
+				});
+				assertCurrentConnectionRows(overrides, connectionBindings, "saved score override");
+				if (
+					customFormatIds.some(
+						(customFormatId) =>
+							overrides.filter((override) => override.customFormatId === customFormatId).length ===
+							0,
+					)
+				) {
+					throw new ConflictError(
+						"One or more overrides changed or are not bound to the current ARR connection. Refresh and try again.",
+					);
+				}
+
+				const intentAt = new Date();
+				await app.prisma.$transaction(async (transaction) => {
+					for (const override of overrides) {
+						const write = await transaction.instanceQualityProfileOverride.updateMany({
+							where: {
+								id: override.id,
+								updatedAt: override.updatedAt,
+								status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
+							},
+							data: {
+								status: "PENDING",
+								intentOperation: "RESET_SCORE",
+								intendedScore: templateScores.get(override.customFormatId)!.score,
+								updatedAt: intentAt,
+							},
+						});
+						if (write.count !== 1) {
+							throw new ConflictError(
+								"One or more overrides changed while the reset intent was being saved. Refresh and try again.",
+							);
+						}
+					}
+				});
+
+				const pendingResetWhere = {
+					userId,
+					status: "PENDING",
+					OR: overrides.map((override) => ({ id: override.id, updatedAt: intentAt })),
+				} as const;
+				let writeAttempted = false;
+				try {
+					const client = app.arrClientFactory.create(connectionContext.instance) as
+						| SonarrClient
+						| RadarrClient;
+					const profile = await client.qualityProfile.getById(profileId);
+					assertExactLiveProfile(profile, profileId, mapping.qualityProfileName);
+					for (const customFormatId of customFormatIds) {
+						const matches = (profile.formatItems ?? []).filter(
+							(item) => item.format === customFormatId,
+						);
+						if (matches.length !== 1) {
+							throw new ConflictError(
+								"The selected Custom Format is missing or duplicated in the live quality profile.",
+							);
+						}
+					}
+					const reviewedProfileToken = createQualityProfileStateToken(profile);
+					const updatedProfile = {
+						...profile,
+						formatItems: (profile.formatItems ?? []).map((item) => {
+							const reset = item.format === undefined ? undefined : templateScores.get(item.format);
+							return reset ? { ...item, score: reset.score } : item;
+						}),
+					};
+					const freshProfile = await client.qualityProfile.getById(profileId);
+					assertExactLiveProfile(freshProfile, profileId, mapping.qualityProfileName);
+					if (createQualityProfileStateToken(freshProfile) !== reviewedProfileToken) {
+						throw new ConflictError(
+							"The quality profile changed while the override reset was being prepared. Refresh and try again.",
+						);
+					}
+					writeAttempted = true;
+					// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
+					await client.qualityProfile.update(profileId, updatedProfile as any);
+					const postWriteProfile = await client.qualityProfile.getById(profileId);
+					assertExactLiveProfile(postWriteProfile, profileId, mapping.qualityProfileName);
+					for (const [customFormatId, reset] of templateScores) {
+						const matches = (postWriteProfile.formatItems ?? []).filter(
+							(item) => item.format === customFormatId,
+						);
+						if (matches.length !== 1 || matches[0]!.score !== reset.score) {
+							throw new ConflictError(
+								"ARR accepted the profile update, but the reset scores could not be verified. Saved overrides were retained for retry.",
+							);
+						}
+					}
+				} catch (error) {
+					try {
+						if (writeAttempted) {
+							await app.prisma.instanceQualityProfileOverride.updateMany({
+								where: pendingResetWhere,
+								data: { status: "UNCERTAIN" },
+							});
+						} else {
+							await app.prisma.$transaction(async (transaction) => {
+								for (const override of overrides) {
+									const restored = await transaction.instanceQualityProfileOverride.updateMany({
+										where: {
+											id: override.id,
+											userId,
+											status: "PENDING",
+											updatedAt: intentAt,
+										},
+										data: {
+											status: override.status,
+											intentOperation: override.intentOperation,
+											intendedScore: override.intendedScore,
+											updatedAt: override.updatedAt,
+										},
+									});
+									if (restored.count !== 1) {
+										throw new ConflictError(
+											"The reset was not sent to ARR, but its saved override state changed before it could be restored.",
+										);
+									}
+								}
+							});
+						}
+					} catch (intentError) {
+						app.log.error(
+							{ err: intentError, instanceId, profileId },
+							writeAttempted
+								? "Failed to mark an uncertain quality-profile reset intent"
+								: "Failed to restore a quality-profile reset intent that was not sent upstream",
+						);
+					}
+					throw error;
+				}
+				const deleted = await app.prisma.instanceQualityProfileOverride.deleteMany({
+					where: pendingResetWhere,
+				});
+				if (deleted.count !== overrides.length) {
+					throw new ConflictError(
+						"Scores were reset upstream, but one or more saved overrides changed concurrently and were retained.",
+					);
+				}
+				return { deletedCount: customFormatIds.length, templateScores };
+			},
+		);
+	}
+
 	/**
 	 * PATCH /api/trash-guides/instances/:instanceId/quality-profiles/:profileId/scores
 	 * Update custom format scores for a quality profile

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -9,7 +9,6 @@ import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { AppValidationError, ConflictError } from "../../lib/errors.js";
 import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
-import { readPersistedManagedCustomFormatIdentities } from "../../lib/trash-guides/deployment-managed-format-state.js";
 import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deployment-operation-gate.js";
 import {
 	assertNoLegacyDeploymentConnectionMappings,
@@ -18,6 +17,7 @@ import {
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	getEquivalentServiceInstanceIds,
+	isCurrentDeploymentConnectionMapping,
 } from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -42,7 +42,7 @@ interface ParsedTemplateCustomFormat {
 /** Parsed template configuration data structure */
 interface ParsedTemplateConfig {
 	customFormats?: ParsedTemplateCustomFormat[];
-	qualityProfile?: { trash_score_set?: string };
+	scoreSet?: string;
 	[key: string]: unknown;
 }
 
@@ -74,37 +74,75 @@ const updateScoresSchema = z.object({
 		}),
 });
 
-const bulkDeleteOverridesSchema = z.object({
-	customFormatIds: z.array(z.number().int().positive().safe()).min(1).max(500),
+const bulkOverridesSchema = z.object({
+	profileIds: z.array(z.number().int().positive().safe()).min(1),
 });
 
-const promoteOverrideSchema = z.object({
-	customFormatId: z.number().int().positive().safe(),
-	templateId: z.string().min(1),
-});
+function parsePositiveSafeIntegerParam(value: string): number | null {
+	if (!/^[1-9]\d*$/.test(value)) return null;
+	const parsed = Number(value);
+	return Number.isSafeInteger(parsed) ? parsed : null;
+}
 
-function getTemplateScore(
-	config: ParsedTemplateConfig,
-	customFormatId: number,
-	trashId?: string,
-): { score: number; inTemplate: boolean } {
-	const templateCf = config.customFormats?.find(
-		(cf) =>
-			(trashId !== undefined && cf.trashId === trashId) ||
-			cf.originalConfig?._instanceCFId === customFormatId,
-	);
-	if (!templateCf) return { score: 0, inTemplate: false };
-	if (templateCf.scoreOverride !== undefined) {
-		return { score: templateCf.scoreOverride, inTemplate: true };
+function assertCurrentConnectionRows(
+	rows: Array<{
+		instanceId: string;
+		connectionGeneration?: number | null;
+		connectionStateToken?: string | null;
+	}>,
+	bindings: Parameters<typeof isCurrentDeploymentConnectionMapping>[1],
+	recordLabel: string,
+): void {
+	if (rows.some((row) => !isCurrentDeploymentConnectionMapping(row, bindings))) {
+		throw new ConflictError(
+			`An equivalent ARR alias has a stale ${recordLabel} for this quality profile. Reconcile the alias before changing scores.`,
+		);
 	}
-	const scoreSet = config.qualityProfile?.trash_score_set;
-	const scoreSetValue = scoreSet ? templateCf.originalConfig?.trash_scores?.[scoreSet] : undefined;
-	if (scoreSetValue !== undefined) {
-		return { score: scoreSetValue, inTemplate: true };
+}
+
+function assertExactLiveProfile(
+	profile: { id?: number; name?: string | null },
+	requestedProfileId: number,
+	expectedProfileName?: string,
+): void {
+	if (!Number.isSafeInteger(profile.id) || profile.id !== requestedProfileId) {
+		throw new ConflictError(
+			"ARR returned a different quality profile identity than the requested profile.",
+		);
 	}
+	if (expectedProfileName !== undefined && profile.name !== expectedProfileName) {
+		throw new ConflictError(
+			"The mapped quality profile name no longer matches the live ARR profile.",
+		);
+	}
+}
+
+function describeRecoveryIntent(
+	override: {
+		instanceId: string;
+		qualityProfileId: number;
+		customFormatId: number;
+		intentOperation: string | null;
+		intendedScore: number | null;
+		status: string;
+		connectionGeneration?: number | null;
+		connectionStateToken?: string | null;
+	},
+	bindings: Parameters<typeof isCurrentDeploymentConnectionMapping>[1],
+) {
+	const retryable =
+		isCurrentDeploymentConnectionMapping(override, bindings) &&
+		override.intentOperation === "SET_SCORE" &&
+		override.intendedScore !== null;
 	return {
-		score: templateCf.originalConfig?.trash_scores?.default ?? 0,
-		inTemplate: true,
+		qualityProfileId: override.qualityProfileId,
+		customFormatId: override.customFormatId,
+		operation: override.intentOperation,
+		intendedScore: override.intendedScore,
+		status: override.status,
+		retryable,
+		requiresManualReconciliation: !retryable,
+		retryAction: retryable ? { method: "PATCH" as const, score: override.intendedScore! } : null,
 	};
 }
 
@@ -180,269 +218,6 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		return { instance, aliases, equivalentInstanceIds, connectionReadBindings };
 	}
 
-	async function resetScoreOverrides(
-		userId: string,
-		instanceId: string,
-		profileId: number,
-		requestedCustomFormatIds: number[],
-	) {
-		const customFormatIds = [...new Set(requestedCustomFormatIds)];
-		if (customFormatIds.length !== requestedCustomFormatIds.length) {
-			throw new AppValidationError("Each Custom Format can only be reset once per request.");
-		}
-		const selectConnection = {
-			id: true,
-			baseUrl: true,
-			service: true,
-			encryptedApiKey: true,
-			encryptionIv: true,
-			encryptedHttpAuthCredentials: true,
-			httpAuthEncryptionIv: true,
-			connectionGeneration: true,
-		} as const;
-		const instance = await app.prisma.serviceInstance.findFirst({
-			where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
-			select: selectConnection,
-		});
-		if (!instance) throw new AppValidationError("Instance not found or access denied");
-
-		return runWithCoordinatedEndpointMutation(
-			userId,
-			instance,
-			"Quality profile override reset",
-			async (endpointKey) => {
-				const currentInstance = await app.prisma.serviceInstance.findFirst({
-					where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
-					select: selectConnection,
-				});
-				if (
-					!currentInstance ||
-					createDeploymentEndpointKey(userId, currentInstance) !== endpointKey
-				) {
-					throw new ConflictError(
-						"The ARR service connection changed while the override reset was starting.",
-					);
-				}
-				const aliases = await app.prisma.serviceInstance.findMany({
-					where: { userId, service: currentInstance.service },
-					select: selectConnection,
-				});
-				const credentialIdentity =
-					app.arrClientFactory.createConnectionCredentialIdentity(currentInstance);
-				const equivalentInstanceIds = getEquivalentServiceInstanceIds(
-					aliases.map((alias) => ({
-						...alias,
-						credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(alias),
-					})),
-					{ ...currentInstance, credentialIdentity },
-				);
-				if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
-				const connectionBindings = aliases
-					.filter((alias) => equivalentInstanceIds.includes(alias.id))
-					.flatMap(createDeploymentConnectionBindingCandidates);
-
-				const mappings = await app.prisma.templateQualityProfileMapping.findMany({
-					where: {
-						qualityProfileId: profileId,
-						OR: connectionBindings,
-						template: { userId },
-					},
-					include: { template: true },
-					orderBy: { updatedAt: "desc" },
-				});
-				assertNoLegacyDeploymentConnectionMappings(mappings);
-				const templateIds = new Set(mappings.map((mapping) => mapping.templateId));
-				if (mappings.length === 0 || templateIds.size !== 1) {
-					throw new ConflictError(
-						"The quality profile does not have one current template mapping for this ARR connection.",
-					);
-				}
-				const mapping = mappings[0]!;
-				const managedFormats = readPersistedManagedCustomFormatIdentities(mapping);
-				const trashIdByResourceId = new Map(
-					managedFormats.map((format) => [format.resourceId, format.trashId]),
-				);
-				let templateConfig: ParsedTemplateConfig;
-				try {
-					templateConfig = JSON.parse(mapping.template.configData) as ParsedTemplateConfig;
-				} catch (error) {
-					throw new AppValidationError(
-						`Template configuration is invalid: ${getErrorMessage(error)}`,
-					);
-				}
-				const pendingResetIntents = await app.prisma.instanceQualityProfileOverride.findMany({
-					where: {
-						userId,
-						instanceId: { in: equivalentInstanceIds },
-						qualityProfileId: profileId,
-						customFormatId: { in: customFormatIds },
-						status: { in: ["PENDING", "UNCERTAIN"] },
-					},
-					select: {
-						id: true,
-						instanceId: true,
-						connectionGeneration: true,
-						connectionStateToken: true,
-						customFormatId: true,
-						intentOperation: true,
-						intendedScore: true,
-					},
-				});
-				const currentBindingKeys = new Set(
-					connectionBindings.map(
-						(binding) =>
-							`${binding.instanceId}:${binding.connectionGeneration}:${binding.connectionStateToken}`,
-					),
-				);
-				if (
-					pendingResetIntents.some(
-						(intent) =>
-							!currentBindingKeys.has(
-								`${intent.instanceId}:${intent.connectionGeneration}:${intent.connectionStateToken}`,
-							),
-					)
-				) {
-					throw new ConflictError(
-						"A saved score reset belongs to an older ARR connection. Retry or resolve it before resetting current overrides.",
-					);
-				}
-				const persistedResetScores = new Map(
-					pendingResetIntents.flatMap((intent) =>
-						intent.intentOperation === "RESET_SCORE" && intent.intendedScore !== null
-							? [[intent.customFormatId, intent.intendedScore] as const]
-							: [],
-					),
-				);
-				const templateScores = new Map(
-					customFormatIds.map((customFormatId) => [
-						customFormatId,
-						persistedResetScores.has(customFormatId)
-							? { score: persistedResetScores.get(customFormatId)!, inTemplate: true }
-							: getTemplateScore(
-									templateConfig,
-									customFormatId,
-									trashIdByResourceId.get(customFormatId),
-								),
-					]),
-				);
-				await assertNoPendingDeploymentOperation(app.prisma, userId, equivalentInstanceIds, {
-					qualityProfileId: profileId,
-					operation: "RESET_SCORE",
-					scoreUpdates: customFormatIds.map((customFormatId) => ({
-						customFormatId,
-						score: templateScores.get(customFormatId)!.score,
-					})),
-					connectionBindings,
-				});
-				const overrides = await app.prisma.instanceQualityProfileOverride.findMany({
-					where: {
-						userId,
-						qualityProfileId: profileId,
-						customFormatId: { in: customFormatIds },
-						status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
-						OR: connectionBindings,
-					},
-				});
-				if (overrides.length !== customFormatIds.length) {
-					throw new ConflictError(
-						"One or more overrides changed or are not bound to the current ARR connection. Refresh and try again.",
-					);
-				}
-				const intentAt = new Date();
-				try {
-					await app.prisma.$transaction(async (transaction) => {
-						for (const override of overrides) {
-							const write = await transaction.instanceQualityProfileOverride.updateMany({
-								where: {
-									id: override.id,
-									updatedAt: override.updatedAt,
-									status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
-								},
-								data: {
-									status: "PENDING",
-									intentOperation: "RESET_SCORE",
-									intendedScore: templateScores.get(override.customFormatId)!.score,
-									updatedAt: intentAt,
-								},
-							});
-							if (write.count !== 1) {
-								throw new ConflictError(
-									"One or more overrides changed while the reset intent was being saved. Refresh and try again.",
-								);
-							}
-						}
-					});
-				} catch (error) {
-					if (error instanceof ConflictError) throw error;
-					throw new ConflictError(
-						"The score reset intents could not be saved atomically. Refresh and try again.",
-					);
-				}
-
-				const client = app.arrClientFactory.create(currentInstance) as SonarrClient | RadarrClient;
-				const profile = await client.qualityProfile.getById(profileId);
-				const reviewedProfileToken = createQualityProfileStateToken(profile);
-				const updatedProfile = {
-					...profile,
-					formatItems: (profile.formatItems ?? []).map((item) => {
-						const reset = item.format === undefined ? undefined : templateScores.get(item.format);
-						return reset ? { ...item, score: reset.score } : item;
-					}),
-				};
-				const freshProfile = await client.qualityProfile.getById(profileId);
-				if (createQualityProfileStateToken(freshProfile) !== reviewedProfileToken) {
-					throw new ConflictError(
-						"The quality profile changed while the override reset was being prepared. Refresh and try again.",
-					);
-				}
-				try {
-					// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
-					await client.qualityProfile.update(profileId, updatedProfile as any);
-					const postWriteProfile = await client.qualityProfile.getById(profileId);
-					for (const [customFormatId, reset] of templateScores) {
-						const actual =
-							postWriteProfile.formatItems?.find((item) => item.format === customFormatId)?.score ??
-							0;
-						if (actual !== reset.score) {
-							throw new ConflictError(
-								"ARR accepted the profile update, but the reset scores could not be verified. Saved overrides were retained for retry.",
-							);
-						}
-					}
-				} catch (error) {
-					try {
-						await app.prisma.instanceQualityProfileOverride.updateMany({
-							where: {
-								userId,
-								status: "PENDING",
-								OR: overrides.map((override) => ({ id: override.id, updatedAt: intentAt })),
-							},
-							data: { status: "UNCERTAIN" },
-						});
-					} catch (intentError) {
-						app.log.error(
-							{ err: intentError, instanceId, profileId },
-							"Failed to mark an uncertain quality-profile reset intent",
-						);
-					}
-					throw error;
-				}
-				const deleted = await app.prisma.instanceQualityProfileOverride.deleteMany({
-					where: {
-						userId,
-						status: "PENDING",
-						OR: overrides.map((override) => ({ id: override.id, updatedAt: intentAt })),
-					},
-				});
-				if (deleted.count !== overrides.length) {
-					throw new ConflictError(
-						"Scores were reset upstream, but one or more saved overrides changed concurrently and were retained.",
-					);
-				}
-				return { deletedCount: deleted.count, templateScores };
-			},
-		);
-	}
 	/**
 	 * PATCH /api/trash-guides/instances/:instanceId/quality-profiles/:profileId/scores
 	 * Update custom format scores for a quality profile
@@ -454,9 +229,9 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// userId is guaranteed by preHandler authentication check
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
-		const profileIdNum = Number.parseInt(profileId, 10);
+		const profileIdNum = parsePositiveSafeIntegerParam(profileId);
 
-		if (Number.isNaN(profileIdNum)) {
+		if (profileIdNum === null) {
 			return reply.status(400).send({
 				statusCode: 400,
 				error: "BadRequest",
@@ -618,21 +393,37 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					{
 						where: {
 							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
+							instanceId: { in: equivalentInstanceIds },
 							template: { userId },
 						},
 						orderBy: { updatedAt: "desc" },
 					},
 				);
 				assertNoLegacyDeploymentConnectionMappings(templateMappings);
+				assertCurrentConnectionRows(templateMappings, connectionBindings, "template mapping");
 				if (new Set(templateMappings.map((mapping) => mapping.templateId)).size > 1) {
 					throw new ConflictError(
 						"Equivalent records for this ARR instance have conflicting template mappings.",
 					);
 				}
 				const templateMapping = templateMappings[0];
+				const mappedProfileNames = new Set(
+					templateMappings.flatMap((mapping) =>
+						typeof mapping.qualityProfileName === "string" && mapping.qualityProfileName.length > 0
+							? [mapping.qualityProfileName]
+							: [],
+					),
+				);
+				if (mappedProfileNames.size > 1) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting mapped profile names.",
+					);
+				}
+				const expectedProfileName = mappedProfileNames.values().next().value;
+				assertExactLiveProfile(profile, profileIdNum, expectedProfileName);
 
 				const freshProfile = await client.qualityProfile.getById(profileIdNum);
+				assertExactLiveProfile(freshProfile, profileIdNum, expectedProfileName);
 				if (
 					createQualityProfileStateToken(freshProfile) !== createQualityProfileStateToken(profile)
 				) {
@@ -684,11 +475,11 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 							const existingOverrides = await transaction.instanceQualityProfileOverride.findMany({
 								where: {
 									userId,
+									instanceId: { in: equivalentInstanceIds },
 									qualityProfileId: profileIdNum,
 									customFormatId: {
 										in: scoreUpdates.map((update) => update.customFormatId),
 									},
-									OR: connectionBindings,
 								},
 								select: {
 									id: true,
@@ -696,8 +487,15 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 									customFormatId: true,
 									score: true,
 									status: true,
+									connectionGeneration: true,
+									connectionStateToken: true,
 								},
 							});
+							assertCurrentConnectionRows(
+								existingOverrides,
+								connectionBindings,
+								"saved score override",
+							);
 							if (existingOverrides.some((override) => override.status !== "APPLIED")) {
 								throw new ConflictError(
 									"An equivalent score override changed while the score intent was being saved. Refresh and retry the exact pending change.",
@@ -782,6 +580,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					}),
 					client.qualityProfile.getById(profileIdNum),
 				]);
+				assertExactLiveProfile(writeProfile, profileIdNum, expectedProfileName);
 				if (
 					!writeInstance ||
 					createDeploymentConnectionStateToken(writeInstance) !== connectionStateToken ||
@@ -807,6 +606,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
 					await client.qualityProfile.update(profileIdNum, updatedProfile as any);
 					const postWriteProfile = await client.qualityProfile.getById(profileIdNum);
+					assertExactLiveProfile(postWriteProfile, profileIdNum, expectedProfileName);
 					for (const update of scoreUpdates) {
 						const appliedScore =
 							postWriteProfile.formatItems?.find((item) => item.format === update.customFormatId)
@@ -875,9 +675,9 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// userId is guaranteed by preHandler authentication check
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
-		const profileIdNum = Number.parseInt(profileId, 10);
+		const profileIdNum = parsePositiveSafeIntegerParam(profileId);
 
-		if (Number.isNaN(profileIdNum)) {
+		if (profileIdNum === null) {
 			return reply.status(400).send({
 				statusCode: 400,
 				error: "BadRequest",
@@ -925,18 +725,13 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		const appliedOverrides = [...appliedOverridesByFormat.values()];
 		const recoveryIntents = overrides
 			.filter((override) => override.status !== "APPLIED")
-			.map((override) => ({
-				customFormatId: override.customFormatId,
-				operation: override.intentOperation,
-				intendedScore: override.intendedScore,
-				status: override.status,
-				retryAction:
-					override.intentOperation === "RESET_SCORE" && override.intendedScore !== null
-						? { method: "DELETE" as const }
-						: override.intentOperation === "SET_SCORE" && override.intendedScore !== null
-							? { method: "PATCH" as const, score: override.intendedScore }
-							: null,
-			}));
+			.map((override) => {
+				const { qualityProfileId: _qualityProfileId, ...intent } = describeRecoveryIntent(
+					override,
+					connectionContext.connectionReadBindings,
+				);
+				return intent;
+			});
 
 		return reply.status(200).send({
 			success: true,
@@ -957,7 +752,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
 		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatId, templateId } = validateRequest(promoteOverrideSchema, request.body);
+		const { customFormatId, templateId } = request.body;
 
 		if (Number.isNaN(profileIdNum)) {
 			return reply.status(400).send({
@@ -967,13 +762,13 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Verify the user owns this instance before acquiring its endpoint lock.
+		// Verify the user owns this instance first
 		const instance = await request.server.prisma.serviceInstance.findFirst({
 			where: {
 				id: instanceId,
 				userId,
 			},
-			select: arrConnectionSelect,
+			select: { id: true },
 		});
 
 		if (!instance) {
@@ -984,227 +779,122 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		return runWithCoordinatedEndpointMutation(
-			userId,
-			instance,
-			"Score override promotion",
-			async (endpointKey) => {
-				const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
-				if (
-					!connectionContext ||
-					createDeploymentEndpointKey(userId, connectionContext.instance) !== endpointKey
-				) {
-					throw new ConflictError(
-						"The ARR service connection changed while the override promotion was starting.",
-					);
-				}
-
-				const overrides = await request.server.prisma.instanceQualityProfileOverride.findMany({
-					where: {
-						qualityProfileId: profileIdNum,
-						customFormatId,
-						userId,
-						OR: [
-							{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
-							{
-								status: { in: ["PENDING", "UNCERTAIN"] },
-								instanceId: { in: connectionContext.equivalentInstanceIds },
-							},
-						],
-					},
-					orderBy: { updatedAt: "desc" },
-				});
-				const override = overrides[0];
-				if (!override) {
-					return reply.status(404).send({
-						statusCode: 404,
-						error: "NotFound",
-						message: "Override not found",
-					});
-				}
-				if (overrides.some((candidate) => candidate.status !== "APPLIED")) {
-					throw new ConflictError(
-						"This score has an unresolved upstream result. Retry or resolve it before promoting the override.",
-					);
-				}
-				if (overrides.some((candidate) => candidate.score !== override.score)) {
-					throw new ConflictError(
-						"Equivalent records for this ARR instance have conflicting saved score overrides.",
-					);
-				}
-
-				const connectionBindings = connectionContext.aliases
-					.filter((alias) => connectionContext.equivalentInstanceIds.includes(alias.id))
-					.flatMap(createDeploymentConnectionBindingCandidates);
-				const templateMappings = await request.server.prisma.templateQualityProfileMapping.findMany(
-					{
-						where: {
-							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
-							template: { userId },
-						},
-						include: { template: true },
-						orderBy: { updatedAt: "desc" },
-					},
-				);
-				assertNoLegacyDeploymentConnectionMappings(templateMappings);
-				if (new Set(templateMappings.map((mapping) => mapping.templateId)).size > 1) {
-					throw new ConflictError(
-						"Equivalent records for this ARR instance have conflicting template mappings.",
-					);
-				}
-				const matchingMappings = templateMappings.filter(
-					(mapping) => mapping.templateId === templateId,
-				);
-				if (matchingMappings.length === 0) {
-					return reply.status(400).send({
-						statusCode: 400,
-						error: "BadRequest",
-						message: "Quality profile is not mapped to the specified template",
-					});
-				}
-				const template = matchingMappings[0]!.template;
-				const reviewedMappingState = templateMappings
-					.map((mapping) => ({
-						id: mapping.id,
-						templateId: mapping.templateId,
-						updatedAt: mapping.updatedAt,
-						connectionGeneration: mapping.connectionGeneration,
-						connectionStateToken: mapping.connectionStateToken,
-					}))
-					.sort((left, right) => left.id.localeCompare(right.id));
-
-				let configData: ParsedTemplateConfig;
-				try {
-					configData = JSON.parse(template.configData);
-				} catch (parseError) {
-					return reply.status(500).send({
-						statusCode: 500,
-						error: "InternalServerError",
-						message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-					});
-				}
-
-				const customFormats = configData.customFormats || [];
-				const customFormat = customFormats.find(
-					(cf) => cf.originalConfig?._instanceCFId === customFormatId,
-				);
-				if (!customFormat) {
-					return reply.status(400).send({
-						statusCode: 400,
-						error: "BadRequest",
-						message: "Custom Format not found in template",
-					});
-				}
-				customFormat.scoreOverride = override.score;
-
-				await request.server.prisma.$transaction(async (transaction) => {
-					const transactionInstance = await transaction.serviceInstance.findFirst({
-						where: { id: instanceId, userId },
-						select: arrConnectionSelect,
-					});
-					if (
-						!transactionInstance ||
-						createDeploymentConnectionStateToken(transactionInstance) !==
-							createDeploymentConnectionStateToken(connectionContext.instance)
-					) {
-						throw new ConflictError(
-							"The ARR service connection changed while the override was being promoted. Refresh and try again.",
-						);
-					}
-					const transactionMappings = await transaction.templateQualityProfileMapping.findMany({
-						where: {
-							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
-							template: { userId },
-						},
-						select: {
-							id: true,
-							templateId: true,
-							updatedAt: true,
-							connectionGeneration: true,
-							connectionStateToken: true,
-						},
-					});
-					const transactionMappingState = transactionMappings
-						.map((mapping) => ({
-							id: mapping.id,
-							templateId: mapping.templateId,
-							updatedAt: mapping.updatedAt,
-							connectionGeneration: mapping.connectionGeneration,
-							connectionStateToken: mapping.connectionStateToken,
-						}))
-						.sort((left, right) => left.id.localeCompare(right.id));
-					if (JSON.stringify(transactionMappingState) !== JSON.stringify(reviewedMappingState)) {
-						throw new ConflictError(
-							"The template mapping changed while the override was being promoted. Refresh and try again.",
-						);
-					}
-					const removed = await transaction.instanceQualityProfileOverride.deleteMany({
-						where: {
-							userId,
-							status: "APPLIED",
-							OR: overrides.map((candidate) => ({
-								id: candidate.id,
-								updatedAt: candidate.updatedAt,
-							})),
-						},
-					});
-					if (removed.count !== overrides.length) {
-						throw new ConflictError(
-							"The saved score override changed while it was being promoted. Refresh and try again.",
-						);
-					}
-					const remaining = await transaction.instanceQualityProfileOverride.count({
-						where: {
-							qualityProfileId: profileIdNum,
-							customFormatId,
-							userId,
-							OR: [
-								{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
-								{
-									status: { in: ["PENDING", "UNCERTAIN"] },
-									instanceId: { in: connectionContext.equivalentInstanceIds },
-								},
-							],
-						},
-					});
-					if (remaining !== 0) {
-						throw new ConflictError(
-							"The saved score override set changed while it was being promoted. Refresh and try again.",
-						);
-					}
-
-					const updated = await transaction.trashTemplate.updateMany({
-						where: { id: templateId, userId, updatedAt: template.updatedAt },
-						data: {
-							configData: JSON.stringify(configData),
-							hasUserModifications: true,
-							lastModifiedAt: new Date(),
-							lastModifiedBy: userId,
-						},
-					});
-					if (updated.count !== 1) {
-						throw new ConflictError(
-							"The template changed while the score override was being promoted. Refresh and try again.",
-						);
-					}
-				});
-
-				request.server.log.info(
-					{ cfName: customFormat.name, instanceCFId: customFormatId, newScore: override.score },
-					"Promoted CF score override to template",
-				);
-				return reply.status(200).send({
-					success: true,
-					message:
-						"Override promoted to template. All instances using this template will receive the updated score on next sync.",
-					templateId,
+		// Get the instance override
+		const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
+			where: {
+				instanceId_qualityProfileId_customFormatId: {
+					instanceId,
+					qualityProfileId: profileIdNum,
 					customFormatId,
-					newScore: override.score,
-				});
+				},
 			},
-		);
+		});
+
+		if (!override) {
+			return reply.status(404).send({
+				statusCode: 404,
+				error: "NotFound",
+				message: "Override not found",
+			});
+		}
+
+		// Ensure this profile is actually mapped to the requested template
+		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
+			where: {
+				instanceId_qualityProfileId: {
+					instanceId,
+					qualityProfileId: profileIdNum,
+				},
+			},
+			include: { template: true },
+		});
+
+		if (!templateMapping || templateMapping.templateId !== templateId) {
+			return reply.status(400).send({
+				statusCode: 400,
+				error: "BadRequest",
+				message: "Quality profile is not mapped to the specified template",
+			});
+		}
+
+		// Verify the user owns this template
+		if (templateMapping.template.userId !== userId) {
+			return reply.status(403).send({
+				statusCode: 403,
+				error: "Forbidden",
+				message: "You do not have access to this template",
+			});
+		}
+
+		const template = templateMapping.template;
+
+		// Parse template config
+		let configData: ParsedTemplateConfig;
+		try {
+			configData = JSON.parse(template.configData);
+		} catch (parseError) {
+			return reply.status(500).send({
+				statusCode: 500,
+				error: "InternalServerError",
+				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
+			});
+		}
+
+		// Find and update the CF's scoreOverride in the template
+		const customFormats = configData.customFormats || [];
+		let cfUpdated = false;
+
+		for (const cf of customFormats) {
+			// Match by instance custom format ID (stored in originalConfig._instanceCFId)
+			if (cf.originalConfig?._instanceCFId === customFormatId) {
+				cf.scoreOverride = override.score;
+				cfUpdated = true;
+				request.server.log.info(
+					{ cfName: cf.name, instanceCFId: customFormatId, newScore: override.score },
+					"Updated CF scoreOverride in template",
+				);
+				break;
+			}
+		}
+
+		if (!cfUpdated) {
+			return reply.status(400).send({
+				statusCode: 400,
+				error: "BadRequest",
+				message: "Custom Format not found in template",
+			});
+		}
+
+		// Update template with new scoreOverride
+		await request.server.prisma.trashTemplate.update({
+			where: { id: templateId },
+			data: {
+				configData: JSON.stringify(configData),
+				hasUserModifications: true,
+				lastModifiedAt: new Date(),
+				lastModifiedBy: userId,
+			},
+		});
+
+		// Delete the instance override (now it's in the template)
+		await request.server.prisma.instanceQualityProfileOverride.delete({
+			where: {
+				instanceId_qualityProfileId_customFormatId: {
+					instanceId,
+					qualityProfileId: profileIdNum,
+					customFormatId,
+				},
+			},
+		});
+
+		return reply.status(200).send({
+			success: true,
+			message:
+				"Override promoted to template. All instances using this template will receive the updated score on next sync.",
+			templateId,
+			customFormatId,
+			newScore: override.score,
+		});
 	});
 
 	/**
@@ -1219,25 +909,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// userId is guaranteed by preHandler authentication check
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId } = request.params;
-		const { profileIds } = request.body;
-
-		if (!Array.isArray(profileIds) || profileIds.length === 0) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "profileIds must be a non-empty array of numbers",
-			});
-		}
-
-		// Validate all profileIds are numbers
-		const invalidIds = profileIds.filter((id) => typeof id !== "number" || Number.isNaN(id));
-		if (invalidIds.length > 0) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "All profileIds must be valid numbers",
-			});
-		}
+		const { profileIds } = validateRequest(bulkOverridesSchema, request.body);
 
 		const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
 
@@ -1305,17 +977,9 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		}
 		const recoveryIntents = overrides
 			.filter((override) => override.status !== "APPLIED")
-			.map((override) => ({
-				qualityProfileId: override.qualityProfileId,
-				customFormatId: override.customFormatId,
-				operation: override.intentOperation,
-				intendedScore: override.intendedScore,
-				status: override.status,
-				retryable:
-					(override.intentOperation === "RESET_SCORE" ||
-						override.intentOperation === "SET_SCORE") &&
-					override.intendedScore !== null,
-			}));
+			.map((override) =>
+				describeRecoveryIntent(override, connectionContext.connectionReadBindings),
+			);
 		const appliedOverrideCount = appliedScores.size;
 
 		return reply.status(200).send({
@@ -1349,17 +1013,171 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				});
 			}
 
-			const result = await resetScoreOverrides(userId, instanceId, profileIdNum, [
-				customFormatIdNum,
-			]);
-			const reset = result.templateScores.get(customFormatIdNum)!;
+			// Check if override exists
+			const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
+				where: {
+					instanceId_qualityProfileId_customFormatId: {
+						instanceId,
+						qualityProfileId: profileIdNum,
+						customFormatId: customFormatIdNum,
+					},
+				},
+			});
+
+			if (!override) {
+				return reply.status(404).send({
+					statusCode: 404,
+					error: "NotFound",
+					message: "Override not found",
+				});
+			}
+
+			// Get the template mapping to find the template score
+			const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
+				where: {
+					instanceId_qualityProfileId: {
+						instanceId,
+						qualityProfileId: profileIdNum,
+					},
+				},
+				include: {
+					template: true,
+				},
+			});
+
+			if (!templateMapping) {
+				return reply.status(400).send({
+					statusCode: 400,
+					error: "BadRequest",
+					message: "Quality profile is not managed by a template",
+				});
+			}
+
+			// Parse template config to get the template score for this custom format
+			let templateConfigReset: ParsedTemplateConfig;
+			try {
+				templateConfigReset = JSON.parse(
+					templateMapping.template.configData,
+				) as ParsedTemplateConfig;
+			} catch (parseError) {
+				return reply.status(500).send({
+					statusCode: 500,
+					error: "InternalServerError",
+					message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
+				});
+			}
+			const templateCf = templateConfigReset.customFormats?.find(
+				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === customFormatIdNum,
+			);
+
+			// Calculate the template score (if CF not in template, default to 0)
+			// This can happen if the CF was manually added or the template was updated
+			let templateScore = 0;
+			if (templateCf) {
+				// Priority 1: User's score override from wizard
+				if (templateCf.scoreOverride !== undefined) {
+					templateScore = templateCf.scoreOverride;
+				}
+				// Priority 2: TRaSH Guides score from template's score set
+				else if (
+					templateConfigReset.scoreSet != null &&
+					templateConfigReset.scoreSet !== "" &&
+					templateCf.originalConfig?.trash_scores?.[templateConfigReset.scoreSet] !== undefined
+				) {
+					templateScore = templateCf.originalConfig.trash_scores[templateConfigReset.scoreSet]!;
+				}
+				// Priority 3: TRaSH Guides default score
+				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
+					templateScore = templateCf.originalConfig.trash_scores.default;
+				}
+				// Priority 4: Explicit zero (CF exists in template but has no score)
+				// remains 0
+			}
+
+			// Get the instance from database
+			const instance = await request.server.prisma.serviceInstance.findFirst({
+				where: {
+					id: instanceId,
+					userId,
+					service: {
+						in: ["RADARR", "SONARR"],
+					},
+				},
+				select: {
+					id: true,
+					baseUrl: true,
+					service: true,
+					encryptedApiKey: true,
+					encryptionIv: true,
+					encryptedHttpAuthCredentials: true,
+					httpAuthEncryptionIv: true,
+				},
+			});
+
+			if (!instance) {
+				return reply.status(404).send({
+					statusCode: 404,
+					error: "NotFound",
+					message: "Instance not found or access denied",
+				});
+			}
+
+			// Create SDK client using factory
+			const client = request.server.arrClientFactory.create(instance) as
+				| SonarrClient
+				| RadarrClient;
+
+			// Fetch current quality profile
+			const profile = await client.qualityProfile.getById(profileIdNum);
+
+			// Update the formatItems with the template score
+			const profileFormatItems = profile.formatItems ?? [];
+			const updatedFormatItems = profileFormatItems.map((item) => {
+				if (item.format === customFormatIdNum) {
+					return {
+						...item,
+						score: templateScore,
+					};
+				}
+				return item;
+			});
+
+			// Update the quality profile in Radarr/Sonarr
+			// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
+			const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
+			await client.qualityProfile.update(profileIdNum, updatedProfile);
+
+			// Delete the override from database
+			await request.server.prisma.instanceQualityProfileOverride.delete({
+				where: {
+					instanceId_qualityProfileId_customFormatId: {
+						instanceId,
+						qualityProfileId: profileIdNum,
+						customFormatId: customFormatIdNum,
+					},
+				},
+			});
+
+			request.server.log.info(
+				{
+					instanceId,
+					profileId: profileIdNum,
+					customFormatId: customFormatIdNum,
+					templateScore,
+					cfInTemplate: !!templateCf,
+				},
+				"Deleted instance-level score override and reverted to template score",
+			);
+
+			const message = templateCf
+				? `Override removed. Score reverted to template value (${templateScore}).`
+				: "Override removed. Score set to 0 (custom format not in template).";
+
 			return reply.status(200).send({
 				success: true,
-				message: reset.inTemplate
-					? `Override removed. Score reverted to template value (${reset.score}).`
-					: "Override removed. Score set to 0 (custom format not in template).",
+				message,
 				customFormatId: customFormatIdNum,
-				revertedScore: reset.score,
+				revertedScore: templateScore,
 			});
 		},
 	);
@@ -1376,7 +1194,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
 		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatIds } = validateRequest(bulkDeleteOverridesSchema, request.body);
+		const { customFormatIds } = request.body;
 
 		if (Number.isNaN(profileIdNum)) {
 			return reply.status(400).send({
@@ -1386,11 +1204,153 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		const result = await resetScoreOverrides(userId, instanceId, profileIdNum, customFormatIds);
+		if (!Array.isArray(customFormatIds) || customFormatIds.length === 0) {
+			return reply.status(400).send({
+				statusCode: 400,
+				error: "BadRequest",
+				message: "customFormatIds must be a non-empty array",
+			});
+		}
+
+		// Get the template mapping to find template scores
+		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
+			where: {
+				instanceId_qualityProfileId: {
+					instanceId,
+					qualityProfileId: profileIdNum,
+				},
+			},
+			include: {
+				template: true,
+			},
+		});
+
+		if (!templateMapping) {
+			return reply.status(400).send({
+				statusCode: 400,
+				error: "BadRequest",
+				message: "Quality profile is not managed by a template",
+			});
+		}
+
+		// Parse template config
+		let templateConfigParsed: ParsedTemplateConfig;
+		try {
+			templateConfigParsed = JSON.parse(templateMapping.template.configData);
+		} catch (parseError) {
+			return reply.status(500).send({
+				statusCode: 500,
+				error: "InternalServerError",
+				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
+			});
+		}
+
+		// Get the instance from database with ownership verification
+		const instance = await request.server.prisma.serviceInstance.findFirst({
+			where: {
+				id: instanceId,
+				userId,
+				service: {
+					in: ["RADARR", "SONARR"],
+				},
+			},
+			select: {
+				id: true,
+				baseUrl: true,
+				service: true,
+				encryptedApiKey: true,
+				encryptionIv: true,
+				encryptedHttpAuthCredentials: true,
+				httpAuthEncryptionIv: true,
+			},
+		});
+
+		if (!instance) {
+			return reply.status(404).send({
+				statusCode: 404,
+				error: "NotFound",
+				message: "Instance not found or access denied",
+			});
+		}
+
+		// Create SDK client using factory
+		const client = request.server.arrClientFactory.create(instance) as SonarrClient | RadarrClient;
+
+		// Fetch current quality profile
+		const profile = await client.qualityProfile.getById(profileIdNum);
+
+		// Build a map of customFormatId -> template score
+		const templateScores = new Map<number, number>();
+		for (const cfId of customFormatIds) {
+			const templateCf = templateConfigParsed.customFormats?.find(
+				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === cfId,
+			);
+			if (templateCf) {
+				// Priority 1: User's score override from wizard
+				let score = 0;
+				if (templateCf.scoreOverride !== undefined) {
+					score = templateCf.scoreOverride;
+				}
+				// Priority 2: TRaSH Guides score from template's score set
+				else if (
+					templateConfigParsed.scoreSet != null &&
+					templateConfigParsed.scoreSet !== "" &&
+					templateCf.originalConfig?.trash_scores?.[templateConfigParsed.scoreSet] !== undefined
+				) {
+					score = templateCf.originalConfig.trash_scores[templateConfigParsed.scoreSet]!;
+				}
+				// Priority 3: TRaSH Guides default score
+				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
+					score = templateCf.originalConfig.trash_scores.default;
+				}
+				// Priority 4: Explicit zero (remains 0)
+
+				templateScores.set(cfId, score);
+			} else {
+				// CF not found in template - set to 0 to neutralize the override in ARR
+				// This matches single-DELETE behavior and ensures ARR doesn't retain hidden overrides
+				templateScores.set(cfId, 0);
+			}
+		}
+
+		// Update the formatItems with template scores for the specified CFs
+		const profileFormatItems = profile.formatItems ?? [];
+		const updatedFormatItems = profileFormatItems.map((item) => {
+			const templateScore = item.format !== undefined ? templateScores.get(item.format) : undefined;
+			if (templateScore !== undefined) {
+				return {
+					...item,
+					score: templateScore,
+				};
+			}
+			return item;
+		});
+
+		// Update the quality profile in Radarr/Sonarr
+		// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
+		const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
+		await client.qualityProfile.update(profileIdNum, updatedProfile);
+
+		// Delete all specified overrides from database
+		const result = await request.server.prisma.instanceQualityProfileOverride.deleteMany({
+			where: {
+				instanceId,
+				qualityProfileId: profileIdNum,
+				customFormatId: {
+					in: customFormatIds,
+				},
+			},
+		});
+
+		request.server.log.info(
+			{ instanceId, profileId: profileIdNum, count: result.count },
+			"Bulk deleted instance-level score overrides and reverted to template scores",
+		);
+
 		return reply.status(200).send({
 			success: true,
-			message: `Removed ${result.deletedCount} override(s). Scores reverted to template values.`,
-			deletedCount: result.deletedCount,
+			message: `Removed ${result.count} override(s). Scores reverted to template values.`,
+			deletedCount: result.count,
 		});
 	});
 

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -719,6 +719,18 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					for (const [customFormatId, identity] of customFormatIdentities) {
 						await assertCurrentCustomFormatIdentity(client, customFormatId, identity);
 					}
+					const currentTemplateCount = await app.prisma.trashTemplate.count({
+						where: {
+							id: mapping.templateId,
+							userId,
+							updatedAt: mapping.template.updatedAt,
+						},
+					});
+					if (currentTemplateCount !== 1) {
+						throw new ConflictError(
+							"The template changed while the override reset was being prepared. Refresh and try again.",
+						);
+					}
 					writeAttempted = true;
 					// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
 					await client.qualityProfile.update(profileId, updatedProfile as any);

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -9,6 +9,7 @@ import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { AppValidationError, ConflictError } from "../../lib/errors.js";
 import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { readPersistedManagedCustomFormatIdentities } from "../../lib/trash-guides/deployment-managed-format-state.js";
 import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deployment-operation-gate.js";
 import {
 	assertNoLegacyDeploymentConnectionMappings,
@@ -16,6 +17,7 @@ import {
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
+	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
 	isCurrentDeploymentConnectionMapping,
 } from "../../lib/trash-guides/deployment-target.js";
@@ -42,7 +44,7 @@ interface ParsedTemplateCustomFormat {
 /** Parsed template configuration data structure */
 interface ParsedTemplateConfig {
 	customFormats?: ParsedTemplateCustomFormat[];
-	scoreSet?: string;
+	qualityProfile?: { trash_score_set?: string };
 	[key: string]: unknown;
 }
 
@@ -51,6 +53,10 @@ interface ParsedTemplateConfig {
 // ============================================================================
 
 const updateScoresSchema = z.object({
+	recoveryToken: z
+		.string()
+		.regex(/^[a-f0-9]{64}$/)
+		.optional(),
 	scoreUpdates: z
 		.array(
 			z.object({
@@ -78,10 +84,44 @@ const bulkOverridesSchema = z.object({
 	profileIds: z.array(z.number().int().positive().safe()).min(1),
 });
 
+const bulkDeleteOverridesSchema = z.object({
+	customFormatIds: z.array(z.number().int().positive().safe()).min(1).max(500),
+});
+
+const promoteOverrideSchema = z.object({
+	customFormatId: z.number().int().positive().safe(),
+	templateId: z.string().min(1),
+});
+
 function parsePositiveSafeIntegerParam(value: string): number | null {
 	if (!/^[1-9]\d*$/.test(value)) return null;
 	const parsed = Number(value);
 	return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function getTemplateScore(
+	config: ParsedTemplateConfig,
+	customFormatId: number,
+	trashId?: string,
+): { score: number; inTemplate: boolean } {
+	const templateCf = config.customFormats?.find(
+		(cf) =>
+			(trashId !== undefined && cf.trashId === trashId) ||
+			cf.originalConfig?._instanceCFId === customFormatId,
+	);
+	if (!templateCf) return { score: 0, inTemplate: false };
+	if (templateCf.scoreOverride !== undefined) {
+		return { score: templateCf.scoreOverride, inTemplate: true };
+	}
+	const scoreSet = config.qualityProfile?.trash_score_set;
+	const scoreSetValue = scoreSet ? templateCf.originalConfig?.trash_scores?.[scoreSet] : undefined;
+	if (scoreSetValue !== undefined) {
+		return { score: scoreSetValue, inTemplate: true };
+	}
+	return {
+		score: templateCf.originalConfig?.trash_scores?.default ?? 0,
+		inTemplate: true,
+	};
 }
 
 function assertCurrentConnectionRows(
@@ -117,33 +157,98 @@ function assertExactLiveProfile(
 	}
 }
 
-function describeRecoveryIntent(
-	override: {
+function createScoreRecoveryToken(
+	rows: Array<{
+		id: string;
 		instanceId: string;
 		qualityProfileId: number;
 		customFormatId: number;
 		intentOperation: string | null;
 		intendedScore: number | null;
 		status: string;
+		updatedAt: Date;
 		connectionGeneration?: number | null;
 		connectionStateToken?: string | null;
-	},
+	}>,
+): string {
+	return createUpstreamResourceStateToken(
+		rows
+			.map((row) => ({
+				id: row.id,
+				instanceId: row.instanceId,
+				qualityProfileId: row.qualityProfileId,
+				customFormatId: row.customFormatId,
+				intentOperation: row.intentOperation,
+				intendedScore: row.intendedScore,
+				status: row.status,
+				updatedAt: row.updatedAt.toISOString(),
+				connectionGeneration: row.connectionGeneration ?? null,
+				connectionStateToken: row.connectionStateToken ?? null,
+			}))
+			.sort((left, right) => left.id.localeCompare(right.id)),
+	);
+}
+
+function buildScoreRecoveryPlans(
+	overrides: Array<{
+		id: string;
+		instanceId: string;
+		qualityProfileId: number;
+		customFormatId: number;
+		intentOperation: string | null;
+		intendedScore: number | null;
+		status: string;
+		updatedAt: Date;
+		connectionGeneration?: number | null;
+		connectionStateToken?: string | null;
+	}>,
 	bindings: Parameters<typeof isCurrentDeploymentConnectionMapping>[1],
 ) {
-	const retryable =
-		isCurrentDeploymentConnectionMapping(override, bindings) &&
-		override.intentOperation === "SET_SCORE" &&
-		override.intendedScore !== null;
-	return {
-		qualityProfileId: override.qualityProfileId,
-		customFormatId: override.customFormatId,
-		operation: override.intentOperation,
-		intendedScore: override.intendedScore,
-		status: override.status,
-		retryable,
-		requiresManualReconciliation: !retryable,
-		retryAction: retryable ? { method: "PATCH" as const, score: override.intendedScore! } : null,
-	};
+	const byProfile = new Map<number, typeof overrides>();
+	for (const override of overrides) {
+		const rows = byProfile.get(override.qualityProfileId) ?? [];
+		rows.push(override);
+		byProfile.set(override.qualityProfileId, rows);
+	}
+	return [...byProfile.entries()].map(([qualityProfileId, rows]) => {
+		const desiredScores = new Map<number, number>();
+		let retryable = true;
+		for (const row of rows) {
+			if (
+				!isCurrentDeploymentConnectionMapping(row, bindings) ||
+				row.intentOperation !== "SET_SCORE" ||
+				row.intendedScore === null
+			) {
+				retryable = false;
+				continue;
+			}
+			const existing = desiredScores.get(row.customFormatId);
+			if (existing !== undefined && existing !== row.intendedScore) retryable = false;
+			desiredScores.set(row.customFormatId, row.intendedScore);
+		}
+		if (desiredScores.size !== rows.length) retryable = false;
+		return {
+			qualityProfileId,
+			entries: rows.map((row) => ({
+				customFormatId: row.customFormatId,
+				operation: row.intentOperation,
+				intendedScore: row.intendedScore,
+				status: row.status,
+			})),
+			retryable,
+			requiresManualReconciliation: !retryable,
+			retryAction: retryable
+				? {
+						method: "PATCH" as const,
+						recoveryToken: createScoreRecoveryToken(rows),
+						scoreUpdates: [...desiredScores].map(([customFormatId, score]) => ({
+							customFormatId,
+							score,
+						})),
+					}
+				: null,
+		};
+	});
 }
 
 // ============================================================================
@@ -162,21 +267,42 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		httpAuthEncryptionIv: true,
 		connectionGeneration: true,
 	} as const;
+	type ArrConnectionInstance = Parameters<
+		typeof app.arrClientFactory.createConnectionCredentialIdentity
+	>[0] & { id: string };
+
+	function withCredentialIdentity(instance: ArrConnectionInstance) {
+		return {
+			...instance,
+			credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(instance),
+		};
+	}
+
+	function createEndpointKey(userId: string, instance: ArrConnectionInstance): string {
+		return createDeploymentEndpointKey(userId, withCredentialIdentity(instance));
+	}
+
+	function connectionBindingCandidates(instance: ArrConnectionInstance) {
+		return createDeploymentConnectionBindingCandidates(
+			instance,
+			app.arrClientFactory.createConnectionCredentialIdentity(instance),
+		);
+	}
 
 	async function runWithCoordinatedEndpointMutation<T>(
 		userId: string,
-		instance: Parameters<typeof createDeploymentEndpointKey>[1],
+		instance: ArrConnectionInstance,
 		operation: string,
 		action: (endpointKey: string) => Promise<T>,
 	): Promise<T> {
-		const endpointKey = createDeploymentEndpointKey(userId, instance);
-		const predecessor = endpointMutationTails.get(endpointKey) ?? Promise.resolve();
+		const lockedEndpointKey = createEndpointKey(userId, instance);
+		const predecessor = endpointMutationTails.get(lockedEndpointKey) ?? Promise.resolve();
 		let releaseSlot!: () => void;
 		const slot = new Promise<void>((resolve) => {
 			releaseSlot = resolve;
 		});
 		const tail = predecessor.catch(() => undefined).then(() => slot);
-		endpointMutationTails.set(endpointKey, tail);
+		endpointMutationTails.set(lockedEndpointKey, tail);
 
 		await predecessor.catch(() => undefined);
 		try {
@@ -187,8 +313,8 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			);
 		} finally {
 			releaseSlot();
-			if (endpointMutationTails.get(endpointKey) === tail) {
-				endpointMutationTails.delete(endpointKey);
+			if (endpointMutationTails.get(lockedEndpointKey) === tail) {
+				endpointMutationTails.delete(lockedEndpointKey);
 			}
 		}
 	}
@@ -214,7 +340,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
 		const connectionReadBindings = aliases
 			.filter((alias) => equivalentInstanceIds.includes(alias.id))
-			.flatMap(createDeploymentConnectionBindingCandidates);
+			.flatMap(connectionBindingCandidates);
 		return { instance, aliases, equivalentInstanceIds, connectionReadBindings };
 	}
 
@@ -239,7 +365,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
 				if (
 					!connectionContext ||
-					createDeploymentEndpointKey(userId, connectionContext.instance) !== endpointKey ||
+					createEndpointKey(userId, connectionContext.instance) !== endpointKey ||
 					createDeploymentConnectionStateToken(connectionContext.instance) !==
 						createDeploymentConnectionStateToken(initialContext.instance)
 				) {
@@ -527,7 +653,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		}
 
 		// Validate request body
-		const { scoreUpdates } = validateRequest(updateScoresSchema, request.body);
+		const { recoveryToken, scoreUpdates } = validateRequest(updateScoresSchema, request.body);
 
 		// Get the instance from database with ownership verification
 		const instance = await request.server.prisma.serviceInstance.findFirst({
@@ -579,7 +705,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				});
 				if (
 					!currentInstance ||
-					createDeploymentEndpointKey(userId, currentInstance) !== endpointKey ||
+					createEndpointKey(userId, currentInstance) !== endpointKey ||
 					createDeploymentConnectionStateToken(currentInstance) !== requestedConnectionStateToken
 				) {
 					throw new ConflictError(
@@ -612,7 +738,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
 				const connectionBindings = aliases
 					.filter((alias) => equivalentInstanceIds.includes(alias.id))
-					.flatMap(createDeploymentConnectionBindingCandidates);
+					.flatMap(connectionBindingCandidates);
 				await assertNoPendingDeploymentOperation(
 					request.server.prisma,
 					userId,
@@ -633,12 +759,52 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					},
 					select: {
 						id: true,
+						instanceId: true,
+						qualityProfileId: true,
 						updatedAt: true,
 						customFormatId: true,
 						intentOperation: true,
 						intendedScore: true,
+						status: true,
+						connectionGeneration: true,
+						connectionStateToken: true,
 					},
 				});
+				if (recoveryToken && retryIntents.length === 0) {
+					throw new ConflictError(
+						"The saved score recovery plan no longer exists. Refresh before making another change.",
+					);
+				}
+				if (retryIntents.length > 0) {
+					if (recoveryToken && createScoreRecoveryToken(retryIntents) !== recoveryToken) {
+						throw new ConflictError(
+							"The saved score recovery plan changed. Refresh before retrying it.",
+						);
+					}
+					assertCurrentConnectionRows(retryIntents, connectionBindings, "score retry intent");
+					const desiredScores = new Map<number, number>();
+					for (const intent of retryIntents) {
+						if (intent.intentOperation !== "SET_SCORE" || intent.intendedScore === null) {
+							throw new ConflictError(
+								"The saved recovery plan contains a different operation and requires manual reconciliation.",
+							);
+						}
+						if (desiredScores.has(intent.customFormatId)) {
+							throw new ConflictError(
+								"Equivalent ARR aliases contain duplicate score recovery intent and require manual reconciliation.",
+							);
+						}
+						desiredScores.set(intent.customFormatId, intent.intendedScore);
+					}
+					if (
+						desiredScores.size !== scoreUpdates.length ||
+						scoreUpdates.some((update) => desiredScores.get(update.customFormatId) !== update.score)
+					) {
+						throw new ConflictError(
+							"Retry the complete saved score recovery plan for this quality profile; partial retries are not allowed.",
+						);
+					}
+				}
 
 				const client = request.server.arrClientFactory.create(currentInstance) as
 					| SonarrClient
@@ -1010,20 +1176,15 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			if (!existing) appliedOverridesByFormat.set(override.customFormatId, override);
 		}
 		const appliedOverrides = [...appliedOverridesByFormat.values()];
-		const recoveryIntents = overrides
-			.filter((override) => override.status !== "APPLIED")
-			.map((override) => {
-				const { qualityProfileId: _qualityProfileId, ...intent } = describeRecoveryIntent(
-					override,
-					connectionContext.connectionReadBindings,
-				);
-				return intent;
-			});
+		const recoveryPlans = buildScoreRecoveryPlans(
+			overrides.filter((override) => override.status !== "APPLIED"),
+			connectionContext.connectionReadBindings,
+		);
 
 		return reply.status(200).send({
 			success: true,
 			overrides: appliedOverrides,
-			recoveryIntents,
+			recoveryPlans,
 		});
 	});
 
@@ -1038,10 +1199,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// userId is guaranteed by preHandler authentication check
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
-		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatId, templateId } = request.body;
+		const profileIdNum = parsePositiveSafeIntegerParam(profileId);
+		const { customFormatId, templateId } = validateRequest(promoteOverrideSchema, request.body);
 
-		if (Number.isNaN(profileIdNum)) {
+		if (profileIdNum === null) {
 			return reply.status(400).send({
 				statusCode: 400,
 				error: "BadRequest",
@@ -1049,13 +1210,13 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Verify the user owns this instance first
+		// Verify the user owns this instance before acquiring its endpoint lock.
 		const instance = await request.server.prisma.serviceInstance.findFirst({
 			where: {
 				id: instanceId,
 				userId,
 			},
-			select: { id: true },
+			select: arrConnectionSelect,
 		});
 
 		if (!instance) {
@@ -1066,122 +1227,248 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Get the instance override
-		const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
-			where: {
-				instanceId_qualityProfileId_customFormatId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-					customFormatId,
-				},
-			},
-		});
+		return runWithCoordinatedEndpointMutation(
+			userId,
+			instance,
+			"Score override promotion",
+			async (endpointKey) => {
+				const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
+				if (
+					!connectionContext ||
+					createEndpointKey(userId, connectionContext.instance) !== endpointKey
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while the override promotion was starting.",
+					);
+				}
 
-		if (!override) {
-			return reply.status(404).send({
-				statusCode: 404,
-				error: "NotFound",
-				message: "Override not found",
-			});
-		}
-
-		// Ensure this profile is actually mapped to the requested template
-		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-			where: {
-				instanceId_qualityProfileId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-				},
-			},
-			include: { template: true },
-		});
-
-		if (!templateMapping || templateMapping.templateId !== templateId) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Quality profile is not mapped to the specified template",
-			});
-		}
-
-		// Verify the user owns this template
-		if (templateMapping.template.userId !== userId) {
-			return reply.status(403).send({
-				statusCode: 403,
-				error: "Forbidden",
-				message: "You do not have access to this template",
-			});
-		}
-
-		const template = templateMapping.template;
-
-		// Parse template config
-		let configData: ParsedTemplateConfig;
-		try {
-			configData = JSON.parse(template.configData);
-		} catch (parseError) {
-			return reply.status(500).send({
-				statusCode: 500,
-				error: "InternalServerError",
-				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-			});
-		}
-
-		// Find and update the CF's scoreOverride in the template
-		const customFormats = configData.customFormats || [];
-		let cfUpdated = false;
-
-		for (const cf of customFormats) {
-			// Match by instance custom format ID (stored in originalConfig._instanceCFId)
-			if (cf.originalConfig?._instanceCFId === customFormatId) {
-				cf.scoreOverride = override.score;
-				cfUpdated = true;
-				request.server.log.info(
-					{ cfName: cf.name, instanceCFId: customFormatId, newScore: override.score },
-					"Updated CF scoreOverride in template",
+				const overrides = await request.server.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						qualityProfileId: profileIdNum,
+						customFormatId,
+						userId,
+						OR: [
+							{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+							{
+								status: { in: ["PENDING", "UNCERTAIN"] },
+								instanceId: { in: connectionContext.equivalentInstanceIds },
+							},
+						],
+					},
+					orderBy: { updatedAt: "desc" },
+				});
+				const override = overrides[0];
+				if (!override) {
+					return reply.status(404).send({
+						statusCode: 404,
+						error: "NotFound",
+						message: "Override not found",
+					});
+				}
+				if (overrides.some((candidate) => candidate.status !== "APPLIED")) {
+					throw new ConflictError(
+						"This score has an unresolved upstream result. Retry or resolve it before promoting the override.",
+					);
+				}
+				assertCurrentConnectionRows(
+					overrides,
+					connectionContext.connectionReadBindings,
+					"saved score override",
 				);
-				break;
-			}
-		}
+				if (overrides.some((candidate) => candidate.score !== override.score)) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting saved score overrides.",
+					);
+				}
 
-		if (!cfUpdated) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Custom Format not found in template",
-			});
-		}
+				const connectionBindings = connectionContext.aliases
+					.filter((alias) => connectionContext.equivalentInstanceIds.includes(alias.id))
+					.flatMap(connectionBindingCandidates);
+				const templateMappings = await request.server.prisma.templateQualityProfileMapping.findMany(
+					{
+						where: {
+							qualityProfileId: profileIdNum,
+							OR: connectionBindings,
+							template: { userId },
+						},
+						include: { template: true },
+						orderBy: { updatedAt: "desc" },
+					},
+				);
+				assertNoLegacyDeploymentConnectionMappings(templateMappings);
+				assertCurrentConnectionRows(templateMappings, connectionBindings, "template mapping");
+				if (new Set(templateMappings.map((mapping) => mapping.templateId)).size > 1) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting template mappings.",
+					);
+				}
+				const matchingMappings = templateMappings.filter(
+					(mapping) => mapping.templateId === templateId,
+				);
+				if (matchingMappings.length === 0) {
+					return reply.status(400).send({
+						statusCode: 400,
+						error: "BadRequest",
+						message: "Quality profile is not mapped to the specified template",
+					});
+				}
+				const template = matchingMappings[0]!.template;
+				const managedTrashIds = new Set(
+					matchingMappings.flatMap((mapping) =>
+						readPersistedManagedCustomFormatIdentities(mapping)
+							.filter(
+								(format) =>
+									format.profileId === profileIdNum && format.resourceId === customFormatId,
+							)
+							.map((format) => format.trashId),
+					),
+				);
+				if (managedTrashIds.size !== 1) {
+					throw new ConflictError(
+						"The Custom Format is not bound to one exact managed TRaSH identity for this profile.",
+					);
+				}
+				const managedTrashId = [...managedTrashIds][0]!;
+				const reviewedMappingState = templateMappings
+					.map((mapping) => ({
+						id: mapping.id,
+						templateId: mapping.templateId,
+						updatedAt: mapping.updatedAt,
+						connectionGeneration: mapping.connectionGeneration,
+						connectionStateToken: mapping.connectionStateToken,
+					}))
+					.sort((left, right) => left.id.localeCompare(right.id));
 
-		// Update template with new scoreOverride
-		await request.server.prisma.trashTemplate.update({
-			where: { id: templateId },
-			data: {
-				configData: JSON.stringify(configData),
-				hasUserModifications: true,
-				lastModifiedAt: new Date(),
-				lastModifiedBy: userId,
-			},
-		});
+				let configData: ParsedTemplateConfig;
+				try {
+					configData = JSON.parse(template.configData);
+				} catch (parseError) {
+					return reply.status(500).send({
+						statusCode: 500,
+						error: "InternalServerError",
+						message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
+					});
+				}
 
-		// Delete the instance override (now it's in the template)
-		await request.server.prisma.instanceQualityProfileOverride.delete({
-			where: {
-				instanceId_qualityProfileId_customFormatId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
+				const customFormats = configData.customFormats || [];
+				const matchingCustomFormats = customFormats.filter((cf) => cf.trashId === managedTrashId);
+				const customFormat = matchingCustomFormats[0];
+				if (!customFormat || matchingCustomFormats.length !== 1) {
+					return reply.status(400).send({
+						statusCode: 400,
+						error: "BadRequest",
+						message: "Custom Format not found in template",
+					});
+				}
+				customFormat.scoreOverride = override.score;
+
+				await request.server.prisma.$transaction(async (transaction) => {
+					const transactionInstance = await transaction.serviceInstance.findFirst({
+						where: { id: instanceId, userId },
+						select: arrConnectionSelect,
+					});
+					if (
+						!transactionInstance ||
+						createDeploymentConnectionStateToken(transactionInstance) !==
+							createDeploymentConnectionStateToken(connectionContext.instance)
+					) {
+						throw new ConflictError(
+							"The ARR service connection changed while the override was being promoted. Refresh and try again.",
+						);
+					}
+					const transactionMappings = await transaction.templateQualityProfileMapping.findMany({
+						where: {
+							qualityProfileId: profileIdNum,
+							OR: connectionBindings,
+							template: { userId },
+						},
+						select: {
+							id: true,
+							templateId: true,
+							updatedAt: true,
+							connectionGeneration: true,
+							connectionStateToken: true,
+						},
+					});
+					const transactionMappingState = transactionMappings
+						.map((mapping) => ({
+							id: mapping.id,
+							templateId: mapping.templateId,
+							updatedAt: mapping.updatedAt,
+							connectionGeneration: mapping.connectionGeneration,
+							connectionStateToken: mapping.connectionStateToken,
+						}))
+						.sort((left, right) => left.id.localeCompare(right.id));
+					if (JSON.stringify(transactionMappingState) !== JSON.stringify(reviewedMappingState)) {
+						throw new ConflictError(
+							"The template mapping changed while the override was being promoted. Refresh and try again.",
+						);
+					}
+					const removed = await transaction.instanceQualityProfileOverride.deleteMany({
+						where: {
+							userId,
+							status: "APPLIED",
+							OR: overrides.map((candidate) => ({
+								id: candidate.id,
+								updatedAt: candidate.updatedAt,
+							})),
+						},
+					});
+					if (removed.count !== overrides.length) {
+						throw new ConflictError(
+							"The saved score override changed while it was being promoted. Refresh and try again.",
+						);
+					}
+					const remaining = await transaction.instanceQualityProfileOverride.count({
+						where: {
+							qualityProfileId: profileIdNum,
+							customFormatId,
+							userId,
+							OR: [
+								{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+								{
+									status: { in: ["PENDING", "UNCERTAIN"] },
+									instanceId: { in: connectionContext.equivalentInstanceIds },
+								},
+							],
+						},
+					});
+					if (remaining !== 0) {
+						throw new ConflictError(
+							"The saved score override set changed while it was being promoted. Refresh and try again.",
+						);
+					}
+
+					const updated = await transaction.trashTemplate.updateMany({
+						where: { id: templateId, userId, updatedAt: template.updatedAt },
+						data: {
+							configData: JSON.stringify(configData),
+							hasUserModifications: true,
+							lastModifiedAt: new Date(),
+							lastModifiedBy: userId,
+						},
+					});
+					if (updated.count !== 1) {
+						throw new ConflictError(
+							"The template changed while the score override was being promoted. Refresh and try again.",
+						);
+					}
+				});
+
+				request.server.log.info(
+					{ cfName: customFormat.name, instanceCFId: customFormatId, newScore: override.score },
+					"Promoted CF score override to template",
+				);
+				return reply.status(200).send({
+					success: true,
+					message:
+						"Override promoted to template. All instances using this template will receive the updated score on next sync.",
+					templateId,
 					customFormatId,
-				},
+					newScore: override.score,
+				});
 			},
-		});
-
-		return reply.status(200).send({
-			success: true,
-			message:
-				"Override promoted to template. All instances using this template will receive the updated score on next sync.",
-			templateId,
-			customFormatId,
-			newScore: override.score,
-		});
+		);
 	});
 
 	/**
@@ -1262,18 +1549,17 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				updatedAt: override.updatedAt,
 			});
 		}
-		const recoveryIntents = overrides
-			.filter((override) => override.status !== "APPLIED")
-			.map((override) =>
-				describeRecoveryIntent(override, connectionContext.connectionReadBindings),
-			);
+		const recoveryPlans = buildScoreRecoveryPlans(
+			overrides.filter((override) => override.status !== "APPLIED"),
+			connectionContext.connectionReadBindings,
+		);
 		const appliedOverrideCount = appliedScores.size;
 
 		return reply.status(200).send({
 			success: true,
 			overridesByProfile,
 			totalOverrides: appliedOverrideCount,
-			recoveryIntents,
+			recoveryPlans,
 		});
 	});
 
@@ -1289,10 +1575,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			// userId is guaranteed by preHandler authentication check
 			const userId = request.currentUser!.id; // preHandler guarantees auth
 			const { instanceId, profileId, customFormatId } = request.params;
-			const profileIdNum = Number.parseInt(profileId, 10);
-			const customFormatIdNum = Number.parseInt(customFormatId, 10);
+			const profileIdNum = parsePositiveSafeIntegerParam(profileId);
+			const customFormatIdNum = parsePositiveSafeIntegerParam(customFormatId);
 
-			if (Number.isNaN(profileIdNum) || Number.isNaN(customFormatIdNum)) {
+			if (profileIdNum === null || customFormatIdNum === null) {
 				return reply.status(400).send({
 					statusCode: 400,
 					error: "BadRequest",
@@ -1300,171 +1586,17 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				});
 			}
 
-			// Check if override exists
-			const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
-				where: {
-					instanceId_qualityProfileId_customFormatId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-						customFormatId: customFormatIdNum,
-					},
-				},
-			});
-
-			if (!override) {
-				return reply.status(404).send({
-					statusCode: 404,
-					error: "NotFound",
-					message: "Override not found",
-				});
-			}
-
-			// Get the template mapping to find the template score
-			const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-				where: {
-					instanceId_qualityProfileId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-					},
-				},
-				include: {
-					template: true,
-				},
-			});
-
-			if (!templateMapping) {
-				return reply.status(400).send({
-					statusCode: 400,
-					error: "BadRequest",
-					message: "Quality profile is not managed by a template",
-				});
-			}
-
-			// Parse template config to get the template score for this custom format
-			let templateConfigReset: ParsedTemplateConfig;
-			try {
-				templateConfigReset = JSON.parse(
-					templateMapping.template.configData,
-				) as ParsedTemplateConfig;
-			} catch (parseError) {
-				return reply.status(500).send({
-					statusCode: 500,
-					error: "InternalServerError",
-					message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-				});
-			}
-			const templateCf = templateConfigReset.customFormats?.find(
-				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === customFormatIdNum,
-			);
-
-			// Calculate the template score (if CF not in template, default to 0)
-			// This can happen if the CF was manually added or the template was updated
-			let templateScore = 0;
-			if (templateCf) {
-				// Priority 1: User's score override from wizard
-				if (templateCf.scoreOverride !== undefined) {
-					templateScore = templateCf.scoreOverride;
-				}
-				// Priority 2: TRaSH Guides score from template's score set
-				else if (
-					templateConfigReset.scoreSet != null &&
-					templateConfigReset.scoreSet !== "" &&
-					templateCf.originalConfig?.trash_scores?.[templateConfigReset.scoreSet] !== undefined
-				) {
-					templateScore = templateCf.originalConfig.trash_scores[templateConfigReset.scoreSet]!;
-				}
-				// Priority 3: TRaSH Guides default score
-				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
-					templateScore = templateCf.originalConfig.trash_scores.default;
-				}
-				// Priority 4: Explicit zero (CF exists in template but has no score)
-				// remains 0
-			}
-
-			// Get the instance from database
-			const instance = await request.server.prisma.serviceInstance.findFirst({
-				where: {
-					id: instanceId,
-					userId,
-					service: {
-						in: ["RADARR", "SONARR"],
-					},
-				},
-				select: {
-					id: true,
-					baseUrl: true,
-					service: true,
-					encryptedApiKey: true,
-					encryptionIv: true,
-					encryptedHttpAuthCredentials: true,
-					httpAuthEncryptionIv: true,
-				},
-			});
-
-			if (!instance) {
-				return reply.status(404).send({
-					statusCode: 404,
-					error: "NotFound",
-					message: "Instance not found or access denied",
-				});
-			}
-
-			// Create SDK client using factory
-			const client = request.server.arrClientFactory.create(instance) as
-				| SonarrClient
-				| RadarrClient;
-
-			// Fetch current quality profile
-			const profile = await client.qualityProfile.getById(profileIdNum);
-
-			// Update the formatItems with the template score
-			const profileFormatItems = profile.formatItems ?? [];
-			const updatedFormatItems = profileFormatItems.map((item) => {
-				if (item.format === customFormatIdNum) {
-					return {
-						...item,
-						score: templateScore,
-					};
-				}
-				return item;
-			});
-
-			// Update the quality profile in Radarr/Sonarr
-			// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
-			const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
-			await client.qualityProfile.update(profileIdNum, updatedProfile);
-
-			// Delete the override from database
-			await request.server.prisma.instanceQualityProfileOverride.delete({
-				where: {
-					instanceId_qualityProfileId_customFormatId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-						customFormatId: customFormatIdNum,
-					},
-				},
-			});
-
-			request.server.log.info(
-				{
-					instanceId,
-					profileId: profileIdNum,
-					customFormatId: customFormatIdNum,
-					templateScore,
-					cfInTemplate: !!templateCf,
-				},
-				"Deleted instance-level score override and reverted to template score",
-			);
-
-			const message = templateCf
-				? `Override removed. Score reverted to template value (${templateScore}).`
-				: "Override removed. Score set to 0 (custom format not in template).";
-
+			const result = await resetScoreOverrides(userId, instanceId, profileIdNum, [
+				customFormatIdNum,
+			]);
+			const reset = result.templateScores.get(customFormatIdNum)!;
 			return reply.status(200).send({
 				success: true,
-				message,
+				message: reset.inTemplate
+					? `Override removed. Score reverted to template value (${reset.score}).`
+					: "Override removed. Score set to 0 (custom format not in template).",
 				customFormatId: customFormatIdNum,
-				revertedScore: templateScore,
+				revertedScore: reset.score,
 			});
 		},
 	);
@@ -1480,10 +1612,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// userId is guaranteed by preHandler authentication check
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
-		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatIds } = request.body;
+		const profileIdNum = parsePositiveSafeIntegerParam(profileId);
+		const { customFormatIds } = validateRequest(bulkDeleteOverridesSchema, request.body);
 
-		if (Number.isNaN(profileIdNum)) {
+		if (profileIdNum === null) {
 			return reply.status(400).send({
 				statusCode: 400,
 				error: "BadRequest",
@@ -1491,153 +1623,11 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		if (!Array.isArray(customFormatIds) || customFormatIds.length === 0) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "customFormatIds must be a non-empty array",
-			});
-		}
-
-		// Get the template mapping to find template scores
-		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-			where: {
-				instanceId_qualityProfileId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-				},
-			},
-			include: {
-				template: true,
-			},
-		});
-
-		if (!templateMapping) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Quality profile is not managed by a template",
-			});
-		}
-
-		// Parse template config
-		let templateConfigParsed: ParsedTemplateConfig;
-		try {
-			templateConfigParsed = JSON.parse(templateMapping.template.configData);
-		} catch (parseError) {
-			return reply.status(500).send({
-				statusCode: 500,
-				error: "InternalServerError",
-				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-			});
-		}
-
-		// Get the instance from database with ownership verification
-		const instance = await request.server.prisma.serviceInstance.findFirst({
-			where: {
-				id: instanceId,
-				userId,
-				service: {
-					in: ["RADARR", "SONARR"],
-				},
-			},
-			select: {
-				id: true,
-				baseUrl: true,
-				service: true,
-				encryptedApiKey: true,
-				encryptionIv: true,
-				encryptedHttpAuthCredentials: true,
-				httpAuthEncryptionIv: true,
-			},
-		});
-
-		if (!instance) {
-			return reply.status(404).send({
-				statusCode: 404,
-				error: "NotFound",
-				message: "Instance not found or access denied",
-			});
-		}
-
-		// Create SDK client using factory
-		const client = request.server.arrClientFactory.create(instance) as SonarrClient | RadarrClient;
-
-		// Fetch current quality profile
-		const profile = await client.qualityProfile.getById(profileIdNum);
-
-		// Build a map of customFormatId -> template score
-		const templateScores = new Map<number, number>();
-		for (const cfId of customFormatIds) {
-			const templateCf = templateConfigParsed.customFormats?.find(
-				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === cfId,
-			);
-			if (templateCf) {
-				// Priority 1: User's score override from wizard
-				let score = 0;
-				if (templateCf.scoreOverride !== undefined) {
-					score = templateCf.scoreOverride;
-				}
-				// Priority 2: TRaSH Guides score from template's score set
-				else if (
-					templateConfigParsed.scoreSet != null &&
-					templateConfigParsed.scoreSet !== "" &&
-					templateCf.originalConfig?.trash_scores?.[templateConfigParsed.scoreSet] !== undefined
-				) {
-					score = templateCf.originalConfig.trash_scores[templateConfigParsed.scoreSet]!;
-				}
-				// Priority 3: TRaSH Guides default score
-				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
-					score = templateCf.originalConfig.trash_scores.default;
-				}
-				// Priority 4: Explicit zero (remains 0)
-
-				templateScores.set(cfId, score);
-			} else {
-				// CF not found in template - set to 0 to neutralize the override in ARR
-				// This matches single-DELETE behavior and ensures ARR doesn't retain hidden overrides
-				templateScores.set(cfId, 0);
-			}
-		}
-
-		// Update the formatItems with template scores for the specified CFs
-		const profileFormatItems = profile.formatItems ?? [];
-		const updatedFormatItems = profileFormatItems.map((item) => {
-			const templateScore = item.format !== undefined ? templateScores.get(item.format) : undefined;
-			if (templateScore !== undefined) {
-				return {
-					...item,
-					score: templateScore,
-				};
-			}
-			return item;
-		});
-
-		// Update the quality profile in Radarr/Sonarr
-		// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
-		const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
-		await client.qualityProfile.update(profileIdNum, updatedProfile);
-
-		// Delete all specified overrides from database
-		const result = await request.server.prisma.instanceQualityProfileOverride.deleteMany({
-			where: {
-				instanceId,
-				qualityProfileId: profileIdNum,
-				customFormatId: {
-					in: customFormatIds,
-				},
-			},
-		});
-
-		request.server.log.info(
-			{ instanceId, profileId: profileIdNum, count: result.count },
-			"Bulk deleted instance-level score overrides and reverted to template scores",
-		);
-
+		const result = await resetScoreOverrides(userId, instanceId, profileIdNum, customFormatIds);
 		return reply.status(200).send({
 			success: true,
-			message: `Removed ${result.count} override(s). Scores reverted to template values.`,
-			deletedCount: result.count,
+			message: `Removed ${result.deletedCount} override(s). Scores reverted to template values.`,
+			deletedCount: result.deletedCount,
 		});
 	});
 

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -19,6 +19,7 @@ import {
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
+	isVerifiedClonedProfileSourceConnection,
 	isCurrentDeploymentConnectionMapping,
 } from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
@@ -36,6 +37,8 @@ interface ParsedTemplateCustomFormat {
 	conditionsEnabled?: Record<string, boolean>;
 	originalConfig?: {
 		_instanceCFId?: number;
+		name?: string;
+		specifications?: unknown[];
 		trash_scores?: Record<string, number>;
 		[key: string]: unknown;
 	};
@@ -44,6 +47,10 @@ interface ParsedTemplateCustomFormat {
 /** Parsed template configuration data structure */
 interface ParsedTemplateConfig {
 	customFormats?: ParsedTemplateCustomFormat[];
+	completeQualityProfile?: {
+		sourceInstanceId?: string;
+		sourceConnectionStateToken?: string;
+	};
 	qualityProfile?: { trash_score_set?: string };
 	[key: string]: unknown;
 }
@@ -99,15 +106,37 @@ function parsePositiveSafeIntegerParam(value: string): number | null {
 	return Number.isSafeInteger(parsed) ? parsed : null;
 }
 
+function findTemplateCustomFormat(
+	config: ParsedTemplateConfig,
+	customFormatId: number,
+	trashId?: string,
+	allowInstanceIdFallback = false,
+): ParsedTemplateCustomFormat | undefined {
+	const matches =
+		config.customFormats?.filter((cf) =>
+			trashId !== undefined
+				? cf.trashId === trashId
+				: allowInstanceIdFallback && cf.originalConfig?._instanceCFId === customFormatId,
+		) ?? [];
+	if (matches.length > 1) {
+		throw new ConflictError(
+			"The template contains a duplicate Custom Format identity for this score reset.",
+		);
+	}
+	return matches[0];
+}
+
 function getTemplateScore(
 	config: ParsedTemplateConfig,
 	customFormatId: number,
 	trashId?: string,
+	allowInstanceIdFallback = false,
 ): { score: number; inTemplate: boolean } {
-	const templateCf = config.customFormats?.find(
-		(cf) =>
-			(trashId !== undefined && cf.trashId === trashId) ||
-			cf.originalConfig?._instanceCFId === customFormatId,
+	const templateCf = findTemplateCustomFormat(
+		config,
+		customFormatId,
+		trashId,
+		allowInstanceIdFallback,
 	);
 	if (!templateCf) return { score: 0, inTemplate: false };
 	if (templateCf.scoreOverride !== undefined) {
@@ -122,6 +151,75 @@ function getTemplateScore(
 		score: templateCf.originalConfig?.trash_scores?.default ?? 0,
 		inTemplate: true,
 	};
+}
+
+type ScoreResetCustomFormatIdentity =
+	| { kind: "managed"; stateToken: string }
+	| { kind: "source"; stateToken: string };
+
+function createSourceCustomFormatIdentity(
+	templateCustomFormat: ParsedTemplateCustomFormat | undefined,
+): ScoreResetCustomFormatIdentity {
+	const originalConfig = templateCustomFormat?.originalConfig;
+	if (
+		!originalConfig ||
+		typeof originalConfig.name !== "string" ||
+		originalConfig.name.length === 0 ||
+		!Array.isArray(originalConfig.specifications)
+	) {
+		throw new ConflictError(
+			"Custom Format identity could not be established from the verified source template.",
+		);
+	}
+	return {
+		kind: "source",
+		stateToken: createUpstreamResourceStateToken({
+			name: originalConfig.name,
+			specifications: originalConfig.specifications,
+		}),
+	};
+}
+
+async function assertCurrentCustomFormatIdentity(
+	client: SonarrClient | RadarrClient,
+	customFormatId: number,
+	expected: ScoreResetCustomFormatIdentity,
+): Promise<void> {
+	let live: unknown;
+	try {
+		live = await client.customFormat.getById(customFormatId);
+	} catch {
+		throw new ConflictError(
+			"The Custom Format identity changed or could not be verified. Refresh and try again.",
+		);
+	}
+	if (!live || typeof live !== "object" || Array.isArray(live)) {
+		throw new ConflictError(
+			"The Custom Format identity changed or could not be verified. Refresh and try again.",
+		);
+	}
+	const candidate = live as {
+		id?: number;
+		name?: unknown;
+		specifications?: unknown;
+	};
+	if (candidate.id !== customFormatId) {
+		throw new ConflictError(
+			"The Custom Format identity changed or could not be verified. Refresh and try again.",
+		);
+	}
+	const liveStateToken =
+		expected.kind === "managed"
+			? createUpstreamResourceStateToken(live)
+			: createUpstreamResourceStateToken({
+					name: candidate.name,
+					specifications: candidate.specifications,
+				});
+	if (liveStateToken !== expected.stateToken) {
+		throw new ConflictError(
+			"The Custom Format identity changed or could not be verified. Refresh and try again.",
+		);
+	}
 }
 
 function assertCurrentConnectionRows(
@@ -406,9 +504,25 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					);
 				}
 				const managedFormats = readPersistedManagedCustomFormatIdentities(mapping);
-				const trashIdByResourceId = new Map(
-					managedFormats.map((format) => [format.resourceId, format.trashId]),
-				);
+				const trashIdByResourceId = new Map<number, string>();
+				const managedIdentityByResourceId = new Map<number, ScoreResetCustomFormatIdentity>();
+				const resourceIdByTrashId = new Map<string, number>();
+				for (const format of managedFormats) {
+					if (
+						trashIdByResourceId.has(format.resourceId) ||
+						resourceIdByTrashId.has(format.trashId)
+					) {
+						throw new ConflictError(
+							"The deployment mapping contains duplicate managed Custom Format authority.",
+						);
+					}
+					trashIdByResourceId.set(format.resourceId, format.trashId);
+					managedIdentityByResourceId.set(format.resourceId, {
+						kind: "managed",
+						stateToken: format.stateToken,
+					});
+					resourceIdByTrashId.set(format.trashId, format.resourceId);
+				}
 				let templateConfig: ParsedTemplateConfig;
 				try {
 					templateConfig = JSON.parse(mapping.template.configData) as ParsedTemplateConfig;
@@ -417,7 +531,6 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						`Template configuration is invalid: ${getErrorMessage(error)}`,
 					);
 				}
-
 				const pendingResetIntents = await app.prisma.instanceQualityProfileOverride.findMany({
 					where: {
 						userId,
@@ -452,6 +565,44 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					}
 					persistedResetScores.set(intent.customFormatId, intent.intendedScore);
 				}
+				const requiresInstanceIdFallback = customFormatIds.some(
+					(customFormatId) => !trashIdByResourceId.has(customFormatId),
+				);
+				const sourceBinding = templateConfig.completeQualityProfile;
+				const isRecordedSourceConnection = Boolean(
+					requiresInstanceIdFallback &&
+						sourceBinding?.sourceInstanceId &&
+						connectionContext.equivalentInstanceIds.includes(sourceBinding.sourceInstanceId),
+				);
+				const allowInstanceIdFallback = isRecordedSourceConnection
+					? isVerifiedClonedProfileSourceConnection({
+							sourceInstanceId: sourceBinding?.sourceInstanceId,
+							sourceConnectionStateToken: sourceBinding?.sourceConnectionStateToken,
+							equivalentInstanceIds: connectionContext.equivalentInstanceIds,
+							sourceInstance: connectionContext.aliases.find(
+								(alias) => alias.id === sourceBinding?.sourceInstanceId,
+							),
+						})
+					: false;
+				const customFormatIdentities = new Map<number, ScoreResetCustomFormatIdentity>();
+				for (const customFormatId of customFormatIds) {
+					const managedIdentity = managedIdentityByResourceId.get(customFormatId);
+					if (managedIdentity) {
+						customFormatIdentities.set(customFormatId, managedIdentity);
+						continue;
+					}
+					if (!allowInstanceIdFallback) {
+						throw new ConflictError(
+							"Custom Format identity could not be established for this ARR connection.",
+						);
+					}
+					customFormatIdentities.set(
+						customFormatId,
+						createSourceCustomFormatIdentity(
+							findTemplateCustomFormat(templateConfig, customFormatId, undefined, true),
+						),
+					);
+				}
 				const templateScores = new Map(
 					customFormatIds.map((customFormatId) => [
 						customFormatId,
@@ -461,6 +612,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 									templateConfig,
 									customFormatId,
 									trashIdByResourceId.get(customFormatId),
+									allowInstanceIdFallback,
 								),
 					]),
 				);
@@ -499,6 +651,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						"One or more overrides changed or are not bound to the current ARR connection. Refresh and try again.",
 					);
 				}
+				const client = app.arrClientFactory.create(connectionContext.instance) as
+					| SonarrClient
+					| RadarrClient;
+				for (const [customFormatId, identity] of customFormatIdentities) {
+					await assertCurrentCustomFormatIdentity(client, customFormatId, identity);
+				}
 
 				const intentAt = new Date();
 				await app.prisma.$transaction(async (transaction) => {
@@ -531,9 +689,6 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				} as const;
 				let writeAttempted = false;
 				try {
-					const client = app.arrClientFactory.create(connectionContext.instance) as
-						| SonarrClient
-						| RadarrClient;
 					const profile = await client.qualityProfile.getById(profileId);
 					assertExactLiveProfile(profile, profileId, mapping.qualityProfileName);
 					for (const customFormatId of customFormatIds) {
@@ -561,9 +716,15 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 							"The quality profile changed while the override reset was being prepared. Refresh and try again.",
 						);
 					}
+					for (const [customFormatId, identity] of customFormatIdentities) {
+						await assertCurrentCustomFormatIdentity(client, customFormatId, identity);
+					}
 					writeAttempted = true;
 					// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
 					await client.qualityProfile.update(profileId, updatedProfile as any);
+					for (const [customFormatId, identity] of customFormatIdentities) {
+						await assertCurrentCustomFormatIdentity(client, customFormatId, identity);
+					}
 					const postWriteProfile = await client.qualityProfile.getById(profileId);
 					assertExactLiveProfile(postWriteProfile, profileId, mapping.qualityProfileName);
 					for (const [customFormatId, reset] of templateScores) {

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -7,6 +7,18 @@
 import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
+import { AppValidationError, ConflictError } from "../../lib/errors.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { readPersistedManagedCustomFormatIdentities } from "../../lib/trash-guides/deployment-managed-format-state.js";
+import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deployment-operation-gate.js";
+import {
+	assertNoLegacyDeploymentConnectionMappings,
+	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionStateToken,
+	createDeploymentEndpointKey,
+	createQualityProfileStateToken,
+	getEquivalentServiceInstanceIds,
+} from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
@@ -30,7 +42,7 @@ interface ParsedTemplateCustomFormat {
 /** Parsed template configuration data structure */
 interface ParsedTemplateConfig {
 	customFormats?: ParsedTemplateCustomFormat[];
-	scoreSet?: string;
+	qualityProfile?: { trash_score_set?: string };
 	[key: string]: unknown;
 }
 
@@ -39,19 +51,398 @@ interface ParsedTemplateConfig {
 // ============================================================================
 
 const updateScoresSchema = z.object({
-	scoreUpdates: z.array(
-		z.object({
-			customFormatId: z.number(),
-			score: z.number(),
+	scoreUpdates: z
+		.array(
+			z.object({
+				customFormatId: z.number().int().positive().safe(),
+				score: z.number().int().safe(),
+			}),
+		)
+		.min(1)
+		.superRefine((updates, context) => {
+			const seen = new Set<number>();
+			for (const [index, update] of updates.entries()) {
+				if (seen.has(update.customFormatId)) {
+					context.addIssue({
+						code: "custom",
+						message: "Each Custom Format can only be updated once per request",
+						path: [index, "customFormatId"],
+					});
+				}
+				seen.add(update.customFormatId);
+			}
 		}),
-	),
 });
+
+const bulkDeleteOverridesSchema = z.object({
+	customFormatIds: z.array(z.number().int().positive().safe()).min(1).max(500),
+});
+
+const promoteOverrideSchema = z.object({
+	customFormatId: z.number().int().positive().safe(),
+	templateId: z.string().min(1),
+});
+
+function getTemplateScore(
+	config: ParsedTemplateConfig,
+	customFormatId: number,
+	trashId?: string,
+): { score: number; inTemplate: boolean } {
+	const templateCf = config.customFormats?.find(
+		(cf) =>
+			(trashId !== undefined && cf.trashId === trashId) ||
+			cf.originalConfig?._instanceCFId === customFormatId,
+	);
+	if (!templateCf) return { score: 0, inTemplate: false };
+	if (templateCf.scoreOverride !== undefined) {
+		return { score: templateCf.scoreOverride, inTemplate: true };
+	}
+	const scoreSet = config.qualityProfile?.trash_score_set;
+	const scoreSetValue = scoreSet ? templateCf.originalConfig?.trash_scores?.[scoreSet] : undefined;
+	if (scoreSetValue !== undefined) {
+		return { score: scoreSetValue, inTemplate: true };
+	}
+	return {
+		score: templateCf.originalConfig?.trash_scores?.default ?? 0,
+		inTemplate: true,
+	};
+}
 
 // ============================================================================
 // Route Handlers
 // ============================================================================
 
 const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts, done) => {
+	const endpointMutationTails = new Map<string, Promise<void>>();
+	const arrConnectionSelect = {
+		id: true,
+		baseUrl: true,
+		service: true,
+		encryptedApiKey: true,
+		encryptionIv: true,
+		encryptedHttpAuthCredentials: true,
+		httpAuthEncryptionIv: true,
+		connectionGeneration: true,
+	} as const;
+
+	async function runWithCoordinatedEndpointMutation<T>(
+		userId: string,
+		instance: Parameters<typeof createDeploymentEndpointKey>[1],
+		operation: string,
+		action: (endpointKey: string) => Promise<T>,
+	): Promise<T> {
+		const endpointKey = createDeploymentEndpointKey(userId, instance);
+		const predecessor = endpointMutationTails.get(endpointKey) ?? Promise.resolve();
+		let releaseSlot!: () => void;
+		const slot = new Promise<void>((resolve) => {
+			releaseSlot = resolve;
+		});
+		const tail = predecessor.catch(() => undefined).then(() => slot);
+		endpointMutationTails.set(endpointKey, tail);
+
+		await predecessor.catch(() => undefined);
+		try {
+			return await withCleanupTopologyMutationLease(
+				{ prisma: app.prisma, log: app.log },
+				userId,
+				() => app.deploymentExecutor.runWithEndpointMutation(userId, instance, operation, action),
+			);
+		} finally {
+			releaseSlot();
+			if (endpointMutationTails.get(endpointKey) === tail) {
+				endpointMutationTails.delete(endpointKey);
+			}
+		}
+	}
+
+	async function getEquivalentConnectionContext(userId: string, instanceId: string) {
+		const instance = await app.prisma.serviceInstance.findFirst({
+			where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
+			select: arrConnectionSelect,
+		});
+		if (!instance) return null;
+		const aliases = await app.prisma.serviceInstance.findMany({
+			where: { userId, service: instance.service },
+			select: arrConnectionSelect,
+		});
+		const credentialIdentity = app.arrClientFactory.createConnectionCredentialIdentity(instance);
+		const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+			aliases.map((alias) => ({
+				...alias,
+				credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(alias),
+			})),
+			{ ...instance, credentialIdentity },
+		);
+		if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
+		const connectionReadBindings = aliases
+			.filter((alias) => equivalentInstanceIds.includes(alias.id))
+			.flatMap(createDeploymentConnectionBindingCandidates);
+		return { instance, aliases, equivalentInstanceIds, connectionReadBindings };
+	}
+
+	async function resetScoreOverrides(
+		userId: string,
+		instanceId: string,
+		profileId: number,
+		requestedCustomFormatIds: number[],
+	) {
+		const customFormatIds = [...new Set(requestedCustomFormatIds)];
+		if (customFormatIds.length !== requestedCustomFormatIds.length) {
+			throw new AppValidationError("Each Custom Format can only be reset once per request.");
+		}
+		const selectConnection = {
+			id: true,
+			baseUrl: true,
+			service: true,
+			encryptedApiKey: true,
+			encryptionIv: true,
+			encryptedHttpAuthCredentials: true,
+			httpAuthEncryptionIv: true,
+			connectionGeneration: true,
+		} as const;
+		const instance = await app.prisma.serviceInstance.findFirst({
+			where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
+			select: selectConnection,
+		});
+		if (!instance) throw new AppValidationError("Instance not found or access denied");
+
+		return runWithCoordinatedEndpointMutation(
+			userId,
+			instance,
+			"Quality profile override reset",
+			async (endpointKey) => {
+				const currentInstance = await app.prisma.serviceInstance.findFirst({
+					where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
+					select: selectConnection,
+				});
+				if (
+					!currentInstance ||
+					createDeploymentEndpointKey(userId, currentInstance) !== endpointKey
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while the override reset was starting.",
+					);
+				}
+				const aliases = await app.prisma.serviceInstance.findMany({
+					where: { userId, service: currentInstance.service },
+					select: selectConnection,
+				});
+				const credentialIdentity =
+					app.arrClientFactory.createConnectionCredentialIdentity(currentInstance);
+				const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+					aliases.map((alias) => ({
+						...alias,
+						credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(alias),
+					})),
+					{ ...currentInstance, credentialIdentity },
+				);
+				if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
+				const connectionBindings = aliases
+					.filter((alias) => equivalentInstanceIds.includes(alias.id))
+					.flatMap(createDeploymentConnectionBindingCandidates);
+
+				const mappings = await app.prisma.templateQualityProfileMapping.findMany({
+					where: {
+						qualityProfileId: profileId,
+						OR: connectionBindings,
+						template: { userId },
+					},
+					include: { template: true },
+					orderBy: { updatedAt: "desc" },
+				});
+				assertNoLegacyDeploymentConnectionMappings(mappings);
+				const templateIds = new Set(mappings.map((mapping) => mapping.templateId));
+				if (mappings.length === 0 || templateIds.size !== 1) {
+					throw new ConflictError(
+						"The quality profile does not have one current template mapping for this ARR connection.",
+					);
+				}
+				const mapping = mappings[0]!;
+				const managedFormats = readPersistedManagedCustomFormatIdentities(mapping);
+				const trashIdByResourceId = new Map(
+					managedFormats.map((format) => [format.resourceId, format.trashId]),
+				);
+				let templateConfig: ParsedTemplateConfig;
+				try {
+					templateConfig = JSON.parse(mapping.template.configData) as ParsedTemplateConfig;
+				} catch (error) {
+					throw new AppValidationError(
+						`Template configuration is invalid: ${getErrorMessage(error)}`,
+					);
+				}
+				const pendingResetIntents = await app.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						userId,
+						instanceId: { in: equivalentInstanceIds },
+						qualityProfileId: profileId,
+						customFormatId: { in: customFormatIds },
+						status: { in: ["PENDING", "UNCERTAIN"] },
+					},
+					select: {
+						id: true,
+						instanceId: true,
+						connectionGeneration: true,
+						connectionStateToken: true,
+						customFormatId: true,
+						intentOperation: true,
+						intendedScore: true,
+					},
+				});
+				const currentBindingKeys = new Set(
+					connectionBindings.map(
+						(binding) =>
+							`${binding.instanceId}:${binding.connectionGeneration}:${binding.connectionStateToken}`,
+					),
+				);
+				if (
+					pendingResetIntents.some(
+						(intent) =>
+							!currentBindingKeys.has(
+								`${intent.instanceId}:${intent.connectionGeneration}:${intent.connectionStateToken}`,
+							),
+					)
+				) {
+					throw new ConflictError(
+						"A saved score reset belongs to an older ARR connection. Retry or resolve it before resetting current overrides.",
+					);
+				}
+				const persistedResetScores = new Map(
+					pendingResetIntents.flatMap((intent) =>
+						intent.intentOperation === "RESET_SCORE" && intent.intendedScore !== null
+							? [[intent.customFormatId, intent.intendedScore] as const]
+							: [],
+					),
+				);
+				const templateScores = new Map(
+					customFormatIds.map((customFormatId) => [
+						customFormatId,
+						persistedResetScores.has(customFormatId)
+							? { score: persistedResetScores.get(customFormatId)!, inTemplate: true }
+							: getTemplateScore(
+									templateConfig,
+									customFormatId,
+									trashIdByResourceId.get(customFormatId),
+								),
+					]),
+				);
+				await assertNoPendingDeploymentOperation(app.prisma, userId, equivalentInstanceIds, {
+					qualityProfileId: profileId,
+					operation: "RESET_SCORE",
+					scoreUpdates: customFormatIds.map((customFormatId) => ({
+						customFormatId,
+						score: templateScores.get(customFormatId)!.score,
+					})),
+					connectionBindings,
+				});
+				const overrides = await app.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						userId,
+						qualityProfileId: profileId,
+						customFormatId: { in: customFormatIds },
+						status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
+						OR: connectionBindings,
+					},
+				});
+				if (overrides.length !== customFormatIds.length) {
+					throw new ConflictError(
+						"One or more overrides changed or are not bound to the current ARR connection. Refresh and try again.",
+					);
+				}
+				const intentAt = new Date();
+				try {
+					await app.prisma.$transaction(async (transaction) => {
+						for (const override of overrides) {
+							const write = await transaction.instanceQualityProfileOverride.updateMany({
+								where: {
+									id: override.id,
+									updatedAt: override.updatedAt,
+									status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
+								},
+								data: {
+									status: "PENDING",
+									intentOperation: "RESET_SCORE",
+									intendedScore: templateScores.get(override.customFormatId)!.score,
+									updatedAt: intentAt,
+								},
+							});
+							if (write.count !== 1) {
+								throw new ConflictError(
+									"One or more overrides changed while the reset intent was being saved. Refresh and try again.",
+								);
+							}
+						}
+					});
+				} catch (error) {
+					if (error instanceof ConflictError) throw error;
+					throw new ConflictError(
+						"The score reset intents could not be saved atomically. Refresh and try again.",
+					);
+				}
+
+				const client = app.arrClientFactory.create(currentInstance) as SonarrClient | RadarrClient;
+				const profile = await client.qualityProfile.getById(profileId);
+				const reviewedProfileToken = createQualityProfileStateToken(profile);
+				const updatedProfile = {
+					...profile,
+					formatItems: (profile.formatItems ?? []).map((item) => {
+						const reset = item.format === undefined ? undefined : templateScores.get(item.format);
+						return reset ? { ...item, score: reset.score } : item;
+					}),
+				};
+				const freshProfile = await client.qualityProfile.getById(profileId);
+				if (createQualityProfileStateToken(freshProfile) !== reviewedProfileToken) {
+					throw new ConflictError(
+						"The quality profile changed while the override reset was being prepared. Refresh and try again.",
+					);
+				}
+				try {
+					// biome-ignore lint/suspicious/noExplicitAny: Sonarr/Radarr profile types are runtime-compatible
+					await client.qualityProfile.update(profileId, updatedProfile as any);
+					const postWriteProfile = await client.qualityProfile.getById(profileId);
+					for (const [customFormatId, reset] of templateScores) {
+						const actual =
+							postWriteProfile.formatItems?.find((item) => item.format === customFormatId)?.score ??
+							0;
+						if (actual !== reset.score) {
+							throw new ConflictError(
+								"ARR accepted the profile update, but the reset scores could not be verified. Saved overrides were retained for retry.",
+							);
+						}
+					}
+				} catch (error) {
+					try {
+						await app.prisma.instanceQualityProfileOverride.updateMany({
+							where: {
+								userId,
+								status: "PENDING",
+								OR: overrides.map((override) => ({ id: override.id, updatedAt: intentAt })),
+							},
+							data: { status: "UNCERTAIN" },
+						});
+					} catch (intentError) {
+						app.log.error(
+							{ err: intentError, instanceId, profileId },
+							"Failed to mark an uncertain quality-profile reset intent",
+						);
+					}
+					throw error;
+				}
+				const deleted = await app.prisma.instanceQualityProfileOverride.deleteMany({
+					where: {
+						userId,
+						status: "PENDING",
+						OR: overrides.map((override) => ({ id: override.id, updatedAt: intentAt })),
+					},
+				});
+				if (deleted.count !== overrides.length) {
+					throw new ConflictError(
+						"Scores were reset upstream, but one or more saved overrides changed concurrently and were retained.",
+					);
+				}
+				return { deletedCount: deleted.count, templateScores };
+			},
+		);
+	}
 	/**
 	 * PATCH /api/trash-guides/instances/:instanceId/quality-profiles/:profileId/scores
 	 * Update custom format scores for a quality profile
@@ -93,6 +484,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				encryptionIv: true,
 				encryptedHttpAuthCredentials: true,
 				httpAuthEncryptionIv: true,
+				connectionGeneration: true,
 			},
 		});
 
@@ -103,107 +495,374 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				message: "Instance not found or access denied",
 			});
 		}
+		const requestedConnectionStateToken = createDeploymentConnectionStateToken(instance);
 
-		// Create SDK client using factory
-		const client = request.server.arrClientFactory.create(instance) as SonarrClient | RadarrClient;
-
-		// Fetch current quality profile
-		const profile = await client.qualityProfile.getById(profileIdNum);
-
-		// Update the formatItems with new scores
-		const formatItems = profile.formatItems ?? [];
-		const updatedFormatItems = formatItems.map((item) => {
-			const update = scoreUpdates.find((u) => u.customFormatId === item.format);
-			if (update) {
-				return {
-					...item,
-					score: update.score,
-				};
-			}
-			return item;
-		});
-
-		// Add new format items for custom formats that don't exist yet
-		for (const update of scoreUpdates) {
-			const exists = formatItems.some((item) => item.format === update.customFormatId);
-			if (!exists) {
-				updatedFormatItems.push({
-					format: update.customFormatId,
-					score: update.score,
-				});
-			}
-		}
-
-		// Update the quality profile
-		// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
-		const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
-		await client.qualityProfile.update(profileIdNum, updatedProfile);
-
-		// Check if this quality profile is managed by a template
-		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-			where: {
-				instanceId_qualityProfileId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-				},
-			},
-		});
-
-		// Only save instance-level overrides for template-managed profiles
-		// Non-template profiles don't need override tracking since they have no template to sync from
-		if (templateMapping) {
-			for (const update of scoreUpdates) {
-				await request.server.prisma.instanceQualityProfileOverride.upsert({
-					where: {
-						instanceId_qualityProfileId_customFormatId: {
-							instanceId,
-							qualityProfileId: profileIdNum,
-							customFormatId: update.customFormatId,
-						},
+		return runWithCoordinatedEndpointMutation(
+			userId,
+			instance,
+			"Quality profile score update",
+			async (endpointKey) => {
+				const currentInstance = await request.server.prisma.serviceInstance.findFirst({
+					where: { id: instanceId, userId, service: { in: ["RADARR", "SONARR"] } },
+					select: {
+						id: true,
+						baseUrl: true,
+						service: true,
+						encryptedApiKey: true,
+						encryptionIv: true,
+						encryptedHttpAuthCredentials: true,
+						httpAuthEncryptionIv: true,
+						connectionGeneration: true,
 					},
-					create: {
-						instanceId,
+				});
+				if (
+					!currentInstance ||
+					createDeploymentEndpointKey(userId, currentInstance) !== endpointKey ||
+					createDeploymentConnectionStateToken(currentInstance) !== requestedConnectionStateToken
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while the score update was starting.",
+					);
+				}
+				const aliases = await request.server.prisma.serviceInstance.findMany({
+					where: { userId, service: currentInstance.service },
+					select: {
+						id: true,
+						baseUrl: true,
+						service: true,
+						encryptedApiKey: true,
+						encryptionIv: true,
+						encryptedHttpAuthCredentials: true,
+						httpAuthEncryptionIv: true,
+						connectionGeneration: true,
+					},
+				});
+				const credentialIdentity =
+					request.server.arrClientFactory.createConnectionCredentialIdentity(currentInstance);
+				const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+					aliases.map((alias) => ({
+						...alias,
+						credentialIdentity:
+							request.server.arrClientFactory.createConnectionCredentialIdentity(alias),
+					})),
+					{ ...currentInstance, credentialIdentity },
+				);
+				if (!equivalentInstanceIds.includes(instanceId)) equivalentInstanceIds.push(instanceId);
+				const connectionBindings = aliases
+					.filter((alias) => equivalentInstanceIds.includes(alias.id))
+					.flatMap(createDeploymentConnectionBindingCandidates);
+				await assertNoPendingDeploymentOperation(
+					request.server.prisma,
+					userId,
+					equivalentInstanceIds,
+					{
 						qualityProfileId: profileIdNum,
-						customFormatId: update.customFormatId,
-						score: update.score,
-						userId,
+						operation: "SET_SCORE",
+						scoreUpdates,
+						connectionBindings,
 					},
-					update: {
-						score: update.score,
+				);
+				const retryIntents = await request.server.prisma.instanceQualityProfileOverride.findMany({
+					where: {
 						userId,
-						updatedAt: new Date(),
+						instanceId: { in: equivalentInstanceIds },
+						qualityProfileId: profileIdNum,
+						status: { in: ["PENDING", "UNCERTAIN"] },
+					},
+					select: {
+						id: true,
+						updatedAt: true,
+						customFormatId: true,
+						intentOperation: true,
+						intendedScore: true,
 					},
 				});
-			}
 
-			request.server.log.info(
-				{
-					instanceId,
+				const client = request.server.arrClientFactory.create(currentInstance) as
+					| SonarrClient
+					| RadarrClient;
+				const [profile, customFormats] = await Promise.all([
+					client.qualityProfile.getById(profileIdNum),
+					client.customFormat.getAll(),
+				]);
+				const knownFormatIds = new Set(
+					customFormats.flatMap((format) => (format.id === undefined ? [] : [format.id])),
+				);
+				const unknownFormat = scoreUpdates.find(
+					(update) => !knownFormatIds.has(update.customFormatId),
+				);
+				if (unknownFormat) {
+					throw new AppValidationError(
+						`Custom Format ${unknownFormat.customFormatId} does not exist on this ARR instance.`,
+					);
+				}
+				const updatesByFormatId = new Map(
+					scoreUpdates.map((update) => [update.customFormatId, update.score]),
+				);
+				const formatItems = profile.formatItems ?? [];
+				const updatedFormatItems = formatItems.map((item) => ({
+					...item,
+					score:
+						item.format === undefined
+							? item.score
+							: (updatesByFormatId.get(item.format) ?? item.score),
+				}));
+				for (const update of scoreUpdates) {
+					if (!formatItems.some((item) => item.format === update.customFormatId)) {
+						updatedFormatItems.push({ format: update.customFormatId, score: update.score });
+					}
+				}
+				const updatedProfile = { ...profile, formatItems: updatedFormatItems };
+				const connectionStateToken = createDeploymentConnectionStateToken(currentInstance);
+				const templateMappings = await request.server.prisma.templateQualityProfileMapping.findMany(
+					{
+						where: {
+							qualityProfileId: profileIdNum,
+							OR: connectionBindings,
+							template: { userId },
+						},
+						orderBy: { updatedAt: "desc" },
+					},
+				);
+				assertNoLegacyDeploymentConnectionMappings(templateMappings);
+				if (new Set(templateMappings.map((mapping) => mapping.templateId)).size > 1) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting template mappings.",
+					);
+				}
+				const templateMapping = templateMappings[0];
+
+				const freshProfile = await client.qualityProfile.getById(profileIdNum);
+				if (
+					createQualityProfileStateToken(freshProfile) !== createQualityProfileStateToken(profile)
+				) {
+					throw new ConflictError(
+						"The quality profile changed while the score update was being prepared. Refresh and try again.",
+					);
+				}
+
+				// Persist the desired score before the upstream write. If ARR commits
+				// but the response is lost, the idempotent intent survives for retry.
+				const intentAt = new Date();
+				if (retryIntents.length > 0) {
+					try {
+						await request.server.prisma.$transaction(async (transaction) => {
+							for (const intent of retryIntents) {
+								const write = await transaction.instanceQualityProfileOverride.updateMany({
+									where: {
+										id: intent.id,
+										updatedAt: intent.updatedAt,
+										status: { in: ["PENDING", "UNCERTAIN"] },
+										intentOperation: "SET_SCORE",
+										intendedScore: intent.intendedScore,
+									},
+									data: {
+										instanceId,
+										score: updatesByFormatId.get(intent.customFormatId)!,
+										status: "PENDING",
+										connectionGeneration: currentInstance.connectionGeneration,
+										connectionStateToken,
+										updatedAt: intentAt,
+									},
+								});
+								if (write.count !== 1) {
+									throw new ConflictError(
+										"The saved score retry changed while it was being resumed. Refresh and try again.",
+									);
+								}
+							}
+						});
+					} catch (error) {
+						if (error instanceof ConflictError) throw error;
+						throw new ConflictError(
+							"The saved score retry could not be rebound to this ARR connection. Refresh and resolve any duplicate override before retrying.",
+						);
+					}
+				} else {
+					try {
+						await request.server.prisma.$transaction(async (transaction) => {
+							const existingOverrides = await transaction.instanceQualityProfileOverride.findMany({
+								where: {
+									userId,
+									qualityProfileId: profileIdNum,
+									customFormatId: {
+										in: scoreUpdates.map((update) => update.customFormatId),
+									},
+									OR: connectionBindings,
+								},
+								select: {
+									id: true,
+									instanceId: true,
+									customFormatId: true,
+									score: true,
+									status: true,
+								},
+							});
+							if (existingOverrides.some((override) => override.status !== "APPLIED")) {
+								throw new ConflictError(
+									"An equivalent score override changed while the score intent was being saved. Refresh and retry the exact pending change.",
+								);
+							}
+							const appliedScoresByFormat = new Map<number, number>();
+							for (const override of existingOverrides) {
+								const priorScore = appliedScoresByFormat.get(override.customFormatId);
+								if (
+									appliedScoresByFormat.has(override.customFormatId) &&
+									priorScore !== override.score
+								) {
+									throw new ConflictError(
+										"Equivalent records for this ARR instance have conflicting saved score overrides.",
+									);
+								}
+								appliedScoresByFormat.set(override.customFormatId, override.score);
+							}
+							const aliasOverrideIds = existingOverrides
+								.filter((override) => override.instanceId !== instanceId)
+								.map((override) => override.id);
+							if (aliasOverrideIds.length > 0) {
+								const deleted = await transaction.instanceQualityProfileOverride.deleteMany({
+									where: {
+										id: { in: aliasOverrideIds },
+										status: "APPLIED",
+										userId,
+									},
+								});
+								if (deleted.count !== aliasOverrideIds.length) {
+									throw new ConflictError(
+										"An equivalent score override changed before it could be replaced. Refresh and try again.",
+									);
+								}
+							}
+							for (const update of scoreUpdates) {
+								await transaction.instanceQualityProfileOverride.upsert({
+									where: {
+										instanceId_qualityProfileId_customFormatId: {
+											instanceId,
+											qualityProfileId: profileIdNum,
+											customFormatId: update.customFormatId,
+										},
+									},
+									create: {
+										instanceId,
+										qualityProfileId: profileIdNum,
+										customFormatId: update.customFormatId,
+										score: update.score,
+										status: "PENDING",
+										intentOperation: "SET_SCORE",
+										intendedScore: update.score,
+										userId,
+										connectionGeneration: currentInstance.connectionGeneration,
+										connectionStateToken,
+										updatedAt: intentAt,
+									},
+									update: {
+										score: update.score,
+										status: "PENDING",
+										intentOperation: "SET_SCORE",
+										intendedScore: update.score,
+										userId,
+										connectionGeneration: currentInstance.connectionGeneration,
+										connectionStateToken,
+										updatedAt: intentAt,
+									},
+								});
+							}
+						});
+					} catch (error) {
+						if (error instanceof ConflictError) throw error;
+						throw new ConflictError(
+							"Equivalent score overrides could not be consolidated safely. Refresh and try again.",
+						);
+					}
+				}
+
+				const [writeInstance, writeProfile] = await Promise.all([
+					request.server.prisma.serviceInstance.findFirst({
+						where: { id: instanceId, userId },
+					}),
+					client.qualityProfile.getById(profileIdNum),
+				]);
+				if (
+					!writeInstance ||
+					createDeploymentConnectionStateToken(writeInstance) !== connectionStateToken ||
+					createQualityProfileStateToken(writeProfile) !== createQualityProfileStateToken(profile)
+				) {
+					throw new ConflictError(
+						"The ARR connection or quality profile changed before the score update. The saved score intent was not applied upstream.",
+					);
+				}
+				const overrideWhere = {
+					userId,
+					instanceId: { in: equivalentInstanceIds },
+					qualityProfileId: profileIdNum,
+					status: "PENDING",
+					OR: scoreUpdates.map((update) => ({
+						customFormatId: update.customFormatId,
+						intentOperation: "SET_SCORE",
+						intendedScore: update.score,
+						updatedAt: intentAt,
+					})),
+				} as const;
+				try {
+					// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
+					await client.qualityProfile.update(profileIdNum, updatedProfile as any);
+					const postWriteProfile = await client.qualityProfile.getById(profileIdNum);
+					for (const update of scoreUpdates) {
+						const appliedScore =
+							postWriteProfile.formatItems?.find((item) => item.format === update.customFormatId)
+								?.score ?? 0;
+						if (appliedScore !== update.score) {
+							throw new ConflictError(
+								"ARR accepted the quality profile update, but its resulting scores could not be verified. The saved score intent remains available for retry.",
+							);
+						}
+					}
+					const completed = templateMapping
+						? await request.server.prisma.instanceQualityProfileOverride.updateMany({
+								where: overrideWhere,
+								data: { status: "APPLIED", intentOperation: null, intendedScore: null },
+							})
+						: await request.server.prisma.instanceQualityProfileOverride.deleteMany({
+								where: overrideWhere,
+							});
+					if (completed.count !== scoreUpdates.length) {
+						throw new ConflictError(
+							"ARR accepted the score update, but the saved retry state changed before completion.",
+						);
+					}
+				} catch (error) {
+					await request.server.prisma.instanceQualityProfileOverride.updateMany({
+						where: overrideWhere,
+						data: { status: "UNCERTAIN" },
+					});
+					throw error;
+				}
+
+				request.server.log.info(
+					{
+						instanceId,
+						profileId: profileIdNum,
+						scoreUpdates: scoreUpdates.length,
+						templateId: templateMapping?.templateId,
+					},
+					templateMapping
+						? "Applied durable instance-level score overrides"
+						: "Applied quality profile scores without persistent overrides",
+				);
+
+				const message = templateMapping
+					? `Updated ${scoreUpdates.length} custom format score(s) in quality profile "${profile.name}". Override will persist across template syncs.`
+					: `Updated ${scoreUpdates.length} custom format score(s) in quality profile "${profile.name}".`;
+				return reply.status(200).send({
+					success: true,
+					message,
 					profileId: profileIdNum,
-					scoreUpdates: scoreUpdates.length,
-					templateId: templateMapping.templateId,
-				},
-				"Saved instance-level score overrides for template-managed profile",
-			);
-		} else {
-			request.server.log.info(
-				{ instanceId, profileId: profileIdNum, scoreUpdates: scoreUpdates.length },
-				"Skipped override tracking for non-template profile (scores updated in Radarr/Sonarr only)",
-			);
-		}
-
-		const message = templateMapping
-			? `Updated ${scoreUpdates.length} custom format score(s) in quality profile "${profile.name}". Override will persist across template syncs.`
-			: `Updated ${scoreUpdates.length} custom format score(s) in quality profile "${profile.name}".`;
-
-		return reply.status(200).send({
-			success: true,
-			message,
-			profileId: profileIdNum,
-			profileName: profile.name,
-			updatedCount: scoreUpdates.length,
-			isTemplateManaged: !!templateMapping,
-		});
+					profileName: profile.name,
+					updatedCount: scoreUpdates.length,
+					isTemplateManaged: !!templateMapping,
+				});
+			},
+		);
 	});
 
 	/**
@@ -226,16 +885,9 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Verify the user owns this instance before returning overrides
-		const instance = await request.server.prisma.serviceInstance.findFirst({
-			where: {
-				id: instanceId,
-				userId,
-			},
-			select: { id: true },
-		});
+		const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
 
-		if (!instance) {
+		if (!connectionContext) {
 			return reply.status(403).send({
 				statusCode: 403,
 				error: "Forbidden",
@@ -243,20 +895,53 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Get all overrides for this quality profile
+		// Include unfinished intents so a reload never hides a retryable upstream result.
 		const overrides = await request.server.prisma.instanceQualityProfileOverride.findMany({
 			where: {
-				instanceId,
+				userId,
 				qualityProfileId: profileIdNum,
+				OR: [
+					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: { in: ["PENDING", "UNCERTAIN"] },
+						instanceId: { in: connectionContext.equivalentInstanceIds },
+					},
+				],
 			},
 			orderBy: {
 				updatedAt: "desc",
 			},
 		});
+		const appliedOverridesByFormat = new Map<number, (typeof overrides)[number]>();
+		for (const override of overrides.filter((row) => row.status === "APPLIED")) {
+			const existing = appliedOverridesByFormat.get(override.customFormatId);
+			if (existing && existing.score !== override.score) {
+				throw new ConflictError(
+					"Equivalent records for this ARR instance have conflicting saved score overrides.",
+				);
+			}
+			if (!existing) appliedOverridesByFormat.set(override.customFormatId, override);
+		}
+		const appliedOverrides = [...appliedOverridesByFormat.values()];
+		const recoveryIntents = overrides
+			.filter((override) => override.status !== "APPLIED")
+			.map((override) => ({
+				customFormatId: override.customFormatId,
+				operation: override.intentOperation,
+				intendedScore: override.intendedScore,
+				status: override.status,
+				retryAction:
+					override.intentOperation === "RESET_SCORE" && override.intendedScore !== null
+						? { method: "DELETE" as const }
+						: override.intentOperation === "SET_SCORE" && override.intendedScore !== null
+							? { method: "PATCH" as const, score: override.intendedScore }
+							: null,
+			}));
 
 		return reply.status(200).send({
 			success: true,
-			overrides,
+			overrides: appliedOverrides,
+			recoveryIntents,
 		});
 	});
 
@@ -272,7 +957,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
 		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatId, templateId } = request.body;
+		const { customFormatId, templateId } = validateRequest(promoteOverrideSchema, request.body);
 
 		if (Number.isNaN(profileIdNum)) {
 			return reply.status(400).send({
@@ -282,13 +967,13 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Verify the user owns this instance first
+		// Verify the user owns this instance before acquiring its endpoint lock.
 		const instance = await request.server.prisma.serviceInstance.findFirst({
 			where: {
 				id: instanceId,
 				userId,
 			},
-			select: { id: true },
+			select: arrConnectionSelect,
 		});
 
 		if (!instance) {
@@ -299,122 +984,227 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Get the instance override
-		const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
-			where: {
-				instanceId_qualityProfileId_customFormatId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-					customFormatId,
-				},
-			},
-		});
+		return runWithCoordinatedEndpointMutation(
+			userId,
+			instance,
+			"Score override promotion",
+			async (endpointKey) => {
+				const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
+				if (
+					!connectionContext ||
+					createDeploymentEndpointKey(userId, connectionContext.instance) !== endpointKey
+				) {
+					throw new ConflictError(
+						"The ARR service connection changed while the override promotion was starting.",
+					);
+				}
 
-		if (!override) {
-			return reply.status(404).send({
-				statusCode: 404,
-				error: "NotFound",
-				message: "Override not found",
-			});
-		}
+				const overrides = await request.server.prisma.instanceQualityProfileOverride.findMany({
+					where: {
+						qualityProfileId: profileIdNum,
+						customFormatId,
+						userId,
+						OR: [
+							{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+							{
+								status: { in: ["PENDING", "UNCERTAIN"] },
+								instanceId: { in: connectionContext.equivalentInstanceIds },
+							},
+						],
+					},
+					orderBy: { updatedAt: "desc" },
+				});
+				const override = overrides[0];
+				if (!override) {
+					return reply.status(404).send({
+						statusCode: 404,
+						error: "NotFound",
+						message: "Override not found",
+					});
+				}
+				if (overrides.some((candidate) => candidate.status !== "APPLIED")) {
+					throw new ConflictError(
+						"This score has an unresolved upstream result. Retry or resolve it before promoting the override.",
+					);
+				}
+				if (overrides.some((candidate) => candidate.score !== override.score)) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting saved score overrides.",
+					);
+				}
 
-		// Ensure this profile is actually mapped to the requested template
-		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-			where: {
-				instanceId_qualityProfileId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-				},
-			},
-			include: { template: true },
-		});
-
-		if (!templateMapping || templateMapping.templateId !== templateId) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Quality profile is not mapped to the specified template",
-			});
-		}
-
-		// Verify the user owns this template
-		if (templateMapping.template.userId !== userId) {
-			return reply.status(403).send({
-				statusCode: 403,
-				error: "Forbidden",
-				message: "You do not have access to this template",
-			});
-		}
-
-		const template = templateMapping.template;
-
-		// Parse template config
-		let configData: ParsedTemplateConfig;
-		try {
-			configData = JSON.parse(template.configData);
-		} catch (parseError) {
-			return reply.status(500).send({
-				statusCode: 500,
-				error: "InternalServerError",
-				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-			});
-		}
-
-		// Find and update the CF's scoreOverride in the template
-		const customFormats = configData.customFormats || [];
-		let cfUpdated = false;
-
-		for (const cf of customFormats) {
-			// Match by instance custom format ID (stored in originalConfig._instanceCFId)
-			if (cf.originalConfig?._instanceCFId === customFormatId) {
-				cf.scoreOverride = override.score;
-				cfUpdated = true;
-				request.server.log.info(
-					{ cfName: cf.name, instanceCFId: customFormatId, newScore: override.score },
-					"Updated CF scoreOverride in template",
+				const connectionBindings = connectionContext.aliases
+					.filter((alias) => connectionContext.equivalentInstanceIds.includes(alias.id))
+					.flatMap(createDeploymentConnectionBindingCandidates);
+				const templateMappings = await request.server.prisma.templateQualityProfileMapping.findMany(
+					{
+						where: {
+							qualityProfileId: profileIdNum,
+							OR: connectionBindings,
+							template: { userId },
+						},
+						include: { template: true },
+						orderBy: { updatedAt: "desc" },
+					},
 				);
-				break;
-			}
-		}
+				assertNoLegacyDeploymentConnectionMappings(templateMappings);
+				if (new Set(templateMappings.map((mapping) => mapping.templateId)).size > 1) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting template mappings.",
+					);
+				}
+				const matchingMappings = templateMappings.filter(
+					(mapping) => mapping.templateId === templateId,
+				);
+				if (matchingMappings.length === 0) {
+					return reply.status(400).send({
+						statusCode: 400,
+						error: "BadRequest",
+						message: "Quality profile is not mapped to the specified template",
+					});
+				}
+				const template = matchingMappings[0]!.template;
+				const reviewedMappingState = templateMappings
+					.map((mapping) => ({
+						id: mapping.id,
+						templateId: mapping.templateId,
+						updatedAt: mapping.updatedAt,
+						connectionGeneration: mapping.connectionGeneration,
+						connectionStateToken: mapping.connectionStateToken,
+					}))
+					.sort((left, right) => left.id.localeCompare(right.id));
 
-		if (!cfUpdated) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Custom Format not found in template",
-			});
-		}
+				let configData: ParsedTemplateConfig;
+				try {
+					configData = JSON.parse(template.configData);
+				} catch (parseError) {
+					return reply.status(500).send({
+						statusCode: 500,
+						error: "InternalServerError",
+						message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
+					});
+				}
 
-		// Update template with new scoreOverride
-		await request.server.prisma.trashTemplate.update({
-			where: { id: templateId },
-			data: {
-				configData: JSON.stringify(configData),
-				hasUserModifications: true,
-				lastModifiedAt: new Date(),
-				lastModifiedBy: userId,
-			},
-		});
+				const customFormats = configData.customFormats || [];
+				const customFormat = customFormats.find(
+					(cf) => cf.originalConfig?._instanceCFId === customFormatId,
+				);
+				if (!customFormat) {
+					return reply.status(400).send({
+						statusCode: 400,
+						error: "BadRequest",
+						message: "Custom Format not found in template",
+					});
+				}
+				customFormat.scoreOverride = override.score;
 
-		// Delete the instance override (now it's in the template)
-		await request.server.prisma.instanceQualityProfileOverride.delete({
-			where: {
-				instanceId_qualityProfileId_customFormatId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
+				await request.server.prisma.$transaction(async (transaction) => {
+					const transactionInstance = await transaction.serviceInstance.findFirst({
+						where: { id: instanceId, userId },
+						select: arrConnectionSelect,
+					});
+					if (
+						!transactionInstance ||
+						createDeploymentConnectionStateToken(transactionInstance) !==
+							createDeploymentConnectionStateToken(connectionContext.instance)
+					) {
+						throw new ConflictError(
+							"The ARR service connection changed while the override was being promoted. Refresh and try again.",
+						);
+					}
+					const transactionMappings = await transaction.templateQualityProfileMapping.findMany({
+						where: {
+							qualityProfileId: profileIdNum,
+							OR: connectionBindings,
+							template: { userId },
+						},
+						select: {
+							id: true,
+							templateId: true,
+							updatedAt: true,
+							connectionGeneration: true,
+							connectionStateToken: true,
+						},
+					});
+					const transactionMappingState = transactionMappings
+						.map((mapping) => ({
+							id: mapping.id,
+							templateId: mapping.templateId,
+							updatedAt: mapping.updatedAt,
+							connectionGeneration: mapping.connectionGeneration,
+							connectionStateToken: mapping.connectionStateToken,
+						}))
+						.sort((left, right) => left.id.localeCompare(right.id));
+					if (JSON.stringify(transactionMappingState) !== JSON.stringify(reviewedMappingState)) {
+						throw new ConflictError(
+							"The template mapping changed while the override was being promoted. Refresh and try again.",
+						);
+					}
+					const removed = await transaction.instanceQualityProfileOverride.deleteMany({
+						where: {
+							userId,
+							status: "APPLIED",
+							OR: overrides.map((candidate) => ({
+								id: candidate.id,
+								updatedAt: candidate.updatedAt,
+							})),
+						},
+					});
+					if (removed.count !== overrides.length) {
+						throw new ConflictError(
+							"The saved score override changed while it was being promoted. Refresh and try again.",
+						);
+					}
+					const remaining = await transaction.instanceQualityProfileOverride.count({
+						where: {
+							qualityProfileId: profileIdNum,
+							customFormatId,
+							userId,
+							OR: [
+								{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+								{
+									status: { in: ["PENDING", "UNCERTAIN"] },
+									instanceId: { in: connectionContext.equivalentInstanceIds },
+								},
+							],
+						},
+					});
+					if (remaining !== 0) {
+						throw new ConflictError(
+							"The saved score override set changed while it was being promoted. Refresh and try again.",
+						);
+					}
+
+					const updated = await transaction.trashTemplate.updateMany({
+						where: { id: templateId, userId, updatedAt: template.updatedAt },
+						data: {
+							configData: JSON.stringify(configData),
+							hasUserModifications: true,
+							lastModifiedAt: new Date(),
+							lastModifiedBy: userId,
+						},
+					});
+					if (updated.count !== 1) {
+						throw new ConflictError(
+							"The template changed while the score override was being promoted. Refresh and try again.",
+						);
+					}
+				});
+
+				request.server.log.info(
+					{ cfName: customFormat.name, instanceCFId: customFormatId, newScore: override.score },
+					"Promoted CF score override to template",
+				);
+				return reply.status(200).send({
+					success: true,
+					message:
+						"Override promoted to template. All instances using this template will receive the updated score on next sync.",
+					templateId,
 					customFormatId,
-				},
+					newScore: override.score,
+				});
 			},
-		});
-
-		return reply.status(200).send({
-			success: true,
-			message:
-				"Override promoted to template. All instances using this template will receive the updated score on next sync.",
-			templateId,
-			customFormatId,
-			newScore: override.score,
-		});
+		);
 	});
 
 	/**
@@ -449,16 +1239,9 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		// Verify the user owns this instance before returning overrides
-		const instance = await request.server.prisma.serviceInstance.findFirst({
-			where: {
-				id: instanceId,
-				userId,
-			},
-			select: { id: true },
-		});
+		const connectionContext = await getEquivalentConnectionContext(userId, instanceId);
 
-		if (!instance) {
+		if (!connectionContext) {
 			return reply.status(403).send({
 				statusCode: 403,
 				error: "Forbidden",
@@ -469,10 +1252,17 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		// Fetch all overrides for the specified profiles in a single query
 		const overrides = await request.server.prisma.instanceQualityProfileOverride.findMany({
 			where: {
-				instanceId,
+				userId,
 				qualityProfileId: {
 					in: profileIds,
 				},
+				OR: [
+					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: { in: ["PENDING", "UNCERTAIN"] },
+						instanceId: { in: connectionContext.equivalentInstanceIds },
+					},
+				],
 			},
 			orderBy: {
 				qualityProfileId: "asc",
@@ -489,8 +1279,21 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			}>
 		> = {};
 
+		const appliedScores = new Map<string, number>();
 		for (const override of overrides) {
+			if (override.status !== "APPLIED") continue;
 			const profileId = override.qualityProfileId;
+			const key = `${profileId}:${override.customFormatId}`;
+			const existingScore = appliedScores.get(key);
+			if (existingScore !== undefined) {
+				if (existingScore !== override.score) {
+					throw new ConflictError(
+						"Equivalent records for this ARR instance have conflicting saved score overrides.",
+					);
+				}
+				continue;
+			}
+			appliedScores.set(key, override.score);
 			if (!overridesByProfile[profileId]) {
 				overridesByProfile[profileId] = [];
 			}
@@ -500,11 +1303,26 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				updatedAt: override.updatedAt,
 			});
 		}
+		const recoveryIntents = overrides
+			.filter((override) => override.status !== "APPLIED")
+			.map((override) => ({
+				qualityProfileId: override.qualityProfileId,
+				customFormatId: override.customFormatId,
+				operation: override.intentOperation,
+				intendedScore: override.intendedScore,
+				status: override.status,
+				retryable:
+					(override.intentOperation === "RESET_SCORE" ||
+						override.intentOperation === "SET_SCORE") &&
+					override.intendedScore !== null,
+			}));
+		const appliedOverrideCount = appliedScores.size;
 
 		return reply.status(200).send({
 			success: true,
 			overridesByProfile,
-			totalOverrides: overrides.length,
+			totalOverrides: appliedOverrideCount,
+			recoveryIntents,
 		});
 	});
 
@@ -531,171 +1349,17 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				});
 			}
 
-			// Check if override exists
-			const override = await request.server.prisma.instanceQualityProfileOverride.findUnique({
-				where: {
-					instanceId_qualityProfileId_customFormatId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-						customFormatId: customFormatIdNum,
-					},
-				},
-			});
-
-			if (!override) {
-				return reply.status(404).send({
-					statusCode: 404,
-					error: "NotFound",
-					message: "Override not found",
-				});
-			}
-
-			// Get the template mapping to find the template score
-			const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-				where: {
-					instanceId_qualityProfileId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-					},
-				},
-				include: {
-					template: true,
-				},
-			});
-
-			if (!templateMapping) {
-				return reply.status(400).send({
-					statusCode: 400,
-					error: "BadRequest",
-					message: "Quality profile is not managed by a template",
-				});
-			}
-
-			// Parse template config to get the template score for this custom format
-			let templateConfigReset: ParsedTemplateConfig;
-			try {
-				templateConfigReset = JSON.parse(
-					templateMapping.template.configData,
-				) as ParsedTemplateConfig;
-			} catch (parseError) {
-				return reply.status(500).send({
-					statusCode: 500,
-					error: "InternalServerError",
-					message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-				});
-			}
-			const templateCf = templateConfigReset.customFormats?.find(
-				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === customFormatIdNum,
-			);
-
-			// Calculate the template score (if CF not in template, default to 0)
-			// This can happen if the CF was manually added or the template was updated
-			let templateScore = 0;
-			if (templateCf) {
-				// Priority 1: User's score override from wizard
-				if (templateCf.scoreOverride !== undefined) {
-					templateScore = templateCf.scoreOverride;
-				}
-				// Priority 2: TRaSH Guides score from template's score set
-				else if (
-					templateConfigReset.scoreSet != null &&
-					templateConfigReset.scoreSet !== "" &&
-					templateCf.originalConfig?.trash_scores?.[templateConfigReset.scoreSet] !== undefined
-				) {
-					templateScore = templateCf.originalConfig.trash_scores[templateConfigReset.scoreSet]!;
-				}
-				// Priority 3: TRaSH Guides default score
-				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
-					templateScore = templateCf.originalConfig.trash_scores.default;
-				}
-				// Priority 4: Explicit zero (CF exists in template but has no score)
-				// remains 0
-			}
-
-			// Get the instance from database
-			const instance = await request.server.prisma.serviceInstance.findFirst({
-				where: {
-					id: instanceId,
-					userId,
-					service: {
-						in: ["RADARR", "SONARR"],
-					},
-				},
-				select: {
-					id: true,
-					baseUrl: true,
-					service: true,
-					encryptedApiKey: true,
-					encryptionIv: true,
-					encryptedHttpAuthCredentials: true,
-					httpAuthEncryptionIv: true,
-				},
-			});
-
-			if (!instance) {
-				return reply.status(404).send({
-					statusCode: 404,
-					error: "NotFound",
-					message: "Instance not found or access denied",
-				});
-			}
-
-			// Create SDK client using factory
-			const client = request.server.arrClientFactory.create(instance) as
-				| SonarrClient
-				| RadarrClient;
-
-			// Fetch current quality profile
-			const profile = await client.qualityProfile.getById(profileIdNum);
-
-			// Update the formatItems with the template score
-			const profileFormatItems = profile.formatItems ?? [];
-			const updatedFormatItems = profileFormatItems.map((item) => {
-				if (item.format === customFormatIdNum) {
-					return {
-						...item,
-						score: templateScore,
-					};
-				}
-				return item;
-			});
-
-			// Update the quality profile in Radarr/Sonarr
-			// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
-			const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
-			await client.qualityProfile.update(profileIdNum, updatedProfile);
-
-			// Delete the override from database
-			await request.server.prisma.instanceQualityProfileOverride.delete({
-				where: {
-					instanceId_qualityProfileId_customFormatId: {
-						instanceId,
-						qualityProfileId: profileIdNum,
-						customFormatId: customFormatIdNum,
-					},
-				},
-			});
-
-			request.server.log.info(
-				{
-					instanceId,
-					profileId: profileIdNum,
-					customFormatId: customFormatIdNum,
-					templateScore,
-					cfInTemplate: !!templateCf,
-				},
-				"Deleted instance-level score override and reverted to template score",
-			);
-
-			const message = templateCf
-				? `Override removed. Score reverted to template value (${templateScore}).`
-				: "Override removed. Score set to 0 (custom format not in template).";
-
+			const result = await resetScoreOverrides(userId, instanceId, profileIdNum, [
+				customFormatIdNum,
+			]);
+			const reset = result.templateScores.get(customFormatIdNum)!;
 			return reply.status(200).send({
 				success: true,
-				message,
+				message: reset.inTemplate
+					? `Override removed. Score reverted to template value (${reset.score}).`
+					: "Override removed. Score set to 0 (custom format not in template).",
 				customFormatId: customFormatIdNum,
-				revertedScore: templateScore,
+				revertedScore: reset.score,
 			});
 		},
 	);
@@ -712,7 +1376,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 		const userId = request.currentUser!.id; // preHandler guarantees auth
 		const { instanceId, profileId } = request.params;
 		const profileIdNum = Number.parseInt(profileId, 10);
-		const { customFormatIds } = request.body;
+		const { customFormatIds } = validateRequest(bulkDeleteOverridesSchema, request.body);
 
 		if (Number.isNaN(profileIdNum)) {
 			return reply.status(400).send({
@@ -722,153 +1386,11 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 			});
 		}
 
-		if (!Array.isArray(customFormatIds) || customFormatIds.length === 0) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "customFormatIds must be a non-empty array",
-			});
-		}
-
-		// Get the template mapping to find template scores
-		const templateMapping = await request.server.prisma.templateQualityProfileMapping.findUnique({
-			where: {
-				instanceId_qualityProfileId: {
-					instanceId,
-					qualityProfileId: profileIdNum,
-				},
-			},
-			include: {
-				template: true,
-			},
-		});
-
-		if (!templateMapping) {
-			return reply.status(400).send({
-				statusCode: 400,
-				error: "BadRequest",
-				message: "Quality profile is not managed by a template",
-			});
-		}
-
-		// Parse template config
-		let templateConfigParsed: ParsedTemplateConfig;
-		try {
-			templateConfigParsed = JSON.parse(templateMapping.template.configData);
-		} catch (parseError) {
-			return reply.status(500).send({
-				statusCode: 500,
-				error: "InternalServerError",
-				message: `Template configData is invalid JSON: ${getErrorMessage(parseError)}`,
-			});
-		}
-
-		// Get the instance from database with ownership verification
-		const instance = await request.server.prisma.serviceInstance.findFirst({
-			where: {
-				id: instanceId,
-				userId,
-				service: {
-					in: ["RADARR", "SONARR"],
-				},
-			},
-			select: {
-				id: true,
-				baseUrl: true,
-				service: true,
-				encryptedApiKey: true,
-				encryptionIv: true,
-				encryptedHttpAuthCredentials: true,
-				httpAuthEncryptionIv: true,
-			},
-		});
-
-		if (!instance) {
-			return reply.status(404).send({
-				statusCode: 404,
-				error: "NotFound",
-				message: "Instance not found or access denied",
-			});
-		}
-
-		// Create SDK client using factory
-		const client = request.server.arrClientFactory.create(instance) as SonarrClient | RadarrClient;
-
-		// Fetch current quality profile
-		const profile = await client.qualityProfile.getById(profileIdNum);
-
-		// Build a map of customFormatId -> template score
-		const templateScores = new Map<number, number>();
-		for (const cfId of customFormatIds) {
-			const templateCf = templateConfigParsed.customFormats?.find(
-				(cf: ParsedTemplateCustomFormat) => cf.originalConfig?._instanceCFId === cfId,
-			);
-			if (templateCf) {
-				// Priority 1: User's score override from wizard
-				let score = 0;
-				if (templateCf.scoreOverride !== undefined) {
-					score = templateCf.scoreOverride;
-				}
-				// Priority 2: TRaSH Guides score from template's score set
-				else if (
-					templateConfigParsed.scoreSet != null &&
-					templateConfigParsed.scoreSet !== "" &&
-					templateCf.originalConfig?.trash_scores?.[templateConfigParsed.scoreSet] !== undefined
-				) {
-					score = templateCf.originalConfig.trash_scores[templateConfigParsed.scoreSet]!;
-				}
-				// Priority 3: TRaSH Guides default score
-				else if (templateCf.originalConfig?.trash_scores?.default !== undefined) {
-					score = templateCf.originalConfig.trash_scores.default;
-				}
-				// Priority 4: Explicit zero (remains 0)
-
-				templateScores.set(cfId, score);
-			} else {
-				// CF not found in template - set to 0 to neutralize the override in ARR
-				// This matches single-DELETE behavior and ensures ARR doesn't retain hidden overrides
-				templateScores.set(cfId, 0);
-			}
-		}
-
-		// Update the formatItems with template scores for the specified CFs
-		const profileFormatItems = profile.formatItems ?? [];
-		const updatedFormatItems = profileFormatItems.map((item) => {
-			const templateScore = item.format !== undefined ? templateScores.get(item.format) : undefined;
-			if (templateScore !== undefined) {
-				return {
-					...item,
-					score: templateScore,
-				};
-			}
-			return item;
-		});
-
-		// Update the quality profile in Radarr/Sonarr
-		// biome-ignore lint/suspicious/noExplicitAny: SonarrClient | RadarrClient union creates impossible intersection for QualityProfile.update() parameter
-		const updatedProfile: any = { ...profile, formatItems: updatedFormatItems };
-		await client.qualityProfile.update(profileIdNum, updatedProfile);
-
-		// Delete all specified overrides from database
-		const result = await request.server.prisma.instanceQualityProfileOverride.deleteMany({
-			where: {
-				instanceId,
-				qualityProfileId: profileIdNum,
-				customFormatId: {
-					in: customFormatIds,
-				},
-			},
-		});
-
-		request.server.log.info(
-			{ instanceId, profileId: profileIdNum, count: result.count },
-			"Bulk deleted instance-level score overrides and reverted to template scores",
-		);
-
+		const result = await resetScoreOverrides(userId, instanceId, profileIdNum, customFormatIds);
 		return reply.status(200).send({
 			success: true,
-			message: `Removed ${result.count} override(s). Scores reverted to template values.`,
-			deletedCount: result.count,
+			message: `Removed ${result.deletedCount} override(s). Scores reverted to template values.`,
+			deletedCount: result.deletedCount,
 		});
 	});
 

--- a/apps/api/src/routes/trash-guides/profile-clone-routes.ts
+++ b/apps/api/src/routes/trash-guides/profile-clone-routes.ts
@@ -649,6 +649,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				trashCFLookup.set(cf.trash_id, cf);
 			}
 		}
+		const sourceProfileScores = new Map<number, number>();
+		for (const item of fullProfile.formatItems ?? []) {
+			if (Number.isInteger(item.format) && Number.isFinite(item.score)) {
+				sourceProfileScores.set(item.format, item.score);
+			}
+		}
 
 		// Build template config from selections using extracted helpers
 		const customFormatsConfig = buildCustomFormatsConfig(
@@ -656,6 +662,7 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			cfLookup,
 			trashCFLookup,
 			sourceInstanceId,
+			sourceProfileScores,
 		);
 
 		const completeQualityProfile = buildCompleteQualityProfile(fullProfile, profileConfig, {

--- a/apps/api/src/routes/trash-guides/profile-clone-routes.ts
+++ b/apps/api/src/routes/trash-guides/profile-clone-routes.ts
@@ -43,7 +43,7 @@ import { z } from "zod";
 const instanceIdParams = z.object({ instanceId: z.string().min(1) });
 const instanceProfileParams = z.object({
 	instanceId: z.string().min(1),
-	profileId: z.coerce.number().int().positive(),
+	profileId: z.coerce.number().int().positive().safe(),
 });
 
 const profileImportSchema = z.object({
@@ -94,7 +94,7 @@ const createTemplateSchema = z.object({
 		}),
 	),
 	sourceInstanceId: z.string().min(1),
-	sourceProfileId: z.number().int(),
+	sourceProfileId: z.number().int().positive().safe(),
 	sourceProfileName: z.string(),
 	sourceInstanceLabel: z.string(),
 	profileConfig: z.object({
@@ -117,6 +117,81 @@ function requireSourceProfileName(profile: { name?: string | null }): string {
 		);
 	}
 	return profile.name;
+}
+
+interface CloneSourceCustomFormat {
+	id?: number;
+	name?: string | null;
+	specifications?: unknown[] | null;
+	includeCustomFormatWhenRenaming?: boolean | null;
+}
+
+function validateCloneSourceState(
+	requestedProfileId: number,
+	profile: ArrQualityProfileResponse,
+	allCustomFormats: CloneSourceCustomFormat[],
+) {
+	if (!Number.isSafeInteger(profile.id) || profile.id <= 0 || profile.id !== requestedProfileId) {
+		throw new ConflictError(
+			"The cloned source quality profile identity changed while it was being reviewed. Refresh the profile and try again.",
+		);
+	}
+
+	const profileFormatIds: number[] = [];
+	const sourceProfileScores = new Map<number, number>();
+	for (const item of profile.formatItems ?? []) {
+		if (!Number.isSafeInteger(item.format) || item.format <= 0) {
+			throw new ConflictError(
+				"The source quality profile contains an invalid Custom Format identity.",
+			);
+		}
+		if (sourceProfileScores.has(item.format)) {
+			throw new ConflictError(
+				"The source quality profile contains a duplicate Custom Format identity.",
+			);
+		}
+		if (!Number.isFinite(item.score)) {
+			throw new ConflictError(
+				"The source quality profile contains an invalid Custom Format score.",
+			);
+		}
+		profileFormatIds.push(item.format);
+		sourceProfileScores.set(item.format, item.score);
+	}
+
+	const seenCustomFormatIds = new Set<number>();
+	for (const customFormat of allCustomFormats) {
+		if (!Number.isSafeInteger(customFormat.id) || customFormat.id! <= 0) {
+			throw new ConflictError("ARR returned an invalid Custom Format identity.");
+		}
+		if (seenCustomFormatIds.has(customFormat.id!)) {
+			throw new ConflictError("ARR returned a duplicate Custom Format identity.");
+		}
+		seenCustomFormatIds.add(customFormat.id!);
+	}
+
+	const customFormatsById = new Map<number, CloneSourceCustomFormat>();
+	for (const customFormat of allCustomFormats) {
+		customFormatsById.set(customFormat.id!, customFormat);
+	}
+	for (const customFormatId of [...profileFormatIds].sort((left, right) => left - right)) {
+		const customFormat = customFormatsById.get(customFormatId);
+		if (
+			!customFormat ||
+			typeof customFormat.name !== "string" ||
+			customFormat.name.trim().length === 0
+		) {
+			throw new ConflictError(
+				`Custom Format ${customFormatId} no longer has an exact live definition in ARR.`,
+			);
+		}
+	}
+
+	return {
+		profileFormatIds: new Set(profileFormatIds),
+		sourceProfileScores,
+		customFormatsById,
+	};
 }
 
 // ============================================================================
@@ -291,12 +366,13 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			client.customFormat.getAll(),
 		]);
 		requireSourceProfileName(profile);
-		// Get the CFs used in this profile (from formatItems)
-		const profileCFIds = new Set(
-			((profile as ArrQualityProfileResponse).formatItems || []).map(
-				(item: { format: number }) => item.format,
-			),
+		const cloneSourceState = validateCloneSourceState(
+			profileId,
+			profile as ArrQualityProfileResponse,
+			allCustomFormats,
 		);
+		// Get the CFs used in this profile (from formatItems)
+		const profileCFIds = cloneSourceState.profileFormatIds;
 
 		// Filter to only CFs used in the profile and include score
 		// Use type guard to filter out CFs with undefined id or name
@@ -602,12 +678,12 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 			client.qualityProfile.getById(sourceProfileId) as Promise<ArrQualityProfileResponse>,
 			client.customFormat.getAll(),
 		]);
-		if (fullProfile.id !== sourceProfileId) {
-			throw new ConflictError(
-				"The cloned source quality profile identity changed while the template was being created. Refresh the profile and try again.",
-			);
-		}
 		const sourceProfileName = requireSourceProfileName(fullProfile);
+		const cloneSourceState = validateCloneSourceState(
+			sourceProfileId,
+			fullProfile,
+			allCustomFormats,
+		);
 		const validCustomFormats = allCustomFormats.filter(
 			(cf): cf is typeof cf & { id: number; name: string } =>
 				cf.id !== undefined && cf.name !== undefined && cf.name !== null,
@@ -626,12 +702,14 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 
 		// Build a lookup map for instance CFs (filter out CFs with undefined id or name)
 		const cfLookup = new Map<number, { id: number; name: string; specifications?: unknown[] }>();
-		for (const cf of validCustomFormats) {
-			cfLookup.set(cf.id, {
-				id: cf.id,
-				name: cf.name,
-				specifications: cf.specifications ?? undefined,
-			});
+		for (const [customFormatId, cf] of cloneSourceState.customFormatsById) {
+			if (cf.name !== undefined && cf.name !== null) {
+				cfLookup.set(customFormatId, {
+					id: customFormatId,
+					name: cf.name,
+					specifications: cf.specifications ?? undefined,
+				});
+			}
 		}
 
 		// Get TRaSH cache for matching
@@ -649,20 +727,13 @@ const profileCloneRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				trashCFLookup.set(cf.trash_id, cf);
 			}
 		}
-		const sourceProfileScores = new Map<number, number>();
-		for (const item of fullProfile.formatItems ?? []) {
-			if (Number.isInteger(item.format) && Number.isFinite(item.score)) {
-				sourceProfileScores.set(item.format, item.score);
-			}
-		}
-
 		// Build template config from selections using extracted helpers
 		const customFormatsConfig = buildCustomFormatsConfig(
 			customFormatSelections,
 			cfLookup,
 			trashCFLookup,
 			sourceInstanceId,
-			sourceProfileScores,
+			cloneSourceState.sourceProfileScores,
 		);
 
 		const completeQualityProfile = buildCompleteQualityProfile(fullProfile, profileConfig, {

--- a/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
@@ -1,0 +1,352 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hookMocks = vi.hoisted(() => ({
+	bulkScoresLoaded: vi.fn(),
+	bulkScoresVersion: 0,
+	bulkUpdateScores: vi.fn(),
+}));
+
+const bulkScoresResponse = {
+	success: true,
+	data: {
+		scores: [
+			{
+				trashId: "cf-10",
+				name: "First CF",
+				serviceType: "RADARR" as const,
+				hasAnyModifications: false,
+				templateScores: [
+					{
+						templateId: "instance-1-101",
+						templateName: "Test Radarr",
+						qualityProfileName: "Profile 101",
+						scoreSet: "default",
+						currentScore: 0,
+						defaultScore: 0,
+						isModified: false,
+						isTemplateManaged: true,
+					},
+					{
+						templateId: "instance-1-202",
+						templateName: "Test Radarr",
+						qualityProfileName: "Profile 202",
+						scoreSet: "default",
+						currentScore: 0,
+						defaultScore: 0,
+						isModified: false,
+						isTemplateManaged: true,
+					},
+				],
+			},
+		],
+	},
+};
+
+vi.mock("../../../../hooks/api/useBulkScores", async () => {
+	const { useEffect, useState } = await import("react");
+	return {
+		useBulkScores: ({ instanceId }: { instanceId: string }) => {
+			const [data, setData] = useState<typeof bulkScoresResponse | undefined>();
+			useEffect(() => {
+				setData(instanceId ? structuredClone(bulkScoresResponse) : undefined);
+				hookMocks.bulkScoresLoaded(instanceId, hookMocks.bulkScoresVersion);
+			}, [instanceId, hookMocks.bulkScoresVersion]);
+			return { data, isLoading: false };
+		},
+	};
+});
+
+vi.mock("../../../../hooks/api/useQualityProfileScores", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../../hooks/api/useQualityProfileScores")>();
+	const { useState } = await import("react");
+	return {
+		...actual,
+		useBulkUpdateScores: () => {
+			const [isPending, setIsPending] = useState(false);
+			return {
+				isPending,
+				mutateAsync: async (...args: Parameters<typeof hookMocks.bulkUpdateScores>) => {
+					setIsPending(true);
+					try {
+						return await hookMocks.bulkUpdateScores(...args);
+					} finally {
+						setIsPending(false);
+					}
+				},
+			};
+		},
+	};
+});
+
+vi.mock("../../../../hooks/api/useQualityProfileOverrides", () => ({
+	useBulkDeleteOverrides: () => ({ isPending: false, mutateAsync: vi.fn() }),
+	useDeleteOverride: () => ({ isPending: false, mutateAsync: vi.fn() }),
+}));
+
+vi.mock("../../../../hooks/api/useServicesQuery", () => ({
+	useServicesQuery: () => ({
+		data: [{ id: "instance-1", label: "Test Radarr", service: "radarr" }],
+	}),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#6366f1",
+			to: "#8b5cf6",
+			glow: "rgba(99, 102, 241, 0.3)",
+		},
+	}),
+}));
+
+import {
+	BulkUpdateScoresError,
+	type BulkUpdateScoresResult,
+} from "../../../../hooks/api/useQualityProfileScores";
+import { BulkScoreManager } from "../bulk-score-manager";
+
+function renderWithQueryClient(children: ReactNode) {
+	const queryClient = new QueryClient({
+		defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+	});
+	return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+async function selectInstanceAndLoadScores() {
+	fireEvent.change(screen.getByRole("combobox"), { target: { value: "instance-1" } });
+	await waitFor(() => expect(screen.getAllByRole("spinbutton")).toHaveLength(2));
+}
+
+describe("BulkScoreManager partial saves", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		hookMocks.bulkScoresVersion = 0;
+		bulkScoresResponse.data.scores[0]!.templateScores[0]!.currentScore = 0;
+		bulkScoresResponse.data.scores[0]!.templateScores[1]!.currentScore = 0;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({ success: true, overridesByProfile: {} }),
+			}),
+		);
+	});
+
+	it("retries only the edit retained after a partial profile failure", async () => {
+		const partialResult: BulkUpdateScoresResult = {
+			totalProfiles: 2,
+			successCount: 1,
+			failureCount: 1,
+			results: [
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					success: true,
+					response: { success: true, message: "Saved", updatedCount: 1 },
+				},
+				{
+					entryKey: "instance-1-202",
+					instanceId: "instance-1",
+					profileId: 202,
+					success: false,
+					error: new Error("Profile 202 is locked"),
+				},
+			],
+		};
+		const retryResult: BulkUpdateScoresResult = {
+			totalProfiles: 1,
+			successCount: 1,
+			failureCount: 0,
+			results: [
+				{
+					entryKey: "instance-1-202",
+					instanceId: "instance-1",
+					profileId: 202,
+					success: true,
+					response: { success: true, message: "Saved", updatedCount: 1 },
+				},
+			],
+		};
+		hookMocks.bulkUpdateScores
+			.mockRejectedValueOnce(new BulkUpdateScoresError("One profile failed", partialResult))
+			.mockResolvedValueOnce(retryResult);
+
+		renderWithQueryClient(<BulkScoreManager userId="user-1" />);
+		await selectInstanceAndLoadScores();
+		const [profile101Input, profile202Input] = screen.getAllByRole("spinbutton");
+		fireEvent.change(profile101Input!, { target: { value: "-10000" } });
+		fireEvent.change(profile202Input!, { target: { value: "125" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(1));
+		expect(hookMocks.bulkUpdateScores).toHaveBeenNthCalledWith(1, [
+			{
+				entryKey: "instance-1-101",
+				instanceId: "instance-1",
+				profileId: 101,
+				changes: [{ cfTrashId: "cf-10", score: -10000 }],
+			},
+			{
+				entryKey: "instance-1-202",
+				instanceId: "instance-1",
+				profileId: 202,
+				changes: [{ cfTrashId: "cf-10", score: 125 }],
+			},
+		]);
+
+		fireEvent.click(await screen.findByRole("button", { name: "Save Changes" }));
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(2));
+		expect(hookMocks.bulkUpdateScores).toHaveBeenNthCalledWith(2, [
+			{
+				entryKey: "instance-1-202",
+				instanceId: "instance-1",
+				profileId: 202,
+				changes: [{ cfTrashId: "cf-10", score: 125 }],
+			},
+		]);
+	});
+
+	it("retains a newer value written while the submitted save is in flight", async () => {
+		const inFlightSave = createDeferred<BulkUpdateScoresResult>();
+		const successfulResult: BulkUpdateScoresResult = {
+			totalProfiles: 1,
+			successCount: 1,
+			failureCount: 0,
+			results: [
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					success: true,
+					response: { success: true, message: "Saved", updatedCount: 1 },
+				},
+			],
+		};
+		hookMocks.bulkUpdateScores
+			.mockReturnValueOnce(inFlightSave.promise)
+			.mockResolvedValueOnce(successfulResult);
+
+		renderWithQueryClient(<BulkScoreManager userId="user-1" />);
+		await selectInstanceAndLoadScores();
+		const profile101Input = screen.getAllByRole("spinbutton")[0]!;
+		fireEvent.change(profile101Input, { target: { value: "50" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(1));
+
+		fireEvent.change(profile101Input, { target: { value: "75" } });
+		expect(profile101Input).toHaveValue(75);
+		act(() => inFlightSave.resolve(successfulResult));
+
+		fireEvent.click(await screen.findByRole("button", { name: "Save Changes" }));
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(2));
+		expect(hookMocks.bulkUpdateScores).toHaveBeenNthCalledWith(2, [
+			{
+				entryKey: "instance-1-101",
+				instanceId: "instance-1",
+				profileId: 101,
+				changes: [{ cfTrashId: "cf-10", score: 75 }],
+			},
+		]);
+	});
+
+	it("disables instance switching and conflicting controls while an affected edit is saving", async () => {
+		const inFlightSave = createDeferred<BulkUpdateScoresResult>();
+		hookMocks.bulkUpdateScores.mockReturnValue(inFlightSave.promise);
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				success: true,
+				overridesByProfile: {
+					101: [{ customFormatId: 10, score: 50 }],
+				},
+			}),
+		} as Response);
+
+		renderWithQueryClient(<BulkScoreManager userId="user-1" />);
+		await selectInstanceAndLoadScores();
+		const instanceSelect = screen.getByRole("combobox");
+		const [affectedInput, unaffectedInput] = screen.getAllByRole("spinbutton");
+		fireEvent.click(screen.getByRole("button", { name: "Select First CF" }));
+		const removeOverride = await screen.findByRole("button", {
+			name: "Remove override for First CF",
+		});
+		fireEvent.change(affectedInput!, { target: { value: "50" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+		const savingButton = await screen.findByRole("button", { name: "Saving..." });
+		expect(instanceSelect).toBeDisabled();
+		expect(affectedInput).toBeDisabled();
+		expect(unaffectedInput).toBeEnabled();
+		expect(savingButton).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Discard" })).toBeDisabled();
+		expect(screen.getByRole("button", { name: "Reset to Template" })).toBeDisabled();
+		expect(removeOverride).toBeDisabled();
+
+		act(() =>
+			inFlightSave.resolve({
+				totalProfiles: 1,
+				successCount: 1,
+				failureCount: 0,
+				results: [
+					{
+						entryKey: "instance-1-101",
+						instanceId: "instance-1",
+						profileId: 101,
+						success: true,
+						response: { success: true, message: "Saved", updatedCount: 1 },
+					},
+				],
+			}),
+		);
+	});
+
+	it("preserves a retained failed edit when refreshed query data arrives", async () => {
+		const failedResult: BulkUpdateScoresResult = {
+			totalProfiles: 1,
+			successCount: 0,
+			failureCount: 1,
+			results: [
+				{
+					entryKey: "instance-1-202",
+					instanceId: "instance-1",
+					profileId: 202,
+					success: false,
+					error: new Error("Profile 202 is locked"),
+				},
+			],
+		};
+		hookMocks.bulkUpdateScores.mockRejectedValue(
+			new BulkUpdateScoresError("Profile failed", failedResult),
+		);
+
+		renderWithQueryClient(<BulkScoreManager userId="user-1" />);
+		await selectInstanceAndLoadScores();
+		const profile202Input = screen.getAllByRole("spinbutton")[1]!;
+		fireEvent.change(profile202Input, { target: { value: "125" } });
+		fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(1));
+		await waitFor(() => expect(profile202Input).toHaveValue(125));
+
+		bulkScoresResponse.data.scores[0]!.templateScores[1]!.currentScore = 5;
+		hookMocks.bulkScoresVersion += 1;
+		fireEvent.click(screen.getByRole("button", { name: "Modified Only" }));
+
+		await waitFor(() => expect(hookMocks.bulkScoresLoaded).toHaveBeenCalledWith("instance-1", 1));
+		expect(screen.getAllByRole("spinbutton")[1]).toHaveValue(125);
+	});
+});

--- a/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const hookMocks = vi.hoisted(() => ({
 	bulkScoresLoaded: vi.fn(),
-	bulkScoresVersion: 0,
+	refreshBulkScores: vi.fn(),
 	bulkUpdateScores: vi.fn(),
 }));
 
@@ -50,10 +50,17 @@ vi.mock("../../../../hooks/api/useBulkScores", async () => {
 	return {
 		useBulkScores: ({ instanceId }: { instanceId: string }) => {
 			const [data, setData] = useState<typeof bulkScoresResponse | undefined>();
+			const [refreshVersion, setRefreshVersion] = useState(0);
+			useEffect(() => {
+				hookMocks.refreshBulkScores.mockImplementation(() => {
+					setRefreshVersion((version) => version + 1);
+				});
+				return () => hookMocks.refreshBulkScores.mockReset();
+			}, []);
 			useEffect(() => {
 				setData(instanceId ? structuredClone(bulkScoresResponse) : undefined);
-				hookMocks.bulkScoresLoaded(instanceId, hookMocks.bulkScoresVersion);
-			}, [instanceId, hookMocks.bulkScoresVersion]);
+				hookMocks.bulkScoresLoaded(instanceId, refreshVersion);
+			}, [instanceId, refreshVersion]);
 			return { data, isLoading: false };
 		},
 	};
@@ -134,7 +141,6 @@ async function selectInstanceAndLoadScores() {
 describe("BulkScoreManager partial saves", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		hookMocks.bulkScoresVersion = 0;
 		bulkScoresResponse.data.scores[0]!.templateScores[0]!.currentScore = 0;
 		bulkScoresResponse.data.scores[0]!.templateScores[1]!.currentScore = 0;
 		vi.stubGlobal(
@@ -297,21 +303,26 @@ describe("BulkScoreManager partial saves", () => {
 		expect(screen.getByRole("button", { name: "Reset to Template" })).toBeDisabled();
 		expect(removeOverride).toBeDisabled();
 
-		act(() =>
-			inFlightSave.resolve({
-				totalProfiles: 1,
-				successCount: 1,
-				failureCount: 0,
-				results: [
-					{
-						entryKey: "instance-1-101",
-						instanceId: "instance-1",
-						profileId: 101,
-						success: true,
-						response: { success: true, message: "Saved", updatedCount: 1 },
-					},
-				],
-			}),
+		const saveResult: BulkUpdateScoresResult = {
+			totalProfiles: 1,
+			successCount: 1,
+			failureCount: 0,
+			results: [
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					success: true,
+					response: { success: true, message: "Saved", updatedCount: 1 },
+				},
+			],
+		};
+		await act(async () => {
+			inFlightSave.resolve(saveResult);
+			await inFlightSave.promise;
+		});
+		await waitFor(() =>
+			expect(screen.queryByRole("button", { name: "Saving..." })).not.toBeInTheDocument(),
 		);
 	});
 
@@ -343,7 +354,7 @@ describe("BulkScoreManager partial saves", () => {
 		await waitFor(() => expect(profile202Input).toHaveValue(125));
 
 		bulkScoresResponse.data.scores[0]!.templateScores[1]!.currentScore = 5;
-		hookMocks.bulkScoresVersion += 1;
+		hookMocks.refreshBulkScores();
 		fireEvent.click(screen.getByRole("button", { name: "Modified Only" }));
 
 		await waitFor(() => expect(hookMocks.bulkScoresLoaded).toHaveBeenCalledWith("instance-1", 1));

--- a/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
@@ -356,7 +356,9 @@ describe("BulkScoreManager partial saves", () => {
 		await waitFor(() => expect(profile202Input).toHaveValue(125));
 
 		bulkScoresResponse.data.scores[0]!.templateScores[1]!.currentScore = 5;
-		hookMocks.refreshBulkScores();
+		act(() => {
+			hookMocks.refreshBulkScores();
+		});
 		fireEvent.click(screen.getByRole("button", { name: "Modified Only" }));
 
 		await waitFor(() => expect(hookMocks.bulkScoresLoaded).toHaveBeenCalledWith("instance-1", 1));

--- a/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
@@ -364,4 +364,65 @@ describe("BulkScoreManager partial saves", () => {
 		await waitFor(() => expect(hookMocks.bulkScoresLoaded).toHaveBeenCalledWith("instance-1", 1));
 		expect(screen.getAllByRole("spinbutton")[1]).toHaveValue(125);
 	});
+
+	it("restores an exact score retry from durable recovery data after reload", async () => {
+		vi.mocked(fetch).mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				success: true,
+				overridesByProfile: {},
+				recoveryPlans: [
+					{
+						qualityProfileId: 101,
+						entries: [
+							{
+								customFormatId: 10,
+								operation: "SET_SCORE",
+								intendedScore: 75,
+								status: "UNCERTAIN",
+							},
+						],
+						retryable: true,
+						requiresManualReconciliation: false,
+						retryAction: {
+							method: "PATCH",
+							recoveryToken: "a".repeat(64),
+							scoreUpdates: [{ customFormatId: 10, score: 75 }],
+						},
+					},
+				],
+			}),
+		} as Response);
+		hookMocks.bulkUpdateScores.mockResolvedValue({
+			totalProfiles: 1,
+			successCount: 1,
+			failureCount: 0,
+			results: [
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					success: true,
+					response: { success: true, message: "Recovered", updatedCount: 1 },
+				},
+			],
+		});
+
+		renderWithQueryClient(<BulkScoreManager userId="user-1" />);
+		await selectInstanceAndLoadScores();
+		fireEvent.click(
+			await screen.findByRole("button", { name: "Retry score update for Profile 101" }),
+		);
+
+		await waitFor(() => expect(hookMocks.bulkUpdateScores).toHaveBeenCalledTimes(1));
+		expect(hookMocks.bulkUpdateScores).toHaveBeenCalledWith([
+			{
+				entryKey: "instance-1-101",
+				instanceId: "instance-1",
+				profileId: 101,
+				changes: [{ cfTrashId: "cf-10", score: 75 }],
+				recoveryToken: "a".repeat(64),
+			},
+		]);
+	});
 });

--- a/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/bulk-score-manager-partial-save.test.tsx
@@ -55,7 +55,9 @@ vi.mock("../../../../hooks/api/useBulkScores", async () => {
 				hookMocks.refreshBulkScores.mockImplementation(() => {
 					setRefreshVersion((version) => version + 1);
 				});
-				return () => hookMocks.refreshBulkScores.mockReset();
+				return () => {
+					hookMocks.refreshBulkScores.mockReset();
+				};
 			}, []);
 			useEffect(() => {
 				setData(instanceId ? structuredClone(bulkScoresResponse) : undefined);

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -42,6 +42,10 @@ import {
 } from "../../../hooks/api/useQualityProfileScores";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
 import { useThemeGradient } from "../../../hooks/useThemeGradient";
+import type {
+	BulkOverridesResponse,
+	ScoreRecoveryPlan,
+} from "../../../lib/api-client/trash-guides";
 import { getErrorMessage } from "../../../lib/error-utils";
 import { SEMANTIC_COLORS, SERVICE_GRADIENTS } from "../../../lib/theme-gradients";
 
@@ -174,6 +178,8 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 	const [allOverrides, setAllOverrides] = useState<
 		Map<string, { customFormatId: number; score: number }>
 	>(new Map());
+	const [scoreRecoveryPlans, setScoreRecoveryPlans] = useState<ScoreRecoveryPlan[]>([]);
+	const [retryingProfileId, setRetryingProfileId] = useState<number | null>(null);
 
 	// Create override map for quick lookups: `${profileId}-${cfId}` → has override
 	const overrideMap = useMemo(() => {
@@ -208,7 +214,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 					throw new Error(`Failed to fetch bulk overrides: ${response.status}`);
 				}
 
-				const data = await response.json();
+				const data = (await response.json()) as BulkOverridesResponse;
 
 				const newOverrides = new Map<string, { customFormatId: number; score: number }>();
 
@@ -226,10 +232,12 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 				}
 
 				setAllOverrides(newOverrides);
+				setScoreRecoveryPlans(data?.success ? (data.recoveryPlans ?? []) : []);
 			} catch (error) {
 				if (error instanceof Error && error.name === "AbortError") {
 					return;
 				}
+				setScoreRecoveryPlans([]);
 				toast.error("Failed to fetch quality profile overrides");
 			}
 		},
@@ -248,6 +256,8 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		setSelectedCFs(new Set());
 		setQualityProfileIds([]);
 		setAllOverrides(new Map());
+		setScoreRecoveryPlans([]);
+		setRetryingProfileId(null);
 	}, [instanceId]);
 
 	// Sync scores from query data and reapply retained local edits.
@@ -402,6 +412,31 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		});
 		if (result.successCount > 0) {
 			onOperationComplete?.();
+		}
+	};
+
+	const handleRecoveryRetry = async (plan: ScoreRecoveryPlan) => {
+		if (!instanceId || !plan.retryAction || retryingProfileId !== null) return;
+		setRetryingProfileId(plan.qualityProfileId);
+		try {
+			await bulkUpdateScores.mutateAsync([
+				{
+					entryKey: `${instanceId}-${plan.qualityProfileId}`,
+					profileId: plan.qualityProfileId,
+					instanceId,
+					changes: plan.retryAction.scoreUpdates.map((update) => ({
+						cfTrashId: `cf-${update.customFormatId}`,
+						score: update.score,
+					})),
+					recoveryToken: plan.retryAction.recoveryToken,
+				},
+			]);
+			await fetchOverridesForProfiles(qualityProfileIds);
+			onOperationComplete?.();
+		} catch (error) {
+			toast.error(getErrorMessage(error, "The exact score retry failed"));
+		} finally {
+			setRetryingProfileId(null);
 		}
 	};
 
@@ -660,6 +695,64 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 					)}
 				</div>
 			</div>
+
+			{scoreRecoveryPlans.length > 0 && (
+				<div className="rounded-2xl border border-warning/40 bg-warning/10 p-4">
+					<div className="flex items-start gap-3">
+						<AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-warning" />
+						<div className="min-w-0 flex-1 space-y-3">
+							<div>
+								<p className="font-medium text-foreground">Unfinished score updates</p>
+								<p className="text-sm text-muted-foreground">
+									A previous ARR write has an uncertain result. Resolve it before making other score
+									or deployment changes.
+								</p>
+							</div>
+							{scoreRecoveryPlans.map((plan) => {
+								const profileName =
+									scores
+										.flatMap((score) => score.templateScores)
+										.find(
+											(templateScore) =>
+												parseInt(templateScore.templateId.split("-").pop() || "0", 10) ===
+												plan.qualityProfileId,
+										)?.qualityProfileName ?? `Profile ${plan.qualityProfileId}`;
+								return (
+									<div
+										key={plan.qualityProfileId}
+										className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-border/50 bg-card/60 p-3"
+									>
+										<div>
+											<p className="text-sm font-medium text-foreground">{profileName}</p>
+											<p className="text-xs text-muted-foreground">
+												{plan.entries.length} unresolved score operation
+												{plan.entries.length === 1 ? "" : "s"}
+											</p>
+										</div>
+										{plan.retryable && plan.retryAction ? (
+											<button
+												type="button"
+												onClick={() => void handleRecoveryRetry(plan)}
+												disabled={isScoreSavePending || retryingProfileId !== null}
+												className="inline-flex items-center gap-2 rounded-xl border border-warning/50 bg-warning/15 px-4 py-2 text-sm font-medium text-foreground disabled:opacity-50"
+											>
+												{retryingProfileId === plan.qualityProfileId && (
+													<Loader2 className="h-4 w-4 animate-spin" />
+												)}
+												Retry score update for {profileName}
+											</button>
+										) : (
+											<p className="text-sm font-medium text-warning">
+												Manual reconciliation required
+											</p>
+										)}
+									</div>
+								);
+							})}
+						</div>
+					</div>
+				</div>
+			)}
 
 			{/* Save/Discard Changes Bar */}
 			{modifiedScores.size > 0 && (

--- a/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
+++ b/apps/web/src/features/trash-guides/components/bulk-score-manager.tsx
@@ -27,7 +27,7 @@ import {
 	Square,
 	X,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useBulkScores } from "../../../hooks/api/useBulkScores";
 import {
@@ -36,6 +36,8 @@ import {
 } from "../../../hooks/api/useQualityProfileOverrides";
 import {
 	type BulkScoreUpdateEntry,
+	BulkUpdateScoresError,
+	type BulkUpdateScoresResult,
 	useBulkUpdateScores,
 } from "../../../hooks/api/useQualityProfileScores";
 import { useServicesQuery } from "../../../hooks/api/useServicesQuery";
@@ -51,6 +53,69 @@ const SERVICE_COLORS = {
 	radarr: SERVICE_GRADIENTS.radarr,
 	sonarr: SERVICE_GRADIENTS.sonarr,
 };
+
+function createScoreEditKey(cfTrashId: string, entryKey: string) {
+	return JSON.stringify([entryKey, cfTrashId]);
+}
+
+type ModifiedScores = Map<string, Map<string, number>>;
+
+function mergeModifiedScoresIntoQuery(
+	queryScores: CustomFormatScoreEntry[],
+	previousScores: CustomFormatScoreEntry[],
+	modifiedScores: ModifiedScores,
+): CustomFormatScoreEntry[] {
+	const previousByTrashId = new Map(previousScores.map((score) => [score.trashId, score]));
+	const mergedScores = [...queryScores];
+	const includedTrashIds = new Set(queryScores.map((score) => score.trashId));
+
+	for (const cfTrashId of modifiedScores.keys()) {
+		const previousScore = previousByTrashId.get(cfTrashId);
+		if (!includedTrashIds.has(cfTrashId) && previousScore) {
+			mergedScores.push(previousScore);
+			includedTrashIds.add(cfTrashId);
+		}
+	}
+
+	return mergedScores.map((score) => {
+		const edits = modifiedScores.get(score.trashId);
+		if (!edits || edits.size === 0) return score;
+
+		const previousTemplateScores = new Map(
+			(previousByTrashId.get(score.trashId)?.templateScores ?? []).map((templateScore) => [
+				templateScore.templateId,
+				templateScore,
+			]),
+		);
+		const templateScores = [...score.templateScores];
+		const templateIndexes = new Map(
+			templateScores.map((templateScore, index) => [templateScore.templateId, index]),
+		);
+
+		for (const [entryKey, currentScore] of edits) {
+			const existingIndex = templateIndexes.get(entryKey);
+			const existingTemplateScore =
+				existingIndex === undefined
+					? previousTemplateScores.get(entryKey)
+					: templateScores[existingIndex];
+			if (!existingTemplateScore) continue;
+
+			const mergedTemplateScore = {
+				...existingTemplateScore,
+				currentScore,
+				isModified: currentScore !== existingTemplateScore.defaultScore,
+			};
+			if (existingIndex === undefined) {
+				templateIndexes.set(entryKey, templateScores.length);
+				templateScores.push(mergedTemplateScore);
+			} else {
+				templateScores[existingIndex] = mergedTemplateScore;
+			}
+		}
+
+		return { ...score, templateScores, hasAnyModifications: true };
+	});
+}
 
 interface BulkScoreManagerProps {
 	/** User ID for data fetching */
@@ -88,7 +153,10 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 	const [scores, setScores] = useState<CustomFormatScoreEntry[]>([]);
 
 	// Track modified scores for saving
-	const [modifiedScores, setModifiedScores] = useState<Map<string, Map<string, number>>>(new Map());
+	const [modifiedScores, setModifiedScores] = useState<ModifiedScores>(new Map());
+	const modifiedScoresRef = useRef<ModifiedScores>(modifiedScores);
+	const previousInstanceIdRef = useRef(instanceId);
+	const [pendingScoreEditKeys, setPendingScoreEditKeys] = useState<Set<string>>(new Set());
 
 	// Track selected CFs for bulk operations
 	const [selectedCFs, setSelectedCFs] = useState<Set<string>>(new Set());
@@ -99,6 +167,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 	// Bulk update scores hook
 	const bulkUpdateScores = useBulkUpdateScores();
+	const isScoreSavePending = bulkUpdateScores.isPending || pendingScoreEditKeys.size > 0;
 
 	// Track quality profile IDs and their overrides
 	const [qualityProfileIds, setQualityProfileIds] = useState<number[]>([]);
@@ -114,6 +183,10 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		}
 		return map;
 	}, [allOverrides]);
+
+	useEffect(() => {
+		modifiedScoresRef.current = modifiedScores;
+	}, [modifiedScores]);
 
 	// Fetch overrides for multiple quality profiles using bulk API
 	const fetchOverridesForProfiles = useCallback(
@@ -141,7 +214,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 				if (data?.success && data.overridesByProfile) {
 					for (const [profileIdStr, overrides] of Object.entries(data.overridesByProfile)) {
-						const profileId = parseInt(profileIdStr);
+						const profileId = parseInt(profileIdStr, 10);
 						for (const override of overrides as Array<{ customFormatId: number; score: number }>) {
 							const key = `${profileId}-${override.customFormatId}`;
 							newOverrides.set(key, {
@@ -163,11 +236,27 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		[instanceId],
 	);
 
-	// Sync scores from query data and fetch overrides
+	// Clear instance-specific local state before applying data for another instance.
+	useEffect(() => {
+		if (previousInstanceIdRef.current === instanceId) return;
+		previousInstanceIdRef.current = instanceId;
+		const emptyModifiedScores: ModifiedScores = new Map();
+		modifiedScoresRef.current = emptyModifiedScores;
+		setScores([]);
+		setModifiedScores(emptyModifiedScores);
+		setPendingScoreEditKeys(new Set());
+		setSelectedCFs(new Set());
+		setQualityProfileIds([]);
+		setAllOverrides(new Map());
+	}, [instanceId]);
+
+	// Sync scores from query data and reapply retained local edits.
 	useEffect(() => {
 		if (bulkScoresData?.data?.scores) {
 			const queryScores = bulkScoresData.data.scores;
-			setScores(queryScores);
+			setScores((previousScores) =>
+				mergeModifiedScoresIntoQuery(queryScores, previousScores, modifiedScoresRef.current),
+			);
 
 			const profileIds = new Set<number>();
 			for (const score of queryScores) {
@@ -190,13 +279,6 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 			};
 		}
 	}, [bulkScoresData, fetchOverridesForProfiles]);
-
-	// Clear local state when instance changes
-	useEffect(() => {
-		setScores([]);
-		setModifiedScores(new Map());
-		setSelectedCFs(new Set());
-	}, [instanceId]);
 
 	// Handle score change in table
 	const handleScoreChange = (cfTrashId: string, templateId: string, newScore: number) => {
@@ -234,6 +316,8 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 	// Save all modified scores
 	const handleSaveChanges = async () => {
+		if (isScoreSavePending) return;
+
 		if (modifiedScores.size === 0) {
 			toast.error("No changes to save");
 			return;
@@ -243,10 +327,23 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 			toast.error("No instance selected");
 			return;
 		}
+		const submittedScores = new Map(
+			Array.from(modifiedScores, ([cfTrashId, templateScores]) => [
+				cfTrashId,
+				new Map(templateScores),
+			]),
+		);
+		setPendingScoreEditKeys(
+			new Set(
+				Array.from(submittedScores).flatMap(([cfTrashId, templateScores]) =>
+					Array.from(templateScores.keys(), (entryKey) => createScoreEditKey(cfTrashId, entryKey)),
+				),
+			),
+		);
 
 		const profileUpdates = new Map<string, Array<{ cfTrashId: string; score: number }>>();
 
-		for (const [cfTrashId, templateScores] of modifiedScores.entries()) {
+		for (const [cfTrashId, templateScores] of submittedScores.entries()) {
 			for (const [templateId, newScore] of templateScores.entries()) {
 				if (!profileUpdates.has(templateId)) {
 					profileUpdates.set(templateId, []);
@@ -257,8 +354,9 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 		const entries: BulkScoreUpdateEntry[] = Array.from(profileUpdates.entries()).map(
 			([templateId, changes]) => {
-				const profileId = parseInt(templateId.split("-").pop() || "0");
+				const profileId = parseInt(templateId.split("-").pop() || "0", 10);
 				return {
+					entryKey: templateId,
 					profileId,
 					instanceId,
 					changes,
@@ -266,17 +364,50 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 			},
 		);
 
+		let result: BulkUpdateScoresResult;
 		try {
-			await bulkUpdateScores.mutateAsync(entries);
-			setModifiedScores(new Map());
+			result = await bulkUpdateScores.mutateAsync(entries);
+		} catch (error) {
+			if (!(error instanceof BulkUpdateScoresError)) {
+				return;
+			}
+			result = error.result;
+		} finally {
+			setPendingScoreEditKeys(new Set());
+		}
+
+		const successfulEntryKeys = new Set(
+			result.results
+				.filter((profileResult) => profileResult.success)
+				.map(({ entryKey }) => entryKey),
+		);
+		setModifiedScores((current) => {
+			const retained = new Map<string, Map<string, number>>();
+			for (const [cfTrashId, templateScores] of current) {
+				const retainedTemplateScores = new Map(templateScores);
+				for (const entryKey of successfulEntryKeys) {
+					const submittedScore = submittedScores.get(cfTrashId)?.get(entryKey);
+					if (
+						submittedScore !== undefined &&
+						retainedTemplateScores.get(entryKey) === submittedScore
+					) {
+						retainedTemplateScores.delete(entryKey);
+					}
+				}
+				if (retainedTemplateScores.size > 0) {
+					retained.set(cfTrashId, retainedTemplateScores);
+				}
+			}
+			return retained;
+		});
+		if (result.successCount > 0) {
 			onOperationComplete?.();
-		} catch (_error) {
-			// error surfaced through mutation state
 		}
 	};
 
 	// Discard unsaved changes
 	const handleDiscardChanges = () => {
+		if (isScoreSavePending) return;
 		if (modifiedScores.size === 0) return;
 
 		if (confirm("Are you sure you want to discard all unsaved changes?")) {
@@ -291,12 +422,13 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		customFormatId: number,
 		customFormatName: string,
 	) => {
+		if (isScoreSavePending) return;
 		if (!instanceId) {
 			toast.error("No instance selected");
 			return;
 		}
 
-		const profileId = parseInt(templateId.split("-").pop() || "0");
+		const profileId = parseInt(templateId.split("-").pop() || "0", 10);
 		if (profileId === 0) {
 			toast.error("Invalid quality profile ID");
 			return;
@@ -323,6 +455,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 
 	// Handle bulk reset to template
 	const handleBulkResetToTemplate = async () => {
+		if (isScoreSavePending) return;
 		if (!instanceId) {
 			toast.error("Please select an instance first");
 			return;
@@ -336,8 +469,8 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 		const profileToCFs = new Map<number, Set<number>>();
 
 		for (const trashId of selectedCFs) {
-			const cfId = parseInt(trashId.replace("cf-", ""));
-			if (isNaN(cfId)) continue;
+			const cfId = parseInt(trashId.replace("cf-", ""), 10);
+			if (Number.isNaN(cfId)) continue;
 
 			for (const profileId of qualityProfileIds) {
 				const overrideKey = `${profileId}-${cfId}`;
@@ -467,7 +600,10 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 					<div className="relative min-w-[200px]">
 						<select
 							value={instanceId}
-							onChange={(e) => setInstanceId(e.target.value)}
+							onChange={(e) => {
+								if (!isScoreSavePending) setInstanceId(e.target.value);
+							}}
+							disabled={isScoreSavePending}
 							className="w-full appearance-none rounded-xl border border-border/50 bg-card/50 px-4 py-2.5 pr-10 text-sm font-medium text-foreground focus:outline-hidden focus:ring-2 transition-all"
 							style={{ ["--tw-ring-color" as string]: themeGradient.from }}
 						>
@@ -557,7 +693,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 							<button
 								type="button"
 								onClick={handleDiscardChanges}
-								disabled={bulkUpdateScores.isPending}
+								disabled={isScoreSavePending}
 								className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium transition-colors border border-border/50 bg-card/50 hover:bg-card/80 text-foreground disabled:opacity-50"
 							>
 								<X className="h-4 w-4" />
@@ -566,14 +702,14 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 							<button
 								type="button"
 								onClick={handleSaveChanges}
-								disabled={bulkUpdateScores.isPending}
+								disabled={isScoreSavePending}
 								className="inline-flex items-center gap-2 rounded-xl px-5 py-2 text-sm font-medium text-white transition-all duration-200 disabled:opacity-50"
 								style={{
 									background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,
 									boxShadow: `0 4px 12px -4px ${themeGradient.glow}`,
 								}}
 							>
-								{bulkUpdateScores.isPending ? (
+								{isScoreSavePending ? (
 									<>
 										<Loader2 className="h-4 w-4 animate-spin" />
 										Saving...
@@ -621,6 +757,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 						<button
 							type="button"
 							onClick={handleBulkResetToTemplate}
+							disabled={isScoreSavePending}
 							className="inline-flex items-center gap-2 rounded-xl px-5 py-2 text-sm font-medium text-white transition-all duration-200"
 							style={{
 								background: `linear-gradient(135deg, ${SEMANTIC_COLORS.warning.from}, #d97706)`,
@@ -764,10 +901,10 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 										</td>
 										{/* Editable score cells for each template */}
 										{score.templateScores.map((templateScore) => {
-											const cfId = parseInt(score.trashId.replace("cf-", ""));
+											const cfId = parseInt(score.trashId.replace("cf-", ""), 10);
 											const parts = templateScore.templateId.split("-");
 											const lastPart = parts[parts.length - 1];
-											const profileId = parseInt(lastPart || "0");
+											const profileId = parseInt(lastPart || "0", 10);
 
 											const overrideKey = `${profileId}-${cfId}`;
 											const hasOverride = overrideMap.has(overrideKey);
@@ -779,8 +916,11 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 														<input
 															type="number"
 															value={templateScore.currentScore}
+															disabled={pendingScoreEditKeys.has(
+																createScoreEditKey(score.trashId, templateScore.templateId),
+															)}
 															onChange={(e) => {
-																const newScore = parseInt(e.target.value) || 0;
+																const newScore = parseInt(e.target.value, 10) || 0;
 																handleScoreChange(
 																	score.trashId,
 																	templateScore.templateId,
@@ -822,6 +962,7 @@ export function BulkScoreManager({ userId: _userId, onOperationComplete }: BulkS
 																onClick={() =>
 																	handleDeleteOverride(templateScore.templateId, cfId, score.name)
 																}
+																disabled={isScoreSavePending}
 																className="absolute -top-1.5 -right-1.5 flex h-5 w-5 items-center justify-center rounded-full text-white transition-all duration-200 hover:scale-110"
 																style={{
 																	background: `linear-gradient(135deg, ${themeGradient.from}, ${themeGradient.to})`,

--- a/apps/web/src/hooks/api/__tests__/useQualityProfileScores.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useQualityProfileScores.test.tsx
@@ -1,0 +1,279 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { toast } from "sonner";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { bulkScoreKeys, qualityProfileKeys } from "../../../lib/query-keys";
+
+const apiMocks = vi.hoisted(() => ({
+	updateQualityProfileScores: vi.fn(),
+}));
+
+vi.mock("../../../lib/api-client/trash-guides", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../lib/api-client/trash-guides")>();
+	return {
+		...actual,
+		updateQualityProfileScores: apiMocks.updateQualityProfileScores,
+	};
+});
+
+vi.mock("sonner", () => ({
+	toast: {
+		error: vi.fn(),
+		success: vi.fn(),
+		warning: vi.fn(),
+	},
+}));
+
+import { useBulkUpdateScores } from "../useQualityProfileScores";
+
+function createWrapper(queryClient: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+	};
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, reject, resolve };
+}
+
+const successfulResponse = {
+	success: true,
+	message: "Scores updated",
+	updatedCount: 1,
+};
+
+describe("useBulkUpdateScores", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("waits for each profile update before starting the next one", async () => {
+		const firstUpdate = createDeferred<typeof successfulResponse>();
+		const secondUpdate = createDeferred<typeof successfulResponse>();
+		apiMocks.updateQualityProfileScores
+			.mockReturnValueOnce(firstUpdate.promise)
+			.mockReturnValueOnce(secondUpdate.promise);
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		let mutationPromise!: ReturnType<typeof result.current.mutateAsync>;
+		act(() => {
+			mutationPromise = result.current.mutateAsync([
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					changes: [{ cfTrashId: "cf-10", score: -10000 }],
+				},
+				{
+					entryKey: "instance-1-202",
+					instanceId: "instance-1",
+					profileId: 202,
+					changes: [{ cfTrashId: "cf-20", score: 125 }],
+				},
+			]);
+		});
+
+		await waitFor(() => expect(apiMocks.updateQualityProfileScores).toHaveBeenCalledTimes(1));
+		expect(apiMocks.updateQualityProfileScores).toHaveBeenNthCalledWith(1, "instance-1", 101, {
+			scoreUpdates: [{ customFormatId: 10, score: -10000 }],
+		});
+
+		act(() => firstUpdate.resolve(successfulResponse));
+		await waitFor(() => expect(apiMocks.updateQualityProfileScores).toHaveBeenCalledTimes(2));
+
+		act(() => secondUpdate.resolve(successfulResponse));
+		await act(async () => {
+			await mutationPromise;
+		});
+		queryClient.clear();
+	});
+
+	it("reports complete success as saved quality profiles", async () => {
+		apiMocks.updateQualityProfileScores.mockResolvedValue(successfulResponse);
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await act(async () => {
+			await result.current.mutateAsync([
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					changes: [{ cfTrashId: "cf-10", score: -10000 }],
+				},
+			]);
+		});
+
+		expect(toast.success).toHaveBeenCalledWith("Saved scores for 1 quality profile");
+		expect(toast.warning).not.toHaveBeenCalled();
+		expect(toast.error).not.toHaveBeenCalled();
+		queryClient.clear();
+	});
+
+	it("returns typed partial results and refreshes every successful profile", async () => {
+		apiMocks.updateQualityProfileScores
+			.mockResolvedValueOnce(successfulResponse)
+			.mockRejectedValueOnce(new Error("Profile 202 is locked"));
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		let caught: unknown;
+		await act(async () => {
+			caught = await result.current
+				.mutateAsync([
+					{
+						entryKey: "instance-1-101",
+						instanceId: "instance-1",
+						profileId: 101,
+						changes: [{ cfTrashId: "cf-10", score: -10000 }],
+					},
+					{
+						entryKey: "instance-1-202",
+						instanceId: "instance-1",
+						profileId: 202,
+						changes: [{ cfTrashId: "cf-20", score: 125 }],
+					},
+				])
+				.catch((error: unknown) => error);
+		});
+
+		expect(caught).toMatchObject({
+			name: "BulkUpdateScoresError",
+			result: {
+				totalProfiles: 2,
+				successCount: 1,
+				failureCount: 1,
+				results: [
+					{
+						entryKey: "instance-1-101",
+						instanceId: "instance-1",
+						profileId: 101,
+						success: true,
+					},
+					{
+						entryKey: "instance-1-202",
+						instanceId: "instance-1",
+						profileId: 202,
+						success: false,
+					},
+				],
+			},
+		});
+		await waitFor(() =>
+			expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: bulkScoreKeys.all }),
+		);
+		expect(invalidateQueries).toHaveBeenCalledWith({
+			queryKey: qualityProfileKeys.overrides("instance-1", 101),
+		});
+		expect(invalidateQueries).not.toHaveBeenCalledWith({
+			queryKey: qualityProfileKeys.overrides("instance-1", 202),
+		});
+		expect(toast.warning).toHaveBeenCalledWith("Saved scores for 1 of 2 quality profiles", {
+			description: "1 quality profile failed. Failed edits were kept for retry.",
+		});
+		expect(toast.error).not.toHaveBeenCalled();
+		queryClient.clear();
+	});
+
+	it("reports complete failure without implying that any scores were saved", async () => {
+		apiMocks.updateQualityProfileScores.mockRejectedValue(new Error("Profile 101 is locked"));
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await act(async () => {
+			await result.current
+				.mutateAsync([
+					{
+						entryKey: "instance-1-101",
+						instanceId: "instance-1",
+						profileId: 101,
+						changes: [{ cfTrashId: "cf-10", score: -10000 }],
+					},
+				])
+				.catch(() => undefined);
+		});
+
+		expect(toast.error).toHaveBeenCalledWith("No quality profile scores were saved", {
+			description: "Failed to update 1 quality profile(s): Profile 101 is locked",
+		});
+		expect(toast.success).not.toHaveBeenCalled();
+		expect(toast.warning).not.toHaveBeenCalled();
+		queryClient.clear();
+	});
+
+	it("rejects an invalid Custom Format ID before starting any profile update", async () => {
+		apiMocks.updateQualityProfileScores.mockResolvedValue(successfulResponse);
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		let caught: unknown;
+		await act(async () => {
+			caught = await result.current
+				.mutateAsync([
+					{
+						entryKey: "instance-1-101",
+						instanceId: "instance-1",
+						profileId: 101,
+						changes: [{ cfTrashId: "cf-10", score: -10000 }],
+					},
+					{
+						entryKey: "instance-1-202",
+						instanceId: "instance-1",
+						profileId: 202,
+						changes: [{ cfTrashId: "not-a-cf-id", score: 125 }],
+					},
+				])
+				.catch((error: unknown) => error);
+		});
+
+		expect(apiMocks.updateQualityProfileScores).not.toHaveBeenCalled();
+		expect(caught).toMatchObject({
+			name: "BulkUpdateScoresError",
+			result: {
+				totalProfiles: 2,
+				successCount: 0,
+				failureCount: 2,
+				results: [
+					{ entryKey: "instance-1-101", success: false },
+					{
+						entryKey: "instance-1-202",
+						success: false,
+						error: expect.objectContaining({
+							message: expect.stringContaining('Invalid Custom Format ID "not-a-cf-id"'),
+						}),
+					},
+				],
+			},
+		});
+		queryClient.clear();
+	});
+});

--- a/apps/web/src/hooks/api/__tests__/useQualityProfileScores.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useQualityProfileScores.test.tsx
@@ -126,6 +126,34 @@ describe("useBulkUpdateScores", () => {
 		queryClient.clear();
 	});
 
+	it("forwards the durable recovery token on an exact retry", async () => {
+		apiMocks.updateQualityProfileScores.mockResolvedValue(successfulResponse);
+		const queryClient = new QueryClient({
+			defaultOptions: { mutations: { retry: false }, queries: { retry: false } },
+		});
+		const { result } = renderHook(() => useBulkUpdateScores(), {
+			wrapper: createWrapper(queryClient),
+		});
+
+		await act(async () => {
+			await result.current.mutateAsync([
+				{
+					entryKey: "instance-1-101",
+					instanceId: "instance-1",
+					profileId: 101,
+					changes: [{ cfTrashId: "cf-10", score: 75 }],
+					recoveryToken: "a".repeat(64),
+				},
+			]);
+		});
+
+		expect(apiMocks.updateQualityProfileScores).toHaveBeenCalledWith("instance-1", 101, {
+			recoveryToken: "a".repeat(64),
+			scoreUpdates: [{ customFormatId: 10, score: 75 }],
+		});
+		queryClient.clear();
+	});
+
 	it("returns typed partial results and refreshes every successful profile", async () => {
 		apiMocks.updateQualityProfileScores
 			.mockResolvedValueOnce(successfulResponse)

--- a/apps/web/src/hooks/api/useQualityProfileScores.ts
+++ b/apps/web/src/hooks/api/useQualityProfileScores.ts
@@ -15,6 +15,7 @@ export type BulkScoreUpdateEntry = {
 	profileId: number;
 	instanceId: string;
 	changes: Array<{ cfTrashId: string; score: number }>;
+	recoveryToken?: string;
 };
 
 /**
@@ -147,12 +148,14 @@ export function useBulkUpdateScores() {
 			}
 
 			for (const entry of preparedEntries) {
-				const { entryKey, profileId, instanceId, scoreUpdates } = entry;
+				const { entryKey, profileId, instanceId, recoveryToken, scoreUpdates } = entry;
 
 				try {
-					const response = await updateQualityProfileScores(instanceId, profileId, {
-						scoreUpdates,
-					});
+					const response = await updateQualityProfileScores(
+						instanceId,
+						profileId,
+						recoveryToken ? { recoveryToken, scoreUpdates } : { scoreUpdates },
+					);
 
 					results.push({
 						entryKey,

--- a/apps/web/src/hooks/api/useQualityProfileScores.ts
+++ b/apps/web/src/hooks/api/useQualityProfileScores.ts
@@ -11,6 +11,7 @@ import { bulkScoreKeys, qualityProfileKeys } from "../../lib/query-keys";
  * Entry for bulk score update operations
  */
 export type BulkScoreUpdateEntry = {
+	entryKey: string;
 	profileId: number;
 	instanceId: string;
 	changes: Array<{ cfTrashId: string; score: number }>;
@@ -19,13 +20,21 @@ export type BulkScoreUpdateEntry = {
 /**
  * Result from a single profile score update
  */
-export type ProfileUpdateResult = {
+type ProfileUpdateResultBase = {
+	entryKey: string;
 	profileId: number;
 	instanceId: string;
-	success: boolean;
-	response?: UpdateProfileScoresResponse;
-	error?: Error;
 };
+
+export type ProfileUpdateResult =
+	| (ProfileUpdateResultBase & {
+			success: true;
+			response: UpdateProfileScoresResponse;
+	  })
+	| (ProfileUpdateResultBase & {
+			success: false;
+			error: Error;
+	  });
 
 /**
  * Result from bulk score update mutation
@@ -36,6 +45,40 @@ export type BulkUpdateScoresResult = {
 	failureCount: number;
 	results: ProfileUpdateResult[];
 };
+
+export class BulkUpdateScoresError extends Error {
+	readonly result: BulkUpdateScoresResult;
+
+	constructor(message: string, result: BulkUpdateScoresResult) {
+		super(message);
+		this.name = "BulkUpdateScoresError";
+		this.result = result;
+	}
+}
+
+type PreparedBulkScoreUpdateEntry = BulkScoreUpdateEntry & {
+	scoreUpdates: UpdateProfileScoresPayload["scoreUpdates"];
+	validationError?: Error;
+};
+
+function prepareBulkScoreUpdateEntry(entry: BulkScoreUpdateEntry): PreparedBulkScoreUpdateEntry {
+	const scoreUpdates: UpdateProfileScoresPayload["scoreUpdates"] = [];
+	let validationError: Error | undefined;
+
+	for (const { cfTrashId, score } of entry.changes) {
+		const match = /^cf-(\d+)$/.exec(cfTrashId);
+		const customFormatId = match?.[1] === undefined ? Number.NaN : Number(match[1]);
+		if (!Number.isSafeInteger(customFormatId) || customFormatId <= 0) {
+			validationError ??= new Error(
+				`Invalid Custom Format ID "${cfTrashId}"; expected "cf-{positive integer}".`,
+			);
+			continue;
+		}
+		scoreUpdates.push({ customFormatId, score });
+	}
+
+	return { ...entry, scoreUpdates, validationError };
+}
 
 /**
  * Hook to update scores for a single quality profile
@@ -68,8 +111,7 @@ export function useUpdateProfileScores() {
 /**
  * Hook to bulk update scores across multiple quality profiles
  *
- * Accepts an array of { profileId, instanceId, changes } and calls the
- * updateQualityProfileScores API for each entry via Promise.all
+ * Accepts an array of profile score changes and updates each profile in order.
  */
 export function useBulkUpdateScores() {
 	const queryClient = useQueryClient();
@@ -77,55 +119,58 @@ export function useBulkUpdateScores() {
 	return useMutation<BulkUpdateScoresResult, Error, BulkScoreUpdateEntry[]>({
 		mutationFn: async (entries) => {
 			const results: ProfileUpdateResult[] = [];
+			const preparedEntries = entries.map(prepareBulkScoreUpdateEntry);
+			const invalidEntries = preparedEntries.filter(
+				(entry): entry is PreparedBulkScoreUpdateEntry & { validationError: Error } =>
+					entry.validationError !== undefined,
+			);
 
-			// Process all profile updates in parallel
-			const updatePromises = entries.map(async (entry) => {
-				const { profileId, instanceId, changes } = entry;
+			if (invalidEntries.length > 0) {
+				const validationResults: ProfileUpdateResult[] = preparedEntries.map((entry) => ({
+					entryKey: entry.entryKey,
+					profileId: entry.profileId,
+					instanceId: entry.instanceId,
+					success: false,
+					error:
+						entry.validationError ??
+						new Error("Not attempted because another submitted Custom Format ID was invalid."),
+				}));
+				throw new BulkUpdateScoresError(
+					`Score updates were not started: ${invalidEntries.map((entry) => entry.validationError.message).join(" ")}`,
+					{
+						totalProfiles: entries.length,
+						successCount: 0,
+						failureCount: entries.length,
+						results: validationResults,
+					},
+				);
+			}
 
-				// Convert changes to API format (extract CF ID from trashId format "cf-{id}")
-				// Validate cfTrashId format and filter out invalid entries
-				const scoreUpdates = changes
-					.map(({ cfTrashId, score }) => {
-						// Validate format: must be "cf-" followed by digits
-						const match = cfTrashId.match(/^cf-(\d+)$/);
-						if (!match || !match[1]) {
-							console.warn(
-								`Invalid cfTrashId format: "${cfTrashId}" - expected "cf-{number}", skipping`,
-							);
-							return null;
-						}
-						const customFormatId = parseInt(match[1], 10);
-						if (!Number.isFinite(customFormatId)) {
-							console.warn(`Failed to parse customFormatId from "${cfTrashId}", skipping`);
-							return null;
-						}
-						return { customFormatId, score };
-					})
-					.filter((entry): entry is { customFormatId: number; score: number } => entry !== null);
+			for (const entry of preparedEntries) {
+				const { entryKey, profileId, instanceId, scoreUpdates } = entry;
 
 				try {
 					const response = await updateQualityProfileScores(instanceId, profileId, {
 						scoreUpdates,
 					});
 
-					return {
+					results.push({
+						entryKey,
 						profileId,
 						instanceId,
 						success: true,
 						response,
-					} as ProfileUpdateResult;
+					});
 				} catch (error) {
-					return {
+					results.push({
+						entryKey,
 						profileId,
 						instanceId,
 						success: false,
 						error: error instanceof Error ? error : new Error(String(error)),
-					} as ProfileUpdateResult;
+					});
 				}
-			});
-
-			const settledResults = await Promise.all(updatePromises);
-			results.push(...settledResults);
+			}
 
 			const successCount = results.filter((r) => r.success).length;
 			const failureCount = results.filter((r) => !r.success).length;
@@ -137,18 +182,15 @@ export function useBulkUpdateScores() {
 					.map((r) => r.error?.message || "Unknown error")
 					.join(", ");
 
-				const error = Object.assign(
-					new Error(`Failed to update ${failureCount} quality profile(s): ${errorMessages}`),
+				throw new BulkUpdateScoresError(
+					`Failed to update ${failureCount} quality profile(s): ${errorMessages}`,
 					{
-						results: {
-							totalProfiles: entries.length,
-							successCount,
-							failureCount,
-							results,
-						},
+						totalProfiles: entries.length,
+						successCount,
+						failureCount,
+						results,
 					},
 				);
-				throw error;
 			}
 
 			return {
@@ -159,9 +201,8 @@ export function useBulkUpdateScores() {
 			};
 		},
 		onSuccess: (result) => {
-			// Show success toast
 			toast.success(
-				`Successfully saved ${result.successCount} custom format score change${result.successCount === 1 ? "" : "s"}`,
+				`Saved scores for ${result.successCount} quality profile${result.successCount === 1 ? "" : "s"}`,
 			);
 
 			// Invalidate cache keys for all successfully updated profiles
@@ -182,7 +223,29 @@ export function useBulkUpdateScores() {
 			}
 		},
 		onError: (error) => {
-			toast.error("Failed to update custom format scores", {
+			if (error instanceof BulkUpdateScoresError && error.result.successCount > 0) {
+				queryClient.invalidateQueries({
+					queryKey: bulkScoreKeys.all,
+				});
+				for (const profileResult of error.result.results) {
+					if (profileResult.success) {
+						queryClient.invalidateQueries({
+							queryKey: qualityProfileKeys.overrides(
+								profileResult.instanceId,
+								profileResult.profileId,
+							),
+						});
+					}
+				}
+				toast.warning(
+					`Saved scores for ${error.result.successCount} of ${error.result.totalProfiles} quality profiles`,
+					{
+						description: `${error.result.failureCount} quality profile${error.result.failureCount === 1 ? "" : "s"} failed. Failed edits were kept for retry.`,
+					},
+				);
+				return;
+			}
+			toast.error("No quality profile scores were saved", {
 				description: error.message,
 			});
 		},

--- a/apps/web/src/lib/api-client/trash-guides/index.ts
+++ b/apps/web/src/lib/api-client/trash-guides/index.ts
@@ -70,6 +70,7 @@ export {
 export type {
 	BulkDeleteOverridesPayload,
 	BulkDeleteOverridesResponse,
+	BulkOverridesResponse,
 	CFMatchDetails,
 	CFMatchResult,
 	CFValidationResponse,
@@ -91,6 +92,7 @@ export type {
 	PromoteOverrideResponse,
 	// Profile matching types
 	RecommendedCF,
+	ScoreRecoveryPlan,
 	// Score update types
 	ScoreUpdate,
 	UpdateProfileScoresPayload,

--- a/apps/web/src/lib/api-client/trash-guides/profiles.ts
+++ b/apps/web/src/lib/api-client/trash-guides/profiles.ts
@@ -77,9 +77,37 @@ export type InstanceOverride = {
 	updatedAt: string;
 };
 
+export type ScoreRecoveryPlan = {
+	qualityProfileId: number;
+	entries: Array<{
+		customFormatId: number;
+		operation: string | null;
+		intendedScore: number | null;
+		status: string;
+	}>;
+	retryable: boolean;
+	requiresManualReconciliation: boolean;
+	retryAction: {
+		method: "PATCH";
+		recoveryToken: string;
+		scoreUpdates: ScoreUpdate[];
+	} | null;
+};
+
 export type GetOverridesResponse = {
 	success: boolean;
 	overrides: InstanceOverride[];
+	recoveryPlans: ScoreRecoveryPlan[];
+};
+
+export type BulkOverridesResponse = {
+	success: boolean;
+	overridesByProfile: Record<
+		string,
+		Array<{ customFormatId: number; score: number; updatedAt: string }>
+	>;
+	totalOverrides: number;
+	recoveryPlans: ScoreRecoveryPlan[];
 };
 
 export type PromoteOverridePayload = {
@@ -122,6 +150,7 @@ export type ScoreUpdate = {
 
 export type UpdateProfileScoresPayload = {
 	scoreUpdates: ScoreUpdate[];
+	recoveryToken?: string;
 };
 
 export type UpdateProfileScoresResponse = {


### PR DESCRIPTION
## Summary

Hardens per-instance TRaSH profile score retention and the deployment recovery boundary. Instance-only formats retain their exact source scores, while interrupted or unverifiable ARR writes are recorded and surfaced as needing reconciliation instead of being reported as success or ordinary failure.

This PR is stacked on #681 because it relies on that PR source-profile and connection authority checks.

## What changed

- binds cloned profile selections to the exact source profile, connection, Custom Format definitions, and source scores
- resolves equivalent ARR aliases through current connection authority and rejects stale, rebound, conflicting, or cross-user state
- migrates profile mappings and template score overrides with compare-and-swap protection when equivalent aliases change or are removed
- serializes connection and deployment mutations for equivalent endpoints
- records durable pending/applied/uncertain operation state for Custom Format, quality-profile, naming, and score-reset writes
- restores exact prior override state when a reset aborts before any ARR write; attempted but unverifiable writes remain uncertain
- verifies post-write state and preserves exact upstream IDs for recovery and rollback, including duplicate-name cases
- resolves template defaults through persisted Custom Format resource identity and fails closed on conflicting alias snapshots
- reconciles interrupted operations after restart and fails closed when mutation outcome or ownership cannot be established
- binds recovery tokens to the reviewed deployment intent
- separates uncertain outcomes from definite failures in API counters, history, notifications, SSE completion, and direct/bulk UI
- adds a dedicated reconciliation notification event while preserving existing failure subscriptions without duplicate delivery
- retains failed or newer bulk score edits for safe retry and reports complete, partial, failed, and reconciliation-required outcomes honestly

## Validation

Validated commit `fadd706b`:

- shared package build passed
- root typecheck passed
- full tests passed: API 3,645 passed / 43 skipped; web 597 passed; shared 89 passed; 4,331 total passed
- lint passed
- production API and web builds passed
- all changed/new files passed targeted formatting
- independent data-safety review: clean
- independent regression review: clean

The repository-wide format command still reports four inherited OIDC files from the stacked base. None are part of this PR.

## Live verification

The earlier candidate `6adaf26f` was exercised in the isolated Library Cleanup harness against two Radarr and two Sonarr instances:

- cloned fresh templates from HD and UHD profiles for both services
- retained exact live scores, including `-10000` and `250`
- confirmed source scores came from the exact reviewed connection and profile
- completed a renamed cloned-profile deployment without browser errors
- completed an app-driven rollback after verifying the restored Radarr profile matched its saved pre-deployment state

The additional recovery hardening through `fadd706b` is covered by the full automated gauntlet and the two independent clean reviews above; it has not been represented as a newer live-instance run.

Related to #666