### PR TITLE
test(library-cleanup): keep provider retry fixture fresh

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/media-server-rescan.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/media-server-rescan.test.ts
@@ -995,17 +995,19 @@ describe("durable media-server rescans", () => {
 	});
 
 	it("renews record-only retry evidence from current cache data under stable provider identity", async () => {
-		const capturedAt = new Date("2026-08-15T00:00:00.000Z");
-		const refreshedAt = new Date("2026-08-15T00:05:00.000Z");
+		const refreshedAt = new Date(Date.now() - 60_000);
+		const capturedAt = new Date(refreshedAt.getTime() - 5 * 60_000);
+		const identityVerifiedAt = new Date(refreshedAt.getTime() - 60 * 60_000);
+		const instanceUpdatedAt = new Date(refreshedAt.getTime() - 30 * 60_000);
 		const plexInstance = {
 			...instance("plex-1", "PLEX"),
 			expectedIdentity: "plex-machine",
 			identityKind: "PLEX_MACHINE_IDENTIFIER",
 			identityStatus: "VERIFIED",
-			identityVerifiedAt: new Date("2026-08-14T23:00:00.000Z"),
+			identityVerifiedAt,
 			connectionGeneration: 3,
 			identityGeneration: 7,
-			updatedAt: new Date("2026-08-14T23:30:00.000Z"),
+			updatedAt: instanceUpdatedAt,
 		};
 		const accepted = createSanitizedProviderEvidence(
 			["plex"],


### PR DESCRIPTION
## Summary

- derive provider retry evidence timestamps from the current test clock
- preserve the intended ordering between identity verification, instance update, accepted evidence, and refreshed evidence
- prevent the 24-hour production freshness check from making this test expire as wall-clock time advances

## Why

The fixture used absolute August 15 timestamps. Once those timestamps aged beyond the production freshness window, the unchanged test began failing locally and in CI, including on changes unrelated to Library Cleanup.

## Validation

- exact regression test: passed
- `media-server-rescan.test.ts`: 51 passed
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test`: shared 89 passed; web 651 passed; API 3,980 passed and 49 skipped
- `pnpm run lint`
- independent regression review: resolved
- independent data-safety review: resolved

This restores the stable baseline needed by #743.
