### PR TITLE
fix(calendar): use viewer timezone for Sonarr air dates

### DIFF
--- a/apps/web/src/features/calendar/hooks/use-calendar-data.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-data.ts
@@ -1,5 +1,6 @@
 import type { CalendarItem, ServiceInstanceSummary } from "@arr/shared";
 import { useMemo } from "react";
+import { getCalendarDateKey } from "../lib/calendar-formatters";
 import type { CalendarFilters } from "./use-calendar-state";
 
 /**
@@ -190,15 +191,10 @@ export const useCalendarData = (
 	const eventsByDate = useMemo(() => {
 		const map = new Map<string, DeduplicatedCalendarItem[]>();
 		for (const item of filteredEvents) {
-			// Prefer local date (airDate/releaseDate) over UTC for bucketing into grid cells.
-			// airDateUtc can shift events to the next day for users in negative UTC offsets
-			// (e.g., a Sunday 8pm ET show has airDateUtc on Monday UTC). See issue #207.
-			const iso = item.airDate ?? item.releaseDate ?? item.airDateUtc;
-			if (!iso) {
+			const dateKey = getCalendarDateKey(item);
+			if (!dateKey) {
 				continue;
 			}
-			const separatorIndex = iso.indexOf("T");
-			const dateKey = separatorIndex === -1 ? iso : iso.slice(0, separatorIndex);
 			const existing = map.get(dateKey);
 			if (existing) {
 				existing.push(item);

--- a/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
@@ -1,0 +1,57 @@
+import type { CalendarItem } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import { getCalendarDateKey } from "./calendar-formatters";
+
+const createItem = (overrides: Partial<CalendarItem> = {}): CalendarItem => ({
+	id: 1,
+	title: "Test event",
+	service: "sonarr",
+	type: "episode",
+	instanceId: "sonarr-1",
+	instanceName: "Sonarr",
+	...overrides,
+});
+
+describe("getCalendarDateKey", () => {
+	it("uses the local day of a Sonarr airDateUtc for timezones east of UTC", () => {
+		const item = createItem({
+			airDate: "2026-08-16",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "Europe/Stockholm")).toBe("2026-08-17");
+	});
+
+	it("uses the local day of a Sonarr airDateUtc for timezones west of UTC", () => {
+		const item = createItem({
+			airDate: "2026-08-16",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "America/New_York")).toBe("2026-08-16");
+	});
+
+	it("preserves date-only semantics for non-Sonarr services", () => {
+		const item = createItem({
+			service: "radarr",
+			type: "movie",
+			airDate: "2026-08-17T00:00:00Z",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "America/Los_Angeles")).toBe("2026-08-17");
+	});
+
+	it("falls back to airDate when Sonarr provides an invalid UTC timestamp", () => {
+		const item = createItem({
+			airDate: "2026-08-17",
+			airDateUtc: "not-a-date",
+		});
+
+		expect(getCalendarDateKey(item, "Europe/Stockholm")).toBe("2026-08-17");
+	});
+
+	it("returns undefined when an item has no calendar date", () => {
+		expect(getCalendarDateKey(createItem(), "Europe/Stockholm")).toBeUndefined();
+	});
+});

--- a/apps/web/src/features/calendar/lib/calendar-formatters.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.ts
@@ -9,6 +9,52 @@ export const formatDateOnly = (date: Date): string => {
 	return index === -1 ? iso : iso.slice(0, index);
 };
 
+const extractDatePart = (value: string): string => {
+	const separatorIndex = value.indexOf("T");
+	return separatorIndex === -1 ? value : value.slice(0, separatorIndex);
+};
+
+const formatDateInTimeZone = (value: string, timeZone?: string): string | undefined => {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		return undefined;
+	}
+
+	const parts = new Intl.DateTimeFormat("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		timeZone,
+	}).formatToParts(parsed);
+	const year = parts.find((part) => part.type === "year")?.value;
+	const month = parts.find((part) => part.type === "month")?.value;
+	const day = parts.find((part) => part.type === "day")?.value;
+
+	return year && month && day ? `${year}-${month}-${day}` : undefined;
+};
+
+/**
+ * Selects the calendar grid day for an event.
+ * Sonarr provides a precise UTC airing time, which must be converted to the
+ * viewer's local day. Other services use release dates with date-only meaning.
+ */
+export const getCalendarDateKey = (item: CalendarItem, timeZone?: string): string | undefined => {
+	if (item.service === "sonarr") {
+		if (item.airDateUtc) {
+			const localDate = formatDateInTimeZone(item.airDateUtc, timeZone);
+			if (localDate) {
+				return localDate;
+			}
+		}
+
+		const fallback = item.airDate ?? item.releaseDate;
+		return fallback ? extractDatePart(fallback) : undefined;
+	}
+
+	const date = item.airDate ?? item.releaseDate ?? item.airDateUtc;
+	return date ? extractDatePart(date) : undefined;
+};
+
 /**
  * Creates a date at the start of the specified month in UTC
  */

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -168,3 +168,69 @@ test.describe("Calendar - Refresh", () => {
 		await expect(page.getByRole("heading", { name: /calendar/i, level: 1 })).toBeVisible();
 	});
 });
