### PR TITLE
fix(cache): bound Plex and Emby refresh memory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      - name: Run provider cache heap regression
+        run: pnpm --filter @arr/api run test:provider-cache-heap
+
   # End-to-End Tests with Playwright (sharded for parallelism)
   # Uses production builds for faster, more realistic testing
   e2e:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
 		"format": "biome format src",
 		"typecheck": "tsc --noEmit",
 		"test": "pnpm --filter @arr/shared build && vitest",
+		"test:provider-cache-heap": "node scripts/test-provider-cache-heap.mjs",
 		"db:generate": "prisma generate --schema prisma/schema.prisma",
 		"db:push": "prisma db push --schema prisma/schema.prisma",
 		"db:sync": "prisma db push --schema prisma/schema.prisma --skip-generate",

--- a/apps/api/scripts/test-provider-cache-heap.mjs
+++ b/apps/api/scripts/test-provider-cache-heap.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const apiDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-cache-heap-"));
+const databasePath = path.join(testDir, "provider-cache.db");
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+function run(command, args, env = {}) {
+	const result = spawnSync(command, args, {
+		cwd: apiDir,
+		env: { ...process.env, ...env },
+		stdio: "inherit",
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) process.exitCode = result.status ?? 1;
+	return result.status === 0;
+}
+
+try {
+	const initialized = run(
+		pnpm,
+		["exec", "prisma", "db", "push", "--schema", "prisma/schema.prisma"],
+		{ DATABASE_URL: `file:${databasePath}` },
+	);
+	if (initialized) {
+		run(
+			process.execPath,
+			[
+				"node_modules/vitest/vitest.mjs",
+				"run",
+				"src/lib/plex/__tests__/provider-cache-heap.test.ts",
+				"--execArgv=--expose-gc",
+				"--maxWorkers=1",
+				"--no-file-parallelism",
+				"--disableConsoleIntercept",
+			],
+			{
+				TEST_HEAP: "true",
+				PROVIDER_CACHE_TEST_DB_PATH: databasePath,
+			},
+		);
+	}
+} finally {
+	fs.rmSync(testDir, { recursive: true, force: true });
+}

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -7,7 +7,11 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshJellyfinCache } from "../jellyfin-cache-refresher.js";
+import {
+	JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE,
+	JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS,
+	refreshJellyfinCache,
+} from "../jellyfin-cache-refresher.js";
 import type {
 	JellyfinClient,
 	JellyfinItem,
@@ -111,6 +115,31 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
+	it("publishes a large cache through bounded createMany calls", async () => {
+		const itemCount = JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE * 2 + 17;
+		const items = Array.from({ length: itemCount }, (_, index) =>
+			makeSeriesItem({
+				id: `jf-series-${index}`,
+				name: `Series ${index}`,
+				tmdbId: 100_000 + index,
+			}),
+		);
+		const client = makeMockClient(items);
+		const { stub, tx } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: itemCount });
+		expect(tx.jellyfinCache.createMany).toHaveBeenCalledTimes(3);
+		for (const [call] of tx.jellyfinCache.createMany.mock.calls) {
+			expect(call.data.length).toBeLessThanOrEqual(JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE);
+		}
+		expect(stub.$transaction).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.objectContaining({ timeout: JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS }),
+		);
+	});
+
 	it("sets lastWatchedAt for a fully-watched series (item.played === true)", async () => {
 		const item = makeSeriesItem({
 			played: true,
@@ -445,6 +474,7 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 		expect(tx.cacheRefreshStatus.upsert).toHaveBeenCalledOnce();
 		expect(stub.$transaction).toHaveBeenCalledWith(expect.any(Function), {
 			isolationLevel: "Serializable",
+			timeout: JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS,
 		});
 	});
 
@@ -553,6 +583,8 @@ describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
 			'SELECT "id" FROM "ServiceInstance" WHERE "id" = $1 FOR UPDATE',
 			"inst-1",
 		);
-		expect(stub.$transaction).toHaveBeenCalledWith(expect.any(Function), undefined);
+		expect(stub.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			timeout: JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS,
+		});
 	});
 });

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -21,6 +21,10 @@ import { withCurrentJellyfinConnection } from "./jellyfin-connection-guard.js";
 import type { JellyfinClient, JellyfinLibrary, JellyfinUser } from "./jellyfin-client.js";
 
 export const JELLYFIN_STALE_EVICTION_CHUNK_SIZE = 500;
