### PR TITLE
feat: add guarded Tautulli provider routes

### DIFF
--- a/apps/api/src/lib/services/provider-cache-status.ts
+++ b/apps/api/src/lib/services/provider-cache-status.ts
@@ -6,6 +6,51 @@ import {
 	withCurrentProviderConnection,
 } from "./provider-connection-guard.js";
 
+/** Persist an in-flight attempt before any provider request is sent. */
+export async function recordProviderCacheRefreshPending(
+	prisma: Pick<PrismaClient, "$transaction">,
+	instanceId: string,
+	cacheType: string,
+	expected: ProviderConnectionIdentity,
+	log: Pick<FastifyBaseLogger, "warn">,
+	attemptedAt: Date = new Date(),
+): Promise<"recorded" | "superseded" | "failed"> {
+	try {
+		const result = await withCurrentProviderConnection(
+			prisma,
+			instanceId,
+			expected,
+			async (tx) =>
+				await tx.cacheRefreshStatus.upsert({
+					where: { instanceId_cacheType: { instanceId, cacheType } },
+					create: {
+						instanceId,
+						cacheType,
+						lastRefreshedAt: attemptedAt,
+						lastResult: "error",
+						lastErrorMessage: "No complete cache generation has been published",
+						itemCount: 0,
+						lastAttemptAt: attemptedAt,
+						lastAttemptResult: "pending",
+						lastAttemptErrorMessage: null,
+					},
+					update: {
+						lastAttemptAt: attemptedAt,
+						lastAttemptResult: "pending",
+						lastAttemptErrorMessage: null,
+					},
+				}),
+		);
+		return result.matched ? "recorded" : "superseded";
+	} catch (error) {
+		log.warn(
+			{ err: error, instanceId, cacheType },
+			"Failed to record provider cache refresh pending status",
+		);
+		return "failed";
+	}
+}
+
 /**
  * Record a provider refresh failure only while the connection generation that
  * produced the attempt is still current.

--- a/apps/api/src/lib/services/provider-connection-guard.ts
+++ b/apps/api/src/lib/services/provider-connection-guard.ts
@@ -33,6 +33,19 @@ export function providerConnectionIdentity(
 	};
 }
 
+export function matchesProviderConnectionIdentity(
+	instance: ProviderConnectionSource,
+	expected: ProviderConnectionIdentity,
+): boolean {
+	const current = providerConnectionIdentity(instance);
+	return (
+		current.userId === expected.userId &&
+		current.service === expected.service &&
+		current.connectionGeneration === expected.connectionGeneration &&
+		current.connectionFingerprint === expected.connectionFingerprint
+	);
+}
+
 export async function withCurrentProviderConnection<T>(
 	prisma: Pick<PrismaClient, "$transaction">,
 	instanceId: string,
@@ -62,13 +75,7 @@ export async function withCurrentProviderConnection<T>(
 						connectionGeneration: true,
 					},
 				});
-				if (
-					!current?.enabled ||
-					current.userId !== expected.userId ||
-					current.service !== expected.service ||
-					current.connectionGeneration !== expected.connectionGeneration ||
-					plexConnectionFingerprint(current) !== expected.connectionFingerprint
-				) {
+				if (!current?.enabled || !matchesProviderConnectionIdentity(current, expected)) {
 					return { matched: false };
 				}
 			}

--- a/apps/api/src/lib/tautulli/current-tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/current-tautulli-client.ts
@@ -1,0 +1,52 @@
+import type { FastifyInstance } from "fastify";
+import type { ServiceInstance } from "../prisma.js";
+import {
+	matchesProviderConnectionIdentity,
+	providerConnectionIdentity,
+} from "../services/provider-connection-guard.js";
+import {
+	createTautulliClient,
+	type TautulliClient,
+	type TautulliClientInstanceData,
+} from "./tautulli-client.js";
+
+export class TautulliConnectionChangedError extends Error {
+	constructor() {
+		super("Tautulli connection changed during request");
+		this.name = "TautulliConnectionChangedError";
+	}
+}
+
+export function isTautulliConnectionChanged(error: unknown): boolean {
+	return error instanceof TautulliConnectionChangedError;
+}
+
+export function createCurrentTautulliClient(
+	app: Pick<FastifyInstance, "encryptor" | "prisma" | "log">,
+	instance: ServiceInstance,
+): { client: TautulliClient; ensureCurrent: () => Promise<void> } {
+	const expected = providerConnectionIdentity(instance);
+	const ensureCurrent = async (): Promise<void> => {
+		const current = await app.prisma.serviceInstance.findFirst({
+			where: {
+				id: instance.id,
+				userId: expected.userId,
+				service: "TAUTULLI",
+				enabled: true,
+			},
+		});
+		if (!current || !matchesProviderConnectionIdentity(current, expected)) {
+			throw new TautulliConnectionChangedError();
+		}
+	};
+
+	return {
+		client: createTautulliClient(
+			app.encryptor,
+			instance as TautulliClientInstanceData,
+			app.log,
+			ensureCurrent,
+		),
+		ensureCurrent,
+	};
+}

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.test.ts
@@ -146,6 +146,33 @@ function makeAtomicPrisma(options?: {
 }
 
 describe("refreshTautulliCache", () => {
+	it("records a durable pending attempt before contacting Tautulli", async () => {
+		const { prisma, state } = makeAtomicPrisma();
+		let releaseLibraries: (() => void) | undefined;
+		const client = completeClient();
+		client.getLibraries = vi.fn<TautulliClient["getLibraries"]>(
+			() =>
+				new Promise((resolve) => {
+					releaseLibraries = () =>
+						resolve([
+							{
+								section_id: "movies",
+								section_name: "Movies",
+								section_type: "movie",
+								count: "2",
+							},
+						]);
+				}),
+		);
+
+		const refresh = refreshTautulliCache(client, prisma, "tautulli-1", log, expectedConnection);
+		await vi.waitFor(() => expect(state.status.lastAttemptResult).toBe("pending"));
+		expect(client.getLibraries).toHaveBeenCalledTimes(1);
+
+		releaseLibraries?.();
+		await refresh;
+	});
+
 	it("publishes a complete staged generation and success attempt atomically", async () => {
 		const { prisma, state } = makeAtomicPrisma();
 
@@ -373,10 +400,11 @@ describe("refreshTautulliCache", () => {
 		const second = refreshTautulliCache(client, prisma, "tautulli-1", log, expectedConnection);
 
 		expect(first).toBe(second);
-		expect(client.getLibraries).toHaveBeenCalledTimes(1);
+		await vi.waitFor(() => expect(client.getLibraries).toHaveBeenCalledTimes(1));
 		release?.();
 		await expect(Promise.all([first, second])).resolves.toHaveLength(2);
-		expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+		// One transaction records the pending witness and one publishes the generation.
+		expect(prisma.$transaction).toHaveBeenCalledTimes(2);
 	});
 
 	it.each([

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -8,7 +8,10 @@ import { randomUUID } from "node:crypto";
 import type { TautulliHistoryItem, TautulliHistorySnapshot } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { PrismaClient } from "../prisma.js";
-import { recordProviderCacheRefreshFailure } from "../services/provider-cache-status.js";
+import {
+	recordProviderCacheRefreshFailure,
+	recordProviderCacheRefreshPending,
+} from "../services/provider-cache-status.js";
 import {
 	type ProviderConnectionIdentity,
 	withCurrentProviderConnection,
@@ -82,6 +85,25 @@ async function performTautulliCacheRefresh(
 	log: FastifyBaseLogger,
 	expectedConnection: ProviderConnectionIdentity,
 ): Promise<TautulliCacheRefreshResult> {
+	const pending = await recordProviderCacheRefreshPending(
+		prisma,
+		instanceId,
+		CACHE_TYPE,
+		expectedConnection,
+		log,
+	);
+	if (pending !== "recorded") {
+		return {
+			upserted: 0,
+			errors: pending === "failed" ? 1 : 0,
+			errorMessages:
+				pending === "failed"
+					? ["Tautulli cache refresh could not record its pending attempt"]
+					: ["Tautulli service connection changed before refresh"],
+			complete: false,
+			superseded: pending === "superseded" || undefined,
+		};
+	}
 	try {
 		const staged = await gatherCompleteSnapshot(client, instanceId);
 		const completedAt = new Date();

--- a/apps/api/src/lib/tautulli/tautulli-client.test.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.test.ts
@@ -33,6 +33,24 @@ function historyPage(start: number, count: number, total = 3) {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("TautulliClient", () => {
+	it("runs the current-connection guard before any provider request", async () => {
+		const fetchMock = vi.fn();
+		const beforeRequest = vi.fn().mockRejectedValue(new Error("connection changed"));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new TautulliClient(
+			"http://tautulli.example",
+			"api-key-value",
+			log,
+			10_000,
+			{},
+			beforeRequest,
+		);
+
+		await expect(client.getInfo()).rejects.toThrow("connection changed");
+		expect(beforeRequest).toHaveBeenCalledTimes(1);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("keeps API-key query authentication when optional HTTP Basic auth is used", async () => {
 		const fetchMock = vi.fn().mockResolvedValue(success({ tautulli_version: "2.15.1" }));
 		vi.stubGlobal("fetch", fetchMock);
@@ -46,6 +64,31 @@ describe("TautulliClient", () => {
 		expect(new URL(requestUrl).searchParams.get("apikey")).toBe("api-key-value");
 		expect(new URL(requestUrl).searchParams.get("cmd")).toBe("get_tautulli_info");
 		expect(new Headers(request.headers).get("authorization")).toBe("Basic cHJveHk6c2VjcmV0");
+	});
+
+	it("fetches documented provider user identities and preserves friendly names", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			success([
+				{
+					user_id: "133788",
+					username: "jon@example.test",
+					friendly_name: "Jon Snow",
+					is_active: 1,
+					ignored_future_field: true,
+				},
+			]),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new TautulliClient("http://tautulli.example", "api-key-value", log);
+
+		await expect(client.getUsers()).resolves.toEqual([
+			expect.objectContaining({
+				user_id: "133788",
+				username: "jon@example.test",
+				friendly_name: "Jon Snow",
+			}),
+		]);
+		expect(new URL(fetchMock.mock.calls[0]![0]).searchParams.get("cmd")).toBe("get_users");
 	});
 
 	it("rejects a non-Tautulli instance before decrypting its credentials", () => {
@@ -153,6 +196,28 @@ describe("TautulliClient", () => {
 			order: [{ column: 0, dir: "asc" }],
 			start: 0,
 			length: 2,
+		});
+	});
+
+	it("uses documented newest-first date ordering for a bounded user-facing history page", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(success(historyPage(0, 1, 1)));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new TautulliClient("http://tautulli.example", "api-key-value", log);
+
+		await client.getHistoryNewestPage({ start: 0, length: 1 });
+
+		const request = new URL(fetchMock.mock.calls[0]![0]);
+		expect(JSON.parse(request.searchParams.get("json_data")!)).toMatchObject({
+			columns: [
+				{ data: "date", orderable: true, searchable: false },
+				{ data: "row_id", orderable: true, searchable: false },
+			],
+			order: [
+				{ column: 0, dir: "desc" },
+				{ column: 1, dir: "desc" },
+			],
+			start: 0,
+			length: 1,
 		});
 	});
 

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -4,6 +4,7 @@ import type {
 	TautulliHomeStat,
 	TautulliInfo,
 	TautulliLibrary,
+	TautulliUser,
 	TautulliUserWatchTimeStat,
 } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
@@ -22,12 +23,14 @@ import {
 	tautulliMetadataSchema,
 	tautulliPlaysByDateDataSchema,
 	tautulliResponseWrapperSchema,
+	tautulliUserSchema,
 	tautulliUserWatchTimeStatsSchema,
 } from "./tautulli-schemas.js";
 
 const DEFAULT_TIMEOUT = 10_000;
 const DEFAULT_HISTORY_PAGE_SIZE = 500;
 const MAX_HISTORY_PAGE_SIZE = 1_000;
+export const MAX_TAUTULLI_HISTORY_PAGE_LENGTH = 500;
 export const MAX_TAUTULLI_HISTORY_RESULTS = 100_000;
 
 export interface TautulliHistoryData {
@@ -86,6 +89,12 @@ export interface TautulliHistorySnapshotOptions {
 	section_id?: string;
 }
 
+export interface TautulliHistoryPageOptions {
+	start: number;
+	length: number;
+	sectionId?: string;
+}
+
 export type TautulliClientInstanceData = Omit<ClientInstanceData, "service"> & {
 	service: "TAUTULLI";
 };
@@ -96,6 +105,7 @@ export class TautulliClient {
 	private readonly log: FastifyBaseLogger;
 	private readonly timeout: number;
 	private readonly httpAuthHeaders: Record<string, string>;
+	private readonly beforeRequest?: () => Promise<void>;
 
 	constructor(
 		baseUrl: string,
@@ -103,12 +113,14 @@ export class TautulliClient {
 		log: FastifyBaseLogger,
 		timeout = DEFAULT_TIMEOUT,
 		httpAuthHeaders: Record<string, string> = {},
+		beforeRequest?: () => Promise<void>,
 	) {
 		this.baseUrl = baseUrl.replace(/\/$/, "");
 		this.apiKey = apiKey;
 		this.log = log;
 		this.timeout = timeout;
 		this.httpAuthHeaders = httpAuthHeaders;
+		this.beforeRequest = beforeRequest;
 	}
 
 	getInfo(): Promise<TautulliInfo> {
@@ -121,6 +133,41 @@ export class TautulliClient {
 
 	getHistory(params?: Record<string, string | number | undefined>): Promise<TautulliHistoryData> {
 		return this.command("get_history", params, tautulliHistoryDataSchema);
+	}
+
+	/** User-facing history pages use Tautulli's documented date-descending order. */
+	getHistoryNewestPage(options: TautulliHistoryPageOptions): Promise<TautulliHistoryData> {
+		if (
+			!Number.isSafeInteger(options.start) ||
+			options.start < 0 ||
+			!Number.isSafeInteger(options.length) ||
+			options.length < 1 ||
+			options.length > MAX_TAUTULLI_HISTORY_PAGE_LENGTH
+		) {
+			throw new Error(
+				`Tautulli history pages require a non-negative start and a length from 1 to ${MAX_TAUTULLI_HISTORY_PAGE_LENGTH}`,
+			);
+		}
+
+		return this.getHistory({
+			section_id: options.sectionId,
+			grouping: 0,
+			include_activity: 0,
+			json_data: JSON.stringify({
+				draw: 1,
+				columns: [
+					{ data: "date", orderable: true, searchable: false },
+					{ data: "row_id", orderable: true, searchable: false },
+				],
+				order: [
+					{ column: 0, dir: "desc" },
+					{ column: 1, dir: "desc" },
+				],
+				start: options.start,
+				length: options.length,
+				search: { value: "" },
+			}),
+		});
 	}
 
 	async getHistorySnapshot(
@@ -252,7 +299,14 @@ export class TautulliClient {
 		);
 	}
 
