### PR TITLE
fix(plex): require live settlement authority

### DIFF
--- a/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
@@ -9,10 +9,74 @@ const mocks = vi.hoisted(() => ({
 	createPlexClient: vi.fn(),
 }));
 
-vi.mock("../../plex/plex-evidence-repository.js", () => ({
-	loadInstanceSelectedEvidence: mocks.loadInstanceSelectedEvidence,
-	loadInstanceSelectedMutationEvidence: mocks.loadInstanceSelectedEvidence,
+vi.mock("../../plex/plex-authority-service.js", () => ({
+	PlexAuthorityService: class {
+		private readonly prisma: {
+			serviceInstance?: { findFirst: (input: unknown) => Promise<Record<string, unknown> | null> };
+		};
+		private lastEvidence?: ReturnType<typeof authoritativeEvidence>;
+
+		constructor(input: { prisma: PlexAuthorityServiceTestPrisma }) {
+			this.prisma = input.prisma;
+		}
+
+		async readInstanceSelected(input: Record<string, unknown>) {
+			const evidence = await mocks.loadInstanceSelectedEvidence(this.prisma, input);
+			this.lastEvidence = evidence;
+			return evidence;
+		}
+
+		async mutateMetadataTag(input: {
+			target: { tmdbId: number; mediaType: string };
+			expectedRatingKey: string;
+			type: string;
+			action: string;
+			name: string;
+		}) {
+			const evidence = await mocks.loadInstanceSelectedEvidence(this.prisma, {
+				selection: { kind: "targets", targets: [input.target] },
+				domains: ["membership"],
+			});
+			if (
+				!evidence.available ||
+				evidence.evidence.publicationLevel !== "authoritative" ||
+				evidence.evidence.completeness !== "complete" ||
+				evidence.evidence.reasonCodes.length > 0
+			) {
+				return { ok: false, reasonCode: "plex_content_digest_changed" };
+			}
+			const matching = evidence.rows.filter(
+				(row: {
+					tmdbId: number;
+					mediaType: string;
+					ratingKey: string | null;
+					thumb: string | null;
+				}) =>
+					row.tmdbId === input.target.tmdbId &&
+					row.mediaType === input.target.mediaType &&
+					row.ratingKey === input.expectedRatingKey &&
+					row.thumb?.match(/\/library\/metadata\/(\d+)/)?.[1] === input.expectedRatingKey,
+			);
+			if (new Set(matching.map((row: { ratingKey: string }) => row.ratingKey)).size !== 1) {
+				return { ok: false, reasonCode: "plex_content_digest_changed" };
+			}
+			const current = await this.prisma.serviceInstance?.findFirst({});
+			if (
+				!current ||
+				current.connectionGeneration !== this.lastEvidence?.connectionGeneration ||
+				current.identityGeneration !== this.lastEvidence?.identityGeneration
+			) {
+				return { ok: false, reasonCode: "connection_generation_mismatch" };
+			}
+			await mocks.updateMetadataTags(input.expectedRatingKey, input.type, input.action, input.name);
+			return { ok: true };
+		}
+	},
 }));
+
+type PlexAuthorityServiceTestPrisma = {
+	serviceInstance?: { findFirst: (input: unknown) => Promise<Record<string, unknown> | null> };
+};
 
 vi.mock("../../plex/plex-client.js", () => ({
 	createPlexClient: mocks.createPlexClient,
@@ -135,6 +199,7 @@ describe("Plex label-sync evidence boundary", () => {
 			userId: "user-1",
 			instanceId: "plex-source",
 			selection: { kind: "label-membership", label: "Kids" },
+			domains: ["membership", "display"],
 		});
 	});
 

--- a/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
@@ -6,8 +6,7 @@
  * apply the destination label.
  */
 
-import { createPlexClient } from "../../plex/plex-client.js";
-import { loadInstanceSelectedMutationEvidence } from "../../plex/plex-evidence-repository.js";
+import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
 import type { DestWriteResult, DestWriter, DestWriterOpts } from "../strategy-types.js";
 
 export const plexDestWriter: DestWriter = {
@@ -35,10 +34,12 @@ export const plexDestWriter: DestWriter = {
 			tmdbId: candidate.tmdbId,
 			mediaType: candidate.mediaType,
 		}));
-		const evidence = await loadInstanceSelectedMutationEvidence(prisma, {
+		const authority = new PlexAuthorityService({ prisma, encryptor, log });
+		const evidence = await authority.readInstanceSelected({
 			userId: rule.userId,
 			instanceId: rule.destInstanceId,
 			selection: { kind: "targets", targets },
+			domains: ["membership"],
 		});
 		if (
 			!evidence.available ||
@@ -72,26 +73,23 @@ export const plexDestWriter: DestWriter = {
 			}
 			if (attemptedRatingKeys.has(ratingKey)) continue;
 			attemptedRatingKeys.add(ratingKey);
-			const currentEvidence = await loadInstanceSelectedMutationEvidence(prisma, {
-				userId: rule.userId,
-				instanceId: rule.destInstanceId,
-				selection: {
-					kind: "targets",
-					targets: [{ tmdbId: row.tmdbId, mediaType: row.mediaType }],
-				},
-			});
-			if (
-				!currentEvidence.available ||
-				currentEvidence.evidence.publicationLevel !== "authoritative" ||
-				currentEvidence.evidence.completeness !== "complete" ||
-				currentEvidence.evidence.reasonCodes.length > 0 ||
-				!currentEvidence.rows.some(
-					(current) =>
-						current.tmdbId === row.tmdbId &&
-						current.mediaType === row.mediaType &&
-						resolveParitySafeCachedRatingKey(current) === ratingKey,
-				)
-			) {
+			let mutation: Awaited<ReturnType<PlexAuthorityService["mutateMetadataTag"]>>;
+			try {
+				mutation = await authority.mutateMetadataTag({
+					userId: rule.userId,
+					instanceId: rule.destInstanceId,
+					target: { tmdbId: row.tmdbId, mediaType: row.mediaType },
+					expectedRatingKey: ratingKey,
+					type: "label",
+					action: "add",
+					name: rule.destTagName,
+				});
+			} catch (err) {
+				log.warn({ ratingKey, err }, "Failed to apply Plex label");
+				failures++;
+				continue;
+			}
+			if (!mutation.ok) {
 				log.warn(
 					{ tmdbId: row.tmdbId, ratingKey },
 					"Plex label target evidence changed before mutation",
@@ -99,35 +97,7 @@ export const plexDestWriter: DestWriter = {
 				failures++;
 				continue;
 			}
-			const currentInstance = await prisma.serviceInstance.findFirst({
-				where: {
-					id: rule.destInstanceId,
-					userId: rule.userId,
-					service: "PLEX",
-					enabled: true,
-				},
-			});
-			if (
-				!currentInstance ||
-				currentInstance.connectionGeneration !== currentEvidence.connectionGeneration ||
-				currentInstance.identityGeneration !== currentEvidence.identityGeneration
-			) {
-				log.warn(
-					{ tmdbId: row.tmdbId, ratingKey },
-					"Plex label destination connection changed before mutation",
-				);
-				failures++;
-				continue;
-			}
-
-			try {
-				const plexClient = createPlexClient(encryptor, currentInstance, log);
-				await plexClient.updateMetadataTags(ratingKey, "label", "add", rule.destTagName);
-				labelsApplied++;
-			} catch (err) {
-				log.warn({ ratingKey, err }, "Failed to apply Plex label");
-				failures++;
-			}
+			labelsApplied++;
 		}
 
 		return { matchesFound: matched.length, labelsApplied, failures };

--- a/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
+++ b/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
@@ -12,7 +12,7 @@ import type {
 	SourceReaderOpts,
 	SourceReadResult,
 } from "../strategy-types.js";
-import { loadInstanceSelectedEvidence } from "../../plex/plex-evidence-repository.js";
+import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
 
 export const plexSourceReader: SourceReader = {
 	prismaService: "PLEX",
@@ -21,10 +21,18 @@ export const plexSourceReader: SourceReader = {
 
 		let rows: Array<{ tmdbId: number; mediaType: string; title: string; labels: string }>;
 		try {
-			const evidence = await loadInstanceSelectedEvidence(prisma, {
+			const evidence = await new PlexAuthorityService({
+				prisma,
+				encryptor: opts.encryptor,
+				log,
+			}).readInstanceSelected({
 				userId: rule.userId,
 				instanceId: sourceInstance.id,
 				selection: { kind: "label-membership", label: rule.sourceTagName },
+				// The selection itself proves membership in the configured source
+				// label. Unrelated labels on the same selected item are outside this
+				// read's authority domain and must not revoke otherwise stable evidence.
+				domains: ["membership", "display"],
 			});
 			if (
 				!evidence.available ||

--- a/apps/api/src/lib/library-cleanup/__tests__/media-server-rescan.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/media-server-rescan.test.ts
@@ -16,6 +16,51 @@ import {
 	serializeProviderScanAuthority,
 } from "../shared-plex-safety.js";
 
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: never;
+
+			constructor(input: { prisma: never }) {
+				this.prisma = input.prisma;
+			}
+
+			readInstance(input: never) {
+				return repository.loadInstanceEvidence(this.prisma, input);
+			}
+
+			scanInstancePolicy(input: never) {
+				return repository.scanInstancePolicyEvidence(this.prisma, input);
+			}
+		},
+	};
+});
+
+function plexV3Metadata(itemCount: number) {
+	return JSON.stringify({
+		version: 3,
+		publicationLevel: "authoritative",
+		completeness: "complete",
+		itemCount,
+		canonicalizationVersion: 1,
+		sections: [
+			{
+				key: "movies",
+				uuid: "movies-uuid",
+				title: "Movies",
+				type: "movie",
+				refreshing: false,
+				scannedAt: 1_777_000_000,
+				updatedAt: 1_777_000_100,
+			},
+		],
+		roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+	});
+}
+
 function authorityFingerprint(value: unknown): string {
 	const canonicalize = (input: unknown): unknown => {
 		if (input instanceof Date) return input.toISOString();
@@ -584,7 +629,7 @@ describe("durable media-server rescans", () => {
 						connectionGeneration: 3,
 						identityGeneration: 7,
 						generationId: "plex-generation-1",
-						generationMetadata: '{"sections":[{"key":"movies","title":"Movies","type":"movie"}]}',
+						generationMetadata: plexV3Metadata(0),
 					},
 				]),
 			},
@@ -1084,7 +1129,7 @@ describe("durable media-server rescans", () => {
 						connectionGeneration: 3,
 						identityGeneration: 7,
 						generationId: "generation-b",
-						generationMetadata: '{"sections":[{"key":"movies","title":"Movies","type":"movie"}]}',
+						generationMetadata: plexV3Metadata(1),
 					},
 				]),
 			},

--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -60,6 +60,86 @@ vi.mock("../../jellyfin/jellyfin-episode-cache-refresher.js", () => ({
 	refreshJellyfinEpisodeCache: refreshMocks.jellyfinEpisodes,
 }));
 
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: {
+				serviceInstance: { findMany: (input: unknown) => Promise<Array<Record<string, unknown>>> };
+			};
+
+			constructor(input: {
+				prisma: {
+					serviceInstance: {
+						findMany: (input: unknown) => Promise<Array<Record<string, unknown>>>;
+					};
+				};
+			}) {
+				this.prisma = input.prisma;
+			}
+
+			async scanInstancePolicy(input: { userId: string; instanceId: string }) {
+				const instances = await this.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				const result = await repository.scanInstancePolicyEvidence(
+					{
+						...this.prisma,
+						serviceInstance: {
+							...this.prisma.serviceInstance,
+							findFirst: vi.fn().mockResolvedValue(instance ?? null),
+						},
+					} as never,
+					input,
+				);
+				return result;
+			}
+
+			async readInstance(input: { userId: string; instanceId: string }) {
+				const instances = await this.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return repository.loadInstanceEvidence(
+					{
+						...this.prisma,
+						serviceInstance: {
+							...this.prisma.serviceInstance,
+							findFirst: vi.fn().mockResolvedValue(instance ?? null),
+						},
+					} as never,
+					input,
+				);
+			}
+		},
+	};
+});
+
+function plexV3Metadata(itemCount: number) {
+	return JSON.stringify({
+		version: 3,
+		publicationLevel: "authoritative",
+		completeness: "complete",
+		itemCount,
+		canonicalizationVersion: 1,
+		sections: [
+			{
+				key: "movies",
+				uuid: "movies-uuid",
+				title: "Movies",
+				type: "movie",
+				refreshing: false,
+				scannedAt: 1_777_000_000,
+				updatedAt: 1_777_000_100,
+			},
+		],
+		roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+	});
+}
+
 function rule(ruleType: string) {
 	return {
 		id: `rule-${ruleType}`,
@@ -155,9 +235,7 @@ function makeDeps(
 					lastResult: "success",
 					itemCount: 0,
 					generationId: `generation-${instanceId}`,
-					generationMetadata: JSON.stringify({
-						sections: [{ key: "1", title: "Movies", type: "movie" }],
-					}),
+					generationMetadata: plexV3Metadata(0),
 					lastErrorMessage: null,
 					lastAttemptAt: publishedAt,
 					lastAttemptResult: "success",
@@ -673,9 +751,7 @@ describe("authoritative mutation policy snapshots", () => {
 						lastResult: "success",
 						itemCount: instanceId === plexB.id ? 1 : 0,
 						generationId: generationIds.get(instanceId),
-						generationMetadata: JSON.stringify({
-							sections: [{ key: "movies", title: "Movies", type: "movie" }],
-						}),
+						generationMetadata: plexV3Metadata(instanceId === plexB.id ? 1 : 0),
 						lastErrorMessage: null,
 						lastAttemptAt: publishedAt,
 						lastAttemptResult: "success",

--- a/apps/api/src/lib/library-cleanup/__tests__/plex-policy-snapshot.database.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/plex-policy-snapshot.database.test.ts
@@ -105,8 +105,20 @@ async function publish(
 			completedAt: new Date(),
 			generationId,
 			generationMetadata: encodeAuthoritativePlexGenerationMetadata({
-				sections: [{ key: "movies", title: "Movies", type: "movie" }],
+				sections: [
+					{
+						key: "movies",
+						uuid: "movies-uuid",
+						title: "Movies",
+						type: "movie",
+						refreshing: false,
+						scannedAt: 1,
+						updatedAt: 1,
+					},
+				],
 				itemCount: 1,
+				canonicalizationVersion: 1,
+				roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
 			}),
 			attempt: attempt!,
 		});

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -21,6 +21,114 @@ import {
 import { evaluateItemAgainstRules } from "../rule-evaluators.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
+const authorityMock = vi.hoisted(() => ({
+	policyEvidence: new Map<string, unknown>(),
+}));
+
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: {
+				serviceInstance?: { findMany: (input: unknown) => Promise<Array<Record<string, unknown>>> };
+			};
+
+			constructor(input: {
+				prisma: {
+					serviceInstance?: {
+						findMany: (input: unknown) => Promise<Array<Record<string, unknown>>>;
+					};
+				};
+			}) {
+				this.prisma = input.prisma;
+			}
+
+			private async instance(input: { userId: string; instanceId: string }) {
+				if (!this.prisma.serviceInstance) {
+					return {
+						id: input.instanceId,
+						userId: input.userId,
+						service: "PLEX",
+						enabled: true,
+						label: "Plex",
+						expectedIdentity: "stored-plex-machine-identity",
+						identityKind: "PLEX_MACHINE_IDENTIFIER",
+						identityStatus: "VERIFIED",
+						identityVerifiedAt: new Date(0),
+						connectionGeneration: 3,
+						identityGeneration: 7,
+					};
+				}
+				const instances = await this.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				return instances.find((instance) => instance.id === input.instanceId);
+			}
+
+			private repositoryInput() {
+				return this.prisma as never;
+			}
+
+			private repositoryWithInstance(instance: Record<string, unknown> | undefined) {
+				return {
+					...this.prisma,
+					serviceInstance: {
+						...this.prisma.serviceInstance,
+						findFirst: vi.fn().mockResolvedValue(instance ?? null),
+					},
+				} as never;
+			}
+
+			async readInstance(input: { userId: string; instanceId: string }) {
+				const scanned = authorityMock.policyEvidence.get(input.instanceId);
+				if (scanned) return scanned;
+				const instance = await this.instance(input);
+				return repository.loadInstanceEvidence(this.repositoryWithInstance(instance), input);
+			}
+
+			async readInstanceSelected(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.loadInstanceSelectedEvidence(
+					this.repositoryWithInstance(instance),
+					input as never,
+				);
+			}
+
+			async scanInstancePolicy(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				const evidence = await repository.scanInstancePolicyEvidence(
+					this.repositoryWithInstance(instance),
+					input,
+				);
+				authorityMock.policyEvidence.set(input.instanceId, evidence);
+				return evidence;
+			}
+
+			scanUserPolicy(input: never) {
+				return repository.scanUserPolicyEvidence(this.repositoryInput(), input);
+			}
+
+			async readInstanceEpisodes(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.loadInstanceEpisodeEvidence(this.repositoryInput(), {
+					...input,
+					instance: instance as never,
+				});
+			}
+
+			async readInstanceSelectedEpisodes(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.loadInstanceSelectedEpisodeEvidence(this.repositoryInput(), {
+					...input,
+					instance: instance as never,
+				} as never);
+			}
+		},
+	};
+});
+
 function makePlexRow(overrides: {
 	id: string;
 	instanceId?: string;
@@ -99,7 +207,23 @@ function completeStatus(instanceId: string, completedAt = new Date(), itemCount 
 		itemCount,
 		generationId: `generation-${instanceId}`,
 		generationMetadata: JSON.stringify({
-			sections: [{ key: "1", title: "Movies", type: "movie" }],
+			version: 3,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			itemCount,
+			canonicalizationVersion: 1,
+			sections: [
+				{
+					key: "1",
+					uuid: "movies-uuid",
+					title: "Movies",
+					type: "movie",
+					refreshing: false,
+					scannedAt: 1_777_000_000,
+					updatedAt: 1_777_000_100,
+				},
+			],
+			roots: [{ sectionKey: "1", domain: "membership", digest: "a".repeat(64) }],
 		}),
 		lastErrorMessage: null,
 		lastAttemptAt: completedAt,
@@ -116,9 +240,12 @@ function completeEpisodeStatus(instanceId: string, completedAt: Date, itemCount:
 		cacheType: "plex_episode",
 		generationId: `episode-generation-${instanceId}`,
 		generationMetadata: JSON.stringify({
-			version: 1,
+			version: 2,
 			parentPlexGenerationId: `generation-${instanceId}`,
 			parentPublicationLevel: "authoritative",
+			parentMetadataVersion: 3,
+			canonicalizationVersion: 1,
+			episodeDigest: "b".repeat(64),
 			connectionGeneration: 3,
 			identityGeneration: 7,
 		}),
@@ -792,7 +919,7 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 
 		const map = await prefetchPlexData({ prisma, log } as never, "user-1");
 
-		// Two findMany calls — pagination must have continued past batch 1.
+		// Two paginated reads; the central service carries the proven fixed point.
 		expect(findManySpy).toHaveBeenCalledTimes(2);
 
 		// Single merged entry for movie:42 — NOT two separate entries.

--- a/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
@@ -6,6 +6,108 @@ import {
 } from "../shared-plex-safety.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: {
+				serviceInstance: { findMany: (input: unknown) => Promise<Array<Record<string, unknown>>> };
+			};
+
+			constructor(input: {
+				prisma: {
+					serviceInstance: {
+						findMany: (input: unknown) => Promise<Array<Record<string, unknown>>>;
+					};
+				};
+			}) {
+				this.prisma = input.prisma;
+			}
+
+			private async instance(input: { userId: string; instanceId: string }) {
+				const instances = await this.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				return instances.find((instance) => instance.id === input.instanceId);
+			}
+
+			private repositoryWithInstance(instance: Record<string, unknown> | undefined) {
+				return {
+					...this.prisma,
+					serviceInstance: {
+						...this.prisma.serviceInstance,
+						findFirst: vi.fn().mockResolvedValue(instance ?? null),
+					},
+				} as never;
+			}
+
+			async scanInstancePolicy(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.scanInstancePolicyEvidence(this.repositoryWithInstance(instance), input);
+			}
+
+			async readInstanceEpisodes(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.loadInstanceEpisodeEvidence(
+					this.prisma as never,
+					{
+						...input,
+						instance: instance as never,
+					} as never,
+				);
+			}
+
+			async readInstanceSelectedEpisodes(input: { userId: string; instanceId: string }) {
+				const instance = await this.instance(input);
+				return repository.loadInstanceSelectedEpisodeEvidence(
+					this.prisma as never,
+					{
+						...input,
+						instance: instance as never,
+					} as never,
+				);
+			}
+		},
+	};
+});
+
+function plexV3Metadata(itemCount = 1) {
+	return JSON.stringify({
+		version: 3,
+		publicationLevel: "authoritative",
+		completeness: "complete",
+		itemCount,
+		canonicalizationVersion: 1,
+		sections: [
+			{
+				key: "1",
+				uuid: "movies-uuid",
+				title: "Movies",
+				type: "movie",
+				refreshing: false,
+				scannedAt: 1_777_000_000,
+				updatedAt: 1_777_000_100,
+			},
+		],
+		roots: [{ sectionKey: "1", domain: "membership", digest: "a".repeat(64) }],
+	});
+}
+
+function plexEpisodeV2Metadata(parentGenerationId: string) {
+	return JSON.stringify({
+		version: 2,
+		parentPlexGenerationId: parentGenerationId,
+		parentPublicationLevel: "authoritative",
+		parentMetadataVersion: 3,
+		canonicalizationVersion: 1,
+		episodeDigest: "b".repeat(64),
+		connectionGeneration: 3,
+		identityGeneration: 7,
+	});
+}
+
 function fingerprint(value: unknown): string {
 	const canonicalize = (input: unknown): unknown => {
 		if (input instanceof Date) return input.toISOString();
@@ -65,9 +167,7 @@ function fixture(
 		connectionGeneration: 3,
 		identityGeneration: 7,
 		generationId: "generation-a",
-		generationMetadata: JSON.stringify({
-			sections: [{ key: "1", title: "Movies", type: "movie" }],
-		}),
+		generationMetadata: plexV3Metadata(),
 		...statusOverrides,
 	};
 	let rows = [
@@ -335,15 +435,9 @@ function cacheTypeFixture(
 		generationId: "generation-a",
 		generationMetadata:
 			cacheType === "plex"
-				? JSON.stringify({ sections: [{ key: "1", title: "Movies", type: "movie" }] })
+				? plexV3Metadata()
 				: cacheType === "plex_episode"
-					? JSON.stringify({
-							version: 1,
-							parentPlexGenerationId: "parent-generation-a",
-							parentPublicationLevel: "authoritative",
-							connectionGeneration: 3,
-							identityGeneration: 7,
-						})
+					? plexEpisodeV2Metadata("parent-generation-a")
 					: "{}",
 		...options.statusOverrides,
 	};
@@ -410,9 +504,7 @@ function cacheTypeFixture(
 								...status,
 								cacheType: "plex",
 								generationId: "parent-generation-a",
-								generationMetadata: JSON.stringify({
-									sections: [{ key: "1", title: "Movies", type: "movie" }],
-								}),
+								generationMetadata: plexV3Metadata(),
 							},
 						]
 					: [status],

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -48,6 +48,27 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 					instance,
 				});
 			}
+
+			async revalidatePersistedSnapshot(
+				input: Parameters<
+					InstanceType<typeof actual.PlexAuthorityService>["revalidatePersistedSnapshot"]
+				>[0],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await new actual.PlexAuthorityService({
+					...this.deps,
+					prisma: {
+						...this.deps.prisma,
+						serviceInstance: {
+							...this.deps.prisma.serviceInstance,
+							findFirst: vi.fn().mockResolvedValue(instance ?? null),
+						},
+					},
+				} as never).revalidatePersistedSnapshot(input);
+			}
 		},
 	};
 });
@@ -1885,7 +1906,7 @@ describe("shared Plex deletion safety", () => {
 		]);
 	});
 
-	it("rejects row drift even while the accepted provider status token is lagging", async () => {
+	it("rejects live row drift before opening the approval transaction", async () => {
 		const fixture = makeDeps({ mediaPartCount: 1 });
 		const authority = configurePlexApprovalAuthority(fixture, {
 			items: [{ id: "cache-provider-1", arrItemId: 101, title: "Example Movie" }],
@@ -1895,7 +1916,7 @@ describe("shared Plex deletion safety", () => {
 		const result = await executeCleanupRun(fixture.deps, "user-1");
 
 		expect(result.itemsFlagged).toBe(1);
-		expect(authority.transaction).toHaveBeenCalledOnce();
+		expect(authority.transaction).not.toHaveBeenCalled();
 		expect(authority.transactionCreate).not.toHaveBeenCalled();
 		expect(authority.rootCreate).not.toHaveBeenCalled();
 		expect(result).toMatchObject({ itemsSkipped: 1, itemsRemoved: 0, status: "partial" });
@@ -1927,11 +1948,8 @@ describe("shared Plex deletion safety", () => {
 
 		const result = await executeCleanupRun(fixture.deps, "user-1");
 
-		expect(authority.transaction).toHaveBeenCalledTimes(2);
+		expect(authority.transaction).toHaveBeenCalledOnce();
 		expect(authority.transaction).toHaveBeenNthCalledWith(1, expect.any(Function), {
-			isolationLevel: "Serializable",
-		});
-		expect(authority.transaction).toHaveBeenNthCalledWith(2, expect.any(Function), {
 			isolationLevel: "Serializable",
 		});
 		expect(authority.transactionCreate).toHaveBeenCalledOnce();

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -1,5 +1,57 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			constructor(
+				private readonly deps: {
+					prisma: Parameters<typeof repository.scanInstancePolicyEvidence>[0];
+				},
+			) {}
+
+			async readInstance(input: Parameters<typeof repository.loadInstanceEvidence>[1]) {
+				const evidence = await repository.loadUserEvidence(this.deps.prisma, input);
+				return evidence.find((entry) => entry.instanceId === input.instanceId) ?? evidence[0];
+			}
+
+			async scanInstancePolicy(input: Parameters<typeof repository.scanInstancePolicyEvidence>[1]) {
+				const evidence = await repository.scanUserPolicyEvidence(this.deps.prisma, input);
+				return evidence.find((entry) => entry.instanceId === input.instanceId) ?? evidence[0];
+			}
+
+			async readInstanceSelectedEpisodes(
+				input: Parameters<typeof repository.loadInstanceSelectedEpisodeEvidence>[1],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await repository.loadInstanceSelectedEpisodeEvidence(this.deps.prisma, {
+					...input,
+					instance,
+				});
+			}
+
+			async readInstanceEpisodes(
+				input: Parameters<typeof repository.loadInstanceEpisodeEvidence>[1],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await repository.loadInstanceEpisodeEvidence(this.deps.prisma, {
+					...input,
+					instance,
+				});
+			}
+		},
+	};
+});
+
 import * as plexRefreshOrchestration from "../../plex/plex-refresh-orchestration.js";
 import { withQuiObservationTopologyGuard } from "../../qui/observation-topology-guard.js";
 import {
@@ -975,11 +1027,23 @@ function configurePlexApprovalAuthority(
 		identityGeneration: 7,
 		generationId: `plex-generation-${generationRevision}`,
 		generationMetadata: JSON.stringify({
-			version: 2,
+			version: 3,
 			publicationLevel: "authoritative",
 			completeness: "complete",
 			itemCount: rows.length,
-			sections: [{ key: "movies", title: "Movies", type: "movie" }],
+			canonicalizationVersion: 1,
+			sections: [
+				{
+					key: "movies",
+					title: "Movies",
+					type: "movie",
+					uuid: "movies-uuid",
+					refreshing: false,
+					scannedAt: 1,
+					updatedAt: 1,
+				},
+			],
+			roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
 		}),
 		...options.statusOverrides,
 	});

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1,5 +1,57 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
+	const repository = await import("../../plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			constructor(
+				private readonly deps: {
+					prisma: Parameters<typeof repository.scanInstancePolicyEvidence>[0];
+				},
+			) {}
+
+			async readInstance(input: Parameters<typeof repository.loadInstanceEvidence>[1]) {
+				const evidence = await repository.loadUserEvidence(this.deps.prisma, input);
+				return evidence.find((entry) => entry.instanceId === input.instanceId) ?? evidence[0];
+			}
+
+			async scanInstancePolicy(input: Parameters<typeof repository.scanInstancePolicyEvidence>[1]) {
+				const evidence = await repository.scanUserPolicyEvidence(this.deps.prisma, input);
+				return evidence.find((entry) => entry.instanceId === input.instanceId) ?? evidence[0];
+			}
+
+			async readInstanceSelectedEpisodes(
+				input: Parameters<typeof repository.loadInstanceSelectedEpisodeEvidence>[1],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await repository.loadInstanceSelectedEpisodeEvidence(this.deps.prisma, {
+					...input,
+					instance,
+				});
+			}
+
+			async readInstanceEpisodes(
+				input: Parameters<typeof repository.loadInstanceEpisodeEvidence>[1],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await repository.loadInstanceEpisodeEvidence(this.deps.prisma, {
+					...input,
+					instance,
+				});
+			}
+		},
+	};
+});
+
 import { PlexSeriesNotFoundError } from "../../plex/plex-client.js";
 import { plexConnectionFingerprint } from "../../plex/service-instance-fingerprint.js";
 import {
@@ -483,7 +535,23 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		itemCount: parentRows.length,
 		generationId: parentGenerationId,
 		generationMetadata: JSON.stringify({
-			sections: [{ key: "shows", title: "Shows", type: "show" }],
+			version: 3,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			itemCount: parentRows.length,
+			canonicalizationVersion: 1,
+			sections: [
+				{
+					key: "shows",
+					title: "Shows",
+					type: "show",
+					uuid: "shows-uuid",
+					refreshing: false,
+					scannedAt: 1,
+					updatedAt: 1,
+				},
+			],
+			roots: [{ sectionKey: "shows", domain: "membership", digest: "a".repeat(64) }],
 		}),
 		connectionGeneration: 1,
 		identityGeneration: 1,
@@ -494,9 +562,12 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 		itemCount: episodeRows.length,
 		generationId: "plex-episode-generation-1",
 		generationMetadata: JSON.stringify({
-			version: 1,
+			version: 2,
 			parentPlexGenerationId: parentGenerationId,
 			parentPublicationLevel: "authoritative",
+			parentMetadataVersion: 3,
+			canonicalizationVersion: 1,
+			episodeDigest: "b".repeat(64),
 			connectionGeneration: 1,
 			identityGeneration: 1,
 		}),
@@ -595,6 +666,7 @@ function makeSonarrDeps(options: SonarrTestOptions = {}) {
 			},
 			plexEpisodeCache: {
 				findMany: vi.fn().mockResolvedValue(episodeRows),
+				count: vi.fn(async () => episodeStatus.itemCount),
 				findFirst: vi.fn().mockResolvedValue({
 					watchCount: 1,
 					refreshedAt: new Date(),
@@ -3056,9 +3128,12 @@ describe("verified Sonarr mutation handoff", () => {
 			itemCount: secondEpisodeRows.length,
 			generationId: "plex-episode-generation-2",
 			generationMetadata: JSON.stringify({
-				version: 1,
+				version: 2,
 				parentPlexGenerationId: secondParentGenerationId,
 				parentPublicationLevel: "authoritative",
+				parentMetadataVersion: 3,
+				canonicalizationVersion: 1,
+				episodeDigest: "c".repeat(64),
 				connectionGeneration: 1,
 				identityGeneration: 1,
 			}),

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -48,6 +48,27 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 					instance,
 				});
 			}
+
+			async revalidatePersistedSnapshot(
+				input: Parameters<
+					InstanceType<typeof actual.PlexAuthorityService>["revalidatePersistedSnapshot"]
+				>[0],
+			) {
+				const instances = await this.deps.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return await new actual.PlexAuthorityService({
+					...this.deps,
+					prisma: {
+						...this.deps.prisma,
+						serviceInstance: {
+							...this.deps.prisma.serviceInstance,
+							findFirst: vi.fn().mockResolvedValue(instance ?? null),
+						},
+					},
+				} as never).revalidatePersistedSnapshot(input);
+			}
 		},
 	};
 });

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -694,6 +694,86 @@ async function revalidateExactProviderCacheAuthority(
 	});
 }
 
