### PR TITLE
feat(cleanup): freeze direct run selection

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/selection-planner.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/selection-planner.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { planDirectCleanupSelection } from "../selection-planner.js";
+
+const fresh = (...keys: string[]) => keys.map((key) => ({ key, value: key }));
+const freshCandidate = (key: string, value: string) => ({ key, value });
+const retry = (id: string, reviewedAt: Date | null = null) => ({
+	id,
+	key: id,
+	value: id,
+	reviewedAt,
+	createdAt: new Date("2026-06-01T00:00:00.000Z"),
+});
+
+describe("planDirectCleanupSelection", () => {
+	it("uses deterministic retry order and reserves only remaining budget for fresh work", () => {
+		const plan = planDirectCleanupSelection({
+			limit: 3,
+			fresh: fresh("fresh-1", "fresh-2", "fresh-3"),
+			pendingRetries: [retry("retry-2"), retry("retry-1")],
+			inFlightRetries: [],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedRetries.map((candidate) => candidate.id)).toEqual(["retry-1", "retry-2"]);
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh-1"]);
+		expect(plan.counts.deferredBudget).toBe(2);
+	});
+
+	it("deduplicates fresh candidates before the run budget", () => {
+		const plan = planDirectCleanupSelection({
+			limit: 2,
+			fresh: [
+				freshCandidate("first", "first"),
+				freshCandidate("first", "first-duplicate-before-limit"),
+				freshCandidate("second", "second"),
+				freshCandidate("first", "first-duplicate-after-limit"),
+				freshCandidate("third", "third"),
+			],
+			pendingRetries: [],
+			inFlightRetries: [],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.value)).toEqual(["first", "second"]);
+		expect(plan.counts).toMatchObject({
+			selectedFresh: 2,
+			deferredDuplicateTarget: 2,
+			deferredBudget: 1,
+			total: 5,
+		});
+	});
+
+	it("defers retries attempted since the prior run when distinct fresh work exists", () => {
+		const boundary = new Date("2026-07-01T00:00:00.000Z");
+		const plan = planDirectCleanupSelection({
+			limit: 2,
+			fresh: fresh("retry-new", "fresh-1", "fresh-2"),
+			pendingRetries: [
+				retry("retry-old", new Date("2026-06-30T23:59:59.000Z")),
+				retry("retry-new", boundary),
+			],
+			inFlightRetries: [],
+			previousRunStartedAt: boundary,
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedRetries.map((candidate) => candidate.id)).toEqual(["retry-old"]);
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh-1"]);
+		expect(plan.counts.deferredRetryFairness).toBe(1);
+	});
+
+	it("reports in-flight work without selecting its matching fresh target", () => {
+		const plan = planDirectCleanupSelection({
+			limit: 2,
+			fresh: fresh("in-flight", "fresh"),
+			pendingRetries: [],
+			inFlightRetries: [retry("in-flight")],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh"]);
+		expect(plan.counts).toMatchObject({ inFlight: 1, deferredInFlightTarget: 1, total: 3 });
+	});
+
+	it("defers pending retries whose target is owned by an in-flight record", () => {
+		const timestamp = new Date("2026-07-01T00:00:00.000Z");
+		const plan = planDirectCleanupSelection({
+			limit: 2,
+			fresh: fresh("same-target", "fresh"),
+			pendingRetries: [
+				{ ...retry("pending-z", timestamp), key: "same-target", createdAt: timestamp },
+				{ ...retry("pending-a", timestamp), key: "same-target", createdAt: timestamp },
+			],
+			inFlightRetries: [
+				{ ...retry("executing", timestamp), key: "same-target", createdAt: timestamp },
+			],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedRetries).toEqual([]);
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh"]);
+		expect(plan.counts).toMatchObject({
+			deferredInFlightTarget: 2,
+			deferredDuplicateTarget: 1,
+			inFlight: 1,
+			total: 5,
+		});
+	});
+
+	it("elects one stable pending owner per target regardless of database order", () => {
+		const timestamp = new Date("2026-07-01T00:00:00.000Z");
+		const pending = [
+			{ ...retry("retry-z", timestamp), key: "same-retry", createdAt: timestamp },
+			{ ...retry("retry-b", timestamp), key: "other-retry", createdAt: timestamp },
+			{ ...retry("retry-a", timestamp), key: "same-retry", createdAt: timestamp },
+		];
+		const inputFresh = [
+			freshCandidate("same-retry", "fresh-shadowed-by-retry"),
+			freshCandidate("fresh", "fresh-first"),
+			freshCandidate("fresh", "fresh-duplicate"),
+			freshCandidate("last", "last-budget-deferred"),
+		];
+		const buildPlan = (pendingRetries: typeof pending) =>
+			planDirectCleanupSelection({
+				limit: 3,
+				fresh: inputFresh,
+				pendingRetries,
+				inFlightRetries: [],
+				retryStateLoaded: true,
+			});
+
+		for (const plan of [buildPlan(pending), buildPlan([...pending].reverse())]) {
+			expect(plan.selectedRetries.map((candidate) => candidate.id)).toEqual(["retry-a", "retry-b"]);
+			expect(plan.selectedFresh.map((candidate) => candidate.value)).toEqual(["fresh-first"]);
+			expect(plan.counts).toMatchObject({
+				selectedRetries: 2,
+				selectedFresh: 1,
+				deferredDuplicateTarget: 3,
+				deferredBudget: 1,
+				total: 7,
+			});
+		}
+	});
+
+	it("fails closed when durable retry state is unavailable", () => {
+		const plan = planDirectCleanupSelection({
+			limit: 100,
+			fresh: fresh("first", "second"),
+			pendingRetries: [],
+			inFlightRetries: [],
+			retryStateLoaded: false,
+		});
+
+		expect(plan.selectedFresh).toEqual([]);
+		expect(plan.selectedRetries).toEqual([]);
+		expect(plan.counts).toMatchObject({ retryStateUnavailable: 2, retryState: "unavailable" });
+	});
+
+	it.each([
+		{ limit: 0, selected: [] },
+		{ limit: -1, selected: [] },
+		{ limit: 1, selected: ["first"] },
+		{ limit: 2, selected: ["first", "second"] },
+		{ limit: 101, selected: [] },
+	])("applies maxRemovalsPerRun boundary $limit", ({ limit, selected }) => {
+		const plan = planDirectCleanupSelection({
+			limit,
+			fresh: fresh("first", "second", "third"),
+			pendingRetries: [],
+			inFlightRetries: [],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(selected);
+	});
+});

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1749,19 +1749,81 @@ describe("shared Plex deletion safety", () => {
 			itemsFlagged: 1,
 			pendingRetryCount: 1,
 			itemsSkipped: 1,
-			details: [
+		});
+		expect(result.details).toHaveLength(2);
+		expect(result.details).toEqual(
+			expect.arrayContaining([
 				expect.objectContaining({
 					arrItemId: 101,
-					reason: expect.stringContaining("Durable retry pending"),
+					reason: expect.stringContaining("Selected for a retry attempt"),
 				}),
-			],
-		});
-		expect(result.details).toHaveLength(1);
+			]),
+		);
 		expect(deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
-			expect.objectContaining({ take: 1 }),
+			expect.objectContaining({
+				orderBy: [
+					{ reviewedAt: { sort: "asc", nulls: "first" } },
+					{ createdAt: "asc" },
+					{ id: "asc" },
+				],
+			}),
 		);
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
 		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("uses the same frozen direct selection for preview, configured dry run, and live execution", async () => {
+		const cacheItems = [
+			matchingDryRunCacheItem({ id: "cache-selected", arrItemId: 101, title: "Selected" }),
+			matchingDryRunCacheItem({ id: "cache-deferred", arrItemId: 102, title: "Deferred" }),
+		];
+		const config = {
+			...dryRunConfig(1),
+			requireApproval: false,
+			rules: [{ ...dryRunConfig(1).rules[0]!, action: "unmonitor" }],
+		};
+		const selectedIds = (result: Awaited<ReturnType<typeof executeCleanupRun>>) =>
+			result.details
+				.filter((detail) => detail.action !== "skipped")
+				.map((detail) => detail.arrItemId);
+
+		const previewFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(previewFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+		} as never);
+		vi.mocked(previewFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(
+			cacheItems as never,
+		);
+		const preview = await executeCleanupPreview(previewFixture.deps, "user-1");
+
+		const dryRunFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(dryRunFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: true,
+		} as never);
+		vi.mocked(dryRunFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(
+			cacheItems as never,
+		);
+		const dryRun = await executeCleanupRun(dryRunFixture.deps, "user-1");
+
+		const liveFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(liveFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+		} as never);
+		vi.mocked(liveFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(cacheItems as never);
+		const live = await executeCleanupRun(liveFixture.deps, "user-1");
+
+		expect(selectedIds(preview)).toEqual([101]);
+		expect(selectedIds(dryRun)).toEqual([101]);
+		expect(selectedIds(live)).toEqual([101]);
+		expect(previewFixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+		expect(dryRunFixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+		expect(liveFixture.targetClient.movie.update).toHaveBeenCalledWith(
+			101,
+			expect.objectContaining({ monitored: false }),
+		);
 	});
 
 	it("does not recount a pending retry beyond the configured dry-run detail budget", async () => {
@@ -1790,13 +1852,11 @@ describe("shared Plex deletion safety", () => {
 		});
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
 			where,
-			select,
 		}: {
 			where: { status?: string };
-			select?: Record<string, boolean>;
 		}) => {
 			if (where.status !== "retry_pending") return [];
-			return select ? [selectedRetry, deferredRetry] : [selectedRetry];
+			return [selectedRetry, deferredRetry];
 		}) as never);
 		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
 			matchingDryRunCacheItem({
@@ -1812,9 +1872,9 @@ describe("shared Plex deletion safety", () => {
 			itemsEvaluated: 1,
 			itemsFlagged: 1,
 			pendingRetryCount: 2,
-			itemsSkipped: 0,
+			itemsSkipped: 2,
 		});
-		expect(result.details).toHaveLength(1);
+		expect(result.details).toHaveLength(3);
 		expect(result.details[0]?.arrItemId).toBe(101);
 	});
 
@@ -1868,12 +1928,17 @@ describe("shared Plex deletion safety", () => {
 			itemsEvaluated: 1,
 			itemsFlagged: 0,
 			pendingRetryCount: 0,
-			itemsSkipped: 1,
+			itemsSkipped: 2,
 			details: [
 				expect.objectContaining({
 					arrItemId: 101,
 					action: "skipped",
 					reason: "Deferred: another cleanup run is already executing this durable retry.",
+				}),
+				expect.objectContaining({
+					arrItemId: 101,
+					action: "skipped",
+					reason: expect.stringContaining("already executing"),
 				}),
 			],
 		});
@@ -2520,10 +2585,10 @@ describe("shared Plex deletion safety", () => {
 			itemsFlagged: 0,
 			pendingRetryCount: 1,
 		});
-		expect(result.details).toHaveLength(1);
+		expect(result.details).toHaveLength(2);
 		expect(result.details[0]).toMatchObject({
 			arrItemId: 101,
-			reason: expect.stringContaining("Durable retry pending"),
+			reason: expect.stringContaining("Selected for a retry attempt"),
 		});
 	});
 
@@ -4905,9 +4970,13 @@ describe("shared Plex deletion safety", () => {
 		expect(deferredResult).toMatchObject({
 			status: "partial",
 			itemsFlagged: 1,
-			itemsSkipped: 1,
-			details: [expect.objectContaining({ reason: expect.stringContaining("already executing") })],
+			itemsSkipped: 2,
 		});
+		expect(deferredResult.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: expect.stringContaining("already executing") }),
+			]),
+		);
 		expect(deleteMovieFile).toHaveBeenCalledOnce();
 		expect(deleteMovie).toHaveBeenCalledTimes(2);
 	});
