### PR TITLE
fix(test): prevent pipefail exits in integration log checks

### DIFF
--- a/e2e/integration/scripts/postgres-test.sh
+++ b/e2e/integration/scripts/postgres-test.sh
@@ -91,13 +91,13 @@ docker run -d \
 
 wait_health "http://localhost:${PORT_API}/health" 120 || {
   log "Container logs:"
-  docker logs "$CONTAINER_APP" 2>&1 | tail -20
+  docker logs --tail 20 "$CONTAINER_APP" 2>&1
   fail "arr-dashboard did not start with PostgreSQL"
 }
 pass "arr-dashboard started with PostgreSQL"
 
 # Check startup logs for provider switch
-STARTUP_LOGS=$(docker logs "$CONTAINER_APP" 2>&1 | head -100)
+STARTUP_LOGS=$(docker logs "$CONTAINER_APP" 2>&1 | sed -n '1,100p')
 if echo "$STARTUP_LOGS" | grep -qi "postgresql"; then
   pass "PostgreSQL provider detected in logs"
 fi
@@ -106,7 +106,7 @@ if echo "$STARTUP_LOGS" | grep -q "synchronized successfully\|already in sync"; 
   pass "Database schema sync succeeded"
 else
   log "  Schema sync logs:"
-  echo "$STARTUP_LOGS" | grep -i "schema\|database\|prisma" | head -10
+  grep -i -m 10 "schema\|database\|prisma" <<<"$STARTUP_LOGS" || true
   fail "Database schema sync could not be confirmed on PostgreSQL"
 fi
 

--- a/e2e/integration/scripts/upgrade-test.sh
+++ b/e2e/integration/scripts/upgrade-test.sh
@@ -161,10 +161,10 @@ NEW_VERSION=$(curl -sf "http://localhost:${PORT_API}/health" | python3 -c "impor
 log "  New version: ${NEW_VERSION}"
 
 # Check startup logs for migration issues
-STARTUP_LOGS=$(docker logs "$CONTAINER" 2>&1 | head -100)
+STARTUP_LOGS=$(docker logs "$CONTAINER" 2>&1 | sed -n '1,100p')
 if echo "$STARTUP_LOGS" | grep -qi "panic\|FATAL\|cannot open database"; then
   log "  Fatal errors found in startup logs:"
-  echo "$STARTUP_LOGS" | grep -i "panic\|FATAL\|cannot open database" | head -5
+  grep -i -m 5 "panic\|FATAL\|cannot open database" <<<"$STARTUP_LOGS"
   fail "Fatal startup errors detected"
 fi
 
@@ -173,7 +173,7 @@ if echo "$STARTUP_LOGS" | grep -q "already in sync\|synchronized successfully"; 
   pass "Database schema sync succeeded"
 else
   log "  Schema sync logs:"
-  echo "$STARTUP_LOGS" | grep -i "schema\|database\|prisma" | head -10
+  grep -i -m 10 "schema\|database\|prisma" <<<"$STARTUP_LOGS" || true
   fail "Database schema sync could not be confirmed"
 fi
 


### PR DESCRIPTION
## Summary

- Preserve the first 100 startup log lines without using `head` in a `pipefail` pipeline.
- Bound diagnostic matches with `grep -m` while allowing the no-match diagnostic path to reach the intended failure message.
- Use Docker's native `--tail` option for the PostgreSQL startup-failure log excerpt.

## Root cause

Both integration harnesses run with `set -euo pipefail`. When enough log output was present, `head` exited after reaching its limit and the upstream `docker logs` or `grep` process received SIGPIPE. The resulting status 141 could terminate the harness before its actual validation or failure message ran.

## Validation

- `bash -n e2e/integration/scripts/postgres-test.sh`
- `bash -n e2e/integration/scripts/upgrade-test.sh`
- Deterministic 200,000-line Docker-log reproduction: status changed from 141 to 0 while preserving startup lines 0 through 99.
- `bash e2e/integration/scripts/postgres-test.sh`
- `bash e2e/integration/scripts/upgrade-test.sh`
- `pnpm run format`
- `pnpm --filter @arr/api run db:generate && pnpm run typecheck`
- `pnpm run test` — 4,027 passed, 50 skipped
- `pnpm run lint`
- Independent infrastructure review: no findings

## Scope and follow-up

This changes test harness behavior only; application runtime behavior is unchanged. The local upgrade run also exposed stale image selection (`2.24.1` to `2.24.0`). Correct image selection and version-order enforcement are intentionally reserved for a separate focused change.