### PR TITLE
fix(calendar): forward-port viewer timezone bucketing

### DIFF
--- a/apps/web/src/features/calendar/components/calendar-client.tsx
+++ b/apps/web/src/features/calendar/components/calendar-client.tsx
@@ -10,7 +10,7 @@ import { useCalendarData } from "../hooks/use-calendar-data";
 import { useCalendarPlexLinks } from "../hooks/use-calendar-plex-links";
 import { useFirstDayOfWeek } from "../../../hooks/useFirstDayOfWeek";
 import { useCalendarState } from "../hooks/use-calendar-state";
-import { formatDateOnly } from "../lib/calendar-formatters";
+import { formatDateOnly, getPaddedCalendarDateRange } from "../lib/calendar-formatters";
 import { CalendarEventList } from "./calendar-event-list";
 import { CalendarFilters } from "./calendar-filters";
 import { CalendarGrid } from "./calendar-grid";
@@ -22,10 +22,16 @@ export const CalendarClient = () => {
 	const { calendarStart, calendarEnd, filters, monthStart, selectedDate, daysInView } =
 		calendarState;
 
-	const queryParams = useMemo(
+	const visibleRange = useMemo(
 		() => ({
 			start: formatDateOnly(calendarStart),
 			end: formatDateOnly(calendarEnd),
+		}),
+		[calendarStart, calendarEnd],
+	);
+	const queryParams = useMemo(
+		() => ({
+			...getPaddedCalendarDateRange(calendarStart, calendarEnd),
 			unmonitored: filters.includeUnmonitored,
 		}),
 		[calendarStart, calendarEnd, filters.includeUnmonitored],
@@ -36,7 +42,7 @@ export const CalendarClient = () => {
 
 	const { data: services } = useServicesQuery();
 
-	const calendarData = useCalendarData(data, services, filters);
+	const calendarData = useCalendarData(data, services, filters, visibleRange);
 	const { eventsByDate, serviceMap, instanceOptions, filteredEvents } = calendarData;
 
 	// Plex deep links — only fetched when Plex is configured

--- a/apps/web/src/features/calendar/hooks/use-calendar-data.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-data.ts
@@ -1,5 +1,6 @@
 import type { CalendarItem, ServiceInstanceSummary } from "@arr/shared";
 import { useMemo } from "react";
+import { getCalendarDateKey } from "../lib/calendar-formatters";
 import type { CalendarFilters } from "./use-calendar-state";
 
 /**
@@ -190,15 +191,10 @@ export const useCalendarData = (
 	const eventsByDate = useMemo(() => {
 		const map = new Map<string, DeduplicatedCalendarItem[]>();
 		for (const item of filteredEvents) {
-			// Prefer local date (airDate/releaseDate) over UTC for bucketing into grid cells.
-			// airDateUtc can shift events to the next day for users in negative UTC offsets
-			// (e.g., a Sunday 8pm ET show has airDateUtc on Monday UTC). See issue #207.
-			const iso = item.airDate ?? item.releaseDate ?? item.airDateUtc;
-			if (!iso) {
+			const dateKey = getCalendarDateKey(item);
+			if (!dateKey) {
 				continue;
 			}
-			const separatorIndex = iso.indexOf("T");
-			const dateKey = separatorIndex === -1 ? iso : iso.slice(0, separatorIndex);
 			const existing = map.get(dateKey);
 			if (existing) {
 				existing.push(item);

--- a/apps/web/src/features/calendar/hooks/use-calendar-data.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-data.ts
@@ -1,6 +1,10 @@
 import type { CalendarItem, ServiceInstanceSummary } from "@arr/shared";
 import { useMemo } from "react";
-import { getCalendarDateKey } from "../lib/calendar-formatters";
+import {
+	type CalendarDateRange,
+	getCalendarDateKey,
+	isCalendarItemInDateRange,
+} from "../lib/calendar-formatters";
 import type { CalendarFilters } from "./use-calendar-state";
 
 /**
@@ -130,6 +134,7 @@ export const useCalendarData = (
 		| undefined,
 	services: ServiceInstanceSummary[] | undefined,
 	filters: CalendarFilters,
+	visibleRange: CalendarDateRange,
 ): CalendarDataHookResult => {
 	const aggregated = useMemo(() => data?.aggregated ?? [], [data?.aggregated]);
 	const instances = useMemo(() => data?.instances ?? [], [data?.instances]);
@@ -156,6 +161,9 @@ export const useCalendarData = (
 	const filteredEvents = useMemo(() => {
 		const term = filters.searchTerm.trim().toLowerCase();
 		const filtered = aggregated.filter((item) => {
+			if (!isCalendarItemInDateRange(item, visibleRange)) {
+				return false;
+			}
 			if (filters.serviceFilter !== "all" && item.service !== filters.serviceFilter) {
 				return false;
 			}
@@ -186,7 +194,7 @@ export const useCalendarData = (
 		});
 		// Deduplicate events that appear in multiple instances
 		return deduplicateEvents(filtered);
-	}, [aggregated, filters]);
+	}, [aggregated, filters, visibleRange]);
 
 	const eventsByDate = useMemo(() => {
 		const map = new Map<string, DeduplicatedCalendarItem[]>();

--- a/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
@@ -1,0 +1,57 @@
+import type { CalendarItem } from "@arr/shared";
+import { describe, expect, it } from "vitest";
+import { getCalendarDateKey } from "./calendar-formatters";
+
+const createItem = (overrides: Partial<CalendarItem> = {}): CalendarItem => ({
+	id: 1,
+	title: "Test event",
+	service: "sonarr",
+	type: "episode",
+	instanceId: "sonarr-1",
+	instanceName: "Sonarr",
+	...overrides,
+});
+
+describe("getCalendarDateKey", () => {
+	it("uses the local day of a Sonarr airDateUtc for timezones east of UTC", () => {
+		const item = createItem({
+			airDate: "2026-08-16",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "Europe/Stockholm")).toBe("2026-08-17");
+	});
+
+	it("uses the local day of a Sonarr airDateUtc for timezones west of UTC", () => {
+		const item = createItem({
+			airDate: "2026-08-16",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "America/New_York")).toBe("2026-08-16");
+	});
+
+	it("preserves date-only semantics for non-Sonarr services", () => {
+		const item = createItem({
+			service: "radarr",
+			type: "movie",
+			airDate: "2026-08-17T00:00:00Z",
+			airDateUtc: "2026-08-17T00:00:00Z",
+		});
+
+		expect(getCalendarDateKey(item, "America/Los_Angeles")).toBe("2026-08-17");
+	});
+
+	it("falls back to airDate when Sonarr provides an invalid UTC timestamp", () => {
+		const item = createItem({
+			airDate: "2026-08-17",
+			airDateUtc: "not-a-date",
+		});
+
+		expect(getCalendarDateKey(item, "Europe/Stockholm")).toBe("2026-08-17");
+	});
+
+	it("returns undefined when an item has no calendar date", () => {
+		expect(getCalendarDateKey(createItem(), "Europe/Stockholm")).toBeUndefined();
+	});
+});

--- a/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
@@ -1,6 +1,10 @@
 import type { CalendarItem } from "@arr/shared";
 import { describe, expect, it } from "vitest";
-import { getCalendarDateKey } from "./calendar-formatters";
+import {
+	getCalendarDateKey,
+	getPaddedCalendarDateRange,
+	isCalendarItemInDateRange,
+} from "./calendar-formatters";
 
 const createItem = (overrides: Partial<CalendarItem> = {}): CalendarItem => ({
 	id: 1,
@@ -53,5 +57,61 @@ describe("getCalendarDateKey", () => {
 
 	it("returns undefined when an item has no calendar date", () => {
 		expect(getCalendarDateKey(createItem(), "Europe/Stockholm")).toBeUndefined();
+	});
+});
+
+describe("calendar fetch boundaries", () => {
+	it("pads the visible grid by one UTC day on both sides", () => {
+		expect(
+			getPaddedCalendarDateRange(
+				new Date("2026-07-26T00:00:00Z"),
+				new Date("2026-09-05T00:00:00Z"),
+			),
+		).toEqual({ start: "2026-07-25", end: "2026-09-06" });
+	});
+
+	it("keeps a padded UTC event that rebuckets onto the first visible day", () => {
+		const item = createItem({
+			airDate: "2026-07-25",
+			airDateUtc: "2026-07-25T23:30:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-05" },
+				"Europe/Stockholm",
+			),
+		).toBe(true);
+	});
+
+	it("drops an event that remains outside the visible range after rebucketing", () => {
+		const item = createItem({
+			airDate: "2026-07-25",
+			airDateUtc: "2026-07-25T12:00:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-05" },
+				"Europe/Stockholm",
+			),
+		).toBe(false);
+	});
+
+	it("keeps a UTC event that rebuckets onto the last visible day west of UTC", () => {
+		const item = createItem({
+			airDate: "2026-09-07",
+			airDateUtc: "2026-09-07T00:30:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-06" },
+				"America/New_York",
+			),
+		).toBe(true);
 	});
 });

--- a/apps/web/src/features/calendar/lib/calendar-formatters.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.ts
@@ -9,6 +9,27 @@ export const formatDateOnly = (date: Date): string => {
 	return index === -1 ? iso : iso.slice(0, index);
 };
 
+export interface CalendarDateRange {
+	start: string;
+	end: string;
+}
+
+/**
+ * Expands the visible grid range enough to cover every valid viewer timezone.
+ * A UTC timestamp can move by at most one calendar day after local conversion.
+ */
+export const getPaddedCalendarDateRange = (start: Date, end: Date): CalendarDateRange => {
+	const paddedStart = new Date(start);
+	paddedStart.setUTCDate(paddedStart.getUTCDate() - 1);
+	const paddedEnd = new Date(end);
+	paddedEnd.setUTCDate(paddedEnd.getUTCDate() + 1);
+
+	return {
+		start: formatDateOnly(paddedStart),
+		end: formatDateOnly(paddedEnd),
+	};
+};
+
 const extractDatePart = (value: string): string => {
 	const separatorIndex = value.indexOf("T");
 	return separatorIndex === -1 ? value : value.slice(0, separatorIndex);
@@ -53,6 +74,20 @@ export const getCalendarDateKey = (item: CalendarItem, timeZone?: string): strin
 
 	const date = item.airDate ?? item.releaseDate ?? item.airDateUtc;
 	return date ? extractDatePart(date) : undefined;
+};
+
+/**
+ * Checks visibility after service dates have been normalized to calendar keys.
+ * This clips the extra fetch padding without dropping events that rebucket onto
+ * the first or last visible day.
+ */
+export const isCalendarItemInDateRange = (
+	item: CalendarItem,
+	range: CalendarDateRange,
+	timeZone?: string,
+): boolean => {
+	const dateKey = getCalendarDateKey(item, timeZone);
+	return dateKey !== undefined && dateKey >= range.start && dateKey <= range.end;
 };
 
 /**

--- a/apps/web/src/features/calendar/lib/calendar-formatters.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.ts
@@ -9,6 +9,52 @@ export const formatDateOnly = (date: Date): string => {
 	return index === -1 ? iso : iso.slice(0, index);
 };
 
+const extractDatePart = (value: string): string => {
+	const separatorIndex = value.indexOf("T");
+	return separatorIndex === -1 ? value : value.slice(0, separatorIndex);
+};
+
+const formatDateInTimeZone = (value: string, timeZone?: string): string | undefined => {
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) {
+		return undefined;
+	}
+
+	const parts = new Intl.DateTimeFormat("en-US", {
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		timeZone,
+	}).formatToParts(parsed);
+	const year = parts.find((part) => part.type === "year")?.value;
+	const month = parts.find((part) => part.type === "month")?.value;
+	const day = parts.find((part) => part.type === "day")?.value;
+
+	return year && month && day ? `${year}-${month}-${day}` : undefined;
+};
+
+/**
+ * Selects the calendar grid day for an event.
+ * Sonarr provides a precise UTC airing time, which must be converted to the
+ * viewer's local day. Other services use release dates with date-only meaning.
+ */
+export const getCalendarDateKey = (item: CalendarItem, timeZone?: string): string | undefined => {
+	if (item.service === "sonarr") {
+		if (item.airDateUtc) {
+			const localDate = formatDateInTimeZone(item.airDateUtc, timeZone);
+			if (localDate) {
+				return localDate;
+			}
+		}
+
+		const fallback = item.airDate ?? item.releaseDate;
+		return fallback ? extractDatePart(fallback) : undefined;
+	}
+
+	const date = item.airDate ?? item.releaseDate ?? item.airDateUtc;
+	return date ? extractDatePart(date) : undefined;
+};
+
 /**
  * Creates a date at the start of the specified month in UTC
  */

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -168,3 +168,60 @@ test.describe("Calendar - Refresh", () => {
 		await expect(page.getByRole("heading", { name: /calendar/i, level: 1 })).toBeVisible();
 	});
 });
+
+test.describe("Calendar - Timezone Bucketing", () => {
+	test.use({ timezoneId: "Europe/Stockholm" });
+
+	test("places an early-morning Sonarr episode on the viewer's local day", async ({ page }) => {
+		await page.clock.setFixedTime(new Date("2026-08-16T12:00:00Z"));
+		const networkDate = "2026-08-15";
+		const localDate = "2026-08-16";
+		const title = "Stockholm timezone regression";
+
+		await page.route("**/api/services", async (route) => {
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({ services: [] }),
+			});
+		});
+		await page.route("**/api/dashboard/calendar?**", async (route) => {
+			const item = {
+				id: 756,
+				title,
+				seriesTitle: title,
+				service: "sonarr",
+				type: "episode",
+				airDate: networkDate,
+				airDateUtc: `${localDate}T00:00:00Z`,
+				seasonNumber: 1,
+				episodeNumber: 1,
+				instanceId: "sonarr-1",
+				instanceName: "Sonarr",
+			};
+
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({
+					instances: [
+						{
+							instanceId: "sonarr-1",
+							instanceName: "Sonarr",
+							service: "sonarr",
+							data: [item],
+						},
+					],
+					aggregated: [item],
+					totalCount: 1,
+				}),
+			});
+		});
+
+		const baseUrl = process.env.TEST_BASE_URL ?? "";
+		await page.goto(`${baseUrl}${ROUTES.calendar}`);
+		const eventChip = page.getByText(title, { exact: true });
+		await expect(eventChip).toBeVisible({ timeout: TIMEOUTS.medium });
+
+		const eventCell = eventChip.locator("xpath=ancestor::button[1]");
+		await expect(eventCell.locator("span").filter({ hasText: /^16$/ })).toBeVisible();
+	});
+});

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -224,4 +224,69 @@ test.describe("Calendar - Timezone Bucketing", () => {
 		const eventCell = eventChip.locator("xpath=ancestor::button[1]");
 		await expect(eventCell.locator("span").filter({ hasText: /^16$/ })).toBeVisible();
 	});
