### PR TITLE
docs: bound gauntlet review convergence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,29 @@ TRaSH deployment, and upstream write paths are safety-critical.
   data-dependent, or deletion-adjacent code changes. Do not spend subagents on
   trivial documentation-only changes.
 
+## Review convergence
+
+For substantial or safety-critical gauntlets, freeze the acceptance contract
+before full review, give each required critic one discovery pass, and record
+actionable findings in a stable ledger. After discovery closes, review only
+unresolved findings, their remediation delta, and directly affected mutation
+paths; do not restart an unrestricted whole-feature audit after every fix.
+
+- P0 and P1 findings always block. P2 findings block when they violate the
+  frozen contract or were introduced by the current delta. Record unrelated or
+  pre-existing hardening as a follow-up with maintainer rationale.
+- Request one full hosted pull-request review on the frozen candidate and
+  address accepted findings in one remediation batch. Request another full
+  hosted review only when that remediation materially changes the architecture
+  or a safety-critical mutation boundary; otherwise use targeted closure review
+  and CI. A third full review requires a newly scoped gauntlet wave rather than
+  another expansion of the current pull request.
+- A review budget limits repeated re-auditing. It never permits merging with a
+  known unresolved blocker.
+
+Library Cleanup uses the detailed discovery, closure, and exit gates in
+`docs/library-cleanup-gauntlet.md`.
+
 ## Verification gauntlet
 
 Run the narrowest useful test while iterating. Before every PR:

--- a/docs/library-cleanup-gauntlet.md
+++ b/docs/library-cleanup-gauntlet.md
@@ -104,23 +104,87 @@ the matrix pass.
 
 ## Builder and critic loop
 
+The gauntlet has a bounded discovery phase followed by a finding-ledger closure
+phase. A correction does not restart an unrestricted review of the whole
+feature.
+
+### Contract freeze
+
+Before a major implementation wave, freeze its acceptance scenarios, mutation
+boundaries, threat model, required evidence, and explicit out-of-scope work.
+New information may amend the contract, but the amendment and maintainer
+rationale must be recorded before it can expand the blocking scope.
+
+### Discovery phase
+
 For each independently testable gap:
 
 1. Reproduce it against the real code or a production-shaped fixture.
 2. Add a test that fails for the reported behavior.
 3. Have a builder implement the smallest coherent correction.
 4. Run focused validation.
-5. Give the actual diff, tests, and running artifact to fresh critics:
+5. Give the actual diff, tests, and running artifact to independent critics for
+   one complete pass over their assigned surface:
    - rule semantics and preview parity;
    - destructive data safety;
    - retry/idempotency and regression;
    - operator UX and observability, when affected.
-6. Send every reproducible P0, P1, or P2 gap back through the loop.
-7. Run a whole-feature integration pass after each major wave so individually
+6. Record every actionable finding in one ledger with a stable identifier,
+   severity, violated acceptance requirement, owner, status, and closure
+   evidence.
+7. Triage the complete discovery set before starting a remediation batch.
+8. Run a whole-feature integration pass after each major wave so individually
    correct parts do not form an inconsistent system.
 
+Discovery closes after every required critic has completed its assigned pass.
+It is not reopened merely because a later reviewer identifies unrelated
+hardening or a pre-existing condition outside the frozen contract.
+
+### Closure phase
+
+1. Address accepted findings in coherent batches rather than requesting a new
+   review after every small correction.
+2. Closure critics review the unresolved finding identifiers, the lines changed
+   to resolve them, and directly affected mutation paths. They do not begin a
+   fresh whole-feature audit.
+3. A new finding may block closure only when it demonstrates a P0 or P1 issue,
+   or a P2 issue that violates the frozen acceptance contract or was introduced
+   by the remediation delta.
+4. Pre-existing, unrelated, or future-hardening findings are recorded as
+   follow-up candidates with maintainer rationale. They do not reopen the
+   current gauntlet.
+5. Additional targeted closure is required when evidence for an accepted
+   finding is incomplete or a remediation materially changes an architecture or
+   mutation boundary. The review remains scoped to that change.
+
+Severity controls the merge decision:
+
+- P0 and P1 findings always block.
+- P2 findings block when they are in the frozen contract or introduced by the
+  current delta. Other P2 findings require a recorded follow-up decision.
+- P3 suggestions and non-actionable hardening ideas enter the backlog and do
+  not block closure.
+
+### Hosted review budget
+
+Request one full hosted pull-request review on the frozen candidate. Triage all
+of its findings before editing, address accepted findings in one remediation
+batch, and use targeted closure review plus CI to verify that batch. Request a
+second full hosted review only when the remediation materially changes the
+architecture or a safety-critical mutation boundary; otherwise another
+whole-PR review would restart discovery without changing the quality bar. A
+third full hosted review is not part of the current loop. If the exceptional
+second review exposes a contract-invalidating architectural problem, close the
+current wave as not mergeable and open a newly scoped gauntlet wave rather than
+expanding the pull request again.
+
+The normal review budget is one discovery pass per critic domain, one closure
+pass per domain, one full hosted review, and one hosted-review remediation
+batch. This budget limits repeated re-auditing; it never permits merging with a
+known unresolved blocker.
+
 The implementer does not grade its own mutation boundary. Hosted pull-request
-review is an additional critic, not a replacement for the independent
+review remains an additional critic, not a replacement for the independent
 data-safety and regression reviews.
 
 ## Live verification policy
@@ -180,11 +244,19 @@ The umbrella gauntlet is complete only when all of the following are true:
   maintainer rationale and evidence.
 - Every acceptance scenario is green in its required automated and live layers.
 - A fresh repository search finds no untracked open Library Cleanup issue.
-- Fresh independent critics find no reproducible P0, P1, or P2 gap.
+- Every accepted finding identifier has closure evidence; no P0 or P1 finding
+  remains open, and no P2 finding that is in scope or introduced by the current
+  delta remains open.
+- Independent closure critics confirm the accepted findings and directly
+  affected mutation paths. Out-of-scope discoveries have recorded maintainer
+  rationale and follow-up disposition rather than silently expanding the
+  feature.
 - Formatting, shared build when applicable, root typecheck, full tests, lint,
   production build, database smoke tests, Docker builds, and browser
   verification pass.
-- Hosted review is clean and all review threads are resolved.
+- Hosted review has completed within the review budget, every actionable thread
+  is resolved with evidence, and any material-boundary exception has passed its
+  targeted additional review.
 - The final pull request is marked ready, then all newly triggered reviews and
   CI are allowed to finish before a merge decision.
 - Documentation describes the behavior that was actually verified.

