### PR TITLE
fix(cleanup): freeze approval-run selection before safety checks

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/rejection-memory.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/rejection-memory.test.ts
@@ -103,7 +103,7 @@ describe("resolveRejectionMemoryWindow — per-rule override", () => {
 // `buildDedupOrClauses` — the Prisma OR-clause shape that drives the actual
 // dedup query inside executeWithApproval. The helper exists so we can pin the
 // cutoff math + clause structure without mocking Prisma. Per-mode boundaries:
-//   - off:     only the pending-dedup clause, no rejected-skip
+//   - off:     active approval/execution states only, no rejected-skip
 //   - days:    rejected-skip with `reviewedAt: { gt: now - days }`
 //   - forever: rejected-skip with no time bound
 // ============================================================================
@@ -112,14 +112,17 @@ describe("buildDedupOrClauses", () => {
 	// Fixed reference instant so the cutoff math is deterministic across runs.
 	const NOW = new Date("2026-05-27T12:00:00.000Z");
 
-	it("mode 'off' → only the pending-dedup clause (no rejection skip)", () => {
+	it("mode 'off' → active ownership only (no rejection skip)", () => {
 		const clauses = buildDedupOrClauses({ mode: "off" }, NOW);
-		expect(clauses).toEqual([{ status: "pending" }]);
+		expect(clauses).toEqual([{ status: { in: ["pending", "approved", "executing"] } }]);
 	});
 
 	it("mode 'forever' → pending + unconditional rejected skip", () => {
 		const clauses = buildDedupOrClauses({ mode: "forever" }, NOW);
-		expect(clauses).toEqual([{ status: "pending" }, { status: "rejected" }]);
+		expect(clauses).toEqual([
+			{ status: { in: ["pending", "approved", "executing"] } },
+			{ status: "rejected" },
+		]);
 		// No reviewedAt clause on the rejected branch — forever means
 		// "remember this rejection regardless of when it happened."
 		const rejectedClause = clauses[1] as { status: string; reviewedAt?: unknown };
@@ -129,7 +132,9 @@ describe("buildDedupOrClauses", () => {
 	it("mode 'days' → rejected skip with cutoff = now - N days", () => {
 		const clauses = buildDedupOrClauses({ mode: "days", days: 7 }, NOW);
 		expect(clauses).toHaveLength(2);
-		expect(clauses[0]).toEqual({ status: "pending" });
+		expect(clauses[0]).toEqual({
+			status: { in: ["pending", "approved", "executing"] },
+		});
 		const rejectedClause = clauses[1] as { status: string; reviewedAt: { gt: Date } };
 		expect(rejectedClause.status).toBe("rejected");
 		// Cutoff: 7 days before NOW = 2026-05-20T12:00:00Z

--- a/apps/api/src/lib/library-cleanup/__tests__/selection-planner.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/selection-planner.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { planDirectCleanupSelection } from "../selection-planner.js";
+import { planApprovalCleanupSelection, planDirectCleanupSelection } from "../selection-planner.js";
 
 const fresh = (...keys: string[]) => keys.map((key) => ({ key, value: key }));
 const freshCandidate = (key: string, value: string) => ({ key, value });
@@ -172,5 +172,92 @@ describe("planDirectCleanupSelection", () => {
 		});
 
 		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(selected);
+	});
+});
+
+describe("planApprovalCleanupSelection", () => {
+	it("applies approval memory before the hard run budget", () => {
+		const plan = planApprovalCleanupSelection({
+			limit: 2,
+			fresh: fresh("pending", "rejected", "selected-1", "selected-2", "deferred"),
+			approvalExclusions: new Map([
+				["pending", "Already pending in the approval queue"],
+				["rejected", "Previously rejected"],
+			]),
+			nonterminalRetryKeys: new Set(),
+			inFlightRetries: [],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual([
+			"selected-1",
+			"selected-2",
+		]);
+		expect(plan.counts).toMatchObject({ deferredApproval: 2, deferredBudget: 1 });
+	});
+
+	it("defers durable retry ownership and duplicate fresh targets before selection", () => {
+		const plan = planApprovalCleanupSelection({
+			limit: 2,
+			fresh: fresh("retry-owned", "first", "first", "second"),
+			approvalExclusions: new Map(),
+			nonterminalRetryKeys: new Set(["retry-owned"]),
+			inFlightRetries: [],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["first", "second"]);
+		expect(plan.counts).toMatchObject({
+			deferredApproval: 1,
+			deferredDuplicateTarget: 1,
+		});
+	});
+
+	it("reports in-flight retries without charging approval-run budget", () => {
+		const plan = planApprovalCleanupSelection({
+			limit: 1,
+			fresh: fresh("fresh"),
+			approvalExclusions: new Map(),
+			nonterminalRetryKeys: new Set(),
+			inFlightRetries: [retry("executing")],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh"]);
+		expect(plan.counts).toMatchObject({ selectedFresh: 1, inFlight: 1, total: 2 });
+	});
+
+	it("represents an in-flight target once when the same target still matches a rule", () => {
+		const plan = planApprovalCleanupSelection({
+			limit: 1,
+			fresh: fresh("executing", "fresh"),
+			approvalExclusions: new Map(),
+			nonterminalRetryKeys: new Set(["executing"]),
+			inFlightRetries: [retry("executing"), { ...retry("duplicate"), key: "executing" }],
+			retryStateLoaded: true,
+		});
+
+		expect(plan.selectedFresh.map((candidate) => candidate.key)).toEqual(["fresh"]);
+		expect(plan.counts).toMatchObject({ selectedFresh: 1, inFlight: 1, total: 2 });
+		expect(
+			plan.decisions.filter((decision) => decision.candidate.key === "executing"),
+		).toHaveLength(1);
+	});
+
+	it("fails closed when approval or retry state is unavailable", () => {
+		const plan = planApprovalCleanupSelection({
+			limit: 2,
+			fresh: fresh("first", "second"),
+			approvalExclusions: new Map(),
+			nonterminalRetryKeys: new Set(),
+			inFlightRetries: [],
+			retryStateLoaded: false,
+		});
+
+		expect(plan.selectedFresh).toEqual([]);
+		expect(plan.counts).toMatchObject({
+			retryState: "unavailable",
+			retryStateUnavailable: 2,
+		});
 	});
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1144,7 +1144,16 @@ describe("shared Plex deletion safety", () => {
 					title: "Fresh approval candidate",
 				}),
 			] as never);
-			const retryTarget = approvalRecord({ status: retryStatus }) as Record<string, unknown>;
+			const retryTarget = approvalRecord({
+				status: retryStatus,
+				sizeOnDisk: 2_000n,
+				year: 2024,
+				rating: 8,
+				matchedRuleId: "rule-1",
+				matchedRuleName: "Old media",
+				createdAt: new Date("2026-07-27T12:00:00.000Z"),
+				reviewedAt: null,
+			}) as Record<string, unknown>;
 			vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
 				where,
 				select,
@@ -1823,6 +1832,271 @@ describe("shared Plex deletion safety", () => {
 		expect(liveFixture.targetClient.movie.update).toHaveBeenCalledWith(
 			101,
 			expect.objectContaining({ monitored: false }),
+		);
+	});
+
+	it("uses the same frozen approval selection for preview, configured dry run, and live queueing", async () => {
+		const cacheItems = [
+			matchingDryRunCacheItem({ id: "cache-pending", arrItemId: 101, title: "Pending" }),
+			matchingDryRunCacheItem({ id: "cache-selected", arrItemId: 102, title: "Selected" }),
+			matchingDryRunCacheItem({ id: "cache-deferred", arrItemId: 103, title: "Deferred" }),
+		];
+		const config = {
+			...dryRunConfig(1),
+			requireApproval: true,
+			rules: [{ ...dryRunConfig(1).rules[0]!, action: "unmonitor" }],
+		};
+		const pendingApproval = approvalRecord({
+			id: "approval-pending",
+			arrItemId: 101,
+			status: "pending",
+			action: "unmonitor",
+		});
+		const configureSelectionState = (deps: CleanupExecutorDeps) => {
+			vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+				where,
+			}: {
+				where: { status?: { in: string[] }; OR?: unknown[] };
+			}) => {
+				if (where.status?.in) return [];
+				if (where.OR) return [pendingApproval];
+				return [];
+			}) as never);
+		};
+		const selectedIds = (result: Awaited<ReturnType<typeof executeCleanupRun>>) =>
+			result.details
+				.filter((detail) => detail.action !== "skipped")
+				.map((detail) => detail.arrItemId);
+
+		const previewFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(previewFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+		} as never);
+		vi.mocked(previewFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(
+			cacheItems as never,
+		);
+		configureSelectionState(previewFixture.deps);
+		const preview = await executeCleanupPreview(previewFixture.deps, "user-1");
+
+		const dryRunFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(dryRunFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: true,
+		} as never);
+		vi.mocked(dryRunFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(
+			cacheItems as never,
+		);
+		configureSelectionState(dryRunFixture.deps);
+		const dryRun = await executeCleanupRun(dryRunFixture.deps, "user-1");
+
+		const liveFixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(liveFixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+		} as never);
+		vi.mocked(liveFixture.deps.prisma.libraryCache.findMany).mockResolvedValue(cacheItems as never);
+		configureSelectionState(liveFixture.deps);
+		const live = await executeCleanupRun(liveFixture.deps, "user-1");
+
+		expect(selectedIds(preview)).toEqual([102]);
+		expect(selectedIds(dryRun)).toEqual([102]);
+		expect(selectedIds(live)).toEqual([102]);
+		expect(previewFixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+		expect(dryRunFixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+		expect(liveFixture.deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledOnce();
+		expect(liveFixture.deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ arrItemId: 102 }) }),
+		);
+	});
+
+	it("does not backfill a later approval candidate when selected safety fails closed", async () => {
+		const fixture = makeDeps({ targetFailure: new Error("Radarr unavailable") });
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...dryRunConfig(1),
+			dryRunMode: false,
+			requireApproval: true,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({ id: "cache-selected", arrItemId: 101, title: "Selected" }),
+			matchingDryRunCacheItem({ id: "cache-deferred", arrItemId: 102, title: "Deferred" }),
+		] as never);
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result.status).toBe("partial");
+		expect(result.details).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ arrItemId: 101, action: "skipped" }),
+				expect.objectContaining({
+					arrItemId: 102,
+					action: "skipped",
+					reason: expect.stringContaining("budget is full"),
+				}),
+			]),
+		);
+		expect(fixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+	});
+
+	it("fails approval queueing closed when durable selection state is unavailable", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...dryRunConfig(1),
+			dryRunMode: false,
+			requireApproval: true,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({ arrItemId: 101 }),
+		] as never);
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockRejectedValue(
+			new Error("database unavailable"),
+		);
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({ status: "partial", itemsFlagged: 0 });
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining("Fresh cleanup targets were deferred for safety"),
+		);
+		expect(fixture.deps.prisma.libraryCleanupApproval.create).not.toHaveBeenCalled();
+		expect(fixture.targetClient.movie.update).not.toHaveBeenCalled();
+		expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+		expect(fixture.deleteMovie).not.toHaveBeenCalled();
+	});
+
+	it("paginates a large retry backlog and finds a relevant collision beyond the first page", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...dryRunConfig(1),
+			dryRunMode: false,
+			requireApproval: true,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({ id: "cache-collision", arrItemId: 101 }),
+			matchingDryRunCacheItem({ id: "cache-selected", arrItemId: 102 }),
+		] as never);
+		const retryBacklog = Array.from({ length: 501 }, (_, index) =>
+			approvalRecord({
+				id: `retry-${String(index).padStart(4, "0")}`,
+				arrItemId: index === 500 ? 101 : 1_000 + index,
+				status: "retry_pending",
+			}),
+		);
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+			cursor,
+			take,
+		}: {
+			where: { status?: { in: string[] } };
+			cursor?: { id: string };
+			take: number;
+		}) => {
+			if (!where.status?.in) return [];
+			const start = cursor ? retryBacklog.findIndex((retry) => retry.id === cursor.id) + 1 : 0;
+			return retryBacklog.slice(start, start + take);
+		}) as never);
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({ status: "partial", itemsFlagged: 1 });
+		expect(fixture.deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ arrItemId: 102 }) }),
+		);
+		expect(fixture.deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({ cursor: { id: "retry-0499" }, skip: 1 }),
+		);
+	});
+
+	it.each([
+		{ label: "still matches", includeFreshMatch: true },
+		{ label: "no longer matches", includeFreshMatch: false },
+	])(
+		"renders one distinct approval preview row for an in-flight target that $label",
+		async ({ includeFreshMatch }) => {
+			const fixture = makeDeps({ mediaPartCount: 1 });
+			vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+				...dryRunConfig(1),
+				dryRunMode: false,
+				requireApproval: true,
+			} as never);
+			vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue(
+				includeFreshMatch ? ([matchingDryRunCacheItem({ arrItemId: 101 })] as never) : [],
+			);
+			const retry = approvalRecord({
+				id: "retry-executing",
+				arrItemId: 101,
+				status: "retry_executing",
+				lastExecutionError: "Previous attempt is still being reconciled",
+				sizeOnDisk: 2_000n,
+				year: 2024,
+				rating: 8,
+				matchedRuleId: "rule-1",
+				matchedRuleName: "Old media",
+				createdAt: new Date("2026-07-27T12:00:00.000Z"),
+				reviewedAt: null,
+			});
+			vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+				where,
+			}: {
+				where: { status?: { in: string[] } };
+			}) => (where.status?.in ? [retry] : [])) as never);
+
+			const result = await executeCleanupPreview(fixture.deps, "user-1");
+
+			expect(result).toMatchObject({
+				status: "partial",
+				itemsFlagged: 0,
+				itemsSkipped: 1,
+				previewItemCount: 1,
+			});
+			expect(result.details).toEqual([
+				expect.objectContaining({
+					arrItemId: 101,
+					action: "skipped",
+					reason: expect.stringContaining("already executing"),
+				}),
+			]);
+		},
+	);
+
+	it("reserves a target held by an unrecovered approved queue item", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...dryRunConfig(1),
+			dryRunMode: false,
+			requireApproval: true,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem({ id: "cache-approved", arrItemId: 101 }),
+			matchingDryRunCacheItem({ id: "cache-selected", arrItemId: 102 }),
+		] as never);
+		const approved = approvalRecord({
+			id: "approval-approved",
+			arrItemId: 101,
+			status: "approved",
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
+			where,
+		}: {
+			where: { status?: { in: string[] }; OR?: unknown[] };
+		}) => (where.OR ? [approved] : [])) as never);
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result.itemsFlagged).toBe(1);
+		expect(fixture.deps.prisma.libraryCleanupApproval.create).toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ arrItemId: 102 }) }),
+		);
+		expect(fixture.deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					OR: expect.arrayContaining([
+						expect.objectContaining({
+							status: { in: ["pending", "approved", "executing"] },
+						}),
+					]),
+				}),
+			}),
 		);
 	});
 

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -2096,11 +2096,8 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(result.skippedDetails).toHaveLength(2);
 		expect(fixture.deps.prisma.libraryCleanupApproval.findMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				select: expect.objectContaining({
-					episodeFileId: true,
-					action: true,
-					safetySnapshot: true,
-				}),
+				take: 501,
+				where: expect.objectContaining({ OR: expect.any(Array) }),
 			}),
 		);
 	});

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -62,6 +62,7 @@ import type { ProviderCacheType } from "./provider-cache-evidence.js";
 import { applyQuiSeedingFilter, isQuiSeedingState } from "./qui-filter.js";
 import {
 	type DirectCleanupSelectionPlan,
+	planApprovalCleanupSelection,
 	planDirectCleanupSelection,
 } from "./selection-planner.js";
 import {
@@ -257,6 +258,7 @@ function parsePublishedStringArray(value: string, label: string): string[] {
 // the caller cannot inspect.
 const PREVIEW_SAFETY_INSPECTION_LIMIT = 200;
 const DIRECT_RETRY_INVENTORY_LIMIT = 500;
+const APPROVAL_SELECTION_PAGE_SIZE = 500;
 const INVALID_CLEANUP_RUN_LIMIT_WARNING =
 	"Cleanup did not select any items because the stored per-run removal limit is invalid. Set it to a whole number from 1 through 100.";
 
@@ -749,8 +751,8 @@ export function resolveRejectionMemoryWindow(
 
 /**
  * Build the Prisma `OR` clauses for the cleanup-approval dedup query
- * (issue #474). Always returns the `pending` skip; additionally appends a
- * `rejected`-skip clause when the memory window is non-off. Exported and
+ * (issue #474). Always excludes every active operator/execution state;
+ * additionally appends a `rejected`-skip clause when the memory window is non-off. Exported and
  * `now`-parameterised so unit tests can pin the cutoff math without
  * monkey-patching Date.now.
  */
@@ -758,7 +760,9 @@ export function buildDedupOrClauses(
 	memWindow: RejectionMemoryWindow,
 	now: Date = new Date(),
 ): Prisma.LibraryCleanupApprovalWhereInput[] {
-	const clauses: Prisma.LibraryCleanupApprovalWhereInput[] = [{ status: "pending" }];
+	const clauses: Prisma.LibraryCleanupApprovalWhereInput[] = [
+		{ status: { in: ["pending", "approved", "executing"] } },
+	];
 	if (memWindow.mode === "forever") {
 		clauses.push({ status: "rejected" });
 	} else if (memWindow.mode === "days") {
@@ -1678,6 +1682,17 @@ interface DirectSelectionState {
 	warnings: string[];
 }
 
+interface ApprovalSelectionState {
+	plan: DirectCleanupSelectionPlan<FlaggedItem, LibraryCleanupApproval>;
+	selected: FlaggedItem[];
+	skippedDetails: CleanupRunResult["details"];
+	pendingRetryCount: number | null;
+	inFlightRetryTargetCount: number;
+	unmatchedInFlightRetryTargetCount: number;
+	retryStateLoaded: boolean;
+	warnings: string[];
+}
+
 async function loadDirectSelectionState(
 	deps: CleanupExecutorDeps,
 	userId: string,
@@ -1958,43 +1973,60 @@ export async function executeCleanupPreview(
 		};
 	}
 
-	const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
-	const freshCandidates = flagged.filter(
-		(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
+	const configuredRunLimitIsValid =
+		Number.isSafeInteger(config.maxRemovalsPerRun) &&
+		config.maxRemovalsPerRun > 0 &&
+		config.maxRemovalsPerRun <= 100;
+	const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
+	const approvalSelection = await loadApprovalSelectionState(
+		deps,
+		config,
+		userId,
+		flagged,
+		configuredRunLimit,
 	);
-	const retryDetails = retryPreview.details.slice(0, PREVIEW_SAFETY_INSPECTION_LIMIT);
-	const inspected = selectInspectableCleanupPreviewItems(
-		freshCandidates,
-		PREVIEW_SAFETY_INSPECTION_LIMIT - retryDetails.length,
-	);
+	const selectedFresh = approvalSelection.selected;
 	const safetyContext = createSharedPlexSafetyContext();
 	const sharedPlexBlocks = await findSharedPlexDeleteBlocks(
 		deps,
 		userId,
-		toDeleteTargets(inspected),
+		toDeleteTargets(selectedFresh),
 		safetyContext,
 	);
 	await blockPlansThatDifferFromEvaluatedCache(
 		deps,
 		userId,
-		inspected,
+		selectedFresh,
 		safetyContext,
 		sharedPlexBlocks,
 	);
 	const allWarnings = withSharedPlexWarning(
-		retryPreview.warning ? [...warnings, retryPreview.warning] : warnings,
+		[
+			...warnings,
+			...approvalSelection.warnings,
+			...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
+		],
 		sharedPlexBlocks.size,
 	);
-
-	const details = [...retryDetails, ...buildCleanupPreviewDetails(inspected, sharedPlexBlocks)];
+	const details = [
+		...buildCleanupPreviewDetails(selectedFresh, sharedPlexBlocks),
+		...approvalSelection.skippedDetails,
+	].slice(0, PREVIEW_SAFETY_INSPECTION_LIMIT);
+	const selectionDeferred =
+		approvalSelection.plan.decisions.filter((decision) => decision.disposition !== "selected")
+			.length +
+		Math.max(
+			0,
+			approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
+		);
 
 	const hasWarnings = allWarnings.length > 0;
 	log.info(
 		{
 			totalEvaluated,
 			totalRuleMatches: flagged.length,
-			totalFlagged: freshCandidates.length,
-			pendingRetryCount: retryPreview.total,
+			selectedFresh: approvalSelection.plan.selectedFresh.length,
+			pendingRetryCount: approvalSelection.pendingRetryCount,
 			sharedPlexBlocks: sharedPlexBlocks.size,
 			hasWarnings,
 		},
@@ -2005,13 +2037,18 @@ export async function executeCleanupPreview(
 		isDryRun: true,
 		status: hasWarnings ? ("partial" as const) : ("completed" as const),
 		itemsEvaluated: totalEvaluated,
-		itemsFlagged: freshCandidates.length,
-		pendingRetryCount: retryPreview.total,
-		previewItemCount: retryPreview.targetKeys.size + freshCandidates.length,
+		itemsFlagged: approvalSelection.plan.selectedFresh.length,
+		pendingRetryCount: approvalSelection.pendingRetryCount ?? undefined,
+		previewItemCount:
+			approvalSelection.plan.counts.total +
+			Math.max(
+				0,
+				approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
+			),
 		itemsRemoved: 0,
 		itemsUnmonitored: 0,
 		itemsFilesDeleted: 0,
-		itemsSkipped: sharedPlexBlocks.size,
+		itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
 		details,
 		durationMs: Date.now() - startTime,
 		prefetchHealth,
@@ -2128,51 +2165,58 @@ async function executeCleanupRunGuarded(
 			await createRunLog(prisma, config.id, result, log);
 			return result;
 		}
-		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id, configuredRunLimit);
-		const freshCandidates = flagged.filter(
-			(item) => !retryPreview.targetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
+		const approvalSelection = await loadApprovalSelectionState(
+			deps,
+			config,
+			userId,
+			flagged,
+			configuredRunLimit,
 		);
-		const freshBudget = retryPreview.loaded
-			? Math.max(0, configuredRunLimit - retryPreview.retries.length)
-			: 0;
-		const limited = freshCandidates.slice(0, freshBudget);
+		const selectedFresh = approvalSelection.selected;
 		const safetyContext = createSharedPlexSafetyContext();
 		const sharedPlexBlocks = await findSharedPlexDeleteBlocks(
 			deps,
 			userId,
-			toDeleteTargets(limited),
+			toDeleteTargets(selectedFresh),
 			safetyContext,
 		);
 		await blockPlansThatDifferFromEvaluatedCache(
 			deps,
 			userId,
-			limited,
+			selectedFresh,
 			safetyContext,
 			sharedPlexBlocks,
 		);
 		const allWarnings = withSharedPlexWarning(
-			retryPreview.warning ? [...warnings, retryPreview.warning] : warnings,
+			[
+				...warnings,
+				...approvalSelection.warnings,
+				...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
+			],
 			sharedPlexBlocks.size,
 		);
 		const details = [
-			...retryPreview.details,
-			...buildCleanupPreviewDetails(limited, sharedPlexBlocks),
-		];
+			...buildCleanupPreviewDetails(selectedFresh, sharedPlexBlocks),
+			...approvalSelection.skippedDetails,
+		].slice(0, PREVIEW_SAFETY_INSPECTION_LIMIT);
+		const selectionDeferred =
+			approvalSelection.plan.decisions.filter((decision) => decision.disposition !== "selected")
+				.length +
+			Math.max(
+				0,
+				approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
+			);
 
 		const result: CleanupRunResult = {
 			isDryRun: true,
 			status: allWarnings.length > 0 ? "partial" : "completed",
 			itemsEvaluated: totalEvaluated,
-			itemsFlagged: retryPreview.retries.length + limited.length,
-			pendingRetryCount: retryPreview.total,
+			itemsFlagged: approvalSelection.plan.selectedFresh.length,
+			pendingRetryCount: approvalSelection.pendingRetryCount ?? undefined,
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
-			itemsSkipped:
-				freshCandidates.length -
-				limited.length +
-				sharedPlexBlocks.size +
-				retryPreview.inFlightRetries.length,
+			itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
 			details,
 			durationMs: Date.now() - startTime,
 			prefetchHealth,
@@ -2197,35 +2241,17 @@ async function executeCleanupRunGuarded(
 		);
 		// Real execution
 		if (config.requireApproval) {
-			const nonterminalRetryTargets = await prisma.libraryCleanupApproval.findMany({
-				where: {
-					configId: config.id,
-					config: { userId },
-					status: { in: ["retry_pending", "retry_executing"] },
-				},
-				select: {
-					instanceId: true,
-					arrItemId: true,
-					itemType: true,
-					targetScope: true,
-					arrEpisodeId: true,
-					episodeFileId: true,
-					action: true,
-					safetySnapshot: true,
-				},
-			});
-			const retryTargetKeys = new Set(
-				nonterminalRetryTargets.map((retry) => cleanupApprovalTargetKey(retry)),
-			);
-			const freshCandidates = flagged.filter(
-				(item) => !retryTargetKeys.has(cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
-			);
-			const approvalSelection = await selectApprovalCandidatesBeforeLimit(
+			const configuredRunLimitIsValid =
+				Number.isSafeInteger(config.maxRemovalsPerRun) &&
+				config.maxRemovalsPerRun > 0 &&
+				config.maxRemovalsPerRun <= 100;
+			const configuredRunLimit = configuredRunLimitIsValid ? config.maxRemovalsPerRun : 0;
+			const approvalSelection = await loadApprovalSelectionState(
 				deps,
 				config,
 				userId,
-				freshCandidates,
-				config.maxRemovalsPerRun,
+				flagged,
+				configuredRunLimit,
 			);
 			const limited = approvalSelection.selected;
 			const safetyContext = createSharedPlexSafetyContext();
@@ -2242,7 +2268,14 @@ async function executeCleanupRunGuarded(
 				safetyContext,
 				sharedPlexBlocks,
 			);
-			const allWarnings = withSharedPlexWarning(warnings, sharedPlexBlocks.size);
+			const allWarnings = withSharedPlexWarning(
+				[
+					...warnings,
+					...approvalSelection.warnings,
+					...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
+				],
+				sharedPlexBlocks.size,
+			);
 			return await executeWithApproval(
 				deps,
 				config,
@@ -2256,6 +2289,7 @@ async function executeCleanupRunGuarded(
 				safetyContext.plans,
 				providerEvidence,
 				approvalSelection.skippedDetails,
+				approvalSelection.unmatchedInFlightRetryTargetCount,
 			);
 		}
 
@@ -5834,6 +5868,88 @@ export async function selectApprovalCandidatesBeforeLimit(
 	selected: FlaggedItem[];
 	skippedDetails: CleanupRunResult["details"];
 }> {
+	const selection = await loadApprovalSelectionState(deps, config, userId, flagged, limit);
+	return { selected: selection.selected, skippedDetails: selection.skippedDetails };
+}
+
+function buildApprovalSelectionDetails(
+	selectionPlan: DirectCleanupSelectionPlan<FlaggedItem, LibraryCleanupApproval>,
+): CleanupRunResult["details"] {
+	const details: CleanupRunResult["details"] = [];
+	for (const decision of selectionPlan.decisions) {
+		if (details.length >= PREVIEW_SAFETY_INSPECTION_LIMIT) break;
+		if (decision.disposition === "selected") continue;
+		const value = decision.candidate.value;
+		details.push(
+			"cacheItem" in value
+				? buildDetail(value, "skipped", decision.reason)
+				: buildRetryDetail(value, "skipped", decision.reason),
+		);
+	}
+	return details;
+}
+
+function unavailableApprovalSelectionState(
+	flagged: FlaggedItem[],
+	limit: number,
+	warning: string,
+): ApprovalSelectionState {
+	const plan = planApprovalCleanupSelection<FlaggedItem, LibraryCleanupApproval>({
+		limit,
+		fresh: flagged.map((item) => ({
+			key: cleanupDeleteTargetKey(flaggedDeleteTarget(item)),
+			value: item,
+		})),
+		approvalExclusions: new Map(),
+		nonterminalRetryKeys: new Set(),
+		inFlightRetries: [],
+		retryStateLoaded: false,
+	});
+	return {
+		plan,
+		selected: [],
+		skippedDetails: buildApprovalSelectionDetails(plan),
+		pendingRetryCount: null,
+		inFlightRetryTargetCount: 0,
+		unmatchedInFlightRetryTargetCount: 0,
+		retryStateLoaded: false,
+		warnings: [warning],
+	};
+}
+
+async function visitApprovalSelectionPages(
+	deps: CleanupExecutorDeps,
+	where: Prisma.LibraryCleanupApprovalWhereInput,
+	visit: (row: LibraryCleanupApproval) => void,
+): Promise<void> {
+	let cursorId: string | undefined;
+	while (true) {
+		const page = await deps.prisma.libraryCleanupApproval.findMany({
+			where,
+			orderBy: { id: "asc" },
+			take: APPROVAL_SELECTION_PAGE_SIZE + 1,
+			...(cursorId ? { cursor: { id: cursorId }, skip: 1 } : {}),
+		});
+		const rows = page.slice(0, APPROVAL_SELECTION_PAGE_SIZE);
+		for (const row of rows) visit(row);
+		if (page.length <= APPROVAL_SELECTION_PAGE_SIZE) return;
+		const nextCursorId = rows.at(-1)?.id;
+		if (!nextCursorId || nextCursorId === cursorId) {
+			throw new Error("Approval selection pagination did not advance");
+		}
+		cursorId = nextCursorId;
+	}
+}
+
+async function loadApprovalSelectionState(
+	deps: CleanupExecutorDeps,
+	config: LibraryCleanupConfig & { rules: LibraryCleanupRule[] },
+	userId: string,
+	flagged: FlaggedItem[],
+	limit: number,
+): Promise<ApprovalSelectionState> {
+	const unavailableWarning =
+		"Durable cleanup retry or approval state could not be loaded. Fresh cleanup targets were deferred for safety.";
 	const memoryByRuleId = new Map<string, RejectionMemoryWindow>();
 	for (const rule of config.rules) {
 		memoryByRuleId.set(rule.id, resolveRejectionMemoryWindow(rule, config));
@@ -5849,56 +5965,95 @@ export async function selectApprovalCandidatesBeforeLimit(
 			.map((window) => window.days),
 	);
 	const now = new Date();
-	const approvalDedupRows = await deps.prisma.libraryCleanupApproval.findMany({
-		where: {
-			configId: config.id,
-			config: { userId },
-			OR: [
-				{ status: "pending" },
-				...(remembersForever
-					? [{ status: "rejected" }]
-					: maxRememberedDays > 0
-						? [
-								{
-									status: "rejected",
-									reviewedAt: {
-										gt: new Date(now.getTime() - maxRememberedDays * 24 * 60 * 60 * 1000),
-									},
-								},
-							]
-						: []),
-			],
-		},
-		select: {
-			instanceId: true,
-			arrItemId: true,
-			itemType: true,
-			targetScope: true,
-			arrEpisodeId: true,
-			episodeFileId: true,
-			action: true,
-			safetySnapshot: true,
-			status: true,
-			reviewedAt: true,
-		},
-	});
-	const approvalDedupRowsByTarget = new Map<string, typeof approvalDedupRows>();
-	for (const row of approvalDedupRows) {
-		const targetKey = cleanupApprovalTargetKey(row);
-		const rows = approvalDedupRowsByTarget.get(targetKey);
-		if (rows) rows.push(row);
-		else approvalDedupRowsByTarget.set(targetKey, [row]);
+	const candidateKeys = new Set(
+		flagged.map((item) => cleanupDeleteTargetKey(flaggedDeleteTarget(item))),
+	);
+	const approvalDedupRowsByTarget = new Map<string, LibraryCleanupApproval[]>();
+	const nonterminalRetryKeys = new Set<string>();
+	const inFlightRetryTargetKeys = new Set<string>();
+	const inFlightRetries: Array<{
+		id: string;
+		key: string;
+		value: LibraryCleanupApproval;
+		reviewedAt: Date | null;
+		createdAt: Date;
+	}> = [];
+	let pendingRetryCount = 0;
+	try {
+		await Promise.all([
+			visitApprovalSelectionPages(
+				deps,
+				{
+					configId: config.id,
+					config: { userId },
+					status: { in: ["retry_pending", "retry_executing"] },
+				},
+				(retry) => {
+					const targetKey = cleanupApprovalTargetKey(retry);
+					if (candidateKeys.has(targetKey)) nonterminalRetryKeys.add(targetKey);
+					if (retry.status === "retry_pending") pendingRetryCount++;
+					if (retry.status === "retry_executing" && !inFlightRetryTargetKeys.has(targetKey)) {
+						inFlightRetryTargetKeys.add(targetKey);
+						if (
+							inFlightRetries.length < PREVIEW_SAFETY_INSPECTION_LIMIT ||
+							candidateKeys.has(targetKey)
+						) {
+							inFlightRetries.push({
+								id: retry.id,
+								key: targetKey,
+								value: retry,
+								reviewedAt: retry.reviewedAt,
+								createdAt: retry.createdAt,
+							});
+						}
+					}
+				},
+			),
+			visitApprovalSelectionPages(
+				deps,
+				{
+					configId: config.id,
+					config: { userId },
+					OR: [
+						{ status: { in: ["pending", "approved", "executing"] } },
+						...(remembersForever
+							? [{ status: "rejected" }]
+							: maxRememberedDays > 0
+								? [
+										{
+											status: "rejected",
+											reviewedAt: {
+												gt: new Date(now.getTime() - maxRememberedDays * 24 * 60 * 60 * 1000),
+											},
+										},
+									]
+								: []),
+					],
+				},
+				(row) => {
+					const targetKey = cleanupApprovalTargetKey(row);
+					if (!candidateKeys.has(targetKey)) return;
+					const rows = approvalDedupRowsByTarget.get(targetKey);
+					if (rows) rows.push(row);
+					else approvalDedupRowsByTarget.set(targetKey, [row]);
+				},
+			),
+		]);
+	} catch (error) {
+		deps.log.error(
+			{ err: error, configId: config.id },
+			"Cleanup could not load durable approval selection state",
+		);
+		return unavailableApprovalSelectionState(flagged, limit, unavailableWarning);
 	}
 
-	const selected: FlaggedItem[] = [];
-	const skippedDetails: CleanupRunResult["details"] = [];
+	const approvalExclusions = new Map<string, string>();
 	for (const item of flagged) {
-		if (selected.length >= limit) break;
 		const memWindow = memoryByRuleId.get(item.match.ruleId) ?? { mode: "off" as const };
 		const targetRows =
 			approvalDedupRowsByTarget.get(cleanupDeleteTargetKey(flaggedDeleteTarget(item))) ?? [];
 		const existing = targetRows.find((row) => {
-			if (row.status === "pending") return true;
+			if (["pending", "approved", "executing"].includes(row.status)) return true;
 			if (row.status !== "rejected") return false;
 			if (memWindow.mode === "forever") return true;
 			if (memWindow.mode === "days" && row.reviewedAt) {
@@ -5907,14 +6062,51 @@ export async function selectApprovalCandidatesBeforeLimit(
 			return false;
 		});
 		if (existing) {
-			skippedDetails.push(
-				buildDetail(item, "skipped", buildApprovalDedupSkipReason(existing.status, memWindow)),
+			approvalExclusions.set(
+				cleanupDeleteTargetKey(flaggedDeleteTarget(item)),
+				buildApprovalDedupSkipReason(existing.status, memWindow) ??
+					"Already owned by a nonterminal approval queue item",
 			);
-			continue;
 		}
-		selected.push(item);
 	}
-	return { selected, skippedDetails };
+	const plan = planApprovalCleanupSelection<FlaggedItem, LibraryCleanupApproval>({
+		limit,
+		fresh: flagged.map((item) => ({
+			key: cleanupDeleteTargetKey(flaggedDeleteTarget(item)),
+			value: item,
+		})),
+		approvalExclusions,
+		nonterminalRetryKeys,
+		inFlightRetries,
+		retryStateLoaded: true,
+	});
+	const warnings: string[] = [];
+	if (pendingRetryCount > 0) {
+		warnings.push(
+			`${pendingRetryCount} durable cleanup ${
+				pendingRetryCount === 1 ? "retry is" : "retries are"
+			} pending outside the approval-run budget.`,
+		);
+	}
+	if (inFlightRetryTargetKeys.size > 0) {
+		warnings.push(
+			`${inFlightRetryTargetKeys.size} durable cleanup ${
+				inFlightRetryTargetKeys.size === 1 ? "retry is" : "retries are"
+			} already executing and deferred from this approval run.`,
+		);
+	}
+	return {
+		plan,
+		selected: plan.selectedFresh.map((candidate) => candidate.value),
+		skippedDetails: buildApprovalSelectionDetails(plan),
+		pendingRetryCount,
+		inFlightRetryTargetCount: inFlightRetryTargetKeys.size,
+		unmatchedInFlightRetryTargetCount: [...inFlightRetryTargetKeys].filter(
+			(targetKey) => !candidateKeys.has(targetKey),
+		).length,
+		retryStateLoaded: true,
+		warnings,
+	};
 }
 
 /**
@@ -5934,6 +6126,7 @@ async function executeWithApproval(
 	safetyPlans: Map<string, SharedMediaSafetyPlan> = new Map(),
 	providerEvidence: SanitizedProviderEvidence = createSanitizedProviderEvidence([], []),
 	preSkippedDetails: CleanupRunResult["details"] = [],
+	additionalSkippedCount = 0,
 ): Promise<CleanupRunResult> {
 	const { prisma, log } = deps;
 	const now = new Date();
@@ -5967,8 +6160,8 @@ async function executeWithApproval(
 		try {
 			const memWindow = memoryByRuleId.get(item.match.ruleId) ?? { mode: "off" as const };
 
-			// Dedup query: always skip pending approvals; additionally skip
-			// rejected approvals when the rule's memory window says so (#474).
+			// Dedup query: always preserve active approval/execution ownership;
+			// additionally skip rejected approvals when the rule's memory window says so (#474).
 			const orClauses = buildDedupOrClauses(memWindow);
 
 			const existing = await prisma.libraryCleanupApproval.findFirst({
@@ -6058,6 +6251,7 @@ async function executeWithApproval(
 		itemsSkipped:
 			totalFlaggedBeforeLimit -
 			flagged.length +
+			additionalSkippedCount +
 			sharedPlexBlocks.size +
 			approvalDedupSkipped +
 			approvalQueueFailures,

--- a/apps/api/src/lib/library-cleanup/selection-planner.ts
+++ b/apps/api/src/lib/library-cleanup/selection-planner.ts
@@ -1,6 +1,7 @@
 export type DirectCleanupSelectionDisposition =
 	| "selected"
 	| "deferred_budget"
+	| "deferred_approval"
 	| "deferred_retry_fairness"
 	| "deferred_in_flight_target"
 	| "deferred_duplicate_target"
@@ -32,6 +33,7 @@ export interface DirectCleanupSelectionPlan<TFresh, TRetry> {
 		selectedFresh: number;
 		selectedRetries: number;
 		deferredBudget: number;
+		deferredApproval: number;
 		deferredRetryFairness: number;
 		deferredInFlightTarget: number;
 		deferredDuplicateTarget: number;
@@ -48,6 +50,15 @@ export interface DirectCleanupSelectionInput<TFresh, TRetry> {
 	pendingRetries: Array<CleanupSelectionRetry<TRetry>>;
 	inFlightRetries: Array<CleanupSelectionRetry<TRetry>>;
 	previousRunStartedAt?: Date;
+	retryStateLoaded: boolean;
+}
+
+export interface ApprovalCleanupSelectionInput<TFresh, TRetry> {
+	limit: number;
+	fresh: Array<CleanupSelectionCandidate<TFresh>>;
+	approvalExclusions: Map<string, string>;
+	nonterminalRetryKeys: Set<string>;
+	inFlightRetries: Array<CleanupSelectionRetry<TRetry>>;
 	retryStateLoaded: boolean;
 }
 
@@ -91,6 +102,7 @@ function buildCounts<TFresh, TRetry>(
 		selectedFresh: selectedFresh.length,
 		selectedRetries: selectedRetries.length,
 		deferredBudget: count("deferred_budget"),
+		deferredApproval: count("deferred_approval"),
 		deferredRetryFairness: count("deferred_retry_fairness"),
 		deferredInFlightTarget: count("deferred_in_flight_target"),
 		deferredDuplicateTarget: count("deferred_duplicate_target"),
@@ -98,6 +110,87 @@ function buildCounts<TFresh, TRetry>(
 		retryStateUnavailable: count("retry_state_unavailable"),
 		retryState,
 		total: decisions.length,
+	};
+}
+
+/**
+ * Side-effect-free approval-run selection. Existing approvals and durable
+ * retry ownership are applied before the hard run budget, so excluded targets
+ * cannot consume slots that should go to later eligible candidates.
+ */
+export function planApprovalCleanupSelection<TFresh, TRetry = never>(
+	input: ApprovalCleanupSelectionInput<TFresh, TRetry>,
+): DirectCleanupSelectionPlan<TFresh, TRetry> {
+	const limit = normalizedLimit(input.limit);
+	const decisions: Array<DirectCleanupSelectionDecision<TFresh | TRetry>> = [];
+
+	if (!input.retryStateLoaded) {
+		for (const candidate of input.fresh) {
+			decisions.push({
+				candidate,
+				disposition: "retry_state_unavailable",
+				reason: RETRY_STATE_UNAVAILABLE_REASON,
+			});
+		}
+		return {
+			selectedFresh: [],
+			selectedRetries: [],
+			decisions,
+			counts: buildCounts([], [], decisions, "unavailable"),
+		};
+	}
+
+	const inFlightByTarget = new Map<string, CleanupSelectionRetry<TRetry>>();
+	for (const retry of [...input.inFlightRetries].sort(compareRetryOrder)) {
+		if (!inFlightByTarget.has(retry.key)) inFlightByTarget.set(retry.key, retry);
+	}
+	for (const retry of inFlightByTarget.values()) {
+		decisions.push({ candidate: retry, disposition: "in_flight", reason: IN_FLIGHT_REASON });
+	}
+	const inFlightKeys = new Set(inFlightByTarget.keys());
+
+	const eligible: Array<CleanupSelectionCandidate<TFresh>> = [];
+	const eligibleKeys = new Set<string>();
+	for (const candidate of input.fresh) {
+		if (inFlightKeys.has(candidate.key)) continue;
+		const approvalReason = input.approvalExclusions.get(candidate.key);
+		if (approvalReason) {
+			decisions.push({
+				candidate,
+				disposition: "deferred_approval",
+				reason: approvalReason,
+			});
+		} else if (input.nonterminalRetryKeys.has(candidate.key)) {
+			decisions.push({
+				candidate,
+				disposition: "deferred_approval",
+				reason: "Deferred: a durable cleanup retry already exists for this target",
+			});
+		} else if (eligibleKeys.has(candidate.key)) {
+			decisions.push({
+				candidate,
+				disposition: "deferred_duplicate_target",
+				reason: DUPLICATE_TARGET_REASON,
+			});
+		} else {
+			eligibleKeys.add(candidate.key);
+			eligible.push(candidate);
+		}
+	}
+
+	const selectedFresh = eligible.slice(0, limit);
+	for (const [index, candidate] of eligible.entries()) {
+		decisions.push(
+			index < selectedFresh.length
+				? { candidate, disposition: "selected", reason: "Selected for the next approval run" }
+				: { candidate, disposition: "deferred_budget", reason: RUN_BUDGET_REASON },
+		);
+	}
+	return {
+		selectedFresh,
+		selectedRetries: [],
+		decisions,
+		counts: buildCounts(selectedFresh, [], decisions),
 	};
 }
 


### PR DESCRIPTION
## Summary

- freeze approval-mode targets before shared-media safety inspection so blocked items cannot backfill later candidates
- apply pending, rejected-memory, approved, executing, and durable-retry ownership before the hard run budget
- paginate durable state safely, coalesce in-flight targets, and keep preview, configured dry-run, and live queue selection aligned

## Safety behavior

- unavailable durable state fails closed without queueing or mutating anything
- approval and retry inventories are read completely in bounded pages
- one physical episode file is represented by one target across delete and delete-files actions
- selected safety failures remain skipped and do not pull a later item into the same run

## Review

The frozen diff received independent data-safety and regression reviews. Their combined findings were handled in one correction pass: active approved/executing ownership is preserved, state pagination no longer stops runs at 500 rows, and in-flight preview targets are counted and rendered once.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test (API 3971 passed / 52 skipped; web 807 passed; shared 121 passed)
- pnpm run lint
- pnpm run build