### PR TITLE
fix(seerr): preserve selected Sonarr approval overrides

### DIFF
--- a/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+import { getLinuxSavePath, getLinuxServerName } from "../../../../lib/incognito";
 
 const mockUseApproveSeerrRequest = vi.fn();
 const mockUseSeerrRequestOptions = vi.fn();
@@ -44,7 +45,15 @@ const request: SeerrRequest = {
 	},
 	createdAt: "2026-08-14T00:00:00.000Z",
 	updatedAt: "2026-08-14T00:00:00.000Z",
-	requestedBy: { id: 1, displayName: "Requester" },
+	requestedBy: {
+		id: 1,
+		displayName: "Requester",
+		createdAt: "2026-08-14T00:00:00.000Z",
+		updatedAt: "2026-08-14T00:00:00.000Z",
+		permissions: 0,
+		requestCount: 1,
+		userType: 1,
+	},
 	is4k: false,
 };
 
@@ -91,6 +100,7 @@ function renderDialog(children: ReactNode) {
 describe("ApproveWithOptionsDialog", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		localStorage.clear();
 		mockUseApproveSeerrRequest.mockReturnValue(mutation);
 		mockUseSeerrRequestOptions.mockReturnValue({
 			data: { servers: sonarrServers },
@@ -139,5 +149,36 @@ describe("ApproveWithOptionsDialog", () => {
 			{ instanceId: "seerr-1", requestId: 706, overrides: undefined },
 			expect.any(Object),
 		);
+	});
+
+	it("masks Sonarr server names and root folders in incognito mode", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+
+		renderDialog(
+			<ApproveWithOptionsDialog
+				request={request}
+				instanceId="seerr-1"
+				open
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("option", {
+					name: `${getLinuxServerName("Sonarr A")} (default)`,
+				}),
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.getByRole("option", { name: getLinuxServerName("Sonarr B") }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", {
+				name: `${getLinuxSavePath("/tv-a")} (server default)`,
+			}),
+		).toBeInTheDocument();
+		expect(screen.queryByText("Sonarr A (default)")).not.toBeInTheDocument();
+		expect(screen.queryByText("/tv-a (server default)")).not.toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
@@ -166,19 +166,79 @@ describe("ApproveWithOptionsDialog", () => {
 		await waitFor(() => {
 			expect(
 				screen.getByRole("option", {
-					name: `${getLinuxServerName("Sonarr A")} (default)`,
+					name: `${getLinuxServerName("Sonarr A")} 1 (default)`,
 				}),
 			).toBeInTheDocument();
 		});
 		expect(
-			screen.getByRole("option", { name: getLinuxServerName("Sonarr B") }),
+			screen.getByRole("option", { name: `${getLinuxServerName("Sonarr B")} 2` }),
 		).toBeInTheDocument();
 		expect(
 			screen.getByRole("option", {
-				name: `${getLinuxSavePath("/tv-a")} (server default)`,
+				name: `${getLinuxSavePath("/tv-a")} 1 (server default)`,
 			}),
 		).toBeInTheDocument();
 		expect(screen.queryByText("Sonarr A (default)")).not.toBeInTheDocument();
 		expect(screen.queryByText("/tv-a (server default)")).not.toBeInTheDocument();
+	});
+
+	it("keeps colliding incognito aliases distinguishable", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		expect(getLinuxServerName("Main")).toBe(getLinuxServerName("Default"));
+		expect(getLinuxSavePath("/media/tv")).toBe(getLinuxSavePath("/media/tv4k"));
+		const defaultServer = sonarrServers[0]!;
+		const alternateServer = sonarrServers[1]!;
+		mockUseSeerrRequestOptions.mockReturnValue({
+			data: {
+				servers: [
+					{
+						...defaultServer,
+						server: {
+							...defaultServer.server,
+							name: "Main",
+							activeDirectory: "/media/tv",
+						},
+						rootFolders: [
+							{ id: 100, path: "/media/tv" },
+							{ id: 101, path: "/media/tv4k" },
+						],
+					},
+					{
+						...alternateServer,
+						server: { ...alternateServer.server, name: "Default" },
+					},
+				],
+			},
+			isLoading: false,
+			isError: false,
+		});
+
+		renderDialog(
+			<ApproveWithOptionsDialog
+				request={request}
+				instanceId="seerr-1"
+				open
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(
+				screen.getByRole("option", {
+					name: `${getLinuxServerName("Main")} 1 (default)`,
+				}),
+			).toBeInTheDocument();
+		});
+		expect(
+			screen.getByRole("option", { name: `${getLinuxServerName("Default")} 2` }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", {
+				name: `${getLinuxSavePath("/media/tv")} 1 (server default)`,
+			}),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("option", { name: `${getLinuxSavePath("/media/tv4k")} 2` }),
+		).toBeInTheDocument();
 	});
 });

