### PR TITLE
fix(cleanup): fail closed on incomplete external evidence

### DIFF
--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -74,6 +74,8 @@ function makeMockPrisma() {
 				upserts.push(args);
 				return Promise.resolve({});
 			}),
+			findMany: vi.fn().mockResolvedValue([]),
+			deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 		},
 		$transaction: vi.fn(async (ops: unknown[]) => {
 			for (const op of ops) await op;
@@ -170,5 +172,36 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(upserts).toHaveLength(1);
 		const payload = (upserts[0] as { create: { lastWatchedAt: Date | null } }).create;
 		expect(payload.lastWatchedAt).toEqual(new Date("2024-06-20T22:00:00Z"));
+	});
+
+	it("evicts stale rows when a complete refresh finds no media libraries", async () => {
+		const client = {
+			...makeMockClient([]),
+			getLibraries: vi.fn().mockResolvedValue([]),
+		} as unknown as JellyfinClient;
+		const { stub } = makeMockPrisma();
+		stub.jellyfinCache.findMany.mockResolvedValue([
+			{ id: "stale-1", tmdbId: 1, mediaType: "series", libraryId: "old-lib" },
+		]);
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result.errors).toBe(0);
+		expect(stub.jellyfinCache.deleteMany).toHaveBeenCalledWith({
+			where: { id: { in: ["stale-1"] } },
+		});
+	});
+
+	it("reports missing users as incomplete instead of authorizing an empty cache", async () => {
+		const client = {
+			...makeMockClient([]),
+			getUsers: vi.fn().mockResolvedValue([]),
+		} as unknown as JellyfinClient;
+		const { stub } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result.errors).toBe(1);
+		expect(stub.jellyfinCache.deleteMany).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -192,6 +192,36 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		});
 	});
 
