### PR TITLE
chore(codex): add project-native workflows

### DIFF
--- a/.agents/skills/arr-fix-issue/SKILL.md
+++ b/.agents/skills/arr-fix-issue/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: arr-fix-issue
+description: Use when investigating, reproducing, fixing, or implementing a reported arr-dashboard GitHub issue, especially when the affected release line or safe issue linkage must be established.
+---
+
+# Fix an arr-dashboard issue safely
+
+1. Read `AGENTS.md`, `CLAUDE.md`, the issue URL or number, every reporter
+   comment, and all available reproduction evidence. Capture the reported
+   version, deployment, database, integrations, expected behavior, actual
+   behavior, and what remains unverified.
+2. Resolve the real base and branch roles from the current `AGENTS.md` and
+   repository state. Preserve unrelated worktree changes; do not infer a base
+   from the issue age or a plausible code path.
+3. Reproduce the reporter's actual scenario before editing. Trace the complete
+   data and mutation path, and stop with an explicit verification gap when the
+   reporter environment or exact scenario cannot be established.
+4. Add a failing regression test where practical, then implement the smallest
+   coherent correction. For destructive or upstream mutation paths, dispatch
+   the required independent `data_safety_reviewer` and `regression_reviewer`
+   passes before declaring readiness.
+5. Use `$arr-validate` for final checks and live-verify user-visible behavior.
+   Report the root cause, behavior changed, files, risks, validation evidence,
+   residual uncertainty, and any forward-port or release action.
+6. Do not commit, push, open a PR, comment, or close an issue unless the user
+   authorized it. Default issue linkage to `Related to #N`. Use a standalone
+   `Closes #N` only after exact reproduction and verification of the reported
+   scenario; never use closure language merely because a test or code path is
+   plausible. Sanitize commit messages as an independent auto-close surface.

--- a/.agents/skills/arr-fix-issue/agents/openai.yaml
+++ b/.agents/skills/arr-fix-issue/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fix arr-dashboard issue"
+  short_description: "Reproduce and fix a reported issue safely"
+  default_prompt: "Use $arr-fix-issue to investigate and fix this arr-dashboard issue."

--- a/.agents/skills/arr-integration-change/SKILL.md
+++ b/.agents/skills/arr-integration-change/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: arr-integration-change
+description: Use when adding, changing, debugging, or auditing arr-dashboard integrations with Sonarr, Radarr, Prowlarr, Lidarr, Readarr, Plex, Jellyfin, Emby, Seerr, Tautulli, Tracearr, or qui.
+---
+
+# Change an arr-dashboard integration
+
+1. Resolve the current target branch and the requested service contract before
+   copying an adjacent integration. Tautulli is supported on stable 2.x;
+   Tracearr replaces it on 3.0. Keep the change on the intended release line.
+2. Read [integration-risks.md](references/integration-risks.md) for contract
+   changes, service mutations, or production-shape audits. Record the target
+   service, upstream contract, and complete caller/consumer surface.
+3. Trace the change end to end: shared schema and Prisma service type,
+   credentials and client/factory, normalizer, routes/webhooks, API client,
+   query hooks, UI consumers, jobs, and existing tests. Include every caller
+   of changed helpers and every consumer of changed response fields.
+4. Normalize upstream data at the boundary and preserve repository contracts:
+   encrypt credentials with value plus IV; scope user-owned Prisma queries with
+   `request.currentUser!.id`; parse bodies with `validateRequest()`; register
+   route groups in the manifest and API route docs; support incognito fields;
+   use centralized query keys and polling constants.
+5. For Radarr/Sonarr updates, fetch the complete resource with `getById()` at
+   execution time, spread that fresh resource into the `PUT`, and apply only
+   the intended normalized change. Never send a partial update body or mutate
+   when ownership, service identity, or shared-library correlation is unclear.
+6. Add focused success, malformed-payload, dependency, retry/idempotency,
+   partial-success, and production-shaped failure tests for the traced callers.
+   Cover optional-service absence and, when applicable, pagination, auth
+   collisions, concurrent invocation, and multiple instances sharing a
+   library. Use populated fixtures rather than an empty development database.
+7. Delegate `data_safety_reviewer` for every service mutation or webhook
+   installation, and delegate `regression_reviewer` for substantial,
+   data-dependent, or deletion-adjacent changes. Resolve findings before
+   declaring the contract ready; disclose missing live evidence explicitly.
+8. Rebuild `@arr/shared` when its exports change, run `$arr-validate`, and
+   live-verify user-visible behavior when a reachable service is available.
+   Do not refactor unrelated integrations.

--- a/.agents/skills/arr-integration-change/agents/openai.yaml
+++ b/.agents/skills/arr-integration-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Change an integration"
+  short_description: "Modify external service contracts safely"
+  default_prompt: "Use $arr-integration-change to implement this arr-dashboard integration change."

--- a/.agents/skills/arr-integration-change/references/integration-risks.md
+++ b/.agents/skills/arr-integration-change/references/integration-risks.md
@@ -1,0 +1,73 @@
+# Integration contract and production risks
+
+Read this reference before changing an external-service contract, adding an
+upstream mutation, or auditing a production-shaped integration path. Trace the
+specific caller and consumer before selecting which cases apply.
+
+## Service matrix and optional dependencies
+
+Confirm the target release line and service contract instead of copying a
+neighbor. Sonarr, Radarr, Prowlarr, Lidarr, and Readarr have different resource
+shapes and mutation requirements. Plex, Jellyfin, Emby, Seerr, Tautulli,
+Tracearr, and qui have different authentication and response conventions.
+Treat an unconfigured optional service as an expected state: skip dependent
+work with an honest result, avoid misleading UI, and test the dependency
+failure. Do not turn a missing service into a successful upstream mutation.
+
+## Complete caller and consumer tracing
+
+Search every caller of a changed client, helper, normalizer, route, webhook, or
+shared type. Follow the value through schemas, Prisma persistence, factories,
+normalizers, jobs, routes, API clients, query hooks, UI, and tests. Check both
+list and detail paths, background work, retries, and webhook-triggered paths.
+Verify that response-field changes are understood by every consumer and that
+credentials remain encrypted as value plus IV. User-owned queries must include
+`request.currentUser!.id`; request bodies must use `validateRequest()`.
+
+## Upstream shape and boundary handling
+
+Normalize unstable or versioned responses at the integration boundary. Test
+missing fields, extra fields, wrong types, malformed JSON, error envelopes,
+pagination, rate limits, timeouts, and unavailable dependencies. Preserve
+pagination cursors and do not silently treat a truncated page as complete.
+Use bounded retries only for safe, retryable failures; ensure mutations are
+idempotent or carry a tested deduplication strategy.
+
+## Radarr and Sonarr full-resource updates
+
+Radarr and Sonarr may reject a partial update body. For every update, re-fetch
+the complete current resource with `getById()` immediately before mutation,
+spread that response into the `PUT`, and change only the intended field. Test
+required fields such as `qualityProfileId`, `rootFolderPath`, and existing
+tags, plus already-applied, fetch-failure, update-failure, and later-item
+continuation cases. Preserve all upstream fields and avoid stale list data.
+
+## Authentication and authorization boundaries
+
+Do not send unconditional Basic `Authorization`. It can collide with Bearer,
+MediaBrowser, or service-specific headers such as qui's API key. Test the
+authentication matrix for each service and ensure credentials are not exposed
+in URLs, logs, error messages, API responses, or browser state. Resolve and
+authorize the service instance at execution time; fail closed when identity or
+ownership is uncertain.
+
+## Shared libraries and multiple instances
+
+Treat multiple Sonarr/Radarr/etc. instances pointing to the same media library
+as normal production. Test same-title items across instances, distinct items
+with the same path, cross-instance IDs, stale cached ownership, and a client
+that returns a valid-looking resource from the wrong instance. Correlate by
+authorized instance identity and stable library/file identity, not title or a
+client-supplied owner. If correlation cannot be proven, skip the mutation and
+leave an actionable retryable result.
+
+## Mutation outcomes and review
+
+Record success only after the upstream mutation succeeds. Preserve honest
+partial-success state when one item fails, and test retry/idempotency and
+concurrent invocation. Dry runs and previews must select the same targets and
+actions without side effects. Every service mutation or webhook installation
+requires an independent read-only `data_safety_reviewer`; substantial or
+data-dependent changes also require `regression_reviewer`. Mocked tests prove
+request shape but do not replace live evidence; report unavailable live
+verification rather than claiming it.

