### PR TITLE
docs: make local handover loading conditional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,11 @@
 # AGENTS.md — arr-dashboard
 
-Read `CLAUDE.md` for the tracked architecture and pattern reference. If a local
-`HANDOVER.md` exists, read it for machine-specific state and recent project
-history; do not assume it exists in a fresh clone.
+Read `CLAUDE.md` for the tracked architecture and pattern reference. A local
+`HANDOVER.md`, when present, is an optional machine-state snapshot: read it only
+when the task depends on the maintainer environment, local checkout state, or
+live instances. Do not load it for repository-only work, treat it as project
+policy, or use it as a credential source. Verify its volatile details before
+acting, and do not assume it exists in a fresh clone.
 
 Codex-native task workflows live in `.agents/skills/` and are automatically
 discoverable. Use the matching `arr-*` skill for issue fixes, validation,


### PR DESCRIPTION
## Summary

- Treat a local `HANDOVER.md` as an optional machine-state snapshot.
- Load it only for tasks that depend on the maintainer environment, local checkout state, or live instances.
- Clarify that it is neither project policy nor a credential source and that volatile details must be verified.

## Why

This keeps repository-only work from consuming stale local context and avoids encouraging machine-specific or authentication details in tracked guidance.

## Validation

- `pnpm run typecheck` — passed
- `pnpm run test` — passed (4 Turbo tasks)
- `pnpm run lint` — passed
- Public diff privacy scan — passed; only `AGENTS.md` is changed, with no local paths, endpoints, or credentials
- `pnpm run format` — currently fails on four unchanged OIDC files already present in `origin/main`; this documentation-only branch does not modify those files

## Risk

Documentation-only. No application runtime, API, persistence, or user-visible behavior changes.