+	it("discovers libraries visible only to a later Jellyfin user", async () => {
+		const restrictedUser = { id: "user-restricted", name: "Restricted" };
+		const libraryUser = { id: "user-library", name: "Library User" };
+		const client = {
+			...makeMockClient([]),
+			getUsers: vi.fn().mockResolvedValue([restrictedUser, libraryUser]),
+			getLibraries: vi.fn(async (userId: string) =>
+				userId === restrictedUser.id ? [] : oneLibrary,
+			),
+			getLibraryItems: vi.fn().mockResolvedValue([makeSeriesItem()]),
+		} as unknown as JellyfinClient;
+		const { stub, upserts } = makeMockPrisma();
+		stub.jellyfinCache.findMany.mockResolvedValue([
+			{ id: "stale-1", tmdbId: 1, mediaType: "series", libraryId: "old-lib" },
+		]);
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ upserted: 1, errors: 0 });
+		expect(client.getLibraries).toHaveBeenCalledWith(restrictedUser.id);
+		expect(client.getLibraries).toHaveBeenCalledWith(libraryUser.id);
+		expect(client.getLibraryItems).toHaveBeenCalledWith(libraryUser.id, "lib-1", {
+			includeItemTypes: "Series",
+		});
+		expect(upserts).toHaveLength(1);
+		expect(stub.jellyfinCache.deleteMany).toHaveBeenCalledWith({
+			where: { id: { in: ["stale-1"] } },
+		});
+	});
+
 	it("reports missing users as incomplete instead of authorizing an empty cache", async () => {
 		const client = {
 			...makeMockClient([]),

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -59,7 +59,11 @@ export async function refreshJellyfinCache(
 		const users = await client.getUsers();
 		if (users.length === 0) {
 			log.warn({ instanceId }, "Jellyfin cache refresh: no users found");
-			return { upserted: 0, errors: 0, errorMessages: [] };
+			return {
+				upserted: 0,
+				errors: 1,
+				errorMessages: ["Jellyfin returned no users, so cache completeness could not be verified"],
+			};
 		}
 
 		// Use the first user (admin) for library enumeration
@@ -76,7 +80,6 @@ export async function refreshJellyfinCache(
 
 		if (mediaLibraries.length === 0) {
 			log.info({ instanceId }, "Jellyfin cache refresh: no movie/TV libraries found");
-			return { upserted: 0, errors: 0, errorMessages: [] };
 		}
 
 		// Step 3: Aggregate items across all users
@@ -250,12 +253,17 @@ export async function refreshJellyfinCache(
 					.map((row) => row.id);
 
 				if (staleIds.length > 0) {
-					await prisma.jellyfinCache.deleteMany({
-						where: { id: { in: staleIds } },
-					});
+					const DELETE_BATCH_SIZE = 500;
+					for (let i = 0; i < staleIds.length; i += DELETE_BATCH_SIZE) {
+						await prisma.jellyfinCache.deleteMany({
+							where: { id: { in: staleIds.slice(i, i + DELETE_BATCH_SIZE) } },
+						});
+					}
 					log.info({ instanceId, evicted: staleIds.length }, "Evicted stale Jellyfin cache rows");
 				}
 			} catch (err) {
+				errors++;
+				errorMessages.push(`Stale row eviction failed: ${getErrorMessage(err, "unknown")}`);
 				log.warn({ err, instanceId }, "Failed to evict stale Jellyfin cache rows");
 			}
 		}

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -66,34 +66,51 @@ export async function refreshJellyfinCache(
 			};
 		}
 
-		// Use the first user (admin) for library enumeration
-		const primaryUserId = users[0]!.id;
+		// Step 2: Enumerate each user's visible media libraries. The first
+		// returned user is not guaranteed to be an administrator, so using only
+		// that account can make a populated server look empty.
+		const mediaLibrariesByUser = new Map<
+			string,
+			Awaited<ReturnType<JellyfinClient["getLibraries"]>>
+		>();
+		for (const user of users) {
+			try {
+				const libraries = await client.getLibraries(user.id);
+				mediaLibrariesByUser.set(
+					user.id,
+					libraries.filter(
+						(lib) =>
+							lib.collectionType === "movies" ||
+							lib.collectionType === "tvshows" ||
+							lib.collectionType === "CollectionFolder",
+					),
+				);
+			} catch (err) {
+				errors++;
+				const message = `Library enumeration failed for user ${user.name}: ${getErrorMessage(err, "unknown")}`;
+				errorMessages.push(message);
+				log.warn({ err, instanceId, userId: user.id }, message);
+			}
+		}
+		const mediaLibraryCount = new Set(
+			[...mediaLibrariesByUser.values()].flat().map((library) => library.id),
+		).size;
 
-		// Step 2: Get libraries and filter to movie/tvshow
-		const libraries = await client.getLibraries(primaryUserId);
-		const mediaLibraries = libraries.filter(
-			(lib) =>
-				lib.collectionType === "movies" ||
-				lib.collectionType === "tvshows" ||
-				lib.collectionType === "CollectionFolder",
-		);
-
-		if (mediaLibraries.length === 0) {
+		if (mediaLibraryCount === 0) {
 			log.info({ instanceId }, "Jellyfin cache refresh: no movie/TV libraries found");
 		}
 
 		// Step 3: Aggregate items across all users
 		const aggregations = new Map<string, ItemAggregation>();
 
-		for (const library of mediaLibraries) {
-			const includeItemTypes =
-				library.collectionType === "movies"
-					? "Movie"
-					: library.collectionType === "tvshows"
-						? "Series"
-						: "Movie,Series"; // CollectionFolder or unknown — fetch both
-
-			for (const user of users) {
+		for (const user of users) {
+			for (const library of mediaLibrariesByUser.get(user.id) ?? []) {
+				const includeItemTypes =
+					library.collectionType === "movies"
+						? "Movie"
+						: library.collectionType === "tvshows"
+							? "Series"
+							: "Movie,Series"; // CollectionFolder or unknown — fetch both
 				try {
 					const items = await client.getLibraryItems(user.id, library.id, {
 						includeItemTypes,
@@ -158,23 +175,28 @@ export async function refreshJellyfinCache(
 			}
 		}
 
-		// Step 4: Get resume items to mark onDeck
-		try {
-			const resumeItems = await client.getResumeItems(primaryUserId);
-			const nextUp = await client.getNextUp(primaryUserId);
-			const onDeckIds = new Set([
-				...resumeItems.map((i) => i.tmdbId).filter(Boolean),
-				...nextUp.map((i) => i.tmdbId).filter(Boolean),
-			]);
-			for (const agg of aggregations.values()) {
-				if (onDeckIds.has(agg.tmdbId)) {
-					agg.onDeck = true;
+		// Step 4: Aggregate resume/next-up state across every user.
+		const onDeckIds = new Set<number>();
+		for (const user of users) {
+			try {
+				const resumeItems = await client.getResumeItems(user.id);
+				const nextUp = await client.getNextUp(user.id);
+				for (const item of [...resumeItems, ...nextUp]) {
+					if (item.tmdbId) onDeckIds.add(item.tmdbId);
 				}
+			} catch (err) {
+				errors++;
+				errorMessages.push(
+					`Resume/NextUp fetch failed for user ${user.name}: ${getErrorMessage(err, "unknown")}`,
+				);
+				log.warn(
+					{ err, instanceId, userId: user.id },
+					"Failed to fetch Jellyfin resume/nextUp for onDeck status",
+				);
 			}
-		} catch (err) {
-			errors++;
-			errorMessages.push(`Resume/NextUp fetch failed: ${getErrorMessage(err, "unknown")}`);
-			log.warn({ err, instanceId }, "Failed to fetch Jellyfin resume/nextUp for onDeck status");
+		}
+		for (const agg of aggregations.values()) {
+			if (onDeckIds.has(agg.tmdbId)) agg.onDeck = true;
 		}
 
 		// Step 5: Upsert into JellyfinCache in batches

--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-deps.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-deps.test.ts
@@ -31,6 +31,7 @@ describe("library cleanup scheduler dependencies", () => {
 	it("passes complete qUI mutation-boundary factories to scheduled execution", async () => {
 		const quiClientFactory = vi.fn();
 		const quiFileHashIndexFactory = vi.fn();
+		const externalRuleCacheRefresher = vi.fn();
 		const prisma = {
 			libraryCleanupApproval: {
 				updateMany: vi.fn().mockResolvedValue({ count: 0 }),
@@ -53,7 +54,7 @@ describe("library cleanup scheduler dependencies", () => {
 			{} as never,
 			{ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
 			undefined,
-			{ quiClientFactory, quiFileHashIndexFactory } as never,
+			{ quiClientFactory, quiFileHashIndexFactory, externalRuleCacheRefresher } as never,
 		);
 
 		await (
@@ -63,7 +64,11 @@ describe("library cleanup scheduler dependencies", () => {
 		).checkAndRun();
 
 		expect(executorMocks.executeCleanupRun).toHaveBeenCalledWith(
-			expect.objectContaining({ quiClientFactory, quiFileHashIndexFactory }),
+			expect.objectContaining({
+				quiClientFactory,
+				quiFileHashIndexFactory,
+				externalRuleCacheRefresher,
+			}),
 			"user-1",
 		);
 	});

--- a/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
@@ -1,0 +1,129 @@
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import { buildEvalContext, prefetchSeerrRequests } from "../cleanup-executor.js";
+import type { CleanupExecutorDeps } from "../types.js";
+
+const log = {
+	child: vi.fn().mockReturnThis(),
+	info: vi.fn(),
+	warn: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+function seerrInstance(id: string) {
+	return {
+		id,
+		baseUrl: `http://${id}.internal`,
+		encryptedApiKey: "encrypted-key",
+		encryptionIv: "iv",
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
+		service: "SEERR",
+		label: id,
+	};
+}
+
+function seerrRequest(id: number, tmdbId: number) {
+	const timestamp = "2026-08-13T12:00:00.000Z";
+	return {
+		id,
+		status: 2,
+		type: "tv",
+		media: {
+			id,
+			tmdbId,
+			status: 5,
+			createdAt: timestamp,
+			updatedAt: timestamp,
+		},
+		createdAt: timestamp,
+		updatedAt: timestamp,
+		requestedBy: {
+			id: 1,
+			displayName: "Owner",
+			createdAt: timestamp,
+			updatedAt: timestamp,
+			permissions: 0,
+			requestCount: 1,
+			userType: 1,
+		},
+		is4k: false,
+	};
+}
+
+describe("external parent-rule authority", () => {
+	it.each(["plex_episode_completion", "jellyfin_episode_completion"])(
+		"does not treat an unconfigured %s provider as complete evidence",
+		async (ruleType) => {
+			const prisma = {
+				serviceInstance: { findMany: vi.fn().mockResolvedValue([]) },
+				plexEpisodeCache: { groupBy: vi.fn() },
+				jellyfinEpisodeCache: { groupBy: vi.fn() },
+				plexCache: { findMany: vi.fn() },
+			} as unknown as CleanupExecutorDeps["prisma"];
+
+			const context = await buildEvalContext(
+				{ prisma, arrClientFactory: {} as never, log } as CleanupExecutorDeps,
+				"user-1",
+				[{ enabled: true, ruleType, conditions: null }],
+				{ destructiveAuthority: true },
+			);
+
+			expect(context.plexEpisodeMap).toBeUndefined();
+			expect(context.jellyfinEpisodeMap).toBeUndefined();
+			expect(prisma.plexEpisodeCache.groupBy).not.toHaveBeenCalled();
+			expect(prisma.jellyfinEpisodeCache.groupBy).not.toHaveBeenCalled();
+		},
+	);
+
+	it("combines complete request evidence from every enabled Seerr instance", async () => {
+		const instances = [seerrInstance("seerr-a"), seerrInstance("seerr-b")];
+		const rawRequest = vi.fn(async (instance: { id: string }) => {
+			const tmdbId = instance.id === "seerr-a" ? 101 : 202;
+			return Response.json({
+				pageInfo: { pages: 1, pageSize: 50, results: 1, page: 1 },
+				results: [seerrRequest(tmdbId, tmdbId)],
+			});
+		});
+		const deps = {
+			prisma: {
+				serviceInstance: { findMany: vi.fn().mockResolvedValue(instances) },
+			},
+			arrClientFactory: { rawRequest },
+			log,
+		} as unknown as CleanupExecutorDeps;
+
+		const result = await prefetchSeerrRequests(deps, "user-1");
+
+		expect(result?.has("tv:101")).toBe(true);
+		expect(result?.has("tv:202")).toBe(true);
+		expect(rawRequest).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects Seerr evidence when pagination reaches the safety cap", async () => {
+		const rawRequest = vi.fn(async (_instance: unknown, path: string) => {
+			const skip = Number(new URL(path, "http://seerr.invalid").searchParams.get("skip") ?? 0);
+			return Response.json({
+				pageInfo: { pages: 101, pageSize: 50, results: 5_050, page: skip / 50 + 1 },
+				results: Array.from({ length: 50 }, (_, index) =>
+					seerrRequest(skip + index + 1, skip + index + 1),
+				),
+			});
+		});
+		const deps = {
+			prisma: {
+				serviceInstance: {
+					findMany: vi.fn().mockResolvedValue([seerrInstance("seerr-a")]),
+				},
+			},
+			arrClientFactory: { rawRequest },
+			log,
+		} as unknown as CleanupExecutorDeps;
+
+		await expect(prefetchSeerrRequests(deps, "user-1")).resolves.toBeUndefined();
+		expect(rawRequest).toHaveBeenCalledTimes(100);
+	});
+});

--- a/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
@@ -103,14 +103,11 @@ describe("external parent-rule authority", () => {
 		expect(rawRequest).toHaveBeenCalledTimes(2);
 	});
 
-	it("rejects Seerr evidence when pagination reaches the safety cap", async () => {
-		const rawRequest = vi.fn(async (_instance: unknown, path: string) => {
-			const skip = Number(new URL(path, "http://seerr.invalid").searchParams.get("skip") ?? 0);
+	it("rejects Seerr evidence above the bounded snapshot limit", async () => {
+		const rawRequest = vi.fn(async () => {
 			return Response.json({
-				pageInfo: { pages: 101, pageSize: 50, results: 5_050, page: skip / 50 + 1 },
-				results: Array.from({ length: 50 }, (_, index) =>
-					seerrRequest(skip + index + 1, skip + index + 1),
-				),
+				pageInfo: { pages: 2, pageSize: 5_001, results: 5_050, page: 1 },
+				results: Array.from({ length: 5_001 }, (_, index) => seerrRequest(index + 1, index + 1)),
 			});
 		});
 		const deps = {
@@ -124,6 +121,52 @@ describe("external parent-rule authority", () => {
 		} as unknown as CleanupExecutorDeps;
 
 		await expect(prefetchSeerrRequests(deps, "user-1")).resolves.toBeUndefined();
-		expect(rawRequest).toHaveBeenCalledTimes(100);
+		expect(rawRequest).toHaveBeenCalledOnce();
+	});
+
+	it("accepts complete Seerr evidence with exactly 5,000 requests", async () => {
+		const rawRequest = vi.fn(async () => {
+			return Response.json({
+				pageInfo: { pages: 1, pageSize: 5_001, results: 5_000, page: 1 },
+				results: Array.from({ length: 5_000 }, (_, index) => seerrRequest(index + 1, index + 1)),
+			});
+		});
+		const deps = {
+			prisma: {
+				serviceInstance: {
+					findMany: vi.fn().mockResolvedValue([seerrInstance("seerr-a")]),
+				},
+			},
+			arrClientFactory: { rawRequest },
+			log,
+		} as unknown as CleanupExecutorDeps;
+
+		const result = await prefetchSeerrRequests(deps, "user-1");
+
+		expect(result).toHaveLength(5_000);
+		expect(result?.has("tv:1")).toBe(true);
+		expect(result?.has("tv:5000")).toBe(true);
+		expect(rawRequest).toHaveBeenCalledOnce();
+	});
+
+	it("rejects an incomplete Seerr snapshot", async () => {
+		const rawRequest = vi.fn(async () => {
+			return Response.json({
+				pageInfo: { pages: 1, pageSize: 5_001, results: 5_000, page: 1 },
+				results: Array.from({ length: 4_999 }, (_, index) => seerrRequest(index + 1, index + 1)),
+			});
+		});
+		const deps = {
+			prisma: {
+				serviceInstance: {
+					findMany: vi.fn().mockResolvedValue([seerrInstance("seerr-a")]),
+				},
+			},
+			arrClientFactory: { rawRequest },
+			log,
+		} as unknown as CleanupExecutorDeps;
+
+		await expect(prefetchSeerrRequests(deps, "user-1")).resolves.toBeUndefined();
+		expect(rawRequest).toHaveBeenCalledOnce();
 	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -2492,6 +2492,81 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
 
+	it("rechecks parent Plex evidence after unmonitoring and before file deletion", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		let parentMatches = false;
+		let refreshCount = 0;
+		vi.mocked(fixture.deps.externalRuleCacheRefresher!).mockImplementation(async () => {
+			refreshCount++;
+			if (refreshCount >= 3) parentMatches = true;
+		});
+		vi.mocked(fixture.deps.prisma.plexCache.findMany).mockImplementation(
+			(args) =>
+				Promise.resolve(
+					args?.cursor
+						? []
+						: [
+								{
+									id: "plex-series-456",
+									tmdbId: 456,
+									mediaType: "series",
+									sectionId: "tv",
+									sectionTitle: "TV",
+									lastWatchedAt: new Date(),
+									watchCount: parentMatches ? 20 : 0,
+									watchedByUsers: "[]",
+									onDeck: false,
+									userRating: null,
+									collections: "[]",
+									labels: "[]",
+									addedAt: null,
+								},
+							],
+				) as never,
+		);
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			id: "config-1",
+			respectQuiSeeding: true,
+			rules: [
+				{
+					...episodeCleanupRule(),
+					id: "parent-plex-rule",
+					priority: 0,
+					targetScope: "series",
+					ruleType: "plex_watch_count",
+					parameters: JSON.stringify({ operator: "greater_than", count: 10 }),
+				},
+				episodeCleanupRule(),
+			],
+		} as never);
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(refreshCount).toBeGreaterThanOrEqual(3);
+	});
+
 	it.each(["matches", "unavailable"] as const)(
 		"blocks an episode when current parent Plex evidence %s",
 		async (mode) => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -360,6 +360,9 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 					sourceFingerprint: plexConnectionFingerprint(plexInstance),
 				}),
 			},
+			plexCache: {
+				findMany: vi.fn().mockResolvedValue([]),
+			},
 			libraryCleanupLog: {
 				create: vi.fn().mockResolvedValue({}),
 			},
@@ -2421,6 +2424,129 @@ describe("verified Sonarr mutation handoff", () => {
 			expect(storedApproval).toMatchObject({ status: "expired" });
 			expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
 			expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		},
+	);
+
+	it("executes an episode when a current parent Plex rule is proven not to match", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			id: "config-1",
+			respectQuiSeeding: true,
+			rules: [
+				{
+					...episodeCleanupRule(),
+					id: "parent-plex-rule",
+					priority: 0,
+					targetScope: "series",
+					ruleType: "plex_watch_count",
+					parameters: JSON.stringify({ operator: "greater_than", count: 10 }),
+				},
+				episodeCleanupRule(),
+			],
+		} as never);
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		await expect(executeApprovedItems(fixture.deps, "user-1", ["approval-1"])).resolves.toEqual({
+			removed: 1,
+			failed: 0,
+			errors: [],
+		});
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
+	it.each(["matches", "unavailable"] as const)(
+		"blocks an episode when current parent Plex evidence %s",
+		async (mode) => {
+			const fixture = makeSonarrDeps();
+			const episodeTarget = exactEpisodeTarget();
+			const context = createSharedPlexSafetyContext();
+			await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+			const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+			if (plan?.kind !== "verified_sonarr_episode") {
+				throw new Error("Expected verified Sonarr episode plan");
+			}
+			const plexFindMany = vi.mocked(fixture.deps.prisma.plexCache.findMany);
+			if (mode === "matches") {
+				plexFindMany.mockImplementation(
+					(args) =>
+						Promise.resolve(
+							args?.cursor
+								? []
+								: [
+										{
+											id: "plex-series-456",
+											tmdbId: 456,
+											mediaType: "series",
+											sectionId: "tv",
+											sectionTitle: "TV",
+											lastWatchedAt: new Date(),
+											watchCount: 20,
+											watchedByUsers: "[]",
+											onDeck: false,
+											userRating: null,
+											collections: "[]",
+											labels: "[]",
+											addedAt: null,
+										},
+									],
+						) as never,
+				);
+			} else {
+				plexFindMany.mockRejectedValue(new Error("Plex evidence unavailable"));
+			}
+			vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+				id: "config-1",
+				respectQuiSeeding: true,
+				rules: [
+					{
+						...episodeCleanupRule(),
+						id: "parent-plex-rule",
+						priority: 0,
+						targetScope: "series",
+						ruleType: "plex_watch_count",
+						parameters: JSON.stringify({ operator: "greater_than", count: 10 }),
+					},
+					episodeCleanupRule(),
+				],
+			} as never);
+			const storedApproval = {
+				...approval(),
+				targetScope: "episode",
+				arrEpisodeId: 9_001,
+				seasonNumber: 1,
+				episodeNumber: 1,
+				episodeTitle: "Episode 1",
+				matchedRuleId: "episode-rule",
+				matchedRuleName: "Remove watched episodes",
+				safetySnapshot: serializeExecutableSafetyPlan(plan),
+			} as unknown as Record<string, unknown>;
+			configureApprovalStore(fixture.deps, storedApproval);
+
+			const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+			expect(result).toMatchObject({ removed: 0, failed: 1 });
+			expect(storedApproval).toMatchObject({ status: "expired" });
+			expect(fixture.bulkDelete).not.toHaveBeenCalled();
+			expect(fixture.deleteSeries).not.toHaveBeenCalled();
 		},
 	);
 

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -375,6 +375,12 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 			plexCache: {
 				findMany: vi.fn().mockResolvedValue([]),
 			},
+			tmdbListCache: {
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+			traktListCache: {
+				findMany: vi.fn().mockResolvedValue([]),
+			},
 			libraryCleanupLog: {
 				create: vi.fn().mockResolvedValue({}),
 			},
@@ -2684,6 +2690,54 @@ describe("verified Sonarr mutation handoff", () => {
 		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
 
 		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("blocks an episode when a parent list rule has only cached non-match evidence", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		vi.mocked(fixture.deps.prisma.tmdbListCache.findMany).mockResolvedValue([
+			{ listId: "8068", tmdbId: 999 },
+		] as never);
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			id: "config-1",
+			respectQuiSeeding: true,
+			rules: [
+				{
+					...episodeCleanupRule(),
+					id: "parent-list-rule",
+					priority: 0,
+					targetScope: "series",
+					ruleType: "tmdb_list_member",
+					parameters: JSON.stringify({ listId: "8068", operator: "is_in" }),
+				},
+				episodeCleanupRule(),
+			],
+		} as never);
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({ status: "expired" });
+		expect(fixture.deps.prisma.tmdbListCache.findMany).toHaveBeenCalled();
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -303,13 +303,16 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 				updateMany: cleanupConfigUpdateMany,
 			},
 			serviceInstance: {
-				findMany: vi.fn(({ where }: { where: { service: string } }) =>
-					where.service === "PLEX"
-						? Promise.resolve([plexInstance])
-						: where.service === "QUI"
-							? Promise.resolve([quiInstance])
-							: Promise.resolve([targetInstance]),
-				),
+				findMany: vi.fn(({ where }: { where: { service?: string | { in?: string[] } } }) => {
+					const services =
+						typeof where.service === "string" ? [where.service] : (where.service?.in ?? []);
+					if (services.includes("PLEX")) return Promise.resolve([plexInstance]);
+					if (services.includes("QUI")) return Promise.resolve([quiInstance]);
+					if (services.includes("SEERR")) return Promise.resolve([]);
+					if (services.includes("JELLYFIN") || services.includes("EMBY"))
+						return Promise.resolve([]);
+					return Promise.resolve([targetInstance]);
+				}),
 				findFirst: vi.fn().mockResolvedValue(targetInstance),
 			},
 			crossDomainRule: {
@@ -344,6 +347,15 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 				deleteMany: episodeFileCacheDeleteMany,
 			},
 			plexEpisodeCache: {
+				groupBy: vi
+					.fn()
+					.mockImplementation(({ where }: { where: { watched?: boolean } }) =>
+						Promise.resolve(
+							where.watched
+								? [{ showTmdbId: 456, seasonNumber: 1, _count: { id: 1 } }]
+								: [{ showTmdbId: 456, seasonNumber: 1, _count: { id: 2 } }],
+						),
+					),
 				findMany: vi.fn().mockImplementation((({ where }: { where: { episodeNumber: number } }) =>
 					Promise.resolve([
 						{
@@ -377,6 +389,7 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		quiFileHashIndexFactory: vi.fn().mockResolvedValue({
 			resolve: vi.fn().mockResolvedValue({ hashes: ["episode-hash"], complete: true }),
 		}),
+		externalRuleCacheRefresher: vi.fn().mockResolvedValue(undefined),
 		log: silentLog,
 	};
 
@@ -2469,6 +2482,12 @@ describe("verified Sonarr mutation handoff", () => {
 			failed: 0,
 			errors: [],
 		});
+		const evidenceRefresher = vi.mocked(fixture.deps.externalRuleCacheRefresher!);
+		const plexFindMany = vi.mocked(fixture.deps.prisma.plexCache.findMany);
+		expect(evidenceRefresher).toHaveBeenCalledWith("plex", fixture.plexInstance);
+		expect(evidenceRefresher.mock.invocationCallOrder[0]).toBeLessThan(
+			plexFindMany.mock.invocationCallOrder[0]!,
+		);
 		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
 		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
@@ -2549,6 +2568,49 @@ describe("verified Sonarr mutation handoff", () => {
 			expect(fixture.deleteSeries).not.toHaveBeenCalled();
 		},
 	);
+
+	it("blocks an episode when a parent episode-completion rule cannot be proven live", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			id: "config-1",
+			respectQuiSeeding: true,
+			rules: [
+				{
+					...episodeCleanupRule(),
+					id: "parent-completion-rule",
+					priority: 0,
+					targetScope: "series",
+					ruleType: "plex_episode_completion",
+					parameters: JSON.stringify({ operator: "less_than", percentage: 100 }),
+				},
+				episodeCleanupRule(),
+			],
+		} as never);
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
 
 	it("still uses exact-file deletion when no media-server notification applies", async () => {
 		const { deps, targetClient, episodeFiles, bulkDelete, deleteSeries } = makeSonarrDeps({

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -123,8 +123,7 @@ const PREVIEW_SAFETY_INSPECTION_LIMIT = 200;
 // Circuit breaker: abort after N consecutive ARR API failures
 const CIRCUIT_BREAKER_THRESHOLD = 3;
 
-const SEERR_PREFETCH_PAGE_SIZE = 50;
-const SEERR_PREFETCH_MAX_PAGES = 100;
+const SEERR_PREFETCH_MAX_REQUESTS = 5_000;
 
 export const CLEANUP_RUN_LEASE_MS = 2 * 60 * 60 * 1000;
 const CLEANUP_RUN_HEARTBEAT_MS = 60 * 1000;
@@ -2040,8 +2039,9 @@ function hasCompleteLiveSonarrEvidenceForRuleType(
 	}
 	if (ruleType === "jellyfin_episode_completion") return false;
 	if (ruleType.startsWith("jellyfin_")) return ctx.jellyfinMap !== undefined;
-	if (ruleType === "tmdb_list_member") return ctx.tmdbListMemberships !== undefined;
-	if (ruleType === "trakt_list_member") return ctx.traktListMemberships !== undefined;
+	// List memberships are background caches without a source-bound live
+	// refresh at this mutation boundary, so they cannot prove a non-match.
+	if (ruleType === "tmdb_list_member" || ruleType === "trakt_list_member") return false;
 	const statistics =
 		typeof rawSeries.statistics === "object" && rawSeries.statistics !== null
 			? (rawSeries.statistics as Record<string, unknown>)
@@ -3217,41 +3217,36 @@ export async function prefetchSeerrRequests(
 
 		for (const seerrInstance of seerrInstances) {
 			const client = new SeerrClient(arrClientFactory, seerrInstance, log);
-			let skip = 0;
-			let complete = false;
-
-			for (let page = 0; page < SEERR_PREFETCH_MAX_PAGES; page++) {
-				const result = await client.getRequests({ take: SEERR_PREFETCH_PAGE_SIZE, skip });
-
-				for (const req of result.results) {
-					const key = `${req.type}:${req.media.tmdbId}`;
-					const info: SeerrRequestInfo = {
-						requestId: req.id,
-						status: req.status,
-						requestedBy: req.requestedBy.displayName,
-						requestedByUserId: req.requestedBy.id,
-						createdAt: req.createdAt,
-						updatedAt: req.updatedAt,
-						modifiedBy: req.modifiedBy?.displayName ?? null,
-						is4k: req.is4k ?? false,
-					};
-
-					const existing = map.get(key);
-					if (existing) existing.push(info);
-					else map.set(key, [info]);
-				}
-
-				if (result.results.length < SEERR_PREFETCH_PAGE_SIZE) {
-					complete = true;
-					break;
-				}
-				skip += SEERR_PREFETCH_PAGE_SIZE;
+			// Seerr accepts an arbitrary `take` value. Fetching the bounded set in
+			// one request avoids offset-pagination drift while establishing a live
+			// destructive non-match. The extra sentinel item detects overflow.
+			const result = await client.getRequests({ take: SEERR_PREFETCH_MAX_REQUESTS + 1, skip: 0 });
+			if (
+				result.pageInfo.results > SEERR_PREFETCH_MAX_REQUESTS ||
+				result.results.length !== result.pageInfo.results ||
+				new Set(result.results.map((request) => request.id)).size !== result.results.length
+			) {
+				throw new Error(
+					`Seerr instance ${seerrInstance.id} did not return one complete bounded request snapshot`,
+				);
 			}
 
-			if (!complete) {
-				throw new Error(
-					`Seerr instance ${seerrInstance.id} exceeded the complete request prefetch limit`,
-				);
+			for (const req of result.results) {
+				const key = `${req.type}:${req.media.tmdbId}`;
+				const info: SeerrRequestInfo = {
+					requestId: req.id,
+					status: req.status,
+					requestedBy: req.requestedBy.displayName,
+					requestedByUserId: req.requestedBy.id,
+					createdAt: req.createdAt,
+					updatedAt: req.updatedAt,
+					modifiedBy: req.modifiedBy?.displayName ?? null,
+					is4k: req.is4k ?? false,
+				};
+
+				const existing = map.get(key);
+				if (existing) existing.push(info);
+				else map.set(key, [info]);
 			}
 		}
 

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -123,6 +123,9 @@ const PREVIEW_SAFETY_INSPECTION_LIMIT = 200;
 // Circuit breaker: abort after N consecutive ARR API failures
 const CIRCUIT_BREAKER_THRESHOLD = 3;
 
+const SEERR_PREFETCH_PAGE_SIZE = 50;
+const SEERR_PREFETCH_MAX_PAGES = 100;
+
 export const CLEANUP_RUN_LEASE_MS = 2 * 60 * 60 * 1000;
 const CLEANUP_RUN_HEARTBEAT_MS = 60 * 1000;
 
@@ -1266,6 +1269,7 @@ function createSonarrEpisodeMutationAuthority(
 	assertExecutionAllowed?: () => Promise<void>,
 ): () => Promise<void> {
 	let revalidationCount = 0;
+	const seriesEvidence: EpisodeSeriesAuthorityEvidence = {};
 	return async () => {
 		await assertExecutionAllowed?.();
 		await assertCurrentEpisodeMutationAuthority(
@@ -1274,6 +1278,8 @@ function createSonarrEpisodeMutationAuthority(
 			instance,
 			target.arrItemId,
 			expectedRule,
+			undefined,
+			seriesEvidence,
 		);
 		const context = createSharedPlexSafetyContext();
 		const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -1325,6 +1331,7 @@ function createSonarrEpisodeMutationAuthority(
 			target.arrItemId,
 			expectedRule,
 			{ liveEpisodeWatchSources },
+			seriesEvidence,
 		);
 		await assertExecutionAllowed?.();
 	};
@@ -2024,7 +2031,9 @@ function hasCompleteLiveSonarrEvidenceForRuleType(
 	if (ruleType === "seerr_requester_watched" || ruleType === "seerr_requester_not_watched") {
 		return ctx.seerrMap !== undefined && ctx.plexMap !== undefined;
 	}
-	if (ruleType === "plex_episode_completion") return ctx.plexEpisodeMap !== undefined;
+	// Episode-completion caches are intentionally bounded background indexes,
+	// not complete live evidence for a destructive parent-policy decision.
+	if (ruleType === "plex_episode_completion") return false;
 	if (
 		ruleType.startsWith("plex_") ||
 		ruleType === "user_retention" ||
@@ -2033,7 +2042,7 @@ function hasCompleteLiveSonarrEvidenceForRuleType(
 	) {
 		return ctx.plexMap !== undefined;
 	}
-	if (ruleType === "jellyfin_episode_completion") return ctx.jellyfinEpisodeMap !== undefined;
+	if (ruleType === "jellyfin_episode_completion") return false;
 	if (ruleType.startsWith("jellyfin_")) return ctx.jellyfinMap !== undefined;
 	if (ruleType === "tmdb_list_member") return ctx.tmdbListMemberships !== undefined;
 	if (ruleType === "trakt_list_member") return ctx.traktListMemberships !== undefined;
@@ -2157,6 +2166,10 @@ function assertCompleteLiveSonarrSeriesRuleEvidence(
 	}
 }
 
+interface EpisodeSeriesAuthorityEvidence {
+	context?: Promise<EvalContext>;
+}
+
 async function assertCurrentEpisodeMutationAuthority(
 	deps: CleanupExecutorDeps,
 	userId: string,
@@ -2164,6 +2177,7 @@ async function assertCurrentEpisodeMutationAuthority(
 	arrSeriesId: number,
 	expectedRule: { matchedRuleId: string; action: RuleAction },
 	evidence?: { liveEpisodeWatchSources: VerifiedEpisodePlexWatchSource[] },
+	seriesEvidence: EpisodeSeriesAuthorityEvidence = {},
 ): Promise<void> {
 	const config = await deps.prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
@@ -2195,7 +2209,10 @@ async function assertCurrentEpisodeMutationAuthority(
 	let rawSeries: Record<string, unknown>;
 	let currentSeriesContext: EvalContext;
 	try {
-		currentSeriesContext = await buildEvalContext(deps, userId, currentSeriesRules);
+		seriesEvidence.context ??= buildEvalContext(deps, userId, currentSeriesRules, {
+			destructiveAuthority: true,
+		});
+		currentSeriesContext = await seriesEvidence.context;
 		const sonarr = deps.arrClientFactory.create(instance) as InstanceType<typeof SonarrClient>;
 		rawSeries = (await sonarr.series.getById(arrSeriesId)) as unknown as Record<string, unknown>;
 		const liveSeries = buildLibraryItem(instance, "sonarr", rawSeries);
@@ -3178,18 +3195,19 @@ function collectActiveRuleTypes(
 }
 
 /**
- * Prefetch all Seerr requests and build a lookup map keyed by "movie:tmdbId" or "tv:tmdbId".
- * Returns undefined if no Seerr instance is configured (Seerr rules silently skip).
+ * Prefetch all requests from every enabled Seerr instance and build a lookup
+ * map keyed by "movie:tmdbId" or "tv:tmdbId". A capped or failed read returns
+ * undefined so mutation authority cannot treat an incomplete result as a
+ * proven non-match.
  */
-async function prefetchSeerrRequests(
+export async function prefetchSeerrRequests(
 	deps: CleanupExecutorDeps,
 	userId: string,
 ): Promise<SeerrRequestMap | undefined> {
 	const { prisma, arrClientFactory, log } = deps;
 
-	// Find user's Seerr instance
-	const seerrInstance = await prisma.serviceInstance.findFirst({
-		where: { userId, service: "SEERR" },
+	const seerrInstances = await prisma.serviceInstance.findMany({
+		where: { userId, service: "SEERR", enabled: true },
 		select: {
 			id: true,
 			baseUrl: true,
@@ -3202,45 +3220,56 @@ async function prefetchSeerrRequests(
 		},
 	});
 
-	if (!seerrInstance) return undefined;
+	if (seerrInstances.length === 0) return undefined;
 
 	try {
-		const client = new SeerrClient(arrClientFactory, seerrInstance, log);
 		const map: SeerrRequestMap = new Map();
-		const take = 50;
-		let skip = 0;
-		const maxPages = 100; // Up to 5,000 requests
 
-		for (let page = 0; page < maxPages; page++) {
-			const result = await client.getRequests({ take, skip });
+		for (const seerrInstance of seerrInstances) {
+			const client = new SeerrClient(arrClientFactory, seerrInstance, log);
+			let skip = 0;
+			let complete = false;
 
-			for (const req of result.results) {
-				const key = `${req.type}:${req.media.tmdbId}`;
-				const info: SeerrRequestInfo = {
-					requestId: req.id,
-					status: req.status,
-					requestedBy: req.requestedBy.displayName,
-					requestedByUserId: req.requestedBy.id,
-					createdAt: req.createdAt,
-					updatedAt: req.updatedAt,
-					modifiedBy: req.modifiedBy?.displayName ?? null,
-					is4k: req.is4k ?? false,
-				};
+			for (let page = 0; page < SEERR_PREFETCH_MAX_PAGES; page++) {
+				const result = await client.getRequests({ take: SEERR_PREFETCH_PAGE_SIZE, skip });
 
-				const existing = map.get(key);
-				if (existing) {
-					existing.push(info);
-				} else {
-					map.set(key, [info]);
+				for (const req of result.results) {
+					const key = `${req.type}:${req.media.tmdbId}`;
+					const info: SeerrRequestInfo = {
+						requestId: req.id,
+						status: req.status,
+						requestedBy: req.requestedBy.displayName,
+						requestedByUserId: req.requestedBy.id,
+						createdAt: req.createdAt,
+						updatedAt: req.updatedAt,
+						modifiedBy: req.modifiedBy?.displayName ?? null,
+						is4k: req.is4k ?? false,
+					};
+
+					const existing = map.get(key);
+					if (existing) existing.push(info);
+					else map.set(key, [info]);
 				}
+
+				if (result.results.length < SEERR_PREFETCH_PAGE_SIZE) {
+					complete = true;
+					break;
+				}
+				skip += SEERR_PREFETCH_PAGE_SIZE;
 			}
 
-			if (result.results.length < take) break;
-			skip += take;
+			if (!complete) {
+				throw new Error(
+					`Seerr instance ${seerrInstance.id} exceeded the complete request prefetch limit`,
+				);
+			}
 		}
 
 		log.info(
-			{ totalRequests: [...map.values()].reduce((sum, arr) => sum + arr.length, 0) },
+			{
+				instances: seerrInstances.length,
+				totalRequests: [...map.values()].reduce((sum, arr) => sum + arr.length, 0),
+			},
 			"Seerr request prefetch complete for cleanup",
 		);
 		return map;
@@ -3267,7 +3296,7 @@ export async function prefetchPlexData(
 	const { prisma, log } = deps;
 
 	const plexInstances = await prisma.serviceInstance.findMany({
-		where: { userId, service: "PLEX" },
+		where: { userId, service: "PLEX", enabled: true },
 		select: { id: true },
 	});
 
@@ -3409,7 +3438,7 @@ async function prefetchJellyfinData(
 	const { prisma, log } = deps;
 
 	const jellyfinInstances = await prisma.serviceInstance.findMany({
-		where: { userId, service: { in: ["JELLYFIN", "EMBY"] } },
+		where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
 		select: { id: true },
 	});
 
@@ -3521,11 +3550,11 @@ async function prefetchJellyfinEpisodeData(
 
 	try {
 		const instances = await prisma.serviceInstance.findMany({
-			where: { userId, service: { in: ["JELLYFIN", "EMBY"] } },
+			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
 			select: { id: true },
 		});
 		const instanceIds = instances.map((i) => i.id);
-		if (instanceIds.length === 0) return new Map();
+		if (instanceIds.length === 0) return undefined;
 
 		const totalCounts = await prisma.jellyfinEpisodeCache.groupBy({
 			by: ["showTmdbId"],
@@ -3603,11 +3632,11 @@ async function prefetchPlexEpisodeData(
 
 	try {
 		const instances = await prisma.serviceInstance.findMany({
-			where: { userId },
+			where: { userId, service: "PLEX", enabled: true },
 			select: { id: true },
 		});
 		const instanceIds = instances.map((i) => i.id);
-		if (instanceIds.length === 0) return new Map();
+		if (instanceIds.length === 0) return undefined;
 
 		// Three groupBy queries: show-level totals, show-level watched, and per-season counts
 		const totalCounts = await prisma.plexEpisodeCache.groupBy({
@@ -6840,17 +6869,78 @@ async function deleteFilesFromArr(
 	}
 }
 
+function ruleTypeUsesPlexSeriesCache(ruleType: string): boolean {
+	return (
+		(ruleType.startsWith("plex_") && ruleType !== "plex_episode_completion") ||
+		ruleType === "user_retention" ||
+		ruleType === "staleness_score" ||
+		ruleType === "recently_active" ||
+		ruleType === "seerr_requester_watched" ||
+		ruleType === "seerr_requester_not_watched"
+	);
+}
+
+function ruleTypeUsesJellyfinSeriesCache(ruleType: string): boolean {
+	return ruleType.startsWith("jellyfin_") && ruleType !== "jellyfin_episode_completion";
+}
+
+async function refreshCurrentExternalRuleCaches(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	activeTypes: Set<string>,
+): Promise<void> {
+	const sources: Array<{
+		source: "plex" | "jellyfin";
+		services: Array<ServiceInstance["service"]>;
+		needed: boolean;
+	}> = [
+		{
+			source: "plex",
+			services: ["PLEX"],
+			needed: [...activeTypes].some(ruleTypeUsesPlexSeriesCache),
+		},
+		{
+			source: "jellyfin",
+			services: ["JELLYFIN", "EMBY"],
+			needed: [...activeTypes].some(ruleTypeUsesJellyfinSeriesCache),
+		},
+	];
+
+	for (const { source, services, needed } of sources) {
+		if (!needed) continue;
+		const instances = await deps.prisma.serviceInstance.findMany({
+			where: { userId, service: { in: services }, enabled: true },
+		});
+		if (instances.length === 0) {
+			throw new Error(`No enabled ${source} instance is available for current rule evidence`);
+		}
+
+		for (const instance of instances) {
+			if (!deps.externalRuleCacheRefresher) {
+				throw new Error(`No ${source} evidence refresher is available`);
+			}
+			await deps.externalRuleCacheRefresher(source, instance);
+		}
+	}
+}
+
 /**
  * Build a fully-populated EvalContext by running all relevant prefetch functions.
  * Used by the explain endpoint so it can evaluate rules with real external data
  * rather than an empty context that always returns "not matched" for external rules.
+ * Destructive episode authority refreshes cache-backed parent-series evidence
+ * from every enabled source before reading it.
  */
 export async function buildEvalContext(
 	deps: CleanupExecutorDeps,
 	userId: string,
 	rules: Array<{ enabled: boolean; ruleType: string; conditions: string | null }>,
+	options: { destructiveAuthority?: boolean } = {},
 ): Promise<EvalContext> {
 	const activeTypes = collectActiveRuleTypes(rules);
+	if (options.destructiveAuthority) {
+		await refreshCurrentExternalRuleCaches(deps, userId, activeTypes);
+	}
 
 	const SEERR_RULE_TYPES = [
 		"seerr_requested_by",

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -2012,7 +2012,31 @@ function hasCompleteLiveSonarrTags(rawSeries: Record<string, unknown>): boolean 
 function hasCompleteLiveSonarrEvidenceForRuleType(
 	rawSeries: Record<string, unknown>,
 	ruleType: string,
+	ctx: EvalContext,
 ): boolean {
+	if (
+		ruleType.startsWith("seerr_") &&
+		ruleType !== "seerr_requester_watched" &&
+		ruleType !== "seerr_requester_not_watched"
+	) {
+		return ctx.seerrMap !== undefined;
+	}
+	if (ruleType === "seerr_requester_watched" || ruleType === "seerr_requester_not_watched") {
+		return ctx.seerrMap !== undefined && ctx.plexMap !== undefined;
+	}
+	if (ruleType === "plex_episode_completion") return ctx.plexEpisodeMap !== undefined;
+	if (
+		ruleType.startsWith("plex_") ||
+		ruleType === "user_retention" ||
+		ruleType === "staleness_score" ||
+		ruleType === "recently_active"
+	) {
+		return ctx.plexMap !== undefined;
+	}
+	if (ruleType === "jellyfin_episode_completion") return ctx.jellyfinEpisodeMap !== undefined;
+	if (ruleType.startsWith("jellyfin_")) return ctx.jellyfinMap !== undefined;
+	if (ruleType === "tmdb_list_member") return ctx.tmdbListMemberships !== undefined;
+	if (ruleType === "trakt_list_member") return ctx.traktListMemberships !== undefined;
 	const statistics =
 		typeof rawSeries.statistics === "object" && rawSeries.statistics !== null
 			? (rawSeries.statistics as Record<string, unknown>)
@@ -2113,6 +2137,7 @@ function assertCompleteLiveSonarrSeriesRuleEvidence(
 	rawSeries: Record<string, unknown>,
 	item: CacheItemForEval,
 	rules: LibraryCleanupRule[],
+	ctx: EvalContext,
 ): void {
 	if (typeof rawSeries.title !== "string" || rawSeries.title.trim().length === 0) {
 		throw new Error("Live Sonarr series title was unavailable");
@@ -2121,8 +2146,11 @@ function assertCompleteLiveSonarrSeriesRuleEvidence(
 		if (!liveSonarrRuleApplies(rawSeries, item, rule)) continue;
 		const ruleTypes = liveSonarrRuleTypes(rule);
 		if (
+			ruleUsesUnavailableData(rule, new Set()) ||
 			!ruleTypes ||
-			ruleTypes.some((ruleType) => !hasCompleteLiveSonarrEvidenceForRuleType(rawSeries, ruleType))
+			ruleTypes.some(
+				(ruleType) => !hasCompleteLiveSonarrEvidenceForRuleType(rawSeries, ruleType, ctx),
+			)
 		) {
 			throw new Error(`Current evidence was unavailable for series rule ${rule.id}`);
 		}
@@ -2165,7 +2193,9 @@ async function assertCurrentEpisodeMutationAuthority(
 
 	let item: CacheItemForEval;
 	let rawSeries: Record<string, unknown>;
+	let currentSeriesContext: EvalContext;
 	try {
+		currentSeriesContext = await buildEvalContext(deps, userId, currentSeriesRules);
 		const sonarr = deps.arrClientFactory.create(instance) as InstanceType<typeof SonarrClient>;
 		rawSeries = (await sonarr.series.getById(arrSeriesId)) as unknown as Record<string, unknown>;
 		const liveSeries = buildLibraryItem(instance, "sonarr", rawSeries);
@@ -2206,14 +2236,19 @@ async function assertCurrentEpisodeMutationAuthority(
 			infoHash: null,
 			torrentState: null,
 		};
-		assertCompleteLiveSonarrSeriesRuleEvidence(rawSeries, item, currentSeriesRules);
+		assertCompleteLiveSonarrSeriesRuleEvidence(
+			rawSeries,
+			item,
+			currentSeriesRules,
+			currentSeriesContext,
+		);
 		if (!liveSonarrRuleApplies(rawSeries, item, currentEpisodeRule)) {
 			throw new Error("The matched episode cleanup rule no longer applies to the live series");
 		}
 		const currentSeriesMatch = seriesCleanupRules.find(
 			(rule) =>
 				liveSonarrRuleApplies(rawSeries, item, rule) &&
-				evaluateRuleViaEngine(item, rule, "SONARR", { now: new Date() }) !== null,
+				evaluateRuleViaEngine(item, rule, "SONARR", currentSeriesContext) !== null,
 		);
 		if (currentSeriesMatch) {
 			throw new Error(
@@ -2253,7 +2288,7 @@ async function assertCurrentEpisodeMutationAuthority(
 		seriesRetentionProtectsEpisode(
 			item,
 			seriesRetentionRules,
-			{ now: new Date() },
+			currentSeriesContext,
 			new Set<DataSourceDependency>(),
 		)
 	) {

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1269,7 +1269,6 @@ function createSonarrEpisodeMutationAuthority(
 	assertExecutionAllowed?: () => Promise<void>,
 ): () => Promise<void> {
 	let revalidationCount = 0;
-	const seriesEvidence: EpisodeSeriesAuthorityEvidence = {};
 	return async () => {
 		await assertExecutionAllowed?.();
 		await assertCurrentEpisodeMutationAuthority(
@@ -1278,8 +1277,6 @@ function createSonarrEpisodeMutationAuthority(
 			instance,
 			target.arrItemId,
 			expectedRule,
-			undefined,
-			seriesEvidence,
 		);
 		const context = createSharedPlexSafetyContext();
 		const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -1331,7 +1328,6 @@ function createSonarrEpisodeMutationAuthority(
 			target.arrItemId,
 			expectedRule,
 			{ liveEpisodeWatchSources },
-			seriesEvidence,
 		);
 		await assertExecutionAllowed?.();
 	};
@@ -2166,10 +2162,6 @@ function assertCompleteLiveSonarrSeriesRuleEvidence(
 	}
 }
 
-interface EpisodeSeriesAuthorityEvidence {
-	context?: Promise<EvalContext>;
-}
-
 async function assertCurrentEpisodeMutationAuthority(
 	deps: CleanupExecutorDeps,
 	userId: string,
@@ -2177,7 +2169,6 @@ async function assertCurrentEpisodeMutationAuthority(
 	arrSeriesId: number,
 	expectedRule: { matchedRuleId: string; action: RuleAction },
 	evidence?: { liveEpisodeWatchSources: VerifiedEpisodePlexWatchSource[] },
-	seriesEvidence: EpisodeSeriesAuthorityEvidence = {},
 ): Promise<void> {
 	const config = await deps.prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
@@ -2209,10 +2200,9 @@ async function assertCurrentEpisodeMutationAuthority(
 	let rawSeries: Record<string, unknown>;
 	let currentSeriesContext: EvalContext;
 	try {
-		seriesEvidence.context ??= buildEvalContext(deps, userId, currentSeriesRules, {
+		currentSeriesContext = await buildEvalContext(deps, userId, currentSeriesRules, {
 			destructiveAuthority: true,
 		});
-		currentSeriesContext = await seriesEvidence.context;
 		const sonarr = deps.arrClientFactory.create(instance) as InstanceType<typeof SonarrClient>;
 		rawSeries = (await sonarr.series.getById(arrSeriesId)) as unknown as Record<string, unknown>;
 		const liveSeries = buildLibraryItem(instance, "sonarr", rawSeries);

--- a/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
@@ -92,6 +92,7 @@ export class CleanupScheduler {
 	private trackTick: TickWrapper;
 	private quiClientFactory?: CleanupExecutorDeps["quiClientFactory"];
 	private quiFileHashIndexFactory?: CleanupExecutorDeps["quiFileHashIndexFactory"];
+	private externalRuleCacheRefresher?: CleanupExecutorDeps["externalRuleCacheRefresher"];
 
 	/** Whether a cleanup run is currently in progress */
 	get isRunning(): boolean {
@@ -108,12 +109,14 @@ export class CleanupScheduler {
 			trackTick?: TickWrapper;
 			quiClientFactory?: CleanupExecutorDeps["quiClientFactory"];
 			quiFileHashIndexFactory?: CleanupExecutorDeps["quiFileHashIndexFactory"];
+			externalRuleCacheRefresher?: CleanupExecutorDeps["externalRuleCacheRefresher"];
 		},
 	) {
 		this.notifyFn = notifyFn;
 		this.trackTick = options?.trackTick ?? passthroughTickWrapper;
 		this.quiClientFactory = options?.quiClientFactory;
 		this.quiFileHashIndexFactory = options?.quiFileHashIndexFactory;
+		this.externalRuleCacheRefresher = options?.externalRuleCacheRefresher;
 	}
 
 	/**
@@ -307,6 +310,7 @@ export class CleanupScheduler {
 							encryptor: this.encryptor,
 							quiClientFactory: this.quiClientFactory,
 							quiFileHashIndexFactory: this.quiFileHashIndexFactory,
+							externalRuleCacheRefresher: this.externalRuleCacheRefresher,
 							log: this.logger,
 						},
 						config.userId,

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -36,6 +36,14 @@ export interface CleanupExecutorDeps {
 	quiClientFactory?: (instance: ServiceInstance) => Pick<QuiClient, "getTorrentsByHash">;
 	/** Build one fresh, complete qUI/filesystem inode snapshot for destructive authorization. */
 	quiFileHashIndexFactory?: (instance: ServiceInstance) => Promise<CompleteQuiFileHashIndex>;
+	/**
+	 * Test seam for the authoritative Plex/Jellyfin cache refresh performed before
+	 * cache-backed parent-series rules can authorize an episode mutation.
+	 */
+	externalRuleCacheRefresher?: (
+		source: "plex" | "jellyfin",
+		instance: ServiceInstance,
+	) => Promise<void>;
 	log: FastifyBaseLogger;
 }
 

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -236,6 +236,48 @@ describe("evictStaleRows", () => {
 		expect(deleteCalls).toEqual([]);
 	});
 
+	it("marks history evidence incomplete when Plex exceeds the cache limit", async () => {
+		const history = Array.from({ length: 5_001 }, (_, index) => ({
+			ratingKey: `history-${index}`,
+			title: `History ${index}`,
+			type: "movie",
+			viewedAt: 1_700_000_000 + index,
+			accountID: 1,
+		}));
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([]),
+			getLibraryItems: vi.fn(),
+			getHistory: vi.fn().mockResolvedValue(history),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const { prisma, deleteCalls } = makeMockPrisma(["retained-1"]);
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+		expect(mockClient.getHistory).toHaveBeenCalledWith({ maxResults: 5_001 });
+		expect(result.errors).toBe(1);
+		expect(result.errorMessages).toContainEqual(expect.stringContaining("history exceeded 5000"));
+		expect(deleteCalls).toEqual([]);
+	});
+
+	it("marks on-deck evidence incomplete when Plex cannot return it", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([]),
+			getLibraryItems: vi.fn(),
+			getHistory: vi.fn().mockResolvedValue([]),
+			getOnDeck: vi.fn().mockRejectedValue(new Error("Plex on-deck unavailable")),
+		} as unknown as PlexClient;
+		const { prisma, deleteCalls } = makeMockPrisma(["retained-1"]);
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+		expect(result.errors).toBe(1);
+		expect(result.errorMessages).toContainEqual(expect.stringContaining("on-deck fetch failed"));
+		expect(deleteCalls).toEqual([]);
+	});
+
 	it("never uses `notIn` — the original P2029 trigger", async () => {
 		// Guard against a future regression where someone re-introduces the
 		// oversized `notIn` query. The mock's deleteMany only accepts `id.in`,

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -202,6 +202,40 @@ describe("evictStaleRows", () => {
 		expect(new Set(deletedIds)).toEqual(new Set(existingIds));
 	});
 
+	it("evicts stale rows after a complete refresh finds an empty library", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([]),
+			getLibraryItems: vi.fn(),
+			getHistory: vi.fn().mockResolvedValue([]),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const { prisma, deleteCalls } = makeMockPrisma(["stale-1", "stale-2"]);
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ upserted: 0, errors: 0 });
+		expect(deleteCalls.flatMap((call) => call.idsInFilter)).toEqual(["stale-1", "stale-2"]);
+	});
+
+	it("does not evict cache rows after an incomplete library refresh", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi
+				.fn()
+				.mockResolvedValue([{ key: "1", title: "Unavailable", type: "show" }]),
+			getLibraryItems: vi.fn().mockRejectedValue(new Error("Plex library unavailable")),
+			getHistory: vi.fn().mockResolvedValue([]),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+		const { prisma, deleteCalls } = makeMockPrisma(["retained-1"]);
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+		expect(result.errors).toBe(1);
+		expect(deleteCalls).toEqual([]);
+	});
+
 	it("never uses `notIn` — the original P2029 trigger", async () => {
 		// Guard against a future regression where someone re-introduces the
 		// oversized `notIn` query. The mock's deleteMany only accepts `id.in`,

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -369,15 +369,15 @@ export async function refreshPlexCache(
 		// SQLite's default SQLITE_MAX_VARIABLE_NUMBER, surfacing as Prisma P2029 (issue #323).
 		// Instead we read the existing ids, compute the stale diff in memory, and delete in
 		// bounded chunks using `id: { in: chunk }` so each statement stays well under the limit.
-		if (upsertedIds.length > 0) {
+		if (errors === 0) {
 			const evictedCount = await evictStaleRows(prisma, instanceId, upsertedIds);
 			if (evictedCount > 0) {
 				log.info({ instanceId, evicted: evictedCount }, "Plex cache: evicted stale rows");
 			}
-		} else if (aggregationsArray.length > 0) {
+		} else {
 			log.warn(
 				{ instanceId, aggregationSize: aggregationsArray.length, errors },
-				"Plex cache: skipping eviction — all upserts failed, stale rows may accumulate",
+				"Plex cache: skipping eviction because the refresh was incomplete",
 			);
 		}
 

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -140,8 +140,16 @@ export async function refreshPlexCache(
 		}
 
 		// 4. Get history and aggregate (per-section: key includes sectionId)
+		const HISTORY_CACHE_LIMIT = 5_000;
 		let history: Awaited<ReturnType<typeof client.getHistory>> | undefined =
-			await client.getHistory({ maxResults: 5000 });
+			await client.getHistory({ maxResults: HISTORY_CACHE_LIMIT + 1 });
+		if (history.length > HISTORY_CACHE_LIMIT) {
+			errors++;
+			errorMessages.push(
+				`Plex history exceeded ${HISTORY_CACHE_LIMIT} entries, so watch evidence is incomplete`,
+			);
+			history = history.slice(0, HISTORY_CACHE_LIMIT);
+		}
 		const historyCount = history.length;
 		const aggregations = new Map<string, ItemAggregation>();
 
@@ -234,6 +242,8 @@ export async function refreshPlexCache(
 				}
 			}
 		} catch (err) {
+			errors++;
+			errorMessages.push(`Plex on-deck fetch failed: ${getErrorMessage(err)}`);
 			log.warn({ err }, "Failed to fetch Plex on-deck items");
 		}
 

--- a/apps/api/src/plugins/library-cleanup-scheduler.ts
+++ b/apps/api/src/plugins/library-cleanup-scheduler.ts
@@ -5,6 +5,10 @@ import {
 	buildFreshCompleteFileIdIndex,
 	getAllHashesForFileIdComplete,
 } from "../lib/library-sync/infohash-backfill-by-inode.js";
+import { refreshJellyfinCache } from "../lib/jellyfin/jellyfin-cache-refresher.js";
+import { createJellyfinClient } from "../lib/jellyfin/jellyfin-client.js";
+import { refreshPlexCache } from "../lib/plex/plex-cache-refresher.js";
+import { createPlexClient } from "../lib/plex/plex-client.js";
 import { createQuiClient } from "../lib/qui/client-factory.js";
 import { runSchedulerInit } from "../lib/scheduler-registry/init-helpers.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
@@ -43,6 +47,25 @@ const libraryCleanupSchedulerPlugin = fastifyPlugin(
 								return {
 									resolve: (path) => getAllHashesForFileIdComplete(path, index),
 								};
+							},
+							externalRuleCacheRefresher: async (source, instance) => {
+								const result =
+									source === "plex"
+										? await refreshPlexCache(
+												createPlexClient(app.encryptor, instance, app.log),
+												app.prisma,
+												instance.id,
+												app.log,
+											)
+										: await refreshJellyfinCache(
+												createJellyfinClient(app.encryptor, instance, app.log),
+												app.prisma,
+												instance.id,
+												app.log,
+											);
+								if (result.errors > 0) {
+									throw new Error(`${source} evidence refresh completed with errors`);
+								}
 							},
 						},
 					);

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -39,11 +39,15 @@ import {
 	isSupportedEpisodeCleanupRule,
 } from "../lib/library-cleanup/episode-scope.js";
 import { getFilterReason } from "../lib/library-cleanup/rule-evaluators.js";
-import type { CacheItemForEval } from "../lib/library-cleanup/types.js";
+import type { CacheItemForEval, CleanupExecutorDeps } from "../lib/library-cleanup/types.js";
 import {
 	buildFreshCompleteFileIdIndex,
 	getAllHashesForFileIdComplete,
 } from "../lib/library-sync/infohash-backfill-by-inode.js";
+import { refreshJellyfinCache } from "../lib/jellyfin/jellyfin-cache-refresher.js";
+import { createJellyfinClient } from "../lib/jellyfin/jellyfin-client.js";
+import { refreshPlexCache } from "../lib/plex/plex-cache-refresher.js";
+import { createPlexClient } from "../lib/plex/plex-client.js";
 import { createQuiClient } from "../lib/qui/client-factory.js";
 import { explainItemAgainstRulesViaEngine } from "../lib/rules/cleanup-adapter.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
@@ -191,6 +195,28 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		return {
 			resolve: (path: string) => getAllHashesForFileIdComplete(path, index),
 		};
+	};
+	const externalRuleCacheRefresher: CleanupExecutorDeps["externalRuleCacheRefresher"] = async (
+		source,
+		instance,
+	) => {
+		const result =
+			source === "plex"
+				? await refreshPlexCache(
+						createPlexClient(app.encryptor, instance, app.log),
+						app.prisma,
+						instance.id,
+						app.log,
+					)
+				: await refreshJellyfinCache(
+						createJellyfinClient(app.encryptor, instance, app.log),
+						app.prisma,
+						instance.id,
+						app.log,
+					);
+		if (result.errors > 0) {
+			throw new Error(`${source} evidence refresh completed with errors`);
+		}
 	};
 	app.addHook("preHandler", async (request, reply) => {
 		if (!request.currentUser?.id) {
@@ -763,6 +789,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						encryptor: app.encryptor,
 						quiClientFactory: (instance) => createQuiClient(app, instance),
 						quiFileHashIndexFactory,
+						externalRuleCacheRefresher,
 						log: request.log,
 					},
 					userId,
@@ -936,6 +963,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						encryptor: app.encryptor,
 						quiClientFactory: (instance) => createQuiClient(app, instance),
 						quiFileHashIndexFactory,
+						externalRuleCacheRefresher,
 						log: request.log,
 					},
 					userId,
@@ -1059,6 +1087,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 							encryptor: app.encryptor,
 							quiClientFactory: (instance) => createQuiClient(app, instance),
 							quiFileHashIndexFactory,
+							externalRuleCacheRefresher,
 							log: request.log,
 						},
 						userId,
@@ -1093,6 +1122,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						encryptor: app.encryptor,
 						quiClientFactory: (instance) => createQuiClient(app, instance),
 						quiFileHashIndexFactory,
+						externalRuleCacheRefresher,
 						log: request.log,
 					},
 					userId,
@@ -1175,6 +1205,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						encryptor: app.encryptor,
 						quiClientFactory: (instance) => createQuiClient(app, instance),
 						quiFileHashIndexFactory,
+						externalRuleCacheRefresher,
 						log: request.log,
 					},
 					userId,


### PR DESCRIPTION
## Summary

- revalidate parent Plex and Jellyfin rules from every enabled provider at each episode mutation boundary
- collect one bounded, complete request snapshot from every enabled Seerr instance and fail closed on overflow or inconsistent results
- prevent background TMDb/Trakt list caches and bounded episode-completion caches from authorizing destructive parent-rule non-matches
- aggregate Jellyfin libraries and playback state across every visible user, and preserve stale rows whenever refresh completeness is unknown

This is the focused follow-up to the inline review finding on #698.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API: 2,888 passed / 41 skipped; web: 681 passed; shared: 117 passed)
- `pnpm run lint`
- `pnpm run build`
- independent regression and data-safety correction reviews: all recorded findings resolved

Related to #698