### PR TITLE
feat(cleanup): persist recursive rule documents

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { evaluateItemMutationPolicyStateViaEngine } from "../../rules/cleanup-adapter.js";
+import {
+	evaluateItemMutationPolicyStateViaEngine,
+	evaluateRuleViaEngine,
+} from "../../rules/cleanup-adapter.js";
 import { deriveArrPolicyEvidence } from "../arr-policy-evidence.js";
 import { executeDirectRemoval } from "../cleanup-executor.js";
 import { createArrServiceFingerprint } from "../shared-plex-safety.js";
@@ -465,6 +468,90 @@ function mutationEvidenceItem(data: Record<string, unknown>) {
 }
 
 describe("mutation policy evidence authority", () => {
+	it("uses the same nested positive expression for preview and mutation authorization", () => {
+		const expression = {
+			version: 1,
+			root: {
+				all: [
+					{ kind: "year_range", params: { operator: "before", year: 2030 } },
+					{
+						any: [
+							{ kind: "year_range", params: { operator: "after", year: 2010 } },
+							{ kind: "year_range", params: { operator: "before", year: 2000 } },
+						],
+					},
+				],
+			},
+		};
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive",
+				operator: null,
+				conditions: JSON.stringify(expression),
+			},
+		);
+		const item = mutationEvidenceItem({ _arrDashboardEvidence: {} });
+		const context = { now: new Date() };
+
+		expect(evaluateRuleViaEngine(item as never, rule as never, "RADARR", context)).toMatchObject({
+			ruleId: "rule-recursive",
+		});
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", context),
+		).toMatchObject({ kind: "cleanup", match: { ruleId: "rule-recursive" } });
+	});
+
+	it("fails closed when a nested expression depends on a failed provider", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-plex",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						all: [
+							{ kind: "year_range", params: { operator: "before", year: 2030 } },
+							{ kind: "plex_watch_count", params: { operator: "less_than", count: 1 } },
+						],
+					},
+				}),
+			},
+		);
+		const context = {
+			now: new Date(),
+			plexMap: new Map([
+				[
+					"movie:42",
+					{
+						lastWatchedAt: null,
+						watchCount: 0,
+						watchedByUsers: [],
+						onDeck: false,
+						userRating: null,
+						collections: [],
+						labels: [],
+						addedAt: null,
+						sections: [],
+					},
+				],
+			]),
+		};
+
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(
+				mutationEvidenceItem({ _arrDashboardEvidence: {} }) as never,
+				[rule] as never,
+				"RADARR",
+				context,
+				new Set(["plex"]),
+			),
+		).toEqual({ kind: "unknown", ruleId: "rule-recursive-plex" });
+	});
+
 	it.each([
 		["missing source", { ratings: {} }],
 		["zero sentinel", { ratings: { tmdb: { value: 0 }, imdb: { value: 0 } } }],

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -204,6 +204,46 @@ const unavailablePlexEvidenceCases = [
 ] satisfies ReadonlyArray<readonly [string, () => PlexStatusOverride]>;
 
 describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
+	it("discovers Plex evidence required by a canonical nested expression", async () => {
+		const serviceFindMany = vi.fn().mockResolvedValue([]);
+		const prisma = {
+			serviceInstance: { findMany: serviceFindMany },
+		} as unknown as CleanupExecutorDeps["prisma"];
+
+		await expect(
+			buildEvalContext(
+				{ prisma, log } as CleanupExecutorDeps,
+				"user-1",
+				[
+					{
+						enabled: true,
+						ruleType: "composite",
+						parameters: "{}",
+						operator: null,
+						conditions: JSON.stringify({
+							version: 1,
+							root: {
+								all: [
+									{ kind: "year_range", params: { operator: "before", year: 2030 } },
+									{
+										any: [
+											{
+												kind: "plex_watch_count",
+												params: { operator: "less_than", count: 1 },
+											},
+										],
+									},
+								],
+							},
+						}),
+					},
+				],
+				{ requireAvailableEvidence: true },
+			),
+		).rejects.toThrow(/required evaluation evidence is unavailable: plex/i);
+		expect(serviceFindMany).toHaveBeenCalled();
+	});
+
 	it.each(unavailablePlexEvidenceCases)(
 		"blocks Plex cleanup evidence for %s",
 		async (caseName, overrides) => {

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -46,6 +46,7 @@ import {
 	evaluateItemMutationPolicyStateViaEngine,
 	evaluateRuleViaEngine,
 } from "../rules/cleanup-adapter.js";
+import { mapCriteriaV0ToDocument } from "../rules/v0-mappers.js";
 import { SeerrClient } from "../seerr/seerr-client.js";
 import { hasAuthoritativeProviderCacheGeneration } from "../services/provider-identity-guard.js";
 import { getErrorMessage } from "../utils/error-message.js";
@@ -5507,17 +5508,35 @@ async function executeQueuedCleanupItems(
  * Collect all rule types from enabled rules, including conditions inside composite rules.
  * Used to decide which external data to prefetch (Seerr, Plex, Jellyfin).
  */
+type CleanupCriteriaStorageRow = {
+	ruleType: string;
+	parameters?: string;
+	operator?: string | null;
+	conditions: string | null;
+};
+
+function storedCleanupPredicates(rule: CleanupCriteriaStorageRow) {
+	try {
+		const document = mapCriteriaV0ToDocument({
+			ruleType: rule.ruleType,
+			parameters: rule.parameters ?? "{}",
+			operator: rule.operator ?? null,
+			conditions: rule.conditions,
+		});
+		return [...walkPredicates(document.root)];
+	} catch {
+		return [];
+	}
+}
+
 function collectActiveRuleTypes(
-	rules: Pick<LibraryCleanupRule, "enabled" | "ruleType" | "conditions">[],
+	rules: Array<CleanupCriteriaStorageRow & { enabled: boolean }>,
 ): Set<string> {
 	const types = new Set<string>();
 	for (const r of rules) {
 		if (!r.enabled) continue;
 		types.add(r.ruleType);
-		if (r.conditions) {
-			const conds = safeJsonParse(r.conditions) as Array<{ ruleType?: string }> | null;
-			if (Array.isArray(conds)) for (const c of conds) if (c.ruleType) types.add(c.ruleType);
-		}
+		for (const predicate of storedCleanupPredicates(r)) types.add(predicate.kind);
 	}
 	return types;
 }
@@ -7538,16 +7557,11 @@ export function seriesRetentionProtectsEpisode(
  */
 function getRuleDataSources(rule: LibraryCleanupRule): Set<DataSourceDependency> {
 	const sources = new Set<DataSourceDependency>();
-	const dep = ruleDataSourceMap[rule.ruleType];
-	if (dep) sources.add(dep);
-	if (rule.conditions) {
-		const conds = safeJsonParse(rule.conditions) as Array<{ ruleType?: string }> | null;
-		if (Array.isArray(conds)) {
-			for (const c of conds) {
-				const cdep = c.ruleType ? ruleDataSourceMap[c.ruleType] : undefined;
-				if (cdep) sources.add(cdep);
-			}
-		}
+	const topLevelDependency = ruleDataSourceMap[rule.ruleType];
+	if (topLevelDependency) sources.add(topLevelDependency);
+	for (const predicate of storedCleanupPredicates(rule)) {
+		const dependency = ruleDataSourceMap[predicate.kind];
+		if (dependency) sources.add(dependency);
 	}
 	return sources;
 }
@@ -10156,12 +10170,12 @@ async function refreshCurrentExternalRuleCaches(
 export async function buildEvalContext(
 	deps: CleanupExecutorDeps,
 	userId: string,
-	rules: Array<{
-		enabled: boolean;
-		ruleType: string;
-		conditions: string | null;
-		plexLibraryFilter?: string | null;
-	}>,
+	rules: Array<
+		CleanupCriteriaStorageRow & {
+			enabled: boolean;
+			plexLibraryFilter?: string | null;
+		}
+	>,
 	options: {
 		destructiveAuthority?: boolean;
 		requireAvailableEvidence?: boolean;
@@ -10313,7 +10327,7 @@ async function createRunLog(
 export async function prefetchCleanupListMemberships(
 	deps: CleanupExecutorDeps,
 	userId: string,
-	rules: Array<{ ruleType: string; parameters?: string; conditions: string | null }>,
+	rules: CleanupCriteriaStorageRow[],
 	cacheKind: "tmdb" | "trakt",
 ): Promise<Map<string, Set<number>>> {
 	const targetType = cacheKind === "tmdb" ? "tmdb_list_member" : "trakt_list_member";
@@ -10327,13 +10341,8 @@ export async function prefetchCleanupListMemberships(
 		if (typeof value === "string" && value.length > 0) identifiers.add(value);
 	};
 	for (const rule of rules) {
-		collectFromParams(rule.ruleType, safeJsonParse(rule.parameters ?? ""));
-		const conditions = safeJsonParse(rule.conditions ?? "") as Array<{
-			ruleType: string;
-			parameters: unknown;
-		}> | null;
-		if (Array.isArray(conditions)) {
-			for (const cond of conditions) collectFromParams(cond?.ruleType, cond?.parameters);
+		for (const predicate of storedCleanupPredicates(rule)) {
+			collectFromParams(predicate.kind, predicate.params);
 		}
 	}
 	if (identifiers.size === 0) return new Map();

--- a/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
+++ b/apps/api/src/lib/library-cleanup/list-membership-prefetch.test.ts
@@ -74,6 +74,43 @@ describe("prefetchCleanupListMemberships", () => {
 		expect(map.get("1234")).toEqual(new Set([300]));
 	});
 
+	it("collects identifiers from every predicate in a canonical nested document", async () => {
+		const rules = [
+			{
+				...rule({}),
+				ruleType: "composite",
+				operator: null,
+				parameters: "{}",
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						all: [
+							{ kind: "age", params: { operator: "older_than", days: 30 } },
+							{
+								any: [
+									{
+										kind: "tmdb_list_member",
+										params: { listId: "nested-list", operator: "is_in" },
+									},
+								],
+							},
+						],
+					},
+				}),
+			},
+		] as LibraryCleanupRule[];
+		const { deps, findMany } = makeDeps([{ listId: "nested-list", tmdbId: 300 }]);
+
+		const map = await prefetchCleanupListMemberships(deps, "user-1", rules, "tmdb");
+
+		expect(findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { userId: "user-1", listId: { in: ["nested-list"] } },
+			}),
+		);
+		expect(map.get("nested-list")).toEqual(new Set([300]));
+	});
+
 	it("returns an empty map with ZERO queries when no rule references the kind", async () => {
 		const { deps, findMany } = makeDeps([]);
 		const map = await prefetchCleanupListMemberships(

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -57,8 +57,14 @@ import type {
 	VideoCodecRuleParams,
 	YearRangeRuleParams,
 } from "@arr/shared";
-import { type DataSourceDependency, isRegexSafe, ruleDataSourceMap } from "@arr/shared";
+import {
+	type DataSourceDependency,
+	isRegexSafe,
+	ruleDataSourceMap,
+	walkPredicates,
+} from "@arr/shared";
 import type { LibraryCleanupRule } from "../prisma.js";
+import { mapCriteriaV0ToDocument } from "../rules/v0-mappers.js";
 import { safeJsonParse } from "../utils/json.js";
 import {
 	evaluateJellyfinAddedAt,
@@ -1581,30 +1587,18 @@ export function ruleUsesUnavailableData(
 	rule: LibraryCleanupRule,
 	failedSources?: Set<DataSourceDependency>,
 ): boolean {
-	// Check top-level rule type
-	if (shouldSkipRuleType(rule.ruleType, rule.parameters, failedSources)) return true;
-
-	// Check composite sub-conditions
-	if (rule.conditions) {
-		const conds = safeJsonParse(rule.conditions) as Array<{
-			ruleType?: string;
-			parameters?: Record<string, unknown>;
-		}> | null;
-		if (Array.isArray(conds)) {
-			for (const c of conds) {
-				if (
-					c.ruleType &&
-					shouldSkipRuleType(
-						c.ruleType,
-						c.parameters ? JSON.stringify(c.parameters) : null,
-						failedSources,
-					)
-				)
-					return true;
+	try {
+		const document = mapCriteriaV0ToDocument(rule);
+		for (const predicate of walkPredicates(document.root)) {
+			if (shouldSkipRuleType(predicate.kind, JSON.stringify(predicate.params), failedSources)) {
+				return true;
 			}
 		}
+		return false;
+	} catch {
+		// A malformed rule cannot prove that all of its dependencies are available.
+		return true;
 	}
-	return false;
 }
 
 /** Compatibility name for callers that only need cleanup-rule skip semantics. */

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -24,7 +24,7 @@
  * `evaluateRuleViaEngine` once the differential parity suite is green.
  */
 
-import type { DataSourceDependency, RuleDocument } from "@arr/shared";
+import { type DataSourceDependency, type RuleDocument, walkPredicates } from "@arr/shared";
 import {
 	evaluateSingleCondition,
 	getFilterReason,
@@ -376,42 +376,17 @@ function ruleHasMutationEvidence(
 		rule.excludeTags === null ? [] : (safeJsonParse(rule.excludeTags) as unknown[]);
 	if (excludedTags.length > 0 && !evidenceFlag(data, "tags")) return false;
 
-	if (rule.operator || rule.conditions) {
-		if (!rule.operator || !rule.conditions) return false;
-		const conditions = safeJsonParse(rule.conditions) as unknown;
-		if (!Array.isArray(conditions) || conditions.length === 0) return false;
-		return conditions.every((condition) => {
-			if (typeof condition !== "object" || condition === null || Array.isArray(condition)) {
-				return false;
-			}
-			const entry = condition as Record<string, unknown>;
-			return (
-				typeof entry.ruleType === "string" &&
-				typeof entry.parameters === "object" &&
-				entry.parameters !== null &&
-				!Array.isArray(entry.parameters) &&
-				ruleTypeHasMutationEvidence(
-					item,
-					entry.ruleType,
-					entry.parameters as Record<string, unknown>,
-					instanceService,
-					ctx,
-				)
-			);
-		});
+	let document: RuleDocument;
+	try {
+		document = mapCriteriaV0ToDocument(rule);
+	} catch {
+		return false;
 	}
-
-	const parameters = safeJsonParse(rule.parameters) as unknown;
+	const predicates = [...walkPredicates(document.root)];
 	return (
-		typeof parameters === "object" &&
-		parameters !== null &&
-		!Array.isArray(parameters) &&
-		ruleTypeHasMutationEvidence(
-			item,
-			rule.ruleType,
-			parameters as Record<string, unknown>,
-			instanceService,
-			ctx,
+		predicates.length > 0 &&
+		predicates.every((predicate) =>
+			ruleTypeHasMutationEvidence(item, predicate.kind, predicate.params, instanceService, ctx),
 		)
 	);
 }

--- a/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
@@ -25,6 +25,17 @@ import {
 
 const USER_ID = "user-rule-scope";
 const timestamp = new Date("2026-08-12T00:00:00.000Z");
+const recursiveExpression = {
+	version: 1,
+	root: {
+		all: [
+			{ kind: "age", params: { operator: "older_than", days: 30 } },
+			{
+				any: [{ kind: "year_range", params: { operator: "before", year: 2030 } }],
+			},
+		],
+	},
+};
 
 function makeRule(overrides: Record<string, unknown> = {}) {
 	return {
@@ -57,6 +68,9 @@ function makeRule(overrides: Record<string, unknown> = {}) {
 
 let app: FastifyInstance;
 let configFindUnique: ReturnType<typeof vi.fn>;
+let configUpsert: ReturnType<typeof vi.fn>;
+let configUpdate: ReturnType<typeof vi.fn>;
+let prismaTransaction: ReturnType<typeof vi.fn>;
 let ruleFindFirst: ReturnType<typeof vi.fn>;
 let ruleCreate: ReturnType<typeof vi.fn>;
 let ruleUpdate: ReturnType<typeof vi.fn>;
@@ -78,6 +92,9 @@ beforeEach(async () => {
 		rejectionMemoryDays: 0,
 		rules: [rule],
 	});
+	configUpsert = vi.fn().mockImplementation(async () => configFindUnique.mock.results[0]?.value);
+	configUpdate = vi.fn();
+	prismaTransaction = vi.fn().mockResolvedValue([]);
 	ruleFindFirst = vi.fn().mockResolvedValue(rule);
 	ruleCreate = vi.fn().mockImplementation(async ({ data }) => ({ ...rule, ...data }));
 	ruleUpdate = vi.fn().mockImplementation(async ({ data }) => ({ ...rule, ...data }));
@@ -89,7 +106,11 @@ beforeEach(async () => {
 	setupAuthInjection(app, { id: USER_ID, username: "admin" });
 	registerTestErrorHandler(app);
 	app.decorate("prisma", {
-		libraryCleanupConfig: { findUnique: configFindUnique },
+		libraryCleanupConfig: {
+			findUnique: configFindUnique,
+			upsert: configUpsert,
+			update: configUpdate,
+		},
 		libraryCleanupRule: {
 			findFirst: ruleFindFirst,
 			create: ruleCreate,
@@ -97,6 +118,7 @@ beforeEach(async () => {
 		},
 		serviceInstance: { findMany: serviceInstanceFindMany },
 		episodeFileCache: { findMany: vi.fn().mockResolvedValue([]) },
+		$transaction: prismaTransaction,
 	} as never);
 	app.decorate("arrClientFactory", {} as never);
 	app.decorate("encryptor", {} as never);
@@ -109,6 +131,367 @@ afterEach(async () => {
 });
 
 describe("library cleanup rule scope persistence", () => {
+	it("stores a recursive expression in the canonical composite representation", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
+			body: {
+				name: "Nested cleanup",
+				enabled: true,
+				priority: 0,
+				ruleType: "composite",
+				parameters: {},
+				expression: recursiveExpression,
+			},
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(ruleCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					ruleType: "composite",
+					parameters: "{}",
+					operator: null,
+					conditions: JSON.stringify(recursiveExpression),
+				}),
+			}),
+		);
+		expect(response.json()).toMatchObject({
+			expression: recursiveExpression,
+			conditions: null,
+		});
+	});
+
+	it("rejects NOT expressions until false evidence is authoritative", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
+			body: {
+				name: "Unsafe negation",
+				ruleType: "composite",
+				parameters: {},
+				expression: {
+					version: 1,
+					root: { not: { kind: "age", params: { operator: "older_than", days: 30 } } },
+				},
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().error).toContain("NOT cleanup expressions are not supported");
+		expect(ruleCreate).not.toHaveBeenCalled();
+	});
+
+	it("serializes canonical rows separately from legacy composite conditions", async () => {
+		const legacyConditions = [
+			{ ruleType: "age", parameters: { operator: "older_than", days: 30 } },
+		];
+		configFindUnique.mockResolvedValueOnce({
+			id: "cleanup-config",
+			enabled: false,
+			intervalHours: 24,
+			lastRunAt: null,
+			nextRunAt: null,
+			dryRunMode: true,
+			maxRemovalsPerRun: 10,
+			requireApproval: true,
+			respectQuiSeeding: false,
+			rejectionMemoryDays: 0,
+			rules: [
+				makeRule({
+					ruleType: "composite",
+					parameters: "{}",
+					operator: null,
+					conditions: JSON.stringify(recursiveExpression),
+					targetScope: "series",
+				}),
+				makeRule({
+					id: "rule-legacy",
+					ruleType: "composite",
+					parameters: "{}",
+					operator: "AND",
+					conditions: JSON.stringify(legacyConditions),
+					targetScope: "series",
+				}),
+				makeRule({
+					id: "rule-legacy-null-operator",
+					ruleType: "composite",
+					parameters: "{}",
+					operator: null,
+					conditions: JSON.stringify(legacyConditions),
+					targetScope: "series",
+				}),
+			],
+		});
+
+		const response = await createInjectAuthenticated(app)("GET", "/library-cleanup/config");
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json().rules).toEqual([
+			expect.objectContaining({ expression: recursiveExpression, conditions: null }),
+			expect.objectContaining({ expression: null, conditions: legacyConditions }),
+			expect.objectContaining({ expression: null, conditions: legacyConditions }),
+		]);
+	});
+
+	it("rejects a config mutation before changing authority when a stored expression is invalid", async () => {
+		configFindUnique.mockResolvedValueOnce({
+			id: "cleanup-config",
+			rules: [
+				makeRule({
+					ruleType: "composite",
+					operator: null,
+					conditions: '{"version":1,"root":{"not":false}}',
+				}),
+			],
+		});
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/config", {
+			body: { dryRunMode: false },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(configUpsert).not.toHaveBeenCalled();
+		expect(configUpdate).not.toHaveBeenCalled();
+	});
+
+	it("rejects a reorder before its transaction when a stored expression is invalid", async () => {
+		configFindUnique.mockResolvedValueOnce({ id: "cleanup-config" }).mockResolvedValueOnce({
+			id: "cleanup-config",
+			rules: [
+				makeRule({
+					ruleType: "composite",
+					operator: null,
+					conditions: '{"version":1,"root":{"not":false}}',
+				}),
+			],
+		});
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/reorder", {
+			body: { ruleIds: ["rule-1"] },
+		});
+
+		expect(response.statusCode).toBe(409);
+		expect(prismaTransaction).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["malformed", '{"version":1,"root":{"not":false}}', "invalid"],
+		["empty", JSON.stringify({ version: 1, root: { all: [] } }), "empty all group"],
+	] as const)(
+		"fails closed for a %s stored canonical expression",
+		async (_label, conditions, message) => {
+			configFindUnique.mockResolvedValueOnce({
+				id: "cleanup-config",
+				enabled: false,
+				intervalHours: 24,
+				lastRunAt: null,
+				nextRunAt: null,
+				dryRunMode: true,
+				maxRemovalsPerRun: 10,
+				requireApproval: true,
+				respectQuiSeeding: false,
+				rejectionMemoryDays: 0,
+				rules: [
+					makeRule({
+						ruleType: "composite",
+						parameters: "{}",
+						operator: null,
+						conditions,
+						targetScope: "series",
+					}),
+				],
+			});
+
+			const response = await createInjectAuthenticated(app)("GET", "/library-cleanup/config");
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json().message).toContain(message);
+		},
+	);
+
+	it.each([
+		[
+			"legacy conditions",
+			{
+				operator: "AND",
+				conditions: [{ ruleType: "age", parameters: { operator: "older_than", days: 30 } }],
+			},
+		],
+		["legacy parameters", { parameters: { operator: "older_than", days: 30 } }],
+		["an empty group", { expression: { version: 1, root: { all: [] } } }],
+	] as const)("rejects an expression mixed with %s on create", async (_label, overrides) => {
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
+			body: {
+				name: "Ambiguous cleanup",
+				enabled: true,
+				priority: 0,
+				ruleType: "composite",
+				parameters: {},
+				expression: recursiveExpression,
+				...overrides,
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(ruleCreate).not.toHaveBeenCalled();
+	});
+
+	it("rejects legacy composite conditions without an operator", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
+			body: {
+				name: "Incomplete legacy composite",
+				ruleType: "composite",
+				parameters: {},
+				conditions: [
+					{
+						ruleType: "age",
+						parameters: { operator: "older_than", days: 30 },
+					},
+				],
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(ruleCreate).not.toHaveBeenCalled();
+	});
+
+	it("preserves a canonical expression when an update changes unrelated fields", async () => {
+		const stored = makeRule({
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify(recursiveExpression),
+			targetScope: "series",
+		});
+		ruleFindFirst.mockResolvedValueOnce(stored);
+		ruleUpdate.mockImplementationOnce(async ({ data }) => ({ ...stored, ...data }));
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: { name: "Renamed nested cleanup" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(ruleUpdate).toHaveBeenCalledWith({
+			where: { id: "rule-1" },
+			data: { name: "Renamed nested cleanup" },
+		});
+		expect(response.json()).toMatchObject({ expression: recursiveExpression, conditions: null });
+	});
+
+	it("preserves a stored retired predicate during an unrelated update", async () => {
+		const retiredExpression = {
+			version: 1,
+			root: { kind: "retired_cleanup_kind", params: {} },
+		};
+		const stored = makeRule({
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify(retiredExpression),
+			targetScope: "series",
+		});
+		ruleFindFirst.mockResolvedValueOnce(stored);
+		ruleUpdate.mockImplementationOnce(async ({ data }) => ({ ...stored, ...data }));
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: { name: "Renamed retired cleanup" },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(ruleUpdate).toHaveBeenCalledWith({
+			where: { id: "rule-1" },
+			data: { name: "Renamed retired cleanup" },
+		});
+		expect(response.json()).toMatchObject({ expression: retiredExpression, conditions: null });
+	});
+
+	it("rejects canonical representation edits when expression is omitted", async () => {
+		const stored = makeRule({
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify(recursiveExpression),
+			targetScope: "series",
+		});
+		ruleFindFirst.mockResolvedValueOnce(stored);
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: { parameters: { operator: "older_than", days: 60 } },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(ruleUpdate).not.toHaveBeenCalled();
+	});
+
+	it("requires a complete legacy replacement when clearing a canonical expression", async () => {
+		const stored = makeRule({
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify(recursiveExpression),
+			targetScope: "series",
+		});
+		ruleFindFirst.mockResolvedValueOnce(stored);
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: { expression: null },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(ruleUpdate).not.toHaveBeenCalled();
+	});
+
+	it("converts a canonical expression to a complete legacy replacement", async () => {
+		const stored = makeRule({
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify(recursiveExpression),
+			targetScope: "series",
+		});
+		ruleFindFirst.mockResolvedValueOnce(stored);
+		ruleUpdate.mockImplementationOnce(async ({ data }) => ({ ...stored, ...data }));
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: {
+				expression: null,
+				ruleType: "age",
+				parameters: { operator: "older_than", days: 60 },
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(ruleUpdate).toHaveBeenCalledWith({
+			where: { id: "rule-1" },
+			data: {
+				ruleType: "age",
+				parameters: JSON.stringify({ operator: "older_than", days: 60 }),
+				operator: null,
+				conditions: null,
+			},
+		});
+		expect(response.json()).toMatchObject({ expression: null, ruleType: "age", conditions: null });
+	});
+
+	it("converts a legacy rule to canonical recursive storage on update", async () => {
+		const stored = makeRule({ targetScope: "series" });
+		ruleFindFirst.mockResolvedValueOnce(stored);
+		ruleUpdate.mockImplementationOnce(async ({ data }) => ({ ...stored, ...data }));
+
+		const response = await createInjectAuthenticated(app)("PUT", "/library-cleanup/rules/rule-1", {
+			body: { expression: recursiveExpression },
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(ruleUpdate).toHaveBeenCalledWith({
+			where: { id: "rule-1" },
+			data: {
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify(recursiveExpression),
+			},
+		});
+		expect(response.json()).toMatchObject({ expression: recursiveExpression, conditions: null });
+	});
+
 	it("stores and serializes an exact canonical media-server rescan selection", async () => {
 		serviceInstanceFindMany.mockResolvedValueOnce([
 			{ id: "jellyfin-primary" },

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -14,8 +14,11 @@ import {
 	isKindLegalForContext,
 	reorderRulesSchema,
 	ruleParamSchemaMap,
+	type RuleDocument,
 	updateCleanupConfigSchema,
 	updateCleanupRuleSchema,
+	validateV1Bounds,
+	walkPredicates,
 } from "@arr/shared";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
@@ -63,6 +66,7 @@ import {
 } from "../lib/plex/plex-cache-refresher.js";
 import { createQuiClient } from "../lib/qui/client-factory.js";
 import { explainItemAgainstRulesViaEngine } from "../lib/rules/cleanup-adapter.js";
+import { mapCriteriaV0ToDocument } from "../lib/rules/v0-mappers.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { safeJsonParse as utilSafeJsonParse } from "../lib/utils/json.js";
 import { parsePaginationQuery } from "../lib/utils/pagination.js";
@@ -110,6 +114,7 @@ function serializeConfig(config: Record<string, unknown>) {
 }
 
 function serializeRule(rule: Record<string, unknown>) {
+	const expression = getStoredCleanupExpression(rule);
 	return {
 		id: rule.id,
 		name: rule.name,
@@ -127,13 +132,122 @@ function serializeRule(rule: Record<string, unknown>) {
 		scanMediaServerAfterDelete: rule.scanMediaServerAfterDelete === true,
 		scanMediaServerInstanceIds: parseMediaServerInstanceIds(rule.scanMediaServerInstanceIds),
 		operator: (rule.operator as string) ?? null,
-		conditions: safeJsonParse(rule.conditions as string | null),
+		conditions: expression ? null : safeJsonParse(rule.conditions as string | null),
+		expression,
 		retentionMode: rule.retentionMode ?? false,
 		useGlobalRejectionMemory: rule.useGlobalRejectionMemory ?? true,
 		rejectionMemoryDays: rule.rejectionMemoryDays ?? null,
 		createdAt: (rule.createdAt as Date).toISOString(),
 		updatedAt: (rule.updatedAt as Date).toISOString(),
 	};
+}
+
+class StoredCleanupExpressionError extends Error {
+	statusCode = 409;
+
+	constructor(message: string) {
+		super(message);
+		this.name = "StoredCleanupExpressionError";
+	}
+}
+
+function getStoredCleanupExpression(rule: Record<string, unknown>): RuleDocument | null {
+	if (
+		rule.ruleType !== "composite" ||
+		rule.operator !== null ||
+		typeof rule.conditions !== "string"
+	) {
+		return null;
+	}
+	const stored = safeJsonParse(rule.conditions);
+	if (
+		typeof stored !== "object" ||
+		stored === null ||
+		Array.isArray(stored) ||
+		(stored as Record<string, unknown>).version !== 1
+	) {
+		return null;
+	}
+
+	let expression: RuleDocument;
+	try {
+		expression = mapCriteriaV0ToDocument({
+			ruleType: rule.ruleType as string,
+			parameters: rule.parameters as string,
+			operator: rule.operator as string | null,
+			conditions: rule.conditions as string | null,
+		});
+	} catch (error) {
+		throw new StoredCleanupExpressionError(
+			`Stored recursive cleanup expression is invalid: ${getErrorMessage(error)}`,
+		);
+	}
+
+	const emptyGroupError = getCleanupExpressionEmptyGroupError(expression.root);
+	if (emptyGroupError) {
+		throw new StoredCleanupExpressionError(
+			`Stored recursive cleanup expression is invalid: ${emptyGroupError}`,
+		);
+	}
+	return expression;
+}
+
+function getCleanupExpressionEmptyGroupError(
+	node: RuleDocument["root"],
+	path = "root",
+): string | null {
+	if ("kind" in node) return null;
+	if ("not" in node) return getCleanupExpressionEmptyGroupError(node.not, `${path}.not`);
+	if ("all" in node) {
+		if (node.all.length === 0) {
+			return `Recursive cleanup expression contains an empty all group at ${path}`;
+		}
+		for (let index = 0; index < node.all.length; index++) {
+			const error = getCleanupExpressionEmptyGroupError(node.all[index]!, `${path}.all[${index}]`);
+			if (error) return error;
+		}
+		return null;
+	}
+	if (node.any.length === 0) {
+		return `Recursive cleanup expression contains an empty any group at ${path}`;
+	}
+	for (let index = 0; index < node.any.length; index++) {
+		const error = getCleanupExpressionEmptyGroupError(node.any[index]!, `${path}.any[${index}]`);
+		if (error) return error;
+	}
+	return null;
+}
+
+function validateExpressionParameters(expression: RuleDocument): string | null {
+	const boundsError = validateV1Bounds(expression);
+	if (boundsError) return boundsError;
+	const emptyGroupError = getCleanupExpressionEmptyGroupError(expression.root);
+	if (emptyGroupError) return emptyGroupError;
+	if (cleanupExpressionContainsNot(expression.root)) {
+		return "NOT cleanup expressions are not supported until preview and execution can prove false evidence consistently";
+	}
+	for (const predicate of walkPredicates(expression.root)) {
+		if (!isKindLegalForContext("library-cleanup", predicate.kind)) {
+			return `Unknown rule type in expression: "${predicate.kind}"`;
+		}
+		const result = ruleParamSchemaMap[predicate.kind]?.safeParse(predicate.params);
+		if (!result?.success) {
+			const message = result?.error.issues.map((issue) => issue.message).join(", ");
+			return `Invalid parameters for expression rule type "${predicate.kind}": ${message || "unknown condition"}`;
+		}
+	}
+	return null;
+}
+
+function cleanupExpressionContainsNot(node: RuleDocument["root"]): boolean {
+	if ("kind" in node) return false;
+	if ("not" in node) return true;
+	const children = "all" in node ? node.all : node.any;
+	return children.some(cleanupExpressionContainsNot);
+}
+
+function assertStoredCleanupRulesSerializable(rules: readonly Record<string, unknown>[]): void {
+	for (const rule of rules) getStoredCleanupExpression(rule);
 }
 
 function storedStringArrayCount(value: unknown): number {
@@ -764,6 +878,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			{ prisma: app.prisma, log: request.log },
 			userId,
 			async () => {
+				const current = await app.prisma.libraryCleanupConfig.findUnique({
+					where: { userId },
+					include: { rules: true },
+				});
+				if (current) {
+					assertStoredCleanupRulesSerializable(
+						current.rules as unknown as Record<string, unknown>[],
+					);
+				}
 				const config = await app.prisma.libraryCleanupConfig.upsert({
 					where: { userId },
 					update: data,
@@ -792,17 +915,26 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 	app.post("/library-cleanup/rules", async (request, reply) => {
 		const userId = request.currentUser!.id;
 		const data = validateRequest(createCleanupRuleSchema, request.body);
+		const expression = data.expression ?? null;
+		if (expression && Object.keys(data.parameters).length > 0) {
+			return reply.status(400).send({
+				error: "Recursive cleanup expressions cannot mix legacy parameters",
+			});
+		}
 
 		// Write-time parameter validation: validate params against type-specific schema
-		const paramValidationError = validateRuleParameters(
-			data.ruleType,
-			data.parameters,
-			data.conditions ?? null,
-		);
+		const paramValidationError = expression
+			? validateExpressionParameters(expression)
+			: validateRuleParameters(
+					data.ruleType,
+					data.parameters,
+					data.operator ?? null,
+					data.conditions ?? null,
+				);
 		if (paramValidationError) {
 			return reply.status(400).send({ error: paramValidationError });
 		}
-		const scopeValidationError = getCleanupRuleScopeValidationError(data);
+		const scopeValidationError = getCleanupRuleScopeValidationError({ ...data, expression });
 		if (scopeValidationError) {
 			return reply.status(400).send({ error: scopeValidationError });
 		}
@@ -831,8 +963,8 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						name: data.name,
 						enabled: data.enabled,
 						priority: data.priority,
-						ruleType: data.ruleType,
-						parameters: JSON.stringify(data.parameters),
+						ruleType: expression ? "composite" : data.ruleType,
+						parameters: JSON.stringify(expression ? {} : data.parameters),
 						serviceFilter: data.serviceFilter ? JSON.stringify(data.serviceFilter) : null,
 						instanceFilter: data.instanceFilter ? JSON.stringify(data.instanceFilter) : null,
 						excludeTags: data.excludeTags ? JSON.stringify(data.excludeTags) : null,
@@ -846,8 +978,12 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						scanMediaServerInstanceIds: data.scanMediaServerAfterDelete
 							? JSON.stringify(scanMediaServerInstanceIds)
 							: null,
-						operator: data.operator ?? null,
-						conditions: data.conditions ? JSON.stringify(data.conditions) : null,
+						operator: expression ? null : (data.operator ?? null),
+						conditions: expression
+							? JSON.stringify(expression)
+							: data.conditions
+								? JSON.stringify(data.conditions)
+								: null,
 						retentionMode: data.retentionMode ?? false,
 						useGlobalRejectionMemory: data.useGlobalRejectionMemory ?? true,
 						// `?? 0` would collapse a deliberate `null` (forever) to `0` (off),
@@ -885,11 +1021,12 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			async () => {
 				const config = await app.prisma.libraryCleanupConfig.findUnique({
 					where: { userId },
-					include: { rules: { select: { id: true } } },
+					include: { rules: true },
 				});
 				if (!config) {
 					return reply.status(404).send({ error: "Config not found" });
 				}
+				assertStoredCleanupRulesSerializable(config.rules as unknown as Record<string, unknown>[]);
 
 				// Verify all IDs belong to this config and all rules are included
 				const existingIds = new Set(config.rules.map((r) => r.id));
@@ -941,17 +1078,73 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			return reply.status(404).send({ error: "Rule not found" });
 		}
 
-		// Write-time parameter validation (when ruleType or parameters are changed)
-		const effectiveRuleType = hasSuppliedField("ruleType") ? data.ruleType! : existing.ruleType;
-		const effectiveParams = hasSuppliedField("parameters")
-			? data.parameters!
-			: (utilSafeJsonParse(existing.parameters) as Record<string, unknown>);
-		const effectiveConditions = hasSuppliedField("conditions")
-			? (data.conditions ?? null)
-			: (utilSafeJsonParse(existing.conditions ?? "") as Array<{
-					ruleType: string;
-					parameters: Record<string, unknown>;
-				}> | null);
+		const storedExpression = getStoredCleanupExpression(
+			existing as unknown as Record<string, unknown>,
+		);
+		const expressionSupplied = hasSuppliedField("expression");
+		const effectiveExpression = expressionSupplied ? (data.expression ?? null) : storedExpression;
+		const isClearingStoredExpression = Boolean(
+			expressionSupplied && data.expression === null && storedExpression,
+		);
+		const representationFieldSupplied = ["ruleType", "parameters", "operator", "conditions"].some(
+			hasSuppliedField,
+		);
+
+		if (storedExpression && !expressionSupplied && representationFieldSupplied) {
+			return reply.status(400).send({
+				error: "Canonical cleanup expressions must be updated through the expression field",
+			});
+		}
+		if (
+			isClearingStoredExpression &&
+			(!hasSuppliedField("ruleType") || !hasSuppliedField("parameters"))
+		) {
+			return reply.status(400).send({
+				error: "Clearing a recursive cleanup expression requires a complete legacy replacement",
+			});
+		}
+
+		if (
+			effectiveExpression &&
+			((hasSuppliedField("ruleType") && data.ruleType !== "composite") ||
+				(hasSuppliedField("parameters") && Object.keys(data.parameters ?? {}).length > 0) ||
+				(hasSuppliedField("operator") && data.operator !== null) ||
+				(hasSuppliedField("conditions") && data.conditions !== null))
+		) {
+			return reply.status(400).send({
+				error: "Recursive cleanup expressions must use canonical composite storage",
+			});
+		}
+
+		const effectiveRuleType = effectiveExpression
+			? "composite"
+			: hasSuppliedField("ruleType")
+				? data.ruleType!
+				: existing.ruleType;
+		const effectiveParams = effectiveExpression
+			? {}
+			: hasSuppliedField("parameters")
+				? data.parameters!
+				: isClearingStoredExpression
+					? {}
+					: (utilSafeJsonParse(existing.parameters) as Record<string, unknown>);
+		const effectiveOperator = effectiveExpression
+			? null
+			: hasSuppliedField("operator")
+				? (data.operator ?? null)
+				: isClearingStoredExpression
+					? null
+					: existing.operator;
+		const effectiveConditions = effectiveExpression
+			? null
+			: hasSuppliedField("conditions")
+				? (data.conditions ?? null)
+				: isClearingStoredExpression
+					? null
+					: (utilSafeJsonParse(existing.conditions ?? "") as Array<{
+							ruleType: string;
+							parameters: Record<string, unknown>;
+						}> | null);
 		const effectiveTargetScope = hasSuppliedField("targetScope")
 			? data.targetScope
 			: existing.targetScope === "episode"
@@ -989,8 +1182,9 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			retentionMode: effectiveRetentionMode,
 			ruleType: effectiveRuleType,
 			parameters: effectiveParams ?? {},
-			operator: hasSuppliedField("operator") ? data.operator : existing.operator,
+			operator: effectiveOperator,
 			conditions: effectiveConditions ?? null,
+			expression: effectiveExpression,
 		});
 		if (scopeValidationError) {
 			return reply.status(400).send({ error: scopeValidationError });
@@ -1011,16 +1205,15 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			);
 			if (selectionError) return reply.status(400).send({ error: selectionError });
 		}
-		if (
-			hasSuppliedField("ruleType") ||
-			hasSuppliedField("parameters") ||
-			hasSuppliedField("conditions")
-		) {
-			const paramValidationError = validateRuleParameters(
-				effectiveRuleType,
-				effectiveParams ?? {},
-				effectiveConditions ?? null,
-			);
+		if (expressionSupplied || representationFieldSupplied) {
+			const paramValidationError = effectiveExpression
+				? validateExpressionParameters(effectiveExpression)
+				: validateRuleParameters(
+						effectiveRuleType,
+						effectiveParams ?? {},
+						effectiveOperator,
+						effectiveConditions ?? null,
+					);
 			if (paramValidationError) {
 				return reply.status(400).send({ error: paramValidationError });
 			}
@@ -1030,8 +1223,25 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		if (hasSuppliedField("name")) updateData.name = data.name;
 		if (hasSuppliedField("enabled")) updateData.enabled = data.enabled;
 		if (hasSuppliedField("priority")) updateData.priority = data.priority;
-		if (hasSuppliedField("ruleType")) updateData.ruleType = data.ruleType;
-		if (hasSuppliedField("parameters")) updateData.parameters = JSON.stringify(data.parameters);
+		if (effectiveExpression && expressionSupplied) {
+			updateData.ruleType = "composite";
+			updateData.parameters = "{}";
+			updateData.operator = null;
+			updateData.conditions = JSON.stringify(effectiveExpression);
+		} else if (isClearingStoredExpression) {
+			updateData.ruleType = effectiveRuleType;
+			updateData.parameters = JSON.stringify(effectiveParams ?? {});
+			updateData.operator = effectiveOperator;
+			updateData.conditions = effectiveConditions?.length
+				? JSON.stringify(effectiveConditions)
+				: null;
+		} else {
+			if (hasSuppliedField("ruleType")) updateData.ruleType = data.ruleType;
+			if (hasSuppliedField("parameters")) updateData.parameters = JSON.stringify(data.parameters);
+			if (hasSuppliedField("operator")) updateData.operator = data.operator ?? null;
+			if (hasSuppliedField("conditions"))
+				updateData.conditions = data.conditions?.length ? JSON.stringify(data.conditions) : null;
+		}
 		if (hasSuppliedField("serviceFilter"))
 			updateData.serviceFilter = data.serviceFilter ? JSON.stringify(data.serviceFilter) : null;
 		if (hasSuppliedField("instanceFilter"))
@@ -1057,9 +1267,6 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 				? JSON.stringify(effectiveScanMediaServerInstanceIds)
 				: null;
 		}
-		if (hasSuppliedField("operator")) updateData.operator = data.operator ?? null;
-		if (hasSuppliedField("conditions"))
-			updateData.conditions = data.conditions?.length ? JSON.stringify(data.conditions) : null;
 		if (hasSuppliedField("retentionMode")) updateData.retentionMode = data.retentionMode;
 		if (hasSuppliedField("useGlobalRejectionMemory"))
 			updateData.useGlobalRejectionMemory = data.useGlobalRejectionMemory;
@@ -2338,6 +2545,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 function validateRuleParameters(
 	ruleType: string,
 	parameters: Record<string, unknown>,
+	operator: string | null,
 	conditions: Array<{ ruleType: string; parameters: Record<string, unknown> }> | null,
 ): string | null {
 	// Reject mode-mismatch: a leaf ruleType carrying operator+conditions
@@ -2346,6 +2554,12 @@ function validateRuleParameters(
 	// mixed shape would validate one thing and evaluate another (the same
 	// guard auto-tag.ts has carried; ported per review finding).
 	const compositeByShape = conditions != null && conditions.length > 0;
+	const compositeByOperator = operator != null;
+	if (compositeByShape !== compositeByOperator) {
+		return compositeByShape
+			? "Composite rule conditions require an operator"
+			: "Composite rule operator requires at least one condition";
+	}
 	const compositeByRuleType = ruleType === "composite";
 	if (compositeByShape !== compositeByRuleType) {
 		return compositeByShape

--- a/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/automation-panel.test.tsx
@@ -133,6 +133,37 @@ describe("<AutomationPanel />", () => {
 		expect(screen.getByText(/could not be read/i)).toBeInTheDocument();
 	});
 
+	it("does not offer the flat editor for a recursive cleanup document", () => {
+		mockUseAutomationRules.mockReturnValue({
+			data: response([
+				{
+					id: "nested-cleanup",
+					name: "Nested cleanup",
+					enabled: true,
+					context: "library-cleanup",
+					document: {
+						version: 1,
+						root: {
+							all: [
+								{ kind: "age", params: { operator: "older_than", days: 30 } },
+								{
+									any: [{ kind: "year_range", params: { operator: "before", year: 2000 } }],
+								},
+							],
+						},
+					},
+					unavailableKinds: [],
+					unparseable: false,
+				},
+			]),
+		});
+
+		render(<AutomationPanel />, { wrapper: createWrapper() });
+
+		expect(screen.getByText("Nested cleanup")).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /edit nested cleanup/i })).not.toBeInTheDocument();
+	});
+
 	it("shows cross-domain draft lifecycle actions and requires a preview before deploy", () => {
 		mockUseAutomationRules.mockReturnValue({
 			data: response([

--- a/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
@@ -231,6 +231,19 @@ describe("CleanupRuleComposerDialog — edit", () => {
 		expect(updateMutate).not.toHaveBeenCalled();
 	});
 
+	it("keeps a flat canonical expression read-only instead of submitting legacy fields", async () => {
+		const expression = automationData.rules[0]!.document!;
+		configData!.rules[0]!.operator = null;
+		configData!.rules[0]!.conditions = null;
+		configData!.rules[0]!.expression = expression;
+
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
+
+		expect(await screen.findByText(/recursive rule is read-only/i)).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+		expect(updateMutate).not.toHaveBeenCalled();
+	});
+
 	it("prefills name + action + both composite conditions from the joined sources", async () => {
 		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
 

--- a/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
+++ b/apps/web/src/features/console/components/__tests__/cleanup-rule-composer-dialog.test.tsx
@@ -196,6 +196,7 @@ describe("CleanupRuleComposerDialog — edit", () => {
 						{ ruleType: "age", parameters: { operator: "older_than", days: 90 } },
 						{ ruleType: "plex_watch_count", parameters: { operator: "less_than", count: 1 } },
 					],
+					expression: null,
 					retentionMode: true,
 					useGlobalRejectionMemory: true,
 					rejectionMemoryDays: null,
@@ -204,6 +205,30 @@ describe("CleanupRuleComposerDialog — edit", () => {
 				},
 			],
 		};
+	});
+
+	it("shows a real recursive response read-only without attempting to flatten it", async () => {
+		const expression = {
+			version: 1 as const,
+			root: {
+				all: [
+					{ kind: "age", params: { operator: "older_than", days: 90 } },
+					{
+						any: [{ kind: "year_range", params: { operator: "before", year: 2000 } }],
+					},
+				],
+			},
+		};
+		automationData.rules[0]!.document = expression;
+		configData!.rules[0]!.operator = null;
+		configData!.rules[0]!.conditions = null;
+		configData!.rules[0]!.expression = expression;
+
+		wrapper(<CleanupRuleComposerDialog open onOpenChange={() => {}} editRuleId="rule-1" />);
+
+		expect(await screen.findByText(/recursive rule is read-only/i)).toBeInTheDocument();
+		expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+		expect(updateMutate).not.toHaveBeenCalled();
 	});
 
 	it("prefills name + action + both composite conditions from the joined sources", async () => {
@@ -265,6 +290,7 @@ describe("CleanupRuleComposerDialog — edit", () => {
 					scanMediaServerInstanceIds: [],
 					operator: null,
 					conditions: null,
+					expression: null,
 					retentionMode: false,
 					useGlobalRejectionMemory: true,
 					rejectionMemoryDays: 0,

--- a/apps/web/src/features/console/components/automation-panel.tsx
+++ b/apps/web/src/features/console/components/automation-panel.tsx
@@ -49,6 +49,7 @@ import { getErrorMessage } from "../../../lib/error-utils";
 import { getLinuxInstanceName, getLinuxIsoName } from "../../../lib/incognito";
 import { SEMANTIC_COLORS } from "../../../lib/theme-gradients";
 import { RuleDocumentView } from "./rule-document-view";
+import { isCriteriaDocumentV0Editable } from "../lib/rule-document-editor";
 
 const CleanupRuleComposerDialog = lazy(() =>
 	import("./cleanup-rule-composer-dialog").then((m) => ({
@@ -296,7 +297,10 @@ export function AutomationPanel() {
 											// dead-end (picker shows a wrong kind, save is blocked). Route
 											// those to the domain surface to repair instead.
 											const ctx = editableContext(rule.context);
-											return ctx && rule.unavailableKinds.length === 0
+											return ctx &&
+												rule.unavailableKinds.length === 0 &&
+												rule.document &&
+												isCriteriaDocumentV0Editable(rule.document)
 												? () => openEdit(ctx, rule.id)
 												: undefined;
 										})()}

--- a/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
@@ -47,6 +47,7 @@ import { getDefaultConditionParams } from "../../rule-criteria/components/condit
 import {
 	type CriteriaEditorState,
 	decomposeCriteriaDocument,
+	isCriteriaDocumentV0Editable,
 	toCriteriaV0Payload,
 } from "../lib/rule-document-editor";
 import { CriteriaConditionEditor } from "./criteria-condition-editor";
@@ -117,6 +118,11 @@ export function CleanupRuleComposerDialog({
 	// retentionMode:false) and write them over the stored values — on a media-
 	// deletion rule, silently flipping e.g. "unmonitor" → "delete". So we gate.
 	const editDataReady = !isEdit || (Boolean(summary) && Boolean(configRule));
+	const isRecursiveReadOnly = Boolean(
+		isEdit &&
+			configRule?.expression &&
+			(!summary?.document || !isCriteriaDocumentV0Editable(summary.document)),
+	);
 
 	const [name, setName] = useState("");
 	const [enabled, setEnabled] = useState(true);
@@ -149,7 +155,9 @@ export function CleanupRuleComposerDialog({
 			// rule was unparseable (document null) we fall back to a fresh editor so
 			// the operator can re-author rather than see a broken form.
 			setEditorState(
-				summary?.document ? decomposeCriteriaDocument(summary.document) : freshEditorState(),
+				summary?.document && !isRecursiveReadOnly
+					? decomposeCriteriaDocument(summary.document)
+					: freshEditorState(),
 			);
 		} else {
 			setName("");
@@ -160,7 +168,7 @@ export function CleanupRuleComposerDialog({
 			setEpisodeWatchCount(1);
 			setEditorState(freshEditorState());
 		}
-	}, [open, isEdit, editDataReady, summary, configRule]);
+	}, [open, isEdit, editDataReady, isRecursiveReadOnly, summary, configRule]);
 
 	const inputStyles = getInputStyles(gradient);
 	const inputClass = `${inputStyles.base} focus:outline-hidden`;
@@ -189,7 +197,7 @@ export function CleanupRuleComposerDialog({
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
-		if (isSaving) return;
+		if (isSaving || isRecursiveReadOnly) return;
 
 		if (!name.trim()) {
 			setError("Give the rule a name.");
@@ -303,6 +311,23 @@ export function CleanupRuleComposerDialog({
 					<div className="flex items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
 						<Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
 						Loading rule…
+					</div>
+				) : isRecursiveReadOnly ? (
+					<div className="mt-2 space-y-4 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4">
+						<p className="text-sm font-medium text-foreground">Recursive rule is read-only</p>
+						<p className="text-sm text-muted-foreground">
+							The flat composer cannot safely represent this nested expression. The stored rule has
+							not been changed.
+						</p>
+						<div className="flex justify-end">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-lg border border-border/50 px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Close
+							</button>
+						</div>
 					</div>
 				) : (
 					<form

--- a/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
+++ b/apps/web/src/features/console/components/cleanup-rule-composer-dialog.tsx
@@ -47,7 +47,6 @@ import { getDefaultConditionParams } from "../../rule-criteria/components/condit
 import {
 	type CriteriaEditorState,
 	decomposeCriteriaDocument,
-	isCriteriaDocumentV0Editable,
 	toCriteriaV0Payload,
 } from "../lib/rule-document-editor";
 import { CriteriaConditionEditor } from "./criteria-condition-editor";
@@ -118,11 +117,7 @@ export function CleanupRuleComposerDialog({
 	// retentionMode:false) and write them over the stored values — on a media-
 	// deletion rule, silently flipping e.g. "unmonitor" → "delete". So we gate.
 	const editDataReady = !isEdit || (Boolean(summary) && Boolean(configRule));
-	const isRecursiveReadOnly = Boolean(
-		isEdit &&
-			configRule?.expression &&
-			(!summary?.document || !isCriteriaDocumentV0Editable(summary.document)),
-	);
+	const isRecursiveReadOnly = Boolean(isEdit && configRule?.expression);
 
 	const [name, setName] = useState("");
 	const [enabled, setEnabled] = useState(true);

--- a/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
@@ -142,6 +142,7 @@ function makeEditRule(overrides: Partial<CleanupRuleResponse> = {}): CleanupRule
 		scanMediaServerInstanceIds: [],
 		operator: null,
 		conditions: null,
+		expression: null,
 		retentionMode: false,
 		useGlobalRejectionMemory: true,
 		rejectionMemoryDays: 0,
@@ -318,6 +319,32 @@ describe("CleanupRuleDialog", () => {
 	// ================================================================
 
 	describe("edit mode", () => {
+		it("keeps recursive expressions read-only instead of flattening them", () => {
+			const onSave = vi.fn();
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({
+					ruleType: "composite",
+					parameters: {},
+					expression: {
+						version: 1,
+						root: {
+							all: [
+								{ kind: "age", params: { operator: "older_than", days: 30 } },
+								{
+									any: [{ kind: "year_range", params: { operator: "before", year: 2000 } }],
+								},
+							],
+						},
+					},
+				}),
+			});
+
+			expect(screen.getByText(/recursive rule is read-only/i)).toBeInTheDocument();
+			expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
+			expect(onSave).not.toHaveBeenCalled();
+		});
+
 		it("renders the dialog title for edit mode", () => {
 			renderDialog({ editRule: makeEditRule() });
 			expect(screen.getByText("Edit Rule")).toBeInTheDocument();

--- a/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
@@ -196,6 +196,7 @@ function makeConfig(overrides: Partial<CleanupConfigResponse> = {}): CleanupConf
 				scanMediaServerInstanceIds: [],
 				operator: null,
 				conditions: null,
+				expression: null,
 				retentionMode: false,
 				useGlobalRejectionMemory: true,
 				rejectionMemoryDays: 0,

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -72,6 +72,7 @@ export function CleanupRuleDialog({
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
 	const isEdit = !!editRule;
+	const isRecursiveReadOnly = Boolean(editRule?.expression);
 	const { data: fieldOptions, isLoading: fieldOptionsLoading } = useCleanupFieldOptions();
 	const { data: allServices } = useServicesQuery();
 	const mediaServerInstances = fieldOptions?.mediaServerInstances ?? [];
@@ -766,6 +767,7 @@ export function CleanupRuleDialog({
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		if (isRecursiveReadOnly) return;
 		const isEpisodeScope = targetScope === "episode";
 		const shouldScanMediaServers = canScanMediaServers && scanMediaServerAfterDelete;
 		if (shouldScanMediaServers && scanMediaServerInstanceIds.length === 0) {
@@ -898,7 +900,27 @@ export function CleanupRuleDialog({
 					</div>
 				)}
 
+				{isRecursiveReadOnly && (
+					<div className="mt-2 space-y-4 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4">
+						<p className="text-sm font-medium text-foreground">Recursive rule is read-only</p>
+						<p className="text-sm text-muted-foreground">
+							This editor cannot safely represent nested cleanup conditions yet. The stored rule has
+							not been changed; close this dialog to keep it intact.
+						</p>
+						<div className="flex justify-end">
+							<button
+								type="button"
+								onClick={() => onOpenChange(false)}
+								className="rounded-lg px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+							>
+								Close
+							</button>
+						</div>
+					</div>
+				)}
+
 				<form
+					hidden={isRecursiveReadOnly}
 					onSubmit={handleSubmit}
 					className="space-y-5 mt-2"
 					onFocus={(e) => {

--- a/packages/shared/src/types/__tests__/library-cleanup.test.ts
+++ b/packages/shared/src/types/__tests__/library-cleanup.test.ts
@@ -13,6 +13,15 @@ const validEpisodeRule = {
 	targetScope: "episode" as const,
 };
 
+const recursiveExpression = {
+	version: 1 as const,
+	root: {
+		not: {
+			all: [{ kind: "age", params: { operator: "older_than", days: 30 } }],
+		},
+	},
+};
+
 describe("library cleanup target scope", () => {
 	it("defaults legacy rules to series scope", () => {
 		const parsed = createCleanupRuleSchema.parse({
@@ -32,6 +41,88 @@ describe("library cleanup target scope", () => {
 		expect(createCleanupRuleSchema.parse(validEpisodeRule).targetScope).toBe("episode");
 	});
 
+	it("accepts a recursive expression only for a composite cleanup rule", () => {
+		const parsed = createCleanupRuleSchema.parse({
+			name: "Keep recent items",
+			ruleType: "composite",
+			parameters: {},
+			expression: recursiveExpression,
+		});
+
+		expect(parsed.expression).toEqual(recursiveExpression);
+	});
+
+	it("accepts an explicit null expression on create", () => {
+		const parsed = createCleanupRuleSchema.parse({
+			name: "Legacy rule",
+			ruleType: "age",
+			parameters: { days: 30 },
+			expression: null,
+		});
+
+		expect(parsed.expression).toBeNull();
+	});
+
+	it.each([
+		[
+			{ ruleType: "age", parameters: {}, expression: recursiveExpression },
+			"must use ruleType composite",
+		],
+		[
+			{
+				ruleType: "composite",
+				parameters: {},
+				expression: recursiveExpression,
+				operator: "AND",
+			},
+			"cannot mix expression with operator",
+		],
+		[
+			{
+				ruleType: "composite",
+				parameters: {},
+				expression: recursiveExpression,
+				conditions: [{ ruleType: "age", parameters: {} }],
+			},
+			"cannot mix expression with conditions",
+		],
+	])("rejects an ambiguous recursive expression payload %#", (rule, message) => {
+		const result = createCleanupRuleSchema.safeParse({ name: "Ambiguous", ...rule });
+
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues.some((issue) => issue.message.includes(message))).toBe(true);
+		}
+	});
+
+	it("accepts an expression update without repeating the composite discriminator", () => {
+		expect(updateCleanupRuleSchema.parse({ expression: recursiveExpression }).expression).toEqual(
+			recursiveExpression,
+		);
+	});
+
+	it("accepts an explicit null expression update", () => {
+		expect(updateCleanupRuleSchema.parse({ expression: null }).expression).toBeNull();
+	});
+
+	it("rejects an expression update with an explicitly non-composite discriminator", () => {
+		expect(
+			updateCleanupRuleSchema.safeParse({
+				ruleType: "age",
+				expression: recursiveExpression,
+			}).success,
+		).toBe(false);
+	});
+
+	it("rejects a recursive expression explicitly paired with episode scope", () => {
+		expect(
+			updateCleanupRuleSchema.safeParse({
+				targetScope: "episode",
+				expression: recursiveExpression,
+			}).success,
+		).toBe(false);
+	});
+
 	it.each([
 		[{ ...validEpisodeRule, serviceFilter: ["RADARR"] }, "Sonarr only"],
 		[{ ...validEpisodeRule, serviceFilter: ["SONARR", "RADARR"] }, "Sonarr only"],
@@ -43,6 +134,15 @@ describe("library cleanup target scope", () => {
 				ruleType: "composite",
 				operator: "AND",
 				conditions: [{ ruleType: "plex_watch_count", parameters: validEpisodeRule.parameters }],
+			},
+			"cannot be composite",
+		],
+		[
+			{
+				...validEpisodeRule,
+				ruleType: "composite",
+				parameters: {},
+				expression: recursiveExpression,
 			},
 			"cannot be composite",
 		],

--- a/packages/shared/src/types/library-cleanup.ts
+++ b/packages/shared/src/types/library-cleanup.ts
@@ -11,6 +11,7 @@
  */
 
 import { z } from "zod";
+import { type RuleDocument, ruleDocumentSchema } from "../rules/grammar.js";
 import { getRegexSafetyError, REGEX_MAX_LENGTH } from "./regex-safety.js";
 import {
 	type CompositeOperator,
@@ -75,6 +76,8 @@ const baseCleanupRuleSchema = z.object({
 		.default([]),
 	operator: compositeOperatorSchema.nullable().optional(),
 	conditions: z.array(conditionSchema).nullable().optional(),
+	/** Recursive v1 criteria, persisted in the existing conditions column. */
+	expression: ruleDocumentSchema.nullable().optional(),
 	retentionMode: z.boolean().optional().default(false),
 	/**
 	 * When true, this rule inherits the config-level `rejectionMemoryDays`.
@@ -101,6 +104,7 @@ interface CleanupRuleScopeInput {
 	parameters?: Record<string, unknown> | null;
 	operator?: CompositeOperator | string | null;
 	conditions?: readonly unknown[] | null;
+	expression?: RuleDocument | null;
 }
 
 interface CleanupMediaServerScanInput {
@@ -154,7 +158,8 @@ export function getCleanupRuleScopeValidationError(rule: CleanupRuleScopeInput):
 	if (
 		rule.ruleType === "composite" ||
 		rule.operator != null ||
-		(rule.conditions?.length ?? 0) > 0
+		(rule.conditions?.length ?? 0) > 0 ||
+		rule.expression != null
 	) {
 		return "Episode-scoped cleanup rules cannot be composite";
 	}
@@ -168,7 +173,42 @@ export function getCleanupRuleScopeValidationError(rule: CleanupRuleScopeInput):
 	return null;
 }
 
+function validateCleanupExpression(
+	data: {
+		ruleType?: RuleType;
+		operator?: CompositeOperator | null;
+		conditions?: Condition[] | null;
+		expression?: RuleDocument | null;
+	},
+	ctx: z.RefinementCtx,
+	requireCompositeRuleType: boolean,
+): void {
+	if (data.expression == null) return;
+	if (data.ruleType !== "composite" && (requireCompositeRuleType || data.ruleType !== undefined)) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Recursive cleanup expressions must use ruleType composite",
+			path: ["ruleType"],
+		});
+	}
+	if (data.operator != null) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Cleanup rules cannot mix expression with operator",
+			path: ["operator"],
+		});
+	}
+	if (data.conditions != null) {
+		ctx.addIssue({
+			code: z.ZodIssueCode.custom,
+			message: "Cleanup rules cannot mix expression with conditions",
+			path: ["conditions"],
+		});
+	}
+}
+
 export const createCleanupRuleSchema = baseCleanupRuleSchema.superRefine((data, ctx) => {
+	validateCleanupExpression(data, ctx, true);
 	if (data.operator != null && (!data.conditions || data.conditions.length === 0)) {
 		ctx.addIssue({
 			code: z.ZodIssueCode.custom,
@@ -207,6 +247,7 @@ export const updateCleanupRuleSchema = baseCleanupRuleSchema
 		scanMediaServerInstanceIds: z.array(z.string().trim().min(1).max(128)).max(50).optional(),
 	})
 	.superRefine((data, ctx) => {
+		validateCleanupExpression(data, ctx, false);
 		if (data.operator != null && (!data.conditions || data.conditions.length === 0)) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
@@ -226,6 +267,13 @@ export const updateCleanupRuleSchema = baseCleanupRuleSchema
 					path: ["scanMediaServerAfterDelete"],
 				});
 			}
+		}
+		if (data.targetScope === "episode" && data.expression != null) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "Episode-scoped cleanup rules cannot be composite",
+				path: ["targetScope"],
+			});
 		}
 	});
 
@@ -299,6 +347,7 @@ export interface CleanupRuleResponse {
 	scanMediaServerInstanceIds: string[];
 	operator: CompositeOperator | null;
 	conditions: Condition[] | null;
+	expression: RuleDocument | null;
 	retentionMode: boolean;
 	/** Issue #474: when true, rule inherits config's rejectionMemoryDays. */
 	useGlobalRejectionMemory: boolean;


### PR DESCRIPTION
## Summary

- expose bounded recursive cleanup expressions through the shared API contract
- persist canonical version 1 documents without mixing legacy rule fields
- preserve existing legacy composite rows and reject malformed canonical storage before policy mutations
- traverse every nested predicate for failed-provider and execution-time evidence checks
- keep recursive rules read-only in flat editors so their meaning cannot be lost
- block NOT authoring until preview and mutation execution can distinguish false from unknown evidence consistently

## Safety

Cleanup execution still fails closed. Every nested positive predicate must have authoritative mutation evidence, failed provider dependencies block the rule, and malformed stored expressions are rejected before configuration or priority writes occur.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- pnpm run build
- focused API, shared-schema, and rendered UI regression suites