+
+test.describe("Calendar - Timezone Bucketing", () => {
+	test.use({ timezoneId: "Europe/Stockholm" });
+
+	test("places an early-morning Sonarr episode on the viewer's local day", async ({ page }) => {
+		const dateParts = new Intl.DateTimeFormat("en-US", {
+			timeZone: "Europe/Stockholm",
+			year: "numeric",
+			month: "2-digit",
+		}).formatToParts(new Date());
+		const year = dateParts.find((part) => part.type === "year")?.value;
+		const month = dateParts.find((part) => part.type === "month")?.value;
+		expect(year).toBeTruthy();
+		expect(month).toBeTruthy();
+
+		const networkDate = `${year}-${month}-15`;
+		const localDate = `${year}-${month}-16`;
+		const title = "Stockholm timezone regression";
+
+		await page.route("**/api/services", async (route) => {
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({ services: [] }),
+			});
+		});
+		await page.route("**/api/dashboard/calendar?**", async (route) => {
+			const item = {
+				id: 756,
+				title,
+				seriesTitle: title,
+				service: "sonarr",
+				type: "episode",
+				airDate: networkDate,
+				airDateUtc: `${localDate}T00:00:00Z`,
+				seasonNumber: 1,
+				episodeNumber: 1,
+				instanceId: "sonarr-1",
+				instanceName: "Sonarr",
+			};
+
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({
+					instances: [
+						{
+							instanceId: "sonarr-1",
+							instanceName: "Sonarr",
+							service: "sonarr",
+							data: [item],
+						},
+					],
+					aggregated: [item],
+					totalCount: 1,
+				}),
+			});
+		});
+
+		const baseUrl = process.env.TEST_BASE_URL ?? "";
+		await page.goto(`${baseUrl}${ROUTES.calendar}`);
+		const eventChip = page.getByText(title, { exact: true });
+		await expect(eventChip).toBeVisible({ timeout: TIMEOUTS.medium });
+
+		const eventCell = eventChip.locator("xpath=ancestor::button[1]");
+		await expect(eventCell.locator("span").filter({ hasText: /^16$/ })).toBeVisible();
+	});
+});

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -173,18 +173,9 @@ test.describe("Calendar - Timezone Bucketing", () => {
 	test.use({ timezoneId: "Europe/Stockholm" });
 
 	test("places an early-morning Sonarr episode on the viewer's local day", async ({ page }) => {
-		const dateParts = new Intl.DateTimeFormat("en-US", {
-			timeZone: "Europe/Stockholm",
-			year: "numeric",
-			month: "2-digit",
-		}).formatToParts(new Date());
-		const year = dateParts.find((part) => part.type === "year")?.value;
-		const month = dateParts.find((part) => part.type === "month")?.value;
-		expect(year).toBeTruthy();
-		expect(month).toBeTruthy();
-
-		const networkDate = `${year}-${month}-15`;
-		const localDate = `${year}-${month}-16`;
+		await page.clock.setFixedTime(new Date("2026-08-16T12:00:00Z"));
+		const networkDate = "2026-08-15";
+		const localDate = "2026-08-16";
 		const title = "Stockholm timezone regression";
 
 		await page.route("**/api/services", async (route) => {


### PR DESCRIPTION
## Summary

- Bucket Sonarr episodes by the viewer's local calendar day from `airDateUtc`.
- Preserve date-only bucketing for Radarr, Lidarr, and Readarr.
- Fall back to Sonarr's `airDate` when the UTC timestamp is missing or invalid.
- Add unit coverage for timezones east and west of UTC, plus a rendered Stockholm regression test.

## Verification

- Confirmed the published stable image places the reporter-style episode in the August 15 cell.
- Confirmed the fixed production image places the same episode in the August 16 cell with Chromium set to `Europe/Stockholm`.
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- Prisma generation followed by `pnpm run typecheck`
- `pnpm run test` with 4,772 passing tests and 50 intentional skips
- `pnpm run lint`
- `pnpm run build`
- Production Docker image build
- Independent regression review with no actionable findings

## Risk

This changes frontend calendar bucketing only. API queries, persistence, service writes, and intra-day sorting are unchanged.

## Forward port

After the stable fix merges, it should be ported to `next` in a separate PR.

Closes #756
