### PR TITLE
fix(e2e): stabilize library cleanup harness

### DIFF
--- a/docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md
+++ b/docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md
@@ -130,4 +130,3 @@ image identities retained.
 
 Because this is deletion-adjacent harness work, independent data-safety and
 regression reviews are required before merge readiness is claimed.
-

--- a/docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md
+++ b/docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md
@@ -1,0 +1,133 @@
+# Library Cleanup Harness Stabilization Design
+
+## Context
+
+Issue #690 tracks compatibility drift in the disposable Library Cleanup live
+harness. The observed failures are in fixture setup and command orchestration,
+not in the production cleanup providers:
+
+- the loopback Plex history response lacks a stable `historyKey`;
+- current Radarr and Sonarr images can expose duplicate file rows after an
+  unnecessary or stale-state rescan;
+- qBittorrent now rejects unauthenticated bootstrap requests;
+- harness scripts resolve Docker Compose through different command paths; and
+- mutable integration image tags make a previously passing run irreproducible.
+
+The harness exercises deletion-adjacent behavior, so setup must remain
+fail-closed and must never weaken application identity or ownership checks.
+
+## Scope
+
+This change is limited to `e2e/library-cleanup` and its documentation. It will:
+
+1. establish reproducible integration-image defaults;
+2. make the Plex bridge fixture satisfy the application's stable-history-row
+   contract;
+3. make ARR fixture setup converge without arbitrarily choosing among
+   duplicate rows;
+4. authenticate every qBittorrent bootstrap request;
+5. route all validation, bootstrap, scenario, browser, and teardown operations
+   through one Compose command resolver; and
+6. add focused tests plus clean SQLite and PostgreSQL live-run evidence.
+
+Production cleanup, Radarr, Sonarr, Plex, and qUI client behavior is explicitly
+out of scope unless the stabilized harness reproduces a separate application
+defect.
+
+## Image compatibility contract
+
+The checked-in defaults for Radarr, Sonarr, Plex, and qBittorrent will use
+immutable, multi-architecture image references rather than `latest`. Existing
+environment overrides remain available for intentional compatibility runs.
+
+Static validation will reject mutable checked-in defaults and the live run will
+continue recording the resolved image identity. An override is treated as an
+explicit test choice, not as evidence that the default compatibility set
+passed.
+
+## Shared Compose command path
+
+A small POSIX shell helper will own Compose resolution and the fixed harness
+file set. It will:
+
+- use the exact executable supplied in `ARR_COMPOSE_BIN` when present;
+- otherwise use the Docker Compose plugin available to the caller;
+- apply the validated project name and the fixed base/debug Compose files; and
+- forward only the requested Compose subcommand and arguments.
+
+Every harness script, including validation and teardown, will invoke that
+helper. Teardown retains its exact project-name confirmation and live model
+validation before the helper can run `down --volumes --remove-orphans`.
+
+Tests will exercise an injected fake Compose executable and statically assert
+that no harness phase bypasses the helper.
+
+## Plex history fixture
+
+The loopback history row will receive a unique, stable `historyKey` whose value
+is consistent across pagination calls. Existing completeness and stable-row
+identity checks remain unchanged. A fixture-level test will prevent the field
+from disappearing again.
+
+## Deterministic ARR fixture convergence
+
+The bootstrap will classify fixture state using all of the following:
+
+- the exact isolated service URL;
+- the known TMDb or TVDb identifier;
+- the exact controlled item root and media path;
+- safe integer item and file identifiers; and
+- the parent movie or episode association to the matching file row.
+
+If exactly one valid record is already attached to the expected parent, setup
+will reuse it and skip a redundant rescan. If the controlled fixture is absent,
+setup will add it and wait for its initial import before considering an explicit
+rescan.
+
+If stale or duplicate state belongs entirely to the exact controlled fixture,
+the harness will rebuild that fixture's ARR database entry with file deletion
+disabled, preserving the guarded hardlink, then re-add and verify it. It will
+never select one duplicate merely by order or ID. Any unexpected path, parent,
+external identifier, malformed ID, failed removal, or remaining duplicate
+causes an explicit failure before a cleanup scenario can start.
+
+This normalization is harness-only. The production application continues to
+reject ambiguous ARR identities.
+
+## Authenticated qBittorrent bootstrap
+
+The shell bootstrap will read each disposable instance's temporary password
+from that instance's container log. The password will be passed only as an
+environment value to the isolated runner and will never be printed.
+
+The Node bootstrap will create one authenticated session per qBittorrent
+instance, retain the returned session cookie, and use it for torrent lookup,
+add, and verification calls. Login success requires both an accepted status and
+a session cookie. A 401/403 or malformed response will identify the service,
+method, endpoint, and status without exposing credentials.
+
+qUI's later subnet-whitelist setup remains independent; torrent setup no longer
+depends on README ordering or unauthenticated access.
+
+## Verification strategy
+
+Implementation will be test-first. Focused tests will cover:
+
+- fresh, already-valid, missing, stale, duplicate, and foreign ARR fixture
+  states;
+- refusal to normalize a path or identity outside the exact fixture boundary;
+- qBittorrent login, cookie propagation, authentication failures, and redacted
+  diagnostics;
+- stable Plex `historyKey` presence;
+- immutable checked-in image defaults; and
+- Compose helper selection, fixed file/project arguments, teardown guarding,
+  and the absence of direct bypasses.
+
+After focused tests, the repository verification gauntlet will run. The final
+acceptance test is a clean disposable environment that completes both SQLite
+and PostgreSQL scenarios using the pinned defaults, with exact diagnostics and
+image identities retained.
+
+Because this is deletion-adjacent harness work, independent data-safety and
+regression reviews are required before merge readiness is claimed.
+

--- a/docs/plans/2026-08-10-library-cleanup-harness-stabilization-plan.md
+++ b/docs/plans/2026-08-10-library-cleanup-harness-stabilization-plan.md
@@ -1,0 +1,162 @@
+# Library Cleanup Harness Stabilization Implementation Plan
+
+> **Issue:** #690  
+> **Base:** `origin/main`  
+> **Branch:** `codex/690-stabilize-cleanup-harness`  
+> **Design:** `docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md`
+
+## Goal
+
+Make the disposable Library Cleanup harness reproducible and able to complete
+clean SQLite and PostgreSQL runs without weakening any production identity,
+ownership, or deletion safeguard.
+
+## Task 1: Lock the Compose execution contract
+
+**Files:**
+
+- Create `e2e/library-cleanup/compose-command.sh`
+- Create `e2e/library-cleanup/compose-command.test.sh`
+- Modify every `e2e/library-cleanup/*.sh` script that invokes Compose
+- Modify `e2e/library-cleanup/README.md`
+
+**Steps:**
+
+1. Add failing tests using a temporary fake `ARR_COMPOSE_BIN` that assert the
+   exact project, base/debug files, profiles, and forwarded subcommand.
+2. Add a static test that rejects direct `docker compose`, local `COMPOSE_BIN`,
+   or private `compose()` wrappers outside the shared helper.
+3. Run `sh e2e/library-cleanup/compose-command.test.sh` and confirm failure.
+4. Implement the POSIX helper with exact executable validation and fixed file
+   paths.
+5. Migrate validation, bootstrap, browser, scenario, build, and teardown paths.
+6. Preserve teardown confirmation and validation before any `down` command.
+7. Rerun the focused test and `sh e2e/library-cleanup/validate-compose.sh`.
+
+## Task 2: Pin and validate integration-image defaults
+
+**Files:**
+
+- Modify `e2e/library-cleanup/.env.example`
+- Modify `e2e/library-cleanup/compose.yml`
+- Modify `e2e/library-cleanup/check-compose-model.py`
+- Modify `e2e/library-cleanup/README.md`
+
+**Steps:**
+
+1. Add negative model self-tests for mutable Radarr, Sonarr, Plex, and
+   qBittorrent defaults.
+2. Resolve immutable multi-architecture digests for the locally tested image
+   set and verify their manifests.
+3. Replace checked-in `latest` defaults with those immutable references.
+4. Add exact allowlists or immutable-reference validation for the four
+   integration service groups while retaining explicit environment overrides
+   for compatibility experiments.
+5. Verify positive and negative Compose model tests.
+
+## Task 3: Restore stable Plex history identity
+
+**Files:**
+
+- Modify `e2e/library-cleanup/compose.yml`
+- Modify `e2e/library-cleanup/bootstrap-plex.test.mjs`
+
+**Steps:**
+
+1. Add a test that extracts or requests the bridge history fixture and requires
+   a non-empty stable `historyKey` alongside `ratingKey`.
+2. Confirm the test fails against the current fixture.
+3. Add one deterministic unique `historyKey` to the loopback row.
+4. Rerun Plex and Compose model tests.
+
+## Task 4: Authenticate qBittorrent fixture setup
+
+**Files:**
+
+- Modify `e2e/library-cleanup/bootstrap-torrents.mjs`
+- Modify `e2e/library-cleanup/bootstrap-torrents.test.mjs`
+- Modify `e2e/library-cleanup/bootstrap-torrents.sh`
+
+**Steps:**
+
+1. Add mocked-fetch tests for successful login, required SID cookie,
+   authenticated torrent lookup/add/verification, rejected credentials,
+   401/403 diagnostics, and secret redaction.
+2. Confirm the new tests fail.
+3. Implement a per-service session helper that logs in using environment-only
+   disposable credentials and attaches the returned cookie to every request.
+4. Extract each temporary password through the shared Compose path and pass it
+   only into the isolated runner process.
+5. Rerun torrent tests and ensure output contains no password values.
+
+## Task 5: Make ARR fixture convergence deterministic
+
+**Files:**
+
+- Modify `e2e/library-cleanup/bootstrap-arr.mjs`
+- Modify `e2e/library-cleanup/bootstrap-arr.test.mjs`
+- Modify `e2e/library-cleanup/README.md`
+
+**Steps:**
+
+1. Add pure classification tests for absent, freshly associated, detached,
+   duplicate-controlled, malformed, and foreign-path file states.
+2. Add request-level tests proving normalization uses only the exact fixture
+   external ID, item path, file path, and safe integer IDs.
+3. Confirm these tests fail before implementation.
+4. Reuse a single valid attached file without rescanning.
+5. For an absent fixture, add it and wait for initial import before rescanning.
+6. For stale or duplicate state wholly inside the controlled fixture, remove
+   only that fixture's ARR database entry with file deletion disabled, verify
+   absence, re-add it, and require one freshly associated row.
+7. Fail before mutation on any ambiguous ownership or path and fail if
+   convergence still yields zero or multiple rows.
+8. Rerun ARR tests twice to verify idempotent behavior.
+
+## Task 6: Focused harness verification
+
+**Commands:**
+
+```sh
+node --test e2e/library-cleanup/bootstrap-arr.test.mjs
+node --test e2e/library-cleanup/bootstrap-plex.test.mjs
+node --test e2e/library-cleanup/bootstrap-torrents.test.mjs
+sh e2e/library-cleanup/compose-command.test.sh
+sh e2e/library-cleanup/provenance-helpers.test.sh
+sh e2e/library-cleanup/validate-compose.sh
+```
+
+Run `git diff --check`, inspect the full branch diff, and remove any generated
+files or secrets.
+
+## Task 7: Independent safety and regression reviews
+
+1. Delegate the completed diff read-only to the required
+   `data_safety_reviewer` agent.
+2. Delegate a separate read-only pass to `regression_reviewer`.
+3. Classify each finding against #690 scope before changing code.
+4. Fix only demonstrated correctness, safety, or regression defects; record
+   unrelated suggestions for later rather than expanding the PR.
+5. Rerun only the affected focused tests after each accepted finding.
+
+## Task 8: Repository gauntlet and clean live acceptance
+
+**Commands:**
+
+```sh
+pnpm run format
+pnpm run typecheck
+pnpm run test
+pnpm run lint
+pnpm run build
+```
+
+Then create a fresh unique `lc-e2e-*` project using ignored temporary secrets,
+build the candidate from the clean checkout, and run the documented bootstrap
+and scenario sequence against SQLite and PostgreSQL. Capture resolved image
+identities and exact diagnostics under the ignored artifact directory.
+
+Finally, run guarded teardown for the exact project name, confirm only the
+disposable project volumes were removed, and reassess PR readiness with
+`arr-validate` and `arr-prepare-pr`.
+

--- a/docs/plans/2026-08-10-library-cleanup-harness-stabilization-plan.md
+++ b/docs/plans/2026-08-10-library-cleanup-harness-stabilization-plan.md
@@ -1,8 +1,8 @@
 # Library Cleanup Harness Stabilization Implementation Plan
 
-> **Issue:** #690  
-> **Base:** `origin/main`  
-> **Branch:** `codex/690-stabilize-cleanup-harness`  
+> **Issue:** #690
+> **Base:** `origin/main`
+> **Branch:** `codex/690-stabilize-cleanup-harness`
 > **Design:** `docs/plans/2026-08-10-library-cleanup-harness-stabilization-design.md`
 
 ## Goal
@@ -159,4 +159,3 @@ identities and exact diagnostics under the ignored artifact directory.
 Finally, run guarded teardown for the exact project name, confirm only the
 disposable project volumes were removed, and reassess PR readiness with
 `arr-validate` and `arr-prepare-pr`.
-

--- a/e2e/library-cleanup/.env.example
+++ b/e2e/library-cleanup/.env.example
@@ -9,10 +9,10 @@ PGID=1000
 HARNESS_SUBNET=172.31.250.0/24
 
 # Image defaults are intentionally overridable for repeatable compatibility runs.
-RADARR_IMAGE=lscr.io/linuxserver/radarr:latest
-SONARR_IMAGE=lscr.io/linuxserver/sonarr:latest
-PLEX_IMAGE=lscr.io/linuxserver/plex:latest
-QBITTORRENT_IMAGE=lscr.io/linuxserver/qbittorrent:latest
+RADARR_IMAGE=lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a
+SONARR_IMAGE=lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7
+PLEX_IMAGE=lscr.io/linuxserver/plex:1.41.5@sha256:5c07f70ae39709c71927ecb864cb9328acb01eb6c08779d1efb09b90b68a0692
+QBITTORRENT_IMAGE=lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e
 # qUI is deliberately allowlisted by the safety checker. See README before bumping.
 QUI_IMAGE=ghcr.io/autobrr/qui:v1.16.1
 POSTGRES_IMAGE=postgres:16-alpine

--- a/e2e/library-cleanup/.env.example
+++ b/e2e/library-cleanup/.env.example
@@ -2,6 +2,8 @@
 # lc-e2e-local, lc-e2e-test, and lc-e2e-default are rejected by live preflights.
 # Example: lc-e2e-616-20260803-153000
 COMPOSE_PROJECT_NAME=
+# Generate once per run with: openssl rand -hex 32
+LC_E2E_RUN_TOKEN=
 
 TZ=Etc/UTC
 PUID=1000

--- a/e2e/library-cleanup/README.md
+++ b/e2e/library-cleanup/README.md
@@ -84,8 +84,11 @@ characters (`A-Z`, `a-z`, `0-9`, `.`, `_`, `~`, and `-`).
 The preflight only runs Compose model rendering; it does not build, pull,
 create, or start containers. All harness scripts resolve Compose through
 `compose-command.sh`. It discovers Docker Compose v2 portably; set
-`ARR_COMPOSE_BIN` only to override it with an exact executable. The baseline default is
-`khak1s/arr-dashboard:2.23.0`, matching `docs/RELEASING.md`. Most images remain
+`ARR_COMPOSE_BIN` only to override it with an exact executable. Set
+`ARR_DOCKER_BIN` instead when the harness must use a specific Docker CLI or
+context; that CLI must provide Compose v2, and the two overrides cannot be used
+together. The baseline default is `khak1s/arr-dashboard:2.23.0`, matching
+`docs/RELEASING.md`. Most images remain
 configurable in the ignored `.env` for pinned compatibility runs, but Radarr,
 Sonarr, Plex, and qBittorrent overrides must retain the expected LinuxServer
 repository and an immutable digest. The checked-in defaults pin the reviewed

--- a/e2e/library-cleanup/README.md
+++ b/e2e/library-cleanup/README.md
@@ -76,11 +76,16 @@ The PostgreSQL password preflight reads the secret file without displaying its
 value. It rejects empty values and anything outside URL-safe unreserved ASCII
 characters (`A-Z`, `a-z`, `0-9`, `.`, `_`, `~`, and `-`).
 
-The preflight only runs `docker compose config`; it does not build, pull, create,
-or start containers. The baseline default is
+The preflight only runs Compose model rendering; it does not build, pull,
+create, or start containers. All harness scripts resolve Compose through
+`compose-command.sh`. Set `ARR_COMPOSE_BIN` to the exact Compose v2 executable
+when the default standalone plugin path is not available. The baseline default is
 `khak1s/arr-dashboard:2.23.0`, matching `docs/RELEASING.md`. Most images remain
-configurable in the ignored `.env` for pinned compatibility runs. qUI is the
-exception: both instances are allowlisted to the reviewed official
+configurable in the ignored `.env` for pinned compatibility runs, but Radarr,
+Sonarr, Plex, and qBittorrent overrides must retain the expected LinuxServer
+repository and an immutable digest. The checked-in defaults pin the reviewed
+Radarr 5.16.3, Sonarr 4.0.15, Plex 1.41.5, and qBittorrent 5.1.2 manifests. qUI
+is the exception: both instances are allowlisted to the reviewed official
 `ghcr.io/autobrr/qui:v1.16.1` image and use a Compose-defined probe against
 `/healthz/readiness`. An arbitrary override such as `busybox` fails validation.
 
@@ -104,18 +109,20 @@ CANDIDATE_IMAGE=$(sh ./build-candidate-image.sh)
 
 # Required immediately before a live command.
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+COMPOSE_PROJECT_NAME="$PROJECT_NAME"
+export COMPOSE_PROJECT_NAME
+. ./compose-command.sh
 
 # Candidate built from this checkout, SQLite
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" COMPOSE_PROJECT_NAME="$PROJECT_NAME" \
-  docker compose --profile candidate-sqlite up --no-build --wait dashboard-sqlite
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
+  compose --profile candidate-sqlite up --no-build --wait dashboard-sqlite
 
 # Candidate built from this checkout, PostgreSQL
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" COMPOSE_PROJECT_NAME="$PROJECT_NAME" \
-  docker compose --profile candidate-postgres up --no-build --wait dashboard-postgres
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
+  compose --profile candidate-postgres up --no-build --wait dashboard-postgres
 
 # Published 2.23.0 baseline reproduction
-COMPOSE_PROJECT_NAME="$PROJECT_NAME" docker compose \
-  --profile baseline up --wait dashboard-baseline
+compose --profile baseline up --wait dashboard-baseline
 ```
 
 The Compose model has no project-name fallback. Do not use stale generic names
@@ -161,18 +168,16 @@ sh ./run-live-scenario.sh policy-gate
 sh ./run-live-scenario.sh policy-core
 sh ./run-browser-policy.sh
 
-COMPOSE_PROJECT_NAME="$PROJECT_NAME" docker compose -f compose.yml -f compose.debug.yml \
-  stop dashboard-sqlite
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" COMPOSE_PROJECT_NAME="$PROJECT_NAME" \
-  docker compose -f compose.yml -f compose.debug.yml --profile candidate-postgres \
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" compose stop dashboard-sqlite
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
+  compose --profile candidate-postgres \
   up --no-build --wait dashboard-postgres
 LC_E2E_DASHBOARD_SERVICE=dashboard-postgres sh ./bootstrap-dashboard.sh
 LC_E2E_DASHBOARD_SERVICE=dashboard-postgres sh ./run-browser-policy.sh
 
-COMPOSE_PROJECT_NAME="$PROJECT_NAME" docker compose -f compose.yml -f compose.debug.yml \
-  stop dashboard-postgres
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" COMPOSE_PROJECT_NAME="$PROJECT_NAME" \
-  docker compose -f compose.yml -f compose.debug.yml --profile candidate-sqlite \
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" compose stop dashboard-postgres
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
+  compose --profile candidate-sqlite \
   up --no-build --wait dashboard-sqlite
 sh ./bootstrap-dashboard.sh
 
@@ -216,9 +221,17 @@ project, and checkout/container identity is checked again after the tests. Set
 PostgreSQL candidate.
 
 The ARR bootstrap is idempotent for an already populated fixture. It skips an
-unnecessary rescan when the exact expected file has one record and fails if an
-ARR instance reports duplicate records for the same path, rather than letting
-ambiguous ownership reach a cleanup scenario.
+unnecessary rescan only when the exact expected file row is freshly associated
+with its movie or S01E01 parent. If the exact controlled fixture has detached or
+duplicate rows, the bootstrap preserves the guarded hardlink, removes only that
+fixture's ARR database entry with file deletion disabled, and recreates it. Any
+foreign path, external ID, parent, malformed identity, or failure to converge
+still stops before a cleanup scenario.
+
+Torrent bootstrap authenticates separately to each disposable qBittorrent
+instance using its temporary startup password and forwards only the resulting
+SID cookie. It no longer depends on qUI's later isolated-subnet authorization
+setup or on unauthenticated Web API access.
 
 The Radarr and Sonarr series-deletion scenarios enable the #667 post-delete
 media-server scan option and poll Plex directly without manually starting a

--- a/e2e/library-cleanup/README.md
+++ b/e2e/library-cleanup/README.md
@@ -11,6 +11,10 @@ fail-closed policy and mutation scenarios for issues #616, #618, #619, #657,
 - Use a unique project name beginning with `lc-e2e-`, such as
   `lc-e2e-616-20260803-153000`. Live preflights reject empty, malformed,
   generic, production-like, and non-run-specific names.
+- Generate one random `LC_E2E_RUN_TOKEN` per project and retain it in the
+  ignored `.env` until teardown. Every container, volume, and network carries
+  that token; live commands also take a per-project process lock and refuse
+  stale, foreign, bind-mounted, image-drifted, or differently owned resources.
 - Every config, database, and media store is a Compose named volume. There are
   no host media/config/database bind mounts and no external volumes or networks.
 - The base file publishes only one selected dashboard profile, on `127.0.0.1`.
@@ -64,6 +68,7 @@ cp .env.example .env
 mkdir -p secrets
 openssl rand -hex 24 >secrets/postgres-password.txt
 : >secrets/plex-claim.txt
+# Add the output of `openssl rand -hex 32` as LC_E2E_RUN_TOKEN in .env.
 # Edit .env and set a unique name, for example:
 # COMPOSE_PROJECT_NAME=lc-e2e-616-20260803-153000
 sh ./validate-compose.sh --live-project lc-e2e-616-20260803-153000
@@ -78,8 +83,8 @@ characters (`A-Z`, `a-z`, `0-9`, `.`, `_`, `~`, and `-`).
 
 The preflight only runs Compose model rendering; it does not build, pull,
 create, or start containers. All harness scripts resolve Compose through
-`compose-command.sh`. Set `ARR_COMPOSE_BIN` to the exact Compose v2 executable
-when the default standalone plugin path is not available. The baseline default is
+`compose-command.sh`. It discovers Docker Compose v2 portably; set
+`ARR_COMPOSE_BIN` only to override it with an exact executable. The baseline default is
 `khak1s/arr-dashboard:2.23.0`, matching `docs/RELEASING.md`. Most images remain
 configurable in the ignored `.env` for pinned compatibility runs, but Radarr,
 Sonarr, Plex, and qBittorrent overrides must retain the expected LinuxServer
@@ -106,23 +111,21 @@ if [ -n "$(git status --porcelain)" ]; then
   exit 1
 fi
 CANDIDATE_IMAGE=$(sh ./build-candidate-image.sh)
+CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE"
+export CANDIDATE_DASHBOARD_IMAGE
 
 # Required immediately before a live command.
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
 COMPOSE_PROJECT_NAME="$PROJECT_NAME"
 export COMPOSE_PROJECT_NAME
-. ./compose-command.sh
-
 # Candidate built from this checkout, SQLite
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
-  compose --profile candidate-sqlite up --no-build --wait dashboard-sqlite
+sh ./start-profile.sh sqlite
 
 # Candidate built from this checkout, PostgreSQL
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
-  compose --profile candidate-postgres up --no-build --wait dashboard-postgres
+sh ./start-profile.sh postgres
 
 # Published 2.23.0 baseline reproduction
-compose --profile baseline up --wait dashboard-baseline
+sh ./start-profile.sh baseline
 ```
 
 The Compose model has no project-name fallback. Do not use stale generic names
@@ -150,12 +153,18 @@ sh ./bootstrap-arr.sh
 sh ./bootstrap-torrents.sh
 sh ./bootstrap-qui.sh
 sh ./bootstrap-plex.sh
+# Now that Plex libraries exist, persist and verify every ARR notification.
+sh ./bootstrap-arr.sh
 sh ./bootstrap-dashboard.sh
 ```
 
 The unclaimed Plex fixture exposes real local library and episode metadata. Its
 loopback-only bridge supplies one deterministic owner history row because an
 unclaimed server does not publish owner history through the normal endpoint.
+Candidate dashboard startup waits for that bridge before reporting healthy.
+ARR notification records are initially saved with ARR's explicit validation
+deferral because Plex libraries are created in the next bootstrap step; the
+later deletion scenarios prove that the live notification and scan path works.
 The application still performs its normal cache refresh, pagination, episode
 metadata, shared-path, and mutation-boundary checks against Plex. The bridge has
 no published port, storage, or connection to a non-harness network.
@@ -168,17 +177,19 @@ sh ./run-live-scenario.sh policy-gate
 sh ./run-live-scenario.sh policy-core
 sh ./run-browser-policy.sh
 
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" compose stop dashboard-sqlite
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
-  compose --profile candidate-postgres \
-  up --no-build --wait dashboard-postgres
+sh ./stop-profile.sh sqlite
+sh ./start-profile.sh postgres
+export LC_E2E_DASHBOARD_SERVICE=dashboard-postgres
+sh ./bootstrap-arr.sh
+sh ./bootstrap-plex.sh
+sh ./bootstrap-torrents.sh
+sh ./bootstrap-qui.sh
 LC_E2E_DASHBOARD_SERVICE=dashboard-postgres sh ./bootstrap-dashboard.sh
 LC_E2E_DASHBOARD_SERVICE=dashboard-postgres sh ./run-browser-policy.sh
 
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" compose stop dashboard-postgres
-CANDIDATE_DASHBOARD_IMAGE="$CANDIDATE_IMAGE" \
-  compose --profile candidate-sqlite \
-  up --no-build --wait dashboard-sqlite
+unset LC_E2E_DASHBOARD_SERVICE
+sh ./stop-profile.sh postgres
+sh ./start-profile.sh sqlite
 sh ./bootstrap-dashboard.sh
 
 sh ./run-live-scenario.sh delete:radarr-uhd
@@ -195,10 +206,11 @@ sh ./run-live-scenario.sh episode:sonarr-uhd
 ```
 
 `policy` runs the gate and core policy cases together when no fixture refresh
-can occur between them. `policy-gate` is the deterministic qUI assertion: run
-it only after the qUI torrent-state scheduler has published a complete fresh
-generation. `policy-core` covers #618, #619, and #660 independently of that
-scheduler timing.
+can occur between them. `policy-gate` is the deterministic qUI assertion: the
+runner restarts the selected disposable dashboard under the project lock and
+waits for its qUI torrent-state scheduler to publish a complete fresh
+generation before evaluating the rule. `policy-core` covers #618, #619, and
+#660 independently of that scheduler timing.
 
 `run-browser-policy.sh` drives a signed Chromium session against the selected
 candidate dashboard. It authors and round-trips `(A AND B) OR (A AND NOT C)`,

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -222,6 +222,23 @@ export function buildPlexNotificationPayload(schema, fixture) {
 	};
 }
 
+export function plexNotificationSaveEndpoint(current) {
+	if (current === undefined) return "/api/v3/notification?forceSave=true";
+	if (!Number.isSafeInteger(current?.id) || current.id <= 0) {
+		throw new Error("existing Plex notification has an invalid identity");
+	}
+	return `/api/v3/notification/${current.id}?forceSave=true`;
+}
+
+export function isMissingPlexLibraryValidation(error, kind) {
+	if (!(error instanceof Error) || !error.message.includes("failed with HTTP 400")) return false;
+	const expected =
+		kind === "movie"
+			? ["At least one Movie library is required"]
+			: ["At least one TV library is required", "At least one Series library is required"];
+	return expected.some((message) => error.message.includes(message));
+}
+
 export function isPathWithinRoot(candidate, root) {
 	return candidate === root || candidate.startsWith(`${root}/`);
 }
@@ -541,15 +558,21 @@ async function ensurePlexNotification(baseUrl, apiKey, fixture) {
 		throw new Error(`${fixture.service} has duplicate Library Cleanup Plex notifications`);
 	}
 	const current = matching[0];
-	const saved = await requestJson(
-		baseUrl,
-		apiKey,
-		current ? `/api/v3/notification/${current.id}` : "/api/v3/notification",
-		{
+	let saved;
+	try {
+		saved = await requestJson(baseUrl, apiKey, plexNotificationSaveEndpoint(current), {
 			method: current ? "PUT" : "POST",
 			body: current ? { ...desired, id: current.id } : desired,
-		},
-	);
+		});
+	} catch (error) {
+		if (!current && isMissingPlexLibraryValidation(error, fixture.kind)) {
+			process.stdout.write(
+				`${fixture.service}: Plex notification deferred until fixture libraries exist\n`,
+			);
+			return false;
+		}
+		throw error;
+	}
 	if (!Number.isSafeInteger(saved?.id) || saved.implementation !== "PlexServer") {
 		throw new Error(`${fixture.service} did not persist the Plex notification`);
 	}
@@ -565,6 +588,7 @@ async function ensurePlexNotification(baseUrl, apiKey, fixture) {
 	) {
 		throw new Error(`${fixture.service} Plex path mapping did not round-trip exactly`);
 	}
