### PR TITLE
fix(calendar): cover viewer-timezone grid boundaries

### DIFF
--- a/apps/web/src/features/calendar/components/calendar-client.tsx
+++ b/apps/web/src/features/calendar/components/calendar-client.tsx
@@ -10,7 +10,7 @@ import { useCalendarData } from "../hooks/use-calendar-data";
 import { useCalendarPlexLinks } from "../hooks/use-calendar-plex-links";
 import { useFirstDayOfWeek } from "../../../hooks/useFirstDayOfWeek";
 import { useCalendarState } from "../hooks/use-calendar-state";
-import { formatDateOnly } from "../lib/calendar-formatters";
+import { formatDateOnly, getPaddedCalendarDateRange } from "../lib/calendar-formatters";
 import { CalendarEventList } from "./calendar-event-list";
 import { CalendarFilters } from "./calendar-filters";
 import { CalendarGrid } from "./calendar-grid";
@@ -22,10 +22,16 @@ export const CalendarClient = () => {
 	const { calendarStart, calendarEnd, filters, monthStart, selectedDate, daysInView } =
 		calendarState;
 
-	const queryParams = useMemo(
+	const visibleRange = useMemo(
 		() => ({
 			start: formatDateOnly(calendarStart),
 			end: formatDateOnly(calendarEnd),
+		}),
+		[calendarStart, calendarEnd],
+	);
+	const queryParams = useMemo(
+		() => ({
+			...getPaddedCalendarDateRange(calendarStart, calendarEnd),
 			unmonitored: filters.includeUnmonitored,
 		}),
 		[calendarStart, calendarEnd, filters.includeUnmonitored],
@@ -35,7 +41,7 @@ export const CalendarClient = () => {
 
 	const { data: services } = useServicesQuery();
 
-	const calendarData = useCalendarData(data, services, filters);
+	const calendarData = useCalendarData(data, services, filters, visibleRange);
 	const { eventsByDate, serviceMap, instanceOptions, filteredEvents } = calendarData;
 
 	// Plex deep links — only fetched when Plex is configured

--- a/apps/web/src/features/calendar/hooks/use-calendar-data.ts
+++ b/apps/web/src/features/calendar/hooks/use-calendar-data.ts
@@ -1,6 +1,10 @@
 import type { CalendarItem, ServiceInstanceSummary } from "@arr/shared";
 import { useMemo } from "react";
-import { getCalendarDateKey } from "../lib/calendar-formatters";
+import {
+	type CalendarDateRange,
+	getCalendarDateKey,
+	isCalendarItemInDateRange,
+} from "../lib/calendar-formatters";
 import type { CalendarFilters } from "./use-calendar-state";
 
 /**
@@ -130,6 +134,7 @@ export const useCalendarData = (
 		| undefined,
 	services: ServiceInstanceSummary[] | undefined,
 	filters: CalendarFilters,
+	visibleRange: CalendarDateRange,
 ): CalendarDataHookResult => {
 	const aggregated = useMemo(() => data?.aggregated ?? [], [data?.aggregated]);
 	const instances = useMemo(() => data?.instances ?? [], [data?.instances]);
@@ -156,6 +161,9 @@ export const useCalendarData = (
 	const filteredEvents = useMemo(() => {
 		const term = filters.searchTerm.trim().toLowerCase();
 		const filtered = aggregated.filter((item) => {
+			if (!isCalendarItemInDateRange(item, visibleRange)) {
+				return false;
+			}
 			if (filters.serviceFilter !== "all" && item.service !== filters.serviceFilter) {
 				return false;
 			}
@@ -186,7 +194,7 @@ export const useCalendarData = (
 		});
 		// Deduplicate events that appear in multiple instances
 		return deduplicateEvents(filtered);
-	}, [aggregated, filters]);
+	}, [aggregated, filters, visibleRange]);
 
 	const eventsByDate = useMemo(() => {
 		const map = new Map<string, DeduplicatedCalendarItem[]>();

--- a/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.test.ts
@@ -1,6 +1,10 @@
 import type { CalendarItem } from "@arr/shared";
 import { describe, expect, it } from "vitest";
-import { getCalendarDateKey } from "./calendar-formatters";
+import {
+	getCalendarDateKey,
+	getPaddedCalendarDateRange,
+	isCalendarItemInDateRange,
+} from "./calendar-formatters";
 
 const createItem = (overrides: Partial<CalendarItem> = {}): CalendarItem => ({
 	id: 1,
@@ -53,5 +57,61 @@ describe("getCalendarDateKey", () => {
 
 	it("returns undefined when an item has no calendar date", () => {
 		expect(getCalendarDateKey(createItem(), "Europe/Stockholm")).toBeUndefined();
+	});
+});
+
+describe("calendar fetch boundaries", () => {
+	it("pads the visible grid by one UTC day on both sides", () => {
+		expect(
+			getPaddedCalendarDateRange(
+				new Date("2026-07-26T00:00:00Z"),
+				new Date("2026-09-05T00:00:00Z"),
+			),
+		).toEqual({ start: "2026-07-25", end: "2026-09-06" });
+	});
+
+	it("keeps a padded UTC event that rebuckets onto the first visible day", () => {
+		const item = createItem({
+			airDate: "2026-07-25",
+			airDateUtc: "2026-07-25T23:30:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-05" },
+				"Europe/Stockholm",
+			),
+		).toBe(true);
+	});
+
+	it("drops an event that remains outside the visible range after rebucketing", () => {
+		const item = createItem({
+			airDate: "2026-07-25",
+			airDateUtc: "2026-07-25T12:00:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-05" },
+				"Europe/Stockholm",
+			),
+		).toBe(false);
+	});
+
+	it("keeps a UTC event that rebuckets onto the last visible day west of UTC", () => {
+		const item = createItem({
+			airDate: "2026-09-07",
+			airDateUtc: "2026-09-07T00:30:00Z",
+		});
+
+		expect(
+			isCalendarItemInDateRange(
+				item,
+				{ start: "2026-07-26", end: "2026-09-06" },
+				"America/New_York",
+			),
+		).toBe(true);
 	});
 });

--- a/apps/web/src/features/calendar/lib/calendar-formatters.ts
+++ b/apps/web/src/features/calendar/lib/calendar-formatters.ts
@@ -9,6 +9,27 @@ export const formatDateOnly = (date: Date): string => {
 	return index === -1 ? iso : iso.slice(0, index);
 };
 
+export interface CalendarDateRange {
+	start: string;
+	end: string;
+}
+
+/**
+ * Expands the visible grid range enough to cover every valid viewer timezone.
+ * A UTC timestamp can move by at most one calendar day after local conversion.
+ */
+export const getPaddedCalendarDateRange = (start: Date, end: Date): CalendarDateRange => {
+	const paddedStart = new Date(start);
+	paddedStart.setUTCDate(paddedStart.getUTCDate() - 1);
+	const paddedEnd = new Date(end);
+	paddedEnd.setUTCDate(paddedEnd.getUTCDate() + 1);
+
+	return {
+		start: formatDateOnly(paddedStart),
+		end: formatDateOnly(paddedEnd),
+	};
+};
+
 const extractDatePart = (value: string): string => {
 	const separatorIndex = value.indexOf("T");
 	return separatorIndex === -1 ? value : value.slice(0, separatorIndex);
@@ -53,6 +74,20 @@ export const getCalendarDateKey = (item: CalendarItem, timeZone?: string): strin
 
 	const date = item.airDate ?? item.releaseDate ?? item.airDateUtc;
 	return date ? extractDatePart(date) : undefined;
+};
+
+/**
+ * Checks visibility after service dates have been normalized to calendar keys.
+ * This clips the extra fetch padding without dropping events that rebucket onto
+ * the first or last visible day.
+ */
+export const isCalendarItemInDateRange = (
+	item: CalendarItem,
+	range: CalendarDateRange,
+	timeZone?: string,
+): boolean => {
+	const dateKey = getCalendarDateKey(item, timeZone);
+	return dateKey !== undefined && dateKey >= range.start && dateKey <= range.end;
 };
 
 /**

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -224,4 +224,69 @@ test.describe("Calendar - Timezone Bucketing", () => {
 		const eventCell = eventChip.locator("xpath=ancestor::button[1]");
 		await expect(eventCell.locator("span").filter({ hasText: /^16$/ })).toBeVisible();
 	});
+
+	test("fetches and clips timezone padding around the visible grid", async ({ page }) => {
+		await page.clock.setFixedTime(new Date("2026-08-16T12:00:00Z"));
+		const boundaryTitle = "Visible boundary episode";
+		const paddingOnlyTitle = "Padding-only episode";
+
+		await page.route("**/api/services", async (route) => {
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({ services: [] }),
+			});
+		});
+		await page.route("**/api/dashboard/calendar?**", async (route) => {
+			const url = new URL(route.request().url());
+			expect(url.searchParams.get("start")).toBe("2026-07-25");
+			expect(url.searchParams.get("end")).toBe("2026-09-06");
+
+			const boundaryItem = {
+				id: 757,
+				title: boundaryTitle,
+				seriesTitle: boundaryTitle,
+				service: "sonarr",
+				type: "episode",
+				airDate: "2026-07-25",
+				airDateUtc: "2026-07-25T23:30:00Z",
+				seasonNumber: 1,
+				episodeNumber: 1,
+				instanceId: "sonarr-1",
+				instanceName: "Sonarr",
+			};
+			const paddingOnlyItem = {
+				...boundaryItem,
+				id: 758,
+				title: paddingOnlyTitle,
+				seriesTitle: paddingOnlyTitle,
+				airDateUtc: "2026-07-25T12:00:00Z",
+				episodeNumber: 2,
+			};
+
+			await route.fulfill({
+				contentType: "application/json",
+				body: JSON.stringify({
+					instances: [
+						{
+							instanceId: "sonarr-1",
+							instanceName: "Sonarr",
+							service: "sonarr",
+							data: [boundaryItem, paddingOnlyItem],
+						},
+					],
+					aggregated: [boundaryItem, paddingOnlyItem],
+					totalCount: 2,
+				}),
+			});
+		});
+
+		const baseUrl = process.env.TEST_BASE_URL ?? "";
+		await page.goto(`${baseUrl}${ROUTES.calendar}`);
+		const boundaryChip = page.getByText(boundaryTitle, { exact: true });
+		await expect(boundaryChip).toBeVisible({ timeout: TIMEOUTS.medium });
+		await expect(page.getByText(paddingOnlyTitle, { exact: true })).toHaveCount(0);
+
+		const boundaryCell = boundaryChip.locator("xpath=ancestor::button[1]");
+		await expect(boundaryCell.locator("span").filter({ hasText: /^26$/ })).toBeVisible();
+	});
 });