--- a/docs/superpowers/plans/2026-08-10-maintenance-issue-gauntlet-program.md
+++ b/docs/superpowers/plans/2026-08-10-maintenance-issue-gauntlet-program.md
@@ -1,0 +1,227 @@
+# Stable Maintenance Issue Gauntlet Program
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve the verified TRaSH Guides and Plex cache reports on stable 2.x
+without combining independent defects, repeatedly reopening full reviews, or
+expanding a pull request beyond its frozen acceptance contract.
+
+**Architecture:** Treat issue closure, Plex history compatibility, TRaSH Auto
+Sync, and Library Cleanup recovery as four independent waves. Each code wave
+gets one focused branch and pull request, a stable finding ledger, one discovery
+pass per required critic, one closure pass, and one hosted review on the frozen
+candidate.
+
+**Tech Stack:** GitHub issues and Actions, TypeScript, Fastify, Prisma,
+Vitest, Next.js, React Query, Docker Compose, Radarr, Sonarr, and Plex.
+
+## Global Constraints
+
+- Stable-user fixes target `main`. Reproduce on `next` after the stable fix and
+  forward-port with a separate pull request when affected.
+- Do not add Plex cache behavior to a TRaSH Guides pull request or TRaSH Guides
+  behavior to a Plex pull request.
+- Production services are read-only evidence sources. Upstream mutations run
+  only against disposable Radarr, Sonarr, Plex, and database fixtures.
+- P0 and P1 findings always block. P2 findings block only when they violate the
+  frozen acceptance contract or were introduced by the current delta.
+- Each wave receives one full hosted review and one remediation batch. A second
+  full review is allowed only after a material architecture or mutation-boundary
+  change. A third full review starts a new scoped wave instead of expanding the
+  current pull request.
+- Do not request a fresh whole-pull-request review after every correction.
+  Closure reviewers inspect accepted finding IDs, their remediation delta, and
+  directly affected paths.
+- Use the humanizer skill for reporter-facing issue and pull-request comments.
+- Use standalone `Closes #N` only after reproducing the reported scenario and
+  verifying the correction against the same scenario.
+
+---
+
+## Scope ledger
+
+| Wave | Reports | Frozen outcome | Pull-request boundary |
+| --- | --- | --- | --- |
+| A: completed-report closure | #665 and #666 | Reporters receive exact merged and `:dev` evidence; completed issues close without code changes | No code pull request |
+| B: Plex history compatibility | #673 and #675 | Both cache refreshers and Library Cleanup can consume complete Plex history on the reported server while incomplete or unstable pagination still fails closed | One Plex-only `main` pull request |
+| C: TRaSH Auto Sync | #674 | A deployed `auto` mapping persists, is represented honestly in the UI, detects an upstream change, and updates the exact mapped ARR profile once | One TRaSH-only `main` pull request |
+| D: Library Cleanup recovery | Existing RECOVERY and AUDIT gates | Real restart and fault-injection evidence verifies durable, idempotent recovery | Separate harness or focused runtime pull requests |
+
+Issues #665 and #666 cannot add new implementation scope unless a reporter
+provides a scenario that still fails on the merged `:dev` image. Such a report
+receives a new finding ID and a new focused wave.
+
+## Bounded gauntlet lifecycle
+
+Every code wave follows these gates:
+
+1. **Contract freeze:** Record the exact reported version, deployment,
+   database, integration version, expected behavior, observed failure, and
+   accepted regression scenarios.
+2. **Reproduction:** Add or run a check that fails at the real boundary before
+   changing production behavior.
+3. **Discovery:** The implementer, regression reviewer, and data-safety reviewer
+   when applicable each inspect the frozen surface once. Record findings as
+   `PLEX-675-NNN`, `TRASH-674-NNN`, or `RECOVERY-NNN`.
+4. **Remediation:** Address accepted findings in one coherent batch with focused
+   red-green tests.
+5. **Closure:** Review only unresolved finding IDs, changed lines, and directly
+   affected callers. Unrelated hardening becomes a follow-up issue with
+   maintainer rationale.
+6. **Integration:** Run the repository gauntlet and the wave's live scenario.
+7. **Hosted review:** Request one whole-pull-request review on the frozen
+   candidate. Triage every result before editing, then use one remediation batch
+   and targeted closure review.
+8. **Release evidence:** Merge only with green required checks. Confirm the
+   `:dev` image before telling reporters the correction is available.
+
+## Task 1: Close reports already fixed by the merged stack
+
+**Files:**
+
+- No repository files change.
+- Evidence: pull requests #681 and #682, merge commits `517605ae` and
+  `d21eed0e`, and successful `main` development-image workflow `31395082514`.
+
+**Interfaces:**
+
+- Consumes: merged live and automated verification for renamed clone targeting
+  and retained instance scores.
+- Produces: closed issues #665 and #666 with accurate release guidance.
+
+- [ ] **Step 1: Reconfirm remote evidence**
+
+  Run:
+
+  ```bash
+  gh pr view 681 --repo Kha-kis/arr-dashboard --json state,mergedAt,mergeCommit,statusCheckRollup
+  gh pr view 682 --repo Kha-kis/arr-dashboard --json state,mergedAt,mergeCommit,statusCheckRollup
+  gh run view 31395082514 --repo Kha-kis/arr-dashboard --json status,conclusion,headSha,url
+  ```
+
+  Expected: both pull requests are merged and the development-image workflow
+  succeeded at `d21eed0e` or a descendant.
+
+- [ ] **Step 2: Respond to and close #665**
+
+  Run the final response through the humanizer skill. The response must state
+  that #681 preserves the exact cloned source profile even when the template is
+  renamed, that the isolated Radarr verification created no duplicate profile,
+  and that the correction is available on `:dev` and will be in the next stable
+  release. Close the issue as completed.
+
+- [ ] **Step 3: Respond to and close #666**
+
+  Run the final response through the humanizer skill. The response must state
+  that #682 preserves exact instance-only scores including negative values such
+  as `-10000`, and that the correction is available on `:dev` and will be in the
+  next stable release. Close the issue as completed.
+
+- [ ] **Step 4: Retire the superseded integration pull request**
+
+  Confirm #672 contains no commits absent from merged replacement pull requests
+  #676 through #682. Add a concise replacement-stack comment and close #672
+  without merging it.
+
+## Task 2: Execute the Plex compatibility wave
+
+**Files:**
+
+- Plan: `docs/superpowers/plans/2026-08-10-plex-history-compatibility.md`
+
+**Interfaces:**
+
+- Consumes: exact HTTP 400 evidence from #673 and #675.
+- Produces: one verified Plex-only stable pull request and reporter follow-up.
+
+- [ ] **Step 1: Complete every task in the Plex plan**
+
+  Do not begin #674 while the Plex implementation branch has unresolved
+  accepted findings or red required checks.
+
+- [ ] **Step 2: Merge and verify the development image**
+
+  After merge, wait for the `Build and Push Dev Docker Image` workflow at the
+  merge commit. Do not claim `:dev` availability from pull-request CI alone.
+
+- [ ] **Step 3: Respond to both Plex reports**
+
+  Explain that both reports shared the same history-sort compatibility defect,
+  include the verified Plex server version and cache paths, and identify the
+  release channel. Close both only after the live cache and Library Cleanup
+  prefetch checks pass.
+
+## Task 3: Execute the TRaSH Auto Sync wave
+
+**Files:**
+
+- Plan: `docs/superpowers/plans/2026-08-10-trash-auto-sync-674.md`
+
+**Interfaces:**
+
+- Consumes: #674's persisted-strategy, UI, and scheduler reproduction.
+- Produces: one verified TRaSH-only stable pull request and reporter follow-up.
+
+- [ ] **Step 1: Complete every task in the Auto Sync plan**
+
+  Do not import Plex compatibility or Library Cleanup recovery work into this
+  branch.
+
+- [ ] **Step 2: Merge and verify the development image**
+
+  Confirm the merged image against disposable Radarr and Sonarr before telling
+  the reporter to retry.
+
+- [ ] **Step 3: Respond to #674**
+
+  Describe the exact reproduced failure and corrected behavior. Do not describe
+  a selected-but-disabled UI control as a scheduler fix unless the live
+  scheduled mutation also passed.
+
+## Task 4: Resume Library Cleanup recovery
+
+**Files:**
+
+- Existing specification: `docs/library-cleanup-gauntlet.md`
+- Future plan: a separately approved recovery and fault-injection plan.
+
+**Interfaces:**
+
+- Consumes: working Plex cache evidence from Wave B.
+- Produces: live SQLite and PostgreSQL restart evidence without reopening Waves
+  B or C.
+
+- [ ] **Step 1: Refresh the Library Cleanup issue audit**
+
+  Search all open issues and comments after Waves B and C merge. Add only
+  reports that directly affect Library Cleanup behavior.
+
+- [ ] **Step 2: Freeze the recovery matrix**
+
+  Cover lost Radarr deletion responses, interrupted Sonarr episode and series
+  operations, terminal-audit recovery, and independently retryable media scans
+  on SQLite and PostgreSQL.
+
+- [ ] **Step 3: Execute recovery as a new bounded wave**
+
+  Production code changes require a reproduced live failure. Passing scenarios
+  remain harness-and-evidence work.
+
+## Program exit gate
+
+The maintenance program is complete when:
+
+- #665 and #666 are closed with accurate merged and `:dev` evidence;
+- #673 and #675 pass the same cache-refresh and Library Cleanup scenarios that
+  previously returned HTTP 400;
+- #674 passes persistence, UI, scheduler, exact-target mutation, restart, and
+  manual/notify non-regression scenarios;
+- every accepted finding ID is closed with evidence;
+- no P0, P1, or in-contract/current-delta P2 remains open;
+- each code wave has green focused tests, repository gauntlet, build, live
+  verification, independent assigned critics, hosted review, and merge CI; and
+- follow-up candidates are recorded outside the closed wave instead of silently
+  expanding its pull request.

