### PR TITLE
feat(cleanup): verify qUI physical files before deletion

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/qui-physical-file-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/qui-physical-file-safety.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	createSharedPlexSafetyContext,
+	verifyFreshQuiPhysicalFileSafety,
+} from "../shared-plex-safety.js";
+import type { CleanupExecutorDeps } from "../types.js";
+
+const log = {
+	warn: vi.fn(),
+	error: vi.fn(),
+	info: vi.fn(),
+} as unknown as CleanupExecutorDeps["log"];
+
+function quiInstance(id: string, overrides: Record<string, unknown> = {}) {
+	return {
+		id,
+		userId: "user-1",
+		service: "QUI",
+		label: id,
+		baseUrl: `http://${id}.internal:7476`,
+		encryptedApiKey: `encrypted-${id}`,
+		encryptionIv: `iv-${id}`,
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
+		enabled: true,
+		hasLocalFilesystemAccess: true,
+		pathPrefix: null,
+		...overrides,
+	};
+}
+
+function makeDeps(
+	options: {
+		instances?: Array<ReturnType<typeof quiInstance>>;
+		hashesByInstance?: Record<string, string[]>;
+		torrentsByInstance?: Record<
+			string,
+			Array<{ hash: string; state: string; instanceId?: number }>
+		>;
+		resolveError?: Error;
+		torrentError?: Error;
+	} = {},
+) {
+	const instances = options.instances ?? [quiInstance("qui-1")];
+	const resolve = vi.fn(async (instanceId: string) => {
+		if (options.resolveError) throw options.resolveError;
+		return {
+			hashes: options.hashesByInstance?.[instanceId] ?? ["movie-hash"],
+			complete: true as const,
+		};
+	});
+	const getTorrentsByHash = vi.fn(async (instanceId: string, hash: string) => {
+		if (options.torrentError) throw options.torrentError;
+		return (
+			options.torrentsByInstance?.[instanceId] ?? [{ hash, state: "pausedUP", instanceId: 7 }]
+		).filter((torrent) => torrent.hash.toLowerCase() === hash.toLowerCase());
+	});
+	const deps = {
+		prisma: {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue(instances),
+			},
+		},
+		quiFileHashIndexFactory: vi.fn(async (instance) => ({
+			resolve: vi.fn(() => resolve(instance.id)),
+		})),
+		quiClientFactory: vi.fn((instance) => ({
+			getTorrentsByHash: vi.fn((hash: string) => getTorrentsByHash(instance.id, hash)),
+		})),
+		log,
+	} as unknown as CleanupExecutorDeps;
+	return { deps, resolve, getTorrentsByHash };
+}
+
+describe("fresh qUI physical-file safety evidence", () => {
+	it("does not inspect qUI when protection is disabled", async () => {
+		const { deps } = makeDeps();
+		const evidence = await verifyFreshQuiPhysicalFileSafety(
+			deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			false,
+		);
+		expect(evidence).toEqual({ enabled: false, instances: [] });
+		expect(deps.prisma.serviceInstance.findMany).not.toHaveBeenCalled();
+	});
+
+	it("is a no-op when no enabled qUI instance exists", async () => {
+		const { deps } = makeDeps({ instances: [] });
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).resolves.toEqual({ enabled: false, instances: [] });
+		expect(deps.quiFileHashIndexFactory).not.toHaveBeenCalled();
+	});
+
+	it("records complete safe evidence for every qUI and every physical-file hash", async () => {
+		const { deps } = makeDeps({
+			instances: [quiInstance("qui-b"), quiInstance("qui-a")],
+			hashesByInstance: {
+				"qui-a": ["primary", "cross-seed"],
+				"qui-b": ["primary"],
+			},
+			torrentsByInstance: {
+				"qui-a": [
+					{ hash: "primary", state: "pausedUP", instanceId: 7 },
+					{ hash: "cross-seed", state: "error", instanceId: 8 },
+				],
+				"qui-b": [{ hash: "primary", state: "pausedDL", instanceId: 3 }],
+			},
+		});
+		const evidence = await verifyFreshQuiPhysicalFileSafety(
+			deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			true,
+		);
+		expect(evidence.enabled).toBe(true);
+		expect(evidence.instances.map((instance) => instance.instanceId)).toEqual(["qui-a", "qui-b"]);
+		expect(evidence.instances[0]!.files[0]!.hashes).toEqual(["cross-seed", "primary"]);
+		expect(evidence.instances[0]!.torrents).toEqual([
+			{ hash: "cross-seed", qbitInstanceId: 8, state: "error" },
+			{ hash: "primary", qbitInstanceId: 7, state: "pausedUP" },
+		]);
+	});
+
+	it.each([
+		"downloading",
+		"uploading",
+		"stalledUP",
+		"stalledDL",
+		"queuedUP",
+		"queuedDL",
+		"checkingUP",
+		"checkingDL",
+		"metaDL",
+		"moving",
+		"forcedUP",
+		"forcedDL",
+	] as const)("blocks the supported active or transitional qUI state %s", async (state) => {
+		const { deps } = makeDeps({
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state, instanceId: 7 }],
+			},
+		});
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow("active or transitional");
+	});
+
+	it.each(["pausedUP", "pausedDL", "error", "missingFiles"] as const)(
+		"records the exact supported inactive qUI state %s",
+		async (state) => {
+			const { deps } = makeDeps({
+				torrentsByInstance: {
+					"qui-1": [{ hash: "movie-hash", state, instanceId: 7 }],
+				},
+			});
+			const evidence = await verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			);
+			expect(evidence.instances[0]!.torrents[0]!.state).toBe(state);
+		},
+	);
+
+	it("fails closed on an unknown or newly introduced qUI state", async () => {
+		const { deps } = makeDeps({
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state: "unknown", instanceId: 7 }],
+			},
+		});
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow("unknown or unsupported");
+	});
+
+	it.each([
+		["unreachable qUI", { torrentError: new Error("offline") }],
+		["incomplete path inventory", { resolveError: new Error("partial walk") }],
+	] as const)("fails closed on %s", async (_label, options) => {
+		const { deps } = makeDeps(options);
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow();
+	});
+
+	it("fails closed when inode ownership and exact-hash inventory disagree", async () => {
+		const { deps } = makeDeps({
+			torrentsByInstance: { "qui-1": [] },
+		});
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow("inode ownership did not match");
+	});
+
+	it("fails closed when qUI returns a mismatched torrent hash", async () => {
+		const { deps } = makeDeps();
+		deps.quiClientFactory = vi.fn(() => ({
+			getTorrentsByHash: vi
+				.fn()
+				.mockResolvedValue([{ hash: "different-hash", state: "pausedUP", instanceId: 7 }]),
+		})) as never;
+
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow("mismatched torrent identity");
+	});
+
+	it("fails closed when qUI cannot identify the owning qBittorrent instance", async () => {
+		const { deps } = makeDeps({
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state: "pausedUP" }],
+			},
+		});
+		await expect(
+			verifyFreshQuiPhysicalFileSafety(
+				deps,
+				createSharedPlexSafetyContext(),
+				"user-1",
+				["/movies/example.mkv"],
+				true,
+			),
+		).rejects.toThrow("owning qBittorrent instance");
+	});
+
+	it("changes the proof when qUI identity or torrent state changes", async () => {
+		const first = makeDeps();
+		const firstEvidence = await verifyFreshQuiPhysicalFileSafety(
+			first.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			true,
+		);
+		const second = makeDeps({
+			instances: [quiInstance("qui-1", { pathPrefix: "/downloads>/data" })],
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state: "error", instanceId: 7 }],
+			},
+		});
+		const secondEvidence = await verifyFreshQuiPhysicalFileSafety(
+			second.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			true,
+		);
+		expect(secondEvidence).not.toEqual(firstEvidence);
+	});
+
+	it("changes the proof when the physical path or inode-owned hash changes", async () => {
+		const first = makeDeps({ hashesByInstance: { "qui-1": ["old-hash"] } });
+		const second = makeDeps({ hashesByInstance: { "qui-1": ["new-hash"] } });
+
+		const firstEvidence = await verifyFreshQuiPhysicalFileSafety(
+			first.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/old/example.mkv"],
+			true,
+		);
+		const secondEvidence = await verifyFreshQuiPhysicalFileSafety(
+			second.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/new/example.mkv"],
+			true,
+		);
+
+		expect(secondEvidence).not.toEqual(firstEvidence);
+	});
+
+	it("preserves directional state so paused upload to paused download is proof drift", async () => {
+		const first = makeDeps({
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state: "pausedUP", instanceId: 7 }],
+			},
+		});
+		const second = makeDeps({
+			torrentsByInstance: {
+				"qui-1": [{ hash: "movie-hash", state: "pausedDL", instanceId: 7 }],
+			},
+		});
+
+		const firstEvidence = await verifyFreshQuiPhysicalFileSafety(
+			first.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			true,
+		);
+		const secondEvidence = await verifyFreshQuiPhysicalFileSafety(
+			second.deps,
+			createSharedPlexSafetyContext(),
+			"user-1",
+			["/movies/example.mkv"],
+			true,
+		);
+
+		expect(secondEvidence).not.toEqual(firstEvidence);
+	});
+});

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -2,6 +2,7 @@ import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { buildMovieItem } from "../../library/movie-normalizer.js";
 import { PlexMovieNotFoundError } from "../../plex/plex-client.js";
