### PR TITLE
Fix stale watch history in Library Cleanup previews

### DIFF
--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -196,6 +196,92 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(payload.lastWatchedAt).toEqual(new Date("2024-06-20T22:00:00Z"));
 	});
 
+	it("discovers and scans media libraries visible only to a later user", async () => {
+		const twoUsers: JellyfinUser[] = [
+			{ id: "user-1", name: "Alice" },
+			{ id: "user-2", name: "Bob" },
+		];
+		const aliceLibrary: JellyfinLibrary = {
+			id: "lib-alice",
+			name: "Alice TV",
+			collectionType: "tvshows",
+		};
+		const bobLibrary: JellyfinLibrary = {
+			id: "lib-bob",
+			name: "Bob Movies",
+			collectionType: "movies",
+		};
+		const bobMovie = makeSeriesItem({
+			id: "jf-movie-bob",
+			name: "Bob's Recent Movie",
+			type: "Movie",
+			tmdbId: 4242,
+			played: true,
+			playCount: 1,
+			lastPlayedDate: "2026-08-09T20:00:00Z",
+		});
+		const client = {
+			getUsers: vi.fn().mockResolvedValue(twoUsers),
+			getLibraries: vi.fn(async (userId: string) =>
+				userId === "user-1" ? [aliceLibrary] : [bobLibrary],
+			),
+			getLibraryItems: vi.fn(async (userId: string, libraryId: string) => {
+				if (userId === "user-2" && libraryId === "lib-bob") return [bobMovie];
+				return [];
+			}),
+			getResumeItems: vi.fn().mockResolvedValue([]),
+			getNextUp: vi.fn().mockResolvedValue([]),
+		} as unknown as JellyfinClient;
+		const { stub, upserts } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		expect(client.getLibraries).toHaveBeenNthCalledWith(1, "user-1");
+		expect(client.getLibraries).toHaveBeenNthCalledWith(2, "user-2");
+		expect(client.getLibraryItems).toHaveBeenCalledWith(
+			"user-2",
+			"lib-bob",
+			expect.objectContaining({ includeItemTypes: "Movie" }),
+		);
+		expect(upserts).toHaveLength(1);
+		expect(upserts[0]).toMatchObject({
+			create: {
+				libraryId: "lib-bob",
+				lastWatchedAt: new Date("2026-08-09T20:00:00Z"),
+				watchCount: 1,
+				watchedByUsers: '["Bob"]',
+			},
+		});
+	});
+
+	it("fails closed when any user's library inventory is unavailable", async () => {
+		const twoUsers: JellyfinUser[] = [
+			{ id: "user-1", name: "Alice" },
+			{ id: "user-2", name: "Bob" },
+		];
+		const client = {
+			getUsers: vi.fn().mockResolvedValue(twoUsers),
+			getLibraries: vi
+				.fn()
+				.mockResolvedValueOnce(oneLibrary)
+				.mockRejectedValueOnce(new Error("Bob's library inventory was truncated")),
+		} as unknown as JellyfinClient;
+		const deleteMany = vi.fn();
+		const transaction = vi.fn();
+		const stub = { jellyfinCache: { deleteMany }, $transaction: transaction };
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result.complete).toBe(false);
+		expect(result.errors).toBeGreaterThan(0);
+		expect(result.errorMessages).toContainEqual(
+			expect.stringContaining("Bob's library inventory was truncated"),
+		);
+		expect(deleteMany).not.toHaveBeenCalled();
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
 	it("evicts stale rows when a discovered library is authoritatively empty", async () => {
 		const client = makeMockClient([]);
 		const { stub, tx } = makeMockPrisma();
@@ -360,6 +446,35 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(stub.$transaction).toHaveBeenCalledWith(expect.any(Function), {
 			isolationLevel: "Serializable",
 		});
+	});
+
+	it("collects a complete live snapshot without publishing cache state", async () => {
+		const watchedAt = "2024-08-06T10:00:00Z";
+		const client = makeMockClient([
+			makeSeriesItem({ played: true, playCount: 1, lastPlayedDate: watchedAt }),
+		]);
+		const transaction = vi.fn();
+		const stub = { $transaction: transaction };
+
+		const result = await refreshJellyfinCache(
+			client,
+			stub as never,
+			"inst-1",
+			silentLog,
+			undefined,
+			{ publish: false },
+		);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 0 });
+		expect(result.snapshot?.rows).toEqual([
+			expect.objectContaining({
+				instanceId: "inst-1",
+				tmdbId: 99999,
+				lastWatchedAt: new Date(watchedAt),
+				watchCount: 1,
+			}),
+		]);
+		expect(transaction).not.toHaveBeenCalled();
 	});
 
 	it("discards a completed scan when the service connection changed before publication", async () => {

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -18,7 +18,7 @@ import type { FastifyBaseLogger } from "fastify";
 import { getErrorMessage } from "../utils/error-message.js";
 import type { PrismaClient } from "../prisma.js";
 import { withCurrentJellyfinConnection } from "./jellyfin-connection-guard.js";
-import type { JellyfinClient } from "./jellyfin-client.js";
+import type { JellyfinClient, JellyfinLibrary, JellyfinUser } from "./jellyfin-client.js";
 
 export const JELLYFIN_STALE_EVICTION_CHUNK_SIZE = 500;
 
@@ -43,6 +43,49 @@ interface ItemAggregation {
 	thumb: string | null;
 }
 
+export interface JellyfinCacheSnapshotRow {
+	instanceId: string;
+	tmdbId: number;
+	mediaType: "movie" | "series";
+	libraryId: string;
+	libraryName: string;
+	title: string;
+	jellyfinId: string;
+	lastWatchedAt: Date | null;
+	watchCount: number;
+	watchedByUsers: string;
+	onDeck: boolean;
+	userRating: number | null;
+	collections: string;
+	addedAt: Date | null;
+	thumb: string | null;
+}
+
+export interface JellyfinCacheSnapshot {
+	rows: JellyfinCacheSnapshotRow[];
+	users: Array<{ id: string; name: string }>;
+	libraries: Array<{
+		userId: string;
+		libraryId: string;
+		libraryName: string;
+		collectionType: string;
+	}>;
+}
+
+export interface JellyfinCacheRefreshOptions {
+	publish?: boolean;
+}
+
+export interface JellyfinCacheRefreshResult {
+	upserted: number;
+	errors: number;
+	errorMessages: string[];
+	complete: boolean;
+	completedAt?: Date;
+	superseded?: boolean;
+	snapshot?: JellyfinCacheSnapshot;
+}
+
 // ============================================================================
 // Main Refresh Function
 // ============================================================================
@@ -53,14 +96,8 @@ export async function refreshJellyfinCache(
 	instanceId: string,
 	log: FastifyBaseLogger,
 	expectedConnectionFingerprint?: string,
-): Promise<{
-	upserted: number;
-	errors: number;
-	errorMessages: string[];
-	complete: boolean;
-	completedAt?: Date;
-	superseded?: boolean;
-}> {
+	options: JellyfinCacheRefreshOptions = {},
+): Promise<JellyfinCacheRefreshResult> {
 	let upserted = 0;
 	let errors = 0;
 	let complete = true;
@@ -80,19 +117,27 @@ export async function refreshJellyfinCache(
 			};
 		}
 
-		// Use the first user (admin) for library enumeration
-		const primaryUserId = users[0]!.id;
+		// Step 2: Inventory each user's visible media libraries. Jellyfin and Emby
+		// permissions can expose different libraries to different users, so no
+		// single user is an authoritative proxy for server-wide coverage.
+		const librariesByUser: Array<{
+			user: JellyfinUser;
+			libraries: JellyfinLibrary[];
+		}> = [];
+		for (const user of users) {
+			const libraries = await client.getLibraries(user.id);
+			librariesByUser.push({
+				user,
+				libraries: libraries.filter(
+					(lib) =>
+						lib.collectionType === "movies" ||
+						lib.collectionType === "tvshows" ||
+						lib.collectionType === "CollectionFolder",
+				),
+			});
+		}
 
-		// Step 2: Get libraries and filter to movie/tvshow
-		const libraries = await client.getLibraries(primaryUserId);
-		const mediaLibraries = libraries.filter(
-			(lib) =>
-				lib.collectionType === "movies" ||
-				lib.collectionType === "tvshows" ||
-				lib.collectionType === "CollectionFolder",
-		);
-
-		if (mediaLibraries.length === 0) {
+		if (librariesByUser.every(({ libraries }) => libraries.length === 0)) {
 			complete = false;
 			log.info({ instanceId }, "Jellyfin cache refresh: no movie/TV libraries found");
 			return {
@@ -106,15 +151,15 @@ export async function refreshJellyfinCache(
 		// Step 3: Aggregate items across all users
 		const aggregations = new Map<string, ItemAggregation>();
 
-		for (const library of mediaLibraries) {
-			const includeItemTypes =
-				library.collectionType === "movies"
-					? "Movie"
-					: library.collectionType === "tvshows"
-						? "Series"
-						: "Movie,Series"; // CollectionFolder or unknown — fetch both
+		for (const { user, libraries } of librariesByUser) {
+			for (const library of libraries) {
+				const includeItemTypes =
+					library.collectionType === "movies"
+						? "Movie"
+						: library.collectionType === "tvshows"
+							? "Series"
+							: "Movie,Series"; // CollectionFolder or unknown — fetch both
 
-			for (const user of users) {
 				try {
 					const items = await client.getLibraryItems(user.id, library.id, {
 						includeItemTypes,
@@ -232,9 +277,55 @@ export async function refreshJellyfinCache(
 		// Step 5: Publish a complete replacement atomically. An incomplete scan
 		// must leave the previous successful generation untouched.
 		const items = Array.from(aggregations.values());
+		const rows: JellyfinCacheSnapshotRow[] = items.map((agg) => ({
+			instanceId,
+			tmdbId: agg.tmdbId,
+			mediaType: agg.mediaType,
+			libraryId: agg.libraryId,
+			libraryName: agg.libraryName,
+			title: agg.title,
+			jellyfinId: agg.jellyfinId,
+			lastWatchedAt: agg.lastWatchedAt,
+			watchCount: agg.watchCount,
+			watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
+			onDeck: agg.onDeck,
+			userRating: agg.userRating,
+			collections: JSON.stringify([...agg.collections].sort()),
+			addedAt: agg.addedAt,
+			thumb: agg.thumb,
+		}));
 		let completedAt: Date | undefined;
 		if (errors === 0 && complete) {
 			completedAt = new Date();
+			if (options.publish === false) {
+				return {
+					upserted: 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt,
+					snapshot: {
+						rows,
+						users: users
+							.map((user) => ({ id: user.id, name: user.name }))
+							.sort((left, right) => left.id.localeCompare(right.id)),
+						libraries: librariesByUser
+							.flatMap(({ user, libraries }) =>
+								libraries.map((library) => ({
+									userId: user.id,
+									libraryId: library.id,
+									libraryName: library.name,
+									collectionType: library.collectionType,
+								})),
+							)
+							.sort(
+								(left, right) =>
+									left.userId.localeCompare(right.userId) ||
+									left.libraryId.localeCompare(right.libraryId),
+							),
+					},
+				};
+			}
 			try {
 				const publication = await withCurrentJellyfinConnection(
 					prisma,
@@ -313,7 +404,13 @@ export async function refreshJellyfinCache(
 			log.warn({ instanceId, errors }, "Skipping cache publication due to incomplete refresh");
 		}
 
-		return { upserted, errors, errorMessages, complete: complete && errors === 0, completedAt };
+		return {
+			upserted,
+			errors,
+			errorMessages,
+			complete: complete && errors === 0,
+			completedAt,
+		};
 	} catch (err) {
 		complete = false;
 		errors++;

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createMutationPolicySnapshotGetter,
+	executeCleanupPreview,
 	MUTATION_POLICY_SNAPSHOT_MAX_AGE_MS,
 } from "../cleanup-executor.js";
 import type { CleanupExecutorDeps } from "../types.js";
@@ -332,4 +333,260 @@ describe("authoritative mutation policy snapshots", () => {
 		expect(findInstances).not.toHaveBeenCalled();
 		expect(refreshMocks.plex).not.toHaveBeenCalled();
 	});
+});
+
+describe("interactive preview live watch authority", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-08-10T12:00:00.000Z"));
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it.each([
+		["Plex", "PLEX", "plex_last_watched", refreshMocks.plex, "plex"],
+		["Tautulli", "TAUTULLI", "tautulli_last_watched", refreshMocks.tautulli, "tautulli"],
+		["Jellyfin", "JELLYFIN", "jellyfin_last_watched", refreshMocks.jellyfin, "jellyfin"],
+	] as const)(
+		"uses live %s authority without publishing provider cache state",
+		async (_label, service, ruleType, refreshMock, source) => {
+			const provider = { ...instance(service), connectionGeneration: 1 };
+			const radarr = {
+				...instance("PLEX"),
+				id: "radarr-1",
+				service: "RADARR",
+				name: "Radarr",
+				baseUrl: "http://radarr.test",
+				connectionGeneration: 1,
+			};
+			const recentWatch = new Date("2026-08-09T12:00:00.000Z");
+			const snapshot =
+				service === "PLEX"
+					? {
+							rows: [
+								{
+									instanceId: provider.id,
+									tmdbId: 42,
+									mediaType: "movie",
+									sectionId: "1",
+									sectionTitle: "Movies",
+									title: "Recent Movie",
+									ratingKey: "plex-42",
+									lastWatchedAt: recentWatch,
+									watchCount: 1,
+									watchedByUsers: '["alice"]',
+									onDeck: false,
+									userRating: null,
+									collections: "[]",
+									labels: "[]",
+									addedAt: new Date("2025-01-01T00:00:00.000Z"),
+									thumb: null,
+								},
+							],
+							sections: [{ key: "1", title: "Movies", type: "movie" }],
+						}
+					: service === "TAUTULLI"
+						? {
+								rows: [
+									{
+										instanceId: provider.id,
+										tmdbId: 42,
+										mediaType: "movie",
+										lastWatchedAt: recentWatch,
+										watchCount: 1,
+										watchedByUsers: '["alice"]',
+									},
+								],
+							}
+						: {
+								rows: [
+									{
+										instanceId: provider.id,
+										tmdbId: 42,
+										mediaType: "movie",
+										libraryId: "1",
+										libraryName: "Movies",
+										title: "Recent Movie",
+										jellyfinId: "jf-42",
+										lastWatchedAt: recentWatch,
+										watchCount: 1,
+										watchedByUsers: '["alice"]',
+										onDeck: false,
+										userRating: null,
+										collections: "[]",
+										addedAt: new Date("2025-01-01T00:00:00.000Z"),
+										thumb: null,
+									},
+								],
+								users: [{ id: "user-1", name: "Alice" }],
+								libraries: [
+									{
+										userId: "user-1",
+										libraryId: "1",
+										libraryName: "Movies",
+										collectionType: "movies",
+									},
+								],
+							};
+			refreshMock.mockResolvedValue({
+				upserted: 0,
+				errors: 0,
+				errorMessages: [],
+				complete: true,
+				completedAt: new Date(),
+				snapshot,
+			});
+			const transaction = vi.fn();
+			const deleteMany = vi.fn();
+			const createMany = vi.fn();
+			const statusUpsert = vi.fn();
+			const findInstances = vi.fn(async ({ where }: { where: { service?: unknown } }) => {
+				const all = [radarr, provider];
+				if (typeof where.service === "string") {
+					return all.filter((entry) => entry.service === where.service);
+				}
+				if (where.service && typeof where.service === "object" && "in" in where.service) {
+					const services = (where.service as { in: string[] }).in;
+					return all.filter((entry) => services.includes(entry.service));
+				}
+				return all;
+			});
+			const configRule = {
+				...rule(ruleType),
+				parameters: JSON.stringify({ operator: "older_than", days: 30 }),
+				action: "unmonitor",
+				plexLibraryFilter: null,
+				excludeTags: null,
+				excludeTitles: null,
+				scanMediaServerAfterDelete: false,
+				rejectionMemoryDays: 0,
+			};
+			const candidate = {
+				id: "cache-42",
+				instanceId: "radarr-1",
+				arrItemId: 42,
+				itemType: "movie",
+				title: "Recent Movie",
+				year: 2024,
+				monitored: true,
+				hasFile: true,
+				status: "released",
+				qualityProfileId: 1,
+				qualityProfileName: "HD",
+				sizeOnDisk: 1_000n,
+				arrAddedAt: new Date("2025-01-01T00:00:00.000Z"),
+				cachedAt: new Date(),
+				data: JSON.stringify({ tmdbId: 42, service: "radarr" }),
+				torrentState: null,
+				infoHash: null,
+			};
+			const libraryFindMany = vi.fn().mockResolvedValueOnce([candidate]).mockResolvedValue([]);
+			const deps = {
+				prisma: {
+					$transaction: transaction,
+					libraryCleanupConfig: {
+						findUnique: vi.fn().mockResolvedValue({
+							id: "config-1",
+							userId: "user-1",
+							enabled: true,
+							dryRunMode: true,
+							requireApproval: false,
+							maxRemovalsPerRun: 10,
+							respectQuiSeeding: false,
+							rejectionMemoryDays: 0,
+							rules: [configRule],
+						}),
+					},
+					serviceInstance: { findMany: findInstances },
+					libraryCache: { findMany: libraryFindMany },
+					plexCache: { deleteMany, createMany },
+					tautulliCache: { deleteMany, createMany },
+					jellyfinCache: { deleteMany, createMany },
+					cacheRefreshStatus: { upsert: statusUpsert },
+					libraryCleanupApproval: { findMany: vi.fn().mockResolvedValue([]) },
+					libraryCleanupLog: { findFirst: vi.fn().mockResolvedValue(null) },
+				},
+				arrClientFactory: { create: vi.fn() },
+				plexCacheClientFactory: vi.fn(() => ({}) as never),
+				tautulliCacheClientFactory: vi.fn(() => ({}) as never),
+				jellyfinCacheClientFactory: vi.fn(() => ({}) as never),
+				log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+			} as unknown as CleanupExecutorDeps;
+
+			const result = await executeCleanupPreview(deps, "user-1");
+
+			expect(result.itemsEvaluated).toBe(1);
+			expect(result.itemsFlagged).toBe(0);
+			expect(result.previewItemCount).toBe(0);
+			expect(result.details).toEqual([]);
+			expect(result.prefetchHealth?.[source]).toBe("ok");
+			expect(refreshMock).toHaveBeenCalledTimes(2);
+			expect(transaction).not.toHaveBeenCalled();
+			expect(deleteMany).not.toHaveBeenCalled();
+			expect(createMany).not.toHaveBeenCalled();
+			expect(statusUpsert).not.toHaveBeenCalled();
+
+			const changedSnapshot = structuredClone(snapshot);
+			changedSnapshot.rows[0]!.watchCount += 1;
+			refreshMock
+				.mockReset()
+				.mockResolvedValueOnce({
+					upserted: 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt: new Date(),
+					snapshot,
+				})
+				.mockResolvedValueOnce({
+					upserted: 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt: new Date(),
+					snapshot: changedSnapshot,
+				});
+			libraryFindMany.mockReset().mockResolvedValueOnce([candidate]).mockResolvedValue([]);
+
+			const changedResult = await executeCleanupPreview(deps, "user-1");
+
+			expect(changedResult.itemsEvaluated).toBe(1);
+			expect(changedResult.itemsFlagged).toBe(0);
+			expect(changedResult.previewItemCount).toBe(0);
+			expect(changedResult.prefetchHealth?.[source]).toBe("failed");
+			expect(changedResult.warnings).toContainEqual(expect.stringContaining("unavailable"));
+			expect(transaction).not.toHaveBeenCalled();
+			expect(deleteMany).not.toHaveBeenCalled();
+			expect(createMany).not.toHaveBeenCalled();
+			expect(statusUpsert).not.toHaveBeenCalled();
+
+			configRule.parameters = JSON.stringify({ operator: "never" });
+			const unrelatedSnapshot = structuredClone(snapshot);
+			unrelatedSnapshot.rows = [];
+			refreshMock.mockReset().mockResolvedValue({
+				upserted: 0,
+				errors: 0,
+				errorMessages: [],
+				complete: true,
+				completedAt: new Date(),
+				snapshot: unrelatedSnapshot,
+			});
+			libraryFindMany.mockReset().mockResolvedValueOnce([candidate]).mockResolvedValue([]);
+
+			const unrelatedResult = await executeCleanupPreview(deps, "user-1");
+
+			expect(unrelatedResult.itemsEvaluated).toBe(1);
+			expect(unrelatedResult.itemsFlagged).toBe(0);
+			expect(unrelatedResult.previewItemCount).toBe(0);
+			expect(unrelatedResult.prefetchHealth?.[source]).toBe("ok");
+			expect(refreshMock).toHaveBeenCalledTimes(2);
+			expect(transaction).not.toHaveBeenCalled();
+			expect(deleteMany).not.toHaveBeenCalled();
+			expect(createMany).not.toHaveBeenCalled();
+			expect(statusUpsert).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -15,13 +15,16 @@ import type { CleanupRuleExpression, DataSourceDependency } from "@arr/shared";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { Prisma } from "../../generated/prisma/client.js";
 import { isNotFoundError } from "../arr/client-factory.js";
-import { refreshJellyfinCache } from "../jellyfin/jellyfin-cache-refresher.js";
+import {
+	type JellyfinCacheSnapshotRow,
+	refreshJellyfinCache,
+} from "../jellyfin/jellyfin-cache-refresher.js";
 import { runJellyfinCacheRefreshSingleFlight } from "../jellyfin/jellyfin-cache-singleflight.js";
 import { createJellyfinClient } from "../jellyfin/jellyfin-client.js";
 import { refreshJellyfinEpisodeCache } from "../jellyfin/jellyfin-episode-cache-refresher.js";
 import { jellyfinConnectionFingerprint } from "../jellyfin/service-instance-fingerprint.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
-import { refreshPlexCache } from "../plex/plex-cache-refresher.js";
+import { type PlexCacheSnapshotRow, refreshPlexCache } from "../plex/plex-cache-refresher.js";
 import { createPlexClient } from "../plex/plex-client.js";
 import { refreshPlexEpisodeCache } from "../plex/plex-episode-cache-refresher.js";
 import { plexConnectionFingerprint } from "../plex/service-instance-fingerprint.js";
@@ -34,7 +37,10 @@ import type {
 import { withQuiObservationTopologyGuard } from "../qui/observation-topology-guard.js";
 import { SeerrClient } from "../seerr/seerr-client.js";
 import { providerConnectionIdentity } from "../services/provider-connection-guard.js";
-import { refreshTautulliCache } from "../tautulli/tautulli-cache-refresher.js";
+import {
+	refreshTautulliCache,
+	type TautulliCacheSnapshotRow,
+} from "../tautulli/tautulli-cache-refresher.js";
 import { createTautulliClient } from "../tautulli/tautulli-client.js";
 import { createTmdbV3Client } from "../tmdb/list-client.js";
 import { createTraktClient } from "../trakt/list-client.js";
@@ -4589,6 +4595,148 @@ export async function prefetchSeerrRequests(
 	}
 }
 
+function snapshotUsers(value: string): string[] {
+	const parsed = safeJsonParse(value);
+	if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+		throw new Error("Provider snapshot contained invalid watched-user data");
+	}
+	return parsed;
+}
+
+function tautulliSnapshotToWatchMap(rows: TautulliCacheSnapshotRow[]): TautulliWatchMap {
+	const map: TautulliWatchMap = new Map();
+	for (const row of rows) {
+		const key = `${row.mediaType}:${row.tmdbId}`;
+		const watchedByUsers = snapshotUsers(row.watchedByUsers);
+		const existing = map.get(key);
+		if (existing) {
+			if (
+				row.lastWatchedAt &&
+				(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
+			) {
+				existing.lastWatchedAt = row.lastWatchedAt;
+			}
+			existing.watchCount += row.watchCount;
+			for (const user of watchedByUsers) {
+				if (!existing.watchedByUsers.includes(user)) existing.watchedByUsers.push(user);
+			}
+		} else {
+			map.set(key, {
+				lastWatchedAt: row.lastWatchedAt,
+				watchCount: row.watchCount,
+				watchedByUsers: [...watchedByUsers],
+			});
+		}
+	}
+	return map;
+}
+
+function plexSnapshotToWatchMap(rows: PlexCacheSnapshotRow[]): PlexWatchMap {
+	const map: PlexWatchMap = new Map();
+	for (const row of rows) {
+		const key = `${row.mediaType}:${row.tmdbId}`;
+		const watchedByUsers = snapshotUsers(row.watchedByUsers);
+		const collections = snapshotUsers(row.collections);
+		const labels = snapshotUsers(row.labels);
+		const sectionInfo: PlexSectionWatchInfo = {
+			sectionId: row.sectionId,
+			sectionTitle: row.sectionTitle,
+			lastWatchedAt: row.lastWatchedAt,
+			watchCount: row.watchCount,
+			watchedByUsers,
+			onDeck: row.onDeck,
+			userRating: row.userRating,
+			collections,
+			labels,
+			addedAt: row.addedAt,
+		};
+		const existing = map.get(key);
+		if (existing) {
+			existing.sections.push(sectionInfo);
+			if (
+				row.lastWatchedAt &&
+				(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
+			) {
+				existing.lastWatchedAt = row.lastWatchedAt;
+			}
+			existing.watchCount += row.watchCount;
+			for (const user of watchedByUsers) {
+				if (!existing.watchedByUsers.includes(user)) existing.watchedByUsers.push(user);
+			}
+			existing.onDeck = existing.onDeck || row.onDeck;
+			if (row.userRating != null) {
+				existing.userRating =
+					existing.userRating != null
+						? Math.max(existing.userRating, row.userRating)
+						: row.userRating;
+			}
+			for (const collection of collections) {
+				if (!existing.collections.includes(collection)) existing.collections.push(collection);
+			}
+			for (const label of labels) {
+				if (!existing.labels.includes(label)) existing.labels.push(label);
+			}
+			if (row.addedAt && (!existing.addedAt || row.addedAt < existing.addedAt)) {
+				existing.addedAt = row.addedAt;
+			}
+		} else {
+			map.set(key, {
+				lastWatchedAt: row.lastWatchedAt,
+				watchCount: row.watchCount,
+				watchedByUsers: [...watchedByUsers],
+				onDeck: row.onDeck,
+				userRating: row.userRating,
+				collections: [...collections],
+				labels: [...labels],
+				addedAt: row.addedAt,
+				sections: [sectionInfo],
+			});
+		}
+	}
+	return map;
+}
+
+function jellyfinSnapshotToWatchMap(rows: JellyfinCacheSnapshotRow[]): JellyfinWatchMap {
+	const map: JellyfinWatchMap = new Map();
+	for (const row of rows) {
+		const key = `${row.mediaType}:${row.tmdbId}`;
+		const watchedByUsers = snapshotUsers(row.watchedByUsers);
+		const existing = map.get(key);
+		if (existing) {
+			if (
+				row.lastWatchedAt &&
+				(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
+			) {
+				existing.lastWatchedAt = row.lastWatchedAt;
+			}
+			existing.watchCount += row.watchCount;
+			for (const user of watchedByUsers) {
+				if (!existing.watchedByUsers.includes(user)) existing.watchedByUsers.push(user);
+			}
+			existing.onDeck = existing.onDeck || row.onDeck;
+			if (row.userRating != null) {
+				existing.userRating =
+					existing.userRating != null
+						? Math.max(existing.userRating, row.userRating)
+						: row.userRating;
+			}
+			if (row.addedAt && (!existing.addedAt || row.addedAt < existing.addedAt)) {
+				existing.addedAt = row.addedAt;
+			}
+		} else {
+			map.set(key, {
+				lastWatchedAt: row.lastWatchedAt,
+				watchCount: row.watchCount,
+				watchedByUsers: [...watchedByUsers],
+				onDeck: row.onDeck,
+				userRating: row.userRating,
+				addedAt: row.addedAt,
+			});
+		}
+	}
+	return map;
+}
+
 /**
  * Prefetch Tautulli watch data from the TautulliCache table and build a lookup map.
  * Returns undefined if no Tautulli instance is configured.
@@ -5247,7 +5395,7 @@ async function evaluateAllItems(
 	];
 	const hasTautulliRules = TAUTULLI_RULE_TYPES.some((t) => activeTypes.has(t));
 	const tautulliResult = hasTautulliRules
-		? await prefetchTautulliData(deps, config.userId)
+		? await collectLiveTautulliPolicyEvidence(deps, config.userId)
 		: undefined;
 	const tautulliMap = hasTautulliRules ? tautulliResult : undefined;
 
@@ -5272,7 +5420,7 @@ async function evaluateAllItems(
 	const needsPlexSectionInventory = collectConfiguredPlexSectionTitles(seriesRules).size > 0;
 	const publishedPlexEvidence =
 		hasPlexRules || needsPlexSectionInventory
-			? await loadPublishedPlexPolicyEvidence(deps, config.userId, seriesRules)
+			? await collectLivePlexPolicyEvidence(deps, config.userId, seriesRules)
 			: undefined;
 	const plexMap = hasPlexRules ? publishedPlexEvidence?.plexMap : undefined;
 
@@ -5287,7 +5435,7 @@ async function evaluateAllItems(
 	];
 	const hasJellyfinRules = JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t));
 	const jellyfinResult = hasJellyfinRules
-		? await prefetchJellyfinData(deps, config.userId)
+		? await collectLiveJellyfinPolicyEvidence(deps, config.userId)
 		: undefined;
 	const jellyfinMap = hasJellyfinRules ? jellyfinResult : undefined;
 
@@ -8368,6 +8516,7 @@ function providerTopologyFingerprint(instances: ServiceInstance[]): string {
 			service: instance.service,
 			baseUrl: instance.baseUrl,
 			enabled: instance.enabled,
+			connectionGeneration: instance.connectionGeneration,
 			encryptedApiKey: instance.encryptedApiKey,
 			encryptionIv: instance.encryptionIv,
 			encryptedHttpAuthCredentials: instance.encryptedHttpAuthCredentials,
@@ -8511,6 +8660,218 @@ async function loadPublishedPlexPolicyEvidence(
 		return await loadPublishedPlexPolicyEvidenceUnsafe(deps, userId, rules);
 	} catch (error) {
 		deps.log.warn({ err: error }, "Published Plex policy evidence was unavailable");
+		return undefined;
+	}
+}
+
+function sortProviderRows<T extends { instanceId: string; mediaType: string; tmdbId: number }>(
+	rows: T[],
+): T[] {
+	const detailKey = (row: T): string => {
+		if ("sectionId" in row && typeof row.sectionId === "string") return row.sectionId;
+		if ("libraryId" in row && typeof row.libraryId === "string") return row.libraryId;
+		return "";
+	};
+	return [...rows].sort(
+		(left, right) =>
+			left.instanceId.localeCompare(right.instanceId) ||
+			left.mediaType.localeCompare(right.mediaType) ||
+			left.tmdbId - right.tmdbId ||
+			detailKey(left).localeCompare(detailKey(right)) ||
+			evidenceFingerprint(left).localeCompare(evidenceFingerprint(right)),
+	);
+}
+
+async function collectLivePlexPolicyEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	rules: Array<{ enabled: boolean; plexLibraryFilter?: string | null }>,
+): Promise<PublishedPlexPolicyEvidence | undefined> {
+	try {
+		const initial = await loadProviderInstances(deps, userId, ["PLEX"]);
+		if (initial.length === 0) return undefined;
+		const topology = providerTopologyFingerprint(initial);
+		let accepted:
+			| {
+					plexMap: PlexWatchMap;
+					plexSectionTitles: Set<string>;
+					fingerprint: string;
+					completedAt: Date;
+			  }
+			| undefined;
+		for (let pass = 0; pass < 2; pass++) {
+			const rows: PlexCacheSnapshotRow[] = [];
+			const sections = new Set<string>();
+			const completions: Date[] = [];
+			for (const instance of initial) {
+				const client =
+					deps.plexCacheClientFactory?.(instance) ??
+					(deps.encryptor ? createPlexClient(deps.encryptor, instance, deps.log) : null);
+				if (!client) throw new Error("Plex credentials were unavailable");
+				const collected = await refreshPlexCache(
+					client,
+					deps.prisma,
+					instance.id,
+					deps.log,
+					providerConnectionIdentity(instance),
+					{ publish: false },
+				);
+				if (
+					collected.errors > 0 ||
+					collected.complete !== true ||
+					!collected.completedAt ||
+					!collected.snapshot
+				) {
+					throw new Error("Plex live evidence collection was incomplete");
+				}
+				rows.push(...collected.snapshot.rows);
+				for (const section of collected.snapshot.sections) sections.add(section.title);
+				completions.push(collected.completedAt);
+			}
+			const after = await loadProviderInstances(deps, userId, ["PLEX"]);
+			if (providerTopologyFingerprint(after) !== topology) {
+				throw new Error("Plex topology changed during live evidence collection");
+			}
+			for (const title of collectConfiguredPlexSectionTitles(rules)) {
+				if (!sections.has(title)) throw new Error(`Plex library ${title} was unavailable`);
+			}
+			const sortedRows = sortProviderRows(rows);
+			const fingerprint = evidenceFingerprint([topology, sortedRows, sections]);
+			if (accepted && accepted.fingerprint !== fingerprint) {
+				throw new Error("Plex evidence changed between verification passes");
+			}
+			accepted = {
+				plexMap: plexSnapshotToWatchMap(sortedRows),
+				plexSectionTitles: sections,
+				fingerprint,
+				completedAt: new Date(Math.min(...completions.map((date) => date.getTime()))),
+			};
+		}
+		return accepted
+			? {
+					plexMap: accepted.plexMap,
+					plexSectionTitles: accepted.plexSectionTitles,
+					completedAt: accepted.completedAt,
+					generationFingerprint: accepted.fingerprint,
+				}
+			: undefined;
+	} catch (error) {
+		deps.log.warn({ err: error }, "Live read-only Plex policy evidence failed closed");
+		return undefined;
+	}
+}
+
+async function collectLiveTautulliPolicyEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<TautulliWatchMap | undefined> {
+	try {
+		const initial = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
+		if (initial.length === 0) return undefined;
+		const topology = providerTopologyFingerprint(initial);
+		let accepted: { map: TautulliWatchMap; fingerprint: string } | undefined;
+		for (let pass = 0; pass < 2; pass++) {
+			const rows: TautulliCacheSnapshotRow[] = [];
+			for (const instance of initial) {
+				const client =
+					deps.tautulliCacheClientFactory?.(instance) ??
+					(deps.encryptor ? createTautulliClient(deps.encryptor, instance, deps.log) : null);
+				if (!client) throw new Error("Tautulli credentials were unavailable");
+				const collected = await refreshTautulliCache(
+					client,
+					deps.prisma,
+					instance.id,
+					deps.log,
+					providerConnectionIdentity(instance),
+					{ publish: false },
+				);
+				if (collected.errors > 0 || collected.complete !== true || !collected.snapshot) {
+					throw new Error("Tautulli live evidence collection was incomplete");
+				}
+				rows.push(...collected.snapshot.rows);
+			}
+			const after = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
+			if (providerTopologyFingerprint(after) !== topology) {
+				throw new Error("Tautulli topology changed during live evidence collection");
+			}
+			const sortedRows = sortProviderRows(rows);
+			const fingerprint = evidenceFingerprint([topology, sortedRows]);
+			if (accepted && accepted.fingerprint !== fingerprint) {
+				throw new Error("Tautulli evidence changed between verification passes");
+			}
+			accepted = { map: tautulliSnapshotToWatchMap(sortedRows), fingerprint };
+		}
+		return accepted?.map;
+	} catch (error) {
+		deps.log.warn({ err: error }, "Live read-only Tautulli policy evidence failed closed");
+		return undefined;
+	}
+}
+
+async function collectLiveJellyfinPolicyEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<JellyfinWatchMap | undefined> {
+	try {
+		const initial = await loadProviderInstances(deps, userId, ["JELLYFIN", "EMBY"]);
+		if (initial.length === 0) return undefined;
+		const topology = providerTopologyFingerprint(initial);
+		let accepted: { map: JellyfinWatchMap; fingerprint: string } | undefined;
+		for (let pass = 0; pass < 2; pass++) {
+			const rows: JellyfinCacheSnapshotRow[] = [];
+			const coverage: Array<{
+				instanceId: string;
+				users: Array<{ id: string; name: string }>;
+				libraries: Array<{
+					userId: string;
+					libraryId: string;
+					libraryName: string;
+					collectionType: string;
+				}>;
+			}> = [];
+			for (const instance of initial) {
+				const client =
+					deps.jellyfinCacheClientFactory?.(instance) ??
+					(deps.encryptor ? createJellyfinClient(deps.encryptor, instance, deps.log) : null);
+				if (!client) throw new Error("Jellyfin credentials were unavailable");
+				const collected = await refreshJellyfinCache(
+					client,
+					deps.prisma,
+					instance.id,
+					deps.log,
+					jellyfinConnectionFingerprint(instance),
+					{ publish: false },
+				);
+				if (
+					collected.errors > 0 ||
+					collected.complete !== true ||
+					!collected.snapshot ||
+					!Array.isArray(collected.snapshot.users) ||
+					!Array.isArray(collected.snapshot.libraries)
+				) {
+					throw new Error("Jellyfin live evidence collection was incomplete");
+				}
+				rows.push(...collected.snapshot.rows);
+				coverage.push({
+					instanceId: instance.id,
+					users: collected.snapshot.users,
+					libraries: collected.snapshot.libraries,
+				});
+			}
+			const after = await loadProviderInstances(deps, userId, ["JELLYFIN", "EMBY"]);
+			if (providerTopologyFingerprint(after) !== topology) {
+				throw new Error("Jellyfin topology changed during live evidence collection");
+			}
+			const sortedRows = sortProviderRows(rows);
+			const fingerprint = evidenceFingerprint([topology, sortedRows, coverage]);
+			if (accepted && accepted.fingerprint !== fingerprint) {
+				throw new Error("Jellyfin evidence changed between verification passes");
+			}
+			accepted = { map: jellyfinSnapshotToWatchMap(sortedRows), fingerprint };
+		}
+		return accepted?.map;
+	} catch (error) {
+		deps.log.warn({ err: error }, "Live read-only Jellyfin policy evidence failed closed");
 		return undefined;
 	}
 }
@@ -9134,6 +9495,7 @@ export async function buildEvalContextWithHealth(
 		conditions: string | null;
 		plexLibraryFilter?: string | null;
 	}>,
+	options: { providerEvidence?: "published" | "live" } = {},
 ): Promise<{ ctx: EvalContext; failedSources: Set<DataSourceDependency> }> {
 	const activeTypes = collectActiveRuleTypes(rules);
 
@@ -9199,12 +9561,22 @@ export async function buildEvalContextWithHealth(
 		listEvidence,
 	] = await Promise.all([
 		needsSeerr ? prefetchSeerrRequests(deps, userId) : undefined,
-		needsTautulli ? prefetchTautulliData(deps, userId) : undefined,
+		needsTautulli
+			? options.providerEvidence === "live"
+				? collectLiveTautulliPolicyEvidence(deps, userId)
+				: prefetchTautulliData(deps, userId)
+			: undefined,
 		needsPlex || needsPlexSectionInventory
-			? loadPublishedPlexPolicyEvidence(deps, userId, rules)
+			? options.providerEvidence === "live"
+				? collectLivePlexPolicyEvidence(deps, userId, rules)
+				: loadPublishedPlexPolicyEvidence(deps, userId, rules)
 			: undefined,
 		needsPlexEpisodes ? prefetchPlexEpisodeData(deps, userId) : undefined,
-		needsJellyfin ? prefetchJellyfinData(deps, userId) : undefined,
+		needsJellyfin
+			? options.providerEvidence === "live"
+				? collectLiveJellyfinPolicyEvidence(deps, userId)
+				: prefetchJellyfinData(deps, userId)
+			: undefined,
 		needsJellyfinEpisodes ? prefetchJellyfinEpisodeData(deps, userId) : undefined,
 		refreshListMutationEvidence(deps, userId, rules),
 	]);

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
@@ -711,7 +711,7 @@ describe("qualified provider negatives", () => {
 		).toMatchObject({ kind: "retained", evidence: "unknown" });
 	});
 
-	it("certifies zero only after every configured Plex selector resolves", () => {
+	it("does not certify zero from resolved Plex selectors without an observed item", () => {
 		const rule = makeRule({
 			ruleType: "plex_on_deck",
 			parameters: JSON.stringify({ isDeck: false }),
@@ -724,7 +724,7 @@ describe("qualified provider negatives", () => {
 
 		expect(
 			evaluateRuleState(makeCacheItem(), rule as LibraryCleanupRule, "RADARR", ctx).state,
-		).toBe("true");
+		).toBe("unknown");
 	});
 
 	it.each(["tmdb", "trakt"] as const)(
@@ -800,7 +800,7 @@ describe("tautulli_watch_count rule", () => {
 		expect(result).toContain("play count: 10");
 	});
 
-	it("infers 0 plays for items missing from tautulli when map is populated", () => {
+	it("does not infer 0 plays for an item missing from Tautulli history", () => {
 		// Item with tmdbId 99999 — not in the tautulliMap
 		const missingData = { ...DEFAULT_DATA, remoteIds: { tmdbId: 99999 } };
 		const result = evaluateSingleCondition(
@@ -809,7 +809,7 @@ describe("tautulli_watch_count rule", () => {
 			{ operator: "less_than", count: 1 },
 			ctx,
 		);
-		expect(result).toContain("Tautulli play count: 0");
+		expect(result).toBeNull();
 	});
 
 	it("does not match when count equals threshold for less_than", () => {
@@ -1128,7 +1128,7 @@ describe("composite rules", () => {
 		},
 		{
 			name: "Plex condition without a per-item row",
-			expected: "true",
+			expected: "unknown",
 			ruleType: "plex_on_deck",
 			parameters: { isDeck: true },
 			item: makeCacheItem(),
@@ -1745,18 +1745,18 @@ describe("golden test — multi-rule priority evaluation", () => {
 		expect(result!.ruleId).toBe("r-declined"); // declined rule still matches first
 	});
 
-	it("treats absence from a complete Plex inventory as never watched", () => {
+	it("treats absence from the Plex item inventory as unknown coverage", () => {
 		// No seerr data (tmdbId 99999), high rating (9.0), recently added (1 day)
 		// - r-declined: no seerr data → skip
 		// - r-low-rating: 9.0 not < 5 → skip
-		// - r-never-watched: no per-item Plex row in a complete inventory → known never watched
+		// - r-never-watched: no per-item Plex row → provider coverage is unknown
 		const result = evaluateItemAgainstRules(
 			recentHighRated,
 			rules as LibraryCleanupRule[],
 			"RADARR",
 			ctx,
 		);
-		expect(result).toMatchObject({ ruleId: "r-never-watched", action: "unmonitor" });
+		expect(result).toBeNull();
 	});
 
 	it("protected item is excluded by title pattern in composite rule", () => {

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -865,7 +865,9 @@ function lookupTautulliWatch(
 	const mediaType = item.itemType === "movie" ? "movie" : "series";
 	const key = `${mediaType}:${tmdbId}`;
 
-	return tautulliMap.get(key) ?? { lastWatchedAt: null, watchCount: 0, watchedByUsers: [] };
+	// A complete Tautulli history scan proves only the rows it observed. An
+	// absent TMDB id may belong to another Plex library, so absence is UNKNOWN.
+	return tautulliMap.get(key) ?? null;
 }
 
 /**
@@ -919,23 +921,7 @@ function evaluateTautulliWatchCount(
 	ctx: EvalContext,
 ): string | null {
 	const watch = lookupTautulliWatch(item, ctx.tautulliMap);
-	if (!watch) {
-		// Not in Tautulli — infer 0 plays when Tautulli is configured and item has a file
-		if (
-			ctx.tautulliMap &&
-			ctx.tautulliMap.size > 0 &&
-			params.operator === "less_than" &&
-			params.count > 0 &&
-			item.hasFile &&
-			item.arrAddedAt
-		) {
-			const ageDays = Math.floor(
-				(ctx.now.getTime() - item.arrAddedAt.getTime()) / (1000 * 60 * 60 * 24),
-			);
-			return `Not tracked by Tautulli, in library for ${ageDays} days (threshold: < ${params.count} plays)`;
-		}
-		return null;
-	}
+	if (!watch) return null;
 	const count = watch.watchCount;
 
 	// Age context for low play counts
@@ -1019,7 +1005,10 @@ function lookupPlexWatch(
 		addedAt: null,
 		sections: [],
 	};
-	const entry = plexMap.get(key) ?? emptyEntry;
+	const entry = plexMap.get(key);
+	// Plex refreshes inventory every item in each visible section, including
+	// unwatched items. Only an observed row can therefore certify a negative.
+	if (!entry) return null;
 
 	// If no filter, return the pre-computed aggregates (existing behavior)
 	if (!plexLibraryFilter || plexLibraryFilter.length === 0) return entry;
@@ -1340,16 +1329,9 @@ function lookupJellyfinWatch(
 	const tmdbId = remoteIds?.tmdbId;
 	if (!tmdbId) return null;
 	const mediaType = item.itemType === "movie" ? "movie" : "series";
-	return (
-		jellyfinMap.get(`${mediaType}:${tmdbId}`) ?? {
-			lastWatchedAt: null,
-			watchCount: 0,
-			watchedByUsers: [],
-			onDeck: false,
-			userRating: null,
-			addedAt: null,
-		}
-	);
+	// Jellyfin refreshes every item visible to every enumerated user. Missing
+	// rows are not evidence that an unrelated ARR library was never watched.
+	return jellyfinMap.get(`${mediaType}:${tmdbId}`) ?? null;
 }
 
 function evaluateJellyfinLastWatched(

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -221,6 +221,47 @@ describe("evictStaleRows", () => {
 		expect(tx.plexCache.createMany).not.toHaveBeenCalled();
 	});
 
+	it("collects a verified live snapshot without publishing cache state", async () => {
+		const watchedAt = 1_723_000_000;
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "rk-1",
+					title: "Recent Movie",
+					type: "movie",
+					Guid: [{ id: "tmdb://12345" }],
+				},
+			]),
+			getHistory: vi
+				.fn()
+				.mockResolvedValue([
+					{ type: "movie", ratingKey: "rk-1", accountID: 1, viewedAt: watchedAt },
+				]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined, {
+			publish: false,
+		});
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 0 });
+		expect(result.snapshot?.rows).toEqual([
+			expect.objectContaining({
+				instanceId: "inst-1",
+				tmdbId: 12345,
+				lastWatchedAt: new Date(watchedAt * 1000),
+				watchCount: 1,
+			}),
+		]);
+		expect(result.snapshot?.sections).toEqual([{ key: "1", title: "Movies", type: "movie" }]);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
 	it("discards an outgoing Plex generation after its connection changes before publication", async () => {
 		let resolveLibraryItems: (items: unknown[]) => void = () => {};
 		const pendingLibraryItems = new Promise<unknown[]>((resolve) => {

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -67,6 +67,44 @@ interface ItemAggregation {
 	thumb: string | null;
 }
 
+export interface PlexCacheSnapshotRow {
+	instanceId: string;
+	tmdbId: number;
+	mediaType: "movie" | "series";
+	sectionId: string;
+	sectionTitle: string;
+	title: string;
+	ratingKey: string | null;
+	lastWatchedAt: Date | null;
+	watchCount: number;
+	watchedByUsers: string;
+	onDeck: boolean;
+	userRating: number | null;
+	collections: string;
+	labels: string;
+	addedAt: Date | null;
+	thumb: string | null;
+}
+
+export interface PlexCacheSnapshot {
+	rows: PlexCacheSnapshotRow[];
+	sections: Array<{ key: string; title: string; type: "movie" | "show" }>;
+}
+
+export interface PlexCacheRefreshOptions {
+	publish?: boolean;
+}
+
+export interface PlexCacheRefreshResult {
+	upserted: number;
+	errors: number;
+	errorMessages: string[];
+	complete: boolean;
+	completedAt?: Date;
+	superseded?: boolean;
+	snapshot?: PlexCacheSnapshot;
+}
+
 function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): string[] {
 	return items
 		.map((item) =>
@@ -93,14 +131,8 @@ export async function refreshPlexCache(
 	instanceId: string,
 	log: FastifyBaseLogger,
 	expectedConnection: ProviderConnectionIdentity | undefined,
-): Promise<{
-	upserted: number;
-	errors: number;
-	errorMessages: string[];
-	complete: boolean;
-	completedAt?: Date;
-	superseded?: boolean;
-}> {
+	options: PlexCacheRefreshOptions = {},
+): Promise<PlexCacheRefreshResult> {
 	let upserted = 0;
 	let errors = 0;
 	let complete = true;
@@ -311,6 +343,46 @@ export async function refreshPlexCache(
 				throw new Error("Plex on-deck state changed before cache publication");
 			}
 			completedAt = new Date();
+			if (options.publish === false) {
+				const sections = mediaLibs
+					.map((section) => ({
+						key: section.key,
+						title: section.title,
+						type: section.type as "movie" | "show",
+					}))
+					.sort(
+						(left, right) =>
+							left.key.localeCompare(right.key) ||
+							left.title.localeCompare(right.title) ||
+							left.type.localeCompare(right.type),
+					);
+				const rows: PlexCacheSnapshotRow[] = aggregationsArray.map((agg) => ({
+					instanceId,
+					tmdbId: agg.tmdbId,
+					mediaType: agg.mediaType,
+					sectionId: agg.sectionId,
+					sectionTitle: agg.sectionTitle,
+					title: agg.title,
+					ratingKey: agg.ratingKey,
+					lastWatchedAt: agg.lastWatchedAt,
+					watchCount: agg.watchCount,
+					watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
+					onDeck: agg.onDeck,
+					userRating: agg.userRating,
+					collections: JSON.stringify([...agg.collections].sort()),
+					labels: JSON.stringify([...agg.labels].sort()),
+					addedAt: agg.addedAt,
+					thumb: agg.thumb,
+				}));
+				return {
+					upserted: 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt,
+					snapshot: { rows, sections },
+				};
+			}
 			const generationId = randomUUID();
 			const generationMetadata = JSON.stringify({
 				sections: mediaLibs

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -297,6 +297,58 @@ describe("refreshTautulliCache (end-to-end)", () => {
 		expect(tx.tautulliCache.createMany).not.toHaveBeenCalled();
 	});
 
+	it("collects a verified live snapshot without publishing cache state", async () => {
+		const watchedAt = 1_723_000_000;
+		const mockClient = {
+			getLibraries: vi
+				.fn()
+				.mockResolvedValue([
+					{ section_id: "1", section_name: "Movies", section_type: "movie", count: "1" },
+				]),
+			getHistory: vi.fn().mockResolvedValue({
+				data: [
+					{
+						row_id: 1,
+						rating_key: "rk-1",
+						parent_rating_key: "",
+						grandparent_rating_key: "",
+						title: "Recent Movie",
+						grandparent_title: "",
+						media_type: "movie",
+						user: "alice",
+						date: watchedAt,
+						play_count: 1,
+					},
+				],
+				recordsFiltered: 1,
+				recordsTotal: 1,
+			}),
+			getMetadata: vi.fn().mockResolvedValue({
+				guids: ["tmdb://12345"],
+				media_type: "movie",
+				title: "Recent Movie",
+				rating_key: "rk-1",
+			}),
+		} as unknown as TautulliClient;
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined, {
+			publish: false,
+		});
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 0 });
+		expect(result.snapshot?.rows).toEqual([
+			expect.objectContaining({
+				instanceId: "inst-1",
+				tmdbId: 12345,
+				lastWatchedAt: new Date(watchedAt * 1000),
+				watchCount: 1,
+			}),
+		]);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
 	it("discards an outgoing Tautulli generation after its connection changes before publication", async () => {
 		let resolveHistory: (result: {
 			data: unknown[];

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -39,6 +39,33 @@ interface ParsedGuid {
 	mediaType: "movie" | "series";
 }
 
+export interface TautulliCacheSnapshotRow {
+	instanceId: string;
+	tmdbId: number;
+	mediaType: "movie" | "series";
+	lastWatchedAt: Date;
+	watchCount: number;
+	watchedByUsers: string;
+}
+
+export interface TautulliCacheSnapshot {
+	rows: TautulliCacheSnapshotRow[];
+}
+
+export interface TautulliCacheRefreshOptions {
+	publish?: boolean;
+}
+
+export interface TautulliCacheRefreshResult {
+	upserted: number;
+	errors: number;
+	errorMessages: string[];
+	complete: boolean;
+	completedAt?: Date;
+	superseded?: boolean;
+	snapshot?: TautulliCacheSnapshot;
+}
+
 /**
  * Refresh the TautulliCache for a given instance.
  * Fetches history from Tautulli and aggregates into per-item watch stats.
@@ -49,14 +76,8 @@ export async function refreshTautulliCache(
 	instanceId: string,
 	log: FastifyBaseLogger,
 	expectedConnection: ProviderConnectionIdentity | undefined,
-): Promise<{
-	upserted: number;
-	errors: number;
-	errorMessages: string[];
-	complete: boolean;
-	completedAt?: Date;
-	superseded?: boolean;
-}> {
+	options: TautulliCacheRefreshOptions = {},
+): Promise<TautulliCacheRefreshResult> {
 	let upserted = 0;
 	let errors = 0;
 	let complete = true;
@@ -383,14 +404,7 @@ export async function refreshTautulliCache(
 		}
 
 		// 5. Stage every row, then publish a complete replacement atomically.
-		const rows: Array<{
-			instanceId: string;
-			tmdbId: number;
-			mediaType: "movie" | "series";
-			lastWatchedAt: Date;
-			watchCount: number;
-			watchedByUsers: string;
-		}> = [];
+		const rows: TautulliCacheSnapshotRow[] = [];
 		for (const [ratingKey, info] of itemMap) {
 			const guid = ratingKeyToGuid.get(ratingKey);
 			if (!guid) continue;
@@ -410,6 +424,16 @@ export async function refreshTautulliCache(
 			// Re-read the entire snapshot immediately before publication.
 			await verifyCompleteHistorySnapshot();
 			completedAt = new Date();
+			if (options.publish === false) {
+				return {
+					upserted: 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt,
+					snapshot: { rows },
+				};
+			}
 			try {
 				const publication = await withCurrentProviderConnection(
 					prisma,

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -2061,6 +2061,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			},
 			userId,
 			config.rules.filter((rule) => rule.targetScope !== "episode"),
+			{ providerEvidence: "live" },
 		);
 
 		const results = explainItemAgainstRules(


### PR DESCRIPTION
## Summary

Library Cleanup now collects fresh, read-only watch evidence from Plex, Tautulli, Jellyfin, and Emby before previewing or selecting title-level cleanup candidates. A recent play can no longer be missed just because the scheduled provider cache has not refreshed yet.

## What changed

- Added non-publishing snapshot mode to the Plex, Tautulli, and Jellyfin/Emby cache refreshers.
- Require two matching, complete live snapshots before provider evidence is accepted.
- Use the same live evidence for preview, dry-run, approval discovery, direct discovery, and item explanations.
- Treat titles absent from a provider inventory as unknown instead of manufacturing never-watched evidence.
- Enumerate every Jellyfin/Emby user visible library and bind that topology into snapshot verification.
- Leave scheduled/manual cache publication behavior unchanged.

## Safety

Read-only collection performs upstream GETs only and does not update provider cache rows or cache status. Any incomplete scan, changing result, changed service topology, unresolved Plex section, or missing title coverage fails closed and skips dependent cleanup rules.

The required data-safety and regression reviews produced one bounded correction batch for provider coverage and Jellyfin per-user library discovery. Durable upstream-server identity is tracked separately in #689 rather than expanding this fix into service lifecycle and schema changes. Live-harness compatibility drift is tracked in #690.

## Validation

- API typecheck passed.
- 1,014 focused provider and Library Cleanup tests passed with one pre-existing skip.
- Full repository suite passed: 4,500 tests.
- Root typecheck, lint, and production build passed.
- All 11 changed files pass formatting and `git diff --check`.
- Root format still reports inherited drift in four untouched OIDC files.
- Provenance-bound candidate image built from `7145e3fb`.
- Disposable SQLite and PostgreSQL tests both forced the published Plex row for Breaking Bad stale while live Plex history contained its recent watch. Preview evaluated one Sonarr item, selected zero, reported Plex healthy, did not publish cache or generation state, and left the upstream series monitored with its file intact.
- All 12 hosted checks passed, including three E2E shards, SQLite and PostgreSQL smoke tests, security scans, and Docker build.

Closes #655