--- a/docs/superpowers/plans/2026-08-10-maintenance-issue-gauntlet-program.md
+++ b/docs/superpowers/plans/2026-08-10-maintenance-issue-gauntlet-program.md
@@ -48,7 +48,8 @@ Vitest, Next.js, React Query, Docker Compose, Radarr, Sonarr, and Plex.
 | A: completed-report closure | #665 and #666 | Reporters receive exact merged and `:dev` evidence; completed issues close without code changes | No code pull request |
 | B: Plex history compatibility | #673 and #675 | Both cache refreshers and Library Cleanup can consume complete Plex history on the reported server while incomplete or unstable pagination still fails closed | One Plex-only `main` pull request |
 | C: TRaSH Auto Sync | #674 | A deployed `auto` mapping persists, is represented honestly in the UI, detects an upstream change, and updates the exact mapped ARR profile once | One TRaSH-only `main` pull request |
-| D: Library Cleanup recovery | Existing RECOVERY and AUDIT gates | Real restart and fault-injection evidence verifies durable, idempotent recovery | Separate harness or focused runtime pull requests |
+| D: residual deployment-plan UI | PR #672 | The remaining deployment-plan display and incognito masking are separated from the superseded integration branch and verified without importing its replaced safety stack | One focused TRaSH UI pull request |
+| E: Library Cleanup recovery | Existing RECOVERY and AUDIT gates | Real restart and fault-injection evidence verifies durable, idempotent recovery | Separate harness or focused runtime pull requests |
 
 Issues #665 and #666 cannot add new implementation scope unless a reporter
 provides a scenario that still fails on the merged `:dev` image. Such a report
@@ -124,7 +125,9 @@ Every code wave follows these gates:
 
   Confirm #672 contains no commits absent from merged replacement pull requests
   #676 through #682. Add a concise replacement-stack comment and close #672
-  without merging it.
+  without merging it only if no effective implementation remains. If unique
+  behavior remains, keep #672 open, identify the exact residual paths, and
+  route them to Wave D instead of importing them into Waves B or C.
 
 ## Task 2: Execute the Plex compatibility wave
 
@@ -181,7 +184,41 @@ Every code wave follows these gates:
   a selected-but-disabled UI control as a scheduler fix unless the live
   scheduled mutation also passed.
 
-## Task 4: Resume Library Cleanup recovery
+## Task 4: Extract the residual deployment-plan UI from #672
+
+**Files:**
+
+- Source evidence: PR #672 commits `983c790` and `118c32c`
+- Expected paths:
+  `apps/web/src/features/trash-guides/components/sync-validation-panels.tsx`
+  and
+  `apps/web/src/features/trash-guides/components/sync-validation-modal.tsx`
+
+**Interfaces:**
+
+- Consumes: the deployment-plan display and incognito masking that remain only
+  on #672.
+- Produces: one focused `main` pull request without the safety and recovery
+  implementation already replaced by #676 through #682.
+
+- [ ] **Step 1: Freeze the residual diff**
+
+  Compare #672 at the two identified commits with current `main`. Record only
+  behavior that is still absent. Do not cherry-pick or merge the integration
+  branch wholesale.
+
+- [ ] **Step 2: Write and approve a focused implementation plan**
+
+  Cover deployment-plan rendering, incognito behavior, user-visible browser
+  verification, focused component tests, and the bounded review budget. Keep
+  this wave behind the user-reported Plex and Auto Sync bugs.
+
+- [ ] **Step 3: Implement, verify, and retire #672**
+
+  Merge the focused replacement only after its own gauntlet. Then update and
+  close #672 unmerged with exact replacement evidence.
+
+## Task 5: Resume Library Cleanup recovery
 
 **Files:**
 
@@ -219,6 +256,9 @@ The maintenance program is complete when:
   previously returned HTTP 400;
 - #674 passes persistence, UI, scheduler, exact-target mutation, restart, and
   manual/notify non-regression scenarios;
