### PR TITLE
fix(docker): make PostgreSQL v2.24 upgrades resilient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,7 @@ COPY --from=builder --chown=abc:abc /app/apps/web/public ./web/apps/web/public
 # Copy startup scripts and fix line endings (single layer)
 COPY --chown=abc:abc docker/start-combined.sh ./
 COPY --chown=abc:abc docker/read-base-path.cjs ./api/
+COPY --chown=abc:abc docker/sync-postgresql-schema.cjs ./api/
 COPY --chown=abc:abc docker/validate-runtime.sh ./api/
 # Heap-snapshot helper for operators (issue #427). Installed in PATH so
 # users can run `docker exec <container> dump-heap` without needing to

--- a/apps/api/prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql
+++ b/apps/api/prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql
@@ -1,0 +1,53 @@
+BEGIN;
+
+-- Multiple app containers can start against one database at the same time.
+-- Serialize this transaction so concurrent CREATE INDEX attempts cannot
+-- deadlock or make one otherwise healthy container fail startup.
+SELECT pg_advisory_xact_lock(
+  hashtext('arr-dashboard'),
+  hashtext('postgresql-v2.24-list-cache-identity')
+);
+
+DO $migration$
+DECLARE
+  schema_name text := current_schema();
+BEGIN
+  IF to_regclass(format('%I.%I', schema_name, 'tmdb_list_cache')) IS NOT NULL THEN
+    EXECUTE format(
+      'CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.%I (%I, %I, %I, %I)',
+      'tmdb_list_cache_userId_listId_mediaType_tmdbId_key',
+      schema_name,
+      'tmdb_list_cache',
+      'userId',
+      'listId',
+      'mediaType',
+      'tmdbId'
+    );
+    EXECUTE format(
+      'DROP INDEX IF EXISTS %I.%I',
+      schema_name,
+      'tmdb_list_cache_userId_listId_tmdbId_key'
+    );
+  END IF;
+
+  IF to_regclass(format('%I.%I', schema_name, 'trakt_list_cache')) IS NOT NULL THEN
+    EXECUTE format(
+      'CREATE UNIQUE INDEX IF NOT EXISTS %I ON %I.%I (%I, %I, %I, %I)',
+      'trakt_list_cache_userId_listSlug_mediaType_tmdbId_key',
+      schema_name,
+      'trakt_list_cache',
+      'userId',
+      'listSlug',
+      'mediaType',
+      'tmdbId'
+    );
+    EXECUTE format(
+      'DROP INDEX IF EXISTS %I.%I',
+      schema_name,
+      'trakt_list_cache_userId_listSlug_tmdbId_key'
+    );
+  END IF;
+END
+$migration$;
+
+COMMIT;

