### PR TITLE
feat(rules): add bounded recursive cleanup grammar

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -508,6 +508,41 @@ describe("mutation policy evidence authority", () => {
 		},
 	);
 
+	it("preserves a matching v0 retention rule with 64 conditions", () => {
+		const conditions = Array.from({ length: 64 }, () => ({
+			ruleType: "year_range",
+			parameters: { operator: "before", year: 2030 },
+		}));
+		const retentionRule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-retain-64",
+				priority: 1,
+				retentionMode: true,
+				operator: "AND",
+				conditions: JSON.stringify(conditions),
+			},
+		);
+		const deleteRule = mutationEvidenceRule("year_range", {
+			operator: "before",
+			year: 2030,
+		});
+
+		const result = evaluateItemMutationPolicyStateViaEngine(
+			mutationEvidenceItem({ _arrDashboardEvidence: {} }) as never,
+			[deleteRule, retentionRule] as never,
+			"RADARR",
+			{ now: new Date() },
+		);
+
+		expect(result).toEqual({
+			kind: "retained",
+			ruleId: "rule-retain-64",
+			evidence: "true",
+		});
+	});
+
 	it("authorizes hdr_type only when the dynamic-range field was explicit", () => {
 		const rule = mutationEvidenceRule("hdr_type", { operator: "is", types: ["HDR10"] });
 		const explicit = evaluateItemMutationPolicyStateViaEngine(

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -7153,6 +7153,41 @@ describe("shared Plex deletion safety", () => {
 		});
 	});
 
+	it("fails closed for a NOT exemption before executing an approved mutation", async () => {
+		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
+		const storedApproval = approvalRecord() as Record<string, unknown>;
+		configureApprovalStore(deps, storedApproval);
+		vi.mocked(deps.prisma.crossDomainRule.findMany).mockResolvedValue([
+			deployedCleanupExemption({
+				version: 1,
+				root: {
+					not: {
+						kind: "year_range",
+						params: { operator: "after", year: 2030 },
+					},
+				},
+			}),
+		] as never);
+
+		const result = await executeApprovedItems(deps, "user-1", ["approval-1"]);
+
+		expect(result).toEqual({
+			removed: 0,
+			failed: 1,
+			errors: [
+				"Skipped for safety: current deployed cleanup exemption policy covers this ARR target.",
+			],
+		});
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(storedApproval).toMatchObject({
+			status: "pending",
+			executionToken: null,
+			lastExecutionError:
+				"Skipped for safety: current deployed cleanup exemption policy covers this ARR target.",
+		});
+	});
+
 	it("evaluates execution-time exemptions from the live ARR resource", async () => {
 		const { deps, deleteMovie, deleteMovieFile } = makeDeps({
 			mediaPartCount: 1,
@@ -7284,6 +7319,45 @@ describe("shared Plex deletion safety", () => {
 				root: {
 					kind: "year_range",
 					params: { operator: "before", year: 2030 },
+				},
+			}),
+		] as never);
+
+		const result = await executeRetryItems(deps, "user-1", ["approval-1"]);
+
+		expect(result).toEqual({
+			removed: 0,
+			reconciled: 0,
+			failed: 1,
+			errors: [
+				"Skipped for safety: current deployed cleanup exemption policy covers this ARR target.",
+			],
+		});
+		expect(deleteMovieFile).not.toHaveBeenCalled();
+		expect(deleteMovie).not.toHaveBeenCalled();
+		expect(storedRetry).toMatchObject({
+			status: "expired",
+			executionToken: null,
+			lastExecutionError:
+				"Skipped for safety: current deployed cleanup exemption policy covers this ARR target.",
+		});
+	});
+
+	it("fails closed for a NOT exemption before resuming a durable retry mutation", async () => {
+		const { deps, deleteMovie, deleteMovieFile } = makeDeps({ mediaPartCount: 1 });
+		const storedRetry = approvalRecord({
+			status: "retry_pending",
+			executionToken: null,
+		}) as Record<string, unknown>;
+		configureApprovalStore(deps, storedRetry);
+		vi.mocked(deps.prisma.crossDomainRule.findMany).mockResolvedValue([
+			deployedCleanupExemption({
+				version: 1,
+				root: {
+					not: {
+						kind: "year_range",
+						params: { operator: "after", year: 2030 },
+					},
 				},
 			}),
 		] as never);

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -18,6 +18,7 @@ import {
 	type DataSourceDependency,
 	groupChildren,
 	isKindLegalForContext,
+	isRuleNot,
 	isRulePredicate,
 	type RuleDocument,
 	type RuleNode,
@@ -6451,6 +6452,17 @@ function cleanupExemptionScopeApplies(
 	return true;
 }
 
+function containsRuleNot(root: RuleNode): boolean {
+	const pending = [root];
+	while (pending.length > 0) {
+		const node = pending.pop();
+		if (!node || isRulePredicate(node)) continue;
+		if (isRuleNot(node)) return true;
+		pending.push(...groupChildren(node));
+	}
+	return false;
+}
+
 async function loadCleanupExemptionPolicy(
 	deps: CleanupExecutorDeps,
 	userId: string,
@@ -6516,7 +6528,12 @@ async function loadCleanupExemptionPolicy(
 			if (!isKindLegalForContext("library-cleanup", predicate.kind)) return true;
 			return !ruleParamSchemaMap[predicate.kind]?.safeParse(predicate.params).success;
 		});
-		if (predicates.length === 0 || invalidPredicate || validateV1Depth(parsedDocument.data)) {
+		if (
+			predicates.length === 0 ||
+			invalidPredicate ||
+			containsRuleNot(parsedDocument.data.root) ||
+			validateV1Depth(parsedDocument.data)
+		) {
 			policy.unusableScopes.push(parsedScope.data);
 			deps.log.error(
 				{ ruleId: row.id },

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -392,6 +392,80 @@ describe("parity — composites", () => {
 	it("legacy quirk — unparseable composite conditions no-match", () => {
 		assertParity(makeRule({ ruleType: "composite", operator: "AND", conditions: "not-json{{{" }));
 	});
+
+	it("evaluates a self-describing recursive document stored in conditions", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						all: [
+							{ kind: "age", params: ageCond.parameters },
+							{
+								any: [
+									{ kind: "size", params: noMatchCond.parameters },
+									{ kind: "size", params: sizeCond.parameters },
+								],
+							},
+						],
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
+		expect(result?.reason).toContain(" AND ");
+	});
+
+	it("fails closed when NOT receives unavailable cleanup evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: { kind: "plex_last_watched", params: { operator: "older_than", days: 30 } },
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx({ plexMap: new Map() }),
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("temporarily treats a legacy false leaf as unknown under NOT until Task 3", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({ arrAddedAt: new Date("2026-02-28T00:00:00Z") }),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: { kind: "age", params: { operator: "older_than", days: 30 } },
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
+		// evaluateSingleCondition currently collapses proven false and unavailable
+		// evidence to null. Wave 3A converts that null to unknown so NOT cannot
+		// authorize deletion; Task 3 will supply evidence-aware leaf states.
+		expect(result).toBeNull();
+	});
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/lib/rules/__tests__/engine.test.ts
+++ b/apps/api/src/lib/rules/__tests__/engine.test.ts
@@ -17,6 +17,7 @@ import {
 	listUnavailableKinds,
 	normalizeDocument,
 	type PredicateEvaluator,
+	UNKNOWN,
 } from "../engine.js";
 
 /** Evaluator stub: kind "match_*" matches with its suffix as reason. */
@@ -98,10 +99,51 @@ describe("evaluateNode — any groups (legacy OR semantics)", () => {
 	});
 });
 
-describe("evaluateDocument — recursion ready", () => {
-	it("evaluates nested groups correctly even though v1 writes are depth-1", () => {
-		// The engine handles depth the grammar permits structurally; the
-		// depth-1 restriction is a write-path policy, not an engine limit.
+describe("evaluateNode — NOT and three-valued composition", () => {
+	const threeValuedEvaluator: PredicateEvaluator = (p) => {
+		if (p.kind === "match") return "reason:match";
+		if (p.kind === "unknown") return UNKNOWN;
+		return null;
+	};
+
+	it("inverts true and false while preserving unknown", () => {
+		expect(evaluateNode({ not: { kind: "match", params: {} } }, threeValuedEvaluator)).toEqual({
+			matched: false,
+		});
+		expect(evaluateNode({ not: { kind: "no_match", params: {} } }, threeValuedEvaluator)).toEqual({
+			matched: true,
+			reason: "NOT",
+		});
+		expect(evaluateNode({ not: { kind: "unknown", params: {} } }, threeValuedEvaluator)).toEqual({
+			matched: false,
+			unknown: true,
+		});
+	});
+
+	it("propagates unknown through nested all, any, and not", () => {
+		const result = evaluateDocument(
+			doc({
+				all: [
+					{ kind: "match", params: {} },
+					{
+						not: {
+							any: [
+								{ kind: "no_match", params: {} },
+								{ kind: "unknown", params: {} },
+							],
+						},
+					},
+				],
+			}),
+			threeValuedEvaluator,
+		);
+
+		expect(result).toEqual({ matched: false, unknown: true });
+	});
+});
+
+describe("evaluateDocument — recursive composition", () => {
+	it("evaluates nested groups correctly", () => {
 		const result = evaluateDocument(
 			doc({
 				all: [

--- a/apps/api/src/lib/rules/__tests__/notifications-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/notifications-parity.test.ts
@@ -144,4 +144,17 @@ describe("notifications parity — composition", () => {
 			]),
 		).toBe(false);
 	});
+
+	it("preserves the v0 maximum of 64 matching conditions", () => {
+		const conditions = Array.from(
+			{ length: 64 },
+			(): RuleCondition => ({
+				field: "eventType",
+				operator: "equals",
+				value: "HUNT_COMPLETED",
+			}),
+		);
+
+		expect(assertParity(payload(), conditions)).toBe(true);
+	});
 });

--- a/apps/api/src/lib/rules/__tests__/v0-mappers.test.ts
+++ b/apps/api/src/lib/rules/__tests__/v0-mappers.test.ts
@@ -133,6 +133,75 @@ describe("mapCriteriaV0ToDocument — composites", () => {
 		expect(doc.root).toEqual({ all: [] });
 	});
 
+	it("parses a self-describing v1 document from composite conditions", () => {
+		const expression = {
+			version: 1,
+			root: {
+				not: {
+					all: [{ kind: "age", params: { operator: "older_than", days: 30 } }],
+				},
+			},
+		};
+		expect(
+			mapCriteriaV0ToDocument(
+				row({
+					ruleType: "composite",
+					parameters: "{}",
+					operator: null,
+					conditions: JSON.stringify(expression),
+				}),
+			),
+		).toEqual(expression);
+	});
+
+	it.each([
+		[
+			{
+				ruleType: "composite",
+				operator: "AND",
+				conditions: JSON.stringify({ version: 1, root: sizeCond }),
+			},
+			"operator",
+		],
+		[
+			{
+				ruleType: "age",
+				operator: null,
+				conditions: JSON.stringify({ version: 1, root: sizeCond }),
+			},
+			"ruleType",
+		],
+		[
+			{ ruleType: "composite", operator: null, conditions: JSON.stringify([sizeCond]) },
+			"v1 document",
+		],
+		[
+			{
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({ version: 1, root: { nope: [] } }),
+			},
+			"invalid",
+		],
+	])("rejects mixed or malformed v1 cleanup storage %#", (overrides, message) => {
+		expect(() => mapCriteriaV0ToDocument(row(overrides))).toThrow(message);
+	});
+
+	it("keeps a legacy leaf row with stray conditions on its original single-rule path", () => {
+		const doc = mapCriteriaV0ToDocument(
+			row({
+				ruleType: "age",
+				operator: null,
+				conditions: JSON.stringify([sizeCond]),
+			}),
+		);
+		expect(doc.root).toEqual({
+			kind: "age",
+			params: { field: "arrAddedAt", operator: "older_than", days: 365 },
+		});
+	});
+
 	it("leaf ruleType carrying operator+conditions maps as COMPOSITE — conditions win (review shape)", () => {
 		// Legacy evaluateRule keys the composite path on operator+conditions,
 		// ignoring the leaf ruleType/parameters entirely. The mapper must

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -44,7 +44,7 @@ import type {
 } from "../library-cleanup/types.js";
 import type { LibraryCleanupRule } from "../prisma.js";
 import { safeJsonParse } from "../utils/json.js";
-import { evaluateDocument, type PredicateEvaluator } from "./engine.js";
+import { evaluateDocument, type PredicateEvaluator, UNKNOWN } from "./engine.js";
 import { mapCriteriaV0ToDocument } from "./v0-mappers.js";
 
 /**
@@ -70,10 +70,12 @@ export function evaluateRuleViaEngine(
 
 	// Domain quirk guards (rule-level policy, deliberately NOT in the
 	// engine — see engine.ts header on empty-group semantics).
+	const isStoredV1Document =
+		rule.ruleType === "composite" && rule.operator === null && rule.conditions !== null;
 	if (rule.operator && rule.conditions) {
 		const conditions = safeJsonParse(rule.conditions) as unknown[] | null;
 		if (!conditions?.length) return null;
-	} else {
+	} else if (!isStoredV1Document) {
 		const params = safeJsonParse(rule.parameters) as Record<string, unknown> | null;
 		if (!params) return null;
 	}
@@ -86,8 +88,20 @@ export function evaluateRuleViaEngine(
 		return null;
 	}
 
-	const evalPredicate: PredicateEvaluator = (predicate) =>
-		evaluateSingleCondition(item, predicate.kind, predicate.params, ctx, plexLibFilter);
+	const evalPredicate: PredicateEvaluator = (predicate) => {
+		const reason = evaluateSingleCondition(
+			item,
+			predicate.kind,
+			predicate.params,
+			ctx,
+			plexLibFilter,
+		);
+		// Temporary Wave 3A bridge: the legacy evaluator collapses proven false
+		// and unavailable evidence to null. Recursive cleanup documents treat that
+		// null as unknown so NOT cannot create deletion authority. Task 3 replaces
+		// this bridge with evidence-aware true/false/unknown predicate results.
+		return reason ?? (isStoredV1Document ? UNKNOWN : null);
+	};
 
 	const result = evaluateDocument(doc, evalPredicate);
 	return result.matched

--- a/apps/api/src/lib/rules/engine.ts
+++ b/apps/api/src/lib/rules/engine.ts
@@ -32,6 +32,7 @@
 
 import {
 	groupChildren,
+	isRuleNot,
 	isRulePredicate,
 	type RuleDocument,
 	type RuleGroup,
@@ -44,21 +45,29 @@ import {
 // ============================================================================
 
 /**
- * A predicate evaluator returns the human-readable match reason, or
- * null for no-match. Unknown/retired kinds and stale params MUST return
- * null (tier-3 permissive null), never throw.
+ * `null` retains the legacy no-match contract used by notifications and
+ * auto-tag. Cleanup v1 callers opt into `UNKNOWN` when their source evidence
+ * is unavailable; that distinction is necessary for NOT to fail closed.
  */
-export type PredicateEvaluator = (predicate: RulePredicate) => string | null;
+export const UNKNOWN = Symbol("rule-evaluation-unknown");
 
-export type EvalResult = { matched: true; reason: string } | { matched: false };
+export type PredicateEvaluator = (predicate: RulePredicate) => string | null | typeof UNKNOWN;
+
+export type EvalResult =
+	| { matched: true; reason: string }
+	| { matched: false; unknown?: false }
+	| { matched: false; unknown: true };
 
 const NO_MATCH: EvalResult = { matched: false };
+const UNKNOWN_RESULT: EvalResult = { matched: false, unknown: true };
 
 export function evaluateNode(node: RuleNode, evalPredicate: PredicateEvaluator): EvalResult {
 	if (isRulePredicate(node)) {
 		const reason = evalPredicate(node);
+		if (reason === UNKNOWN) return UNKNOWN_RESULT;
 		return reason === null ? NO_MATCH : { matched: true, reason };
 	}
+	if (isRuleNot(node)) return evaluateNot(node, evalPredicate);
 	return evaluateGroup(node, evalPredicate);
 }
 
@@ -69,20 +78,39 @@ function evaluateGroup(group: RuleGroup, evalPredicate: PredicateEvaluator): Eva
 		// Vacuous truth on []: notifications' "no conditions = match all
 		// events". Cleanup never reaches here with [] (adapter guard).
 		const reasons: string[] = [];
+		let hasUnknown = false;
 		for (const child of children) {
 			const result = evaluateNode(child, evalPredicate);
-			if (!result.matched) return NO_MATCH;
-			reasons.push(result.reason);
+			if (result.matched) {
+				reasons.push(result.reason);
+			} else if (result.unknown) {
+				hasUnknown = true;
+			} else {
+				return NO_MATCH;
+			}
 		}
+		if (hasUnknown) return UNKNOWN_RESULT;
 		return { matched: true, reason: reasons.join(" AND ") };
 	}
 
 	// any: first matching child's reason only (legacy OR semantics)
+	let hasUnknown = false;
 	for (const child of children) {
 		const result = evaluateNode(child, evalPredicate);
 		if (result.matched) return result;
+		if (result.unknown) hasUnknown = true;
 	}
-	return NO_MATCH;
+	return hasUnknown ? UNKNOWN_RESULT : NO_MATCH;
+}
+
+function evaluateNot(
+	node: Extract<RuleNode, { not: RuleNode }>,
+	evalPredicate: PredicateEvaluator,
+): EvalResult {
+	const result = evaluateNode(node.not, evalPredicate);
+	if (!result.matched && result.unknown) return UNKNOWN_RESULT;
+	if (result.matched) return NO_MATCH;
+	return { matched: true, reason: "NOT" };
 }
 
 export function evaluateDocument(doc: RuleDocument, evalPredicate: PredicateEvaluator): EvalResult {
@@ -119,6 +147,7 @@ function annotateNode(node: RuleNode, legalKinds: ReadonlySet<string>): RuleNode
 		}
 		return { ...node, unavailableKind: true };
 	}
+	if (isRuleNot(node)) return { not: annotateNode(node.not, legalKinds) };
 	if ("all" in node) {
 		return { all: node.all.map((child) => annotateNode(child, legalKinds)) };
 	}
@@ -131,6 +160,10 @@ export function listUnavailableKinds(doc: RuleDocument, legalKinds: ReadonlySet<
 	const walk = (node: RuleNode): void => {
 		if (isRulePredicate(node)) {
 			if (!legalKinds.has(node.kind)) found.add(node.kind);
+			return;
+		}
+		if (isRuleNot(node)) {
+			walk(node.not);
 			return;
 		}
 		for (const child of groupChildren(node)) walk(child);

--- a/apps/api/src/lib/rules/v0-mappers.ts
+++ b/apps/api/src/lib/rules/v0-mappers.ts
@@ -28,6 +28,7 @@ import {
 	type RuleDocument,
 	type RuleNode,
 	ruleDocumentSchema,
+	validateV1Bounds,
 } from "@arr/shared";
 
 // ============================================================================
@@ -93,6 +94,49 @@ function parseJsonObject(raw: string, what: string): Record<string, unknown> {
 	return parsed as Record<string, unknown>;
 }
 
+function parseStoredV1Document(row: CriteriaV0Row): RuleDocument | null {
+	if (row.conditions === null) return null;
+
+	let conditions: unknown;
+	try {
+		conditions = JSON.parse(row.conditions);
+	} catch {
+		if (row.ruleType === "composite" && row.operator === null) {
+			throw new V0MapperError("composite conditions must be a self-describing v1 document");
+		}
+		return null;
+	}
+	const isEnvelope =
+		conditions !== null &&
+		typeof conditions === "object" &&
+		!Array.isArray(conditions) &&
+		Object.hasOwn(conditions, "version");
+
+	if (!isEnvelope) {
+		if (row.ruleType === "composite" && row.operator === null) {
+			throw new V0MapperError("composite conditions must be a self-describing v1 document");
+		}
+		return null;
+	}
+	if (row.ruleType !== "composite") {
+		throw new V0MapperError("v1 cleanup document requires ruleType composite");
+	}
+	if (row.operator !== null) {
+		throw new V0MapperError("v1 cleanup document requires operator null");
+	}
+	const params = parseJsonObject(row.parameters || "{}", "rule parameters");
+	if (Object.keys(params).length > 0) {
+		throw new V0MapperError("v1 cleanup document cannot mix legacy parameters");
+	}
+	const parsed = ruleDocumentSchema.safeParse(conditions);
+	if (!parsed.success) {
+		throw new V0MapperError("v1 cleanup document is invalid", parsed.error.flatten());
+	}
+	const boundsError = validateV1Bounds(parsed.data);
+	if (boundsError) throw new V0MapperError(boundsError);
+	return parsed.data;
+}
+
 /**
  * Map a cleanup/auto-tag v0 row to a v1 document (near-identity, §3).
  *
@@ -105,6 +149,9 @@ function parseJsonObject(raw: string, what: string): Record<string, unknown> {
  * crashed boot or a 500'd list.
  */
 export function mapCriteriaV0ToDocument(row: CriteriaV0Row): RuleDocument {
+	const v1Document = parseStoredV1Document(row);
+	if (v1Document) return v1Document;
+
 	// Composite-mode discriminator MUST match legacy `evaluateRule`
 	// (`rule.operator && rule.conditions`), NOT `ruleType === "composite"`.
 	// A stored row with a leaf ruleType plus operator+conditions evaluates
@@ -115,6 +162,9 @@ export function mapCriteriaV0ToDocument(row: CriteriaV0Row): RuleDocument {
 	// rejects the mixed shape, but stored rows predating that guard must
 	// keep their legacy meaning forever.
 	if (!(row.operator && row.conditions)) {
+		if (row.ruleType.length === 0) {
+			throw new V0MapperError("single rule has no ruleType");
+		}
 		const doc: RuleDocument = {
 			version: 1,
 			root: {
@@ -122,7 +172,7 @@ export function mapCriteriaV0ToDocument(row: CriteriaV0Row): RuleDocument {
 				params: parseJsonObject(row.parameters || "{}", "rule parameters"),
 			},
 		};
-		return ruleDocumentSchema.parse(doc);
+		return doc;
 	}
 
 	if (row.operator !== "AND" && row.operator !== "OR") {
@@ -158,7 +208,7 @@ export function mapCriteriaV0ToDocument(row: CriteriaV0Row): RuleDocument {
 		version: 1,
 		root: row.operator === "AND" ? { all: children } : { any: children },
 	};
-	return ruleDocumentSchema.parse(doc);
+	return doc;
 }
 
 // ============================================================================
@@ -197,5 +247,5 @@ export function mapNotificationsV0ToDocument(conditions: unknown): RuleDocument 
 	});
 
 	const doc: RuleDocument = { version: 1, root: { all: children } };
-	return ruleDocumentSchema.parse(doc);
+	return doc;
 }

--- a/apps/web/src/features/console/components/__tests__/rule-document-view.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/rule-document-view.test.tsx
@@ -39,6 +39,34 @@ describe("<RuleDocumentView />", () => {
 		expect(screen.getByText("Any of")).toBeInTheDocument();
 	});
 
+	it("renders nested groups and NOT without dropping predicates", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "age", params: { operator: "older_than", days: 90 } },
+					{
+						not: {
+							any: [
+								{ kind: "genre", params: { genres: ["Horror"] } },
+								{ kind: "no_file", params: {} },
+							],
+						},
+					},
+				],
+			},
+		};
+
+		render(<RuleDocumentView document={doc} context="library-cleanup" incognito={false} />);
+
+		expect(screen.getByText("All of")).toBeInTheDocument();
+		expect(screen.getByText("Not")).toBeInTheDocument();
+		expect(screen.getByText("Any of")).toBeInTheDocument();
+		expect(screen.getByText("Age")).toBeInTheDocument();
+		expect(screen.getByText("Genre")).toBeInTheDocument();
+		expect(screen.getByText("No file")).toBeInTheDocument();
+	});
+
 	it("annotates an empty group as 'matches every event' for notifications", () => {
 		const doc: RuleDocument = { version: 1, root: { all: [] } };
 		render(<RuleDocumentView document={doc} context="notifications" incognito={false} />);

--- a/apps/web/src/features/console/components/rule-document-view.tsx
+++ b/apps/web/src/features/console/components/rule-document-view.tsx
@@ -3,9 +3,8 @@
 /**
  * Read-only renderer for a v1 {@link RuleDocument} (charter §5.1 read surface).
  *
- * Walks the document tree with the grammar helpers and renders each predicate
- * as a humanized row. Depth is v1-limited to 1 (one group level), so the tree
- * is a root predicate OR a single all/any group of predicates.
+ * Walks the bounded recursive document tree and renders every all/any/not node
+ * and predicate without flattening its meaning.
  *
  * Empty-group honesty: the three domains' live evaluators disagree on an empty
  * group, so the annotation is context-aware — cleanup and auto-tag no-match an
@@ -14,7 +13,7 @@
  */
 
 import type { RuleContextId, RuleDocument, RuleNode } from "@arr/shared";
-import { groupChildren, isRulePredicate } from "@arr/shared";
+import { groupChildren, isRuleNot, isRulePredicate } from "@arr/shared";
 import { AlertTriangle } from "lucide-react";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { describePredicate } from "../lib/describe-predicate";
@@ -70,33 +69,50 @@ export function RuleDocumentView({
 	context: RuleContextId;
 	incognito: boolean;
 }) {
-	const root = document.root;
+	return <RuleNodeView node={document.root} context={context} incognito={incognito} />;
+}
 
-	if (isRulePredicate(root)) {
-		return <PredicateRow node={root} incognito={incognito} />;
+function RuleNodeView({
+	node,
+	context,
+	incognito,
+}: {
+	node: RuleNode;
+	context: RuleContextId;
+	incognito: boolean;
+}) {
+	if (isRulePredicate(node)) return <PredicateRow node={node} incognito={incognito} />;
+
+	if (isRuleNot(node)) {
+		return (
+			<div className="space-y-1.5">
+				<span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+					Not
+				</span>
+				<div className="border-l border-border/50 pl-3">
+					<RuleNodeView node={node.not} context={context} incognito={incognito} />
+				</div>
+			</div>
+		);
 	}
 
-	const children = groupChildren(root);
+	const children = groupChildren(node);
 	if (children.length === 0) {
 		return <p className="text-sm italic text-muted-foreground">{emptyGroupNote(context)}</p>;
 	}
 
-	const joiner = "all" in root ? "All of" : "Any of";
+	const joiner = "all" in node ? "All of" : "Any of";
 
 	return (
 		<div className="space-y-1.5">
 			<span className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
 				{joiner}
 			</span>
-			<div className="space-y-1">
-				{children.map((child, index) =>
-					isRulePredicate(child) ? (
-						// Stable enough: v1 depth-1 means children are a flat predicate
-						// list rendered in document order.
-						// biome-ignore lint/suspicious/noArrayIndexKey: predicates have no id; order is stable
-						<PredicateRow key={index} node={child} incognito={incognito} />
-					) : null,
-				)}
+			<div className="space-y-1 border-l border-border/50 pl-3">
+				{children.map((child, index) => (
+					// biome-ignore lint/suspicious/noArrayIndexKey: rule nodes have no id; order is stable
+					<RuleNodeView key={index} node={child} context={context} incognito={incognito} />
+				))}
 			</div>
 		</div>
 	);

--- a/apps/web/src/features/console/lib/__tests__/notification-rule-editor.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/notification-rule-editor.test.ts
@@ -64,4 +64,31 @@ describe("notification rule editor", () => {
 			{ id: "condition-0", field: "body", operator: "greater_than", value: 12 },
 		]);
 	});
+
+	it.each([
+		{
+			version: 1 as const,
+			root: {
+				not: {
+					kind: "field_match",
+					params: { field: "title", operator: "contains", value: "Radarr" },
+				},
+			},
+		},
+		{
+			version: 1 as const,
+			root: {
+				all: [
+					{
+						not: {
+							kind: "field_match",
+							params: { field: "title", operator: "contains", value: "Radarr" },
+						},
+					},
+				],
+			},
+		},
+	])("rejects recursive expressions instead of flattening notification v0 storage", (document) => {
+		expect(() => decomposeNotificationDocument(document)).toThrow(/notification v0/i);
+	});
 });

--- a/apps/web/src/features/console/lib/__tests__/rule-document-editor.test.ts
+++ b/apps/web/src/features/console/lib/__tests__/rule-document-editor.test.ts
@@ -14,6 +14,7 @@ import {
 	buildCriteriaDocument,
 	type CriteriaEditorState,
 	decomposeCriteriaDocument,
+	isCriteriaDocumentV0Editable,
 	toCriteriaV0Payload,
 	validateCriteriaEditor,
 } from "../rule-document-editor";
@@ -53,6 +54,30 @@ describe("buildCriteriaDocument", () => {
 });
 
 describe("decomposeCriteriaDocument", () => {
+	it("identifies recursive and NOT documents as read-only for the flat v0 editor", () => {
+		const recursive: RuleDocument = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "age", params: { operator: "older_than", days: 90 } },
+					{ not: { kind: "no_file", params: {} } },
+				],
+			},
+		};
+
+		expect(isCriteriaDocumentV0Editable(recursive)).toBe(false);
+		expect(() => decomposeCriteriaDocument(recursive)).toThrow(/recursive/i);
+	});
+
+	it("keeps a flat all/any document editable", () => {
+		const flat: RuleDocument = {
+			version: 1,
+			root: { any: [{ kind: "no_file", params: {} }] },
+		};
+
+		expect(isCriteriaDocumentV0Editable(flat)).toBe(true);
+	});
+
 	it("predicate root → single mode with one condition", () => {
 		const doc: RuleDocument = {
 			version: 1,

--- a/apps/web/src/features/console/lib/notification-rule-editor.ts
+++ b/apps/web/src/features/console/lib/notification-rule-editor.ts
@@ -8,6 +8,7 @@ import {
 	FIELD_MATCH_KIND,
 	fieldMatchParamsSchema,
 	isKindLegalForContext,
+	isRuleNot,
 	isRulePredicate,
 	type RuleCondition,
 	type RuleDocument,
@@ -40,7 +41,13 @@ export function buildNotificationDocument(state: NotificationEditorState): RuleD
 
 export function decomposeNotificationDocument(doc: RuleDocument): NotificationEditorState {
 	const root = doc.root;
+	if (isRuleNot(root)) {
+		throw new Error("NOT expressions are not editable in notification v0 storage");
+	}
 	const nodes = isRulePredicate(root) ? [root] : "all" in root ? root.all : root.any;
+	if (!nodes.every(isRulePredicate)) {
+		throw new Error("Recursive expressions are not editable in notification v0 storage");
+	}
 
 	return {
 		conditions: nodes.map((node, index) => ({

--- a/apps/web/src/features/console/lib/rule-document-editor.ts
+++ b/apps/web/src/features/console/lib/rule-document-editor.ts
@@ -21,6 +21,7 @@
 import {
 	type CriteriaV0Payload,
 	isKindLegalForContext,
+	isRuleNot,
 	isRulePredicate,
 	type RuleContextId,
 	type RuleDocument,
@@ -79,6 +80,15 @@ export function buildCriteriaDocument(state: CriteriaEditorState): RuleDocument 
 	};
 }
 
+/** Whether the flat editor can round-trip this document without changing its meaning. */
+export function isCriteriaDocumentV0Editable(doc: RuleDocument): boolean {
+	const root = doc.root;
+	if (isRulePredicate(root)) return true;
+	if (isRuleNot(root)) return false;
+	const children = "all" in root ? root.all : root.any;
+	return children.every(isRulePredicate);
+}
+
 /**
  * v1 document → editor state (edit prefill). A predicate root is single mode; a
  * group is composite with operator + child predicates. Retired-kind predicates
@@ -95,19 +105,22 @@ export function decomposeCriteriaDocument(doc: RuleDocument): CriteriaEditorStat
 			conditions: [{ id: "cond-0", kind: root.kind, params: root.params }],
 		};
 	}
+	if (isRuleNot(root)) {
+		throw new Error("Recursive criteria documents cannot be edited by the flat v0 editor");
+	}
 
 	const isAll = "all" in root;
 	const children = isAll ? root.all : root.any;
+	if (!children.every(isRulePredicate)) {
+		throw new Error("Recursive criteria documents cannot be edited by the flat v0 editor");
+	}
 	return {
 		mode: "composite",
 		operator: isAll ? "all" : "any",
 		conditions: children.map((child, i) => ({
 			id: `cond-${i}`,
-			// Depth-1: children are predicates. A stray nested group (shouldn't
-			// occur from the read API) collapses to an empty predicate row that
-			// validation then flags.
-			kind: isRulePredicate(child) ? child.kind : "",
-			params: isRulePredicate(child) ? child.params : {},
+			kind: child.kind,
+			params: child.params,
 		})),
 	};
 }

--- a/packages/shared/src/rules/__tests__/grammar.test.ts
+++ b/packages/shared/src/rules/__tests__/grammar.test.ts
@@ -7,11 +7,18 @@
 import { describe, expect, it } from "vitest";
 import {
 	CONTEXT_KINDS,
+	groupChildren,
 	isKindLegalForContext,
+	isRuleGroup,
 	listKindsMissingParamSchemas,
+	nodeCount,
 	nodeDepth,
+	RULE_DOCUMENT_V1_MAX_DEPTH,
+	RULE_DOCUMENT_V1_MAX_NODES,
 	type RuleDocument,
+	type RuleNot,
 	ruleDocumentSchema,
+	validateV1Bounds,
 	validateV1Depth,
 	walkPredicates,
 } from "../index.js";
@@ -33,13 +40,54 @@ describe("ruleDocumentSchema", () => {
 		).not.toThrow();
 	});
 
-	it("permits recursion structurally (depth is a separate write-time check)", () => {
+	it("accepts recursive NOT nodes alongside all/any groups", () => {
+		const doc = {
+			version: 1,
+			root: { all: [predicate, { not: { any: [predicate] } }] },
+		};
+		expect(ruleDocumentSchema.parse(doc)).toEqual(doc);
+	});
+
+	it("accepts nested groups within the document bounds", () => {
 		const nested = { version: 1, root: { all: [{ any: [predicate] }] } };
 		expect(() => ruleDocumentSchema.parse(nested)).not.toThrow();
 	});
 
 	it("rejects non-v1 versions", () => {
 		expect(() => ruleDocumentSchema.parse({ version: 2, root: predicate })).toThrow();
+	});
+
+	it.each([
+		{ version: 1, root: predicate, unexpected: true },
+		{ version: 1, root: { ...predicate, unexpected: true } },
+		{ version: 1, root: { all: [predicate], unexpected: true } },
+		{ version: 1, root: { any: [predicate], unexpected: true } },
+		{ version: 1, root: { not: predicate, unexpected: true } },
+		{ version: 1, root: { all: [predicate], any: [predicate] } },
+	])("rejects an envelope or node with an ambiguous/unknown field %#", (doc) => {
+		expect(ruleDocumentSchema.safeParse(doc).success).toBe(false);
+	});
+
+	it("rejects a far-over-depth tree without overflowing the parser stack", () => {
+		let root: unknown = predicate;
+		for (let depth = 0; depth < 10_000; depth += 1) root = { not: root };
+
+		let result: ReturnType<typeof ruleDocumentSchema.safeParse> | undefined;
+		expect(() => {
+			result = ruleDocumentSchema.safeParse({ version: 1, root });
+		}).not.toThrow();
+		expect(result?.success).toBe(false);
+	});
+
+	it("rejects a cyclic node graph without overflowing the parser stack", () => {
+		const cyclicNode: { not?: unknown } = {};
+		cyclicNode.not = cyclicNode;
+
+		let result: ReturnType<typeof ruleDocumentSchema.safeParse> | undefined;
+		expect(() => {
+			result = ruleDocumentSchema.safeParse({ version: 1, root: cyclicNode });
+		}).not.toThrow();
+		expect(result?.success).toBe(false);
 	});
 });
 
@@ -50,20 +98,64 @@ describe("depth validation", () => {
 		expect(validateV1Depth({ version: 1, root: { all: [predicate] } })).toBeNull();
 	});
 
-	it("nested groups exceed the v1 limit", () => {
+	it("nested groups are legal within the recursive v1 limit", () => {
 		const doc: RuleDocument = { version: 1, root: { all: [{ any: [predicate] }] } };
-		expect(validateV1Depth(doc)).toMatch(/depth limit/);
+		expect(validateV1Depth(doc)).toBeNull();
 	});
 
 	it("an empty group is depth 1 (legal) — the disabled-orphan shape", () => {
 		expect(validateV1Depth({ version: 1, root: { all: [] } })).toBeNull();
 	});
+
+	it("permits the maximum recursive depth and rejects one more level", () => {
+		let atLimit: RuleDocument["root"] = predicate;
+		for (let depth = 0; depth < RULE_DOCUMENT_V1_MAX_DEPTH; depth += 1) {
+			atLimit = { not: atLimit };
+		}
+		const overLimit = { not: atLimit };
+
+		expect(nodeDepth(atLimit)).toBe(RULE_DOCUMENT_V1_MAX_DEPTH);
+		expect(validateV1Bounds({ version: 1, root: atLimit })).toBeNull();
+		expect(ruleDocumentSchema.safeParse({ version: 1, root: atLimit }).success).toBe(true);
+		expect(validateV1Bounds({ version: 1, root: overLimit })).toMatch(/depth limit/);
+		expect(ruleDocumentSchema.safeParse({ version: 1, root: overLimit }).success).toBe(false);
+	});
+
+	it("permits the maximum node count and rejects one more node", () => {
+		const atLimit = {
+			version: 1 as const,
+			root: {
+				all: Array.from({ length: RULE_DOCUMENT_V1_MAX_NODES - 1 }, () => predicate),
+			},
+		};
+		const overLimit = {
+			version: 1 as const,
+			root: {
+				all: Array.from({ length: RULE_DOCUMENT_V1_MAX_NODES }, () => predicate),
+			},
+		};
+
+		expect(nodeCount(atLimit.root)).toBe(RULE_DOCUMENT_V1_MAX_NODES);
+		expect(validateV1Bounds(atLimit)).toBeNull();
+		expect(ruleDocumentSchema.safeParse(atLimit).success).toBe(true);
+		expect(validateV1Bounds(overLimit)).toMatch(/node limit/);
+		expect(ruleDocumentSchema.safeParse(overLimit).success).toBe(false);
+	});
 });
 
 describe("walkPredicates", () => {
 	it("yields every predicate depth-first", () => {
-		const root = { all: [predicate, { any: [{ kind: "size", params: {} }] }] };
+		const root = { all: [predicate, { not: { any: [{ kind: "size", params: {} }] } }] };
 		expect([...walkPredicates(root)].map((p) => p.kind)).toEqual(["age", "size"]);
+	});
+});
+
+describe("composition helpers", () => {
+	it("keeps NOT distinct from all/any groups without breaking generic traversal", () => {
+		const notNode: RuleNot = { not: predicate };
+
+		expect(isRuleGroup(notNode)).toBe(false);
+		expect(groupChildren(notNode)).toEqual([predicate]);
 	});
 });
 

--- a/packages/shared/src/rules/__tests__/v1-serializer.test.ts
+++ b/packages/shared/src/rules/__tests__/v1-serializer.test.ts
@@ -54,12 +54,28 @@ describe("serializeCriteriaDocumentToV0", () => {
 		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(V1SerializerError);
 	});
 
-	it("rejects a nested group (v1 is depth-1)", () => {
+	it("rejects a nested group because criteria v0 storage is flat", () => {
 		const doc: RuleDocument = {
 			version: 1,
 			root: { all: [{ any: [{ kind: "age", params: {} }] }] },
 		};
-		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(/depth-1/);
+		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(/nested group.*v0/i);
+	});
+
+	it("rejects a NOT root because recursive documents have no v0 representation", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { not: { kind: "age", params: {} } },
+		};
+		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(/NOT.*v0/i);
+	});
+
+	it("rejects a nested NOT instead of treating it as a flat condition", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: { all: [{ not: { kind: "age", params: {} } }] },
+		};
+		expect(() => serializeCriteriaDocumentToV0(doc)).toThrow(/NOT.*v0/i);
 	});
 });
 
@@ -106,6 +122,19 @@ describe("serializeNotificationsDocumentToV0", () => {
 			},
 		};
 		expect(() => serializeNotificationsDocumentToV0(doc)).toThrow(/OR/);
+	});
+
+	it("rejects NOT because notification v0 conditions cannot represent it", () => {
+		const doc: RuleDocument = {
+			version: 1,
+			root: {
+				not: {
+					kind: "field_match",
+					params: { field: "title", operator: "contains", value: "4K" },
+				},
+			},
+		};
+		expect(() => serializeNotificationsDocumentToV0(doc)).toThrow(/NOT.*v0/i);
 	});
 
 	it("rejects a non-field_match predicate", () => {

--- a/packages/shared/src/rules/grammar.ts
+++ b/packages/shared/src/rules/grammar.ts
@@ -2,7 +2,7 @@
  * Unified rule grammar — serialization v1.
  *
  * docs/design/unified-rule-grammar.md §2.1. One predicate shape
- * (kind + params) composed by all/any groups, wrapped in a versioned
+ * (kind + params) composed by all/any/not nodes, wrapped in a versioned
  * document envelope stored in the existing JSON rule columns.
  *
  * Naming note: the design doc calls these Condition / ConditionGroup /
@@ -39,9 +39,11 @@ export interface RulePredicate {
 	unavailableKind?: boolean;
 }
 
+export type RuleNot = { not: RuleNode };
+
 export type RuleGroup = { all: RuleNode[] } | { any: RuleNode[] };
 
-export type RuleNode = RulePredicate | RuleGroup;
+export type RuleNode = RulePredicate | RuleGroup | RuleNot;
 
 /** The stored document envelope (per rule row, in existing JSON columns). */
 export interface RuleDocument {
@@ -53,24 +55,203 @@ export interface RuleDocument {
 // Zod schemas (structural — see header note on kind-legality)
 // ============================================================================
 
-export const rulePredicateSchema: z.ZodType<RulePredicate> = z.object({
-	kind: z.string().min(1),
-	params: z.record(z.string(), z.unknown()),
-	unavailableKind: z.boolean().optional(),
-});
+export const rulePredicateSchema: z.ZodType<RulePredicate> = z
+	.object({
+		kind: z.string().min(1),
+		params: z.record(z.string(), z.unknown()),
+		unavailableKind: z.boolean().optional(),
+	})
+	.strict();
 
 export const ruleNodeSchema: z.ZodType<RuleNode> = z.lazy(() =>
-	z.union([rulePredicateSchema, ruleGroupSchema]),
+	z.union([rulePredicateSchema, ruleGroupSchema, ruleNotSchema]),
 );
 
 export const ruleGroupSchema: z.ZodType<RuleGroup> = z.lazy(() =>
-	z.union([z.object({ all: z.array(ruleNodeSchema) }), z.object({ any: z.array(ruleNodeSchema) })]),
+	z.union([
+		z.object({ all: z.array(ruleNodeSchema) }).strict(),
+		z.object({ any: z.array(ruleNodeSchema) }).strict(),
+	]),
 );
 
-export const ruleDocumentSchema: z.ZodType<RuleDocument> = z.object({
-	version: z.literal(1),
-	root: ruleNodeSchema,
-});
+export const ruleNotSchema: z.ZodType<RuleNot> = z.lazy(() =>
+	z.object({ not: ruleNodeSchema }).strict(),
+);
+
+export const RULE_DOCUMENT_V1_MAX_DEPTH = 8;
+export const RULE_DOCUMENT_V1_MAX_NODES = 64;
+
+interface RuleDocumentInspection {
+	error: string | null;
+	maxDepth: number;
+	nodeCount: number;
+}
+
+interface RuleDocumentInspectionLimits {
+	maxDepth: number;
+	maxNodes: number;
+}
+
+type RuleNodeWork =
+	| { action: "enter"; value: unknown; depth: number; path: string }
+	| { action: "exit"; value: object };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasExactKeys(
+	value: Record<string, unknown>,
+	required: readonly string[],
+	optional: readonly string[] = [],
+): boolean {
+	const allowed = new Set([...required, ...optional]);
+	return (
+		required.every((key) => Object.hasOwn(value, key)) &&
+		Object.keys(value).every((key) => allowed.has(key))
+	);
+}
+
+/**
+ * Validate and measure the recursive tree without recursive function calls.
+ * The ancestor set detects cycles while still allowing a shared acyclic node
+ * object to appear in separate branches (equivalent to duplicated JSON).
+ */
+function inspectRuleDocument(
+	value: unknown,
+	limits: RuleDocumentInspectionLimits,
+): RuleDocumentInspection {
+	const invalid = (error: string, maxDepth = 0, nodeCount = 0): RuleDocumentInspection => ({
+		error,
+		maxDepth,
+		nodeCount,
+	});
+
+	if (!isRecord(value) || !hasExactKeys(value, ["version", "root"])) {
+		return invalid("Rule document envelope must contain exactly version and root");
+	}
+	if (value.version !== 1) return invalid("Rule document version must be 1");
+
+	const ancestors = new Set<object>();
+	const stack: RuleNodeWork[] = [{ action: "enter", value: value.root, depth: 0, path: "root" }];
+	let maxDepth = 0;
+	let nodeCount = 0;
+
+	while (stack.length > 0) {
+		const work = stack.pop();
+		if (!work) break;
+		if (work.action === "exit") {
+			ancestors.delete(work.value);
+			continue;
+		}
+
+		const node = work.value;
+		if (!isRecord(node)) {
+			return invalid(`${work.path} must be a rule node object`, maxDepth, nodeCount);
+		}
+		if (ancestors.has(node)) {
+			return invalid(`${work.path} contains a cycle`, maxDepth, nodeCount);
+		}
+
+		const isPredicate = Object.hasOwn(node, "kind");
+		const isAll = Object.hasOwn(node, "all");
+		const isAny = Object.hasOwn(node, "any");
+		const isNot = Object.hasOwn(node, "not");
+		const variantCount = Number(isPredicate) + Number(isAll) + Number(isAny) + Number(isNot);
+		if (variantCount !== 1) {
+			return invalid(
+				`${work.path} must contain exactly one of kind, all, any, or not`,
+				maxDepth,
+				nodeCount,
+			);
+		}
+
+		const currentDepth = isPredicate ? work.depth : work.depth + 1;
+		maxDepth = Math.max(maxDepth, currentDepth);
+		nodeCount += 1;
+		if (maxDepth > limits.maxDepth) {
+			return invalid(
+				`Rule document exceeds v1 depth limit (${maxDepth} > ${limits.maxDepth})`,
+				maxDepth,
+				nodeCount,
+			);
+		}
+		if (nodeCount > limits.maxNodes) {
+			return invalid(
+				`Rule document exceeds v1 node limit (${nodeCount} > ${limits.maxNodes})`,
+				maxDepth,
+				nodeCount,
+			);
+		}
+
+		ancestors.add(node);
+		stack.push({ action: "exit", value: node });
+
+		if (isPredicate) {
+			if (!hasExactKeys(node, ["kind", "params"], ["unavailableKind"])) {
+				return invalid(`${work.path} predicate has unexpected fields`, maxDepth, nodeCount);
+			}
+			if (typeof node.kind !== "string" || node.kind.length === 0) {
+				return invalid(`${work.path}.kind must be a non-empty string`, maxDepth, nodeCount);
+			}
+			if (!isRecord(node.params)) {
+				return invalid(`${work.path}.params must be an object`, maxDepth, nodeCount);
+			}
+			if (Object.hasOwn(node, "unavailableKind") && typeof node.unavailableKind !== "boolean") {
+				return invalid(`${work.path}.unavailableKind must be a boolean`, maxDepth, nodeCount);
+			}
+			continue;
+		}
+
+		if (isNot) {
+			if (!hasExactKeys(node, ["not"])) {
+				return invalid(`${work.path} NOT node has unexpected fields`, maxDepth, nodeCount);
+			}
+			stack.push({
+				action: "enter",
+				value: node.not,
+				depth: work.depth + 1,
+				path: `${work.path}.not`,
+			});
+			continue;
+		}
+
+		const key = isAll ? "all" : "any";
+		if (!hasExactKeys(node, [key])) {
+			return invalid(`${work.path} ${key} node has unexpected fields`, maxDepth, nodeCount);
+		}
+		const children = node[key];
+		if (!Array.isArray(children)) {
+			return invalid(`${work.path}.${key} must be an array`, maxDepth, nodeCount);
+		}
+		for (let index = children.length - 1; index >= 0; index -= 1) {
+			stack.push({
+				action: "enter",
+				value: children[index],
+				depth: work.depth + 1,
+				path: `${work.path}.${key}[${index}]`,
+			});
+		}
+	}
+
+	return { error: null, maxDepth, nodeCount };
+}
+
+const boundedRuleDocumentSchema = z
+	.unknown()
+	.superRefine((value, ctx) => {
+		const inspection = inspectRuleDocument(value, {
+			maxDepth: RULE_DOCUMENT_V1_MAX_DEPTH,
+			maxNodes: RULE_DOCUMENT_V1_MAX_NODES,
+		});
+		if (inspection.error) {
+			ctx.addIssue({ code: z.ZodIssueCode.custom, message: inspection.error });
+		}
+	})
+	.transform((value) => value as RuleDocument);
+
+/** Strict, cycle-safe, bounded parser for stored rule documents. */
+export const ruleDocumentSchema: z.ZodType<RuleDocument> = boundedRuleDocumentSchema;
 
 // ============================================================================
 // Node helpers
@@ -84,37 +265,68 @@ export function isRulePredicate(node: RuleNode): node is RulePredicate {
 	return "kind" in node;
 }
 
-/** Children of a group, regardless of all/any variant. */
-export function groupChildren(group: RuleGroup): RuleNode[] {
-	return "all" in group ? group.all : group.any;
+export function isRuleNot(node: RuleNode): node is RuleNot {
+	return "not" in node;
+}
+
+/**
+ * Children of a composition node. NOT remains a distinct node variant but is
+ * exposed as a one-child composition for generic tree walkers.
+ */
+export function groupChildren(group: RuleGroup | RuleNot): RuleNode[] {
+	if ("all" in group) return group.all;
+	if ("any" in group) return group.any;
+	return [group.not];
 }
 
 /** Depth of a node tree; a bare predicate is depth 0, one group level is 1. */
 export function nodeDepth(node: RuleNode): number {
-	if (isRulePredicate(node)) return 0;
-	const children = groupChildren(node);
-	if (children.length === 0) return 1;
-	return 1 + Math.max(...children.map(nodeDepth));
+	const inspection = inspectRuleDocument(
+		{ version: 1, root: node },
+		{ maxDepth: Number.POSITIVE_INFINITY, maxNodes: Number.POSITIVE_INFINITY },
+	);
+	if (inspection.error) throw new TypeError(inspection.error);
+	return inspection.maxDepth;
 }
 
 /**
- * v1 documents are restricted to depth 1 (matching every existing rule;
- * §2.1 — depth is a future unlock, not a migration burden). Write paths
- * call this; the structural schema deliberately permits recursion.
+ * Recursive v1 documents are bounded at write/parse boundaries. Kind legality
+ * remains permissive so retired predicates can be annotated and safely
+ * no-match rather than discarded or rewritten.
  */
-export const RULE_DOCUMENT_V1_MAX_DEPTH = 1;
-
 export function validateV1Depth(doc: RuleDocument): string | null {
-	const depth = nodeDepth(doc.root);
-	return depth > RULE_DOCUMENT_V1_MAX_DEPTH
-		? `Rule document exceeds v1 depth limit (${depth} > ${RULE_DOCUMENT_V1_MAX_DEPTH})`
-		: null;
+	return inspectRuleDocument(doc, {
+		maxDepth: RULE_DOCUMENT_V1_MAX_DEPTH,
+		maxNodes: Number.POSITIVE_INFINITY,
+	}).error;
+}
+
+/** Count every predicate and composition node in a document tree. */
+export function nodeCount(node: RuleNode): number {
+	const inspection = inspectRuleDocument(
+		{ version: 1, root: node },
+		{ maxDepth: Number.POSITIVE_INFINITY, maxNodes: Number.POSITIVE_INFINITY },
+	);
+	if (inspection.error) throw new TypeError(inspection.error);
+	return inspection.nodeCount;
+}
+
+/** Apply both v1 recursion guards at a storage or write boundary. */
+export function validateV1Bounds(doc: RuleDocument): string | null {
+	return inspectRuleDocument(doc, {
+		maxDepth: RULE_DOCUMENT_V1_MAX_DEPTH,
+		maxNodes: RULE_DOCUMENT_V1_MAX_NODES,
+	}).error;
 }
 
 /** Walk every predicate in a document (depth-first). */
 export function* walkPredicates(node: RuleNode): Generator<RulePredicate> {
 	if (isRulePredicate(node)) {
 		yield node;
+		return;
+	}
+	if (isRuleNot(node)) {
+		yield* walkPredicates(node.not);
 		return;
 	}
 	for (const child of groupChildren(node)) {

--- a/packages/shared/src/rules/v1-serializer.ts
+++ b/packages/shared/src/rules/v1-serializer.ts
@@ -14,15 +14,15 @@
  * `serialize(map(v0)) === v0` and `map(serialize(v1)) === v1` for every
  * authorable rule (see __tests__/v1-serializer.test.ts).
  *
- * v1 is depth-1 (§2.1), so a composite's children must all be predicates;
- * a nested group throws. Empty groups also throw: an empty composite is not a
- * meaningful authored rule and would serialize to a no-op `{kind:"composite"}`
- * / `{all:[]}` shape — the form must reject it before it reaches here.
+ * The canonical v1 grammar is recursive, but v0 criteria/notification storage
+ * is flat. These serializers reject NOT and nested expressions explicitly;
+ * recursive cleanup documents use their self-describing v1 storage path.
  */
 
 import { FIELD_MATCH_KIND } from "./field-match.js";
 import {
 	groupChildren,
+	isRuleNot,
 	isRulePredicate,
 	type RuleDocument,
 	type RulePredicate,
@@ -61,6 +61,9 @@ export function serializeCriteriaDocumentToV0(doc: RuleDocument): CriteriaV0Payl
 			conditions: null,
 		};
 	}
+	if (isRuleNot(root)) {
+		throw new V1SerializerError("NOT expressions are not representable in criteria v0 storage");
+	}
 
 	const children = groupChildren(root);
 	if (children.length === 0) {
@@ -68,9 +71,14 @@ export function serializeCriteriaDocumentToV0(doc: RuleDocument): CriteriaV0Payl
 	}
 
 	const conditions = children.map((child, i) => {
+		if (isRuleNot(child)) {
+			throw new V1SerializerError(
+				`composite condition[${i}] is a NOT expression — not representable in criteria v0 storage`,
+			);
+		}
 		if (!isRulePredicate(child)) {
 			throw new V1SerializerError(
-				`composite condition[${i}] is a nested group — v1 rules are depth-1`,
+				`composite condition[${i}] is a nested group — not representable in criteria v0 storage`,
 			);
 		}
 		return { ruleType: child.kind, parameters: child.params };
@@ -111,6 +119,11 @@ export function serializeNotificationsDocumentToV0(doc: RuleDocument): Notificat
 		predicates = [root];
 	} else if ("all" in root) {
 		predicates = root.all.map((child, i) => {
+			if (isRuleNot(child)) {
+				throw new V1SerializerError(
+					`notification condition[${i}] is a NOT expression — not representable in v0`,
+				);
+			}
 			if (!isRulePredicate(child)) {
 				throw new V1SerializerError(
 					`notification condition[${i}] is a nested group — not representable in v0`,
@@ -118,6 +131,8 @@ export function serializeNotificationsDocumentToV0(doc: RuleDocument): Notificat
 			}
 			return child;
 		});
+	} else if (isRuleNot(root)) {
+		throw new V1SerializerError("NOT expressions are not representable in notification v0 storage");
 	} else {
 		throw new V1SerializerError(
 			"notification rules use implicit AND; an 'any' (OR) group is not representable in v0",


### PR DESCRIPTION
## Summary

- add a strict, cycle-safe v1 rule grammar with bounded recursive `all`, `any`, and `not` nodes
- add three-state engine evaluation so unavailable cleanup evidence cannot become deletion authority through negation
- preserve flat v0 cleanup and notification behavior, including existing 64-condition rows
- make flat serializers and Console editors reject recursive documents instead of silently flattening them
- render recursive documents accurately and fail closed when cleanup exemptions contain `not` until evidence-aware exemption evaluation is implemented

## Scope

This is the recursive grammar and compatibility foundation. It does not expose recursive rule persistence or authoring through the cleanup routes yet; that is the next dependent change.

## Safety

- native v1 documents are limited to depth 8 and 64 nodes
- malformed, cyclic, or over-limit native documents are rejected
- legacy v0 rows retain their existing evaluation limits and semantics
- unsupported `not` cleanup exemptions block approved and durable-retry mutations
- the independent data-safety and regression review findings were addressed in one frozen correction pass

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 4,128; web 832; shared 144)
- `pnpm run lint`
- `pnpm run build`