### PR TITLE
feat(cleanup): add evidence-aware NOT semantics

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -503,6 +503,80 @@ describe("mutation policy evidence authority", () => {
 		).toMatchObject({ kind: "cleanup", match: { ruleId: "rule-recursive" } });
 	});
 
+	it("uses the same proven NOT expression for preview and mutation authorization", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-not",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { not: { kind: "year_range", params: { operator: "after", year: 2030 } } },
+				}),
+			},
+		);
+		const item = mutationEvidenceItem({ _arrDashboardEvidence: {} });
+		const context = { now: new Date() };
+
+		expect(evaluateRuleViaEngine(item as never, rule as never, "RADARR", context)).toMatchObject({
+			ruleId: "rule-recursive-not",
+			reason: "NOT",
+		});
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", context),
+		).toMatchObject({ kind: "cleanup", match: { ruleId: "rule-recursive-not" } });
+	});
+
+	it("fails closed when NOT lacks the field needed to prove false", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-not-missing",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { not: { kind: "year_range", params: { operator: "after", year: 2030 } } },
+				}),
+			},
+		);
+		const item = { ...mutationEvidenceItem({ _arrDashboardEvidence: {} }), year: null };
+		const context = { now: new Date() };
+
+		expect(evaluateRuleViaEngine(item as never, rule as never, "RADARR", context)).toBeNull();
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", context),
+		).toEqual({ kind: "unknown", ruleId: "rule-recursive-not-missing" });
+	});
+
+	it("keeps partial file evidence unknown in both NOT preview and mutation authorization", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-not-partial-file",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: { kind: "custom_format_score", params: { operator: "greater_than", score: 0 } },
+					},
+				}),
+			},
+		);
+		const item = mutationEvidenceItem({
+			movieFile: { customFormatScore: null },
+			_arrDashboardEvidence: { hasFile: true },
+		});
+		const context = { now: new Date() };
+
+		expect(evaluateRuleViaEngine(item as never, rule as never, "RADARR", context)).toBeNull();
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", context),
+		).toEqual({ kind: "unknown", ruleId: "rule-recursive-not-partial-file" });
+	});
+
 	it("fails closed when a nested expression depends on a failed provider", () => {
 		const rule = mutationEvidenceRule(
 			"composite",

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -577,6 +577,117 @@ describe("mutation policy evidence authority", () => {
 		).toEqual({ kind: "unknown", ruleId: "rule-recursive-not-partial-file" });
 	});
 
+	it("requires every weighted staleness input before authorizing NOT", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-not-staleness",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: {
+							kind: "staleness_score",
+							params: {
+								operator: "greater_than",
+								threshold: 1,
+								weights: {
+									daysSinceLastWatch: 0,
+									inverseWatchCount: 0,
+									notOnDeck: 0,
+									lowUserRating: 0,
+									lowTmdbRating: 0,
+									sizeOnDisk: 1,
+								},
+							},
+						},
+					},
+				}),
+			},
+		);
+		const item = {
+			...mutationEvidenceItem({ _arrDashboardEvidence: { sizeOnDisk: false } }),
+			sizeOnDisk: 0n,
+		};
+		const context = {
+			now: new Date(),
+			plexMap: new Map([
+				[
+					"movie:42",
+					{
+						lastWatchedAt: null,
+						watchCount: 0,
+						watchedByUsers: [],
+						onDeck: false,
+						userRating: null,
+						collections: [],
+						labels: [],
+						addedAt: null,
+						sections: [],
+					},
+				],
+			]),
+		};
+
+		expect(evaluateRuleViaEngine(item as never, rule as never, "RADARR", context)).toBeNull();
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", context),
+		).toEqual({ kind: "unknown", ruleId: "rule-recursive-not-staleness" });
+	});
+
+	it("authorizes negative tag logic from a complete empty inventory", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-empty-tags",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: {
+							kind: "tag_match",
+							params: { operator: "includes_any", tagIds: [99] },
+						},
+					},
+				}),
+			},
+		);
+		const item = mutationEvidenceItem({ _arrDashboardEvidence: { tags: true } });
+
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", {
+				now: new Date(),
+			}),
+		).toMatchObject({ kind: "cleanup", match: { ruleId: "rule-recursive-empty-tags" } });
+	});
+
+	it("authorizes explicit SDR after normalization removes the null field", () => {
+		const rule = mutationEvidenceRule(
+			"composite",
+			{},
+			{
+				id: "rule-recursive-sdr",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { kind: "hdr_type", params: { operator: "none" } },
+				}),
+			},
+		);
+		const item = mutationEvidenceItem({
+			movieFile: { id: 1001 },
+			_arrDashboardEvidence: { hasFile: true, hdrType: true },
+		});
+
+		expect(
+			evaluateItemMutationPolicyStateViaEngine(item as never, [rule] as never, "RADARR", {
+				now: new Date(),
+			}),
+		).toMatchObject({ kind: "cleanup", match: { ruleId: "rule-recursive-sdr" } });
+	});
+
 	it("fails closed when a nested expression depends on a failed provider", () => {
 		const rule = mutationEvidenceRule(
 			"composite",

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -7086,7 +7086,12 @@ async function evaluateAllItems(
 					? "ok"
 					: "failed"
 				: "skipped",
-		jellyfin: hasJellyfinRules ? (jellyfinMap ? "ok" : "failed") : "skipped",
+		jellyfin:
+			hasJellyfinRules || hasJellyfinEpisodeRules
+				? (!hasJellyfinRules || jellyfinMap) && (!hasJellyfinEpisodeRules || jellyfinEpisodeMap)
+					? "ok"
+					: "failed"
+				: "skipped",
 	};
 
 	// Check for failed prefetches that have dependent rules — generate warnings
@@ -7116,6 +7121,9 @@ async function evaluateAllItems(
 	// Build evaluation context
 	const ctx: EvalContext = {
 		now,
+		availableDataSources: new Set(
+			(["seerr", "plex", "jellyfin"] as const).filter((source) => prefetchHealth[source] === "ok"),
+		),
 		seerrMap,
 		plexMap,
 		plexSectionTitles: plexEvidence?.plexSectionTitles,
@@ -10264,6 +10272,13 @@ export async function buildEvalContext(
 
 	return {
 		now: new Date(),
+		availableDataSources: new Set([
+			...(needsSeerr && seerrMap ? (["seerr"] as const) : []),
+			...(plexEvidence ? (["plex"] as const) : []),
+			...((needsJellyfin && jellyfinMap) || (needsJellyfinEpisodes && jellyfinEpisodeMap)
+				? (["jellyfin"] as const)
+				: []),
+		]),
 		seerrMap: seerrMap ?? undefined,
 		plexMap: plexEvidence?.plexMap,
 		plexSectionTitles: plexEvidence?.plexSectionTitles,

--- a/apps/api/src/lib/library-cleanup/types.ts
+++ b/apps/api/src/lib/library-cleanup/types.ts
@@ -4,7 +4,7 @@
  * Internal types for the cleanup rule evaluation pipeline.
  */
 
-import type { CleanupProviderEvidence } from "@arr/shared";
+import type { CleanupProviderEvidence, DataSourceDependency } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
@@ -184,6 +184,8 @@ export type PlexEpisodeMap = Map<number, PlexEpisodeStats>;
  */
 export interface EvalContext {
 	now: Date;
+	/** Successful complete external snapshots, including valid empty snapshots. */
+	availableDataSources?: ReadonlySet<Exclude<DataSourceDependency, null>>;
 	seerrMap?: SeerrRequestMap;
 	plexMap?: PlexWatchMap;
 	/** Complete, current Plex movie/show section-title inventory across enabled instances. */

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -595,6 +595,101 @@ describe("parity — composites", () => {
 		expect(result?.reason).toBe("NOT");
 	});
 
+	it("keeps NOT unknown when a weighted staleness input lacks ARR evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({
+				sizeOnDisk: 0n,
+				data: JSON.stringify({
+					remoteIds: { tmdbId: 12345 },
+					_arrDashboardEvidence: { sizeOnDisk: false },
+				}),
+			}),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: {
+							kind: "staleness_score",
+							params: {
+								operator: "greater_than",
+								threshold: 1,
+								weights: {
+									daysSinceLastWatch: 0,
+									inverseWatchCount: 0,
+									notOnDeck: 0,
+									lowUserRating: 0,
+									lowTmdbRating: 0,
+									sizeOnDisk: 1,
+								},
+							},
+						},
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx({ plexMap: new Map([["movie:12345", makePlexInfo()]]) }),
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("uses an authoritative empty tag inventory as negative evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({
+				data: JSON.stringify({
+					remoteIds: { tmdbId: 12345 },
+					_arrDashboardEvidence: { tags: true },
+				}),
+			}),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: {
+							kind: "tag_match",
+							params: { operator: "includes_any", tagIds: [1] },
+						},
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
+		expect(result?.reason).toBe("NOT");
+	});
+
+	it("uses an explicit normalized SDR marker as hdr_type evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({
+				data: JSON.stringify({
+					remoteIds: { tmdbId: 12345 },
+					movieFile: { id: 1 },
+					_arrDashboardEvidence: { hdrType: true },
+				}),
+			}),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { kind: "hdr_type", params: { operator: "none" } },
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
+		expect(result).toMatchObject({ ruleId: "rule-1" });
+	});
+
 	it("allows NOT to invert a provider predicate with item-level evidence", () => {
 		const plexMap = new Map([["movie:12345", makePlexInfo({ onDeck: false })]]);
 		const result = evaluateRuleViaEngine(

--- a/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
+++ b/apps/api/src/lib/rules/__tests__/cleanup-parity.test.ts
@@ -443,7 +443,7 @@ describe("parity — composites", () => {
 		expect(result).toBeNull();
 	});
 
-	it("temporarily treats a legacy false leaf as unknown under NOT until Task 3", () => {
+	it("allows NOT to invert a locally proven false predicate", () => {
 		const result = evaluateRuleViaEngine(
 			makeCacheItem({ arrAddedAt: new Date("2026-02-28T00:00:00Z") }),
 			makeRule({
@@ -461,10 +461,225 @@ describe("parity — composites", () => {
 			baseCtx(),
 		);
 
-		// evaluateSingleCondition currently collapses proven false and unavailable
-		// evidence to null. Wave 3A converts that null to unknown so NOT cannot
-		// authorize deletion; Task 3 will supply evidence-aware leaf states.
+		expect(result?.reason).toBe("NOT");
+	});
+
+	it("keeps NOT unknown when a local predicate lacks its required evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({ arrAddedAt: null }),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: { kind: "age", params: { operator: "older_than", days: 30 } },
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
 		expect(result).toBeNull();
+	});
+
+	it.each([
+		[
+			"rating without a source",
+			"rating",
+			{ operator: "greater_than", score: 8 },
+			{ ratings: {} },
+			"RADARR",
+		],
+		[
+			"rating with a zero sentinel",
+			"rating",
+			{ operator: "greater_than", score: 8 },
+			{ ratings: { tmdb: { value: 0 } } },
+			"RADARR",
+		],
+		[
+			"IMDb rating on Sonarr",
+			"imdb_rating",
+			{ operator: "greater_than", score: 8 },
+			{ ratings: { imdb: { value: 7 } } },
+			"SONARR",
+		],
+		[
+			"non-TMDb rating on Radarr",
+			"rating",
+			{ operator: "greater_than", score: 8 },
+			{ ratings: { imdb: { value: 7 } } },
+			"RADARR",
+		],
+		[
+			"blank language",
+			"language",
+			{ operator: "includes_any", languages: ["English"] },
+			{ originalLanguage: "" },
+			"RADARR",
+		],
+		[
+			"null custom-format score",
+			"custom_format_score",
+			{ operator: "greater_than", score: 0 },
+			{ movieFile: { customFormatScore: null } },
+			"RADARR",
+		],
+		[
+			"blank codec",
+			"video_codec",
+			{ operator: "is", codecs: ["h265"] },
+			{ movieFile: { videoCodec: "" } },
+			"RADARR",
+		],
+		[
+			"missing dynamic-range field",
+			"hdr_type",
+			{ operator: "is", types: ["HDR10"] },
+			{ movieFile: {} },
+			"RADARR",
+		],
+		["blank path", "file_path", { operator: "matches", pattern: "movie" }, { path: "" }, "RADARR"],
+		[
+			"runtime available only through an unsupported fallback",
+			"runtime",
+			{ operator: "greater_than", minutes: 60 },
+			{ statistics: { runtime: 120 } },
+			"RADARR",
+		],
+		[
+			"malformed tag inventory",
+			"tag_match",
+			{ operator: "includes_any", tagIds: [1] },
+			{ tags: [null] },
+			"RADARR",
+		],
+	] as const)(
+		"keeps NOT unknown for incomplete %s evidence",
+		(_label, kind, params, data, service) => {
+			const result = evaluateRuleViaEngine(
+				makeCacheItem({ data: JSON.stringify({ remoteIds: { tmdbId: 12345 }, ...data }) }),
+				makeRule({
+					ruleType: "composite",
+					parameters: "{}",
+					operator: null,
+					conditions: JSON.stringify({ version: 1, root: { not: { kind, params } } }),
+				}),
+				service,
+				baseCtx(),
+			);
+
+			expect(result).toBeNull();
+		},
+	);
+
+	it("allows NOT to invert a rating comparison with a complete source value", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { not: { kind: "rating", params: { operator: "greater_than", score: 8 } } },
+				}),
+			}),
+			"RADARR",
+			baseCtx(),
+		);
+
+		expect(result?.reason).toBe("NOT");
+	});
+
+	it("allows NOT to invert a provider predicate with item-level evidence", () => {
+		const plexMap = new Map([["movie:12345", makePlexInfo({ onDeck: false })]]);
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { not: { kind: "plex_on_deck", params: { isDeck: true } } },
+				}),
+			}),
+			"RADARR",
+			baseCtx({ plexMap }),
+		);
+
+		expect(result?.reason).toBe("NOT");
+	});
+
+	it("keeps NOT unknown when a successful media snapshot lacks the exact item", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: { not: { kind: "plex_on_deck", params: { isDeck: true } } },
+				}),
+			}),
+			"RADARR",
+			baseCtx({ plexMap: new Map(), availableDataSources: new Set(["plex"]) }),
+		);
+
+		expect(result).toBeNull();
+	});
+
+	it("uses an explicit successful empty source snapshot as negative evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem(),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: { kind: "seerr_is_requested", params: { isRequested: true } },
+					},
+				}),
+			}),
+			"RADARR",
+			baseCtx({ seerrMap: new Map(), availableDataSources: new Set(["seerr"]) }),
+		);
+
+		expect(result?.reason).toBe("NOT");
+	});
+
+	it("uses a successful episode-only provider snapshot as false evidence", () => {
+		const result = evaluateRuleViaEngine(
+			makeCacheItem({ itemType: "series" }),
+			makeRule({
+				ruleType: "composite",
+				parameters: "{}",
+				operator: null,
+				conditions: JSON.stringify({
+					version: 1,
+					root: {
+						not: {
+							kind: "jellyfin_episode_completion",
+							params: { operator: "less_than", percentage: 50 },
+						},
+					},
+				}),
+			}),
+			"SONARR",
+			baseCtx({
+				availableDataSources: new Set(["jellyfin"]),
+				jellyfinEpisodeMap: new Map([[12345, { total: 10, watched: 10, seasons: new Map() }]]),
+			}),
+		);
+
+		expect(result?.reason).toBe("NOT");
 	});
 });
 