-	getUserWatchTimeStats(userId: string, queryDays?: string): Promise<TautulliUserWatchTimeStat[]> {
+	getUsers(): Promise<TautulliUser[]> {
+		return this.command("get_users", undefined, tautulliUserSchema.array());
+	}
+
+	getUserWatchTimeStats(
+		userId: string,
+		queryDays?: string | number,
+	): Promise<TautulliUserWatchTimeStat[]> {
 		if (!userId.trim()) {
 			throw new Error("Tautulli user watch-time stats require a user id");
 		}
@@ -263,10 +317,10 @@ export class TautulliClient {
 		);
 	}
 
-	getHomeStats(timeRange = 30): Promise<TautulliHomeStat[]> {
+	getHomeStats(timeRange = 30, statsCount = 10): Promise<TautulliHomeStat[]> {
 		return this.command(
 			"get_home_stats",
-			{ time_range: timeRange },
+			{ time_range: timeRange, stats_count: statsCount },
 			tautulliHomeStatSchema.array(),
 		);
 	}
@@ -280,6 +334,7 @@ export class TautulliClient {
 		params: Record<string, string | number | undefined> | undefined,
 		schema: z.ZodType<T>,
 	): Promise<T> {
+		await this.beforeRequest?.();
 		const url = new URL(`${this.baseUrl}/api/v2`);
 		url.searchParams.set("apikey", this.apiKey);
 		url.searchParams.set("cmd", cmd);
@@ -327,6 +382,7 @@ export function createTautulliClient(
 	encryptor: Encryptor,
 	instance: TautulliClientInstanceData,
 	log: FastifyBaseLogger,
+	beforeRequest?: () => Promise<void>,
 ): TautulliClient {
 	if (instance.service !== "TAUTULLI") {
 		throw new Error("Instance is not a Tautulli service");
@@ -341,5 +397,6 @@ export function createTautulliClient(
 		log,
 		DEFAULT_TIMEOUT,
 		getStoredHttpAuthHeaders(encryptor, instance),
+		beforeRequest,
 	);
 }

--- a/apps/api/src/lib/tautulli/tautulli-schemas.test.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { tautulliHomeStatSchema, tautulliMetadataSchema } from "./tautulli-schemas.js";
+import {
+	tautulliHomeStatSchema,
+	tautulliMetadataSchema,
+	tautulliUserSchema,
+} from "./tautulli-schemas.js";
 
 describe("Tautulli boundary schemas", () => {
 	it("normalizes a sparse metadata success payload without inventing identity", () => {
@@ -16,5 +20,35 @@ describe("Tautulli boundary schemas", () => {
 		});
 
 		expect(parsed.rows[0]).toMatchObject({ total_plays: 0, total_duration: 0 });
+	});
+
+	it("accepts documented user identities without inventing fields", () => {
+		expect(
+			tautulliUserSchema.parse({
+				user_id: "133788",
+				username: "jon@example.test",
+				friendly_name: "Jon Snow",
+			}),
+		).toEqual({
+			user_id: "133788",
+			username: "jon@example.test",
+			friendly_name: "Jon Snow",
+		});
+	});
+
+	it("preserves documented stat-specific row identity and metrics", () => {
+		const platform = tautulliHomeStatSchema.parse({
+			stat_id: "top_platforms",
+			stat_title: "Most Active Platforms",
+			rows: [{ title: "", platform: "Chrome", total_plays: 4, total_duration: 120 }],
+		});
+		const concurrent = tautulliHomeStatSchema.parse({
+			stat_id: "most_concurrent",
+			stat_title: "Most Concurrent Streams",
+			rows: [{ title: "Concurrent Streams", count: 3, started: 10, stopped: 20 }],
+		});
+
+		expect(platform.rows[0]).toMatchObject({ platform: "Chrome", total_plays: 4 });
+		expect(concurrent.rows[0]).toMatchObject({ count: 3, started: 10, stopped: 20 });
 	});
 });

--- a/apps/api/src/lib/tautulli/tautulli-schemas.test.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.test.ts
@@ -40,15 +40,21 @@ describe("Tautulli boundary schemas", () => {
 		const platform = tautulliHomeStatSchema.parse({
 			stat_id: "top_platforms",
 			stat_title: "Most Active Platforms",
-			rows: [{ title: "", platform: "Chrome", total_plays: 4, total_duration: 120 }],
+			rows: [{ platform: "Chrome", total_plays: 4, total_duration: 120 }],
+		});
+		const user = tautulliHomeStatSchema.parse({
+			stat_id: "top_users",
+			stat_title: "Most Active Users",
+			rows: [{ user: "jon", friendly_name: "Jon Snow", total_plays: 4 }],
 		});
 		const concurrent = tautulliHomeStatSchema.parse({
 			stat_id: "most_concurrent",
 			stat_title: "Most Concurrent Streams",
-			rows: [{ title: "Concurrent Streams", count: 3, started: 10, stopped: 20 }],
+			rows: [{ count: 3, started: 10, stopped: 20 }],
 		});
 
 		expect(platform.rows[0]).toMatchObject({ platform: "Chrome", total_plays: 4 });
+		expect(user.rows[0]).toMatchObject({ user: "jon", friendly_name: "Jon Snow" });
 		expect(concurrent.rows[0]).toMatchObject({ count: 3, started: 10, stopped: 20 });
 	});
 });

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -89,7 +89,7 @@ export const tautulliHomeStatSchema = z.looseObject({
 	stat_title: z.string(),
 	rows: z.array(
 		z.looseObject({
-			title: z.string(),
+			title: z.string().optional(),
 			friendly_name: z.string().optional(),
 			user: z.string().optional(),
 			user_id: z.coerce.string().optional(),

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -91,12 +91,28 @@ export const tautulliHomeStatSchema = z.looseObject({
 		z.looseObject({
 			title: z.string(),
 			friendly_name: z.string().optional(),
+			user: z.string().optional(),
+			user_id: z.coerce.string().optional(),
+			section_id: z.coerce.string().optional(),
+			section_name: z.string().optional(),
+			section_type: z.string().optional(),
 			total_plays: z.coerce.number().optional().default(0),
 			total_duration: z.coerce.number().optional().default(0),
 			platform: z.string().optional(),
+			count: z.coerce.number().int().nonnegative().optional(),
+			started: z.coerce.number().int().nonnegative().optional(),
+			stopped: z.coerce.number().int().nonnegative().optional(),
+			rating_key: z.coerce.string().optional(),
+			grandparent_rating_key: z.coerce.string().optional(),
 			thumb: z.string().optional(),
 		}),
 	),
+});
+
+export const tautulliUserSchema = z.looseObject({
+	user_id: z.coerce.string(),
+	username: z.string(),
+	friendly_name: z.string().optional(),
 });
 
 export const tautulliUserWatchTimeStatsSchema = z.looseObject({

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -14,7 +14,7 @@ import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 import { providerConnectionIdentity } from "../lib/services/provider-connection-guard.js";
 import { recordProviderCacheRefreshFailure } from "../lib/services/provider-cache-status.js";
 import { refreshTautulliCache } from "../lib/tautulli/tautulli-cache-refresher.js";
-import { createTautulliClient } from "../lib/tautulli/tautulli-client.js";
+import { createCurrentTautulliClient } from "../lib/tautulli/current-tautulli-client.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 
 const INTERVAL_MS = 6 * 60 * 60 * 1000;
@@ -51,8 +51,7 @@ export async function refreshScheduledTautulliCacheInstance(
 			return "superseded";
 		}
 
-		const tautulliInstance = currentInstance as ServiceInstance & { service: "TAUTULLI" };
-		const client = createTautulliClient(app.encryptor, tautulliInstance, app.log);
+		const { client } = createCurrentTautulliClient(app, currentInstance);
 		const result = await refreshTautulliCache(
 			client,
 			app.prisma,

--- a/apps/api/src/routes/route-manifest.ts
+++ b/apps/api/src/routes/route-manifest.ts
@@ -44,6 +44,7 @@ import { registerSeerrRoutes } from "./seerr/index.js";
 import { registerServiceRoutes } from "./services.js";
 import { registerSetupRoutes } from "./setup.js";
 import { registerSystemRoutes } from "./system.js";
+import { registerTautulliRoutes } from "./tautulli/index.js";
 import { registerTracearrRoutes } from "./tracearr.js";
 import { registerTrashGuidesRoutes } from "./trash-guides/index.js";
 
@@ -259,6 +260,14 @@ export const PROTECTED_ROUTE_GROUPS: readonly RouteGroup[] = [
 		register: registerJellyfinRoutes,
 		maturity: "stable",
 		summary: "Jellyfin activity and library data",
+	},
+	{
+		path: "/api/tautulli",
+		prefix: "/api/tautulli",
+		register: registerTautulliRoutes,
+		maturity: "stable",
+		summary:
+			"Provider-specific Tautulli activity, historical analytics, and guarded cache refreshes",
 	},
 	{
 		path: "/api/label-sync",

--- a/apps/api/src/routes/tautulli/__tests__/aggregation.test.ts
+++ b/apps/api/src/routes/tautulli/__tests__/aggregation.test.ts
@@ -1,0 +1,950 @@
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateTautulliClient, mockRefreshTautulliCache } = vi.hoisted(() => ({
+	mockCreateTautulliClient: vi.fn(),
+	mockRefreshTautulliCache: vi.fn(),
+}));
+
+vi.mock("../../../lib/tautulli/tautulli-client.js", () => ({
+	createTautulliClient: (...args: unknown[]) => mockCreateTautulliClient(...args),
+	MAX_TAUTULLI_HISTORY_PAGE_LENGTH: 500,
+}));
+
+vi.mock("../../../lib/tautulli/tautulli-cache-refresher.js", () => ({
+	refreshTautulliCache: (...args: unknown[]) => mockRefreshTautulliCache(...args),
+}));
+
+import { providerConnectionIdentity } from "../../../lib/services/provider-connection-guard.js";
+import { registerTautulliRoutes } from "../index.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+
+const instanceOne = {
+	id: "tautulli-one",
+	userId: "user-1",
+	service: "TAUTULLI",
+	label: "Family Tautulli",
+	baseUrl: "http://tautulli-one.test",
+	encryptedApiKey: "encrypted",
+	encryptionIv: "iv",
+	enabled: true,
+	connectionGeneration: 4,
+};
+
+const instanceTwo = { ...instanceOne, id: "tautulli-two", label: "Guest Tautulli" };
+
+function makeClient(overrides: Record<string, unknown> = {}) {
+	return {
+		getActivity: vi.fn().mockResolvedValue({
+			sessions: [
+				{
+					session_key: "session-1",
+					rating_key: "42",
+					title: "A Sensitive Title",
+					grandparent_title: "A Sensitive Show",
+					media_type: "episode",
+					user: "private-user",
+					friendly_name: "Private User",
+					player: "Chrome",
+					platform: "Web",
+					product: "Plex Web",
+					state: "playing",
+					progress_percent: "50",
+					transcode_decision: "direct play",
+					stream_video_decision: "direct play",
+					stream_audio_decision: "direct play",
+					video_resolution: "1080",
+					audio_codec: "aac",
+					video_codec: "h264",
+					bandwidth: "4000",
+					location: "lan",
+				},
+			],
+			stream_count: "1",
+			total_bandwidth: 4000,
+			lan_bandwidth: 4000,
+			wan_bandwidth: 0,
+		}),
+		getHistory: vi.fn().mockResolvedValue({
+			data: [
+				{
+					row_id: 2,
+					rating_key: "42",
+					parent_rating_key: "41",
+					grandparent_rating_key: "40",
+					title: "Newer Sensitive Title",
+					grandparent_title: "Sensitive Show",
+					media_type: "episode",
+					user: "private-user",
+					date: 2_000,
+				},
+				{
+					row_id: 1,
+					rating_key: "40",
+					parent_rating_key: "",
+					grandparent_rating_key: "",
+					title: "Older Sensitive Title",
+					grandparent_title: "",
+					media_type: "movie",
+					user: "private-user",
+					date: 1_000,
+				},
+			],
+			recordsFiltered: 2,
+			recordsTotal: 2,
+		}),
+		getHistoryPage: vi.fn().mockResolvedValue({
+			data: [
+				{
+					row_id: 2,
+					rating_key: "42",
+					parent_rating_key: "41",
+					grandparent_rating_key: "40",
+					title: "Newer Sensitive Title",
+					grandparent_title: "Sensitive Show",
+					media_type: "episode",
+					user: "private-user",
+					date: 2_000,
+				},
+				{
+					row_id: 1,
+					rating_key: "40",
+					parent_rating_key: "",
+					grandparent_rating_key: "",
+					title: "Older Sensitive Title",
+					grandparent_title: "",
+					media_type: "movie",
+					user: "private-user",
+					date: 1_000,
+				},
+			],
+			recordsFiltered: 2,
+			recordsTotal: 2,
+		}),
+		getHistoryNewestPage: vi.fn().mockResolvedValue({
+			data: [
+				{
+					row_id: 2,
+					rating_key: "42",
+					parent_rating_key: "41",
+					grandparent_rating_key: "40",
+					title: "Newer Sensitive Title",
+					grandparent_title: "Sensitive Show",
+					media_type: "episode",
+					user: "private-user",
+					date: 2_000,
+				},
+				{
+					row_id: 1,
+					rating_key: "40",
+					parent_rating_key: "",
+					grandparent_rating_key: "",
+					title: "Older Sensitive Title",
+					grandparent_title: "",
+					media_type: "movie",
+					user: "private-user",
+					date: 1_000,
+				},
+			],
+			recordsFiltered: 2,
+			recordsTotal: 2,
+		}),
+		getHomeStats: vi.fn().mockResolvedValue([
+			{
+				stat_id: "top_movies",
+				stat_title: "Top Movies",
+				rows: [{ title: "A Sensitive Title", total_plays: 2, total_duration: 100 }],
+			},
+		]),
+		getUsers: vi.fn().mockResolvedValue([{ user_id: "provider-user-1", username: "Private User" }]),
+		getUserWatchTimeStats: vi
+			.fn()
+			.mockImplementation((_userId: string, timeRange: number) =>
+				Promise.resolve([{ query_days: timeRange, total_plays: 2, total_time: 100 }]),
+			),
+		getPlaysByDate: vi.fn().mockResolvedValue({
+			categories: ["2026-08-10"],
+			series: [{ name: "Movies", data: [2] }],
+		}),
+		...overrides,
+	};
+}
+
+function pagedHistory(instanceName: string, totalCount: number, firstDate: number, step = 1) {
+	return vi.fn(({ start, length }: { start: number; length: number }) => ({
+		data: Array.from({ length: Math.max(0, Math.min(length, totalCount - start)) }, (_, index) => {
+			const row = start + index;
+			return {
+				row_id: row + 1,
+				rating_key: `${instanceName}-${row}`,
+				parent_rating_key: "",
+				grandparent_rating_key: "",
+				title: `${instanceName} ${row}`,
+				grandparent_title: "",
+				media_type: "movie",
+				user: instanceName,
+				date: firstDate - row * step,
+			};
+		}),
+		recordsFiltered: totalCount,
+		recordsTotal: totalCount,
+	}));
+}
+
+let app: FastifyInstance;
+let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+let prisma: any;
+
+beforeEach(async () => {
+	vi.clearAllMocks();
+	prisma = {
+		serviceInstance: {
+			findMany: vi.fn().mockResolvedValue([instanceOne]),
+			findFirst: vi.fn().mockResolvedValue(instanceOne),
+		},
+		tautulliCache: { count: vi.fn().mockResolvedValue(3) },
+		cacheRefreshStatus: {
+			findUnique: vi.fn().mockResolvedValue({
+				instanceId: instanceOne.id,
+				cacheType: "tautulli",
+				lastRefreshedAt: new Date("2026-08-12T00:00:00.000Z"),
+				lastResult: "success",
+				lastErrorMessage: null,
+				itemCount: 3,
+				lastAttemptAt: null,
+				lastAttemptResult: null,
+				lastAttemptErrorMessage: null,
+			}),
+			findMany: vi.fn().mockResolvedValue([]),
+		},
+	};
+	mockCreateTautulliClient.mockImplementation((_encryptor, instance) =>
+		makeClient(
+			instance.id === instanceTwo.id
+				? {
+						getHomeStats: vi.fn().mockResolvedValue([
+							{
+								stat_id: "top_movies",
+								stat_title: "Top Movies",
+								rows: [{ title: "A Sensitive Title", total_plays: 3, total_duration: 150 }],
+							},
+						]),
+						getUsers: vi
+							.fn()
+							.mockResolvedValue([{ user_id: "provider-user-2", username: "Guest User" }]),
+						getUserWatchTimeStats: vi
+							.fn()
+							.mockImplementation((_userId: string, timeRange: number) =>
+								Promise.resolve([{ query_days: timeRange, total_plays: 3, total_time: 150 }]),
+							),
+					}
+				: {},
+		),
+	);
+	mockRefreshTautulliCache.mockResolvedValue({
+		complete: true,
+		completedAt: new Date("2026-08-12T00:01:00.000Z"),
+		upserted: 3,
+		errors: 0,
+		errorMessages: [],
+	});
+
+	app = Fastify();
+	app.decorate("prisma", prisma as never);
+	app.decorate("encryptor", {} as never);
+	setupAuthInjection(app);
+	registerTestErrorHandler(app);
+	await app.register(registerTautulliRoutes, { prefix: "/api/tautulli" });
+	await app.ready();
+	injectAuthenticated = createInjectAuthenticated(app);
+});
+
+afterAll(async () => {
+	await app?.close();
+});
+
+describe("Tautulli provider routes", () => {
+	it("returns Tautulli-scoped activity with separately typed sensitive source fields", async () => {
+		const response = await injectAuthenticated("GET", "/api/tautulli/activity");
+		expect(response.statusCode).toBe(200);
+		const body = JSON.parse(response.payload);
+		expect(body.provider).toBe("tautulli");
+		expect(body.sources[0].sessions[0]).toMatchObject({
+			title: "A Sensitive Title",
+			user: "Private User",
+			instanceId: "tautulli-one",
+			instanceLabel: "Family Tautulli",
+		});
+		expect(body.sources[0]).toMatchObject({
+			instanceId: "tautulli-one",
+			instanceLabel: "Family Tautulli",
+			reachable: true,
+		});
+		expect(prisma.serviceInstance.findMany).toHaveBeenCalledWith({
+			where: { userId: "user-1", service: "TAUTULLI", enabled: true },
+			orderBy: { label: "asc" },
+		});
+	});
+
+	it("does not return activity fetched from a connection that changed before response", async () => {
+		prisma.serviceInstance.findFirst.mockResolvedValue({
+			...instanceOne,
+			connectionGeneration: instanceOne.connectionGeneration + 1,
+		});
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/activity");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources).toEqual([
+			expect.objectContaining({
+				instanceId: "tautulli-one",
+				reachable: false,
+				incompleteReason: "connection_changed",
+				sessions: [],
+			}),
+		]);
+	});
+
+	it("keeps statistics scoped to each enabled Tautulli instance", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([instanceOne, instanceTwo]);
+		const response = await injectAuthenticated("GET", "/api/tautulli/stats?timeRange=14");
+		expect(response.statusCode).toBe(200);
+		const body = JSON.parse(response.payload);
+		expect(body.provider).toBe("tautulli");
+		expect(body.sources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					instanceId: "tautulli-one",
+					homeStats: [
+						expect.objectContaining({
+							rows: [expect.objectContaining({ total_plays: 2, total_duration: 100 })],
+						}),
+					],
+					userStats: [
+						expect.objectContaining({
+							userId: "provider-user-1",
+							friendlyName: "Private User",
+							totalPlays: 2,
+						}),
+					],
+					userStatsComplete: true,
+					failedUserCount: 0,
+				}),
+				expect.objectContaining({
+					instanceId: "tautulli-two",
+					homeStats: [
+						expect.objectContaining({
+							rows: [expect.objectContaining({ total_plays: 3, total_duration: 150 })],
+						}),
+					],
+					userStats: [
+						expect.objectContaining({
+							userId: "provider-user-2",
+							friendlyName: "Guest User",
+							totalPlays: 3,
+						}),
+					],
+				}),
+			]),
+		);
+		expect(body).not.toHaveProperty("homeStats");
+		expect(body).not.toHaveProperty("userStats");
+	});
+
+	it("preserves home rankings per source instead of claiming a truncated global aggregate", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([instanceOne, instanceTwo]);
+		mockCreateTautulliClient.mockImplementation((_encryptor, instance) =>
+			makeClient({
+				getHomeStats: vi.fn().mockResolvedValue([
+					{
+						stat_id: "top_platforms",
+						stat_title: "Most Active Platforms",
+						rows: [
+							{
+								title: "",
+								platform: instance.id === instanceOne.id ? "Chrome" : "Android",
+								total_plays: instance.id === instanceOne.id ? 2 : 3,
+								total_duration: 100,
+							},
+						],
+					},
+				]),
+			}),
+		);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/stats?timeRange=14");
+		const body = JSON.parse(response.payload);
+
+		expect(body).not.toHaveProperty("homeStats");
+		expect(body.sources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					instanceId: "tautulli-one",
+					homeStats: [
+						expect.objectContaining({
+							rows: [expect.objectContaining({ platform: "Chrome", total_plays: 2 })],
+						}),
+					],
+				}),
+				expect.objectContaining({
+					instanceId: "tautulli-two",
+					homeStats: [
+						expect.objectContaining({
+							rows: [expect.objectContaining({ platform: "Android", total_plays: 3 })],
+						}),
+					],
+				}),
+			]),
+		);
+	});
+
+	it("preserves an instance's home stats when one documented per-user watch-time request is malformed or fails", async () => {
+		const client = makeClient({
+			getUsers: vi.fn().mockResolvedValue([
+				{ user_id: "provider-user-1", username: "Private User" },
+				{ user_id: "provider-user-2", username: "Unavailable User" },
+			]),
+			getUserWatchTimeStats: vi.fn(async (userId: string, timeRange: number) => {
+				if (userId === "provider-user-2") throw new Error("upstream user totals malformed");
+				return [{ query_days: timeRange, total_plays: 2, total_time: 100 }];
+			}),
+		});
+		mockCreateTautulliClient.mockReturnValue(client);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/stats?timeRange=14");
+
+		expect(response.statusCode).toBe(200);
+		const body = JSON.parse(response.payload);
+		expect(body.sources[0]).toMatchObject({
+			instanceId: "tautulli-one",
+			instanceLabel: "Family Tautulli",
+			reachable: true,
+			userStatsComplete: false,
+			failedUserCount: 1,
+			incompleteReason: "user_stats_partial",
+		});
+		expect(body.sources[0].homeStats).toEqual([
+			expect.objectContaining({
+				stat_id: "top_movies",
+				rows: [expect.objectContaining({ total_plays: 2 })],
+			}),
+		]);
+		expect(body.sources[0].userStats).toEqual([
+			expect.objectContaining({
+				userId: "provider-user-1",
+				friendlyName: "Private User",
+				totalPlays: 2,
+				totalDuration: 100,
+				instanceId: "tautulli-one",
+			}),
+		]);
+		expect(client.getUserWatchTimeStats).toHaveBeenCalledWith("provider-user-1", 14);
+		expect(client.getUserWatchTimeStats).toHaveBeenCalledWith("provider-user-2", 14);
+	});
+
+	it("keeps reachable home stats but marks user statistics incomplete when the user list is unavailable", async () => {
+		const client = makeClient({
+			getUsers: vi.fn().mockRejectedValue(new Error("private upstream detail")),
+		});
+		mockCreateTautulliClient.mockReturnValue(client);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/stats?timeRange=14");
+
+		expect(response.statusCode).toBe(200);
+		const body = JSON.parse(response.payload);
+		expect(body.sources[0].homeStats).toEqual([
+			expect.objectContaining({
+				stat_id: "top_movies",
+				rows: [expect.objectContaining({ total_plays: 2 })],
+			}),
+		]);
+		expect(body.sources[0].userStats).toEqual([]);
+		expect(body.sources[0]).toMatchObject({
+			instanceId: "tautulli-one",
+			instanceLabel: "Family Tautulli",
+			reachable: true,
+			userStatsComplete: false,
+			failedUserCount: 0,
+			incompleteReason: "user_list_unavailable",
+		});
+	});
+
+	it("bounds watch-time requests across instances while preserving source-correct users around an isolated failure", async () => {
+		const pending = new Map<
+			string,
+			{ reject: (reason: Error) => void; resolve: (value: Array<Record<string, number>>) => void }
+		>();
+		let inFlight = 0;
+		let maxInFlight = 0;
+		const deferredWatchTime = vi.fn((userId: string) => {
+			inFlight++;
+			maxInFlight = Math.max(maxInFlight, inFlight);
+			return new Promise((resolve, reject) => {
+				pending.set(userId, {
+					resolve: (value) => {
+						inFlight--;
+						resolve(value);
+					},
+					reject: (reason) => {
+						inFlight--;
+						reject(reason);
+					},
+				});
+			});
+		});
+		const firstClient = makeClient({
+			getUsers: vi.fn().mockResolvedValue(
+				Array.from({ length: 3 }, (_, index) => ({
+					user_id: `first-user-${index + 1}`,
+					username: `First User ${index + 1}`,
+				})),
+			),
+			getUserWatchTimeStats: deferredWatchTime,
+		});
+		const secondClient = makeClient({
+			getUsers: vi.fn().mockResolvedValue(
+				Array.from({ length: 3 }, (_, index) => ({
+					user_id: `second-user-${index + 1}`,
+					username: `Second User ${index + 1}`,
+				})),
+			),
+			getUserWatchTimeStats: deferredWatchTime,
+		});
+		prisma.serviceInstance.findMany.mockResolvedValue([instanceOne, instanceTwo]);
+		mockCreateTautulliClient.mockImplementation((_encryptor, instance) =>
+			instance.id === instanceOne.id ? firstClient : secondClient,
+		);
+
+		const responsePromise = injectAuthenticated("GET", "/api/tautulli/stats?timeRange=14");
+
+		await vi.waitFor(() => expect(deferredWatchTime).toHaveBeenCalledTimes(4));
+		expect(maxInFlight).toBeLessThanOrEqual(4);
+		expect(deferredWatchTime.mock.calls.map(([userId]) => userId)).toEqual([
+			"first-user-1",
+			"first-user-2",
+			"first-user-3",
+			"second-user-1",
+		]);
+
+		pending.get("first-user-1")!.resolve([{ query_days: 14, total_plays: 1, total_time: 100 }]);
+		await vi.waitFor(() => expect(deferredWatchTime).toHaveBeenCalledTimes(5));
+		pending.get("first-user-2")!.reject(new Error("one user failed"));
+		await vi.waitFor(() => expect(deferredWatchTime).toHaveBeenCalledTimes(6));
+		for (const userId of ["first-user-3", "second-user-1", "second-user-2", "second-user-3"]) {
+			pending.get(userId)!.resolve([{ query_days: 14, total_plays: 1, total_time: 100 }]);
+		}
+
+		const response = await responsePromise;
+
+		expect(response.statusCode).toBe(200);
+		expect(maxInFlight).toBeLessThanOrEqual(4);
+		const sources = JSON.parse(response.payload).sources;
+		expect(sources.flatMap((source: { userStats: unknown[] }) => source.userStats)).toEqual([
+			expect.objectContaining({
+				userId: "first-user-1",
+				instanceId: "tautulli-one",
+				instanceLabel: "Family Tautulli",
+			}),
+			expect.objectContaining({
+				userId: "first-user-3",
+				instanceId: "tautulli-one",
+				instanceLabel: "Family Tautulli",
+			}),
+			expect.objectContaining({
+				userId: "second-user-1",
+				instanceId: "tautulli-two",
+				instanceLabel: "Guest Tautulli",
+			}),
+			expect.objectContaining({
+				userId: "second-user-2",
+				instanceId: "tautulli-two",
+				instanceLabel: "Guest Tautulli",
+			}),
+			expect.objectContaining({
+				userId: "second-user-3",
+				instanceId: "tautulli-two",
+				instanceLabel: "Guest Tautulli",
+			}),
+		]);
+	});
+
+	it("keeps paginated history total and completeness visible", async () => {
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=1&limit=1");
+		expect(response.statusCode).toBe(200);
+		const body = JSON.parse(response.payload);
+		expect(body.sources[0].history).toHaveLength(1);
+		expect(body.sources[0].history[0].title).toBe("Older Sensitive Title");
+		expect(body.pagination).toMatchObject({ offset: 1, limit: 1, complete: true });
+		expect(body.sources).toEqual([
+			{
+				instanceId: "tautulli-one",
+				instanceLabel: "Family Tautulli",
+				totalCount: 2,
+				history: [expect.objectContaining({ title: "Older Sensitive Title" })],
+				complete: true,
+			},
+		]);
+	});
+
+	it("uses the newest-first typed history page helper when the requested page exceeds Tautulli's default size", async () => {
+		const client = makeClient();
+		mockCreateTautulliClient.mockReturnValue(client);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=25&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(client.getHistoryNewestPage).toHaveBeenCalledWith({ start: 0, length: 26 });
+		expect(client.getHistoryPage).not.toHaveBeenCalled();
+		expect(client.getHistory).not.toHaveBeenCalled();
+	});
+
+	it("retrieves a single instance's requested history prefix beyond 500 records in bounded pages", async () => {
+		const getHistoryNewestPage = pagedHistory("Single", 600, 2_000_000);
+		const client = makeClient({ getHistoryNewestPage });
+		mockCreateTautulliClient.mockReturnValue(client);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=500&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources[0].history).toEqual([
+			expect.objectContaining({ title: "Single 500" }),
+		]);
+		expect(getHistoryNewestPage).toHaveBeenNthCalledWith(1, { start: 0, length: 500 });
+		expect(getHistoryNewestPage).toHaveBeenNthCalledWith(2, { start: 500, length: 1 });
+	});
+
+	it("marks a deep source page incomplete when totals drift between upstream pages", async () => {
+		const getHistoryNewestPage = vi
+			.fn()
+			.mockResolvedValueOnce({
+				data: Array.from({ length: 500 }, (_, index) => ({
+					row_id: 600 - index,
+					rating_key: String(index),
+					parent_rating_key: "",
+					grandparent_rating_key: "",
+					title: `Item ${index}`,
+					grandparent_title: "",
+					media_type: "movie",
+					user: "one",
+					date: 2_000 - index,
+				})),
+				recordsFiltered: 600,
+				recordsTotal: 600,
+			})
+			.mockResolvedValueOnce({ data: [], recordsFiltered: 601, recordsTotal: 601 });
+		mockCreateTautulliClient.mockReturnValue(makeClient({ getHistoryNewestPage }));
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=500&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources[0]).toMatchObject({
+			complete: false,
+			incompleteReason: "upstream_total_changed",
+		});
+	});
+
+	it("marks a source incomplete when a page returns more rows than its declared total", async () => {
+		mockCreateTautulliClient.mockReturnValue(
+			makeClient({
+				getHistoryNewestPage: vi.fn().mockResolvedValue({
+					data: [
+						{
+							row_id: 1,
+							rating_key: "1",
+							parent_rating_key: "",
+							grandparent_rating_key: "",
+							title: "Contradictory row",
+							grandparent_title: "",
+							media_type: "movie",
+							user: "one",
+							date: 2_000,
+						},
+					],
+					recordsFiltered: 0,
+					recordsTotal: 0,
+				}),
+			}),
+		);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=0&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources[0]).toMatchObject({
+			complete: false,
+			incompleteReason: "page_overflow",
+		});
+	});
+
+	it("preserves bounded deep history pages separately for each source", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([instanceOne, instanceTwo]);
+		const oneHistory = pagedHistory("One", 600, 2_000_000, 2);
+		const twoHistory = pagedHistory("Two", 600, 1_999_999, 2);
+		const one = makeClient({ getHistoryNewestPage: oneHistory });
+		const two = makeClient({ getHistoryNewestPage: twoHistory });
+		mockCreateTautulliClient.mockImplementation((_encryptor, instance) =>
+			instance.id === instanceOne.id ? one : two,
+		);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=500&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources).toEqual([
+			expect.objectContaining({
+				instanceId: "tautulli-one",
+				history: [expect.objectContaining({ title: "One 500" })],
+			}),
+			expect.objectContaining({
+				instanceId: "tautulli-two",
+				history: [expect.objectContaining({ title: "Two 500" })],
+			}),
+		]);
+		for (const getHistoryNewestPage of [oneHistory, twoHistory]) {
+			expect(getHistoryNewestPage).toHaveBeenNthCalledWith(1, { start: 0, length: 500 });
+			expect(getHistoryNewestPage).toHaveBeenNthCalledWith(2, { start: 500, length: 1 });
+		}
+	});
+
+	it("rejects history retrieval depths above the documented 5000-record maximum", async () => {
+		const response = await injectAuthenticated(
+			"GET",
+			"/api/tautulli/history?offset=4901&limit=100",
+		);
+
+		expect(response.statusCode).toBe(400);
+		expect(response.payload).toContain("5000");
+	});
+
+	it("labels an unreachable history source with a sanitized incomplete reason", async () => {
+		const client = makeClient({
+			getHistoryNewestPage: vi.fn().mockRejectedValue(new Error("http://secret")),
+		});
+		mockCreateTautulliClient.mockReturnValue(client);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=0&limit=1");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).sources).toEqual([
+			expect.objectContaining({ complete: false, incompleteReason: "source_unreachable" }),
+		]);
+	});
+
+	it("paginates each Tautulli source independently", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([instanceOne, instanceTwo]);
+		const one = makeClient({
+			getHistoryNewestPage: vi.fn().mockResolvedValue({
+				data: [
+					{
+						row_id: 3,
+						rating_key: "3",
+						parent_rating_key: "",
+						grandparent_rating_key: "",
+						title: "One newest",
+						grandparent_title: "",
+						media_type: "movie",
+						user: "one",
+						date: 3_000,
+					},
+					{
+						row_id: 1,
+						rating_key: "1",
+						parent_rating_key: "",
+						grandparent_rating_key: "",
+						title: "One older",
+						grandparent_title: "",
+						media_type: "movie",
+						user: "one",
+						date: 1_000,
+					},
+				],
+				recordsFiltered: 2,
+				recordsTotal: 2,
+			}),
+		});
+		const two = makeClient({
+			getHistoryNewestPage: vi.fn().mockResolvedValue({
+				data: [
+					{
+						row_id: 4,
+						rating_key: "4",
+						parent_rating_key: "",
+						grandparent_rating_key: "",
+						title: "Two newest",
+						grandparent_title: "",
+						media_type: "movie",
+						user: "two",
+						date: 4_000,
+					},
+					{
+						row_id: 2,
+						rating_key: "2",
+						parent_rating_key: "",
+						grandparent_rating_key: "",
+						title: "Two older",
+						grandparent_title: "",
+						media_type: "movie",
+						user: "two",
+						date: 2_000,
+					},
+				],
+				recordsFiltered: 2,
+				recordsTotal: 2,
+			}),
+		});
+		mockCreateTautulliClient.mockImplementation((_encryptor, instance) =>
+			instance.id === instanceOne.id ? one : two,
+		);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/history?offset=1&limit=2");
+
+		expect(response.statusCode).toBe(200);
+		expect(
+			JSON.parse(response.payload).sources.map((source: { history: Array<{ title: string }> }) =>
+				source.history.map((item) => item.title),
+			),
+		).toEqual([["One older"], ["Two older"]]);
+		expect(one.getHistoryNewestPage).toHaveBeenCalledWith({ start: 0, length: 3 });
+		expect(two.getHistoryNewestPage).toHaveBeenCalledWith({ start: 0, length: 3 });
+	});
+
+	it("returns an honest unavailable result when no enabled Tautulli instance exists", async () => {
+		prisma.serviceInstance.findMany.mockResolvedValue([]);
+		const response = await injectAuthenticated("GET", "/api/tautulli/activity");
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			provider: "tautulli",
+			configured: false,
+			sources: [],
+		});
+	});
+
+	it("rejects cache status requests for an instance not owned by the current user", async () => {
+		prisma.serviceInstance.findFirst.mockResolvedValue(null);
+		const response = await injectAuthenticated("GET", "/api/tautulli/cache/other-user/status");
+		expect(response.statusCode).toBe(404);
+		expect(prisma.tautulliCache.count).not.toHaveBeenCalled();
+	});
+
+	it("returns the durable cache witness for the owned Tautulli instance", async () => {
+		const response = await injectAuthenticated("GET", "/api/tautulli/cache/tautulli-one/status");
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			instanceId: "tautulli-one",
+			cachedItems: 3,
+			hasCacheData: true,
+			status: { cacheType: "tautulli", itemCount: 3, lastResult: "success" },
+		});
+	});
+
+	it.each([
+		["newer", "2026-08-12T00:01:00.000Z"],
+		["equal", "2026-08-12T00:00:00.000Z"],
+	])(
+		"reports a %s failed cache attempt as the effective health result without replacing the successful generation",
+		async (_comparison, lastAttemptAt) => {
+			prisma.cacheRefreshStatus.findMany.mockResolvedValue([
+				{
+					instanceId: instanceOne.id,
+					cacheType: "tautulli",
+					lastRefreshedAt: new Date("2026-08-12T00:00:00.000Z"),
+					lastResult: "success",
+					lastErrorMessage: null,
+					itemCount: 3,
+					lastAttemptAt: new Date(lastAttemptAt),
+					lastAttemptResult: "error",
+					lastAttemptErrorMessage: "refresh failed in /config/private.ts",
+				},
+			]);
+
+			const response = await injectAuthenticated("GET", "/api/tautulli/cache/health");
+
+			expect(response.statusCode).toBe(200);
+			expect(JSON.parse(response.payload).items).toEqual([
+				expect.objectContaining({
+					lastRefreshedAt: "2026-08-12T00:00:00.000Z",
+					lastResult: "success",
+					itemCount: 3,
+					lastAttemptAt,
+					lastAttemptResult: "error",
+					lastAttemptErrorMessage: "refresh failed in [path]",
+					effectiveResult: "partial",
+				}),
+			]);
+		},
+	);
+
+	it("reports a durable in-flight cache attempt as pending without replacing the successful generation", async () => {
+		prisma.cacheRefreshStatus.findMany.mockResolvedValue([
+			{
+				instanceId: instanceOne.id,
+				cacheType: "tautulli",
+				lastRefreshedAt: new Date("2026-08-12T00:00:00.000Z"),
+				lastResult: "success",
+				lastErrorMessage: null,
+				itemCount: 3,
+				lastAttemptAt: new Date("2026-08-12T00:01:00.000Z"),
+				lastAttemptResult: "pending",
+				lastAttemptErrorMessage: null,
+			},
+		]);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/cache/health");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).items).toEqual([
+			expect.objectContaining({
+				lastResult: "success",
+				itemCount: 3,
+				lastAttemptResult: "pending",
+				effectiveResult: "pending",
+			}),
+		]);
+	});
+
+	it("reports an unsuccessful cache generation as an error rather than a partial success", async () => {
+		prisma.cacheRefreshStatus.findMany.mockResolvedValue([
+			{
+				instanceId: instanceOne.id,
+				cacheType: "tautulli",
+				lastRefreshedAt: new Date("2026-08-12T00:00:00.000Z"),
+				lastResult: "error",
+				lastErrorMessage: "initial refresh failed",
+				itemCount: 0,
+				lastAttemptAt: new Date("2026-08-12T00:00:00.000Z"),
+				lastAttemptResult: "error",
+				lastAttemptErrorMessage: "initial refresh failed",
+			},
+		]);
+
+		const response = await injectAuthenticated("GET", "/api/tautulli/cache/health");
+
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload).items).toEqual([
+			expect.objectContaining({
+				lastResult: "error",
+				itemCount: 0,
+				effectiveResult: "error",
+			}),
+		]);
+	});
+
+	it("refreshes only an owned current Tautulli instance through the guarded refresher", async () => {
+		const response = await injectAuthenticated("POST", "/api/tautulli/cache/tautulli-one/refresh");
+		expect(response.statusCode).toBe(200);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			success: true,
+			complete: true,
+			upserted: 3,
+		});
+		expect(mockRefreshTautulliCache).toHaveBeenCalledWith(
+			expect.anything(),
+			prisma,
+			"tautulli-one",
+			expect.anything(),
+			providerConnectionIdentity(instanceOne as never),
+		);
+	});
+});