--- a/apps/api/src/lib/utils/__tests__/docker-schema-sync-contract.test.ts
+++ b/apps/api/src/lib/utils/__tests__/docker-schema-sync-contract.test.ts
@@ -7,6 +7,14 @@ describe("Docker schema synchronization contract", () => {
 		resolve(process.cwd(), "../../docker/start-combined.sh"),
 		"utf8",
 	);
+	const postgresListCacheMigration = readFileSync(
+		resolve(process.cwd(), "prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql"),
+		"utf8",
+	);
+	const postgresSchemaSync = readFileSync(
+		resolve(process.cwd(), "../../docker/sync-postgresql-schema.cjs"),
+		"utf8",
+	);
 
 	it("synchronizes the runtime schema without approving data loss", () => {
 		const schemaSyncCommand = startupScript
@@ -15,6 +23,73 @@ describe("Docker schema synchronization contract", () => {
 
 		expect(schemaSyncCommand).toContain("prisma db push --schema prisma/schema.prisma");
 		expect(schemaSyncCommand).not.toContain("--accept-data-loss");
+	});
+
+	it("runs the reviewed PostgreSQL list-cache migration before schema synchronization", () => {
+		const migration = postgresSchemaSync.indexOf(
+			"prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql",
+		);
+		const schemaSync = postgresSchemaSync.indexOf('"db", "push"');
+
+		expect(startupScript).toContain('if [ "$DB_PROVIDER" = "postgresql" ]; then');
+		expect(startupScript).toContain("node /app/api/sync-postgresql-schema.cjs");
+		expect(migration).toBeGreaterThan(-1);
+		expect(schemaSync).toBeGreaterThan(migration);
+		expect(postgresSchemaSync).not.toContain("--accept-data-loss");
+	});
+
+	it.each([
+		[
+			"tmdb_list_cache",
+			"tmdb_list_cache_userId_listId_mediaType_tmdbId_key",
+			"tmdb_list_cache_userId_listId_tmdbId_key",
+		],
+		[
+			"trakt_list_cache",
+			"trakt_list_cache_userId_listSlug_mediaType_tmdbId_key",
+			"trakt_list_cache_userId_listSlug_tmdbId_key",
+		],
+	])(
+		"creates the %s replacement index before dropping its stricter predecessor",
+		(table, replacement, predecessor) => {
+			const tableGuard = postgresListCacheMigration.indexOf(`'${table}'`);
+			const createReplacement = postgresListCacheMigration.indexOf(`'${replacement}'`);
+			const dropPredecessor = postgresListCacheMigration.indexOf(`'${predecessor}'`);
+
+			expect(tableGuard).toBeGreaterThan(-1);
+			expect(createReplacement).toBeGreaterThan(tableGuard);
+			expect(dropPredecessor).toBeGreaterThan(createReplacement);
+		},
+	);
+
+	it("keeps the PostgreSQL index replacement atomic and non-destructive", () => {
+		expect(postgresListCacheMigration.trimStart()).toMatch(/^BEGIN;/);
+		expect(postgresListCacheMigration.trimEnd()).toMatch(/COMMIT;$/);
+		expect(postgresListCacheMigration).not.toMatch(/\b(?:DELETE|TRUNCATE|DROP TABLE)\b/i);
+	});
+
+	it("serializes concurrent PostgreSQL list-cache migrations", () => {
+		const advisoryLock = postgresListCacheMigration.indexOf("pg_advisory_xact_lock");
+		const firstIndexCreation = postgresListCacheMigration.indexOf(
+			"CREATE UNIQUE INDEX IF NOT EXISTS",
+		);
+
+		expect(advisoryLock).toBeGreaterThan(-1);
+		expect(firstIndexCreation).toBeGreaterThan(advisoryLock);
+	});
+
+	it("retries PostgreSQL schema reconciliation after concurrent DDL conflicts", () => {
+		const migration = postgresSchemaSync.indexOf(
+			"prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql",
+		);
+		const retryLimit = postgresSchemaSync.indexOf("maxSchemaPushAttempts = 5");
+		const schemaSync = postgresSchemaSync.indexOf('"db", "push"');
+
+		expect(retryLimit).toBeGreaterThan(-1);
+		expect(migration).toBeGreaterThan(-1);
+		expect(schemaSync).toBeGreaterThan(migration);
+		expect(postgresSchemaSync).toContain("attempt <= maxSchemaPushAttempts");
+		expect(postgresSchemaSync).not.toContain("--accept-data-loss");
 	});
 
 	it("hands the runtime schema to a remapped PUID before synchronization", () => {
@@ -50,6 +125,13 @@ describe("Docker schema synchronization contract", () => {
 			"Destructive schema changes are intentionally rejected at startup",
 		);
 		expect(startupScript).toContain("consult the release notes for an explicit upgrade path");
+	});
+
+	it("reports an unknown migration outcome without claiming rollback", () => {
+		expect(startupScript).toContain(
+			"The migration outcome may be unknown; the next startup will reconcile it safely",
+		);
+		expect(startupScript).not.toContain("Existing constraints were preserved");
 	});
 
 	it("does not echo any portion of DATABASE_URL on synchronization failure", () => {

--- a/apps/api/src/lib/utils/__tests__/postgres-list-cache-pre-sync.test.ts
+++ b/apps/api/src/lib/utils/__tests__/postgres-list-cache-pre-sync.test.ts
@@ -1,0 +1,82 @@
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Client } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+const postgresUrl = process.env.TEST_POSTGRES_URL;
+const describePostgres = postgresUrl ? describe : describe.skip;
+
+describePostgres("PostgreSQL v2.24 list-cache pre-sync migration", () => {
+	const schema = `pre_sync_${randomUUID().replaceAll("-", "")}`;
+	const migration = readFileSync(
+		resolve(process.cwd(), "prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql"),
+		"utf8",
+	);
+	let admin: Client;
+
+	beforeAll(async () => {
+		admin = new Client({ connectionString: postgresUrl });
+		await admin.connect();
+		await admin.query(`CREATE SCHEMA "${schema}"`);
+		await admin.query(`
+			CREATE TABLE "${schema}"."tmdb_list_cache" (
+				"userId" text NOT NULL,
+				"listId" text NOT NULL,
+				"mediaType" text NOT NULL,
+				"tmdbId" integer NOT NULL
+			);
+			CREATE UNIQUE INDEX "tmdb_list_cache_userId_listId_tmdbId_key"
+				ON "${schema}"."tmdb_list_cache" ("userId", "listId", "tmdbId");
+			CREATE TABLE "${schema}"."trakt_list_cache" (
+				"userId" text NOT NULL,
+				"listSlug" text NOT NULL,
+				"mediaType" text NOT NULL,
+				"tmdbId" integer NOT NULL
+			);
+			CREATE UNIQUE INDEX "trakt_list_cache_userId_listSlug_tmdbId_key"
+				ON "${schema}"."trakt_list_cache" ("userId", "listSlug", "tmdbId");
+			INSERT INTO "${schema}"."tmdb_list_cache"
+			SELECT 'user', 'list', 'movie', value FROM generate_series(1, 1000) AS value;
+			INSERT INTO "${schema}"."trakt_list_cache"
+			SELECT 'user', 'owner/list', 'series', value FROM generate_series(1, 1000) AS value;
+		`);
+	});
+
+	afterAll(async () => {
+		if (admin) {
+			await admin.query(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+			await admin.end();
+		}
+	});
+
+	it("allows two startup attempts to reconcile the same populated schema", async () => {
+		const runMigration = async () => {
+			const client = new Client({ connectionString: postgresUrl });
+			await client.connect();
+			try {
+				await client.query(`SET search_path TO "${schema}"`);
+				await client.query(migration);
+			} finally {
+				await client.end();
+			}
+		};
+
+		await Promise.all([runMigration(), runMigration()]);
+
+		const result = await admin.query<{ indexname: string }>(
+			`SELECT indexname
+			 FROM pg_indexes
+			 WHERE schemaname = $1
+			   AND tablename IN ('tmdb_list_cache', 'trakt_list_cache')
+			   AND indexname LIKE '%_key'
+			 ORDER BY indexname`,
+			[schema],
+		);
+
+		expect(result.rows.map((row) => row.indexname)).toEqual([
+			"tmdb_list_cache_userId_listId_mediaType_tmdbId_key",
+			"trakt_list_cache_userId_listSlug_mediaType_tmdbId_key",
+		]);
+	});
+});

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -292,26 +292,38 @@ fi
 
 echo ""
 echo "Synchronizing database schema..."
-# Use 'db push' instead of 'migrate deploy' to support multi-provider (SQLite/PostgreSQL).
-# Prisma migrations are provider-specific SQL, but db push generates correct SQL for any provider.
-# Deliberately do NOT pass --accept-data-loss here. A release that needs a destructive
-# schema transition must ship an explicit, reviewed migration/backup path instead of
-# silently discarding operator data merely because a new container started.
-# Note: Prisma 7 removed --skip-generate flag (db push no longer regenerates by default)
-if ! run_as_user ./node_modules/.bin/prisma db push --schema prisma/schema.prisma; then
-    echo "ERROR: Database schema synchronization failed" >&2
-    if [ "$ROOTLESS" = true ]; then
-        echo "  - In rootless mode, ensure the database file is readable/writable by UID:$PUID" >&2
-        echo "  - If switching from root to rootless, run: chown $PUID:$PGID /path/to/config/prod.db" >&2
+# v2.24 broadens the TMDb and Trakt list-cache identity to include mediaType.
+# The previous unique indexes are stricter, so an existing row set that
+# satisfies them must also satisfy the replacements. Prisma still classifies
+# replacement unique indexes as potentially destructive. Apply this reviewed,
+# transactional PostgreSQL migration first so db push can remain fail-closed
+# without --accept-data-loss.
+if [ "$DB_PROVIDER" = "postgresql" ]; then
+    echo "  - Applying serialized PostgreSQL schema synchronization..."
+    if ! run_as_user node /app/api/sync-postgresql-schema.cjs; then
+        echo "ERROR: PostgreSQL schema synchronization failed" >&2
+        echo "  - The migration outcome may be unknown; the next startup will reconcile it safely" >&2
+        exit 1
     fi
-    echo "  - Destructive schema changes are intentionally rejected at startup" >&2
-    echo "  - Restore the previous image and consult the release notes for an explicit upgrade path" >&2
-    echo "  - Ensure DATABASE_URL is correct and the database is accessible" >&2
-    echo "  - For PostgreSQL: Check that the database exists and user has permissions" >&2
-    echo "  - Detected database provider: $DB_PROVIDER" >&2
-    exit 1
+    echo "  - PostgreSQL schema synchronized successfully"
+else
+    # Use 'db push' instead of 'migrate deploy' to support SQLite without a
+    # provider-specific migration history. Deliberately do NOT pass
+    # --accept-data-loss: destructive transitions require an explicit path.
+    if ! run_as_user ./node_modules/.bin/prisma db push --schema prisma/schema.prisma; then
+        echo "ERROR: Database schema synchronization failed" >&2
+        if [ "$ROOTLESS" = true ]; then
+            echo "  - In rootless mode, ensure the database file is readable/writable by UID:$PUID" >&2
+            echo "  - If switching from root to rootless, run: chown $PUID:$PGID /path/to/config/prod.db" >&2
+        fi
+        echo "  - Destructive schema changes are intentionally rejected at startup" >&2
+        echo "  - Restore the previous image and consult the release notes for an explicit upgrade path" >&2
+        echo "  - Ensure DATABASE_URL is correct and the database is accessible" >&2
+        echo "  - Detected database provider: $DB_PROVIDER" >&2
+        exit 1
+    fi
+    echo "  - Database schema synchronized successfully"
 fi
-echo "  - Database schema synchronized successfully"
 
 # ============================================
 # Read system settings from database

--- a/docker/sync-postgresql-schema.cjs
+++ b/docker/sync-postgresql-schema.cjs
@@ -1,0 +1,68 @@
+const { spawn } = require("node:child_process");
+
+const prisma = "/app/api/node_modules/.bin/prisma";
+const maxSchemaPushAttempts = 5;
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function runPrisma(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(prisma, args, {
+      cwd: "/app/api",
+      env: process.env,
+      stdio: "inherit",
+    });
+
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(
+        new Error(
+          signal
+            ? `Prisma schema command terminated by ${signal}`
+            : `Prisma schema command exited with code ${code}`,
+        ),
+      );
+    });
+  });
+}
+
+async function main() {
+  await runPrisma([
+    "db",
+    "execute",
+    "--file",
+    "prisma/pre-sync/postgresql-v2.24-list-cache-identity.sql",
+    "--config",
+    "prisma.config.ts",
+  ]);
+
+  for (let attempt = 1; attempt <= maxSchemaPushAttempts; attempt += 1) {
+    try {
+      await runPrisma(["db", "push", "--schema", "prisma/schema.prisma"]);
+      return;
+    } catch (error) {
+      if (attempt === maxSchemaPushAttempts) {
+        throw error;
+      }
+
+      const retryDelay = attempt * 500 + Math.floor(Math.random() * 500);
+      console.error(
+        `PostgreSQL schema synchronization attempt ${attempt} failed; retrying in ${retryDelay}ms`,
+      );
+      await delay(retryDelay);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("ERROR: PostgreSQL schema synchronization failed");
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- replace the two v2.23 list-cache indexes with their media-type-aware v2.24 equivalents in one atomic PostgreSQL migration
- retry fail-closed Prisma schema reconciliation when simultaneous containers encounter a transient DDL conflict
- keep fresh installs, repeated starts, SQLite, and transaction-pooled PostgreSQL endpoints on safe paths

## Why

Prisma correctly refused the v2.24 PostgreSQL index replacement without its destructive-change override, which blocked an otherwise safe upgrade. The old indexes are stricter than the new ones, so this change creates each replacement before dropping its predecessor and never deletes cache rows.

## Verification

- full repository gauntlet: format, shared build, root typecheck, 4,748 tests, lint, and production build
- fresh PostgreSQL startup
- populated v2.23 to v2.24 PostgreSQL upgrade with cache rows preserved
- repeated startup and concurrent migration integration tests
- two containers concurrently upgrading the same v2.23 PostgreSQL database, including a reproduced and recovered Prisma DDL conflict
- independent data-safety and regression reviews completed with no unresolved findings