### PR TITLE
fix(cleanup): revalidate series and movie mutation policy

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -1,0 +1,559 @@
+import { describe, expect, it, vi } from "vitest";
+import { evaluateItemMutationPolicyStateViaEngine } from "../../rules/cleanup-adapter.js";
+import { deriveArrPolicyEvidence } from "../arr-policy-evidence.js";
+import { executeDirectRemoval } from "../cleanup-executor.js";
+import { createArrServiceFingerprint } from "../shared-plex-safety.js";
+import type { CleanupExecutorDeps } from "../types.js";
+
+type Service = "RADARR" | "SONARR";
+
+function cleanupRule(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "rule-age",
+		configId: "config-1",
+		name: "Old items",
+		enabled: true,
+		priority: 10,
+		ruleType: "age",
+		parameters: JSON.stringify({ field: "arrAddedAt", operator: "older_than", days: 30 }),
+		operator: null,
+		conditions: null,
+		serviceFilter: null,
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		action: "unmonitor",
+		retentionMode: false,
+		useGlobalRejectionMemory: true,
+		rejectionMemoryDays: 0,
+		createdAt: new Date("2026-08-01T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+		...overrides,
+	};
+}
+
+function cleanupConfig(rules = [cleanupRule()], overrides: Record<string, unknown> = {}) {
+	return {
+		id: "config-1",
+		userId: "user-1",
+		enabled: true,
+		intervalHours: 24,
+		lastRunAt: new Date("2026-08-01T00:00:00.000Z"),
+		nextRunAt: new Date("2026-08-02T00:00:00.000Z"),
+		dryRunMode: false,
+		maxRemovalsPerRun: 10,
+		requireApproval: false,
+		runClaimToken: "run-1",
+		runClaimedAt: new Date("2026-08-01T00:00:00.000Z"),
+		respectQuiSeeding: false,
+		rejectionMemoryDays: 0,
+		createdAt: new Date("2026-08-01T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+		rules,
+		...overrides,
+	};
+}
+
+function makeFixture(
+	service: Service,
+	action: "delete" | "unmonitor" = "unmonitor",
+	ruleOverrides: Record<string, unknown> = {},
+) {
+	const instance = {
+		id: `${service.toLowerCase()}-1`,
+		userId: "user-1",
+		service,
+		label: service === "RADARR" ? "Radarr" : "Sonarr",
+		baseUrl: `http://${service.toLowerCase()}.test`,
+		encryptedApiKey: "encrypted",
+		encryptionIv: "iv",
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
+		enabled: true,
+		createdAt: new Date("2026-08-01T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-01T00:00:00.000Z"),
+	};
+	const rule = cleanupRule({ action, ...ruleOverrides });
+	const config = cleanupConfig([rule]);
+	let liveConfig = config;
+	let currentInstance = instance;
+	let hasFile = action === "delete";
+	let recordExists = true;
+	const movie = {
+		id: 101,
+		tmdbId: 42,
+		title: "Example Movie",
+		path: "/movies/Example Movie",
+		monitored: true,
+		qualityProfileId: 1,
+		hasFile,
+		sizeOnDisk: 2_000,
+		movieFileId: 1001 as number | undefined,
+		movieFile: { id: 1001, path: "/movies/Example Movie/example.mkv", size: 2_000 } as
+			| { id: number; path: string; size: number }
+			| undefined,
+		added: "2020-01-01T00:00:00.000Z",
+		statistics: { movieFileCount: 1, sizeOnDisk: 2_000 },
+	};
+	const series = {
+		id: 101,
+		tvdbId: 42,
+		title: "Example Series",
+		path: "/series/Example Series",
+		monitored: true,
+		qualityProfileId: 1,
+		added: "2020-01-01T00:00:00.000Z",
+	};
+	const markMovieFileDeleted = () => {
+		hasFile = false;
+		movie.hasFile = false;
+		movie.sizeOnDisk = 0;
+		movie.movieFileId = undefined;
+		movie.movieFile = undefined;
+		movie.statistics = { movieFileCount: 0, sizeOnDisk: 0 };
+	};
+	const deleteMovieFile = vi.fn(async () => {
+		markMovieFileDeleted();
+	});
+	const deleteMovie = vi.fn(async () => {
+		recordExists = false;
+	});
+	const updateMovie = vi.fn();
+	const updateSeries = vi.fn();
+	const radarrClient = {
+		movie: {
+			getById: vi.fn(async () => {
+				if (!recordExists) throw new Error("not found");
+				return movie;
+			}),
+			delete: deleteMovie,
+			update: updateMovie,
+		},
+		movieFile: { getById: vi.fn(async () => movie.movieFile), delete: deleteMovieFile },
+		qualityProfile: { getById: vi.fn(async () => ({ id: 1, name: "Default" })) },
+		notification: { getAll: vi.fn().mockResolvedValue([]) },
+	};
+	const sonarrClient = {
+		series: {
+			getById: vi.fn(async () => series),
+			getAll: vi.fn(async () => [series]),
+			update: updateSeries,
+			delete: vi.fn(),
+		},
+		episode: { getAll: vi.fn(), setMonitored: vi.fn() },
+		episodeFile: { getBySeries: vi.fn(), bulkDelete: vi.fn() },
+		qualityProfile: { getById: vi.fn(async () => ({ id: 1, name: "Default" })) },
+		notification: { getAll: vi.fn().mockResolvedValue([]) },
+	};
+	const sourceFingerprint = createArrServiceFingerprint(instance as never);
+	const cacheItem = {
+		id: "cache-1",
+		instanceId: instance.id,
+		arrItemId: 101,
+		itemType: service === "RADARR" ? "movie" : "series",
+		title: service === "RADARR" ? movie.title : series.title,
+		year: 2020,
+		monitored: true,
+		hasFile: action === "delete",
+		status: "released",
+		qualityProfileId: 1,
+		qualityProfileName: "Default",
+		sizeOnDisk: 2_000n,
+		arrAddedAt: new Date("2020-01-01T00:00:00.000Z"),
+		cachedAt: new Date("2026-08-02T00:00:00.000Z"),
+		data: JSON.stringify({
+			_arrDashboardSource: { serviceFingerprint: sourceFingerprint },
+			path: service === "RADARR" ? movie.path : series.path,
+			remoteIds: service === "RADARR" ? { tmdbId: 42 } : { tvdbId: 42 },
+			...(service === "RADARR" ? { movieFile: movie.movieFile, hasFile: action === "delete" } : {}),
+		}),
+	};
+	const deps = {
+		prisma: {
+			libraryCleanupConfig: { findUnique: vi.fn(async () => liveConfig) },
+			serviceInstance: {
+				findFirst: vi.fn(async () => currentInstance),
+				findMany: vi.fn(async () => [instance]),
+			},
+			libraryCleanupLog: { findFirst: vi.fn().mockResolvedValue(null), create: vi.fn() },
+			libraryCleanupApproval: {
+				findMany: vi.fn().mockResolvedValue([]),
+				create: vi.fn().mockResolvedValue({}),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+			libraryCache: {
+				findFirst: vi.fn().mockResolvedValue(cacheItem),
+				deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+			},
+			crossDomainRule: { findMany: vi.fn().mockResolvedValue([]) },
+		} as unknown as CleanupExecutorDeps["prisma"],
+		arrClientFactory: {
+			create: vi.fn(() => (service === "RADARR" ? radarrClient : sonarrClient)),
+		} as unknown as CleanupExecutorDeps["arrClientFactory"],
+		log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as unknown as CleanupExecutorDeps["log"],
+	} satisfies CleanupExecutorDeps;
+	const flagged = {
+		cacheItem,
+		match: { ruleId: rule.id, ruleName: rule.name, reason: "Matched", action },
+		rating: null,
+	};
+
+	return {
+		deps,
+		instance,
+		config,
+		flagged,
+		movie,
+		series,
+		deleteMovieFile,
+		deleteMovie,
+		updateMovie,
+		updateSeries,
+		radarrQualityProfileGetById: radarrClient.qualityProfile.getById,
+		sonarrQualityProfileGetById: sonarrClient.qualityProfile.getById,
+		radarrGetById: radarrClient.movie.getById,
+		sonarrGetById: sonarrClient.series.getById,
+		markMovieFileDeleted,
+		setCurrentInstance: (next: typeof instance) => {
+			currentInstance = next;
+		},
+		setLiveConfig: (next: typeof config) => {
+			liveConfig = next;
+		},
+	};
+}
+
+async function runDirect(fixture: ReturnType<typeof makeFixture>) {
+	return await executeDirectRemoval(
+		fixture.deps,
+		fixture.config as never,
+		"user-1",
+		[fixture.flagged] as never,
+		1,
+		1,
+		Date.now(),
+	);
+}
+
+describe("execution-time cleanup policy authority", () => {
+	it.each([
+		["configuration", "RADARR", cleanupConfig([cleanupRule()], { enabled: false })],
+		["configuration", "SONARR", cleanupConfig([cleanupRule()], { enabled: false })],
+		["rule", "RADARR", cleanupConfig([cleanupRule({ action: "delete" })])],
+		["rule", "SONARR", cleanupConfig([cleanupRule({ action: "delete" })])],
+	] as const)(
+		"blocks a changed cleanup %s fingerprint before %s unmonitoring",
+		async (_change, service, changedConfig) => {
+			const fixture = makeFixture(service);
+			fixture.setLiveConfig(changedConfig);
+
+			const result = await runDirect(fixture);
+
+			expect(result.itemsUnmonitored).toBe(0);
+			expect(
+				service === "RADARR" ? fixture.updateMovie : fixture.updateSeries,
+			).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"rechecks the %s instance fingerprint after the final live policy read",
+		async (service) => {
+			const fixture = makeFixture(service);
+			const repoint = () =>
+				fixture.setCurrentInstance({
+					...fixture.instance,
+					baseUrl: `http://replacement-${service.toLowerCase()}.test`,
+					updatedAt: new Date("2026-08-14T00:00:00.000Z"),
+				});
+			if (service === "RADARR") {
+				const originalGetById = fixture.radarrGetById.getMockImplementation();
+				if (!originalGetById) throw new Error("Expected a live Radarr lookup implementation");
+				fixture.radarrGetById.mockImplementation(async () => {
+					const result = await originalGetById();
+					if (fixture.radarrGetById.mock.calls.length >= 2) repoint();
+					return result;
+				});
+			} else {
+				const originalGetById = fixture.sonarrGetById.getMockImplementation();
+				if (!originalGetById) throw new Error("Expected a live Sonarr lookup implementation");
+				fixture.sonarrGetById.mockImplementation(async () => {
+					const result = await originalGetById();
+					if (fixture.sonarrGetById.mock.calls.length >= 2) repoint();
+					return result;
+				});
+			}
+
+			const result = await runDirect(fixture);
+
+			expect(result.itemsUnmonitored).toBe(0);
+			expect(
+				service === "RADARR" ? fixture.updateMovie : fixture.updateSeries,
+			).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"re-evaluates live ARR state against the matched rule before %s unmonitoring",
+		async (service) => {
+			const fixture = makeFixture(service);
+			if (service === "RADARR") fixture.movie.added = "2026-08-14T00:00:00.000Z";
+			else fixture.series.added = "2026-08-14T00:00:00.000Z";
+
+			const result = await runDirect(fixture);
+
+			expect(result.itemsUnmonitored).toBe(0);
+			expect(
+				service === "RADARR" ? fixture.updateMovie : fixture.updateSeries,
+			).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"updates %s from the exact full resource accepted by final policy authorization",
+		async (service) => {
+			const fixture = makeFixture(service);
+			let latestPolicyRevision = 0;
+			let updateUsedLatestPolicyRevision = false;
+			const getById = service === "RADARR" ? fixture.radarrGetById : fixture.sonarrGetById;
+			const source = service === "RADARR" ? fixture.movie : fixture.series;
+			getById.mockImplementation(async () => {
+				latestPolicyRevision += 1;
+				return { ...source, policyRevision: latestPolicyRevision } as never;
+			});
+			const update = service === "RADARR" ? fixture.updateMovie : fixture.updateSeries;
+			update.mockImplementation(async (_id, payload) => {
+				updateUsedLatestPolicyRevision =
+					(payload as { policyRevision?: number }).policyRevision === latestPolicyRevision;
+			});
+
+			const result = await runDirect(fixture);
+
+			expect(result.itemsUnmonitored).toBe(1);
+			expect(update).toHaveBeenCalledOnce();
+			expect(updateUsedLatestPolicyRevision).toBe(true);
+		},
+	);
+
+	it.each(["RADARR", "SONARR"] as const)(
+		"resolves the live %s quality profile before applying a quality-profile policy",
+		async (service) => {
+			const fixture = makeFixture(service, "unmonitor", {
+				id: "rule-quality-profile",
+				name: "Default profile",
+				ruleType: "quality_profile",
+				parameters: JSON.stringify({ operator: "is", profileNames: ["Default"] }),
+			});
+
+			const result = await runDirect(fixture);
+
+			expect(result.itemsUnmonitored).toBe(1);
+			expect(
+				service === "RADARR"
+					? fixture.radarrQualityProfileGetById
+					: fixture.sonarrQualityProfileGetById,
+			).toHaveBeenCalledWith(1);
+			expect(
+				service === "RADARR" ? fixture.updateMovie : fixture.updateSeries,
+			).toHaveBeenCalledOnce();
+		},
+	);
+
+	it.each([
+		["bookkeeping", false],
+		["policy", true],
+	] as const)(
+		"permits only unrelated state changes between Radarr file and record writes (%s)",
+		async (_kind, shouldBlockRecordDelete) => {
+			const fixture = makeFixture("RADARR", "delete");
+			fixture.deleteMovieFile.mockImplementationOnce(async () => {
+				fixture.markMovieFileDeleted();
+				fixture.setLiveConfig(
+					shouldBlockRecordDelete
+						? cleanupConfig([cleanupRule({ action: "delete" })], { maxRemovalsPerRun: 1 })
+						: cleanupConfig([cleanupRule({ action: "delete" })], {
+								lastRunAt: new Date("2026-08-03T00:00:00.000Z"),
+								nextRunAt: new Date("2026-08-04T00:00:00.000Z"),
+								runClaimToken: null,
+								runClaimedAt: null,
+							}),
+				);
+			});
+
+			const result = await runDirect(fixture);
+
+			expect(fixture.deleteMovieFile).toHaveBeenCalledOnce();
+			if (shouldBlockRecordDelete) {
+				expect(result.itemsRemoved).toBe(0);
+				expect(fixture.deleteMovie).not.toHaveBeenCalled();
+			} else {
+				expect(result.itemsRemoved).toBe(1);
+				expect(fixture.deleteMovie).toHaveBeenCalledOnce();
+			}
+		},
+	);
+});
+
+function mutationEvidenceRule(
+	ruleType: string,
+	parameters: Record<string, unknown>,
+	overrides: Record<string, unknown> = {},
+) {
+	return cleanupRule({
+		id: `rule-${ruleType}`,
+		ruleType,
+		parameters: JSON.stringify(parameters),
+		action: "delete",
+		...overrides,
+	});
+}
+
+function mutationEvidenceItem(data: Record<string, unknown>) {
+	return {
+		id: "live:radarr-1:movie:101",
+		instanceId: "radarr-1",
+		arrItemId: 101,
+		itemType: "movie",
+		title: "Example Movie",
+		year: 2020,
+		monitored: true,
+		hasFile: true,
+		status: "released",
+		qualityProfileId: 1,
+		qualityProfileName: "Default",
+		sizeOnDisk: 2_000n,
+		arrAddedAt: new Date("2020-01-01T00:00:00.000Z"),
+		cachedAt: new Date(),
+		data: JSON.stringify({ remoteIds: { tmdbId: 42 }, ...data }),
+		infoHash: null,
+		torrentState: null,
+	} as const;
+}
+
+describe("mutation policy evidence authority", () => {
+	it.each([
+		["missing source", { ratings: {} }],
+		["zero sentinel", { ratings: { tmdb: { value: 0 }, imdb: { value: 0 } } }],
+	] as const)("does not treat Radarr %s ratings as authoritative", (_label, raw) => {
+		const evidence = deriveArrPolicyEvidence("radarr", raw as Record<string, unknown>);
+
+		expect(evidence.rating).toBe(false);
+		expect(evidence.imdbRating).toBe(false);
+	});
+
+	it("accepts explicit positive Radarr ratings", () => {
+		const evidence = deriveArrPolicyEvidence("radarr", {
+			ratings: { tmdb: { value: 7.5 }, imdb: { value: 8.1 } },
+		});
+
+		expect(evidence.rating).toBe(true);
+		expect(evidence.imdbRating).toBe(true);
+	});
+
+	it.each(["tmdb_list_member", "trakt_list_member"])(
+		"fails closed for %s without a complete fresh list snapshot",
+		(ruleType) => {
+			const identifierKey = ruleType === "tmdb_list_member" ? "listId" : "listSlug";
+			const context =
+				ruleType === "tmdb_list_member"
+					? { now: new Date(), tmdbListMemberships: new Map<string, Set<number>>() }
+					: { now: new Date(), traktListMemberships: new Map<string, Set<number>>() };
+			const result = evaluateItemMutationPolicyStateViaEngine(
+				mutationEvidenceItem({ _arrDashboardEvidence: {} }) as never,
+				[
+					mutationEvidenceRule(ruleType, {
+						operator: "not_in",
+						[identifierKey]: "example-list",
+					}),
+				] as never,
+				"RADARR",
+				context,
+			);
+
+			expect(result).toEqual({ kind: "unknown", ruleId: `rule-${ruleType}` });
+		},
+	);
+
+	it("authorizes hdr_type only when the dynamic-range field was explicit", () => {
+		const rule = mutationEvidenceRule("hdr_type", { operator: "is", types: ["HDR10"] });
+		const explicit = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem({
+				movieFile: { videoDynamicRange: "HDR10" },
+				_arrDashboardEvidence: { hasFile: true, hdrType: true },
+			}) as never,
+			[rule] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+		const omitted = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem({
+				movieFile: { videoDynamicRange: "HDR10" },
+				_arrDashboardEvidence: { hasFile: true, hdrType: false },
+			}) as never,
+			[rule] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+
+		expect(explicit).toMatchObject({ kind: "cleanup" });
+		expect(omitted).toEqual({ kind: "unknown", ruleId: "rule-hdr_type" });
+	});
+
+	it.each([
+		["video_codec", { operator: "is", codecs: ["x265"] }],
+		["audio_codec", { operator: "is", codecs: ["AAC"] }],
+		["audio_channels", { operator: "is", channels: 2 }],
+		["resolution", { operator: "is", resolutions: ["R1080p"] }],
+		["custom_format_score", { operator: "less_than", score: 0 }],
+		["release_group", { operator: "is", groups: ["Example"] }],
+	] as const)("requires predicate-specific %s file evidence", (ruleType, parameters) => {
+		const result = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem({
+				movieFile: { id: 1001, path: "/movies/example.mkv" },
+				_arrDashboardEvidence: { hasFile: true },
+			}) as never,
+			[mutationEvidenceRule(ruleType, parameters)] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+
+		expect(result).toEqual({ kind: "unknown", ruleId: `rule-${ruleType}` });
+	});
+
+	it("requires a parseable channel count for audio_channels evidence", () => {
+		const result = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem({
+				movieFile: { audioCodec: "AAC" },
+				_arrDashboardEvidence: { hasFile: true },
+			}) as never,
+			[mutationEvidenceRule("audio_channels", { operator: "is", channels: 2 })] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+
+		expect(result).toEqual({ kind: "unknown", ruleId: "rule-audio_channels" });
+	});
+
+	it.each([
+		{ originalLanguage: { name: "" } },
+		{ languages: [] },
+		{ languages: ["   "] },
+		{ languages: [{ name: "" }] },
+	])("rejects blank language evidence: %j", (languageData) => {
+		const result = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem(languageData) as never,
+			[
+				mutationEvidenceRule("language", {
+					operator: "excludes_all",
+					languages: ["English"],
+				}),
+			] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+
+		expect(result).toEqual({ kind: "unknown", ruleId: "rule-language" });
+	});
+});

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -135,6 +135,8 @@ function approvalRecord(overrides: Record<string, unknown> = {}) {
 		itemType: "movie",
 		title: "Example Movie",
 		reason: "Matched 4K cleanup rule",
+		matchedRuleId: "rule-1",
+		matchedRuleName: "Old media",
 		action: "delete",
 		safetySnapshot: radarrSafetySnapshot(),
 		...overrides,
@@ -214,6 +216,10 @@ function notificationFields(options: TestOptions) {
 }
 
 function makeDeps(options: TestOptions = {}) {
+	const currentCleanupConfig = dryRunConfig();
+	currentCleanupConfig.dryRunMode = false;
+	currentCleanupConfig.requireApproval = true;
+	currentCleanupConfig.rules[0]!.action = options.action ?? "delete";
 	const targetInstance = {
 		id: "radarr-4k",
 		userId: "user-1",
@@ -252,8 +258,14 @@ function makeDeps(options: TestOptions = {}) {
 		id: 101,
 		tmdbId: 42,
 		title: "Example Movie",
+		year: 2024,
 		tags: options.movieTags ?? [],
+		monitored: true,
 		hasFile: true,
+		sizeOnDisk: 2_000,
+		added: "2020-01-01T00:00:00.000Z",
+		status: "released",
+		qualityProfileId: 1,
 		movieFileId: 1001,
 		path: "/movies-4k/Example Movie (2024)",
 		rootFolderPath: "/movies-4k",
@@ -300,8 +312,13 @@ function makeDeps(options: TestOptions = {}) {
 						return {
 							...targetMovie,
 							hasFile: liveMovieFileId !== undefined,
+							sizeOnDisk: liveMovieFileId !== undefined ? 2_000 : 0,
 							movieFileId: liveMovieFileId,
 							movieFile: liveMovieFileId !== undefined ? targetMovieFile : undefined,
+							statistics: {
+								movieFileCount: liveMovieFileId !== undefined ? 1 : 0,
+								sizeOnDisk: liveMovieFileId !== undefined ? 2_000 : 0,
+							},
 						};
 					}),
 			delete: deleteMovie,
@@ -376,7 +393,7 @@ function makeDeps(options: TestOptions = {}) {
 	const deps: CleanupExecutorDeps = {
 		prisma: {
 			libraryCleanupConfig: {
-				findUnique: vi.fn().mockResolvedValue({ id: "config-1" }),
+				findUnique: vi.fn().mockResolvedValue(currentCleanupConfig),
 				updateMany: cleanupConfigUpdateMany,
 			},
 			serviceInstance: {
@@ -654,6 +671,8 @@ function configureApprovalStore(
 	deps: CleanupExecutorDeps,
 	storedApproval: Record<string, unknown>,
 ) {
+	storedApproval.matchedRuleId ??= "rule-1";
+	storedApproval.matchedRuleName ??= "Old media";
 	storedApproval.status ??= "approved";
 	storedApproval.executionToken ??= null;
 	vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
@@ -692,6 +711,8 @@ function configureApprovalStores(
 	storedApprovals: Array<Record<string, unknown>>,
 ) {
 	for (const approval of storedApprovals) {
+		approval.matchedRuleId ??= "rule-1";
+		approval.matchedRuleName ??= "Old media";
 		approval.status ??= "approved";
 		approval.executionToken ??= null;
 	}
@@ -762,6 +783,53 @@ function dryRunConfig(maxRemovalsPerRun = 10) {
 			},
 		],
 	};
+}
+
+function configureFreshRadarrUnmonitorPolicy(fixture: ReturnType<typeof makeDeps>) {
+	const currentConfig = dryRunConfig(1);
+	currentConfig.dryRunMode = false;
+	(currentConfig.rules[0] as { excludeTitles: string | null }).excludeTitles = JSON.stringify([
+		"^Fresh Movie$",
+	]);
+	currentConfig.rules.push({
+		...currentConfig.rules[0]!,
+		id: "rule-2",
+		name: "Fresh unmonitor",
+		priority: 2,
+		action: "unmonitor",
+		excludeTitles: null,
+	});
+	vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+		currentConfig as never,
+	);
+	const getMovieById = fixture.targetClient.movie.getById.getMockImplementation();
+	if (!getMovieById) throw new Error("Expected a Radarr movie lookup implementation");
+	fixture.targetClient.movie.getById.mockImplementation(async (arrItemId: number) =>
+		Number(arrItemId) === 102
+			? {
+					id: 102,
+					tmdbId: 43,
+					title: "Fresh Movie",
+					year: 2024,
+					tags: [],
+					monitored: true,
+					hasFile: true,
+					sizeOnDisk: 2_000,
+					added: "2020-01-01T00:00:00.000Z",
+					status: "released",
+					qualityProfileId: 1,
+					movieFileId: 1002,
+					path: "/movies-4k/Fresh Movie (2024)",
+					rootFolderPath: "/movies-4k",
+					movieFile: {
+						id: 1002,
+						path: "/movies-4k/Fresh Movie (2024)/Fresh.Movie.2160p.mkv",
+						size: 2_000,
+					},
+					statistics: { movieFileCount: 1, sizeOnDisk: 2_000 },
+				}
+			: getMovieById(arrItemId),
+	);
 }
 
 function plexPolicyCleanupConfig(options: {
@@ -4476,15 +4544,7 @@ describe("shared Plex deletion safety", () => {
 			mediaPartCount: 1,
 		});
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				action: "delete",
-				title: "Example Movie",
-				safetySnapshot: radarrSafetySnapshot(null),
-			} as never,
+			approvalRecord({ safetySnapshot: radarrSafetySnapshot(null) }) as never,
 		]);
 
 		await expect(executeApprovedItems(deps, "user-1", ["approval-1"])).resolves.toEqual({
@@ -4614,15 +4674,7 @@ describe("shared Plex deletion safety", () => {
 			setLiveMovieFileId(1002);
 		});
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				action: "delete",
-				title: "Example Movie",
-				safetySnapshot: radarrSafetySnapshot(),
-			} as never,
+			approvalRecord() as never,
 		]);
 
 		const result = await executeApprovedItems(deps, "user-1", ["approval-1"]);
@@ -4648,15 +4700,7 @@ describe("shared Plex deletion safety", () => {
 			throw new Error("response lost");
 		});
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				action: "delete_files",
-				title: "Example Movie",
-				safetySnapshot: radarrSafetySnapshot(),
-			} as never,
+			approvalRecord({ action: "delete_files" }) as never,
 		]);
 
 		await expect(executeApprovedItems(deps, "user-1", ["approval-1"])).resolves.toEqual({
@@ -4673,15 +4717,7 @@ describe("shared Plex deletion safety", () => {
 			throw new Error("response lost");
 		});
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				action: "delete",
-				title: "Example Movie",
-				safetySnapshot: radarrSafetySnapshot(),
-			} as never,
+			approvalRecord() as never,
 		]);
 
 		await expect(executeApprovedItems(deps, "user-1", ["approval-1"])).resolves.toEqual({
@@ -5096,8 +5132,14 @@ describe("shared Plex deletion safety", () => {
 			id: 101,
 			tmdbId: 42,
 			title: "Example Movie",
+			year: 2024,
 			tags: [],
+			monitored: true,
 			hasFile: true,
+			sizeOnDisk: 2_000,
+			added: "2020-01-01T00:00:00.000Z",
+			status: "released",
+			qualityProfileId: 1,
 			movieFileId: 1001,
 			path: "/movies-4k/Example Movie (2024)",
 			rootFolderPath: "/movies-4k",
@@ -5637,9 +5679,11 @@ describe("shared Plex deletion safety", () => {
 	});
 
 	it("defers a dispatched failed retry for one run so fresh work can make progress safely", async () => {
-		const { deps, targetClient, deleteMovie, deleteMovieFile } = makeDeps({
+		const fixture = makeDeps({
 			mediaPartCount: 1,
 		});
+		configureFreshRadarrUnmonitorPolicy(fixture);
+		const { deps, targetClient, deleteMovie, deleteMovieFile } = fixture;
 		const retries = configureRetryStore(deps);
 		retries.push({
 			...approvalRecord(),
@@ -5661,7 +5705,20 @@ describe("shared Plex deletion safety", () => {
 				title: "Fresh Movie",
 				year: 2024,
 				monitored: true,
-				...radarrCachedFileIdentity,
+				hasFile: true,
+				cachedAt: new Date("2026-07-27T12:05:00.000Z"),
+				data: JSON.stringify({
+					_arrDashboardSource: {
+						serviceFingerprint: radarrTargetIdentity.serviceFingerprint,
+					},
+					remoteIds: { tmdbId: 43 },
+					path: "/movies-4k/Fresh Movie (2024)",
+					movieFile: {
+						id: 1002,
+						path: "/movies-4k/Fresh Movie (2024)/Fresh.Movie.2160p.mkv",
+						size: 2_000,
+					},
+				}),
 				sizeOnDisk: 2_000n,
 			},
 			match: {
@@ -6026,16 +6083,7 @@ describe("shared Plex deletion safety", () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
 		deleteMovie.mockRejectedValue(new Error("Radarr movie delete unavailable"));
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				title: "Example Movie",
-				reason: "Matched 4K cleanup rule",
-				action: "delete",
-				safetySnapshot: radarrPostPartialSafetySnapshot(),
-			} as never,
+			approvalRecord({ safetySnapshot: radarrPostPartialSafetySnapshot() }) as never,
 		]);
 
 		const result = await executeApprovedItems(deps, "user-1", ["approval-1"]);
@@ -6228,7 +6276,7 @@ describe("shared Plex deletion safety", () => {
 		).toBeLessThan(deleteMovie.mock.invocationCallOrder[0]!);
 	});
 
-	it("explicitly resumes a durable retry while safer cleanup modes are enabled", async () => {
+	it("retains a durable retry while dry-run mode prevents current mutation authority", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
 		const storedRetry = approvalRecord({
 			status: "retry_pending",
@@ -6243,10 +6291,15 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeRetryItems(deps, "user-1", ["approval-1"]);
 
-		expect(result).toEqual({ removed: 1, reconciled: 0, failed: 0, errors: [] });
-		expect(deleteMovieFile).toHaveBeenCalledOnce();
-		expect(deleteMovie).toHaveBeenCalledOnce();
-		expect(storedRetry).toMatchObject({ status: "executed", executionToken: null });
+		expect(result).toEqual({
+			removed: 0,
+			reconciled: 0,
+			failed: 1,
+			errors: ["Cleanup item could not be executed. Review the API logs for details."],
+		});
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(storedRetry).toMatchObject({ status: "retry_pending", executionToken: null });
 	});
 
 	it("rechecks deployed exemptions before executing an approved mutation", async () => {
@@ -6836,16 +6889,7 @@ describe("shared Plex deletion safety", () => {
 	it("does not requeue a successful approved delete when its cache cleanup fails", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				title: "Example Movie",
-				reason: "Matched 4K cleanup rule",
-				action: "delete",
-				safetySnapshot: radarrSafetySnapshot(),
-			} as never,
+			approvalRecord() as never,
 		]);
 		vi.mocked(deps.prisma.libraryCache.deleteMany).mockRejectedValue(
 			new Error("cache unavailable"),
@@ -6869,16 +6913,7 @@ describe("shared Plex deletion safety", () => {
 	it("retries only the executed-status write after an approved delete succeeds", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockResolvedValue([
-			{
-				id: "approval-1",
-				instanceId: "radarr-4k",
-				arrItemId: 101,
-				itemType: "movie",
-				title: "Example Movie",
-				reason: "Matched 4K cleanup rule",
-				action: "delete",
-				safetySnapshot: radarrSafetySnapshot(),
-			} as never,
+			approvalRecord() as never,
 		]);
 		let terminalWriteAttempts = 0;
 		vi.mocked(deps.prisma.libraryCleanupApproval.updateMany).mockImplementation((async ({
@@ -6910,18 +6945,10 @@ describe("shared Plex deletion safety", () => {
 
 	it("exclusively claims an approval across concurrent execution requests", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
-		const approval = {
-			id: "approval-1",
-			instanceId: "radarr-4k",
-			arrItemId: 101,
-			itemType: "movie",
-			title: "Example Movie",
-			reason: "Matched 4K cleanup rule",
-			action: "delete",
-			safetySnapshot: radarrSafetySnapshot(),
+		const approval = approvalRecord({
 			status: "approved",
 			executionToken: null,
-		} as unknown as Record<string, unknown>;
+		}) as Record<string, unknown>;
 		configureApprovalStore(deps, approval);
 		let releaseFileDelete!: () => void;
 		const originalFileDelete = deleteMovieFile.getMockImplementation()!;
@@ -7002,16 +7029,7 @@ describe("shared Plex deletion safety", () => {
 
 	it("cannot replay an approval when both executed-status writes fail", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
-		const approval = {
-			id: "approval-1",
-			instanceId: "radarr-4k",
-			arrItemId: 101,
-			itemType: "movie",
-			title: "Example Movie",
-			reason: "Matched 4K cleanup rule",
-			action: "delete",
-			safetySnapshot: radarrSafetySnapshot(),
-		} as never;
+		const approval = approvalRecord() as never;
 		let state = "approved";
 		let executionToken: string | null = null;
 		vi.mocked(deps.prisma.libraryCleanupApproval.updateMany).mockImplementation((async ({
@@ -7051,16 +7069,7 @@ describe("shared Plex deletion safety", () => {
 
 	it("executes earlier claims when a later approval claim fails", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
-		const approval = {
-			id: "approval-1",
-			instanceId: "radarr-4k",
-			arrItemId: 101,
-			itemType: "movie",
-			title: "Example Movie",
-			reason: "Matched 4K cleanup rule",
-			action: "delete",
-			safetySnapshot: radarrSafetySnapshot(),
-		} as never;
+		const approval = approvalRecord() as never;
 		vi.mocked(deps.prisma.libraryCleanupApproval.updateMany).mockImplementation(((args: {
 			where: { id: string };
 		}) =>

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -66,8 +66,39 @@ function episodeCleanupRule(action: "delete" | "delete_files" | "unmonitor" = "d
 	};
 }
 
+function seriesCleanupRule(action: "delete" | "delete_files" = "delete") {
+	return {
+		id: "rule-1",
+		configId: "config-1",
+		name: "Example series cleanup",
+		enabled: true,
+		priority: 1,
+		ruleType: "file_path",
+		parameters: JSON.stringify({
+			operator: "matches",
+			pattern: "^/tv-4k/Example Series$",
+			field: "path",
+		}),
+		serviceFilter: JSON.stringify(["SONARR"]),
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		targetScope: "series",
+		action,
+		operator: null,
+		conditions: null,
+		retentionMode: false,
+		useGlobalRejectionMemory: true,
+		rejectionMemoryDays: 0,
+		createdAt: new Date("2026-07-27T12:00:00.000Z"),
+		updatedAt: new Date("2026-07-27T12:00:00.000Z"),
+	};
+}
+
 interface SonarrTestOptions {
 	action?: "delete" | "delete_files";
+	seriesPolicyAction?: "delete" | "delete_files" | null;
 	livePlexWatchCount?: number;
 	notificationKind?: "plex" | "mediabrowser" | "kodi" | "synology" | "none";
 	onSeriesDelete?: boolean;
@@ -169,9 +200,14 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		tvdbId: 123,
 		tmdbId: 456,
 		title: "Example Series",
+		year: 2024,
 		path: "/tv-4k/Example Series",
+		rootFolderPath: "/tv-4k",
 		tags: options.seriesTags ?? [],
 		monitored: true,
+		added: "2020-01-01T00:00:00.000Z",
+		status: "continuing",
+		qualityProfileId: 1,
 	};
 	const episodeFiles = options.episodeFiles ?? [
 		{
@@ -236,7 +272,13 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		series: {
 			getById: vi.fn(async () => {
 				if (!liveSeriesExists) throw new NotFoundError("Series not found");
-				return series;
+				return {
+					...series,
+					statistics: {
+						episodeFileCount: liveEpisodeFiles.length,
+						sizeOnDisk: liveEpisodeFiles.reduce((total, file) => total + (file.size ?? 0), 0),
+					},
+				};
 			}),
 			delete: deleteSeries,
 		},
@@ -303,8 +345,16 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 			libraryCleanupConfig: {
 				findUnique: vi.fn().mockResolvedValue({
 					id: "config-1",
+					userId: "user-1",
+					enabled: true,
+					dryRunMode: false,
+					requireApproval: true,
+					maxRemovalsPerRun: 10,
 					respectQuiSeeding: false,
 					rules: [
+						...(options.seriesPolicyAction === null
+							? []
+							: [seriesCleanupRule(options.seriesPolicyAction ?? options.action ?? "delete")]),
 						episodeCleanupRule(),
 						episodeCleanupRule("delete_files"),
 						episodeCleanupRule("unmonitor"),
@@ -1848,6 +1898,8 @@ describe("verified Sonarr mutation handoff", () => {
 			itemType: "series",
 			action,
 			title: "Example Series",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Example series cleanup",
 			safetySnapshot: serializeExecutableSafetyPlan({
 				kind: "verified_sonarr",
 				target: {
@@ -1954,6 +2006,8 @@ describe("verified Sonarr mutation handoff", () => {
 		deps: CleanupExecutorDeps,
 		storedApproval: Record<string, unknown>,
 	) {
+		storedApproval.matchedRuleId ??= "rule-1";
+		storedApproval.matchedRuleName ??= "Example series cleanup";
 		storedApproval.status ??= "approved";
 		storedApproval.executionToken ??= null;
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
@@ -2209,7 +2263,7 @@ describe("verified Sonarr mutation handoff", () => {
 	});
 
 	it("unmonitors and deletes only the approved episode without removing its series", async () => {
-		const fixture = makeSonarrDeps();
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
 		const episodeTarget = exactEpisodeTarget();
 		const context = createSharedPlexSafetyContext();
 		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
@@ -2301,7 +2355,7 @@ describe("verified Sonarr mutation handoff", () => {
 	);
 
 	it("executes a direct episode delete through the same exact durable boundary", async () => {
-		const fixture = makeSonarrDeps();
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
 		const intents = configureRetryStore(fixture.deps);
 		const result = await executeDirectRemoval(
 			fixture.deps,

--- a/apps/api/src/lib/library-cleanup/arr-policy-evidence.ts
+++ b/apps/api/src/lib/library-cleanup/arr-policy-evidence.ts
@@ -1,0 +1,100 @@
+export interface ArrPolicyEvidence {
+	monitored: boolean;
+	hasFile: boolean;
+	episodeFileCount: boolean;
+	sizeOnDisk: boolean;
+	tags: boolean;
+	rating: boolean;
+	imdbRating: boolean;
+	hdrType: boolean;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isCompleteRatingValue(value: unknown): boolean {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 && value <= 10;
+}
+
+function hasCompleteTags(value: unknown): boolean {
+	return (
+		Array.isArray(value) &&
+		value.every(
+			(tag) =>
+				(typeof tag === "number" && Number.isSafeInteger(tag) && tag >= 0) ||
+				(typeof tag === "string" && tag.trim().length > 0),
+		)
+	);
+}
+
+function hasCompleteSourceRating(ratings: Record<string, unknown>, source: string): boolean {
+	if (!Object.hasOwn(ratings, source)) return false;
+	const child = ratings[source];
+	return isRecord(child) && isCompleteRatingValue(child.value);
+}
+
+function hasCompleteFlatRating(ratings: Record<string, unknown>): boolean {
+	if (!Object.hasOwn(ratings, "value")) return false;
+	return isCompleteRatingValue(ratings.value);
+}
+
+function hasExplicitDynamicRange(raw: Record<string, unknown>): boolean {
+	const file = isRecord(raw.movieFile)
+		? raw.movieFile
+		: isRecord(raw.episodeFile)
+			? raw.episodeFile
+			: undefined;
+	const mediaInfo = file && isRecord(file.mediaInfo) ? file.mediaInfo : undefined;
+	return (
+		mediaInfo !== undefined &&
+		Object.hasOwn(mediaInfo, "videoDynamicRange") &&
+		(typeof mediaInfo.videoDynamicRange === "string" || mediaInfo.videoDynamicRange === null)
+	);
+}
+
+/**
+ * Capture which cleanup-policy fields existed in the raw ARR response before
+ * normalizers apply defaults such as `hasFile: false` or an episode count of
+ * zero. Mutation-time evaluation must never treat those defaults as proof.
+ */
+export function deriveArrPolicyEvidence(
+	service: "sonarr" | "radarr",
+	raw: Record<string, unknown>,
+): ArrPolicyEvidence {
+	const statistics = isRecord(raw.statistics) ? raw.statistics : undefined;
+	const monitored = typeof raw.monitored === "boolean";
+
+	if (service === "sonarr") {
+		const episodeFileCount =
+			isNonNegativeSafeInteger(statistics?.episodeFileCount) ||
+			isNonNegativeSafeInteger(raw.episodeFileCount);
+		const ratings = isRecord(raw.ratings) ? raw.ratings : undefined;
+		return {
+			monitored,
+			hasFile: episodeFileCount,
+			episodeFileCount,
+			sizeOnDisk: isNonNegativeSafeInteger(statistics?.sizeOnDisk),
+			tags: hasCompleteTags(raw.tags),
+			rating: ratings !== undefined && hasCompleteFlatRating(ratings),
+			imdbRating: false,
+			hdrType: hasExplicitDynamicRange(raw),
+		};
+	}
+
+	const ratings = isRecord(raw.ratings) ? raw.ratings : undefined;
+	return {
+		monitored,
+		hasFile: typeof raw.hasFile === "boolean",
+		episodeFileCount: false,
+		sizeOnDisk: isNonNegativeSafeInteger(raw.sizeOnDisk),
+		tags: hasCompleteTags(raw.tags),
+		rating: ratings !== undefined && hasCompleteSourceRating(ratings, "tmdb"),
+		imdbRating: ratings !== undefined && hasCompleteSourceRating(ratings, "imdb"),
+		hdrType: hasExplicitDynamicRange(raw),
+	};
+}

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -41,6 +41,7 @@ import type {
 } from "../prisma.js";
 import {
 	evaluateItemAgainstRulesViaEngine,
+	evaluateItemMutationPolicyStateViaEngine,
 	evaluateRuleViaEngine,
 } from "../rules/cleanup-adapter.js";
 import { SeerrClient } from "../seerr/seerr-client.js";
@@ -51,6 +52,7 @@ import {
 	withCleanupOperationGuard,
 	withExclusiveCleanupOperationGuard,
 } from "./cleanup-maintenance-gate.js";
+import { deriveArrPolicyEvidence } from "./arr-policy-evidence.js";
 import {
 	type EpisodeCleanupCandidate,
 	type EpisodePlexWatchEvidence,
@@ -137,6 +139,610 @@ const APPROVAL_EXPIRY_DAYS = 7;
 // Batch size for LibraryCache queries
 const CACHE_QUERY_BATCH_SIZE = 500;
 const PROVIDER_EVIDENCE_FRESHNESS_MS = 24 * 60 * 60 * 1000;
+
+export type SeriesMutationTransition = "unchanged" | "all_files_deleted";
+
+type MutationAuthorityEvidence =
+	| { liveEpisodeWatchSources: VerifiedEpisodePlexWatchSource[] }
+	| { seriesTransition: SeriesMutationTransition };
+
+type MutationAuthorityCheck = (
+	evidence?: MutationAuthorityEvidence,
+) => Promise<Record<string, unknown> | undefined>;
+
+export interface MutationPolicySnapshot {
+	capturedAt: Date;
+	configFingerprint: string;
+	rules: LibraryCleanupRule[];
+	ruleFingerprint: string;
+	ctx: EvalContext;
+	failedSources: Set<DataSourceDependency>;
+	providerTopologyFingerprint: string;
+}
+
+interface AuthorizedSeriesMutationPolicy {
+	snapshot: MutationPolicySnapshot;
+	rawItem: Record<string, unknown>;
+	policyItem: CacheItemForEval;
+}
+
+/** A snapshot is captured for one target/write and is never reused by a later run. */
+export const MUTATION_POLICY_SNAPSHOT_MAX_AGE_MS = 2 * 60 * 1000;
+
+function compareCanonicalPolicyValues(left: unknown, right: unknown): number {
+	return JSON.stringify(left).localeCompare(JSON.stringify(right));
+}
+
+function canonicalPolicyValue(value: unknown): unknown {
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value === "bigint") return `${value}n`;
+	if (value instanceof Set) {
+		return [...value].map(canonicalPolicyValue).sort(compareCanonicalPolicyValues);
+	}
+	if (value instanceof Map) {
+		return [...value.entries()]
+			.map(([key, entry]) => [canonicalPolicyValue(key), canonicalPolicyValue(entry)])
+			.sort((left, right) => compareCanonicalPolicyValues(left[0], right[0]));
+	}
+	if (Array.isArray(value)) return value.map(canonicalPolicyValue);
+	if (typeof value !== "object" || value === null) return value;
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.sort(([left], [right]) => left.localeCompare(right))
+			.map(([key, entry]) => [key, canonicalPolicyValue(entry)]),
+	);
+}
+
+function mutationPolicyFingerprint(value: unknown): string {
+	return createHash("sha256")
+		.update(JSON.stringify(canonicalPolicyValue(value)))
+		.digest("hex");
+}
+
+function completeMutationConfigFingerprint(config: {
+	id?: unknown;
+	enabled?: unknown;
+	dryRunMode?: unknown;
+	requireApproval?: unknown;
+	maxRemovalsPerRun?: unknown;
+	respectQuiSeeding?: unknown;
+}): string | undefined {
+	if (
+		typeof config.id !== "string" ||
+		typeof config.enabled !== "boolean" ||
+		typeof config.dryRunMode !== "boolean" ||
+		typeof config.requireApproval !== "boolean" ||
+		typeof config.respectQuiSeeding !== "boolean" ||
+		typeof config.maxRemovalsPerRun !== "number" ||
+		!Number.isSafeInteger(config.maxRemovalsPerRun) ||
+		config.maxRemovalsPerRun < 1 ||
+		config.maxRemovalsPerRun > 100
+	) {
+		return undefined;
+	}
+	return mutationPolicyFingerprint({
+		id: config.id,
+		enabled: config.enabled,
+		dryRunMode: config.dryRunMode,
+		requireApproval: config.requireApproval,
+		maxRemovalsPerRun: config.maxRemovalsPerRun,
+		respectQuiSeeding: config.respectQuiSeeding,
+	});
+}
+
+function orderedMutationRules(rules: LibraryCleanupRule[]): LibraryCleanupRule[] {
+	return [...rules].sort(
+		(left, right) => left.priority - right.priority || left.id.localeCompare(right.id),
+	);
+}
+
+const MUTATION_POLICY_PROVIDER_SERVICES: ServiceInstance["service"][] = [
+	"PLEX",
+	"JELLYFIN",
+	"EMBY",
+	"SEERR",
+];
+
+async function loadMutationPolicyProviderInstances(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<ServiceInstance[]> {
+	return await deps.prisma.serviceInstance.findMany({
+		where: {
+			userId,
+			enabled: true,
+			service: { in: MUTATION_POLICY_PROVIDER_SERVICES },
+		},
+		orderBy: { id: "asc" },
+	});
+}
+
+function providerTopologyFingerprint(instances: ServiceInstance[]): string {
+	return mutationPolicyFingerprint(
+		[...instances]
+			.sort((left, right) => left.id.localeCompare(right.id))
+			.map((instance) => ({
+				id: instance.id,
+				service: instance.service,
+				baseUrl: instance.baseUrl,
+				enabled: instance.enabled,
+				encryptedApiKey: instance.encryptedApiKey,
+				encryptionIv: instance.encryptionIv,
+				encryptedHttpAuthCredentials: instance.encryptedHttpAuthCredentials,
+				httpAuthEncryptionIv: instance.httpAuthEncryptionIv,
+				expectedIdentity: instance.expectedIdentity,
+				identityStatus: instance.identityStatus,
+				connectionGeneration: instance.connectionGeneration,
+				identityGeneration: instance.identityGeneration,
+			})),
+	);
+}
+
+function mutationPolicyUsesProviderTopology(rules: LibraryCleanupRule[]): boolean {
+	const activeTypes = collectActiveRuleTypes(rules);
+	return (
+		rules.some((rule) => getRuleDataSources(rule).size > 0) ||
+		activeTypes.has("user_retention") ||
+		activeTypes.has("staleness_score") ||
+		activeTypes.has("recently_active") ||
+		activeTypes.has("seerr_requester_watched") ||
+		activeTypes.has("seerr_requester_not_watched")
+	);
+}
+
+async function createMutationPolicySnapshot(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	expectedConfigFingerprint?: string,
+	cleanupRunClaimToken?: string,
+): Promise<MutationPolicySnapshot> {
+	const capturedAt = new Date();
+	const config = await deps.prisma.libraryCleanupConfig.findUnique({
+		where: { userId },
+		include: { rules: true },
+	});
+	if (!config?.enabled || config.dryRunMode) {
+		throw new Error("The cleanup configuration is no longer enabled for mutation");
+	}
+	const configFingerprint = completeMutationConfigFingerprint(config);
+	if (!configFingerprint) throw new Error("Cleanup mutation settings were incomplete");
+	if (expectedConfigFingerprint && configFingerprint !== expectedConfigFingerprint) {
+		throw new Error("Cleanup mutation settings changed after run authorization");
+	}
+
+	const rules = orderedMutationRules(config.rules.filter((rule) => rule.targetScope !== "episode"));
+	const ruleFingerprint = mutationPolicyFingerprint(rules);
+	const needsProviderTopology = mutationPolicyUsesProviderTopology(rules);
+	const topologyBefore = needsProviderTopology
+		? await loadMutationPolicyProviderInstances(deps, userId)
+		: [];
+	const ctx = await buildEvalContext(deps, userId, rules, {
+		destructiveAuthority: true,
+		requireAvailableEvidence: true,
+		cleanupRunClaimToken,
+	});
+	const topologyAfter = needsProviderTopology
+		? await loadMutationPolicyProviderInstances(deps, userId)
+		: [];
+	const beforeTopologyFingerprint = providerTopologyFingerprint(topologyBefore);
+	const afterTopologyFingerprint = providerTopologyFingerprint(topologyAfter);
+	if (beforeTopologyFingerprint !== afterTopologyFingerprint) {
+		throw new Error("Provider topology changed while cleanup authority was being captured");
+	}
+
+	const currentConfig = await deps.prisma.libraryCleanupConfig.findUnique({
+		where: { userId },
+		include: { rules: true },
+	});
+	const currentRules = currentConfig
+		? orderedMutationRules(currentConfig.rules.filter((rule) => rule.targetScope !== "episode"))
+		: [];
+	if (
+		!currentConfig?.enabled ||
+		currentConfig.dryRunMode ||
+		completeMutationConfigFingerprint(currentConfig) !== configFingerprint ||
+		mutationPolicyFingerprint(currentRules) !== ruleFingerprint
+	) {
+		throw new Error("Cleanup rules or mutation settings changed while authority was captured");
+	}
+	if (Date.now() - capturedAt.getTime() > MUTATION_POLICY_SNAPSHOT_MAX_AGE_MS) {
+		throw new Error("Cleanup mutation authority capture exceeded its freshness window");
+	}
+	return {
+		capturedAt,
+		configFingerprint,
+		rules,
+		ruleFingerprint,
+		ctx,
+		failedSources: new Set<DataSourceDependency>(),
+		providerTopologyFingerprint: afterTopologyFingerprint,
+	};
+}
+
+/** Capture fresh policy evidence for one mutation boundary. */
+export function createMutationPolicySnapshotGetter(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	expectedConfigFingerprint?: string,
+	cleanupRunClaimToken?: string,
+): () => Promise<MutationPolicySnapshot> {
+	return async () =>
+		await createMutationPolicySnapshot(
+			deps,
+			userId,
+			expectedConfigFingerprint,
+			cleanupRunClaimToken,
+		);
+}
+
+function assertMutationPolicySnapshotFresh(snapshot: MutationPolicySnapshot): void {
+	const age = Date.now() - snapshot.capturedAt.getTime();
+	if (age < 0 || age > MUTATION_POLICY_SNAPSHOT_MAX_AGE_MS) {
+		throw new Error("Cleanup mutation authority snapshot is stale");
+	}
+}
+
+function toLiveSeriesPolicyItem(
+	instance: ServiceInstance,
+	arrItemId: number,
+	rawItem: Record<string, unknown>,
+): CacheItemForEval {
+	if (instance.service !== "RADARR" && instance.service !== "SONARR") {
+		throw new Error(`Unsupported cleanup service: ${instance.service}`);
+	}
+	const service = instance.service === "RADARR" ? "radarr" : "sonarr";
+	const liveItem = buildLibraryItem(instance, service, rawItem);
+	const liveItemId =
+		typeof liveItem.id === "number" ? liveItem.id : Number.parseInt(String(liveItem.id), 10);
+	const expectedType = instance.service === "RADARR" ? "movie" : "series";
+	if (
+		liveItemId !== arrItemId ||
+		liveItem.type !== expectedType ||
+		typeof rawItem.title !== "string" ||
+		rawItem.title.trim() === "" ||
+		typeof liveItem.title !== "string" ||
+		liveItem.title.trim() === ""
+	) {
+		throw new Error(
+			`Live ARR item identity did not match the cleanup target (expected ${expectedType} ${arrItemId}, received ${liveItem.type} ${liveItemId})`,
+		);
+	}
+	const addedAt = liveItem.added ? new Date(liveItem.added) : null;
+	const rawStatistics =
+		typeof rawItem.statistics === "object" && rawItem.statistics !== null
+			? (rawItem.statistics as Record<string, unknown>)
+			: {};
+	return {
+		id: `live:${instance.id}:${expectedType}:${arrItemId}`,
+		instanceId: instance.id,
+		arrItemId,
+		itemType: expectedType,
+		title: liveItem.title,
+		year: liveItem.year ?? null,
+		monitored: liveItem.monitored ?? true,
+		hasFile: liveItem.hasFile ?? false,
+		status: liveItem.status ?? null,
+		qualityProfileId: liveItem.qualityProfileId ?? null,
+		qualityProfileName:
+			liveItem.qualityProfileName ??
+			(typeof rawItem.profileName === "string" ? rawItem.profileName : null),
+		sizeOnDisk: BigInt(Math.max(0, Math.trunc(liveItem.sizeOnDisk ?? 0))),
+		arrAddedAt: addedAt && !Number.isNaN(addedAt.getTime()) ? addedAt : null,
+		cachedAt: new Date(),
+		data: JSON.stringify({
+			...rawItem,
+			...liveItem,
+			statistics: { ...rawStatistics, ...liveItem.statistics },
+			_arrDashboardSource: { serviceFingerprint: createArrServiceFingerprint(instance) },
+			_arrDashboardEvidence: deriveArrPolicyEvidence(service, rawItem),
+		}),
+		infoHash: null,
+		torrentState: null,
+	};
+}
+
+async function loadLiveSeriesPolicyItem(
+	deps: CleanupExecutorDeps,
+	instance: ServiceInstance,
+	arrItemId: number,
+	rules: LibraryCleanupRule[],
+): Promise<{ rawItem: Record<string, unknown>; item: CacheItemForEval }> {
+	const client = deps.arrClientFactory.create(instance);
+	let rawItem =
+		instance.service === "RADARR"
+			? ((await (client as InstanceType<typeof RadarrClient>).movie.getById(
+					arrItemId,
+				)) as unknown as Record<string, unknown>)
+			: instance.service === "SONARR"
+				? ((await (client as InstanceType<typeof SonarrClient>).series.getById(
+						arrItemId,
+					)) as unknown as Record<string, unknown>)
+				: (() => {
+						throw new Error(`Unsupported cleanup service: ${instance.service}`);
+					})();
+	let item = toLiveSeriesPolicyItem(instance, arrItemId, rawItem);
+	if (
+		collectActiveRuleTypes(rules).has("quality_profile") &&
+		(!item.qualityProfileName || item.qualityProfileName.trim().length === 0)
+	) {
+		const qualityProfileId = item.qualityProfileId;
+		if (
+			typeof qualityProfileId !== "number" ||
+			!Number.isSafeInteger(qualityProfileId) ||
+			qualityProfileId <= 0
+		) {
+			throw new Error("Live ARR quality-profile identity was incomplete");
+		}
+		const profile =
+			instance.service === "RADARR"
+				? await (client as InstanceType<typeof RadarrClient>).qualityProfile.getById(
+						qualityProfileId,
+					)
+				: await (client as InstanceType<typeof SonarrClient>).qualityProfile.getById(
+						qualityProfileId,
+					);
+		if (typeof profile.name !== "string" || profile.name.trim().length === 0) {
+			throw new Error("Live ARR quality-profile name was incomplete");
+		}
+		rawItem = { ...rawItem, profileName: profile.name };
+		item = toLiveSeriesPolicyItem(instance, arrItemId, rawItem);
+	}
+	return { rawItem, item };
+}
+
+const RADARR_FILE_TRANSITION_FIELDS = new Set([
+	"hasFile",
+	"movieFile",
+	"movieFileId",
+	"sizeOnDisk",
+]);
+const RADARR_STATISTICS_FILE_TRANSITION_FIELDS = new Set([
+	"movieFileCount",
+	"releaseGroups",
+	"sizeOnDisk",
+]);
+const SONARR_FILE_TRANSITION_FIELDS = new Set([
+	"episodeFile",
+	"episodeFileCount",
+	"hasFile",
+	"sizeOnDisk",
+]);
+const SONARR_STATISTICS_FILE_TRANSITION_FIELDS = new Set([
+	"episodeCount",
+	"episodeFileCount",
+	"percentOfEpisodes",
+	"releaseGroups",
+	"sizeOnDisk",
+]);
+
+function policyStateOutsideExpectedFileDeletion(
+	value: unknown,
+	service: "RADARR" | "SONARR",
+	context: "root" | "statistics" | "nested" = "root",
+): unknown {
+	if (Array.isArray(value)) {
+		return value.map((entry) => policyStateOutsideExpectedFileDeletion(entry, service, "nested"));
+	}
+	if (typeof value !== "object" || value === null) return value;
+	const result: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		if (
+			context === "root" &&
+			(service === "RADARR"
+				? RADARR_FILE_TRANSITION_FIELDS.has(key)
+				: SONARR_FILE_TRANSITION_FIELDS.has(key))
+		) {
+			continue;
+		}
+		if (
+			context === "statistics" &&
+			(service === "RADARR"
+				? RADARR_STATISTICS_FILE_TRANSITION_FIELDS.has(key)
+				: SONARR_STATISTICS_FILE_TRANSITION_FIELDS.has(key))
+		) {
+			continue;
+		}
+		result[key] = policyStateOutsideExpectedFileDeletion(
+			entry,
+			service,
+			key === "statistics" ? "statistics" : "nested",
+		);
+	}
+	return result;
+}
+
+function assertExpectedSeriesArrTransition(
+	instance: ServiceInstance,
+	before: Record<string, unknown>,
+	after: Record<string, unknown>,
+	afterItem: CacheItemForEval,
+	transition: SeriesMutationTransition,
+): void {
+	if (instance.service !== "RADARR" && instance.service !== "SONARR") {
+		throw new Error("Unsupported ARR service for cleanup policy mutation");
+	}
+	if (transition === "unchanged") {
+		if (mutationPolicyFingerprint(before) !== mutationPolicyFingerprint(after)) {
+			throw new Error("Live ARR policy state changed before the authorized mutation");
+		}
+		return;
+	}
+	if (
+		mutationPolicyFingerprint(policyStateOutsideExpectedFileDeletion(before, instance.service)) !==
+		mutationPolicyFingerprint(policyStateOutsideExpectedFileDeletion(after, instance.service))
+	) {
+		throw new Error("Live ARR policy state changed outside the expected file transition");
+	}
+	if (afterItem.hasFile || afterItem.sizeOnDisk !== 0n) {
+		throw new Error("ARR did not expose the expected complete file-deletion transition");
+	}
+	const evidence = deriveArrPolicyEvidence(
+		instance.service === "RADARR" ? "radarr" : "sonarr",
+		after,
+	);
+	if (!evidence.hasFile || !evidence.sizeOnDisk) {
+		throw new Error("ARR did not provide complete post-file-deletion policy evidence");
+	}
+	if (instance.service === "RADARR") {
+		if (
+			after.hasFile !== false ||
+			after.sizeOnDisk !== 0 ||
+			(typeof after.movieFileId === "number" && after.movieFileId > 0) ||
+			(typeof after.movieFile === "object" && after.movieFile !== null)
+		) {
+			throw new Error("Radarr's post-file-deletion state was missing or ambiguous");
+		}
+		return;
+	}
+	const statistics =
+		typeof after.statistics === "object" && after.statistics !== null
+			? (after.statistics as Record<string, unknown>)
+			: null;
+	if (statistics?.episodeFileCount !== 0 || statistics.sizeOnDisk !== 0) {
+		throw new Error("Sonarr's post-file-deletion statistics were missing or ambiguous");
+	}
+}
+
+export async function assertCurrentSeriesMutationAuthority(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	instance: ServiceInstance,
+	arrItemId: number,
+	expectedRule: { matchedRuleId: string; action: RuleAction },
+	snapshot: MutationPolicySnapshot,
+): Promise<AuthorizedSeriesMutationPolicy> {
+	try {
+		assertMutationPolicySnapshotFresh(snapshot);
+		if (instance.userId !== userId) {
+			throw new Error("The live ARR instance does not belong to the cleanup owner");
+		}
+		const { rawItem, item } = await loadLiveSeriesPolicyItem(
+			deps,
+			instance,
+			arrItemId,
+			snapshot.rules,
+		);
+		await assertSeriesMutationInstanceStillCurrent(deps, userId, instance);
+		const policy = evaluateItemMutationPolicyStateViaEngine(
+			item,
+			snapshot.rules,
+			instance.service,
+			snapshot.ctx,
+			snapshot.failedSources,
+		);
+		if (
+			policy.kind !== "cleanup" ||
+			policy.match.ruleId !== expectedRule.matchedRuleId ||
+			policy.match.action !== expectedRule.action
+		) {
+			throw new Error("The exact matched cleanup policy is no longer authoritative");
+		}
+		return { snapshot, rawItem, policyItem: item };
+	} catch (error) {
+		deps.log.warn(
+			{ err: error, instanceId: instance.id, arrItemId, ruleId: expectedRule.matchedRuleId },
+			"Cleanup could not revalidate current series/movie policy authority",
+		);
+		throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+			"Skipped for safety: live ARR state, current cleanup precedence, retention policy, or required provider evidence could not re-authorize this item.",
+		);
+	}
+}
+
+export async function assertCurrentSeriesPostStepMutationAuthority(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	instance: ServiceInstance,
+	arrItemId: number,
+	expectedRule: { matchedRuleId: string; action: RuleAction },
+	authorizedPolicy: AuthorizedSeriesMutationPolicy,
+	transition: SeriesMutationTransition,
+	getSnapshot: () => Promise<MutationPolicySnapshot> = createMutationPolicySnapshotGetter(
+		deps,
+		userId,
+		authorizedPolicy.snapshot.configFingerprint,
+	),
+): Promise<Record<string, unknown>> {
+	try {
+		const currentSnapshot = await getSnapshot();
+		assertMutationPolicySnapshotFresh(currentSnapshot);
+		if (
+			currentSnapshot.configFingerprint !== authorizedPolicy.snapshot.configFingerprint ||
+			currentSnapshot.ruleFingerprint !== authorizedPolicy.snapshot.ruleFingerprint ||
+			currentSnapshot.providerTopologyFingerprint !==
+				authorizedPolicy.snapshot.providerTopologyFingerprint
+		) {
+			throw new Error(
+				"Cleanup rules, settings, or provider topology changed after the first write",
+			);
+		}
+		const { rawItem, item } = await loadLiveSeriesPolicyItem(
+			deps,
+			instance,
+			arrItemId,
+			currentSnapshot.rules,
+		);
+		await assertSeriesMutationInstanceStillCurrent(deps, userId, instance);
+		assertExpectedSeriesArrTransition(
+			instance,
+			authorizedPolicy.rawItem,
+			rawItem,
+			item,
+			transition,
+		);
+
+		const cleanupPolicy = evaluateItemMutationPolicyStateViaEngine(
+			authorizedPolicy.policyItem,
+			currentSnapshot.rules,
+			instance.service,
+			currentSnapshot.ctx,
+			currentSnapshot.failedSources,
+		);
+		if (
+			cleanupPolicy.kind !== "cleanup" ||
+			cleanupPolicy.match.ruleId !== expectedRule.matchedRuleId ||
+			cleanupPolicy.match.action !== expectedRule.action
+		) {
+			throw new Error("The exact matched cleanup policy is no longer authoritative");
+		}
+		const retentionPolicy = evaluateItemMutationPolicyStateViaEngine(
+			item,
+			currentSnapshot.rules.filter((rule) => rule.retentionMode),
+			instance.service,
+			currentSnapshot.ctx,
+			currentSnapshot.failedSources,
+		);
+		if (retentionPolicy.kind === "retained") {
+			throw new Error("Current retention policy protects the post-step ARR state");
+		}
+		return rawItem;
+	} catch (error) {
+		deps.log.warn(
+			{ err: error, instanceId: instance.id, arrItemId, ruleId: expectedRule.matchedRuleId },
+			"Cleanup could not revalidate post-step series/movie authority",
+		);
+		throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+			"Skipped for safety: the verified post-step ARR state, current retention policy, provider authority, topology, or cleanup configuration could not authorize the next write.",
+		);
+	}
+}
+
+async function assertSeriesMutationInstanceStillCurrent(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	expected: ServiceInstance,
+): Promise<void> {
+	const current = await deps.prisma.serviceInstance.findFirst({
+		where: { id: expected.id, userId, enabled: true },
+	});
+	if (
+		!current ||
+		(current.service !== "RADARR" && current.service !== "SONARR") ||
+		createArrServiceFingerprint(current) !== createArrServiceFingerprint(expected)
+	) {
+		throw new Error("The ARR instance identity changed before the authorized mutation");
+	}
+}
 
 type ProviderEvidenceAuthority = {
 	id: string;
@@ -1370,14 +1976,14 @@ function createRadarrDestructiveMutationAuthority(
 	userId: string,
 	target: CleanupDeleteTarget,
 	safetyPlan: SharedMediaSafetyPlan,
-	assertExecutionAllowed?: () => Promise<void>,
+	assertExecutionAllowed?: MutationAuthorityCheck,
 	postFileOwnershipPlan?: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>,
-): () => Promise<void> {
+): MutationAuthorityCheck {
 	let fileDeleteAuthorityConsumed = false;
 	const ownershipPlan = safetyPlan.kind === "verified_radarr" ? safetyPlan : postFileOwnershipPlan;
 
-	return async () => {
-		await assertExecutionAllowed?.();
+	return async (evidence) => {
+		const authorizedResource = await assertExecutionAllowed?.(evidence);
 		if (safetyPlan.kind === "verified_radarr_empty") {
 			if (postFileOwnershipPlan && postFileOwnershipPlan.ownership.length > 0) {
 				await assertVerifiedRadarrPeerOwnershipRetained(
@@ -1386,7 +1992,7 @@ function createRadarrDestructiveMutationAuthority(
 					target.arrItemId,
 					postFileOwnershipPlan,
 				);
-				return;
+				return authorizedResource;
 			}
 			const context = createSharedPlexSafetyContext();
 			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -1400,10 +2006,10 @@ function createRadarrDestructiveMutationAuthority(
 					"Skipped for safety: verified Radarr ownership changed at the mutation boundary. Run cleanup again before deleting the record.",
 				);
 			}
-			return;
+			return authorizedResource;
 		}
-		if (!ownershipPlan) return;
-		if (ownershipPlan.ownership.length === 0) return;
+		if (!ownershipPlan) return authorizedResource;
+		if (ownershipPlan.ownership.length === 0) return authorizedResource;
 		if (!fileDeleteAuthorityConsumed && safetyPlan.kind === "verified_radarr") {
 			const context = createSharedPlexSafetyContext();
 			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -1418,9 +2024,10 @@ function createRadarrDestructiveMutationAuthority(
 				);
 			}
 			fileDeleteAuthorityConsumed = true;
-			return;
+			return authorizedResource;
 		}
 		await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, ownershipPlan);
+		return authorizedResource;
 	};
 }
 
@@ -1429,11 +2036,11 @@ function createSonarrDestructiveMutationAuthority(
 	userId: string,
 	target: CleanupDeleteTarget,
 	safetyPlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
-	assertExecutionAllowed?: () => Promise<void>,
-): () => Promise<void> {
+	assertExecutionAllowed?: MutationAuthorityCheck,
+): MutationAuthorityCheck {
 	let fileDeleteAuthorityConsumed = false;
-	return async () => {
-		await assertExecutionAllowed?.();
+	return async (evidence) => {
+		const authorizedResource = await assertExecutionAllowed?.(evidence);
 		if (fileDeleteAuthorityConsumed || safetyPlan.files.episodeFiles.length === 0) {
 			if (safetyPlan.ownership.length === 0) {
 				const context = createSharedPlexSafetyContext();
@@ -1452,10 +2059,10 @@ function createSonarrDestructiveMutationAuthority(
 						"Skipped for safety: verified Sonarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
 					);
 				}
-				return;
+				return authorizedResource;
 			}
 			await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
-			return;
+			return authorizedResource;
 		}
 		const context = createSharedPlexSafetyContext();
 		const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
@@ -1470,6 +2077,7 @@ function createSonarrDestructiveMutationAuthority(
 			);
 		}
 		fileDeleteAuthorityConsumed = true;
+		return authorizedResource;
 	};
 }
 
@@ -1480,9 +2088,9 @@ function createSonarrEpisodeMutationAuthority(
 	target: CleanupDeleteTarget,
 	safetyPlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr_episode" }>,
 	expectedRule: { matchedRuleId: string; action: RuleAction },
-	assertExecutionAllowed?: () => Promise<void>,
+	assertExecutionAllowed?: MutationAuthorityCheck,
 	cleanupRunClaimToken?: string,
-): () => Promise<void> {
+): MutationAuthorityCheck {
 	let revalidationCount = 0;
 	return async () => {
 		await assertExecutionAllowed?.();
@@ -1548,6 +2156,7 @@ function createSonarrEpisodeMutationAuthority(
 			cleanupRunClaimToken,
 		);
 		await assertExecutionAllowed?.();
+		return undefined;
 	};
 }
 
@@ -2911,9 +3520,25 @@ async function executeQueuedCleanupItems(
 	const { prisma, arrClientFactory, log } = deps;
 	const currentConfig = await prisma.libraryCleanupConfig.findUnique({
 		where: { userId },
-		select: { respectQuiSeeding: true },
+		select: {
+			id: true,
+			enabled: true,
+			dryRunMode: true,
+			requireApproval: true,
+			maxRemovalsPerRun: true,
+			respectQuiSeeding: true,
+		},
 	});
 	const currentRespectQuiSeeding = currentConfig?.respectQuiSeeding === true;
+	const expectedConfigFingerprint = currentConfig
+		? completeMutationConfigFingerprint(currentConfig)
+		: undefined;
+	const getMutationPolicySnapshot = createMutationPolicySnapshotGetter(
+		deps,
+		userId,
+		expectedConfigFingerprint,
+		options.cleanupRunClaimToken,
+	);
 
 	// Atomically transition approved → executing to prevent double-execution
 	// Also enforce expiry — don't execute items past their expiration
@@ -3403,9 +4028,46 @@ async function executeQueuedCleanupItems(
 						approval.itemType,
 					);
 				}
-				const assertMutationAuthority = async () => {
+				let authorizedSeriesPolicy: AuthorizedSeriesMutationPolicy | undefined;
+				const assertMutationAuthority: MutationAuthorityCheck = async (evidence) => {
 					await options.assertExecutionAllowed?.();
+					let authorizedResource: Record<string, unknown> | undefined;
+					if (safetyPlan!.kind !== "verified_sonarr_episode") {
+						if (!evidence || !("seriesTransition" in evidence)) {
+							throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+								"Skipped for safety: the expected ARR mutation transition was unavailable.",
+							);
+						}
+						if (!authorizedSeriesPolicy) {
+							if (evidence.seriesTransition !== "unchanged") {
+								throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+									"Skipped for safety: no original ARR policy state was captured before the file transition.",
+								);
+							}
+							authorizedSeriesPolicy = await assertCurrentSeriesMutationAuthority(
+								deps,
+								userId,
+								mutationInstance,
+								approval.arrItemId,
+								{ matchedRuleId: approval.matchedRuleId, action },
+								await getMutationPolicySnapshot(),
+							);
+							authorizedResource = authorizedSeriesPolicy.rawItem;
+						} else {
+							authorizedResource = await assertCurrentSeriesPostStepMutationAuthority(
+								deps,
+								userId,
+								mutationInstance,
+								approval.arrItemId,
+								{ matchedRuleId: approval.matchedRuleId, action },
+								authorizedSeriesPolicy,
+								evidence.seriesTransition,
+								getMutationPolicySnapshot,
+							);
+						}
+					}
 					mutationBudgetConsumedIds.add(approval.id);
+					return authorizedResource;
 				};
 				const mutationTarget: CleanupDeleteTarget = {
 					instanceId: approval.instanceId,
@@ -6346,6 +7008,12 @@ export async function executeDirectRemoval(
 	let retriedUnmonitored = 0;
 	let retriedFilesDeleted = 0;
 	const sharedPlexSafetyContext = createSharedPlexSafetyContext();
+	const getMutationPolicySnapshot = createMutationPolicySnapshotGetter(
+		deps,
+		userId,
+		completeMutationConfigFingerprint(config),
+		cleanupRunClaimToken,
+	);
 	const configuredRunLimitIsValid =
 		Number.isSafeInteger(config.maxRemovalsPerRun) &&
 		config.maxRemovalsPerRun > 0 &&
@@ -6687,6 +7355,45 @@ export async function executeDirectRemoval(
 				item.cacheItem.arrItemId,
 				item.cacheItem.itemType,
 			);
+			let authorizedSeriesPolicy: AuthorizedSeriesMutationPolicy | undefined;
+			const assertDirectExecutionAuthority: MutationAuthorityCheck = async (evidence) => {
+				await assertRunLease?.();
+				if (safetyPlan!.kind === "verified_sonarr_episode") return;
+				if (!evidence || !("seriesTransition" in evidence)) {
+					throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+						"Skipped for safety: the expected ARR mutation transition was unavailable.",
+					);
+				}
+				let authorizedResource: Record<string, unknown>;
+				if (!authorizedSeriesPolicy) {
+					if (evidence.seriesTransition !== "unchanged") {
+						throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+							"Skipped for safety: no original ARR policy state was captured before the file transition.",
+						);
+					}
+					authorizedSeriesPolicy = await assertCurrentSeriesMutationAuthority(
+						deps,
+						userId,
+						mutationInstance,
+						item.cacheItem.arrItemId,
+						{ matchedRuleId: item.match.ruleId, action: ruleAction },
+						await getMutationPolicySnapshot(),
+					);
+					authorizedResource = authorizedSeriesPolicy.rawItem;
+				} else {
+					authorizedResource = await assertCurrentSeriesPostStepMutationAuthority(
+						deps,
+						userId,
+						mutationInstance,
+						item.cacheItem.arrItemId,
+						{ matchedRuleId: item.match.ruleId, action: ruleAction },
+						authorizedSeriesPolicy,
+						evidence.seriesTransition,
+						getMutationPolicySnapshot,
+					);
+				}
+				return authorizedResource;
+			};
 			const assertDestructiveMutationAuthority =
 				safetyPlan?.kind === "verified_sonarr_episode"
 					? createSonarrEpisodeMutationAuthority(
@@ -6696,7 +7403,7 @@ export async function executeDirectRemoval(
 							{ ...flaggedDeleteTarget(item), action: ruleAction },
 							safetyPlan,
 							{ matchedRuleId: item.match.ruleId, action: ruleAction },
-							assertRunLease,
+							assertDirectExecutionAuthority,
 							cleanupRunClaimToken,
 						)
 					: mutationInstance.service === "RADARR"
@@ -6705,7 +7412,7 @@ export async function executeDirectRemoval(
 								userId,
 								{ ...flaggedDeleteTarget(item), action: ruleAction },
 								safetyPlan!,
-								assertRunLease,
+								assertDirectExecutionAuthority,
 							)
 						: mutationInstance.service === "SONARR" && safetyPlan?.kind === "verified_sonarr"
 							? createSonarrDestructiveMutationAuthority(
@@ -6713,9 +7420,9 @@ export async function executeDirectRemoval(
 									userId,
 									{ ...flaggedDeleteTarget(item), action: ruleAction },
 									safetyPlan,
-									assertRunLease,
+									assertDirectExecutionAuthority,
 								)
-							: assertRunLease;
+							: assertDirectExecutionAuthority;
 
 			if (ruleAction === "unmonitor") {
 				await unmonitorInArr(
@@ -7330,12 +8037,12 @@ async function deleteVerifiedRadarrFile(
 	arrItemId: number,
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>["target"],
 	expected: VerifiedRadarrFileIdentity,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<void> {
 	await assertVerifiedRadarrFileUnchanged(radarr, arrItemId, expectedTarget, expected);
+	await assertMutationAuthority?.({ seriesTransition: "unchanged" });
 	let deleteError: unknown;
 	try {
-		await assertMutationAuthority?.();
 		await radarr.movieFile.delete(expected.movieFileId);
 	} catch (error) {
 		deleteError = error;
@@ -7380,7 +8087,7 @@ async function deleteRadarrRecordWithoutFiles(
 		{ kind: "verified_radarr_empty" }
 	>["target"],
 	deletedFileIds: number[],
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<void> {
 	let lastDeleteError: unknown;
 	for (let attempt = 0; attempt < 2; attempt++) {
@@ -7409,24 +8116,28 @@ async function deleteRadarrRecordWithoutFiles(
 		}
 
 		try {
-			await assertMutationAuthority?.();
+			await assertMutationAuthority?.({
+				seriesTransition: deletedFileIds.length > 0 ? "all_files_deleted" : "unchanged",
+			});
+		} catch (error) {
+			if (deletedFileIds.length === 0) throw error;
+			throw new ArrDeletePartialError({
+				cause: error,
+				service: "RADARR",
+				deletedFileIds,
+				hasRemainingFiles: false,
+				message:
+					"Partial cleanup: the verified Radarr movie file was deleted, but execution authority was lost or changed before the movie record could be removed.",
+			});
+		}
+
+		try {
 			await radarr.movie.delete(arrItemId, {
 				deleteFiles: false,
 				addImportExclusion: false,
 			});
 			return;
 		} catch (error) {
-			if (error instanceof CleanupRunLeaseLostError) {
-				if (deletedFileIds.length === 0) throw error;
-				throw new ArrDeletePartialError({
-					cause: error,
-					service: "RADARR",
-					deletedFileIds,
-					hasRemainingFiles: false,
-					message:
-						"Partial cleanup: the verified Radarr movie file was deleted, but execution authority was lost before the movie record could be removed.",
-				});
-			}
 			lastDeleteError = error;
 			try {
 				await radarr.movie.getById(arrItemId);
@@ -7458,15 +8169,15 @@ async function deleteVerifiedSonarrFiles(
 	arrItemId: number,
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>["target"],
 	expected: VerifiedSonarrFileIdentity,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<number[]> {
 	await assertVerifiedSonarrFilesUnchanged(sonarr, arrItemId, expectedTarget, expected);
 	const expectedIds = expected.episodeFiles.map((file) => file.episodeFileId);
 	if (expectedIds.length === 0) return [];
 
+	await assertMutationAuthority?.({ seriesTransition: "unchanged" });
 	let bulkError: unknown;
 	try {
-		await assertMutationAuthority?.();
 		await sonarr.episodeFile.bulkDelete(expectedIds);
 	} catch (error) {
 		bulkError = error;
@@ -7527,7 +8238,7 @@ async function deleteVerifiedSonarrEpisodeFile(
 	sonarr: InstanceType<typeof SonarrClient>,
 	arrItemId: number,
 	plan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr_episode" }>,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 	monitoredMode: "exact" | "require_unmonitored" = "exact",
 ): Promise<void> {
 	await assertVerifiedSonarrEpisodeUnchanged(sonarr, arrItemId, plan, {
@@ -7599,7 +8310,7 @@ async function deleteSonarrRecordWithoutFiles(
 	expectedTarget: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>["target"],
 	expected: VerifiedSonarrFileIdentity,
 	deletedFileIds: number[],
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<void> {
 	let lastDeleteError: unknown;
 	const emptyExpected: VerifiedSonarrFileIdentity = {
@@ -7642,24 +8353,28 @@ async function deleteSonarrRecordWithoutFiles(
 		}
 
 		try {
-			await assertMutationAuthority?.();
+			await assertMutationAuthority?.({
+				seriesTransition: deletedFileIds.length > 0 ? "all_files_deleted" : "unchanged",
+			});
+		} catch (error) {
+			if (deletedFileIds.length === 0) throw error;
+			throw new ArrDeletePartialError({
+				cause: error,
+				service: "SONARR",
+				deletedFileIds,
+				hasRemainingFiles: false,
+				message:
+					"Partial cleanup: the verified Sonarr episode files were deleted, but execution authority was lost or changed before the series record could be removed.",
+			});
+		}
+
+		try {
 			await sonarr.series.delete(arrItemId, {
 				deleteFiles: false,
 				addImportListExclusion: false,
 			});
 			return;
 		} catch (error) {
-			if (error instanceof CleanupRunLeaseLostError) {
-				if (deletedFileIds.length === 0) throw error;
-				throw new ArrDeletePartialError({
-					cause: error,
-					service: "SONARR",
-					deletedFileIds,
-					hasRemainingFiles: false,
-					message:
-						"Partial cleanup: the verified Sonarr episode files were deleted, but execution authority was lost before the series record could be removed.",
-				});
-			}
 			lastDeleteError = error;
 			try {
 				await sonarr.series.getById(arrItemId);
@@ -7809,7 +8524,7 @@ async function deleteFromArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<void> {
 	const client = arrClientFactory.create(instance);
 
@@ -7930,7 +8645,7 @@ async function unmonitorInArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<void> {
 	if (safetyPlan.kind !== "verified_arr_target" && safetyPlan.kind !== "verified_sonarr_episode") {
 		throw new Error("A verified ARR target identity is required before unmonitoring");
@@ -7942,8 +8657,26 @@ async function unmonitorInArr(
 			const radarr = client as InstanceType<typeof RadarrClient>;
 			const movie = await radarr.movie.getById(arrItemId);
 			assertVerifiedArrTargetUnchanged(instance, movie.tmdbId, movie.path, safetyPlan.target);
-			await assertMutationAuthority?.();
-			await radarr.movie.update(arrItemId, { ...movie, id: arrItemId, monitored: false });
+			const authorizedResource = await assertMutationAuthority?.({
+				seriesTransition: "unchanged",
+			});
+			if (!authorizedResource) {
+				throw new Error("Final Radarr mutation authority did not return the authorized resource");
+			}
+			const authorizedMovie = authorizedResource as Awaited<
+				ReturnType<typeof radarr.movie.getById>
+			>;
+			assertVerifiedArrTargetUnchanged(
+				instance,
+				authorizedMovie.tmdbId,
+				authorizedMovie.path,
+				safetyPlan.target,
+			);
+			await radarr.movie.update(arrItemId, {
+				...authorizedMovie,
+				id: arrItemId,
+				monitored: false,
+			});
 			break;
 		}
 		case "SONARR": {
@@ -7972,9 +8705,23 @@ async function unmonitorInArr(
 			}
 			const series = await sonarr.series.getById(arrItemId);
 			assertVerifiedArrTargetUnchanged(instance, series.tvdbId, series.path, safetyPlan.target);
-			await assertMutationAuthority?.();
+			const authorizedResource = await assertMutationAuthority?.({
+				seriesTransition: "unchanged",
+			});
+			if (!authorizedResource) {
+				throw new Error("Final Sonarr mutation authority did not return the authorized resource");
+			}
+			const authorizedSeries = authorizedResource as Awaited<
+				ReturnType<typeof sonarr.series.getById>
+			>;
+			assertVerifiedArrTargetUnchanged(
+				instance,
+				authorizedSeries.tvdbId,
+				authorizedSeries.path,
+				safetyPlan.target,
+			);
 			await sonarr.series.update(arrItemId, {
-				...series,
+				...authorizedSeries,
 				id: arrItemId,
 				monitored: false,
 			} as Parameters<typeof sonarr.series.update>[1]);
@@ -7994,7 +8741,7 @@ async function deleteFilesFromArr(
 	instance: ServiceInstance,
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
-	assertMutationAuthority?: () => Promise<void>,
+	assertMutationAuthority?: MutationAuthorityCheck,
 ): Promise<boolean> {
 	const client = arrClientFactory.create(instance);
 

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -28,6 +28,7 @@ import type { DataSourceDependency, RuleDocument } from "@arr/shared";
 import {
 	evaluateSingleCondition,
 	getFilterReason,
+	parseAudioChannels,
 	passesCleanupRuleFilters,
 	passesInstanceFilter,
 	passesServiceFilter,
@@ -125,6 +126,312 @@ export function evaluateItemAgainstRulesViaEngine(
 		if (match) return match;
 	}
 	return null;
+}
+
+export type MutationPolicyState =
+	| { kind: "cleanup"; match: RuleMatch }
+	| { kind: "retained"; ruleId: string; evidence: "true" | "unknown" }
+	| { kind: "unknown"; ruleId: string }
+	| { kind: "no_match" };
+
+function storedStringArrayIsValid(value: string | null): boolean {
+	if (value === null) return true;
+	const parsed = safeJsonParse(value) as unknown;
+	return Array.isArray(parsed) && parsed.every((entry) => typeof entry === "string");
+}
+
+function mutationFiltersAreValid(rule: LibraryCleanupRule): boolean {
+	const tags = rule.excludeTags === null ? [] : (safeJsonParse(rule.excludeTags) as unknown);
+	return (
+		storedStringArrayIsValid(rule.serviceFilter) &&
+		storedStringArrayIsValid(rule.instanceFilter) &&
+		storedStringArrayIsValid(rule.excludeTitles) &&
+		storedStringArrayIsValid(rule.plexLibraryFilter) &&
+		Array.isArray(tags) &&
+		tags.every((tag) => typeof tag === "number" && Number.isSafeInteger(tag) && tag >= 0)
+	);
+}
+
+function itemData(item: CacheItemForEval): Record<string, unknown> | null {
+	const parsed = safeJsonParse(item.data) as unknown;
+	return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+		? (parsed as Record<string, unknown>)
+		: null;
+}
+
+function evidenceFlag(data: Record<string, unknown>, flag: string): boolean {
+	const evidence = data._arrDashboardEvidence;
+	return (
+		typeof evidence === "object" &&
+		evidence !== null &&
+		!Array.isArray(evidence) &&
+		(evidence as Record<string, unknown>)[flag] === true
+	);
+}
+
+function hasLanguageEvidence(data: Record<string, unknown>): boolean {
+	if (typeof data.originalLanguage === "string" && data.originalLanguage.trim().length > 0) {
+		return true;
+	}
+	if (typeof data.originalLanguage === "object" && data.originalLanguage !== null) {
+		const name = (data.originalLanguage as Record<string, unknown>).name;
+		if (typeof name === "string" && name.trim().length > 0) return true;
+	}
+	return (
+		Array.isArray(data.languages) &&
+		data.languages.length > 0 &&
+		data.languages.every(
+			(language) =>
+				(typeof language === "string" && language.trim().length > 0) ||
+				(typeof language === "object" &&
+					language !== null &&
+					typeof (language as Record<string, unknown>).name === "string" &&
+					((language as Record<string, unknown>).name as string).trim().length > 0),
+		)
+	);
+}
+
+function hasFileMetadataEvidence(data: Record<string, unknown>, ruleType: string): boolean {
+	if (evidenceFlag(data, "hasFile") && data.hasFile === false) return true;
+	const file =
+		typeof data.movieFile === "object" && data.movieFile !== null
+			? (data.movieFile as Record<string, unknown>)
+			: typeof data.episodeFile === "object" && data.episodeFile !== null
+				? (data.episodeFile as Record<string, unknown>)
+				: null;
+	if (!file) return false;
+	if (ruleType === "video_codec") {
+		return typeof file.videoCodec === "string" && file.videoCodec.trim().length > 0;
+	}
+	if (ruleType === "audio_codec") {
+		return typeof file.audioCodec === "string" && file.audioCodec.trim().length > 0;
+	}
+	if (ruleType === "audio_channels") {
+		return typeof file.audioCodec === "string" && parseAudioChannels(file.audioCodec) !== null;
+	}
+	if (ruleType === "resolution") {
+		return typeof file.resolution === "string" && file.resolution.trim().length > 0;
+	}
+	if (ruleType === "custom_format_score") {
+		return typeof file.customFormatScore === "number" && Number.isFinite(file.customFormatScore);
+	}
+	if (ruleType === "release_group") {
+		return typeof file.releaseGroup === "string" && file.releaseGroup.trim().length > 0;
+	}
+	return false;
+}
+
+function externalIdentity(item: CacheItemForEval): { tmdbId: number | null; key: string | null } {
+	const data = itemData(item);
+	const remoteIds =
+		typeof data?.remoteIds === "object" && data.remoteIds !== null
+			? (data.remoteIds as Record<string, unknown>)
+			: null;
+	const candidate = remoteIds?.tmdbId ?? data?.tmdbId;
+	const tmdbId =
+		typeof candidate === "number" && Number.isSafeInteger(candidate) && candidate > 0
+			? candidate
+			: null;
+	return { tmdbId, key: tmdbId === null ? null : `${item.itemType}:${tmdbId}` };
+}
+
+function ruleTypeHasMutationEvidence(
+	item: CacheItemForEval,
+	ruleType: string,
+	parameters: Record<string, unknown>,
+	instanceService: string,
+	ctx: EvalContext,
+): boolean {
+	const data = itemData(item);
+	if (!data) return false;
+	const { tmdbId, key } = externalIdentity(item);
+
+	switch (ruleType) {
+		case "age":
+			return item.arrAddedAt instanceof Date && !Number.isNaN(item.arrAddedAt.getTime());
+		case "size":
+			return evidenceFlag(data, "sizeOnDisk");
+		case "rating":
+			return evidenceFlag(data, "rating");
+		case "imdb_rating":
+			return instanceService === "RADARR" && evidenceFlag(data, "imdbRating");
+		case "status":
+			return typeof item.status === "string" && item.status.trim().length > 0;
+		case "unmonitored":
+			return evidenceFlag(data, "monitored");
+		case "genre":
+			return Array.isArray(data.genres) && data.genres.every((genre) => typeof genre === "string");
+		case "year_range":
+			return typeof item.year === "number" && Number.isFinite(item.year);
+		case "no_file":
+			return evidenceFlag(data, "hasFile");
+		case "quality_profile":
+			return typeof item.qualityProfileName === "string" && item.qualityProfileName.length > 0;
+		case "language":
+			return hasLanguageEvidence(data);
+		case "runtime":
+			return typeof data.runtime === "number" && Number.isFinite(data.runtime);
+		case "file_path":
+			return (
+				(typeof data.path === "string" && data.path.length > 0) ||
+				(typeof data.rootFolderPath === "string" && data.rootFolderPath.length > 0)
+			);
+		case "tag_match":
+			return evidenceFlag(data, "tags");
+		case "video_codec":
+		case "audio_codec":
+		case "audio_channels":
+		case "resolution":
+		case "custom_format_score":
+		case "release_group":
+			return hasFileMetadataEvidence(data, ruleType);
+		case "hdr_type":
+			return evidenceFlag(data, "hdrType");
+		case "plex_episode_completion":
+			return tmdbId !== null && ctx.plexEpisodeMap?.has(tmdbId) === true;
+		case "jellyfin_episode_completion":
+			return tmdbId !== null && ctx.jellyfinEpisodeMap?.has(tmdbId) === true;
+		case "plex_last_watched":
+		case "plex_watch_count":
+		case "plex_on_deck":
+		case "plex_user_rating":
+		case "plex_watched_by":
+		case "plex_collection":
+		case "plex_label":
+		case "plex_added_at":
+		case "user_retention":
+		case "staleness_score":
+			return key !== null && ctx.plexMap?.has(key) === true;
+		case "recently_active":
+			return (
+				item.arrAddedAt instanceof Date &&
+				!Number.isNaN(item.arrAddedAt.getTime()) &&
+				(parameters.requireActivity !== true || (key !== null && ctx.plexMap?.has(key) === true))
+			);
+		case "jellyfin_last_watched":
+		case "jellyfin_watch_count":
+		case "jellyfin_on_deck":
+		case "jellyfin_user_rating":
+		case "jellyfin_watched_by":
+		case "jellyfin_added_at":
+			return key !== null && ctx.jellyfinMap?.has(key) === true;
+		case "seerr_requested_by":
+		case "seerr_request_age":
+		case "seerr_request_status":
+		case "seerr_is_4k":
+		case "seerr_request_modified_age":
+		case "seerr_modified_by":
+		case "seerr_is_requested":
+		case "seerr_request_count":
+			return key !== null && ctx.seerrMap instanceof Map;
+		case "seerr_requester_watched":
+		case "seerr_requester_not_watched":
+			return key !== null && ctx.seerrMap instanceof Map && ctx.plexMap?.has(key) === true;
+		case "tmdb_list_member":
+		case "trakt_list_member":
+			// Membership rows do not currently carry a per-list generation or
+			// an empty-list marker. Presence of a Map therefore cannot prove
+			// that an absent item is authoritatively `not_in` the live list.
+			return false;
+		default:
+			return false;
+	}
+}
+
+function ruleHasMutationEvidence(
+	item: CacheItemForEval,
+	rule: LibraryCleanupRule,
+	instanceService: string,
+	ctx: EvalContext,
+): boolean {
+	if (!mutationFiltersAreValid(rule)) return false;
+	const data = itemData(item);
+	if (!data) return false;
+	const excludedTags =
+		rule.excludeTags === null ? [] : (safeJsonParse(rule.excludeTags) as unknown[]);
+	if (excludedTags.length > 0 && !evidenceFlag(data, "tags")) return false;
+
+	if (rule.operator || rule.conditions) {
+		if (!rule.operator || !rule.conditions) return false;
+		const conditions = safeJsonParse(rule.conditions) as unknown;
+		if (!Array.isArray(conditions) || conditions.length === 0) return false;
+		return conditions.every((condition) => {
+			if (typeof condition !== "object" || condition === null || Array.isArray(condition)) {
+				return false;
+			}
+			const entry = condition as Record<string, unknown>;
+			return (
+				typeof entry.ruleType === "string" &&
+				typeof entry.parameters === "object" &&
+				entry.parameters !== null &&
+				!Array.isArray(entry.parameters) &&
+				ruleTypeHasMutationEvidence(
+					item,
+					entry.ruleType,
+					entry.parameters as Record<string, unknown>,
+					instanceService,
+					ctx,
+				)
+			);
+		});
+	}
+
+	const parameters = safeJsonParse(rule.parameters) as unknown;
+	return (
+		typeof parameters === "object" &&
+		parameters !== null &&
+		!Array.isArray(parameters) &&
+		ruleTypeHasMutationEvidence(
+			item,
+			rule.ruleType,
+			parameters as Record<string, unknown>,
+			instanceService,
+			ctx,
+		)
+	);
+}
+
+/**
+ * Re-evaluate policy for an irreversible write without allowing normalized
+ * cache defaults or missing provider rows to stand in for current evidence.
+ */
+export function evaluateItemMutationPolicyStateViaEngine(
+	item: CacheItemForEval,
+	rules: LibraryCleanupRule[],
+	instanceService: string,
+	ctx: EvalContext,
+	failedSources?: Set<DataSourceDependency>,
+): MutationPolicyState {
+	const orderedRules = [...rules].sort(
+		(left, right) => left.priority - right.priority || left.id.localeCompare(right.id),
+	);
+	for (const rule of orderedRules) {
+		if (!rule.retentionMode || !rule.enabled) continue;
+		if (!passesCleanupRuleFilters(item, rule, instanceService)) continue;
+		if (
+			ruleUsesUnavailableData(rule, failedSources) ||
+			!ruleHasMutationEvidence(item, rule, instanceService, ctx)
+		) {
+			return { kind: "retained", ruleId: rule.id, evidence: "unknown" };
+		}
+		if (evaluateRuleViaEngine(item, rule, instanceService, ctx)) {
+			return { kind: "retained", ruleId: rule.id, evidence: "true" };
+		}
+	}
+
+	for (const rule of orderedRules) {
+		if (rule.retentionMode || !rule.enabled) continue;
+		if (!passesCleanupRuleFilters(item, rule, instanceService)) continue;
+		if (
+			ruleUsesUnavailableData(rule, failedSources) ||
+			!ruleHasMutationEvidence(item, rule, instanceService, ctx)
+		) {
+			return { kind: "unknown", ruleId: rule.id };
+		}
+		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
+		if (match) return { kind: "cleanup", match };
+	}
+	return { kind: "no_match" };
 }
 
 /** Per-rule breakdown row for the explain endpoint. */


### PR DESCRIPTION
## Summary

- capture immutable cleanup settings, ordered rules, and provider topology before each series or movie mutation boundary
- re-evaluate current Radarr or Sonarr state and retention precedence using explicit live evidence, then verify expected file-state transitions before follow-up writes
- fail closed when the ARR connection changes, policy evidence is incomplete, ratings use zero or missing sentinels, or list membership lacks a complete fresh snapshot
- preserve HDR cleanup support only when ARR explicitly supplies dynamic-range evidence

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- focused mutation-policy and shared Radarr/Sonarr suites: 327 tests passed
- independent data-safety and regression reviews completed with one frozen correction pass

## Risk

This changes deletion-adjacent execution authority. Missing or ambiguous evidence now blocks the mutation instead of falling back to normalized defaults or stale cache absence. No live destructive mutation was run against production instances; populated regression fixtures cover direct, approved, retry, partial-completion, configuration drift, ARR repointing, and post-file transition behavior.