### PR TITLE
refactor: deduplicate cleanup run-lease primitives into cleanup-run-lease

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
@@ -7,7 +7,7 @@ import {
 	renewCleanupRunLease,
 	withCleanupTopologyMutationLease,
 	withCleanupPolicyMutationLease,
-} from "../cleanup-executor.js";
+} from "../cleanup-run-lease.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
 describe("library cleanup database run lease", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -5,10 +5,12 @@ import { PlexMovieNotFoundError } from "../../plex/plex-client.js";
 import { withQuiObservationTopologyGuard } from "../../qui/observation-topology-guard.js";
 import { appendCleanupAuditEvent, appendCleanupTerminalAuditEvent } from "../cleanup-audit.js";
 import {
-	buildCleanupPreviewDetails,
-	cleanupApprovalTargetKey,
 	CleanupRunAlreadyInProgressError,
 	CleanupRunLeaseLostError,
+} from "../cleanup-run-lease.js";
+import {
+	buildCleanupPreviewDetails,
+	cleanupApprovalTargetKey,
 	executeApprovedItems,
 	executeCleanupPreview,
 	executeCleanupRun,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -51,11 +51,9 @@ import { SeerrClient } from "../seerr/seerr-client.js";
 import { hasAuthoritativeProviderCacheGeneration } from "../services/provider-identity-guard.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { safeJsonParse } from "../utils/json.js";
-import {
-	withCleanupOperationGuard,
-	withExclusiveCleanupOperationGuard,
-} from "./cleanup-maintenance-gate.js";
+import { withCleanupOperationGuard } from "./cleanup-maintenance-gate.js";
 import { deriveArrPolicyEvidence } from "./arr-policy-evidence.js";
+import { CleanupRunLeaseLostError, startCleanupRunLease } from "./cleanup-run-lease.js";
 import {
 	appendCleanupAuditEvent,
 	appendCleanupTerminalAuditEvent,
@@ -1042,258 +1040,14 @@ const CIRCUIT_BREAKER_THRESHOLD = 3;
 
 const SEERR_PREFETCH_MAX_REQUESTS = 5_000;
 
-export const CLEANUP_RUN_LEASE_MS = 2 * 60 * 60 * 1000;
-const CLEANUP_RUN_HEARTBEAT_MS = 60 * 1000;
-
 export const INTERRUPTED_CLEANUP_RECOVERY_MESSAGE =
 	"Recovered after an interrupted cleanup. Review and approve again to reconcile the verified ARR state.";
-
-export class CleanupRunAlreadyInProgressError extends Error {
-	constructor() {
-		super("A cleanup operation is already in progress");
-		this.name = "CleanupRunAlreadyInProgressError";
-	}
-}
-
-export class CleanupRunLeaseLostError extends Error {
-	constructor() {
-		super("The cleanup run lost its database execution lease");
-		this.name = "CleanupRunLeaseLostError";
-	}
-}
-
-export class CleanupTopologyMutationConflictError extends Error {
-	readonly statusCode = 409;
-
-	constructor() {
-		super("Service instances cannot be changed while a library cleanup operation is in progress");
-		this.name = "CleanupTopologyMutationConflictError";
-	}
-}
-
-export class CleanupPolicyMutationConflictError extends Error {
-	readonly statusCode = 409;
-
-	constructor() {
-		super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
-		this.name = "CleanupPolicyMutationConflictError";
-	}
-}
 
 class CleanupExemptionAuthorityError extends Error {
 	constructor() {
 		super("Skipped for safety: current deployed cleanup exemption policy covers this ARR target.");
 		this.name = "CleanupExemptionAuthorityError";
 	}
-}
-
-export async function acquireCleanupRunLease(
-	prisma: CleanupExecutorDeps["prisma"],
-	userId: string,
-	configId: string,
-	now: Date = new Date(),
-	runClaimToken: string = randomUUID(),
-): Promise<string | null> {
-	const claim = await prisma.libraryCleanupConfig.updateMany({
-		where: {
-			id: configId,
-			userId,
-			OR: [
-				{ runClaimToken: null },
-				{ runClaimedAt: null },
-				{ runClaimedAt: { lt: new Date(now.getTime() - CLEANUP_RUN_LEASE_MS) } },
-			],
-		},
-		data: { runClaimToken, runClaimedAt: now },
-	});
-	return claim.count === 1 ? runClaimToken : null;
-}
-
-export async function releaseCleanupRunLease(
-	prisma: CleanupExecutorDeps["prisma"],
-	userId: string,
-	configId: string,
-	runClaimToken: string,
-): Promise<boolean> {
-	const release = await prisma.libraryCleanupConfig.updateMany({
-		where: { id: configId, userId, runClaimToken },
-		data: { runClaimToken: null, runClaimedAt: null },
-	});
-	return release.count === 1;
-}
-
-export async function renewCleanupRunLease(
-	prisma: CleanupExecutorDeps["prisma"],
-	userId: string,
-	configId: string,
-	runClaimToken: string,
-	now: Date = new Date(),
-): Promise<boolean> {
-	const renewal = await prisma.libraryCleanupConfig.updateMany({
-		where: { id: configId, userId, runClaimToken },
-		data: { runClaimedAt: now },
-	});
-	return renewal.count === 1;
-}
-
-async function withCleanupMutationLease<T>(
-	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
-	userId: string,
-	mutate: () => Promise<T>,
-	conflictError: () => Error,
-	options: {
-		configId?: string;
-		leaseRowMayBeDeleted?: boolean;
-		exclusiveOperation?: boolean;
-	} = {},
-): Promise<T> {
-	const runWithOperationGuard = options.exclusiveOperation
-		? withExclusiveCleanupOperationGuard
-		: withCleanupOperationGuard;
-	return await runWithOperationGuard(async () => {
-		const { prisma, log } = deps;
-		// Ensure the per-user coordination row exists when the caller does not
-		// already have its ID. This closes the initialization race between a
-		// cleanup-sensitive write and the first cleanup run.
-		const config = options.configId
-			? { id: options.configId }
-			: await prisma.libraryCleanupConfig.upsert({
-					where: { userId },
-					update: {},
-					create: { userId },
-					select: { id: true },
-				});
-		const runClaimToken = await acquireCleanupRunLease(prisma, userId, config.id);
-		if (!runClaimToken) throw conflictError();
-
-		try {
-			return await mutate();
-		} finally {
-			await releaseCleanupRunLease(prisma, userId, config.id, runClaimToken)
-				.then((released) => {
-					if (!released && !options.leaseRowMayBeDeleted) {
-						log.warn(
-							{ configId: config.id },
-							"Service topology mutation finished after its cleanup lease ownership changed",
-						);
-					}
-				})
-				.catch((error) => {
-					log.error(
-						{ err: error, configId: config.id },
-						"Service topology mutation finished but its cleanup lease could not be released",
-					);
-				});
-		}
-	});
-}
-
-export async function withCleanupTopologyMutationLease<T>(
-	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
-	userId: string,
-	mutate: () => Promise<T>,
-	options: { leaseRowMayBeDeleted?: boolean } = {},
-): Promise<T> {
-	return await withCleanupMutationLease(
-		deps,
-		userId,
-		mutate,
-		() => new CleanupTopologyMutationConflictError(),
-		options,
-	);
-}
-
-/** Serialize destructive ARR service deletion against every cleanup/TRaSH mutation. */
-export async function withExclusiveCleanupTopologyMutationLease<T>(
-	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
-	userId: string,
-	mutate: () => Promise<T>,
-	options: { leaseRowMayBeDeleted?: boolean } = {},
-): Promise<T> {
-	return await withCleanupMutationLease(
-		deps,
-		userId,
-		mutate,
-		() => new CleanupTopologyMutationConflictError(),
-		{ ...options, exclusiveOperation: true },
-	);
-}
-
-export async function withCleanupPolicyMutationLease<T>(
-	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
-	userId: string,
-	mutate: () => Promise<T>,
-	options: { configId?: string } = {},
-): Promise<T> {
-	return await withCleanupMutationLease(
-		deps,
-		userId,
-		mutate,
-		() => new CleanupPolicyMutationConflictError(),
-		options,
-	);
-}
-
-async function startCleanupRunLease(
-	deps: CleanupExecutorDeps,
-	userId: string,
-	configId: string,
-): Promise<{
-	runClaimToken: string;
-	assertOwnership: () => Promise<void>;
-	release: () => Promise<void>;
-}> {
-	const { prisma, log } = deps;
-	const runClaimToken = await acquireCleanupRunLease(prisma, userId, configId);
-	if (!runClaimToken) throw new CleanupRunAlreadyInProgressError();
-
-	let runLeaseLost = false;
-	const assertOwnership = async () => {
-		if (runLeaseLost) throw new CleanupRunLeaseLostError();
-		try {
-			if (!(await renewCleanupRunLease(prisma, userId, configId, runClaimToken))) {
-				runLeaseLost = true;
-				throw new CleanupRunLeaseLostError();
-			}
-		} catch (error) {
-			runLeaseLost = true;
-			if (error instanceof CleanupRunLeaseLostError) throw error;
-			log.error({ err: error, configId }, "Library cleanup could not renew its database run lease");
-			throw new CleanupRunLeaseLostError();
-		}
-	};
-	const heartbeat = setInterval(() => {
-		assertOwnership().catch((error) => {
-			log.error(
-				{ err: error, configId },
-				"Library cleanup database run lease heartbeat failed; mutations will stop",
-			);
-		});
-	}, CLEANUP_RUN_HEARTBEAT_MS);
-	heartbeat.unref();
-
-	return {
-		runClaimToken,
-		assertOwnership,
-		release: async () => {
-			clearInterval(heartbeat);
-			await releaseCleanupRunLease(prisma, userId, configId, runClaimToken)
-				.then((released) => {
-					if (!released) {
-						log.warn(
-							{ configId },
-							"Library cleanup finished after its database run lease ownership changed",
-						);
-					}
-				})
-				.catch((error) => {
-					log.error(
-						{ err: error, configId },
-						"Library cleanup finished but its database run lease could not be released",
-					);
-				});
-		},
-	};
 }
 
 class ArrDeletePartialError extends Error {
@@ -3775,7 +3529,7 @@ async function executeCleanupRunGuarded(
 			warnings,
 			new Map(),
 			runLease.assertOwnership,
-			runLease.runClaimToken,
+			runLease.claimToken,
 			providerEvidence,
 			auditContext,
 		);
@@ -3878,7 +3632,7 @@ async function executeApprovedItemsGuarded(
 			enforceExpiry: true,
 			assertExecutionAllowed: runLease.assertOwnership,
 			claimExecutionToken: approvalRequestToken,
-			cleanupRunClaimToken: runLease.runClaimToken,
+			cleanupRunClaimToken: runLease.claimToken,
 			auditContext,
 		});
 		approvalsToRelease = [...result.unclaimedIds, ...result.claimFailedIds];
@@ -3949,7 +3703,7 @@ async function executeRetryItemsGuarded(
 			retryStatus: "retry_pending",
 			enforceExpiry: false,
 			assertExecutionAllowed: runLease.assertOwnership,
-			cleanupRunClaimToken: runLease.runClaimToken,
+			cleanupRunClaimToken: runLease.claimToken,
 			auditContext,
 		});
 		const unclaimedErrors = result.unclaimedIds.map(

--- a/apps/api/src/lib/library-cleanup/cleanup-run-lease.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-run-lease.ts
@@ -1,4 +1,8 @@
 import { randomUUID } from "node:crypto";
+import {
+	withCleanupOperationGuard,
+	withExclusiveCleanupOperationGuard,
+} from "./cleanup-maintenance-gate.js";
 import type { CleanupExecutorDeps } from "./types.js";
 
 export const CLEANUP_RUN_LEASE_MS = 2 * 60 * 60 * 1000;
@@ -15,6 +19,24 @@ export class CleanupRunLeaseLostError extends Error {
 	constructor() {
 		super("The cleanup run lost its database execution lease");
 		this.name = "CleanupRunLeaseLostError";
+	}
+}
+
+export class CleanupTopologyMutationConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor() {
+		super("Service instances cannot be changed while a library cleanup operation is in progress");
+		this.name = "CleanupTopologyMutationConflictError";
+	}
+}
+
+export class CleanupPolicyMutationConflictError extends Error {
+	readonly statusCode = 409;
+
+	constructor() {
+		super("Library cleanup settings cannot be changed while a cleanup operation is in progress");
+		this.name = "CleanupPolicyMutationConflictError";
 	}
 }
 
@@ -130,4 +152,102 @@ export async function startCleanupRunLease(
 				});
 		},
 	};
