### PR TITLE
fix(cache): bound provider cache publication memory on 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Run tests
         run: pnpm run test
 
+      - name: Run provider cache heap regression
+        run: pnpm --filter @arr/api run test:provider-cache-heap
+
   # End-to-End Tests with Playwright (sharded for parallelism)
   # Uses production builds for faster, more realistic testing
   e2e:

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
 		"format": "biome format src",
 		"typecheck": "tsc --noEmit",
 		"test": "pnpm --filter @arr/shared build && vitest",
+		"test:provider-cache-heap": "node scripts/test-provider-cache-heap.mjs",
 		"db:generate": "prisma generate --schema prisma/schema.prisma",
 		"db:push": "prisma db push --schema prisma/schema.prisma",
 		"db:sync": "prisma db push --schema prisma/schema.prisma --skip-generate",

--- a/apps/api/scripts/test-provider-cache-heap.mjs
+++ b/apps/api/scripts/test-provider-cache-heap.mjs
@@ -1,0 +1,49 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const apiDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const testDir = fs.mkdtempSync(path.join(os.tmpdir(), "provider-cache-heap-"));
+const databasePath = path.join(testDir, "provider-cache.db");
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+function run(command, args, env = {}) {
+	const result = spawnSync(command, args, {
+		cwd: apiDir,
+		env: { ...process.env, ...env },
+		stdio: "inherit",
+	});
+	if (result.error) throw result.error;
+	if (result.status !== 0) process.exitCode = result.status ?? 1;
+	return result.status === 0;
+}
+
+try {
+	const initialized = run(
+		pnpm,
+		["exec", "prisma", "db", "push", "--schema", "prisma/schema.prisma"],
+		{ DATABASE_URL: `file:${databasePath}` },
+	);
+	if (initialized) {
+		run(
+			process.execPath,
+			[
+				"node_modules/vitest/vitest.mjs",
+				"run",
+				"src/lib/plex/__tests__/provider-cache-heap.test.ts",
+				"--execArgv=--expose-gc",
+				"--maxWorkers=1",
+				"--no-file-parallelism",
+				"--disableConsoleIntercept",
+			],
+			{
+				TEST_HEAP: "true",
+				PROVIDER_CACHE_TEST_DB_PATH: databasePath,
+			},
+		);
+	}
+} finally {
+	fs.rmSync(testDir, { recursive: true, force: true });
+}

