### PR TITLE
fix(plex): restore history cache refresh compatibility

### DIFF
--- a/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
@@ -19,10 +19,12 @@ const mockState: {
 	evaluateReason: string | null;
 	evaluateCalls: number;
 	buildContextThrows: boolean;
+	lastBuildRules: Array<Record<string, unknown>> | null;
 } = {
 	evaluateReason: "matched",
 	evaluateCalls: 0,
 	buildContextThrows: false,
+	lastBuildRules: null,
 };
 
 vi.mock("../../library-cleanup/rule-evaluators.js", () => ({
@@ -33,7 +35,8 @@ vi.mock("../../library-cleanup/rule-evaluators.js", () => ({
 }));
 
 vi.mock("../../library-cleanup/cleanup-executor.js", () => ({
-	buildEvalContext: vi.fn(async () => {
+	buildEvalContext: vi.fn(async (_deps, _userId, rules) => {
+		mockState.lastBuildRules = rules;
 		if (mockState.buildContextThrows) {
 			throw new Error("prefetch failed");
 		}
@@ -180,6 +183,7 @@ describe("executeAutoTagRule (orchestration)", () => {
 		mockState.evaluateReason = "matched";
 		mockState.evaluateCalls = 0;
 		mockState.buildContextThrows = false;
+		mockState.lastBuildRules = null;
 
 		// Restore the default mock implementation — individual tests sometimes
 		// override `evaluateSingleCondition.mockImplementation(...)` and the
@@ -459,6 +463,29 @@ describe("executeAutoTagRule (orchestration)", () => {
 		expect(prisma.libraryCache.findMany).not.toHaveBeenCalled();
 		expect(arrClient.tag.getAll).not.toHaveBeenCalled();
 		expect(arrClient.movie.update).not.toHaveBeenCalled();
+	});
+
+	it("forwards the Plex library filter into evidence validation", async () => {
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([makeInstance()]) },
+			libraryCache: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await executeAutoTagRule({
+			rule: makeRule({
+				ruleType: "plex_user_rating",
+				parameters: { operator: "unrated" },
+				plexLibraryFilter: ["Movies"],
+			}),
+			prisma: prisma as never,
+			arrClientFactory: { create: vi.fn() } as never,
+			encryptor: {} as never,
+			log,
+		});
+
+		expect(mockState.lastBuildRules).toEqual([
+			expect.objectContaining({ plexLibraryFilter: JSON.stringify(["Movies"]) }),
+		]);
 	});
 
 	// ── Edge cases (PR C — defensive coverage) ────────────────────────

--- a/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/execute-rule.test.ts
@@ -432,7 +432,7 @@ describe("executeAutoTagRule (orchestration)", () => {
 		expect(result.totals.failures).toBe(1);
 	});
 
-	it("buildEvalContext throwing falls back to empty context (rule still runs)", async () => {
+	it("fails closed without scanning or writing when evaluation evidence cannot be built", async () => {
 		mockState.buildContextThrows = true;
 		const arrClient = makeArrClient();
 		const prisma = {
@@ -453,7 +453,12 @@ describe("executeAutoTagRule (orchestration)", () => {
 			log,
 		});
 
-		expect(result.totals.itemsMatched).toBe(1);
+		expect(result.status).toBe("failed");
+		expect(result.message).toMatch(/evaluation context/i);
+		expect(result.totals.itemsScanned).toBe(0);
+		expect(prisma.libraryCache.findMany).not.toHaveBeenCalled();
+		expect(arrClient.tag.getAll).not.toHaveBeenCalled();
+		expect(arrClient.movie.update).not.toHaveBeenCalled();
 	});
 
 	// ── Edge cases (PR C — defensive coverage) ────────────────────────

--- a/apps/api/src/lib/auto-tag/__tests__/webhook-handler.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/webhook-handler.test.ts
@@ -12,14 +12,20 @@ import type { AutoTagRule, ServiceInstance, User } from "../../prisma.js";
 
 // Mock the evaluator + prefetch context builder. The evaluator returns a
 // reason string (truthy = match) by default; tests can override per-call.
-const evalState: { reason: string | null } = { reason: "matched" };
+const evalState: { reason: string | null; buildContextThrows: boolean } = {
+	reason: "matched",
+	buildContextThrows: false,
+};
 
 vi.mock("../../library-cleanup/rule-evaluators.js", () => ({
 	evaluateSingleCondition: vi.fn(() => evalState.reason),
 }));
 
 vi.mock("../../library-cleanup/cleanup-executor.js", () => ({
-	buildEvalContext: vi.fn(async () => ({ now: new Date() })),
+	buildEvalContext: vi.fn(async () => {
+		if (evalState.buildContextThrows) throw new Error("Plex evidence unavailable");
+		return { now: new Date() };
+	}),
 }));
 
 import { processWebhook, resolveUserFromBearer } from "../webhook-handler.js";
@@ -192,6 +198,7 @@ describe("resolveUserFromBearer", () => {
 describe("processWebhook", () => {
 	beforeEach(() => {
 		evalState.reason = "matched";
+		evalState.buildContextThrows = false;
 	});
 
 	it("test event returns status 'test' without invoking *arr API", async () => {
@@ -260,6 +267,38 @@ describe("processWebhook", () => {
 		expect(result.status).toBe("ok");
 		expect(result.tagsApplied).toBe(1);
 		expect(arrClient.movie.update).toHaveBeenCalledWith(100, { id: 100, tags: [7] });
+	});
+
+	it("fails closed without creating or applying tags when rule evidence is unavailable", async () => {
+		evalState.buildContextThrows = true;
+		const arrClient = makeArrClient();
+		const prisma = {
+			autoTagRule: {
+				findMany: vi.fn().mockResolvedValue([
+					makeRule({
+						ruleType: "plex_user_rating",
+						parameters: JSON.stringify({ operator: "unrated" }),
+					}),
+				]),
+			},
+		};
+
+		const result = await processWebhook({
+			deps: {
+				prisma: prisma as never,
+				arrClientFactory: { create: vi.fn().mockReturnValue(arrClient) } as never,
+				encryptor: {} as never,
+				log,
+			},
+			user: makeUser(),
+			instance: makeInstance(),
+			payload: { eventType: "Download", movie: { id: 100 } },
+		});
+
+		expect(result.status).toBe("error");
+		expect(result.message).toMatch(/evaluation evidence/i);
+		expect(arrClient.tag.getAll).not.toHaveBeenCalled();
+		expect(arrClient.movie.update).not.toHaveBeenCalled();
 	});
 
 	it("idempotent: item already has the tag → no update call, still status ok", async () => {

--- a/apps/api/src/lib/auto-tag/__tests__/webhook-handler.test.ts
+++ b/apps/api/src/lib/auto-tag/__tests__/webhook-handler.test.ts
@@ -12,9 +12,14 @@ import type { AutoTagRule, ServiceInstance, User } from "../../prisma.js";
 
 // Mock the evaluator + prefetch context builder. The evaluator returns a
 // reason string (truthy = match) by default; tests can override per-call.
-const evalState: { reason: string | null; buildContextThrows: boolean } = {
+const evalState: {
+	reason: string | null;
+	buildContextThrows: boolean;
+	lastBuildRules: Array<Record<string, unknown>> | null;
+} = {
 	reason: "matched",
 	buildContextThrows: false,
+	lastBuildRules: null,
 };
 
 vi.mock("../../library-cleanup/rule-evaluators.js", () => ({
@@ -22,7 +27,8 @@ vi.mock("../../library-cleanup/rule-evaluators.js", () => ({
 }));
 
 vi.mock("../../library-cleanup/cleanup-executor.js", () => ({
-	buildEvalContext: vi.fn(async () => {
+	buildEvalContext: vi.fn(async (_deps, _userId, rules) => {
+		evalState.lastBuildRules = rules;
 		if (evalState.buildContextThrows) throw new Error("Plex evidence unavailable");
 		return { now: new Date() };
 	}),
@@ -199,6 +205,7 @@ describe("processWebhook", () => {
 	beforeEach(() => {
 		evalState.reason = "matched";
 		evalState.buildContextThrows = false;
+		evalState.lastBuildRules = null;
 	});
 
 	it("test event returns status 'test' without invoking *arr API", async () => {
@@ -299,6 +306,37 @@ describe("processWebhook", () => {
 		expect(result.message).toMatch(/evaluation evidence/i);
 		expect(arrClient.tag.getAll).not.toHaveBeenCalled();
 		expect(arrClient.movie.update).not.toHaveBeenCalled();
+	});
+
+	it("forwards the Plex library filter into webhook evidence validation", async () => {
+		const arrClient = makeArrClient();
+		const prisma = {
+			autoTagRule: {
+				findMany: vi.fn().mockResolvedValue([
+					makeRule({
+						ruleType: "plex_user_rating",
+						parameters: JSON.stringify({ operator: "unrated" }),
+						plexLibraryFilter: JSON.stringify(["Movies"]),
+					}),
+				]),
+			},
+		};
+
+		await processWebhook({
+			deps: {
+				prisma: prisma as never,
+				arrClientFactory: { create: vi.fn().mockReturnValue(arrClient) } as never,
+				encryptor: {} as never,
+				log,
+			},
+			user: makeUser(),
+			instance: makeInstance(),
+			payload: { eventType: "Download", movie: { id: 100 } },
+		});
+
+		expect(evalState.lastBuildRules).toEqual([
+			expect.objectContaining({ plexLibraryFilter: JSON.stringify(["Movies"]) }),
+		]);
 	});
 
 	it("idempotent: item already has the tag → no update call, still status ok", async () => {

--- a/apps/api/src/lib/auto-tag/execute-rule.ts
+++ b/apps/api/src/lib/auto-tag/execute-rule.ts
@@ -114,16 +114,21 @@ export async function executeAutoTagRule(opts: ExecuteOpts): Promise<AutoTagRunR
 	// shape it expects from our rule.
 	let evalCtx: EvalContext;
 	try {
-		evalCtx = await buildEvalContext({ prisma, arrClientFactory, log: childLog }, rule.userId, [
-			{
-				enabled: true,
-				ruleType: rule.ruleType,
-				conditions: rule.conditions ? JSON.stringify(rule.conditions) : null,
-			},
-		]);
+		evalCtx = await buildEvalContext(
+			{ prisma, arrClientFactory, log: childLog },
+			rule.userId,
+			[
+				{
+					enabled: true,
+					ruleType: rule.ruleType,
+					conditions: rule.conditions ? JSON.stringify(rule.conditions) : null,
+				},
+			],
+			{ requireAvailableEvidence: true },
+		);
 	} catch (err) {
-		childLog.warn({ err }, "Failed to build evaluation context — proceeding with empty maps");
-		evalCtx = { now: new Date() };
+		childLog.warn({ err }, "Failed to build evaluation context — skipping auto-tag writes");
+		return failure("Evaluation context could not be built; no tags were changed.");
 	}
 
 	// Layer in TMDb/Trakt list-membership prefetch — these aren't part of

--- a/apps/api/src/lib/auto-tag/execute-rule.ts
+++ b/apps/api/src/lib/auto-tag/execute-rule.ts
@@ -122,6 +122,7 @@ export async function executeAutoTagRule(opts: ExecuteOpts): Promise<AutoTagRunR
 					enabled: true,
 					ruleType: rule.ruleType,
 					conditions: rule.conditions ? JSON.stringify(rule.conditions) : null,
+					plexLibraryFilter: rule.plexLibraryFilter ? JSON.stringify(rule.plexLibraryFilter) : null,
 				},
 			],
 			{ requireAvailableEvidence: true },

--- a/apps/api/src/lib/auto-tag/webhook-handler.ts
+++ b/apps/api/src/lib/auto-tag/webhook-handler.ts
@@ -139,6 +139,12 @@ export async function processWebhook(opts: {
 	// prefetched data. The rules pass their criteria types in via the same
 	// shape `buildEvalContext` expects.
 	const ctx = await safeBuildContext(deps, user.id, applicable, log);
+	if (!ctx) {
+		return {
+			status: "error",
+			message: "Required evaluation evidence is unavailable; no tags were changed.",
+		};
+	}
 
 	let tagsApplied = 0;
 	const tagsToApply: string[] = [];
@@ -421,7 +427,7 @@ async function safeBuildContext(
 	userId: string,
 	rules: AutoTagRule[],
 	log: FastifyBaseLogger,
-): Promise<Awaited<ReturnType<typeof buildEvalContext>>> {
+): Promise<Awaited<ReturnType<typeof buildEvalContext>> | null> {
 	try {
 		return await buildEvalContext(
 			{ prisma: deps.prisma, arrClientFactory: deps.arrClientFactory, log },
@@ -431,10 +437,11 @@ async function safeBuildContext(
 				ruleType: r.ruleType,
 				conditions: r.conditions,
 			})),
+			{ requireAvailableEvidence: true },
 		);
 	} catch (err) {
-		log.warn({ err }, "Failed to build evaluation context — continuing with empty maps");
-		return { now: new Date() };
+		log.warn({ err }, "Failed to build evaluation context — skipping webhook auto-tag writes");
+		return null;
 	}
 }
 

--- a/apps/api/src/lib/auto-tag/webhook-handler.ts
+++ b/apps/api/src/lib/auto-tag/webhook-handler.ts
@@ -436,6 +436,7 @@ async function safeBuildContext(
 				enabled: true,
 				ruleType: r.ruleType,
 				conditions: r.conditions,
+				plexLibraryFilter: r.plexLibraryFilter,
 			})),
 			{ requireAvailableEvidence: true },
 		);

--- a/apps/api/src/lib/automation/__tests__/cross-domain-executor.test.ts
+++ b/apps/api/src/lib/automation/__tests__/cross-domain-executor.test.ts
@@ -1,4 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const executorMocks = vi.hoisted(() => ({
+	scanCrossDomainRule: vi.fn(),
+	executeAutoTagRule: vi.fn(),
+}));
+
+vi.mock("../cross-domain-rules.js", () => ({
+	scanCrossDomainRule: executorMocks.scanCrossDomainRule,
+}));
+
+vi.mock("../../auto-tag/execute-rule.js", () => ({
+	executeAutoTagRule: executorMocks.executeAutoTagRule,
+}));
+
 import { executeCrossDomainRule } from "../cross-domain-executor.js";
 
 const document = {
@@ -7,6 +21,26 @@ const document = {
 };
 
 describe("executeCrossDomainRule", () => {
+	beforeEach(() => {
+		executorMocks.scanCrossDomainRule.mockReset();
+		executorMocks.executeAutoTagRule.mockReset();
+		executorMocks.scanCrossDomainRule.mockResolvedValue({
+			itemsEvaluated: 1,
+			matches: [
+				{
+					cacheId: "cache-1",
+					instanceId: "radarr-1",
+					instanceName: "Radarr",
+					arrItemId: 42,
+					itemType: "movie",
+					title: "Old Movie",
+					year: 1999,
+					reason: "Matched age condition",
+				},
+			],
+		});
+	});
+
 	it("delivers a one-shot action only once per item and deployment", async () => {
 		let ledgerRow: Record<string, unknown> | null = null;
 		const notify = vi.fn(async () => undefined);
@@ -93,5 +127,61 @@ describe("executeCrossDomainRule", () => {
 			{ userId: "user-1" },
 		);
 		expect(ledgerRow).toMatchObject({ completedActions: '["send_notification"]' });
+	});
+
+	it("records a retryable context failure instead of claiming the item disappeared", async () => {
+		const upsert = vi.fn().mockResolvedValue({});
+		const prisma = {
+			crossDomainRuleMatch: {
+				findMany: vi.fn().mockResolvedValue([]),
+				upsert,
+			},
+		};
+		executorMocks.executeAutoTagRule.mockResolvedValue({
+			status: "failed",
+			message: "Evaluation context could not be built; no tags were changed.",
+			totals: {
+				instancesScanned: 0,
+				itemsScanned: 0,
+				itemsMatched: 0,
+				tagsApplied: 0,
+				failures: 0,
+			},
+			itemOutcomes: [],
+		});
+		const deps = {
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: {} as never,
+			notificationService: {} as never,
+			log: {} as never,
+		};
+		const rule = {
+			id: "rule-1",
+			userId: "user-1",
+			deployedName: "Archive workflow",
+			deployedDocument: JSON.stringify(document),
+			deployedScope: JSON.stringify({ serviceTypes: ["RADARR"], instanceIds: [] }),
+			deployedActions: JSON.stringify([{ type: "apply_tag", tagName: "archive" }]),
+			deploymentVersion: 1,
+		};
+
+		const result = await executeCrossDomainRule(deps, rule);
+
+		expect(result.status).toBe("failed");
+		expect(upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					lastError: "Evaluation context could not be built; no tags were changed.",
+				}),
+			}),
+		);
+		expect(upsert).not.toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					lastError: "Matched item disappeared before tag action",
+				}),
+			}),
+		);
 	});
 });

--- a/apps/api/src/lib/automation/cross-domain-executor.ts
+++ b/apps/api/src/lib/automation/cross-domain-executor.ts
@@ -115,6 +115,7 @@ export async function executeCrossDomainRule(
 			targetCacheItemIds: pending.map((match) => match.cacheId),
 		});
 		const outcomes = new Map(result.itemOutcomes.map((outcome) => [outcome.cacheId, outcome]));
+		const runFailure = result.status === "failed" ? result.message : null;
 		for (const match of pending) {
 			const outcome = outcomes.get(match.cacheId);
 			if (outcome?.success) {
@@ -126,7 +127,7 @@ export async function executeCrossDomainRule(
 					deps.prisma,
 					rule,
 					match,
-					outcome?.error ?? "Matched item disappeared before tag action",
+					outcome?.error ?? runFailure ?? "Matched item disappeared before tag action",
 				);
 			}
 		}

--- a/apps/api/src/lib/automation/cross-domain-rules.ts
+++ b/apps/api/src/lib/automation/cross-domain-rules.ts
@@ -122,7 +122,9 @@ export async function scanCrossDomainRule(
 		conditions: v0.conditions ? JSON.stringify(v0.conditions) : null,
 	};
 	const cleanupDeps: CleanupExecutorDeps = deps;
-	const context = await buildEvalContext(cleanupDeps, userId, [evalRule]);
+	const context = await buildEvalContext(cleanupDeps, userId, [evalRule], {
+		requireAvailableEvidence: true,
+	});
 
 	const instances = await deps.prisma.serviceInstance.findMany({
 		where: {

--- a/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/external-rule-authority.test.ts
@@ -55,6 +55,98 @@ function seerrRequest(id: number, tmdbId: number) {
 }
 
 describe("external parent-rule authority", () => {
+	it("fails closed when Jellyfin negative rules have no proven cache generation", async () => {
+		const instance = { id: "jellyfin-1", updatedAt: new Date(0) };
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([]) },
+			jellyfinCache: { findMany: vi.fn() },
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		await expect(
+			buildEvalContext(
+				{ prisma, arrClientFactory: {} as never, log } as CleanupExecutorDeps,
+				"user-1",
+				[{ enabled: true, ruleType: "jellyfin_user_rating", conditions: null }],
+				{ requireAvailableEvidence: true },
+			),
+		).rejects.toThrow(/required evaluation evidence is unavailable: jellyfin\/emby/i);
+		expect(prisma.jellyfinCache.findMany).not.toHaveBeenCalled();
+	});
+
+	it("accepts a status-proven empty Jellyfin generation as authoritative evidence", async () => {
+		const instance = { id: "jellyfin-1", updatedAt: new Date(0) };
+		const status = {
+			instanceId: instance.id,
+			lastRefreshedAt: new Date(),
+			lastResult: "success",
+			lastErrorMessage: null,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			itemCount: 0,
+			generationId: "jellyfin-generation-1",
+			generationMetadata: null,
+		};
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([status]) },
+			jellyfinCache: { findMany: vi.fn().mockResolvedValue([]) },
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const context = await buildEvalContext(
+			{ prisma, arrClientFactory: {} as never, log } as CleanupExecutorDeps,
+			"user-1",
+			[{ enabled: true, ruleType: "jellyfin_user_rating", conditions: null }],
+			{ requireAvailableEvidence: true },
+		);
+
+		expect(context.jellyfinMap).toEqual(new Map());
+		expect(prisma.cacheRefreshStatus.findMany).toHaveBeenCalledTimes(2);
+	});
+
+	it("rejects malformed Jellyfin user evidence before negative rules can match", async () => {
+		const instance = { id: "jellyfin-1", updatedAt: new Date(0) };
+		const status = {
+			instanceId: instance.id,
+			lastRefreshedAt: new Date(),
+			lastResult: "success",
+			lastErrorMessage: null,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			itemCount: 1,
+			generationId: "jellyfin-generation-1",
+			generationMetadata: null,
+		};
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([status]) },
+			jellyfinCache: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						id: "row-1",
+						tmdbId: 42,
+						mediaType: "series",
+						lastWatchedAt: null,
+						watchCount: 0,
+						watchedByUsers: "null",
+						onDeck: false,
+						userRating: null,
+						addedAt: null,
+					},
+				]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		await expect(
+			buildEvalContext(
+				{ prisma, arrClientFactory: {} as never, log } as CleanupExecutorDeps,
+				"user-1",
+				[{ enabled: true, ruleType: "jellyfin_watched_by", conditions: null }],
+				{ requireAvailableEvidence: true },
+			),
+		).rejects.toThrow(/required evaluation evidence is unavailable: jellyfin\/emby/i);
+	});
+
 	it.each(["plex_episode_completion", "jellyfin_episode_completion"])(
 		"does not treat an unconfigured %s provider as complete evidence",
 		async (ruleType) => {

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -163,6 +163,7 @@ type PlexStatusOverride =
 const unavailablePlexEvidenceCases = [
 	["missing status", () => undefined],
 	["stale timestamp", () => ({ lastRefreshedAt: new Date(Date.now() - 25 * 60 * 60 * 1000) })],
+	["future timestamp", () => ({ lastRefreshedAt: new Date(Date.now() + 60 * 1000) })],
 	["failed result", () => ({ lastResult: "error" })],
 	["failed latest attempt", () => ({ lastAttemptResult: "error" })],
 	["completed-generation error", () => ({ lastErrorMessage: "refresh failed" })],
@@ -322,6 +323,70 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		expect(result.ctx.plexEpisodeMap?.get(84)).toMatchObject({ total: 1, watched: 0 });
 		expect(episodeGroupBy).toHaveBeenCalledTimes(4);
 	});
+
+	it.each(["generation", "row"] as const)(
+		"rejects a future-dated Plex episode %s",
+		async (futureTarget) => {
+			const instance = {
+				id: "plex-inst-1",
+				updatedAt: new Date(0),
+				service: "PLEX",
+				enabled: true,
+				baseUrl: "http://plex.internal:32400",
+				encryptedApiKey: "encrypted-token",
+				encryptionIv: "iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+				label: null,
+			};
+			const completedAt = new Date();
+			const futureAt = new Date(completedAt.getTime() + 60 * 1000);
+			const normalStatus = completeStatus(instance.id, completedAt, 1);
+			const episodeStatus = completeStatus(
+				instance.id,
+				futureTarget === "generation" ? futureAt : completedAt,
+				1,
+			);
+			const episodeGroupBy = vi.fn().mockResolvedValue([]);
+			const prisma = {
+				serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+				cacheRefreshStatus: {
+					findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+						Promise.resolve([where.cacheType === "plex_episode" ? episodeStatus : normalStatus]),
+					),
+				},
+				plexCache: {
+					count: vi.fn().mockResolvedValue(1),
+					findMany: vi
+						.fn()
+						.mockResolvedValue([
+							makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+						]),
+				},
+				plexEpisodeCache: {
+					findMany: vi.fn().mockResolvedValue([
+						{
+							instanceId: instance.id,
+							showTmdbId: 42,
+							refreshedAt: futureTarget === "row" ? futureAt : completedAt,
+							sourceFingerprint: plexConnectionFingerprint(instance as never),
+						},
+					]),
+					groupBy: episodeGroupBy,
+				},
+			} as unknown as CleanupExecutorDeps["prisma"];
+
+			const result = await buildPlexEvalContextWithHealth(
+				{ prisma, log } as CleanupExecutorDeps,
+				"user-1",
+				[plexCleanupRule("plex_episode_completion")],
+			);
+
+			expect(result.ctx.plexEpisodeMap).toBeUndefined();
+			expect(result.failedSources).toContain("plex");
+			expect(episodeGroupBy).not.toHaveBeenCalled();
+		},
+	);
 
 	it("rejects an interleaved map/section generation", async () => {
 		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };
@@ -524,6 +589,50 @@ describe("prefetchFreshPlexEpisodeWatchData", () => {
 		const result = await prefetchFreshPlexEpisodeWatchData(
 			{ prisma, log } as CleanupExecutorDeps,
 			[currentInstance] as never,
+			now,
+			warnings,
+		);
+
+		expect(result).toEqual(new Map());
+		expect(warnings).toContainEqual(expect.stringContaining("stale Plex episode watch"));
+	});
+
+	it("rejects future-dated episode-scoped watch evidence", async () => {
+		const now = new Date("2026-07-30T12:00:00.000Z");
+		const warnings: string[] = [];
+		const instance = {
+			id: "plex-inst-1",
+			service: "PLEX",
+			enabled: true,
+			baseUrl: "http://plex.internal:32400",
+			encryptedApiKey: "encrypted-token",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			updatedAt: new Date("2026-07-30T11:30:00.000Z"),
+		};
+		const prisma = {
+			plexEpisodeCache: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: instance.id,
+						showTmdbId: 42,
+						seasonNumber: 1,
+						episodeNumber: 2,
+						watchCount: 1,
+						lastWatchedAt: now,
+						watchedByUsers: "[]",
+						ratingKey: "episode-123",
+						refreshedAt: new Date("2026-07-30T12:01:00.000Z"),
+						sourceFingerprint: plexConnectionFingerprint(instance as never),
+					},
+				]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await prefetchFreshPlexEpisodeWatchData(
+			{ prisma, log } as CleanupExecutorDeps,
+			[instance] as never,
 			now,
 			warnings,
 		);

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -13,7 +13,12 @@
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import { plexConnectionFingerprint } from "../../plex/service-instance-fingerprint.js";
-import { prefetchFreshPlexEpisodeWatchData, prefetchPlexData } from "../cleanup-executor.js";
+import {
+	buildEvalContext,
+	prefetchFreshPlexEpisodeWatchData,
+	prefetchPlexData,
+} from "../cleanup-executor.js";
+import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
 function makePlexRow(overrides: {
@@ -58,7 +63,305 @@ const log = {
 	fatal: vi.fn(),
 } as unknown as FastifyBaseLogger;
 
+async function buildPlexEvalContextWithHealth(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	rules: Array<{
+		enabled: boolean;
+		ruleType: string;
+		conditions: string | null;
+		plexLibraryFilter?: string | null;
+	}>,
+) {
+	const ctx = await buildEvalContext(deps, userId, rules);
+	const failedSources = new Set<"plex">();
+	const needsEpisodeEvidence = rules.some(
+		(rule) => rule.enabled && rule.ruleType === "plex_episode_completion",
+	);
+	if (!ctx.plexMap || (needsEpisodeEvidence && !ctx.plexEpisodeMap)) {
+		failedSources.add("plex");
+	}
+	return { ctx, failedSources };
+}
+
+function completeStatus(instanceId: string, completedAt = new Date(), itemCount = 0) {
+	return {
+		instanceId,
+		lastRefreshedAt: completedAt,
+		lastResult: "success",
+		itemCount,
+		generationId: `generation-${instanceId}`,
+		generationMetadata: JSON.stringify({
+			sections: [{ key: "1", title: "Movies", type: "movie" }],
+		}),
+		lastErrorMessage: null,
+		lastAttemptResult: "success",
+		lastAttemptErrorMessage: null,
+	};
+}
+
+function plexCleanupRule(ruleType = "plex_watch_count") {
+	return {
+		id: `rule-${ruleType}`,
+		configId: "config-1",
+		name: ruleType,
+		enabled: true,
+		priority: 1,
+		ruleType,
+		parameters: JSON.stringify(
+			ruleType === "plex_episode_completion"
+				? { operator: "less_than", percent: 100 }
+				: { operator: "greater_than", count: 0 },
+		),
+		serviceFilter: null,
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		targetScope: "series",
+		action: "delete",
+		scanMediaServerAfterDelete: false,
+		scanMediaServerInstanceIds: null,
+		operator: null,
+		conditions: null,
+		retentionMode: false,
+		useGlobalRejectionMemory: true,
+		rejectionMemoryDays: 0,
+		createdAt: new Date("2026-08-10T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-10T00:00:00.000Z"),
+	};
+}
+
+const plexDecisionItem = {
+	id: "library-1",
+	instanceId: "sonarr-1",
+	arrItemId: 42,
+	itemType: "series" as const,
+	title: "Example Series",
+	year: 2020,
+	monitored: true,
+	hasFile: true,
+	status: "ended",
+	qualityProfileId: 1,
+	qualityProfileName: "Default",
+	sizeOnDisk: 1n,
+	arrAddedAt: new Date("2026-01-01T00:00:00.000Z"),
+	data: JSON.stringify({ remoteIds: { tmdbId: 42 } }),
+};
+
+type PlexStatusOverride =
+	| Partial<{
+			lastRefreshedAt: Date;
+			lastResult: string;
+			lastAttemptResult: string;
+			lastErrorMessage: string | null;
+			lastAttemptErrorMessage: string | null;
+			itemCount: number;
+	  }>
+	| undefined;
+
+const unavailablePlexEvidenceCases = [
+	["missing status", () => undefined],
+	["stale timestamp", () => ({ lastRefreshedAt: new Date(Date.now() - 25 * 60 * 60 * 1000) })],
+	["failed result", () => ({ lastResult: "error" })],
+	["failed latest attempt", () => ({ lastAttemptResult: "error" })],
+	["completed-generation error", () => ({ lastErrorMessage: "refresh failed" })],
+	["latest-attempt error", () => ({ lastAttemptErrorMessage: "refresh failed" })],
+	["connection repoint", () => ({ lastRefreshedAt: new Date("2026-08-10T10:00:00.000Z") })],
+	["normal cache row-count mismatch", () => ({ itemCount: 2 })],
+] satisfies ReadonlyArray<readonly [string, () => PlexStatusOverride]>;
+
 describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
+	it.each(unavailablePlexEvidenceCases)(
+		"blocks Plex cleanup evidence for %s",
+		async (caseName, overrides) => {
+			const instance = {
+				id: "plex-inst-1",
+				updatedAt:
+					caseName === "connection repoint"
+						? new Date("2026-08-10T11:00:00.000Z")
+						: new Date("2026-08-10T00:00:00.000Z"),
+			};
+			const baseStatus = completeStatus(instance.id, new Date(), 1);
+			const statusOverride = overrides();
+			const status = statusOverride ? { ...baseStatus, ...statusOverride } : undefined;
+			const prisma = {
+				serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+				cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue(status ? [status] : []) },
+				plexCache: {
+					count: vi.fn().mockResolvedValue(1),
+					findMany: vi
+						.fn()
+						.mockResolvedValue([
+							makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+						]),
+				},
+			} as unknown as CleanupExecutorDeps["prisma"];
+			const rule = plexCleanupRule();
+
+			const result = await buildPlexEvalContextWithHealth(
+				{ prisma, log } as CleanupExecutorDeps,
+				"user-1",
+				[rule],
+			);
+
+			expect(result.ctx.plexMap).toBeUndefined();
+			expect(result.failedSources).toContain("plex");
+			expect(
+				evaluateItemAgainstRules(
+					plexDecisionItem,
+					[rule],
+					"SONARR",
+					result.ctx,
+					result.failedSources,
+				),
+			).toBeNull();
+		},
+	);
+
+	it("keeps a complete Plex generation available for cleanup evaluation", async () => {
+		const completedAt = new Date();
+		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };
+		const status = completeStatus(instance.id, completedAt, 1);
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([status]) },
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+					]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await buildPlexEvalContextWithHealth(
+			{ prisma, log } as CleanupExecutorDeps,
+			"user-1",
+			[plexCleanupRule()],
+		);
+
+		expect(result.failedSources).not.toContain("plex");
+		expect(result.ctx.plexMap?.get("series:42")).toEqual(
+			expect.objectContaining({ watchCount: 0 }),
+		);
+	});
+
+	it("blocks Plex episode cleanup when the episode cache row count mismatches", async () => {
+		const instance = {
+			id: "plex-inst-1",
+			updatedAt: new Date(0),
+			service: "PLEX",
+			enabled: true,
+			baseUrl: "http://plex.internal:32400",
+			encryptedApiKey: "encrypted-token",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			label: null,
+		};
+		const completedAt = new Date();
+		const normalStatus = completeStatus(instance.id, completedAt, 1);
+		const episodeStatus = completeStatus(instance.id, completedAt, 2);
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: {
+				findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+					Promise.resolve([where.cacheType === "plex_episode" ? episodeStatus : normalStatus]),
+				),
+			},
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+					]),
+			},
+			plexEpisodeCache: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: instance.id,
+						refreshedAt: completedAt,
+						sourceFingerprint: plexConnectionFingerprint(instance as never),
+					},
+				]),
+				groupBy: vi.fn().mockResolvedValue([]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await buildPlexEvalContextWithHealth(
+			{ prisma, log } as CleanupExecutorDeps,
+			"user-1",
+			[plexCleanupRule("plex_episode_completion")],
+		);
+
+		expect(result.ctx.plexEpisodeMap).toBeUndefined();
+		expect(result.failedSources).toContain("plex");
+		expect(
+			evaluateItemAgainstRules(
+				plexDecisionItem,
+				[plexCleanupRule("plex_episode_completion")],
+				"SONARR",
+				result.ctx,
+				result.failedSources,
+			),
+		).toBeNull();
+	});
+
+	it("rejects an interleaved map/section generation", async () => {
+		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };
+		const completedAt = new Date();
+		const status = (generationId: string, includeNewSection: boolean) => ({
+			...completeStatus(instance.id, completedAt, 1),
+			generationId,
+			generationMetadata: JSON.stringify({
+				sections: [
+					{ key: "1", title: "Movies", type: "movie" },
+					...(includeNewSection ? [{ key: "2", title: "New Movies", type: "movie" }] : []),
+				],
+			}),
+			lastErrorMessage: null,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+		});
+		const statusReads = vi
+			.fn()
+			.mockResolvedValueOnce([status("generation-1", false)])
+			.mockResolvedValueOnce([status("generation-2", true)])
+			.mockResolvedValueOnce([status("generation-2", true)]);
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: { findMany: statusReads },
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "movie", sectionId: "1" }),
+					]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await buildPlexEvalContextWithHealth(
+			{ prisma, log } as CleanupExecutorDeps,
+			"user-1",
+			[
+				{
+					enabled: true,
+					ruleType: "age",
+					conditions: null,
+					plexLibraryFilter: JSON.stringify(["Movies"]),
+				},
+			],
+		);
+
+		expect(statusReads).toHaveBeenCalledTimes(3);
+		expect(result.failedSources).toContain("plex");
+		expect(result.ctx.plexMap).toBeUndefined();
+		expect(result.ctx.plexSectionTitles).toBeUndefined();
+	});
 	it("merges watch data when the same tmdbId appears across two batches", async () => {
 		// Batch 1: 500 unique rows (forces a second findMany call). Last row is
 		// movie tmdbId=42 in section "lib-1" with one user watch.
@@ -106,7 +409,10 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 
 		const prisma = {
 			serviceInstance: {
-				findMany: vi.fn().mockResolvedValue([{ id: "plex-inst-1" }]),
+				findMany: vi.fn().mockResolvedValue([{ id: "plex-inst-1", updatedAt: new Date(0) }]),
+			},
+			cacheRefreshStatus: {
+				findMany: vi.fn().mockResolvedValue([completeStatus("plex-inst-1", new Date(), 501)]),
 			},
 			plexCache: { findMany: findManySpy },
 		} as unknown as CleanupExecutorDeps["prisma"];
@@ -146,7 +452,12 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 			]);
 
 		const prisma = {
-			serviceInstance: { findMany: vi.fn().mockResolvedValue([{ id: "plex-inst-1" }]) },
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([{ id: "plex-inst-1", updatedAt: new Date(0) }]),
+			},
+			cacheRefreshStatus: {
+				findMany: vi.fn().mockResolvedValue([completeStatus("plex-inst-1", new Date(), 1)]),
+			},
 			plexCache: { findMany: findManySpy },
 		} as unknown as CleanupExecutorDeps["prisma"];
 

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -264,7 +264,6 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		};
 		const completedAt = new Date();
 		const normalStatus = completeStatus(instance.id, completedAt, 1);
-		const retainedAt = new Date(completedAt.getTime() - 6 * 60 * 60 * 1000);
 		const episodeStatus = completeStatus(instance.id, completedAt, 1);
 		const episodeGroupBy = vi
 			.fn()
@@ -287,6 +286,10 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 			},
 			plexCache: {
 				count: vi.fn().mockResolvedValue(1),
+				groupBy: vi.fn().mockResolvedValue([
+					{ instanceId: instance.id, tmdbId: 42 },
+					{ instanceId: instance.id, tmdbId: 84 },
+				]),
 				findMany: vi
 					.fn()
 					.mockResolvedValue([
@@ -294,20 +297,10 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 					]),
 			},
 			plexEpisodeCache: {
-				findMany: vi.fn().mockResolvedValue([
-					{
-						instanceId: instance.id,
-						showTmdbId: 42,
-						refreshedAt: completedAt,
-						sourceFingerprint: plexConnectionFingerprint(instance as never),
-					},
-					{
-						instanceId: instance.id,
-						showTmdbId: 84,
-						refreshedAt: retainedAt,
-						sourceFingerprint: plexConnectionFingerprint(instance as never),
-					},
-				]),
+				findMany: vi.fn(() => {
+					throw new Error("episode evidence validation must stay database-bounded");
+				}),
+				count: vi.fn().mockResolvedValue(2),
 				groupBy: episodeGroupBy,
 			},
 		} as unknown as CleanupExecutorDeps["prisma"];
@@ -322,6 +315,70 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		expect(result.ctx.plexEpisodeMap?.get(42)).toMatchObject({ total: 1, watched: 1 });
 		expect(result.ctx.plexEpisodeMap?.get(84)).toMatchObject({ total: 1, watched: 0 });
 		expect(episodeGroupBy).toHaveBeenCalledTimes(4);
+	});
+
+	it("ignores episode rows orphaned from the current eligible Plex inventory", async () => {
+		const instance = {
+			id: "plex-inst-1",
+			updatedAt: new Date(0),
+			service: "PLEX",
+			enabled: true,
+			baseUrl: "http://plex.internal:32400",
+			encryptedApiKey: "encrypted-token",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			label: null,
+		};
+		const completedAt = new Date();
+		const normalStatus = completeStatus(instance.id, completedAt, 1);
+		const episodeStatus = completeStatus(instance.id, completedAt, 1);
+		const episodeGroupBy = vi
+			.fn()
+			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]);
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: {
+				findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+					Promise.resolve([where.cacheType === "plex_episode" ? episodeStatus : normalStatus]),
+				),
+			},
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: vi.fn().mockResolvedValue([{ instanceId: instance.id, tmdbId: 42 }]),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+					]),
+			},
+			plexEpisodeCache: {
+				findMany: vi.fn(() => {
+					throw new Error("orphan rows must not be materialized for validation");
+				}),
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: episodeGroupBy,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await buildPlexEvalContextWithHealth(
+			{ prisma, log } as CleanupExecutorDeps,
+			"user-1",
+			[plexCleanupRule("plex_episode_completion")],
+		);
+
+		expect(result.failedSources).not.toContain("plex");
+		expect(result.ctx.plexEpisodeMap?.get(42)).toMatchObject({ total: 1, watched: 1 });
+		expect(result.ctx.plexEpisodeMap?.has(84)).toBe(false);
+		for (const call of episodeGroupBy.mock.calls) {
+			const where = JSON.stringify(call[0]?.where);
+			expect(where).toContain(`"instanceId":"${instance.id}"`);
+			expect(where).toContain('"showTmdbId":{"in":[42]}');
+			expect(where).not.toContain("84");
+		}
 	});
 
 	it.each(["generation", "row"] as const)(
@@ -357,6 +414,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 				},
 				plexCache: {
 					count: vi.fn().mockResolvedValue(1),
+					groupBy: vi.fn().mockResolvedValue([{ instanceId: instance.id, tmdbId: 42 }]),
 					findMany: vi
 						.fn()
 						.mockResolvedValue([
@@ -364,14 +422,13 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 						]),
 				},
 				plexEpisodeCache: {
-					findMany: vi.fn().mockResolvedValue([
-						{
-							instanceId: instance.id,
-							showTmdbId: 42,
-							refreshedAt: futureTarget === "row" ? futureAt : completedAt,
-							sourceFingerprint: plexConnectionFingerprint(instance as never),
-						},
-					]),
+					findMany: vi.fn(() => {
+						throw new Error("episode evidence validation must stay database-bounded");
+					}),
+					count: vi
+						.fn()
+						.mockResolvedValueOnce(1)
+						.mockResolvedValueOnce(futureTarget === "row" ? 0 : 1),
 					groupBy: episodeGroupBy,
 				},
 			} as unknown as CleanupExecutorDeps["prisma"];
@@ -387,6 +444,69 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 			expect(episodeGroupBy).not.toHaveBeenCalled();
 		},
 	);