### PR DESCRIPTION
## Summary

- request one extra UTC calendar day on each side of the visible 42-day grid
- clip returned items only after converting Sonarr UTC air times to the viewer calendar day
- add first-boundary, last-boundary, padding-exclusion, and production-browser regression coverage

## Root cause

The viewer-timezone bucketing added in #761 can move a Sonarr episode onto the first or last visible grid day. The previous request still fetched exactly the visible date-only range, so Sonarr could exclude that episode before the browser had a chance to rebucket it.

## Verification

- correction patch ID exactly matches `next` correction commit `6b9de41ac3b4923861cbde3fae4c61656ff588e6`
- focused formatter tests: 9 passed
- production Playwright timezone scenarios: 3 passed, including authentication setup, the reported Stockholm shift, and fetch-boundary clipping
- `pnpm run format`
- `pnpm --filter @arr/shared build`
- `pnpm run typecheck`
- `pnpm run test` (API 4,027 passed / 50 skipped; shared 89 passed; web 660 passed)
- `pnpm run lint`
- `pnpm run build`

## Risk

Calendar requests include two additional days total. Results are clipped to the visible grid after service-specific date normalization, so padding-only events do not render or trigger downstream Plex-link work. Other service date semantics and intra-day sorting are unchanged.

Related to #756