### PR TITLE
fix(qui): accept omitted empty cross-instance inventory

### DIFF
--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -538,6 +538,215 @@ describe("createQuiClient", () => {
 		expect(result).toBeNull();
 	});
 
+	// ── qUI v1.26.0 compatibility boundary (#770) ─────────────────────
+	// qUI v1.26.0's TorrentResponse.CrossInstanceTorrents carries
+	// `json:"cross_instance_torrents,omitempty"` (sync_manager.go:234). Go's
+	// omitempty drops the field entirely when the slice is empty, so a
+	// complete empty inventory is serialized WITHOUT the key — not as `[]`
+	// and not as `null`. Completeness is still proven by the always-present
+	// `total`/`hasMore`/`partialResults` fields (none carry omitempty).
+
+	it("accepts a complete empty inventory where qUI v1.26.0 omits cross_instance_torrents (#770)", async () => {
+		// Exact v1.26.0 wire shape for a complete zero-torrent inventory:
+		// cross_instance_torrents is absent, but total/hasMore/partialResults
+		// are present and prove completeness.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: false,
+					isCrossInstance: true,
+					trackerHealthSupported: false,
+					useSubcategories: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const inventory = await client.listTorrentInventory();
+
+		expect(inventory.complete).toBe(true);
+		expect(inventory.torrents).toEqual([]);
+	});
+
+	it("accepts a complete empty inventory via requireComplete listAllTorrents (#770)", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const torrents = await client.listAllTorrents({ requireComplete: true });
+
+		expect(torrents).toEqual([]);
+	});
+
+	it("accepts a complete empty inventory for exact-hash lookup (#770)", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: false,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const results = await client.getTorrentsByHash("abc123");
+
+		expect(results).toEqual([]);
+	});
+
+	it("tolerates additive unknown fields alongside a known complete inventory (#770)", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: false,
+					someFutureField: { nested: true },
+					anotherFutureField: "hello",
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const inventory = await client.listTorrentInventory();
+
+		expect(inventory.complete).toBe(true);
+		expect(inventory.torrents).toEqual([]);
+	});
+
+	it("rejects an unknown wrapper that lacks completeness metadata (#770)", async () => {
+		// A torrent-looking payload under an unverified semantic shape must
+		// not be guessed into an authoritative empty inventory.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(JSON.stringify({ torrents: [] }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow();
+	});
+
+	it("does not treat a missing cross_instance_torrents with partialResults as empty (#770)", async () => {
+		// partialResults=true means some instances failed; absence is NOT
+		// authoritative even though the collection key is missing.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: true,
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow(
+			"partial results",
+		);
+	});
+
+	// ── Metadata-consistency safety matrix (#770) ─────────────────────
+	// The normalization rule is NOT "missing cross_instance_torrents => []".
+	// It is: known qUI semantic response AND omitted collection AND metadata
+	// proves zero results => []. Any contradiction fails closed.
+
+	it("rejects a non-empty total with an omitted collection (CASE B)", async () => {
+		// total=5 claims torrents exist but no collection is supplied.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({ total: 5, hasMore: false, partialResults: false }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow(
+			"ended before its declared total",
+		);
+	});
+
+	it("rejects an omitted collection while more pages supposedly exist (CASE C)", async () => {
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({ total: 5, hasMore: true, partialResults: false }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow(
+			"empty page with more results",
+		);
+	});
+
+	it("fails closed for requireComplete when partialResults metadata is missing (CASE E)", async () => {
+		// Missing partialResults means completeness cannot be proven; the
+		// strict requireComplete schema rejects it outright.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({ total: 0, hasMore: false }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow();
+	});
+
+	it("reports incomplete (not authoritative) for read-only inventory missing partialResults (CASE E)", async () => {
+		// The non-requireComplete path tolerates the missing metadata but
+		// must NOT claim completeness, so absence is not authoritative.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({ total: 0, hasMore: false }),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		const inventory = await client.listTorrentInventory();
+
+		expect(inventory.complete).toBe(false);
+		expect(inventory.torrents).toEqual([]);
+	});
+
+	it("rejects a returned count greater than total with an omitted collection (CASE F)", async () => {
+		// total=0 but a collection is supplied — impossible, must fail closed.
+		fetchSpy.mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					total: 0,
+					hasMore: false,
+					partialResults: false,
+					cross_instance_torrents: [wireTorrent({ hash: "abc123", instance_id: 1 })],
+				}),
+				{ status: 200, headers: { "content-type": "application/json" } },
+			),
+		);
+
+		const client = createQuiClient(buildApp(), buildInstance());
+		await expect(client.listAllTorrents({ requireComplete: true })).rejects.toThrow(
+			"more rows than its total",
+		);
+	});
+
 	it("derives tracker health from the raw qBit status int", async () => {
 		fetchSpy.mockResolvedValueOnce(
 			new Response(

--- a/apps/api/src/lib/qui/client-factory.ts
+++ b/apps/api/src/lib/qui/client-factory.ts
@@ -289,21 +289,55 @@ const wireTorrentSchema = z
 		}),
 	);
 
-const wireCrossInstanceLookupResponseSchema = z.object({
-	cross_instance_torrents: z.array(wireTorrentSchema).nullable(),
-});
+// qUI's TorrentResponse.CrossInstanceTorrents carries
+// `json:"cross_instance_torrents,omitempty"` (upstream sync_manager.go). Go's
+// omitempty drops the key entirely when the slice is empty, so a complete
+// empty inventory serializes WITHOUT `cross_instance_torrents` — not `[]` and
+// not `null`. The collection field is therefore NOT a completeness signal:
+// completeness is proven by `total`/`hasMore`/`partialResults`, which are
+// always emitted (no omitempty). We tolerate an absent collection and
+// normalize it to `[]` at the call sites via `?? []`; the completeness gate
+// lives on the metadata fields, not on the collection.
+//
+// A valid cross-instance response is discriminated by the presence of at
+// least one known semantic field: the `cross_instance_torrents` collection
+// (older metadata-free releases) or `total` (current releases, which always
+// emit it). An object with neither is an unknown wrapper and is rejected
+// rather than guessed into an authoritative empty inventory. `.passthrough()`
+// tolerates additive unknown fields so future qUI releases that add metadata
+// do not require an arr-dashboard patch.
+const wireCrossInstanceCollection = {
+	cross_instance_torrents: z.array(wireTorrentSchema).nullable().optional(),
+};
 
-const wireCrossInstanceInventoryResponseSchema = wireCrossInstanceLookupResponseSchema.extend({
-	hasMore: z.boolean().optional(),
-	partialResults: z.boolean().optional(),
-	total: z.number().int().nonnegative().optional(),
-});
+const crossInstanceShapeGuard = (obj: {
+	cross_instance_torrents?: unknown;
+	total?: unknown;
+}): boolean => obj.cross_instance_torrents !== undefined || obj.total !== undefined;
 
-const wireCrossInstanceResponseSchema = wireCrossInstanceLookupResponseSchema.extend({
-	hasMore: z.boolean(),
-	partialResults: z.boolean(),
-	total: z.number().int().nonnegative(),
-});
+const wireCrossInstanceLookupResponseSchema = z
+	.object(wireCrossInstanceCollection)
+	.passthrough()
+	.refine(crossInstanceShapeGuard, { message: "unrecognized cross-instance response shape" });
+
+const wireCrossInstanceInventoryResponseSchema = z
+	.object({
+		...wireCrossInstanceCollection,
+		hasMore: z.boolean().optional(),
+		partialResults: z.boolean().optional(),
+		total: z.number().int().nonnegative().optional(),
+	})
+	.passthrough()
+	.refine(crossInstanceShapeGuard, { message: "unrecognized cross-instance response shape" });
+
+const wireCrossInstanceResponseSchema = z
+	.object({
+		...wireCrossInstanceCollection,
+		hasMore: z.boolean(),
+		partialResults: z.boolean(),
+		total: z.number().int().nonnegative(),
+	})
+	.passthrough();
 
 function crossInstanceTorrentIdentity(torrent: QuiTorrent, operation: string): string {
 	if (


### PR DESCRIPTION
## Summary

Fixes #770.

qUI's `/api/torrents/cross-instance` response defines
`cross_instance_torrents` with Go's `omitempty` behavior.

When an inventory is genuinely empty, qUI omits that field entirely while
still returning authoritative completeness metadata:

```json
{
  "total": 0,
  "hasMore": false,
  "partialResults": false
}
```

arr-dashboard's wire schema required `cross_instance_torrents` to be present,
so a complete empty inventory failed Zod validation with
`expected array, received undefined` and surfaced as a `QuiApiError` (502),
aborting torrent-state sync and infoHash/path backfill.

## Change

The cross-instance wire schemas now tolerate an omitted `cross_instance_torrents`
field, normalizing it to `[]` at the call sites. Completeness authority remains
on `total`/`hasMore`/`partialResults`, which qUI always emits.

The normalization rule is **not** "missing collection => empty". It is:

> known qUI semantic response AND omitted collection AND metadata proves zero
> results => `[]`

Otherwise the response fails closed.

- `.passthrough()` tolerates additive unknown fields so future qUI releases
  that add metadata do not require an arr-dashboard patch.
- A shape guard rejects unknown wrappers (e.g. `{ "torrents": [] }`) that carry
  none of the verified cross-instance discriminators.
- The strict `requireComplete` schema still requires `total`/`hasMore`/
  `partialResults`, so authoritative-absence callers remain fail-closed.

## Safety

- Complete empty inventory (`total:0, hasMore:false, partialResults:false`,
  no collection) → accepted as authoritative empty.
- Non-empty `total` with omitted collection → rejected.
- `hasMore:true` with omitted collection → rejected.
- `partialResults:true` → rejected for `requireComplete` callers.
- Missing completeness metadata → `requireComplete` fails closed; read-only
  inventory reports `complete:false`.
- Contradictory totals / rows > total → rejected.

No caller semantics changed. The `complete` / `requireComplete` distinction is
preserved: positive-observation callers may consume known rows; authoritative-
absence callers still require a provably complete inventory.

## Tests

Added regression coverage for the exact #770 response plus the metadata-
consistency safety matrix (authoritative empty, non-empty total with omitted
collection, hasMore with omitted collection, partial results, missing
metadata, contradictory totals, additive fields, unknown wrapper).