+
+	it("rejects episode aggregates interleaved with a newer cache generation", async () => {
+		const instance = {
+			id: "plex-inst-1",
+			updatedAt: new Date(0),
+			service: "PLEX",
+			enabled: true,
+			baseUrl: "http://plex.internal:32400",
+			encryptedApiKey: "encrypted-token",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			label: null,
+		};
+		const completedAt = new Date();
+		const normalStatus = completeStatus(instance.id, completedAt, 1);
+		const episodeStatus = completeStatus(instance.id, completedAt, 1);
+		let episodeStatusReads = 0;
+		const episodeGroupBy = vi
+			.fn()
+			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 100 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 100 } }])
+			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]);
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: {
+				findMany: vi.fn(({ where }: { where: { cacheType: string } }) => {
+					if (where.cacheType !== "plex_episode") return Promise.resolve([normalStatus]);
+					episodeStatusReads += 1;
+					return Promise.resolve([
+						episodeStatusReads === 1
+							? episodeStatus
+							: { ...episodeStatus, generationId: "generation-plex-inst-2" },
+					]);
+				}),
+			},
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: vi.fn().mockResolvedValue([{ instanceId: instance.id, tmdbId: 42 }]),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+					]),
+			},
+			plexEpisodeCache: {
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: episodeGroupBy,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const result = await buildPlexEvalContextWithHealth(
+			{ prisma, log } as CleanupExecutorDeps,
+			"user-1",
+			[plexCleanupRule("plex_episode_completion")],
+		);
+
+		expect(episodeGroupBy).toHaveBeenCalledTimes(4);
+		expect(episodeStatusReads).toBe(2);
+		expect(result.ctx.plexEpisodeMap).toBeUndefined();
+		expect(result.failedSources).toContain("plex");
+	});
 
 	it("rejects an interleaved map/section generation", async () => {
 		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -220,6 +220,65 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		},
 	);
 