+- #672 has no unique implementation left and is closed unmerged after its
+  deployment-plan display and incognito masking land through a focused pull
+  request;
 - every accepted finding ID is closed with evidence;
 - no P0, P1, or in-contract/current-delta P2 remains open;
 - each code wave has green focused tests, repository gauntlet, build, live

--- a/docs/superpowers/plans/2026-08-10-plex-history-compatibility.md
+++ b/docs/superpowers/plans/2026-08-10-plex-history-compatibility.md
@@ -95,7 +95,8 @@ Compose, SQLite, and PostgreSQL.
   Run:
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/plex/__tests__/plex-client-completeness.test.ts
   ```
 
   Expected: the new test fails with `Plex API error: HTTP 400 Bad Request`
@@ -144,7 +145,8 @@ Compose, SQLite, and PostgreSQL.
   Run:
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/plex/__tests__/plex-client-completeness.test.ts
   ```
 
   Expected: the compatibility regression and all existing completeness tests
@@ -193,7 +195,8 @@ Compose, SQLite, and PostgreSQL.
 - [ ] **Step 4: Run the client safety suite**
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts src/lib/plex/__tests__/plex-client-media-parts.test.ts
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/plex/__tests__/plex-client-completeness.test.ts src/lib/plex/__tests__/plex-client-media-parts.test.ts
   ```
 
   Expected: all tests pass with no skipped new regression.
@@ -225,7 +228,8 @@ Compose, SQLite, and PostgreSQL.
 - [ ] **Step 1: Run both cache refresher suites**
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-cache-refresher.test.ts src/lib/plex/plex-episode-cache-refresher.test.ts
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/plex/__tests__/plex-cache-refresher.test.ts src/lib/plex/plex-episode-cache-refresher.test.ts
   ```
 
   Expected: both suites pass, including incomplete-history and verification