--- a/apps/api/src/routes/tautulli/__tests__/aggregation.test.ts
+++ b/apps/api/src/routes/tautulli/__tests__/aggregation.test.ts
@@ -365,7 +365,6 @@ describe("Tautulli provider routes", () => {
 						stat_title: "Most Active Platforms",
 						rows: [
 							{
-								title: "",
 								platform: instance.id === instanceOne.id ? "Chrome" : "Android",
 								total_plays: instance.id === instanceOne.id ? 2 : 3,
 								total_duration: 100,

--- a/apps/api/src/routes/tautulli/activity-routes.ts
+++ b/apps/api/src/routes/tautulli/activity-routes.ts
@@ -1,0 +1,89 @@
+import type { TautulliActivityResponse, TautulliActivitySession } from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import {
+	createCurrentTautulliClient,
+	isTautulliConnectionChanged,
+} from "../../lib/tautulli/current-tautulli-client.js";
+
+const activityState = (state: string): TautulliActivitySession["state"] =>
+	state === "playing" || state === "paused" || state === "buffering" ? state : "unknown";
+
+const activityLocation = (location: string): TautulliActivitySession["location"] =>
+	location === "lan" || location === "wan" ? location : "unknown";
+
+export async function registerActivityRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/", async (request, reply) => {
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId: request.currentUser!.id, service: "TAUTULLI", enabled: true },
+			orderBy: { label: "asc" },
+		});
+		const results = await Promise.all(
+			instances.map(async (instance) => {
+				try {
+					const { client, ensureCurrent } = createCurrentTautulliClient(app, instance);
+					const activity = await client.getActivity();
+					await ensureCurrent();
+					return {
+						instanceId: instance.id,
+						instanceLabel: instance.label,
+						reachable: true as const,
+						sessions: activity.sessions.map(
+							(session): TautulliActivitySession => ({
+								sessionKey: session.session_key,
+								ratingKey: session.rating_key,
+								title: session.title,
+								grandparentTitle: session.grandparent_title || undefined,
+								mediaType: session.media_type,
+								user: session.friendly_name || session.user,
+								player: session.player,
+								platform: session.platform,
+								product: session.product,
+								state: activityState(session.state),
+								progressPercent: Number(session.progress_percent) || 0,
+								transcodeDecision: session.transcode_decision,
+								videoDecision: session.stream_video_decision || session.transcode_decision,
+								audioDecision: session.stream_audio_decision || "direct play",
+								videoResolution: session.video_resolution,
+								audioCodec: session.audio_codec,
+								videoCodec: session.video_codec,
+								bandwidth: Number(session.bandwidth) || 0,
+								location: activityLocation(session.location),
+								thumb: session.thumb,
+								instanceId: instance.id,
+								instanceLabel: instance.label,
+							}),
+						),
+						streamCount: Number(activity.stream_count) || 0,
+						totalBandwidth: activity.total_bandwidth,
+						lanBandwidth: activity.lan_bandwidth,
+						wanBandwidth: activity.wan_bandwidth,
+					};
+				} catch (error) {
+					request.log.warn(
+						{ err: error, instanceId: instance.id },
+						"Tautulli activity request failed",
+					);
+					return {
+						instanceId: instance.id,
+						instanceLabel: instance.label,
+						reachable: false as const,
+						incompleteReason: isTautulliConnectionChanged(error)
+							? ("connection_changed" as const)
+							: ("source_unreachable" as const),
+						sessions: [],
+						streamCount: 0,
+						totalBandwidth: 0,
+						lanBandwidth: 0,
+						wanBandwidth: 0,
+					};
+				}
+			}),
+		);
+		const response: TautulliActivityResponse = {
+			provider: "tautulli",
+			configured: instances.length > 0,
+			sources: results,
+		};
+		return reply.send(response);
+	});
+}