+	return true;
 }
 
 async function firstQualityProfileId(baseUrl, apiKey, service) {
@@ -673,24 +697,31 @@ async function associatedFileId(baseUrl, apiKey, fixture, item) {
 	}
 
 	const episodes = await requestJson(baseUrl, apiKey, `/api/v3/episode?seriesId=${item.id}`);
+	const association = classifyFixtureEpisodeAssociation(episodes, item.id);
+	if (association.kind === "pending") return undefined;
+	return association.fileId;
+}
+
+export function classifyFixtureEpisodeAssociation(episodes, itemId) {
 	if (!Array.isArray(episodes)) {
-		throw new Error(`${fixture.service} returned an invalid episode list`);
+		throw new Error("Sonarr returned an invalid episode list");
 	}
 	const matching = episodes.filter(
 		(episode) => episode.seasonNumber === 1 && episode.episodeNumber === 1,
 	);
-	if (matching.length !== 1) {
-		throw new Error(`${fixture.service} did not return exactly one S01E01 fixture episode`);
+	if (matching.length === 0) return { kind: "pending" };
+	if (matching.length > 1) {
+		throw new Error("Sonarr returned duplicate S01E01 fixture episodes");
 	}
 	const episode = matching[0];
-	if (!Number.isSafeInteger(episode?.id) || episode.seriesId !== item.id) {
-		throw new Error(`${fixture.service} returned an invalid S01E01 identity`);
+	if (!Number.isSafeInteger(episode?.id) || episode.seriesId !== itemId) {
+		throw new Error("Sonarr returned an invalid S01E01 identity");
 	}
-	if (episode.hasFile === false) return null;
+	if (episode.hasFile === false) return { kind: "ready", fileId: null };
 	if (episode.hasFile !== true || !Number.isSafeInteger(episode.episodeFileId)) {
-		throw new Error(`${fixture.service} returned an invalid episode-file association`);
+		throw new Error("Sonarr returned an invalid episode-file association");
 	}
-	return episode.episodeFileId;
+	return { kind: "ready", fileId: episode.episodeFileId };
 }
 
 function fixtureFileEndpoint(fixture, item) {
@@ -701,11 +732,15 @@ function fixtureFileEndpoint(fixture, item) {
 
 async function readFixtureFileState(baseUrl, apiKey, fixture, item) {
 	const records = await requestJson(baseUrl, apiKey, fixtureFileEndpoint(fixture, item));
+	const fileId = await associatedFileId(baseUrl, apiKey, fixture, item);
+	if (fixture.kind === "series" && fileId === undefined) {
+		return { kind: "transient", reason: "episode-pending" };
+	}
 	return classifyFixtureFileState({
 		fixture,
 		item,
 		records,
-		associatedFileId: await associatedFileId(baseUrl, apiKey, fixture, item),
+		associatedFileId: fileId,
 	});
 }
 

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -233,6 +233,81 @@ export function fileRecordMatches(record, itemPath, expectedPath) {
 	return record.relativePath === expectedRelative;
 }
 
+export function fixtureLibraryPath(fixture) {
+	return fixture.kind === "movie"
+		? path.posix.join(fixture.itemPath, fixture.fileName)
+		: path.posix.join(fixture.itemPath, "Season 01", fixture.fileName);
+}
+
+export function classifyFixtureFileState({ fixture, item, records, associatedFileId }) {
+	if (!Number.isSafeInteger(item?.id) || item.id <= 0 || item.path !== fixture.itemPath) {
+		throw new Error(`${fixture.service} has an invalid fixture item identity`);
+	}
+	if (!Array.isArray(records)) {
+		throw new Error(`${fixture.service} returned an invalid ${fixture.kind} file list`);
+	}
+	if (
+		associatedFileId !== null &&
+		(!Number.isSafeInteger(associatedFileId) || associatedFileId <= 0)
+	) {
+		throw new Error(`${fixture.service} returned an invalid parent file association`);
+	}
+
+	const expectedPath = fixtureLibraryPath(fixture);
+	const parentField = fixture.kind === "movie" ? "movieId" : "seriesId";
+	for (const record of records) {
+		if (!fileRecordMatches(record, item.path, expectedPath)) {
+			throw new Error(`${fixture.service} returned a foreign file path for the controlled fixture`);
+		}
+		if (!Number.isSafeInteger(record?.id) || record.id <= 0 || record[parentField] !== item.id) {
+			throw new Error(
+				`${fixture.service} returned an invalid file identity for the controlled fixture`,
+			);
+		}
+	}
+
+	if (records.length === 0) {
+		if (associatedFileId !== null) {
+			throw new Error(
+				`${fixture.service} returned a conflicting file association without a file row`,
+			);
+		}
+		return { kind: "absent" };
+	}
+	if (records.length > 1) {
+		return {
+			kind: "reset",
+			reason: "duplicate",
+			recordIds: records.map((record) => record.id).sort((left, right) => left - right),
+		};
+	}
+
+	const record = records[0];
+	if (associatedFileId === null) {
+		return { kind: "reset", reason: "detached", recordIds: [record.id] };
+	}
+	if (associatedFileId !== record.id) {
+		throw new Error(`${fixture.service} returned a conflicting file association`);
+	}
+	if (!Number.isFinite(Number(record.size)) || Number(record.size) <= 0) {
+		return { kind: "pending" };
+	}
+	return { kind: "ready", record };
+}
+
+export function buildFixtureRemoval(fixture, item) {
+	if (!Number.isSafeInteger(item?.id) || item.id <= 0) {
+		throw new Error(`${fixture.service} has an invalid item identity for fixture removal`);
+	}
+	return {
+		endpoint:
+			fixture.kind === "movie"
+				? `/api/v3/movie/${item.id}?deleteFiles=false&addImportExclusion=false`
+				: `/api/v3/series/${item.id}?deleteFiles=false&addImportListExclusion=false`,
+		method: "DELETE",
+	};
+}
+
 export function buildPlaceholderBuffer(fixture) {
 	const marker = [
 		"",
@@ -495,6 +570,7 @@ async function ensureMovie(baseUrl, apiKey, fixture) {
 	if (matching.length > 1)
 		throw new Error(`${fixture.service} has duplicate TMDb ${MOVIE.tmdbId} movies`);
 	let movie = matching[0];
+	let created = false;
 	if (!movie) {
 		const qualityProfileId = await firstQualityProfileId(baseUrl, apiKey, fixture.service);
 		await requestJson(baseUrl, apiKey, "/api/v3/movie", {
@@ -503,11 +579,12 @@ async function ensureMovie(baseUrl, apiKey, fixture) {
 		});
 		const refreshed = await requestJson(baseUrl, apiKey, "/api/v3/movie");
 		movie = refreshed.find((candidate) => candidate.tmdbId === MOVIE.tmdbId);
+		created = true;
 	}
 	if (!Number.isSafeInteger(movie?.id) || movie?.path !== fixture.itemPath) {
 		throw new Error(`${fixture.service} movie is missing or outside its exact fixture root`);
 	}
-	return movie;
+	return { item: movie, created };
 }
 
 async function ensureSeries(baseUrl, apiKey, fixture) {
@@ -518,6 +595,7 @@ async function ensureSeries(baseUrl, apiKey, fixture) {
 	if (matching.length > 1)
 		throw new Error(`${fixture.service} has duplicate TVDb ${SERIES.tvdbId} series`);
 	let series = matching[0];
+	let created = false;
 	if (!series) {
 		const qualityProfileId = await firstQualityProfileId(baseUrl, apiKey, fixture.service);
 		await requestJson(baseUrl, apiKey, "/api/v3/series", {
@@ -526,11 +604,134 @@ async function ensureSeries(baseUrl, apiKey, fixture) {
 		});
 		const refreshed = await requestJson(baseUrl, apiKey, "/api/v3/series");
 		series = refreshed.find((candidate) => candidate.tvdbId === SERIES.tvdbId);
+		created = true;
 	}
 	if (!Number.isSafeInteger(series?.id) || series?.path !== fixture.itemPath) {
 		throw new Error(`${fixture.service} series is missing or outside its exact fixture root`);
 	}
-	return series;
+	return { item: series, created };
+}
+
+function assertControlledItem(fixture, item) {
+	const externalId = fixture.kind === "movie" ? item?.tmdbId : item?.tvdbId;
+	const expectedExternalId = fixture.kind === "movie" ? MOVIE.tmdbId : SERIES.tvdbId;
+	if (
+		!Number.isSafeInteger(item?.id) ||
+		item.id <= 0 ||
+		item.path !== fixture.itemPath ||
+		externalId !== expectedExternalId
+	) {
+		throw new Error(`${fixture.service} changed the controlled fixture identity`);
+	}
+	return item;
+}
+
+function assertGuardedFixtureFile(fixture) {
+	const libraryPath = fixtureLibraryPath(fixture);
+	let content;
+	try {
+		content = readFileSync(libraryPath);
+	} catch (error) {
+		throw new Error(
+			`${fixture.service} guarded fixture file is unavailable: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+	if (
+		!content.includes(Buffer.from("ARR-DASHBOARD-LIBRARY-CLEANUP-E2E")) ||
+		!content.includes(Buffer.from(`${fixture.service}:${fixture.kind}:${fixture.quality}`))
+	) {
+		throw new Error(`${fixture.service} refused to normalize an unguarded fixture file`);
+	}
+}
+
+async function associatedFileId(baseUrl, apiKey, fixture, item) {
+	if (fixture.kind === "movie") {
+		const current = assertControlledItem(
+			fixture,
+			await requestJson(baseUrl, apiKey, `/api/v3/movie/${item.id}`),
+		);
+		if (current.hasFile === false) return null;
+		if (current.hasFile !== true || !Number.isSafeInteger(current.movieFile?.id)) {
+			throw new Error(`${fixture.service} returned an invalid movie-file association`);
+		}
+		return current.movieFile.id;
+	}
+
+	const episodes = await requestJson(baseUrl, apiKey, `/api/v3/episode?seriesId=${item.id}`);
+	if (!Array.isArray(episodes)) {
+		throw new Error(`${fixture.service} returned an invalid episode list`);
+	}
+	const matching = episodes.filter(
+		(episode) => episode.seasonNumber === 1 && episode.episodeNumber === 1,
+	);
+	if (matching.length !== 1) {
+		throw new Error(`${fixture.service} did not return exactly one S01E01 fixture episode`);
+	}
+	const episode = matching[0];
+	if (!Number.isSafeInteger(episode?.id) || episode.seriesId !== item.id) {
+		throw new Error(`${fixture.service} returned an invalid S01E01 identity`);
+	}
+	if (episode.hasFile === false) return null;
+	if (episode.hasFile !== true || !Number.isSafeInteger(episode.episodeFileId)) {
+		throw new Error(`${fixture.service} returned an invalid episode-file association`);
+	}
+	return episode.episodeFileId;
+}
+
+function fixtureFileEndpoint(fixture, item) {
+	return fixture.kind === "movie"
+		? `/api/v3/moviefile?movieId=${item.id}`
+		: `/api/v3/episodefile?seriesId=${item.id}`;
+}
+
+async function readFixtureFileState(baseUrl, apiKey, fixture, item) {
+	const records = await requestJson(baseUrl, apiKey, fixtureFileEndpoint(fixture, item));
+	return classifyFixtureFileState({
+		fixture,
+		item,
+		records,
+		associatedFileId: await associatedFileId(baseUrl, apiKey, fixture, item),
+	});
+}
+
+async function resetControlledFixture(baseUrl, apiKey, fixture, item) {
+	assertGuardedFixtureFile(fixture);
+	const current = assertControlledItem(
+		fixture,
+		await requestJson(
+			baseUrl,
+			apiKey,
+			fixture.kind === "movie" ? `/api/v3/movie/${item.id}` : `/api/v3/series/${item.id}`,
+		),
+	);
+	const state = await readFixtureFileState(baseUrl, apiKey, fixture, current);
+	if (state.kind === "ready") return false;
+	if (state.kind !== "reset") {
+		throw new Error(`${fixture.service} refused to reset fixture state ${state.kind}`);
+	}
+
+	const removal = buildFixtureRemoval(fixture, current);
+	await requestJson(baseUrl, apiKey, removal.endpoint, { method: removal.method });
+	assertGuardedFixtureFile(fixture);
+
+	const items = await requestJson(
+		baseUrl,
+		apiKey,
+		fixture.kind === "movie" ? "/api/v3/movie" : "/api/v3/series",
+	);
+	if (!Array.isArray(items)) {
+		throw new Error(`${fixture.service} returned an invalid item list after fixture reset`);
+	}
+	const expectedExternalId = fixture.kind === "movie" ? MOVIE.tmdbId : SERIES.tvdbId;
+	const remaining = items.filter((candidate) =>
+		fixture.kind === "movie"
+			? candidate.tmdbId === expectedExternalId
+			: candidate.tvdbId === expectedExternalId,
+	);
+	if (remaining.length !== 0) {
+		throw new Error(`${fixture.service} did not remove the controlled fixture database entry`);
+	}
+	return true;
 }
 
 async function runRescan(baseUrl, apiKey, fixture, itemId) {
@@ -557,29 +758,23 @@ async function runRescan(baseUrl, apiKey, fixture, itemId) {
 	throw new Error(`${fixture.service} ${commandName} did not finish in time`);
 }
 
-async function waitForFileRecord(baseUrl, apiKey, fixture, item, libraryPath) {
-	const endpoint =
-		fixture.kind === "movie"
-			? `/api/v3/moviefile?movieId=${item.id}`
-			: `/api/v3/episodefile?seriesId=${item.id}`;
+async function waitForFileRecord(baseUrl, apiKey, fixture, item) {
 	const deadline = Date.now() + FILE_RECORD_TIMEOUT_MS;
+	let lastState = "absent";
 	while (Date.now() < deadline) {
-		const records = await requestJson(baseUrl, apiKey, endpoint);
-		if (Array.isArray(records)) {
-			const matching = records.filter((candidate) =>
-				fileRecordMatches(candidate, item.path, libraryPath),
+		const state = await readFixtureFileState(baseUrl, apiKey, fixture, item);
+		lastState = state.kind === "reset" ? state.reason : state.kind;
+		if (state.kind === "ready") return state.record;
+		if (state.kind === "reset" && state.reason === "duplicate") {
+			throw new Error(
+				`${fixture.service} still returned duplicate exact fixture rows after normalization: ${state.recordIds.join(", ")}`,
 			);
-			if (matching.length > 1) {
-				throw new Error(
-					`${fixture.service} returned ${matching.length} records for the exact fixture file`,
-				);
-			}
-			const record = matching[0];
-			if (record && Number(record.size) > 0) return record;
 		}
 		await new Promise((resolve) => setTimeout(resolve, 1_000));
 	}
-	throw new Error(`${fixture.service} did not create the expected ${fixture.kind} file record`);
+	throw new Error(
+		`${fixture.service} did not create one freshly associated ${fixture.kind} file record (last state: ${lastState})`,
+	);
 }
 
 async function bootstrapFixture(fixture, apiKey) {
@@ -588,38 +783,48 @@ async function bootstrapFixture(fixture, apiKey) {
 	await ensureRootFolder(baseUrl, apiKey, fixture);
 	await ensurePlexNotification(baseUrl, apiKey, fixture);
 
-	const item =
+	let ensured =
 		fixture.kind === "movie"
 			? await ensureMovie(baseUrl, apiKey, fixture)
 			: await ensureSeries(baseUrl, apiKey, fixture);
-	const libraryPath =
-		fixture.kind === "movie"
-			? path.posix.join(fixture.itemPath, fixture.fileName)
-			: path.posix.join(fixture.itemPath, "Season 01", fixture.fileName);
-
-	const endpoint =
-		fixture.kind === "movie"
-			? `/api/v3/moviefile?movieId=${item.id}`
-			: `/api/v3/episodefile?seriesId=${item.id}`;
-	const existingRecords = await requestJson(baseUrl, apiKey, endpoint);
-	if (!Array.isArray(existingRecords)) {
-		throw new Error(`${fixture.service} returned an invalid ${fixture.kind} file list`);
-	}
-	const matchingExisting = existingRecords.filter((candidate) =>
-		fileRecordMatches(candidate, item.path, libraryPath),
-	);
-	if (matchingExisting.length > 1) {
-		throw new Error(
-			`${fixture.service} returned ${matchingExisting.length} records for the exact fixture file`,
+	let state = await readFixtureFileState(baseUrl, apiKey, fixture, ensured.item);
+	if (state.kind === "ready") {
+		process.stdout.write(
+			`${fixture.service}: ${fixture.quality} ${fixture.kind} fixture ready (item ${ensured.item.id}, file ${state.record.id})\n`,
 		);
+		return;
 	}
-	// Always rescan after restoring the fixture hardlink. Sonarr can retain an
-	// episode-file row after cleanup while the episode and series statistics
-	// remain detached from it; path existence alone is not fresh evidence.
-	await runRescan(baseUrl, apiKey, fixture, item.id);
-	const record = await waitForFileRecord(baseUrl, apiKey, fixture, item, libraryPath);
+
+	if (state.kind === "reset") {
+		const reset = await resetControlledFixture(baseUrl, apiKey, fixture, ensured.item);
+		if (!reset) {
+			state = await readFixtureFileState(baseUrl, apiKey, fixture, ensured.item);
+			if (state.kind !== "ready") {
+				throw new Error(
+					`${fixture.service} fixture changed while normalization was being authorized`,
+				);
+			}
+			process.stdout.write(
+				`${fixture.service}: ${fixture.quality} ${fixture.kind} fixture ready (item ${ensured.item.id}, file ${state.record.id})\n`,
+			);
+			return;
+		}
+		ensured =
+			fixture.kind === "movie"
+				? await ensureMovie(baseUrl, apiKey, fixture)
+				: await ensureSeries(baseUrl, apiKey, fixture);
+		if (!ensured.created) {
+			throw new Error(`${fixture.service} did not recreate the normalized fixture`);
+		}
+	} else if (state.kind === "absent" && !ensured.created) {
+		await runRescan(baseUrl, apiKey, fixture, ensured.item.id);
+	} else if (state.kind !== "absent" && state.kind !== "pending") {
+		throw new Error(`${fixture.service} returned unsupported fixture state ${state.kind}`);
+	}
+
+	const record = await waitForFileRecord(baseUrl, apiKey, fixture, ensured.item);
 	process.stdout.write(
-		`${fixture.service}: ${fixture.quality} ${fixture.kind} fixture ready (item ${item.id}, file ${record.id})\n`,
+		`${fixture.service}: ${fixture.quality} ${fixture.kind} fixture ready (item ${ensured.item.id}, file ${record.id})\n`,
 	);
 }
 
@@ -627,11 +832,7 @@ export function prepareFilesystem() {
 	assertUniqueProjectName(requireEnvironment("COMPOSE_PROJECT_NAME"));
 	for (const fixture of ARR_FIXTURES) {
 		prepareRootFolder(fixture);
-		const libraryPath =
-			fixture.kind === "movie"
-				? path.posix.join(fixture.itemPath, fixture.fileName)
-				: path.posix.join(fixture.itemPath, "Season 01", fixture.fileName);
-		createHardlinkedFixture(fixture, libraryPath);
+		createHardlinkedFixture(fixture, fixtureLibraryPath(fixture));
 	}
 }
 

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -245,7 +245,7 @@ export function isPathWithinRoot(candidate, root) {
 
 export function fileRecordMatches(record, itemPath, expectedPath) {
 	if (!record || typeof record !== "object") return false;
-	if (record.path === expectedPath) return true;
+	if (record.path !== undefined && record.path !== null) return record.path === expectedPath;
 	const expectedRelative = path.posix.relative(itemPath, expectedPath);
 	return record.relativePath === expectedRelative;
 }

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -266,33 +266,48 @@ export function classifyFixtureFileState({ fixture, item, records, associatedFil
 		}
 	}
 
+	const recordIds = records.map((record) => record.id).sort((left, right) => left - right);
 	if (records.length === 0) {
 		if (associatedFileId !== null) {
-			throw new Error(
-				`${fixture.service} returned a conflicting file association without a file row`,
-			);
+			return { kind: "transient", reason: "association-ahead", recordIds };
 		}
 		return { kind: "absent" };
+	}
+	if (associatedFileId === null) {
+		return { kind: "transient", reason: "association-behind", recordIds };
+	}
+	if (!recordIds.includes(associatedFileId)) {
+		return { kind: "transient", reason: "association-mismatch", recordIds };
 	}
 	if (records.length > 1) {
 		return {
 			kind: "reset",
 			reason: "duplicate",
-			recordIds: records.map((record) => record.id).sort((left, right) => left - right),
+			recordIds,
 		};
 	}
 
 	const record = records[0];
-	if (associatedFileId === null) {
-		return { kind: "reset", reason: "detached", recordIds: [record.id] };
-	}
-	if (associatedFileId !== record.id) {
-		throw new Error(`${fixture.service} returned a conflicting file association`);
-	}
 	if (!Number.isFinite(Number(record.size)) || Number(record.size) <= 0) {
 		return { kind: "pending" };
 	}
 	return { kind: "ready", record };
+}
+
+export function isRepeatedFixtureResetState(first, second) {
+	return (
+		first?.kind === "reset" &&
+		second?.kind === "reset" &&
+		first.reason === second.reason &&
+		Array.isArray(first.recordIds) &&
+		Array.isArray(second.recordIds) &&
+		first.recordIds.length === second.recordIds.length &&
+		first.recordIds.length > 0 &&
+		first.recordIds.every(
+			(recordId, index) =>
+				Number.isSafeInteger(recordId) && recordId > 0 && recordId === second.recordIds[index],
+		)
+	);
 }
 
 export function buildFixtureRemoval(fixture, item) {
@@ -694,7 +709,19 @@ async function readFixtureFileState(baseUrl, apiKey, fixture, item) {
 	});
 }
 
-async function resetControlledFixture(baseUrl, apiKey, fixture, item) {
+async function waitForStableFixtureFileState(baseUrl, apiKey, fixture, item) {
+	const deadline = Date.now() + FILE_RECORD_TIMEOUT_MS;
+	let lastReason = "unknown";
+	while (Date.now() < deadline) {
+		const state = await readFixtureFileState(baseUrl, apiKey, fixture, item);
+		if (state.kind !== "transient") return state;
+		lastReason = state.reason;
+		await new Promise((resolve) => setTimeout(resolve, 1_000));
+	}
+	throw new Error(`${fixture.service} file state did not stabilize (last state: ${lastReason})`);
+}
+
+async function resetControlledFixture(baseUrl, apiKey, fixture, item, expectedState) {
 	assertGuardedFixtureFile(fixture);
 	const current = assertControlledItem(
 		fixture,
@@ -706,11 +733,31 @@ async function resetControlledFixture(baseUrl, apiKey, fixture, item) {
 	);
 	const state = await readFixtureFileState(baseUrl, apiKey, fixture, current);
 	if (state.kind === "ready") return false;
-	if (state.kind !== "reset") {
-		throw new Error(`${fixture.service} refused to reset fixture state ${state.kind}`);
+	if (!isRepeatedFixtureResetState(expectedState, state)) {
+		throw new Error(
+			`${fixture.service} fixture reset state did not stabilize before authorization`,
+		);
 	}
 
-	const removal = buildFixtureRemoval(fixture, current);
+	const currentImmediatelyBeforeDelete = assertControlledItem(
+		fixture,
+		await requestJson(
+			baseUrl,
+			apiKey,
+			fixture.kind === "movie" ? `/api/v3/movie/${current.id}` : `/api/v3/series/${current.id}`,
+		),
+	);
+	const stateImmediatelyBeforeDelete = await readFixtureFileState(
+		baseUrl,
+		apiKey,
+		fixture,
+		currentImmediatelyBeforeDelete,
+	);
+	if (!isRepeatedFixtureResetState(state, stateImmediatelyBeforeDelete)) {
+		throw new Error(`${fixture.service} fixture reset state changed before deletion`);
+	}
+	assertGuardedFixtureFile(fixture);
+	const removal = buildFixtureRemoval(fixture, currentImmediatelyBeforeDelete);
 	await requestJson(baseUrl, apiKey, removal.endpoint, { method: removal.method });
 	assertGuardedFixtureFile(fixture);
 
@@ -787,7 +834,7 @@ async function bootstrapFixture(fixture, apiKey) {
 		fixture.kind === "movie"
 			? await ensureMovie(baseUrl, apiKey, fixture)
 			: await ensureSeries(baseUrl, apiKey, fixture);
-	let state = await readFixtureFileState(baseUrl, apiKey, fixture, ensured.item);
+	let state = await waitForStableFixtureFileState(baseUrl, apiKey, fixture, ensured.item);
 	if (state.kind === "ready") {
 		process.stdout.write(
 			`${fixture.service}: ${fixture.quality} ${fixture.kind} fixture ready (item ${ensured.item.id}, file ${state.record.id})\n`,
@@ -796,7 +843,7 @@ async function bootstrapFixture(fixture, apiKey) {
 	}
 
 	if (state.kind === "reset") {
-		const reset = await resetControlledFixture(baseUrl, apiKey, fixture, ensured.item);
+		const reset = await resetControlledFixture(baseUrl, apiKey, fixture, ensured.item, state);
 		if (!reset) {
 			state = await readFixtureFileState(baseUrl, apiKey, fixture, ensured.item);
 			if (state.kind !== "ready") {

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -422,9 +422,28 @@ async function waitForService(baseUrl, apiKey, service) {
 	);
 }
 
-function composeExec(service, variables, script) {
+export function parseFilesystemComposeCommand(command) {
+	if (
+		Array.isArray(command) &&
+		command.length === 1 &&
+		typeof command[0] === "string" &&
+		command[0].length > 0
+	) {
+		return command;
+	}
+	if (
+		Array.isArray(command) &&
+		command.length === 2 &&
+		command[0] === "docker" &&
+		command[1] === "compose"
+	) {
+		return command;
+	}
+	throw new Error("--filesystem-only requires an executable or the exact docker compose command");
+}
+
+function composeExec(composeCommand, service, variables, script) {
 	const projectName = assertUniqueProjectName(requireEnvironment("COMPOSE_PROJECT_NAME"));
-	const composeBin = requireEnvironment("ARR_COMPOSE_BIN");
 	const args = ["-p", projectName];
 	for (const composeFile of COMPOSE_FILES) args.push("-f", composeFile);
 	args.push("exec", "-T", "--user", "0");
@@ -433,7 +452,7 @@ function composeExec(service, variables, script) {
 	}
 	args.push(service, "sh", "-eu", "-c", script);
 
-	const result = spawnSync(composeBin, args, {
+	const result = spawnSync(composeCommand[0], [...composeCommand.slice(1), ...args], {
 		cwd: SCRIPT_DIR,
 		encoding: "utf8",
 		env: process.env,
@@ -447,8 +466,9 @@ function composeExec(service, variables, script) {
 	}
 }
 
-function prepareRootFolder(fixture) {
+function prepareRootFolder(composeCommand, fixture) {
 	composeExec(
+		composeCommand,
 		fixture.service,
 		{
 			FIXTURE_ROOT: fixture.rootFolderPath,
@@ -461,11 +481,12 @@ chmod 0775 "$FIXTURE_ROOT"`,
 	);
 }
 
-function createHardlinkedFixture(fixture, libraryPath) {
+function createHardlinkedFixture(composeCommand, fixture, libraryPath) {
 	const contentBuffer = buildPlaceholderBuffer(fixture);
 	const expectedSha256 = createHash("sha256").update(contentBuffer).digest("hex");
 
 	composeExec(
+		composeCommand,
 		fixture.service,
 		{
 			FIXTURE_SOURCE: fixture.sourcePath,
@@ -859,7 +880,7 @@ async function waitForFileRecord(baseUrl, apiKey, fixture, item) {
 	);
 }
 
-async function bootstrapFixture(fixture, apiKey) {
+export async function bootstrapFixture(fixture, apiKey) {
 	const baseUrl = assertHarnessServiceUrl(fixture.baseUrl, fixture.service);
 	await waitForService(baseUrl, apiKey, fixture.service);
 	await ensureRootFolder(baseUrl, apiKey, fixture);
@@ -910,11 +931,12 @@ async function bootstrapFixture(fixture, apiKey) {
 	);
 }
 
-export function prepareFilesystem() {
+export function prepareFilesystem(command) {
+	const composeCommand = parseFilesystemComposeCommand(command);
 	assertUniqueProjectName(requireEnvironment("COMPOSE_PROJECT_NAME"));
 	for (const fixture of ARR_FIXTURES) {
-		prepareRootFolder(fixture);
-		createHardlinkedFixture(fixture, fixtureLibraryPath(fixture));
+		prepareRootFolder(composeCommand, fixture);
+		createHardlinkedFixture(composeCommand, fixture, fixtureLibraryPath(fixture));
 	}
 }
 
@@ -929,7 +951,7 @@ export async function bootstrapApis(credentials) {
 export async function main() {
 	const mode = process.argv[2];
 	if (mode === "--filesystem-only") {
-		prepareFilesystem();
+		prepareFilesystem(process.argv.slice(3));
 		return;
 	}
 	if (mode === "--api-only") {

--- a/e2e/library-cleanup/bootstrap-arr.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.mjs
@@ -422,7 +422,10 @@ async function waitForService(baseUrl, apiKey, service) {
 	);
 }
 
-export function parseFilesystemComposeCommand(command) {
+export function parseFilesystemComposeCommand(
+	command,
+	configuredDocker = process.env.ARR_DOCKER_BIN || "docker",
+) {
 	if (
 		Array.isArray(command) &&
 		command.length === 1 &&
@@ -434,12 +437,14 @@ export function parseFilesystemComposeCommand(command) {
 	if (
 		Array.isArray(command) &&
 		command.length === 2 &&
-		command[0] === "docker" &&
+		command[0] === configuredDocker &&
 		command[1] === "compose"
 	) {
 		return command;
 	}
-	throw new Error("--filesystem-only requires an executable or the exact docker compose command");
+	throw new Error(
+		"--filesystem-only requires an executable or the resolved Docker Compose command",
+	);
 }
 
 function composeExec(composeCommand, service, variables, script) {

--- a/e2e/library-cleanup/bootstrap-arr.sh
+++ b/e2e/library-cleanup/bootstrap-arr.sh
@@ -151,10 +151,25 @@ CREDENTIALS_FILE=$TEMP_DIR/credentials.json
 	printf '"}'
 } >"$CREDENTIALS_FILE"
 
-COMPOSE_PROJECT_NAME=$PROJECT_NAME \
-	FIXTURE_PUID=${PUID:-1000} \
-	FIXTURE_PGID=${PGID:-1000} \
-	node "$SCRIPT_DIR/bootstrap-arr.mjs" --filesystem-only
+case "$COMPOSE_COMMAND" in
+	docker)
+		COMPOSE_PROJECT_NAME=$PROJECT_NAME \
+			FIXTURE_PUID=${PUID:-1000} \
+			FIXTURE_PGID=${PGID:-1000} \
+			node "$SCRIPT_DIR/bootstrap-arr.mjs" --filesystem-only \
+			"$ARR_RESOLVED_COMPOSE_EXECUTABLE" "$ARR_RESOLVED_COMPOSE_ARGUMENT"
+		;;
+	executable)
+		COMPOSE_PROJECT_NAME=$PROJECT_NAME \
+			FIXTURE_PUID=${PUID:-1000} \
+			FIXTURE_PGID=${PGID:-1000} \
+			node "$SCRIPT_DIR/bootstrap-arr.mjs" --filesystem-only "$ARR_RESOLVED_COMPOSE_EXECUTABLE"
+		;;
+	*)
+		echo "ARR bootstrap refused: invalid Compose command selection." >&2
+		exit 1
+		;;
+esac
 
 compose exec -T --user 0 "$RUNNER_SERVICE" mkdir -p "$RUNNER_DIR"
 RUNNER_PREPARED=1

--- a/e2e/library-cleanup/bootstrap-arr.sh
+++ b/e2e/library-cleanup/bootstrap-arr.sh
@@ -8,6 +8,8 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+export DOCKER_CONFIG
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 RUNNER_SERVICE=${ARR_BOOTSTRAP_RUNNER_SERVICE:-${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}}
@@ -22,8 +24,6 @@ case "$RUNNER_SERVICE" in
 		;;
 esac
 
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
 cd "$SCRIPT_DIR"
 
 TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-arr-bootstrap.XXXXXX")

--- a/e2e/library-cleanup/bootstrap-arr.sh
+++ b/e2e/library-cleanup/bootstrap-arr.sh
@@ -8,7 +8,7 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
+. "$SCRIPT_DIR/compose-command.sh"
 RUNNER_SERVICE=${ARR_BOOTSTRAP_RUNNER_SERVICE:-dashboard-sqlite}
 CONFIG_TIMEOUT_SECONDS=${ARR_BOOTSTRAP_CONFIG_TIMEOUT_SECONDS:-120}
 POLL_SECONDS=2
@@ -21,11 +21,6 @@ case "$RUNNER_SERVICE" in
 		;;
 esac
 
-if [ ! -x "$COMPOSE_BIN" ]; then
-	echo "ARR bootstrap refused: Compose binary is not executable at $COMPOSE_BIN." >&2
-	exit 1
-fi
-
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
 cd "$SCRIPT_DIR"
@@ -34,14 +29,6 @@ TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-arr-bootstrap.XXXXXX")
 umask 077
 RUNNER_DIR=/tmp/lc-e2e-arr-bootstrap-$PROJECT_NAME
 RUNNER_SCRIPT=$RUNNER_DIR/bootstrap-arr.mjs
-
-compose() {
-	"$COMPOSE_BIN" \
-		-p "$PROJECT_NAME" \
-		-f "$SCRIPT_DIR/compose.yml" \
-		-f "$SCRIPT_DIR/compose.debug.yml" \
-		"$@"
-}
 
 cleanup() {
 	if [ "${RUNNER_PREPARED:-0}" -eq 1 ]; then
@@ -74,12 +61,10 @@ fi
 python3 check-dockerignore.py "$REPO_ROOT/.dockerignore" --self-test
 
 BASE_MODEL=$TEMP_DIR/base-model.json
-"$COMPOSE_BIN" \
-	-p "$PROJECT_NAME" \
+compose_base \
 	--profile candidate-sqlite \
 	--profile candidate-postgres \
 	--profile baseline \
-	-f "$SCRIPT_DIR/compose.yml" \
 	config --format json >"$BASE_MODEL"
 python3 check-compose-model.py \
 	--self-test \
@@ -87,13 +72,10 @@ python3 check-compose-model.py \
 	--expected-project "$PROJECT_NAME" <"$BASE_MODEL"
 
 DEBUG_MODEL=$TEMP_DIR/debug-model.json
-"$COMPOSE_BIN" \
-	-p "$PROJECT_NAME" \
+compose \
 	--profile candidate-sqlite \
 	--profile candidate-postgres \
 	--profile baseline \
-	-f "$SCRIPT_DIR/compose.yml" \
-	-f "$SCRIPT_DIR/compose.debug.yml" \
 	config --format json >"$DEBUG_MODEL"
 python3 check-compose-model.py \
 	--require-live-name \
@@ -166,7 +148,6 @@ CREDENTIALS_FILE=$TEMP_DIR/credentials.json
 } >"$CREDENTIALS_FILE"
 
 COMPOSE_PROJECT_NAME=$PROJECT_NAME \
-	ARR_COMPOSE_BIN=$COMPOSE_BIN \
 	FIXTURE_PUID=${PUID:-1000} \
 	FIXTURE_PGID=${PGID:-1000} \
 	node "$SCRIPT_DIR/bootstrap-arr.mjs" --filesystem-only

--- a/e2e/library-cleanup/bootstrap-arr.sh
+++ b/e2e/library-cleanup/bootstrap-arr.sh
@@ -9,7 +9,8 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
-RUNNER_SERVICE=${ARR_BOOTSTRAP_RUNNER_SERVICE:-dashboard-sqlite}
+. "$SCRIPT_DIR/live-project-guard.sh"
+RUNNER_SERVICE=${ARR_BOOTSTRAP_RUNNER_SERVICE:-${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}}
 CONFIG_TIMEOUT_SECONDS=${ARR_BOOTSTRAP_CONFIG_TIMEOUT_SECONDS:-120}
 POLL_SECONDS=2
 
@@ -80,6 +81,9 @@ compose \
 python3 check-compose-model.py \
 	--require-live-name \
 	--expected-project "$PROJECT_NAME" <"$DEBUG_MODEL"
+
+acquire_live_project_lock
+verify_live_project
 
 require_running_service() {
 	rrs_service=$1

--- a/e2e/library-cleanup/bootstrap-arr.sh
+++ b/e2e/library-cleanup/bootstrap-arr.sh
@@ -8,8 +8,10 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
+if [ -z "${ARR_DOCKER_BIN:-}" ]; then
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+	export DOCKER_CONFIG
+fi
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 RUNNER_SERVICE=${ARR_BOOTSTRAP_RUNNER_SERVICE:-${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}}

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -9,7 +9,10 @@ import {
 	buildPlexNotificationPayload,
 	buildPlaceholderBuffer,
 	buildSeriesAddBody,
+	buildFixtureRemoval,
+	classifyFixtureFileState,
 	fileRecordMatches,
+	fixtureLibraryPath,
 	isPathWithinRoot,
 	MOVIE,
 	SERIES,
@@ -128,7 +131,8 @@ test("Plex notifications carry exact per-instance path mappings and delete event
 	};
 	const radarr = buildPlexNotificationPayload(schema, ARR_FIXTURES[0]);
 	const sonarr = buildPlexNotificationPayload(schema, ARR_FIXTURES[2]);
-	const values = (payload) => Object.fromEntries(payload.fields.map((field) => [field.name, field.value]));
+	const values = (payload) =>
+		Object.fromEntries(payload.fields.map((field) => [field.name, field.value]));
 	assert.deepEqual(values(radarr), {
 		host: "plex",
 		port: 33240,
@@ -176,4 +180,98 @@ test("file record verification accepts only the expected absolute or relative pa
 		),
 		false,
 	);
+});
+
+test("fixture state reuses only one exact freshly associated ARR file", () => {
+	const fixture = ARR_FIXTURES[0];
+	const libraryPath = fixtureLibraryPath(fixture);
+	const record = { id: 41, movieId: 7, path: libraryPath, size: 1_024 };
+	assert.deepEqual(
+		classifyFixtureFileState({
+			fixture,
+			item: { id: 7, path: fixture.itemPath },
+			records: [record],
+			associatedFileId: 41,
+		}),
+		{ kind: "ready", record },
+	);
+});
+
+test("fixture state distinguishes absent, detached, and duplicate controlled rows", () => {
+	const fixture = ARR_FIXTURES[2];
+	const libraryPath = fixtureLibraryPath(fixture);
+	const item = { id: 9, path: fixture.itemPath };
+	assert.deepEqual(
+		classifyFixtureFileState({ fixture, item, records: [], associatedFileId: null }),
+		{ kind: "absent" },
+	);
+	assert.deepEqual(
+		classifyFixtureFileState({
+			fixture,
+			item,
+			records: [{ id: 12, seriesId: 9, path: libraryPath, size: 512 }],
+			associatedFileId: null,
+		}),
+		{ kind: "reset", reason: "detached", recordIds: [12] },
+	);
+	assert.deepEqual(
+		classifyFixtureFileState({
+			fixture,
+			item,
+			records: [
+				{ id: 14, seriesId: 9, path: libraryPath, size: 512 },
+				{ id: 13, seriesId: 9, relativePath: `Season 01/${fixture.fileName}`, size: 512 },
+			],
+			associatedFileId: 14,
+		}),
+		{ kind: "reset", reason: "duplicate", recordIds: [13, 14] },
+	);
+});
+
+test("fixture state fails closed for foreign paths, malformed rows, or conflicting associations", () => {
+	const fixture = ARR_FIXTURES[0];
+	const libraryPath = fixtureLibraryPath(fixture);
+	const item = { id: 7, path: fixture.itemPath };
+	assert.throws(
+		() =>
+			classifyFixtureFileState({
+				fixture,
+				item,
+				records: [{ id: 41, movieId: 7, path: `${fixture.itemPath}/foreign.mkv`, size: 1 }],
+				associatedFileId: null,
+			}),
+		/foreign file path/,
+	);
+	assert.throws(
+		() =>
+			classifyFixtureFileState({
+				fixture,
+				item,
+				records: [{ id: "41", movieId: 7, path: libraryPath, size: 1 }],
+				associatedFileId: null,
+			}),
+		/invalid file identity/,
+	);
+	assert.throws(
+		() =>
+			classifyFixtureFileState({
+				fixture,
+				item,
+				records: [{ id: 41, movieId: 7, path: libraryPath, size: 1 }],
+				associatedFileId: 42,
+			}),
+		/conflicting file association/,
+	);
+});
+
+test("fixture removal always preserves files and disables exclusion side effects", () => {
+	assert.deepEqual(buildFixtureRemoval(ARR_FIXTURES[0], { id: 7 }), {
+		endpoint: "/api/v3/movie/7?deleteFiles=false&addImportExclusion=false",
+		method: "DELETE",
+	});
+	assert.deepEqual(buildFixtureRemoval(ARR_FIXTURES[2], { id: 9 }), {
+		endpoint: "/api/v3/series/9?deleteFiles=false&addImportListExclusion=false",
+		method: "DELETE",
+	});
+	assert.throws(() => buildFixtureRemoval(ARR_FIXTURES[0], { id: "7" }), /invalid item identity/);
 });

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -1,27 +1,82 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
 	ARR_FIXTURES,
 	assertHarnessServiceUrl,
 	assertUniqueProjectName,
-	buildMovieAddBody,
-	buildPlexNotificationPayload,
-	buildPlaceholderBuffer,
-	buildSeriesAddBody,
+	bootstrapFixture,
 	buildFixtureRemoval,
-	classifyFixtureFileState,
+	buildMovieAddBody,
+	buildPlaceholderBuffer,
+	buildPlexNotificationPayload,
+	buildSeriesAddBody,
 	classifyFixtureEpisodeAssociation,
+	classifyFixtureFileState,
 	fileRecordMatches,
 	fixtureLibraryPath,
-	isRepeatedFixtureResetState,
 	isMissingPlexLibraryValidation,
 	isPathWithinRoot,
+	isRepeatedFixtureResetState,
 	MOVIE,
 	plexNotificationSaveEndpoint,
 	SERIES,
 	validateCredentials,
 } from "./bootstrap-arr.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+test("filesystem bootstrap executes Docker Compose as a two-token command vector", async (t) => {
+	const tempDir = await mkdtemp(path.join(tmpdir(), "lc-e2e-bootstrap-arr-command-"));
+	t.after(() => rm(tempDir, { recursive: true, force: true }));
+	const composeLog = path.join(tempDir, "compose.log");
+	const fakeDocker = path.join(tempDir, "docker");
+	await writeFile(
+		fakeDocker,
+		`#!/bin/sh
+{
+	printf '%s\\n' "$@"
+	printf '%s\\n' --
+} >>"$ARR_COMPOSE_LOG"
+`,
+	);
+	await chmod(fakeDocker, 0o755);
+
+	const result = spawnSync(
+		process.execPath,
+		[path.join(SCRIPT_DIR, "bootstrap-arr.mjs"), "--filesystem-only", "docker", "compose"],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				ARR_COMPOSE_LOG: composeLog,
+				COMPOSE_PROJECT_NAME: "lc-e2e-690-20260810",
+				FIXTURE_PUID: "1000",
+				FIXTURE_PGID: "1000",
+				PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+			},
+		},
+	);
+	assert.equal(result.status, 0, result.stderr);
+
+	const invocations = (await readFile(composeLog, "utf8"))
+		.trim()
+		.split("--\n")
+		.filter(Boolean)
+		.map((invocation) => invocation.trim().split("\n"));
+	assert.equal(invocations.length, ARR_FIXTURES.length * 2);
+	for (const invocation of invocations) {
+		assert.deepEqual(invocation.slice(0, 3), ["compose", "-p", "lc-e2e-690-20260810"]);
+		const shellIndex = invocation.lastIndexOf("sh");
+		assert.equal(invocation[shellIndex + 1], "-eu");
+		assert.equal(invocation[shellIndex + 2], "-c");
+	}
+});
 
 test("project guard accepts only unique disposable harness names", () => {
 	assert.equal(assertUniqueProjectName("lc-e2e-616-20260804"), "lc-e2e-616-20260804");
@@ -323,6 +378,132 @@ test("fixture reset authorization requires identical duplicate snapshots", () =>
 		false,
 	);
 	assert.equal(isRepeatedFixtureResetState(duplicate, { kind: "ready", record: {} }), false);
+});
+
+test("duplicate ARR reset deletes bodylessly, verifies absence, recreates one row, and retains the file", async (t) => {
+	const tempDir = await mkdtemp(path.join(tmpdir(), "lc-e2e-duplicate-reset-"));
+	t.after(() => rm(tempDir, { recursive: true, force: true }));
+	const fixture = {
+		...ARR_FIXTURES[0],
+		rootFolderPath: path.join(tempDir, "root"),
+		itemPath: path.join(tempDir, "library", "The Matrix (1999)"),
+		sourcePath: path.join(tempDir, "torrents", "The.Matrix.1999.1080p.BluRay.x264-LCE2E.mkv"),
+	};
+	const libraryPath = fixtureLibraryPath(fixture);
+	const fixtureContent = buildPlaceholderBuffer(fixture);
+	await mkdir(path.dirname(libraryPath), { recursive: true });
+	await writeFile(libraryPath, fixtureContent);
+
+	const oldMovie = {
+		id: 7,
+		tmdbId: MOVIE.tmdbId,
+		path: fixture.itemPath,
+		hasFile: true,
+		movieFile: { id: 14 },
+	};
+	const recreatedMovie = {
+		id: 8,
+		tmdbId: MOVIE.tmdbId,
+		path: fixture.itemPath,
+		hasFile: true,
+		movieFile: { id: 22 },
+	};
+	const duplicateRecords = [
+		{ id: 13, movieId: oldMovie.id, path: libraryPath, size: fixtureContent.length },
+		{ id: 14, movieId: oldMovie.id, path: libraryPath, size: fixtureContent.length },
+	];
+	const calls = [];
+	let deleted = false;
+	let recreated = false;
+	const originalFetch = globalThis.fetch;
+	globalThis.fetch = async (input, init = {}) => {
+		const url = new URL(String(input));
+		const method = init.method ?? "GET";
+		calls.push({ method, path: `${url.pathname}${url.search}`, body: init.body });
+		const json = (value) => new Response(JSON.stringify(value), { status: 200 });
+		if (url.pathname === "/api/v3/system/status") return json({ version: "5.0" });
+		if (url.pathname === "/api/v3/rootfolder") {
+			return method === "POST"
+				? json({ path: fixture.rootFolderPath, accessible: true })
+				: json([]);
+		}
+		if (url.pathname === "/api/v3/notification/schema") {
+			return json([
+				{
+					implementation: "PlexServer",
+					fields: [
+						"host",
+						"port",
+						"useSsl",
+						"urlBase",
+						"authToken",
+						"updateLibrary",
+						"mapFrom",
+						"mapTo",
+					].map((name) => ({ name })),
+				},
+			]);
+		}
+		if (url.pathname === "/api/v3/notification") {
+			if (method === "GET") return json([]);
+			return json({ ...JSON.parse(init.body), id: 1 });
+		}
+		if (url.pathname === "/api/v3/qualityprofile") return json([{ id: 1 }]);
+		if (url.pathname === "/api/v3/moviefile") {
+			return json(
+				recreated
+					? [{ id: 22, movieId: recreatedMovie.id, path: libraryPath, size: fixtureContent.length }]
+					: duplicateRecords,
+			);
+		}
+		if (url.pathname === "/api/v3/movie/7") {
+			if (method === "DELETE") {
+				deleted = true;
+				return new Response(null, { status: 200 });
+			}
+			return json(oldMovie);
+		}
+		if (url.pathname === "/api/v3/movie/8") return json(recreatedMovie);
+		if (url.pathname === "/api/v3/movie") {
+			if (method === "POST") {
+				recreated = true;
+				return json(recreatedMovie);
+			}
+			if (!deleted) return json([oldMovie]);
+			return json(recreated ? [recreatedMovie] : []);
+		}
+		throw new Error(`unexpected request ${method} ${url.pathname}${url.search}`);
+	};
+	t.after(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	await bootstrapFixture(fixture, "a".repeat(32));
+
+	const deletion = calls.find((call) => call.method === "DELETE");
+	assert.deepEqual(deletion, {
+		method: "DELETE",
+		path: "/api/v3/movie/7?deleteFiles=false&addImportExclusion=false",
+		body: undefined,
+	});
+	const deletionIndex = calls.indexOf(deletion);
+	assert.deepEqual(calls[deletionIndex + 1], {
+		method: "GET",
+		path: "/api/v3/movie",
+		body: undefined,
+	});
+	assert.equal(calls[deletionIndex + 2].method, "GET");
+	assert.deepEqual(calls[deletionIndex + 4], {
+		method: "POST",
+		path: "/api/v3/movie",
+		body: JSON.stringify(buildMovieAddBody(1, fixture.rootFolderPath, fixture.itemPath)),
+	});
+	assert.equal(calls.filter((call) => call.path === "/api/v3/moviefile?movieId=7").length, 3);
+	assert.deepEqual(
+		calls.filter((call) => call.path === "/api/v3/moviefile?movieId=8"),
+		[{ method: "GET", path: "/api/v3/moviefile?movieId=8", body: undefined }],
+	);
+	assert.deepEqual(await readFile(libraryPath), fixtureContent);
 });
 
 test("fixture state fails closed for foreign paths or malformed rows", () => {

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -13,6 +13,7 @@ import {
 	classifyFixtureFileState,
 	fileRecordMatches,
 	fixtureLibraryPath,
+	isRepeatedFixtureResetState,
 	isPathWithinRoot,
 	MOVIE,
 	SERIES,
@@ -197,7 +198,7 @@ test("fixture state reuses only one exact freshly associated ARR file", () => {
 	);
 });
 
-test("fixture state distinguishes absent, detached, and duplicate controlled rows", () => {
+test("fixture state treats import transitions between separate reads as transient", () => {
 	const fixture = ARR_FIXTURES[2];
 	const libraryPath = fixtureLibraryPath(fixture);
 	const item = { id: 9, path: fixture.itemPath };
@@ -212,8 +213,27 @@ test("fixture state distinguishes absent, detached, and duplicate controlled row
 			records: [{ id: 12, seriesId: 9, path: libraryPath, size: 512 }],
 			associatedFileId: null,
 		}),
-		{ kind: "reset", reason: "detached", recordIds: [12] },
+		{ kind: "transient", reason: "association-behind", recordIds: [12] },
 	);
+	assert.deepEqual(
+		classifyFixtureFileState({
+			fixture,
+			item,
+			records: [],
+			associatedFileId: 12,
+		}),
+		{ kind: "transient", reason: "association-ahead", recordIds: [] },
+	);
+	assert.deepEqual(
+		classifyFixtureFileState({
+			fixture,
+			item,
+			records: [{ id: 12, seriesId: 9, path: libraryPath, size: 512 }],
+			associatedFileId: 13,
+		}),
+		{ kind: "transient", reason: "association-mismatch", recordIds: [12] },
+	);
+
 	assert.deepEqual(
 		classifyFixtureFileState({
 			fixture,
@@ -228,7 +248,29 @@ test("fixture state distinguishes absent, detached, and duplicate controlled row
 	);
 });
 
-test("fixture state fails closed for foreign paths, malformed rows, or conflicting associations", () => {
+test("fixture reset authorization requires identical duplicate snapshots", () => {
+	const duplicate = { kind: "reset", reason: "duplicate", recordIds: [13, 14] };
+	assert.equal(isRepeatedFixtureResetState(duplicate, duplicate), true);
+	assert.equal(
+		isRepeatedFixtureResetState(duplicate, {
+			kind: "reset",
+			reason: "duplicate",
+			recordIds: [13, 15],
+		}),
+		false,
+	);
+	assert.equal(
+		isRepeatedFixtureResetState(duplicate, {
+			kind: "transient",
+			reason: "association-behind",
+			recordIds: [13, 14],
+		}),
+		false,
+	);
+	assert.equal(isRepeatedFixtureResetState(duplicate, { kind: "ready", record: {} }), false);
+});
+
+test("fixture state fails closed for foreign paths or malformed rows", () => {
 	const fixture = ARR_FIXTURES[0];
 	const libraryPath = fixtureLibraryPath(fixture);
 	const item = { id: 7, path: fixture.itemPath };
@@ -251,16 +293,6 @@ test("fixture state fails closed for foreign paths, malformed rows, or conflicti
 				associatedFileId: null,
 			}),
 		/invalid file identity/,
-	);
-	assert.throws(
-		() =>
-			classifyFixtureFileState({
-				fixture,
-				item,
-				records: [{ id: 41, movieId: 7, path: libraryPath, size: 1 }],
-				associatedFileId: 42,
-			}),
-		/conflicting file association/,
 	);
 });
 

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -24,6 +24,7 @@ import {
 	isPathWithinRoot,
 	isRepeatedFixtureResetState,
 	MOVIE,
+	parseFilesystemComposeCommand,
 	plexNotificationSaveEndpoint,
 	SERIES,
 	validateCredentials,
@@ -31,11 +32,25 @@ import {
 
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 
-test("filesystem bootstrap executes Docker Compose as a two-token command vector", async (t) => {
+test("filesystem command parsing accepts only the configured Docker executable", () => {
+	const configuredDocker = "/opt/docker wrappers/docker";
+	assert.deepEqual(
+		parseFilesystemComposeCommand([configuredDocker, "compose"], configuredDocker),
+		[configuredDocker, "compose"],
+	);
+	assert.throws(
+		() => parseFilesystemComposeCommand(["docker", "compose"], configuredDocker),
+		/resolved Docker Compose command/,
+	);
+});
+
+test("filesystem bootstrap executes the resolved Docker Compose command vector", async (t) => {
 	const tempDir = await mkdtemp(path.join(tmpdir(), "lc-e2e-bootstrap-arr-command-"));
 	t.after(() => rm(tempDir, { recursive: true, force: true }));
 	const composeLog = path.join(tempDir, "compose.log");
-	const fakeDocker = path.join(tempDir, "docker");
+	const wrapperDir = path.join(tempDir, "docker wrappers");
+	const fakeDocker = path.join(wrapperDir, "docker");
+	await mkdir(wrapperDir);
 	await writeFile(
 		fakeDocker,
 		`#!/bin/sh
@@ -58,18 +73,35 @@ test("filesystem bootstrap executes Docker Compose as a two-token command vector
 				COMPOSE_PROJECT_NAME: "lc-e2e-690-20260810",
 				FIXTURE_PUID: "1000",
 				FIXTURE_PGID: "1000",
-				PATH: `${tempDir}${path.delimiter}${process.env.PATH}`,
+				PATH: `${wrapperDir}${path.delimiter}${process.env.PATH}`,
 			},
 		},
 	);
 	assert.equal(result.status, 0, result.stderr);
+
+	const configuredResult = spawnSync(
+		process.execPath,
+		[path.join(SCRIPT_DIR, "bootstrap-arr.mjs"), "--filesystem-only", fakeDocker, "compose"],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				ARR_COMPOSE_LOG: composeLog,
+				ARR_DOCKER_BIN: fakeDocker,
+				COMPOSE_PROJECT_NAME: "lc-e2e-690-20260810",
+				FIXTURE_PUID: "1000",
+				FIXTURE_PGID: "1000",
+			},
+		},
+	);
+	assert.equal(configuredResult.status, 0, configuredResult.stderr);
 
 	const invocations = (await readFile(composeLog, "utf8"))
 		.trim()
 		.split("--\n")
 		.filter(Boolean)
 		.map((invocation) => invocation.trim().split("\n"));
-	assert.equal(invocations.length, ARR_FIXTURES.length * 2);
+	assert.equal(invocations.length, ARR_FIXTURES.length * 4);
 	for (const invocation of invocations) {
 		assert.deepEqual(invocation.slice(0, 3), ["compose", "-p", "lc-e2e-690-20260810"]);
 		const shellIndex = invocation.lastIndexOf("sh");

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -11,11 +11,14 @@ import {
 	buildSeriesAddBody,
 	buildFixtureRemoval,
 	classifyFixtureFileState,
+	classifyFixtureEpisodeAssociation,
 	fileRecordMatches,
 	fixtureLibraryPath,
 	isRepeatedFixtureResetState,
+	isMissingPlexLibraryValidation,
 	isPathWithinRoot,
 	MOVIE,
+	plexNotificationSaveEndpoint,
 	SERIES,
 	validateCredentials,
 } from "./bootstrap-arr.mjs";
@@ -151,6 +154,36 @@ test("Plex notifications carry exact per-instance path mappings and delete event
 	assert.throws(() => buildPlexNotificationPayload({ ...schema, fields: [] }, ARR_FIXTURES[0]));
 });
 
+test("Plex notification bootstrap explicitly defers library validation", () => {
+	assert.equal(plexNotificationSaveEndpoint(undefined), "/api/v3/notification?forceSave=true");
+	assert.equal(plexNotificationSaveEndpoint({ id: 19 }), "/api/v3/notification/19?forceSave=true");
+	assert.throws(() => plexNotificationSaveEndpoint({ id: "19" }), /invalid identity/);
+});
+
+test("only the exact missing Plex library validation is deferrable", () => {
+	assert.equal(
+		isMissingPlexLibraryValidation(
+			new Error("POST failed with HTTP 400: At least one Movie library is required"),
+			"movie",
+		),
+		true,
+	);
+	assert.equal(
+		isMissingPlexLibraryValidation(
+			new Error("POST failed with HTTP 400: Authentication Token is invalid"),
+			"movie",
+		),
+		false,
+	);
+	assert.equal(
+		isMissingPlexLibraryValidation(
+			new Error("POST failed with HTTP 400: At least one Movie library is required"),
+			"series",
+		),
+		false,
+	);
+});
+
 test("placeholder media has a Matroska header and unique per-instance content", () => {
 	const buffers = ARR_FIXTURES.map((fixture) => buildPlaceholderBuffer(fixture));
 	assert.equal(new Set(buffers.map((buffer) => buffer.toString("base64"))).size, 4);
@@ -245,6 +278,28 @@ test("fixture state treats import transitions between separate reads as transien
 			associatedFileId: 14,
 		}),
 		{ kind: "reset", reason: "duplicate", recordIds: [13, 14] },
+	);
+});
+
+test("Sonarr episode creation is pending until exactly one valid S01E01 exists", () => {
+	assert.deepEqual(classifyFixtureEpisodeAssociation([], 9), { kind: "pending" });
+	assert.deepEqual(
+		classifyFixtureEpisodeAssociation(
+			[{ id: 4, seriesId: 9, seasonNumber: 1, episodeNumber: 1, hasFile: false }],
+			9,
+		),
+		{ kind: "ready", fileId: null },
+	);
+	assert.throws(
+		() =>
+			classifyFixtureEpisodeAssociation(
+				[
+					{ id: 4, seriesId: 9, seasonNumber: 1, episodeNumber: 1, hasFile: false },
+					{ id: 5, seriesId: 9, seasonNumber: 1, episodeNumber: 1, hasFile: false },
+				],
+				9,
+			),
+		/duplicate S01E01/,
 	);
 });
 

--- a/e2e/library-cleanup/bootstrap-arr.test.mjs
+++ b/e2e/library-cleanup/bootstrap-arr.test.mjs
@@ -61,6 +61,9 @@ test("filesystem bootstrap executes the resolved Docker Compose command vector",
 `,
 	);
 	await chmod(fakeDocker, 0o755);
+	const defaultDockerEnv = { ...process.env };
+	delete defaultDockerEnv.ARR_DOCKER_BIN;
+	delete defaultDockerEnv.ARR_COMPOSE_BIN;
 
 	const result = spawnSync(
 		process.execPath,
@@ -68,7 +71,7 @@ test("filesystem bootstrap executes the resolved Docker Compose command vector",
 		{
 			encoding: "utf8",
 			env: {
-				...process.env,
+				...defaultDockerEnv,
 				ARR_COMPOSE_LOG: composeLog,
 				COMPOSE_PROJECT_NAME: "lc-e2e-690-20260810",
 				FIXTURE_PUID: "1000",
@@ -85,7 +88,7 @@ test("filesystem bootstrap executes the resolved Docker Compose command vector",
 		{
 			encoding: "utf8",
 			env: {
-				...process.env,
+				...defaultDockerEnv,
 				ARR_COMPOSE_LOG: composeLog,
 				ARR_DOCKER_BIN: fakeDocker,
 				COMPOSE_PROJECT_NAME: "lc-e2e-690-20260810",
@@ -296,6 +299,17 @@ test("file record verification accepts only the expected absolute or relative pa
 	assert.equal(
 		fileRecordMatches(
 			{ relativePath: "Season 02/Breaking.Bad.S01E01.1080p.mkv" },
+			itemPath,
+			expectedPath,
+		),
+		false,
+	);
+	assert.equal(
+		fileRecordMatches(
+			{
+				path: `${itemPath}/Season 02/Breaking.Bad.S01E01.1080p.mkv`,
+				relativePath: "Season 01/Breaking.Bad.S01E01.1080p.mkv",
+			},
 			itemPath,
 			expectedPath,
 		),

--- a/e2e/library-cleanup/bootstrap-dashboard.sh
+++ b/e2e/library-cleanup/bootstrap-dashboard.sh
@@ -8,6 +8,7 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
 DASHBOARD_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
@@ -22,6 +23,8 @@ esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 extract_api_key() {
 	service=$1

--- a/e2e/library-cleanup/bootstrap-dashboard.sh
+++ b/e2e/library-cleanup/bootstrap-dashboard.sh
@@ -7,8 +7,8 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+. "$SCRIPT_DIR/compose-command.sh"
 DASHBOARD_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
-COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
 
@@ -22,10 +22,6 @@ esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
-
-compose() {
-	"$COMPOSE_BIN" -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml "$@"
-}
 
 extract_api_key() {
 	service=$1

--- a/e2e/library-cleanup/bootstrap-dashboard.sh
+++ b/e2e/library-cleanup/bootstrap-dashboard.sh
@@ -7,8 +7,10 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
+if [ -z "${ARR_DOCKER_BIN:-}" ]; then
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+	export DOCKER_CONFIG
+fi
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 DASHBOARD_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}

--- a/e2e/library-cleanup/bootstrap-dashboard.sh
+++ b/e2e/library-cleanup/bootstrap-dashboard.sh
@@ -7,12 +7,11 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+export DOCKER_CONFIG
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 DASHBOARD_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
-
 case "$DASHBOARD_SERVICE" in
 	dashboard-sqlite | dashboard-postgres) ;;
 	*)

--- a/e2e/library-cleanup/bootstrap-plex.mjs
+++ b/e2e/library-cleanup/bootstrap-plex.mjs
@@ -161,9 +161,8 @@ async function ensureWatchedEpisode(showSection) {
 	await request(
 		`/:/scrobble?key=${encodeURIComponent(episode.ratingKey)}&identifier=com.plexapp.plugins.library`,
 	);
-	const refreshedEpisodes = (
-		await request(`/library/metadata/${show.ratingKey}/allLeaves`)
-	).json()?.MediaContainer?.Metadata;
+	const refreshedEpisodes = (await request(`/library/metadata/${show.ratingKey}/allLeaves`)).json()
+		?.MediaContainer?.Metadata;
 	const refreshed = Array.isArray(refreshedEpisodes)
 		? refreshedEpisodes.find((candidate) => candidate.ratingKey === episode.ratingKey)
 		: undefined;

--- a/e2e/library-cleanup/bootstrap-plex.sh
+++ b/e2e/library-cleanup/bootstrap-plex.sh
@@ -7,13 +7,12 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+export DOCKER_CONFIG
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-plex-$PROJECT_NAME.mjs
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
-
 case "$RUNNER_SERVICE" in
 	dashboard-sqlite | dashboard-postgres) ;;
 	*)

--- a/e2e/library-cleanup/bootstrap-plex.sh
+++ b/e2e/library-cleanup/bootstrap-plex.sh
@@ -7,8 +7,10 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
+if [ -z "${ARR_DOCKER_BIN:-}" ]; then
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+	export DOCKER_CONFIG
+fi
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}

--- a/e2e/library-cleanup/bootstrap-plex.sh
+++ b/e2e/library-cleanup/bootstrap-plex.sh
@@ -8,13 +8,24 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
-RUNNER_SERVICE=dashboard-sqlite
+. "$SCRIPT_DIR/live-project-guard.sh"
+RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-plex-$PROJECT_NAME.mjs
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
 
+case "$RUNNER_SERVICE" in
+	dashboard-sqlite | dashboard-postgres) ;;
+	*)
+		echo "Plex bootstrap refused: unsupported runner service $RUNNER_SERVICE." >&2
+		exit 1
+		;;
+esac
+
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true

--- a/e2e/library-cleanup/bootstrap-plex.sh
+++ b/e2e/library-cleanup/bootstrap-plex.sh
@@ -7,7 +7,7 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
+. "$SCRIPT_DIR/compose-command.sh"
 RUNNER_SERVICE=dashboard-sqlite
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-plex-$PROJECT_NAME.mjs
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
@@ -15,10 +15,6 @@ export DOCKER_CONFIG
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
-
-compose() {
-	"$COMPOSE_BIN" -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml "$@"
-}
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true

--- a/e2e/library-cleanup/bootstrap-plex.test.mjs
+++ b/e2e/library-cleanup/bootstrap-plex.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -7,6 +8,19 @@ import {
 	PLEX_LIBRARIES,
 	parseSections,
 } from "./bootstrap-plex.mjs";
+
+test("loopback Plex history fixture has one stable nonempty history key", () => {
+	const compose = readFileSync(new URL("./compose.yml", import.meta.url), "utf8");
+	const historyFixture = compose.match(
+		/if \(requestUrl\.pathname === "\/status\/sessions\/history\/all"\) \{([\s\S]*?)\n          \}/,
+	)?.[1];
+
+	assert.ok(historyFixture, "loopback Plex history fixture must be present");
+	const historyKeys = [...historyFixture.matchAll(/historyKey:\s*"([^"]+)"/g)].map(
+		([, historyKey]) => historyKey,
+	);
+	assert.deepEqual(historyKeys, ["lc-e2e-plex-history-pilot-17"]);
+});
 
 test("Plex URL stays on the exact isolated loopback bridge", () => {
 	assert.equal(assertHarnessPlexUrl("http://plex:33240"), "http://plex:33240");

--- a/e2e/library-cleanup/bootstrap-qui.sh
+++ b/e2e/library-cleanup/bootstrap-qui.sh
@@ -4,10 +4,22 @@ set -eu
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
 PRIVATE_SUBNET=${HARNESS_SUBNET:-172.31.250.0/24}
+RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
+
+case "$RUNNER_SERVICE" in
+	dashboard-sqlite | dashboard-postgres) ;;
+	*)
+		echo "qUI bootstrap refused: unsupported runner service $RUNNER_SERVICE." >&2
+		exit 1
+		;;
+esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 temporary_password() {
 	service=$1
@@ -26,7 +38,7 @@ register_pair() {
 	qbit_password=$2
 	upper_pair=$(printf '%s' "$pair" | tr '[:lower:]' '[:upper:]')
 
-	compose exec -T -e QBIT_PASSWORD="$qbit_password" -e PRIVATE_SUBNET="$PRIVATE_SUBNET" dashboard-sqlite node -e '
+	compose exec -T -e QBIT_PASSWORD="$qbit_password" -e PRIVATE_SUBNET="$PRIVATE_SUBNET" "$RUNNER_SERVICE" node -e '
 		const [quiHost, qbitHost, name] = process.argv.slice(1);
 		const login = await fetch(`${qbitHost}/api/v2/auth/login`, {
 			method: "POST",

--- a/e2e/library-cleanup/bootstrap-qui.sh
+++ b/e2e/library-cleanup/bootstrap-qui.sh
@@ -3,14 +3,11 @@ set -eu
 
 SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+. "$SCRIPT_DIR/compose-command.sh"
 PRIVATE_SUBNET=${HARNESS_SUBNET:-172.31.250.0/24}
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
-
-compose() {
-	docker compose -f compose.yml -f compose.debug.yml "$@"
-}
 
 temporary_password() {
 	service=$1

--- a/e2e/library-cleanup/bootstrap-torrents.mjs
+++ b/e2e/library-cleanup/bootstrap-torrents.mjs
@@ -133,12 +133,7 @@ function extractSidCookie(response) {
 	return undefined;
 }
 
-export async function createQbitSession({
-	baseUrl,
-	credentials,
-	fetchImpl = fetch,
-	service,
-}) {
+export async function createQbitSession({ baseUrl, credentials, fetchImpl = fetch, service }) {
 	const endpoint = "/api/v2/auth/login";
 	const response = await fetchImpl(`${baseUrl}${endpoint}`, {
 		body: new URLSearchParams(credentials),
@@ -152,7 +147,9 @@ export async function createQbitSession({
 	}
 	const sidCookie = extractSidCookie(response);
 	if (!sidCookie) {
-		throw new Error(`${service} POST ${endpoint} failed with HTTP ${response.status}: SID cookie missing`);
+		throw new Error(
+			`${service} POST ${endpoint} failed with HTTP ${response.status}: SID cookie missing`,
+		);
 	}
 	return { baseUrl, fetchImpl, service, sidCookie };
 }

--- a/e2e/library-cleanup/bootstrap-torrents.mjs
+++ b/e2e/library-cleanup/bootstrap-torrents.mjs
@@ -100,20 +100,82 @@ export function buildTorrent(fileName, content) {
 	};
 }
 
-async function qbitRequest(baseUrl, endpoint, init = {}) {
-	const response = await fetch(`${baseUrl}${endpoint}`, {
+function credentialEnvironmentNames(service) {
+	const prefix = service.toUpperCase().replaceAll("-", "_");
+	return {
+		password: `${prefix}_PASSWORD`,
+		username: `${prefix}_USERNAME`,
+	};
+}
+
+export function resolveQbitCredentials(service, environment = process.env) {
+	const names = credentialEnvironmentNames(service);
+	const username = environment[names.username];
+	const password = environment[names.password];
+	if (typeof username !== "string" || username.length === 0) {
+		throw new Error(`${service} requires ${names.username}`);
+	}
+	if (typeof password !== "string" || password.length === 0) {
+		throw new Error(`${service} requires ${names.password}`);
+	}
+	return { username, password };
+}
+
+function extractSidCookie(response) {
+	const setCookies =
+		typeof response.headers.getSetCookie === "function"
+			? response.headers.getSetCookie()
+			: [response.headers.get("set-cookie")].filter(Boolean);
+	for (const setCookie of setCookies) {
+		const match = /(?:^|;\s*)SID=([^;,\s]+)/.exec(setCookie);
+		if (match?.[1]) return `SID=${match[1]}`;
+	}
+	return undefined;
+}
+
+export async function createQbitSession({
+	baseUrl,
+	credentials,
+	fetchImpl = fetch,
+	service,
+}) {
+	const endpoint = "/api/v2/auth/login";
+	const response = await fetchImpl(`${baseUrl}${endpoint}`, {
+		body: new URLSearchParams(credentials),
+		headers: { "Content-Type": "application/x-www-form-urlencoded" },
+		method: "POST",
+		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+	});
+	await response.text();
+	if (!response.ok) {
+		throw new Error(`${service} POST ${endpoint} failed with HTTP ${response.status}`);
+	}
+	const sidCookie = extractSidCookie(response);
+	if (!sidCookie) {
+		throw new Error(`${service} POST ${endpoint} failed with HTTP ${response.status}: SID cookie missing`);
+	}
+	return { baseUrl, fetchImpl, service, sidCookie };
+}
+
+export async function qbitRequest(session, endpoint, init = {}) {
+	const method = init.method ?? "GET";
+	const response = await session.fetchImpl(`${session.baseUrl}${endpoint}`, {
 		...init,
+		headers: { ...init.headers, Cookie: session.sidCookie },
 		signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
 	});
 	const text = await response.text();
 	if (!response.ok) {
-		throw new Error(`${init.method ?? "GET"} ${endpoint} failed with HTTP ${response.status}`);
+		throw new Error(`${session.service} ${method} ${endpoint} failed with HTTP ${response.status}`);
 	}
 	return text;
 }
 
-async function addAndVerify(fixture) {
+async function addAndVerify(fixture, session) {
 	const baseUrl = assertHarnessQbitUrl(fixture.baseUrl, fixture.service);
+	if (session.baseUrl !== baseUrl || session.service !== fixture.service) {
+		throw new Error(`${fixture.service} session does not match its isolated endpoint`);
+	}
 	const content = await readFile(fixture.sourcePath);
 	if (!content.includes(Buffer.from("ARR-DASHBOARD-LIBRARY-CLEANUP-E2E"))) {
 		throw new Error(`${fixture.service} source is not a guarded gauntlet fixture`);
@@ -121,20 +183,20 @@ async function addAndVerify(fixture) {
 	const fileName = path.posix.basename(fixture.sourcePath);
 	const { infoHash, metainfo } = buildTorrent(fileName, content);
 	const existing = JSON.parse(
-		await qbitRequest(baseUrl, `/api/v2/torrents/info?hashes=${infoHash}`),
+		await qbitRequest(session, `/api/v2/torrents/info?hashes=${infoHash}`),
 	);
 	if (existing.length === 0) {
 		const form = new FormData();
 		form.append("torrents", new Blob([metainfo]), `${fileName}.torrent`);
 		form.append("savepath", path.posix.dirname(fixture.sourcePath));
 		form.append("category", "arr-dashboard-library-cleanup-gauntlet");
-		await qbitRequest(baseUrl, "/api/v2/torrents/add", { method: "POST", body: form });
+		await qbitRequest(session, "/api/v2/torrents/add", { method: "POST", body: form });
 	}
 
 	const deadline = Date.now() + VERIFY_TIMEOUT_MS;
 	while (Date.now() < deadline) {
 		const torrents = JSON.parse(
-			await qbitRequest(baseUrl, `/api/v2/torrents/info?hashes=${infoHash}`),
+			await qbitRequest(session, `/api/v2/torrents/info?hashes=${infoHash}`),
 		);
 		const torrent = torrents[0];
 		if (
@@ -151,8 +213,22 @@ async function addAndVerify(fixture) {
 	throw new Error(`${fixture.service} did not expose the exact torrent fixture`);
 }
 
-export async function main() {
-	for (const fixture of TORRENT_FIXTURES) await addAndVerify(fixture);
+export async function main({ environment = process.env, fetchImpl = fetch } = {}) {
+	const sessions = new Map();
+	for (const fixture of TORRENT_FIXTURES) {
+		let session = sessions.get(fixture.service);
+		if (!session) {
+			const baseUrl = assertHarnessQbitUrl(fixture.baseUrl, fixture.service);
+			session = await createQbitSession({
+				baseUrl,
+				credentials: resolveQbitCredentials(fixture.service, environment),
+				fetchImpl,
+				service: fixture.service,
+			});
+			sessions.set(fixture.service, session);
+		}
+		await addAndVerify(fixture, session);
+	}
 }
 
 const isMain = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);

--- a/e2e/library-cleanup/bootstrap-torrents.sh
+++ b/e2e/library-cleanup/bootstrap-torrents.sh
@@ -9,8 +9,10 @@ fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-torrents-$PROJECT_NAME.mjs
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
+if [ -z "${ARR_DOCKER_BIN:-}" ]; then
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+	export DOCKER_CONFIG
+fi
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 

--- a/e2e/library-cleanup/bootstrap-torrents.sh
+++ b/e2e/library-cleanup/bootstrap-torrents.sh
@@ -7,14 +7,25 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-RUNNER_SERVICE=dashboard-sqlite
+RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-torrents-$PROJECT_NAME.mjs
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
+
+case "$RUNNER_SERVICE" in
+	dashboard-sqlite | dashboard-postgres) ;;
+	*)
+		echo "Torrent bootstrap refused: unsupported runner service $RUNNER_SERVICE." >&2
+		exit 1
+		;;
+esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true

--- a/e2e/library-cleanup/bootstrap-torrents.sh
+++ b/e2e/library-cleanup/bootstrap-torrents.sh
@@ -7,18 +7,14 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
 RUNNER_SERVICE=dashboard-sqlite
 RUNNER_SCRIPT=/tmp/lc-e2e-bootstrap-torrents-$PROJECT_NAME.mjs
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 export DOCKER_CONFIG
+. "$SCRIPT_DIR/compose-command.sh"
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
-
-compose() {
-	"$COMPOSE_BIN" -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml "$@"
-}
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true
@@ -32,7 +28,34 @@ for service in qbittorrent-a qbittorrent-b "$RUNNER_SERVICE"; do
 	fi
 done
 
+temporary_password() {
+	service=$1
+	password=$(compose logs --no-color "$service" |
+		sed -n 's/.*temporary password is provided for this session: //p' |
+		tail -n 1)
+	if [ -z "$password" ]; then
+		echo "Torrent bootstrap could not find the disposable qBittorrent password for $service." >&2
+		exit 1
+	fi
+	printf '%s' "$password"
+}
+
+QBITTORRENT_A_USERNAME=admin
+QBITTORRENT_B_USERNAME=admin
+QBITTORRENT_A_PASSWORD=$(temporary_password qbittorrent-a)
+QBITTORRENT_B_PASSWORD=$(temporary_password qbittorrent-b)
+export QBITTORRENT_A_USERNAME QBITTORRENT_A_PASSWORD
+export QBITTORRENT_B_USERNAME QBITTORRENT_B_PASSWORD
+
 compose cp "$SCRIPT_DIR/bootstrap-torrents.mjs" "$RUNNER_SERVICE:$RUNNER_SCRIPT" >/dev/null
-compose exec -T "$RUNNER_SERVICE" node "$RUNNER_SCRIPT"
+compose exec -T \
+	-e QBITTORRENT_A_USERNAME \
+	-e QBITTORRENT_A_PASSWORD \
+	-e QBITTORRENT_B_USERNAME \
+	-e QBITTORRENT_B_PASSWORD \
+	"$RUNNER_SERVICE" node "$RUNNER_SCRIPT"
+
+unset QBITTORRENT_A_USERNAME QBITTORRENT_A_PASSWORD
+unset QBITTORRENT_B_USERNAME QBITTORRENT_B_PASSWORD
 
 echo "Disposable qBittorrent fixtures are registered and verified."

--- a/e2e/library-cleanup/bootstrap-torrents.test.mjs
+++ b/e2e/library-cleanup/bootstrap-torrents.test.mjs
@@ -83,7 +83,10 @@ test("qBittorrent session logs in with disposable credentials and retains the SI
 	assert.equal(session.sidCookie, "SID=disposable-a");
 	assert.equal(mock.calls[0].url, "http://qbittorrent-a:8080/api/v2/auth/login");
 	assert.equal(mock.calls[0].init.method, "POST");
-	assert.equal(mock.calls[0].init.body.toString(), "username=bootstrap-a&password=not-in-error-output");
+	assert.equal(
+		mock.calls[0].init.body.toString(),
+		"username=bootstrap-a&password=not-in-error-output",
+	);
 });
 
 test("qBittorrent session rejects a successful login response without a SID cookie", async () => {

--- a/e2e/library-cleanup/bootstrap-torrents.test.mjs
+++ b/e2e/library-cleanup/bootstrap-torrents.test.mjs
@@ -5,8 +5,28 @@ import {
 	assertHarnessQbitUrl,
 	bencode,
 	buildTorrent,
+	createQbitSession,
+	qbitRequest,
+	resolveQbitCredentials,
 	TORRENT_FIXTURES,
 } from "./bootstrap-torrents.mjs";
+
+function response(body, { headers, status = 200 } = {}) {
+	return new Response(body, { headers, status });
+}
+
+function fetchSequence(responses) {
+	const calls = [];
+	return {
+		calls,
+		fetch: async (url, init) => {
+			calls.push({ url, init });
+			const next = responses.shift();
+			if (!next) throw new Error(`unexpected request to ${url}`);
+			return next;
+		},
+	};
+}
 
 test("qBittorrent URLs stay on exact isolated service endpoints", () => {
 	assert.equal(
@@ -46,4 +66,92 @@ test("fixture set maps two exact payloads to each isolated qBittorrent", () => {
 	for (const fixture of TORRENT_FIXTURES) {
 		assert.match(fixture.sourcePath, /^\/data\/torrents\/(?:radarr|sonarr)-[ab]\//);
 	}
+});
+
+test("qBittorrent session logs in with disposable credentials and retains the SID", async () => {
+	const mock = fetchSequence([
+		response("Ok.", { headers: { "set-cookie": "SID=disposable-a; HttpOnly; Path=/" } }),
+	]);
+
+	const session = await createQbitSession({
+		baseUrl: "http://qbittorrent-a:8080",
+		credentials: { username: "bootstrap-a", password: "not-in-error-output" },
+		fetchImpl: mock.fetch,
+		service: "qbittorrent-a",
+	});
+
+	assert.equal(session.sidCookie, "SID=disposable-a");
+	assert.equal(mock.calls[0].url, "http://qbittorrent-a:8080/api/v2/auth/login");
+	assert.equal(mock.calls[0].init.method, "POST");
+	assert.equal(mock.calls[0].init.body.toString(), "username=bootstrap-a&password=not-in-error-output");
+});
+
+test("qBittorrent session rejects a successful login response without a SID cookie", async () => {
+	const mock = fetchSequence([response("Ok.")]);
+
+	await assert.rejects(
+		createQbitSession({
+			baseUrl: "http://qbittorrent-a:8080",
+			credentials: { username: "bootstrap-a", password: "secret-password" },
+			fetchImpl: mock.fetch,
+			service: "qbittorrent-a",
+		}),
+		(error) =>
+			error instanceof Error &&
+			error.message ===
+				"qbittorrent-a POST /api/v2/auth/login failed with HTTP 200: SID cookie missing" &&
+			!error.message.includes("secret-password"),
+	);
+});
+
+test("qBittorrent session reports refused login status without exposing credentials", async () => {
+	for (const status of [401, 403]) {
+		const mock = fetchSequence([response("Fails.", { status })]);
+		await assert.rejects(
+			createQbitSession({
+				baseUrl: "http://qbittorrent-a:8080",
+				credentials: { username: "bootstrap-a", password: "secret-password" },
+				fetchImpl: mock.fetch,
+				service: "qbittorrent-a",
+			}),
+			(error) =>
+				error instanceof Error &&
+				error.message === `qbittorrent-a POST /api/v2/auth/login failed with HTTP ${status}` &&
+				!error.message.includes("secret-password"),
+		);
+	}
+});
+
+test("qBittorrent session sends its SID cookie to info, add, and verification requests", async () => {
+	const mock = fetchSequence([
+		response("Ok.", { headers: { "set-cookie": "SID=disposable-a; HttpOnly; Path=/" } }),
+		response("[]"),
+		response("Ok."),
+		response("[]"),
+	]);
+	const session = await createQbitSession({
+		baseUrl: "http://qbittorrent-a:8080",
+		credentials: { username: "bootstrap-a", password: "secret-password" },
+		fetchImpl: mock.fetch,
+		service: "qbittorrent-a",
+	});
+
+	await qbitRequest(session, "/api/v2/torrents/info?hashes=before-add");
+	await qbitRequest(session, "/api/v2/torrents/add", { method: "POST", body: new FormData() });
+	await qbitRequest(session, "/api/v2/torrents/info?hashes=after-add");
+
+	for (const call of mock.calls.slice(1)) {
+		assert.equal(call.init.headers.Cookie, "SID=disposable-a");
+	}
+});
+
+test("qBittorrent credentials are isolated by service", () => {
+	assert.deepEqual(
+		resolveQbitCredentials("qbittorrent-b", {
+			QBITTORRENT_B_USERNAME: "bootstrap-b",
+			QBITTORRENT_B_PASSWORD: "secret-password",
+		}),
+		{ username: "bootstrap-b", password: "secret-password" },
+	);
+	assert.throws(() => resolveQbitCredentials("qbittorrent-a", {}), /QBITTORRENT_A_USERNAME/);
 });

--- a/e2e/library-cleanup/check-compose-model.py
+++ b/e2e/library-cleanup/check-compose-model.py
@@ -48,14 +48,14 @@ EXPECTED_VOLUMES = {
 }
 EXPECTED_NETWORKS = {"cleanup-internal", "metadata-egress"}
 ALLOWED_QUI_IMAGES = {"ghcr.io/autobrr/qui:v1.16.1"}
-EXPECTED_INTEGRATION_IMAGES = {
-    "radarr-a": "lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a",
-    "radarr-b": "lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a",
-    "sonarr-a": "lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7",
-    "sonarr-b": "lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7",
-    "plex": "lscr.io/linuxserver/plex:1.41.5@sha256:5c07f70ae39709c71927ecb864cb9328acb01eb6c08779d1efb09b90b68a0692",
-    "qbittorrent-a": "lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e",
-    "qbittorrent-b": "lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e",
+EXPECTED_INTEGRATION_IMAGE_REPOSITORIES = {
+    "radarr-a": "lscr.io/linuxserver/radarr",
+    "radarr-b": "lscr.io/linuxserver/radarr",
+    "sonarr-a": "lscr.io/linuxserver/sonarr",
+    "sonarr-b": "lscr.io/linuxserver/sonarr",
+    "plex": "lscr.io/linuxserver/plex",
+    "qbittorrent-a": "lscr.io/linuxserver/qbittorrent",
+    "qbittorrent-b": "lscr.io/linuxserver/qbittorrent",
 }
 QUI_READINESS_TEST = [
     "CMD",
@@ -162,9 +162,15 @@ def validate_model(
     if set(services) != EXPECTED_SERVICES:
         fail("rendered service set does not exactly match the Library Cleanup harness")
 
-    for service_name, expected_image in EXPECTED_INTEGRATION_IMAGES.items():
-        if services[service_name].get("image") != expected_image:
-            fail(f"{service_name} image is not the reviewed immutable integration default")
+    for service_name, expected_repository in EXPECTED_INTEGRATION_IMAGE_REPOSITORIES.items():
+        image = services[service_name].get("image")
+        if not isinstance(image, str) or not re.fullmatch(
+            rf"{re.escape(expected_repository)}:[A-Za-z0-9._-]+@sha256:[a-f0-9]{{64}}", image
+        ):
+            fail(f"{service_name} image must be an immutable digest from its expected repository")
+    for left, right in (("radarr-a", "radarr-b"), ("sonarr-a", "sonarr-b"), ("qbittorrent-a", "qbittorrent-b")):
+        if services[left].get("image") != services[right].get("image"):
+            fail(f"{left} and {right} must use the same integration image")
 
     for service_name, service_value in services.items():
         if not isinstance(service_value, dict):
@@ -373,6 +379,13 @@ def run_self_tests(model: dict[str, object]) -> None:
         mutated["services"][service_name]["image"] = "busybox@sha256:" + "0" * 64
         expect_rejected(mutated, f"unexpected integration image for {service_name}")
         negative_count += 1
+
+    immutable_override = copy.deepcopy(model)
+    for service_name in ("radarr-a", "radarr-b"):
+        immutable_override["services"][service_name]["image"] = (
+            "lscr.io/linuxserver/radarr:compat@sha256:" + "1" * 64
+        )
+    validate_model(immutable_override)
 
     mutated = copy.deepcopy(model)
     mutated["services"]["qui-a"].pop("healthcheck", None)

--- a/e2e/library-cleanup/check-compose-model.py
+++ b/e2e/library-cleanup/check-compose-model.py
@@ -48,6 +48,15 @@ EXPECTED_VOLUMES = {
 }
 EXPECTED_NETWORKS = {"cleanup-internal", "metadata-egress"}
 ALLOWED_QUI_IMAGES = {"ghcr.io/autobrr/qui:v1.16.1"}
+EXPECTED_INTEGRATION_IMAGES = {
+    "radarr-a": "lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a",
+    "radarr-b": "lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a",
+    "sonarr-a": "lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7",
+    "sonarr-b": "lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7",
+    "plex": "lscr.io/linuxserver/plex:1.41.5@sha256:5c07f70ae39709c71927ecb864cb9328acb01eb6c08779d1efb09b90b68a0692",
+    "qbittorrent-a": "lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e",
+    "qbittorrent-b": "lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e",
+}
 QUI_READINESS_TEST = [
     "CMD",
     "wget",
@@ -152,6 +161,10 @@ def validate_model(
     services = services_value
     if set(services) != EXPECTED_SERVICES:
         fail("rendered service set does not exactly match the Library Cleanup harness")
+
+    for service_name, expected_image in EXPECTED_INTEGRATION_IMAGES.items():
+        if services[service_name].get("image") != expected_image:
+            fail(f"{service_name} image is not the reviewed immutable integration default")
 
     for service_name, service_value in services.items():
         if not isinstance(service_value, dict):
@@ -344,6 +357,22 @@ def run_self_tests(model: dict[str, object]) -> None:
     mutated["services"]["qui-a"]["image"] = "busybox:latest"
     expect_rejected(mutated, "arbitrary qUI image")
     negative_count += 1
+
+    for service_name in (
+        "radarr-a",
+        "sonarr-a",
+        "plex",
+        "qbittorrent-a",
+    ):
+        mutated = copy.deepcopy(model)
+        mutated["services"][service_name]["image"] = "lscr.io/linuxserver/example:latest"
+        expect_rejected(mutated, f"mutable integration image for {service_name}")
+        negative_count += 1
+
+        mutated = copy.deepcopy(model)
+        mutated["services"][service_name]["image"] = "busybox@sha256:" + "0" * 64
+        expect_rejected(mutated, f"unexpected integration image for {service_name}")
+        negative_count += 1
 
     mutated = copy.deepcopy(model)
     mutated["services"]["qui-a"].pop("healthcheck", None)

--- a/e2e/library-cleanup/check-compose-model.py
+++ b/e2e/library-cleanup/check-compose-model.py
@@ -78,6 +78,8 @@ GENERIC_LIVE_PROJECTS = {
 }
 GENERIC_LIVE_PARTS = {"default", "demo", "dev", "local", "shared", "test"}
 SUSPICIOUS_LIVE_PREFIXES = ("main", "prod", "stable")
+RUN_PROJECT_LABEL = "io.arr-dashboard.library-cleanup.project"
+RUN_TOKEN_LABEL = "io.arr-dashboard.library-cleanup.run-token"
 
 
 class SafetyError(ValueError):
@@ -102,6 +104,19 @@ def validate_project_name(project: str, *, require_live_name: bool) -> None:
         fail("live project name contains a production-like or branch-like identifier")
     if not any(character.isdigit() for character in project) or len(project) < 16:
         fail("live project name must include a run-specific numeric discriminator")
+
+
+def validate_run_labels(labels: object, project: str, expected_token: str | None = None) -> str:
+    if not isinstance(labels, dict):
+        fail("harness resource is missing run-ownership labels")
+    if labels.get(RUN_PROJECT_LABEL) != project:
+        fail("harness resource has a mismatched run project label")
+    token = labels.get(RUN_TOKEN_LABEL)
+    if not isinstance(token, str) or not re.fullmatch(r"[a-f0-9]{64}", token):
+        fail("LC_E2E_RUN_TOKEN must be a random 64-character lowercase hex token")
+    if expected_token is not None and token != expected_token:
+        fail("harness resources do not share one run-ownership token")
+    return token
 
 
 def validate_postgres_password_value(value: bytes) -> None:
@@ -161,6 +176,7 @@ def validate_model(
     services = services_value
     if set(services) != EXPECTED_SERVICES:
         fail("rendered service set does not exactly match the Library Cleanup harness")
+    run_token = validate_run_labels(services["radarr-a"].get("labels"), project)
 
     for service_name, expected_repository in EXPECTED_INTEGRATION_IMAGE_REPOSITORIES.items():
         image = services[service_name].get("image")
@@ -176,6 +192,7 @@ def validate_model(
         if not isinstance(service_value, dict):
             fail(f"{service_name} has an invalid rendered definition")
         service = service_value
+        validate_run_labels(service.get("labels"), project, run_token)
         if "container_name" in service:
             fail(f"{service_name} sets container_name")
         for mount in service.get("volumes", []):
@@ -188,6 +205,10 @@ def validate_model(
     volumes_value = model.get("volumes", {})
     if not isinstance(volumes_value, dict):
         fail("rendered Compose volumes are missing")
+    for volume in volumes_value.values():
+        validate_run_labels(
+            volume.get("labels") if isinstance(volume, dict) else None, project, run_token
+        )
     if set(volumes_value) != EXPECTED_VOLUMES:
         fail("rendered volume set does not exactly match the Library Cleanup harness")
     for volume_name, volume in volumes_value.items():
@@ -203,6 +224,9 @@ def validate_model(
     if set(networks_value) != EXPECTED_NETWORKS:
         fail("rendered network set does not exactly match the Library Cleanup harness")
     for network_name, network in networks_value.items():
+        validate_run_labels(
+            network.get("labels") if isinstance(network, dict) else None, project, run_token
+        )
         if network.get("external"):
             fail(f"network {network_name} is external")
         expected_name = f"{project}_{network_name}"
@@ -260,6 +284,13 @@ def validate_model(
         fail("Plex loopback proxy must share only the disposable Plex network namespace")
     if plex_proxy.get("volumes") or plex_proxy.get("ports"):
         fail("Plex loopback proxy must not mount data or publish ports")
+
+    for dashboard_name in ("dashboard-sqlite", "dashboard-postgres", "dashboard-baseline"):
+        proxy_dependency = services[dashboard_name].get("depends_on", {}).get(
+            "plex-loopback-proxy", {}
+        )
+        if proxy_dependency.get("condition") != "service_healthy":
+            fail(f"{dashboard_name} must wait for the Plex loopback proxy")
 
     shared_targets = {
         "radarr-a": "/radarr-a/data",
@@ -393,6 +424,11 @@ def run_self_tests(model: dict[str, object]) -> None:
     negative_count += 1
 
     mutated = copy.deepcopy(model)
+    mutated["services"]["dashboard-sqlite"]["depends_on"].pop("plex-loopback-proxy")
+    expect_rejected(mutated, "dashboard bypasses the Plex loopback readiness gate")
+    negative_count += 1
+
+    mutated = copy.deepcopy(model)
     mutated["services"]["radarr-a"]["volumes"][0]["type"] = "bind"
     expect_rejected(mutated, "runtime bind mount")
     negative_count += 1
@@ -401,6 +437,19 @@ def run_self_tests(model: dict[str, object]) -> None:
     mutated["services"]["unexpected"] = {}
     expect_rejected(mutated, "unexpected service")
     negative_count += 1
+
+    for resource_type, resource_name in (
+        ("services", "radarr-a"),
+        ("volumes", "shared-media"),
+        ("networks", "cleanup-internal"),
+    ):
+        mutated = copy.deepcopy(model)
+        current = mutated[resource_type][resource_name]["labels"][RUN_TOKEN_LABEL]
+        mutated[resource_type][resource_name]["labels"][RUN_TOKEN_LABEL] = (
+            "1" * 64 if current != "1" * 64 else "2" * 64
+        )
+        expect_rejected(mutated, f"mismatched run token on {resource_type}/{resource_name}")
+        negative_count += 1
 
     mutated = copy.deepcopy(model)
     mutated["volumes"]["shared-media"]["name"] = "unrelated_shared-media"

--- a/e2e/library-cleanup/check-live-project.py
+++ b/e2e/library-cleanup/check-live-project.py
@@ -52,6 +52,34 @@ def matching_ids(kind: str, project: str) -> set[str]:
 	return ids
 
 
+def model_resource_names(model: dict[str, Any], resource_kind: str) -> set[str]:
+	resources = model.get(f"{resource_kind}s")
+	if not isinstance(resources, dict):
+		raise OwnershipError(f"rendered model has no {resource_kind}s")
+	physical_names: set[str] = set()
+	for logical_name, definition in resources.items():
+		if not isinstance(logical_name, str) or not isinstance(definition, dict):
+			raise OwnershipError(f"rendered model has an invalid {resource_kind} definition")
+		physical_name = definition.get("name")
+		if not isinstance(physical_name, str) or not physical_name:
+			raise OwnershipError(f"rendered {resource_kind} {logical_name} has no physical name")
+		physical_names.add(physical_name)
+	return physical_names
+
+
+def existing_named_ids(kind: str, physical_names: set[str]) -> set[str]:
+	if not physical_names:
+		return set()
+	result = subprocess.run(
+		["docker", kind, "ls", "--format", "{{.Name}}"],
+		check=True,
+		stdout=subprocess.PIPE,
+		stderr=subprocess.PIPE,
+		text=True,
+	)
+	return {name for name in result.stdout.splitlines() if name in physical_names}
+
+
 def inspect_many(kind: str, identifiers: set[str]) -> list[dict[str, Any]]:
 	if not identifiers:
 		return []
@@ -321,6 +349,8 @@ def main() -> int:
 		container_ids = matching_ids("container", args.project)
 		volume_ids = matching_ids("volume", args.project)
 		network_ids = matching_ids("network", args.project)
+		volume_ids.update(existing_named_ids("volume", model_resource_names(model, "volume")))
+		network_ids.update(existing_named_ids("network", model_resource_names(model, "network")))
 		containers = inspect_many("container", container_ids)
 		volumes = inspect_many("volume", volume_ids)
 		networks = inspect_many("network", network_ids)

--- a/e2e/library-cleanup/check-live-project.py
+++ b/e2e/library-cleanup/check-live-project.py
@@ -27,17 +27,17 @@ class OwnershipError(ValueError):
 	"""A live resource cannot be attributed to this exact harness run."""
 
 
-def docker_json(*args: str) -> Any:
+def docker_json(docker_bin: str, *args: str) -> Any:
 	result = subprocess.run(
-		["docker", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+		[docker_bin, *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
 	)
 	return json.loads(result.stdout)
 
 
-def matching_ids(kind: str, project: str) -> set[str]:
+def matching_ids(docker_bin: str, kind: str, project: str) -> set[str]:
 	ids: set[str] = set()
 	for label in (f"{PROJECT_LABEL}={project}", f"{RUN_PROJECT_LABEL}={project}"):
-		command = ["docker", kind, "ls"]
+		command = [docker_bin, kind, "ls"]
 		if kind == "container":
 			command.append("-a")
 		command.extend(["--filter", f"label={label}", "--quiet"])
@@ -67,11 +67,34 @@ def model_resource_names(model: dict[str, Any], resource_kind: str) -> set[str]:
 	return physical_names
 
 
-def existing_named_ids(kind: str, physical_names: set[str]) -> set[str]:
+def model_container_names(model: dict[str, Any], project: str) -> set[str]:
+	services = model.get("services")
+	if not isinstance(services, dict):
+		raise OwnershipError("rendered model has no services")
+	physical_names: set[str] = set()
+	for service_name, service in services.items():
+		if not isinstance(service_name, str) or not isinstance(service, dict):
+			raise OwnershipError("rendered model has an invalid service definition")
+		container_name = service.get("container_name")
+		if container_name is None:
+			physical_names.add(f"{project}-{service_name}-1")
+		elif isinstance(container_name, str) and container_name:
+			physical_names.add(container_name)
+		else:
+			raise OwnershipError(f"rendered service {service_name} has an invalid container_name")
+	return physical_names
+
+
+def existing_named_ids(docker_bin: str, kind: str, physical_names: set[str]) -> set[str]:
 	if not physical_names:
 		return set()
+	format_field = "{{.Names}}" if kind == "container" else "{{.Name}}"
+	command = [docker_bin, kind, "ls"]
+	if kind == "container":
+		command.append("-a")
+	command.extend(["--format", format_field])
 	result = subprocess.run(
-		["docker", kind, "ls", "--format", "{{.Name}}"],
+		command,
 		check=True,
 		stdout=subprocess.PIPE,
 		stderr=subprocess.PIPE,
@@ -80,10 +103,10 @@ def existing_named_ids(kind: str, physical_names: set[str]) -> set[str]:
 	return {name for name in result.stdout.splitlines() if name in physical_names}
 
 
-def inspect_many(kind: str, identifiers: set[str]) -> list[dict[str, Any]]:
+def inspect_many(docker_bin: str, kind: str, identifiers: set[str]) -> list[dict[str, Any]]:
 	if not identifiers:
 		return []
-	return docker_json(kind, "inspect", *sorted(identifiers))
+	return docker_json(docker_bin, kind, "inspect", *sorted(identifiers))
 
 
 def labels_of(resource: dict[str, Any]) -> dict[str, str]:
@@ -329,6 +352,7 @@ def main() -> int:
 	parser.add_argument("--run-token")
 	parser.add_argument("--config-files")
 	parser.add_argument("--working-dir")
+	parser.add_argument("--docker-bin")
 	parser.add_argument("--allow-empty", action="store_true")
 	parser.add_argument("--self-test", action="store_true")
 	args = parser.parse_args()
@@ -336,38 +360,53 @@ def main() -> int:
 		run_self_tests()
 		return 0
 	if not all(
-		(args.model, args.hashes, args.project, args.run_token, args.config_files, args.working_dir)
+		(
+			args.model,
+			args.hashes,
+			args.project,
+			args.run_token,
+			args.config_files,
+			args.working_dir,
+			args.docker_bin,
+		)
 	):
 		parser.error(
-			"--model, --hashes, --project, --run-token, --config-files, and --working-dir are required"
+				"--model, --hashes, --project, --run-token, --config-files, --working-dir, and --docker-bin are required"
 		)
 	try:
 		model = json.loads(args.model.read_text())
 		config_hashes = dict(
 			line.split(maxsplit=1) for line in args.hashes.read_text().splitlines() if line.strip()
 		)
-		container_ids = matching_ids("container", args.project)
-		volume_ids = matching_ids("volume", args.project)
-		network_ids = matching_ids("network", args.project)
-		volume_ids.update(existing_named_ids("volume", model_resource_names(model, "volume")))
-		network_ids.update(existing_named_ids("network", model_resource_names(model, "network")))
-		containers = inspect_many("container", container_ids)
-		volumes = inspect_many("volume", volume_ids)
-		networks = inspect_many("network", network_ids)
+		container_ids = matching_ids(args.docker_bin, "container", args.project)
+		volume_ids = matching_ids(args.docker_bin, "volume", args.project)
+		network_ids = matching_ids(args.docker_bin, "network", args.project)
+		container_ids.update(
+			existing_named_ids(args.docker_bin, "container", model_container_names(model, args.project))
+		)
+		volume_ids.update(
+			existing_named_ids(args.docker_bin, "volume", model_resource_names(model, "volume"))
+		)
+		network_ids.update(
+			existing_named_ids(args.docker_bin, "network", model_resource_names(model, "network"))
+		)
+		containers = inspect_many(args.docker_bin, "container", container_ids)
+		volumes = inspect_many(args.docker_bin, "volume", volume_ids)
+		networks = inspect_many(args.docker_bin, "network", network_ids)
 		image_refs = {
 			service.get("image")
 			for service in model["services"].values()
 			if isinstance(service.get("image"), str)
 		}
 		image_ids = {
-			image: docker_json("image", "inspect", image)[0]["Id"]
+			image: docker_json(args.docker_bin, "image", "inspect", image)[0]["Id"]
 			for image in image_refs
 			if any(container.get("Config", {}).get("Image") == image for container in containers)
 		}
 		for container in containers:
 			for mount in container.get("Mounts", []):
 				if mount.get("Type") == "volume":
-					mount["Labels"] = docker_json("volume", "inspect", mount["Name"])[0].get("Labels", {})
+					mount["Labels"] = docker_json(args.docker_bin, "volume", "inspect", mount["Name"])[0].get("Labels", {})
 		validate_resources(
 			model,
 			args.project,

--- a/e2e/library-cleanup/check-live-project.py
+++ b/e2e/library-cleanup/check-live-project.py
@@ -103,10 +103,26 @@ def existing_named_ids(docker_bin: str, kind: str, physical_names: set[str]) -> 
 	return {name for name in result.stdout.splitlines() if name in physical_names}
 
 
+def deduplicate_inspections(kind: str, inspections: Any) -> list[dict[str, Any]]:
+	if not isinstance(inspections, list):
+		raise OwnershipError(f"docker {kind} inspect returned an invalid response")
+	unique: dict[str, dict[str, Any]] = {}
+	for resource in inspections:
+		if not isinstance(resource, dict):
+			raise OwnershipError(f"docker {kind} inspect returned an invalid resource")
+		identity = resource.get("Id") or resource.get("ID") or resource.get("Name")
+		if not isinstance(identity, str) or not identity:
+			raise OwnershipError(f"docker {kind} inspect returned a resource without an identity")
+		unique.setdefault(identity, resource)
+	return list(unique.values())
+
+
 def inspect_many(docker_bin: str, kind: str, identifiers: set[str]) -> list[dict[str, Any]]:
 	if not identifiers:
 		return []
-	return docker_json(docker_bin, kind, "inspect", *sorted(identifiers))
+	return deduplicate_inspections(
+		kind, docker_json(docker_bin, kind, "inspect", *sorted(identifiers))
+	)
 
 
 def labels_of(resource: dict[str, Any]) -> dict[str, str]:
@@ -276,6 +292,7 @@ def run_self_tests() -> None:
 	volume_labels = {**labels, VOLUME_LABEL: "data"}
 	network_labels = {**labels, NETWORK_LABEL: "private"}
 	container = {
+		"Id": "container-id",
 		"Name": f"/{project}-app-1",
 		"Config": {"Labels": labels, "Image": "example:test"},
 		"Image": "sha256:image",
@@ -290,6 +307,9 @@ def run_self_tests() -> None:
 	}
 	volume = {"Name": f"{project}_data", "Labels": volume_labels}
 	network = {"Name": f"{project}_private", "Labels": network_labels}
+	assert deduplicate_inspections("container", [container, json.loads(json.dumps(container))]) == [
+		container
+	]
 	validate_resources(
 		model,
 		project,

--- a/e2e/library-cleanup/check-live-project.py
+++ b/e2e/library-cleanup/check-live-project.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Prove live Docker resources belong to one disposable harness run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+PROJECT_LABEL = "com.docker.compose.project"
+SERVICE_LABEL = "com.docker.compose.service"
+VOLUME_LABEL = "com.docker.compose.volume"
+NETWORK_LABEL = "com.docker.compose.network"
+CONFIG_HASH_LABEL = "com.docker.compose.config-hash"
+CONFIG_FILES_LABEL = "com.docker.compose.project.config_files"
+WORKING_DIR_LABEL = "com.docker.compose.project.working_dir"
+RUN_PROJECT_LABEL = "io.arr-dashboard.library-cleanup.project"
+RUN_TOKEN_LABEL = "io.arr-dashboard.library-cleanup.run-token"
+
+
+class OwnershipError(ValueError):
+	"""A live resource cannot be attributed to this exact harness run."""
+
+
+def docker_json(*args: str) -> Any:
+	result = subprocess.run(
+		["docker", *args], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+	)
+	return json.loads(result.stdout)
+
+
+def matching_ids(kind: str, project: str) -> set[str]:
+	ids: set[str] = set()
+	for label in (f"{PROJECT_LABEL}={project}", f"{RUN_PROJECT_LABEL}={project}"):
+		command = ["docker", kind, "ls"]
+		if kind == "container":
+			command.append("-a")
+		command.extend(["--filter", f"label={label}", "--quiet"])
+		result = subprocess.run(
+			command,
+			check=True,
+			stdout=subprocess.PIPE,
+			stderr=subprocess.PIPE,
+			text=True,
+		)
+		ids.update(line for line in result.stdout.splitlines() if line)
+	return ids
+
+
+def inspect_many(kind: str, identifiers: set[str]) -> list[dict[str, Any]]:
+	if not identifiers:
+		return []
+	return docker_json(kind, "inspect", *sorted(identifiers))
+
+
+def labels_of(resource: dict[str, Any]) -> dict[str, str]:
+	if "Config" in resource:
+		labels = resource.get("Config", {}).get("Labels")
+	else:
+		labels = resource.get("Labels")
+	return labels if isinstance(labels, dict) else {}
+
+
+def require_owned(labels: dict[str, str], project: str, token: str, description: str) -> None:
+	if labels.get(PROJECT_LABEL) != project or labels.get(RUN_PROJECT_LABEL) != project:
+		raise OwnershipError(f"{description} has mismatched project ownership")
+	if labels.get(RUN_TOKEN_LABEL) != token:
+		raise OwnershipError(f"{description} has a different run token")
+
+
+def model_mounts(service: dict[str, Any]) -> tuple[set[str], set[str]]:
+	volume_targets = {
+		mount["target"]
+		for mount in service.get("volumes", [])
+		if isinstance(mount, dict) and mount.get("type") == "volume"
+	}
+	secret_targets: set[str] = set()
+	for secret in service.get("secrets", []):
+		if not isinstance(secret, dict) or not isinstance(secret.get("source"), str):
+			continue
+		target = secret.get("target", secret["source"])
+		if isinstance(target, str):
+			secret_targets.add(target if target.startswith("/") else f"/run/secrets/{target}")
+	return volume_targets, secret_targets
+
+
+def validate_resources(
+	model: dict[str, Any],
+	project: str,
+	token: str,
+	containers: list[dict[str, Any]],
+	volumes: list[dict[str, Any]],
+	networks: list[dict[str, Any]],
+	image_ids: dict[str, str],
+	config_hashes: dict[str, str],
+	expected_config_files: str,
+	expected_working_dir: str,
+	*,
+	allow_empty: bool,
+) -> None:
+	if not re.fullmatch(r"[a-f0-9]{64}", token):
+		raise OwnershipError("LC_E2E_RUN_TOKEN must be 64 lowercase hex characters")
+	if not containers and not volumes and not networks:
+		if allow_empty:
+			return
+		raise OwnershipError("no live resources exist for the confirmed harness run")
+
+	services = model["services"]
+	model_volumes = model["volumes"]
+	model_networks = model["networks"]
+	seen_services: set[str] = set()
+	containers_by_service = {
+		labels_of(container).get(SERVICE_LABEL): container for container in containers
+	}
+	for container in containers:
+		labels = labels_of(container)
+		name = container.get("Name", "unknown container").lstrip("/")
+		require_owned(labels, project, token, name)
+		service_name = labels.get(SERVICE_LABEL)
+		if service_name not in services:
+			raise OwnershipError(f"{name} has unexpected Compose service {service_name!r}")
+		if service_name in seen_services:
+			raise OwnershipError(f"multiple containers claim service {service_name}")
+		seen_services.add(service_name)
+		if labels.get(CONFIG_FILES_LABEL) != expected_config_files:
+			raise OwnershipError(f"{name} was created from different Compose files")
+		if labels.get(WORKING_DIR_LABEL) != expected_working_dir:
+			raise OwnershipError(f"{name} was created from a different working directory")
+		if service_name == "plex-loopback-proxy":
+			# Compose v5 hashes this network_mode sidecar differently during `up`
+			# than `config --hash`. Verify its effective mutation boundary instead.
+			if not re.fullmatch(r"[a-f0-9]{64}", labels.get(CONFIG_HASH_LABEL, "")):
+				raise OwnershipError(f"{name} has no valid Compose config hash")
+			service = services[service_name]
+			if container.get("Config", {}).get("Cmd") != service.get("command"):
+				raise OwnershipError(f"{name} command differs from the validated model")
+			if container.get("Config", {}).get("Entrypoint") != service.get("entrypoint"):
+				raise OwnershipError(f"{name} entrypoint differs from the validated model")
+			if container.get("Config", {}).get("Healthcheck", {}).get("Test") != service.get(
+				"healthcheck", {}
+			).get("test"):
+				raise OwnershipError(f"{name} healthcheck differs from the validated model")
+			plex_container = containers_by_service.get("plex")
+			if not plex_container or container.get("HostConfig", {}).get("NetworkMode") != (
+				f"container:{plex_container.get('Id')}"
+			):
+				raise OwnershipError(f"{name} does not share the verified Plex network namespace")
+		elif labels.get(CONFIG_HASH_LABEL) != config_hashes.get(service_name):
+			raise OwnershipError(f"{name} config hash differs from the validated model")
+		expected_image = services[service_name].get("image")
+		if container.get("Config", {}).get("Image") != expected_image:
+			raise OwnershipError(f"{name} image reference differs from the validated model")
+		if container.get("Image") != image_ids.get(expected_image):
+			raise OwnershipError(f"{name} image identity differs from the validated model")
+
+		expected_volumes, expected_secrets = model_mounts(services[service_name])
+		actual_volumes: set[str] = set()
+		for mount in container.get("Mounts", []):
+			mount_type = mount.get("Type")
+			target = mount.get("Destination")
+			if mount_type == "volume":
+				actual_volumes.add(target)
+				mount_labels = mount.get("Labels", {})
+				require_owned(mount_labels, project, token, f"volume mounted at {target}")
+			elif not (
+				mount_type == "bind" and target in expected_secrets and mount.get("RW") is False
+			):
+				raise OwnershipError(f"{name} has unapproved {mount_type} mount at {target}")
+		if actual_volumes != expected_volumes:
+			raise OwnershipError(f"{name} mounted-volume targets differ from the validated model")
+
+		expected_network_names = {
+			model_networks[network_name]["name"]
+			for network_name in services[service_name].get("networks", {})
+		}
+		actual_network_names = set(container.get("NetworkSettings", {}).get("Networks", {}))
+		if actual_network_names != expected_network_names:
+			raise OwnershipError(f"{name} network attachments differ from the validated model")
+
+	for volume in volumes:
+		labels = labels_of(volume)
+		name = volume.get("Name", "unknown volume")
+		require_owned(labels, project, token, name)
+		logical_name = labels.get(VOLUME_LABEL)
+		if logical_name not in model_volumes or name != model_volumes[logical_name].get("name"):
+			raise OwnershipError(f"{name} is not an expected project-scoped volume")
+
+	for network in networks:
+		labels = labels_of(network)
+		name = network.get("Name", "unknown network")
+		require_owned(labels, project, token, name)
+		logical_name = labels.get(NETWORK_LABEL)
+		if logical_name not in model_networks or name != model_networks[logical_name].get("name"):
+			raise OwnershipError(f"{name} is not an expected project-scoped network")
+
+
+def run_self_tests() -> None:
+	token = "a" * 64
+	project = "lc-e2e-690-20260810"
+	labels = {
+		PROJECT_LABEL: project,
+		RUN_PROJECT_LABEL: project,
+		RUN_TOKEN_LABEL: token,
+		SERVICE_LABEL: "app",
+		CONFIG_HASH_LABEL: "hash",
+		CONFIG_FILES_LABEL: "/workspace/compose.yml,/workspace/compose.debug.yml",
+		WORKING_DIR_LABEL: "/workspace",
+	}
+	model = {
+		"services": {
+			"app": {
+				"image": "example:test",
+				"volumes": [{"type": "volume", "source": "data", "target": "/data"}],
+				"networks": {"private": {}},
+			}
+		},
+		"volumes": {"data": {"name": f"{project}_data"}},
+		"networks": {"private": {"name": f"{project}_private"}},
+	}
+	volume_labels = {**labels, VOLUME_LABEL: "data"}
+	network_labels = {**labels, NETWORK_LABEL: "private"}
+	container = {
+		"Name": f"/{project}-app-1",
+		"Config": {"Labels": labels, "Image": "example:test"},
+		"Image": "sha256:image",
+		"Mounts": [
+			{
+				"Type": "volume",
+				"Destination": "/data",
+				"Labels": volume_labels,
+			}
+		],
+		"NetworkSettings": {"Networks": {f"{project}_private": {}}},
+	}
+	volume = {"Name": f"{project}_data", "Labels": volume_labels}
+	network = {"Name": f"{project}_private", "Labels": network_labels}
+	validate_resources(
+		model,
+		project,
+		token,
+		[container],
+		[volume],
+		[network],
+		{"example:test": "sha256:image"},
+		{"app": "hash"},
+		"/workspace/compose.yml,/workspace/compose.debug.yml",
+		"/workspace",
+		allow_empty=False,
+	)
+	validate_resources(
+		model,
+		project,
+		token,
+		[],
+		[],
+		[],
+		{},
+		{},
+		"/workspace/compose.yml,/workspace/compose.debug.yml",
+		"/workspace",
+		allow_empty=True,
+	)
+	for description, mutation in (
+		("foreign token", lambda value: value["Config"]["Labels"].update({RUN_TOKEN_LABEL: "b" * 64})),
+		("bind mount", lambda value: value["Mounts"][0].update({"Type": "bind"})),
+		("image drift", lambda value: value.update({"Image": "sha256:other"})),
+		("config drift", lambda value: value["Config"]["Labels"].update({CONFIG_HASH_LABEL: "other"})),
+	):
+		candidate = json.loads(json.dumps(container))
+		mutation(candidate)
+		try:
+			validate_resources(
+				model,
+				project,
+				token,
+				[candidate],
+				[volume],
+				[network],
+				{"example:test": "sha256:image"},
+				{"app": "hash"},
+				"/workspace/compose.yml,/workspace/compose.debug.yml",
+				"/workspace",
+				allow_empty=False,
+			)
+		except OwnershipError:
+			continue
+		raise AssertionError(f"live ownership self-test accepted {description}")
+	print("live project ownership negative tests passed: 4")
+
+
+def main() -> int:
+	parser = argparse.ArgumentParser()
+	parser.add_argument("--model", type=Path)
+	parser.add_argument("--hashes", type=Path)
+	parser.add_argument("--project")
+	parser.add_argument("--run-token")
+	parser.add_argument("--config-files")
+	parser.add_argument("--working-dir")
+	parser.add_argument("--allow-empty", action="store_true")
+	parser.add_argument("--self-test", action="store_true")
+	args = parser.parse_args()
+	if args.self_test:
+		run_self_tests()
+		return 0
+	if not all(
+		(args.model, args.hashes, args.project, args.run_token, args.config_files, args.working_dir)
+	):
+		parser.error(
+			"--model, --hashes, --project, --run-token, --config-files, and --working-dir are required"
+		)
+	try:
+		model = json.loads(args.model.read_text())
+		config_hashes = dict(
+			line.split(maxsplit=1) for line in args.hashes.read_text().splitlines() if line.strip()
+		)
+		container_ids = matching_ids("container", args.project)
+		volume_ids = matching_ids("volume", args.project)
+		network_ids = matching_ids("network", args.project)
+		containers = inspect_many("container", container_ids)
+		volumes = inspect_many("volume", volume_ids)
+		networks = inspect_many("network", network_ids)
+		image_refs = {
+			service.get("image")
+			for service in model["services"].values()
+			if isinstance(service.get("image"), str)
+		}
+		image_ids = {
+			image: docker_json("image", "inspect", image)[0]["Id"]
+			for image in image_refs
+			if any(container.get("Config", {}).get("Image") == image for container in containers)
+		}
+		for container in containers:
+			for mount in container.get("Mounts", []):
+				if mount.get("Type") == "volume":
+					mount["Labels"] = docker_json("volume", "inspect", mount["Name"])[0].get("Labels", {})
+		validate_resources(
+			model,
+			args.project,
+			args.run_token,
+			containers,
+			volumes,
+			networks,
+			image_ids,
+			config_hashes,
+			args.config_files,
+			args.working_dir,
+			allow_empty=args.allow_empty,
+		)
+	except (OwnershipError, OSError, KeyError, json.JSONDecodeError, subprocess.CalledProcessError) as error:
+		print(f"live project ownership check failed: {error}", file=sys.stderr)
+		return 1
+	print(f"live project ownership verified: {args.project}")
+	return 0
+
+
+if __name__ == "__main__":
+	raise SystemExit(main())

--- a/e2e/library-cleanup/check-live-project.py
+++ b/e2e/library-cleanup/check-live-project.py
@@ -77,7 +77,9 @@ def model_container_names(model: dict[str, Any], project: str) -> set[str]:
 			raise OwnershipError("rendered model has an invalid service definition")
 		container_name = service.get("container_name")
 		if container_name is None:
-			physical_names.add(f"{project}-{service_name}-1")
+			physical_names.update(
+				{f"{project}-{service_name}-1", f"{project}_{service_name}_1"}
+			)
 		elif isinstance(container_name, str) and container_name:
 			physical_names.add(container_name)
 		else:

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -14,6 +14,7 @@ is_compose_v2() {
 }
 
 resolve_compose_command() {
+	DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
 	if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
 		if [ ! -x "$ARR_COMPOSE_BIN" ]; then
 			echo "Library-cleanup harness refused: ARR_COMPOSE_BIN is not an executable: $ARR_COMPOSE_BIN." >&2
@@ -51,7 +52,7 @@ resolve_compose_command() {
 		fi
 	done
 
-	if command -v docker >/dev/null 2>&1 && is_compose_v2 docker compose; then
+	if command -v "$DOCKER_BIN" >/dev/null 2>&1 && is_compose_v2 "$DOCKER_BIN" compose; then
 		COMPOSE_COMMAND=docker
 		return
 	fi
@@ -65,7 +66,7 @@ resolve_compose_command
 resolve_compose_command_vector() {
 	case "$COMPOSE_COMMAND" in
 		docker)
-			ARR_RESOLVED_COMPOSE_EXECUTABLE=docker
+			ARR_RESOLVED_COMPOSE_EXECUTABLE=$DOCKER_BIN
 			ARR_RESOLVED_COMPOSE_ARGUMENT=compose
 			;;
 		executable)
@@ -83,7 +84,7 @@ resolve_compose_command_vector
 
 run_compose() {
 	case "$COMPOSE_COMMAND" in
-		docker) docker compose "$@" ;;
+		docker) "$DOCKER_BIN" compose "$@" ;;
 		executable) "$ARR_COMPOSE_BIN" "$@" ;;
 		*)
 			echo "Library-cleanup harness refused: invalid Compose command selection." >&2

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+: "${SCRIPT_DIR:?compose-command.sh requires SCRIPT_DIR}"
+: "${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}"
+
+ARR_COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
+export ARR_COMPOSE_BIN
+
+if [ ! -x "$ARR_COMPOSE_BIN" ]; then
+	echo "Library-cleanup harness refused: Compose binary is not executable at $ARR_COMPOSE_BIN." >&2
+	exit 1
+fi
+
+compose_base() {
+	"$ARR_COMPOSE_BIN" -p "$COMPOSE_PROJECT_NAME" -f "$SCRIPT_DIR/compose.yml" "$@"
+}
+
+compose() {
+	compose_base -f "$SCRIPT_DIR/compose.debug.yml" "$@"
+}

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -15,6 +15,18 @@ is_compose_v2() {
 
 resolve_compose_command() {
 	DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
+	if [ -n "${ARR_DOCKER_BIN:-}" ]; then
+		if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
+			echo "Library-cleanup harness refused: ARR_DOCKER_BIN and ARR_COMPOSE_BIN cannot both be set." >&2
+			exit 1
+		fi
+		if ! command -v "$DOCKER_BIN" >/dev/null 2>&1 || ! is_compose_v2 "$DOCKER_BIN" compose; then
+			echo "Library-cleanup harness refused: ARR_DOCKER_BIN must provide Docker Compose v2 or newer." >&2
+			exit 1
+		fi
+		COMPOSE_COMMAND=docker
+		return
+	fi
 	if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
 		if [ ! -x "$ARR_COMPOSE_BIN" ]; then
 			echo "Library-cleanup harness refused: ARR_COMPOSE_BIN is not an executable: $ARR_COMPOSE_BIN." >&2

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -62,6 +62,25 @@ resolve_compose_command() {
 
 resolve_compose_command
 
+resolve_compose_command_vector() {
+	case "$COMPOSE_COMMAND" in
+		docker)
+			ARR_RESOLVED_COMPOSE_EXECUTABLE=docker
+			ARR_RESOLVED_COMPOSE_ARGUMENT=compose
+			;;
+		executable)
+			ARR_RESOLVED_COMPOSE_EXECUTABLE=$ARR_COMPOSE_BIN
+			ARR_RESOLVED_COMPOSE_ARGUMENT=
+			;;
+		*)
+			echo "Library-cleanup harness refused: invalid Compose command selection." >&2
+			exit 1
+			;;
+	esac
+}
+
+resolve_compose_command_vector
+
 run_compose() {
 	case "$COMPOSE_COMMAND" in
 		docker) docker compose "$@" ;;

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -3,16 +3,64 @@
 : "${SCRIPT_DIR:?compose-command.sh requires SCRIPT_DIR}"
 : "${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}"
 
-ARR_COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
-export ARR_COMPOSE_BIN
+resolve_compose_command() {
+	if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
+		if [ ! -x "$ARR_COMPOSE_BIN" ]; then
+			echo "Library-cleanup harness refused: ARR_COMPOSE_BIN is not an executable: $ARR_COMPOSE_BIN." >&2
+			exit 1
+		fi
+		COMPOSE_COMMAND=executable
+		return
+	fi
 
-if [ ! -x "$ARR_COMPOSE_BIN" ]; then
-	echo "Library-cleanup harness refused: Compose binary is not executable at $ARR_COMPOSE_BIN." >&2
+	if command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+		ARR_COMPOSE_BIN=$(command -v docker-compose)
+		export ARR_COMPOSE_BIN
+		COMPOSE_COMMAND=executable
+		return
+	fi
+
+	for compose_plugin in \
+		"${DOCKER_CONFIG:+$DOCKER_CONFIG/cli-plugins/docker-compose}" \
+		"${XDG_CONFIG_HOME:+$XDG_CONFIG_HOME/docker/cli-plugins/docker-compose}" \
+		"${HOME:+$HOME/.docker/cli-plugins/docker-compose}" \
+		"${HOME:+$HOME/.local/lib/docker/cli-plugins/docker-compose}" \
+		/usr/local/lib/docker/cli-plugins/docker-compose \
+		/usr/local/libexec/docker/cli-plugins/docker-compose \
+		/usr/lib/docker/cli-plugins/docker-compose \
+		/usr/libexec/docker/cli-plugins/docker-compose; do
+		if [ -n "$compose_plugin" ] && [ -x "$compose_plugin" ]; then
+			ARR_COMPOSE_BIN=$compose_plugin
+			export ARR_COMPOSE_BIN
+			COMPOSE_COMMAND=executable
+			return
+		fi
+	done
+
+	if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+		COMPOSE_COMMAND=docker
+		return
+	fi
+
+	echo "Library-cleanup harness refused: Docker Compose v2 was not found. Set ARR_COMPOSE_BIN to an executable." >&2
 	exit 1
-fi
+}
+
+resolve_compose_command
+
+run_compose() {
+	case "$COMPOSE_COMMAND" in
+		docker) docker compose "$@" ;;
+		executable) "$ARR_COMPOSE_BIN" "$@" ;;
+		*)
+			echo "Library-cleanup harness refused: invalid Compose command selection." >&2
+			exit 1
+			;;
+	esac
+}
 
 compose_base() {
-	"$ARR_COMPOSE_BIN" -p "$COMPOSE_PROJECT_NAME" -f "$SCRIPT_DIR/compose.yml" "$@"
+	run_compose -p "$COMPOSE_PROJECT_NAME" -f "$SCRIPT_DIR/compose.yml" "$@"
 }
 
 compose() {

--- a/e2e/library-cleanup/compose-command.sh
+++ b/e2e/library-cleanup/compose-command.sh
@@ -3,17 +3,31 @@
 : "${SCRIPT_DIR:?compose-command.sh requires SCRIPT_DIR}"
 : "${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}"
 
+is_compose_v2() {
+	compose_version=$("$@" version --short 2>/dev/null) || return 1
+	compose_version=${compose_version#v}
+	compose_major=${compose_version%%.*}
+	case "$compose_major" in
+		'' | *[!0-9]*) return 1 ;;
+		*) [ "$compose_major" -ge 2 ] ;;
+	esac
+}
+
 resolve_compose_command() {
 	if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
 		if [ ! -x "$ARR_COMPOSE_BIN" ]; then
 			echo "Library-cleanup harness refused: ARR_COMPOSE_BIN is not an executable: $ARR_COMPOSE_BIN." >&2
 			exit 1
 		fi
+		if ! is_compose_v2 "$ARR_COMPOSE_BIN"; then
+			echo "Library-cleanup harness refused: ARR_COMPOSE_BIN must provide Docker Compose v2 or newer." >&2
+			exit 1
+		fi
 		COMPOSE_COMMAND=executable
 		return
 	fi
 
-	if command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then
+	if command -v docker-compose >/dev/null 2>&1 && is_compose_v2 docker-compose; then
 		ARR_COMPOSE_BIN=$(command -v docker-compose)
 		export ARR_COMPOSE_BIN
 		COMPOSE_COMMAND=executable
@@ -29,7 +43,7 @@ resolve_compose_command() {
 		/usr/local/libexec/docker/cli-plugins/docker-compose \
 		/usr/lib/docker/cli-plugins/docker-compose \
 		/usr/libexec/docker/cli-plugins/docker-compose; do
-		if [ -n "$compose_plugin" ] && [ -x "$compose_plugin" ]; then
+		if [ -n "$compose_plugin" ] && [ -x "$compose_plugin" ] && is_compose_v2 "$compose_plugin"; then
 			ARR_COMPOSE_BIN=$compose_plugin
 			export ARR_COMPOSE_BIN
 			COMPOSE_COMMAND=executable
@@ -37,7 +51,7 @@ resolve_compose_command() {
 		fi
 	done
 
-	if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+	if command -v docker >/dev/null 2>&1 && is_compose_v2 docker compose; then
 		COMPOSE_COMMAND=docker
 		return
 	fi

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -40,6 +40,7 @@ for script in \
 	bootstrap-dashboard.sh \
 	bootstrap-plex.sh \
 	bootstrap-qui.sh \
+	bootstrap-torrents.sh \
 	run-browser-policy.sh \
 	run-live-scenario.sh \
 	teardown.sh \

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -7,33 +7,124 @@ trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 
 FAKE_COMPOSE="$TEMP_DIR/fake-compose"
 COMPOSE_LOG="$TEMP_DIR/compose.log"
+FAKE_DOCKER_BIN_DIR="$TEMP_DIR/docker-bin"
+FAKE_STANDALONE_BIN_DIR="$TEMP_DIR/standalone-bin"
+EMPTY_BIN_DIR="$TEMP_DIR/empty-bin"
+FAKE_HOME="$TEMP_DIR/home"
+EMPTY_HOME="$TEMP_DIR/empty-home"
+ISOLATED_DOCKER_CONFIG="$TEMP_DIR/isolated-docker-config"
+SYSTEM_PATH=$PATH
+mkdir -p \
+	"$FAKE_DOCKER_BIN_DIR" \
+	"$FAKE_STANDALONE_BIN_DIR" \
+	"$EMPTY_BIN_DIR" \
+	"$FAKE_HOME/.docker/cli-plugins" \
+	"$EMPTY_HOME" \
+	"$ISOLATED_DOCKER_CONFIG"
+
 cat >"$FAKE_COMPOSE" <<'EOF'
 #!/bin/sh
-printf '%s\n' "$@" >"$ARR_COMPOSE_LOG"
+{
+	printf '%s\n' override
+	printf '%s\n' "$@"
+} >"$ARR_COMPOSE_LOG"
 EOF
 chmod +x "$FAKE_COMPOSE"
 
-COMPOSE_PROJECT_NAME=lc-e2e-contract
-ARR_COMPOSE_BIN="$FAKE_COMPOSE"
-ARR_COMPOSE_LOG="$COMPOSE_LOG"
-export COMPOSE_PROJECT_NAME ARR_COMPOSE_BIN ARR_COMPOSE_LOG
-
-. "$SCRIPT_DIR/compose-command.sh"
-compose ps --status running --services
-
-expected_args="$TEMP_DIR/expected-args"
-{
-	printf '%s\n' -p lc-e2e-contract
-	printf '%s\n' -f "$SCRIPT_DIR/compose.yml"
-	printf '%s\n' -f "$SCRIPT_DIR/compose.debug.yml"
-	printf '%s\n' ps --status running --services
-} >"$expected_args"
-
-if ! cmp -s "$expected_args" "$COMPOSE_LOG"; then
-	echo "compose helper did not invoke ARR_COMPOSE_BIN with the isolated harness model." >&2
-	diff -u "$expected_args" "$COMPOSE_LOG" >&2 || true
-	exit 1
+cat >"$FAKE_DOCKER_BIN_DIR/docker" <<'EOF'
+#!/bin/sh
+if [ "$1" = compose ] && [ "$2" = version ]; then
+	exit 0
 fi
+{
+	printf '%s\n' docker
+	printf '%s\n' "$@"
+} >"$ARR_COMPOSE_LOG"
+EOF
+chmod +x "$FAKE_DOCKER_BIN_DIR/docker"
+
+cat >"$FAKE_STANDALONE_BIN_DIR/docker-compose" <<'EOF'
+#!/bin/sh
+if [ "$1" = version ]; then
+	exit 0
+fi
+{
+	printf '%s\n' docker-compose
+	printf '%s\n' "$@"
+} >"$ARR_COMPOSE_LOG"
+EOF
+chmod +x "$FAKE_STANDALONE_BIN_DIR/docker-compose"
+
+FAKE_PLUGIN="$FAKE_HOME/.docker/cli-plugins/docker-compose"
+cat >"$FAKE_PLUGIN" <<'EOF'
+#!/bin/sh
+{
+	printf '%s\n' plugin
+	printf '%s\n' "$@"
+} >"$ARR_COMPOSE_LOG"
+EOF
+chmod +x "$FAKE_PLUGIN"
+
+assert_compose_args() {
+	expected_command=$1
+	expected_args="$TEMP_DIR/expected-args"
+	{
+		printf '%s\n' "$expected_command"
+		if [ "$expected_command" = docker ]; then
+			printf '%s\n' compose
+		fi
+		printf '%s\n' -p lc-e2e-contract
+		printf '%s\n' -f "$SCRIPT_DIR/compose.yml"
+		printf '%s\n' -f "$SCRIPT_DIR/compose.debug.yml"
+		printf '%s\n' ps --status running --services
+	} >"$expected_args"
+
+	if ! cmp -s "$expected_args" "$COMPOSE_LOG"; then
+		echo "compose helper did not select $expected_command with the isolated harness model." >&2
+		diff -u "$expected_args" "$COMPOSE_LOG" >&2 || true
+		exit 1
+	fi
+}
+
+exercise_compose() {
+	COMPOSE_PROJECT_NAME=lc-e2e-contract
+	ARR_COMPOSE_LOG="$COMPOSE_LOG"
+	export COMPOSE_PROJECT_NAME ARR_COMPOSE_LOG
+	. "$SCRIPT_DIR/compose-command.sh"
+	compose ps --status running --services
+}
+
+ARR_COMPOSE_BIN="$FAKE_COMPOSE"
+export ARR_COMPOSE_BIN
+exercise_compose
+assert_compose_args override
+
+unset ARR_COMPOSE_BIN
+HOME="$EMPTY_HOME"
+DOCKER_CONFIG="$ISOLATED_DOCKER_CONFIG"
+PATH=$FAKE_DOCKER_BIN_DIR
+export PATH HOME DOCKER_CONFIG
+exercise_compose
+PATH=$SYSTEM_PATH
+export PATH
+assert_compose_args docker
+
+unset ARR_COMPOSE_BIN
+PATH=$FAKE_STANDALONE_BIN_DIR
+export PATH
+exercise_compose
+PATH=$SYSTEM_PATH
+export PATH
+assert_compose_args docker-compose
+
+unset ARR_COMPOSE_BIN
+PATH=$EMPTY_BIN_DIR
+HOME="$FAKE_HOME"
+export PATH
+exercise_compose
+PATH=$SYSTEM_PATH
+export PATH
+assert_compose_args plugin
 
 for script in \
 	bootstrap-arr.sh \

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -154,7 +154,7 @@ unset ARR_COMPOSE_BIN
 ARR_DOCKER_BIN="$WRAPPED_DOCKER"
 HOME="$EMPTY_HOME"
 DOCKER_CONFIG="$ISOLATED_DOCKER_CONFIG"
-PATH=$EMPTY_BIN_DIR:$SYSTEM_PATH
+PATH=$FAKE_STANDALONE_BIN_DIR:$EMPTY_BIN_DIR:$SYSTEM_PATH
 export ARR_DOCKER_BIN PATH HOME DOCKER_CONFIG
 exercise_compose
 assert_resolved_compose_vector "$WRAPPED_DOCKER" compose
@@ -162,6 +162,19 @@ PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args docker
 unset ARR_DOCKER_BIN
+
+if (
+	ARR_DOCKER_BIN="$WRAPPED_DOCKER"
+	ARR_COMPOSE_BIN="$FAKE_COMPOSE"
+	HOME="$EMPTY_HOME"
+	DOCKER_CONFIG="$ISOLATED_DOCKER_CONFIG"
+	PATH=$FAKE_DOCKER_BIN_DIR
+	export ARR_DOCKER_BIN ARR_COMPOSE_BIN HOME DOCKER_CONFIG PATH
+	exercise_compose
+) >/dev/null 2>&1; then
+	echo "compose helper accepted conflicting Docker and Compose executable overrides." >&2
+	exit 1
+fi
 
 unset ARR_COMPOSE_BIN
 PATH=$FAKE_STANDALONE_BIN_DIR
@@ -245,8 +258,45 @@ EOF
 	fi
 }
 
-for script in bootstrap-arr.sh bootstrap-dashboard.sh bootstrap-plex.sh run-live-scenario.sh; do
+assert_configured_docker_preserves_caller_config() {
+	script=$1
+	harness_dir=$TEMP_DIR/configured-docker-config-$script
+	resolver_log=$harness_dir/resolver-docker-config
+	expected_resolver_log=$harness_dir/expected-resolver-docker-config
+	mkdir -p "$harness_dir"
+	cp "$SCRIPT_DIR/$script" "$harness_dir/$script"
+	cat >"$harness_dir/compose-command.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${DOCKER_CONFIG-}" >"$ARR_COMPOSE_RESOLVER_CONFIG_LOG"
+exit 0
+EOF
+	if ! (
+		unset DOCKER_CONFIG
+		COMPOSE_PROJECT_NAME=lc-e2e-contract
+		ARR_DOCKER_BIN=/custom/docker
+		ARR_COMPOSE_RESOLVER_CONFIG_LOG=$resolver_log
+		export COMPOSE_PROJECT_NAME ARR_DOCKER_BIN ARR_COMPOSE_RESOLVER_CONFIG_LOG
+		sh "$harness_dir/$script"
+	); then
+		echo "$script did not reach the shared Compose resolver." >&2
+		exit 1
+	fi
+	printf '\n' >"$expected_resolver_log"
+	if ! cmp -s "$expected_resolver_log" "$resolver_log"; then
+		echo "$script replaced the configured Docker CLI's caller-selected config." >&2
+		diff -u "$expected_resolver_log" "$resolver_log" >&2 || true
+		exit 1
+	fi
+}
+
+for script in \
+	bootstrap-arr.sh \
+	bootstrap-dashboard.sh \
+	bootstrap-plex.sh \
+	bootstrap-torrents.sh \
+	run-live-scenario.sh; do
 	assert_default_docker_config_precedes_resolver "$script"
+	assert_configured_docker_preserves_caller_config "$script"
 done
 
 echo "compose command contract and bypass checks passed."

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -106,6 +106,16 @@ assert_compose_args() {
 	fi
 }
 
+assert_resolved_compose_vector() {
+	expected_executable=$1
+	expected_argument=$2
+	if [ "$ARR_RESOLVED_COMPOSE_EXECUTABLE" != "$expected_executable" ] || \
+		[ "$ARR_RESOLVED_COMPOSE_ARGUMENT" != "$expected_argument" ]; then
+		echo "compose helper did not preserve the resolved command vector." >&2
+		exit 1
+	fi
+}
+
 exercise_compose() {
 	COMPOSE_PROJECT_NAME=lc-e2e-contract
 	ARR_COMPOSE_LOG="$COMPOSE_LOG"
@@ -117,6 +127,7 @@ exercise_compose() {
 ARR_COMPOSE_BIN="$FAKE_COMPOSE"
 export ARR_COMPOSE_BIN
 exercise_compose
+assert_resolved_compose_vector "$FAKE_COMPOSE" ""
 assert_compose_args override
 
 unset ARR_COMPOSE_BIN
@@ -125,6 +136,7 @@ DOCKER_CONFIG="$ISOLATED_DOCKER_CONFIG"
 PATH=$FAKE_DOCKER_BIN_DIR
 export PATH HOME DOCKER_CONFIG
 exercise_compose
+assert_resolved_compose_vector docker compose
 PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args docker
@@ -133,6 +145,7 @@ unset ARR_COMPOSE_BIN
 PATH=$FAKE_STANDALONE_BIN_DIR
 export PATH
 exercise_compose
+assert_resolved_compose_vector "$FAKE_STANDALONE_BIN_DIR/docker-compose" ""
 PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args docker-compose
@@ -142,6 +155,7 @@ PATH=$EMPTY_BIN_DIR
 HOME="$FAKE_HOME"
 export PATH
 exercise_compose
+assert_resolved_compose_vector "$FAKE_PLUGIN" ""
 PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args plugin
@@ -152,6 +166,7 @@ PATH=$EMPTY_BIN_DIR
 HOME="$FAKE_HOME"
 export PATH HOME
 exercise_compose
+assert_resolved_compose_vector "$FAKE_PLUGIN" ""
 PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args plugin

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -13,6 +13,7 @@ EMPTY_BIN_DIR="$TEMP_DIR/empty-bin"
 FAKE_HOME="$TEMP_DIR/home"
 EMPTY_HOME="$TEMP_DIR/empty-home"
 ISOLATED_DOCKER_CONFIG="$TEMP_DIR/isolated-docker-config"
+WRAPPED_DOCKER="$TEMP_DIR/docker wrapper"
 SYSTEM_PATH=$PATH
 mkdir -p \
 	"$FAKE_DOCKER_BIN_DIR" \
@@ -21,6 +22,12 @@ mkdir -p \
 	"$FAKE_HOME/.docker/cli-plugins" \
 	"$EMPTY_HOME" \
 	"$ISOLATED_DOCKER_CONFIG"
+
+cat >"$EMPTY_BIN_DIR/docker" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$EMPTY_BIN_DIR/docker"
 
 cat >"$FAKE_COMPOSE" <<'EOF'
 #!/bin/sh
@@ -47,6 +54,8 @@ fi
 } >"$ARR_COMPOSE_LOG"
 EOF
 chmod +x "$FAKE_DOCKER_BIN_DIR/docker"
+cp "$FAKE_DOCKER_BIN_DIR/docker" "$WRAPPED_DOCKER"
+chmod +x "$WRAPPED_DOCKER"
 
 cat >"$FAKE_STANDALONE_BIN_DIR/docker-compose" <<'EOF'
 #!/bin/sh
@@ -142,6 +151,19 @@ export PATH
 assert_compose_args docker
 
 unset ARR_COMPOSE_BIN
+ARR_DOCKER_BIN="$WRAPPED_DOCKER"
+HOME="$EMPTY_HOME"
+DOCKER_CONFIG="$ISOLATED_DOCKER_CONFIG"
+PATH=$EMPTY_BIN_DIR:$SYSTEM_PATH
+export ARR_DOCKER_BIN PATH HOME DOCKER_CONFIG
+exercise_compose
+assert_resolved_compose_vector "$WRAPPED_DOCKER" compose
+PATH=$SYSTEM_PATH
+export PATH
+assert_compose_args docker
+unset ARR_DOCKER_BIN
+
+unset ARR_COMPOSE_BIN
 PATH=$FAKE_STANDALONE_BIN_DIR
 export PATH
 exercise_compose
@@ -151,7 +173,7 @@ export PATH
 assert_compose_args docker-compose
 
 unset ARR_COMPOSE_BIN
-PATH=$EMPTY_BIN_DIR
+PATH=$EMPTY_BIN_DIR:$SYSTEM_PATH
 HOME="$FAKE_HOME"
 export PATH
 exercise_compose
@@ -162,7 +184,7 @@ assert_compose_args plugin
 
 unset ARR_COMPOSE_BIN
 ln -s "$FAKE_STANDALONE_BIN_DIR/legacy-compose" "$EMPTY_BIN_DIR/docker-compose"
-PATH=$EMPTY_BIN_DIR
+PATH=$EMPTY_BIN_DIR:$SYSTEM_PATH
 HOME="$FAKE_HOME"
 export PATH HOME
 exercise_compose
@@ -191,6 +213,40 @@ for script in \
 		echo "$script bypasses the shared Compose helper." >&2
 		exit 1
 	fi
+done
+
+assert_default_docker_config_precedes_resolver() {
+	script=$1
+	harness_dir=$TEMP_DIR/default-config-$script
+	resolver_log=$harness_dir/resolver-docker-config
+	expected_resolver_log=$harness_dir/expected-resolver-docker-config
+	mkdir -p "$harness_dir"
+	cp "$SCRIPT_DIR/$script" "$harness_dir/$script"
+	cat >"$harness_dir/compose-command.sh" <<'EOF'
+#!/bin/sh
+printf '%s\n' "${DOCKER_CONFIG-}" >"$ARR_COMPOSE_RESOLVER_CONFIG_LOG"
+exit 0
+EOF
+	if ! (
+		unset DOCKER_CONFIG
+		COMPOSE_PROJECT_NAME=lc-e2e-contract
+		ARR_COMPOSE_RESOLVER_CONFIG_LOG=$resolver_log
+		export COMPOSE_PROJECT_NAME ARR_COMPOSE_RESOLVER_CONFIG_LOG
+		sh "$harness_dir/$script"
+	); then
+		echo "$script did not reach the shared Compose resolver." >&2
+		exit 1
+	fi
+	printf '%s\n' /tmp/lc-e2e-docker-config >"$expected_resolver_log"
+	if ! cmp -s "$expected_resolver_log" "$resolver_log"; then
+		echo "$script resolved Compose before exporting its default isolated DOCKER_CONFIG." >&2
+		diff -u "$expected_resolver_log" "$resolver_log" >&2 || true
+		exit 1
+	fi
+}
+
+for script in bootstrap-arr.sh bootstrap-dashboard.sh bootstrap-plex.sh run-live-scenario.sh; do
+	assert_default_docker_config_precedes_resolver "$script"
 done
 
 echo "compose command contract and bypass checks passed."

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-compose-command-test.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+FAKE_COMPOSE="$TEMP_DIR/fake-compose"
+COMPOSE_LOG="$TEMP_DIR/compose.log"
+cat >"$FAKE_COMPOSE" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" >"$ARR_COMPOSE_LOG"
+EOF
+chmod +x "$FAKE_COMPOSE"
+
+COMPOSE_PROJECT_NAME=lc-e2e-contract
+ARR_COMPOSE_BIN="$FAKE_COMPOSE"
+ARR_COMPOSE_LOG="$COMPOSE_LOG"
+export COMPOSE_PROJECT_NAME ARR_COMPOSE_BIN ARR_COMPOSE_LOG
+
+. "$SCRIPT_DIR/compose-command.sh"
+compose ps --status running --services
+
+expected_args="$TEMP_DIR/expected-args"
+{
+	printf '%s\n' -p lc-e2e-contract
+	printf '%s\n' -f "$SCRIPT_DIR/compose.yml"
+	printf '%s\n' -f "$SCRIPT_DIR/compose.debug.yml"
+	printf '%s\n' ps --status running --services
+} >"$expected_args"
+
+if ! cmp -s "$expected_args" "$COMPOSE_LOG"; then
+	echo "compose helper did not invoke ARR_COMPOSE_BIN with the isolated harness model." >&2
+	diff -u "$expected_args" "$COMPOSE_LOG" >&2 || true
+	exit 1
+fi
+
+for script in \
+	bootstrap-arr.sh \
+	bootstrap-dashboard.sh \
+	bootstrap-plex.sh \
+	bootstrap-qui.sh \
+	run-browser-policy.sh \
+	run-live-scenario.sh \
+	teardown.sh \
+	validate-compose.sh; do
+	if ! grep -Fq '. "$SCRIPT_DIR/compose-command.sh"' "$SCRIPT_DIR/$script"; then
+		echo "$script does not load the shared Compose helper." >&2
+		exit 1
+	fi
+	if grep -Eq '(^|[^[:alnum:]_])(docker[[:space:]]+compose|COMPOSE_BIN=|run_compose[[:space:]]*\(|compose[[:space:]]*\()' "$SCRIPT_DIR/$script"; then
+		echo "$script bypasses the shared Compose helper." >&2
+		exit 1
+	fi
+done
+
+echo "compose command contract and bypass checks passed."

--- a/e2e/library-cleanup/compose-command.test.sh
+++ b/e2e/library-cleanup/compose-command.test.sh
@@ -24,6 +24,10 @@ mkdir -p \
 
 cat >"$FAKE_COMPOSE" <<'EOF'
 #!/bin/sh
+if [ "$1" = version ] && [ "$2" = --short ]; then
+	printf '%s\n' 2.40.0
+	exit 0
+fi
 {
 	printf '%s\n' override
 	printf '%s\n' "$@"
@@ -33,7 +37,8 @@ chmod +x "$FAKE_COMPOSE"
 
 cat >"$FAKE_DOCKER_BIN_DIR/docker" <<'EOF'
 #!/bin/sh
-if [ "$1" = compose ] && [ "$2" = version ]; then
+if [ "$1" = compose ] && [ "$2" = version ] && [ "$3" = --short ]; then
+	printf '%s\n' 2.40.0
 	exit 0
 fi
 {
@@ -45,7 +50,8 @@ chmod +x "$FAKE_DOCKER_BIN_DIR/docker"
 
 cat >"$FAKE_STANDALONE_BIN_DIR/docker-compose" <<'EOF'
 #!/bin/sh
-if [ "$1" = version ]; then
+if [ "$1" = version ] && [ "$2" = --short ]; then
+	printf '%s\n' 2.40.0
 	exit 0
 fi
 {
@@ -58,12 +64,26 @@ chmod +x "$FAKE_STANDALONE_BIN_DIR/docker-compose"
 FAKE_PLUGIN="$FAKE_HOME/.docker/cli-plugins/docker-compose"
 cat >"$FAKE_PLUGIN" <<'EOF'
 #!/bin/sh
+if [ "$1" = version ] && [ "$2" = --short ]; then
+	printf '%s\n' 5.1.0
+	exit 0
+fi
 {
 	printf '%s\n' plugin
 	printf '%s\n' "$@"
 } >"$ARR_COMPOSE_LOG"
 EOF
 chmod +x "$FAKE_PLUGIN"
+
+cat >"$FAKE_STANDALONE_BIN_DIR/legacy-compose" <<'EOF'
+#!/bin/sh
+if [ "$1" = version ] && [ "$2" = --short ]; then
+	printf '%s\n' 1.29.2
+	exit 0
+fi
+exit 99
+EOF
+chmod +x "$FAKE_STANDALONE_BIN_DIR/legacy-compose"
 
 assert_compose_args() {
 	expected_command=$1
@@ -126,6 +146,16 @@ PATH=$SYSTEM_PATH
 export PATH
 assert_compose_args plugin
 
+unset ARR_COMPOSE_BIN
+ln -s "$FAKE_STANDALONE_BIN_DIR/legacy-compose" "$EMPTY_BIN_DIR/docker-compose"
+PATH=$EMPTY_BIN_DIR
+HOME="$FAKE_HOME"
+export PATH HOME
+exercise_compose
+PATH=$SYSTEM_PATH
+export PATH
+assert_compose_args plugin
+
 for script in \
 	bootstrap-arr.sh \
 	bootstrap-dashboard.sh \
@@ -134,6 +164,8 @@ for script in \
 	bootstrap-torrents.sh \
 	run-browser-policy.sh \
 	run-live-scenario.sh \
+	start-profile.sh \
+	stop-profile.sh \
 	teardown.sh \
 	validate-compose.sh; do
 	if ! grep -Fq '. "$SCRIPT_DIR/compose-command.sh"' "$SCRIPT_DIR/$script"; then

--- a/e2e/library-cleanup/compose.yml
+++ b/e2e/library-cleanup/compose.yml
@@ -43,7 +43,7 @@ x-dashboard-dependencies: &dashboard-dependencies
 
 services:
   radarr-a:
-    image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:latest}
+    image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a}
     environment: *linuxserver-environment
     volumes:
       - radarr-a-config:/config
@@ -58,7 +58,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7878/ping"]
 
   radarr-b:
-    image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:latest}
+    image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a}
     environment: *linuxserver-environment
     volumes:
       - radarr-b-config:/config
@@ -73,7 +73,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7878/ping"]
 
   sonarr-a:
-    image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:latest}
+    image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7}
     environment: *linuxserver-environment
     volumes:
       - sonarr-a-config:/config
@@ -88,7 +88,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8989/ping"]
 
   sonarr-b:
-    image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:latest}
+    image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7}
     environment: *linuxserver-environment
     volumes:
       - sonarr-b-config:/config
@@ -103,7 +103,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8989/ping"]
 
   plex:
-    image: ${PLEX_IMAGE:-lscr.io/linuxserver/plex:latest}
+    image: ${PLEX_IMAGE:-lscr.io/linuxserver/plex:1.41.5@sha256:5c07f70ae39709c71927ecb864cb9328acb01eb6c08779d1efb09b90b68a0692}
     environment:
       <<: *linuxserver-environment
       VERSION: docker
@@ -137,6 +137,7 @@ services:
             const offset = Number(requestUrl.searchParams.get("X-Plex-Container-Start") ?? "0");
             const metadata = offset === 0 ? [{
               ratingKey: "17",
+              historyKey: "lc-e2e-plex-history-pilot-17",
               parentRatingKey: "16",
               grandparentRatingKey: "15",
               title: "Pilot",
@@ -188,7 +189,7 @@ services:
       start_period: 5s
 
   qbittorrent-a:
-    image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:latest}
+    image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e}
     environment:
       <<: *linuxserver-environment
       WEBUI_PORT: "8080"
@@ -208,7 +209,7 @@ services:
       start_period: 30s
 
   qbittorrent-b:
-    image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:latest}
+    image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e}
     environment:
       <<: *linuxserver-environment
       WEBUI_PORT: "8080"

--- a/e2e/library-cleanup/compose.yml
+++ b/e2e/library-cleanup/compose.yml
@@ -1,5 +1,12 @@
 name: ${COMPOSE_PROJECT_NAME:?Set a unique lc-e2e-* project name}
 
+x-run-labels: &run-labels
+  io.arr-dashboard.library-cleanup.project: ${COMPOSE_PROJECT_NAME}
+  io.arr-dashboard.library-cleanup.run-token: ${LC_E2E_RUN_TOKEN:?Set a random LC_E2E_RUN_TOKEN}
+
+x-run-owned-service: &run-owned-service
+  labels: *run-labels
+
 x-linuxserver-environment: &linuxserver-environment
   PUID: ${PUID:-1000}
   PGID: ${PGID:-1000}
@@ -28,7 +35,7 @@ x-dashboard-dependencies: &dashboard-dependencies
     condition: service_healthy
   sonarr-b:
     condition: service_healthy
-  plex:
+  plex-loopback-proxy:
     condition: service_healthy
   qbittorrent-a:
     condition: service_healthy
@@ -43,6 +50,7 @@ x-dashboard-dependencies: &dashboard-dependencies
 
 services:
   radarr-a:
+    <<: *run-owned-service
     image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a}
     environment: *linuxserver-environment
     volumes:
@@ -58,6 +66,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7878/ping"]
 
   radarr-b:
+    <<: *run-owned-service
     image: ${RADARR_IMAGE:-lscr.io/linuxserver/radarr:5.16.3@sha256:eb894bd26fd3fb29981bf91b140834417ce2ed28ab8217d0ce121db5c460f39a}
     environment: *linuxserver-environment
     volumes:
@@ -73,6 +82,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:7878/ping"]
 
   sonarr-a:
+    <<: *run-owned-service
     image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7}
     environment: *linuxserver-environment
     volumes:
@@ -88,6 +98,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8989/ping"]
 
   sonarr-b:
+    <<: *run-owned-service
     image: ${SONARR_IMAGE:-lscr.io/linuxserver/sonarr:4.0.15@sha256:fbe67c25693dc5f3de220c5691f374576ae265df782c16918cc071b630490bd7}
     environment: *linuxserver-environment
     volumes:
@@ -103,6 +114,7 @@ services:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8989/ping"]
 
   plex:
+    <<: *run-owned-service
     image: ${PLEX_IMAGE:-lscr.io/linuxserver/plex:1.41.5@sha256:5c07f70ae39709c71927ecb864cb9328acb01eb6c08779d1efb09b90b68a0692}
     environment:
       <<: *linuxserver-environment
@@ -126,6 +138,7 @@ services:
       start_period: 45s
 
   plex-loopback-proxy:
+    <<: *run-owned-service
     image: ${CANDIDATE_DASHBOARD_IMAGE:-arr-dashboard-library-cleanup:local}
     entrypoint: ["node", "-e"]
     command:
@@ -154,11 +167,13 @@ services:
             return;
           }
           const { "x-plex-token": _discardedToken, ...forwardedHeaders } = request.headers;
+          requestUrl.searchParams.delete("X-Plex-Token");
+          const upstreamPath = requestUrl.pathname + requestUrl.search;
           const upstream = http.request({
             host: "127.0.0.1",
             port: 32400,
             method: request.method,
-            path: request.url,
+            path: upstreamPath,
             headers: { ...forwardedHeaders, host: "127.0.0.1:32400" },
           }, (upstreamResponse) => {
             response.writeHead(upstreamResponse.statusCode ?? 502, upstreamResponse.headers);
@@ -189,6 +204,7 @@ services:
       start_period: 5s
 
   qbittorrent-a:
+    <<: *run-owned-service
     image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e}
     environment:
       <<: *linuxserver-environment
@@ -209,6 +225,7 @@ services:
       start_period: 30s
 
   qbittorrent-b:
+    <<: *run-owned-service
     image: ${QBITTORRENT_IMAGE:-lscr.io/linuxserver/qbittorrent:5.1.2@sha256:7034f73a3c6fa4ea40fd67df462939d1665d765231b572523921c98c2db5362e}
     environment:
       <<: *linuxserver-environment
@@ -229,6 +246,7 @@ services:
       start_period: 30s
 
   qui-a:
+    <<: *run-owned-service
     image: ${QUI_IMAGE:-ghcr.io/autobrr/qui:v1.16.1}
     environment:
       TZ: ${TZ:-Etc/UTC}
@@ -261,6 +279,7 @@ services:
       start_period: 30s
 
   qui-b:
+    <<: *run-owned-service
     image: ${QUI_IMAGE:-ghcr.io/autobrr/qui:v1.16.1}
     environment:
       TZ: ${TZ:-Etc/UTC}
@@ -293,6 +312,7 @@ services:
       start_period: 30s
 
   postgres:
+    <<: *run-owned-service
     image: ${POSTGRES_IMAGE:-postgres:16-alpine}
     environment:
       POSTGRES_USER: arr_dashboard
@@ -314,6 +334,7 @@ services:
       start_period: 15s
 
   toxiproxy:
+    <<: *run-owned-service
     image: ${TOXIPROXY_IMAGE:-ghcr.io/shopify/toxiproxy:2.12.0}
     expose:
       - "8474"
@@ -328,6 +349,7 @@ services:
       start_period: 10s
 
   dashboard-sqlite:
+    <<: *run-owned-service
     image: ${CANDIDATE_DASHBOARD_IMAGE:-arr-dashboard-library-cleanup:local}
     build:
       context: ../..
@@ -360,6 +382,7 @@ services:
     healthcheck: *dashboard-healthcheck
 
   dashboard-postgres:
+    <<: *run-owned-service
     image: ${CANDIDATE_DASHBOARD_IMAGE:-arr-dashboard-library-cleanup:local}
     build:
       context: ../..
@@ -401,6 +424,7 @@ services:
     healthcheck: *dashboard-healthcheck
 
   dashboard-baseline:
+    <<: *run-owned-service
     image: ${BASELINE_DASHBOARD_IMAGE:-khak1s/arr-dashboard:2.23.0}
     profiles: ["baseline"]
     environment:
@@ -434,25 +458,41 @@ secrets:
 
 volumes:
   shared-media:
+    labels: *run-labels
   radarr-a-config:
+    labels: *run-labels
   radarr-b-config:
+    labels: *run-labels
   sonarr-a-config:
+    labels: *run-labels
   sonarr-b-config:
+    labels: *run-labels
   plex-config:
+    labels: *run-labels
   qbittorrent-a-config:
+    labels: *run-labels
   qbittorrent-b-config:
+    labels: *run-labels
   qui-a-config:
+    labels: *run-labels
   qui-b-config:
+    labels: *run-labels
   postgres-data:
+    labels: *run-labels
   dashboard-sqlite-config:
+    labels: *run-labels
   dashboard-postgres-config:
+    labels: *run-labels
   dashboard-baseline-config:
+    labels: *run-labels
 
 networks:
   cleanup-internal:
+    labels: *run-labels
     internal: true
     ipam:
       config:
         - subnet: ${HARNESS_SUBNET:-172.31.250.0/24}
   metadata-egress:
     driver: bridge
+    labels: *run-labels

--- a/e2e/library-cleanup/live-project-guard.sh
+++ b/e2e/library-cleanup/live-project-guard.sh
@@ -67,6 +67,7 @@ verify_dashboard_profile() {
 
 verify_live_project() {
 	allow_empty=${1:-}
+	docker_bin=${ARR_DOCKER_BIN:-docker}
 	model_file=$(mktemp "${TMPDIR:-/tmp}/lc-e2e-live-model.XXXXXX")
 	hash_file=$(mktemp "${TMPDIR:-/tmp}/lc-e2e-live-hashes.XXXXXX")
 	if ! compose --profile candidate-sqlite --profile candidate-postgres --profile baseline \
@@ -79,11 +80,13 @@ verify_live_project() {
 	if [ "$allow_empty" = "--allow-empty" ]; then
 		python3 "$SCRIPT_DIR/check-live-project.py" --model "$model_file" --hashes "$hash_file" \
 			--project "$PROJECT_NAME" --run-token "$LC_E2E_RUN_TOKEN" \
+			--docker-bin "$docker_bin" \
 			--config-files "$SCRIPT_DIR/compose.yml,$SCRIPT_DIR/compose.debug.yml" \
 			--working-dir "$SCRIPT_DIR" --allow-empty
 	else
 		python3 "$SCRIPT_DIR/check-live-project.py" --model "$model_file" --hashes "$hash_file" \
 			--project "$PROJECT_NAME" --run-token "$LC_E2E_RUN_TOKEN" \
+			--docker-bin "$docker_bin" \
 			--config-files "$SCRIPT_DIR/compose.yml,$SCRIPT_DIR/compose.debug.yml" \
 			--working-dir "$SCRIPT_DIR"
 	fi

--- a/e2e/library-cleanup/live-project-guard.sh
+++ b/e2e/library-cleanup/live-project-guard.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+: "${SCRIPT_DIR:?live-project-guard.sh requires SCRIPT_DIR}"
+: "${PROJECT_NAME:?live-project-guard.sh requires PROJECT_NAME}"
+
+if [ -z "${LC_E2E_RUN_TOKEN:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
+	LC_E2E_RUN_TOKEN=$(sed -n 's/^LC_E2E_RUN_TOKEN=//p' "$SCRIPT_DIR/.env" | tail -n 1)
+	export LC_E2E_RUN_TOKEN
+fi
+
+case "${LC_E2E_RUN_TOKEN:-}" in
+	????????????????????????????????????????????????????????????????)
+		case "$LC_E2E_RUN_TOKEN" in
+			*[!0-9a-f]*) echo "Harness refused: LC_E2E_RUN_TOKEN must be 64 lowercase hex characters." >&2; exit 1 ;;
+		esac
+		;;
+	*) echo "Harness refused: set one random 64-character lowercase hex LC_E2E_RUN_TOKEN per run." >&2; exit 1 ;;
+esac
+
+acquire_live_project_lock() {
+	if ! command -v flock >/dev/null 2>&1; then
+		echo "Harness refused: flock is required for the per-project mutation lock." >&2
+		exit 2
+	fi
+	lock_root=${LC_E2E_LOCK_ROOT:-${XDG_RUNTIME_DIR:-/tmp}/arr-dashboard-library-cleanup-locks}
+	mkdir -p "$lock_root"
+	lock_file=$lock_root/$PROJECT_NAME.lock
+	exec 9>"$lock_file"
+	if ! flock -n 9; then
+		echo "Harness refused: another process owns the live lock for $PROJECT_NAME." >&2
+		exit 1
+	fi
+}
+
+verify_live_project() {
+	allow_empty=${1:-}
+	model_file=$(mktemp "${TMPDIR:-/tmp}/lc-e2e-live-model.XXXXXX")
+	hash_file=$(mktemp "${TMPDIR:-/tmp}/lc-e2e-live-hashes.XXXXXX")
+	if ! compose --profile candidate-sqlite --profile candidate-postgres --profile baseline \
+		config --format json >"$model_file" || \
+		! compose --profile candidate-sqlite --profile candidate-postgres --profile baseline \
+		config --hash='*' >"$hash_file"; then
+		rm -f "$model_file" "$hash_file"
+		return 1
+	fi
+	if [ "$allow_empty" = "--allow-empty" ]; then
+		python3 "$SCRIPT_DIR/check-live-project.py" --model "$model_file" --hashes "$hash_file" \
+			--project "$PROJECT_NAME" --run-token "$LC_E2E_RUN_TOKEN" \
+			--config-files "$SCRIPT_DIR/compose.yml,$SCRIPT_DIR/compose.debug.yml" \
+			--working-dir "$SCRIPT_DIR" --allow-empty
+	else
+		python3 "$SCRIPT_DIR/check-live-project.py" --model "$model_file" --hashes "$hash_file" \
+			--project "$PROJECT_NAME" --run-token "$LC_E2E_RUN_TOKEN" \
+			--config-files "$SCRIPT_DIR/compose.yml,$SCRIPT_DIR/compose.debug.yml" \
+			--working-dir "$SCRIPT_DIR"
+	fi
+	result=$?
+	rm -f "$model_file" "$hash_file"
+	return "$result"
+}

--- a/e2e/library-cleanup/live-project-guard.sh
+++ b/e2e/library-cleanup/live-project-guard.sh
@@ -32,6 +32,39 @@ acquire_live_project_lock() {
 	fi
 }
 
+verify_dashboard_profile() {
+	selected_service=${1:?verify_dashboard_profile requires one dashboard service}
+	require_running=${2:-}
+	case "$selected_service" in
+		dashboard-sqlite | dashboard-postgres | dashboard-baseline) ;;
+		*)
+			echo "Harness refused: unsupported selected dashboard service $selected_service." >&2
+			return 2
+			;;
+	esac
+
+	if ! running_services=$(compose ps --status running --services); then
+		echo "Harness refused: could not determine which dashboard profile is running." >&2
+		return 1
+	fi
+	selected_running=0
+	for running_service in $running_services; do
+		case "$running_service" in
+			dashboard-sqlite | dashboard-postgres | dashboard-baseline)
+				if [ "$running_service" != "$selected_service" ]; then
+					echo "Harness start refused: $running_service is already running; stop it before starting $selected_service." >&2
+					return 1
+				fi
+				selected_running=1
+				;;
+		esac
+	done
+	if [ "$require_running" = "--require-running" ] && [ "$selected_running" -ne 1 ]; then
+		echo "Harness refused: $selected_service is not the running dashboard after Compose up." >&2
+		return 1
+	fi
+}
+
 verify_live_project() {
 	allow_empty=${1:-}
 	model_file=$(mktemp "${TMPDIR:-/tmp}/lc-e2e-live-model.XXXXXX")

--- a/e2e/library-cleanup/live-project-ownership.test.sh
+++ b/e2e/library-cleanup/live-project-ownership.test.sh
@@ -49,6 +49,9 @@ if [ "$command" = ls ]; then
 			container-default)
 				[ "$kind" = container ] && case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}-app-1" ;; esac
 				;;
+			container-compat)
+				[ "$kind" = container ] && case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}_app_1" ;; esac
+				;;
 			container-named)
 				[ "$kind" = container ] && case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}-named-physical" ;; esac
 				;;
@@ -64,6 +67,9 @@ if [ "$command" = inspect ]; then
 		case "${LC_E2E_TEST_COLLISION:?}:$kind" in
 			container-default:container)
 				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}-app-1\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
+				;;
+			container-compat:container)
+				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}_app_1\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
 				;;
 			container-named:container)
 				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}-named-physical\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
@@ -105,6 +111,7 @@ assert_rejects_collision() {
 	fi
 	case "$kind" in
 		container-default) expected_name="${PROJECT}-app-1" ;;
+		container-compat) expected_name="${PROJECT}_app_1" ;;
 		container-named) expected_name="${PROJECT}-named-physical" ;;
 		*) expected_name="${PROJECT}_" ;;
 	esac
@@ -118,6 +125,7 @@ assert_rejects_collision() {
 assert_rejects_collision volume
 assert_rejects_collision network
 assert_rejects_collision container-default
+assert_rejects_collision container-compat
 assert_rejects_collision container-named
 
 echo "live project exact-name ownership tests passed."

--- a/e2e/library-cleanup/live-project-ownership.test.sh
+++ b/e2e/library-cleanup/live-project-ownership.test.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-live-project-ownership-test.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+
+PROJECT=lc-e2e-690-20260810
+TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+MODEL_FILE=$TEMP_DIR/model.json
+HASH_FILE=$TEMP_DIR/hashes.txt
+FAKE_BIN_DIR=$TEMP_DIR/bin
+mkdir -p "$FAKE_BIN_DIR"
+
+cat >"$MODEL_FILE" <<EOF
+{
+  "services": {"app": {"image": "example:test", "volumes": [], "networks": {}}},
+  "volumes": {"data": {"name": "${PROJECT}_data"}},
+  "networks": {"private": {"name": "${PROJECT}_private"}}
+}
+EOF
+printf '%s\n' 'app hash' >"$HASH_FILE"
+
+cat >"$FAKE_BIN_DIR/docker" <<'EOF'
+#!/bin/sh
+set -eu
+
+kind=$1
+command=$2
+shift 2
+
+if [ "$command" = ls ]; then
+
+	case " $* " in
+		*' --format '*)
+			case "${LC_E2E_TEST_COLLISION:?}" in
+				volume) [ "$kind" = volume ] && printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
+				network) [ "$kind" = network ] && printf '%s\n' "${LC_E2E_TEST_PROJECT}_private" ;;
+			esac
+			;;
+	esac
+	exit 0
+fi
+
+if [ "$command" = inspect ]; then
+	case "${LC_E2E_TEST_COLLISION:?}:$kind" in
+		volume:volume)
+			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_data\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
+			;;
+		network:network)
+			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_private\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
+			;;
+	esac
+	exit 0
+fi
+
+echo "unexpected fake docker invocation: $kind $command $*" >&2
+exit 99
+EOF
+chmod +x "$FAKE_BIN_DIR/docker"
+
+assert_rejects_collision() {
+	kind=$1
+	if PATH="$FAKE_BIN_DIR:$PATH" \
+		LC_E2E_TEST_COLLISION=$kind \
+		LC_E2E_TEST_PROJECT=$PROJECT \
+		python3 "$SCRIPT_DIR/check-live-project.py" \
+			--model "$MODEL_FILE" \
+			--hashes "$HASH_FILE" \
+			--project "$PROJECT" \
+			--run-token "$TOKEN" \
+			--config-files /workspace/compose.yml,/workspace/compose.debug.yml \
+			--working-dir /workspace \
+			--allow-empty >"$TEMP_DIR/$kind.out" 2>&1; then
+		echo "ownership check accepted an existing $kind with the rendered physical name" >&2
+		cat "$TEMP_DIR/$kind.out" >&2
+		exit 1
+	fi
+	if ! grep -Fq "${PROJECT}_" "$TEMP_DIR/$kind.out"; then
+		echo "ownership check rejected the $kind collision without identifying its physical name" >&2
+		cat "$TEMP_DIR/$kind.out" >&2
+		exit 1
+	fi
+}
+
+assert_rejects_collision volume
+assert_rejects_collision network
+
+echo "live project exact-name ownership tests passed."

--- a/e2e/library-cleanup/live-project-ownership.test.sh
+++ b/e2e/library-cleanup/live-project-ownership.test.sh
@@ -10,11 +10,23 @@ TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 MODEL_FILE=$TEMP_DIR/model.json
 HASH_FILE=$TEMP_DIR/hashes.txt
 FAKE_BIN_DIR=$TEMP_DIR/bin
-mkdir -p "$FAKE_BIN_DIR"
+EMPTY_BIN_DIR=$TEMP_DIR/empty-bin
+WRAPPED_DOCKER="$TEMP_DIR/docker wrapper"
+mkdir -p "$FAKE_BIN_DIR" "$EMPTY_BIN_DIR"
+
+cat >"$EMPTY_BIN_DIR/docker" <<'EOF'
+#!/bin/sh
+echo "literal docker must not be used when --docker-bin is configured" >&2
+exit 99
+EOF
+chmod +x "$EMPTY_BIN_DIR/docker"
 
 cat >"$MODEL_FILE" <<EOF
 {
-  "services": {"app": {"image": "example:test", "volumes": [], "networks": {}}},
+  "services": {
+    "app": {"image": "example:test", "volumes": [], "networks": {}},
+    "named": {"container_name": "${PROJECT}-named-physical", "image": "example:test", "volumes": [], "networks": {}}
+  },
   "volumes": {"data": {"name": "${PROJECT}_data"}},
   "networks": {"private": {"name": "${PROJECT}_private"}}
 }
@@ -33,8 +45,14 @@ if [ "$command" = ls ]; then
 
 	case " $* " in
 		*' --format '*)
-			case "${LC_E2E_TEST_COLLISION:?}" in
-				volume) [ "$kind" = volume ] && printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
+		case "${LC_E2E_TEST_COLLISION:?}" in
+			container-default)
+				[ "$kind" = container ] && case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}-app-1" ;; esac
+				;;
+			container-named)
+				[ "$kind" = container ] && case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}-named-physical" ;; esac
+				;;
+			volume) [ "$kind" = volume ] && printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
 				network) [ "$kind" = network ] && printf '%s\n' "${LC_E2E_TEST_PROJECT}_private" ;;
 			esac
 			;;
@@ -43,7 +61,13 @@ if [ "$command" = ls ]; then
 fi
 
 if [ "$command" = inspect ]; then
-	case "${LC_E2E_TEST_COLLISION:?}:$kind" in
+		case "${LC_E2E_TEST_COLLISION:?}:$kind" in
+			container-default:container)
+				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}-app-1\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
+				;;
+			container-named:container)
+				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}-named-physical\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
+				;;
 		volume:volume)
 			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_data\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
 			;;
@@ -58,17 +82,20 @@ echo "unexpected fake docker invocation: $kind $command $*" >&2
 exit 99
 EOF
 chmod +x "$FAKE_BIN_DIR/docker"
+cp "$FAKE_BIN_DIR/docker" "$WRAPPED_DOCKER"
+chmod +x "$WRAPPED_DOCKER"
 
 assert_rejects_collision() {
 	kind=$1
-	if PATH="$FAKE_BIN_DIR:$PATH" \
+	if PATH="$EMPTY_BIN_DIR:$PATH" \
 		LC_E2E_TEST_COLLISION=$kind \
 		LC_E2E_TEST_PROJECT=$PROJECT \
 		python3 "$SCRIPT_DIR/check-live-project.py" \
 			--model "$MODEL_FILE" \
 			--hashes "$HASH_FILE" \
 			--project "$PROJECT" \
-			--run-token "$TOKEN" \
+		--run-token "$TOKEN" \
+		--docker-bin "$WRAPPED_DOCKER" \
 			--config-files /workspace/compose.yml,/workspace/compose.debug.yml \
 			--working-dir /workspace \
 			--allow-empty >"$TEMP_DIR/$kind.out" 2>&1; then
@@ -76,7 +103,12 @@ assert_rejects_collision() {
 		cat "$TEMP_DIR/$kind.out" >&2
 		exit 1
 	fi
-	if ! grep -Fq "${PROJECT}_" "$TEMP_DIR/$kind.out"; then
+	case "$kind" in
+		container-default) expected_name="${PROJECT}-app-1" ;;
+		container-named) expected_name="${PROJECT}-named-physical" ;;
+		*) expected_name="${PROJECT}_" ;;
+	esac
+	if ! grep -Fq "$expected_name" "$TEMP_DIR/$kind.out"; then
 		echo "ownership check rejected the $kind collision without identifying its physical name" >&2
 		cat "$TEMP_DIR/$kind.out" >&2
 		exit 1
@@ -85,5 +117,7 @@ assert_rejects_collision() {
 
 assert_rejects_collision volume
 assert_rejects_collision network
+assert_rejects_collision container-default
+assert_rejects_collision container-named
 
 echo "live project exact-name ownership tests passed."

--- a/e2e/library-cleanup/live-scenarios.mjs
+++ b/e2e/library-cleanup/live-scenarios.mjs
@@ -9,7 +9,7 @@ const USERNAME = "gauntlet-admin";
 const PASSWORD = "LibraryCleanupGauntlet2026!";
 const LEGACY_HARNESS_RULE_NAMES = new Set(["qUI seeding exclusion"]);
 
-const ARR = Object.freeze({
+export const ARR = Object.freeze({
 	"radarr-hd": {
 		label: "Library Cleanup Radarr HD",
 		service: "RADARR",
@@ -17,7 +17,8 @@ const ARR = Object.freeze({
 		apiKeyEnv: "RADARR_A_KEY",
 		kind: "movie",
 		quality: "1080p",
-		libraryPath: "/radarr-a/data/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264-LCE2E.mkv",
+		libraryPath:
+			"/radarr-a/data/library/radarr-a/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264-LCE2E.mkv",
 		plexPath:
 			"/plex/data/library/radarr-a/The Matrix (1999)/The.Matrix.1999.1080p.BluRay.x264-LCE2E.mkv",
 	},
@@ -28,7 +29,8 @@ const ARR = Object.freeze({
 		apiKeyEnv: "RADARR_B_KEY",
 		kind: "movie",
 		quality: "2160p",
-		libraryPath: "/radarr-b/data/The Matrix (1999)/The.Matrix.1999.2160p.UHD.BluRay.x265-LCE2E.mkv",
+		libraryPath:
+			"/radarr-b/data/library/radarr-b/The Matrix (1999)/The.Matrix.1999.2160p.UHD.BluRay.x265-LCE2E.mkv",
 		plexPath:
 			"/plex/data/library/radarr-b/The Matrix (1999)/The.Matrix.1999.2160p.UHD.BluRay.x265-LCE2E.mkv",
 	},
@@ -40,7 +42,7 @@ const ARR = Object.freeze({
 		kind: "series",
 		quality: "1080p",
 		libraryPath:
-			"/sonarr-a/data/Breaking Bad/Season 01/Breaking.Bad.S01E01.1080p.BluRay.x264-LCE2E.mkv",
+			"/sonarr-a/data/library/sonarr-a/Breaking Bad/Season 01/Breaking.Bad.S01E01.1080p.BluRay.x264-LCE2E.mkv",
 		plexPath:
 			"/plex/data/library/sonarr-a/Breaking Bad/Season 01/Breaking.Bad.S01E01.1080p.BluRay.x264-LCE2E.mkv",
 	},
@@ -52,7 +54,7 @@ const ARR = Object.freeze({
 		kind: "series",
 		quality: "2160p",
 		libraryPath:
-			"/sonarr-b/data/Breaking Bad/Season 01/Breaking.Bad.S01E01.2160p.UHD.BluRay.x265-LCE2E.mkv",
+			"/sonarr-b/data/library/sonarr-b/Breaking Bad/Season 01/Breaking.Bad.S01E01.2160p.UHD.BluRay.x265-LCE2E.mkv",
 		plexPath:
 			"/plex/data/library/sonarr-b/Breaking Bad/Season 01/Breaking.Bad.S01E01.2160p.UHD.BluRay.x265-LCE2E.mkv",
 	},
@@ -310,6 +312,12 @@ async function assertArrRemoved(spec) {
 	);
 }
 
+async function assertFixtureFilePresent(spec) {
+	await fs.access(spec.libraryPath).catch((error) => {
+		throw new Error(`${spec.label} fixture file was absent before execution: ${error.message}`);
+	});
+}
+
 async function assertQuiSourcesRemain(api) {
 	const summary = await api("/api/qui/summary");
 	invariant(
@@ -485,6 +493,7 @@ async function runSeriesDelete(ctx, targetKey) {
 		scanMediaServerAfterDelete: true,
 	});
 	assertPreview(await preview(api), [target.label], "delete");
+	await assertFixtureFilePresent(target);
 	const result = await execute(api);
 	invariant(
 		result.isDryRun === false && result.itemsRemoved === 1,
@@ -565,6 +574,7 @@ async function runEpisodeDelete(ctx, targetKey) {
 			episodePreview.items[0]?.episodeNumber === 1,
 		"Episode preview did not identify Breaking Bad S01E01",
 	);
+	await assertFixtureFilePresent(target);
 	const result = await execute(api);
 	invariant(
 		result.itemsFilesDeleted === 1 && result.itemsRemoved === 0,

--- a/e2e/library-cleanup/live-scenarios.test.mjs
+++ b/e2e/library-cleanup/live-scenarios.test.mjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ARR_FIXTURES, fixtureLibraryPath } from "./bootstrap-arr.mjs";
+import { ARR } from "./live-scenarios.mjs";
+
+test("live deletion assertions use the exact bootstrap fixture paths", () => {
+	const livePaths = new Map(
+		Object.values(ARR).map((fixture) => [fixture.baseUrl, fixture.libraryPath]),
+	);
+	assert.equal(livePaths.size, ARR_FIXTURES.length);
+	for (const fixture of ARR_FIXTURES) {
+		assert.equal(livePaths.get(fixture.baseUrl), fixtureLibraryPath(fixture), fixture.service);
+	}
+});

--- a/e2e/library-cleanup/profile-ownership.test.sh
+++ b/e2e/library-cleanup/profile-ownership.test.sh
@@ -72,9 +72,12 @@ is_post_up_run() {
 }
 
 if [ "$command" = ls ]; then
-	case " $* " in
-		*' --format '*)
+		case " $* " in
+			*' --format '*)
 			case "${LC_E2E_TEST_COLLISION:-}:$kind" in
+				container:container)
+					case " $* " in *' -a '*) printf '%s\n' "${LC_E2E_TEST_PROJECT}-app-1" ;; esac
+				;;
 				volume:volume) printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
 				network:network) printf '%s\n' "${LC_E2E_TEST_PROJECT}_private" ;;
 				*)
@@ -91,8 +94,11 @@ if [ "$command" = ls ]; then
 	exit 0
 fi
 
-if [ "$command" = inspect ]; then
-	case "${LC_E2E_TEST_COLLISION:-}:$kind" in
+	if [ "$command" = inspect ]; then
+		case "${LC_E2E_TEST_COLLISION:-}:$kind" in
+			container:container)
+				printf '%s\n' "[{\"Name\":\"/${LC_E2E_TEST_PROJECT}-app-1\",\"Config\":{\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}}]"
+				;;
 		volume:volume)
 			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_data\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
 			;;
@@ -199,5 +205,6 @@ assert_name_collision_stops_before_up() {
 
 assert_name_collision_stops_before_up volume
 assert_name_collision_stops_before_up network
+assert_name_collision_stops_before_up container
 
 echo "dashboard profile ownership test passed."

--- a/e2e/library-cleanup/profile-ownership.test.sh
+++ b/e2e/library-cleanup/profile-ownership.test.sh
@@ -1,0 +1,203 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-profile-ownership-test.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
+HARNESS_DIR=$TEMP_DIR/harness
+FAKE_BIN_DIR=$TEMP_DIR/bin
+COMPOSE_LOG=$TEMP_DIR/compose.log
+mkdir -p "$HARNESS_DIR" "$FAKE_BIN_DIR"
+
+cp \
+	"$SCRIPT_DIR/start-profile.sh" \
+	"$SCRIPT_DIR/live-project-guard.sh" \
+	"$SCRIPT_DIR/compose-command.sh" \
+	"$SCRIPT_DIR/check-live-project.py" \
+	"$HARNESS_DIR/"
+cat >"$HARNESS_DIR/validate-compose.sh" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$HARNESS_DIR/validate-compose.sh"
+
+cat >"$FAKE_BIN_DIR/flock" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+cat >"$FAKE_BIN_DIR/fake-compose" <<'EOF'
+#!/bin/sh
+set -eu
+
+if [ "$1" = version ] && [ "$2" = --short ]; then
+	printf '%s\n' 2.40.0
+	exit 0
+fi
+
+printf '%s\n' "$*" >>"$LC_E2E_TEST_COMPOSE_LOG"
+case " $* " in
+	*' config --format json '*)
+		cat <<MODEL
+{
+  "services": {"app": {"image": "example:test", "volumes": [], "networks": {}}},
+  "volumes": {"data": {"name": "${LC_E2E_TEST_PROJECT}_data"}},
+  "networks": {"private": {"name": "${LC_E2E_TEST_PROJECT}_private"}}
+}
+MODEL
+		;;
+	*' config --hash='*) printf '%s\n' 'app hash' ;;
+	*' ps --status running --services '*)
+		case "${LC_E2E_TEST_PROFILE_MODE:?}" in
+			pre-conflict) printf '%s\n' dashboard-postgres ;;
+			post-conflict)
+				if [ -f "${LC_E2E_TEST_UP_MARKER:?}" ]; then
+					printf '%s\n' dashboard-postgres
+				fi
+				;;
+		esac
+		;;
+	*' up '*) : >"${LC_E2E_TEST_UP_MARKER:?}" ;;
+esac
+EOF
+cat >"$FAKE_BIN_DIR/docker" <<'EOF'
+#!/bin/sh
+set -eu
+
+kind=$1
+command=$2
+shift 2
+
+is_post_up_run() {
+	[ "${LC_E2E_TEST_PROFILE_MODE:-}" = post-conflict ] && [ -f "${LC_E2E_TEST_UP_MARKER:?}" ]
+}
+
+if [ "$command" = ls ]; then
+	case " $* " in
+		*' --format '*)
+			case "${LC_E2E_TEST_COLLISION:-}:$kind" in
+				volume:volume) printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
+				network:network) printf '%s\n' "${LC_E2E_TEST_PROJECT}_private" ;;
+				*)
+					if is_post_up_run; then
+						case "$kind" in
+							volume) printf '%s\n' "${LC_E2E_TEST_PROJECT}_data" ;;
+							network) printf '%s\n' "${LC_E2E_TEST_PROJECT}_private" ;;
+						esac
+					fi
+					;;
+			esac
+			;;
+	esac
+	exit 0
+fi
+
+if [ "$command" = inspect ]; then
+	case "${LC_E2E_TEST_COLLISION:-}:$kind" in
+		volume:volume)
+			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_data\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
+			;;
+		network:network)
+			printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_private\",\"Labels\":{\"com.docker.compose.project\":\"foreign\"}}]"
+			;;
+	esac
+	if is_post_up_run; then
+		case "$kind" in
+			volume)
+				printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_data\",\"Labels\":{\"com.docker.compose.project\":\"${LC_E2E_TEST_PROJECT}\",\"io.arr-dashboard.library-cleanup.project\":\"${LC_E2E_TEST_PROJECT}\",\"io.arr-dashboard.library-cleanup.run-token\":\"${LC_E2E_RUN_TOKEN}\",\"com.docker.compose.volume\":\"data\"}}]"
+				;;
+			network)
+				printf '%s\n' "[{\"Name\":\"${LC_E2E_TEST_PROJECT}_private\",\"Labels\":{\"com.docker.compose.project\":\"${LC_E2E_TEST_PROJECT}\",\"io.arr-dashboard.library-cleanup.project\":\"${LC_E2E_TEST_PROJECT}\",\"io.arr-dashboard.library-cleanup.run-token\":\"${LC_E2E_RUN_TOKEN}\",\"com.docker.compose.network\":\"private\"}}]"
+				;;
+		esac
+	fi
+	exit 0
+fi
+
+echo "unexpected fake docker invocation: $kind $command $*" >&2
+exit 99
+EOF
+chmod +x "$FAKE_BIN_DIR/flock" "$FAKE_BIN_DIR/fake-compose" "$FAKE_BIN_DIR/docker"
+
+run_start_profile() {
+	mode=$1
+	output_file=$2
+	up_marker=$3
+	PATH="$FAKE_BIN_DIR:$PATH" \
+		ARR_COMPOSE_BIN="$FAKE_BIN_DIR/fake-compose" \
+		LC_E2E_TEST_COMPOSE_LOG="$COMPOSE_LOG" \
+		LC_E2E_TEST_PROFILE_MODE=$mode \
+		LC_E2E_TEST_UP_MARKER=$up_marker \
+		LC_E2E_TEST_PROJECT=lc-e2e-690-20260810 \
+		LC_E2E_LOCK_ROOT="$TEMP_DIR/locks-$mode" \
+		COMPOSE_PROJECT_NAME=lc-e2e-690-20260810 \
+		LC_E2E_RUN_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+		sh "$HARNESS_DIR/start-profile.sh" sqlite >"$output_file" 2>&1
+}
+
+if run_start_profile pre-conflict "$TEMP_DIR/pre-start.out" "$TEMP_DIR/pre-up"; then
+	echo "sqlite startup accepted a running postgres dashboard" >&2
+	cat "$TEMP_DIR/pre-start.out" >&2
+	exit 1
+fi
+
+if grep -Eq '(^| )up( |$)' "$COMPOSE_LOG"; then
+	echo "sqlite startup reached Compose up while postgres was running" >&2
+	cat "$COMPOSE_LOG" >&2
+	exit 1
+fi
+
+if ! grep -Fq 'dashboard-postgres' "$TEMP_DIR/pre-start.out"; then
+	echo "profile conflict refusal did not identify the running dashboard" >&2
+	cat "$TEMP_DIR/pre-start.out" >&2
+	exit 1
+fi
+
+POST_UP_MARKER=$TEMP_DIR/post-up
+if run_start_profile post-conflict "$TEMP_DIR/post-start.out" "$POST_UP_MARKER"; then
+	echo "sqlite startup accepted postgres as the dashboard after Compose up" >&2
+	cat "$TEMP_DIR/post-start.out" >&2
+	exit 1
+fi
+
+if [ ! -f "$POST_UP_MARKER" ]; then
+	echo "post-up dashboard test never reached Compose up" >&2
+	cat "$COMPOSE_LOG" >&2
+	exit 1
+fi
+
+if ! grep -Fq 'dashboard-postgres' "$TEMP_DIR/post-start.out"; then
+	echo "post-up dashboard refusal did not identify the running dashboard" >&2
+	cat "$TEMP_DIR/post-start.out" >&2
+	exit 1
+fi
+
+assert_name_collision_stops_before_up() {
+	kind=$1
+	output_file=$TEMP_DIR/$kind-collision.out
+	up_marker=$TEMP_DIR/$kind-collision-up
+	if PATH="$FAKE_BIN_DIR:$PATH" \
+		ARR_COMPOSE_BIN="$FAKE_BIN_DIR/fake-compose" \
+		LC_E2E_TEST_COLLISION=$kind \
+		LC_E2E_TEST_COMPOSE_LOG="$COMPOSE_LOG" \
+		LC_E2E_TEST_PROFILE_MODE=empty \
+		LC_E2E_TEST_PROJECT=lc-e2e-690-20260810 \
+		LC_E2E_TEST_UP_MARKER=$up_marker \
+		LC_E2E_LOCK_ROOT="$TEMP_DIR/locks-$kind" \
+		COMPOSE_PROJECT_NAME=lc-e2e-690-20260810 \
+		LC_E2E_RUN_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+		sh "$HARNESS_DIR/start-profile.sh" sqlite >"$output_file" 2>&1; then
+		echo "sqlite startup accepted a conflicting $kind name" >&2
+		cat "$output_file" >&2
+		exit 1
+	fi
+	if [ -f "$up_marker" ]; then
+		echo "sqlite startup reached Compose up with a conflicting $kind name" >&2
+		cat "$COMPOSE_LOG" >&2
+		exit 1
+	fi
+}
+
+assert_name_collision_stops_before_up volume
+assert_name_collision_stops_before_up network
+
+echo "dashboard profile ownership test passed."

--- a/e2e/library-cleanup/run-browser-policy.sh
+++ b/e2e/library-cleanup/run-browser-policy.sh
@@ -10,6 +10,7 @@ fi
 
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
 
@@ -23,6 +24,8 @@ esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 if ! compose ps --status running --services | grep -Fxq "$RUNNER_SERVICE"; then
 	echo "Browser policy gate refused: $RUNNER_SERVICE is not running in $PROJECT_NAME." >&2

--- a/e2e/library-cleanup/run-browser-policy.sh
+++ b/e2e/library-cleanup/run-browser-policy.sh
@@ -9,16 +9,9 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+. "$SCRIPT_DIR/compose-command.sh"
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
-
-run_compose() {
-	if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
-		"$ARR_COMPOSE_BIN" "$@"
-	else
-		"$DOCKER_BIN" compose "$@"
-	fi
-}
 
 case "$RUNNER_SERVICE" in
 	dashboard-sqlite | dashboard-postgres) ;;
@@ -31,14 +24,12 @@ esac
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
 
-if ! run_compose -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml \
-	ps --status running --services | grep -Fxq "$RUNNER_SERVICE"; then
+if ! compose ps --status running --services | grep -Fxq "$RUNNER_SERVICE"; then
 	echo "Browser policy gate refused: $RUNNER_SERVICE is not running in $PROJECT_NAME." >&2
 	exit 1
 fi
 
-container_id=$(run_compose -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml \
-	ps -q "$RUNNER_SERVICE")
+container_id=$(compose ps -q "$RUNNER_SERVICE")
 container_project=$("$DOCKER_BIN" inspect "$container_id" \
 	--format '{{index .Config.Labels "com.docker.compose.project"}}')
 container_service=$("$DOCKER_BIN" inspect "$container_id" \
@@ -202,8 +193,7 @@ LC_E2E_BASE_URL=$BASE_URL \
 	PLAYWRIGHT_STATUS=$?
 
 POST_CHECKOUT_COMMIT=$(git -C "$REPO_ROOT" rev-parse HEAD)
-POST_CONTAINER_ID=$(run_compose -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml \
-	ps -q "$RUNNER_SERVICE")
+POST_CONTAINER_ID=$(compose ps -q "$RUNNER_SERVICE")
 if [ "$POST_CHECKOUT_COMMIT" != "$CHECKOUT_COMMIT" ] || \
 	[ -n "$(git -C "$REPO_ROOT" status --porcelain)" ] || \
 	[ "$POST_CONTAINER_ID" != "$container_id" ]; then

--- a/e2e/library-cleanup/run-live-scenario.sh
+++ b/e2e/library-cleanup/run-live-scenario.sh
@@ -7,8 +7,8 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+. "$SCRIPT_DIR/compose-command.sh"
 MODE=${1:?Specify policy, delete:<fixture>, or episode:<fixture>}
-COMPOSE_BIN=${ARR_COMPOSE_BIN:-/home/khak1s/.docker/cli-plugins/docker-compose}
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-live-scenarios-$PROJECT_NAME.mjs
@@ -24,10 +24,6 @@ esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
-
-compose() {
-	"$COMPOSE_BIN" -p "$PROJECT_NAME" -f compose.yml -f compose.debug.yml "$@"
-}
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true

--- a/e2e/library-cleanup/run-live-scenario.sh
+++ b/e2e/library-cleanup/run-live-scenario.sh
@@ -7,8 +7,10 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
-export DOCKER_CONFIG
+if [ -z "${ARR_DOCKER_BIN:-}" ]; then
+	DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+	export DOCKER_CONFIG
+fi
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 MODE=${1:?Specify policy, delete:<fixture>, or episode:<fixture>}

--- a/e2e/library-cleanup/run-live-scenario.sh
+++ b/e2e/library-cleanup/run-live-scenario.sh
@@ -13,6 +13,7 @@ MODE=${1:?Specify policy, delete:<fixture>, or episode:<fixture>}
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-live-scenarios-$PROJECT_NAME.mjs
+DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
 export DOCKER_CONFIG
 
 case "$RUNNER_SERVICE" in
@@ -54,9 +55,32 @@ done
 
 case "$MODE" in
 	policy | policy-gate)
-		sync_started=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+		container_id=$(compose ps -q "$RUNNER_SERVICE")
+		if [ -z "$container_id" ]; then
+			echo "Policy gate refused: could not identify $RUNNER_SERVICE before restart." >&2
+			exit 1
+		fi
 		compose restart "$RUNNER_SERVICE"
 		compose up --no-build --wait "$RUNNER_SERVICE"
+		verify_live_project
+		restarted_container_id=$(compose ps -q "$RUNNER_SERVICE")
+		if [ "$restarted_container_id" != "$container_id" ]; then
+			echo "Policy gate refused: $RUNNER_SERVICE container identity changed during restart." >&2
+			exit 1
+		fi
+		container_project=$("$DOCKER_BIN" inspect "$restarted_container_id" \
+			--format '{{index .Config.Labels "com.docker.compose.project"}}')
+		container_service=$("$DOCKER_BIN" inspect "$restarted_container_id" \
+			--format '{{index .Config.Labels "com.docker.compose.service"}}')
+		if [ "$container_project" != "$PROJECT_NAME" ] || [ "$container_service" != "$RUNNER_SERVICE" ]; then
+			echo "Policy gate refused a container outside $PROJECT_NAME/$RUNNER_SERVICE after restart." >&2
+			exit 1
+		fi
+		sync_started=$("$DOCKER_BIN" inspect "$restarted_container_id" --format '{{.State.StartedAt}}')
+		if [ -z "$sync_started" ] || [ "$sync_started" = "0001-01-01T00:00:00Z" ]; then
+			echo "Policy gate refused: restarted $RUNNER_SERVICE has no precise StartedAt timestamp." >&2
+			exit 1
+		fi
 		sync_complete=0
 		for attempt in $(seq 1 30); do
 			if compose logs --no-color --since "$sync_started" "$RUNNER_SERVICE" 2>&1 |

--- a/e2e/library-cleanup/run-live-scenario.sh
+++ b/e2e/library-cleanup/run-live-scenario.sh
@@ -7,14 +7,14 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 	export COMPOSE_PROJECT_NAME
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
+export DOCKER_CONFIG
 . "$SCRIPT_DIR/compose-command.sh"
 . "$SCRIPT_DIR/live-project-guard.sh"
 MODE=${1:?Specify policy, delete:<fixture>, or episode:<fixture>}
-DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
 RUNNER_SCRIPT=/tmp/lc-e2e-live-scenarios-$PROJECT_NAME.mjs
 DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
-export DOCKER_CONFIG
 
 case "$RUNNER_SERVICE" in
 	dashboard-sqlite | dashboard-postgres) ;;

--- a/e2e/library-cleanup/run-live-scenario.sh
+++ b/e2e/library-cleanup/run-live-scenario.sh
@@ -8,6 +8,7 @@ if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
 fi
 PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
 MODE=${1:?Specify policy, delete:<fixture>, or episode:<fixture>}
 DOCKER_CONFIG=${DOCKER_CONFIG:-/tmp/lc-e2e-docker-config}
 RUNNER_SERVICE=${LC_E2E_DASHBOARD_SERVICE:-dashboard-sqlite}
@@ -24,6 +25,8 @@ esac
 
 cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 cleanup() {
 	compose exec -T --user 0 "$RUNNER_SERVICE" rm -f "$RUNNER_SCRIPT" >/dev/null 2>&1 || true
@@ -48,6 +51,27 @@ for service in radarr-a radarr-b sonarr-a sonarr-b plex plex-loopback-proxy qui-
 		exit 1
 	fi
 done
+
+case "$MODE" in
+	policy | policy-gate)
+		sync_started=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+		compose restart "$RUNNER_SERVICE"
+		compose up --no-build --wait "$RUNNER_SERVICE"
+		sync_complete=0
+		for attempt in $(seq 1 30); do
+			if compose logs --no-color --since "$sync_started" "$RUNNER_SERVICE" 2>&1 |
+				grep -Fq '"msg":"qUI torrent-state sync completed"'; then
+				sync_complete=1
+				break
+			fi
+			sleep 2
+		done
+		if [ "$sync_complete" -ne 1 ]; then
+			echo "Policy gate refused: qUI torrent-state sync did not complete after restart." >&2
+			exit 1
+		fi
+		;;
+esac
 
 radarr_a_key=$(extract_api_key radarr-a)
 radarr_b_key=$(extract_api_key radarr-b)

--- a/e2e/library-cleanup/run-live-scenario.test.sh
+++ b/e2e/library-cleanup/run-live-scenario.test.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-live-scenario-test.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/bin"
+cp "$SCRIPT_DIR/run-live-scenario.sh" "$TEMP_DIR/run-live-scenario.sh"
+
+cat >"$TEMP_DIR/compose-command.sh" <<'EOF'
+compose() {
+	case "$1" in
+		ps)
+			if [ "$2" = "-q" ]; then
+				printf '%s\n' runner-container-id
+			else
+				printf '%s\n' radarr-a radarr-b sonarr-a sonarr-b plex plex-loopback-proxy qui-a qui-b dashboard-sqlite
+			fi
+			;;
+		restart | up | cp) ;;
+		logs)
+			printf '%s\n' "$*" >>"$LC_E2E_TEST_LOG_ARGS"
+			case "$*" in
+				*--since\ 2026-08-10T12:00:00.123456789Z*) ;;
+				*) printf '%s\n' '{"msg":"qUI torrent-state sync completed"}' ;;
+			esac
+			;;
+		exec)
+			case "$*" in
+				*config.xml*) printf '%s\n' test-api-key ;;
+			esac
+			;;
+		*) echo "unexpected compose command: $*" >&2; return 1 ;;
+	esac
+}
+EOF
+
+cat >"$TEMP_DIR/live-project-guard.sh" <<'EOF'
+acquire_live_project_lock() { :; }
+verify_live_project() { :; }
+EOF
+
+cat >"$TEMP_DIR/validate-compose.sh" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$TEMP_DIR/validate-compose.sh"
+
+cat >"$TEMP_DIR/bin/docker" <<'EOF'
+#!/bin/sh
+case "$*" in
+	*'{{.State.StartedAt}}'*) printf '%s\n' 2026-08-10T12:00:00.123456789Z ;;
+	*'com.docker.compose.project'*) printf '%s\n' live-test-project ;;
+	*'com.docker.compose.service'*) printf '%s\n' dashboard-sqlite ;;
+	*) echo "unexpected docker inspect: $*" >&2; exit 1 ;;
+esac
+EOF
+cat >"$TEMP_DIR/bin/sleep" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod +x "$TEMP_DIR/bin/docker" "$TEMP_DIR/bin/sleep"
+
+set +e
+PATH="$TEMP_DIR/bin:$PATH" \
+	ARR_DOCKER_BIN=docker \
+	COMPOSE_PROJECT_NAME=live-test-project \
+	LC_E2E_TEST_LOG_ARGS="$TEMP_DIR/log-args" \
+	sh "$TEMP_DIR/run-live-scenario.sh" policy-gate >"$TEMP_DIR/output" 2>&1
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+	echo "policy gate accepted a stale qUI completion from before restart." >&2
+	exit 1
+fi
+if ! grep -Fq 'Policy gate refused: qUI torrent-state sync did not complete after restart.' "$TEMP_DIR/output"; then
+	echo "policy gate did not reject the stale qUI completion." >&2
+	cat "$TEMP_DIR/output" >&2
+	exit 1
+fi
+if ! grep -Fq -- '--since 2026-08-10T12:00:00.123456789Z' "$TEMP_DIR/log-args"; then
+	echo "policy gate did not bind log evidence to the restarted container StartedAt." >&2
+	exit 1
+fi
+
+echo "live scenario rejects stale same-second qUI logs"