+import { withQuiObservationTopologyGuard } from "../../qui/observation-topology-guard.js";
 import {
 	buildCleanupPreviewDetails,
 	cleanupApprovalTargetKey,
@@ -34,6 +35,14 @@ const silentLog = {
 	error: vi.fn(),
 	info: vi.fn(),
 } as unknown as CleanupExecutorDeps["log"];
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
+}
 
 const radarrTargetIdentity = {
 	serviceFingerprint: createArrServiceFingerprint({
@@ -477,6 +486,43 @@ function makeDeps(options: TestOptions = {}) {
 		setLiveMovieIdentity: (tmdbId: number, path: string) => {
 			targetMovie.tmdbId = tmdbId;
 			targetMovie.path = path;
+		},
+	};
+}
+
+function configureQuiSafety(fixture: ReturnType<typeof makeDeps>, initialState = "pausedUP") {
+	const quiInstance = {
+		id: "qui-1",
+		userId: "user-1",
+		service: "QUI",
+		label: "qUI",
+		baseUrl: "http://qui.internal:7476",
+		encryptedApiKey: "encrypted-qui-key",
+		encryptionIv: "qui-iv",
+		encryptedHttpAuthCredentials: null,
+		httpAuthEncryptionIv: null,
+		enabled: true,
+		hasLocalFilesystemAccess: true,
+		pathPrefix: null,
+	};
+	let state = initialState;
+	const getTorrentsByHash = vi.fn(async (hash: string) => [{ hash, state, instanceId: 7 }]);
+	vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(
+		(args) =>
+			(args?.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance])
+				: args?.where?.service === "QUI"
+					? Promise.resolve([quiInstance])
+					: Promise.resolve([fixture.targetInstance])) as never,
+	);
+	fixture.deps.quiClientFactory = vi.fn(() => ({ getTorrentsByHash })) as never;
+	fixture.deps.quiFileHashIndexFactory = vi.fn().mockResolvedValue({
+		resolve: vi.fn().mockResolvedValue({ hashes: ["movie-hash"], complete: true }),
+	});
+	return {
+		getTorrentsByHash,
+		setState: (nextState: string) => {
+			state = nextState;
 		},
 	};
 }