--- a/apps/api/src/routes/tautulli/cache-routes.ts
+++ b/apps/api/src/routes/tautulli/cache-routes.ts
@@ -1,0 +1,142 @@
+import type {
+	TautulliCacheHealthResponse,
+	TautulliCacheRefreshResponse,
+	TautulliCacheStatusResponse,
+} from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import { refreshTautulliCache } from "../../lib/tautulli/tautulli-cache-refresher.js";
+import { createCurrentTautulliClient } from "../../lib/tautulli/current-tautulli-client.js";
+import { providerConnectionIdentity } from "../../lib/services/provider-connection-guard.js";
+import { sanitizeErrorMessage } from "../../lib/media-stats/cache-health-helpers.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+const instanceParams = z.object({ instanceId: z.string().min(1) });
+const emptyBody = z.object({}).strict();
+const staleThresholdMs = 12 * 60 * 60 * 1000;
+
+export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/cache/:instanceId/status", async (request, reply) => {
+		const { instanceId } = validateRequest(instanceParams, request.params);
+		const instance = await app.prisma.serviceInstance.findFirst({
+			where: {
+				id: instanceId,
+				userId: request.currentUser!.id,
+				service: "TAUTULLI",
+				enabled: true,
+			},
+		});
+		if (!instance) {
+			return reply.status(404).send({ error: "Instance not found or access denied" });
+		}
+		const [cachedItems, status] = await Promise.all([
+			app.prisma.tautulliCache.count({ where: { instanceId } }),
+			app.prisma.cacheRefreshStatus.findUnique({
+				where: { instanceId_cacheType: { instanceId, cacheType: "tautulli" } },
+			}),
+		]);
+		const response: TautulliCacheStatusResponse = {
+			instanceId,
+			cachedItems,
+			hasCacheData: cachedItems > 0,
+			status: status && {
+				cacheType: "tautulli",
+				lastRefreshedAt: status.lastRefreshedAt.toISOString(),
+				lastResult: status.lastResult,
+				lastErrorMessage: sanitizeErrorMessage(status.lastErrorMessage),
+				itemCount: status.itemCount,
+				lastAttemptAt: status.lastAttemptAt?.toISOString() ?? null,
+				lastAttemptResult: status.lastAttemptResult,
+				lastAttemptErrorMessage: sanitizeErrorMessage(status.lastAttemptErrorMessage),
+			},
+		};
+		return reply.send(response);
+	});
+
+	app.get("/cache/health", async (request, reply) => {
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId: request.currentUser!.id, service: "TAUTULLI", enabled: true },
+			select: { id: true, label: true },
+		});
+		const statuses = instances.length
+			? await app.prisma.cacheRefreshStatus.findMany({
+					where: {
+						instanceId: { in: instances.map((instance) => instance.id) },
+						cacheType: "tautulli",
+					},
+				})
+			: [];
+		const statusByInstance = new Map(statuses.map((status) => [status.instanceId, status]));
+		const response: TautulliCacheHealthResponse = {
+			items: instances.map((instance) => {
+				const status = statusByInstance.get(instance.id);
+				const newerPendingAttempt =
+					status?.lastAttemptResult === "pending" &&
+					status.lastAttemptAt != null &&
+					status.lastAttemptAt.getTime() >= status.lastRefreshedAt.getTime();
+				const newerFailedAttempt =
+					status?.lastAttemptResult === "error" &&
+					status.lastAttemptAt != null &&
+					status.lastAttemptAt.getTime() >= status.lastRefreshedAt.getTime();
+				return {
+					instanceId: instance.id,
+					instanceLabel: instance.label,
+					cacheType: "tautulli",
+					lastRefreshedAt: status?.lastRefreshedAt.toISOString() ?? null,
+					lastResult: status?.lastResult ?? null,
+					lastErrorMessage: sanitizeErrorMessage(status?.lastErrorMessage ?? null),
+					itemCount: status?.itemCount ?? 0,
+					lastAttemptAt: status?.lastAttemptAt?.toISOString() ?? null,
+					lastAttemptResult: status?.lastAttemptResult ?? null,
+					lastAttemptErrorMessage: sanitizeErrorMessage(status?.lastAttemptErrorMessage ?? null),
+					effectiveResult: newerPendingAttempt
+						? "pending"
+						: status?.lastResult === "error"
+							? "error"
+							: newerFailedAttempt
+								? "partial"
+								: (status?.lastResult ?? null),
+					isStale: status ? Date.now() - status.lastRefreshedAt.getTime() > staleThresholdMs : null,
+				};
+			}),
+		};
+		return reply.send(response);
+	});
+
+	app.post(
+		"/cache/:instanceId/refresh",
+		{ config: { rateLimit: { max: 2, timeWindow: "5m" } } },
+		async (request, reply) => {
+			const { instanceId } = validateRequest(instanceParams, request.params);
+			validateRequest(emptyBody, request.body ?? {});
+			// Resolve the current owned enabled instance immediately before the guarded refresh.
+			const instance = await app.prisma.serviceInstance.findFirst({
+				where: {
+					id: instanceId,
+					userId: request.currentUser!.id,
+					service: "TAUTULLI",
+					enabled: true,
+				},
+			});
+			if (!instance) {
+				return reply.status(404).send({ error: "Instance not found or access denied" });
+			}
+			const { client } = createCurrentTautulliClient(app, instance);
+			const result = await refreshTautulliCache(
+				client,
+				app.prisma,
+				instanceId,
+				request.log,
+				providerConnectionIdentity(instance),
+			);
+			const response: TautulliCacheRefreshResponse = {
+				success: result.complete && Boolean(result.completedAt),
+				complete: result.complete,
+				superseded: Boolean(result.superseded),
+				upserted: result.upserted,
+				errors: result.errors,
+			};
+			return reply.send(response);
+		},
+	);
+}