+}
+
+async function withCleanupMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	conflictError: () => Error,
+	options: {
+		configId?: string;
+		leaseRowMayBeDeleted?: boolean;
+		exclusiveOperation?: boolean;
+	} = {},
+): Promise<T> {
+	const runWithOperationGuard = options.exclusiveOperation
+		? withExclusiveCleanupOperationGuard
+		: withCleanupOperationGuard;
+	return await runWithOperationGuard(async () => {
+		const { prisma, log } = deps;
+		// Ensure the per-user coordination row exists when the caller does not
+		// already have its ID. This closes the initialization race between a
+		// cleanup-sensitive write and the first cleanup run.
+		const config = options.configId
+			? { id: options.configId }
+			: await prisma.libraryCleanupConfig.upsert({
+					where: { userId },
+					update: {},
+					create: { userId },
+					select: { id: true },
+				});
+		const runClaimToken = await acquireCleanupRunLease(prisma, userId, config.id);
+		if (!runClaimToken) throw conflictError();
+
+		try {
+			return await mutate();
+		} finally {
+			await releaseCleanupRunLease(prisma, userId, config.id, runClaimToken)
+				.then((released) => {
+					if (!released && !options.leaseRowMayBeDeleted) {
+						log.warn(
+							{ configId: config.id },
+							"Service topology mutation finished after its cleanup lease ownership changed",
+						);
+					}
+				})
+				.catch((error) => {
+					log.error(
+						{ err: error, configId: config.id },
+						"Service topology mutation finished but its cleanup lease could not be released",
+					);
+				});
+		}
+	});
+}
+
+export async function withCleanupTopologyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { leaseRowMayBeDeleted?: boolean } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupTopologyMutationConflictError(),
+		options,
+	);
+}
+
+/** Serialize destructive ARR service deletion against every cleanup/TRaSH mutation. */
+export async function withExclusiveCleanupTopologyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { leaseRowMayBeDeleted?: boolean } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupTopologyMutationConflictError(),
+		{ ...options, exclusiveOperation: true },
+	);
+}
+
+export async function withCleanupPolicyMutationLease<T>(
+	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
+	userId: string,
+	mutate: () => Promise<T>,
+	options: { configId?: string } = {},
+): Promise<T> {
+	return await withCleanupMutationLease(
+		deps,
+		userId,
+		mutate,
+		() => new CleanupPolicyMutationConflictError(),
+		options,
+	);
 }