--- a/.agents/skills/arr-prepare-pr/SKILL.md
+++ b/.agents/skills/arr-prepare-pr/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: arr-prepare-pr
+description: Assess arr-dashboard pull-request readiness and draft an accurate title and body from the real branch diff. Use when Codex is asked to prepare, open, refresh, or review a PR.
+---
+
+# Prepare an arr-dashboard pull request
+
+1. Resolve the actual base from an existing PR or branch intent. Stable 2.x
+   maintenance targets `main`; 3.0 work targets `next`.
+2. Inspect commits, the triple-dot diff, working-tree changes, linked issues,
+   and CI state. Surface unrelated or uncommitted work.
+3. Use `$arr-review-change`, then `$arr-validate`. A validation failure remains
+   visible even if it predates the branch.
+4. Draft:
+   - a conventional title under 70 characters describing the outcome;
+   - a concise summary and domain-specific change sections;
+   - an honest test plan using checks actually performed;
+   - files changed when it helps reviewers;
+   - risks, compatibility, and forward-port notes when applicable.
+5. Default issue references to `Related to #N`. Upgrade to a standalone
+   `Closes #N` line only after reproducing the exact reporter scenario before
+   the fix and verifying it afterward. Check commit messages for auto-close
+   language separately.
+6. Never `@`-mention people. Refer to `Kha-kis` in backticks or prose.
+
+Preparing text does not authorize committing, pushing, opening, updating, or
+merging a PR. Perform those actions only when the user explicitly requests
+them.

--- a/.agents/skills/arr-prepare-pr/agents/openai.yaml
+++ b/.agents/skills/arr-prepare-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare arr-dashboard PR"
+  short_description: "Prepare a focused and evidence-backed PR"
+  default_prompt: "Use $arr-prepare-pr to assess readiness and draft this pull request."

--- a/.agents/skills/arr-release/SKILL.md
+++ b/.agents/skills/arr-release/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: arr-release
+description: Prepare and verify arr-dashboard stable releases and 3.0 prereleases, including readiness, changelog, version surfaces, tagging, registries, GitHub Releases, and issue follow-up. Use for release planning or execution.
+---
+
+# Release arr-dashboard
+
+1. Read `docs/RELEASING.md`; it is authoritative. Resolve whether this is:
+   - a stable 2.x release from `main`; or
+   - a 3.0 alpha/beta/RC from an exact reviewed `next` SHA.
+2. Audit scope and blockers with `$arr-review-change` and `$arr-validate`.
+   Include `pnpm run build`.
+3. Prepare user-facing release notes from the actual commit range. Update every
+   version surface required by `docs/RELEASING.md`, including the wiki when
+   specified.
+4. Before publishing, confirm ancestry, clean state, reviewed SHA, CI, target
+   registries, tag type, and stable-versus-prerelease GitHub metadata.
+5. Use annotated tags. After publication, verify Docker Hub and GHCR artifacts,
+   container `/health` version/commit metadata, and the human-facing GitHub
+   Release. A successful image workflow does not create that release.
+6. Close only reproduced and resolved issues, with an explanatory release
+   comment. Keep unrelated or partially addressed issues open.
+
+Release planning and preparation do not authorize tagging, pushing, publishing,
+marking Latest, or closing issues. Perform each external action only when the
+user explicitly includes it in scope.

--- a/.agents/skills/arr-release/agents/openai.yaml
+++ b/.agents/skills/arr-release/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release arr-dashboard"
+  short_description: "Prepare stable and prerelease releases safely"
+  default_prompt: "Use $arr-release to prepare and verify this arr-dashboard release."

--- a/.agents/skills/arr-review-change/SKILL.md
+++ b/.agents/skills/arr-review-change/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: arr-review-change
+description: Review arr-dashboard branches and diffs for correctness, regressions, privacy, authorization, production data-shape failures, and mutation safety. Use for code review, merge-readiness, stabilization, trust checks, or regression audits.
+---
+
+# Review an arr-dashboard change
+
+1. Read `AGENTS.md` and `CLAUDE.md`.
+2. Resolve the actual PR base (`main` or `next`). Inspect the triple-dot branch
+   diff, commits, and uncommitted changes; never assume `main`.
+3. For substantial code changes, delegate a separate read-only pass to the
+   `regression_reviewer` project agent. For destructive or upstream mutations,
+   also delegate to `data_safety_reviewer`. Do not delegate trivial docs-only
+   reviews.
+4. Trace changed behavior through callers, shared contracts, API routes,
+   persistence, caches, and UI consumers. Test assumptions against populated,
+   paginated, multi-instance, null/fractional, and partial-failure data where
+   applicable.
+5. Check:
+   - authorization and `userId` scoping;
+   - validation, encryption, incognito masking, error redaction, and logging;
+   - centralized query keys, invalidation, polling, and durable status labels;
+   - route-manifest/API documentation contracts;
+   - dry-run parity, fail-closed behavior, idempotency, and honest partial
+     failure state for mutations;
+   - regression tests at the real failure boundary.
+6. Use `$arr-validate` when the user asks for readiness or when changes were
+   implemented in the same task.
+
+For review-only requests, do not implement fixes. Report concrete findings
+first, ordered by severity, with file/line references and failure scenarios.
+If none qualify, state that and list residual risks or validation gaps.

