### PR TITLE
feat(cleanup): clarify preview selection on next

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2695,6 +2695,7 @@ describe("shared Plex deletion safety", () => {
 			],
 			warnings: [expect.stringContaining("next live direct cleanup run")],
 		});
+		expect(result.previewSelection).toBeUndefined();
 		expect(deleteMovieFile).not.toHaveBeenCalled();
 		expect(deleteMovie).not.toHaveBeenCalled();
 		expect(targetClient.movie.update).not.toHaveBeenCalled();

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2045,7 +2045,7 @@ describe("shared Plex deletion safety", () => {
 
 			expect(result).toMatchObject({
 				status: "partial",
-				itemsFlagged: 0,
+				itemsFlagged: includeFreshMatch ? 1 : 0,
 				itemsSkipped: 1,
 				previewItemCount: 1,
 			});
@@ -2700,6 +2700,67 @@ describe("shared Plex deletion safety", () => {
 		expect(targetClient.movie.update).not.toHaveBeenCalled();
 	});
 
+	it("reports complete direct preview selection counts separately from rule matches", async () => {
+		const { deps } = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			dryRunConfig(100) as never,
+		);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue(
+			Array.from({ length: 250 }, (_, index) =>
+				matchingDryRunCacheItem({
+					id: `cache-${String(index + 1).padStart(3, "0")}`,
+					arrItemId: index + 1,
+					title: `Movie ${index + 1}`,
+				}),
+			) as never,
+		);
+
+		const result = await executeCleanupPreview(deps, "user-1");
+
+		expect(result.itemsFlagged).toBe(250);
+		expect(result.selectionCountsComplete).toBe(true);
+		expect(result.previewSelection).toMatchObject({
+			selectedFresh: 100,
+			selectedRetries: 0,
+			deferredBudget: 150,
+			blocked: 0,
+			retryState: "complete",
+			total: 250,
+		});
+		expect(result.previewItemCount).toBe(250);
+	});
+
+	it("fails closed with unavailable direct preview selection counts when retry state cannot load", async () => {
+		const { deps } = makeDeps({ mediaPartCount: 1 });
+		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			dryRunConfig(100) as never,
+		);
+		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockRejectedValue(
+			new Error("retry store unavailable"),
+		);
+		vi.mocked(deps.prisma.libraryCache.findMany).mockResolvedValue(
+			Array.from({ length: 250 }, (_, index) =>
+				matchingDryRunCacheItem({
+					id: `cache-${String(index + 1).padStart(3, "0")}`,
+					arrItemId: index + 1,
+					title: `Movie ${index + 1}`,
+				}),
+			) as never,
+		);
+
+		const result = await executeCleanupPreview(deps, "user-1");
+
+		expect(result.pendingRetryCount).toBeNull();
+		expect(result.selectionCountsComplete).toBe(false);
+		expect(result.previewSelection).toMatchObject({
+			selectedFresh: 0,
+			selectedRetries: 0,
+			retryStateUnavailable: 250,
+			retryState: "unavailable",
+			total: 250,
+		});
+	});
+
 	it("does not preview a filtered Plex rule when the configured section is unavailable", async () => {
 		const fixture = makeDeps();
 		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
@@ -2824,7 +2885,7 @@ describe("shared Plex deletion safety", () => {
 		expect(result.warnings).toContainEqual(expect.stringContaining("plex data unavailable"));
 	});
 
-	it("does not count a rule match twice when a durable retry already represents its target", async () => {
+	it("counts a current rule match separately from its durable retry", async () => {
 		const { deps } = makeDeps({ mediaPartCount: 1 });
 		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
 			dryRunConfig() as never,
@@ -2856,7 +2917,7 @@ describe("shared Plex deletion safety", () => {
 
 		expect(result).toMatchObject({
 			itemsEvaluated: 1,
-			itemsFlagged: 0,
+			itemsFlagged: 1,
 			pendingRetryCount: 1,
 		});
 		expect(result.details).toHaveLength(2);
@@ -5827,7 +5888,11 @@ describe("shared Plex deletion safety", () => {
 						? await executeCleanupPreview(deps, "user-1")
 						: await executeCleanupRun(deps, "user-1");
 
-				expect(result).toMatchObject({ status: "partial", itemsFlagged: 0, itemsSkipped: 1 });
+				expect(result).toMatchObject({
+					status: "partial",
+					itemsFlagged: mode === "preview" ? 1 : 0,
+					itemsSkipped: 1,
+				});
 				expect(result.warnings).toContainEqual(
 					expect.stringContaining("whole number from 1 through 100"),
 				);

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1868,7 +1868,22 @@ export async function executeCleanupPreview(
 			status: "completed",
 			itemsEvaluated: 0,
 			itemsFlagged: 0,
+			selectionCountsComplete: true,
 			previewItemCount: 0,
+			previewSelection: {
+				selectedFresh: 0,
+				selectedRetries: 0,
+				deferredBudget: 0,
+				deferredApproval: 0,
+				deferredRetryFairness: 0,
+				deferredInFlightTarget: 0,
+				deferredDuplicateTarget: 0,
+				inFlight: 0,
+				blocked: 0,
+				retryStateUnavailable: 0,
+				retryState: "complete",
+				total: 0,
+			},
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
@@ -1880,13 +1895,29 @@ export async function executeCleanupPreview(
 
 	if (config.rules.length === 0) {
 		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
+		const retryState = retryPreview.loaded ? "complete" : "unavailable";
 		return {
 			isDryRun: true,
 			status: retryPreview.warning ? "partial" : "completed",
 			itemsEvaluated: 0,
 			itemsFlagged: 0,
-			pendingRetryCount: retryPreview.total,
+			pendingRetryCount: retryPreview.loaded ? retryPreview.total : null,
+			selectionCountsComplete: retryPreview.loaded,
 			previewItemCount: retryPreview.targetKeys.size,
+			previewSelection: {
+				selectedFresh: 0,
+				selectedRetries: 0,
+				deferredBudget: 0,
+				deferredApproval: 0,
+				deferredRetryFairness: 0,
+				deferredInFlightTarget: 0,
+				deferredDuplicateTarget: 0,
+				inFlight: 0,
+				blocked: 0,
+				retryStateUnavailable: 0,
+				retryState,
+				total: retryPreview.targetKeys.size,
+			},
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
@@ -1939,9 +1970,10 @@ export async function executeCleanupPreview(
 			sharedPlexBlocks.size,
 		);
 		const details = buildDirectSelectionDetails(directSelection, sharedPlexBlocks);
-		const selectionDeferred = directSelection.plan.decisions.filter(
-			(decision) => decision.disposition !== "selected",
-		).length;
+		const previewSelection = {
+			...directSelection.plan.counts,
+			blocked: sharedPlexBlocks.size,
+		};
 
 		log.info(
 			{
@@ -1959,13 +1991,23 @@ export async function executeCleanupPreview(
 			isDryRun: true,
 			status: allWarnings.length > 0 ? "partial" : "completed",
 			itemsEvaluated: totalEvaluated,
-			itemsFlagged: directSelection.plan.selectedFresh.length,
-			pendingRetryCount: directSelection.pendingRetryCount ?? undefined,
-			previewItemCount: directSelection.plan.counts.total,
+			itemsFlagged: flagged.length,
+			pendingRetryCount: directSelection.pendingRetryCount,
+			selectionCountsComplete: directSelection.retryStateLoaded,
+			previewItemCount: previewSelection.total,
+			previewSelection,
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
-			itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
+			itemsSkipped:
+				previewSelection.deferredBudget +
+				previewSelection.deferredApproval +
+				previewSelection.deferredRetryFairness +
+				previewSelection.deferredInFlightTarget +
+				previewSelection.deferredDuplicateTarget +
+				previewSelection.inFlight +
+				previewSelection.retryStateUnavailable +
+				previewSelection.blocked,
 			details,
 			durationMs: Date.now() - startTime,
 			prefetchHealth,
@@ -2012,13 +2054,16 @@ export async function executeCleanupPreview(
 		...buildCleanupPreviewDetails(selectedFresh, sharedPlexBlocks),
 		...approvalSelection.skippedDetails,
 	].slice(0, PREVIEW_SAFETY_INSPECTION_LIMIT);
-	const selectionDeferred =
-		approvalSelection.plan.decisions.filter((decision) => decision.disposition !== "selected")
-			.length +
-		Math.max(
-			0,
-			approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
-		);
+	const additionalInFlightTargets = Math.max(
+		0,
+		approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
+	);
+	const previewSelection = {
+		...approvalSelection.plan.counts,
+		inFlight: approvalSelection.plan.counts.inFlight + additionalInFlightTargets,
+		blocked: sharedPlexBlocks.size,
+		total: approvalSelection.plan.counts.total + additionalInFlightTargets,
+	};
 
 	const hasWarnings = allWarnings.length > 0;
 	log.info(
@@ -2037,18 +2082,23 @@ export async function executeCleanupPreview(
 		isDryRun: true,
 		status: hasWarnings ? ("partial" as const) : ("completed" as const),
 		itemsEvaluated: totalEvaluated,
-		itemsFlagged: approvalSelection.plan.selectedFresh.length,
-		pendingRetryCount: approvalSelection.pendingRetryCount ?? undefined,
-		previewItemCount:
-			approvalSelection.plan.counts.total +
-			Math.max(
-				0,
-				approvalSelection.inFlightRetryTargetCount - approvalSelection.plan.counts.inFlight,
-			),
+		itemsFlagged: flagged.length,
+		pendingRetryCount: approvalSelection.pendingRetryCount,
+		selectionCountsComplete: approvalSelection.retryStateLoaded,
+		previewItemCount: previewSelection.total,
+		previewSelection,
 		itemsRemoved: 0,
 		itemsUnmonitored: 0,
 		itemsFilesDeleted: 0,
-		itemsSkipped: selectionDeferred + sharedPlexBlocks.size,
+		itemsSkipped:
+			previewSelection.deferredBudget +
+			previewSelection.deferredApproval +
+			previewSelection.deferredRetryFairness +
+			previewSelection.deferredInFlightTarget +
+			previewSelection.deferredDuplicateTarget +
+			previewSelection.inFlight +
+			previewSelection.retryStateUnavailable +
+			previewSelection.blocked,
 		details,
 		durationMs: Date.now() - startTime,
 		prefetchHealth,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1895,7 +1895,6 @@ export async function executeCleanupPreview(
 
 	if (config.rules.length === 0) {
 		const retryPreview = await loadDurableRetryPreview(deps, userId, config.id);
-		const retryState = retryPreview.loaded ? "complete" : "unavailable";
 		return {
 			isDryRun: true,
 			status: retryPreview.warning ? "partial" : "completed",
@@ -1904,20 +1903,6 @@ export async function executeCleanupPreview(
 			pendingRetryCount: retryPreview.loaded ? retryPreview.total : null,
 			selectionCountsComplete: retryPreview.loaded,
 			previewItemCount: retryPreview.targetKeys.size,
-			previewSelection: {
-				selectedFresh: 0,
-				selectedRetries: 0,
-				deferredBudget: 0,
-				deferredApproval: 0,
-				deferredRetryFairness: 0,
-				deferredInFlightTarget: 0,
-				deferredDuplicateTarget: 0,
-				inFlight: 0,
-				blocked: 0,
-				retryStateUnavailable: 0,
-				retryState,
-				total: retryPreview.targetKeys.size,
-			},
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -234,9 +234,29 @@ export interface CleanupRunResult {
 	itemsEvaluated: number;
 	itemsFlagged: number;
 	/** Durable retries shown alongside current rule matches in preview responses. */
-	pendingRetryCount?: number;
-	/** Distinct retry and fresh-candidate targets available to an interactive preview. */
+	pendingRetryCount?: number | null;
+	/** Whether retry ownership and planner counts were loaded completely. */
+	selectionCountsComplete?: boolean;
+	/** Known retry and fresh-candidate targets available to an interactive preview. */
 	previewItemCount?: number;
+	/**
+	 * Next-run slot selection counts; blocked is an overlapping subset of
+	 * selectedFresh because safety-blocked slots are never backfilled.
+	 */
+	previewSelection?: {
+		selectedFresh: number;
+		selectedRetries: number;
+		deferredBudget: number;
+		deferredApproval: number;
+		deferredRetryFairness: number;
+		deferredInFlightTarget: number;
+		deferredDuplicateTarget: number;
+		inFlight: number;
+		blocked: number;
+		retryStateUnavailable: number;
+		retryState: "complete" | "unavailable";
+		total: number;
+	};
 	itemsRemoved: number;
 	itemsUnmonitored: number;
 	itemsFilesDeleted: number;

--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -332,6 +332,23 @@ describe("library cleanup approval compare-and-set routes", () => {
 			status: "completed",
 			itemsEvaluated: 201,
 			itemsFlagged: 201,
+			pendingRetryCount: 0,
+			selectionCountsComplete: true,
+			previewItemCount: 201,
+			previewSelection: {
+				selectedFresh: 100,
+				selectedRetries: 0,
+				deferredBudget: 101,
+				deferredApproval: 0,
+				deferredRetryFairness: 0,
+				deferredInFlightTarget: 0,
+				deferredDuplicateTarget: 0,
+				inFlight: 0,
+				blocked: 0,
+				retryStateUnavailable: 0,
+				retryState: "complete" as const,
+				total: 201,
+			},
 			itemsRemoved: 0,
 			itemsUnmonitored: 0,
 			itemsFilesDeleted: 0,
@@ -345,8 +362,16 @@ describe("library cleanup approval compare-and-set routes", () => {
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toMatchObject({
+			totalEvaluated: 201,
 			totalFlagged: 201,
-			warnings: ["Existing warning", "Showing 200 of 201 preview items"],
+			pendingRetryCount: 0,
+			selectionCountsComplete: true,
+			selection: { selectedFresh: 100, deferredBudget: 101, total: 201 },
+			display: { shown: 200, hidden: 1, limit: 200, complete: false },
+			warnings: [
+				"Existing warning",
+				"Display capped at 200 of 201 preview items; selection counts remain complete.",
+			],
 		});
 		expect(response.json().items).toHaveLength(200);
 	});
@@ -387,6 +412,8 @@ describe("library cleanup approval compare-and-set routes", () => {
 		expect(response.json()).toMatchObject({
 			totalFlagged: 0,
 			pendingRetryCount: 1,
+			selectionCountsComplete: true,
+			display: { shown: 1, hidden: 0, limit: 200, complete: true },
 			warnings: [],
 		});
 		expect(response.json().items).toHaveLength(1);
@@ -426,7 +453,9 @@ describe("library cleanup approval compare-and-set routes", () => {
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toMatchObject({
 			pendingRetryCount: 0,
-			warnings: ["Showing 200 of 201 preview items"],
+			selectionCountsComplete: true,
+			display: { shown: 200, hidden: 1, limit: 200, complete: false },
+			warnings: ["Display capped at 200 of 201 preview items; selection counts remain complete."],
 		});
 		expect(response.json().items).toHaveLength(200);
 	});

--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -419,6 +419,67 @@ describe("library cleanup approval compare-and-set routes", () => {
 		expect(response.json().items).toHaveLength(1);
 	});
 
+	it("uses legacy preview counts when the executor omits selection metadata", async () => {
+		executorMocks.executeCleanupPreview.mockResolvedValueOnce({
+			isDryRun: true,
+			status: "completed",
+			itemsEvaluated: 2,
+			itemsFlagged: 2,
+			itemsRemoved: 0,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 0,
+			details: [],
+			durationMs: 1,
+		});
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/preview");
+		expect(response.json()).toMatchObject({
+			pendingRetryCount: 0,
+			selectionCountsComplete: true,
+			display: { shown: 0, hidden: 2, limit: 200, complete: false },
+		});
+		expect(response.json().selection).toBeUndefined();
+	});
+
+	it("preserves unavailable retry count with incomplete capped preview warning", async () => {
+		const details = Array.from({ length: 200 }, (_, index) => ({
+			instanceId: "radarr-1",
+			arrItemId: index + 1,
+			itemType: "movie",
+			title: `Movie ${index + 1}`,
+			rule: "Cleanup",
+			reason: "Deferred",
+			action: "skipped" as const,
+			sizeOnDisk: "1000",
+			year: 2024,
+			rating: 8,
+		}));
+		executorMocks.executeCleanupPreview.mockResolvedValueOnce({
+			isDryRun: true,
+			status: "partial",
+			itemsEvaluated: 201,
+			itemsFlagged: 201,
+			pendingRetryCount: null,
+			selectionCountsComplete: false,
+			previewItemCount: 201,
+			itemsRemoved: 0,
+			itemsUnmonitored: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 201,
+			details,
+			durationMs: 1,
+		});
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/preview");
+		expect(response.json()).toMatchObject({
+			pendingRetryCount: null,
+			selectionCountsComplete: false,
+			display: { shown: 200, hidden: 1, limit: 200, complete: false },
+			warnings: [
+				"Display capped at 200 of 201 known preview items; retry-backed selection counts are incomplete because durable retry state could not be loaded.",
+			],
+		});
+	});
+
 	it("warns when executing retries exceed the rendered preview cap", async () => {
 		const details = Array.from({ length: 200 }, (_, index) => ({
 			instanceId: "radarr-1",

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -813,11 +813,17 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				}
 
 				const MAX_PREVIEW_ITEMS = 200;
+				const selectionCountsComplete =
+					result.selectionCountsComplete ?? result.previewSelection?.retryState !== "unavailable";
 				const totalPreviewItems =
 					result.previewItemCount ??
-					Math.max(result.itemsFlagged + (result.pendingRetryCount ?? 0), result.details.length);
+					Math.max(
+						result.itemsFlagged +
+							(typeof result.pendingRetryCount === "number" ? result.pendingRetryCount : 0),
+						result.details.length,
+					);
 				const previewDetails = result.details.slice(0, MAX_PREVIEW_ITEMS);
-				const truncated = totalPreviewItems > previewDetails.length;
+				const hiddenPreviewItems = Math.max(0, totalPreviewItems - previewDetails.length);
 
 				// qui-derived safety hint (Phase 3.3). Single bulk query joins
 				// LibraryCache for every previewed item so operators see
@@ -901,7 +907,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				return reply.send({
 					totalEvaluated: result.itemsEvaluated,
 					totalFlagged: result.itemsFlagged,
-					pendingRetryCount: result.pendingRetryCount ?? 0,
+					pendingRetryCount: result.pendingRetryCount === undefined ? 0 : result.pendingRetryCount,
+					selectionCountsComplete,
+					selection: result.previewSelection,
+					display: {
+						shown: previewDetails.length,
+						hidden: hiddenPreviewItems,
+						limit: MAX_PREVIEW_ITEMS,
+						complete: hiddenPreviewItems === 0,
+					},
 					items: previewDetails.map((d) => {
 						const itemType = d.itemType ?? "movie";
 						const key =
@@ -932,8 +946,12 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 					prefetchHealth: result.prefetchHealth,
 					warnings: [
 						...(result.warnings ?? []),
-						...(truncated
-							? [`Showing ${previewDetails.length} of ${totalPreviewItems} preview items`]
+						...(hiddenPreviewItems > 0
+							? [
+									selectionCountsComplete
+										? `Display capped at ${previewDetails.length} of ${totalPreviewItems} preview items; selection counts remain complete.`
+										: `Display capped at ${previewDetails.length} of ${totalPreviewItems} known preview items; retry-backed selection counts are incomplete because durable retry state could not be loaded.`,
+								]
 							: []),
 					],
 				});

--- a/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
@@ -822,7 +822,80 @@ describe("LibraryCleanupClient", () => {
 			render(<LibraryCleanupClient />, { wrapper: createWrapper() });
 
 			expect(
-				screen.getByText("Preview Results (0 of 0 items flagged · 1 retry pending)"),
+				screen.getByText("Preview Results (0 of 0 rule matches · 1 retry pending)"),
+			).toBeInTheDocument();
+		});
+
+		it("explains complete and unavailable next-run selection counts", () => {
+			mockUseCleanupPreview.mockReturnValue(
+				defaultMutation({
+					data: {
+						totalEvaluated: 5,
+						totalFlagged: 2,
+						pendingRetryCount: 1,
+						selectionCountsComplete: true,
+						selection: {
+							selectedFresh: 1,
+							selectedRetries: 1,
+							deferredBudget: 3,
+							deferredApproval: 0,
+							deferredRetryFairness: 0,
+							deferredInFlightTarget: 0,
+							deferredDuplicateTarget: 0,
+							inFlight: 0,
+							blocked: 1,
+							retryStateUnavailable: 0,
+							retryState: "complete",
+							total: 5,
+						},
+						items: [],
+					},
+				}),
+			);
+			render(<LibraryCleanupClient />, { wrapper: createWrapper() });
+			expect(
+				screen.getByText("Preview Results (2 of 5 rule matches · 1 retry pending)"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/Next run reserves 1 fresh slot \+ 1 retry attempt\. 3 deferred\./),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/Selected fresh slots include 1 currently safety-blocked item\./),
+			).toBeInTheDocument();
+		});
+
+		it("fails closed when durable retry state is unavailable", () => {
+			mockUseCleanupPreview.mockReturnValue(
+				defaultMutation({
+					data: {
+						totalEvaluated: 5,
+						totalFlagged: 2,
+						pendingRetryCount: null,
+						selectionCountsComplete: false,
+						selection: {
+							selectedFresh: 0,
+							selectedRetries: 0,
+							deferredBudget: 0,
+							deferredApproval: 0,
+							deferredRetryFairness: 0,
+							deferredInFlightTarget: 0,
+							deferredDuplicateTarget: 0,
+							inFlight: 0,
+							blocked: 0,
+							retryStateUnavailable: 2,
+							retryState: "unavailable",
+							total: 2,
+						},
+						items: [],
+					},
+				}),
+			);
+			render(<LibraryCleanupClient />, { wrapper: createWrapper() });
+			expect(
+				screen.getByText("Preview Results (2 of 5 rule matches · retry count unavailable)"),
+			).toBeInTheDocument();
+			expect(
+				screen.getByText(/Next run cannot be determined: durable retry state is unavailable\./),
 			).toBeInTheDocument();
 		});
 

--- a/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
@@ -824,9 +824,10 @@ describe("LibraryCleanupClient", () => {
 			expect(
 				screen.getByText("Preview Results (0 of 0 rule matches · 1 retry pending)"),
 			).toBeInTheDocument();
+			expect(screen.queryByText(/Next run reserves/)).not.toBeInTheDocument();
 		});
 
-		it("explains complete and unavailable next-run selection counts", () => {
+		it("explains complete next-run selection counts and in-flight retries separately", () => {
 			mockUseCleanupPreview.mockReturnValue(
 				defaultMutation({
 					data: {
@@ -842,7 +843,7 @@ describe("LibraryCleanupClient", () => {
 							deferredRetryFairness: 0,
 							deferredInFlightTarget: 0,
 							deferredDuplicateTarget: 0,
-							inFlight: 0,
+							inFlight: 2,
 							blocked: 1,
 							retryStateUnavailable: 0,
 							retryState: "complete",
@@ -857,7 +858,9 @@ describe("LibraryCleanupClient", () => {
 				screen.getByText("Preview Results (2 of 5 rule matches · 1 retry pending)"),
 			).toBeInTheDocument();
 			expect(
-				screen.getByText(/Next run reserves 1 fresh slot \+ 1 retry attempt\. 3 deferred\./),
+				screen.getByText(
+					/Next run reserves 1 fresh slot \+ 1 retry attempt\. 3 deferred\. 2 currently in flight\./,
+				),
 			).toBeInTheDocument();
 			expect(
 				screen.getByText(/Selected fresh slots include 1 currently safety-blocked item\./),

--- a/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
+++ b/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
@@ -646,15 +646,43 @@ function ConfigTab({
 					/>
 					<div className="relative p-5">
 						<h4 className="text-h4 mb-3">
-							Preview Results ({previewData.totalFlagged} of {previewData.totalEvaluated} items
-							flagged
-							{previewData.pendingRetryCount
-								? ` · ${previewData.pendingRetryCount} ${
-										previewData.pendingRetryCount === 1 ? "retry" : "retries"
-									} pending`
-								: ""}
+							Preview Results ({previewData.totalFlagged} of {previewData.totalEvaluated} rule
+							matches
+							{previewData.pendingRetryCount === null
+								? " · retry count unavailable"
+								: previewData.pendingRetryCount
+									? ` · ${previewData.pendingRetryCount} ${
+											previewData.pendingRetryCount === 1 ? "retry" : "retries"
+										} pending`
+									: ""}
 							)
 						</h4>
+						{previewData.selectionCountsComplete === false ||
+						previewData.selection?.retryState === "unavailable" ? (
+							<p className="mb-3 text-sm text-muted-foreground">
+								Next run cannot be determined: durable retry state is unavailable.
+							</p>
+						) : previewData.selection ? (
+							<p className="mb-3 text-sm text-muted-foreground">
+								Next run reserves {previewData.selection.selectedFresh} fresh{" "}
+								{previewData.selection.selectedFresh === 1 ? "slot" : "slots"}
+								{previewData.selection.selectedRetries > 0
+									? ` + ${previewData.selection.selectedRetries} retry ${previewData.selection.selectedRetries === 1 ? "attempt" : "attempts"}`
+									: ""}
+								.{" "}
+								{previewData.selection.deferredBudget +
+									previewData.selection.deferredApproval +
+									previewData.selection.deferredRetryFairness +
+									(previewData.selection.deferredInFlightTarget ?? 0) +
+									(previewData.selection.deferredDuplicateTarget ?? 0) +
+									previewData.selection.inFlight +
+									previewData.selection.retryStateUnavailable}{" "}
+								deferred.
+								{previewData.selection.blocked > 0
+									? ` Selected fresh slots include ${previewData.selection.blocked} currently safety-blocked ${previewData.selection.blocked === 1 ? "item" : "items"}.`
+									: ""}
+							</p>
+						) : null}
 						{previewData.prefetchHealth &&
 							Object.entries(previewData.prefetchHealth).some(([, s]) => s === "failed") && (
 								<div className="mb-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-400">

--- a/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
+++ b/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
@@ -675,9 +675,11 @@ function ConfigTab({
 									previewData.selection.deferredRetryFairness +
 									(previewData.selection.deferredInFlightTarget ?? 0) +
 									(previewData.selection.deferredDuplicateTarget ?? 0) +
-									previewData.selection.inFlight +
 									previewData.selection.retryStateUnavailable}{" "}
 								deferred.
+								{previewData.selection.inFlight > 0
+									? ` ${previewData.selection.inFlight} currently in flight.`
+									: ""}
 								{previewData.selection.blocked > 0
 									? ` Selected fresh slots include ${previewData.selection.blocked} currently safety-blocked ${previewData.selection.blocked === 1 ? "item" : "items"}.`
 									: ""}

--- a/packages/shared/src/types/library-cleanup.ts
+++ b/packages/shared/src/types/library-cleanup.ts
@@ -388,9 +388,26 @@ export interface CleanupPreviewItem {
 export interface CleanupPreviewResponse {
 	totalEvaluated: number;
 	totalFlagged: number;
-	/** Durable mutation retries displayed separately from current rule matches. */
-	pendingRetryCount?: number;
+	/** Null means durable retry storage was unavailable and the count is unknown. */
+	pendingRetryCount?: number | null;
+	/** True only when durable retry ownership and all selection counts are trustworthy. */
+	selectionCountsComplete: boolean;
 	items: CleanupPreviewItem[];
+	selection?: {
+		selectedFresh: number;
+		selectedRetries: number;
+		deferredBudget: number;
+		deferredApproval: number;
+		deferredRetryFairness: number;
+		deferredInFlightTarget?: number;
+		deferredDuplicateTarget?: number;
+		inFlight: number;
+		blocked: number;
+		retryStateUnavailable: number;
+		retryState?: "complete" | "unavailable";
+		total: number;
+	};
+	display?: { shown: number; hidden: number; limit: number; complete: boolean };
 	prefetchHealth?: PrefetchHealthStatus;
 	warnings?: string[];
 	providerEvidence?: CleanupProviderEvidence;

--- a/packages/shared/src/types/library-cleanup.ts
+++ b/packages/shared/src/types/library-cleanup.ts
@@ -399,12 +399,12 @@ export interface CleanupPreviewResponse {
 		deferredBudget: number;
 		deferredApproval: number;
 		deferredRetryFairness: number;
-		deferredInFlightTarget?: number;
-		deferredDuplicateTarget?: number;
+		deferredInFlightTarget: number;
+		deferredDuplicateTarget: number;
 		inFlight: number;
 		blocked: number;
 		retryStateUnavailable: number;
-		retryState?: "complete" | "unavailable";
+		retryState: "complete" | "unavailable";
 		total: number;
 	};
 	display?: { shown: number; hidden: number; limit: number; complete: boolean };


### PR DESCRIPTION
## Summary

- distinguish all rule matches from the frozen next-run selection
- expose complete selected, deferred, blocked, in-flight, retry, and display-cap metadata
- preserve unknown retry state as `null` and keep legacy response fallbacks
- clarify the cleanup preview copy without changing planner or mutation behavior

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck` after the CI-equivalent Prisma generation prerequisite
- `pnpm run test` — API 3,975 passed / 52 skipped; web 809 passed; shared 121 passed
- `pnpm run lint`
- `pnpm run build`
- isolated loopback browser verification of rule-match, selected/deferred, in-flight, and safety-blocked wording with zero console errors

## Review

- independent regression and data-safety review used one frozen inventory
- one scoped correction pass addressed all recorded findings
- scoped re-review is clean

This is an additive preview-reporting forward-port for `next`. It does not change cleanup planning, run budgets, database schema, qUI authority, or upstream mutations.