### PR TITLE
fix(plex): exclude personal media from cache authority

### DIFF
--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -759,4 +759,322 @@ describe("collectPlexCacheLiveEvidence", () => {
 		expect(result.errors).toBeGreaterThan(0);
 		expect(deleteMany).not.toHaveBeenCalled();
 	});
+
+	describe("Personal Media / Other Videos libraries (#769)", () => {
+		const supportedMovie = {
+			ratingKey: "movie-1",
+			title: "Supported Movie",
+			type: "movie",
+			Guid: [{ id: "tmdb://42" }],
+		};
+		const personalMediaItem = {
+			ratingKey: "personal-1",
+			title: "Home Video",
+			type: "movie",
+			Guid: [],
+		};
+		const mixedSections = [
+			{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+			{ key: "2", title: "Other Videos", type: "movie", agent: "com.plexapp.agents.none" },
+		];
+
+		it("excludes a Personal Media section from the supported-media authority domain", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue(mixedSections),
+				getLibraryItems: vi
+					.fn()
+					.mockImplementation((key: string) => (key === "1" ? [supportedMovie] : [personalMediaItem])),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+			expect(result.snapshot?.rows).toHaveLength(1);
+			expect(result.snapshot?.rows[0]).toEqual(expect.objectContaining({ tmdbId: 42 }));
+			expect(result.snapshot?.sections).toEqual([{ key: "1", title: "Movies", type: "movie" }]);
+			expect(result.inventoryTargets).toEqual([
+				{ mediaType: "movie", tmdbId: 42, ratingKey: "movie-1" },
+			]);
+		});
+
+		it("does not poison completeness when Personal Media history cannot map", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue(mixedSections),
+				getLibraryItems: vi
+					.fn()
+					.mockImplementation((key: string) => (key === "1" ? [supportedMovie] : [personalMediaItem])),
+				getHistory: vi.fn().mockResolvedValue([
+					{ type: "movie", ratingKey: "personal-1", accountID: 1, viewedAt: 1_700_000_000 },
+				]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+			expect(result.snapshot?.rows).toHaveLength(1);
+			expect(result.snapshot?.rows[0]).toEqual(expect.objectContaining({ tmdbId: 42 }));
+		});
+
+		it("still fails closed when a supported movie lacks TMDB metadata", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue([
+					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+				]),
+				getLibraryItems: vi.fn().mockResolvedValue([
+					{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
+				]),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 current library item(s) without TMDB metadata",
+			);
+		});
+
+		it("still fails closed when supported history cannot map to TMDB metadata", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue([
+					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+				]),
+				getLibraryItems: vi.fn().mockResolvedValue([
+					{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
+				]),
+				getHistory: vi.fn().mockResolvedValue([
+					{ type: "movie", ratingKey: "broken-1", accountID: 1, viewedAt: 1_700_000_000 },
+				]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 current history item(s) without mapped TMDB metadata",
+			);
+		});
+
+		it("does not exclude a section with an unknown agent merely for lacking TMDB", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue([
+					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+					{ key: "3", title: "Custom", type: "movie", agent: "com.example.agents.custom" },
+				]),
+				getLibraryItems: vi
+					.fn()
+					.mockImplementation((key: string) =>
+						key === "1"
+							? [supportedMovie]
+							: [{ ratingKey: "custom-1", title: "Custom", type: "movie", Guid: [] }],
+					),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 current library item(s) without TMDB metadata",
+			);
+		});
+	});
+
+	describe("Personal Media history with missing media keys (#769)", () => {
+		const supportedMovie = {
+			ratingKey: "movie-1",
+			title: "Supported Movie",
+			type: "movie",
+			Guid: [{ id: "tmdb://42" }],
+		};
+		const sections = [
+			{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+			{ key: "2", title: "Other Videos", type: "movie", agent: "com.plexapp.agents.none" },
+		];
+
+		function clientWith(history: unknown[]) {
+			return {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue(sections),
+				getLibraryItems: vi.fn().mockResolvedValue([supportedMovie]),
+				getHistory: vi.fn().mockResolvedValue(history),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+		}
+
+		it("ignores Personal Media movie history with a missing rating key", async () => {
+			const mockClient = clientWith([
+				{
+					type: "movie",
+					ratingKey: "",
+					librarySectionID: "2",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+		});
+
+		it("ignores Personal Media episode history with a missing grandparent key", async () => {
+			const mockClient = clientWith([
+				{
+					type: "episode",
+					ratingKey: "episode-1",
+					librarySectionID: "2",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+		});
+
+		it("fails closed for supported movie history with a missing rating key", async () => {
+			const mockClient = clientWith([
+				{
+					type: "movie",
+					ratingKey: "",
+					librarySectionID: "1",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 history item(s) without a usable media key",
+			);
+		});
+
+		it("fails closed for supported episode history with a missing grandparent key", async () => {
+			const mockClient = clientWith([
+				{
+					type: "episode",
+					ratingKey: "episode-1",
+					librarySectionID: "1",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 history item(s) without a usable media key",
+			);
+		});
+
+		it("fails closed for history with a missing librarySectionID and missing key", async () => {
+			const mockClient = clientWith([
+				{ type: "movie", ratingKey: "", accountID: 1, viewedAt: 1_700_000_000 },
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 history item(s) without a usable media key",
+			);
+		});
+
+		it("fails closed for history with an unknown librarySectionID and missing key", async () => {
+			const mockClient = clientWith([
+				{
+					type: "movie",
+					ratingKey: "",
+					librarySectionID: "999",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: false });
+			expect(result.errorMessages).toContain(
+				"Plex cache incomplete: 1 history item(s) without a usable media key",
+			);
+		});
+
+		it("preserves stale-history protection for a usable key outside current inventory", async () => {
+			const mockClient = clientWith([
+				{
+					type: "movie",
+					ratingKey: "stale",
+					librarySectionID: "1",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+			expect(result.snapshot?.rows).toHaveLength(1);
+			expect(result.snapshot?.rows[0]).toEqual(expect.objectContaining({ tmdbId: 42 }));
+		});
+
+		it("completes a mixed production topology with Personal Media history missing keys", async () => {
+			const mockClient = clientWith([
+				{
+					type: "movie",
+					ratingKey: "",
+					librarySectionID: "2",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+				{
+					type: "episode",
+					ratingKey: "episode-1",
+					librarySectionID: "2",
+					accountID: 1,
+					viewedAt: 1_700_000_000,
+				},
+			]);
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog, undefined);
+
+			expect(result).toMatchObject({ complete: true, errors: 0 });
+			expect(result.snapshot?.rows).toHaveLength(1);
+			expect(result.snapshot?.rows[0]).toEqual(expect.objectContaining({ tmdbId: 42 }));
+		});
+	});
 });

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -218,6 +218,36 @@ describe("PlexClient authoritative inventory completeness", () => {
 		);
 	});
 
+	it("rejects a librarySectionID change between collection and verification", async () => {
+		const base = {
+			historyKey: "/status/sessions/history/1",
+			ratingKey: "",
+			title: "Home Video",
+			type: "movie",
+			viewedAt: 1_700_000_000,
+			accountID: 1,
+		};
+		const initial = [{ ...base, librarySectionID: "personal-section" }];
+		const changed = [{ ...base, librarySectionID: "supported-section" }];
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValueOnce(
+					response({ offset: 0, size: 1, totalSize: 1, Metadata: initial }),
+				)
+				.mockResolvedValueOnce(
+					response({ offset: 0, size: 1, totalSize: 1, Metadata: changed }),
+				),
+		);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		const snapshot = await client.getHistory({ maxResults: 100_000, requireComplete: true });
+		await expect(client.verifyHistorySnapshot(snapshot)).rejects.toThrow(
+			/changed before.*snapshot/i,
+		);
+	});
+
 	it("rejects equal-count churn in a middle page during complete verification", async () => {
 		const history = Array.from({ length: 401 }, (_, index) => ({
 			historyKey: `/status/sessions/history/${index}`,
@@ -271,6 +301,86 @@ describe("PlexClient authoritative inventory completeness", () => {
 
 		await expect(client.getLibrarySections()).resolves.toHaveLength(1);
 		await expect(client.getAccounts()).resolves.toEqual([{ id: 1, name: "Admin" }]);
+	});
+
+	it("preserves the section agent through the wire mapping", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			response({
+				size: 1,
+				Directory: [
+					{ key: "7", title: "Personal", type: "movie", agent: "com.plexapp.agents.none" },
+				],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getLibrarySections()).resolves.toEqual([
+			{ key: "7", title: "Personal", type: "movie", agent: "com.plexapp.agents.none" },
+		]);
+	});
+
+	it("leaves an absent section agent undefined rather than defaulting it", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			response({ size: 1, Directory: [{ key: "1", title: "Movies", type: "movie" }] }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		const sections = await client.getLibrarySections();
+		expect(sections[0]).toEqual({ key: "1", title: "Movies", type: "movie" });
+		expect(sections[0]?.agent).toBeUndefined();
+	});
+
+	it("coerces a numeric librarySectionID to a string through getHistory", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			response({
+				offset: 0,
+				size: 1,
+				totalSize: 1,
+				Metadata: [
+					{
+						historyKey: "/status/sessions/history/1",
+						ratingKey: "movie-1",
+						title: "Movie",
+						type: "movie",
+						viewedAt: 1_700_000_000,
+						accountID: 1,
+						librarySectionID: 7,
+					},
+				],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		const history = await client.getHistory({ maxResults: 100_000, requireComplete: true });
+		expect(history[0]?.librarySectionID).toBe("7");
+	});
+
+	it("leaves a missing librarySectionID undefined through getHistory", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			response({
+				offset: 0,
+				size: 1,
+				totalSize: 1,
+				Metadata: [
+					{
+						historyKey: "/status/sessions/history/1",
+						ratingKey: "movie-1",
+						title: "Movie",
+						type: "movie",
+						viewedAt: 1_700_000_000,
+						accountID: 1,
+					},
+				],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		const history = await client.getHistory({ maxResults: 100_000, requireComplete: true });
+		expect(history[0]?.librarySectionID).toBeUndefined();
 	});
 
 	it("rejects inconsistent optional pagination metadata on sections and accounts", async () => {

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -68,6 +68,31 @@ function parsePlexTvdbId(guids: Array<{ id: string }> | undefined): number | nul
 }
 
 // ============================================================================
+// Library Classification
+// ============================================================================
+
+/**
+ * Plex agents that never produce TMDB/TVDB GUIDs. A section using one of these
+ * (e.g. an "Other Videos" / "Personal Media" library) cannot participate in
+ * ARR/Plex cleanup correlation, so it is excluded from the authority domain
+ * rather than treated as incomplete supported evidence.
+ *
+ * This is deliberately a closed allowlist of "no metadata" agents. A section
+ * with a metadata agent (or a missing/unknown agent) is still treated as
+ * supported media and fails closed when its items lack the required identity.
+ *
+ * `com.plexapp.agents.none` is Plex's Personal Media primary agent. Local Media
+ * Assets (`com.plexapp.agents.localmedia`) is NOT included: it is an asset
+ * source, not a section-level primary agent, and is not equivalent to a
+ * Personal Media library.
+ */
+const PERSONAL_MEDIA_AGENTS = new Set(["com.plexapp.agents.none"]);
+
+function isPersonalMediaSection(section: { type: string; agent?: string }): boolean {
+	return section.agent !== undefined && PERSONAL_MEDIA_AGENTS.has(section.agent);
+}
+
+// ============================================================================
 // Aggregation Types
 // ============================================================================
 
@@ -379,9 +404,24 @@ export async function collectPlexCacheLiveEvidence(
 			accountMap.set(account.id, account.name);
 		}
 
-		// 2. Get library sections (movie and show only)
+		// 2. Get library sections (movie and show only). Personal Media / Other
+		// Videos sections report a movie/show type but use a "no metadata" agent,
+		// so they are excluded from the cleanup-authority domain rather than
+		// poisoning completeness for supported media.
 		const sections = await client.getLibrarySections();
-		const mediaLibs = sections.filter((s) => s.type === "movie" || s.type === "show");
+		const mediaLibs = sections.filter(
+			(s) => (s.type === "movie" || s.type === "show") && !isPersonalMediaSection(s),
+		);
+		// Retain the Personal Media section IDs so history rows can be attributed
+		// to an unsupported section even when they lack a usable media key.
+		// Unknown/missing section IDs are never treated as safe.
+		const personalMediaSectionIds = new Set<string>();
+		for (const section of sections) {
+			if (section.type !== "movie" && section.type !== "show") continue;
+			if (isPersonalMediaSection(section)) {
+				personalMediaSectionIds.add(section.key);
+			}
+		}
 		const initialMediaLibrarySignature = mediaLibrarySignature(mediaLibs);
 		if (mediaLibs.length === 0) {
 			markIncomplete("noMediaLibraries");
@@ -477,7 +517,16 @@ export async function collectPlexCacheLiveEvidence(
 			const isRelevantHistory = entry.type === "movie" || entry.type === "episode";
 			const itemRatingKey = entry.type === "episode" ? entry.grandparentRatingKey : entry.ratingKey;
 			if (!itemRatingKey?.trim()) {
-				if (isRelevantHistory) markIncomplete("historyItemsWithoutUsableMediaKey");
+				if (isRelevantHistory) {
+					// A movie/episode history row without a usable media key is only
+					// safe to ignore when it belongs to a known Personal Media
+					// section. Supported sections and unknown/missing section IDs
+					// must fail closed.
+					if (entry.librarySectionID && personalMediaSectionIds.has(entry.librarySectionID)) {
+						continue;
+					}
+					markIncomplete("historyItemsWithoutUsableMediaKey");
+				}
 				continue;
 			}
 
@@ -604,7 +653,9 @@ export async function collectPlexCacheLiveEvidence(
 		if (errors === 0 && complete) {
 			const latestSections = await client.getLibrarySections();
 			const latestMediaLibs = latestSections.filter(
-				(section) => section.type === "movie" || section.type === "show",
+				(section) =>
+					(section.type === "movie" || section.type === "show") &&
+					!isPersonalMediaSection(section),
 			);
 			if (
 				JSON.stringify(mediaLibrarySignature(latestMediaLibs)) !==

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -42,6 +42,7 @@ export interface PlexLibrary {
 	key: string; // section ID
 	title: string;
 	type: string; // "movie" | "show" | "artist"
+	agent?: string; // e.g. "tv.plex.agents.movie", "com.plexapp.agents.none"
 }
 
 export interface PlexGuid {
@@ -105,6 +106,7 @@ export interface PlexHistoryItem {
 	type: string; // "movie" | "episode" | "track"
 	viewedAt: number; // Unix timestamp
 	accountID: number;
+	librarySectionID?: string;
 }
 
 export interface PlexAccount {
@@ -234,6 +236,7 @@ export class PlexClient {
 			key: d.key,
 			title: d.title,
 			type: d.type,
+			agent: d.agent,
 		}));
 	}
 
@@ -485,6 +488,7 @@ export class PlexClient {
 					type: item.type,
 					viewedAt: item.viewedAt,
 					accountID: item.accountID,
+					librarySectionID: item.librarySectionID,
 				});
 			}
 			offset += items.length;
@@ -513,6 +517,7 @@ export class PlexClient {
 						item.type,
 						item.viewedAt,
 						item.accountID,
+						item.librarySectionID ?? null,
 					]),
 				)
 				.sort();

--- a/apps/api/src/lib/plex/plex-schemas.ts
+++ b/apps/api/src/lib/plex/plex-schemas.ts
@@ -43,6 +43,7 @@ export const plexSectionsResponseSchema = z.looseObject({
 					key: z.string(),
 					title: z.string().optional().default(""),
 					type: z.string(),
+					agent: z.string().optional(),
 				}),
 			)
 			.optional(),
@@ -148,6 +149,7 @@ export const plexHistoryResponseSchema = z.looseObject({
 					type: z.string(),
 					viewedAt: z.number(),
 					accountID: z.number(),
+					librarySectionID: z.coerce.string().optional(),
 				}),
 			)
 			.optional(),


### PR DESCRIPTION
## Summary

Fixes #769.

Plex Personal Media / "Other Videos" libraries can report themselves as
movie/show sections while using the `com.plexapp.agents.none` agent and
providing no TMDB/TVDB metadata.

The Plex cache refresher previously treated those sections as supported
cleanup evidence, causing Personal Media items and history to mark the entire
Plex cache incomplete and block Library Cleanup / Episode Evidence.

This change excludes explicitly identified Personal Media sections from the
cleanup-authority domain while preserving fail-closed behavior for supported,
unknown, or malformed Movie/TV evidence.

## Root cause

Two independent paths caused the production failure:

1. Section discovery classified support using only `type`, so Personal Media
   sections reporting `movie` or `show` were scanned as cleanup-authoritative
   media.

2. Missing-key history was marked incomplete before the history row's Plex
   section could be considered. `librarySectionID` was available upstream but
   was not preserved by the Plex client.

## Fix

- Preserve Plex section `agent` through schema/client mapping.
- Recognize only the explicit Personal Media agent
  `com.plexapp.agents.none`.
- Exclude known Personal Media sections from supported cleanup authority.
- Preserve `librarySectionID` from Plex history.
- Ignore missing-key history only when it belongs to a section explicitly
  known to be Personal Media.
- Continue failing closed for:
  - supported sections
  - unknown agents
  - missing section IDs
  - unknown section IDs
  - supported Movie/TV items missing required metadata
- Include `librarySectionID` in history snapshot revalidation so section
  attribution cannot change between collection and publication without being
  detected.

## Safety properties

Unknown remains unsafe.

A Plex section is excluded only when its explicit primary agent is the known
Personal Media agent.

Missing or unfamiliar agents remain inside the supported authority domain and
continue to fail closed if required metadata is unavailable.

Likewise, a history row with a missing media key is ignored only when its
`librarySectionID` is explicitly mapped to a known Personal Media section.

No Personal Media item can enter authoritative Plex cache rows or
`inventoryTargets`.

Existing stale-history and provider-publication safeguards remain unchanged.

## Regression coverage

New regression coverage includes:

- Personal Media movie/show sections
- Personal Media movie history with missing rating key
- Personal Media episode history with missing grandparent key
- supported Movie/TV missing-key history remains fail-closed
- missing/unknown `librarySectionID` remains fail-closed
- unknown agents remain fail-closed
- mixed Movies + TV + Personal Media topology
- unsupported media excluded from inventory targets
- section-agent wire mapping
- `librarySectionID` wire mapping/coercion
- `librarySectionID` snapshot-churn rejection
- existing #693 stale-history behavior

## Validation

- Focused Plex + cleanup suites: 409 passed
- Shared build: PASS
- Lint: PASS
- Production build: PASS
- `git diff --check`: PASS

### Existing main baseline failures

The current `main` baseline already has unrelated validation failures:

- Typecheck fails because the generated Prisma client is missing identity
  fields used elsewhere in the repository.
- Full test suite has 3 failures in `service-identity-schema.test.ts`.

Both failures were reproduced unchanged on a clean `main` checkout with the
#769 changes removed.

The #769 changed files introduce no typecheck errors.

Do not represent those pre-existing failures as introduced by this PR.

Closes #769.
