### PR TITLE
fix(backup): preserve durable configuration across restore

### DIFF
--- a/apps/api/src/lib/backup/__tests__/backup-config-preservation.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-config-preservation.test.ts
@@ -1,0 +1,591 @@
+/**
+ * F-01 regression contract: backup/restore must preserve durable configuration.
+ *
+ * These tests define the safety contract that current `next` violates: the
+ * backup export omits durable configuration tables, while restore's
+ * `deleteMany(user)` / `deleteMany(serviceInstance)` cascades erase them.
+ *
+ * They exercise the real `exportDatabase` / `restoreDatabase` boundary against
+ * a disposable SQLite database (no mocks), mirroring the pattern in
+ * `media-server-rescan-database.test.ts`.
+ *
+ * Run with TEST_DB=true (see .github/workflows/ci.yml).
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import type { PrismaClient } from "../../prisma.js";
+import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { BACKUP_VERSION, validateBackup } from "../backup-validation.js";
+
+const RUN_DB_TESTS = process.env.TEST_DB === "true";
+const execFileAsync = promisify(execFile);
+
+/**
+ * Canonical durable-configuration inventory.
+ *
+ * These are the user-owned / instance-owned tables that represent operator
+ * configuration and MUST survive a full backup/restore. They are distinct from
+ * ephemeral cache/state/log tables (see EPHEMERAL_MODELS) which are rebuildable
+ * and intentionally not required to round-trip.
+ *
+ * This list is the single source of truth for the F-01 contract. It is
+ * cross-checked against schema.prisma in the "export completeness" test so a
+ * future durable-config model added to the schema without backup support fails
+ * here rather than silently losing data.
+ */
+const DURABLE_CONFIG_MODELS = [
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"crossDomainRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+] as const;
+
+/**
+ * Rebuildable/operational state that is intentionally NOT required to survive
+ * restore. The eventual fix must not turn backup into a full 67-table dump.
+ */
+const EPHEMERAL_MODELS = [
+	"libraryCache",
+	"episodeFileCache",
+	"plexCache",
+	"tautulliCache",
+	"jellyfinCache",
+	"librarySyncStatus",
+	"cacheRefreshStatus",
+	"sessionSnapshot",
+	"queueCleanerStrike",
+	"queueCleanerLog",
+	"libraryCleanupApproval",
+	"libraryCleanupLog",
+	"libraryCleanupAuditEvent",
+	"huntLog",
+	"huntSearchHistory",
+	"seerrActionLog",
+	"quiActivityLog",
+	"quiActionLog",
+	"quiEventLog",
+	"pulseDismissal",
+	"systemNoticeDismissal",
+	"tmdbListCache",
+	"traktListCache",
+	"inodeIndexCache",
+	"crossDomainRuleMatch",
+	"libraryCleanupMediaServerScan",
+] as const;
+
+const USER_ID = "f01-user";
+const INSTANCE_ID = "f01-instance";
+
+function seedDurableConfig(prisma: PrismaClient) {
+	return {
+		user: prisma.user.create({ data: { id: USER_ID, username: "f01-user" } }),
+		instance: prisma.serviceInstance.create({
+			data: {
+				id: INSTANCE_ID,
+				userId: USER_ID,
+				service: "RADARR",
+				label: "F-01 Radarr",
+				baseUrl: "http://radarr:7878",
+				encryptedApiKey: "ciphertext-api-key",
+				encryptionIv: "iv-api-key",
+			},
+		}),
+	};
+}
+
+async function seedAllDurableConfig(prisma: PrismaClient) {
+	await seedDurableConfig(prisma).user;
+	await seedDurableConfig(prisma).instance;
+
+	// Notification channels (2) + subscriptions
+	await prisma.notificationChannel.create({
+		data: {
+			id: "chan-1",
+			userId: USER_ID,
+			name: "Channel 1",
+			type: "WEBHOOK",
+			encryptedConfig: "ciphertext-config-1",
+			configIv: "iv-config-1",
+		},
+	});
+	await prisma.notificationChannel.create({
+		data: {
+			id: "chan-2",
+			userId: USER_ID,
+			name: "Channel 2",
+			type: "BROWSER_PUSH",
+			encryptedConfig: "ciphertext-config-2",
+			configIv: "iv-config-2",
+		},
+	});
+	await prisma.notificationSubscription.create({
+		data: { channelId: "chan-1", eventType: "HUNT_COMPLETED" },
+	});
+
+	// Notification rules + aggregation
+	await prisma.notificationRule.create({
+		data: {
+			id: "rule-1",
+			userId: USER_ID,
+			name: "Rule 1",
+			action: "suppress",
+			conditions: '[{"field":"title","operator":"eq","value":"x"}]',
+		},
+	});
+	await prisma.notificationAggregationConfig.create({
+		data: { id: "agg-1", userId: USER_ID, eventType: "HUNT_CONTENT_FOUND", enabled: true },
+	});
+
+	// Automation rules
+	await prisma.autoTagRule.create({
+		data: {
+			id: "autotag-1",
+			userId: USER_ID,
+			name: "AutoTag 1",
+			ruleType: "age",
+			parameters: '{"days":30}',
+			tagName: "qa-tag",
+		},
+	});
+	await prisma.labelSyncRule.create({
+		data: {
+			id: "labelsync-1",
+			userId: USER_ID,
+			name: "LabelSync 1",
+			sourceService: "radarr",
+			sourceTagName: "src",
+			destService: "plex",
+			destInstanceId: INSTANCE_ID,
+			destTagName: "dst",
+		},
+	});
+	await prisma.crossDomainRule.create({
+		data: {
+			id: "crossdomain-1",
+			userId: USER_ID,
+			name: "CrossDomain 1",
+			document: "{}",
+			scope: "{}",
+			actions: "[]",
+		},
+	});
+
+	// Queue cleaner + library cleanup
+	await prisma.queueCleanerConfig.create({
+		data: { id: "qc-1", instanceId: INSTANCE_ID, enabled: true, dryRunMode: false },
+	});
+	const lc = await prisma.libraryCleanupConfig.create({
+		data: { id: "lc-1", userId: USER_ID, enabled: true },
+	});
+	await prisma.libraryCleanupRule.create({
+		data: {
+			id: "lcr-1",
+			configId: lc.id,
+			name: "Cleanup Rule 1",
+			ruleType: "age",
+			parameters: '{"days":90}',
+		},
+	});
+
+	// Naming + custom formats
+	await prisma.namingConfig.create({
+		data: {
+			id: "naming-1",
+			instanceId: INSTANCE_ID,
+			userId: USER_ID,
+			serviceType: "RADARR",
+			selectedPresets: '{"standard":true}',
+		},
+	});
+	await prisma.userCustomFormat.create({
+		data: {
+			id: "ucf-1",
+			userId: USER_ID,
+			name: "Custom Format 1",
+			serviceType: "RADARR",
+			specifications: "[]",
+		},
+	});
+}
+
+async function seedEphemeralState(prisma: PrismaClient) {
+	await prisma.libraryCache.create({
+		data: {
+			id: "libcache-1",
+			instanceId: INSTANCE_ID,
+			arrItemId: 1,
+			itemType: "movie",
+			title: "Cached Movie",
+			data: "{}",
+		},
+	});
+	await prisma.queueCleanerStrike.create({
+		data: {
+			id: "strike-1",
+			instanceId: INSTANCE_ID,
+			downloadId: "dl-1",
+			downloadTitle: "Struck Download",
+			lastRule: "stalled",
+			lastReason: "stalled",
+		},
+	});
+	await prisma.libraryCleanupApproval.create({
+		data: {
+			id: "approval-1",
+			configId: "lc-1",
+			instanceId: INSTANCE_ID,
+			arrItemId: 2,
+			itemType: "movie",
+			title: "Pending Approval",
+			matchedRuleId: "lcr-1",
+			matchedRuleName: "Cleanup Rule 1",
+			reason: "matched",
+			sizeOnDisk: 1n,
+			expiresAt: new Date("2027-01-01T00:00:00.000Z"),
+		},
+	});
+	await prisma.huntLog.create({
+		data: { id: "huntlog-1", instanceId: INSTANCE_ID, huntType: "missing", status: "completed" },
+	});
+	await prisma.sessionSnapshot.create({
+		data: {
+			id: "snap-1",
+			instanceId: INSTANCE_ID,
+			concurrentStreams: 1,
+			sessionsJson: "[]",
+		},
+	});
+}
+
+async function countAll(prisma: PrismaClient, models: readonly string[]) {
+	const result: Record<string, number> = {};
+	const client = prisma as unknown as Record<string, { count: () => Promise<number> }>;
+	for (const m of models) {
+		result[m] = await client[m]!.count();
+	}
+	return result;
+}
+
+(RUN_DB_TESTS ? describe : describe.skip)(
+	"F-01 backup/restore durable-config contract (SQLite)",
+	() => {
+		let prisma: PrismaClient;
+		let databaseDir: string;
+
+		beforeAll(async () => {
+			databaseDir = await mkdtemp(path.join(os.tmpdir(), "arr-f01-"));
+			const databasePath = path.join(databaseDir, "f01.db");
+			const schemaPath = path.resolve(import.meta.dirname, "../../../../prisma/schema.prisma");
+			const prismaCli = path.resolve(
+				import.meta.dirname,
+				"../../../../node_modules/prisma/build/index.js",
+			);
+			await execFileAsync(process.execPath, [
+				prismaCli,
+				"db",
+				"push",
+				"--schema",
+				schemaPath,
+				"--url",
+				`file:${databasePath}`,
+			]);
+			prisma = createTestPrismaClient(databasePath);
+		});
+
+		afterAll(async () => {
+			await prisma.$disconnect();
+			await rm(databaseDir, { recursive: true, force: true });
+		});
+
+		it("A — durable configuration round-trips through export/restore", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			const pre = await countAll(prisma, DURABLE_CONFIG_MODELS);
+
+			const data = await exportDatabase(prisma, { excludeOperationalHistory: false });
+			await restoreDatabase(prisma, data as never);
+
+			const post = await countAll(prisma, DURABLE_CONFIG_MODELS);
+
+			for (const model of DURABLE_CONFIG_MODELS) {
+				expect(post[model], `${model} must survive restore`).toBe(pre[model]);
+			}
+
+			// Identity + representative field values + encrypted values survive.
+			const channel = await prisma.notificationChannel.findUnique({ where: { id: "chan-1" } });
+			expect(channel).toMatchObject({
+				id: "chan-1",
+				userId: USER_ID,
+				name: "Channel 1",
+				type: "WEBHOOK",
+				encryptedConfig: "ciphertext-config-1",
+				configIv: "iv-config-1",
+			});
+
+			const instance = await prisma.serviceInstance.findUnique({ where: { id: INSTANCE_ID } });
+			expect(instance).toMatchObject({
+				encryptedApiKey: "ciphertext-api-key",
+				encryptionIv: "iv-api-key",
+			});
+
+			// FK relationship survives: subscription still points at its channel.
+			const sub = await prisma.notificationSubscription.findUnique({
+				where: { channelId_eventType: { channelId: "chan-1", eventType: "HUNT_COMPLETED" } },
+			});
+			expect(sub).not.toBeNull();
+
+			// Library-cleanup rule still points at its config.
+			const rule = await prisma.libraryCleanupRule.findUnique({ where: { id: "lcr-1" } });
+			expect(rule?.configId).toBe("lc-1");
+		});
+
+		it("B — export includes explicit coverage for every durable-config model", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			const data = await exportDatabase(prisma, { excludeOperationalHistory: false });
+			const keys = Object.keys(data);
+
+			for (const model of DURABLE_CONFIG_MODELS) {
+				expect(keys, `export must include ${model}`).toContain(model);
+				expect(
+					Array.isArray((data as Record<string, unknown>)[model]),
+					`${model} must be an array`,
+				).toBe(true);
+			}
+		});
+
+		it("C — ephemeral/operational state is intentionally not required to round-trip", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+			await seedEphemeralState(prisma);
+
+			const preEphemeral = await countAll(prisma, EPHEMERAL_MODELS);
+			// Sanity: the ephemeral seed actually produced rows.
+			expect(preEphemeral.libraryCache).toBeGreaterThan(0);
+
+			const data = await exportDatabase(prisma, { excludeOperationalHistory: false });
+			await restoreDatabase(prisma, data as never);
+
+			// Durable config must survive.
+			const postConfig = await countAll(prisma, DURABLE_CONFIG_MODELS);
+			for (const model of DURABLE_CONFIG_MODELS) {
+				expect(postConfig[model], `${model} must survive`).toBeGreaterThan(0);
+			}
+
+			// Ephemeral state is NOT required to round-trip. This pins the boundary
+			// so the fix does not become a full 67-table dump: we assert the durable
+			// boundary holds while explicitly NOT asserting ephemeral rows survive.
+			// (On current `next` these are wiped by cascade — acceptable for
+			// rebuildable state, and this test documents that intent.)
+			expect(postConfig.notificationChannel).toBe(2);
+		});
+
+		it("D — a legacy/incomplete backup cannot silently erase durable configuration", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			// A valid-format backup that predates durable-config export: it carries
+			// the core tables but none of the durable-config arrays.
+			const legacyData = {
+				users: [{ id: USER_ID, username: "f01-user" }],
+				sessions: [],
+				serviceInstances: [
+					{
+						id: INSTANCE_ID,
+						userId: USER_ID,
+						service: "RADARR",
+						label: "F-01 Radarr",
+						baseUrl: "http://radarr:7878",
+						encryptedApiKey: "ciphertext-api-key",
+						encryptionIv: "iv-api-key",
+					},
+				],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+			};
+
+			// Required safety outcome: restore must fail closed rather than silently
+			// erase the durable configuration already present in the target DB.
+			await expect(restoreDatabase(prisma, legacyData as never)).rejects.toThrow();
+
+			// Existing durable configuration remains intact.
+			const post = await countAll(prisma, DURABLE_CONFIG_MODELS);
+			for (const model of DURABLE_CONFIG_MODELS) {
+				expect(
+					post[model],
+					`${model} must remain intact after rejected legacy restore`,
+				).toBeGreaterThan(0);
+			}
+			expect(post.notificationChannel).toBe(2);
+		});
+
+		it("E — transaction rollback restores full pre-restore state on mid-restore failure", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			const pre = await countAll(prisma, DURABLE_CONFIG_MODELS);
+
+			// Force a deterministic failure after destructive deletes have begun but
+			// before completion: a user record missing its required `username` field
+			// passes the coordination check, then fails `validateRecords` during the
+			// create phase (which runs after `deleteMany`).
+			const malformedData = {
+				users: [{ id: USER_ID }], // missing `username`
+				sessions: [],
+				serviceInstances: [],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+			};
+
+			await expect(restoreDatabase(prisma, malformedData as never)).rejects.toThrow();
+
+			// No partial restore may be observable: durable config fully intact.
+			const post = await countAll(prisma, DURABLE_CONFIG_MODELS);
+			expect(post).toEqual(pre);
+		});
+
+		it("F — malformed configuration is rejected before destructive commit", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			const pre = await countAll(prisma, DURABLE_CONFIG_MODELS);
+
+			// A backup that carries a durable-config array with a malformed record
+			// (non-object) must be rejected, not silently accepted.
+			const malformedData = {
+				users: [{ id: USER_ID, username: "f01-user" }],
+				sessions: [],
+				serviceInstances: [],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+				notificationChannels: ["not-an-object"],
+			};
+
+			await expect(restoreDatabase(prisma, malformedData as never)).rejects.toThrow();
+
+			const post = await countAll(prisma, DURABLE_CONFIG_MODELS);
+			expect(post).toEqual(pre);
+		});
+
+		it("G — encrypted config and IVs survive byte-for-byte", async () => {
+			await prisma.user.deleteMany();
+			await seedAllDurableConfig(prisma);
+
+			const data = await exportDatabase(prisma, { excludeOperationalHistory: false });
+			await restoreDatabase(prisma, data as never);
+
+			const channel = await prisma.notificationChannel.findUnique({ where: { id: "chan-1" } });
+			expect(channel?.encryptedConfig).toBe("ciphertext-config-1");
+			expect(channel?.configIv).toBe("iv-config-1");
+
+			const instance = await prisma.serviceInstance.findUnique({ where: { id: INSTANCE_ID } });
+			expect(instance?.encryptedApiKey).toBe("ciphertext-api-key");
+			expect(instance?.encryptionIv).toBe("iv-api-key");
+		});
+
+		it("H — new-format backup with explicit empty config arrays is valid", () => {
+			const emptyConfig = Object.fromEntries(DURABLE_CONFIG_MODELS.map((model) => [model, []]));
+			const backup = {
+				version: BACKUP_VERSION,
+				appVersion: "3.0.0",
+				timestamp: new Date().toISOString(),
+				data: {
+					users: [],
+					sessions: [],
+					serviceInstances: [],
+					serviceTags: [],
+					serviceInstanceTags: [],
+					oidcAccounts: [],
+					webAuthnCredentials: [],
+					...emptyConfig,
+				},
+				secrets: {
+					encryptionKey: "test-encryption-key-32-bytes-hex",
+					sessionCookieSecret: "test-session-cookie-secret",
+				},
+			};
+
+			expect(() => validateBackup(backup)).not.toThrow();
+		});
+
+		it("I — new-format backup missing a required config property is rejected", () => {
+			const emptyConfig = Object.fromEntries(DURABLE_CONFIG_MODELS.map((model) => [model, []]));
+			// Drop one required property to simulate an incomplete new-format backup.
+			delete emptyConfig.notificationChannel;
+			const backup = {
+				version: BACKUP_VERSION,
+				appVersion: "3.0.0",
+				timestamp: new Date().toISOString(),
+				data: {
+					users: [],
+					sessions: [],
+					serviceInstances: [],
+					serviceTags: [],
+					serviceInstanceTags: [],
+					oidcAccounts: [],
+					webAuthnCredentials: [],
+					...emptyConfig,
+				},
+				secrets: {
+					encryptionKey: "test-encryption-key-32-bytes-hex",
+					sessionCookieSecret: "test-session-cookie-secret",
+				},
+			};
+
+			expect(() => validateBackup(backup)).toThrow(/notificationChannel/);
+		});
+
+		it("J — legacy backup restores into a clean target with no durable configuration", async () => {
+			await prisma.user.deleteMany();
+
+			// A legacy-format backup (no durable-config arrays) into a target with
+			// zero durable configuration must be permitted — there is nothing to lose.
+			const legacyData = {
+				users: [{ id: USER_ID, username: "f01-user" }],
+				sessions: [],
+				serviceInstances: [
+					{
+						id: INSTANCE_ID,
+						userId: USER_ID,
+						service: "RADARR",
+						label: "F-01 Radarr",
+						baseUrl: "http://radarr:7878",
+						encryptedApiKey: "ciphertext-api-key",
+						encryptionIv: "iv-api-key",
+					},
+				],
+				serviceTags: [],
+				serviceInstanceTags: [],
+				oidcAccounts: [],
+				webAuthnCredentials: [],
+			};
+
+			await expect(restoreDatabase(prisma, legacyData as never)).resolves.toBeUndefined();
+
+			expect(await prisma.user.count()).toBe(1);
+			expect(await prisma.serviceInstance.count()).toBe(1);
+		});
+	},
+);