@@ -234,7 +238,8 @@ Compose, SQLite, and PostgreSQL.
 - [ ] **Step 2: Run the Plex-dependent Library Cleanup suites**
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
   ```
 
   Expected: complete evidence remains usable and incomplete evidence remains

--- a/docs/superpowers/plans/2026-08-10-plex-history-compatibility.md
+++ b/docs/superpowers/plans/2026-08-10-plex-history-compatibility.md
@@ -1,0 +1,341 @@
+# Plex History Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix issues #673 and #675 so Plex cache refresh, episode cache refresh,
+and Library Cleanup can consume a complete history snapshot on Plex
+`1.43.3.10861-07dfddaeb` without weakening pagination safety.
+
+**Architecture:** Send the Plex-compatible single history sort key
+`viewedAt:desc`. Continue to require stable `historyKey` values, exact pagination
+metadata, duplicate rejection, total-size consistency, and a complete second
+snapshot comparison before publishing safety-relevant cache data.
+
+**Tech Stack:** TypeScript, Plex HTTP API, Fastify logging, Zod, Vitest, Docker
+Compose, SQLite, and PostgreSQL.
+
+## Global Constraints
+
+- Target `main` first because both reports affect v2.23.0 stable users.
+- This pull request changes only Plex history request compatibility and its
+  tests. Do not include TRaSH Auto Sync, OIDC formatting, dependency updates, or
+  unrelated Plex endpoint cleanup.
+- Live verification against the user's Plex server is read-only. Do not delete,
+  refresh a media section, change metadata, or expose a Plex token.
+- A complete history inventory remains mandatory for safety-relevant cache
+  publication. Compatibility failure must never become permission to publish a
+  partial snapshot.
+- Use finding IDs `PLEX-675-NNN`. One regression discovery pass and one
+  data-safety discovery pass precede the frozen candidate.
+
+---
+
+### Task 1: Reproduce the compound-sort failure in a focused client test
+
+**Files:**
+
+- Modify: `apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts`
+- Read: `apps/api/src/lib/plex/plex-client.ts:405-510`
+
+**Interfaces:**
+
+- Consumes: `PlexClient.getHistory({ maxResults, requireComplete })`.
+- Produces: a failing regression that accepts only `sort=viewedAt:desc` and
+  returns HTTP 400 for the current comma-separated sort value.
+
+- [ ] **Step 1: Create a stable 201-row history fixture**
+
+  Add a local helper that produces unique stable history rows, including rows
+  sharing the same `viewedAt` value:
+
+  ```ts
+  function historyItem(index: number) {
+    return {
+      historyKey: `/status/sessions/history/${index}`,
+      ratingKey: `movie-${index}`,
+      title: `Movie ${index}`,
+      type: "movie",
+      viewedAt: 1_700_000_000,
+      accountID: 1,
+    };
+  }
+  ```
+
+- [ ] **Step 2: Write the reported compatibility regression**
+
+  Add a test whose fetch stub returns HTTP 400 whenever the `sort` query value
+  contains a comma and returns two valid pages for `viewedAt:desc`:
+
+  ```ts
+  it("uses a Plex-compatible single sort key for complete history", async () => {
+    const history = Array.from({ length: 201 }, (_, index) => historyItem(index));
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(input instanceof Request ? input.url : input.toString());
+      if (url.searchParams.get("sort") !== "viewedAt:desc") {
+        return new Response(null, { status: 400, statusText: "Bad Request" });
+      }
+      const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+      const page = history.slice(offset, offset + 200);
+      return response({ offset, size: page.length, totalSize: history.length, Metadata: page });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = new PlexClient("http://plex.test", "token", log);
+    await expect(
+      client.getHistory({ maxResults: 100_000, requireComplete: true }),
+    ).resolves.toHaveLength(201);
+  });
+  ```
+
+- [ ] **Step 3: Verify the regression fails before implementation**
+
+  Run:
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts
+  ```
+
+  Expected: the new test fails with `Plex API error: HTTP 400 Bad Request`
+  because the request contains `viewedAt:desc,historyKey:desc`.
+
+- [ ] **Step 4: Record the reproduction**
+
+  Create finding `PLEX-675-001` in the branch notes or pull-request finding
+  ledger with the exact current URL, mocked Plex response, and affected callers:
+  `refreshPlexCache`, `refreshPleEpisodeCache`, and Library Cleanup Plex
+  prefetch.
+
+### Task 2: Use the compatible sort without weakening completeness checks
+
+**Files:**
+
+- Modify: `apps/api/src/lib/plex/plex-client.ts:414-487`
+- Test: `apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts`
+
+**Interfaces:**
+
+- Consumes: Plex history pagination parameters.
+- Produces: history requests with the exact sort value `viewedAt:desc`; all
+  existing safety checks remain active.
+
+- [ ] **Step 1: Define the request sort once**
+
+  Add beside the other Plex safety constants:
+
+  ```ts
+  const HISTORY_SORT = "viewedAt:desc";
+  ```
+
+- [ ] **Step 2: Replace the compound query value**
+
+  Build the history path with the constant while leaving page offsets, page
+  sizes, total validation, duplicate checks, and stable-row requirements
+  unchanged:
+
+  ```ts
+  `/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${offset}&X-Plex-Container-Size=${take}`
+  ```
+
+- [ ] **Step 3: Verify the new regression passes**
+
+  Run:
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts
+  ```
+
+  Expected: the compatibility regression and all existing completeness tests
+  pass.
+
+- [ ] **Step 4: Commit the red-green slice**
+
+  ```bash
+  git add apps/api/src/lib/plex/plex-client.ts apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+  git commit -m "fix(plex): use compatible history sorting"
+  ```
+
+### Task 3: Prove same-second pagination still fails closed
+
+**Files:**
+
+- Modify: `apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts`
+
+**Interfaces:**
+
+- Consumes: single-key history ordering and stable history identities.
+- Produces: regression evidence that equal timestamps cannot silently create a
+  partial published inventory.
+
+- [ ] **Step 1: Assert every page uses the compatible sort**
+
+  Extend the 201-row same-second test to inspect every fetch call:
+
+  ```ts
+  for (const [input] of fetchMock.mock.calls) {
+    const url = new URL(input instanceof Request ? input.url : input.toString());
+    expect(url.searchParams.get("sort")).toBe("viewedAt:desc");
+  }
+  ```
+
+- [ ] **Step 2: Preserve duplicate-page rejection**
+
+  Keep the existing repeated-page test and make its rows share one `viewedAt`
+  value. It must still reject with `duplicate row while paging`.
+
+- [ ] **Step 3: Preserve second-snapshot drift rejection**
+
+  Keep the existing equal-count and middle-page churn tests. Both must still
+  reject before cache publication when the stable history signatures differ.
+
+- [ ] **Step 4: Run the client safety suite**
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-client-completeness.test.ts src/lib/plex/__tests__/plex-client-media-parts.test.ts
+  ```
+
+  Expected: all tests pass with no skipped new regression.
+
+- [ ] **Step 5: Commit the safety assertions**
+
+  ```bash
+  git add apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+  git commit -m "test(plex): retain complete history pagination"
+  ```
+
+### Task 4: Verify every affected cache consumer
+
+**Files:**
+
+- Verify: `apps/api/src/lib/plex/plex-cache-refresher.ts`
+- Verify: `apps/api/src/lib/plex/plex-episode-cache-refresher.ts`
+- Verify: `apps/api/src/lib/library-cleanup/cleanup-executor.ts`
+- Test: `apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts`
+- Test: `apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts`
+
+**Interfaces:**
+
+- Consumes: corrected `PlexClient.getHistory()` and
+  `PlexClient.verifyHistorySnapshot()` behavior.
+- Produces: unchanged atomic cache publication and Library Cleanup fail-closed
+  semantics.
+
+- [ ] **Step 1: Run both cache refresher suites**
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/plex/__tests__/plex-cache-refresher.test.ts src/lib/plex/plex-episode-cache-refresher.test.ts
+  ```
+
+  Expected: both suites pass, including incomplete-history and verification
+  failure cases.
+
+- [ ] **Step 2: Run the Plex-dependent Library Cleanup suites**
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+  ```
+
+  Expected: complete evidence remains usable and incomplete evidence remains
+  blocked.
+
+### Task 5: Live-verify the reporter scenario read-only
+
+**Files:**
+
+- No production files change.
+- Evidence output must exclude tokens, usernames, media titles, and server URLs.
+
+**Interfaces:**
+
+- Consumes: the user's configured Plex instance and the disposable Plex harness.
+- Produces: before-and-after HTTP, cache, episode-cache, and Library Cleanup
+  evidence for the exact reported scenario.
+
+- [ ] **Step 1: Capture the failing baseline**
+
+  On the unmodified base or published v2.23.0 image, trigger the existing Plex
+  cache refresh action. Record Plex version, HTTP 400 status, and the sanitized
+  history path. Do not print or copy the Plex token.
+
+- [ ] **Step 2: Run the candidate against the same Plex server**
+
+  Trigger both Plex cache refresh and Plex episode cache refresh. Confirm both
+  complete without an HTTP 400 and publish fresh cache timestamps.
+
+- [ ] **Step 3: Run a Library Cleanup dry run**
+
+  Use a rule that depends on Plex watch evidence. Confirm Plex prefetch is
+  complete and the dry run remains side-effect free.
+
+- [ ] **Step 4: Exercise the disposable Plex harness**
+
+  Run the existing Library Cleanup policy and retained-identity scenarios on
+  the candidate image. Confirm the single-sort change does not alter retained
+  Plex identity or safety outcomes.
+
+### Task 6: Apply the bounded review and merge gates
+
+**Files:**
+
+- Update: `docs/library-cleanup-gauntlet.md` only if the live evidence changes a
+  recorded Plex compatibility status.
+
+**Interfaces:**
+
+- Consumes: frozen diff and finding ledger.
+- Produces: one merge-ready Plex pull request with bounded review evidence.
+
+- [ ] **Step 1: Run one regression discovery pass**
+
+  Delegate the frozen diff to `regression_reviewer`. Record actionable results
+  as `PLEX-675-NNN` and triage the complete set before editing.
+
+- [ ] **Step 2: Run one data-safety discovery pass**
+
+  Delegate to `data_safety_reviewer` because Plex history is Library Cleanup
+  safety evidence. The reviewer must verify that compatibility fallback cannot
+  publish partial watch history as complete.
+
+- [ ] **Step 3: Address accepted findings in one batch**
+
+  Add focused tests for accepted blockers, apply the smallest corrections, and
+  request targeted closure from the assigned critics. Record unrelated
+  hardening separately.
+
+- [ ] **Step 4: Run the repository gauntlet**
+
+  ```bash
+  pnpm run format
+  pnpm run typecheck
+  pnpm run test
+  pnpm run lint
+  pnpm run build
+  ```
+
+  Expected: every branch-caused gate passes. Any inherited base failure remains
+  visible with a base-branch reproduction.
+
+- [ ] **Step 5: Open the focused pull request**
+
+  Use `Related to #673` and `Related to #675` until the live reporter scenarios
+  pass. Upgrade to standalone close lines only after exact verification.
+
+- [ ] **Step 6: Request one hosted review**
+
+  Triage the complete hosted finding set before editing. Use one remediation
+  batch and targeted closure. Request a second full hosted review only after a
+  material change to history pagination or cache-publication safety.
+
+- [ ] **Step 7: Merge and verify `:dev`**
+
+  Squash-merge after required checks and reviewers are green. Wait for the
+  development-image workflow at the merge commit, then use humanized responses
+  on #673 and #675.
+
+- [ ] **Step 8: Assess `next` separately**
+
+  Reproduce the request construction on `next`. If affected, forward-port the
+  focused commit in a separate branch and pull request without merging `main`
+  wholesale.