+/** Bound Prisma's cached createMany query plans for production-sized libraries. */
+export const JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE = 100;
+/** Allow bounded publication batches to complete on higher-latency databases. */
+export const JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS = 60_000;
 
 // ============================================================================
 // Aggregation Types
@@ -277,27 +281,27 @@ export async function refreshJellyfinCache(
 		// Step 5: Publish a complete replacement atomically. An incomplete scan
 		// must leave the previous successful generation untouched.
 		const items = Array.from(aggregations.values());
-		const rows: JellyfinCacheSnapshotRow[] = items.map((agg) => ({
-			instanceId,
-			tmdbId: agg.tmdbId,
-			mediaType: agg.mediaType,
-			libraryId: agg.libraryId,
-			libraryName: agg.libraryName,
-			title: agg.title,
-			jellyfinId: agg.jellyfinId,
-			lastWatchedAt: agg.lastWatchedAt,
-			watchCount: agg.watchCount,
-			watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
-			onDeck: agg.onDeck,
-			userRating: agg.userRating,
-			collections: JSON.stringify([...agg.collections].sort()),
-			addedAt: agg.addedAt,
-			thumb: agg.thumb,
-		}));
 		let completedAt: Date | undefined;
 		if (errors === 0 && complete) {
 			completedAt = new Date();
 			if (options.publish === false) {
+				const rows: JellyfinCacheSnapshotRow[] = items.map((agg) => ({
+					instanceId,
+					tmdbId: agg.tmdbId,
+					mediaType: agg.mediaType,
+					libraryId: agg.libraryId,
+					libraryName: agg.libraryName,
+					title: agg.title,
+					jellyfinId: agg.jellyfinId,
+					lastWatchedAt: agg.lastWatchedAt,
+					watchCount: agg.watchCount,
+					watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
+					onDeck: agg.onDeck,
+					userRating: agg.userRating,
+					collections: JSON.stringify([...agg.collections].sort()),
+					addedAt: agg.addedAt,
+					thumb: agg.thumb,
+				}));
 				return {
 					upserted: 0,
 					errors: 0,
@@ -334,25 +338,32 @@ export async function refreshJellyfinCache(
 					async (tx) => {
 						await tx.jellyfinCache.deleteMany({ where: { instanceId } });
 						if (items.length > 0) {
-							await tx.jellyfinCache.createMany({
-								data: items.map((agg) => ({
-									instanceId,
-									tmdbId: agg.tmdbId,
-									mediaType: agg.mediaType,
-									libraryId: agg.libraryId,
-									libraryName: agg.libraryName,
-									title: agg.title,
-									jellyfinId: agg.jellyfinId,
-									lastWatchedAt: agg.lastWatchedAt,
-									watchCount: agg.watchCount,
-									watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
-									onDeck: agg.onDeck,
-									userRating: agg.userRating,
-									collections: JSON.stringify(agg.collections),
-									addedAt: agg.addedAt,
-									thumb: agg.thumb,
-								})),
-							});
+							for (
+								let start = 0;
+								start < items.length;
+								start += JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE
+							) {
+								const chunk = items.slice(start, start + JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE);
+								await tx.jellyfinCache.createMany({
+									data: chunk.map((agg) => ({
+										instanceId,
+										tmdbId: agg.tmdbId,
+										mediaType: agg.mediaType,
+										libraryId: agg.libraryId,
+										libraryName: agg.libraryName,
+										title: agg.title,
+										jellyfinId: agg.jellyfinId,
+										lastWatchedAt: agg.lastWatchedAt,
+										watchCount: agg.watchCount,
+										watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
+										onDeck: agg.onDeck,
+										userRating: agg.userRating,
+										collections: JSON.stringify(agg.collections),
+										addedAt: agg.addedAt,
+										thumb: agg.thumb,
+									})),
+								});
+							}
 						}
 						await tx.cacheRefreshStatus.upsert({
 							where: { instanceId_cacheType: { instanceId, cacheType: "jellyfin" } },
@@ -376,6 +387,7 @@ export async function refreshJellyfinCache(
 							},
 						});
 					},
+					{ timeout: JELLYFIN_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS },
 				);
 				if (!publication.matched) throw new JellyfinRefreshSupersededError();
 				upserted = items.length;

--- a/apps/api/src/lib/jellyfin/jellyfin-connection-guard.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-connection-guard.ts
@@ -5,6 +5,11 @@ type GuardPrisma = Pick<PrismaClient, "$transaction">;
 
 type GuardResult<T> = { matched: true; value: T } | { matched: false };
 
+export type JellyfinConnectionTransactionOptions = {
+	maxWait?: number;
+	timeout?: number;
+};
+
 /**
  * Run a cache/status write only while the originating Jellyfin/Emby
  * connection is still current.
@@ -18,11 +23,13 @@ export async function withCurrentJellyfinConnection<T>(
 	instanceId: string,
 	expectedConnectionFingerprint: string | undefined,
 	action: (tx: Prisma.TransactionClient) => Promise<T>,
+	options?: JellyfinConnectionTransactionOptions,
 ): Promise<GuardResult<T>> {
+	const postgresql = isPostgresqlDatabase();
 	return await prisma.$transaction(
 		async (tx) => {
 			if (expectedConnectionFingerprint) {
-				if (isPostgresqlDatabase()) {
+				if (postgresql) {
 					await tx.$queryRawUnsafe(
 						'SELECT "id" FROM "ServiceInstance" WHERE "id" = $1 FOR UPDATE',
 						instanceId,
@@ -52,7 +59,7 @@ export async function withCurrentJellyfinConnection<T>(
 
 			return { matched: true, value: await action(tx) };
 		},
-		isPostgresqlDatabase() ? undefined : { isolationLevel: "Serializable" },
+		postgresql ? options : { isolationLevel: "Serializable", ...options },
 	);
 }
 

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -17,6 +17,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "../../prisma.js";
 import {
 	evictStaleRows,
+	PLEX_CACHE_PUBLICATION_CHUNK_SIZE,
+	PLEX_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS,
 	refreshPlexCache,
 	STALE_EVICTION_CHUNK_SIZE,
 } from "../plex-cache-refresher.js";
@@ -175,7 +177,20 @@ describe("evictStaleRows", () => {
 
 		expect(replacementDelete).toHaveBeenCalledWith({ where: { instanceId: "inst-1" } });
 		expect(publishedRows).toHaveLength(LIBRARY_SIZE);
+		expect(tx.plexCache.createMany).toHaveBeenCalledTimes(
+			Math.ceil(LIBRARY_SIZE / PLEX_CACHE_PUBLICATION_CHUNK_SIZE),
+		);
+		let chunkedRows = 0;
+		for (const [call] of tx.plexCache.createMany.mock.calls) {
+			expect(call.data.length).toBeLessThanOrEqual(PLEX_CACHE_PUBLICATION_CHUNK_SIZE);
+			chunkedRows += call.data.length;
+		}
+		expect(chunkedRows).toBe(LIBRARY_SIZE);
 		expect(tx.cacheRefreshStatus.upsert).toHaveBeenCalledOnce();
+		expect(mockPrisma.$transaction).toHaveBeenCalledWith(
+			expect.any(Function),
+			expect.objectContaining({ timeout: PLEX_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS }),
+		);
 	});
 
 	it("never uses `notIn` — the original P2029 trigger", async () => {

--- a/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
+++ b/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Production-shaped heap regression for issue #694.
+ *
+ * Opt in with TEST_HEAP=true and run Node with --expose-gc. The reporter's
+ * v2.23.0 process retained roughly 550 MB immediately after publishing a
+ * 15k-row Plex cache and 12k-row Emby cache. This exercises the current
+ * replacement-publication path against real SQLite/Prisma instead of mocks.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import { refreshJellyfinCache } from "../../jellyfin/jellyfin-cache-refresher.js";
+import type { JellyfinClient, JellyfinItem } from "../../jellyfin/jellyfin-client.js";
+import type { PrismaClient } from "../../prisma.js";
+import { refreshPlexCache } from "../plex-cache-refresher.js";
+import type { PlexClient, PlexLibraryItem } from "../plex-client.js";
+
+const RUN_HEAP_TESTS = process.env.TEST_HEAP === "true";
+const MIB = 1024 * 1024;
+const PLEX_ITEMS = 15_000;
+const JELLYFIN_ITEMS = 12_000;
+
+const silentLog = {
+	warn: vi.fn(),
+	info: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+	child: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+function collectHeap(): number {
+	if (!global.gc) throw new Error("Run this heap test with Node --expose-gc");
+	global.gc();
+	global.gc();
+	return process.memoryUsage().heapUsed;
+}
+
+function reportHeap(message: string): void {
+	process.stdout.write(`${message}\n`);
+}
+
+(RUN_HEAP_TESTS ? describe : describe.skip)(
+	"provider cache publication heap (TEST_HEAP=true)",
+	() => {
+		let prisma: PrismaClient;
+		let plexClient: PlexClient;
+		let jellyfinClient: JellyfinClient;
+
+		beforeAll(async () => {
+			const testDb = process.env.PROVIDER_CACHE_TEST_DB_PATH;
+			if (!testDb) throw new Error("Run this test through pnpm test:provider-cache-heap");
+			prisma = createTestPrismaClient(testDb);
+
+			await prisma.user.create({ data: { id: "heap-user", username: "heap-user" } });
+			await prisma.serviceInstance.createMany({
+				data: [
+					{
+						id: "heap-plex",
+						userId: "heap-user",
+						service: "PLEX",
+						label: "Heap Plex",
+						baseUrl: "http://plex.invalid",
+						encryptedApiKey: "x",
+						encryptionIv: "y",
+					},
+					{
+						id: "heap-emby",
+						userId: "heap-user",
+						service: "EMBY",
+						label: "Heap Emby",
+						baseUrl: "http://emby.invalid",
+						encryptedApiKey: "x",
+						encryptionIv: "y",
+					},
+				],
+			});
+
+			const plexItems: PlexLibraryItem[] = Array.from({ length: PLEX_ITEMS }, (_, index) => ({
+				ratingKey: `plex-${index}`,
+				title: `Plex Movie ${index}`,
+				type: "movie",
+				Guid: [{ id: `tmdb://${100_000 + index}` }],
+				Collection: [{ tag: `Collection ${index % 20}` }],
+				Label: [{ tag: `Label ${index % 10}` }],
+				addedAt: 1_700_000_000 + index,
+				thumb: `/library/metadata/${index}/thumb`,
+			}));
+			plexClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+				getLibraryItems: vi.fn().mockResolvedValue(plexItems),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+
+			const jellyfinItems: JellyfinItem[] = Array.from({ length: JELLYFIN_ITEMS }, (_, index) => ({
+				id: `emby-${index}`,
+				name: `Emby Movie ${index}`,
+				type: "Movie",
+				tmdbId: 200_000 + index,
+				played: index % 3 === 0,
+				playCount: index % 3 === 0 ? 1 : 0,
+				lastPlayedDate: index % 3 === 0 ? "2026-01-01T00:00:00Z" : null,
+				isFavorite: index % 11 === 0,
+				dateCreated: "2025-01-01T00:00:00Z",
+				imageTags: { Primary: `image-${index}` },
+			}));
+			jellyfinClient = {
+				getUsers: vi.fn().mockResolvedValue([{ id: "user-1", name: "Alice" }]),
+				getLibraries: vi
+					.fn()
+					.mockResolvedValue([{ id: "movies", name: "Movies", collectionType: "movies" }]),
+				getLibraryItems: vi.fn().mockResolvedValue(jellyfinItems),
+				getResumeItems: vi.fn().mockResolvedValue([]),
+				getNextUp: vi.fn().mockResolvedValue([]),
+			} as unknown as JellyfinClient;
+		}, 120_000);
+
+		afterAll(async () => {
+			await prisma.$disconnect();
+		});
+
+		async function refreshPlexAndAssert(): Promise<void> {
+			const plex = await refreshPlexCache(plexClient, prisma, "heap-plex", silentLog, undefined);
+			expect(plex).toMatchObject({ complete: true, errors: 0, upserted: PLEX_ITEMS });
+		}
+
+		async function refreshJellyfinAndAssert(): Promise<void> {
+			const jellyfin = await refreshJellyfinCache(jellyfinClient, prisma, "heap-emby", silentLog);
+			expect(jellyfin).toMatchObject({ complete: true, errors: 0, upserted: JELLYFIN_ITEMS });
+		}
+
+		async function refreshBoth(): Promise<void> {
+			await refreshPlexAndAssert();
+			await refreshJellyfinAndAssert();
+		}
+
+		it("does not retain the v2.23.0 post-refresh heap spike", async () => {
+			const baseline = collectHeap();
+			reportHeap(`Provider cache baseline heap: ${(baseline / MIB).toFixed(1)} MB`);
+
+			await refreshPlexAndAssert();
+			const afterPlex = collectHeap();
+			reportHeap(`Provider cache heap after Plex publication: ${(afterPlex / MIB).toFixed(1)} MB`);
+
+			await refreshJellyfinAndAssert();
+			const afterFirst = collectHeap();
+			const firstGrowth = afterFirst - baseline;
+			reportHeap(
+				`Provider cache heap growth after first publication: ${(firstGrowth / MIB).toFixed(1)} MB`,
+			);
+
+			for (let cycle = 0; cycle < 3; cycle++) await refreshBoth();
+			const afterRepeated = collectHeap();
+			const repeatedGrowth = afterRepeated - afterFirst;
+			reportHeap(
+				`Provider cache heap growth after three more publications: ${(repeatedGrowth / MIB).toFixed(1)} MB`,
+			);
+			// The attached #694 log retained ~552 MB. Allow normal Prisma/V8 warmup,
+			// while failing far below the production regression.
+			expect(firstGrowth).toBeLessThan(100 * MIB);
+			expect(repeatedGrowth).toBeLessThan(50 * MIB);
+		}, 180_000);
+
+		it("rolls back Plex deletion and earlier chunks when a later chunk fails", async () => {
+			await prisma.plexCache.deleteMany({ where: { instanceId: "heap-plex" } });
+			await prisma.plexCache.create({
+				data: {
+					instanceId: "heap-plex",
+					tmdbId: 100_000,
+					mediaType: "movie",
+					sectionId: "1",
+					sectionTitle: "Movies",
+					title: "Preserved Plex generation",
+					ratingKey: "old-plex",
+					watchedByUsers: "[]",
+					collections: "[]",
+					labels: "[]",
+				},
+			});
+			await prisma.$executeRawUnsafe(`
+				CREATE TRIGGER fail_plex_second_chunk
+				BEFORE INSERT ON plex_cache
+				WHEN NEW.ratingKey = 'plex-100'
+				BEGIN
+					SELECT RAISE(ABORT, 'injected Plex second chunk failure');
+				END
+			`);
+
+			try {
+				const result = await refreshPlexCache(
+					plexClient,
+					prisma,
+					"heap-plex",
+					silentLog,
+					undefined,
+				);
+				expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+				expect(result.errorMessages.join(" ")).toMatch(
+					/Atomic Plex cache publication failed:.*constraint/is,
+				);
+				expect(await prisma.plexCache.findMany({ where: { instanceId: "heap-plex" } })).toEqual([
+					expect.objectContaining({ title: "Preserved Plex generation", ratingKey: "old-plex" }),
+				]);
+			} finally {
+				await prisma.$executeRawUnsafe("DROP TRIGGER IF EXISTS fail_plex_second_chunk");
+			}
+		}, 120_000);
+
+		it("rolls back Jellyfin deletion and earlier chunks when a later chunk fails", async () => {
+			await prisma.jellyfinCache.deleteMany({ where: { instanceId: "heap-emby" } });
+			await prisma.jellyfinCache.create({
+				data: {
+					instanceId: "heap-emby",
+					tmdbId: 200_000,
+					mediaType: "movie",
+					libraryId: "movies",
+					libraryName: "Movies",
+					title: "Preserved Emby generation",
+					jellyfinId: "old-emby",
+					watchedByUsers: "[]",
+					collections: "[]",
+				},
+			});
+			await prisma.$executeRawUnsafe(`
+				CREATE TRIGGER fail_jellyfin_second_chunk
+				BEFORE INSERT ON jellyfin_cache
+				WHEN NEW.jellyfinId = 'emby-100'
+				BEGIN
+					SELECT RAISE(ABORT, 'injected Jellyfin second chunk failure');
+				END
+			`);
+
+			try {
+				const result = await refreshJellyfinCache(jellyfinClient, prisma, "heap-emby", silentLog);
+				expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+				expect(result.errorMessages.join(" ")).toMatch(
+					/Atomic cache publication failed:.*constraint/is,
+				);
+				expect(await prisma.jellyfinCache.findMany({ where: { instanceId: "heap-emby" } })).toEqual(
+					[expect.objectContaining({ title: "Preserved Emby generation", jellyfinId: "old-emby" })],
+				);
+			} finally {
+				await prisma.$executeRawUnsafe("DROP TRIGGER IF EXISTS fail_jellyfin_second_chunk");
+			}
+		}, 120_000);
+	},
+);

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -24,6 +24,11 @@ import {
 import { getErrorMessage } from "../utils/error-message.js";
 import type { PlexClient } from "./plex-client.js";
 
+/** Bound Prisma's cached createMany query plans for production-sized libraries. */
+export const PLEX_CACHE_PUBLICATION_CHUNK_SIZE = 100;
+/** Allow bounded publication batches to complete on higher-latency databases. */
+export const PLEX_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS = 60_000;
+
 // ============================================================================
 // GUID Parsing
 // ============================================================================
@@ -546,26 +551,36 @@ export async function refreshPlexCache(
 					async (tx) => {
 						await tx.plexCache.deleteMany({ where: { instanceId } });
 						if (aggregationsArray.length > 0) {
-							await tx.plexCache.createMany({
-								data: aggregationsArray.map((agg) => ({
-									instanceId,
-									tmdbId: agg.tmdbId,
-									mediaType: agg.mediaType,
-									sectionId: agg.sectionId,
-									sectionTitle: agg.sectionTitle,
-									title: agg.title,
-									ratingKey: agg.ratingKey,
-									lastWatchedAt: agg.lastWatchedAt,
-									watchCount: agg.watchCount,
-									watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
-									onDeck: agg.onDeck,
-									userRating: agg.userRating,
-									collections: JSON.stringify(agg.collections),
-									labels: JSON.stringify(agg.labels),
-									addedAt: agg.addedAt,
-									thumb: agg.thumb,
-								})),
-							});
+							for (
+								let start = 0;
+								start < aggregationsArray.length;
+								start += PLEX_CACHE_PUBLICATION_CHUNK_SIZE
+							) {
+								const chunk = aggregationsArray.slice(
+									start,
+									start + PLEX_CACHE_PUBLICATION_CHUNK_SIZE,
+								);
+								await tx.plexCache.createMany({
+									data: chunk.map((agg) => ({
+										instanceId,
+										tmdbId: agg.tmdbId,
+										mediaType: agg.mediaType,
+										sectionId: agg.sectionId,
+										sectionTitle: agg.sectionTitle,
+										title: agg.title,
+										ratingKey: agg.ratingKey,
+										lastWatchedAt: agg.lastWatchedAt,
+										watchCount: agg.watchCount,
+										watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
+										onDeck: agg.onDeck,
+										userRating: agg.userRating,
+										collections: JSON.stringify(agg.collections),
+										labels: JSON.stringify(agg.labels),
+										addedAt: agg.addedAt,
+										thumb: agg.thumb,
+									})),
+								});
+							}
 						}
 						await tx.cacheRefreshStatus.upsert({
 							where: { instanceId_cacheType: { instanceId, cacheType: "plex" } },
@@ -593,6 +608,7 @@ export async function refreshPlexCache(
 							},
 						});
 					},
+					{ timeout: PLEX_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS },
 				);
 				if (publication.matched) {
 					upserted = aggregationsArray.length;

--- a/apps/api/src/lib/services/provider-connection-guard.ts
+++ b/apps/api/src/lib/services/provider-connection-guard.ts
@@ -17,17 +17,24 @@ export function providerConnectionIdentity(
 type GuardPrisma = Pick<PrismaClient, "$transaction">;
 type GuardResult<T> = { matched: true; value: T } | { matched: false };
 
+export type ProviderConnectionTransactionOptions = {
+	maxWait?: number;
+	timeout?: number;
+};
+
 /** Keep provider cache/status writes bound to the service generation that produced them. */
 export async function withCurrentProviderConnection<T>(
 	prisma: GuardPrisma,
 	instanceId: string,
 	expected: ProviderConnectionIdentity | undefined,
 	action: (tx: Prisma.TransactionClient) => Promise<T>,
+	options?: ProviderConnectionTransactionOptions,
 ): Promise<GuardResult<T>> {
+	const postgresql = isPostgresqlDatabase();
 	return await prisma.$transaction(
 		async (tx) => {
 			if (expected) {
-				if (isPostgresqlDatabase()) {
+				if (postgresql) {
 					await tx.$queryRawUnsafe(
 						'SELECT "id" FROM "ServiceInstance" WHERE "id" = $1 FOR UPDATE',
 						instanceId,
@@ -48,7 +55,7 @@ export async function withCurrentProviderConnection<T>(
 
 			return { matched: true, value: await action(tx) };
 		},
-		isPostgresqlDatabase() ? undefined : { isolationLevel: "Serializable" },
+		postgresql ? options : { isolationLevel: "Serializable", ...options },
 	);
 }
 


### PR DESCRIPTION
## Summary

- publish Plex and Jellyfin or Emby cache replacements in bounded 100-row createMany batches while keeping each replacement in one transaction
- avoid building unused Jellyfin snapshot rows during a real database publication
- run a production-shaped SQLite heap and rollback regression in CI

## Root cause

The issue log showed a stable process near 139 MB until the first full cache publication of about 15,000 Plex rows and 12,000 Emby rows. Memory then jumped by roughly 552 MB, remained near 700 MB after garbage collection, and the container restarted.

A matching fixture reproduced retained Prisma query-plan bindings from provider-sized one-shot createMany calls. Repeating full refreshes retained another 598.4 MB before this fix.

## Verification

- fixed first-publication heap growth: 31.0 MB
- fixed retained growth across three additional full refresh cycles: -0.2 MB
- real SQLite tests confirm a failure in the second batch rolls back the deletion and every earlier batch for both providers
- 48 focused refresher tests pass
- root format, shared build, typecheck, 3,817 API tests plus web and shared suites, lint, production build, and diff checks pass
- independent regression, data-safety, and supply-chain review completed; the accepted test-runner findings were corrected

The extra database calls stay inside the existing atomic transaction. A failed batch still leaves the previous successful cache generation intact and returns an incomplete, retryable result.

Closes #694