### PR TITLE
feat(services): add durable provider identity foundation

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -21,6 +21,19 @@ enum ServiceType {
   QUI
 }
 
+enum ProviderIdentityKind {
+  PLEX_MACHINE_IDENTIFIER @map("plex-machine-identifier")
+  JELLYFIN_SERVER_ID      @map("jellyfin-server-id")
+  EMBY_SERVER_ID          @map("emby-server-id")
+  TAUTULLI_PMS_IDENTIFIER @map("tautulli-pms-identifier")
+}
+
+enum ProviderIdentityStatus {
+  UNVERIFIED @map("unverified")
+  VERIFIED   @map("verified")
+  MISMATCH   @map("mismatch")
+}
+
 // Library item type enum - uses lowercase to match Zod schema in shared package
 enum LibraryItemType {
   movie
@@ -139,6 +152,13 @@ model ServiceInstance {
   // Monotonic generation for Jellyfin/Emby connection identity. Unlike
   // updatedAt, unrelated label/default/tag edits must not supersede refreshes.
   connectionGeneration         Int         @default(0)
+  // Durable provider-identity state. Lifecycle activation is intentionally deferred.
+  expectedIdentity             String?
+  identityKind                 ProviderIdentityKind?
+  identityStatus               ProviderIdentityStatus @default(UNVERIFIED)
+  identityGeneration           Int                    @default(0)
+  identityVerifiedAt           DateTime?
+  identityLastCheckedAt        DateTime?
   createdAt                    DateTime    @default(now())
   updatedAt                    DateTime    @updatedAt
 
@@ -177,6 +197,7 @@ model ServiceInstance {
 
   @@index([service])
   @@index([userId])
+  @@index([service, enabled, identityStatus])
 }
 
 // Persisted inode-index snapshot per qui instance — eliminates the

--- a/apps/api/src/lib/arr/__tests__/client-helpers.test.ts
+++ b/apps/api/src/lib/arr/__tests__/client-helpers.test.ts
@@ -61,6 +61,12 @@ const createMockInstance = (
 	hasLocalFilesystemAccess: false,
 	pathPrefix: null,
 	connectionGeneration: 0,
+	expectedIdentity: null,
+	identityKind: null,
+	identityStatus: "UNVERIFIED",
+	identityGeneration: 0,
+	identityVerifiedAt: null,
+	identityLastCheckedAt: null,
 	createdAt: new Date(),
 	updatedAt: new Date(),
 });

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -12,7 +12,7 @@
 import { libraryItemSchema } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
-import type { PrismaClient, ServiceType } from "../../../lib/prisma.js";
+import type { PrismaClient, ServiceInstance, ServiceType } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
 import { createArrServiceFingerprint } from "../../arr/service-fingerprint.js";
 import type { Encryptor } from "../../auth/encryption.js";
@@ -45,7 +45,7 @@ function makeRawItem(overrides: Record<string, unknown> = {}): Record<string, un
 	};
 }
 