--- a/e2e/library-cleanup/start-profile.sh
+++ b/e2e/library-cleanup/start-profile.sh
@@ -37,6 +37,7 @@ cd "$SCRIPT_DIR"
 sh ./validate-compose.sh --live-project "$PROJECT_NAME"
 acquire_live_project_lock
 verify_live_project --allow-empty
+verify_dashboard_profile "$service"
 
 if [ "$no_build" -eq 1 ]; then
 	compose --profile "$compose_profile" up --no-build --wait "$service"
@@ -44,3 +45,4 @@ else
 	compose --profile "$compose_profile" up --wait "$service"
 fi
 verify_live_project
+verify_dashboard_profile "$service" --require-running

--- a/e2e/library-cleanup/start-profile.sh
+++ b/e2e/library-cleanup/start-profile.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
+	COMPOSE_PROJECT_NAME=$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' "$SCRIPT_DIR/.env" | tail -n 1)
+	export COMPOSE_PROJECT_NAME
+fi
+PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+PROFILE=${1:?Specify sqlite, postgres, or baseline}
+. "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
+
+case "$PROFILE" in
+	sqlite)
+		compose_profile=candidate-sqlite
+		service=dashboard-sqlite
+		no_build=1
+		;;
+	postgres)
+		compose_profile=candidate-postgres
+		service=dashboard-postgres
+		no_build=1
+		;;
+	baseline)
+		compose_profile=baseline
+		service=dashboard-baseline
+		no_build=0
+		;;
+	*)
+		echo "Harness start refused: profile must be sqlite, postgres, or baseline." >&2
+		exit 2
+		;;
+esac
+
+cd "$SCRIPT_DIR"
+sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project --allow-empty
+
+if [ "$no_build" -eq 1 ]; then
+	compose --profile "$compose_profile" up --no-build --wait "$service"
+else
+	compose --profile "$compose_profile" up --wait "$service"
+fi
+verify_live_project

