### PR TITLE
chore(release): prepare v2.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.24.1] - 2026-08-16 — Recovery and timezone correctness
+
+This patch makes partial Sonarr episode cleanup recover safely, fixes public
+OIDC callback selection behind reverse proxies, and keeps Sonarr calendar
+dates correct at viewer-timezone and visible-grid boundaries.
+
+### Changed
+
+- Maintainer-local agent tooling, temporary plans, generated screenshots, and
+  source files proven unreachable from the application were removed from the
+  public repository. Durable contributor guidance remains in
+  `docs/DEVELOPMENT.md` (#754).
+- Docker Login Action and CodeQL Action were refreshed across the stable
+  workflows while retaining immutable commit pins (#683).
+
+### Fixed
+
+- **Sonarr episode cleanup recovery** — The cleanup executor now records each
+  upstream phase durably, resumes confirmed partial work without repeating the
+  unmonitor request, and refuses file deletion when the unmonitor outcome
+  cannot be attributed safely (#755, related to #659).
+- **OIDC callbacks behind reverse proxies** — Setup and authenticated provider
+  management now derive callbacks from operator-controlled public origins,
+  including `WEBAUTHN_ORIGIN` when `APP_URL` is local. Forwarded host and
+  protocol headers cannot select the callback origin (#759, closes #752).
+- **Sonarr calendar dates** — Sonarr episodes are bucketed by the viewer's
+  local day from `airDateUtc`, with a padded fetch range so timezone conversion
+  cannot drop events at the first or last visible grid day (#761, #763, closes
+  #756).
+
 ## [2.24.0] - 2026-08-16 — Safer cleanup & resilient automation
 
 Library Cleanup can now target individual Sonarr episodes. This release also

--- a/DOCKERHUB.md
+++ b/DOCKERHUB.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.24.0** — The **safer cleanup & resilient automation release**. Library Cleanup can now target individual Sonarr episodes and does more to protect shared media before deletion. TRaSH deployments and auto-sync recover from interrupted runs and refuse to write from stale or unverified data. This release also fixes Plex cache refreshes, OIDC linking behind proxy providers, qUI webhook registration, Seerr approval routing, PostgreSQL upgrades, vulnerable dependencies, and refresh-time memory use.
+> **Version 2.24.1** — The **recovery and timezone correctness patch**. Sonarr episode cleanup now resumes safely after partial failures, OIDC callbacks honor configured public origins behind reverse proxies, and Sonarr calendar dates remain correct across viewer timezones and visible-grid boundaries. Workflow action pins and public repository hygiene are also refreshed.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -95,6 +95,7 @@ services:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.24.1` | **Recovery and timezone correctness** — Makes Sonarr episode cleanup recovery durable, fixes OIDC callback origins behind reverse proxies, and corrects Sonarr calendar bucketing and fetch boundaries in the viewer's timezone (#755, #759, #761, #763). |
 | `2.24.0` | **Safer cleanup & resilient automation** — Adds episode-scoped Sonarr cleanup and tighter shared-library deletion checks. TRaSH deployments and auto-sync recover from interrupted runs and refuse stale or unverified data. Also fixes Plex cache refreshes, OIDC linking, qUI webhooks, Seerr routing, PostgreSQL upgrades, vulnerable dependencies, and provider-cache memory (#629, #661, #685, #693, #718, #721, #743, #745, #747–#750). |
 | `2.23.0` | **Torrent payload safeguards** — Adds an opt-in Queue Cleaner torrent file-extension allowlist inspected through qui. Mixed torrents containing any unexpected file are removed in full through Sonarr or Radarr when existing safety gates permit cleanup; unavailable manifest metadata fails closed and is retried later (#565, #612). Updates PostCSS to 8.5.20 to resolve GHSA-6g55-p6wh-862q (#611). |
 | `2.22.0` | **Authenticated services & hardened maintenance** — Adds optional encrypted HTTP Basic Auth for service instances behind authenticated reverse proxies (#600), restores new-library notifications for between-poll imports (#601, #543), supports Sonarr flat ratings in Library Cleanup (#604), refreshes production/development dependencies and GitHub Actions, restores a zero-diagnostic quality baseline, and pins third-party actions with dependency release-age and provenance policies (#547, #582, #583, #597, #598, #603, #605). |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Arr Dashboard
 
-> **Version 2.24.0** — The **safer cleanup & resilient automation release**. Library Cleanup can now target individual Sonarr episodes and does more to protect shared media before deletion. TRaSH deployments and auto-sync recover from interrupted runs and refuse to write from stale or unverified data. This release also fixes Plex cache refreshes, OIDC linking behind proxy providers, qUI webhook registration, Seerr approval routing, PostgreSQL upgrades, vulnerable dependencies, and refresh-time memory use.
+> **Version 2.24.1** — The **recovery and timezone correctness patch**. Sonarr episode cleanup now resumes safely after partial failures, OIDC callbacks honor configured public origins behind reverse proxies, and Sonarr calendar dates remain correct across viewer timezones and visible-grid boundaries. Workflow action pins and public repository hygiene are also refreshed.
 
 A unified dashboard for managing multiple **Sonarr**, **Radarr**, **Prowlarr**, **Lidarr**, **Readarr**, **Plex**, **Tautulli**, **Jellyfin**, **Emby**, and **Seerr** instances. Consolidate your media automation management into a single, secure, and powerful interface.
 
@@ -233,6 +233,7 @@ First-class support is reserved for services listed in the table above.
 | Tag | Description |
 |-----|-------------|
 | `latest` | Latest stable release |
+| `2.24.1` | **Recovery and timezone correctness** — Makes Sonarr episode cleanup recovery durable, fixes OIDC callback origins behind reverse proxies, and corrects Sonarr calendar bucketing and fetch boundaries in the viewer's timezone (#755, #759, #761, #763). |
 | `2.24.0` | **Safer cleanup & resilient automation** — Adds episode-scoped Sonarr cleanup and tighter shared-library deletion checks. TRaSH deployments and auto-sync recover from interrupted runs and refuse stale or unverified data. Also fixes Plex cache refreshes, OIDC linking, qUI webhooks, Seerr routing, PostgreSQL upgrades, vulnerable dependencies, and provider-cache memory (#629, #661, #685, #693, #718, #721, #743, #745, #747–#750). |
 | `2.23.0` | **Torrent payload safeguards** — Adds an opt-in Queue Cleaner torrent file-extension allowlist inspected through qui. Mixed torrents containing any unexpected file are removed in full through Sonarr or Radarr when existing safety gates permit cleanup; unavailable manifest metadata fails closed and is retried later (#565, #612). Updates PostCSS to 8.5.20 to resolve GHSA-6g55-p6wh-862q (#611). |
 | `2.22.0` | **Authenticated services & hardened maintenance** — Adds optional encrypted HTTP Basic Auth for service instances behind authenticated reverse proxies (#600), restores new-library notifications for between-poll imports (#601, #543), supports Sonarr flat ratings in Library Cleanup (#604), refreshes production/development dependencies and GitHub Actions, restores a zero-diagnostic quality baseline, and pins third-party actions with dependency release-age and provenance policies (#547, #582, #583, #597, #598, #603, #605). |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "arr-dashboard-platform",
-	"version": "2.24.0",
+	"version": "2.24.1",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {


### PR DESCRIPTION
## Summary

Prepare the stable `v2.24.1` patch release.

- bump the root package version to `2.24.1`
- add release notes for the exact `v2.24.0..main` range
- update the README and Docker Hub version surfaces
- keep the still-unconfirmed Plex cache report open rather than claiming it closed

## Included changes

- durable Sonarr episode-cleanup recovery (#755)
- public OIDC callback origins behind reverse proxies (#759)
- viewer-timezone Sonarr calendar bucketing and boundary coverage (#761, #763)
- public repository hygiene (#754)
- immutable Docker Login and CodeQL action refresh (#683)

## Validation

- `pnpm run format`
- Prisma generation followed by root `pnpm run typecheck`
- `pnpm run test` — 4,776 passed, 50 skipped
- `pnpm run lint`
- `pnpm run build`
- production Docker build
- fresh SQLite and PostgreSQL startup
- SQLite and PostgreSQL upgrades from the published `v2.24.0` image with persisted login
- real disposable Sonarr and Radarr full-resource tag write, verification, revert, and tag cleanup
- `/health` reports version `2.24.1`
- zero open Dependabot, code-scanning, or secret-scanning alerts
- independent release-scope audit: no findings

## Publication gate

The wiki edits are prepared separately. The tag, registry publication, and GitHub Release will be created only after this PR is reviewed, green, and merged.