### PR TITLE
feat: restore Tautulli service setup

### DIFF
--- a/apps/api/src/lib/services/__tests__/connection-tester.test.ts
+++ b/apps/api/src/lib/services/__tests__/connection-tester.test.ts
@@ -259,3 +259,80 @@ describe("testServiceConnection — Tracearr health probe", () => {
 		expect(result.error).toMatch(/unexpected tracearr response/i);
 	});
 });
+
+describe("testServiceConnection — Tautulli information probe", () => {
+	let fetchSpy: FetchSpy;
+
+	beforeEach(() => {
+		fetchSpy = vi.fn();
+		vi.stubGlobal("fetch", fetchSpy);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("uses Tautulli's query-authenticated get_tautulli_info command", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			jsonResponse({
+				response: {
+					result: "success",
+					message: null,
+					data: { tautulli_version: "2.15.1" },
+				},
+			}),
+		);
+
+		const result = await testServiceConnection(
+			"http://tautulli:8181/",
+			"tautulli-api-key",
+			"tautulli",
+			{ username: "proxy-user", password: "proxy-pass" },
+		);
+
+		expect(result).toMatchObject({
+			success: true,
+			version: "2.15.1",
+			message: "Successfully connected to Tautulli",
+		});
+		const requestUrl = new URL(fetchSpy.mock.calls[0]?.[0] as string);
+		expect(requestUrl.origin + requestUrl.pathname).toBe("http://tautulli:8181/api/v2");
+		expect(requestUrl.searchParams.get("apikey")).toBe("tautulli-api-key");
+		expect(requestUrl.searchParams.get("cmd")).toBe("get_tautulli_info");
+		const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+		expect((init.headers as Record<string, string>).Authorization).toBe(
+			"Basic cHJveHktdXNlcjpwcm94eS1wYXNz",
+		);
+	});
+
+	it("rejects an API-level error returned with HTTP 200", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			jsonResponse({
+				response: { result: "error", message: "Invalid apikey", data: {} },
+			}),
+		);
+
+		const result = await testServiceConnection("http://tautulli:8181", "bad-key", "tautulli");
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/tautulli authentication failed/i);
+	});
+
+	it("rejects a success response that is not Tautulli information", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			jsonResponse({
+				response: { result: "success", message: null, data: { version: "not-tautulli" } },
+			}),
+		);
+
+		const result = await testServiceConnection(
+			"http://tautulli:8181",
+			"tautulli-api-key",
+			"tautulli",
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.error).toMatch(/unexpected tautulli response/i);
+	});
+});

--- a/apps/api/src/lib/services/connection-tester.ts
+++ b/apps/api/src/lib/services/connection-tester.ts
@@ -1,3 +1,4 @@
+import { tautulliInfoSchema, tautulliResponseWrapperSchema } from "../tautulli/tautulli-schemas.js";
 import { createHttpAuthHeaders, type HttpAuthCredentials } from "./http-auth.js";
 import { getHttpAuthConflict } from "./http-auth-validation.js";
 
@@ -105,6 +106,12 @@ export async function testServiceConnection(
 			return await testTracearrConnection(normalizedBaseUrl, apiKey);
 		}
 
+		// Tautulli uses query-parameter API-key authentication and wraps command
+		// results in its own response envelope.
+		if (service === "tautulli") {
+			return await testTautulliConnection(normalizedBaseUrl, apiKey, httpAuth);
+		}
+
 		// Seerr uses its own status endpoint; Prowlarr/Lidarr/Readarr use v1; Sonarr/Radarr use v3
 		const apiPath =
 			service === "seerr"
@@ -177,6 +184,101 @@ export async function testServiceConnection(
 	} catch (error: unknown) {
 		return handleConnectionError(error);
 	}