-function createMockInstance(service: ServiceType) {
+function createMockInstance(service: ServiceType): ServiceInstance {
 	return {
 		id: INSTANCE_ID,
 		label: `Test ${service}`,
@@ -63,6 +63,12 @@ function createMockInstance(service: ServiceType) {
 		httpAuthEncryptionIv: null,
 		enabled: true,
 		connectionGeneration: 0,
+		expectedIdentity: null,
+		identityKind: null,
+		identityStatus: "UNVERIFIED",
+		identityGeneration: 0,
+		identityVerifiedAt: null,
+		identityLastCheckedAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),
 	};

--- a/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
+++ b/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
@@ -75,7 +75,7 @@ describe("ServiceInstance dormant identity schema", () => {
 		} finally {
 			database.close();
 		}
-	}, 15_000);
+	}, 30_000);
 
 	it("keeps dormant identity state out of formatted service responses", () => {
 		const formatted = formatServiceInstance({

--- a/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
+++ b/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import Database from "better-sqlite3";
+import { afterEach, describe, expect, it } from "vitest";
+import { formatServiceInstance } from "../service-formatter.js";
+
+const apiRoot = resolve(process.cwd());
+const schemaPath = resolve(apiRoot, "prisma/schema.prisma");
+const identityEnums = `enum ProviderIdentityKind {
+  PLEX_MACHINE_IDENTIFIER @map("plex-machine-identifier")
+  JELLYFIN_SERVER_ID      @map("jellyfin-server-id")
+  EMBY_SERVER_ID          @map("emby-server-id")
+  TAUTULLI_PMS_IDENTIFIER @map("tautulli-pms-identifier")
+}
+
+enum ProviderIdentityStatus {
+  UNVERIFIED @map("unverified")
+  VERIFIED   @map("verified")
+  MISMATCH   @map("mismatch")
+}
+
+`;
+const identityFields = `  // Durable provider-identity state. Lifecycle activation is intentionally deferred.
+  expectedIdentity             String?
+  identityKind                 ProviderIdentityKind?
+  identityStatus               ProviderIdentityStatus @default(UNVERIFIED)
+  identityGeneration           Int                    @default(0)
+  identityVerifiedAt           DateTime?
+  identityLastCheckedAt        DateTime?
+`;
+const identityIndexes = `  @@index([service, enabled, identityStatus])
+`;
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("ServiceInstance dormant identity schema", () => {
+	it("preserves a legacy instance as unverified generation zero after schema sync", () => {
+		const directory = mkdtempSync(join(tmpdir(), "arr-identity-schema-"));
+		temporaryDirectories.push(directory);
+		const databasePath = join(directory, "identity.db");
+		const legacySchemaPath = join(directory, "legacy-schema.prisma");
+		const legacySchema = removeIdentityState(readFileSync(schemaPath, "utf8"));
+
+		writeFileSync(legacySchemaPath, legacySchema);
+		syncSchema(legacySchemaPath, databasePath);
+		insertLegacyInstance(databasePath);
+		syncSchema(schemaPath, databasePath);
+
+		const database = new Database(databasePath, { readonly: true });
+		try {
+			const identity = database
+				.prepare(
+					`SELECT expectedIdentity, identityKind, identityStatus, identityGeneration,
+						identityVerifiedAt, identityLastCheckedAt
+					 FROM ServiceInstance WHERE id = ?`,
+				)
+				.get("legacy-instance");
+
+			expect(identity).toEqual({
+				expectedIdentity: null,
+				identityKind: null,
+				identityStatus: "unverified",
+				identityGeneration: 0,
+				identityVerifiedAt: null,
+				identityLastCheckedAt: null,
+			});
+		} finally {
+			database.close();
+		}
+	});
+
+	it("keeps dormant identity state out of formatted service responses", () => {
+		const formatted = formatServiceInstance({
+			id: "instance-1",
+			service: "PLEX",
+			label: "Living Room",
+			baseUrl: "http://plex.test",
+			externalUrl: null,
+			enabled: true,
+			isDefault: false,
+			createdAt: new Date("2026-08-14T00:00:00.000Z"),
+			updatedAt: new Date("2026-08-14T00:00:00.000Z"),
+			encryptedApiKey: "ciphertext",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			storageGroupId: null,
+			hasLocalFilesystemAccess: false,
+			pathPrefix: null,
+			tags: [],
+		});
+
+		expect(JSON.stringify(formatted)).toBe(
+			'{"id":"instance-1","service":"plex","label":"Living Room","baseUrl":"http://plex.test","externalUrl":null,"enabled":true,"isDefault":false,"createdAt":"2026-08-14T00:00:00.000Z","updatedAt":"2026-08-14T00:00:00.000Z","hasApiKey":true,"hasHttpAuth":false,"storageGroupId":null,"hasLocalFilesystemAccess":false,"pathPrefix":null,"tags":[]}',
+		);
+	});
+});
+
+function removeIdentityState(schema: string): string {
+	if (!schema.includes(identityEnums)) {
+		throw new Error("Provider identity enums are missing from the Prisma schema");
+	}
+	if (!schema.includes(identityFields)) {
+		throw new Error("ServiceInstance identity fields are missing from the Prisma schema");
+	}
+	if (!schema.includes(identityIndexes)) {
+		throw new Error("ServiceInstance identity indexes are missing from the Prisma schema");
+	}
+
+	return schema.replace(identityEnums, "").replace(identityFields, "").replace(identityIndexes, "");
+}
+
+function syncSchema(schema: string, databasePath: string): void {
+	execFileSync("pnpm", ["exec", "prisma", "db", "push", "--schema", schema], {
+		cwd: apiRoot,
+		env: { ...process.env, DATABASE_URL: `file:${databasePath}` },
+		stdio: "pipe",
+	});
+}
+
+function insertLegacyInstance(databasePath: string): void {
+	const database = new Database(databasePath);
+	try {
+		database
+			.prepare(
+				"INSERT INTO User (id, username, createdAt, updatedAt) VALUES (?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+			)
+			.run("legacy-user", "legacy-user");
+		database
+			.prepare(
+				`INSERT INTO ServiceInstance (
+					id, userId, service, label, baseUrl, encryptedApiKey, encryptionIv,
+					isDefault, enabled, hasLocalFilesystemAccess, connectionGeneration, createdAt, updatedAt
+				) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+			)
+			.run(
+				"legacy-instance",
+				"legacy-user",
+				"PLEX",
+				"Legacy Plex",
+				"http://legacy-plex.test",
+				"ciphertext",
+				"iv",
+				0,
+				1,
+				0,
+				0,
+			);
+	} finally {
+		database.close();
+	}
+}

--- a/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
+++ b/apps/api/src/lib/services/__tests__/service-identity-schema.test.ts
@@ -75,7 +75,7 @@ describe("ServiceInstance dormant identity schema", () => {
 		} finally {
 			database.close();
 		}
-	});
+	}, 15_000);
 
 	it("keeps dormant identity state out of formatted service responses", () => {
 		const formatted = formatServiceInstance({

--- a/apps/api/src/lib/services/__tests__/service-identity.test.ts
+++ b/apps/api/src/lib/services/__tests__/service-identity.test.ts
@@ -1,0 +1,150 @@
+import { createHash } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	confirmProviderIdentity,
+	type DecryptedOwnedServiceSnapshot,
+	readProviderIdentity,
+} from "../service-identity.js";
+
+const log = { warn: vi.fn() } as never;
+
+function snapshot(
+	service: DecryptedOwnedServiceSnapshot["service"],
+): DecryptedOwnedServiceSnapshot {
+	return {
+		service,
+		baseUrl: "http://media.test",
+		apiKey: "test-api-key",
+		label: "Living Room",
+	};
+}
+
+function response(data: unknown): Response {
+	return new Response(JSON.stringify(data), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("readProviderIdentity", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("reads Plex machineIdentifier without exposing the raw identity in its fingerprint", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				response({
+					MediaContainer: {
+						machineIdentifier: "plex-machine-123",
+						version: "1.0.0",
+					},
+				}),
+			),
+		);
+
+		const observation = await readProviderIdentity(snapshot("PLEX"), log);
+
+		expect(observation).toMatchObject({
+			service: "PLEX",
+			identityKind: "plex-machine-identifier",
+			rawIdentity: "plex-machine-123",
+			displayName: "Living Room",
+		});
+		expect(observation.confirmationDigest).toBe(
+			createHash("sha256").update("PLEX:plex-machine-identifier:plex-machine-123").digest("hex"),
+		);
+		expect(observation.fingerprint).toMatch(/^[a-f0-9]{12}$/);
+		expect(observation.fingerprint).not.toContain("plex-machine-123");
+	});
+
+	it("reads Jellyfin and Emby Id values through the existing server-info client", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockImplementation(async () =>
+				response({
+					Id: "jellyfin-server-456",
+					ServerName: "Media Server",
+					Version: "10.9.0",
+				}),
+			),
+		);
+
+		const jellyfin = await readProviderIdentity(snapshot("JELLYFIN"), log);
+		const emby = await readProviderIdentity(snapshot("EMBY"), log);
+
+		expect(jellyfin).toMatchObject({
+			service: "JELLYFIN",
+			identityKind: "jellyfin-server-id",
+			rawIdentity: "jellyfin-server-456",
+			displayName: "Media Server",
+		});
+		expect(emby).toMatchObject({
+			service: "EMBY",
+			identityKind: "emby-server-id",
+			rawIdentity: "jellyfin-server-456",
+		});
+	});
+
+	it("reads Tautulli pms_identifier as its primary identity", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				response({
+					response: {
+						result: "success",
+						message: null,
+						data: { pms_identifier: "tautulli-pms-789", pms_name: "Plex Monitor" },
+					},
+				}),
+			),
+		);
+
+		const observation = await readProviderIdentity(snapshot("TAUTULLI"), log);
+
+		expect(observation).toMatchObject({
+			service: "TAUTULLI",
+			identityKind: "tautulli-pms-identifier",
+			rawIdentity: "tautulli-pms-789",
+			displayName: "Plex Monitor",
+		});
+	});
+
+	it("uses constant-time comparison for equal and different confirmation digests", () => {
+		const digest = createHash("sha256").update("identity").digest("hex");
+		expect(confirmProviderIdentity(digest, digest)).toBe(true);
+		expect(confirmProviderIdentity(digest, "0".repeat(64))).toBe(false);
+		expect(confirmProviderIdentity(digest, "not-a-digest")).toBe(false);
+	});
+
+	it("sanitizes upstream identity and credentials from public reader errors", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockRejectedValue(new Error("http://user:pass@media.test?token=secret")),
+		);
+
+		await expect(readProviderIdentity(snapshot("PLEX"), log)).rejects.toThrow(
+			"Unable to read PLEX provider identity",
+		);
+		await expect(readProviderIdentity(snapshot("PLEX"), log)).rejects.not.toThrow(
+			/user:pass|secret|test-api-key/,
+		);
+	});
+
+	it("keeps Jellyfin Basic Auth credentials out of reader errors", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const instance = snapshot("JELLYFIN");
+		instance.httpAuthHeaders = { Authorization: "Basic dXNlcjpwYXNz" };
+
+		await expect(readProviderIdentity(instance, log)).rejects.toThrow(
+			"Unable to read JELLYFIN provider identity",
+		);
+		await expect(readProviderIdentity(instance, log)).rejects.not.toThrow(
+			/Basic|dXNlcjpwYXNz|user:pass/,
+		);
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/apps/api/src/lib/services/service-identity.ts
+++ b/apps/api/src/lib/services/service-identity.ts
@@ -1,0 +1,132 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { FastifyBaseLogger } from "fastify";
+import { JellyfinClient } from "../jellyfin/jellyfin-client.js";
+import { PlexClient } from "../plex/plex-client.js";
+import { TautulliClient } from "../tautulli/tautulli-client.js";
+
+const DISPLAY_FINGERPRINT_LENGTH = 12;
+
+export type ProviderIdentityService = "PLEX" | "JELLYFIN" | "EMBY" | "TAUTULLI";
+
+/** A service record already ownership-checked and decrypted by the caller. */
+export interface DecryptedOwnedServiceSnapshot {
+	service: ProviderIdentityService;
+	baseUrl: string;
+	apiKey: string;
+	httpAuthHeaders?: Record<string, string>;
+	label?: string | null;
+}
+
+/** Internal-only raw identity paired with safe-to-display derived values. */
+export interface ProviderIdentityObservation {
+	service: ProviderIdentityService;
+	identityKind:
+		| "plex-machine-identifier"
+		| "jellyfin-server-id"
+		| "emby-server-id"
+		| "tautulli-pms-identifier";
+	rawIdentity: string;
+	confirmationDigest: string;
+	fingerprint: string;
+	displayName?: string;
+}
+
+export async function readProviderIdentity(
+	instance: DecryptedOwnedServiceSnapshot,
+	log: FastifyBaseLogger,
+): Promise<ProviderIdentityObservation> {
+	try {
+		switch (instance.service) {
+			case "PLEX": {
+				const server = await new PlexClient(
+					instance.baseUrl,
+					instance.apiKey,
+					log,
+					undefined,
+					instance.httpAuthHeaders,
+				).getIdentity();
+				return observe("PLEX", "plex-machine-identifier", server.machineIdentifier, instance.label);
+			}
+			case "JELLYFIN":
+			case "EMBY": {
+				if (
+					instance.service === "JELLYFIN" &&
+					Object.keys(instance.httpAuthHeaders ?? {}).length > 0
+				) {
+					throw new Error("Jellyfin HTTP Basic Auth is unsupported");
+				}
+				const server = await new JellyfinClient(
+					instance.baseUrl,
+					instance.apiKey,
+					log,
+					undefined,
+					instance.httpAuthHeaders,
+				).getServerInfo();
+				return observe(
+					instance.service,
+					instance.service === "JELLYFIN" ? "jellyfin-server-id" : "emby-server-id",
+					server.id,
+					server.serverName,
+				);
+			}
+			case "TAUTULLI": {
+				const server = await new TautulliClient(
+					instance.baseUrl,
+					instance.apiKey,
+					log,
+					undefined,
+					instance.httpAuthHeaders,
+				).getServerIdentity();
+				return observe(
+					"TAUTULLI",
+					"tautulli-pms-identifier",
+					server.identifier,
+					server.displayName,
+				);
+			}
+		}
+	} catch {
+		// Credentials, URLs, and upstream identity values must not escape this boundary.
+		throw new Error(`Unable to read ${instance.service} provider identity`);
+	}
+}
+
+export function confirmProviderIdentity(expected: string, actual: string): boolean {
+	if (!isSha256Digest(expected) || !isSha256Digest(actual)) return false;
+	return timingSafeEqual(Buffer.from(expected, "hex"), Buffer.from(actual, "hex"));
+}
+
+function observe(
+	service: ProviderIdentityService,
+	identityKind: ProviderIdentityObservation["identityKind"],
+	rawIdentity: string,
+	displayName: string | null | undefined,
+): ProviderIdentityObservation {
+	const normalizedIdentity = rawIdentity.trim();
+	if (!normalizedIdentity) throw new Error("provider identity missing");
+	const confirmationDigest = digest(`${service}:${identityKind}:${normalizedIdentity}`);
+	return {
+		service,
+		identityKind,
+		rawIdentity: normalizedIdentity,
+		confirmationDigest,
+		fingerprint: digest(`display:${service}:${identityKind}:${normalizedIdentity}`).slice(
+			0,
+			DISPLAY_FINGERPRINT_LENGTH,
+		),
+		displayName: normalizeDisplayName(displayName),
+	};
+}
+
+function digest(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function isSha256Digest(value: string): boolean {
+	return /^[a-f0-9]{64}$/i.test(value);
+}
+
+function normalizeDisplayName(value: string | null | undefined): string | undefined {
+	const displayName = value?.trim();
+	return displayName || undefined;
+}

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
@@ -52,7 +52,7 @@ describe("TautulliClient server identity", () => {
 		const fetchMock = vi
 			.fn()
 			.mockResolvedValueOnce(success({ pms_name: "Plex" }))
-			.mockResolvedValueOnce(success([{ machine_identifier: "fallback-id", pms_name: "Plex" }]));
+			.mockResolvedValueOnce(success([{ machine_identifier: "fallback-id", name: "Plex" }]));
 		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
@@ -66,6 +66,7 @@ describe("TautulliClient server identity", () => {
 	it.each([
 		[[]],
 		[[{ machine_identifier: "" }]],
+		[[{ machine_identifier: "" }, { machine_identifier: "only" }]],
 		[[{ machine_identifier: "one" }, { machine_identifier: "two" }]],
 		[[{ machine_identifier: "same" }, { machine_identifier: "same" }]],
 		[[{ machine_identifier: 42 }]],

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TautulliClient } from "../tautulli-client.js";
+
+const log = { warn: vi.fn() } as never;
+
+function success(data: unknown): Response {
+	return new Response(JSON.stringify({ response: { result: "success", message: null, data } }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+describe("TautulliClient server identity", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("uses get_server_info.pms_identifier as the primary identity", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValue(success({ pms_identifier: "primary-id", pms_name: "Plex" }));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new TautulliClient("http://tautulli.test", "api-key", log).getServerIdentity(),
+		).resolves.toEqual({
+			identifier: "primary-id",
+			displayName: "Plex",
+		});
+		expect(new URL(fetchMock.mock.calls[0]![0] as string).searchParams.get("cmd")).toBe(
+			"get_server_info",
+		);
+	});
+
+	it("falls back only when get_servers_info returns exactly one non-empty machine_identifier", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(success({ pms_identifier: "" }))
+			.mockResolvedValueOnce(success([{ machine_identifier: "fallback-id", pms_name: "Plex" }]));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new TautulliClient("http://tautulli.test", "api-key", log).getServerIdentity(),
+		).resolves.toEqual({
+			identifier: "fallback-id",
+			displayName: "Plex",
+		});
+	});
+
+	it.each([
+		[[]],
+		[[{ machine_identifier: "" }]],
+		[[{ machine_identifier: "one" }, { machine_identifier: "two" }]],
+		[[{ machine_identifier: "same" }, { machine_identifier: "same" }]],
+		[[{ machine_identifier: 42 }]],
+	])("rejects an ambiguous or malformed compatibility fallback: %j", async (servers) => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(success({ pms_identifier: "" }))
+				.mockResolvedValueOnce(success(servers)),
+		);
+
+		await expect(
+			new TautulliClient("http://tautulli.test", "api-key", log).getServerIdentity(),
+		).rejects.toThrow("Tautulli server identity is unavailable");
+	});
+});

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-client-identity.test.ts
@@ -48,6 +48,21 @@ describe("TautulliClient server identity", () => {
 		});
 	});
 
+	it("uses the single compatibility fallback when get_server_info omits pms_identifier", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(success({ pms_name: "Plex" }))
+			.mockResolvedValueOnce(success([{ machine_identifier: "fallback-id", pms_name: "Plex" }]));
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new TautulliClient("http://tautulli.test", "api-key", log).getServerIdentity(),
+		).resolves.toEqual({
+			identifier: "fallback-id",
+			displayName: "Plex",
+		});
+	});
+
 	it.each([
 		[[]],
 		[[{ machine_identifier: "" }]],

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -169,14 +169,16 @@ export class TautulliClient {
 			}
 
 			const servers = await this.command("get_servers_info", undefined, tautulliServersInfoSchema);
-			const candidates = servers
-				.map((server) => ({
-					identifier: server.machine_identifier.trim(),
-					displayName: normalizeDisplayName(server.name) ?? normalizeDisplayName(server.pms_name),
-				}))
-				.filter((server) => server.identifier.length > 0);
-			if (candidates.length !== 1) throw new Error("ambiguous fallback identity");
-			return candidates[0]!;
+			if (servers.length !== 1) throw new Error("ambiguous fallback identity");
+			const fallbackServer = servers[0]!;
+			const fallbackIdentifier = fallbackServer.machine_identifier.trim();
+			if (!fallbackIdentifier) throw new Error("ambiguous fallback identity");
+			return {
+				identifier: fallbackIdentifier,
+				displayName:
+					normalizeDisplayName(fallbackServer.name) ??
+					normalizeDisplayName(fallbackServer.pms_name),
+			};
 		} catch {
 			// The upstream identity and response details are intentionally internal.
 			throw new Error("Tautulli server identity is unavailable");

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -21,6 +21,8 @@ import {
 	tautulliMetadataSchema,
 	tautulliPlaysByDateDataSchema,
 	tautulliResponseWrapperSchema,
+	tautulliServerInfoSchema,
+	tautulliServersInfoSchema,
 	tautulliUserWatchTimeStatsSchema,
 } from "./tautulli-schemas.js";
 
@@ -104,11 +106,21 @@ export interface TautulliHomeStat {
 	}>;
 }
 
+export interface TautulliServerIdentity {
+	identifier: string;
+	displayName?: string;
+}
+
 // ============================================================================
 // Client Implementation
 // ============================================================================
 
 const DEFAULT_TIMEOUT = 10_000;
+
+function normalizeDisplayName(value: string | undefined): string | undefined {
+	const displayName = value?.trim();
+	return displayName || undefined;
+}
 
 export class TautulliClient {
 	private readonly baseUrl: string;
@@ -136,6 +148,39 @@ export class TautulliClient {
 	 */
 	async getInfo(): Promise<TautulliInfo> {
 		return this.command("get_tautulli_info", undefined, tautulliInfoSchema);
+	}
+
+	/**
+	 * Read the linked Plex Media Server identity.
+	 *
+	 * `get_server_info.pms_identifier` is authoritative. Older Tautulli
+	 * versions may omit it, so a single non-empty `get_servers_info`
+	 * `machine_identifier` is accepted as a compatibility fallback only.
+	 */
+	async getServerIdentity(): Promise<TautulliServerIdentity> {
+		try {
+			const serverInfo = await this.command("get_server_info", undefined, tautulliServerInfoSchema);
+			const primaryIdentifier = serverInfo.pms_identifier.trim();
+			if (primaryIdentifier) {
+				return {
+					identifier: primaryIdentifier,
+					displayName: normalizeDisplayName(serverInfo.pms_name),
+				};
+			}
+
+			const servers = await this.command("get_servers_info", undefined, tautulliServersInfoSchema);
+			const candidates = servers
+				.map((server) => ({
+					identifier: server.machine_identifier.trim(),
+					displayName: normalizeDisplayName(server.pms_name),
+				}))
+				.filter((server) => server.identifier.length > 0);
+			if (candidates.length !== 1) throw new Error("ambiguous fallback identity");
+			return candidates[0]!;
+		} catch {
+			// The upstream identity and response details are intentionally internal.
+			throw new Error("Tautulli server identity is unavailable");
+		}
 	}
 
 	/**

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -160,7 +160,7 @@ export class TautulliClient {
 	async getServerIdentity(): Promise<TautulliServerIdentity> {
 		try {
 			const serverInfo = await this.command("get_server_info", undefined, tautulliServerInfoSchema);
-			const primaryIdentifier = serverInfo.pms_identifier.trim();
+			const primaryIdentifier = serverInfo.pms_identifier?.trim();
 			if (primaryIdentifier) {
 				return {
 					identifier: primaryIdentifier,

--- a/apps/api/src/lib/tautulli/tautulli-client.ts
+++ b/apps/api/src/lib/tautulli/tautulli-client.ts
@@ -172,7 +172,7 @@ export class TautulliClient {
 			const candidates = servers
 				.map((server) => ({
 					identifier: server.machine_identifier.trim(),
-					displayName: normalizeDisplayName(server.pms_name),
+					displayName: normalizeDisplayName(server.name) ?? normalizeDisplayName(server.pms_name),
 				}))
 				.filter((server) => server.identifier.length > 0);
 			if (candidates.length !== 1) throw new Error("ambiguous fallback identity");

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -22,6 +22,20 @@ export const tautulliInfoSchema = z.looseObject({
 	tautulli_version: z.string(),
 });
 
+/** get_server_info — the linked Plex Media Server identity. */
+export const tautulliServerInfoSchema = z.looseObject({
+	pms_identifier: z.string(),
+	pms_name: z.string().optional(),
+});
+
+/** get_servers_info — compatibility identity fallback for older Tautulli versions. */
+export const tautulliServersInfoSchema = z.array(
+	z.looseObject({
+		machine_identifier: z.string(),
+		pms_name: z.string().optional(),
+	}),
+);
+
 /** get_libraries — array item */
 export const tautulliLibrarySchema = z.looseObject({
 	section_id: z.string(),

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -24,7 +24,7 @@ export const tautulliInfoSchema = z.looseObject({
 
 /** get_server_info — the linked Plex Media Server identity. */
 export const tautulliServerInfoSchema = z.looseObject({
-	pms_identifier: z.string(),
+	pms_identifier: z.string().optional(),
 	pms_name: z.string().optional(),
 });
 

--- a/apps/api/src/lib/tautulli/tautulli-schemas.ts
+++ b/apps/api/src/lib/tautulli/tautulli-schemas.ts
@@ -32,6 +32,7 @@ export const tautulliServerInfoSchema = z.looseObject({
 export const tautulliServersInfoSchema = z.array(
 	z.looseObject({
 		machine_identifier: z.string(),
+		name: z.string().optional(),
 		pms_name: z.string().optional(),
 	}),
 );


### PR DESCRIPTION
## Summary

- add typed upstream identity readers for Plex, Jellyfin, Emby, and Tautulli
- add privacy-preserving confirmation digests and display fingerprints
- add dormant provider identity state and generation fields to service instances
- preserve current runtime behavior; identity enforcement remains in the next atomic change

## Provider compatibility

- Plex uses the machine identifier from `/identity`
- Jellyfin and Emby use the server ID from `/System/Info`
- Tautulli prefers `get_server_info.pms_identifier` and only accepts the older `get_servers_info.machine_identifier` fallback when exactly one non-empty server is returned
- raw upstream identities are not exposed through service responses

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` — API 3,834 passed / 46 skipped; web 635 passed; shared 89 passed
- `pnpm run lint`
- `pnpm run build`
- SQLite fresh and populated legacy schema synchronization
- PostgreSQL fresh and populated legacy schema synchronization
- exact-head combined image smoke-tested with healthy API and web endpoints on SQLite and PostgreSQL
- independent data-safety, regression, schema/container, and final whole-change reviews

## Risk and rollout

This PR is intentionally behavior-neutral. Existing instances remain `unverified` at identity generation zero, and no route, scheduler, cache, cleanup, or UI path consumes the new fields yet. The follow-up activation PR will enroll identities and enforce them atomically across cache publication and cleanup execution.

Related to #689