+
+	test("fetches and clips timezone padding around the visible grid", async ({ page }) => {
+		await page.clock.setFixedTime(new Date("2026-08-16T12:00:00Z"));
+		const boundaryTitle = "Visible boundary episode";
+		const paddingOnlyTitle = "Padding-only episode";
+
+		await page.route("**/api/services", async (route) => {
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({ services: [] }),
+			});
+		});
+		await page.route("**/api/dashboard/calendar?**", async (route) => {
+			const url = new URL(route.request().url());
+			expect(url.searchParams.get("start")).toBe("2026-07-25");
+			expect(url.searchParams.get("end")).toBe("2026-09-06");
+
+			const boundaryItem = {
+				id: 757,
+				title: boundaryTitle,
+				seriesTitle: boundaryTitle,
+				service: "sonarr",
+				type: "episode",
+				airDate: "2026-07-25",
+				airDateUtc: "2026-07-25T23:30:00Z",
+				seasonNumber: 1,
+				episodeNumber: 1,
+				instanceId: "sonarr-1",
+				instanceName: "Sonarr",
+			};
+			const paddingOnlyItem = {
+				...boundaryItem,
+				id: 758,
+				title: paddingOnlyTitle,
+				seriesTitle: paddingOnlyTitle,
+				airDateUtc: "2026-07-25T12:00:00Z",
+				episodeNumber: 2,
+			};
+
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({
+					instances: [
+						{
+							instanceId: "sonarr-1",
+							instanceName: "Sonarr",
+							service: "sonarr",
+							data: [boundaryItem, paddingOnlyItem],
+						},
+					],
+					aggregated: [boundaryItem, paddingOnlyItem],
+					totalCount: 2,
+				}),
+			});
+		});
+
+		const baseUrl = process.env.TEST_BASE_URL ?? "";
+		await page.goto(`${baseUrl}${ROUTES.calendar}`);
+		const boundaryChip = page.getByText(boundaryTitle, { exact: true });
+		await expect(boundaryChip).toBeVisible({ timeout: TIMEOUTS.medium });
+		await expect(page.getByText(paddingOnlyTitle, { exact: true })).toHaveCount(0);
+
+		const boundaryCell = boundaryChip.locator("xpath=ancestor::button[1]");
+		await expect(boundaryCell.locator("span").filter({ hasText: /^26$/ })).toBeVisible();
+	});
 });


