### PR TITLE
fix(auth): forward-port configured OIDC callback origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ The `/config` volume contains critical data that must be preserved:
 | `BACKUP_PASSWORD` | - | Password for encrypted backups (optional) |
 | `WEBAUTHN_RP_NAME` | `Arr Dashboard` | Passkey display name |
 | `WEBAUTHN_RP_ID` | `localhost` | Passkey relying party ID (your domain, no protocol) |
-| `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Passkey origin URL (full URL with protocol) |
+| `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Public browser origin for passkeys; also an OIDC callback fallback when `APP_URL` is local |
+| `APP_URL` | `http://localhost:3000` | Preferred public application URL for OIDC callbacks |
 | `LOG_LEVEL` | `info` | Logging level (`debug`, `info`, `warn`, `error`) |
 | `GITHUB_TOKEN` | - | Optional GitHub token for TRaSH Guides (higher rate limits) |
 | `HEAP_AUTO_SNAPSHOT` | `0` | Set to `1` to capture a V8 heap snapshot just before OOM (lands in `/config/heap-snapshots/`). Off by default — each snapshot is ~3x the heap (~2.3 GB at the 768 MB cap). Manual snapshots via `kill -USR2 <pid>` are always available regardless of this setting. |

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -44,6 +44,7 @@ export const envSchema = z
 			.optional()
 			.transform((v) => parseBooleanEnv(v)),
 		APP_URL: z.string().url().default("http://localhost:3000"),
+		WEBAUTHN_ORIGIN: z.string().optional(),
 		TMDB_BASE_URL: z.string().url().default("https://api.themoviedb.org/3"),
 		TMDB_IMAGE_BASE_URL: z.string().url().default("https://image.tmdb.org/t/p"),
 		// Logging — these are informational in the schema; the logger reads them at

--- a/apps/api/src/lib/auth/__tests__/oidc-redirect-uri.test.ts
+++ b/apps/api/src/lib/auth/__tests__/oidc-redirect-uri.test.ts
@@ -1,24 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { buildOidcRedirectUriFromAppUrl } from "../oidc-redirect-uri.js";
+import { resolveOidcAppUrl } from "../oidc-redirect-uri.js";
 
