### PR TITLE
fix(cleanup): restore Jellyfin composite controls

### DIFF
--- a/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "@/contexts/IncognitoContext";
 
 // ---------------------------------------------------------------------------
 // jsdom polyfills required by Radix UI
@@ -111,7 +112,9 @@ function createWrapper() {
 		defaultOptions: { queries: { retry: false, gcTime: 0 } },
 	});
 	return ({ children }: { children: ReactNode }) => (
-		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		<IncognitoProvider>
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		</IncognitoProvider>
 	);
 }
 
@@ -163,6 +166,7 @@ function makeEditRule(overrides: Partial<CleanupRuleResponse> = {}): CleanupRule
 describe("CleanupRuleDialog", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		localStorage.setItem("arr-dashboard-incognito-mode", "false");
 		mockServicesQueryState.data = [];
 		mockServicesQueryState.isLoading = false;
 		mockServicesQueryState.isFetching = false;
@@ -987,6 +991,35 @@ describe("CleanupRuleDialog", () => {
 	// ================================================================
 
 	describe("composite validation", () => {
+		it("rejects a Jellyfin watched-by condition with no selected users", async () => {
+			const onSave = vi.fn();
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({
+					ruleType: "composite",
+					parameters: {},
+					operator: "AND",
+					conditions: [
+						{
+							ruleType: "jellyfin_watched_by",
+							parameters: { operator: "includes_any", userNames: [] },
+						},
+					],
+				}),
+			});
+
+			fireEvent.click(screen.getByText("Save Changes").closest("button")!);
+
+			await waitFor(() =>
+				expect(
+					screen.getByText(
+						"Each condition that targets users must have at least one username selected.",
+					),
+				).toBeInTheDocument(),
+			);
+			expect(onSave).not.toHaveBeenCalled();
+		});
+
 		it("shows error when submitting composite with zero conditions", async () => {
 			const onSave = vi.fn();
 			renderDialog({ onSave });

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -1588,6 +1588,7 @@ export function CleanupRuleDialog({
 					(cond.ruleType === "seerr_requested_by" ||
 						cond.ruleType === "plex_watched_by" ||
 						cond.ruleType === "tautulli_watched_by" ||
+						cond.ruleType === "jellyfin_watched_by" ||
 						cond.ruleType === "seerr_modified_by") &&
 					Array.isArray(p.userNames) &&
 					p.userNames.length === 0

--- a/apps/web/src/features/rule-criteria/components/__tests__/condition-params-fields.test.tsx
+++ b/apps/web/src/features/rule-criteria/components/__tests__/condition-params-fields.test.tsx
@@ -1,6 +1,11 @@
-import type { CleanupFieldOptionsResponse, CleanupRuleType } from "@arr/shared";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+	type CleanupFieldOptionsResponse,
+	type CleanupRuleType,
+	jellyfinEpisodeCompletionParamsSchema,
+} from "@arr/shared";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "@/contexts/IncognitoContext";
 
 vi.mock("@/hooks/useThemeGradient", () => ({
 	useThemeGradient: () => ({
@@ -36,24 +41,34 @@ const fieldOptions: CleanupFieldOptionsResponse = {
 	hasJellyfin: true,
 };
 
-function renderFields(ruleType: CleanupRuleType, params = getDefaultConditionParams(ruleType)) {
+function renderFields(
+	ruleType: CleanupRuleType,
+	params = getDefaultConditionParams(ruleType),
+	options = fieldOptions,
+) {
 	cleanup();
 	const onParamsChange = vi.fn();
 	render(
-		<ConditionParamsFields
-			ruleType={ruleType}
-			params={params}
-			onParamsChange={onParamsChange}
-			fieldOptions={fieldOptions}
-			fieldOptionsLoading={false}
-			inputClass="input"
-			labelClass="label"
-		/>,
+		<IncognitoProvider>
+			<ConditionParamsFields
+				ruleType={ruleType}
+				params={params}
+				onParamsChange={onParamsChange}
+				fieldOptions={options}
+				fieldOptionsLoading={false}
+				inputClass="input"
+				labelClass="label"
+			/>
+		</IncognitoProvider>,
 	);
 	return onParamsChange;
 }
 
 describe("ConditionParamsFields Jellyfin composite conditions", () => {
+	beforeEach(() => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "false");
+	});
+
 	it.each([
 		["jellyfin_last_watched", { operator: "older_than", days: 90 }],
 		["jellyfin_watch_count", { operator: "less_than", count: 1 }],
@@ -115,5 +130,68 @@ describe("ConditionParamsFields Jellyfin composite conditions", () => {
 		const onParamsChange = renderFields("jellyfin_on_deck", { isDeck: false });
 		fireEvent.click(screen.getByRole("switch", { name: "Item is on Continue Watching" }));
 		expect(onParamsChange).toHaveBeenCalledWith({ isDeck: true });
+	});
+
+	it("keeps colliding masked Jellyfin users distinct while preserving raw values", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		const onParamsChange = renderFields(
+			"jellyfin_watched_by",
+			{
+				operator: "includes_any",
+				userNames: [],
+			},
+			{ ...fieldOptions, jellyfinUsers: ["Alex", "B"] },
+		);
+
+		await waitFor(() => expect(screen.getByText("root 1")).toBeInTheDocument());
+		expect(screen.getByText("root 2")).toBeInTheDocument();
+		expect(screen.queryByText("Alex")).not.toBeInTheDocument();
+		expect(screen.queryByText("B")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("checkbox", { name: "root 2" }));
+		expect(onParamsChange).toHaveBeenCalledWith({
+			operator: "includes_any",
+			userNames: ["B"],
+		});
+	});
+
+	it("preserves an unavailable selected user when its alias collides with an available user", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		const onParamsChange = renderFields(
+			"jellyfin_watched_by",
+			{
+				operator: "includes_any",
+				userNames: ["B"],
+			},
+			{ ...fieldOptions, jellyfinUsers: ["Alex"] },
+		);
+
+		await waitFor(() => expect(screen.getByText("root 1")).toBeInTheDocument());
+		expect(screen.getByRole("checkbox", { name: "root 1" })).not.toBeChecked();
+		expect(screen.getByText("1 selected")).toBeInTheDocument();
+		expect(screen.queryByText("Alex")).not.toBeInTheDocument();
+		expect(screen.queryByText("B")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Select all" }));
+		expect(onParamsChange).toHaveBeenCalledWith({
+			operator: "includes_any",
+			userNames: ["B", "Alex"],
+		});
+	});
+
+	it("omits an empty Jellyfin minimum season instead of serializing zero", () => {
+		let onParamsChange = renderFields("jellyfin_episode_completion");
+		expect(screen.getByLabelText("Min Season")).toHaveValue(null);
+
+		onParamsChange = renderFields("jellyfin_episode_completion", {
+			operator: "less_than",
+			percentage: 10,
+			minSeason: 2,
+		});
+		fireEvent.change(screen.getByLabelText("Min Season"), { target: { value: "" } });
+
+		const updatedParams = onParamsChange.mock.calls[0]![0];
+		expect(updatedParams).toEqual({ operator: "less_than", percentage: 10 });
+		expect(jellyfinEpisodeCompletionParamsSchema.safeParse(updatedParams).success).toBe(true);
 	});
 });

--- a/apps/web/src/features/rule-criteria/components/__tests__/condition-params-fields.test.tsx
+++ b/apps/web/src/features/rule-criteria/components/__tests__/condition-params-fields.test.tsx
@@ -1,0 +1,119 @@
+import type { CleanupFieldOptionsResponse, CleanupRuleType } from "@arr/shared";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#3b82f6",
+			to: "#8b5cf6",
+			glow: "rgba(59,130,246,0.3)",
+			fromLight: "#3b82f610",
+			fromMedium: "#3b82f620",
+			fromMuted: "#3b82f630",
+		},
+	}),
+}));
+
+import { ConditionParamsFields, getDefaultConditionParams } from "../condition-params-fields";
+
+const fieldOptions: CleanupFieldOptionsResponse = {
+	videoCodecs: [],
+	audioCodecs: [],
+	resolutions: [],
+	hdrTypes: [],
+	releaseGroups: [],
+	tautulliUsers: [],
+	plexUsers: [],
+	plexLibraries: [],
+	plexCollections: [],
+	plexLabels: [],
+	jellyfinUsers: ["Alex"],
+	jellyfinLibraries: [],
+	arrTags: [],
+	hasPlex: false,
+	hasTautulli: false,
+	hasJellyfin: true,
+};
+
+function renderFields(ruleType: CleanupRuleType, params = getDefaultConditionParams(ruleType)) {
+	cleanup();
+	const onParamsChange = vi.fn();
+	render(
+		<ConditionParamsFields
+			ruleType={ruleType}
+			params={params}
+			onParamsChange={onParamsChange}
+			fieldOptions={fieldOptions}
+			fieldOptionsLoading={false}
+			inputClass="input"
+			labelClass="label"
+		/>,
+	);
+	return onParamsChange;
+}
+
+describe("ConditionParamsFields Jellyfin composite conditions", () => {
+	it.each([
+		["jellyfin_last_watched", { operator: "older_than", days: 90 }],
+		["jellyfin_watch_count", { operator: "less_than", count: 1 }],
+		["jellyfin_on_deck", { isDeck: false }],
+		["jellyfin_user_rating", { operator: "less_than", rating: 5 }],
+		["jellyfin_watched_by", { operator: "includes_any", userNames: [] }],
+		["jellyfin_added_at", { operator: "older_than", days: 90 }],
+		["jellyfin_episode_completion", { operator: "less_than", percentage: 10 }],
+	] as [CleanupRuleType, Record<string, unknown>][])(
+		"defaults %s to the schema-compatible composite parameters",
+		(ruleType, expected) => {
+			expect(getDefaultConditionParams(ruleType)).toEqual(expected);
+		},
+	);
+
+	it("renders the controls required by every Jellyfin condition in a composite rule", () => {
+		renderFields("jellyfin_last_watched");
+		expect(screen.getByRole("combobox")).toHaveValue("older_than");
+		expect(screen.getByDisplayValue("90")).toBeInTheDocument();
+
+		for (const [ruleType, expectedOperator, expectedValue] of [
+			["jellyfin_watch_count", "less_than", "1"],
+			["jellyfin_user_rating", "less_than", "5"],
+			["jellyfin_added_at", "older_than", "90"],
+			["jellyfin_episode_completion", "less_than", "10"],
+		] as [CleanupRuleType, string, string][]) {
+			renderFields(ruleType);
+			expect(screen.getByRole("combobox")).toHaveValue(expectedOperator);
+			expect(screen.getByDisplayValue(expectedValue)).toBeInTheDocument();
+		}
+
+		renderFields("jellyfin_on_deck");
+		expect(screen.getByRole("switch", { name: "Item is on Continue Watching" })).toHaveAttribute(
+			"aria-checked",
+			"false",
+		);
+
+		renderFields("jellyfin_watched_by");
+		expect(screen.getByRole("combobox")).toHaveValue("includes_any");
+		expect(screen.getByText("Jellyfin Users")).toBeInTheDocument();
+		expect(screen.getByText("Alex")).toBeInTheDocument();
+	});
+
+	it("passes Jellyfin field changes through without discarding composite parameters", () => {
+		const onParamsChange = renderFields("jellyfin_watch_count", {
+			operator: "less_than",
+			count: 1,
+			extra: "preserved",
+		});
+		fireEvent.change(screen.getByDisplayValue("1"), { target: { value: "3" } });
+		expect(onParamsChange).toHaveBeenCalledWith({
+			operator: "less_than",
+			count: 3,
+			extra: "preserved",
+		});
+	});
+
+	it("passes Jellyfin continue-watching toggle changes through", () => {
+		const onParamsChange = renderFields("jellyfin_on_deck", { isDeck: false });
+		fireEvent.click(screen.getByRole("switch", { name: "Item is on Continue Watching" }));
+		expect(onParamsChange).toHaveBeenCalledWith({ isDeck: true });
+	});
+});

--- a/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
+++ b/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
@@ -3,6 +3,7 @@
 import type { CleanupFieldOptionsResponse, CleanupRuleType } from "@arr/shared";
 import { ToggleSwitch } from "@/components/layout/config-primitives";
 import { useThemeGradient } from "@/hooks/useThemeGradient";
+import { getLinuxUsername, useIncognitoMode } from "@/lib/incognito";
 import { MultiSelectField } from "./multi-select-field";
 
 // ============================================================================
@@ -152,8 +153,14 @@ export function ConditionParamsFields({
 	labelClass,
 }: ConditionParamsFieldsProps) {
 	const { gradient } = useThemeGradient();
+	const [incognitoMode] = useIncognitoMode();
 	const get = <T,>(key: string, def: T): T => (params[key] as T) ?? def;
 	const set = (key: string, val: unknown) => onParamsChange({ ...params, [key]: val });
+	const unset = (key: string) => {
+		const nextParams = { ...params };
+		delete nextParams[key];
+		onParamsChange(nextParams);
+	};
 
 	switch (ruleType) {
 		case "age":
@@ -1453,7 +1460,32 @@ export function ConditionParamsFields({
 			);
 		}
 
-		case "jellyfin_watched_by":
+		case "jellyfin_watched_by": {
+			const rawUsers = fieldOptions?.jellyfinUsers ?? [];
+			const selectedRawUsers = get("userNames", []) as string[];
+			const allRawUsers = [...new Set([...rawUsers, ...selectedRawUsers])];
+			const aliasCounts = new Map<string, number>();
+			if (incognitoMode) {
+				for (const userName of allRawUsers) {
+					const alias = getLinuxUsername(userName);
+					aliasCounts.set(alias, (aliasCounts.get(alias) ?? 0) + 1);
+				}
+			}
+			const displayEntries = allRawUsers.map((rawUserName, index) => {
+				const alias = incognitoMode ? getLinuxUsername(rawUserName) : rawUserName;
+				return {
+					rawUserName,
+					displayUserName:
+						incognitoMode && (aliasCounts.get(alias) ?? 0) > 1 ? `${alias} ${index + 1}` : alias,
+				};
+			});
+			const displayByRaw = new Map(
+				displayEntries.map(({ rawUserName, displayUserName }) => [rawUserName, displayUserName]),
+			);
+			const rawByDisplay = new Map(
+				displayEntries.map(({ rawUserName, displayUserName }) => [displayUserName, rawUserName]),
+			);
+
 			return (
 				<div className="space-y-2">
 					<label className="block">
@@ -1469,9 +1501,20 @@ export function ConditionParamsFields({
 					</label>
 					<MultiSelectField
 						label="Jellyfin Users"
-						options={fieldOptions?.jellyfinUsers ?? []}
-						selected={get("userNames", []) as string[]}
-						onChange={(v) => set("userNames", v)}
+						options={rawUsers.map((rawUserName) => displayByRaw.get(rawUserName) ?? rawUserName)}
+						selected={selectedRawUsers.map(
+							(rawUserName) =>
+								displayByRaw.get(rawUserName) ??
+								(incognitoMode ? getLinuxUsername(rawUserName) : rawUserName),
+						)}
+						onChange={(displayUserNames) =>
+							set(
+								"userNames",
+								displayUserNames.map(
+									(displayUserName) => rawByDisplay.get(displayUserName) ?? displayUserName,
+								),
+							)
+						}
 						loading={fieldOptionsLoading}
 						inputClass={inputClass}
 						labelClass={labelClass}
@@ -1481,6 +1524,7 @@ export function ConditionParamsFields({
 					</p>
 				</div>
 			);
+		}
 
 		case "jellyfin_added_at":
 			return (
@@ -1544,16 +1588,27 @@ export function ConditionParamsFields({
 							<span className={labelClass}>Min Season</span>
 							<input
 								type="number"
-								value={get("minSeason", 0)}
-								onChange={(e) => set("minSeason", Number(e.target.value))}
-								min={0}
-								placeholder="0 = all"
+								value={
+									typeof params.minSeason === "number" && params.minSeason >= 1
+										? params.minSeason
+										: ""
+								}
+								onChange={(e) => {
+									const minSeason = Number(e.target.value);
+									if (e.target.value === "" || minSeason < 1) {
+										unset("minSeason");
+									} else {
+										set("minSeason", minSeason);
+									}
+								}}
+								min={1}
+								placeholder="All seasons"
 								className={inputClass}
 							/>
 						</label>
 					</div>
 					<p className="text-xs text-muted-foreground">
-						Only count episodes from this season onward. 0 or empty = all seasons.
+						Only count episodes from this season onward. Leave blank for all seasons.
 					</p>
 				</div>
 			);

--- a/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
+++ b/apps/web/src/features/rule-criteria/components/condition-params-fields.tsx
@@ -106,6 +106,20 @@ export function getDefaultConditionParams(ruleType: CleanupRuleType): Record<str
 			return { operator: "older_than", days: 90 };
 		case "plex_episode_completion":
 			return { operator: "less_than", percentage: 10 };
+		case "jellyfin_last_watched":
+			return { operator: "older_than", days: 90 };
+		case "jellyfin_watch_count":
+			return { operator: "less_than", count: 1 };
+		case "jellyfin_on_deck":
+			return { isDeck: false };
+		case "jellyfin_user_rating":
+			return { operator: "less_than", rating: 5 };
+		case "jellyfin_watched_by":
+			return { operator: "includes_any", userNames: [] };
+		case "jellyfin_added_at":
+			return { operator: "older_than", days: 90 };
+		case "jellyfin_episode_completion":
+			return { operator: "less_than", percentage: 10 };
 		case "user_retention":
 			return { operator: "watched_by_none", source: "plex" };
 		case "staleness_score":
@@ -1271,6 +1285,236 @@ export function ConditionParamsFields({
 			);
 
 		case "plex_episode_completion":
+			return (
+				<div className="space-y-2">
+					<div className="flex gap-2">
+						<label className="block flex-1">
+							<span className={labelClass}>Operator</span>
+							<select
+								value={get("operator", "less_than")}
+								onChange={(e) => set("operator", e.target.value)}
+								className={inputClass}
+							>
+								<option value="less_than">Less than</option>
+								<option value="greater_than">Greater than</option>
+							</select>
+						</label>
+						<label className="block w-24">
+							<span className={labelClass}>Percent</span>
+							<input
+								type="number"
+								value={get("percentage", 10)}
+								onChange={(e) => set("percentage", Number(e.target.value))}
+								min={0}
+								max={100}
+								className={inputClass}
+							/>
+						</label>
+						<label className="block w-28">
+							<span className={labelClass}>Min Season</span>
+							<input
+								type="number"
+								value={get("minSeason", 0)}
+								onChange={(e) => set("minSeason", Number(e.target.value))}
+								min={0}
+								placeholder="0 = all"
+								className={inputClass}
+							/>
+						</label>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Only count episodes from this season onward. 0 or empty = all seasons.
+					</p>
+				</div>
+			);
+
+		case "jellyfin_last_watched": {
+			const jellyfinLastWatchedOp = get<string>("operator", "older_than");
+			return (
+				<div className="space-y-2">
+					<div className="flex gap-2">
+						<label className="block flex-1">
+							<span className={labelClass}>Operator</span>
+							<select
+								value={jellyfinLastWatchedOp}
+								onChange={(e) => set("operator", e.target.value)}
+								className={inputClass}
+							>
+								<option value="older_than">Last watched older than</option>
+								<option value="never">Never watched</option>
+							</select>
+						</label>
+						{jellyfinLastWatchedOp !== "never" && (
+							<label className="block w-24">
+								<span className={labelClass}>Days</span>
+								<input
+									type="number"
+									value={get("days", 90)}
+									onChange={(e) => set("days", Number(e.target.value))}
+									min={1}
+									className={inputClass}
+								/>
+							</label>
+						)}
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Requires a Jellyfin instance to be configured.
+					</p>
+				</div>
+			);
+		}
+
+		case "jellyfin_watch_count":
+			return (
+				<div className="space-y-2">
+					<div className="flex gap-2">
+						<label className="block flex-1">
+							<span className={labelClass}>Operator</span>
+							<select
+								value={get("operator", "less_than")}
+								onChange={(e) => set("operator", e.target.value)}
+								className={inputClass}
+							>
+								<option value="less_than">Less than</option>
+								<option value="greater_than">Greater than</option>
+							</select>
+						</label>
+						<label className="block w-24">
+							<span className={labelClass}>Count</span>
+							<input
+								type="number"
+								value={get("count", 1)}
+								onChange={(e) => set("count", Number(e.target.value))}
+								min={0}
+								className={inputClass}
+							/>
+						</label>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Flag items by total play count from Jellyfin.
+					</p>
+				</div>
+			);
+
+		case "jellyfin_on_deck": {
+			const isDeck = get("isDeck", false);
+			return (
+				<div className="space-y-2">
+					<ToggleSwitch
+						label="Item is on Continue Watching"
+						checked={isDeck}
+						onChange={(v) => set("isDeck", v)}
+					/>
+					<p className="text-xs text-muted-foreground">
+						{isDeck
+							? "Matches items currently on Jellyfin's Continue Watching."
+							: "Matches items NOT on Jellyfin's Continue Watching."}
+					</p>
+				</div>
+			);
+		}
+
+		case "jellyfin_user_rating": {
+			const jellyfinRatingOp = get<string>("operator", "less_than");
+			return (
+				<div className="space-y-2">
+					<div className="flex gap-2">
+						<label className="block flex-1">
+							<span className={labelClass}>Operator</span>
+							<select
+								value={jellyfinRatingOp}
+								onChange={(e) => set("operator", e.target.value)}
+								className={inputClass}
+							>
+								<option value="less_than">Less than</option>
+								<option value="greater_than">Greater than</option>
+								<option value="unrated">Unrated</option>
+							</select>
+						</label>
+						{jellyfinRatingOp !== "unrated" && (
+							<label className="block w-24">
+								<span className={labelClass}>Rating</span>
+								<input
+									type="number"
+									value={get("rating", 5)}
+									onChange={(e) => set("rating", Number(e.target.value))}
+									min={0}
+									max={10}
+									step={0.5}
+									className={inputClass}
+								/>
+							</label>
+						)}
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Flag items by user rating in Jellyfin (0-10; favorites = 10).
+					</p>
+				</div>
+			);
+		}
+
+		case "jellyfin_watched_by":
+			return (
+				<div className="space-y-2">
+					<label className="block">
+						<span className={labelClass}>Operator</span>
+						<select
+							value={get("operator", "includes_any")}
+							onChange={(e) => set("operator", e.target.value)}
+							className={inputClass}
+						>
+							<option value="includes_any">Watched by any of</option>
+							<option value="excludes_all">Not watched by any of</option>
+						</select>
+					</label>
+					<MultiSelectField
+						label="Jellyfin Users"
+						options={fieldOptions?.jellyfinUsers ?? []}
+						selected={get("userNames", []) as string[]}
+						onChange={(v) => set("userNames", v)}
+						loading={fieldOptionsLoading}
+						inputClass={inputClass}
+						labelClass={labelClass}
+					/>
+					<p className="text-xs text-muted-foreground">
+						Flag items based on which Jellyfin users have watched them.
+					</p>
+				</div>
+			);
+
+		case "jellyfin_added_at":
+			return (
+				<div className="space-y-2">
+					<div className="flex gap-2">
+						<label className="block flex-1">
+							<span className={labelClass}>Operator</span>
+							<select
+								value={get("operator", "older_than")}
+								onChange={(e) => set("operator", e.target.value)}
+								className={inputClass}
+							>
+								<option value="older_than">Added more than</option>
+								<option value="newer_than">Added less than</option>
+							</select>
+						</label>
+						<label className="block w-24">
+							<span className={labelClass}>Days</span>
+							<input
+								type="number"
+								value={get("days", 90)}
+								onChange={(e) => set("days", Number(e.target.value))}
+								min={1}
+								className={inputClass}
+							/>
+						</label>
+					</div>
+					<p className="text-xs text-muted-foreground">
+						Flag items by when they were added to Jellyfin. Requires a Jellyfin instance.
+					</p>
+				</div>
+			);
+
+		case "jellyfin_episode_completion":
 			return (
 				<div className="space-y-2">
 					<div className="flex gap-2">


### PR DESCRIPTION
## Summary

- restore all seven Jellyfin condition editors in Composite Rule mode
- use schema-compatible defaults and operator/value controls for watch activity, ratings, users, added date, and episode completion
- reject empty Jellyfin watched-by selections before save and omit minimum season when all seasons are intended
- mask Jellyfin usernames in incognito mode while preserving raw persisted values and keeping colliding aliases distinguishable
- preserve selected users missing from refreshed options, including when their masked alias collides with an available user

## Validation

- RED: Jellyfin composite defaults were empty and the shared condition renderer returned no controls
- RED: independent review regressions demonstrated raw incognito usernames, empty watched-by saves reaching API validation, and `minSeason: 0`
- affected component/dialog suites: 78 tests passed in the final parent verification; the frozen pre-PR correction batch passed 126 affected tests
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- `git diff --check`

## Risk

The change is limited to composite-rule field rendering and client-side validation. Existing shared schemas and backend evaluators are unchanged. Incognito labels are display-only; saved usernames remain the original Jellyfin values.

Closes #703