+}
+
+/** Tests Tautulli reachability and credentials with its lightweight info command. */
+async function testTautulliConnection(
+	baseUrl: string,
+	apiKey: string,
+	httpAuth: HttpAuthCredentials | null,
+): Promise<ConnectionTestResult> {
+	const url = new URL(`${baseUrl}/api/v2`);
+	url.searchParams.set("apikey", apiKey);
+	url.searchParams.set("cmd", "get_tautulli_info");
+	const testUrl = url.toString();
+
+	let response: Response;
+	try {
+		response = await fetch(testUrl, {
+			headers: {
+				Accept: "application/json",
+				...createHttpAuthHeaders(httpAuth),
+			},
+			signal: AbortSignal.timeout(5000),
+		});
+	} catch (error) {
+		return handleConnectionError(error);
+	}
+
+	const proxyDetected = detectAuthProxy(response, testUrl);
+	if (proxyDetected) {
+		return {
+			success: false,
+			error: "Authentication proxy detected",
+			details: `${proxyDetected}\n\n${AUTH_PROXY_ADVICE}`,
+		};
+	}
+
+	if (!response.ok) {
+		return handleHttpError(response, baseUrl);
+	}
+
+	const contentType = response.headers.get("content-type");
+	if (!contentType?.includes("application/json")) {
+		return {
+			success: false,
+			error: "Invalid response format",
+			details:
+				"Received a non-JSON response from Tautulli. Check that the base URL points at the Tautulli host and includes any configured URL base.",
+		};
+	}
+
+	let raw: unknown;
+	try {
+		raw = await response.json();
+	} catch {
+		return {
+			success: false,
+			error: "Invalid response format",
+			details: "Tautulli returned malformed JSON. Check the service and reverse-proxy logs.",
+		};
+	}
+
+	const wrapper = tautulliResponseWrapperSchema.safeParse(raw);
+	if (!wrapper.success) {
+		return {
+			success: false,
+			error: "Unexpected Tautulli response",
+			details:
+				"Reached the URL, but the response did not match Tautulli's API envelope. Check that the base URL points at a Tautulli instance.",
+		};
+	}
+
+	if (wrapper.data.response.result !== "success") {
+		return {
+			success: false,
+			error: "Tautulli authentication failed",
+			details:
+				wrapper.data.response.message ??
+				"Tautulli rejected the API request. Verify the configured API key.",
+		};
+	}
+
+	const info = tautulliInfoSchema.safeParse(wrapper.data.response.data);
+	if (!info.success) {
+		return {
+			success: false,
+			error: "Unexpected Tautulli response",
+			details:
+				"Tautulli reported success without its version information. Check that the URL points at a supported Tautulli instance.",
+		};
+	}
+
+	return {
+		success: true,
+		message: "Successfully connected to Tautulli",
+		version: info.data.tautulli_version,
+	};
 }
 
 /**

--- a/apps/api/src/routes/__tests__/services.test.ts
+++ b/apps/api/src/routes/__tests__/services.test.ts
@@ -222,6 +222,24 @@ describe("POST /services", () => {
 		);
 	});
 
+	it("accepts Tautulli as a supported integration", async () => {
+		const res = await injectAuthenticated("POST", "/services", {
+			body: {
+				label: "Primary Tautulli",
+				baseUrl: "http://tautulli:8181",
+				apiKey: "tautulli-api-key",
+				service: "tautulli",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.serviceInstance.create).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ service: "TAUTULLI" }),
+			}),
+		);
+	});
+
 	it("demotes other instances when isDefault is true", async () => {
 		const res = await injectAuthenticated("POST", "/services", {
 			body: {
@@ -496,6 +514,23 @@ describe("POST /services/test-connection", () => {
 
 		expect(res.statusCode).toBe(200);
 		expect(mockTestConnection).toHaveBeenCalledWith("http://sonarr:8989", "test-key", "sonarr");
+	});
+
+	it("passes Tautulli through to its dedicated connection tester", async () => {
+		const res = await injectAuthenticated("POST", "/services/test-connection", {
+			body: {
+				baseUrl: "http://tautulli:8181",
+				apiKey: "tautulli-api-key",
+				service: "tautulli",
+			},
+		});
+
+		expect(res.statusCode).toBe(200);
+		expect(mockTestConnection).toHaveBeenCalledWith(
+			"http://tautulli:8181",
+			"tautulli-api-key",
+			"tautulli",
+		);
 	});
 
 	it("rejects non-http scheme (SSRF prevention)", async () => {

--- a/apps/web/src/features/settings/components/service-form.tsx
+++ b/apps/web/src/features/settings/components/service-form.tsx
@@ -540,6 +540,7 @@ const COMPANION_PORTS: Record<string, number> = {
 	emby: 8096,
 	qui: 7476,
 	tracearr: 3000,
+	tautulli: 8181,
 };
 
 /**

--- a/apps/web/src/features/settings/lib/settings-constants.ts
+++ b/apps/web/src/features/settings/lib/settings-constants.ts
@@ -2,32 +2,11 @@
  * Constants for settings feature
  */
 