@@ -4957,11 +5026,13 @@ describe("shared Plex deletion safety", () => {
 		expect(deferredResult).toMatchObject({
 			status: "partial",
 			itemsFlagged: 1,
-			itemsSkipped: 1,
-			details: [
-				expect.objectContaining({ reason: expect.stringContaining("another cleanup run claimed") }),
-			],
+			itemsSkipped: 2,
 		});
+		expect(deferredResult.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: expect.stringContaining("another cleanup run claimed") }),
+			]),
+		);
 		expect(deferredResult.warnings).toContainEqual(
 			expect.stringContaining("another cleanup run claimed it first"),
 		);
@@ -4970,7 +5041,7 @@ describe("shared Plex deletion safety", () => {
 		expect(deleteMovie).toHaveBeenCalledTimes(2);
 	});
 
-	it("does not let a safety-blocked retry consume the fresh mutation budget", async () => {
+	it("keeps a safety-blocked retry's selected slot fixed for the run", async () => {
 		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
 		const retries = configureRetryStore(deps);
 		retries.push({
@@ -5021,25 +5092,26 @@ describe("shared Plex deletion safety", () => {
 				config: { userId: "user-1" },
 				status: "retry_pending",
 			},
-			orderBy: [{ reviewedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
-			take: 1,
+			orderBy: [
+				{ reviewedAt: { sort: "asc", nulls: "first" } },
+				{ createdAt: "asc" },
+				{ id: "asc" },
+			],
+			take: 501,
 		});
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
-		expect(targetClient.movie.update).toHaveBeenCalledWith(
-			102,
-			expect.objectContaining({ monitored: false }),
-		);
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
 		expect(result).toMatchObject({
 			status: "partial",
-			itemsFlagged: 2,
-			itemsUnmonitored: 1,
-			itemsSkipped: 1,
+			itemsFlagged: 1,
+			itemsUnmonitored: 0,
+			itemsSkipped: 2,
 		});
 		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
 	});
 
-	it("fills a freed retry slot from candidates beyond the initial run limit", async () => {
+	it("does not fill a failed retry slot from candidates beyond the initial run limit", async () => {
 		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
 		const config = {
 			...dryRunConfig(1),
@@ -5076,14 +5148,11 @@ describe("shared Plex deletion safety", () => {
 
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
-		expect(targetClient.movie.update).toHaveBeenCalledWith(
-			102,
-			expect.objectContaining({ monitored: false }),
-		);
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
 		expect(result).toMatchObject({
 			status: "partial",
-			itemsFlagged: 2,
-			itemsUnmonitored: 1,
+			itemsFlagged: 1,
+			itemsUnmonitored: 0,
 		});
 		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
 	});
@@ -5159,15 +5228,11 @@ describe("shared Plex deletion safety", () => {
 
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
-		expect(targetClient.movie.update).toHaveBeenCalledTimes(1);
-		expect(targetClient.movie.update).toHaveBeenCalledWith(
-			103,
-			expect.objectContaining({ monitored: false }),
-		);
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
 		expect(retries[1]).toMatchObject({ id: "approval-2", status: "retry_pending" });
 		expect(result).toMatchObject({
 			status: "partial",
-			itemsUnmonitored: 1,
+			itemsUnmonitored: 0,
 		});
 	});
 
@@ -5324,6 +5389,181 @@ describe("shared Plex deletion safety", () => {
 		expect(secondResult.warnings).toContainEqual(expect.stringContaining("deferred for one run"));
 	});
 
+	it("does not backfill fresh work when a selected retry fails closed", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps();
+		const retries = configureRetryStore(deps);
+		retries.push({
+			...approvalRecord(),
+			configId: "config-1",
+			status: "retry_pending",
+			executionToken: null,
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Prior delete",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		});
+		const freshItem = {
+			cacheItem: {
+				instanceId: "radarr-4k",
+				arrItemId: 102,
+				itemType: "movie",
+				title: "Fresh Movie",
+				year: 2024,
+				monitored: true,
+				...radarrCachedFileIdentity,
+				sizeOnDisk: 2_000n,
+			},
+			match: {
+				ruleId: "rule-2",
+				ruleName: "Fresh unmonitor",
+				reason: "Matched fresh rule",
+				action: "unmonitor",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[freshItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(retries[0]).toMatchObject({ status: "retry_pending" });
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsFlagged: 1,
+			itemsUnmonitored: 0,
+		});
+		expect(result.warnings).toContainEqual(expect.stringContaining("retry remains"));
+	});
+
+	it("fails closed for all fresh work when durable retry state is unavailable", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+			mediaPartCount: 1,
+		});
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockRejectedValue(
+			new Error("database unavailable"),
+		);
+		const flagged = [101, 102].map((arrItemId) => ({
+			cacheItem: matchingDryRunCacheItem({
+				id: `cache-${arrItemId}`,
+				arrItemId,
+				title: `Movie ${arrItemId}`,
+			}),
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Old media",
+				reason: "Matched",
+				action: "delete",
+			},
+			rating: 8,
+		}));
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 2, rules: [] } as never,
+			"user-1",
+			flagged as never,
+			2,
+			2,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "partial", itemsFlagged: 0, itemsSkipped: 2 });
+		expect(result.details).toHaveLength(2);
+		expect(targetClient.movie.getById).not.toHaveBeenCalled();
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(targetClient.movie.update).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when the durable retry inventory exceeds its bounded load", async () => {
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+			mediaPartCount: 1,
+		});
+		const retryBacklog = Array.from({ length: 501 }, (_, index) =>
+			approvalRecord({
+				id: `retry-${index}`,
+				arrItemId: 10_000 + index,
+				configId: "config-1",
+				status: "retry_pending",
+				reviewedAt: null,
+				createdAt: new Date(1_700_000_000_000 + index),
+			}),
+		);
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+		}: {
+			where: { status?: string };
+		}) => (where.status === "retry_pending" ? retryBacklog : [])) as never);
+		const flaggedItem = {
+			cacheItem: matchingDryRunCacheItem({ id: "cache-fresh", arrItemId: 101 }),
+			match: {
+				ruleId: "rule-1",
+				ruleName: "Old media",
+				reason: "Matched",
+				action: "delete",
+			},
+			rating: 8,
+		} as never;
+
+		const result = await executeDirectRemoval(
+			deps,
+			{ id: "config-1", maxRemovalsPerRun: 1, rules: [] } as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ status: "partial", itemsFlagged: 0, itemsSkipped: 1 });
+		expect(result.warnings).toContainEqual(expect.stringContaining("could not be loaded"));
+		expect(targetClient.movie.getById).not.toHaveBeenCalled();
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it.each([0, 101])(
+		"reports an invalid direct cleanup limit consistently in preview and configured dry run (%i)",
+		async (maxRemovalsPerRun) => {
+			for (const mode of ["preview", "configured"] as const) {
+				const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+					mediaPartCount: 1,
+				});
+				vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+					...dryRunConfig(maxRemovalsPerRun),
+					dryRunMode: mode === "configured",
+					requireApproval: false,
+				} as never);
+				vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue([
+					matchingDryRunCacheItem(),
+				] as never);
+
+				const result =
+					mode === "preview"
+						? await executeCleanupPreview(deps, "user-1")
+						: await executeCleanupRun(deps, "user-1");
+
+				expect(result).toMatchObject({ status: "partial", itemsFlagged: 0, itemsSkipped: 1 });
+				expect(result.warnings).toContainEqual(
+					expect.stringContaining("whole number from 1 through 100"),
+				);
+				expect(targetClient.movie.getById).not.toHaveBeenCalled();
+				expect(deleteMovieFile).not.toHaveBeenCalled();
+				expect(deleteMovie).not.toHaveBeenCalled();
+			}
+		},
+	);
+
 	it("accounts for a durable retry whose post-claim read fails", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
 		const retries = configureRetryStore(deps);
@@ -5381,9 +5621,13 @@ describe("shared Plex deletion safety", () => {
 		expect(deferredResult).toMatchObject({
 			status: "partial",
 			itemsFlagged: 1,
-			itemsSkipped: 1,
-			details: [expect.objectContaining({ reason: expect.stringContaining("after claiming it") })],
+			itemsSkipped: 2,
 		});
+		expect(deferredResult.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ reason: expect.stringContaining("after claiming it") }),
+			]),
+		);
 		expect(deferredResult.warnings).toContainEqual(
 			expect.stringContaining("post-claim read failure"),
 		);

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -33,7 +33,12 @@ import { isNotFoundError } from "../arr/client-factory.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
 import { buildMovieFile } from "../library/movie-normalizer.js";
 import { plexConnectionFingerprint } from "../plex/service-instance-fingerprint.js";
