### PR TITLE
fix(seerr): honor selected approval server

### DIFF
--- a/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
@@ -1,0 +1,126 @@
+import type { SeerrRequest } from "@arr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockUseSeerrRequestOptions = vi.fn();
+const mockUseApproveSeerrRequest = vi.fn();
+
+vi.mock("../../../../hooks/api/useSeerr", () => ({
+	useSeerrRequestOptions: (...args: unknown[]) => mockUseSeerrRequestOptions(...args),
+	useApproveSeerrRequest: () => mockUseApproveSeerrRequest(),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#3b82f6",
+			to: "#8b5cf6",
+			glow: "rgba(59,130,246,0.3)",
+			fromLight: "#3b82f610",
+			fromMedium: "#3b82f620",
+			fromMuted: "#3b82f630",
+		},
+	}),
+}));
+
+import { ApproveWithOptionsDialog } from "../approve-with-options-dialog";
+
+const defaultServer = {
+	server: {
+		id: 1,
+		name: "Sonarr A",
+		is4k: false,
+		isDefault: true,
+		activeProfileId: 10,
+		activeDirectory: "/tv-a",
+	},
+	profiles: [{ id: 10, name: "HD-1080p" }],
+	rootFolders: [{ id: 100, path: "/tv-a" }],
+};
+
+const alternateServer = {
+	server: {
+		id: 2,
+		name: "Sonarr B",
+		is4k: false,
+		isDefault: false,
+		activeProfileId: 20,
+		activeDirectory: "/tv-b",
+	},
+	profiles: [{ id: 20, name: "WEB-1080p" }],
+	rootFolders: [{ id: 200, path: "/tv-b" }],
+};
+
+const request = {
+	id: 42,
+	type: "tv",
+	is4k: false,
+	serverId: undefined,
+	profileId: undefined,
+	rootFolder: undefined,
+} as SeerrRequest;
+
+const defaultMutation = {
+	mutate: vi.fn(),
+	isPending: false,
+};
+
+function renderDialog() {
+	return render(
+		<ApproveWithOptionsDialog request={request} instanceId="seerr-1" open onOpenChange={vi.fn()} />,
+	);
+}
+
+describe("ApproveWithOptionsDialog", () => {
+	let mutate: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mutate = vi.fn();
+		mockUseSeerrRequestOptions.mockReturnValue({
+			data: { servers: [defaultServer, alternateServer] },
+			isLoading: false,
+			isError: false,
+		});
+		mockUseApproveSeerrRequest.mockReturnValue({ ...defaultMutation, mutate });
+	});
+
+	it("sends selected server defaults as overrides when changing a first-time route", () => {
+		renderDialog();
+
+		fireEvent.change(screen.getByLabelText("Server"), { target: { value: "2" } });
+		fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+		expect(mutate).toHaveBeenCalledWith(
+			{
+				instanceId: "seerr-1",
+				requestId: 42,
+				overrides: {
+					serverId: 2,
+					profileId: 20,
+					rootFolder: "/tv-b",
+				},
+			},
+			expect.any(Object),
+		);
+	});
+
+	it("does not send overrides when approving the default first-time route", () => {
+		renderDialog();
+
+		fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+		expect(mutate).toHaveBeenCalledWith(
+			{
+				instanceId: "seerr-1",
+				requestId: 42,
+				overrides: undefined,
+			},
+			expect.any(Object),
+		);
+	});
+});

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -105,13 +105,14 @@ export const ApproveWithOptionsDialog = ({
 			profileId?: number;
 			rootFolder?: string;
 		} = {};
-		// Compare against the *effective* current values — the request's own fields
-		// when set, otherwise the selected server's defaults. This way a confirm
+		// Compare against the request's original/default routing values — the request's own fields
+		// when set, otherwise the original server's defaults. This way a confirm
 		// without changes doesn't fire a pointless PUT or write `overridden: true`
 		// to the audit log for first-time-routed requests.
-		const effectiveServerId = request.serverId ?? selectedServer?.server.id;
-		const effectiveProfileId = request.profileId ?? selectedServer?.server.activeProfileId;
-		const effectiveRootFolder = request.rootFolder ?? selectedServer?.server.activeDirectory;
+		const originalServer = resolveSelectedServer(filteredServers, request.serverId);
+		const effectiveServerId = request.serverId ?? originalServer?.server.id;
+		const effectiveProfileId = request.profileId ?? originalServer?.server.activeProfileId;
+		const effectiveRootFolder = request.rootFolder ?? originalServer?.server.activeDirectory;
 
 		if (serverId !== undefined && serverId !== effectiveServerId) {
 			overrides.serverId = serverId;


### PR DESCRIPTION
## Summary

- preserve the request's original/default Sonarr routing as the comparison baseline
- send the newly selected non-default Sonarr server, profile, and root folder as explicit approval overrides
- avoid marking an unchanged default approval as overridden
- add rendered component regressions for both paths

## Root cause

The approval dialog compared the selected server against that same newly selected server. For a request without pre-existing routing fields, that made the non-default selection look unchanged and omitted `serverId` from the approval request. Seerr then used its default Sonarr instance.

## Validation

- RED before the fix: the two-server component regression expected Sonarr B overrides but received `undefined`
- focused Seerr tests: 3 files, 39 tests passed
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- independent regression review: no findings
- disposable unauthenticated two-server fixture rendered the real component and both server choices; the constrained browser wrapper could not dispatch a native-select change, so payload verification remains at the rendered component boundary

## Compatibility and risk

The API contract is unchanged. Existing API coverage already verifies that explicit approval overrides are forwarded to Seerr. The change is limited to how the dialog decides whether an override differs from the request's original/default route.

The same defect exists on `next`; a separate semantic forward-port will follow this stable fix.

Closes #706
