### PR TITLE
fix(seerr): mask approval routing options

### DIFF
--- a/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
@@ -1,6 +1,8 @@
 import type { SeerrRequest } from "@arr/shared";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { getLinuxSavePath, getLinuxServerName } from "../../../../lib/incognito";
 
 const mockUseSeerrRequestOptions = vi.fn();
 const mockUseApproveSeerrRequest = vi.fn();
@@ -71,7 +73,14 @@ const defaultMutation = {
 
 function renderDialog() {
 	return render(
-		<ApproveWithOptionsDialog request={request} instanceId="seerr-1" open onOpenChange={vi.fn()} />,
+		<IncognitoProvider>
+			<ApproveWithOptionsDialog
+				request={request}
+				instanceId="seerr-1"
+				open
+				onOpenChange={vi.fn()}
+			/>
+		</IncognitoProvider>,
 	);
 }
 
@@ -80,6 +89,7 @@ describe("ApproveWithOptionsDialog", () => {
 
 	beforeEach(() => {
 		vi.clearAllMocks();
+		localStorage.clear();
 		mutate = vi.fn();
 		mockUseSeerrRequestOptions.mockReturnValue({
 			data: { servers: [defaultServer, alternateServer] },
@@ -122,5 +132,80 @@ describe("ApproveWithOptionsDialog", () => {
 			},
 			expect.any(Object),
 		);
+	});
+
+	it("masks Sonarr server names and root folders in incognito mode", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+
+		renderDialog();
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("option", {
+					name: `${getLinuxServerName("Sonarr A")} 1 (default)`,
+				}),
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.getByRole("option", { name: `${getLinuxServerName("Sonarr B")} 2` }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", {
+				name: `${getLinuxSavePath("/tv-a")} 1 (server default)`,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Sonarr A (default)")).not.toBeInTheDocument();
+		expect(screen.queryByText("/tv-a (server default)")).not.toBeInTheDocument();
+	});
+
+	it("keeps colliding incognito aliases distinguishable", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		expect(getLinuxServerName("Main")).toBe(getLinuxServerName("Default"));
+		expect(getLinuxSavePath("/media/tv")).toBe(getLinuxSavePath("/media/tv4k"));
+		mockUseSeerrRequestOptions.mockReturnValue({
+			data: {
+				servers: [
+					{
+						...defaultServer,
+						server: {
+							...defaultServer.server,
+							name: "Main",
+							activeDirectory: "/media/tv",
+						},
+						rootFolders: [
+							{ id: 100, path: "/media/tv" },
+							{ id: 101, path: "/media/tv4k" },
+						],
+					},
+					{
+						...alternateServer,
+						server: { ...alternateServer.server, name: "Default" },
+					},
+				],
+			},
+			isLoading: false,
+			isError: false,
+		});
+
+		renderDialog();
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("option", {
+					name: `${getLinuxServerName("Main")} 1 (default)`,
+				}),
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.getByRole("option", { name: `${getLinuxServerName("Default")} 2` }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", {
+				name: `${getLinuxSavePath("/media/tv")} 1 (server default)`,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", { name: `${getLinuxSavePath("/media/tv4k")} 2` }),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -26,6 +26,7 @@ import {
 	SelectOption,
 } from "../../../components/ui";
 import { useApproveSeerrRequest, useSeerrRequestOptions } from "../../../hooks/api/useSeerr";
+import { getLinuxSavePath, getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
 
 interface ApproveWithOptionsDialogProps {
 	request: SeerrRequest;
@@ -53,6 +54,7 @@ export const ApproveWithOptionsDialog = ({
 	open,
 	onOpenChange,
 }: ApproveWithOptionsDialogProps) => {
+	const [incognitoMode] = useIncognitoMode();
 	const profileFieldId = useId();
 	const folderFieldId = useId();
 	const serverFieldId = useId();
@@ -197,9 +199,11 @@ export const ApproveWithOptionsDialog = ({
 									value={serverId ?? ""}
 									onChange={(e) => handleServerChange(Number(e.target.value))}
 								>
-									{filteredServers.map((s) => (
+									{filteredServers.map((s, index) => (
 										<SelectOption key={s.server.id} value={s.server.id}>
-											{s.server.name}
+											{incognitoMode
+												? `${getLinuxServerName(s.server.name)} ${index + 1}`
+												: s.server.name}
 											{s.server.isDefault ? " (default)" : ""}
 										</SelectOption>
 									))}
@@ -240,9 +244,9 @@ export const ApproveWithOptionsDialog = ({
 								value={rootFolder ?? ""}
 								onChange={(e) => setRootFolder(e.target.value)}
 							>
-								{selectedServer.rootFolders.map((f) => (
+								{selectedServer.rootFolders.map((f, index) => (
 									<SelectOption key={f.id} value={f.path}>
-										{f.path}
+										{incognitoMode ? `${getLinuxSavePath(f.path)} ${index + 1}` : f.path}
 										{f.path === selectedServer.server.activeDirectory ? " (server default)" : ""}
 									</SelectOption>
 								))}


### PR DESCRIPTION
## Summary

- render Seerr Sonarr server names through the existing incognito server-name helper
- render root-folder paths through the existing incognito path helper
- append stable selector ordinals so colliding masked aliases remain distinguishable
- wrap approval-dialog tests in `IncognitoProvider`
- add an explicit regression proving raw server names and paths are absent in incognito mode

## Root cause

The approval dialog displayed server names and root-folder paths directly and did not consume the incognito context. The routing regression tests added in #710 also rendered the component without its required privacy provider, so they could not exercise the masked state.

## Validation

- RED before the implementation: the incognito regression could not find the masked default Sonarr option and showed the raw values
- focused Seerr tests: 3 files, 41 tests passed
- collision regression for two server names and two root paths that map to identical base aliases
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `git diff --check`

## Risk

The underlying `<option>` values remain the original server IDs and root paths, so approval behavior is unchanged. Only visible labels are anonymized when incognito mode is enabled. Ordinals follow the selector order and do not expose the original values.

Follow-up to #710 and the Codex review finding on that PR.

Related to #706
