### PR TITLE
fix(trash-guides): port deployment plan privacy

### DIFF
--- a/apps/web/src/features/trash-guides/components/__tests__/deployment-preview-modal-incognito.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/deployment-preview-modal-incognito.test.tsx
@@ -1,0 +1,286 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { DeploymentPreview } from "@arr/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+const hookMocks = vi.hoisted(() => ({
+	useDeploymentPreview: vi.fn(),
+	useExecuteDeployment: vi.fn(),
+}));
+
+vi.mock("../../../../hooks/api/useDeploymentPreview", () => hookMocks);
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#6366f1",
+			to: "#8b5cf6",
+			glow: "rgba(99, 102, 241, 0.3)",
+			fromLight: "rgba(99, 102, 241, 0.1)",
+			fromMuted: "rgba(99, 102, 241, 0.3)",
+		},
+	}),
+}));
+
+import { DeploymentPreviewModal } from "../deployment-preview-modal";
+
+const preview: DeploymentPreview = {
+	templateId: "template-1",
+	templateName: "Private Movie Profile",
+	instanceId: "instance-1",
+	instanceLabel: "Private Radarr",
+	instanceServiceType: "RADARR",
+	instanceVersion: "5.0.0",
+	executionToken: "b".repeat(64),
+	summary: {
+		totalItems: 3,
+		newCustomFormats: 1,
+		updatedCustomFormats: 1,
+		deletedCustomFormats: 0,
+		skippedCustomFormats: 1,
+		totalConflicts: 1,
+		unresolvedConflicts: 1,
+		unmatchedCustomFormats: 1,
+		orphanedCustomFormats: 1,
+	},
+	customFormats: [
+		{
+			trashId: "format-new",
+			name: "Secret New Format",
+			action: "create",
+			defaultScore: 1000,
+			scoreOverride: 1000,
+			templateData: {},
+			conflicts: [],
+			hasConflicts: false,
+		},
+		{
+			trashId: "format-update",
+			name: "Secret HDR",
+			action: "update",
+			defaultScore: 500,
+			scoreOverride: 500,
+			templateData: {},
+			instanceData: {},
+			conflicts: [
+				{
+					cfTrashId: "format-update",
+					cfName: "Secret HDR",
+					conflictType: "name_conflict",
+					templateValue: "Private Template Value",
+					instanceValue: "Private Instance Value",
+					suggestedResolution: "use_template",
+				},
+			],
+			hasConflicts: true,
+		},
+		{
+			trashId: "format-skip",
+			name: "Secret Family Profile",
+			action: "skip",
+			defaultScore: 25,
+			scoreOverride: 25,
+			templateData: {},
+			instanceData: {},
+			conflicts: [],
+			hasConflicts: false,
+		},
+	],
+	unmatchedCustomFormats: [
+		{ instanceId: 8, name: "Private Unknown Format", reason: "Private match reason" },
+	],
+	orphanedCustomFormats: [{ instanceId: 7, name: "Private Old Format", score: 100 }],
+	namingChanges: ["privateMovieFolderFormat"],
+	canDeploy: true,
+	requiresConflictResolution: true,
+	instanceReachable: true,
+	warnings: ["Private warning at http://private-radarr:7878"],
+};
+
+function renderWithProviders(children: ReactNode) {
+	const queryClient = new QueryClient({
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	});
+	return render(
+		<QueryClientProvider client={queryClient}>
+			<IncognitoProvider>{children}</IncognitoProvider>
+		</QueryClientProvider>,
+	);
+}
+
+describe("DeploymentPreviewModal privacy boundary", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		localStorage.setItem("arr-dashboard-incognito-mode", "false");
+		hookMocks.useDeploymentPreview.mockReturnValue({
+			data: { success: true, data: preview },
+			isLoading: false,
+			error: null,
+		});
+		hookMocks.useExecuteDeployment.mockReturnValue({
+			mutate: vi.fn(),
+			isError: false,
+			isPending: false,
+			data: undefined,
+			error: null,
+		});
+	});
+
+	it("shows every action in the reachable deployment plan", async () => {
+		renderWithProviders(
+			<DeploymentPreviewModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				templateName="Private Movie Profile"
+				instanceId="instance-1"
+				instanceLabel="Private Radarr"
+			/>,
+		);
+
+		expect(await screen.findByText("Deployment Summary")).toBeInTheDocument();
+		expect(screen.getByText("Skipped / disabled")).toBeInTheDocument();
+		expect(screen.getByText("Secret New Format")).toBeInTheDocument();
+		expect(screen.getByText("Secret HDR")).toBeInTheDocument();
+		expect(screen.getByText("Secret Family Profile")).toBeInTheDocument();
+		expect(screen.getByText("Private Unknown Format")).toBeInTheDocument();
+		expect(screen.getByText("Private match reason")).toBeInTheDocument();
+		expect(screen.getByText("Private Old Format")).toBeInTheDocument();
+		expect(screen.getByText("100 → 0")).toBeInTheDocument();
+		expect(screen.getByText("Naming Changes (1)")).toBeInTheDocument();
+		expect(screen.getByText("privateMovieFolderFormat")).toBeInTheDocument();
+		expect(screen.getByText(/Private warning at/)).toBeInTheDocument();
+	});
+
+	it("masks the reachable plan without changing execution authority", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		const mutate = vi.fn();
+		hookMocks.useExecuteDeployment.mockReturnValue({
+			mutate,
+			isError: true,
+			isPending: false,
+			data: undefined,
+			error: new Error("Private deployment error at http://private-radarr:7878"),
+		});
+
+		renderWithProviders(
+			<DeploymentPreviewModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				templateName="Private Movie Profile"
+				instanceId="instance-1"
+				instanceLabel="Private Radarr"
+			/>,
+		);
+
+		expect(await screen.findByText(/TRaSH template/)).toBeInTheDocument();
+		expect(screen.getByText(/Radarr 4K.*RADARR/)).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 2")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 3")).toBeInTheDocument();
+		expect(screen.getByText("Unmatched Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Orphaned Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Naming setting 1")).toBeInTheDocument();
+		expect(screen.getByText("Deployment warnings hidden in incognito mode.")).toBeInTheDocument();
+		expect(
+			screen.getByText("Deployment error details hidden in incognito mode."),
+		).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: "Instance Overrides" })).toBeNull();
+
+		fireEvent.click(screen.getByRole("button", { name: "View differences" }));
+		expect(
+			screen.getAllByText("Conflict details hidden in incognito mode.").length,
+		).toBeGreaterThan(0);
+		fireEvent.change(screen.getByRole("combobox"), { target: { value: "keep_existing" } });
+		fireEvent.click(screen.getByRole("button", { name: "Deploy to Instance" }));
+		expect(mutate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				templateId: "template-1",
+				instanceId: "instance-1",
+				executionToken: "b".repeat(64),
+				conflictResolutions: { "format-update": "keep_existing" },
+			}),
+			expect.any(Object),
+		);
+
+		for (const sensitiveText of [
+			"Private Movie Profile",
+			"Private Radarr",
+			"Secret New Format",
+			"Secret HDR",
+			"Secret Family Profile",
+			"Private Template Value",
+			"Private Instance Value",
+			"Private Unknown Format",
+			"Private match reason",
+			"Private Old Format",
+			"privateMovieFolderFormat",
+			"Private warning",
+			"Private deployment error",
+			"private-radarr",
+		]) {
+			expect(document.body.innerHTML).not.toContain(sensitiveText);
+		}
+	});
+
+	it("keeps a naming-only reviewed preview deployable", async () => {
+		const mutate = vi.fn();
+		hookMocks.useDeploymentPreview.mockReturnValue({
+			data: {
+				success: true,
+				data: {
+					...preview,
+					summary: {
+						...preview.summary,
+						totalItems: 0,
+						newCustomFormats: 0,
+						updatedCustomFormats: 0,
+						skippedCustomFormats: 0,
+						totalConflicts: 0,
+						unresolvedConflicts: 0,
+						unmatchedCustomFormats: 0,
+						orphanedCustomFormats: 0,
+					},
+					customFormats: [],
+					unmatchedCustomFormats: [],
+					orphanedCustomFormats: [],
+					warnings: [],
+					namingChanges: ["privateMovieFolderFormat"],
+					requiresConflictResolution: false,
+				},
+			},
+			isLoading: false,
+			error: null,
+		});
+		hookMocks.useExecuteDeployment.mockReturnValue({
+			mutate,
+			isError: false,
+			isPending: false,
+			data: undefined,
+			error: null,
+		});
+
+		renderWithProviders(
+			<DeploymentPreviewModal
+				open
+				onClose={vi.fn()}
+				templateId="template-1"
+				templateName="Private Movie Profile"
+				instanceId="instance-1"
+				instanceLabel="Private Radarr"
+			/>,
+		);
+
+		const deployButton = await screen.findByRole("button", { name: "Deploy to Instance" });
+		expect(screen.queryByText("Instance is up to date")).toBeNull();
+		expect(deployButton).toBeEnabled();
+		fireEvent.click(deployButton);
+		expect(mutate).toHaveBeenCalledWith(
+			expect.objectContaining({ executionToken: "b".repeat(64) }),
+			expect.any(Object),
+		);
+	});
+});

