### PR TITLE
fix(library): preserve ARR rating provenance on next

### DIFF
--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -437,6 +437,29 @@ describe("syncInstance", () => {
 				),
 			).toBeNull();
 		});
+
+		it("drops Radarr zero sentinels instead of matching them as low ratings", async () => {
+			const { data, cacheItem } = await syncRating("RADARR", {
+				imdb: { value: 0, votes: 0 },
+				tmdb: { value: "0", votes: 0 },
+			});
+			expect(data.ratings).toBeUndefined();
+			expect(extractRating(cacheItem)).toBeNull();
+			expect(
+				evaluateSingleCondition(
+					cacheItem,
+					"imdb_rating",
+					{ operator: "less_than", score: 5 },
+					{ now: new Date("2026-07-30T00:00:00Z") },
+				),
+			).toBeNull();
+		});
+
+		it("drops Sonarr zero sentinels instead of caching a general rating", async () => {
+			const { data, cacheItem } = await syncRating("SONARR", { value: "0", votes: 0 });
+			expect(data.ratings).toBeUndefined();
+			expect(extractRating(cacheItem)).toBeNull();
+		});
 	});
 
 	// --- Data column selection tests ----------------------------------------

--- a/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
+++ b/apps/api/src/lib/library-sync/__tests__/sync-executor.test.ts
@@ -9,12 +9,15 @@
  * - Memory instrumentation at debug level
  */
 
+import { libraryItemSchema } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient, ServiceInstance, ServiceType } from "../../../lib/prisma.js";
 import type { ArrClientFactory } from "../../arr/client-factory.js";
 import { createArrServiceFingerprint } from "../../arr/service-fingerprint.js";
 import type { Encryptor } from "../../auth/encryption.js";
+import { evaluateSingleCondition, extractRating } from "../../library-cleanup/rule-evaluators.js";
+import type { CacheItemForEval } from "../../library-cleanup/types.js";
 import { type LibraryStreamFn, type SyncExecutorDeps, syncInstance } from "../sync-executor.js";
 
 const MOCK_USER_ID = "user-1";