--- a/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
+++ b/apps/web/src/features/seerr/components/__tests__/approve-with-options-dialog.test.tsx
@@ -1,0 +1,143 @@
+import type { SeerrRequest, SeerrServerWithDetails } from "@arr/shared";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+const mockUseApproveSeerrRequest = vi.fn();
+const mockUseSeerrRequestOptions = vi.fn();
+
+vi.mock("../../../../hooks/api/useSeerr", () => ({
+	useApproveSeerrRequest: () => mockUseApproveSeerrRequest(),
+	useSeerrRequestOptions: (...args: unknown[]) => mockUseSeerrRequestOptions(...args),
+}));
+
+vi.mock("sonner", () => ({
+	toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#3b82f6",
+			to: "#8b5cf6",
+			glow: "rgba(59,130,246,0.3)",
+			fromLight: "#3b82f610",
+			fromMedium: "#3b82f620",
+			fromMuted: "#3b82f630",
+		},
+	}),
+}));
+
+import { ApproveWithOptionsDialog } from "../approve-with-options-dialog";
+
+const request: SeerrRequest = {
+	id: 706,
+	status: 1,
+	type: "tv",
+	media: {
+		id: 706,
+		tmdbId: 706,
+		status: 1,
+		createdAt: "2026-08-14T00:00:00.000Z",
+		updatedAt: "2026-08-14T00:00:00.000Z",
+	},
+	createdAt: "2026-08-14T00:00:00.000Z",
+	updatedAt: "2026-08-14T00:00:00.000Z",
+	requestedBy: { id: 1, displayName: "Requester" },
+	is4k: false,
+};
+
+const sonarrServers: SeerrServerWithDetails[] = [
+	{
+		server: {
+			id: 1,
+			name: "Sonarr A",
+			is4k: false,
+			isDefault: true,
+			activeProfileId: 10,
+			activeDirectory: "/tv-a",
+			activeTags: [],
+		},
+		profiles: [{ id: 10, name: "HD" }],
+		rootFolders: [{ id: 10, path: "/tv-a" }],
+		tags: [],
+	},
+	{
+		server: {
+			id: 2,
+			name: "Sonarr B",
+			is4k: false,
+			isDefault: false,
+			activeProfileId: 20,
+			activeDirectory: "/tv-b",
+			activeTags: [],
+		},
+		profiles: [{ id: 20, name: "UHD" }],
+		rootFolders: [{ id: 20, path: "/tv-b" }],
+		tags: [],
+	},
+];
+
+const mutation = {
+	mutate: vi.fn(),
+	isPending: false,
+};
+
+function renderDialog(children: ReactNode) {
+	return render(children, { wrapper: IncognitoProvider });
+}
+
+describe("ApproveWithOptionsDialog", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockUseApproveSeerrRequest.mockReturnValue(mutation);
+		mockUseSeerrRequestOptions.mockReturnValue({
+			data: { servers: sonarrServers },
+			isLoading: false,
+			isError: false,
+		});
+	});
+
+	it("submits Sonarr B's server, profile, and root folder after selecting it", async () => {
+		renderDialog(
+			<ApproveWithOptionsDialog
+				request={request}
+				instanceId="seerr-1"
+				open
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		fireEvent.change(screen.getByLabelText("Server"), { target: { value: "2" } });
+		await waitFor(() => expect(screen.getByLabelText("Server")).toHaveValue("2"));
+		fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+		expect(mutation.mutate).toHaveBeenCalledWith(
+			{
+				instanceId: "seerr-1",
+				requestId: 706,
+				overrides: { serverId: 2, profileId: 20, rootFolder: "/tv-b" },
+			},
+			expect.any(Object),
+		);
+	});
+
+	it("submits no overrides when approving the unchanged original Sonarr route", () => {
+		renderDialog(
+			<ApproveWithOptionsDialog
+				request={request}
+				instanceId="seerr-1"
+				open
+				onOpenChange={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+		expect(mutation.mutate).toHaveBeenCalledWith(
+			{ instanceId: "seerr-1", requestId: 706, overrides: undefined },
+			expect.any(Object),
+		);
+	});
+});

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -202,9 +202,11 @@ export const ApproveWithOptionsDialog = ({
 									value={serverId ?? ""}
 									onChange={(e) => handleServerChange(Number(e.target.value))}
 								>
-									{filteredServers.map((s) => (
+									{filteredServers.map((s, index) => (
 										<SelectOption key={s.server.id} value={s.server.id}>
-											{incognitoMode ? getLinuxServerName(s.server.name) : s.server.name}
+											{incognitoMode
+												? `${getLinuxServerName(s.server.name)} ${index + 1}`
+												: s.server.name}
 											{s.server.isDefault ? " (default)" : ""}
 										</SelectOption>
 									))}
@@ -245,9 +247,9 @@ export const ApproveWithOptionsDialog = ({
 								value={rootFolder ?? ""}
 								onChange={(e) => setRootFolder(e.target.value)}
 							>
-								{selectedServer.rootFolders.map((f) => (
+								{selectedServer.rootFolders.map((f, index) => (
 									<SelectOption key={f.id} value={f.path}>
-										{incognitoMode ? getLinuxSavePath(f.path) : f.path}
+										{incognitoMode ? `${getLinuxSavePath(f.path)} ${index + 1}` : f.path}
 										{f.path === selectedServer.server.activeDirectory ? " (server default)" : ""}
 									</SelectOption>
 								))}

--- a/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
+++ b/apps/web/src/features/seerr/components/approve-with-options-dialog.tsx
@@ -10,7 +10,6 @@
  */
 
 import type { SeerrRequest, SeerrServerWithDetails } from "@arr/shared";
-import { getLinuxSavePath, getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
 import { Loader2 } from "lucide-react";
 import { useEffect, useId, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -27,6 +26,7 @@ import {
 	SelectOption,
 } from "../../../components/ui";
 import { useApproveSeerrRequest, useSeerrRequestOptions } from "../../../hooks/api/useSeerr";
+import { getLinuxSavePath, getLinuxServerName, useIncognitoMode } from "../../../lib/incognito";
 
 interface ApproveWithOptionsDialogProps {
 	request: SeerrRequest;
@@ -80,6 +80,10 @@ export const ApproveWithOptionsDialog = ({
 		() => resolveSelectedServer(filteredServers, serverId),
 		[filteredServers, serverId],
 	);
+	const originalServer = useMemo(
+		() => resolveSelectedServer(filteredServers, request.serverId),
+		[filteredServers, request.serverId],
+	);
 
 	// When the dialog opens or servers load, default selection to the request's
 	// current values (or the server defaults if the request has none yet).
@@ -107,13 +111,13 @@ export const ApproveWithOptionsDialog = ({
 			profileId?: number;
 			rootFolder?: string;
 		} = {};
-		// Compare against the *effective* current values — the request's own fields
-		// when set, otherwise the selected server's defaults. This way a confirm
+		// Compare against the *effective* original values — the request's own fields
+		// when set, otherwise the request's original/default server values. This way a confirm
 		// without changes doesn't fire a pointless PUT or write `overridden: true`
 		// to the audit log for first-time-routed requests.
-		const effectiveServerId = request.serverId ?? selectedServer?.server.id;
-		const effectiveProfileId = request.profileId ?? selectedServer?.server.activeProfileId;
-		const effectiveRootFolder = request.rootFolder ?? selectedServer?.server.activeDirectory;
+		const effectiveServerId = request.serverId ?? originalServer?.server.id;
+		const effectiveProfileId = request.profileId ?? originalServer?.server.activeProfileId;
+		const effectiveRootFolder = request.rootFolder ?? originalServer?.server.activeDirectory;
 
 		if (serverId !== undefined && serverId !== effectiveServerId) {
 			overrides.serverId = serverId;


### PR DESCRIPTION
## Summary

- forward-port the #706 Sonarr approval-routing fix onto the native 3.0 dialog
- compare selections against the request's original/default server rather than the newly selected server
- preserve 3.0 incognito masking for server names and root-folder paths
- keep colliding masked labels distinguishable with stable selector ordinals
- add explicit regressions for non-default routing, unchanged default routing, masked labels, and alias collisions

## Root cause

As on the stable line, a first-time request had no explicit routing fields. After the user selected Sonarr B, the dialog used Sonarr B itself as the comparison baseline, decided nothing had changed, and omitted the overrides. Seerr then routed the request to its default Sonarr instance.

## Validation

- RED before the fix: selecting Sonarr B produced `overrides: undefined`
- focused Seerr tests: 3 files, 41 tests passed
- independent focused review: no routing, hook-dependency, or incognito findings
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `git diff --check`

## Compatibility and risk

The API contract is unchanged. The fix uses the existing 3.0 dialog and privacy helpers, and the underlying server IDs and root paths remain unchanged when their labels are masked. Ordinals follow selector order and do not expose the original values.

Stable fix: #710
Stable privacy correction: #711

Related to #706
