### PR TITLE
test(security): remove scanner-reported mass assignment

### DIFF
--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -453,27 +453,27 @@ describe("Service instance lifecycle", () => {
 			},
 		});
 		const id = JSON.parse(created.payload).service.id;
-		Object.assign(prisma._instances.get(id), {
-			service,
-			expectedIdentity: null,
-			identityKind: null,
-			identityStatus: "UNVERIFIED",
-			identityGeneration: 0,
-			identityVerifiedAt: null,
-			identityLastCheckedAt: null,
-		});
+		const instance = prisma._instances.get(id);
+		if (!instance) throw new Error("created service fixture is missing");
+		instance.service = service;
+		instance.expectedIdentity = null;
+		instance.identityKind = null;
+		instance.identityStatus = "UNVERIFIED";
+		instance.identityGeneration = 0;
+		instance.identityVerifiedAt = null;
+		instance.identityLastCheckedAt = null;
 		return id;
 	}
 
 	async function createExistingVerifiedProvider() {
 		const id = await createExistingUnverifiedProvider();
-		Object.assign(prisma._instances.get(id), {
-			expectedIdentity: "enrolled-plex-machine",
-			identityKind: "PLEX_MACHINE_IDENTIFIER",
-			identityStatus: "VERIFIED",
-			identityGeneration: 3,
-			identityVerifiedAt: new Date("2026-08-15T00:00:00.000Z"),
-		});
+		const instance = prisma._instances.get(id);
+		if (!instance) throw new Error("created service fixture is missing");
+		instance.expectedIdentity = "enrolled-plex-machine";
+		instance.identityKind = "PLEX_MACHINE_IDENTIFIER";
+		instance.identityStatus = "VERIFIED";
+		instance.identityGeneration = 3;
+		instance.identityVerifiedAt = new Date("2026-08-15T00:00:00.000Z");
 		return id;
 	}
 


### PR DESCRIPTION
## Summary

- replace mass assignment in service lifecycle fixtures with explicit field updates
- preserve the same verified and unverified provider test states
- resolve Semgrep code-scanning alert 348 without suppressing the rule

## Validation

- focused service lifecycle tests (35 tests)
- Semgrep auto scan of the affected file (0 findings)
- pnpm run format
- pnpm --filter @arr/shared build
- Prisma client generation
- pnpm run typecheck
- pnpm run test (4,748 tests)
- pnpm run lint