@@ -551,6 +766,34 @@ describe("parity — evaluateItemAgainstRules (two-phase loop)", () => {
 			parameters: JSON.stringify({ operator: "older_than", days: 30 }),
 		});
 		const result = assertLoopParity([plexRule], makeCacheItem(), new Set(["plex"]));
+		expect(result).toBeNull();
+	});
+
+	it("lets unknown canonical retention evidence block a later cleanup match", () => {
+		const canonicalRetention = makeRule({
+			id: "retention-v1",
+			retentionMode: true,
+			ruleType: "composite",
+			parameters: "{}",
+			operator: null,
+			conditions: JSON.stringify({
+				version: 1,
+				root: { kind: "age", params: { operator: "newer_than", days: 30 } },
+			}),
+		});
+		const cleanup = matchingRule({
+			id: "cleanup-no-file",
+			ruleType: "no_file",
+			parameters: "{}",
+		});
+
+		const result = evaluateItemAgainstRulesViaEngine(
+			makeCacheItem({ arrAddedAt: null, hasFile: false }),
+			[canonicalRetention, cleanup],
+			"RADARR",
+			baseCtx(),
+		);
+
 		expect(result).toBeNull();
 	});
 });

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -44,6 +44,7 @@ import type {
 } from "../library-cleanup/types.js";
 import type { LibraryCleanupRule } from "../prisma.js";
 import { safeJsonParse } from "../utils/json.js";
