### PR TITLE
fix(trash-guides): bind quality-size automation to verified data

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/template-updater-cache-provenance.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/template-updater-cache-provenance.test.ts
@@ -18,6 +18,7 @@ describe("TemplateUpdater cache provenance", () => {
 				getLatestCommit: vi.fn().mockResolvedValue({ commitHash }),
 			} as never,
 			{
+				getSnapshot: vi.fn().mockResolvedValue(null),
 				getProvenance: vi.fn().mockResolvedValue({
 					...expectedProvenance,
 					commitHash: "old",

--- a/apps/api/src/lib/trash-guides/__tests__/update-scheduler-cache-provenance.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/update-scheduler-cache-provenance.test.ts
@@ -1,0 +1,169 @@
+import type { TrashQualitySize } from "@arr/shared";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ cacheGet: vi.fn() }));
+
+vi.mock("../cache-manager.js", () => ({
+	createCacheManager: vi.fn(() => ({ get: mocks.cacheGet })),
+}));
+
+import { UpdateScheduler } from "../update-scheduler.js";
+
+const radarrInstance = {
+	id: "instance-1",
+	userId: "user-1",
+	service: "RADARR",
+	label: "Radarr",
+	enabled: true,
+};
+
+function createHarness(instance = radarrInstance, liveInstance = instance) {
+	const prisma = {
+		qualitySizeMapping: {
+			count: vi.fn().mockResolvedValue(1),
+			findMany: vi.fn().mockResolvedValue([
+				{
+					id: "quality-size-1",
+					instanceId: instance.id,
+					serviceType: "RADARR",
+					presetTrashId: "preset-1",
+					appliedDataHash: "stale",
+					syncStrategy: "auto",
+					instance,
+				},
+			]),
+			update: vi.fn(),
+		},
+		serviceInstance: {
+			findFirst: vi.fn().mockResolvedValue(liveInstance),
+		},
+	};
+	const rawRequest = vi.fn().mockResolvedValue({ ok: true });
+	const updateAll = vi.fn().mockResolvedValue(undefined);
+	const create = vi.fn().mockReturnValue({
+		qualityDefinition: {
+			getAll: vi.fn().mockResolvedValue([]),
+			updateAll,
+		},
+	});
+	const scheduler = new UpdateScheduler(
+		{ enabled: true, intervalHours: 12 },
+		{} as never,
+		{} as never,
+		prisma as never,
+		{ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+		{ rawRequest, create } as never,
+	) as unknown as {
+		processQualitySizeSync: (
+			verifiedData: ReadonlyMap<"RADARR" | "SONARR", readonly TrashQualitySize[]>,
+		) => Promise<{ autoSynced: number; errors: string[] }>;
+	};
+
+	return { scheduler, prisma, rawRequest, create, updateAll };
+}
+
+describe("TRaSH scheduler cache provenance", () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it("does not read retained quality-size data when the tick did not verify its provenance", async () => {
+		const harness = createHarness();
+		mocks.cacheGet.mockResolvedValue([{ trash_id: "preset-1", qualities: [] }]);
+
+		const result = await harness.scheduler.processQualitySizeSync(new Map());
+
+		expect(result.autoSynced).toBe(0);
+		expect(mocks.cacheGet).not.toHaveBeenCalled();
+		expect(harness.rawRequest).not.toHaveBeenCalled();
+		expect(harness.create).not.toHaveBeenCalled();
+	});
+
+	it("executes with the verified payload even if the shared cache is replaced", async () => {
+		const harness = createHarness();
+		const verifiedData: TrashQualitySize[] = [
+			{ trash_id: "preset-1", type: "movie", qualities: [] },
+		];
+		mocks.cacheGet.mockResolvedValue([
+			{ trash_id: "replacement", qualities: [{ quality: "wrong", min: 1, max: 2 }] },
+		]);
+
+		const result = await harness.scheduler.processQualitySizeSync(
+			new Map([["RADARR", verifiedData]]),
+		);
+
+		expect(result.autoSynced).toBe(1);
+		expect(mocks.cacheGet).not.toHaveBeenCalled();
+		expect(harness.rawRequest).toHaveBeenCalledTimes(1);
+		expect(harness.updateAll).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects a stale mapping whose service type no longer matches the live instance", async () => {
+		const harness = createHarness(radarrInstance, { ...radarrInstance, service: "SONARR" });
+		const verifiedData: TrashQualitySize[] = [
+			{ trash_id: "preset-1", type: "movie", qualities: [] },
+		];
+
+		const result = await harness.scheduler.processQualitySizeSync(
+			new Map([["RADARR", verifiedData]]),
+		);
+
+		expect(result.autoSynced).toBe(0);
+		expect(result.errors[0]).toContain("service type changed");
+		expect(harness.rawRequest).not.toHaveBeenCalled();
+		expect(harness.create).not.toHaveBeenCalled();
+	});
+
+	it("authorizes only the service whose quality-size payload was verified", async () => {
+		const sonarrData: TrashQualitySize[] = [
+			{ trash_id: "sonarr-preset", type: "series", qualities: [] },
+		];
+		const templateUpdater = {
+			refreshAllCaches: vi.fn(async (serviceType: "RADARR" | "SONARR") => ({
+				refreshed: serviceType === "SONARR" ? 1 : 0,
+				failed: serviceType === "RADARR" ? 1 : 0,
+				errors: serviceType === "RADARR" ? ["QUALITY_SIZE: unavailable"] : [],
+				verifiedConfigTypes: serviceType === "SONARR" ? ["QUALITY_SIZE"] : [],
+				verifiedQualitySizeData: serviceType === "SONARR" ? sonarrData : null,
+			})),
+			checkForUpdates: vi.fn().mockResolvedValue({
+				totalTemplates: 0,
+				outdatedTemplates: 0,
+				templatesWithUpdates: [],
+			}),
+		};
+		const scheduler = new UpdateScheduler(
+			{ enabled: true, intervalHours: 12 },
+			templateUpdater as never,
+			{
+				getLatestCommit: vi.fn().mockResolvedValue({ commitHash: "latest", commitDate: "today" }),
+			} as never,
+			{
+				trashTemplate: {
+					count: vi.fn().mockResolvedValue(0),
+					findMany: vi.fn().mockResolvedValue([]),
+				},
+			} as never,
+			{ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+		);
+		const privateScheduler = scheduler as unknown as {
+			processQualitySizeSync: (
+				verifiedData: ReadonlyMap<"RADARR" | "SONARR", readonly TrashQualitySize[]>,
+			) => Promise<unknown>;
+			processNamingSync: () => Promise<unknown>;
+		};
+		const qualitySizeSpy = vi
+			.spyOn(privateScheduler, "processQualitySizeSync")
+			.mockResolvedValue({ autoSynced: 0, updatesPending: 0, errors: [] });
+		vi.spyOn(privateScheduler, "processNamingSync").mockResolvedValue({
+			autoSynced: 0,
+			updatesPending: 0,
+			errors: [],
+		});
+
+		await scheduler.triggerCheck();
+
+		expect(qualitySizeSpy).toHaveBeenCalledTimes(1);
+		const verifiedData = qualitySizeSpy.mock.calls[0]?.[0];
+		expect(verifiedData?.has("RADARR")).toBe(false);
+		expect(verifiedData?.get("SONARR")).toBe(sonarrData);
+	});
+});

--- a/apps/api/src/lib/trash-guides/template-updater.ts
+++ b/apps/api/src/lib/trash-guides/template-updater.ts
@@ -20,6 +20,7 @@ import type {
 	TrashCustomFormat,
 	TrashCustomFormatGroup,
 	TrashQualityProfile,
+	TrashQualitySize,
 } from "@arr/shared";
 import { z } from "zod";
 import type { PrismaClient } from "../../lib/prisma.js";
@@ -42,6 +43,7 @@ import {
 	trashCustomFormatGroupSchema,
 	trashCustomFormatSchema,
 	trashQualityProfileSchema,
+	trashQualitySizeSchema,
 } from "./github-schemas.js";
 
 const log = loggers.trashGuides;
@@ -1474,6 +1476,8 @@ export class TemplateUpdater {
 		refreshed: number;
 		failed: number;
 		errors: string[];
+		verifiedConfigTypes: TrashConfigType[];
+		verifiedQualitySizeData: TrashQualitySize[] | null;
 	}> {
 		const configTypes: TrashConfigType[] = [
 			"CUSTOM_FORMATS",
@@ -1487,6 +1491,8 @@ export class TemplateUpdater {
 		let refreshed = 0;
 		let failed = 0;
 		const errors: string[] = [];
+		const verifiedConfigTypes: TrashConfigType[] = [];
+		let verifiedQualitySizeData: TrashQualitySize[] | null = null;
 
 		let latestCommit: VersionInfo;
 		let expectedProvenance: TrashCacheProvenance;
@@ -1496,15 +1502,50 @@ export class TemplateUpdater {
 		} catch (error) {
 			const errorMsg = `[TemplateUpdater] Failed to establish commit provenance: ${getErrorMessage(error)}`;
 			errors.push(errorMsg);
-			return { refreshed: 0, failed: configTypes.length, errors };
+			return {
+				refreshed: 0,
+				failed: configTypes.length,
+				errors,
+				verifiedConfigTypes,
+				verifiedQualitySizeData,
+			};
 		}
 
 		for (const configType of configTypes) {
 			try {
+				if (configType === "QUALITY_SIZE") {
+					const snapshot = await this.cacheManager.getSnapshot<TrashQualitySize[]>(
+						serviceType,
+						configType,
+						z.array(trashQualitySizeSchema),
+					);
+					if (sameCacheProvenance(snapshot?.provenance ?? null, expectedProvenance)) {
+						verifiedQualitySizeData = snapshot!.data;
+						verifiedConfigTypes.push(configType);
+						continue;
+					}
+
+					const data = z
+						.array(trashQualitySizeSchema)
+						.parse(
+							await this.githubFetcher.fetchConfigsAtCommit(
+								serviceType,
+								configType,
+								latestCommit.commitHash,
+							),
+						);
+					await this.cacheManager.setVerified(serviceType, configType, data, expectedProvenance);
+					verifiedQualitySizeData = data;
+					refreshed++;
+					verifiedConfigTypes.push(configType);
+					continue;
+				}
+
 				const currentProvenance = await this.cacheManager.getProvenance(serviceType, configType);
 
 				if (sameCacheProvenance(currentProvenance, expectedProvenance)) {
 					await this.cacheManager.touchCache(serviceType, configType);
+					verifiedConfigTypes.push(configType);
 					continue;
 				}
 
@@ -1516,13 +1557,14 @@ export class TemplateUpdater {
 				await this.cacheManager.setVerified(serviceType, configType, data, expectedProvenance);
 
 				refreshed++;
+				verifiedConfigTypes.push(configType);
 			} catch (error) {
 				failed++;
 				errors.push(`${configType}: ${getErrorMessage(error)}`);
 			}
 		}
 
-		return { refreshed, failed, errors };
+		return { refreshed, failed, errors, verifiedConfigTypes, verifiedQualitySizeData };
 	}
 }
 

--- a/apps/api/src/lib/trash-guides/update-scheduler.ts
+++ b/apps/api/src/lib/trash-guides/update-scheduler.ts
@@ -15,14 +15,12 @@ import {
 	type TrashRepoConfig,
 } from "@arr/shared";
 import type { RadarrClient, SonarrClient } from "arr-sdk";
-import { z } from "zod";
 import type { PrismaClient } from "../../lib/prisma.js";
 import type { ArrClientFactory } from "../arr/client-factory.js";
 import { withCleanupOperationGuard } from "../library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { createCacheManager } from "./cache-manager.js";
 import { createTrashFetcher } from "./github-fetcher.js";
-import { trashQualitySizeSchema } from "./github-schemas.js";
 import { computeNamingHash, resolvePayload } from "./naming-deployer.js";
 import { applyQualitySizeToDefinitions } from "./quality-size-matcher.js";
 import type {
@@ -345,8 +343,18 @@ export class UpdateScheduler {
 				errors.push(...sonarrCacheResult.errors.map((e: string) => `Sonarr: ${e}`));
 			}
 
+			// Only service caches whose repository-and-commit provenance was verified
+			// during this tick may authorize an upstream quality-size write.
+			const verifiedQualitySizeData = new Map<"RADARR" | "SONARR", readonly TrashQualitySize[]>();
+			if (radarrCacheResult.verifiedQualitySizeData) {
+				verifiedQualitySizeData.set("RADARR", radarrCacheResult.verifiedQualitySizeData);
+			}
+			if (sonarrCacheResult.verifiedQualitySizeData) {
+				verifiedQualitySizeData.set("SONARR", sonarrCacheResult.verifiedQualitySizeData);
+			}
+
 			// Process quality size auto-sync after caches are refreshed
-			const qsResult = await this.processQualitySizeSync();
+			const qsResult = await this.processQualitySizeSync(verifiedQualitySizeData);
 			qualitySizeAutoSynced = qsResult.autoSynced;
 			qualitySizeUpdatesPending = qsResult.updatesPending;
 			if (qsResult.errors.length > 0) {
@@ -577,7 +585,9 @@ export class UpdateScheduler {
 	 * Compares current preset hash to the stored appliedDataHash and applies changes
 	 * for "auto" mappings, or counts pending updates for "notify" mappings.
 	 */
-	private async processQualitySizeSync(): Promise<{
+	private async processQualitySizeSync(
+		verifiedData: ReadonlyMap<"RADARR" | "SONARR", readonly TrashQualitySize[]>,
+	): Promise<{
 		autoSynced: number;
 		updatesPending: number;
 		errors: string[];
@@ -607,21 +617,25 @@ export class UpdateScheduler {
 
 		if (mappings.length === 0) return result;
 
-		const cacheManager = createCacheManager(this.prisma);
+		const warnedUnverifiedServiceTypes = new Set<"RADARR" | "SONARR">();
 
 		for (const mapping of mappings) {
 			try {
-				// Get latest preset data from cache
-				const cached = await cacheManager.get<TrashQualitySize[]>(
-					mapping.serviceType as "RADARR" | "SONARR",
-					"QUALITY_SIZE",
-					z.array(trashQualitySizeSchema),
-				);
+				const serviceType = mapping.serviceType as "RADARR" | "SONARR";
+				const cached = verifiedData.get(serviceType);
 				if (!cached) {
-					this.logger.warn(
-						`Quality size cache empty for ${mapping.serviceType} — skipping sync for instance ${mapping.instance.label}`,
-					);
+					if (!warnedUnverifiedServiceTypes.has(serviceType)) {
+						warnedUnverifiedServiceTypes.add(serviceType);
+						this.logger.warn(
+							`Quality size cache provenance was not verified for ${serviceType} during this scheduler tick — skipping sync`,
+						);
+					}
 					continue;
+				}
+				if (mapping.instance.service !== serviceType) {
+					throw new Error(
+						`Quality size mapping service type changed from ${serviceType} to ${mapping.instance.service}`,
+					);
 				}
 
 				const preset = cached.find((p) => p.trash_id === mapping.presetTrashId);
@@ -649,17 +663,26 @@ export class UpdateScheduler {
 					continue;
 				}
 
-				// Auto-sync: reset to factory defaults first, then apply
-				if (!mapping.instance.enabled) {
+				// Re-resolve the target immediately before the destructive reset. A stale
+				// mapping must never authorize data for a different service type.
+				const liveInstance = await this.prisma.serviceInstance.findFirst({
+					where: { id: mapping.instanceId, userId: mapping.instance.userId },
+				});
+				if (!liveInstance || liveInstance.service !== serviceType) {
+					throw new Error(
+						`Quality size mapping service type changed before execution for instance ${mapping.instance.label}`,
+					);
+				}
+				if (!liveInstance.enabled) {
 					this.logger.debug(
-						`Skipping quality size sync for disabled instance ${mapping.instance.label}`,
+						`Skipping quality size sync for disabled instance ${liveInstance.label}`,
 					);
 					continue;
 				}
 
 				// Reset to factory defaults before applying (matches manual apply flow)
 				const resetResponse = await this.arrClientFactory.rawRequest(
-					mapping.instance,
+					liveInstance,
 					"/api/v3/qualitydefinition/reset",
 					{ method: "PUT" },
 				);
@@ -671,9 +694,7 @@ export class UpdateScheduler {
 
 				// Apply preset on top of factory defaults
 				try {
-					const client = this.arrClientFactory.create(mapping.instance) as
-						| SonarrClient
-						| RadarrClient;
+					const client = this.arrClientFactory.create(liveInstance) as SonarrClient | RadarrClient;
 					const definitions = await client.qualityDefinition.getAll();
 					const { updated, appliedCount } = applyQualitySizeToDefinitions(
 						preset.qualities,


### PR DESCRIPTION
## Summary

- carry the exact repository-and-commit-verified quality-size payload from cache refresh into scheduled execution
- skip Radarr or Sonarr independently when that service payload could not be verified during the current tick
- re-resolve the live instance immediately before reset and reject stale mappings whose service type changed
- cover failed provenance, cache replacement, partial per-service verification, and execution-time service changes

## Validation

- focused provenance/scheduler suites: 4 files, 7 tests
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (4,741 passed, 49 skipped)
- `pnpm run lint`
- `pnpm run build`
- independent data-safety review: both recorded findings resolved

Related to #674
Related to #746