### PR TITLE
fix(trash-guides): preserve automatic sync authority

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/cache-manager-snapshot.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/cache-manager-snapshot.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { TrashCacheManager } from "../cache-manager.js";
+
+describe("TrashCacheManager snapshots", () => {
+	it("returns payload and provenance from the same cache row", async () => {
+		const findUnique = vi.fn().mockResolvedValue({
+			data: JSON.stringify([{ trash_id: "cf-1", name: "Test" }]),
+			commitHash: "verified:v1:TRaSH-Guides%2FGuides:0123456789abcdef0123456789abcdef01234567",
+		});
+		const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+		const manager = new TrashCacheManager(
+			{
+				trashCache: {
+					findUnique,
+					updateMany,
+				},
+			} as never,
+			{ compressionEnabled: false },
+		);
+
+		const snapshot = await manager.getSnapshot("RADARR", "CUSTOM_FORMATS");
+
+		expect(snapshot).toEqual({
+			data: [{ trash_id: "cf-1", name: "Test" }],
+			commitHash: "0123456789abcdef0123456789abcdef01234567",
+			provenance: {
+				version: 1,
+				repository: "TRaSH-Guides/Guides",
+				commitHash: "0123456789abcdef0123456789abcdef01234567",
+			},
+		});
+		expect(findUnique).toHaveBeenCalledTimes(1);
+		expect(updateMany).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not trust a legacy plain commit hash after restart", async () => {
+		const manager = new TrashCacheManager(
+			{
+				trashCache: {
+					findUnique: vi.fn().mockResolvedValue({
+						data: "[]",
+						commitHash: "0123456789abcdef0123456789abcdef01234567",
+					}),
+					updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+				},
+			} as never,
+			{ compressionEnabled: false },
+		);
+
+		await expect(manager.getSnapshot("RADARR", "CUSTOM_FORMATS")).resolves.toEqual({
+			data: [],
+			commitHash: null,
+			provenance: null,
+		});
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/github-fetcher.test.ts
@@ -70,15 +70,15 @@ describe("TrashGitHubFetcher URL construction (issue #406)", () => {
 		);
 		// 2nd & 3rd calls: per-file raw fetches. We return invalid bodies so
 		// validateAndCollect logs+drops them; this test only cares about URLs.
-		fetchSpy.mockResolvedValueOnce(buildJsonResponse({}));
-		fetchSpy.mockResolvedValueOnce(buildJsonResponse({}));
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([]));
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([]));
 
-		const fetcher = new TrashGitHubFetcher();
+		const fetcher = new TrashGitHubFetcher({ retries: 1 });
 		await fetcher.fetchCustomFormats("RADARR");
 
 		const calls = fetchSpy.mock.calls.map((call) => call[0] as string);
 		expect(calls[0]).toBe(
-			"https://api.github.com/repos/TRaSH-Guides/Guides/contents/docs/json/radarr/cf",
+			"https://api.github.com/repos/TRaSH-Guides/Guides/contents/docs/json/radarr/cf?ref=master",
 		);
 		expect(calls[1]).toBe(
 			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/docs/json/radarr/cf/1080p.json",
@@ -86,6 +86,66 @@ describe("TrashGitHubFetcher URL construction (issue #406)", () => {
 		expect(calls[2]).toBe(
 			"https://raw.githubusercontent.com/TRaSH-Guides/Guides/refs/heads/master/docs/json/radarr/cf/2160p.json",
 		);
+	});
+
+	it("fetches directory listings and payloads from the requested commit", async () => {
+		const commitHash = "0123456789abcdef0123456789abcdef01234567";
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([{ name: "1080p.json", type: "file" }]));
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([]));
+
+		const fetcher = new TrashGitHubFetcher();
+		await fetcher.fetchConfigsAtCommit("RADARR", "CUSTOM_FORMATS", commitHash);
+
+		const calls = fetchSpy.mock.calls.map((call) => call[0] as string);
+		expect(calls[0]).toBe(
+			`https://api.github.com/repos/TRaSH-Guides/Guides/contents/docs/json/radarr/cf?ref=${commitHash}`,
+		);
+		expect(calls[1]).toBe(
+			`https://raw.githubusercontent.com/TRaSH-Guides/Guides/${commitHash}/docs/json/radarr/cf/1080p.json`,
+		);
+	});
+
+	it("rejects a partial commit-addressed category", async () => {
+		const commitHash = "0123456789abcdef0123456789abcdef01234567";
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([{ name: "1080p.json", type: "file" }]));
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse({}, 500));
+
+		const fetcher = new TrashGitHubFetcher({ retries: 1 });
+		await expect(
+			fetcher.fetchConfigsAtCommit("RADARR", "CUSTOM_FORMATS", commitHash),
+		).rejects.toThrow("HTTP 500");
+	});
+
+	it("pins CF description discovery to the requested commit", async () => {
+		const commitHash = "0123456789abcdef0123456789abcdef01234567";
+		fetchSpy.mockResolvedValueOnce(buildJsonResponse([]));
+
+		const fetcher = new TrashGitHubFetcher();
+		await fetcher.fetchConfigsAtCommit("RADARR", "CF_DESCRIPTIONS", commitHash);
+
+		expect(fetchSpy.mock.calls[0]?.[0]).toBe(
+			`https://api.github.com/repos/TRaSH-Guides/Guides/contents/includes/cf-descriptions?ref=${commitHash}`,
+		);
+	});
+
+	it("fails closed for commit-addressed supplementary merges", async () => {
+		const fetcher = new TrashGitHubFetcher({
+			repoConfig: {
+				owner: "example",
+				name: "custom-guides",
+				branch: "main",
+				mode: "supplementary",
+			},
+		});
+
+		await expect(
+			fetcher.fetchConfigsAtCommit(
+				"RADARR",
+				"CUSTOM_FORMATS",
+				"0123456789abcdef0123456789abcdef01234567",
+			),
+		).rejects.toThrow("supplementary");
+		expect(fetchSpy).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/lib/trash-guides/__tests__/template-differ-provenance.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-differ-provenance.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+import { computeTemplateDiff } from "../template-differ.js";
+
+describe("template diff cache provenance", () => {
+	it("refreshes and rereads all preview payloads when one snapshot is not at the target", async () => {
+		const targetCommit = "0123456789abcdef0123456789abcdef01234567";
+		const repository = "trash-guides/guides";
+		const expectedProvenance = { version: 1 as const, repository, commitHash: targetCommit };
+		let readRound = 0;
+		const getSnapshot = vi.fn(async (_serviceType: string, configType: string) => {
+			if (configType === "CUSTOM_FORMATS") readRound++;
+			return {
+				data: [],
+				commitHash: configType === "QUALITY_PROFILES" && readRound === 1 ? "old" : targetCommit,
+				provenance:
+					configType === "QUALITY_PROFILES" && readRound === 1
+						? { ...expectedProvenance, commitHash: "old" }
+						: expectedProvenance,
+			};
+		});
+		const setVerified = vi.fn();
+		const fetchConfigsAtCommit = vi.fn().mockResolvedValue([]);
+
+		const result = await computeTemplateDiff(
+			{
+				id: "template-1",
+				name: "Template",
+				serviceType: "RADARR",
+				configData: JSON.stringify({ customFormats: [], customFormatGroups: [] }),
+				trashGuidesCommitHash: "old",
+				hasUserModifications: false,
+				changeLog: null,
+				sourceQualityProfileTrashId: null,
+			},
+			targetCommit,
+			{ getSnapshot, setVerified } as never,
+			{
+				getCommitProvenance: vi.fn().mockReturnValue(expectedProvenance),
+				fetchConfigsAtCommit,
+			} as never,
+		);
+
+		expect(result.latestCommit).toBe(targetCommit);
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
+		expect(fetchConfigsAtCommit).toHaveBeenCalledTimes(3);
+		expect(setVerified).toHaveBeenCalledTimes(3);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -16,6 +16,10 @@ const template = {
 	hasUserModifications: false,
 };
 
+function provenance(commitHash = "new") {
+	return { version: 1 as const, repository: "trash-guides/guides", commitHash };
+}
+
 function instance(id: string, baseUrl: string, enabled = true) {
 	return {
 		id,
@@ -595,10 +599,14 @@ describe("TemplateUpdater automation authority", () => {
 				}),
 			} as never,
 			{
-				get: vi.fn().mockResolvedValue([]),
-				getCommitHash: vi.fn().mockResolvedValue("new"),
+				getSnapshot: vi
+					.fn()
+					.mockResolvedValue({ data: [], commitHash: "new", provenance: provenance() }),
 			} as never,
-			{ fetchConfigs: vi.fn() } as never,
+			{
+				getCommitProvenance: vi.fn().mockReturnValue(provenance()),
+				fetchConfigs: vi.fn(),
+			} as never,
 		);
 
 		const result = await updater.syncTemplate(template.id, "new", template.userId, {
@@ -627,7 +635,7 @@ describe("TemplateUpdater automation authority", () => {
 			changeLog: null,
 		};
 		const update = vi.fn();
-		const fetchConfigs = vi.fn().mockRejectedValue(new Error("cache refresh unavailable"));
+		const fetchConfigsAtCommit = vi.fn().mockRejectedValue(new Error("cache refresh unavailable"));
 		const prisma = {
 			trashTemplate: {
 				findUnique: vi.fn().mockResolvedValue(storedTemplate),
@@ -648,11 +656,13 @@ describe("TemplateUpdater automation authority", () => {
 				}),
 			} as never,
 			{
-				get: vi.fn().mockResolvedValue([]),
-				getCommitHash: vi.fn().mockResolvedValue(null),
-				set: vi.fn(),
+				getSnapshot: vi.fn().mockResolvedValue({ data: [], commitHash: null, provenance: null }),
+				setVerified: vi.fn(),
 			} as never,
-			{ fetchConfigs } as never,
+			{
+				getCommitProvenance: vi.fn().mockReturnValue(provenance()),
+				fetchConfigsAtCommit,
+			} as never,
 		);
 
 		const result = await updater.syncTemplate(template.id, "new", template.userId, {
@@ -661,9 +671,114 @@ describe("TemplateUpdater automation authority", () => {
 
 		expect(result).toMatchObject({
 			success: false,
-			errors: [expect.stringContaining("Failed to refresh CUSTOM_FORMATS cache")],
+			errors: [expect.stringContaining("cache refresh unavailable")],
 		});
-		expect(fetchConfigs).toHaveBeenCalledWith("RADARR", "CUSTOM_FORMATS");
+		expect(fetchConfigsAtCommit).toHaveBeenCalled();
+		expect(update).not.toHaveBeenCalled();
+	});
+
+	it("rejects supplementary cache data before reading it", async () => {
+		const storedTemplate = {
+			...template,
+			serviceType: "RADARR",
+			sourceQualityProfileTrashId: "trash-profile",
+			trashGuidesCommitHash: null,
+			deletedAt: null,
+			changeLog: null,
+		};
+		const getSnapshot = vi.fn();
+		const updater = new TemplateUpdater(
+			{
+				trashTemplate: { findUnique: vi.fn().mockResolvedValue(storedTemplate) },
+				templateQualityProfileMapping: {
+					findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+				},
+			} as never,
+			{
+				getCommitInfo: vi.fn().mockResolvedValue({
+					commitHash: "0123456789abcdef0123456789abcdef01234567",
+				}),
+			} as never,
+			{ getSnapshot } as never,
+			{
+				getCommitProvenance: vi.fn(() => {
+					throw new Error("supplementary mode cannot provide one commit provenance");
+				}),
+			} as never,
+		);
+
+		const result = await updater.syncTemplate(
+			storedTemplate.id,
+			"0123456789abcdef0123456789abcdef01234567",
+			storedTemplate.userId,
+			{
+				expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(storedTemplate),
+			},
+		);
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("supplementary")],
+		});
+		expect(getSnapshot).not.toHaveBeenCalled();
+	});
+
+	it("binds automatic sync payloads to their cache commit snapshots", async () => {
+		const storedTemplate = {
+			...template,
+			serviceType: "RADARR",
+			sourceQualityProfileTrashId: "trash-profile",
+			trashGuidesCommitHash: null,
+			deletedAt: null,
+			changeLog: null,
+		};
+		const update = vi.fn();
+		const getCommitHash = vi.fn().mockResolvedValue("new");
+		const fetchConfigsAtCommit = vi.fn().mockRejectedValue(new Error("exact fetch unavailable"));
+		const set = vi.fn();
+		const getSnapshot = vi.fn(async (_serviceType: string, configType: string) => ({
+			data: [],
+			commitHash: configType === "CUSTOM_FORMATS" ? "old" : "new",
+			provenance: provenance(configType === "CUSTOM_FORMATS" ? "old" : "new"),
+		}));
+		const prisma = {
+			trashTemplate: {
+				findUnique: vi.fn().mockResolvedValue(storedTemplate),
+				update,
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+			},
+		};
+		const updater = new TemplateUpdater(
+			prisma as never,
+			{
+				getCommitInfo: vi.fn().mockResolvedValue({
+					commitHash: "new",
+					commitDate: "2026-08-16",
+					commitMessage: "update",
+					commitUrl: "https://example.com/commit/new",
+				}),
+			} as never,
+			{ getSnapshot, getCommitHash, set, setVerified: vi.fn() } as never,
+			{
+				getCommitProvenance: vi.fn().mockReturnValue(provenance()),
+				fetchConfigsAtCommit,
+			} as never,
+		);
+
+		const result = await updater.syncTemplate(template.id, "new", template.userId, {
+			expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(storedTemplate),
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("exact fetch unavailable")],
+		});
+		expect(getSnapshot).toHaveBeenCalledTimes(3);
+		expect(getCommitHash).not.toHaveBeenCalled();
+		expect(fetchConfigsAtCommit).toHaveBeenCalled();
+		expect(set).not.toHaveBeenCalled();
 		expect(update).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-authority.test.ts
@@ -553,6 +553,120 @@ describe("TemplateUpdater automation authority", () => {
 		expect(prisma.trashTemplate.update).not.toHaveBeenCalled();
 	});
 
+	it("blocks automatic sync when the last Auto mapping is revoked before persistence", async () => {
+		const storedTemplate = {
+			...template,
+			serviceType: "RADARR",
+			sourceQualityProfileTrashId: "trash-profile",
+			deletedAt: null,
+			changeLog: null,
+		};
+		const update = vi.fn();
+		const transactionUpdate = vi.fn();
+		const transaction = {
+			trashTemplate: {
+				findUnique: vi.fn().mockResolvedValue(storedTemplate),
+				update: transactionUpdate,
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue(null),
+			},
+		};
+		const prisma = {
+			trashTemplate: {
+				findUnique: vi.fn().mockResolvedValue(storedTemplate),
+				update,
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+			},
+			$transaction: vi.fn(async (action: (tx: typeof transaction) => Promise<unknown>) =>
+				action(transaction),
+			),
+		};
+		const updater = new TemplateUpdater(
+			prisma as never,
+			{
+				getCommitInfo: vi.fn().mockResolvedValue({
+					commitHash: "new",
+					commitDate: "2026-08-16",
+					commitMessage: "update",
+					commitUrl: "https://example.com/commit/new",
+				}),
+			} as never,
+			{
+				get: vi.fn().mockResolvedValue([]),
+				getCommitHash: vi.fn().mockResolvedValue("new"),
+			} as never,
+			{ fetchConfigs: vi.fn() } as never,
+		);
+
+		const result = await updater.syncTemplate(template.id, "new", template.userId, {
+			expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(storedTemplate),
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("no longer authorized")],
+		});
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+			timeout: 10000,
+		});
+		expect(update).not.toHaveBeenCalled();
+		expect(transactionUpdate).not.toHaveBeenCalled();
+	});
+
+	it("blocks null-commit recovery when cache commit provenance is unavailable", async () => {
+		const storedTemplate = {
+			...template,
+			serviceType: "RADARR",
+			sourceQualityProfileTrashId: "trash-profile",
+			trashGuidesCommitHash: null,
+			deletedAt: null,
+			changeLog: null,
+		};
+		const update = vi.fn();
+		const fetchConfigs = vi.fn().mockRejectedValue(new Error("cache refresh unavailable"));
+		const prisma = {
+			trashTemplate: {
+				findUnique: vi.fn().mockResolvedValue(storedTemplate),
+				update,
+			},
+			templateQualityProfileMapping: {
+				findFirst: vi.fn().mockResolvedValue({ id: "mapping-1" }),
+			},
+		};
+		const updater = new TemplateUpdater(
+			prisma as never,
+			{
+				getCommitInfo: vi.fn().mockResolvedValue({
+					commitHash: "new",
+					commitDate: "2026-08-16",
+					commitMessage: "update",
+					commitUrl: "https://example.com/commit/new",
+				}),
+			} as never,
+			{
+				get: vi.fn().mockResolvedValue([]),
+				getCommitHash: vi.fn().mockResolvedValue(null),
+				set: vi.fn(),
+			} as never,
+			{ fetchConfigs } as never,
+		);
+
+		const result = await updater.syncTemplate(template.id, "new", template.userId, {
+			expectedAutomationStateToken: createAutomationCatchUpTemplateStateToken(storedTemplate),
+		});
+
+		expect(result).toMatchObject({
+			success: false,
+			errors: [expect.stringContaining("Failed to refresh CUSTOM_FORMATS cache")],
+		});
+		expect(fetchConfigs).toHaveBeenCalledWith("RADARR", "CUSTOM_FORMATS");
+		expect(update).not.toHaveBeenCalled();
+	});
+
 	it("preserves an uncertain auto-deployment as needing review", async () => {
 		const target = instance("instance-1", "http://radarr:7878");
 		const { updater } = createUpdater([mapping(target)], {

--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-cache-provenance.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-cache-provenance.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { TemplateUpdater } from "../template-updater.js";
+
+describe("TemplateUpdater cache provenance", () => {
+	it("publishes cache entries only from the commit recorded with them", async () => {
+		const commitHash = "0123456789abcdef0123456789abcdef01234567";
+		const fetchConfigsAtCommit = vi.fn().mockResolvedValue([]);
+		const fetchConfigs = vi.fn();
+		const setVerified = vi.fn();
+		const expectedProvenance = {
+			version: 1 as const,
+			repository: "trash-guides/guides",
+			commitHash,
+		};
+		const updater = new TemplateUpdater(
+			{} as never,
+			{
+				getLatestCommit: vi.fn().mockResolvedValue({ commitHash }),
+			} as never,
+			{
+				getProvenance: vi.fn().mockResolvedValue({
+					...expectedProvenance,
+					commitHash: "old",
+				}),
+				setVerified,
+			} as never,
+			{
+				getCommitProvenance: vi.fn().mockReturnValue(expectedProvenance),
+				fetchConfigsAtCommit,
+				fetchConfigs,
+			} as never,
+		);
+
+		const result = await updater.refreshAllCaches("RADARR");
+
+		expect(result).toMatchObject({ refreshed: 6, failed: 0, errors: [] });
+		expect(fetchConfigsAtCommit).toHaveBeenCalledTimes(6);
+		expect(fetchConfigsAtCommit).toHaveBeenCalledWith("RADARR", "CUSTOM_FORMATS", commitHash);
+		expect(fetchConfigs).not.toHaveBeenCalled();
+		expect(setVerified).toHaveBeenCalledTimes(6);
+		for (const call of setVerified.mock.calls) {
+			expect(call[3]).toEqual(expectedProvenance);
+		}
+	});
+});

--- a/apps/api/src/lib/trash-guides/cache-manager.ts
+++ b/apps/api/src/lib/trash-guides/cache-manager.ts
@@ -97,6 +97,38 @@ interface CacheStats {
 	newestEntry?: Date;
 }
 
+export interface TrashCacheProvenance {
+	version: 1;
+	repository: string;
+	commitHash: string;
+}
+
+export interface TrashCacheSnapshot<T> {
+	data: T;
+	commitHash: string | null;
+	provenance: TrashCacheProvenance | null;
+}
+
+const VERIFIED_PROVENANCE_PREFIX = "verified:v1:";
+
+function encodeVerifiedProvenance(provenance: TrashCacheProvenance): string {
+	if (!provenance.repository || !/^[0-9a-f]{40}$/i.test(provenance.commitHash)) {
+		throw new Error("Verified TRaSH cache provenance requires a repository and full commit hash");
+	}
+	return `${VERIFIED_PROVENANCE_PREFIX}${encodeURIComponent(provenance.repository)}:${provenance.commitHash.toLowerCase()}`;
+}
+
+function decodeVerifiedProvenance(value: string | null): TrashCacheProvenance | null {
+	if (!value?.startsWith(VERIFIED_PROVENANCE_PREFIX)) return null;
+	const encoded = value.slice(VERIFIED_PROVENANCE_PREFIX.length);
+	const separatorIndex = encoded.lastIndexOf(":");
+	if (separatorIndex <= 0) return null;
+	const repository = decodeURIComponent(encoded.slice(0, separatorIndex));
+	const commitHash = encoded.slice(separatorIndex + 1);
+	if (!repository || !/^[0-9a-f]{40}$/i.test(commitHash)) return null;
+	return { version: 1, repository, commitHash: commitHash.toLowerCase() };
+}
+
 /** Thrown when a cache entry is corrupted and has been automatically cleaned up. */
 export class CacheCorruptionError extends Error {
 	readonly statusCode = 500;
@@ -132,6 +164,18 @@ export class TrashCacheManager {
 		configType: TrashConfigType,
 		schema?: z.ZodType<T>,
 	): Promise<T | null> {
+		const snapshot = await this.getSnapshot(serviceType, configType, schema);
+		return snapshot?.data ?? null;
+	}
+
+	/**
+	 * Get cached data and its source commit from the same database row.
+	 */
+	async getSnapshot<T = unknown>(
+		serviceType: "RADARR" | "SONARR",
+		configType: TrashConfigType,
+		schema?: z.ZodType<T>,
+	): Promise<TrashCacheSnapshot<T> | null> {
 		const cacheEntry = await this.prisma.trashCache.findUnique({
 			where: {
 				serviceType_configType: {
@@ -150,8 +194,13 @@ export class TrashCacheManager {
 
 		// Decompress and return data
 		try {
+			const provenance = decodeVerifiedProvenance(cacheEntry.commitHash);
 			if (this.options.compressionEnabled) {
-				return await decompressData<T>(cacheEntry.data, schema);
+				return {
+					data: await decompressData<T>(cacheEntry.data, schema),
+					commitHash: provenance?.commitHash ?? null,
+					provenance,
+				};
 			}
 
 			const parsed = safeJsonParse<T>(cacheEntry.data, {
@@ -163,7 +212,11 @@ export class TrashCacheManager {
 				await this.delete(serviceType, configType);
 				throw new CacheCorruptionError(serviceType, configType);
 			}
-			return parsed;
+			return {
+				data: parsed,
+				commitHash: provenance?.commitHash ?? null,
+				provenance,
+			};
 		} catch (error) {
 			if (error instanceof CacheCorruptionError) throw error;
 			// Handle decompression or parsing errors
@@ -230,6 +283,16 @@ export class TrashCacheManager {
 				lastCheckedAt: now,
 			},
 		});
+	}
+
+	/** Store cache data with durable, commit-addressed repository provenance. */
+	async setVerified<T = unknown>(
+		serviceType: "RADARR" | "SONARR",
+		configType: TrashConfigType,
+		data: T,
+		provenance: TrashCacheProvenance,
+	): Promise<void> {
+		await this.set(serviceType, configType, data, encodeVerifiedProvenance(provenance));
 	}
 
 	/**
@@ -513,6 +576,14 @@ export class TrashCacheManager {
 		serviceType: "RADARR" | "SONARR",
 		configType: TrashConfigType,
 	): Promise<string | null> {
+		return (await this.getProvenance(serviceType, configType))?.commitHash ?? null;
+	}
+
+	/** Get durable provenance without decompressing the cache payload. */
+	async getProvenance(
+		serviceType: "RADARR" | "SONARR",
+		configType: TrashConfigType,
+	): Promise<TrashCacheProvenance | null> {
 		const cacheEntry = await this.prisma.trashCache.findUnique({
 			where: {
 				serviceType_configType: {
@@ -525,7 +596,7 @@ export class TrashCacheManager {
 			},
 		});
 
-		return cacheEntry?.commitHash || null;
+		return decodeVerifiedProvenance(cacheEntry?.commitHash ?? null);
 	}
 }
 

--- a/apps/api/src/lib/trash-guides/github-fetcher.ts
+++ b/apps/api/src/lib/trash-guides/github-fetcher.ts
@@ -25,6 +25,7 @@ import { marked } from "marked";
 import { z } from "zod";
 import { loggers } from "../logger.js";
 import { parseUpstreamOrThrow, UpstreamValidationError } from "../validation/parse-upstream.js";
+import type { TrashCacheProvenance } from "./cache-manager.js";
 import {
 	radarrNamingSchema,
 	recordSchemaFingerprint,
@@ -239,6 +240,10 @@ interface FetchOptions {
 	 * Forks must follow the same directory structure as the official repo.
 	 */
 	repoConfig?: TrashRepoConfig;
+	/** Immutable commit used for commit-addressed cache population. */
+	contentRef?: string;
+	/** Reject partial categories instead of returning best-effort data. */
+	strictContent?: boolean;
 }
 
 /** Schema for TRaSH Guides metadata file */
@@ -484,6 +489,8 @@ export class TrashGitHubFetcher {
 	private cfDescriptionsBaseUrl: string;
 	private repoContentsApiUrl: string;
 	private rawBaseUrl: string;
+	private contentRef?: string;
+	private strictContent: boolean;
 
 	constructor(options: FetchOptions = {}) {
 		this.fetchOptions = options;
@@ -492,10 +499,13 @@ export class TrashGitHubFetcher {
 
 		// Build URLs from repo config (custom fork or official)
 		this.repoConfig = options.repoConfig ?? DEFAULT_TRASH_REPO;
+		this.contentRef = options.contentRef;
+		this.strictContent = options.strictContent ?? false;
 		const { owner, name, branch } = this.repoConfig;
 		// GitHub now requires the canonical `refs/heads/{branch}` path for raw content.
 		// The legacy `…/{branch}/…` form returns 404 for many repos (issue #406).
-		this.rawBaseUrl = `https://raw.githubusercontent.com/${owner}/${name}/refs/heads/${branch}`;
+		const rawRef = this.contentRef ?? `refs/heads/${branch}`;
+		this.rawBaseUrl = `https://raw.githubusercontent.com/${owner}/${name}/${rawRef}`;
 		this.baseUrl = `${this.rawBaseUrl}/docs/json`;
 		this.metadataUrl = `${this.rawBaseUrl}/metadata.json`;
 		this.cfDescriptionsBaseUrl = `${this.rawBaseUrl}/includes/cf-descriptions`;
@@ -568,17 +578,22 @@ export class TrashGitHubFetcher {
 				const url = `${baseUrl}/${file}`;
 				const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 
-				if (response.ok) {
-					const rawData: unknown = await response.json();
-					const result = validateAndCollect(rawData, trashCustomFormatSchema, file, this.log, {
-						integration: "trash-guides",
-						category: "customFormats",
-						skipFingerprint: true,
-					});
-					formats.push(...result.items);
-					recordValidationStats("customFormats", result.stats);
+				if (!response.ok) {
+					throw new Error(`Failed to fetch ${file}: HTTP ${response.status}`);
 				}
+				const rawData: unknown = await response.json();
+				const result = validateAndCollect(rawData, trashCustomFormatSchema, file, this.log, {
+					integration: "trash-guides",
+					category: "customFormats",
+					skipFingerprint: true,
+				});
+				if (this.strictContent && result.stats.rejected > 0) {
+					throw new Error(`${file} contained ${result.stats.rejected} invalid Custom Formats`);
+				}
+				formats.push(...result.items);
+				recordValidationStats("customFormats", result.stats);
 			} catch (error) {
+				if (this.strictContent) throw error;
 				this.log.warn({ err: error, file }, "Failed to fetch config file");
 				// Continue with other files
 			}
@@ -604,17 +619,22 @@ export class TrashGitHubFetcher {
 				const url = `${baseUrl}/${file}`;
 				const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 
-				if (response.ok) {
-					const rawData: unknown = await response.json();
-					const result = validateAndCollect(rawData, trashCustomFormatGroupSchema, file, this.log, {
-						integration: "trash-guides",
-						category: "customFormatGroups",
-						skipFingerprint: true,
-					});
-					groups.push(...result.items);
-					recordValidationStats("customFormatGroups", result.stats);
+				if (!response.ok) throw new Error(`Failed to fetch ${file}: HTTP ${response.status}`);
+				const rawData: unknown = await response.json();
+				const result = validateAndCollect(rawData, trashCustomFormatGroupSchema, file, this.log, {
+					integration: "trash-guides",
+					category: "customFormatGroups",
+					skipFingerprint: true,
+				});
+				if (this.strictContent && result.stats.rejected > 0) {
+					throw new Error(
+						`${file} contained ${result.stats.rejected} invalid Custom Format Groups`,
+					);
 				}
+				groups.push(...result.items);
+				recordValidationStats("customFormatGroups", result.stats);
 			} catch (error) {
+				if (this.strictContent) throw error;
 				this.log.warn({ err: error, file }, "Failed to fetch config file");
 			}
 		}
@@ -637,17 +657,20 @@ export class TrashGitHubFetcher {
 				const url = `${baseUrl}/${file}`;
 				const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 
-				if (response.ok) {
-					const rawData: unknown = await response.json();
-					const result = validateAndCollect(rawData, trashQualitySizeSchema, file, this.log, {
-						integration: "trash-guides",
-						category: "qualitySize",
-						skipFingerprint: true,
-					});
-					settings.push(...result.items);
-					recordValidationStats("qualitySize", result.stats);
+				if (!response.ok) throw new Error(`Failed to fetch ${file}: HTTP ${response.status}`);
+				const rawData: unknown = await response.json();
+				const result = validateAndCollect(rawData, trashQualitySizeSchema, file, this.log, {
+					integration: "trash-guides",
+					category: "qualitySize",
+					skipFingerprint: true,
+				});
+				if (this.strictContent && result.stats.rejected > 0) {
+					throw new Error(`${file} contained ${result.stats.rejected} invalid Quality Sizes`);
 				}
+				settings.push(...result.items);
+				recordValidationStats("qualitySize", result.stats);
 			} catch (error) {
+				if (this.strictContent) throw error;
 				this.log.warn({ err: error, file }, "Failed to fetch config file");
 			}
 		}
@@ -670,17 +693,20 @@ export class TrashGitHubFetcher {
 				const url = `${baseUrl}/${file}`;
 				const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 
-				if (response.ok) {
-					const rawData: unknown = await response.json();
-					const result = validateAndCollect(rawData, trashQualityProfileSchema, file, this.log, {
-						integration: "trash-guides",
-						category: "qualityProfiles",
-						skipFingerprint: true,
-					});
-					profiles.push(...result.items);
-					recordValidationStats("qualityProfiles", result.stats);
+				if (!response.ok) throw new Error(`Failed to fetch ${file}: HTTP ${response.status}`);
+				const rawData: unknown = await response.json();
+				const result = validateAndCollect(rawData, trashQualityProfileSchema, file, this.log, {
+					integration: "trash-guides",
+					category: "qualityProfiles",
+					skipFingerprint: true,
+				});
+				if (this.strictContent && result.stats.rejected > 0) {
+					throw new Error(`${file} contained ${result.stats.rejected} invalid Quality Profiles`);
 				}
+				profiles.push(...result.items);
+				recordValidationStats("qualityProfiles", result.stats);
 			} catch (error) {
+				if (this.strictContent) throw error;
 				this.log.warn({ err: error, file }, "Failed to fetch config file");
 			}
 		}
@@ -700,6 +726,9 @@ export class TrashGitHubFetcher {
 		try {
 			const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 			if (!response.ok) {
+				if (this.strictContent) {
+					throw new Error(`Failed to fetch quality profile groups: HTTP ${response.status}`);
+				}
 				this.log.warn(`Failed to fetch quality profile groups: ${response.status}`);
 				return [];
 			}
@@ -709,6 +738,7 @@ export class TrashGitHubFetcher {
 				category: "qualityProfileGroups",
 			}).items;
 		} catch (error) {
+			if (this.strictContent) throw error;
 			this.log.error("Error fetching quality profile groups:", error);
 			return [];
 		}
@@ -724,6 +754,9 @@ export class TrashGitHubFetcher {
 		try {
 			const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 			if (!response.ok) {
+				if (this.strictContent) {
+					throw new Error(`Failed to fetch CF conflicts: HTTP ${response.status}`);
+				}
 				this.log.warn(`Failed to fetch CF conflicts: ${response.status}`);
 				return [];
 			}
@@ -740,6 +773,7 @@ export class TrashGitHubFetcher {
 			return parsed.custom_formats;
 		} catch (error) {
 			if (error instanceof UpstreamValidationError) throw error;
+			if (this.strictContent) throw error;
 			this.log.error("Error fetching CF conflicts:", error);
 			return [];
 		}
@@ -802,6 +836,9 @@ export class TrashGitHubFetcher {
 			const response = await fetchWithRetry(url, this.fetchOptions, this.log);
 
 			if (!response.ok) {
+				if (this.strictContent) {
+					throw new Error(`CF description ${cfName} failed: HTTP ${response.status}`);
+				}
 				this.log.warn(`CF description not found: ${cfName}`);
 				return null;
 			}
@@ -840,6 +877,7 @@ export class TrashGitHubFetcher {
 				fetchedAt: new Date().toISOString(),
 			};
 		} catch (error) {
+			if (this.strictContent) throw error;
 			this.log.error({ err: error, cfName }, `Failed to fetch CF description for ${cfName}`);
 			return null;
 		}
@@ -850,12 +888,16 @@ export class TrashGitHubFetcher {
 	 */
 	async fetchAllCFDescriptions(): Promise<TrashCFDescription[]> {
 		// First, discover all markdown files in cf-descriptions directory
-		const apiUrl = `${this.repoContentsApiUrl}/includes/cf-descriptions`;
+		const ref = this.contentRef ?? this.repoConfig.branch;
+		const apiUrl = `${this.repoContentsApiUrl}/includes/cf-descriptions?ref=${encodeURIComponent(ref)}`;
 
 		try {
 			const response = await fetchWithRetry(apiUrl, { ...this.fetchOptions, retries: 2 }, this.log);
 
 			if (!response.ok) {
+				if (this.strictContent) {
+					throw new Error(`CF description listing failed: HTTP ${response.status}`);
+				}
 				this.log.warn(`GitHub API returned ${response.status} for CF descriptions`);
 				return [];
 			}
@@ -890,6 +932,7 @@ export class TrashGitHubFetcher {
 
 			return descriptions;
 		} catch (error) {
+			if (this.strictContent) throw error;
 			if (error instanceof UpstreamValidationError) {
 				this.log.warn(
 					{ integration: error.integration, issues: error.issues },
@@ -1030,6 +1073,54 @@ export class TrashGitHubFetcher {
 	}
 
 	/**
+	 * Fetch one config category from an immutable repository commit.
+	 * Supplementary mode combines two repositories and therefore cannot be
+	 * represented honestly by one commit hash, so it fails closed here.
+	 */
+	async fetchConfigsAtCommit(
+		serviceType: "RADARR" | "SONARR",
+		configType: TrashConfigType,
+		commitHash: string,
+	): Promise<unknown[]> {
+		this.getCommitProvenance(commitHash);
+		const supportedTypes: TrashConfigType[] = [
+			"CUSTOM_FORMATS",
+			"CF_GROUPS",
+			"QUALITY_SIZE",
+			"QUALITY_PROFILES",
+			"CF_DESCRIPTIONS",
+			"CONFLICTS",
+		];
+		if (!supportedTypes.includes(configType)) {
+			throw new Error(`Commit-addressed fetching is not supported for ${configType}`);
+		}
+
+		const commitFetcher = new TrashGitHubFetcher({
+			...this.fetchOptions,
+			repoConfig: this.repoConfig,
+			contentRef: commitHash,
+			strictContent: true,
+		});
+		return commitFetcher.fetchConfigsFromRepo(serviceType, configType);
+	}
+
+	getCommitProvenance(commitHash: string): TrashCacheProvenance {
+		if (!/^[0-9a-f]{40}$/i.test(commitHash)) {
+			throw new Error("Commit-addressed TRaSH fetch requires a full commit hash");
+		}
+		if (this.repoConfig.mode === "supplementary") {
+			throw new Error(
+				"Commit-addressed TRaSH fetch is unavailable in supplementary mode because one commit cannot identify both repositories",
+			);
+		}
+		return {
+			version: 1,
+			repository: `${this.repoConfig.owner}/${this.repoConfig.name}`.toLowerCase(),
+			commitHash: commitHash.toLowerCase(),
+		};
+	}
+
+	/**
 	 * Fetch configs from this fetcher's single repo (no merge logic).
 	 */
 	private async fetchConfigsFromRepo(
@@ -1064,22 +1155,23 @@ export class TrashGitHubFetcher {
 	 * Discover available config files in a directory using GitHub API
 	 */
 	private async discoverConfigFiles(baseUrl: string): Promise<string[]> {
-		// Extract the repo-relative path from the raw URL.
-		// baseUrl format: https://raw.githubusercontent.com/{owner}/{name}/refs/heads/{branch}/docs/json/{service}/{type}
-		const branchEscaped = this.repoConfig.branch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-		const pathMatch = baseUrl.match(new RegExp(`/refs/heads/${branchEscaped}/(.+)$`));
-		if (!pathMatch) {
+		const rawPrefix = `${this.rawBaseUrl}/`;
+		if (!baseUrl.startsWith(rawPrefix)) {
 			this.log.warn(`Could not extract path from URL: ${baseUrl}`);
 			return [];
 		}
 
-		const repoPath = pathMatch[1];
-		const apiUrl = `${this.repoContentsApiUrl}/${repoPath}`;
+		const repoPath = baseUrl.slice(rawPrefix.length);
+		const ref = this.contentRef ?? this.repoConfig.branch;
+		const apiUrl = `${this.repoContentsApiUrl}/${repoPath}?ref=${encodeURIComponent(ref)}`;
 
 		try {
 			const response = await fetchWithRetry(apiUrl, { ...this.fetchOptions, retries: 2 }, this.log);
 
 			if (!response.ok) {
+				if (this.strictContent) {
+					throw new Error(`GitHub directory listing failed: HTTP ${response.status}`);
+				}
 				this.log.warn(`GitHub API returned ${response.status} for ${apiUrl}`);
 				return [];
 			}
@@ -1096,11 +1188,15 @@ export class TrashGitHubFetcher {
 				.map((file) => file.name);
 
 			if (jsonFiles.length === 0) {
+				if (this.strictContent) {
+					throw new Error(`No JSON files discovered at ${baseUrl}`);
+				}
 				this.log.warn(`No JSON files discovered at ${baseUrl}`);
 			}
 
 			return jsonFiles;
 		} catch (error) {
+			if (this.strictContent) throw error;
 			if (error instanceof UpstreamValidationError) {
 				this.log.warn(
 					{ integration: error.integration, issues: error.issues },

--- a/apps/api/src/lib/trash-guides/template-differ.ts
+++ b/apps/api/src/lib/trash-guides/template-differ.ts
@@ -17,16 +17,25 @@ import type {
 	TemplateCustomFormatGroup,
 	TemplateDiffResult,
 	TemplateMigrationNotice,
-	TrashConfigType,
 	TrashCustomFormat,
 	TrashCustomFormatGroup,
 	TrashQualityProfile,
 } from "@arr/shared";
 import { dequal as deepEqual } from "dequal";
+import { z } from "zod";
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
-import type { TrashCacheManager } from "./cache-manager.js";
+import type {
+	TrashCacheManager,
+	TrashCacheProvenance,
+	TrashCacheSnapshot,
+} from "./cache-manager.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
+import {
+	trashCustomFormatGroupSchema,
+	trashCustomFormatSchema,
+	trashQualityProfileSchema,
+} from "./github-schemas.js";
 import { getMigrationNotices } from "./migration-notices.js";
 import {
 	getCurrentScore,
@@ -50,6 +59,10 @@ export interface DiffTemplateInput {
 	hasUserModifications: boolean;
 	changeLog: string | null;
 	sourceQualityProfileTrashId: string | null;
+}
+
+function snapshotFromVerified<T>(data: T, provenance: TrashCacheProvenance): TrashCacheSnapshot<T> {
+	return { data, commitHash: provenance.commitHash, provenance };
 }
 
 // ============================================================================
@@ -104,30 +117,81 @@ export async function computeTemplateDiff(
 		};
 	}
 
-	// Validate cache commit matches target; auto-refresh if stale
-	const cacheCommitHash = await cacheManager.getCommitHash(serviceType, "CUSTOM_FORMATS");
-	if (!cacheCommitHash || cacheCommitHash !== targetCommitHash) {
-		const requiredCacheTypes: TrashConfigType[] = [
-			"CUSTOM_FORMATS",
-			"CF_GROUPS",
-			"QUALITY_PROFILES",
-		];
+	const expectedProvenance = githubFetcher.getCommitProvenance(targetCommitHash);
+	const matchesExpected = (snapshot: TrashCacheSnapshot<unknown> | null) =>
+		snapshot?.provenance?.version === expectedProvenance.version &&
+		snapshot.provenance.repository === expectedProvenance.repository &&
+		snapshot.provenance.commitHash === expectedProvenance.commitHash;
 
-		for (const configType of requiredCacheTypes) {
-			try {
-				const data = await githubFetcher.fetchConfigs(serviceType, configType);
-				await cacheManager.set(serviceType, configType, data, targetCommitHash);
-			} catch (fetchError) {
-				const errorMsg = getErrorMessage(fetchError);
-				throw new Error(`Failed to refresh ${configType} cache for ${serviceType}: ${errorMsg}`);
-			}
+	let [customFormatsSnapshot, cfGroupsSnapshot, qualityProfilesSnapshot] = await Promise.all([
+		cacheManager.getSnapshot<TrashCustomFormat[]>(
+			serviceType,
+			"CUSTOM_FORMATS",
+			z.array(trashCustomFormatSchema),
+		),
+		cacheManager.getSnapshot<TrashCustomFormatGroup[]>(
+			serviceType,
+			"CF_GROUPS",
+			z.array(trashCustomFormatGroupSchema),
+		),
+		cacheManager.getSnapshot<TrashQualityProfile[]>(
+			serviceType,
+			"QUALITY_PROFILES",
+			z.array(trashQualityProfileSchema),
+		),
+	]);
+
+	if (
+		!customFormatsSnapshot ||
+		!cfGroupsSnapshot ||
+		!qualityProfilesSnapshot ||
+		!matchesExpected(customFormatsSnapshot) ||
+		!matchesExpected(cfGroupsSnapshot) ||
+		!matchesExpected(qualityProfilesSnapshot)
+	) {
+		try {
+			const [rawCustomFormats, rawGroups, rawQualityProfiles] = await Promise.all([
+				githubFetcher.fetchConfigsAtCommit(serviceType, "CUSTOM_FORMATS", targetCommitHash),
+				githubFetcher.fetchConfigsAtCommit(serviceType, "CF_GROUPS", targetCommitHash),
+				githubFetcher.fetchConfigsAtCommit(serviceType, "QUALITY_PROFILES", targetCommitHash),
+			]);
+			const customFormats = z.array(trashCustomFormatSchema).parse(rawCustomFormats);
+			const customFormatGroups = z.array(trashCustomFormatGroupSchema).parse(rawGroups);
+			const qualityProfiles = z.array(trashQualityProfileSchema).parse(rawQualityProfiles);
+			await Promise.all([
+				cacheManager.setVerified(serviceType, "CUSTOM_FORMATS", customFormats, expectedProvenance),
+				cacheManager.setVerified(serviceType, "CF_GROUPS", customFormatGroups, expectedProvenance),
+				cacheManager.setVerified(
+					serviceType,
+					"QUALITY_PROFILES",
+					qualityProfiles,
+					expectedProvenance,
+				),
+			]);
+			customFormatsSnapshot = snapshotFromVerified(customFormats, expectedProvenance);
+			cfGroupsSnapshot = snapshotFromVerified(customFormatGroups, expectedProvenance);
+			qualityProfilesSnapshot = snapshotFromVerified(qualityProfiles, expectedProvenance);
+		} catch (fetchError) {
+			throw new Error(
+				`Failed to refresh verified TRaSH cache for ${serviceType}: ${getErrorMessage(fetchError)}`,
+			);
 		}
 	}
 
-	// Get latest cache data for comparison
-	const customFormatsCache = await cacheManager.get(serviceType, "CUSTOM_FORMATS");
-	const cfGroupsCache = await cacheManager.get(serviceType, "CF_GROUPS");
-	const qualityProfilesCache = await cacheManager.get(serviceType, "QUALITY_PROFILES");
+	if (
+		!customFormatsSnapshot ||
+		!cfGroupsSnapshot ||
+		!qualityProfilesSnapshot ||
+		!matchesExpected(customFormatsSnapshot) ||
+		!matchesExpected(cfGroupsSnapshot) ||
+		!matchesExpected(qualityProfilesSnapshot)
+	) {
+		throw new Error(`TRaSH cache provenance could not be verified at ${targetCommitHash}`);
+	}
+
+	const customFormatsCache = customFormatsSnapshot.data;
+	const cfGroupsCache = cfGroupsSnapshot.data;
+	const qualityProfilesCache = qualityProfilesSnapshot.data;
 
 	// Parse template config — throw on corruption so callers get a clear error
 	// instead of silently returning an empty diff

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -25,7 +25,11 @@ import { z } from "zod";
 import type { PrismaClient } from "../../lib/prisma.js";
 import { ConflictError, TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
-import { CacheCorruptionError, type TrashCacheManager } from "./cache-manager.js";
+import {
+	CacheCorruptionError,
+	type TrashCacheManager,
+	type TrashCacheProvenance,
+} from "./cache-manager.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
 import {
 	assertEquivalentDeploymentMappingAuthority,
@@ -34,7 +38,11 @@ import {
 	createUpstreamResourceStateToken,
 } from "./deployment-target.js";
 import type { TrashGitHubFetcher } from "./github-fetcher.js";
-import { trashCustomFormatGroupSchema, trashCustomFormatSchema } from "./github-schemas.js";
+import {
+	trashCustomFormatGroupSchema,
+	trashCustomFormatSchema,
+	trashQualityProfileSchema,
+} from "./github-schemas.js";
 
 const log = loggers.trashGuides;
 
@@ -71,6 +79,29 @@ interface AutomationDeploymentOutcome {
 	success: boolean;
 	status: "SUCCESS" | "FAILED" | "UNCERTAIN";
 	errors: string[];
+}
+
+const REQUIRED_SYNC_CACHE_TYPES = ["CUSTOM_FORMATS", "CF_GROUPS", "QUALITY_PROFILES"] as const;
+type RequiredSyncCacheType = (typeof REQUIRED_SYNC_CACHE_TYPES)[number];
+
+interface TrashSyncDataResult {
+	success: boolean;
+	customFormats: TrashCustomFormat[];
+	customFormatGroups: TrashCustomFormatGroup[];
+	qualityProfiles: TrashQualityProfile[];
+	cacheProvenances: Record<RequiredSyncCacheType, TrashCacheProvenance | null>;
+	error?: string;
+}
+
+function sameCacheProvenance(
+	actual: TrashCacheProvenance | null,
+	expected: TrashCacheProvenance,
+): boolean {
+	return (
+		actual?.version === expected.version &&
+		actual.repository === expected.repository &&
+		actual.commitHash === expected.commitHash
+	);
 }
 
 // ============================================================================
@@ -540,6 +571,20 @@ export class TemplateUpdater {
 		const serviceType = template.serviceType as "RADARR" | "SONARR";
 
 		try {
+			let expectedProvenance: TrashCacheProvenance;
+			try {
+				expectedProvenance = this.githubFetcher.getCommitProvenance(targetCommit.commitHash);
+			} catch (provenanceError) {
+				return {
+					success: false,
+					templateId,
+					previousCommit,
+					newCommit: targetCommit.commitHash,
+					errors: [getErrorMessage(provenanceError)],
+					errorType: "sync_failed",
+				};
+			}
+
 			let currentConfig: TemplateConfig = {
 				customFormats: [],
 				customFormatGroups: [],
@@ -551,95 +596,21 @@ export class TemplateUpdater {
 			}
 
 			let fetchResult = await this.fetchLatestTrashData(serviceType);
+			const unverifiedCacheTypes = REQUIRED_SYNC_CACHE_TYPES.filter(
+				(configType) =>
+					!fetchResult.success ||
+					!sameCacheProvenance(fetchResult.cacheProvenances[configType], expectedProvenance),
+			);
+			if (!fetchResult.success || unverifiedCacheTypes.length > 0) {
+				fetchResult = await this.fetchTrashDataAtCommit(serviceType, expectedProvenance);
+			}
 			if (!fetchResult.success) {
 				return {
 					success: false,
 					templateId,
 					previousCommit,
 					newCommit: targetCommit.commitHash,
-					errors: [`Failed to fetch TRaSH data: ${fetchResult.error}`],
-					errorType: "sync_failed",
-				};
-			}
-
-			const requiredCacheTypes: TrashConfigType[] = [
-				"CUSTOM_FORMATS",
-				"CF_GROUPS",
-				"QUALITY_PROFILES",
-			];
-			const readRequiredCacheCommits = async () =>
-				new Map(
-					await Promise.all(
-						requiredCacheTypes.map(
-							async (configType) =>
-								[
-									configType,
-									await this.cacheManager.getCommitHash(serviceType, configType),
-								] as const,
-						),
-					),
-				);
-			let requiredCacheCommits = await readRequiredCacheCommits();
-			if (
-				requiredCacheTypes.some(
-					(configType) => requiredCacheCommits.get(configType) !== targetCommit.commitHash,
-				)
-			) {
-				log.info(
-					{
-						cacheCommits: Object.fromEntries(requiredCacheCommits),
-						targetCommit: targetCommit.commitHash,
-						templateId,
-						serviceType,
-					},
-					"Cache provenance mismatch — auto-refreshing cache",
-				);
-
-				for (const configType of requiredCacheTypes) {
-					try {
-						const data = await this.githubFetcher.fetchConfigs(serviceType, configType);
-						await this.cacheManager.set(serviceType, configType, data, targetCommit.commitHash);
-					} catch (fetchError) {
-						return {
-							success: false,
-							templateId,
-							previousCommit,
-							newCommit: targetCommit.commitHash,
-							errors: [
-								`Failed to refresh ${configType} cache for ${serviceType}: ${getErrorMessage(fetchError)}`,
-							],
-							errorType: "sync_failed" as const,
-						};
-					}
-				}
-
-				fetchResult = await this.fetchLatestTrashData(serviceType);
-				if (!fetchResult.success) {
-					return {
-						success: false,
-						templateId,
-						previousCommit,
-						newCommit: targetCommit.commitHash,
-						errors: [`Failed to fetch TRaSH data after cache refresh: ${fetchResult.error}`],
-						errorType: "sync_failed",
-					};
-				}
-
-				requiredCacheCommits = await readRequiredCacheCommits();
-			}
-
-			const unverifiedCacheTypes = requiredCacheTypes.filter(
-				(configType) => requiredCacheCommits.get(configType) !== targetCommit.commitHash,
-			);
-			if (unverifiedCacheTypes.length > 0) {
-				return {
-					success: false,
-					templateId,
-					previousCommit,
-					newCommit: targetCommit.commitHash,
-					errors: [
-						`TRaSH cache provenance could not be verified for ${unverifiedCacheTypes.join(", ")} at commit ${targetCommit.commitHash}.`,
-					],
+					errors: [`Failed to fetch verified TRaSH data: ${fetchResult.error}`],
 					errorType: "sync_failed",
 				};
 			}
@@ -650,9 +621,7 @@ export class TemplateUpdater {
 
 			const qualityProfileCFIds = new Set<string>();
 			if (options?.includeQualityProfileCFs && template.sourceQualityProfileTrashId) {
-				const qualityProfilesCache = await this.cacheManager.get(serviceType, "QUALITY_PROFILES");
-				const qualityProfilesData = (qualityProfilesCache as TrashQualityProfile[] | null) ?? [];
-				const linkedProfile = qualityProfilesData.find(
+				const linkedProfile = fetchResult.qualityProfiles.find(
 					(p) => p.trash_id === template.sourceQualityProfileTrashId,
 				);
 
@@ -884,50 +853,120 @@ export class TemplateUpdater {
 	 * Fetch latest TRaSH Guides custom formats and groups from cache
 	 * @private
 	 */
-	private async fetchLatestTrashData(serviceType: "RADARR" | "SONARR"): Promise<{
-		success: boolean;
-		customFormats: TrashCustomFormat[];
-		customFormatGroups: TrashCustomFormatGroup[];
-		cacheCommitHash: string | null;
-		error?: string;
-	}> {
+	private async fetchLatestTrashData(
+		serviceType: "RADARR" | "SONARR",
+	): Promise<TrashSyncDataResult> {
 		try {
-			const [cfCache, groupCache, cacheCommitHash] = await Promise.all([
-				this.cacheManager.get<TrashCustomFormat[]>(
+			const [cfSnapshot, groupSnapshot, qualityProfileSnapshot] = await Promise.all([
+				this.cacheManager.getSnapshot<TrashCustomFormat[]>(
 					serviceType,
 					"CUSTOM_FORMATS",
 					z.array(trashCustomFormatSchema),
 				),
-				this.cacheManager.get<TrashCustomFormatGroup[]>(
+				this.cacheManager.getSnapshot<TrashCustomFormatGroup[]>(
 					serviceType,
 					"CF_GROUPS",
 					z.array(trashCustomFormatGroupSchema),
 				),
-				this.cacheManager.getCommitHash(serviceType, "CUSTOM_FORMATS"),
+				this.cacheManager.getSnapshot<TrashQualityProfile[]>(
+					serviceType,
+					"QUALITY_PROFILES",
+					z.array(trashQualityProfileSchema),
+				),
 			]);
 
-			if (cfCache == null || groupCache == null) {
+			if (cfSnapshot == null || groupSnapshot == null || qualityProfileSnapshot == null) {
 				return {
 					success: false,
 					customFormats: [],
 					customFormatGroups: [],
-					cacheCommitHash: null,
-					error: "TRaSH cache miss: CUSTOM_FORMATS or CF_GROUPS not ready",
+					qualityProfiles: [],
+					cacheProvenances: {
+						CUSTOM_FORMATS: null,
+						CF_GROUPS: null,
+						QUALITY_PROFILES: null,
+					},
+					error: "TRaSH cache miss: required sync data is not ready",
 				};
 			}
 
 			return {
 				success: true,
-				customFormats: cfCache,
-				customFormatGroups: groupCache,
-				cacheCommitHash,
+				customFormats: cfSnapshot.data,
+				customFormatGroups: groupSnapshot.data,
+				qualityProfiles: qualityProfileSnapshot.data,
+				cacheProvenances: {
+					CUSTOM_FORMATS: cfSnapshot.provenance,
+					CF_GROUPS: groupSnapshot.provenance,
+					QUALITY_PROFILES: qualityProfileSnapshot.provenance,
+				},
 			};
 		} catch (error) {
 			return {
 				success: false,
 				customFormats: [],
 				customFormatGroups: [],
-				cacheCommitHash: null,
+				qualityProfiles: [],
+				cacheProvenances: {
+					CUSTOM_FORMATS: null,
+					CF_GROUPS: null,
+					QUALITY_PROFILES: null,
+				},
+				error: getErrorMessage(error),
+			};
+		}
+	}
+
+	private async fetchTrashDataAtCommit(
+		serviceType: "RADARR" | "SONARR",
+		provenance: TrashCacheProvenance,
+	): Promise<TrashSyncDataResult> {
+		try {
+			const [rawCustomFormats, rawGroups, rawQualityProfiles] = await Promise.all([
+				this.githubFetcher.fetchConfigsAtCommit(
+					serviceType,
+					"CUSTOM_FORMATS",
+					provenance.commitHash,
+				),
+				this.githubFetcher.fetchConfigsAtCommit(serviceType, "CF_GROUPS", provenance.commitHash),
+				this.githubFetcher.fetchConfigsAtCommit(
+					serviceType,
+					"QUALITY_PROFILES",
+					provenance.commitHash,
+				),
+			]);
+			const customFormats = z.array(trashCustomFormatSchema).parse(rawCustomFormats);
+			const customFormatGroups = z.array(trashCustomFormatGroupSchema).parse(rawGroups);
+			const qualityProfiles = z.array(trashQualityProfileSchema).parse(rawQualityProfiles);
+
+			await Promise.all([
+				this.cacheManager.setVerified(serviceType, "CUSTOM_FORMATS", customFormats, provenance),
+				this.cacheManager.setVerified(serviceType, "CF_GROUPS", customFormatGroups, provenance),
+				this.cacheManager.setVerified(serviceType, "QUALITY_PROFILES", qualityProfiles, provenance),
+			]);
+
+			return {
+				success: true,
+				customFormats,
+				customFormatGroups,
+				qualityProfiles,
+				cacheProvenances: {
+					CUSTOM_FORMATS: provenance,
+					CF_GROUPS: provenance,
+					QUALITY_PROFILES: provenance,
+				},
+			};
+		} catch (error) {
+			return {
+				success: false,
+				customFormats: [],
+				customFormatGroups: [],
+				qualityProfiles: [],
+				cacheProvenances: {
+					CUSTOM_FORMATS: null,
+					CF_GROUPS: null,
+					QUALITY_PROFILES: null,
+				},
 				error: getErrorMessage(error),
 			};
 		}
@@ -1415,8 +1454,9 @@ export class TemplateUpdater {
 	): Promise<{ needsUpdate: boolean; error?: string }> {
 		try {
 			const latestCommit = await this.versionTracker.getLatestCommit();
-			const currentCommitHash = await this.cacheManager.getCommitHash(serviceType, configType);
-			const needsUpdate = currentCommitHash !== latestCommit.commitHash;
+			const expectedProvenance = this.githubFetcher.getCommitProvenance(latestCommit.commitHash);
+			const currentProvenance = await this.cacheManager.getProvenance(serviceType, configType);
+			const needsUpdate = !sameCacheProvenance(currentProvenance, expectedProvenance);
 			return { needsUpdate };
 		} catch (error) {
 			return {
@@ -1449,25 +1489,31 @@ export class TemplateUpdater {
 		const errors: string[] = [];
 
 		let latestCommit: VersionInfo;
+		let expectedProvenance: TrashCacheProvenance;
 		try {
 			latestCommit = await this.versionTracker.getLatestCommit();
+			expectedProvenance = this.githubFetcher.getCommitProvenance(latestCommit.commitHash);
 		} catch (error) {
-			const errorMsg = `[TemplateUpdater] Failed to fetch latest commit: ${getErrorMessage(error)}`;
+			const errorMsg = `[TemplateUpdater] Failed to establish commit provenance: ${getErrorMessage(error)}`;
 			errors.push(errorMsg);
 			return { refreshed: 0, failed: configTypes.length, errors };
 		}
 
 		for (const configType of configTypes) {
 			try {
-				const currentCommitHash = await this.cacheManager.getCommitHash(serviceType, configType);
+				const currentProvenance = await this.cacheManager.getProvenance(serviceType, configType);
 
-				if (currentCommitHash === latestCommit.commitHash) {
+				if (sameCacheProvenance(currentProvenance, expectedProvenance)) {
 					await this.cacheManager.touchCache(serviceType, configType);
 					continue;
 				}
 
-				const data = await this.githubFetcher.fetchConfigs(serviceType, configType);
-				await this.cacheManager.set(serviceType, configType, data, latestCommit.commitHash);
+				const data = await this.githubFetcher.fetchConfigsAtCommit(
+					serviceType,
+					configType,
+					latestCommit.commitHash,
+				);
+				await this.cacheManager.setVerified(serviceType, configType, data, expectedProvenance);
 
 				refreshed++;
 			} catch (error) {

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -23,7 +23,7 @@ import type {
 } from "@arr/shared";
 import { z } from "zod";
 import type { PrismaClient } from "../../lib/prisma.js";
-import { TemplateNotFoundError } from "../errors.js";
+import { ConflictError, TemplateNotFoundError } from "../errors.js";
 import { loggers } from "../logger.js";
 import { CacheCorruptionError, type TrashCacheManager } from "./cache-manager.js";
 import type { DeploymentExecutorService } from "./deployment-executor.js";
@@ -562,22 +562,38 @@ export class TemplateUpdater {
 				};
 			}
 
-			if (fetchResult.cacheCommitHash && fetchResult.cacheCommitHash !== targetCommit.commitHash) {
+			const requiredCacheTypes: TrashConfigType[] = [
+				"CUSTOM_FORMATS",
+				"CF_GROUPS",
+				"QUALITY_PROFILES",
+			];
+			const readRequiredCacheCommits = async () =>
+				new Map(
+					await Promise.all(
+						requiredCacheTypes.map(
+							async (configType) =>
+								[
+									configType,
+									await this.cacheManager.getCommitHash(serviceType, configType),
+								] as const,
+						),
+					),
+				);
+			let requiredCacheCommits = await readRequiredCacheCommits();
+			if (
+				requiredCacheTypes.some(
+					(configType) => requiredCacheCommits.get(configType) !== targetCommit.commitHash,
+				)
+			) {
 				log.info(
 					{
-						cacheCommit: fetchResult.cacheCommitHash,
+						cacheCommits: Object.fromEntries(requiredCacheCommits),
 						targetCommit: targetCommit.commitHash,
 						templateId,
 						serviceType,
 					},
-					"Cache/version mismatch — auto-refreshing cache",
+					"Cache provenance mismatch — auto-refreshing cache",
 				);
-
-				const requiredCacheTypes: TrashConfigType[] = [
-					"CUSTOM_FORMATS",
-					"CF_GROUPS",
-					"QUALITY_PROFILES",
-				];
 
 				for (const configType of requiredCacheTypes) {
 					try {
@@ -608,6 +624,24 @@ export class TemplateUpdater {
 						errorType: "sync_failed",
 					};
 				}
+
+				requiredCacheCommits = await readRequiredCacheCommits();
+			}
+
+			const unverifiedCacheTypes = requiredCacheTypes.filter(
+				(configType) => requiredCacheCommits.get(configType) !== targetCommit.commitHash,
+			);
+			if (unverifiedCacheTypes.length > 0) {
+				return {
+					success: false,
+					templateId,
+					previousCommit,
+					newCommit: targetCommit.commitHash,
+					errors: [
+						`TRaSH cache provenance could not be verified for ${unverifiedCacheTypes.join(", ")} at commit ${targetCommit.commitHash}.`,
+					],
+					errorType: "sync_failed",
+				};
 			}
 
 			const currentCFTrashIds = new Set(
@@ -765,15 +799,50 @@ export class TemplateUpdater {
 
 			const syncedAt = new Date();
 			const syncedConfigData = JSON.stringify(mergeResult.mergedConfig);
-			await this.prisma.trashTemplate.update({
-				where: { id: templateId },
-				data: {
-					changeLog: JSON.stringify(updatedChangeLog),
-					configData: syncedConfigData,
-					trashGuidesCommitHash: targetCommit.commitHash,
-					lastSyncedAt: syncedAt,
-				},
-			});
+			const updateData = {
+				changeLog: JSON.stringify(updatedChangeLog),
+				configData: syncedConfigData,
+				trashGuidesCommitHash: targetCommit.commitHash,
+				lastSyncedAt: syncedAt,
+			};
+			if (options?.expectedAutomationStateToken) {
+				await this.prisma.$transaction(
+					async (transaction) => {
+						const [liveTemplate, autoMapping] = await Promise.all([
+							transaction.trashTemplate.findUnique({ where: { id: templateId } }),
+							transaction.templateQualityProfileMapping.findFirst({
+								where: { templateId, syncStrategy: "auto" },
+								select: { id: true },
+							}),
+						]);
+						if (
+							!liveTemplate ||
+							!userId ||
+							liveTemplate.userId !== userId ||
+							liveTemplate.deletedAt ||
+							liveTemplate.hasUserModifications ||
+							(!liveTemplate.trashGuidesCommitHash && !liveTemplate.sourceQualityProfileTrashId) ||
+							!autoMapping ||
+							createAutomationCatchUpTemplateStateToken(liveTemplate) !==
+								options.expectedAutomationStateToken
+						) {
+							throw new ConflictError(
+								"Automatic sync is no longer authorized because the template or Auto mapping changed after selection.",
+							);
+						}
+						await transaction.trashTemplate.update({
+							where: { id: templateId },
+							data: updateData,
+						});
+					},
+					{ isolationLevel: "Serializable", timeout: 10000 },
+				);
+			} else {
+				await this.prisma.trashTemplate.update({
+					where: { id: templateId },
+					data: updateData,
+				});
+			}
 
 			const metricsResult = completeMetrics();
 			metricsResult.recordSuccess();


### PR DESCRIPTION
## Summary

- bind CUSTOM_FORMATS, CF_GROUPS, and QUALITY_PROFILES payloads to durable repository-and-commit provenance from the same cache rows
- exact-refresh missing, legacy, or mismatched cache generations and consume the returned immutable payloads in both preview and execution
- reject partial commit-addressed fetches and pin both raw files and GitHub directory listings to the requested commit
- recheck the live template and Auto mapping in the same serializable transaction that persists an automatic sync
- fail closed before reading supplementary-mode cache data because one commit cannot identify both source repositories

## Why this follow-up

PR #743 restored stalled automatic sync and null-commit recovery. The bounded safety review and the hosted review on this PR found remaining provenance and execution-authority gaps: payloads could be mixed with later cache hashes, branch HEAD could be labeled as a requested historical commit, legacy rows could remain falsely trusted after restart, and preview could differ from execution. This follow-up closes that single trust boundary before the fix is forward-ported to next.

## Validation

- pnpm run format
- pnpm --filter @arr/shared build
- pnpm --filter @arr/api db:generate
- pnpm run typecheck
- pnpm run test
- pnpm run lint
- pnpm run build
- focused provenance, strict-fetch, preview, and automation-authority tests: 39 passed
- shared: 89 passed
- web: 651 passed
- API: 3997 passed, 49 skipped
- live immutable TRaSH raw-content and Contents API smoke checks: HTTP 200
- independent regression reviewer: all three recorded findings resolved
- independent data-safety reviewer: both recorded findings resolved

Related to #674