--- a/e2e/library-cleanup/stop-profile.sh
+++ b/e2e/library-cleanup/stop-profile.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+if [ -z "${COMPOSE_PROJECT_NAME:-}" ] && [ -f "$SCRIPT_DIR/.env" ]; then
+	COMPOSE_PROJECT_NAME=$(sed -n 's/^COMPOSE_PROJECT_NAME=//p' "$SCRIPT_DIR/.env" | tail -n 1)
+	export COMPOSE_PROJECT_NAME
+fi
+PROJECT_NAME=${COMPOSE_PROJECT_NAME:?Set the unique live COMPOSE_PROJECT_NAME}
+PROFILE=${1:?Specify sqlite, postgres, or baseline}
+. "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
+
+case "$PROFILE" in
+	sqlite) service=dashboard-sqlite ;;
+	postgres) service=dashboard-postgres ;;
+	baseline) service=dashboard-baseline ;;
+	*)
+		echo "Harness stop refused: profile must be sqlite, postgres, or baseline." >&2
+		exit 2
+		;;
+esac
+
+cd "$SCRIPT_DIR"
+sh ./validate-compose.sh --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
+compose stop "$service"
+verify_live_project

--- a/e2e/library-cleanup/teardown.sh
+++ b/e2e/library-cleanup/teardown.sh
@@ -15,6 +15,10 @@ if [ "$PROJECT_NAME" != "$CONFIRMED_PROJECT" ]; then
   exit 1
 fi
 