--- a/apps/api/src/routes/tautulli/history-routes.ts
+++ b/apps/api/src/routes/tautulli/history-routes.ts
@@ -1,0 +1,195 @@
+import type {
+	TautulliHistoryIncompleteReason,
+	TautulliHistorySource,
+	TautulliWatchHistoryItem,
+	TautulliWatchHistoryResponse,
+} from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import {
+	type TautulliClient,
+	MAX_TAUTULLI_HISTORY_PAGE_LENGTH,
+} from "../../lib/tautulli/tautulli-client.js";
+import {
+	createCurrentTautulliClient,
+	isTautulliConnectionChanged,
+} from "../../lib/tautulli/current-tautulli-client.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+
+/** Maximum cross-instance history prefix a public request may retrieve. */
+export const MAX_TAUTULLI_HISTORY_RETRIEVAL_DEPTH = 5_000;
+
+const historyQuery = z
+	.object({
+		offset: z.coerce.number().int().min(0).default(0),
+		limit: z.coerce.number().int().min(1).max(100).default(25),
+	})
+	.superRefine(({ offset, limit }, context) => {
+		if (offset + limit > MAX_TAUTULLI_HISTORY_RETRIEVAL_DEPTH) {
+			context.addIssue({
+				code: z.ZodIssueCode.custom,
+				path: ["limit"],
+				message: `offset plus limit must not exceed ${MAX_TAUTULLI_HISTORY_RETRIEVAL_DEPTH}`,
+			});
+		}
+	});
+
+export async function registerHistoryRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/", async (request, reply) => {
+		const { offset, limit } = validateRequest(historyQuery, request.query);
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId: request.currentUser!.id, service: "TAUTULLI", enabled: true },
+			orderBy: { label: "asc" },
+		});
+		const requestedDepth = offset + limit;
+		const results = await Promise.all(
+			instances.map(async (instance) => {
+				try {
+					const { client, ensureCurrent } = createCurrentTautulliClient(app, instance);
+					const data = await getRequestedHistoryPrefix(client, requestedDepth);
+					await ensureCurrent();
+					return {
+						instance,
+						data,
+					};
+				} catch (error) {
+					request.log.warn(
+						{ err: error, instanceId: instance.id },
+						"Tautulli history request failed",
+					);
+					return {
+						instance,
+						incompleteReason: isTautulliConnectionChanged(error)
+							? ("connection_changed" as const)
+							: ("source_unreachable" as const),
+					};
+				}
+			}),
+		);
+		const sources: TautulliHistorySource[] = results.map((item) => {
+			if (!item.data) {
+				return {
+					instanceId: item.instance.id,
+					instanceLabel: item.instance.label,
+					totalCount: 0,
+					history: [],
+					complete: false,
+					incompleteReason: item.incompleteReason!,
+				};
+			}
+			if (!item.data.complete) {
+				return {
+					instanceId: item.instance.id,
+					instanceLabel: item.instance.label,
+					totalCount: item.data.totalCount,
+					history: mapHistory(item.data.items, item.instance).slice(offset, offset + limit),
+					complete: false,
+					incompleteReason: item.data.incompleteReason,
+				};
+			}
+			return {
+				instanceId: item.instance.id,
+				instanceLabel: item.instance.label,
+				totalCount: item.data.totalCount,
+				history: mapHistory(item.data.items, item.instance).slice(offset, offset + limit),
+				complete: true,
+			};
+		});
+		const response: TautulliWatchHistoryResponse = {
+			provider: "tautulli",
+			configured: instances.length > 0,
+			sources,
+			pagination: {
+				offset,
+				limit,
+				complete: sources.every((source) => source.complete),
+			},
+		};
+		return reply.send(response);
+	});
+}
+
+type TautulliHistoryPage = Awaited<ReturnType<TautulliClient["getHistoryNewestPage"]>>;
+
+async function getRequestedHistoryPrefix(
+	client: TautulliClient,
+	requestedDepth: number,
+): Promise<
+	{
+		items: TautulliHistoryPage["data"];
+		totalCount: number;
+	} & ({ complete: true } | { complete: false; incompleteReason: TautulliHistoryIncompleteReason })
+> {
+	const items: TautulliHistoryPage["data"] = [];
+	let totalCount = 0;
+	let totalRecords = 0;
+	let previousDate: number | undefined;
+	let previousRowId: number | undefined;
+	const rowIds = new Set<number>();
+
+	for (let start = 0; start < requestedDepth; start += MAX_TAUTULLI_HISTORY_PAGE_LENGTH) {
+		const length = Math.min(MAX_TAUTULLI_HISTORY_PAGE_LENGTH, requestedDepth - start);
+		const page = await client.getHistoryNewestPage({ start, length });
+		if (page.recordsTotal < page.recordsFiltered) {
+			return { items, totalCount, complete: false, incompleteReason: "upstream_total_changed" };
+		}
+		if (start === 0) {
+			totalCount = page.recordsFiltered;
+			totalRecords = page.recordsTotal;
+		} else if (page.recordsFiltered !== totalCount || page.recordsTotal !== totalRecords) {
+			return { items, totalCount, complete: false, incompleteReason: "upstream_total_changed" };
+		}
+
+		const remaining = Math.max(0, totalCount - start);
+		const expectedRows = Math.min(length, remaining);
+		if (page.data.length > expectedRows) {
+			return { items, totalCount, complete: false, incompleteReason: "page_overflow" };
+		}
+		for (const row of page.data) {
+			if (row.row_id === undefined) {
+				return { items, totalCount, complete: false, incompleteReason: "missing_row_id" };
+			}
+			if (rowIds.has(row.row_id)) {
+				return { items, totalCount, complete: false, incompleteReason: "duplicate_row_id" };
+			}
+			if (
+				previousDate !== undefined &&
+				(row.date > previousDate ||
+					(row.date === previousDate && previousRowId !== undefined && row.row_id >= previousRowId))
+			) {
+				return { items, totalCount, complete: false, incompleteReason: "unstable_row_id" };
+			}
+			rowIds.add(row.row_id);
+			previousDate = row.date;
+			previousRowId = row.row_id;
+			items.push(row);
+		}
+		if (page.data.length < expectedRows) {
+			return { items, totalCount, complete: false, incompleteReason: "page_truncated" };
+		}
+		if (items.length >= totalCount || start + length >= requestedDepth) {
+			return { items, totalCount, complete: true };
+		}
+	}
+
+	return { items, totalCount, complete: true };
+}
+
+function mapHistory(
+	items: TautulliHistoryPage["data"],
+	instance: { id: string; label: string },
+): TautulliWatchHistoryItem[] {
+	return items.map((raw) => ({
+		title: raw.title,
+		grandparentTitle: raw.grandparent_title || undefined,
+		mediaType:
+			raw.media_type === "movie" || raw.media_type === "episode" || raw.media_type === "track"
+				? raw.media_type
+				: "unknown",
+		watchedAt: new Date(raw.date * 1000).toISOString(),
+		user: raw.user,
+		ratingKey: raw.rating_key,
+		instanceId: instance.id,
+		instanceLabel: instance.label,
+	}));
+}

