### PR TITLE
style: restore stable formatting baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Build shared package
         run: pnpm --filter @arr/shared run build
 
+      - name: Check formatting
+        run: pnpm run format
+
       - name: Run linting
         run: pnpm run lint
 

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -784,7 +784,9 @@ describe("collectPlexCacheLiveEvidence", () => {
 				getLibrarySections: vi.fn().mockResolvedValue(mixedSections),
 				getLibraryItems: vi
 					.fn()
-					.mockImplementation((key: string) => (key === "1" ? [supportedMovie] : [personalMediaItem])),
+					.mockImplementation((key: string) =>
+						key === "1" ? [supportedMovie] : [personalMediaItem],
+					),
 				getHistory: vi.fn().mockResolvedValue([]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
@@ -808,10 +810,14 @@ describe("collectPlexCacheLiveEvidence", () => {
 				getLibrarySections: vi.fn().mockResolvedValue(mixedSections),
 				getLibraryItems: vi
 					.fn()
-					.mockImplementation((key: string) => (key === "1" ? [supportedMovie] : [personalMediaItem])),
-				getHistory: vi.fn().mockResolvedValue([
-					{ type: "movie", ratingKey: "personal-1", accountID: 1, viewedAt: 1_700_000_000 },
-				]),
+					.mockImplementation((key: string) =>
+						key === "1" ? [supportedMovie] : [personalMediaItem],
+					),
+				getHistory: vi
+					.fn()
+					.mockResolvedValue([
+						{ type: "movie", ratingKey: "personal-1", accountID: 1, viewedAt: 1_700_000_000 },
+					]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
 			} as unknown as PlexClient;
@@ -827,12 +833,16 @@ describe("collectPlexCacheLiveEvidence", () => {
 		it("still fails closed when a supported movie lacks TMDB metadata", async () => {
 			const mockClient = {
 				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
-				getLibrarySections: vi.fn().mockResolvedValue([
-					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
-				]),
-				getLibraryItems: vi.fn().mockResolvedValue([
-					{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
-				]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([
+						{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+					]),
+				getLibraryItems: vi
+					.fn()
+					.mockResolvedValue([
+						{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
+					]),
 				getHistory: vi.fn().mockResolvedValue([]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
@@ -850,15 +860,21 @@ describe("collectPlexCacheLiveEvidence", () => {
 		it("still fails closed when supported history cannot map to TMDB metadata", async () => {
 			const mockClient = {
 				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
-				getLibrarySections: vi.fn().mockResolvedValue([
-					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
-				]),
-				getLibraryItems: vi.fn().mockResolvedValue([
-					{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
-				]),
-				getHistory: vi.fn().mockResolvedValue([
-					{ type: "movie", ratingKey: "broken-1", accountID: 1, viewedAt: 1_700_000_000 },
-				]),
+				getLibrarySections: vi
+					.fn()
+					.mockResolvedValue([
+						{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+					]),
+				getLibraryItems: vi
+					.fn()
+					.mockResolvedValue([
+						{ ratingKey: "broken-1", title: "Broken Movie", type: "movie", Guid: [] },
+					]),
+				getHistory: vi
+					.fn()
+					.mockResolvedValue([
+						{ type: "movie", ratingKey: "broken-1", accountID: 1, viewedAt: 1_700_000_000 },
+					]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
 			} as unknown as PlexClient;

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -233,12 +233,8 @@ describe("PlexClient authoritative inventory completeness", () => {
 			"fetch",
 			vi
 				.fn()
-				.mockResolvedValueOnce(
-					response({ offset: 0, size: 1, totalSize: 1, Metadata: initial }),
-				)
-				.mockResolvedValueOnce(
-					response({ offset: 0, size: 1, totalSize: 1, Metadata: changed }),
-				),
+				.mockResolvedValueOnce(response({ offset: 0, size: 1, totalSize: 1, Metadata: initial }))
+				.mockResolvedValueOnce(response({ offset: 0, size: 1, totalSize: 1, Metadata: changed })),
 		);
 		const client = new PlexClient("http://plex.test", "token", log);
 
@@ -321,9 +317,11 @@ describe("PlexClient authoritative inventory completeness", () => {
 	});
 
 	it("leaves an absent section agent undefined rather than defaulting it", async () => {
-		const fetchMock = vi.fn().mockResolvedValueOnce(
-			response({ size: 1, Directory: [{ key: "1", title: "Movies", type: "movie" }] }),
-		);
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				response({ size: 1, Directory: [{ key: "1", title: "Movies", type: "movie" }] }),
+			);
 		vi.stubGlobal("fetch", fetchMock);
 		const client = new PlexClient("http://plex.test", "token", log);
 

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -654,8 +654,7 @@ export async function collectPlexCacheLiveEvidence(
 			const latestSections = await client.getLibrarySections();
 			const latestMediaLibs = latestSections.filter(
 				(section) =>
-					(section.type === "movie" || section.type === "show") &&
-					!isPersonalMediaSection(section),
+					(section.type === "movie" || section.type === "show") && !isPersonalMediaSection(section),
 			);
 			if (
 				JSON.stringify(mediaLibrarySignature(latestMediaLibs)) !==

--- a/apps/api/src/lib/qui/__tests__/client-factory.test.ts
+++ b/apps/api/src/lib/qui/__tests__/client-factory.test.ts
@@ -670,10 +670,10 @@ describe("createQuiClient", () => {
 	it("rejects a non-empty total with an omitted collection (CASE B)", async () => {
 		// total=5 claims torrents exist but no collection is supplied.
 		fetchSpy.mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({ total: 5, hasMore: false, partialResults: false }),
-				{ status: 200, headers: { "content-type": "application/json" } },
-			),
+			new Response(JSON.stringify({ total: 5, hasMore: false, partialResults: false }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
 		);
 
 		const client = createQuiClient(buildApp(), buildInstance());
@@ -684,10 +684,10 @@ describe("createQuiClient", () => {
 
 	it("rejects an omitted collection while more pages supposedly exist (CASE C)", async () => {
 		fetchSpy.mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({ total: 5, hasMore: true, partialResults: false }),
-				{ status: 200, headers: { "content-type": "application/json" } },
-			),
+			new Response(JSON.stringify({ total: 5, hasMore: true, partialResults: false }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
 		);
 
 		const client = createQuiClient(buildApp(), buildInstance());
@@ -700,10 +700,10 @@ describe("createQuiClient", () => {
 		// Missing partialResults means completeness cannot be proven; the
 		// strict requireComplete schema rejects it outright.
 		fetchSpy.mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({ total: 0, hasMore: false }),
-				{ status: 200, headers: { "content-type": "application/json" } },
-			),
+			new Response(JSON.stringify({ total: 0, hasMore: false }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
 		);
 
 		const client = createQuiClient(buildApp(), buildInstance());
@@ -714,10 +714,10 @@ describe("createQuiClient", () => {
 		// The non-requireComplete path tolerates the missing metadata but
 		// must NOT claim completeness, so absence is not authoritative.
 		fetchSpy.mockResolvedValueOnce(
-			new Response(
-				JSON.stringify({ total: 0, hasMore: false }),
-				{ status: 200, headers: { "content-type": "application/json" } },
-			),
+			new Response(JSON.stringify({ total: 0, hasMore: false }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
 		);
 
 		const client = createQuiClient(buildApp(), buildInstance());

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-reversal-classification.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-reversal-classification.test.ts
@@ -110,7 +110,12 @@ describe("classifyTargetReversal", () => {
 		const before = { id: 7, name: "CF", specifications: [] };
 		const state = baseState({
 			customFormatDeployments: [
-				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 7,
+					postStateToken: "post",
+				}),
 			],
 		});
 		const c = client({
@@ -126,7 +131,12 @@ describe("classifyTargetReversal", () => {
 		const before = { id: 7, name: "CF", specifications: [] };
 		const state = baseState({
 			customFormatDeployments: [
-				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 7,
+					postStateToken: "post",
+				}),
 			],
 		});
 		const c = client({
@@ -346,7 +356,12 @@ describe("classifyTargetReversal", () => {
 		const before = { id: 7, name: "CF", specifications: [] };
 		const state = baseState({
 			customFormatDeployments: [
-				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 7,
+					postStateToken: "post",
+				}),
 			],
 		});
 		const c = client({
@@ -362,7 +377,12 @@ describe("classifyTargetReversal", () => {
 		const before = { id: 7, name: "CF", specifications: [] };
 		const state = baseState({
 			customFormatDeployments: [
-				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 7,
+					postStateToken: "post",
+				}),
 				cfMutation({ resourceId: 8, name: "CF2", postStateToken: "post" }),
 			],
 		});
@@ -382,7 +402,12 @@ describe("classifyTargetReversal", () => {
 		const before = { id: 7, name: "CF", specifications: [] };
 		const state = baseState({
 			customFormatDeployments: [
-				cfMutation({ beforeFormat: before, action: "updated", resourceId: 7, postStateToken: "post" }),
+				cfMutation({
+					beforeFormat: before,
+					action: "updated",
+					resourceId: 7,
+					postStateToken: "post",
+				}),
 				cfMutation({ resourceId: null, name: "CF2", postStateToken: null }),
 			],
 		});


### PR DESCRIPTION
## Summary

Restores a clean, deterministic formatting baseline on stable `main` and adds
formatting to the required CI validation job.

`pnpm run format` previously failed on five files even though the existing
required CI checks were green.

This patch applies only the repository-pinned Biome 2.5.5 formatter output to
those five files and adds a non-writing hard formatting check to CI.

## Root cause

Five files changed during recent Plex, qUI, and TRaSH recovery fixes without
the final Biome formatting output being committed:

- `plex-cache-refresher.test.ts`
- `plex-client-completeness.test.ts`
- `plex-cache-refresher.ts`
- `client-factory.test.ts`
- `deployment-reversal-classification.test.ts`

The repository CI ran lint, typecheck, and tests, but did not run the root
format check.

The formatting baseline could therefore drift while all required checks
remained green.

## Changes

### Formatter-only source and test cleanup

Applied:

```text
pnpm --filter @arr/api exec biome format --write <five exact paths>
```

using the repository-pinned Biome 2.5.5.

The production `plex-cache-refresher.ts` change is whitespace/layout only.

The test changes consist solely of formatter-produced layout and punctuation
normalization, including:

- multiline call layout;
- object and argument wrapping;
- redundant arrow-body parenthesis removal;
- trailing comma normalization.

No identifier, literal, condition, expectation, fixture value, mock behavior,
call ordering, import behavior, or control flow changed.

### Required CI formatting gate

Adds this hard, non-writing step to the required
`Lint, Type Check & Test` job:

```yaml
- name: Check formatting
  run: pnpm run format
```

The step:

- does not use `--write`;
- does not use `continue-on-error`;
- does not repair files before checking them;
- fails the required job on future formatting drift.

All existing Prisma integrity, lint, typecheck, test, heap, E2E, and Docker
validation remains unchanged.

## Line-ending validation

The correction was reproduced and applied in a clean WSL checkout where the
five files were:

```text
i/lf w/lf
```

The original primary Windows/UNC checkout contained unrelated pre-existing
working-tree CRLF residue across many files.

No repository-wide line-ending normalization is included in this PR.

The committed files remain LF and Linux CI is unaffected by that separate
local-checkout condition.

## Validation

- original format check: **failed with exactly five files**
- post-fix format check: **PASS**
- second format/idempotence run: **PASS**
- focused affected suites: **137/137 passed**
- shared build: **PASS**
- lint: **PASS**
- typecheck: **PASS**
- full repository tests:
  - shared: **89 passed**
  - web: **660 passed**
  - API: **4101 passed / 50 skipped**
- provider-cache heap regression: **6/6 passed**
- production build: **PASS**
- Prisma exact-tree guard: **PASS**
- Prisma guard tests: **17/17 passed**
- Prisma schema validation: **PASS**
- clean LF worktree validation: **PASS**
- `git diff --check`: **PASS**

## Scope

Changed files are limited to:

- the five formatter-corrected API files;
- `.github/workflows/ci.yml`.

This patch does not include:

- runtime behavior changes;
- Prisma schema or generated-client changes;
- dependency or lockfile changes;
- issue #779 integration-fixture work;
- Docker supervision changes;
- release metadata;
- a version bump;
- a forward-port to `next`.