### PR TITLE
fix: forward-port durable Sonarr episode recovery

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-scheduler-recovery.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { appendCleanupAuditEvent, appendCleanupTerminalAuditEvent } from "../cleanup-audit.js";
-import { INTERRUPTED_CLEANUP_RECOVERY_MESSAGE } from "../cleanup-executor.js";
+import {
+	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+} from "../cleanup-executor.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupMaintenanceGuard,
@@ -59,6 +64,7 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "active",
 				status: "executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: {
 					runClaimToken: "live-owner",
@@ -69,12 +75,14 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "unleased",
 				status: "executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: { runClaimToken: null, runClaimedAt: null, userId: "user-1" },
 			},
 			{
 				id: "stale-lease",
 				status: "retry_executing",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: {
 					runClaimToken: "crashed-owner",
@@ -85,15 +93,33 @@ describe("library cleanup scheduler recovery", () => {
 			{
 				id: "approved-after-crash",
 				status: "approved",
+				lastExecutionError: null as string | null,
 				reviewedAt: new Date("2026-07-27T13:00:00.000Z"),
 				config: { runClaimToken: null, runClaimedAt: null, userId: "user-1" },
 			},
 		];
 		const approvalFindMany = vi.fn(
-			async ({ where }: { where: { status?: string; reviewedAt?: { lt: Date } } }) =>
+			async ({
+				where,
+			}: {
+				where: {
+					status?: string;
+					lastExecutionError?: string;
+					OR?: Array<{ lastExecutionError: null | { notIn?: string[] } }>;
+					reviewedAt?: { lt: Date };
+				};
+			}) =>
 				rows.filter(
 					(row) =>
 						(!where.status || row.status === where.status) &&
+						(where.lastExecutionError === undefined ||
+							row.lastExecutionError === where.lastExecutionError) &&
+						(!where.OR ||
+							where.OR.some((condition) =>
+								condition.lastExecutionError === null
+									? row.lastExecutionError === null
+									: !condition.lastExecutionError.notIn?.includes(row.lastExecutionError ?? ""),
+							)) &&
 						(!where.reviewedAt || row.reviewedAt < where.reviewedAt.lt),
 				),
 		);
@@ -103,7 +129,10 @@ describe("library cleanup scheduler recovery", () => {
 				data,
 			}: {
 				where: {
+					id?: string;
 					status: string;
+					lastExecutionError?: string;
+					OR?: Array<{ lastExecutionError: null | { notIn?: string[] } }>;
 					reviewedAt?: { lt: Date };
 					config?: { OR: Array<{ runClaimedAt?: null | { lt: Date }; runClaimToken?: null }> };
 				};
@@ -114,7 +143,24 @@ describe("library cleanup scheduler recovery", () => {
 					(condition) => condition.runClaimedAt && typeof condition.runClaimedAt === "object",
 				)?.runClaimedAt as { lt: Date } | undefined;
 				for (const row of rows) {
+					if (where.id && row.id !== where.id) continue;
 					if (row.status !== where.status) continue;
+					if (
+						where.lastExecutionError !== undefined &&
+						row.lastExecutionError !== where.lastExecutionError
+					) {
+						continue;
+					}
+					if (
+						where.OR &&
+						!where.OR.some((condition) =>
+							condition.lastExecutionError === null
+								? row.lastExecutionError === null
+								: !condition.lastExecutionError.notIn?.includes(row.lastExecutionError ?? ""),
+						)
+					) {
+						continue;
+					}
 					if (where.reviewedAt && row.reviewedAt >= where.reviewedAt.lt) continue;
 					if (where.config) {
 						const leaseIsRecoverable =
@@ -178,6 +224,169 @@ describe("library cleanup scheduler recovery", () => {
 				}),
 			}),
 		);
+	});
+
+	it("preserves durable Sonarr episode phases during interrupted recovery", async () => {
+		const oldReview = new Date("2026-07-27T13:00:00.000Z");
+		const base = {
+			configId: "config-1",
+			instanceId: "sonarr-1",
+			arrItemId: 42,
+			arrEpisodeId: 9001,
+			itemType: "series",
+			targetScope: "episode",
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Pilot",
+			title: "Example Series",
+			matchedRuleId: "rule-1",
+			matchedRuleName: "Old episodes",
+			reason: "Episode was watched",
+			action: "delete",
+			reviewedAt: oldReview,
+			expiresAt: new Date("2026-07-28T15:00:00.000Z"),
+			reconciledWithoutMutation: false,
+			terminalAuditRecordedAt: null as Date | null,
+			config: { userId: "user-1", runClaimToken: null, runClaimedAt: null },
+		};
+		const rows = [
+			{
+				...base,
+				id: "started",
+				status: "executing",
+				lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+			},
+			{
+				...base,
+				id: "confirmed",
+				status: "executing",
+				lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+			},
+			{
+				...base,
+				id: "legacy-partial",
+				status: "retry_executing",
+				lastExecutionError: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+			},
+		];
+		const findMany = vi.fn(
+			async ({ where }: { where: { status: string; lastExecutionError: string } }) =>
+				rows.filter(
+					(row) =>
+						row.status === where.status && row.lastExecutionError === where.lastExecutionError,
+				),
+		);
+		const updateMany = vi.fn(
+			async ({
+				where,
+				data,
+			}: {
+				where: { id: string; status: string; lastExecutionError: string };
+				data: Record<string, unknown>;
+			}) => {
+				const row = rows.find(
+					(candidate) =>
+						candidate.id === where.id &&
+						candidate.status === where.status &&
+						candidate.lastExecutionError === where.lastExecutionError,
+				);
+				if (!row) return { count: 0 };
+				Object.assign(row, data);
+				return { count: 1 };
+			},
+		);
+		const prisma = {
+			libraryCleanupApproval: { findMany, updateMany },
+			$transaction: vi.fn(async (run: (tx: unknown) => Promise<unknown>) => await run(prisma)),
+		};
+		let terminalAuditAttempts = 0;
+		vi.mocked(appendCleanupTerminalAuditEvent).mockImplementation(async () => {
+			terminalAuditAttempts++;
+			if (terminalAuditAttempts === 1) throw new Error("audit unavailable");
+			(rows[0] as Record<string, unknown>).terminalAuditRecordedAt = new Date();
+			return {} as never;
+		});
+		const scheduler = new CleanupScheduler(
+			prisma as never,
+			{} as never,
+			{} as never,
+			{ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+		);
+
+		await (
+			scheduler as unknown as {
+				recoverInterruptedSonarrEpisodePhases: (
+					stuckThreshold: Date,
+					staleRunLeaseThreshold: Date,
+				) => Promise<void>;
+			}
+		).recoverInterruptedSonarrEpisodePhases(
+			new Date("2026-07-27T14:00:00.000Z"),
+			new Date("2026-07-27T14:30:00.000Z"),
+		);
+
+		expect(rows).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					id: "started",
+					status: "expired",
+					lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+					terminalAuditEventType: "expired",
+					terminalAuditOutcome: "blocked",
+					terminalAuditActorType: "scheduler",
+					terminalAuditTrigger: "recovery",
+					terminalAuditReason: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+					terminalAuditRecordedAt: null,
+				}),
+				expect.objectContaining({
+					id: "confirmed",
+					status: "retry_pending",
+					lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+				}),
+				expect.objectContaining({
+					id: "legacy-partial",
+					status: "retry_pending",
+					lastExecutionError: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+				}),
+			]),
+		);
+		expect(appendCleanupAuditEvent).toHaveBeenCalledTimes(2);
+		expect(appendCleanupTerminalAuditEvent).toHaveBeenCalledWith(
+			prisma,
+			expect.objectContaining({
+				eventType: "expired",
+				trigger: "recovery",
+				outcome: "blocked",
+				evidence: expect.objectContaining({
+					fromStatus: "executing",
+					toStatus: "expired",
+					mutationOutcome: "unknown",
+				}),
+			}),
+			{ approvalId: "started", status: "expired" },
+		);
+
+		findMany.mockImplementation((async ({ where }: { where: Record<string, unknown> }) =>
+			where.terminalAuditRecordedAt === null ? [rows[0]] : []) as never);
+		await (
+			scheduler as unknown as { repairMissingTerminalAuditEvents: () => Promise<void> }
+		).repairMissingTerminalAuditEvents();
+
+		expect(appendCleanupTerminalAuditEvent).toHaveBeenCalledTimes(2);
+		expect(appendCleanupTerminalAuditEvent).toHaveBeenLastCalledWith(
+			prisma,
+			expect.objectContaining({
+				eventType: "expired",
+				trigger: "recovery",
+				evidence: expect.objectContaining({
+					fromStatus: "executing",
+					toStatus: "expired",
+					mutationOutcome: "unknown",
+				}),
+			}),
+			{ approvalId: "started", status: "expired" },
+		);
+		expect((rows[0] as Record<string, unknown>).terminalAuditRecordedAt).toBeInstanceOf(Date);
 	});
 
 	it("persists a repairable expiration envelope with transition-specific history", async () => {
@@ -288,8 +497,35 @@ describe("library cleanup scheduler recovery", () => {
 			lastExecutionError: null as string | null,
 			config: { userId: "user-1", runClaimToken: null, runClaimedAt: null },
 		};
-		const findMany = vi.fn(async ({ where }: { where: { status?: unknown } }) =>
-			where.status === "executing" ? [approval] : [],
+		const findMany = vi.fn(
+			async ({
+				where,
+			}: {
+				where: {
+					status?: unknown;
+					lastExecutionError?: string;
+					OR?: Array<{ lastExecutionError: null | { notIn?: string[] } }>;
+				};
+			}) => {
+				if (where.status !== "executing") return [];
+				if (
+					where.lastExecutionError !== undefined &&
+					approval.lastExecutionError !== where.lastExecutionError
+				) {
+					return [];
+				}
+				if (
+					where.OR &&
+					!where.OR.some((condition) =>
+						condition.lastExecutionError === null
+							? approval.lastExecutionError === null
+							: !condition.lastExecutionError.notIn?.includes(approval.lastExecutionError ?? ""),
+					)
+				) {
+					return [];
+				}
+				return [approval];
+			},
 		);
 		const updateMany = vi.fn(
 			async ({ where, data }: { where: { status: string }; data: object }) => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -2043,6 +2043,7 @@ describe("verified Sonarr mutation handoff", () => {
 					instanceId?: string;
 					arrItemId?: number;
 					arrEpisodeId?: number;
+					episodeFileId?: number;
 					status?: string;
 					lastExecutionError?: string;
 				};
@@ -2054,6 +2055,7 @@ describe("verified Sonarr mutation handoff", () => {
 						(where.instanceId === undefined || retry.instanceId === where.instanceId) &&
 						(where.arrItemId === undefined || retry.arrItemId === where.arrItemId) &&
 						(where.arrEpisodeId === undefined || retry.arrEpisodeId === where.arrEpisodeId) &&
+						(where.episodeFileId === undefined || retry.episodeFileId === where.episodeFileId) &&
 						(where.status === undefined || retry.status === where.status) &&
 						(where.lastExecutionError === undefined ||
 							retry.lastExecutionError === where.lastExecutionError),
@@ -2431,6 +2433,7 @@ describe("verified Sonarr mutation handoff", () => {
 			instanceId: "sonarr-4k",
 			arrItemId: 201,
 			arrEpisodeId: 9_001,
+			episodeFileId: 3_001,
 			targetScope: "episode",
 			status: "expired",
 			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
@@ -2460,6 +2463,42 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(intents).toHaveLength(1);
 		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("does not let an old unknown-unmonitor tombstone block a replacement episode file", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		const intents = configureRetryStore(fixture.deps);
+		intents.push({
+			id: "expired-unknown-old-file",
+			configId: "config-1",
+			instanceId: "sonarr-4k",
+			arrItemId: 201,
+			arrEpisodeId: 9_001,
+			episodeFileId: 2_999,
+			targetScope: "episode",
+			status: "expired",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{
+				id: "config-1",
+				maxRemovalsPerRun: 10,
+				respectQuiSeeding: true,
+				rules: [episodeCleanupRule()],
+			} as never,
+			"user-1",
+			[directEpisodeFlaggedItem(fixture)],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ itemsRemoved: 1, itemsFilesDeleted: 0, itemsSkipped: 0 });
+		expect(intents).toHaveLength(2);
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
 	});
 
 	it("deduplicates approval candidates by physical episode file using legacy snapshot identity", async () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -2,11 +2,14 @@ import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { PlexSeriesNotFoundError } from "../../plex/plex-client.js";
 import { plexConnectionFingerprint } from "../../plex/service-instance-fingerprint.js";
+import { appendCleanupAuditEvent } from "../cleanup-audit.js";
 import {
 	executeApprovedItems,
 	executeDirectRemoval,
 	executeRetryItems,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 	selectApprovalCandidatesBeforeLimit,
 } from "../cleanup-executor.js";
 import {
@@ -459,6 +462,7 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 			libraryCleanupApproval: {
 				updateMany: approvalUpdate,
 				findMany: vi.fn().mockResolvedValue([]),
+				findFirst: vi.fn().mockResolvedValue(null),
 				create: vi.fn().mockResolvedValue({}),
 				update: vi.fn().mockResolvedValue({}),
 			},
@@ -2029,6 +2033,32 @@ describe("verified Sonarr mutation handoff", () => {
 
 	function configureRetryStore(deps: CleanupExecutorDeps) {
 		const retries: Array<Record<string, unknown>> = [];
+		vi.mocked(deps.prisma.libraryCleanupApproval.findFirst).mockImplementation(
+			(async ({
+				where,
+			}: {
+				where: {
+					id?: string;
+					configId?: string;
+					instanceId?: string;
+					arrItemId?: number;
+					arrEpisodeId?: number;
+					status?: string;
+					lastExecutionError?: string;
+				};
+			}) =>
+				retries.find(
+					(retry) =>
+						(where.id === undefined || retry.id === where.id) &&
+						(where.configId === undefined || retry.configId === where.configId) &&
+						(where.instanceId === undefined || retry.instanceId === where.instanceId) &&
+						(where.arrItemId === undefined || retry.arrItemId === where.arrItemId) &&
+						(where.arrEpisodeId === undefined || retry.arrEpisodeId === where.arrEpisodeId) &&
+						(where.status === undefined || retry.status === where.status) &&
+						(where.lastExecutionError === undefined ||
+							retry.lastExecutionError === where.lastExecutionError),
+				) ?? null) as never,
+		);
 		vi.mocked(deps.prisma.libraryCleanupApproval.findMany).mockImplementation((async ({
 			where,
 		}: {
@@ -2103,14 +2133,37 @@ describe("verified Sonarr mutation handoff", () => {
 			where,
 			data,
 		}: {
-			where: { id?: string; status?: string; executionToken?: string };
+			where: {
+				id?: string;
+				status?: string;
+				executionToken?: string;
+				lastExecutionError?: { in?: string[]; notIn?: string[] } | null;
+				OR?: Array<{ lastExecutionError: { notIn?: string[] } | null }>;
+			};
 			data: Record<string, unknown>;
 		}) => {
+			const matchesLastExecutionError = (
+				filter: { in?: string[]; notIn?: string[] } | null | undefined,
+			) => {
+				const current = (storedApproval.lastExecutionError as string | null | undefined) ?? null;
+				if (filter === null) return current === null;
+				if (!filter) return true;
+				if (filter.in && !filter.in.includes(current ?? "")) return false;
+				if (filter.notIn && (current === null || filter.notIn.includes(current))) return false;
+				return true;
+			};
 			if (where.id && where.id !== storedApproval.id) return { count: 0 };
 			if (where.status && where.status !== storedApproval.status) return { count: 0 };
 			if (
 				where.executionToken !== undefined &&
 				where.executionToken !== storedApproval.executionToken
+			) {
+				return { count: 0 };
+			}
+			if (!matchesLastExecutionError(where.lastExecutionError)) return { count: 0 };
+			if (
+				where.OR &&
+				!where.OR.some((condition) => matchesLastExecutionError(condition.lastExecutionError))
 			) {
 				return { count: 0 };
 			}
@@ -2187,6 +2240,227 @@ describe("verified Sonarr mutation handoff", () => {
 		}
 		return serializeExecutableSafetyPlan(plan);
 	}
+
+	async function storedEpisodeApproval(
+		fixture: ReturnType<typeof makeSonarrDeps>,
+		overrides: Record<string, unknown> = {},
+	) {
+		return {
+			...approval(),
+			matchedRuleId: "episode-rule",
+			matchedRuleName: "Remove watched episodes",
+			targetScope: "episode",
+			arrEpisodeId: 9_001,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			episodeTitle: "Episode 1",
+			safetySnapshot: await verifiedEpisodeSafetySnapshot(fixture),
+			...overrides,
+		} as unknown as Record<string, unknown>;
+	}
+
+	it("does not call Sonarr when the episode unmonitor phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		vi.mocked(appendCleanupAuditEvent).mockClear();
+		const storedApproval = await storedEpisodeApproval(fixture);
+		const update = configureApprovalStore(fixture.deps, storedApproval);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE) {
+				throw new Error("Database phase write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: expect.stringContaining("Sonarr was not called"),
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(appendCleanupAuditEvent).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ eventType: "mutation_started" }),
+		);
+	});
+
+	it("does not delete the episode file when the confirmed phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		const storedApproval = await storedEpisodeApproval(fixture);
+		const update = configureApprovalStore(fixture.deps, storedApproval);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError === SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE) {
+				throw new Error("Database confirmation write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+
+		const result = await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+		expect(fixture.setEpisodeMonitored).toHaveBeenCalledWith([9_001], false);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("expires an interrupted started phase without repeating an upstream mutation", async () => {
+		const fixture = makeSonarrDeps();
+		const storedApproval = await storedEpisodeApproval(fixture, {
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+		configureApprovalStore(fixture.deps, storedApproval);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findFirst).mockRejectedValue(
+			new Error("database offline"),
+		);
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "expired",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+		expect(fixture.deps.prisma.serviceInstance.findFirst).not.toHaveBeenCalled();
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
+
+	it("resumes a confirmed unmonitor without sending the unmonitor twice", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		const storedApproval = await storedEpisodeApproval(fixture, {
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+		});
+		fixture.setLiveEpisodeMonitored(9_001, false);
+		configureApprovalStore(fixture.deps, storedApproval);
+
+		const result = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(result).toMatchObject({ removed: 1, failed: 0 });
+		expect(storedApproval).toMatchObject({ status: "executed", lastExecutionError: null });
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+	});
+
+	it("preserves a confirmed recovery across a transient instance lookup failure", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		const storedApproval = await storedEpisodeApproval(fixture, {
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+		});
+		fixture.setLiveEpisodeMonitored(9_001, false);
+		configureApprovalStore(fixture.deps, storedApproval);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findFirst).mockRejectedValueOnce(
+			new Error("database offline"),
+		);
+
+		const first = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(first).toMatchObject({ removed: 0, failed: 1 });
+		expect(storedApproval).toMatchObject({
+			status: "retry_pending",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+		});
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+
+		const retry = await executeRetryItems(fixture.deps, "user-1", ["approval-1"]);
+
+		expect(retry).toMatchObject({ removed: 1, failed: 0 });
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+	});
+
+	it("does not call Sonarr for direct cleanup when the started phase cannot be persisted", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		vi.mocked(appendCleanupAuditEvent).mockClear();
+		const intents = configureRetryStore(fixture.deps);
+		const update = vi.mocked(fixture.deps.prisma.libraryCleanupApproval.updateMany);
+		const baseUpdate = update.getMockImplementation()!;
+		update.mockImplementation((async (args: { data: { lastExecutionError?: string } }) => {
+			if (args.data.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE) {
+				throw new Error("Database phase write failed");
+			}
+			return baseUpdate(args as never);
+		}) as never);
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{
+				id: "config-1",
+				maxRemovalsPerRun: 10,
+				respectQuiSeeding: true,
+				rules: [episodeCleanupRule()],
+			} as never,
+			"user-1",
+			[directEpisodeFlaggedItem(fixture)],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ itemsRemoved: 0, itemsFilesDeleted: 0, itemsSkipped: 1 });
+		expect(intents).toEqual([
+			expect.objectContaining({
+				status: "retry_pending",
+				lastExecutionError: expect.stringContaining("Sonarr was not called"),
+			}),
+		]);
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(appendCleanupAuditEvent).not.toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ eventType: "mutation_started" }),
+		);
+	});
+
+	it("blocks a fresh direct intent for an expired unknown episode unmonitor", async () => {
+		const fixture = makeSonarrDeps({ seriesPolicyAction: null });
+		const intents = configureRetryStore(fixture.deps);
+		intents.push({
+			id: "expired-unknown-unmonitor",
+			configId: "config-1",
+			instanceId: "sonarr-4k",
+			arrItemId: 201,
+			arrEpisodeId: 9_001,
+			targetScope: "episode",
+			status: "expired",
+			lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+		});
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{
+				id: "config-1",
+				maxRemovalsPerRun: 10,
+				respectQuiSeeding: true,
+				rules: [episodeCleanupRule()],
+			} as never,
+			"user-1",
+			[directEpisodeFlaggedItem(fixture)],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({
+			itemsRemoved: 0,
+			itemsFilesDeleted: 0,
+			itemsSkipped: 1,
+			details: [expect.objectContaining({ reason: expect.stringContaining("approval mode") })],
+		});
+		expect(intents).toHaveLength(1);
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+	});
 
 	it("deduplicates approval candidates by physical episode file using legacy snapshot identity", async () => {
 		const fixture = makeSonarrDeps();

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -1322,8 +1322,29 @@ class ArrDeletePartialError extends Error {
 	}
 }
 
-const SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE =
+export const SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE =
 	"Partial cleanup: Sonarr accepted the episode unmonitor, but its file was not deleted. The upstream change was recorded and the mutation will remain retryable.";
+const EPISODE_UNMONITOR_STARTED_PHASE = "episode_unmonitor_started";
+const EPISODE_UNMONITOR_CONFIRMED_PHASE = "episode_unmonitor_confirmed";
+type EpisodeUnmonitorPhase =
+	| typeof EPISODE_UNMONITOR_STARTED_PHASE
+	| typeof EPISODE_UNMONITOR_CONFIRMED_PHASE;
+export const SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE =
+	"Sonarr confirmed the episode unmonitor, but arr-dashboard did not durably record the episode file deletion outcome. The deletion outcome is unknown and the mutation remains retryable.";
+export const SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE =
+	"Cleanup stopped because an interrupted episode unmonitor could not be safely attributed. No file deletion was attempted; review the episode in Sonarr before trying again.";
+const SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES: string[] = [
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+];
+
+function isSonarrEpisodeUnmonitorConfirmedRecovery(message: string | null): boolean {
+	return (
+		message === SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE ||
+		message === SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE
+	);
+}
 
 class SonarrEpisodeUnmonitorPartialError extends Error {
 	constructor(cause: unknown) {
@@ -1338,6 +1359,37 @@ class SonarrEpisodeUnmonitorOutcomeUnknownError extends Error {
 			{ cause },
 		);
 	}
+}
+
+class SonarrEpisodeUnmonitorStartPersistenceError extends Error {
+	constructor(cause: unknown) {
+		super(
+			"Cleanup could not durably record the episode unmonitor before contacting Sonarr. Sonarr was not called and the mutation remains retryable.",
+			{ cause },
+		);
+	}
+}
+
+class SonarrEpisodeUnmonitorConfirmationPersistenceError extends Error {
+	constructor(cause: unknown) {
+		super(
+			"Sonarr confirmed the episode unmonitor, but arr-dashboard could not durably advance its recovery phase. No file deletion was attempted and the mutation remains retryable.",
+			{ cause },
+		);
+	}
+}
+
+class SonarrEpisodeUnmonitorUncertaintyTombstoneError extends Error {
+	constructor() {
+		super(
+			"Skipped for safety: an earlier episode unmonitor has an unknown outcome. Review the episode in Sonarr and use approval mode before allowing another cleanup mutation.",
+		);
+	}
+}
+
+interface EpisodeUnmonitorRecoveryBoundary {
+	phase: EpisodeUnmonitorPhase | null;
+	persist(phase: EpisodeUnmonitorPhase): Promise<void>;
 }
 
 class CleanupApprovalOwnershipLostError extends Error {
@@ -2357,6 +2409,24 @@ async function persistAndClaimDirectMutationIntent(
 	const executablePlan = asExecutableSafetyPlan(safetyPlan);
 	if (!executablePlan) {
 		throw new Error("No executable cleanup safety plan was available for the mutation intent");
+	}
+	if (item.episodeTarget && item.match.action === "delete") {
+		const uncertaintyTombstone = await deps.prisma.libraryCleanupApproval.findFirst({
+			where: {
+				configId: config.id,
+				config: { userId },
+				instanceId: item.cacheItem.instanceId,
+				arrItemId: item.cacheItem.arrItemId,
+				targetScope: "episode",
+				arrEpisodeId: item.episodeTarget.arrEpisodeId,
+				status: "expired",
+				lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+			},
+			select: { id: true },
+		});
+		if (uncertaintyTombstone) {
+			throw new SonarrEpisodeUnmonitorUncertaintyTombstoneError();
+		}
 	}
 	const mediaServerScanPolicy = normalizeCleanupMediaServerScanPolicy(item.match);
 	const retryEventFingerprint = createHash("sha256")
@@ -4445,6 +4515,61 @@ async function executeQueuedCleanupItems(
 				unclaimedIds.push(approval.id);
 				continue;
 			}
+			const approvedEnvelope = parseExecutableSafetyEnvelope(approval.safetySnapshot);
+			let approvedPlan = approvedEnvelope?.plan ?? null;
+			let approvedProviderEvidence = approvedEnvelope?.providerEvidence;
+			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
+			let recoveringEpisodeUnmonitorPartial = isSonarrEpisodeUnmonitorConfirmedRecovery(
+				approval.lastExecutionError,
+			);
+			const durableEpisodeUnmonitorRecoveryMessage =
+				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE ||
+				recoveringEpisodeUnmonitorPartial
+					? approval.lastExecutionError
+					: null;
+			if (
+				options.claimStatus === "retry_pending" &&
+				approvedPlan?.kind === "verified_sonarr_episode" &&
+				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+			) {
+				const executionError = SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+				errors.push(executionError);
+				failed++;
+				await updateClaimedCleanupApproval(
+					prisma,
+					userId,
+					approval.id,
+					options.executeStatus,
+					claimedExecutionToken,
+					{
+						status: "expired",
+						executionToken: null,
+						lastExecutionError: executionError,
+						reviewedAt: new Date(),
+						...buildCleanupTerminalAuditState(
+							userId,
+							approval,
+							executionAuditCorrelationId,
+							"blocked",
+							options.auditContext,
+							false,
+							executionError,
+						),
+					},
+				);
+				expiredIds.push(approval.id);
+				await appendCleanupTerminalAudit(
+					deps,
+					userId,
+					approval,
+					executionAuditCorrelationId,
+					"blocked",
+					options.auditContext,
+					false,
+					executionError,
+				);
+				continue;
+			}
 			let instance: ServiceInstance | null = null;
 			try {
 				instance = await prisma.serviceInstance.findFirst({
@@ -4457,9 +4582,10 @@ async function executeQueuedCleanupItems(
 				);
 			}
 			if (!instance) {
-				const executionError =
+				const instanceLoadError =
 					"Cleanup item was not executed because its ARR instance could not be loaded.";
-				errors.push(executionError);
+				const executionError = durableEpisodeUnmonitorRecoveryMessage ?? instanceLoadError;
+				errors.push(instanceLoadError);
 				failed++;
 				try {
 					await persistCleanupFailureTransition(
@@ -4495,9 +4621,10 @@ async function executeQueuedCleanupItems(
 			try {
 				action = validateCleanupMutationShape(instance, approval.itemType, approval.action);
 			} catch (error) {
-				const executionError =
+				const invalidMutationError =
 					"Cleanup item was not executed because its stored action or media type is invalid.";
-				errors.push(executionError);
+				const executionError = durableEpisodeUnmonitorRecoveryMessage ?? invalidMutationError;
+				errors.push(invalidMutationError);
 				failed++;
 				log.error(
 					{ err: error, approvalId: approval.id, instanceId: approval.instanceId },
@@ -4535,16 +4662,10 @@ async function executeQueuedCleanupItems(
 
 			let sharedPlexBlock: string | undefined;
 			let approvalIdentityChanged = false;
-			const approvedEnvelope = parseExecutableSafetyEnvelope(approval.safetySnapshot);
-			let approvedPlan = approvedEnvelope?.plan ?? null;
-			let approvedProviderEvidence = approvedEnvelope?.providerEvidence;
-			let safetyPlan: SharedMediaSafetyPlan | undefined = approvedPlan ?? undefined;
 			const durableEpisodePostPartialMutation =
 				approvedEnvelope?.mutationCheckpoint === "post_partial_mutation" &&
 				approvedPlan?.kind === "verified_sonarr_episode" &&
 				action === "delete";
-			let recoveringEpisodeUnmonitorPartial =
-				approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE;
 			let postFileOwnershipPlan:
 				| Extract<ExecutableSharedMediaSafetyPlan, { kind: "verified_radarr" }>
 				| undefined;
@@ -4898,6 +5019,29 @@ async function executeQueuedCleanupItems(
 			let executionCompleted = false;
 			let reconciledWithoutMutation = false;
 			let mutationStartedAuditAttempted = false;
+			const episodeUnmonitorRecovery: EpisodeUnmonitorRecoveryBoundary = {
+				phase: recoveringEpisodeUnmonitorPartial
+					? EPISODE_UNMONITOR_CONFIRMED_PHASE
+					: approval.lastExecutionError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+						? EPISODE_UNMONITOR_STARTED_PHASE
+						: null,
+				persist: async (phase) => {
+					const durableMessage =
+						phase === EPISODE_UNMONITOR_CONFIRMED_PHASE
+							? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE
+							: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+					await updateClaimedCleanupApproval(
+						prisma,
+						userId,
+						approval.id,
+						options.executeStatus,
+						claimedExecutionToken,
+						{ lastExecutionError: durableMessage },
+					);
+					approval.lastExecutionError = durableMessage;
+					episodeUnmonitorRecovery.phase = phase;
+				},
+			};
 			try {
 				await options.assertExecutionAllowed?.();
 				const ownership = await prisma.libraryCleanupApproval.updateMany({
@@ -5151,6 +5295,7 @@ async function executeQueuedCleanupItems(
 								approval.arrItemId,
 								safetyPlan!,
 								assertMutationAuthorityWithAudit,
+								episodeUnmonitorRecovery,
 							),
 					);
 					executionCompleted = true;
@@ -5227,7 +5372,13 @@ async function executeQueuedCleanupItems(
 				}
 			} catch (error) {
 				if (error instanceof CleanupRunLeaseLostError) {
-					const leaseError = "Cleanup execution paused because its database run lease was lost.";
+					const phaseRecoveryError = approval.lastExecutionError;
+					const leaseError =
+						(isSonarrEpisodeUnmonitorConfirmedRecovery(phaseRecoveryError) ||
+							phaseRecoveryError === SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE) &&
+						phaseRecoveryError
+							? phaseRecoveryError
+							: "Cleanup execution paused because its database run lease was lost.";
 					try {
 						await persistCleanupFailureTransition(
 							deps,
@@ -5314,14 +5465,20 @@ async function executeQueuedCleanupItems(
 					(action === "delete" || action === "delete_files") &&
 					safetyPlan?.kind === "verified_sonarr_episode";
 				const executionError = preserveEpisodeUnmonitorPartial
-					? SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE
-					: error instanceof CleanupExemptionAuthorityError ||
-							error instanceof ArrFileChangedDuringSafetyCheckError ||
-							error instanceof ArrDeletePartialError ||
-							error instanceof SonarrEpisodeUnmonitorPartialError ||
-							error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError
-						? error.message
-						: "Cleanup item could not be executed. Review the API logs for details.";
+					? (approval.lastExecutionError ?? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE)
+					: ((action === "delete" || action === "delete_files") &&
+								error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError) ||
+							error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+						? SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+						: error instanceof CleanupExemptionAuthorityError ||
+								error instanceof ArrFileChangedDuringSafetyCheckError ||
+								error instanceof ArrDeletePartialError ||
+								error instanceof SonarrEpisodeUnmonitorPartialError ||
+								error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+								error instanceof SonarrEpisodeUnmonitorStartPersistenceError ||
+								error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+							? error.message
+							: "Cleanup item could not be executed. Review the API logs for details.";
 				const mutationAuthorityChanged =
 					(error instanceof ArrMutationAuthorityChangedDuringSafetyCheckError &&
 						!preserveEpisodeUnmonitorPartial) ||
@@ -5347,6 +5504,8 @@ async function executeQueuedCleanupItems(
 				const nextFailureStatus =
 					error instanceof SonarrEpisodeUnmonitorPartialError ||
 					error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+					error instanceof SonarrEpisodeUnmonitorStartPersistenceError ||
+					error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError ||
 					episodeFileDeletePartial ||
 					preserveEpisodeUnmonitorPartial
 						? ("retry_pending" as const)
@@ -5475,27 +5634,50 @@ async function executeQueuedCleanupItems(
 	} finally {
 		for (const [approvalId, executionToken] of claimedApprovalTokens) {
 			if (mutationAttemptedApprovalIds.has(approvalId)) continue;
-			await prisma.libraryCleanupApproval
-				.updateMany({
+			const releaseWhere = {
+				id: approvalId,
+				config: { userId },
+				status: options.executeStatus,
+				executionToken,
+			};
+			try {
+				const preservedPhase = await prisma.libraryCleanupApproval.updateMany({
 					where: {
-						id: approvalId,
-						config: { userId },
-						status: options.executeStatus,
-						executionToken,
+						...releaseWhere,
+						lastExecutionError: { in: SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES },
 					},
 					data: {
 						status: options.retryStatus,
 						executionToken: null,
-						lastExecutionError:
-							"Cleanup execution was interrupted before this item reached a terminal state.",
 					},
-				})
-				.catch((error) => {
-					log.error(
-						{ err: error, approvalId },
-						"Cleanup could not release an unprocessed claimed approval",
-					);
 				});
+				if (preservedPhase.count === 0) {
+					await prisma.libraryCleanupApproval.updateMany({
+						where: {
+							...releaseWhere,
+							OR: [
+								{ lastExecutionError: null },
+								{
+									lastExecutionError: {
+										notIn: SONARR_EPISODE_UNMONITOR_DURABLE_RECOVERY_MESSAGES,
+									},
+								},
+							],
+						},
+						data: {
+							status: options.retryStatus,
+							executionToken: null,
+							lastExecutionError:
+								"Cleanup execution was interrupted before this item reached a terminal state.",
+						},
+					});
+				}
+			} catch (error) {
+				log.error(
+					{ err: error, approvalId },
+					"Cleanup could not release an unprocessed claimed approval",
+				);
+			}
 		}
 	}
 }
@@ -8455,6 +8637,20 @@ export async function executeDirectRemoval(
 			directMutationExecutionToken = intent.executionToken;
 			directMutationAuditCorrelationId = intent.executionAuditCorrelationId;
 		} catch (error) {
+			if (error instanceof SonarrEpisodeUnmonitorUncertaintyTombstoneError) {
+				runtimeSafetyBlocks++;
+				details.push(buildDetail(item, "skipped", error.message));
+				log.warn(
+					{
+						title: item.cacheItem.title,
+						instanceId: instance.id,
+						arrItemId: item.cacheItem.arrItemId,
+						arrEpisodeId: item.episodeTarget?.arrEpisodeId,
+					},
+					"Cleanup direct mutation blocked by an unresolved episode-unmonitor tombstone",
+				);
+				continue;
+			}
 			directRetryPersistenceFailures++;
 			log.error(
 				{
@@ -8493,6 +8689,24 @@ export async function executeDirectRemoval(
 			...normalizeCleanupMediaServerScanPolicy(item.match),
 		} as const;
 		let directMutationStartedAuditAttempted = false;
+		const directEpisodeUnmonitorRecovery: EpisodeUnmonitorRecoveryBoundary = {
+			phase: null,
+			persist: async (phase) => {
+				const durableMessage =
+					phase === EPISODE_UNMONITOR_CONFIRMED_PHASE
+						? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE
+						: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE;
+				await updateClaimedCleanupApproval(
+					prisma,
+					userId,
+					directMutationIntentId,
+					"retry_executing",
+					directMutationExecutionToken,
+					{ lastExecutionError: durableMessage },
+				);
+				directEpisodeUnmonitorRecovery.phase = phase;
+			},
+		};
 		try {
 			await assertRunLease?.();
 			const ownership = await prisma.libraryCleanupApproval.updateMany({
@@ -8720,6 +8934,7 @@ export async function executeDirectRemoval(
 						item.cacheItem.arrItemId,
 						safetyPlan!,
 						assertDirectMutationAuthorityWithAudit,
+						directEpisodeUnmonitorRecovery,
 					),
 				);
 				await reconcileSonarrEpisodeFileCache(
@@ -8799,7 +9014,12 @@ export async function executeDirectRemoval(
 			}
 		} catch (error) {
 			if (error instanceof CleanupRunLeaseLostError) {
-				const leaseError = "Cleanup execution paused because its database run lease was lost.";
+				const leaseError =
+					directEpisodeUnmonitorRecovery.phase === EPISODE_UNMONITOR_CONFIRMED_PHASE
+						? SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE
+						: directEpisodeUnmonitorRecovery.phase === EPISODE_UNMONITOR_STARTED_PHASE
+							? SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+							: "Cleanup execution paused because its database run lease was lost.";
 				try {
 					await persistCleanupFailureTransition(
 						deps,
@@ -8879,9 +9099,18 @@ export async function executeDirectRemoval(
 			}
 			if (
 				error instanceof SonarrEpisodeUnmonitorPartialError ||
-				error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError
+				error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+				error instanceof SonarrEpisodeUnmonitorStartPersistenceError ||
+				error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
 			) {
-				partialArrDeletes++;
+				if (!(error instanceof SonarrEpisodeUnmonitorStartPersistenceError)) {
+					partialArrDeletes++;
+				}
+				const episodeExecutionError =
+					error instanceof SonarrEpisodeUnmonitorOutcomeUnknownError ||
+					error instanceof SonarrEpisodeUnmonitorConfirmationPersistenceError
+						? SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE
+						: error.message;
 				const postEpisodeUnmonitorSnapshot =
 					error instanceof SonarrEpisodeUnmonitorPartialError
 						? serializeExecutableSafetyPlan(
@@ -8900,7 +9129,7 @@ export async function executeDirectRemoval(
 						{
 							status: "retry_pending",
 							executionToken: null,
-							lastExecutionError: error.message,
+							lastExecutionError: episodeExecutionError,
 							...(postEpisodeUnmonitorSnapshot
 								? { safetySnapshot: postEpisodeUnmonitorSnapshot }
 								: {}),
@@ -8910,7 +9139,7 @@ export async function executeDirectRemoval(
 						{
 							durableStatus: "retry_pending",
 							mutationAttempted: directMutationStartedAuditAttempted,
-							reason: error.message,
+							reason: episodeExecutionError,
 						},
 					);
 				} catch (retryError) {
@@ -8925,7 +9154,7 @@ export async function executeDirectRemoval(
 						"Cleanup could not persist the partial episode unmonitor",
 					);
 				}
-				details.push(buildDetail(item, "skipped", error.message));
+				details.push(buildDetail(item, "skipped", episodeExecutionError));
 				log.error(
 					{ err: error, title: item.cacheItem.title, instanceId: instance.id },
 					"Cleanup could not complete the exact Sonarr episode mutation",
@@ -9829,6 +10058,7 @@ async function deleteFromArr(
 	arrItemId: number,
 	safetyPlan: SharedMediaSafetyPlan,
 	assertMutationAuthority?: MutationAuthorityCheck,
+	episodeUnmonitorRecovery?: EpisodeUnmonitorRecoveryBoundary,
 ): Promise<void> {
 	const client = arrClientFactory.create(instance);
 
@@ -9880,21 +10110,50 @@ async function deleteFromArr(
 				await assertVerifiedSonarrEpisodeUnchanged(sonarr, arrItemId, safetyPlan, {
 					monitoredMode: "allow_unmonitored",
 				});
-				await assertMutationAuthority?.();
 				if (safetyPlan.episode.monitored) {
-					try {
-						await sonarr.episode.setMonitored([safetyPlan.episode.arrEpisodeId], false);
-					} catch (error) {
+					if (episodeUnmonitorRecovery?.phase !== EPISODE_UNMONITOR_CONFIRMED_PHASE) {
+						try {
+							await episodeUnmonitorRecovery?.persist(EPISODE_UNMONITOR_STARTED_PHASE);
+						} catch (error) {
+							throw new SonarrEpisodeUnmonitorStartPersistenceError(error);
+						}
+						await assertMutationAuthority?.();
+						try {
+							await sonarr.episode.setMonitored([safetyPlan.episode.arrEpisodeId], false);
+						} catch (error) {
+							const unmonitored = await sonarrEpisodeRemainsUnmonitored(
+								sonarr,
+								arrItemId,
+								safetyPlan,
+							);
+							if (unmonitored === false) throw error;
+							if (unmonitored === null) {
+								throw new SonarrEpisodeUnmonitorOutcomeUnknownError(error);
+							}
+						}
 						const unmonitored = await sonarrEpisodeRemainsUnmonitored(
 							sonarr,
 							arrItemId,
 							safetyPlan,
 						);
-						if (unmonitored === false) throw error;
-						if (unmonitored === null) {
-							throw new SonarrEpisodeUnmonitorOutcomeUnknownError(error);
+						if (unmonitored === false) {
+							throw new Error("Sonarr did not apply the approved episode unmonitor");
 						}
+						if (unmonitored === null) {
+							throw new SonarrEpisodeUnmonitorOutcomeUnknownError(
+								new Error("Sonarr episode unmonitor readback was unavailable"),
+							);
+						}
+						try {
+							await episodeUnmonitorRecovery?.persist(EPISODE_UNMONITOR_CONFIRMED_PHASE);
+						} catch (error) {
+							throw new SonarrEpisodeUnmonitorConfirmationPersistenceError(error);
+						}
+					} else {
+						await assertMutationAuthority?.();
 					}
+				} else {
+					await assertMutationAuthority?.();
 				}
 				try {
 					await deleteVerifiedSonarrEpisodeFile(

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -2419,6 +2419,7 @@ async function persistAndClaimDirectMutationIntent(
 				arrItemId: item.cacheItem.arrItemId,
 				targetScope: "episode",
 				arrEpisodeId: item.episodeTarget.arrEpisodeId,
+				episodeFileId: item.episodeTarget.episodeFileId,
 				status: "expired",
 				lastExecutionError: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 			},

--- a/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
@@ -31,6 +31,9 @@ import {
 	CleanupRunAlreadyInProgressError,
 	executeCleanupRun,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 } from "./cleanup-executor.js";
 import {
 	CleanupMaintenanceConflictError,
@@ -151,6 +154,55 @@ function buildSchedulerTransitionAuditInput(
 	};
 }
 
+function buildSchedulerRecoveryExpiredAuditInput(
+	approval: SchedulerAuditApproval,
+	fromStatus: string,
+	reason: string,
+	recoveryAt: Date,
+): AppendCleanupAuditEventInput {
+	const eventType = "expired" as const;
+	const correlationId = `recovery:${approval.id}:episode-phase:${fromStatus}:${recoveryAt.getTime()}`;
+	return {
+		userId: approval.config.userId,
+		configId: approval.configId,
+		eventKey: createCleanupAuditEventKey({ actionId: approval.id, correlationId, eventType }),
+		actionId: approval.id,
+		correlationId,
+		actorType: "scheduler",
+		eventType,
+		trigger: "recovery",
+		target: schedulerAuditTarget(approval),
+		summary: schedulerAuditSummary(approval, reason),
+		outcome: "blocked",
+		evidence: {
+			stateTransitionPersisted: true,
+			fromStatus,
+			toStatus: "expired",
+			mutationOutcome: "unknown",
+		},
+	};
+}
+
+function episodeRecoverySourceStatus(
+	correlationId: string,
+): "executing" | "retry_executing" | null {
+	const marker = ":episode-phase:";
+	const markerIndex = correlationId.lastIndexOf(marker);
+	if (!correlationId.startsWith("recovery:") || markerIndex < 0) return null;
+	const [fromStatus, timestamp, ...remainder] = correlationId
+		.slice(markerIndex + marker.length)
+		.split(":");
+	if (
+		remainder.length > 0 ||
+		(fromStatus !== "executing" && fromStatus !== "retry_executing") ||
+		!timestamp ||
+		!/^[0-9]+$/.test(timestamp)
+	) {
+		return null;
+	}
+	return fromStatus;
+}
+
 function buildPersistedTerminalAuditInput(
 	approval: SchedulerAuditApproval,
 ): AppendCleanupAuditEventInput | null {
@@ -189,7 +241,16 @@ function buildPersistedTerminalAuditInput(
 	if (eventType === "approval_reviewed") {
 		evidence = { decision: "rejected" };
 	} else if (eventType === "expired") {
-		evidence = { stateTransitionPersisted: true, fromStatus: "pending", toStatus: "expired" };
+		const recoverySourceStatus =
+			trigger === "recovery" ? episodeRecoverySourceStatus(correlationId) : null;
+		evidence = recoverySourceStatus
+			? {
+					stateTransitionPersisted: true,
+					fromStatus: recoverySourceStatus,
+					toStatus: "expired",
+					mutationOutcome: "unknown",
+				}
+			: { stateTransitionPersisted: true, fromStatus: "pending", toStatus: "expired" };
 	} else {
 		evidence = {
 			authoritativeTerminalStatePersisted: true,
@@ -406,6 +467,7 @@ export class CleanupScheduler {
 		stuckThreshold: Date,
 		staleRunLeaseThreshold: Date,
 		logMessage: string,
+		excludedLastExecutionErrors: string[] = [],
 	): Promise<void> {
 		const leaseIsRecoverable = {
 			OR: [
@@ -414,8 +476,22 @@ export class CleanupScheduler {
 				{ runClaimedAt: { lt: staleRunLeaseThreshold } },
 			],
 		};
+		const lastExecutionErrorFilter =
+			excludedLastExecutionErrors.length > 0
+				? {
+						OR: [
+							{ lastExecutionError: null },
+							{ lastExecutionError: { notIn: excludedLastExecutionErrors } },
+						],
+					}
+				: {};
 		const approvals = await this.prisma.libraryCleanupApproval.findMany({
-			where: { status: fromStatus, reviewedAt: { lt: stuckThreshold }, config: leaseIsRecoverable },
+			where: {
+				status: fromStatus,
+				reviewedAt: { lt: stuckThreshold },
+				config: leaseIsRecoverable,
+				...lastExecutionErrorFilter,
+			},
 			include: { config: { select: { userId: true } } },
 			orderBy: { id: "asc" },
 			take: TRANSITION_AUDIT_BATCH_LIMIT,
@@ -441,6 +517,7 @@ export class CleanupScheduler {
 							config: { userId: approval.config.userId, ...leaseIsRecoverable },
 							status: fromStatus,
 							reviewedAt: { lt: stuckThreshold },
+							...lastExecutionErrorFilter,
 						},
 						data: {
 							status: toStatus,
@@ -461,6 +538,147 @@ export class CleanupScheduler {
 			}
 		}
 		if (recoveredCount > 0) this.logger.warn({ recoveredCount }, logMessage);
+	}
+
+	private async recoverInterruptedSonarrEpisodePhases(
+		stuckThreshold: Date,
+		staleRunLeaseThreshold: Date,
+	): Promise<void> {
+		const leaseIsRecoverable = {
+			OR: [
+				{ runClaimToken: null },
+				{ runClaimedAt: null },
+				{ runClaimedAt: { lt: staleRunLeaseThreshold } },
+			],
+		};
+		const transitions = [
+			{
+				fromStatus: "executing",
+				toStatus: "expired",
+				reason: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "expired",
+				reason: SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+			},
+			{
+				fromStatus: "executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+			},
+			{
+				fromStatus: "executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+			},
+			{
+				fromStatus: "retry_executing",
+				toStatus: "retry_pending",
+				reason: SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+			},
+		] as const;
+
+		for (const transition of transitions) {
+			const approvals = await this.prisma.libraryCleanupApproval.findMany({
+				where: {
+					status: transition.fromStatus,
+					lastExecutionError: transition.reason,
+					reviewedAt: { lt: stuckThreshold },
+					config: leaseIsRecoverable,
+				},
+				include: { config: { select: { userId: true } } },
+				orderBy: { id: "asc" },
+				take: TRANSITION_AUDIT_BATCH_LIMIT,
+			});
+			let recoveredCount = 0;
+			for (const approval of approvals) {
+				const recoveryAt = new Date();
+				const terminalRecovery = transition.toStatus === "expired";
+				const auditInput = terminalRecovery
+					? buildSchedulerRecoveryExpiredAuditInput(
+							approval,
+							transition.fromStatus,
+							transition.reason,
+							recoveryAt,
+						)
+					: buildSchedulerTransitionAuditInput(approval, {
+							eventType: "recovered",
+							fromStatus: transition.fromStatus,
+							toStatus: transition.toStatus,
+							reason: transition.reason,
+						});
+				try {
+					let changed = false;
+					if (terminalRecovery) {
+						const result = await this.prisma.libraryCleanupApproval.updateMany({
+							where: {
+								id: approval.id,
+								config: { userId: approval.config.userId, ...leaseIsRecoverable },
+								status: transition.fromStatus,
+								lastExecutionError: transition.reason,
+								reviewedAt: { lt: stuckThreshold },
+							},
+							data: {
+								status: transition.toStatus,
+								executionToken: null,
+								reviewedAt: recoveryAt,
+								...createCleanupTerminalAuditState(auditInput),
+							},
+						});
+						changed = result.count === 1;
+						if (changed) {
+							await appendCleanupTerminalAuditEvent(this.prisma, auditInput, {
+								approvalId: approval.id,
+								status: "expired",
+							}).catch((error) => {
+								this.logger.warn(
+									{ err: error, approvalId: approval.id },
+									"Failed to append Sonarr episode recovery terminal audit; its envelope remains repairable",
+								);
+							});
+						}
+					} else {
+						changed = await this.prisma.$transaction(async (tx) => {
+							const result = await tx.libraryCleanupApproval.updateMany({
+								where: {
+									id: approval.id,
+									config: { userId: approval.config.userId, ...leaseIsRecoverable },
+									status: transition.fromStatus,
+									lastExecutionError: transition.reason,
+									reviewedAt: { lt: stuckThreshold },
+								},
+								data: {
+									status: transition.toStatus,
+									executionToken: null,
+									reviewedAt: recoveryAt,
+								},
+							});
+							if (result.count !== 1) return false;
+							await appendCleanupAuditEvent(tx, auditInput);
+							return true;
+						});
+					}
+					if (changed) recoveredCount++;
+				} catch (error) {
+					this.logger.warn(
+						{ err: error, approvalId: approval.id, phase: transition.reason },
+						"Failed to recover an interrupted Sonarr episode cleanup phase",
+					);
+				}
+			}
+			if (recoveredCount > 0) {
+				this.logger.warn(
+					{ recoveredCount, phase: transition.reason },
+					"Recovered interrupted Sonarr episode cleanup phase",
+				);
+			}
+		}
 	}
 
 	/**
@@ -552,6 +770,17 @@ export class CleanupScheduler {
 					).catch((err) => {
 						this.logger.warn({ err }, "Failed to recover stuck approved cleanup items");
 					});
+					await this.recoverInterruptedSonarrEpisodePhases(
+						stuckThreshold,
+						staleRunLeaseThreshold,
+					).catch((err) => {
+						this.logger.warn({ err }, "Failed to recover interrupted Sonarr episode phases");
+					});
+					const durableEpisodeRecoveryMessages = [
+						SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
+						SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
+						SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
+					];
 					await this.recoverStaleApprovals(
 						"executing",
 						"pending",
@@ -559,6 +788,7 @@ export class CleanupScheduler {
 						stuckThreshold,
 						staleRunLeaseThreshold,
 						"Recovered stuck executing approval items — returned them to pending review",
+						durableEpisodeRecoveryMessages,
 					).catch((err) => {
 						this.logger.warn({ err }, "Failed to recover stuck executing approvals");
 					});
@@ -569,6 +799,7 @@ export class CleanupScheduler {
 						stuckThreshold,
 						staleRunLeaseThreshold,
 						"Recovered stuck record-only cleanup retries — returned them to retry pending",
+						durableEpisodeRecoveryMessages,
 					).catch((err) => {
 						this.logger.warn({ err }, "Failed to recover stuck record-only cleanup retries");
 					});


### PR DESCRIPTION
## Summary

- forward-port the durable Sonarr episode-unmonitor recovery from #755 into the newer `next` cleanup and audit architecture
- persist STARTED and CONFIRMED phases around the Sonarr mutation, verify the exact episode readback, and fail closed when the outcome cannot be attributed
- recover confirmed phases without repeating the unmonitor, expire uncertain started phases, and block fresh direct-mode intents for unresolved episode tombstones
- preserve exact recovery transition evidence through terminal-audit repair

## Safety

The mutation boundary was reviewed independently for data safety and regression risk. The review findings were resolved before publication. The local Codex review also identified and verified fixes for fresh direct-intent bypass and inaccurate repaired audit evidence.

## Validation

- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- focused cleanup suite: 129 tests passed
- full suite: API 4,208 passed / 58 skipped; web 855 passed; shared 154 passed

Related to #659
