### PR TITLE
feat: schedule and monitor guarded Tautulli refreshes

### DIFF
--- a/apps/api/src/bootstrap/schedulers.ts
+++ b/apps/api/src/bootstrap/schedulers.ts
@@ -18,6 +18,7 @@ import quiTorrentStateSchedulerPlugin from "../plugins/qui-torrent-state-schedul
 import seerrHealthSchedulerPlugin from "../plugins/seerr-health-scheduler.js";
 import sessionCleanupPlugin from "../plugins/session-cleanup.js";
 import sessionSnapshotSchedulerPlugin from "../plugins/session-snapshot-scheduler.js";
+import tautulliCacheSchedulerPlugin from "../plugins/tautulli-cache-scheduler.js";
 import tmdbListCacheSchedulerPlugin from "../plugins/tmdb-list-cache-scheduler.js";
 import traktListCacheSchedulerPlugin from "../plugins/trakt-list-cache-scheduler.js";
 import trashBackupCleanupPlugin from "../plugins/trash-backup-cleanup.js";
@@ -54,11 +55,12 @@ export function registerSchedulers(app: FastifyInstance): void {
 	app.register(trashUpdateSchedulerPlugin);
 	app.register(trashSyncSchedulerPlugin);
 
-	// Media server caches (Plex / Jellyfin / Emby)
+	// Media server caches (Plex / Jellyfin / Emby / Tautulli)
 	app.register(plexCacheSchedulerPlugin);
 	app.register(plexEpisodeCacheSchedulerPlugin);
 	app.register(jellyfinCacheSchedulerPlugin);
 	app.register(jellyfinEpisodeCacheSchedulerPlugin);
+	app.register(tautulliCacheSchedulerPlugin);
 
 	// Seerr health monitoring
 	app.register(seerrHealthSchedulerPlugin);

--- a/apps/api/src/lib/pulse/__tests__/collectors-tautulli.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-tautulli.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { FastifyBaseLogger, FastifyInstance } from "fastify";
+import { collectTautulliCacheHealth } from "../collectors.js";
+
+const log = {
+	warn: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+	debug: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+const HOUR = 60 * 60 * 1000;
+
+function makeApp(statuses: unknown[]): FastifyInstance {
+	return {
+		prisma: {
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue(statuses) },
+		},
+	} as unknown as FastifyInstance;
+}
+
+function status(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "status-row",
+		instanceId: "tautulli-1",
+		cacheType: "tautulli",
+		lastRefreshedAt: new Date(Date.now() - HOUR),
+		lastResult: "success",
+		lastErrorMessage: null,
+		lastAttemptAt: null,
+		lastAttemptResult: null,
+		lastAttemptErrorMessage: null,
+		instance: { enabled: true, service: "TAUTULLI" },
+		...overrides,
+	};
+}
+
+describe("collectTautulliCacheHealth", () => {
+	it("treats no configured Tautulli instance as healthy absence", async () => {
+		const app = makeApp([]);
+
+		expect(await collectTautulliCacheHealth(app, "user-1", log)).toEqual([]);
+		expect(app.prisma.cacheRefreshStatus.findMany).toHaveBeenCalledWith({
+			where: {
+				cacheType: "tautulli",
+				instance: { userId: "user-1", service: "TAUTULLI", enabled: true },
+			},
+			include: { instance: { select: { enabled: true, service: true } } },
+		});
+	});
+
+	it("reports a newer failed attempt with a stable instance id without leaking upstream data", async () => {
+		const app = makeApp([
+			status({
+				id: "different-status-row",
+				lastAttemptAt: new Date(),
+				lastAttemptResult: "error",
+				lastAttemptErrorMessage:
+					"https://secret.example user=alice title=Private Show apiKey=super-secret raw response",
+			}),
+		]);
+
+		const [item] = await collectTautulliCacheHealth(app, "user-1", log);
+
+		expect(item).toMatchObject({
+			id: "tautulli-cache-failure-tautulli-1",
+			severity: "warning",
+			category: "health",
+			title: "Tautulli cache refresh failed",
+			actionUrl: "/settings",
+			actionLabel: "Check Tautulli settings",
+			source: "tautulli",
+		});
+		expect(item?.detail).toContain("last successful cache generation is still available");
+		expect(item?.detail).not.toMatch(/secret|alice|Private Show|apiKey|raw response/i);
+	});
+
+	it("reports stale Tautulli data with an entity-keyed id and skips disabled instances", async () => {
+		const stale = status({
+			id: "old-status-row",
+			lastRefreshedAt: new Date(Date.now() - 13 * HOUR),
+		});
+		const disabled = status({
+			id: "disabled-status-row",
+			instanceId: "tautulli-disabled",
+			lastRefreshedAt: new Date(Date.now() - 13 * HOUR),
+			instance: { enabled: false, service: "TAUTULLI" },
+		});
+
+		const items = await collectTautulliCacheHealth(makeApp([stale, disabled]), "user-1", log);
+
+		expect(items).toEqual([
+			expect.objectContaining({
+				id: "tautulli-cache-stale-tautulli-1",
+				title: "Tautulli cache is stale",
+				actionUrl: "/settings",
+			}),
+		]);
+	});
+});

--- a/apps/api/src/lib/pulse/__tests__/collectors-tautulli.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/collectors-tautulli.test.ts
@@ -75,6 +75,25 @@ describe("collectTautulliCacheHealth", () => {
 		expect(item?.detail).not.toMatch(/secret|alice|Private Show|apiKey|raw response/i);
 	});
 