--- a/apps/api/src/routes/tautulli/index.ts
+++ b/apps/api/src/routes/tautulli/index.ts
@@ -1,0 +1,13 @@
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { registerActivityRoutes } from "./activity-routes.js";
+import { registerCacheRoutes } from "./cache-routes.js";
+import { registerHistoryRoutes } from "./history-routes.js";
+import { registerStatsRoutes } from "./stats-routes.js";
+
+/** Provider-specific Tautulli analytics only; never register unified live-session routes here. */
+export async function registerTautulliRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.register(registerActivityRoutes, { prefix: "/activity" });
+	app.register(registerHistoryRoutes, { prefix: "/history" });
+	app.register(registerStatsRoutes, { prefix: "/stats" });
+	app.register(registerCacheRoutes);
+}

--- a/apps/api/src/routes/tautulli/stats-routes.ts
+++ b/apps/api/src/routes/tautulli/stats-routes.ts
@@ -1,0 +1,242 @@
+import type {
+	TautulliAnalyticsUserStat,
+	TautulliPlaysByDateResponse,
+	TautulliStatsResponse,
+	TautulliStatsSource,
+} from "@arr/shared";
+import type { FastifyInstance, FastifyPluginOptions } from "fastify";
+import { z } from "zod";
+import {
+	createCurrentTautulliClient,
+	isTautulliConnectionChanged,
+} from "../../lib/tautulli/current-tautulli-client.js";
+import type { TautulliClient } from "../../lib/tautulli/tautulli-client.js";
+import { validateRequest } from "../../lib/utils/validate.js";
+import { runWithConcurrency } from "../seerr/lib/enrichment-helpers.js";
+
+const statsQuery = z.object({ timeRange: z.coerce.number().int().min(1).max(365).default(30) });
+const TAUTULLI_USER_STATS_CONCURRENCY = 4;
+const TAUTULLI_HOME_STATS_LIMIT = 10;
+
+type UserStatsStatus = {
+	userStatsComplete: boolean;
+	failedUserCount: number;
+	incompleteReason?: "user_list_unavailable" | "user_stats_partial";
+};
+
+export async function registerStatsRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
+	app.get("/", async (request, reply) => {
+		const { timeRange } = validateRequest(statsQuery, request.query);
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId: request.currentUser!.id, service: "TAUTULLI", enabled: true },
+			orderBy: { label: "asc" },
+		});
+		const results = await Promise.all(
+			instances.map(async (instance) => {
+				try {
+					const { client, ensureCurrent } = createCurrentTautulliClient(app, instance);
+					const homeStats = await client.getHomeStats(timeRange, TAUTULLI_HOME_STATS_LIMIT);
+					const userList = await getOptionalUsers(client, instance.id, request.log);
+					await ensureCurrent();
+					return {
+						instance,
+						client,
+						ensureCurrent,
+						reachable: true as const,
+						homeStats,
+						...userList,
+					};
+				} catch (error) {
+					request.log.warn(
+						{ err: error, instanceId: instance.id },
+						"Tautulli statistics request failed",
+					);
+					return {
+						instance,
+						reachable: false as const,
+						incompleteReason: isTautulliConnectionChanged(error)
+							? ("connection_changed" as const)
+							: ("source_unreachable" as const),
+					};
+				}
+			}),
+		);
+
+		const userStatTasks = results.flatMap((item) =>
+			item.reachable
+				? item.users.map((user) => ({ client: item.client, instance: item.instance, user }))
+				: [],
+		);
+		const userStatsByInstance = new Map<string, TautulliAnalyticsUserStat[]>();
+		const userStatsStatusByInstance = new Map<string, UserStatsStatus>();
+		for (const item of results) {
+			if (!item.reachable) continue;
+			userStatsStatusByInstance.set(item.instance.id, {
+				userStatsComplete: item.userStatsComplete,
+				failedUserCount: 0,
+				incompleteReason: item.incompleteReason,
+			});
+		}
+
+		const userStatResults = await runWithConcurrency(
+			userStatTasks.map(
+				({ client, instance, user }) =>
+					async (): Promise<TautulliAnalyticsUserStat> => {
+						const windows = await client.getUserWatchTimeStats(user.user_id, timeRange);
+						const stats = windows.find((window) => window.query_days === timeRange);
+						if (!stats) {
+							throw new Error(
+								"Tautulli user watch-time stats did not include the requested time range",
+							);
+						}
+						return {
+							userId: user.user_id,
+							friendlyName: user.friendly_name?.trim() || user.username,
+							totalPlays: stats.total_plays,
+							totalDuration: stats.total_time,
+							instanceId: instance.id,
+							instanceLabel: instance.label,
+						};
+					},
+			),
+			TAUTULLI_USER_STATS_CONCURRENCY,
+		);
+		for (const [index, result] of userStatResults.entries()) {
+			const task = userStatTasks[index]!;
+			if (result.status === "fulfilled") {
+				const rows = userStatsByInstance.get(task.instance.id) ?? [];
+				rows.push(result.value);
+				userStatsByInstance.set(task.instance.id, rows);
+				continue;
+			}
+			const status = userStatsStatusByInstance.get(task.instance.id)!;
+			status.userStatsComplete = false;
+			status.failedUserCount += 1;
+			status.incompleteReason = "user_stats_partial";
+			request.log.warn(
+				{ err: result.reason, instanceId: task.instance.id },
+				"Tautulli user watch-time request failed",
+			);
+		}
+
+		const sources: TautulliStatsSource[] = await Promise.all(
+			results.map(async (item): Promise<TautulliStatsSource> => {
+				if (!item.reachable) {
+					return unavailableStatsSource(item.instance, item.incompleteReason);
+				}
+				try {
+					await item.ensureCurrent();
+					const status = userStatsStatusByInstance.get(item.instance.id)!;
+					return {
+						instanceId: item.instance.id,
+						instanceLabel: item.instance.label,
+						reachable: true,
+						homeStats: item.homeStats,
+						userStats: (userStatsByInstance.get(item.instance.id) ?? []).sort(
+							(left, right) => right.totalDuration - left.totalDuration,
+						),
+						rankingLimit: TAUTULLI_HOME_STATS_LIMIT,
+						...status,
+					};
+				} catch (error) {
+					return unavailableStatsSource(
+						item.instance,
+						isTautulliConnectionChanged(error) ? "connection_changed" : "source_unreachable",
+					);
+				}
+			}),
+		);
+
+		const response: TautulliStatsResponse = {
+			provider: "tautulli",
+			configured: instances.length > 0,
+			sources,
+			timeRange,
+		};
+		return reply.send(response);
+	});
+
+	app.get("/plays-by-date", async (request, reply) => {
+		const { timeRange } = validateRequest(statsQuery, request.query);
+		const instances = await app.prisma.serviceInstance.findMany({
+			where: { userId: request.currentUser!.id, service: "TAUTULLI", enabled: true },
+			orderBy: { label: "asc" },
+		});
+		const sources = await Promise.all(
+			instances.map(async (instance) => {
+				try {
+					const { client, ensureCurrent } = createCurrentTautulliClient(app, instance);
+					const data = await client.getPlaysByDate(timeRange);
+					await ensureCurrent();
+					return {
+						instanceId: instance.id,
+						instanceLabel: instance.label,
+						reachable: true as const,
+						categories: data.categories,
+						series: data.series,
+					};
+				} catch (error) {
+					request.log.warn(
+						{ err: error, instanceId: instance.id },
+						"Tautulli plays-by-date request failed",
+					);
+					return {
+						instanceId: instance.id,
+						instanceLabel: instance.label,
+						reachable: false as const,
+						incompleteReason: isTautulliConnectionChanged(error)
+							? ("connection_changed" as const)
+							: ("source_unreachable" as const),
+						categories: [],
+						series: [],
+					};
+				}
+			}),
+		);
+		const response: TautulliPlaysByDateResponse = {
+			provider: "tautulli",
+			configured: instances.length > 0,
+			sources,
+			timeRange,
+		};
+		return reply.send(response);
+	});
+}
+
+function unavailableStatsSource(
+	instance: { id: string; label: string },
+	incompleteReason: "source_unreachable" | "connection_changed",
+): TautulliStatsSource {
+	return {
+		instanceId: instance.id,
+		instanceLabel: instance.label,
+		reachable: false,
+		incompleteReason,
+		homeStats: [],
+		userStats: [],
+		rankingLimit: TAUTULLI_HOME_STATS_LIMIT,
+		userStatsComplete: false,
+		failedUserCount: 0,
+	};
+}
+
+async function getOptionalUsers(
+	client: TautulliClient,
+	instanceId: string,
+	log: FastifyInstance["log"],
+): Promise<{
+	users: Awaited<ReturnType<TautulliClient["getUsers"]>>;
+	userStatsComplete: boolean;
+	incompleteReason?: "user_list_unavailable";
+}> {
+	try {
+		return { users: await client.getUsers(), userStatsComplete: true };
+	} catch (error) {
+		log.warn({ err: error, instanceId }, "Tautulli user identity request failed");
+		return {
+			users: [],
+			userStatsComplete: false,
+			incompleteReason: "user_list_unavailable",
+		};
+	}
+}