--- a/.agents/skills/arr-review-change/agents/openai.yaml
+++ b/.agents/skills/arr-review-change/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review arr-dashboard change"
+  short_description: "Review changes for regressions and safety"
+  default_prompt: "Use $arr-review-change to assess this branch for correctness and merge risk."

--- a/.agents/skills/arr-validate/SKILL.md
+++ b/.agents/skills/arr-validate/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: arr-validate
+description: Run and report the arr-dashboard verification gauntlet. Use when Codex is asked to validate, test, check, stabilize, or assess readiness of a change, and before preparing a pull request.
+---
+
+# Validate arr-dashboard
+
+1. Read `AGENTS.md` and resolve the change scope with `git status` and the diff
+   against the actual base branch.
+2. Run:
+
+   ```bash
+   pnpm run format
+   pnpm --filter @arr/shared build   # only when packages/shared changed
+   pnpm run typecheck
+   pnpm run test
+   pnpm run lint
+   ```
+
+3. Run `pnpm run build` for release-sensitive, dependency, Docker, routing, or
+   substantial frontend changes.
+4. Live-verify user-visible behavior in a real browser. Use populated fixtures
+   for data-dependent behavior.
+5. When a gate fails, determine whether the failure exists on the untouched
+   base. Do not bypass it or attribute it to the branch without evidence.
+6. Report `Check | Status | Details`, including skipped checks and why they were
+   not applicable.
+
+Validation-only requests authorize diagnosis, not unrelated fixes.

--- a/.agents/skills/arr-validate/agents/openai.yaml
+++ b/.agents/skills/arr-validate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate arr-dashboard"
+  short_description: "Run the repository verification gauntlet"
+  default_prompt: "Use $arr-validate to run and report the appropriate verification checks."

--- a/.codex/agents/data-safety-reviewer.toml
+++ b/.codex/agents/data-safety-reviewer.toml
@@ -1,0 +1,28 @@
+name = "data_safety_reviewer"
+description = "Read-only reviewer for deletion, cleanup, restore, schema, deployment, and upstream mutation safety."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and CLAUDE.md. Review the requested diff against its actual PR
+base; do not implement fixes.
+
+Trace the complete mutation path from user or scheduler input through target
+selection, preview or dry-run, authorization, upstream calls, persistence,
+caches, audit logs, notifications, retries, and restart behavior.
+
+Test mentally against multiple service instances sharing a media library,
+same-title collisions, stale previews and caches, missing integrations,
+timeouts after partial upstream success, concurrent execution, and retry after
+restart.
+
+Require preview/execution parity, execution-time ownership and identity,
+fail-closed uncertainty, upstream success before local success, honest
+retryable partial-failure state, idempotency, actionable redacted logs, and
+stable API/config compatibility.
+
+Report only concrete critical/high findings at confidence 80 or above, plus
+medium findings representing realistic data loss or a false operator audit
+trail. Use:
+Severity | Confidence | Location | Invariant | Failure scenario | Required fix
+If none qualify, list the paths and adversarial scenarios reviewed.
+"""

--- a/.codex/agents/regression-reviewer.toml
+++ b/.codex/agents/regression-reviewer.toml
@@ -1,0 +1,23 @@
+name = "regression_reviewer"
+description = "Read-only independent reviewer for correctness, production data shapes, regressions, and missing tests."
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Read AGENTS.md and CLAUDE.md. Review the requested diff against its actual PR
+base; do not implement fixes.
+
+Trace changed behavior through callers, shared contracts, routes, persistence,
+caches, hooks, and user-facing consumers. Look for data-dependent failures that
+empty development databases and mocked happy paths miss: pagination,
+multi-instance collisions, null or fractional values, partial results, stale
+cache, bodyless mutation requests, transient statuses, and optional-service
+absence.
+
+Check authorization, validation, encryption, privacy masking, query
+invalidation, upstream API contracts, failure reporting, and regression tests
+at the actual failure boundary.
+
+Report only actionable findings with severity, confidence, file/line,
+production failure scenario, and smallest required correction. If no findings
+qualify, state that and identify residual test or runtime-verification gaps.
+"""

--- a/.gitignore
+++ b/.gitignore
@@ -77,7 +77,9 @@ auth-state.json
 .claude/skills/next-best-practices
 .claude/skills/shadcn
 .claude/skills/web-design-guidelines