--- a/docs/superpowers/plans/2026-08-10-trash-auto-sync-674.md
+++ b/docs/superpowers/plans/2026-08-10-trash-auto-sync-674.md
@@ -1,0 +1,434 @@
+# TRaSH Auto Sync Issue 674 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reproduce and correct issue #674 so selecting Auto Sync during a
+template deployment is persisted, displayed honestly, and causes one verified
+deployment to the exact mapped Radarr or Sonarr endpoint after an upstream TRaSH
+change.
+
+**Architecture:** Treat Auto Sync as a linked contract with five observable
+boundaries: deployment request, durable mapping authority, UI readback, global
+update detection, and exact-endpoint scheduled deployment. Diagnose those
+boundaries in order and correct only the first broken contract plus directly
+dependent behavior. Keep the separate per-template `TrashSyncSchedule.autoApply`
+feature out of the correction unless the reporter's exact reproduction proves
+that it is the failed trigger.
+
+**Tech Stack:** TypeScript, Fastify, Prisma, Vitest, React, React Query, Docker
+Compose, SQLite, PostgreSQL, Radarr, and Sonarr.
+
+## Frozen acceptance contract
+
+- The stable-user correction targets `main`; `next` is assessed and
+  forward-ported separately.
+- A successful single or bulk deployment submitted with `syncStrategy: "auto"`
+  stores `auto` on every equivalent endpoint mapping that was authorized by the
+  deployment.
+- Reloading the template statistics shows Auto Sync as the current strategy. A
+  disabled Auto Sync menu item may mean "already selected," but the surrounding
+  UI must make that state unambiguous.
+- The global TRaSH update scheduler, enabled by default and running immediately
+  at startup and then on its configured interval, detects a newer repository
+  commit and calls `processAutoUpdates(userId)`.
+- An eligible auto mapping updates its template and deploys to each distinct
+  physical ARR endpoint exactly once. Equivalent service aliases do not create
+  duplicate writes.
+- `manual` mappings never deploy from the global update scheduler. `notify`
+  mappings report available updates without mutating ARR.
+- User modifications, new CF-group approval requirements, stale connection
+  authority, ambiguous mappings, disabled instances, partial writes, and
+  uncertain responses remain fail-closed and visible.
+- Production Radarr and Sonarr instances are read-only evidence sources. Every
+  scheduled write is exercised against disposable instances.
+- Use finding IDs `TRASH-674-NNN`. P0/P1 and in-contract or delta-introduced P2
+  findings block; unrelated hardening becomes a follow-up.
+
+---
+
+### Task 1: Capture the exact reported state before changing code
+
+**Files:**
+
+- Read: `apps/api/src/plugins/trash-update-scheduler.ts`
+- Read: `apps/api/src/lib/trash-guides/update-scheduler.ts`
+- Read: `apps/api/src/lib/trash-guides/template-updater.ts`
+- Read: `apps/api/src/routes/trash-guides/deployment-routes.ts`
+- Read: `apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx`
+- Read: `apps/web/src/features/trash-guides/components/template-stats.tsx`
+
+**Interfaces:**
+
+- Consumes: issue #674 on v2.23.0, Unraid, and SQLite.
+- Produces: a sanitized evidence record identifying the first broken boundary.
+
+- [ ] **Step 1: Create the stable task branch**
+
+  ```bash
+  git fetch origin main next
+  git switch --create codex/fix-674-trash-auto-sync origin/main
+  pnpm install --frozen-lockfile
+  ```
+
+- [ ] **Step 2: Inspect the reporter-equivalent persisted state read-only**
+
+  Deploy a template with Auto Sync in a disposable v2.23.0 environment, then
+  capture these values without secrets or profile names:
+
+  - deployment request `syncStrategy`;
+  - mapping `templateId`, `instanceId`, `qualityProfileId`, `syncStrategy`,
+    `connectionGeneration`, and whether `connectionStateToken` is present;
+  - template `trashGuidesCommitHash`, `hasUserModifications`, and
+    `lastSyncedAt`;
+  - update-scheduler enabled state, interval, last run, next run, and last
+    result; and
+  - the template-stats API strategy returned after a full reload.
+
+  Record the boundary as one of:
+
+  1. request lost before execution;
+  2. mapping persisted with the wrong strategy;
+  3. mapping is correct but UI readback is misleading;
+  4. scheduler does not detect or process the update; or
+  5. processing begins but exact-endpoint deployment is skipped or fails.
+
+- [ ] **Step 3: Confirm which scheduler contract the reporter used**
+
+  Verify that choosing Auto Sync in deployment creates or updates
+  `TemplateQualityProfileMapping.syncStrategy`; it does not implicitly create a
+  `TrashSyncSchedule`. Open the schedule dialog only to record whether the
+  reporter also created an explicit schedule. Do not combine the two mechanisms
+  in the correction merely because both can write to ARR.
+
+- [ ] **Step 4: Record the root reproduction**
+
+  Add `TRASH-674-001` to the pull-request finding ledger with the first failed
+  boundary, exact sanitized inputs, expected output, actual output, and the
+  narrow production paths that own the failure. Freeze that file set before
+  implementation.
+
+### Task 2: Add an end-to-end contract regression before the fix
+
+**Files:**
+
+- Modify: `apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts`
+- Modify: `apps/api/src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts`
+- Modify: `apps/api/src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts`
+- Modify: `apps/web/src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx`
+- Modify:
+  `apps/web/src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx`
+- Create only if UI readback is the failed boundary:
+  `apps/web/src/features/trash-guides/components/__tests__/template-stats-sync-strategy.test.tsx`
+
+**Interfaces:**
+
+- Consumes: the frozen `TRASH-674-001` reproduction.
+- Produces: one failing test at the first broken boundary and passing coverage
+  for already-correct adjacent boundaries.
+
+- [ ] **Step 1: Assert deployment strategy persistence**
+
+  Extend the deployment authority route suite so a successful request with
+  `syncStrategy: "auto"` leaves every equivalent mapping at `auto` while
+  retaining the exact user, template, profile, connection generation, and
+  connection state token. Assert one authorized upstream deployment and no
+  strategy update when deployment fails or is uncertain.
+
+- [ ] **Step 2: Assert frontend request and readback behavior**
+
+  Extend `deployment-execution-token.test.tsx` to select the Auto-sync button,
+  execute the deployment, and assert the mutation payload contains both the
+  exact preview token and `syncStrategy: "auto"`. Extend the hook suite to
+  assert successful execution invalidates all of these query surfaces:
+
+  ```ts
+  trashGuidesKeys.deployment.all
+  trashGuidesKeys.templates.stats(templateId)
+  TEMPLATES_QUERY_KEY
+  ```
+
+  If `TRASH-674-001` is UI-only, add a focused component test with
+  `<IncognitoProvider>` that renders an `auto` mapping as the selected state and
+  explains why its matching menu command is disabled.
+
+- [ ] **Step 3: Assert update detection and scheduler handoff**
+
+  Build an outdated template fixture whose persisted mapping is `auto`, whose
+  repository commit changes from `old` to `new`, and whose
+  `hasUserModifications` value is false. Assert:
+
+  ```ts
+  expect(updateCheck.templatesWithUpdates[0]).toMatchObject({
+    autoSyncInstanceCount: 1,
+    canAutoSync: true,
+  });
+  ```
+
+  Then trigger `UpdateScheduler.triggerCheck()` and assert
+  `processAutoUpdates(userId)` runs once for the owning user.
+
+- [ ] **Step 4: Assert exact-endpoint deployment**
+
+  Extend `template-updater-authority.test.ts` with one Radarr mapping, one
+  Sonarr mapping, and an equivalent alias fixture in separate test cases. For
+  each service, assert an eligible update:
+
+  - synchronizes the template from `old` to `new`;
+  - invokes the deployment executor once per distinct physical endpoint;
+  - passes no client preview token into scheduler automation;
+  - resolves authority again from current mappings and connection state; and
+  - returns successful only after verified upstream completion.
+
+- [ ] **Step 5: Run the focused tests before implementation**
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+  pnpm --filter @arr/web test -- src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
+  ```
+
+  Expected: exactly the test representing `TRASH-674-001` fails. If all tests
+  pass, stop and reproduce the live timing, repository configuration, or UI
+  cache state more faithfully; do not invent a production change.
+
+### Task 3: Correct only the reproduced boundary
+
+**Files:**
+
+- Allowed deployment-persistence paths:
+  `apps/api/src/lib/trash-guides/deployment-executor.ts`,
+  `apps/api/src/routes/trash-guides/deployment-routes.ts`
+- Allowed UI paths:
+  `apps/web/src/hooks/api/useDeploymentPreview.ts`,
+  `apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx`,
+  `apps/web/src/features/trash-guides/components/template-stats.tsx`
+- Allowed scheduler paths:
+  `apps/api/src/plugins/trash-update-scheduler.ts`,
+  `apps/api/src/lib/trash-guides/update-scheduler.ts`,
+  `apps/api/src/lib/trash-guides/template-updater.ts`
+
+**Interfaces:**
+
+- Consumes: the single failing contract regression.
+- Produces: the smallest correction that makes the exact reproduction pass.
+
+- [ ] **Step 1: Select one remediation path from the evidence**
+
+  Apply only the path matching `TRASH-674-001`:
+
+  - **Persistence path:** carry the validated deployment strategy through
+    successful finalization and atomically persist it across equivalent
+    mappings. Never change mapping authority after failed or uncertain writes.
+  - **UI path:** invalidate the exact stats key after deployment and render the
+    persisted strategy as a selected status. Keep commands disabled only while
+    a mutation is pending or when selecting the already-current value.
+  - **Scheduler path:** make startup/interval execution include every owning
+    user with an eligible mapped template, compare the configured repository
+    commit consistently, and call `processAutoUpdates` once. Preserve the
+    concurrent-run guard and maintenance guard.
+  - **Automation deployment path:** resolve current equivalent mappings and
+    current connection authority immediately before mutation, deduplicate by
+    endpoint key, and preserve failed versus uncertain results.
+
+  If evidence shows more than one pre-existing boundary is broken, split the
+  additional independent boundary into `TRASH-674-002` and a second focused
+  commit in this same issue wave. Do not add unrelated TRaSH redesign work.
+
+- [ ] **Step 2: Make the failing regression pass**
+
+  Run the focused command from Task 2 after each coherent edit. Do not weaken
+  the regression or replace exact assertions with call-count-only checks.
+
+- [ ] **Step 3: Commit the red-green correction**
+
+  Stage only the frozen file set and its tests:
+
+  ```bash
+  git diff --check
+  git diff --stat
+  git commit -m "fix(trash): honor automatic deployment strategy"
+  ```
+
+### Task 4: Run the Auto Sync behavior matrix
+
+**Files:**
+
+- Modify: `apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts`
+- Modify: `apps/api/src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts`
+- Modify when directly affected:
+  `apps/api/src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts`
+- Modify when directly affected:
+  `apps/api/src/lib/trash-guides/__tests__/maintenance-gate.test.ts`
+
+**Interfaces:**
+
+- Consumes: corrected Auto Sync boundary.
+- Produces: regression proof for eligibility, safety, retries, aliases, and
+  non-auto strategies.
+
+- [ ] **Step 1: Cover positive and negative strategies**
+
+  Add parameterized assertions for:
+
+  | Mapping state | Template state | Expected scheduler behavior |
+  | --- | --- | --- |
+  | `auto` | newer commit, unmodified | one exact-endpoint deployment |
+  | `manual` | newer commit | no deployment and no automatic mutation |
+  | `notify` | newer commit | pending/notification evidence, no deployment |
+  | `auto` | same commit | no sync and no deployment |
+  | `auto` | user modifications | skip with actionable attention state |
+  | `auto` | CF-group approval required | skip with approval state |
+  | `auto` | disabled instance | no upstream mutation |
+
+- [ ] **Step 2: Cover identity and concurrency**
+
+  Prove equivalent service aliases produce one physical write, conflicting
+  aliases fail closed, stale connection mappings fail closed, and concurrent
+  scheduler invocations cannot overlap on the same endpoint.
+
+- [ ] **Step 3: Cover partial, uncertain, and retry behavior**
+
+  Prove that:
+
+  - a verified success advances mapping/history state once;
+  - a definite failure remains failed and retryable;
+  - an uncertain write is not reported as success and creates the existing
+    review notification;
+  - restarting after an uncertain operation cannot blindly repeat the write;
+    and
+  - a second scheduler tick with no new repository commit performs no write.
+
+- [ ] **Step 4: Keep explicit schedules independent**
+
+  Run the `sync-scheduler-uncertain.test.ts` suite. Assert that changing
+  deployment Auto Sync does not create, alter, or execute a
+  `TrashSyncSchedule`, and that `autoApply: false` remains non-mutating for the
+  explicit schedule feature.
+
+- [ ] **Step 5: Run the complete focused matrix**
+
+  ```bash
+  pnpm --filter @arr/api test -- src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/sync-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts src/lib/trash-guides/__tests__/maintenance-gate.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+  pnpm --filter @arr/web test -- src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
+  ```
+
+### Task 5: Verify the real lifecycle against disposable ARR instances
+
+**Files:**
+
+- No production files change.
+- Store only sanitized evidence in the pull request.
+
+**Interfaces:**
+
+- Consumes: candidate API/web image, disposable Radarr and Sonarr, controlled
+  TRaSH repository/cache fixture, SQLite, and PostgreSQL.
+- Produces: observable persistence, UI, scheduler, mutation, restart, and
+  idempotency evidence.
+
+- [ ] **Step 1: Run the Radarr lifecycle on SQLite**
+
+  Deploy a cloned quality profile with Auto Sync. Reload the browser and verify
+  the strategy status. Advance the controlled TRaSH commit with one benign score
+  change, trigger the same global scheduler path used in production, and verify
+  the exact mapped Radarr profile changes once. Confirm mapping identity,
+  deployment history, scheduler statistics, and notification state.
+
+- [ ] **Step 2: Run the Sonarr lifecycle on PostgreSQL**
+
+  Repeat the same scenario with a disposable Sonarr instance and PostgreSQL.
+  Use an episode-capable quality profile, but keep the mutation limited to
+  quality-profile configuration rather than media files.
+
+- [ ] **Step 3: Verify restart and repeat behavior**
+
+  Restart the candidate after the successful update. Confirm the startup
+  scheduler runs, sees the current commit, and performs no duplicate ARR write.
+  Then advance the controlled commit again and confirm one new write.
+
+- [ ] **Step 4: Verify manual, notify, and guarded states live**
+
+  Change the disposable mapping to Manual and then Notify Only. Advance the
+  controlled commit for each state and confirm zero ARR writes. Re-enable Auto,
+  introduce a user modification or approval-required CF group, and confirm the
+  scheduler reports the block without mutation.
+
+- [ ] **Step 5: Compare production configuration read-only**
+
+  Against the user's production Radarr and Sonarr, inspect only service version,
+  scheduler status, and sanitized mapping eligibility. Do not trigger a
+  deployment or alter repository state.
+
+### Task 6: Apply the bounded review and release gates
+
+**Files:**
+
+- Update API route documentation only if the correction changes a route
+  contract. Do not add documentation churn otherwise.
+
+**Interfaces:**
+
+- Consumes: frozen diff, finding ledger, focused tests, and live evidence.
+- Produces: one merge-ready TRaSH-only pull request.
+
+- [ ] **Step 1: Run one regression discovery pass**
+
+  Delegate the complete frozen diff to `regression_reviewer`. Record findings
+  as `TRASH-674-NNN`, triage all of them before editing, and reject findings
+  outside the frozen contract as follow-up candidates.
+
+- [ ] **Step 2: Run one data-safety discovery pass**
+
+  Delegate independently to `data_safety_reviewer` because Auto Sync writes to
+  Radarr and Sonarr. Require review of execution-time ownership, endpoint
+  deduplication, preview independence, partial results, uncertainty, and retry
+  behavior.
+
+- [ ] **Step 3: Address accepted findings in one remediation batch**
+
+  Add red tests for accepted blockers, apply one coherent correction batch, and
+  request targeted closure against finding IDs and changed lines. Do not ask
+  either critic to rediscover the entire pull request.
+
+- [ ] **Step 4: Run the repository gauntlet**
+
+  ```bash
+  pnpm run format
+  pnpm run typecheck
+  pnpm run test
+  pnpm run lint
+  pnpm run build
+  ```
+
+  Expected: every branch-caused gate passes. Any inherited base failure is
+  reproduced on `origin/main` and reported without suppressing it.
+
+- [ ] **Step 5: Open the focused pull request**
+
+  Use `Related to #674` until both the Radarr and Sonarr live lifecycles pass.
+  The pull-request body must include the contract, `TRASH-674-NNN` ledger,
+  focused and full validation, sanitized live evidence, risks, and the separate
+  `next` action.
+
+- [ ] **Step 6: Request one hosted review**
+
+  Triage the complete hosted result before editing. Address accepted findings
+  in one batch and close them with targeted review. Request a second full
+  hosted review only if the correction materially changes scheduler
+  architecture or the upstream mutation boundary. A third full review becomes
+  a new scoped wave.
+
+- [ ] **Step 7: Merge and verify `:dev`**
+
+  Squash-merge only after required checks, assigned critics, hosted review, and
+  both live lifecycles are green. Wait for the development-image workflow at
+  the merge commit and smoke-test that image before using a humanized response
+  on #674.
+
+- [ ] **Step 8: Assess `next` separately**
+
+  Reproduce all five boundaries on `next`. If affected, forward-port the
+  focused stable commit in a separate branch and pull request; do not merge
+  `main` wholesale.

