### PR TITLE
fix: make Sonarr episode cleanup recovery durable

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
@@ -17,6 +17,11 @@ vi.mock("../media-server-rescan.js", async (importOriginal) => ({
 
 import { CleanupScheduler } from "../cleanup-scheduler.js";
 import {
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+} from "../cleanup-executor.js";
+import {
 	CleanupMaintenanceConflictError,
 	withCleanupMaintenanceGuard,
 } from "../cleanup-maintenance-gate.js";
@@ -91,6 +96,7 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "active",
 				status: "executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: {
 					runClaimToken: "live-owner",
@@ -100,12 +106,14 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "unleased",
 				status: "executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: { runClaimToken: null, runClaimedAt: null },
 			},
 			{
 				id: "stale-lease",
 				status: "retry_executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: {
 					runClaimToken: "crashed-owner",
@@ -115,6 +123,7 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "approved-after-crash",
 				status: "approved",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: { runClaimToken: null, runClaimedAt: null },
 			},
@@ -126,6 +135,7 @@ describe("library cleanup scheduler recovery", () => {
 			}: {
 				where: {
 					status: string;
+					lastExecutionError?: string;
 					reviewedAt?: { lt: Date };
 					config?: { OR: Array<{ runClaimedAt?: null | { lt: Date }; runClaimToken?: null }> };
 				};
@@ -137,6 +147,12 @@ describe("library cleanup scheduler recovery", () => {
 				)?.runClaimedAt as { lt: Date } | undefined;
 				for (const row of rows) {
 					if (row.status !== where.status) continue;
+					if (
+						typeof where.lastExecutionError === "string" &&
+						row.lastExecutionError !== where.lastExecutionError
+					) {
+						continue;
+					}
 					if (where.reviewedAt && row.reviewedAt >= where.reviewedAt.lt) continue;
 					if (where.config) {
 						const leaseIsRecoverable =
@@ -181,6 +197,99 @@ describe("library cleanup scheduler recovery", () => {
 			approvalUpdateMany.mock.calls.find(([args]) => args.where.status === "executing")?.[0].where
 				.config,
 		).toBeDefined();
+	});
+
+	it("preserves durable Sonarr episode phases while recovering interrupted execution", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-07-27T15:00:00.000Z"));
+		const startedMessage = SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+		const confirmedMessage = SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE;
+		const legacyPartialMessage = SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE;
+		const expiredAt = new Date("2026-07-27T14:00:00.000Z");
+		const rows = [
+			{ id: "started", status: "executing", lastExecutionError: startedMessage },
+			{
+				id: "confirmed",
+				status: "executing",
+				lastExecutionError: confirmedMessage,
+				expiresAt: expiredAt,
+			},
+			{
+				id: "legacy-partial",
+				status: "executing",
+				lastExecutionError: legacyPartialMessage,
+			},
+			{ id: "retry-started", status: "retry_executing", lastExecutionError: startedMessage },
+			{ id: "retry-confirmed", status: "retry_executing", lastExecutionError: confirmedMessage },
+			{ id: "ordinary", status: "executing", lastExecutionError: null },
+			{ id: "ordinary-retry", status: "retry_executing", lastExecutionError: "retrying" },
+		];
+		const updateMany = vi.fn(
+			async ({
+				where,
+				data,
+			}: {
+				where: {
+					status: string;
+					lastExecutionError?: string | { notIn?: string[] };
+				};
+				data: Record<string, unknown>;
+			}) => {
+				let count = 0;
+				for (const row of rows) {
+					if (row.status !== where.status) continue;
+					if (typeof where.lastExecutionError === "string") {
+						if (row.lastExecutionError !== where.lastExecutionError) continue;
+					} else if (where.lastExecutionError?.notIn?.includes(row.lastExecutionError ?? "")) {
+						continue;
+					}
+					Object.assign(row, data);
+					count++;
+				}
+				return { count };
+			},
+		);
+		const prisma = {
+			libraryCleanupApproval: { updateMany },
+			libraryCleanupConfig: { findFirst: vi.fn().mockResolvedValue(null) },
+		};
+		const log = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+		const scheduler = new CleanupScheduler(prisma as never, {} as never, {} as never, log as never);
+
+		await (scheduler as unknown as { checkAndRun: () => Promise<void> }).checkAndRun();
+
+		expect(rows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "started",
+					status: "expired",
+					lastExecutionError: startedMessage,
+				}),
+				expect.objectContaining({
+					id: "confirmed",
+					status: "retry_pending",
+					lastExecutionError: confirmedMessage,
+					expiresAt: expiredAt,
+				}),
+				expect.objectContaining({
+					id: "legacy-partial",
+					status: "retry_pending",
+					lastExecutionError: legacyPartialMessage,
+				}),
+				expect.objectContaining({
+					id: "retry-started",
+					status: "expired",
+					lastExecutionError: startedMessage,
+				}),
+				expect.objectContaining({
+					id: "retry-confirmed",
+					status: "retry_pending",
+					lastExecutionError: confirmedMessage,
+				}),
+				expect.objectContaining({ id: "ordinary", status: "pending" }),
+				expect.objectContaining({ id: "ordinary-retry", status: "retry_pending" }),
+			]),
+		);
 	});
 
 	it("appends expiry and crash-recovery events only after the authoritative transitions", async () => {
@@ -232,7 +341,12 @@ describe("library cleanup scheduler recovery", () => {
 					Object.assign(expired, data);
 					return { count: 1 };
 				}
-				if (where.status === "executing" && crashed.status === "executing") {
+				if (
+					where.status === "executing" &&
+					crashed.status === "executing" &&
+					(typeof where.lastExecutionError !== "string" ||
+						crashed.lastExecutionError === where.lastExecutionError)
+				) {
 					Object.assign(crashed, data);
 					return { count: 1 };
 				}

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -9,6 +9,8 @@ import {
 	executeDirectRemoval,
 	executeRetryItems,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 } from "../cleanup-executor.js";
 import {
 	assertVerifiedSonarrPeerOwnershipRetained,
@@ -2720,14 +2722,37 @@ describe("verified Sonarr mutation handoff", () => {
 			where,
 			data,
 		}: {
-			where: { id?: string; status?: string; executionToken?: string };
+			where: {
+				id?: string;
+				status?: string;
+				executionToken?: string;
+				lastExecutionError?: { in?: string[]; notIn?: string[] } | null;
+				OR?: Array<{ lastExecutionError: { notIn?: string[] } | null }>;
+			};
 			data: Record<string, unknown>;
 		}) => {
+			const matchesLastExecutionError = (
+				filter: { in?: string[]; notIn?: string[] } | null | undefined,
+			) => {
+				const current = (storedApproval.lastExecutionError as string | null | undefined) ?? null;
+				if (filter === null) return current === null;
+				if (!filter) return true;
+				if (filter.in && !filter.in.includes(current ?? "")) return false;
+				if (filter.notIn && (current === null || filter.notIn.includes(current))) return false;
+				return true;
+			};
 			if (where.id && where.id !== storedApproval.id) return { count: 0 };
 			if (where.status && where.status !== storedApproval.status) return { count: 0 };
 			if (
 				where.executionToken !== undefined &&
 				where.executionToken !== storedApproval.executionToken
+			) {
+				return { count: 0 };
+			}
+			if (!matchesLastExecutionError(where.lastExecutionError)) return { count: 0 };
+			if (
+				where.OR &&
+				!where.OR.some((condition) => matchesLastExecutionError(condition.lastExecutionError))
 			) {
 				return { count: 0 };
 			}
@@ -3286,6 +3311,358 @@ describe("verified Sonarr mutation handoff", () => {
 		});
 	});
 
+	it("does not call Sonarr when the episode unmonitor phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		const update = configureApprovalStore(fixture.deps, storedApproval);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError?.includes("could not be safely attributed")) {
+				throw new Error("Database phase write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: expect.stringContaining("Sonarr was not called"),
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("does not delete the episode file when the confirmed phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const storedApproval = {
+			...approval(),
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		const update = configureApprovalStore(fixture.deps, storedApproval);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError === SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE) {
+				throw new Error("Database confirmation write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: expect.stringContaining("could not be safely attributed"),
+		});
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("does not call Sonarr for direct cleanup when the started phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps();
+		const intents = configureRetryStore(fixture.deps);
+		const update = vi.mocked(fixture.deps.prisma.libraryCleanupApproval.updateMany);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError?.includes("could not be safely attributed")) {
+				throw new Error("Database phase write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+		const config = {
+			id: "config-1",
+			maxRemovalsPerRun: 10,
+			respectQuiSeeding: true,
+			rules: [episodeCleanupRule()],
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			config,
+			"user-1",
+			[directEpisodeFlaggedItem(fixture)],
+			1,
+			1,
+			Date.now(),
+			undefined,
+			undefined,
+			new Map(),
+			undefined,
+			TEST_PLEX_PROVIDER_EVIDENCE,
+		);
+
+		expect(result).toMatchObject({
+			status: "completed",
+			itemsRemoved: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 1,
+		});
+		expect(intents).toEqual([
+			expect.objectContaining({
+				status: "retry_pending",
+				lastExecutionError: expect.stringContaining("Sonarr was not called"),
+			}),
+		]);
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("does not delete a direct episode file when the confirmed phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps();
+		const intents = configureRetryStore(fixture.deps);
+		const update = vi.mocked(fixture.deps.prisma.libraryCleanupApproval.updateMany);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError === SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE) {
+				throw new Error("Database confirmation write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+		const config = {
+			id: "config-1",
+			maxRemovalsPerRun: 10,
+			respectQuiSeeding: true,
+			rules: [episodeCleanupRule()],
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			config,
+			"user-1",
+			[directEpisodeFlaggedItem(fixture)],
+			1,
+			1,
+			Date.now(),
+			undefined,
+			undefined,
+			new Map(),
+			undefined,
+			TEST_PLEX_PROVIDER_EVIDENCE,
+		);
+
+		expect(result).toMatchObject({
+			status: "completed",
+			itemsRemoved: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 1,
+		});
+		expect(intents).toEqual([
+			expect.objectContaining({
+				status: "retry_pending",
+				lastExecutionError: expect.stringContaining("could not be safely attributed"),
+			}),
+		]);
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("expires an interrupted started phase without repeating an upstream mutation", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const storedApproval = {
+			...approval(),
+			status: "retry_pending",
+			lastExecutionError:
+				"Cleanup stopped because an interrupted episode unmonitor could not be safely attributed. No file deletion was attempted; review the episode in Sonarr before trying again.",
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "expired",
+			lastExecutionError: expect.stringContaining("could not be safely attributed"),
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("resumes a confirmed unmonitor without sending the unmonitor twice", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		fixture.setLiveEpisodeMonitored(9_001, false);
+		const storedApproval = {
+			...approval(),
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 1, failed: 0 });
+		expect(storedApproval).toMatchObject({ status: "executed", lastExecutionError: null });
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+	});
+
+	it("expires a started recovery before a transient instance lookup can erase its phase", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		const storedApproval = {
+			...approval(),
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findFirst).mockRejectedValue(
+			new Error("database offline"),
+		);
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "expired",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+		expect(fixture.deps.prisma.serviceInstance.findFirst).not.toHaveBeenCalled();
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("preserves a confirmed recovery across a transient instance lookup failure", async () => {
+		const fixture = makeSonarrDeps();
+		const episodeTarget = exactEpisodeTarget();
+		const context = createSharedPlexSafetyContext();
+		await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+		const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+		if (plan?.kind !== "verified_sonarr_episode") {
+			throw new Error("Expected verified Sonarr episode plan");
+		}
+		fixture.setLiveEpisodeMonitored(9_001, false);
+		const storedApproval = {
+			...approval(),
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: serializeExecutableSafetyPlan(plan),
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findFirst).mockRejectedValueOnce(
+			new Error("database offline"),
+		);
+
+		const firstAttempt = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(firstAttempt).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+
+		const retry = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(retry).toMatchObject({ removed: 1, failed: 0 });
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+	});
+
+	it.each([
+		SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	])("preserves a durable episode phase when claimed approvals cannot be loaded", async (phase) => {
+		const fixture = makeSonarrDeps();
+		const storedApproval = {
+			...approval(),
+			status: "retry_pending",
+			lastExecutionError: phase,
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+		} as unknown as Record<string, unknown>;
+		configureApprovalStore(fixture.deps, storedApproval);
+		vi.mocked(fixture.deps.prisma.libraryCleanupApproval.findMany).mockRejectedValueOnce(
+			new Error("database offline"),
+		);
+
+		await expect(executeRetryItems(fixture.deps, "user-1", ["approval-1"])).rejects.toThrow(
+			"database offline",
+		);
+
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			executionToken: null,
+			lastExecutionError: phase,
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
 	it("uses the Sonarr-to-Plex path mapping when revalidating an episode unmonitor", async () => {
 		const fixture = makeSonarrDeps({
 			mapFrom: "/tv-4k",
@@ -3489,7 +3866,7 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 	});
 
-	it("keeps an already-unmonitored episode retry durable across a new verified Plex mapping", async () => {
+	it("expires an unattributed episode retry even when a Plex mapping later becomes valid", async () => {
 		const fixture = makeSonarrDeps();
 		const episodeTarget = exactEpisodeTarget();
 		const context = createSharedPlexSafetyContext();
@@ -3556,9 +3933,12 @@ describe("verified Sonarr mutation handoff", () => {
 
 		const retry = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
 
-		expect(retry).toMatchObject({ removed: 1, failed: 0, errors: [] });
-		expect(storedApproval).toMatchObject({ status: "executed" });
-		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+		expect(retry).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "expired",
+			lastExecutionError: expect.stringContaining("could not be safely attributed"),
+		});
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
 
@@ -3617,8 +3997,11 @@ describe("verified Sonarr mutation handoff", () => {
 
 		expect(retry).toMatchObject({ removed: 0, failed: 1 });
 		expect(storedApproval).toMatchObject({ status: "expired" });
-		expect(fixture.deps.quiFileHashIndexFactory).toHaveBeenCalled();
-		expect(fixture.deps.quiClientFactory).toHaveBeenCalled();
+		expect(storedApproval).toMatchObject({
+			lastExecutionError: expect.stringContaining("could not be safely attributed"),
+		});
+		expect(fixture.deps.quiFileHashIndexFactory).not.toHaveBeenCalled();
+		expect(fixture.deps.quiClientFactory).not.toHaveBeenCalled();
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 		expect(fixture.deleteSeries).not.toHaveBeenCalled();
 	});
@@ -4417,7 +4800,7 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(intents).toEqual([
 			expect.objectContaining({
 				status: "retry_pending",
-				lastExecutionError: expect.stringContaining("database run lease"),
+				lastExecutionError: expect.stringContaining("accepted the episode unmonitor"),
 			}),
 		]);
 
@@ -4464,6 +4847,7 @@ describe("verified Sonarr mutation handoff", () => {
 			itemsFlagged: 0,
 		});
 		expect(intents).toEqual([expect.objectContaining({ status: "executed" })]);
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledTimes(1);
 		expect(fixture.bulkDelete).toHaveBeenCalledOnce();
 		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
 	});
@@ -4493,8 +4877,7 @@ describe("verified Sonarr mutation handoff", () => {
 			seasonNumber: 1,
 			episodeNumber: 1,
 			episodeTitle: "Episode 1",
-			lastExecutionError:
-				"Partial cleanup: Sonarr accepted the episode unmonitor, but its file was not deleted. The upstream change was recorded and the mutation will remain retryable.",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
 			safetySnapshot: serializeExecutableSafetyPlan(stalePlan),
 		};
 		configureApprovalStore(fixture.deps, storedRetry);
@@ -4503,7 +4886,7 @@ describe("verified Sonarr mutation handoff", () => {
 
 		expect(result).toMatchObject({ removed: 1, failed: 0 });
 		expect(storedRetry).toMatchObject({ status: "executed" });
-		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
 		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
 	});
 
@@ -4542,7 +4925,7 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(storedApproval).toMatchObject({
 			status: "retry_pending",
 			executionToken: null,
-			lastExecutionError: expect.stringContaining("accepted the episode unmonitor"),
+			lastExecutionError: expect.stringContaining("its file was not deleted"),
 		});
 		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
@@ -4589,7 +4972,7 @@ describe("verified Sonarr mutation handoff", () => {
 			expect.objectContaining({
 				status: "retry_pending",
 				executionToken: null,
-				lastExecutionError: expect.stringContaining("accepted the episode unmonitor"),
+				lastExecutionError: expect.stringContaining("its file was not deleted"),
 			}),
 		]);
 		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -679,8 +679,26 @@ class ArrDeletePartialError extends Error {
 	}
 }
 
-const SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE =
+export const SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE =
 	"Partial cleanup: Sonarr accepted the episode unmonitor, but its file was not deleted. The upstream change was recorded and the mutation will remain retryable.";
+const EPISODE_UNMONITOR_STARTED_PHASE = "episode_unmonitor_started";
+const EPISODE_UNMONITOR_CONFIRMED_PHASE = "episode_unmonitor_confirmed";
+export const SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE =
+	"Sonarr confirmed the episode unmonitor, but arr-dashboard did not durably record the episode file deletion outcome. The deletion outcome is unknown and the mutation remains retryable.";
+export const SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE =
+	"Cleanup stopped because an interrupted episode unmonitor could not be safely attributed. No file deletion was attempted; review the episode in Sonarr before trying again.";
+const SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES: string[] = [
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+];
+
+function isSonarrEpisodeUnmonitorConfirmedRecovery(message: string | null): boolean {
+	return (
+		message === SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE ||
+		message === SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE
+	);
+}
 
 class SonarrEpisodeUnmonitorPartialError extends Error {
 	constructor(cause: unknown) {
@@ -692,6 +710,24 @@ class SonarrEpisodeUnmonitorOutcomeUnknownError extends Error {
 	constructor(cause: unknown) {
 		super(
 			"Sonarr may have accepted the episode unmonitor, but arr-dashboard could not confirm the result. The mutation will remain retryable and no file deletion was attempted.",
+			{ cause },
+		);
+	}
+}
+
+class SonarrEpisodeUnmonitorStartPersistenceError extends Error {
+	constructor(cause: unknown) {
+		super(
+			"Cleanup could not durably record the episode unmonitor before contacting Sonarr. Sonarr was not called and the mutation remains retryable.",
+			{ cause },
+		);
+	}
+}
+
+class SonarrEpisodeUnmonitorConfirmationPersistenceError extends Error {
+	constructor(cause: unknown) {
+		super(
+			"Sonarr confirmed the episode unmonitor, but arr-dashboard could not durably advance its recovery phase. No file deletion was attempted and the mutation remains retryable.",
 			{ cause },
 		);
 	}
@@ -4048,6 +4084,41 @@ async function executeQueuedCleanupItemsCore(
 					"cleanup execution claim",
 				);
 			}
+			const approvedEnvelope = parseExecutableSafetyEnvelope(approval.safetySnapshot);
+			let approvedPlan = approvedEnvelope?.plan ?? null;
+			let approvedProviderEvidence = approvedEnvelope?.providerEvidence;
+			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
+			let recoveringEpisodeUnmonitorPartial = isSonarrEpisodeUnmonitorConfirmedRecovery(
+				approval.lastExecutionError,
+			);
+			const durableEpisodeUnmonitorRecoveryMessage =
+				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE ||
+				recoveringEpisodeUnmonitorPartial
+					? approval.lastExecutionError
+					: null;
+			if (
+				options.claimStatus === "retry_pending" &&
+				approvedPlan?.kind === "verified_sonarr_episode" &&
+				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+			) {
+				errors.push(SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE);
+				failed++;
+				await updateClaimedCleanupApproval(
+					prisma,
+					userId,
+					approval.id,
+					options.executeStatus,
+					claimedExecutionToken,
+					{
+						status: "expired",
+						executionToken: null,
+						lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+						reviewedAt: new Date(),
+					},
+				);
+				expiredIds.push(approval.id);
+				continue;
+			}
 			let instance: ServiceInstance | null = null;
 			try {
 				instance = await prisma.serviceInstance.findFirst({
@@ -4060,7 +4131,9 @@ async function executeQueuedCleanupItemsCore(
 				);
 			}
 			if (!instance) {
-				errors.push("Cleanup item was not executed because its ARR instance could not be loaded.");
+				const instanceLoadError =
+					"Cleanup item was not executed because its ARR instance could not be loaded.";
+				errors.push(instanceLoadError);
 				failed++;
 				await updateClaimedCleanupApproval(
 					prisma,
@@ -4071,8 +4144,7 @@ async function executeQueuedCleanupItemsCore(
 					{
 						status: options.retryStatus,
 						executionToken: null,
-						lastExecutionError:
-							"Cleanup item was not executed because its ARR instance could not be loaded.",
+						lastExecutionError: durableEpisodeUnmonitorRecoveryMessage ?? instanceLoadError,
 					},
 				).catch((revertErr) => {
 					log.warn(
@@ -4104,7 +4176,7 @@ async function executeQueuedCleanupItemsCore(
 					{
 						status: options.retryStatus,
 						executionToken: null,
-						lastExecutionError: executionError,
+						lastExecutionError: durableEpisodeUnmonitorRecoveryMessage ?? executionError,
 					},
 				).catch((revertErr) => {
 					log.warn(
@@ -4117,12 +4189,6 @@ async function executeQueuedCleanupItemsCore(
 
 			let sharedPlexBlock: string | undefined;
 			let approvalIdentityChanged = false;
-			const approvedEnvelope = parseExecutableSafetyEnvelope(approval.safetySnapshot);
-			let approvedPlan = approvedEnvelope?.plan ?? null;
-			let approvedProviderEvidence = approvedEnvelope?.providerEvidence;
-			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
-			let recoveringEpisodeUnmonitorPartial =
-				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE;
 			const recoveringInterruptedMutation =
 				options.claimStatus === "retry_pending" ||
 				approval.lastExecutionError === INTERRUPTED_CLEANUP_RECOVERY_MESSAGE ||
@@ -4535,6 +4601,28 @@ async function executeQueuedCleanupItemsCore(
 				);
 				let mutationAttempt = 0;
 				const mutationAuditBoundary: MutationAuditBoundary = {
+					episodeUnmonitorPhase:
+						recoveringEpisodeUnmonitorPartial ||
+						isSonarrEpisodeUnmonitorConfirmedRecovery(approval.lastExecutionError)
+							? EPISODE_UNMONITOR_CONFIRMED_PHASE
+							: approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+								? EPISODE_UNMONITOR_STARTED_PHASE
+								: null,
+					persistEpisodeUnmonitorPhase: async (phase) => {
+						const durableMessage =
+							phase === EPISODE_UNMONITOR_CONFIRMED_PHASE
+								? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE
+								: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+						await updateClaimedCleanupApproval(
+							prisma,
+							userId,
+							approval.id,
+							options.executeStatus,
+							claimedExecutionToken,
+							{ lastExecutionError: durableMessage },
+						);
+						approval.lastExecutionError = durableMessage;
+					},
 					prepare: async (step) => {
 						mutationAttempt++;
 						const correlationId = auditCorrelationIds.get(approval.id);
@@ -4775,6 +4863,11 @@ async function executeQueuedCleanupItemsCore(
 				}
 			} catch (error) {
 				if (error instanceof CleanupRunLeaseLostError) {
+					const leaseRecoveryError =
+						isSonarrEpisodeUnmonitorConfirmedRecovery(approval.lastExecutionError) ||
+						approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+							? approval.lastExecutionError
+							: "Cleanup execution paused because its database run lease was lost.";
 					await prisma.libraryCleanupApproval
 						.updateMany({
 							where: {
@@ -4786,8 +4879,7 @@ async function executeQueuedCleanupItemsCore(
 							data: {
 								status: options.retryStatus,
 								executionToken: null,
-								lastExecutionError:
-									"Cleanup execution paused because its database run lease was lost.",
+								lastExecutionError: leaseRecoveryError,
 							},
 						})
 						.catch((revertErr) => {
@@ -4842,13 +4934,19 @@ async function executeQueuedCleanupItemsCore(
 					(action === "delete" || action === "delete_files") &&
 					safetyPlan?.kind === "verified_sonarr_episode";
 				const executionError = preserveEpisodeUnmonitorPartial
-					? SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE
-					: error instanceof ArrFileChangedDuringSafetyCheckError ||
-							error instanceof ArrDeletePartialError ||
-							error instanceof SonarrEpisodeUnmonitorPartialError ||
-							error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError
-						? error.message
-						: "Cleanup item could not be executed. Review the API logs for details.";
+					? (approval.lastExecutionError ?? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE)
+					: ((action === "delete" || action === "delete_files") &&
+								error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError) ||
+							error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+						? SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+						: error instanceof ArrFileChangedDuringSafetyCheckError ||
+								error instanceof ArrDeletePartialError ||
+								error instanceof SonarrEpisodeUnmonitorPartialError ||
+								error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+								error instanceof SonarrEpisodeUnmonitorStartPersistenceError ||
+								error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+							? error.message
+							: "Cleanup item could not be executed. Review the API logs for details.";
 				const mutationAuthorityChanged =
 					(error instanceof ArrMutationAuthorityChangedDuringSafetyCheckError ||
 						isProviderExecutionAuthorityFailure(error)) &&
@@ -4879,6 +4977,8 @@ async function executeQueuedCleanupItemsCore(
 							status:
 								error instanceof SonarrEpisodeUnmonitorPartialError ||
 								error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+								error instanceof SonarrEpisodeUnmonitorStartPersistenceError ||
+								error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError ||
 								episodeFileDeletePartial ||
 								preserveEpisodeUnmonitorPartial
 									? "retry_pending"
@@ -4958,27 +5058,50 @@ async function executeQueuedCleanupItemsCore(
 	} finally {
 		for (const [approvalId, executionToken] of claimedApprovalTokens) {
 			if (mutationAttemptedApprovalIds.has(approvalId)) continue;
-			await prisma.libraryCleanupApproval
-				.updateMany({
+			const releaseWhere = {
+				id: approvalId,
+				config: { userId },
+				status: options.executeStatus,
+				executionToken,
+			};
+			try {
+				const preservedPhase = await prisma.libraryCleanupApproval.updateMany({
 					where: {
-						id: approvalId,
-						config: { userId },
-						status: options.executeStatus,
-						executionToken,
+						...releaseWhere,
+						lastExecutionError: { in: SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES },
 					},
 					data: {
 						status: options.retryStatus,
 						executionToken: null,
-						lastExecutionError:
-							"Cleanup execution was interrupted before this item reached a terminal state.",
 					},
-				})
-				.catch((error) => {
-					log.error(
-						{ err: error, approvalId },
-						"Cleanup could not release an unprocessed claimed approval",
-					);
 				});
+				if (preservedPhase.count === 0) {
+					await prisma.libraryCleanupApproval.updateMany({
+						where: {
+							...releaseWhere,
+							OR: [
+								{ lastExecutionError: null },
+								{
+									lastExecutionError: {
+										notIn: SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES,
+									},
+								},
+							],
+						},
+						data: {
+							status: options.retryStatus,
+							executionToken: null,
+							lastExecutionError:
+								"Cleanup execution was interrupted before this item reached a terminal state.",
+						},
+					});
+				}
+			} catch (error) {
+				log.error(
+					{ err: error, approvalId },
+					"Cleanup could not release an unprocessed claimed approval",
+				);
+			}
 		}
 	}
 }
@@ -7842,6 +7965,22 @@ export async function executeDirectRemoval(
 			);
 			let mutationAttempt = 0;
 			const mutationAuditBoundary: MutationAuditBoundary = {
+				episodeUnmonitorPhase: null,
+				persistEpisodeUnmonitorPhase: async (phase) => {
+					const durableMessage =
+						phase === EPISODE_UNMONITOR_CONFIRMED_PHASE
+							? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE
+							: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+					await updateClaimedCleanupApproval(
+						prisma,
+						userId,
+						directMutationIntentId,
+						"retry_executing",
+						directMutationExecutionToken,
+						{ lastExecutionError: durableMessage },
+					);
+					mutationAuditBoundary.episodeUnmonitorPhase = phase;
+				},
 				prepare: async (step) => {
 					mutationAttempt++;
 					if (!cleanupAuditEnabled(prisma)) return;
@@ -8291,6 +8430,12 @@ export async function executeDirectRemoval(
 				continue;
 			}
 			consecutiveFailures++;
+			const directExecutionError =
+				((ruleAction === "delete" || ruleAction === "delete_files") &&
+					error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError) ||
+				error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+					? SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+					: `Action failed: ${getErrorMessage(error)}`;
 			await updateClaimedCleanupApproval(
 				prisma,
 				userId,
@@ -8300,7 +8445,7 @@ export async function executeDirectRemoval(
 				{
 					status: "retry_pending",
 					executionToken: null,
-					lastExecutionError: `Action failed: ${getErrorMessage(error)}`,
+					lastExecutionError: directExecutionError,
 				},
 			).catch((persistError) => {
 				directRetryPersistenceFailures++;
@@ -8313,9 +8458,7 @@ export async function executeDirectRemoval(
 				{ err: error, title: item.cacheItem.title, instanceId: instance.id, consecutiveFailures },
 				"Cleanup: failed to execute action on item",
 			);
-			details.push(
-				buildDetail(item, "skipped", `Action failed: ${getErrorMessage(error)}`, directIdentity),
-			);
+			details.push(buildDetail(item, "skipped", directExecutionError, directIdentity));
 		}
 	}
 
@@ -8560,6 +8703,10 @@ interface MutationAuditBoundary {
 	prepare(step: string): Promise<void>;
 	/** Mark the exact point immediately before the upstream mutation call. */
 	attempted(step: string): void;
+	/** Current durable phase for the multi-step Sonarr episode delete. */
+	episodeUnmonitorPhase?: string | null;
+	/** Persist an authoritative phase before continuing the multi-step mutation. */
+	persistEpisodeUnmonitorPhase?(phase: string): Promise<void>;
 }
 
 async function deleteVerifiedRadarrFile(
@@ -9158,14 +9305,39 @@ async function deleteFromArr(
 					monitoredMode: "allow_unmonitored",
 				});
 				await assertMutationAuthority?.();
-				mutationAudit?.attempted(step);
-				try {
-					await sonarr.episode.setMonitored([safetyPlan.episode.arrEpisodeId], false);
-				} catch (error) {
+				if (mutationAudit?.episodeUnmonitorPhase !== EPISODE_UNMONITOR_CONFIRMED_PHASE) {
+					try {
+						await mutationAudit?.persistEpisodeUnmonitorPhase?.(EPISODE_UNMONITOR_STARTED_PHASE);
+					} catch (error) {
+						throw new SonarrEpisodeUnmonitorStartPersistenceError(error);
+					}
+					mutationAudit?.attempted(step);
+					try {
+						await sonarr.episode.setMonitored([safetyPlan.episode.arrEpisodeId], false);
+					} catch (error) {
+						const unmonitored = await sonarrEpisodeRemainsUnmonitored(
+							sonarr,
+							arrItemId,
+							safetyPlan,
+						);
+						if (unmonitored === false) throw error;
+						if (unmonitored === null) {
+							throw new SonarrEpisodeUnmonitorOutcomeUnknownError(error);
+						}
+					}
 					const unmonitored = await sonarrEpisodeRemainsUnmonitored(sonarr, arrItemId, safetyPlan);
-					if (unmonitored === false) throw error;
+					if (unmonitored === false) {
+						throw new Error("Sonarr did not apply the approved episode unmonitor");
+					}
 					if (unmonitored === null) {
-						throw new SonarrEpisodeUnmonitorOutcomeUnknownError(error);
+						throw new SonarrEpisodeUnmonitorOutcomeUnknownError(
+							new Error("Sonarr episode unmonitor readback was unavailable"),
+						);
+					}
+					try {
+						await mutationAudit?.persistEpisodeUnmonitorPhase?.(EPISODE_UNMONITOR_CONFIRMED_PHASE);
+					} catch (error) {
+						throw new SonarrEpisodeUnmonitorConfirmationPersistenceError(error);
 					}
 				}
 				try {

--- a/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
@@ -30,6 +30,9 @@ import {
 	CleanupRunAlreadyInProgressError,
 	executeCleanupRun,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 } from "./cleanup-executor.js";
 import {
 	CleanupMaintenanceConflictError,
@@ -172,6 +175,125 @@ export class CleanupScheduler {
 				return;
 			}
 			this.logger.warn({ err: error }, failureMessage);
+		}
+	}
+
+	private async recoverInterruptedSonarrEpisodePhases(
+		stuckThreshold: Date,
+		staleRunLeaseThreshold: Date,
+	): Promise<void> {
+		const recoverableConfigWhere = {
+			OR: [
+				{ runClaimToken: null },
+				{ runClaimedAt: null },
+				{ runClaimedAt: { lt: staleRunLeaseThreshold } },
+			],
+		};
+		const transitions = [
+			{
+				fromStatus: "executing",
+				toStatus: "expired",
+				reason: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "expired",
+				reason: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+			{
+				fromStatus: "executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+			{
+				fromStatus: "executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+				mutationOutcome: "unknown",
+			},
+		] as const;
+
+		for (const transition of transitions) {
+			const recoveryAt = new Date();
+			const auditRows = cleanupAuditEnabled(this.prisma)
+				? await this.prisma.libraryCleanupApproval.findMany({
+						where: {
+							status: transition.fromStatus,
+							lastExecutionError: transition.reason,
+							reviewedAt: { lt: stuckThreshold },
+							config: recoverableConfigWhere,
+						},
+					})
+				: [];
+			try {
+				const result = await this.prisma.libraryCleanupApproval.updateMany({
+					where: {
+						status: transition.fromStatus,
+						lastExecutionError: transition.reason,
+						reviewedAt: { lt: stuckThreshold },
+						config: recoverableConfigWhere,
+					},
+					data: {
+						status: transition.toStatus,
+						executionToken: null,
+						reviewedAt: recoveryAt,
+					},
+				});
+				if (result.count === 0) continue;
+				this.logger.warn(
+					{ recoveredCount: result.count, phase: transition.reason },
+					"Recovered interrupted Sonarr episode cleanup phase",
+				);
+				await runCleanupAuditBestEffort(
+					async () => {
+						const transitioned = await this.prisma.libraryCleanupApproval.findMany({
+							where: {
+								id: { in: auditRows.map((approval) => approval.id) },
+								status: transition.toStatus,
+								reviewedAt: recoveryAt,
+								lastExecutionError: transition.reason,
+							},
+						});
+						for (const approval of transitioned) {
+							await recordApprovalRecoveryTransition(
+								this.prisma,
+								{
+									approval: approvalRecordToAuditSnapshot(approval),
+									correlationId: `recovery:${approval.id}:episode-phase:${approval.reviewedAt?.getTime() ?? 0}`,
+									fromStatus: transition.fromStatus,
+									toStatus: transition.toStatus,
+									reason: transition.reason,
+									mutationOutcome: transition.mutationOutcome,
+									trigger: "scheduled",
+								},
+								this.logger,
+							);
+						}
+					},
+					this.logger,
+					"scheduler Sonarr episode phase recovery",
+				);
+			} catch (error) {
+				this.logger.warn(
+					{ err: error, phase: transition.reason },
+					"Failed to recover interrupted Sonarr episode cleanup phase",
+				);
+			}
 		}
 	}
 
@@ -343,6 +465,7 @@ export class CleanupScheduler {
 					.catch((err) => {
 						this.logger.warn({ err }, "Failed to recover stuck approved cleanup items");
 					});
+				await this.recoverInterruptedSonarrEpisodePhases(stuckThreshold, staleRunLeaseThreshold);
 				const executingRecoveryAuditRows = cleanupAuditEnabled(this.prisma)
 					? await this.prisma.libraryCleanupApproval.findMany({
 							where: {
@@ -357,6 +480,18 @@ export class CleanupScheduler {
 					.updateMany({
 						where: {
 							status: "executing",
+							OR: [
+								{ lastExecutionError: null },
+								{
+									lastExecutionError: {
+										notIn: [
+											SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+											SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+											SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+										],
+									},
+								},
+							],
 							reviewedAt: { lt: stuckThreshold },
 							config: recoverableConfigWhere,
 						},
@@ -423,6 +558,18 @@ export class CleanupScheduler {
 					.updateMany({
 						where: {
 							status: "retry_executing",
+							OR: [
+								{ lastExecutionError: null },
+								{
+									lastExecutionError: {
+										notIn: [
+											SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+											SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+											SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+										],
+									},
+								},
+							],
 							reviewedAt: { lt: stuckThreshold },
 							config: recoverableConfigWhere,
 						},


### PR DESCRIPTION
## Summary

Makes Sonarr episode-scoped cleanup recover safely across database failures, lease loss, and process interruption.

## What changed

- Durably records an unmonitor-started phase before contacting Sonarr.
- Confirms the exact episode is unmonitored and durably records that phase before deleting its file.
- Fails closed when the unmonitor outcome cannot be attributed; no file deletion is attempted.
- Resumes a confirmed partial cleanup without sending a duplicate Sonarr unmonitor.
- Preserves phase markers through prerequisite failures, scheduler crash recovery, and unprocessed-claim recovery.
- Applies the same phase boundary to approval-queue and direct cleanup execution.

## Validation

- `pnpm run format`
- `pnpm --filter @arr/api db:generate` followed by `pnpm run typecheck`
- `pnpm run test` — 4,759 tests passed; repository-configured skips unchanged
- `pnpm run lint`
- Focused Sonarr and scheduler suites — 218 tests passed
- Independent data-safety and regression reviews
- Local Codex review and GitHub Codex review; all in-scope findings corrected and regression-tested

## Risk and compatibility

No schema, API, or UI changes. Unknown upstream outcomes are intentionally expired for manual review; confirmed unmonitor progress remains retryable. This targets stable 2.x `main` and requires a separate forward-port to `next`.

Related to #659