### PR TITLE
fix(cleanup): port shared-library mutation safety to next

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { buildMovieItem } from "../../library/movie-normalizer.js";
 import { PlexMovieNotFoundError } from "../../plex/plex-client.js";
 import {
 	buildCleanupPreviewDetails,
@@ -1659,6 +1660,103 @@ describe("shared Plex deletion safety", () => {
 		});
 	});
 
+	it("blocks a Radarr plan when a peer imports the movie during Plex verification", async () => {
+		const fixture = makeDeps();
+		const peer = configureVerifiedRadarrPeer(fixture);
+		fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			peer.peerClient.movie.getAll.mockResolvedValue([{ ...peer.peerMovie, movieFileId: 2999 }]);
+			peer.peerClient.movieFile.getById.mockResolvedValue({
+				...peer.peerMovieFile,
+				id: 2999,
+				path: "/downloads-hd/Example Movie (2024)/Example.Movie.Replacement.mkv",
+			});
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
+
+		const context = createSharedPlexSafetyContext();
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+
+		expect(blocks.has(cleanupDeleteTargetKey(target))).toBe(true);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({ kind: "blocked" });
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("blocks a Radarr plan when its target file changes during Plex verification", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			fixture.targetClient.movieFile.getById.mockResolvedValue({
+				id: 1002,
+				path: "/movies-4k/Example Movie (2024)/Example.Movie.Replacement.2160p.mkv",
+				relativePath: "Example.Movie.Replacement.2160p.mkv",
+				size: 2_500,
+			});
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
+
+		const context = createSharedPlexSafetyContext();
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+
+		expect(blocks.has(cleanupDeleteTargetKey(target))).toBe(true);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({ kind: "blocked" });
+	});
+
+	it("blocks a Radarr plan when target delete notifications change during Plex verification", async () => {
+		const fixture = makeDeps({ onMovieDelete: true, onMovieFileDelete: true, mediaPartCount: 1 });
+		const initialNotifications = await fixture.targetClient.notification.getAll();
+		fixture.targetClient.notification.getAll.mockClear();
+		fixture.targetClient.notification.getAll.mockResolvedValue(initialNotifications);
+		fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			fixture.targetClient.notification.getAll.mockResolvedValue(
+				initialNotifications.map((notification: Record<string, unknown>) => ({
+					...notification,
+					fields: notificationFields({ mapFrom: "/movies-4k", mapTo: "/changed-root" }),
+				})),
+			);
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
+
+		const context = createSharedPlexSafetyContext();
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+
+		expect(blocks.has(cleanupDeleteTargetKey(target))).toBe(true);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({ kind: "blocked" });
+	});
+
 	it("blocks a merged Plex movie when an extra part has no verified Radarr owner", async () => {
 		const fixture = makeDeps({
 			plexItems: [
@@ -1760,9 +1858,11 @@ describe("shared Plex deletion safety", () => {
 		]);
 
 		expect(blocks).toEqual(new Map());
-		expect(peerClient.movie.getAll).toHaveBeenCalledTimes(2);
+		// One stable inventory is read for planning and one terminal inventory is
+		// shared across the batch after every Plex lookup completes.
+		expect(peerClient.movie.getAll).toHaveBeenCalledTimes(4);
 		expect(peerClient.movie.getById).not.toHaveBeenCalled();
-		expect(peerClient.movieFile.getById).toHaveBeenCalledTimes(2);
+		expect(peerClient.movieFile.getById).toHaveBeenCalledTimes(4);
 		expect(peerClient.movieFile.getById).toHaveBeenCalledWith(2002);
 	});
 
@@ -1993,7 +2093,7 @@ describe("shared Plex deletion safety", () => {
 		});
 	});
 
-	it("loads Radarr notifications once per instance across multiple safety targets", async () => {
+	it("loads initial and terminal Radarr notifications once per instance across a planning batch", async () => {
 		const { deps, targetClient } = makeDeps({ mediaPartCount: 1 });
 		const context = createSharedPlexSafetyContext();
 
@@ -2004,8 +2104,8 @@ describe("shared Plex deletion safety", () => {
 			context,
 		);
 
-		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
-		expect(targetClient.movie.getById).toHaveBeenCalledTimes(2);
+		expect(targetClient.notification.getAll).toHaveBeenCalledTimes(2);
+		expect(targetClient.movie.getById).toHaveBeenCalledTimes(6);
 	});
 
 	it("refetches Radarr notifications across separate safety checks", async () => {
@@ -2478,6 +2578,25 @@ describe("shared Plex deletion safety", () => {
 					implementation: "PlexServer",
 					onMovieDelete: true,
 					onMovieFileDelete: true,
+					fields: notificationFields({}),
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					implementation: "PlexServer",
+					onMovieDelete: true,
+					onMovieFileDelete: true,
+					fields: [
+						...notificationFields({}).filter((field) => field.name !== "host"),
+						{ name: "host", value: "plex-new.internal" },
+					],
+				},
+			])
+			.mockResolvedValueOnce([
+				{
+					implementation: "PlexServer",
+					onMovieDelete: true,
+					onMovieFileDelete: true,
 					fields: [
 						...notificationFields({}).filter((field) => field.name !== "host"),
 						{ name: "host", value: "plex-new.internal" },
@@ -2897,6 +3016,61 @@ describe("shared Plex deletion safety", () => {
 		expect(result).toMatchObject({ status: "completed", itemsRemoved: 1, itemsSkipped: 0 });
 	});
 
+	it("blocks a no-notification Radarr deletion when a sibling appears after planning", async () => {
+		const fixture = makeDeps({ includePlexNotification: false, mediaPartCount: 1 });
+		const sibling = {
+			...fixture.targetInstance,
+			id: "radarr-hd",
+			label: "HD Radarr",
+			baseUrl: "http://radarr-hd.internal:7878",
+		};
+		let topologyReads = 0;
+		vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation((args) => {
+			if (args?.where?.service === "PLEX") return Promise.resolve([]) as never;
+			if (typeof args?.where?.service === "object" && "in" in args.where.service) {
+				topologyReads++;
+				return Promise.resolve(
+					topologyReads === 1 ? [fixture.targetInstance] : [fixture.targetInstance, sibling],
+				) as never;
+			}
+			return Promise.resolve([
+				{ id: fixture.targetInstance.id, updatedAt: fixture.targetInstance.updatedAt },
+			]) as never;
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched 4K profile",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "partial", itemsRemoved: 0, itemsFilesDeleted: 0 });
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
 	it("retains a no-peer Radarr record when Plex gains an unowned part after exact file deletion", async () => {
 		const fixture = makeDeps({ mediaPartCount: 1 });
 		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
@@ -3279,6 +3453,135 @@ describe("shared Plex deletion safety", () => {
 		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
 	});
 
+	it("retains a Radarr record when its peer changes during post-file Plex verification", async () => {
+		const fixture = makeDeps();
+		const peer = configureVerifiedRadarrPeer(fixture);
+		let plexLookups = 0;
+		fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			plexLookups++;
+			if (plexLookups === 3) peer.peerClient.movie.getAll.mockResolvedValue([]);
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched 4K profile",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(plexLookups).toBe(3);
+		expect(result).toMatchObject({ status: "partial", itemsRemoved: 0, itemsFilesDeleted: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("retains a Radarr record when target notifications change during post-file Plex verification", async () => {
+		const fixture = makeDeps({ onMovieDelete: true, onMovieFileDelete: true });
+		configureVerifiedRadarrPeer(fixture);
+		const initialNotifications = await fixture.targetClient.notification.getAll();
+		fixture.targetClient.notification.getAll.mockClear();
+		fixture.targetClient.notification.getAll.mockResolvedValue(initialNotifications);
+		let plexLookups = 0;
+		fixture.getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			plexLookups++;
+			if (plexLookups === 3) {
+				fixture.targetClient.notification.getAll.mockResolvedValue(
+					initialNotifications.map((notification: Record<string, unknown>) => ({
+						...notification,
+						fields: notificationFields({
+							mapFrom: "/movies-4k",
+							mapTo: "/changed-after-file-delete",
+						}),
+					})),
+				);
+			}
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched 4K profile",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(plexLookups).toBe(3);
+		expect(result).toMatchObject({ status: "partial", itemsRemoved: 0, itemsFilesDeleted: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
 	it("removes an already-fileless Radarr record without enabling file deletion", async () => {
 		const { deps, deleteMovie, deleteMovieFile, getMovieMediaPartsByTmdbId } = makeDeps({
 			initialMovieFileId: null,
@@ -3502,30 +3805,38 @@ describe("shared Plex deletion safety", () => {
 	});
 
 	it("fails closed when Radarr replaces the verified file before a full delete", async () => {
-		const { deps, deleteMovie, deleteMovieFile, targetClient } = makeDeps({
-			mediaPartCount: 1,
-		});
-		targetClient.movie.getById
-			.mockResolvedValueOnce({
-				id: 101,
-				tmdbId: 42,
-				title: "Example Movie",
-				tags: [],
-				hasFile: true,
-				movieFileId: 1001,
-				path: "/movies-4k/Example Movie (2024)",
-				rootFolderPath: "/movies-4k",
-			})
-			.mockResolvedValueOnce({
-				id: 101,
-				tmdbId: 42,
-				title: "Example Movie",
-				tags: [],
-				hasFile: true,
-				movieFileId: 1002,
-				path: "/movies-4k/Example Movie (2024)",
-				rootFolderPath: "/movies-4k",
+		const { deps, deleteMovie, deleteMovieFile, targetClient, getMovieMediaPartsByTmdbId } =
+			makeDeps({
+				mediaPartCount: 1,
 			});
+		const originalMovie = {
+			id: 101,
+			tmdbId: 42,
+			title: "Example Movie",
+			tags: [],
+			hasFile: true,
+			movieFileId: 1001,
+			path: "/movies-4k/Example Movie (2024)",
+			rootFolderPath: "/movies-4k",
+		};
+		targetClient.movie.getById.mockResolvedValue(originalMovie);
+		getMovieMediaPartsByTmdbId.mockImplementation(async () => {
+			targetClient.movie.getById.mockResolvedValue({
+				...originalMovie,
+				movieFileId: 1002,
+			});
+			return [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+					],
+				},
+			];
+		});
 		const flaggedItem = {
 			cacheItem: {
 				instanceId: "radarr-4k",
@@ -3605,6 +3916,62 @@ describe("shared Plex deletion safety", () => {
 		expect(result.details[0]?.reason).toContain("differs from the cached item");
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("accepts the exact Radarr file identity serialized by the production movie normalizer", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const normalized = buildMovieItem(fixture.targetInstance as never, "radarr", {
+			id: 101,
+			tmdbId: 42,
+			title: "Example Movie",
+			hasFile: true,
+			movieFileId: 1001,
+			path: "/movies-4k/Example Movie (2024)",
+			movieFile: {
+				id: 1001,
+				relativePath: "Example.Movie.2160p.mkv",
+				size: 2_000,
+			},
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				hasFile: true,
+				cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+				data: JSON.stringify({
+					...normalized,
+					_arrDashboardSource: {
+						serviceFingerprint: radarrTargetIdentity.serviceFingerprint,
+					},
+				}),
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched normalized cache file",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "completed", itemsRemoved: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).toHaveBeenCalledOnce();
 	});
 
 	it("does not use cache rows that predate a service configuration change", async () => {
@@ -3847,11 +4214,11 @@ describe("shared Plex deletion safety", () => {
 			path: "/movies-4k/Example Movie (2024)",
 			rootFolderPath: "/movies-4k",
 		};
-		targetClient.movie.getById
-			.mockResolvedValueOnce(movie)
-			.mockResolvedValueOnce(movie)
-			.mockResolvedValueOnce(movie)
-			.mockResolvedValueOnce({ ...movie, hasFile: false });
+		targetClient.movie.getById.mockImplementation(async () =>
+			deleteMovieFile.mock.calls.length === 0
+				? movie
+				: { ...movie, hasFile: false, movieFileId: 1001 },
+		);
 		deleteMovieFile.mockResolvedValueOnce(undefined);
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
 			approvalRecord({ action: "delete_files" }) as never,

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { PlexMovieNotFoundError } from "../../plex/plex-client.js";
 import {
 	buildCleanupPreviewDetails,
 	CleanupRunAlreadyInProgressError,
@@ -13,6 +14,7 @@ import {
 	selectInspectableCleanupPreviewItems,
 } from "../cleanup-executor.js";
 import {
+	assertVerifiedRadarrPeerOwnershipRetained,
 	buildRadarrCacheSafetyPlan,
 	cleanupDeleteTargetKey,
 	createArrServiceFingerprint,
@@ -67,7 +69,18 @@ function radarrSafetySnapshot(
 					target: radarrTargetIdentity,
 					file,
 					peers: [],
-					ownership: [],
+					peerInventoryComplete: true,
+					ownership: [
+						{
+							plexServerUrl: "http://plex.internal:32400",
+							target: {
+								ratingKey: "plex-movie-42",
+								fullPath: file.fullPath,
+								size: file.size,
+							},
+							retained: [],
+						},
+					],
 					targetDeleteNotifications: [],
 				}
 			: { kind: "verified_radarr_empty", target: radarrTargetIdentity },
@@ -484,6 +497,59 @@ function configureVerifiedRadarrPeer(
 		(instance) => (instance.id === peerInstance.id ? peerClient : fixture.targetClient) as never,
 	);
 	return { peerInstance, peerMovie, peerMovieFile, peerClient };
+}
+
+function configureUntrackedRadarrPeerWithoutPlexCorrelation(
+	fixture: ReturnType<typeof makeDeps>,
+	movieTmdbId: number | undefined,
+) {
+	const peer = configureVerifiedRadarrPeer(fixture);
+	(peer.peerMovie as { tmdbId?: number }).tmdbId = movieTmdbId;
+	peer.peerClient.notification.getAll.mockResolvedValue([]);
+	return peer;
+}
+
+function uncorrelatedRadarrPeerSafetySnapshot(
+	peerInstance: ReturnType<typeof configureVerifiedRadarrPeer>["peerInstance"],
+) {
+	return serializeExecutableSafetyPlan({
+		kind: "verified_radarr",
+		target: radarrTargetIdentity,
+		file: {
+			movieFileId: 1001,
+			fullPath: {
+				value: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+				windows: false,
+			},
+			size: 2_000,
+		},
+		peers: [
+			{
+				instanceId: peerInstance.id,
+				serviceFingerprint: createArrServiceFingerprint(peerInstance as never),
+				externalId: 42,
+				arrItemId: null,
+				mediaPath: null,
+				file: null,
+			},
+		],
+		peerInventoryComplete: true,
+		ownership: [
+			{
+				plexServerUrl: "http://plex.internal:32400",
+				target: {
+					ratingKey: "plex-movie-42",
+					fullPath: {
+						value: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						windows: false,
+					},
+					size: 2_000,
+				},
+				retained: [],
+			},
+		],
+		targetDeleteNotifications: [],
+	});
 }
 
 function configureRetryStore(deps: CleanupExecutorDeps) {
@@ -1544,7 +1610,7 @@ describe("shared Plex deletion safety", () => {
 		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
 
 		expect(blocks).toEqual(new Map());
-		expect(peerClient.movie.getAll).toHaveBeenCalledWith({ tmdbId: 42 });
+		expect(peerClient.movie.getAll).toHaveBeenCalledWith();
 		expect(peerClient.movie.delete).not.toHaveBeenCalled();
 		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
 		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
@@ -1694,10 +1760,140 @@ describe("shared Plex deletion safety", () => {
 		]);
 
 		expect(blocks).toEqual(new Map());
-		expect(peerClient.movie.getAll).toHaveBeenCalledOnce();
+		expect(peerClient.movie.getAll).toHaveBeenCalledTimes(2);
 		expect(peerClient.movie.getById).not.toHaveBeenCalled();
-		expect(peerClient.movieFile.getById).toHaveBeenCalledOnce();
+		expect(peerClient.movieFile.getById).toHaveBeenCalledTimes(2);
 		expect(peerClient.movieFile.getById).toHaveBeenCalledWith(2002);
+	});
+
+	it.each([
+		["alternate", 43],
+		["missing", undefined],
+	])(
+		"blocks an %s-TMDb Radarr peer that owns the exact target Plex part",
+		async (_label, peerTmdbId) => {
+			const fixture = makeDeps({ mediaPartCount: 1 });
+			const peer = configureVerifiedRadarrPeer(fixture, {
+				filePath: "/downloads-hd/Example Movie (2024)/Example.Movie.2160p.mkv",
+				fileSize: 2_000,
+				mapTo: "/movies-4k",
+			});
+			(peer.peerMovie as { tmdbId?: number }).tmdbId = peerTmdbId;
+			peer.peerClient.movie.getAll.mockImplementation((query?: { tmdbId?: number }) =>
+				Promise.resolve(query ? [] : [peer.peerMovie]),
+			);
+
+			const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+			expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+				"another configured Radarr instance may access the same storage",
+			);
+			expect(peer.peerClient.movie.getAll).toHaveBeenCalledWith();
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+			expect(peer.peerClient.movie.delete).not.toHaveBeenCalled();
+			expect(peer.peerClient.movieFile.delete).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		["alternate", 43],
+		["missing", undefined],
+	])(
+		"blocks planning for an untracked Radarr peer with %s TMDb metadata and no Plex correlation",
+		async (_label, peerTmdbId) => {
+			const fixture = makeDeps({ mediaPartCount: 1 });
+			const peer = configureUntrackedRadarrPeerWithoutPlexCorrelation(fixture, peerTmdbId);
+
+			const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+			expect(blocks.get(cleanupDeleteTargetKey(target))).toEqual(
+				expect.stringContaining("could not match the exact Radarr movie file"),
+			);
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+			expect(peer.peerClient.movieFile.delete).not.toHaveBeenCalled();
+			expect(peer.peerClient.movie.delete).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["queued", "direct", "retry"] as const)(
+		"blocks %s Radarr deletion for an untracked alternate-TMDb peer without Plex correlation",
+		async (mode) => {
+			const fixture = makeDeps({ mediaPartCount: 1 });
+			const peer = configureUntrackedRadarrPeerWithoutPlexCorrelation(fixture, 43);
+			const safetySnapshot = uncorrelatedRadarrPeerSafetySnapshot(peer.peerInstance);
+
+			if (mode === "queued") {
+				const storedApproval = approvalRecord({ safetySnapshot }) as Record<string, unknown>;
+				configureApprovalStore(fixture.deps, storedApproval);
+				const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+				expect(result).toMatchObject({ removed: 0, failed: 1 });
+			} else if (mode === "direct") {
+				const flaggedItem = {
+					cacheItem: {
+						instanceId: "radarr-4k",
+						arrItemId: 101,
+						itemType: "movie",
+						title: "Example Movie",
+						year: 2024,
+						...radarrCachedFileIdentity,
+						sizeOnDisk: 2_000n,
+					},
+					match: {
+						ruleId: "rule-1",
+						ruleName: "4K cleanup",
+						reason: "Matched 4K profile",
+						action: "delete",
+					},
+					rating: 8,
+				} as never;
+				const result = await executeDirectRemoval(
+					fixture.deps,
+					{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+					"user-1",
+					[flaggedItem],
+					1,
+					1,
+					Date.now(),
+				);
+				expect(result).toMatchObject({ itemsFilesDeleted: 0, itemsRemoved: 0 });
+			} else {
+				const storedRetry = approvalRecord({
+					status: "retry_pending",
+					executionToken: null,
+					safetySnapshot,
+				}) as Record<string, unknown>;
+				configureApprovalStore(fixture.deps, storedRetry);
+				fixture.setLiveMovieFileId(undefined);
+				const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+				expect(result).toMatchObject({ removed: 0, failed: 1 });
+				expect(storedRetry).toMatchObject({ status: "retry_pending" });
+			}
+
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+			expect(peer.peerClient.movieFile.delete).not.toHaveBeenCalled();
+			expect(peer.peerClient.movie.delete).not.toHaveBeenCalled();
+		},
+	);
+
+	it("fails closed when the complete Radarr peer inventory changes while it is read", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const peer = configureVerifiedRadarrPeer(fixture);
+		(peer.peerMovie as { hasFile?: boolean; movieFileId?: number }).hasFile = false;
+		(peer.peerMovie as { movieFileId?: number }).movieFileId = undefined;
+		peer.peerClient.movie.getAll
+			.mockResolvedValueOnce([peer.peerMovie])
+			.mockResolvedValueOnce([{ ...peer.peerMovie, id: 203 }]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Radarr instance may access the same storage",
+		);
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
 	});
 
 	it("renders only preview items that can receive live safety inspection", () => {
@@ -2700,6 +2896,228 @@ describe("shared Plex deletion safety", () => {
 		});
 		expect(result).toMatchObject({ status: "completed", itemsRemoved: 1, itemsSkipped: 0 });
 	});
+
+	it("retains a no-peer Radarr record when Plex gains an unowned part after exact file deletion", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockResolvedValue([
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.Remux.mkv",
+							size: 3_000,
+						},
+					],
+				},
+			]);
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched 4K profile",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "partial", itemsRemoved: 0, itemsFilesDeleted: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("removes the Radarr record when Plex drops the no-retained movie after exact file deletion", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord() as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockRejectedValue(new PlexMovieNotFoundError(42));
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toEqual({ removed: 1, failed: 0, errors: [] });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledOnce();
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).toHaveBeenCalledWith(101, {
+			deleteFiles: false,
+			addImportExclusion: false,
+		});
+	});
+
+	it("exposes a typed Plex movie-not-found error for Radarr safety", () => {
+		expect(new PlexMovieNotFoundError(42)).toMatchObject({
+			name: "PlexMovieNotFoundError",
+			message: "Plex returned no movie item for TMDb 42",
+		});
+	});
+
+	it("accepts a persisted no-retained Radarr proof after Plex drops the deleted movie", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const planned = context.plans.get(cleanupDeleteTargetKey(target));
+		if (planned?.kind !== "verified_radarr") {
+			throw new Error("Expected a verified Radarr safety plan");
+		}
+		const plan = parseExecutableSafetyPlan(serializeExecutableSafetyPlan(planned));
+		if (plan?.kind !== "verified_radarr") {
+			throw new Error("Expected a persisted verified Radarr safety plan");
+		}
+		expect(plan.ownership).toEqual([expect.objectContaining({ retained: [] })]);
+		fixture.setLiveMovieFileId(undefined);
+		fixture.getMovieMediaPartsByTmdbId.mockRejectedValue(new PlexMovieNotFoundError(42));
+
+		await expect(
+			assertVerifiedRadarrPeerOwnershipRetained(fixture.deps, "user-1", 101, plan),
+		).resolves.toBeUndefined();
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("resumes a no-retained Radarr retry after Plex drops the deleted movie", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const storedRetry = approvalRecord({
+			status: "retry_pending",
+			executionToken: null,
+		}) as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedRetry);
+		fixture.setLiveMovieFileId(undefined);
+		fixture.getMovieMediaPartsByTmdbId.mockRejectedValue(new PlexMovieNotFoundError(42));
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toEqual({ removed: 1, reconciled: 0, failed: 0, errors: [] });
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).toHaveBeenCalledOnce();
+		expect(fixture.deleteMovie).toHaveBeenCalledWith(101, {
+			deleteFiles: false,
+			addImportExclusion: false,
+		});
+		expect(storedRetry).toMatchObject({ status: "executed" });
+	});
+
+	it("keeps a retained-peer Radarr retry blocked when Plex drops the movie", async () => {
+		const fixture = makeDeps();
+		const peer = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") throw new Error("Expected a verified Radarr safety plan");
+		expect(plan.ownership).toEqual([expect.objectContaining({ retained: [expect.any(Object)] })]);
+		const storedRetry = approvalRecord({
+			status: "retry_pending",
+			executionToken: null,
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		}) as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedRetry);
+		fixture.setLiveMovieFileId(undefined);
+		fixture.getMovieMediaPartsByTmdbId.mockRejectedValue(new PlexMovieNotFoundError(42));
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(storedRetry).toMatchObject({ status: "retry_pending" });
+		expect(peer.peerClient.movieFile.delete).not.toHaveBeenCalled();
+		expect(peer.peerClient.movie.delete).not.toHaveBeenCalled();
+	});
+
+	it.each(["queued", "direct"] as const)(
+		"blocks %s fileless Radarr record deletion when a Plex notification appears after preflight",
+		async (mode) => {
+			const fixture = makeDeps({ initialMovieFileId: null, includePlexNotification: false });
+			const appearingNotification = {
+				implementation: "PlexServer",
+				configContract: "PlexServerSettings",
+				onMovieDelete: true,
+				onMovieFileDelete: true,
+				tags: [],
+				fields: notificationFields({ mapFrom: "/movies-4k", mapTo: "/plex/movies-4k" }),
+			};
+			fixture.targetClient.notification.getAll
+				.mockResolvedValueOnce([])
+				.mockResolvedValue([appearingNotification]);
+
+			if (mode === "queued") {
+				vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+					approvalRecord({ safetySnapshot: radarrSafetySnapshot(null) }) as never,
+				]);
+				await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+			} else {
+				const flaggedItem = {
+					cacheItem: {
+						instanceId: "radarr-4k",
+						arrItemId: 101,
+						itemType: "movie",
+						title: "Example Movie",
+						year: 2024,
+						hasFile: false,
+						cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+						sizeOnDisk: 0n,
+						data: JSON.stringify({
+							_arrDashboardSource: {
+								serviceFingerprint: radarrTargetIdentity.serviceFingerprint,
+							},
+							remoteIds: { tmdbId: 42 },
+							path: "/movies-4k/Example Movie (2024)",
+						}),
+					},
+					match: {
+						ruleId: "rule-1",
+						ruleName: "Fileless cleanup",
+						reason: "Matched fileless cleanup rule",
+						action: "delete",
+					},
+					rating: 8,
+				} as never;
+				await executeDirectRemoval(
+					fixture.deps,
+					{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+					"user-1",
+					[flaggedItem],
+					1,
+					1,
+					Date.now(),
+				);
+			}
+
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		},
+	);
 
 	it("blocks queued execution when the retained Radarr peer file changes after planning", async () => {
 		const fixture = makeDeps();

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -13,6 +13,7 @@ import {
 	selectInspectableCleanupPreviewItems,
 } from "../cleanup-executor.js";
 import {
+	buildRadarrCacheSafetyPlan,
 	cleanupDeleteTargetKey,
 	createArrServiceFingerprint,
 	createSharedPlexSafetyContext,
@@ -705,6 +706,24 @@ describe("shared Plex deletion safety", () => {
 						size: 2_000,
 					},
 				}),
+			),
+		).toBeNull();
+	});
+
+	it("does not turn cached Radarr file metadata into a destructive executable plan", () => {
+		expect(
+			buildRadarrCacheSafetyPlan(
+				{
+					remoteIds: { tmdbId: 42 },
+					path: "/movies-4k/Example Movie (2024)",
+					movieFile: {
+						id: 1001,
+						path: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						size: 2_000,
+					},
+				},
+				true,
+				radarrTargetIdentity,
 			),
 		).toBeNull();
 	});

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -17,6 +17,7 @@ import {
 	createArrServiceFingerprint,
 	createSharedPlexSafetyContext,
 	findSharedPlexDeleteBlocks,
+	parseExecutableSafetyPlan,
 	serializeExecutableSafetyPlan,
 } from "../shared-plex-safety.js";
 import type { CleanupExecutorDeps } from "../types.js";
@@ -60,7 +61,14 @@ function radarrSafetySnapshot(
 ) {
 	return serializeExecutableSafetyPlan(
 		file
-			? { kind: "verified_radarr", target: radarrTargetIdentity, file }
+			? {
+					kind: "verified_radarr",
+					target: radarrTargetIdentity,
+					file,
+					peers: [],
+					ownership: [],
+					targetDeleteNotifications: [],
+				}
 			: { kind: "verified_radarr_empty", target: radarrTargetIdentity },
 	);
 }
@@ -395,6 +403,88 @@ function makeDeps(options: TestOptions = {}) {
 	};
 }
 
+function configureVerifiedRadarrPeer(
+	fixture: ReturnType<typeof makeDeps>,
+	overrides: {
+		id?: string;
+		baseUrl?: string;
+		filePath?: string;
+		fileSize?: number;
+		mapFrom?: string;
+		mapTo?: string;
+		movieTmdbId?: number;
+		movieFileId?: number;
+		movieTags?: number[];
+		notificationTags?: number[];
+		notificationEnable?: boolean;
+		updateLibrary?: boolean;
+	} = {},
+) {
+	const peerInstance = {
+		...fixture.targetInstance,
+		id: overrides.id ?? "radarr-hd",
+		label: "HD Radarr",
+		baseUrl: overrides.baseUrl ?? "http://radarr-hd.internal:7878",
+		encryptedApiKey: "encrypted-radarr-hd-key",
+		encryptionIv: "radarr-hd-iv",
+	};
+	const peerMovie = {
+		id: 202,
+		tmdbId: overrides.movieTmdbId ?? 42,
+		title: "Example Movie",
+		tags: overrides.movieTags ?? [],
+		hasFile: true,
+		movieFileId: overrides.movieFileId ?? 2002,
+		path: "/downloads-hd/Example Movie (2024)",
+		rootFolderPath: "/downloads-hd",
+	};
+	const peerMovieFile = {
+		id: overrides.movieFileId ?? 2002,
+		path: overrides.filePath ?? "/downloads-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+		relativePath: "Example.Movie.1080p.mkv",
+		size: overrides.fileSize ?? 1_000,
+	};
+	const peerClient = {
+		movie: {
+			getAll: vi.fn().mockResolvedValue([peerMovie]),
+			getById: vi.fn().mockResolvedValue(peerMovie),
+			delete: vi.fn(),
+			update: vi.fn(),
+		},
+		movieFile: {
+			getById: vi.fn().mockResolvedValue(peerMovieFile),
+			delete: vi.fn(),
+		},
+		notification: {
+			getAll: vi.fn().mockResolvedValue([
+				{
+					enable: overrides.notificationEnable,
+					implementation: "PlexServer",
+					configContract: "PlexServerSettings",
+					onMovieDelete: true,
+					onMovieFileDelete: true,
+					tags: overrides.notificationTags ?? [],
+					fields: notificationFields({
+						mapFrom: overrides.mapFrom ?? "/downloads-hd",
+						mapTo: overrides.mapTo ?? "/plex/movies-hd",
+						updateLibrary: overrides.updateLibrary,
+					}),
+				},
+			]),
+		},
+	};
+	vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+		(args) =>
+			(args?.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance])
+				: Promise.resolve([fixture.targetInstance, peerInstance])) as never,
+	);
+	vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+		(instance) => (instance.id === peerInstance.id ? peerClient : fixture.targetClient) as never,
+	);
+	return { peerInstance, peerMovie, peerMovieFile, peerClient };
+}
+
 function configureRetryStore(deps: CleanupExecutorDeps) {
 	const retries: Array<Record<string, unknown>> = [];
 	vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
@@ -600,6 +690,24 @@ describe("shared Plex deletion safety", () => {
 		itemType: "movie",
 		action: "delete",
 	};
+
+	it("rejects a retained Radarr plan that predates peer ownership witnesses", () => {
+		expect(
+			parseExecutableSafetyPlan(
+				JSON.stringify({
+					kind: "verified_radarr",
+					target: radarrTargetIdentity,
+					file: {
+						movieFileId: 1001,
+						fullPath: {
+							value: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						},
+						size: 2_000,
+					},
+				}),
+			),
+		).toBeNull();
+	});
 
 	it("does not acquire the mutation lease for a dry run", async () => {
 		const { deps } = makeDeps();
@@ -1406,7 +1514,171 @@ describe("shared Plex deletion safety", () => {
 				service: { in: ["RADARR", "SONARR"] },
 			},
 		});
-		expect(targetClient.notification.getAll).not.toHaveBeenCalled();
+		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
+	});
+
+	it("allows a merged Plex movie only when a Radarr peer proves ownership of every retained part", async () => {
+		const fixture = makeDeps();
+		const { peerInstance, peerClient } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+
+		expect(blocks).toEqual(new Map());
+		expect(peerClient.movie.getAll).toHaveBeenCalledWith({ tmdbId: 42 });
+		expect(peerClient.movie.delete).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_radarr",
+			file: { movieFileId: 1001 },
+			peers: [
+				{
+					instanceId: peerInstance.id,
+					arrItemId: 202,
+					file: {
+						movieFileId: 2002,
+						fullPath: {
+							value: "/downloads-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+						},
+						size: 1_000,
+					},
+				},
+			],
+			ownership: [
+				{
+					plexServerUrl: "http://plex.internal:32400",
+					target: {
+						ratingKey: "plex-movie-42",
+						fullPath: {
+							value: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+						},
+						size: 2_000,
+					},
+					retained: [
+						{
+							instanceId: peerInstance.id,
+							ratingKey: "plex-movie-42",
+							fullPath: {
+								value: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							},
+							size: 1_000,
+							mapping: {
+								from: { value: "/downloads-hd" },
+								to: { value: "/plex/movies-hd" },
+							},
+						},
+					],
+				},
+			],
+			targetDeleteNotifications: expect.any(Array),
+		});
+	});
+
+	it("blocks a merged Plex movie when an extra part has no verified Radarr owner", async () => {
+		const fixture = makeDeps({
+			plexItems: [
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{
+							file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv",
+							size: 1_000,
+						},
+						{
+							file: "/movies-4k/Example Movie (2024)/Example.Movie.2160p.mkv",
+							size: 2_000,
+						},
+						{
+							file: "/plex/movies-remux/Example Movie (2024)/Example.Movie.Remux.mkv",
+							size: 3_000,
+						},
+					],
+				},
+			],
+		});
+		configureVerifiedRadarrPeer(fixture);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain("Plex has multiple files merged");
+	});
+
+	it("blocks when a Radarr peer resolves to the selected Plex part", async () => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture, {
+			filePath: "/downloads-hd/Example Movie (2024)/Example.Movie.2160p.mkv",
+			fileSize: 2_000,
+			mapTo: "/movies-4k",
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Radarr instance may access the same storage",
+		);
+	});
+
+	it("blocks duplicate Radarr peer claims for one retained Plex part", async () => {
+		const fixture = makeDeps();
+		const firstPeer = configureVerifiedRadarrPeer(fixture);
+		const secondPeer = configureVerifiedRadarrPeer(fixture, {
+			id: "radarr-hd-duplicate",
+			baseUrl: "http://radarr-hd-duplicate.internal:7878",
+		});
+		vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+			(args) =>
+				(args?.where?.service === "PLEX"
+					? Promise.resolve([fixture.plexInstance])
+					: Promise.resolve([
+							fixture.targetInstance,
+							firstPeer.peerInstance,
+							secondPeer.peerInstance,
+						])) as never,
+		);
+		vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+			(instance) =>
+				(instance.id === firstPeer.peerInstance.id
+					? firstPeer.peerClient
+					: instance.id === secondPeer.peerInstance.id
+						? secondPeer.peerClient
+						: fixture.targetClient) as never,
+		);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain("Plex has multiple files merged");
+	});
+
+	it.each([
+		["a stale peer media identity", { movieTmdbId: 43 }, "Plex has multiple files merged"],
+		[
+			"a stale peer movie-file size",
+			{ fileSize: 1_001 },
+			"could not match the exact Radarr movie file",
+		],
+	])("blocks retained ownership proof with %s", async (_label, peer, reason) => {
+		const fixture = makeDeps();
+		configureVerifiedRadarrPeer(fixture, peer);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(reason);
+	});
+
+	it("builds one complete peer inventory for a planning batch", async () => {
+		const fixture = makeDeps();
+		const { peerClient } = configureVerifiedRadarrPeer(fixture);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [
+			target,
+			{ ...target, arrItemId: 102 },
+		]);
+
+		expect(blocks).toEqual(new Map());
+		expect(peerClient.movie.getAll).toHaveBeenCalledOnce();
+		expect(peerClient.movie.getById).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.getById).toHaveBeenCalledOnce();
+		expect(peerClient.movieFile.getById).toHaveBeenCalledWith(2002);
 	});
 
 	it("renders only preview items that can receive live safety inspection", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2701,6 +2701,166 @@ describe("shared Plex deletion safety", () => {
 		expect(result).toMatchObject({ status: "completed", itemsRemoved: 1, itemsSkipped: 0 });
 	});
 
+	it("blocks queued execution when the retained Radarr peer file changes after planning", async () => {
+		const fixture = makeDeps();
+		const { peerClient, peerMovie } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") throw new Error("Expected a verified Radarr safety plan");
+		const storedApproval = approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) });
+		const updateApproval = configureApprovalStore(fixture.deps, storedApproval);
+		const updateStoredApproval = updateApproval.getMockImplementation();
+		if (!updateStoredApproval) throw new Error("Expected an approval store implementation");
+		updateApproval.mockImplementation((async (args: {
+			where: { status?: string };
+			data: { reviewedAt?: Date };
+		}) => {
+			const result = await updateStoredApproval(args as never);
+			if (args.data.reviewedAt && args.where.status === "executing") {
+				peerClient.movieFile.getById.mockResolvedValue({
+					...peerMovie,
+					id: 2999,
+					path: "/downloads-hd/Example Movie (2024)/Example.Movie.Replacement.mkv",
+					size: 1_100,
+				});
+			}
+			return result;
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(result.errors[0]).toContain("ownership changed");
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(peerClient.movie.delete).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
+	});
+
+	it("retains the queued Radarr record when its Plex notification mapping changes after file deletion", async () => {
+		const fixture = makeDeps({ onMovieDelete: true, onMovieFileDelete: true });
+		const { peerClient } = configureVerifiedRadarrPeer(fixture);
+		const originalNotifications = await fixture.targetClient.notification.getAll();
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") throw new Error("Expected a verified Radarr safety plan");
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approvalRecord({ safetySnapshot: serializeExecutableSafetyPlan(plan) }) as never,
+		]);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.targetClient.notification.getAll.mockResolvedValue(
+				originalNotifications.map((notification: Record<string, unknown>) => ({
+					...notification,
+					fields: notificationFields({ mapFrom: "/movies-4k", mapTo: "/changed-plex-root" }),
+				})),
+			);
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(result.errors[0]).toContain("Partial cleanup");
+		expect(peerClient.movie.delete).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
+	});
+
+	it("retains the direct Radarr record when a new unowned Plex part appears after file deletion", async () => {
+		const fixture = makeDeps();
+		const { peerClient } = configureVerifiedRadarrPeer(fixture);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			fixture.getMovieMediaPartsByTmdbId.mockResolvedValue([
+				{
+					ratingKey: "plex-movie-42",
+					parts: [
+						{ file: "/plex/movies-hd/Example Movie (2024)/Example.Movie.1080p.mkv", size: 1_000 },
+						{
+							file: "/plex/movies-remux/Example Movie (2024)/Example.Movie.Remux.mkv",
+							size: 3_000,
+						},
+					],
+				},
+			]);
+		});
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				title: "Example Movie",
+				year: 2024,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "4K cleanup",
+				reason: "Matched 4K profile",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "partial", itemsRemoved: 0, itemsFilesDeleted: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(peerClient.movie.delete).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
+	});
+
+	it("retains a retrying Radarr record when its retained peer disappears after file deletion", async () => {
+		const fixture = makeDeps();
+		const { peerClient } = configureVerifiedRadarrPeer(fixture);
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_radarr") throw new Error("Expected a verified Radarr safety plan");
+		const storedApproval = approvalRecord({
+			status: "retry_pending",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		});
+		configureApprovalStore(fixture.deps, storedApproval);
+		const deleteSelectedFile = fixture.deleteMovieFile.getMockImplementation();
+		if (!deleteSelectedFile) throw new Error("Expected a target file delete implementation");
+		fixture.deleteMovieFile.mockImplementation(async (movieFileId) => {
+			await deleteSelectedFile(movieFileId);
+			peerClient.movie.getAll.mockResolvedValue([]);
+		});
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.deleteMovieFile).toHaveBeenCalledWith(1001);
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		expect(storedApproval).toMatchObject({ status: "retry_pending" });
+		expect(peerClient.movie.delete).not.toHaveBeenCalled();
+		expect(peerClient.movieFile.delete).not.toHaveBeenCalled();
+	});
+
 	it("removes an already-fileless Radarr record without enabling file deletion", async () => {
 		const { deps, deleteMovie, deleteMovieFile, getMovieMediaPartsByTmdbId } = makeDeps({
 			initialMovieFileId: null,
@@ -3272,6 +3432,7 @@ describe("shared Plex deletion safety", () => {
 		targetClient.movie.getById
 			.mockResolvedValueOnce(movie)
 			.mockResolvedValueOnce(movie)
+			.mockResolvedValueOnce(movie)
 			.mockResolvedValueOnce({ ...movie, hasFile: false });
 		deleteMovieFile.mockResolvedValueOnce(undefined);
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
@@ -3790,7 +3951,7 @@ describe("shared Plex deletion safety", () => {
 		expect(targetClient.movie.update).not.toHaveBeenCalled();
 		expect(retries[0]).toMatchObject({
 			status: "retry_pending",
-			safetySnapshot: radarrSafetySnapshot(null),
+			safetySnapshot: radarrSafetySnapshot(),
 		});
 		expect(result).toMatchObject({
 			status: "partial",
@@ -4036,7 +4197,7 @@ describe("shared Plex deletion safety", () => {
 			data: expect.objectContaining({
 				status: "pending",
 				lastExecutionError: expect.stringContaining("movie record could not be removed"),
-				safetySnapshot: radarrSafetySnapshot(null),
+				safetySnapshot: radarrSafetySnapshot(),
 			}),
 		});
 	});
@@ -4078,7 +4239,7 @@ describe("shared Plex deletion safety", () => {
 		expect(firstResult).toMatchObject({ removed: 0, failed: 1 });
 		expect(storedApproval).toMatchObject({
 			status: "pending",
-			safetySnapshot: radarrSafetySnapshot(null),
+			safetySnapshot: radarrSafetySnapshot(),
 		});
 
 		storedApproval.status = "approved";
@@ -4111,7 +4272,7 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovie).toHaveBeenCalledOnce();
 		expect(storedApproval).toMatchObject({
 			status: "executed",
-			safetySnapshot: radarrSafetySnapshot(null),
+			safetySnapshot: radarrSafetySnapshot(),
 			lastExecutionError: null,
 		});
 		expect(
@@ -4288,7 +4449,7 @@ describe("shared Plex deletion safety", () => {
 		expect(storedApproval).toMatchObject({
 			status: "pending",
 			executionToken: null,
-			safetySnapshot: radarrSafetySnapshot(null),
+			safetySnapshot: radarrSafetySnapshot(),
 			lastExecutionError: expect.stringContaining("execution authority was lost"),
 		});
 	});
@@ -4649,7 +4810,7 @@ describe("shared Plex deletion safety", () => {
 		expect(retries).toHaveLength(1);
 		expect(retries[0]).toMatchObject({
 			status: "retry_executing",
-			safetySnapshot: radarrSafetySnapshot(null),
+			safetySnapshot: radarrSafetySnapshot(),
 		});
 		expect(retryResult).toMatchObject({
 			status: "partial",

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1543,6 +1543,7 @@ describe("verified Sonarr mutation handoff", () => {
 		targetClient.episodeFile.getBySeries
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([]);
 
 		await expect(executeApprovedItems(deps, "user-1", ["approval-1"])).resolves.toEqual({
@@ -1568,6 +1569,7 @@ describe("verified Sonarr mutation handoff", () => {
 		} = makeSonarrDeps();
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
 		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([]);
@@ -1622,6 +1624,45 @@ describe("verified Sonarr mutation handoff", () => {
 		});
 	});
 
+	it("blocks queued deletion when a Sonarr peer appears at the mutation boundary", async () => {
+		const fixture = makeSonarrDeps();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan.peers).toEqual([]);
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		let peerAdded = false;
+		vi.mocked(fixture.deps.prisma.crossDomainRule.findMany).mockImplementation((async () => {
+			if (!peerAdded) {
+				peerAdded = true;
+				addSonarrPeer(fixture, {
+					seriesPath: fixture.series.path,
+					episodeFiles: [
+						{
+							id: 4001,
+							path: fixture.episodeFiles[0]!.path!,
+							relativePath: fixture.episodeFiles[0]!.relativePath!,
+							size: fixture.episodeFiles[0]!.size!,
+						},
+					],
+				});
+			}
+			return [];
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(peerAdded).toBe(true);
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
 	it("retains the series when peer ownership changes after target file deletion", async () => {
 		const fixture = makeSonarrDeps();
 		const peer = addSonarrPeer(fixture);
@@ -1661,24 +1702,27 @@ describe("verified Sonarr mutation handoff", () => {
 		const { deps, targetClient, episodeFiles, bulkDelete, deleteSeries, approvalUpdate } =
 			makeSonarrDeps();
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
-		targetClient.episodeFile.getBySeries.mockResolvedValueOnce(episodeFiles).mockResolvedValueOnce([
-			...episodeFiles,
-			{
-				id: 3003,
-				path: "/tv-4k/Example Series/Season 01/Example.S01E03.2160p.mkv",
-				size: 2_003,
-			},
-		]);
+		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
+			.mockResolvedValueOnce(episodeFiles)
+			.mockResolvedValueOnce([
+				...episodeFiles,
+				{
+					id: 3003,
+					path: "/tv-4k/Example Series/Season 01/Example.S01E03.2160p.mkv",
+					size: 2_003,
+				},
+			]);
 
 		const result = await executeApprovedItems(deps, "user-1", ["approval-1"]);
 
 		expect(result).toMatchObject({ removed: 0, failed: 1 });
-		expect(result.errors[0]).toContain("Sonarr episode files changed");
+		expect(result.errors[0]).toContain("verified Sonarr ownership changed");
 		expect(bulkDelete).not.toHaveBeenCalled();
 		expect(deleteSeries).not.toHaveBeenCalled();
 		expect(approvalUpdate).toHaveBeenCalledWith({
 			where: expect.objectContaining({ id: "approval-1", status: "executing" }),
-			data: expect.objectContaining({ status: "pending" }),
+			data: expect.objectContaining({ status: "expired" }),
 		});
 	});
 
@@ -1693,6 +1737,7 @@ describe("verified Sonarr mutation handoff", () => {
 		} = makeSonarrDeps();
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
 		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([episodeFiles[1]!]);
@@ -1732,6 +1777,7 @@ describe("verified Sonarr mutation handoff", () => {
 		targetClient.episodeFile.getBySeries
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([]);
 
 		await expect(executeApprovedItems(deps, "user-1", ["approval-1"])).resolves.toEqual({
@@ -1763,6 +1809,7 @@ describe("verified Sonarr mutation handoff", () => {
 		};
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
 		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([replacement]);
@@ -1797,6 +1844,7 @@ describe("verified Sonarr mutation handoff", () => {
 		targetClient.episodeFile.getBySeries
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([])
 			.mockResolvedValueOnce([replacement])
 			.mockRejectedValueOnce(new Error("Sonarr read unavailable"));
@@ -1821,6 +1869,7 @@ describe("verified Sonarr mutation handoff", () => {
 		} = makeSonarrDeps();
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
 		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([]);
@@ -2216,6 +2265,69 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(deleteSeries).toHaveBeenCalledTimes(3);
 	});
 
+	it("blocks direct deletion when a Sonarr peer appears at the mutation boundary", async () => {
+		const fixture = makeSonarrDeps();
+		const retries = configureRetryStore(fixture.deps);
+		let peerAdded = false;
+		vi.mocked(fixture.deps.prisma.crossDomainRule.findMany).mockImplementation((async () => {
+			if (!peerAdded) {
+				peerAdded = true;
+				addSonarrPeer(fixture, {
+					seriesPath: fixture.series.path,
+					episodeFiles: [
+						{
+							id: 4001,
+							path: fixture.episodeFiles[0]!.path!,
+							relativePath: fixture.episodeFiles[0]!.relativePath!,
+							size: fixture.episodeFiles[0]!.size!,
+						},
+					],
+				});
+			}
+			return [];
+		}) as never);
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "sonarr-4k",
+				arrItemId: 201,
+				itemType: "series",
+				title: "Example Series",
+				year: 2024,
+				hasFile: true,
+				cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+				sizeOnDisk: 4_003n,
+				data: JSON.stringify({
+					_arrDashboardSource: { serviceFingerprint: sonarrServiceFingerprint },
+					path: "/tv-4k/Example Series",
+					remoteIds: { tvdbId: 123 },
+				}),
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Large series cleanup",
+				reason: "Matched size rule",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(peerAdded).toBe(true);
+		expect(retries).toHaveLength(1);
+		expect(result).toMatchObject({ itemsFilesDeleted: 0, itemsRemoved: 0 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
 	it("removes an empty verified series without issuing a bulk file deletion", async () => {
 		const { deps, targetClient, bulkDelete, deleteSeries } = makeSonarrDeps({
 			episodeFiles: [],
@@ -2239,7 +2351,7 @@ describe("verified Sonarr mutation handoff", () => {
 	});
 
 	it.each(["delete", "delete_files"] as const)(
-		"allows %s for a fileless no-notification series when a sibling Sonarr exists",
+		"does not mutate %s for a stored fileless plan that omits a live sibling Sonarr",
 		async (action) => {
 			const fixture = makeSonarrDeps({
 				action,
@@ -2251,14 +2363,15 @@ describe("verified Sonarr mutation handoff", () => {
 				approval(action, [], []),
 			] as never);
 
-			await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
-				removed: action === "delete" ? 1 : 0,
-				failed: 0,
-				errors: [],
+			await expect(
+				executeApprovedItems(fixture.deps, "user-1", ["approval-1"]),
+			).resolves.toMatchObject({
+				removed: 0,
+				failed: action === "delete" ? 1 : 0,
 			});
 			expect(fixture.bulkDelete).not.toHaveBeenCalled();
-			expect(fixture.deleteSeries).toHaveBeenCalledTimes(action === "delete" ? 1 : 0);
-			expect(peer.peerClient.series.getAll).not.toHaveBeenCalled();
+			expect(fixture.deleteSeries).toHaveBeenCalledTimes(0);
+			expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(0);
 		},
 	);
 
@@ -2267,6 +2380,7 @@ describe("verified Sonarr mutation handoff", () => {
 			makeSonarrDeps();
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
 		targetClient.episodeFile.getBySeries
+			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce([]);

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1,5 +1,6 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { PlexSeriesNotFoundError } from "../../plex/plex-client.js";
 import {
 	executeApprovedItems,
 	executeDirectRemoval,
@@ -7,11 +8,13 @@ import {
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
 } from "../cleanup-executor.js";
 import {
+	assertVerifiedSonarrPeerOwnershipRetained,
 	cleanupDeleteTargetKey,
 	createArrServiceFingerprint,
 	createSharedPlexSafetyContext,
 	findSharedPlexDeleteBlocks,
 	serializeExecutableSafetyPlan,
+	type VerifiedSonarrTargetDeleteNotification,
 } from "../shared-plex-safety.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
@@ -232,31 +235,6 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 				update: vi.fn().mockResolvedValue({}),
 			},
 			libraryCache: {
-				findFirst: vi.fn().mockResolvedValue({
-					id: "cache-sonarr-201",
-					instanceId: "sonarr-4k",
-					arrItemId: 201,
-					itemType: "series",
-					title: "Example Series",
-					year: 2024,
-					monitored: true,
-					hasFile: true,
-					status: "continuing",
-					qualityProfileId: 1,
-					qualityProfileName: "4K",
-					sizeOnDisk: 4_003n,
-					arrAddedAt: new Date("2020-01-01T00:00:00.000Z"),
-					cachedAt: new Date("2026-07-27T12:05:00.000Z"),
-					data: JSON.stringify({
-						remoteIds: { tvdbId: 123, tmdbId: 456 },
-						path: "/tv-4k/Example Series",
-						episodeFile: {
-							videoCodec: "x265",
-							audioCodec: "5.1",
-							resolution: "R2160p",
-						},
-					}),
-				}),
 				deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
 				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
 			},
@@ -284,8 +262,10 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 	return {
 		deps,
 		targetInstance,
+		plexInstance,
 		targetClient,
 		series,
+		notification,
 		episodeFiles,
 		bulkDelete,
 		deleteSeries,
@@ -304,6 +284,63 @@ const target = {
 	itemType: "series",
 	action: "delete",
 };
+
+function addSonarrPeer(
+	fixture: ReturnType<typeof makeSonarrDeps>,
+	options: {
+		episodeFiles?: Array<{ id: number; path: string; relativePath?: string; size: number }>;
+		seriesPath?: string;
+		tvdbId?: number | null;
+		notification?: Record<string, unknown>;
+	} = {},
+) {
+	const seriesPath = options.seriesPath ?? "/tv-hd/Example Series";
+	const episodeFiles = options.episodeFiles ?? [
+		{
+			id: 4003,
+			path: `${seriesPath}/Season 01/Example.S01E03.1080p.mkv`,
+			relativePath: "Season 01/Example.S01E03.1080p.mkv",
+			size: 1_003,
+		},
+	];
+	const peerInstance = {
+		...fixture.targetInstance,
+		id: "sonarr-hd",
+		label: "HD Sonarr",
+		baseUrl: "http://sonarr-hd.internal:8989",
+		encryptedApiKey: "encrypted-sonarr-hd-key",
+		encryptionIv: "sonarr-hd-iv",
+	};
+	const peerSeries = {
+		...fixture.series,
+		id: 202,
+		path: seriesPath,
+		...(options.tvdbId === null ? { tvdbId: undefined } : { tvdbId: options.tvdbId ?? 123 }),
+	};
+	const peerNotification = options.notification ?? fixture.notification;
+	const peerClient = {
+		series: {
+			getAll: vi.fn().mockResolvedValue([peerSeries]),
+			getById: vi.fn().mockResolvedValue(peerSeries),
+		},
+		episodeFile: {
+			getBySeries: vi.fn().mockResolvedValue(episodeFiles),
+		},
+		notification: {
+			getAll: vi.fn().mockResolvedValue([peerNotification]),
+		},
+	};
+	vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+		(args) =>
+			(args?.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance])
+				: Promise.resolve([fixture.targetInstance, peerInstance])) as never,
+	);
+	vi.mocked(fixture.deps.arrClientFactory.create).mockImplementation(
+		(instance) => (instance.id === peerInstance.id ? peerClient : fixture.targetClient) as never,
+	);
+	return { peerInstance, peerSeries, peerClient, episodeFiles };
+}
 
 describe("shared Plex deletion safety for Sonarr", () => {
 	it("blocks at scale when another Sonarr may mount the same storage under a different path", async () => {
@@ -341,7 +378,7 @@ describe("shared Plex deletion safety for Sonarr", () => {
 				service: { in: ["RADARR", "SONARR"] },
 			},
 		});
-		expect(targetClient.notification.getAll).not.toHaveBeenCalled();
+		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
 	});
 
 	it("verifies the complete exact episode-file set for a single-source Plex show", async () => {
@@ -356,7 +393,674 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		});
 	});
 
-	it("loads Sonarr notifications once per instance across multiple safety targets", async () => {
+	it("allows a shared Plex show when every retained part has an exact peer Sonarr file", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peerFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			peers: [
+				{
+					instanceId: "sonarr-hd",
+					arrItemId: 202,
+					files: { episodeFiles: [{ episodeFileId: 4003 }] },
+				},
+			],
+			ownership: [
+				{
+					target: expect.arrayContaining([
+						expect.objectContaining({ ratingKey: "show-123", size: 2_001 }),
+						expect.objectContaining({ ratingKey: "show-123", size: 2_002 }),
+					]),
+					retained: [
+						expect.objectContaining({
+							instanceId: "sonarr-hd",
+							ratingKey: "show-123",
+							size: 1_003,
+						}),
+					],
+				},
+			],
+		});
+	});
+
+	it("allows separate Plex show items when each one maps completely to a Sonarr instance", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-4k",
+				episodes: fixture.episodeFiles.map((file, index) => ({
+					ratingKey: `target-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+			{
+				ratingKey: "show-hd",
+				episodes: peerFiles.map((file, index) => ({
+					ratingKey: `peer-${index + 1}`,
+					parts: [{ file: file.path, size: file.size }],
+				})),
+			},
+		]);
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+	});
+
+	it("snapshots a configured Sonarr peer that does not contain the TVDB series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			peers: [
+				{
+					instanceId: "sonarr-hd",
+					arrItemId: null,
+					mediaPath: null,
+					files: null,
+				},
+			],
+		});
+		expect(peer.peerClient.episodeFile.getBySeries).not.toHaveBeenCalled();
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+	});
+
+	it("applies the retained Sonarr peer's own Plex path mapping", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, {
+			notification: {
+				...fixture.notification,
+				fields: notificationFields({
+					mapFrom: "/tv-hd",
+					mapTo: "/media/tv-hd",
+				}),
+			},
+		});
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [
+					...fixture.episodeFiles.map((file, index) => ({
+						ratingKey: `target-${index + 1}`,
+						parts: [{ file: file.path!, size: file.size! }],
+					})),
+					{
+						ratingKey: "peer-1",
+						parts: [
+							{
+								file: peer.episodeFiles[0]!.path.replace("/tv-hd", "/media/tv-hd"),
+								size: peer.episodeFiles[0]!.size,
+							},
+						],
+					},
+				],
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
+			kind: "verified_sonarr",
+			ownership: [
+				{
+					retained: [
+						expect.objectContaining({
+							mapping: {
+								from: expect.objectContaining({ value: "/tv-hd" }),
+								to: expect.objectContaining({ value: "/media/tv-hd" }),
+							},
+						}),
+					],
+				},
+			],
+		});
+	});
+
+	it("blocks a shared Plex show when any retained part lacks a peer Sonarr file", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [
+					...fixture.episodeFiles.map((file, index) => ({
+						ratingKey: `target-${index + 1}`,
+						parts: [{ file: file.path!, size: file.size! }],
+					})),
+					{
+						ratingKey: "peer-1",
+						parts: [{ file: peerFiles[0]!.path, size: peerFiles[0]!.size }],
+					},
+					{
+						ratingKey: "unowned-1",
+						parts: [{ file: "/tv-other/Example.S01E04.mkv", size: 1_004 }],
+					},
+				],
+			},
+		]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain("Plex has multiple files merged");
+	});
+
+	it("blocks when target and peer Sonarr instances claim the same Plex part", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it.each([
+		["a different TVDB ID", 999],
+		["no TVDB ID", null],
+	])("blocks a peer that tracks the target file under %s", async (_label, tvdbId) => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId,
+			seriesPath: fixture.series.path,
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("allows an alternate-TVDB peer whose physical series path is unrelated", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, { tvdbId: 999 });
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+	});
+
+	it("bounds concurrent episode-file reads while checking every untracked peer series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, { tvdbId: 998 });
+		const allSeries = Array.from({ length: 12 }, (_, index) => ({
+			...peer.peerSeries,
+			id: 202 + index,
+			tvdbId: 998 + index,
+			path: `/tv-alt/Series ${index + 1}`,
+		}));
+		peer.peerClient.series.getAll.mockResolvedValue(allSeries);
+		let activeReads = 0;
+		let maximumActiveReads = 0;
+		peer.peerClient.episodeFile.getBySeries.mockImplementation(async (seriesId) => {
+			activeReads += 1;
+			maximumActiveReads = Math.max(maximumActiveReads, activeReads);
+			await new Promise((resolve) => setTimeout(resolve, 1));
+			activeReads -= 1;
+			return [
+				{
+					id: 4_000 + seriesId,
+					seriesId,
+					path: `/tv-alt/Series ${seriesId - 201}/Season 01/Episode.mkv`,
+					relativePath: "Season 01/Episode.mkv",
+					size: 1_000 + seriesId,
+				},
+			];
+		});
+
+		await expect(findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target])).resolves.toEqual(
+			new Map(),
+		);
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalledTimes(allSeries.length * 2);
+		expect(maximumActiveReads).toBeGreaterThan(1);
+		expect(maximumActiveReads).toBeLessThanOrEqual(8);
+	});
+
+	it("reuses one stable peer inventory across a batch of target series", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, { tvdbId: 998 });
+		const secondTarget = { ...target, arrItemId: 202 };
+
+		await expect(
+			findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target, secondTarget]),
+		).resolves.toEqual(new Map());
+
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalledTimes(2);
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+	});
+
+	it("blocks an alternate-TVDB peer through its own Plex path mapping", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: "/tv-alt/Example Series",
+			episodeFiles: [
+				{
+					id: 4001,
+					path: "/tv-alt/Example Series/Season 01/Example.S01E01.2160p.mkv",
+					relativePath: "Season 01/Example.S01E01.2160p.mkv",
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+			notification: {
+				...fixture.notification,
+				fields: notificationFields({
+					mapFrom: "/tv-alt",
+					mapTo: "/tv-4k",
+				}),
+			},
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("fails closed when an alternate-TVDB peer has files but no target-Plex correlation", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			notification: {
+				...fixture.notification,
+				fields: [
+					{ name: "host", value: "different-plex.internal" },
+					{ name: "port", value: 32400 },
+					{ name: "useSsl", value: false },
+					{ name: "urlBase", value: "" },
+					{ name: "updateLibrary", value: true },
+				],
+			},
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("blocks an alternate-TVDB peer that claims the target path with a stale size", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: fixture.series.path,
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size! + 1,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("checks alternate-TVDB episode files even when the current series root is unrelated", async () => {
+		const fixture = makeSonarrDeps();
+		addSonarrPeer(fixture, {
+			tvdbId: 999,
+			seriesPath: "/tv-new/Example Series",
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!,
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: fixture.episodeFiles[0]!.size!,
+				},
+			],
+		});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("refetches the peer catalog after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll
+			.mockResolvedValueOnce([])
+			.mockResolvedValue([{ ...peer.peerSeries, tvdbId: 999, path: fixture.series.path }]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				id: 4001,
+				seriesId: peer.peerSeries.id,
+				path: fixture.episodeFiles[0]!.path!,
+				relativePath: fixture.episodeFiles[0]!.relativePath!,
+				size: fixture.episodeFiles[0]!.size!,
+			},
+		]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(fixture.getSeriesEpisodeMediaPartsByTvdbId).toHaveBeenCalledWith(123);
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("revalidates a tracked peer's path mapping after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture, {
+			episodeFiles: [
+				{
+					id: 4001,
+					path: fixture.episodeFiles[0]!.path!.replace("/tv-4k", "/tv-hd"),
+					relativePath: fixture.episodeFiles[0]!.relativePath!,
+					size: 1_001,
+				},
+			],
+		});
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		peer.peerClient.notification.getAll
+			.mockResolvedValueOnce([fixture.notification])
+			.mockResolvedValue([
+				{
+					...fixture.notification,
+					fields: notificationFields({
+						mapFrom: "/tv-hd",
+						mapTo: "/tv-4k",
+					}),
+				},
+			]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+	});
+
+	it("revalidates the target delete notification after Plex verification", async () => {
+		const fixture = makeSonarrDeps();
+		fixture.targetClient.notification.getAll
+			.mockResolvedValueOnce([fixture.notification])
+			.mockResolvedValue([
+				{
+					...fixture.notification,
+					onEpisodeFileDelete: false,
+				},
+			]);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(fixture.getSeriesEpisodeMediaPartsByTvdbId).toHaveBeenCalledWith(123);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"could not verify the live Sonarr series and Plex media state",
+		);
+	});
+
+	it("revalidates the target delete notification after the terminal peer scan", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		peer.peerClient.series.getAll
+			.mockResolvedValueOnce([peer.peerSeries])
+			.mockImplementation(async () => {
+				fixture.targetClient.notification.getAll.mockResolvedValue([
+					{
+						...fixture.notification,
+						onEpisodeFileDelete: false,
+					},
+				]);
+				return [peer.peerSeries];
+			});
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(peer.peerClient.series.getAll).toHaveBeenCalledTimes(3);
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"could not verify the live Sonarr series and Plex media state",
+		);
+	});
+
+	it("revalidates retained peer files after the target episode files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const { episodeFiles: peerFiles } = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peerFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).resolves.toBeUndefined();
+	});
+
+	it("accepts a vanished Plex show after deletion when no peer parts were retained", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan.ownership).toEqual([expect.objectContaining({ retained: [] })]);
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockRejectedValue(new PlexSeriesNotFoundError(123));
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).resolves.toBeUndefined();
+	});
+
+	it("accepts a legacy series-only notification snapshot after target files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan.targetDeleteNotifications).toEqual([
+			expect.objectContaining({
+				onSeriesDelete: false,
+				onEpisodeFileDelete: true,
+			}),
+		]);
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, {
+				...plan,
+				targetDeleteNotifications: [],
+			}),
+		).resolves.toBeUndefined();
+	});
+
+	it("blocks a new alternate-TVDB peer claim after target files are gone", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		peer.peerClient.series.getAll.mockResolvedValue([
+			{ ...peer.peerSeries, tvdbId: 999, path: fixture.series.path },
+		]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				id: 4001,
+				seriesId: peer.peerSeries.id,
+				path: fixture.episodeFiles[0]!.path!,
+				relativePath: fixture.episodeFiles[0]!.relativePath!,
+				size: fixture.episodeFiles[0]!.size!,
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("another configured Sonarr instance");
+	});
+
+	it("rejects a vanished Plex show when peer parts were retained", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockRejectedValue(new PlexSeriesNotFoundError(123));
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("no series item for TVDB 123");
+	});
+
+	it("blocks record deletion when a retained peer episode file changes", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		peer.peerClient.episodeFile.getBySeries.mockResolvedValue([
+			{
+				...peer.episodeFiles[0]!,
+				size: peer.episodeFiles[0]!.size + 1,
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("another configured Sonarr instance");
+	});
+
+	it("blocks record deletion when Plex gains an unowned part after file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		const initialPlexSeries = [
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		];
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue(initialPlexSeries);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				...initialPlexSeries[0]!,
+				episodes: [
+					...initialPlexSeries[0]!.episodes,
+					{
+						ratingKey: "episode-new",
+						parts: [{ file: "/tv-other/Example.S01E04.mkv", size: 1_004 }],
+					},
+				],
+			},
+		]);
+
+		await expect(
+			assertVerifiedSonarrPeerOwnershipRetained(fixture.deps, "user-1", target.arrItemId, plan),
+		).rejects.toThrow("another configured Sonarr instance");
+	});
+
+	it("caches initial Sonarr notifications and revalidates each target after Plex", async () => {
 		const { deps, targetClient } = makeSonarrDeps();
 		const context = createSharedPlexSafetyContext();
 
@@ -367,8 +1071,8 @@ describe("shared Plex deletion safety for Sonarr", () => {
 			context,
 		);
 
-		expect(targetClient.notification.getAll).toHaveBeenCalledOnce();
-		expect(targetClient.series.getById).toHaveBeenCalledTimes(2);
+		expect(targetClient.notification.getAll).toHaveBeenCalledTimes(3);
+		expect(targetClient.series.getById).toHaveBeenCalledTimes(4);
 	});
 
 	it("refetches Sonarr notifications across separate safety checks", async () => {
@@ -692,6 +1396,14 @@ describe("verified Sonarr mutation handoff", () => {
 				size: 2_002,
 			},
 		],
+		targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[] = [
+			{
+				plexServerUrl: "http://plex.internal:32400",
+				onSeriesDelete: false,
+				onEpisodeFileDelete: true,
+				mapping: null,
+			},
+		],
 	) {
 		return {
 			id: "approval-1",
@@ -723,6 +1435,9 @@ describe("verified Sonarr mutation handoff", () => {
 						size: file.size!,
 					})),
 				},
+				peers: [],
+				ownership: [],
+				targetDeleteNotifications,
 			}),
 		};
 	}
@@ -822,7 +1537,9 @@ describe("verified Sonarr mutation handoff", () => {
 		const { deps, targetClient, episodeFiles, bulkDelete, deleteSeries } = makeSonarrDeps({
 			notificationKind: "none",
 		});
-		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([approval()] as never);
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approval("delete", undefined, []),
+		] as never);
 		targetClient.episodeFile.getBySeries
 			.mockResolvedValueOnce(episodeFiles)
 			.mockResolvedValueOnce(episodeFiles)
@@ -870,34 +1587,73 @@ describe("verified Sonarr mutation handoff", () => {
 		});
 	});
 
-	it("fails closed for Sonarr file exemptions until multi-file semantics are defined", async () => {
-		const { deps, bulkDelete, deleteSeries } = makeSonarrDeps();
-		const storedApproval = approval() as unknown as Record<string, unknown>;
-		configureApprovalStore(deps, storedApproval);
-		vi.mocked(deps.prisma.crossDomainRule.findMany).mockResolvedValue([
+	it("deletes only the target Sonarr files after revalidating shared Plex ownership", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
 			{
-				id: "sonarr-file-exemption",
-				deployedDocument: JSON.stringify({
-					version: 1,
-					root: {
-						kind: "video_codec",
-						params: { operator: "is", codecs: ["x265"] },
-					},
-				}),
-				deployedScope: JSON.stringify({ serviceTypes: ["SONARR"], instanceIds: [] }),
-				deployedActions: JSON.stringify([
-					{ type: "send_notification" },
-					{ type: "exempt_cleanup" },
-				]),
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
 			},
-		] as never);
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
 
-		const result = await executeApprovedItems(deps, "user-1", ["approval-1"]);
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(peer.peerClient.episodeFile.getBySeries).toHaveBeenCalled();
+		expect(fixture.deleteSeries).toHaveBeenCalledWith(201, {
+			deleteFiles: false,
+			addImportListExclusion: false,
+		});
+	});
+
+	it("retains the series when peer ownership changes after target file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		peer.peerClient.episodeFile.getBySeries.mockImplementation(async () => {
+			return fixture.bulkDelete.mock.calls.length === 0
+				? peer.episodeFiles
+				: [{ ...peer.episodeFiles[0]!, size: peer.episodeFiles[0]!.size + 1 }];
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
 
 		expect(result).toMatchObject({ removed: 0, failed: 1 });
-		expect(result.errors[0]).toContain("deployed cleanup exemption policy");
-		expect(bulkDelete).not.toHaveBeenCalled();
-		expect(deleteSeries).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 		expect(storedApproval).toMatchObject({ status: "pending" });
 	});
 
@@ -1119,6 +1875,55 @@ describe("verified Sonarr mutation handoff", () => {
 		});
 	});
 
+	it("retries a shared Sonarr series-delete notification after target files were removed", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		peer.peerClient.series.getAll.mockResolvedValue([]);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: fixture.episodeFiles.map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		fixture.deleteSeries
+			.mockRejectedValueOnce(new Error("series delete unavailable"))
+			.mockRejectedValueOnce(new Error("series delete unavailable"));
+
+		const firstResult = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(firstResult).toMatchObject({ removed: 0, failed: 1 });
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [expect.objectContaining({ instanceId: "sonarr-hd", arrItemId: null })],
+			ownership: [expect.objectContaining({ retained: [] })],
+		});
+
+		storedApproval.status = "approved";
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
+		expect(fixture.deleteSeries).toHaveBeenCalledTimes(3);
+	});
+
 	it("reconciles an interrupted approved Sonarr mutation to the unchanged file remainder", async () => {
 		const remainingFile = {
 			id: 3002,
@@ -1149,6 +1954,52 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(approvalUpdate.mock.invocationCallOrder[0]).toBeLessThan(
 			bulkDelete.mock.invocationCallOrder[0]!,
 		);
+	});
+
+	it("recovers a shared Sonarr crash after files were deleted but before the snapshot changed", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.bulkDelete.mockClear();
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+			lastExecutionError: INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).toHaveBeenCalledOnce();
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			ownership: [
+				expect.objectContaining({
+					retained: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+				}),
+			],
+		});
 	});
 
 	it("reconciles an interrupted Sonarr file-delete retry when no episode files remain", async () => {
@@ -1276,8 +2127,22 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(storedApproval).toMatchObject({ status: "expired", executionToken: null });
 	});
 
-	it("durably retries a direct Sonarr record deletion after exact file removal", async () => {
-		const { deps, episodeFiles, bulkDelete, deleteSeries } = makeSonarrDeps();
+	it("durably retries direct shared-Sonarr record deletion after exact file removal", async () => {
+		const fixture = makeSonarrDeps({
+			onSeriesDelete: true,
+			onEpisodeFileDelete: true,
+		});
+		const peer = addSonarrPeer(fixture);
+		fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+			{
+				ratingKey: "show-123",
+				episodes: [...fixture.episodeFiles, ...peer.episodeFiles].map((file, index) => ({
+					ratingKey: `episode-${index + 1}`,
+					parts: [{ file: file.path!, size: file.size! }],
+				})),
+			},
+		]);
+		const { deps, episodeFiles, bulkDelete, deleteSeries } = fixture;
 		const retries = configureRetryStore(deps);
 		deleteSeries
 			.mockRejectedValueOnce(new Error("series delete unavailable"))
@@ -1329,7 +2194,17 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(retries).toHaveLength(1);
 		expect(retries[0]).toMatchObject({
 			status: "executed",
-			safetySnapshot: approval("delete", []).safetySnapshot,
+			safetySnapshot: expect.any(String),
+		});
+		expect(JSON.parse(retries[0]!.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+			ownership: [
+				expect.objectContaining({
+					retained: [expect.objectContaining({ instanceId: "sonarr-hd" })],
+				}),
+			],
 		});
 		expect(retryResult).toMatchObject({
 			status: "completed",
@@ -1362,6 +2237,30 @@ describe("verified Sonarr mutation handoff", () => {
 			addImportListExclusion: false,
 		});
 	});
+
+	it.each(["delete", "delete_files"] as const)(
+		"allows %s for a fileless no-notification series when a sibling Sonarr exists",
+		async (action) => {
+			const fixture = makeSonarrDeps({
+				action,
+				notificationKind: "none",
+				episodeFiles: [],
+			});
+			const peer = addSonarrPeer(fixture);
+			vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+				approval(action, [], []),
+			] as never);
+
+			await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+				removed: action === "delete" ? 1 : 0,
+				failed: 0,
+				errors: [],
+			});
+			expect(fixture.bulkDelete).not.toHaveBeenCalled();
+			expect(fixture.deleteSeries).toHaveBeenCalledTimes(action === "delete" ? 1 : 0);
+			expect(peer.peerClient.series.getAll).not.toHaveBeenCalled();
+		},
+	);
 
 	it("accepts a lost Sonarr record-delete response after a not-found readback", async () => {
 		const { deps, targetClient, episodeFiles, deleteSeries, setLiveSeriesExists } =

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -390,6 +390,14 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		expect(context.plans.get(cleanupDeleteTargetKey(target))).toMatchObject({
 			kind: "verified_sonarr",
 			files: { episodeFiles: [{ episodeFileId: 3001 }, { episodeFileId: 3002 }] },
+			ownership: [
+				expect.objectContaining({
+					retained: [],
+					target: expect.arrayContaining([
+						expect.objectContaining({ ratingKey: "show-123", size: 2_001 }),
+					]),
+				}),
+			],
 		});
 	});
 
@@ -1323,6 +1331,20 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		expect(getSeriesEpisodeMediaPartsByTvdbId).not.toHaveBeenCalled();
 	});
 
+	it("blocks fileless Sonarr planning when a sibling instance is already configured", async () => {
+		const fixture = makeSonarrDeps({ notificationKind: "none", episodeFiles: [] });
+		const peer = addSonarrPeer(fixture);
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(target))).toContain(
+			"another configured Sonarr instance may access the same storage",
+		);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+		expect(peer.peerClient.episodeFile.getBySeries).not.toHaveBeenCalled();
+	});
+
 	it("respects notification tags", async () => {
 		const { deps, getSeriesEpisodeMediaPartsByTvdbId } = makeSonarrDeps({
 			seriesTags: [1],
@@ -1436,7 +1458,21 @@ describe("verified Sonarr mutation handoff", () => {
 					})),
 				},
 				peers: [],
-				ownership: [],
+				peerInventoryComplete: true,
+				ownership:
+					targetDeleteNotifications.length === 0
+						? []
+						: [
+								{
+									plexServerUrl: "http://plex.internal:32400",
+									target: episodeFiles.map((file) => ({
+										ratingKey: `show-123`,
+										fullPath: { value: file.path!, windows: false },
+										size: file.size!,
+									})),
+									retained: [],
+								},
+							],
 				targetDeleteNotifications,
 			}),
 		};
@@ -1587,6 +1623,40 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(episodeFileCacheDeleteMany).toHaveBeenCalledWith({
 			where: { instanceId: "sonarr-4k", arrSeriesId: 201 },
 		});
+	});
+
+	it("retains a no-peer Sonarr record when Plex gains an unowned part after exact file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approval(),
+		] as never);
+		const deleteVerifiedFiles = fixture.bulkDelete.getMockImplementation();
+		if (!deleteVerifiedFiles) throw new Error("Expected a Sonarr bulk-delete implementation");
+		fixture.bulkDelete.mockImplementation(async (episodeFileIds) => {
+			await deleteVerifiedFiles(episodeFileIds);
+			fixture.getSeriesEpisodeMediaPartsByTvdbId.mockResolvedValue([
+				{
+					ratingKey: "show-123",
+					episodes: [
+						{
+							ratingKey: "episode-new",
+							parts: [
+								{
+									file: "/tv-4k/Example Series/Season 01/Example.S01E03.2160p.mkv",
+									size: 2_003,
+								},
+							],
+						},
+					],
+				},
+			]);
+		});
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
 
 	it("deletes only the target Sonarr files after revalidating shared Plex ownership", async () => {
@@ -1909,7 +1979,12 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(firstResult).toMatchObject({ removed: 0, failed: 1 });
 		expect(storedApproval).toMatchObject({
 			status: "pending",
-			safetySnapshot: approval("delete", []).safetySnapshot,
+		});
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peerInventoryComplete: true,
+			ownership: [expect.objectContaining({ retained: [] })],
 		});
 
 		storedApproval.status = "approved";
@@ -1969,6 +2044,38 @@ describe("verified Sonarr mutation handoff", () => {
 			failed: 0,
 			errors: [],
 		});
+		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
+		expect(fixture.deleteSeries).toHaveBeenCalledTimes(3);
+	});
+
+	it("retries a no-peer Sonarr series-delete notification after target files were removed", async () => {
+		const fixture = makeSonarrDeps({ onSeriesDelete: true, onEpisodeFileDelete: true });
+		const context = createSharedPlexSafetyContext();
+		expect(await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context)).toEqual(
+			new Map(),
+		);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		expect(plan).toMatchObject({
+			peers: [],
+			peerInventoryComplete: true,
+			ownership: [expect.objectContaining({ retained: [] })],
+		});
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		fixture.deleteSeries
+			.mockRejectedValueOnce(new Error("series delete unavailable"))
+			.mockRejectedValueOnce(new Error("series delete unavailable"));
+
+		const firstResult = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+		storedApproval.status = "approved";
+		const retryResult = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(firstResult).toMatchObject({ removed: 0, failed: 1 });
+		expect(retryResult).toEqual({ removed: 1, failed: 0, errors: [] });
 		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
 		expect(fixture.deleteSeries).toHaveBeenCalledTimes(3);
 	});
@@ -2048,6 +2155,39 @@ describe("verified Sonarr mutation handoff", () => {
 					retained: [expect.objectContaining({ instanceId: "sonarr-hd" })],
 				}),
 			],
+		});
+	});
+
+	it("recovers an interrupted no-peer Sonarr record deletion from a complete empty inventory", async () => {
+		const fixture = makeSonarrDeps({ onSeriesDelete: true, onEpisodeFileDelete: true });
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [target], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(target));
+		if (plan?.kind !== "verified_sonarr") throw new Error("Expected verified Sonarr plan");
+		await fixture.targetClient.episodeFile.bulkDelete([3001, 3002]);
+		fixture.bulkDelete.mockClear();
+		const storedApproval = {
+			...approval(),
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+			lastExecutionError: INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).toHaveBeenCalledWith(201, {
+			deleteFiles: false,
+			addImportListExclusion: false,
+		});
+		expect(JSON.parse(storedApproval.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [],
+			peerInventoryComplete: true,
 		});
 	});
 
@@ -2265,6 +2405,71 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(deleteSeries).toHaveBeenCalledTimes(3);
 	});
 
+	it("durably retries direct no-peer Sonarr record deletion after exact file removal", async () => {
+		const fixture = makeSonarrDeps({ onSeriesDelete: true, onEpisodeFileDelete: true });
+		const retries = configureRetryStore(fixture.deps);
+		fixture.deleteSeries
+			.mockRejectedValueOnce(new Error("series delete unavailable"))
+			.mockRejectedValueOnce(new Error("series delete unavailable"));
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "sonarr-4k",
+				arrItemId: 201,
+				itemType: "series",
+				title: "Example Series",
+				year: 2024,
+				hasFile: true,
+				cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+				sizeOnDisk: 4_003n,
+				data: JSON.stringify({
+					_arrDashboardSource: { serviceFingerprint: sonarrServiceFingerprint },
+					path: "/tv-4k/Example Series",
+					remoteIds: { tvdbId: 123 },
+				}),
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Large series cleanup",
+				reason: "Matched size rule",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+		const config = { id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never;
+
+		const firstResult = await executeDirectRemoval(
+			fixture.deps,
+			config,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+		const retryResult = await executeDirectRemoval(
+			fixture.deps,
+			config,
+			"user-1",
+			[],
+			0,
+			0,
+			Date.now(),
+		);
+
+		expect(firstResult).toMatchObject({ status: "partial", itemsFilesDeleted: 1 });
+		expect(retries).toHaveLength(1);
+		expect(JSON.parse(retries[0]!.safetySnapshot as string)).toMatchObject({
+			kind: "verified_sonarr",
+			files: { episodeFiles: [] },
+			peers: [],
+			peerInventoryComplete: true,
+			ownership: [expect.objectContaining({ retained: [] })],
+		});
+		expect(retryResult).toMatchObject({ status: "completed", itemsRemoved: 1 });
+		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
+		expect(fixture.deleteSeries).toHaveBeenCalledTimes(3);
+	});
+
 	it("blocks direct deletion when a Sonarr peer appears at the mutation boundary", async () => {
 		const fixture = makeSonarrDeps();
 		const retries = configureRetryStore(fixture.deps);
@@ -2348,6 +2553,125 @@ describe("verified Sonarr mutation handoff", () => {
 			deleteFiles: false,
 			addImportListExclusion: false,
 		});
+	});
+
+	it("blocks queued fileless record deletion when a Plex series-delete notification appears", async () => {
+		const fixture = makeSonarrDeps({
+			notificationKind: "none",
+			episodeFiles: [],
+			plexSeries: [],
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approval("delete", [], []),
+		] as never);
+		fixture.targetClient.notification.getAll.mockResolvedValueOnce([]).mockResolvedValue([
+			{
+				implementation: "PlexServer",
+				configContract: "PlexServerSettings",
+				onSeriesDelete: true,
+				onEpisodeFileDelete: true,
+				tags: [],
+				fields: notificationFields({
+					mapFrom: "/tv-4k",
+					mapTo: "/plex/tv-4k",
+				}),
+			},
+		]);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
+	it("blocks queued record deletion when a Plex series-delete notification appears after file removal", async () => {
+		const fixture = makeSonarrDeps({ notificationKind: "none" });
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			approval("delete", undefined, []),
+		] as never);
+		fixture.targetClient.notification.getAll
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValue([
+				{
+					implementation: "PlexServer",
+					configContract: "PlexServerSettings",
+					onSeriesDelete: true,
+					onEpisodeFileDelete: true,
+					tags: [],
+					fields: notificationFields({
+						mapFrom: "/tv-4k",
+						mapTo: "/plex/tv-4k",
+					}),
+				},
+			]);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3001, 3002]);
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
+	it("blocks direct fileless record deletion when a Plex series-delete notification appears", async () => {
+		const fixture = makeSonarrDeps({
+			notificationKind: "none",
+			episodeFiles: [],
+			plexSeries: [],
+		});
+		fixture.targetClient.notification.getAll.mockResolvedValueOnce([]).mockResolvedValue([
+			{
+				implementation: "PlexServer",
+				configContract: "PlexServerSettings",
+				onSeriesDelete: true,
+				onEpisodeFileDelete: true,
+				tags: [],
+				fields: notificationFields({
+					mapFrom: "/tv-4k",
+					mapTo: "/plex/tv-4k",
+				}),
+			},
+		]);
+		const flaggedItem = {
+			cacheItem: {
+				instanceId: "sonarr-4k",
+				arrItemId: 201,
+				itemType: "series",
+				title: "Example Series",
+				year: 2024,
+				hasFile: false,
+				cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+				sizeOnDisk: 0n,
+				data: JSON.stringify({
+					_arrDashboardSource: { serviceFingerprint: sonarrServiceFingerprint },
+					path: "/tv-4k/Example Series",
+					remoteIds: { tvdbId: 123 },
+				}),
+			},
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Large series cleanup",
+				reason: "Matched size rule",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ itemsFilesDeleted: 0, itemsRemoved: 0 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
 
 	it.each(["delete", "delete_files"] as const)(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -10,45 +10,46 @@
  * Supports three actions per rule: delete, unmonitor, delete_files.
  */
 
+import { createHash, randomUUID } from "node:crypto";
 import {
-	crossDomainActionsSchema,
 	type CrossDomainRuleScope,
+	crossDomainActionsSchema,
 	crossDomainRuleScopeSchema,
 	type DataSourceDependency,
 	groupChildren,
 	isKindLegalForContext,
 	isRulePredicate,
 	type RuleDocument,
-	ruleDocumentSchema,
-	ruleDataSourceMap,
 	type RuleNode,
+	ruleDataSourceMap,
+	ruleDocumentSchema,
 	ruleParamSchemaMap,
 	validateV1Depth,
 	walkPredicates,
 } from "@arr/shared";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
-import { createHash, randomUUID } from "node:crypto";
 import type { Prisma } from "../../generated/prisma/client.js";
 import { isNotFoundError } from "../arr/client-factory.js";
 import { buildMovieFile } from "../library/movie-normalizer.js";
 import type { LibraryCleanupConfig, LibraryCleanupRule, ServiceInstance } from "../prisma.js";
+import { evaluateItemAgainstRulesViaEngine } from "../rules/cleanup-adapter.js";
 import { SeerrClient } from "../seerr/seerr-client.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
+import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 import { applyQuiSeedingFilter } from "./qui-filter.js";
-import { evaluateItemAgainstRulesViaEngine } from "../rules/cleanup-adapter.js";
 import { evaluateSingleCondition, extractRating, parseAudioChannels } from "./rule-evaluators.js";
 import {
 	ArrCrossInstanceOwnershipChangedDuringSafetyCheckError,
 	ArrFileChangedDuringSafetyCheckError,
 	ArrMutationAuthorityChangedDuringSafetyCheckError,
+	ArrTargetChangedDuringSafetyCheckError,
 	assertVerifiedArrTargetUnchanged,
 	assertVerifiedRadarrEmptyUnchanged,
 	assertVerifiedRadarrFileUnchanged,
 	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
 	assertVerifiedSonarrPeerOwnershipRetained,
-	ArrTargetChangedDuringSafetyCheckError,
 	buildCacheTargetSafetyPlan,
 	buildRadarrCacheSafetyPlan,
 	buildSonarrCacheSafetyPlan,
@@ -61,9 +62,9 @@ import {
 	findSharedPlexDeleteBlocks,
 	parseExecutableSafetyPlan,
 	RadarrFileChangedDuringSafetyCheckError,
-	serializeExecutableSafetyPlan,
 	type SharedMediaSafetyPlan,
 	SonarrFilesChangedDuringSafetyCheckError,
+	serializeExecutableSafetyPlan,
 	type VerifiedRadarrFileIdentity,
 	type VerifiedSonarrFileIdentity,
 } from "./shared-plex-safety.js";
@@ -83,7 +84,6 @@ import type {
 	SeerrRequestInfo,
 	SeerrRequestMap,
 } from "./types.js";
-import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 
 // Default approval expiry: 7 days
 const APPROVAL_EXPIRY_DAYS = 7;
@@ -479,7 +479,7 @@ function hasVerifiedSonarrOwnershipProof(
 	return (
 		action === "delete" &&
 		plan?.kind === "verified_sonarr" &&
-		plan.peers.length > 0 &&
+		plan.peerInventoryComplete === true &&
 		plan.ownership.length > 0
 	);
 }
@@ -785,6 +785,7 @@ async function buildEvaluatedCacheSafetyPlan(
 		? {
 				...cachePlan,
 				peers: livePlan.peers,
+				peerInventoryComplete: livePlan.peerInventoryComplete,
 				ownership: livePlan.ownership,
 				targetDeleteNotifications: livePlan.targetDeleteNotifications,
 			}
@@ -903,7 +904,32 @@ function createRadarrDestructiveMutationAuthority(
 
 	return async () => {
 		await assertExecutionAllowed?.();
+		if (safetyPlan.kind === "verified_radarr_empty") {
+			if (postFileOwnershipPlan && postFileOwnershipPlan.ownership.length > 0) {
+				await assertVerifiedRadarrPeerOwnershipRetained(
+					deps,
+					userId,
+					target.arrItemId,
+					postFileOwnershipPlan,
+				);
+				return;
+			}
+			const context = createSharedPlexSafetyContext();
+			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+			const livePlan = asExecutableSafetyPlan(context.plans.get(cleanupDeleteTargetKey(target)));
+			if (
+				blocks.has(cleanupDeleteTargetKey(target)) ||
+				!livePlan ||
+				!executableSafetyPlansEqual(safetyPlan, livePlan)
+			) {
+				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+					"Skipped for safety: verified Radarr ownership changed at the mutation boundary. Run cleanup again before deleting the record.",
+				);
+			}
+			return;
+		}
 		if (!ownershipPlan) return;
+		if (ownershipPlan.ownership.length === 0) return;
 		if (!fileDeleteAuthorityConsumed && safetyPlan.kind === "verified_radarr") {
 			const context = createSharedPlexSafetyContext();
 			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -935,6 +961,25 @@ function createSonarrDestructiveMutationAuthority(
 	return async () => {
 		await assertExecutionAllowed?.();
 		if (fileDeleteAuthorityConsumed || safetyPlan.files.episodeFiles.length === 0) {
+			if (safetyPlan.ownership.length === 0) {
+				const context = createSharedPlexSafetyContext();
+				const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+				const livePlan = asExecutableSafetyPlan(context.plans.get(cleanupDeleteTargetKey(target)));
+				const emptyFileRemainder = {
+					...safetyPlan,
+					files: { ...safetyPlan.files, episodeFiles: [] },
+				};
+				if (
+					blocks.has(cleanupDeleteTargetKey(target)) ||
+					!livePlan ||
+					!executableSafetyPlansEqual(emptyFileRemainder, livePlan)
+				) {
+					throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+						"Skipped for safety: verified Sonarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+					);
+				}
+				return;
+			}
 			await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
 			return;
 		}

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1998,9 +1998,7 @@ async function executeQueuedCleanupItems(
 								assertMutationAuthority,
 								postFileOwnershipPlan,
 							)
-						: mutationInstance.service === "SONARR" &&
-								safetyPlan?.kind === "verified_sonarr" &&
-								safetyPlan.peers.length > 0
+						: mutationInstance.service === "SONARR" && safetyPlan?.kind === "verified_sonarr"
 							? createSonarrDestructiveMutationAuthority(
 									deps,
 									userId,
@@ -4320,9 +4318,7 @@ export async function executeDirectRemoval(
 							safetyPlan!,
 							assertRunLease,
 						)
-					: mutationInstance.service === "SONARR" &&
-							safetyPlan?.kind === "verified_sonarr" &&
-							safetyPlan.peers.length > 0
+					: mutationInstance.service === "SONARR" && safetyPlan?.kind === "verified_sonarr"
 						? createSonarrDestructiveMutationAuthority(
 								deps,
 								userId,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -47,6 +47,7 @@ import {
 	assertVerifiedRadarrFileUnchanged,
 	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
+	assertVerifiedSonarrPeerOwnershipRetained,
 	ArrTargetChangedDuringSafetyCheckError,
 	buildCacheTargetSafetyPlan,
 	buildRadarrCacheSafetyPlan,
@@ -407,8 +408,7 @@ function buildPostPartialRetrySnapshot(
 		return undefined;
 	}
 	return serializeExecutableSafetyPlan({
-		kind: "verified_sonarr",
-		target: safetyPlan.target,
+		...safetyPlan,
 		files: {
 			seriesPath: safetyPlan.files.seriesPath,
 			episodeFiles: [],
@@ -469,6 +469,18 @@ function isRecordedRadarrFilelessRetry(
 		approvedPlan.kind === "verified_radarr" &&
 		livePlan.kind === "verified_radarr_empty" &&
 		lastExecutionError?.startsWith("Partial cleanup: the verified Radarr movie file") === true
+	);
+}
+
+function hasVerifiedSonarrOwnershipProof(
+	action: string,
+	plan: ExecutableSharedMediaSafetyPlan | null,
+): plan is Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }> {
+	return (
+		action === "delete" &&
+		plan?.kind === "verified_sonarr" &&
+		plan.peers.length > 0 &&
+		plan.ownership.length > 0
 	);
 }
 
@@ -645,6 +657,7 @@ async function loadCurrentMutationInstance(
 	if (
 		verifiedFileCount > 0 &&
 		executablePlan.kind !== "verified_radarr" &&
+		!(executablePlan.kind === "verified_sonarr" && executablePlan.peers.length > 0) &&
 		instances.some(
 			(candidate) => candidate.id !== instance.id && candidate.service === instance.service,
 		)
@@ -761,13 +774,21 @@ async function buildEvaluatedCacheSafetyPlan(
 		where: { instanceId: item.instanceId, arrSeriesId: item.arrItemId },
 		select: { arrEpisodeFileId: true, path: true, size: true },
 	});
-	return buildSonarrCacheSafetyPlan(
+	const cachePlan = buildSonarrCacheSafetyPlan(
 		seriesPath,
 		tvdbId,
 		item.hasFile,
 		episodeFiles,
 		livePlan.target,
 	);
+	return cachePlan?.kind === "verified_sonarr"
+		? {
+				...cachePlan,
+				peers: livePlan.peers,
+				ownership: livePlan.ownership,
+				targetDeleteNotifications: livePlan.targetDeleteNotifications,
+			}
+		: cachePlan;
 }
 
 async function blockPlansThatDifferFromEvaluatedCache(
@@ -900,6 +921,36 @@ function createRadarrDestructiveMutationAuthority(
 			return;
 		}
 		await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, ownershipPlan);
+	};
+}
+
+function createSonarrDestructiveMutationAuthority(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	target: CleanupDeleteTarget,
+	safetyPlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
+	assertExecutionAllowed?: () => Promise<void>,
+): () => Promise<void> {
+	let fileDeleteAuthorityConsumed = false;
+	return async () => {
+		await assertExecutionAllowed?.();
+		if (fileDeleteAuthorityConsumed || safetyPlan.files.episodeFiles.length === 0) {
+			await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
+			return;
+		}
+		const context = createSharedPlexSafetyContext();
+		const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+		const livePlan = asExecutableSafetyPlan(context.plans.get(cleanupDeleteTargetKey(target)));
+		if (
+			blocks.has(cleanupDeleteTargetKey(target)) ||
+			!livePlan ||
+			!executableSafetyPlansEqual(safetyPlan, livePlan)
+		) {
+			throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+				"Skipped for safety: verified Sonarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+			);
+		}
+		fileDeleteAuthorityConsumed = true;
 	};
 }
 
@@ -1676,7 +1727,7 @@ async function executeQueuedCleanupItems(
 
 			let sharedPlexBlock: string | undefined;
 			let approvalIdentityChanged = false;
-			const approvedPlan = parseExecutableSafetyPlan(approval.safetySnapshot);
+			let approvedPlan = parseExecutableSafetyPlan(approval.safetySnapshot);
 			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
 			let postFileOwnershipPlan:
 				| Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>
@@ -1708,86 +1759,154 @@ async function executeQueuedCleanupItems(
 					);
 				}
 			}
-			if (!sharedPlexBlock && !retryTargetAlreadyAbsent) {
+			if (
+				!sharedPlexBlock &&
+				!retryTargetAlreadyAbsent &&
+				recoveringInterruptedMutation &&
+				hasVerifiedSonarrOwnershipProof(action, approvedPlan) &&
+				approvedPlan.files.episodeFiles.length > 0
+			) {
 				try {
-					const targetKey = cleanupDeleteTargetKey(approval);
-					const blocks = await findSharedPlexDeleteBlocks(
+					await assertVerifiedSonarrPeerOwnershipRetained(
 						deps,
 						userId,
-						[
-							{
-								instanceId: approval.instanceId,
-								arrItemId: approval.arrItemId,
-								itemType: approval.itemType,
-								action,
-							},
-						],
-						sharedPlexSafetyContext,
+						approval.arrItemId,
+						approvedPlan,
 					);
-					sharedPlexBlock = blocks.get(targetKey);
-					safetyPlan = sharedPlexSafetyContext.plans.get(targetKey);
+					const reconciledPlan: Extract<
+						ExecutableSharedMediaSafetyPlan,
+						{ kind: "verified_sonarr" }
+					> = {
+						...approvedPlan,
+						files: { seriesPath: approvedPlan.files.seriesPath, episodeFiles: [] },
+					};
+					await updateClaimedCleanupApproval(
+						prisma,
+						userId,
+						approval.id,
+						options.executeStatus,
+						claimedExecutionToken,
+						{
+							safetySnapshot: serializeExecutableSafetyPlan(reconciledPlan),
+							lastExecutionError:
+								"Recovered a persisted Sonarr mutation after verifying that its target files were already removed.",
+						},
+					);
+					approvedPlan = reconciledPlan;
+					safetyPlan = reconciledPlan;
 				} catch (error) {
-					log.error(
+					log.info(
 						{ err: error, approvalId: approval.id },
-						"Approved cleanup item safety preflight failed closed",
+						"Interrupted Sonarr cleanup was not a verified record-only recovery",
 					);
-					sharedPlexBlock =
-						"Skipped for safety: arr-dashboard could not complete the live ARR and media-server preflight.";
 				}
-				if (!sharedPlexBlock && !safetyPlan) {
-					sharedPlexBlock =
-						"Skipped for safety: arr-dashboard did not produce an explicit ARR mutation safety plan.";
-				}
-				if (!sharedPlexBlock) {
-					const livePlan = asExecutableSafetyPlan(safetyPlan);
-					const exactPlanMatch =
-						approvedPlan && livePlan && executableSafetyPlansEqual(approvedPlan, livePlan);
-					const recordedRadarrFilelessRetry =
-						approvedPlan && livePlan
-							? isRecordedRadarrFilelessRetry(
-									action,
-									approvedPlan,
-									livePlan,
-									approval.lastExecutionError,
-								)
-							: false;
-					const recoverableFileRemainder =
-						(recoveringInterruptedMutation || recordedRadarrFilelessRetry) &&
-						(action === "delete" || action === "delete_files") &&
-						approvedPlan &&
-						livePlan &&
-						isVerifiedFileRemainder(approvedPlan, livePlan);
-					if (!exactPlanMatch && !recoverableFileRemainder) {
-						approvalIdentityChanged = true;
+			}
+			if (!sharedPlexBlock && !retryTargetAlreadyAbsent) {
+				const sonarrRecordOnlyRetryPlan =
+					hasVerifiedSonarrOwnershipProof(action, approvedPlan) &&
+					approvedPlan.files.episodeFiles.length === 0
+						? approvedPlan
+						: null;
+				if (sonarrRecordOnlyRetryPlan) {
+					try {
+						await assertVerifiedSonarrPeerOwnershipRetained(
+							deps,
+							userId,
+							approval.arrItemId,
+							sonarrRecordOnlyRetryPlan,
+						);
+						safetyPlan = sonarrRecordOnlyRetryPlan;
+					} catch (error) {
+						log.error(
+							{ err: error, approvalId: approval.id },
+							"Approved Sonarr record-only retry ownership revalidation failed closed",
+						);
 						sharedPlexBlock =
-							"Skipped for safety: the ARR target or file identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
-					} else if (recoverableFileRemainder && !exactPlanMatch) {
-						if (
-							approvedPlan?.kind === "verified_radarr" &&
-							livePlan?.kind === "verified_radarr_empty"
-						) {
-							postFileOwnershipPlan = approvedPlan;
-						}
-						try {
-							await updateClaimedCleanupApproval(
-								prisma,
-								userId,
-								approval.id,
-								options.executeStatus,
-								claimedExecutionToken,
+							"Skipped for safety: the retained Sonarr-to-Plex ownership changed before the series record could be retried.";
+					}
+				} else {
+					try {
+						const targetKey = cleanupDeleteTargetKey(approval);
+						const blocks = await findSharedPlexDeleteBlocks(
+							deps,
+							userId,
+							[
 								{
-									safetySnapshot: serializeExecutableSafetyPlan(postFileOwnershipPlan ?? livePlan),
-									lastExecutionError:
-										"Recovered a persisted cleanup mutation after verifying the remaining ARR file set.",
+									instanceId: approval.instanceId,
+									arrItemId: approval.arrItemId,
+									itemType: approval.itemType,
+									action,
 								},
-							);
-						} catch (error) {
-							log.error(
-								{ err: error, approvalId: approval.id },
-								"Cleanup could not persist its reconciled crash-recovery snapshot",
-							);
+							],
+							sharedPlexSafetyContext,
+						);
+						sharedPlexBlock = blocks.get(targetKey);
+						safetyPlan = sharedPlexSafetyContext.plans.get(targetKey);
+					} catch (error) {
+						log.error(
+							{ err: error, approvalId: approval.id },
+							"Approved cleanup item safety preflight failed closed",
+						);
+						sharedPlexBlock =
+							"Skipped for safety: arr-dashboard could not complete the live ARR and media-server preflight.";
+					}
+					if (!sharedPlexBlock && !safetyPlan) {
+						sharedPlexBlock =
+							"Skipped for safety: arr-dashboard did not produce an explicit ARR mutation safety plan.";
+					}
+					if (!sharedPlexBlock) {
+						const livePlan = asExecutableSafetyPlan(safetyPlan);
+						const exactPlanMatch =
+							approvedPlan && livePlan && executableSafetyPlansEqual(approvedPlan, livePlan);
+						const recordedRadarrFilelessRetry =
+							approvedPlan && livePlan
+								? isRecordedRadarrFilelessRetry(
+										action,
+										approvedPlan,
+										livePlan,
+										approval.lastExecutionError,
+									)
+								: false;
+						const recoverableFileRemainder =
+							(recoveringInterruptedMutation || recordedRadarrFilelessRetry) &&
+							(action === "delete" || action === "delete_files") &&
+							approvedPlan &&
+							livePlan &&
+							isVerifiedFileRemainder(approvedPlan, livePlan);
+						if (!exactPlanMatch && !recoverableFileRemainder) {
+							approvalIdentityChanged = true;
 							sharedPlexBlock =
-								"Skipped for safety: arr-dashboard could not persist the verified crash-recovery state before continuing.";
+								"Skipped for safety: the ARR target or file identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
+						} else if (recoverableFileRemainder && !exactPlanMatch) {
+							if (
+								approvedPlan?.kind === "verified_radarr" &&
+								livePlan?.kind === "verified_radarr_empty"
+							) {
+								postFileOwnershipPlan = approvedPlan;
+							}
+							try {
+								await updateClaimedCleanupApproval(
+									prisma,
+									userId,
+									approval.id,
+									options.executeStatus,
+									claimedExecutionToken,
+									{
+										safetySnapshot: serializeExecutableSafetyPlan(
+											postFileOwnershipPlan ?? livePlan,
+										),
+										lastExecutionError:
+											"Recovered a persisted cleanup mutation after verifying the remaining ARR file set.",
+									},
+								);
+							} catch (error) {
+								log.error(
+									{ err: error, approvalId: approval.id },
+									"Cleanup could not persist its reconciled crash-recovery snapshot",
+								);
+								sharedPlexBlock =
+									"Skipped for safety: arr-dashboard could not persist the verified crash-recovery state before continuing.";
+							}
 						}
 					}
 				}
@@ -1879,7 +1998,22 @@ async function executeQueuedCleanupItems(
 								assertMutationAuthority,
 								postFileOwnershipPlan,
 							)
-						: assertMutationAuthority;
+						: mutationInstance.service === "SONARR" &&
+								safetyPlan?.kind === "verified_sonarr" &&
+								safetyPlan.peers.length > 0
+							? createSonarrDestructiveMutationAuthority(
+									deps,
+									userId,
+									{
+										instanceId: approval.instanceId,
+										arrItemId: approval.arrItemId,
+										itemType: approval.itemType,
+										action,
+									},
+									safetyPlan,
+									assertMutationAuthority,
+								)
+							: assertMutationAuthority;
 
 				if (retryTargetAlreadyAbsent) {
 					executionCompleted = true;
@@ -4186,7 +4320,22 @@ export async function executeDirectRemoval(
 							safetyPlan!,
 							assertRunLease,
 						)
-					: assertRunLease;
+					: mutationInstance.service === "SONARR" &&
+							safetyPlan?.kind === "verified_sonarr" &&
+							safetyPlan.peers.length > 0
+						? createSonarrDestructiveMutationAuthority(
+								deps,
+								userId,
+								{
+									instanceId: item.cacheItem.instanceId,
+									arrItemId: item.cacheItem.arrItemId,
+									itemType: item.cacheItem.itemType,
+									action: ruleAction,
+								},
+								safetyPlan,
+								assertRunLease,
+							)
+						: assertRunLease;
 
 			if (ruleAction === "unmonitor") {
 				await unmonitorInArr(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -45,6 +45,7 @@ import {
 	assertVerifiedArrTargetUnchanged,
 	assertVerifiedRadarrEmptyUnchanged,
 	assertVerifiedRadarrFileUnchanged,
+	assertVerifiedRadarrPeerOwnershipRetained,
 	assertVerifiedSonarrFilesUnchanged,
 	ArrTargetChangedDuringSafetyCheckError,
 	buildCacheTargetSafetyPlan,
@@ -392,10 +393,7 @@ function buildPostPartialRetrySnapshot(
 		) {
 			return undefined;
 		}
-		return serializeExecutableSafetyPlan({
-			kind: "verified_radarr_empty",
-			target: safetyPlan.target,
-		});
+		return serializeExecutableSafetyPlan(safetyPlan);
 	}
 
 	if (safetyPlan?.kind !== "verified_sonarr") return undefined;
@@ -457,6 +455,20 @@ function isVerifiedFileRemainder(
 	);
 	return livePlan.files.episodeFiles.every(
 		(file) => approvedFiles.get(file.episodeFileId) === JSON.stringify(file),
+	);
+}
+
+function isRecordedRadarrFilelessRetry(
+	action: RuleAction,
+	approvedPlan: ExecutableSharedMediaSafetyPlan,
+	livePlan: ExecutableSharedMediaSafetyPlan,
+	lastExecutionError: string | null,
+): boolean {
+	return (
+		action === "delete" &&
+		approvedPlan.kind === "verified_radarr" &&
+		livePlan.kind === "verified_radarr_empty" &&
+		lastExecutionError?.startsWith("Partial cleanup: the verified Radarr movie file") === true
 	);
 }
 
@@ -632,6 +644,7 @@ async function loadCurrentMutationInstance(
 				: 0;
 	if (
 		verifiedFileCount > 0 &&
+		executablePlan.kind !== "verified_radarr" &&
 		instances.some(
 			(candidate) => candidate.id !== instance.id && candidate.service === instance.service,
 		)
@@ -780,6 +793,7 @@ async function blockPlansThatDifferFromEvaluatedCache(
 		const livePlan = asExecutableSafetyPlan(context.plans.get(targetKey));
 		if (!livePlan) continue;
 		let cachePlan: ExecutableSharedMediaSafetyPlan | null = null;
+		let cacheEvaluationLoaded = false;
 		try {
 			const serviceUpdatedAt = instanceUpdatedAt.get(item.cacheItem.instanceId);
 			if (
@@ -790,6 +804,7 @@ async function blockPlansThatDifferFromEvaluatedCache(
 				throw new Error("Cached ARR item predates the current service configuration");
 			}
 			cachePlan = await buildEvaluatedCacheSafetyPlan(deps.prisma, item.cacheItem, livePlan);
+			cacheEvaluationLoaded = true;
 		} catch (error) {
 			deps.log.warn(
 				{
@@ -800,6 +815,21 @@ async function blockPlansThatDifferFromEvaluatedCache(
 				"Cleanup could not load the cached file identity used for rule evaluation",
 			);
 		}
+		const cacheData = safeJsonParse(item.cacheItem.data);
+		if (
+			livePlan.kind === "verified_radarr" &&
+			cacheEvaluationLoaded &&
+			cachePlan === null &&
+			cacheData !== null &&
+			typeof cacheData === "object" &&
+			cacheRadarrEvaluationMatchesLiveProof(
+				cacheData as Record<string, unknown>,
+				item.cacheItem.hasFile,
+				livePlan,
+			)
+		) {
+			continue;
+		}
 		if (cachePlan && executableSafetyPlansEqual(cachePlan, livePlan)) continue;
 
 		const reason =
@@ -807,6 +837,70 @@ async function blockPlansThatDifferFromEvaluatedCache(
 		blocks.set(targetKey, reason);
 		context.plans.set(targetKey, { kind: "blocked", reason });
 	}
+}
+
+function cacheRadarrEvaluationMatchesLiveProof(
+	data: Record<string, unknown>,
+	hasFile: boolean,
+	livePlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
+): boolean {
+	if (!hasFile) return false;
+	const remoteIds =
+		data.remoteIds && typeof data.remoteIds === "object"
+			? (data.remoteIds as Record<string, unknown>)
+			: undefined;
+	const source =
+		"_arrDashboardSource" in data &&
+		data._arrDashboardSource &&
+		typeof data._arrDashboardSource === "object"
+			? (data._arrDashboardSource as Record<string, unknown>)
+			: undefined;
+	const movieFile =
+		data.movieFile && typeof data.movieFile === "object"
+			? (data.movieFile as Record<string, unknown>)
+			: undefined;
+	return (
+		source?.serviceFingerprint === livePlan.target.serviceFingerprint &&
+		remoteIds?.tmdbId === livePlan.target.externalId &&
+		data.path === livePlan.target.mediaPath.value &&
+		movieFile?.id === livePlan.file.movieFileId &&
+		movieFile.path === livePlan.file.fullPath.value &&
+		movieFile.size === livePlan.file.size
+	);
+}
+
+function createRadarrDestructiveMutationAuthority(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	target: CleanupDeleteTarget,
+	safetyPlan: SharedMediaSafetyPlan,
+	assertExecutionAllowed?: () => Promise<void>,
+	postFileOwnershipPlan?: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
+): () => Promise<void> {
+	let fileDeleteAuthorityConsumed = false;
+	const ownershipPlan = safetyPlan.kind === "verified_radarr" ? safetyPlan : postFileOwnershipPlan;
+
+	return async () => {
+		await assertExecutionAllowed?.();
+		if (!ownershipPlan) return;
+		if (!fileDeleteAuthorityConsumed && safetyPlan.kind === "verified_radarr") {
+			const context = createSharedPlexSafetyContext();
+			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
+			const livePlan = asExecutableSafetyPlan(context.plans.get(cleanupDeleteTargetKey(target)));
+			if (
+				blocks.has(cleanupDeleteTargetKey(target)) ||
+				!livePlan ||
+				!executableSafetyPlansEqual(ownershipPlan, livePlan)
+			) {
+				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+					"Skipped for safety: verified Radarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+				);
+			}
+			fileDeleteAuthorityConsumed = true;
+			return;
+		}
+		await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, ownershipPlan);
+	};
 }
 
 function withSharedPlexWarning(warnings: string[], blockCount: number): string[] {
@@ -1584,6 +1678,9 @@ async function executeQueuedCleanupItems(
 			let approvalIdentityChanged = false;
 			const approvedPlan = parseExecutableSafetyPlan(approval.safetySnapshot);
 			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
+			let postFileOwnershipPlan:
+				| Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>
+				| undefined;
 			const recoveringInterruptedMutation =
 				options.claimStatus === "retry_pending" ||
 				approval.lastExecutionError === INTERRUPTED_CLEANUP_RECOVERY_MESSAGE;
@@ -1645,8 +1742,17 @@ async function executeQueuedCleanupItems(
 					const livePlan = asExecutableSafetyPlan(safetyPlan);
 					const exactPlanMatch =
 						approvedPlan && livePlan && executableSafetyPlansEqual(approvedPlan, livePlan);
+					const recordedRadarrFilelessRetry =
+						approvedPlan && livePlan
+							? isRecordedRadarrFilelessRetry(
+									action,
+									approvedPlan,
+									livePlan,
+									approval.lastExecutionError,
+								)
+							: false;
 					const recoverableFileRemainder =
-						recoveringInterruptedMutation &&
+						(recoveringInterruptedMutation || recordedRadarrFilelessRetry) &&
 						(action === "delete" || action === "delete_files") &&
 						approvedPlan &&
 						livePlan &&
@@ -1656,6 +1762,12 @@ async function executeQueuedCleanupItems(
 						sharedPlexBlock =
 							"Skipped for safety: the ARR target or file identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
 					} else if (recoverableFileRemainder && !exactPlanMatch) {
+						if (
+							approvedPlan?.kind === "verified_radarr" &&
+							livePlan?.kind === "verified_radarr_empty"
+						) {
+							postFileOwnershipPlan = approvedPlan;
+						}
 						try {
 							await updateClaimedCleanupApproval(
 								prisma,
@@ -1664,7 +1776,7 @@ async function executeQueuedCleanupItems(
 								options.executeStatus,
 								claimedExecutionToken,
 								{
-									safetySnapshot: serializeExecutableSafetyPlan(livePlan),
+									safetySnapshot: serializeExecutableSafetyPlan(postFileOwnershipPlan ?? livePlan),
 									lastExecutionError:
 										"Recovered a persisted cleanup mutation after verifying the remaining ARR file set.",
 								},
@@ -1752,6 +1864,22 @@ async function executeQueuedCleanupItems(
 					await options.assertExecutionAllowed?.();
 					mutationBudgetConsumedIds.add(approval.id);
 				};
+				const assertDestructiveMutationAuthority =
+					mutationInstance.service === "RADARR"
+						? createRadarrDestructiveMutationAuthority(
+								deps,
+								userId,
+								{
+									instanceId: approval.instanceId,
+									arrItemId: approval.arrItemId,
+									itemType: approval.itemType,
+									action,
+								},
+								safetyPlan!,
+								assertMutationAuthority,
+								postFileOwnershipPlan,
+							)
+						: assertMutationAuthority;
 
 				if (retryTargetAlreadyAbsent) {
 					executionCompleted = true;
@@ -1801,7 +1929,7 @@ async function executeQueuedCleanupItems(
 						mutationInstance,
 						approval.arrItemId,
 						safetyPlan!,
-						assertMutationAuthority,
+						assertDestructiveMutationAuthority,
 					);
 					executionCompleted = true;
 					reconciledWithoutMutation = !deletedFiles;
@@ -1827,7 +1955,7 @@ async function executeQueuedCleanupItems(
 						mutationInstance,
 						approval.arrItemId,
 						safetyPlan!,
-						assertMutationAuthority,
+						assertDestructiveMutationAuthority,
 					);
 					executionCompleted = true;
 					await reconcileSonarrEpisodeFileCache(prisma, mutationInstance, approval.arrItemId, log);
@@ -4044,6 +4172,21 @@ export async function executeDirectRemoval(
 				item.cacheItem.arrItemId,
 				item.cacheItem.itemType,
 			);
+			const assertDestructiveMutationAuthority =
+				mutationInstance.service === "RADARR"
+					? createRadarrDestructiveMutationAuthority(
+							deps,
+							userId,
+							{
+								instanceId: item.cacheItem.instanceId,
+								arrItemId: item.cacheItem.arrItemId,
+								itemType: item.cacheItem.itemType,
+								action: ruleAction,
+							},
+							safetyPlan!,
+							assertRunLease,
+						)
+					: assertRunLease;
 
 			if (ruleAction === "unmonitor") {
 				await unmonitorInArr(
@@ -4081,7 +4224,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
-					assertRunLease,
+					assertDestructiveMutationAuthority,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,
@@ -4128,7 +4271,7 @@ export async function executeDirectRemoval(
 					mutationInstance,
 					item.cacheItem.arrItemId,
 					safetyPlan!,
-					assertRunLease,
+					assertDestructiveMutationAuthority,
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -61,6 +61,7 @@ import {
 	executableSafetyPlansEqual,
 	findSharedPlexDeleteBlocks,
 	parseExecutableSafetyPlan,
+	radarrCachedFileIdentityMatches,
 	RadarrFileChangedDuringSafetyCheckError,
 	type SharedMediaSafetyPlan,
 	SonarrFilesChangedDuringSafetyCheckError,
@@ -654,6 +655,21 @@ async function loadCurrentMutationInstance(
 			: executablePlan.kind === "verified_sonarr"
 				? executablePlan.files.episodeFiles.length
 				: 0;
+	if (executablePlan.kind === "verified_radarr") {
+		const currentPeers = instances.filter(
+			(candidate) => candidate.id !== instance.id && candidate.service === "RADARR",
+		);
+		const verifiedPeers = new Map(
+			executablePlan.peers.map((peer) => [peer.instanceId, peer.serviceFingerprint]),
+		);
+		if (
+			executablePlan.peerInventoryComplete !== true ||
+			currentPeers.length !== verifiedPeers.size ||
+			currentPeers.some((peer) => verifiedPeers.get(peer.id) !== createArrServiceFingerprint(peer))
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+	}
 	if (
 		verifiedFileCount > 0 &&
 		executablePlan.kind !== "verified_radarr" &&
@@ -885,9 +901,7 @@ function cacheRadarrEvaluationMatchesLiveProof(
 		source?.serviceFingerprint === livePlan.target.serviceFingerprint &&
 		remoteIds?.tmdbId === livePlan.target.externalId &&
 		data.path === livePlan.target.mediaPath.value &&
-		movieFile?.id === livePlan.file.movieFileId &&
-		movieFile.path === livePlan.file.fullPath.value &&
-		movieFile.size === livePlan.file.size
+		radarrCachedFileIdentityMatches(data.path, movieFile, livePlan.file)
 	);
 }
 

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -688,6 +688,25 @@ export function buildRadarrCacheSafetyPlan(
 	return null;
 }
 
+export function radarrCachedFileIdentityMatches(
+	moviePath: unknown,
+	movieFile: Record<string, unknown> | undefined,
+	expected: VerifiedRadarrFileIdentity,
+): boolean {
+	if (!movieFile || movieFile.id !== expected.movieFileId || movieFile.size !== expected.size) {
+		return false;
+	}
+	try {
+		const fullPath =
+			typeof movieFile.path === "string" && movieFile.path.trim() !== ""
+				? movieFile.path
+				: joinMediaPath(moviePath, movieFile.relativePath, "RADARR");
+		return pathsEqual(normalizeMediaPath(fullPath), expected.fullPath);
+	} catch {
+		return false;
+	}
+}
+
 export function buildSonarrCacheSafetyPlan(
 	seriesPath: unknown,
 	externalId: unknown,
@@ -1866,6 +1885,20 @@ function radarrPeerFileCatalogWitness(
 	);
 }
 
+function radarrPeerInventoriesEqual(
+	left: StableRadarrPeerInventory,
+	right: StableRadarrPeerInventory,
+): boolean {
+	return (
+		radarrPeerMovieCatalogWitness(left.movieCatalog) ===
+			radarrPeerMovieCatalogWitness(right.movieCatalog) &&
+		radarrPeerNotificationCatalogWitness(left.notifications) ===
+			radarrPeerNotificationCatalogWitness(right.notifications) &&
+		radarrPeerFileCatalogWitness(left.filesByMovie) ===
+			radarrPeerFileCatalogWitness(right.filesByMovie)
+	);
+}
+
 function radarrPeerMovieFileId(movie: Movie): number | null {
 	const movieFileId = movie.movieFileId;
 	if (movie.hasFile === false && typeof movieFileId === "number" && movieFileId > 0) {
@@ -2494,6 +2527,22 @@ export async function findSharedPlexDeleteBlocks(
 		ownership: VerifiedSonarrPlexOwnership[];
 		targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
 	}> = [];
+	const pendingRadarrPlans: Array<{
+		target: CleanupDeleteTarget;
+		targetKey: string;
+		client: InstanceType<typeof RadarrClient>;
+		targetIdentity: VerifiedArrTargetIdentity;
+		targetFile: VerifiedRadarrFileIdentity;
+		peers: NonNullable<PlexVerificationInput["radarrPeers"]>;
+		peerCatalogs: Array<{
+			instanceId: string;
+			serviceFingerprint: string;
+			client: InstanceType<typeof RadarrClient>;
+			inventory: StableRadarrPeerInventory;
+		}>;
+		ownership: VerifiedRadarrPlexOwnership[];
+		targetDeleteNotifications: VerifiedRadarrTargetDeleteNotification[];
+	}> = [];
 
 	const getRadarrClient = (instance: ServiceInstance): InstanceType<typeof RadarrClient> => {
 		let client = radarrClients.get(instance.id);
@@ -2661,6 +2710,7 @@ export async function findSharedPlexDeleteBlocks(
 						continue;
 					}
 					if (verifiedPlan.kind === "verified_radarr") {
+						verifiedPlan.peerInventoryComplete = true;
 						context.verifiedRadarrFiles.set(targetKey, verifiedPlan.file);
 					}
 					context.plans.set(targetKey, verifiedPlan);
@@ -2711,9 +2761,21 @@ export async function findSharedPlexDeleteBlocks(
 				const radarrUntrackedPeerFiles: NonNullable<
 					PlexVerificationInput["radarrUntrackedPeerFiles"]
 				> = [];
+				const radarrPeerCatalogs: Array<{
+					instanceId: string;
+					serviceFingerprint: string;
+					client: InstanceType<typeof RadarrClient>;
+					inventory: StableRadarrPeerInventory;
+				}> = [];
 				for (const peerInstance of peerInstances) {
 					const peerClient = getRadarrClient(peerInstance);
 					const inventory = await getRadarrPeerInventory(peerInstance, peerClient);
+					radarrPeerCatalogs.push({
+						instanceId: peerInstance.id,
+						serviceFingerprint: createArrServiceFingerprint(peerInstance),
+						client: peerClient,
+						inventory,
+					});
 					const peerMovies = inventory.movieCatalog.filter(
 						(candidate) => candidate.tmdbId === tmdbId,
 					);
@@ -2789,18 +2851,20 @@ export async function findSharedPlexDeleteBlocks(
 					blocks.set(targetKey, verification.block);
 					context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 				} else {
-					context.verifiedRadarrFiles.set(targetKey, targetFile);
-					context.plans.set(targetKey, {
-						kind: "verified_radarr",
-						target: targetIdentity,
-						file: targetFile,
-						peers: radarrPeers.map((peer) => peer.identity),
-						peerInventoryComplete: true,
+					const targetDeleteNotifications = radarrTargetDeleteNotificationWitnesses(
+						plexNotifications,
+						movie,
+					);
+					pendingRadarrPlans.push({
+						target,
+						targetKey,
+						client: radarr,
+						targetIdentity,
+						targetFile,
+						peers: radarrPeers,
+						peerCatalogs: radarrPeerCatalogs,
 						ownership: verification.ownership,
-						targetDeleteNotifications: radarrTargetDeleteNotificationWitnesses(
-							plexNotifications,
-							movie,
-						),
+						targetDeleteNotifications,
 					});
 				}
 				continue;
@@ -2988,7 +3052,7 @@ export async function findSharedPlexDeleteBlocks(
 			}
 		} catch (error) {
 			const reason =
-				error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError
+				error instanceof ArrFileChangedDuringSafetyCheckError
 					? error.message
 					: error instanceof FileMatchVerificationError
 						? fileMatchFailedReason(service)
@@ -3001,6 +3065,79 @@ export async function findSharedPlexDeleteBlocks(
 					instanceId: target.instanceId,
 					arrItemId: target.arrItemId,
 					service,
+				},
+				"Cleanup shared-Plex safety check failed closed",
+			);
+		}
+	}
+
+	const terminalRadarrPeerInventories = new Map<string, Promise<StableRadarrPeerInventory>>();
+	const terminalRadarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
+	for (const pending of pendingRadarrPlans) {
+		try {
+			for (const peerCatalog of pending.peerCatalogs) {
+				const inventoryKey = `${peerCatalog.instanceId}:${peerCatalog.serviceFingerprint}`;
+				let inventoryPromise = terminalRadarrPeerInventories.get(inventoryKey);
+				if (!inventoryPromise) {
+					inventoryPromise = readStableRadarrPeerInventory(peerCatalog.client);
+					terminalRadarrPeerInventories.set(inventoryKey, inventoryPromise);
+				}
+				const freshInventory = await inventoryPromise;
+				if (!radarrPeerInventoriesEqual(peerCatalog.inventory, freshInventory)) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+			}
+			let notificationsPromise = terminalRadarrNotifications.get(
+				pending.targetIdentity.serviceFingerprint,
+			);
+			if (!notificationsPromise) {
+				notificationsPromise = pending.client.notification.getAll();
+				terminalRadarrNotifications.set(
+					pending.targetIdentity.serviceFingerprint,
+					notificationsPromise,
+				);
+			}
+			const freshTargetDeleteNotifications = radarrTargetDeleteNotificationWitnesses(
+				await notificationsPromise,
+				await pending.client.movie.getById(pending.target.arrItemId),
+			);
+			if (
+				JSON.stringify(freshTargetDeleteNotifications) !==
+				JSON.stringify(pending.targetDeleteNotifications)
+			) {
+				throw new ArrTargetChangedDuringSafetyCheckError();
+			}
+			await assertVerifiedRadarrFileUnchanged(
+				pending.client,
+				pending.target.arrItemId,
+				pending.targetIdentity,
+				pending.targetFile,
+			);
+			context.verifiedRadarrFiles.set(pending.targetKey, pending.targetFile);
+			context.plans.set(pending.targetKey, {
+				kind: "verified_radarr",
+				target: pending.targetIdentity,
+				file: pending.targetFile,
+				peers: pending.peers.map((peer) => peer.identity),
+				peerInventoryComplete: true,
+				ownership: pending.ownership,
+				targetDeleteNotifications: pending.targetDeleteNotifications,
+			});
+		} catch (error) {
+			const reason =
+				error instanceof ArrFileChangedDuringSafetyCheckError
+					? error.message
+					: error instanceof FileMatchVerificationError
+						? fileMatchFailedReason("RADARR")
+						: verificationFailedReason("RADARR");
+			blocks.set(pending.targetKey, reason);
+			context.plans.set(pending.targetKey, { kind: "blocked", reason });
+			deps.log.warn(
+				{
+					err: getErrorMessage(error),
+					instanceId: pending.target.instanceId,
+					arrItemId: pending.target.arrItemId,
+					service: "RADARR",
 				},
 				"Cleanup shared-Plex safety check failed closed",
 			);
@@ -3139,6 +3276,10 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 
 	const livePeers = new Map<string, NonNullable<PlexVerificationInput["radarrPeers"]>[number]>();
 	const untrackedPeerFiles: NonNullable<PlexVerificationInput["radarrUntrackedPeerFiles"]> = [];
+	const peerInventories: Array<{
+		client: InstanceType<typeof RadarrClient>;
+		inventory: StableRadarrPeerInventory;
+	}> = [];
 	for (const peer of plan.peers) {
 		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
 		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
@@ -3146,6 +3287,7 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 		}
 		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof RadarrClient>;
 		const inventory = await readStableRadarrPeerInventory(client);
+		peerInventories.push({ client, inventory });
 		const movie = assertVerifiedRadarrPeerIdentityFromInventory(peer, inventory);
 		const trackedMovieId = peer.arrItemId;
 		for (const catalogMovie of inventory.movieCatalog) {
@@ -3249,6 +3391,22 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 				}
 			}
 		}
+	}
+	for (const peerInventory of peerInventories) {
+		const freshInventory = await readStableRadarrPeerInventory(peerInventory.client);
+		if (!radarrPeerInventoriesEqual(peerInventory.inventory, freshInventory)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+	}
+	const finalTargetDeleteNotifications = radarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		await targetClient.movie.getById(targetArrItemId),
+	);
+	if (
+		JSON.stringify(finalTargetDeleteNotifications) !==
+		JSON.stringify(plan.targetDeleteNotifications)
+	) {
+		throw new ArrTargetChangedDuringSafetyCheckError();
 	}
 	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
 }

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -1971,3 +1971,151 @@ export async function findSharedPlexDeleteBlocks(
 
 	return blocks;
 }
+
+/**
+ * Revalidate the retained side of a verified multi-Radarr ownership proof after
+ * the selected target file is gone. This deliberately does not require the
+ * deleted target Plex part to remain visible, so it can guard the subsequent
+ * fileless Radarr record deletion and its notification.
+ */
+export async function assertVerifiedRadarrPeerOwnershipRetained(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	targetArrItemId: number,
+	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
+): Promise<void> {
+	const [arrInstances, plexInstances] = await Promise.all([
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["RADARR", "SONARR"] } },
+		}),
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX" },
+		}),
+	]);
+	const peerInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "RADARR" &&
+			createArrServiceFingerprint(instance) !== plan.target.serviceFingerprint,
+	);
+	const targetInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "RADARR" &&
+			createArrServiceFingerprint(instance) === plan.target.serviceFingerprint,
+	);
+	const peerIds = new Set(plan.peers.map((peer) => peer.instanceId));
+	if (
+		targetInstances.length !== 1 ||
+		peerInstances.length !== peerIds.size ||
+		peerInstances.some((instance) => !peerIds.has(instance.id))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+
+	const targetClient = deps.arrClientFactory.create(targetInstances[0]!) as InstanceType<
+		typeof RadarrClient
+	>;
+	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
+	const currentTargetMovie = await targetClient.movie.getById(targetArrItemId);
+	const currentTargetDeleteNotifications = radarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		currentTargetMovie,
+	);
+	if (
+		JSON.stringify(currentTargetDeleteNotifications) !==
+		JSON.stringify(plan.targetDeleteNotifications)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+
+	const livePeers = new Map<string, NonNullable<PlexVerificationInput["radarrPeers"]>[number]>();
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof RadarrClient>;
+		const movies = (await client.movie.getAll({ tmdbId: peer.externalId })).filter(
+			(movie) => movie.tmdbId === peer.externalId,
+		);
+		if (peer.arrItemId === null) {
+			if (movies.length !== 0) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			continue;
+		}
+		const movie = movies[0];
+		if (movies.length !== 1 || !movie || movie.id !== peer.arrItemId || peer.mediaPath === null) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		const peerTarget: VerifiedArrTargetIdentity = {
+			serviceFingerprint: peer.serviceFingerprint,
+			externalId: peer.externalId,
+			mediaPath: peer.mediaPath,
+		};
+		if (peer.file) {
+			await assertVerifiedRadarrFileUnchanged(client, peer.arrItemId, peerTarget, peer.file);
+		} else {
+			await assertVerifiedRadarrEmptyUnchanged(client, peer.arrItemId, peerTarget);
+		}
+		livePeers.set(peer.instanceId, {
+			identity: peer,
+			movieTags: movie.tags ?? [],
+			notifications: await client.notification.getAll(),
+		});
+	}
+
+	const context = createSharedPlexSafetyContext();
+	const ownerChecks = new Map<string, Promise<void>>();
+	for (const ownership of plan.ownership) {
+		const matchingPlexInstances = plexInstances.filter(
+			(instance) => normalizedServerUrl(instance.baseUrl) === ownership.plexServerUrl,
+		);
+		if (matchingPlexInstances.length === 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		for (const plexInstance of matchingPlexInstances) {
+			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
+			const mediaItems = await plex.getMovieMediaPartsByTmdbId(plan.target.externalId);
+			const targetItems = mediaItems.filter(
+				(item) => item.ratingKey === ownership.target.ratingKey,
+			);
+			if (targetItems.length > 1) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			for (const expected of ownership.retained) {
+				const peer = livePeers.get(expected.instanceId);
+				if (!peer) throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				const match = matchingPeerPlexPart(peer, mediaItems, ownership.plexServerUrl);
+				if (
+					!match ||
+					match.item.ratingKey !== expected.ratingKey ||
+					match.part.size !== expected.size ||
+					!pathsEqual(normalizeMediaPath(match.part.file), expected.fullPath) ||
+					JSON.stringify(match.mapping) !== JSON.stringify(expected.mapping)
+				) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+			}
+			const currentTargetItem = targetItems[0];
+			if (currentTargetItem) {
+				const allowedTargetItemParts = new Set([
+					plexPartKey({
+						file: ownership.target.fullPath.value,
+						size: ownership.target.size,
+					}),
+					...ownership.retained
+						.filter((expected) => expected.ratingKey === ownership.target.ratingKey)
+						.map((expected) => plexPartKey({ file: expected.fullPath.value, size: expected.size })),
+				]);
+				const currentTargetItemPartKeys = currentTargetItem.parts.map(plexPartKey);
+				if (
+					new Set(currentTargetItemPartKeys).size !== currentTargetItemPartKeys.length ||
+					currentTargetItemPartKeys.some((partKey) => !allowedTargetItemParts.has(partKey))
+				) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
+			}
+		}
+	}
+	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
+}

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -450,34 +450,13 @@ export function buildRadarrCacheSafetyPlan(
 		externalId: requiredPositiveSafeInteger(remoteIds?.tmdbId, "Cached Radarr TMDb ID"),
 		mediaPath: normalizeMediaPath(item.path),
 	};
-	const movieFile = item.movieFile as Record<string, unknown> | null | undefined;
-	const movieFileId = movieFile?.id;
+	const movieFileId = (item.movieFile as Record<string, unknown> | null | undefined)?.id;
 	if (!hasFile) {
 		return typeof movieFileId !== "number" || movieFileId <= 0
 			? { kind: "verified_radarr_empty", target }
 			: null;
 	}
-	if (!movieFile) return null;
-	try {
-		const pathValue =
-			typeof movieFile.path === "string" && movieFile.path.trim()
-				? movieFile.path
-				: joinMediaPath(item.path, movieFile.relativePath, "RADARR");
-		return canonicalExecutableSafetyPlan({
-			kind: "verified_radarr",
-			target,
-			file: {
-				movieFileId,
-				fullPath: { value: pathValue },
-				size: movieFile.size,
-			},
-			peers: [],
-			ownership: [],
-			targetDeleteNotifications: [],
-		});
-	} catch {
-		return null;
-	}
+	return null;
 }
 
 export function buildSonarrCacheSafetyPlan(

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -88,6 +88,37 @@ export interface VerifiedArrTargetIdentity {
 	mediaPath: NormalizedMediaPath;
 }
 
+export interface VerifiedRadarrPeerIdentity {
+	instanceId: string;
+	serviceFingerprint: string;
+	externalId: number;
+	arrItemId: number | null;
+	mediaPath: NormalizedMediaPath | null;
+	file: VerifiedRadarrFileIdentity | null;
+}
+
+export interface VerifiedRadarrPlexOwnership {
+	plexServerUrl: string;
+	target: {
+		ratingKey: string;
+		fullPath: NormalizedMediaPath;
+		size: number;
+	};
+	retained: Array<{
+		instanceId: string;
+		ratingKey: string;
+		fullPath: NormalizedMediaPath;
+		size: number;
+		mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+	}>;
+}
+
+export interface VerifiedRadarrTargetDeleteNotification {
+	plexServerUrl: string;
+	onMovieFileDelete: boolean;
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}
+
 export type VerifiedCleanupFileIdentity =
 	| { service: "RADARR"; file: VerifiedRadarrFileIdentity }
 	| { service: "SONARR"; files: VerifiedSonarrFileIdentity };
@@ -101,6 +132,9 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_radarr";
 			target: VerifiedArrTargetIdentity;
 			file: VerifiedRadarrFileIdentity;
+			peers: VerifiedRadarrPeerIdentity[];
+			ownership: VerifiedRadarrPlexOwnership[];
+			targetDeleteNotifications: VerifiedRadarrTargetDeleteNotification[];
 	  }
 	| {
 			kind: "verified_sonarr";
@@ -148,6 +182,162 @@ function canonicalTargetIdentity(value: unknown): VerifiedArrTargetIdentity {
 	};
 }
 
+function canonicalRadarrFileIdentity(value: unknown): VerifiedRadarrFileIdentity {
+	if (!value || typeof value !== "object") {
+		throw new FileMatchVerificationError("Radarr file identity is invalid");
+	}
+	const file = value as Record<string, unknown>;
+	return {
+		movieFileId: requiredPositiveSafeInteger(file.movieFileId, "Radarr movie file ID"),
+		fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
+		size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
+	};
+}
+
+function canonicalRadarrPeers(value: unknown): VerifiedRadarrPeerIdentity[] {
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr peer safety snapshot is invalid");
+	}
+	const peers = value
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Radarr peer safety snapshot is invalid");
+			}
+			const peer = entry as Record<string, unknown>;
+			const serviceFingerprint = requiredNonEmptyString(
+				peer.serviceFingerprint,
+				"Radarr peer service fingerprint",
+			);
+			if (!/^[a-f0-9]{64}$/.test(serviceFingerprint)) {
+				throw new FileMatchVerificationError("Radarr peer service fingerprint is invalid");
+			}
+			const arrItemId =
+				peer.arrItemId === null
+					? null
+					: requiredPositiveSafeInteger(peer.arrItemId, "Radarr peer movie ID");
+			const mediaPath =
+				peer.mediaPath === null
+					? null
+					: normalizeMediaPath((peer.mediaPath as Record<string, unknown> | undefined)?.value);
+			const file = peer.file === null ? null : canonicalRadarrFileIdentity(peer.file);
+			if (arrItemId === null ? mediaPath !== null || file !== null : mediaPath === null) {
+				throw new FileMatchVerificationError("Radarr peer movie snapshot is inconsistent");
+			}
+			return {
+				instanceId: requiredNonEmptyString(peer.instanceId, "Radarr peer instance ID"),
+				serviceFingerprint,
+				externalId: requiredPositiveSafeInteger(peer.externalId, "Radarr peer external media ID"),
+				arrItemId,
+				mediaPath,
+				file,
+			};
+		})
+		.sort((left, right) => left.instanceId.localeCompare(right.instanceId));
+	if (new Set(peers.map((peer) => peer.instanceId)).size !== peers.length) {
+		throw new FileMatchVerificationError(
+			"Radarr peer safety snapshot contains duplicate instances",
+		);
+	}
+	return peers;
+}
+
+function canonicalRadarrOwnership(value: unknown): VerifiedRadarrPlexOwnership[] {
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+	}
+	const ownership = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+		}
+		const witness = entry as Record<string, unknown>;
+		const target = witness.target as Record<string, unknown> | undefined;
+		if (!target || !Array.isArray(witness.retained)) {
+			throw new FileMatchVerificationError("Radarr Plex ownership snapshot is invalid");
+		}
+		const retained = witness.retained
+			.map((retainedEntry) => {
+				if (!retainedEntry || typeof retainedEntry !== "object") {
+					throw new FileMatchVerificationError("Radarr retained-part snapshot is invalid");
+				}
+				const part = retainedEntry as Record<string, unknown>;
+				const mapping = part.mapping as Record<string, unknown> | null | undefined;
+				return {
+					instanceId: requiredNonEmptyString(part.instanceId, "Radarr retained-part instance ID"),
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Radarr retained Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Radarr retained Plex part size"),
+					mapping:
+						mapping === null
+							? null
+							: {
+									from: normalizeMediaPath(
+										(mapping?.from as Record<string, unknown> | undefined)?.value,
+									),
+									to: normalizeMediaPath(
+										(mapping?.to as Record<string, unknown> | undefined)?.value,
+									),
+								},
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		return {
+			plexServerUrl: requiredNonEmptyString(witness.plexServerUrl, "Radarr ownership Plex URL"),
+			target: {
+				ratingKey: requiredNonEmptyString(target.ratingKey, "Radarr target Plex rating key"),
+				fullPath: normalizeMediaPath(
+					(target.fullPath as Record<string, unknown> | undefined)?.value,
+				),
+				size: requiredPositiveSafeInteger(target.size, "Radarr target Plex part size"),
+			},
+			retained,
+		};
+	});
+	const unique = new Map(ownership.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
+function canonicalRadarrTargetDeleteNotifications(
+	value: unknown,
+): VerifiedRadarrTargetDeleteNotification[] {
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Radarr target notification snapshot is invalid");
+	}
+	const notifications = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Radarr target notification snapshot is invalid");
+		}
+		const notification = entry as Record<string, unknown>;
+		const normalizedUrl = normalizedServerUrl(
+			requiredNonEmptyString(notification.plexServerUrl, "Radarr target notification Plex URL"),
+		);
+		if (!normalizedUrl) {
+			throw new FileMatchVerificationError("Radarr target notification Plex URL is invalid");
+		}
+		const mapping = notification.mapping as Record<string, unknown> | null | undefined;
+		return {
+			plexServerUrl: normalizedUrl,
+			onMovieFileDelete: notification.onMovieFileDelete === true,
+			mapping:
+				mapping === null
+					? null
+					: {
+							from: normalizeMediaPath(
+								(mapping?.from as Record<string, unknown> | undefined)?.value,
+							),
+							to: normalizeMediaPath((mapping?.to as Record<string, unknown> | undefined)?.value),
+						},
+		};
+	});
+	const unique = new Map(notifications.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
 function buildTargetIdentity(
 	instance: ServiceInstance,
 	externalId: unknown,
@@ -178,16 +368,15 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 		};
 	}
 	if (candidate.kind === "verified_radarr") {
-		const file = candidate.file as Record<string, unknown> | undefined;
-		if (!file) throw new FileMatchVerificationError("Radarr safety snapshot is invalid");
 		return {
 			kind: "verified_radarr",
 			target: canonicalTargetIdentity(candidate.target),
-			file: {
-				movieFileId: requiredPositiveSafeInteger(file.movieFileId, "Radarr movie file ID"),
-				fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
-				size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
-			},
+			file: canonicalRadarrFileIdentity(candidate.file),
+			peers: canonicalRadarrPeers(candidate.peers),
+			ownership: canonicalRadarrOwnership(candidate.ownership),
+			targetDeleteNotifications: canonicalRadarrTargetDeleteNotifications(
+				candidate.targetDeleteNotifications,
+			),
 		};
 	}
 	if (candidate.kind === "verified_sonarr") {
@@ -282,6 +471,9 @@ export function buildRadarrCacheSafetyPlan(
 				fullPath: { value: pathValue },
 				size: movieFile.size,
 			},
+			peers: [],
+			ownership: [],
+			targetDeleteNotifications: [],
 		});
 	} catch {
 		return null;
@@ -378,6 +570,7 @@ export class SonarrFilesChangedDuringSafetyCheckError extends ArrFileChangedDuri
 }
 
 interface NotificationLike {
+	enable?: boolean | null;
 	implementation?: string | null;
 	implementationName?: string | null;
 	configContract?: string | null;
@@ -712,7 +905,7 @@ function matchingPlexItems(
 	items: PlexMovieMediaItem[],
 	notification: NotificationLike,
 	service: "RADARR" | "SONARR",
-): PlexMovieMediaItem[] {
+): Array<{ item: PlexMovieMediaItem; part: { file: string; size: number } }> {
 	return targets.map((target) => {
 		const mappedTarget = {
 			...target,
@@ -730,7 +923,7 @@ function matchingPlexItems(
 					: `Multiple Plex media parts matched the ${serviceLabel(service)} file path and size`,
 			);
 		}
-		return matches[0]!.item;
+		return matches[0]!;
 	});
 }
 
@@ -869,6 +1062,7 @@ function radarrNotificationApplies(
 	action: string,
 ): boolean {
 	if (
+		(notification as NotificationLike).enable === false ||
 		mediaServerNotificationKind(notification) === null ||
 		!notificationMutatesLibrary(notification)
 	) {
@@ -956,6 +1150,54 @@ function normalizedServerUrl(value: string): string | null {
 	}
 }
 
+function notificationPathMapping(
+	notification: NotificationLike,
+	label: string,
+): { from: NormalizedMediaPath; to: NormalizedMediaPath } | null {
+	const rawMapFrom = fieldValue(notification, "mapFrom");
+	const rawMapTo = fieldValue(notification, "mapTo");
+	const hasMapFrom = typeof rawMapFrom === "string" && rawMapFrom.trim() !== "";
+	const hasMapTo = typeof rawMapTo === "string" && rawMapTo.trim() !== "";
+	if (hasMapFrom !== hasMapTo) {
+		throw new FileMatchVerificationError(`${label} Plex path mapping is incomplete`);
+	}
+	return hasMapFrom && hasMapTo
+		? {
+				from: normalizeMediaPath(rawMapFrom),
+				to: normalizeMediaPath(rawMapTo),
+			}
+		: null;
+}
+
+function radarrTargetDeleteNotificationWitnesses(
+	notifications: RadarrNotification[],
+	movie: Movie,
+): VerifiedRadarrTargetDeleteNotification[] {
+	const witnesses = notifications
+		.filter(
+			(notification) =>
+				radarrNotificationApplies(notification, movie, "delete") &&
+				notification.onMovieDelete === true,
+		)
+		.map((notification) => {
+			if (mediaServerNotificationKind(notification) !== "plex") {
+				throw new FileMatchVerificationError(
+					"Radarr target has an unsupported movie-delete notification",
+				);
+			}
+			const plexServerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+			if (!plexServerUrl) {
+				throw new FileMatchVerificationError("Radarr target movie-delete Plex URL is invalid");
+			}
+			return {
+				plexServerUrl,
+				onMovieFileDelete: notification.onMovieFileDelete === true,
+				mapping: notificationPathMapping(notification, "Radarr target"),
+			};
+		});
+	return canonicalRadarrTargetDeleteNotifications(witnesses);
+}
+
 function plexConnectionFingerprint(instance: ServiceInstance): string {
 	return JSON.stringify([
 		instance.id,
@@ -1013,6 +1255,111 @@ interface PlexVerificationInput {
 	notifications: PlexNotification[];
 	externalId: number;
 	files: MediaFileIdentity[];
+	radarrPeers?: Array<{
+		identity: VerifiedRadarrPeerIdentity;
+		movieTags: number[];
+		notifications: RadarrNotification[];
+	}>;
+}
+
+interface PlexVerificationResult {
+	block?: string;
+	ownership: VerifiedRadarrPlexOwnership[];
+}
+
+function matchingPeerPlexPart(
+	peer: NonNullable<PlexVerificationInput["radarrPeers"]>[number],
+	items: PlexMovieMediaItem[],
+	notificationUrl: string,
+): {
+	item: PlexMovieMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+} | null {
+	if (!peer.identity.file) return null;
+	const file = comparableFile(peer.identity.file);
+	const serverNotifications: RadarrNotification[] = [];
+	for (const notification of peer.notifications) {
+		if (mediaServerNotificationKind(notification) !== "plex") continue;
+		let peerUrl: string | null = null;
+		try {
+			peerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+		} catch {
+			continue;
+		}
+		if (peerUrl === notificationUrl) serverNotifications.push(notification);
+	}
+	const matchingNotifications = serverNotifications.filter(
+		(notification) =>
+			(notification as NotificationLike).enable !== false &&
+			notificationMutatesLibrary(notification) &&
+			notificationTagsApply(notification, peer.movieTags),
+	);
+	const unusableConfiguredMapping = serverNotifications.some((notification) => {
+		const rawMapFrom = fieldValue(notification, "mapFrom");
+		const rawMapTo = fieldValue(notification, "mapTo");
+		return (
+			!matchingNotifications.includes(notification) &&
+			((typeof rawMapFrom === "string" && rawMapFrom.trim() !== "") ||
+				(typeof rawMapTo === "string" && rawMapTo.trim() !== ""))
+		);
+	});
+	if (matchingNotifications.length === 0 && unusableConfiguredMapping) {
+		throw new FileMatchVerificationError("Radarr peer has only non-applicable Plex path mappings");
+	}
+
+	const pathCandidates = new Map<
+		string,
+		{
+			fullPath: NormalizedMediaPath;
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>();
+	if (matchingNotifications.length === 0) {
+		pathCandidates.set(JSON.stringify([file.fullPath, null]), {
+			fullPath: file.fullPath,
+			mapping: null,
+		});
+	}
+	for (const notification of matchingNotifications) {
+		const mapping = notificationPathMapping(notification, "Radarr peer");
+		const fullPath = mapping
+			? mappedArrPathForNotification(file, notification, "RADARR")
+			: file.fullPath;
+		pathCandidates.set(JSON.stringify([fullPath, mapping]), { fullPath, mapping });
+	}
+	if (pathCandidates.size !== 1) {
+		throw new FileMatchVerificationError("Radarr peer Plex path mappings conflict");
+	}
+	const pathCandidate = [...pathCandidates.values()][0]!;
+	const matches = new Map<
+		string,
+		{
+			item: PlexMovieMediaItem;
+			part: { file: string; size: number };
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>();
+	const mappedFile = { ...file, fullPath: pathCandidate.fullPath };
+	for (const item of items) {
+		for (const part of item.parts) {
+			if (mediaPartMatchesTarget(mappedFile, part)) {
+				matches.set(`${item.ratingKey}:${plexPartKey(part)}`, {
+					item,
+					part,
+					mapping: pathCandidate.mapping,
+				});
+			}
+		}
+	}
+	if (matches.size !== 1) {
+		throw new FileMatchVerificationError(
+			matches.size === 0
+				? "No Plex media part matched the retained Radarr peer file"
+				: "Multiple Plex media parts matched the retained Radarr peer file",
+		);
+	}
+	return [...matches.values()][0]!;
 }
 
 async function verifyPlexMediaState(
@@ -1023,8 +1370,9 @@ async function verifyPlexMediaState(
 	movieLookups: Map<SafetyPlexClient, Map<number, Promise<PlexMovieMediaItem[]>>>,
 	seriesLookups: Map<SafetyPlexClient, Map<number, Promise<PlexSeriesMediaItem[]>>>,
 	input: PlexVerificationInput,
-): Promise<string | undefined> {
-	if (input.files.length === 0) return undefined;
+): Promise<PlexVerificationResult> {
+	const ownership: VerifiedRadarrPlexOwnership[] = [];
+	if (input.files.length === 0) return { ownership };
 
 	for (const notification of input.notifications) {
 		const notificationUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
@@ -1062,14 +1410,65 @@ async function verifyPlexMediaState(
 						mediaPartsPromise = plex.getMovieMediaPartsByTmdbId(input.externalId);
 						clientLookups.set(input.externalId, mediaPartsPromise);
 					}
-					const matchedItems = matchingPlexItems(
+					const mediaItems = await mediaPartsPromise;
+					const targetMatches = matchingPlexItems(
 						input.files,
-						await mediaPartsPromise,
+						mediaItems,
 						notification,
 						input.service,
 					);
-					if (matchedItems.some((item) => item.parts.length > 1)) {
-						return mergedItemReason(input.service);
+					for (const targetMatch of targetMatches) {
+						const targetPartKey = plexPartKey(targetMatch.part);
+						const retainedPartKeys = new Set<string>();
+						const retained: VerifiedRadarrPlexOwnership["retained"] = [];
+						if (input.radarrPeers?.length && notificationUrl) {
+							for (const peer of input.radarrPeers) {
+								const peerMatch = matchingPeerPlexPart(peer, mediaItems, notificationUrl);
+								if (!peerMatch) continue;
+								const peerPartKey = plexPartKey(peerMatch.part);
+								if (peerPartKey === targetPartKey) {
+									return {
+										block: crossInstanceOwnershipReason("RADARR"),
+										ownership,
+									};
+								}
+								retained.push({
+									instanceId: peer.identity.instanceId,
+									ratingKey: peerMatch.item.ratingKey,
+									fullPath: normalizeMediaPath(peerMatch.part.file),
+									size: peerMatch.part.size,
+									mapping: peerMatch.mapping,
+								});
+								if (peerMatch.item.ratingKey === targetMatch.item.ratingKey) {
+									if (retainedPartKeys.has(peerPartKey)) {
+										return { block: mergedItemReason(input.service), ownership };
+									}
+									retainedPartKeys.add(peerPartKey);
+								}
+							}
+						}
+						if (input.radarrPeers?.length && notificationUrl) {
+							ownership.push({
+								plexServerUrl: notificationUrl,
+								target: {
+									ratingKey: targetMatch.item.ratingKey,
+									fullPath: normalizeMediaPath(targetMatch.part.file),
+									size: targetMatch.part.size,
+								},
+								retained,
+							});
+						}
+						if (targetMatch.item.parts.length <= 1) continue;
+						if (!input.radarrPeers?.length || !notificationUrl) {
+							return { block: mergedItemReason(input.service), ownership };
+						}
+						const unownedParts = targetMatch.item.parts.filter((part) => {
+							const partKey = plexPartKey(part);
+							return partKey !== targetPartKey && !retainedPartKeys.has(partKey);
+						});
+						if (retainedPartKeys.size === 0 || unownedParts.length > 0) {
+							return { block: mergedItemReason(input.service), ownership };
+						}
 					}
 				} else {
 					let clientLookups = seriesLookups.get(plex);
@@ -1086,7 +1485,7 @@ async function verifyPlexMediaState(
 						matchingPlexSeriesShows(input.files, await mediaPartsPromise, notification);
 					} catch (error) {
 						if (error instanceof SharedPlexItemError) {
-							return mergedItemReason(input.service);
+							return { block: mergedItemReason(input.service), ownership };
 						}
 						throw error;
 					}
@@ -1110,7 +1509,7 @@ async function verifyPlexMediaState(
 			throw new Error("No matching Plex credential could verify owner-visible media state");
 		}
 	}
-	return undefined;
+	return { ownership };
 }
 
 /**
@@ -1163,6 +1562,8 @@ export async function findSharedPlexDeleteBlocks(
 	const radarrClients = new Map<string, InstanceType<typeof RadarrClient>>();
 	const sonarrClients = new Map<string, InstanceType<typeof SonarrClient>>();
 	const radarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
+	const radarrMovies = new Map<string, Promise<Movie[]>>();
+	const radarrPeerFiles = new Map<string, Promise<VerifiedRadarrFileIdentity | null>>();
 	const sonarrNotifications = new Map<string, Promise<SonarrNotification[]>>();
 	const plexOwnerChecks = new Map<string, Promise<void>>();
 	const plexMovieLookups = new Map<SafetyPlexClient, Map<number, Promise<PlexMovieMediaItem[]>>>();
@@ -1199,6 +1600,20 @@ export async function findSharedPlexDeleteBlocks(
 			radarrNotifications.set(instance.id, notifications);
 		}
 		return notifications;
+	};
+
+	const getRadarrMovies = (
+		instance: ServiceInstance,
+		client: InstanceType<typeof RadarrClient>,
+		tmdbId: number,
+	): Promise<Movie[]> => {
+		const lookupKey = `${instance.id}:${tmdbId}`;
+		let movies = radarrMovies.get(lookupKey);
+		if (!movies) {
+			movies = client.movie.getAll({ tmdbId });
+			radarrMovies.set(lookupKey, movies);
+		}
+		return movies;
 	};
 
 	const getSonarrNotifications = (
@@ -1294,21 +1709,24 @@ export async function findSharedPlexDeleteBlocks(
 							await radarr.movieFile.getById(movieFileId),
 							movieFileId,
 						),
+						peers: [],
+						ownership: [],
+						targetDeleteNotifications: [],
 					};
-				}
-				if (
-					verifiedPlan.kind === "verified_radarr" &&
-					otherInstanceMayOwnFile(targetInstance, service, 1)
-				) {
-					const reason = crossInstanceOwnershipReason(service);
-					blocks.set(targetKey, reason);
-					context.plans.set(targetKey, { kind: "blocked", reason });
-					continue;
 				}
 				const notifications = (await getRadarrNotifications(targetInstance, radarr)).filter(
 					(notification) => radarrNotificationApplies(notification, movie, action),
 				);
 				if (notifications.length === 0) {
+					if (
+						verifiedPlan.kind === "verified_radarr" &&
+						otherInstanceMayOwnFile(targetInstance, service, 1)
+					) {
+						const reason = crossInstanceOwnershipReason(service);
+						blocks.set(targetKey, reason);
+						context.plans.set(targetKey, { kind: "blocked", reason });
+						continue;
+					}
 					if (verifiedPlan.kind === "verified_radarr") {
 						context.verifiedRadarrFiles.set(targetKey, verifiedPlan.file);
 					}
@@ -1353,8 +1771,70 @@ export async function findSharedPlexDeleteBlocks(
 					context.plans.set(targetKey, verifiedPlan);
 					continue;
 				}
+				const peerInstances = instances.filter(
+					(candidate) => candidate.id !== targetInstance.id && candidate.service === "RADARR",
+				);
+				const radarrPeers: NonNullable<PlexVerificationInput["radarrPeers"]> = [];
+				for (const peerInstance of peerInstances) {
+					const peerClient = getRadarrClient(peerInstance);
+					const peerMovies = (await getRadarrMovies(peerInstance, peerClient, tmdbId)).filter(
+						(candidate) => candidate.tmdbId === tmdbId,
+					);
+					if (peerMovies.length > 1) {
+						throw new FileMatchVerificationError("Radarr peer returned multiple matching movies");
+					}
+					if (peerMovies.length === 0) {
+						radarrPeers.push({
+							identity: {
+								instanceId: peerInstance.id,
+								serviceFingerprint: createArrServiceFingerprint(peerInstance),
+								externalId: tmdbId,
+								arrItemId: null,
+								mediaPath: null,
+								file: null,
+							},
+							movieTags: [],
+							notifications: [],
+						});
+						continue;
+					}
+					const peerMovie = peerMovies[0]!;
+					const peerMovieId = requiredPositiveSafeInteger(peerMovie.id, "Radarr peer movie ID");
+					const peerMovieFileId = peerMovie.movieFileId;
+					let peerFile: VerifiedRadarrFileIdentity | null = null;
+					if (
+						peerMovie.hasFile !== false ||
+						(typeof peerMovieFileId === "number" && peerMovieFileId > 0)
+					) {
+						const verifiedPeerFileId = requiredPositiveSafeInteger(
+							peerMovieFileId,
+							"Radarr peer movie file ID",
+						);
+						const peerFileKey = `${peerInstance.id}:${tmdbId}:${verifiedPeerFileId}`;
+						let peerFilePromise = radarrPeerFiles.get(peerFileKey);
+						if (!peerFilePromise) {
+							peerFilePromise = peerClient.movieFile
+								.getById(verifiedPeerFileId)
+								.then((file) => radarrFileIdentity(peerMovie, file, verifiedPeerFileId));
+							radarrPeerFiles.set(peerFileKey, peerFilePromise);
+						}
+						peerFile = await peerFilePromise;
+					}
+					radarrPeers.push({
+						identity: {
+							instanceId: peerInstance.id,
+							serviceFingerprint: createArrServiceFingerprint(peerInstance),
+							externalId: tmdbId,
+							arrItemId: peerMovieId,
+							mediaPath: normalizeMediaPath(peerMovie.path),
+							file: peerFile,
+						},
+						movieTags: peerMovie.tags ?? [],
+						notifications: await getRadarrNotifications(peerInstance, peerClient),
+					});
+				}
 				const targetFile = verifiedPlan.file;
-				const block = await verifyPlexMediaState(
+				const verification = await verifyPlexMediaState(
 					deps,
 					context,
 					plexOwnerChecks,
@@ -1367,17 +1847,24 @@ export async function findSharedPlexDeleteBlocks(
 						notifications: plexNotifications,
 						externalId: tmdbId,
 						files: [comparableFile(targetFile)],
+						radarrPeers,
 					},
 				);
-				if (block) {
-					blocks.set(targetKey, block);
-					context.plans.set(targetKey, { kind: "blocked", reason: block });
+				if (verification.block) {
+					blocks.set(targetKey, verification.block);
+					context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 				} else {
 					context.verifiedRadarrFiles.set(targetKey, targetFile);
 					context.plans.set(targetKey, {
 						kind: "verified_radarr",
 						target: targetIdentity,
 						file: targetFile,
+						peers: radarrPeers.map((peer) => peer.identity),
+						ownership: verification.ownership,
+						targetDeleteNotifications: radarrTargetDeleteNotificationWitnesses(
+							plexNotifications,
+							movie,
+						),
 					});
 				}
 				continue;
@@ -1458,7 +1945,7 @@ export async function findSharedPlexDeleteBlocks(
 				context.plans.set(targetKey, { kind: "blocked", reason });
 				continue;
 			}
-			const block = await verifyPlexMediaState(
+			const verification = await verifyPlexMediaState(
 				deps,
 				context,
 				plexOwnerChecks,
@@ -1473,9 +1960,9 @@ export async function findSharedPlexDeleteBlocks(
 					files: verifiedFiles.episodeFiles.map(comparableFile),
 				},
 			);
-			if (block) {
-				blocks.set(targetKey, block);
-				context.plans.set(targetKey, { kind: "blocked", reason: block });
+			if (verification.block) {
+				blocks.set(targetKey, verification.block);
+				context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 			} else {
 				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
 				context.plans.set(targetKey, {

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -15,6 +15,7 @@ import {
 	type PlexClient,
 	type PlexMovieMediaItem,
 	type PlexSeriesMediaItem,
+	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
 import type { ServiceInstance } from "../prisma.js";
 export { createArrServiceFingerprint } from "../arr/service-fingerprint.js";
@@ -82,6 +83,39 @@ export interface VerifiedSonarrFileIdentity {
 	episodeFiles: VerifiedSonarrEpisodeFileIdentity[];
 }
 
+export interface VerifiedSonarrPeerIdentity {
+	instanceId: string;
+	serviceFingerprint: string;
+	externalId: number;
+	arrItemId: number | null;
+	mediaPath: NormalizedMediaPath | null;
+	files: VerifiedSonarrFileIdentity | null;
+}
+
+interface VerifiedSonarrPlexPart {
+	ratingKey: string;
+	fullPath: NormalizedMediaPath;
+	size: number;
+}
+
+export interface VerifiedSonarrPlexOwnership {
+	plexServerUrl: string;
+	target: VerifiedSonarrPlexPart[];
+	retained: Array<
+		VerifiedSonarrPlexPart & {
+			instanceId: string;
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+		}
+	>;
+}
+
+export interface VerifiedSonarrTargetDeleteNotification {
+	plexServerUrl: string;
+	onSeriesDelete: boolean;
+	onEpisodeFileDelete: boolean;
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}
+
 export interface VerifiedArrTargetIdentity {
 	serviceFingerprint: string;
 	externalId: number;
@@ -140,6 +174,9 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_sonarr";
 			target: VerifiedArrTargetIdentity;
 			files: VerifiedSonarrFileIdentity;
+			peers: VerifiedSonarrPeerIdentity[];
+			ownership: VerifiedSonarrPlexOwnership[];
+			targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
 	  };
 
 export type ExecutableSharedMediaSafetyPlan = Extract<
@@ -192,6 +229,199 @@ function canonicalRadarrFileIdentity(value: unknown): VerifiedRadarrFileIdentity
 		fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
 		size: requiredPositiveSafeInteger(file.size, "Radarr movie file size"),
 	};
+}
+
+function canonicalSonarrFiles(value: unknown): VerifiedSonarrFileIdentity {
+	if (!value || typeof value !== "object") {
+		throw new FileMatchVerificationError("Sonarr file safety snapshot is invalid");
+	}
+	const files = value as Record<string, unknown>;
+	if (!Array.isArray(files.episodeFiles)) {
+		throw new FileMatchVerificationError("Sonarr file safety snapshot is invalid");
+	}
+	const episodeFiles = files.episodeFiles
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Sonarr episode-file snapshot is invalid");
+			}
+			const file = entry as Record<string, unknown>;
+			return {
+				episodeFileId: requiredPositiveSafeInteger(file.episodeFileId, "Sonarr episode file ID"),
+				fullPath: normalizeMediaPath((file.fullPath as Record<string, unknown> | undefined)?.value),
+				size: requiredPositiveSafeInteger(file.size, "Sonarr episode file size"),
+			};
+		})
+		.sort((left, right) => left.episodeFileId - right.episodeFileId);
+	if (new Set(episodeFiles.map((file) => file.episodeFileId)).size !== episodeFiles.length) {
+		throw new FileMatchVerificationError("Sonarr safety snapshot contains duplicate file IDs");
+	}
+	return {
+		seriesPath: normalizeMediaPath(
+			(files.seriesPath as Record<string, unknown> | undefined)?.value,
+		),
+		episodeFiles,
+	};
+}
+
+function canonicalSonarrPeers(value: unknown): VerifiedSonarrPeerIdentity[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr peer safety snapshot is invalid");
+	}
+	const peers = value
+		.map((entry) => {
+			if (!entry || typeof entry !== "object") {
+				throw new FileMatchVerificationError("Sonarr peer safety snapshot is invalid");
+			}
+			const peer = entry as Record<string, unknown>;
+			const serviceFingerprint = requiredNonEmptyString(
+				peer.serviceFingerprint,
+				"Sonarr peer service fingerprint",
+			);
+			if (!/^[a-f0-9]{64}$/.test(serviceFingerprint)) {
+				throw new FileMatchVerificationError("Sonarr peer service fingerprint is invalid");
+			}
+			const arrItemId =
+				peer.arrItemId === null
+					? null
+					: requiredPositiveSafeInteger(peer.arrItemId, "Sonarr peer series ID");
+			const mediaPath =
+				peer.mediaPath === null
+					? null
+					: normalizeMediaPath((peer.mediaPath as Record<string, unknown> | undefined)?.value);
+			const files = peer.files === null ? null : canonicalSonarrFiles(peer.files);
+			if (
+				arrItemId === null
+					? mediaPath !== null || files !== null
+					: mediaPath === null || files === null || !pathsEqual(files.seriesPath, mediaPath)
+			) {
+				throw new FileMatchVerificationError("Sonarr peer series snapshot is inconsistent");
+			}
+			return {
+				instanceId: requiredNonEmptyString(peer.instanceId, "Sonarr peer instance ID"),
+				serviceFingerprint,
+				externalId: requiredPositiveSafeInteger(peer.externalId, "Sonarr peer external media ID"),
+				arrItemId,
+				mediaPath,
+				files,
+			};
+		})
+		.sort((left, right) => left.instanceId.localeCompare(right.instanceId));
+	if (new Set(peers.map((peer) => peer.instanceId)).size !== peers.length) {
+		throw new FileMatchVerificationError(
+			"Sonarr peer safety snapshot contains duplicate instances",
+		);
+	}
+	return peers;
+}
+
+function canonicalSonarrOwnership(value: unknown): VerifiedSonarrPlexOwnership[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+	}
+	const ownership = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+		}
+		const witness = entry as Record<string, unknown>;
+		if (!Array.isArray(witness.target) || !Array.isArray(witness.retained)) {
+			throw new FileMatchVerificationError("Sonarr Plex ownership snapshot is invalid");
+		}
+		const target = witness.target
+			.map((targetEntry) => {
+				if (!targetEntry || typeof targetEntry !== "object") {
+					throw new FileMatchVerificationError("Sonarr target-part snapshot is invalid");
+				}
+				const part = targetEntry as Record<string, unknown>;
+				return {
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Sonarr target Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Sonarr target Plex part size"),
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		const retained = witness.retained
+			.map((retainedEntry) => {
+				if (!retainedEntry || typeof retainedEntry !== "object") {
+					throw new FileMatchVerificationError("Sonarr retained-part snapshot is invalid");
+				}
+				const part = retainedEntry as Record<string, unknown>;
+				const mapping = part.mapping as Record<string, unknown> | null | undefined;
+				return {
+					instanceId: requiredNonEmptyString(part.instanceId, "Sonarr retained-part instance ID"),
+					ratingKey: requiredNonEmptyString(part.ratingKey, "Sonarr retained Plex rating key"),
+					fullPath: normalizeMediaPath(
+						(part.fullPath as Record<string, unknown> | undefined)?.value,
+					),
+					size: requiredPositiveSafeInteger(part.size, "Sonarr retained Plex part size"),
+					mapping:
+						mapping === null
+							? null
+							: {
+									from: normalizeMediaPath(
+										(mapping?.from as Record<string, unknown> | undefined)?.value,
+									),
+									to: normalizeMediaPath(
+										(mapping?.to as Record<string, unknown> | undefined)?.value,
+									),
+								},
+				};
+			})
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		return {
+			plexServerUrl: requiredNonEmptyString(witness.plexServerUrl, "Sonarr ownership Plex URL"),
+			target,
+			retained,
+		};
+	});
+	const unique = new Map(ownership.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
+}
+
+function canonicalSonarrTargetDeleteNotifications(
+	value: unknown,
+): VerifiedSonarrTargetDeleteNotification[] {
+	if (value === undefined) return [];
+	if (!Array.isArray(value)) {
+		throw new FileMatchVerificationError("Sonarr target notification snapshot is invalid");
+	}
+	const notifications = value.map((entry) => {
+		if (!entry || typeof entry !== "object") {
+			throw new FileMatchVerificationError("Sonarr target notification snapshot is invalid");
+		}
+		const notification = entry as Record<string, unknown>;
+		const normalizedUrl = normalizedServerUrl(
+			requiredNonEmptyString(notification.plexServerUrl, "Sonarr target notification Plex URL"),
+		);
+		if (!normalizedUrl) {
+			throw new FileMatchVerificationError("Sonarr target notification Plex URL is invalid");
+		}
+		const mapping = notification.mapping as Record<string, unknown> | null | undefined;
+		return {
+			plexServerUrl: normalizedUrl,
+			onSeriesDelete:
+				notification.onSeriesDelete === undefined ? true : notification.onSeriesDelete === true,
+			onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
+			mapping:
+				mapping === null
+					? null
+					: {
+							from: normalizeMediaPath(
+								(mapping?.from as Record<string, unknown> | undefined)?.value,
+							),
+							to: normalizeMediaPath((mapping?.to as Record<string, unknown> | undefined)?.value),
+						},
+		};
+	});
+	const unique = new Map(notifications.map((entry) => [JSON.stringify(entry), entry]));
+	return [...unique.values()].sort((left, right) =>
+		JSON.stringify(left).localeCompare(JSON.stringify(right)),
+	);
 }
 
 function canonicalRadarrPeers(value: unknown): VerifiedRadarrPeerIdentity[] {
@@ -380,35 +610,15 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 		};
 	}
 	if (candidate.kind === "verified_sonarr") {
-		const files = candidate.files as Record<string, unknown> | undefined;
-		if (!files || !Array.isArray(files.episodeFiles)) {
-			throw new FileMatchVerificationError("Sonarr safety snapshot is invalid");
-		}
-		const episodeFiles = files.episodeFiles
-			.map((entry) => {
-				const file = entry as Record<string, unknown>;
-				return {
-					episodeFileId: requiredPositiveSafeInteger(file.episodeFileId, "Sonarr episode file ID"),
-					fullPath: normalizeMediaPath(
-						(file.fullPath as Record<string, unknown> | undefined)?.value,
-					),
-					size: requiredPositiveSafeInteger(file.size, "Sonarr episode file size"),
-				};
-			})
-			.sort((left, right) => left.episodeFileId - right.episodeFileId);
-		const uniqueIds = new Set(episodeFiles.map((file) => file.episodeFileId));
-		if (uniqueIds.size !== episodeFiles.length) {
-			throw new FileMatchVerificationError("Sonarr safety snapshot contains duplicate file IDs");
-		}
 		return {
 			kind: "verified_sonarr",
 			target: canonicalTargetIdentity(candidate.target),
-			files: {
-				seriesPath: normalizeMediaPath(
-					(files.seriesPath as Record<string, unknown> | undefined)?.value,
-				),
-				episodeFiles,
-			},
+			files: canonicalSonarrFiles(candidate.files),
+			peers: canonicalSonarrPeers(candidate.peers),
+			ownership: canonicalSonarrOwnership(candidate.ownership),
+			targetDeleteNotifications: canonicalSonarrTargetDeleteNotifications(
+				candidate.targetDeleteNotifications,
+			),
 		};
 	}
 	throw new FileMatchVerificationError("Cleanup safety snapshot is not executable");
@@ -484,6 +694,9 @@ export function buildSonarrCacheSafetyPlan(
 					size: Number(file.size),
 				})),
 			},
+			peers: [],
+			ownership: [],
+			targetDeleteNotifications: [],
 		});
 	} catch {
 		return null;
@@ -848,11 +1061,19 @@ function mappedArrPathForNotification(
 	notification: NotificationLike,
 	service: "RADARR" | "SONARR",
 ): NormalizedMediaPath {
+	return mappedMediaPathForNotification(target.fullPath, notification, service);
+}
+
+function mappedMediaPathForNotification(
+	fullPath: NormalizedMediaPath,
+	notification: NotificationLike,
+	service: "RADARR" | "SONARR",
+): NormalizedMediaPath {
 	const rawMapFrom = fieldValue(notification, "mapFrom");
 	const rawMapTo = fieldValue(notification, "mapTo");
 	const hasMapFrom = typeof rawMapFrom === "string" && rawMapFrom.trim() !== "";
 	const hasMapTo = typeof rawMapTo === "string" && rawMapTo.trim() !== "";
-	if (!hasMapFrom && !hasMapTo) return target.fullPath;
+	if (!hasMapFrom && !hasMapTo) return fullPath;
 	if (!hasMapFrom || !hasMapTo) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} Plex path mapping is incomplete`,
@@ -861,21 +1082,22 @@ function mappedArrPathForNotification(
 
 	const mapFrom = normalizeMediaPath(rawMapFrom);
 	const mapTo = normalizeMediaPath(rawMapTo);
-	if (mapFrom.windows !== target.fullPath.windows) {
+	if (mapFrom.windows !== fullPath.windows) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} Plex source mapping uses a different path type`,
 		);
 	}
-	const caseInsensitive = target.fullPath.windows;
-	const targetPath = comparablePath(target.fullPath, caseInsensitive);
+	const caseInsensitive = fullPath.windows;
+	const targetPath = comparablePath(fullPath, caseInsensitive);
 	const sourceValue = mapFrom.value.replace(/\/+$/, "");
 	const sourcePrefix = comparablePath({ ...mapFrom, value: sourceValue }, caseInsensitive);
-	if (!targetPath.startsWith(`${sourcePrefix}/`)) {
+	if (targetPath !== sourcePrefix && !targetPath.startsWith(`${sourcePrefix}/`)) {
 		throw new FileMatchVerificationError(
 			`${serviceLabel(service)} path is outside its Plex source mapping`,
 		);
 	}
-	const relativePath = target.fullPath.value.slice(sourceValue.length + 1);
+	if (targetPath === sourcePrefix) return mapTo;
+	const relativePath = fullPath.value.slice(sourceValue.length + 1);
 	return normalizeMediaPath(`${mapTo.value.replace(/\/+$/, "")}/${relativePath}`);
 }
 
@@ -911,16 +1133,22 @@ function plexPartKey(part: { file: string; size: number }): string {
 	return JSON.stringify([path.windows, comparablePath(path, path.windows), part.size]);
 }
 
-function matchingPlexSeriesShows(
+function matchingPlexSeriesParts(
 	targets: MediaFileIdentity[],
 	seriesItems: PlexSeriesMediaItem[],
 	notification: NotificationLike,
-): PlexSeriesMediaItem[] {
+): Array<{
+	show: PlexSeriesMediaItem;
+	part: { file: string; size: number };
+}> {
 	const mappedTargets = targets.map((target) => ({
 		...target,
 		fullPath: mappedArrPathForNotification(target, notification, "SONARR"),
 	}));
-	const matchedShows = new Map<string, PlexSeriesMediaItem>();
+	const matches: Array<{
+		show: PlexSeriesMediaItem;
+		part: { file: string; size: number };
+	}> = [];
 
 	for (const target of mappedTargets) {
 		const physicalMatches = new Map<
@@ -945,26 +1173,10 @@ function matchingPlexSeriesShows(
 			);
 		}
 		const match = [...physicalMatches.values()][0]!;
-		matchedShows.set(match.show.ratingKey, match.show);
+		matches.push(match);
 	}
-
-	const targetKeys = new Set(
-		mappedTargets.map((target) => plexPartKey({ file: target.fullPath.value, size: target.size })),
-	);
-	for (const show of matchedShows.values()) {
-		const showPartKeys = new Set(
-			show.episodes.flatMap((episode) => episode.parts.map((part) => plexPartKey(part))),
-		);
-		for (const partKey of showPartKeys) {
-			if (!targetKeys.has(partKey)) {
-				throw new SharedPlexItemError();
-			}
-		}
-	}
-	return [...matchedShows.values()];
+	return matches;
 }
-
-class SharedPlexItemError extends Error {}
 
 export function cleanupDeleteTargetKey(
 	target: Pick<CleanupDeleteTarget, "instanceId" | "arrItemId" | "itemType">,
@@ -1060,6 +1272,7 @@ function sonarrNotificationApplies(
 	action: string,
 ): boolean {
 	if (
+		(notification as NotificationLike).enable === false ||
 		mediaServerNotificationKind(notification) === null ||
 		!notificationMutatesLibrary(notification)
 	) {
@@ -1177,6 +1390,38 @@ function radarrTargetDeleteNotificationWitnesses(
 	return canonicalRadarrTargetDeleteNotifications(witnesses);
 }
 
+function sonarrTargetDeleteNotificationWitnesses(
+	notifications: SonarrNotification[],
+	series: Series,
+	action: string,
+	seriesDeleteOnly = false,
+): VerifiedSonarrTargetDeleteNotification[] {
+	const witnesses = notifications
+		.filter(
+			(notification) =>
+				sonarrNotificationApplies(notification, series, action) &&
+				(!seriesDeleteOnly || notification.onSeriesDelete === true),
+		)
+		.map((notification) => {
+			if (mediaServerNotificationKind(notification) !== "plex") {
+				throw new FileMatchVerificationError(
+					"Sonarr target has an unsupported series-delete notification",
+				);
+			}
+			const plexServerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+			if (!plexServerUrl) {
+				throw new FileMatchVerificationError("Sonarr target series-delete Plex URL is invalid");
+			}
+			return {
+				plexServerUrl,
+				onSeriesDelete: notification.onSeriesDelete === true,
+				onEpisodeFileDelete: notification.onEpisodeFileDelete === true,
+				mapping: notificationPathMapping(notification, "Sonarr target"),
+			};
+		});
+	return canonicalSonarrTargetDeleteNotifications(witnesses);
+}
+
 function plexConnectionFingerprint(instance: ServiceInstance): string {
 	return JSON.stringify([
 		instance.id,
@@ -1239,11 +1484,17 @@ interface PlexVerificationInput {
 		movieTags: number[];
 		notifications: RadarrNotification[];
 	}>;
+	sonarrPeers?: Array<{
+		identity: VerifiedSonarrPeerIdentity;
+		seriesTags: number[];
+		notifications: SonarrNotification[];
+	}>;
 }
 
 interface PlexVerificationResult {
 	block?: string;
 	ownership: VerifiedRadarrPlexOwnership[];
+	sonarrOwnership: VerifiedSonarrPlexOwnership[];
 }
 
 function matchingPeerPlexPart(
@@ -1341,6 +1592,385 @@ function matchingPeerPlexPart(
 	return [...matches.values()][0]!;
 }
 
+function mappedSonarrPeerFileCandidate(
+	files: MediaFileIdentity[],
+	seriesTags: number[],
+	notifications: SonarrNotification[],
+	notificationUrl: string,
+): {
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+	files: MediaFileIdentity[];
+	hasExplicitServerCorrelation: boolean;
+} {
+	const serverNotifications: SonarrNotification[] = [];
+	for (const notification of notifications) {
+		if (mediaServerNotificationKind(notification) !== "plex") continue;
+		let peerUrl: string | null = null;
+		try {
+			peerUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
+		} catch {
+			continue;
+		}
+		if (peerUrl === notificationUrl) serverNotifications.push(notification);
+	}
+	const matchingNotifications = serverNotifications.filter(
+		(notification) =>
+			(notification as NotificationLike).enable !== false &&
+			notificationMutatesLibrary(notification) &&
+			notificationTagsApply(notification, seriesTags),
+	);
+	const unusableConfiguredMapping = serverNotifications.some((notification) => {
+		const rawMapFrom = fieldValue(notification, "mapFrom");
+		const rawMapTo = fieldValue(notification, "mapTo");
+		return (
+			!matchingNotifications.includes(notification) &&
+			((typeof rawMapFrom === "string" && rawMapFrom.trim() !== "") ||
+				(typeof rawMapTo === "string" && rawMapTo.trim() !== ""))
+		);
+	});
+	if (matchingNotifications.length === 0 && unusableConfiguredMapping) {
+		throw new FileMatchVerificationError("Sonarr peer has only non-applicable Plex path mappings");
+	}
+
+	const pathCandidates = new Map<
+		string,
+		{
+			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+			files: MediaFileIdentity[];
+		}
+	>();
+	if (matchingNotifications.length === 0) {
+		pathCandidates.set(JSON.stringify([null, files.map((file) => file.fullPath)]), {
+			mapping: null,
+			files,
+		});
+	}
+	for (const notification of matchingNotifications) {
+		const mapping = notificationPathMapping(notification, "Sonarr peer");
+		const mappedFiles = files.map((file) => ({
+			...file,
+			fullPath: mapping
+				? mappedArrPathForNotification(file, notification, "SONARR")
+				: file.fullPath,
+		}));
+		pathCandidates.set(JSON.stringify([mapping, mappedFiles.map((file) => file.fullPath)]), {
+			mapping,
+			files: mappedFiles,
+		});
+	}
+	if (pathCandidates.size !== 1) {
+		throw new FileMatchVerificationError("Sonarr peer Plex path mappings conflict");
+	}
+	return {
+		...[...pathCandidates.values()][0]!,
+		hasExplicitServerCorrelation: matchingNotifications.length > 0,
+	};
+}
+
+function matchingSonarrPeerPlexParts(
+	peer: NonNullable<PlexVerificationInput["sonarrPeers"]>[number],
+	items: PlexSeriesMediaItem[],
+	notificationUrl: string,
+): Array<{
+	show: PlexSeriesMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+}> {
+	if (!peer.identity.files) return [];
+	const pathCandidate = mappedSonarrPeerFileCandidate(
+		peer.identity.files.episodeFiles.map(comparableFile),
+		peer.seriesTags,
+		peer.notifications,
+		notificationUrl,
+	);
+
+	return pathCandidate.files.map((file) => {
+		const matches = new Map<
+			string,
+			{ show: PlexSeriesMediaItem; part: { file: string; size: number } }
+		>();
+		for (const show of items) {
+			for (const episode of show.episodes) {
+				for (const part of episode.parts) {
+					if (mediaPartMatchesTarget(file, part)) {
+						matches.set(`${show.ratingKey}:${plexPartKey(part)}`, { show, part });
+					}
+				}
+			}
+		}
+		if (matches.size !== 1) {
+			throw new FileMatchVerificationError(
+				matches.size === 0
+					? "No Plex media part matched a retained Sonarr peer file"
+					: "Multiple Plex show items matched a retained Sonarr peer file",
+			);
+		}
+		return { ...[...matches.values()][0]!, mapping: pathCandidate.mapping };
+	});
+}
+
+function assertVerifiedSonarrTrackedPeerMappingUnchanged(
+	peer: VerifiedSonarrPeerIdentity,
+	series: Series | null,
+	notifications: SonarrNotification[],
+	ownership: VerifiedSonarrPlexOwnership[],
+): void {
+	for (const witness of ownership) {
+		const expected = witness.retained
+			.filter((part) => part.instanceId === peer.instanceId)
+			.map((part) => ({
+				fullPath: part.fullPath,
+				size: part.size,
+				mapping: part.mapping,
+			}))
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		if (peer.files === null) {
+			if (expected.length !== 0) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+			continue;
+		}
+		if (!series) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const mappedCandidate = mappedSonarrPeerFileCandidate(
+			peer.files.episodeFiles.map(comparableFile),
+			series.tags ?? [],
+			notifications,
+			witness.plexServerUrl,
+		);
+		if (
+			mappedCandidate.files.some((file) =>
+				witness.target.some((part) => pathsEqual(file.fullPath, part.fullPath)),
+			)
+		) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const current = mappedCandidate.files
+			.map((file) => ({
+				fullPath: file.fullPath,
+				size: file.size,
+				mapping: mappedCandidate.mapping,
+			}))
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		if (JSON.stringify(current) !== JSON.stringify(expected)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+	}
+}
+
+/**
+ * A TVDB lookup is not a complete ownership boundary: another Sonarr may have
+ * imported the same physical file under a different or missing external ID.
+ * Inspect every untracked peer series whose mapped root can contain a target
+ * Plex part and fail closed if one of its exact episode files matches.
+ */
+const SONARR_PEER_FILE_READ_CONCURRENCY = 8;
+
+interface StableSonarrPeerInventory {
+	seriesCatalog: Series[];
+	notifications: SonarrNotification[];
+	filesBySeries: Map<number, VerifiedSonarrEpisodeFileIdentity[]>;
+}
+
+function sonarrPeerSeriesCatalogWitness(seriesCatalog: Series[]): string {
+	return JSON.stringify(
+		seriesCatalog
+			.map((series) => ({
+				id: requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID"),
+				tvdbId: series.tvdbId ?? null,
+				path: normalizeMediaPath(series.path),
+				tags: [...(series.tags ?? [])].sort((left, right) => left - right),
+				episodeFileCount: series.statistics?.episodeFileCount ?? null,
+				sizeOnDisk: series.statistics?.sizeOnDisk ?? null,
+			}))
+			.sort((left, right) => left.id - right.id),
+	);
+}
+
+function sonarrPeerNotificationCatalogWitness(notifications: SonarrNotification[]): string {
+	return JSON.stringify(notifications.map((notification) => JSON.stringify(notification)).sort());
+}
+
+function sonarrPeerFileCatalogWitness(
+	filesBySeries: ReadonlyMap<number, VerifiedSonarrEpisodeFileIdentity[]>,
+): string {
+	return JSON.stringify(
+		[...filesBySeries]
+			.map(([seriesId, files]) => ({
+				seriesId,
+				files: files
+					.map((file) => [
+						file.episodeFileId,
+						file.fullPath.windows,
+						comparablePath(file.fullPath, file.fullPath.windows),
+						file.size,
+					])
+					.sort((left, right) => Number(left[0]) - Number(right[0])),
+			}))
+			.sort((left, right) => left.seriesId - right.seriesId),
+	);
+}
+
+async function readSonarrPeerFilesBySeries(
+	sonarr: InstanceType<typeof SonarrClient>,
+	seriesCatalog: Series[],
+): Promise<Map<number, VerifiedSonarrEpisodeFileIdentity[]>> {
+	const seriesById = new Map<number, Series>();
+	for (const series of seriesCatalog) {
+		const seriesId = requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID");
+		if (seriesById.has(seriesId)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		seriesById.set(seriesId, series);
+	}
+	const filesBySeries = new Map<number, VerifiedSonarrEpisodeFileIdentity[]>();
+	const allSeries = [...seriesById.entries()];
+	let nextSeriesIndex = 0;
+	await Promise.all(
+		Array.from(
+			{
+				length: Math.min(SONARR_PEER_FILE_READ_CONCURRENCY, allSeries.length),
+			},
+			async () => {
+				while (nextSeriesIndex < allSeries.length) {
+					const [seriesId, series] = allSeries[nextSeriesIndex++]!;
+					const files = (await sonarr.episodeFile.getBySeries(seriesId)).map((file) => {
+						if (
+							requiredPositiveSafeInteger(
+								file.seriesId ?? seriesId,
+								"Unverified Sonarr episode file series ID",
+							) !== seriesId
+						) {
+							throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+						}
+						return sonarrEpisodeFileIdentity(series, file);
+					});
+					filesBySeries.set(seriesId, files);
+				}
+			},
+		),
+	);
+	return filesBySeries;
+}
+
+async function readStableSonarrPeerInventory(
+	sonarr: InstanceType<typeof SonarrClient>,
+	initialSeriesCatalog?: Series[],
+	initialNotifications?: SonarrNotification[],
+): Promise<StableSonarrPeerInventory> {
+	const seriesCatalog = initialSeriesCatalog ?? (await sonarr.series.getAll());
+	const notifications = initialNotifications ?? (await sonarr.notification.getAll());
+	const firstFilesBySeries = await readSonarrPeerFilesBySeries(sonarr, seriesCatalog);
+	const finalFilesBySeries = await readSonarrPeerFilesBySeries(sonarr, seriesCatalog);
+	const [finalSeriesCatalog, finalNotifications] = await Promise.all([
+		sonarr.series.getAll(),
+		sonarr.notification.getAll(),
+	]);
+	if (
+		sonarrPeerSeriesCatalogWitness(finalSeriesCatalog) !==
+			sonarrPeerSeriesCatalogWitness(seriesCatalog) ||
+		sonarrPeerNotificationCatalogWitness(finalNotifications) !==
+			sonarrPeerNotificationCatalogWitness(notifications) ||
+		sonarrPeerFileCatalogWitness(finalFilesBySeries) !==
+			sonarrPeerFileCatalogWitness(firstFilesBySeries)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	return {
+		seriesCatalog: finalSeriesCatalog,
+		notifications: finalNotifications,
+		filesBySeries: finalFilesBySeries,
+	};
+}
+
+function assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+	trackedSeriesIds: ReadonlySet<number>,
+	ownership: VerifiedSonarrPlexOwnership[],
+	inventory: StableSonarrPeerInventory,
+): void {
+	for (const series of inventory.seriesCatalog) {
+		const seriesId = requiredPositiveSafeInteger(series.id, "Unverified Sonarr peer series ID");
+		if (trackedSeriesIds.has(seriesId)) continue;
+		const peerFiles = (inventory.filesBySeries.get(seriesId) ?? []).map(comparableFile);
+		for (const witness of ownership) {
+			if (peerFiles.length === 0) continue;
+			const mappedCandidate = mappedSonarrPeerFileCandidate(
+				peerFiles,
+				series.tags ?? [],
+				inventory.notifications,
+				witness.plexServerUrl,
+			);
+			if (
+				!mappedCandidate.hasExplicitServerCorrelation ||
+				mappedCandidate.files.some((file) =>
+					witness.target.some((part) => pathsEqual(file.fullPath, part.fullPath)),
+				)
+			) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+		}
+	}
+}
+
+function assertVerifiedSonarrPeerIdentityFromInventory(
+	peer: VerifiedSonarrPeerIdentity,
+	inventory: StableSonarrPeerInventory,
+): Series | null {
+	const matchingSeries = inventory.seriesCatalog.filter(
+		(series) => series.tvdbId === peer.externalId,
+	);
+	if (peer.arrItemId === null) {
+		if (matchingSeries.length !== 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		return null;
+	}
+	const series = matchingSeries[0];
+	if (
+		matchingSeries.length !== 1 ||
+		!series ||
+		series.id !== peer.arrItemId ||
+		peer.mediaPath === null ||
+		peer.files === null ||
+		!pathsEqual(normalizeMediaPath(series.path), peer.mediaPath) ||
+		sonarrPeerFileCatalogWitness(
+			new Map([[peer.arrItemId, inventory.filesBySeries.get(peer.arrItemId) ?? []]]),
+		) !== sonarrPeerFileCatalogWitness(new Map([[peer.arrItemId, peer.files.episodeFiles]]))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	return series;
+}
+
+export async function assertVerifiedSonarrPeerInventoryUnchanged(
+	sonarr: InstanceType<typeof SonarrClient>,
+	peer: VerifiedSonarrPeerIdentity,
+	ownership: VerifiedSonarrPlexOwnership[],
+	seriesCatalog?: Series[],
+	notifications?: SonarrNotification[],
+): Promise<{ series: Series | null; notifications: SonarrNotification[] }> {
+	try {
+		const inventory = await readStableSonarrPeerInventory(sonarr, seriesCatalog, notifications);
+		const series = assertVerifiedSonarrPeerIdentityFromInventory(peer, inventory);
+		assertVerifiedSonarrTrackedPeerMappingUnchanged(
+			peer,
+			series,
+			inventory.notifications,
+			ownership,
+		);
+		assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+			new Set(peer.arrItemId === null ? [] : [peer.arrItemId]),
+			ownership,
+			inventory,
+		);
+		return { series, notifications: inventory.notifications };
+	} catch (error) {
+		if (error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError) throw error;
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+}
+
 async function verifyPlexMediaState(
 	deps: CleanupExecutorDeps,
 	context: SharedPlexSafetyContext,
@@ -1351,7 +1981,8 @@ async function verifyPlexMediaState(
 	input: PlexVerificationInput,
 ): Promise<PlexVerificationResult> {
 	const ownership: VerifiedRadarrPlexOwnership[] = [];
-	if (input.files.length === 0) return { ownership };
+	const sonarrOwnership: VerifiedSonarrPlexOwnership[] = [];
+	if (input.files.length === 0) return { ownership, sonarrOwnership };
 
 	for (const notification of input.notifications) {
 		const notificationUrl = normalizedServerUrl(plexConnectionBaseUrl(notification));
@@ -1409,6 +2040,7 @@ async function verifyPlexMediaState(
 									return {
 										block: crossInstanceOwnershipReason("RADARR"),
 										ownership,
+										sonarrOwnership,
 									};
 								}
 								retained.push({
@@ -1420,7 +2052,7 @@ async function verifyPlexMediaState(
 								});
 								if (peerMatch.item.ratingKey === targetMatch.item.ratingKey) {
 									if (retainedPartKeys.has(peerPartKey)) {
-										return { block: mergedItemReason(input.service), ownership };
+										return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
 									}
 									retainedPartKeys.add(peerPartKey);
 								}
@@ -1439,14 +2071,14 @@ async function verifyPlexMediaState(
 						}
 						if (targetMatch.item.parts.length <= 1) continue;
 						if (!input.radarrPeers?.length || !notificationUrl) {
-							return { block: mergedItemReason(input.service), ownership };
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
 						}
 						const unownedParts = targetMatch.item.parts.filter((part) => {
 							const partKey = plexPartKey(part);
 							return partKey !== targetPartKey && !retainedPartKeys.has(partKey);
 						});
 						if (retainedPartKeys.size === 0 || unownedParts.length > 0) {
-							return { block: mergedItemReason(input.service), ownership };
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
 						}
 					}
 				} else {
@@ -1460,13 +2092,86 @@ async function verifyPlexMediaState(
 						mediaPartsPromise = plex.getSeriesEpisodeMediaPartsByTvdbId(input.externalId);
 						clientLookups.set(input.externalId, mediaPartsPromise);
 					}
-					try {
-						matchingPlexSeriesShows(input.files, await mediaPartsPromise, notification);
-					} catch (error) {
-						if (error instanceof SharedPlexItemError) {
-							return { block: mergedItemReason(input.service), ownership };
+					const mediaItems = await mediaPartsPromise;
+					const targetMatches = matchingPlexSeriesParts(input.files, mediaItems, notification);
+					const targetPhysicalKeys = new Set(
+						targetMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+					);
+					if (targetPhysicalKeys.size !== targetMatches.length) {
+						throw new FileMatchVerificationError(
+							"Multiple Sonarr episode files matched the same Plex media part",
+						);
+					}
+					const targetPartKeys = new Set(targetMatches.map((match) => plexPartKey(match.part)));
+					const retainedMatches: Array<{
+						instanceId: string;
+						show: PlexSeriesMediaItem;
+						part: { file: string; size: number };
+						mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+					}> = [];
+					const retainedPartOwners = new Map<string, string>();
+					for (const peer of input.sonarrPeers ?? []) {
+						for (const match of matchingSonarrPeerPlexParts(peer, mediaItems, notificationUrl)) {
+							const partKey = plexPartKey(match.part);
+							if (targetPartKeys.has(partKey)) {
+								return {
+									block: crossInstanceOwnershipReason("SONARR"),
+									ownership,
+									sonarrOwnership,
+								};
+							}
+							const existingOwner = retainedPartOwners.get(partKey);
+							if (existingOwner) {
+								if (existingOwner !== peer.identity.instanceId) {
+									return {
+										block: crossInstanceOwnershipReason("SONARR"),
+										ownership,
+										sonarrOwnership,
+									};
+								}
+								throw new FileMatchVerificationError(
+									"Multiple Sonarr peer files matched the same Plex media part",
+								);
+							}
+							retainedPartOwners.set(partKey, peer.identity.instanceId);
+							retainedMatches.push({
+								instanceId: peer.identity.instanceId,
+								...match,
+							});
 						}
-						throw error;
+					}
+					if (input.sonarrPeers?.length) {
+						sonarrOwnership.push({
+							plexServerUrl: notificationUrl,
+							target: targetMatches.map((match) => ({
+								ratingKey: match.show.ratingKey,
+								fullPath: normalizeMediaPath(match.part.file),
+								size: match.part.size,
+							})),
+							retained: retainedMatches.map((match) => ({
+								instanceId: match.instanceId,
+								ratingKey: match.show.ratingKey,
+								fullPath: normalizeMediaPath(match.part.file),
+								size: match.part.size,
+								mapping: match.mapping,
+							})),
+						});
+					}
+					const allowedPartKeys = new Set([
+						...targetMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+						...retainedMatches.map((match) => `${match.show.ratingKey}:${plexPartKey(match.part)}`),
+					]);
+					for (const show of mediaItems) {
+						const showPartKeys = new Set(
+							show.episodes.flatMap((episode) => episode.parts.map(plexPartKey)),
+						);
+						if (
+							[...showPartKeys].some(
+								(partKey) => !allowedPartKeys.has(`${show.ratingKey}:${partKey}`),
+							)
+						) {
+							return { block: mergedItemReason(input.service), ownership, sonarrOwnership };
+						}
 					}
 				}
 			} catch (error) {
@@ -1488,13 +2193,16 @@ async function verifyPlexMediaState(
 			throw new Error("No matching Plex credential could verify owner-visible media state");
 		}
 	}
-	return { ownership };
+	return { ownership, sonarrOwnership };
 }
 
 /**
  * Fail-closed preflight for shared Plex library deletions initiated through
  * either Radarr or Sonarr. The live ARR file set is correlated to exact Plex
- * media parts after applying the target ARR connection's path mapping.
+ * media parts after applying the target ARR connection's path mapping. A
+ * shared Radarr movies and Sonarr shows are allowed only when every retained
+ * Plex part is backed by an exact peer ARR file and every configured peer is
+ * snapshotted.
  */
 export async function findSharedPlexDeleteBlocks(
 	deps: CleanupExecutorDeps,
@@ -1543,6 +2251,7 @@ export async function findSharedPlexDeleteBlocks(
 	const radarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
 	const radarrMovies = new Map<string, Promise<Movie[]>>();
 	const radarrPeerFiles = new Map<string, Promise<VerifiedRadarrFileIdentity | null>>();
+	const sonarrSeries = new Map<string, Promise<Series[]>>();
 	const sonarrNotifications = new Map<string, Promise<SonarrNotification[]>>();
 	const plexOwnerChecks = new Map<string, Promise<void>>();
 	const plexMovieLookups = new Map<SafetyPlexClient, Map<number, Promise<PlexMovieMediaItem[]>>>();
@@ -1550,6 +2259,21 @@ export async function findSharedPlexDeleteBlocks(
 		SafetyPlexClient,
 		Map<number, Promise<PlexSeriesMediaItem[]>>
 	>();
+	const pendingSonarrPlans: Array<{
+		target: CleanupDeleteTarget;
+		targetKey: string;
+		client: InstanceType<typeof SonarrClient>;
+		action: string;
+		targetIdentity: VerifiedArrTargetIdentity;
+		verifiedFiles: VerifiedSonarrFileIdentity;
+		peers: NonNullable<PlexVerificationInput["sonarrPeers"]>;
+		peerCatalogs: Array<{
+			client: InstanceType<typeof SonarrClient>;
+			peer: VerifiedSonarrPeerIdentity;
+		}>;
+		ownership: VerifiedSonarrPlexOwnership[];
+		targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
+	}> = [];
 
 	const getRadarrClient = (instance: ServiceInstance): InstanceType<typeof RadarrClient> => {
 		let client = radarrClients.get(instance.id);
@@ -1605,6 +2329,18 @@ export async function findSharedPlexDeleteBlocks(
 			sonarrNotifications.set(instance.id, notifications);
 		}
 		return notifications;
+	};
+
+	const getSonarrSeries = (
+		instance: ServiceInstance,
+		client: InstanceType<typeof SonarrClient>,
+	): Promise<Series[]> => {
+		let series = sonarrSeries.get(instance.id);
+		if (!series) {
+			series = client.series.getAll();
+			sonarrSeries.set(instance.id, series);
+		}
+		return series;
 	};
 
 	const otherInstanceMayOwnFile = (
@@ -1872,21 +2608,24 @@ export async function findSharedPlexDeleteBlocks(
 					sonarrEpisodeFileIdentity(series, file),
 				),
 			};
-			if (otherInstanceMayOwnFile(targetInstance, service, verifiedFiles.episodeFiles.length)) {
-				const reason = crossInstanceOwnershipReason(service);
-				blocks.set(targetKey, reason);
-				context.plans.set(targetKey, { kind: "blocked", reason });
-				continue;
-			}
 			const notifications = (await getSonarrNotifications(targetInstance, sonarr)).filter(
 				(notification) => sonarrNotificationApplies(notification, series, action),
 			);
 			if (notifications.length === 0) {
+				if (otherInstanceMayOwnFile(targetInstance, service, verifiedFiles.episodeFiles.length)) {
+					const reason = crossInstanceOwnershipReason(service);
+					blocks.set(targetKey, reason);
+					context.plans.set(targetKey, { kind: "blocked", reason });
+					continue;
+				}
 				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
 				context.plans.set(targetKey, {
 					kind: "verified_sonarr",
 					target: targetIdentity,
 					files: verifiedFiles,
+					peers: [],
+					ownership: [],
+					targetDeleteNotifications: [],
 				});
 				continue;
 			}
@@ -1924,6 +2663,69 @@ export async function findSharedPlexDeleteBlocks(
 				context.plans.set(targetKey, { kind: "blocked", reason });
 				continue;
 			}
+			const peerInstances = instances.filter(
+				(candidate) => candidate.id !== targetInstance.id && candidate.service === "SONARR",
+			);
+			const sonarrPeers: NonNullable<PlexVerificationInput["sonarrPeers"]> = [];
+			const sonarrPeerCatalogs: Array<{
+				client: InstanceType<typeof SonarrClient>;
+				peer: VerifiedSonarrPeerIdentity;
+			}> = [];
+			for (const peerInstance of peerInstances) {
+				const peerClient = getSonarrClient(peerInstance);
+				const peerSeriesCatalog = await getSonarrSeries(peerInstance, peerClient);
+				const peerSeriesItems = peerSeriesCatalog.filter(
+					(candidate) => candidate.tvdbId === tvdbId,
+				);
+				const peerNotifications = await getSonarrNotifications(peerInstance, peerClient);
+				if (peerSeriesItems.length > 1) {
+					throw new FileMatchVerificationError("Sonarr peer returned multiple matching series");
+				}
+				if (peerSeriesItems.length === 0) {
+					const peerIdentity: VerifiedSonarrPeerIdentity = {
+						instanceId: peerInstance.id,
+						serviceFingerprint: createArrServiceFingerprint(peerInstance),
+						externalId: tvdbId,
+						arrItemId: null,
+						mediaPath: null,
+						files: null,
+					};
+					sonarrPeerCatalogs.push({ client: peerClient, peer: peerIdentity });
+					sonarrPeers.push({
+						identity: peerIdentity,
+						seriesTags: [],
+						notifications: [],
+					});
+					continue;
+				}
+				const peerSeries = peerSeriesItems[0]!;
+				const peerSeriesId = requiredPositiveSafeInteger(peerSeries.id, "Sonarr peer series ID");
+				const peerFiles: VerifiedSonarrFileIdentity = {
+					seriesPath: normalizeMediaPath(peerSeries.path),
+					episodeFiles: (await peerClient.episodeFile.getBySeries(peerSeriesId)).map((file) =>
+						sonarrEpisodeFileIdentity(peerSeries, file),
+					),
+				};
+				const peerIdentity: VerifiedSonarrPeerIdentity = {
+					instanceId: peerInstance.id,
+					serviceFingerprint: createArrServiceFingerprint(peerInstance),
+					externalId: tvdbId,
+					arrItemId: peerSeriesId,
+					mediaPath: normalizeMediaPath(peerSeries.path),
+					files: peerFiles,
+				};
+				sonarrPeerCatalogs.push({ client: peerClient, peer: peerIdentity });
+				sonarrPeers.push({
+					identity: peerIdentity,
+					seriesTags: peerSeries.tags ?? [],
+					notifications: peerFiles.episodeFiles.length === 0 ? [] : peerNotifications,
+				});
+			}
+			const targetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+				plexNotifications,
+				series,
+				action,
+			);
 			const verification = await verifyPlexMediaState(
 				deps,
 				context,
@@ -1937,24 +2739,33 @@ export async function findSharedPlexDeleteBlocks(
 					notifications: plexNotifications,
 					externalId: tvdbId,
 					files: verifiedFiles.episodeFiles.map(comparableFile),
+					sonarrPeers,
 				},
 			);
 			if (verification.block) {
 				blocks.set(targetKey, verification.block);
 				context.plans.set(targetKey, { kind: "blocked", reason: verification.block });
 			} else {
-				context.verifiedSonarrFiles.set(targetKey, verifiedFiles);
-				context.plans.set(targetKey, {
-					kind: "verified_sonarr",
-					target: targetIdentity,
-					files: verifiedFiles,
+				pendingSonarrPlans.push({
+					target,
+					targetKey,
+					client: sonarr,
+					action,
+					targetIdentity,
+					verifiedFiles,
+					peers: sonarrPeers,
+					peerCatalogs: sonarrPeerCatalogs,
+					ownership: verification.sonarrOwnership,
+					targetDeleteNotifications,
 				});
 			}
 		} catch (error) {
 			const reason =
-				error instanceof FileMatchVerificationError
-					? fileMatchFailedReason(service)
-					: verificationFailedReason(service);
+				error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError
+					? error.message
+					: error instanceof FileMatchVerificationError
+						? fileMatchFailedReason(service)
+						: verificationFailedReason(service);
 			blocks.set(targetKey, reason);
 			context.plans.set(targetKey, { kind: "blocked", reason });
 			deps.log.warn(
@@ -1963,6 +2774,74 @@ export async function findSharedPlexDeleteBlocks(
 					instanceId: target.instanceId,
 					arrItemId: target.arrItemId,
 					service,
+				},
+				"Cleanup shared-Plex safety check failed closed",
+			);
+		}
+	}
+
+	const sonarrPeerInventories = new Map<string, Promise<StableSonarrPeerInventory>>();
+	for (const pending of pendingSonarrPlans) {
+		try {
+			for (const peerCatalog of pending.peerCatalogs) {
+				const inventoryKey = `${peerCatalog.peer.instanceId}:${peerCatalog.peer.serviceFingerprint}`;
+				let inventoryPromise = sonarrPeerInventories.get(inventoryKey);
+				if (!inventoryPromise) {
+					inventoryPromise = readStableSonarrPeerInventory(peerCatalog.client);
+					sonarrPeerInventories.set(inventoryKey, inventoryPromise);
+				}
+				const inventory = await inventoryPromise;
+				const freshPeerSeries = assertVerifiedSonarrPeerIdentityFromInventory(
+					peerCatalog.peer,
+					inventory,
+				);
+				assertVerifiedSonarrTrackedPeerMappingUnchanged(
+					peerCatalog.peer,
+					freshPeerSeries,
+					inventory.notifications,
+					pending.ownership,
+				);
+				assertNoUnverifiedSonarrPeerOwnsTargetPartsFromInventory(
+					new Set(peerCatalog.peer.arrItemId === null ? [] : [peerCatalog.peer.arrItemId]),
+					pending.ownership,
+					inventory,
+				);
+			}
+			const freshTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+				await pending.client.notification.getAll(),
+				await pending.client.series.getById(pending.target.arrItemId),
+				pending.action,
+			);
+			if (
+				JSON.stringify(freshTargetDeleteNotifications) !==
+				JSON.stringify(pending.targetDeleteNotifications)
+			) {
+				throw new ArrTargetChangedDuringSafetyCheckError();
+			}
+			context.verifiedSonarrFiles.set(pending.targetKey, pending.verifiedFiles);
+			context.plans.set(pending.targetKey, {
+				kind: "verified_sonarr",
+				target: pending.targetIdentity,
+				files: pending.verifiedFiles,
+				peers: pending.peers.map((peer) => peer.identity),
+				ownership: pending.ownership,
+				targetDeleteNotifications: pending.targetDeleteNotifications,
+			});
+		} catch (error) {
+			const reason =
+				error instanceof ArrCrossInstanceOwnershipChangedDuringSafetyCheckError
+					? error.message
+					: error instanceof FileMatchVerificationError
+						? fileMatchFailedReason("SONARR")
+						: verificationFailedReason("SONARR");
+			blocks.set(pending.targetKey, reason);
+			context.plans.set(pending.targetKey, { kind: "blocked", reason });
+			deps.log.warn(
+				{
+					err: getErrorMessage(error),
+					instanceId: pending.target.instanceId,
+					arrItemId: pending.target.arrItemId,
+					service: "SONARR",
 				},
 				"Cleanup shared-Plex safety check failed closed",
 			);
@@ -2118,4 +2997,199 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 		}
 	}
 	await assertVerifiedRadarrEmptyUnchanged(targetClient, targetArrItemId, plan.target);
+}
+
+/**
+ * Revalidate every retained Sonarr episode-file witness after the selected
+ * target files are gone and immediately before the fileless series record is
+ * deleted. The final target-file read is deliberately last.
+ */
+export async function assertVerifiedSonarrPeerOwnershipRetained(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	targetArrItemId: number,
+	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
+): Promise<void> {
+	const [arrInstances, plexInstances] = await Promise.all([
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: ["RADARR", "SONARR"] } },
+		}),
+		deps.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX" },
+		}),
+	]);
+	const peerInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "SONARR" &&
+			createArrServiceFingerprint(instance) !== plan.target.serviceFingerprint,
+	);
+	const targetInstances = arrInstances.filter(
+		(instance) =>
+			instance.service === "SONARR" &&
+			createArrServiceFingerprint(instance) === plan.target.serviceFingerprint,
+	);
+	const peerIds = new Set(plan.peers.map((peer) => peer.instanceId));
+	if (
+		targetInstances.length !== 1 ||
+		peerInstances.length !== peerIds.size ||
+		peerInstances.some((instance) => !peerIds.has(instance.id))
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+	const targetClient = deps.arrClientFactory.create(targetInstances[0]!) as InstanceType<
+		typeof SonarrClient
+	>;
+	const emptyTargetFiles: VerifiedSonarrFileIdentity = {
+		seriesPath: plan.files.seriesPath,
+		episodeFiles: [],
+	};
+	const expectedTargetSeriesDeleteNotifications = plan.targetDeleteNotifications.filter(
+		(notification) => notification.onSeriesDelete,
+	);
+	await assertVerifiedSonarrFilesUnchanged(
+		targetClient,
+		targetArrItemId,
+		plan.target,
+		emptyTargetFiles,
+	);
+	const currentTargetSeries = await targetClient.series.getById(targetArrItemId);
+	const currentTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		currentTargetSeries,
+		"delete",
+		true,
+	);
+	if (
+		JSON.stringify(currentTargetDeleteNotifications) !==
+		JSON.stringify(expectedTargetSeriesDeleteNotifications)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
+
+	const livePeers = new Map<string, NonNullable<PlexVerificationInput["sonarrPeers"]>[number]>();
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof SonarrClient>;
+		const seriesCatalog = await client.series.getAll();
+		const peerNotifications = await client.notification.getAll();
+		const verifiedPeer = await assertVerifiedSonarrPeerInventoryUnchanged(
+			client,
+			peer,
+			plan.ownership,
+			seriesCatalog,
+			peerNotifications,
+		);
+		if (peer.arrItemId === null || peer.files === null || verifiedPeer.series === null) continue;
+		livePeers.set(peer.instanceId, {
+			identity: peer,
+			seriesTags: verifiedPeer.series.tags ?? [],
+			notifications: peer.files.episodeFiles.length ? verifiedPeer.notifications : [],
+		});
+	}
+
+	const context = createSharedPlexSafetyContext();
+	const ownerChecks = new Map<string, Promise<void>>();
+	for (const ownership of plan.ownership) {
+		const matchingPlexInstances = plexInstances.filter(
+			(instance) => normalizedServerUrl(instance.baseUrl) === ownership.plexServerUrl,
+		);
+		if (matchingPlexInstances.length === 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		for (const plexInstance of matchingPlexInstances) {
+			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
+			let mediaItems: PlexSeriesMediaItem[];
+			try {
+				mediaItems = await plex.getSeriesEpisodeMediaPartsByTvdbId(plan.target.externalId);
+			} catch (error) {
+				if (error instanceof PlexSeriesNotFoundError && ownership.retained.length === 0) {
+					mediaItems = [];
+				} else {
+					throw error;
+				}
+			}
+			const liveRetained: VerifiedSonarrPlexOwnership["retained"] = [];
+			for (const expectedPeer of plan.peers) {
+				const peer = livePeers.get(expectedPeer.instanceId);
+				if (!peer) continue;
+				for (const match of matchingSonarrPeerPlexParts(
+					peer,
+					mediaItems,
+					ownership.plexServerUrl,
+				)) {
+					liveRetained.push({
+						instanceId: expectedPeer.instanceId,
+						ratingKey: match.show.ratingKey,
+						fullPath: normalizeMediaPath(match.part.file),
+						size: match.part.size,
+						mapping: match.mapping,
+					});
+				}
+			}
+			const expectedRetained = [...ownership.retained].sort((left, right) =>
+				JSON.stringify(left).localeCompare(JSON.stringify(right)),
+			);
+			liveRetained.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+			if (JSON.stringify(liveRetained) !== JSON.stringify(expectedRetained)) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+			}
+
+			const allowedPartKeys = new Set([
+				...ownership.target.map(
+					(part) =>
+						`${part.ratingKey}:${plexPartKey({ file: part.fullPath.value, size: part.size })}`,
+				),
+				...ownership.retained.map(
+					(part) =>
+						`${part.ratingKey}:${plexPartKey({ file: part.fullPath.value, size: part.size })}`,
+				),
+			]);
+			for (const show of mediaItems) {
+				for (const partKey of new Set(
+					show.episodes.flatMap((episode) => episode.parts.map(plexPartKey)),
+				)) {
+					if (!allowedPartKeys.has(`${show.ratingKey}:${partKey}`)) {
+						throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+					}
+				}
+			}
+		}
+	}
+	for (const peer of plan.peers) {
+		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
+		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+		}
+		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof SonarrClient>;
+		const seriesCatalog = await client.series.getAll();
+		const currentPeerNotifications = await client.notification.getAll();
+		await assertVerifiedSonarrPeerInventoryUnchanged(
+			client,
+			peer,
+			plan.ownership,
+			seriesCatalog,
+			currentPeerNotifications,
+		);
+	}
+	const finalTargetDeleteNotifications = sonarrTargetDeleteNotificationWitnesses(
+		await targetClient.notification.getAll(),
+		await targetClient.series.getById(targetArrItemId),
+		"delete",
+		true,
+	);
+	if (
+		JSON.stringify(finalTargetDeleteNotifications) !==
+		JSON.stringify(expectedTargetSeriesDeleteNotifications)
+	) {
+		throw new ArrTargetChangedDuringSafetyCheckError();
+	}
+	await assertVerifiedSonarrFilesUnchanged(
+		targetClient,
+		targetArrItemId,
+		plan.target,
+		emptyTargetFiles,
+	);
 }

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -1,24 +1,27 @@
 import type {
 	Movie,
 	MovieFile,
-	Notification as RadarrNotification,
 	RadarrClient,
+	Notification as RadarrNotification,
 } from "arr-sdk/radarr";
 import type {
 	EpisodeFile,
-	Notification as SonarrNotification,
 	Series,
 	SonarrClient,
+	Notification as SonarrNotification,
 } from "arr-sdk/sonarr";
 import {
 	createPlexClient,
 	type PlexClient,
 	type PlexMovieMediaItem,
+	PlexMovieNotFoundError,
 	type PlexSeriesMediaItem,
 	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
 import type { ServiceInstance } from "../prisma.js";
+
 export { createArrServiceFingerprint } from "../arr/service-fingerprint.js";
+
 import { createArrServiceFingerprint } from "../arr/service-fingerprint.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import type { CleanupExecutorDeps } from "./types.js";
@@ -167,6 +170,7 @@ export type SharedMediaSafetyPlan =
 			target: VerifiedArrTargetIdentity;
 			file: VerifiedRadarrFileIdentity;
 			peers: VerifiedRadarrPeerIdentity[];
+			peerInventoryComplete?: true;
 			ownership: VerifiedRadarrPlexOwnership[];
 			targetDeleteNotifications: VerifiedRadarrTargetDeleteNotification[];
 	  }
@@ -175,6 +179,7 @@ export type SharedMediaSafetyPlan =
 			target: VerifiedArrTargetIdentity;
 			files: VerifiedSonarrFileIdentity;
 			peers: VerifiedSonarrPeerIdentity[];
+			peerInventoryComplete?: true;
 			ownership: VerifiedSonarrPlexOwnership[];
 			targetDeleteNotifications: VerifiedSonarrTargetDeleteNotification[];
 	  };
@@ -603,6 +608,7 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 			target: canonicalTargetIdentity(candidate.target),
 			file: canonicalRadarrFileIdentity(candidate.file),
 			peers: canonicalRadarrPeers(candidate.peers),
+			...(candidate.peerInventoryComplete === true ? { peerInventoryComplete: true as const } : {}),
 			ownership: canonicalRadarrOwnership(candidate.ownership),
 			targetDeleteNotifications: canonicalRadarrTargetDeleteNotifications(
 				candidate.targetDeleteNotifications,
@@ -615,6 +621,7 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 			target: canonicalTargetIdentity(candidate.target),
 			files: canonicalSonarrFiles(candidate.files),
 			peers: canonicalSonarrPeers(candidate.peers),
+			...(candidate.peerInventoryComplete === true ? { peerInventoryComplete: true as const } : {}),
 			ownership: canonicalSonarrOwnership(candidate.ownership),
 			targetDeleteNotifications: canonicalSonarrTargetDeleteNotifications(
 				candidate.targetDeleteNotifications,
@@ -641,7 +648,19 @@ export function executableSafetyPlansEqual(
 	left: ExecutableSharedMediaSafetyPlan,
 	right: ExecutableSharedMediaSafetyPlan,
 ): boolean {
-	return serializeExecutableSafetyPlan(left) === serializeExecutableSafetyPlan(right);
+	if (serializeExecutableSafetyPlan(left) === serializeExecutableSafetyPlan(right)) return true;
+	const withoutNoPeerTopology = (plan: ExecutableSharedMediaSafetyPlan) => {
+		if (
+			(plan.kind !== "verified_radarr" && plan.kind !== "verified_sonarr") ||
+			plan.peers.length !== 0
+		) {
+			return plan;
+		}
+		return { ...plan, peerInventoryComplete: undefined, ownership: [] };
+	};
+	return (
+		JSON.stringify(withoutNoPeerTopology(left)) === JSON.stringify(withoutNoPeerTopology(right))
+	);
 }
 
 export function buildRadarrCacheSafetyPlan(
@@ -900,6 +919,9 @@ function radarrFileIdentity(
 	movieFile: MovieFile,
 	movieFileId: number,
 ): VerifiedRadarrFileIdentity {
+	if (movieFile.id !== movieFileId) {
+		throw new FileMatchVerificationError("Radarr movie file identity does not match its movie");
+	}
 	const size = movieFile.size;
 	if (typeof size !== "number" || !Number.isSafeInteger(size) || size <= 0) {
 		throw new FileMatchVerificationError("Radarr movie file size is unavailable");
@@ -1484,6 +1506,11 @@ interface PlexVerificationInput {
 		movieTags: number[];
 		notifications: RadarrNotification[];
 	}>;
+	radarrUntrackedPeerFiles?: Array<{
+		file: VerifiedRadarrFileIdentity;
+		movieTags: number[];
+		notifications: RadarrNotification[];
+	}>;
 	sonarrPeers?: Array<{
 		identity: VerifiedSonarrPeerIdentity;
 		seriesTags: number[];
@@ -1497,17 +1524,22 @@ interface PlexVerificationResult {
 	sonarrOwnership: VerifiedSonarrPlexOwnership[];
 }
 
-function matchingPeerPlexPart(
-	peer: NonNullable<PlexVerificationInput["radarrPeers"]>[number],
-	items: PlexMovieMediaItem[],
+function mappedRadarrPeerFileCandidate(
+	peer: {
+		file: VerifiedRadarrFileIdentity | null;
+		movieTags: number[];
+		notifications: RadarrNotification[];
+	},
 	notificationUrl: string,
+	requireExplicitPlexCorrelation = false,
 ): {
-	item: PlexMovieMediaItem;
-	part: { file: string; size: number };
+	fileId: number;
+	fullPath: NormalizedMediaPath;
+	size: number;
 	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
 } | null {
-	if (!peer.identity.file) return null;
-	const file = comparableFile(peer.identity.file);
+	if (!peer.file) return null;
+	const file = comparableFile(peer.file);
 	const serverNotifications: RadarrNotification[] = [];
 	for (const notification of peer.notifications) {
 		if (mediaServerNotificationKind(notification) !== "plex") continue;
@@ -1534,10 +1566,12 @@ function matchingPeerPlexPart(
 				(typeof rawMapTo === "string" && rawMapTo.trim() !== ""))
 		);
 	});
-	if (matchingNotifications.length === 0 && unusableConfiguredMapping) {
+	if (
+		matchingNotifications.length === 0 &&
+		(requireExplicitPlexCorrelation || unusableConfiguredMapping)
+	) {
 		throw new FileMatchVerificationError("Radarr peer has only non-applicable Plex path mappings");
 	}
-
 	const pathCandidates = new Map<
 		string,
 		{
@@ -1561,7 +1595,23 @@ function matchingPeerPlexPart(
 	if (pathCandidates.size !== 1) {
 		throw new FileMatchVerificationError("Radarr peer Plex path mappings conflict");
 	}
-	const pathCandidate = [...pathCandidates.values()][0]!;
+	return { ...file, ...[...pathCandidates.values()][0]! };
+}
+
+function matchingPeerPlexPart(
+	peer: NonNullable<PlexVerificationInput["radarrPeers"]>[number],
+	items: PlexMovieMediaItem[],
+	notificationUrl: string,
+): {
+	item: PlexMovieMediaItem;
+	part: { file: string; size: number };
+	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+} | null {
+	const pathCandidate = mappedRadarrPeerFileCandidate(
+		{ file: peer.identity.file, movieTags: peer.movieTags, notifications: peer.notifications },
+		notificationUrl,
+	);
+	if (!pathCandidate) return null;
 	const matches = new Map<
 		string,
 		{
@@ -1570,7 +1620,7 @@ function matchingPeerPlexPart(
 			mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
 		}
 	>();
-	const mappedFile = { ...file, fullPath: pathCandidate.fullPath };
+	const mappedFile = pathCandidate;
 	for (const item of items) {
 		for (const part of item.parts) {
 			if (mediaPartMatchesTarget(mappedFile, part)) {
@@ -1766,6 +1816,163 @@ function assertVerifiedSonarrTrackedPeerMappingUnchanged(
  * Plex part and fail closed if one of its exact episode files matches.
  */
 const SONARR_PEER_FILE_READ_CONCURRENCY = 8;
+const RADARR_PEER_FILE_READ_CONCURRENCY = 8;
+
+interface StableRadarrPeerInventory {
+	movieCatalog: Movie[];
+	notifications: RadarrNotification[];
+	filesByMovie: Map<number, VerifiedRadarrFileIdentity | null>;
+}
+
+function radarrPeerMovieCatalogWitness(movieCatalog: Movie[]): string {
+	return JSON.stringify(
+		movieCatalog
+			.map((movie) => ({
+				id: requiredPositiveSafeInteger(movie.id, "Unverified Radarr peer movie ID"),
+				tmdbId:
+					movie.tmdbId === undefined || movie.tmdbId === null
+						? null
+						: requiredPositiveSafeInteger(movie.tmdbId, "Unverified Radarr peer TMDb ID"),
+				path: normalizeMediaPath(movie.path),
+				hasFile: movie.hasFile === true,
+				movieFileId: movie.movieFileId ?? null,
+				tags: [...(movie.tags ?? [])].sort((left, right) => left - right),
+			}))
+			.sort((left, right) => left.id - right.id),
+	);
+}
+
+function radarrPeerNotificationCatalogWitness(notifications: RadarrNotification[]): string {
+	return JSON.stringify(notifications.map((notification) => JSON.stringify(notification)).sort());
+}
+
+function radarrPeerFileCatalogWitness(
+	filesByMovie: ReadonlyMap<number, VerifiedRadarrFileIdentity | null>,
+): string {
+	return JSON.stringify(
+		[...filesByMovie]
+			.map(([movieId, file]) => ({
+				movieId,
+				file: file
+					? [
+							file.movieFileId,
+							file.fullPath.windows,
+							comparablePath(file.fullPath, file.fullPath.windows),
+							file.size,
+						]
+					: null,
+			}))
+			.sort((left, right) => left.movieId - right.movieId),
+	);
+}
+
+function radarrPeerMovieFileId(movie: Movie): number | null {
+	const movieFileId = movie.movieFileId;
+	if (movie.hasFile === false && typeof movieFileId === "number" && movieFileId > 0) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+	if (movie.hasFile !== false) {
+		return requiredPositiveSafeInteger(movieFileId, "Radarr peer movie file ID");
+	}
+	return null;
+}
+
+async function readRadarrPeerFilesByMovie(
+	radarr: InstanceType<typeof RadarrClient>,
+	movieCatalog: Movie[],
+): Promise<Map<number, VerifiedRadarrFileIdentity | null>> {
+	const moviesById = new Map<number, Movie>();
+	const fileOwners = new Map<number, number>();
+	for (const movie of movieCatalog) {
+		const movieId = requiredPositiveSafeInteger(movie.id, "Unverified Radarr peer movie ID");
+		if (moviesById.has(movieId)) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		moviesById.set(movieId, movie);
+		const movieFileId = radarrPeerMovieFileId(movie);
+		if (movieFileId !== null) {
+			if (fileOwners.has(movieFileId)) {
+				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			fileOwners.set(movieFileId, movieId);
+		}
+	}
+	const filesByMovie = new Map<number, VerifiedRadarrFileIdentity | null>();
+	const movies = [...moviesById.entries()];
+	let nextMovieIndex = 0;
+	await Promise.all(
+		Array.from({ length: Math.min(RADARR_PEER_FILE_READ_CONCURRENCY, movies.length) }, async () => {
+			while (nextMovieIndex < movies.length) {
+				const [movieId, movie] = movies[nextMovieIndex++]!;
+				const movieFileId = radarrPeerMovieFileId(movie);
+				if (movieFileId === null) {
+					filesByMovie.set(movieId, null);
+					continue;
+				}
+				filesByMovie.set(
+					movieId,
+					radarrFileIdentity(movie, await radarr.movieFile.getById(movieFileId), movieFileId),
+				);
+			}
+		}),
+	);
+	return filesByMovie;
+}
+
+async function readStableRadarrPeerInventory(
+	radarr: InstanceType<typeof RadarrClient>,
+	initialMovieCatalog?: Movie[],
+	initialNotifications?: RadarrNotification[],
+): Promise<StableRadarrPeerInventory> {
+	const movieCatalog = initialMovieCatalog ?? (await radarr.movie.getAll());
+	const notifications = initialNotifications ?? (await radarr.notification.getAll());
+	const firstFilesByMovie = await readRadarrPeerFilesByMovie(radarr, movieCatalog);
+	const finalFilesByMovie = await readRadarrPeerFilesByMovie(radarr, movieCatalog);
+	const [finalMovieCatalog, finalNotifications] = await Promise.all([
+		radarr.movie.getAll(),
+		radarr.notification.getAll(),
+	]);
+	if (
+		radarrPeerMovieCatalogWitness(finalMovieCatalog) !==
+			radarrPeerMovieCatalogWitness(movieCatalog) ||
+		radarrPeerNotificationCatalogWitness(finalNotifications) !==
+			radarrPeerNotificationCatalogWitness(notifications) ||
+		radarrPeerFileCatalogWitness(finalFilesByMovie) !==
+			radarrPeerFileCatalogWitness(firstFilesByMovie)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+	return {
+		movieCatalog: finalMovieCatalog,
+		notifications: finalNotifications,
+		filesByMovie: finalFilesByMovie,
+	};
+}
+
+function assertVerifiedRadarrPeerIdentityFromInventory(
+	peer: VerifiedRadarrPeerIdentity,
+	inventory: StableRadarrPeerInventory,
+): Movie | null {
+	const matchingMovies = inventory.movieCatalog.filter((movie) => movie.tmdbId === peer.externalId);
+	if (peer.arrItemId === null) {
+		if (matchingMovies.length !== 0) {
+			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		}
+		return null;
+	}
+	const movie = matchingMovies[0];
+	if (
+		matchingMovies.length !== 1 ||
+		!movie ||
+		movie.id !== peer.arrItemId ||
+		peer.mediaPath === null ||
+		!pathsEqual(normalizeMediaPath(movie.path), peer.mediaPath) ||
+		JSON.stringify(inventory.filesByMovie.get(peer.arrItemId) ?? null) !== JSON.stringify(peer.file)
+	) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
+	return movie;
+}
 
 interface StableSonarrPeerInventory {
 	seriesCatalog: Series[];
@@ -2028,6 +2235,20 @@ async function verifyPlexMediaState(
 						input.service,
 					);
 					for (const targetMatch of targetMatches) {
+						for (const peer of input.radarrUntrackedPeerFiles ?? []) {
+							const candidate = mappedRadarrPeerFileCandidate(peer, notificationUrl, true);
+							if (
+								candidate &&
+								candidate.size === targetMatch.part.size &&
+								pathsEqual(candidate.fullPath, normalizeMediaPath(targetMatch.part.file))
+							) {
+								return {
+									block: crossInstanceOwnershipReason("RADARR"),
+									ownership,
+									sonarrOwnership,
+								};
+							}
+						}
 						const targetPartKey = plexPartKey(targetMatch.part);
 						const retainedPartKeys = new Set<string>();
 						const retained: VerifiedRadarrPlexOwnership["retained"] = [];
@@ -2058,7 +2279,7 @@ async function verifyPlexMediaState(
 								}
 							}
 						}
-						if (input.radarrPeers?.length && notificationUrl) {
+						if (notificationUrl) {
 							ownership.push({
 								plexServerUrl: notificationUrl,
 								target: {
@@ -2140,7 +2361,7 @@ async function verifyPlexMediaState(
 							});
 						}
 					}
-					if (input.sonarrPeers?.length) {
+					if (notificationUrl) {
 						sonarrOwnership.push({
 							plexServerUrl: notificationUrl,
 							target: targetMatches.map((match) => ({
@@ -2249,8 +2470,7 @@ export async function findSharedPlexDeleteBlocks(
 	const radarrClients = new Map<string, InstanceType<typeof RadarrClient>>();
 	const sonarrClients = new Map<string, InstanceType<typeof SonarrClient>>();
 	const radarrNotifications = new Map<string, Promise<RadarrNotification[]>>();
-	const radarrMovies = new Map<string, Promise<Movie[]>>();
-	const radarrPeerFiles = new Map<string, Promise<VerifiedRadarrFileIdentity | null>>();
+	const radarrPeerInventories = new Map<string, Promise<StableRadarrPeerInventory>>();
 	const sonarrSeries = new Map<string, Promise<Series[]>>();
 	const sonarrNotifications = new Map<string, Promise<SonarrNotification[]>>();
 	const plexOwnerChecks = new Map<string, Promise<void>>();
@@ -2305,18 +2525,16 @@ export async function findSharedPlexDeleteBlocks(
 		return notifications;
 	};
 
-	const getRadarrMovies = (
+	const getRadarrPeerInventory = (
 		instance: ServiceInstance,
 		client: InstanceType<typeof RadarrClient>,
-		tmdbId: number,
-	): Promise<Movie[]> => {
-		const lookupKey = `${instance.id}:${tmdbId}`;
-		let movies = radarrMovies.get(lookupKey);
-		if (!movies) {
-			movies = client.movie.getAll({ tmdbId });
-			radarrMovies.set(lookupKey, movies);
+	): Promise<StableRadarrPeerInventory> => {
+		let inventory = radarrPeerInventories.get(instance.id);
+		if (!inventory) {
+			inventory = readStableRadarrPeerInventory(client);
+			radarrPeerInventories.set(instance.id, inventory);
 		}
-		return movies;
+		return inventory;
 	};
 
 	const getSonarrNotifications = (
@@ -2490,9 +2708,13 @@ export async function findSharedPlexDeleteBlocks(
 					(candidate) => candidate.id !== targetInstance.id && candidate.service === "RADARR",
 				);
 				const radarrPeers: NonNullable<PlexVerificationInput["radarrPeers"]> = [];
+				const radarrUntrackedPeerFiles: NonNullable<
+					PlexVerificationInput["radarrUntrackedPeerFiles"]
+				> = [];
 				for (const peerInstance of peerInstances) {
 					const peerClient = getRadarrClient(peerInstance);
-					const peerMovies = (await getRadarrMovies(peerInstance, peerClient, tmdbId)).filter(
+					const inventory = await getRadarrPeerInventory(peerInstance, peerClient);
+					const peerMovies = inventory.movieCatalog.filter(
 						(candidate) => candidate.tmdbId === tmdbId,
 					);
 					if (peerMovies.length > 1) {
@@ -2511,42 +2733,39 @@ export async function findSharedPlexDeleteBlocks(
 							movieTags: [],
 							notifications: [],
 						});
-						continue;
+					} else {
+						const peerMovie = peerMovies[0]!;
+						const peerMovieId = requiredPositiveSafeInteger(peerMovie.id, "Radarr peer movie ID");
+						radarrPeers.push({
+							identity: {
+								instanceId: peerInstance.id,
+								serviceFingerprint: createArrServiceFingerprint(peerInstance),
+								externalId: tmdbId,
+								arrItemId: peerMovieId,
+								mediaPath: normalizeMediaPath(peerMovie.path),
+								file: inventory.filesByMovie.get(peerMovieId) ?? null,
+							},
+							movieTags: peerMovie.tags ?? [],
+							notifications: inventory.notifications,
+						});
 					}
-					const peerMovie = peerMovies[0]!;
-					const peerMovieId = requiredPositiveSafeInteger(peerMovie.id, "Radarr peer movie ID");
-					const peerMovieFileId = peerMovie.movieFileId;
-					let peerFile: VerifiedRadarrFileIdentity | null = null;
-					if (
-						peerMovie.hasFile !== false ||
-						(typeof peerMovieFileId === "number" && peerMovieFileId > 0)
-					) {
-						const verifiedPeerFileId = requiredPositiveSafeInteger(
-							peerMovieFileId,
-							"Radarr peer movie file ID",
+					const trackedPeerMovieId = peerMovies[0]
+						? requiredPositiveSafeInteger(peerMovies[0].id, "Radarr peer movie ID")
+						: null;
+					for (const peerMovie of inventory.movieCatalog) {
+						const peerMovieId = requiredPositiveSafeInteger(
+							peerMovie.id,
+							"Unverified Radarr peer movie ID",
 						);
-						const peerFileKey = `${peerInstance.id}:${tmdbId}:${verifiedPeerFileId}`;
-						let peerFilePromise = radarrPeerFiles.get(peerFileKey);
-						if (!peerFilePromise) {
-							peerFilePromise = peerClient.movieFile
-								.getById(verifiedPeerFileId)
-								.then((file) => radarrFileIdentity(peerMovie, file, verifiedPeerFileId));
-							radarrPeerFiles.set(peerFileKey, peerFilePromise);
-						}
-						peerFile = await peerFilePromise;
-					}
-					radarrPeers.push({
-						identity: {
-							instanceId: peerInstance.id,
-							serviceFingerprint: createArrServiceFingerprint(peerInstance),
-							externalId: tmdbId,
-							arrItemId: peerMovieId,
-							mediaPath: normalizeMediaPath(peerMovie.path),
+						if (peerMovieId === trackedPeerMovieId) continue;
+						const peerFile = inventory.filesByMovie.get(peerMovieId);
+						if (!peerFile) continue;
+						radarrUntrackedPeerFiles.push({
 							file: peerFile,
-						},
-						movieTags: peerMovie.tags ?? [],
-						notifications: await getRadarrNotifications(peerInstance, peerClient),
-					});
+							movieTags: peerMovie.tags ?? [],
+							notifications: inventory.notifications,
+						});
+					}
 				}
 				const targetFile = verifiedPlan.file;
 				const verification = await verifyPlexMediaState(
@@ -2563,6 +2782,7 @@ export async function findSharedPlexDeleteBlocks(
 						externalId: tmdbId,
 						files: [comparableFile(targetFile)],
 						radarrPeers,
+						radarrUntrackedPeerFiles,
 					},
 				);
 				if (verification.block) {
@@ -2575,6 +2795,7 @@ export async function findSharedPlexDeleteBlocks(
 						target: targetIdentity,
 						file: targetFile,
 						peers: radarrPeers.map((peer) => peer.identity),
+						peerInventoryComplete: true,
 						ownership: verification.ownership,
 						targetDeleteNotifications: radarrTargetDeleteNotificationWitnesses(
 							plexNotifications,
@@ -2612,7 +2833,13 @@ export async function findSharedPlexDeleteBlocks(
 				(notification) => sonarrNotificationApplies(notification, series, action),
 			);
 			if (notifications.length === 0) {
-				if (otherInstanceMayOwnFile(targetInstance, service, verifiedFiles.episodeFiles.length)) {
+				if (
+					otherInstanceMayOwnFile(
+						targetInstance,
+						service,
+						verifiedFiles.episodeFiles.length > 0 || action === "delete" ? 1 : 0,
+					)
+				) {
 					const reason = crossInstanceOwnershipReason(service);
 					blocks.set(targetKey, reason);
 					context.plans.set(targetKey, { kind: "blocked", reason });
@@ -2824,6 +3051,7 @@ export async function findSharedPlexDeleteBlocks(
 				target: pending.targetIdentity,
 				files: pending.verifiedFiles,
 				peers: pending.peers.map((peer) => peer.identity),
+				peerInventoryComplete: true,
 				ownership: pending.ownership,
 				targetDeleteNotifications: pending.targetDeleteNotifications,
 			});
@@ -2863,6 +3091,9 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 	targetArrItemId: number,
 	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
 ): Promise<void> {
+	if (plan.peerInventoryComplete !== true) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+	}
 	const [arrInstances, plexInstances] = await Promise.all([
 		deps.prisma.serviceInstance.findMany({
 			where: { userId, service: { in: ["RADARR", "SONARR"] } },
@@ -2907,40 +3138,37 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 	}
 
 	const livePeers = new Map<string, NonNullable<PlexVerificationInput["radarrPeers"]>[number]>();
+	const untrackedPeerFiles: NonNullable<PlexVerificationInput["radarrUntrackedPeerFiles"]> = [];
 	for (const peer of plan.peers) {
 		const peerInstance = peerInstances.find((instance) => instance.id === peer.instanceId);
 		if (!peerInstance || createArrServiceFingerprint(peerInstance) !== peer.serviceFingerprint) {
 			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
 		}
 		const client = deps.arrClientFactory.create(peerInstance) as InstanceType<typeof RadarrClient>;
-		const movies = (await client.movie.getAll({ tmdbId: peer.externalId })).filter(
-			(movie) => movie.tmdbId === peer.externalId,
-		);
-		if (peer.arrItemId === null) {
-			if (movies.length !== 0) {
-				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
-			}
-			continue;
+		const inventory = await readStableRadarrPeerInventory(client);
+		const movie = assertVerifiedRadarrPeerIdentityFromInventory(peer, inventory);
+		const trackedMovieId = peer.arrItemId;
+		for (const catalogMovie of inventory.movieCatalog) {
+			const movieId = requiredPositiveSafeInteger(
+				catalogMovie.id,
+				"Unverified Radarr peer movie ID",
+			);
+			if (movieId === trackedMovieId) continue;
+			const file = inventory.filesByMovie.get(movieId);
+			if (!file) continue;
+			untrackedPeerFiles.push({
+				file,
+				movieTags: catalogMovie.tags ?? [],
+				notifications: inventory.notifications,
+			});
 		}
-		const movie = movies[0];
-		if (movies.length !== 1 || !movie || movie.id !== peer.arrItemId || peer.mediaPath === null) {
-			throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+		if (movie) {
+			livePeers.set(peer.instanceId, {
+				identity: peer,
+				movieTags: movie.tags ?? [],
+				notifications: inventory.notifications,
+			});
 		}
-		const peerTarget: VerifiedArrTargetIdentity = {
-			serviceFingerprint: peer.serviceFingerprint,
-			externalId: peer.externalId,
-			mediaPath: peer.mediaPath,
-		};
-		if (peer.file) {
-			await assertVerifiedRadarrFileUnchanged(client, peer.arrItemId, peerTarget, peer.file);
-		} else {
-			await assertVerifiedRadarrEmptyUnchanged(client, peer.arrItemId, peerTarget);
-		}
-		livePeers.set(peer.instanceId, {
-			identity: peer,
-			movieTags: movie.tags ?? [],
-			notifications: await client.notification.getAll(),
-		});
 	}
 
 	const context = createSharedPlexSafetyContext();
@@ -2954,12 +3182,31 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 		}
 		for (const plexInstance of matchingPlexInstances) {
 			const plex = await requirePlexClient(deps, context, ownerChecks, plexInstance);
-			const mediaItems = await plex.getMovieMediaPartsByTmdbId(plan.target.externalId);
+			let mediaItems: PlexMovieMediaItem[];
+			try {
+				mediaItems = await plex.getMovieMediaPartsByTmdbId(plan.target.externalId);
+			} catch (error) {
+				if (error instanceof PlexMovieNotFoundError && ownership.retained.length === 0) {
+					mediaItems = [];
+				} else {
+					throw error;
+				}
+			}
 			const targetItems = mediaItems.filter(
 				(item) => item.ratingKey === ownership.target.ratingKey,
 			);
 			if (targetItems.length > 1) {
 				throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+			}
+			for (const peer of untrackedPeerFiles) {
+				const candidate = mappedRadarrPeerFileCandidate(peer, ownership.plexServerUrl, true);
+				if (
+					candidate &&
+					candidate.size === ownership.target.size &&
+					pathsEqual(candidate.fullPath, ownership.target.fullPath)
+				) {
+					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
+				}
 			}
 			for (const expected of ownership.retained) {
 				const peer = livePeers.get(expected.instanceId);
@@ -2975,21 +3222,28 @@ export async function assertVerifiedRadarrPeerOwnershipRetained(
 					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
 				}
 			}
-			const currentTargetItem = targetItems[0];
-			if (currentTargetItem) {
-				const allowedTargetItemParts = new Set([
+			const allowedPartsByRatingKey = new Map<string, Set<string>>();
+			allowedPartsByRatingKey.set(
+				ownership.target.ratingKey,
+				new Set([
 					plexPartKey({
 						file: ownership.target.fullPath.value,
 						size: ownership.target.size,
 					}),
-					...ownership.retained
-						.filter((expected) => expected.ratingKey === ownership.target.ratingKey)
-						.map((expected) => plexPartKey({ file: expected.fullPath.value, size: expected.size })),
-				]);
-				const currentTargetItemPartKeys = currentTargetItem.parts.map(plexPartKey);
+				]),
+			);
+			for (const retained of ownership.retained) {
+				const allowedParts = allowedPartsByRatingKey.get(retained.ratingKey) ?? new Set<string>();
+				allowedParts.add(plexPartKey({ file: retained.fullPath.value, size: retained.size }));
+				allowedPartsByRatingKey.set(retained.ratingKey, allowedParts);
+			}
+			for (const item of mediaItems) {
+				const allowedParts = allowedPartsByRatingKey.get(item.ratingKey);
+				const partKeys = item.parts.map(plexPartKey);
 				if (
-					new Set(currentTargetItemPartKeys).size !== currentTargetItemPartKeys.length ||
-					currentTargetItemPartKeys.some((partKey) => !allowedTargetItemParts.has(partKey))
+					!allowedParts ||
+					new Set(partKeys).size !== partKeys.length ||
+					partKeys.some((partKey) => !allowedParts.has(partKey))
 				) {
 					throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("RADARR");
 				}
@@ -3010,6 +3264,9 @@ export async function assertVerifiedSonarrPeerOwnershipRetained(
 	targetArrItemId: number,
 	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
 ): Promise<void> {
+	if (plan.peerInventoryComplete !== true) {
+		throw new ArrCrossInstanceOwnershipChangedDuringSafetyCheckError("SONARR");
+	}
 	const [arrInstances, plexInstances] = await Promise.all([
 		deps.prisma.serviceInstance.findMany({
 			where: { userId, service: { in: ["RADARR", "SONARR"] } },

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -77,6 +77,13 @@ export interface PlexSeriesMediaItem {
 	episodes: PlexEpisodeMediaItem[];
 }
 
+export class PlexSeriesNotFoundError extends Error {
+	constructor(tvdbId: number) {
+		super(`Plex returned no series item for TVDB ${tvdbId}`);
+		this.name = "PlexSeriesNotFoundError";
+	}
+}
+
 export interface PlexHistoryItem {
 	ratingKey: string;
 	parentRatingKey?: string;
@@ -349,7 +356,7 @@ export class PlexClient {
 			(item) => item.type === "show" && item.Guid?.some((guid) => guid.id === `tvdb://${tvdbId}`),
 		);
 		if (exactShows.length === 0) {
-			throw new Error(`Plex returned no series item for TVDB ${tvdbId}`);
+			throw new PlexSeriesNotFoundError(tvdbId);
 		}
 
 		const seriesItems = await Promise.all(

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -77,6 +77,13 @@ export interface PlexSeriesMediaItem {
 	episodes: PlexEpisodeMediaItem[];
 }
 
+export class PlexMovieNotFoundError extends Error {
+	constructor(tmdbId: number) {
+		super(`Plex returned no movie item for TMDb ${tmdbId}`);
+		this.name = "PlexMovieNotFoundError";
+	}
+}
+
 export class PlexSeriesNotFoundError extends Error {
 	constructor(tvdbId: number) {
 		super(`Plex returned no series item for TVDB ${tvdbId}`);
@@ -322,7 +329,7 @@ export class PlexClient {
 			item.Guid?.some((guid) => guid.id === `tmdb://${tmdbId}`),
 		);
 		if (items.length === 0) {
-			throw new Error(`Plex returned no movie item for TMDb ${tmdbId}`);
+			throw new PlexMovieNotFoundError(tmdbId);
 		}
 
 		return items.map((item) => {


### PR DESCRIPTION
## Summary

- forward-port the retained Radarr variant and shared Sonarr ownership proofs from #656 and #658
- bind deletion plans to complete peer inventories, exact ARR file identities, Plex ownership, and current notification mappings
- revalidate peer topology and ownership both before exact-file deletion and before removing the now-empty ARR record
- accept the real normalized Radarr cache shape by reconstructing `path + movieFile.relativePath`

## Safety behavior

Cleanup now fails closed when a sibling ARR instance appears, disappears, changes connection identity, imports a conflicting file, or changes its media-server notification mapping during verification. After exact-file deletion, any changed retained ownership leaves the ARR record intact in an honest partial/retryable state.

Terminal inventory and notification reads are shared per instance across a planning batch so the stronger proof does not multiply upstream calls per target.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 2,765 passed; web 664 passed; shared 106 passed)
- `pnpm run lint`
- `pnpm run build`
- focused shared-Plex suites: 249 passed
- independent regression review: no remaining frozen findings
- independent data-safety review: no remaining mutation-boundary findings

No live destructive test was run against a real two-Radarr shared-Plex library. The automated coverage reproduces the reported ownership, topology, file-replacement, notification-change, partial-completion, and retry boundaries.

Related to #616
Related to #659