@@ -346,6 +349,96 @@ function setupSync(
 // ============================================================================
 
 describe("syncInstance", () => {
+	describe("rating cache contract", () => {
+		async function syncRating(
+			service: "RADARR" | "SONARR",
+			ratings: unknown,
+		): Promise<{ data: Record<string, unknown>; cacheItem: CacheItemForEval }> {
+			const raw = makeRawItem({
+				ratings,
+				...(service === "SONARR" ? { statistics: { episodeFileCount: 0, sizeOnDisk: 0 } } : {}),
+			});
+			const { deps, instance, mockPrisma } = setupSync(service, [raw], []);
+			expect((await syncInstance(deps, instance)).success).toBe(true);
+			const serialized = mockPrisma._txCreates[0]?.data.data;
+			expect(typeof serialized).toBe("string");
+			const data = JSON.parse(serialized as string) as Record<string, unknown>;
+			expect(libraryItemSchema.safeParse(data).success).toBe(true);
+			return {
+				data,
+				cacheItem: {
+					id: "rating-cache",
+					instanceId: instance.id,
+					arrItemId: 1,
+					itemType: service === "RADARR" ? "movie" : "series",
+					title: "Test Item",
+					year: 2024,
+					monitored: true,
+					hasFile: false,
+					status: "released",
+					qualityProfileId: 1,
+					qualityProfileName: "Test Profile",
+					sizeOnDisk: 0n,
+					arrAddedAt: null,
+					data: serialized as string,
+				},
+			};
+		}
+
+		it("preserves Radarr source provenance and matches IMDb cleanup from cached data", async () => {
+			const { data, cacheItem } = await syncRating("RADARR", {
+				imdb: { value: 7.4, votes: 100 },
+				tmdb: { value: 8.6, votes: 200 },
+				metacritic: { value: 84, votes: 20 },
+			});
+			expect(data.ratings).toEqual({
+				imdb: { value: 7.4, votes: 100 },
+				tmdb: { value: 8.6, votes: 200 },
+				metacritic: { value: 84, votes: 20 },
+			});
+			expect(extractRating(cacheItem)).toBe(8.6);
+			expect(
+				evaluateSingleCondition(
+					cacheItem,
+					"imdb_rating",
+					{ operator: "less_than", score: 10 },
+					{ now: new Date("2026-07-30T00:00:00Z") },
+				),
+			).toBe("IMDb rating: 7.4 (threshold: < 10)");
+		});
+
+		it("keeps Sonarr's flat score separate from IMDb", async () => {
+			const { data, cacheItem } = await syncRating("SONARR", { value: 6.8, votes: 500 });
+			expect(data.ratings).toEqual({ value: 6.8, votes: 500 });
+			expect(extractRating(cacheItem)).toBe(6.8);
+			expect(
+				evaluateSingleCondition(
+					cacheItem,
+					"imdb_rating",
+					{ operator: "less_than", score: 10 },
+					{ now: new Date("2026-07-30T00:00:00Z") },
+				),
+			).toBeNull();
+		});
+
+		it("drops blank Radarr values instead of matching them as zero ratings", async () => {
+			const { data, cacheItem } = await syncRating("RADARR", {
+				imdb: { value: "   ", votes: 100 },
+				tmdb: { value: 8.6, votes: 200 },
+			});
+			expect(data.ratings).toEqual({ tmdb: { value: 8.6, votes: 200 } });
+			expect(extractRating(cacheItem)).toBe(8.6);
+			expect(
+				evaluateSingleCondition(
+					cacheItem,
+					"imdb_rating",
+					{ operator: "less_than", score: 10 },
+					{ now: new Date("2026-07-30T00:00:00Z") },
+				),
+			).toBeNull();
+		});
+	});
+
 	// --- Data column selection tests ----------------------------------------
 
 	describe("LibraryCache data column selection", () => {

--- a/apps/api/src/lib/library/movie-normalizer.ts
+++ b/apps/api/src/lib/library/movie-normalizer.ts
@@ -1,6 +1,7 @@
 import type { LibraryItem, LibraryService } from "@arr/shared";
 import type { ServiceInstance } from "../../lib/prisma.js";
 import { normalizeImages } from "./image-normalizer.js";
+import { normalizeRatings } from "./rating-normalizer.js";
 import {
 	normalizeGenres,
 	normalizeTags,
@@ -140,6 +141,7 @@ export const buildMovieItem = (
 			tmdbId: toNumber(raw?.tmdbId),
 			imdbId: toStringValue(raw?.imdbId),
 		},
+		ratings: normalizeRatings(raw?.ratings, service),
 		movieFile: buildMovieFile(raw?.movieFile as Record<string, unknown>),
 		statistics: {
 			movieFileQuality: (() => {

--- a/apps/api/src/lib/library/rating-normalizer.ts
+++ b/apps/api/src/lib/library/rating-normalizer.ts
@@ -11,7 +11,8 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 
 function normalizeRatingValue(value: unknown): number | undefined {
 	if (typeof value === "string" && value.trim() === "") return undefined;
-	return toNumber(value);
+	const rating = toNumber(value);
+	return rating !== undefined && rating > 0 ? rating : undefined;
 }
 
 function normalizeRatingChild(value: unknown) {

--- a/apps/api/src/lib/library/rating-normalizer.ts
+++ b/apps/api/src/lib/library/rating-normalizer.ts
@@ -1,0 +1,64 @@
+import type { LibraryRatings, LibraryService } from "@arr/shared";
+import { toNumber, toStringValue } from "./type-converters.js";
+
+const RADARR_RATING_SOURCES = ["imdb", "tmdb", "metacritic", "rottenTomatoes", "trakt"] as const;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: undefined;
+}
+
+function normalizeRatingValue(value: unknown): number | undefined {
+	if (typeof value === "string" && value.trim() === "") return undefined;
+	return toNumber(value);
+}
+
+function normalizeRatingChild(value: unknown) {
+	const child = asRecord(value);
+	if (!child) return undefined;
+
+	const rating = normalizeRatingValue(child.value);
+	if (rating === undefined) return undefined;
+
+	return {
+		value: rating,
+		votes: toNumber(child.votes),
+		type: toStringValue(child.type),
+	};
+}
+
+/**
+ * Preserve the rating provenance exposed by each supported *arr service.
+ *
+ * Radarr has explicit per-source children, including IMDb. Sonarr exposes one
+ * source-less SkyHook score; it remains useful to the general rating rule but
+ * must not be promoted to IMDb.
+ */
+export function normalizeRatings(
+	value: unknown,
+	service: LibraryService,
+): LibraryRatings | undefined {
+	const ratings = asRecord(value);
+	if (!ratings) return undefined;
+
+	if (service === "radarr") {
+		const normalized: LibraryRatings = {};
+		for (const source of RADARR_RATING_SOURCES) {
+			const child = normalizeRatingChild(ratings[source]);
+			if (child) normalized[source] = child;
+		}
+		return Object.keys(normalized).length > 0 ? normalized : undefined;
+	}
+
+	if (service === "sonarr") {
+		const rating = normalizeRatingValue(ratings.value);
+		if (rating === undefined) return undefined;
+		return {
+			value: rating,
+			votes: toNumber(ratings.votes),
+		};
+	}
+
+	return undefined;
+}

--- a/apps/api/src/lib/library/series-normalizer.ts
+++ b/apps/api/src/lib/library/series-normalizer.ts
@@ -2,6 +2,7 @@ import type { LibraryItem, LibraryService } from "@arr/shared";
 import type { ServiceInstance } from "../../lib/prisma.js";
 import { normalizeImages } from "./image-normalizer.js";
 import { extractYear } from "./movie-normalizer.js";
+import { normalizeRatings } from "./rating-normalizer.js";
 import {
 	normalizeGenres,
 	normalizeTags,
@@ -108,6 +109,7 @@ export const buildSeriesItem = (
 			imdbId: toStringValue(raw?.imdbId),
 			tvdbId: toNumber(raw?.tvdbId),
 		},
+		ratings: normalizeRatings(raw?.ratings, service),
 		seasons: normalizeSeasons(raw?.seasons),
 		statistics: {
 			seasonCount: toNumber(stats?.seasonCount),

--- a/packages/shared/src/types/library.ts
+++ b/packages/shared/src/types/library.ts
@@ -75,6 +75,34 @@ export const librarySeasonSchema = z.object({
 
 export type LibrarySeason = z.infer<typeof librarySeasonSchema>;
 
+export const libraryRatingChildSchema = z.object({
+	votes: z.number().optional(),
+	value: z.number(),
+	type: z.string().optional(),
+});
+
+export type LibraryRatingChild = z.infer<typeof libraryRatingChildSchema>;
+
+/**
+ * Normalized *arr ratings while preserving the upstream rating source.
+ *
+ * Radarr supplies source-keyed children (`imdb`, `tmdb`, etc.). Sonarr
+ * supplies a source-less SkyHook rating directly as `{ value, votes }`.
+ * Keeping those shapes distinct prevents consumers from treating Sonarr's
+ * general series score as an IMDb score.
+ */
+export const libraryRatingsSchema = z.object({
+	imdb: libraryRatingChildSchema.optional(),
+	tmdb: libraryRatingChildSchema.optional(),
+	metacritic: libraryRatingChildSchema.optional(),
+	rottenTomatoes: libraryRatingChildSchema.optional(),
+	trakt: libraryRatingChildSchema.optional(),
+	value: z.number().optional(),
+	votes: z.number().optional(),
+});
+
+export type LibraryRatings = z.infer<typeof libraryRatingsSchema>;
+
 export const libraryItemSchema = z.object({
 	id: z.union([z.number(), z.string()]),
 	instanceId: z.string(),
@@ -126,6 +154,7 @@ export const libraryItemSchema = z.object({
 			asin: z.string().optional(),
 		})
 		.optional(),
+	ratings: libraryRatingsSchema.optional(),
 	statistics: libraryItemStatisticsSchema.optional(),
 });
 


### PR DESCRIPTION
## Summary

- add a shared source-aware rating contract for normalized library items
- preserve Radarr IMDb/TMDb/etc. ratings and the source-less Sonarr score through library sync and cache serialization
- reject blank, non-finite, zero, and negative rating values so unavailable upstream data cannot become a cleanup match
- cover the exact Radarr IMDb less-than path and prove Sonarr is not treated as IMDb

## Validation

- TDD reproduced both rating shapes being dropped on next
- focused sync executor suite: 37 passed
- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck after local Prisma generation
- pnpm run test: shared 121, web 807, API 3,935 passed with expected skips
- pnpm run lint
- pnpm run build
- independent regression review: blank-value finding corrected; no other actionable findings
- hosted review: zero-sentinel finding corrected in one pass
- independent data-safety review of the final diff: no actionable findings

This forward-ports the focused rating behavior from stable PR #668 and the exact regression from PR #671 without importing the broader cleanup stack.

Related to #660