### PR TITLE
chore(format): restore main formatting baseline

### DIFF
--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -282,27 +282,24 @@ describe("POST /auth/oidc/setup", () => {
 		"https://admin:secret@arr.example.com/",
 		"ftp://arr.example.com/",
 		"mailto:admin@example.com",
-	])(
-		"rejects an unsafe APP_URL when generating the setup callback: %s",
-		async (appUrl) => {
-			Object.assign(app.config, { APP_URL: appUrl });
+	])("rejects an unsafe APP_URL when generating the setup callback: %s", async (appUrl) => {
+		Object.assign(app.config, { APP_URL: appUrl });
 
-			const res = await app.inject({
-				method: "POST",
-				url: "/auth/oidc/setup",
-				payload: {
-					displayName: "My OIDC Provider",
-					clientId: "my-client-id",
-					clientSecret: "my-client-secret",
-					issuer: "https://provider.example.com",
-				},
-			});
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
 
-			expect(res.statusCode).toBe(400);
-			expect(JSON.parse(res.payload).error).toContain("APP_URL");
-			expect(mockPrisma.oIDCProvider.create).not.toHaveBeenCalled();
-		},
-	);
+		expect(res.statusCode).toBe(400);
+		expect(JSON.parse(res.payload).error).toContain("APP_URL");
+		expect(mockPrisma.oIDCProvider.create).not.toHaveBeenCalled();
+	});
 
 	it("returns 403 when users already exist", async () => {
 		// Make the transaction see existing users

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -153,27 +153,24 @@ describe("POST /api/oidc-providers", () => {
 		"https://admin:secret@arr.example.com/",
 		"ftp://arr.example.com/",
 		"mailto:admin@example.com",
-	])(
-		"rejects an unsafe APP_URL when generating the admin callback: %s",
-		async (appUrl) => {
-			Object.assign(app.config, { APP_URL: appUrl });
+	])("rejects an unsafe APP_URL when generating the admin callback: %s", async (appUrl) => {
+		Object.assign(app.config, { APP_URL: appUrl });
 
-			const response = await app.inject({
-				method: "POST",
-				url: "/api/oidc-providers",
-				payload: {
-					displayName: "Authentik",
-					clientId: "arr-dashboard",
-					clientSecret: "secret",
-					issuer: "https://auth.example.com",
-				},
-			});
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/oidc-providers",
+			payload: {
+				displayName: "Authentik",
+				clientId: "arr-dashboard",
+				clientSecret: "secret",
+				issuer: "https://auth.example.com",
+			},
+		});
 
-			expect(response.statusCode).toBe(400);
-			expect(JSON.parse(response.payload).error).toContain("APP_URL");
-			expect(findProvider).not.toHaveBeenCalled();
-		},
-	);
+		expect(response.statusCode).toBe(400);
+		expect(JSON.parse(response.payload).error).toContain("APP_URL");
+		expect(findProvider).not.toHaveBeenCalled();
+	});
 });
 
 describe("DELETE /api/oidc-providers", () => {

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -386,10 +386,7 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 					// snapshot is installed with a replacement password.
 					const affectedUsers = await tx.user.findMany({
 						where: {
-							OR: [
-								{ id: request.currentUser!.id },
-								{ oidcAccounts: { some: {} } },
-							],
+							OR: [{ id: request.currentUser!.id }, { oidcAccounts: { some: {} } }],
 						},
 						select: { id: true, hashedPassword: true },
 					});
@@ -437,8 +434,7 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 				}
 				if (error instanceof Error && error.message === OIDC_ADMIN_AUTH_CHANGED) {
 					return reply.status(409).send({
-						error:
-							"Your password changed while deletion was in progress. Sign in and try again.",
+						error: "Your password changed while deletion was in progress. Sign in and try again.",
 					});
 				}
 				throw error;

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-	type CurrentUser,
-	deleteOidcProviderSchema,
-	type UpdateOIDCProvider,
-} from "@arr/shared";
+import { type CurrentUser, deleteOidcProviderSchema, type UpdateOIDCProvider } from "@arr/shared";
 import {
 	AlertCircle,
 	Check,


### PR DESCRIPTION
## Summary

- apply the repository formatter to four OIDC files that were already out of format on `main`
- restore a clean formatting baseline so focused maintenance PRs can pass the required full gauntlet
- make no behavioral changes

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `git diff --check`

## Risk

Formatter-only changes. The diff contains no altered conditions, data flow, API behavior, or test assertions.