--- a/apps/web/src/hooks/api/__tests__/useTautulli.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useTautulli.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../lib/api-client/tautulli");
+
+import * as tautulliApi from "../../../lib/api-client/tautulli";
+import { tautulliKeys } from "../../../lib/query-keys";
+import { useTautulliActivity, useTautulliCacheRefresh } from "../useTautulli";
+
+function createWrapper() {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+	});
+	return {
+		queryClient,
+		wrapper: ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		),
+	};
+}
+
+beforeEach(() => {
+	vi.resetAllMocks();
+});
+
+describe("Tautulli hooks", () => {
+	it("uses the provider-specific centralized activity key", async () => {
+		vi.mocked(tautulliApi.fetchTautulliActivity).mockResolvedValue({
+			provider: "tautulli",
+			configured: false,
+			sources: [],
+		});
+		const { wrapper, queryClient } = createWrapper();
+		renderHook(() => useTautulliActivity(), { wrapper });
+		await waitFor(() => expect(tautulliApi.fetchTautulliActivity).toHaveBeenCalledOnce());
+		expect(queryClient.getQueryData(tautulliKeys.activity())).toBeDefined();
+	});
+
+	it("invalidates every Tautulli cache family after a manual refresh", async () => {
+		vi.mocked(tautulliApi.refreshTautulliCache).mockResolvedValue({
+			success: true,
+			complete: true,
+			superseded: false,
+			upserted: 2,
+			errors: 0,
+		});
+		const { wrapper, queryClient } = createWrapper();
+		const invalidate = vi.spyOn(queryClient, "invalidateQueries");
+		const { result } = renderHook(() => useTautulliCacheRefresh(), { wrapper });
+		await act(async () => result.current.mutateAsync("tautulli-one"));
+		expect(invalidate).toHaveBeenCalledWith({ queryKey: tautulliKeys.all });
+	});
+});

--- a/apps/web/src/hooks/api/useTautulli.ts
+++ b/apps/web/src/hooks/api/useTautulli.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import type {
+	TautulliActivityResponse,
+	TautulliCacheHealthResponse,
+	TautulliCacheRefreshResponse,
+	TautulliCacheStatusResponse,
+	TautulliPlaysByDateResponse,
+	TautulliStatsResponse,
+	TautulliWatchHistoryResponse,
+} from "@arr/shared";
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+	fetchTautulliActivity,
+	fetchTautulliCacheHealth,
+	fetchTautulliCacheStatus,
+	fetchTautulliHistory,
+	fetchTautulliPlaysByDate,
+	fetchTautulliStats,
+	refreshTautulliCache,
+} from "../../lib/api-client/tautulli";
+import { POLLING_REALTIME, POLLING_STATS, POLLING_STANDARD } from "../../lib/polling-intervals";
+import { tautulliKeys } from "../../lib/query-keys";
+
+export const useTautulliActivity = (enabled = true) =>
+	useQuery<TautulliActivityResponse>({
+		queryKey: tautulliKeys.activity(),
+		queryFn: fetchTautulliActivity,
+		enabled,
+		refetchInterval: POLLING_REALTIME,
+		staleTime: POLLING_REALTIME,
+	});
+
+export const useTautulliStats = (timeRange = 30, enabled = true) =>
+	useQuery<TautulliStatsResponse>({
+		queryKey: tautulliKeys.stats(timeRange),
+		queryFn: () => fetchTautulliStats(timeRange),
+		enabled,
+		staleTime: POLLING_STATS,
+	});
+
+export const useTautulliPlaysByDate = (timeRange = 30, enabled = true) =>
+	useQuery<TautulliPlaysByDateResponse>({
+		queryKey: tautulliKeys.playsByDate(timeRange),
+		queryFn: () => fetchTautulliPlaysByDate(timeRange),
+		enabled,
+		staleTime: POLLING_STATS,
+	});
+
+export const useTautulliHistory = (offset = 0, limit = 25, enabled = true) =>
+	useQuery<TautulliWatchHistoryResponse>({
+		queryKey: tautulliKeys.history(offset, limit),
+		queryFn: () => fetchTautulliHistory(offset, limit),
+		enabled,
+		staleTime: POLLING_STANDARD,
+		placeholderData: keepPreviousData,
+	});
+
+export const useTautulliCacheStatus = (instanceId: string | null | undefined) =>
+	useQuery<TautulliCacheStatusResponse>({
+		queryKey: tautulliKeys.cacheStatus(instanceId ?? ""),
+		queryFn: () => fetchTautulliCacheStatus(instanceId!),
+		enabled: Boolean(instanceId),
+		staleTime: POLLING_STANDARD,
+	});
+
+export const useTautulliCacheHealth = (enabled = true) =>
+	useQuery<TautulliCacheHealthResponse>({
+		queryKey: tautulliKeys.cacheHealth(),
+		queryFn: fetchTautulliCacheHealth,
+		enabled,
+		staleTime: POLLING_STANDARD,
+	});
+
+export const useTautulliCacheRefresh = () => {
+	const queryClient = useQueryClient();
+	return useMutation<TautulliCacheRefreshResponse, Error, string>({
+		mutationFn: refreshTautulliCache,
+		onSuccess: () => queryClient.invalidateQueries({ queryKey: tautulliKeys.all }),
+	});
+};

--- a/apps/web/src/lib/api-client/tautulli.ts
+++ b/apps/web/src/lib/api-client/tautulli.ts
@@ -1,0 +1,41 @@
+import type {
+	TautulliActivityResponse,
+	TautulliCacheHealthResponse,
+	TautulliCacheRefreshResponse,
+	TautulliCacheStatusResponse,
+	TautulliPlaysByDateResponse,
+	TautulliStatsResponse,
+	TautulliWatchHistoryResponse,
+} from "@arr/shared";
+import { apiRequest } from "./base";
+
+export const fetchTautulliActivity = (): Promise<TautulliActivityResponse> =>
+	apiRequest("/api/tautulli/activity");
+
+export const fetchTautulliStats = (timeRange: number): Promise<TautulliStatsResponse> =>
+	apiRequest(`/api/tautulli/stats?timeRange=${encodeURIComponent(timeRange)}`);
+
+export const fetchTautulliPlaysByDate = (timeRange: number): Promise<TautulliPlaysByDateResponse> =>
+	apiRequest(`/api/tautulli/stats/plays-by-date?timeRange=${encodeURIComponent(timeRange)}`);
+
+export const fetchTautulliHistory = (
+	offset: number,
+	limit: number,
+): Promise<TautulliWatchHistoryResponse> =>
+	apiRequest(
+		`/api/tautulli/history?offset=${encodeURIComponent(offset)}&limit=${encodeURIComponent(limit)}`,
+	);
+
+export const fetchTautulliCacheStatus = (
+	instanceId: string,
+): Promise<TautulliCacheStatusResponse> =>
+	apiRequest(`/api/tautulli/cache/${encodeURIComponent(instanceId)}/status`);
+
+export const fetchTautulliCacheHealth = (): Promise<TautulliCacheHealthResponse> =>
+	apiRequest("/api/tautulli/cache/health");
+
+export const refreshTautulliCache = (instanceId: string): Promise<TautulliCacheRefreshResponse> =>
+	apiRequest(`/api/tautulli/cache/${encodeURIComponent(instanceId)}/refresh`, {
+		method: "POST",
+		json: {},
+	});

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -358,6 +358,20 @@ export const tracearrKeys = {
 };
 
 /* -------------------------------------------------------------------------- */