+COMPOSE_PROJECT_NAME=$PROJECT_NAME
+export COMPOSE_PROJECT_NAME
+. "$SCRIPT_DIR/compose-command.sh"
+
 TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-teardown.XXXXXX")
 trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
 umask 077
@@ -30,11 +34,8 @@ export POSTGRES_PASSWORD_FILE PLEX_CLAIM_FILE
 sh "$SCRIPT_DIR/validate-compose.sh" --live-project "$PROJECT_NAME"
 
 echo "Removing only disposable project $PROJECT_NAME, including its named volumes."
-docker compose \
-  -p "$PROJECT_NAME" \
-  --profile candidate-sqlite \
+compose \
+	--profile candidate-sqlite \
   --profile candidate-postgres \
   --profile baseline \
-  -f "$SCRIPT_DIR/compose.yml" \
-  -f "$SCRIPT_DIR/compose.debug.yml" \
-  down --volumes --remove-orphans
+	down --volumes --remove-orphans

--- a/e2e/library-cleanup/teardown.sh
+++ b/e2e/library-cleanup/teardown.sh
@@ -18,6 +18,7 @@ fi
 COMPOSE_PROJECT_NAME=$PROJECT_NAME
 export COMPOSE_PROJECT_NAME
 . "$SCRIPT_DIR/compose-command.sh"