+	it("withholds episode evidence when the normal Plex inventory is rejected", async () => {
+		const instance = {
+			id: "plex-inst-1",
+			updatedAt: new Date(0),
+			service: "PLEX",
+			enabled: true,
+			baseUrl: "http://plex.internal:32400",
+			encryptedApiKey: "encrypted-token",
+			encryptionIv: "iv",
+			encryptedHttpAuthCredentials: null,
+			httpAuthEncryptionIv: null,
+			label: null,
+		};
+		const completedAt = new Date();
+		const rejectedNormalStatus = {
+			...completeStatus(instance.id, completedAt, 2),
+			generationId: "normal-generation",
+		};
+		const episodeStatus = {
+			...completeStatus(instance.id, completedAt, 1),
+			generationId: "episode-generation",
+		};
+		const prisma = {
+			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+			cacheRefreshStatus: {
+				findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+					Promise.resolve([
+						where.cacheType === "plex_episode" ? episodeStatus : rejectedNormalStatus,
+					]),
+				),
+			},
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: vi.fn().mockResolvedValue([{ instanceId: instance.id, tmdbId: 42 }]),
+				findMany: vi
+					.fn()
+					.mockResolvedValue([
+						makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+					]),
+			},
+			plexEpisodeCache: {
+				count: vi.fn().mockResolvedValue(1),
+				groupBy: vi
+					.fn()
+					.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+					.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+					.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }])
+					.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]),
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		const ctx = await buildEvalContext({ prisma, log } as CleanupExecutorDeps, "user-1", [
+			plexCleanupRule("plex_episode_completion"),
+		]);
+
+		expect(ctx.plexMap).toBeUndefined();
+		expect(ctx.plexEpisodeMap).toBeUndefined();
+	});
+
 	it("keeps a complete Plex generation available for cleanup evaluation", async () => {
 		const completedAt = new Date();
 		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };
@@ -377,7 +436,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 			const where = JSON.stringify(call[0]?.where);
 			expect(where).toContain(`"instanceId":"${instance.id}"`);
 			expect(where).toContain('"showTmdbId":{"in":[42]}');
-			expect(where).not.toContain("84");
+			expect(where).not.toContain('"showTmdbId":{"in":[84]}');
 		}
 	});
 

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -248,7 +248,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		);
 	});
 
-	it("blocks Plex episode cleanup when the episode cache row count mismatches", async () => {
+	it("keeps fresh retained episode rows from earlier incremental refreshes", async () => {
 		const instance = {
 			id: "plex-inst-1",
 			updatedAt: new Date(0),
@@ -263,7 +263,20 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		};
 		const completedAt = new Date();
 		const normalStatus = completeStatus(instance.id, completedAt, 1);
-		const episodeStatus = completeStatus(instance.id, completedAt, 2);
+		const retainedAt = new Date(completedAt.getTime() - 6 * 60 * 60 * 1000);
+		const episodeStatus = completeStatus(instance.id, completedAt, 1);
+		const episodeGroupBy = vi
+			.fn()
+			.mockResolvedValueOnce([
+				{ showTmdbId: 42, _count: { id: 1 } },
+				{ showTmdbId: 84, _count: { id: 1 } },
+			])
+			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+			.mockResolvedValueOnce([
+				{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } },
+				{ showTmdbId: 84, seasonNumber: 1, _count: { id: 1 } },
+			])
+			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]);
 		const prisma = {
 			serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
 			cacheRefreshStatus: {
@@ -283,11 +296,18 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 				findMany: vi.fn().mockResolvedValue([
 					{
 						instanceId: instance.id,
+						showTmdbId: 42,
 						refreshedAt: completedAt,
 						sourceFingerprint: plexConnectionFingerprint(instance as never),
 					},
+					{
+						instanceId: instance.id,
+						showTmdbId: 84,
+						refreshedAt: retainedAt,
+						sourceFingerprint: plexConnectionFingerprint(instance as never),
+					},
 				]),
-				groupBy: vi.fn().mockResolvedValue([]),
+				groupBy: episodeGroupBy,
 			},
 		} as unknown as CleanupExecutorDeps["prisma"];
 
@@ -297,17 +317,10 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 			[plexCleanupRule("plex_episode_completion")],
 		);
 
-		expect(result.ctx.plexEpisodeMap).toBeUndefined();
-		expect(result.failedSources).toContain("plex");
-		expect(
-			evaluateItemAgainstRules(
-				plexDecisionItem,
-				[plexCleanupRule("plex_episode_completion")],
-				"SONARR",
-				result.ctx,
-				result.failedSources,
-			),
-		).toBeNull();
+		expect(result.failedSources).not.toContain("plex");
+		expect(result.ctx.plexEpisodeMap?.get(42)).toMatchObject({ total: 1, watched: 1 });
+		expect(result.ctx.plexEpisodeMap?.get(84)).toMatchObject({ total: 1, watched: 0 });
+		expect(episodeGroupBy).toHaveBeenCalledTimes(4);
 	});
 
 	it("rejects an interleaved map/section generation", async () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -93,6 +93,7 @@ function completeStatus(instanceId: string, completedAt = new Date(), itemCount 
 		generationId: `generation-${instanceId}`,
 		generationMetadata: JSON.stringify({
 			sections: [{ key: "1", title: "Movies", type: "movie" }],
+			parentGenerationId: `generation-${instanceId}`,
 		}),
 		lastErrorMessage: null,
 		lastAttemptResult: "success",
@@ -327,8 +328,8 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		const episodeGroupBy = vi
 			.fn()
 			.mockResolvedValueOnce([
-				{ showTmdbId: 42, _count: { id: 1 } },
-				{ showTmdbId: 84, _count: { id: 1 } },
+				{ instanceId: instance.id, showTmdbId: 42, _count: { id: 1 } },
+				{ instanceId: instance.id, showTmdbId: 84, _count: { id: 1 } },
 			])
 			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
 			.mockResolvedValueOnce([
@@ -394,7 +395,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		const episodeStatus = completeStatus(instance.id, completedAt, 1);
 		const episodeGroupBy = vi
 			.fn()
-			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
+			.mockResolvedValueOnce([{ instanceId: instance.id, showTmdbId: 42, _count: { id: 1 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]);
@@ -523,7 +524,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		let episodeStatusReads = 0;
 		const episodeGroupBy = vi
 			.fn()
-			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 100 } }])
+			.mockResolvedValueOnce([{ instanceId: instance.id, showTmdbId: 42, _count: { id: 100 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, _count: { id: 1 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 100 } }])
 			.mockResolvedValueOnce([{ showTmdbId: 42, seasonNumber: 1, _count: { id: 1 } }]);
@@ -566,6 +567,81 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 		expect(result.ctx.plexEpisodeMap).toBeUndefined();
 		expect(result.failedSources).toContain("plex");
 	});
+
+	it.each(["missing coverage", "parent mismatch"] as const)(
+		"rejects Plex episode evidence with %s",
+		async (failure) => {
+			const instance = {
+				id: "plex-inst-1",
+				updatedAt: new Date(0),
+				service: "PLEX",
+				enabled: true,
+				baseUrl: "http://plex.internal:32400",
+				encryptedApiKey: "encrypted-token",
+				encryptionIv: "iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+				label: null,
+			};
+			const completedAt = new Date();
+			const normalStatus = completeStatus(instance.id, completedAt, 1);
+			const episodeStatus = {
+				...completeStatus(instance.id, completedAt, 1),
+				generationId: "episode-generation",
+				generationMetadata: JSON.stringify({
+					parentGenerationId:
+						failure === "parent mismatch" ? "old-plex-generation" : normalStatus.generationId,
+				}),
+			};
+			const episodeGroupBy = vi
+				.fn()
+				.mockResolvedValueOnce(
+					failure === "missing coverage"
+						? [{ instanceId: instance.id, showTmdbId: 42, _count: { id: 1 } }]
+						: [],
+				);
+			const prisma = {
+				serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) },
+				cacheRefreshStatus: {
+					findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+						Promise.resolve([where.cacheType === "plex_episode" ? episodeStatus : normalStatus]),
+					),
+				},
+				plexCache: {
+					count: vi.fn().mockResolvedValue(1),
+					groupBy: vi.fn().mockResolvedValue(
+						failure === "missing coverage"
+							? [
+									{ instanceId: instance.id, tmdbId: 42 },
+									{ instanceId: instance.id, tmdbId: 84 },
+								]
+							: [{ instanceId: instance.id, tmdbId: 42 }],
+					),
+					findMany: vi
+						.fn()
+						.mockResolvedValue([
+							makePlexRow({ id: "row-1", tmdbId: 42, mediaType: "series", sectionId: "1" }),
+						]),
+				},
+				plexEpisodeCache: {
+					count: vi.fn().mockResolvedValue(failure === "missing coverage" ? 1 : 0),
+					groupBy: episodeGroupBy,
+				},
+			} as unknown as CleanupExecutorDeps["prisma"];
+
+			const ctx = await buildEvalContext({ prisma, log } as CleanupExecutorDeps, "user-1", [
+				plexCleanupRule("plex_episode_completion"),
+			]);
+
+			expect(ctx.plexMap).toBeDefined();
+			expect(ctx.plexEpisodeMap).toBeUndefined();
+			if (failure === "missing coverage") {
+				expect(episodeGroupBy).toHaveBeenCalledOnce();
+			} else {
+				expect(episodeGroupBy).not.toHaveBeenCalled();
+			}
+		},
+	);
 
 	it("rejects an interleaved map/section generation", async () => {
 		const instance = { id: "plex-inst-1", updatedAt: new Date(0) };

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -209,6 +209,11 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 
 			expect(result.ctx.plexMap).toBeUndefined();
 			expect(result.failedSources).toContain("plex");
+			await expect(
+				buildEvalContext({ prisma, log } as CleanupExecutorDeps, "user-1", [rule], {
+					requireAvailableEvidence: true,
+				}),
+			).rejects.toThrow(/required evaluation evidence is unavailable: plex/i);
 			expect(
 				evaluateItemAgainstRules(
 					plexDecisionItem,

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2176,6 +2176,81 @@ describe("shared Plex deletion safety", () => {
 		expect(fixture.deleteMovie).not.toHaveBeenCalled();
 	});
 
+	it("reports Plex unavailable when episode-completion evidence fails", async () => {
+		const fixture = makeDeps();
+		Object.assign(fixture.plexInstance, {
+			enabled: true,
+			updatedAt: new Date(0),
+		});
+		const config = dryRunConfig();
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			rules: [
+				{
+					...config.rules[0]!,
+					name: "Retain incomplete series",
+					ruleType: "plex_episode_completion",
+					parameters: JSON.stringify({ operator: "less_than", percentage: 100 }),
+					retentionMode: true,
+				},
+			],
+		} as never);
+		const completedAt = new Date();
+		const normalStatus = {
+			instanceId: fixture.plexInstance.id,
+			lastRefreshedAt: completedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			itemCount: 1,
+			generationId: "plex-generation-1",
+			generationMetadata: JSON.stringify({
+				sections: [{ key: "1", title: "TV Shows", type: "show" }],
+			}),
+		};
+		Object.assign(fixture.deps.prisma, {
+			cacheRefreshStatus: {
+				findMany: vi.fn(({ where }: { where: { cacheType: string } }) =>
+					Promise.resolve(
+						where.cacheType === "plex_episode"
+							? [{ ...normalStatus, lastResult: "error", lastErrorMessage: "refresh failed" }]
+							: [normalStatus],
+					),
+				),
+			},
+			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([
+					{
+						id: "plex-cache-1",
+						tmdbId: 42,
+						mediaType: "series",
+						sectionId: "1",
+						sectionTitle: "TV Shows",
+						lastWatchedAt: null,
+						watchCount: 0,
+						watchedByUsers: "[]",
+						onDeck: false,
+						userRating: null,
+						collections: "[]",
+						labels: "[]",
+						addedAt: null,
+					},
+				]),
+			},
+			plexEpisodeCache: {
+				findMany: vi.fn().mockResolvedValue([]),
+				groupBy: vi.fn().mockResolvedValue([]),
+			},
+		});
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result.prefetchHealth).toMatchObject({ plex: "failed" });
+		expect(result.warnings).toContainEqual(expect.stringContaining("plex data unavailable"));
+	});
+
 	it("does not count a rule match twice when a durable retry already represents its target", async () => {
 		const { deps } = makeDeps({ mediaPartCount: 1 });
 		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -718,6 +718,82 @@ function dryRunConfig(maxRemovalsPerRun = 10) {
 	};
 }
 
+function plexPolicyCleanupConfig(options: {
+	ruleType: "plex_last_watched" | "plex_watch_count";
+	parameters: Record<string, unknown>;
+	plexLibraryFilter?: string[];
+}) {
+	const config = dryRunConfig();
+	return {
+		...config,
+		rules: [
+			{
+				...config.rules[0]!,
+				name: "Plex policy",
+				ruleType: options.ruleType,
+				parameters: JSON.stringify(options.parameters),
+				plexLibraryFilter: options.plexLibraryFilter
+					? JSON.stringify(options.plexLibraryFilter)
+					: null,
+			},
+		],
+	};
+}
+
+function configurePublishedPlexEvidence(
+	fixture: ReturnType<typeof makeDeps>,
+	options: { itemCount: number; rowCount: number; sectionTitles?: string[] },
+) {
+	const completedAt = new Date();
+	Object.assign(fixture.plexInstance, {
+		enabled: true,
+		updatedAt: new Date(0),
+	});
+	Object.assign(fixture.deps.prisma, {
+		cacheRefreshStatus: {
+			findMany: vi.fn().mockResolvedValue([
+				{
+					instanceId: fixture.plexInstance.id,
+					lastRefreshedAt: completedAt,
+					lastResult: "success",
+					lastErrorMessage: null,
+					lastAttemptResult: "success",
+					lastAttemptErrorMessage: null,
+					itemCount: options.itemCount,
+					generationId: "plex-generation-1",
+					generationMetadata: JSON.stringify({
+						sections: (options.sectionTitles ?? ["Movies"]).map((title, index) => ({
+							key: String(index + 1),
+							title,
+							type: "movie",
+						})),
+					}),
+				},
+			]),
+		},
+		plexCache: {
+			count: vi.fn().mockResolvedValue(options.rowCount),
+			findMany: vi.fn().mockResolvedValue([
+				{
+					id: "plex-cache-1",
+					tmdbId: 42,
+					mediaType: "movie",
+					sectionId: "1",
+					sectionTitle: "Movies",
+					lastWatchedAt: null,
+					watchCount: 0,
+					watchedByUsers: "[]",
+					onDeck: false,
+					userRating: null,
+					collections: "[]",
+					labels: "[]",
+					addedAt: new Date("2026-01-01T00:00:00.000Z"),
+				},
+			]),
+		},
+	});
+}
+
 function matchingDryRunCacheItem(overrides: Record<string, unknown> = {}) {
 	return {
 		id: "cache-fresh",
@@ -2049,6 +2125,55 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
 		expect(targetClient.movie.update).not.toHaveBeenCalled();
+	});
+
+	it("does not preview a filtered Plex rule when the configured section is unavailable", async () => {
+		const fixture = makeDeps();
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			plexPolicyCleanupConfig({
+				ruleType: "plex_last_watched",
+				parameters: { operator: "never" },
+				plexLibraryFilter: ["Missing Library"],
+			}) as never,
+		);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem(),
+		] as never);
+		configurePublishedPlexEvidence(fixture, { itemCount: 1, rowCount: 1 });
+
+		const result = await executeCleanupPreview(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({
+			itemsEvaluated: 1,
+			itemsFlagged: 0,
+			prefetchHealth: { plex: "failed" },
+		});
+		expect(result.warnings).toContainEqual(expect.stringContaining("plex data unavailable"));
+	});
+
+	it("does not select a Plex cleanup candidate when the published row count mismatches", async () => {
+		const fixture = makeDeps();
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			plexPolicyCleanupConfig({
+				ruleType: "plex_watch_count",
+				parameters: { operator: "less_than", count: 1 },
+			}) as never,
+		);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem(),
+		] as never);
+		configurePublishedPlexEvidence(fixture, { itemCount: 2, rowCount: 1 });
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({
+			isDryRun: true,
+			itemsEvaluated: 1,
+			itemsFlagged: 0,
+			prefetchHealth: { plex: "failed" },
+		});
+		expect(fixture.targetClient.movie.update).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
 	});
 
 	it("does not count a rule match twice when a durable retry already represents its target", async () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -373,7 +373,25 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 				}),
 			},
 			plexCache: {
+				count: vi.fn().mockResolvedValue(1),
 				findMany: vi.fn().mockResolvedValue([]),
+			},
+			cacheRefreshStatus: {
+				findMany: vi.fn().mockResolvedValue([
+					{
+						instanceId: plexInstance.id,
+						lastRefreshedAt: new Date(),
+						lastResult: "success",
+						lastErrorMessage: null,
+						lastAttemptResult: "success",
+						lastAttemptErrorMessage: null,
+						itemCount: 1,
+						generationId: "plex-generation-1",
+						generationMetadata: JSON.stringify({
+							sections: [{ key: "tv", title: "TV", type: "show" }],
+						}),
+					},
+				]),
 			},
 			tmdbListCache: {
 				findMany: vi.fn().mockResolvedValue([]),

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -618,6 +618,35 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 	});
 
