### PR TITLE
fix(cleanup): unify episode target identity

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1335,6 +1335,7 @@ model LibraryCleanupApproval {
   itemType        LibraryItemType              // movie | series
   targetScope     String    @default("series") // "series" | "episode"
   arrEpisodeId    Int?
+  episodeFileId   Int?
   seasonNumber    Int?
   episodeNumber   Int?
   episodeTitle    String?

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -4,6 +4,7 @@ import { buildMovieItem } from "../../library/movie-normalizer.js";
 import { PlexMovieNotFoundError } from "../../plex/plex-client.js";
 import {
 	buildCleanupPreviewDetails,
+	cleanupApprovalTargetKey,
 	CleanupRunAlreadyInProgressError,
 	CleanupRunLeaseLostError,
 	executeApprovedItems,
@@ -889,6 +890,106 @@ describe("shared Plex deletion safety", () => {
 		itemType: "movie",
 		action: "delete",
 	};
+
+	it("keys file-changing episode work by physical file and unmonitoring by episode", () => {
+		const episodeTarget = (
+			arrEpisodeId: number,
+			episodeFileId: number,
+			action: "delete" | "delete_files" | "unmonitor",
+		) => ({
+			instanceId: "sonarr-1",
+			arrItemId: 42,
+			itemType: "series",
+			targetScope: "episode",
+			arrEpisodeId,
+			episodeFileId,
+			action,
+		});
+
+		expect(cleanupDeleteTargetKey(episodeTarget(101, 7001, "delete"))).toBe(
+			cleanupDeleteTargetKey(episodeTarget(102, 7001, "delete_files")),
+		);
+		expect(cleanupDeleteTargetKey(episodeTarget(101, 7001, "unmonitor"))).not.toBe(
+			cleanupDeleteTargetKey(episodeTarget(102, 7001, "unmonitor")),
+		);
+		expect(() => cleanupDeleteTargetKey(episodeTarget(101, Number.NaN, "delete"))).toThrow(
+			"episode file ID",
+		);
+		expect(() =>
+			cleanupDeleteTargetKey({
+				...episodeTarget(101, 7001, "unmonitor"),
+				arrEpisodeId: undefined,
+			}),
+		).toThrow("episode ID");
+	});
+
+	it("recovers legacy retry file identity from its verified safety snapshot and otherwise fails closed", () => {
+		const safetySnapshot = serializeExecutableSafetyPlan({
+			kind: "verified_sonarr_episode",
+			target: radarrTargetIdentity,
+			episode: {
+				arrEpisodeId: 101,
+				seasonNumber: 1,
+				episodeNumber: 1,
+				episodeFileId: 7001,
+				episodeFileConsumerIds: [101],
+				monitored: true,
+			},
+			selectedFile: {
+				episodeFileId: 7001,
+				fullPath: { value: "/shows/Example/Example.S01E01.mkv", windows: false },
+				size: 2_000,
+			},
+			retainedTargetFiles: [],
+			watchProof: {
+				plexInstanceId: "plex-1",
+				sourceFingerprint: "source-fingerprint",
+				plexServerUrl: "http://plex.internal:32400",
+				ratingKey: "episode-101",
+				watchCount: 1,
+				refreshedAt: "2026-08-12T12:00:00.000Z",
+				fullPath: { value: "/plex/shows/Example/Example.S01E01.mkv", windows: false },
+				size: 2_000,
+				mapping: null,
+			},
+			quiIdentity: { enabled: false, infoHash: null, torrentState: null },
+			peers: [],
+			ownership: [],
+			targetDeleteNotifications: [],
+		});
+		const legacyRetry = {
+			instanceId: "sonarr-1",
+			arrItemId: 42,
+			itemType: "series",
+			targetScope: "episode",
+			arrEpisodeId: 101,
+			episodeFileId: null,
+			action: "delete_files",
+			safetySnapshot,
+		};
+
+		expect(cleanupApprovalTargetKey(legacyRetry)).toBe("sonarr-1:42:series:episode-file:7001");
+		expect(() => cleanupApprovalTargetKey({ ...legacyRetry, safetySnapshot: null })).toThrow(
+			"episode file ID",
+		);
+	});
+
+	it("orders equal-priority cleanup rules deterministically in every executor query", async () => {
+		const { deps } = makeDeps();
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(null);
+
+		await executeCleanupPreview(deps, "user-1");
+		await executeCleanupRun(deps, "user-1");
+
+		expect(deps.prisma.libraryCleanupConfig.findUnique).toHaveBeenNthCalledWith(1, {
+			where: { userId: "user-1" },
+			include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
+		});
+		expect(deps.prisma.libraryCleanupConfig.findUnique).toHaveBeenNthCalledWith(2, {
+			where: { userId: "user-1" },
+			include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
+		});
+	});
 
 	it("rejects a retained Radarr plan that predates peer ownership witnesses", () => {
 		expect(

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -7,6 +7,7 @@ import {
 	executeDirectRemoval,
 	executeRetryItems,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	selectApprovalCandidatesBeforeLimit,
 } from "../cleanup-executor.js";
 import {
 	assertVerifiedSonarrPeerOwnershipRetained,
@@ -17,7 +18,7 @@ import {
 	serializeExecutableSafetyPlan,
 	type VerifiedSonarrTargetDeleteNotification,
 } from "../shared-plex-safety.js";
-import type { CleanupExecutorDeps } from "../types.js";
+import type { CleanupExecutorDeps, FlaggedItem } from "../types.js";
 
 const silentLog = {
 	warn: vi.fn(),
@@ -1982,7 +1983,7 @@ describe("verified Sonarr mutation handoff", () => {
 		return updateMany;
 	}
 
-	function directEpisodeFlaggedItem(fixture: ReturnType<typeof makeSonarrDeps>) {
+	function directEpisodeFlaggedItem(fixture: ReturnType<typeof makeSonarrDeps>): FlaggedItem {
 		return {
 			cacheItem: {
 				id: "series-cache",
@@ -2038,6 +2039,177 @@ describe("verified Sonarr mutation handoff", () => {
 			},
 		} as never;
 	}
+
+	async function verifiedEpisodeSafetySnapshot(fixture: ReturnType<typeof makeSonarrDeps>) {
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		return serializeExecutableSafetyPlan(plan);
+	}
+
+	it("deduplicates approval candidates by physical episode file using legacy snapshot identity", async () => {
+		const fixture = makeSonarrDeps();
+		const first = directEpisodeFlaggedItem(fixture);
+		const second = {
+			...first,
+			match: { ...first.match, action: "delete_files" },
+			episodeTarget: {
+				...first.episodeTarget,
+				arrEpisodeId: 9_002,
+				episodeNumber: 2,
+				episodeTitle: "Episode 2",
+			},
+		} as never;
+		const legacyPending = {
+			instanceId: "sonarr-4k",
+			arrItemId: 201,
+			itemType: "series",
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			episodeFileId: null,
+			action: "delete",
+			safetySnapshot: await verifiedEpisodeSafetySnapshot(fixture),
+			status: "pending",
+			reviewedAt: null,
+		};
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			legacyPending as never,
+		]);
+
+		const result = await selectApprovalCandidatesBeforeLimit(
+			fixture.deps,
+			{
+				id: "config-1",
+				rejectionMemoryDays: 0,
+				rules: [episodeCleanupRule(), episodeCleanupRule("delete_files")],
+			} as never,
+			"user-1",
+			[first, second],
+			10,
+		);
+
+		expect(result.selected).toEqual([]);
+		expect(result.skippedDetails).toHaveLength(2);
+		expect(fixture.deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				select: expect.objectContaining({
+					episodeFileId: true,
+					action: true,
+					safetySnapshot: true,
+				}),
+			}),
+		);
+	});
+
+	it("keeps unmonitor approval ownership distinct per episode", async () => {
+		const fixture = makeSonarrDeps();
+		const flagged = directEpisodeFlaggedItem(fixture);
+		flagged.match.action = "unmonitor";
+		flagged.match.ruleId = "episode-rule-unmonitor";
+		flagged.episodeTarget!.arrEpisodeId = 9_002;
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
+			{
+				instanceId: "sonarr-4k",
+				arrItemId: 201,
+				itemType: "series",
+				targetScope: "episode",
+				arrEpisodeId: 9_001,
+				episodeFileId: null,
+				action: "unmonitor",
+				safetySnapshot: null,
+				status: "pending",
+				reviewedAt: null,
+			} as never,
+		]);
+
+		const result = await selectApprovalCandidatesBeforeLimit(
+			fixture.deps,
+			{
+				id: "config-1",
+				rejectionMemoryDays: 0,
+				rules: [episodeCleanupRule("unmonitor")],
+			} as never,
+			"user-1",
+			[flagged],
+			10,
+		);
+
+		expect(result.selected).toEqual([flagged]);
+		expect(result.skippedDetails).toEqual([]);
+	});
+
+	it("suppresses fresh same-file episode work behind a legacy in-flight retry", async () => {
+		const fixture = makeSonarrDeps();
+		const flagged = directEpisodeFlaggedItem(fixture);
+		flagged.episodeTarget!.arrEpisodeId = 9_002;
+		const inFlightRetry = {
+			id: "retry-1",
+			configId: "config-1",
+			instanceId: "sonarr-4k",
+			arrItemId: 201,
+			itemType: "series",
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			episodeFileId: null,
+			action: "delete",
+			safetySnapshot: await verifiedEpisodeSafetySnapshot(fixture),
+			status: "retry_executing",
+			title: "Example Series",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			reason: "Plex watch count 1 > 0",
+			sizeOnDisk: 2_001n,
+			year: 2024,
+			createdAt: new Date("2026-08-01T00:00:00.000Z"),
+			reviewedAt: new Date("2026-08-01T00:00:00.000Z"),
+		};
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+			select,
+		}: {
+			where: { status?: string | { in: string[] } };
+			select?: Record<string, boolean>;
+		}) => {
+			const statuses = typeof where.status === "string" ? [where.status] : (where.status?.in ?? []);
+			if (!statuses.includes("retry_executing")) return [];
+			if (!select) return [inFlightRetry];
+			return [
+				Object.fromEntries(
+					Object.keys(select).map((field) => [
+						field,
+						inFlightRetry[field as keyof typeof inFlightRetry],
+					]),
+				),
+			];
+		}) as never);
+		Object.assign(fixture.deps.prisma.libraryCleanupLog, {
+			findFirst: vi.fn().mockResolvedValue(null),
+		});
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{ id: "config-1", maxRemovalsPerRun: 10, rules: [] } as never,
+			"user-1",
+			[flagged],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result.details).toContainEqual(
+			expect.objectContaining({
+				arrEpisodeId: 9_002,
+				action: "skipped",
+				reason: expect.stringContaining("already executing"),
+			}),
+		);
+		expect(fixture.deps.prisma.serviceInstance.findFirst).not.toHaveBeenCalled();
+		expect(fixture.targetClient.episodeFile.bulkDelete).not.toHaveBeenCalled();
+	});
 
 	it("unmonitors and deletes only the approved episode without removing its series", async () => {
 		const fixture = makeSonarrDeps();

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -796,6 +796,7 @@ function buildRetryDetail(
 		year: number | null;
 		targetScope?: string | null;
 		arrEpisodeId?: number | null;
+		episodeFileId?: number | null;
 		seasonNumber?: number | null;
 		episodeNumber?: number | null;
 		episodeTitle?: string | null;
@@ -816,12 +817,43 @@ function buildRetryDetail(
 		itemType: approval.itemType,
 		targetScope: approval.targetScope === "episode" ? "episode" : "series",
 		arrEpisodeId: approval.arrEpisodeId ?? undefined,
+		episodeFileId: approval.episodeFileId ?? undefined,
 		seasonNumber: approval.seasonNumber ?? undefined,
 		episodeNumber: approval.episodeNumber ?? undefined,
 		sizeOnDisk: approval.sizeOnDisk.toString(),
 		year: approval.year,
 		rating: null,
 	};
+}
+
+type CleanupApprovalTarget = {
+	instanceId: string;
+	arrItemId: number;
+	itemType: string;
+	targetScope?: string | null;
+	arrEpisodeId?: number | null;
+	episodeFileId?: number | null;
+	action?: string | null;
+	safetySnapshot?: string | null;
+};
+
+function retryEpisodeFileId(approval: CleanupApprovalTarget): number | undefined {
+	if (
+		typeof approval.episodeFileId === "number" &&
+		Number.isSafeInteger(approval.episodeFileId) &&
+		approval.episodeFileId > 0
+	) {
+		return approval.episodeFileId;
+	}
+	const plan = parseExecutableSafetyPlan(approval.safetySnapshot);
+	return plan?.kind === "verified_sonarr_episode" ? plan.selectedFile.episodeFileId : undefined;
+}
+
+export function cleanupApprovalTargetKey(approval: CleanupApprovalTarget): string {
+	return cleanupDeleteTargetKey({
+		...approval,
+		episodeFileId: retryEpisodeFileId(approval),
+	});
 }
 
 function toDeleteTargets(items: FlaggedItem[]): CleanupDeleteTarget[] {
@@ -1092,6 +1124,7 @@ async function persistAndClaimDirectMutationIntent(
 				itemType: item.cacheItem.itemType,
 				targetScope: item.episodeTarget ? "episode" : "series",
 				arrEpisodeId: item.episodeTarget?.arrEpisodeId,
+				episodeFileId: item.episodeTarget?.episodeFileId,
 				seasonNumber: item.episodeTarget?.seasonNumber,
 				episodeNumber: item.episodeTarget?.episodeNumber,
 				title: item.cacheItem.title,
@@ -1553,6 +1586,9 @@ async function loadDurableRetryPreview(
 					itemType: true,
 					targetScope: true,
 					arrEpisodeId: true,
+					episodeFileId: true,
+					action: true,
+					safetySnapshot: true,
 				},
 			}),
 			deps.prisma.libraryCleanupApproval.findMany({
@@ -1582,7 +1618,7 @@ async function loadDurableRetryPreview(
 		);
 		const total = Math.max(pendingRetryTargets.length, retryDetails.length);
 		const targetKeys = new Set(
-			[...pendingRetryTargets, ...inFlightRetries].map((retry) => cleanupDeleteTargetKey(retry)),
+			[...pendingRetryTargets, ...inFlightRetries].map((retry) => cleanupApprovalTargetKey(retry)),
 		);
 		const warningParts = [];
 		if (total > 0) {
@@ -1636,7 +1672,7 @@ export async function executeCleanupPreview(
 
 	const config = await prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
-		include: { rules: { orderBy: { priority: "asc" } } },
+		include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 	});
 
 	if (!config) {
@@ -1765,7 +1801,7 @@ async function executeCleanupRunGuarded(
 
 	const config = await prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
-		include: { rules: { orderBy: { priority: "asc" } } },
+		include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 	});
 
 	if (!config?.enabled || config.rules.length === 0) {
@@ -1874,10 +1910,13 @@ async function executeCleanupRunGuarded(
 					itemType: true,
 					targetScope: true,
 					arrEpisodeId: true,
+					episodeFileId: true,
+					action: true,
+					safetySnapshot: true,
 				},
 			});
 			const retryTargetKeys = new Set(
-				nonterminalRetryTargets.map((retry) => cleanupDeleteTargetKey(retry)),
+				nonterminalRetryTargets.map((retry) => cleanupApprovalTargetKey(retry)),
 			);
 			const freshCandidates = flagged.filter(
 				(item) => !retryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
@@ -2353,7 +2392,7 @@ async function assertCurrentEpisodeMutationAuthority(
 ): Promise<void> {
 	const config = await deps.prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
-		include: { rules: { orderBy: { priority: "asc" } } },
+		include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 	});
 	if (!config) {
 		throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
@@ -5486,7 +5525,7 @@ function buildApprovalDedupSkipReason(
 	return undefined;
 }
 
-async function selectApprovalCandidatesBeforeLimit(
+export async function selectApprovalCandidatesBeforeLimit(
 	deps: CleanupExecutorDeps,
 	config: LibraryCleanupConfig & { rules: LibraryCleanupRule[] },
 	userId: string,
@@ -5537,13 +5576,16 @@ async function selectApprovalCandidatesBeforeLimit(
 			itemType: true,
 			targetScope: true,
 			arrEpisodeId: true,
+			episodeFileId: true,
+			action: true,
+			safetySnapshot: true,
 			status: true,
 			reviewedAt: true,
 		},
 	});
 	const approvalDedupRowsByTarget = new Map<string, typeof approvalDedupRows>();
 	for (const row of approvalDedupRows) {
-		const targetKey = cleanupDeleteTargetKey(row);
+		const targetKey = cleanupApprovalTargetKey(row);
 		const rows = approvalDedupRowsByTarget.get(targetKey);
 		if (rows) rows.push(row);
 		else approvalDedupRowsByTarget.set(targetKey, [row]);
@@ -5638,7 +5680,17 @@ async function executeWithApproval(
 					arrItemId: item.cacheItem.arrItemId,
 					itemType: item.cacheItem.itemType,
 					targetScope: item.episodeTarget ? "episode" : "series",
-					arrEpisodeId: item.episodeTarget?.arrEpisodeId ?? null,
+					...(item.episodeTarget
+						? item.match.action === "unmonitor"
+							? {
+									arrEpisodeId: item.episodeTarget.arrEpisodeId,
+									action: "unmonitor",
+								}
+							: {
+									episodeFileId: item.episodeTarget.episodeFileId,
+									AND: [{ OR: [{ action: null }, { action: { not: "unmonitor" } }] }],
+								}
+						: {}),
 					OR: orClauses,
 				},
 			});
@@ -5659,6 +5711,7 @@ async function executeWithApproval(
 					itemType: item.cacheItem.itemType,
 					targetScope: item.episodeTarget ? "episode" : "series",
 					arrEpisodeId: item.episodeTarget?.arrEpisodeId,
+					episodeFileId: item.episodeTarget?.episodeFileId,
 					seasonNumber: item.episodeTarget?.seasonNumber,
 					episodeNumber: item.episodeTarget?.episodeNumber,
 					title: item.cacheItem.title,
@@ -5809,6 +5862,9 @@ export async function executeDirectRemoval(
 				itemType: true,
 				targetScope: true,
 				arrEpisodeId: true,
+				episodeFileId: true,
+				action: true,
+				safetySnapshot: true,
 			},
 		});
 		const loadedDirectRetries = await prisma.libraryCleanupApproval.findMany({
@@ -5828,15 +5884,15 @@ export async function executeDirectRemoval(
 			},
 		});
 		for (const retry of executingDirectRetries) {
-			const targetKey = cleanupDeleteTargetKey(retry);
+			const targetKey = cleanupApprovalTargetKey(retry);
 			directRetryTargetKeys.add(targetKey);
 			inFlightDirectRetryTargetKeys.add(targetKey);
 		}
 		for (const retry of loadedDirectRetries) {
-			directRetryTargetKeys.add(cleanupDeleteTargetKey(retry));
+			directRetryTargetKeys.add(cleanupApprovalTargetKey(retry));
 		}
 		for (const retryTarget of nonterminalRetryTargets) {
-			directRetryTargetKeys.add(cleanupDeleteTargetKey(retryTarget));
+			directRetryTargetKeys.add(cleanupApprovalTargetKey(retryTarget));
 		}
 		const hasDistinctFreshCandidate = flagged.some(
 			(item) => !directRetryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
@@ -5866,7 +5922,7 @@ export async function executeDirectRemoval(
 	}
 
 	for (const retry of directRetries) {
-		const targetKey = cleanupDeleteTargetKey(retry);
+		const targetKey = cleanupApprovalTargetKey(retry);
 		selectedDirectRetryTargetKeys.add(targetKey);
 		try {
 			const retryResult = await executeQueuedCleanupItems(deps, userId, [retry.id], {

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -2488,12 +2488,28 @@ function matchingPlexSeriesParts(
 
 export function cleanupDeleteTargetKey(
 	target: Pick<CleanupDeleteTarget, "instanceId" | "arrItemId" | "itemType"> &
-		Partial<Pick<CleanupDeleteTarget, "targetScope" | "arrEpisodeId">>,
+		Partial<Pick<CleanupDeleteTarget, "targetScope" | "arrEpisodeId" | "episodeFileId" | "action">>,
 ): string {
 	const seriesKey = `${target.instanceId}:${target.arrItemId}:${target.itemType}`;
-	return target.targetScope === "episode" && typeof target.arrEpisodeId === "number"
-		? `${seriesKey}:episode:${target.arrEpisodeId}`
-		: seriesKey;
+	if (target.targetScope !== "episode") return seriesKey;
+	if (target.action === "unmonitor") {
+		if (
+			typeof target.arrEpisodeId !== "number" ||
+			!Number.isSafeInteger(target.arrEpisodeId) ||
+			target.arrEpisodeId <= 0
+		) {
+			throw new Error("Episode-scoped unmonitor target is missing its episode ID");
+		}
+		return `${seriesKey}:episode:${target.arrEpisodeId}`;
+	}
+	if (
+		typeof target.episodeFileId !== "number" ||
+		!Number.isSafeInteger(target.episodeFileId) ||
+		target.episodeFileId <= 0
+	) {
+		throw new Error("File-changing episode target is missing its episode file ID");
+	}
+	return `${seriesKey}:episode-file:${target.episodeFileId}`;
 }
 
 function isDestructiveTarget(target: CleanupDeleteTarget): boolean {

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -454,7 +454,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 
 		let config = await app.prisma.libraryCleanupConfig.findUnique({
 			where: { userId },
-			include: { rules: { orderBy: { priority: "asc" } } },
+			include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 		});
 
 		if (!config) {
@@ -466,7 +466,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				async () => {
 					const initialized = await app.prisma.libraryCleanupConfig.findUnique({
 						where: { userId },
-						include: { rules: { orderBy: { priority: "asc" } } },
+						include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 					});
 					if (!initialized) throw new Error("Cleanup configuration could not be initialized");
 					return initialized;
@@ -490,7 +490,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 					where: { userId },
 					update: data,
 					create: { userId, ...data },
-					include: { rules: { orderBy: { priority: "asc" } } },
+					include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 				});
 
 				// Recalculate nextRunAt when enabled or intervalHours changes
@@ -627,7 +627,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 
 				const updated = await app.prisma.libraryCleanupConfig.findUnique({
 					where: { userId },
-					include: { rules: { orderBy: { priority: "asc" } } },
+					include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 				});
 				return reply.send(serializeConfig(updated as unknown as Record<string, unknown>));
 			},
@@ -1470,7 +1470,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		// Load config + rules
 		const config = await app.prisma.libraryCleanupConfig.findUnique({
 			where: { userId },
-			include: { rules: { orderBy: { priority: "asc" } } },
+			include: { rules: { orderBy: [{ priority: "asc" }, { id: "asc" }] } },
 		});
 		if (!config || config.rules.length === 0) {
 			return reply.send({


### PR DESCRIPTION
## Summary

- key file-changing episode cleanup by the physical Sonarr episode file while keeping unmonitor actions episode-scoped
- persist episode-file identity on approvals and direct retries, with verified safety-snapshot recovery for legacy rows
- make equal-priority cleanup rules deterministic by rule ID across routes, previews, runs, and mutation revalidation
- cover approval deduplication, in-flight retry suppression, legacy fallback, and per-episode unmonitor separation with populated executor tests

## Safety

- missing or invalid episode identity fails closed
- legacy file-changing rows are accepted only when their verified safety snapshot proves the exact episode file
- nullable schema addition preserves existing approval rows

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm --dir apps/api db:generate`
- `pnpm run typecheck`
- `pnpm run test` (121 shared, 807 web, 3,941 API)
- `pnpm run lint`
- `pnpm run build`
- independent data-safety review: no findings
- independent regression review: one missing-coverage finding corrected in the same pass