### PR TITLE
feat(cleanup): add recursive rule authoring

### DIFF
--- a/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
@@ -1,6 +1,6 @@
 import type { CleanupRuleResponse, CreateCleanupRule } from "@arr/shared";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { IncognitoProvider } from "../../../../contexts/IncognitoContext";
@@ -312,6 +312,77 @@ describe("CleanupRuleDialog", () => {
 			renderDialog();
 			expect(screen.queryByText(/Template applied/)).not.toBeInTheDocument();
 		});
+
+		it("authors a bounded nested expression without using legacy composite fields", async () => {
+			const onSave = vi.fn();
+			renderDialog({ onSave });
+
+			fireEvent.change(screen.getByPlaceholderText("e.g., Old low-rated movies"), {
+				target: { value: "Nested cleanup" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+
+			expect(screen.getByLabelText("ALL group")).toBeInTheDocument();
+			expect(screen.getByText("Age")).toBeInTheDocument();
+			fireEvent.change(screen.getByRole("spinbutton", { name: "Days" }), {
+				target: { value: "45" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Add NOT to ALL group" }));
+			const notGroup = screen.getByLabelText("NOT group");
+			expect(notGroup).toBeInTheDocument();
+			expect(within(notGroup).getAllByRole("button", { name: "Remove node" })).toHaveLength(1);
+
+			fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			const payload = onSave.mock.calls[0]![0] as CreateCleanupRule;
+			expect(payload.ruleType).toBe("composite");
+			expect(payload.operator).toBeNull();
+			expect(payload.conditions).toBeNull();
+			expect(payload.expression).toEqual({
+				version: 1,
+				root: {
+					all: [
+						{ kind: "age", params: { operator: "older_than", days: 45 } },
+						{ not: { kind: "age", params: { operator: "older_than", days: 30 } } },
+					],
+				},
+			});
+		});
+
+		it("blocks an empty nested group before calling the API", async () => {
+			const onSave = vi.fn();
+			renderDialog({ onSave });
+			fireEvent.change(screen.getByPlaceholderText("e.g., Old low-rated movies"), {
+				target: { value: "Invalid nested cleanup" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+			fireEvent.click(screen.getByRole("button", { name: "Remove node" }));
+
+			fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
+
+			expect(await screen.findByText(/add at least one condition/i)).toBeInTheDocument();
+			expect(onSave).not.toHaveBeenCalled();
+		});
+
+		it("blocks negated list membership until complete negative evidence exists", async () => {
+			const onSave = vi.fn();
+			renderDialog({ onSave });
+			fireEvent.change(screen.getByPlaceholderText("e.g., Old low-rated movies"), {
+				target: { value: "Unsafe negative list" },
+			});
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+			fireEvent.click(screen.getByRole("button", { name: "Add NOT to ALL group" }));
+			const conditionTypes = screen.getAllByRole("combobox", { name: "Condition type" });
+			fireEvent.change(conditionTypes[1]!, { target: { value: "tmdb_list_member" } });
+
+			fireEvent.click(screen.getByRole("button", { name: "Add Rule" }));
+
+			expect(
+				await screen.findByText(/list membership conditions cannot be used inside NOT/i),
+			).toBeInTheDocument();
+			expect(onSave).not.toHaveBeenCalled();
+		});
 	});
 
 	// ================================================================
@@ -319,30 +390,55 @@ describe("CleanupRuleDialog", () => {
 	// ================================================================
 
 	describe("edit mode", () => {
-		it("keeps recursive expressions read-only instead of flattening them", () => {
+		it("keeps rule-mode conversion available for existing flat rules", () => {
+			renderDialog({ editRule: makeEditRule() });
+
+			expect(screen.getByRole("button", { name: "Single Condition" })).not.toBeDisabled();
+			expect(screen.getByRole("button", { name: "Composite Rule" })).not.toBeDisabled();
+			expect(screen.getByRole("button", { name: "Nested Rule" })).not.toBeDisabled();
+
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+			expect(screen.getByLabelText("ALL group")).toBeInTheDocument();
+		});
+
+		it("round-trips recursive expressions through the visual editor", async () => {
 			const onSave = vi.fn();
+			const expression = {
+				version: 1 as const,
+				root: {
+					all: [
+						{ kind: "age", params: { operator: "older_than", days: 30 } },
+						{
+							any: [{ kind: "year_range", params: { operator: "before", year: 2000 } }],
+						},
+					],
+				},
+			};
 			renderDialog({
 				onSave,
 				editRule: makeEditRule({
 					ruleType: "composite",
 					parameters: {},
-					expression: {
-						version: 1,
-						root: {
-							all: [
-								{ kind: "age", params: { operator: "older_than", days: 30 } },
-								{
-									any: [{ kind: "year_range", params: { operator: "before", year: 2000 } }],
-								},
-							],
-						},
-					},
+					expression,
 				}),
 			});
 
-			expect(screen.getByText(/recursive rule is read-only/i)).toBeInTheDocument();
-			expect(screen.queryByRole("button", { name: /save changes/i })).not.toBeInTheDocument();
-			expect(onSave).not.toHaveBeenCalled();
+			expect(screen.queryByText(/recursive rule is read-only/i)).not.toBeInTheDocument();
+			expect(screen.getByLabelText("ALL group")).toBeInTheDocument();
+			expect(screen.getByLabelText("ANY group")).toBeInTheDocument();
+			expect(screen.getByRole("button", { name: "Single Condition" })).toBeDisabled();
+			expect(screen.getByRole("button", { name: "Composite Rule" })).toBeDisabled();
+			expect(screen.getByRole("button", { name: "Nested Rule" })).toBeDisabled();
+
+			fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			expect(onSave.mock.calls[0]![0]).toMatchObject({
+				ruleType: "composite",
+				operator: null,
+				conditions: null,
+				expression,
+			});
 		});
 
 		it("renders the dialog title for edit mode", () => {

--- a/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/cleanup-rule-dialog.test.tsx
@@ -343,7 +343,10 @@ describe("CleanupRuleDialog", () => {
 				version: 1,
 				root: {
 					all: [
-						{ kind: "age", params: { operator: "older_than", days: 45 } },
+						{
+							kind: "age",
+							params: { field: "arrAddedAt", operator: "older_than", days: 45 },
+						},
 						{ not: { kind: "age", params: { operator: "older_than", days: 30 } } },
 					],
 				},
@@ -390,15 +393,88 @@ describe("CleanupRuleDialog", () => {
 	// ================================================================
 
 	describe("edit mode", () => {
-		it("keeps rule-mode conversion available for existing flat rules", () => {
-			renderDialog({ editRule: makeEditRule() });
+		it("preserves explicitly edited flat criteria when converting to nested mode", async () => {
+			const onSave = vi.fn();
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({
+					ruleType: "size",
+					parameters: { operator: "greater_than", sizeGb: 100 },
+				}),
+			});
 
 			expect(screen.getByRole("button", { name: "Single Condition" })).not.toBeDisabled();
 			expect(screen.getByRole("button", { name: "Composite Rule" })).not.toBeDisabled();
 			expect(screen.getByRole("button", { name: "Nested Rule" })).not.toBeDisabled();
 
+			fireEvent.change(screen.getByRole("spinbutton", { name: "Size (GB)" }), {
+				target: { value: "120" },
+			});
 			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
-			expect(screen.getByLabelText("ALL group")).toBeInTheDocument();
+			expect(screen.getByRole("combobox", { name: "Condition type" })).toHaveValue("size");
+			fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			expect(onSave.mock.calls[0]![0]).toMatchObject({
+				ruleType: "composite",
+				expression: {
+					version: 1,
+					root: { kind: "size", params: { operator: "greater_than", sizeGb: 120 } },
+				},
+			});
+		});
+
+		it("preserves untouched normalization-sensitive parameters byte-for-byte", async () => {
+			const onSave = vi.fn();
+			const parameters = { profileNames: [" HD-1080p "] };
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({ ruleType: "quality_profile", parameters }),
+			});
+
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+			fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			expect(onSave.mock.calls[0]![0]).toMatchObject({
+				expression: {
+					version: 1,
+					root: { kind: "quality_profile", params: parameters },
+				},
+			});
+		});
+
+		it("preserves an existing legacy composite when converting it to nested mode", async () => {
+			const onSave = vi.fn();
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({
+					ruleType: "composite",
+					parameters: {},
+					operator: "OR",
+					conditions: [
+						{ ruleType: "age", parameters: { operator: "older_than", days: 365 } },
+						{ ruleType: "size", parameters: { operator: "greater_than", sizeGb: 100 } },
+					],
+				}),
+			});
+
+			fireEvent.click(screen.getByRole("button", { name: "Nested Rule" }));
+			expect(screen.getByLabelText("ANY group")).toBeInTheDocument();
+			fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			expect(onSave.mock.calls[0]![0]).toMatchObject({
+				expression: {
+					version: 1,
+					root: {
+						any: [
+							{ kind: "age", params: { operator: "older_than", days: 365 } },
+							{ kind: "size", params: { operator: "greater_than", sizeGb: 100 } },
+						],
+					},
+				},
+			});
 		});
 
 		it("round-trips recursive expressions through the visual editor", async () => {
@@ -438,6 +514,38 @@ describe("CleanupRuleDialog", () => {
 				operator: null,
 				conditions: null,
 				expression,
+			});
+		});
+
+		it("wraps a recursive root predicate so more conditions can be added", async () => {
+			const onSave = vi.fn();
+			renderDialog({
+				onSave,
+				editRule: makeEditRule({
+					ruleType: "composite",
+					parameters: {},
+					expression: {
+						version: 1,
+						root: { kind: "age", params: { operator: "older_than", days: 90 } },
+					},
+				}),
+			});
+
+			fireEvent.click(screen.getByRole("button", { name: "Wrap root in ALL group" }));
+			fireEvent.click(screen.getByRole("button", { name: "Add condition to ALL group" }));
+			fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+			await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+			expect(onSave.mock.calls[0]![0]).toMatchObject({
+				expression: {
+					version: 1,
+					root: {
+						all: [
+							{ kind: "age", params: { operator: "older_than", days: 90 } },
+							{ kind: "age", params: { operator: "older_than", days: 30 } },
+						],
+					},
+				},
 			});
 		});
 

--- a/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
+++ b/apps/web/src/features/library-cleanup/components/__tests__/library-cleanup-client.test.tsx
@@ -532,6 +532,36 @@ describe("LibraryCleanupClient", () => {
 	});
 
 	describe("rule list indicators", () => {
+		it("labels recursive rules by their authored predicate count", () => {
+			setupDefaultMocks({
+				rules: [
+					{
+						...makeConfig().rules[0]!,
+						ruleType: "composite",
+						parameters: {},
+						expression: {
+							version: 1,
+							root: {
+								all: [
+									{ kind: "age", params: { operator: "older_than", days: 30 } },
+									{
+										not: {
+											kind: "rating",
+											params: { source: "tmdb", operator: "less_than", score: 5 },
+										},
+									},
+								],
+							},
+						},
+					},
+				] as CleanupConfigResponse["rules"],
+			});
+
+			render(<LibraryCleanupClient />, { wrapper: createWrapper() });
+
+			expect(screen.getByText("Nested (2 conditions)")).toBeInTheDocument();
+		});
+
 		it("shows a Media scan badge for rules that rescan selected media servers", () => {
 			setupDefaultMocks({
 				rules: [

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -183,6 +183,7 @@ export function CleanupRuleDialog({
 	>([]);
 	const [recursiveExpression, setRecursiveExpression] = useState<RuleDocument | null>(null);
 	const [recursiveError, setRecursiveError] = useState<string | null>(null);
+	const [flatParametersDirty, setFlatParametersDirty] = useState(false);
 
 	// ── New rule params (Phase C) ───────────────────────────────────
 	const [imdbRatingOp, setImdbRatingOp] = useState("less_than");
@@ -240,6 +241,7 @@ export function CleanupRuleDialog({
 	useEffect(() => {
 		if (!open) return;
 		if (editRule) {
+			setFlatParametersDirty(false);
 			const editAction = (editRule.action as "delete" | "unmonitor" | "delete_files") ?? "delete";
 			const editRetentionMode = editRule.retentionMode ?? false;
 			const canHydrateMediaScan = canScanAfterAction(editAction, editRetentionMode);
@@ -494,6 +496,7 @@ export function CleanupRuleDialog({
 			setExcludeTitles(editRule.excludeTitles ? editRule.excludeTitles.join(", ") : "");
 		} else {
 			// Reset to defaults for create mode
+			setFlatParametersDirty(false);
 			setName("");
 			setTargetScope("series");
 			setRuleType("age");
@@ -748,6 +751,31 @@ export function CleanupRuleDialog({
 		behaviorParams,
 	};
 	const buildParams = () => buildParamsPure(buildParamsState);
+	const buildRecursiveSeed = (): RuleDocument => {
+		if (isComposite) {
+			const children = conditions
+				.filter((condition) => condition.ruleType !== "composite")
+				.map((condition) => ({ kind: condition.ruleType, params: condition.params }));
+			return {
+				version: 1,
+				root: compositeOperator === "AND" ? { all: children } : { any: children },
+			};
+		}
+		const kind = ruleType === "composite" ? "age" : ruleType;
+		const predicate = {
+			kind,
+			params:
+				ruleType === "composite"
+					? getDefaultConditionParams("age")
+					: isEdit && editRule && !flatParametersDirty
+						? editRule.parameters
+						: buildParams(),
+		};
+		return {
+			version: 1,
+			root: isEdit ? predicate : { all: [predicate] },
+		};
+	};
 	const effectiveRuleType: CleanupRuleType =
 		targetScope === "episode" ? "plex_watch_count" : ruleType;
 	const visibleArrInstances =
@@ -1258,23 +1286,10 @@ export function CleanupRuleDialog({
 										type="button"
 										disabled={isRecursiveEdit}
 										onClick={() => {
+											setRecursiveExpression((current) => current ?? buildRecursiveSeed());
 											setIsComposite(false);
 											setConditions([]);
 											setCompositeError(null);
-											setRecursiveExpression(
-												(current) =>
-													current ?? {
-														version: 1,
-														root: {
-															all: [
-																{
-																	kind: "age",
-																	params: getDefaultConditionParams("age"),
-																},
-															],
-														},
-													},
-											);
 											setRecursiveError(null);
 										}}
 										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60"
@@ -1547,6 +1562,7 @@ export function CleanupRuleDialog({
 								<span className="text-sm font-medium">Parameters</span>
 							</div>
 							<ParamsFields
+								onParametersChange={() => setFlatParametersDirty(true)}
 								model={{
 									ruleType: effectiveRuleType,
 									targetScope,

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-dialog.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { CleanupRuleResponse, CleanupRuleType, CreateCleanupRule } from "@arr/shared";
+import type {
+	CleanupRuleResponse,
+	CleanupRuleType,
+	CreateCleanupRule,
+	RuleDocument,
+} from "@arr/shared";
 import { ChevronDown, Loader2, Save, ShieldOff, SlidersHorizontal, Target } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import {
@@ -28,7 +33,12 @@ import {
 	buildParams as buildParamsPure,
 	splitCsv,
 } from "../lib/rule-dialog-logic";
+import {
+	stripCleanupRuleAnnotations,
+	validateCleanupRuleDocument,
+} from "../lib/recursive-rule-editor";
 import { ExcludeTagsPicker, ParamsFields } from "./cleanup-rule-params-fields";
+import { RecursiveCleanupRuleEditor } from "./recursive-cleanup-rule-editor";
 import { RULE_CATEGORIES, RULE_TYPE_MAP, RULE_TYPES } from "./rule-type-catalog";
 
 // ============================================================================
@@ -72,7 +82,7 @@ export function CleanupRuleDialog({
 	const { gradient } = useThemeGradient();
 	const [incognitoMode] = useIncognitoMode();
 	const isEdit = !!editRule;
-	const isRecursiveReadOnly = Boolean(editRule?.expression);
+	const isRecursiveEdit = Boolean(editRule?.expression);
 	const { data: fieldOptions, isLoading: fieldOptionsLoading } = useCleanupFieldOptions();
 	const { data: allServices } = useServicesQuery();
 	const mediaServerInstances = fieldOptions?.mediaServerInstances ?? [];
@@ -171,6 +181,8 @@ export function CleanupRuleDialog({
 	const [conditions, setConditions] = useState<
 		Array<{ id: string; ruleType: CleanupRuleType; params: Record<string, unknown> }>
 	>([]);
+	const [recursiveExpression, setRecursiveExpression] = useState<RuleDocument | null>(null);
+	const [recursiveError, setRecursiveError] = useState<string | null>(null);
 
 	// ── New rule params (Phase C) ───────────────────────────────────
 	const [imdbRatingOp, setImdbRatingOp] = useState("less_than");
@@ -251,8 +263,16 @@ export function CleanupRuleDialog({
 			if (editRule.rejectionMemoryDays && editRule.rejectionMemoryDays > 0) {
 				setRejectionDays(String(editRule.rejectionMemoryDays));
 			}
-			// Composite mode
-			if (editRule.operator && editRule.conditions) {
+			// Flat composite and recursive modes are mutually exclusive on the wire.
+			if (editRule.expression) {
+				setRecursiveExpression(editRule.expression);
+				setRecursiveError(null);
+				setIsComposite(false);
+				setCompositeOperator("AND");
+				setConditions([]);
+			} else if (editRule.operator && editRule.conditions) {
+				setRecursiveExpression(null);
+				setRecursiveError(null);
 				setIsComposite(true);
 				setCompositeOperator(editRule.operator as "AND" | "OR");
 				setConditions(
@@ -264,6 +284,8 @@ export function CleanupRuleDialog({
 					).map((c, i) => ({ id: `cond-${i}`, ruleType: c.ruleType, params: c.parameters ?? {} })),
 				);
 			} else {
+				setRecursiveExpression(null);
+				setRecursiveError(null);
 				setIsComposite(false);
 				setCompositeOperator("AND");
 				setConditions([]);
@@ -548,6 +570,8 @@ export function CleanupRuleDialog({
 			setIsComposite(false);
 			setCompositeOperator("AND");
 			setConditions([]);
+			setRecursiveExpression(null);
+			setRecursiveError(null);
 			// Phase C
 			setImdbRatingOp("less_than");
 			setImdbRatingScore(5);
@@ -599,7 +623,12 @@ export function CleanupRuleDialog({
 				if (templateData.serviceFilter) {
 					setServiceFilter(templateData.serviceFilter);
 				}
-				if (templateData.operator && templateData.conditions) {
+				if (templateData.expression) {
+					setRecursiveExpression(templateData.expression);
+					setRecursiveError(null);
+					setIsComposite(false);
+					setRuleType("composite");
+				} else if (templateData.operator && templateData.conditions) {
 					// Composite template
 					setIsComposite(true);
 					setCompositeOperator(templateData.operator as "AND" | "OR");
@@ -742,6 +771,8 @@ export function CleanupRuleDialog({
 			setIsComposite(false);
 			setConditions([]);
 			setCompositeError(null);
+			setRecursiveExpression(null);
+			setRecursiveError(null);
 			setRetentionMode(false);
 			setExpandedCategories(new Set(["plex"]));
 		}
@@ -767,8 +798,17 @@ export function CleanupRuleDialog({
 
 	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
-		if (isRecursiveReadOnly) return;
 		const isEpisodeScope = targetScope === "episode";
+		let recursiveDocument: RuleDocument | null = null;
+		if (!isEpisodeScope && recursiveExpression) {
+			recursiveDocument = stripCleanupRuleAnnotations(recursiveExpression);
+			const validationError = validateCleanupRuleDocument(recursiveDocument);
+			if (validationError) {
+				setRecursiveError(validationError);
+				return;
+			}
+		}
+		setRecursiveError(null);
 		const shouldScanMediaServers = canScanMediaServers && scanMediaServerAfterDelete;
 		if (shouldScanMediaServers && scanMediaServerInstanceIds.length === 0) {
 			setMediaScanError("Select at least one media server to scan after deletion.");
@@ -818,14 +858,14 @@ export function CleanupRuleDialog({
 			targetScope,
 			ruleType: isEpisodeScope
 				? ("plex_watch_count" as const)
-				: isComposite
+				: recursiveDocument || isComposite
 					? ("composite" as const)
 					: ruleType,
 			enabled,
 			priority: editRule?.priority ?? 0,
 			parameters: isEpisodeScope
 				? { operator: "greater_than", count: plexWatchCountVal }
-				: isComposite
+				: recursiveDocument || isComposite
 					? {}
 					: buildParams(),
 			action,
@@ -846,9 +886,9 @@ export function CleanupRuleDialog({
 			excludeTitles: excludeTitles.trim() ? splitCsv(excludeTitles) : null,
 			plexLibraryFilter:
 				!isEpisodeScope && selectedPlexLibraries.length > 0 ? selectedPlexLibraries : null,
-			operator: !isEpisodeScope && isComposite ? compositeOperator : null,
+			operator: !isEpisodeScope && isComposite && !recursiveDocument ? compositeOperator : null,
 			conditions:
-				!isEpisodeScope && isComposite
+				!isEpisodeScope && isComposite && !recursiveDocument
 					? conditions
 							.filter((c) => c.ruleType !== "composite")
 							.map((c) => ({
@@ -856,6 +896,7 @@ export function CleanupRuleDialog({
 								parameters: c.params,
 							}))
 					: null,
+			expression: recursiveDocument,
 		};
 		onSave(base);
 	};
@@ -900,27 +941,7 @@ export function CleanupRuleDialog({
 					</div>
 				)}
 
-				{isRecursiveReadOnly && (
-					<div className="mt-2 space-y-4 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4">
-						<p className="text-sm font-medium text-foreground">Recursive rule is read-only</p>
-						<p className="text-sm text-muted-foreground">
-							This editor cannot safely represent nested cleanup conditions yet. The stored rule has
-							not been changed; close this dialog to keep it intact.
-						</p>
-						<div className="flex justify-end">
-							<button
-								type="button"
-								onClick={() => onOpenChange(false)}
-								className="rounded-lg px-4 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
-							>
-								Close
-							</button>
-						</div>
-					</div>
-				)}
-
 				<form
-					hidden={isRecursiveReadOnly}
 					onSubmit={handleSubmit}
 					className="space-y-5 mt-2"
 					onFocus={(e) => {
@@ -1191,14 +1212,17 @@ export function CleanupRuleDialog({
 								<div className="flex gap-2 mt-1.5">
 									<button
 										type="button"
+										disabled={isRecursiveEdit}
 										onClick={() => {
+											setRecursiveExpression(null);
+											setRecursiveError(null);
 											setIsComposite(false);
 											setConditions([]);
 											setCompositeError(null);
 										}}
-										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60"
 										style={
-											!isComposite
+											!isComposite && !recursiveExpression
 												? {
 														borderColor: gradient.from,
 														backgroundColor: gradient.fromLight,
@@ -1211,10 +1235,15 @@ export function CleanupRuleDialog({
 									</button>
 									<button
 										type="button"
-										onClick={() => setIsComposite(true)}
-										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200"
+										disabled={isRecursiveEdit}
+										onClick={() => {
+											setRecursiveExpression(null);
+											setRecursiveError(null);
+											setIsComposite(true);
+										}}
+										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60"
 										style={
-											isComposite
+											isComposite && !recursiveExpression
 												? {
 														borderColor: gradient.from,
 														backgroundColor: gradient.fromLight,
@@ -1224,6 +1253,42 @@ export function CleanupRuleDialog({
 										}
 									>
 										Composite Rule
+									</button>
+									<button
+										type="button"
+										disabled={isRecursiveEdit}
+										onClick={() => {
+											setIsComposite(false);
+											setConditions([]);
+											setCompositeError(null);
+											setRecursiveExpression(
+												(current) =>
+													current ?? {
+														version: 1,
+														root: {
+															all: [
+																{
+																	kind: "age",
+																	params: getDefaultConditionParams("age"),
+																},
+															],
+														},
+													},
+											);
+											setRecursiveError(null);
+										}}
+										className="rounded-lg border px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-60"
+										style={
+											recursiveExpression
+												? {
+														borderColor: gradient.from,
+														backgroundColor: gradient.fromLight,
+														color: gradient.from,
+													}
+												: { borderColor: "var(--color-border)" }
+										}
+									>
+										Nested Rule
 									</button>
 								</div>
 							</div>
@@ -1247,6 +1312,19 @@ export function CleanupRuleDialog({
 									Only Plex Watch Count is supported for episode targets.
 								</span>
 							</div>
+						) : recursiveExpression ? (
+							<RecursiveCleanupRuleEditor
+								document={recursiveExpression}
+								onChange={(document) => {
+									setRecursiveExpression(document);
+									setRecursiveError(null);
+								}}
+								fieldOptions={fieldOptions}
+								fieldOptionsLoading={fieldOptionsLoading}
+								inputClass={inputClass}
+								labelClass={labelClass}
+								error={recursiveError}
+							/>
 						) : isComposite ? (
 							<div className="space-y-4">
 								<div>
@@ -1462,7 +1540,7 @@ export function CleanupRuleDialog({
 					</div>
 
 					{/* ── Parameters Section ───────────────────────── */}
-					{(targetScope === "episode" || !isComposite) && (
+					{(targetScope === "episode" || (!isComposite && !recursiveExpression)) && (
 						<div className="rounded-xl border border-border/50 bg-card/30 backdrop-blur-sm p-4 space-y-3">
 							<div className="flex items-center gap-2 mb-2">
 								<SlidersHorizontal className="h-4 w-4" style={{ color: gradient.from }} />

--- a/apps/web/src/features/library-cleanup/components/cleanup-rule-params-fields.tsx
+++ b/apps/web/src/features/library-cleanup/components/cleanup-rule-params-fields.tsx
@@ -236,10 +236,31 @@ export interface ParamsFieldsModel {
 	presentation: PresentationFields;
 }
 
-export function ParamsFields({ model }: { model: ParamsFieldsModel }) {
+function trackParameterSetters(
+	props: ParamsFieldsProps,
+	onParametersChange: () => void,
+): ParamsFieldsProps {
+	const tracked = { ...props } as Record<string, unknown>;
+	for (const [key, value] of Object.entries(props)) {
+		if (!key.startsWith("set") || typeof value !== "function") continue;
+		tracked[key] = (...args: unknown[]) => {
+			onParametersChange();
+			return (value as (...input: unknown[]) => unknown)(...args);
+		};
+	}
+	return tracked as unknown as ParamsFieldsProps;
+}
+
+export function ParamsFields({
+	model,
+	onParametersChange,
+}: {
+	model: ParamsFieldsModel;
+	onParametersChange?: () => void;
+}) {
 	const [incognitoMode] = useIncognitoMode();
 	const { targetScope } = model;
-	const props: ParamsFieldsProps = {
+	const rawProps: ParamsFieldsProps = {
 		ruleType: model.ruleType,
 		...model.criteria,
 		...model.seerr,
@@ -249,6 +270,7 @@ export function ParamsFields({ model }: { model: ParamsFieldsModel }) {
 		...model.behavior,
 		...model.presentation,
 	};
+	const props = onParametersChange ? trackParameterSetters(rawProps, onParametersChange) : rawProps;
 	const {
 		ruleType,
 		days,

--- a/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
+++ b/apps/web/src/features/library-cleanup/components/library-cleanup-client.tsx
@@ -9,6 +9,7 @@ import type {
 	CleanupRuleResponse,
 	CreateCleanupRule,
 } from "@arr/shared";
+import { walkPredicates } from "@arr/shared";
 import {
 	AlertTriangle,
 	BarChart3,
@@ -893,9 +894,11 @@ function ConfigTab({
 									<div className="flex-1 min-w-0">
 										<span className="font-medium text-sm">{rule.name}</span>
 										<span className="text-xs text-muted-foreground ml-2">
-											{rule.operator
-												? `${rule.operator} (${(rule.conditions as unknown[])?.length ?? 0} conditions)`
-												: rule.ruleType}
+											{rule.expression
+												? `Nested (${[...walkPredicates(rule.expression.root)].length} conditions)`
+												: rule.operator
+													? `${rule.operator} (${(rule.conditions as unknown[])?.length ?? 0} conditions)`
+													: rule.ruleType}
 										</span>
 										{rule.serviceFilter && rule.serviceFilter.length > 0 && (
 											<span className="text-xs text-muted-foreground ml-2">

--- a/apps/web/src/features/library-cleanup/components/recursive-cleanup-rule-editor.tsx
+++ b/apps/web/src/features/library-cleanup/components/recursive-cleanup-rule-editor.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import {
+	type CleanupFieldOptionsResponse,
+	type CleanupRuleType,
+	isRuleNot,
+	isRulePredicate,
+	type RuleDocument,
+	type RuleNode,
+} from "@arr/shared";
+import { Braces, CirclePlus, GitBranch, Trash2, Undo2 } from "lucide-react";
+import {
+	ConditionParamsFields,
+	getDefaultConditionParams,
+} from "../../rule-criteria/components/condition-params-fields";
+import {
+	appendRuleChild,
+	removeRuleNode,
+	type RuleNodePath,
+	updateRuleNode,
+} from "../lib/recursive-rule-editor";
+import { RULE_TYPE_MAP, RULE_TYPES } from "./rule-type-catalog";
+
+interface RecursiveCleanupRuleEditorProps {
+	document: RuleDocument;
+	onChange: (document: RuleDocument) => void;
+	fieldOptions: CleanupFieldOptionsResponse | undefined;
+	fieldOptionsLoading: boolean;
+	inputClass: string;
+	labelClass: string;
+	error: string | null;
+}
+
+function defaultPredicate(): RuleNode {
+	return { kind: "age", params: getDefaultConditionParams("age") };
+}
+
+export function RecursiveCleanupRuleEditor({
+	document,
+	onChange,
+	fieldOptions,
+	fieldOptionsLoading,
+	inputClass,
+	labelClass,
+	error,
+}: RecursiveCleanupRuleEditorProps) {
+	const changeRoot = (root: RuleNode) => onChange({ version: 1, root });
+
+	const replaceAt = (path: RuleNodePath, replacement: RuleNode) => {
+		changeRoot(updateRuleNode(document.root, path, () => replacement));
+	};
+
+	const removeAt = (path: RuleNodePath) => {
+		const next = removeRuleNode(document.root, path);
+		if (next) changeRoot(next);
+	};
+
+	const addTo = (path: RuleNodePath, child: RuleNode) => {
+		changeRoot(appendRuleChild(document.root, path, child));
+	};
+
+	return (
+		<div className="space-y-3">
+			<div className="rounded-lg border border-border/40 bg-card/20 p-3">
+				<p className="text-sm font-medium text-foreground">Nested condition tree</p>
+				<p className="mt-1 text-xs text-muted-foreground">
+					Combine conditions with ALL, ANY, and NOT. The same tree is used for preview and
+					execution.
+				</p>
+			</div>
+			<RuleNodeEditor
+				node={document.root}
+				path={[]}
+				isRoot
+				onReplace={replaceAt}
+				onRemove={removeAt}
+				onAdd={addTo}
+				fieldOptions={fieldOptions}
+				fieldOptionsLoading={fieldOptionsLoading}
+				inputClass={inputClass}
+				labelClass={labelClass}
+			/>
+			{error && (
+				<div className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+					{error}
+				</div>
+			)}
+		</div>
+	);
+}
+
+interface RuleNodeEditorProps {
+	node: RuleNode;
+	path: RuleNodePath;
+	isRoot?: boolean;
+	canRemove?: boolean;
+	onReplace: (path: RuleNodePath, node: RuleNode) => void;
+	onRemove: (path: RuleNodePath) => void;
+	onAdd: (path: RuleNodePath, node: RuleNode) => void;
+	fieldOptions: CleanupFieldOptionsResponse | undefined;
+	fieldOptionsLoading: boolean;
+	inputClass: string;
+	labelClass: string;
+}
+
+function RuleNodeEditor(props: RuleNodeEditorProps) {
+	const { node, path, isRoot = false, canRemove = true, onReplace, onRemove } = props;
+
+	if (isRulePredicate(node)) {
+		const knownKind = RULE_TYPE_MAP.has(node.kind as CleanupRuleType);
+		return (
+			<div className="space-y-2 rounded-lg border border-border/40 bg-background/40 p-3">
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+						Condition
+					</span>
+					<NodeActions {...props} isRoot={isRoot} />
+				</div>
+				<select
+					aria-label="Condition type"
+					value={node.kind}
+					onChange={(event) => {
+						const kind = event.target.value as CleanupRuleType;
+						onReplace(path, { kind, params: getDefaultConditionParams(kind) });
+					}}
+					className={props.inputClass}
+				>
+					{!knownKind && <option value={node.kind}>Unavailable: {node.kind}</option>}
+					{RULE_TYPES.filter((item) => item.value !== "composite").map((item) => (
+						<option key={item.value} value={item.value}>
+							{item.label}
+						</option>
+					))}
+				</select>
+				<p className="text-xs text-muted-foreground">
+					{RULE_TYPE_MAP.get(node.kind as CleanupRuleType)?.desc ??
+						"This stored condition is unavailable. Choose a supported type before saving."}
+				</p>
+				{knownKind && (
+					<ConditionParamsFields
+						ruleType={node.kind as CleanupRuleType}
+						params={node.params}
+						onParamsChange={(params) => onReplace(path, { kind: node.kind, params })}
+						fieldOptions={props.fieldOptions}
+						fieldOptionsLoading={props.fieldOptionsLoading}
+						inputClass={props.inputClass}
+						labelClass={props.labelClass}
+					/>
+				)}
+			</div>
+		);
+	}
+
+	if (isRuleNot(node)) {
+		return (
+			<div
+				role="group"
+				aria-label="NOT group"
+				className="space-y-2 rounded-lg border border-amber-500/25 bg-amber-500/5 p-3"
+			>
+				<div className="flex flex-wrap items-center justify-between gap-2">
+					<div>
+						<span className="text-xs font-semibold uppercase tracking-wide text-amber-500">
+							NOT
+						</span>
+						<p className="text-xs text-muted-foreground">Invert the child result.</p>
+					</div>
+					<div className="flex items-center gap-1.5">
+						<button
+							type="button"
+							onClick={() => onReplace(path, node.not)}
+							className="inline-flex items-center gap-1 rounded-md border border-border/40 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+						>
+							<Undo2 className="h-3 w-3" aria-hidden="true" /> Remove NOT
+						</button>
+						{!isRoot && canRemove && (
+							<button
+								type="button"
+								aria-label="Remove node"
+								onClick={() => onRemove(path)}
+								className="rounded-md p-1 text-muted-foreground hover:text-destructive"
+							>
+								<Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+							</button>
+						)}
+					</div>
+				</div>
+				<div className="border-l border-amber-500/30 pl-3">
+					<RuleNodeEditor
+						{...props}
+						node={node.not}
+						path={[...path, 0]}
+						isRoot={false}
+						canRemove={false}
+					/>
+				</div>
+			</div>
+		);
+	}
+
+	const isAll = "all" in node;
+	const children = isAll ? node.all : node.any;
+	const label = isAll ? "ALL" : "ANY";
+	return (
+		<div
+			role="group"
+			aria-label={`${label} group`}
+			className="space-y-3 rounded-lg border border-primary/20 bg-primary/5 p-3"
+		>
+			<div className="flex flex-wrap items-start justify-between gap-2">
+				<div>
+					<div className="flex gap-1.5" aria-label="Group operator">
+						{(["ALL", "ANY"] as const).map((operator) => (
+							<button
+								key={operator}
+								type="button"
+								aria-pressed={label === operator}
+								onClick={() =>
+									onReplace(path, operator === "ALL" ? { all: children } : { any: children })
+								}
+								className={`rounded-md border px-2 py-1 text-xs font-semibold ${
+									label === operator
+										? "border-primary/30 bg-primary/15 text-primary"
+										: "border-border/40 text-muted-foreground"
+								}`}
+							>
+								{operator}
+							</button>
+						))}
+					</div>
+					<p className="mt-1 text-xs text-muted-foreground">
+						{isAll ? "Every child must match." : "At least one child must match."}
+					</p>
+				</div>
+				<NodeActions {...props} isRoot={isRoot} />
+			</div>
+
+			<div className="space-y-2 border-l border-primary/20 pl-3">
+				{children.map((child, index) => (
+					<RuleNodeEditor
+						{...props}
+						// biome-ignore lint/suspicious/noArrayIndexKey: paths define stable tree positions
+						key={index}
+						node={child}
+						path={[...path, index]}
+						isRoot={false}
+						canRemove
+					/>
+				))}
+				{children.length === 0 && (
+					<p className="text-xs italic text-destructive">Add at least one child before saving.</p>
+				)}
+			</div>
+
+			<div className="flex flex-wrap gap-1.5">
+				<button
+					type="button"
+					aria-label={`Add condition to ${label} group`}
+					onClick={() => props.onAdd(path, defaultPredicate())}
+					className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/50 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+				>
+					<CirclePlus className="h-3 w-3" aria-hidden="true" /> Condition
+				</button>
+				<button
+					type="button"
+					aria-label={`Add group to ${label} group`}
+					onClick={() => props.onAdd(path, { all: [defaultPredicate()] })}
+					className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/50 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+				>
+					<GitBranch className="h-3 w-3" aria-hidden="true" /> Group
+				</button>
+				<button
+					type="button"
+					aria-label={`Add NOT to ${label} group`}
+					onClick={() => props.onAdd(path, { not: defaultPredicate() })}
+					className="inline-flex items-center gap-1 rounded-md border border-dashed border-border/50 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+				>
+					<Braces className="h-3 w-3" aria-hidden="true" /> NOT
+				</button>
+			</div>
+		</div>
+	);
+}
+
+function NodeActions(props: RuleNodeEditorProps) {
+	const { node, path, isRoot = false, canRemove = true, onReplace, onRemove } = props;
+	return (
+		<div className="flex items-center gap-1.5">
+			<button
+				type="button"
+				onClick={() => onReplace(path, { not: node })}
+				className="rounded-md border border-border/40 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+			>
+				Negate
+			</button>
+			{!isRoot && canRemove && (
+				<button
+					type="button"
+					aria-label="Remove node"
+					onClick={() => onRemove(path)}
+					className="rounded-md p-1 text-muted-foreground hover:text-destructive"
+				>
+					<Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+				</button>
+			)}
+		</div>
+	);
+}

--- a/apps/web/src/features/library-cleanup/components/recursive-cleanup-rule-editor.tsx
+++ b/apps/web/src/features/library-cleanup/components/recursive-cleanup-rule-editor.tsx
@@ -285,7 +285,27 @@ function RuleNodeEditor(props: RuleNodeEditorProps) {
 function NodeActions(props: RuleNodeEditorProps) {
 	const { node, path, isRoot = false, canRemove = true, onReplace, onRemove } = props;
 	return (
-		<div className="flex items-center gap-1.5">
+		<div className="flex flex-wrap items-center gap-1.5">
+			{isRoot && isRulePredicate(node) && (
+				<>
+					<button
+						type="button"
+						aria-label="Wrap root in ALL group"
+						onClick={() => onReplace(path, { all: [node] })}
+						className="inline-flex items-center gap-1 rounded-md border border-border/40 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						<GitBranch className="h-3 w-3" aria-hidden="true" /> Wrap in ALL
+					</button>
+					<button
+						type="button"
+						aria-label="Wrap root in ANY group"
+						onClick={() => onReplace(path, { any: [node] })}
+						className="inline-flex items-center gap-1 rounded-md border border-border/40 px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+					>
+						<GitBranch className="h-3 w-3" aria-hidden="true" /> Wrap in ANY
+					</button>
+				</>
+			)}
 			<button
 				type="button"
 				onClick={() => onReplace(path, { not: node })}

--- a/apps/web/src/features/library-cleanup/lib/__tests__/recursive-rule-editor.test.ts
+++ b/apps/web/src/features/library-cleanup/lib/__tests__/recursive-rule-editor.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+	RULE_DOCUMENT_V1_MAX_DEPTH,
+	RULE_DOCUMENT_V1_MAX_NODES,
+	type RuleDocument,
+	type RuleNode,
+} from "@arr/shared";
+import {
+	appendRuleChild,
+	removeRuleNode,
+	stripCleanupRuleAnnotations,
+	updateRuleNode,
+	validateCleanupRuleDocument,
+} from "../recursive-rule-editor";
+
+const age = (days = 30): RuleNode => ({
+	kind: "age",
+	params: { operator: "older_than", days },
+});
+
+const document = (root: RuleNode): RuleDocument => ({ version: 1, root });
+
+describe("recursive cleanup rule editor", () => {
+	it("updates a nested ALL/ANY/NOT child without mutating the original tree", () => {
+		const root: RuleNode = {
+			all: [age(30), { any: [{ not: age(60) }, age(90)] }],
+		};
+
+		const updated = updateRuleNode(root, [1, 0, 0], () => age(120));
+
+		expect(updated).toEqual({
+			all: [age(30), { any: [{ not: age(120) }, age(90)] }],
+		});
+		expect(root).toEqual({
+			all: [age(30), { any: [{ not: age(60) }, age(90)] }],
+		});
+		expect(updated).not.toBe(root);
+		expect((updated as { all: RuleNode[] }).all[0]).toBe((root as { all: RuleNode[] }).all[0]);
+	});
+
+	it("appends to groups in order and rejects appending to NOT or a predicate", () => {
+		const root: RuleNode = { all: [age(30)] };
+
+		expect(appendRuleChild(root, [], age(60))).toEqual({ all: [age(30), age(60)] });
+		expect(root).toEqual({ all: [age(30)] });
+		expect(() => appendRuleChild({ not: age() }, [], age())).toThrow(/NOT/i);
+		expect(() => appendRuleChild(age(), [], age())).toThrow(/group/i);
+	});
+
+	it("removes nested group children immutably and returns null only when removing the root", () => {
+		const root: RuleNode = { any: [age(30), { not: age(60) }, age(90)] };
+
+		expect(removeRuleNode(root, [1])).toEqual({ any: [age(30), age(90)] });
+		expect(removeRuleNode(root, [])).toBeNull();
+		expect(() => removeRuleNode(root, [1, 0])).toThrow(/NOT/i);
+		expect(root).toEqual({ any: [age(30), { not: age(60) }, age(90)] });
+		expect(() => removeRuleNode(root, [9])).toThrow(/path/i);
+	});
+
+	it("rejects paths that do not address a child or use non-index segments", () => {
+		expect(() => updateRuleNode(age(), [0], () => age())).toThrow(/path/i);
+		expect(() => updateRuleNode(age(), [-1], () => age())).toThrow(/index/i);
+		expect(() => updateRuleNode(age(), [1.5], () => age())).toThrow(/index/i);
+	});
+
+	it("deep-clones documents while removing unavailable-kind annotations", () => {
+		const input = document({
+			all: [
+				{ kind: "age", params: { operator: "older_than", days: 1 }, unavailableKind: true },
+				{
+					not: {
+						kind: "size",
+						params: { operator: "greater_than", sizeGb: 1 },
+						unavailableKind: false,
+					},
+				},
+			],
+		});
+
+		const stripped = stripCleanupRuleAnnotations(input);
+
+		expect(stripped).toEqual(
+			document({
+				all: [age(1), { not: { kind: "size", params: { operator: "greater_than", sizeGb: 1 } } }],
+			}),
+		);
+		expect(stripped).not.toBe(input);
+		expect(stripped.root).not.toBe(input.root);
+		expect(input.root).toEqual({
+			all: [
+				{ kind: "age", params: { operator: "older_than", days: 1 }, unavailableKind: true },
+				{
+					not: {
+						kind: "size",
+						params: { operator: "greater_than", sizeGb: 1 },
+						unavailableKind: false,
+					},
+				},
+			],
+		});
+	});
+
+	it.each(["all", "any"] as const)("rejects an empty %s group", (key) => {
+		const root: RuleNode = key === "all" ? { all: [] } : { any: [] };
+		expect(validateCleanupRuleDocument(document(root))).toMatch(/at least one/i);
+	});
+
+	it("rejects unavailable and retired predicates before parameter validation", () => {
+		expect(
+			validateCleanupRuleDocument(
+				document({
+					kind: "age",
+					params: { operator: "older_than", days: 1 },
+					unavailableKind: true,
+				}),
+			),
+		).toMatch(/unavailable/i);
+		expect(
+			validateCleanupRuleDocument(document({ kind: "tautulli_last_watched", params: {} })),
+		).toMatch(/not available/i);
+	});
+
+	it("rejects invalid predicate parameters without throwing", () => {
+		expect(() =>
+			validateCleanupRuleDocument(document({ kind: "age", params: { days: 0 } })),
+		).not.toThrow();
+		expect(validateCleanupRuleDocument(document({ kind: "age", params: { days: 0 } }))).toMatch(
+			/age/i,
+		);
+	});
+
+	it("uses the shared depth and node bounds", () => {
+		let deep: RuleNode = age();
+		for (let index = 0; index <= RULE_DOCUMENT_V1_MAX_DEPTH; index += 1) deep = { not: deep };
+		expect(validateCleanupRuleDocument(document(deep))).toMatch(/depth limit/i);
+
+		const tooMany: RuleNode = {
+			all: Array.from({ length: RULE_DOCUMENT_V1_MAX_NODES }, () => age()),
+		};
+		expect(validateCleanupRuleDocument(document(tooMany))).toMatch(/node limit/i);
+	});
+
+	it("rejects list membership beneath any NOT ancestor, including double NOT", () => {
+		const listMember: RuleNode = {
+			kind: "tmdb_list_member",
+			params: { listId: "8068", operator: "is_in" },
+		};
+
+		expect(validateCleanupRuleDocument(document({ not: listMember }))).toMatch(
+			/list membership.*NOT/i,
+		);
+		expect(
+			validateCleanupRuleDocument(document({ all: [{ not: { any: [{ not: listMember }] } }] })),
+		).toMatch(/list membership.*NOT/i);
+		expect(validateCleanupRuleDocument(document(listMember))).toBeNull();
+	});
+});

--- a/apps/web/src/features/library-cleanup/lib/recursive-rule-editor.ts
+++ b/apps/web/src/features/library-cleanup/lib/recursive-rule-editor.ts
@@ -1,0 +1,197 @@
+import {
+	isKindLegalForContext,
+	isRuleNot,
+	isRulePredicate,
+	ruleParamSchemaMap,
+	type RuleDocument,
+	type RuleNode,
+	validateV1Bounds,
+} from "@arr/shared";
+
+export type RuleNodePath = readonly number[];
+
+function formatPath(path: RuleNodePath): string {
+	return path.length === 0 ? "root" : `root[${path.join("][")}]`;
+}
+
+function assertPath(path: RuleNodePath): void {
+	for (const segment of path) {
+		if (!Number.isInteger(segment) || segment < 0) {
+			throw new TypeError("Rule node path index values must be non-negative integers");
+		}
+	}
+}
+
+function cloneValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+	if (value === null || typeof value !== "object") return value;
+	const known = seen.get(value);
+	if (known) return known;
+	if (Array.isArray(value)) {
+		const copy: unknown[] = [];
+		seen.set(value, copy);
+		for (const item of value) copy.push(cloneValue(item, seen));
+		return copy;
+	}
+	const copy: Record<string, unknown> = {};
+	seen.set(value, copy);
+	for (const [key, item] of Object.entries(value)) copy[key] = cloneValue(item, seen);
+	return copy;
+}
+
+function cloneRuleNode(node: RuleNode): RuleNode {
+	if (isRulePredicate(node)) {
+		return {
+			kind: node.kind,
+			params: cloneValue(node.params) as Record<string, unknown>,
+			...(node.unavailableKind === undefined ? {} : { unavailableKind: node.unavailableKind }),
+		};
+	}
+	if (isRuleNot(node)) return { not: cloneRuleNode(node.not) };
+	if ("all" in node) return { all: node.all.map(cloneRuleNode) };
+	return { any: node.any.map(cloneRuleNode) };
+}
+
+function childAt(node: RuleNode, index: number, path: RuleNodePath): RuleNode {
+	if (isRulePredicate(node)) {
+		throw new Error(`Rule path ${formatPath(path)} cannot continue through a predicate`);
+	}
+	if (isRuleNot(node)) {
+		if (index !== 0)
+			throw new RangeError(`Rule path ${formatPath(path)} has no NOT child at index ${index}`);
+		return node.not;
+	}
+	const children = "all" in node ? node.all : node.any;
+	const child = children[index];
+	if (!child) throw new RangeError(`Rule path ${formatPath(path)} has no child at index ${index}`);
+	return child;
+}
+
+function replaceRuleNode(
+	root: RuleNode,
+	path: RuleNodePath,
+	updater: (node: RuleNode) => RuleNode,
+): RuleNode {
+	if (path.length === 0) return updater(cloneRuleNode(root));
+	const [index, ...remaining] = path;
+	if (index === undefined) throw new Error("Rule path is missing an index");
+	const child = childAt(root, index, path);
+	const replacement = replaceRuleNode(child, remaining, updater);
+	if (isRuleNot(root)) return { not: replacement };
+	if (isRulePredicate(root))
+		throw new Error(`Rule path ${formatPath(path)} cannot continue through a predicate`);
+	if ("all" in root) {
+		return { all: root.all.map((item, childIndex) => (childIndex === index ? replacement : item)) };
+	}
+	return { any: root.any.map((item, childIndex) => (childIndex === index ? replacement : item)) };
+}
+
+/** Replace a node at a path without mutating the supplied tree. */
+export function updateRuleNode(
+	root: RuleNode,
+	path: RuleNodePath,
+	updater: (node: RuleNode) => RuleNode,
+): RuleNode {
+	assertPath(path);
+	if (typeof updater !== "function") throw new TypeError("Rule node updater must be a function");
+	return replaceRuleNode(root, path, updater);
+}
+
+/** Append a child to an ALL or ANY node, preserving the existing sibling order. */
+export function appendRuleChild(
+	root: RuleNode,
+	groupPath: RuleNodePath,
+	child: RuleNode,
+): RuleNode {
+	return updateRuleNode(root, groupPath, (group) => {
+		if (isRuleNot(group)) throw new Error("Cannot append a child to a NOT node");
+		if (isRulePredicate(group))
+			throw new Error("Can only append a rule child to an ALL or ANY group");
+		if ("all" in group) return { all: [...group.all, cloneRuleNode(child)] };
+		return { any: [...group.any, cloneRuleNode(child)] };
+	});
+}
+
+/** Remove a node by path. Removing the root intentionally returns null. */
+export function removeRuleNode(root: RuleNode, path: RuleNodePath): RuleNode | null {
+	assertPath(path);
+	if (path.length === 0) return null;
+	const parentPath = path.slice(0, -1);
+	const index = path[path.length - 1];
+	if (index === undefined) throw new Error("Rule path is missing an index");
+	return updateRuleNode(root, parentPath, (parent) => {
+		if (isRuleNot(parent)) throw new Error("Cannot remove the required child of a NOT node");
+		if (isRulePredicate(parent)) throw new Error("Cannot remove a child from a predicate");
+		if ("all" in parent) {
+			if (!parent.all[index])
+				throw new RangeError(`Rule path ${formatPath(path)} has no child at index ${index}`);
+			return { all: parent.all.filter((_, childIndex) => childIndex !== index) };
+		}
+		if (!parent.any[index])
+			throw new RangeError(`Rule path ${formatPath(path)} has no child at index ${index}`);
+		return { any: parent.any.filter((_, childIndex) => childIndex !== index) };
+	});
+}
+
+/** Deep-copy a cleanup rule document while removing read-only API annotations. */
+export function stripCleanupRuleAnnotations(document: RuleDocument): RuleDocument {
+	return { version: document.version, root: stripNodeAnnotations(document.root) };
+}
+
+function stripNodeAnnotations(node: RuleNode): RuleNode {
+	if (isRulePredicate(node))
+		return { kind: node.kind, params: cloneValue(node.params) as Record<string, unknown> };
+	if (isRuleNot(node)) return { not: stripNodeAnnotations(node.not) };
+	if ("all" in node) return { all: node.all.map(stripNodeAnnotations) };
+	return { any: node.any.map(stripNodeAnnotations) };
+}
+
+/**
+ * Validate a cleanup rule for authoring. This is intentionally stricter than
+ * the shared structural parser: retired and API-annotated predicates cannot be
+ * saved, empty groups cannot be authored, and list membership cannot be
+ * negated because its cached membership semantics are one-way.
+ */
+export function validateCleanupRuleDocument(document: RuleDocument): string | null {
+	const boundsError = validateV1Bounds(document);
+	if (boundsError) return boundsError;
+
+	const stack: Array<{ node: RuleNode; hasNotAncestor: boolean }> = [
+		{ node: document.root, hasNotAncestor: false },
+	];
+	while (stack.length > 0) {
+		const current = stack.pop();
+		if (!current) break;
+		const { node, hasNotAncestor } = current;
+		if (isRulePredicate(node)) {
+			if (node.unavailableKind) return `"${node.kind}" is unavailable and must be replaced.`;
+			if (!isKindLegalForContext("library-cleanup", node.kind)) {
+				return `"${node.kind}" is not available for library cleanup.`;
+			}
+			if (
+				hasNotAncestor &&
+				(node.kind === "tmdb_list_member" || node.kind === "trakt_list_member")
+			) {
+				return "List membership conditions cannot be used inside NOT expressions.";
+			}
+			const parsed = ruleParamSchemaMap[node.kind]?.safeParse(node.params);
+			if (parsed && !parsed.success) {
+				const issue = parsed.error.issues[0];
+				const where = issue?.path.length ? ` (${issue.path.join(".")})` : "";
+				return `${node.kind}: ${issue?.message ?? "invalid parameters"}${where}.`;
+			}
+			continue;
+		}
+		if (isRuleNot(node)) {
+			stack.push({ node: node.not, hasNotAncestor: true });
+			continue;
+		}
+		const children = "all" in node ? node.all : node.any;
+		if (children.length === 0) return "Add at least one condition to every ALL or ANY group.";
+		for (let index = children.length - 1; index >= 0; index -= 1) {
+			const child = children[index];
+			if (child) stack.push({ node: child, hasNotAncestor });
+		}
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary

- replace the recursive-rule read-only guard with a bounded visual tree editor for predicates, ALL, ANY, and NOT
- reuse the existing cleanup condition controls while preserving flat single-condition and legacy composite workflows
- submit canonical expression payloads, strip read-only annotations, and reject invalid, empty, over-limit, retired, or unsupported negated-list trees before saving
- label nested rules by authored predicate count in the cleanup rule list

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm run typecheck
- pnpm run test (4,178 API, 851 web, 154 shared before the final correction)
- pnpm run lint
- pnpm run build
- focused recursive authoring suite after correction: 100 tests passed
- web typecheck, lint, and production build passed after correction

## Review boundary

The required independent regression review found one flat-edit mode regression. The correction now locks mode conversion only for existing recursive rules, keeps flat-rule conversion available, and adds rendered coverage for both boundaries. No backend grammar or execution semantics are changed.