-export type ServiceType =
-	| "sonarr"
-	| "radarr"
-	| "prowlarr"
-	| "lidarr"
-	| "readarr"
-	| "seerr"
-	| "plex"
-	| "jellyfin"
-	| "emby"
-	| "qui"
-	| "tracearr";
+import { ALL_SERVICES, type ArrServiceType } from "@arr/shared";
 
-export const SERVICE_TYPES: ServiceType[] = [
-	"sonarr",
-	"radarr",
-	"prowlarr",
-	"lidarr",
-	"readarr",
-	"seerr",
-	"plex",
-	"jellyfin",
-	"emby",
-	"qui",
-	"tracearr",
-];
+export type ServiceType = ArrServiceType;
+
+export const SERVICE_TYPES: ServiceType[] = [...ALL_SERVICES];
 
 export const OPTION_STYLE = {
 	backgroundColor: "hsl(var(--color-bg))",

--- a/apps/web/src/features/settings/lib/settings-utils.ts
+++ b/apps/web/src/features/settings/lib/settings-utils.ts
@@ -124,6 +124,11 @@ export const getServicePlaceholders = (service: ServiceType) => {
 				label: "Primary Tracearr",
 				baseUrl: "http://localhost:3000",
 			};
+		case "tautulli":
+			return {
+				label: "Primary Tautulli",
+				baseUrl: "http://localhost:8181",
+			};
 		default:
 			return {
 				label: "Primary Instance",

--- a/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
@@ -144,7 +144,9 @@ describe("ServiceOnboarding", () => {
 	it("offers Tautulli as a manual analytics service and submits its connection details", async () => {
 		render(<ServiceOnboarding />);
 		expect(
-			screen.getByText(/Tracearr is recommended for new analytics setups/),
+			screen.getByText(
+				/Tracearr is recommended for new analytics setups.+Choose one historical analytics provider/,
+			),
 		).toBeInTheDocument();
 		fireEvent.click(screen.getByRole("button", { name: "tautulli" }));
 

--- a/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
+++ b/apps/web/src/features/setup/components/__tests__/service-onboarding.test.tsx
@@ -141,6 +141,44 @@ describe("ServiceOnboarding", () => {
 		).toBeInTheDocument();
 	});
 
+	it("offers Tautulli as a manual analytics service and submits its connection details", async () => {
+		render(<ServiceOnboarding />);
+		expect(
+			screen.getByText(/Tracearr is recommended for new analytics setups/),
+		).toBeInTheDocument();
+		fireEvent.click(screen.getByRole("button", { name: "tautulli" }));
+
+		expect(screen.getByLabelText("Label")).toHaveValue("Primary Tautulli");
+		expect(screen.getByLabelText("Base URL")).toHaveAttribute(
+			"placeholder",
+			"http://localhost:8181",
+		);
+		expect(screen.getByRole("checkbox", { name: "Reverse proxy HTTP Basic Auth" })).toBeEnabled();
+
+		fireEvent.change(screen.getByLabelText("Base URL"), {
+			target: { value: "http://tautulli:8181" },
+		});
+		fireEvent.change(screen.getByLabelText("API key"), {
+			target: { value: "tautulli-api-key" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Test and add" }));
+
+		await waitFor(() => expect(mocks.createService).toHaveBeenCalledOnce());
+		expect(mocks.testConnection).toHaveBeenCalledWith({
+			service: "tautulli",
+			label: "Primary Tautulli",
+			baseUrl: "http://tautulli:8181",
+			apiKey: "tautulli-api-key",
+			httpAuth: undefined,
+		});
+		expect(mocks.createService).toHaveBeenCalledWith(
+			expect.objectContaining({
+				service: "tautulli",
+				isDefault: true,
+			}),
+		);
+	});
+
 	it("continues to the Console walkthrough without requiring a service", () => {
 		render(<ServiceOnboarding />);
 		fireEvent.click(screen.getByRole("button", { name: "Continue without services" }));

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -245,7 +245,8 @@ export const ServiceOnboarding = () => {
 				<CardContent className="space-y-4">
 					<p className="text-sm text-muted-foreground">
 						Tracearr is recommended for new analytics setups. Tautulli remains a supported
-						alternative; you can connect either or both.
+						alternative for existing Plex analytics setups. Choose one historical analytics
+						provider.
 					</p>
 					<div className="flex flex-wrap gap-2">
 						{SERVICE_TYPES.map((service) => (

--- a/apps/web/src/features/setup/components/service-onboarding.tsx
+++ b/apps/web/src/features/setup/components/service-onboarding.tsx
@@ -243,6 +243,10 @@ export const ServiceOnboarding = () => {
 					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-4">
+					<p className="text-sm text-muted-foreground">
+						Tracearr is recommended for new analytics setups. Tautulli remains a supported
+						alternative; you can connect either or both.
+					</p>
 					<div className="flex flex-wrap gap-2">
 						{SERVICE_TYPES.map((service) => (
 							<Button

--- a/apps/web/src/hooks/api/useServiceMutations.ts
+++ b/apps/web/src/hooks/api/useServiceMutations.ts
@@ -1,8 +1,7 @@
 ﻿"use client";
 
-import type { ServiceInstanceSummary } from "@arr/shared";
+import type { ArrServiceType, ServiceInstanceSummary } from "@arr/shared";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { libraryCleanupKeys, serviceKeys, systemKeys } from "../../lib/query-keys";
 import {
 	type CreateServicePayload,
 	createService,
@@ -10,6 +9,7 @@ import {
 	type UpdateServicePayload,
 	updateService,
 } from "../../lib/api-client/services";
+import { libraryCleanupKeys, serviceKeys, systemKeys } from "../../lib/query-keys";
 
 type UpdateVariables = {
 	id: string;
@@ -104,18 +104,7 @@ export const useTestConnectionBeforeAdd = () => {
 		{
 			baseUrl: string;
 			apiKey: string;
-			service:
-				| "sonarr"
-				| "radarr"
-				| "prowlarr"
-				| "lidarr"
-				| "readarr"
-				| "seerr"
-				| "plex"
-				| "jellyfin"
-				| "emby"
-				| "qui"
-				| "tracearr";
+			service: ArrServiceType;
 			httpAuth?: { username: string; password: string };
 		}
 	>({

--- a/apps/web/src/lib/api-client/services.ts
+++ b/apps/web/src/lib/api-client/services.ts
@@ -1,4 +1,9 @@
-import type { ServiceInstanceSummary, ServiceResponse, ServicesResponse } from "@arr/shared";
+import type {
+	ArrServiceType,
+	ServiceInstanceSummary,
+	ServiceResponse,
+	ServicesResponse,
+} from "@arr/shared";
 import { apiRequest, UnauthorizedError } from "./base";
 
 export async function fetchServices(): Promise<ServiceInstanceSummary[]> {
@@ -19,18 +24,7 @@ export type CreateServicePayload = {
 	externalUrl?: string | null;
 	apiKey: string;
 	httpAuth?: { username: string; password: string } | null;
-	service:
-		| "sonarr"
-		| "radarr"
-		| "prowlarr"
-		| "lidarr"
-		| "readarr"
-		| "seerr"
-		| "plex"
-		| "jellyfin"
-		| "emby"
-		| "qui"
-		| "tracearr";
+	service: ArrServiceType;
 	enabled?: boolean;
 	isDefault?: boolean;
 	tags?: string[];
@@ -87,18 +81,7 @@ export async function testServiceConnection(
 export async function testConnectionBeforeAdd(
 	baseUrl: string,
 	apiKey: string,
-	service:
-		| "sonarr"
-		| "radarr"
-		| "prowlarr"
-		| "lidarr"
-		| "readarr"
-		| "seerr"
-		| "plex"
-		| "jellyfin"
-		| "emby"
-		| "qui"
-		| "tracearr",
+	service: ArrServiceType,
 	httpAuth?: { username: string; password: string },
 ): Promise<TestConnectionResponse> {
 	return await apiRequest<TestConnectionResponse>("/api/services/test-connection", {

--- a/apps/web/src/lib/theme-gradients.ts
+++ b/apps/web/src/lib/theme-gradients.ts
@@ -70,6 +70,7 @@
  * - Semantic colors (SEMANTIC_COLORS): success=green, warning=amber, error=red
  */
 
+import type { ArrServiceType } from "@arr/shared";
 import type { ColorTheme } from "../providers/color-theme-provider";
 
 /**
@@ -324,18 +325,7 @@ export interface ServiceGradient {
 }
 
 /** Valid service types for gradient lookup */
-export type ServiceType =
-	| "sonarr"
-	| "radarr"
-	| "prowlarr"
-	| "lidarr"
-	| "readarr"
-	| "seerr"
-	| "plex"
-	| "jellyfin"
-	| "emby"
-	| "qui"
-	| "tracearr";
+export type ServiceType = ArrServiceType;
 
 /**
  * Service-specific gradients for visual distinction
@@ -403,6 +393,11 @@ export const SERVICE_GRADIENTS: Record<ServiceType, ServiceGradient> = {
 		from: "#d946ef", // fuchsia-500 (analytics / insight — distinct from the blues)
 		to: "#6366f1", // indigo-500 (long magenta→indigo sweep, unused elsewhere)
 		glow: "rgba(217, 70, 239, 0.4)",
+	},
+	tautulli: {
+		from: "#ef4444", // red-500 (Tautulli analytics identity)
+		to: "#f59e0b", // amber-500
+		glow: "rgba(239, 68, 68, 0.4)",
 	},
 };
 

--- a/packages/shared/src/types/__tests__/arr.test.ts
+++ b/packages/shared/src/types/__tests__/arr.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { ALL_SERVICES, arrServiceTypeSchema, multiInstanceConfigSchema } from "../arr.js";
+
+describe("service type taxonomy", () => {
+	it("accepts both analytics providers as supported integrations", () => {
+		expect(ALL_SERVICES).toContain("tracearr");
+		expect(ALL_SERVICES).toContain("tautulli");
+		expect(arrServiceTypeSchema.parse("tracearr")).toBe("tracearr");
+		expect(arrServiceTypeSchema.parse("tautulli")).toBe("tautulli");
+	});
+
+	it("initializes multi-instance collections for both analytics providers", () => {
+		const config = multiInstanceConfigSchema.parse({});
+
+		expect(config.tracearr).toEqual([]);
+		expect(config.tautulli).toEqual([]);
+	});
+});

--- a/packages/shared/src/types/arr.ts
+++ b/packages/shared/src/types/arr.ts
@@ -18,6 +18,7 @@ export const INTEGRATION_SERVICES = [
 	"emby",
 	"qui",
 	"tracearr",
+	"tautulli",
 ] as const;
 
 /** All supported service types */
@@ -76,6 +77,8 @@ export const multiInstanceConfigSchema = z.object({
 	jellyfin: z.array(serviceInstanceSchema).default([]),
 	emby: z.array(serviceInstanceSchema).default([]),
 	qui: z.array(serviceInstanceSchema).default([]),
+	tracearr: z.array(serviceInstanceSchema).default([]),
+	tautulli: z.array(serviceInstanceSchema).default([]),
 });
 
 export type MultiInstanceConfig = z.infer<typeof multiInstanceConfigSchema>;


### PR DESCRIPTION
## Summary

- restore Tautulli to the shared service taxonomy so create, edit, and pre-save connection tests accept it
- add Tautulli to Settings and setup with port `8181`, a service gradient, and Tracearr-first provider guidance
- test connections with Tautulli's real `get_tautulli_info` API envelope, including optional reverse-proxy HTTP Basic Auth
- replace duplicated frontend service unions with the shared taxonomy and add regression coverage

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — shared 119, web 696, API 3,030 passed
- `pnpm run lint`
- `pnpm run build`
- independent regression review: no findings

An authenticated browser/live Tautulli smoke test was not run in this slice. That verification will be added through the planned disposable Plex/Tautulli/Tracearr development harness rather than using a real account or production data.