### PR TITLE
fix(trash-guides): recover stalled automatic sync

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -102,6 +102,67 @@ function createUpdater(
 }
 
 describe("TemplateUpdater automation authority", () => {
+	it("recovers an auto-sync template whose initial commit could not be recorded", async () => {
+		const storedTemplate = {
+			id: template.id,
+			name: template.name,
+			serviceType: "RADARR",
+			trashGuidesCommitHash: null,
+			hasUserModifications: false,
+			configData: '{"customFormats":[],"customFormatGroups":[]}',
+			changeLog: null,
+			lastSyncedAt: null,
+			qualityProfileMappings: [
+				{
+					syncStrategy: "auto",
+					lastSyncedAt: new Date("2026-08-09T12:00:00.000Z"),
+					instance: { enabled: true },
+				},
+			],
+		};
+		const findMany = vi.fn().mockResolvedValue([storedTemplate]);
+		const prisma = {
+			trashTemplate: {
+				findMany,
+			},
+		};
+		const updater = new TemplateUpdater(
+			prisma as never,
+			{
+				getLatestCommit: vi.fn().mockResolvedValue({
+					commitHash: "current",
+					commitDate: "2026-08-10",
+					commitMessage: "current",
+					commitUrl: "https://example.com/commit/current",
+				}),
+			} as never,
+			{ get: vi.fn().mockResolvedValue([]) } as never,
+			{} as never,
+		);
+
+		const result = await updater.checkForUpdates(template.userId);
+
+		expect(result.templatesWithUpdates).toEqual([
+			expect.objectContaining({
+				templateId: template.id,
+				currentCommit: null,
+				latestCommit: "current",
+				canAutoSync: true,
+			}),
+		]);
+		expect(result.outdatedTemplates).toBe(1);
+
+		findMany.mockResolvedValueOnce([{ ...storedTemplate, hasUserModifications: true }]);
+		const modifiedResult = await updater.checkForUpdates(template.userId);
+		expect(modifiedResult.templatesWithUpdates).toEqual([
+			expect.objectContaining({ templateId: template.id, canAutoSync: false }),
+		]);
+
+		findMany.mockResolvedValueOnce([{ ...storedTemplate, qualityProfileMappings: [] }]);
+		const unauthorizedResult = await updater.checkForUpdates(template.userId);
+		expect(unauthorizedResult.templatesWithUpdates).toEqual([]);
+	});
+
 	it("reports deployment catch-up after a disabled auto target is re-enabled", async () => {
 		const templateSyncedAt = new Date("2026-08-10T12:00:00.000Z");
 		const prisma = {
@@ -345,6 +406,7 @@ describe("TemplateUpdater automation authority", () => {
 					autoSyncInstanceCount: 1,
 					canAutoSync: true,
 					serviceType: "RADARR",
+					automationStateToken: "selected-template-state",
 				},
 			],
 			latestCommit: {
@@ -361,6 +423,7 @@ describe("TemplateUpdater automation authority", () => {
 			templateId: template.id,
 			previousCommit: "old",
 			newCommit: "new",
+			automationStateToken: "synced-template-state",
 		});
 
 		const result = await updater.processAutoUpdates(template.userId);
@@ -373,6 +436,85 @@ describe("TemplateUpdater automation authority", () => {
 				errors: [expect.stringContaining("ARR rejected the deployment")],
 			}),
 		]);
+	});
+
+	it("binds automatic sync and deployment to the selected template states", async () => {
+		const target = instance("instance-1", "http://radarr:7878");
+		const { updater, privateUpdater } = createUpdater([mapping(target)]);
+		vi.spyOn(updater, "checkForUpdates").mockResolvedValue({
+			templatesWithUpdates: [
+				{
+					templateId: template.id,
+					templateName: template.name,
+					currentCommit: null,
+					latestCommit: "new",
+					hasUserModifications: false,
+					autoSyncInstanceCount: 1,
+					canAutoSync: true,
+					serviceType: "RADARR",
+					automationStateToken: "selected-template-state",
+				},
+			],
+			latestCommit: {
+				commitHash: "new",
+				commitDate: "2026-08-09",
+				commitMessage: "update",
+				commitUrl: "https://example.com/commit/new",
+			},
+			totalTemplates: 1,
+			outdatedTemplates: 1,
+		} as never);
+		const syncTemplate = vi.spyOn(updater, "syncTemplate").mockResolvedValue({
+			success: true,
+			templateId: template.id,
+			previousCommit: null,
+			newCommit: "new",
+			automationStateToken: "synced-template-state",
+		} as never);
+		const deployToMappedInstances = vi
+			.spyOn(privateUpdater, "deployToMappedInstances")
+			.mockResolvedValue([]);
+
+		await updater.processAutoUpdates(template.userId);
+
+		expect(syncTemplate).toHaveBeenCalledWith(template.id, "new", template.userId, {
+			includeQualityProfileCFs: true,
+			applyScoreUpdates: true,
+			expectedAutomationStateToken: "selected-template-state",
+		});
+		expect(deployToMappedInstances).toHaveBeenCalledWith(
+			template.id,
+			false,
+			"synced-template-state",
+		);
+	});
+
+	it("blocks automatic sync when the template changes after selection", async () => {
+		const selectedTemplate = { ...template, deletedAt: null };
+		const changedTemplate = {
+			...selectedTemplate,
+			configData: '{"customFormats":[{"name":"edited while queued"}]}',
+		};
+		const prisma = {
+			trashTemplate: {
+				findUnique: vi.fn().mockResolvedValue(changedTemplate),
+				update: vi.fn(),
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+			},
+		};
+		const updater = new TemplateUpdater(prisma as never, {} as never, {} as never, {} as never);
+
+		const result = await updater.syncTemplate(template.id, "new", template.userId, {
+			expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(selectedTemplate),
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("template or Auto mapping changed")],
+		});
+		expect(prisma.trashTemplate.update).not.toHaveBeenCalled();
 	});
 
 	it("preserves an uncertain auto-deployment as needing review", async () => {
@@ -393,6 +535,7 @@ describe("TemplateUpdater automation authority", () => {
 					autoSyncInstanceCount: 1,
 					canAutoSync: true,
 					serviceType: "RADARR",
+					automationStateToken: "selected-template-state",
 				},
 			],
 			latestCommit: {
@@ -409,6 +552,7 @@ describe("TemplateUpdater automation authority", () => {
 			templateId: template.id,
 			previousCommit: "old",
 			newCommit: "new",
+			automationStateToken: "synced-template-state",
 		});
 
 		const result = await updater.processAutoUpdates(template.userId);
@@ -455,6 +599,7 @@ describe("TemplateUpdater automation authority", () => {
 					autoSyncInstanceCount: 2,
 					canAutoSync: true,
 					serviceType: "RADARR",
+					automationStateToken: "selected-template-state",
 				},
 			],
 			latestCommit: {
@@ -471,6 +616,7 @@ describe("TemplateUpdater automation authority", () => {
 			templateId: template.id,
 			previousCommit: "old",
 			newCommit: "new",
+			automationStateToken: "synced-template-state",
 		});
 
 		const result = await updater.processAutoUpdates(template.userId);
@@ -498,6 +644,7 @@ describe("TemplateUpdater automation authority", () => {
 					autoSyncInstanceCount: 1,
 					canAutoSync: true,
 					serviceType: "RADARR",
+					automationStateToken: "selected-template-state",
 				},
 			],
 			latestCommit: {
@@ -514,6 +661,7 @@ describe("TemplateUpdater automation authority", () => {
 			templateId: template.id,
 			previousCommit: "old",
 			newCommit: "new",
+			automationStateToken: "synced-template-state",
 		});
 
 		const result = await updater.processAutoUpdates(template.userId);

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -107,6 +107,7 @@ describe("TemplateUpdater automation authority", () => {
 			id: template.id,
 			name: template.name,
 			serviceType: "RADARR",
+			sourceQualityProfileTrashId: "trash-profile",
 			trashGuidesCommitHash: null,
 			hasUserModifications: false,
 			configData: '{"customFormats":[],"customFormatGroups":[]}',
@@ -157,6 +158,10 @@ describe("TemplateUpdater automation authority", () => {
 		expect(modifiedResult.templatesWithUpdates).toEqual([
 			expect.objectContaining({ templateId: template.id, canAutoSync: false }),
 		]);
+
+		findMany.mockResolvedValueOnce([{ ...storedTemplate, sourceQualityProfileTrashId: null }]);
+		const untrackedResult = await updater.checkForUpdates(template.userId);
+		expect(untrackedResult.templatesWithUpdates).toEqual([]);
 
 		findMany.mockResolvedValueOnce([{ ...storedTemplate, qualityProfileMappings: [] }]);
 		const unauthorizedResult = await updater.checkForUpdates(template.userId);
@@ -498,6 +503,37 @@ describe("TemplateUpdater automation authority", () => {
 		const prisma = {
 			trashTemplate: {
 				findUnique: vi.fn().mockResolvedValue(changedTemplate),
+				update: vi.fn(),
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+			},
+		};
+		const updater = new TemplateUpdater(prisma as never, {} as never, {} as never, {} as never);
+
+		const result = await updater.syncTemplate(template.id, "new", template.userId, {
+			expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(selectedTemplate),
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("template or Auto mapping changed")],
+		});
+		expect(prisma.trashTemplate.update).not.toHaveBeenCalled();
+	});
+
+	it("blocks initial automatic sync when TRaSH provenance is removed after selection", async () => {
+		const selectedTemplate = {
+			...template,
+			deletedAt: null,
+			trashGuidesCommitHash: null,
+			sourceQualityProfileTrashId: "trash-profile",
+		};
+		const prisma = {
+			trashTemplate: {
+				findUnique: vi
+					.fn()
+					.mockResolvedValue({ ...selectedTemplate, sourceQualityProfileTrashId: null }),
 				update: vi.fn(),
 			},
 			templateQualityProfileMapping: {

--- a/apps/api/src/lib/trash-guides/__tests__/update-scheduler-liveness.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/update-scheduler-liveness.test.ts
@@ -77,7 +77,10 @@ describe("TRaSH update scheduler liveness", () => {
 					deletedAt: null,
 					OR: [
 						{ trashGuidesCommitHash: { not: null } },
-						{ qualityProfileMappings: { some: { syncStrategy: "auto" } } },
+						{
+							sourceQualityProfileTrashId: { not: null },
+							qualityProfileMappings: { some: { syncStrategy: "auto" } },
+						},
 					],
 				},
 			}),

--- a/apps/api/src/lib/trash-guides/__tests__/update-scheduler-liveness.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/update-scheduler-liveness.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from "vitest";
+import { UpdateScheduler } from "../update-scheduler.js";
+
+describe("TRaSH update scheduler liveness", () => {
+	it("releases the in-progress latch when scheduler preflight fails", async () => {
+		const templateUpdater = {
+			refreshAllCaches: vi.fn().mockResolvedValue({ refreshed: 0, failed: 0, errors: [] }),
+			checkForUpdates: vi.fn().mockResolvedValue({
+				totalTemplates: 0,
+				outdatedTemplates: 0,
+				templatesWithUpdates: [],
+			}),
+		};
+		const prisma = {
+			trashTemplate: {
+				count: vi
+					.fn()
+					.mockRejectedValueOnce(new Error("transient strategy count failure"))
+					.mockResolvedValue(0),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		};
+		const logger = {
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+		};
+		const notify = vi.fn().mockResolvedValue(undefined);
+		const scheduler = new UpdateScheduler(
+			{ enabled: true, intervalHours: 12 },
+			templateUpdater as never,
+			{
+				getLatestCommit: vi.fn().mockResolvedValue({
+					commitHash: "latest",
+					commitDate: "today",
+				}),
+			} as never,
+			prisma as never,
+			logger,
+			undefined,
+			{ notifyFn: notify },
+		);
+		const privateScheduler = scheduler as unknown as {
+			processQualitySizeSync: () => Promise<unknown>;
+			processNamingSync: () => Promise<unknown>;
+		};
+		vi.spyOn(privateScheduler, "processQualitySizeSync").mockResolvedValue({
+			autoSynced: 0,
+			updatesPending: 0,
+			errors: [],
+		});
+		vi.spyOn(privateScheduler, "processNamingSync").mockResolvedValue({
+			autoSynced: 0,
+			updatesPending: 0,
+			errors: [],
+		});
+
+		await expect(scheduler.triggerCheck()).rejects.toThrow("transient strategy count failure");
+		expect(scheduler.getStats().lastCheckResult).toMatchObject({
+			templatesChecked: 0,
+			templatesOutdated: 0,
+			errors: ["transient strategy count failure"],
+		});
+		expect(notify).toHaveBeenCalledWith(
+			expect.objectContaining({
+				eventType: "TRASH_SYNC_ERROR",
+				body: "transient strategy count failure",
+			}),
+		);
+		await scheduler.triggerCheck();
+
+		expect(templateUpdater.refreshAllCaches).toHaveBeenCalledTimes(2);
+		expect(prisma.trashTemplate.findMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					deletedAt: null,
+					OR: [
+						{ trashGuidesCommitHash: { not: null } },
+						{ qualityProfileMappings: { some: { syncStrategy: "auto" } } },
+					],
+				},
+			}),
+		);
+		expect(scheduler.getStats().lastCheckResult).toMatchObject({
+			templatesChecked: 0,
+			templatesOutdated: 0,
+			errors: [],
+		});
+		expect(logger.warn).not.toHaveBeenCalledWith("Update check already in progress, skipping");
+	});
+});

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -419,7 +419,7 @@ export class DeploymentExecutorService {
 			createAutomationCatchUpTemplateStateToken(template) !== expectedStateToken
 		) {
 			throw new ConflictError(
-				"Automatic catch-up is no longer authorized because the template changed after target selection.",
+				"Automatic deployment is no longer authorized because the template changed after target selection.",
 			);
 		}
 	}
@@ -1794,7 +1794,7 @@ export class DeploymentExecutorService {
 					createAutomationCatchUpTemplateStateToken(template) !== catchUpTemplateStateToken)
 			) {
 				throw new ConflictError(
-					"Automatic catch-up is no longer authorized because the template changed after target selection.",
+					"Automatic deployment is no longer authorized because the template changed after target selection.",
 				);
 			}
 			if (!executionToken && !instance.enabled) {

--- a/apps/api/src/lib/trash-guides/template-updater-types.ts
+++ b/apps/api/src/lib/trash-guides/template-updater-types.ts
@@ -35,6 +35,8 @@ export interface TemplateUpdateInfo {
 	lastAutoSyncTimestamp?: string;
 	/** True when the template is current but an enabled auto target still needs deployment */
 	deploymentCatchUp?: boolean;
+	/** Exact template state that authorized a pending automatic sync */
+	automationStateToken?: string;
 }
 
 export interface UpdateCheckResult {
@@ -65,6 +67,8 @@ export interface SyncResult {
 	mergeStats?: MergeStats;
 	/** Score conflicts that couldn't be auto-applied due to user overrides */
 	scoreConflicts?: ScoreConflict[];
+	/** Exact post-sync template state required by automatic deployment */
+	automationStateToken?: string;
 }
 
 export interface MergeStats {

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -127,6 +127,7 @@ export class TemplateUpdater {
 				id: true,
 				name: true,
 				serviceType: true,
+				sourceQualityProfileTrashId: true,
 				trashGuidesCommitHash: true,
 				hasUserModifications: true,
 				configData: true,
@@ -161,10 +162,13 @@ export class TemplateUpdater {
 				(mapping) => mapping.syncStrategy === "auto",
 			).length;
 
-			// A transient version lookup during import can leave an explicitly auto-synced
-			// template without its initial commit. Treat that as pending initial sync instead
-			// of excluding the mapping forever. Templates without auto authority remain untracked.
-			if (!template.trashGuidesCommitHash && autoSyncInstanceCount === 0) {
+			// A transient version lookup during a known TRaSH profile import can leave an
+			// explicitly auto-synced template without its initial commit. Custom, duplicated,
+			// and JSON-imported templates have no TRaSH profile identity and remain untracked.
+			if (
+				!template.trashGuidesCommitHash &&
+				(!template.sourceQualityProfileTrashId || autoSyncInstanceCount === 0)
+			) {
 				continue;
 			}
 
@@ -496,6 +500,7 @@ export class TemplateUpdater {
 				template.userId !== userId ||
 				template.deletedAt ||
 				template.hasUserModifications ||
+				(!template.trashGuidesCommitHash && !template.sourceQualityProfileTrashId) ||
 				!autoMapping ||
 				createAutomationCatchUpTemplateStateToken(template) !== options.expectedAutomationStateToken
 			) {

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -130,6 +130,7 @@ export class TemplateUpdater {
 				trashGuidesCommitHash: true,
 				hasUserModifications: true,
 				configData: true,
+				instanceOverrides: true,
 				changeLog: true,
 				lastSyncedAt: true,
 				qualityProfileMappings: {
@@ -156,15 +157,18 @@ export class TemplateUpdater {
 		const templatesWithUpdates: TemplateUpdateInfo[] = [];
 
 		for (const template of templates) {
-			if (!template.trashGuidesCommitHash) {
+			const autoSyncInstanceCount = template.qualityProfileMappings.filter(
+				(mapping) => mapping.syncStrategy === "auto",
+			).length;
+
+			// A transient version lookup during import can leave an explicitly auto-synced
+			// template without its initial commit. Treat that as pending initial sync instead
+			// of excluding the mapping forever. Templates without auto authority remain untracked.
+			if (!template.trashGuidesCommitHash && autoSyncInstanceCount === 0) {
 				continue;
 			}
 
 			if (template.trashGuidesCommitHash !== latestCommit.commitHash) {
-				const autoSyncInstanceCount = template.qualityProfileMappings.filter(
-					(m) => m.syncStrategy === "auto",
-				).length;
-
 				const canAutoSync = autoSyncInstanceCount > 0 && !template.hasUserModifications;
 				const serviceType = template.serviceType as "RADARR" | "SONARR";
 
@@ -223,12 +227,14 @@ export class TemplateUpdater {
 					pendingCFGroupAdditions: pendingCFGroupAdditions?.length
 						? pendingCFGroupAdditions
 						: undefined,
+					...(canAutoSync && !needsApproval
+						? { automationStateToken: createAutomationCatchUpTemplateStateToken(template) }
+						: {}),
 				});
 			} else {
 				const autoMappings = template.qualityProfileMappings.filter(
 					(mapping) => mapping.syncStrategy === "auto",
 				);
-				const autoSyncInstanceCount = autoMappings.length;
 				const pendingEnabledDeployments = template.lastSyncedAt
 					? autoMappings.filter(
 							(mapping) =>
@@ -390,6 +396,7 @@ export class TemplateUpdater {
 		options?: {
 			includeQualityProfileCFs?: boolean;
 			applyScoreUpdates?: boolean;
+			expectedAutomationStateToken?: string;
 		},
 	): Promise<SyncResult> {
 		const owner = await this.prisma.trashTemplate.findUnique({
@@ -428,6 +435,7 @@ export class TemplateUpdater {
 		options?: {
 			includeQualityProfileCFs?: boolean;
 			applyScoreUpdates?: boolean;
+			expectedAutomationStateToken?: string;
 		},
 	): Promise<SyncResult> {
 		const metrics = getSyncMetrics();
@@ -476,6 +484,33 @@ export class TemplateUpdater {
 				errors: ["Template not found"],
 				errorType: "not_found",
 			};
+		}
+
+		if (options?.expectedAutomationStateToken) {
+			const autoMapping = await this.prisma.templateQualityProfileMapping.findFirst({
+				where: { templateId, syncStrategy: "auto" },
+				select: { id: true },
+			});
+			if (
+				!userId ||
+				template.userId !== userId ||
+				template.deletedAt ||
+				template.hasUserModifications ||
+				!autoMapping ||
+				createAutomationCatchUpTemplateStateToken(template) !== options.expectedAutomationStateToken
+			) {
+				completeMetrics().recordFailure("Automatic sync authority changed");
+				return {
+					success: false,
+					templateId,
+					previousCommit: template.trashGuidesCommitHash,
+					newCommit: targetCommitHash || "",
+					errors: [
+						"Automatic sync is no longer authorized because the template or Auto mapping changed after selection.",
+					],
+					errorType: "sync_failed",
+				};
+			}
 		}
 
 		let targetCommit: VersionInfo;
@@ -723,13 +758,15 @@ export class TemplateUpdater {
 
 			const updatedChangeLog = [...existingChangeLog, autoSyncChangeLogEntry];
 
+			const syncedAt = new Date();
+			const syncedConfigData = JSON.stringify(mergeResult.mergedConfig);
 			await this.prisma.trashTemplate.update({
 				where: { id: templateId },
 				data: {
 					changeLog: JSON.stringify(updatedChangeLog),
-					configData: JSON.stringify(mergeResult.mergedConfig),
+					configData: syncedConfigData,
 					trashGuidesCommitHash: targetCommit.commitHash,
-					lastSyncedAt: new Date(),
+					lastSyncedAt: syncedAt,
 				},
 			});
 
@@ -741,6 +778,15 @@ export class TemplateUpdater {
 				templateId,
 				previousCommit,
 				newCommit: targetCommit.commitHash,
+				automationStateToken: options?.expectedAutomationStateToken
+					? createAutomationCatchUpTemplateStateToken({
+							configData: syncedConfigData,
+							instanceOverrides: template.instanceOverrides,
+							trashGuidesCommitHash: targetCommit.commitHash,
+							lastSyncedAt: syncedAt,
+							hasUserModifications: template.hasUserModifications,
+						})
+					: undefined,
 				mergeStats: mergeResult.stats,
 				scoreConflicts:
 					mergeResult.scoreConflicts.length > 0 ? mergeResult.scoreConflicts : undefined,
@@ -844,6 +890,18 @@ export class TemplateUpdater {
 		let templatesWithScoreConflicts = 0;
 
 		for (const template of autoSyncTemplates) {
+			if (!template.deploymentCatchUp && !template.automationStateToken) {
+				results.push({
+					success: false,
+					templateId: template.templateId,
+					previousCommit: template.currentCommit,
+					newCommit: template.latestCommit,
+					errors: ["Automatic sync selection is missing its required template authority."],
+					errorType: "sync_failed",
+				});
+				failed++;
+				continue;
+			}
 			const result: SyncResult = template.deploymentCatchUp
 				? {
 						success: true,
@@ -851,14 +909,24 @@ export class TemplateUpdater {
 						previousCommit: template.currentCommit,
 						newCommit: template.latestCommit,
 					}
-				: await this.syncTemplate(template.templateId, template.latestCommit, undefined, {
+				: await this.syncTemplate(template.templateId, template.latestCommit, userId, {
 						includeQualityProfileCFs: true,
 						applyScoreUpdates: true,
+						expectedAutomationStateToken: template.automationStateToken,
 					});
 
 			results.push(result);
 
 			if (result.success) {
+				if (!template.deploymentCatchUp && !result.automationStateToken) {
+					result.success = false;
+					result.errors = [
+						...(result.errors ?? []),
+						"Automatic deployment is missing the post-sync template authority token.",
+					];
+					failed++;
+					continue;
+				}
 				if (result.scoreConflicts && result.scoreConflicts.length > 0) {
 					templatesWithScoreConflicts++;
 				}
@@ -866,7 +934,11 @@ export class TemplateUpdater {
 				try {
 					const deploymentOutcomes = template.deploymentCatchUp
 						? await this.deployToMappedInstances(template.templateId, true)
-						: await this.deployToMappedInstances(template.templateId);
+						: await this.deployToMappedInstances(
+								template.templateId,
+								false,
+								result.automationStateToken,
+							);
 					const failedDeployments = deploymentOutcomes.filter(
 						(outcome) => outcome.status === "FAILED",
 					);
@@ -935,6 +1007,7 @@ export class TemplateUpdater {
 	private async deployToMappedInstances(
 		templateId: string,
 		catchUpOnly = false,
+		expectedTemplateStateToken?: string,
 	): Promise<AutomationDeploymentOutcome[]> {
 		if (!this.deploymentExecutor) {
 			return [];
@@ -1126,11 +1199,20 @@ export class TemplateUpdater {
 								? createAutomationCatchUpTemplateStateToken(template)
 								: undefined,
 						)
-					: await this.deploymentExecutor.deploySingleInstanceFromAutomation(
-							templateId,
-							mapping.instanceId,
-							template.userId,
-						);
+					: expectedTemplateStateToken
+						? await this.deploymentExecutor.deploySingleInstanceFromAutomation(
+								templateId,
+								mapping.instanceId,
+								template.userId,
+								undefined,
+								undefined,
+								expectedTemplateStateToken,
+							)
+						: await this.deploymentExecutor.deploySingleInstanceFromAutomation(
+								templateId,
+								mapping.instanceId,
+								template.userId,
+							);
 
 				if (result.status === "UNCERTAIN") {
 					const errors =

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -259,13 +259,15 @@ export class UpdateScheduler {
 		}
 
 		this.isCheckInProgress = true;
+		try {
+			await this.checkForUpdatesAttempt();
+		} finally {
+			this.isCheckInProgress = false;
+		}
+	}
+
+	private async checkForUpdatesAttempt(): Promise<void> {
 		const startTime = Date.now();
-
-		// Re-read repo config and rebuild services if the user changed settings
-		await this.refreshRepoConfigIfNeeded();
-
-		this.logger.info("Checking for TRaSH Guides updates...");
-
 		const errors: string[] = [];
 		let templatesAutoSynced = 0;
 		let templatesNeedingAttention = 0;
@@ -276,34 +278,40 @@ export class UpdateScheduler {
 		let qualitySizeUpdatesPending = 0;
 		let namingAutoSynced = 0;
 		let namingUpdatesPending = 0;
-
-		// Count templates by sync strategy (unique templates with at least one mapping of each type)
-		const [templatesWithAutoStrategy, templatesWithNotifyStrategy] = await Promise.all([
-			this.prisma.trashTemplate.count({
-				where: {
-					deletedAt: null,
-					trashGuidesCommitHash: { not: null },
-					qualityProfileMappings: {
-						some: {
-							syncStrategy: "auto",
-						},
-					},
-				},
-			}),
-			this.prisma.trashTemplate.count({
-				where: {
-					deletedAt: null,
-					trashGuidesCommitHash: { not: null },
-					qualityProfileMappings: {
-						some: {
-							syncStrategy: "notify",
-						},
-					},
-				},
-			}),
-		]);
+		let templatesWithAutoStrategy = 0;
+		let templatesWithNotifyStrategy = 0;
 
 		try {
+			// Re-read repo config and rebuild services if the user changed settings
+			await this.refreshRepoConfigIfNeeded();
+
+			this.logger.info("Checking for TRaSH Guides updates...");
+
+			// Count templates by sync strategy (unique templates with at least one mapping of each type)
+			[templatesWithAutoStrategy, templatesWithNotifyStrategy] = await Promise.all([
+				this.prisma.trashTemplate.count({
+					where: {
+						deletedAt: null,
+						qualityProfileMappings: {
+							some: {
+								syncStrategy: "auto",
+							},
+						},
+					},
+				}),
+				this.prisma.trashTemplate.count({
+					where: {
+						deletedAt: null,
+						trashGuidesCommitHash: { not: null },
+						qualityProfileMappings: {
+							some: {
+								syncStrategy: "notify",
+							},
+						},
+					},
+				}),
+			]);
+
 			// Get latest version info
 			const latestCommit = await this.versionTracker.getLatestCommit();
 			this.logger.debug(
@@ -353,7 +361,10 @@ export class UpdateScheduler {
 			const templatesWithUsers = await this.prisma.trashTemplate.findMany({
 				where: {
 					deletedAt: null,
-					trashGuidesCommitHash: { not: null },
+					OR: [
+						{ trashGuidesCommitHash: { not: null } },
+						{ qualityProfileMappings: { some: { syncStrategy: "auto" } } },
+					],
 				},
 				select: { userId: true },
 				distinct: ["userId"],
@@ -551,8 +562,6 @@ export class UpdateScheduler {
 			});
 
 			throw error;
-		} finally {
-			this.isCheckInProgress = false;
 		}
 	}
 

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -292,6 +292,10 @@ export class UpdateScheduler {
 				this.prisma.trashTemplate.count({
 					where: {
 						deletedAt: null,
+						OR: [
+							{ trashGuidesCommitHash: { not: null } },
+							{ sourceQualityProfileTrashId: { not: null } },
+						],
 						qualityProfileMappings: {
 							some: {
 								syncStrategy: "auto",
@@ -363,7 +367,10 @@ export class UpdateScheduler {
 					deletedAt: null,
 					OR: [
 						{ trashGuidesCommitHash: { not: null } },
-						{ qualityProfileMappings: { some: { syncStrategy: "auto" } } },
+						{
+							sourceQualityProfileTrashId: { not: null },
+							qualityProfileMappings: { some: { syncStrategy: "auto" } },
+						},
 					],
 				},
 				select: { userId: true },


### PR DESCRIPTION
## Summary

- release the TRaSH update scheduler latch after failures anywhere in preflight or update processing
- recover Auto mappings created without an initial TRaSH commit after a transient version lookup failure
- bind automatic sync and deployment to revalidated template state so edits, deletion, ownership changes, or strategy changes fail closed
- record failed preflight checks in scheduler status and emit the existing TRaSH sync error notification

## Safety

Automatic sync now revalidates the template owner, deletion state, user-modification state, Auto mapping, and exact selected template state under the template mutation guard. Successful sync produces a post-sync state token that is rechecked at both deployment boundaries before any upstream mutation.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run build`
- 53 focused scheduler, updater, and deployment authority tests
- full suite: shared 89 passed; web 651 passed; API 3,983 passed and 49 skipped, with one pre-existing Library Cleanup failure reproduced identically on a clean `origin/main` worktree
- independent regression review: resolved
- independent data-safety review: resolved

Related to #674