--- a/apps/web/src/features/trash-guides/components/__tests__/sync-validation-modal.test.tsx
+++ b/apps/web/src/features/trash-guides/components/__tests__/sync-validation-modal.test.tsx
@@ -1,0 +1,299 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
+
+const validation = vi.hoisted(() => ({
+	valid: true,
+	conflicts: [
+		{
+			configName: "Private Legacy Conflict",
+			existingId: 42,
+			action: "REPLACE" as const,
+			reason: "Private legacy conflict reason",
+		},
+	],
+	errors: [] as string[],
+	warnings: [] as string[],
+	executionToken: "a".repeat(64),
+	preview: {
+		templateId: "template-1",
+		templateName: "Private Movie Profile",
+		instanceId: "instance-1",
+		instanceLabel: "Private Radarr",
+		instanceServiceType: "RADARR" as const,
+		summary: {
+			totalItems: 3,
+			newCustomFormats: 1,
+			updatedCustomFormats: 1,
+			deletedCustomFormats: 0,
+			skippedCustomFormats: 1,
+			totalConflicts: 1,
+			unresolvedConflicts: 1,
+			unmatchedCustomFormats: 1,
+			orphanedCustomFormats: 1,
+		},
+		customFormats: [
+			{
+				trashId: "format-new",
+				name: "Secret New Format",
+				action: "create" as const,
+				defaultScore: 1000,
+				scoreOverride: 1000,
+				templateData: {},
+				instanceData: {},
+				conflicts: [],
+				hasConflicts: false,
+			},
+			{
+				trashId: "format-1",
+				name: "Secret HDR",
+				action: "update" as const,
+				defaultScore: 500,
+				scoreOverride: 500,
+				templateData: {},
+				instanceData: {},
+				conflicts: [
+					{
+						cfTrashId: "format-1",
+						conflictType: "name",
+						templateValue: "Private Template Value",
+						instanceValue: "Private Instance Value",
+					},
+				],
+				hasConflicts: true,
+			},
+			{
+				trashId: "format-2",
+				name: "Secret Family Profile",
+				action: "skip" as const,
+				defaultScore: 25,
+				scoreOverride: 25,
+				templateData: {},
+				instanceData: {},
+				conflicts: [],
+				hasConflicts: false,
+			},
+		],
+		unmatchedCustomFormats: [
+			{ instanceId: 8, name: "Private Unknown Format", reason: "Private match reason" },
+		],
+		orphanedCustomFormats: [{ instanceId: 7, name: "Private Old Format", score: 100 }],
+		canDeploy: true,
+		requiresConflictResolution: true,
+		instanceReachable: true,
+		executionToken: "a".repeat(64),
+		namingChanges: ["privateMovieFolderFormat"],
+		warnings: ["Private legacy mapping will be rebound during execution."],
+	},
+}));
+
+const hookState = vi.hoisted(() => ({
+	mode: "success" as "success" | "error" | "silent",
+	callbackInvoked: vi.fn(),
+	error: new Error("Private validation error at http://private-radarr:7878"),
+}));
+
+vi.mock("../../../../hooks/api/useSync", () => ({
+	useValidateSync: (options: {
+		onSuccess?: (data: typeof validation) => void;
+		onError?: (error: Error) => void;
+	}) => ({
+		mutate: (_request: unknown, callbacks?: { onSuccess?: (data: typeof validation) => void }) => {
+			if (hookState.mode === "error") {
+				hookState.callbackInvoked("error");
+				options.onError?.(hookState.error);
+				return;
+			}
+			if (hookState.mode === "silent") {
+				validation.valid = false;
+				validation.errors.length = 0;
+				hookState.callbackInvoked("silent");
+			}
+			options.onSuccess?.(validation);
+			callbacks?.onSuccess?.(validation);
+		},
+		isPending: false,
+		isError: hookState.mode === "error",
+		isSuccess: hookState.mode !== "error",
+		error: hookState.mode === "error" ? hookState.error : null,
+		cancelRetry: vi.fn(),
+	}),
+}));
+
+vi.mock("../../../../hooks/useThemeGradient", () => ({
+	useThemeGradient: () => ({
+		gradient: {
+			from: "#334155",
+			to: "#475569",
+			glow: "#334155",
+			fromLight: "#33415520",
+			fromMuted: "#33415540",
+		},
+	}),
+}));
+
+import { SyncValidationModal } from "../sync-validation-modal";
+
+function renderModal() {
+	return render(
+		<IncognitoProvider>
+			<SyncValidationModal
+				templateId="template-1"
+				templateName="Private Movie Profile"
+				instanceId="instance-1"
+				instanceName="Private Radarr"
+				onConfirm={vi.fn()}
+				onCancel={vi.fn()}
+			/>
+		</IncognitoProvider>,
+	);
+}
+
+describe("SyncValidationModal deployment plan", () => {
+	beforeEach(() => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "false");
+		hookState.mode = "success";
+		hookState.callbackInvoked.mockClear();
+		validation.valid = true;
+		validation.errors.length = 0;
+		validation.warnings.length = 0;
+	});
+
+	it("shows the complete upstream plan authorized by the execution token", async () => {
+		const onConfirm = vi.fn();
+		render(
+			<IncognitoProvider>
+				<SyncValidationModal
+					templateId="template-1"
+					templateName="Private Movie Profile"
+					instanceId="instance-1"
+					instanceName="Private Radarr"
+					onConfirm={onConfirm}
+					onCancel={vi.fn()}
+				/>
+			</IncognitoProvider>,
+		);
+
+		await waitFor(() => expect(screen.getByText("Deployment plan")).toBeInTheDocument());
+		expect(
+			screen.getByText(/1 create, 1 update, 1 score reset, 1 skipped\/disabled/),
+		).toBeInTheDocument();
+		expect(screen.getByText("Secret New Format")).toBeInTheDocument();
+		expect(screen.getByText("Create")).toBeInTheDocument();
+		expect(screen.getByText("Secret HDR")).toBeInTheDocument();
+		expect(screen.getByText("Update")).toBeInTheDocument();
+		expect(screen.getByText("Score: 500")).toBeInTheDocument();
+		expect(screen.getByText("Secret Family Profile")).toBeInTheDocument();
+		expect(screen.getAllByText("Skip").length).toBeGreaterThan(0);
+		expect(screen.getByText("Private Old Format")).toBeInTheDocument();
+		expect(screen.getByText("100 → 0")).toBeInTheDocument();
+		expect(screen.getByText("Private Unknown Format")).toBeInTheDocument();
+		expect(screen.getByText("Private match reason")).toBeInTheDocument();
+		expect(screen.getByText("privateMovieFolderFormat")).toBeInTheDocument();
+		expect(screen.getByText(/Private legacy mapping will be rebound/)).toBeInTheDocument();
+		expect(screen.getByText("Private Legacy Conflict")).toBeInTheDocument();
+		expect(screen.getByText("Private legacy conflict reason")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Use template version of Secret HDR" }));
+		fireEvent.click(
+			screen.getByRole("button", {
+				name: "Replace Private Legacy Conflict with template version",
+			}),
+		);
+		fireEvent.click(screen.getByRole("button", { name: "Proceed with Resolutions" }));
+		expect(onConfirm).toHaveBeenCalledWith("a".repeat(64), {
+			"format-1": "REPLACE",
+			"Private Legacy Conflict": "REPLACE",
+		});
+	});
+
+	it("masks every name-bearing deployment-plan field in incognito mode", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		validation.warnings.push("Missing Custom Formats at http://private-radarr:7878");
+		renderModal();
+
+		await waitFor(() => expect(screen.getByText("Deployment plan")).toBeInTheDocument());
+		expect(screen.getByText("TRaSH template")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 2")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format 3")).toBeInTheDocument();
+		expect(screen.getByText("Orphaned Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Unmatched Custom Format 1")).toBeInTheDocument();
+		expect(screen.getByText("Naming setting 1")).toBeInTheDocument();
+		expect(screen.getByText("Custom Format conflict 1")).toBeInTheDocument();
+		expect(
+			screen.getAllByText("Conflict details hidden in incognito mode.").length,
+		).toBeGreaterThan(0);
+		expect(
+			screen.getAllByText(/Deployment warnings hidden in incognito mode\./).length,
+		).toBeGreaterThan(0);
+
+		for (const sensitiveText of [
+			"Private Movie Profile",
+			"Secret New Format",
+			"Secret HDR",
+			"Secret Family Profile",
+			"Private Template Value",
+			"Private Instance Value",
+			"Private Old Format",
+			"Private Unknown Format",
+			"Private match reason",
+			"privateMovieFolderFormat",
+			"Private legacy mapping will be rebound during execution.",
+			"Private Legacy Conflict",
+			"Private legacy conflict reason",
+			"http://private-radarr:7878",
+		]) {
+			expect(document.body.innerHTML).not.toContain(sensitiveText);
+		}
+		expect(
+			screen.queryByRole("button", {
+				name: /Secret New Format|Secret HDR|Private Legacy Conflict/,
+			}),
+		).toBeNull();
+	});
+
+	it("masks validation errors in incognito mode", async () => {
+		localStorage.setItem("arr-dashboard-incognito-mode", "true");
+		validation.valid = false;
+		validation.errors.push("Private Radarr at http://private-radarr:7878 is unreachable");
+		renderModal();
+
+		await waitFor(() =>
+			expect(screen.getByText(/Validation errors hidden in incognito mode\./)).toBeInTheDocument(),
+		);
+		expect(screen.queryByText(/Private Radarr|private-radarr/)).toBeNull();
+	});
+
+	it.each(["error", "silent"] as const)(
+		"does not log raw %s callback payloads in incognito mode",
+		async (mode) => {
+			localStorage.setItem("arr-dashboard-incognito-mode", "true");
+			hookState.mode = mode;
+			const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+			try {
+				renderModal();
+				await waitFor(() => expect(hookState.callbackInvoked).toHaveBeenCalledWith(mode));
+				const serializedLogs = JSON.stringify([...errorSpy.mock.calls, ...warnSpy.mock.calls]);
+				for (const sensitiveText of [
+					"Private validation error",
+					"private-radarr",
+					"Private Legacy Conflict",
+					"Secret New Format",
+					"Secret HDR",
+					"Private Movie Profile",
+					"Private Radarr",
+					"Private Template Value",
+					"Private Instance Value",
+				]) {
+					expect(serializedLogs).not.toContain(sensitiveText);
+				}
+			} finally {
+				errorSpy.mockRestore();
+				warnSpy.mockRestore();
+			}
+		},
+	);
+});