+. "$SCRIPT_DIR/live-project-guard.sh"
 
 TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/lc-e2e-teardown.XXXXXX")
 trap 'rm -rf "$TEMP_DIR"' EXIT HUP INT TERM
@@ -32,6 +33,8 @@ export POSTGRES_PASSWORD_FILE PLEX_CLAIM_FILE
 # names; checks the exact harness service/model contract; validates secrets;
 # and accepts no caller-supplied Compose files or external paths.
 sh "$SCRIPT_DIR/validate-compose.sh" --live-project "$PROJECT_NAME"
+acquire_live_project_lock
+verify_live_project
 
 echo "Removing only disposable project $PROJECT_NAME, including its named volumes."
 compose \

--- a/e2e/library-cleanup/validate-compose.sh
+++ b/e2e/library-cleanup/validate-compose.sh
@@ -20,6 +20,11 @@ elif [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
   export COMPOSE_PROJECT_NAME
 fi
 
+if [ "$REQUIRE_LIVE_NAME" -eq 0 ] && [ -z "${LC_E2E_RUN_TOKEN:-}" ]; then
+  LC_E2E_RUN_TOKEN=0000000000000000000000000000000000000000000000000000000000000000
+  export LC_E2E_RUN_TOKEN
+fi
+
 . "$SCRIPT_DIR/compose-command.sh"
 
 if ! compose version >/dev/null 2>&1; then

--- a/e2e/library-cleanup/validate-compose.sh
+++ b/e2e/library-cleanup/validate-compose.sh
@@ -5,15 +5,6 @@ SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)
 REQUIRE_LIVE_NAME=0
 EXPECTED_PROJECT=""
