### PR TITLE
feat(cleanup): bind provider evidence to previews and retries

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1367,7 +1367,7 @@ describe("shared Plex deletion safety", () => {
 		).toBeNull();
 	});
 
-	it("does not acquire the mutation lease for a dry run", async () => {
+	it("holds the provider publication lease across a configured dry run", async () => {
 		const { deps } = makeDeps();
 		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
 			dryRunConfig() as never,
@@ -1381,8 +1381,93 @@ describe("shared Plex deletion safety", () => {
 			itemsEvaluated: 0,
 			itemsRemoved: 0,
 		});
-		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
+		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				data: { runClaimToken: expect.any(String), runClaimedAt: expect.any(Date) },
+			}),
+		);
+		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenNthCalledWith(
+			2,
+			expect.objectContaining({ data: { runClaimToken: null, runClaimedAt: null } }),
+		);
 		expect(deps.prisma.libraryCleanupLog.create).not.toHaveBeenCalled();
+	});
+
+	it.each(["interactive preview", "configured dry run"] as const)(
+		"returns the captured provider authority with an %s",
+		async (mode) => {
+			const fixture = makeDeps({ mediaPartCount: 1 });
+			const config = plexPolicyCleanupConfig({
+				ruleType: "plex_watch_count",
+				parameters: { operator: "less_than", count: 1 },
+			});
+			vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+				...config,
+				dryRunMode: mode === "configured dry run",
+				requireApproval: false,
+			} as never);
+			vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+				matchingDryRunCacheItem(),
+			] as never);
+			configurePublishedPlexEvidence(fixture, { itemCount: 1, rowCount: 1 });
+			const evidence = plexProviderEvidence();
+			const capture = vi.fn().mockResolvedValue(evidence);
+			Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
+
+			const result =
+				mode === "interactive preview"
+					? await executeCleanupPreview(fixture.deps, "user-1")
+					: await executeCleanupRun(fixture.deps, "user-1");
+
+			expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
+			expect(result.providerEvidence).toEqual(evidence);
+			const leaseWrites = vi.mocked(fixture.deps.prisma.libraryCleanupConfig.updateMany);
+			expect(leaseWrites).toHaveBeenCalledTimes(2);
+			expect(leaseWrites.mock.invocationCallOrder[0]).toBeLessThan(
+				capture.mock.invocationCallOrder[0]!,
+			);
+			expect(capture.mock.invocationCallOrder[0]).toBeLessThan(
+				leaseWrites.mock.invocationCallOrder[1]!,
+			);
+		},
+	);
+
+	it("retains provider authority when only a durable retry is selected", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const config = plexPolicyCleanupConfig({
+			ruleType: "plex_watch_count",
+			parameters: { operator: "less_than", count: 1 },
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+			requireApproval: false,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([] as never);
+		configurePublishedPlexEvidence(fixture, { itemCount: 0, rowCount: 0 });
+		const evidence = plexProviderEvidence();
+		const capture = vi.fn().mockResolvedValue(evidence);
+		Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
+		const retries = configureRetryStore(fixture.deps);
+		retries.push({
+			...approvalRecord({ status: "retry_pending", executionToken: null }),
+			configId: "config-1",
+			sizeOnDisk: 2_000n,
+			year: 2024,
+			createdAt: new Date("2026-08-15T04:00:00.000Z"),
+			reviewedAt: new Date("2026-08-15T04:00:00.000Z"),
+		});
+
+		const result = await executeCleanupPreview(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({
+			itemsFlagged: 0,
+			previewSelection: { selectedFresh: 0, selectedRetries: 1 },
+			providerEvidence: evidence,
+		});
+		expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
 	});
 
 	it.each([
@@ -2118,7 +2203,7 @@ describe("shared Plex deletion safety", () => {
 			}),
 		);
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
-		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
 	});
 
 	it("uses the same frozen direct selection for preview, configured dry run, and live execution", async () => {
@@ -2557,7 +2642,7 @@ describe("shared Plex deletion safety", () => {
 			],
 		});
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
-		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
 	});
 
 	it("blocks when another Radarr instance may mount the same storage under a different path", async () => {
@@ -3115,6 +3200,8 @@ describe("shared Plex deletion safety", () => {
 			matchingDryRunCacheItem(),
 		] as never);
 		configurePublishedPlexEvidence(fixture, { itemCount: 1, rowCount: 1 });
+		const capture = vi.fn().mockRejectedValue(new Error("Plex authority unavailable"));
+		Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
 
 		const result = await executeCleanupPreview(fixture.deps, "user-1");
 
@@ -3124,6 +3211,45 @@ describe("shared Plex deletion safety", () => {
 			prefetchHealth: { plex: "failed" },
 		});
 		expect(result.warnings).toContainEqual(expect.stringContaining("plex data unavailable"));
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining("provider evidence was unavailable"),
+		);
+		expect(result.providerEvidence).toBeUndefined();
+		expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
+	});
+
+	it("keeps ARR-only matches when Jellyfin or Emby authority is unavailable", async () => {
+		const fixture = makeDeps();
+		const config = dryRunConfig();
+		config.rules.push({
+			...config.rules[0]!,
+			id: "provider-rule",
+			name: "Jellyfin or Emby policy",
+			priority: 2,
+			ruleType: "jellyfin_watch_count",
+			parameters: JSON.stringify({ operator: "less_than", count: 1 }),
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			config as never,
+		);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem(),
+		] as never);
+		const capture = vi.fn().mockRejectedValue(new Error("Jellyfin authority unavailable"));
+		Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
+
+		const result = await executeCleanupRun(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({
+			status: "partial",
+			itemsEvaluated: 1,
+			itemsFlagged: 1,
+		});
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining("provider evidence was unavailable"),
+		);
+		expect(result.providerEvidence).toBeUndefined();
+		expect(capture).toHaveBeenCalledWith("user-1", ["jellyfin"]);
 	});
 
 	it("does not select a Plex cleanup candidate when the published row count mismatches", async () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -82,6 +82,22 @@ function plexProviderEvidence(completedAt = "2026-08-15T04:00:00.000Z") {
 	);
 }
 
