### PR TITLE
fix(ci): avoid dev image builds for docs-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI
 on:
   push:
     branches: [main, "release/**"]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".vscode/**"
+      - "LICENSE"
+      - ".gitignore"
   pull_request:
     branches: [main, "release/**"]
 


### PR DESCRIPTION
## Summary

- restore documentation-only path exclusions for CI push events
- keep pull request CI unconditional so required checks still report
- prevent successful documentation-only main runs from triggering dev image publication

## Validation

- actionlint .github/workflows/ci.yml
- independent supply-chain review: no findings
- verified docker-dev runs after successful main CI through workflow_run

Related to #716