### PR TITLE
fix(plex): ignore stale history outside current library

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -146,13 +146,15 @@ function makeDeps(
 describe("authoritative mutation policy snapshots", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		refreshMocks.plex.mockResolvedValue({
+		refreshMocks.plex.mockImplementation(async (_client, _prisma, instanceId: string) => ({
 			upserted: 0,
 			errors: 0,
 			errorMessages: [],
 			complete: true,
 			completedAt: new Date(),
-		});
+			generationId: `generation-${instanceId}`,
+			inventoryTargets: [],
+		}));
 		refreshMocks.plexEpisodes.mockResolvedValue({
 			upserted: 0,
 			errors: 0,
@@ -264,6 +266,23 @@ describe("authoritative mutation policy snapshots", () => {
 		expect(refreshMocks.plexEpisodes).toHaveBeenCalledOnce();
 	});
 
+	it("rejects inventory identities that do not belong to the published Plex generation", async () => {
+		refreshMocks.plex.mockResolvedValue({
+			upserted: 0,
+			errors: 0,
+			errorMessages: [],
+			complete: true,
+			completedAt: new Date(),
+			generationId: "different-generation",
+			inventoryTargets: [],
+		});
+		const { deps } = makeDeps([rule("plex_watch_count")], [instance("PLEX")]);
+
+		const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
+
+		expect(snapshot.failedSources).toEqual(new Set(["plex"]));
+	});
+
 	it("excludes disabled Plex episode caches from refreshed authority", async () => {
 		const { deps, findInstances } = makeDeps([rule("plex_episode_completion")], [instance("PLEX")]);
 
@@ -336,13 +355,117 @@ describe("authoritative mutation policy snapshots", () => {
 	});
 
 	it.each([
-		["Radarr", "blocks", "RADARR", "movie", true],
-		["Sonarr", "blocks", "SONARR", "series", true],
-		["Radarr", "allows", "RADARR", "movie", false],
-		["Sonarr", "allows", "SONARR", "series", false],
+		[
+			"Radarr",
+			"blocks an added target",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84"],
+			["plex-a-84"],
+			["plex-b-84"],
+			true,
+			false,
+		],
+		[
+			"Sonarr",
+			"blocks an added target",
+			"SONARR",
+			"series",
+			[],
+			["plex-b-84"],
+			["plex-a-84"],
+			["plex-b-84"],
+			true,
+			false,
+		],
+		[
+			"Radarr",
+			"allows unchanged identity",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84"],
+			[],
+			["plex-b-84"],
+			false,
+			false,
+		],
+		[
+			"Sonarr",
+			"allows unchanged identity",
+			"SONARR",
+			"series",
+			[],
+			["plex-b-84"],
+			[],
+			["plex-b-84"],
+			false,
+			false,
+		],
+		[
+			"Sonarr",
+			"allows unchanged identity without an optional TMDb ID",
+			"SONARR",
+			"series",
+			[],
+			["plex-b-84"],
+			[],
+			["plex-b-84"],
+			false,
+			true,
+		],
+		[
+			"Radarr",
+			"blocks a disappeared target",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84"],
+			[],
+			[],
+			true,
+			false,
+		],
+		[
+			"Sonarr",
+			"blocks a disappeared target",
+			"SONARR",
+			"series",
+			[],
+			["plex-b-84"],
+			[],
+			[],
+			true,
+			false,
+		],
+		[
+			"Radarr",
+			"allows unchanged duplicate editions",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84-a", "plex-b-84-b"],
+			[],
+			["plex-b-84-a", "plex-b-84-b"],
+			false,
+			false,
+		],
+		[
+			"Sonarr",
+			"allows unchanged duplicate editions",
+			"SONARR",
+			"series",
+			[],
+			["plex-b-84-a", "plex-b-84-b"],
+			[],
+			["plex-b-84-a", "plex-b-84-b"],
+			false,
+			false,
+		],
 	] as const)(
-		"%s %s a Plex-authorized delete after final target revalidation",
-		async (_label, expectedOutcome, service, mediaType, becomesCurrent) => {
+		"%s %s after final target revalidation",
+		async (_label, _expectedBehavior, service, mediaType, plexATargetsAtSnapshot, plexBTargetsAtSnapshot, plexATargetsAtMutation, plexBTargetsAtMutation, expectedToBlock, omitSonarrTmdbId) => {
 			const plexA = { ...instance("PLEX"), id: "plex-a", name: "Plex A" };
 			const plexB = { ...instance("PLEX"), id: "plex-b", name: "Plex B" };
 			const plexRule = {
@@ -353,7 +476,21 @@ describe("authoritative mutation policy snapshots", () => {
 				action: "delete",
 				scanMediaServerAfterDelete: false,
 			};
-			const { deps } = makeDeps([plexRule], [plexA, plexB]);
+			const matchedRule = omitSonarrTmdbId
+				? {
+						...rule("age"),
+						parameters: JSON.stringify({ operator: "older_than", days: 0 }),
+						serviceFilter: JSON.stringify([service]),
+						targetScope: "series",
+						action: "delete",
+						scanMediaServerAfterDelete: false,
+					}
+				: plexRule;
+			const plexDependencyRule = omitSonarrTmdbId ? { ...plexRule, priority: 2 } : plexRule;
+			const { deps } = makeDeps(omitSonarrTmdbId ? [matchedRule, plexDependencyRule] : [plexRule], [
+				plexA,
+				plexB,
+			]);
 			const publishedRow = {
 				id: "plex-row-b",
 				instanceId: plexB.id,
@@ -361,7 +498,7 @@ describe("authoritative mutation policy snapshots", () => {
 				mediaType,
 				sectionId: "movies",
 				sectionTitle: "Movies",
-				ratingKey: "plex-b-84",
+				ratingKey: plexBTargetsAtSnapshot[0] ?? null,
 				lastWatchedAt: null,
 				watchCount: 0,
 				watchedByUsers: "[]",
@@ -378,6 +515,8 @@ describe("authoritative mutation policy snapshots", () => {
 				where: { instanceId: string };
 			}) => (where.instanceId === plexB.id ? 1 : 0)) as never);
 			const publishedAt = new Date();
+			const generationIds = new Map<string, string>();
+			let refreshCallCount = 0;
 			vi.mocked(deps.prisma.cacheRefreshStatus.findMany).mockImplementation((async ({
 				where,
 			}: {
@@ -388,7 +527,7 @@ describe("authoritative mutation policy snapshots", () => {
 					lastRefreshedAt: publishedAt,
 					lastResult: "success",
 					itemCount: instanceId === plexB.id ? 1 : 0,
-					generationId: `generation-${instanceId}`,
+					generationId: generationIds.get(instanceId),
 					generationMetadata: JSON.stringify({
 						sections: [{ key: "movies", title: "Movies", type: "movie" }],
 					}),
@@ -396,13 +535,34 @@ describe("authoritative mutation policy snapshots", () => {
 					lastAttemptResult: "success",
 					lastAttemptErrorMessage: null,
 				}))) as never);
+			refreshMocks.plex.mockImplementation(async (_client, _prisma, instanceId: string) => {
+				const pass = Math.floor(refreshCallCount / 2) + 1;
+				refreshCallCount++;
+				const generationId = `generation-${pass}-${instanceId}`;
+				generationIds.set(instanceId, generationId);
+				return {
+					upserted: instanceId === plexB.id ? 1 : 0,
+					errors: 0,
+					errorMessages: [],
+					complete: true,
+					completedAt: publishedAt,
+					generationId,
+					inventoryTargets: (instanceId === plexA.id
+						? plexATargetsAtSnapshot
+						: plexBTargetsAtSnapshot
+					).map((ratingKey) => ({
+						mediaType,
+						tmdbId: 84,
+						...(mediaType === "series" ? { tvdbId: 84 } : {}),
+						ratingKey,
+					})),
+				};
+			});
 
 			const currentTargets = (plexInstanceId: string) =>
-				plexInstanceId === plexA.id
-					? becomesCurrent
-						? [{ ratingKey: "plex-a-84" }]
-						: []
-					: [{ ratingKey: "plex-b-84" }];
+				(plexInstanceId === plexA.id ? plexATargetsAtMutation : plexBTargetsAtMutation).map(
+					(ratingKey) => ({ ratingKey }),
+				);
 			deps.plexCacheClientFactory = vi.fn(
 				(plexInstance) =>
 					({
@@ -428,7 +588,9 @@ describe("authoritative mutation policy snapshots", () => {
 			};
 			const rawItem = {
 				id: 101,
-				...(service === "RADARR" ? { tmdbId: 84 } : { tvdbId: 84, tmdbId: 84 }),
+				...(service === "RADARR"
+					? { tmdbId: 84 }
+					: { tvdbId: 84, ...(omitSonarrTmdbId ? {} : { tmdbId: 84 }) }),
 				title: `Example ${_label} Item`,
 				path: `/media/example-${service.toLowerCase()}`,
 				monitored: true,
@@ -458,7 +620,7 @@ describe("authoritative mutation policy snapshots", () => {
 					arrInstance as never,
 					101,
 					{
-						matchedRuleId: plexRule.id,
+						matchedRuleId: matchedRule.id,
 						action: "delete",
 						scanMediaServerAfterDelete: false,
 					},
@@ -466,7 +628,7 @@ describe("authoritative mutation policy snapshots", () => {
 				);
 				await deleteMovieFile();
 			};
-			if (expectedOutcome === "blocks") {
+			if (expectedToBlock) {
 				await expect(executeAuthorizedDelete()).rejects.toThrow(
 					/provider evidence could not re-authorize/i,
 				);

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -408,6 +408,19 @@ describe("authoritative mutation policy snapshots", () => {
 			true,
 		],
 		[
+			"Radarr",
+			"blocks a live ARR policy change during the Plex refresh",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84"],
+			[],
+			["plex-b-84"],
+			true,
+			false,
+			false,
+		],
+		[
 			"Sonarr",
 			"allows unchanged identity",
 			"SONARR",
@@ -488,6 +501,8 @@ describe("authoritative mutation policy snapshots", () => {
 	] as const)(
 		"%s %s after final target revalidation",
 		async (_label, _expectedBehavior, service, mediaType, plexATargetsAtSnapshot, plexBTargetsAtSnapshot, plexATargetsAtMutation, plexBTargetsAtMutation, expectedToBlock, omitSonarrTmdbId, policyChangesAfterSnapshot) => {
+			const arrPolicyChangesDuringRefresh =
+				_expectedBehavior === "blocks a live ARR policy change during the Plex refresh";
 			const plexA = { ...instance("PLEX"), id: "plex-a", name: "Plex A" };
 			const plexB = { ...instance("PLEX"), id: "plex-b", name: "Plex B" };
 			const plexRule = {
@@ -511,10 +526,21 @@ describe("authoritative mutation policy snapshots", () => {
 					}
 				: plexRule;
 			const plexDependencyRule = omitSonarrTmdbId ? { ...plexRule, priority: 2 } : plexRule;
-			const { deps } = makeDeps(omitSonarrTmdbId ? [matchedRule, plexDependencyRule] : [plexRule], [
-				plexA,
-				plexB,
-			]);
+			const liveRetentionRule = {
+				...rule("monitored"),
+				id: "retain-monitored",
+				priority: 0,
+				parameters: "{}",
+				serviceFilter: JSON.stringify([service]),
+				targetScope: "series",
+				retentionMode: true,
+			};
+			const snapshotRules = arrPolicyChangesDuringRefresh
+				? [liveRetentionRule, plexRule]
+				: omitSonarrTmdbId
+					? [matchedRule, plexDependencyRule]
+					: [plexRule];
+			const { deps } = makeDeps(snapshotRules, [plexA, plexB]);
 			let refreshCallCount = 0;
 			let policyChangedDuringTargetLookup = false;
 			const publishedRow = {
@@ -624,7 +650,7 @@ describe("authoritative mutation policy snapshots", () => {
 					: { tvdbId: 84, ...(omitSonarrTmdbId ? {} : { tmdbId: 84 }) }),
 				title: `Example ${_label} Item`,
 				path: `/media/example-${service.toLowerCase()}`,
-				monitored: true,
+				monitored: !arrPolicyChangesDuringRefresh,
 				status: "ended",
 				qualityProfileId: 1,
 				sizeOnDisk: 2_000,
@@ -634,11 +660,16 @@ describe("authoritative mutation policy snapshots", () => {
 						? { movieFileCount: 1, sizeOnDisk: 2_000 }
 						: { episodeFileCount: 1, sizeOnDisk: 2_000 },
 			};
+			const getById = vi
+				.fn()
+				.mockResolvedValueOnce(rawItem)
+				.mockResolvedValue({
+					...rawItem,
+					monitored: arrPolicyChangesDuringRefresh ? true : rawItem.monitored,
+				});
 			deps.arrClientFactory = {
 				create: vi.fn(() =>
-					service === "RADARR"
-						? { movie: { getById: vi.fn().mockResolvedValue(rawItem) } }
-						: { series: { getById: vi.fn().mockResolvedValue(rawItem) } },
+					service === "RADARR" ? { movie: { getById } } : { series: { getById } },
 				),
 			} as never;
 			const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
@@ -670,6 +701,77 @@ describe("authoritative mutation policy snapshots", () => {
 			}
 		},
 	);
+
+	it("allows a non-Plex winner when only a lower-priority cleanup rule needs unavailable Plex evidence", async () => {
+		const plex = instance("PLEX");
+		const ageRule = {
+			...rule("age"),
+			priority: 1,
+			parameters: JSON.stringify({ operator: "older_than", days: 0 }),
+			serviceFilter: JSON.stringify(["RADARR"]),
+			targetScope: "series",
+			action: "delete",
+			scanMediaServerAfterDelete: false,
+		};
+		const lowerPlexRule = {
+			...rule("plex_last_watched"),
+			priority: 2,
+			parameters: JSON.stringify({ operator: "never" }),
+			serviceFilter: JSON.stringify(["RADARR"]),
+			targetScope: "series",
+			action: "delete",
+			scanMediaServerAfterDelete: false,
+		};
+		refreshMocks.plex.mockResolvedValue({
+			upserted: 0,
+			errors: 1,
+			errorMessages: ["Plex unavailable"],
+			complete: false,
+			completedAt: new Date(),
+		});
+		const { deps } = makeDeps([ageRule, lowerPlexRule], [plex]);
+		const rawItem = {
+			id: 101,
+			tmdbId: 84,
+			title: "Example Radarr Item",
+			path: "/media/example-radarr",
+			monitored: true,
+			status: "released",
+			qualityProfileId: 1,
+			sizeOnDisk: 2_000,
+			added: "2025-01-01T00:00:00.000Z",
+			statistics: { movieFileCount: 1, sizeOnDisk: 2_000 },
+		};
+		const getById = vi.fn().mockResolvedValue(rawItem);
+		deps.arrClientFactory = {
+			create: vi.fn(() => ({ movie: { getById } })),
+		} as never;
+		const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
+		const radarr = {
+			...instance("PLEX"),
+			id: "radarr-1",
+			name: "Radarr",
+			service: "RADARR",
+			baseUrl: "http://radarr.test",
+		};
+
+		expect(snapshot.failedSources).toContain("plex");
+		await expect(
+			assertCurrentSeriesMutationAuthority(
+				deps,
+				"user-1",
+				radarr as never,
+				101,
+				{
+					matchedRuleId: ageRule.id,
+					action: "delete",
+					scanMediaServerAfterDelete: false,
+				},
+				snapshot,
+			),
+		).resolves.toMatchObject({ rawItem });
+		expect(getById).toHaveBeenCalledOnce();
+	});
 });
 
 describe("interactive preview live watch authority", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -366,6 +366,7 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84"],
 			true,
 			false,
+			false,
 		],
 		[
 			"Sonarr",
@@ -377,6 +378,7 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-a-84"],
 			["plex-b-84"],
 			true,
+			false,
 			false,
 		],
 		[
@@ -390,6 +392,20 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84"],
 			false,
 			false,
+			false,
+		],
+		[
+			"Radarr",
+			"blocks a mutable policy change with unchanged identity",
+			"RADARR",
+			"movie",
+			[],
+			["plex-b-84"],
+			[],
+			["plex-b-84"],
+			true,
+			false,
+			true,
 		],
 		[
 			"Sonarr",
@@ -400,6 +416,7 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84"],
 			[],
 			["plex-b-84"],
+			false,
 			false,
 			false,
 		],
@@ -414,6 +431,7 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84"],
 			false,
 			true,
+			false,
 		],
 		[
 			"Radarr",
@@ -425,6 +443,7 @@ describe("authoritative mutation policy snapshots", () => {
 			[],
 			[],
 			true,
+			false,
 			false,
 		],
 		[
@@ -438,6 +457,7 @@ describe("authoritative mutation policy snapshots", () => {
 			[],
 			true,
 			false,
+			false,
 		],
 		[
 			"Radarr",
@@ -450,6 +470,7 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84-a", "plex-b-84-b"],
 			false,
 			false,
+			false,
 		],
 		[
 			"Sonarr",
@@ -460,17 +481,20 @@ describe("authoritative mutation policy snapshots", () => {
 			["plex-b-84-a", "plex-b-84-b"],
 			[],
 			["plex-b-84-a", "plex-b-84-b"],
+			false,
 			false,
 			false,
 		],
 	] as const)(
 		"%s %s after final target revalidation",
-		async (_label, _expectedBehavior, service, mediaType, plexATargetsAtSnapshot, plexBTargetsAtSnapshot, plexATargetsAtMutation, plexBTargetsAtMutation, expectedToBlock, omitSonarrTmdbId) => {
+		async (_label, _expectedBehavior, service, mediaType, plexATargetsAtSnapshot, plexBTargetsAtSnapshot, plexATargetsAtMutation, plexBTargetsAtMutation, expectedToBlock, omitSonarrTmdbId, policyChangesAfterSnapshot) => {
 			const plexA = { ...instance("PLEX"), id: "plex-a", name: "Plex A" };
 			const plexB = { ...instance("PLEX"), id: "plex-b", name: "Plex B" };
 			const plexRule = {
-				...rule("plex_last_watched"),
-				parameters: JSON.stringify({ operator: "never" }),
+				...rule(policyChangesAfterSnapshot ? "plex_on_deck" : "plex_last_watched"),
+				parameters: JSON.stringify(
+					policyChangesAfterSnapshot ? { isDeck: false } : { operator: "never" },
+				),
 				serviceFilter: JSON.stringify([service]),
 				targetScope: "series",
 				action: "delete",
@@ -491,6 +515,8 @@ describe("authoritative mutation policy snapshots", () => {
 				plexA,
 				plexB,
 			]);
+			let refreshCallCount = 0;
+			let policyChangedDuringTargetLookup = false;
 			const publishedRow = {
 				id: "plex-row-b",
 				instanceId: plexB.id,
@@ -508,7 +534,12 @@ describe("authoritative mutation policy snapshots", () => {
 				labels: "[]",
 				addedAt: new Date("2025-01-01T00:00:00.000Z"),
 			};
-			vi.mocked(deps.prisma.plexCache.findMany).mockResolvedValue([publishedRow] as never);
+			vi.mocked(deps.prisma.plexCache.findMany).mockImplementation((async () => [
+				{
+					...publishedRow,
+					onDeck: policyChangesAfterSnapshot && policyChangedDuringTargetLookup,
+				},
+			]) as never);
 			vi.mocked(deps.prisma.plexCache.count).mockImplementation((async ({
 				where,
 			}: {
@@ -516,7 +547,6 @@ describe("authoritative mutation policy snapshots", () => {
 			}) => (where.instanceId === plexB.id ? 1 : 0)) as never);
 			const publishedAt = new Date();
 			const generationIds = new Map<string, string>();
-			let refreshCallCount = 0;
 			vi.mocked(deps.prisma.cacheRefreshStatus.findMany).mockImplementation((async ({
 				where,
 			}: {
@@ -563,15 +593,16 @@ describe("authoritative mutation policy snapshots", () => {
 				(plexInstanceId === plexA.id ? plexATargetsAtMutation : plexBTargetsAtMutation).map(
 					(ratingKey) => ({ ratingKey }),
 				);
-			deps.plexCacheClientFactory = vi.fn(
-				(plexInstance) =>
-					({
-						getMovieMediaPartsByTmdbId: vi.fn().mockResolvedValue(currentTargets(plexInstance.id)),
-						getSeriesEpisodeMediaPartsByTvdbId: vi
-							.fn()
-							.mockResolvedValue(currentTargets(plexInstance.id)),
-					}) as never,
-			);
+			deps.plexCacheClientFactory = vi.fn((plexInstance) => {
+				const readCurrentTargets = async () => {
+					if (policyChangesAfterSnapshot) policyChangedDuringTargetLookup = true;
+					return currentTargets(plexInstance.id);
+				};
+				return {
+					getMovieMediaPartsByTmdbId: vi.fn(readCurrentTargets),
+					getSeriesEpisodeMediaPartsByTvdbId: vi.fn(readCurrentTargets),
+				} as never;
+			});
 			const arrInstance = {
 				id: `${service.toLowerCase()}-1`,
 				userId: "user-1",

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	assertCurrentSeriesMutationAuthority,
 	createMutationPolicySnapshotGetter,
 	executeCleanupPreview,
 	MUTATION_POLICY_SNAPSHOT_MAX_AGE_MS,
@@ -70,8 +71,8 @@ function instance(service: "PLEX" | "TAUTULLI" | "JELLYFIN") {
 }
 
 function makeDeps(
-	rules: ReturnType<typeof rule>[],
-	instances = [] as ReturnType<typeof instance>[],
+	rules: Array<Record<string, unknown>>,
+	instances = [] as Array<Record<string, unknown> & { id: string; service: string }>,
 ) {
 	const findConfig = vi.fn().mockResolvedValue({
 		id: "config-1",
@@ -333,6 +334,149 @@ describe("authoritative mutation policy snapshots", () => {
 		expect(findInstances).not.toHaveBeenCalled();
 		expect(refreshMocks.plex).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		["Radarr", "blocks", "RADARR", "movie", true],
+		["Sonarr", "blocks", "SONARR", "series", true],
+		["Radarr", "allows", "RADARR", "movie", false],
+		["Sonarr", "allows", "SONARR", "series", false],
+	] as const)(
+		"%s %s a Plex-authorized delete after final target revalidation",
+		async (_label, expectedOutcome, service, mediaType, becomesCurrent) => {
+			const plexA = { ...instance("PLEX"), id: "plex-a", name: "Plex A" };
+			const plexB = { ...instance("PLEX"), id: "plex-b", name: "Plex B" };
+			const plexRule = {
+				...rule("plex_last_watched"),
+				parameters: JSON.stringify({ operator: "never" }),
+				serviceFilter: JSON.stringify([service]),
+				targetScope: "series",
+				action: "delete",
+				scanMediaServerAfterDelete: false,
+			};
+			const { deps } = makeDeps([plexRule], [plexA, plexB]);
+			const publishedRow = {
+				id: "plex-row-b",
+				instanceId: plexB.id,
+				tmdbId: 84,
+				mediaType,
+				sectionId: "movies",
+				sectionTitle: "Movies",
+				ratingKey: "plex-b-84",
+				lastWatchedAt: null,
+				watchCount: 0,
+				watchedByUsers: "[]",
+				onDeck: false,
+				userRating: null,
+				collections: "[]",
+				labels: "[]",
+				addedAt: new Date("2025-01-01T00:00:00.000Z"),
+			};
+			vi.mocked(deps.prisma.plexCache.findMany).mockResolvedValue([publishedRow] as never);
+			vi.mocked(deps.prisma.plexCache.count).mockImplementation((async ({
+				where,
+			}: {
+				where: { instanceId: string };
+			}) => (where.instanceId === plexB.id ? 1 : 0)) as never);
+			const publishedAt = new Date();
+			vi.mocked(deps.prisma.cacheRefreshStatus.findMany).mockImplementation((async ({
+				where,
+			}: {
+				where: { instanceId: { in: string[] } };
+			}) =>
+				where.instanceId.in.map((instanceId) => ({
+					instanceId,
+					lastRefreshedAt: publishedAt,
+					lastResult: "success",
+					itemCount: instanceId === plexB.id ? 1 : 0,
+					generationId: `generation-${instanceId}`,
+					generationMetadata: JSON.stringify({
+						sections: [{ key: "movies", title: "Movies", type: "movie" }],
+					}),
+					lastErrorMessage: null,
+					lastAttemptResult: "success",
+					lastAttemptErrorMessage: null,
+				}))) as never);
+
+			const currentTargets = (plexInstanceId: string) =>
+				plexInstanceId === plexA.id
+					? becomesCurrent
+						? [{ ratingKey: "plex-a-84" }]
+						: []
+					: [{ ratingKey: "plex-b-84" }];
+			deps.plexCacheClientFactory = vi.fn(
+				(plexInstance) =>
+					({
+						getMovieMediaPartsByTmdbId: vi.fn().mockResolvedValue(currentTargets(plexInstance.id)),
+						getSeriesEpisodeMediaPartsByTvdbId: vi
+							.fn()
+							.mockResolvedValue(currentTargets(plexInstance.id)),
+					}) as never,
+			);
+			const arrInstance = {
+				id: `${service.toLowerCase()}-1`,
+				userId: "user-1",
+				name: _label,
+				service,
+				baseUrl: `http://${service.toLowerCase()}.test`,
+				encryptedApiKey: "encrypted",
+				encryptionIv: "iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+				enabled: true,
+				createdAt: new Date("2026-07-31T12:00:00.000Z"),
+				updatedAt: new Date("2026-07-31T12:00:00.000Z"),
+			};
+			const rawItem = {
+				id: 101,
+				...(service === "RADARR" ? { tmdbId: 84 } : { tvdbId: 84, tmdbId: 84 }),
+				title: `Example ${_label} Item`,
+				path: `/media/example-${service.toLowerCase()}`,
+				monitored: true,
+				status: "ended",
+				qualityProfileId: 1,
+				sizeOnDisk: 2_000,
+				added: "2025-01-01T00:00:00.000Z",
+				statistics:
+					service === "RADARR"
+						? { movieFileCount: 1, sizeOnDisk: 2_000 }
+						: { episodeFileCount: 1, sizeOnDisk: 2_000 },
+			};
+			deps.arrClientFactory = {
+				create: vi.fn(() =>
+					service === "RADARR"
+						? { movie: { getById: vi.fn().mockResolvedValue(rawItem) } }
+						: { series: { getById: vi.fn().mockResolvedValue(rawItem) } },
+				),
+			} as never;
+			const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
+			const deleteMovieFile = vi.fn();
+
+			const executeAuthorizedDelete = async () => {
+				await assertCurrentSeriesMutationAuthority(
+					deps,
+					"user-1",
+					arrInstance as never,
+					101,
+					{
+						matchedRuleId: plexRule.id,
+						action: "delete",
+						scanMediaServerAfterDelete: false,
+					},
+					snapshot,
+				);
+				await deleteMovieFile();
+			};
+			if (expectedOutcome === "blocks") {
+				await expect(executeAuthorizedDelete()).rejects.toThrow(
+					/provider evidence could not re-authorize/i,
+				);
+				expect(deleteMovieFile).not.toHaveBeenCalled();
+			} else {
+				await expect(executeAuthorizedDelete()).resolves.toBeUndefined();
+				expect(deleteMovieFile).toHaveBeenCalledOnce();
+			}
+		},
+	);
 });
 
 describe("interactive preview live watch authority", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -13,12 +13,12 @@
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import { plexConnectionFingerprint } from "../../plex/service-instance-fingerprint.js";
-import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import {
 	buildEvalContextWithHealth,
 	prefetchFreshPlexEpisodeWatchData,
 	prefetchPlexData,
 } from "../cleanup-executor.js";
+import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
 function makePlexRow(overrides: {
@@ -26,6 +26,8 @@ function makePlexRow(overrides: {
 	tmdbId: number;
 	mediaType: "movie" | "series";
 	sectionId: string;
+	instanceId?: string;
+	ratingKey?: string;
 	sectionTitle?: string;
 	watchCount?: number;
 	watchedByUsers?: string[];
@@ -38,8 +40,10 @@ function makePlexRow(overrides: {
 }) {
 	return {
 		id: overrides.id,
+		instanceId: overrides.instanceId ?? "plex-inst-1",
 		tmdbId: overrides.tmdbId,
 		mediaType: overrides.mediaType,
+		ratingKey: overrides.ratingKey ?? `rating-${overrides.id}`,
 		sectionId: overrides.sectionId,
 		sectionTitle: overrides.sectionTitle ?? `Section ${overrides.sectionId}`,
 		lastWatchedAt: overrides.lastWatchedAt ?? null,

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -13,12 +13,12 @@
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import { plexConnectionFingerprint } from "../../plex/service-instance-fingerprint.js";
+import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import {
 	buildEvalContextWithHealth,
 	prefetchFreshPlexEpisodeWatchData,
 	prefetchPlexData,
 } from "../cleanup-executor.js";
-import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
 function makePlexRow(overrides: {
@@ -26,8 +26,6 @@ function makePlexRow(overrides: {
 	tmdbId: number;
 	mediaType: "movie" | "series";
 	sectionId: string;
-	instanceId?: string;
-	ratingKey?: string;
 	sectionTitle?: string;
 	watchCount?: number;
 	watchedByUsers?: string[];
@@ -40,10 +38,8 @@ function makePlexRow(overrides: {
 }) {
 	return {
 		id: overrides.id,
-		instanceId: overrides.instanceId ?? "plex-inst-1",
 		tmdbId: overrides.tmdbId,
 		mediaType: overrides.mediaType,
-		ratingKey: overrides.ratingKey ?? `rating-${overrides.id}`,
 		sectionId: overrides.sectionId,
 		sectionTitle: overrides.sectionTitle ?? `Section ${overrides.sectionId}`,
 		lastWatchedAt: overrides.lastWatchedAt ?? null,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -24,7 +24,11 @@ import { createJellyfinClient } from "../jellyfin/jellyfin-client.js";
 import { refreshJellyfinEpisodeCache } from "../jellyfin/jellyfin-episode-cache-refresher.js";
 import { jellyfinConnectionFingerprint } from "../jellyfin/service-instance-fingerprint.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
-import { type PlexCacheSnapshotRow, refreshPlexCache } from "../plex/plex-cache-refresher.js";
+import {
+	type PlexCacheSnapshotRow,
+	type PlexInventoryTarget,
+	refreshPlexCache,
+} from "../plex/plex-cache-refresher.js";
 import {
 	createPlexClient,
 	type PlexClient,
@@ -2861,6 +2865,24 @@ type PlexTargetLookupClient = Pick<
 	"getMovieMediaPartsByTmdbId" | "getSeriesEpisodeMediaPartsByTvdbId"
 >;
 
+type PlexTargetRatingKeysByInstance = Map<string, Map<string, Set<string>>>;
+
+function plexTargetIdentityKey(
+	mediaType: PlexInventoryTarget["mediaType"],
+	idType: "tmdb" | "tvdb",
+	externalId: number,
+): string {
+	return `${mediaType}:${idType}:${externalId}`;
+}
+
+function plexInventoryTargetKeys(target: PlexInventoryTarget): string[] {
+	const keys = [plexTargetIdentityKey(target.mediaType, "tmdb", target.tmdbId)];
+	if (target.mediaType === "series" && target.tvdbId) {
+		keys.push(plexTargetIdentityKey("series", "tvdb", target.tvdbId));
+	}
+	return keys;
+}
+
 async function readCurrentPlexTargetRatingKeys(
 	client: PlexTargetLookupClient,
 	service: "RADARR" | "SONARR",
@@ -2892,7 +2914,8 @@ async function assertCurrentPlexTargetCoveredByPolicySnapshot(
 	userId: string,
 	service: "RADARR" | "SONARR",
 	externalId: number,
-	ratingKeysByInstance: Map<string, Set<string>>,
+	targetKey: string,
+	ratingKeysByInstance: PlexTargetRatingKeysByInstance,
 	expectedTopologyFingerprint: string,
 ): Promise<void> {
 	const initial = await loadProviderInstances(deps, userId, ["PLEX"]);
@@ -2918,9 +2941,11 @@ async function assertCurrentPlexTargetCoveredByPolicySnapshot(
 			throw new Error("Plex target identity changed between verification passes");
 		}
 
-		const coveredRatingKeys = ratingKeysByInstance.get(instance.id)!;
-		if (second.some((ratingKey) => !coveredRatingKeys.has(ratingKey))) {
-			throw new Error("Plex target became current after the policy snapshot was captured");
+		const expectedRatingKeys = [
+			...(ratingKeysByInstance.get(instance.id)?.get(targetKey) ?? new Set<string>()),
+		].sort();
+		if (evidenceFingerprint(second) !== evidenceFingerprint(expectedRatingKeys)) {
+			throw new Error("Plex target identity changed after the policy snapshot was captured");
 		}
 	}
 
@@ -2985,19 +3010,36 @@ export async function assertCurrentSeriesMutationAuthority(
 				ruleUsesUnavailableData(rule, plexDependency),
 		);
 		if (plexCanAffectPolicy) {
-			if (!policySnapshot.plexRatingKeysByInstance || !policySnapshot.plexTopologyFingerprint) {
+			if (
+				!policySnapshot.plexTargetRatingKeysByInstance ||
+				!policySnapshot.plexTopologyFingerprint
+			) {
 				throw new Error("The policy snapshot lacked complete Plex target coverage");
 			}
-			const externalId = instance.service === "RADARR" ? rawItem.tmdbId : rawItem.tvdbId;
-			if (typeof externalId !== "number" || !Number.isSafeInteger(externalId) || externalId <= 0) {
-				throw new Error("Live ARR state lacked the external ID required for Plex verification");
+			const lookupExternalId = instance.service === "RADARR" ? rawItem.tmdbId : rawItem.tvdbId;
+			const policyTmdbId = rawItem.tmdbId;
+			const hasPolicyTmdbId =
+				typeof policyTmdbId === "number" && Number.isSafeInteger(policyTmdbId) && policyTmdbId > 0;
+			if (
+				typeof lookupExternalId !== "number" ||
+				!Number.isSafeInteger(lookupExternalId) ||
+				lookupExternalId <= 0
+			) {
+				throw new Error("Live ARR state lacked the IDs required for Plex verification");
 			}
+			const targetKey =
+				instance.service === "RADARR"
+					? plexTargetIdentityKey("movie", "tmdb", lookupExternalId)
+					: hasPolicyTmdbId
+						? plexTargetIdentityKey("series", "tmdb", policyTmdbId)
+						: plexTargetIdentityKey("series", "tvdb", lookupExternalId);
 			await assertCurrentPlexTargetCoveredByPolicySnapshot(
 				deps,
 				userId,
 				instance.service,
-				externalId,
-				policySnapshot.plexRatingKeysByInstance,
+				lookupExternalId,
+				targetKey,
+				policySnapshot.plexTargetRatingKeysByInstance,
 				policySnapshot.plexTopologyFingerprint,
 			);
 		}
@@ -4935,15 +4977,17 @@ async function prefetchTautulliData(
 	}
 }
 
-interface PublishedPlexCacheData {
-	plexMap: PlexWatchMap;
-	ratingKeysByInstance: Map<string, Set<string>>;
-}
-
-async function prefetchPlexCacheData(
+/**
+ * Prefetch Plex watch data from the PlexCache table and build a lookup map.
+ * Now section-aware: each row carries sectionId/sectionTitle, and PlexWatchInfo
+ * contains both pre-computed cross-section aggregates and a per-section breakdown.
+ * Also includes collections and labels from the PlexCache table.
+ * Returns undefined if no Plex instance is configured.
+ */
+export async function prefetchPlexData(
 	deps: CleanupExecutorDeps,
 	userId: string,
-): Promise<PublishedPlexCacheData | undefined> {
+): Promise<PlexWatchMap | undefined> {
 	const { prisma, log } = deps;
 
 	const plexInstances = await prisma.serviceInstance.findMany({
@@ -4960,23 +5004,18 @@ async function prefetchPlexCacheData(
 		}
 		const map: PlexWatchMap = new Map();
 		const instanceIds = plexInstances.map((i) => i.id);
-		const ratingKeysByInstance = new Map(
-			instanceIds.map((instanceId) => [instanceId, new Set<string>()]),
-		);
 		let cursor: string | undefined;
 		let totalRows = 0;
 
-		// Cursor-paginate to bound peak heap. Preserve the per-instance rating-key
-		// coverage used by final destructive policy revalidation.
+		// Cursor-paginate to bound peak heap. Project only columns the watch-map
+		// builder reads — skipping ratingKey/thumb/title and the per-row instanceId.
 		while (true) {
 			const batch = await prisma.plexCache.findMany({
 				where: { instanceId: { in: instanceIds } },
 				select: {
 					id: true,
-					instanceId: true,
 					tmdbId: true,
 					mediaType: true,
-					ratingKey: true,
 					sectionId: true,
 					sectionTitle: true,
 					lastWatchedAt: true,
@@ -4998,9 +5037,6 @@ async function prefetchPlexCacheData(
 
 			for (const row of batch) {
 				try {
-					if (typeof row.ratingKey !== "string" || row.ratingKey.trim() === "") {
-						throw new Error("Plex cache row lacked a usable rating key");
-					}
 					// Key is mediaType:tmdbId (aggregating across sections)
 					const key = `${row.mediaType}:${row.tmdbId}`;
 					const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
@@ -5067,7 +5103,6 @@ async function prefetchPlexCacheData(
 							sections: [sectionInfo],
 						});
 					}
-					ratingKeysByInstance.get(row.instanceId)?.add(row.ratingKey);
 				} catch (rowErr) {
 					log.warn({ err: rowErr, tmdbId: row.tmdbId }, "Skipping Plex cache row with bad data");
 				}
@@ -5081,7 +5116,7 @@ async function prefetchPlexCacheData(
 			{ totalRows, totalEntries: map.size },
 			"Plex watch data prefetch complete for cleanup",
 		);
-		return { plexMap: map, ratingKeysByInstance };
+		return map;
 	} catch (error) {
 		log.warn(
 			{ err: error },
@@ -5089,20 +5124,6 @@ async function prefetchPlexCacheData(
 		);
 		return undefined;
 	}
-}
-
-/**
- * Prefetch Plex watch data from the PlexCache table and build a lookup map.
- * Now section-aware: each row carries sectionId/sectionTitle, and PlexWatchInfo
- * contains both pre-computed cross-section aggregates and a per-section breakdown.
- * Also includes collections and labels from the PlexCache table.
- * Returns undefined if no Plex instance is configured.
- */
-export async function prefetchPlexData(
-	deps: CleanupExecutorDeps,
-	userId: string,
-): Promise<PlexWatchMap | undefined> {
-	return (await prefetchPlexCacheData(deps, userId))?.plexMap;
 }
 
 /**
@@ -8661,12 +8682,15 @@ async function loadProviderInstances(
 	});
 }
 
-interface PublishedPlexPolicyEvidence {
+interface PlexPolicyEvidence {
 	plexMap: PlexWatchMap;
 	plexSectionTitles: Set<string>;
-	ratingKeysByInstance: Map<string, Set<string>>;
 	completedAt: Date;
 	generationFingerprint: string;
+}
+
+interface PublishedPlexPolicyEvidence extends PlexPolicyEvidence {
+	generationIdsByInstance: Map<string, string>;
 }
 
 function parsePublishedPlexSections(metadata: string | null): Array<{
@@ -8764,16 +8788,18 @@ async function loadPublishedPlexPolicyEvidenceUnsafe(
 		if (!sectionTitles.has(title)) return undefined;
 	}
 
-	const plexCacheData = await prefetchPlexCacheData(deps, userId);
-	if (!plexCacheData) return undefined;
+	const plexMap = await prefetchPlexData(deps, userId);
+	if (!plexMap) return undefined;
 	const after = await readStatuses();
 	if (evidenceFingerprint(before) !== evidenceFingerprint(after)) return undefined;
 	return {
-		plexMap: plexCacheData.plexMap,
+		plexMap,
 		plexSectionTitles: sectionTitles,
-		ratingKeysByInstance: plexCacheData.ratingKeysByInstance,
 		completedAt: new Date(Math.min(...before.map((status) => status.lastRefreshedAt.getTime()))),
 		generationFingerprint: evidenceFingerprint(before),
+		generationIdsByInstance: new Map(
+			before.map((status) => [status.instanceId, status.generationId!]),
+		),
 	};
 }
 
@@ -8812,7 +8838,7 @@ async function collectLivePlexPolicyEvidence(
 	deps: CleanupExecutorDeps,
 	userId: string,
 	rules: Array<{ enabled: boolean; plexLibraryFilter?: string | null }>,
-): Promise<PublishedPlexPolicyEvidence | undefined> {
+): Promise<PlexPolicyEvidence | undefined> {
 	try {
 		const initial = await loadProviderInstances(deps, userId, ["PLEX"]);
 		if (initial.length === 0) return undefined;
@@ -8821,7 +8847,6 @@ async function collectLivePlexPolicyEvidence(
 			| {
 					plexMap: PlexWatchMap;
 					plexSectionTitles: Set<string>;
-					ratingKeysByInstance: Map<string, Set<string>>;
 					fingerprint: string;
 					completedAt: Date;
 			  }
@@ -8863,30 +8888,13 @@ async function collectLivePlexPolicyEvidence(
 				if (!sections.has(title)) throw new Error(`Plex library ${title} was unavailable`);
 			}
 			const sortedRows = sortProviderRows(rows);
-			const ratingKeysByInstance = new Map(
-				initial.map((instance) => [instance.id, new Set<string>()]),
-			);
-			for (const row of sortedRows) {
-				if (typeof row.ratingKey !== "string" || row.ratingKey.trim() === "") {
-					throw new Error("Plex live evidence lacked a usable rating key");
-				}
-				const ratingKeys = ratingKeysByInstance.get(row.instanceId);
-				if (!ratingKeys) throw new Error("Plex live evidence referenced an unknown instance");
-				ratingKeys.add(row.ratingKey);
-			}
-			const fingerprint = evidenceFingerprint([
-				topology,
-				sortedRows,
-				sections,
-				ratingKeysByInstance,
-			]);
+			const fingerprint = evidenceFingerprint([topology, sortedRows, sections]);
 			if (accepted && accepted.fingerprint !== fingerprint) {
 				throw new Error("Plex evidence changed between verification passes");
 			}
 			accepted = {
 				plexMap: plexSnapshotToWatchMap(sortedRows),
 				plexSectionTitles: sections,
-				ratingKeysByInstance,
 				fingerprint,
 				completedAt: new Date(Math.min(...completions.map((date) => date.getTime()))),
 			};
@@ -8895,7 +8903,6 @@ async function collectLivePlexPolicyEvidence(
 			? {
 					plexMap: accepted.plexMap,
 					plexSectionTitles: accepted.plexSectionTitles,
-					ratingKeysByInstance: accepted.ratingKeysByInstance,
 					completedAt: accepted.completedAt,
 					generationFingerprint: accepted.fingerprint,
 				}
@@ -9030,7 +9037,7 @@ async function refreshPlexMutationEvidence(
 	| {
 			plexMap: PlexWatchMap;
 			plexSectionTitles: Set<string>;
-			ratingKeysByInstance: Map<string, Set<string>>;
+			ratingKeysByInstance: PlexTargetRatingKeysByInstance;
 			plexEpisodeMap?: PlexEpisodeMap;
 			completedAt: Date;
 			topologyFingerprint: string;
@@ -9045,7 +9052,7 @@ async function refreshPlexMutationEvidence(
 			| {
 					plexMap: PlexWatchMap;
 					plexSectionTitles: Set<string>;
-					ratingKeysByInstance: Map<string, Set<string>>;
+					ratingKeysByInstance: PlexTargetRatingKeysByInstance;
 					plexEpisodeMap?: PlexEpisodeMap;
 					fingerprint: string;
 					completedAt: Date;
@@ -9053,6 +9060,10 @@ async function refreshPlexMutationEvidence(
 			| undefined;
 		for (let pass = 0; pass < 2; pass++) {
 			const passCompletions: Date[] = [];
+			const generationIdsByInstance = new Map<string, string>();
+			const ratingKeysByInstance: PlexTargetRatingKeysByInstance = new Map(
+				initial.map((instance) => [instance.id, new Map<string, Set<string>>()]),
+			);
 			for (const instance of initial) {
 				const client =
 					deps.plexCacheClientFactory?.(instance) ??
@@ -9069,8 +9080,22 @@ async function refreshPlexMutationEvidence(
 				if (refreshed.errors > 0 || refreshed.complete !== true) {
 					throw new Error("Plex cache refresh was incomplete");
 				}
-				if (!refreshed.completedAt) throw new Error("Plex refresh lacked a completion timestamp");
+				if (!refreshed.completedAt || !refreshed.generationId || !refreshed.inventoryTargets) {
+					throw new Error("Plex refresh lacked complete inventory identity evidence");
+				}
 				passCompletions.push(refreshed.completedAt);
+				generationIdsByInstance.set(instance.id, refreshed.generationId);
+				const instanceTargets = ratingKeysByInstance.get(instance.id)!;
+				for (const target of refreshed.inventoryTargets) {
+					for (const targetKey of plexInventoryTargetKeys(target)) {
+						let ratingKeys = instanceTargets.get(targetKey);
+						if (!ratingKeys) {
+							ratingKeys = new Set<string>();
+							instanceTargets.set(targetKey, ratingKeys);
+						}
+						ratingKeys.add(target.ratingKey);
+					}
+				}
 				if (includeEpisodes) {
 					const episodes = await refreshPlexEpisodeCache(
 						client,
@@ -9100,11 +9125,16 @@ async function refreshPlexMutationEvidence(
 			if (!publishedPlex || (includeEpisodes && !plexEpisodeMap)) {
 				throw new Error("Plex refreshed evidence could not be loaded");
 			}
+			if (
+				evidenceFingerprint(publishedPlex.generationIdsByInstance) !==
+				evidenceFingerprint(generationIdsByInstance)
+			) {
+				throw new Error("Plex inventory identity did not match the published generation");
+			}
 			const fingerprint = evidenceFingerprint([
-				publishedPlex.generationFingerprint,
 				publishedPlex.plexMap,
 				publishedPlex.plexSectionTitles,
-				publishedPlex.ratingKeysByInstance,
+				ratingKeysByInstance,
 				plexEpisodeMap,
 			]);
 			if (accepted && accepted.fingerprint !== fingerprint) {
@@ -9113,7 +9143,7 @@ async function refreshPlexMutationEvidence(
 			accepted = {
 				plexMap: publishedPlex.plexMap,
 				plexSectionTitles: publishedPlex.plexSectionTitles,
-				ratingKeysByInstance: publishedPlex.ratingKeysByInstance,
+				ratingKeysByInstance,
 				plexEpisodeMap,
 				fingerprint,
 				completedAt: new Date(Math.min(...passCompletions.map((date) => date.getTime()))),
@@ -9443,7 +9473,7 @@ async function buildMutationEvalContext(
 	ctx: EvalContext;
 	failedSources: Set<DataSourceDependency>;
 	sourceCompletedAt: Map<Exclude<DataSourceDependency, null>, Date>;
-	plexRatingKeysByInstance?: Map<string, Set<string>>;
+	plexTargetRatingKeysByInstance?: PlexTargetRatingKeysByInstance;
 	plexTopologyFingerprint?: string;
 }> {
 	const activeTypes = collectActiveRuleTypes(rules);
@@ -9541,7 +9571,7 @@ async function buildMutationEvalContext(
 		},
 		failedSources,
 		sourceCompletedAt,
-		plexRatingKeysByInstance: plexEvidence?.ratingKeysByInstance,
+		plexTargetRatingKeysByInstance: plexEvidence?.ratingKeysByInstance,
 		plexTopologyFingerprint: plexEvidence?.topologyFingerprint,
 	};
 }
@@ -9556,7 +9586,7 @@ export interface MutationPolicySnapshot {
 	failedSources: Set<DataSourceDependency>;
 	sourceCompletedAt: Map<Exclude<DataSourceDependency, null>, Date>;
 	oldestSourceCompletedAt: Date | null;
-	plexRatingKeysByInstance?: Map<string, Set<string>>;
+	plexTargetRatingKeysByInstance?: PlexTargetRatingKeysByInstance;
 	plexTopologyFingerprint?: string;
 	providerTopologyFingerprint: string;
 }
@@ -9600,7 +9630,7 @@ async function createMutationPolicySnapshot(
 		ctx,
 		failedSources,
 		sourceCompletedAt,
-		plexRatingKeysByInstance,
+		plexTargetRatingKeysByInstance,
 		plexTopologyFingerprint,
 	} = await buildMutationEvalContext(deps, userId, rules);
 	const oldestSourceCompletedAt =
@@ -9630,7 +9660,7 @@ async function createMutationPolicySnapshot(
 		failedSources,
 		sourceCompletedAt,
 		oldestSourceCompletedAt,
-		plexRatingKeysByInstance,
+		plexTargetRatingKeysByInstance,
 		plexTopologyFingerprint,
 		providerTopologyFingerprint: providerTopologyFingerprint(providerInstances),
 	};

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -2977,6 +2977,30 @@ function assertRefreshedPlexTargetMatchesPolicySnapshot(
 	}
 }
 
+function plexRulesCapableOfAffectingExpectedSeriesPolicy(
+	item: CacheItemForEval,
+	rules: LibraryCleanupRule[],
+	service: "RADARR" | "SONARR",
+	expectedRuleId: string,
+): LibraryCleanupRule[] {
+	const expectedRule = rules.find((rule) => rule.id === expectedRuleId);
+	if (!expectedRule || expectedRule.retentionMode) {
+		throw new Error("The expected cleanup winner was absent from the policy snapshot");
+	}
+	const plexDependency = new Set<DataSourceDependency>(["plex"]);
+	return rules.filter((rule) => {
+		const canAffectExpectedWinner =
+			rule.retentionMode ||
+			rule.priority < expectedRule.priority ||
+			(rule.priority === expectedRule.priority && rule.id.localeCompare(expectedRule.id) <= 0);
+		return (
+			canAffectExpectedWinner &&
+			passesCleanupRuleFilters(item, rule, service) &&
+			ruleUsesUnavailableData(rule, plexDependency)
+		);
+	});
+}
+
 /**
  * Re-establish series/movie cleanup authorization at the mutation boundary.
  * The queued/preview match is durable intent only: current live ARR state,
@@ -3008,16 +3032,17 @@ export async function assertCurrentSeriesMutationAuthority(
 					: (() => {
 							throw new Error(`Unsupported cleanup service: ${instance.service}`);
 						})();
-		const liveItem = toLiveSeriesPolicyItem(instance, arrItemId, rawItem);
-		const plexDependency = new Set<DataSourceDependency>(["plex"]);
-		const plexCanAffectPolicy = policySnapshot.rules.some(
-			(rule) =>
-				passesCleanupRuleFilters(liveItem, rule, instance.service) &&
-				ruleUsesUnavailableData(rule, plexDependency),
+		let authoritativeRawItem = rawItem;
+		let authoritativeLiveItem = toLiveSeriesPolicyItem(instance, arrItemId, rawItem);
+		const plexPolicyRules = plexRulesCapableOfAffectingExpectedSeriesPolicy(
+			authoritativeLiveItem,
+			policySnapshot.rules,
+			instance.service,
+			expectedRule.matchedRuleId,
 		);
 		let currentPolicyCtx = policySnapshot.ctx;
 		let currentFailedSources = policySnapshot.failedSources;
-		if (plexCanAffectPolicy) {
+		if (plexPolicyRules.length > 0) {
 			if (
 				!policySnapshot.plexTargetRatingKeysByInstance ||
 				!policySnapshot.plexTopologyFingerprint
@@ -3051,12 +3076,12 @@ export async function assertCurrentSeriesMutationAuthority(
 				policySnapshot.plexTopologyFingerprint,
 			);
 
-			const activeTypes = collectActiveRuleTypes(policySnapshot.rules);
+			const activeTypes = collectActiveRuleTypes(plexPolicyRules);
 			const currentPlexEvidence = await refreshPlexMutationEvidence(
 				deps,
 				userId,
 				activeTypes.has("plex_episode_completion"),
-				policySnapshot.rules,
+				plexPolicyRules,
 			);
 			if (
 				!currentPlexEvidence ||
@@ -3079,9 +3104,57 @@ export async function assertCurrentSeriesMutationAuthority(
 			};
 			currentFailedSources = new Set(policySnapshot.failedSources);
 			currentFailedSources.delete("plex");
+
+			authoritativeRawItem =
+				instance.service === "RADARR"
+					? ((await (arrClient as InstanceType<typeof RadarrClient>).movie.getById(
+							arrItemId,
+						)) as unknown as Record<string, unknown>)
+					: ((await (arrClient as InstanceType<typeof SonarrClient>).series.getById(
+							arrItemId,
+						)) as unknown as Record<string, unknown>);
+			authoritativeLiveItem = toLiveSeriesPolicyItem(instance, arrItemId, authoritativeRawItem);
+			const currentLookupExternalId =
+				instance.service === "RADARR" ? authoritativeRawItem.tmdbId : authoritativeRawItem.tvdbId;
+			const currentPolicyTmdbId = authoritativeRawItem.tmdbId;
+			const currentHasPolicyTmdbId =
+				typeof currentPolicyTmdbId === "number" &&
+				Number.isSafeInteger(currentPolicyTmdbId) &&
+				currentPolicyTmdbId > 0;
+			if (
+				typeof currentLookupExternalId !== "number" ||
+				!Number.isSafeInteger(currentLookupExternalId) ||
+				currentLookupExternalId <= 0
+			) {
+				throw new Error("Refreshed ARR state lacked the IDs required for Plex verification");
+			}
+			const currentTargetKey =
+				instance.service === "RADARR"
+					? plexTargetIdentityKey("movie", "tmdb", currentLookupExternalId)
+					: currentHasPolicyTmdbId
+						? plexTargetIdentityKey("series", "tmdb", currentPolicyTmdbId)
+						: plexTargetIdentityKey("series", "tvdb", currentLookupExternalId);
+			if (currentLookupExternalId !== lookupExternalId || currentTargetKey !== targetKey) {
+				throw new Error("ARR target identity changed during Plex policy revalidation");
+			}
+			const refreshedPlexPolicyRules = plexRulesCapableOfAffectingExpectedSeriesPolicy(
+				authoritativeLiveItem,
+				policySnapshot.rules,
+				instance.service,
+				expectedRule.matchedRuleId,
+			);
+			const refreshedRuleIds = new Set(refreshedPlexPolicyRules.map((rule) => rule.id));
+			if (refreshedRuleIds.size > plexPolicyRules.length) {
+				throw new Error("A new Plex-dependent policy became applicable during revalidation");
+			}
+			for (const ruleId of refreshedRuleIds) {
+				if (!plexPolicyRules.some((rule) => rule.id === ruleId)) {
+					throw new Error("A new Plex-dependent policy became applicable during revalidation");
+				}
+			}
 		}
 		const policy = evaluateItemPolicyState(
-			liveItem,
+			authoritativeLiveItem,
 			policySnapshot.rules,
 			instance.service,
 			currentPolicyCtx,
@@ -3096,7 +3169,11 @@ export async function assertCurrentSeriesMutationAuthority(
 			throw new Error("The exact matched cleanup policy is no longer authoritative");
 		}
 		await assertCurrentSeriesPolicySnapshotUnchanged(deps, userId, expectedRule, policySnapshot);
-		return { snapshot: policySnapshot, rawItem, policyItem: liveItem };
+		return {
+			snapshot: policySnapshot,
+			rawItem: authoritativeRawItem,
+			policyItem: authoritativeLiveItem,
+		};
 	} catch (error) {
 		deps.log.warn(
 			{ err: error, instanceId: instance.id, arrItemId, ruleId: expectedRule.matchedRuleId },

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -25,7 +25,12 @@ import { refreshJellyfinEpisodeCache } from "../jellyfin/jellyfin-episode-cache-
 import { jellyfinConnectionFingerprint } from "../jellyfin/service-instance-fingerprint.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
 import { type PlexCacheSnapshotRow, refreshPlexCache } from "../plex/plex-cache-refresher.js";
-import { createPlexClient } from "../plex/plex-client.js";
+import {
+	createPlexClient,
+	type PlexClient,
+	PlexMovieNotFoundError,
+	PlexSeriesNotFoundError,
+} from "../plex/plex-client.js";
 import { refreshPlexEpisodeCache } from "../plex/plex-episode-cache-refresher.js";
 import { plexConnectionFingerprint } from "../plex/service-instance-fingerprint.js";
 import type {
@@ -2851,6 +2856,80 @@ export async function assertCurrentSeriesPolicySnapshotUnchanged(
 	}
 }
 
+type PlexTargetLookupClient = Pick<
+	PlexClient,
+	"getMovieMediaPartsByTmdbId" | "getSeriesEpisodeMediaPartsByTvdbId"
+>;
+
+async function readCurrentPlexTargetRatingKeys(
+	client: PlexTargetLookupClient,
+	service: "RADARR" | "SONARR",
+	externalId: number,
+): Promise<string[]> {
+	try {
+		const items =
+			service === "RADARR"
+				? await client.getMovieMediaPartsByTmdbId(externalId)
+				: await client.getSeriesEpisodeMediaPartsByTvdbId(externalId);
+		const ratingKeys = new Set<string>();
+		for (const item of items) {
+			if (typeof item.ratingKey !== "string" || item.ratingKey.trim() === "") {
+				throw new Error("Plex returned a target without a usable rating key");
+			}
+			ratingKeys.add(item.ratingKey);
+		}
+		return [...ratingKeys].sort();
+	} catch (error) {
+		if (error instanceof PlexMovieNotFoundError || error instanceof PlexSeriesNotFoundError) {
+			return [];
+		}
+		throw error;
+	}
+}
+
+async function assertCurrentPlexTargetCoveredByPolicySnapshot(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	service: "RADARR" | "SONARR",
+	externalId: number,
+	ratingKeysByInstance: Map<string, Set<string>>,
+	expectedTopologyFingerprint: string,
+): Promise<void> {
+	const initial = await loadProviderInstances(deps, userId, ["PLEX"]);
+	if (
+		initial.length === 0 ||
+		providerTopologyFingerprint(initial) !== expectedTopologyFingerprint ||
+		ratingKeysByInstance.size !== initial.length ||
+		initial.some((instance) => !ratingKeysByInstance.has(instance.id))
+	) {
+		throw new Error("Plex topology no longer matched the policy snapshot");
+	}
+
+	for (const instance of initial) {
+		const client =
+			deps.plexClientFactory?.(instance) ??
+			deps.plexCacheClientFactory?.(instance) ??
+			(deps.encryptor ? createPlexClient(deps.encryptor, instance, deps.log) : null);
+		if (!client) throw new Error("Plex credentials were unavailable");
+
+		const first = await readCurrentPlexTargetRatingKeys(client, service, externalId);
+		const second = await readCurrentPlexTargetRatingKeys(client, service, externalId);
+		if (evidenceFingerprint(first) !== evidenceFingerprint(second)) {
+			throw new Error("Plex target identity changed between verification passes");
+		}
+
+		const coveredRatingKeys = ratingKeysByInstance.get(instance.id)!;
+		if (second.some((ratingKey) => !coveredRatingKeys.has(ratingKey))) {
+			throw new Error("Plex target became current after the policy snapshot was captured");
+		}
+	}
+
+	const after = await loadProviderInstances(deps, userId, ["PLEX"]);
+	if (providerTopologyFingerprint(after) !== expectedTopologyFingerprint) {
+		throw new Error("Plex topology changed during final target verification");
+	}
+}
+
 /**
  * Re-establish series/movie cleanup authorization at the mutation boundary.
  * The queued/preview match is durable intent only: current live ARR state,
@@ -2897,6 +2976,30 @@ export async function assertCurrentSeriesMutationAuthority(
 			(policy.match.scanMediaServerAfterDelete === true) !== expectedRule.scanMediaServerAfterDelete
 		) {
 			throw new Error("The exact matched cleanup policy is no longer authoritative");
+		}
+
+		const plexDependency = new Set<DataSourceDependency>(["plex"]);
+		const plexCanAffectPolicy = policySnapshot.rules.some(
+			(rule) =>
+				passesCleanupRuleFilters(liveItem, rule, instance.service) &&
+				ruleUsesUnavailableData(rule, plexDependency),
+		);
+		if (plexCanAffectPolicy) {
+			if (!policySnapshot.plexRatingKeysByInstance || !policySnapshot.plexTopologyFingerprint) {
+				throw new Error("The policy snapshot lacked complete Plex target coverage");
+			}
+			const externalId = instance.service === "RADARR" ? rawItem.tmdbId : rawItem.tvdbId;
+			if (typeof externalId !== "number" || !Number.isSafeInteger(externalId) || externalId <= 0) {
+				throw new Error("Live ARR state lacked the external ID required for Plex verification");
+			}
+			await assertCurrentPlexTargetCoveredByPolicySnapshot(
+				deps,
+				userId,
+				instance.service,
+				externalId,
+				policySnapshot.plexRatingKeysByInstance,
+				policySnapshot.plexTopologyFingerprint,
+			);
 		}
 		return { snapshot: policySnapshot, rawItem, policyItem: liveItem };
 	} catch (error) {
@@ -4832,17 +4935,15 @@ async function prefetchTautulliData(
 	}
 }
 
-/**
- * Prefetch Plex watch data from the PlexCache table and build a lookup map.
- * Now section-aware: each row carries sectionId/sectionTitle, and PlexWatchInfo
- * contains both pre-computed cross-section aggregates and a per-section breakdown.
- * Also includes collections and labels from the PlexCache table.
- * Returns undefined if no Plex instance is configured.
- */
-export async function prefetchPlexData(
+interface PublishedPlexCacheData {
+	plexMap: PlexWatchMap;
+	ratingKeysByInstance: Map<string, Set<string>>;
+}
+
+async function prefetchPlexCacheData(
 	deps: CleanupExecutorDeps,
 	userId: string,
-): Promise<PlexWatchMap | undefined> {
+): Promise<PublishedPlexCacheData | undefined> {
 	const { prisma, log } = deps;
 
 	const plexInstances = await prisma.serviceInstance.findMany({
@@ -4859,18 +4960,23 @@ export async function prefetchPlexData(
 		}
 		const map: PlexWatchMap = new Map();
 		const instanceIds = plexInstances.map((i) => i.id);
+		const ratingKeysByInstance = new Map(
+			instanceIds.map((instanceId) => [instanceId, new Set<string>()]),
+		);
 		let cursor: string | undefined;
 		let totalRows = 0;
 
-		// Cursor-paginate to bound peak heap. Project only columns the watch-map
-		// builder reads — skipping ratingKey/thumb/title and the per-row instanceId.
+		// Cursor-paginate to bound peak heap. Preserve the per-instance rating-key
+		// coverage used by final destructive policy revalidation.
 		while (true) {
 			const batch = await prisma.plexCache.findMany({
 				where: { instanceId: { in: instanceIds } },
 				select: {
 					id: true,
+					instanceId: true,
 					tmdbId: true,
 					mediaType: true,
+					ratingKey: true,
 					sectionId: true,
 					sectionTitle: true,
 					lastWatchedAt: true,
@@ -4892,6 +4998,9 @@ export async function prefetchPlexData(
 
 			for (const row of batch) {
 				try {
+					if (typeof row.ratingKey !== "string" || row.ratingKey.trim() === "") {
+						throw new Error("Plex cache row lacked a usable rating key");
+					}
 					// Key is mediaType:tmdbId (aggregating across sections)
 					const key = `${row.mediaType}:${row.tmdbId}`;
 					const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
@@ -4958,6 +5067,7 @@ export async function prefetchPlexData(
 							sections: [sectionInfo],
 						});
 					}
+					ratingKeysByInstance.get(row.instanceId)?.add(row.ratingKey);
 				} catch (rowErr) {
 					log.warn({ err: rowErr, tmdbId: row.tmdbId }, "Skipping Plex cache row with bad data");
 				}
@@ -4971,7 +5081,7 @@ export async function prefetchPlexData(
 			{ totalRows, totalEntries: map.size },
 			"Plex watch data prefetch complete for cleanup",
 		);
-		return map;
+		return { plexMap: map, ratingKeysByInstance };
 	} catch (error) {
 		log.warn(
 			{ err: error },
@@ -4979,6 +5089,20 @@ export async function prefetchPlexData(
 		);
 		return undefined;
 	}
+}
+
+/**
+ * Prefetch Plex watch data from the PlexCache table and build a lookup map.
+ * Now section-aware: each row carries sectionId/sectionTitle, and PlexWatchInfo
+ * contains both pre-computed cross-section aggregates and a per-section breakdown.
+ * Also includes collections and labels from the PlexCache table.
+ * Returns undefined if no Plex instance is configured.
+ */
+export async function prefetchPlexData(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<PlexWatchMap | undefined> {
+	return (await prefetchPlexCacheData(deps, userId))?.plexMap;
 }
 
 /**
@@ -8540,6 +8664,7 @@ async function loadProviderInstances(
 interface PublishedPlexPolicyEvidence {
 	plexMap: PlexWatchMap;
 	plexSectionTitles: Set<string>;
+	ratingKeysByInstance: Map<string, Set<string>>;
 	completedAt: Date;
 	generationFingerprint: string;
 }
@@ -8639,13 +8764,14 @@ async function loadPublishedPlexPolicyEvidenceUnsafe(
 		if (!sectionTitles.has(title)) return undefined;
 	}
 
-	const plexMap = await prefetchPlexData(deps, userId);
-	if (!plexMap) return undefined;
+	const plexCacheData = await prefetchPlexCacheData(deps, userId);
+	if (!plexCacheData) return undefined;
 	const after = await readStatuses();
 	if (evidenceFingerprint(before) !== evidenceFingerprint(after)) return undefined;
 	return {
-		plexMap,
+		plexMap: plexCacheData.plexMap,
 		plexSectionTitles: sectionTitles,
+		ratingKeysByInstance: plexCacheData.ratingKeysByInstance,
 		completedAt: new Date(Math.min(...before.map((status) => status.lastRefreshedAt.getTime()))),
 		generationFingerprint: evidenceFingerprint(before),
 	};
@@ -8695,6 +8821,7 @@ async function collectLivePlexPolicyEvidence(
 			| {
 					plexMap: PlexWatchMap;
 					plexSectionTitles: Set<string>;
+					ratingKeysByInstance: Map<string, Set<string>>;
 					fingerprint: string;
 					completedAt: Date;
 			  }
@@ -8736,13 +8863,30 @@ async function collectLivePlexPolicyEvidence(
 				if (!sections.has(title)) throw new Error(`Plex library ${title} was unavailable`);
 			}
 			const sortedRows = sortProviderRows(rows);
-			const fingerprint = evidenceFingerprint([topology, sortedRows, sections]);
+			const ratingKeysByInstance = new Map(
+				initial.map((instance) => [instance.id, new Set<string>()]),
+			);
+			for (const row of sortedRows) {
+				if (typeof row.ratingKey !== "string" || row.ratingKey.trim() === "") {
+					throw new Error("Plex live evidence lacked a usable rating key");
+				}
+				const ratingKeys = ratingKeysByInstance.get(row.instanceId);
+				if (!ratingKeys) throw new Error("Plex live evidence referenced an unknown instance");
+				ratingKeys.add(row.ratingKey);
+			}
+			const fingerprint = evidenceFingerprint([
+				topology,
+				sortedRows,
+				sections,
+				ratingKeysByInstance,
+			]);
 			if (accepted && accepted.fingerprint !== fingerprint) {
 				throw new Error("Plex evidence changed between verification passes");
 			}
 			accepted = {
 				plexMap: plexSnapshotToWatchMap(sortedRows),
 				plexSectionTitles: sections,
+				ratingKeysByInstance,
 				fingerprint,
 				completedAt: new Date(Math.min(...completions.map((date) => date.getTime()))),
 			};
@@ -8751,6 +8895,7 @@ async function collectLivePlexPolicyEvidence(
 			? {
 					plexMap: accepted.plexMap,
 					plexSectionTitles: accepted.plexSectionTitles,
+					ratingKeysByInstance: accepted.ratingKeysByInstance,
 					completedAt: accepted.completedAt,
 					generationFingerprint: accepted.fingerprint,
 				}
@@ -8885,8 +9030,10 @@ async function refreshPlexMutationEvidence(
 	| {
 			plexMap: PlexWatchMap;
 			plexSectionTitles: Set<string>;
+			ratingKeysByInstance: Map<string, Set<string>>;
 			plexEpisodeMap?: PlexEpisodeMap;
 			completedAt: Date;
+			topologyFingerprint: string;
 	  }
 	| undefined
 > {
@@ -8898,6 +9045,7 @@ async function refreshPlexMutationEvidence(
 			| {
 					plexMap: PlexWatchMap;
 					plexSectionTitles: Set<string>;
+					ratingKeysByInstance: Map<string, Set<string>>;
 					plexEpisodeMap?: PlexEpisodeMap;
 					fingerprint: string;
 					completedAt: Date;
@@ -8956,6 +9104,7 @@ async function refreshPlexMutationEvidence(
 				publishedPlex.generationFingerprint,
 				publishedPlex.plexMap,
 				publishedPlex.plexSectionTitles,
+				publishedPlex.ratingKeysByInstance,
 				plexEpisodeMap,
 			]);
 			if (accepted && accepted.fingerprint !== fingerprint) {
@@ -8964,6 +9113,7 @@ async function refreshPlexMutationEvidence(
 			accepted = {
 				plexMap: publishedPlex.plexMap,
 				plexSectionTitles: publishedPlex.plexSectionTitles,
+				ratingKeysByInstance: publishedPlex.ratingKeysByInstance,
 				plexEpisodeMap,
 				fingerprint,
 				completedAt: new Date(Math.min(...passCompletions.map((date) => date.getTime()))),
@@ -8973,8 +9123,10 @@ async function refreshPlexMutationEvidence(
 			? {
 					plexMap: accepted.plexMap,
 					plexSectionTitles: accepted.plexSectionTitles,
+					ratingKeysByInstance: accepted.ratingKeysByInstance,
 					plexEpisodeMap: accepted.plexEpisodeMap,
 					completedAt: accepted.completedAt,
+					topologyFingerprint: topology,
 				}
 			: undefined;
 	} catch (error) {
@@ -9291,6 +9443,8 @@ async function buildMutationEvalContext(
 	ctx: EvalContext;
 	failedSources: Set<DataSourceDependency>;
 	sourceCompletedAt: Map<Exclude<DataSourceDependency, null>, Date>;
+	plexRatingKeysByInstance?: Map<string, Set<string>>;
+	plexTopologyFingerprint?: string;
 }> {
 	const activeTypes = collectActiveRuleTypes(rules);
 	const needsSeerr = [
@@ -9387,6 +9541,8 @@ async function buildMutationEvalContext(
 		},
 		failedSources,
 		sourceCompletedAt,
+		plexRatingKeysByInstance: plexEvidence?.ratingKeysByInstance,
+		plexTopologyFingerprint: plexEvidence?.topologyFingerprint,
 	};
 }
 
@@ -9400,6 +9556,8 @@ export interface MutationPolicySnapshot {
 	failedSources: Set<DataSourceDependency>;
 	sourceCompletedAt: Map<Exclude<DataSourceDependency, null>, Date>;
 	oldestSourceCompletedAt: Date | null;
+	plexRatingKeysByInstance?: Map<string, Set<string>>;
+	plexTopologyFingerprint?: string;
 	providerTopologyFingerprint: string;
 }
 
@@ -9438,11 +9596,13 @@ async function createMutationPolicySnapshot(
 	const rules = config.rules
 		.filter((rule) => rule.targetScope !== "episode")
 		.sort((left, right) => left.priority - right.priority || left.id.localeCompare(right.id));
-	const { ctx, failedSources, sourceCompletedAt } = await buildMutationEvalContext(
-		deps,
-		userId,
-		rules,
-	);
+	const {
+		ctx,
+		failedSources,
+		sourceCompletedAt,
+		plexRatingKeysByInstance,
+		plexTopologyFingerprint,
+	} = await buildMutationEvalContext(deps, userId, rules);
 	const oldestSourceCompletedAt =
 		sourceCompletedAt.size > 0
 			? new Date(Math.min(...[...sourceCompletedAt.values()].map((date) => date.getTime())))
@@ -9470,6 +9630,8 @@ async function createMutationPolicySnapshot(
 		failedSources,
 		sourceCompletedAt,
 		oldestSourceCompletedAt,
+		plexRatingKeysByInstance,
+		plexTopologyFingerprint,
 		providerTopologyFingerprint: providerTopologyFingerprint(providerInstances),
 	};
 	deps.log.info(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -2955,6 +2955,28 @@ async function assertCurrentPlexTargetCoveredByPolicySnapshot(
 	}
 }
 
+function assertRefreshedPlexTargetMatchesPolicySnapshot(
+	expected: PlexTargetRatingKeysByInstance,
+	current: PlexTargetRatingKeysByInstance,
+	targetKey: string,
+): void {
+	if (
+		expected.size !== current.size ||
+		[...expected.keys()].some((instanceId) => !current.has(instanceId))
+	) {
+		throw new Error("Refreshed Plex target coverage did not match the policy snapshot");
+	}
+	for (const [instanceId, expectedTargets] of expected) {
+		const expectedRatingKeys = [...(expectedTargets.get(targetKey) ?? new Set<string>())].sort();
+		const currentRatingKeys = [
+			...(current.get(instanceId)?.get(targetKey) ?? new Set<string>()),
+		].sort();
+		if (evidenceFingerprint(currentRatingKeys) !== evidenceFingerprint(expectedRatingKeys)) {
+			throw new Error("Plex target identity changed during final policy revalidation");
+		}
+	}
+}
+
 /**
  * Re-establish series/movie cleanup authorization at the mutation boundary.
  * The queued/preview match is durable intent only: current live ARR state,
@@ -2987,28 +3009,14 @@ export async function assertCurrentSeriesMutationAuthority(
 							throw new Error(`Unsupported cleanup service: ${instance.service}`);
 						})();
 		const liveItem = toLiveSeriesPolicyItem(instance, arrItemId, rawItem);
-		const policy = evaluateItemPolicyState(
-			liveItem,
-			policySnapshot.rules,
-			instance.service,
-			policySnapshot.ctx,
-			policySnapshot.failedSources,
-		);
-		if (
-			policy.kind !== "cleanup" ||
-			policy.match.ruleId !== expectedRule.matchedRuleId ||
-			policy.match.action !== expectedRule.action ||
-			(policy.match.scanMediaServerAfterDelete === true) !== expectedRule.scanMediaServerAfterDelete
-		) {
-			throw new Error("The exact matched cleanup policy is no longer authoritative");
-		}
-
 		const plexDependency = new Set<DataSourceDependency>(["plex"]);
 		const plexCanAffectPolicy = policySnapshot.rules.some(
 			(rule) =>
 				passesCleanupRuleFilters(liveItem, rule, instance.service) &&
 				ruleUsesUnavailableData(rule, plexDependency),
 		);
+		let currentPolicyCtx = policySnapshot.ctx;
+		let currentFailedSources = policySnapshot.failedSources;
 		if (plexCanAffectPolicy) {
 			if (
 				!policySnapshot.plexTargetRatingKeysByInstance ||
@@ -3042,7 +3050,52 @@ export async function assertCurrentSeriesMutationAuthority(
 				policySnapshot.plexTargetRatingKeysByInstance,
 				policySnapshot.plexTopologyFingerprint,
 			);
+
+			const activeTypes = collectActiveRuleTypes(policySnapshot.rules);
+			const currentPlexEvidence = await refreshPlexMutationEvidence(
+				deps,
+				userId,
+				activeTypes.has("plex_episode_completion"),
+				policySnapshot.rules,
+			);
+			if (
+				!currentPlexEvidence ||
+				!policySnapshot.plexTopologyFingerprint ||
+				currentPlexEvidence.topologyFingerprint !== policySnapshot.plexTopologyFingerprint
+			) {
+				throw new Error("Current Plex policy evidence did not match the authorized topology");
+			}
+			assertRefreshedPlexTargetMatchesPolicySnapshot(
+				policySnapshot.plexTargetRatingKeysByInstance,
+				currentPlexEvidence.ratingKeysByInstance,
+				targetKey,
+			);
+			currentPolicyCtx = {
+				...policySnapshot.ctx,
+				now: new Date(),
+				plexMap: currentPlexEvidence.plexMap,
+				plexSectionTitles: currentPlexEvidence.plexSectionTitles,
+				plexEpisodeMap: currentPlexEvidence.plexEpisodeMap,
+			};
+			currentFailedSources = new Set(policySnapshot.failedSources);
+			currentFailedSources.delete("plex");
 		}
+		const policy = evaluateItemPolicyState(
+			liveItem,
+			policySnapshot.rules,
+			instance.service,
+			currentPolicyCtx,
+			currentFailedSources,
+		);
+		if (
+			policy.kind !== "cleanup" ||
+			policy.match.ruleId !== expectedRule.matchedRuleId ||
+			policy.match.action !== expectedRule.action ||
+			(policy.match.scanMediaServerAfterDelete === true) !== expectedRule.scanMediaServerAfterDelete
+		) {
+			throw new Error("The exact matched cleanup policy is no longer authoritative");
+		}
+		await assertCurrentSeriesPolicySnapshotUnchanged(deps, userId, expectedRule, policySnapshot);
 		return { snapshot: policySnapshot, rawItem, policyItem: liveItem };
 	} catch (error) {
 		deps.log.warn(

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -547,6 +547,7 @@ describe("evictStaleRows", () => {
 				callback(tx),
 			),
 		} as unknown as PrismaClient;
+		vi.mocked(silentLog.info).mockClear();
 
 		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
@@ -555,6 +556,42 @@ describe("evictStaleRows", () => {
 			expect.objectContaining({ ignoredHistoricalItems: 1 }),
 			"Plex cache refresh complete",
 		);
+	});
+
+	it("fails closed when stale relevant history belongs to an unknown account", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "current",
+					title: "Current Movie",
+					type: "movie",
+					Guid: [{ id: "tmdb://42" }],
+				},
+			]),
+			getHistory: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "stale",
+					title: "Stale Movie",
+					type: "movie",
+					viewedAt: 1_700_000_000,
+					accountID: 999,
+				},
+			]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages).toContain(
+			"Plex cache incomplete: 1 history item(s) with unknown accounts",
+		);
+		expect(transaction).not.toHaveBeenCalled();
 	});
 
 	it.each([

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -558,6 +558,94 @@ describe("evictStaleRows", () => {
 		);
 	});
 
+	it("fails closed when a stale history key becomes current before publication", async () => {
+		const currentMovie = {
+			ratingKey: "current",
+			title: "Current Movie",
+			type: "movie",
+			Guid: [{ id: "tmdb://42" }],
+		};
+		const importedMovie = {
+			ratingKey: "imported",
+			title: "Imported Movie",
+			type: "movie",
+			Guid: [{ id: "tmdb://84" }],
+		};
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi
+				.fn()
+				.mockResolvedValueOnce([currentMovie])
+				.mockResolvedValueOnce([currentMovie, importedMovie]),
+			getHistory: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "imported",
+					title: "Imported Movie",
+					type: "movie",
+					viewedAt: 1_700_000_000,
+					accountID: 1,
+				},
+			]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const tx = {
+			plexCache: { deleteMany: vi.fn(), createMany: vi.fn() },
+			cacheRefreshStatus: { upsert: vi.fn() },
+		};
+		const transaction = vi.fn(
+			async (callback: (transactionClient: typeof tx) => Promise<unknown>) => callback(tx),
+		);
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages).toContain(
+			"Plex cache refresh failed: Plex library inventory changed before cache publication",
+		);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when cleanup-relevant library metadata changes before publication", async () => {
+		const initialMovie = {
+			ratingKey: "current",
+			title: "Current Movie",
+			type: "movie",
+			Guid: [{ id: "tmdb://42" }],
+			Label: [{ tag: "eligible-for-cleanup" }],
+		};
+		const changedMovie = { ...initialMovie, Label: [] };
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi
+				.fn()
+				.mockResolvedValueOnce([initialMovie])
+				.mockResolvedValueOnce([changedMovie]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const tx = {
+			plexCache: { deleteMany: vi.fn(), createMany: vi.fn() },
+			cacheRefreshStatus: { upsert: vi.fn() },
+		};
+		const transaction = vi.fn(
+			async (callback: (transactionClient: typeof tx) => Promise<unknown>) => callback(tx),
+		);
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages).toContain(
+			"Plex cache refresh failed: Plex library inventory changed before cache publication",
+		);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
 	it("fails closed when stale relevant history belongs to an unknown account", async () => {
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -513,6 +513,123 @@ describe("evictStaleRows", () => {
 		);
 	});
 
+	it("publishes a complete current show library while ignoring stale episode history", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "2", title: "Shows", type: "show" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "current-show",
+					title: "Current Show",
+					type: "show",
+					Guid: [{ id: "tmdb://84" }],
+				},
+			]),
+			getHistory: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "stale-episode",
+					grandparentRatingKey: "stale-show",
+					title: "Stale Episode",
+					type: "episode",
+					viewedAt: 1_700_000_000,
+					accountID: 1,
+				},
+			]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const tx = {
+			plexCache: { deleteMany: vi.fn(), createMany: vi.fn() },
+			cacheRefreshStatus: { upsert: vi.fn() },
+		};
+		const prisma = {
+			$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+				callback(tx),
+			),
+		} as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		expect(silentLog.info).toHaveBeenCalledWith(
+			expect.objectContaining({ ignoredHistoricalItems: 1 }),
+			"Plex cache refresh complete",
+		);
+	});
+
+	it.each([
+		[
+			"movie history has an empty rating key",
+			{ type: "movie", ratingKey: "", title: "Movie", viewedAt: 1_700_000_000, accountID: 1 },
+			"Plex cache incomplete: 1 history item(s) without a usable media key",
+		],
+		[
+			"episode history has no grandparent rating key",
+			{
+				type: "episode",
+				ratingKey: "episode-1",
+				title: "Episode",
+				viewedAt: 1_700_000_000,
+				accountID: 1,
+			},
+			"Plex cache incomplete: 1 history item(s) without a usable media key",
+		],
+	] as const)(
+		"fails closed without publication when %s",
+		async (_caseName, historyEntry, message) => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+				getLibraryItems: vi.fn().mockResolvedValue([
+					{
+						ratingKey: "current",
+						title: "Current Movie",
+						type: "movie",
+						Guid: [{ id: "tmdb://42" }],
+					},
+				]),
+				getHistory: vi.fn().mockResolvedValue([historyEntry]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const transaction = vi.fn();
+			const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false, upserted: 0 });
+			expect(result.errorMessages).toContain(message);
+			expect(transaction).not.toHaveBeenCalled();
+		},
+	);
+
+	it("fails closed without publication when a current library item has an empty rating key", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi
+				.fn()
+				.mockResolvedValue([
+					{ ratingKey: "", title: "Current Movie", type: "movie", Guid: [{ id: "tmdb://42" }] },
+				]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages).toContain(
+			"Plex cache incomplete: 1 current library item(s) without a usable rating key",
+		);
+		expect(transaction).not.toHaveBeenCalled();
+	});
+
 	it("fails closed when a current historical item has no TMDB metadata", async () => {
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
@@ -536,14 +653,17 @@ describe("evictStaleRows", () => {
 			]),
 			getOnDeck: vi.fn().mockResolvedValue([]),
 		} as unknown as PlexClient;
-		const deleteMany = vi.fn();
-		const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+		const transaction = vi.fn();
+		const prisma = { $transaction: transaction } as unknown as PrismaClient;
 		vi.mocked(silentLog.warn).mockClear();
 
 		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(deleteMany).not.toHaveBeenCalled();
+		expect(result.errorMessages).toContain(
+			"Plex cache incomplete: 1 current library item(s) without TMDB metadata",
+		);
+		expect(transaction).not.toHaveBeenCalled();
 		expect(silentLog.warn).toHaveBeenCalledWith(
 			expect.objectContaining({
 				incompleteReasons: expect.objectContaining({ currentItemsWithoutTmdbMetadata: 1 }),

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -463,7 +463,7 @@ describe("evictStaleRows", () => {
 		expect(deleteMany).not.toHaveBeenCalled();
 	});
 
-	it("fails closed when a relevant history row cannot be mapped to current metadata", async () => {
+	it("publishes a complete current library while ignoring history for a stale library key", async () => {
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
 			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
@@ -477,8 +477,58 @@ describe("evictStaleRows", () => {
 			]),
 			getHistory: vi.fn().mockResolvedValue([
 				{
-					ratingKey: "missing",
-					title: "Missing Movie",
+					ratingKey: "stale",
+					title: "Stale Movie",
+					type: "movie",
+					viewedAt: 1_700_000_000,
+					accountID: 1,
+				},
+			]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
+		const createMany = vi.fn().mockResolvedValue({ count: 1 });
+		const tx = {
+			plexCache: { deleteMany, createMany },
+			cacheRefreshStatus: { upsert: vi.fn().mockResolvedValue({}) },
+		};
+		const prisma = {
+			$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+				callback(tx),
+			),
+		} as unknown as PrismaClient;
+		vi.mocked(silentLog.info).mockClear();
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		expect(deleteMany).toHaveBeenCalledWith({ where: { instanceId: "inst-1" } });
+		expect(createMany).toHaveBeenCalledWith({
+			data: [expect.objectContaining({ ratingKey: "current", tmdbId: 42 })],
+		});
+		expect(silentLog.info).toHaveBeenCalledWith(
+			expect.objectContaining({ ignoredHistoricalItems: 1 }),
+			"Plex cache refresh complete",
+		);
+	});
+
+	it("fails closed when a current historical item has no TMDB metadata", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "current-without-tmdb",
+					title: "Current Movie Without TMDB",
+					type: "movie",
+					Guid: [],
+				},
+			]),
+			getHistory: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "current-without-tmdb",
+					title: "Current Movie Without TMDB",
 					type: "movie",
 					viewedAt: 1_700_000_000,
 					accountID: 1,
@@ -487,19 +537,19 @@ describe("evictStaleRows", () => {
 			getOnDeck: vi.fn().mockResolvedValue([]),
 		} as unknown as PlexClient;
 		const deleteMany = vi.fn();
-		const prisma = {
-			plexCache: {
-				upsert: vi.fn().mockResolvedValue({ id: "fresh-1" }),
-				findMany: vi.fn(),
-				deleteMany,
-			},
-			$transaction: vi.fn(async (operations: Promise<unknown>[]) => Promise.all(operations)),
-		} as unknown as PrismaClient;
+		const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+		vi.mocked(silentLog.warn).mockClear();
 
 		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
-		expect(result.complete).toBe(false);
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
 		expect(deleteMany).not.toHaveBeenCalled();
+		expect(silentLog.warn).toHaveBeenCalledWith(
+			expect.objectContaining({
+				incompleteReasons: expect.objectContaining({ currentItemsWithoutTmdbMetadata: 1 }),
+			}),
+			"Plex cache: skipping eviction because the refreshed inventory was incomplete",
+		);
 	});
 
 	it("fails closed when one discovered library returns only a partial snapshot", async () => {

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -646,6 +646,119 @@ describe("evictStaleRows", () => {
 		expect(transaction).not.toHaveBeenCalled();
 	});
 
+	it.each(["history", "on-deck"] as const)(
+		"fails closed when Plex %s changes during final library verification",
+		async (activity) => {
+			let inventoryVerificationFinished = false;
+			const currentMovie = {
+				ratingKey: "current",
+				title: "Current Movie",
+				type: "movie",
+				Guid: [{ id: "tmdb://42" }],
+			};
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+				getLibraryItems: vi
+					.fn()
+					.mockResolvedValueOnce([currentMovie])
+					.mockImplementationOnce(async () => {
+						inventoryVerificationFinished = true;
+						return [currentMovie];
+					}),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn(async () => {
+					if (activity === "history" && inventoryVerificationFinished) {
+						throw new Error("Plex history changed during inventory verification");
+					}
+				}),
+				getOnDeck: vi.fn(async () =>
+					activity === "on-deck" && inventoryVerificationFinished
+						? [{ ratingKey: "current", type: "movie" }]
+						: [],
+				),
+			} as unknown as PlexClient;
+			const tx = {
+				plexCache: { deleteMany: vi.fn(), createMany: vi.fn() },
+				cacheRefreshStatus: { upsert: vi.fn() },
+			};
+			const transaction = vi.fn(
+				async (callback: (transactionClient: typeof tx) => Promise<unknown>) => callback(tx),
+			);
+			const prisma = { $transaction: transaction } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false, upserted: 0 });
+			expect(transaction).not.toHaveBeenCalled();
+		},
+	);
+
+	it("preserves every current rating key when duplicate editions share one cache row", async () => {
+		const editions = [
+			{
+				ratingKey: "edition-a",
+				title: "Example Movie",
+				type: "movie",
+				Guid: [{ id: "tmdb://42" }],
+			},
+			{
+				ratingKey: "edition-b",
+				title: "Example Movie",
+				type: "movie",
+				Guid: [{ id: "tmdb://42" }],
+			},
+		];
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue(editions),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined, {
+			publish: false,
+		});
+
+		expect(result.snapshot?.rows).toHaveLength(1);
+		expect(result.inventoryTargets).toEqual([
+			{ mediaType: "movie", tmdbId: 42, ratingKey: "edition-a" },
+			{ mediaType: "movie", tmdbId: 42, ratingKey: "edition-b" },
+		]);
+	});
+
+	it("uses TVDb identity for current Sonarr series targets", async () => {
+		const series = {
+			ratingKey: "show-123",
+			title: "Example Series",
+			type: "show",
+			Guid: [{ id: "tmdb://42" }, { id: "tvdb://123" }],
+		};
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "2", title: "Shows", type: "show" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([series]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined, {
+			publish: false,
+		});
+
+		expect(result.snapshot?.rows).toHaveLength(1);
+		expect(result.inventoryTargets).toEqual([
+			{ mediaType: "series", tmdbId: 42, tvdbId: 123, ratingKey: "show-123" },
+		]);
+	});
+
 	it("fails closed when stale relevant history belongs to an unknown account", async () => {
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),

--- a/apps/api/src/lib/plex/__tests__/plex-client-media-parts.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-media-parts.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PlexClient } from "../plex-client.js";
+import { PlexClient, PlexMovieNotFoundError } from "../plex-client.js";
 
 const log = {
 	warn: vi.fn(),
@@ -74,8 +74,8 @@ describe("PlexClient.getMovieMediaPartsByTmdbId", () => {
 		);
 		const client = new PlexClient("http://plex:32400", "token", log);
 
-		await expect(client.getMovieMediaPartsByTmdbId(42)).rejects.toThrow(
-			"no movie item for TMDb 42",
+		await expect(client.getMovieMediaPartsByTmdbId(42)).rejects.toBeInstanceOf(
+			PlexMovieNotFoundError,
 		);
 	});
 

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -139,12 +139,20 @@ export async function refreshPlexCache(
 	let completedAt: Date | undefined;
 	let superseded = false;
 	const errorMessages: string[] = [];
+	const incompleteReasons: Record<string, number> = {};
+	let totalLibraryItems = 0;
+	let mappedLibraryItems = 0;
+	let ignoredHistoricalItems = 0;
+	const markIncomplete = (reason: string) => {
+		complete = false;
+		incompleteReasons[reason] = (incompleteReasons[reason] ?? 0) + 1;
+	};
 
 	try {
 		// 1. Build accountId → username map
 		const accounts = await client.getAccounts();
 		if (accounts.length === 0) {
-			complete = false;
+			markIncomplete("noUserAccounts");
 			errors++;
 			errorMessages.push("Plex returned no user accounts");
 			log.warn({ instanceId }, "Plex cache refresh: no user accounts discovered");
@@ -158,7 +166,7 @@ export async function refreshPlexCache(
 		const sections = await client.getLibrarySections();
 		const mediaLibs = sections.filter((s) => s.type === "movie" || s.type === "show");
 		if (mediaLibs.length === 0) {
-			complete = false;
+			markIncomplete("noMediaLibraries");
 			errors++;
 			errorMessages.push("Plex returned no movie or show libraries");
 			log.warn({ instanceId }, "Plex cache refresh: no movie or show libraries discovered");
@@ -181,14 +189,19 @@ export async function refreshPlexCache(
 				thumb: string | null;
 			}
 		>();
+		const currentLibraryRatingKeys = new Set<string>();
 
 		for (const lib of mediaLibs) {
 			try {
 				const items = await client.getLibraryItems(lib.key);
 				for (const item of items) {
+					totalLibraryItems++;
+					if (item.ratingKey) {
+						currentLibraryRatingKeys.add(item.ratingKey);
+					}
 					const tmdbId = parsePlexTmdbId(item.Guid);
 					if (!tmdbId) {
-						complete = false;
+						markIncomplete("currentItemsWithoutTmdbMetadata");
 						continue;
 					}
 
@@ -208,13 +221,14 @@ export async function refreshPlexCache(
 					});
 				}
 			} catch (err) {
-				complete = false;
+				markIncomplete("librarySnapshotFetchFailures");
 				const msg = `Failed to fetch library "${lib.title}": ${getErrorMessage(err)}`;
 				log.warn({ err, sectionId: lib.key, sectionTitle: lib.title }, msg);
 				errors++;
 				errorMessages.push(msg);
 			}
 		}
+		mappedLibraryItems = ratingKeyMap.size;
 
 		// 4. Get history and aggregate (per-section: key includes sectionId)
 		const history = await client.getHistory({ maxResults: 100_000, requireComplete: true });
@@ -228,16 +242,22 @@ export async function refreshPlexCache(
 				? (entry.grandparentRatingKey ?? entry.ratingKey)
 				: entry.ratingKey;
 
+			const isRelevantHistory = entry.type === "movie" || entry.type === "episode";
+			if (isRelevantHistory && !currentLibraryRatingKeys.has(itemRatingKey)) {
+				ignoredHistoricalItems++;
+				continue;
+			}
+
 			const itemData = ratingKeyMap.get(itemRatingKey);
 			if (!itemData) {
-				if (entry.type === "movie" || entry.type === "episode") complete = false;
+				if (isRelevantHistory) markIncomplete("currentHistoryItemsWithoutMappedMetadata");
 				continue;
 			}
 
 			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
 			const username = accountMap.get(entry.accountID);
 			if (!username) {
-				complete = false;
+				markIncomplete("historyItemsWithUnknownAccounts");
 				continue;
 			}
 
@@ -308,7 +328,9 @@ export async function refreshPlexCache(
 
 				const itemData = ratingKeyMap.get(itemRatingKey);
 				if (!itemData) {
-					if (deckItem.type === "movie" || deckItem.type === "episode") complete = false;
+					if (deckItem.type === "movie" || deckItem.type === "episode") {
+						markIncomplete("onDeckItemsWithoutMappedMetadata");
+					}
 					continue;
 				}
 
@@ -319,14 +341,13 @@ export async function refreshPlexCache(
 				}
 			}
 		} catch (err) {
-			complete = false;
+			markIncomplete("onDeckFetchFailures");
 			errors++;
 			errorMessages.push(`Failed to fetch Plex on-deck items: ${getErrorMessage(err)}`);
 			log.warn({ err }, "Failed to fetch Plex on-deck items");
 		}
 
 		// Release ratingKeyMap — all data now lives in aggregations (#239)
-		const libraryItemCount = ratingKeyMap.size;
 		ratingKeyMap.clear();
 
 		// 6. Publish one complete generation atomically. Until every upstream
@@ -466,7 +487,15 @@ export async function refreshPlexCache(
 			}
 		} else {
 			log.warn(
-				{ instanceId, aggregationSize: aggregationsArray.length, errors },
+				{
+					instanceId,
+					aggregationSize: aggregationsArray.length,
+					totalLibraryItems,
+					mappedLibraryItems,
+					ignoredHistoricalItems,
+					incompleteReasons,
+					errors,
+				},
 				"Plex cache: skipping eviction because the refreshed inventory was incomplete",
 			);
 		}
@@ -474,7 +503,10 @@ export async function refreshPlexCache(
 		log.info(
 			{
 				instanceId,
-				totalLibraryItems: libraryItemCount,
+				totalLibraryItems,
+				mappedLibraryItems,
+				ignoredHistoricalItems,
+				incompleteReasons,
 				totalHistory: historyCount,
 				uniqueItems: aggregationsArray.length,
 				upserted,

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -118,6 +118,33 @@ function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): s
 		.sort();
 }
 
+function mediaLibrarySignature(
+	sections: Awaited<ReturnType<PlexClient["getLibrarySections"]>>,
+): string[] {
+	return sections
+		.map((section) => JSON.stringify([section.key, section.title, section.type]))
+		.sort();
+}
+
+function libraryInventoryItemSignature(
+	section: { key: string; type: string },
+	item: Awaited<ReturnType<PlexClient["getLibraryItems"]>>[number],
+): string {
+	return JSON.stringify([
+		section.key,
+		section.type,
+		item.ratingKey,
+		item.type,
+		item.title,
+		item.userRating ?? null,
+		item.addedAt ?? null,
+		item.thumb ?? null,
+		(item.Guid ?? []).map((guid) => guid.id).sort(),
+		(item.Collection ?? []).map((collection) => collection.tag).sort(),
+		(item.Label ?? []).map((label) => label.tag).sort(),
+	]);
+}
+
 const incompleteReasonLabels: Record<string, string> = {
 	currentLibraryItemsWithoutRatingKeys: "current library item(s) without a usable rating key",
 	currentItemsWithoutTmdbMetadata: "current library item(s) without TMDB metadata",
@@ -184,6 +211,7 @@ export async function refreshPlexCache(
 		// 2. Get library sections (movie and show only)
 		const sections = await client.getLibrarySections();
 		const mediaLibs = sections.filter((s) => s.type === "movie" || s.type === "show");
+		const initialMediaLibrarySignature = mediaLibrarySignature(mediaLibs);
 		if (mediaLibs.length === 0) {
 			markIncomplete("noMediaLibraries");
 			errors++;
@@ -209,11 +237,13 @@ export async function refreshPlexCache(
 			}
 		>();
 		const currentLibraryRatingKeys = new Set<string>();
+		const initialLibraryInventorySignature: string[] = [];
 
 		for (const lib of mediaLibs) {
 			try {
 				const items = await client.getLibraryItems(lib.key);
 				for (const item of items) {
+					initialLibraryInventorySignature.push(libraryInventoryItemSignature(lib, item));
 					totalLibraryItems++;
 					if (!item.ratingKey.trim()) {
 						markIncomplete("currentLibraryItemsWithoutRatingKeys");
@@ -249,6 +279,7 @@ export async function refreshPlexCache(
 				errorMessages.push(msg);
 			}
 		}
+		initialLibraryInventorySignature.sort();
 		mappedLibraryItems = ratingKeyMap.size;
 
 		// 4. Get history and aggregate (per-section: key includes sectionId)
@@ -389,6 +420,30 @@ export async function refreshPlexCache(
 			const latestOnDeckSignature = onDeckSignature(await client.getOnDeck());
 			if (JSON.stringify(latestOnDeckSignature) !== JSON.stringify(verifiedOnDeckSignature)) {
 				throw new Error("Plex on-deck state changed before cache publication");
+			}
+			const latestSections = await client.getLibrarySections();
+			const latestMediaLibs = latestSections.filter(
+				(section) => section.type === "movie" || section.type === "show",
+			);
+			if (
+				JSON.stringify(mediaLibrarySignature(latestMediaLibs)) !==
+				JSON.stringify(initialMediaLibrarySignature)
+			) {
+				throw new Error("Plex library sections changed before cache publication");
+			}
+			const latestLibraryInventorySignature: string[] = [];
+			for (const lib of latestMediaLibs) {
+				const items = await client.getLibraryItems(lib.key);
+				for (const item of items) {
+					latestLibraryInventorySignature.push(libraryInventoryItemSignature(lib, item));
+				}
+			}
+			latestLibraryInventorySignature.sort();
+			if (
+				JSON.stringify(latestLibraryInventorySignature) !==
+				JSON.stringify(initialLibraryInventorySignature)
+			) {
+				throw new Error("Plex library inventory changed before cache publication");
 			}
 			completedAt = new Date();
 			if (options.publish === false) {

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -45,6 +45,19 @@ function parsePlexTmdbId(guids: Array<{ id: string }> | undefined): number | nul
 	return null;
 }
 
+function parsePlexTvdbId(guids: Array<{ id: string }> | undefined): number | null {
+	if (!guids) return null;
+
+	for (const guid of guids) {
+		const match = guid.id.match(/^tvdb:\/\/(\d+)$/);
+		if (match?.[1]) {
+			return Number.parseInt(match[1], 10);
+		}
+	}
+
+	return null;
+}
+
 // ============================================================================
 // Aggregation Types
 // ============================================================================
@@ -91,6 +104,13 @@ export interface PlexCacheSnapshot {
 	sections: Array<{ key: string; title: string; type: "movie" | "show" }>;
 }
 
+export interface PlexInventoryTarget {
+	mediaType: "movie" | "series";
+	tmdbId: number;
+	tvdbId?: number;
+	ratingKey: string;
+}
+
 export interface PlexCacheRefreshOptions {
 	publish?: boolean;
 }
@@ -102,7 +122,9 @@ export interface PlexCacheRefreshResult {
 	complete: boolean;
 	completedAt?: Date;
 	superseded?: boolean;
+	generationId?: string;
 	snapshot?: PlexCacheSnapshot;
+	inventoryTargets?: PlexInventoryTarget[];
 }
 
 function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): string[] {
@@ -184,11 +206,13 @@ export async function refreshPlexCache(
 	let complete = true;
 	let completedAt: Date | undefined;
 	let superseded = false;
+	let publishedGenerationId: string | undefined;
 	const errorMessages: string[] = [];
 	const incompleteReasons: Record<string, number> = {};
 	let totalLibraryItems = 0;
 	let mappedLibraryItems = 0;
 	let ignoredHistoricalItems = 0;
+	let verifiedInventoryTargets: PlexInventoryTarget[] | undefined;
 	const markIncomplete = (reason: string) => {
 		complete = false;
 		incompleteReasons[reason] = (incompleteReasons[reason] ?? 0) + 1;
@@ -238,6 +262,7 @@ export async function refreshPlexCache(
 		>();
 		const currentLibraryRatingKeys = new Set<string>();
 		const initialLibraryInventorySignature: string[] = [];
+		const inventoryTargets: PlexInventoryTarget[] = [];
 
 		for (const lib of mediaLibs) {
 			try {
@@ -257,6 +282,13 @@ export async function refreshPlexCache(
 					}
 
 					const mediaType: "movie" | "series" = item.type === "movie" ? "movie" : "series";
+					const tvdbId = mediaType === "series" ? parsePlexTvdbId(item.Guid) : null;
+					inventoryTargets.push({
+						mediaType,
+						tmdbId,
+						...(tvdbId ? { tvdbId } : {}),
+						ratingKey: item.ratingKey,
+					});
 					ratingKeyMap.set(item.ratingKey, {
 						tmdbId,
 						mediaType,
@@ -280,6 +312,13 @@ export async function refreshPlexCache(
 			}
 		}
 		initialLibraryInventorySignature.sort();
+		inventoryTargets.sort(
+			(left, right) =>
+				left.mediaType.localeCompare(right.mediaType) ||
+				left.tmdbId - right.tmdbId ||
+				(left.tvdbId ?? 0) - (right.tvdbId ?? 0) ||
+				left.ratingKey.localeCompare(right.ratingKey),
+		);
 		mappedLibraryItems = ratingKeyMap.size;
 
 		// 4. Get history and aggregate (per-section: key includes sectionId)
@@ -416,11 +455,6 @@ export async function refreshPlexCache(
 		aggregations.clear();
 
 		if (errors === 0 && complete) {
-			await client.verifyHistorySnapshot(history);
-			const latestOnDeckSignature = onDeckSignature(await client.getOnDeck());
-			if (JSON.stringify(latestOnDeckSignature) !== JSON.stringify(verifiedOnDeckSignature)) {
-				throw new Error("Plex on-deck state changed before cache publication");
-			}
 			const latestSections = await client.getLibrarySections();
 			const latestMediaLibs = latestSections.filter(
 				(section) => section.type === "movie" || section.type === "show",
@@ -445,6 +479,12 @@ export async function refreshPlexCache(
 			) {
 				throw new Error("Plex library inventory changed before cache publication");
 			}
+			await client.verifyHistorySnapshot(history);
+			const latestOnDeckSignature = onDeckSignature(await client.getOnDeck());
+			if (JSON.stringify(latestOnDeckSignature) !== JSON.stringify(verifiedOnDeckSignature)) {
+				throw new Error("Plex on-deck state changed before cache publication");
+			}
+			verifiedInventoryTargets = inventoryTargets;
 			completedAt = new Date();
 			if (options.publish === false) {
 				const sections = mediaLibs
@@ -483,6 +523,7 @@ export async function refreshPlexCache(
 					errorMessages: [],
 					complete: true,
 					completedAt,
+					inventoryTargets,
 					snapshot: { rows, sections },
 				};
 			}
@@ -555,6 +596,7 @@ export async function refreshPlexCache(
 				);
 				if (publication.matched) {
 					upserted = aggregationsArray.length;
+					publishedGenerationId = generationId;
 				} else {
 					superseded = true;
 					complete = false;
@@ -613,6 +655,9 @@ export async function refreshPlexCache(
 		complete: complete && errors === 0,
 		completedAt,
 		superseded: superseded || undefined,
+		generationId: complete && errors === 0 && completedAt ? publishedGenerationId : undefined,
+		inventoryTargets:
+			complete && errors === 0 && completedAt ? verifiedInventoryTargets : undefined,
 	};
 }
 

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -118,6 +118,25 @@ function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): s
 		.sort();
 }
 
+const incompleteReasonLabels: Record<string, string> = {
+	currentLibraryItemsWithoutRatingKeys: "current library item(s) without a usable rating key",
+	currentItemsWithoutTmdbMetadata: "current library item(s) without TMDB metadata",
+	historyItemsWithoutUsableMediaKey: "history item(s) without a usable media key",
+	currentHistoryItemsWithoutMappedMetadata: "current history item(s) without mapped TMDB metadata",
+	historyItemsWithUnknownAccounts: "history item(s) with unknown accounts",
+	onDeckItemsWithoutMappedMetadata: "on-deck item(s) without mapped TMDB metadata",
+};
+
+function appendIncompleteReasonMessages(
+	errorMessages: string[],
+	incompleteReasons: Record<string, number>,
+): void {
+	for (const [reason, count] of Object.entries(incompleteReasons)) {
+		const label = incompleteReasonLabels[reason];
+		if (label) errorMessages.push(`Plex cache incomplete: ${count} ${label}`);
+	}
+}
+
 // ============================================================================
 // Refresher
 // ============================================================================
@@ -196,9 +215,11 @@ export async function refreshPlexCache(
 				const items = await client.getLibraryItems(lib.key);
 				for (const item of items) {
 					totalLibraryItems++;
-					if (item.ratingKey) {
-						currentLibraryRatingKeys.add(item.ratingKey);
+					if (!item.ratingKey.trim()) {
+						markIncomplete("currentLibraryItemsWithoutRatingKeys");
+						continue;
 					}
+					currentLibraryRatingKeys.add(item.ratingKey);
 					const tmdbId = parsePlexTmdbId(item.Guid);
 					if (!tmdbId) {
 						markIncomplete("currentItemsWithoutTmdbMetadata");
@@ -236,13 +257,12 @@ export async function refreshPlexCache(
 		const aggregations = new Map<string, ItemAggregation>();
 
 		for (const entry of history) {
-			// For episodes, use the show's ratingKey
-			const isEpisode = entry.type === "episode";
-			const itemRatingKey = isEpisode
-				? (entry.grandparentRatingKey ?? entry.ratingKey)
-				: entry.ratingKey;
-
 			const isRelevantHistory = entry.type === "movie" || entry.type === "episode";
+			const itemRatingKey = entry.type === "episode" ? entry.grandparentRatingKey : entry.ratingKey;
+			if (isRelevantHistory && !itemRatingKey?.trim()) {
+				markIncomplete("historyItemsWithoutUsableMediaKey");
+				continue;
+			}
 			if (isRelevantHistory && !currentLibraryRatingKeys.has(itemRatingKey)) {
 				ignoredHistoricalItems++;
 				continue;
@@ -521,6 +541,8 @@ export async function refreshPlexCache(
 		errors++;
 		errorMessages.push(msg);
 	}
+
+	appendIncompleteReasonMessages(errorMessages, incompleteReasons);
 
 	return {
 		upserted,

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -259,13 +259,21 @@ export async function refreshPlexCache(
 		for (const entry of history) {
 			const isRelevantHistory = entry.type === "movie" || entry.type === "episode";
 			const itemRatingKey = entry.type === "episode" ? entry.grandparentRatingKey : entry.ratingKey;
-			if (isRelevantHistory && !itemRatingKey?.trim()) {
-				markIncomplete("historyItemsWithoutUsableMediaKey");
+			if (!itemRatingKey?.trim()) {
+				if (isRelevantHistory) markIncomplete("historyItemsWithoutUsableMediaKey");
 				continue;
 			}
-			if (isRelevantHistory && !currentLibraryRatingKeys.has(itemRatingKey)) {
-				ignoredHistoricalItems++;
-				continue;
+
+			const username = accountMap.get(entry.accountID);
+			if (isRelevantHistory) {
+				if (!username) {
+					markIncomplete("historyItemsWithUnknownAccounts");
+					continue;
+				}
+				if (!currentLibraryRatingKeys.has(itemRatingKey)) {
+					ignoredHistoricalItems++;
+					continue;
+				}
 			}
 
 			const itemData = ratingKeyMap.get(itemRatingKey);
@@ -275,7 +283,6 @@ export async function refreshPlexCache(
 			}
 
 			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
-			const username = accountMap.get(entry.accountID);
 			if (!username) {
 				markIncomplete("historyItemsWithUnknownAccounts");
 				continue;

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -81,6 +81,13 @@ export interface PlexSeriesMediaItem {
 	episodes: PlexEpisodeMediaItem[];
 }
 
+export class PlexMovieNotFoundError extends Error {
+	constructor(tmdbId: number) {
+		super(`Plex returned no movie item for TMDb ${tmdbId}`);
+		this.name = "PlexMovieNotFoundError";
+	}
+}
+
 export class PlexSeriesNotFoundError extends Error {
 	constructor(tvdbId: number) {
 		super(`Plex returned no series item for TVDB ${tvdbId}`);
@@ -339,7 +346,7 @@ export class PlexClient {
 			item.Guid?.some((guid) => guid.id === `tmdb://${tmdbId}`),
 		);
 		if (items.length === 0) {
-			throw new Error(`Plex returned no movie item for TMDb ${tmdbId}`);
+			throw new PlexMovieNotFoundError(tmdbId);
 		}
 
 		return items.map((item) => {


### PR DESCRIPTION
## Summary

- distinguish Plex's complete current-library inventory from retained history and TMDB-mapped cache evidence
- re-read every Plex section and item, then re-check history and on-deck activity, before publishing a cache generation
- bind exact per-instance movie and series identities to the generation that supplied the policy rows
- preserve duplicate Plex editions and both TMDB/TVDB series identity where available
- re-check Radarr and Sonarr targets twice at the final mutation boundary and fail closed on additions, removals, unstable reads, or topology changes
- re-read mutable Plex policy fields after target lookup and re-evaluate the exact rule before mutation
- re-read the ARR resource after the final Plex refresh so policy evaluation and downstream writes use current ARR state
- require Plex only for retention rules and cleanup rules capable of preceding the expected winner
- preserve bounded diagnostics without logging titles, account names, URLs, or media identifiers

## Root cause

Plex can retain watch-history rows after media leaves the current library. The cache refresher treated every history key missing from its TMDB map as incomplete, even when a complete current-library snapshot proved that key was historical. That prevented atomic publication and left Pulse reporting degraded cache coverage.

Cleanup also needed stronger generation and target binding. Aggregate cache rows can collapse duplicate editions, a target can appear or disappear after the policy snapshot, Sonarr's TMDB ID is optional even though its TVDB ID remains usable for exact Plex lookup, and mutable Plex or ARR policy values can change while a rating key remains stable.

## Safety

Atomic generation replacement and connection revalidation remain intact. A retained history key is ignored only when its valid media key is absent from a completely fetched current inventory. Sections, item identity, GUIDs, labels, collections, ratings, added dates, artwork identity, and titles are fetched again before publication. History and on-deck are checked after that potentially long inventory pass, so activity that changes during verification also fails closed without replacing the previous generation.

For cleanup mutations, each refresh pass verifies that its complete in-memory inventory belongs to the exact generation published to the database. The two accepted passes compare stable policy content, section coverage, target identities, and episode evidence rather than volatile generation IDs. Exact rating-key sets are retained per enabled Plex instance, including duplicate editions. Series identities carry TVDB alongside TMDB when Plex exposes both, allowing Sonarr targets without an optional TMDB ID to remain verifiable.

Immediately before an authorized Radarr or Sonarr mutation, the target is read twice from every enabled Plex instance. After that potentially long identity lookup, a final two-pass generation-bound refresh re-captures mutable Plex policy values and exact target identities together. Its topology and target set must still match the original authorized snapshot.

After the final Plex refresh, the ARR resource is fetched again. Its Plex correlation identity must remain unchanged, any newly applicable Plex-dependent policy fails closed, and the exact winning rule/action is evaluated against the fresh ARR resource and fresh Plex evidence. All retention rules remain authoritative, while a lower-priority Plex cleanup rule cannot disable a higher-priority non-Plex winner during a Plex outage. Configuration is checked again last, and the refreshed ARR resource is retained for downstream mutation checks.

An added or disappeared target, unstable read, changed label/collection/rating/watch/on-deck state, changed ARR policy state, missing identity evidence, generation mismatch, topology change, or rule change rejects the mutation.

This changes no schema, public API contract, frontend behavior, dependencies, filesystem cleanup implementation, or Plex mutation path.

## Validation

- focused mutation-authority suite: 25 passed
- `pnpm run typecheck` - passed
- `pnpm run test` - 89 shared, 617 web, and 3,816 API tests passed; 43 API tests skipped
- `pnpm run lint` - passed
- `pnpm run build` - passed
- disposable Plex reproduction: after removing one library item while retaining its watched-history row, refresh ignored the stale row, atomically reduced the cache to the current inventory, and completed with zero errors
- two independent local Codex review passes found no actionable defects
- independent regression and data-safety reviews passed the final correction batch

`pnpm run format` still reports four unrelated OIDC files that are byte-identical to `origin/main` and fail identically on the untouched base. Every file changed by this PR passes the formatter.

Related to #675