+	it("blocks future-dated episode evidence at the mutation boundary", async () => {
+		const fixture = makeSonarrDeps();
+		const futureAt = new Date(Date.now() + 60 * 1000);
+		vi.mocked(fixture.deps.prisma.plexEpisodeCache.findMany).mockResolvedValue([
+			{
+				instanceId: fixture.plexInstance.id,
+				ratingKey: "episode-1",
+				watchCount: 1,
+				refreshedAt: futureAt,
+				sourceFingerprint: PLEX_SOURCE_FINGERPRINT,
+			},
+		] as never);
+		vi.mocked(fixture.deps.prisma.plexEpisodeCache.findFirst).mockResolvedValue({
+			watchCount: 1,
+			refreshedAt: futureAt,
+			sourceFingerprint: PLEX_SOURCE_FINGERPRINT,
+		} as never);
+		const episodeTarget = exactEpisodeTarget();
+
+		const blocks = await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget]);
+
+		expect(blocks.get(cleanupDeleteTargetKey(episodeTarget))).toContain(
+			"watched Plex episode could not be mapped",
+		);
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
 	it("blocks episode evidence whose Plex rating key resolves to another physical copy", async () => {
 		const fixture = makeSonarrDeps({
 			plexSeries: [
@@ -2403,6 +2432,43 @@ describe("verified Sonarr mutation handoff", () => {
 			matchedRuleId: "episode-rule",
 			matchedRuleName: "Remove watched episodes",
 			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({ status: "expired" });
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("expires an episode approval whose watch proof is future-dated", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const futurePlan = {
+			...plan,
+			watchProof: {
+				...plan.watchProof,
+				refreshedAt: new Date(Date.now() + 60 * 1000).toISOString(),
+			},
+		};
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(futurePlan),
 		} as unknown as Record<string, unknown>;
 		configureApprovalStore(fixture.deps, storedApproval);
 

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -52,11 +52,6 @@ import {
 	isSupportedEpisodeCleanupRule,
 	toEpisodeTargetMetadata,
 } from "./episode-scope.js";
-import {
-	prepareMediaServerRescans,
-	rescanMediaType,
-	triggerCoalescedMediaServerRescans,
-} from "./media-server-rescan.js";
 import { applyQuiSeedingFilter, isQuiSeedingState } from "./qui-filter.js";
 import {
 	evaluateSingleCondition,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -124,7 +124,6 @@ async function loadCompleteCacheGenerations(
 	deps: CleanupExecutorDeps,
 	instances: Array<{ id: string; updatedAt: Date }>,
 	cacheType: string,
-	now: Date = new Date(),
 ): Promise<Map<string, { completedAt: Date; itemCount: number }> | undefined> {
 	if (instances.length === 0) return undefined;
 	const statuses = await deps.prisma.cacheRefreshStatus.findMany({
@@ -140,7 +139,8 @@ async function loadCompleteCacheGenerations(
 		},
 	});
 	const byInstance = new Map(statuses.map((status) => [status.instanceId, status]));
-	const freshnessThreshold = now.getTime() - PROVIDER_EVIDENCE_FRESHNESS_MS;
+	const nowMs = Date.now();
+	const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
 	const generations = new Map<string, { completedAt: Date; itemCount: number }>();
 	for (const instance of instances) {
 		const status = byInstance.get(instance.id);
@@ -149,6 +149,7 @@ async function loadCompleteCacheGenerations(
 			status.lastErrorMessage != null ||
 			status.lastAttemptErrorMessage != null ||
 			(status.lastAttemptResult != null && status.lastAttemptResult !== "success") ||
+			status.lastRefreshedAt.getTime() > nowMs ||
 			status.lastRefreshedAt.getTime() < freshnessThreshold ||
 			status.lastRefreshedAt.getTime() < instance.updatedAt.getTime()
 		) {
@@ -2551,10 +2552,17 @@ async function executeQueuedCleanupItems(
 				sharedPlexBlock =
 					"Skipped for safety: the ARR target identity changed after this cleanup item was queued. Run cleanup again and review a new approval.";
 			}
+			const approvedEpisodeRefreshTime =
+				approvedPlan?.kind === "verified_sonarr_episode"
+					? Date.parse(approvedPlan.watchProof.refreshedAt)
+					: null;
 			if (
 				approvedPlan?.kind === "verified_sonarr_episode" &&
 				!recoveringInterruptedMutation &&
-				Date.parse(approvedPlan.watchProof.refreshedAt) < now.getTime() - PLEX_EPISODE_FRESHNESS_MS
+				(approvedEpisodeRefreshTime === null ||
+					!Number.isFinite(approvedEpisodeRefreshTime) ||
+					approvedEpisodeRefreshTime > now.getTime() ||
+					approvedEpisodeRefreshTime < now.getTime() - PLEX_EPISODE_FRESHNESS_MS)
 			) {
 				approvalIdentityChanged = true;
 				sharedPlexBlock =
@@ -3562,6 +3570,7 @@ async function loadPublishedPlexPolicyEvidence(
 				},
 			});
 		const before = await readStatuses();
+		const nowMs = Date.now();
 		if (
 			before.length !== instances.length ||
 			before.some((status) => {
@@ -3574,7 +3583,8 @@ async function loadPublishedPlexPolicyEvidence(
 					(status.lastAttemptResult != null && status.lastAttemptResult !== "success") ||
 					!status.generationId ||
 					!status.generationMetadata ||
-					Date.now() - status.lastRefreshedAt.getTime() > PROVIDER_EVIDENCE_FRESHNESS_MS ||
+					status.lastRefreshedAt.getTime() > nowMs ||
+					nowMs - status.lastRefreshedAt.getTime() > PROVIDER_EVIDENCE_FRESHNESS_MS ||
 					status.lastRefreshedAt.getTime() < instance.updatedAt.getTime()
 				);
 			})
@@ -3834,7 +3844,8 @@ async function prefetchPlexEpisodeData(
 			where: { instanceId: { in: instanceIds } },
 			select: { instanceId: true, refreshedAt: true, sourceFingerprint: true },
 		});
-		const freshnessThreshold = Date.now() - PROVIDER_EVIDENCE_FRESHNESS_MS;
+		const nowMs = Date.now();
+		const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
 		for (const row of generationRows) {
 			const generation = generations.get(row.instanceId);
 			const instance = instances.find((candidate) => candidate.id === row.instanceId);
@@ -4538,7 +4549,12 @@ async function evaluateAllItems(
 	// Build prefetch health status
 	const prefetchHealth: PrefetchResults = {
 		seerr: hasSeerrRules ? (seerrMap ? "ok" : "failed") : "skipped",
-		plex: hasPlexRules || needsPlexSectionInventory ? (plexEvidence ? "ok" : "failed") : "skipped",
+		plex:
+			hasPlexRules || needsPlexSectionInventory
+				? plexEvidence && (!hasEpisodeRules || plexEpisodeMap)
+					? "ok"
+					: "failed"
+				: "skipped",
 		jellyfin: hasJellyfinRules ? (jellyfinMap ? "ok" : "failed") : "skipped",
 	};
 
@@ -4785,6 +4801,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 				!Number.isFinite(sourceUpdatedAt) ||
 				!sourceFingerprint ||
 				row.sourceFingerprint !== sourceFingerprint ||
+				row.refreshedAt.getTime() > now.getTime() ||
 				row.refreshedAt.getTime() < freshnessThreshold ||
 				row.refreshedAt.getTime() < sourceUpdatedAt
 			) {

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -4496,8 +4496,12 @@ async function evaluateAllItems(
 		"seerr_requester_not_watched",
 	];
 	const hasPlexRules = PLEX_RULE_TYPES.some((t) => activeTypes.has(t));
-	const plexResult = hasPlexRules ? await prefetchPlexData(deps, config.userId) : undefined;
-	const plexMap = hasPlexRules ? plexResult : undefined;
+	const needsPlexSectionInventory = collectConfiguredPlexSectionTitles(rules).size > 0;
+	const plexEvidence =
+		hasPlexRules || needsPlexSectionInventory
+			? await loadPublishedPlexPolicyEvidence(deps, config.userId, rules)
+			: undefined;
+	const plexMap = hasPlexRules ? plexEvidence?.plexMap : undefined;
 
 	// Prefetch Jellyfin watch data if any Jellyfin rule types are active
 	const JELLYFIN_RULE_TYPES = [
@@ -4539,7 +4543,7 @@ async function evaluateAllItems(
 	// Build prefetch health status
 	const prefetchHealth: PrefetchResults = {
 		seerr: hasSeerrRules ? (seerrMap ? "ok" : "failed") : "skipped",
-		plex: hasPlexRules ? (plexMap ? "ok" : "failed") : "skipped",
+		plex: hasPlexRules || needsPlexSectionInventory ? (plexEvidence ? "ok" : "failed") : "skipped",
 		jellyfin: hasJellyfinRules ? (jellyfinMap ? "ok" : "failed") : "skipped",
 	};
 
@@ -4572,6 +4576,7 @@ async function evaluateAllItems(
 		now,
 		seerrMap,
 		plexMap,
+		plexSectionTitles: plexEvidence?.plexSectionTitles,
 		plexEpisodeMap,
 		jellyfinMap,
 		jellyfinEpisodeMap,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -125,7 +125,16 @@ async function loadCompleteCacheGenerations(
 	instances: Array<{ id: string; updatedAt: Date }>,
 	cacheType: string,
 ): Promise<
-	Map<string, { completedAt: Date; itemCount: number; generationId: string | null }> | undefined
+	| Map<
+			string,
+			{
+				completedAt: Date;
+				itemCount: number;
+				generationId: string | null;
+				generationMetadata: string | null;
+			}
+	  >
+	| undefined
 > {
 	if (instances.length === 0) return undefined;
 	const statuses = await deps.prisma.cacheRefreshStatus.findMany({
@@ -139,6 +148,7 @@ async function loadCompleteCacheGenerations(
 			lastAttemptErrorMessage: true,
 			itemCount: true,
 			generationId: true,
+			generationMetadata: true,
 		},
 	});
 	const byInstance = new Map(statuses.map((status) => [status.instanceId, status]));
@@ -146,7 +156,12 @@ async function loadCompleteCacheGenerations(
 	const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
 	const generations = new Map<
 		string,
-		{ completedAt: Date; itemCount: number; generationId: string | null }
+		{
+			completedAt: Date;
+			itemCount: number;
+			generationId: string | null;
+			generationMetadata: string | null;
+		}
 	>();
 	for (const instance of instances) {
 		const status = byInstance.get(instance.id);
@@ -165,9 +180,19 @@ async function loadCompleteCacheGenerations(
 			completedAt: status.lastRefreshedAt,
 			itemCount: status.itemCount,
 			generationId: status.generationId,
+			generationMetadata: status.generationMetadata,
 		});
 	}
 	return generations;
+}
+
+function parseEpisodeParentGenerationId(metadata: string | null): string | undefined {
+	const parsed = safeJsonParse(metadata);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+	const parentGenerationId = (parsed as Record<string, unknown>).parentGenerationId;
+	return typeof parentGenerationId === "string" && parentGenerationId.length > 0
+		? parentGenerationId
+		: undefined;
 }
 
 // The route returns at most 200 preview rows; avoid live safety I/O for rows
@@ -3503,6 +3528,7 @@ export async function prefetchPlexData(
 interface PublishedPlexPolicyEvidence {
 	plexMap: PlexWatchMap;
 	plexSectionTitles: Set<string>;
+	generationIds: Map<string, string>;
 }
 
 function parsePublishedPlexSections(metadata: string | null): Array<{
@@ -3616,7 +3642,11 @@ async function loadPublishedPlexPolicyEvidence(
 		if (!plexMap) return undefined;
 		const after = await readStatuses();
 		if (JSON.stringify(before) !== JSON.stringify(after)) return undefined;
-		return { plexMap, plexSectionTitles: sectionTitles };
+		return {
+			plexMap,
+			plexSectionTitles: sectionTitles,
+			generationIds: new Map(before.map((status) => [status.instanceId, status.generationId!])),
+		};
 	} catch (error) {
 		deps.log.warn({ err: error }, "Published Plex policy evidence was unavailable");
 		return undefined;
@@ -3823,6 +3853,7 @@ async function prefetchJellyfinEpisodeData(
 async function prefetchPlexEpisodeData(
 	deps: CleanupExecutorDeps,
 	userId: string,
+	acceptedPlexGenerations: ReadonlyMap<string, string>,
 ): Promise<PlexEpisodeMap | undefined> {
 	const { prisma, log } = deps;
 
@@ -3845,8 +3876,9 @@ async function prefetchPlexEpisodeData(
 		});
 		const instanceIds = instances.map((i) => i.id);
 		if (instanceIds.length === 0) return undefined;
-		const generations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
-		if (!generations) return undefined;
+		const episodeGenerations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
+		const plexGenerations = await loadCompleteCacheGenerations(deps, instances, "plex");
+		if (!episodeGenerations || !plexGenerations) return undefined;
 		const eligibleShowRows = await prisma.plexCache.groupBy({
 			by: ["instanceId", "tmdbId"],
 			where: {
@@ -3866,10 +3898,21 @@ async function prefetchPlexEpisodeData(
 		const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
 		const currentEpisodeSources: Prisma.PlexEpisodeCacheWhereInput[] = [];
 		for (const instance of instances) {
+			const episodeGeneration = episodeGenerations.get(instance.id);
+			const plexGeneration = plexGenerations.get(instance.id);
+			const acceptedPlexGenerationId = acceptedPlexGenerations.get(instance.id);
+			if (
+				!episodeGeneration?.generationId ||
+				!plexGeneration?.generationId ||
+				!acceptedPlexGenerationId ||
+				plexGeneration.generationId !== acceptedPlexGenerationId ||
+				parseEpisodeParentGenerationId(episodeGeneration.generationMetadata) !==
+					acceptedPlexGenerationId
+			) {
+				return undefined;
+			}
 			const showTmdbIds = eligibleShowsByInstance.get(instance.id) ?? [];
 			if (showTmdbIds.length === 0) continue;
-			const generation = generations.get(instance.id);
-			if (!generation?.generationId) return undefined;
 			const sourceWhere: Prisma.PlexEpisodeCacheWhereInput = {
 				instanceId: instance.id,
 				showTmdbId: { in: showTmdbIds },
@@ -3879,7 +3922,7 @@ async function prefetchPlexEpisodeData(
 				refreshedAt: {
 					not: null,
 					gte: new Date(Math.max(freshnessThreshold, instance.updatedAt.getTime())),
-					lte: generation.completedAt,
+					lte: episodeGeneration.completedAt,
 				},
 				sourceFingerprint: plexConnectionFingerprint(instance as ServiceInstance),
 			};
@@ -3887,7 +3930,7 @@ async function prefetchPlexEpisodeData(
 			const validRows = await prisma.plexEpisodeCache.count({
 				where: validatedSourceWhere,
 			});
-			if (totalRows !== validRows) {
+			if (totalRows === 0 || totalRows !== validRows) {
 				return undefined;
 			}
 			currentEpisodeSources.push(validatedSourceWhere);
@@ -3898,11 +3941,25 @@ async function prefetchPlexEpisodeData(
 		};
 
 		// Four bounded groupBy queries: show and season totals plus their watched subsets.
-		const totalCounts = await prisma.plexEpisodeCache.groupBy({
-			by: ["showTmdbId"],
+		const sourceTotalCounts = await prisma.plexEpisodeCache.groupBy({
+			by: ["instanceId", "showTmdbId"],
 			where: currentEpisodeWhere,
 			_count: { id: true },
 		});
+		const coveredSources = new Set(
+			sourceTotalCounts.map((group) => `${group.instanceId}:${group.showTmdbId}`),
+		);
+		if (eligibleShowRows.some((row) => !coveredSources.has(`${row.instanceId}:${row.tmdbId}`))) {
+			return undefined;
+		}
+		const totalByShow = new Map<number, number>();
+		for (const group of sourceTotalCounts) {
+			totalByShow.set(group.showTmdbId, (totalByShow.get(group.showTmdbId) ?? 0) + group._count.id);
+		}
+		const totalCounts = [...totalByShow].map(([showTmdbId, count]) => ({
+			showTmdbId,
+			_count: { id: count },
+		}));
 
 		const watchedCounts = await prisma.plexEpisodeCache.groupBy({
 			by: ["showTmdbId"],
@@ -3922,18 +3979,36 @@ async function prefetchPlexEpisodeData(
 			where: { AND: [currentEpisodeWhere, { watched: true }] },
 			_count: { id: true },
 		});
-		const finalGenerations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
+		const finalEpisodeGenerations = await loadCompleteCacheGenerations(
+			deps,
+			instances,
+			"plex_episode",
+		);
+		const finalPlexGenerations = await loadCompleteCacheGenerations(deps, instances, "plex");
 		if (
-			!finalGenerations ||
+			!finalEpisodeGenerations ||
+			!finalPlexGenerations ||
 			instances.some((instance) => {
-				const before = generations.get(instance.id);
-				const after = finalGenerations.get(instance.id);
+				const beforeEpisode = episodeGenerations.get(instance.id);
+				const afterEpisode = finalEpisodeGenerations.get(instance.id);
+				const beforePlex = plexGenerations.get(instance.id);
+				const afterPlex = finalPlexGenerations.get(instance.id);
+				const acceptedPlexGenerationId = acceptedPlexGenerations.get(instance.id);
 				return (
-					!before?.generationId ||
-					!after?.generationId ||
-					before.generationId !== after.generationId ||
-					before.completedAt.getTime() !== after.completedAt.getTime() ||
-					before.itemCount !== after.itemCount
+					!beforeEpisode?.generationId ||
+					!afterEpisode?.generationId ||
+					!beforePlex?.generationId ||
+					!afterPlex?.generationId ||
+					!acceptedPlexGenerationId ||
+					beforeEpisode.generationId !== afterEpisode.generationId ||
+					beforeEpisode.completedAt.getTime() !== afterEpisode.completedAt.getTime() ||
+					beforeEpisode.itemCount !== afterEpisode.itemCount ||
+					beforePlex.generationId !== acceptedPlexGenerationId ||
+					afterPlex.generationId !== acceptedPlexGenerationId ||
+					beforePlex.completedAt.getTime() !== afterPlex.completedAt.getTime() ||
+					beforePlex.itemCount !== afterPlex.itemCount ||
+					parseEpisodeParentGenerationId(afterEpisode.generationMetadata) !==
+						acceptedPlexGenerationId
 				);
 			})
 		) {
@@ -4580,7 +4655,7 @@ async function evaluateAllItems(
 	const hasEpisodeRules = activeTypes.has("plex_episode_completion");
 	const plexEpisodeMap =
 		hasEpisodeRules && plexEvidence
-			? await prefetchPlexEpisodeData(deps, config.userId)
+			? await prefetchPlexEpisodeData(deps, config.userId, plexEvidence.generationIds)
 			: undefined;
 
 	const hasJellyfinEpisodeRules = activeTypes.has("jellyfin_episode_completion");
@@ -7275,24 +7350,24 @@ export async function buildEvalContext(
 
 	const needsPlex = PLEX_RULE_TYPES_LIST.some((type) => activeTypes.has(type));
 	const needsPlexSectionInventory = collectConfiguredPlexSectionTitles(rules).size > 0;
-	const [seerrMap, plexEvidence, prefetchedPlexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] =
-		await Promise.all([
-			SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
-				? prefetchSeerrRequests(deps, userId)
-				: undefined,
-			needsPlex || needsPlexSectionInventory
-				? loadPublishedPlexPolicyEvidence(deps, userId, rules)
-				: undefined,
-			activeTypes.has("plex_episode_completion")
-				? prefetchPlexEpisodeData(deps, userId)
-				: undefined,
-			JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t))
-				? prefetchJellyfinData(deps, userId)
-				: undefined,
-			activeTypes.has("jellyfin_episode_completion")
-				? prefetchJellyfinEpisodeData(deps, userId)
-				: undefined,
-		]);
+	const plexEvidence =
+		needsPlex || needsPlexSectionInventory
+			? await loadPublishedPlexPolicyEvidence(deps, userId, rules)
+			: undefined;
+	const [seerrMap, prefetchedPlexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] = await Promise.all([
+		SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
+			? prefetchSeerrRequests(deps, userId)
+			: undefined,
+		activeTypes.has("plex_episode_completion") && plexEvidence
+			? prefetchPlexEpisodeData(deps, userId, plexEvidence.generationIds)
+			: undefined,
+		JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t))
+			? prefetchJellyfinData(deps, userId)
+			: undefined,
+		activeTypes.has("jellyfin_episode_completion")
+			? prefetchJellyfinEpisodeData(deps, userId)
+			: undefined,
+	]);
 	const tmdbListMemberships = activeTypes.has("tmdb_list_member")
 		? await prefetchCleanupListMemberships(deps, userId, rules, "tmdb")
 		: undefined;

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -124,7 +124,9 @@ async function loadCompleteCacheGenerations(
 	deps: CleanupExecutorDeps,
 	instances: Array<{ id: string; updatedAt: Date }>,
 	cacheType: string,
-): Promise<Map<string, { completedAt: Date; itemCount: number }> | undefined> {
+): Promise<
+	Map<string, { completedAt: Date; itemCount: number; generationId: string | null }> | undefined
+> {
 	if (instances.length === 0) return undefined;
 	const statuses = await deps.prisma.cacheRefreshStatus.findMany({
 		where: { instanceId: { in: instances.map((instance) => instance.id) }, cacheType },
@@ -136,12 +138,16 @@ async function loadCompleteCacheGenerations(
 			lastAttemptResult: true,
 			lastAttemptErrorMessage: true,
 			itemCount: true,
+			generationId: true,
 		},
 	});
 	const byInstance = new Map(statuses.map((status) => [status.instanceId, status]));
 	const nowMs = Date.now();
 	const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
-	const generations = new Map<string, { completedAt: Date; itemCount: number }>();
+	const generations = new Map<
+		string,
+		{ completedAt: Date; itemCount: number; generationId: string | null }
+	>();
 	for (const instance of instances) {
 		const status = byInstance.get(instance.id);
 		if (
@@ -158,6 +164,7 @@ async function loadCompleteCacheGenerations(
 		generations.set(instance.id, {
 			completedAt: status.lastRefreshedAt,
 			itemCount: status.itemCount,
+			generationId: status.generationId,
 		});
 	}
 	return generations;
@@ -3840,53 +3847,98 @@ async function prefetchPlexEpisodeData(
 		if (instanceIds.length === 0) return undefined;
 		const generations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
 		if (!generations) return undefined;
-		const generationRows = await prisma.plexEpisodeCache.findMany({
-			where: { instanceId: { in: instanceIds } },
-			select: { instanceId: true, refreshedAt: true, sourceFingerprint: true },
+		const eligibleShowRows = await prisma.plexCache.groupBy({
+			by: ["instanceId", "tmdbId"],
+			where: {
+				instanceId: { in: instanceIds },
+				mediaType: "series",
+				ratingKey: { not: null },
+				watchCount: { gt: 0 },
+			},
 		});
+		const eligibleShowsByInstance = new Map<string, number[]>();
+		for (const row of eligibleShowRows) {
+			const showIds = eligibleShowsByInstance.get(row.instanceId) ?? [];
+			showIds.push(row.tmdbId);
+			eligibleShowsByInstance.set(row.instanceId, showIds);
+		}
 		const nowMs = Date.now();
 		const freshnessThreshold = nowMs - PROVIDER_EVIDENCE_FRESHNESS_MS;
-		for (const row of generationRows) {
-			const generation = generations.get(row.instanceId);
-			const instance = instances.find((candidate) => candidate.id === row.instanceId);
-			if (
-				!generation ||
-				!instance ||
-				row.refreshedAt === null ||
-				row.refreshedAt.getTime() > generation.completedAt.getTime() ||
-				row.refreshedAt.getTime() < freshnessThreshold ||
-				row.refreshedAt.getTime() < instance.updatedAt.getTime() ||
-				row.sourceFingerprint !== plexConnectionFingerprint(instance as ServiceInstance)
-			) {
+		const currentEpisodeSources: Prisma.PlexEpisodeCacheWhereInput[] = [];
+		for (const instance of instances) {
+			const showTmdbIds = eligibleShowsByInstance.get(instance.id) ?? [];
+			if (showTmdbIds.length === 0) continue;
+			const generation = generations.get(instance.id);
+			if (!generation?.generationId) return undefined;
+			const sourceWhere: Prisma.PlexEpisodeCacheWhereInput = {
+				instanceId: instance.id,
+				showTmdbId: { in: showTmdbIds },
+			};
+			const validatedSourceWhere: Prisma.PlexEpisodeCacheWhereInput = {
+				...sourceWhere,
+				refreshedAt: {
+					not: null,
+					gte: new Date(Math.max(freshnessThreshold, instance.updatedAt.getTime())),
+					lte: generation.completedAt,
+				},
+				sourceFingerprint: plexConnectionFingerprint(instance as ServiceInstance),
+			};
+			const totalRows = await prisma.plexEpisodeCache.count({ where: sourceWhere });
+			const validRows = await prisma.plexEpisodeCache.count({
+				where: validatedSourceWhere,
+			});
+			if (totalRows !== validRows) {
 				return undefined;
 			}
+			currentEpisodeSources.push(validatedSourceWhere);
 		}
+		if (currentEpisodeSources.length === 0) return new Map();
+		const currentEpisodeWhere: Prisma.PlexEpisodeCacheWhereInput = {
+			OR: currentEpisodeSources,
+		};
 
-		// Three groupBy queries: show-level totals, show-level watched, and per-season counts
+		// Four bounded groupBy queries: show and season totals plus their watched subsets.
 		const totalCounts = await prisma.plexEpisodeCache.groupBy({
 			by: ["showTmdbId"],
-			where: { instanceId: { in: instanceIds } },
+			where: currentEpisodeWhere,
 			_count: { id: true },
 		});
 
 		const watchedCounts = await prisma.plexEpisodeCache.groupBy({
 			by: ["showTmdbId"],
-			where: { instanceId: { in: instanceIds }, watched: true },
+			where: { AND: [currentEpisodeWhere, { watched: true }] },
 			_count: { id: true },
 		});
 
 		// Per-season counts for minSeason filtering
 		const seasonTotals = await prisma.plexEpisodeCache.groupBy({
 			by: ["showTmdbId", "seasonNumber"],
-			where: { instanceId: { in: instanceIds } },
+			where: currentEpisodeWhere,
 			_count: { id: true },
 		});
 
 		const seasonWatched = await prisma.plexEpisodeCache.groupBy({
 			by: ["showTmdbId", "seasonNumber"],
-			where: { instanceId: { in: instanceIds }, watched: true },
+			where: { AND: [currentEpisodeWhere, { watched: true }] },
 			_count: { id: true },
 		});
+		const finalGenerations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
+		if (
+			!finalGenerations ||
+			instances.some((instance) => {
+				const before = generations.get(instance.id);
+				const after = finalGenerations.get(instance.id);
+				return (
+					!before?.generationId ||
+					!after?.generationId ||
+					before.generationId !== after.generationId ||
+					before.completedAt.getTime() !== after.completedAt.getTime() ||
+					before.itemCount !== after.itemCount
+				);
+			})
+		) {
+			return undefined;
+		}
 
 		// Build per-season watched lookup: "showTmdbId:seasonNumber" → count
 		const seasonWatchedMap = new Map(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -3834,26 +3834,21 @@ async function prefetchPlexEpisodeData(
 			where: { instanceId: { in: instanceIds } },
 			select: { instanceId: true, refreshedAt: true, sourceFingerprint: true },
 		});
-		const rowCounts = new Map<string, number>();
+		const freshnessThreshold = Date.now() - PROVIDER_EVIDENCE_FRESHNESS_MS;
 		for (const row of generationRows) {
 			const generation = generations.get(row.instanceId);
 			const instance = instances.find((candidate) => candidate.id === row.instanceId);
 			if (
 				!generation ||
 				!instance ||
-				row.refreshedAt?.getTime() !== generation.completedAt.getTime() ||
+				row.refreshedAt === null ||
+				row.refreshedAt.getTime() > generation.completedAt.getTime() ||
+				row.refreshedAt.getTime() < freshnessThreshold ||
+				row.refreshedAt.getTime() < instance.updatedAt.getTime() ||
 				row.sourceFingerprint !== plexConnectionFingerprint(instance as ServiceInstance)
 			) {
 				return undefined;
 			}
-			rowCounts.set(row.instanceId, (rowCounts.get(row.instanceId) ?? 0) + 1);
-		}
-		if (
-			instances.some(
-				(instance) => (rowCounts.get(instance.id) ?? 0) !== generations.get(instance.id)!.itemCount,
-			)
-		) {
-			return undefined;
 		}
 
 		// Three groupBy queries: show-level totals, show-level watched, and per-season counts

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -52,6 +52,11 @@ import {
 	isSupportedEpisodeCleanupRule,
 	toEpisodeTargetMetadata,
 } from "./episode-scope.js";
+import {
+	prepareMediaServerRescans,
+	rescanMediaType,
+	triggerCoalescedMediaServerRescans,
+} from "./media-server-rescan.js";
 import { applyQuiSeedingFilter, isQuiSeedingState } from "./qui-filter.js";
 import {
 	evaluateSingleCondition,
@@ -118,6 +123,49 @@ const APPROVAL_EXPIRY_DAYS = 7;
 
 // Batch size for LibraryCache queries
 const CACHE_QUERY_BATCH_SIZE = 500;
+const PROVIDER_EVIDENCE_FRESHNESS_MS = 24 * 60 * 60 * 1000;
+
+async function loadCompleteCacheGenerations(
+	deps: CleanupExecutorDeps,
+	instances: Array<{ id: string; updatedAt: Date }>,
+	cacheType: string,
+	now: Date = new Date(),
+): Promise<Map<string, { completedAt: Date; itemCount: number }> | undefined> {
+	if (instances.length === 0) return undefined;
+	const statuses = await deps.prisma.cacheRefreshStatus.findMany({
+		where: { instanceId: { in: instances.map((instance) => instance.id) }, cacheType },
+		select: {
+			instanceId: true,
+			lastRefreshedAt: true,
+			lastResult: true,
+			lastErrorMessage: true,
+			lastAttemptResult: true,
+			lastAttemptErrorMessage: true,
+			itemCount: true,
+		},
+	});
+	const byInstance = new Map(statuses.map((status) => [status.instanceId, status]));
+	const freshnessThreshold = now.getTime() - PROVIDER_EVIDENCE_FRESHNESS_MS;
+	const generations = new Map<string, { completedAt: Date; itemCount: number }>();
+	for (const instance of instances) {
+		const status = byInstance.get(instance.id);
+		if (
+			status?.lastResult !== "success" ||
+			status.lastErrorMessage != null ||
+			status.lastAttemptErrorMessage != null ||
+			(status.lastAttemptResult != null && status.lastAttemptResult !== "success") ||
+			status.lastRefreshedAt.getTime() < freshnessThreshold ||
+			status.lastRefreshedAt.getTime() < instance.updatedAt.getTime()
+		) {
+			return undefined;
+		}
+		generations.set(instance.id, {
+			completedAt: status.lastRefreshedAt,
+			itemCount: status.itemCount,
+		});
+	}
+	return generations;
+}
 
 // The route returns at most 200 preview rows; avoid live safety I/O for rows
 // the caller cannot inspect.
@@ -3308,12 +3356,16 @@ export async function prefetchPlexData(
 
 	const plexInstances = await prisma.serviceInstance.findMany({
 		where: { userId, service: "PLEX", enabled: true },
-		select: { id: true },
+		orderBy: { id: "asc" },
+		select: { id: true, updatedAt: true },
 	});
 
 	if (plexInstances.length === 0) return undefined;
 
 	try {
+		if (!(await loadCompleteCacheGenerations(deps, plexInstances, "plex"))) {
+			throw new Error("Plex cache did not have a complete fresh generation for every instance");
+		}
 		const map: PlexWatchMap = new Map();
 		const instanceIds = plexInstances.map((i) => i.id);
 		let cursor: string | undefined;
@@ -3434,6 +3486,127 @@ export async function prefetchPlexData(
 			{ err: error },
 			"Failed to prefetch Plex data for cleanup — Plex rules will be skipped",
 		);
+		return undefined;
+	}
+}
+
+interface PublishedPlexPolicyEvidence {
+	plexMap: PlexWatchMap;
+	plexSectionTitles: Set<string>;
+}
+
+function parsePublishedPlexSections(metadata: string | null): Array<{
+	key: string;
+	title: string;
+	type: "movie" | "show";
+}> | null {
+	const parsed = safeJsonParse(metadata);
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
+	const sections = (parsed as Record<string, unknown>).sections;
+	if (!Array.isArray(sections)) return null;
+	const normalized: Array<{ key: string; title: string; type: "movie" | "show" }> = [];
+	for (const section of sections) {
+		if (typeof section !== "object" || section === null || Array.isArray(section)) return null;
+		const row = section as Record<string, unknown>;
+		if (
+			typeof row.key !== "string" ||
+			row.key.length === 0 ||
+			typeof row.title !== "string" ||
+			row.title.length === 0 ||
+			(row.type !== "movie" && row.type !== "show")
+		) {
+			return null;
+		}
+		normalized.push({ key: row.key, title: row.title, type: row.type });
+	}
+	return normalized;
+}
+
+function collectConfiguredPlexSectionTitles(
+	rules: Array<{ enabled: boolean; plexLibraryFilter?: string | null }>,
+): Set<string> {
+	const titles = new Set<string>();
+	for (const rule of rules) {
+		if (!rule.enabled || !rule.plexLibraryFilter) continue;
+		const configured = safeJsonParse(rule.plexLibraryFilter);
+		if (!Array.isArray(configured)) continue;
+		for (const value of configured) {
+			if (typeof value === "string" && value.length > 0) titles.add(value);
+		}
+	}
+	return titles;
+}
+
+async function loadPublishedPlexPolicyEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	rules: Array<{ enabled: boolean; plexLibraryFilter?: string | null }>,
+): Promise<PublishedPlexPolicyEvidence | undefined> {
+	try {
+		const instances = await deps.prisma.serviceInstance.findMany({
+			where: { userId, service: "PLEX", enabled: true },
+			orderBy: { id: "asc" },
+			select: { id: true, updatedAt: true },
+		});
+		if (instances.length === 0) return undefined;
+		const instanceIds = instances.map((instance) => instance.id);
+		const readStatuses = async () =>
+			await deps.prisma.cacheRefreshStatus.findMany({
+				where: { instanceId: { in: instanceIds }, cacheType: "plex" },
+				orderBy: { instanceId: "asc" },
+				select: {
+					instanceId: true,
+					lastRefreshedAt: true,
+					lastResult: true,
+					itemCount: true,
+					generationId: true,
+					generationMetadata: true,
+					lastErrorMessage: true,
+					lastAttemptResult: true,
+					lastAttemptErrorMessage: true,
+				},
+			});
+		const before = await readStatuses();
+		if (
+			before.length !== instances.length ||
+			before.some((status) => {
+				const instance = instances.find((candidate) => candidate.id === status.instanceId);
+				return (
+					!instance ||
+					status.lastResult !== "success" ||
+					status.lastErrorMessage != null ||
+					status.lastAttemptErrorMessage != null ||
+					(status.lastAttemptResult != null && status.lastAttemptResult !== "success") ||
+					!status.generationId ||
+					!status.generationMetadata ||
+					Date.now() - status.lastRefreshedAt.getTime() > PROVIDER_EVIDENCE_FRESHNESS_MS ||
+					status.lastRefreshedAt.getTime() < instance.updatedAt.getTime()
+				);
+			})
+		) {
+			return undefined;
+		}
+
+		const sectionTitles = new Set<string>();
+		for (const status of before) {
+			const sections = parsePublishedPlexSections(status.generationMetadata);
+			if (!sections || sections.length === 0) return undefined;
+			for (const section of sections) sectionTitles.add(section.title);
+			const count = await deps.prisma.plexCache.count({
+				where: { instanceId: status.instanceId },
+			});
+			if (count !== status.itemCount) return undefined;
+		}
+		for (const title of collectConfiguredPlexSectionTitles(rules)) {
+			if (!sectionTitles.has(title)) return undefined;
+		}
+		const plexMap = await prefetchPlexData(deps, userId);
+		if (!plexMap) return undefined;
+		const after = await readStatuses();
+		if (JSON.stringify(before) !== JSON.stringify(after)) return undefined;
+		return { plexMap, plexSectionTitles: sectionTitles };
+	} catch (error) {
+		deps.log.warn({ err: error }, "Published Plex policy evidence was unavailable");
 		return undefined;
 	}
 }
@@ -3644,10 +3817,49 @@ async function prefetchPlexEpisodeData(
 	try {
 		const instances = await prisma.serviceInstance.findMany({
 			where: { userId, service: "PLEX", enabled: true },
-			select: { id: true },
+			orderBy: { id: "asc" },
+			select: {
+				id: true,
+				updatedAt: true,
+				baseUrl: true,
+				encryptedApiKey: true,
+				encryptionIv: true,
+				encryptedHttpAuthCredentials: true,
+				httpAuthEncryptionIv: true,
+				service: true,
+				label: true,
+				enabled: true,
+			},
 		});
 		const instanceIds = instances.map((i) => i.id);
 		if (instanceIds.length === 0) return undefined;
+		const generations = await loadCompleteCacheGenerations(deps, instances, "plex_episode");
+		if (!generations) return undefined;
+		const generationRows = await prisma.plexEpisodeCache.findMany({
+			where: { instanceId: { in: instanceIds } },
+			select: { instanceId: true, refreshedAt: true, sourceFingerprint: true },
+		});
+		const rowCounts = new Map<string, number>();
+		for (const row of generationRows) {
+			const generation = generations.get(row.instanceId);
+			const instance = instances.find((candidate) => candidate.id === row.instanceId);
+			if (
+				!generation ||
+				!instance ||
+				row.refreshedAt?.getTime() !== generation.completedAt.getTime() ||
+				row.sourceFingerprint !== plexConnectionFingerprint(instance as ServiceInstance)
+			) {
+				return undefined;
+			}
+			rowCounts.set(row.instanceId, (rowCounts.get(row.instanceId) ?? 0) + 1);
+		}
+		if (
+			instances.some(
+				(instance) => (rowCounts.get(instance.id) ?? 0) !== generations.get(instance.id)!.itemCount,
+			)
+		) {
+			return undefined;
+		}
 
 		// Three groupBy queries: show-level totals, show-level watched, and per-season counts
 		const totalCounts = await prisma.plexEpisodeCache.groupBy({
@@ -6945,7 +7157,12 @@ async function refreshCurrentExternalRuleCaches(
 export async function buildEvalContext(
 	deps: CleanupExecutorDeps,
 	userId: string,
-	rules: Array<{ enabled: boolean; ruleType: string; conditions: string | null }>,
+	rules: Array<{
+		enabled: boolean;
+		ruleType: string;
+		conditions: string | null;
+		plexLibraryFilter?: string | null;
+	}>,
 	options: { destructiveAuthority?: boolean } = {},
 ): Promise<EvalContext> {
 	const activeTypes = collectActiveRuleTypes(rules);
@@ -6991,21 +7208,26 @@ export async function buildEvalContext(
 		"jellyfin_added_at",
 	];
 
-	const [seerrMap, plexMap, plexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] = await Promise.all([
-		SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
-			? prefetchSeerrRequests(deps, userId)
-			: undefined,
-		PLEX_RULE_TYPES_LIST.some((t) => activeTypes.has(t))
-			? prefetchPlexData(deps, userId)
-			: undefined,
-		activeTypes.has("plex_episode_completion") ? prefetchPlexEpisodeData(deps, userId) : undefined,
-		JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t))
-			? prefetchJellyfinData(deps, userId)
-			: undefined,
-		activeTypes.has("jellyfin_episode_completion")
-			? prefetchJellyfinEpisodeData(deps, userId)
-			: undefined,
-	]);
+	const needsPlex = PLEX_RULE_TYPES_LIST.some((type) => activeTypes.has(type));
+	const needsPlexSectionInventory = collectConfiguredPlexSectionTitles(rules).size > 0;
+	const [seerrMap, plexEvidence, plexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] =
+		await Promise.all([
+			SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
+				? prefetchSeerrRequests(deps, userId)
+				: undefined,
+			needsPlex || needsPlexSectionInventory
+				? loadPublishedPlexPolicyEvidence(deps, userId, rules)
+				: undefined,
+			activeTypes.has("plex_episode_completion")
+				? prefetchPlexEpisodeData(deps, userId)
+				: undefined,
+			JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t))
+				? prefetchJellyfinData(deps, userId)
+				: undefined,
+			activeTypes.has("jellyfin_episode_completion")
+				? prefetchJellyfinEpisodeData(deps, userId)
+				: undefined,
+		]);
 	const tmdbListMemberships = activeTypes.has("tmdb_list_member")
 		? await prefetchCleanupListMemberships(deps, userId, rules, "tmdb")
 		: undefined;
@@ -7016,7 +7238,8 @@ export async function buildEvalContext(
 	return {
 		now: new Date(),
 		seerrMap: seerrMap ?? undefined,
-		plexMap: plexMap ?? undefined,
+		plexMap: plexEvidence?.plexMap,
+		plexSectionTitles: plexEvidence?.plexSectionTitles,
 		plexEpisodeMap: plexEpisodeMap ?? undefined,
 		jellyfinMap: jellyfinMap ?? undefined,
 		jellyfinEpisodeMap: jellyfinEpisodeMap ?? undefined,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -195,6 +195,14 @@ function parseEpisodeParentGenerationId(metadata: string | null): string | undef
 		: undefined;
 }
 
+function parsePublishedStringArray(value: string, label: string): string[] {
+	const parsed = safeJsonParse(value);
+	if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+		throw new Error(`${label} evidence was not a string array`);
+	}
+	return parsed as string[];
+}
+
 // The route returns at most 200 preview rows; avoid live safety I/O for rows
 // the caller cannot inspect.
 const PREVIEW_SAFETY_INSPECTION_LIMIT = 200;
@@ -3405,6 +3413,7 @@ export async function prefetchPlexData(
 		const instanceIds = plexInstances.map((i) => i.id);
 		let cursor: string | undefined;
 		let totalRows = 0;
+		let invalidRows = 0;
 
 		// Cursor-paginate to bound peak heap. Project only columns the watch-map
 		// builder reads — skipping ratingKey/thumb/title and the per-row instanceId.
@@ -3438,9 +3447,9 @@ export async function prefetchPlexData(
 				try {
 					// Key is mediaType:tmdbId (aggregating across sections)
 					const key = `${row.mediaType}:${row.tmdbId}`;
-					const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
-					const collections = (safeJsonParse(row.collections) as string[]) ?? [];
-					const labels = (safeJsonParse(row.labels) as string[]) ?? [];
+					const watchedByUsers = parsePublishedStringArray(row.watchedByUsers, "Plex watched-by");
+					const collections = parsePublishedStringArray(row.collections, "Plex collection");
+					const labels = parsePublishedStringArray(row.labels, "Plex label");
 
 					const sectionInfo: PlexSectionWatchInfo = {
 						sectionId: row.sectionId,
@@ -3503,12 +3512,16 @@ export async function prefetchPlexData(
 						});
 					}
 				} catch (rowErr) {
+					invalidRows++;
 					log.warn({ err: rowErr, tmdbId: row.tmdbId }, "Skipping Plex cache row with bad data");
 				}
 			}
 
 			cursor = batch[batch.length - 1]!.id;
 			if (batch.length < CACHE_QUERY_BATCH_SIZE) break;
+		}
+		if (invalidRows > 0) {
+			throw new Error("Plex cache contained malformed policy evidence");
 		}
 
 		log.info(
@@ -3665,16 +3678,37 @@ async function prefetchJellyfinData(
 
 	const jellyfinInstances = await prisma.serviceInstance.findMany({
 		where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
-		select: { id: true },
+		orderBy: { id: "asc" },
+		select: { id: true, updatedAt: true },
 	});
 
 	if (jellyfinInstances.length === 0) return undefined;
 
 	try {
+		const before = await loadCompleteCacheGenerations(deps, jellyfinInstances, "jellyfin");
+		if (!before || [...before.values()].some((generation) => !generation.generationId)) {
+			throw new Error("Jellyfin cache did not have a complete fresh generation for every instance");
+		}
+		const generationSignature = (
+			generations: NonNullable<Awaited<ReturnType<typeof loadCompleteCacheGenerations>>>,
+		) =>
+			JSON.stringify(
+				[...generations.entries()].map(([instanceId, generation]) => [
+					instanceId,
+					generation.completedAt.toISOString(),
+					generation.itemCount,
+					generation.generationId,
+				]),
+			);
+		const expectedRows = [...before.values()].reduce(
+			(total, generation) => total + generation.itemCount,
+			0,
+		);
 		const map: JellyfinWatchMap = new Map();
 		const instanceIds = jellyfinInstances.map((i) => i.id);
 		let cursor: string | undefined;
 		let totalRows = 0;
+		let invalidRows = 0;
 
 		// Cursor-paginate. Project only columns the watch-map reader uses.
 		while (true) {
@@ -3702,7 +3736,10 @@ async function prefetchJellyfinData(
 			for (const row of batch) {
 				try {
 					const key = `${row.mediaType}:${row.tmdbId}`;
-					const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
+					const watchedByUsers = parsePublishedStringArray(
+						row.watchedByUsers,
+						"Jellyfin watched-by",
+					);
 
 					const existing = map.get(key);
 					if (existing) {
@@ -3739,6 +3776,7 @@ async function prefetchJellyfinData(
 						});
 					}
 				} catch (rowErr) {
+					invalidRows++;
 					log.warn(
 						{ err: rowErr, tmdbId: row.tmdbId },
 						"Skipping Jellyfin cache row with bad data",
@@ -3748,6 +3786,13 @@ async function prefetchJellyfinData(
 
 			cursor = batch[batch.length - 1]!.id;
 			if (batch.length < CACHE_QUERY_BATCH_SIZE) break;
+		}
+		if (invalidRows > 0 || totalRows !== expectedRows) {
+			throw new Error("Jellyfin cache rows did not match their published generation");
+		}
+		const after = await loadCompleteCacheGenerations(deps, jellyfinInstances, "jellyfin");
+		if (!after || generationSignature(after) !== generationSignature(before)) {
+			throw new Error("Jellyfin cache generation changed while evidence was being read");
 		}
 
 		log.info(
@@ -7303,7 +7348,7 @@ export async function buildEvalContext(
 		conditions: string | null;
 		plexLibraryFilter?: string | null;
 	}>,
-	options: { destructiveAuthority?: boolean } = {},
+	options: { destructiveAuthority?: boolean; requireAvailableEvidence?: boolean } = {},
 ): Promise<EvalContext> {
 	const activeTypes = collectActiveRuleTypes(rules);
 	if (options.destructiveAuthority) {
@@ -7354,19 +7399,17 @@ export async function buildEvalContext(
 		needsPlex || needsPlexSectionInventory
 			? await loadPublishedPlexPolicyEvidence(deps, userId, rules)
 			: undefined;
+	const needsSeerr = SEERR_RULE_TYPES.some((type) => activeTypes.has(type));
+	const needsPlexEpisodes = activeTypes.has("plex_episode_completion");
+	const needsJellyfin = JELLYFIN_RULE_TYPES.some((type) => activeTypes.has(type));
+	const needsJellyfinEpisodes = activeTypes.has("jellyfin_episode_completion");
 	const [seerrMap, prefetchedPlexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] = await Promise.all([
-		SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
-			? prefetchSeerrRequests(deps, userId)
-			: undefined,
-		activeTypes.has("plex_episode_completion") && plexEvidence
+		needsSeerr ? prefetchSeerrRequests(deps, userId) : undefined,
+		needsPlexEpisodes && plexEvidence
 			? prefetchPlexEpisodeData(deps, userId, plexEvidence.generationIds)
 			: undefined,
-		JELLYFIN_RULE_TYPES.some((t) => activeTypes.has(t))
-			? prefetchJellyfinData(deps, userId)
-			: undefined,
-		activeTypes.has("jellyfin_episode_completion")
-			? prefetchJellyfinEpisodeData(deps, userId)
-			: undefined,
+		needsJellyfin ? prefetchJellyfinData(deps, userId) : undefined,
+		needsJellyfinEpisodes ? prefetchJellyfinEpisodeData(deps, userId) : undefined,
 	]);
 	const tmdbListMemberships = activeTypes.has("tmdb_list_member")
 		? await prefetchCleanupListMemberships(deps, userId, rules, "tmdb")
@@ -7374,6 +7417,18 @@ export async function buildEvalContext(
 	const traktListMemberships = activeTypes.has("trakt_list_member")
 		? await prefetchCleanupListMemberships(deps, userId, rules, "trakt")
 		: undefined;
+
+	if (options.requireAvailableEvidence) {
+		const unavailable: string[] = [];
+		if (needsSeerr && !seerrMap) unavailable.push("Seerr");
+		if ((needsPlex || needsPlexSectionInventory) && !plexEvidence) unavailable.push("Plex");
+		if (needsPlexEpisodes && !prefetchedPlexEpisodeMap) unavailable.push("Plex episode");
+		if (needsJellyfin && !jellyfinMap) unavailable.push("Jellyfin/Emby");
+		if (needsJellyfinEpisodes && !jellyfinEpisodeMap) unavailable.push("Jellyfin/Emby episode");
+		if (unavailable.length > 0) {
+			throw new Error(`Required evaluation evidence is unavailable: ${unavailable.join(", ")}`);
+		}
+	}
 
 	return {
 		now: new Date(),

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -4578,9 +4578,10 @@ async function evaluateAllItems(
 
 	// Prefetch Plex episode data if episode completion rule is active
 	const hasEpisodeRules = activeTypes.has("plex_episode_completion");
-	const plexEpisodeMap = hasEpisodeRules
-		? await prefetchPlexEpisodeData(deps, config.userId)
-		: undefined;
+	const plexEpisodeMap =
+		hasEpisodeRules && plexEvidence
+			? await prefetchPlexEpisodeData(deps, config.userId)
+			: undefined;
 
 	const hasJellyfinEpisodeRules = activeTypes.has("jellyfin_episode_completion");
 	const jellyfinEpisodeMap = hasJellyfinEpisodeRules
@@ -7274,7 +7275,7 @@ export async function buildEvalContext(
 
 	const needsPlex = PLEX_RULE_TYPES_LIST.some((type) => activeTypes.has(type));
 	const needsPlexSectionInventory = collectConfiguredPlexSectionTitles(rules).size > 0;
-	const [seerrMap, plexEvidence, plexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] =
+	const [seerrMap, plexEvidence, prefetchedPlexEpisodeMap, jellyfinMap, jellyfinEpisodeMap] =
 		await Promise.all([
 			SEERR_RULE_TYPES.some((t) => activeTypes.has(t))
 				? prefetchSeerrRequests(deps, userId)
@@ -7304,7 +7305,7 @@ export async function buildEvalContext(
 		seerrMap: seerrMap ?? undefined,
 		plexMap: plexEvidence?.plexMap,
 		plexSectionTitles: plexEvidence?.plexSectionTitles,
-		plexEpisodeMap: plexEpisodeMap ?? undefined,
+		plexEpisodeMap: plexEvidence ? (prefetchedPlexEpisodeMap ?? undefined) : undefined,
 		jellyfinMap: jellyfinMap ?? undefined,
 		jellyfinEpisodeMap: jellyfinEpisodeMap ?? undefined,
 		tmdbListMemberships,

--- a/apps/api/src/lib/library-cleanup/evaluators/plex-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/evaluators/plex-evaluators.ts
@@ -91,7 +91,7 @@ export function evaluatePlexLastWatched(
 	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 
 	if (params.operator === "never") {
-		if (!watch || watch.lastWatchedAt === null) {
+		if (watch?.lastWatchedAt === null) {
 			return "Never watched (per Plex)";
 		}
 		return null;
@@ -135,6 +135,7 @@ export function evaluatePlexWatchCount(
 	if (!watch) {
 		// Not in Plex — infer 0 plays when Plex is configured and item has a file
 		if (
+			(!plexLibraryFilter || plexLibraryFilter.length === 0) &&
 			ctx.plexMap &&
 			ctx.plexMap.size > 0 &&
 			params.operator === "less_than" &&

--- a/apps/api/src/lib/library-cleanup/evaluators/plex-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/evaluators/plex-evaluators.ts
@@ -22,6 +22,7 @@ export function lookupPlexWatch(
 	item: CacheItemForEval,
 	plexMap: PlexWatchMap | undefined,
 	plexLibraryFilter?: string[] | null,
+	plexSectionTitles?: Set<string>,
 ): PlexWatchInfo | null {
 	if (!plexMap || plexMap.size === 0) return null;
 
@@ -41,6 +42,12 @@ export function lookupPlexWatch(
 
 	// If no filter, return the pre-computed aggregates (existing behavior)
 	if (!plexLibraryFilter || plexLibraryFilter.length === 0) return entry;
+	if (
+		!plexSectionTitles ||
+		plexLibraryFilter.some((sectionTitle) => !plexSectionTitles.has(sectionTitle))
+	) {
+		return null;
+	}
 
 	// Filter to matching sections only
 	const matchingSections = entry.sections.filter((s) => plexLibraryFilter.includes(s.sectionTitle));
@@ -81,7 +88,7 @@ export function evaluatePlexLastWatched(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 
 	if (params.operator === "never") {
 		if (!watch || watch.lastWatchedAt === null) {
@@ -124,7 +131,7 @@ export function evaluatePlexWatchCount(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch) {
 		// Not in Plex — infer 0 plays when Plex is configured and item has a file
 		if (
@@ -168,7 +175,7 @@ export function evaluatePlexOnDeck(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch) return null;
 	const isOnDeck = watch.onDeck;
 
@@ -191,7 +198,7 @@ export function evaluatePlexUserRating(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 
 	if (params.operator === "unrated") {
 		if (!watch || watch.userRating === null) {
@@ -228,7 +235,7 @@ export function evaluatePlexWatchedBy(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch) return null;
 	const watchedBy = watch.watchedByUsers.map((u) => u.toLowerCase());
 	const targetNames = params.userNames.map((n) => n.toLowerCase());
@@ -257,7 +264,7 @@ export function evaluatePlexCollection(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch) return null;
 	const collections = watch.collections;
 
@@ -287,7 +294,7 @@ export function evaluatePlexLabel(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch) return null;
 	const labels = watch.labels;
 
@@ -319,7 +326,7 @@ export function evaluatePlexAddedAt(
 	ctx: EvalContext,
 	plexLibraryFilter?: string[] | null,
 ): string | null {
-	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles);
 	if (!watch?.addedAt) return null;
 
 	const ageDays = (ctx.now.getTime() - watch.addedAt.getTime()) / (1000 * 60 * 60 * 24);

--- a/apps/api/src/lib/library-cleanup/phase1-features.test.ts
+++ b/apps/api/src/lib/library-cleanup/phase1-features.test.ts
@@ -355,14 +355,12 @@ describe("prefetch failure handling", () => {
 		expect(result).toBeNull();
 	});
 
-	it("no failedSources = normal evaluation", () => {
+	it("does not infer never-watched without a positive Plex witness", () => {
 		const plexRule = makeRule({
 			id: "plex-rule",
 			ruleType: "plex_last_watched",
 			parameters: JSON.stringify({ operator: "never" }),
 		});
-		// No plexMap in context, so plex_last_watched with "never" and no watch data
-		// should match (watch is null → "never" matches)
 		const result = evaluateItemAgainstRules(
 			makeCacheItem(),
 			[plexRule] as LibraryCleanupRule[],
@@ -370,7 +368,7 @@ describe("prefetch failure handling", () => {
 			ctx,
 			undefined,
 		);
-		expect(result).not.toBeNull();
+		expect(result).toBeNull();
 	});
 
 	it("does not let a filtered-out unavailable retention rule protect the item", () => {

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.test.ts
@@ -458,16 +458,14 @@ describe("plex_last_watched rule", () => {
 		expect(result).toBeNull();
 	});
 
-	it("never operator matches when no plex data exists", () => {
-		// With no plexMap at all, lookupPlexWatch returns null.
-		// The code checks `!watch || watch.lastWatchedAt === null` — null watch triggers "never".
+	it("never operator does not match when no Plex evidence exists", () => {
 		const result = evaluateSingleCondition(
 			makeCacheItem(),
 			"plex_last_watched",
 			{ operator: "never" },
 			baseCtx(), // no plexMap
 		);
-		expect(result).toBe("Never watched (per Plex)");
+		expect(result).toBeNull();
 	});
 
 	it("never operator matches item with null lastWatchedAt", () => {
@@ -756,27 +754,18 @@ describe("golden test — multi-rule priority evaluation", () => {
 		expect(result!.ruleId).toBe("r-declined"); // declined rule still matches first
 	});
 
-	it("recent high-rated item with no plex data gets no match", () => {
+	it("recent high-rated item with no Plex data gets no match", () => {
 		// No seerr data (tmdbId 99999), high rating (9.0), recently added (1 day)
 		// - r-declined: no seerr data → skip
 		// - r-low-rating: 9.0 not < 5 → skip
-		// - r-never-watched: no plex data → lookupPlexWatch returns null
-		//   "never" with null watch → "Never watched (per Plex)"... wait
-		//   Actually: watch is null (not in plexMap), so returns null for "never"
-		//   because the function only returns match when watch exists but lastWatchedAt is null
+		// - r-never-watched: no Plex row means there is no positive never-watched witness
 		const result = evaluateItemAgainstRules(
 			recentHighRated,
 			rules as LibraryCleanupRule[],
 			"RADARR",
 			ctx,
 		);
-		// plex_last_watched with "never": if watch is null (no plex entry), the function returns null
-		// (you need to be IN plex with null lastWatchedAt to match)
-		// But wait — looking at the code: `if (!watch || watch.lastWatchedAt === null)` — so null watch
-		// DOES match "never". So this will match r-never-watched.
-		expect(result).not.toBeNull();
-		expect(result!.ruleId).toBe("r-never-watched");
-		expect(result!.action).toBe("unmonitor");
+		expect(result).toBeNull();
 	});
 
 	it("protected item is excluded by title pattern in composite rule", () => {

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -565,11 +565,12 @@ function evaluateSeerrRequesterWatched(
 	seerrMap: SeerrRequestMap | undefined,
 	plexMap: PlexWatchMap | undefined,
 	plexLibraryFilter?: string[] | null,
+	plexSectionTitles?: Set<string>,
 ): string | null {
 	const requests = lookupSeerrRequests(item, seerrMap);
 	if (!requests || requests.length === 0) return null;
 
-	const watch = lookupPlexWatch(item, plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, plexMap, plexLibraryFilter, plexSectionTitles);
 	if (!watch) return null;
 
 	const watchedBy = watch.watchedByUsers.map((u) => u.toLowerCase());
@@ -595,12 +596,13 @@ function evaluateSeerrRequesterNotWatched(
 	seerrMap: SeerrRequestMap | undefined,
 	plexMap: PlexWatchMap | undefined,
 	plexLibraryFilter?: string[] | null,
+	plexSectionTitles?: Set<string>,
 ): string | null {
 	const requests = lookupSeerrRequests(item, seerrMap);
 	if (!requests || requests.length === 0) return null;
 
 	// Require Plex data — without it we can't distinguish "not watched" from "unknown"
-	const watch = lookupPlexWatch(item, plexMap, plexLibraryFilter);
+	const watch = lookupPlexWatch(item, plexMap, plexLibraryFilter, plexSectionTitles);
 	if (!watch) return null;
 
 	const watchedBy = watch.watchedByUsers.map((u) => u.toLowerCase());
@@ -1289,9 +1291,21 @@ export function evaluateSingleCondition(
 
 		// ── Phase 4: Requester-aware cross-service rules ─────────────
 		case "seerr_requester_watched":
-			return evaluateSeerrRequesterWatched(item, ctx.seerrMap, ctx.plexMap, plexLibFilter);
+			return evaluateSeerrRequesterWatched(
+				item,
+				ctx.seerrMap,
+				ctx.plexMap,
+				plexLibFilter,
+				ctx.plexSectionTitles,
+			);
 		case "seerr_requester_not_watched":
-			return evaluateSeerrRequesterNotWatched(item, ctx.seerrMap, ctx.plexMap, plexLibFilter);
+			return evaluateSeerrRequesterNotWatched(
+				item,
+				ctx.seerrMap,
+				ctx.plexMap,
+				plexLibFilter,
+				ctx.plexSectionTitles,
+			);
 
 		case "tmdb_list_member":
 			return evaluateListMembership(item, params, ctx.tmdbListMemberships, "listId", "TMDb list");

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -2828,6 +2828,7 @@ async function verifyEpisodePlexWatchProof(
 			row.refreshedAt === null ||
 			row.sourceFingerprint !== sourceFingerprint ||
 			!Number.isFinite(sourceUpdatedAt) ||
+			row.refreshedAt.getTime() > Date.now() ||
 			row.refreshedAt.getTime() < Date.now() - 24 * 60 * 60 * 1000 ||
 			row.refreshedAt.getTime() < sourceUpdatedAt!
 		) {
@@ -2987,7 +2988,13 @@ async function verifyEpisodePlexWatchProof(
 		const plexUpdatedAt = plexInstance.updatedAt.getTime();
 		const currentPlexFingerprint = plexEvidenceSourceFingerprint(plexInstance);
 		if (evidence.sourceFingerprint !== currentPlexFingerprint) continue;
-		if (!Number.isFinite(plexUpdatedAt) || approvedRefreshedAt.getTime() < plexUpdatedAt) continue;
+		if (
+			!Number.isFinite(plexUpdatedAt) ||
+			approvedRefreshedAt.getTime() > Date.now() ||
+			approvedRefreshedAt.getTime() < plexUpdatedAt
+		) {
+			continue;
+		}
 		const currentEvidence = await deps.prisma.plexEpisodeCache.findFirst({
 			where: {
 				instanceId: plexInstance.id,
@@ -3004,6 +3011,7 @@ async function verifyEpisodePlexWatchProof(
 			currentEvidence.refreshedAt === null ||
 			currentEvidence.sourceFingerprint !== currentPlexFingerprint ||
 			currentEvidence.watchCount < evidence.watchCount ||
+			currentEvidence.refreshedAt.getTime() > Date.now() ||
 			currentEvidence.refreshedAt.getTime() < Date.now() - 24 * 60 * 60 * 1000 ||
 			currentEvidence.refreshedAt.getTime() < plexUpdatedAt
 		) {

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -167,6 +167,8 @@ export interface EvalContext {
 	now: Date;
 	seerrMap?: SeerrRequestMap;
 	plexMap?: PlexWatchMap;
+	/** Complete, current Plex movie/show section-title inventory across enabled instances. */
+	plexSectionTitles?: Set<string>;
 	plexEpisodeMap?: PlexEpisodeMap;
 	jellyfinMap?: JellyfinWatchMap;
 	/** Reuses PlexEpisodeMap shape — same total/watched/seasons structure */

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -12,7 +12,9 @@
  * behaviour so we don't regress it.
  */
 
+import type { FastifyBaseLogger } from "fastify";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PrismaClient } from "../../prisma.js";
 import {
 	clearPlexCacheRefreshSingleFlightsForTests,
 	evictStaleRows,
@@ -21,9 +23,7 @@ import {
 	STALE_EVICTION_CHUNK_SIZE,
 } from "../plex-cache-refresher.js";
 import type { PlexClient } from "../plex-client.js";
-import type { PrismaClient } from "../../prisma.js";
 import { providerConnectionIdentity } from "../../services/provider-connection-guard.js";
-import type { FastifyBaseLogger } from "fastify";
 
 const silentLog = {
 	warn: vi.fn(),
@@ -151,6 +151,7 @@ describe("evictStaleRows", () => {
 			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
 			getLibraryItems: vi.fn().mockResolvedValue(libraryItems),
 			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 			getOnDeck: vi.fn().mockResolvedValue([]),
 		} as unknown as PlexClient;
 
@@ -241,13 +242,6 @@ describe("evictStaleRows", () => {
 	});
 
 	it("marks history evidence incomplete when Plex exceeds the cache limit", async () => {
-		const history = Array.from({ length: 5_001 }, (_, index) => ({
-			ratingKey: `history-${index}`,
-			title: `History ${index}`,
-			type: "movie",
-			viewedAt: 1_700_000_000 + index,
-			accountID: 1,
-		}));
 		const mockClient = {
 			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
 			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
@@ -259,16 +253,23 @@ describe("evictStaleRows", () => {
 					Guid: [{ id: "tmdb://123" }],
 				},
 			]),
-			getHistory: vi.fn().mockResolvedValue(history),
+			getHistory: vi
+				.fn()
+				.mockRejectedValue(new Error("Plex history exceeded the safe 100000-row limit")),
 			getOnDeck: vi.fn().mockResolvedValue([]),
 		} as unknown as PlexClient;
 		const { prisma, deleteCalls } = makeMockPrisma(["retained-1"]);
 
 		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
 
-		expect(mockClient.getHistory).toHaveBeenCalledWith({ maxResults: 5_001 });
+		expect(mockClient.getHistory).toHaveBeenCalledWith({
+			maxResults: 100_000,
+			requireComplete: true,
+		});
 		expect(result.errors).toBe(1);
-		expect(result.errorMessages).toContainEqual(expect.stringContaining("history exceeded 5000"));
+		expect(result.errorMessages).toContainEqual(
+			expect.stringContaining("history exceeded the safe 100000-row limit"),
+		);
 		expect(deleteCalls).toEqual([]);
 	});
 
@@ -330,6 +331,7 @@ function makeCompletePlexClient(): PlexClient {
 			},
 		]),
 		getHistory: vi.fn().mockResolvedValue([]),
+		verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 		getOnDeck: vi.fn().mockResolvedValue([]),
 	} as unknown as PlexClient;
 }
@@ -454,27 +456,65 @@ describe("refreshPlexCache atomic publication", () => {
 		expect(state).toEqual({ rows: [{ title: "Previous generation" }], status: "previous-success" });
 	});
 
-	it("accepts exactly 5,000 Plex history rows when the one-row probe is not filled", async () => {
-		const { prisma, state } = makeAtomicPlexPrisma();
-		const client = makeCompletePlexClient();
-		vi.mocked(client.getHistory).mockResolvedValueOnce(
-			Array.from({ length: 5_000 }, (_, index) => ({
-				ratingKey: `unmapped-${index}`,
-				title: `Unmapped ${index}`,
-				type: "other",
-				accountID: 1,
-				viewedAt: index,
-			})),
-		);
+	it.each([
+		["bounded history", "Plex history exceeded the safe 100000-row limit"],
+		["repeated page", "Plex history returned a duplicate row while paging"],
+	] as const)(
+		"rejects incomplete %s history before publishing a cache generation",
+		async (_caseName, message) => {
+			const getHistory = vi.fn().mockRejectedValue(new Error(message));
+			const cacheDelete = vi.fn();
+			const statusUpsert = vi.fn();
+			const tx = {
+				plexCache: { deleteMany: cacheDelete, createMany: vi.fn() },
+				cacheRefreshStatus: { upsert: statusUpsert },
+			};
+			const prisma = {
+				$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
+					callback(tx),
+				),
+			} as unknown as PrismaClient;
+			const client = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+				getLibraryItems: vi.fn().mockResolvedValue([]),
+				getHistory,
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
 
-		const result = await refreshPlexCache(client, prisma, "inst-1", silentLog);
+			const result = await refreshPlexCache(client, prisma, "inst-1", silentLog, undefined);
 
-		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
-		expect(client.getHistory).toHaveBeenCalledWith({ maxResults: 5001 });
-		expect(state).toEqual({
-			rows: [expect.objectContaining({ title: "The Current Movie" })],
-			status: "fresh-success",
-		});
+			expect(getHistory).toHaveBeenCalledWith({ maxResults: 100_000, requireComplete: true });
+			expect(result.complete).toBe(false);
+			expect(prisma.$transaction).not.toHaveBeenCalled();
+			expect(cacheDelete).not.toHaveBeenCalled();
+			expect(statusUpsert).not.toHaveBeenCalled();
+		},
+	);
+
+	it("keeps the previous generation when playback starts during history verification", async () => {
+		const getOnDeck = vi
+			.fn()
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([{ ratingKey: "rk-1", type: "movie" }]);
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck,
+		} as unknown as PlexClient;
+		const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+		const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages.join(" ")).toMatch(/on-deck state changed/i);
+		expect(getOnDeck).toHaveBeenCalledTimes(2);
+		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
 
 	it("keeps the previous generation when on-deck evidence is unavailable", async () => {

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -55,6 +55,31 @@ describe("PlexClient complete history authority", () => {
 		}
 	});
 
+	it("supports bounded compatibility reads when Plex omits pagination metadata", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(response({ size: 1, Metadata: [historyItem(1)] })),
+		);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({ maxResults: 200 }),
+		).resolves.toHaveLength(1);
+	});
+
+	it("rejects missing pagination metadata at the complete-history safety boundary", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(response({ size: 1, Metadata: [historyItem(1)] })),
+		);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).rejects.toThrow(/complete pagination metadata/i);
+	});
+
 	it("rejects a declared history inventory larger than the safety cap", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -116,6 +116,31 @@ describe("PlexClient complete history authority", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 
+	it("proves a metadata-light inventory that ends on the exact safety cap", async () => {
+		const history = Array.from({ length: 400 }, (_, index) => ({
+			...historyItem(index),
+			historyKey: undefined,
+		}));
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			const size = Number(url.searchParams.get("X-Plex-Container-Size") ?? "200");
+			const page = history.slice(offset, offset + size);
+			return response({ size: page.length, Metadata: page });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 400,
+				requireComplete: true,
+			}),
+		).resolves.toHaveLength(400);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
+		expect(fetchMock.mock.calls[2]?.[0].toString()).toContain("X-Plex-Container-Start=400");
+		expect(fetchMock.mock.calls[2]?.[0].toString()).toContain("X-Plex-Container-Size=1");
+	});
+
 	it("rejects a declared history inventory larger than the safety cap", async () => {
 		vi.stubGlobal(
 			"fetch",

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PlexClient } from "../plex-client.js";
+
+const log = { warn: vi.fn() } as never;
+
+function response(MediaContainer: Record<string, unknown>): Response {
+	return new Response(JSON.stringify({ MediaContainer }), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function historyItem(index: number) {
+	return {
+		historyKey: `/status/sessions/history/${index}`,
+		ratingKey: `movie-${index}`,
+		title: `Movie ${index}`,
+		type: "movie",
+		viewedAt: 1_700_000_000 + index,
+		accountID: 1,
+	};
+}
+
+describe("PlexClient complete history authority", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.clearAllMocks();
+	});
+
+	it("uses the Plex-compatible single sort key while paging complete history", async () => {
+		const history = Array.from({ length: 201 }, (_, index) => ({
+			...historyItem(index),
+			viewedAt: 1_700_000_000,
+		}));
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			if (url.searchParams.get("sort") !== "viewedAt:desc") {
+				return new Response(null, { status: 400, statusText: "Bad Request" });
+			}
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			const page = history.slice(offset, offset + 200);
+			return response({ offset, size: page.length, totalSize: history.length, Metadata: page });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).resolves.toHaveLength(201);
+		for (const [input] of fetchMock.mock.calls) {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			expect(url.searchParams.get("sort")).toBe("viewedAt:desc");
+		}
+	});
+
+	it("rejects a declared history inventory larger than the safety cap", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					response({ offset: 0, size: 1, totalSize: 100_001, Metadata: [historyItem(1)] }),
+				),
+		);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).rejects.toThrow(/exceeding the safe 100000-row limit/i);
+	});
+
+	it("rejects a repeated page instead of publishing an incomplete inventory", async () => {
+		const firstPage = Array.from({ length: 200 }, (_, index) => historyItem(index));
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(
+					response({ offset: 0, size: 200, totalSize: 400, Metadata: firstPage }),
+				)
+				.mockResolvedValueOnce(
+					response({ offset: 200, size: 200, totalSize: 400, Metadata: firstPage }),
+				),
+		);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).rejects.toThrow(/duplicate row while paging/i);
+	});
+
+	it("rejects equal-count history churn before cache publication", async () => {
+		const initial = Array.from({ length: 200 }, (_, index) => historyItem(index));
+		const changed = [historyItem(999), ...initial.slice(0, 199)];
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(
+					response({ offset: 0, size: 200, totalSize: 200, Metadata: initial }),
+				)
+				.mockResolvedValueOnce(
+					response({ offset: 0, size: 200, totalSize: 200, Metadata: changed }),
+				),
+		);
+
+		const client = new PlexClient("http://plex.test", "token", log);
+		const snapshot = await client.getHistory({ maxResults: 100_000, requireComplete: true });
+		await expect(client.verifyHistorySnapshot(snapshot)).rejects.toThrow(
+			/changed before.*snapshot/i,
+		);
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -55,21 +55,56 @@ describe("PlexClient complete history authority", () => {
 		}
 	});
 
-	it("supports bounded compatibility reads when Plex omits pagination metadata", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue(response({ size: 1, Metadata: [historyItem(1)] })),
-		);
+	it("supports bounded complete reads when Plex omits pagination metadata and row keys", async () => {
+		const metadataLightItem = { ...historyItem(1), historyKey: undefined };
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			return offset === 0
+				? response({ size: 1, Metadata: [metadataLightItem] })
+				: response({ size: 0, Metadata: [] });
+		});
+		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(
-			new PlexClient("http://plex.test", "token", log).getHistory({ maxResults: 200 }),
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
 		).resolves.toHaveLength(1);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 
-	it("rejects missing pagination metadata at the complete-history safety boundary", async () => {
+	it("rejects contradictory fields in a partially metadata-light inventory", async () => {
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			return offset === 0
+				? response({ totalSize: 2, Metadata: [historyItem(1)] })
+				: response({ size: 0, Metadata: [] });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).rejects.toThrow(/contradictory pagination metadata/i);
+	});
+
+	it("rejects a full metadata-light page at the complete-history safety boundary", async () => {
 		vi.stubGlobal(
 			"fetch",
-			vi.fn().mockResolvedValue(response({ size: 1, Metadata: [historyItem(1)] })),
+			vi.fn().mockResolvedValue(
+				response({
+					size: 200,
+					Metadata: Array.from({ length: 200 }, (_, index) => ({
+						...historyItem(index),
+						historyKey: undefined,
+					})),
+				}),
+			),
 		);
 
 		await expect(
@@ -77,7 +112,7 @@ describe("PlexClient complete history authority", () => {
 				maxResults: 100_000,
 				requireComplete: true,
 			}),
-		).rejects.toThrow(/complete pagination metadata/i);
+		).rejects.toThrow(/bounded metadata-light/i);
 	});
 
 	it("rejects a declared history inventory larger than the safety cap", async () => {

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -116,6 +116,29 @@ describe("PlexClient complete history authority", () => {
 		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 
+	it("continues when Plex enforces a smaller page cap than requested", async () => {
+		const history = Array.from({ length: 125 }, (_, index) => ({
+			...historyItem(index),
+			historyKey: undefined,
+		}));
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			const requested = Number(url.searchParams.get("X-Plex-Container-Size") ?? "200");
+			const page = history.slice(offset, offset + Math.min(requested, 50));
+			return response({ size: page.length, Metadata: page });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		await expect(
+			new PlexClient("http://plex.test", "token", log).getHistory({
+				maxResults: 100_000,
+				requireComplete: true,
+			}),
+		).resolves.toHaveLength(125);
+		expect(fetchMock).toHaveBeenCalledTimes(6);
+	});
+
 	it("proves a metadata-light inventory that ends on the exact safety cap", async () => {
 		const history = Array.from({ length: 400 }, (_, index) => ({
 			...historyItem(index),

--- a/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-history-authority.test.ts
@@ -93,26 +93,27 @@ describe("PlexClient complete history authority", () => {
 		).rejects.toThrow(/contradictory pagination metadata/i);
 	});
 
-	it("rejects a full metadata-light page at the complete-history safety boundary", async () => {
-		vi.stubGlobal(
-			"fetch",
-			vi.fn().mockResolvedValue(
-				response({
-					size: 200,
-					Metadata: Array.from({ length: 200 }, (_, index) => ({
-						...historyItem(index),
-						historyKey: undefined,
-					})),
-				}),
-			),
-		);
+	it("pages a metadata-light history beyond the first full page", async () => {
+		const history = Array.from({ length: 201 }, (_, index) => ({
+			...historyItem(index),
+			historyKey: undefined,
+		}));
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(input instanceof Request ? input.url : input.toString());
+			const offset = Number(url.searchParams.get("X-Plex-Container-Start") ?? "0");
+			const size = Number(url.searchParams.get("X-Plex-Container-Size") ?? "200");
+			const page = history.slice(offset, offset + size);
+			return response({ size: page.length, Metadata: page });
+		});
+		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(
 			new PlexClient("http://plex.test", "token", log).getHistory({
 				maxResults: 100_000,
 				requireComplete: true,
 			}),
-		).rejects.toThrow(/bounded metadata-light/i);
+		).resolves.toHaveLength(201);
+		expect(fetchMock).toHaveBeenCalledTimes(3);
 	});
 
 	it("rejects a declared history inventory larger than the safety cap", async () => {

--- a/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
+++ b/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
@@ -95,6 +95,7 @@ function reportHeap(message: string): void {
 					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
 				getLibraryItems: vi.fn().mockResolvedValue(plexItems),
 				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
 			} as unknown as PlexClient;
 

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -15,13 +15,13 @@
  */
 
 import { randomUUID } from "node:crypto";
+import type { FastifyBaseLogger } from "fastify";
 import type { PrismaClient } from "../prisma.js";
 import {
 	type ProviderConnectionIdentity,
 	withCurrentProviderConnection,
 } from "../services/provider-connection-guard.js";
 import { getErrorMessage } from "../utils/error-message.js";
-import type { FastifyBaseLogger } from "fastify";
 import type { PlexClient } from "./plex-client.js";
 
 /** Bound Prisma's cached createMany query plans for production-sized libraries. */
@@ -70,10 +70,18 @@ interface ItemAggregation {
 	thumb: string | null;
 }
 
-// Plex 1.43 rejects the stable-reference history sort/verification API. Ask
-// for one row beyond the supported cache limit so exactly 5,000 results remain
-// distinguishable from a truncated response.
-const PLEX_HISTORY_CACHE_LIMIT = 5_000;
+function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): string[] {
+	return items
+		.map((item) =>
+			JSON.stringify([
+				item.type,
+				item.ratingKey,
+				item.parentRatingKey ?? null,
+				item.grandparentRatingKey ?? null,
+			]),
+		)
+		.sort();
+}
 
 export type PlexCacheRefreshResult = {
 	upserted: number;
@@ -206,21 +214,7 @@ async function performPlexCacheRefresh(
 		}
 
 		// 4. Get history and aggregate (per-section: key includes sectionId)
-		let history: Awaited<ReturnType<typeof client.getHistory>> | undefined =
-			await client.getHistory({ maxResults: PLEX_HISTORY_CACHE_LIMIT + 1 });
-		const fetchedHistoryCount = history.length;
-		if (fetchedHistoryCount > PLEX_HISTORY_CACHE_LIMIT) {
-			complete = false;
-			errors++;
-			errorMessages.push(
-				`Plex history exceeded ${PLEX_HISTORY_CACHE_LIMIT} entries, so watch evidence is incomplete`,
-			);
-			log.warn(
-				{ instanceId, historyCount: fetchedHistoryCount, historyLimit: PLEX_HISTORY_CACHE_LIMIT },
-				"Plex cache refresh: history exceeds the supported cache limit",
-			);
-			history = history.slice(0, PLEX_HISTORY_CACHE_LIMIT);
-		}
+		const history = await client.getHistory({ maxResults: 100_000, requireComplete: true });
 		const historyCount = history.length;
 		const aggregations = new Map<string, ItemAggregation>();
 
@@ -279,9 +273,6 @@ async function performPlexCacheRefresh(
 			}
 		}
 
-		// Release history array — only historyCount is needed from here (#239)
-		history = undefined;
-
 		// Ensure all library items are in aggregations (even if unwatched)
 		for (const [_ratingKey, itemData] of ratingKeyMap) {
 			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
@@ -307,8 +298,10 @@ async function performPlexCacheRefresh(
 		}
 
 		// 5. Get on-deck items and mark
+		let verifiedOnDeckSignature: string[] = [];
 		try {
 			const onDeckItems = await client.getOnDeck();
+			verifiedOnDeckSignature = onDeckSignature(onDeckItems);
 			for (const deckItem of onDeckItems) {
 				// For episodes, use the show's ratingKey
 				const itemRatingKey =
@@ -351,6 +344,11 @@ async function performPlexCacheRefresh(
 		aggregations.clear();
 
 		if (errors === 0 && complete) {
+			await client.verifyHistorySnapshot(history);
+			const latestOnDeckSignature = onDeckSignature(await client.getOnDeck());
+			if (JSON.stringify(latestOnDeckSignature) !== JSON.stringify(verifiedOnDeckSignature)) {
+				throw new Error("Plex on-deck state changed before cache publication");
+			}
 			completedAt = new Date();
 			const generationId = randomUUID();
 			const generationMetadata = JSON.stringify({

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -96,6 +96,7 @@ export class PlexSeriesNotFoundError extends Error {
 }
 
 export interface PlexHistoryItem {
+	historyKey?: string;
 	ratingKey: string;
 	parentRatingKey?: string;
 	grandparentRatingKey?: string;
@@ -151,6 +152,7 @@ export interface PlexEpisodeItem {
 const DEFAULT_TIMEOUT = 15_000;
 const SAFETY_PAGE_SIZE = 200;
 const SAFETY_MAX_ITEMS = 100_000;
+const HISTORY_SORT = "viewedAt:desc";
 
 /**
  * Extract a ratingKey from a Plex path like "/library/metadata/65486".
@@ -398,24 +400,71 @@ export class PlexClient {
 	 * Get watch history across all users.
 	 * Uses /status/sessions/history/all for multi-user history.
 	 */
-	async getHistory(options?: { maxResults?: number }): Promise<PlexHistoryItem[]> {
+	async getHistory(options?: {
+		maxResults?: number;
+		requireComplete?: boolean;
+	}): Promise<PlexHistoryItem[]> {
+		return this.getHistoryPass(options);
+	}
+
+	private async getHistoryPass(options?: {
+		maxResults?: number;
+		requireComplete?: boolean;
+	}): Promise<PlexHistoryItem[]> {
 		const allItems: PlexHistoryItem[] = [];
 		const pageSize = 200;
 		const maxResults = options?.maxResults ?? 5000;
+		const requireComplete = options?.requireComplete ?? false;
+		const seenHistoryRows = new Set<string>();
+		let expectedTotal: number | undefined;
 		let offset = 0;
 
-		while (allItems.length < maxResults) {
-			const remaining = maxResults - allItems.length;
+		while (
+			allItems.length < maxResults &&
+			(expectedTotal === undefined || allItems.length < expectedTotal)
+		) {
+			const remaining =
+				expectedTotal === undefined
+					? maxResults - allItems.length
+					: Math.min(maxResults, expectedTotal) - allItems.length;
 			const take = Math.min(pageSize, remaining);
 
 			const data = await this.request(
-				`/status/sessions/history/all?sort=viewedAt:desc&X-Plex-Container-Start=${offset}&X-Plex-Container-Size=${take}`,
+				`/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${offset}&X-Plex-Container-Size=${take}`,
 				{ schema: plexHistoryResponseSchema },
 			);
 
-			const items = data.MediaContainer.Metadata ?? [];
+			const container = data.MediaContainer;
+			const items = container.Metadata ?? [];
+			if (container.offset !== offset || container.size !== items.length) {
+				throw new Error("Plex history pagination metadata did not match the returned page");
+			}
+			if (expectedTotal === undefined) {
+				expectedTotal = container.totalSize;
+				if (requireComplete && expectedTotal > maxResults) {
+					throw new Error(
+						`Plex history contains ${expectedTotal} rows, exceeding the safe ${maxResults}-row limit`,
+					);
+				}
+			} else if (container.totalSize !== expectedTotal) {
+				throw new Error("Plex history changed while it was being paged");
+			}
+			if (offset + items.length > expectedTotal) {
+				throw new Error("Plex history pagination exceeded its declared total");
+			}
+			if (items.length === 0 && offset < Math.min(expectedTotal, maxResults)) {
+				throw new Error("Plex history pagination stopped before the declared total");
+			}
 			for (const item of items) {
+				if (requireComplete && !item.historyKey) {
+					throw new Error("Plex history did not provide a stable row identity");
+				}
+				if (item.historyKey && seenHistoryRows.has(item.historyKey)) {
+					throw new Error("Plex history returned a duplicate row while paging");
+				}
+				if (item.historyKey) seenHistoryRows.add(item.historyKey);
 				allItems.push({
+					historyKey: item.historyKey,
 					ratingKey: item.ratingKey,
 					parentRatingKey: item.parentRatingKey ?? extractRatingKey(item.parentKey),
 					grandparentRatingKey: item.grandparentRatingKey ?? extractRatingKey(item.grandparentKey),
@@ -427,11 +476,41 @@ export class PlexClient {
 				});
 			}
 
-			if (items.length < take) break;
-			offset += take;
+			offset += items.length;
 		}
 
+		if (requireComplete && (expectedTotal === undefined || allItems.length !== expectedTotal)) {
+			throw new Error("Plex history inventory could not be verified as complete");
+		}
 		return allItems;
+	}
+
+	/** Re-read and compare every watch-relevant field before publication. */
+	async verifyHistorySnapshot(history: readonly PlexHistoryItem[]): Promise<void> {
+		const verification = await this.getHistoryPass({
+			maxResults: SAFETY_MAX_ITEMS,
+			requireComplete: true,
+		});
+		const signatures = (items: readonly PlexHistoryItem[]) =>
+			items
+				.map((item) =>
+					JSON.stringify([
+						item.historyKey,
+						item.ratingKey,
+						item.parentRatingKey ?? null,
+						item.grandparentRatingKey ?? null,
+						item.type,
+						item.viewedAt,
+						item.accountID,
+					]),
+				)
+				.sort();
+		if (
+			verification.length !== history.length ||
+			JSON.stringify(signatures(verification)) !== JSON.stringify(signatures(history))
+		) {
+			throw new Error("Plex history changed before its complete snapshot could be verified");
+		}
 	}
 
 	/**

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -567,6 +567,25 @@ export class PlexClient {
 					);
 					const terminalItems = terminalProbe.MediaContainer.Metadata ?? [];
 					const terminalContainer = terminalProbe.MediaContainer;
+					if (terminalItems.length === 1) {
+						if (
+							(terminalContainer.offset !== undefined && terminalContainer.offset !== itemCount) ||
+							(terminalContainer.size !== undefined && terminalContainer.size !== 1) ||
+							(terminalContainer.totalSize !== undefined &&
+								terminalContainer.totalSize <= itemCount)
+						) {
+							throw new Error("Plex history returned contradictory terminal-probe metadata");
+						}
+						if (terminalContainer.totalSize !== undefined) {
+							expectedTotal = terminalContainer.totalSize;
+							if (expectedTotal > maxResults) {
+								throw new Error(
+									`Plex history contains ${expectedTotal} rows, exceeding the safe ${maxResults}-row limit`,
+								);
+							}
+						}
+						continue;
+					}
 					if (
 						terminalItems.length !== 0 ||
 						(terminalContainer.offset !== undefined && terminalContainer.offset !== itemCount) ||

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -417,6 +417,7 @@ export class PlexClient {
 		const requireComplete = options?.requireComplete ?? false;
 		const seenHistoryRows = new Set<string>();
 		let expectedTotal: number | undefined;
+		let metadataLightSnapshot = false;
 		let offset = 0;
 
 		while (
@@ -441,7 +442,33 @@ export class PlexClient {
 				container.size !== undefined &&
 				container.totalSize !== undefined;
 			if (requireComplete && !hasCompletePaginationMetadata) {
-				throw new Error("Plex history did not provide complete pagination metadata");
+				if (offset !== 0 || items.length >= take) {
+					throw new Error("Plex history could not prove a bounded metadata-light inventory");
+				}
+				if (
+					(container.offset !== undefined && container.offset !== 0) ||
+					(container.size !== undefined && container.size !== items.length) ||
+					(container.totalSize !== undefined && container.totalSize !== items.length)
+				) {
+					throw new Error("Plex history returned contradictory pagination metadata");
+				}
+				const terminalProbe = await this.request(
+					`/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${items.length}&X-Plex-Container-Size=1`,
+					{ schema: plexHistoryResponseSchema },
+				);
+				const terminalItems = terminalProbe.MediaContainer.Metadata ?? [];
+				const terminalContainer = terminalProbe.MediaContainer;
+				if (
+					terminalItems.length !== 0 ||
+					(terminalContainer.offset !== undefined && terminalContainer.offset !== items.length) ||
+					(terminalContainer.size !== undefined && terminalContainer.size !== 0) ||
+					(terminalContainer.totalSize !== undefined &&
+						terminalContainer.totalSize !== items.length)
+				) {
+					throw new Error("Plex history could not prove a bounded metadata-light inventory");
+				}
+				metadataLightSnapshot = true;
+				expectedTotal = items.length;
 			}
 			if (
 				(container.offset !== undefined && container.offset !== offset) ||
@@ -449,14 +476,22 @@ export class PlexClient {
 			) {
 				throw new Error("Plex history pagination metadata did not match the returned page");
 			}
-			if (expectedTotal === undefined && container.totalSize !== undefined) {
+			if (
+				!metadataLightSnapshot &&
+				expectedTotal === undefined &&
+				container.totalSize !== undefined
+			) {
 				expectedTotal = container.totalSize;
 				if (requireComplete && expectedTotal > maxResults) {
 					throw new Error(
 						`Plex history contains ${expectedTotal} rows, exceeding the safe ${maxResults}-row limit`,
 					);
 				}
-			} else if (expectedTotal !== undefined && container.totalSize !== expectedTotal) {
+			} else if (
+				!metadataLightSnapshot &&
+				expectedTotal !== undefined &&
+				container.totalSize !== expectedTotal
+			) {
 				throw new Error("Plex history changed while it was being paged");
 			}
 			if (expectedTotal !== undefined && offset + items.length > expectedTotal) {
@@ -470,7 +505,7 @@ export class PlexClient {
 				throw new Error("Plex history pagination stopped before the declared total");
 			}
 			for (const item of items) {
-				if (requireComplete && !item.historyKey) {
+				if (requireComplete && !metadataLightSnapshot && !item.historyKey) {
 					throw new Error("Plex history did not provide a stable row identity");
 				}
 				if (item.historyKey && seenHistoryRows.has(item.historyKey)) {
@@ -491,6 +526,7 @@ export class PlexClient {
 			}
 
 			offset += items.length;
+			if (metadataLightSnapshot) break;
 			if (!requireComplete && expectedTotal === undefined && items.length < take) break;
 		}
 

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -560,7 +560,7 @@ export class PlexClient {
 					}
 					continue;
 				}
-				if (items.length < take) {
+				if (items.length < take || itemCount === maxResults) {
 					const terminalProbe = await this.request(
 						`/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${itemCount}&X-Plex-Container-Size=1`,
 						{ schema: plexHistoryResponseSchema },

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -5,6 +5,7 @@
  * Plex returns JSON when Accept: application/json is set.
  */
 
+import { createHash } from "node:crypto";
 import type { FastifyBaseLogger } from "fastify";
 import type { z } from "zod";
 import type { ClientInstanceData } from "../arr/client-factory.js";
@@ -153,6 +154,42 @@ const DEFAULT_TIMEOUT = 15_000;
 const SAFETY_PAGE_SIZE = 200;
 const SAFETY_MAX_ITEMS = 100_000;
 const HISTORY_SORT = "viewedAt:desc";
+const UINT64_MASK = (1n << 64n) - 1n;
+
+function createHistoryProofAccumulator() {
+	let count = 0;
+	const sums = [0n, 0n, 0n, 0n];
+	return {
+		add(item: PlexHistoryItem) {
+			const digest = createHash("sha256")
+				.update(
+					JSON.stringify([
+						item.historyKey,
+						item.ratingKey,
+						item.parentRatingKey ?? null,
+						item.grandparentRatingKey ?? null,
+						item.type,
+						item.viewedAt,
+						item.accountID,
+					]),
+				)
+				.digest();
+			for (let index = 0; index < sums.length; index += 1) {
+				sums[index] = (sums[index]! + digest.readBigUInt64BE(index * 8)) & UINT64_MASK;
+			}
+			count += 1;
+		},
+		value() {
+			return `${count}:${sums.map((sum) => sum.toString(16).padStart(16, "0")).join("")}`;
+		},
+	};
+}
+
+function historyProof(items: readonly PlexHistoryItem[]): string {
+	const proof = createHistoryProofAccumulator();
+	for (const item of items) proof.add(item);
+	return proof.value();
+}
 
 /**
  * Extract a ratingKey from a Plex path like "/library/metadata/65486".
@@ -404,30 +441,33 @@ export class PlexClient {
 		maxResults?: number;
 		requireComplete?: boolean;
 	}): Promise<PlexHistoryItem[]> {
-		return this.getHistoryPass(options);
+		return (await this.getHistoryPass(options)).items;
 	}
 
-	private async getHistoryPass(options?: {
-		maxResults?: number;
-		requireComplete?: boolean;
-	}): Promise<PlexHistoryItem[]> {
+	private async getHistoryPass(
+		options?: {
+			maxResults?: number;
+			requireComplete?: boolean;
+		},
+		collectItems = true,
+	): Promise<{ items: PlexHistoryItem[]; count: number; proof: string }> {
 		const allItems: PlexHistoryItem[] = [];
+		const proof = createHistoryProofAccumulator();
 		const pageSize = 200;
 		const maxResults = options?.maxResults ?? 5000;
 		const requireComplete = options?.requireComplete ?? false;
 		const seenHistoryRows = new Set<string>();
+		const seenMetadataLightPages = new Set<string>();
 		let expectedTotal: number | undefined;
 		let metadataLightSnapshot = false;
+		let itemCount = 0;
 		let offset = 0;
 
-		while (
-			allItems.length < maxResults &&
-			(expectedTotal === undefined || allItems.length < expectedTotal)
-		) {
+		while (itemCount < maxResults && (expectedTotal === undefined || itemCount < expectedTotal)) {
 			const remaining =
 				expectedTotal === undefined
-					? maxResults - allItems.length
-					: Math.min(maxResults, expectedTotal) - allItems.length;
+					? maxResults - itemCount
+					: Math.min(maxResults, expectedTotal) - itemCount;
 			const take = Math.min(pageSize, remaining);
 
 			const data = await this.request(
@@ -442,45 +482,15 @@ export class PlexClient {
 				container.size !== undefined &&
 				container.totalSize !== undefined;
 			if (requireComplete && !hasCompletePaginationMetadata) {
-				if (offset !== 0 || items.length >= take) {
-					throw new Error("Plex history could not prove a bounded metadata-light inventory");
-				}
-				if (
-					(container.offset !== undefined && container.offset !== 0) ||
-					(container.size !== undefined && container.size !== items.length) ||
-					(container.totalSize !== undefined && container.totalSize !== items.length)
-				) {
-					throw new Error("Plex history returned contradictory pagination metadata");
-				}
-				const terminalProbe = await this.request(
-					`/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${items.length}&X-Plex-Container-Size=1`,
-					{ schema: plexHistoryResponseSchema },
-				);
-				const terminalItems = terminalProbe.MediaContainer.Metadata ?? [];
-				const terminalContainer = terminalProbe.MediaContainer;
-				if (
-					terminalItems.length !== 0 ||
-					(terminalContainer.offset !== undefined && terminalContainer.offset !== items.length) ||
-					(terminalContainer.size !== undefined && terminalContainer.size !== 0) ||
-					(terminalContainer.totalSize !== undefined &&
-						terminalContainer.totalSize !== items.length)
-				) {
-					throw new Error("Plex history could not prove a bounded metadata-light inventory");
-				}
 				metadataLightSnapshot = true;
-				expectedTotal = items.length;
 			}
 			if (
 				(container.offset !== undefined && container.offset !== offset) ||
 				(container.size !== undefined && container.size !== items.length)
 			) {
-				throw new Error("Plex history pagination metadata did not match the returned page");
+				throw new Error("Plex history returned contradictory pagination metadata");
 			}
-			if (
-				!metadataLightSnapshot &&
-				expectedTotal === undefined &&
-				container.totalSize !== undefined
-			) {
+			if (expectedTotal === undefined && container.totalSize !== undefined) {
 				expectedTotal = container.totalSize;
 				if (requireComplete && expectedTotal > maxResults) {
 					throw new Error(
@@ -488,8 +498,8 @@ export class PlexClient {
 					);
 				}
 			} else if (
-				!metadataLightSnapshot &&
 				expectedTotal !== undefined &&
+				container.totalSize !== undefined &&
 				container.totalSize !== expectedTotal
 			) {
 				throw new Error("Plex history changed while it was being paged");
@@ -504,6 +514,7 @@ export class PlexClient {
 			) {
 				throw new Error("Plex history pagination stopped before the declared total");
 			}
+			const normalizedItems: PlexHistoryItem[] = [];
 			for (const item of items) {
 				if (requireComplete && !metadataLightSnapshot && !item.historyKey) {
 					throw new Error("Plex history did not provide a stable row identity");
@@ -512,7 +523,7 @@ export class PlexClient {
 					throw new Error("Plex history returned a duplicate row while paging");
 				}
 				if (item.historyKey) seenHistoryRows.add(item.historyKey);
-				allItems.push({
+				normalizedItems.push({
 					historyKey: item.historyKey,
 					ratingKey: item.ratingKey,
 					parentRatingKey: item.parentRatingKey ?? extractRatingKey(item.parentKey),
@@ -524,42 +535,70 @@ export class PlexClient {
 					accountID: item.accountID,
 				});
 			}
+			if (metadataLightSnapshot && normalizedItems.length > 0) {
+				const pageProof = historyProof(normalizedItems);
+				if (seenMetadataLightPages.has(pageProof)) {
+					throw new Error("Plex history repeated a metadata-light page while paging");
+				}
+				seenMetadataLightPages.add(pageProof);
+			}
+			for (const item of normalizedItems) {
+				proof.add(item);
+				if (collectItems) allItems.push(item);
+			}
 
 			offset += items.length;
-			if (metadataLightSnapshot) break;
+			itemCount += items.length;
+			if (metadataLightSnapshot) {
+				if (expectedTotal !== undefined) {
+					if (itemCount > expectedTotal) {
+						throw new Error("Plex history pagination exceeded its declared total");
+					}
+					if (itemCount === expectedTotal) break;
+					if (items.length < take) {
+						throw new Error("Plex history returned contradictory pagination metadata");
+					}
+					continue;
+				}
+				if (items.length < take) {
+					const terminalProbe = await this.request(
+						`/status/sessions/history/all?sort=${HISTORY_SORT}&X-Plex-Container-Start=${itemCount}&X-Plex-Container-Size=1`,
+						{ schema: plexHistoryResponseSchema },
+					);
+					const terminalItems = terminalProbe.MediaContainer.Metadata ?? [];
+					const terminalContainer = terminalProbe.MediaContainer;
+					if (
+						terminalItems.length !== 0 ||
+						(terminalContainer.offset !== undefined && terminalContainer.offset !== itemCount) ||
+						(terminalContainer.size !== undefined && terminalContainer.size !== 0) ||
+						(terminalContainer.totalSize !== undefined && terminalContainer.totalSize !== itemCount)
+					) {
+						throw new Error("Plex history could not prove a bounded metadata-light inventory");
+					}
+					expectedTotal = itemCount;
+					break;
+				}
+				continue;
+			}
 			if (!requireComplete && expectedTotal === undefined && items.length < take) break;
 		}
 
-		if (requireComplete && (expectedTotal === undefined || allItems.length !== expectedTotal)) {
+		if (requireComplete && (expectedTotal === undefined || itemCount !== expectedTotal)) {
 			throw new Error("Plex history inventory could not be verified as complete");
 		}
-		return allItems;
+		return { items: allItems, count: itemCount, proof: proof.value() };
 	}
 
 	/** Re-read and compare every watch-relevant field before publication. */
 	async verifyHistorySnapshot(history: readonly PlexHistoryItem[]): Promise<void> {
-		const verification = await this.getHistoryPass({
-			maxResults: SAFETY_MAX_ITEMS,
-			requireComplete: true,
-		});
-		const signatures = (items: readonly PlexHistoryItem[]) =>
-			items
-				.map((item) =>
-					JSON.stringify([
-						item.historyKey,
-						item.ratingKey,
-						item.parentRatingKey ?? null,
-						item.grandparentRatingKey ?? null,
-						item.type,
-						item.viewedAt,
-						item.accountID,
-					]),
-				)
-				.sort();
-		if (
-			verification.length !== history.length ||
-			JSON.stringify(signatures(verification)) !== JSON.stringify(signatures(history))
-		) {
+		const verification = await this.getHistoryPass(
+			{
+				maxResults: SAFETY_MAX_ITEMS,
+				requireComplete: true,
+			},
+			false,
+		);
+		if (verification.count !== history.length || verification.proof !== historyProof(history)) {
 			throw new Error("Plex history changed before its complete snapshot could be verified");
 		}
 	}

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -436,23 +436,37 @@ export class PlexClient {
 
 			const container = data.MediaContainer;
 			const items = container.Metadata ?? [];
-			if (container.offset !== offset || container.size !== items.length) {
+			const hasCompletePaginationMetadata =
+				container.offset !== undefined &&
+				container.size !== undefined &&
+				container.totalSize !== undefined;
+			if (requireComplete && !hasCompletePaginationMetadata) {
+				throw new Error("Plex history did not provide complete pagination metadata");
+			}
+			if (
+				(container.offset !== undefined && container.offset !== offset) ||
+				(container.size !== undefined && container.size !== items.length)
+			) {
 				throw new Error("Plex history pagination metadata did not match the returned page");
 			}
-			if (expectedTotal === undefined) {
+			if (expectedTotal === undefined && container.totalSize !== undefined) {
 				expectedTotal = container.totalSize;
 				if (requireComplete && expectedTotal > maxResults) {
 					throw new Error(
 						`Plex history contains ${expectedTotal} rows, exceeding the safe ${maxResults}-row limit`,
 					);
 				}
-			} else if (container.totalSize !== expectedTotal) {
+			} else if (expectedTotal !== undefined && container.totalSize !== expectedTotal) {
 				throw new Error("Plex history changed while it was being paged");
 			}
-			if (offset + items.length > expectedTotal) {
+			if (expectedTotal !== undefined && offset + items.length > expectedTotal) {
 				throw new Error("Plex history pagination exceeded its declared total");
 			}
-			if (items.length === 0 && offset < Math.min(expectedTotal, maxResults)) {
+			if (
+				expectedTotal !== undefined &&
+				items.length === 0 &&
+				offset < Math.min(expectedTotal, maxResults)
+			) {
 				throw new Error("Plex history pagination stopped before the declared total");
 			}
 			for (const item of items) {
@@ -477,6 +491,7 @@ export class PlexClient {
 			}
 
 			offset += items.length;
+			if (!requireComplete && expectedTotal === undefined && items.length < take) break;
 		}
 
 		if (requireComplete && (expectedTotal === undefined || allItems.length !== expectedTotal)) {

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
@@ -15,6 +15,60 @@ const plexConnection = {
 };
 
 describe("refreshPlexEpisodeCache watch count", () => {
+	it("publishes a guarded empty generation when the parent has no watched shows", async () => {
+		const deleteMany = vi.fn().mockResolvedValue({ count: 3 });
+		const statusUpsert = vi.fn().mockResolvedValue({});
+		const prisma = {
+			cacheRefreshStatus: {
+				findUnique: vi.fn().mockResolvedValue({ generationId: "parent-a", lastResult: "success" }),
+			},
+			plexCache: { findMany: vi.fn().mockResolvedValue([]) },
+			plexEpisodeCache: { groupBy: vi.fn().mockResolvedValue([]) },
+			$transaction: vi.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+				callback({
+					serviceInstance: { findUnique: vi.fn().mockResolvedValue(plexConnection) },
+					plexEpisodeCache: { deleteMany, createMany: vi.fn() },
+					cacheRefreshStatus: {
+						findUnique: vi.fn().mockResolvedValue({ generationId: "parent-a" }),
+						upsert: statusUpsert,
+					},
+				}),
+			),
+		};
+		const client = {
+			getHistory: vi.fn(),
+			getAccounts: vi.fn(),
+			getEpisodes: vi.fn(),
+		};
+
+		const result = await refreshPlexEpisodeCache(
+			client as never,
+			prisma as never,
+			"plex-1",
+			{ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+			"connection-fingerprint",
+			providerConnectionIdentity(plexConnection),
+		);
+
+		expect(result).toMatchObject({
+			complete: true,
+			eligibleShows: 0,
+			refreshedShows: 0,
+			upserted: 0,
+		});
+		expect(deleteMany).toHaveBeenCalledWith({ where: { instanceId: "plex-1" } });
+		expect(statusUpsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					lastResult: "success",
+					itemCount: 0,
+					generationMetadata: JSON.stringify({ parentGenerationId: "parent-a" }),
+				}),
+			}),
+		);
+		expect(client.getHistory).not.toHaveBeenCalled();
+	});
+
 	it("does not publish a selected batch when one duplicate copy fails", async () => {
 		const upsert = vi.fn().mockResolvedValue({});
 		const prisma = {

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -110,7 +110,7 @@ export async function refreshPlexEpisodeCache(
 		},
 	});
 
-	if (recentlyWatchedShows.length === 0) {
+	if (recentlyWatchedShows.length === 0 && !expectedConnection) {
 		log.debug({ instanceId }, "No recently watched shows to refresh episodes for");
 		return {
 			upserted,
@@ -139,14 +139,17 @@ export async function refreshPlexEpisodeCache(
 	// Rotate the bounded batch toward shows with the oldest episode evidence.
 	// This guarantees eventual coverage instead of permanently refreshing only
 	// the same newest 50 watched shows.
-	const existingRefreshes = await prisma.plexEpisodeCache.groupBy({
-		by: ["showTmdbId"],
-		where: {
-			instanceId,
-			showTmdbId: { in: [...showMap.keys()] },
-		},
-		_max: { refreshedAt: true },
-	});
+	const existingRefreshes =
+		showMap.size > 0
+			? await prisma.plexEpisodeCache.groupBy({
+					by: ["showTmdbId"],
+					where: {
+						instanceId,
+						showTmdbId: { in: [...showMap.keys()] },
+					},
+					_max: { refreshedAt: true },
+				})
+			: [];
 	const newestRefreshByShow = new Map<number, number>();
 	for (const row of existingRefreshes) {
 		if (row._max.refreshedAt) {
@@ -177,13 +180,15 @@ export async function refreshPlexEpisodeCache(
 	>();
 	let history: Awaited<ReturnType<PlexClient["getHistory"]>> = [];
 	let historyAvailable = true;
-	try {
-		history = await client.getHistory({ maxResults: MAX_HISTORY_RESULTS });
-	} catch (err) {
-		historyAvailable = false;
-		log.warn({ err, instanceId }, "Failed to fetch history for episode cache refresh");
-		errors++;
-		errorMessages.push(`Failed to fetch history: ${getErrorMessage(err)}`);
+	if (eligibleShows > 0) {
+		try {
+			history = await client.getHistory({ maxResults: MAX_HISTORY_RESULTS });
+		} catch (err) {
+			historyAvailable = false;
+			log.warn({ err, instanceId }, "Failed to fetch history for episode cache refresh");
+			errors++;
+			errorMessages.push(`Failed to fetch history: ${getErrorMessage(err)}`);
+		}
 	}
 	const historyComplete = historyAvailable && history.length < MAX_HISTORY_RESULTS;
 	if (historyAvailable && !historyComplete) {
@@ -531,7 +536,9 @@ export async function refreshPlexEpisodeCache(
 						return { published: false as const, count: 0 };
 					}
 					const selectedShowIds = selectedShows.map(([tmdbId]) => tmdbId);
-					if (selectedShowIds.length > 0) {
+					if (eligibleShows === 0) {
+						await tx.plexEpisodeCache.deleteMany({ where: { instanceId } });
+					} else if (selectedShowIds.length > 0) {
 						await tx.plexEpisodeCache.deleteMany({
 							where: { instanceId, showTmdbId: { in: selectedShowIds } },
 						});

--- a/apps/api/src/lib/plex/plex-schemas.ts
+++ b/apps/api/src/lib/plex/plex-schemas.ts
@@ -129,10 +129,11 @@ export const plexEpisodeMediaItemsResponseSchema = z.looseObject({
 /** /status/sessions/history/all endpoint (paginated) */
 export const plexHistoryResponseSchema = z.looseObject({
 	MediaContainer: z.looseObject({
-		size: z.number().optional(),
+		...plexSafetyPaginationFields,
 		Metadata: z
 			.array(
 				z.looseObject({
+					historyKey: z.string().min(1).optional(),
 					ratingKey: z.string().optional().default(""),
 					parentRatingKey: z.string().optional(),
 					parentKey: z.string().optional(),

--- a/apps/api/src/lib/plex/plex-schemas.ts
+++ b/apps/api/src/lib/plex/plex-schemas.ts
@@ -71,10 +71,16 @@ const plexMediaSchema = z.looseObject({
 	Part: z.array(plexMediaPartSchema).min(1),
 });
 
+const plexSafetyPaginationNumberSchema = z.coerce
+	.number()
+	.int()
+	.nonnegative()
+	.refine(Number.isSafeInteger);
+
 const plexSafetyPaginationFields = {
-	offset: z.coerce.number().int().nonnegative().refine(Number.isSafeInteger),
-	size: z.coerce.number().int().nonnegative().refine(Number.isSafeInteger),
-	totalSize: z.coerce.number().int().nonnegative().refine(Number.isSafeInteger),
+	offset: plexSafetyPaginationNumberSchema,
+	size: plexSafetyPaginationNumberSchema,
+	totalSize: plexSafetyPaginationNumberSchema,
 };
 
 /** /library/sections/{id}/all with includeMedia=1 */
@@ -129,7 +135,9 @@ export const plexEpisodeMediaItemsResponseSchema = z.looseObject({
 /** /status/sessions/history/all endpoint (paginated) */
 export const plexHistoryResponseSchema = z.looseObject({
 	MediaContainer: z.looseObject({
-		...plexSafetyPaginationFields,
+		offset: plexSafetyPaginationNumberSchema.optional(),
+		size: plexSafetyPaginationNumberSchema.optional(),
+		totalSize: plexSafetyPaginationNumberSchema.optional(),
 		Metadata: z
 			.array(
 				z.looseObject({


### PR DESCRIPTION
## Summary

- use the Plex-compatible single history sort key
- page and verify complete history snapshots before cache publication
- safely page metadata-light Plex history beyond 200 rows, including server-enforced page caps below the requested size and an explicit terminal probe at the configured row limit
- reject contradictory, repeated, oversized, unstable, stale, or future-dated history evidence
- route preview, cleanup-run, scheduled auto-tag, webhook auto-tag, and cross-domain policy evaluation through authoritative generation-bound provider evidence
- forward configured Plex library filters into scheduled and webhook evidence validation so renamed or missing sections fail closed
- fail closed before scans, tag creation, or upstream writes when required Plex, Jellyfin, Emby, or Seerr evidence is unavailable
- preserve retryable evidence failures in cross-domain action outcomes instead of incorrectly reporting that matched items disappeared
- publish a guarded zero-row Plex episode generation and evict stale child rows when the current parent generation proves there are no eligible watched shows
- require strict policy-row shapes and exact published-generation counts; a proven empty generation remains valid evidence
- expose Plex episode evidence only when the parent inventory is accepted and bind it to that exact generation
- require valid episode coverage for every eligible Plex instance and show while ignoring orphaned rows
- keep the forward-port independently buildable on `next` without stable-only cleanup imports

## Validation

- formatting passed
- shared package build and branch-correct Prisma client generation passed
- root typecheck passed
- root tests passed: API 3,753, web 777, shared 121
- lint passed
- production build passed
- server-enforced page-cap and guarded-empty-generation regression suites passed: 31/31 on this PR branch
- scheduled auto-tag, webhook auto-tag, and cross-domain executor suite passed: 38/38
- focused authority, Plex history, cache refresher, scheduled auto-tag, and webhook auto-tag suite passed: 75/75
- independent regression and data-safety reviews found no blockers on all recorded correction passes
- the rebased top branch preserves the durable provider-identity implementation of atomic empty-generation publication; its affected Plex suites pass 19/19

## Stack

This is the first remaining PR in the `next` parity stack and targets `next` directly. It forward-ports the stable Plex history compatibility work from #685 while preserving the stricter 3.0 cleanup authority model. PRs #726 and #727 are stacked above it and have been rebased onto this exact head.

Related to #685