-DOCKER_BIN=${ARR_DOCKER_BIN:-docker}
-
-run_compose() {
-  if [ -n "${ARR_COMPOSE_BIN:-}" ]; then
-    "$ARR_COMPOSE_BIN" "$@"
-  else
-    "$DOCKER_BIN" compose "$@"
-  fi
-}
 
 if [ "$#" -gt 0 ]; then
   if [ "$#" -ne 2 ] || [ "$1" != "--live-project" ]; then
@@ -29,7 +20,9 @@ elif [ -z "${COMPOSE_PROJECT_NAME:-}" ]; then
   export COMPOSE_PROJECT_NAME
 fi
 
-if ! run_compose version >/dev/null 2>&1; then
+. "$SCRIPT_DIR/compose-command.sh"
+
+if ! compose version >/dev/null 2>&1; then
   echo "Docker Compose v2 is not available." >&2
   exit 2
 fi
@@ -71,12 +64,11 @@ check_base_model() {
   fi
 }
 
-run_compose \
+compose_base \
   --profile candidate-sqlite \
   --profile candidate-postgres \
   --profile baseline \
-  -f compose.yml \
-  config --format json | check_base_model
+	config --format json | check_base_model
 
 check_debug_model() {
   if [ "$REQUIRE_LIVE_NAME" -eq 1 ]; then
@@ -88,12 +80,10 @@ check_debug_model() {
   fi
 }
 
-run_compose \
+compose \
   --profile candidate-sqlite \
   --profile candidate-postgres \
   --profile baseline \
-  -f compose.yml \
-  -f compose.debug.yml \
-  config --format json | check_debug_model
+	config --format json | check_debug_model
 
 echo "Compose syntax and safety checks passed without building, pulling, or starting services."


### PR DESCRIPTION
## Summary

- pin reviewed multi-architecture Radarr, Sonarr, Plex, and qBittorrent images and authenticate qBittorrent bootstrap sessions
- make ARR and Plex fixture setup converge deterministically while preserving exact identity, cross-instance, and file-retention checks
- use one portable Compose v2 command path across validation, bootstrap, scenarios, startup, and teardown
- keep Docker ownership checks and Compose mutations on the same configured daemon, with fail-closed override conflicts
- preserve caller Docker configuration for explicit CLI wrappers and isolate configuration only for auto-discovered Docker
- label and verify every disposable container, volume, and network; reject exact-name foreign resources before startup and prevent concurrent dashboard profiles
- retain candidate/image/source provenance for browser evidence and require a precise post-restart qUI synchronization generation

## Regression coverage

- added request-level duplicate-reset coverage for repeated authorization snapshots, bodyless `DELETE`, `deleteFiles=false`, absence verification, recreation, final convergence, and retained media
- added negative tests for Compose fallback/override paths, Docker/Compose override conflicts, exact-name Docker resource collisions, profile exclusivity, stale same-second qUI logs, candidate provenance, and absolute file identity mismatches
- focused harness suite: 33 Node tests plus all shell ownership, Compose, provenance, and scenario tests passed

## Validation

- `pnpm run typecheck`
- `pnpm run test` — API 3,791, web 617, shared 89 passed
- `pnpm run lint`
- `pnpm run build`
- exact-image SQLite and PostgreSQL bootstraps, qUI policy gates, and signed Chromium rule round-trips
- exact `a40f84aa` image passed the populated live scenario through a configured Docker wrapper whose path contains a space
- real SQLite Radarr UHD deletion retained the HD copy, shared Plex identity, and all qUI source torrents; fixture restore passed
- real foreign-volume collision was refused before container creation; PostgreSQL startup was refused while SQLite was active
- guarded teardown left zero project containers, volumes, or networks
- independent data-safety and regression closure reviews found no blocker

## Known baseline check

`pnpm run format` still reports the four OIDC files already unformatted on `origin/main`; none are changed by this branch. All changed JavaScript and Markdown pass their focused format and diff checks.

Closes #690