-.agents/
+.agents/*
+!.agents/skills/
+!.agents/skills/**
 skills-lock.json
 
 # AI/ML development tool artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,112 @@
+# AGENTS.md — arr-dashboard
+
+Read `CLAUDE.md` for the tracked architecture and pattern reference. A local
+`HANDOVER.md`, when present, is an optional machine-state snapshot: read it only
+when the task depends on the maintainer environment, local checkout state, or
+live instances. Do not load it for repository-only work, treat it as project
+policy, or use it as a credential source. Verify its volatile details before
+acting, and do not assume it exists in a fresh clone.
+
+Codex-native task workflows live in `.agents/skills/` and are automatically
+discoverable. Use the matching `arr-*` skill for issue fixes, validation,
+reviews, integration changes, PR preparation, and releases. Project reviewers
+live in `.codex/agents/`. `.claude/` files are compatibility material, not the
+canonical Codex workflow.
+
+## Branch and issue discipline
+
+- `main` is stable 2.x maintenance. Limit it to security fixes, data-safety
+  fixes, regressions, and explicitly approved maintenance.
+- `next` is 3.0 development and stabilization. New 3.0 work targets `next`.
+- Fetch the intended base and create a task branch before editing. Do not add
+  work to an unrelated branch merely because it is currently checked out.
+- For a bug affecting both lines, reproduce on both. Fix `main` first when
+  stable users are affected, then forward-port with a separate `next` change;
+  do not merge the branches wholesale.
+- Squash-merge PRs. Keep each PR focused on one coherent concern.
+- Never `@`-mention anyone in PR or issue text. The owner is `Kha-kis`;
+  `khak1s` is an unrelated GitHub user. Attribute with backticks or prose.
+- Use a standalone `Closes #N` PR-body line only after reproducing the
+  reporter's actual scenario and verifying the fix against it. Otherwise use
+  `Related to #N`. Sanitize commit messages as an independent auto-close
+  surface.
+
+## Safety-critical mutations
+
+Deletion, file removal, unmonitoring, queue cleanup, restore, schema change,
+TRaSH deployment, and upstream write paths are safety-critical.
+
+- Dry-run and preview modes must not mutate the database, filesystem, or an
+  upstream service. Previewed targets and actions must be the same targets and
+  actions used by real execution.
+- Fail closed when ownership, service identity, shared-library correlation,
+  file identity, upstream state, or a safety dependency cannot be established.
+  A failed safety check never becomes permission to mutate.
+- Resolve and authorize every target at execution time. Never trust a cached
+  preview, client-supplied owner, title, path, or instance identifier as final
+  authority.
+- Treat multiple service instances pointing at the same media library as a
+  normal production scenario. Test cross-instance and same-title collisions.
+- Record success only after the upstream mutation succeeds. On partial
+  failure, preserve an honest retryable state and an actionable audit trail;
+  never claim completion from a cache-only update.
+- Cover success, expected failure, dependency failure, dry-run, real mutation,
+  partial completion, retry/idempotency, and concurrent invocation as
+  applicable.
+- Run an independent data-safety review before merging deletion-adjacent work.
+  Delegate it to the read-only `data_safety_reviewer` project agent; the
+  implementer must not be the only reviewer of the mutation boundary.
+- Delegate a separate `regression_reviewer` pass for substantial,
+  data-dependent, or deletion-adjacent code changes. Do not spend subagents on
+  trivial documentation-only changes.
+
+## Verification gauntlet
+
+Run the narrowest useful test while iterating. Before every PR:
+
+```bash
+pnpm run format
+pnpm --filter @arr/shared build   # required when packages/shared changed
+pnpm run typecheck                # root Turbo check; per-package tsc is insufficient
+pnpm run test
+pnpm run lint
+```
+
+Use `$arr-validate` to apply and report this gauntlet consistently.
+
+Run `pnpm run build` for release-sensitive, dependency, Docker, routing, or
+substantial frontend changes. Live-verify user-visible behavior in a real
+browser. Use populated fixtures for data-dependent behavior; an empty
+development database is not sufficient evidence.
+
+## Code invariants
+
+1. Frontend calls `/api/*` through Next rewrites, never `localhost:3001`.
+2. Include `userId: request.currentUser!.id` in every Prisma query for
+   user-owned resources.
+3. Encrypt API keys with `app.encryptor.encrypt()` and store both value and IV.
+4. Parse request bodies with `validateRequest()`; never cast
+   `request.body as Type`.
+5. Sensitive titles, usernames, URLs, and instance names require incognito
+   helpers; component tests require `<IncognitoProvider>`.
+6. Use centralized query keys and polling constants; invalidate after
+   mutations.
+7. Use semantic/brand/theme colors and semantic z-index classes.
+8. Radarr/Sonarr updates fetch the full resource with `getById()` and spread it
+   into the PUT payload.
+9. A new route group requires a route-manifest entry and
+   `docs/API-ROUTES.md`; a new Pulse collector requires `COLLECTOR_LABELS` and
+   a stable entity-keyed signal id.
+10. Use `getErrorMessage()` and pino (`request.log`/`app.log`), never production
+    `console.log`.
+
+## Definition of done
+
+- The reported scenario is represented by a regression test where practical.
+- Focused tests and the repository gauntlet pass; failures are reported
+  honestly rather than bypassed.
+- User-visible behavior is live-verified and documented when needed.
+- No secrets, generated artifacts, placeholders, commented-out
+  implementations, or unrelated cleanup enter the diff.
+- The final handoff states behavior changed, files affected, risks, validation,
+  and any required forward-port or release action.

--- a/docs/ENGINEERING.md
+++ b/docs/ENGINEERING.md
@@ -1,0 +1,232 @@
+# Engineering Guide
+
+Repository policy and workflow routing live in [`AGENTS.md`](../AGENTS.md).
+This document explains the architecture and established implementation
+patterns. Domain-specific details remain authoritative in the linked reference
+documents.
+
+## Quick Start
+
+Install dependencies and start the API and web applications:
+
+```bash
+pnpm install && pnpm run dev  # API (3001) + Web (3000)
+```
+
+Before submitting a change, run the repository verification commands:
+
+```bash
+pnpm run format
+pnpm --filter @arr/shared build                  # Required after shared changes
+pnpm run typecheck                               # CI-equivalent Turbo typecheck
+pnpm run test
+pnpm run lint
+```
+
+## Repository Map
+
+```text
+apps/api/src/routes/                         # API route handlers
+apps/api/src/lib/                            # Shared backend logic
+apps/api/prisma/schema.prisma                # Database schema source of truth
+apps/web/app/                                # Next.js pages
+apps/web/src/features/                       # Feature-specific components by domain
+apps/web/src/hooks/api/                      # React Query hooks
+apps/web/src/lib/api-client/                 # API client modules
+apps/web/src/lib/theme-gradients.ts          # Color system source of truth
+apps/web/src/components/layout/premium-components.tsx  # Reusable UI components
+packages/shared/src/types/                   # Shared Zod schemas and TypeScript types
+```
+
+## Architecture
+
+The repository is a pnpm 10+ Turbo monorepo containing a Fastify 5 API, a
+Next.js 16 App Router web application, and shared Zod types. The frontend uses
+React 19, TanStack Query, TailwindCSS, and shadcn/ui. SQLite is the default
+database and PostgreSQL is supported.
+
+The application is a single-admin, self-hosted system. Authentication is
+session-based rather than JWT-based, with password, OIDC, and passkey methods.
+Authentication internals are documented in [`docs/AUTH.md`](AUTH.md).
+
+Frontend requests use `/api/*` paths through Next.js rewrites. The navigation
+preflight assists with redirects, while the API protected scope is the
+authoritative authentication gate and returns 401 for unauthenticated
+requests.
+
+Fastify route handlers can use the auth-populated `request.currentUser` and
+`request.sessionToken`, together with `app.prisma`, `app.encryptor`,
+`app.sessionService`, and `app.config`.
+
+## Code Style and Conventions
+
+- Biome formats the API and shared packages; ESLint applies web-specific rules.
+  Use `pnpm run lint` and `pnpm run format`.
+- TypeScript uses strict mode with `noUncheckedIndexedAccess: true`.
+- Feature modules use relative imports. Base UI components use the `@/` alias.
+- Default to Server Components; add `"use client"` for hooks or
+  interactivity.
+- Use `useThemeGradient()` for theme colors and the centralized semantic,
+  brand, service, and protocol color helpers. Never hardcode colors or use the
+  retired two-line theme pattern. See [`docs/THEMING.md`](THEMING.md).
+- Use semantic z-index classes such as `z-modal`, `z-toast`, and `z-dropdown`;
+  do not use arbitrary values such as `z-[9999]`.
+- Check `premium-components.tsx` before creating custom UI. It contains shared
+  cards, badges, tabs, tables, and buttons.
+- Use `getErrorMessage()` from
+  `apps/api/src/lib/utils/error-message.ts` for API error text.
+- Use pino through `request.log` or `app.log`; do not use production
+  `console.log`.
+- Define React Query keys in `lib/query-keys.ts`, and use named constants from
+  `lib/polling-intervals.ts` instead of inline interval numbers.
+- Use `useRefreshState()` from `hooks/useRefreshState.ts` for refresh buttons.
+- Avoid broad refactors and unrelated cleanup.
+
+## Adding Features
+
+For a new API route:
+
+1. Create `apps/api/src/routes/<domain>.ts`.
+2. Register it in `apps/api/src/routes/route-manifest.ts` and document the
+   group in [`docs/API-ROUTES.md`](API-ROUTES.md).
+3. Add Zod types to `packages/shared/src/types/<domain>.ts`.
+4. Add an API client to `apps/web/src/lib/api-client/<domain>.ts`.
+5. Add a React Query hook to `apps/web/src/hooks/api/use<Domain>.ts`.
+
+For a new frontend page:
+
+1. Create `apps/web/app/<route>/page.tsx`.
+2. Add components under `apps/web/src/features/<feature>/`.
+3. Keep data flow as API client → React Query hook → component.
+
+When a new route group is introduced, update the route manifest and the API
+route reference together. Use the domain documents for route, auth, and UI
+specific rules rather than copying those rules here.
+
+## Database
+
+`apps/api/prisma/schema.prisma` is the single source of truth. The project uses
+`db push` rather than migrations for multi-provider support:
+
+```bash
+pnpm --filter @arr/api run db:push       # sync schema and regenerate client
+pnpm --filter @arr/api run db:generate   # regenerate Prisma client only
+pnpm --filter @arr/api run db:sync       # sync schema only, skip client regeneration
+```
+
+Local development defaults to `file:./dev.db`. The supported single-container
+image sets `DATABASE_URL` to `file:/config/prod.db`; the API's production
+fallback is `file:/app/data/prod.db` when no deployment value is supplied.
+PostgreSQL is supported through `DATABASE_URL`.
+
+## Backend Patterns
+
+- Use `createInstanceFetcher(app, instance)` for calls to configured external
+  application instances.
+- Use `requireInstance()` from `lib/arr/instance-helpers.ts` for instance
+  lookup; it throws `InstanceNotFoundError` when the instance is unavailable.
+- Use `requireTemplate()` from `lib/trash-guides/template-helpers.ts` for
+  template lookup.
+- Use `resolveCanonicalIssuer()` from `lib/auth/oidc-utils.ts` for OIDC
+  discovery URLs.
+- Use `parsePaginationQuery()` from `lib/utils/pagination.ts` for pagination.
+- Error handling is centralized in `server.ts`, with branches for ARR errors,
+  status-code conventions, Prisma errors, and a generic fallback. Custom
+  errors belong in `lib/errors.ts`.
+
+## Frontend Patterns
+
+Keep the data path as API client module → domain hook → feature hook →
+component. Domain hooks in `hooks/api/use*.ts` wrap API queries and mutations;
+feature hooks manage feature state, filters, and derived data. Components
+render and handle interaction, but should not call `useQuery` or `useMutation`
+directly.
+
+Server state belongs in TanStack Query. UI state such as expanded sections,
+filters, and modal visibility belongs in `useState` within feature hooks or
+components. Filterable pages use a `use-*-state.ts` or `use-*-filters.ts` hook;
+setters reset pagination to page 1.
+
+Query keys are centralized in `apps/web/src/lib/query-keys.ts`. Use its domain
+key factories for queries and mutation invalidation; factories return `as const`
+tuples for type safety, prefix-based invalidation is supported, and local key
+objects or raw string arrays are forbidden. Polling constants live in
+`apps/web/src/lib/polling-intervals.ts`: `POLLING_FAST` (5s),
+`POLLING_REALTIME` (15s), `POLLING_ACTIVE` (30s), `POLLING_STANDARD` (60s),
+`POLLING_STATS` (120s), and `POLLING_BACKGROUND` (5min). Inspect call sites
+before changing a hook that accepts `refetchInterval`.
+
+Use `useEnrichableItems(items, typeMapping)` when extracting media IDs for
+cross-service enrichment; its mapping distinguishes the `tv` and `series`
+representations of the same media type.
+
+For monitored counts, use `episodeCount` rather than `totalEpisodeCount` for
+Sonarr and `trackCount` rather than `totalTrackCount` for Lidarr.
+
+Use `React.lazy` and `Suspense` for modals rendered behind a state guard. Named
+exports need an adapter such as:
+
+```tsx
+lazy(() => import("./file").then((m) => ({ default: m.NamedExport })))
+```
+
+Use `GlassmorphicCard` or the established glassmorphic card classes. Staggered
+animations use `animationDelay: \`${index * 30}ms\`` with
+`animate-in fade-in slide-in-from-bottom-2`.
+
+## Testing
+
+Use the repository commands in Quick Start. Building `@arr/shared` before the
+root Turbo typecheck is required after shared-package changes; per-package
+TypeScript checks can hide stale shared output.
+
+Components that use `useIncognitoMode()` require an `IncognitoProvider` in
+tests. Test production-shaped data and relevant failure paths when behavior
+depends on external services, persistence, authorization, or counts.
+
+## Environment and Deployment
+
+The single-container deployment exposes port 3000 and uses `/config/` for the
+production database and secrets. Startup is handled by
+`docker/start-combined.sh`. Production startup uses a database-backed runtime
+lease and fail-closed schema synchronization; only one API/container should
+operate against a database at a time.
+
+The supported environment settings include `DATABASE_URL`, `API_PORT` (3001),
+`PORT` (3000), `HOST` (0.0.0.0), `PUID`, `PGID`, `SESSION_TTL_HOURS` (24),
+`ENCRYPTION_KEY`, `SESSION_COOKIE_SECRET`, `WEBAUTHN_RP_ID`, and
+`WEBAUTHN_ORIGIN`. Unset encryption and session-cookie settings can be
+generated into the deployment secrets file.
+
+Continuous integration is defined in `.github/workflows/ci.yml` and covers
+linting, type checking, and the Docker build. Release procedures are
+maintained in [`docs/RELEASING.md`](RELEASING.md).
+
+## Patterns and Gotchas
+
+- Frontend API calls use `/api/*` and Next.js rewrites; direct backend host
+  URLs do not belong in frontend code.
+- Next.js App Router components are server components by default.
+- Docker and development use different environment names and filesystem
+  paths (`/config/` versus `./`).
+- Error responses use `{ error: "message" }`, with optional `details` for
+  validation. Common statuses are 400, 401, 403, 404, and 423.
+- The backup service is split across `backup-crypto.ts`,
+  `backup-validation.ts`, `backup-file-utils.ts`, and `backup-database.ts`.
+- Queue Cleaner has its own `QueueCleanerConfig` model for per-instance
+  automatic cleanup settings.
+- Mutations must invalidate affected query keys after the server state changes.
+- Data transformations belong in hooks or utilities, not presentational
+  components.
+
+## Domain References
+
+- [Authentication System](AUTH.md) — session, OIDC, passkey, encryption, and
+  lockout internals.
+- [UI Theming System](THEMING.md) — gradients, colors, components, z-index,
+  typography, and animation conventions.
+- [API Routes Reference](API-ROUTES.md) — route groups, methods,
+  authentication requirements, and purposes.
+- [Release Process](RELEASING.md) — release preparation, publication, and
+  hotfix procedures.
+- Domain-specific service behavior is documented under [`docs/domains/`](domains/).

--- a/docs/superpowers/plans/2026-08-11-next-maintenance-parity-program.md
+++ b/docs/superpowers/plans/2026-08-11-next-maintenance-parity-program.md
@@ -1,0 +1,400 @@
+# Next Maintenance Parity Program
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring `next` to semantic parity with every applicable stable 2.x
+maintenance, data-safety, provider-cache, Plex, and TRaSH correction without
+merging `main` wholesale or reintroducing behavior intentionally removed from
+3.0.
+
+**Architecture:** Treat parity as an ordered program of independently
+reviewable pull requests. First install the project Codex controls on `next`,
+then port Library Cleanup and provider evidence in dependency order, add the
+live validation harness, and finally port the TRaSH deployment safety stack.
+Each wave adapts behavior to 3.0's unified rule engine, Composer, and Tautulli
+removal rather than cherry-picking stable files blindly.
+
+**Tech Stack:** TypeScript, Fastify 5, Prisma, Next.js 16, React 19, Vitest,
+Playwright, Docker Compose, SQLite, PostgreSQL, Sonarr, Radarr, Plex, Jellyfin,
+Emby, qUI, GitHub Actions, and Codex project skills.
+
+## Global Constraints
+
+- `main` remains stable 2.x; every change in this program targets `next` on a
+  dedicated branch and pull request.
+- Never merge `main` into `next`. Port the verified behavior and tests, then
+  adapt them to 3.0 architecture.
+- Do not restore Tautulli runtime, routes, cache refreshers, schedulers, UI, or
+  dependencies. Preserve migration and fail-closed handling for stored
+  Tautulli-origin rules.
+- Keep 2.x version, changelog, README, Docker tag, and release metadata on
+  `main`.
+- Prisma clients are regenerated from the resulting `next` schema. Generated
+  files are never copied from stable commits.
+- Every mutation-adjacent wave uses red/green tests, one independent
+  `data_safety_reviewer` discovery pass, one `regression_reviewer` pass, one
+  correction batch, and targeted closure review.
+- Run one whole-PR hosted Codex review on the frozen candidate. A newly found
+  concern becomes follow-up work unless it proves the current wave unsafe or
+  invalid.
+- Automatic TRaSH deployment must not be enabled from an intermediate state
+  that has durable recovery but lacks reviewed-preview execution authority.
+- Production services are read-only evidence sources. Upstream mutation tests
+  use disposable fixtures.
+- Every PR runs changed-surface tests plus `pnpm run format`, shared build when
+  applicable, root typecheck, root test, root lint, and build when required by
+  `AGENTS.md`.
+
+---
+
+## Audited Commit Ledger
+
+The audit compared all 47 commits unique to `main` against `origin/next` at
+`60749495`. Patch identity was supporting evidence only; classifications were
+confirmed from the live source paths and 3.0 architecture.
+
+### Already equivalent or intentionally adapted
+
+| Stable work | `next` evidence | Disposition |
+| --- | --- | --- |
+| #582, #583, #597, #598, #547, #603, #605, #607, #611 | #581, #584, #609, #610 and current workflow/schema-sync contracts | No port |
+| #600 reverse-proxy Basic Auth | #599 | No port; Tautulli-specific stable code remains 2.x-only |
+| #601 new-library notifications | #575 notification correction and current scheduler/executor | No port |
+| #604 flat Sonarr ratings | #608 | No port |
+| #612 torrent-file allowlist | #613 | No port |
+| #629 and #634 shared-media coordination | #633 and #635 | No port |
+| #636 null Plex player token | #637 | No port |
+| #638 bodyless POST | #639 | No port |
+| #640 Pulse cleanup links | #641 | No port |
+| #642 approval history | #643 | No port |
+| #644 Seerr attention | #645 | No port |
+| #646 qUI webhook registration | #647 | No port |
+| #651, #648, #653 OIDC/External URL/Authentik | #652, #649, #654 | No port |
+| v2.22.0 and v2.23.0 release commits | Stable-line metadata | Never port |
+
+### Required parity work
+
+| Stable work | Required 3.0 outcome | Wave |
+| --- | --- | --- |
+| #628 | Codex-native `AGENTS.md`, project skills, and independent reviewers | 0 |
+| #656, #658 | Radarr retained-variant and Sonarr shared-Plex ownership proof at mutation time | 1 |
+| #661 | Episode-scoped Sonarr cleanup, exact episode files, cache evidence, qUI, API, and UI | 2 |
+| #668, #671 | Durable policy evidence, selection plan, audit, leases, rescan recovery, IMDb regression | 3 |
+| #670 | Provider connection generations, guarded cache publication, actionable Jellyfin failures | 4 |
+| #685 | Plex 1.43-compatible history sorting without weakening completeness checks | 5 |
+| #688 | Fresh Plex/Jellyfin watch evidence before selection and execution | 5 |
+| #693 | Current-library inventory, stale-history filtering, and final mutation-time Plex proof | 5 |
+| #669, #691 | Signed browser policy gate and deterministic disposable cleanup harness | 6 |
+| #676-#678 | Durable TRaSH state, ownership, backup schema, and exact upstream state capture | 7 |
+| #679 | Durable partial/uncertain recovery, restart reconciliation, and honest notifications | 8 |
+| #680 | Execution tokens, current authority, writer locks, and preview/execution binding | 9 |
+| #681-#682 | Exact cloned-profile target and score/alias recovery | 10 |
+| #686 | Execution-time disabled-target and equivalent-alias enforcement | 11 |
+| #687 | Complete incognito masking of deployment plans and diagnostics | 12 |
+
+### Additional `next` baseline debt discovered
+
+| Existing `next` debt | Required outcome | Wave |
+| --- | --- | --- |
+| Four OIDC files introduced by #649/#652 fail the root Biome formatter | Restore a clean formatting baseline in a dedicated mechanical-only PR | -1 |
+
+---
+
+### Task 1: Establish and freeze the `next` baseline
+
+**Files:**
+
+- Verify: repository at `origin/next`
+- Create: this program document
+
+**Interfaces:**
+
+- Consumes: `origin/main`, `origin/next`, the 47-commit audit, and open PR/issue
+  state.
+- Produces: a clean baseline and immutable parity ledger.
+
+- [x] **Step 1: Fetch and identify branch topology**
+
+  Run:
+
+  ```bash
+  git fetch origin main next
+  git merge-base origin/main origin/next
+  git rev-list --left-right --count origin/next...origin/main
+  git cherry -v origin/next origin/main
+  ```
+
+  Recorded baseline: merge base `18f3e900`; 85 `next`-only commits and 47
+  `main`-only commits.
+
+- [x] **Step 2: Audit semantic equivalents**
+
+  Inspect every main-only commit against current `next` source, paired PRs, and
+  3.0 ADRs. Record adaptations instead of treating a changed patch ID as
+  missing behavior.
+
+- [x] **Step 3: Verify the untouched test baseline**
+
+  Run from a new worktree based on `origin/next`:
+
+  ```bash
+  pnpm install --frozen-lockfile
+  pnpm run test
+  ```
+
+  Expected: all runnable baseline tests pass before any parity change.
+
+- [x] **Step 4: Record pre-existing gauntlet failures**
+
+  `pnpm run format` fails on four unchanged OIDC files at `origin/next`
+  (`60749495`). The parity worktree has no source diff for those files, so this
+  is tracked as Wave -1 rather than being hidden inside the workflow PR.
+
+### Task 2: Wave -1 - Restore the formatting baseline
+
+**Files:**
+
+- Format: `apps/api/src/routes/__tests__/auth-oidc.test.ts`
+- Format: `apps/api/src/routes/__tests__/oidc-providers.test.ts`
+- Format: `apps/api/src/routes/oidc-providers.ts`
+- Format: `apps/web/src/features/settings/components/oidc-provider-section.tsx`
+
+**Interfaces:**
+
+- Consumes: the exact unchanged files already present on `origin/next`.
+- Produces: a mechanical-only prerequisite PR with no behavior change.
+
+- [x] **Step 1: Apply only the repository formatter's exact output**
+
+  Start a dedicated branch from `origin/next` and run Biome with `--write` on
+  only the four named files. Reject any unrelated diff.
+
+- [x] **Step 2: Prove the baseline is restored**
+
+  Run the focused OIDC tests and the complete repository gauntlet. Confirm the
+  final diff contains formatting changes only.
+
+- [ ] **Step 3: Publish the prerequisite**
+
+  Commit, push, and open a focused PR against `next` after explicit publication
+  authorization. Merge it before freezing the Wave 0 candidate.
+
+### Task 3: Wave 0 - Codex workflow parity
+
+**Files:**
+
+- Modify: `.gitignore`
+- Create: `AGENTS.md`
+- Create: `.agents/skills/arr-fix-issue/**`
+- Create: `.agents/skills/arr-integration-change/**`
+- Create: `.agents/skills/arr-prepare-pr/**`
+- Create: `.agents/skills/arr-release/**`
+- Create: `.agents/skills/arr-review-change/**`
+- Create: `.agents/skills/arr-validate/**`
+- Create: `.codex/agents/data-safety-reviewer.toml`
+- Create: `.codex/agents/regression-reviewer.toml`
+- Create: `docs/ENGINEERING.md`
+- Modify: this program document only if audit evidence changes
+
+**Interfaces:**
+
+- Consumes: the approved Codex-native guidance on stable plus 3.0's actual
+  architecture in `CLAUDE.md`.
+- Produces: branch discipline, validation commands, mutation invariants, and
+  discoverable project workflows plus a public engineering entry point for
+  every later `next` worktree.
+
+- [x] **Step 1: Port current Codex-native controls**
+
+  Track only the project-owned `.agents/skills/` subtree, then add
+  `AGENTS.md`, `.agents/skills/`, `.codex/agents/`, and
+  `docs/ENGINEERING.md`. Keep all other `.agents/` artifacts ignored. Do not
+  import `.claude/` compatibility files as canonical workflow and do not
+  overwrite 3.0's `CLAUDE.md`.
+
+- [x] **Step 2: Make handover loading conditional**
+
+  State that `HANDOVER.md` is optional machine state and is read only when a
+  task depends on local services, checkout history, or machine integration.
+
+- [x] **Step 3: Verify workflow paths and privacy**
+
+  Run:
+
+  ```bash
+  find .agents .codex/agents -type f -print | sort
+  rg -n '/home/|/Users/|token|password|private.*url' AGENTS.md .agents .codex/agents docs/ENGINEERING.md
+  git diff --check origin/next...HEAD
+  ```
+
+  Expected: all referenced skills/reviewers exist and no private machine path,
+  endpoint, credential, or secret enters tracked files.
+
+- [ ] **Step 4: Validate and open the focused governance PR**
+
+  Run the project gauntlet. Open one documentation/workflow PR against `next`;
+  do not mix runtime forward-port code into it.
+
+### Task 4: Waves 1-6 - Library Cleanup and provider evidence
+
+**Files:**
+
+- Wave-specific plans must list exact paths after rebasing on the preceding
+  merged wave; expected domains are `apps/api/src/lib/library-cleanup/`,
+  `apps/api/src/lib/plex/`, `apps/api/src/lib/jellyfin/`, provider schedulers and
+  routes, Prisma schema, shared cleanup types, cleanup UI, and
+  `e2e/library-cleanup/`.
+
+**Interfaces:**
+
+- Consumes: the current unified-rule adapter and Tautulli migration contract.
+- Produces: stable-equivalent mutation authority while preserving 3.0 rule
+  parity and Tracearr/Tautulli decisions.
+
+- [ ] **Step 1: Port retained-variant safety (#656, #658)**
+
+  Start with failing Radarr and Sonarr shared-library collision regressions.
+  Implement canonical peer proofs and execution-time revalidation, then run
+  focused shared-Plex suites and independent data-safety review.
+
+- [ ] **Step 2: Port episode-scoped cleanup (#661)**
+
+  Write a separate code-level plan covering schema, Plex episode cache,
+  Sonarr episode identity, per-episode versus per-series mutation, qUI
+  correlation, routes, shared types, and UI. Preserve unified-rule parity.
+
+- [ ] **Step 3: Port policy and recovery foundation (#668, #671)**
+
+  Add durable policy evidence, selection planning, audit events, run leases,
+  media-server rescan jobs, retry/idempotency, and IMDb-rating coverage behind
+  the unified cleanup adapter. Omit Tautulli runtime collectors while keeping
+  stored-rule migration fail closed.
+
+- [ ] **Step 4: Port provider cache correctness (#670)**
+
+  Add connection generations, guarded status/publication writes, Jellyfin
+  single-flight refreshes, and actionable Pulse retries for Plex, Jellyfin, and
+  Emby. Do not restore Tautulli. Place issue #689 immediately after this wave so
+  its durable expected-server identity extends, rather than replaces, the
+  generation contract.
+
+- [ ] **Step 5: Port Plex evidence correctness (#685, #688, #693)**
+
+  Apply compatible single-key history sorting, then fresh Plex/Jellyfin watch
+  evidence, then current-library filtering and final target/inventory proof.
+  Regression coverage must include stale watched-history rows, pagination
+  churn, duplicate editions, same-title collisions, changed ARR state, and
+  lower-priority Plex rules.
+
+- [ ] **Step 6: Port validation infrastructure (#669, #691)**
+
+  Add the signed browser-policy gate first, then deterministic Compose
+  ownership guards and ARR/Plex/qUI bootstrap. Validate that the harness cannot
+  target an unrelated Compose project or live service.
+
+### Task 5: Waves 7-12 - TRaSH deployment safety
+
+**Files:**
+
+- Wave-specific plans must list exact paths after the Cleanup/provider stack is
+  merged; expected domains are `apps/api/src/lib/trash-guides/`, TRaSH routes,
+  schedulers, Prisma schema, backup/notification integration, shared types,
+  frontend hooks/components, and `docs/API-ROUTES.md`.
+
+**Interfaces:**
+
+- Consumes: current 3.0 Composer and TRaSH deployment flows.
+- Produces: durable, authority-bound, privacy-safe deployment and recovery
+  without weakening Composer registry validation.
+
+- [ ] **Step 1: Port state and ownership foundation (#676-#678)**
+
+  Add nullable/defaulted schema fields, exact endpoint identity, backup version
+  parsing, active ownership, legacy rebinding, operation gates, and captured
+  custom-format/profile/naming state. Legacy state without proof fails closed.
+
+- [ ] **Step 2: Port durable recovery (#679)**
+
+  Persist partial and uncertain results, startup recovery, retry progress, and
+  `TRASH_DEPLOY_UNCERTAIN` metadata while preserving 3.0's
+  `AUTOMATION_RULE_MATCHED` registry contract.
+
+- [ ] **Step 3: Port execution authority (#680)**
+
+  Bind preview to execution with 64-character tokens, current connection and
+  target identity, writer locks, stale-token rejection, and current-state
+  revalidation. Resolve Composer serialization explicitly before enabling
+  automatic deployment.
+
+- [ ] **Step 4: Port profile recovery (#681-#682)**
+
+  Preserve exact cloned source targets, negative and instance-only scores,
+  equivalent aliases, and same-title profiles without duplicate or wrong-target
+  writes.
+
+- [ ] **Step 5: Port disabled auto-sync enforcement (#686)**
+
+  Re-read service enabled state and authority at execution time; skip disabled
+  instances, aliases, and unresolved recovery states, then apply pending work
+  exactly once after safe re-enable.
+
+- [ ] **Step 6: Port deployment-plan privacy (#687)**
+
+  Mask custom-format names, conflicts, naming fields, orphaned formats,
+  instance labels, and embedded diagnostics under incognito mode without
+  changing execution authority or the underlying plan.
+
+### Task 6: Close parity and clean the working queue
+
+**Files:**
+
+- Update: this ledger as each wave merges
+- Review: open PRs #692, #684, #595, and #592
+
+**Interfaces:**
+
+- Consumes: every merged parity PR and current GitHub issue/PR state.
+- Produces: zero unclassified main-only maintenance behavior and a deliberate
+  disposition for stale drafts.
+
+- [ ] **Step 1: Re-run the semantic audit**
+
+  Repeat the commit ledger against the final `next`. Every applicable stable
+  outcome must point to a merged `next` commit and regression evidence; release
+  metadata and superseded Tautulli runtime remain explicitly excluded.
+
+- [ ] **Step 2: Run the complete 3.0 gauntlet**
+
+  Run formatting, shared build, root typecheck, full tests, lint, production
+  build, SQLite/PostgreSQL smoke tests, Docker build, and the disposable cleanup
+  and TRaSH mutation scenarios.
+
+- [ ] **Step 3: Resolve stale draft PRs deliberately**
+
+  Rebase and finish only still-valid focused changes. Extract useful behavior
+  from superseded plans, then close stale branches without merging obsolete
+  implementation. Do not delete local worktrees or branches without separate
+  explicit authorization.
+
+- [ ] **Step 4: Declare the clean restart point**
+
+  Record the final `next` commit, merged PR list, open follow-up issues, and
+  validation evidence. Resume 3.0 feature work only after no required parity
+  item remains unowned.
+
+## Program Exit Gate
+
+- All 47 original `main`-only commits have a recorded disposition.
+- All 21 required commits have semantic `next` equivalents; partial commits
+  list intentionally omitted 2.x/Tautulli surfaces.
+- Issue #689 is either resolved on both lines or explicitly remains the only
+  named provider-identity follow-up with an owner and plan.
+- No known P0/P1 or in-scope P2 data-safety finding remains open.
+- The full 3.0 gauntlet, database smoke checks, Docker checks, and disposable
+  mutation scenarios pass on the final exact head.
+- Open draft PRs have an explicit merge, rebase, extract-and-close, or retain
+  decision.
+- `next` is ready for new 3.0 work without hidden stable forward-port debt.


### PR DESCRIPTION
## Summary

- add the public `AGENTS.md` working agreement for stable and 3.0 development
- add Codex-native issue, integration, review, validation, PR, and release workflows
- add independent regression and data-safety reviewer definitions
- document the public engineering workflow and ordered 3.0 maintenance-parity program

## Why

The remaining 3.0 maintenance work crosses cleanup, provider, container, and deployment safety boundaries. These project-native controls make branch selection, validation, mutation safety, and review responsibilities explicit before those runtime waves are published.

## Runtime impact

None. This PR contains project guidance, Codex workflow definitions, reviewer configuration, and engineering documentation only.

## Validation

- high-signal private path and credential scan over every changed file
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`

## Risk

Low runtime risk because application behavior is unchanged. The primary maintenance risk is stale workflow guidance; the files reference only paths and commands that exist in this branch.