-import type { LibraryCleanupConfig, LibraryCleanupRule, ServiceInstance } from "../prisma.js";
+import type {
+	LibraryCleanupApproval,
+	LibraryCleanupConfig,
+	LibraryCleanupRule,
+	ServiceInstance,
+} from "../prisma.js";
 import {
 	evaluateItemAgainstRulesViaEngine,
 	evaluateRuleViaEngine,
@@ -55,6 +60,10 @@ import {
 } from "./episode-scope.js";
 import type { ProviderCacheType } from "./provider-cache-evidence.js";
 import { applyQuiSeedingFilter, isQuiSeedingState } from "./qui-filter.js";
+import {
+	type DirectCleanupSelectionPlan,
+	planDirectCleanupSelection,
+} from "./selection-planner.js";
 import {
 	evaluateSingleCondition,
 	extractRating,
@@ -247,6 +256,9 @@ function parsePublishedStringArray(value: string, label: string): string[] {
 // The route returns at most 200 preview rows; avoid live safety I/O for rows
 // the caller cannot inspect.
 const PREVIEW_SAFETY_INSPECTION_LIMIT = 200;
+const DIRECT_RETRY_INVENTORY_LIMIT = 500;
+const INVALID_CLEANUP_RUN_LIMIT_WARNING =
+	"Cleanup did not select any items because the stored per-run removal limit is invalid. Set it to a whole number from 1 through 100.";
 
 // Circuit breaker: abort after N consecutive ARR API failures
 const CIRCUIT_BREAKER_THRESHOLD = 3;
@@ -1659,6 +1671,166 @@ async function loadDurableRetryPreview(
 	}
 }
 
+interface DirectSelectionState {
+	plan: DirectCleanupSelectionPlan<FlaggedItem, LibraryCleanupApproval>;
+	pendingRetryCount: number | null;
+	retryStateLoaded: boolean;
+	warnings: string[];
+}
+
+async function loadDirectSelectionState(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	configId: string,
+	flagged: FlaggedItem[],
+	limit: number,
+): Promise<DirectSelectionState> {
+	const warnings: string[] = [];
+	let previousRunStartedAt: Date | undefined;
+	try {
+		const previousRun = await deps.prisma.libraryCleanupLog.findFirst({
+			where: { configId, isDryRun: false, completedAt: { not: null } },
+			orderBy: { startedAt: "desc" },
+			select: { startedAt: true },
+		});
+		previousRunStartedAt = previousRun?.startedAt;
+	} catch (error) {
+		deps.log.warn(
+			{ err: error, configId },
+			"Cleanup could not load its prior run boundary for retry fairness",
+		);
+		warnings.push(
+			"Retry fairness history could not be loaded; existing retries retain their normal deterministic order.",
+		);
+	}
+
+	try {
+		const [pendingRetries, inFlightRetries] = await Promise.all([
+			deps.prisma.libraryCleanupApproval.findMany({
+				where: { configId, config: { userId }, status: "retry_pending" },
+				orderBy: [
+					{ reviewedAt: { sort: "asc", nulls: "first" } },
+					{ createdAt: "asc" },
+					{ id: "asc" },
+				],
+				take: DIRECT_RETRY_INVENTORY_LIMIT + 1,
+			}),
+			deps.prisma.libraryCleanupApproval.findMany({
+				where: { configId, config: { userId }, status: "retry_executing" },
+				orderBy: [{ createdAt: "asc" }, { id: "asc" }],
+				take: DIRECT_RETRY_INVENTORY_LIMIT + 1,
+			}),
+		]);
+		if (pendingRetries.length + inFlightRetries.length > DIRECT_RETRY_INVENTORY_LIMIT) {
+			throw new Error(
+				`Durable retry inventory exceeds the safe load limit of ${DIRECT_RETRY_INVENTORY_LIMIT}`,
+			);
+		}
+		const plan = planDirectCleanupSelection<FlaggedItem, LibraryCleanupApproval>({
+			limit,
+			fresh: flagged.map((item) => ({
+				key: cleanupDeleteTargetKey(flaggedDeleteTarget(item)),
+				value: item,
+			})),
+			pendingRetries: pendingRetries.map((retry) => ({
+				id: retry.id,
+				key: cleanupApprovalTargetKey(retry),
+				value: retry,
+				reviewedAt: retry.reviewedAt,
+				createdAt: retry.createdAt,
+			})),
+			inFlightRetries: inFlightRetries.map((retry) => ({
+				id: retry.id,
+				key: cleanupApprovalTargetKey(retry),
+				value: retry,
+				reviewedAt: retry.reviewedAt,
+				createdAt: retry.createdAt,
+			})),
+			previousRunStartedAt,
+			retryStateLoaded: true,
+		});
+		if (pendingRetries.length > 0) {
+			warnings.push(
+				`${pendingRetries.length} durable cleanup ${
+					pendingRetries.length === 1 ? "retry is" : "retries are"
+				} pending resume from the Approval Queue or the next live direct cleanup run.`,
+			);
+		}
+		if (inFlightRetries.length > 0) {
+			warnings.push(
+				`${inFlightRetries.length} durable cleanup ${
+					inFlightRetries.length === 1 ? "retry is" : "retries are"
+				} already executing and deferred from this run.`,
+			);
+		}
+		return {
+			plan,
+			pendingRetryCount: pendingRetries.length,
+			retryStateLoaded: true,
+			warnings,
+		};
+	} catch (error) {
+		deps.log.error({ err: error, configId }, "Cleanup could not load durable ARR retries");
+		warnings.push(
+			"Durable cleanup retry state could not be loaded. Fresh cleanup work is deferred for safety.",
+		);
+		return {
+			plan: planDirectCleanupSelection<FlaggedItem, LibraryCleanupApproval>({
+				limit,
+				fresh: flagged.map((item) => ({
+					key: cleanupDeleteTargetKey(flaggedDeleteTarget(item)),
+					value: item,
+				})),
+				pendingRetries: [],
+				inFlightRetries: [],
+				previousRunStartedAt,
+				retryStateLoaded: false,
+			}),
+			pendingRetryCount: null,
+			retryStateLoaded: false,
+			warnings,
+		};
+	}
+}
+
+function buildDirectSelectionDetails(
+	state: DirectSelectionState,
+	sharedPlexBlocks: Map<string, string>,
+	limit = PREVIEW_SAFETY_INSPECTION_LIMIT,
+): CleanupRunResult["details"] {
+	const details: CleanupRunResult["details"] = [];
+	for (const { value: retry } of state.plan.selectedRetries) {
+		if (details.length >= limit) break;
+		const action: DetailAction =
+			retry.action === "delete" || retry.action === "delete_files" || retry.action === "unmonitor"
+				? retry.action
+				: "skipped";
+		details.push(
+			buildRetryDetail(
+				retry,
+				action,
+				"Selected for a retry attempt in the next cleanup run. The outcome depends on live ARR safety checks.",
+			),
+		);
+	}
+	for (const { value: item } of state.plan.selectedFresh) {
+		if (details.length >= limit) break;
+		const safetyReason = sharedPlexBlocks.get(cleanupDeleteTargetKey(flaggedDeleteTarget(item)));
+		details.push(buildDetail(item, safetyReason ? "skipped" : item.match.action, safetyReason));
+	}
+	for (const decision of state.plan.decisions) {
+		if (details.length >= limit) break;
+		if (decision.disposition === "selected") continue;
+		const value = decision.candidate.value;
+		details.push(
+			"cacheItem" in value
+				? buildDetail(value, "skipped", decision.reason)
+				: buildRetryDetail(value, "skipped", decision.reason),
+		);
+	}
+	return details;
+}
+
 /**
  * Run a preview evaluation without making any changes.
  * Returns all items that would be flagged by the current rule set.
@@ -1691,8 +1863,8 @@ export async function executeCleanupPreview(
 		};
 	}
 
-	const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
 	if (config.rules.length === 0) {
+		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
 		return {
 			isDryRun: true,
 			status: retryPreview.warning ? "partial" : "completed",
@@ -1715,6 +1887,78 @@ export async function executeCleanupPreview(
 		config,
 		config.rules,
 	);
+	if (!config.requireApproval) {
+		const configuredRunLimitIsValid =
+			Number.isSafeInteger(config.maxRemovalsPerRun) &&
+			config.maxRemovalsPerRun > 0 &&
+			config.maxRemovalsPerRun <= 100;
+		const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
+		const directSelection = await loadDirectSelectionState(
+			deps,
+			userId,
+			config.id,
+			flagged,
+			configuredRunLimit,
+		);
+		const selectedFresh = directSelection.plan.selectedFresh.map((candidate) => candidate.value);
+		const safetyContext = createSharedPlexSafetyContext();
+		const sharedPlexBlocks = await findSharedPlexDeleteBlocks(
+			deps,
+			userId,
+			toDeleteTargets(selectedFresh),
+			safetyContext,
+		);
+		await blockPlansThatDifferFromEvaluatedCache(
+			deps,
+			userId,
+			selectedFresh,
+			safetyContext,
+			sharedPlexBlocks,
+		);
+		const allWarnings = withSharedPlexWarning(
+			[
+				...warnings,
+				...directSelection.warnings,
+				...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
+			],
+			sharedPlexBlocks.size,
+		);
+		const details = buildDirectSelectionDetails(directSelection, sharedPlexBlocks);
+		const selectionDeferred = directSelection.plan.decisions.filter(
+			(decision) => decision.disposition !== "selected",
+		).length;
+
+		log.info(
+			{
+				totalEvaluated,
+				totalRuleMatches: flagged.length,
+				selectedFresh: directSelection.plan.selectedFresh.length,
+				selectedRetries: directSelection.plan.selectedRetries.length,
+				pendingRetryCount: directSelection.pendingRetryCount,
+				sharedPlexBlocks: sharedPlexBlocks.size,
+			},
+			"Library cleanup preview completed",
+		);
+
+		return {
+			isDryRun: true,
+			status: allWarnings.length > 0 ? "partial" : "completed",
+			itemsEvaluated: totalEvaluated,
+			itemsFlagged: directSelection.plan.selectedFresh.length,
+			pendingRetryCount: directSelection.pendingRetryCount ?? undefined,
+			previewItemCount: directSelection.plan.counts.total,
+			itemsRemoved: 0,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
+			details,
+			durationMs: Date.now() - startTime,
+			prefetchHealth,
+			warnings: allWarnings,
+		};
+	}
+
+	const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
 	const freshCandidates = flagged.filter(
 		(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
 	);
@@ -1825,10 +2069,65 @@ async function executeCleanupRunGuarded(
 			config,
 			config.rules,
 		);
-		const configuredRunLimit =
-			Number.isSafeInteger(config.maxRemovalsPerRun) && config.maxRemovalsPerRun > 0
-				? config.maxRemovalsPerRun
-				: Number.MAX_SAFE_INTEGER;
+		const configuredRunLimitIsValid =
+			Number.isSafeInteger(config.maxRemovalsPerRun) &&
+			config.maxRemovalsPerRun > 0 &&
+			config.maxRemovalsPerRun <= 100;
+		const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
+		if (!config.requireApproval) {
+			const directSelection = await loadDirectSelectionState(
+				deps,
+				userId,
+				config.id,
+				flagged,
+				configuredRunLimit,
+			);
+			const selectedFresh = directSelection.plan.selectedFresh.map((candidate) => candidate.value);
+			const safetyContext = createSharedPlexSafetyContext();
+			const sharedPlexBlocks = await findSharedPlexDeleteBlocks(
+				deps,
+				userId,
+				toDeleteTargets(selectedFresh),
+				safetyContext,
+			);
+			await blockPlansThatDifferFromEvaluatedCache(
+				deps,
+				userId,
+				selectedFresh,
+				safetyContext,
+				sharedPlexBlocks,
+			);
+			const allWarnings = withSharedPlexWarning(
+				[
+					...warnings,
+					...directSelection.warnings,
+					...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
+				],
+				sharedPlexBlocks.size,
+			);
+			const selectionDeferred = directSelection.plan.decisions.filter(
+				(decision) => decision.disposition !== "selected",
+			).length;
+			const result: CleanupRunResult = {
+				isDryRun: true,
+				status: allWarnings.length > 0 ? "partial" : "completed",
+				itemsEvaluated: totalEvaluated,
+				itemsFlagged:
+					directSelection.plan.selectedFresh.length + directSelection.plan.selectedRetries.length,
+				pendingRetryCount: directSelection.pendingRetryCount ?? undefined,
+				itemsRemoved: 0,
+				itemsUnmonitored: 0,
+				itemsFilesDeleted: 0,
+				itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
+				details: buildDirectSelectionDetails(directSelection, sharedPlexBlocks),
+				durationMs: Date.now() - startTime,
+				prefetchHealth,
+				warnings: allWarnings,
+			};
+
+			await createRunLog(prisma, config.id, result, log);
+			return result;
+		}
 		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id, configuredRunLimit);
 		const freshCandidates = flagged.filter(
 			(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
@@ -5817,113 +6116,33 @@ export async function executeDirectRemoval(
 	let retriedRemoved = 0;
 	let retriedUnmonitored = 0;
 	let retriedFilesDeleted = 0;
-	let directRetryCount = 0;
-	let directRetryMutationBudgetConsumed = 0;
 	const sharedPlexSafetyContext = createSharedPlexSafetyContext();
-	const directRetryTargetKeys = new Set<string>();
-	const selectedDirectRetryTargetKeys = new Set<string>();
-	const inFlightDirectRetryTargetKeys = new Set<string>();
 	const configuredRunLimitIsValid =
 		Number.isSafeInteger(config.maxRemovalsPerRun) &&
 		config.maxRemovalsPerRun > 0 &&
 		config.maxRemovalsPerRun <= 100;
 	const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
-
-	let directRetries: Awaited<ReturnType<typeof prisma.libraryCleanupApproval.findMany>> = [];
-	let fairnessDeferredRetries: typeof directRetries = [];
-	let previousRunStartedAt: Date | undefined;
-	try {
-		const previousRun = await prisma.libraryCleanupLog.findFirst({
-			where: {
-				configId: config.id,
-				isDryRun: false,
-				completedAt: { not: null },
-			},
-			orderBy: { startedAt: "desc" },
-			select: { startedAt: true },
-		});
-		previousRunStartedAt = previousRun?.startedAt;
-	} catch (error) {
-		log.warn(
-			{ err: error, configId: config.id },
-			"Cleanup could not load its prior run boundary for retry fairness",
-		);
-	}
-	try {
-		const nonterminalRetryTargets = await prisma.libraryCleanupApproval.findMany({
-			where: {
-				configId: config.id,
-				config: { userId },
-				status: { in: ["retry_pending", "retry_executing"] },
-			},
-			select: {
-				instanceId: true,
-				arrItemId: true,
-				itemType: true,
-				targetScope: true,
-				arrEpisodeId: true,
-				episodeFileId: true,
-				action: true,
-				safetySnapshot: true,
-			},
-		});
-		const loadedDirectRetries = await prisma.libraryCleanupApproval.findMany({
-			where: {
-				configId: config.id,
-				config: { userId },
-				status: "retry_pending",
-			},
-			orderBy: [{ reviewedAt: { sort: "asc", nulls: "first" } }, { createdAt: "asc" }],
-			take: configuredRunLimit,
-		});
-		const executingDirectRetries = await prisma.libraryCleanupApproval.findMany({
-			where: {
-				configId: config.id,
-				config: { userId },
-				status: "retry_executing",
-			},
-		});
-		for (const retry of executingDirectRetries) {
-			const targetKey = cleanupApprovalTargetKey(retry);
-			directRetryTargetKeys.add(targetKey);
-			inFlightDirectRetryTargetKeys.add(targetKey);
-		}
-		for (const retry of loadedDirectRetries) {
-			directRetryTargetKeys.add(cleanupApprovalTargetKey(retry));
-		}
-		for (const retryTarget of nonterminalRetryTargets) {
-			directRetryTargetKeys.add(cleanupApprovalTargetKey(retryTarget));
-		}
-		const hasDistinctFreshCandidate = flagged.some(
-			(item) => !directRetryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
-		);
-		if (previousRunStartedAt && hasDistinctFreshCandidate) {
-			fairnessDeferredRetries = loadedDirectRetries.filter(
-				(retry) => retry.reviewedAt && retry.reviewedAt >= previousRunStartedAt,
-			);
-		}
-		const fairnessDeferredIds = new Set(fairnessDeferredRetries.map((retry) => retry.id));
-		directRetries = loadedDirectRetries.filter((retry) => !fairnessDeferredIds.has(retry.id));
-		directRetryFairnessDeferred = fairnessDeferredRetries.length;
-		directRetryCount = loadedDirectRetries.length;
-	} catch (error) {
-		directRetryLoadFailures++;
-		log.error({ err: error, configId: config.id }, "Cleanup could not load durable ARR retries");
-	}
-
-	for (const retry of fairnessDeferredRetries) {
+	const directSelection = await loadDirectSelectionState(
+		deps,
+		userId,
+		config.id,
+		flagged,
+		configuredRunLimit,
+	);
+	const directRetries = directSelection.plan.selectedRetries.map((retry) => retry.value);
+	directRetryLoadFailures = directSelection.retryStateLoaded ? 0 : 1;
+	directRetryFairnessDeferred = directSelection.plan.counts.deferredRetryFairness;
+	for (const decision of directSelection.plan.decisions) {
+		if (decision.disposition === "selected") continue;
+		const value = decision.candidate.value;
 		details.push(
-			buildRetryDetail(
-				retry,
-				"skipped",
-				"Deferred for one run after its previous attempt so fresh cleanup work can make progress",
-			),
+			"cacheItem" in value
+				? buildDetail(value, "skipped", decision.reason)
+				: buildRetryDetail(value, "skipped", decision.reason),
 		);
 	}
 
 	for (const retry of directRetries) {
-		const targetKey = cleanupApprovalTargetKey(retry);
-		selectedDirectRetryTargetKeys.add(targetKey);
 		try {
 			const retryResult = await executeQueuedCleanupItems(deps, userId, [retry.id], {
 				claimStatus: "retry_pending",
@@ -5933,9 +6152,6 @@ export async function executeDirectRemoval(
 				assertExecutionAllowed: assertRunLease,
 				cleanupRunClaimToken,
 			});
-			if (retryResult.mutationBudgetConsumedIds.includes(retry.id)) {
-				directRetryMutationBudgetConsumed++;
-			}
 			if (retryResult.unclaimedIds.includes(retry.id)) {
 				directRetryConcurrent++;
 				details.push(
@@ -6046,33 +6262,11 @@ export async function executeDirectRemoval(
 		}
 	}
 
-	const freshCandidates = flagged.filter((item) => {
-		if (!directRetryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item)))) return true;
-		return false;
-	});
-	const inFlightDeferredItems = flagged.filter(
-		(item) =>
-			!(
-				selectedDirectRetryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))) ||
-				!inFlightDirectRetryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item)))
-			),
-	);
-	for (const item of inFlightDeferredItems) {
-		details.push(
-			buildDetail(
-				item,
-				"skipped",
-				"Deferred: a durable record-only cleanup retry for this ARR target is already executing",
-			),
-		);
-	}
-	// Only retries that reached an ARR write consume the current run budget.
-	// Successful, partial, and indeterminate writes all count because ARR may
-	// have changed. reviewedAt plus the prior run boundary defers a just-tried
-	// retry for one later run when distinct fresh work exists.
-	const freshBudget = Math.max(0, configuredRunLimit - directRetryMutationBudgetConsumed);
-	const freshItems = freshCandidates.slice(0, freshBudget);
-	const budgetDeferredItems = freshCandidates.length - freshItems.length;
+	// The complete direct-run selection was fixed before retry attempts, safety
+	// checks, or writes. A selected target that fails closed keeps its slot; a
+	// later candidate is never pulled into the same run as backfill.
+	const freshItems = directSelection.plan.selectedFresh.map((candidate) => candidate.value);
+	const budgetDeferredItems = directSelection.plan.counts.deferredBudget;
 
 	for (const item of freshItems) {
 		if (directRetryLoadFailures > 0) {
@@ -6675,9 +6869,7 @@ export async function executeDirectRemoval(
 
 	const allWarnings = withSharedPlexWarning([...(warnings ?? [])], runtimeSafetyBlocks);
 	if (!configuredRunLimitIsValid) {
-		allWarnings.push(
-			"Cleanup did not mutate any items because the stored per-run removal limit is invalid. Set it to a whole number from 1 through 100.",
-		);
+		allWarnings.push(INVALID_CLEANUP_RUN_LIMIT_WARNING);
 	}
 	if (exemptionPolicyBlocks > 0) {
 		allWarnings.push(
@@ -6775,11 +6967,27 @@ export async function executeDirectRemoval(
 			} not persisted. Manual ARR recovery may be required.`,
 		);
 	}
-	if (inFlightDeferredItems.length > 0) {
+	if (directSelection.plan.counts.inFlight > 0) {
 		allWarnings.push(
-			`${inFlightDeferredItems.length} ${
-				inFlightDeferredItems.length === 1 ? "item was" : "items were"
-			} deferred because a durable record-only retry for the same ARR target is already executing.`,
+			`${directSelection.plan.counts.inFlight} ${
+				directSelection.plan.counts.inFlight === 1 ? "item was" : "items were"
+			} already executing in another cleanup run.`,
+		);
+	}
+	if (directSelection.plan.counts.deferredInFlightTarget > 0) {
+		allWarnings.push(
+			`${directSelection.plan.counts.deferredInFlightTarget} pending cleanup ${
+				directSelection.plan.counts.deferredInFlightTarget === 1 ? "retry was" : "retries were"
+			} deferred because an in-flight retry already owns the same target.`,
+		);
+	}
+	if (directSelection.plan.counts.deferredDuplicateTarget > 0) {
+		allWarnings.push(
+			`${directSelection.plan.counts.deferredDuplicateTarget} duplicate cleanup ${
+				directSelection.plan.counts.deferredDuplicateTarget === 1
+					? "candidate was"
+					: "candidates were"
+			} deferred because another candidate owns the same target.`,
 		);
 	}
 	const hasWarnings = allWarnings.length > 0;
@@ -6789,12 +6997,17 @@ export async function executeDirectRemoval(
 	const directFilesDeleted = filesDeleted - retriedFilesDeleted;
 	const unsuccessfulRetries = directRetryFailures + directRetryExpired + directRetryConcurrent;
 	const accountedUnsuccessfulRetries = unsuccessfulRetries + directRetryExecutionFailures;
+	const selectedOrActiveCount =
+		directSelection.plan.selectedFresh.length +
+		directSelection.plan.selectedRetries.length +
+		directSelection.plan.counts.deferredRetryFairness +
+		directSelection.plan.counts.inFlight;
 
 	const result: CleanupRunResult = {
 		isDryRun: false,
 		status: circuitBroken || hasWarnings ? "partial" : "completed",
 		itemsEvaluated: totalEvaluated,
-		itemsFlagged: directlyEvaluated + directRetryCount + inFlightDeferredItems.length,
+		itemsFlagged: selectedOrActiveCount,
 		itemsRemoved: removed,
 		itemsUnmonitored: unmonitored,
 		itemsFilesDeleted: filesDeleted,
@@ -6802,7 +7015,10 @@ export async function executeDirectRemoval(
 			totalFlaggedBeforeLimit -
 			flagged.length +
 			budgetDeferredItems +
-			inFlightDeferredItems.length +
+			directSelection.plan.counts.inFlight +
+			directSelection.plan.counts.deferredInFlightTarget +
+			directSelection.plan.counts.deferredDuplicateTarget +
+			directSelection.plan.counts.retryStateUnavailable +
 			directRetryFairnessDeferred +
 			(directlyEvaluated - directRemoved - directUnmonitored - directFilesDeleted) +
 			accountedUnsuccessfulRetries +

--- a/apps/api/src/lib/library-cleanup/selection-planner.ts
+++ b/apps/api/src/lib/library-cleanup/selection-planner.ts
@@ -1,0 +1,236 @@
+export type DirectCleanupSelectionDisposition =
+	| "selected"
+	| "deferred_budget"
+	| "deferred_retry_fairness"
+	| "deferred_in_flight_target"
+	| "deferred_duplicate_target"
+	| "in_flight"
+	| "retry_state_unavailable";
+
+export interface CleanupSelectionCandidate<T> {
+	key: string;
+	value: T;
+}
+
+export interface CleanupSelectionRetry<T> extends CleanupSelectionCandidate<T> {
+	id: string;
+	reviewedAt: Date | null;
+	createdAt: Date;
+}
+
+export interface DirectCleanupSelectionDecision<T> {
+	candidate: CleanupSelectionCandidate<T>;
+	disposition: DirectCleanupSelectionDisposition;
+	reason: string;
+}
+
+export interface DirectCleanupSelectionPlan<TFresh, TRetry> {
+	selectedFresh: Array<CleanupSelectionCandidate<TFresh>>;
+	selectedRetries: Array<CleanupSelectionRetry<TRetry>>;
+	decisions: Array<DirectCleanupSelectionDecision<TFresh | TRetry>>;
+	counts: {
+		selectedFresh: number;
+		selectedRetries: number;
+		deferredBudget: number;
+		deferredRetryFairness: number;
+		deferredInFlightTarget: number;
+		deferredDuplicateTarget: number;
+		inFlight: number;
+		retryStateUnavailable: number;
+		retryState: "complete" | "unavailable";
+		total: number;
+	};
+}
+
+export interface DirectCleanupSelectionInput<TFresh, TRetry> {
+	limit: number;
+	fresh: Array<CleanupSelectionCandidate<TFresh>>;
+	pendingRetries: Array<CleanupSelectionRetry<TRetry>>;
+	inFlightRetries: Array<CleanupSelectionRetry<TRetry>>;
+	previousRunStartedAt?: Date;
+	retryStateLoaded: boolean;
+}
+
+const RUN_BUDGET_REASON = "Deferred: the next cleanup run budget is full";
+const RETRY_FAIRNESS_REASON =
+	"Deferred for one run after its previous attempt so fresh cleanup work can make progress";
+const IN_FLIGHT_TARGET_REASON =
+	"Deferred: another durable cleanup retry for this target is already executing";
+const IN_FLIGHT_REASON = "Deferred: another cleanup run is already executing this durable retry.";
+const DUPLICATE_TARGET_REASON =
+	"Deferred: another candidate already owns this cleanup target for the next run";
+const RETRY_STATE_UNAVAILABLE_REASON =
+	"Deferred: durable cleanup retry state could not be loaded safely";
+
+function normalizedLimit(limit: number): number {
+	return Number.isSafeInteger(limit) && limit > 0 && limit <= 100 ? limit : 0;
+}
+
+function compareRetryOrder<T>(
+	left: CleanupSelectionRetry<T>,
+	right: CleanupSelectionRetry<T>,
+): number {
+	const leftReviewedAt = left.reviewedAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+	const rightReviewedAt = right.reviewedAt?.getTime() ?? Number.NEGATIVE_INFINITY;
+	return (
+		leftReviewedAt - rightReviewedAt ||
+		left.createdAt.getTime() - right.createdAt.getTime() ||
+		left.id.localeCompare(right.id)
+	);
+}
+
+function buildCounts<TFresh, TRetry>(
+	selectedFresh: Array<CleanupSelectionCandidate<TFresh>>,
+	selectedRetries: Array<CleanupSelectionRetry<TRetry>>,
+	decisions: Array<DirectCleanupSelectionDecision<TFresh | TRetry>>,
+	retryState: "complete" | "unavailable" = "complete",
+): DirectCleanupSelectionPlan<TFresh, TRetry>["counts"] {
+	const count = (disposition: DirectCleanupSelectionDisposition) =>
+		decisions.filter((decision) => decision.disposition === disposition).length;
+	return {
+		selectedFresh: selectedFresh.length,
+		selectedRetries: selectedRetries.length,
+		deferredBudget: count("deferred_budget"),
+		deferredRetryFairness: count("deferred_retry_fairness"),
+		deferredInFlightTarget: count("deferred_in_flight_target"),
+		deferredDuplicateTarget: count("deferred_duplicate_target"),
+		inFlight: count("in_flight"),
+		retryStateUnavailable: count("retry_state_unavailable"),
+		retryState,
+		total: decisions.length,
+	};
+}
+
+/**
+ * Side-effect-free direct-run selection. The selected set is fixed before any
+ * safety inspection or mutation, so a selected item that later fails closed
+ * never causes a later candidate to be pulled into the same run.
+ */
+export function planDirectCleanupSelection<TFresh, TRetry = never>(
+	input: DirectCleanupSelectionInput<TFresh, TRetry>,
+): DirectCleanupSelectionPlan<TFresh, TRetry> {
+	const limit = normalizedLimit(input.limit);
+	const decisions: Array<DirectCleanupSelectionDecision<TFresh | TRetry>> = [];
+
+	if (!input.retryStateLoaded) {
+		for (const candidate of input.fresh) {
+			decisions.push({
+				candidate,
+				disposition: "retry_state_unavailable",
+				reason: RETRY_STATE_UNAVAILABLE_REASON,
+			});
+		}
+		return {
+			selectedFresh: [],
+			selectedRetries: [],
+			decisions,
+			counts: buildCounts([], [], decisions, "unavailable"),
+		};
+	}
+
+	const orderedPendingRetries = [...input.pendingRetries].sort(compareRetryOrder);
+	const orderedInFlightRetries = [...input.inFlightRetries].sort(compareRetryOrder);
+	const inFlightKeys = new Set(orderedInFlightRetries.map((retry) => retry.key));
+
+	for (const retry of orderedInFlightRetries) {
+		decisions.push({ candidate: retry, disposition: "in_flight", reason: IN_FLIGHT_REASON });
+	}
+
+	const duplicatePendingRetries: Array<CleanupSelectionRetry<TRetry>> = [];
+	const uniquePendingRetries: Array<CleanupSelectionRetry<TRetry>> = [];
+	const pendingKeys = new Set<string>();
+	for (const retry of orderedPendingRetries) {
+		if (pendingKeys.has(retry.key)) duplicatePendingRetries.push(retry);
+		else {
+			pendingKeys.add(retry.key);
+			uniquePendingRetries.push(retry);
+		}
+	}
+	for (const retry of duplicatePendingRetries) {
+		decisions.push({
+			candidate: retry,
+			disposition: "deferred_duplicate_target",
+			reason: DUPLICATE_TARGET_REASON,
+		});
+	}
+
+	const freshCandidates: Array<CleanupSelectionCandidate<TFresh>> = [];
+	const freshKeys = new Set<string>();
+	for (const candidate of input.fresh) {
+		if (inFlightKeys.has(candidate.key)) {
+			decisions.push({
+				candidate,
+				disposition: "deferred_in_flight_target",
+				reason: IN_FLIGHT_TARGET_REASON,
+			});
+		} else if (pendingKeys.has(candidate.key) || freshKeys.has(candidate.key)) {
+			decisions.push({
+				candidate,
+				disposition: "deferred_duplicate_target",
+				reason: DUPLICATE_TARGET_REASON,
+			});
+		} else {
+			freshKeys.add(candidate.key);
+			freshCandidates.push(candidate);
+		}
+	}
+
+	const fairnessDeferred: Array<CleanupSelectionRetry<TRetry>> = [];
+	const inFlightTargetDeferred: Array<CleanupSelectionRetry<TRetry>> = [];
+	const eligibleRetries: Array<CleanupSelectionRetry<TRetry>> = [];
+	for (const retry of uniquePendingRetries) {
+		if (inFlightKeys.has(retry.key)) inFlightTargetDeferred.push(retry);
+		else if (
+			freshCandidates.length > 0 &&
+			input.previousRunStartedAt &&
+			retry.reviewedAt &&
+			retry.reviewedAt >= input.previousRunStartedAt
+		) {
+			fairnessDeferred.push(retry);
+		} else eligibleRetries.push(retry);
+	}
+	for (const retry of inFlightTargetDeferred) {
+		decisions.push({
+			candidate: retry,
+			disposition: "deferred_in_flight_target",
+			reason: IN_FLIGHT_TARGET_REASON,
+		});
+	}
+	for (const retry of fairnessDeferred) {
+		decisions.push({
+			candidate: retry,
+			disposition: "deferred_retry_fairness",
+			reason: RETRY_FAIRNESS_REASON,
+		});
+	}
+
+	const selectedRetries = eligibleRetries.slice(0, limit);
+	const selectedRetryIds = new Set(selectedRetries.map((retry) => retry.id));
+	for (const retry of eligibleRetries) {
+		decisions.push(
+			selectedRetryIds.has(retry.id)
+				? {
+						candidate: retry,
+						disposition: "selected",
+						reason: "Selected for a retry attempt in the next cleanup run",
+					}
+				: { candidate: retry, disposition: "deferred_budget", reason: RUN_BUDGET_REASON },
+		);
+	}
+
+	const selectedFresh = freshCandidates.slice(0, Math.max(0, limit - selectedRetries.length));
+	for (const [index, candidate] of freshCandidates.entries()) {
+		decisions.push(
+			index < selectedFresh.length
+				? { candidate, disposition: "selected", reason: "Selected for the next cleanup run" }
+				: { candidate, disposition: "deferred_budget", reason: RUN_BUDGET_REASON },
+		);
+	}
+
+	return {
+		selectedFresh,
+		selectedRetries,
+		decisions,
+		counts: buildCounts(selectedFresh, selectedRetries, decisions),
+	};
+}


### PR DESCRIPTION
## Summary

- choose the complete direct cleanup target set before safety checks or mutations
- share one hard per-run budget across durable retries and fresh matches
- deduplicate physical episode-file targets and defer in-flight or recently attempted retries deterministically
- use the same selection plan for interactive preview, configured dry-run, and live direct execution
- fail closed when retry state is unavailable, invalid, or exceeds the bounded 500-record inventory

## Safety behavior

A selected retry or fresh target keeps its slot even if its live safety check fails, its claim is lost, or its mutation fails. Later candidates are not pulled into the run as backfill. Preview and dry-run remain non-mutating.

## Validation

- 314 focused cleanup tests passed
- full API suite: 3,959 passed, 52 skipped
- web suite: 807 passed
- shared suite: 121 passed
- root format, shared build, root typecheck, lint, and production build passed
- independent data-safety review: no findings
- independent regression review: two findings corrected in one frozen correction pass