### PR TITLE
fix(trash-guides): preserve interrupted deployment recovery

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-active-ownership.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { resolveActiveDeploymentOwnership } from "../deployment-active-ownership.js";
+import {
+	resolveActiveDeploymentOwnership,
+	UNVERIFIABLE_DEPLOYMENT_OWNERSHIP,
+} from "../deployment-active-ownership.js";
 
 function state(overrides: Record<string, unknown> = {}) {
 	return JSON.stringify({
@@ -21,6 +24,13 @@ function state(overrides: Record<string, unknown> = {}) {
 		},
 		namingDeployment: null,
 		...overrides,
+	});
+}
+
+function legacyState() {
+	return JSON.stringify({
+		customFormats: [],
+		qualityProfile: null,
 	});
 }
 
@@ -719,6 +729,156 @@ describe("active deployment ownership", () => {
 		});
 
 		expect(result.restorableSharedQualityProfileIds).not.toContain(3);
+	});
+
+	it.each([
+		{ label: "SUCCESS", status: "SUCCESS" },
+		{ label: "PARTIAL_SUCCESS", status: "PARTIAL_SUCCESS" },
+		{ label: "FAILED", status: "FAILED" },
+	])(
+		"fails closed when an unrolled legacy $label history may still own live resources",
+		async ({ status }) => {
+			const rows = [
+				{
+					templateId: "template-1",
+					backupId: "target",
+					status: "SUCCESS",
+					deployedAt: new Date("2026-01-02"),
+					backup: { backupData: state() },
+				},
+				{
+					templateId: "template-legacy",
+					backupId: "legacy",
+					status,
+					deployedAt: new Date("2026-01-01"),
+					backup: { backupData: legacyState() },
+				},
+			];
+			const prisma = {
+				templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+				trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+			};
+
+			await expect(
+				resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+					backupId: "target",
+					templateId: "template-1",
+				}),
+			).rejects.toThrow("legacy or invalid ownership metadata");
+		},
+	);
+
+	it("tags legacy ownership failures with the structured discriminator", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-legacy",
+				backupId: "legacy",
+				status: "FAILED",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: legacyState() },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toMatchObject({ details: { reason: UNVERIFIABLE_DEPLOYMENT_OWNERSHIP } });
+	});
+
+	it("does not tag a newer-deployment conflict with the discriminator", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-1",
+				backupId: "newer",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: state() },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toMatchObject({ details: undefined });
+	});
+
+	it("fails closed when a malformed non-v2 backup cannot be parsed", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: state() },
+			},
+			{
+				templateId: "template-legacy",
+				backupId: "legacy",
+				status: "FAILED",
+				deployedAt: new Date("2026-01-01"),
+				backup: { backupData: "not-json" },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("legacy or invalid ownership metadata");
+	});
+
+	it("fails closed when the target backup itself is legacy", async () => {
+		const rows = [
+			{
+				templateId: "template-1",
+				backupId: "target",
+				status: "SUCCESS",
+				deployedAt: new Date("2026-01-02"),
+				backup: { backupData: legacyState() },
+			},
+		];
+		const prisma = {
+			templateDeploymentHistory: { findMany: vi.fn().mockResolvedValue(rows) },
+			trashSyncHistory: { findMany: vi.fn().mockResolvedValue([]) },
+		};
+
+		await expect(
+			resolveActiveDeploymentOwnership(prisma as never, "user", ["instance"], {
+				backupId: "target",
+				templateId: "template-1",
+			}),
+		).rejects.toThrow("legacy or invalid ownership metadata");
 	});
 
 	it("does not restore shared naming after manual drift broke the ownership chain", async () => {

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-reversal-classification.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-reversal-classification.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, it, vi } from "vitest";
+import { classifyTargetReversal } from "../deployment-reversal-classification.js";
+import type { DeploymentBackupState } from "../deployment-backup-state.js";
+
+type CFMutation = DeploymentBackupState["customFormatDeployments"][number];
+
+function cfMutation(overrides: Partial<CFMutation> = {}): CFMutation {
+	return {
+		beforeFormat: null,
+		action: "created",
+		resourceId: null,
+		name: "CF",
+		status: "applied",
+		postStateToken: null,
+		intendedPostStateToken: null,
+		...overrides,
+	};
+}
+
+function baseState(overrides: Partial<DeploymentBackupState> = {}): DeploymentBackupState {
+	return {
+		schemaVersion: 2,
+		endpointKey: "endpoint",
+		connectionStateToken: "connection",
+		customFormats: [],
+		customFormatDeployments: [],
+		managedCustomFormats: [],
+		managedCustomFormatsCaptured: true,
+		qualityProfileDeployment: {
+			beforeProfile: null,
+			status: "not_started",
+			action: "created",
+			profileId: null,
+			profileName: "Profile",
+			postStateToken: null,
+			intendedPostStateToken: null,
+		},
+		namingDeployment: null,
+		...overrides,
+	};
+}
+
+function client(overrides: Record<string, unknown> = {}) {
+	return {
+		customFormat: {
+			getAll: vi.fn().mockResolvedValue([]),
+			getById: vi.fn().mockResolvedValue({}),
+		},
+		qualityProfile: {
+			getAll: vi.fn().mockResolvedValue([]),
+			getById: vi.fn().mockResolvedValue({}),
+		},
+		...overrides,
+	} as never;
+}
+
+function clientFactory(rawRequest = vi.fn()) {
+	return { rawRequest } as never;
+}
+
+describe("classifyTargetReversal", () => {
+	it("classifies a created CF as already_reversed when the exact resourceId is absent", async () => {
+		const state = baseState({
+			customFormatDeployments: [cfMutation({ resourceId: 123, postStateToken: "post" })],
+		});
+		const c = client({ customFormat: { getAll: vi.fn().mockResolvedValue([]), getById: vi.fn() } });
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("classifies a created CF as needs_write when the exact resourceId exists", async () => {
+		const state = baseState({
+			customFormatDeployments: [cfMutation({ resourceId: 123, postStateToken: "post" })],
+		});
+		const c = client({
+			customFormat: { getAll: vi.fn().mockResolvedValue([{ id: 123 }]), getById: vi.fn() },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("needs_write");
+	});
+
+	it("classifies a created CF read failure as unknown, not absence", async () => {
+		const state = baseState({
+			customFormatDeployments: [cfMutation({ resourceId: 123, postStateToken: "post" })],
+		});
+		const c = client({
+			customFormat: { getAll: vi.fn().mockRejectedValue(new Error("network")), getById: vi.fn() },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("unknown");
+	});
+
+	it("classifies a created CF with null resourceId as unknown", async () => {
+		const state = baseState({
+			customFormatDeployments: [cfMutation({ resourceId: null, postStateToken: null })],
+		});
+
+		await expect(
+			classifyTargetReversal(client(), clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("unknown");
+	});
+
+	it("classifies an updated CF as already_reversed when current state matches beforeFormat", async () => {
+		const before = { id: 7, name: "CF", specifications: [] };
+		const state = baseState({
+			customFormatDeployments: [
+				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+			],
+		});
+		const c = client({
+			customFormat: { getAll: vi.fn(), getById: vi.fn().mockResolvedValue(before) },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("classifies an updated CF as needs_write when current state differs from beforeFormat", async () => {
+		const before = { id: 7, name: "CF", specifications: [] };
+		const state = baseState({
+			customFormatDeployments: [
+				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+			],
+		});
+		const c = client({
+			customFormat: {
+				getAll: vi.fn(),
+				getById: vi.fn().mockResolvedValue({ id: 7, name: "CF", specifications: [{ name: "x" }] }),
+			},
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("needs_write");
+	});
+
+	it("classifies a created profile as already_reversed when the exact profileId is absent", async () => {
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "applied",
+				action: "created",
+				profileId: 4,
+				profileName: "Profile",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const c = client({
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]), getById: vi.fn() },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("classifies a created profile as needs_write when the exact profileId exists", async () => {
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "applied",
+				action: "created",
+				profileId: 4,
+				profileName: "Profile",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const c = client({
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([{ id: 4 }]), getById: vi.fn() },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("needs_write");
+	});
+
+	it("classifies a created profile read failure as unknown", async () => {
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "applied",
+				action: "created",
+				profileId: 4,
+				profileName: "Profile",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const c = client({
+			qualityProfile: { getAll: vi.fn().mockRejectedValue(new Error("network")), getById: vi.fn() },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("unknown");
+	});
+
+	it("classifies a created profile with null profileId as unknown", async () => {
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: null,
+				status: "applied",
+				action: "created",
+				profileId: null,
+				profileName: "Profile",
+				postStateToken: null,
+				intendedPostStateToken: null,
+			},
+		});
+
+		await expect(
+			classifyTargetReversal(client(), clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("unknown");
+	});
+
+	it("classifies an updated profile as already_reversed when current matches beforeProfile", async () => {
+		const before = { id: 4, name: "Profile", formatItems: [] };
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: before,
+				status: "applied",
+				action: "updated",
+				profileId: 4,
+				profileName: "Profile",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const c = client({
+			qualityProfile: { getAll: vi.fn(), getById: vi.fn().mockResolvedValue(before) },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("classifies an updated profile as needs_write when current differs from beforeProfile", async () => {
+		const before = { id: 4, name: "Profile", formatItems: [] };
+		const state = baseState({
+			qualityProfileDeployment: {
+				beforeProfile: before,
+				status: "applied",
+				action: "updated",
+				profileId: 4,
+				profileName: "Profile",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const c = client({
+			qualityProfile: {
+				getAll: vi.fn(),
+				getById: vi
+					.fn()
+					.mockResolvedValue({ id: 4, name: "Profile", formatItems: [{ format: 1, score: 1 }] }),
+			},
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("needs_write");
+	});
+
+	it("classifies naming as already_reversed when current matches beforeConfig", async () => {
+		const before = { renameMovies: false };
+		const state = baseState({
+			namingDeployment: {
+				beforeConfig: before,
+				status: "applied",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue(before),
+		});
+
+		await expect(
+			classifyTargetReversal(
+				client(),
+				clientFactory(rawRequest),
+				{ service: "RADARR" } as never,
+				state,
+			),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("classifies naming as needs_write when current differs from beforeConfig", async () => {
+		const before = { renameMovies: false };
+		const state = baseState({
+			namingDeployment: {
+				beforeConfig: before,
+				status: "applied",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const rawRequest = vi.fn().mockResolvedValue({
+			ok: true,
+			json: vi.fn().mockResolvedValue({ renameMovies: true }),
+		});
+
+		await expect(
+			classifyTargetReversal(
+				client(),
+				clientFactory(rawRequest),
+				{ service: "RADARR" } as never,
+				state,
+			),
+		).resolves.toBe("needs_write");
+	});
+
+	it("classifies naming read failure as unknown", async () => {
+		const state = baseState({
+			namingDeployment: {
+				beforeConfig: { renameMovies: false },
+				status: "applied",
+				postStateToken: "post",
+				intendedPostStateToken: null,
+			},
+		});
+		const rawRequest = vi.fn().mockRejectedValue(new Error("network"));
+
+		await expect(
+			classifyTargetReversal(
+				client(),
+				clientFactory(rawRequest),
+				{ service: "RADARR" } as never,
+				state,
+			),
+		).resolves.toBe("unknown");
+	});
+
+	it("authorizes no-write completion when all mutations are already reversed", async () => {
+		const before = { id: 7, name: "CF", specifications: [] };
+		const state = baseState({
+			customFormatDeployments: [
+				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+			],
+		});
+		const c = client({
+			customFormat: { getAll: vi.fn(), getById: vi.fn().mockResolvedValue(before) },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+
+	it("does not authorize no-write completion when one mutation needs a write", async () => {
+		const before = { id: 7, name: "CF", specifications: [] };
+		const state = baseState({
+			customFormatDeployments: [
+				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({ resourceId: 8, name: "CF2", postStateToken: "post" }),
+			],
+		});
+		const c = client({
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([{ id: 8 }]),
+				getById: vi.fn().mockResolvedValue(before),
+			},
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("needs_write");
+	});
+
+	it("does not authorize no-write completion when one mutation is unknown", async () => {
+		const before = { id: 7, name: "CF", specifications: [] };
+		const state = baseState({
+			customFormatDeployments: [
+				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({ resourceId: null, name: "CF2", postStateToken: null }),
+			],
+		});
+		const c = client({
+			customFormat: { getAll: vi.fn(), getById: vi.fn().mockResolvedValue(before) },
+		});
+
+		await expect(
+			classifyTargetReversal(c, clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("unknown");
+	});
+
+	it("classifies a ledger with no mutations as already_reversed", async () => {
+		const state = baseState();
+
+		await expect(
+			classifyTargetReversal(client(), clientFactory(), { service: "RADARR" } as never, state),
+		).resolves.toBe("already_reversed");
+	});
+});

--- a/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
+++ b/apps/api/src/lib/trash-guides/deployment-active-ownership.ts
@@ -18,6 +18,13 @@ const ACTIVE_STATUSES = new Set([
 	"RUNNING",
 ]);
 
+/**
+ * Structured discriminator for ownership failures caused by legacy or invalid
+ * backup metadata. Callers may attempt read-only target-local reconciliation
+ * only for this reason, never for other ownership conflicts.
+ */
+export const UNVERIFIABLE_DEPLOYMENT_OWNERSHIP = "UNVERIFIABLE_DEPLOYMENT_OWNERSHIP";
+
 interface OwnershipCandidate {
 	backupId: string;
 	templateId: string;
@@ -219,6 +226,7 @@ export async function resolveActiveDeploymentOwnership(
 			} catch {
 				throw new ConflictError(
 					"An unrolled deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+					{ reason: UNVERIFIABLE_DEPLOYMENT_OWNERSHIP },
 				);
 			}
 		}
@@ -272,6 +280,7 @@ export async function resolveActiveDeploymentOwnership(
 		if (!candidate.state) {
 			throw new ConflictError(
 				"Another active deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+				{ reason: UNVERIFIABLE_DEPLOYMENT_OWNERSHIP },
 			);
 		}
 		if (!candidate.state.managedCustomFormatsCaptured) {
@@ -363,6 +372,7 @@ export async function resolveActiveDeploymentOwnership(
 	if (!latestTarget.state) {
 		throw new ConflictError(
 			"The target deployment has legacy or invalid ownership metadata, so this operation was stopped.",
+			{ reason: UNVERIFIABLE_DEPLOYMENT_OWNERSHIP },
 		);
 	}
 	const targetCustomFormatIds = new Set([

--- a/apps/api/src/lib/trash-guides/deployment-backup-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-backup-state.ts
@@ -102,6 +102,40 @@ export function hasPendingDeploymentMutation(state: DeploymentBackupState): bool
 	);
 }
 
+/**
+ * Mirror the new-work gate's backup evaluation: does this backup, if still
+ * referenced by an unrolled history row, block assertNoPendingDeploymentOperation?
+ *
+ * - invalid JSON => blocks (invalid deployment ledger)
+ * - genuine pre-v2 legacy shape => no pending v2 ledger, does not block
+ * - schemaVersion 2 but unparseable => blocks (invalid deployment ledger)
+ * - valid schema-v2 with a pending mutation => blocks
+ */
+export function deploymentBackupBlocksNewWork(value: string): boolean {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(value);
+	} catch {
+		return true;
+	}
+	if (
+		typeof parsed !== "object" ||
+		parsed === null ||
+		Array.isArray(parsed) ||
+		!("schemaVersion" in parsed) ||
+		parsed.schemaVersion !== 2
+	) {
+		return false;
+	}
+	let state: DeploymentBackupState;
+	try {
+		state = parseDeploymentBackupState(value);
+	} catch {
+		return true;
+	}
+	return hasPendingDeploymentMutation(state);
+}
+
 /** Fail closed when cleanup cannot prove a current deployment ledger is terminal. */
 export function shouldRetainDeploymentBackup(value: string): boolean {
 	let parsed: unknown;

--- a/apps/api/src/lib/trash-guides/deployment-reversal-classification.ts
+++ b/apps/api/src/lib/trash-guides/deployment-reversal-classification.ts
@@ -1,0 +1,125 @@
+import type { RadarrClient, SonarrClient } from "arr-sdk";
+import type { ArrClientFactory } from "../arr/client-factory.js";
+import type { DeploymentBackupState } from "./deployment-backup-state.js";
+import {
+	createQualityProfileStateToken,
+	createUpstreamResourceStateToken,
+} from "./deployment-target.js";
+
+type ArrClient = SonarrClient | RadarrClient;
+
+export type ReversalClassification = "already_reversed" | "needs_write" | "unknown";
+
+/**
+ * Classify whether a single target mutation has already been reversed against
+ * live ARR state, without performing any write. This mirrors the "noop" branch
+ * of the rollback helpers so that a deployment whose every mutation is already
+ * reversed can be finalized without requiring competing-ownership authority.
+ *
+ * Any read failure (network, auth, unexpected shape) yields "unknown", never
+ * "already_reversed": absence of evidence is not evidence of absence.
+ */
+export async function classifyTargetReversal(
+	client: ArrClient,
+	clientFactory: ArrClientFactory,
+	instance: Parameters<ArrClientFactory["rawRequest"]>[0],
+	state: DeploymentBackupState,
+): Promise<ReversalClassification> {
+	const classifications: ReversalClassification[] = [];
+
+	for (const mutation of state.customFormatDeployments) {
+		if (mutation.resourceId === null) {
+			classifications.push("unknown");
+			continue;
+		}
+		if (mutation.action === "created") {
+			try {
+				const listed = await client.customFormat.getAll();
+				const present = listed.some((format) => format.id === mutation.resourceId);
+				classifications.push(present ? "needs_write" : "already_reversed");
+			} catch {
+				classifications.push("unknown");
+			}
+			continue;
+		}
+		if (!mutation.beforeFormat) {
+			classifications.push("unknown");
+			continue;
+		}
+		try {
+			const current = await client.customFormat.getById(mutation.resourceId);
+			classifications.push(
+				createUpstreamResourceStateToken(current) ===
+					createUpstreamResourceStateToken(mutation.beforeFormat)
+					? "already_reversed"
+					: "needs_write",
+			);
+		} catch {
+			classifications.push("unknown");
+		}
+	}
+
+	const profile = state.qualityProfileDeployment;
+	if (profile.status !== "not_started") {
+		if (profile.profileId === null) {
+			classifications.push("unknown");
+		} else if (profile.action === "created") {
+			try {
+				const profiles = await client.qualityProfile.getAll();
+				const present = profiles.some((item) => item.id === profile.profileId);
+				classifications.push(present ? "needs_write" : "already_reversed");
+			} catch {
+				classifications.push("unknown");
+			}
+		} else {
+			if (!profile.beforeProfile) {
+				classifications.push("unknown");
+			} else {
+				try {
+					const current = await client.qualityProfile.getById(profile.profileId);
+					classifications.push(
+						createQualityProfileStateToken(current) ===
+							createQualityProfileStateToken(profile.beforeProfile)
+							? "already_reversed"
+							: "needs_write",
+					);
+				} catch {
+					classifications.push("unknown");
+				}
+			}
+		}
+	}
+
+	const naming = state.namingDeployment;
+	if (naming && naming.status !== "not_started") {
+		try {
+			const currentResponse = await clientFactory.rawRequest(instance, "/api/v3/config/naming");
+			if (!currentResponse.ok) {
+				classifications.push("unknown");
+			} else {
+				const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
+				classifications.push(
+					createUpstreamResourceStateToken(currentConfig) ===
+						createUpstreamResourceStateToken(naming.beforeConfig)
+						? "already_reversed"
+						: "needs_write",
+				);
+			}
+		} catch {
+			classifications.push("unknown");
+		}
+	}
+
+	if (classifications.length === 0) {
+		// A valid schema-v2 deployment with no recorded mutation has nothing to
+		// reverse, so it is already reversed by definition.
+		return "already_reversed";
+	}
+	if (classifications.some((item) => item === "unknown")) {
+		return "unknown";
+	}
+	if (classifications.some((item) => item === "needs_write")) {
+		return "needs_write";
+	}
+	return "already_reversed";
+}

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
@@ -1264,7 +1264,7 @@ describe("deployment history delete", () => {
 	let app: FastifyInstance;
 	const historyFindFirst = vi.fn();
 	const historyDeleteMany = vi.fn();
-	const syncFindFirst = vi.fn();
+	const syncFindMany = vi.fn();
 	const backupFindFirst = vi.fn();
 
 	beforeEach(async () => {
@@ -1277,12 +1277,12 @@ describe("deployment history delete", () => {
 				findFirst: historyFindFirst,
 				deleteMany: historyDeleteMany,
 			},
-			trashSyncHistory: { findFirst: syncFindFirst },
+			trashSyncHistory: { findMany: syncFindMany },
 			trashBackup: { findFirst: backupFindFirst },
 		};
 		app.decorate("prisma", prisma as never);
 		historyDeleteMany.mockResolvedValue({ count: 1 });
-		syncFindFirst.mockResolvedValue(null);
+		syncFindMany.mockResolvedValue([]);
 		backupFindFirst.mockResolvedValue(null);
 		await app.register(deploymentHistoryRoutes);
 		await app.ready();
@@ -1308,9 +1308,44 @@ describe("deployment history delete", () => {
 		};
 	}
 
+	function syncRow(overrides: Record<string, unknown> = {}) {
+		return {
+			id: "sync-1",
+			status: "SUCCESS",
+			rollbackStatus: null,
+			...overrides,
+		};
+	}
+
 	it("rejects deleting an UNCERTAIN deployment with an unresolved paired sync", async () => {
 		historyFindFirst.mockResolvedValue(historyRow({ status: "UNCERTAIN" }));
-		syncFindFirst.mockResolvedValue({ id: "sync-1", status: "UNCERTAIN", rollbackStatus: null });
+		syncFindMany.mockResolvedValue([syncRow({ status: "UNCERTAIN" })]);
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting when a benign SUCCESS paired sync precedes an unresolved UNCERTAIN one", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "UNCERTAIN" }));
+		syncFindMany.mockResolvedValue([
+			syncRow({ id: "sync-a", status: "SUCCESS" }),
+			syncRow({ id: "sync-b", status: "UNCERTAIN" }),
+		]);
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting when a paired sync has rollbackStatus PARTIAL", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "SUCCESS" }));
+		syncFindMany.mockResolvedValue([
+			syncRow({ id: "sync-a", status: "SUCCESS" }),
+			syncRow({ id: "sync-b", status: "SUCCESS", rollbackStatus: "PARTIAL" }),
+		]);
 
 		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
 
@@ -1320,7 +1355,7 @@ describe("deployment history delete", () => {
 
 	it("rejects deleting a deployment whose schema-v2 backup has a pending mutation", async () => {
 		historyFindFirst.mockResolvedValue(historyRow({ status: "FAILED" }));
-		syncFindFirst.mockResolvedValue(null);
+		syncFindMany.mockResolvedValue([syncRow({ status: "SUCCESS" })]);
 		backupFindFirst.mockResolvedValue({
 			backupData: JSON.stringify({
 				schemaVersion: 2,
@@ -1356,6 +1391,43 @@ describe("deployment history delete", () => {
 		expect(historyDeleteMany).not.toHaveBeenCalled();
 	});
 
+	it("rejects deleting when a paired sync references a malformed schema-v2 ledger", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "FAILED" }));
+		syncFindMany.mockResolvedValue([syncRow({ status: "SUCCESS" })]);
+		backupFindFirst.mockResolvedValue({
+			backupData: JSON.stringify({ schemaVersion: 2, customFormatDeployments: [] }),
+		});
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting when a paired sync references invalid JSON backup", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "FAILED" }));
+		syncFindMany.mockResolvedValue([syncRow({ status: "SUCCESS" })]);
+		backupFindFirst.mockResolvedValue({ backupData: "{invalid" });
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("allows deleting when a paired sync references a genuine legacy non-v2 backup", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "SUCCESS" }));
+		syncFindMany.mockResolvedValue([syncRow({ status: "SUCCESS" })]);
+		backupFindFirst.mockResolvedValue({
+			backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+		});
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(200);
+		expect(historyDeleteMany).toHaveBeenCalled();
+	});
+
 	it("rejects deleting a deployment with undeployStatus PARTIAL", async () => {
 		historyFindFirst.mockResolvedValue(historyRow({ undeployStatus: "PARTIAL" }));
 
@@ -1376,7 +1448,7 @@ describe("deployment history delete", () => {
 
 	it("allows deleting a rolled-back deployment with a resolved paired sync", async () => {
 		historyFindFirst.mockResolvedValue(historyRow({ rolledBack: true }));
-		syncFindFirst.mockResolvedValue(null);
+		syncFindMany.mockResolvedValue([]);
 
 		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
 

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
@@ -90,8 +90,11 @@ describe("deployment history undeploy", () => {
 	const historyFindMany = vi.fn();
 	const historyUpdate = vi.fn();
 	const historyUpdateMany = vi.fn();
+	const historyDeleteMany = vi.fn();
 	const syncUpdateMany = vi.fn();
 	const syncFindMany = vi.fn();
+	const syncFindFirst = vi.fn();
+	const backupFindFirst = vi.fn();
 	const instanceFindFirst = vi.fn();
 	const instanceFindMany = vi.fn();
 	const deleteFormat = vi.fn();
@@ -126,8 +129,14 @@ describe("deployment history undeploy", () => {
 				findMany: historyFindMany,
 				update: historyUpdate,
 				updateMany: historyUpdateMany,
+				deleteMany: historyDeleteMany,
 			},
-			trashSyncHistory: { findMany: syncFindMany, updateMany: syncUpdateMany },
+			trashSyncHistory: {
+				findMany: syncFindMany,
+				findFirst: syncFindFirst,
+				updateMany: syncUpdateMany,
+			},
+			trashBackup: { findFirst: backupFindFirst },
 			serviceInstance: {
 				findFirst: instanceFindFirst,
 				findMany: instanceFindMany,
@@ -169,8 +178,11 @@ describe("deployment history undeploy", () => {
 		instanceFindFirst.mockResolvedValue(instance);
 		instanceFindMany.mockResolvedValue([instance]);
 		syncFindMany.mockResolvedValue([]);
+		syncFindFirst.mockResolvedValue(null);
+		backupFindFirst.mockResolvedValue(null);
 		historyUpdate.mockResolvedValue({});
 		historyUpdateMany.mockResolvedValue({ count: 1 });
+		historyDeleteMany.mockResolvedValue({ count: 1 });
 		syncUpdateMany.mockResolvedValue({ count: 1 });
 		await app.register(deploymentHistoryRoutes);
 		await app.ready();
@@ -262,8 +274,54 @@ describe("deployment history undeploy", () => {
 		expect(historyFindFirst).toHaveBeenCalledOnce();
 	});
 
-	it("releases the claim as retryable when ARR validation fails unexpectedly", async () => {
-		const history = currentHistory(backupData());
+	it("releases the undeploy claim back to null when ARR is unreachable", async () => {
+		const history = {
+			...currentHistory(backupData()),
+			undeployStatus: null,
+			undeployAttemptedAt: null,
+		};
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+		systemGet.mockRejectedValueOnce(new Error("ARR read failed"));
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(500);
+		expect(historyUpdateMany).toHaveBeenLastCalledWith({
+			where: {
+				id: "history-1",
+				userId,
+				rolledBack: false,
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: expect.any(Date),
+			},
+			data: {
+				status: "SUCCESS",
+				undeployStatus: null,
+				undeployAttemptedAt: null,
+				undeployProgress: null,
+			},
+		});
+		expect(deleteFormat).not.toHaveBeenCalled();
+	});
+
+	it("restores prior PARTIAL recovery state when a retry fails before mutation", async () => {
+		const priorAttemptedAt = new Date("2026-08-08T12:05:00.000Z");
+		const priorProgress = JSON.stringify([
+			{
+				key: "custom_format:7",
+				kind: "custom_format",
+				name: "Managed CF",
+				outcome: "restored",
+			},
+		]);
+		const history = {
+			...currentHistory(backupData()),
+			status: "PARTIAL_UNDEPLOY",
+			undeployStatus: "PARTIAL",
+			undeployAttemptedAt: priorAttemptedAt,
+			undeployProgress: priorProgress,
+		};
 		historyFindFirst.mockResolvedValue(history);
 		historyFindMany.mockResolvedValue([history]);
 		systemGet.mockRejectedValueOnce(new Error("ARR read failed"));
@@ -282,6 +340,38 @@ describe("deployment history undeploy", () => {
 			data: {
 				status: "PARTIAL_UNDEPLOY",
 				undeployStatus: "PARTIAL",
+				undeployAttemptedAt: priorAttemptedAt,
+				undeployProgress: priorProgress,
+			},
+		});
+		expect(deleteFormat).not.toHaveBeenCalled();
+	});
+
+	it("releases the undeploy claim when a legacy backup cannot be undeployed", async () => {
+		const history = {
+			...currentHistory(JSON.stringify({ customFormats: [], qualityProfile: null })),
+			undeployStatus: null,
+			undeployAttemptedAt: null,
+		};
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyUpdateMany).toHaveBeenLastCalledWith({
+			where: {
+				id: "history-1",
+				userId,
+				rolledBack: false,
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: expect.any(Date),
+			},
+			data: {
+				status: "SUCCESS",
+				undeployStatus: null,
+				undeployAttemptedAt: null,
+				undeployProgress: null,
 			},
 		});
 		expect(deleteFormat).not.toHaveBeenCalled();
@@ -1073,5 +1163,242 @@ describe("deployment history undeploy", () => {
 		expect(response.statusCode).toBe(409);
 		expect(response.json().message).toContain("newer deployment");
 		expect(deleteFormat).not.toHaveBeenCalled();
+	});
+
+	it("fails closed when a created CF still exists and a legacy competitor is unresolved", async () => {
+		const createdFormat = { id: 123, name: "Anime Dual Audio", specifications: [] };
+		const data = backupData({
+			customFormatDeployments: [
+				{
+					beforeFormat: null,
+					action: "created",
+					resourceId: 123,
+					name: "Anime Dual Audio",
+					status: "applied",
+					postStateToken: createUpstreamResourceStateToken(createdFormat),
+					intendedPostStateToken: null,
+				},
+			],
+		});
+		const history = currentHistory(data);
+		const legacy = {
+			...history,
+			id: "history-legacy",
+			templateId: "template-legacy",
+			backupId: "backup-legacy",
+			deployedAt: new Date("2025-12-31"),
+			backup: {
+				id: "backup-legacy",
+				backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+			},
+		};
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history, legacy]);
+		getAllFormats.mockResolvedValue([createdFormat]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json().message).toContain("legacy or invalid ownership metadata");
+		expect(deleteFormat).not.toHaveBeenCalled();
+	});
+
+	it("finalizes recovery when a created CF was already manually deleted", async () => {
+		const createdFormat = { id: 123, name: "Anime Dual Audio", specifications: [] };
+		const data = backupData({
+			customFormatDeployments: [
+				{
+					beforeFormat: null,
+					action: "created",
+					resourceId: 123,
+					name: "Anime Dual Audio",
+					status: "applied",
+					postStateToken: createUpstreamResourceStateToken(createdFormat),
+					intendedPostStateToken: null,
+				},
+			],
+		});
+		const history = currentHistory(data);
+		const legacy = {
+			...history,
+			id: "history-legacy",
+			templateId: "template-legacy",
+			backupId: "backup-legacy",
+			deployedAt: new Date("2025-12-31"),
+			backup: {
+				id: "backup-legacy",
+				backupData: JSON.stringify({ customFormats: [], qualityProfile: null }),
+			},
+		};
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history, legacy]);
+		getAllFormats.mockResolvedValue([]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(response.json().success).toBe(true);
+		expect(deleteFormat).not.toHaveBeenCalled();
+		expect(historyUpdate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "history-1" },
+				data: expect.objectContaining({
+					rolledBack: true,
+					undeployStatus: "COMPLETED",
+				}),
+			}),
+		);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { backupId: "backup-1", userId },
+				data: expect.objectContaining({
+					rolledBack: true,
+					rollbackStatus: "COMPLETED",
+				}),
+			}),
+		);
+	});
+});
+
+describe("deployment history delete", () => {
+	let app: FastifyInstance;
+	const historyFindFirst = vi.fn();
+	const historyDeleteMany = vi.fn();
+	const syncFindFirst = vi.fn();
+	const backupFindFirst = vi.fn();
+
+	beforeEach(async () => {
+		vi.resetAllMocks();
+		app = Fastify({ logger: false });
+		setupAuthInjection(app, { id: userId, username: "admin" });
+		registerTestErrorHandler(app);
+		const prisma = {
+			templateDeploymentHistory: {
+				findFirst: historyFindFirst,
+				deleteMany: historyDeleteMany,
+			},
+			trashSyncHistory: { findFirst: syncFindFirst },
+			trashBackup: { findFirst: backupFindFirst },
+		};
+		app.decorate("prisma", prisma as never);
+		historyDeleteMany.mockResolvedValue({ count: 1 });
+		syncFindFirst.mockResolvedValue(null);
+		backupFindFirst.mockResolvedValue(null);
+		await app.register(deploymentHistoryRoutes);
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		await app.close();
+		vi.clearAllMocks();
+	});
+
+	function historyRow(overrides: Record<string, unknown> = {}) {
+		return {
+			id: "history-1",
+			templateId: "template-1",
+			instanceId: "instance-1",
+			userId,
+			status: "SUCCESS",
+			rolledBack: false,
+			undeployStatus: null,
+			backupId: "backup-1",
+			template: { userId },
+			...overrides,
+		};
+	}
+
+	it("rejects deleting an UNCERTAIN deployment with an unresolved paired sync", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "UNCERTAIN" }));
+		syncFindFirst.mockResolvedValue({ id: "sync-1", status: "UNCERTAIN", rollbackStatus: null });
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting a deployment whose schema-v2 backup has a pending mutation", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "FAILED" }));
+		syncFindFirst.mockResolvedValue(null);
+		backupFindFirst.mockResolvedValue({
+			backupData: JSON.stringify({
+				schemaVersion: 2,
+				endpointKey: "endpoint",
+				connectionStateToken: "connection",
+				customFormats: [],
+				customFormatDeployments: [
+					{
+						beforeFormat: null,
+						action: "created",
+						resourceId: null,
+						name: "CF",
+						status: "pending",
+						postStateToken: null,
+					},
+				],
+				managedCustomFormats: [],
+				managedCustomFormatsCaptured: false,
+				qualityProfileDeployment: {
+					beforeProfile: null,
+					status: "not_started",
+					action: "created",
+					profileId: null,
+					postStateToken: null,
+				},
+				namingDeployment: null,
+			}),
+		});
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting a deployment with undeployStatus PARTIAL", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ undeployStatus: "PARTIAL" }));
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rejects deleting a deployment with status PARTIAL_UNDEPLOY", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "PARTIAL_UNDEPLOY" }));
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(409);
+		expect(historyDeleteMany).not.toHaveBeenCalled();
+	});
+
+	it("allows deleting a rolled-back deployment with a resolved paired sync", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ rolledBack: true }));
+		syncFindFirst.mockResolvedValue(null);
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(200);
+		expect(historyDeleteMany).toHaveBeenCalled();
+	});
+
+	it("allows deleting a deployment with undeployStatus COMPLETED", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ undeployStatus: "COMPLETED" }));
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(200);
+		expect(historyDeleteMany).toHaveBeenCalled();
+	});
+
+	it("allows deleting an ordinary terminal audit row that cannot block new work", async () => {
+		historyFindFirst.mockResolvedValue(historyRow({ status: "SUCCESS", backupId: null }));
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode).toBe(200);
+		expect(historyDeleteMany).toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
@@ -112,6 +112,8 @@ describe("sync rollback route", () => {
 			instance,
 			template: { id: "template-1", userId },
 			backup: { id: "backup-1", backupData },
+			rollbackStatus: null,
+			rollbackAttemptedAt: null,
 			rollbackProgress: null,
 		};
 		syncRecord = sync;
@@ -292,7 +294,52 @@ describe("sync rollback route", () => {
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: expect.any(Date),
 			},
-			data: expect.objectContaining({ rollbackStatus: "PARTIAL" }),
+			data: {
+				rollbackStatus: null,
+				rollbackAttemptedAt: null,
+				rollbackProgress: null,
+			},
+		});
+	});
+
+	it("restores prior PARTIAL rollback state when a retry fails before mutation", async () => {
+		const priorAttemptedAt = new Date("2026-08-08T12:05:00.000Z");
+		const priorProgress = JSON.stringify([
+			{
+				key: "custom_format:7",
+				kind: "custom_format",
+				name: "Updated CF",
+				outcome: "restored",
+			},
+		]);
+		syncRecord = {
+			...syncRecord,
+			rollbackStatus: "PARTIAL",
+			rollbackAttemptedAt: priorAttemptedAt,
+			rollbackProgress: priorProgress,
+			appliedConfigs: "not-json",
+		};
+		syncFindFirst.mockResolvedValue(syncRecord);
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(500);
+		expect(profileUpdate).not.toHaveBeenCalled();
+		expect(formatUpdate).not.toHaveBeenCalled();
+		expect(formatDelete).not.toHaveBeenCalled();
+		expect(syncUpdate).toHaveBeenLastCalledWith({
+			where: {
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+				rollbackAttemptedAt: expect.any(Date),
+			},
+			data: {
+				rollbackStatus: "PARTIAL",
+				rollbackAttemptedAt: priorAttemptedAt,
+				rollbackProgress: priorProgress,
+			},
 		});
 	});
 

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -19,7 +19,7 @@ import {
 } from "../../lib/trash-guides/deployment-active-ownership.js";
 import {
 	type DeploymentBackupState,
-	hasPendingDeploymentMutation,
+	deploymentBackupBlocksNewWork,
 	parseDeploymentBackupState,
 } from "../../lib/trash-guides/deployment-backup-state.js";
 import { rollbackCustomFormatDeployment } from "../../lib/trash-guides/deployment-custom-format-state.js";
@@ -387,8 +387,8 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 		// schema-v2 pending ledger) still requires recovery would leave an invisible
 		// assertNoPendingDeploymentOperation blocker with no supported way to resolve it.
 		if (history.backupId) {
-			const [pairedSync, backup] = await Promise.all([
-				app.prisma.trashSyncHistory.findFirst({
+			const [pairedSyncs, backup] = await Promise.all([
+				app.prisma.trashSyncHistory.findMany({
 					where: { backupId: history.backupId, userId, rolledBack: false },
 					select: { id: true, status: true, rollbackStatus: true },
 				}),
@@ -397,24 +397,22 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 					select: { backupData: true },
 				}),
 			]);
-			const pairedSyncUnresolved =
-				pairedSync !== null &&
-				(pairedSync.status === "UNCERTAIN" ||
-					pairedSync.status === "IN_PROGRESS" ||
-					pairedSync.status === "RUNNING" ||
-					pairedSync.rollbackStatus === "IN_PROGRESS" ||
-					pairedSync.rollbackStatus === "PARTIAL");
-			let pendingLedger = false;
-			if (backup) {
-				try {
-					const state = parseDeploymentBackupState(backup.backupData);
-					pendingLedger = hasPendingDeploymentMutation(state);
-				} catch {
-					// A legacy or malformed backup cannot prove a pending ledger; the
-					// paired-sync check above remains the authoritative blocker.
-				}
-			}
-			if (pairedSyncUnresolved || pendingLedger) {
+			const pairedSyncUnresolved = pairedSyncs.some(
+				(sync) =>
+					sync.status === "UNCERTAIN" ||
+					sync.status === "IN_PROGRESS" ||
+					sync.status === "RUNNING" ||
+					sync.rollbackStatus === "IN_PROGRESS" ||
+					sync.rollbackStatus === "PARTIAL",
+			);
+			// If any unrolled paired sync row will remain after this deletion, its
+			// backup must not independently block new work. Mirror the new-work gate:
+			// invalid JSON, malformed schema-v2, and pending v2 mutations all block.
+			const backupBlocksNewWork =
+				pairedSyncs.length > 0 &&
+				backup !== null &&
+				deploymentBackupBlocksNewWork(backup.backupData);
+			if (pairedSyncUnresolved || backupBlocksNewWork) {
 				return reply.status(409).send({
 					statusCode: 409,
 					error: "Conflict",

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -14,14 +14,18 @@ import {
 	assertSharedDeploymentState,
 	getExpectedSharedDeploymentStateToken,
 	resolveActiveDeploymentOwnership,
+	UNVERIFIABLE_DEPLOYMENT_OWNERSHIP,
+	type ActiveDeploymentOwnership,
 } from "../../lib/trash-guides/deployment-active-ownership.js";
 import {
 	type DeploymentBackupState,
+	hasPendingDeploymentMutation,
 	parseDeploymentBackupState,
 } from "../../lib/trash-guides/deployment-backup-state.js";
 import { rollbackCustomFormatDeployment } from "../../lib/trash-guides/deployment-custom-format-state.js";
 import { restoreNamingDeployment } from "../../lib/trash-guides/deployment-naming-state.js";
 import { rollbackQualityProfileDeployment } from "../../lib/trash-guides/deployment-profile-state.js";
+import { classifyTargetReversal } from "../../lib/trash-guides/deployment-reversal-classification.js";
 import {
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
@@ -378,6 +382,48 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 			});
 		}
 
+		// A deployment that still blocks new work must not lose its recovery handle.
+		// Deleting only TemplateDeploymentHistory while a paired TrashSyncHistory (or a
+		// schema-v2 pending ledger) still requires recovery would leave an invisible
+		// assertNoPendingDeploymentOperation blocker with no supported way to resolve it.
+		if (history.backupId) {
+			const [pairedSync, backup] = await Promise.all([
+				app.prisma.trashSyncHistory.findFirst({
+					where: { backupId: history.backupId, userId, rolledBack: false },
+					select: { id: true, status: true, rollbackStatus: true },
+				}),
+				app.prisma.trashBackup.findFirst({
+					where: { id: history.backupId, userId },
+					select: { backupData: true },
+				}),
+			]);
+			const pairedSyncUnresolved =
+				pairedSync !== null &&
+				(pairedSync.status === "UNCERTAIN" ||
+					pairedSync.status === "IN_PROGRESS" ||
+					pairedSync.status === "RUNNING" ||
+					pairedSync.rollbackStatus === "IN_PROGRESS" ||
+					pairedSync.rollbackStatus === "PARTIAL");
+			let pendingLedger = false;
+			if (backup) {
+				try {
+					const state = parseDeploymentBackupState(backup.backupData);
+					pendingLedger = hasPendingDeploymentMutation(state);
+				} catch {
+					// A legacy or malformed backup cannot prove a pending ledger; the
+					// paired-sync check above remains the authoritative blocker.
+				}
+			}
+			if (pairedSyncUnresolved || pendingLedger) {
+				return reply.status(409).send({
+					statusCode: 409,
+					error: "Conflict",
+					message:
+						"This deployment still requires recovery. Complete or explicitly resolve it before deleting its deployment history.",
+				});
+			}
+		}
+
 		// Delete only if ownership and terminal undeploy state still match at mutation time.
 		// Note: Associated backup will be cascade deleted if configured, otherwise it remains.
 		const deletion = await app.prisma.templateDeploymentHistory.deleteMany({
@@ -468,6 +514,10 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 			});
 		}
 
+		const priorUndeployStatus = history.undeployStatus;
+		const priorUndeployAttemptedAt = history.undeployAttemptedAt;
+		const priorUndeployProgress = history.undeployProgress;
+		const priorStatus = history.status;
 		const undeployAttemptedAt = new Date();
 		const claim = await app.prisma.templateDeploymentHistory.updateMany({
 			where: {
@@ -507,8 +557,31 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 				throw new Error("Undeploy recovery state changed before progress could be persisted");
 			}
 		};
+		// Release this request's claim back to the exact recovery state that existed
+		// before the claim. The compare-and-set guard ensures a stale request cannot
+		// release a newer claim that another process has since taken over.
+		const releaseUndeployClaim = async () => {
+			const result = await app.prisma.templateDeploymentHistory.updateMany({
+				where: {
+					id: historyId,
+					userId,
+					rolledBack: false,
+					undeployStatus: "IN_PROGRESS",
+					undeployAttemptedAt,
+				},
+				data: {
+					status: priorStatus,
+					undeployStatus: priorUndeployStatus,
+					undeployAttemptedAt: priorUndeployAttemptedAt,
+					undeployProgress: priorUndeployProgress,
+				},
+			});
+			if (result.count !== 1) {
+				throw new Error("Undeploy recovery state changed before the claim could be released");
+			}
+		};
 		const stopClaimedUndeploy = async (statusCode: number, payload: Record<string, unknown>) => {
-			await persistPartialUndeploy();
+			await releaseUndeployClaim();
 			return reply.status(statusCode).send(payload);
 		};
 		let upstreamMutationAttempted = false;
@@ -602,6 +675,11 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 						});
 					}
 
+					const client = app.arrClientFactory.create(currentInstance) as
+						| SonarrClient
+						| RadarrClient;
+					await client.system.get();
+
 					const aliases = await app.prisma.serviceInstance.findMany({
 						where: { userId, service: currentInstance.service },
 					});
@@ -614,17 +692,55 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 						})),
 						{ ...currentInstance, credentialIdentity },
 					);
-					const ownership = await resolveActiveDeploymentOwnership(
-						app.prisma,
-						userId,
-						equivalentInstanceIds,
-						{ backupId: deploymentBackup.id, templateId: history.templateId },
-					);
+					let ownership: ActiveDeploymentOwnership | null;
+					try {
+						ownership = await resolveActiveDeploymentOwnership(
+							app.prisma,
+							userId,
+							equivalentInstanceIds,
+							{ backupId: deploymentBackup.id, templateId: history.templateId },
+						);
+					} catch (error) {
+						// Competing ownership could not be resolved because an unrolled
+						// history carries legacy or invalid ownership metadata. If every
+						// mutation owned by THIS deployment is already reversed on the live
+						// ARR endpoint, no upstream write remains, so competing ownership is
+						// not required to authorize anything. Other ownership conflicts (e.g.
+						// a newer deployment) still fail closed.
+						const reason =
+							error && typeof error === "object" && "details" in error
+								? (error as { details?: { reason?: string } }).details?.reason
+								: undefined;
+						if (reason !== UNVERIFIABLE_DEPLOYMENT_OWNERSHIP) {
+							throw error;
+						}
+						const targetReversal = await classifyTargetReversal(
+							client,
+							app.arrClientFactory,
+							currentInstance,
+							backupState,
+						);
+						if (targetReversal !== "already_reversed") {
+							throw error;
+						}
+						ownership = null;
+					}
+					// When every target mutation is already reversed, no write is required,
+					// so competing ownership is not consulted. The empty ownership view keeps
+					// the per-resource loops on their no-op path (no shared resources, no
+					// writes) while still recording durable "already_reversed" steps.
+					const ownershipView: ActiveDeploymentOwnership = ownership ?? {
+						sharedCustomFormatIds: new Set(),
+						sharedQualityProfileIds: new Set(),
+						namingOwnedByAnotherDeployment: false,
+						restorableSharedCustomFormatIds: new Set(),
+						restorableSharedQualityProfileIds: new Set(),
+						sharedNamingRestorationAllowed: false,
+						sharedCustomFormatStateTokens: new Map(),
+						sharedQualityProfileStateTokens: new Map(),
+						sharedNamingStateTokens: new Set(),
+					};
 
-					const client = app.arrClientFactory.create(currentInstance) as
-						| SonarrClient
-						| RadarrClient;
-					await client.system.get();
 					let existingProgress: UndeployStep[];
 					try {
 						existingProgress = parseUndeployProgress(history.undeployProgress);
@@ -685,7 +801,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 						if (!isFinished(key)) {
 							if (
 								profileState.profileId !== null &&
-								ownership.sharedQualityProfileIds.has(profileState.profileId)
+								ownershipView.sharedQualityProfileIds.has(profileState.profileId)
 							) {
 								try {
 									const currentProfile = await client.qualityProfile.getById(
@@ -693,7 +809,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 									);
 									const resourceLabel = `quality profile "${profileState.profileName ?? profileState.profileId}"`;
 									const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-										ownership.sharedQualityProfileStateTokens.get(profileState.profileId),
+										ownershipView.sharedQualityProfileStateTokens.get(profileState.profileId),
 										resourceLabel,
 									);
 									if (createQualityProfileStateToken(currentProfile) === expectedSurvivorToken) {
@@ -705,7 +821,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 										});
 									} else {
 										assertSharedDeploymentRestorationAllowed(
-											ownership.restorableSharedQualityProfileIds.has(profileState.profileId),
+											ownershipView.restorableSharedQualityProfileIds.has(profileState.profileId),
 											resourceLabel,
 										);
 										if (profileState.action === "created") {
@@ -786,13 +902,13 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 						if (isFinished(key)) continue;
 						if (
 							state.resourceId !== null &&
-							ownership.sharedCustomFormatIds.has(state.resourceId)
+							ownershipView.sharedCustomFormatIds.has(state.resourceId)
 						) {
 							try {
 								const currentFormat = await client.customFormat.getById(state.resourceId);
 								const resourceLabel = `Custom Format "${state.name}"`;
 								const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-									ownership.sharedCustomFormatStateTokens.get(state.resourceId),
+									ownershipView.sharedCustomFormatStateTokens.get(state.resourceId),
 									resourceLabel,
 								);
 								if (createUpstreamResourceStateToken(currentFormat) === expectedSurvivorToken) {
@@ -804,7 +920,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 									});
 								} else {
 									assertSharedDeploymentRestorationAllowed(
-										ownership.restorableSharedCustomFormatIds.has(state.resourceId),
+										ownershipView.restorableSharedCustomFormatIds.has(state.resourceId),
 										resourceLabel,
 									);
 									if (state.action === "created") {
@@ -877,7 +993,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 							namingState.postStateToken ??
 							(namingState.status === "pending" ? namingState.intendedPostStateToken : null);
 						if (!isFinished(key)) {
-							if (ownership.namingOwnedByAnotherDeployment) {
+							if (ownershipView.namingOwnedByAnotherDeployment) {
 								try {
 									const currentResponse = await app.arrClientFactory.rawRequest(
 										currentInstance,
@@ -888,7 +1004,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 									}
 									const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
 									const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-										ownership.sharedNamingStateTokens,
+										ownershipView.sharedNamingStateTokens,
 										"naming configuration",
 									);
 									if (createUpstreamResourceStateToken(currentConfig) === expectedSurvivorToken) {
@@ -900,7 +1016,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 										});
 									} else {
 										assertSharedDeploymentRestorationAllowed(
-											ownership.sharedNamingRestorationAllowed,
+											ownershipView.sharedNamingRestorationAllowed,
 											"naming configuration",
 										);
 										if (!rollbackNamingStateToken) {
@@ -1064,7 +1180,11 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 		).catch(async (error) => {
 			const message = getErrorMessage(error, "Undeploy failed");
 			try {
-				await persistPartialUndeploy();
+				if (upstreamMutationAttempted) {
+					await persistPartialUndeploy();
+				} else {
+					await releaseUndeployClaim();
+				}
 			} catch (stateError) {
 				request.log.error(
 					{ err: stateError, historyId, undeployAttemptedAt },

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -639,6 +639,9 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 			});
 		}
 
+		const priorRollbackStatus = sync.rollbackStatus;
+		const priorRollbackAttemptedAt = sync.rollbackAttemptedAt;
+		const priorRollbackProgress = sync.rollbackProgress;
 		const rollbackAttemptedAt = new Date();
 		const claim = await app.prisma.trashSyncHistory.updateMany({
 			where: {
@@ -677,13 +680,36 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 				throw new Error("Rollback recovery state changed before progress could be persisted");
 			}
 		};
+		// Release this request's claim back to the exact recovery state that existed
+		// before the claim. The compare-and-set guard ensures a stale request cannot
+		// release a newer claim that another process has since taken over.
+		const releaseRollbackClaim = async () => {
+			const result = await app.prisma.trashSyncHistory.updateMany({
+				where: {
+					id: syncId,
+					userId,
+					rolledBack: false,
+					rollbackStatus: "IN_PROGRESS",
+					rollbackAttemptedAt,
+				},
+				data: {
+					rollbackStatus: priorRollbackStatus,
+					rollbackAttemptedAt: priorRollbackAttemptedAt,
+					rollbackProgress: priorRollbackProgress,
+				},
+			});
+			if (result.count !== 1) {
+				throw new Error("Rollback recovery state changed before the claim could be released");
+			}
+		};
 		const stopClaimedRollback = async (
 			statusCode: number,
 			payload: { error: string; message: string },
 		) => {
-			await persistPartialRollback();
+			await releaseRollbackClaim();
 			return reply.status(statusCode).send(payload);
 		};
+		let upstreamMutationAttempted = false;
 
 		// Start metrics tracking
 		const metrics = getSyncMetrics();
@@ -1038,6 +1064,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 												`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
 											);
 										}
+										upstreamMutationAttempted = true;
 										await rollbackQualityProfileDeployment(client, backupQualityProfileDeployment);
 										const restoredProfile = await client.qualityProfile.getById(
 											backupQualityProfileDeployment.profileId,
@@ -1071,6 +1098,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 								!isFinished(profileStepKey, "quality_profile", profileStepName)
 							) {
 								try {
+									upstreamMutationAttempted = true;
 									await rollbackQualityProfileDeployment(client, backupQualityProfileDeployment);
 									request.log.info(
 										{
@@ -1149,6 +1177,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 													`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
 												);
 											}
+											upstreamMutationAttempted = true;
 											await rollbackCustomFormatDeployment(client, state);
 											const restoredFormat = await client.customFormat.getById(state.resourceId);
 											assertSharedDeploymentState(
@@ -1177,6 +1206,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 									continue;
 								}
 								try {
+									upstreamMutationAttempted = true;
 									const result = await rollbackCustomFormatDeployment(client, state);
 									if (result === "restored") {
 										setStep({
@@ -1245,6 +1275,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 											ownership.sharedNamingRestorationAllowed,
 											"naming configuration",
 										);
+										upstreamMutationAttempted = true;
 										await restoreNamingDeployment(
 											app.arrClientFactory,
 											currentInstance,
@@ -1289,6 +1320,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 								!isFinished("naming:configuration", "naming", "Naming configuration")
 							) {
 								try {
+									upstreamMutationAttempted = true;
 									await restoreNamingDeployment(
 										app.arrClientFactory,
 										currentInstance,
@@ -1400,7 +1432,11 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 			// Specialized catch: records failure metrics before propagating
 			const errorMessage = getErrorMessage(error, "Rollback failed");
 			try {
-				await persistPartialRollback();
+				if (upstreamMutationAttempted) {
+					await persistPartialRollback();
+				} else {
+					await releaseRollbackClaim();
+				}
 			} catch (stateError) {
 				request.log.error(
 					{ err: stateError, syncId, rollbackAttemptedAt },
@@ -1418,7 +1454,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 				typeof error.statusCode === "number"
 					? error.statusCode
 					: 500;
-			return reply.status(statusCode).send({
+			return reply.status(upstreamMutationAttempted ? 207 : statusCode).send({
 				error: "ROLLBACK_FAILED",
 				message: errorMessage,
 			});


### PR DESCRIPTION
## Summary

Fixes the interrupted-deployment recovery deadlock reported in #774.

A TRaSH deployment can legitimately enter an uncertain state when ARR may have changed but the post-write result cannot be fully proven. The recovery system should remain fail-closed, but it must also preserve a legitimate operator recovery path.

This patch fixes three recovery-state defects:

1. undeploy or rollback failures that occurred before any ARR mutation were incorrectly recorded as partial recovery;
2. deployment-history deletion could remove the visible recovery handle while one or more paired `TrashSyncHistory` rows still blocked future work;
3. a current schema-v2 deployment could not complete local recovery after all of its exact mutations had already been manually reversed, because unrelated legacy ownership prevented the route from proving that no ARR write remained.

## Safety model

The core invariant remains unchanged:

> Unknown ownership does not authorize an ARR write.

Legacy deployment backups contain only a before-snapshot and cannot prove which live ARR resources they still own. Unrolled legacy histories therefore remain fail-closed, including `SUCCESS`, `PARTIAL_SUCCESS`, and `FAILED` rows whose ownership cannot be reconstructed.

Malformed current-format ownership evidence also remains fail-closed.

## Changes

### Preserve pre-mutation recovery state

Undeploy and sync rollback now restore the exact state held before the current attempt when a failure occurs before a new upstream mutation:

```text
null -> IN_PROGRESS -> pre-write failure -> null
PARTIAL -> IN_PROGRESS -> pre-write failure -> PARTIAL
```

Prior progress and attempt evidence are retained. Claim release uses compare-and-swap conditions tied to the current attempt so a stale request cannot release a newer claim.

Once an upstream mutation has actually been attempted, failures continue to remain `PARTIAL`.

### Read-only already-reversed reconciliation

When ownership resolution fails specifically because legacy or invalid metadata makes competing ownership unverifiable, the route may perform a read-only check of the target deployment's own schema-v2 ledger.

The fallback is selected using the structured reason `UNVERIFIABLE_DEPLOYMENT_OWNERSHIP`, not human-readable error text.

It verifies exact target state, including:

- a created Custom Format is absent by exact ARR ID;
- an updated Custom Format matches its recorded before-state token;
- a created quality profile is absent by exact ID;
- an updated profile matches its recorded before-state;
- naming matches its recorded before-state.

Read, network, authentication, or unexpected-shape failures are classified as unknown. If any target mutation still needs a write—or cannot be proven—legacy ownership continues to block recovery.

If every target mutation is already reversed, no ARR write is authorized or attempted, and the paired local recovery records can safely be finalized.

### Keep paired history coherent

`TemplateDeploymentHistory` and every paired `TrashSyncHistory` sharing the same backup represent one deployment attempt. Successful no-write reconciliation finalizes the paired records coherently as rolled back/completed.

### Preserve the visible recovery handle on delete

Deployment-history deletion now evaluates all unrolled paired sync rows rather than one arbitrary row. Deletion is rejected when any paired history is unresolved or when a remaining paired history references backup evidence that would continue to block new work, including:

- `UNCERTAIN`, `IN_PROGRESS`, or `RUNNING` paired history;
- rollback `IN_PROGRESS` or `PARTIAL`;
- invalid JSON backup data;
- malformed schema-v2 deployment state;
- a valid schema-v2 ledger containing pending mutations;
- unfinished undeploy state.

Genuine pre-v2 backups retain the existing distinction that they contain no schema-v2 pending ledger. The delete route never deletes or rewrites paired sync rows merely to make deletion succeed.

Recovered terminal history remains deletable.

## Reporter recovery flow

The reported topology is covered directly:

1. a schema-v2 deployment creates a Custom Format and becomes uncertain;
2. older unverifiable legacy ownership exists on the endpoint;
3. undeploy fails closed while the created resource still exists;
4. the current claim returns to its prior state instead of becoming falsely partial;
5. deployment history cannot be deleted while paired recovery remains unresolved;
6. after the operator manually reverses the exact target resource, retry performs read-only verification;
7. no ARR write is made;
8. paired recovery histories become terminal;
9. terminal history can be deleted and the target recovery no longer blocks future deployment.

## Regression coverage

Coverage includes:

- legacy `SUCCESS`, `PARTIAL_SUCCESS`, and `FAILED` ownership remains fail-closed;
- target legacy and malformed ownership remain blocked;
- undeploy and rollback claim restoration from both null and partial states;
- stale-claim compare-and-swap protection;
- post-write failures remain partial;
- exact CF, profile, and naming reversal classification;
- unknown read failures fail closed;
- structured ownership fallback selection;
- multiple paired sync rows sharing one backup;
- unresolved paired history and partial rollback deletion rejection;
- invalid JSON, malformed schema-v2, and pending-ledger deletion rejection;
- genuine legacy backup distinction;
- paired-history terminalization and terminal deletion.

## Final validation

- Focused #774 tests: **97 passed**
- Related recovery tests: **128 passed / 2 skipped**
- Full TRaSH Guides suites: **761 passed / 20 skipped / 0 failed**
- Real-DB deployment-state persistence contract: **PASS**
- Full repository suite: **4099 passed / 50 skipped / 0 failed**
- Shared build: **PASS**
- Lint: **PASS**
- Typecheck: **PASS**
- Knip: completed; findings were pre-existing and unrelated to this PR
- Provider-cache heap regression: **PASS**
- Production build: **PASS**
- `git diff --check`: **PASS**
- Existing real-service integration suite: **92 passed / 8 skipped / 4 unrelated environment-fixture failures**
- Existing TRaSH Guides real-service integration spec: **6/6 passed**
- Targeted #774 browser/integration verification: **6/6 passed**, covering unresolved paired-recovery deletion rejection, recovery-evidence preservation, successful terminal deletion after resolution, and paired-sync preservation
- GitHub current-head checks: **CI, all three E2E shards, Docker Build, CodeQL, Semgrep, and Docker Smoke all passed**

### Environment notes

- A Windows CRLF checkout artifact affected exact-newline string matching locally; LF-normalized execution and Linux CI passed.
- The four broader integration-suite failures were unrelated fixture/environment conditions: missing seeded ARR indexer/download-client state, a Lidarr poster CSP case, and Seerr requester bootstrap returning 403.
- `prisma generate` exposed pre-existing generated-client staleness; generated tracked files were restored, and this PR contains no generated-file changes.

## Scope note

This fixes the recovery deadlock reported in #774. It does not establish that the reporter's `Anime Dual Audio` Custom Format caused the original Radarr 6.3 deployment interruption; that hypothesis remains unconfirmed and should be investigated separately if it reproduces.

Closes #774.