+	it("reports a failed attempt recorded at the same timestamp as its successful generation", async () => {
+		const publishedAt = new Date();
+		const app = makeApp([
+			status({
+				lastRefreshedAt: publishedAt,
+				lastAttemptAt: publishedAt,
+				lastAttemptResult: "error",
+			}),
+		]);
+
+		const [item] = await collectTautulliCacheHealth(app, "user-1", log);
+
+		expect(item).toMatchObject({
+			id: "tautulli-cache-failure-tautulli-1",
+			title: "Tautulli cache refresh failed",
+		});
+		expect(item?.detail).toContain("last successful cache generation is still available");
+	});
+
 	it("reports stale Tautulli data with an entity-keyed id and skips disabled instances", async () => {
 		const stale = status({
 			id: "old-status-row",

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -751,7 +751,7 @@ const collectTautulliCacheHealth: Collector = async (app, userId) => {
 		const newerFailedAttempt =
 			status.lastAttemptResult === "error" &&
 			status.lastAttemptAt != null &&
-			status.lastAttemptAt.getTime() > status.lastRefreshedAt.getTime();
+			status.lastAttemptAt.getTime() >= status.lastRefreshedAt.getTime();
 
 		if (status.lastResult === "error" || newerFailedAttempt) {
 			items.push({

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -645,6 +645,9 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 	const staleThreshold = Date.now() - STALE_CACHE_HOURS * 60 * 60 * 1000;
 
 	for (const status of cacheStatuses) {
+		// Tautulli has a dedicated collector below. Its status intentionally
+		// omits raw upstream error text and keys signals by instance identity.
+		if (status.cacheType === "tautulli") continue;
 		// Keep the enabled-state gate explicit as well as in the query. This is
 		// defensive against a service being disabled after the relation filter
 		// is planned and keeps fixture-backed collectors honest.
@@ -719,6 +722,73 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 			});
 		}
 	}
+	return items;
+};
+
+// ============================================================================
+// 4a. Tautulli Cache Health
+// ============================================================================
+//
+// Tautulli refresh errors may include upstream URLs, account names, titles, or
+// credential-shaped strings. Pulse therefore reports an actionable status from
+// the durable cache witness without rendering the upstream error itself.
+
+const collectTautulliCacheHealth: Collector = async (app, userId) => {
+	const statuses = await app.prisma.cacheRefreshStatus.findMany({
+		where: {
+			cacheType: "tautulli",
+			instance: { userId, service: "TAUTULLI", enabled: true },
+		},
+		include: { instance: { select: { enabled: true, service: true } } },
+	});
+
+	const items: PulseItem[] = [];
+	const staleThreshold = Date.now() - STALE_CACHE_HOURS * 60 * 60 * 1000;
+
+	for (const status of statuses) {
+		if (!status.instance.enabled || status.instance.service !== "TAUTULLI") continue;
+
+		const newerFailedAttempt =
+			status.lastAttemptResult === "error" &&
+			status.lastAttemptAt != null &&
+			status.lastAttemptAt.getTime() > status.lastRefreshedAt.getTime();
+
+		if (status.lastResult === "error" || newerFailedAttempt) {
+			items.push({
+				id: `tautulli-cache-failure-${status.instanceId}`,
+				severity: "warning",
+				category: "health",
+				title: "Tautulli cache refresh failed",
+				detail:
+					status.lastResult === "error"
+						? "No successful Tautulli cache generation is available. Check the Tautulli connection and credentials in Settings."
+						: "The latest refresh attempt failed; the last successful cache generation is still available. Check the Tautulli connection and credentials in Settings.",
+				actionUrl: "/settings",
+				actionLabel: "Check Tautulli settings",
+				source: "tautulli",
+				timestamp: (status.lastAttemptAt ?? status.lastRefreshedAt).toISOString(),
+			});
+			continue;
+		}
+
+		if (status.lastRefreshedAt.getTime() < staleThreshold) {
+			const hoursAgo = Math.round(
+				(Date.now() - status.lastRefreshedAt.getTime()) / (60 * 60 * 1000),
+			);
+			items.push({
+				id: `tautulli-cache-stale-${status.instanceId}`,
+				severity: "warning",
+				category: "health",
+				title: "Tautulli cache is stale",
+				detail: `Last successful cache generation was published ${hoursAgo} hours ago. Check the Tautulli connection and credentials in Settings.`,
+				actionUrl: "/settings",
+				actionLabel: "Check Tautulli settings",
+				source: "tautulli",
+				timestamp: status.lastRefreshedAt.toISOString(),
+			});
+		}
+	}
+
 	return items;
 };
 
@@ -1228,6 +1298,7 @@ export {
 	collectLibrarySyncHealth,
 	collectMediaServerReachability,
 	collectSchedulerHealth,
+	collectTautulliCacheHealth,
 };
 
 // `collectQuiSignals` is declared after this block; re-exported below.
@@ -1385,6 +1456,7 @@ export const pulseCollectors: Collector[] = [
 	collectArrQueueFailures,
 	collectSeerrCircuitBreaker,
 	collectCacheStaleness,
+	collectTautulliCacheHealth,
 	collectLibrarySyncHealth,
 	collectValidationHealth,
 	collectLibraryInsightCounts,

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -609,7 +609,7 @@ const collectSeerrCircuitBreaker: Collector = async (app, userId) => {
 // cacheType values (e.g. "plex_episode", or pre-migration "tautulli" rows
 // that linger until the 3.0 dialog deletes their instances) still emit a
 // warning — just without an action button, so we don't ship a click the
-// backend can't fulfil.
+// backend can't fulfil. Tautulli is handled by its dedicated collector below.
 const REFRESHABLE_CACHE_TYPES = new Set<PulseCacheType>(["plex", "jellyfin"]);
 
 function actionForCache(

--- a/apps/api/src/lib/scheduler-registry/job-definitions.ts
+++ b/apps/api/src/lib/scheduler-registry/job-definitions.ts
@@ -152,7 +152,7 @@ export const KNOWN_JOBS: readonly JobDefinition[] = [
 		label: "Tautulli history cache",
 		description:
 			"Refreshes guarded Tautulli history cache generations for enabled instances every 6 hours. Ticks are serialized and each publication is bound to the current owner and provider connection.",
-		concurrency: "per-instance",
+		concurrency: "singleton",
 		intervalMs: 6 * 60 * 60 * 1000,
 	},
 	{

--- a/apps/api/src/lib/scheduler-registry/job-definitions.ts
+++ b/apps/api/src/lib/scheduler-registry/job-definitions.ts
@@ -31,6 +31,7 @@ export const JOB_ID = {
 	plexEpisodeCache: "plex-episode-cache",
 	jellyfinCache: "jellyfin-cache",
 	jellyfinEpisodeCache: "jellyfin-episode-cache",
+	tautulliCache: "tautulli-cache",
 	seerrHealth: "seerr-health",
 	labelSync: "label-sync",
 	autoTag: "auto-tag",
@@ -145,6 +146,14 @@ export const KNOWN_JOBS: readonly JobDefinition[] = [
 		description:
 			"Refreshes Jellyfin/Emby episode metadata cache per instance. Per-instance serial.",
 		concurrency: "per-instance",
+	},
+	{
+		id: JOB_ID.tautulliCache,
+		label: "Tautulli history cache",
+		description:
+			"Refreshes guarded Tautulli history cache generations for enabled instances every 6 hours. Ticks are serialized and each publication is bound to the current owner and provider connection.",
+		concurrency: "per-instance",
+		intervalMs: 6 * 60 * 60 * 1000,
 	},
 	{
 		id: JOB_ID.seerrHealth,

--- a/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
+++ b/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
@@ -43,15 +43,19 @@ function instance(id: string, enabled = true) {
 describe("tautulli cache scheduler", () => {
 	let app: ReturnType<typeof Fastify>;
 	let findMany: ReturnType<typeof vi.fn>;
+	let findUnique: ReturnType<typeof vi.fn>;
 
 	beforeEach(async () => {
 		vi.useFakeTimers();
 		vi.clearAllMocks();
 		findMany = vi.fn();
+		findUnique = vi.fn(({ where }: { where: { id: string } }) =>
+			Promise.resolve(instance(where.id)),
+		);
 		app = Fastify({ logger: false });
 		app.decorate("encryptor", {} as never);
 		app.decorate("prisma", {
-			serviceInstance: { findMany },
+			serviceInstance: { findMany, findUnique },
 		} as never);
 		await app.register(schedulerRegistryPlugin);
 		createTautulliClient.mockReturnValue({});
@@ -126,6 +130,54 @@ describe("tautulli cache scheduler", () => {
 		await vi.runAllTicks();
 	});
 
+	it("does not contact a queued instance that was disabled before its refresh began", async () => {
+		findMany.mockResolvedValue([instance("one"), instance("two")]);
+		let releaseFirst: (() => void) | undefined;
+		refreshTautulliCache.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseFirst = () =>
+						resolve({ upserted: 1, errors: 0, errorMessages: [], complete: true });
+				}),
+		);
+		findUnique.mockResolvedValueOnce(instance("one")).mockResolvedValueOnce(instance("two", false));
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+		expect(createTautulliClient).toHaveBeenCalledTimes(1);
+
+		releaseFirst?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(findUnique).toHaveBeenCalledTimes(2);
+		expect(createTautulliClient).toHaveBeenCalledTimes(1);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not contact a queued instance whose connection changed before refresh", async () => {
+		findMany.mockResolvedValue([instance("one"), instance("two")]);
+		let releaseFirst: (() => void) | undefined;
+		refreshTautulliCache.mockImplementationOnce(
+			() =>
+				new Promise((resolve) => {
+					releaseFirst = () =>
+						resolve({ upserted: 1, errors: 0, errorMessages: [], complete: true });
+				}),
+		);
+		findUnique.mockResolvedValueOnce(instance("one")).mockResolvedValueOnce({
+			...instance("two"),
+			connectionGeneration: 5,
+			baseUrl: "https://replacement-tautulli.example.test",
+		});
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+		releaseFirst?.();
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(findUnique).toHaveBeenCalledTimes(2);
+		expect(createTautulliClient).toHaveBeenCalledTimes(1);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(1);
+	});
+
 	it("marks the tracked tick failed after processing every current instance with a failure", async () => {
 		findMany.mockResolvedValue([instance("broken"), instance("healthy")]);
 		createTautulliClient
@@ -194,7 +246,9 @@ describe("tautulli cache scheduler", () => {
 		recordProviderCacheRefreshFailure.mockResolvedValue("recorded");
 		const schedulerApp = {
 			encryptor: {},
-			prisma: {},
+			prisma: {
+				serviceInstance: { findUnique: vi.fn().mockResolvedValue(instance("one")) },
+			},
 			log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 		};
 

--- a/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
+++ b/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
@@ -61,6 +61,7 @@ describe("tautulli cache scheduler", () => {
 			errorMessages: [],
 			complete: true,
 		});
+		recordProviderCacheRefreshFailure.mockResolvedValue("recorded");
 		await app.register(tautulliCacheSchedulerPlugin);
 		await app.ready();
 	});
@@ -125,6 +126,66 @@ describe("tautulli cache scheduler", () => {
 		await vi.runAllTicks();
 	});
 
+	it("marks the tracked tick failed after processing every current instance with a failure", async () => {
+		findMany.mockResolvedValue([instance("broken"), instance("healthy")]);
+		createTautulliClient
+			.mockImplementationOnce(() => {
+				throw new Error("credential could not be decrypted");
+			})
+			.mockReturnValueOnce({});
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+
+		expect(createTautulliClient).toHaveBeenCalledTimes(2);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(1);
+		expect(recordProviderCacheRefreshFailure).toHaveBeenCalledTimes(1);
+		expect(app.schedulerRegistry.getStatus(JOB_ID.tautulliCache)).toMatchObject({
+			totalRuns: 1,
+			totalFailures: 1,
+			consecutiveFailures: 1,
+			lastError: "Tautulli cache refresh failed for 1 configured instance",
+		});
+	});
+
+	it("marks an incomplete current refresh failed without exposing its upstream error", async () => {
+		findMany.mockResolvedValue([instance("one")]);
+		refreshTautulliCache.mockResolvedValueOnce({
+			upserted: 0,
+			errors: 1,
+			errorMessages: ["private upstream response"],
+			complete: false,
+		});
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+
+		expect(app.schedulerRegistry.getStatus(JOB_ID.tautulliCache)).toMatchObject({
+			totalFailures: 1,
+			lastError: "Tautulli cache refresh failed for 1 configured instance",
+		});
+		expect(app.schedulerRegistry.getStatus(JOB_ID.tautulliCache)?.lastError).not.toContain(
+			"private upstream response",
+		);
+	});
+
+	it("treats a superseded refresh as a neutral successful tick", async () => {
+		findMany.mockResolvedValue([instance("one")]);
+		refreshTautulliCache.mockResolvedValueOnce({
+			upserted: 0,
+			errors: 0,
+			errorMessages: ["Tautulli service connection changed during refresh"],
+			complete: false,
+			superseded: true,
+		});
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+
+		expect(app.schedulerRegistry.getStatus(JOB_ID.tautulliCache)).toMatchObject({
+			totalRuns: 1,
+			totalFailures: 0,
+			consecutiveFailures: 0,
+		});
+	});
+
 	it("records a failed attempt through the guarded status boundary without replacing a generation", async () => {
 		const failure = new Error("credential could not be decrypted");
 		createTautulliClient.mockImplementation(() => {
@@ -137,7 +198,9 @@ describe("tautulli cache scheduler", () => {
 			log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
 		};
 
-		await refreshScheduledTautulliCacheInstance(schedulerApp as never, instance("one") as never);
+		await expect(
+			refreshScheduledTautulliCacheInstance(schedulerApp as never, instance("one") as never),
+		).resolves.toBe("failed");
 
 		expect(recordProviderCacheRefreshFailure).toHaveBeenCalledWith(
 			schedulerApp.prisma,

--- a/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
+++ b/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
@@ -1,0 +1,139 @@
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { createTautulliClient, refreshTautulliCache, recordProviderCacheRefreshFailure } =
+	vi.hoisted(() => ({
+		createTautulliClient: vi.fn(),
+		refreshTautulliCache: vi.fn(),
+		recordProviderCacheRefreshFailure: vi.fn(),
+	}));
+
+vi.mock("../../lib/tautulli/tautulli-client.js", () => ({ createTautulliClient }));
+vi.mock("../../lib/tautulli/tautulli-cache-refresher.js", () => ({ refreshTautulliCache }));
+vi.mock("../../lib/services/provider-cache-status.js", () => ({
+	recordProviderCacheRefreshFailure,
+}));
+
+import tautulliCacheSchedulerPlugin, {
+	refreshScheduledTautulliCacheInstance,
+} from "../tautulli-cache-scheduler.js";
+
+const STARTUP_DELAY_MS = 2 * 60_000;
+const INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+function instance(id: string, enabled = true) {
+	return {
+		id,
+		label: `Tautulli ${id}`,
+		service: "TAUTULLI",
+		enabled,
+		connectionGeneration: 4,
+		encryptedApiKey: "encrypted-key",
+		encryptionIv: "key-iv",
+		baseUrl: "https://tautulli.example.test",
+	};
+}
+
+describe("tautulli cache scheduler", () => {
+	let app: ReturnType<typeof Fastify>;
+	let findMany: ReturnType<typeof vi.fn>;
+
+	beforeEach(async () => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		findMany = vi.fn();
+		app = Fastify({ logger: false });
+		app.decorate("encryptor", {} as never);
+		app.decorate("prisma", {
+			serviceInstance: { findMany },
+		} as never);
+		createTautulliClient.mockReturnValue({});
+		refreshTautulliCache.mockResolvedValue({
+			upserted: 1,
+			errors: 0,
+			errorMessages: [],
+			complete: true,
+		});
+		await app.register(tautulliCacheSchedulerPlugin);
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		await app?.close();
+		vi.useRealTimers();
+	});
+
+	it("refreshes each enabled Tautulli instance while skipping a disabled row", async () => {
+		findMany.mockResolvedValue([instance("one"), instance("two"), instance("disabled", false)]);
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+
+		expect(findMany).toHaveBeenCalledWith({
+			where: { service: "TAUTULLI", enabled: true },
+		});
+		expect(createTautulliClient).toHaveBeenCalledTimes(2);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(2);
+		expect(refreshTautulliCache).toHaveBeenNthCalledWith(
+			1,
+			expect.anything(),
+			app.prisma,
+			"one",
+			app.log,
+			{ service: "TAUTULLI", connectionGeneration: 4 },
+		);
+		expect(refreshTautulliCache).toHaveBeenNthCalledWith(
+			2,
+			expect.anything(),
+			app.prisma,
+			"two",
+			app.log,
+			{ service: "TAUTULLI", connectionGeneration: 4 },
+		);
+	});
+
+	it("does not start an overlapping tick while an earlier refresh is in flight", async () => {
+		findMany.mockResolvedValue([instance("one")]);
+		let releaseRefresh: (() => void) | undefined;
+		refreshTautulliCache.mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					releaseRefresh = () =>
+						resolve({ upserted: 1, errors: 0, errorMessages: [], complete: true });
+				}),
+		);
+
+		await vi.advanceTimersByTimeAsync(STARTUP_DELAY_MS);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(1);
+
+		await vi.advanceTimersByTimeAsync(INTERVAL_MS);
+		expect(refreshTautulliCache).toHaveBeenCalledTimes(1);
+		expect(findMany).toHaveBeenCalledTimes(1);
+
+		releaseRefresh?.();
+		await vi.runAllTicks();
+	});
+
+	it("records a failed attempt through the guarded status boundary without replacing a generation", async () => {
+		const failure = new Error("credential could not be decrypted");
+		createTautulliClient.mockImplementation(() => {
+			throw failure;
+		});
+		recordProviderCacheRefreshFailure.mockResolvedValue("recorded");
+		const schedulerApp = {
+			encryptor: {},
+			prisma: {},
+			log: { info: vi.fn(), error: vi.fn(), warn: vi.fn() },
+		};
+
+		await refreshScheduledTautulliCacheInstance(schedulerApp as never, instance("one") as never);
+
+		expect(recordProviderCacheRefreshFailure).toHaveBeenCalledWith(
+			schedulerApp.prisma,
+			"one",
+			"tautulli",
+			"credential could not be decrypted",
+			{ service: "TAUTULLI", connectionGeneration: 4 },
+			schedulerApp.log,
+		);
+	});
+});

--- a/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
+++ b/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
@@ -14,6 +14,9 @@ vi.mock("../../lib/services/provider-cache-status.js", () => ({
 	recordProviderCacheRefreshFailure,
 }));
 
+import { JOB_ID } from "../../lib/scheduler-registry/job-definitions.js";
+import { providerConnectionIdentity } from "../../lib/services/provider-connection-guard.js";
+import schedulerRegistryPlugin from "../scheduler-registry.js";
 import tautulliCacheSchedulerPlugin, {
 	refreshScheduledTautulliCacheInstance,
 } from "../tautulli-cache-scheduler.js";
@@ -24,12 +27,15 @@ const INTERVAL_MS = 6 * 60 * 60 * 1000;
 function instance(id: string, enabled = true) {
 	return {
 		id,
+		userId: "user-1",
 		label: `Tautulli ${id}`,
 		service: "TAUTULLI",
 		enabled,
 		connectionGeneration: 4,
 		encryptedApiKey: "encrypted-key",
 		encryptionIv: "key-iv",
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
 		baseUrl: "https://tautulli.example.test",
 	};
 }
@@ -47,6 +53,7 @@ describe("tautulli cache scheduler", () => {
 		app.decorate("prisma", {
 			serviceInstance: { findMany },
 		} as never);
+		await app.register(schedulerRegistryPlugin);
 		createTautulliClient.mockReturnValue({});
 		refreshTautulliCache.mockResolvedValue({
 			upserted: 1,
@@ -79,7 +86,7 @@ describe("tautulli cache scheduler", () => {
 			app.prisma,
 			"one",
 			app.log,
-			{ service: "TAUTULLI", connectionGeneration: 4 },
+			providerConnectionIdentity(instance("one") as never),
 		);
 		expect(refreshTautulliCache).toHaveBeenNthCalledWith(
 			2,
@@ -87,8 +94,13 @@ describe("tautulli cache scheduler", () => {
 			app.prisma,
 			"two",
 			app.log,
-			{ service: "TAUTULLI", connectionGeneration: 4 },
+			providerConnectionIdentity(instance("two") as never),
 		);
+		expect(app.schedulerRegistry.getStatus(JOB_ID.tautulliCache)).toMatchObject({
+			totalRuns: 1,
+			totalFailures: 0,
+			state: "idle",
+		});
 	});
 
 	it("does not start an overlapping tick while an earlier refresh is in flight", async () => {
@@ -132,7 +144,7 @@ describe("tautulli cache scheduler", () => {
 			"one",
 			"tautulli",
 			"credential could not be decrypted",
-			{ service: "TAUTULLI", connectionGeneration: 4 },
+			providerConnectionIdentity(instance("one") as never),
 			schedulerApp.log,
 		);
 	});

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -20,6 +20,8 @@ import { getErrorMessage } from "../lib/utils/error-message.js";
 const INTERVAL_MS = 6 * 60 * 60 * 1000;
 const STARTUP_DELAY_MS = 2 * 60_000;
 
+export type ScheduledTautulliRefreshOutcome = "success" | "superseded" | "failed";
+
 /**
  * Runs the reviewed cache-publication boundary for one current Tautulli
  * instance. A disabled or changed instance is skipped before client creation;
@@ -28,8 +30,8 @@ const STARTUP_DELAY_MS = 2 * 60_000;
 export async function refreshScheduledTautulliCacheInstance(
 	app: Pick<FastifyInstance, "encryptor" | "prisma" | "log">,
 	instance: ServiceInstance,
-): Promise<void> {
-	if (!instance.enabled || instance.service !== "TAUTULLI") return;
+): Promise<ScheduledTautulliRefreshOutcome> {
+	if (!instance.enabled || instance.service !== "TAUTULLI") return "superseded";
 
 	const expectedConnection = providerConnectionIdentity(instance);
 	const tautulliInstance = instance as ServiceInstance & { service: "TAUTULLI" };
@@ -46,19 +48,29 @@ export async function refreshScheduledTautulliCacheInstance(
 			{ instanceId: instance.id, complete: result.complete, superseded: result.superseded },
 			"Tautulli cache refresh completed for instance",
 		);
+		if (result.superseded) return "superseded";
+		return result.complete ? "success" : "failed";
 	} catch (error) {
 		app.log.error(
 			{ err: error, instanceId: instance.id },
 			"Tautulli cache refresh failed for instance",
 		);
-		await recordProviderCacheRefreshFailure(
-			app.prisma,
-			instance.id,
-			"tautulli",
-			getErrorMessage(error, "Tautulli cache refresh failed"),
-			expectedConnection,
-			app.log,
-		);
+		try {
+			await recordProviderCacheRefreshFailure(
+				app.prisma,
+				instance.id,
+				"tautulli",
+				getErrorMessage(error, "Tautulli cache refresh failed"),
+				expectedConnection,
+				app.log,
+			);
+		} catch (statusError) {
+			app.log.warn(
+				{ err: statusError, instanceId: instance.id },
+				"Failed to record Tautulli cache refresh failure status",
+			);
+		}
+		return "failed";
 	}
 }
 
@@ -84,8 +96,15 @@ const tautulliCacheSchedulerPlugin = fastifyPlugin(
 						return;
 					}
 
+					let failedInstances = 0;
 					for (const instance of instances) {
-						await refreshScheduledTautulliCacheInstance(app, instance);
+						const outcome = await refreshScheduledTautulliCacheInstance(app, instance);
+						if (outcome === "failed") failedInstances += 1;
+					}
+					if (failedInstances > 0) {
+						throw new Error(
+							`Tautulli cache refresh failed for ${failedInstances} configured instance${failedInstances === 1 ? "" : "s"}`,
+						);
 					}
 				});
 			} finally {

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -34,8 +34,24 @@ export async function refreshScheduledTautulliCacheInstance(
 	if (!instance.enabled || instance.service !== "TAUTULLI") return "superseded";
 
 	const expectedConnection = providerConnectionIdentity(instance);
-	const tautulliInstance = instance as ServiceInstance & { service: "TAUTULLI" };
 	try {
+		const currentInstance = await app.prisma.serviceInstance.findUnique({
+			where: { id: instance.id },
+		});
+		if (!currentInstance?.enabled || currentInstance.service !== "TAUTULLI") {
+			return "superseded";
+		}
+		const currentConnection = providerConnectionIdentity(currentInstance);
+		if (
+			currentConnection.userId !== expectedConnection.userId ||
+			currentConnection.service !== expectedConnection.service ||
+			currentConnection.connectionGeneration !== expectedConnection.connectionGeneration ||
+			currentConnection.connectionFingerprint !== expectedConnection.connectionFingerprint
+		) {
+			return "superseded";
+		}
+
+		const tautulliInstance = currentInstance as ServiceInstance & { service: "TAUTULLI" };
 		const client = createTautulliClient(app.encryptor, tautulliInstance, app.log);
 		const result = await refreshTautulliCache(
 			client,

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -1,0 +1,115 @@
+/**
+ * Tautulli Cache Scheduler Plugin
+ *
+ * Refreshes the guarded Tautulli cache for every enabled instance every six
+ * hours. The refresher owns generation publication and durable attempt status;
+ * this plugin only schedules work and records failures that happen before the
+ * refresher boundary can start.
+ */
+
+import type { FastifyInstance } from "fastify";
+import fastifyPlugin from "fastify-plugin";
+import type { ServiceInstance } from "../lib/prisma.js";
+import { providerConnectionIdentity } from "../lib/services/provider-connection-guard.js";
+import { recordProviderCacheRefreshFailure } from "../lib/services/provider-cache-status.js";
+import { refreshTautulliCache } from "../lib/tautulli/tautulli-cache-refresher.js";
+import { createTautulliClient } from "../lib/tautulli/tautulli-client.js";
+import { getErrorMessage } from "../lib/utils/error-message.js";
+
+const INTERVAL_MS = 6 * 60 * 60 * 1000;
+const STARTUP_DELAY_MS = 2 * 60_000;
+
+/**
+ * Runs the reviewed cache-publication boundary for one current Tautulli
+ * instance. A disabled or changed instance is skipped before client creation;
+ * the boundary repeats that guard transactionally before publication.
+ */
+export async function refreshScheduledTautulliCacheInstance(
+	app: Pick<FastifyInstance, "encryptor" | "prisma" | "log">,
+	instance: ServiceInstance,
+): Promise<void> {
+	if (!instance.enabled || instance.service !== "TAUTULLI") return;
+
+	const expectedConnection = providerConnectionIdentity(instance);
+	const tautulliInstance = instance as ServiceInstance & { service: "TAUTULLI" };
+	try {
+		const client = createTautulliClient(app.encryptor, tautulliInstance, app.log);
+		const result = await refreshTautulliCache(
+			client,
+			app.prisma,
+			instance.id,
+			app.log,
+			expectedConnection,
+		);
+		app.log.info(
+			{ instanceId: instance.id, complete: result.complete, superseded: result.superseded },
+			"Tautulli cache refresh completed for instance",
+		);
+	} catch (error) {
+		app.log.error(
+			{ err: error, instanceId: instance.id },
+			"Tautulli cache refresh failed for instance",
+		);
+		await recordProviderCacheRefreshFailure(
+			app.prisma,
+			instance.id,
+			"tautulli",
+			getErrorMessage(error, "Tautulli cache refresh failed"),
+			expectedConnection,
+			app.log,
+		);
+	}
+}
+
+const tautulliCacheSchedulerPlugin = fastifyPlugin(
+	async (app: FastifyInstance) => {
+		let intervalHandle: ReturnType<typeof setInterval> | null = null;
+		let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+		let isRunning = false;
+
+		async function refreshAllTautulliCaches(): Promise<void> {
+			if (isRunning) {
+				app.log.warn("Tautulli cache refresh already running, skipping");
+				return;
+			}
+			isRunning = true;
+			try {
+				const instances = await app.prisma.serviceInstance.findMany({
+					where: { service: "TAUTULLI", enabled: true },
+				});
+				if (instances.length === 0) {
+					app.log.debug("Tautulli cache refresh: no enabled Tautulli instances, skipping");
+					return;
+				}
+
+				for (const instance of instances) {
+					await refreshScheduledTautulliCacheInstance(app, instance);
+				}
+			} finally {
+				isRunning = false;
+			}
+		}
+
+		app.addHook("onReady", async () => {
+			app.log.info("Tautulli cache scheduler initialized (6h interval, 2min startup delay)");
+			timeoutHandle = setTimeout(() => {
+				void refreshAllTautulliCaches().catch((error) => {
+					app.log.error({ err: error }, "Initial Tautulli cache refresh failed");
+				});
+				intervalHandle = setInterval(() => {
+					void refreshAllTautulliCaches().catch((error) => {
+						app.log.error({ err: error }, "Scheduled Tautulli cache refresh failed");
+					});
+				}, INTERVAL_MS);
+			}, STARTUP_DELAY_MS);
+		});
+
+		app.addHook("onClose", async () => {
+			if (timeoutHandle) clearTimeout(timeoutHandle);
+			if (intervalHandle) clearInterval(intervalHandle);
+		});
+	},
+	{ name: "tautulli-cache-scheduler" },
+);
+
+export default tautulliCacheSchedulerPlugin;

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -10,6 +10,7 @@
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import type { ServiceInstance } from "../lib/prisma.js";
+import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { providerConnectionIdentity } from "../lib/services/provider-connection-guard.js";
 import { recordProviderCacheRefreshFailure } from "../lib/services/provider-cache-status.js";
 import { refreshTautulliCache } from "../lib/tautulli/tautulli-cache-refresher.js";
@@ -74,17 +75,19 @@ const tautulliCacheSchedulerPlugin = fastifyPlugin(
 			}
 			isRunning = true;
 			try {
-				const instances = await app.prisma.serviceInstance.findMany({
-					where: { service: "TAUTULLI", enabled: true },
-				});
-				if (instances.length === 0) {
-					app.log.debug("Tautulli cache refresh: no enabled Tautulli instances, skipping");
-					return;
-				}
+				await app.schedulerRegistry.track(JOB_ID.tautulliCache, async () => {
+					const instances = await app.prisma.serviceInstance.findMany({
+						where: { service: "TAUTULLI", enabled: true },
+					});
+					if (instances.length === 0) {
+						app.log.debug("Tautulli cache refresh: no enabled Tautulli instances, skipping");
+						return;
+					}
 
-				for (const instance of instances) {
-					await refreshScheduledTautulliCacheInstance(app, instance);
-				}
+					for (const instance of instances) {
+						await refreshScheduledTautulliCacheInstance(app, instance);
+					}
+				});
 			} finally {
 				isRunning = false;
 			}
@@ -109,7 +112,7 @@ const tautulliCacheSchedulerPlugin = fastifyPlugin(
 			if (intervalHandle) clearInterval(intervalHandle);
 		});
 	},
-	{ name: "tautulli-cache-scheduler" },
+	{ name: "tautulli-cache-scheduler", dependencies: ["scheduler-registry"] },
 );
 
 export default tautulliCacheSchedulerPlugin;

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -1,15 +1,15 @@
 /**
- * Integration tests for cache.refresh action emission on GET /pulse.
+ * Integration tests for cache freshness signals on GET /pulse.
  *
- * Mirrors the structure of pulse-scheduler-health.test.ts: run the real
- * `collectCacheStaleness` against a stubbed Prisma surface and assert the
- * emission gate for each cacheType × status combination.
+ * Runs the real generic and Tautulli cache collectors against a stubbed Prisma
+ * surface, pinning their distinct action and stable-ID contracts.
  *
  * The emission rule under test:
  *   emit action iff
  *     status.lastResult !== "error"
  *     AND status.lastRefreshedAt < now - STALE_CACHE_HOURS
- *     AND status.cacheType ∈ {"plex", "jellyfin"}
+ *     AND status.cacheType ∈ {"plex", "jellyfin"}. Tautulli uses its own
+ *     supported instance-keyed collector and deliberately has no action.
  */
 
 import Fastify from "fastify";
@@ -19,7 +19,9 @@ vi.mock("../../lib/pulse/collectors.js", async () => {
 	const actual = await vi.importActual<typeof import("../../lib/pulse/collectors.js")>(
 		"../../lib/pulse/collectors.js",
 	);
-	return { pulseCollectors: [actual.collectCacheStaleness] };
+	return {
+		pulseCollectors: [actual.collectCacheStaleness, actual.collectTautulliCacheHealth],
+	};
 });
 
 import { registerPulseRoutes } from "../pulse.js";
@@ -100,18 +102,26 @@ describe("GET /pulse — cache.refresh action emission", () => {
 		});
 	});
 
-	it("renders a lingering pre-3.0 tautulli cache row WITHOUT an action (ADR-0007)", async () => {
-		// Tautulli was removed in 3.0; CacheRefreshStatus rows with
-		// cacheType "tautulli" can linger until the migration dialog deletes
-		// their instances. They must still render (operator visibility) but
-		// must NOT carry a refresh button the dispatcher can no longer honor.
-		cacheStatuses = [makeRow({ id: "taut-row", cacheType: "tautulli", instanceId: "inst-taut" })];
+	it("renders a supported Tautulli stale signal with an instance-keyed id and no action", async () => {
+		cacheStatuses = [
+			makeRow({
+				id: "taut-row",
+				cacheType: "tautulli",
+				instanceId: "inst-taut",
+				instance: { label: "Private Tautulli", service: "TAUTULLI", enabled: true },
+			}),
+		];
 
 		const res = await injectAuthenticated("GET", "/pulse");
 		const body = JSON.parse(res.payload);
-		const item = body.items.find((i: { id: string }) => i.id === "cache-stale-taut-row");
+		const item = body.items.find((i: { id: string }) => i.id === "tautulli-cache-stale-inst-taut");
 
-		expect(item).toBeDefined();
+		expect(item).toMatchObject({
+			title: "Tautulli cache is stale",
+			source: "tautulli",
+			actionUrl: "/settings",
+			actionLabel: "Check Tautulli settings",
+		});
 		expect(item.action).toBeUndefined();
 	});
 

--- a/apps/api/src/routes/pulse.ts
+++ b/apps/api/src/routes/pulse.ts
@@ -61,6 +61,7 @@ export const COLLECTOR_LABELS: Record<string, string> = {
 	collectArrQueueFailures: "queue failures",
 	collectSeerrCircuitBreaker: "Seerr circuit breaker",
 	collectCacheStaleness: "cache freshness",
+	collectTautulliCacheHealth: "Tautulli cache health",
 	collectLibrarySyncHealth: "library sync",
 	collectValidationHealth: "validation health",
 	collectLibraryInsightCounts: "library insights",

--- a/apps/web/src/features/console/lib/__tests__/console-domains.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/console-domains.test.ts
@@ -189,6 +189,20 @@ describe("buildDomainTiles — service gating by omission", () => {
 		expect(ids).not.toContain("requests");
 	});
 
+	it("includes Tautulli scheduler health for a Tautulli-only installation", () => {
+		const tiles = buildDomainTiles(
+			[makeJob({ id: "tautulli-cache", consecutiveFailures: 2 })],
+			[{ service: "tautulli", enabled: true }],
+		);
+
+		expect(tiles).toEqual([
+			expect.objectContaining({
+				domain: expect.objectContaining({ id: "media-caches" }),
+				status: "degraded",
+			}),
+		]);
+	});
+
 	it("a DISABLED instance does not satisfy the gate", () => {
 		const tiles = buildDomainTiles(ALL_JOBS, [{ service: "seerr", enabled: false }]);
 		expect(tiles.map((t) => t.domain.id)).not.toContain("requests");

--- a/apps/web/src/features/console/lib/console-domains.ts
+++ b/apps/web/src/features/console/lib/console-domains.ts
@@ -22,7 +22,6 @@
  *   action or page to link to.
  */
 
-import type { ServiceInstanceSummary } from "@arr/shared";
 import type { LucideIcon } from "lucide-react";
 import {
 	Archive,
@@ -103,9 +102,10 @@ export const CONSOLE_DOMAINS: readonly ConsoleDomain[] = [
 			"plex-episode-cache",
 			"jellyfin-cache",
 			"jellyfin-episode-cache",
+			"tautulli-cache",
 			"session-snapshot",
 		],
-		requiresService: ["plex", "jellyfin", "emby"],
+		requiresService: ["plex", "jellyfin", "emby", "tautulli"],
 	},
 	{
 		id: "automation",
@@ -235,7 +235,7 @@ export function deriveDomainTile(
  */
 export function buildDomainTiles(
 	jobs: readonly SystemJobStatus[],
-	services: readonly Pick<ServiceInstanceSummary, "service" | "enabled">[],
+	services: readonly { service: string; enabled: boolean }[],
 ): DomainTileModel[] {
 	const enabledServices = new Set(
 		services.filter((s) => s.enabled).map((s) => s.service.toLowerCase()),


### PR DESCRIPTION
## Summary

- schedule guarded Tautulli cache refreshes every six hours after a two-minute startup delay
- serialize overlapping ticks and publish per-job status through the scheduler registry
- report failed or stale Tautulli cache health in Pulse without rendering upstream URLs, users, titles, or credential-shaped error text
- surface Tautulli scheduler health in the Console Media Caches domain for Tautulli-only installations

## Safety and failure behavior

- every refresh still publishes through the owner-and-connection-bound cache guard merged in #701
- disabled, deleted, changed, or superseded instances cannot publish stale data
- one instance failure does not prevent remaining instances from being attempted
- non-superseded incomplete or caught failures mark the tracked job tick failed with a sanitized count-only message
- superseded refreshes are neutral and do not create false scheduler failures
- timers are cleared at shutdown and overlapping ticks are skipped

## Scope boundary

This slice adds scheduler and health wiring only. Tautulli analytics routes, service setup UI, provider selection wizard, Tracearr integration changes, and the reusable live verification harness remain separate follow-up slices.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test: 3,803 passed, 41 skipped
- pnpm run lint
- pnpm run build
- independent data-safety review: resolved
- independent regression review: resolved