-describe("buildOidcRedirectUriFromAppUrl", () => {
-	it.each([
-		["https://arr.example.com", "https://arr.example.com/auth/oidc/callback"],
-		["https://arr.example.com/", "https://arr.example.com/auth/oidc/callback"],
-		["https://arr.example.com/arr", "https://arr.example.com/arr/auth/oidc/callback"],
-		["https://arr.example.com/arr/", "https://arr.example.com/arr/auth/oidc/callback"],
-	])("builds a canonical callback for %s", (appUrl, expected) => {
-		expect(buildOidcRedirectUriFromAppUrl(appUrl)).toBe(expected);
+describe("resolveOidcAppUrl", () => {
+	it("prefers the saved External URL", () => {
+		expect(
+			resolveOidcAppUrl(
+				"https://canonical.example.com/dashboard",
+				"https://app.example.com",
+				"https://webauthn.example.com",
+			),
+		).toBe("https://canonical.example.com/dashboard");
+	});
+
+	it("keeps a public APP_URL authoritative", () => {
+		expect(
+			resolveOidcAppUrl(null, "https://app.example.com/dashboard", "https://webauthn.example.com"),
+		).toBe("https://app.example.com/dashboard");
+	});
+
+	it("uses the public WebAuthn origin when APP_URL is local", () => {
+		expect(
+			resolveOidcAppUrl(null, "http://localhost:3000", "https://arr.example.com/passkeys"),
+		).toBe("https://arr.example.com");
 	});
 
 	it.each([
-		"https://admin:secret@arr.example.com/",
-		"ftp://arr.example.com/",
-		"mailto:admin@example.com",
-		"https://arr.example.com/arr?tenant=home",
-		"https://arr.example.com/arr#fragment",
-		"https://arr.example.com/arr//nested",
-	])("rejects an unsafe application URL: %s", (appUrl) => {
-		expect(buildOidcRedirectUriFromAppUrl(appUrl)).toBeNull();
+		undefined,
+		"not-a-url",
+		"http://localhost:3000",
+		"https://admin:secret@arr.example.com",
+		"https://arr.example.com?redirect=attacker.example",
+	])("does not replace a local APP_URL with an unsafe WebAuthn origin: %s", (webAuthnOrigin) => {
+		expect(resolveOidcAppUrl(null, "http://localhost:3000", webAuthnOrigin)).toBe(
+			"http://localhost:3000",
+		);
 	});
 });

--- a/apps/api/src/lib/auth/oidc-redirect-uri.ts
+++ b/apps/api/src/lib/auth/oidc-redirect-uri.ts
@@ -1,5 +1,20 @@
 import { oidcRedirectUriSchema } from "@arr/shared";
 
+function isLoopbackAddress(value: string): boolean {
+	const normalized = value
+		.trim()
+		.toLowerCase()
+		.replace(/^\[|\]$/g, "");
+	return (
+		normalized === "localhost" ||
+		normalized === "0.0.0.0" ||
+		normalized === "::" ||
+		normalized === "::1" ||
+		/^127(?:\.\d{1,3}){3}$/.test(normalized) ||
+		/^::ffff:127(?:\.\d{1,3}){3}$/.test(normalized)
+	);
+}
+
 export function buildOidcRedirectUriFromAppUrl(appUrl: string): string | null {
 	try {
 		const baseUrl = new URL(appUrl);
@@ -19,4 +34,57 @@ export function buildOidcRedirectUriFromAppUrl(appUrl: string): string | null {
 	} catch {
 		return null;
 	}
+}
+
+function isPublicHttpOrigin(value: string | undefined): boolean {
+	if (!value) {
+		return false;
+	}
+
+	try {
+		const url = new URL(value);
+		return (
+			["http:", "https:"].includes(url.protocol) &&
+			!url.username &&
+			!url.password &&
+			!url.search &&
+			!url.hash &&
+			!isLoopbackAddress(url.hostname)
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Select a public OIDC base URL exclusively from operator-controlled settings.
+ * A WebAuthn origin is a safe fallback for installations where APP_URL still
+ * has its local default because both features share the browser-facing origin.
+ */
+export function resolveOidcAppUrl(
+	externalUrl: string | null | undefined,
+	appUrl: string,
+	webAuthnOrigin?: string,
+): string {
+	if (externalUrl) {
+		return externalUrl;
+	}
+
+	if (isPublicHttpOrigin(appUrl)) {
+		return appUrl;
+	}
+
+	if (webAuthnOrigin && isPublicHttpOrigin(webAuthnOrigin)) {
+		return new URL(webAuthnOrigin).origin;
+	}
+
+	return appUrl;
+}
+
+export function oidcRedirectUriMatchesAppOrigin(redirectUri: string, appUrl: string): boolean {
+	const expectedRedirectUri = buildOidcRedirectUriFromAppUrl(appUrl);
+	return (
+		expectedRedirectUri !== null &&
+		new URL(redirectUri).origin === new URL(expectedRedirectUri).origin
+	);
 }

--- a/apps/api/src/lib/auth/passkey-service.ts
+++ b/apps/api/src/lib/auth/passkey-service.ts
@@ -322,7 +322,7 @@ export class PasskeyService {
 export function createPasskeyService(app: FastifyInstance): PasskeyService {
 	const rpName = process.env.WEBAUTHN_RP_NAME ?? "Arr Dashboard";
 	const rpID = process.env.WEBAUTHN_RP_ID ?? "localhost";
-	const origin = process.env.WEBAUTHN_ORIGIN ?? "http://localhost:3000";
+	const origin = app.config.WEBAUTHN_ORIGIN ?? "http://localhost:3000";
 
 	return new PasskeyService(app, {
 		rpName,

--- a/apps/api/src/routes/__tests__/auth-oidc.test.ts
+++ b/apps/api/src/routes/__tests__/auth-oidc.test.ts
@@ -134,6 +134,9 @@ function createMockPrisma() {
 	};
 
 	return {
+		systemSettings: {
+			findUnique: vi.fn().mockResolvedValue(null),
+		},
 		user: userMock,
 		oIDCProvider: oidcProviderMock,
 		oIDCAccount: {
@@ -199,6 +202,8 @@ beforeEach(async () => {
 	app.decorate("config", {
 		PASSWORD_POLICY: "relaxed",
 		APP_URL: "http://localhost:3000",
+		WEBAUTHN_ORIGIN: undefined,
+		TRUST_PROXY: false,
 	});
 
 	// Request decorations
@@ -274,6 +279,218 @@ describe("POST /auth/oidc/setup", () => {
 		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
 			data: expect.objectContaining({
 				redirectUri: "https://arr.example.com/dashboard/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("uses the configured WebAuthn origin when APP_URL is still localhost", async () => {
+		Object.assign(app.config, { WEBAUTHN_ORIGIN: "https://arr.example.com" });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("accepts a manual callback matching the configured WebAuthn origin", async () => {
+		Object.assign(app.config, {
+			WEBAUTHN_ORIGIN: "https://arr.example.com",
+		});
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("does not trust request forwarding headers as the public OIDC origin", async () => {
+		Object.assign(app.config, { TRUST_PROXY: true });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				host: "localhost:3001",
+				"x-arr-dashboard-origin": "https://arr.example.com",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("ignores forwarded origins when proxy trust is disabled", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				host: "localhost:3001",
+				"x-arr-dashboard-origin": "https://attacker.example",
+				"x-forwarded-host": "attacker.example",
+				"x-forwarded-proto": "https",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("rejects a manual public callback without a matching configured origin", async () => {
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				"x-arr-dashboard-origin": "https://arr.example.com",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+				redirectUri: "https://arr.example.com/auth/oidc/callback",
+			},
+		});
+
+		expect(res.statusCode).toBe(400);
+		expect(mockPrisma.oIDCProvider.create).not.toHaveBeenCalled();
+	});
+
+	it("prefers the persisted External URL over APP_URL and WebAuthn origin", async () => {
+		Object.assign(app.config, {
+			TRUST_PROXY: true,
+			WEBAUTHN_ORIGIN: "https://webauthn.example.com",
+		});
+		mockPrisma.systemSettings.findUnique.mockResolvedValue({
+			externalUrl: "https://canonical.example.com/dashboard",
+		});
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				"x-arr-dashboard-origin": "https://incidental.example.com",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "https://canonical.example.com/dashboard/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("ignores a forged proxy origin from a non-loopback peer", async () => {
+		Object.assign(app.config, { TRUST_PROXY: true });
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "192.0.2.10",
+			headers: {
+				host: "localhost:3001",
+				"x-arr-dashboard-origin": "https://attacker.example",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "http://localhost:3000/auth/oidc/callback",
+			}),
+		});
+	});
+
+	it("keeps an explicit public APP_URL authoritative over the WebAuthn origin", async () => {
+		Object.assign(app.config, {
+			APP_URL: "https://configured.example.com/dashboard",
+			WEBAUTHN_ORIGIN: "https://webauthn.example.com",
+			TRUST_PROXY: true,
+		});
+
+		const res = await app.inject({
+			method: "POST",
+			url: "/auth/oidc/setup",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				host: "localhost:3001",
+				"x-arr-dashboard-origin": "https://attacker.example",
+			},
+			payload: {
+				displayName: "My OIDC Provider",
+				clientId: "my-client-id",
+				clientSecret: "my-client-secret",
+				issuer: "https://provider.example.com",
+			},
+		});
+
+		expect(res.statusCode).toBe(201);
+		expect(mockPrisma.oIDCProvider.create).toHaveBeenCalledWith({
+			data: expect.objectContaining({
+				redirectUri: "https://configured.example.com/dashboard/auth/oidc/callback",
 			}),
 		});
 	});

--- a/apps/api/src/routes/__tests__/oidc-providers.test.ts
+++ b/apps/api/src/routes/__tests__/oidc-providers.test.ts
@@ -35,6 +35,7 @@ const provider = {
 
 let app: ReturnType<typeof Fastify>;
 const findProvider = vi.fn();
+const createProvider = vi.fn();
 const findLinkedAccount = vi.fn();
 const findUniqueProvider = vi.fn();
 const deleteProvider = vi.fn();
@@ -46,9 +47,11 @@ const updateManyUsers = vi.fn();
 const runTransaction = vi.fn();
 const deleteSessions = vi.fn();
 const clearCookie = vi.fn();
+const findSystemSettings = vi.fn();
 
 beforeEach(async () => {
 	findProvider.mockReset();
+	createProvider.mockReset();
 	findLinkedAccount.mockReset();
 	findUniqueProvider.mockReset();
 	deleteProvider.mockReset();
@@ -60,8 +63,11 @@ beforeEach(async () => {
 	runTransaction.mockReset();
 	deleteSessions.mockReset();
 	clearCookie.mockReset();
+	findSystemSettings.mockReset();
+	findSystemSettings.mockResolvedValue(null);
 
 	findUniqueProvider.mockResolvedValue(provider);
+	createProvider.mockImplementation(({ data }) => ({ ...provider, ...data }));
 	deleteProvider.mockResolvedValue({ count: 1 });
 	deleteOidcAccounts.mockResolvedValue({ count: 1 });
 	findOidcOnlyUsers.mockResolvedValue([{ id: "admin-user", hashedPassword: null }]);
@@ -85,9 +91,11 @@ beforeEach(async () => {
 
 	app = Fastify();
 	app.decorate("prisma", {
+		systemSettings: { findUnique: findSystemSettings },
 		oIDCProvider: {
 			findFirst: findProvider,
 			findUnique: findUniqueProvider,
+			create: createProvider,
 		},
 		oIDCAccount: { findFirst: findLinkedAccount },
 		user: { findMany: findOidcOnlyUsers, findUnique: findUniqueUser },
@@ -95,7 +103,11 @@ beforeEach(async () => {
 		$transaction: runTransaction,
 	});
 	app.decorate("sessionService", { clearCookie });
-	app.decorate("config", { APP_URL: "https://arr.example.com" });
+	app.decorate("config", {
+		APP_URL: "https://arr.example.com",
+		WEBAUTHN_ORIGIN: undefined,
+		TRUST_PROXY: false,
+	});
 	app.decorate("encryptor", {
 		encrypt: vi.fn().mockReturnValue({ value: "encrypted", iv: "iv" }),
 	});
@@ -149,6 +161,59 @@ describe("GET /api/oidc-providers", () => {
 });
 
 describe("POST /api/oidc-providers", () => {
+	it("uses the configured WebAuthn origin when APP_URL is still localhost", async () => {
+		Object.assign(app.config, {
+			APP_URL: "http://localhost:3000",
+			WEBAUTHN_ORIGIN: "https://arr.example.com",
+		});
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/oidc-providers",
+			payload: {
+				displayName: "Authentik",
+				clientId: "arr-dashboard",
+				clientSecret: "secret",
+				issuer: "https://auth.example.com",
+			},
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			redirectUri: "https://arr.example.com/auth/oidc/callback",
+		});
+	});
+
+	it("prefers the persisted External URL when generating the admin callback", async () => {
+		Object.assign(app.config, {
+			APP_URL: "http://localhost:3000",
+			WEBAUTHN_ORIGIN: "https://webauthn.example.com",
+		});
+		findSystemSettings.mockResolvedValue({
+			externalUrl: "https://canonical.example.com/dashboard",
+		});
+
+		const response = await app.inject({
+			method: "POST",
+			url: "/api/oidc-providers",
+			remoteAddress: "127.0.0.1",
+			headers: {
+				"x-arr-dashboard-origin": "https://incidental.example.com",
+			},
+			payload: {
+				displayName: "Authentik",
+				clientId: "arr-dashboard",
+				clientSecret: "secret",
+				issuer: "https://auth.example.com",
+			},
+		});
+
+		expect(response.statusCode).toBe(201);
+		expect(JSON.parse(response.payload)).toMatchObject({
+			redirectUri: "https://canonical.example.com/dashboard/auth/oidc/callback",
+		});
+	});
+
 	it.each([
 		"https://admin:secret@arr.example.com/",
 		"ftp://arr.example.com/",

--- a/apps/api/src/routes/auth-oidc.ts
+++ b/apps/api/src/routes/auth-oidc.ts
@@ -9,7 +9,11 @@ import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
 import { getSessionMetadata } from "../lib/auth/session-metadata.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { validateRequest } from "../lib/utils/validate.js";
-import { buildOidcRedirectUriFromAppUrl } from "../lib/auth/oidc-redirect-uri.js";
+import {
+	buildOidcRedirectUriFromAppUrl,
+	oidcRedirectUriMatchesAppOrigin,
+	resolveOidcAppUrl,
+} from "../lib/auth/oidc-redirect-uri.js";
 
 /**
  * In-memory storage for OIDC states and nonces (production: use Redis)
@@ -128,29 +132,35 @@ const authOidcRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				});
 			}
 
-			// Auto-generate redirect URI if not provided
-			// Use APP_URL (configured env var) as the trusted base URL.
-			// Only fall back to request headers when TRUST_PROXY is enabled (headers are validated by Fastify).
+			const systemSettings = await app.prisma.systemSettings.findUnique({
+				where: { id: 1 },
+				select: { externalUrl: true },
+			});
+			const publicAppUrl = resolveOidcAppUrl(
+				systemSettings?.externalUrl,
+				app.config.APP_URL,
+				app.config.WEBAUTHN_ORIGIN,
+			);
+
+			// Use only operator-controlled origins: External URL, public APP_URL,
+			// then the public WebAuthn origin when APP_URL still has its local default.
 			let redirectUri = parsed.redirectUri;
 			if (redirectUri) {
-				// Validate redirect URI origin matches APP_URL to prevent open redirect
-				const redirectOrigin = new URL(redirectUri).origin;
-				const appOrigin = new URL(app.config.APP_URL).origin;
-				if (redirectOrigin !== appOrigin) {
+				if (!oidcRedirectUriMatchesAppOrigin(redirectUri, publicAppUrl)) {
 					return reply.status(400).send({
 						error: "Redirect URI must match the application URL origin",
 					});
 				}
 			} else {
-				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(app.config.APP_URL);
+				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(publicAppUrl);
 				if (!generatedRedirectUri) {
 					return reply.status(400).send({
 						error:
-							"APP_URL must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
+							"External URL, APP_URL, or WEBAUTHN_ORIGIN must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
 					});
 				}
 				redirectUri = generatedRedirectUri;
-				request.log.info({ redirectUri }, "Auto-generated redirect URI from APP_URL");
+				request.log.info({ redirectUri }, "Auto-generated OIDC redirect URI");
 			}
 
 			try {

--- a/apps/api/src/routes/oidc-providers.ts
+++ b/apps/api/src/routes/oidc-providers.ts
@@ -8,7 +8,10 @@ import {
 	updateOidcProviderSchema,
 } from "@arr/shared";
 import type { FastifyInstance } from "fastify";
-import { buildOidcRedirectUriFromAppUrl } from "../lib/auth/oidc-redirect-uri.js";
+import {
+	buildOidcRedirectUriFromAppUrl,
+	resolveOidcAppUrl,
+} from "../lib/auth/oidc-redirect-uri.js";
 import { resolveCanonicalIssuer } from "../lib/auth/oidc-utils.js";
 import { hashPassword, verifyPassword } from "../lib/auth/password.js";
 import type { Prisma, OIDCProvider as PrismaOIDCProvider } from "../lib/prisma.js";
@@ -97,20 +100,29 @@ export default async function oidcProvidersRoutes(app: FastifyInstance) {
 				});
 			}
 
-			// Auto-generate redirect URI if not provided
-			// Use APP_URL (configured env var) as the trusted base URL.
-			// Only fall back to request headers when TRUST_PROXY is enabled (headers are validated by Fastify).
+			const systemSettings = await app.prisma.systemSettings.findUnique({
+				where: { id: 1 },
+				select: { externalUrl: true },
+			});
+			const publicAppUrl = resolveOidcAppUrl(
+				systemSettings?.externalUrl,
+				app.config.APP_URL,
+				app.config.WEBAUTHN_ORIGIN,
+			);
+
+			// Use only operator-controlled origins: External URL, public APP_URL,
+			// then the public WebAuthn origin when APP_URL still has its local default.
 			let redirectUri = data.redirectUri;
 			if (!redirectUri) {
-				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(app.config.APP_URL);
+				const generatedRedirectUri = buildOidcRedirectUriFromAppUrl(publicAppUrl);
 				if (!generatedRedirectUri) {
 					return reply.status(400).send({
 						error:
-							"APP_URL must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
+							"External URL, APP_URL, or WEBAUTHN_ORIGIN must be a credential-free HTTP(S) URL that can generate a valid OIDC redirect URI.",
 					});
 				}
 				redirectUri = generatedRedirectUri;
-				request.log.info({ redirectUri }, "Auto-generated redirect URI from APP_URL");
+				request.log.info({ redirectUri }, "Auto-generated OIDC redirect URI");
 			}
 
 			// Check if provider already exists (only one allowed)

--- a/apps/web/src/features/settings/components/oidc-provider-section.tsx
+++ b/apps/web/src/features/settings/components/oidc-provider-section.tsx
@@ -386,7 +386,9 @@ export const OIDCProviderSection = ({ currentUser }: OIDCProviderSectionProps) =
 											}
 											className="bg-card/30 border-border/50"
 										/>
-										<p className="text-xs text-muted-foreground">Leave empty to auto-detect</p>
+										<p className="text-xs text-muted-foreground">
+											Leave empty to use External URL, APP_URL, or the public WEBAUTHN_ORIGIN.
+										</p>
 									</div>
 
 									<div className="space-y-2 sm:col-span-2">

--- a/apps/web/src/features/setup/components/oidc-setup.tsx
+++ b/apps/web/src/features/setup/components/oidc-setup.tsx
@@ -126,7 +126,8 @@ export const OIDCSetup = () => {
 					className="rounded-xl"
 				/>
 				<p className="text-xs text-muted-foreground">
-					Leave empty to auto-detect. Must match the redirect URI configured in your OIDC provider.
+					Leave empty to use External URL, APP_URL, or the public WEBAUTHN_ORIGIN. This must match
+					your OIDC provider.
 				</p>
 			</div>
 			<div className="space-y-2">

--- a/docker/README.md
+++ b/docker/README.md
@@ -119,7 +119,7 @@ backup and migration instructions before retrying the upgrade.
 |----------|---------|-------------|
 | `WEBAUTHN_RP_NAME` | `Arr Dashboard` | Display name shown during passkey registration |
 | `WEBAUTHN_RP_ID` | `localhost` | Your domain (no protocol, e.g., `dashboard.example.com`) |
-| `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Full URL with protocol |
+| `WEBAUTHN_ORIGIN` | `http://localhost:3000` | Public browser origin; also an OIDC callback fallback when `APP_URL` is local |
 
 ### Logging
 
@@ -135,7 +135,7 @@ backup and migration instructions before retrying the upgrade.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GITHUB_TOKEN` | — | GitHub token for TRaSH Guides (higher rate limits) |
-| `APP_URL` | — | Public URL for OIDC callback (e.g., `https://dashboard.example.com`) |
+| `APP_URL` | `http://localhost:3000` | Preferred public URL for OIDC callbacks (e.g., `https://dashboard.example.com`) |
 
 ## Ports
 


### PR DESCRIPTION
## Summary

- forward-port the completed 2.x OIDC callback fix from #759 to `next`
- select callback origins only from saved External URL, public `APP_URL`, or public `WEBAUTHN_ORIGIN`
- keep matching manual callbacks available without trusting request forwarding headers
- retain the setup, settings, and environment guidance from the stable fix

## Scope

- patch is byte-for-byte equivalent to the merged stable change by Git patch ID
- no database schema or dependency changes
- does not merge `main` into `next`

## Validation

- focused OIDC tests: 60 passed
- `pnpm run format`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run lint`
- `pnpm run build`
- stable implementation was also live-verified against the real Docker + Authentik fixture before #759 merged

Related to #752