--- a/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/deployment-preview-modal.tsx
@@ -60,6 +60,7 @@ export const DeploymentPreviewModal = ({
 }: DeploymentPreviewModalProps) => {
 	const [incognitoMode] = useIncognitoMode();
 	const { gradient: themeGradient } = useThemeGradient();
+	const displayTemplateName = incognitoMode ? "TRaSH template" : templateName;
 	const { data, isLoading, error } = useDeploymentPreview(templateId, instanceId);
 	const [expandedConflicts, setExpandedConflicts] = useState<Set<string>>(new Set());
 	const [showOverrideEditor, setShowOverrideEditor] = useState(false);
@@ -226,6 +227,22 @@ export const DeploymentPreviewModal = ({
 				? deploymentMutation.data.result.errors.join(", ")
 				: "Deployment failed"
 			: null;
+	const displayedDeploymentMessage =
+		deploymentMessage && incognitoMode
+			? "Deployment error details hidden in incognito mode."
+			: deploymentMessage;
+	const displayedPreviewWarnings = data?.data?.warnings?.length
+		? incognitoMode
+			? ["Deployment warnings hidden in incognito mode."]
+			: data.data.warnings
+		: [];
+	const hasDeployableChanges = Boolean(
+		data?.data &&
+			(data.data.summary.totalItems > 0 ||
+				data.data.customFormats.some((customFormat) => customFormat.action !== "skip") ||
+				data.data.orphanedCustomFormats.length > 0 ||
+				(data.data.namingChanges?.length ?? 0) > 0),
+	);
 
 	return (
 		<LegacyDialog open={open} onOpenChange={onClose} size="xl">
@@ -236,7 +253,7 @@ export const DeploymentPreviewModal = ({
 					<LegacyDialogTitle>Deployment Preview</LegacyDialogTitle>
 					<LegacyDialogDescription>
 						Review changes before deploying template to instance
-						{templateName && ` - "${templateName}"`}
+						{displayTemplateName && ` - "${displayTemplateName}"`}
 					</LegacyDialogDescription>
 				</div>
 			</LegacyDialogHeader>
@@ -271,7 +288,9 @@ export const DeploymentPreviewModal = ({
 									Failed to load deployment preview
 								</p>
 								<p className="text-sm text-muted-foreground mt-1">
-									{getErrorMessage(error, "Please try again")}
+									{incognitoMode
+										? "Preview error details hidden in incognito mode."
+										: getErrorMessage(error, "Please try again")}
 								</p>
 							</div>
 						</div>
@@ -319,15 +338,17 @@ export const DeploymentPreviewModal = ({
 										Version: {data.data.instanceVersion}
 									</p>
 								)}
-								<button
-									type="button"
-									onClick={() => setShowOverrideEditor(true)}
-									className="ml-auto flex items-center gap-2 rounded-xl border border-border/50 bg-card/50 px-3 py-2 text-xs font-medium text-foreground transition hover:bg-card/80"
-									title="Customize scores and enable/disable CFs for this instance"
-								>
-									<Settings className="h-3 w-3" />
-									Instance Overrides
-								</button>
+								{!incognitoMode && (
+									<button
+										type="button"
+										onClick={() => setShowOverrideEditor(true)}
+										className="ml-auto flex items-center gap-2 rounded-xl border border-border/50 bg-card/50 px-3 py-2 text-xs font-medium text-foreground transition hover:bg-card/80"
+										title="Customize scores and enable/disable CFs for this instance"
+									>
+										<Settings className="h-3 w-3" />
+										Instance Overrides
+									</button>
+								)}
 							</div>
 						</div>
 
@@ -437,7 +458,7 @@ export const DeploymentPreviewModal = ({
 						</div>
 
 						{/* Warnings */}
-						{data.data.warnings && data.data.warnings.length > 0 && (
+						{displayedPreviewWarnings.length > 0 && (
 							<div
 								className="rounded-xl p-4"
 								style={{
@@ -451,7 +472,7 @@ export const DeploymentPreviewModal = ({
 										style={{ color: SEMANTIC_COLORS.warning.from }}
 									/>
 									<div className="space-y-2">
-										{data.data.warnings.map((warning, idx) => (
+										{displayedPreviewWarnings.map((warning, idx) => (
 											<p
 												key={idx}
 												className="text-sm"
@@ -468,7 +489,7 @@ export const DeploymentPreviewModal = ({
 						{/* Summary Statistics */}
 						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-4">
 							<h3 className="text-sm font-medium text-foreground mb-3">Deployment Summary</h3>
-							<div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+							<div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-4">
 								<div className="space-y-1">
 									<p className="text-xs text-muted-foreground">Total Items</p>
 									<p className="text-2xl font-semibold text-foreground">
@@ -495,6 +516,17 @@ export const DeploymentPreviewModal = ({
 									</p>
 								</div>
 								<div className="space-y-1">
+									<p className="text-xs" style={{ color: SEMANTIC_COLORS.info.text }}>
+										Skipped / disabled
+									</p>
+									<p
+										className="text-2xl font-semibold"
+										style={{ color: SEMANTIC_COLORS.info.from }}
+									>
+										{data.data.summary.skippedCustomFormats}
+									</p>
+								</div>
+								<div className="space-y-1">
 									<p className="text-xs" style={{ color: SEMANTIC_COLORS.warning.text }}>
 										Conflicts
 									</p>
@@ -503,6 +535,17 @@ export const DeploymentPreviewModal = ({
 										style={{ color: SEMANTIC_COLORS.warning.from }}
 									>
 										{data.data.summary.totalConflicts}
+									</p>
+								</div>
+								<div className="space-y-1">
+									<p className="text-xs" style={{ color: SEMANTIC_COLORS.warning.text }}>
+										Score resets
+									</p>
+									<p
+										className="text-2xl font-semibold"
+										style={{ color: SEMANTIC_COLORS.warning.from }}
+									>
+										{data.data.summary.orphanedCustomFormats ?? 0}
 									</p>
 								</div>
 								<div className="space-y-1">
@@ -541,7 +584,7 @@ export const DeploymentPreviewModal = ({
 									Custom Format Changes ({data.data.customFormats.length})
 								</h3>
 								<div className="space-y-2 max-h-64 overflow-y-auto">
-									{data.data.customFormats.map((item) => (
+									{data.data.customFormats.map((item, itemIndex) => (
 										<div
 											key={item.trashId}
 											className="rounded-xl border p-3"
@@ -552,7 +595,9 @@ export const DeploymentPreviewModal = ({
 													{getActionIcon(item.action)}
 													<div className="flex-1 min-w-0">
 														<div className="flex items-center gap-2">
-															<p className="text-sm font-medium truncate">{item.name}</p>
+															<p className="text-sm font-medium truncate">
+																{incognitoMode ? `Custom Format ${itemIndex + 1}` : item.name}
+															</p>
 															<span className="px-2 py-0.5 rounded-full text-xs font-medium bg-current/10">
 																{getActionLabel(item.action)}
 															</span>
@@ -625,9 +670,11 @@ export const DeploymentPreviewModal = ({
 																				Template:
 																			</p>
 																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-muted-foreground font-mono text-[10px]">
-																				{typeof conflict.templateValue === "object"
-																					? JSON.stringify(conflict.templateValue, null, 2)
-																					: String(conflict.templateValue)}
+																				{incognitoMode
+																					? "Conflict details hidden in incognito mode."
+																					: typeof conflict.templateValue === "object"
+																						? JSON.stringify(conflict.templateValue, null, 2)
+																						: String(conflict.templateValue)}
 																			</pre>
 																		</div>
 																		<div
@@ -644,9 +691,11 @@ export const DeploymentPreviewModal = ({
 																				Instance:
 																			</p>
 																			<pre className="overflow-auto max-h-48 whitespace-pre-wrap wrap-break-word text-muted-foreground font-mono text-[10px]">
-																				{typeof conflict.instanceValue === "object"
-																					? JSON.stringify(conflict.instanceValue, null, 2)
-																					: String(conflict.instanceValue)}
+																				{incognitoMode
+																					? "Conflict details hidden in incognito mode."
+																					: typeof conflict.instanceValue === "object"
+																						? JSON.stringify(conflict.instanceValue, null, 2)
+																						: String(conflict.instanceValue)}
 																			</pre>
 																		</div>
 																	</div>
@@ -662,6 +711,25 @@ export const DeploymentPreviewModal = ({
 							</div>
 						)}
 
+						{/* Naming changes */}
+						{data.data.namingChanges && data.data.namingChanges.length > 0 && (
+							<div className="space-y-3">
+								<h3 className="text-sm font-medium text-foreground">
+									Naming Changes ({data.data.namingChanges.length})
+								</h3>
+								<div className="space-y-2">
+									{data.data.namingChanges.map((field, index) => (
+										<div
+											key={field}
+											className="rounded-xl border border-border/50 bg-card/30 p-3 text-sm text-foreground"
+										>
+											{incognitoMode ? `Naming setting ${index + 1}` : field}
+										</div>
+									))}
+								</div>
+							</div>
+						)}
+
 						{/* Unmatched Custom Formats */}
 						{data.data.unmatchedCustomFormats && data.data.unmatchedCustomFormats.length > 0 && (
 							<div className="space-y-3">
@@ -669,7 +737,7 @@ export const DeploymentPreviewModal = ({
 									Unmatched Custom Formats ({data.data.unmatchedCustomFormats.length})
 								</h3>
 								<div className="space-y-2 max-h-48 overflow-y-auto">
-									{data.data.unmatchedCustomFormats.map((item) => (
+									{data.data.unmatchedCustomFormats.map((item, index) => (
 										<div
 											key={item.instanceId}
 											className="rounded-xl border p-3"
@@ -688,10 +756,12 @@ export const DeploymentPreviewModal = ({
 														className="text-sm font-medium truncate"
 														style={{ color: SEMANTIC_COLORS.info.text }}
 													>
-														{item.name}
+														{incognitoMode ? `Unmatched Custom Format ${index + 1}` : item.name}
 													</p>
 													<p className="text-xs mt-1" style={{ color: SEMANTIC_COLORS.info.from }}>
-														{item.reason}
+														{incognitoMode
+															? "Match details hidden in incognito mode."
+															: item.reason}
 													</p>
 												</div>
 											</div>
@@ -712,7 +782,7 @@ export const DeploymentPreviewModal = ({
 									0.
 								</p>
 								<div className="max-h-48 space-y-2 overflow-y-auto">
-									{data.data.orphanedCustomFormats.map((orphan) => (
+									{data.data.orphanedCustomFormats.map((orphan, index) => (
 										<div
 											key={orphan.instanceId}
 											className="flex items-center justify-between gap-4 rounded-xl border p-3"
@@ -722,7 +792,7 @@ export const DeploymentPreviewModal = ({
 											}}
 										>
 											<span className="min-w-0 truncate text-sm font-medium text-foreground">
-												{orphan.name}
+												{incognitoMode ? `Orphaned Custom Format ${index + 1}` : orphan.name}
 											</span>
 											<span
 												className="shrink-0 font-mono text-sm"
@@ -737,7 +807,7 @@ export const DeploymentPreviewModal = ({
 						)}
 
 						{/* No Changes Message */}
-						{data.data.summary.totalItems === 0 && data.data.orphanedCustomFormats.length === 0 && (
+						{!hasDeployableChanges && (
 							<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-xs p-8 text-center">
 								<CheckCircle2
 									className="h-12 w-12 mx-auto mb-3"
@@ -754,7 +824,7 @@ export const DeploymentPreviewModal = ({
 			</LegacyDialogContent>
 
 			<LegacyDialogFooter>
-				{deploymentMessage && (
+				{displayedDeploymentMessage && (
 					<div
 						className="flex items-start gap-2 rounded-xl p-3 mr-auto"
 						style={{
@@ -776,7 +846,7 @@ export const DeploymentPreviewModal = ({
 							<p className="text-sm font-medium text-foreground">
 								{deploymentUncertain ? "Deployment Result Needs Review" : "Deployment Failed"}
 							</p>
-							<p className="text-sm text-muted-foreground mt-1">{deploymentMessage}</p>
+							<p className="text-sm text-muted-foreground mt-1">{displayedDeploymentMessage}</p>
 						</div>
 					</div>
 				)}
@@ -793,7 +863,7 @@ export const DeploymentPreviewModal = ({
 					disabled={
 						!data?.data ||
 						!data.data.canDeploy ||
-						data.data.summary.totalItems === 0 ||
+						!hasDeployableChanges ||
 						deploymentMutation.isPending
 					}
 					className="gap-2 rounded-xl font-medium"
@@ -814,7 +884,7 @@ export const DeploymentPreviewModal = ({
 			</LegacyDialogFooter>
 
 			{/* Instance Override Editor Modal */}
-			{showOverrideEditor && data?.data && templateId && instanceId && (
+			{showOverrideEditor && !incognitoMode && data?.data && templateId && instanceId && (
 				<InstanceOverrideEditor
 					open={showOverrideEditor}
 					onClose={() => setShowOverrideEditor(false)}

--- a/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
+++ b/apps/web/src/features/trash-guides/components/sync-validation-modal.tsx
@@ -84,6 +84,7 @@ export const SyncValidationModal = ({
 }: SyncValidationModalProps) => {
 	const { gradient: themeGradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
+	const displayTemplateName = incognitoMode ? "TRaSH template" : templateName;
 	const displayInstanceName = incognitoMode ? getLinuxInstanceName(instanceName) : instanceName;
 	const [resolutions, setResolutions] = useState<Record<string, "REPLACE" | "SKIP">>({});
 	const [validation, setValidation] = useState<ValidationResult | null>(null);
@@ -124,17 +125,18 @@ export const SyncValidationModal = ({
 			const endTime = Date.now();
 			setTiming((prev) => {
 				const duration = prev.startTime > 0 ? endTime - prev.startTime : null;
-				console.error("[SyncValidationModal] Validation error:", {
-					error: error.message,
-					templateId,
-					instanceId,
-					retryCount,
-					timing: {
-						startTime: prev.startTime > 0 ? new Date(prev.startTime).toISOString() : null,
-						endTime: new Date(endTime).toISOString(),
-						durationMs: duration,
-					},
-				});
+				if (!incognitoMode) {
+					console.error("[SyncValidationModal] Validation error:", {
+						templateId,
+						instanceId,
+						retryCount,
+						timing: {
+							startTime: prev.startTime > 0 ? new Date(prev.startTime).toISOString() : null,
+							endTime: new Date(endTime).toISOString(),
+							durationMs: duration,
+						},
+					});
+				}
 				return { ...prev, endTime, duration };
 			});
 		},
@@ -143,9 +145,12 @@ export const SyncValidationModal = ({
 			const endTime = Date.now();
 			setTiming((prev) => {
 				const duration = endTime - prev.startTime;
-				if (!data.valid && (!data.errors || data.errors.length === 0)) {
-					console.warn("[SyncValidationModal] Silent failure - full validation response:", {
-						validation: data,
+				if (!incognitoMode && !data.valid && (!data.errors || data.errors.length === 0)) {
+					console.warn("[SyncValidationModal] Silent validation failure:", {
+						valid: data.valid,
+						errorCount: data.errors?.length ?? 0,
+						warningCount: data.warnings?.length ?? 0,
+						hasPreview: Boolean(data.preview),
 						templateId,
 						instanceId,
 						timing: {
@@ -314,10 +319,23 @@ export const SyncValidationModal = ({
 		(w) => !w.includes("is reachable") && !w.includes("Validation passed"),
 	);
 	const hasActualWarnings = actualWarnings.length > 0;
+	const displayedValidationErrors = incognitoMode
+		? ["Validation errors hidden in incognito mode."]
+		: (validation?.errors ?? []);
+	const displayedActualWarnings = incognitoMode
+		? ["Deployment warnings hidden in incognito mode."]
+		: actualWarnings;
+	const displayedInformationalWarnings = incognitoMode
+		? ["Validation information hidden in incognito mode."]
+		: informationalWarnings;
 
 	const _isAutoRetrying = retryProgress !== null && retryProgress.isWaiting;
 
 	const displayError = localError ?? validateMutation.error ?? null;
+	const displayedMutationError =
+		incognitoMode && displayError
+			? new Error("Validation request failed; details hidden in incognito mode.")
+			: displayError;
 
 	const handleConfirm = () => {
 		if (!validation?.executionToken || !canConfirm) return;
@@ -384,8 +402,9 @@ export const SyncValidationModal = ({
 								Validate Sync
 							</h2>
 							<p className="mt-1 text-sm text-muted-foreground">
-								Template: <span className="font-medium text-foreground">{templateName}</span> →
-								Instance: <span className="font-medium text-foreground">{displayInstanceName}</span>
+								Template: <span className="font-medium text-foreground">{displayTemplateName}</span>{" "}
+								→ Instance:{" "}
+								<span className="font-medium text-foreground">{displayInstanceName}</span>
 							</p>
 						</div>
 					</div>
@@ -428,7 +447,7 @@ export const SyncValidationModal = ({
 
 							{hasErrors && (
 								<ValidationErrorPanel
-									errors={validation.errors}
+									errors={displayedValidationErrors}
 									errorTypes={errorTypes}
 									themeGradient={themeGradient}
 									onCancel={onCancel}
@@ -440,7 +459,7 @@ export const SyncValidationModal = ({
 								/>
 							)}
 
-							{hasActualWarnings && <ValidationWarningsPanel warnings={actualWarnings} />}
+							{hasActualWarnings && <ValidationWarningsPanel warnings={displayedActualWarnings} />}
 
 							{/* Informational messages */}
 							{informationalWarnings.length > 0 && canProceed && (
@@ -455,13 +474,30 @@ export const SyncValidationModal = ({
 										<Info className="h-5 w-5 shrink-0" style={{ color: themeGradient.from }} />
 										<div className="flex-1">
 											<ul className="space-y-1 text-sm text-muted-foreground">
-												{informationalWarnings.map((info, index) => (
+												{displayedInformationalWarnings.map((info, index) => (
 													<li key={index}>• {info}</li>
 												))}
 											</ul>
 										</div>
 									</div>
 								</div>
+							)}
+
+							{preview && (
+								<section
+									className="rounded-xl border border-border/50 bg-card/30 p-4"
+									aria-labelledby="sync-deployment-plan"
+								>
+									<h3 id="sync-deployment-plan" className="font-medium text-foreground">
+										Deployment plan
+									</h3>
+									<p className="mt-1 text-xs text-muted-foreground">
+										{preview.summary.newCustomFormats} create,{" "}
+										{preview.summary.updatedCustomFormats} update,{" "}
+										{preview.summary.orphanedCustomFormats} score reset,{" "}
+										{preview.summary.skippedCustomFormats} skipped/disabled
+									</p>
+								</section>
 							)}
 
 							{customFormats.length > 0 && (
@@ -473,9 +509,10 @@ export const SyncValidationModal = ({
 										Custom Format Changes ({customFormats.length})
 									</h3>
 									<div className="space-y-2">
-										{customFormats.map((item) => {
+										{customFormats.map((item, index) => {
 											const hasItemConflicts = item.hasConflicts || item.conflicts.length > 0;
 											const resolution = resolutions[item.trashId];
+											const displayName = incognitoMode ? `Custom Format ${index + 1}` : item.name;
 
 											return (
 												<div
@@ -485,7 +522,7 @@ export const SyncValidationModal = ({
 													<div className="flex items-start justify-between gap-3">
 														<div className="min-w-0">
 															<p className="truncate text-sm font-medium text-foreground">
-																{item.name}
+																{displayName}
 															</p>
 															<p className="mt-1 text-xs text-muted-foreground">
 																Score: {item.scoreOverride}
@@ -513,10 +550,14 @@ export const SyncValidationModal = ({
 																				{formatConflictType(conflict.conflictType)}
 																			</p>
 																			<p className="mt-1 break-words text-muted-foreground">
-																				Template: {formatConflictValue(conflict.templateValue)}
+																				{incognitoMode
+																					? "Conflict details hidden in incognito mode."
+																					: `Template: ${formatConflictValue(conflict.templateValue)}`}
 																			</p>
 																			<p className="mt-1 break-words text-muted-foreground">
-																				Instance: {formatConflictValue(conflict.instanceValue)}
+																				{incognitoMode
+																					? null
+																					: `Instance: ${formatConflictValue(conflict.instanceValue)}`}
 																			</p>
 																		</div>
 																	))}
@@ -526,7 +567,7 @@ export const SyncValidationModal = ({
 																<Button
 																	size="sm"
 																	variant={resolution === "REPLACE" ? "default" : "outline"}
-																	aria-label={`Use template version of ${item.name}`}
+																	aria-label={`Use template version of ${displayName}`}
 																	aria-pressed={resolution === "REPLACE"}
 																	onClick={() => handleResolutionChange(item.trashId, "REPLACE")}
 																	className="rounded-xl"
@@ -536,7 +577,7 @@ export const SyncValidationModal = ({
 																<Button
 																	size="sm"
 																	variant={resolution === "SKIP" ? "default" : "outline"}
-																	aria-label={`Keep existing ${item.name}`}
+																	aria-label={`Keep existing ${displayName}`}
 																	aria-pressed={resolution === "SKIP"}
 																	onClick={() => handleResolutionChange(item.trashId, "SKIP")}
 																	className="rounded-xl"
@@ -559,12 +600,12 @@ export const SyncValidationModal = ({
 										Naming Changes ({namingChanges.length})
 									</h3>
 									<div className="space-y-2">
-										{namingChanges.map((field) => (
+										{namingChanges.map((field, index) => (
 											<div
 												key={field}
 												className="rounded-lg border border-border/50 bg-card/30 px-3 py-2 text-sm text-foreground"
 											>
-												{field}
+												{incognitoMode ? `Naming setting ${index + 1}` : field}
 											</div>
 										))}
 									</div>
@@ -577,13 +618,17 @@ export const SyncValidationModal = ({
 										Unmatched Custom Formats ({unmatchedCustomFormats.length})
 									</h3>
 									<div className="space-y-2">
-										{unmatchedCustomFormats.map((item) => (
+										{unmatchedCustomFormats.map((item, index) => (
 											<div
 												key={item.instanceId}
 												className="rounded-lg border border-border/50 bg-card/30 px-3 py-2"
 											>
-												<p className="text-sm font-medium text-foreground">{item.name}</p>
-												<p className="mt-1 text-xs text-muted-foreground">{item.reason}</p>
+												<p className="text-sm font-medium text-foreground">
+													{incognitoMode ? `Unmatched Custom Format ${index + 1}` : item.name}
+												</p>
+												<p className="mt-1 text-xs text-muted-foreground">
+													{incognitoMode ? "Match details hidden in incognito mode." : item.reason}
+												</p>
 											</div>
 										))}
 									</div>
@@ -612,13 +657,13 @@ export const SyncValidationModal = ({
 												0.
 											</p>
 											<div className="mt-3 space-y-2">
-												{orphanedCustomFormats.map((orphan) => (
+												{orphanedCustomFormats.map((orphan, index) => (
 													<div
 														key={orphan.instanceId}
 														className="flex items-center justify-between gap-4 rounded-lg border border-border/50 bg-card/30 px-3 py-2"
 													>
 														<span className="min-w-0 truncate text-sm font-medium text-foreground">
-															{orphan.name}
+															{incognitoMode ? `Orphaned Custom Format ${index + 1}` : orphan.name}
 														</span>
 														<span
 															className="shrink-0 font-mono text-sm"
@@ -649,16 +694,22 @@ export const SyncValidationModal = ({
 											</p>
 
 											<div className="mt-4 space-y-3">
-												{legacyConflicts.map((conflict) => (
+												{legacyConflicts.map((conflict, index) => (
 													<div
 														key={conflict.configName}
 														className="rounded-xl border border-border/50 bg-card/30 p-3"
 													>
 														<div className="flex items-center justify-between">
 															<div className="flex-1">
-																<p className="font-medium text-foreground">{conflict.configName}</p>
+																<p className="font-medium text-foreground">
+																	{incognitoMode
+																		? `Custom Format conflict ${index + 1}`
+																		: conflict.configName}
+																</p>
 																<p className="mt-0.5 text-xs text-muted-foreground">
-																	{conflict.reason}
+																	{incognitoMode
+																		? "Conflict details hidden in incognito mode."
+																		: conflict.reason}
 																</p>
 															</div>
 
@@ -673,7 +724,11 @@ export const SyncValidationModal = ({
 																	onClick={() =>
 																		handleResolutionChange(conflict.configName, "REPLACE")
 																	}
-																	aria-label={`Replace ${conflict.configName} with template version`}
+																	aria-label={
+																		incognitoMode
+																			? `Replace Custom Format conflict ${index + 1} with template version`
+																			: `Replace ${conflict.configName} with template version`
+																	}
 																	aria-pressed={resolutions[conflict.configName] === "REPLACE"}
 																	className="rounded-xl"
 																	style={
@@ -696,7 +751,11 @@ export const SyncValidationModal = ({
 																	onClick={() =>
 																		handleResolutionChange(conflict.configName, "SKIP")
 																	}
-																	aria-label={`Keep existing ${conflict.configName}`}
+																	aria-label={
+																		incognitoMode
+																			? `Keep existing Custom Format conflict ${index + 1}`
+																			: `Keep existing ${conflict.configName}`
+																	}
 																	aria-pressed={resolutions[conflict.configName] === "SKIP"}
 																	className="rounded-xl"
 																	style={
@@ -739,10 +798,12 @@ export const SyncValidationModal = ({
 					)}
 
 					{/* Mutation Error */}
-					{displayError && <MutationErrorPanel error={displayError} {...retryProps} />}
+					{displayedMutationError && (
+						<MutationErrorPanel error={displayedMutationError} {...retryProps} />
+					)}
 
 					{/* Development Debug Panel */}
-					{isDevelopment && (
+					{isDevelopment && !incognitoMode && (
 						<SyncDebugPanel
 							templateId={templateId}
 							instanceId={instanceId}

--- a/apps/web/src/hooks/api/__tests__/useSync-privacy.test.tsx
+++ b/apps/web/src/hooks/api/__tests__/useSync-privacy.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+	validateSync: vi.fn(),
+}));
+
+vi.mock("../../../lib/api-client/trash-guides", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../../lib/api-client/trash-guides")>();
+	return { ...actual, validateSync: apiMocks.validateSync };
+});
+
+import { useValidateSync } from "../useSync";
+
+function createWrapper(client: QueryClient) {
+	return function Wrapper({ children }: { children: ReactNode }) {
+		return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+	};
+}
+
+describe("useValidateSync log privacy", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("does not log raw validation error messages", async () => {
+		apiMocks.validateSync.mockRejectedValue(
+			new Error("Private API key at http://private-radarr:7878"),
+		);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const { result } = renderHook(() => useValidateSync(), {
+			wrapper: createWrapper(client),
+		});
+
+		try {
+			await act(async () => {
+				await result.current
+					.mutateAsync({ templateId: "template-1", instanceId: "instance-1" })
+					.catch(() => undefined);
+			});
+
+			const serializedLogs = JSON.stringify(errorSpy.mock.calls);
+			expect(serializedLogs).not.toContain("Private API key");
+			expect(serializedLogs).not.toContain("private-radarr");
+		} finally {
+			errorSpy.mockRestore();
+			client.clear();
+		}
+	});
+
+	it("does not log raw silent-failure responses", async () => {
+		apiMocks.validateSync.mockResolvedValue({
+			valid: false,
+			conflicts: [
+				{
+					configName: "Private Custom Format",
+					existingId: 42,
+					action: "REPLACE",
+					reason: "Private conflict reason",
+				},
+			],
+			errors: [],
+			warnings: ["Private warning at http://private-radarr:7878"],
+		});
+		const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+		const { result } = renderHook(() => useValidateSync(), {
+			wrapper: createWrapper(client),
+		});
+
+		try {
+			await act(async () => {
+				await result.current.mutateAsync({ templateId: "template-1", instanceId: "instance-1" });
+			});
+
+			const serializedLogs = JSON.stringify(warnSpy.mock.calls);
+			expect(serializedLogs).not.toContain("Private Custom Format");
+			expect(serializedLogs).not.toContain("Private conflict reason");
+			expect(serializedLogs).not.toContain("Private warning");
+			expect(serializedLogs).not.toContain("private-radarr");
+		} finally {
+			warnSpy.mockRestore();
+			client.clear();
+		}
+	});
+});

--- a/apps/web/src/hooks/api/useSync.ts
+++ b/apps/web/src/hooks/api/useSync.ts
@@ -179,9 +179,8 @@ export function useValidateSync(options?: UseValidateSyncOptions) {
 			);
 		},
 		onError: (error) => {
-			// Enhanced error logging with timestamp
+			// Keep browser logs useful without exposing upstream error details.
 			console.error("[useValidateSync] Validation failed:", {
-				message: error.message,
 				name: error.name,
 				timestamp: new Date().toISOString(),
 			});
@@ -204,7 +203,6 @@ export function useValidateSync(options?: UseValidateSyncOptions) {
 					"[useValidateSync] Silent failure detected - validation invalid with no errors:",
 					logContext,
 				);
-				console.warn("[useValidateSync] Full validation response:", data);
 			} else if (process.env.NODE_ENV === "development") {
 				// eslint-disable-next-line no-console -- dev-only debug logging
 				console.log("[useValidateSync] Validation completed:", logContext);


### PR DESCRIPTION
## Summary

- port the stable deployment-plan completeness and privacy behavior from #687 to the native 3.0 TRaSH UI
- mask template, instance, Custom Format, conflict, warning, error, naming, unmatched, and orphan details in incognito mode
- remove raw validation payloads from browser logs
- preserve execution tokens, target IDs, and conflict resolutions unchanged

## Validation

- regression-first stable privacy suite: 10 failed before the port, then 10 passed
- independent regression review: no actionable findings; focused reviewer slice 25 passed
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`: shared 121, web 807, API suite passed with expected skips
- `pnpm run lint`
- `pnpm run build`

## Review boundary

This is a focused six-file privacy parity port. It does not change API contracts, deployment authority, upstream mutation behavior, or the 3.0 sync-review lifecycle.

Stable parity: #687