+import { evaluateCleanupPredicate } from "./cleanup-predicate-evidence.js";
 import { evaluateDocument, type PredicateEvaluator, UNKNOWN } from "./engine.js";
 import { mapCriteriaV0ToDocument } from "./v0-mappers.js";
 
@@ -51,19 +52,24 @@ import { mapCriteriaV0ToDocument } from "./v0-mappers.js";
  * Engine-backed equivalent of `evaluateRule` (rule-evaluators.ts).
  * Identical inputs, identical outputs — proven by the parity suite.
  */
-export function evaluateRuleViaEngine(
+type CleanupRuleEvaluation =
+	| { state: "match"; match: RuleMatch }
+	| { state: "no_match" }
+	| { state: "unknown" };
+
+function evaluateCleanupRuleState(
 	item: CacheItemForEval,
 	rule: LibraryCleanupRule,
 	instanceService: string,
 	ctx: EvalContext,
-): RuleMatch | null {
-	if (!rule.enabled) return null;
+): CleanupRuleEvaluation {
+	if (!rule.enabled) return { state: "no_match" };
 
 	// Pre-filters — the legacy functions, not copies.
-	if (!passesServiceFilter(instanceService, rule.serviceFilter)) return null;
-	if (!passesInstanceFilter(item.instanceId, rule.instanceFilter)) return null;
-	if (!passesTagExclusion(item, rule.excludeTags)) return null;
-	if (!passesTitleExclusion(item.title, rule.excludeTitles)) return null;
+	if (!passesServiceFilter(instanceService, rule.serviceFilter)) return { state: "no_match" };
+	if (!passesInstanceFilter(item.instanceId, rule.instanceFilter)) return { state: "no_match" };
+	if (!passesTagExclusion(item, rule.excludeTags)) return { state: "no_match" };
+	if (!passesTitleExclusion(item.title, rule.excludeTitles)) return { state: "no_match" };
 
 	const plexLibFilter = safeJsonParse(rule.plexLibraryFilter) as string[] | null;
 	const action = (rule.action ?? "delete") as RuleAction;
@@ -74,10 +80,10 @@ export function evaluateRuleViaEngine(
 		rule.ruleType === "composite" && rule.operator === null && rule.conditions !== null;
 	if (rule.operator && rule.conditions) {
 		const conditions = safeJsonParse(rule.conditions) as unknown[] | null;
-		if (!conditions?.length) return null;
+		if (!conditions?.length) return { state: "no_match" };
 	} else if (!isStoredV1Document) {
 		const params = safeJsonParse(rule.parameters) as Record<string, unknown> | null;
-		if (!params) return null;
+		if (!params) return { state: "no_match" };
 	}
 
 	let doc: RuleDocument;
@@ -85,10 +91,15 @@ export function evaluateRuleViaEngine(
 		doc = mapCriteriaV0ToDocument(rule);
 	} catch {
 		// Unrepresentable row (see header) — no-match, never a thrown run.
-		return null;
+		return isStoredV1Document ? { state: "unknown" } : { state: "no_match" };
 	}
 
 	const evalPredicate: PredicateEvaluator = (predicate) => {
+		if (isStoredV1Document) {
+			const result = evaluateCleanupPredicate(item, predicate, ctx, instanceService, plexLibFilter);
+			if (result.state === "unknown") return UNKNOWN;
+			return result.state === "match" ? result.reason : null;
+		}
 		const reason = evaluateSingleCondition(
 			item,
 			predicate.kind,
@@ -96,28 +107,36 @@ export function evaluateRuleViaEngine(
 			ctx,
 			plexLibFilter,
 		);
-		// Temporary Wave 3A bridge: the legacy evaluator collapses proven false
-		// and unavailable evidence to null. Recursive cleanup documents treat that
-		// null as unknown so NOT cannot create deletion authority. Task 3 replaces
-		// this bridge with evidence-aware true/false/unknown predicate results.
-		return reason ?? (isStoredV1Document ? UNKNOWN : null);
+		return reason;
 	};
 
 	const result = evaluateDocument(doc, evalPredicate);
-	return result.matched
-		? {
-				ruleId: rule.id,
-				ruleName: rule.name,
-				reason: result.reason,
-				action,
-				...(rule.scanMediaServerAfterDelete
-					? {
-							scanMediaServerAfterDelete: true as const,
-							scanMediaServerInstanceIds: rule.scanMediaServerInstanceIds,
-						}
-					: {}),
-			}
-		: null;
+	if (!result.matched) return result.unknown ? { state: "unknown" } : { state: "no_match" };
+	return {
+		state: "match",
+		match: {
+			ruleId: rule.id,
+			ruleName: rule.name,
+			reason: result.reason,
+			action,
+			...(rule.scanMediaServerAfterDelete
+				? {
+						scanMediaServerAfterDelete: true as const,
+						scanMediaServerInstanceIds: rule.scanMediaServerInstanceIds,
+					}
+				: {}),
+		},
+	};
+}
+
+export function evaluateRuleViaEngine(
+	item: CacheItemForEval,
+	rule: LibraryCleanupRule,
+	instanceService: string,
+	ctx: EvalContext,
+): RuleMatch | null {
+	const result = evaluateCleanupRuleState(item, rule, instanceService, ctx);
+	return result.state === "match" ? result.match : null;
 }
 
 /**
@@ -139,16 +158,16 @@ export function evaluateItemAgainstRulesViaEngine(
 		if (!rule.retentionMode) continue;
 		if (!passesCleanupRuleFilters(item, rule, instanceService)) continue;
 		if (ruleUsesUnavailableData(rule, failedSources)) return null;
-		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
-		if (match) return null;
+		const result = evaluateCleanupRuleState(item, rule, instanceService, ctx);
+		if (result.state !== "no_match") return null;
 	}
 
 	// Phase 2: cleanup rules — first match wins
 	for (const rule of rules) {
 		if (rule.retentionMode) continue;
 		if (ruleUsesUnavailableData(rule, failedSources)) continue;
-		const match = evaluateRuleViaEngine(item, rule, instanceService, ctx);
-		if (match) return match;
+		const result = evaluateCleanupRuleState(item, rule, instanceService, ctx);
+		if (result.state === "match") return result.match;
 	}
 	return null;
 }

--- a/apps/api/src/lib/rules/cleanup-adapter.ts
+++ b/apps/api/src/lib/rules/cleanup-adapter.ts
@@ -44,7 +44,10 @@ import type {
 } from "../library-cleanup/types.js";
 import type { LibraryCleanupRule } from "../prisma.js";
 import { safeJsonParse } from "../utils/json.js";
-import { evaluateCleanupPredicate } from "./cleanup-predicate-evidence.js";
+import {
+	evaluateCleanupPredicate,
+	hasRequiredStalenessInputEvidence,
+} from "./cleanup-predicate-evidence.js";
 import { evaluateDocument, type PredicateEvaluator, UNKNOWN } from "./engine.js";
 import { mapCriteriaV0ToDocument } from "./v0-mappers.js";
 
@@ -344,8 +347,13 @@ function ruleTypeHasMutationEvidence(
 		case "plex_label":
 		case "plex_added_at":
 		case "user_retention":
-		case "staleness_score":
 			return key !== null && ctx.plexMap?.has(key) === true;
+		case "staleness_score":
+			return hasRequiredStalenessInputEvidence(parameters, {
+				plex: key !== null && ctx.plexMap?.has(key) === true,
+				rating: evidenceFlag(data, "rating"),
+				sizeOnDisk: evidenceFlag(data, "sizeOnDisk"),
+			});
 		case "recently_active":
 			return (
 				item.arrAddedAt instanceof Date &&

--- a/apps/api/src/lib/rules/cleanup-predicate-evidence.ts
+++ b/apps/api/src/lib/rules/cleanup-predicate-evidence.ts
@@ -11,11 +11,69 @@ export type CleanupPredicateResult =
 
 type ExternalSource = "seerr" | "plex" | "jellyfin";
 
+const DEFAULT_STALENESS_WEIGHTS = {
+	daysSinceLastWatch: 0.3,
+	inverseWatchCount: 0.2,
+	notOnDeck: 0.1,
+	lowUserRating: 0.15,
+	lowTmdbRating: 0.15,
+	sizeOnDisk: 0.1,
+} as const;
+
+type StalenessEvidence = {
+	plex: boolean;
+	rating: boolean;
+	sizeOnDisk: boolean;
+};
+
+function stalenessWeight(params: Record<string, unknown>, key: string): number | null {
+	const weights = params.weights;
+	const configured =
+		typeof weights === "object" && weights !== null && !Array.isArray(weights)
+			? (weights as Record<string, unknown>)[key]
+			: DEFAULT_STALENESS_WEIGHTS[key as keyof typeof DEFAULT_STALENESS_WEIGHTS];
+	return typeof configured === "number" && Number.isFinite(configured) && configured >= 0
+		? configured
+		: null;
+}
+
+/** Keep preview and mutation authorization aligned on weighted score inputs. */
+export function hasRequiredStalenessInputEvidence(
+	params: Record<string, unknown>,
+	evidence: StalenessEvidence,
+): boolean {
+	const weights = Object.fromEntries(
+		Object.keys(DEFAULT_STALENESS_WEIGHTS).map((key) => [key, stalenessWeight(params, key)]),
+	) as Record<keyof typeof DEFAULT_STALENESS_WEIGHTS, number | null>;
+	if (Object.values(weights).some((weight) => weight === null)) return false;
+
+	const needsPlex =
+		weights.daysSinceLastWatch! > 0 ||
+		weights.inverseWatchCount! > 0 ||
+		weights.notOnDeck! > 0 ||
+		weights.lowUserRating! > 0;
+	return (
+		(!needsPlex || evidence.plex) &&
+		(weights.lowTmdbRating === 0 || evidence.rating) &&
+		(weights.sizeOnDisk === 0 || evidence.sizeOnDisk)
+	);
+}
+
 function dataRecord(item: CacheItemForEval): Record<string, unknown> | null {
 	const parsed = safeJsonParse(item.data);
 	return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
 		? (parsed as Record<string, unknown>)
 		: null;
+}
+
+function evidenceFlag(data: Record<string, unknown> | null, flag: string): boolean {
+	const evidence = data?._arrDashboardEvidence;
+	return (
+		typeof evidence === "object" &&
+		evidence !== null &&
+		!Array.isArray(evidence) &&
+		(evidence as Record<string, unknown>)[flag] === true
+	);
 }
 
 function tmdbId(item: CacheItemForEval): number | null {
@@ -194,12 +252,13 @@ function hasPredicateEvidence(
 		}
 		case "tag_match":
 			return (
-				Array.isArray(data?.tags) &&
-				data.tags.every(
-					(tag) =>
-						(typeof tag === "number" && Number.isSafeInteger(tag) && tag >= 0) ||
-						(typeof tag === "string" && tag.trim().length > 0),
-				)
+				(Array.isArray(data?.tags) &&
+					data.tags.every(
+						(tag) =>
+							(typeof tag === "number" && Number.isSafeInteger(tag) && tag >= 0) ||
+							(typeof tag === "string" && tag.trim().length > 0),
+					)) ||
+				(data?.tags === undefined && evidenceFlag(data, "tags"))
 			);
 		case "video_codec":
 		case "audio_codec":
@@ -231,8 +290,9 @@ function hasPredicateEvidence(
 			const file = fileRecord(data);
 			return (
 				file !== null &&
-				Object.hasOwn(file, "videoDynamicRange") &&
-				(typeof file.videoDynamicRange === "string" || file.videoDynamicRange === null)
+				((Object.hasOwn(file, "videoDynamicRange") &&
+					(typeof file.videoDynamicRange === "string" || file.videoDynamicRange === null)) ||
+					evidenceFlag(data, "hdrType"))
 			);
 		}
 		case "seerr_requested_by":
@@ -284,7 +344,14 @@ function hasPredicateEvidence(
 				hasPlexEvidence(item, ctx, plexLibraryFilter)
 			);
 		case "staleness_score":
-			return data !== null && hasPlexEvidence(item, ctx, plexLibraryFilter);
+			return (
+				data !== null &&
+				hasRequiredStalenessInputEvidence(params, {
+					plex: hasPlexEvidence(item, ctx, plexLibraryFilter),
+					rating: hasRatingEvidence(data, "rating", instanceService),
+					sizeOnDisk: evidenceFlag(data, "sizeOnDisk"),
+				})
+			);
 		case "recently_active": {
 			if (!(item.arrAddedAt instanceof Date) || Number.isNaN(item.arrAddedAt.getTime()))
 				return false;

--- a/apps/api/src/lib/rules/cleanup-predicate-evidence.ts
+++ b/apps/api/src/lib/rules/cleanup-predicate-evidence.ts
@@ -1,0 +1,341 @@
+import type { RulePredicate } from "@arr/shared";
+import { lookupPlexWatch } from "../library-cleanup/evaluators/plex-evaluators.js";
+import { evaluateSingleCondition, parseAudioChannels } from "../library-cleanup/rule-evaluators.js";
+import type { CacheItemForEval, EvalContext } from "../library-cleanup/types.js";
+import { safeJsonParse } from "../utils/json.js";
+
+export type CleanupPredicateResult =
+	| { state: "match"; reason: string }
+	| { state: "no_match" }
+	| { state: "unknown" };
+
+type ExternalSource = "seerr" | "plex" | "jellyfin";
+
+function dataRecord(item: CacheItemForEval): Record<string, unknown> | null {
+	const parsed = safeJsonParse(item.data);
+	return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+		? (parsed as Record<string, unknown>)
+		: null;
+}
+
+function tmdbId(item: CacheItemForEval): number | null {
+	const data = dataRecord(item);
+	if (!data) return null;
+	const remoteIds = data.remoteIds;
+	if (typeof remoteIds === "object" && remoteIds !== null && !Array.isArray(remoteIds)) {
+		const remoteTmdbId = (remoteIds as Record<string, unknown>).tmdbId;
+		if (
+			typeof remoteTmdbId === "number" &&
+			Number.isSafeInteger(remoteTmdbId) &&
+			remoteTmdbId > 0
+		) {
+			return remoteTmdbId;
+		}
+	}
+	return typeof data.tmdbId === "number" && Number.isSafeInteger(data.tmdbId) && data.tmdbId > 0
+		? data.tmdbId
+		: null;
+}
+
+function mediaKey(item: CacheItemForEval): string | null {
+	const id = tmdbId(item);
+	return id === null ? null : `${item.itemType}:${id}`;
+}
+
+function sourceAvailable(ctx: EvalContext, source: ExternalSource): boolean {
+	if (ctx.availableDataSources?.has(source)) return true;
+	if (source === "seerr") return ctx.seerrMap !== undefined && ctx.seerrMap.size > 0;
+	if (source === "plex") return ctx.plexMap !== undefined && ctx.plexMap.size > 0;
+	return ctx.jellyfinMap !== undefined && ctx.jellyfinMap.size > 0;
+}
+
+function fileRecord(data: Record<string, unknown>): Record<string, unknown> | null {
+	const candidate =
+		typeof data.movieFile === "object" && data.movieFile !== null
+			? data.movieFile
+			: typeof data.episodeFile === "object" && data.episodeFile !== null
+				? data.episodeFile
+				: null;
+	return candidate && !Array.isArray(candidate) ? (candidate as Record<string, unknown>) : null;
+}
+
+function isCompleteRatingValue(value: unknown): boolean {
+	return typeof value === "number" && Number.isFinite(value) && value > 0 && value <= 10;
+}
+
+function hasRatingEvidence(
+	data: Record<string, unknown> | null,
+	kind: "rating" | "imdb_rating",
+	instanceService: string,
+): boolean {
+	if (!data || typeof data.ratings !== "object" || data.ratings === null) return false;
+	const ratings = data.ratings as Record<string, unknown>;
+	if (kind === "imdb_rating") {
+		const imdb = ratings.imdb;
+		return (
+			instanceService.toUpperCase() === "RADARR" &&
+			typeof imdb === "object" &&
+			imdb !== null &&
+			isCompleteRatingValue((imdb as Record<string, unknown>).value)
+		);
+	}
+	if (instanceService.toUpperCase() === "SONARR") return isCompleteRatingValue(ratings.value);
+	if (instanceService.toUpperCase() !== "RADARR") return false;
+	const tmdb = ratings.tmdb;
+	return (
+		typeof tmdb === "object" &&
+		tmdb !== null &&
+		isCompleteRatingValue((tmdb as Record<string, unknown>).value)
+	);
+}
+
+function hasLanguageEvidence(data: Record<string, unknown> | null): boolean {
+	if (!data) return false;
+	if (typeof data.originalLanguage === "string" && data.originalLanguage.trim().length > 0) {
+		return true;
+	}
+	if (typeof data.originalLanguage === "object" && data.originalLanguage !== null) {
+		const name = (data.originalLanguage as Record<string, unknown>).name;
+		if (typeof name === "string" && name.trim().length > 0) return true;
+	}
+	return (
+		Array.isArray(data.languages) &&
+		data.languages.length > 0 &&
+		data.languages.every(
+			(language) =>
+				(typeof language === "string" && language.trim().length > 0) ||
+				(typeof language === "object" &&
+					language !== null &&
+					typeof (language as Record<string, unknown>).name === "string" &&
+					((language as Record<string, unknown>).name as string).trim().length > 0),
+		)
+	);
+}
+
+function hasPlexEvidence(
+	item: CacheItemForEval,
+	ctx: EvalContext,
+	plexLibraryFilter?: string[] | null,
+): boolean {
+	if (!sourceAvailable(ctx, "plex") || tmdbId(item) === null) return false;
+	if (!plexLibraryFilter?.length) {
+		const key = mediaKey(item);
+		return key !== null && ctx.plexMap?.has(key) === true;
+	}
+	if (
+		!ctx.plexSectionTitles ||
+		plexLibraryFilter.some((sectionTitle) => !ctx.plexSectionTitles!.has(sectionTitle))
+	) {
+		return false;
+	}
+	return lookupPlexWatch(item, ctx.plexMap, plexLibraryFilter, ctx.plexSectionTitles) !== null;
+}
+
+function hasJellyfinEvidence(item: CacheItemForEval, ctx: EvalContext): boolean {
+	const key = mediaKey(item);
+	return sourceAvailable(ctx, "jellyfin") && key !== null && ctx.jellyfinMap?.has(key) === true;
+}
+
+function hasListEvidence(
+	item: CacheItemForEval,
+	params: Record<string, unknown>,
+	memberships: Map<string, Set<number>> | undefined,
+	identifierKey: "listId" | "listSlug",
+): boolean {
+	const identifier = params[identifierKey];
+	return (
+		tmdbId(item) !== null &&
+		typeof identifier === "string" &&
+		identifier.trim().length > 0 &&
+		memberships?.has(identifier) === true
+	);
+}
+
+function hasPredicateEvidence(
+	item: CacheItemForEval,
+	predicate: RulePredicate,
+	ctx: EvalContext,
+	instanceService: string,
+	plexLibraryFilter?: string[] | null,
+): boolean {
+	const { kind, params } = predicate;
+	const data = dataRecord(item);
+
+	switch (kind) {
+		case "age":
+			return item.arrAddedAt instanceof Date && !Number.isNaN(item.arrAddedAt.getTime());
+		case "size":
+		case "unmonitored":
+		case "no_file":
+			return true;
+		case "status":
+			return typeof item.status === "string" && item.status.trim().length > 0;
+		case "year_range":
+			return typeof item.year === "number" && Number.isFinite(item.year);
+		case "quality_profile":
+			return (
+				typeof item.qualityProfileName === "string" && item.qualityProfileName.trim().length > 0
+			);
+		case "rating":
+		case "imdb_rating":
+			return hasRatingEvidence(data, kind, instanceService);
+		case "genre":
+			return Array.isArray(data?.genres) && data.genres.every((genre) => typeof genre === "string");
+		case "language":
+			return hasLanguageEvidence(data);
+		case "runtime":
+			return typeof data?.runtime === "number" && Number.isFinite(data.runtime);
+		case "file_path": {
+			if (!data) return false;
+			if (params.field === "rootFolderPath") {
+				return typeof data.rootFolderPath === "string" && data.rootFolderPath.trim().length > 0;
+			}
+			return typeof data.path === "string" && data.path.trim().length > 0;
+		}
+		case "tag_match":
+			return (
+				Array.isArray(data?.tags) &&
+				data.tags.every(
+					(tag) =>
+						(typeof tag === "number" && Number.isSafeInteger(tag) && tag >= 0) ||
+						(typeof tag === "string" && tag.trim().length > 0),
+				)
+			);
+		case "video_codec":
+		case "audio_codec":
+		case "resolution":
+		case "custom_format_score":
+		case "release_group": {
+			if (!data) return false;
+			const file = fileRecord(data);
+			const field = {
+				video_codec: "videoCodec",
+				audio_codec: "audioCodec",
+				resolution: "resolution",
+				custom_format_score: "customFormatScore",
+				release_group: "releaseGroup",
+			}[kind];
+			if (!file) return false;
+			const value = file[field];
+			return kind === "custom_format_score"
+				? typeof value === "number" && Number.isFinite(value)
+				: typeof value === "string" && value.trim().length > 0;
+		}
+		case "audio_channels": {
+			if (!data) return false;
+			const codec = fileRecord(data)?.audioCodec;
+			return typeof codec === "string" && parseAudioChannels(codec) !== null;
+		}
+		case "hdr_type": {
+			if (!data) return false;
+			const file = fileRecord(data);
+			return (
+				file !== null &&
+				Object.hasOwn(file, "videoDynamicRange") &&
+				(typeof file.videoDynamicRange === "string" || file.videoDynamicRange === null)
+			);
+		}
+		case "seerr_requested_by":
+		case "seerr_request_age":
+		case "seerr_request_status":
+		case "seerr_is_4k":
+		case "seerr_request_modified_age":
+		case "seerr_modified_by":
+		case "seerr_is_requested":
+		case "seerr_request_count":
+			return sourceAvailable(ctx, "seerr") && tmdbId(item) !== null;
+		case "plex_last_watched":
+		case "plex_watch_count":
+		case "plex_on_deck":
+		case "plex_user_rating":
+		case "plex_watched_by":
+		case "plex_collection":
+		case "plex_label":
+		case "plex_added_at":
+			return hasPlexEvidence(item, ctx, plexLibraryFilter);
+		case "jellyfin_last_watched":
+		case "jellyfin_watch_count":
+		case "jellyfin_on_deck":
+		case "jellyfin_user_rating":
+		case "jellyfin_watched_by":
+		case "jellyfin_added_at":
+			return hasJellyfinEvidence(item, ctx);
+		case "plex_episode_completion": {
+			const id = tmdbId(item);
+			return (
+				item.itemType === "series" &&
+				sourceAvailable(ctx, "plex") &&
+				id !== null &&
+				(ctx.plexEpisodeMap?.get(id)?.total ?? 0) > 0
+			);
+		}
+		case "jellyfin_episode_completion": {
+			const id = tmdbId(item);
+			return (
+				item.itemType === "series" &&
+				sourceAvailable(ctx, "jellyfin") &&
+				id !== null &&
+				(ctx.jellyfinEpisodeMap?.get(id)?.total ?? 0) > 0
+			);
+		}
+		case "user_retention":
+			return (
+				(params.source === undefined || params.source === "plex" || params.source === "either") &&
+				hasPlexEvidence(item, ctx, plexLibraryFilter)
+			);
+		case "staleness_score":
+			return data !== null && hasPlexEvidence(item, ctx, plexLibraryFilter);
+		case "recently_active": {
+			if (!(item.arrAddedAt instanceof Date) || Number.isNaN(item.arrAddedAt.getTime()))
+				return false;
+			const protectionDays = params.protectionDays;
+			if (typeof protectionDays !== "number") return false;
+			const ageDays = (ctx.now.getTime() - item.arrAddedAt.getTime()) / (1000 * 60 * 60 * 24);
+			return ageDays > protectionDays || params.requireActivity !== true
+				? true
+				: hasPlexEvidence(item, ctx, plexLibraryFilter);
+		}
+		case "seerr_requester_watched":
+		case "seerr_requester_not_watched":
+			return (
+				sourceAvailable(ctx, "seerr") &&
+				tmdbId(item) !== null &&
+				hasPlexEvidence(item, ctx, plexLibraryFilter)
+			);
+		case "tmdb_list_member":
+			return hasListEvidence(item, params, ctx.tmdbListMemberships, "listId");
+		case "trakt_list_member":
+			return hasListEvidence(item, params, ctx.traktListMemberships, "listSlug");
+		default:
+			return false;
+	}
+}
+
+/**
+ * Evaluate one cleanup leaf without collapsing missing evidence into a proven
+ * false result. Canonical recursive rules use this tri-state contract so NOT
+ * can never turn an unavailable field or provider snapshot into authority.
+ */
+export function evaluateCleanupPredicate(
+	item: CacheItemForEval,
+	predicate: RulePredicate,
+	ctx: EvalContext,
+	instanceService: string,
+	plexLibraryFilter?: string[] | null,
+): CleanupPredicateResult {
+	if (!hasPredicateEvidence(item, predicate, ctx, instanceService, plexLibraryFilter)) {
+		return { state: "unknown" };
+	}
+	try {
+		const reason = evaluateSingleCondition(
+			item,
+			predicate.kind,
+			predicate.params,
+			ctx,
+			plexLibraryFilter,
+		);
+		return reason === null ? { state: "no_match" } : { state: "match", reason };
+	} catch {
+		return { state: "unknown" };
+	}
+}

--- a/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
@@ -160,7 +160,7 @@ describe("library cleanup rule scope persistence", () => {
 		});
 	});
 
-	it("rejects NOT expressions until false evidence is authoritative", async () => {
+	it("stores NOT expressions once false evidence is evaluated authoritatively", async () => {
 		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
 			body: {
 				name: "Unsafe negation",
@@ -173,10 +173,38 @@ describe("library cleanup rule scope persistence", () => {
 			},
 		});
 
-		expect(response.statusCode).toBe(400);
-		expect(response.json().error).toContain("NOT cleanup expressions are not supported");
-		expect(ruleCreate).not.toHaveBeenCalled();
+		expect(response.statusCode).toBe(201);
+		expect(ruleCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					ruleType: "composite",
+					operator: null,
+				}),
+			}),
+		);
 	});
+
+	it.each(["tmdb_list_member", "trakt_list_member"] as const)(
+		"rejects NOT over %s without an execution-time complete list snapshot",
+		async (kind) => {
+			const identifier = kind === "tmdb_list_member" ? { listId: "123" } : { listSlug: "mine" };
+			const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/rules", {
+				body: {
+					name: "Unsafe list negation",
+					ruleType: "composite",
+					parameters: {},
+					expression: {
+						version: 1,
+						root: { not: { kind, params: { operator: "is_in", ...identifier } } },
+					},
+				},
+			});
+
+			expect(response.statusCode).toBe(400);
+			expect(response.json().error).toContain(`NOT cleanup expressions cannot use "${kind}"`);
+			expect(ruleCreate).not.toHaveBeenCalled();
+		},
+	);
 
 	it("serializes canonical rows separately from legacy composite conditions", async () => {
 		const legacyConditions = [

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -223,8 +223,9 @@ function validateExpressionParameters(expression: RuleDocument): string | null {
 	if (boundsError) return boundsError;
 	const emptyGroupError = getCleanupExpressionEmptyGroupError(expression.root);
 	if (emptyGroupError) return emptyGroupError;
-	if (cleanupExpressionContainsNot(expression.root)) {
-		return "NOT cleanup expressions are not supported until preview and execution can prove false evidence consistently";
+	const unsupportedNegatedKind = getUnsupportedNegatedCleanupKind(expression.root);
+	if (unsupportedNegatedKind) {
+		return `NOT cleanup expressions cannot use "${unsupportedNegatedKind}" until a fresh complete list snapshot is available at execution`;
 	}
 	for (const predicate of walkPredicates(expression.root)) {
 		if (!isKindLegalForContext("library-cleanup", predicate.kind)) {
@@ -239,11 +240,22 @@ function validateExpressionParameters(expression: RuleDocument): string | null {
 	return null;
 }
 
-function cleanupExpressionContainsNot(node: RuleDocument["root"]): boolean {
-	if ("kind" in node) return false;
-	if ("not" in node) return true;
+function getUnsupportedNegatedCleanupKind(
+	node: RuleDocument["root"],
+	insideNot = false,
+): "tmdb_list_member" | "trakt_list_member" | null {
+	if ("kind" in node) {
+		return insideNot && (node.kind === "tmdb_list_member" || node.kind === "trakt_list_member")
+			? node.kind
+			: null;
+	}
+	if ("not" in node) return getUnsupportedNegatedCleanupKind(node.not, true);
 	const children = "all" in node ? node.all : node.any;
-	return children.some(cleanupExpressionContainsNot);
+	for (const child of children) {
+		const unsupportedKind = getUnsupportedNegatedCleanupKind(child, insideNot);
+		if (unsupportedKind) return unsupportedKind;
+	}
+	return null;
 }
 
 function assertStoredCleanupRulesSerializable(rules: readonly Record<string, unknown>[]): void {


### PR DESCRIPTION
## Summary

- distinguish cleanup predicate truth from unavailable evidence for canonical recursive rules
- allow NOT only when the underlying false result is supported by complete local or provider evidence
- preserve fail-closed retention behavior when canonical evidence is unknown
- track successful empty provider snapshots and episode-only Jellyfin evidence
- keep negated TMDb and Trakt membership blocked until execution-time list completeness exists

## Safety

Missing, malformed, blank, zero-sentinel, wrong-service, or partial predicate data remains unknown and cannot be inverted into deletion authority. Plex and Jellyfin predicates require the exact media row. Final mutation policy still revalidates fresh ARR and provider evidence.

## Scope

This is the backend truth-semantics wave. Recursive visual authoring remains a separate follow-up so this PR stays focused on execution safety.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test (API 4,172; web 836; shared 154)
- pnpm run lint
- pnpm run build
- independent data-safety and regression review with one correction pass