--- a/docs/superpowers/plans/2026-08-10-trash-auto-sync-674.md
+++ b/docs/superpowers/plans/2026-08-10-trash-auto-sync-674.md
@@ -185,8 +185,9 @@ Compose, SQLite, PostgreSQL, Radarr, and Sonarr.
 - [ ] **Step 5: Run the focused tests before implementation**
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
-  pnpm --filter @arr/web test -- src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+  pnpm --filter @arr/web exec vitest run src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
   ```
 
   Expected: exactly the test representing `TRASH-674-001` fails. If all tests
@@ -310,8 +311,9 @@ Compose, SQLite, PostgreSQL, Radarr, and Sonarr.
 - [ ] **Step 5: Run the complete focused matrix**
 
   ```bash
-  pnpm --filter @arr/api test -- src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/sync-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts src/lib/trash-guides/__tests__/maintenance-gate.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
-  pnpm --filter @arr/web test -- src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
+  pnpm --filter @arr/shared build
+  pnpm --filter @arr/api exec vitest run src/lib/trash-guides/__tests__/template-updater-authority.test.ts src/lib/trash-guides/__tests__/update-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/sync-scheduler-uncertain.test.ts src/lib/trash-guides/__tests__/deployment-operation-gate.test.ts src/lib/trash-guides/__tests__/maintenance-gate.test.ts src/routes/trash-guides/__tests__/deployment-authority-writer-locks.test.ts
+  pnpm --filter @arr/web exec vitest run src/hooks/api/__tests__/useDeploymentPreview-authority.test.tsx src/features/trash-guides/components/__tests__/deployment-execution-token.test.tsx
   ```
 
 ### Task 5: Verify the real lifecycle against disposable ARR instances


### PR DESCRIPTION
## Summary

- bound substantial gauntlets to one discovery pass, a finding ledger, one remediation batch, and targeted closure reviews
- define which review findings block a pull request and when a new concern must become a separate wave
- add the execution program for the remaining stable TRaSH, Plex cache, and Library Cleanup work
- add focused implementation plans for Plex issues #673 and #675 and TRaSH Auto Sync issue #674

## Validation

- `git diff --check`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run format` currently reports unchanged OIDC formatting failures already present on `main`

## Risk

Documentation and workflow guidance only. This pull request does not change runtime behavior.