--- a/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
+++ b/apps/api/src/lib/jellyfin/__tests__/jellyfin-cache-refresher.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { refreshJellyfinCache } from "../jellyfin-cache-refresher.js";
+import {
+	JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE,
+	refreshJellyfinCache,
+} from "../jellyfin-cache-refresher.js";
 import type {
 	JellyfinClient,
 	JellyfinItem,
@@ -128,6 +131,27 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("refreshJellyfinCache — lastWatchedAt aggregation", () => {
+	it("publishes a large cache through bounded createMany calls", async () => {
+		const itemCount = JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE * 2 + 17;
+		const items = Array.from({ length: itemCount }, (_, index) =>
+			makeSeriesItem({
+				id: `jf-series-${index}`,
+				name: `Series ${index}`,
+				tmdbId: 100_000 + index,
+			}),
+		);
+		const client = makeMockClient(items);
+		const { stub, tx } = makeMockPrisma();
+
+		const result = await refreshJellyfinCache(client, stub as never, "inst-1", silentLog);
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: itemCount });
+		expect(tx.jellyfinCache.createMany).toHaveBeenCalledTimes(3);
+		for (const [call] of tx.jellyfinCache.createMany.mock.calls) {
+			expect(call.data.length).toBeLessThanOrEqual(JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE);
+		}
+	});
+
 	it("sets lastWatchedAt for a fully-watched series (item.played === true)", async () => {
 		const item = makeSeriesItem({
 			played: true,

--- a/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
+++ b/apps/api/src/lib/jellyfin/jellyfin-cache-refresher.ts
@@ -12,6 +12,9 @@ import { getErrorMessage } from "../utils/error-message.js";
 import type { JellyfinClient } from "./jellyfin-client.js";
 import { withCurrentJellyfinConnection } from "./jellyfin-connection-guard.js";
 
+/** Bound Prisma's cached createMany query plans for production-sized libraries. */
+export const JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE = 100;
+
 interface ItemAggregation {
 	tmdbId: number;
 	mediaType: "movie" | "series";
@@ -228,25 +231,32 @@ export async function refreshJellyfinCache(
 				async (tx) => {
 					await tx.jellyfinCache.deleteMany({ where: { instanceId } });
 					if (items.length > 0) {
-						await tx.jellyfinCache.createMany({
-							data: items.map((item) => ({
-								instanceId,
-								tmdbId: item.tmdbId,
-								mediaType: item.mediaType,
-								libraryId: item.libraryId,
-								libraryName: item.libraryName,
-								title: item.title,
-								jellyfinId: item.jellyfinId,
-								lastWatchedAt: item.lastWatchedAt,
-								watchCount: item.watchCount,
-								watchedByUsers: JSON.stringify([...item.watchedByUsers]),
-								onDeck: item.onDeck,
-								userRating: item.userRating,
-								collections: JSON.stringify(item.collections),
-								addedAt: item.addedAt,
-								thumb: item.thumb,
-							})),
-						});
+						for (
+							let start = 0;
+							start < items.length;
+							start += JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE
+						) {
+							const chunk = items.slice(start, start + JELLYFIN_CACHE_PUBLICATION_CHUNK_SIZE);
+							await tx.jellyfinCache.createMany({
+								data: chunk.map((item) => ({
+									instanceId,
+									tmdbId: item.tmdbId,
+									mediaType: item.mediaType,
+									libraryId: item.libraryId,
+									libraryName: item.libraryName,
+									title: item.title,
+									jellyfinId: item.jellyfinId,
+									lastWatchedAt: item.lastWatchedAt,
+									watchCount: item.watchCount,
+									watchedByUsers: JSON.stringify([...item.watchedByUsers]),
+									onDeck: item.onDeck,
+									userRating: item.userRating,
+									collections: JSON.stringify(item.collections),
+									addedAt: item.addedAt,
+									thumb: item.thumb,
+								})),
+							});
+						}
 					}
 					await tx.cacheRefreshStatus.upsert({
 						where: { instanceId_cacheType: { instanceId, cacheType: "jellyfin" } },

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	clearPlexCacheRefreshSingleFlightsForTests,
 	evictStaleRows,
+	PLEX_CACHE_PUBLICATION_CHUNK_SIZE,
 	refreshPlexCache,
 	STALE_EVICTION_CHUNK_SIZE,
 } from "../plex-cache-refresher.js";
@@ -178,6 +179,12 @@ describe("evictStaleRows", () => {
 		expect(result.upserted).toBe(LIBRARY_SIZE);
 		expect(deleteMany).toHaveBeenCalledWith({ where: { instanceId: "inst-1" } });
 		expect(publishedRows).toHaveLength(LIBRARY_SIZE);
+		expect(tx.plexCache.createMany).toHaveBeenCalledTimes(
+			Math.ceil(LIBRARY_SIZE / PLEX_CACHE_PUBLICATION_CHUNK_SIZE),
+		);
+		for (const [call] of tx.plexCache.createMany.mock.calls) {
+			expect(call.data.length).toBeLessThanOrEqual(PLEX_CACHE_PUBLICATION_CHUNK_SIZE);
+		}
 		expect(tx.cacheRefreshStatus.upsert).toHaveBeenCalledOnce();
 		const statusWrite = tx.cacheRefreshStatus.upsert.mock.calls[0]![0];
 		expect(statusWrite.create.generationId).toMatch(

--- a/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
+++ b/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Production-shaped heap regression for issue #694.
+ *
+ * Opt in with TEST_HEAP=true and run Node with --expose-gc. The reporter's
+ * v2.23.0 process retained roughly 550 MB immediately after publishing a
+ * 15k-row Plex cache and 12k-row Emby cache. This exercises the current
+ * replacement-publication path against real SQLite/Prisma instead of mocks.
+ */
+
+import type { FastifyBaseLogger } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import { refreshJellyfinCache } from "../../jellyfin/jellyfin-cache-refresher.js";
+import type { JellyfinClient, JellyfinItem } from "../../jellyfin/jellyfin-client.js";
+import type { PrismaClient } from "../../prisma.js";
+import { refreshPlexCache } from "../plex-cache-refresher.js";
+import type { PlexClient, PlexLibraryItem } from "../plex-client.js";
+
+const RUN_HEAP_TESTS = process.env.TEST_HEAP === "true";
+const MIB = 1024 * 1024;
+const PLEX_ITEMS = 15_000;
+const JELLYFIN_ITEMS = 12_000;
+
+const silentLog = {
+	warn: vi.fn(),
+	info: vi.fn(),
+	error: vi.fn(),
+	debug: vi.fn(),
+	trace: vi.fn(),
+	fatal: vi.fn(),
+	child: vi.fn(),
+} as unknown as FastifyBaseLogger;
+
+function collectHeap(): number {
+	if (!global.gc) throw new Error("Run this heap test with Node --expose-gc");
+	global.gc();
+	global.gc();
+	return process.memoryUsage().heapUsed;
+}
+
+function reportHeap(message: string): void {
+	process.stdout.write(`${message}\n`);
+}
+
+(RUN_HEAP_TESTS ? describe : describe.skip)(
+	"provider cache publication heap (TEST_HEAP=true)",
+	() => {
+		let prisma: PrismaClient;
+		let plexClient: PlexClient;
+		let jellyfinClient: JellyfinClient;
+
+		beforeAll(async () => {
+			const testDb = process.env.PROVIDER_CACHE_TEST_DB_PATH;
+			if (!testDb) throw new Error("Run this test through pnpm test:provider-cache-heap");
+			prisma = createTestPrismaClient(testDb);
+
+			await prisma.user.create({ data: { id: "heap-user", username: "heap-user" } });
+			await prisma.serviceInstance.createMany({
+				data: [
+					{
+						id: "heap-plex",
+						userId: "heap-user",
+						service: "PLEX",
+						label: "Heap Plex",
+						baseUrl: "http://plex.invalid",
+						encryptedApiKey: "x",
+						encryptionIv: "y",
+					},
+					{
+						id: "heap-emby",
+						userId: "heap-user",
+						service: "EMBY",
+						label: "Heap Emby",
+						baseUrl: "http://emby.invalid",
+						encryptedApiKey: "x",
+						encryptionIv: "y",
+					},
+				],
+			});
+
+			const plexItems: PlexLibraryItem[] = Array.from({ length: PLEX_ITEMS }, (_, index) => ({
+				ratingKey: `plex-${index}`,
+				title: `Plex Movie ${index}`,
+				type: "movie",
+				Guid: [{ id: `tmdb://${100_000 + index}` }],
+				Collection: [{ tag: `Collection ${index % 20}` }],
+				Label: [{ tag: `Label ${index % 10}` }],
+				addedAt: 1_700_000_000 + index,
+				thumb: `/library/metadata/${index}/thumb`,
+			}));
+			plexClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+				getLibraryItems: vi.fn().mockResolvedValue(plexItems),
+				getHistory: vi.fn().mockResolvedValue([]),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+
+			const jellyfinItems: JellyfinItem[] = Array.from({ length: JELLYFIN_ITEMS }, (_, index) => ({
+				id: `emby-${index}`,
+				name: `Emby Movie ${index}`,
+				type: "Movie",
+				tmdbId: 200_000 + index,
+				played: index % 3 === 0,
+				playCount: index % 3 === 0 ? 1 : 0,
+				lastPlayedDate: index % 3 === 0 ? "2026-01-01T00:00:00Z" : null,
+				isFavorite: index % 11 === 0,
+				dateCreated: "2025-01-01T00:00:00Z",
+				imageTags: { Primary: `image-${index}` },
+			}));
+			jellyfinClient = {
+				getUsers: vi.fn().mockResolvedValue([{ id: "user-1", name: "Alice" }]),
+				getLibraries: vi
+					.fn()
+					.mockResolvedValue([{ id: "movies", name: "Movies", collectionType: "movies" }]),
+				getLibraryItems: vi.fn().mockResolvedValue(jellyfinItems),
+				getResumeItems: vi.fn().mockResolvedValue([]),
+				getNextUp: vi.fn().mockResolvedValue([]),
+			} as unknown as JellyfinClient;
+		}, 120_000);
+
+		afterAll(async () => {
+			await prisma.$disconnect();
+		});
+
+		async function refreshPlexAndAssert(): Promise<void> {
+			const plex = await refreshPlexCache(plexClient, prisma, "heap-plex", silentLog, undefined);
+			expect(plex).toMatchObject({ complete: true, errors: 0, upserted: PLEX_ITEMS });
+		}
+
+		async function refreshJellyfinAndAssert(): Promise<void> {
+			const jellyfin = await refreshJellyfinCache(jellyfinClient, prisma, "heap-emby", silentLog);
+			expect(jellyfin).toMatchObject({ complete: true, errors: 0, upserted: JELLYFIN_ITEMS });
+		}
+
+		async function refreshBoth(): Promise<void> {
+			await refreshPlexAndAssert();
+			await refreshJellyfinAndAssert();
+		}
+
+		it("does not retain the v2.23.0 post-refresh heap spike", async () => {
+			const baseline = collectHeap();
+			reportHeap(`Provider cache baseline heap: ${(baseline / MIB).toFixed(1)} MB`);
+
+			await refreshPlexAndAssert();
+			const afterPlex = collectHeap();
+			reportHeap(`Provider cache heap after Plex publication: ${(afterPlex / MIB).toFixed(1)} MB`);
+
+			await refreshJellyfinAndAssert();
+			const afterFirst = collectHeap();
+			const firstGrowth = afterFirst - baseline;
+			reportHeap(
+				`Provider cache heap growth after first publication: ${(firstGrowth / MIB).toFixed(1)} MB`,
+			);
+
+			for (let cycle = 0; cycle < 3; cycle++) await refreshBoth();
+			const afterRepeated = collectHeap();
+			const repeatedGrowth = afterRepeated - afterFirst;
+			reportHeap(
+				`Provider cache heap growth after three more publications: ${(repeatedGrowth / MIB).toFixed(1)} MB`,
+			);
+			// The attached #694 log retained ~552 MB. Allow normal Prisma/V8 warmup,
+			// while failing far below the production regression.
+			expect(firstGrowth).toBeLessThan(100 * MIB);
+			expect(repeatedGrowth).toBeLessThan(50 * MIB);
+		}, 180_000);
+
+		it("rolls back Plex deletion and earlier chunks when a later chunk fails", async () => {
+			await prisma.plexCache.deleteMany({ where: { instanceId: "heap-plex" } });
+			await prisma.plexCache.create({
+				data: {
+					instanceId: "heap-plex",
+					tmdbId: 100_000,
+					mediaType: "movie",
+					sectionId: "1",
+					sectionTitle: "Movies",
+					title: "Preserved Plex generation",
+					ratingKey: "old-plex",
+					watchedByUsers: "[]",
+					collections: "[]",
+					labels: "[]",
+				},
+			});
+			await prisma.$executeRawUnsafe(`
+				CREATE TRIGGER fail_plex_second_chunk
+				BEFORE INSERT ON plex_cache
+				WHEN NEW.ratingKey = 'plex-100'
+				BEGIN
+					SELECT RAISE(ABORT, 'injected Plex second chunk failure');
+				END
+			`);
+
+			try {
+				const result = await refreshPlexCache(
+					plexClient,
+					prisma,
+					"heap-plex",
+					silentLog,
+					undefined,
+				);
+				expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+				expect(result.errorMessages.join(" ")).toMatch(
+					/Atomic Plex cache publication failed:.*constraint/is,
+				);
+				expect(await prisma.plexCache.findMany({ where: { instanceId: "heap-plex" } })).toEqual([
+					expect.objectContaining({ title: "Preserved Plex generation", ratingKey: "old-plex" }),
+				]);
+			} finally {
+				await prisma.$executeRawUnsafe("DROP TRIGGER IF EXISTS fail_plex_second_chunk");
+			}
+		}, 120_000);
+
+		it("rolls back Jellyfin deletion and earlier chunks when a later chunk fails", async () => {
+			await prisma.jellyfinCache.deleteMany({ where: { instanceId: "heap-emby" } });
+			await prisma.jellyfinCache.create({
+				data: {
+					instanceId: "heap-emby",
+					tmdbId: 200_000,
+					mediaType: "movie",
+					libraryId: "movies",
+					libraryName: "Movies",
+					title: "Preserved Emby generation",
+					jellyfinId: "old-emby",
+					watchedByUsers: "[]",
+					collections: "[]",
+				},
+			});
+			await prisma.$executeRawUnsafe(`
+				CREATE TRIGGER fail_jellyfin_second_chunk
+				BEFORE INSERT ON jellyfin_cache
+				WHEN NEW.jellyfinId = 'emby-100'
+				BEGIN
+					SELECT RAISE(ABORT, 'injected Jellyfin second chunk failure');
+				END
+			`);
+
+			try {
+				const result = await refreshJellyfinCache(jellyfinClient, prisma, "heap-emby", silentLog);
+				expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+				expect(result.errorMessages.join(" ")).toMatch(
+					/Atomic cache publication failed:.*constraint/is,
+				);
+				expect(await prisma.jellyfinCache.findMany({ where: { instanceId: "heap-emby" } })).toEqual(
+					[expect.objectContaining({ title: "Preserved Emby generation", jellyfinId: "old-emby" })],
+				);
+			} finally {
+				await prisma.$executeRawUnsafe("DROP TRIGGER IF EXISTS fail_jellyfin_second_chunk");
+			}
+		}, 120_000);
+	},
+);

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -24,6 +24,9 @@ import { getErrorMessage } from "../utils/error-message.js";
 import type { FastifyBaseLogger } from "fastify";
 import type { PlexClient } from "./plex-client.js";
 
+/** Bound Prisma's cached createMany query plans for production-sized libraries. */
+export const PLEX_CACHE_PUBLICATION_CHUNK_SIZE = 100;
+
 // ============================================================================
 // GUID Parsing
 // ============================================================================
@@ -372,26 +375,36 @@ async function performPlexCacheRefresh(
 					async (tx) => {
 						await tx.plexCache.deleteMany({ where: { instanceId } });
 						if (aggregationsArray.length > 0) {
-							await tx.plexCache.createMany({
-								data: aggregationsArray.map((agg) => ({
-									instanceId,
-									tmdbId: agg.tmdbId,
-									mediaType: agg.mediaType,
-									sectionId: agg.sectionId,
-									sectionTitle: agg.sectionTitle,
-									title: agg.title,
-									ratingKey: agg.ratingKey,
-									lastWatchedAt: agg.lastWatchedAt,
-									watchCount: agg.watchCount,
-									watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
-									onDeck: agg.onDeck,
-									userRating: agg.userRating,
-									collections: JSON.stringify(agg.collections),
-									labels: JSON.stringify(agg.labels),
-									addedAt: agg.addedAt,
-									thumb: agg.thumb,
-								})),
-							});
+							for (
+								let start = 0;
+								start < aggregationsArray.length;
+								start += PLEX_CACHE_PUBLICATION_CHUNK_SIZE
+							) {
+								const chunk = aggregationsArray.slice(
+									start,
+									start + PLEX_CACHE_PUBLICATION_CHUNK_SIZE,
+								);
+								await tx.plexCache.createMany({
+									data: chunk.map((agg) => ({
+										instanceId,
+										tmdbId: agg.tmdbId,
+										mediaType: agg.mediaType,
+										sectionId: agg.sectionId,
+										sectionTitle: agg.sectionTitle,
+										title: agg.title,
+										ratingKey: agg.ratingKey,
+										lastWatchedAt: agg.lastWatchedAt,
+										watchCount: agg.watchCount,
+										watchedByUsers: JSON.stringify([...agg.watchedByUsers]),
+										onDeck: agg.onDeck,
+										userRating: agg.userRating,
+										collections: JSON.stringify(agg.collections),
+										labels: JSON.stringify(agg.labels),
+										addedAt: agg.addedAt,
+										thumb: agg.thumb,
+									})),
+								});
+							}
 						}
 						await tx.cacheRefreshStatus.upsert({
 							where: { instanceId_cacheType: { instanceId, cacheType: "plex" } },


### PR DESCRIPTION
## Summary

- Forward-port the stable provider-cache memory fix into the existing 3.0 refresh pipeline.
- Publish Plex and Jellyfin/Emby cache replacements in 100-row `createMany` batches while preserving the existing guarded transaction, 120-second timeout, and single-flight behavior.
- Add a production-shaped SQLite/Prisma heap regression and real second-chunk rollback checks to CI.

## Why

Issue #694 showed Prisma retaining hundreds of megabytes of query-plan bindings after publishing a 15k-row Plex cache and 12k-row Emby cache. The 3.0 branch had different completeness and connection-safety logic, but still issued one production-sized `createMany` statement per provider.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- `pnpm --filter @arr/api run test:provider-cache-heap`
- Real heap result: about 31 MB first-publication growth and no retained growth across three additional Plex plus Emby cycles.
- Real second-chunk failures preserve the previous Plex and Jellyfin/Emby generations.
- Independent regression, data-safety, and supply-chain reviews reported no blocking findings.

Related to #694