### PR DESCRIPTION
## Summary

- forward-port the stable #761 calendar fix to `next`
- bucket Sonarr episodes by `airDateUtc` in the viewer timezone while preserving date-only behavior for Radarr, Lidarr, and Readarr
- pad calendar fetches by one UTC day on each side, then clip events after viewer-timezone bucketing so first and last grid days are complete
- retain UTC precision for intra-day sorting and add unit plus production-browser regression coverage

## Root cause

The calendar grouped every item by the service-provided date-only field. For Sonarr episodes near midnight UTC, that field could represent a different day than the viewer sees. Rebucketing alone also left a boundary gap because an event could move onto the visible first or last grid day after the upstream request had already excluded it.

## Verification

- the first commit patch ID exactly matches stable squash merge `6877cd70968f8a38787c13b099b1d8fd4d0220db`
- focused formatter tests: 9 passed
- production Playwright timezone scenarios: 3 passed, including authentication setup, the reported Stockholm shift, and fetch-boundary clipping
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 4,216 passed / 58 skipped; shared 154 passed; web 864 passed)
- `pnpm run lint`
- `pnpm run build`
- independent forward-port regression review: no actionable findings before the bounded boundary correction

## Risk

The behavior change is limited to calendar fetching and day bucketing. Requests include one extra UTC day on each side, which covers all valid timezone offsets; results are clipped to the visible grid after service-specific date normalization. Intra-day sorting is unchanged.

Related to #756