@@ -958,6 +1004,232 @@ describe("shared Plex deletion safety", () => {
 		itemType: "movie",
 		action: "delete",
 	};
+
+	it.each(["delete", "delete_files"] as const)(
+		"blocks direct Radarr %s when qUI becomes active at the final mutation boundary",
+		async (action) => {
+			const fixture = makeDeps({ action, mediaPartCount: 1 });
+			const qui = configureQuiSafety(fixture);
+			qui.getTorrentsByHash
+				.mockResolvedValueOnce([{ hash: "movie-hash", state: "pausedUP", instanceId: 7 }])
+				.mockResolvedValue([{ hash: "movie-hash", state: "stalledUP", instanceId: 7 }]);
+			configureRetryStore(fixture.deps);
+			const flaggedItem = {
+				cacheItem: {
+					instanceId: "radarr-4k",
+					arrItemId: 101,
+					itemType: "movie",
+					title: "Example Movie",
+					year: 2024,
+					...radarrCachedFileIdentity,
+					sizeOnDisk: 2_000n,
+				},
+				match: {
+					ruleId: "rule-1",
+					ruleName: "Remove old movie",
+					reason: "Matched cleanup rule",
+					action,
+				},
+				rating: 8,
+				respectQuiSeeding: true,
+			} as never;
+
+			const result = await executeDirectRemoval(
+				fixture.deps,
+				{
+					id: "config-1",
+					maxRemovalsPerRun: 10,
+					respectQuiSeeding: true,
+					rules: [],
+				} as never,
+				"user-1",
+				[flaggedItem],
+				1,
+				1,
+				Date.now(),
+			);
+
+			expect(result).toMatchObject({ itemsRemoved: 0, itemsFilesDeleted: 0 });
+			expect(result.details).toEqual([
+				expect.objectContaining({
+					action: "skipped",
+					reason: expect.stringContaining("qUI physical-file evidence changed"),
+				}),
+			]);
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["delete", "delete_files"] as const)(
+		"blocks queued Radarr %s when persisted qUI evidence becomes active",
+		async (action) => {
+			const fixture = makeDeps({ action, mediaPartCount: 1 });
+			const qui = configureQuiSafety(fixture);
+			const quiTarget = {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				action,
+				respectQuiSeeding: true,
+			};
+			const context = createSharedPlexSafetyContext();
+			await expect(
+				findSharedPlexDeleteBlocks(fixture.deps, "user-1", [quiTarget], context),
+			).resolves.toEqual(new Map());
+			const plan = context.plans.get(cleanupDeleteTargetKey(quiTarget));
+			if (plan?.kind !== "verified_radarr") throw new Error("Expected Radarr safety plan");
+			qui.setState("stalledUP");
+			configureApprovalStore(
+				fixture.deps,
+				approvalRecord({ action, safetySnapshot: serializeExecutableSafetyPlan(plan) }),
+			);
+
+			const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+			expect(result).toMatchObject({ removed: 0, failed: 1 });
+			expect(fixture.deleteMovieFile).not.toHaveBeenCalled();
+			expect(fixture.deleteMovie).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each(["delete", "delete_files"] as const)(
+		"holds qUI state changes until direct Radarr %s finishes its physical mutation",
+		async (action) => {
+			const fixture = makeDeps({ action, mediaPartCount: 1 });
+			const qui = configureQuiSafety(fixture);
+			configureRetryStore(fixture.deps);
+			const finalProofStarted = deferred();
+			const releaseFinalProof = deferred();
+			const fileMutationStarted = deferred();
+			const releaseFileMutation = deferred();
+			const events: string[] = [];
+			qui.getTorrentsByHash
+				.mockResolvedValueOnce([{ hash: "movie-hash", state: "pausedUP", instanceId: 7 }])
+				.mockImplementationOnce(async (hash: string) => {
+					events.push("proof");
+					finalProofStarted.resolve();
+					await releaseFinalProof.promise;
+					return [{ hash, state: "pausedUP", instanceId: 7 }];
+				});
+			fixture.deleteMovieFile.mockImplementationOnce(async () => {
+				events.push("file-start");
+				fileMutationStarted.resolve();
+				await releaseFileMutation.promise;
+				events.push("file-end");
+			});
+			const flaggedItem = {
+				cacheItem: {
+					instanceId: "radarr-4k",
+					arrItemId: 101,
+					itemType: "movie",
+					title: "Example Movie",
+					year: 2024,
+					...radarrCachedFileIdentity,
+					sizeOnDisk: 2_000n,
+				},
+				match: {
+					ruleId: "rule-1",
+					ruleName: "Remove old movie",
+					reason: "Matched cleanup rule",
+					action,
+				},
+				rating: 8,
+				respectQuiSeeding: true,
+			} as never;
+
+			const execution = executeDirectRemoval(
+				fixture.deps,
+				{
+					id: "config-1",
+					maxRemovalsPerRun: 10,
+					respectQuiSeeding: true,
+					rules: [],
+				} as never,
+				"user-1",
+				[flaggedItem],
+				1,
+				1,
+				Date.now(),
+			);
+			await finalProofStarted.promise;
+			const stateChange = withQuiObservationTopologyGuard("user-1", async () => {
+				events.push("state-change");
+			});
+			await Promise.resolve();
+			expect(events).toEqual(["proof"]);
+
+			releaseFinalProof.resolve();
+			await fileMutationStarted.promise;
+			await Promise.resolve();
+			expect(events).toEqual(["proof", "file-start"]);
+
+			releaseFileMutation.resolve();
+			await execution;
+			await stateChange;
+			expect(events).toEqual(["proof", "file-start", "file-end", "state-change"]);
+		},
+	);
+
+	it.each(["delete", "delete_files"] as const)(
+		"holds qUI state changes until queued Radarr %s finishes its physical mutation",
+		async (action) => {
+			const fixture = makeDeps({ action, mediaPartCount: 1 });
+			const qui = configureQuiSafety(fixture);
+			const quiTarget = {
+				instanceId: "radarr-4k",
+				arrItemId: 101,
+				itemType: "movie",
+				action,
+				respectQuiSeeding: true,
+			};
+			const context = createSharedPlexSafetyContext();
+			await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [quiTarget], context);
+			const plan = context.plans.get(cleanupDeleteTargetKey(quiTarget));
+			if (plan?.kind !== "verified_radarr") throw new Error("Expected Radarr safety plan");
+			configureApprovalStore(
+				fixture.deps,
+				approvalRecord({ action, safetySnapshot: serializeExecutableSafetyPlan(plan) }),
+			);
+			const finalProofStarted = deferred();
+			const releaseFinalProof = deferred();
+			const fileMutationStarted = deferred();
+			const releaseFileMutation = deferred();
+			const events: string[] = [];
+			qui.getTorrentsByHash
+				.mockResolvedValueOnce([{ hash: "movie-hash", state: "pausedUP", instanceId: 7 }])
+				.mockImplementationOnce(async (hash: string) => {
+					events.push("proof");
+					finalProofStarted.resolve();
+					await releaseFinalProof.promise;
+					return [{ hash, state: "pausedUP", instanceId: 7 }];
+				});
+			fixture.deleteMovieFile.mockImplementationOnce(async () => {
+				events.push("file-start");
+				fileMutationStarted.resolve();
+				await releaseFileMutation.promise;
+				events.push("file-end");
+			});
+
+			const execution = executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+			await finalProofStarted.promise;
+			const stateChange = withQuiObservationTopologyGuard("user-1", async () => {
+				events.push("state-change");
+			});
+			await Promise.resolve();
+			expect(events).toEqual(["proof"]);
+
+			releaseFinalProof.resolve();
+			await fileMutationStarted.promise;
+			await Promise.resolve();
+			expect(events).toEqual(["proof", "file-start"]);
+
+			releaseFileMutation.resolve();
+			await execution;
+			await stateChange;
+			expect(events).toEqual(["proof", "file-start", "file-end", "state-change"]);
+		},
+	);
 
 	it("keys file-changing episode work by physical file and unmonitoring by episode", () => {
 		const episodeTarget = (

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -470,7 +470,9 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		} as unknown as CleanupExecutorDeps["arrClientFactory"],
 		plexClientFactory,
 		quiClientFactory: vi.fn(() => ({
-			getTorrentsByHash: vi.fn().mockResolvedValue([{ hash: "episode-hash", state: "pausedUP" }]),
+			getTorrentsByHash: vi
+				.fn()
+				.mockResolvedValue([{ hash: "episode-hash", state: "pausedUP", instanceId: 7 }]),
 		})),
 		quiFileHashIndexFactory: vi.fn().mockResolvedValue({
 			resolve: vi.fn().mockResolvedValue({ hashes: ["episode-hash"], complete: true }),

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -33,6 +33,7 @@ import { isNotFoundError } from "../arr/client-factory.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
 import { buildMovieFile } from "../library/movie-normalizer.js";
 import { plexConnectionFingerprint } from "../plex/service-instance-fingerprint.js";
+import { withQuiObservationTopologyGuard } from "../qui/observation-topology-guard.js";
 import type {
 	LibraryCleanupApproval,
 	LibraryCleanupConfig,
@@ -1240,6 +1241,7 @@ function buildPostPartialRetrySnapshot(
 				seriesPath: safetyPlan.files.seriesPath,
 				episodeFiles: [],
 			},
+			quiEvidence: undefined,
 		},
 		providerEvidence,
 		"post_partial_mutation",
@@ -1254,6 +1256,49 @@ function verifiedTargetsEqual(
 		{ kind: "verified_arr_target", target: left },
 		{ kind: "verified_arr_target", target: right },
 	);
+}
+
+function quiEvidenceMatchesRemainingFiles(
+	approvedPlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
+	livePlan: Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_sonarr" }>,
+): boolean {
+	const approvedEvidence = approvedPlan.quiEvidence ?? { enabled: false, instances: [] };
+	const liveEvidence = livePlan.quiEvidence ?? { enabled: false, instances: [] };
+	if (approvedEvidence.enabled !== liveEvidence.enabled) return false;
+	if (!liveEvidence.enabled) return true;
+
+	const liveInstancesById = new Map(
+		liveEvidence.instances.map((instance) => [instance.instanceId, instance]),
+	);
+	if (
+		approvedEvidence.instances.length !== liveEvidence.instances.length ||
+		approvedEvidence.instances.some(
+			(instance) =>
+				liveInstancesById.get(instance.instanceId)?.serviceFingerprint !==
+				instance.serviceFingerprint,
+		)
+	) {
+		return false;
+	}
+
+	const liveHashes = new Set(
+		liveEvidence.instances.flatMap((instance) => instance.files.flatMap((file) => file.hashes)),
+	);
+	const projectedApprovedEvidence = {
+		enabled: true as const,
+		instances: approvedEvidence.instances.map((approvedInstance) => {
+			const liveInstance = liveInstancesById.get(approvedInstance.instanceId)!;
+			const livePathKeys = new Set(liveInstance.files.map((file) => JSON.stringify(file.fullPath)));
+			return {
+				...approvedInstance,
+				files: approvedInstance.files.filter((file) =>
+					livePathKeys.has(JSON.stringify(file.fullPath)),
+				),
+				torrents: approvedInstance.torrents.filter((torrent) => liveHashes.has(torrent.hash)),
+			};
+		}),
+	};
+	return JSON.stringify(projectedApprovedEvidence) === JSON.stringify(liveEvidence);
 }
 
 /**
@@ -1283,8 +1328,10 @@ function isVerifiedFileRemainder(
 	const approvedFiles = new Map(
 		approvedPlan.files.episodeFiles.map((file) => [file.episodeFileId, JSON.stringify(file)]),
 	);
-	return livePlan.files.episodeFiles.every(
-		(file) => approvedFiles.get(file.episodeFileId) === JSON.stringify(file),
+	return (
+		livePlan.files.episodeFiles.every(
+			(file) => approvedFiles.get(file.episodeFileId) === JSON.stringify(file),
+		) && quiEvidenceMatchesRemainingFiles(approvedPlan, livePlan)
 	);
 }
 
@@ -1491,7 +1538,7 @@ function toDeleteTargets(items: FlaggedItem[]): CleanupDeleteTarget[] {
 		episodeFileId: item.episodeTarget?.episodeFileId,
 		episodeFileConsumerIds: item.episodeTarget?.episodeFileConsumerIds,
 		plexWatchEvidence: item.episodeTarget?.plexWatchEvidence,
-		respectQuiSeeding: item.episodeTarget?.respectQuiSeeding,
+		respectQuiSeeding: item.respectQuiSeeding ?? item.episodeTarget?.respectQuiSeeding,
 		episodeFileInfoHash: item.episodeTarget?.fileInfoHash,
 		episodeFileTorrentState: item.episodeTarget?.fileTorrentState,
 	}));
@@ -1505,7 +1552,13 @@ function episodePlanTargetFields(
 	plan: ExecutableSharedMediaSafetyPlan | null | undefined,
 	currentRespectQuiSeeding = false,
 ): Partial<CleanupDeleteTarget> {
-	if (plan?.kind !== "verified_sonarr_episode") return {};
+	if (!plan) return { respectQuiSeeding: currentRespectQuiSeeding };
+	const respectQuiSeeding =
+		currentRespectQuiSeeding ||
+		(plan.kind !== "verified_arr_target" &&
+			plan.kind !== "verified_radarr_empty" &&
+			plan.quiEvidence?.enabled === true);
+	if (plan.kind !== "verified_sonarr_episode") return { respectQuiSeeding };
 	return {
 		episodeFileId: plan.episode.episodeFileId,
 		episodeFileConsumerIds: plan.episode.episodeFileConsumerIds,
@@ -1518,7 +1571,7 @@ function episodePlanTargetFields(
 				refreshedAt: plan.watchProof.refreshedAt,
 			},
 		],
-		respectQuiSeeding: currentRespectQuiSeeding || plan.quiIdentity.enabled,
+		respectQuiSeeding: respectQuiSeeding || plan.quiIdentity.enabled,
 		episodeFileInfoHash: plan.quiIdentity.infoHash,
 		episodeFileTorrentState: plan.quiIdentity.torrentState,
 	};
@@ -1799,7 +1852,17 @@ async function buildEvaluatedCacheSafetyPlan(
 		return buildCacheTargetSafetyPlan(data, item.itemType, livePlan.target);
 	}
 	if (livePlan.kind === "verified_radarr" || livePlan.kind === "verified_radarr_empty") {
-		return buildRadarrCacheSafetyPlan(data, item.hasFile, livePlan.target);
+		const cachePlan = buildRadarrCacheSafetyPlan(data, item.hasFile, livePlan.target);
+		return cachePlan?.kind === "verified_radarr" && livePlan.kind === "verified_radarr"
+			? {
+					...cachePlan,
+					quiEvidence: livePlan.quiEvidence,
+					peers: livePlan.peers,
+					peerInventoryComplete: livePlan.peerInventoryComplete,
+					ownership: livePlan.ownership,
+					targetDeleteNotifications: livePlan.targetDeleteNotifications,
+				}
+			: cachePlan;
 	}
 	const seriesPath =
 		data && typeof data === "object" && "path" in data
@@ -1852,6 +1915,7 @@ async function buildEvaluatedCacheSafetyPlan(
 			),
 			watchProof: livePlan.watchProof,
 			quiIdentity: livePlan.quiIdentity,
+			quiEvidence: livePlan.quiEvidence,
 			peers: livePlan.peers,
 			peerInventoryComplete: livePlan.peerInventoryComplete,
 			ownership: livePlan.ownership,
@@ -1861,6 +1925,7 @@ async function buildEvaluatedCacheSafetyPlan(
 	return cachePlan?.kind === "verified_sonarr"
 		? {
 				...cachePlan,
+				quiEvidence: livePlan.quiEvidence,
 				peers: livePlan.peers,
 				peerInventoryComplete: livePlan.peerInventoryComplete,
 				ownership: livePlan.ownership,
@@ -2009,8 +2074,13 @@ function createRadarrDestructiveMutationAuthority(
 			return authorizedResource;
 		}
 		if (!ownershipPlan) return authorizedResource;
-		if (ownershipPlan.ownership.length === 0) return authorizedResource;
-		if (!fileDeleteAuthorityConsumed && safetyPlan.kind === "verified_radarr") {
+		const requiresPhysicalRevalidation =
+			ownershipPlan.ownership.length > 0 || ownershipPlan.quiEvidence?.enabled === true;
+		if (
+			!fileDeleteAuthorityConsumed &&
+			safetyPlan.kind === "verified_radarr" &&
+			requiresPhysicalRevalidation
+		) {
 			const context = createSharedPlexSafetyContext();
 			const blocks = await findSharedPlexDeleteBlocks(deps, userId, [target], context);
 			const livePlan = asExecutableSafetyPlan(context.plans.get(cleanupDeleteTargetKey(target)));
@@ -2020,12 +2090,13 @@ function createRadarrDestructiveMutationAuthority(
 				!executableSafetyPlansEqual(ownershipPlan, livePlan)
 			) {
 				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
-					"Skipped for safety: verified Radarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+					"Skipped for safety: verified Radarr ownership changed, or qUI physical-file evidence changed at the mutation boundary. Run cleanup again before deleting the file.",
 				);
 			}
 			fileDeleteAuthorityConsumed = true;
 			return authorizedResource;
 		}
+		if (ownershipPlan.ownership.length === 0) return authorizedResource;
 		await assertVerifiedRadarrPeerOwnershipRetained(deps, userId, target.arrItemId, ownershipPlan);
 		return authorizedResource;
 	};
@@ -2041,6 +2112,19 @@ function createSonarrDestructiveMutationAuthority(
 	let fileDeleteAuthorityConsumed = false;
 	return async (evidence) => {
 		const authorizedResource = await assertExecutionAllowed?.(evidence);
+		if (
+			fileDeleteAuthorityConsumed &&
+			safetyPlan.ownership.length === 0 &&
+			safetyPlan.quiEvidence?.enabled === true
+		) {
+			// qUI-only authority is consumed immediately before the one physical
+			// file mutation. Later record-only writes must not stat the removed path.
+			return authorizedResource;
+		}
+		if (fileDeleteAuthorityConsumed && safetyPlan.ownership.length > 0) {
+			await assertVerifiedSonarrPeerOwnershipRetained(deps, userId, target.arrItemId, safetyPlan);
+			return authorizedResource;
+		}
 		if (fileDeleteAuthorityConsumed || safetyPlan.files.episodeFiles.length === 0) {
 			if (safetyPlan.ownership.length === 0) {
 				const context = createSharedPlexSafetyContext();
@@ -2073,7 +2157,7 @@ function createSonarrDestructiveMutationAuthority(
 			!executableSafetyPlansEqual(safetyPlan, livePlan)
 		) {
 			throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
-				"Skipped for safety: verified Sonarr ownership changed at the mutation boundary. Run cleanup again before deleting the file.",
+				"Skipped for safety: verified Sonarr ownership changed, or qUI physical-file evidence changed at the mutation boundary. Run cleanup again before deleting the file.",
 			);
 		}
 		fileDeleteAuthorityConsumed = true;
@@ -2119,7 +2203,7 @@ function createSonarrEpisodeMutationAuthority(
 				));
 		if (blocks.has(targetKey) || !plansMatch) {
 			throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
-				"Skipped for safety: the verified Sonarr episode identity or Plex ownership changed at the mutation boundary.",
+				"Skipped for safety: the verified Sonarr episode identity, Plex ownership, or qUI physical-file evidence changed at the mutation boundary.",
 			);
 		}
 		if (
@@ -2158,6 +2242,14 @@ function createSonarrEpisodeMutationAuthority(
 		await assertExecutionAllowed?.();
 		return undefined;
 	};
+}
+
+async function withQuiPhysicalMutationGuard<T>(
+	userId: string,
+	respectQuiSeeding: boolean,
+	operation: () => Promise<T>,
+): Promise<T> {
+	return respectQuiSeeding ? withQuiObservationTopologyGuard(userId, operation) : operation();
 }
 
 function withSharedPlexWarning(warnings: string[], blockCount: number): string[] {
@@ -4178,12 +4270,17 @@ async function executeQueuedCleanupItems(
 								);
 							});
 				} else if (action === "delete_files") {
-					const deletedFiles = await deleteFilesFromArr(
-						arrClientFactory,
-						mutationInstance,
-						approval.arrItemId,
-						safetyPlan!,
-						assertDestructiveMutationAuthority,
+					const deletedFiles = await withQuiPhysicalMutationGuard(
+						userId,
+						mutationTarget.respectQuiSeeding === true,
+						() =>
+							deleteFilesFromArr(
+								arrClientFactory,
+								mutationInstance,
+								approval.arrItemId,
+								safetyPlan!,
+								assertDestructiveMutationAuthority,
+							),
 					);
 					executionCompleted = true;
 					reconciledWithoutMutation = !deletedFiles;
@@ -4213,12 +4310,17 @@ async function executeQueuedCleanupItems(
 								);
 							});
 				} else {
-					await deleteFromArr(
-						arrClientFactory,
-						mutationInstance,
-						approval.arrItemId,
-						safetyPlan!,
-						assertDestructiveMutationAuthority,
+					await withQuiPhysicalMutationGuard(
+						userId,
+						mutationTarget.respectQuiSeeding === true,
+						() =>
+							deleteFromArr(
+								arrClientFactory,
+								mutationInstance,
+								approval.arrItemId,
+								safetyPlan!,
+								assertDestructiveMutationAuthority,
+							),
 					);
 					executionCompleted = true;
 					await reconcileSonarrEpisodeFileCache(
@@ -6165,6 +6267,7 @@ async function evaluateAllItems(
 					cacheItem: item,
 					match,
 					rating: extractRating(item),
+					respectQuiSeeding,
 				});
 			}
 			if (
@@ -7394,13 +7497,17 @@ export async function executeDirectRemoval(
 				}
 				return authorizedResource;
 			};
+			const mutationTarget: CleanupDeleteTarget = {
+				...flaggedDeleteTarget(item),
+				action: ruleAction,
+			};
 			const assertDestructiveMutationAuthority =
 				safetyPlan?.kind === "verified_sonarr_episode"
 					? createSonarrEpisodeMutationAuthority(
 							deps,
 							userId,
 							mutationInstance,
-							{ ...flaggedDeleteTarget(item), action: ruleAction },
+							mutationTarget,
 							safetyPlan,
 							{ matchedRuleId: item.match.ruleId, action: ruleAction },
 							assertDirectExecutionAuthority,
@@ -7410,7 +7517,7 @@ export async function executeDirectRemoval(
 						? createRadarrDestructiveMutationAuthority(
 								deps,
 								userId,
-								{ ...flaggedDeleteTarget(item), action: ruleAction },
+								mutationTarget,
 								safetyPlan!,
 								assertDirectExecutionAuthority,
 							)
@@ -7418,7 +7525,7 @@ export async function executeDirectRemoval(
 							? createSonarrDestructiveMutationAuthority(
 									deps,
 									userId,
-									{ ...flaggedDeleteTarget(item), action: ruleAction },
+									mutationTarget,
 									safetyPlan,
 									assertDirectExecutionAuthority,
 								)
@@ -7456,12 +7563,17 @@ export async function executeDirectRemoval(
 					"Cleanup: unmonitored item in ARR instance",
 				);
 			} else if (ruleAction === "delete_files") {
-				const deletedFiles = await deleteFilesFromArr(
-					arrClientFactory,
-					mutationInstance,
-					item.cacheItem.arrItemId,
-					safetyPlan!,
-					assertDestructiveMutationAuthority,
+				const deletedFiles = await withQuiPhysicalMutationGuard(
+					userId,
+					mutationTarget.respectQuiSeeding === true,
+					() =>
+						deleteFilesFromArr(
+							arrClientFactory,
+							mutationInstance,
+							item.cacheItem.arrItemId,
+							safetyPlan!,
+							assertDestructiveMutationAuthority,
+						),
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,
@@ -7507,12 +7619,14 @@ export async function executeDirectRemoval(
 				);
 			} else {
 				// Default: delete
-				await deleteFromArr(
-					arrClientFactory,
-					mutationInstance,
-					item.cacheItem.arrItemId,
-					safetyPlan!,
-					assertDestructiveMutationAuthority,
+				await withQuiPhysicalMutationGuard(userId, mutationTarget.respectQuiSeeding === true, () =>
+					deleteFromArr(
+						arrClientFactory,
+						mutationInstance,
+						item.cacheItem.arrItemId,
+						safetyPlan!,
+						assertDestructiveMutationAuthority,
+					),
 				);
 				await reconcileSonarrEpisodeFileCache(
 					prisma,

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -110,6 +110,50 @@ export function createSharedPlexSafetyContext(): SharedPlexSafetyContext {
 
 class FileMatchVerificationError extends Error {}
 class EpisodeWatchProofError extends FileMatchVerificationError {}
+class QuiProtectedTorrentStateError extends FileMatchVerificationError {}
+
+type VerifiedQuiInactiveTorrentState = "pausedUP" | "pausedDL" | "error" | "missingFiles";
+
+const QUI_INACTIVE_TORRENT_STATES = new Set<string>([
+	"pausedUP",
+	"pausedDL",
+	"error",
+	"missingFiles",
+]);
+
+const QUI_PROTECTED_TORRENT_STATES = new Set([
+	"downloading",
+	"uploading",
+	"stalledUP",
+	"stalledDL",
+	"queuedUP",
+	"queuedDL",
+	"checkingUP",
+	"checkingDL",
+	"metaDL",
+	"moving",
+	"forcedUP",
+	"forcedDL",
+]);
+
+function isQuiInactiveTorrentState(state: string): state is VerifiedQuiInactiveTorrentState {
+	return QUI_INACTIVE_TORRENT_STATES.has(state);
+}
+
+function assertQuiTorrentStateAllowsDeletion(
+	state: string,
+): asserts state is VerifiedQuiInactiveTorrentState {
+	if (QUI_PROTECTED_TORRENT_STATES.has(state)) {
+		throw new QuiProtectedTorrentStateError(
+			"Target physical file has an active or transitional torrent in qUI",
+		);
+	}
+	if (!isQuiInactiveTorrentState(state)) {
+		throw new FileMatchVerificationError(
+			"Target physical-file qUI state is unknown or unsupported",
+		);
+	}
+}
 
 function isQuiSeedingTorrentState(state: string | null | undefined): boolean {
 	return state === "seeding" || state === "downloading";
@@ -174,6 +218,23 @@ export interface VerifiedEpisodeQuiIdentity {
 	enabled: boolean;
 	infoHash: string | null;
 	torrentState: string | null;
+}
+
+export interface VerifiedQuiPhysicalFileEvidence {
+	enabled: boolean;
+	instances: Array<{
+		instanceId: string;
+		serviceFingerprint: string;
+		files: Array<{
+			fullPath: NormalizedMediaPath;
+			hashes: string[];
+		}>;
+		torrents: Array<{
+			hash: string;
+			qbitInstanceId: number;
+			state: VerifiedQuiInactiveTorrentState;
+		}>;
+	}>;
 }
 
 export interface VerifiedSonarrPeerIdentity {
@@ -259,6 +320,7 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_radarr";
 			target: VerifiedArrTargetIdentity;
 			file: VerifiedRadarrFileIdentity;
+			quiEvidence?: VerifiedQuiPhysicalFileEvidence;
 			peers: VerifiedRadarrPeerIdentity[];
 			peerInventoryComplete?: true;
 			ownership: VerifiedRadarrPlexOwnership[];
@@ -268,6 +330,7 @@ export type SharedMediaSafetyPlan =
 			kind: "verified_sonarr";
 			target: VerifiedArrTargetIdentity;
 			files: VerifiedSonarrFileIdentity;
+			quiEvidence?: VerifiedQuiPhysicalFileEvidence;
 			peers: VerifiedSonarrPeerIdentity[];
 			peerInventoryComplete?: true;
 			ownership: VerifiedSonarrPlexOwnership[];
@@ -281,6 +344,7 @@ export type SharedMediaSafetyPlan =
 			retainedTargetFiles: VerifiedSonarrEpisodeFileIdentity[];
 			watchProof: VerifiedEpisodePlexWatchProof;
 			quiIdentity: VerifiedEpisodeQuiIdentity;
+			quiEvidence?: VerifiedQuiPhysicalFileEvidence;
 			peers: VerifiedSonarrPeerIdentity[];
 			peerInventoryComplete?: true;
 			ownership: VerifiedSonarrPlexOwnership[];
@@ -532,6 +596,111 @@ function canonicalRetainedSonarrEpisodeFiles(
 		throw new FileMatchVerificationError("Sonarr retained file inventory is ambiguous");
 	}
 	return files;
+}
+
+function canonicalQuiPhysicalFileEvidence(value: unknown): VerifiedQuiPhysicalFileEvidence {
+	if (!value || typeof value !== "object") {
+		throw new FileMatchVerificationError("qUI physical-file evidence is unavailable");
+	}
+	const evidence = value as Record<string, unknown>;
+	if (typeof evidence.enabled !== "boolean" || !Array.isArray(evidence.instances)) {
+		throw new FileMatchVerificationError("qUI physical-file evidence is invalid");
+	}
+	if (!evidence.enabled) {
+		if (evidence.instances.length !== 0) {
+			throw new FileMatchVerificationError("Disabled qUI evidence must not contain instances");
+		}
+		return { enabled: false, instances: [] };
+	}
+	if (evidence.instances.length === 0) {
+		throw new FileMatchVerificationError("Enabled qUI evidence has no service instances");
+	}
+	const seenInstances = new Set<string>();
+	const instances = evidence.instances.map((rawInstance) => {
+		if (!rawInstance || typeof rawInstance !== "object") {
+			throw new FileMatchVerificationError("qUI evidence instance is invalid");
+		}
+		const instance = rawInstance as Record<string, unknown>;
+		const instanceId = requiredNonEmptyString(instance.instanceId, "qUI instance ID");
+		if (seenInstances.has(instanceId)) {
+			throw new FileMatchVerificationError("qUI evidence contains a duplicate service instance");
+		}
+		seenInstances.add(instanceId);
+		const serviceFingerprint = requiredNonEmptyString(
+			instance.serviceFingerprint,
+			"qUI service fingerprint",
+		);
+		if (!Array.isArray(instance.files) || !Array.isArray(instance.torrents)) {
+			throw new FileMatchVerificationError("qUI evidence file inventory is invalid");
+		}
+		const seenPaths = new Set<string>();
+		const files = instance.files.map((rawFile) => {
+			if (!rawFile || typeof rawFile !== "object") {
+				throw new FileMatchVerificationError("qUI evidence file is invalid");
+			}
+			const file = rawFile as Record<string, unknown>;
+			if (!file.fullPath || typeof file.fullPath !== "object") {
+				throw new FileMatchVerificationError("qUI target file path is invalid");
+			}
+			const fullPath = normalizeMediaPath((file.fullPath as Record<string, unknown>).value);
+			const pathKey = JSON.stringify(fullPath);
+			if (seenPaths.has(pathKey)) {
+				throw new FileMatchVerificationError("qUI evidence contains a duplicate file path");
+			}
+			seenPaths.add(pathKey);
+			if (!Array.isArray(file.hashes)) {
+				throw new FileMatchVerificationError("qUI evidence hashes are invalid");
+			}
+			const hashes = file.hashes.map((hash) =>
+				requiredNonEmptyString(hash, "qUI torrent hash").toLowerCase(),
+			);
+			if (new Set(hashes).size !== hashes.length) {
+				throw new FileMatchVerificationError("qUI evidence contains duplicate file hashes");
+			}
+			return { fullPath, hashes: hashes.sort() };
+		});
+		const seenTorrents = new Set<string>();
+		const torrents = instance.torrents.map((rawTorrent) => {
+			if (!rawTorrent || typeof rawTorrent !== "object") {
+				throw new FileMatchVerificationError("qUI torrent evidence is invalid");
+			}
+			const torrent = rawTorrent as Record<string, unknown>;
+			const hash = requiredNonEmptyString(torrent.hash, "qUI torrent hash").toLowerCase();
+			const qbitInstanceId = requiredPositiveSafeInteger(
+				torrent.qbitInstanceId,
+				"qUI qBittorrent instance ID",
+			);
+			const state = requiredNonEmptyString(torrent.state, "qUI torrent state");
+			if (!isQuiInactiveTorrentState(state)) {
+				throw new FileMatchVerificationError(
+					"qUI evidence contains a non-authorizing torrent state",
+				);
+			}
+			const torrentKey = `${qbitInstanceId}\0${hash}`;
+			if (seenTorrents.has(torrentKey)) {
+				throw new FileMatchVerificationError("qUI evidence contains an ambiguous torrent");
+			}
+			seenTorrents.add(torrentKey);
+			return { hash, qbitInstanceId, state };
+		});
+		return {
+			instanceId,
+			serviceFingerprint,
+			files: files.sort((left, right) =>
+				JSON.stringify(left.fullPath).localeCompare(JSON.stringify(right.fullPath)),
+			),
+			torrents: torrents.sort(
+				(left, right) =>
+					left.hash.localeCompare(right.hash) ||
+					left.qbitInstanceId - right.qbitInstanceId ||
+					left.state.localeCompare(right.state),
+			),
+		};
+	});
+	return {
+		enabled: true,
+		instances: instances.sort((left, right) => left.instanceId.localeCompare(right.instanceId)),
+	};
 }
 
 function canonicalSonarrPeers(value: unknown): VerifiedSonarrPeerIdentity[] {
@@ -873,6 +1042,10 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 			kind: "verified_radarr",
 			target: canonicalTargetIdentity(candidate.target),
 			file: canonicalRadarrFileIdentity(candidate.file),
+			quiEvidence:
+				candidate.quiEvidence === undefined
+					? undefined
+					: canonicalQuiPhysicalFileEvidence(candidate.quiEvidence),
 			peers: canonicalRadarrPeers(candidate.peers),
 			...(candidate.peerInventoryComplete === true ? { peerInventoryComplete: true as const } : {}),
 			ownership: canonicalRadarrOwnership(candidate.ownership),
@@ -886,6 +1059,10 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 			kind: "verified_sonarr",
 			target: canonicalTargetIdentity(candidate.target),
 			files: canonicalSonarrFiles(candidate.files),
+			quiEvidence:
+				candidate.quiEvidence === undefined
+					? undefined
+					: canonicalQuiPhysicalFileEvidence(candidate.quiEvidence),
 			peers: canonicalSonarrPeers(candidate.peers),
 			...(candidate.peerInventoryComplete === true ? { peerInventoryComplete: true as const } : {}),
 			ownership: canonicalSonarrOwnership(candidate.ownership),
@@ -914,6 +1091,10 @@ function canonicalExecutableSafetyPlan(plan: unknown): ExecutableSharedMediaSafe
 			),
 			watchProof: canonicalEpisodeWatchProof(candidate.watchProof),
 			quiIdentity: canonicalEpisodeQuiIdentity(candidate.quiIdentity),
+			quiEvidence:
+				candidate.quiEvidence === undefined
+					? undefined
+					: canonicalQuiPhysicalFileEvidence(candidate.quiEvidence),
 			peers: canonicalSonarrPeers(candidate.peers),
 			...(candidate.peerInventoryComplete === true ? { peerInventoryComplete: true as const } : {}),
 			ownership: canonicalSonarrOwnership(candidate.ownership),
@@ -4039,6 +4220,155 @@ async function verifyEpisodePlexWatchProof(
 	);
 }
 
+function createQuiSafetyFingerprint(instance: ServiceInstance): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify([
+				createArrServiceFingerprint(instance),
+				instance.hasLocalFilesystemAccess,
+				instance.pathPrefix,
+			]),
+		)
+		.digest("hex");
+}
+
+/**
+ * Build a fresh, complete qUI proof for every physical file a cleanup action
+ * may delete. The proof is serialized into the executable safety plan so a
+ * queued approval and the final mutation boundary can detect qUI topology,
+ * inode ownership, torrent identity, or state changes.
+ */
+export async function verifyFreshQuiPhysicalFileSafety(
+	deps: CleanupExecutorDeps,
+	context: SharedPlexSafetyContext,
+	userId: string,
+	filePaths: string[],
+	respectQuiSeeding: boolean,
+): Promise<VerifiedQuiPhysicalFileEvidence> {
+	if (!respectQuiSeeding || filePaths.length === 0) {
+		return { enabled: false, instances: [] };
+	}
+	context.quiInstances ??= deps.prisma.serviceInstance.findMany({
+		where: { userId, service: "QUI", enabled: true },
+	});
+	const quiInstances = [...(await context.quiInstances)].sort((left, right) =>
+		left.id.localeCompare(right.id),
+	);
+	if (quiInstances.length === 0) {
+		return { enabled: false, instances: [] };
+	}
+	if (!deps.quiClientFactory || !deps.quiFileHashIndexFactory) {
+		throw new FileMatchVerificationError(
+			"Target physical-file qUI state could not be verified live",
+		);
+	}
+	const normalizedPaths = [
+		...new Map(
+			filePaths.map((filePath) => {
+				const normalized = normalizeMediaPath(filePath);
+				return [JSON.stringify(normalized), normalized] as const;
+			}),
+		).values(),
+	].sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+	const hashes = new Set<string>();
+	const evidenceInstances: VerifiedQuiPhysicalFileEvidence["instances"] = [];
+	for (const instance of quiInstances) {
+		if (instance.hasLocalFilesystemAccess !== true) {
+			throw new FileMatchVerificationError(
+				"Target physical-file qUI state could not be verified live",
+			);
+		}
+		let index = context.quiFileIndexes.get(instance.id);
+		if (!index) {
+			index = deps.quiFileHashIndexFactory(instance);
+			context.quiFileIndexes.set(instance.id, index);
+		}
+		const files: VerifiedQuiPhysicalFileEvidence["instances"][number]["files"] = [];
+		for (const fullPath of normalizedPaths) {
+			try {
+				const resolution = await (await index).resolve(fullPath.value);
+				if (resolution.complete !== true) {
+					throw new Error("Incomplete qUI inode resolution");
+				}
+				const fileHashes = [...new Set(resolution.hashes.map((hash) => hash.toLowerCase()))].sort();
+				for (const hash of fileHashes) {
+					if (hash.trim() === "") throw new Error("Empty qUI torrent hash");
+					hashes.add(hash);
+				}
+				files.push({ fullPath, hashes: fileHashes });
+			} catch {
+				throw new FileMatchVerificationError(
+					"Target physical-file qUI state could not be verified live",
+				);
+			}
+		}
+		evidenceInstances.push({
+			instanceId: instance.id,
+			serviceFingerprint: createQuiSafetyFingerprint(instance),
+			files,
+			torrents: [],
+		});
+	}
+	for (const instanceEvidence of evidenceInstances) {
+		const instance = quiInstances.find(
+			(candidate) => candidate.id === instanceEvidence.instanceId,
+		)!;
+		const ownedHashes = new Set(instanceEvidence.files.flatMap((file) => file.hashes));
+		for (const hash of [...hashes].sort()) {
+			const cacheKey = `${instance.id}\0${hash}`;
+			let torrents = context.quiHashTorrents.get(cacheKey);
+			if (!torrents) {
+				torrents = deps.quiClientFactory(instance).getTorrentsByHash(hash);
+				context.quiHashTorrents.set(cacheKey, torrents);
+			}
+			let exactResults: Awaited<typeof torrents>;
+			try {
+				exactResults = await torrents;
+			} catch {
+				throw new FileMatchVerificationError(
+					"Target physical-file qUI state could not be verified live",
+				);
+			}
+			if (ownedHashes.has(hash) && exactResults.length === 0) {
+				throw new FileMatchVerificationError(
+					"qUI inode ownership did not match its exact-hash inventory",
+				);
+			}
+			const seenExact = new Set<string>();
+			for (const torrent of exactResults) {
+				if (torrent.hash.toLowerCase() !== hash) {
+					throw new FileMatchVerificationError("qUI returned a mismatched torrent identity");
+				}
+				if (
+					typeof torrent.instanceId !== "number" ||
+					!Number.isSafeInteger(torrent.instanceId) ||
+					torrent.instanceId <= 0
+				) {
+					throw new FileMatchVerificationError(
+						"qUI did not identify the owning qBittorrent instance",
+					);
+				}
+				const state = requiredNonEmptyString(torrent.state, "qUI torrent state");
+				const exactKey = `${torrent.instanceId}\0${hash}`;
+				if (seenExact.has(exactKey)) {
+					throw new FileMatchVerificationError("qUI returned an ambiguous torrent identity");
+				}
+				seenExact.add(exactKey);
+				assertQuiTorrentStateAllowsDeletion(state);
+				instanceEvidence.torrents.push({
+					hash,
+					qbitInstanceId: torrent.instanceId,
+					state,
+				});
+			}
+		}
+	}
+	return canonicalQuiPhysicalFileEvidence({
+		enabled: true,
+		instances: evidenceInstances,
+	});
+}
+
 async function verifyFreshEpisodeQuiState(
 	deps: CleanupExecutorDeps,
 	context: SharedPlexSafetyContext,
@@ -5082,6 +5412,55 @@ export async function findSharedPlexDeleteBlocks(
 					service: "SONARR",
 				},
 				"Cleanup shared-Plex safety check failed closed",
+			);
+		}
+	}
+
+	for (const target of deleteTargets) {
+		if (target.respectQuiSeeding !== true || !isDestructiveTarget(target)) continue;
+		const targetKey = cleanupDeleteTargetKey(target);
+		if (blocks.has(targetKey)) continue;
+		const plan = context.plans.get(targetKey);
+		if (!plan || plan.kind === "blocked" || plan.kind === "not_required") continue;
+		let filePaths: string[];
+		if (plan.kind === "verified_radarr") {
+			filePaths = [plan.file.fullPath.value];
+		} else if (plan.kind === "verified_sonarr") {
+			filePaths = plan.files.episodeFiles.map((file) => file.fullPath.value);
+		} else if (plan.kind === "verified_sonarr_episode") {
+			filePaths = [plan.selectedFile.fullPath.value];
+		} else {
+			continue;
+		}
+		if (filePaths.length === 0) continue;
+		try {
+			const quiEvidence = await verifyFreshQuiPhysicalFileSafety(
+				deps,
+				context,
+				userId,
+				filePaths,
+				true,
+			);
+			// Respecting qUI remains a no-op when no enabled qUI participates.
+			context.plans.set(targetKey, quiEvidence.enabled ? { ...plan, quiEvidence } : plan);
+		} catch (error) {
+			const active = error instanceof QuiProtectedTorrentStateError;
+			const targetDescription =
+				target.targetScope === "episode"
+					? "the exact Sonarr episode files"
+					: "every target physical file";
+			const reason = active
+				? `Skipped for safety: qUI reports that at least one of ${targetDescription} has an active or transitional torrent.`
+				: `Skipped for safety: complete fresh qUI evidence for ${targetDescription} could not be established.`;
+			blocks.set(targetKey, reason);
+			context.plans.set(targetKey, { kind: "blocked", reason });
+			deps.log.warn(
+				{
+					err: getErrorMessage(error),
+					instanceId: target.instanceId,
+					arrItemId: target.arrItemId,
+				},
+				"Cleanup qUI physical-file safety check failed closed",
 			);
 		}
 	}

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -220,6 +220,8 @@ export interface FlaggedItem {
 	match: RuleMatch;
 	/** Preferred available *arr rating from the data blob */
 	rating: number | null;
+	/** Apply fresh qUI physical-file protection to destructive actions. */
+	respectQuiSeeding?: boolean;
 	/** Exact Sonarr episode/file identity for a supported episode candidate. */
 	episodeTarget?: EpisodeTargetMetadata;
 }

--- a/apps/api/src/lib/qui/__tests__/action-service.test.ts
+++ b/apps/api/src/lib/qui/__tests__/action-service.test.ts
@@ -21,8 +21,23 @@
 
 import type { FastifyBaseLogger } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateQuiClient, mockRequireQuiInstance } = vi.hoisted(() => ({
+	mockCreateQuiClient: vi.fn(),
+	mockRequireQuiInstance: vi.fn(),
+}));
+
+vi.mock("../client-factory.js", () => ({
+	createQuiClient: mockCreateQuiClient,
+}));
+
+vi.mock("../instance-helpers.js", () => ({
+	requireQuiInstance: mockRequireQuiInstance,
+}));
+
 import { executeQuiAction } from "../action-service.js";
 import type { QuiClient } from "../client-factory.js";
+import { withQuiObservationTopologyGuard } from "../observation-topology-guard.js";
 
 const silentLog = {
 	info: vi.fn(),
@@ -60,7 +75,7 @@ function makeApp(opts: { txReturn?: { id: string }[] } = {}) {
 }
 
 function makeClient(overrides: Partial<QuiClient> = {}): QuiClient {
-	return {
+	const client = {
 		getTorrentsByHash: vi.fn().mockResolvedValue([]),
 		getTorrentByHash: vi.fn().mockResolvedValue(null),
 		getTrackers: vi.fn().mockResolvedValue([]),
@@ -112,20 +127,30 @@ function makeClient(overrides: Partial<QuiClient> = {}): QuiClient {
 		}),
 		...overrides,
 	};
+	mockCreateQuiClient.mockReturnValue(client);
+	return client;
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolve!: () => void;
+	const promise = new Promise<void>((done) => {
+		resolve = done;
+	});
+	return { promise, resolve };
 }
 
 describe("executeQuiAction — per-hash audit granularity", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockRequireQuiInstance.mockResolvedValue({ id: "svc-qui-1", service: "QUI" });
 	});
 
 	it("writes one pending row per hash, then transitions all to success", async () => {
 		const app = makeApp();
-		const client = makeClient();
+		makeClient();
 
 		const result = await executeQuiAction({
 			app,
-			client,
 			userId: "user-1",
 			serviceInstanceId: "svc-qui-1",
 			qbitInstanceId: 7,
@@ -147,9 +172,43 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 		expect(updateArgs.data.completedAt).toBeInstanceOf(Date);
 	});
 
+	it("re-resolves the qUI instance and client after a cleanup physical-file guard", async () => {
+		const app = makeApp();
+		const client = makeClient();
+		const currentInstance = { id: "svc-qui-1", service: "QUI", url: "https://new-qui" };
+		mockRequireQuiInstance.mockResolvedValue(currentInstance);
+		const guardStarted = deferred();
+		const releaseGuard = deferred();
+		const cleanupGuard = withQuiObservationTopologyGuard("user-1", async () => {
+			guardStarted.resolve();
+			await releaseGuard.promise;
+		});
+		await guardStarted.promise;
+
+		const action = executeQuiAction({
+			app,
+			userId: "user-1",
+			serviceInstanceId: "svc-qui-1",
+			qbitInstanceId: 7,
+			hashes: ["aaa"],
+			action: "resume",
+		});
+		await Promise.resolve();
+		expect(mockRequireQuiInstance).not.toHaveBeenCalled();
+		expect(mockCreateQuiClient).not.toHaveBeenCalled();
+		expect(app.__transaction).not.toHaveBeenCalled();
+		expect(client.bulkAction).not.toHaveBeenCalled();
+
+		releaseGuard.resolve();
+		await Promise.all([cleanupGuard, action]);
+		expect(mockRequireQuiInstance).toHaveBeenCalledWith(app, "user-1", "svc-qui-1");
+		expect(mockCreateQuiClient).toHaveBeenCalledWith(app, currentInstance);
+		expect(client.bulkAction).toHaveBeenCalledOnce();
+	});
+
 	it("translates qui errors to `failed` rows without throwing", async () => {
 		const app = makeApp();
-		const client = makeClient({
+		makeClient({
 			bulkAction: vi
 				.fn()
 				.mockRejectedValue(new Error("qui request to /api/... failed: 502 Bad Gateway")),
@@ -157,7 +216,6 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 
 		const result = await executeQuiAction({
 			app,
-			client,
 			userId: "user-1",
 			serviceInstanceId: "svc-qui-1",
 			qbitInstanceId: 7,
@@ -183,7 +241,6 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 
 		const result = await executeQuiAction({
 			app,
-			client,
 			userId: "user-1",
 			serviceInstanceId: "svc-qui-1",
 			qbitInstanceId: 7,
@@ -198,12 +255,11 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 
 	it("stores `setTags` tag list as JSON payload, not other actions", async () => {
 		const app = makeApp();
-		const client = makeClient();
+		makeClient();
 
 		// With tags: payload should be JSON.stringify({ tags })
 		await executeQuiAction({
 			app,
-			client,
 			userId: "user-1",
 			serviceInstanceId: "svc-qui-1",
 			qbitInstanceId: 7,
@@ -234,7 +290,6 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 		// Without tags (pause/resume/etc.): payload should be null
 		await executeQuiAction({
 			app,
-			client,
 			userId: "user-1",
 			serviceInstanceId: "svc-qui-1",
 			qbitInstanceId: 7,
@@ -253,11 +308,10 @@ describe("executeQuiAction — per-hash audit granularity", () => {
 
 	it("scopes the audit row to the caller's (userId, serviceInstanceId)", async () => {
 		const app = makeApp();
-		const client = makeClient();
+		makeClient();
 
 		await executeQuiAction({
 			app,
-			client,
 			userId: "user-42",
 			serviceInstanceId: "svc-qui-foo",
 			qbitInstanceId: 3,

--- a/apps/api/src/lib/qui/action-service.ts
+++ b/apps/api/src/lib/qui/action-service.ts
@@ -14,10 +14,8 @@
  *      (with `completedAt` + sanitized `error`).
  *
  * Trust posture (per qui-integration-design.md §9):
- *   - Ownership is verified by the caller (route handler uses
- *     `requireQuiInstance` which scopes to `request.currentUser.id`).
- *   - This service trusts the caller has already done that check —
- *     re-checking here would double-fetch the ServiceInstance row.
+ *   - Ownership is resolved inside the topology guard with
+ *     `requireQuiInstance`, immediately before constructing the client.
  *   - `error` strings are passed through verbatim from qui's response
  *     body; we don't try to redact, but qui itself doesn't echo the
  *     API key on errors. If that ever changes upstream, the redaction
@@ -27,11 +25,12 @@
 import type { QuiAction, QuiActionPayload } from "@arr/shared";
 import type { FastifyBaseLogger, FastifyInstance } from "fastify";
 import { getErrorMessage } from "../utils/error-message.js";
-import type { QuiClient } from "./client-factory.js";
+import { createQuiClient } from "./client-factory.js";
+import { requireQuiInstance } from "./instance-helpers.js";
+import { withQuiObservationTopologyGuard } from "./observation-topology-guard.js";
 
 export interface ExecuteQuiActionArgs {
 	app: FastifyInstance;
-	client: QuiClient;
 	/** Pre-validated user id from `request.currentUser.id`. */
 	userId: string;
 	/** Pre-validated qui ServiceInstance id (FK target). */
@@ -75,7 +74,6 @@ export async function executeQuiAction(
 ): Promise<ExecuteQuiActionResult> {
 	const {
 		app,
-		client,
 		userId,
 		serviceInstanceId,
 		qbitInstanceId,
@@ -92,113 +90,121 @@ export async function executeQuiAction(
 		return { logRowCount: 0, status: "success", error: null };
 	}
 
-	// Audit log captures the entire payload so an operator can reconstruct
-	// exactly what was sent. `null` for actions with no extras (pause/resume
-	// /recheck/reannounce/forceStart) — empty `{}` would also work but null
-	// reads as "no payload" more clearly.
-	const payloadString =
-		payload !== undefined && Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
+	return withQuiObservationTopologyGuard(userId, async () => {
+		// Re-resolve ownership and construct the client only after obtaining
+		// the topology guard. A queued action must never retain an endpoint or
+		// credentials that were replaced or deleted while it was waiting.
+		const instance = await requireQuiInstance(app, userId, serviceInstanceId);
+		const client = createQuiClient(app, instance);
 
-	// 1. Create pending audit rows in one batch — atomic so we don't leak
-	//    half-recorded intent if the DB layer fails between rows.
-	const requestedAt = new Date();
-	const createdRows = await app.prisma.$transaction(
-		hashes.map((torrentHash) =>
-			app.prisma.quiActionLog.create({
-				data: {
+		// Audit log captures the entire payload so an operator can reconstruct
+		// exactly what was sent. `null` for actions with no extras (pause/resume
+		// /recheck/reannounce/forceStart) — empty `{}` would also work but null
+		// reads as "no payload" more clearly.
+		const payloadString =
+			payload !== undefined && Object.keys(payload).length > 0 ? JSON.stringify(payload) : null;
+
+		// 1. Create pending audit rows in one batch — atomic so we don't leak
+		//    half-recorded intent if the DB layer fails between rows.
+		const requestedAt = new Date();
+		const createdRows = await app.prisma.$transaction(
+			hashes.map((torrentHash) =>
+				app.prisma.quiActionLog.create({
+					data: {
+						userId,
+						serviceInstanceId,
+						qbitInstanceId,
+						torrentHash,
+						action,
+						payload: payloadString,
+						status: "pending",
+						requestedAt,
+					},
+					select: { id: true },
+				}),
+			),
+		);
+		const rowIds = createdRows.map((r) => r.id);
+
+		// 2. Invoke qui. Failure semantics for the two halves of this dance are
+		//    DIFFERENT, so we deliberately split the try blocks:
+		//      a. If qui itself fails (non-2xx, network), mark the audit rows
+		//         `failed` so the operator sees the failure in My Actions.
+		//      b. If qui SUCCEEDED but the post-success bookkeeping update fails
+		//         (transient DB error between qui's 200 and our updateMany), we
+		//         must NOT mark the rows `failed` — that would lie to the operator
+		//         and prompt a duplicate action. Leave the rows `pending` and log
+		//         loudly; a follow-up reconciler can drain pending rows later.
+		let quiOutcome: "ok" | "fail" = "ok";
+		let quiError: unknown = null;
+		try {
+			// Pass extras as undefined when payload is empty so the client
+			// doesn't spread `{}` into qui's POST body (cleaner wire shape, and
+			// preserves the existing test contract that a no-extras action
+			// receives `extras: undefined`).
+			const hasExtras = payload !== undefined && Object.keys(payload).length > 0;
+			await client.bulkAction({
+				qbitInstanceId,
+				hashes,
+				action,
+				extras: hasExtras ? (payload as Record<string, unknown>) : undefined,
+			});
+		} catch (error) {
+			quiOutcome = "fail";
+			quiError = error;
+		}
+
+		const completedAt = new Date();
+		if (quiOutcome === "fail") {
+			const message = getErrorMessage(quiError, "qui action failed");
+			// Mark rows failed. If THIS write itself fails, the rows stay pending —
+			// which is correct ("we tried, we don't know the outcome"). Surface
+			// the secondary failure so an operator can reconcile manually.
+			try {
+				await app.prisma.quiActionLog.updateMany({
+					where: { id: { in: rowIds } },
+					data: { status: "failed", completedAt, error: message },
+				});
+			} catch (updateErr) {
+				log.error(
+					{ err: updateErr, rowIds, userId, serviceInstanceId, action },
+					"qui action failed AND audit-log update failed — pending rows require manual reconciliation",
+				);
+			}
+			log.warn(
+				{
+					err: quiError,
 					userId,
 					serviceInstanceId,
 					qbitInstanceId,
-					torrentHash,
 					action,
-					payload: payloadString,
-					status: "pending",
-					requestedAt,
+					hashCount: hashes.length,
 				},
-				select: { id: true },
-			}),
-		),
-	);
-	const rowIds = createdRows.map((r) => r.id);
+				"qui action failed",
+			);
+			return { logRowCount: rowIds.length, status: "failed", error: message };
+		}
 
-	// 2. Invoke qui. Failure semantics for the two halves of this dance are
-	//    DIFFERENT, so we deliberately split the try blocks:
-	//      a. If qui itself fails (non-2xx, network), mark the audit rows
-	//         `failed` so the operator sees the failure in My Actions.
-	//      b. If qui SUCCEEDED but the post-success bookkeeping update fails
-	//         (transient DB error between qui's 200 and our updateMany), we
-	//         must NOT mark the rows `failed` — that would lie to the operator
-	//         and prompt a duplicate action. Leave the rows `pending` and log
-	//         loudly; a follow-up reconciler can drain pending rows later.
-	let quiOutcome: "ok" | "fail" = "ok";
-	let quiError: unknown = null;
-	try {
-		// Pass extras as undefined when payload is empty so the client
-		// doesn't spread `{}` into qui's POST body (cleaner wire shape, and
-		// preserves the existing test contract that a no-extras action
-		// receives `extras: undefined`).
-		const hasExtras = payload !== undefined && Object.keys(payload).length > 0;
-		await client.bulkAction({
-			qbitInstanceId,
-			hashes,
-			action,
-			extras: hasExtras ? (payload as Record<string, unknown>) : undefined,
-		});
-	} catch (error) {
-		quiOutcome = "fail";
-		quiError = error;
-	}
-
-	const completedAt = new Date();
-	if (quiOutcome === "fail") {
-		const message = getErrorMessage(quiError, "qui action failed");
-		// Mark rows failed. If THIS write itself fails, the rows stay pending —
-		// which is correct ("we tried, we don't know the outcome"). Surface
-		// the secondary failure so an operator can reconcile manually.
+		// qui succeeded. The action HAS happened on the remote system; the
+		// bookkeeping below cannot un-happen it. So a write failure here must
+		// not be misreported as a failed mutation — return success and let the
+		// operator's audit row stay `pending` (the operator can see the gap and
+		// we have an error log for triage).
 		try {
 			await app.prisma.quiActionLog.updateMany({
 				where: { id: { in: rowIds } },
-				data: { status: "failed", completedAt, error: message },
+				data: { status: "success", completedAt },
 			});
 		} catch (updateErr) {
 			log.error(
-				{ err: updateErr, rowIds, userId, serviceInstanceId, action },
-				"qui action failed AND audit-log update failed — pending rows require manual reconciliation",
+				{ err: updateErr, rowIds, userId, serviceInstanceId, action, hashCount: hashes.length },
+				"qui action succeeded but audit-log success-update failed — rows left pending; manual reconciliation required",
 			);
 		}
-		log.warn(
-			{
-				err: quiError,
-				userId,
-				serviceInstanceId,
-				qbitInstanceId,
-				action,
-				hashCount: hashes.length,
-			},
-			"qui action failed",
+		log.info(
+			{ userId, serviceInstanceId, qbitInstanceId, action, hashCount: hashes.length },
+			"qui action succeeded",
 		);
-		return { logRowCount: rowIds.length, status: "failed", error: message };
-	}
-
-	// qui succeeded. The action HAS happened on the remote system; the
-	// bookkeeping below cannot un-happen it. So a write failure here must
-	// not be misreported as a failed mutation — return success and let the
-	// operator's audit row stay `pending` (the operator can see the gap and
-	// we have an error log for triage).
-	try {
-		await app.prisma.quiActionLog.updateMany({
-			where: { id: { in: rowIds } },
-			data: { status: "success", completedAt },
-		});
-	} catch (updateErr) {
-		log.error(
-			{ err: updateErr, rowIds, userId, serviceInstanceId, action, hashCount: hashes.length },
-			"qui action succeeded but audit-log success-update failed — rows left pending; manual reconciliation required",
-		);
-	}
-	log.info(
-		{ userId, serviceInstanceId, qbitInstanceId, action, hashCount: hashes.length },
-		"qui action succeeded",
-	);
-	return { logRowCount: rowIds.length, status: "success", error: null };
+		return { logRowCount: rowIds.length, status: "success", error: null };
+	});
 }

--- a/apps/api/src/routes/qui/action-routes.ts
+++ b/apps/api/src/routes/qui/action-routes.ts
@@ -7,8 +7,6 @@ import {
 } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
 import { executeQuiAction } from "../../lib/qui/action-service.js";
-import { createQuiClient } from "../../lib/qui/client-factory.js";
-import { requireQuiInstance } from "../../lib/qui/instance-helpers.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import {
 	ACTION_LOG_QUERY,
@@ -44,14 +42,10 @@ export function registerActionRoutes(app: FastifyInstance): void {
 
 			// Ownership: requireQuiInstance only returns the row when (userId, id)
 			// match AND service=QUI. Other users' ids surface as 404, not 403.
-			const instance = await requireQuiInstance(app, userId, id);
-			const client = createQuiClient(app, instance);
-
 			const result = await executeQuiAction({
 				app,
-				client,
 				userId,
-				serviceInstanceId: instance.id,
+				serviceInstanceId: id,
 				qbitInstanceId,
 				hashes: [hash],
 				action,
@@ -102,14 +96,10 @@ export function registerActionRoutes(app: FastifyInstance): void {
 		const { hashes: _omitHashes, ...payloadBody } = rawBody;
 		const payload = validateRequest(payloadSchema, payloadBody) as QuiActionPayload;
 
-		const instance = await requireQuiInstance(app, userId, id);
-		const client = createQuiClient(app, instance);
-
 		const result = await executeQuiAction({
 			app,
-			client,
 			userId,
-			serviceInstanceId: instance.id,
+			serviceInstanceId: id,
 			qbitInstanceId,
 			hashes: envelope.hashes,
 			action,


### PR DESCRIPTION
## Summary

- Persist complete qUI path, inode/hash, qBittorrent owner, torrent-state, and service-topology evidence in destructive cleanup plans.
- Rebuild and compare that evidence immediately before Radarr or Sonarr file mutation for direct runs, approvals, episode cleanup, and retries.
- Serialize arr-dashboard qUI torrent actions and qUI topology changes with the cleanup physical-file boundary.
- Preserve safe partial-retry behavior without re-reading a physical path that the authorized mutation already removed.

## Safety behavior

- Active, transitional, unknown, incomplete, mismatched, or ambiguous qUI evidence fails closed.
- No enabled qUI remains a no-op for the respect-qUI option.
- Unmonitor-only actions do not require physical-file evidence.
- Sonarr remainder recovery projects qUI evidence only onto files that still exist.
- Existing Plex ownership and post-file notification checks remain authoritative.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test (4,973 passing; 52 skipped)
- pnpm run lint
- pnpm run build
- Independent regression review: no merge-blocking findings
- Independent data-safety review: qUI action race fixed with shared per-user serialization and concurrency coverage

## Scope

This is the qUI physical-proof parity slice for next. Provider evidence binding, durable audit/activity, media-server scan workers, recursive cleanup grammar, and reusable live harness work remain separate planned slices.