+function plexEpisodeProviderEvidence() {
+	const { fingerprint: _fingerprint, ...plexSource } = plexProviderEvidence().sources[0]!;
+	return createSanitizedProviderEvidence(
+		["plex", "plex_episode"],
+		[
+			plexSource,
+			{
+				...plexSource,
+				cacheType: "plex_episode",
+				statusFingerprint: "e".repeat(64),
+				rowFingerprint: "f".repeat(64),
+			},
+		],
+	);
+}
+
 function radarrSafetySnapshot(
 	file: {
 		movieFileId: number;
@@ -1367,7 +1383,7 @@ describe("shared Plex deletion safety", () => {
 		).toBeNull();
 	});
 
-	it("holds the provider publication lease across a configured dry run", async () => {
+	it("does not mutate the durable run lease for a configured dry run", async () => {
 		const { deps } = makeDeps();
 		vi.mocked(deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
 			dryRunConfig() as never,
@@ -1381,17 +1397,7 @@ describe("shared Plex deletion safety", () => {
 			itemsEvaluated: 0,
 			itemsRemoved: 0,
 		});
-		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
-		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenNthCalledWith(
-			1,
-			expect.objectContaining({
-				data: { runClaimToken: expect.any(String), runClaimedAt: expect.any(Date) },
-			}),
-		);
-		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenNthCalledWith(
-			2,
-			expect.objectContaining({ data: { runClaimToken: null, runClaimedAt: null } }),
-		);
+		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
 		expect(deps.prisma.libraryCleanupLog.create).not.toHaveBeenCalled();
 	});
 
@@ -1421,18 +1427,71 @@ describe("shared Plex deletion safety", () => {
 					? await executeCleanupPreview(fixture.deps, "user-1")
 					: await executeCleanupRun(fixture.deps, "user-1");
 
-			expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
+			expect(capture).toHaveBeenCalledTimes(2);
+			expect(capture).toHaveBeenNthCalledWith(1, "user-1", ["plex"]);
+			expect(capture).toHaveBeenNthCalledWith(2, "user-1", ["plex"]);
 			expect(result.providerEvidence).toEqual(evidence);
-			const leaseWrites = vi.mocked(fixture.deps.prisma.libraryCleanupConfig.updateMany);
-			expect(leaseWrites).toHaveBeenCalledTimes(2);
-			expect(leaseWrites.mock.invocationCallOrder[0]).toBeLessThan(
-				capture.mock.invocationCallOrder[0]!,
-			);
-			expect(capture.mock.invocationCallOrder[0]).toBeLessThan(
-				leaseWrites.mock.invocationCallOrder[1]!,
-			);
+			expect(fixture.deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
 		},
 	);
+
+	it("re-evaluates a preview when provider publication changes during its read", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const config = plexPolicyCleanupConfig({
+			ruleType: "plex_watch_count",
+			parameters: { operator: "less_than", count: 1 },
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			...config,
+			dryRunMode: false,
+			requireApproval: false,
+		} as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([
+			matchingDryRunCacheItem(),
+		] as never);
+		configurePublishedPlexEvidence(fixture, { itemCount: 1, rowCount: 1 });
+		const firstEvidence = plexProviderEvidence("2026-08-15T04:00:00.000Z");
+		const publishedEvidence = plexProviderEvidence("2026-08-15T05:00:00.000Z");
+		const capture = vi
+			.fn()
+			.mockResolvedValueOnce(firstEvidence)
+			.mockResolvedValue(publishedEvidence);
+		Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
+
+		const result = await executeCleanupPreview(fixture.deps, "user-1");
+
+		expect(capture).toHaveBeenCalledTimes(3);
+		expect(fixture.deps.prisma.libraryCache.findMany).toHaveBeenCalledTimes(2);
+		expect(result.providerEvidence).toEqual(publishedEvidence);
+		expect(fixture.deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
+	});
+
+	it("includes Plex episode rows for supported episode watch rules", async () => {
+		const fixture = makeDeps({ mediaPartCount: 1 });
+		const config = dryRunConfig();
+		config.dryRunMode = false;
+		config.rules = [
+			{
+				...config.rules[0]!,
+				targetScope: "episode",
+				ruleType: "plex_watch_count",
+				parameters: JSON.stringify({ operator: "greater_than", count: 0 }),
+				action: "unmonitor",
+			} as (typeof config.rules)[number],
+		];
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue(
+			config as never,
+		);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany).mockResolvedValue([] as never);
+		const evidence = plexEpisodeProviderEvidence();
+		const capture = vi.fn().mockResolvedValue(evidence);
+		Object.assign(fixture.deps, { providerEvidenceCapturer: capture });
+
+		await executeCleanupPreview(fixture.deps, "user-1");
+
+		expect(capture).toHaveBeenCalledTimes(2);
+		expect(capture).toHaveBeenCalledWith("user-1", ["plex", "plex_episode"]);
+	});
 
 	it("retains provider authority when only a durable retry is selected", async () => {
 		const fixture = makeDeps({ mediaPartCount: 1 });
@@ -1467,6 +1526,7 @@ describe("shared Plex deletion safety", () => {
 			previewSelection: { selectedFresh: 0, selectedRetries: 1 },
 			providerEvidence: evidence,
 		});
+		expect(capture).toHaveBeenCalledTimes(2);
 		expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
 	});
 
@@ -2203,7 +2263,7 @@ describe("shared Plex deletion safety", () => {
 			}),
 		);
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
-		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
+		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
 	});
 
 	it("uses the same frozen direct selection for preview, configured dry run, and live execution", async () => {
@@ -2642,7 +2702,7 @@ describe("shared Plex deletion safety", () => {
 			],
 		});
 		expect(targetClient.movie.getById).not.toHaveBeenCalled();
-		expect(deps.prisma.libraryCleanupConfig.updateMany).toHaveBeenCalledTimes(2);
+		expect(deps.prisma.libraryCleanupConfig.updateMany).not.toHaveBeenCalled();
 	});
 
 	it("blocks when another Radarr instance may mount the same storage under a different path", async () => {
@@ -3218,7 +3278,7 @@ describe("shared Plex deletion safety", () => {
 		expect(capture).toHaveBeenCalledWith("user-1", ["plex"]);
 	});
 
-	it("keeps ARR-only matches when Jellyfin or Emby authority is unavailable", async () => {
+	it("withholds selection when Jellyfin or Emby authority is unavailable", async () => {
 		const fixture = makeDeps();
 		const config = dryRunConfig();
 		config.rules.push({
@@ -3243,7 +3303,7 @@ describe("shared Plex deletion safety", () => {
 		expect(result).toMatchObject({
 			status: "partial",
 			itemsEvaluated: 1,
-			itemsFlagged: 1,
+			itemsFlagged: 0,
 		});
 		expect(result.warnings).toContainEqual(
 			expect.stringContaining("provider evidence was unavailable"),

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -13,6 +13,7 @@ import {
 	assertVerifiedSonarrPeerOwnershipRetained,
 	cleanupDeleteTargetKey,
 	createArrServiceFingerprint,
+	createSanitizedProviderEvidence,
 	createSharedPlexSafetyContext,
 	findSharedPlexDeleteBlocks,
 	serializeExecutableSafetyPlan,
@@ -41,6 +42,40 @@ const sonarrServiceFingerprint = createArrServiceFingerprint({
 	encryptedHttpAuthCredentials: null,
 	httpAuthEncryptionIv: null,
 } as never);
+
+function plexProviderEvidence() {
+	return createSanitizedProviderEvidence(
+		["plex", "plex_episode"],
+		[
+			{
+				service: "PLEX",
+				identityKind: "PLEX_MACHINE_IDENTIFIER",
+				identityFingerprint: "b".repeat(64),
+				connectionGeneration: 3,
+				identityGeneration: 7,
+				cacheType: "plex",
+				completedAt: "2026-08-15T04:00:00.000Z",
+				itemCount: 1,
+				verifiedAt: "2026-08-15T03:00:00.000Z",
+				statusFingerprint: "c".repeat(64),
+				rowFingerprint: "d".repeat(64),
+			},
+			{
+				service: "PLEX",
+				identityKind: "PLEX_MACHINE_IDENTIFIER",
+				identityFingerprint: "b".repeat(64),
+				connectionGeneration: 3,
+				identityGeneration: 7,
+				cacheType: "plex_episode",
+				completedAt: "2026-08-15T04:00:00.000Z",
+				itemCount: 1,
+				verifiedAt: "2026-08-15T03:00:00.000Z",
+				statusFingerprint: "e".repeat(64),
+				rowFingerprint: "f".repeat(64),
+			},
+		],
+	);
+}
 
 function episodeCleanupRule(action: "delete" | "delete_files" | "unmonitor" = "delete") {
 	return {
@@ -2597,6 +2632,69 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
 		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
 		expect(fixture.deleteSeries).not.toHaveBeenCalled();
+	});
+
+	it("uses the durable checkpoint when a partial episode error label is replaced", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const matchingConfig = {
+			id: "config-1",
+			respectQuiSeeding: true,
+			rules: [episodeCleanupRule()],
+		};
+		let currentConfig = matchingConfig;
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockImplementation(
+			(async () => currentConfig) as never,
+		);
+		fixture.setEpisodeMonitored.mockImplementation(async (episodeIds, monitored) => {
+			for (const episodeId of episodeIds) fixture.setLiveEpisodeMonitored(episodeId, monitored);
+			currentConfig = {
+				...matchingConfig,
+				rules: [{ ...episodeCleanupRule(), enabled: false }],
+			};
+		});
+		const evidence = plexProviderEvidence();
+		const authorityChecker = vi.fn().mockResolvedValue(undefined);
+		const retryRenewer = vi.fn().mockResolvedValue(evidence);
+		Object.assign(fixture.deps, {
+			providerEvidenceAuthorityChecker: authorityChecker,
+			providerRetryAuthorityRenewer: retryRenewer,
+		});
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			safetySnapshot: serializeExecutableSafetyPlan(plan, evidence),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const first = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+		expect(first).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({ status: "retry_pending" });
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+
+		currentConfig = matchingConfig;
+		storedApproval.lastExecutionError =
+			"Cleanup item could not be executed. Review the API logs for details.";
+		authorityChecker.mockRejectedValue(new Error("provider cache rows changed"));
+		const retry = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(retry).toMatchObject({ removed: 0, failed: 1 });
+		expect(authorityChecker).toHaveBeenLastCalledWith("user-1", evidence, expect.any(Function));
+		expect(retryRenewer).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(storedApproval).toMatchObject({ status: "expired" });
 	});
 
 	it("persists a direct episode delete after its exact unmonitor step", async () => {

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -2555,6 +2555,13 @@ export async function executeCleanupPreview(
 	deps: CleanupExecutorDeps,
 	userId: string,
 ): Promise<CleanupRunResult> {
+	return await withCleanupOperationGuard(() => executeCleanupPreviewGuarded(deps, userId));
+}
+
+async function executeCleanupPreviewGuarded(
+	deps: CleanupExecutorDeps,
+	userId: string,
+): Promise<CleanupRunResult> {
 	const startTime = Date.now();
 	const { prisma, log } = deps;
 
@@ -2614,11 +2621,17 @@ export async function executeCleanupPreview(
 		};
 	}
 
-	const { flagged, totalEvaluated, prefetchHealth, warnings } = await evaluateAllItems(
-		deps,
-		config,
-		config.rules,
-	);
+	const {
+		flagged,
+		totalEvaluated,
+		prefetchHealth,
+		warnings,
+		providerEvidence,
+		providerEvidenceWarning,
+	} = await evaluateCleanupPreviewWithProviderEvidence(deps, userId, config);
+	const previewWarnings = providerEvidenceWarning
+		? [...warnings, providerEvidenceWarning]
+		: warnings;
 	if (!config.requireApproval) {
 		const configuredRunLimitIsValid =
 			Number.isSafeInteger(config.maxRemovalsPerRun) &&
@@ -2649,7 +2662,7 @@ export async function executeCleanupPreview(
 		);
 		const allWarnings = withSharedPlexWarning(
 			[
-				...warnings,
+				...previewWarnings,
 				...directSelection.warnings,
 				...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
 			],
@@ -2698,6 +2711,7 @@ export async function executeCleanupPreview(
 			durationMs: Date.now() - startTime,
 			prefetchHealth,
 			warnings: allWarnings,
+			providerEvidence,
 		};
 	}
 
@@ -2730,7 +2744,7 @@ export async function executeCleanupPreview(
 	);
 	const allWarnings = withSharedPlexWarning(
 		[
-			...warnings,
+			...previewWarnings,
 			...approvalSelection.warnings,
 			...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
 		],
@@ -2789,6 +2803,7 @@ export async function executeCleanupPreview(
 		durationMs: Date.now() - startTime,
 		prefetchHealth,
 		warnings: allWarnings,
+		providerEvidence,
 	};
 }
 
@@ -2837,11 +2852,17 @@ async function executeCleanupRunGuarded(
 	}
 
 	if (config.dryRunMode) {
-		const { flagged, totalEvaluated, prefetchHealth, warnings } = await evaluateAllItems(
-			deps,
-			config,
-			config.rules,
-		);
+		const {
+			flagged,
+			totalEvaluated,
+			prefetchHealth,
+			warnings,
+			providerEvidence,
+			providerEvidenceWarning,
+		} = await evaluateCleanupPreviewWithProviderEvidence(deps, userId, config);
+		const previewWarnings = providerEvidenceWarning
+			? [...warnings, providerEvidenceWarning]
+			: warnings;
 		const configuredRunLimitIsValid =
 			Number.isSafeInteger(config.maxRemovalsPerRun) &&
 			config.maxRemovalsPerRun > 0 &&
@@ -2872,7 +2893,7 @@ async function executeCleanupRunGuarded(
 			);
 			const allWarnings = withSharedPlexWarning(
 				[
-					...warnings,
+					...previewWarnings,
 					...directSelection.warnings,
 					...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
 				],
@@ -2896,6 +2917,7 @@ async function executeCleanupRunGuarded(
 				durationMs: Date.now() - startTime,
 				prefetchHealth,
 				warnings: allWarnings,
+				providerEvidence,
 			};
 
 			await createRunLog(prisma, config.id, result, log);
@@ -2925,7 +2947,7 @@ async function executeCleanupRunGuarded(
 		);
 		const allWarnings = withSharedPlexWarning(
 			[
-				...warnings,
+				...previewWarnings,
 				...approvalSelection.warnings,
 				...(configuredRunLimitIsValid ? [] : [INVALID_CLEANUP_RUN_LIMIT_WARNING]),
 			],
@@ -2957,6 +2979,7 @@ async function executeCleanupRunGuarded(
 			durationMs: Date.now() - startTime,
 			prefetchHealth,
 			warnings: allWarnings,
+			providerEvidence,
 		};
 
 		await createRunLog(prisma, config.id, result, log);
@@ -3774,6 +3797,10 @@ async function executeQueuedCleanupItems(
 			let approvedPlan = approvedEnvelope?.plan ?? null;
 			let approvedProviderEvidence = approvedEnvelope?.providerEvidence;
 			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
+			const durableEpisodePostPartialMutation =
+				approvedEnvelope?.mutationCheckpoint === "post_partial_mutation" &&
+				approvedPlan?.kind === "verified_sonarr_episode" &&
+				action === "delete";
 			let recoveringEpisodeUnmonitorPartial =
 				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE;
 			let postFileOwnershipPlan:
@@ -3795,7 +3822,8 @@ async function executeQueuedCleanupItems(
 				try {
 					if (
 						recoveringInterruptedMutation &&
-						approvedEnvelope?.mutationCheckpoint === "post_partial_mutation"
+						approvedEnvelope?.mutationCheckpoint === "post_partial_mutation" &&
+						!durableEpisodePostPartialMutation
 					) {
 						approvedProviderEvidence = await renewCurrentProviderRetryAuthority(
 							deps,
@@ -6642,6 +6670,47 @@ function providerEvidenceDependenciesForRules(rules: LibraryCleanupRule[]): Prov
 		dependencies.add("jellyfin_episode");
 	}
 	return [...dependencies].sort();
+}
+
+async function evaluateCleanupPreviewWithProviderEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	config: LibraryCleanupConfig & { rules: LibraryCleanupRule[] },
+) {
+	// Provider publication uses the same durable run claim as cleanup. Holding
+	// it across evaluation and evidence capture binds the response to one cache
+	// generation without turning the preview into an upstream mutation.
+	const lease = await startCleanupRunLease(deps, userId, config.id);
+	try {
+		const evaluation = await evaluateAllItems(deps, config, config.rules);
+		const { providerEvidence, warning: providerEvidenceWarning } =
+			await capturePreviewProviderEvidence(deps, userId, config.rules);
+		return { ...evaluation, providerEvidence, providerEvidenceWarning };
+	} finally {
+		await lease.release();
+	}
+}
+
+async function capturePreviewProviderEvidence(
+	deps: CleanupExecutorDeps,
+	userId: string,
+	rules: LibraryCleanupRule[],
+): Promise<{ providerEvidence?: SanitizedProviderEvidence; warning?: string }> {
+	try {
+		return {
+			providerEvidence: await captureCurrentProviderEvidenceAuthority(
+				deps,
+				userId,
+				providerEvidenceDependenciesForRules(rules),
+			),
+		};
+	} catch (error) {
+		deps.log.warn({ err: error }, "Library cleanup preview provider evidence was unavailable");
+		return {
+			warning:
+				"Cleanup provider evidence was unavailable. Provider-backed decisions were not attributed to a durable cache generation.",
+		};
+	}
 }
 
 function buildApprovalDedupSkipReason(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -6658,7 +6658,7 @@ function providerEvidenceDependenciesForRules(rules: LibraryCleanupRule[]): Prov
 	) {
 		dependencies.add("plex");
 	}
-	if (activeTypes.has("plex_episode_completion")) {
+	if (activeTypes.has("plex_episode_completion") || rules.some(isSupportedEpisodeCleanupRule)) {
 		dependencies.add("plex");
 		dependencies.add("plex_episode");
 	}
@@ -6677,32 +6677,56 @@ async function evaluateCleanupPreviewWithProviderEvidence(
 	userId: string,
 	config: LibraryCleanupConfig & { rules: LibraryCleanupRule[] },
 ) {
-	// Provider publication uses the same durable run claim as cleanup. Holding
-	// it across evaluation and evidence capture binds the response to one cache
-	// generation without turning the preview into an upstream mutation.
-	const lease = await startCleanupRunLease(deps, userId, config.id);
-	try {
-		const evaluation = await evaluateAllItems(deps, config, config.rules);
-		const { providerEvidence, warning: providerEvidenceWarning } =
-			await capturePreviewProviderEvidence(deps, userId, config.rules);
-		return { ...evaluation, providerEvidence, providerEvidenceWarning };
-	} finally {
-		await lease.release();
+	const dependencies = providerEvidenceDependenciesForRules(config.rules);
+	if (dependencies.length === 0) {
+		return {
+			...(await evaluateAllItems(deps, config, config.rules)),
+			providerEvidence: createSanitizedProviderEvidence([], []),
+			providerEvidenceWarning: undefined,
+		};
 	}
+
+	let accepted = await capturePreviewProviderEvidence(deps, userId, dependencies);
+	if (!accepted.providerEvidence) {
+		return withUnavailablePreviewProviderEvidence(
+			await evaluateAllItems(deps, config, config.rules),
+			accepted.warning,
+		);
+	}
+
+	for (let attempt = 0; attempt < 2; attempt++) {
+		const acceptedEvidence = accepted.providerEvidence;
+		if (!acceptedEvidence) throw new Error("Provider evidence retry lost its accepted snapshot");
+		const evaluation = await evaluateAllItems(deps, config, config.rules);
+		const current = await capturePreviewProviderEvidence(deps, userId, dependencies);
+		if (
+			current.providerEvidence &&
+			current.providerEvidence.fingerprint === acceptedEvidence.fingerprint
+		) {
+			return {
+				...evaluation,
+				providerEvidence: acceptedEvidence,
+				providerEvidenceWarning: undefined,
+			};
+		}
+		if (attempt === 0 && current.providerEvidence) {
+			accepted = current;
+			continue;
+		}
+		return withUnavailablePreviewProviderEvidence(evaluation, current.warning);
+	}
+
+	throw new Error("Unreachable provider evidence preview attempt");
 }
 
 async function capturePreviewProviderEvidence(
 	deps: CleanupExecutorDeps,
 	userId: string,
-	rules: LibraryCleanupRule[],
+	dependencies: ProviderCacheType[],
 ): Promise<{ providerEvidence?: SanitizedProviderEvidence; warning?: string }> {
 	try {
 		return {
-			providerEvidence: await captureCurrentProviderEvidenceAuthority(
-				deps,
-				userId,
-				providerEvidenceDependenciesForRules(rules),
-			),
+			providerEvidence: await captureCurrentProviderEvidenceAuthority(deps, userId, dependencies),
 		};
 	} catch (error) {
 		deps.log.warn({ err: error }, "Library cleanup preview provider evidence was unavailable");
@@ -6711,6 +6735,20 @@ async function capturePreviewProviderEvidence(
 				"Cleanup provider evidence was unavailable. Provider-backed decisions were not attributed to a durable cache generation.",
 		};
 	}
+}
+
+function withUnavailablePreviewProviderEvidence(
+	evaluation: Awaited<ReturnType<typeof evaluateAllItems>>,
+	warning?: string,
+) {
+	return {
+		...evaluation,
+		flagged: [],
+		providerEvidence: undefined,
+		providerEvidenceWarning:
+			warning ??
+			"Cleanup provider evidence changed while this preview was evaluated. Cleanup selection was withheld; run the preview again.",
+	};
 }
 
 function buildApprovalDedupSkipReason(

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -4,6 +4,7 @@
  * Internal types for the cleanup rule evaluation pipeline.
  */
 
+import type { CleanupProviderEvidence } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
@@ -287,4 +288,6 @@ export interface CleanupRunResult {
 	error?: string;
 	prefetchHealth?: PrefetchResults;
 	warnings?: string[];
+	/** Sanitized provider generations and row fingerprints used by this preview. */
+	providerEvidence?: CleanupProviderEvidence;
 }

--- a/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
@@ -190,6 +190,12 @@ describe("library cleanup rule scope persistence", () => {
 	});
 
 	it("round-trips episode coordinates through preview without changing the series title", async () => {
+		const providerEvidence = {
+			version: 1 as const,
+			dependencies: ["plex", "plex_episode"],
+			fingerprint: "a".repeat(64),
+			sources: [],
+		};
 		executorMocks.executeCleanupPreview.mockResolvedValueOnce({
 			isDryRun: true,
 			status: "completed",
@@ -219,12 +225,14 @@ describe("library cleanup rule scope persistence", () => {
 				},
 			],
 			durationMs: 1,
-		});
+			providerEvidence,
+		} as never);
 
 		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/preview");
 
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toMatchObject({
+			providerEvidence,
 			items: [
 				{
 					targetScope: "episode",

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -944,6 +944,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						};
 					}),
 					prefetchHealth: result.prefetchHealth,
+					providerEvidence: result.providerEvidence,
 					warnings: [
 						...(result.warnings ?? []),
 						...(hiddenPreviewItems > 0


### PR DESCRIPTION
## Summary

- return sanitized provider-generation and row-fingerprint evidence with interactive previews and configured dry runs
- hold the cleanup run claim across evaluation and evidence capture so provider publication cannot change the attributed snapshot
- degrade unavailable optional Plex, Jellyfin, or Emby authority to an explicit partial preview instead of failing the request
- require exact provider evidence for durable Sonarr episode post-partial retries even if their descriptive error text changes

## Safety

- preview and dry-run paths remain non-destructive; the run claim is coordination-only
- no provider credentials, URLs, names, or raw cache rows are returned
- retry execution still fails closed when exact evidence changed while a physical episode-file mutation may remain
- record-only post-partial retries retain the existing stable authority renewal path

## Validation

- pnpm run format
- pnpm --filter @arr/api run db:generate
- pnpm run typecheck
- pnpm run test (4,978 passing; expected skips only)
- pnpm run lint
- pnpm run build
- independent data-safety and regression reviews completed as one frozen inventory, followed by one correction pass