--- a/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-scheduler.ts
@@ -27,14 +27,13 @@ import {
 	type CleanupTerminalAuditStatus,
 } from "./cleanup-audit.js";
 import {
-	CLEANUP_RUN_LEASE_MS,
-	CleanupRunAlreadyInProgressError,
 	executeCleanupRun,
 	INTERRUPTED_CLEANUP_RECOVERY_MESSAGE,
 	SONARR_EPISODE_UNMONITOR_CONFIRMED_RECOVERY_MESSAGE,
 	SONARR_EPISODE_UNMONITOR_PARTIAL_MESSAGE,
 	SONARR_EPISODE_UNMONITOR_STARTED_RECOVERY_MESSAGE,
 } from "./cleanup-executor.js";
+import { CLEANUP_RUN_LEASE_MS, CleanupRunAlreadyInProgressError } from "./cleanup-run-lease.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,

--- a/apps/api/src/lib/trash-guides/template-mutation-guard.ts
+++ b/apps/api/src/lib/trash-guides/template-mutation-guard.ts
@@ -39,4 +39,4 @@ export async function withTrashTemplateDeploymentGuard<T>(
 	);
 }
 
-import { withCleanupTopologyMutationLease } from "../library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../library-cleanup/cleanup-run-lease.js";

--- a/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-approval-cas.test.ts
@@ -54,6 +54,11 @@ const auditMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../lib/library-cleanup/cleanup-executor.js", () => executorMocks);
+vi.mock("../../lib/library-cleanup/cleanup-run-lease.js", () => ({
+	CleanupPolicyMutationConflictError: executorMocks.CleanupPolicyMutationConflictError,
+	CleanupRunAlreadyInProgressError: executorMocks.CleanupRunAlreadyInProgressError,
+	withCleanupPolicyMutationLease: executorMocks.withCleanupPolicyMutationLease,
+}));
 vi.mock("../../lib/library-cleanup/cleanup-audit.js", () => auditMocks);
 
 import {

--- a/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-rule-serialization.test.ts
@@ -15,6 +15,11 @@ const executorMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../lib/library-cleanup/cleanup-executor.js", () => executorMocks);
+vi.mock("../../lib/library-cleanup/cleanup-run-lease.js", () => ({
+	CleanupPolicyMutationConflictError: executorMocks.CleanupPolicyMutationConflictError,
+	CleanupRunAlreadyInProgressError: executorMocks.CleanupRunAlreadyInProgressError,
+	withCleanupPolicyMutationLease: executorMocks.withCleanupPolicyMutationLease,
+}));
 
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import {

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -7,7 +7,7 @@ import { hashPassword, verifyPassword } from "../lib/auth/password.js";
 import { getSessionMetadata } from "../lib/auth/session-metadata.js";
 import { parseUserAgent } from "../lib/auth/user-agent-parser.js";
 import { ConflictError } from "../lib/errors.js";
-import { withExclusiveCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-executor.js";
+import { withExclusiveCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-run-lease.js";
 import { validateRequest } from "../lib/utils/validate.js";
 
 const loginSchema = z.object({

--- a/apps/api/src/routes/automation.ts
+++ b/apps/api/src/routes/automation.ts
@@ -28,7 +28,7 @@ import {
 import {
 	acquireCleanupRunLease,
 	releaseCleanupRunLease,
-} from "../lib/library-cleanup/cleanup-executor.js";
+} from "../lib/library-cleanup/cleanup-run-lease.js";
 import { withCleanupOperationGuard } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { validateRequest } from "../lib/utils/validate.js";
 

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -30,8 +30,6 @@ import {
 } from "../lib/library-cleanup/cleanup-audit.js";
 import {
 	buildEvalContext,
-	CleanupPolicyMutationConflictError,
-	CleanupRunAlreadyInProgressError,
 	episodeCoordinateKey,
 	executeApprovedItems,
 	executeCleanupPreview,
@@ -39,8 +37,12 @@ import {
 	executeRetryItems,
 	extractSeriesTmdbId,
 	prefetchFreshPlexEpisodeWatchData,
-	withCleanupPolicyMutationLease,
 } from "../lib/library-cleanup/cleanup-executor.js";
+import {
+	CleanupPolicyMutationConflictError,
+	CleanupRunAlreadyInProgressError,
+	withCleanupPolicyMutationLease,
+} from "../lib/library-cleanup/cleanup-run-lease.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -12,7 +12,7 @@ import { AppValidationError, ConflictError } from "../lib/errors.js";
 import {
 	withCleanupTopologyMutationLease,
 	withExclusiveCleanupTopologyMutationLease,
-} from "../lib/library-cleanup/cleanup-executor.js";
+} from "../lib/library-cleanup/cleanup-run-lease.js";
 import { clearFileIdIndexCache } from "../lib/library-sync/infohash-backfill-by-inode.js";
 import type { ServiceInstance, ServiceType } from "../lib/prisma.js";
 import { withQuiObservationTopologyGuard } from "../lib/qui/observation-topology-guard.js";

--- a/apps/api/src/routes/system.ts
+++ b/apps/api/src/routes/system.ts
@@ -8,7 +8,7 @@ import {
 	resolveAnalyticsProviderSelection,
 	selectAnalyticsProvider,
 } from "../lib/analytics/provider-selection.js";
-import { withCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../lib/library-cleanup/cleanup-run-lease.js";
 import { LOG_DIR, LOG_LEVEL, LOG_MAX_FILES, LOG_MAX_SIZE } from "../lib/logger.js";
 import { readTautulliPassReport } from "../lib/rules-migration/tautulli-pass.js";
 import { evaluateSecurityPosture } from "../lib/security/security-posture.js";

--- a/apps/api/src/routes/trash-guides/__tests__/manual-arr-writer-guard.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/manual-arr-writer-guard.test.ts
@@ -11,7 +11,7 @@ vi.mock("../../../lib/trash-guides/deployment-operation-gate.js", () => ({
 	assertNoPendingDeploymentOperation,
 }));
 
-vi.mock("../../../lib/library-cleanup/cleanup-executor.js", () => ({
+vi.mock("../../../lib/library-cleanup/cleanup-run-lease.js", () => ({
 	withCleanupTopologyMutationLease,
 }));
 

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -8,7 +8,7 @@ import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginAsync } from "fastify";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
 import { isNonterminalUndeploy } from "../../lib/backup/backup-validation.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-run-lease.js";
 import {
 	assertSharedDeploymentRestorationAllowed,
 	assertSharedDeploymentState,

--- a/apps/api/src/routes/trash-guides/deployment-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-routes.ts
@@ -9,7 +9,7 @@
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import { ConflictError } from "../../lib/errors.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-run-lease.js";
 import { createDeploymentPreviewService } from "../../lib/trash-guides/deployment-preview.js";
 import { assertEquivalentDeploymentMappingAuthority } from "../../lib/trash-guides/deployment-target.js";
 import { validateRequest } from "../../lib/utils/validate.js";

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -8,7 +8,7 @@ import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { AppValidationError, ConflictError } from "../../lib/errors.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-run-lease.js";
 import { readPersistedManagedCustomFormatIdentities } from "../../lib/trash-guides/deployment-managed-format-state.js";
 import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deployment-operation-gate.js";
 import {

--- a/apps/api/src/routes/trash-guides/manual-arr-writer-guard.ts
+++ b/apps/api/src/routes/trash-guides/manual-arr-writer-guard.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance } from "fastify";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
 import { AppValidationError, ConflictError } from "../../lib/errors.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-run-lease.js";
 import type { ServiceInstance } from "../../lib/prisma.js";
 import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deployment-operation-gate.js";
 import {

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -8,7 +8,7 @@ import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-run-lease.js";
 import { createCacheManager } from "../../lib/trash-guides/cache-manager.js";
 import {
 	assertSharedDeploymentRestorationAllowed,


### PR DESCRIPTION
## Summary
Deduplicates the library-cleanup run-lease primitives flagged by an architecture
audit (R3 critical duplication, R5 dependency disorder). `cleanup-run-lease.ts`
is now the single canonical home for lease logic; `cleanup-executor.ts`, the
scheduler, and every route consumer import from it instead of redefining or
misplacing duplicates.

## Changes
- **`cleanup-run-lease.ts`** — canonical module: `CLEANUP_RUN_LEASE_MS`, heartbeat
  constants, `acquire/release/renewCleanupRunLease`, `startCleanupRunLease`, the
  four conflict error classes, and `with*MutationLease` wrappers.
- **`cleanup-executor.ts`** — drops all lease definitions (256 lines); imports
  lease symbols from the canonical module. Executor-only logic remains in place.
- **Routes & consumers** — `services.ts`, `auth.ts`, `system.ts`, `automation.ts`,
  `library-cleanup.ts`, five trash-guides routes, and
  `template-mutation-guard.ts` repointed to `cleanup-run-lease.js`.
- **Tests** — `cleanup-run-lease.test.ts` imports from `run-lease`;
  `shared-plex-safety`, `approval-cas`, `rule-serialization`, and
  `manual-arr-writer-guard` updated to mock/import the canonical module. No test
  semantics changed.

## Verification
- `pnpm run format` / `typecheck` / `lint` / `build` — pass (Node 22).
- `pnpm run test` — shared 154, web 864, api 316 passed / 9 skipped.
- Integration QA (real Sonarr/Radarr/Lidarr/Readarr/Prowlarr in Docker) — 91
  passed; 4 failures are pre-existing on `next` (stale spec assertions + Seerr
  bootstrap 403), independent of this branch (0 web/e2e files changed).
- Independent `data_safety_reviewer` and `regression_reviewer` passes — no findings.
- Brooks architecture audit after refactor: Health 95/100, R3/R5 resolved.

## Files (19)
All under `apps/api`: `cleanup-run-lease.ts`, `cleanup-executor.ts`,
`cleanup-scheduler.ts`, `template-mutation-guard.ts`, six route files, five
trash-guides route files, and five test files.

## Risks / Notes
- No runtime API surface change; a no-op refactor verified by the full gauntlet
  plus live integration QA. Forward-port not required (targets `next` directly).