--- a/apps/api/src/lib/backup/__tests__/backup-database.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-database.test.ts
@@ -35,6 +35,18 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"crossDomainRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
 ] as const;
 
 type TableName = (typeof TABLE_NAMES)[number];
@@ -651,6 +663,20 @@ describe("restoreDatabase — current coordination preservation", () => {
 		currentNaming?: Array<Record<string, unknown>>;
 	}) {
 		const firstDelete = vi.fn().mockResolvedValue({ count: 0 });
+		const durableConfigModels = [
+			"notificationChannel",
+			"notificationSubscription",
+			"notificationRule",
+			"notificationAggregationConfig",
+			"autoTagRule",
+			"labelSyncRule",
+			"crossDomainRule",
+			"queueCleanerConfig",
+			"libraryCleanupConfig",
+			"libraryCleanupRule",
+			"namingConfig",
+			"userCustomFormat",
+		] as const;
 		const tx = {
 			trashSyncHistory: {
 				findMany: vi.fn().mockResolvedValue(options.currentSync ?? []),
@@ -671,6 +697,15 @@ describe("restoreDatabase — current coordination preservation", () => {
 				deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
 			},
 			huntSearchHistory: { deleteMany: firstDelete },
+			...Object.fromEntries(
+				durableConfigModels.map((model) => [
+					model,
+					{
+						count: vi.fn().mockResolvedValue(0),
+						deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+					},
+				]),
+			),
 		};
 		const prisma = {
 			$transaction: vi.fn(async (operation: (transaction: typeof tx) => Promise<void>) =>

--- a/apps/api/src/lib/backup/__tests__/backup-orchestration.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-orchestration.test.ts
@@ -1,0 +1,218 @@
+/**
+ * F-01 orchestration-level regression tests.
+ *
+ * These exercise the real `BackupService.restoreBackup()` boundary (including
+ * secrets/filesystem handling), not just `restoreDatabase()`. They prove the
+ * compatibility preflight runs BEFORE any secrets mutation, and that a
+ * successful cross-key restore leaves a consistent (ciphertext, key) pair.
+ *
+ * Run with TEST_DB=true (see .github/workflows/ci.yml).
+ */
+
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import { Encryptor } from "../../auth/encryption.js";
+import { BackupCompatibilityError } from "../../errors.js";
+import type { PrismaClient } from "../../prisma.js";
+import { exportDatabase, restoreDatabase } from "../backup-database.js";
+import { BackupService } from "../backup-service.js";
+
+const RUN_DB_TESTS = process.env.TEST_DB === "true";
+const execFileAsync = promisify(execFile);
+
+const KEY_A = "a".repeat(64); // 32-byte hex key
+const KEY_B = "b".repeat(64); // 32-byte hex key
+
+const USER_ID = "orch-user";
+const INSTANCE_ID = "orch-instance";
+
+function makeLegacyBackup(encryptionKey: string) {
+	return {
+		version: "1.1",
+		appVersion: "2.23.0",
+		timestamp: new Date().toISOString(),
+		data: {
+			users: [{ id: USER_ID, username: "orch-user" }],
+			sessions: [],
+			serviceInstances: [
+				{
+					id: INSTANCE_ID,
+					userId: USER_ID,
+					service: "RADARR",
+					label: "Orch Radarr",
+					baseUrl: "http://radarr:7878",
+					encryptedApiKey: "ciphertext",
+					encryptionIv: "iv",
+				},
+			],
+			serviceTags: [],
+			serviceInstanceTags: [],
+			oidcAccounts: [],
+			webAuthnCredentials: [],
+		},
+		secrets: {
+			encryptionKey,
+			sessionCookieSecret: "session-secret",
+		},
+	};
+}
+
+(RUN_DB_TESTS ? describe : describe.skip)("F-01 restore orchestration (SQLite)", () => {
+	let prisma: PrismaClient;
+	let databaseDir: string;
+	let secretsPath: string;
+
+	beforeAll(async () => {
+		databaseDir = await mkdtemp(path.join(os.tmpdir(), "arr-f01-orch-"));
+		const databasePath = path.join(databaseDir, "orch.db");
+		secretsPath = path.join(databaseDir, "secrets.json");
+		const schemaPath = path.resolve(import.meta.dirname, "../../../../prisma/schema.prisma");
+		const prismaCli = path.resolve(
+			import.meta.dirname,
+			"../../../../node_modules/prisma/build/index.js",
+		);
+		await execFileAsync(process.execPath, [
+			prismaCli,
+			"db",
+			"push",
+			"--schema",
+			schemaPath,
+			"--url",
+			`file:${databasePath}`,
+		]);
+		prisma = createTestPrismaClient(databasePath);
+	});
+
+	afterAll(async () => {
+		await prisma.$disconnect();
+		await rm(databaseDir, { recursive: true, force: true });
+	});
+
+	it("K — a rejected legacy restore never mutates the secrets file", async () => {
+		// Seed a populated target with durable config + KEY-A secrets.
+		await prisma.user.deleteMany();
+		await prisma.user.create({ data: { id: USER_ID, username: "orch-user" } });
+		await prisma.serviceInstance.create({
+			data: {
+				id: INSTANCE_ID,
+				userId: USER_ID,
+				service: "RADARR",
+				label: "Orch Radarr",
+				baseUrl: "http://radarr:7878",
+				encryptedApiKey: "ciphertext",
+				encryptionIv: "iv",
+			},
+		});
+		await prisma.notificationChannel.create({
+			data: {
+				id: "chan-1",
+				userId: USER_ID,
+				name: "Channel 1",
+				type: "WEBHOOK",
+				encryptedConfig: "ciphertext-config",
+				configIv: "iv-config",
+			},
+		});
+
+		const secretsContent = JSON.stringify(
+			{ encryptionKey: KEY_A, sessionCookieSecret: "session-secret" },
+			null,
+			2,
+		);
+		await writeFile(secretsPath, secretsContent, { mode: 0o600 });
+
+		const service = new BackupService(prisma, secretsPath);
+		const legacyBackup = makeLegacyBackup(KEY_B);
+
+		await expect(service.restoreBackup(JSON.stringify(legacyBackup))).rejects.toBeInstanceOf(
+			BackupCompatibilityError,
+		);
+
+		// Secrets file must be byte-for-byte identical — KEY-B was never written.
+		const afterSecrets = await readFile(secretsPath, "utf-8");
+		expect(afterSecrets).toBe(secretsContent);
+
+		// Database unchanged: durable config still present.
+		expect(await prisma.notificationChannel.count()).toBe(1);
+		expect(await prisma.user.count()).toBe(1);
+	});
+
+	it("O — the database-layer recheck independently fails closed for a direct caller", async () => {
+		// Direct call to restoreDatabase() (bypassing orchestration) must still
+		// reject a legacy backup over a populated target. This is the defense-in-depth
+		// against a stale orchestration preflight decision (TOCTOU).
+		await prisma.user.deleteMany();
+		await prisma.user.create({ data: { id: USER_ID, username: "orch-user" } });
+		await prisma.notificationChannel.create({
+			data: {
+				id: "chan-2",
+				userId: USER_ID,
+				name: "Channel 2",
+				type: "WEBHOOK",
+				encryptedConfig: "ciphertext-config",
+				configIv: "iv-config",
+			},
+		});
+
+		const legacyData = makeLegacyBackup(KEY_B).data;
+		await expect(restoreDatabase(prisma, legacyData as never)).rejects.toBeInstanceOf(
+			BackupCompatibilityError,
+		);
+		expect(await prisma.notificationChannel.count()).toBe(1);
+	});
+
+	it("N — a successful cross-key restore leaves a consistent (ciphertext, key) pair", async () => {
+		// Build a valid v1.2 backup whose ciphertext is encrypted under KEY-B.
+		await prisma.user.deleteMany();
+		const encryptorB = new Encryptor(KEY_B);
+		const { value, iv } = encryptorB.encrypt("secret-api-key");
+		await prisma.user.create({ data: { id: USER_ID, username: "orch-user" } });
+		await prisma.serviceInstance.create({
+			data: {
+				id: INSTANCE_ID,
+				userId: USER_ID,
+				service: "RADARR",
+				label: "Orch Radarr",
+				baseUrl: "http://radarr:7878",
+				encryptedApiKey: value,
+				encryptionIv: iv,
+			},
+		});
+
+		const data = await exportDatabase(prisma, { excludeOperationalHistory: false });
+		const backup = {
+			version: "1.2",
+			appVersion: "3.0.0",
+			timestamp: new Date().toISOString(),
+			data,
+			secrets: { encryptionKey: KEY_B, sessionCookieSecret: "session-secret" },
+		};
+
+		// Target currently uses KEY-A.
+		await writeFile(
+			secretsPath,
+			JSON.stringify({ encryptionKey: KEY_A, sessionCookieSecret: "session-secret" }, null, 2),
+			{ mode: 0o600 },
+		);
+
+		const service = new BackupService(prisma, secretsPath);
+		await service.restoreBackup(JSON.stringify(backup));
+
+		// Secrets file now carries KEY-B.
+		const afterSecrets = JSON.parse(await readFile(secretsPath, "utf-8"));
+		expect(afterSecrets.encryptionKey).toBe(KEY_B);
+
+		// Restored ciphertext decrypts with the active (restored) key.
+		const instance = await prisma.serviceInstance.findUnique({ where: { id: INSTANCE_ID } });
+		const decrypted = new Encryptor(KEY_B).decrypt({
+			value: instance!.encryptedApiKey,
+			iv: instance!.encryptionIv,
+		});
+		expect(decrypted).toBe("secret-api-key");
+	});
+});

--- a/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-safety.test.ts
@@ -2,12 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { loggers } from "../../logger.js";
-import type { PrismaClient } from "../../prisma.js";
 import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,
 } from "../../library-cleanup/cleanup-maintenance-gate.js";
+import { loggers } from "../../logger.js";
+import type { PrismaClient } from "../../prisma.js";
 import { decryptBackupData, type EncryptedBackupEnvelope } from "../backup-crypto.js";
 import { BackupService } from "../backup-service.js";
 
@@ -35,6 +35,18 @@ const TABLE_NAMES = [
 	"huntLog",
 	"huntSearchHistory",
 	"trashBackup",
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"crossDomainRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
 ] as const;
 
 function makePrismaWithCoordinationEvidence(): PrismaClient {
@@ -148,7 +160,7 @@ describe("BackupService coordination safety", () => {
 			};
 
 			expect(envelope.version).toBe("1.0");
-			expect(payload.version).toBe("1.1");
+			expect(payload.version).toBe("1.2");
 			expect(payload.data.trashSyncHistory).toEqual([
 				expect.objectContaining({ id: "rollback-active" }),
 			]);

--- a/apps/api/src/lib/backup/__tests__/backup-service.test.ts
+++ b/apps/api/src/lib/backup/__tests__/backup-service.test.ts
@@ -891,6 +891,7 @@ describe("BackupService - legacy restore normalization", () => {
 		vi.doMock("../backup-database.js", () => ({
 			exportDatabase: vi.fn(),
 			restoreDatabase: restoreSpy,
+			assertRestoreCompatibility: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.resetModules();
 		const { BackupService: IsolatedBackupService } = await import("../backup-service.js");

--- a/apps/api/src/lib/backup/backup-database.ts
+++ b/apps/api/src/lib/backup/backup-database.ts
@@ -6,10 +6,13 @@
  */
 
 import type { BackupData } from "@arr/shared";
+import { BackupCompatibilityError } from "../errors.js";
 import { loggers } from "../logger.js";
 import type { Prisma, PrismaClient, TrashBackup } from "../prisma.js";
 import {
 	type CoordinationState,
+	DURABLE_CONFIG_MODELS,
+	durableConfigPayloadKey,
 	isAuditOnlyUncertainDeployment,
 	isAuditOnlyUncertainSync,
 	isNonterminalRollback,
@@ -487,6 +490,22 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 				(take) => prisma.huntSearchHistory.findMany({ take, orderBy: { searchedAt: "desc" } }),
 			);
 
+	// Durable user configuration (always full — these are config, not history).
+	// Exported as explicit arrays so a new-format backup always carries coverage
+	// for every durable-config model, even when empty.
+	const notificationChannels = await prisma.notificationChannel.findMany();
+	const notificationSubscriptions = await prisma.notificationSubscription.findMany();
+	const notificationRules = await prisma.notificationRule.findMany();
+	const notificationAggregationConfigs = await prisma.notificationAggregationConfig.findMany();
+	const autoTagRules = await prisma.autoTagRule.findMany();
+	const labelSyncRules = await prisma.labelSyncRule.findMany();
+	const crossDomainRules = await prisma.crossDomainRule.findMany();
+	const queueCleanerConfigs = await prisma.queueCleanerConfig.findMany();
+	const libraryCleanupConfigs = await prisma.libraryCleanupConfig.findMany();
+	const libraryCleanupRules = await prisma.libraryCleanupRule.findMany();
+	const namingConfigs = await prisma.namingConfig.findMany();
+	const userCustomFormats = await prisma.userCustomFormat.findMany();
+
 	// Optionally include recent TRaSH instance backups. Snapshots referenced by
 	// nonterminal rollback/undeploy rows are added below regardless of age/expiry.
 	let trashBackups: TrashBackup[] = [];
@@ -566,6 +585,19 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
 		huntConfigs,
 		huntLogs,
 		huntSearchHistory,
+		// Durable user configuration
+		notificationChannel: notificationChannels,
+		notificationSubscription: notificationSubscriptions,
+		notificationRule: notificationRules,
+		notificationAggregationConfig: notificationAggregationConfigs,
+		autoTagRule: autoTagRules,
+		labelSyncRule: labelSyncRules,
+		crossDomainRule: crossDomainRules,
+		queueCleanerConfig: queueCleanerConfigs,
+		libraryCleanupConfig: libraryCleanupConfigs,
+		libraryCleanupRule: libraryCleanupRules,
+		namingConfig: namingConfigs,
+		userCustomFormat: userCustomFormats,
 	};
 }
 
@@ -577,9 +609,62 @@ export async function exportDatabase(prisma: PrismaClient, options: ExportDataba
  * - Performs bulk createMany() operations for all records in a single transaction
  * - Transaction ensures atomicity but can be long-running for large datasets
  */
+
+/**
+ * True when the incoming backup data carries explicit array coverage for every
+ * durable-config model. New-format backups always satisfy this (even with empty
+ * arrays); legacy backups that predate config export do not.
+ */
+function hasDurableConfigCoverage(data: BackupData["data"]): boolean {
+	const record = data as Record<string, unknown>;
+	return DURABLE_CONFIG_MODELS.every((model) =>
+		Array.isArray(record[durableConfigPayloadKey(model)]),
+	);
+}
+
+/**
+ * True when the target database currently contains any durable configuration.
+ * Uses cheap existence checks (count) rather than loading full tables.
+ */
+async function targetHasDurableConfig(
+	prisma: Prisma.TransactionClient | PrismaClient,
+): Promise<boolean> {
+	const client = prisma as unknown as Record<string, { count: () => Promise<number> }>;
+	for (const model of DURABLE_CONFIG_MODELS) {
+		const accessor = client[model];
+		if (accessor && (await accessor.count()) > 0) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Reject a backup that lacks durable-config coverage when the target already
+ * contains durable configuration. This is the single compatibility policy used
+ * both by the orchestration preflight (before any filesystem mutation) and by
+ * the database-layer recheck (inside the restore transaction, as defense-in-depth
+ * against a stale preflight decision).
+ */
+export async function assertRestoreCompatibility(
+	prisma: Prisma.TransactionClient | PrismaClient,
+	data: BackupData["data"],
+): Promise<void> {
+	if (!hasDurableConfigCoverage(data) && (await targetHasDurableConfig(prisma))) {
+		throw new BackupCompatibilityError(
+			"This backup was created before complete configuration backup support and cannot safely be restored over an installation that currently contains configuration. Restore it into a clean installation, or create a new backup from the current installation.",
+		);
+	}
+}
+
 export async function restoreDatabase(prisma: PrismaClient, data: BackupData["data"]) {
 	// Use a transaction to ensure atomicity
 	await prisma.$transaction(async (tx) => {
+		// Database-layer compatibility recheck: protects direct/internal callers
+		// and closes the TOCTOU window between the orchestration preflight and
+		// destructive mutation. Runs before any delete.
+		await assertRestoreCompatibility(tx, data);
+
 		await validateCurrentCoordinationPreserved(tx, data);
 
 		// =================================================================
@@ -608,6 +693,23 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 
 		// System settings (singleton)
 		await tx.systemSettings.deleteMany();
+
+		// Durable user configuration (reverse dependency order: children first).
+		// These are deleted explicitly so a restore that carries config coverage
+		// replaces them deterministically rather than relying on user/instance
+		// cascades (which would also fire for legacy backups that lack coverage).
+		await tx.notificationSubscription.deleteMany();
+		await tx.notificationChannel.deleteMany();
+		await tx.notificationRule.deleteMany();
+		await tx.notificationAggregationConfig.deleteMany();
+		await tx.autoTagRule.deleteMany();
+		await tx.labelSyncRule.deleteMany();
+		await tx.crossDomainRule.deleteMany();
+		await tx.queueCleanerConfig.deleteMany();
+		await tx.libraryCleanupRule.deleteMany();
+		await tx.libraryCleanupConfig.deleteMany();
+		await tx.namingConfig.deleteMany();
+		await tx.userCustomFormat.deleteMany();
 
 		// Core tables (existing)
 		await tx.serviceInstanceTag.deleteMany();
@@ -823,6 +925,98 @@ export async function restoreDatabase(prisma: PrismaClient, data: BackupData["da
 			validateRecords(data.huntSearchHistory, "huntSearchHistory", ["id", "configId"]);
 			await tx.huntSearchHistory.createMany({
 				data: data.huntSearchHistory as Prisma.HuntSearchHistoryCreateManyInput[],
+			});
+		}
+
+		// --- Durable user configuration (dependency order: parents first) ---
+
+		if (data.notificationChannel && data.notificationChannel.length > 0) {
+			validateRecords(data.notificationChannel, "notificationChannel", ["id", "userId"]);
+			await tx.notificationChannel.createMany({
+				data: data.notificationChannel as Prisma.NotificationChannelCreateManyInput[],
+			});
+		}
+
+		if (data.notificationSubscription && data.notificationSubscription.length > 0) {
+			validateRecords(data.notificationSubscription, "notificationSubscription", [
+				"channelId",
+				"eventType",
+			]);
+			await tx.notificationSubscription.createMany({
+				data: data.notificationSubscription as Prisma.NotificationSubscriptionCreateManyInput[],
+			});
+		}
+
+		if (data.notificationRule && data.notificationRule.length > 0) {
+			validateRecords(data.notificationRule, "notificationRule", ["id", "userId"]);
+			await tx.notificationRule.createMany({
+				data: data.notificationRule as Prisma.NotificationRuleCreateManyInput[],
+			});
+		}
+
+		if (data.notificationAggregationConfig && data.notificationAggregationConfig.length > 0) {
+			validateRecords(data.notificationAggregationConfig, "notificationAggregationConfig", [
+				"id",
+				"userId",
+			]);
+			await tx.notificationAggregationConfig.createMany({
+				data: data.notificationAggregationConfig as Prisma.NotificationAggregationConfigCreateManyInput[],
+			});
+		}
+
+		if (data.autoTagRule && data.autoTagRule.length > 0) {
+			validateRecords(data.autoTagRule, "autoTagRule", ["id", "userId"]);
+			await tx.autoTagRule.createMany({
+				data: data.autoTagRule as Prisma.AutoTagRuleCreateManyInput[],
+			});
+		}
+
+		if (data.labelSyncRule && data.labelSyncRule.length > 0) {
+			validateRecords(data.labelSyncRule, "labelSyncRule", ["id", "userId"]);
+			await tx.labelSyncRule.createMany({
+				data: data.labelSyncRule as Prisma.LabelSyncRuleCreateManyInput[],
+			});
+		}
+
+		if (data.crossDomainRule && data.crossDomainRule.length > 0) {
+			validateRecords(data.crossDomainRule, "crossDomainRule", ["id", "userId"]);
+			await tx.crossDomainRule.createMany({
+				data: data.crossDomainRule as Prisma.CrossDomainRuleCreateManyInput[],
+			});
+		}
+
+		if (data.queueCleanerConfig && data.queueCleanerConfig.length > 0) {
+			validateRecords(data.queueCleanerConfig, "queueCleanerConfig", ["id", "instanceId"]);
+			await tx.queueCleanerConfig.createMany({
+				data: data.queueCleanerConfig as Prisma.QueueCleanerConfigCreateManyInput[],
+			});
+		}
+
+		if (data.libraryCleanupConfig && data.libraryCleanupConfig.length > 0) {
+			validateRecords(data.libraryCleanupConfig, "libraryCleanupConfig", ["id", "userId"]);
+			await tx.libraryCleanupConfig.createMany({
+				data: data.libraryCleanupConfig as Prisma.LibraryCleanupConfigCreateManyInput[],
+			});
+		}
+
+		if (data.libraryCleanupRule && data.libraryCleanupRule.length > 0) {
+			validateRecords(data.libraryCleanupRule, "libraryCleanupRule", ["id", "configId"]);
+			await tx.libraryCleanupRule.createMany({
+				data: data.libraryCleanupRule as Prisma.LibraryCleanupRuleCreateManyInput[],
+			});
+		}
+
+		if (data.namingConfig && data.namingConfig.length > 0) {
+			validateRecords(data.namingConfig, "namingConfig", ["id", "instanceId", "userId"]);
+			await tx.namingConfig.createMany({
+				data: data.namingConfig as Prisma.NamingConfigCreateManyInput[],
+			});
+		}
+
+		if (data.userCustomFormat && data.userCustomFormat.length > 0) {
+			validateRecords(data.userCustomFormat, "userCustomFormat", ["id", "userId"]);
+			await tx.userCustomFormat.createMany({
+				data: data.userCustomFormat as Prisma.UserCustomFormatCreateManyInput[],
 			});
 		}
 	});

--- a/apps/api/src/lib/backup/backup-service.ts
+++ b/apps/api/src/lib/backup/backup-service.ts
@@ -32,7 +32,7 @@ import { withCleanupMaintenanceGuard } from "../library-cleanup/cleanup-maintena
 import { loggers } from "../logger.js";
 import { getErrorMessage } from "../utils/error-message.js";
 import { decryptBackupData, encryptBackupData } from "./backup-crypto.js";
-import { exportDatabase, restoreDatabase } from "./backup-database.js";
+import { assertRestoreCompatibility, exportDatabase, restoreDatabase } from "./backup-database.js";
 import {
 	ensureBackupsDirectory,
 	generateBackupId,
@@ -743,6 +743,13 @@ export class BackupService {
 		let secretsBackedUp = false;
 
 		try {
+			// Phase 0: Compatibility preflight against the current database, before
+			// any filesystem mutation. A known-incompatible restore (legacy backup
+			// over a populated target) must be rejected here so the active secrets
+			// file is never touched. The database-layer recheck inside
+			// restoreDatabase() remains as defense-in-depth against TOCTOU.
+			await assertRestoreCompatibility(this.prisma, backup.data);
+
 			// Phase 1: Backup current secrets before making any changes
 			try {
 				const currentSecrets = await fs.readFile(this.secretsPath, "utf-8");

--- a/apps/api/src/lib/backup/backup-validation.ts
+++ b/apps/api/src/lib/backup/backup-validation.ts
@@ -23,10 +23,45 @@ import {
 } from "../trash-guides/deployment-target.js";
 import type { EncryptedBackupEnvelope } from "./backup-crypto.js";
 
-export const BACKUP_VERSION = "1.1";
+export const BACKUP_VERSION = "1.2";
 export const LEGACY_BACKUP_VERSION = "1.0";
+export const PRE_CONFIG_BACKUP_VERSION = "1.1";
 
-const SUPPORTED_BACKUP_VERSIONS = new Set([LEGACY_BACKUP_VERSION, BACKUP_VERSION]);
+const SUPPORTED_BACKUP_VERSIONS = new Set([
+	LEGACY_BACKUP_VERSION,
+	PRE_CONFIG_BACKUP_VERSION,
+	BACKUP_VERSION,
+]);
+
+/**
+ * Durable user configuration models that MUST survive a full backup/restore.
+ *
+ * This is the single source of truth for the F-01 contract. Each entry maps a
+ * backup payload key to the Prisma model accessor it round-trips through. The
+ * list is deliberately limited to operator configuration — rebuildable caches,
+ * logs, strikes, approvals, snapshots, leases, and sync cursors are excluded.
+ */
+export const DURABLE_CONFIG_MODELS = [
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"crossDomainRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+] as const;
+
+export type DurableConfigModel = (typeof DURABLE_CONFIG_MODELS)[number];
+
+/** Backup payload key for a durable config model (matches the Prisma model name). */
+export function durableConfigPayloadKey(model: DurableConfigModel): string {
+	return model;
+}
 
 type CoordinationRecord = Record<string, unknown>;
 type CoordinationValidationOptions = {
@@ -586,11 +621,25 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 		"huntConfigs",
 		"huntLogs",
 		"huntSearchHistory",
+		// Durable user configuration (required in v1.2+, optional in legacy)
+		...DURABLE_CONFIG_MODELS.map(durableConfigPayloadKey),
 	];
 
 	for (const field of optionalArrayFields) {
 		if (dataRecord[field] !== undefined && !Array.isArray(dataRecord[field])) {
 			throw new Error(`Invalid backup format: ${field} must be an array`);
+		}
+	}
+
+	// A v1.2+ backup must explicitly carry every durable-config array, even when
+	// empty. Absence here means the backup is malformed/incomplete, not a
+	// legitimate legacy backup — reject it before any destructive work.
+	if (b.version === BACKUP_VERSION) {
+		for (const model of DURABLE_CONFIG_MODELS) {
+			const key = durableConfigPayloadKey(model);
+			if (!Array.isArray(dataRecord[key])) {
+				throw new Error(`Invalid backup format: ${key} is required for version ${BACKUP_VERSION}`);
+			}
 		}
 	}
 
@@ -602,7 +651,7 @@ export function validateBackup(backup: unknown): asserts backup is BackupData {
 		throw new Error("Invalid backup format: missing or invalid secrets");
 	}
 
-	if (b.version === BACKUP_VERSION) {
+	if (b.version === BACKUP_VERSION || b.version === PRE_CONFIG_BACKUP_VERSION) {
 		const encryptionKey = b.secrets.encryptionKey;
 		let credentialFactory: ArrClientFactory | undefined;
 		validateCoordinationEvidence(dataRecord, {

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -38,6 +38,20 @@ export class AppValidationError extends Error {
 }
 
 /**
+ * Thrown when a backup cannot be safely restored over the current installation
+ * because the backup predates complete durable-configuration backup support and
+ * the target already contains configuration the backup cannot restore. Maps to
+ * HTTP 409 (conflict between backup format and target state).
+ */
+export class BackupCompatibilityError extends Error {
+	readonly statusCode = 409;
+	constructor(message: string) {
+		super(message);
+		this.name = "BackupCompatibilityError";
+	}
+}
+
+/**
  * Thrown when a qui API call fails. Maps the upstream HTTP status to a
  * client-facing status using the same convention the centralised error
  * handler in server.ts already understands (statusCode property).

--- a/apps/api/src/routes/__tests__/backup-restore-route.test.ts
+++ b/apps/api/src/routes/__tests__/backup-restore-route.test.ts
@@ -1,0 +1,147 @@
+/**
+ * F-01 restore route HTTP contract tests.
+ *
+ * Prove the API maps a legacy-incompatibility rejection to HTTP 409 (not 500)
+ * and a malformed v1.2 backup to a 400-class validation error (not 409/500),
+ * without exposing secrets. Both restore entrypoints share the same
+ * BackupService.restoreBackup() path and the same per-route error mapping, so
+ * the uploaded-restore route is exercised directly; the file-restore route
+ * delegates to the identical service method and error branch.
+ */
+
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import Fastify from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerBackupRoutes } from "../backup.js";
+import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
+
+const DURABLE_CONFIG_MODELS = [
+	"notificationChannel",
+	"notificationSubscription",
+	"notificationRule",
+	"notificationAggregationConfig",
+	"autoTagRule",
+	"labelSyncRule",
+	"crossDomainRule",
+	"queueCleanerConfig",
+	"libraryCleanupConfig",
+	"libraryCleanupRule",
+	"namingConfig",
+	"userCustomFormat",
+] as const;
+
+function makeLegacyBackup() {
+	return {
+		version: "1.1",
+		appVersion: "2.23.0",
+		timestamp: new Date().toISOString(),
+		data: {
+			users: [{ id: "user-1", username: "admin" }],
+			sessions: [],
+			serviceInstances: [],
+			serviceTags: [],
+			serviceInstanceTags: [],
+			oidcAccounts: [],
+			webAuthnCredentials: [],
+		},
+		secrets: {
+			encryptionKey: "b".repeat(64),
+			sessionCookieSecret: "session-secret",
+		},
+	};
+}
+
+function makeMalformedV12Backup() {
+	const emptyConfig = Object.fromEntries(DURABLE_CONFIG_MODELS.map((m) => [m, []]));
+	delete emptyConfig.notificationChannel;
+	return {
+		version: "1.2",
+		appVersion: "3.0.0",
+		timestamp: new Date().toISOString(),
+		data: {
+			users: [],
+			sessions: [],
+			serviceInstances: [],
+			serviceTags: [],
+			serviceInstanceTags: [],
+			oidcAccounts: [],
+			webAuthnCredentials: [],
+			...emptyConfig,
+		},
+		secrets: {
+			encryptionKey: "b".repeat(64),
+			sessionCookieSecret: "session-secret",
+		},
+	};
+}
+
+describe("F-01 restore route HTTP contract", () => {
+	let app: ReturnType<typeof Fastify>;
+	let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
+	let dataDir: string;
+
+	beforeEach(async () => {
+		dataDir = await mkdtemp(path.join(tmpdir(), "arr-f01-route-"));
+		app = Fastify();
+
+		// Populated target: every durable-config model reports a non-zero count so
+		// the compatibility preflight detects a populated installation.
+		const configModels = Object.fromEntries(
+			DURABLE_CONFIG_MODELS.map((m) => [m, { count: vi.fn().mockResolvedValue(1) }]),
+		);
+		const prisma = {
+			...configModels,
+			$transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(prisma)),
+		};
+		app.decorate("prisma", prisma as never);
+		app.decorate("config", {
+			DATABASE_URL: `file:${path.join(dataDir, "prod.db")}`,
+		} as never);
+		app.decorate("encryptor", { encrypt: vi.fn(), decrypt: vi.fn() } as never);
+		app.decorate("secretsSynchronized", true as never);
+		app.decorate("lifecycle", { getRestartMessage: () => "ok", restart: vi.fn() } as never);
+
+		setupAuthInjection(app);
+		await app.register(registerBackupRoutes, { prefix: "/api/backup" });
+		await app.ready();
+
+		injectAuthenticated = createInjectAuthenticated(app);
+	});
+
+	afterEach(async () => {
+		await app?.close();
+		await rm(dataDir, { recursive: true, force: true });
+	});
+
+	it("L — legacy backup over populated target returns 409 (not 500)", async () => {
+		const backupJson = JSON.stringify(makeLegacyBackup());
+		const backupData = Buffer.from(backupJson, "utf-8").toString("base64");
+
+		const res = await injectAuthenticated("POST", "/api/backup/restore", {
+			body: { backupData },
+		});
+
+		expect(res.statusCode).toBe(409);
+		const body = res.json();
+		expect(body.error).toBeTruthy();
+		// Actionable but non-sensitive: no key material in the response.
+		expect(JSON.stringify(body)).not.toContain("b".repeat(64));
+		expect(JSON.stringify(body)).not.toContain("encryptionKey");
+	});
+
+	it("M — malformed v1.2 backup returns 400 (not 409/500)", async () => {
+		const backupJson = JSON.stringify(makeMalformedV12Backup());
+		const backupData = Buffer.from(backupJson, "utf-8").toString("base64");
+
+		const res = await injectAuthenticated("POST", "/api/backup/restore", {
+			body: { backupData },
+		});
+
+		expect(res.statusCode).toBe(400);
+		const body = res.json();
+		expect(body.error).toBeTruthy();
+		expect(JSON.stringify(body)).not.toContain("b".repeat(64));
+	});
+});

--- a/apps/api/src/routes/backup.ts
+++ b/apps/api/src/routes/backup.ts
@@ -12,6 +12,7 @@ import {
 import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import { BackupService } from "../lib/backup/backup-service.js";
+import { BackupCompatibilityError } from "../lib/errors.js";
 import { CleanupMaintenanceConflictError } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { resolveSecretsPath } from "../lib/utils/secrets-path.js";
@@ -151,6 +152,11 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 				return reply.status(409).send({ error: error.message });
 			}
 
+			if (error instanceof BackupCompatibilityError) {
+				request.log.warn({ err: error }, "Backup restore rejected: incompatible backup format");
+				return reply.status(409).send({ error: error.message });
+			}
+
 			request.log.error({ err: error }, "Failed to restore backup");
 			const errorMessage = getErrorMessage(error);
 
@@ -209,6 +215,14 @@ const backupRoutes: FastifyPluginCallback = (app, _opts, done) => {
 					request.log.warn(
 						{ err: error },
 						"Backup restore from file blocked by active cleanup maintenance",
+					);
+					return reply.status(409).send({ error: error.message });
+				}
+
+				if (error instanceof BackupCompatibilityError) {
+					request.log.warn(
+						{ err: error },
+						"Backup restore from file rejected: incompatible backup format",
 					);
 					return reply.status(409).send({ error: error.message });
 				}

--- a/packages/shared/src/types/backup.ts
+++ b/packages/shared/src/types/backup.ts
@@ -74,7 +74,7 @@ export const restoreBackupFromFileRequestSchema = z.object({
 export type RestoreBackupFromFileRequest = z.infer<typeof restoreBackupFromFileRequestSchema>;
 
 // Backup structure (internal, not exposed via API)
-export type BackupFormatVersion = "1.0" | "1.1";
+export type BackupFormatVersion = "1.0" | "1.1" | "1.2";
 
 export interface BackupData {
 	version: BackupFormatVersion;
@@ -119,6 +119,23 @@ export interface BackupData {
 		huntConfigs?: unknown[];
 		huntLogs?: unknown[];
 		huntSearchHistory?: unknown[];
+
+		// Durable user configuration (required in v1.2+; absent in legacy backups).
+		// These are always present as arrays in new-format backups, even when
+		// empty, so "empty" is distinguishable from "legacy backup that never
+		// carried configuration coverage". Keys match the Prisma model names.
+		notificationChannel?: unknown[];
+		notificationSubscription?: unknown[];
+		notificationRule?: unknown[];
+		notificationAggregationConfig?: unknown[];
+		autoTagRule?: unknown[];
+		labelSyncRule?: unknown[];
+		crossDomainRule?: unknown[];
+		queueCleanerConfig?: unknown[];
+		libraryCleanupConfig?: unknown[];
+		libraryCleanupRule?: unknown[];
+		namingConfig?: unknown[];
+		userCustomFormat?: unknown[];
 	};
 	secrets: {
 		encryptionKey: string;


### PR DESCRIPTION
## Summary

Fixes F-01 by making backup/restore preserve the complete durable configuration state while keeping ephemeral runtime state outside the backup contract.

The restore path now distinguishes current-format backups from legacy backups and rejects unsafe legacy restores over populated targets before either database or secrets state can be mutated.

## What changed

- Bump the backup format from `1.1` to `1.2` and require all 12 durable-configuration collections to be present (even when empty).
- Export the 12 durable-configuration models: notification channels, subscriptions, rules, aggregation config, auto-tag rules, label-sync rules, cross-domain rules, queue-cleaner config, library-cleanup config + rules, naming config, and user custom formats.
- Restore all 12 models in foreign-key-safe order within the existing transaction.
- Preserve encrypted configuration (ciphertext + IV) byte-for-byte across backup/restore and encryption-key changes.
- Keep ephemeral/runtime-only state (caches, logs, strikes, approvals, snapshots, leases, sync cursors) outside the durable backup boundary.
- Validate the new backup format before restore; a v1.2 backup missing any required config array is rejected as malformed.
- Retain supported legacy restore behavior for clean targets (no durable config present).
- Reject incompatible legacy restores over populated targets with a `BackupCompatibilityError` (HTTP 409).
- Enforce the compatibility protection at both the top-level restore path and the lower-level `restoreDatabase` boundary (defense-in-depth against direct/internal callers and TOCTOU).
- Ensure compatibility rejection occurs before `writeSecrets`, so a rejected legacy restore never mutates `secrets.json`.
- Preserve transaction rollback semantics on failed restore.

## Safety properties

The change preserves these invariants:

- malformed or incomplete current-format backups fail before mutation
- incompatible legacy backups cannot overwrite populated durable configuration
- lower-level/internal callers cannot bypass the legacy compatibility guard
- compatibility rejection does not mutate `secrets.json`
- database failures roll back rather than leaving a partially restored state
- encrypted configuration remains usable after cross-key restore
- legacy clean-target restores remain supported

## Validation

### Focused F-01 regression suite

15/15 passed, covering:

- durable config round trip
- export completeness
- ephemeral-state boundary
- legacy backup fail-closed behavior
- transaction rollback
- malformed configuration rejection
- encrypted round trip
- empty and incomplete v1.2 backups
- legacy clean-target restore
- secrets non-mutation on rejection
- HTTP 409/400 compatibility behavior
- cross-key restore
- lower-level bypass protection

### Backup subsystem

103 passed / 0 failed / 12 skipped.

The 12 skipped tests are pre-existing opt-in integration/heap tests and are not F-01 regressions.

### Repository gauntlet

- format: PASS
- shared build: PASS
- typecheck: PASS
- tests: PASS
  - API: 4218 passed / 71 skipped
  - Web: 864 passed
- lint: PASS
- production build: PASS

### Persistence / CI-parity

- Prisma generate: PASS
- Prisma db push: PASS
- durable persistence DB contracts: 7/7 PASS
- Knip: no F-01-related dead code

### Production Docker validation

- production image built successfully
- container reached healthy state
- `/health`: HTTP 200
- backup scheduler initialized successfully

### Live v1.2 restore

Verified end-to-end that durable notification configuration:

1. existed before backup
2. was included in a v1.2 backup
3. restored successfully
4. survived the launcher-triggered application restart
5. remained queryable afterward
6. retained encrypted configuration

### Legacy fail-closed validation

A v1.1 legacy backup applied to a populated target:

- returned HTTP 409
- left durable DB configuration unchanged
- left `/config/secrets.json` unchanged
- left the application healthy and usable

## Notes

`apps/web/next-env.d.ts` can be mutated by `pnpm run build` due to the separately tracked F-18 issue. It was restored after validation and is not part of this PR.

No unrelated cleanup or refactoring is included.