+async function revalidatePersistedProviderCacheAuthority(
+	deps: CleanupExecutorDeps,
+	tx: Prisma.TransactionClient,
+	authority: ProviderCacheSnapshot<unknown>["authority"],
+	now: Date,
+): Promise<boolean> {
+	const transactionDeps = {
+		...deps,
+		prisma: tx as unknown as CleanupExecutorDeps["prisma"],
+	};
+	const currentInstances = await loadProviderInstances(
+		transactionDeps,
+		authority.instances[0]!.userId,
+		[...new Set(authority.instances.map((instance) => instance.service))],
+	);
+	if (
+		providerTopologyFingerprint(currentInstances) !==
+		providerTopologyFingerprint(authority.instances)
+	) {
+		return false;
+	}
+	if (authority.cacheType === "plex" || authority.cacheType === "plex_episode") {
+		const plexAuthority = cleanupPlexAuthority(transactionDeps);
+		for (const instance of currentInstances) {
+			const generation = authority.generations.get(instance.id);
+			const rows = authority.rows.get(instance.id);
+			if (!generation || !rows) return false;
+			if (
+				!(await plexAuthority.revalidatePersistedSnapshot({
+					userId: instance.userId,
+					instanceId: instance.id,
+					cacheType: authority.cacheType,
+					expected: {
+						statusFingerprint: generation.statusFingerprint,
+						rowCount: rows.rowCount,
+						rowFingerprint: rows.rowFingerprint,
+					},
+					now,
+					maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
+				}))
+			) {
+				return false;
+			}
+		}
+		return currentInstances.length === authority.generations.size;
+	}
+	const currentGenerations = await loadCompleteCacheGenerations(
+		transactionDeps,
+		currentInstances,
+		authority.cacheType,
+		now,
+	);
+	if (!currentGenerations || currentGenerations.size !== authority.generations.size) return false;
+	if (
+		![...authority.generations].every(
+			([instanceId, generation]) =>
+				currentGenerations.get(instanceId)?.statusFingerprint === generation.statusFingerprint,
+		)
+	) {
+		return false;
+	}
+	const instanceIds = authority.instances.map((instance) => instance.id);
+	const currentRows = await loadExactProviderCacheRows(
+		tx,
+		authority.cacheType,
+		instanceIds,
+		authority.instances[0]!.userId,
+		authority.instances,
+	);
+	return instanceIds.every((instanceId) => {
+		const expected = authority.rows.get(instanceId);
+		const rows = currentRows.get(instanceId) ?? [];
+		return (
+			expected !== undefined &&
+			expected.rowCount === rows.length &&
+			expected.rowFingerprint === evidenceFingerprint(rows)
+		);
+	});
+}
+
 class ProviderCacheAuthorityChangedError extends Error {
 	constructor() {
 		super("Provider cache authority changed after cleanup selection");
@@ -719,6 +799,21 @@ async function createApprovalWithProviderCacheAuthority(
 		return await deps.prisma.libraryCleanupApproval.create({ data });
 	}
 	const postgresql = /^postgres(ql)?:\/\//i.test(process.env.DATABASE_URL ?? "");
+	// Plex settlement performs upstream I/O and must finish before Prisma opens
+	// its bounded approval transaction. The transaction then locks the provider
+	// identity and revalidates the exact persisted status and rows before write.
+	for (const authority of authorities) {
+		if (
+			!(await revalidateExactProviderCacheAuthority(
+				deps,
+				deps.prisma as unknown as Prisma.TransactionClient,
+				authority,
+				new Date(),
+			))
+		) {
+			throw new ProviderCacheAuthorityChangedError();
+		}
+	}
 	return await deps.prisma.$transaction(
 		async (tx) => {
 			const instanceIds = [
@@ -734,9 +829,11 @@ async function createApprovalWithProviderCacheAuthority(
 					);
 				}
 			}
-			const now = new Date();
+			const transactionNow = new Date();
 			for (const authority of authorities) {
-				if (!(await revalidateExactProviderCacheAuthority(deps, tx, authority, now))) {
+				if (
+					!(await revalidatePersistedProviderCacheAuthority(deps, tx, authority, transactionNow))
+				) {
 					throw new ProviderCacheAuthorityChangedError();
 				}
 			}

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -41,15 +41,13 @@ import {
 	PlexMovieNotFoundError,
 	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
-import {
-	type AvailablePlexInstanceEvidence,
-	getCurrentPlexMutationAuthorityForOwnedInstance,
-	loadInstanceEpisodeEvidence,
-	scanMutationPolicyEvidenceForOwnedInstances,
-	type AvailablePlexPolicyEvidence,
-	type PlexInstanceEvidence,
-	type PlexPolicyScanEvidence,
-} from "../plex/plex-evidence-repository.js";
+import type {
+	AvailablePlexInstanceEvidence,
+	AvailablePlexPolicyEvidence,
+	PlexInstanceEvidence,
+	PlexPolicyScanEvidence,
+} from "../plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../plex/plex-authority-service.js";
 import {
 	refreshOwnedPlexCache,
 	refreshOwnedPlexEpisodeCache,
@@ -293,6 +291,18 @@ function hasOnlyAuthoritativePlexEntries(
 	);
 }
 
+function cleanupPlexAuthority(
+	deps: CleanupExecutorDeps,
+	prisma: CleanupExecutorDeps["prisma"] = deps.prisma,
+): PlexAuthorityService {
+	return new PlexAuthorityService({
+		prisma,
+		...(deps.encryptor ? { encryptor: deps.encryptor } : {}),
+		log: deps.log,
+		...(deps.plexCacheClientFactory ? { createClient: deps.plexCacheClientFactory } : {}),
+	});
+}
+
 type PlexCleanupEvidenceInstance = Pick<
 	ServiceInstance,
 	| "userId"
@@ -355,8 +365,11 @@ async function loadCompleteCacheGenerations(
 	if (cacheType === "plex") {
 		const evidence: PlexPolicyScanEvidence[] = [];
 		for (const instance of instances) {
-			const current = await getCurrentPlexMutationAuthorityForOwnedInstance(deps.prisma, {
-				instance,
+			const current = await cleanupPlexAuthority(deps).readInstance({
+				userId: instance.userId,
+				instanceId: instance.id,
+				domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+				mutation: true,
 				now,
 				maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
 			});
@@ -368,10 +381,10 @@ async function loadCompleteCacheGenerations(
 		const evidence = [];
 		for (const instance of instances) {
 			evidence.push(
-				await loadInstanceEpisodeEvidence(deps.prisma, {
+				await cleanupPlexAuthority(deps).readInstanceEpisodes({
 					userId: instance.userId,
 					instanceId: instance.id,
-					instance,
+					mutation: true,
 					now,
 					maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
 				}),
@@ -482,8 +495,11 @@ async function revalidateProviderCacheAuthority(
 	}
 	if (authority.cacheType === "plex") {
 		for (const instance of currentInstances) {
-			const current = await getCurrentPlexMutationAuthorityForOwnedInstance(deps.prisma, {
-				instance,
+			const current = await cleanupPlexAuthority(deps).readInstance({
+				userId: instance.userId,
+				instanceId: instance.id,
+				domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+				mutation: true,
 				now,
 				maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
 			});
@@ -609,14 +625,19 @@ async function revalidateExactProviderCacheAuthority(
 		return false;
 	}
 	if (authority.cacheType === "plex") {
-		const currentEvidence = await scanMutationPolicyEvidenceForOwnedInstances(
-			transactionDeps.prisma,
-			{
-				instances: currentInstances,
-				now,
-				maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
-			},
-		);
+		const currentEvidence: PlexPolicyScanEvidence[] = [];
+		for (const instance of currentInstances) {
+			currentEvidence.push(
+				await cleanupPlexAuthority(transactionDeps).scanInstancePolicy({
+					userId: instance.userId,
+					instanceId: instance.id,
+					domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+					mutation: true,
+					now,
+					maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
+				}),
+			);
+		}
 		const currentGenerations = plexGenerationsFromEvidence(currentInstances, currentEvidence);
 		if (!currentGenerations || currentGenerations.size !== authority.generations.size) return false;
 		if (
@@ -659,6 +680,7 @@ async function revalidateExactProviderCacheAuthority(
 		instanceIds,
 		authority.instances[0]!.userId,
 		authority.instances,
+		cleanupPlexAuthority(transactionDeps),
 	);
 	if (!currentRows) return false;
 	return instanceIds.every((instanceId) => {
@@ -5924,7 +5946,7 @@ async function loadPlexDataSnapshot(
 	deps: CleanupExecutorDeps,
 	userId: string,
 ): Promise<PlexPolicyDataSnapshot | undefined> {
-	const { prisma, log } = deps;
+	const { log } = deps;
 
 	const plexInstances = await loadProviderInstances(deps, userId, ["PLEX"]);
 
@@ -5933,85 +5955,96 @@ async function loadPlexDataSnapshot(
 	try {
 		const map: PlexWatchMap = new Map();
 		let totalRows = 0;
-		const authoritativeEvidence = await scanMutationPolicyEvidenceForOwnedInstances(prisma, {
-			instances: plexInstances,
-			maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
-			onBatch: ({ rows }) => {
-				for (const row of rows) {
-					totalRows += 1;
-					try {
-						// Key is mediaType:tmdbId (aggregating across sections)
-						const key = `${row.mediaType}:${row.tmdbId}`;
-						const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
-						const collections = (safeJsonParse(row.collections) as string[]) ?? [];
-						const labels = (safeJsonParse(row.labels) as string[]) ?? [];
+		const authoritativeEvidence: PlexPolicyScanEvidence[] = [];
+		for (const instance of plexInstances) {
+			authoritativeEvidence.push(
+				await cleanupPlexAuthority(deps).scanInstancePolicy({
+					userId: instance.userId,
+					instanceId: instance.id,
+					domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+					mutation: true,
+					maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
+					onBatch: ({ rows }) => {
+						for (const row of rows) {
+							totalRows += 1;
+							try {
+								// Key is mediaType:tmdbId (aggregating across sections)
+								const key = `${row.mediaType}:${row.tmdbId}`;
+								const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
+								const collections = (safeJsonParse(row.collections) as string[]) ?? [];
+								const labels = (safeJsonParse(row.labels) as string[]) ?? [];
 
-						const sectionInfo: PlexSectionWatchInfo = {
-							sectionId: row.sectionId,
-							sectionTitle: row.sectionTitle,
-							lastWatchedAt: row.lastWatchedAt,
-							watchCount: row.watchCount,
-							watchedByUsers,
-							onDeck: row.onDeck,
-							userRating: row.userRating,
-							collections,
-							labels,
-							addedAt: row.addedAt,
-						};
+								const sectionInfo: PlexSectionWatchInfo = {
+									sectionId: row.sectionId,
+									sectionTitle: row.sectionTitle,
+									lastWatchedAt: row.lastWatchedAt,
+									watchCount: row.watchCount,
+									watchedByUsers,
+									onDeck: row.onDeck,
+									userRating: row.userRating,
+									collections,
+									labels,
+									addedAt: row.addedAt,
+								};
 
-						const existing = map.get(key);
-						if (existing) {
-							existing.sections.push(sectionInfo);
-							// Update aggregates: merge across sections
-							if (
-								row.lastWatchedAt &&
-								(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
-							) {
-								existing.lastWatchedAt = row.lastWatchedAt;
-							}
-							existing.watchCount += row.watchCount;
-							for (const user of watchedByUsers) {
-								if (!existing.watchedByUsers.includes(user)) {
-									existing.watchedByUsers.push(user);
+								const existing = map.get(key);
+								if (existing) {
+									existing.sections.push(sectionInfo);
+									// Update aggregates: merge across sections
+									if (
+										row.lastWatchedAt &&
+										(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
+									) {
+										existing.lastWatchedAt = row.lastWatchedAt;
+									}
+									existing.watchCount += row.watchCount;
+									for (const user of watchedByUsers) {
+										if (!existing.watchedByUsers.includes(user)) {
+											existing.watchedByUsers.push(user);
+										}
+									}
+									existing.onDeck = existing.onDeck || row.onDeck;
+									if (row.userRating != null) {
+										existing.userRating =
+											existing.userRating != null
+												? Math.max(existing.userRating, row.userRating)
+												: row.userRating;
+									}
+									// Merge collections and labels
+									for (const c of collections) {
+										if (!existing.collections.includes(c)) existing.collections.push(c);
+									}
+									for (const l of labels) {
+										if (!existing.labels.includes(l)) existing.labels.push(l);
+									}
+									// Merge addedAt: take earliest (first appearance in any library)
+									if (row.addedAt && (!existing.addedAt || row.addedAt < existing.addedAt)) {
+										existing.addedAt = row.addedAt;
+									}
+								} else {
+									map.set(key, {
+										lastWatchedAt: row.lastWatchedAt,
+										watchCount: row.watchCount,
+										watchedByUsers: [...watchedByUsers],
+										onDeck: row.onDeck,
+										userRating: row.userRating,
+										collections: [...collections],
+										labels: [...labels],
+										addedAt: row.addedAt,
+										sections: [sectionInfo],
+									});
 								}
+							} catch (rowErr) {
+								log.warn(
+									{ err: rowErr, tmdbId: row.tmdbId },
+									"Skipping Plex cache row with bad data",
+								);
 							}
-							existing.onDeck = existing.onDeck || row.onDeck;
-							if (row.userRating != null) {
-								existing.userRating =
-									existing.userRating != null
-										? Math.max(existing.userRating, row.userRating)
-										: row.userRating;
-							}
-							// Merge collections and labels
-							for (const c of collections) {
-								if (!existing.collections.includes(c)) existing.collections.push(c);
-							}
-							for (const l of labels) {
-								if (!existing.labels.includes(l)) existing.labels.push(l);
-							}
-							// Merge addedAt: take earliest (first appearance in any library)
-							if (row.addedAt && (!existing.addedAt || row.addedAt < existing.addedAt)) {
-								existing.addedAt = row.addedAt;
-							}
-						} else {
-							map.set(key, {
-								lastWatchedAt: row.lastWatchedAt,
-								watchCount: row.watchCount,
-								watchedByUsers: [...watchedByUsers],
-								onDeck: row.onDeck,
-								userRating: row.userRating,
-								collections: [...collections],
-								labels: [...labels],
-								addedAt: row.addedAt,
-								sections: [sectionInfo],
-							});
 						}
-					} catch (rowErr) {
-						log.warn({ err: rowErr, tmdbId: row.tmdbId }, "Skipping Plex cache row with bad data");
-					}
-				}
-			},
-		});
+					},
+				}),
+			);
+		}
 		const generations = plexGenerationsFromEvidence(plexInstances, authoritativeEvidence);
 		if (!generations) {
 			throw new Error("Plex cache did not have a complete fresh generation for every instance");
@@ -6308,7 +6341,7 @@ async function loadPlexEpisodeDataSnapshot(
 	deps: CleanupExecutorDeps,
 	userId: string,
 ): Promise<ProviderCacheSnapshot<PlexEpisodeMap> | undefined> {
-	const { prisma, log } = deps;
+	const { log } = deps;
 
 	try {
 		const instances = await loadProviderInstances(deps, userId, ["PLEX"]);
@@ -6319,10 +6352,9 @@ async function loadPlexEpisodeDataSnapshot(
 		const episodeEvidence = [];
 		for (const instance of instances) {
 			episodeEvidence.push(
-				await loadInstanceEpisodeEvidence(prisma, {
+				await cleanupPlexAuthority(deps).readInstanceEpisodes({
 					userId,
 					instanceId: instance.id,
-					instance,
 					maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
 				}),
 			);
@@ -6823,10 +6855,10 @@ export async function prefetchFreshPlexEpisodeWatchData(
 		const repositoryEvidence = [];
 		for (const instance of plexInstances) {
 			repositoryEvidence.push(
-				await loadInstanceEpisodeEvidence(deps.prisma, {
+				await cleanupPlexAuthority(deps).readInstanceEpisodes({
 					userId: instance.userId,
 					instanceId: instance.id,
-					instance,
+					mutation: true,
 					now,
 					maxAgeMs: PLEX_EPISODE_FRESHNESS_MS,
 				}),

--- a/apps/api/src/lib/library-cleanup/provider-cache-evidence.ts
+++ b/apps/api/src/lib/library-cleanup/provider-cache-evidence.ts
@@ -1,5 +1,5 @@
 import type { Prisma, ServiceInstance } from "../prisma.js";
-import { loadInstanceEpisodeEvidence } from "../plex/plex-evidence-repository.js";
+import type { PlexAuthorityService } from "../plex/plex-authority-service.js";
 
 export const PROVIDER_CACHE_ROW_SELECTS = {
 	plex: {
@@ -122,6 +122,7 @@ export async function loadExactProviderCacheRows(
 	instanceIds: string[],
 	userId?: string,
 	instances?: ServiceInstance[],
+	plexAuthority?: PlexAuthorityService,
 ): Promise<Map<string, unknown[]>> {
 	const where = { instanceId: { in: instanceIds } };
 	switch (cacheType) {
@@ -132,13 +133,26 @@ export async function loadExactProviderCacheRows(
 			return groupProviderRowsByInstance(instanceIds, []);
 		}
 		case "plex_episode": {
-			if (!userId || !instances) return groupProviderRowsByInstance(instanceIds, []);
+			if (!userId || !instances || !plexAuthority) {
+				return groupProviderRowsByInstance(instanceIds, []);
+			}
 			const rows = [];
 			for (const instance of instances.filter((candidate) => instanceIds.includes(candidate.id))) {
-				const evidence = await loadInstanceEpisodeEvidence(tx as never, {
+				const parent = await plexAuthority.readInstance({
 					userId,
 					instanceId: instance.id,
-					instance,
+					domains: ["membership", "episode-parents"],
+				});
+				if (!parent.available) return groupProviderRowsByInstance(instanceIds, []);
+				const showTmdbIds = [
+					...new Set(
+						parent.rows.filter((row) => row.mediaType === "series").map((row) => row.tmdbId),
+					),
+				];
+				const evidence = await plexAuthority.readInstanceSelectedEpisodes({
+					userId,
+					instanceId: instance.id,
+					showTmdbIds,
 				});
 				if (!evidence.available) return groupProviderRowsByInstance(instanceIds, []);
 				rows.push(...evidence.rows);

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -14,10 +14,7 @@ import type {
 import { evidenceFingerprint } from "../evidence-fingerprint.js";
 import { createOwnedJellyfinPublicationSnapshot } from "../jellyfin/jellyfin-cache-refresher.js";
 import { createOwnedPlexPublicationSnapshot } from "../plex/plex-cache-refresher.js";
-import {
-	loadInstanceEpisodeEvidence,
-	scanMutationPolicyEvidenceForOwnedInstances,
-} from "../plex/plex-evidence-repository.js";
+import { PlexAuthorityService } from "../plex/plex-authority-service.js";
 import {
 	createPlexClient,
 	type PlexClient,
@@ -1290,13 +1287,14 @@ function isCurrentProviderExecutionInstance(instance: ServiceInstance): boolean 
 }
 
 async function loadProviderExecutionEvidence(
-	prisma: CleanupExecutorDeps["prisma"],
+	deps: CleanupExecutorDeps,
 	userId: string,
 	dependencies: string[],
 	cacheTypes: ProviderCacheType[],
 	now: Date,
 	target?: Pick<ProviderScanTarget, "instanceId" | "service">,
 ): Promise<{ evidence: SanitizedProviderEvidence; instances: ServiceInstance[] }> {
+	const { prisma } = deps;
 	const services = providerCacheServicesForDependencies(dependencies);
 	const uniqueCacheTypes = [...new Set(cacheTypes)];
 	if (
@@ -1377,8 +1375,16 @@ async function loadProviderExecutionEvidence(
 			let plexRowAuthority: { rowCount: number; rowFingerprint: string } | undefined;
 			const isPlexEvidence = cacheType === "plex" || cacheType === "plex_episode";
 			if (cacheType === "plex") {
-				const [current] = await scanMutationPolicyEvidenceForOwnedInstances(prisma as never, {
-					instances: [instance],
+				const current = await new PlexAuthorityService({
+					prisma,
+					...(deps.encryptor ? { encryptor: deps.encryptor } : {}),
+					log: deps.log,
+					...(deps.plexCacheClientFactory ? { createClient: deps.plexCacheClientFactory } : {}),
+				}).scanInstancePolicy({
+					userId,
+					instanceId: instance.id,
+					domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+					mutation: true,
 					now,
 					maxAgeMs: PROVIDER_EXECUTION_EVIDENCE_FRESHNESS_MS,
 				});
@@ -1395,10 +1401,15 @@ async function loadProviderExecutionEvidence(
 					rowFingerprint: current.rowFingerprint,
 				};
 			} else if (cacheType === "plex_episode") {
-				const current = await loadInstanceEpisodeEvidence(prisma as never, {
+				const current = await new PlexAuthorityService({
+					prisma,
+					...(deps.encryptor ? { encryptor: deps.encryptor } : {}),
+					log: deps.log,
+					...(deps.plexCacheClientFactory ? { createClient: deps.plexCacheClientFactory } : {}),
+				}).readInstanceEpisodes({
 					userId,
 					instanceId: instance.id,
-					instance,
+					mutation: true,
 					now,
 					maxAgeMs: PROVIDER_EXECUTION_EVIDENCE_FRESHNESS_MS,
 				});
@@ -1470,7 +1481,7 @@ async function loadProviderExecutionEvidence(
 }
 
 async function loadCurrentProviderExecutionEvidence(
-	prisma: CleanupExecutorDeps["prisma"],
+	deps: CleanupExecutorDeps,
 	userId: string,
 	accepted: SanitizedProviderEvidence,
 	now: Date,
@@ -1481,7 +1492,7 @@ async function loadCurrentProviderExecutionEvidence(
 		throw new ProviderExecutionAuthorityChangedError();
 	}
 	return loadProviderExecutionEvidence(
-		prisma,
+		deps,
 		userId,
 		accepted.dependencies,
 		cacheTypes as ProviderCacheType[],
@@ -1505,7 +1516,7 @@ export async function captureCurrentProviderScanAuthority(
 
 		const cacheType: ProviderCacheType = target.service === "PLEX" ? "plex" : "jellyfin";
 		const current = await loadProviderExecutionEvidence(
-			deps.prisma,
+			deps,
 			userId,
 			[cacheType],
 			[cacheType],
@@ -1551,7 +1562,7 @@ export async function createCurrentProviderScanAuthority(
 			acceptedSources.map(({ fingerprint: _fingerprint, ...source }) => source),
 		);
 		const current = await loadCurrentProviderExecutionEvidence(
-			deps.prisma,
+			deps,
 			userId,
 			targetRequest,
 			new Date(),
@@ -1729,7 +1740,7 @@ async function authorizeProviderEvidence(
 		}
 		await assertLease?.();
 		const before = await loadCurrentProviderExecutionEvidence(
-			deps.prisma,
+			deps,
 			userId,
 			accepted,
 			new Date(),
@@ -1774,7 +1785,7 @@ async function authorizeProviderEvidence(
 					}
 				}
 				const current = await loadCurrentProviderExecutionEvidence(
-					tx as unknown as CleanupExecutorDeps["prisma"],
+					{ ...deps, prisma: tx as unknown as CleanupExecutorDeps["prisma"] },
 					userId,
 					accepted,
 					new Date(),
@@ -3795,12 +3806,19 @@ async function verifyEpisodePlexWatchProof(
 		(instance) => instance.service === "PLEX" && instance.enabled === true,
 	);
 	const policyEvidence = [];
+	const authority = new PlexAuthorityService({
+		prisma: deps.prisma,
+		...(deps.encryptor ? { encryptor: deps.encryptor } : {}),
+		log: deps.log,
+		...(deps.plexCacheClientFactory ? { createClient: deps.plexCacheClientFactory } : {}),
+	});
 	for (const instance of enabledPlexInstances) {
 		policyEvidence.push(
-			await loadInstanceEpisodeEvidence(deps.prisma, {
+			await authority.readInstanceSelectedEpisodes({
 				userId: instance.userId,
 				instanceId: instance.id,
-				instance,
+				showTmdbIds: [showTmdbId],
+				mutation: true,
 				maxAgeMs: 24 * 60 * 60 * 1000,
 			}),
 		);
@@ -4016,10 +4034,11 @@ async function verifyEpisodePlexWatchProof(
 		if (!Number.isFinite(plexUpdatedAt) || approvedRefreshedAt.getTime() < plexUpdatedAt) {
 			continue;
 		}
-		const currentGeneration = await loadInstanceEpisodeEvidence(deps.prisma, {
+		const currentGeneration = await authority.readInstanceSelectedEpisodes({
 			userId: plexInstance.userId,
 			instanceId: plexInstance.id,
-			instance: plexInstance,
+			showTmdbIds: [showTmdbId],
+			mutation: true,
 			maxAgeMs: 24 * 60 * 60 * 1000,
 		});
 		const currentEvidence = currentGeneration.available

--- a/apps/api/src/lib/notifications/insights-digest.ts
+++ b/apps/api/src/lib/notifications/insights-digest.ts
@@ -8,10 +8,9 @@
 
 import type { FastifyBaseLogger } from "fastify";
 import type { ArrClientFactory } from "../arr/client-factory.js";
-import {
-	hasAuthoritativePlexEvidence,
-	scanUserPolicyEvidence,
-} from "../plex/plex-evidence-repository.js";
+import type { Encryptor } from "../auth/encryption.js";
+import { hasAuthoritativePlexEvidence } from "../plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../plex/plex-authority-service.js";
 import type { PrismaClient } from "../prisma.js";
 import {
 	passthroughTickWrapper,
@@ -37,6 +36,7 @@ export class InsightsDigestScheduler {
 		private prisma: PrismaClient,
 		private logger: FastifyBaseLogger,
 		private arrClientFactory: ArrClientFactory,
+		private encryptor: Encryptor,
 		private notifyFn?: (payload: NotificationPayload) => Promise<void>,
 		options?: { trackTick?: TickWrapper },
 	) {
@@ -161,8 +161,13 @@ export class InsightsDigestScheduler {
 
 		// Get Plex watch data
 		const plexWatchCounts = new Map<string, number>();
-		const plexEvidence = await scanUserPolicyEvidence(this.prisma, {
+		const plexEvidence = await new PlexAuthorityService({
+			prisma: this.prisma,
+			encryptor: this.encryptor,
+			log: this.logger,
+		}).scanUserPolicy({
 			userId,
+			domains: ["membership", "watch"],
 			onBatch: ({ rows }) => {
 				for (const row of rows) {
 					const key = `${row.mediaType}:${row.tmdbId}`;
@@ -258,8 +263,13 @@ export class InsightsDigestScheduler {
 	): Promise<Array<{ title: string; watchCount: number }>> {
 		// Get Plex watch data
 		const plexWatchData = new Map<string, { watchCount: number }>();
-		const plexEvidence = await scanUserPolicyEvidence(this.prisma, {
+		const plexEvidence = await new PlexAuthorityService({
+			prisma: this.prisma,
+			encryptor: this.encryptor,
+			log: this.logger,
+		}).scanUserPolicy({
 			userId,
+			domains: ["membership", "watch"],
 			onBatch: ({ rows }) => {
 				for (const row of rows) {
 					const key = `${row.mediaType}:${row.tmdbId}`;

--- a/apps/api/src/lib/plex/__tests__/plex-authority-architecture.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-architecture.test.ts
@@ -1,0 +1,95 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const rawObservationImportAllowlist = new Set([
+	path.normalize("src/lib/plex/plex-authority-service.ts"),
+	path.normalize("src/lib/plex/plex-persisted-observation-repository.ts"),
+]);
+const directMetadataMutationAllowlist = new Set([
+	path.normalize("src/lib/plex/plex-authority-service.ts"),
+]);
+const fixedPointMutationConsumers = [
+	path.normalize("src/lib/label-sync/dest-writers/plex-writer.ts"),
+	path.normalize("src/routes/plex/collection-routes.ts"),
+];
+
+async function productionTypeScriptFiles(directory: string): Promise<string[]> {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			if (
+				["__tests__", "fixtures", "generated", "node_modules", "dist", ".next"].includes(entry.name)
+			) {
+				continue;
+			}
+			files.push(...(await productionTypeScriptFiles(absolute)));
+			continue;
+		}
+		if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) continue;
+		files.push(absolute);
+	}
+	return files;
+}
+
+function findPlexAuthorityViolations(relative: string, source: string): string[] {
+	const normalized = path.normalize(relative);
+	const violations: string[] = [];
+	if (
+		/from\s+["'][^"']*plex-evidence-repository\.js["']/.test(source) &&
+		!rawObservationImportAllowlist.has(normalized)
+	) {
+		violations.push("imports the raw persisted-observation repository");
+	}
+	if (
+		/\.updateMetadataTags\s*\(/.test(source) &&
+		!directMetadataMutationAllowlist.has(normalized)
+	) {
+		violations.push("performs a direct Plex metadata mutation");
+	}
+	if (
+		fixedPointMutationConsumers.includes(normalized) &&
+		!/\.mutateMetadataTag\s*\(/.test(source)
+	) {
+		violations.push("bypasses PlexAuthorityService.mutateMetadataTag");
+	}
+	return violations;
+}
+
+describe("Plex authority architecture", () => {
+	it("keeps raw observations and upstream metadata writes behind approved boundaries", async () => {
+		const sourceRoot = path.resolve(process.cwd(), "src");
+		const violations: string[] = [];
+		for (const file of await productionTypeScriptFiles(sourceRoot)) {
+			const relative = path.normalize(path.relative(process.cwd(), file));
+			const source = await readFile(file, "utf8");
+			for (const violation of findPlexAuthorityViolations(relative, source)) {
+				violations.push(`${relative}: ${violation}`);
+			}
+		}
+		expect(violations, violations.join("\n")).toEqual([]);
+	});
+
+	it("detects representative raw-read, direct-write, and fixed-point bypass violations", () => {
+		expect(
+			findPlexAuthorityViolations(
+				"src/routes/plex/example.ts",
+				'import { loadInstanceEvidence } from "../../lib/plex/plex-evidence-repository.js";',
+			),
+		).toContain("imports the raw persisted-observation repository");
+		expect(
+			findPlexAuthorityViolations(
+				"src/routes/plex/example.ts",
+				"await plexClient.updateMetadataTags(key, type, action, name);",
+			),
+		).toContain("performs a direct Plex metadata mutation");
+		expect(
+			findPlexAuthorityViolations(
+				"src/lib/label-sync/dest-writers/plex-writer.ts",
+				"await plexClient.request('/library/metadata/1');",
+			),
+		).toContain("bypasses PlexAuthorityService.mutateMetadataTag");
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PlexCanonicalObservation } from "../plex-canonical-projection.js";
+
+const repositoryMocks = vi.hoisted(() => ({
+	loadInstanceSelectedEvidence: vi.fn(),
+}));
+
+vi.mock("../plex-evidence-repository.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../plex-evidence-repository.js")>();
+	return {
+		...actual,
+		loadInstanceSelectedEvidence: repositoryMocks.loadInstanceSelectedEvidence,
+	};
+});
+
 import {
 	plexEpisodeParentAuthorityChanged,
 	PlexAuthorityService,
@@ -25,6 +38,25 @@ const musicSection = {
 	refreshing: false,
 	scannedAt: 1_777_000_000,
 	updatedAt: 1_777_000_100,
+};
+const secondMovieSection = {
+	...section,
+	key: "movies-b",
+	uuid: "movies-b-uuid",
+	title: "Movies B",
+};
+const firstShowSection = {
+	...section,
+	key: "shows-a",
+	uuid: "shows-a-uuid",
+	title: "Shows A",
+	type: "show" as const,
+};
+const secondShowSection = {
+	...firstShowSection,
+	key: "shows-b",
+	uuid: "shows-b-uuid",
+	title: "Shows B",
 };
 const rowA: PlexCanonicalObservation = {
 	sectionId: "movies",
@@ -95,7 +127,6 @@ async function settle(
 			| { kind: "targets"; targets: Array<{ mediaType: string; tmdbId: number }> };
 		domains?: Array<"membership" | "labels" | "watch">;
 		mutation?: boolean;
-		requireCompleteSectionCatalog?: boolean;
 	} = {},
 ) {
 	const before = input.persisted ?? persisted();
@@ -110,9 +141,7 @@ async function settle(
 		persisted: before,
 		selection: input.selection ?? { kind: "all" },
 		domains: input.domains ?? ["membership", "labels", "watch"],
-		selectedSectionKeys: ["movies"],
 		mutation: input.mutation ?? false,
-		requireCompleteSectionCatalog: input.requireCompleteSectionCatalog ?? false,
 		loadProbe: vi.fn(async () => {
 			const value = probes.shift();
 			if (value instanceof Error) throw value;
@@ -330,10 +359,11 @@ describe("PlexAuthorityService settlement window", () => {
 	it("23. unrelated watch-domain changes preserve selected label authority", async () => {
 		await expect(
 			settle({
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
 				domains: ["membership", "labels"],
 				fresh: [
-					[{ ...rowA, watchCount: 99 }, rowB],
-					[{ ...rowA, watchCount: 99 }, rowB],
+					[rowA, { ...rowB, watchCount: 99 }],
+					[rowA, { ...rowB, watchCount: 99 }],
 				],
 			}),
 		).resolves.toMatchObject({ ok: true });
@@ -377,7 +407,6 @@ describe("PlexAuthorityService settlement window", () => {
 			persisted: before,
 			selection: { kind: "all" },
 			domains: ["membership"],
-			selectedSectionKeys: ["movies"],
 			mutation: true,
 			loadProbe: vi.fn(async () => {
 				events.push("probe");
@@ -406,7 +435,6 @@ describe("PlexAuthorityService settlement window", () => {
 		};
 		await expect(
 			settle({
-				requireCompleteSectionCatalog: true,
 				probes: [
 					probe({
 						activities: [
@@ -431,7 +459,6 @@ describe("PlexAuthorityService settlement window", () => {
 		};
 		await expect(
 			settle({
-				requireCompleteSectionCatalog: true,
 				probes: [probe({ sections: [section, addedSection, musicSection] })],
 			}),
 		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_revision_changed" });
@@ -519,6 +546,222 @@ describe("PlexAuthorityService settlement window", () => {
 		expect(result).toMatchObject({
 			available: false,
 			evidence: { reasonCodes: ["generation_changed"] },
+		});
+	});
+
+	it("32. selected target authority rejects a scan in another persisted supported section", async () => {
+		const before = persisted({
+			metadata: {
+				...persisted().metadata,
+				itemCount: 1,
+				sections: [section, secondMovieSection],
+			},
+			rows: [rowA],
+		});
+		const scanningProbe = probe({
+			activities: [
+				{
+					type: "library.update.section",
+					Context: { librarySectionID: secondMovieSection.key },
+				},
+			],
+			sections: [section, secondMovieSection, musicSection],
+		});
+
+		await expect(
+			settle({
+				persisted: before,
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
+				domains: ["membership"],
+				probes: [scanningProbe, scanningProbe, scanningProbe],
+				fresh: [[rowA], [rowA]],
+			}),
+		).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_library_scan_in_progress",
+		});
+	});
+
+	it("33. selected target authority accepts the complete unchanged supported catalog", async () => {
+		const before = persisted({
+			metadata: {
+				...persisted().metadata,
+				itemCount: 1,
+				sections: [section, secondMovieSection],
+			},
+			rows: [rowA],
+		});
+		const settledProbe = probe({ sections: [section, secondMovieSection, musicSection] });
+
+		await expect(
+			settle({
+				persisted: before,
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
+				domains: ["membership"],
+				probes: [settledProbe, settledProbe, settledProbe],
+				fresh: [[rowA], [rowA]],
+			}),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it("34. selected target authority rejects an idle supported section absent from V3", async () => {
+		const expandedProbe = probe({ sections: [section, secondMovieSection, musicSection] });
+
+		await expect(
+			settle({
+				persisted: persisted({ rows: [rowA] }),
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
+				domains: ["membership"],
+				probes: [expandedProbe, expandedProbe, expandedProbe],
+				fresh: [[rowA], [rowA]],
+			}),
+		).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_library_revision_changed",
+		});
+	});
+
+	it("35. full exact authority rejects an active newly added supported section", async () => {
+		const expandedScanningProbe = probe({
+			activities: [
+				{
+					type: "library.update.section",
+					Context: { librarySectionID: secondMovieSection.key },
+				},
+			],
+			sections: [section, secondMovieSection, musicSection],
+		});
+
+		await expect(
+			settle({
+				probes: [expandedScanningProbe, expandedScanningProbe, expandedScanningProbe],
+			}),
+		).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_library_scan_in_progress",
+		});
+	});
+
+	it("36. selected episode parent authority rejects a scan in another supported Show section", async () => {
+		const showRow = {
+			...rowA,
+			sectionId: firstShowSection.key,
+			sectionTitle: firstShowSection.title,
+			mediaType: "series",
+		};
+		const before = persisted({
+			metadata: {
+				...persisted().metadata,
+				itemCount: 1,
+				sections: [firstShowSection, secondShowSection],
+			},
+			rows: [showRow],
+		});
+		const scanningProbe = probe({
+			activities: [
+				{
+					type: "library.update.section",
+					Context: { librarySectionID: secondShowSection.key },
+				},
+			],
+			sections: [firstShowSection, secondShowSection, musicSection],
+		});
+
+		await expect(
+			settle({
+				persisted: before,
+				selection: { kind: "targets", targets: [{ mediaType: "series", tmdbId: 1 }] },
+				domains: ["membership"],
+				probes: [scanningProbe, scanningProbe, scanningProbe],
+				fresh: [[showRow], [showRow]],
+			}),
+		).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_library_scan_in_progress",
+		});
+	});
+
+	it("37. target mutation does not reach Plex while another supported section scans", async () => {
+		const targetRow = {
+			...rowA,
+			thumb: "/library/metadata/101/thumb/1",
+		};
+		const metadata = {
+			...persisted().metadata,
+			itemCount: 1,
+			sections: [section, secondMovieSection],
+		};
+		const evidence = {
+			available: true,
+			instanceId: "plex-1",
+			instanceName: "Plex",
+			generationId: "generation-1",
+			publishedAt: new Date("2026-08-20T12:00:00.000Z"),
+			itemCount: 1,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata,
+			generationStatus: {},
+			sections: metadata.sections,
+			rows: [targetRow],
+			evidence: {
+				availability: "current",
+				authority: "authoritative",
+				attemptState: "success",
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				reasonCodes: [],
+			},
+		};
+		repositoryMocks.loadInstanceSelectedEvidence.mockResolvedValue(evidence);
+		const updateMetadataTags = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			getActivities: vi.fn().mockResolvedValue([
+				{
+					type: "library.update.section",
+					Context: { librarySectionID: secondMovieSection.key },
+				},
+			]),
+			getLibrarySettlementSections: vi
+				.fn()
+				.mockResolvedValue([section, secondMovieSection, musicSection]),
+			updateMetadataTags,
+		};
+		const service = new PlexAuthorityService({
+			prisma: {
+				serviceInstance: {
+					findFirst: vi.fn().mockResolvedValue({
+						id: "plex-1",
+						userId: "user-1",
+						service: "PLEX",
+						enabled: true,
+						expectedIdentity: "plex-machine-a",
+					}),
+				},
+			} as never,
+			log: {} as never,
+			createClient: () => client as never,
+		});
+		vi.spyOn(
+			service as unknown as {
+				freshRows: (...args: unknown[]) => Promise<readonly PlexCanonicalObservation[]>;
+			},
+			"freshRows",
+		).mockResolvedValue([targetRow]);
+		const result = await service.mutateMetadataTag({
+			userId: "user-1",
+			instanceId: "plex-1",
+			target: { mediaType: "movie", tmdbId: 1 },
+			expectedRatingKey: "101",
+			type: "label",
+			action: "add",
+			name: "Keep",
+		});
+
+		expect(updateMetadataTags).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			ok: false,
+			evidence: { reasonCodes: ["plex_library_scan_in_progress"] },
 		});
 	});
 });

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -1,0 +1,524 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PlexCanonicalObservation } from "../plex-canonical-projection.js";
+import {
+	plexEpisodeParentAuthorityChanged,
+	PlexAuthorityService,
+	PlexAuthorityUnavailableError,
+	settlePlexAuthorityWindow,
+	type PlexPersistedSelectionObservation,
+} from "../plex-authority-service.js";
+
+const section = {
+	key: "movies",
+	uuid: "movies-uuid",
+	title: "Movies",
+	type: "movie" as const,
+	refreshing: false as const,
+	scannedAt: 1_777_000_000,
+	updatedAt: 1_777_000_100,
+};
+const musicSection = {
+	key: "music",
+	uuid: "music-uuid",
+	title: "Music",
+	type: "artist",
+	refreshing: false,
+	scannedAt: 1_777_000_000,
+	updatedAt: 1_777_000_100,
+};
+const rowA: PlexCanonicalObservation = {
+	sectionId: "movies",
+	sectionTitle: "Movies",
+	mediaType: "movie",
+	tmdbId: 1,
+	ratingKey: "101",
+	title: "A",
+	labels: ["Keep"],
+	collections: [],
+	watchCount: 1,
+	watchedByUsers: ["admin"],
+	lastWatchedAt: "2026-08-20T12:00:00.000Z",
+	onDeck: false,
+	userRating: null,
+	addedAt: null,
+	thumb: null,
+};
+const rowB: PlexCanonicalObservation = {
+	...rowA,
+	tmdbId: 2,
+	ratingKey: "102",
+	title: "B",
+	labels: ["Other"],
+	watchCount: 0,
+	watchedByUsers: [],
+	lastWatchedAt: null,
+};
+
+function persisted(
+	overrides: Partial<PlexPersistedSelectionObservation> = {},
+): PlexPersistedSelectionObservation {
+	return {
+		generationId: "generation-1",
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		providerIdentity: "plex-machine-a",
+		metadata: {
+			version: 3,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			itemCount: 2,
+			canonicalizationVersion: 1,
+			sections: [section],
+			roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+		},
+		rows: [rowA, rowB],
+		...overrides,
+	};
+}
+
+function probe(overrides: Record<string, unknown> = {}) {
+	return {
+		activities: [],
+		sections: [section, musicSection],
+		...overrides,
+	};
+}
+
+async function settle(
+	input: {
+		persisted?: PlexPersistedSelectionObservation;
+		probes?: Array<ReturnType<typeof probe> | Error>;
+		fresh?: PlexCanonicalObservation[][];
+		reread?: PlexPersistedSelectionObservation;
+		selection?:
+			| { kind: "all" }
+			| { kind: "targets"; targets: Array<{ mediaType: string; tmdbId: number }> };
+		domains?: Array<"membership" | "labels" | "watch">;
+		mutation?: boolean;
+		requireCompleteSectionCatalog?: boolean;
+	} = {},
+) {
+	const before = input.persisted ?? persisted();
+	const probes = [...(input.probes ?? [probe(), probe(), probe()])];
+	const fresh = [
+		...(input.fresh ?? [
+			[rowA, rowB],
+			[rowA, rowB],
+		]),
+	];
+	return await settlePlexAuthorityWindow({
+		persisted: before,
+		selection: input.selection ?? { kind: "all" },
+		domains: input.domains ?? ["membership", "labels", "watch"],
+		selectedSectionKeys: ["movies"],
+		mutation: input.mutation ?? false,
+		requireCompleteSectionCatalog: input.requireCompleteSectionCatalog ?? false,
+		loadProbe: vi.fn(async () => {
+			const value = probes.shift();
+			if (value instanceof Error) throw value;
+			return value ?? probe();
+		}),
+		loadFreshRows: vi.fn(async () => fresh.shift() ?? [rowA, rowB]),
+		rereadPersisted: vi.fn(async () => input.reread ?? before),
+	});
+}
+
+describe("PlexAuthorityService settlement window", () => {
+	it.each([
+		[
+			1,
+			{
+				version: 1,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: null,
+				sections: [{ key: "movies", title: "Movies", type: "movie" }],
+			},
+		],
+		[
+			2,
+			{
+				version: 2,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 2,
+				sections: [{ key: "movies", title: "Movies", type: "movie" }],
+			},
+		],
+	] as const)("%s. legacy metadata cannot authorize exact evidence", async (_case, metadata) => {
+		await expect(
+			settle({ persisted: persisted({ metadata: structuredClone(metadata) as never }) }),
+		).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_settlement_metadata_missing",
+		});
+	});
+
+	it("3. settled unchanged V3 becomes authoritative", async () => {
+		await expect(settle()).resolves.toMatchObject({
+			ok: true,
+			persisted: { generationId: "generation-1" },
+		});
+	});
+
+	it("4. a relevant section scan is unavailable", async () => {
+		await expect(
+			settle({
+				probes: [
+					probe({
+						activities: [
+							{ type: "library.update.section", Context: { librarySectionID: "movies" } },
+						],
+					}),
+				],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_scan_in_progress" });
+	});
+
+	it("5. a refreshing selected section is unavailable", async () => {
+		await expect(
+			settle({ probes: [probe({ sections: [{ ...section, refreshing: true }, musicSection] })] }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_scan_in_progress" });
+	});
+
+	it("6. unattributable metadata activity blocks the instance", async () => {
+		await expect(
+			settle({ probes: [probe({ activities: [{ type: "library.update.item.metadata" }] })] }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_metadata_refresh_in_progress" });
+	});
+
+	it("7. an attributed music scan does not invalidate Movie authority", async () => {
+		await expect(
+			settle({
+				probes: [
+					probe({
+						activities: [
+							{ type: "library.update.section", Context: { librarySectionID: "music" } },
+						],
+					}),
+					probe(),
+					probe(),
+				],
+			}),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it("8. activities failure is unavailable", async () => {
+		await expect(
+			settle({ probes: [new PlexAuthorityUnavailableError("plex_activity_unavailable")] }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_activity_unavailable" });
+	});
+
+	it("9. section-state failure is unavailable", async () => {
+		await expect(
+			settle({ probes: [new PlexAuthorityUnavailableError("plex_section_state_unavailable")] }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_section_state_unavailable" });
+	});
+
+	it("10. section UUID change is unavailable", async () => {
+		await expect(
+			settle({
+				probes: [probe(), probe({ sections: [{ ...section, uuid: "changed" }, musicSection] })],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_revision_changed" });
+	});
+
+	it("11. a scan that starts after publication is unavailable", async () => {
+		await expect(
+			settle({
+				probes: [
+					probe({
+						activities: [
+							{ type: "library.update.section", Context: { librarySectionID: "movies" } },
+						],
+					}),
+				],
+			}),
+		).resolves.toMatchObject({ ok: false });
+	});
+
+	it("12. a missed completed scan with changed content is unavailable", async () => {
+		await expect(settle({ fresh: [[rowA], [rowA]] })).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_content_digest_changed",
+		});
+	});
+
+	it("13. same-second scannedAt cannot hide deletion", async () => {
+		await expect(
+			settle({ probes: [probe(), probe(), probe()], fresh: [[rowA], [rowA]] }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_content_digest_changed" });
+	});
+
+	it("14. a completed no-op scan may regain authority", async () => {
+		await expect(
+			settle({
+				probes: [
+					probe({ sections: [{ ...section, scannedAt: section.scannedAt + 1 }, musicSection] }),
+					probe({ sections: [{ ...section, scannedAt: section.scannedAt + 1 }, musicSection] }),
+					probe({ sections: [{ ...section, scannedAt: section.scannedAt + 1 }, musicSection] }),
+				],
+			}),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it("15. an addition invalidates the old generation", async () => {
+		const added = { ...rowA, tmdbId: 3, ratingKey: "103", title: "Added" };
+		await expect(
+			settle({
+				fresh: [
+					[rowA, rowB, added],
+					[rowA, rowB, added],
+				],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_content_digest_changed" });
+	});
+
+	it("16. a legitimate deletion invalidates the old generation until refresh", async () => {
+		await expect(settle({ fresh: [[rowA], [rowA]] })).resolves.toMatchObject({ ok: false });
+	});
+
+	it("17. provider identity change during the window is unavailable", async () => {
+		await expect(
+			settle({ reread: persisted({ providerIdentity: "plex-machine-b" }) }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "identity_generation_mismatch" });
+	});
+
+	it("18. connection generation change during the window is unavailable", async () => {
+		await expect(settle({ reread: persisted({ connectionGeneration: 5 }) })).resolves.toMatchObject(
+			{ ok: false, reasonCode: "connection_generation_mismatch" },
+		);
+	});
+
+	it("19. persisted generation change during the window is unavailable", async () => {
+		await expect(
+			settle({ reread: persisted({ generationId: "generation-2" }) }),
+		).resolves.toMatchObject({ ok: false, reasonCode: "generation_changed" });
+	});
+
+	it("20. preliminary and final live projections must match", async () => {
+		await expect(
+			settle({
+				fresh: [
+					[rowA, rowB],
+					[{ ...rowA, labels: ["Changed"] }, rowB],
+				],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_content_digest_changed" });
+	});
+
+	it("21. final live projection must equal the persisted selection", async () => {
+		await expect(settle({ fresh: [[rowA], [rowA]] })).resolves.toMatchObject({
+			ok: false,
+			reasonCode: "plex_content_digest_changed",
+		});
+	});
+
+	it("22. unrelated target label changes preserve selected target authority", async () => {
+		await expect(
+			settle({
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
+				domains: ["membership", "labels"],
+				fresh: [
+					[rowA, { ...rowB, labels: ["Changed"] }],
+					[rowA, { ...rowB, labels: ["Changed"] }],
+				],
+			}),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it("23. unrelated watch-domain changes preserve selected label authority", async () => {
+		await expect(
+			settle({
+				domains: ["membership", "labels"],
+				fresh: [
+					[{ ...rowA, watchCount: 99 }, rowB],
+					[{ ...rowA, watchCount: 99 }, rowB],
+				],
+			}),
+		).resolves.toMatchObject({ ok: true });
+	});
+
+	it.each([1, 2] as const)("24. V%s cannot authorize a mutation", async (version) => {
+		const metadata =
+			version === 1
+				? {
+						version: 1 as const,
+						publicationLevel: "authoritative" as const,
+						completeness: "complete" as const,
+						itemCount: null,
+						sections: [{ key: "movies", title: "Movies", type: "movie" as const }],
+					}
+				: {
+						version: 2 as const,
+						publicationLevel: "authoritative" as const,
+						completeness: "complete" as const,
+						itemCount: 2,
+						sections: [{ key: "movies", title: "Movies", type: "movie" as const }],
+					};
+		await expect(
+			settle({ persisted: persisted({ metadata }), mutation: true }),
+		).resolves.toMatchObject({ ok: false });
+	});
+
+	it("25. mutation cannot proceed while live settlement is unavailable", async () => {
+		await expect(
+			settle({
+				mutation: true,
+				probes: [probe({ activities: [{ type: "library.update.item.metadata" }] })],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_metadata_refresh_in_progress" });
+	});
+
+	it("26. makes the final live projection the terminal upstream observation", async () => {
+		const events: string[] = [];
+		const before = persisted();
+		const result = await settlePlexAuthorityWindow({
+			persisted: before,
+			selection: { kind: "all" },
+			domains: ["membership"],
+			selectedSectionKeys: ["movies"],
+			mutation: true,
+			loadProbe: vi.fn(async () => {
+				events.push("probe");
+				return probe();
+			}),
+			loadFreshRows: vi.fn(async () => {
+				events.push("fresh");
+				return [rowA, rowB];
+			}),
+			rereadPersisted: vi.fn(async () => {
+				events.push("reread");
+				return before;
+			}),
+		});
+
+		expect(result).toMatchObject({ ok: true });
+		expect(events).toEqual(["probe", "fresh", "probe", "probe", "fresh", "reread"]);
+	});
+
+	it("27. full section-catalog authority rejects a newly scanning supported section", async () => {
+		const addedSection = {
+			...section,
+			key: "new-movies",
+			uuid: "new-movies-uuid",
+			title: "New Movies",
+		};
+		await expect(
+			settle({
+				requireCompleteSectionCatalog: true,
+				probes: [
+					probe({
+						activities: [
+							{
+								type: "library.update.section",
+								Context: { librarySectionID: "new-movies" },
+							},
+						],
+						sections: [section, addedSection, musicSection],
+					}),
+				],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_scan_in_progress" });
+	});
+
+	it("28. full section-catalog authority rejects a newly idle supported section", async () => {
+		const addedSection = {
+			...section,
+			key: "new-movies",
+			uuid: "new-movies-uuid",
+			title: "New Movies",
+		};
+		await expect(
+			settle({
+				requireCompleteSectionCatalog: true,
+				probes: [probe({ sections: [section, addedSection, musicSection] })],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_library_revision_changed" });
+	});
+
+	it("29. episode parent comparison detects a changed live parent fixed point", () => {
+		const after = {
+			...persisted(),
+			rows: [{ ...rowA, ratingKey: "changed-parent" }, rowB],
+		};
+		expect(
+			plexEpisodeParentAuthorityChanged(persisted(), after, [{ tmdbId: 1, mediaType: "movie" }]),
+		).toBe("plex_content_digest_changed");
+	});
+
+	it("30. a selected target with multiple live provider identities fails closed", async () => {
+		const edition = { ...rowA, ratingKey: "edition-2" };
+		await expect(
+			settle({
+				selection: { kind: "targets", targets: [{ mediaType: "movie", tmdbId: 1 }] },
+				domains: ["membership"],
+				fresh: [
+					[rowA, edition, rowB],
+					[rowA, edition, rowB],
+				],
+			}),
+		).resolves.toMatchObject({ ok: false, reasonCode: "plex_content_digest_changed" });
+	});
+
+	it("31. the all-episodes path rejects a show added after its initial parent fixed point", async () => {
+		const initialParent = {
+			available: true,
+			instanceId: "plex-1",
+			instanceName: "Plex",
+			generationId: "parent-1",
+			publishedAt: new Date("2026-08-20T12:00:00.000Z"),
+			itemCount: 1,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: persisted().metadata,
+			generationStatus: {},
+			sections: [section],
+			rows: [{ ...rowA, mediaType: "series" }],
+			evidence: {
+				availability: "current",
+				authority: "current",
+				attemptState: "success",
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				reasonCodes: [],
+			},
+		};
+		const changedParent = {
+			...initialParent,
+			generationId: "parent-2",
+			itemCount: 2,
+			rows: [...initialParent.rows, { ...rowB, mediaType: "series", tmdbId: 3, ratingKey: "103" }],
+		};
+		const episodeEvidence = {
+			...initialParent,
+			generationId: "episode-1",
+			parentGenerationId: "parent-1",
+			rows: [],
+		};
+		const findFirst = vi.fn().mockResolvedValue({
+			id: "plex-1",
+			expectedIdentity: "plex-machine-a",
+		});
+		const service = new PlexAuthorityService({
+			prisma: { serviceInstance: { findFirst } } as never,
+			log: {} as never,
+		});
+		const readParent = vi
+			.spyOn(service, "readInstance")
+			.mockResolvedValueOnce(initialParent as never)
+			.mockResolvedValueOnce(changedParent as never);
+		vi.spyOn(service, "readInstanceSelectedEpisodes").mockResolvedValue(episodeEvidence as never);
+
+		const result = await service.readInstanceEpisodes({
+			userId: "user-1",
+			instanceId: "plex-1",
+		});
+
+		expect(readParent).toHaveBeenCalledTimes(2);
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { reasonCodes: ["generation_changed"] },
+		});
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -140,6 +140,68 @@ describe("collectPlexCacheLiveEvidence", () => {
 		expect(transaction).not.toHaveBeenCalled();
 	});
 
+	it("preserves item-level watch state when PMS has not emitted a history row", async () => {
+		const lastViewedAt = 1_723_000_123;
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "rk-1",
+					title: "Watched Movie",
+					type: "movie",
+					Guid: [{ id: "tmdb://12345" }],
+					viewCount: 3,
+					lastViewedAt,
+				},
+			]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+
+		const result = await collectPlexCacheLiveEvidence(mockClient, "inst-1", silentLog);
+
+		expect(result.snapshot?.rows).toEqual([
+			expect.objectContaining({
+				tmdbId: 12345,
+				watchCount: 3,
+				lastWatchedAt: new Date(lastViewedAt * 1000),
+			}),
+		]);
+	});
+
+	it("preserves duplicate provider identities in a fresh authority observation", async () => {
+		const mockClient = {
+			getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "rk-1",
+					title: "First copy",
+					type: "movie",
+					Guid: [{ id: "tmdb://12345" }],
+				},
+				{
+					ratingKey: "rk-2",
+					title: "Second copy",
+					type: "movie",
+					Guid: [{ id: "tmdb://12345" }],
+				},
+			]),
+			getHistory: vi.fn().mockResolvedValue([]),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck: vi.fn().mockResolvedValue([]),
+		} as unknown as PlexClient;
+
+		const result = await collectPlexCacheLiveEvidence(mockClient, "inst-1", silentLog, {
+			preserveProviderDuplicates: true,
+		});
+
+		expect(result.complete).toBe(true);
+		expect(result.snapshot?.rows.map((row) => row.ratingKey).sort()).toEqual(["rk-1", "rk-2"]);
+	});
+
 	it("keeps the previous generation when history changes after enrichment", async () => {
 		const verifyHistorySnapshot = vi.fn().mockRejectedValue(new Error("history changed"));
 		const mockClient = {

--- a/apps/api/src/lib/plex/__tests__/plex-cache-storage.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-storage.test.ts
@@ -22,6 +22,12 @@ type EpisodeParentBatchScanner = (
 	onBatch: (rows: ReadonlyArray<Record<string, unknown>>) => Promise<void> | void,
 ) => Promise<void>;
 
+type SelectedRowsReader = (
+	prisma: unknown,
+	instanceId: string,
+	selection: { kind: "on-deck" | "recently-added"; limit: number },
+) => Promise<Array<{ id: string }>>;
+
 describe("Plex policy cache storage", () => {
 	it("streams the fixed policy projection in id-cursor batches", async () => {
 		const storage = (await import("../plex-cache-storage.js")) as Record<string, unknown>;
@@ -50,6 +56,7 @@ describe("Plex policy cache storage", () => {
 					mediaType: true,
 					sectionId: true,
 					sectionTitle: true,
+					ratingKey: true,
 					lastWatchedAt: true,
 					watchCount: true,
 					watchedByUsers: true,
@@ -179,4 +186,74 @@ describe("Plex episode cache storage selection", () => {
 			expect(findMany).not.toHaveBeenCalled();
 		},
 	);
+});
+
+describe("Plex bounded value selection", () => {
+	it("applies the on-deck limit after canonical identity ordering", async () => {
+		const storage = (await import("../plex-cache-storage.js")) as Record<string, unknown>;
+		const listRows = storage.listSelectedPlexCacheRows as SelectedRowsReader;
+		const rows = [
+			{ id: "db-a", sectionId: "2", mediaType: "movie", tmdbId: 2, ratingKey: "2", onDeck: true },
+			{ id: "db-b", sectionId: "1", mediaType: "movie", tmdbId: 1, ratingKey: "1", onDeck: true },
+		];
+		const findMany = vi.fn().mockResolvedValueOnce(rows);
+
+		const selected = await listRows({ plexCache: { findMany } }, "plex-1", {
+			kind: "on-deck",
+			limit: 1,
+		});
+
+		expect(selected.map((row) => row.id)).toEqual(["db-b"]);
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 500 }));
+	});
+
+	it("uses canonical identity as the recently-added timestamp tie breaker", async () => {
+		const storage = (await import("../plex-cache-storage.js")) as Record<string, unknown>;
+		const listRows = storage.listSelectedPlexCacheRows as SelectedRowsReader;
+		const addedAt = new Date("2026-08-20T12:00:00.000Z");
+		const rows = [
+			{ id: "db-a", sectionId: "2", mediaType: "movie", tmdbId: 2, ratingKey: "2", addedAt },
+			{ id: "db-b", sectionId: "1", mediaType: "movie", tmdbId: 1, ratingKey: "1", addedAt },
+		];
+		const findMany = vi.fn().mockResolvedValueOnce(rows);
+
+		const selected = await listRows({ plexCache: { findMany } }, "plex-1", {
+			kind: "recently-added",
+			limit: 1,
+		});
+
+		expect(selected.map((row) => row.id)).toEqual(["db-b"]);
+		expect(findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 500 }));
+	});
+
+	it("preserves newest-first recently-added response ordering", async () => {
+		const storage = (await import("../plex-cache-storage.js")) as Record<string, unknown>;
+		const listRows = storage.listSelectedPlexCacheRows as SelectedRowsReader;
+		const rows = [
+			{
+				id: "older",
+				sectionId: "1",
+				mediaType: "movie",
+				tmdbId: 1,
+				ratingKey: "1",
+				addedAt: new Date("2026-08-19T12:00:00.000Z"),
+			},
+			{
+				id: "newer",
+				sectionId: "2",
+				mediaType: "movie",
+				tmdbId: 2,
+				ratingKey: "2",
+				addedAt: new Date("2026-08-20T12:00:00.000Z"),
+			},
+		];
+		const findMany = vi.fn().mockResolvedValueOnce(rows);
+
+		const selected = await listRows({ plexCache: { findMany } }, "plex-1", {
+			kind: "recently-added",
+			limit: 2,
+		});
+
+		expect(selected.map((row) => row.id)).toEqual(["newer", "older"]);
+	});
 });

--- a/apps/api/src/lib/plex/__tests__/plex-canonical-projection.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-canonical-projection.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+	PLEX_CANONICALIZATION_VERSION,
+	createPlexSelectionProjection,
+} from "../plex-canonical-projection.js";
+
+const baseRows = [
+	{
+		sectionId: "movies",
+		mediaType: "movie" as const,
+		tmdbId: 1,
+		ratingKey: "101",
+		title: "Selected",
+		labels: ["Keep", "Favorite"],
+		collections: ["A"],
+		watchCount: 2,
+		watchedByUsers: ["admin"],
+		lastWatchedAt: "2026-08-20T12:00:00.000Z",
+		onDeck: false,
+		userRating: 8,
+		addedAt: "2026-08-01T12:00:00.000Z",
+		thumb: "/library/metadata/101/thumb/1",
+	},
+	{
+		sectionId: "movies",
+		mediaType: "movie" as const,
+		tmdbId: 2,
+		ratingKey: "102",
+		title: "Unrelated",
+		labels: ["Other"],
+		collections: [],
+		watchCount: 0,
+		watchedByUsers: [],
+		lastWatchedAt: null,
+		onDeck: false,
+		userRating: null,
+		addedAt: null,
+		thumb: null,
+	},
+];
+
+const selected = {
+	kind: "targets" as const,
+	targets: [{ mediaType: "movie" as const, tmdbId: 1 }],
+};
+
+describe("Plex canonical selection projections", () => {
+	it("uses a stable explicit algorithm and set ordering", () => {
+		const first = createPlexSelectionProjection({
+			rows: baseRows,
+			selection: selected,
+			domains: ["membership", "labels", "collections", "watch"],
+		});
+		const reordered = createPlexSelectionProjection({
+			rows: [
+				{ ...baseRows[1]!, labels: [...baseRows[1]!.labels].reverse() },
+				{ ...baseRows[0]!, labels: [...baseRows[0]!.labels].reverse() },
+			],
+			selection: selected,
+			domains: ["watch", "collections", "labels", "membership"],
+		});
+
+		expect(PLEX_CANONICALIZATION_VERSION).toBe(1);
+		expect(first).toEqual(reordered);
+		expect(first.digest).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("isolates unrelated targets and unrelated domains", () => {
+		const original = createPlexSelectionProjection({
+			rows: baseRows,
+			selection: selected,
+			domains: ["membership", "labels"],
+		});
+		const unrelatedTargetChanged = createPlexSelectionProjection({
+			rows: [baseRows[0]!, { ...baseRows[1]!, labels: ["Changed"] }],
+			selection: selected,
+			domains: ["membership", "labels"],
+		});
+		const unrelatedDomainChanged = createPlexSelectionProjection({
+			rows: [{ ...baseRows[0]!, watchCount: 99 }, baseRows[1]!],
+			selection: selected,
+			domains: ["membership", "labels"],
+		});
+
+		expect(unrelatedTargetChanged).toEqual(original);
+		expect(unrelatedDomainChanged).toEqual(original);
+	});
+
+	it("changes only the meaningful selected domain", () => {
+		const original = createPlexSelectionProjection({
+			rows: baseRows,
+			selection: selected,
+			domains: ["membership", "labels", "watch"],
+		});
+		const labelChanged = createPlexSelectionProjection({
+			rows: [{ ...baseRows[0]!, labels: ["Keep"] }, baseRows[1]!],
+			selection: selected,
+			domains: ["membership", "labels", "watch"],
+		});
+		const watchChanged = createPlexSelectionProjection({
+			rows: [{ ...baseRows[0]!, watchCount: 3 }, baseRows[1]!],
+			selection: selected,
+			domains: ["membership", "labels", "watch"],
+		});
+
+		expect(labelChanged.domains.membership).toBe(original.domains.membership);
+		expect(labelChanged.domains.watch).toBe(original.domains.watch);
+		expect(labelChanged.domains.labels).not.toBe(original.domains.labels);
+		expect(watchChanged.domains.membership).toBe(original.domains.membership);
+		expect(watchChanged.domains.labels).toBe(original.domains.labels);
+		expect(watchChanged.domains.watch).not.toBe(original.domains.watch);
+	});
+
+	it("detects selected additions and deletions through membership", () => {
+		const selection = { kind: "all" as const };
+		const original = createPlexSelectionProjection({
+			rows: baseRows,
+			selection,
+			domains: ["membership"],
+		});
+		const deleted = createPlexSelectionProjection({
+			rows: [baseRows[0]!],
+			selection,
+			domains: ["membership"],
+		});
+		const added = createPlexSelectionProjection({
+			rows: [...baseRows, { ...baseRows[0]!, tmdbId: 3, ratingKey: "103", title: "Added" }],
+			selection,
+			domains: ["membership"],
+		});
+
+		expect(deleted.domains.membership).not.toBe(original.domains.membership);
+		expect(added.domains.membership).not.toBe(original.domains.membership);
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -45,16 +45,50 @@ describe("PlexClient authoritative inventory completeness", () => {
 			)
 			.mockResolvedValueOnce(
 				response({ offset: 200, size: 1, totalSize: 201, Metadata: [libraryItem(201)] }),
-			);
+			)
+			.mockResolvedValueOnce(response({ size: 200, Metadata: firstPage }))
+			.mockResolvedValueOnce(response({ size: 1, Metadata: [libraryItem(201)] }));
 		vi.stubGlobal("fetch", fetchMock);
 		const client = new PlexClient("http://plex.test", "token", log);
 
 		const items = await client.getLibraryItems("movies");
 
 		expect(items).toHaveLength(201);
-		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock).toHaveBeenCalledTimes(4);
 		const secondUrl = new URL(fetchMock.mock.calls[1]?.[0] as string);
 		expect(secondUrl.searchParams.get("X-Plex-Container-Start")).toBe("200");
+	});
+
+	it("enriches complete section rows with item-level labels and collections", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(
+				response({ offset: 0, size: 1, totalSize: 1, Metadata: [libraryItem(1)] }),
+			)
+			.mockResolvedValueOnce(
+				response({
+					size: 1,
+					Metadata: [
+						{
+							...libraryItem(1),
+							Label: [{ tag: "Family" }],
+							Collection: [{ tag: "Classics" }],
+						},
+					],
+				}),
+			);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getLibraryItems("movies")).resolves.toEqual([
+			expect.objectContaining({
+				ratingKey: "item-1",
+				Label: [{ tag: "Family" }],
+				Collection: [{ tag: "Classics" }],
+			}),
+		]);
+		const metadataUrl = new URL(fetchMock.mock.calls[1]?.[0] as string);
+		expect(metadataUrl.pathname).toBe("/library/metadata/item-1");
 	});
 
 	it("rejects a library page that stops before its declared total", async () => {
@@ -379,6 +413,150 @@ describe("PlexClient authoritative inventory completeness", () => {
 
 		const history = await client.getHistory({ maxResults: 100_000, requireComplete: true });
 		expect(history[0]?.librarySectionID).toBeUndefined();
+	});
+
+	it("returns the bounded live section settlement fields", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				response({
+					size: 1,
+					Directory: [
+						{
+							key: "1",
+							uuid: "movie-section-uuid",
+							title: "Movies",
+							type: "movie",
+							agent: "tv.plex.agents.movie",
+							refreshing: "0",
+							scannedAt: "1777000000",
+							updatedAt: 1777000100,
+						},
+					],
+				}),
+			),
+		);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getLibrarySettlementSections()).resolves.toEqual([
+			{
+				key: "1",
+				uuid: "movie-section-uuid",
+				title: "Movies",
+				type: "movie",
+				agent: "tv.plex.agents.movie",
+				refreshing: false,
+				scannedAt: 1_777_000_000,
+				updatedAt: 1_777_000_100,
+			},
+		]);
+	});
+
+	it("preserves an uninitialized section scannedAt as unavailable live state", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				response({
+					size: 1,
+					Directory: [
+						{
+							key: "6",
+							uuid: "new-movie-section-uuid",
+							title: "New Movies",
+							type: "movie",
+							refreshing: "1",
+							updatedAt: 1_777_000_100,
+						},
+					],
+				}),
+			),
+		);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getLibrarySettlementSections()).resolves.toEqual([
+			{
+				key: "6",
+				uuid: "new-movie-section-uuid",
+				title: "New Movies",
+				type: "movie",
+				refreshing: true,
+				scannedAt: null,
+				updatedAt: 1_777_000_100,
+			},
+		]);
+	});
+
+	it("sends the Plex metadata type and locks a tag field before editing it", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(new Response(null, { status: 200 }));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await client.updateMetadataTags("123", "movie", "label", "add", "Family");
+
+		const url = new URL(fetchMock.mock.calls[0]?.[0] as string);
+		expect(url.pathname).toBe("/library/metadata/123");
+		expect(url.searchParams.get("type")).toBe("1");
+		expect(url.searchParams.get("label.locked")).toBe("1");
+		expect(url.searchParams.get("label[0].tag.tag")).toBe("Family");
+		expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "PUT" });
+	});
+
+	it("loads a complete bounded activity inventory", async () => {
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			response({
+				size: 2,
+				Activity: [
+					{ type: "library.update.section", Context: { librarySectionID: 1 } },
+					{ type: "media.generate.bif" },
+				],
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getActivities()).resolves.toEqual([
+			{ type: "library.update.section", Context: { librarySectionID: "1" } },
+			{ type: "media.generate.bif" },
+		]);
+		expect(new URL(fetchMock.mock.calls[0]?.[0] as string).pathname).toBe("/activities");
+	});
+
+	it("fails closed when the activity inventory is malformed or incomplete", async () => {
+		const fetchMock = vi
+			.fn()
+			.mockResolvedValueOnce(response({ size: 1, Activity: [{ Context: {} }] }))
+			.mockResolvedValueOnce(response({ size: 2, Activity: [{ type: "media.generate.bif" }] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await expect(client.getActivities()).rejects.toThrow();
+		await expect(client.getActivities()).rejects.toThrow(/complete single-page/i);
+	});
+
+	it("shares only simultaneous ordinary activity reads and never completed results", async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => response({ size: 0, Activity: [] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		const [first, second] = await Promise.all([client.getActivities(), client.getActivities()]);
+		expect(first).toEqual([]);
+		expect(second).toEqual([]);
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+
+		await client.getActivities();
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not coalesce uncached mutation probes", async () => {
+		const fetchMock = vi.fn().mockImplementation(async () => response({ size: 0, Activity: [] }));
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("http://plex.test", "token", log);
+
+		await Promise.all([
+			client.getActivities({ uncached: true }),
+			client.getActivities({ uncached: true }),
+		]);
+		expect(fetchMock).toHaveBeenCalledTimes(2);
 	});
 
 	it("rejects inconsistent optional pagination metadata on sections and accounts", async () => {

--- a/apps/api/src/lib/plex/__tests__/plex-evidence-repository.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-evidence-repository.test.ts
@@ -13,7 +13,29 @@ import {
 import { verifiedIdentityData } from "../../services/service-identity-lifecycle.js";
 
 const now = new Date("2026-08-20T14:00:00.000Z");
-const sections = [{ key: "movies", title: "Movies", type: "movie" as const }];
+const sections = [
+	{
+		key: "movies",
+		uuid: "movies-uuid",
+		title: "Movies",
+		type: "movie" as const,
+		refreshing: false,
+		scannedAt: 1_777_000_000,
+		updatedAt: 1_777_000_100,
+	},
+];
+
+function v3Metadata(itemCount = 1) {
+	return JSON.stringify({
+		version: 3,
+		publicationLevel: "authoritative",
+		completeness: "complete",
+		itemCount,
+		canonicalizationVersion: 1,
+		sections,
+		roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+	});
+}
 
 function instance(overrides: Record<string, unknown> = {}) {
 	return {
@@ -34,6 +56,7 @@ function instance(overrides: Record<string, unknown> = {}) {
 }
 
 function status(overrides: Record<string, unknown> = {}) {
+	const itemCount = typeof overrides.itemCount === "number" ? overrides.itemCount : 1;
 	return {
 		id: "status-1",
 		instanceId: "plex-1",
@@ -41,9 +64,9 @@ function status(overrides: Record<string, unknown> = {}) {
 		lastRefreshedAt: new Date("2026-08-20T12:00:00.000Z"),
 		lastResult: "success",
 		lastErrorMessage: null,
-		itemCount: 1,
+		itemCount,
 		generationId: "generation-1",
-		generationMetadata: JSON.stringify({ sections }),
+		generationMetadata: v3Metadata(itemCount),
 		lastAttemptAt: new Date("2026-08-20T12:00:00.000Z"),
 		lastAttemptResult: "success",
 		lastAttemptErrorMessage: null,
@@ -85,9 +108,12 @@ function episodeStatus(overrides: Record<string, unknown> = {}) {
 		cacheType: "plex_episode",
 		generationId: "episode-generation-1",
 		generationMetadata: JSON.stringify({
-			version: 1,
+			version: 2,
 			parentPlexGenerationId: "generation-1",
 			parentPublicationLevel: "authoritative",
+			parentMetadataVersion: 3,
+			canonicalizationVersion: 1,
+			episodeDigest: "b".repeat(64),
 			connectionGeneration: 4,
 			identityGeneration: 9,
 		}),
@@ -688,7 +714,7 @@ describe("Plex evidence repository", () => {
 	});
 
 	it("keeps an authoritative empty generation distinct from unavailable", async () => {
-		const emptyStatus = status({ itemCount: 0, generationMetadata: JSON.stringify({ sections }) });
+		const emptyStatus = status({ itemCount: 0 });
 		const result = await load(fixture({ rows: [], statuses: [emptyStatus, { ...emptyStatus }] }));
 		expect(result).toMatchObject({ available: true, rows: [], itemCount: 0 });
 	});
@@ -1134,9 +1160,12 @@ describe("Plex episode evidence repository", () => {
 			episodeFixture({
 				episode: episodeStatus({
 					generationMetadata: JSON.stringify({
-						version: 1,
+						version: 2,
 						parentPlexGenerationId: "other-parent",
 						parentPublicationLevel: "authoritative",
+						parentMetadataVersion: 3,
+						canonicalizationVersion: 1,
+						episodeDigest: "b".repeat(64),
 						connectionGeneration: 4,
 						identityGeneration: 9,
 					}),

--- a/apps/api/src/lib/plex/__tests__/plex-generation-metadata.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-generation-metadata.test.ts
@@ -7,6 +7,33 @@ import {
 } from "../plex-generation-metadata.js";
 
 const sections = [{ key: "movies", title: "Movies", type: "movie" as const }];
+const v3Sections = [
+	{
+		key: "movies",
+		uuid: "section-uuid-movies",
+		title: "Movies",
+		type: "movie" as const,
+		refreshing: false as const,
+		scannedAt: 1_777_000_000,
+		updatedAt: 1_777_000_100,
+	},
+];
+const v3Roots = [
+	{
+		sectionKey: "movies",
+		domain: "membership" as const,
+		digest: "a".repeat(64),
+	},
+];
+const v3Metadata = JSON.stringify({
+	version: 3,
+	publicationLevel: "authoritative",
+	completeness: "complete",
+	itemCount: 1,
+	canonicalizationVersion: 1,
+	sections: v3Sections,
+	roots: v3Roots,
+});
 
 function status(overrides: Record<string, unknown> = {}) {
 	return {
@@ -17,7 +44,7 @@ function status(overrides: Record<string, unknown> = {}) {
 		lastAttemptResult: "success",
 		lastAttemptErrorMessage: null,
 		generationId: "generation-1",
-		generationMetadata: JSON.stringify({ sections }),
+		generationMetadata: v3Metadata,
 		itemCount: 1,
 		...overrides,
 	};
@@ -58,8 +85,23 @@ describe("Plex generation metadata", () => {
 		});
 	});
 
+	it("decodes a bounded V3 authoritative envelope", () => {
+		expect(decodePlexGenerationMetadata(v3Metadata)).toEqual({
+			ok: true,
+			metadata: {
+				version: 3,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				sections: v3Sections,
+				roots: v3Roots,
+			},
+		});
+	});
+
 	it.each([
-		["unknown version", JSON.stringify({ version: 3, sections }), "unknown_metadata_version"],
+		["unknown version", JSON.stringify({ version: 4, sections }), "unknown_metadata_version"],
 		["null", null, "missing_metadata"],
 		["missing", undefined, "missing_metadata"],
 		["invalid JSON", "{", "malformed_metadata"],
@@ -103,21 +145,63 @@ describe("Plex generation metadata", () => {
 		});
 	});
 
-	it("keeps top-level sections and excludes target identities in new metadata", () => {
+	it("keeps bounded section/domain roots and excludes target identities in V3 metadata", () => {
 		const parsed = JSON.parse(
-			encodeAuthoritativePlexGenerationMetadata({ sections, itemCount: 1 }),
+			encodeAuthoritativePlexGenerationMetadata({
+				sections: v3Sections,
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				roots: v3Roots,
+			}),
 		) as Record<string, unknown>;
 
 		expect(parsed).toEqual({
-			version: 2,
+			version: 3,
 			publicationLevel: "authoritative",
 			completeness: "complete",
 			itemCount: 1,
-			sections,
+			canonicalizationVersion: 1,
+			sections: v3Sections,
+			roots: v3Roots,
 		});
 		expect(parsed).not.toHaveProperty("targets");
 		expect(parsed).not.toHaveProperty("ratingKeys");
 	});
+
+	it.each([
+		["V1", JSON.stringify({ sections })],
+		[
+			"V2",
+			JSON.stringify({
+				version: 2,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 1,
+				sections,
+			}),
+		],
+	])(
+		"retains %s as historical observation without exact or mutation authority",
+		(_name, metadata) => {
+			const options = {
+				now: new Date("2026-08-20T14:00:00.000Z"),
+				maxAgeMs: 3 * 60 * 60 * 1000,
+			};
+			const historicalStatus = status({ generationMetadata: metadata });
+
+			expect(evaluatePublishedPlexGeneration(historicalStatus, options)).toMatchObject({
+				available: true,
+				evidence: {
+					availability: "last-known",
+					authority: "unavailable",
+					publicationLevel: "unavailable",
+					completeness: "unknown",
+					reasonCodes: ["plex_settlement_metadata_missing"],
+				},
+			});
+			expect(evaluatePlexMutationAuthority(historicalStatus, options).available).toBe(false);
+		},
+	);
 
 	it("keeps immutable authoritative publication facts but withholds current trust after failure", () => {
 		const result = evaluatePublishedPlexGeneration(

--- a/apps/api/src/lib/plex/__tests__/plex-live-settlement.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-live-settlement.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { evaluatePlexLiveSettlement } from "../plex-live-settlement.js";
+
+const sections = [
+	{
+		key: "1",
+		uuid: "movies-uuid",
+		title: "Movies",
+		type: "movie" as const,
+		refreshing: false,
+		scannedAt: 1_777_000_000,
+		updatedAt: 1_777_000_100,
+	},
+	{
+		key: "2",
+		uuid: "music-uuid",
+		title: "Music",
+		type: "artist" as const,
+		refreshing: false,
+		scannedAt: 1_777_000_000,
+		updatedAt: 1_777_000_100,
+	},
+];
+
+describe("Plex live settlement classification", () => {
+	it("accepts a settled supported selection", () => {
+		expect(
+			evaluatePlexLiveSettlement({ activities: [], sections, selectedSectionKeys: ["1"] }),
+		).toEqual({ settled: true, reasonCodes: [] });
+	});
+
+	it.each([
+		[
+			"supported section scan",
+			[{ type: "library.update.section", Context: { librarySectionID: "1" } }],
+			["plex_library_scan_in_progress"],
+		],
+		[
+			"unattributable metadata refresh",
+			[{ type: "library.update.item.metadata" }],
+			["plex_metadata_refresh_in_progress"],
+		],
+		[
+			"malformed library activity",
+			[{ type: "library.update.section", Context: {} }],
+			["plex_library_activity_unknown"],
+		],
+		[
+			"unknown library activity",
+			[{ type: "library.update.mystery" }],
+			["plex_library_activity_unknown"],
+		],
+	] as const)("fails closed for %s", (_name, activities, reasonCodes) => {
+		expect(
+			evaluatePlexLiveSettlement({ activities, sections, selectedSectionKeys: ["1"] }),
+		).toEqual({ settled: false, reasonCodes });
+	});
+
+	it("does not let an attributed unsupported music scan revoke Movie authority", () => {
+		expect(
+			evaluatePlexLiveSettlement({
+				activities: [{ type: "library.update.section", Context: { librarySectionID: "2" } }],
+				sections,
+				selectedSectionKeys: ["1"],
+			}),
+		).toEqual({ settled: true, reasonCodes: [] });
+	});
+
+	it("fails a refreshing supported section even without activity", () => {
+		expect(
+			evaluatePlexLiveSettlement({
+				activities: [],
+				sections: [{ ...sections[0]!, refreshing: true }, sections[1]!],
+				selectedSectionKeys: ["1"],
+			}),
+		).toEqual({ settled: false, reasonCodes: ["plex_library_scan_in_progress"] });
+	});
+
+	it("fails closed when a new supported section has no completed scan revision", () => {
+		expect(
+			evaluatePlexLiveSettlement({
+				activities: [],
+				sections: [{ ...sections[0]!, scannedAt: null }, sections[1]!],
+				selectedSectionKeys: ["1"],
+			}),
+		).toEqual({ settled: false, reasonCodes: ["plex_library_revision_changed"] });
+	});
+
+	it("ignores validated unrelated non-library activity", () => {
+		expect(
+			evaluatePlexLiveSettlement({
+				activities: [{ type: "media.generate.bif" }],
+				sections,
+				selectedSectionKeys: ["1"],
+			}),
+		).toEqual({ settled: true, reasonCodes: [] });
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
@@ -31,6 +31,12 @@ vi.mock("../plex-authority-service.js", async (importOriginal) => {
 				});
 				return result;
 			}
+
+			async scanInstanceEpisodeParentPolicy(input: {
+				onBatch?: (batch: { rows: Array<Record<string, unknown>> }) => void;
+			}) {
+				return this.scanInstancePolicy(input);
+			}
 		},
 	};
 });

--- a/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
@@ -13,7 +13,27 @@ const authority = vi.hoisted(() => ({
 	identities: [] as string[],
 	identityError: undefined as Error | undefined,
 	events: [] as string[],
+	parentScans: [] as Array<Record<string, unknown>>,
 }));
+
+vi.mock("../plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../plex-authority-service.js")>();
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			async scanInstancePolicy(input: {
+				onBatch?: (batch: { rows: Array<Record<string, unknown>> }) => void;
+			}) {
+				const result = authority.parentScans.shift();
+				if (!result) throw new Error("Parent authority scan was not configured");
+				input.onBatch?.({
+					rows: [{ tmdbId: 42, ratingKey: "show-1" }],
+				});
+				return result;
+			}
+		},
+	};
+});
 
 vi.mock("../plex-client.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../plex-client.js")>();
@@ -80,7 +100,20 @@ function ownedSnapshot(
 }
 
 function dataClient(itemCount = 1): PlexClient {
+	const settlementSections = [
+		{
+			key: "movies",
+			uuid: "movies-uuid",
+			title: "Movies",
+			type: "movie",
+			refreshing: false,
+			scannedAt: 1_777_000_000,
+			updatedAt: 1_777_000_100,
+		},
+	];
 	return {
+		getActivities: vi.fn().mockResolvedValue([]),
+		getLibrarySettlementSections: vi.fn().mockResolvedValue(settlementSections),
 		getAccounts: vi.fn(async () => {
 			authority.events.push("collect");
 			return [{ id: 1, name: "Alice" }];
@@ -164,6 +197,7 @@ describe("Plex publication authority", () => {
 		authority.identities = [];
 		authority.identityError = undefined;
 		authority.events = [];
+		authority.parentScans = [];
 		vi.stubEnv("DATABASE_URL", "file:test.db");
 	});
 
@@ -183,6 +217,7 @@ describe("Plex publication authority", () => {
 			"predicate",
 			"attempt",
 			"identity",
+			"collect",
 			"collect",
 			"identity",
 			"predicate",
@@ -221,6 +256,104 @@ describe("Plex publication authority", () => {
 				}),
 			}),
 		);
+	});
+
+	it("publishes only bounded V3 settlement metadata", async () => {
+		const fixture = prisma();
+		const result = await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+
+		expect(result).toMatchObject({ complete: true, errors: 0, upserted: 1 });
+		const successCall = fixture.tx.cacheRefreshStatus.updateMany.mock.calls.find(
+			([call]) => call.data.lastAttemptResult === "success",
+		)?.[0];
+		expect(successCall).toBeDefined();
+		const metadata = JSON.parse(
+			(successCall as unknown as { data: { generationMetadata: string } }).data.generationMetadata,
+		) as Record<string, unknown>;
+		expect(metadata).toMatchObject({
+			version: 3,
+			canonicalizationVersion: 1,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+		});
+		expect(metadata).toHaveProperty("roots");
+		expect(metadata).not.toHaveProperty("targets");
+		expect(metadata).not.toHaveProperty("ratingKeys");
+	});
+
+	it("does not publish while a supported section scan is active", async () => {
+		const fixture = prisma();
+		authority.client = {
+			...dataClient(),
+			getActivities: vi
+				.fn()
+				.mockResolvedValue([
+					{ type: "library.update.section", Context: { librarySectionID: "movies" } },
+				]),
+		} as unknown as PlexClient;
+
+		const result = await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(fixture.tx.plexCache.deleteMany).not.toHaveBeenCalled();
+		expect(fixture.tx.cacheRefreshStatus.updateMany).not.toHaveBeenCalledWith(
+			expect.objectContaining({ data: expect.objectContaining({ lastAttemptResult: "success" }) }),
+		);
+	});
+
+	it("does not publish when the post-end final canonical pass changes", async () => {
+		const fixture = prisma();
+		const client = dataClient();
+		const first = {
+			ratingKey: "movie-1",
+			title: "Movie 1",
+			type: "movie",
+			Guid: [{ id: "tmdb://42" }],
+		};
+		const changed = { ...first, title: "Changed after end probe" };
+		client.getLibraryItems = vi
+			.fn()
+			.mockResolvedValueOnce([first])
+			.mockResolvedValueOnce([first])
+			.mockResolvedValueOnce([changed])
+			.mockResolvedValueOnce([changed]);
+		authority.client = client;
+
+		const result = await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+
+		expect(result).toMatchObject({ complete: false, upserted: 0 });
+		expect(result.errorMessages.join(" ")).toMatch(/canonical.*changed/i);
+		expect(fixture.tx.plexCache.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("makes the final canonical collection the terminal upstream observation", async () => {
+		const fixture = prisma();
+		const events: string[] = [];
+		const client = dataClient();
+		client.getLibrarySettlementSections = vi.fn(async () => {
+			events.push("probe");
+			return [
+				{
+					key: "movies",
+					uuid: "movies-uuid",
+					title: "Movies",
+					type: "movie",
+					refreshing: false,
+					scannedAt: 1_777_000_000,
+					updatedAt: 1_777_000_100,
+				},
+			];
+		});
+		client.getAccounts = vi.fn(async () => {
+			events.push("collect");
+			return [{ id: 1, name: "Alice" }];
+		});
+		authority.client = client;
+
+		const result = await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+
+		expect(result).toMatchObject({ complete: true, upserted: 1 });
+		expect(events).toEqual(["probe", "collect", "probe", "probe", "collect"]);
 	});
 
 	it("durably revokes prior mutation authority before the first Plex identity read", async () => {
@@ -275,6 +408,7 @@ describe("Plex publication authority", () => {
 			"predicate",
 			"attempt",
 			"identity",
+			"collect",
 			"collect",
 			"identity",
 			"predicate",
@@ -360,8 +494,8 @@ describe("Plex publication authority", () => {
 			sectionTitle: "Shows",
 			title: "Example Show",
 			ratingKey: "show-1",
-			lastWatchedAt: parentPublishedAt,
-			watchCount: 1,
+			lastWatchedAt: null,
+			watchCount: 0,
 			watchedByUsers: "[]",
 			onDeck: false,
 			userRating: null,
@@ -386,7 +520,23 @@ describe("Plex publication authority", () => {
 			identityGeneration: 9,
 			generationId: "parent-generation-1",
 			generationMetadata: JSON.stringify({
-				sections: [{ key: "shows", title: "Shows", type: "show" }],
+				version: 3,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				sections: [
+					{
+						key: "shows",
+						uuid: "shows-uuid",
+						title: "Shows",
+						type: "show",
+						refreshing: false,
+						scannedAt: 1_777_000_000,
+						updatedAt: 1_777_000_100,
+					},
+				],
+				roots: [{ sectionKey: "shows", domain: "membership", digest: "a".repeat(64) }],
 			}),
 		};
 		const parentInstance = {
@@ -395,6 +545,22 @@ describe("Plex publication authority", () => {
 			identityVerifiedAt: new Date(0),
 			updatedAt: new Date(0),
 		};
+		authority.parentScans = [
+			{
+				available: true,
+				evidence: { publicationLevel: "authoritative", completeness: "complete" },
+				generationId: "parent-generation-1",
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+			{
+				available: true,
+				evidence: { publicationLevel: "authoritative", completeness: "complete" },
+				generationId: "parent-generation-1",
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+		];
 		const db = fixture.db as never as {
 			serviceInstance: { findFirst: ReturnType<typeof vi.fn> };
 			cacheRefreshStatus: { findMany: ReturnType<typeof vi.fn> };
@@ -406,7 +572,31 @@ describe("Plex publication authority", () => {
 			findMany: vi.fn().mockResolvedValue([parentRow]),
 			count: vi.fn().mockResolvedValue(1),
 		};
+		const parentClient = dataClient();
 		authority.client = {
+			...parentClient,
+			getLibrarySettlementSections: vi.fn().mockResolvedValue([
+				{
+					key: "shows",
+					uuid: "shows-uuid",
+					title: "Shows",
+					type: "show",
+					refreshing: false,
+					scannedAt: 1_777_000_000,
+					updatedAt: 1_777_000_100,
+				},
+			]),
+			getLibrarySections: vi
+				.fn()
+				.mockResolvedValue([{ key: "shows", title: "Shows", type: "show" }]),
+			getLibraryItems: vi.fn().mockResolvedValue([
+				{
+					ratingKey: "show-1",
+					title: "Example Show",
+					type: "show",
+					Guid: [{ id: "tmdb://42" }],
+				},
+			]),
 			getHistory: vi.fn().mockResolvedValue([
 				{
 					type: "episode",
@@ -434,6 +624,7 @@ describe("Plex publication authority", () => {
 			log,
 		});
 
+		expect(result.errorMessages).toEqual([]);
 		expect(result).toMatchObject({ complete: true, upserted: 1 });
 		expect(fixture.tx.plexEpisodeCache.createMany).toHaveBeenCalledWith({
 			data: [expect.objectContaining({ connectionGeneration: 4, identityGeneration: 9 })],

--- a/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
+++ b/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
@@ -99,6 +99,29 @@ vi.mock("../../services/provider-identity-guard.js", async (importOriginal) => {
 	};
 });
 
+vi.mock("../plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../plex-authority-service.js")>();
+	const repository = await import("../plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			constructor(
+				private readonly deps: {
+					prisma: Parameters<typeof repository.scanInstancePolicyEvidence>[0];
+				},
+			) {}
+
+			async readInstance(input: Parameters<typeof repository.scanInstancePolicyEvidence>[1]) {
+				return await repository.scanInstancePolicyEvidence(this.deps.prisma, input);
+			}
+
+			async scanInstancePolicy(input: Parameters<typeof repository.scanInstancePolicyEvidence>[1]) {
+				return await repository.scanInstancePolicyEvidence(this.deps.prisma, input);
+			}
+		},
+	};
+});
+
 const RUN_HEAP_TESTS = process.env.TEST_HEAP === "true";
 const MIB = 1024 * 1024;
 const PLEX_ITEMS = 15_000;
@@ -204,6 +227,18 @@ function reportHeap(message: string): void {
 			}));
 			plexClient = {
 				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getActivities: vi.fn().mockResolvedValue([]),
+				getLibrarySettlementSections: vi.fn().mockResolvedValue([
+					{
+						key: "1",
+						title: "Movies",
+						type: "movie",
+						uuid: "movies-uuid",
+						refreshing: false,
+						scannedAt: 1,
+						updatedAt: 1,
+					},
+				]),
 				getLibrarySections: vi
 					.fn()
 					.mockResolvedValue([{ key: "1", title: "Movies", type: "movie" }]),
@@ -448,10 +483,20 @@ function reportHeap(message: string): void {
 						generationMetadata: encodeAuthoritativePlexGenerationMetadata({
 							sections: Array.from({ length: 4 }, (_, section) => ({
 								key: `section-${section}`,
+								uuid: `section-${section}-uuid`,
 								title: `Movies ${section}`,
-								type: "movie",
+								type: "movie" as const,
+								refreshing: false as const,
+								scannedAt: 1,
+								updatedAt: 1,
 							})),
 							itemCount: PLEX_POLICY_READ_ITEMS_PER_INSTANCE,
+							canonicalizationVersion: 1,
+							roots: Array.from({ length: 4 }, (_, section) => ({
+								sectionKey: `section-${section}`,
+								domain: "membership" as const,
+								digest: "a".repeat(64),
+							})),
 						}),
 						lastAttemptAt: completedAt,
 						lastAttemptResult: "success",
@@ -517,7 +562,7 @@ function reportHeap(message: string): void {
 			expect(selectedFields).not.toHaveLength(0);
 			for (const select of selectedFields) {
 				expect(select).not.toHaveProperty("title");
-				expect(select).not.toHaveProperty("ratingKey");
+				expect(select).toHaveProperty("ratingKey", true);
 				expect(select).not.toHaveProperty("thumb");
 			}
 			expect(afterRepeatedRelease - afterFirstRelease).toBeLessThan(16 * MIB);

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -81,52 +81,52 @@ export type PlexAuthorityWindowResult =
 	| { ok: true; persisted: PlexPersistedSelectionObservation }
 	| { ok: false; reasonCode: PlexCoverageReasonCode };
 
-function selectedSectionIdentity(
-	sections: readonly PlexLiveSection[],
-	selectedSectionKeys: readonly string[],
-): string | null {
-	const byKey = new Map(sections.map((section) => [section.key, section]));
-	const identity: Array<[string, string, string, string]> = [];
-	for (const key of [...new Set(selectedSectionKeys)].sort()) {
-		const section = byKey.get(key);
-		if (!section) return null;
-		identity.push([section.key, section.uuid, section.type, section.title]);
-	}
-	return JSON.stringify(identity);
+function sectionCatalogIdentity(
+	sections: ReadonlyArray<{ key: string; uuid: string; type: string; title: string }>,
+): string {
+	return JSON.stringify(
+		sections
+			.map(
+				(section) =>
+					[section.key, section.uuid, section.type, section.title] as [
+						string,
+						string,
+						string,
+						string,
+					],
+			)
+			.sort(
+				(left, right) =>
+					left[0].localeCompare(right[0]) ||
+					left[1].localeCompare(right[1]) ||
+					left[2].localeCompare(right[2]) ||
+					left[3].localeCompare(right[3]),
+			),
+	);
 }
 
-function persistedSectionIdentity(
-	metadata: DecodedPlexGenerationMetadata,
-	selectedSectionKeys: readonly string[],
-): string | null {
+function persistedSectionCatalogIdentity(metadata: DecodedPlexGenerationMetadata): string | null {
 	if (metadata.version !== 3) return null;
-	return selectedSectionIdentity(metadata.sections, selectedSectionKeys);
+	return sectionCatalogIdentity(metadata.sections);
 }
 
 function evaluateProbe(
 	probe: PlexAuthorityProbe,
-	selectedSectionKeys: readonly string[],
 	expectedSectionIdentity: string,
-	requireCompleteSectionCatalog: boolean,
 ): PlexCoverageReasonCode | null {
 	const supportedSections = probe.sections.filter(
 		(section) =>
 			(section.type === "movie" || section.type === "show") && !isPersonalMediaSection(section),
 	);
-	const settlementSectionKeys = requireCompleteSectionCatalog
-		? supportedSections.map((section) => section.key)
-		: selectedSectionKeys;
+	const settlementSectionKeys = supportedSections.map((section) => section.key);
 	const settlement = evaluatePlexLiveSettlement({
 		activities: probe.activities,
 		sections: probe.sections,
 		selectedSectionKeys: settlementSectionKeys,
 	});
 	if (!settlement.settled) return settlement.reasonCodes[0] ?? "plex_section_state_unavailable";
-	const identity = selectedSectionIdentity(
-		requireCompleteSectionCatalog ? supportedSections : probe.sections,
-		settlementSectionKeys,
-	);
-	if (identity === null || identity !== expectedSectionIdentity) {
+	const identity = sectionCatalogIdentity(supportedSections);
+	if (identity !== expectedSectionIdentity) {
 		return "plex_library_revision_changed";
 	}
 	return null;
@@ -205,9 +205,7 @@ export async function settlePlexAuthorityWindow(input: {
 	persisted: PlexPersistedSelectionObservation;
 	selection: PlexCanonicalSelection;
 	domains: readonly PlexCanonicalDomain[];
-	selectedSectionKeys: readonly string[];
 	mutation: boolean;
-	requireCompleteSectionCatalog?: boolean;
 	loadProbe: (options: { uncached: boolean }) => Promise<PlexAuthorityProbe>;
 	loadFreshRows: (options: { uncached: boolean }) => Promise<readonly PlexCanonicalObservation[]>;
 	rereadPersisted: () => Promise<PlexPersistedSelectionObservation>;
@@ -215,32 +213,19 @@ export async function settlePlexAuthorityWindow(input: {
 	if (input.persisted.metadata.version !== 3) {
 		return { ok: false, reasonCode: "plex_settlement_metadata_missing" };
 	}
-	const expectedSectionIdentity = persistedSectionIdentity(
-		input.persisted.metadata,
-		input.selectedSectionKeys,
-	);
+	const expectedSectionIdentity = persistedSectionCatalogIdentity(input.persisted.metadata);
 	if (expectedSectionIdentity === null) {
 		return { ok: false, reasonCode: "plex_settlement_metadata_missing" };
 	}
 	const options = { uncached: input.mutation };
 	try {
 		const startProbe = await input.loadProbe(options);
-		const startReason = evaluateProbe(
-			startProbe,
-			input.selectedSectionKeys,
-			expectedSectionIdentity,
-			input.requireCompleteSectionCatalog === true,
-		);
+		const startReason = evaluateProbe(startProbe, expectedSectionIdentity);
 		if (startReason) return { ok: false, reasonCode: startReason };
 
 		const preliminaryRows = await input.loadFreshRows(options);
 		const endProbe = await input.loadProbe(options);
-		const endReason = evaluateProbe(
-			endProbe,
-			input.selectedSectionKeys,
-			expectedSectionIdentity,
-			input.requireCompleteSectionCatalog === true,
-		);
+		const endReason = evaluateProbe(endProbe, expectedSectionIdentity);
 		if (endReason) return { ok: false, reasonCode: endReason };
 
 		const preliminary = createPlexSelectionProjection({
@@ -249,12 +234,7 @@ export async function settlePlexAuthorityWindow(input: {
 			domains: input.domains,
 		});
 		const finalProbe = await input.loadProbe(options);
-		const finalReason = evaluateProbe(
-			finalProbe,
-			input.selectedSectionKeys,
-			expectedSectionIdentity,
-			input.requireCompleteSectionCatalog === true,
-		);
+		const finalReason = evaluateProbe(finalProbe, expectedSectionIdentity);
 		if (finalReason) return { ok: false, reasonCode: finalReason };
 		const finalRows = await input.loadFreshRows(options);
 
@@ -325,23 +305,6 @@ function canonicalSelection(selection: PlexCacheRowSelection): PlexCanonicalSele
 		};
 	}
 	return selection;
-}
-
-function selectionSectionKeys(
-	persisted: AvailablePersistedEvidence,
-	selection: PlexCacheRowSelection | { kind: "all" },
-): string[] {
-	const all = persisted.metadata.sections.map((section) => section.key).sort();
-	if (selection.kind !== "targets") return all;
-	const keys = new Set<string>();
-	for (const target of selection.targets) {
-		const matches = persisted.rows.filter(
-			(row) => row.tmdbId === target.tmdbId && row.mediaType === target.mediaType,
-		);
-		if (matches.length === 0) return all;
-		for (const row of matches) keys.add(row.sectionId);
-	}
-	return [...keys].sort();
 }
 
 function persistedObservation(
@@ -482,9 +445,7 @@ export class PlexAuthorityService {
 			persisted: before,
 			selection,
 			domains: input.domains,
-			selectedSectionKeys: selectionSectionKeys(input.before, input.selection),
 			mutation: input.mutation,
-			requireCompleteSectionCatalog: input.selection.kind === "authority-only",
 			loadProbe: async ({ uncached }) => await this.probe(client, uncached),
 			loadFreshRows: async () => await this.freshRows(client, input.instanceId),
 			rereadPersisted: async () => {
@@ -914,15 +875,10 @@ export class PlexAuthorityService {
 			metadata: parent.metadata,
 			rows: canonicalEpisodeRows(before.rows, parent.rows),
 		};
-		const selectedSectionKeys = selectionSectionKeys(parent, {
-			kind: "targets",
-			targets: showTargets,
-		});
 		const window = await settlePlexAuthorityWindow({
 			persisted: initialObservation,
 			selection: { kind: "all" },
 			domains: ["episodes"],
-			selectedSectionKeys,
 			mutation: input.mutation === true,
 			loadProbe: async ({ uncached }) => await this.probe(client, uncached),
 			loadFreshRows: async () => {

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -1,0 +1,952 @@
+import type { PlexCanonicalDomain, PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
+import type { FastifyBaseLogger } from "fastify";
+import type { Encryptor } from "../auth/encryption.js";
+import type { PrismaClientInstance, ServiceInstance } from "../prisma.js";
+import { collectPlexCacheLiveEvidence, isPersonalMediaSection } from "./plex-cache-refresher.js";
+import type { PlexCacheRowSelection } from "./plex-cache-storage.js";
+import { createPlexClient, type PlexClient } from "./plex-client.js";
+import { collectPlexEpisodeLiveEvidence } from "./plex-episode-live-collector.js";
+import {
+	createPlexSelectionProjection,
+	type PlexCanonicalObservation,
+	type PlexCanonicalSelection,
+} from "./plex-canonical-projection.js";
+import type { DecodedPlexGenerationMetadata } from "./plex-generation-metadata.js";
+import {
+	evaluatePlexLiveSettlement,
+	type PlexLiveActivity,
+	type PlexLiveSection,
+} from "./plex-live-settlement.js";
+import {
+	isCurrentAuthoritativePlexEvidence,
+	loadInstanceEvidence,
+	loadInstanceSelectedEpisodeEvidence,
+	loadInstanceSelectedEvidence,
+	scanInstancePolicyEvidence,
+	type AvailablePlexInstanceEvidence,
+	type AvailableSelectedPlexEvidence,
+	type PlexInstanceEvidence,
+	type PlexPolicyBatchHandler,
+	type PlexPolicyScanEvidence,
+	type SelectedPlexEvidence,
+	type SelectedPlexEpisodeEvidence,
+	type UnavailablePlexInstanceEvidence,
+} from "./plex-evidence-repository.js";
+import { plexConnectionFingerprint } from "./service-instance-fingerprint.js";
+
+export {
+	hasAuthoritativePlexEvidence,
+	hasAuthoritativeSelectedPlexEvidence,
+	hasCompleteAuthoritativePlexEvidence,
+	isCurrentAuthoritativePlexEvidence,
+	listPublishedSections,
+	summarizePlexEvidence,
+} from "./plex-evidence-repository.js";
+export type {
+	AvailablePlexInstanceEvidence,
+	AvailablePlexPolicyEvidence,
+	PlexInstanceEvidence,
+	PlexPolicyScanEvidence,
+	SelectedPlexEvidence,
+	SelectedPlexEpisodeEvidence,
+} from "./plex-evidence-repository.js";
+export { DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS } from "./plex-evidence-repository.js";
+
+export type PlexPersistedSelectionObservation = {
+	generationId: string;
+	connectionGeneration: number;
+	identityGeneration: number;
+	providerIdentity: string;
+	metadata: DecodedPlexGenerationMetadata;
+	rows: readonly PlexCanonicalObservation[];
+};
+
+export type PlexAuthorityProbe = {
+	activities: readonly PlexLiveActivity[];
+	sections: readonly PlexLiveSection[];
+};
+
+export class PlexAuthorityUnavailableError extends Error {
+	constructor(readonly reasonCode: PlexCoverageReasonCode) {
+		super(reasonCode);
+		this.name = "PlexAuthorityUnavailableError";
+	}
+}
+
+export type PlexAuthorityWindowResult =
+	| { ok: true; persisted: PlexPersistedSelectionObservation }
+	| { ok: false; reasonCode: PlexCoverageReasonCode };
+
+function selectedSectionIdentity(
+	sections: readonly PlexLiveSection[],
+	selectedSectionKeys: readonly string[],
+): string | null {
+	const byKey = new Map(sections.map((section) => [section.key, section]));
+	const identity: Array<[string, string, string, string]> = [];
+	for (const key of [...new Set(selectedSectionKeys)].sort()) {
+		const section = byKey.get(key);
+		if (!section) return null;
+		identity.push([section.key, section.uuid, section.type, section.title]);
+	}
+	return JSON.stringify(identity);
+}
+
+function persistedSectionIdentity(
+	metadata: DecodedPlexGenerationMetadata,
+	selectedSectionKeys: readonly string[],
+): string | null {
+	if (metadata.version !== 3) return null;
+	return selectedSectionIdentity(metadata.sections, selectedSectionKeys);
+}
+
+function evaluateProbe(
+	probe: PlexAuthorityProbe,
+	selectedSectionKeys: readonly string[],
+	expectedSectionIdentity: string,
+	requireCompleteSectionCatalog: boolean,
+): PlexCoverageReasonCode | null {
+	const supportedSections = probe.sections.filter(
+		(section) =>
+			(section.type === "movie" || section.type === "show") && !isPersonalMediaSection(section),
+	);
+	const settlementSectionKeys = requireCompleteSectionCatalog
+		? supportedSections.map((section) => section.key)
+		: selectedSectionKeys;
+	const settlement = evaluatePlexLiveSettlement({
+		activities: probe.activities,
+		sections: probe.sections,
+		selectedSectionKeys: settlementSectionKeys,
+	});
+	if (!settlement.settled) return settlement.reasonCodes[0] ?? "plex_section_state_unavailable";
+	const identity = selectedSectionIdentity(
+		requireCompleteSectionCatalog ? supportedSections : probe.sections,
+		settlementSectionKeys,
+	);
+	if (identity === null || identity !== expectedSectionIdentity) {
+		return "plex_library_revision_changed";
+	}
+	return null;
+}
+
+function stateChanged(
+	before: PlexPersistedSelectionObservation,
+	after: PlexPersistedSelectionObservation,
+): PlexCoverageReasonCode | null {
+	if (after.connectionGeneration !== before.connectionGeneration) {
+		return "connection_generation_mismatch";
+	}
+	if (
+		after.identityGeneration !== before.identityGeneration ||
+		after.providerIdentity !== before.providerIdentity
+	) {
+		return "identity_generation_mismatch";
+	}
+	if (after.generationId !== before.generationId) return "generation_changed";
+	if (JSON.stringify(after.metadata) !== JSON.stringify(before.metadata))
+		return "generation_changed";
+	return null;
+}
+
+export function plexEpisodeParentAuthorityChanged(
+	before: PlexPersistedSelectionObservation,
+	after: PlexPersistedSelectionObservation,
+	targets: Array<{ mediaType: string; tmdbId: number }>,
+): PlexCoverageReasonCode | null {
+	const changed = stateChanged(before, after);
+	if (changed) return changed;
+	const selection = { kind: "targets" as const, targets };
+	const domains: PlexCanonicalDomain[] = ["membership", "episode-parents", "watch"];
+	const beforeProjection = createPlexSelectionProjection({
+		rows: before.rows,
+		selection,
+		domains,
+	});
+	const afterProjection = createPlexSelectionProjection({
+		rows: after.rows,
+		selection,
+		domains,
+	});
+	return beforeProjection.digest === afterProjection.digest ? null : "plex_content_digest_changed";
+}
+
+function completeEpisodeParentAuthorityChanged(
+	before: PlexPersistedSelectionObservation,
+	after: PlexPersistedSelectionObservation,
+): PlexCoverageReasonCode | null {
+	const changed = stateChanged(before, after);
+	if (changed) return changed;
+	const domains: PlexCanonicalDomain[] = ["membership", "episode-parents"];
+	const beforeProjection = createPlexSelectionProjection({
+		rows: before.rows,
+		selection: { kind: "all" },
+		domains,
+	});
+	const afterProjection = createPlexSelectionProjection({
+		rows: after.rows,
+		selection: { kind: "all" },
+		domains,
+	});
+	return beforeProjection.digest === afterProjection.digest ? null : "plex_content_digest_changed";
+}
+
+/**
+ * Executes the approved live observation window. Callers supply complete live
+ * rows; this function owns ordering and never exposes an intermediate success.
+ * The final row pass is the terminal upstream observation. Plex provides no
+ * atomic snapshot or scan lock, so a new change can begin after that pass; the
+ * function proves only the observed fixed point and immediately follows it with
+ * the persisted-generation reread.
+ */
+export async function settlePlexAuthorityWindow(input: {
+	persisted: PlexPersistedSelectionObservation;
+	selection: PlexCanonicalSelection;
+	domains: readonly PlexCanonicalDomain[];
+	selectedSectionKeys: readonly string[];
+	mutation: boolean;
+	requireCompleteSectionCatalog?: boolean;
+	loadProbe: (options: { uncached: boolean }) => Promise<PlexAuthorityProbe>;
+	loadFreshRows: (options: { uncached: boolean }) => Promise<readonly PlexCanonicalObservation[]>;
+	rereadPersisted: () => Promise<PlexPersistedSelectionObservation>;
+}): Promise<PlexAuthorityWindowResult> {
+	if (input.persisted.metadata.version !== 3) {
+		return { ok: false, reasonCode: "plex_settlement_metadata_missing" };
+	}
+	const expectedSectionIdentity = persistedSectionIdentity(
+		input.persisted.metadata,
+		input.selectedSectionKeys,
+	);
+	if (expectedSectionIdentity === null) {
+		return { ok: false, reasonCode: "plex_settlement_metadata_missing" };
+	}
+	const options = { uncached: input.mutation };
+	try {
+		const startProbe = await input.loadProbe(options);
+		const startReason = evaluateProbe(
+			startProbe,
+			input.selectedSectionKeys,
+			expectedSectionIdentity,
+			input.requireCompleteSectionCatalog === true,
+		);
+		if (startReason) return { ok: false, reasonCode: startReason };
+
+		const preliminaryRows = await input.loadFreshRows(options);
+		const endProbe = await input.loadProbe(options);
+		const endReason = evaluateProbe(
+			endProbe,
+			input.selectedSectionKeys,
+			expectedSectionIdentity,
+			input.requireCompleteSectionCatalog === true,
+		);
+		if (endReason) return { ok: false, reasonCode: endReason };
+
+		const preliminary = createPlexSelectionProjection({
+			rows: preliminaryRows,
+			selection: input.selection,
+			domains: input.domains,
+		});
+		const finalProbe = await input.loadProbe(options);
+		const finalReason = evaluateProbe(
+			finalProbe,
+			input.selectedSectionKeys,
+			expectedSectionIdentity,
+			input.requireCompleteSectionCatalog === true,
+		);
+		if (finalReason) return { ok: false, reasonCode: finalReason };
+		const finalRows = await input.loadFreshRows(options);
+
+		const final = createPlexSelectionProjection({
+			rows: finalRows,
+			selection: input.selection,
+			domains: input.domains,
+		});
+		if (final.digest !== preliminary.digest) {
+			return { ok: false, reasonCode: "plex_content_digest_changed" };
+		}
+		const persisted = createPlexSelectionProjection({
+			rows: input.persisted.rows,
+			selection: input.selection,
+			domains: input.domains,
+		});
+		if (final.digest !== persisted.digest) {
+			return { ok: false, reasonCode: "plex_content_digest_changed" };
+		}
+
+		const reread = await input.rereadPersisted();
+		const changed = stateChanged(input.persisted, reread);
+		if (changed) return { ok: false, reasonCode: changed };
+		return { ok: true, persisted: input.persisted };
+	} catch (error) {
+		if (error instanceof PlexAuthorityUnavailableError) {
+			return { ok: false, reasonCode: error.reasonCode };
+		}
+		return { ok: false, reasonCode: "plex_content_digest_changed" };
+	}
+}
+
+type PlexAuthorityPrisma = Pick<
+	PrismaClientInstance,
+	"serviceInstance" | "cacheRefreshStatus" | "plexCache" | "plexEpisodeCache"
+>;
+
+type AvailablePersistedEvidence = AvailablePlexInstanceEvidence | AvailableSelectedPlexEvidence;
+
+function unavailableEvidence(
+	instanceId: string,
+	base: PlexEvidenceSummary,
+	reasonCode: PlexCoverageReasonCode,
+): UnavailablePlexInstanceEvidence {
+	return {
+		available: false,
+		instanceId,
+		evidence: {
+			availability: "unavailable",
+			authority: "unavailable",
+			attemptState: base.attemptState ?? "unknown",
+			publicationLevel: "unavailable",
+			completeness: "unknown",
+			reasonCodes: [reasonCode],
+			...(base.publishedGeneration ? { publishedGeneration: base.publishedGeneration } : {}),
+		},
+	};
+}
+
+function canonicalSelection(selection: PlexCacheRowSelection): PlexCanonicalSelection {
+	if (selection.kind === "targets") {
+		return {
+			kind: "targets",
+			targets: selection.targets.map((target) => ({
+				mediaType: target.mediaType,
+				tmdbId: target.tmdbId,
+			})),
+		};
+	}
+	return selection;
+}
+
+function selectionSectionKeys(
+	persisted: AvailablePersistedEvidence,
+	selection: PlexCacheRowSelection | { kind: "all" },
+): string[] {
+	const all = persisted.metadata.sections.map((section) => section.key).sort();
+	if (selection.kind !== "targets") return all;
+	const keys = new Set<string>();
+	for (const target of selection.targets) {
+		const matches = persisted.rows.filter(
+			(row) => row.tmdbId === target.tmdbId && row.mediaType === target.mediaType,
+		);
+		if (matches.length === 0) return all;
+		for (const row of matches) keys.add(row.sectionId);
+	}
+	return [...keys].sort();
+}
+
+function persistedObservation(
+	evidence: AvailablePersistedEvidence,
+	instance: ServiceInstance,
+): PlexPersistedSelectionObservation {
+	if (!instance.expectedIdentity)
+		throw new PlexAuthorityUnavailableError("identity_generation_mismatch");
+	return {
+		generationId: evidence.generationId,
+		connectionGeneration: evidence.connectionGeneration,
+		identityGeneration: evidence.identityGeneration,
+		providerIdentity: instance.expectedIdentity,
+		metadata: evidence.metadata,
+		rows: evidence.rows,
+	};
+}
+
+function canonicalEpisodeRows(
+	rows: ReadonlyArray<{
+		showTmdbId: number;
+		seasonNumber: number;
+		episodeNumber: number;
+		ratingKey: string;
+		title: string;
+		watched: boolean;
+		watchedByUsers: string;
+		lastWatchedAt: Date | null;
+		watchCount: number | null;
+	}>,
+	parentRows: readonly PlexCanonicalObservation[],
+): PlexCanonicalObservation[] {
+	const sectionsByShow = new Map<number, Set<string>>();
+	for (const parent of parentRows) {
+		const sections = sectionsByShow.get(parent.tmdbId) ?? new Set<string>();
+		sections.add(parent.sectionId);
+		sectionsByShow.set(parent.tmdbId, sections);
+	}
+	return rows.flatMap((row) => {
+		if (row.watchCount === null) throw new Error("Incomplete Plex episode watch count");
+		return [...(sectionsByShow.get(row.showTmdbId) ?? [])].sort().map((sectionId) => ({
+			sectionId,
+			mediaType: "episode",
+			tmdbId: row.showTmdbId,
+			ratingKey: row.ratingKey,
+			title: row.title,
+			seasonNumber: row.seasonNumber,
+			episodeNumber: row.episodeNumber,
+			watched: row.watched,
+			watchedByUsers: row.watchedByUsers,
+			lastWatchedAt: row.lastWatchedAt,
+			watchCount: row.watchCount,
+		}));
+	});
+}
+
+/** Central production composition boundary for current Plex authority. */
+export class PlexAuthorityService {
+	constructor(
+		private readonly deps: {
+			prisma: PlexAuthorityPrisma;
+			encryptor?: Encryptor;
+			log: FastifyBaseLogger;
+			createClient?: (instance: ServiceInstance) => PlexClient;
+		},
+	) {}
+
+	private async ownedInstance(userId: string, instanceId: string): Promise<ServiceInstance | null> {
+		return await this.deps.prisma.serviceInstance.findFirst({
+			where: { id: instanceId, userId, service: "PLEX", enabled: true },
+		});
+	}
+
+	private client(instance: ServiceInstance): PlexClient {
+		if (this.deps.createClient) return this.deps.createClient(instance);
+		if (!this.deps.encryptor) {
+			throw new PlexAuthorityUnavailableError("plex_activity_unavailable");
+		}
+		return createPlexClient(this.deps.encryptor, instance, this.deps.log);
+	}
+
+	private async probe(client: PlexClient, uncached: boolean): Promise<PlexAuthorityProbe> {
+		let activities: PlexAuthorityProbe["activities"];
+		try {
+			activities = await client.getActivities({ uncached });
+		} catch {
+			throw new PlexAuthorityUnavailableError("plex_activity_unavailable");
+		}
+		let sections: PlexAuthorityProbe["sections"];
+		try {
+			sections = await client.getLibrarySettlementSections({ uncached });
+		} catch {
+			throw new PlexAuthorityUnavailableError("plex_section_state_unavailable");
+		}
+		return { activities, sections };
+	}
+
+	private async freshRows(client: PlexClient, instanceId: string) {
+		const result = await collectPlexCacheLiveEvidence(client, instanceId, this.deps.log, {
+			preserveProviderDuplicates: true,
+		});
+		if (!result.complete || !result.snapshot) {
+			throw new PlexAuthorityUnavailableError("plex_content_digest_changed");
+		}
+		return result.snapshot.rows;
+	}
+
+	private async settle<TAvailable extends AvailablePersistedEvidence>(input: {
+		userId: string;
+		instanceId: string;
+		before: TAvailable;
+		instance: ServiceInstance;
+		selection: PlexCacheRowSelection | { kind: "all" };
+		domains: readonly PlexCanonicalDomain[];
+		mutation: boolean;
+		reread: () => Promise<PlexInstanceEvidence | SelectedPlexEvidence>;
+		client?: PlexClient;
+	}): Promise<TAvailable | SelectedPlexEvidence> {
+		if (
+			input.before.metadata.version !== 3 ||
+			!isCurrentAuthoritativePlexEvidence(input.before.evidence)
+		) {
+			return unavailableEvidence(
+				input.instanceId,
+				input.before.evidence,
+				input.before.metadata.version === 3
+					? (input.before.evidence.reasonCodes[0] ?? "mutation_authority_unavailable")
+					: "plex_settlement_metadata_missing",
+			);
+		}
+		const client = input.client ?? this.client(input.instance);
+		const before = persistedObservation(input.before, input.instance);
+		const selection =
+			input.selection.kind === "all"
+				? ({ kind: "all" } as const)
+				: canonicalSelection(input.selection);
+		const window = await settlePlexAuthorityWindow({
+			persisted: before,
+			selection,
+			domains: input.domains,
+			selectedSectionKeys: selectionSectionKeys(input.before, input.selection),
+			mutation: input.mutation,
+			requireCompleteSectionCatalog: input.selection.kind === "authority-only",
+			loadProbe: async ({ uncached }) => await this.probe(client, uncached),
+			loadFreshRows: async () => await this.freshRows(client, input.instanceId),
+			rereadPersisted: async () => {
+				const afterEvidence = await input.reread();
+				if (!afterEvidence.available) {
+					throw new PlexAuthorityUnavailableError(
+						afterEvidence.evidence.reasonCodes[0] ?? "generation_changed",
+					);
+				}
+				const afterInstance = await this.ownedInstance(input.userId, input.instanceId);
+				if (!afterInstance) {
+					throw new PlexAuthorityUnavailableError("identity_generation_mismatch");
+				}
+				return persistedObservation(afterEvidence, afterInstance);
+			},
+		});
+		return window.ok
+			? input.before
+			: unavailableEvidence(input.instanceId, input.before.evidence, window.reasonCode);
+	}
+
+	async readInstanceSelected(input: {
+		userId: string;
+		instanceId: string;
+		selection: PlexCacheRowSelection;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<SelectedPlexEvidence> {
+		const instance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!instance) {
+			return unavailableEvidence(
+				input.instanceId,
+				{
+					availability: "unavailable",
+					authority: "unavailable",
+					attemptState: "unknown",
+					publicationLevel: "unavailable",
+					completeness: "unknown",
+					reasonCodes: ["missing_status"],
+				},
+				"missing_status",
+			);
+		}
+		const before = await loadInstanceSelectedEvidence(this.deps.prisma, {
+			userId: input.userId,
+			instanceId: input.instanceId,
+			selection: input.selection,
+			...(input.now ? { now: input.now } : {}),
+			...(input.maxAgeMs === undefined ? {} : { maxAgeMs: input.maxAgeMs }),
+		});
+		if (!before.available) return before;
+		return await this.settle({
+			...input,
+			before,
+			instance,
+			mutation: input.mutation === true,
+			reread: async () =>
+				await loadInstanceSelectedEvidence(this.deps.prisma, {
+					userId: input.userId,
+					instanceId: input.instanceId,
+					selection: input.selection,
+					...(input.now ? { now: input.now } : {}),
+					...(input.maxAgeMs === undefined ? {} : { maxAgeMs: input.maxAgeMs }),
+				}),
+		});
+	}
+
+	async readInstance(input: {
+		userId: string;
+		instanceId: string;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<PlexInstanceEvidence> {
+		const instance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!instance) {
+			return unavailableEvidence(
+				input.instanceId,
+				{
+					availability: "unavailable",
+					authority: "unavailable",
+					attemptState: "unknown",
+					publicationLevel: "unavailable",
+					completeness: "unknown",
+					reasonCodes: ["missing_status"],
+				},
+				"missing_status",
+			);
+		}
+		const before = await loadInstanceEvidence(this.deps.prisma, input);
+		if (!before.available) return before;
+		return (await this.settle({
+			...input,
+			before,
+			instance,
+			selection: { kind: "all" },
+			mutation: input.mutation === true,
+			reread: async () => await loadInstanceEvidence(this.deps.prisma, input),
+		})) as PlexInstanceEvidence;
+	}
+
+	async scanInstancePolicy(input: {
+		userId: string;
+		instanceId: string;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+		onBatch?: PlexPolicyBatchHandler;
+	}): Promise<PlexPolicyScanEvidence> {
+		const current = await this.readInstance(input);
+		if (!current.available) return current;
+		const scanned = await scanInstancePolicyEvidence(this.deps.prisma, input);
+		if (!scanned.available) return scanned;
+		if (scanned.generationId !== current.generationId) {
+			return unavailableEvidence(input.instanceId, current.evidence, "generation_changed");
+		}
+		return scanned;
+	}
+
+	async readUserSelected(input: {
+		userId: string;
+		selection: PlexCacheRowSelection;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<SelectedPlexEvidence[]> {
+		let instances: Array<{ id: string }>;
+		try {
+			instances = await this.deps.prisma.serviceInstance.findMany({
+				where: { userId: input.userId, service: "PLEX", enabled: true },
+				select: { id: true },
+				orderBy: { id: "asc" },
+			});
+		} catch {
+			return [
+				unavailableEvidence(
+					"",
+					{
+						availability: "unavailable",
+						authority: "unavailable",
+						attemptState: "unknown",
+						publicationLevel: "unavailable",
+						completeness: "unknown",
+						reasonCodes: ["query_failed"],
+					},
+					"query_failed",
+				),
+			];
+		}
+		const evidence: SelectedPlexEvidence[] = [];
+		for (const instance of instances) {
+			evidence.push(
+				await this.readInstanceSelected({
+					...input,
+					instanceId: instance.id,
+				}),
+			);
+		}
+		return evidence;
+	}
+
+	async scanUserPolicy(input: {
+		userId: string;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+		onBatch?: PlexPolicyBatchHandler;
+	}): Promise<PlexPolicyScanEvidence[]> {
+		let instances: Array<{ id: string }>;
+		try {
+			instances = await this.deps.prisma.serviceInstance.findMany({
+				where: { userId: input.userId, service: "PLEX", enabled: true },
+				select: { id: true },
+				orderBy: { id: "asc" },
+			});
+		} catch {
+			return [
+				unavailableEvidence(
+					"",
+					{
+						availability: "unavailable",
+						authority: "unavailable",
+						attemptState: "unknown",
+						publicationLevel: "unavailable",
+						completeness: "unknown",
+						reasonCodes: ["query_failed"],
+					},
+					"query_failed",
+				),
+			];
+		}
+		const evidence: PlexPolicyScanEvidence[] = [];
+		for (const instance of instances) {
+			evidence.push(await this.scanInstancePolicy({ ...input, instanceId: instance.id }));
+		}
+		return evidence;
+	}
+
+	/** Uncached selected fixed point followed immediately by Plex tag I/O. */
+	async mutateMetadataTag(input: {
+		userId: string;
+		instanceId: string;
+		target: { tmdbId: number; mediaType: "movie" | "series" };
+		expectedRatingKey?: string;
+		type: "collection" | "label";
+		action: "add" | "remove";
+		name: string;
+	}): Promise<{ ok: true } | { ok: false; evidence: PlexEvidenceSummary }> {
+		const instance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!instance) {
+			return {
+				ok: false,
+				evidence: unavailableEvidence(
+					input.instanceId,
+					{
+						availability: "unavailable",
+						authority: "unavailable",
+						attemptState: "unknown",
+						publicationLevel: "unavailable",
+						completeness: "unknown",
+						reasonCodes: ["missing_status"],
+					},
+					"missing_status",
+				).evidence,
+			};
+		}
+		const selection: PlexCacheRowSelection = { kind: "targets", targets: [input.target] };
+		const before = await loadInstanceSelectedEvidence(this.deps.prisma, {
+			userId: input.userId,
+			instanceId: input.instanceId,
+			selection,
+		});
+		if (!before.available) return { ok: false, evidence: before.evidence };
+		const client = this.client(instance);
+		const current = await this.settle({
+			userId: input.userId,
+			instanceId: input.instanceId,
+			before,
+			instance,
+			selection,
+			domains: ["membership", input.type === "label" ? "labels" : "collections"],
+			mutation: true,
+			client,
+			reread: async () =>
+				await loadInstanceSelectedEvidence(this.deps.prisma, {
+					userId: input.userId,
+					instanceId: input.instanceId,
+					selection,
+				}),
+		});
+		if (!current.available) return { ok: false, evidence: current.evidence };
+		const ratingKeys = [
+			...new Set(
+				current.rows
+					.filter(
+						(row) =>
+							row.tmdbId === input.target.tmdbId &&
+							row.mediaType === input.target.mediaType &&
+							row.ratingKey !== null &&
+							row.thumb?.match(/\/library\/metadata\/(\d+)/)?.[1] === row.ratingKey.trim(),
+					)
+					.map((row) => row.ratingKey?.trim())
+					.filter((ratingKey): ratingKey is string => Boolean(ratingKey)),
+			),
+		];
+		if (
+			ratingKeys.length !== 1 ||
+			(input.expectedRatingKey !== undefined && ratingKeys[0] !== input.expectedRatingKey)
+		) {
+			return {
+				ok: false,
+				evidence: unavailableEvidence(
+					input.instanceId,
+					current.evidence,
+					"mutation_authority_unavailable",
+				).evidence,
+			};
+		}
+		// This I/O immediately follows the terminal selected live observation.
+		// Plex has no mutation lock, so a change can begin afterward; the fixed
+		// point eliminates stale/cached authorization but cannot make Plex atomic.
+		await client.updateMetadataTags(
+			ratingKeys[0]!,
+			input.target.mediaType,
+			input.type,
+			input.action,
+			input.name,
+		);
+		return { ok: true };
+	}
+
+	async readInstanceSelectedEpisodes(input: {
+		userId: string;
+		instanceId: string;
+		showTmdbIds: number[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<SelectedPlexEpisodeEvidence> {
+		const showTargets = [...new Set(input.showTmdbIds)].map((tmdbId) => ({
+			tmdbId,
+			mediaType: "series" as const,
+		}));
+		const parent = await this.readInstanceSelected({
+			...input,
+			selection: { kind: "targets", targets: showTargets },
+			domains: ["membership", "episode-parents", "watch"],
+		});
+		if (!parent.available) return parent;
+		const instance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!instance?.expectedIdentity) {
+			return unavailableEvidence(input.instanceId, parent.evidence, "identity_generation_mismatch");
+		}
+		const before = await loadInstanceSelectedEpisodeEvidence(this.deps.prisma, input);
+		if (!before.available) return before;
+		if (before.parentGenerationId !== parent.generationId) {
+			return unavailableEvidence(
+				input.instanceId,
+				before.evidence,
+				"parent_generation_unavailable",
+			);
+		}
+		const showMap = new Map<number, Set<string>>();
+		for (const row of parent.rows) {
+			if (row.mediaType !== "series" || !row.ratingKey?.trim()) continue;
+			const ratingKeys = showMap.get(row.tmdbId) ?? new Set<string>();
+			ratingKeys.add(row.ratingKey);
+			showMap.set(row.tmdbId, ratingKeys);
+		}
+		if (showTargets.some((target) => !showMap.has(target.tmdbId))) {
+			return unavailableEvidence(
+				input.instanceId,
+				before.evidence,
+				"parent_generation_unavailable",
+			);
+		}
+		const client = this.client(instance);
+		const initialObservation: PlexPersistedSelectionObservation = {
+			generationId: `${parent.generationId}\u0000${before.generationId}`,
+			connectionGeneration: before.connectionGeneration,
+			identityGeneration: before.identityGeneration,
+			providerIdentity: instance.expectedIdentity,
+			metadata: parent.metadata,
+			rows: canonicalEpisodeRows(before.rows, parent.rows),
+		};
+		const selectedSectionKeys = selectionSectionKeys(parent, {
+			kind: "targets",
+			targets: showTargets,
+		});
+		const window = await settlePlexAuthorityWindow({
+			persisted: initialObservation,
+			selection: { kind: "all" },
+			domains: ["episodes"],
+			selectedSectionKeys,
+			mutation: input.mutation === true,
+			loadProbe: async ({ uncached }) => await this.probe(client, uncached),
+			loadFreshRows: async () => {
+				const collected = await collectPlexEpisodeLiveEvidence(
+					client,
+					showMap,
+					instance.id,
+					this.deps.log,
+					plexConnectionFingerprint(instance),
+				);
+				if (!collected.complete || !collected.rows) {
+					throw new PlexAuthorityUnavailableError("plex_content_digest_changed");
+				}
+				return canonicalEpisodeRows(collected.rows, parent.rows);
+			},
+			rereadPersisted: async () => {
+				const [parentAfter, episodeAfter, instanceAfter] = await Promise.all([
+					loadInstanceSelectedEvidence(this.deps.prisma, {
+						userId: input.userId,
+						instanceId: input.instanceId,
+						selection: { kind: "targets", targets: showTargets },
+					}),
+					loadInstanceSelectedEpisodeEvidence(this.deps.prisma, input),
+					this.ownedInstance(input.userId, input.instanceId),
+				]);
+				if (!parentAfter.available || !episodeAfter.available || !instanceAfter?.expectedIdentity) {
+					throw new PlexAuthorityUnavailableError("generation_changed");
+				}
+				return {
+					generationId: `${parentAfter.generationId}\u0000${episodeAfter.generationId}`,
+					connectionGeneration: episodeAfter.connectionGeneration,
+					identityGeneration: episodeAfter.identityGeneration,
+					providerIdentity: instanceAfter.expectedIdentity,
+					metadata: parentAfter.metadata,
+					rows: canonicalEpisodeRows(episodeAfter.rows, parentAfter.rows),
+				};
+			},
+		});
+		if (!window.ok) {
+			return unavailableEvidence(input.instanceId, before.evidence, window.reasonCode);
+		}
+
+		// Re-establish the parent fixed point after the episode observation. A
+		// completed parent-library change in the gap must not leave old episode
+		// rows bound to a parent generation that is only still present in SQLite.
+		const parentAfter = await this.readInstanceSelected({
+			...input,
+			selection: { kind: "targets", targets: showTargets },
+			domains: ["membership", "episode-parents", "watch"],
+		});
+		if (!parentAfter.available) return parentAfter;
+		const parentInstanceAfter = await this.ownedInstance(input.userId, input.instanceId);
+		if (!parentInstanceAfter?.expectedIdentity) {
+			return unavailableEvidence(input.instanceId, before.evidence, "identity_generation_mismatch");
+		}
+		const parentChanged = plexEpisodeParentAuthorityChanged(
+			persistedObservation(parent, instance),
+			persistedObservation(parentAfter, parentInstanceAfter),
+			showTargets,
+		);
+		return parentChanged
+			? unavailableEvidence(input.instanceId, before.evidence, parentChanged)
+			: before;
+	}
+
+	async readInstanceEpisodes(input: {
+		userId: string;
+		instanceId: string;
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<SelectedPlexEpisodeEvidence> {
+		const parent = await this.readInstance({
+			...input,
+			domains: ["membership", "episode-parents"],
+		});
+		if (!parent.available) return parent;
+		const parentInstance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!parentInstance?.expectedIdentity) {
+			return unavailableEvidence(input.instanceId, parent.evidence, "identity_generation_mismatch");
+		}
+		const showTmdbIds = [
+			...new Set(parent.rows.filter((row) => row.mediaType === "series").map((row) => row.tmdbId)),
+		];
+		const episodes = await this.readInstanceSelectedEpisodes({ ...input, showTmdbIds });
+		if (!episodes.available) return episodes;
+
+		const parentAfter = await this.readInstance({
+			...input,
+			domains: ["membership", "episode-parents"],
+		});
+		if (!parentAfter.available) return parentAfter;
+		const parentInstanceAfter = await this.ownedInstance(input.userId, input.instanceId);
+		if (!parentInstanceAfter?.expectedIdentity) {
+			return unavailableEvidence(
+				input.instanceId,
+				episodes.evidence,
+				"identity_generation_mismatch",
+			);
+		}
+		const parentChanged = completeEpisodeParentAuthorityChanged(
+			persistedObservation(parent, parentInstance),
+			persistedObservation(parentAfter, parentInstanceAfter),
+		);
+		return parentChanged
+			? unavailableEvidence(input.instanceId, episodes.evidence, parentChanged)
+			: episodes;
+	}
+}

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -1,6 +1,7 @@
 import type { PlexCanonicalDomain, PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { Encryptor } from "../auth/encryption.js";
+import { evidenceFingerprint } from "../evidence-fingerprint.js";
 import type { PrismaClientInstance, ServiceInstance } from "../prisma.js";
 import { collectPlexCacheLiveEvidence, isPersonalMediaSection } from "./plex-cache-refresher.js";
 import type { PlexCacheRowSelection } from "./plex-cache-storage.js";
@@ -19,14 +20,17 @@ import {
 } from "./plex-live-settlement.js";
 import {
 	isCurrentAuthoritativePlexEvidence,
+	loadInstanceEpisodeEvidence,
 	loadInstanceEvidence,
 	loadInstanceSelectedEpisodeEvidence,
 	loadInstanceSelectedEvidence,
+	scanInstanceEpisodeParentPolicyEvidence,
 	scanInstancePolicyEvidence,
 	type AvailablePlexInstanceEvidence,
 	type AvailableSelectedPlexEvidence,
 	type PlexInstanceEvidence,
 	type PlexPolicyBatchHandler,
+	type PlexEpisodeParentPolicyBatchHandler,
 	type PlexPolicyScanEvidence,
 	type SelectedPlexEvidence,
 	type SelectedPlexEpisodeEvidence,
@@ -602,6 +606,84 @@ export class PlexAuthorityService {
 			return unavailableEvidence(input.instanceId, current.evidence, "generation_changed");
 		}
 		return scanned;
+	}
+
+	async scanInstanceEpisodeParentPolicy(input: {
+		userId: string;
+		instanceId: string;
+		domains: readonly PlexCanonicalDomain[];
+		mutation?: boolean;
+		now?: Date;
+		maxAgeMs?: number;
+		onBatch?: PlexEpisodeParentPolicyBatchHandler;
+	}): Promise<PlexPolicyScanEvidence> {
+		const current = await this.readInstance(input);
+		if (!current.available) return current;
+		const scanned = await scanInstanceEpisodeParentPolicyEvidence(this.deps.prisma, input);
+		if (!scanned.available) return scanned;
+		if (scanned.generationId !== current.generationId) {
+			return unavailableEvidence(input.instanceId, current.evidence, "generation_changed");
+		}
+		return scanned;
+	}
+
+	/**
+	 * Revalidates one already-authorized persisted snapshot without contacting
+	 * Plex. This is intentionally boolean-only so callers cannot treat the
+	 * database observation as live authority.
+	 */
+	async revalidatePersistedSnapshot(input: {
+		userId: string;
+		instanceId: string;
+		cacheType: "plex" | "plex_episode";
+		expected: {
+			statusFingerprint: string;
+			rowCount: number;
+			rowFingerprint: string;
+		};
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<boolean> {
+		const instance = await this.ownedInstance(input.userId, input.instanceId);
+		if (!instance) return false;
+		let rowCount: number;
+		let rowFingerprint: string;
+		let generationStatus: AvailablePlexInstanceEvidence["generationStatus"];
+		if (input.cacheType === "plex") {
+			const current = await scanInstancePolicyEvidence(this.deps.prisma, input);
+			if (!current.available) return false;
+			rowCount = current.rowCount;
+			rowFingerprint = current.rowFingerprint;
+			generationStatus = current.generationStatus;
+		} else {
+			const current = await loadInstanceEpisodeEvidence(this.deps.prisma, {
+				...input,
+				instance,
+			});
+			if (!current.available) return false;
+			rowCount = current.rows.length;
+			rowFingerprint = evidenceFingerprint(
+				[...current.rows].sort((left, right) => left.id.localeCompare(right.id)),
+			);
+			generationStatus = current.generationStatus;
+		}
+		const statusFingerprint = evidenceFingerprint({
+			instance: {
+				id: instance.id,
+				expectedIdentity: instance.expectedIdentity,
+				identityKind: instance.identityKind,
+				identityVerifiedAt: instance.identityVerifiedAt,
+				connectionGeneration: instance.connectionGeneration,
+				identityGeneration: instance.identityGeneration,
+				updatedAt: instance.updatedAt,
+			},
+			status: generationStatus,
+		});
+		return (
+			statusFingerprint === input.expected.statusFingerprint &&
+			rowCount === input.expected.rowCount &&
+			rowFingerprint === input.expected.rowFingerprint
+		);
 	}
 
 	async readUserSelected(input: {

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -15,6 +15,11 @@
  */
 
 import { randomUUID } from "node:crypto";
+import type {
+	PlexCanonicalDomain,
+	PlexGenerationDomainRoot,
+	PlexGenerationSectionV3,
+} from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { Encryptor } from "../auth/encryption.js";
 import type { Prisma, PrismaClient, ServiceInstance } from "../prisma.js";
@@ -37,7 +42,12 @@ import {
 	publishAuthoritativePlexCacheGeneration,
 } from "./plex-cache-storage.js";
 import { PlexClient } from "./plex-client.js";
+import {
+	PLEX_CANONICALIZATION_VERSION,
+	createPlexSelectionProjection,
+} from "./plex-canonical-projection.js";
 import { encodeAuthoritativePlexGenerationMetadata } from "./plex-generation-metadata.js";
+import { evaluatePlexLiveSettlement } from "./plex-live-settlement.js";
 
 /** Bound Prisma's cached createMany query plans for production-sized libraries. */
 export const PLEX_CACHE_PUBLICATION_CHUNK_SIZE = PLEX_CACHE_WRITE_CHUNK_SIZE;
@@ -99,7 +109,7 @@ function parsePlexTvdbId(guids: Array<{ id: string }> | undefined): number | nul
  */
 const PERSONAL_MEDIA_AGENTS = new Set(["com.plexapp.agents.none"]);
 
-function isPersonalMediaSection(section: { type: string; agent?: string }): boolean {
+export function isPersonalMediaSection(section: { type: string; agent?: string }): boolean {
 	return section.agent !== undefined && PERSONAL_MEDIA_AGENTS.has(section.agent);
 }
 
@@ -173,7 +183,20 @@ export interface PlexCacheRefreshResult {
 	generationId?: string;
 	snapshot?: PlexCacheSnapshot;
 	inventoryTargets?: PlexInventoryTarget[];
+	settlement?: {
+		sections: PlexGenerationSectionV3[];
+		roots: PlexGenerationDomainRoot[];
+	};
 }
+
+const PLEX_CACHE_CANONICAL_DOMAINS = [
+	"membership",
+	"display",
+	"labels",
+	"collections",
+	"watch",
+	"on-deck",
+] as const satisfies readonly PlexCanonicalDomain[];
 
 function onDeckSignature(items: Awaited<ReturnType<PlexClient["getOnDeck"]>>): string[] {
 	return items
@@ -208,6 +231,8 @@ function libraryInventoryItemSignature(
 		item.title,
 		item.userRating ?? null,
 		item.addedAt ?? null,
+		item.viewCount ?? 0,
+		item.lastViewedAt ?? null,
 		item.thumb ?? null,
 		(item.Guid ?? []).map((guid) => guid.id).sort(),
 		(item.Collection ?? []).map((collection) => collection.tag).sort(),
@@ -329,7 +354,11 @@ export async function refreshPlexCacheWithAttempt(
 			instance,
 			log,
 			async () =>
-				await collectPlexCacheLiveEvidence(plexClientForSnapshot(instance, log), instance.id, log),
+				await collectSettledPlexCacheLiveEvidence(
+					plexClientForSnapshot(instance, log),
+					instance.id,
+					log,
+				),
 			async (tx, collected) => await publishPlexCacheSnapshot(tx, instance, attempt!, collected),
 			{
 				cleanupRunClaimToken: context.cleanupRunClaimToken,
@@ -386,13 +415,22 @@ async function publishPlexCacheSnapshot(
 	attempt: PlexCacheRefreshAttempt,
 	collected: PlexCacheRefreshResult,
 ): Promise<PlexCacheRefreshResult> {
-	if (!collected.complete || !collected.completedAt || !collected.snapshot) return collected;
+	if (
+		!collected.complete ||
+		!collected.completedAt ||
+		!collected.snapshot ||
+		!collected.settlement
+	) {
+		return collected;
+	}
 
 	const rows = collected.snapshot.rows;
 	const generationId = randomUUID();
 	const generationMetadata = encodeAuthoritativePlexGenerationMetadata({
-		sections: collected.snapshot.sections,
+		sections: collected.settlement.sections,
 		itemCount: rows.length,
+		canonicalizationVersion: PLEX_CANONICALIZATION_VERSION,
+		roots: collected.settlement.roots,
 	});
 	await publishAuthoritativePlexCacheGeneration(tx, {
 		instance,
@@ -414,6 +452,147 @@ async function publishPlexCacheSnapshot(
 	};
 }
 
+function supportedSettlementSections(
+	sections: Awaited<ReturnType<PlexClient["getLibrarySettlementSections"]>>,
+): PlexGenerationSectionV3[] {
+	return sections
+		.filter(
+			(section) =>
+				(section.type === "movie" || section.type === "show") && !isPersonalMediaSection(section),
+		)
+		.map((section) => {
+			if (section.refreshing) throw new Error("Plex supported library scan is in progress");
+			if (section.scannedAt === null)
+				throw new Error("Plex supported library revision is not initialized");
+			return {
+				key: section.key,
+				uuid: section.uuid,
+				title: section.title,
+				type: section.type as "movie" | "show",
+				refreshing: false as const,
+				scannedAt: section.scannedAt,
+				updatedAt: section.updatedAt,
+			};
+		})
+		.sort(
+			(left, right) =>
+				left.key.localeCompare(right.key) ||
+				left.uuid.localeCompare(right.uuid) ||
+				left.type.localeCompare(right.type) ||
+				left.title.localeCompare(right.title),
+		);
+}
+
+function settlementSectionIdentity(sections: readonly PlexGenerationSectionV3[]): string {
+	return JSON.stringify(
+		sections.map((section) => [section.key, section.uuid, section.type, section.title]),
+	);
+}
+
+function snapshotProjection(snapshot: PlexCacheSnapshot) {
+	return createPlexSelectionProjection({
+		rows: snapshot.rows,
+		selection: { kind: "all" },
+		domains: PLEX_CACHE_CANONICAL_DOMAINS,
+	});
+}
+
+function snapshotRoots(
+	snapshot: PlexCacheSnapshot,
+	sections: readonly PlexGenerationSectionV3[],
+): PlexGenerationDomainRoot[] {
+	const roots: PlexGenerationDomainRoot[] = [];
+	for (const section of sections) {
+		const rows = snapshot.rows.filter((row) => row.sectionId === section.key);
+		const projection = createPlexSelectionProjection({
+			rows,
+			selection: { kind: "all" },
+			domains: PLEX_CACHE_CANONICAL_DOMAINS,
+		});
+		for (const domain of PLEX_CACHE_CANONICAL_DOMAINS) {
+			const digest = projection.domains[domain];
+			if (!digest) throw new Error(`Missing Plex canonical ${domain} root`);
+			roots.push({ sectionKey: section.key, domain, digest });
+		}
+	}
+	return roots;
+}
+
+async function loadPublicationSettlementProbe(client: PlexClient) {
+	const [activities, sections] = await Promise.all([
+		client.getActivities({ uncached: true }),
+		client.getLibrarySettlementSections({ uncached: true }),
+	]);
+	const supportedSectionKeys = sections
+		.filter(
+			(section) =>
+				(section.type === "movie" || section.type === "show") && !isPersonalMediaSection(section),
+		)
+		.map((section) => section.key);
+	const settlement = evaluatePlexLiveSettlement({
+		activities,
+		sections,
+		selectedSectionKeys: supportedSectionKeys,
+	});
+	if (!settlement.settled) {
+		throw new Error(`Plex live settlement unavailable: ${settlement.reasonCodes.join(",")}`);
+	}
+	return supportedSettlementSections(sections);
+}
+
+/**
+ * Bracket complete collection with uncached settlement probes, then perform a
+ * post-end complete canonical pass before allowing publication. The last
+ * complete collection is deliberately the terminal upstream observation: a
+ * trailing probe would create a gap in which its older rows could be accepted.
+ * Plex exposes no read lock or atomic snapshot, so a new change may still begin
+ * after that terminal observation; callers only claim authority for the fixed
+ * point that was actually observed.
+ */
+export async function collectSettledPlexCacheLiveEvidence(
+	client: PlexClient,
+	instanceId: string,
+	log: FastifyBaseLogger,
+): Promise<PlexCacheRefreshResult> {
+	try {
+		const startSections = await loadPublicationSettlementProbe(client);
+		const preliminary = await collectPlexCacheLiveEvidence(client, instanceId, log);
+		if (!preliminary.complete || !preliminary.snapshot) return preliminary;
+
+		const endSections = await loadPublicationSettlementProbe(client);
+		if (settlementSectionIdentity(endSections) !== settlementSectionIdentity(startSections)) {
+			throw new Error("Plex library section identity changed during settlement");
+		}
+
+		const finalSections = await loadPublicationSettlementProbe(client);
+		if (settlementSectionIdentity(finalSections) !== settlementSectionIdentity(endSections)) {
+			throw new Error("Plex library section identity changed before final canonical pass");
+		}
+		const final = await collectPlexCacheLiveEvidence(client, instanceId, log);
+		if (!final.complete || !final.snapshot) return final;
+		if (
+			snapshotProjection(final.snapshot).digest !== snapshotProjection(preliminary.snapshot).digest
+		) {
+			throw new Error("Plex canonical projection changed after the settlement end probe");
+		}
+
+		return {
+			...final,
+			settlement: {
+				sections: finalSections,
+				roots: snapshotRoots(final.snapshot, finalSections),
+			},
+		};
+	} catch (error) {
+		return {
+			upserted: 0,
+			errors: 1,
+			errorMessages: [`Plex settlement publication failed: ${getErrorMessage(error)}`],
+			complete: false,
+		};
+	}
+}
+
 // ============================================================================
 // Refresher
 // ============================================================================
@@ -425,6 +604,7 @@ export async function collectPlexCacheLiveEvidence(
 	client: PlexClient,
 	instanceId: string,
 	log: FastifyBaseLogger,
+	options: { preserveProviderDuplicates?: boolean } = {},
 ): Promise<PlexCacheRefreshResult> {
 	const upserted = 0;
 	let errors = 0;
@@ -495,6 +675,8 @@ export async function collectPlexCacheLiveEvidence(
 				collections: string[];
 				labels: string[];
 				addedAt: number | null;
+				viewCount: number;
+				lastViewedAt: number | null;
 				thumb: string | null;
 			}
 		>();
@@ -538,6 +720,8 @@ export async function collectPlexCacheLiveEvidence(
 						collections: item.Collection?.map((c) => c.tag) ?? [],
 						labels: item.Label?.map((l) => l.tag) ?? [],
 						addedAt: item.addedAt ?? null,
+						viewCount: item.viewCount ?? 0,
+						lastViewedAt: item.lastViewedAt ?? null,
 						thumb: item.thumb ?? null,
 					});
 				}
@@ -599,7 +783,9 @@ export async function collectPlexCacheLiveEvidence(
 				continue;
 			}
 
-			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
+			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}${
+				options.preserveProviderDuplicates ? `:${itemData.ratingKey}` : ""
+			}`;
 			if (!username) {
 				markIncomplete("historyItemsWithUnknownAccounts");
 				continue;
@@ -636,8 +822,21 @@ export async function collectPlexCacheLiveEvidence(
 
 		// Ensure all library items are in aggregations (even if unwatched)
 		for (const [_ratingKey, itemData] of ratingKeyMap) {
-			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
-			if (!aggregations.has(aggKey)) {
+			const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}${
+				options.preserveProviderDuplicates ? `:${itemData.ratingKey}` : ""
+			}`;
+			const itemLastWatchedAt =
+				itemData.lastViewedAt === null ? null : new Date(itemData.lastViewedAt * 1000);
+			const existing = aggregations.get(aggKey);
+			if (existing) {
+				existing.watchCount = Math.max(existing.watchCount, itemData.viewCount);
+				if (
+					itemLastWatchedAt &&
+					(!existing.lastWatchedAt || itemLastWatchedAt > existing.lastWatchedAt)
+				) {
+					existing.lastWatchedAt = itemLastWatchedAt;
+				}
+			} else {
 				aggregations.set(aggKey, {
 					tmdbId: itemData.tmdbId,
 					mediaType: itemData.mediaType,
@@ -645,8 +844,8 @@ export async function collectPlexCacheLiveEvidence(
 					sectionTitle: itemData.sectionTitle,
 					title: itemData.title,
 					ratingKey: itemData.ratingKey,
-					lastWatchedAt: null,
-					watchCount: 0,
+					lastWatchedAt: itemLastWatchedAt,
+					watchCount: itemData.viewCount,
 					watchedByUsers: new Set(),
 					onDeck: false,
 					userRating: itemData.userRating,
@@ -678,7 +877,9 @@ export async function collectPlexCacheLiveEvidence(
 					continue;
 				}
 
-				const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}`;
+				const aggKey = `${itemData.mediaType}:${itemData.tmdbId}:${itemData.sectionId}${
+					options.preserveProviderDuplicates ? `:${itemData.ratingKey}` : ""
+				}`;
 				const agg = aggregations.get(aggKey);
 				if (agg) {
 					agg.onDeck = true;

--- a/apps/api/src/lib/plex/plex-cache-storage.ts
+++ b/apps/api/src/lib/plex/plex-cache-storage.ts
@@ -7,6 +7,7 @@ import type {
 } from "../prisma.js";
 import type { OwnedProviderPublicationSnapshot } from "../services/provider-identity-guard.js";
 import type { PlexCacheRefreshAttempt } from "../services/provider-cache-status.js";
+import { selectPlexBoundedValueRows } from "./plex-canonical-projection.js";
 
 export const PLEX_CACHE_READ_PAGE_SIZE = 500;
 export const PLEX_CACHE_WRITE_CHUNK_SIZE = 100;
@@ -34,6 +35,7 @@ export const PLEX_POLICY_CACHE_ROW_SELECT = {
 	instanceId: true,
 	tmdbId: true,
 	mediaType: true,
+	ratingKey: true,
 	sectionId: true,
 	sectionTitle: true,
 	lastWatchedAt: true,
@@ -223,14 +225,12 @@ export async function listSelectedPlexCacheRows(
 ): Promise<PlexCache[]> {
 	if (selection.kind === "authority-only") return [];
 	if (selection.kind === "on-deck") {
-		return listPlexCacheRowsWhere(prisma, { instanceId, onDeck: true }, { limit: selection.limit });
+		const rows = await listPlexCacheRowsWhere(prisma, { instanceId, onDeck: true });
+		return selectPlexBoundedValueRows(rows, selection);
 	}
 	if (selection.kind === "recently-added") {
-		return listPlexCacheRowsWhere(
-			prisma,
-			{ instanceId, addedAt: { not: null } },
-			{ limit: selection.limit, orderBy: { addedAt: "desc" } },
-		);
+		const rows = await listPlexCacheRowsWhere(prisma, { instanceId, addedAt: { not: null } });
+		return selectPlexBoundedValueRows(rows, selection);
 	}
 	if (selection.kind === "label-membership") {
 		return listPlexCacheRowsWhere(prisma, {

--- a/apps/api/src/lib/plex/plex-canonical-projection.ts
+++ b/apps/api/src/lib/plex/plex-canonical-projection.ts
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto";
+import type { PlexCanonicalDomain } from "@arr/shared";
+
+export const PLEX_CANONICALIZATION_VERSION = 1 as const;
+
+export type PlexCanonicalSelection =
+	| { kind: "all" | "authority-only" }
+	| { kind: "targets"; targets: Array<{ mediaType: string; tmdbId: number }> }
+	| { kind: "label-membership"; label: string }
+	| { kind: "recently-added"; limit: number }
+	| { kind: "on-deck"; limit: number };
+
+export type PlexCanonicalObservation = {
+	sectionId: string;
+	sectionTitle?: string | null;
+	mediaType: string;
+	tmdbId: number;
+	ratingKey?: string | null;
+	title?: string | null;
+	labels?: string[] | string | null;
+	collections?: string[] | string | null;
+	watchCount?: number | null;
+	watchedByUsers?: string[] | string | null;
+	lastWatchedAt?: Date | string | number | null;
+	onDeck?: boolean | null;
+	userRating?: number | null;
+	addedAt?: Date | string | number | null;
+	thumb?: string | null;
+	seasonNumber?: number | null;
+	episodeNumber?: number | null;
+	parentRatingKey?: string | null;
+	watched?: boolean | null;
+};
+
+export type PlexCanonicalProjection = {
+	algorithmVersion: typeof PLEX_CANONICALIZATION_VERSION;
+	domains: Partial<Record<PlexCanonicalDomain, string>>;
+	digest: string;
+};
+
+type PlexCanonicalBoundedSelection =
+	| { kind: "recently-added"; limit: number }
+	| { kind: "on-deck"; limit: number };
+
+function sha256(value: string): string {
+	return createHash("sha256").update(value).digest("hex");
+}
+
+function stableString(value: unknown): string {
+	if (value === null) return "null";
+	if (value === undefined) return "undefined";
+	if (typeof value === "string") return `string:${JSON.stringify(value)}`;
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) throw new Error("Canonical Plex numbers must be finite");
+		return `number:${Object.is(value, -0) ? 0 : value}`;
+	}
+	if (typeof value === "boolean") return `boolean:${value}`;
+	if (Array.isArray(value)) return `array:[${value.map(stableString).join(",")}]`;
+	if (typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+			left.localeCompare(right),
+		);
+		return `object:{${entries
+			.map(([key, entry]) => `${JSON.stringify(key)}:${stableString(entry)}`)
+			.join(",")}}`;
+	}
+	throw new Error("Unsupported canonical Plex value");
+}
+
+function stringSet(value: string[] | string | null | undefined): string[] {
+	let parsed: unknown = value;
+	if (typeof value === "string") {
+		try {
+			parsed = JSON.parse(value);
+		} catch {
+			throw new Error("Invalid persisted Plex array");
+		}
+	}
+	if (parsed == null) return [];
+	if (!Array.isArray(parsed) || parsed.some((entry) => typeof entry !== "string")) {
+		throw new Error("Invalid Plex string set");
+	}
+	return [...new Set(parsed)].sort((left, right) => left.localeCompare(right));
+}
+
+function timestamp(value: Date | string | number | null | undefined): string | null {
+	if (value == null) return null;
+	const date = value instanceof Date ? value : new Date(value);
+	if (!Number.isFinite(date.getTime())) throw new Error("Invalid Plex timestamp");
+	return date.toISOString();
+}
+
+function identity(row: PlexCanonicalObservation) {
+	if (!Number.isSafeInteger(row.tmdbId) || row.tmdbId <= 0) {
+		throw new Error("Invalid Plex TMDB identity");
+	}
+	return {
+		sectionId: row.sectionId,
+		mediaType: row.mediaType,
+		tmdbId: row.tmdbId,
+		ratingKey: row.ratingKey == null ? null : String(row.ratingKey),
+	};
+}
+
+export function selectPlexBoundedValueRows<T extends PlexCanonicalObservation>(
+	rows: readonly T[],
+	selection: PlexCanonicalBoundedSelection,
+): T[] {
+	if (selection.kind === "recently-added") {
+		return [...rows]
+			.sort(
+				(left, right) =>
+					(timestamp(right.addedAt) ?? "").localeCompare(timestamp(left.addedAt) ?? "") ||
+					stableString(identity(left)).localeCompare(stableString(identity(right))),
+			)
+			.slice(0, selection.limit);
+	}
+	return rows
+		.filter((row) => row.onDeck === true)
+		.sort((left, right) =>
+			stableString(identity(left)).localeCompare(stableString(identity(right))),
+		)
+		.slice(0, selection.limit);
+}
+
+export function selectPlexCanonicalRows<T extends PlexCanonicalObservation>(
+	rows: readonly T[],
+	selection: PlexCanonicalSelection,
+): T[] {
+	let selected: T[];
+	switch (selection.kind) {
+		case "all":
+			selected = [...rows];
+			break;
+		case "authority-only":
+			selected = [];
+			break;
+		case "targets": {
+			const targets = new Set(
+				selection.targets.map((target) => `${target.mediaType}\u0000${target.tmdbId}`),
+			);
+			selected = rows.filter((row) => targets.has(`${row.mediaType}\u0000${row.tmdbId}`));
+			break;
+		}
+		case "label-membership":
+			selected = rows.filter((row) => stringSet(row.labels).includes(selection.label));
+			break;
+		case "recently-added":
+			selected = selectPlexBoundedValueRows(rows, selection);
+			break;
+		case "on-deck":
+			selected = selectPlexBoundedValueRows(rows, selection);
+			break;
+	}
+	return selected.sort((left, right) =>
+		stableString(identity(left)).localeCompare(stableString(identity(right))),
+	);
+}
+
+function domainRow(domain: PlexCanonicalDomain, row: PlexCanonicalObservation): unknown {
+	const id = identity(row);
+	switch (domain) {
+		case "membership":
+			return id;
+		case "display":
+			return {
+				...id,
+				sectionTitle: row.sectionTitle ?? null,
+				title: row.title ?? null,
+				addedAt: timestamp(row.addedAt),
+				thumb: row.thumb ?? null,
+			};
+		case "labels":
+			return { ...id, labels: stringSet(row.labels) };
+		case "collections":
+			return { ...id, collections: stringSet(row.collections) };
+		case "watch":
+			return {
+				...id,
+				watchCount: row.watchCount ?? 0,
+				watchedByUsers: stringSet(row.watchedByUsers),
+				lastWatchedAt: timestamp(row.lastWatchedAt),
+				userRating: row.userRating ?? null,
+			};
+		case "on-deck":
+			return { ...id, onDeck: row.onDeck === true };
+		case "episode-parents":
+			return { ...id, parentRatingKey: row.parentRatingKey ?? row.ratingKey ?? null };
+		case "episodes":
+			return {
+				...id,
+				title: row.title ?? null,
+				seasonNumber: row.seasonNumber ?? null,
+				episodeNumber: row.episodeNumber ?? null,
+				watched: row.watched === true,
+				watchCount: row.watchCount ?? 0,
+				watchedByUsers: stringSet(row.watchedByUsers),
+				lastWatchedAt: timestamp(row.lastWatchedAt),
+			};
+	}
+}
+
+export function createPlexSelectionProjection(input: {
+	rows: readonly PlexCanonicalObservation[];
+	selection: PlexCanonicalSelection;
+	domains: readonly PlexCanonicalDomain[];
+}): PlexCanonicalProjection {
+	const rows = selectPlexCanonicalRows(input.rows, input.selection);
+	const domains: Partial<Record<PlexCanonicalDomain, string>> = {};
+	for (const domain of [...new Set(input.domains)].sort()) {
+		domains[domain] = sha256(
+			stableString({
+				algorithmVersion: PLEX_CANONICALIZATION_VERSION,
+				domain,
+				rows: rows.map((row) => domainRow(domain, row)),
+			}),
+		);
+	}
+	return {
+		algorithmVersion: PLEX_CANONICALIZATION_VERSION,
+		domains,
+		digest: sha256(stableString({ algorithmVersion: PLEX_CANONICALIZATION_VERSION, domains })),
+	};
+}

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -12,6 +12,7 @@ import type { Encryptor } from "../auth/encryption.js";
 import { getStoredHttpAuthHeaders } from "../services/http-auth.js";
 import { parseUpstreamOrThrow } from "../validation/parse-upstream.js";
 import {
+	plexActivitiesResponseSchema,
 	plexAccountsResponseSchema,
 	plexAllLeavesResponseSchema,
 	plexEpisodeMediaItemsResponseSchema,
@@ -21,8 +22,10 @@ import {
 	plexLibraryGuidItemsResponseSchema,
 	plexLibraryItemsResponseSchema,
 	plexLibraryMediaItemsResponseSchema,
+	plexMetadataTagsResponseSchema,
 	plexOnDeckResponseSchema,
 	plexSectionsResponseSchema,
+	plexSettlementSectionsResponseSchema,
 	plexServerInfoResponseSchema,
 	plexSessionsResponseSchema,
 } from "./plex-schemas.js";
@@ -45,6 +48,18 @@ export interface PlexLibrary {
 	agent?: string; // e.g. "tv.plex.agents.movie", "com.plexapp.agents.none"
 }
 
+export interface PlexSettlementLibrary extends PlexLibrary {
+	uuid: string;
+	refreshing: boolean;
+	scannedAt: number | null;
+	updatedAt: number;
+}
+
+export interface PlexActivity {
+	type: string;
+	Context?: { librarySectionID?: string };
+}
+
 export interface PlexGuid {
 	id: string; // e.g. "tmdb://12345", "imdb://tt1234567"
 }
@@ -56,6 +71,8 @@ export interface PlexLibraryItem {
 	year?: number;
 	userRating?: number; // 0-10 scale
 	addedAt?: number; // Unix timestamp
+	viewCount?: number;
+	lastViewedAt?: number; // Unix timestamp
 	thumb?: string; // Plex thumbnail path
 	Guid?: PlexGuid[];
 	Collection?: Array<{ tag: string }>;
@@ -173,6 +190,7 @@ export class PlexClient {
 	private readonly log: FastifyBaseLogger;
 	private readonly timeout: number;
 	private readonly httpAuthHeaders: Record<string, string>;
+	private readonly ordinaryReadFlights = new Map<string, Promise<unknown>>();
 	constructor(
 		baseUrl: string,
 		token: string,
@@ -240,6 +258,58 @@ export class PlexClient {
 		}));
 	}
 
+	/** Strict complete section-state probe used by live settlement authority. */
+	async getLibrarySettlementSections(
+		options: { uncached?: boolean } = {},
+	): Promise<PlexSettlementLibrary[]> {
+		return this.runOrdinaryRead(
+			"library-settlement-sections",
+			async () => {
+				const data = await this.request("/library/sections", {
+					schema: plexSettlementSectionsResponseSchema,
+				});
+				const directories = data.MediaContainer.Directory ?? [];
+				this.assertCompleteSinglePageContainer(
+					data.MediaContainer,
+					directories.length,
+					"Plex library settlement section inventory",
+				);
+				return directories.map((directory) => ({
+					key: directory.key,
+					uuid: directory.uuid,
+					title: directory.title,
+					type: directory.type,
+					agent: directory.agent,
+					refreshing: directory.refreshing,
+					scannedAt: directory.scannedAt,
+					updatedAt: directory.updatedAt,
+				}));
+			},
+			options.uncached === true,
+		);
+	}
+
+	/** Strict complete activity probe used by live settlement authority. */
+	async getActivities(options: { uncached?: boolean } = {}): Promise<PlexActivity[]> {
+		return this.runOrdinaryRead(
+			"activities",
+			async () => {
+				const data = await this.request("/activities", { schema: plexActivitiesResponseSchema });
+				const activities = data.MediaContainer.Activity ?? [];
+				this.assertCompleteSinglePageContainer(
+					data.MediaContainer,
+					activities.length,
+					"Plex activity inventory",
+				);
+				return activities.map((activity) => ({
+					type: activity.type,
+					...(activity.Context ? { Context: activity.Context } : {}),
+				}));
+			},
+			options.uncached === true,
+		);
+	}
+
 	/**
 	 * Get all items from a library section.
 	 */
@@ -249,6 +319,7 @@ export class PlexClient {
 			plexLibraryItemsResponseSchema,
 			(item) => item.ratingKey,
 		);
+		const tags = await this.getAuthoritativeMetadataTags(items.map((item) => item.ratingKey));
 
 		return items.map((m) => ({
 			ratingKey: m.ratingKey,
@@ -257,11 +328,43 @@ export class PlexClient {
 			year: m.year,
 			userRating: m.userRating,
 			addedAt: m.addedAt,
+			viewCount: m.viewCount,
+			lastViewedAt: m.lastViewedAt,
 			thumb: m.thumb,
 			Guid: m.Guid?.map((g) => ({ id: g.id })),
-			Collection: m.Collection?.map((c) => ({ tag: c.tag })),
-			Label: m.Label?.map((l) => ({ tag: l.tag })),
+			Collection: tags.get(m.ratingKey)?.Collection?.map((c) => ({ tag: c.tag })),
+			Label: tags.get(m.ratingKey)?.Label?.map((l) => ({ tag: l.tag })),
 		}));
+	}
+
+	private async getAuthoritativeMetadataTags(ratingKeys: readonly string[]) {
+		const tags = new Map<
+			string,
+			{ Collection?: Array<{ tag: string }>; Label?: Array<{ tag: string }> }
+		>();
+		for (let offset = 0; offset < ratingKeys.length; offset += SAFETY_PAGE_SIZE) {
+			const chunk = ratingKeys.slice(offset, offset + SAFETY_PAGE_SIZE);
+			const path = `/library/metadata/${chunk.map(encodeURIComponent).join(",")}?includeCollections=1&includeLabels=1`;
+			const data = await this.request(path, { schema: plexMetadataTagsResponseSchema });
+			const metadata = data.MediaContainer.Metadata ?? [];
+			if (data.MediaContainer.size !== metadata.length || metadata.length !== chunk.length) {
+				throw new Error("Plex metadata tag inventory was incomplete");
+			}
+			const expected = new Set(chunk);
+			for (const item of metadata) {
+				if (!expected.has(item.ratingKey) || tags.has(item.ratingKey)) {
+					throw new Error("Plex metadata tag inventory returned an unexpected or duplicate item");
+				}
+				tags.set(item.ratingKey, {
+					...(item.Collection ? { Collection: item.Collection.map(({ tag }) => ({ tag })) } : {}),
+					...(item.Label ? { Label: item.Label.map(({ tag }) => ({ tag })) } : {}),
+				});
+			}
+		}
+		if (tags.size !== ratingKeys.length) {
+			throw new Error("Plex metadata tag inventory did not cover every library item");
+		}
+		return tags;
 	}
 
 	private async getCompleteSafetyMetadata<T>(
@@ -649,13 +752,19 @@ export class PlexClient {
 	 */
 	async updateMetadataTags(
 		ratingKey: string,
+		mediaType: "movie" | "series",
 		type: "collection" | "label",
 		action: "add" | "remove",
 		name: string,
 	): Promise<void> {
 		const tagType = type === "collection" ? "collection" : "label";
 		const suffix = action === "remove" ? "-" : "";
-		const path = `/library/metadata/${ratingKey}?${tagType}[0].tag.tag${suffix}=${encodeURIComponent(name)}`;
+		const params = new URLSearchParams({
+			type: mediaType === "movie" ? "1" : "2",
+			[`${tagType}.locked`]: "1",
+			[`${tagType}[0].tag.tag${suffix}`]: name,
+		});
+		const path = `/library/metadata/${ratingKey}?${params.toString()}`;
 		await this.request(path, { method: "PUT" });
 	}
 
@@ -691,6 +800,24 @@ export class PlexClient {
 		) {
 			throw new Error(`${label} did not provide a complete single-page result`);
 		}
+	}
+
+	private runOrdinaryRead<T>(key: string, load: () => Promise<T>, uncached: boolean): Promise<T> {
+		if (uncached) return load();
+		const existing = this.ordinaryReadFlights.get(key) as Promise<T> | undefined;
+		if (existing) return existing;
+		let promise!: Promise<T>;
+		promise = (async () => {
+			try {
+				return await load();
+			} finally {
+				if (this.ordinaryReadFlights.get(key) === promise) {
+					this.ordinaryReadFlights.delete(key);
+				}
+			}
+		})();
+		this.ordinaryReadFlights.set(key, promise);
+		return promise;
 	}
 
 	/**

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
@@ -62,8 +62,8 @@ vi.mock("./plex-authority-service.js", async (importOriginal) => {
 				this.prisma = input.prisma;
 			}
 
-			scanInstancePolicy(input: never) {
-				return repository.scanInstancePolicyEvidence(this.prisma, input);
+			scanInstanceEpisodeParentPolicy(input: never) {
+				return repository.scanInstanceEpisodeParentPolicyEvidence(this.prisma, input);
 			}
 		},
 	};
@@ -138,7 +138,12 @@ async function refreshPlexEpisodeCache(
 }
 
 function prisma(
-	shows = [{ tmdbId: 42, ratingKey: "show-1" }],
+	shows: Array<{
+		tmdbId: number;
+		ratingKey: string;
+		mediaType?: string;
+		watchCount?: number;
+	}> = [{ tmdbId: 42, ratingKey: "show-1" }],
 	currentConnection = { service: "PLEX", enabled: true, connectionGeneration: 7 },
 	parentStatuses: Array<Record<string, unknown> | null> = [],
 ) {
@@ -244,7 +249,12 @@ function prisma(
 		},
 		plexCache: {
 			count: vi.fn().mockResolvedValue(fullShows.length),
-			findMany: vi.fn().mockResolvedValue(fullShows),
+			findMany: vi.fn(async ({ where }: { where?: Record<string, unknown> }) => {
+				if (where?.mediaType === "series" && where.watchCount) {
+					return fullShows.filter((row) => row.mediaType === "series" && row.watchCount > 0);
+				}
+				return fullShows;
+			}),
 		},
 		$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
 			callback(tx),
@@ -347,6 +357,32 @@ describe("refreshPlexEpisodeCache authoritative publication", () => {
 			connectionGeneration: 7,
 			identityGeneration: 11,
 		});
+	});
+
+	it("ignores more than the show capacity of ineligible parent rows", async () => {
+		const fixture = prisma([
+			{ tmdbId: 42, ratingKey: "show-watched" },
+			...Array.from({ length: 201 }, (_, index) => ({
+				tmdbId: 1_000 + index,
+				ratingKey: `movie-${index}`,
+				mediaType: "movie",
+			})),
+			{ tmdbId: 126, ratingKey: "show-unwatched", watchCount: 0 },
+		]);
+		const getEpisodes = vi.fn().mockResolvedValue([episode()]);
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes } as Partial<PlexClient>),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ complete: true, eligibleShows: 1, refreshedShows: 1 });
+		expect(getEpisodes).toHaveBeenCalledTimes(1);
+		expect(getEpisodes).toHaveBeenCalledWith("show-watched");
 	});
 
 	it("keeps prior episode rows when the authoritative parent metadata is unavailable", async () => {

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
@@ -50,6 +50,25 @@ vi.mock("./service-instance-fingerprint.js", () => ({
 	plexConnectionFingerprint: vi.fn(() => "fingerprint-1"),
 }));
 
+vi.mock("./plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./plex-authority-service.js")>();
+	const repository = await import("./plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: never;
+
+			constructor(input: { prisma: never }) {
+				this.prisma = input.prisma;
+			}
+
+			scanInstancePolicy(input: never) {
+				return repository.scanInstancePolicyEvidence(this.prisma, input);
+			}
+		},
+	};
+});
+
 const log = {
 	warn: vi.fn(),
 	info: vi.fn(),
@@ -136,7 +155,23 @@ function prisma(
 		itemCount: shows.length,
 		generationId: "parent-generation-1",
 		generationMetadata: JSON.stringify({
-			sections: [{ key: "shows", title: "Shows", type: "show" }],
+			version: 3,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			itemCount: shows.length,
+			canonicalizationVersion: 1,
+			sections: [
+				{
+					key: "shows",
+					uuid: "shows-uuid",
+					title: "Shows",
+					type: "show",
+					refreshing: false,
+					scannedAt: 1_777_000_000,
+					updatedAt: 1_777_000_100,
+				},
+			],
+			roots: [{ sectionKey: "shows", domain: "membership", digest: "a".repeat(64) }],
 		}),
 		lastAttemptAt: attemptedAt,
 		lastAttemptResult: "success",
@@ -303,9 +338,12 @@ describe("refreshPlexEpisodeCache authoritative publication", () => {
 			fixture.tx.cacheRefreshStatus.updateMany.mock.calls[0]![0].data.generationMetadata,
 		);
 		expect(metadata).toEqual({
-			version: 1,
+			version: 2,
 			parentPlexGenerationId: "parent-generation-1",
 			parentPublicationLevel: "authoritative",
+			parentMetadataVersion: 3,
+			canonicalizationVersion: 1,
+			episodeDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
 			connectionGeneration: 7,
 			identityGeneration: 11,
 		});

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -5,7 +5,6 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { FastifyBaseLogger } from "fastify";
 import type { Prisma } from "../prisma.js";
 import {
 	beginPlexCacheRefreshAttempt,
@@ -22,17 +21,17 @@ import {
 	PlexRefreshAttemptSupersededError,
 	publishAuthoritativePlexEpisodeGeneration,
 } from "./plex-cache-storage.js";
-import { PlexClient, type PlexEpisodeItem } from "./plex-client.js";
+import { PlexClient } from "./plex-client.js";
+import {
+	collectPlexEpisodeLiveEvidence,
+	type PlexEpisodeRow,
+} from "./plex-episode-live-collector.js";
+import { createPlexSelectionProjection } from "./plex-canonical-projection.js";
 import {
 	DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
-	scanInstanceEpisodeParentPolicyEvidence,
-} from "./plex-evidence-repository.js";
+	PlexAuthorityService,
+} from "./plex-authority-service.js";
 import { plexConnectionFingerprint } from "./service-instance-fingerprint.js";
-
-const MAX_SHOWS_PER_REFRESH = 50;
-const REFRESHES_PER_FRESHNESS_WINDOW = 4;
-const MAX_COMPLETE_SHOWS = MAX_SHOWS_PER_REFRESH * REFRESHES_PER_FRESHNESS_WINDOW;
-const MAX_HISTORY_RESULTS = 100_000;
 
 export interface PlexEpisodeRefreshResult {
 	upserted: number;
@@ -46,21 +45,6 @@ export interface PlexEpisodeRefreshResult {
 	completedAt?: Date;
 	superseded?: boolean;
 }
-
-type PlexEpisodeRow = {
-	instanceId: string;
-	showTmdbId: number;
-	seasonNumber: number;
-	episodeNumber: number;
-	ratingKey: string;
-	title: string;
-	watched: boolean;
-	watchedByUsers: string;
-	lastWatchedAt: Date | null;
-	watchCount: number;
-	refreshedAt: Date;
-	sourceFingerprint: string;
-};
 
 type CollectedPlexEpisodeRefresh = PlexEpisodeRefreshResult & {
 	rows?: PlexEpisodeRow[];
@@ -87,157 +71,6 @@ function failedResult(
 		coverageIncomplete: true,
 		capacityDegraded,
 		complete: false,
-	};
-}
-
-async function collectPlexEpisodeCache(
-	client: PlexClient,
-	showMap: Map<number, Set<string>>,
-	instanceId: string,
-	log: FastifyBaseLogger,
-	sourceFingerprint: string,
-): Promise<CollectedPlexEpisodeRefresh> {
-	const eligibleShows = showMap.size;
-	if (eligibleShows > MAX_COMPLETE_SHOWS) {
-		const message = `Plex episode inventory exceeded ${MAX_COMPLETE_SHOWS} eligible shows`;
-		log.warn({ instanceId, eligibleShows, limit: MAX_COMPLETE_SHOWS }, message);
-		return failedResult([message], eligibleShows, 0, true);
-	}
-
-	const errorMessages: string[] = [];
-	let history: Awaited<ReturnType<PlexClient["getHistory"]>>;
-	try {
-		history = await client.getHistory({
-			maxResults: MAX_HISTORY_RESULTS,
-			requireComplete: true,
-		});
-	} catch (error) {
-		const message = `Failed to prove complete Plex history: ${getErrorMessage(error)}`;
-		log.warn({ err: error, instanceId }, message);
-		return failedResult([message], eligibleShows, 0);
-	}
-
-	let accounts: Awaited<ReturnType<PlexClient["getAccounts"]>> = [];
-	if (history.some((entry) => entry.type === "episode")) {
-		try {
-			accounts = await client.getAccounts();
-		} catch (error) {
-			const message = `Failed to prove complete Plex accounts: ${getErrorMessage(error)}`;
-			log.warn({ err: error, instanceId }, message);
-			return failedResult([message], eligibleShows, 0);
-		}
-	}
-	const accountMap = new Map(accounts.map((account) => [account.id, account.name]));
-	const historyMap = new Map<
-		string,
-		{ users: Set<string>; lastWatched: number; eventCount: number }
-	>();
-	for (const item of history) {
-		if (item.type !== "episode") continue;
-		const userName = accountMap.get(item.accountID);
-		if (!userName?.trim()) {
-			const message = `Plex history account ${item.accountID} was absent from the complete account inventory`;
-			return failedResult([message], eligibleShows, 0);
-		}
-		const current = historyMap.get(item.ratingKey);
-		if (current) {
-			current.users.add(userName);
-			current.lastWatched = Math.max(current.lastWatched, item.viewedAt);
-			current.eventCount++;
-		} else {
-			historyMap.set(item.ratingKey, {
-				users: new Set([userName]),
-				lastWatched: item.viewedAt,
-				eventCount: 1,
-			});
-		}
-	}
-
-	const rows: PlexEpisodeRow[] = [];
-	const completedAt = new Date();
-	let refreshedShows = 0;
-
-	for (const [tmdbId, ratingKeys] of [...showMap.entries()].sort(([a], [b]) => a - b)) {
-		const copies: PlexEpisodeItem[] = [];
-		for (const ratingKey of [...ratingKeys].sort()) {
-			try {
-				copies.push(...(await client.getEpisodes(ratingKey)));
-			} catch (error) {
-				const message = `Failed to fetch episodes for show tmdb:${tmdbId} copy:${ratingKey}: ${getErrorMessage(error)}`;
-				errorMessages.push(message);
-				log.warn({ err: error, instanceId, tmdbId, ratingKey }, message);
-			}
-		}
-		if (errorMessages.length > 0) continue;
-		refreshedShows++;
-
-		const byCoordinate = new Map<string, PlexEpisodeItem[]>();
-		for (const episode of copies) {
-			const coordinate = `${episode.seasonNumber}:${episode.episodeNumber}`;
-			const episodeCopies = byCoordinate.get(coordinate) ?? [];
-			episodeCopies.push(episode);
-			byCoordinate.set(coordinate, episodeCopies);
-		}
-		for (const episodeCopies of [...byCoordinate.values()].sort(
-			([left], [right]) =>
-				left!.seasonNumber - right!.seasonNumber || left!.episodeNumber - right!.episodeNumber,
-		)) {
-			const episode = [...episodeCopies].sort((left, right) => {
-				const leftCount = Number.isSafeInteger(left.viewCount) ? (left.viewCount ?? 0) : 0;
-				const rightCount = Number.isSafeInteger(right.viewCount) ? (right.viewCount ?? 0) : 0;
-				return rightCount - leftCount || left.ratingKey.localeCompare(right.ratingKey);
-			})[0]!;
-			const watchCount = Math.max(0, episode.viewCount ?? 0);
-			const evidence = episodeCopies
-				.map((copy) => historyMap.get(copy.ratingKey))
-				.filter((entry) => entry !== undefined);
-			const lastWatched = Math.max(
-				...evidence.map((entry) => entry.lastWatched),
-				...episodeCopies.map((copy) => copy.lastViewedAt ?? 0),
-				0,
-			);
-			rows.push({
-				instanceId,
-				showTmdbId: tmdbId,
-				seasonNumber: episode.seasonNumber,
-				episodeNumber: episode.episodeNumber,
-				ratingKey: episode.ratingKey,
-				title: episode.title,
-				watched: watchCount > 0 || evidence.some((entry) => entry.eventCount > 0),
-				watchedByUsers: JSON.stringify(
-					[...new Set(evidence.flatMap((entry) => [...entry.users]))].sort(),
-				),
-				lastWatchedAt: lastWatched > 0 ? new Date(lastWatched * 1000) : null,
-				watchCount,
-				refreshedAt: completedAt,
-				sourceFingerprint,
-			});
-		}
-	}
-
-	if (errorMessages.length > 0 || refreshedShows !== eligibleShows) {
-		return failedResult(errorMessages, eligibleShows, refreshedShows);
-	}
-
-	try {
-		await client.verifyHistorySnapshot(history);
-	} catch (error) {
-		const message = `Failed to revalidate Plex history before publication: ${getErrorMessage(error)}`;
-		log.warn({ err: error, instanceId }, message);
-		return failedResult([message], eligibleShows, refreshedShows);
-	}
-
-	return {
-		upserted: 0,
-		errors: 0,
-		errorMessages: [],
-		eligibleShows,
-		refreshedShows,
-		coverageIncomplete: false,
-		capacityDegraded: false,
-		complete: true,
-		completedAt,
-		rows,
 	};
 }
 
@@ -287,9 +120,16 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 			log,
 			async () => {
 				const showMap = new Map<number, Set<string>>();
-				const parentBefore = await scanInstanceEpisodeParentPolicyEvidence(prisma, {
+				const authority = new PlexAuthorityService({
+					prisma,
+					log,
+					createClient: () => client,
+				});
+				const parentBefore = await authority.scanInstancePolicy({
 					userId: instance.userId,
 					instanceId: instance.id,
+					domains: ["membership", "episode-parents", "watch"],
+					mutation: true,
 					maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
 					onBatch: ({ rows }) => {
 						for (const row of rows) {
@@ -307,7 +147,7 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 				) {
 					return failedResult(["Authoritative parent Plex generation is unavailable"], 0, 0);
 				}
-				const collected = await collectPlexEpisodeCache(
+				const collected = await collectPlexEpisodeLiveEvidence(
 					client,
 					showMap,
 					instance.id,
@@ -315,9 +155,11 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 					plexConnectionFingerprint(instance),
 				);
 				if (!collected.complete) return collected;
-				const parentAfter = await scanInstanceEpisodeParentPolicyEvidence(prisma, {
+				const parentAfter = await authority.scanInstancePolicy({
 					userId: instance.userId,
 					instanceId: instance.id,
+					domains: ["membership", "episode-parents", "watch"],
+					mutation: true,
 					maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
 				});
 				if (
@@ -424,10 +266,30 @@ async function publishPlexEpisodeCache(
 	}
 	const rows = collected.rows;
 	const generationId = randomUUID();
+	const episodeDigest = createPlexSelectionProjection({
+		rows: rows.map((row) => ({
+			sectionId: "",
+			mediaType: "episode",
+			tmdbId: row.showTmdbId,
+			ratingKey: row.ratingKey,
+			title: row.title,
+			seasonNumber: row.seasonNumber,
+			episodeNumber: row.episodeNumber,
+			watched: row.watched,
+			watchedByUsers: row.watchedByUsers,
+			lastWatchedAt: row.lastWatchedAt,
+			watchCount: row.watchCount,
+		})),
+		selection: { kind: "all" },
+		domains: ["episodes"],
+	}).domains.episodes!;
 	const generationMetadata = JSON.stringify({
-		version: 1,
+		version: 2,
 		parentPlexGenerationId: collected.parentAuthority.generationId,
 		parentPublicationLevel: collected.parentAuthority.publicationLevel,
+		parentMetadataVersion: 3,
+		canonicalizationVersion: 1,
+		episodeDigest,
 		connectionGeneration: collected.parentAuthority.connectionGeneration,
 		identityGeneration: collected.parentAuthority.identityGeneration,
 	});

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -125,7 +125,7 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 					log,
 					createClient: () => client,
 				});
-				const parentBefore = await authority.scanInstancePolicy({
+				const parentBefore = await authority.scanInstanceEpisodeParentPolicy({
 					userId: instance.userId,
 					instanceId: instance.id,
 					domains: ["membership", "episode-parents", "watch"],
@@ -155,7 +155,7 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 					plexConnectionFingerprint(instance),
 				);
 				if (!collected.complete) return collected;
-				const parentAfter = await authority.scanInstancePolicy({
+				const parentAfter = await authority.scanInstanceEpisodeParentPolicy({
 					userId: instance.userId,
 					instanceId: instance.id,
 					domains: ["membership", "episode-parents", "watch"],

--- a/apps/api/src/lib/plex/plex-episode-live-collector.ts
+++ b/apps/api/src/lib/plex/plex-episode-live-collector.ts
@@ -1,0 +1,205 @@
+import type { FastifyBaseLogger } from "fastify";
+import { getErrorMessage } from "../utils/error-message.js";
+import type { PlexClient, PlexEpisodeItem } from "./plex-client.js";
+
+const MAX_SHOWS_PER_REFRESH = 50;
+const REFRESHES_PER_FRESHNESS_WINDOW = 4;
+const MAX_COMPLETE_SHOWS = MAX_SHOWS_PER_REFRESH * REFRESHES_PER_FRESHNESS_WINDOW;
+const MAX_HISTORY_RESULTS = 100_000;
+
+export type PlexEpisodeRow = {
+	instanceId: string;
+	showTmdbId: number;
+	seasonNumber: number;
+	episodeNumber: number;
+	ratingKey: string;
+	title: string;
+	watched: boolean;
+	watchedByUsers: string;
+	lastWatchedAt: Date | null;
+	watchCount: number;
+	refreshedAt: Date;
+	sourceFingerprint: string;
+};
+
+export interface CollectedPlexEpisodeRefresh {
+	upserted: number;
+	errors: number;
+	errorMessages: string[];
+	eligibleShows: number;
+	refreshedShows: number;
+	coverageIncomplete: boolean;
+	capacityDegraded: boolean;
+	complete: boolean;
+	completedAt?: Date;
+	rows?: PlexEpisodeRow[];
+}
+
+function failedResult(
+	errorMessages: string[],
+	eligibleShows: number,
+	refreshedShows: number,
+	capacityDegraded = false,
+): CollectedPlexEpisodeRefresh {
+	return {
+		upserted: 0,
+		errors: Math.max(1, errorMessages.length),
+		errorMessages,
+		eligibleShows,
+		refreshedShows,
+		coverageIncomplete: true,
+		capacityDegraded,
+		complete: false,
+	};
+}
+
+export async function collectPlexEpisodeLiveEvidence(
+	client: PlexClient,
+	showMap: Map<number, Set<string>>,
+	instanceId: string,
+	log: FastifyBaseLogger,
+	sourceFingerprint: string,
+): Promise<CollectedPlexEpisodeRefresh> {
+	const eligibleShows = showMap.size;
+	if (eligibleShows > MAX_COMPLETE_SHOWS) {
+		const message = `Plex episode inventory exceeded ${MAX_COMPLETE_SHOWS} eligible shows`;
+		log.warn({ instanceId, eligibleShows, limit: MAX_COMPLETE_SHOWS }, message);
+		return failedResult([message], eligibleShows, 0, true);
+	}
+
+	const errorMessages: string[] = [];
+	let history: Awaited<ReturnType<PlexClient["getHistory"]>>;
+	try {
+		history = await client.getHistory({
+			maxResults: MAX_HISTORY_RESULTS,
+			requireComplete: true,
+		});
+	} catch (error) {
+		const message = `Failed to prove complete Plex history: ${getErrorMessage(error)}`;
+		log.warn({ err: error, instanceId }, message);
+		return failedResult([message], eligibleShows, 0);
+	}
+
+	let accounts: Awaited<ReturnType<PlexClient["getAccounts"]>> = [];
+	if (history.some((entry) => entry.type === "episode")) {
+		try {
+			accounts = await client.getAccounts();
+		} catch (error) {
+			const message = `Failed to prove complete Plex accounts: ${getErrorMessage(error)}`;
+			log.warn({ err: error, instanceId }, message);
+			return failedResult([message], eligibleShows, 0);
+		}
+	}
+	const accountMap = new Map(accounts.map((account) => [account.id, account.name]));
+	const historyMap = new Map<
+		string,
+		{ users: Set<string>; lastWatched: number; eventCount: number }
+	>();
+	for (const item of history) {
+		if (item.type !== "episode") continue;
+		const userName = accountMap.get(item.accountID);
+		if (!userName?.trim()) {
+			const message = `Plex history account ${item.accountID} was absent from the complete account inventory`;
+			return failedResult([message], eligibleShows, 0);
+		}
+		const current = historyMap.get(item.ratingKey);
+		if (current) {
+			current.users.add(userName);
+			current.lastWatched = Math.max(current.lastWatched, item.viewedAt);
+			current.eventCount++;
+		} else {
+			historyMap.set(item.ratingKey, {
+				users: new Set([userName]),
+				lastWatched: item.viewedAt,
+				eventCount: 1,
+			});
+		}
+	}
+
+	const rows: PlexEpisodeRow[] = [];
+	const completedAt = new Date();
+	let refreshedShows = 0;
+
+	for (const [tmdbId, ratingKeys] of [...showMap.entries()].sort(([a], [b]) => a - b)) {
+		const copies: PlexEpisodeItem[] = [];
+		for (const ratingKey of [...ratingKeys].sort()) {
+			try {
+				copies.push(...(await client.getEpisodes(ratingKey)));
+			} catch (error) {
+				const message = `Failed to fetch episodes for show tmdb:${tmdbId} copy:${ratingKey}: ${getErrorMessage(error)}`;
+				errorMessages.push(message);
+				log.warn({ err: error, instanceId, tmdbId, ratingKey }, message);
+			}
+		}
+		if (errorMessages.length > 0) continue;
+		refreshedShows++;
+
+		const byCoordinate = new Map<string, PlexEpisodeItem[]>();
+		for (const episode of copies) {
+			const coordinate = `${episode.seasonNumber}:${episode.episodeNumber}`;
+			const episodeCopies = byCoordinate.get(coordinate) ?? [];
+			episodeCopies.push(episode);
+			byCoordinate.set(coordinate, episodeCopies);
+		}
+		for (const episodeCopies of [...byCoordinate.values()].sort(
+			([left], [right]) =>
+				left!.seasonNumber - right!.seasonNumber || left!.episodeNumber - right!.episodeNumber,
+		)) {
+			const episode = [...episodeCopies].sort((left, right) => {
+				const leftCount = Number.isSafeInteger(left.viewCount) ? (left.viewCount ?? 0) : 0;
+				const rightCount = Number.isSafeInteger(right.viewCount) ? (right.viewCount ?? 0) : 0;
+				return rightCount - leftCount || left.ratingKey.localeCompare(right.ratingKey);
+			})[0]!;
+			const watchCount = Math.max(0, episode.viewCount ?? 0);
+			const evidence = episodeCopies
+				.map((copy) => historyMap.get(copy.ratingKey))
+				.filter((entry) => entry !== undefined);
+			const lastWatched = Math.max(
+				...evidence.map((entry) => entry.lastWatched),
+				...episodeCopies.map((copy) => copy.lastViewedAt ?? 0),
+				0,
+			);
+			rows.push({
+				instanceId,
+				showTmdbId: tmdbId,
+				seasonNumber: episode.seasonNumber,
+				episodeNumber: episode.episodeNumber,
+				ratingKey: episode.ratingKey,
+				title: episode.title,
+				watched: watchCount > 0 || evidence.some((entry) => entry.eventCount > 0),
+				watchedByUsers: JSON.stringify(
+					[...new Set(evidence.flatMap((entry) => [...entry.users]))].sort(),
+				),
+				lastWatchedAt: lastWatched > 0 ? new Date(lastWatched * 1000) : null,
+				watchCount,
+				refreshedAt: completedAt,
+				sourceFingerprint,
+			});
+		}
+	}
+
+	if (errorMessages.length > 0 || refreshedShows !== eligibleShows) {
+		return failedResult(errorMessages, eligibleShows, refreshedShows);
+	}
+
+	try {
+		await client.verifyHistorySnapshot(history);
+	} catch (error) {
+		const message = `Failed to revalidate Plex history before publication: ${getErrorMessage(error)}`;
+		log.warn({ err: error, instanceId }, message);
+		return failedResult([message], eligibleShows, refreshedShows);
+	}
+
+	return {
+		upserted: 0,
+		errors: 0,
+		errorMessages: [],
+		eligibleShows,
+		refreshedShows,
+		coverageIncomplete: false,
+		capacityDegraded: false,
+		complete: true,
+		completedAt,
+		rows,
+	};
+}

--- a/apps/api/src/lib/plex/plex-evidence-repository.ts
+++ b/apps/api/src/lib/plex/plex-evidence-repository.ts
@@ -1128,10 +1128,14 @@ export function decodePlexEpisodeGenerationMetadata(raw: string | null):
 	try {
 		const value = JSON.parse(raw) as Record<string, unknown>;
 		if (
-			value.version !== 1 ||
+			value.version !== 2 ||
 			typeof value.parentPlexGenerationId !== "string" ||
 			value.parentPlexGenerationId.trim() === "" ||
 			value.parentPublicationLevel !== "authoritative" ||
+			value.parentMetadataVersion !== 3 ||
+			value.canonicalizationVersion !== 1 ||
+			typeof value.episodeDigest !== "string" ||
+			!/^[a-f0-9]{64}$/.test(value.episodeDigest) ||
 			!Number.isSafeInteger(value.connectionGeneration) ||
 			(value.connectionGeneration as number) < 0 ||
 			!Number.isSafeInteger(value.identityGeneration) ||

--- a/apps/api/src/lib/plex/plex-generation-metadata.ts
+++ b/apps/api/src/lib/plex/plex-generation-metadata.ts
@@ -2,18 +2,22 @@ import type {
 	PlexAttemptState,
 	PlexCoverageReasonCode,
 	PlexEvidenceSummary,
-	PlexGenerationMetadataV2,
+	PlexGenerationDomainRoot,
+	PlexGenerationMetadataV3,
 	PlexGenerationSection,
+	PlexGenerationSectionV3,
 	PlexPublicationLevel,
 } from "@arr/shared";
 
-export type DecodedPlexGenerationMetadata = {
-	version: 1 | 2;
-	publicationLevel: PlexPublicationLevel;
-	completeness: "complete" | "partial";
-	itemCount: number | null;
-	sections: PlexGenerationSection[];
-};
+export type DecodedPlexGenerationMetadata =
+	| {
+			version: 1 | 2;
+			publicationLevel: PlexPublicationLevel;
+			completeness: "complete" | "partial";
+			itemCount: number | null;
+			sections: PlexGenerationSection[];
+	  }
+	| PlexGenerationMetadataV3;
 
 export type PlexGenerationMetadataDecodeResult =
 	| { ok: true; metadata: DecodedPlexGenerationMetadata }
@@ -150,6 +154,76 @@ function normalizeSections(value: unknown): PlexGenerationSection[] | PlexCovera
 	return sections;
 }
 
+function normalizeV3Sections(value: unknown): PlexGenerationSectionV3[] | PlexCoverageReasonCode {
+	const base = normalizeSections(value);
+	if (typeof base === "string") return base;
+	const entries = value as Record<string, unknown>[];
+	const sections: PlexGenerationSectionV3[] = [];
+	for (let index = 0; index < base.length; index++) {
+		const entry = entries[index]!;
+		if (
+			typeof entry.uuid !== "string" ||
+			entry.uuid.trim() === "" ||
+			entry.refreshing !== false ||
+			!Number.isSafeInteger(entry.scannedAt) ||
+			(entry.scannedAt as number) < 0 ||
+			!Number.isSafeInteger(entry.updatedAt) ||
+			(entry.updatedAt as number) < 0
+		) {
+			return "invalid_sections";
+		}
+		sections.push({
+			...base[index]!,
+			uuid: entry.uuid,
+			refreshing: false,
+			scannedAt: entry.scannedAt as number,
+			updatedAt: entry.updatedAt as number,
+		});
+	}
+	return sections;
+}
+
+const canonicalDomains = new Set([
+	"membership",
+	"display",
+	"labels",
+	"collections",
+	"watch",
+	"on-deck",
+	"episode-parents",
+	"episodes",
+]);
+
+function normalizeV3Roots(
+	value: unknown,
+	sectionKeys: ReadonlySet<string>,
+): PlexGenerationDomainRoot[] | PlexCoverageReasonCode {
+	if (!Array.isArray(value)) return "metadata_invalid";
+	const roots: PlexGenerationDomainRoot[] = [];
+	const identities = new Set<string>();
+	for (const entry of value) {
+		if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+			return "metadata_invalid";
+		}
+		const root = entry as Record<string, unknown>;
+		if (
+			typeof root.sectionKey !== "string" ||
+			!sectionKeys.has(root.sectionKey) ||
+			typeof root.domain !== "string" ||
+			!canonicalDomains.has(root.domain) ||
+			typeof root.digest !== "string" ||
+			!/^[a-f0-9]{64}$/.test(root.digest)
+		) {
+			return "metadata_invalid";
+		}
+		const identity = `${root.sectionKey}\u0000${root.domain}`;
+		if (identities.has(identity)) return "metadata_invalid";
+		identities.add(identity);
+		roots.push(root as unknown as PlexGenerationDomainRoot);
+	}
+	return roots;
+}
+
 export function decodePlexGenerationMetadata(
 	raw: string | null | undefined,
 ): PlexGenerationMetadataDecodeResult {
@@ -164,7 +238,10 @@ export function decodePlexGenerationMetadata(
 		return { ok: false, reasonCode: "malformed_metadata" };
 	}
 	const envelope = parsed as Record<string, unknown>;
-	const normalizedSections = normalizeSections(envelope.sections);
+	const normalizedSections =
+		envelope.version === 3
+			? normalizeV3Sections(envelope.sections)
+			: normalizeSections(envelope.sections);
 	if (typeof normalizedSections === "string") {
 		return { ok: false, reasonCode: normalizedSections };
 	}
@@ -181,7 +258,9 @@ export function decodePlexGenerationMetadata(
 			},
 		};
 	}
-	if (envelope.version !== 2) return { ok: false, reasonCode: "unknown_metadata_version" };
+	if (envelope.version !== 2 && envelope.version !== 3) {
+		return { ok: false, reasonCode: "unknown_metadata_version" };
+	}
 	if (
 		envelope.publicationLevel !== "authoritative" &&
 		envelope.publicationLevel !== "positive-only"
@@ -200,6 +279,32 @@ export function decodePlexGenerationMetadata(
 	if (!Number.isSafeInteger(envelope.itemCount) || (envelope.itemCount as number) < 0) {
 		return { ok: false, reasonCode: "invalid_item_count" };
 	}
+	if (envelope.version === 3) {
+		if (
+			envelope.publicationLevel !== "authoritative" ||
+			envelope.completeness !== "complete" ||
+			envelope.canonicalizationVersion !== 1
+		) {
+			return { ok: false, reasonCode: "metadata_invalid" };
+		}
+		const roots = normalizeV3Roots(
+			envelope.roots,
+			new Set(normalizedSections.map((section) => section.key)),
+		);
+		if (typeof roots === "string") return { ok: false, reasonCode: roots };
+		return {
+			ok: true,
+			metadata: {
+				version: 3,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: envelope.itemCount as number,
+				canonicalizationVersion: 1,
+				sections: normalizedSections as PlexGenerationSectionV3[],
+				roots,
+			},
+		};
+	}
 	return {
 		ok: true,
 		metadata: {
@@ -213,15 +318,19 @@ export function decodePlexGenerationMetadata(
 }
 
 export function encodeAuthoritativePlexGenerationMetadata(input: {
-	sections: PlexGenerationSection[];
+	sections: PlexGenerationSectionV3[];
 	itemCount: number;
+	canonicalizationVersion: 1;
+	roots: PlexGenerationDomainRoot[];
 }): string {
-	const metadata: PlexGenerationMetadataV2 = {
-		version: 2,
+	const metadata: PlexGenerationMetadataV3 = {
+		version: 3,
 		publicationLevel: "authoritative",
 		completeness: "complete",
 		itemCount: input.itemCount,
+		canonicalizationVersion: input.canonicalizationVersion,
 		sections: input.sections,
+		roots: input.roots,
 	};
 	const decoded = decodePlexGenerationMetadata(JSON.stringify(metadata));
 	if (!decoded.ok || decoded.metadata.publicationLevel !== "authoritative") {
@@ -272,7 +381,10 @@ export function evaluatePublishedPlexGeneration(
 		decoded.metadata.completeness === "partial" &&
 		(attempt.attemptState === "partial" || attempt.attemptState === "success") &&
 		(attempt.reasonCode === null || attempt.reasonCode === "latest_attempt_partial");
+	const settlementMetadataMissing =
+		decoded.metadata.version < 3 && decoded.metadata.publicationLevel === "authoritative";
 	const authoritativeCurrent =
+		decoded.metadata.version === 3 &&
 		decoded.metadata.publicationLevel === "authoritative" &&
 		decoded.metadata.completeness === "complete" &&
 		attempt.attemptState === "success" &&
@@ -297,7 +409,11 @@ export function evaluatePublishedPlexGeneration(
 					? "positive-only"
 					: "unavailable",
 			completeness: authoritativeCurrent ? "complete" : currentPositiveOnly ? "partial" : "unknown",
-			reasonCodes: attempt.reasonCode ? [attempt.reasonCode] : [],
+			reasonCodes: attempt.reasonCode
+				? [attempt.reasonCode]
+				: settlementMetadataMissing
+					? ["plex_settlement_metadata_missing"]
+					: [],
 			publishedGeneration,
 		},
 	};

--- a/apps/api/src/lib/plex/plex-live-settlement.ts
+++ b/apps/api/src/lib/plex/plex-live-settlement.ts
@@ -1,0 +1,69 @@
+import type { PlexCoverageReasonCode } from "@arr/shared";
+
+export type PlexLiveSection = {
+	key: string;
+	uuid: string;
+	title: string;
+	type: string;
+	refreshing: boolean;
+	scannedAt: number | null;
+	updatedAt: number;
+	agent?: string;
+};
+
+export type PlexLiveActivity = {
+	type: string;
+	Context?: { librarySectionID?: string };
+};
+
+export type PlexLiveSettlementResult =
+	| { settled: true; reasonCodes: [] }
+	| { settled: false; reasonCodes: PlexCoverageReasonCode[] };
+
+export function evaluatePlexLiveSettlement(input: {
+	activities: readonly PlexLiveActivity[];
+	sections: readonly PlexLiveSection[];
+	selectedSectionKeys: readonly string[];
+}): PlexLiveSettlementResult {
+	const sectionByKey = new Map(input.sections.map((section) => [section.key, section]));
+	const selected = new Set(input.selectedSectionKeys);
+	for (const sectionKey of selected) {
+		const section = sectionByKey.get(sectionKey);
+		if (!section) {
+			return { settled: false, reasonCodes: ["plex_library_revision_changed"] };
+		}
+		if (section.refreshing) {
+			return { settled: false, reasonCodes: ["plex_library_scan_in_progress"] };
+		}
+		if (section.scannedAt === null) {
+			return { settled: false, reasonCodes: ["plex_library_revision_changed"] };
+		}
+	}
+
+	for (const activity of input.activities) {
+		if (activity.type === "library.update.item.metadata") {
+			return { settled: false, reasonCodes: ["plex_metadata_refresh_in_progress"] };
+		}
+		if (activity.type === "library.update.section") {
+			const sectionKey = activity.Context?.librarySectionID;
+			if (!sectionKey) {
+				return { settled: false, reasonCodes: ["plex_library_activity_unknown"] };
+			}
+			const section = sectionByKey.get(sectionKey);
+			if (!section) {
+				return { settled: false, reasonCodes: ["plex_library_activity_unknown"] };
+			}
+			if (selected.has(sectionKey)) {
+				return { settled: false, reasonCodes: ["plex_library_scan_in_progress"] };
+			}
+			if (section.type === "artist") continue;
+			if (section.type === "movie" || section.type === "show") continue;
+			return { settled: false, reasonCodes: ["plex_library_activity_unknown"] };
+		}
+		if (activity.type.startsWith("library.update.")) {
+			return { settled: false, reasonCodes: ["plex_library_activity_unknown"] };
+		}
+	}
+
+	return { settled: true, reasonCodes: [] };
+}

--- a/apps/api/src/lib/plex/plex-persisted-observation-repository.ts
+++ b/apps/api/src/lib/plex/plex-persisted-observation-repository.ts
@@ -1,0 +1,12 @@
+/**
+ * Explicit historical-observation surface. These loaders describe immutable
+ * published generations for status, diagnostics, and refresh scheduling only.
+ * They do not establish current exact, negative, or mutation authority.
+ */
+export {
+	getPublishedEpisodeGenerationObservation,
+	getPublishedGenerationObservation,
+	getPublishedGenerationObservationForOwnedInstance,
+	loadGenerationObservationsForOwnedInstances,
+	loadUserGenerationObservations,
+} from "./plex-evidence-repository.js";

--- a/apps/api/src/lib/plex/plex-schemas.ts
+++ b/apps/api/src/lib/plex/plex-schemas.ts
@@ -50,6 +50,59 @@ export const plexSectionsResponseSchema = z.looseObject({
 	}),
 });
 
+const plexBooleanFlagSchema = z
+	.union([z.boolean(), z.literal(0), z.literal(1), z.literal("0"), z.literal("1")])
+	.transform((value) => value === true || value === 1 || value === "1");
+
+const plexUnixTimestampSchema = z.coerce.number().int().nonnegative().refine(Number.isSafeInteger);
+
+const plexUninitializedUnixTimestampSchema = z.preprocess(
+	(value) => (value === undefined || value === null || value === "" ? null : value),
+	plexUnixTimestampSchema.nullable(),
+);
+
+/** Strict /library/sections settlement probe. */
+export const plexSettlementSectionsResponseSchema = z.looseObject({
+	MediaContainer: z.looseObject({
+		offset: plexPaginationFields.offset.optional(),
+		size: plexPaginationFields.size,
+		totalSize: plexPaginationFields.totalSize.optional(),
+		Directory: z
+			.array(
+				z.looseObject({
+					key: z.coerce.string().min(1),
+					uuid: z.string().min(1),
+					title: z.string(),
+					type: z.string().min(1),
+					agent: z.string().optional(),
+					refreshing: plexBooleanFlagSchema,
+					scannedAt: plexUninitializedUnixTimestampSchema,
+					updatedAt: plexUnixTimestampSchema,
+				}),
+			)
+			.optional(),
+	}),
+});
+
+/** Strict complete /activities settlement probe. */
+export const plexActivitiesResponseSchema = z.looseObject({
+	MediaContainer: z.looseObject({
+		offset: plexPaginationFields.offset.optional(),
+		size: plexPaginationFields.size,
+		totalSize: plexPaginationFields.totalSize.optional(),
+		Activity: z
+			.array(
+				z.looseObject({
+					type: z.string().min(1),
+					Context: z
+						.looseObject({ librarySectionID: z.coerce.string().min(1).optional() })
+						.optional(),
+				}),
+			)
+			.optional(),
+	}),
+});
+
 /** /library/sections/{id}/all endpoint */
 export const plexLibraryItemsResponseSchema = z.looseObject({
 	MediaContainer: z.looseObject({
@@ -63,8 +116,26 @@ export const plexLibraryItemsResponseSchema = z.looseObject({
 					year: z.number().optional(),
 					userRating: z.number().optional(),
 					addedAt: z.number().optional(),
+					viewCount: plexUnixTimestampSchema.optional(),
+					lastViewedAt: plexUnixTimestampSchema.optional(),
 					thumb: z.string().optional(),
 					Guid: z.array(z.looseObject({ id: z.string() })).optional(),
+					Collection: z.array(z.looseObject({ tag: z.string() })).optional(),
+					Label: z.array(z.looseObject({ tag: z.string() })).optional(),
+				}),
+			)
+			.optional(),
+	}),
+});
+
+/** /library/metadata/{ids} bounded tag enrichment response. */
+export const plexMetadataTagsResponseSchema = z.looseObject({
+	MediaContainer: z.looseObject({
+		size: plexPaginationFields.size,
+		Metadata: z
+			.array(
+				z.looseObject({
+					ratingKey: z.string().min(1),
 					Collection: z.array(z.looseObject({ tag: z.string() })).optional(),
 					Label: z.array(z.looseObject({ tag: z.string() })).optional(),
 				}),

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -32,7 +32,7 @@ import { createJellyfinClient } from "../jellyfin/jellyfin-client.js";
 import {
 	getPublishedEpisodeGenerationObservation,
 	loadUserGenerationObservations,
-} from "../plex/plex-evidence-repository.js";
+} from "../plex/plex-persisted-observation-repository.js";
 import { createPlexClient } from "../plex/plex-client.js";
 import { createQuiClient } from "../qui/client-factory.js";
 import { listQuiInstances } from "../qui/instance-helpers.js";

--- a/apps/api/src/lib/services/provider-cache-status.database.test.ts
+++ b/apps/api/src/lib/services/provider-cache-status.database.test.ts
@@ -314,8 +314,20 @@ describe("provider cache status SQLite takeover contract", () => {
 				completedAt,
 				generationId: "replacement-generation",
 				generationMetadata: encodeAuthoritativePlexGenerationMetadata({
-					sections: [{ key: "movies", title: "Movies", type: "movie" }],
+					sections: [
+						{
+							key: "movies",
+							uuid: "movies-uuid",
+							title: "Movies",
+							type: "movie",
+							refreshing: false,
+							scannedAt: 1,
+							updatedAt: 1,
+						},
+					],
 					itemCount: 1,
+					canonicalizationVersion: 1,
+					roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
 				}),
 				attempt: attemptB!,
 			});

--- a/apps/api/src/plugins/insights-digest-scheduler.ts
+++ b/apps/api/src/plugins/insights-digest-scheduler.ts
@@ -31,6 +31,7 @@ const insightsDigestSchedulerPlugin = fastifyPlugin(
 						app.prisma,
 						app.log,
 						app.arrClientFactory,
+						app.encryptor,
 						(payload) => app.notificationService.notify(payload),
 						{ trackTick: (fn) => app.schedulerRegistry.track(JOB_ID.insightsDigest, fn) },
 					);

--- a/apps/api/src/plugins/plex-cache-scheduler.ts
+++ b/apps/api/src/plugins/plex-cache-scheduler.ts
@@ -7,7 +7,7 @@
 
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
-import { loadGenerationObservationsForOwnedInstances } from "../lib/plex/plex-evidence-repository.js";
+import { loadGenerationObservationsForOwnedInstances } from "../lib/plex/plex-persisted-observation-repository.js";
 import { refreshOwnedPlexCache } from "../lib/plex/plex-refresh-orchestration.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 

--- a/apps/api/src/plugins/plex-episode-cache-scheduler.ts
+++ b/apps/api/src/plugins/plex-episode-cache-scheduler.ts
@@ -8,7 +8,7 @@
 
 import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
-import { getPublishedEpisodeGenerationObservation } from "../lib/plex/plex-evidence-repository.js";
+import { getPublishedEpisodeGenerationObservation } from "../lib/plex/plex-persisted-observation-repository.js";
 import { refreshOwnedPlexEpisodeCache } from "../lib/plex/plex-refresh-orchestration.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
 

--- a/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
@@ -4,6 +4,43 @@ import { plexConnectionFingerprint } from "../../lib/plex/service-instance-finge
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
 
+vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../lib/plex/plex-authority-service.js")>();
+	const repository = await import("../../lib/plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: {
+				serviceInstance: { findMany: (input: unknown) => Promise<Array<Record<string, unknown>>> };
+			};
+
+			constructor(input: {
+				prisma: {
+					serviceInstance: {
+						findMany: (input: unknown) => Promise<Array<Record<string, unknown>>>;
+					};
+				};
+			}) {
+				this.prisma = input.prisma;
+			}
+
+			async readInstanceEpisodes(input: { userId: string; instanceId: string }) {
+				const instances = await this.prisma.serviceInstance.findMany({
+					where: { userId: input.userId, service: "PLEX", enabled: true },
+				});
+				const instance = instances.find((entry) => entry.id === input.instanceId);
+				return repository.loadInstanceEpisodeEvidence(
+					this.prisma as never,
+					{
+						...input,
+						instance: instance as never,
+					} as never,
+				);
+			}
+		},
+	};
+});
+
 const USER_ID = "user-episode-explain";
 const SONARR_INSTANCE_ID = "sonarr-1";
 const PLEX_INSTANCE_ID = "plex-1";
@@ -170,7 +207,23 @@ beforeEach(async () => {
 								cacheType: "plex",
 								generationId: parentGenerationId,
 								generationMetadata: JSON.stringify({
-									sections: [{ key: "1", title: "TV", type: "show" }],
+									version: 3,
+									publicationLevel: "authoritative",
+									completeness: "complete",
+									itemCount: 1,
+									canonicalizationVersion: 1,
+									sections: [
+										{
+											key: "1",
+											uuid: "shows-uuid",
+											title: "TV",
+											type: "show",
+											refreshing: false,
+											scannedAt: 1_777_000_000,
+											updatedAt: 1_777_000_100,
+										},
+									],
+									roots: [{ sectionKey: "1", domain: "membership", digest: "a".repeat(64) }],
 								}),
 							}
 						: {
@@ -178,9 +231,12 @@ beforeEach(async () => {
 								cacheType: "plex_episode",
 								generationId: "plex-episode-generation-1",
 								generationMetadata: JSON.stringify({
-									version: 1,
+									version: 2,
 									parentPlexGenerationId: parentGenerationId,
 									parentPublicationLevel: "authoritative",
+									parentMetadataVersion: 3,
+									canonicalizationVersion: 1,
+									episodeDigest: "b".repeat(64),
 									connectionGeneration: 4,
 									identityGeneration: 9,
 								}),

--- a/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
@@ -19,6 +19,24 @@
 
 import Fastify, { type FastifyInstance } from "fastify";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../lib/plex/plex-authority-service.js")>();
+	const repository = await import("../../lib/plex/plex-evidence-repository.js");
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			constructor(
+				private readonly deps: { prisma: Parameters<typeof repository.scanUserPolicyEvidence>[0] },
+			) {}
+
+			async scanUserPolicy(input: Parameters<typeof repository.scanUserPolicyEvidence>[1]) {
+				return await repository.scanUserPolicyEvidence(this.deps.prisma, input);
+			}
+		},
+	};
+});
+
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
 
@@ -294,9 +312,34 @@ describe("GET /library-cleanup/field-options — cursor pagination (issue #427)"
 				identityGeneration: 1,
 				generationId: "generation-1",
 				generationMetadata: JSON.stringify({
+					version: 3,
+					publicationLevel: "authoritative",
+					completeness: "complete",
+					itemCount: 501,
+					canonicalizationVersion: 1,
 					sections: [
-						{ key: "movies", title: "Movies", type: "movie" },
-						{ key: "shows", title: "TV Shows", type: "show" },
+						{
+							key: "movies",
+							title: "Movies",
+							type: "movie",
+							uuid: "movies-uuid",
+							refreshing: false,
+							scannedAt: 1,
+							updatedAt: 1,
+						},
+						{
+							key: "shows",
+							title: "TV Shows",
+							type: "show",
+							uuid: "shows-uuid",
+							refreshing: false,
+							scannedAt: 1,
+							updatedAt: 1,
+						},
+					],
+					roots: [
+						{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) },
+						{ sectionKey: "shows", domain: "membership", digest: "b".repeat(64) },
 					],
 				}),
 			},

--- a/apps/api/src/routes/__tests__/library-insights-authority.test.ts
+++ b/apps/api/src/routes/__tests__/library-insights-authority.test.ts
@@ -13,6 +13,15 @@ vi.mock("../../lib/plex/plex-evidence-repository.js", async (importOriginal) => 
 	scanUserPolicyEvidence: mocks.scanUserPolicyEvidence,
 }));
 
+vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../lib/plex/plex-authority-service.js")>()),
+	PlexAuthorityService: class {
+		async scanUserPolicy(input: unknown) {
+			return await mocks.scanUserPolicyEvidence(undefined, input);
+		}
+	},
+}));
+
 import { registerInsightsRoutes } from "../library/insights-routes.js";
 
 const unavailableEvidence = {

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -103,7 +103,25 @@ function makeStaleRow(overrides: Partial<CacheStatusRow> = {}): CacheStatusRow {
 		lastAttemptErrorMessage: null,
 		itemCount: 0,
 		generationId: "plex-generation-1",
-		generationMetadata: '{"sections":[]}',
+		generationMetadata: JSON.stringify({
+			version: 3,
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			itemCount: 0,
+			canonicalizationVersion: 1,
+			sections: [
+				{
+					key: "movies",
+					title: "Movies",
+					type: "movie",
+					uuid: "movies-uuid",
+					refreshing: false,
+					scannedAt: 1,
+					updatedAt: 1,
+				},
+			],
+			roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+		}),
 		connectionGeneration: 1,
 		identityGeneration: 1,
 		instance: {

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -60,9 +60,9 @@ import {
 import {
 	hasAuthoritativePlexEvidence,
 	listPublishedSections,
-	scanUserPolicyEvidence,
 	summarizePlexEvidence,
-} from "../lib/plex/plex-evidence-repository.js";
+} from "../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../lib/plex/plex-authority-service.js";
 import { createQuiClient } from "../lib/qui/client-factory.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
 import { safeJsonParse as utilSafeJsonParse } from "../lib/utils/json.js";
@@ -524,8 +524,13 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 		const scannedPlexUsers = new Set<string>();
 		const scannedPlexCollections = new Set<string>();
 		const scannedPlexLabels = new Set<string>();
-		const plexEvidence = await scanUserPolicyEvidence(app.prisma, {
+		const plexEvidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).scanUserPolicy({
 			userId,
+			domains: ["membership", "watch", "collections", "labels"],
 			onBatch: ({ rows }) => {
 				for (const row of rows) {
 					collectStrings(row.watchedByUsers, scannedPlexUsers);

--- a/apps/api/src/routes/library/insights-routes.ts
+++ b/apps/api/src/routes/library/insights-routes.ts
@@ -14,9 +14,9 @@ import type { FastifyPluginCallback } from "fastify";
 import { z } from "zod";
 import {
 	hasAuthoritativePlexEvidence,
-	scanUserPolicyEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { SeerrClient } from "../../lib/seerr/seerr-client.js";
 import { safeJsonParse } from "../../lib/utils/json.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -104,8 +104,13 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		// Get user's media server instances to load watch data
 		const watchCounts = new Map<string, number>();
 		const [plexEvidence, jellyfinInstances] = await Promise.all([
-			scanUserPolicyEvidence(app.prisma, {
+			new PlexAuthorityService({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				log: request.log,
+			}).scanUserPolicy({
 				userId,
+				domains: ["membership", "watch"],
 				onBatch: ({ rows }) => {
 					for (const row of rows) {
 						const key = `${row.mediaType}:${row.tmdbId}`;
@@ -252,8 +257,13 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 			}
 		};
 		const [plexEvidence, jellyfinInstances] = await Promise.all([
-			scanUserPolicyEvidence(app.prisma, {
+			new PlexAuthorityService({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				log: request.log,
+			}).scanUserPolicy({
 				userId,
+				domains: ["membership", "watch"],
 				onBatch: ({ rows }) => {
 					for (const row of rows) {
 						mergeWatchRow(`${row.mediaType}:${row.tmdbId}`, row.watchCount, row.lastWatchedAt);
@@ -390,8 +400,13 @@ export const registerInsightsRoutes: FastifyPluginCallback = (app, _opts, done) 
 		// Get media server watch data — Plex + Jellyfin/Emby
 		const watchCounts = new Map<string, number>();
 		const [plexEvidence, jellyfinInstances] = await Promise.all([
-			scanUserPolicyEvidence(app.prisma, {
+			new PlexAuthorityService({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				log: request.log,
+			}).scanUserPolicy({
 				userId,
+				domains: ["membership", "watch"],
 				onBatch: ({ rows }) => {
 					for (const row of rows) {
 						const key = `${row.mediaType}:${row.tmdbId}`;

--- a/apps/api/src/routes/plex/__tests__/cache-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/cache-routes.test.ts
@@ -28,6 +28,19 @@ vi.mock("../../../lib/plex/plex-evidence-repository.js", async (importOriginal) 
 	getPublishedEpisodeGenerationObservation: mocks.getPublishedEpisodeGenerationObservation,
 }));
 
+vi.mock("../../../lib/plex/plex-authority-service.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../lib/plex/plex-authority-service.js")>();
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			async readInstance() {
+				return await mocks.getPublishedGenerationObservation();
+			}
+		},
+	};
+});
+
 import { registerCacheRoutes } from "../cache-routes.js";
 
 describe("POST /api/plex/cache/:instanceId/refresh publication authority", () => {

--- a/apps/api/src/routes/plex/__tests__/section-routes-authority.test.ts
+++ b/apps/api/src/routes/plex/__tests__/section-routes-authority.test.ts
@@ -11,6 +11,19 @@ vi.mock("../../../lib/plex/plex-evidence-repository.js", async (importOriginal) 
 	loadUserSelectedEvidence: mocks.loadUserSelectedEvidence,
 }));
 
+vi.mock("../../../lib/plex/plex-authority-service.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../lib/plex/plex-authority-service.js")>();
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			readUserSelected(input: unknown) {
+				return mocks.loadUserSelectedEvidence(undefined, input);
+			}
+		},
+	};
+});
+
 import { registerSectionRoutes } from "../section-routes.js";
 
 describe("GET /api/plex/sections authority", () => {

--- a/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
+++ b/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
@@ -23,6 +23,55 @@ vi.mock("../../../lib/plex/plex-evidence-repository.js", async (importOriginal) 
 	scanUserPolicyEvidence: mocks.scanUserPolicyEvidence,
 }));
 
+vi.mock("../../../lib/plex/plex-authority-service.js", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("../../../lib/plex/plex-authority-service.js")>();
+	return {
+		...actual,
+		PlexAuthorityService: class {
+			private readonly prisma: unknown;
+
+			constructor(input: { prisma: unknown }) {
+				this.prisma = input.prisma;
+			}
+
+			readInstance(input: unknown) {
+				return mocks.loadInstanceEvidence(this.prisma, input);
+			}
+
+			readInstanceSelected(input: unknown) {
+				return mocks.loadInstanceEvidence(this.prisma, input);
+			}
+
+			readUserSelected(input: unknown) {
+				return mocks.loadUserSelectedEvidence(this.prisma, input);
+			}
+
+			async scanInstancePolicy(input: { onBatch?: (batch: { rows: unknown[] }) => void }) {
+				const evidence = await mocks.scanInstancePolicyEvidence(this.prisma, input);
+				if (evidence.available) input.onBatch?.({ rows: evidence.rows });
+				return evidence;
+			}
+
+			async scanUserPolicy(input: { onBatch?: (batch: { rows: unknown[] }) => void }) {
+				const evidence = await mocks.scanUserPolicyEvidence(this.prisma, input);
+				for (const entry of evidence) {
+					if (entry.available) input.onBatch?.({ rows: entry.rows });
+				}
+				return evidence;
+			}
+
+			readInstanceEpisodes(input: unknown) {
+				return mocks.loadInstanceEpisodeEvidence(this.prisma, input);
+			}
+
+			readInstanceSelectedEpisodes(input: unknown) {
+				return mocks.loadInstanceSelectedEpisodeEvidence(this.prisma, input);
+			}
+		},
+	};
+});
+
 import { registerCollectionRoutes } from "../collection-routes.js";
 import { registerCollectionStatsRoutes } from "../collection-stats-routes.js";
 import { registerEpisodeRoutes } from "../episode-routes.js";

--- a/apps/api/src/routes/plex/cache-routes.ts
+++ b/apps/api/src/routes/plex/cache-routes.ts
@@ -12,10 +12,12 @@ import { requireEnabledInstance } from "../../lib/arr/instance-helpers.js";
 import { AppValidationError } from "../../lib/errors.js";
 import {
 	getPublishedEpisodeGenerationObservation,
-	getPublishedGenerationObservation,
-	isCurrentAuthoritativePlexEvidence,
 	loadUserGenerationObservations,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-persisted-observation-repository.js";
+import {
+	isCurrentAuthoritativePlexEvidence,
+	PlexAuthorityService,
+} from "../../lib/plex/plex-authority-service.js";
 import { requirePlexClient } from "../../lib/plex/plex-helpers.js";
 import { refreshOwnedPlexCache } from "../../lib/plex/plex-refresh-orchestration.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -40,7 +42,15 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 		// Verify ownership
 		await requirePlexClient(app, userId, instanceId);
 
-		const evidence = await getPublishedGenerationObservation(app.prisma, { userId, instanceId });
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readInstance({
+			userId,
+			instanceId,
+			domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
+		});
 		if (!evidence.available || !isCurrentAuthoritativePlexEvidence(evidence.evidence)) {
 			return reply.status(503).send({
 				error: "Plex cache evidence is unavailable",

--- a/apps/api/src/routes/plex/collection-routes.ts
+++ b/apps/api/src/routes/plex/collection-routes.ts
@@ -10,10 +10,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	isCurrentAuthoritativePlexEvidence,
-	scanInstancePolicyEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
-import { requirePlexClient } from "../../lib/plex/plex-helpers.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 // ============================================================================
@@ -57,9 +56,14 @@ export async function registerCollectionRoutes(app: FastifyInstance, _opts: Fast
 		}
 
 		const collectionCounts = new Map<string, number>();
-		const evidence = await scanInstancePolicyEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).scanInstancePolicy({
 			userId,
 			instanceId,
+			domains: ["membership", "collections"],
 			onBatch: ({ rows }) => {
 				for (const row of rows) {
 					try {
@@ -104,9 +108,14 @@ export async function registerCollectionRoutes(app: FastifyInstance, _opts: Fast
 		}
 
 		const labelCounts = new Map<string, number>();
-		const evidence = await scanInstancePolicyEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).scanInstancePolicy({
 			userId,
 			instanceId,
+			domains: ["membership", "labels"],
 			onBatch: ({ rows }) => {
 				for (const row of rows) {
 					try {
@@ -144,8 +153,44 @@ export async function registerCollectionRoutes(app: FastifyInstance, _opts: Fast
 		const body = validateRequest(tagUpdateBody, request.body);
 		const userId = request.currentUser!.id;
 
-		const { client } = await requirePlexClient(app, userId, instanceId);
-		await client.updateMetadataTags(ratingKey, body.type, body.action, body.name);
+		const authority = new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		});
+		const evidence = await authority.readInstance({
+			userId,
+			instanceId,
+			domains: ["membership", body.type === "label" ? "labels" : "collections"],
+		});
+		if (!evidence.available || !isCurrentAuthoritativePlexEvidence(evidence.evidence)) {
+			return reply.status(503).send({
+				error: "Plex mutation authority is unavailable",
+				evidence: evidence.evidence,
+			});
+		}
+		const matches = evidence.rows.filter((row) => row.ratingKey?.trim() === ratingKey);
+		if (
+			matches.length !== 1 ||
+			(matches[0]?.mediaType !== "movie" && matches[0]?.mediaType !== "series")
+		) {
+			return reply.status(409).send({ error: "Plex target identity is ambiguous or unavailable" });
+		}
+		const mutation = await authority.mutateMetadataTag({
+			userId,
+			instanceId,
+			target: { tmdbId: matches[0].tmdbId, mediaType: matches[0].mediaType },
+			expectedRatingKey: ratingKey,
+			type: body.type,
+			action: body.action,
+			name: body.name,
+		});
+		if (!mutation.ok) {
+			return reply.status(503).send({
+				error: "Plex mutation authority changed before the upstream write",
+				evidence: mutation.evidence,
+			});
+		}
 
 		return reply.send({ success: true });
 	});

--- a/apps/api/src/routes/plex/collection-stats-routes.ts
+++ b/apps/api/src/routes/plex/collection-stats-routes.ts
@@ -7,9 +7,9 @@
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
 	hasAuthoritativePlexEvidence,
-	scanUserPolicyEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { createCollectionStatsAccumulator } from "./lib/collection-stats-helpers.js";
 
 export async function registerCollectionStatsRoutes(
@@ -20,8 +20,13 @@ export async function registerCollectionStatsRoutes(
 		const userId = request.currentUser!.id;
 
 		const accumulator = createCollectionStatsAccumulator();
-		const evidence = await scanUserPolicyEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).scanUserPolicy({
 			userId,
+			domains: ["membership", "collections"],
 			onBatch: ({ rows }) => accumulator.add(rows),
 		});
 		const summary = summarizePlexEvidence(evidence);

--- a/apps/api/src/routes/plex/episode-routes.ts
+++ b/apps/api/src/routes/plex/episode-routes.ts
@@ -9,9 +9,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	isCurrentAuthoritativePlexEvidence,
-	loadInstanceSelectedEpisodeEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 const episodeQuery = z.object({
@@ -37,7 +37,11 @@ export async function registerEpisodeRoutes(app: FastifyInstance, _opts: Fastify
 		const { instanceId, showTmdbId } = validateRequest(episodeQuery, request.query);
 		const userId = request.currentUser!.id;
 
-		const evidence = await loadInstanceSelectedEpisodeEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readInstanceSelectedEpisodes({
 			userId,
 			instanceId,
 			showTmdbIds: [showTmdbId],

--- a/apps/api/src/routes/plex/on-deck-routes.ts
+++ b/apps/api/src/routes/plex/on-deck-routes.ts
@@ -9,9 +9,9 @@ import type { PlexOnDeckResponse } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
 	hasAuthoritativeSelectedPlexEvidence,
-	loadUserSelectedEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { mapToOnDeckItems } from "./lib/on-deck-helpers.js";
 
 export async function registerOnDeckRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
@@ -23,9 +23,14 @@ export async function registerOnDeckRoutes(app: FastifyInstance, _opts: FastifyP
 	app.get("/", async (request, reply) => {
 		const userId = request.currentUser!.id;
 
-		const evidence = await loadUserSelectedEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readUserSelected({
 			userId,
 			selection: { kind: "on-deck", limit: 50 },
+			domains: ["membership", "display", "on-deck"],
 		});
 		const summary = summarizePlexEvidence(evidence);
 		if (!hasAuthoritativeSelectedPlexEvidence(evidence)) {

--- a/apps/api/src/routes/plex/recently-added-routes.ts
+++ b/apps/api/src/routes/plex/recently-added-routes.ts
@@ -10,9 +10,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	hasAuthoritativeSelectedPlexEvidence,
-	loadUserSelectedEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { mapToRecentlyAddedItems } from "./lib/recently-added-helpers.js";
 
@@ -40,9 +40,14 @@ export async function registerRecentlyAddedRoutes(
 		const { limit } = validateRequest(recentlyAddedQuery, request.query);
 		const userId = request.currentUser!.id;
 
-		const evidence = await loadUserSelectedEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readUserSelected({
 			userId,
 			selection: { kind: "recently-added", limit },
+			domains: ["membership", "display"],
 		});
 		const summary = summarizePlexEvidence(evidence);
 		if (!hasAuthoritativeSelectedPlexEvidence(evidence)) {

--- a/apps/api/src/routes/plex/section-routes.ts
+++ b/apps/api/src/routes/plex/section-routes.ts
@@ -8,9 +8,9 @@ import type { PlexSectionsResponse } from "@arr/shared";
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import {
 	hasAuthoritativeSelectedPlexEvidence,
-	loadUserSelectedEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { mapToSections } from "./lib/section-helpers.js";
 
 export async function registerSectionRoutes(app: FastifyInstance, _opts: FastifyPluginOptions) {
@@ -23,9 +23,14 @@ export async function registerSectionRoutes(app: FastifyInstance, _opts: Fastify
 	app.get("/", async (request, reply) => {
 		const userId = request.currentUser!.id;
 
-		const evidence = await loadUserSelectedEvidence(app.prisma, {
+		const evidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readUserSelected({
 			userId,
 			selection: { kind: "authority-only" },
+			domains: [],
 		});
 		const summary = summarizePlexEvidence(evidence);
 		if (!hasAuthoritativeSelectedPlexEvidence(evidence)) {

--- a/apps/api/src/routes/plex/series-progress-routes.ts
+++ b/apps/api/src/routes/plex/series-progress-routes.ts
@@ -10,9 +10,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	hasCompleteAuthoritativePlexEvidence,
-	loadInstanceSelectedEpisodeEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { aggregateSeriesProgress } from "./lib/series-progress-helpers.js";
 
@@ -64,9 +64,14 @@ export async function registerSeriesProgressRoutes(
 		}
 
 		const evidence = [];
+		const authority = new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		});
 		for (const instance of plexInstances) {
 			evidence.push(
-				await loadInstanceSelectedEpisodeEvidence(app.prisma, {
+				await authority.readInstanceSelectedEpisodes({
 					userId,
 					instanceId: instance.id,
 					showTmdbIds: tmdbIds,

--- a/apps/api/src/routes/plex/user-episode-completion-routes.ts
+++ b/apps/api/src/routes/plex/user-episode-completion-routes.ts
@@ -9,9 +9,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	hasCompleteAuthoritativePlexEvidence,
-	loadInstanceSelectedEpisodeEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { aggregateUserEpisodeCompletion } from "./lib/user-episode-helpers.js";
 
@@ -56,9 +56,14 @@ export async function registerUserEpisodeCompletionRoutes(
 		}
 
 		const evidence = [];
+		const authority = new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		});
 		for (const instance of plexInstances) {
 			evidence.push(
-				await loadInstanceSelectedEpisodeEvidence(app.prisma, {
+				await authority.readInstanceSelectedEpisodes({
 					userId,
 					instanceId: instance.id,
 					showTmdbIds: tmdbIds,

--- a/apps/api/src/routes/plex/watch-enrichment-routes.ts
+++ b/apps/api/src/routes/plex/watch-enrichment-routes.ts
@@ -10,9 +10,9 @@ import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
 import {
 	hasAuthoritativeSelectedPlexEvidence,
-	loadUserSelectedEvidence,
 	summarizePlexEvidence,
-} from "../../lib/plex/plex-evidence-repository.js";
+} from "../../lib/plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { aggregateWatchEnrichment } from "./lib/watch-enrichment-helpers.js";
 
@@ -76,7 +76,11 @@ export async function registerWatchEnrichmentRoutes(
 
 		const tmdbIdList = [...new Set(tmdbIds)];
 
-		const plexEvidence = await loadUserSelectedEvidence(app.prisma, {
+		const plexEvidence = await new PlexAuthorityService({
+			prisma: app.prisma,
+			encryptor: app.encryptor,
+			log: request.log,
+		}).readUserSelected({
 			userId,
 			selection: {
 				kind: "targets",
@@ -85,6 +89,7 @@ export async function registerWatchEnrichmentRoutes(
 					{ tmdbId, mediaType: "series" as const },
 				]),
 			},
+			domains: ["membership", "display", "labels", "collections", "watch", "on-deck"],
 		});
 		const evidenceSummary = summarizePlexEvidence(plexEvidence);
 		if (plexEvidence.length > 0 && !hasAuthoritativeSelectedPlexEvidence(plexEvidence)) {

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -43,7 +43,15 @@ export type PlexCoverageReasonCode =
 	| "metadata_invalid"
 	| "mutation_authority_unavailable"
 	| "query_failed"
-	| "parent_generation_unavailable";
+	| "parent_generation_unavailable"
+	| "plex_activity_unavailable"
+	| "plex_section_state_unavailable"
+	| "plex_library_scan_in_progress"
+	| "plex_metadata_refresh_in_progress"
+	| "plex_library_activity_unknown"
+	| "plex_library_revision_changed"
+	| "plex_content_digest_changed"
+	| "plex_settlement_metadata_missing";
 
 export interface PlexEvidenceSummary {
 	/** Current trust, retained under the original field name for older clients. */
@@ -75,6 +83,42 @@ export interface PlexGenerationMetadataV2 {
 	completeness: "complete" | "partial";
 	itemCount: number;
 	sections: PlexGenerationSection[];
+}
+
+export const PLEX_CANONICAL_DOMAINS = [
+	"membership",
+	"display",
+	"labels",
+	"collections",
+	"watch",
+	"on-deck",
+	"episode-parents",
+	"episodes",
+] as const;
+
+export type PlexCanonicalDomain = (typeof PLEX_CANONICAL_DOMAINS)[number];
+
+export interface PlexGenerationSectionV3 extends PlexGenerationSection {
+	uuid: string;
+	refreshing: false;
+	scannedAt: number;
+	updatedAt: number;
+}
+
+export interface PlexGenerationDomainRoot {
+	sectionKey: string;
+	domain: PlexCanonicalDomain;
+	digest: string;
+}
+
+export interface PlexGenerationMetadataV3 {
+	version: 3;
+	publicationLevel: "authoritative";
+	completeness: "complete";
+	itemCount: number;
+	canonicalizationVersion: 1;
+	sections: PlexGenerationSectionV3[];
+	roots: PlexGenerationDomainRoot[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Plex cache publication, exact reads, and mutations now require a live settled observation that agrees with the persisted V3 generation. Active scans and metadata refreshes in any supported non-Personal-Media Movie or Show library block authority, while content comparison remains limited to the requested targets and domains.

## Related issue

Related to #783

## Scope

This PR adds bounded V3 settlement metadata, strict live Plex probes, versioned canonical projections, and `PlexAuthorityService`. It migrates existing exact-read and mutation consumers in Plex routes, library cleanup, label sync, insights, notifications, and episode reads to that authority boundary.

## Non-goals

PR 2 target ledger, PR 3 positive-only publication, Tautulli, connection testing, `next`, and release work are out of scope.

## Acceptance criteria

- [x] An active Plex library scan or metadata refresh blocks publication and exact or mutation authority.
- [x] A changed content digest, including a same-second collision, fails closed.
- [x] V3 publication requires settled live probes around the terminal canonical observation.
- [x] Mutations reacquire live authority immediately before the write and preserve the existing rating-key and thumbnail parity check.
- [x] Episode reads bind their episode observation to a complete parent-library fixed point.
- [x] Duplicate live provider targets cannot be treated as a unique mutation target.
- [x] Real PMS cases A1 through J passed against `plexinc/pms-docker:1.43.3.10896-cb3ebc72d`.

## Changes

- Added strict activity and settlement probes with in-flight-only read coalescing and uncached mutation probes.
- Added bounded V3 section and domain roots using versioned canonical SHA-256 projections.
- Centralized publication, exact-read, and mutation authority in `PlexAuthorityService`.
- Added a parent-bound episode collector and revalidation fixed point.
- Added architecture tests that prevent raw authority and direct Plex mutation escape hatches.
- Preserved historical observation access behind a named persisted-observation repository.
- Settled and identity-compared the complete supported non-Personal-Media Movie and Show catalog on every authority window.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable
- [x] New queries use centralized query keys and polling constants, when applicable
- [x] New sensitive displays preserve incognito behavior, when applicable
- [x] New Prisma queries for user-owned resources include `userId`, when applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable
- [x] User-facing counts are precise rather than proxies, when applicable
- [x] Action links reach the correct page with required parameters, when applicable
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

Evidence:

- `pnpm run check:prisma-generated`: passed with no generated drift.
- `node --test scripts/check-prisma-generated.test.mjs`: 17 passed.
- `CI=true pnpm run validate:pr`: passed. Repository tests reported 5,230 passed and 51 skipped across shared, web, and API; PR contract tests reported 53 passed.
- `pnpm --filter @arr/api test:provider-cache-heap`: 7 passed. The 20,000-row policy read completed with 252 queries and 184.3 MB peak heap.
- `pnpm run build`: shared, API, and web builds passed.
- MDR-003 focused correction suite: 94 passed across six authority, settlement, projection, caller, episode, and architecture test files. The direct authority suite passed 38 tests, including selected-target, mutation, and episode-parent regressions.
- Final real PMS matrix: A1, A2, and A3 withheld `0`-item transient sections then published settled `100`-item V3 sections; B blocked an active scan; C and D detected digest changes, including an equal-`scannedAt` collision on D attempt 3; E recovered only after a no-op scan settled; F withheld the active deletion and published a new `305` to `304` V3 inventory; G and H invalidated changed targets while preserving unrelated usable targets; I isolated the unsupported music scan; J blocked metadata refresh activity.
- MDR-003 real PMS check: with a selected TMDB target in Movie library A, an active `library.update.section` scan in Movie library B returned `plex_library_scan_in_progress`. Authority recovered after B settled with unrelated additions.
- No frontend behavior changed. The applicable live checks used the authenticated real-PMS authority harness.

## Review plan

- Initial broad-reviewed head: `fa73b845` content, reviewed locally before commit by independent concurrency, data-safety, and compatibility reviewers
- Prior correction head: `7dff9d13`
- MDR-003 correction head: `c6f61746`
- Targeted MDR-003 delta range: `7dff9d13..c6f61746`; the data-safety reviewer found no blocking issue and cleared selected-target, mutation, and episode-parent authority behavior
- Material-scope change declared? No
- Independent regression reviewer: Harvey, four findings resolved and prior targeted delta clear
- Independent data-safety reviewer, when required: Socrates, MDR-003 targeted delta clear
- Independent concurrency reviewer: Sagan, two findings resolved and prior targeted delta clear
- GitHub Codex review head: `fa73b845`; both P1 findings were accepted, corrected in `7dff9d13`, and rechecked for applicability on the current head
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| CON-1 | P1 | Contract violation | A trailing probe could miss a same-second completed scan after terminal collection | Third probe moved before terminal collection; event-order regressions pass | None |
| CON-2 | P2 | Contract documentation gap | Plex provides no atomic snapshot or scan lock | Residual post-observation race documented at settlement and publication boundaries | None |
| DS-1 | High | Contract violation | Duplicate live provider identities could collapse to one mutation rating key | Fresh authority preserves duplicates and mutation fails closed on ambiguity | None |
| DS-2 | Medium | Contract violation / false operator audit | Authority-only catalog reads could omit a newly added supported section | Complete supported non-Personal-Media catalog is now settled and compared | None |
| COMP-1 | P1 | Introduced regression | New supported sections, including missing `scannedAt`, could be ignored | Full supported-section catalog settlement fails closed | None |
| COMP-2 | P1 | Introduced regression | Episode collection could omit a show added after parent observation | Complete parent fixed point is reacquired and compared after episode authority | None |
| COMP-3 | P2 | Introduced regression | Label reads hashed unrelated labels and could spuriously fail | Projection is limited to membership and display domains | None |
| COMP-4 | P2 | Introduced regression | Persisted on-deck and recent limits used a different order from live selection | Shared canonical selection now runs before limiting | None |
| GHC-1 | P1 | Introduced regression | The episode parent scan included movies and unwatched series, risking invalid leaf requests and the 200-show cap | Episode publication now scans only watched series parents before and after collection; the over-cap mixed-row regression passes | None |
| GHC-2 | P1 | Transaction-safety regression | Live Plex settlement ran inside the bounded Prisma approval transaction | Live authority is established before opening the transaction; exact persisted authority is revalidated after locks with a fresh lock-boundary timestamp | None |
| MDR-003 | P1 | Contract violation | A selected target in library A could authorize while another supported Movie or Show library was scanning, allowing a not-yet-discovered duplicate target to escape the authority window | Every authority window now settles and identity-compares the complete supported non-Personal-Media Movie and Show catalog; target comparison remains selection and domain scoped | None |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned

After merge, rerun the real-PMS settlement matrix on the release candidate before the next stable release that includes this change.