+/*  Tautulli                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export const tautulliKeys = {
+	all: ["tautulli"] as const,
+	activity: () => ["tautulli", "activity"] as const,
+	stats: (timeRange: number) => ["tautulli", "stats", timeRange] as const,
+	playsByDate: (timeRange: number) => ["tautulli", "plays-by-date", timeRange] as const,
+	history: (offset: number, limit: number) => ["tautulli", "history", offset, limit] as const,
+	cacheStatus: (instanceId: string) => ["tautulli", "cache", "status", instanceId] as const,
+	cacheHealth: () => ["tautulli", "cache", "health"] as const,
+};
+
+/* -------------------------------------------------------------------------- */
 /*  Jellyfin                                                                   */
 /* -------------------------------------------------------------------------- */
 

--- a/docs/API-ROUTES.md
+++ b/docs/API-ROUTES.md
@@ -52,6 +52,7 @@ for the full rationale.
 | `/api/library-cleanup` | internal | Library cleanup rules, approvals, execution |
 | `/api/plex` | stable | Now playing, on-deck, history, analytics, forecasts |
 | `/api/jellyfin` | stable | Jellyfin activity and library data |
+| `/api/tautulli` | stable | Provider-specific Tautulli activity, historical analytics, and guarded cache refreshes |
 | `/api/label-sync` | operator | Generic any-to-any media-service tag/label sync rules (issue #384). Sub-arc 1 ships Sonarr/Radarr → Plex. |
 | `/api/auto-tag` | operator | Criteria-based auto-tagger — applies tags to LibraryCache items matching the rule's criteria DSL (genre, year, codec, watch state, …). Companion to Label Sync. Webhook config (secret read/rotate) lives here under session auth. |
 | `/api/auto-tag/webhook` | operator | Inbound Sonarr/Radarr Connect webhook for real-time auto-tagging. **Public route** (no session cookie); authenticates via per-user Bearer token (SHA-256 hash of the user's webhook secret). |
@@ -68,6 +69,23 @@ for the full rationale.
 > will fail loudly if either is missing.
 
 ## Per-group route detail
+
+## Tautulli Routes (`/api/tautulli`)
+
+Tautulli routes return only Tautulli-derived data. They do not read Tracearr
+or native live-session state. Titles, usernames, labels, and URLs remain
+sensitive client fields; incognito-aware consumers must use the existing
+incognito helpers before rendering them.
+
+| Method | Route | Auth | Purpose |
+|--------|-------|------|---------|
+| GET | `/api/tautulli/activity` | Yes | Source-scoped active sessions, bandwidth totals, and per-instance reachability |
+| GET | `/api/tautulli/stats?timeRange=` | Yes | Source-scoped Tautulli home rankings and user watch statistics with explicit ranking limits and completeness metadata |
+| GET | `/api/tautulli/stats/plays-by-date?timeRange=` | Yes | Source-scoped Tautulli play-count time series |
+| GET | `/api/tautulli/history?offset=&limit=` | Yes | Independently paginated newest-first history for each source; `offset + limit` is bounded to 5,000 records and completeness is explicit |
+| GET | `/api/tautulli/cache/:instanceId/status` | Yes | Owned-instance cache count and durable refresh witness |
+| GET | `/api/tautulli/cache/health` | Yes | Cache health for the current user's enabled Tautulli instances, including successful-generation and latest-attempt/effective-result metadata |
+| POST | `/api/tautulli/cache/:instanceId/refresh` | Yes | Rate-limited owned-instance refresh through the guarded cache refresher |
 
 ## Guided Setup Routes (`/api/setup`)
 

--- a/packages/shared/src/types/tautulli.ts
+++ b/packages/shared/src/types/tautulli.ts
@@ -40,9 +40,19 @@ export interface TautulliHistorySnapshot {
 export interface TautulliHomeStatRow {
 	title: string;
 	friendly_name?: string;
+	user?: string;
+	user_id?: string;
+	section_id?: string;
+	section_name?: string;
+	section_type?: string;
 	total_plays: number;
 	total_duration: number;
 	platform?: string;
+	count?: number;
+	started?: number;
+	stopped?: number;
+	rating_key?: string;
+	grandparent_rating_key?: string;
 	thumb?: string;
 }
 
@@ -52,8 +62,194 @@ export interface TautulliHomeStat {
 	rows: TautulliHomeStatRow[];
 }
 
+/** A provider-owned Tautulli user identity returned by `get_users`. */
+export interface TautulliUser {
+	user_id: string;
+	username: string;
+	friendly_name?: string;
+}
+
+/** One requested time window returned by `get_user_watch_time_stats`. */
 export interface TautulliUserWatchTimeStat {
 	query_days: number;
 	total_plays: number;
 	total_time: number;
+}
+
+/** Public provider discriminator. Tautulli analytics never fall back to another provider. */
+export type TautulliProvider = "tautulli";
+
+/** Source identity carried alongside provider-specific responses. */
+export interface TautulliInstanceSource {
+	instanceId: string;
+	instanceLabel: string;
+	reachable: boolean;
+}
+
+export interface TautulliActivitySession {
+	sessionKey: string;
+	ratingKey: string;
+	title: string;
+	grandparentTitle?: string;
+	mediaType: string;
+	user: string;
+	player: string;
+	platform: string;
+	product: string;
+	state: "playing" | "paused" | "buffering" | "unknown";
+	progressPercent: number;
+	transcodeDecision: string;
+	videoDecision: string;
+	audioDecision: string;
+	videoResolution: string;
+	audioCodec: string;
+	videoCodec: string;
+	bandwidth: number;
+	location: "lan" | "wan" | "unknown";
+	thumb?: string;
+	instanceId: string;
+	instanceLabel: string;
+}
+
+export interface TautulliActivitySource extends TautulliInstanceSource {
+	incompleteReason?: "source_unreachable" | "connection_changed";
+	sessions: TautulliActivitySession[];
+	streamCount: number;
+	totalBandwidth: number;
+	lanBandwidth: number;
+	wanBandwidth: number;
+}
+
+export interface TautulliActivityResponse {
+	provider: TautulliProvider;
+	configured: boolean;
+	sources: TautulliActivitySource[];
+}
+
+export interface TautulliAnalyticsUserStat {
+	/** Exact provider user id from Tautulli; it is not an arr-dashboard user id. */
+	userId: string;
+	friendlyName: string;
+	totalPlays: number;
+	totalDuration: number;
+	instanceId: string;
+	instanceLabel: string;
+}
+
+export type TautulliStatsIncompleteReason =
+	| "source_unreachable"
+	| "connection_changed"
+	| "user_list_unavailable"
+	| "user_stats_partial";
+
+/** Completeness metadata applies only to stats' optional per-user enrichment. */
+export interface TautulliStatsSource extends TautulliInstanceSource {
+	homeStats: TautulliHomeStat[];
+	userStats: TautulliAnalyticsUserStat[];
+	rankingLimit: number;
+	userStatsComplete: boolean;
+	failedUserCount: number;
+	incompleteReason?: TautulliStatsIncompleteReason;
+}
+
+export interface TautulliStatsResponse {
+	provider: TautulliProvider;
+	configured: boolean;
+	sources: TautulliStatsSource[];
+	timeRange: number;
+}
+
+export interface TautulliPlaysByDateSource extends TautulliInstanceSource {
+	incompleteReason?: "source_unreachable" | "connection_changed";
+	categories: string[];
+	series: Array<{ name: string; data: number[] }>;
+}
+
+export interface TautulliPlaysByDateResponse {
+	provider: TautulliProvider;
+	configured: boolean;
+	sources: TautulliPlaysByDateSource[];
+	timeRange: number;
+}
+
+export interface TautulliWatchHistoryItem {
+	title: string;
+	grandparentTitle?: string;
+	mediaType: "movie" | "episode" | "track" | "unknown";
+	watchedAt: string;
+	user: string;
+	ratingKey: string;
+	instanceId: string;
+	instanceLabel: string;
+}
+
+export type TautulliHistoryIncompleteReason =
+	| NonNullable<TautulliHistorySnapshot["incompleteReason"]>
+	| "source_unreachable"
+	| "connection_changed"
+	| "page_truncated"
+	| "page_overflow";
+
+export type TautulliHistorySource = {
+	instanceId: string;
+	instanceLabel: string;
+	totalCount: number;
+	history: TautulliWatchHistoryItem[];
+} & (
+	| { complete: true; incompleteReason?: never }
+	| { complete: false; incompleteReason: TautulliHistoryIncompleteReason }
+);
+
+export interface TautulliWatchHistoryResponse {
+	provider: TautulliProvider;
+	configured: boolean;
+	sources: TautulliHistorySource[];
+	pagination: {
+		offset: number;
+		limit: number;
+		complete: boolean;
+	};
+}
+
+export interface TautulliCacheStatusResponse {
+	instanceId: string;
+	cachedItems: number;
+	hasCacheData: boolean;
+	status: {
+		cacheType: "tautulli";
+		lastRefreshedAt: string | null;
+		lastResult: string | null;
+		lastErrorMessage: string | null;
+		itemCount: number;
+		lastAttemptAt: string | null;
+		lastAttemptResult: string | null;
+		lastAttemptErrorMessage: string | null;
+	} | null;
+}
+
+export interface TautulliCacheHealthResponse {
+	items: Array<{
+		instanceId: string;
+		instanceLabel: string;
+		cacheType: "tautulli";
+		lastRefreshedAt: string | null;
+		lastResult: string | null;
+		lastErrorMessage: string | null;
+		itemCount: number;
+		/** The latest refresh attempt, retained separately from the successful generation. */
+		lastAttemptAt: string | null;
+		lastAttemptResult: string | null;
+		lastAttemptErrorMessage: string | null;
+		/** The result users should act on after accounting for an in-flight or failed attempt. */
+		effectiveResult: string | null;
+		isStale: boolean | null;
+	}>;
+}
+
+export interface TautulliCacheRefreshResponse {
+	success: boolean;
+	complete: boolean;
+	superseded: boolean;
+	upserted: number;
+	errors: number;
 }

--- a/packages/shared/src/types/tautulli.ts
+++ b/packages/shared/src/types/tautulli.ts
@@ -38,7 +38,7 @@ export interface TautulliHistorySnapshot {
 }
 
 export interface TautulliHomeStatRow {
-	title: string;
+	title?: string;
 	friendly_name?: string;
 	user?: string;
 	user_id?: string;


### PR DESCRIPTION
## Summary

- add provider-specific Tautulli activity, home statistics, user watch-time, plays-by-date, history, cache status, health, and manual-refresh routes
- expose typed shared contracts plus centralized web API clients, query keys, and React Query hooks
- keep every multi-instance response source-scoped so truncated rankings and same-title records are never presented as a complete global aggregate
- preserve real Tautulli stat shapes, prefer provider friendly names, and paginate history deterministically by date and row id

## Safety and failure behavior

- resolve the current owned enabled Tautulli connection before every provider request and revalidate it before returning results
- return an explicit unavailable source when a connection changes or becomes unreachable instead of returning stale data
- fail history completeness closed when totals drift, row ids are missing or duplicated, ordering is unstable, or a page is truncated or overflows its declared total
- persist a guarded pending refresh witness before outbound cache work; success is recorded only with atomic cache publication, while failures retain the previous generation
- coalesce concurrent refreshes for the same connection generation and prevent superseded work from publishing

## Scope boundary

This slice adds the guarded provider API surface and frontend data-access layer. Settings/setup UI, the reusable Plex/Tautulli/Tracearr verification harness, and the provider-selection wizard remain separate follow-up slices.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`: 3,837 passed, 41 skipped
  - API: 3,025 passed, 41 skipped
  - web: 695 passed
  - shared: 117 passed
- `pnpm run lint`
- `pnpm run build`
- independent data-safety closure review: passed
- independent regression closure review: passed
