### PR TITLE
fix(plex): publish positive episode evidence

### DIFF
--- a/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
@@ -160,6 +160,19 @@ function inProgressLatestAttemptEvidence(rows: unknown[]) {
 	};
 }
 
+function positiveOnlyEvidence(rows: unknown[]) {
+	return {
+		...authoritativeEvidence(rows),
+		evidence: {
+			availability: "current",
+			authority: "positive-only",
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			reasonCodes: ["latest_attempt_partial"],
+		},
+	};
+}
+
 function destinationPrisma(): DestWriterOpts["prisma"] {
 	return {
 		serviceInstance: {
@@ -224,6 +237,25 @@ describe("Plex label-sync evidence boundary", () => {
 			matches: [{ tmdbId: 42, mediaType: "movie", title: "Tagged" }],
 			failed: false,
 		});
+	});
+
+	it("does not treat V4 observed rows as an exact label-sync source", async () => {
+		mocks.loadInstanceSelectedEvidence.mockResolvedValue(
+			positiveOnlyEvidence([
+				{ tmdbId: 42, mediaType: "movie", title: "Tagged", labels: '["Kids"]' },
+			]),
+		);
+
+		const result = await plexSourceReader.readTaggedItems({
+			rule,
+			sourceInstance: instance,
+			prisma: {} as SourceReaderOpts["prisma"],
+			arrClientFactory: {} as SourceReaderOpts["arrClientFactory"],
+			encryptor: {} as SourceReaderOpts["encryptor"],
+			log,
+		});
+
+		expect(result).toEqual({ matches: [], failed: true });
 	});
 
 	it("marks last-known source membership degraded after the latest attempt failed", async () => {
@@ -310,6 +342,33 @@ describe("Plex label-sync evidence boundary", () => {
 
 		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
 		expect(mocks.createPlexClient).not.toHaveBeenCalled();
+		expect(mocks.updateMetadataTags).not.toHaveBeenCalled();
+	});
+
+	it("does not authorize a Plex label write from V4 positive-only rows", async () => {
+		mocks.loadInstanceSelectedEvidence.mockResolvedValue(
+			positiveOnlyEvidence([
+				{
+					tmdbId: 42,
+					mediaType: "movie",
+					title: "Target",
+					ratingKey: "123",
+					thumb: "/library/metadata/123/thumb/1",
+				},
+			]),
+		);
+
+		const result = await plexDestWriter.applyLabels({
+			rule,
+			destInstance: { ...instance, id: "plex-dest" } as DestWriterOpts["destInstance"],
+			candidates: [{ tmdbId: 42, mediaType: "movie", title: "Target" }],
+			prisma: destinationPrisma(),
+			arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+			encryptor: {} as DestWriterOpts["encryptor"],
+			log,
+		});
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
 		expect(mocks.updateMetadataTags).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -23,6 +23,7 @@ import type { CleanupExecutorDeps } from "../types.js";
 
 const authorityMock = vi.hoisted(() => ({
 	policyEvidence: new Map<string, unknown>(),
+	positiveEpisodeEvidence: new Map<string, unknown>(),
 }));
 
 vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
@@ -132,6 +133,16 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 					...input,
 					instance: instance as never,
 				} as never);
+			}
+
+			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
+				return (
+					authorityMock.positiveEpisodeEvidence.get(input.instanceId) ?? {
+						available: false,
+						instanceId: input.instanceId,
+						evidence: { reasonCode: "positive_episode_unavailable" },
+					}
+				);
 			}
 		},
 	};
@@ -626,19 +637,36 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 	it("rejects an interleaved map/section generation", async () => {
 		const instance = verifiedPlexInstance();
 		const completedAt = new Date();
-		const status = (generationId: string, includeNewSection: boolean) => ({
-			...completeStatus(instance.id, completedAt, 1),
-			generationId,
-			generationMetadata: JSON.stringify({
-				sections: [
-					{ key: "1", title: "Movies", type: "movie" },
-					...(includeNewSection ? [{ key: "2", title: "New Movies", type: "movie" }] : []),
-				],
-			}),
-			lastErrorMessage: null,
-			lastAttemptResult: "success",
-			lastAttemptErrorMessage: null,
-		});
+		const status = (generationId: string, includeNewSection: boolean) => {
+			const complete = completeStatus(instance.id, completedAt, 1);
+			const metadata = JSON.parse(complete.generationMetadata);
+			return {
+				...complete,
+				generationId,
+				generationMetadata: JSON.stringify({
+					...metadata,
+					sections: [
+						metadata.sections[0],
+						...(includeNewSection
+							? [
+									{
+										key: "2",
+										uuid: "new-movies-uuid",
+										title: "New Movies",
+										type: "movie",
+										refreshing: false,
+										scannedAt: 1_777_000_000,
+										updatedAt: 1_777_000_100,
+									},
+								]
+							: []),
+					],
+				}),
+				lastErrorMessage: null,
+				lastAttemptResult: "success",
+				lastAttemptErrorMessage: null,
+			};
+		};
 		const statusReads = vi
 			.fn()
 			.mockResolvedValueOnce([status("generation-1", false)])
@@ -1094,6 +1122,55 @@ describe("prefetchPlexData — cross-batch Map merge (v2.18.4 OOM fix)", () => {
 });
 
 describe("prefetchFreshPlexEpisodeWatchData", () => {
+	it("uses one positive lower-bound source without requiring a complete V2 episode generation", async () => {
+		const now = new Date("2026-08-24T12:00:00.000Z");
+		const instance = verifiedPlexInstance();
+		authorityMock.positiveEpisodeEvidence.set(instance.id, {
+			available: true,
+			instanceId: instance.id,
+			connectionGeneration: 3,
+			identityGeneration: 7,
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				connectionGeneration: 3,
+				identityGeneration: 7,
+				parentPlexGenerationId: "parent-v4",
+				parentTargetDigest: "parent-target-digest",
+				parentTargetCount: 1,
+				episodeGenerationId: "episode-v3",
+				episodeDigest: "episode-digest",
+				publishedAt: now.toISOString(),
+			},
+			rows: [
+				{
+					showTmdbId: 42,
+					seasonNumber: 1,
+					episodeNumber: 1,
+					ratingKey: "episode-a",
+					lowerBound: 2,
+					sourceFingerprint: plexConnectionFingerprint(instance as never),
+					soleParentTarget: { ratingKey: "show-a" },
+				},
+			],
+		});
+		const warnings: string[] = [];
+
+		const result = await prefetchFreshPlexEpisodeWatchData(
+			{
+				prisma: { serviceInstance: { findMany: vi.fn().mockResolvedValue([instance]) } },
+				log,
+			} as never,
+			[instance] as never,
+			now,
+			warnings,
+		);
+
+		expect(result.get("42:1:1")).toMatchObject([{ lowerBound: 2, watchCount: 0 }]);
+		expect(warnings).toEqual([]);
+		authorityMock.positiveEpisodeEvidence.clear();
+	});
+
 	it.each([
 		["metadata-only instance update", "updatedAt"],
 		["same-identity reverification", "identityVerifiedAt"],

--- a/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/prefetch-plex-data.test.ts
@@ -1171,6 +1171,68 @@ describe("prefetchFreshPlexEpisodeWatchData", () => {
 		authorityMock.positiveEpisodeEvidence.clear();
 	});
 
+	it("retains one valid positive source when another Plex source has no complete exact generation", async () => {
+		const now = new Date("2026-08-24T12:00:00.000Z");
+		const positiveInstance = verifiedPlexInstance({ id: "plex-positive" });
+		const unavailableInstance = verifiedPlexInstance({
+			id: "plex-unavailable",
+			baseUrl: "http://plex-unavailable.internal:32400",
+		});
+		authorityMock.positiveEpisodeEvidence.set(positiveInstance.id, {
+			available: true,
+			instanceId: positiveInstance.id,
+			connectionGeneration: 3,
+			identityGeneration: 7,
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				connectionGeneration: 3,
+				identityGeneration: 7,
+				parentPlexGenerationId: "parent-v4",
+				parentTargetDigest: "parent-target-digest",
+				parentTargetCount: 1,
+				episodeGenerationId: "episode-v3",
+				episodeDigest: "episode-digest",
+				publishedAt: now.toISOString(),
+			},
+			rows: [
+				{
+					showTmdbId: 42,
+					seasonNumber: 1,
+					episodeNumber: 1,
+					ratingKey: "episode-a",
+					lowerBound: 2,
+					sourceFingerprint: plexConnectionFingerprint(positiveInstance as never),
+					soleParentTarget: { ratingKey: "show-a" },
+				},
+			],
+		});
+		const warnings: string[] = [];
+
+		const result = await prefetchFreshPlexEpisodeWatchData(
+			{
+				prisma: {
+					serviceInstance: {
+						findMany: vi.fn().mockResolvedValue([positiveInstance, unavailableInstance]),
+					},
+					cacheRefreshStatus: { findMany: vi.fn().mockResolvedValue([]) },
+				},
+				log,
+			} as never,
+			[positiveInstance, unavailableInstance] as never,
+			now,
+			warnings,
+		);
+
+		expect(result.get("42:1:1")).toMatchObject([
+			{ plexInstanceId: "plex-positive", lowerBound: 2, watchCount: 0 },
+		]);
+		expect(warnings).toContainEqual(
+			expect.stringContaining("no complete fresh published generation"),
+		);
+		authorityMock.positiveEpisodeEvidence.clear();
+	});
+
 	it.each([
 		["metadata-only instance update", "updatedAt"],
 		["same-identity reverification", "identityVerifiedAt"],

--- a/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
@@ -96,6 +96,14 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 					} as never,
 				);
 			}
+
+			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
+				return {
+					available: false as const,
+					instanceId: input.instanceId,
+					evidence: { reasonCode: "positive_episode_unavailable" },
+				};
+			}
 		},
 	};
 });

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-safety.test.ts
@@ -61,6 +61,14 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 				});
 			}
 
+			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
+				return {
+					available: false as const,
+					instanceId: input.instanceId,
+					evidence: { reasonCode: "positive_episode_unavailable" },
+				};
+			}
+
 			async readInstanceEpisodesPersisted(
 				input: Parameters<typeof repository.loadInstanceEpisodeEvidence>[1],
 			) {

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1,5 +1,9 @@
 import { NotFoundError } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
+import { evidenceFingerprint } from "../../evidence-fingerprint.js";
+
+const positiveEpisodeEvidence = vi.hoisted(() => new Map<string, unknown>());
+const exactEpisodeEvidenceUnavailable = vi.hoisted(() => ({ value: false }));
 
 vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../plex/plex-authority-service.js")>();
@@ -38,6 +42,12 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 			async readInstanceSelectedEpisodes(
 				input: Parameters<typeof repository.loadInstanceSelectedEpisodeEvidence>[1],
 			) {
+				if (exactEpisodeEvidenceUnavailable.value) {
+					return {
+						available: false as const,
+						evidence: { reasonCodes: ["exact_episode_unavailable"] },
+					};
+				}
 				const instances = await this.deps.prisma.serviceInstance.findMany({
 					where: { userId: input.userId, service: "PLEX", enabled: true },
 				});
@@ -59,6 +69,16 @@ vi.mock("../../plex/plex-authority-service.js", async (importOriginal) => {
 					...input,
 					instance,
 				});
+			}
+
+			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
+				return (
+					positiveEpisodeEvidence.get(input.instanceId) ?? {
+						available: false as const,
+						instanceId: input.instanceId,
+						evidence: { reasonCode: "positive_episode_unavailable" },
+					}
+				);
 			}
 
 			async revalidatePersistedSnapshot(
@@ -123,6 +143,13 @@ const PLEX_SOURCE_FINGERPRINT = plexConnectionFingerprint({
 	baseUrl: "http://plex.internal:32400",
 	encryptedApiKey: "encrypted",
 	encryptionIv: "iv",
+});
+const POSITIVE_PARENT_DIGEST = "4".repeat(64);
+const POSITIVE_EPISODE_DIGEST = "5".repeat(64);
+const POSITIVE_RULE_FINGERPRINT = evidenceFingerprint({
+	id: "episode-rule",
+	parameters: JSON.stringify({ operator: "greater_than", count: 0 }),
+	action: "delete",
 });
 
 const TEST_PLEX_PROVIDER_EVIDENCE = createSanitizedProviderEvidence(
@@ -947,6 +974,92 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		).resolves.toEqual(new Map());
 
 		expect(fixture.getEpisodeWatchCount).toHaveBeenCalledWith("episode-1");
+	});
+
+	it("reproves a positive-only lower bound with the exact live rating key before a delete", async () => {
+		const fixture = makeSonarrDeps();
+		const observedAt = new Date();
+		const soleParentTarget = {
+			instanceId: "plex-1",
+			generationId: "parent-v4",
+			showTmdbId: 456,
+			sectionId: "shows",
+			sectionUuid: "shows-uuid",
+			mediaType: "series" as const,
+			tvdbId: 123,
+			ratingKey: "show-1",
+		};
+		positiveEpisodeEvidence.set("plex-1", {
+			available: true,
+			instanceId: "plex-1",
+			connectionGeneration: 1,
+			identityGeneration: 1,
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				parentPlexGenerationId: "parent-v4",
+				parentTargetDigest: POSITIVE_PARENT_DIGEST,
+				episodeGenerationId: "episode-v3",
+				episodeDigest: POSITIVE_EPISODE_DIGEST,
+				publishedAt: observedAt.toISOString(),
+			},
+			rows: [
+				{
+					showTmdbId: 456,
+					seasonNumber: 1,
+					episodeNumber: 1,
+					ratingKey: "episode-1",
+					lowerBound: 2,
+					sourceFingerprint: PLEX_SOURCE_FINGERPRINT,
+					soleParentTarget,
+				},
+			],
+		});
+		const episodeTarget = {
+			...exactEpisodeTarget(),
+			plexWatchEvidence: [
+				{
+					...exactEpisodeTarget().plexWatchEvidence[0]!,
+					watchCount: 0,
+					lowerBound: 2,
+					positiveProof: {
+						connectionGeneration: 1,
+						identityGeneration: 1,
+						parentGenerationId: "parent-v4",
+						parentPublicationLevel: "positive-only" as const,
+						parentTargetDigest: POSITIVE_PARENT_DIGEST,
+						soleParentTargetFingerprint: evidenceFingerprint(soleParentTarget),
+						episodeGenerationId: "episode-v3",
+						episodeDigest: POSITIVE_EPISODE_DIGEST,
+						showTmdbId: 456,
+						observedLowerBound: 2,
+						observedAt,
+						operator: "greater_than" as const,
+						threshold: 0,
+						ruleId: "episode-rule",
+						ruleFingerprint: POSITIVE_RULE_FINGERPRINT,
+					},
+				},
+			],
+		};
+		const context = createSharedPlexSafetyContext();
+
+		await expect(
+			findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context),
+		).resolves.toEqual(new Map());
+		expect(fixture.getEpisodeWatchCount).toHaveBeenCalledWith("episode-1");
+		expect(context.plans.get(cleanupDeleteTargetKey(episodeTarget))).toMatchObject({
+			kind: "verified_sonarr_episode",
+			watchProof: {
+				watchCount: 1,
+				positiveProof: {
+					threshold: 0,
+					observedLowerBound: 2,
+					parentGenerationId: "parent-v4",
+				},
+			},
+		});
+		positiveEpisodeEvidence.clear();
 	});
 
 	it("matches the exact episode path across duplicate Plex show copies", async () => {
@@ -4712,6 +4825,149 @@ describe("verified Sonarr mutation handoff", () => {
 		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
 		expect(fixture.bulkDelete).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		[
+			"executes after the live count decreases but remains above threshold",
+			false,
+			false,
+			1,
+			false,
+			true,
+		],
+		[
+			"accepts authoritative recovery when the same predicate remains true",
+			true,
+			false,
+			1,
+			false,
+			true,
+		],
+		["blocks execution when the live count falls to the threshold", false, false, 0, false, false],
+		["reproves the same positive predicate for a retry", false, true, 1, false, true],
+		["blocks execution when the positive generation changes", false, false, 2, true, false],
+	] as const)(
+		"%s",
+		async (_case, recoverToAuthoritative, retry, liveCount, driftGeneration, succeeds) => {
+			const fixture = makeSonarrDeps({ livePlexWatchCount: 2 });
+			const observedAt = new Date();
+			const soleParentTarget = {
+				instanceId: "plex-1",
+				generationId: "parent-v4",
+				showTmdbId: 456,
+				sectionId: "shows",
+				sectionUuid: "shows-uuid",
+				mediaType: "series" as const,
+				tvdbId: 123,
+				ratingKey: "show-1",
+			};
+			const positiveEvidence = {
+				available: true,
+				instanceId: "plex-1",
+				connectionGeneration: 1,
+				identityGeneration: 1,
+				provenance: {
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					parentPlexGenerationId: "parent-v4",
+					parentTargetDigest: POSITIVE_PARENT_DIGEST,
+					episodeGenerationId: "episode-v3",
+					episodeDigest: POSITIVE_EPISODE_DIGEST,
+					publishedAt: observedAt.toISOString(),
+				},
+				rows: [
+					{
+						showTmdbId: 456,
+						seasonNumber: 1,
+						episodeNumber: 1,
+						ratingKey: "episode-1",
+						lowerBound: 2,
+						sourceFingerprint: PLEX_SOURCE_FINGERPRINT,
+						soleParentTarget,
+					},
+				],
+			};
+			positiveEpisodeEvidence.set("plex-1", positiveEvidence);
+			const episodeTarget = {
+				...exactEpisodeTarget(),
+				plexWatchEvidence: [
+					{
+						...exactEpisodeTarget().plexWatchEvidence[0]!,
+						watchCount: 0,
+						lowerBound: 2,
+						positiveProof: {
+							connectionGeneration: 1,
+							identityGeneration: 1,
+							parentGenerationId: "parent-v4",
+							parentPublicationLevel: "positive-only" as const,
+							parentTargetDigest: POSITIVE_PARENT_DIGEST,
+							soleParentTargetFingerprint: evidenceFingerprint(soleParentTarget),
+							episodeGenerationId: "episode-v3",
+							episodeDigest: POSITIVE_EPISODE_DIGEST,
+							showTmdbId: 456,
+							observedLowerBound: 2,
+							observedAt,
+							operator: "greater_than" as const,
+							threshold: 0,
+							ruleId: "episode-rule",
+							ruleFingerprint: POSITIVE_RULE_FINGERPRINT,
+						},
+					},
+				],
+			};
+			const context = createSharedPlexSafetyContext();
+			await findSharedPlexDeleteBlocks(fixture.deps, "user-1", [episodeTarget], context);
+			const plan = context.plans.get(cleanupDeleteTargetKey(episodeTarget));
+			if (plan?.kind !== "verified_sonarr_episode") {
+				throw new Error("Expected verified Sonarr episode plan");
+			}
+			const storedApproval = {
+				...approval(),
+				...(retry
+					? {
+							status: "retry_pending",
+							lastExecutionError: "Interrupted cleanup mutation requires recovery",
+						}
+					: {}),
+				targetScope: "episode",
+				arrEpisodeId: 9_001,
+				seasonNumber: 1,
+				episodeNumber: 1,
+				episodeTitle: "Episode 1",
+				safetySnapshot: serializeExecutableSafetyPlanRaw(
+					plan,
+					createSanitizedProviderEvidence([], []),
+				),
+			};
+			configureApprovalStore(fixture.deps, storedApproval);
+			if (recoverToAuthoritative) positiveEpisodeEvidence.clear();
+			if (driftGeneration) {
+				exactEpisodeEvidenceUnavailable.value = true;
+				positiveEvidence.provenance.episodeGenerationId = "episode-v3-new";
+				positiveEvidence.provenance.episodeDigest = "9".repeat(64);
+				positiveEvidence.provenance.publishedAt = new Date(
+					observedAt.getTime() + 1_000,
+				).toISOString();
+				positiveEvidence.rows[0]!.lowerBound = 3;
+			}
+			fixture.getEpisodeWatchCount.mockResolvedValue(liveCount);
+
+			const result = retry
+				? await executeRetryItems(fixture.deps, "user-1", ["approval-1"])
+				: await executeApprovedItems(fixture.deps, "user-1", ["approval-1"]);
+
+			expect(result).toMatchObject(
+				succeeds ? { removed: 1, failed: 0 } : { removed: 0, failed: 1 },
+			);
+			if (succeeds) {
+				expect(fixture.bulkDelete).toHaveBeenCalledWith([3_001]);
+			} else {
+				expect(fixture.bulkDelete).not.toHaveBeenCalled();
+			}
+			positiveEpisodeEvidence.clear();
+			exactEpisodeEvidenceUnavailable.value = false;
+		},
+	);
 
 	it.each(["approved", "retry-recovery"] as const)(
 		"blocks %s execution when same-coordinate media belongs to another Plex rating key",

--- a/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/shared-plex-sonarr-safety.test.ts
@@ -1383,6 +1383,212 @@ describe("shared Plex deletion safety for Sonarr", () => {
 		expect(fixture.deps.quiClientFactory).not.toHaveBeenCalled();
 	});
 
+	it("selects the reporter episode from Plex A while Plex B remains degraded", async () => {
+		const fixture = makeSonarrDeps();
+		const secondPlexInstance = {
+			...fixture.plexInstance,
+			id: "plex-2",
+			baseUrl: "http://plex-2.internal:32400",
+			encryptedApiKey: "encrypted-2",
+		};
+		const observedAt = new Date();
+		positiveEpisodeEvidence.set(fixture.plexInstance.id, {
+			available: true,
+			instanceId: fixture.plexInstance.id,
+			connectionGeneration: 1,
+			identityGeneration: 1,
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				parentPlexGenerationId: "parent-v4",
+				parentTargetDigest: POSITIVE_PARENT_DIGEST,
+				episodeGenerationId: "episode-v3",
+				episodeDigest: POSITIVE_EPISODE_DIGEST,
+				publishedAt: observedAt.toISOString(),
+			},
+			rows: [
+				{
+					showTmdbId: 456,
+					seasonNumber: 1,
+					episodeNumber: 1,
+					ratingKey: "episode-1",
+					lowerBound: 2,
+					sourceFingerprint: PLEX_SOURCE_FINGERPRINT,
+					soleParentTarget: { ratingKey: "show-123" },
+				},
+			],
+		});
+		vi.mocked(fixture.deps.prisma.libraryCleanupConfig.findUnique).mockResolvedValue({
+			id: "config-1",
+			userId: "user-1",
+			enabled: true,
+			dryRunMode: true,
+			requireApproval: false,
+			maxRemovalsPerRun: 10,
+			respectQuiSeeding: false,
+			rules: [episodeCleanupRule()],
+		} as never);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(((args: {
+			where?: { service?: string };
+		}) => {
+			if (args.where?.service === "PLEX") {
+				return Promise.resolve([fixture.plexInstance, secondPlexInstance]);
+			}
+			if (args.where?.service === "QUI") return Promise.resolve([]);
+			if (args.where?.service) return Promise.resolve([fixture.targetInstance]);
+			return Promise.resolve([fixture.targetInstance, fixture.plexInstance, secondPlexInstance]);
+		}) as never);
+		vi.mocked(fixture.deps.prisma.cacheRefreshStatus.findMany).mockImplementation(((args: {
+			where: { instanceId?: string; cacheType: string };
+		}) => {
+			if (args.where.instanceId === secondPlexInstance.id) return Promise.resolve([]);
+			return Promise.resolve([
+				args.where.cacheType === "plex" ? fixture.mainStatus : fixture.episodeStatus,
+			]);
+		}) as never);
+		vi.mocked(fixture.deps.prisma.libraryCache.findMany)
+			.mockResolvedValueOnce([
+				{
+					id: "series-cache-1",
+					instanceId: fixture.targetInstance.id,
+					arrItemId: fixture.series.id,
+					itemType: "series",
+					title: fixture.series.title,
+					year: 2024,
+					monitored: true,
+					hasFile: true,
+					status: "continuing",
+					qualityProfileId: 1,
+					qualityProfileName: "4K",
+					sizeOnDisk: 4_003n,
+					arrAddedAt: new Date("2025-01-01T00:00:00.000Z"),
+					cachedAt: new Date(),
+					data: JSON.stringify({
+						remoteIds: { tvdbId: fixture.series.tvdbId, tmdbId: fixture.series.tmdbId },
+						path: fixture.series.path,
+						_arrDashboardSource: { serviceFingerprint: sonarrServiceFingerprint },
+					}),
+				},
+			] as never)
+			.mockResolvedValueOnce([]);
+
+		const result = await executeCleanupPreview(fixture.deps, "user-1");
+
+		expect(result).toMatchObject({ itemsFlagged: 1, itemsRemoved: 0 });
+		expect(result.details).toEqual([
+			expect.objectContaining({
+				targetScope: "episode",
+				arrEpisodeId: 9_001,
+				previewDisposition: "selected",
+			}),
+		]);
+		expect(result.warnings).toContainEqual(
+			expect.stringContaining("no complete fresh published generation"),
+		);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		positiveEpisodeEvidence.clear();
+	});
+
+	it("does not bypass shared-Plex safety when an independent Plex source is unavailable", async () => {
+		const fixture = makeSonarrDeps();
+		const secondPlexInstance = {
+			...fixture.plexInstance,
+			id: "plex-2",
+			baseUrl: "http://plex-2.internal:32400",
+			encryptedApiKey: "encrypted-2",
+		};
+		const primaryClient = fixture.deps.plexClientFactory!(fixture.plexInstance as never);
+		vi.mocked(fixture.deps.plexClientFactory!).mockImplementation((instance) =>
+			instance.id === secondPlexInstance.id
+				? ({
+						getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Owner" }]),
+						getMovieMediaPartsByTmdbId: vi.fn(),
+						getSeriesEpisodeMediaPartsByTvdbId: vi
+							.fn()
+							.mockRejectedValue(new Error("Plex B unavailable")),
+						getEpisodeWatchCount: vi.fn(),
+					} as never)
+				: primaryClient,
+		);
+		vi.mocked(fixture.deps.prisma.serviceInstance.findMany).mockImplementation(((args: {
+			where?: { service?: string };
+		}) =>
+			args.where?.service === "PLEX"
+				? Promise.resolve([fixture.plexInstance, secondPlexInstance])
+				: args.where?.service === "QUI"
+					? Promise.resolve([fixture.quiInstance])
+					: Promise.resolve([fixture.targetInstance])) as never);
+		fixture.targetClient.notification.getAll.mockResolvedValue([
+			fixture.notification,
+			{
+				...fixture.notification,
+				fields: fixture.notification.fields.map((field) =>
+					field.name === "host" ? { ...field, value: "plex-2.internal" } : field,
+				),
+			},
+		]);
+		const episodeTarget = exactEpisodeTarget();
+		const flaggedItem = {
+			cacheItem: {
+				id: "series-cache",
+				instanceId: fixture.targetInstance.id,
+				arrItemId: fixture.series.id,
+				itemType: "series",
+				title: fixture.series.title,
+				year: 2024,
+				monitored: true,
+				hasFile: true,
+				status: "continuing",
+				qualityProfileId: 1,
+				qualityProfileName: "HD",
+				sizeOnDisk: 2_001n,
+				arrAddedAt: new Date(),
+				cachedAt: new Date(),
+				data: JSON.stringify({
+					_arrDashboardSource: { serviceFingerprint: sonarrServiceFingerprint },
+					path: fixture.series.path,
+					remoteIds: { tvdbId: fixture.series.tvdbId, tmdbId: fixture.series.tmdbId },
+				}),
+			},
+			match: {
+				ruleId: "episode-rule",
+				ruleName: "Remove watched episodes",
+				reason: "Plex watch count 1 > 0",
+				action: "delete",
+			},
+			rating: 8.2,
+			episodeTarget: {
+				...episodeTarget,
+				seriesTitle: fixture.series.title,
+				episodeTitle: "Episode 1",
+				fileInfoHash: episodeTarget.episodeFileInfoHash,
+				fileTorrentState: episodeTarget.episodeFileTorrentState,
+			},
+		} as never;
+
+		const result = await executeDirectRemoval(
+			fixture.deps,
+			{
+				id: "config-1",
+				maxRemovalsPerRun: 10,
+				respectQuiSeeding: true,
+				rules: [episodeCleanupRule()],
+			} as never,
+			"user-1",
+			[flaggedItem],
+			1,
+			1,
+			Date.now(),
+		);
+
+		expect(result).toMatchObject({ itemsRemoved: 0, itemsFilesDeleted: 0 });
+		expect(result.details).toEqual([
+			expect.objectContaining({ action: "skipped", reason: expect.stringContaining("Plex") }),
+		]);
+		expect(fixture.bulkDelete).not.toHaveBeenCalled();
+		expect(fixture.setEpisodeMonitored).not.toHaveBeenCalled();
+	});
+
 	it("reuses one complete qUI inode snapshot across episode paths in a safety operation", async () => {
 		const fixture = makeSonarrDeps();
 		const first = exactEpisodeTarget();

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -104,6 +104,7 @@ import {
 	type EpisodeCleanupCandidate,
 	type EpisodePlexWatchEvidence,
 	evaluateEpisodeWatchCountRule,
+	evaluateEpisodeWatchCountEvidence,
 	isSupportedEpisodeCleanupRule,
 	toEpisodeTargetMetadata,
 } from "./episode-scope.js";
@@ -7074,6 +7075,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 		};
 	} = {},
 ): Promise<Map<string, EpisodePlexWatchEvidence[]>> {
+	const positiveResult = new Map<string, EpisodePlexWatchEvidence[]>();
 	const plexInstanceIds = instances
 		.filter((instance) => instance.service === "PLEX" && instance.enabled)
 		.map((instance) => instance.id);
@@ -7093,17 +7095,24 @@ export async function prefetchFreshPlexEpisodeWatchData(
 		const plexInstances = instances.filter(
 			(instance) => instance.service === "PLEX" && instance.enabled,
 		);
-		const positiveResult = new Map<string, EpisodePlexWatchEvidence[]>();
 		const positiveEvidenceInstanceIds = new Set<string>();
 		for (const instance of plexInstances) {
-			const positive = await cleanupPlexAuthority(deps).readPositiveEpisodeEvidence({
-				userId: instance.userId,
-				instanceId: instance.id,
-				now,
-				maxAgeMs: PLEX_EPISODE_FRESHNESS_MS,
-			});
+			const positive = await cleanupPlexAuthority(deps)
+				.readPositiveEpisodeEvidence({
+					userId: instance.userId,
+					instanceId: instance.id,
+					now,
+					maxAgeMs: PLEX_EPISODE_FRESHNESS_MS,
+				})
+				.catch((error: unknown) => {
+					deps.log.warn(
+						{ err: error, instanceId: instance.id },
+						"Positive Plex episode evidence was unavailable for one instance",
+					);
+					return undefined;
+				});
 			if (
-				!positive.available ||
+				!positive?.available ||
 				positive.connectionGeneration !== instance.connectionGeneration ||
 				positive.identityGeneration !== instance.identityGeneration
 			) {
@@ -7168,7 +7177,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 			warnings.push(
 				"Plex episode evidence had no complete fresh published generation for every enabled instance; episode-scoped cleanup targets were skipped.",
 			);
-			return new Map();
+			return positiveResult;
 		}
 		const repositoryEvidence = [];
 		for (const instance of authoritativeInstances) {
@@ -7186,7 +7195,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 			warnings.push(
 				"Plex episode evidence did not match its published parent generation; episode-scoped cleanup targets were skipped.",
 			);
-			return new Map();
+			return positiveResult;
 		}
 		const rows = repositoryEvidence
 			.flatMap((entry) => (entry.available ? entry.rows : []))
@@ -7198,7 +7207,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 						row.seasonNumber === options.coordinate.seasonNumber &&
 						row.episodeNumber === options.coordinate.episodeNumber),
 			);
-		const result = positiveResult;
+		const result = new Map<string, EpisodePlexWatchEvidence[]>();
 		const rowsByInstance = new Map<string, unknown[]>(
 			authoritativeInstances.map((instance) => [instance.id, []]),
 		);
@@ -7279,16 +7288,25 @@ export async function prefetchFreshPlexEpisodeWatchData(
 			warnings.push(
 				"Plex episode evidence changed while it was read; episode-scoped cleanup targets were skipped.",
 			);
-			return new Map();
+			return positiveResult;
 		}
 		options.evidenceSink?.(snapshot.evidence);
-		return result;
+		for (const [key, exactEvidence] of result) {
+			const merged = [...(positiveResult.get(key) ?? []), ...exactEvidence];
+			merged.sort(
+				(left, right) =>
+					(right.lowerBound ?? right.watchCount) - (left.lowerBound ?? left.watchCount) ||
+					left.plexInstanceId.localeCompare(right.plexInstanceId),
+			);
+			positiveResult.set(key, merged);
+		}
+		return positiveResult;
 	} catch (error) {
 		deps.log.error({ err: error }, "Failed to load fresh Plex episode watch data");
 		warnings.push(
 			"Plex episode watch data was unavailable or stale; episode-scoped rules were skipped for safety.",
 		);
-		return new Map();
+		return positiveResult;
 	}
 }
 
@@ -7454,10 +7472,9 @@ async function evaluateSeriesEpisodes(
 			// satisfied this rule. Carrying a lower-count source here would let a
 			// physical-path match on that server authorize a rule that only passed
 			// because a different server had enough watches.
-			const qualifyingWatchEvidence = watchEvidence.filter(
-				(evidence) => (evidence.lowerBound ?? evidence.watchCount) > watchCountThreshold,
-			);
-			if (qualifyingWatchEvidence.length === 0) continue;
+			const watchEvaluation = evaluateEpisodeWatchCountEvidence(watchEvidence, rule);
+			if (watchEvaluation.state !== "true" || !watchEvaluation.match) continue;
+			const qualifyingWatchEvidence = watchEvaluation.qualifyingEvidence;
 			const ruleFingerprint = evidenceFingerprint({
 				id: rule.id,
 				parameters: rule.parameters,
@@ -7484,8 +7501,7 @@ async function evaluateSeriesEpisodes(
 						: {}),
 				})),
 			};
-			const match = evaluateEpisodeWatchCountRule(ruleCandidate, rule);
-			if (!match) continue;
+			const match = watchEvaluation.match;
 			flagged.push({
 				cacheItem: { ...item, sizeOnDisk: file.size },
 				match,

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -30,6 +30,13 @@ import { runJellyfinCacheRefreshSingleFlight } from "../jellyfin/jellyfin-cache-
 import { createJellyfinClient } from "../jellyfin/jellyfin-client.js";
 import { refreshJellyfinEpisodeCache } from "../jellyfin/jellyfin-episode-cache-refresher.js";
 import { buildLibraryItem } from "../library/library-item-builder.js";
+import type {
+	AvailablePlexInstanceEvidence,
+	AvailablePlexPolicyEvidence,
+	PlexInstanceEvidence,
+	PlexPolicyScanEvidence,
+} from "../plex/plex-authority-service.js";
+import { PlexAuthorityService } from "../plex/plex-authority-service.js";
 import {
 	collectPlexCacheLiveEvidence,
 	type PlexCacheSnapshotRow,
@@ -41,13 +48,6 @@ import {
 	PlexMovieNotFoundError,
 	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
-import type {
-	AvailablePlexInstanceEvidence,
-	AvailablePlexPolicyEvidence,
-	PlexInstanceEvidence,
-	PlexPolicyScanEvidence,
-} from "../plex/plex-authority-service.js";
-import { PlexAuthorityService } from "../plex/plex-authority-service.js";
 import { requirePlexTargetLedgerBinding } from "../plex/plex-generation-target-ledger.js";
 import {
 	refreshOwnedPlexCache,
@@ -165,6 +165,7 @@ import {
 	type SharedMediaSafetyPlan,
 	SonarrFilesChangedDuringSafetyCheckError,
 	serializeExecutableSafetyPlan,
+	type VerifiedEpisodePlexWatchProof,
 	type VerifiedEpisodePlexWatchSource,
 	type VerifiedRadarrFileIdentity,
 	type VerifiedSonarrFileIdentity,
@@ -246,6 +247,16 @@ interface MatchedRuleProviderAuthority {
 	evidence: SanitizedProviderEvidence;
 	authorities: Array<ProviderCacheSnapshot<unknown>["authority"]>;
 	complete: boolean;
+	boundedPositiveOnly: boolean;
+}
+
+interface BoundedPositiveEpisodeAuthority {
+	userId: string;
+	seasonNumber: number;
+	episodeNumber: number;
+	watchProof: VerifiedEpisodePlexWatchProof & {
+		positiveProof: NonNullable<VerifiedEpisodePlexWatchProof["positiveProof"]>;
+	};
 }
 
 export function mergeSanitizedProviderEvidence(
@@ -792,6 +803,65 @@ async function revalidatePersistedProviderCacheAuthority(
 	});
 }
 
+function boundedPositiveEpisodeAuthorityFromPlan(
+	userId: string,
+	plan: SharedMediaSafetyPlan | undefined,
+): BoundedPositiveEpisodeAuthority | undefined {
+	if (plan?.kind !== "verified_sonarr_episode" || !plan.watchProof.positiveProof) return undefined;
+	return {
+		userId,
+		seasonNumber: plan.episode.seasonNumber,
+		episodeNumber: plan.episode.episodeNumber,
+		watchProof: {
+			...plan.watchProof,
+			positiveProof: plan.watchProof.positiveProof,
+		},
+	};
+}
+
+async function revalidateBoundedPositiveEpisodeAuthority(
+	deps: CleanupExecutorDeps,
+	authority: BoundedPositiveEpisodeAuthority,
+	now = new Date(),
+): Promise<boolean> {
+	const { watchProof } = authority;
+	const proof = watchProof.positiveProof;
+	const current = await cleanupPlexAuthority(deps).readPositiveEpisodeEvidence({
+		userId: authority.userId,
+		instanceId: watchProof.plexInstanceId,
+		now,
+		maxAgeMs: PROVIDER_EVIDENCE_FRESHNESS_MS,
+	});
+	if (
+		!current.available ||
+		current.connectionGeneration !== proof.connectionGeneration ||
+		current.identityGeneration !== proof.identityGeneration ||
+		current.provenance.publicationLevel !== "positive-only" ||
+		current.provenance.parentPlexGenerationId !== proof.parentGenerationId ||
+		current.provenance.parentTargetDigest !== proof.parentTargetDigest ||
+		current.provenance.episodeGenerationId !== proof.episodeGenerationId ||
+		current.provenance.episodeDigest !== proof.episodeDigest ||
+		current.provenance.publishedAt !== proof.observedAt ||
+		watchProof.sourceFingerprint.trim() === "" ||
+		watchProof.ratingKey.trim() === ""
+	) {
+		return false;
+	}
+	const matchingRows = current.rows.filter(
+		(row) =>
+			row.showTmdbId === proof.showTmdbId &&
+			row.seasonNumber === authority.seasonNumber &&
+			row.episodeNumber === authority.episodeNumber &&
+			row.ratingKey === watchProof.ratingKey,
+	);
+	return (
+		matchingRows.length === 1 &&
+		matchingRows[0]!.sourceFingerprint === watchProof.sourceFingerprint &&
+		matchingRows[0]!.lowerBound === proof.observedLowerBound &&
+		evidenceFingerprint(matchingRows[0]!.soleParentTarget) === proof.soleParentTargetFingerprint
+	);
+}
+
 class ProviderCacheAuthorityChangedError extends Error {
 	constructor() {
 		super("Provider cache authority changed after cleanup selection");
@@ -812,8 +882,9 @@ async function createApprovalWithProviderCacheAuthority(
 	deps: CleanupExecutorDeps,
 	authorities: Array<ProviderCacheSnapshot<unknown>["authority"]>,
 	data: Prisma.LibraryCleanupApprovalUncheckedCreateInput,
+	boundedPositiveAuthority?: BoundedPositiveEpisodeAuthority,
 ): Promise<LibraryCleanupApproval> {
-	if (authorities.length === 0) {
+	if (authorities.length === 0 && !boundedPositiveAuthority) {
 		return await deps.prisma.libraryCleanupApproval.create({ data });
 	}
 	const postgresql = /^postgres(ql)?:\/\//i.test(process.env.DATABASE_URL ?? "");
@@ -832,12 +903,19 @@ async function createApprovalWithProviderCacheAuthority(
 			throw new ProviderCacheAuthorityChangedError();
 		}
 	}
+	if (
+		boundedPositiveAuthority &&
+		!(await revalidateBoundedPositiveEpisodeAuthority(deps, boundedPositiveAuthority))
+	) {
+		throw new ProviderCacheAuthorityChangedError();
+	}
 	return await deps.prisma.$transaction(
 		async (tx) => {
 			const instanceIds = [
-				...new Set(
-					authorities.flatMap((authority) => authority.instances.map((instance) => instance.id)),
-				),
+				...new Set([
+					...authorities.flatMap((authority) => authority.instances.map((instance) => instance.id)),
+					...(boundedPositiveAuthority ? [boundedPositiveAuthority.watchProof.plexInstanceId] : []),
+				]),
 			].sort();
 			if (postgresql) {
 				for (const instanceId of instanceIds) {
@@ -851,6 +929,21 @@ async function createApprovalWithProviderCacheAuthority(
 			for (const authority of authorities) {
 				if (
 					!(await revalidatePersistedProviderCacheAuthority(deps, tx, authority, transactionNow))
+				) {
+					throw new ProviderCacheAuthorityChangedError();
+				}
+			}
+			if (boundedPositiveAuthority) {
+				const transactionDeps = {
+					...deps,
+					prisma: tx as unknown as CleanupExecutorDeps["prisma"],
+				};
+				if (
+					!(await revalidateBoundedPositiveEpisodeAuthority(
+						transactionDeps,
+						boundedPositiveAuthority,
+						transactionNow,
+					))
 				) {
 					throw new ProviderCacheAuthorityChangedError();
 				}
@@ -1445,6 +1538,9 @@ function episodePlanTargetFields(
 				ratingKey: plan.watchProof.ratingKey,
 				watchCount: plan.watchProof.watchCount,
 				refreshedAt: plan.watchProof.refreshedAt,
+				...(plan.watchProof.positiveProof
+					? { positiveProof: { ...plan.watchProof.positiveProof } }
+					: {}),
 			},
 		],
 		respectQuiSeeding: respectQuiSeeding || plan.quiIdentity.enabled,
@@ -1496,10 +1592,14 @@ function episodePlansMatchWithRefreshedWatchProof(
 		: liveProofIdentity;
 	const approvedRefreshTime = Date.parse(approvedRefreshedAt);
 	const liveRefreshTime = Date.parse(liveRefreshedAt);
+	const approvedPositiveProof = approvedProofIdentity.positiveProof;
+	const livePositiveProof = liveProofIdentity.positiveProof;
 	if (
 		JSON.stringify(approvedComparableProofIdentity) !==
 			JSON.stringify(liveComparableProofIdentity) ||
-		liveWatchCount < approvedWatchCount ||
+		(approvedPositiveProof
+			? !livePositiveProof || liveWatchCount <= approvedPositiveProof.threshold
+			: liveWatchCount < approvedWatchCount) ||
 		!Number.isFinite(approvedRefreshTime) ||
 		!Number.isFinite(liveRefreshTime) ||
 		liveRefreshTime < approvedRefreshTime
@@ -1711,7 +1811,8 @@ function withSharedPlexOwnershipRevalidation(
 			if (
 				blocks.has(targetKey) ||
 				!comparableLivePlan ||
-				!executableSafetyPlansEqual(safetyPlan, comparableLivePlan)
+				(!executableSafetyPlansEqual(safetyPlan, comparableLivePlan) &&
+					!episodePlansMatchWithRefreshedWatchProof(safetyPlan, comparableLivePlan, false))
 			) {
 				throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
 					"Skipped for safety: the verified Sonarr episode identity, Plex ownership, or qUI physical-file evidence changed at the mutation boundary.",
@@ -3436,6 +3537,7 @@ interface ExpectedCleanupRule {
 	matchedRuleId: string;
 	action: RuleAction;
 	scanMediaServerAfterDelete: boolean;
+	ruleFingerprint?: string;
 	providerDependencies?: string[];
 }
 
@@ -3995,6 +4097,12 @@ async function assertCurrentEpisodeMutationAuthority(
 		!currentEpisodeRule ||
 		!isSupportedEpisodeCleanupRule(currentEpisodeRule) ||
 		currentEpisodeRule.action !== expectedRule.action ||
+		(expectedRule.ruleFingerprint !== undefined &&
+			evidenceFingerprint({
+				id: currentEpisodeRule.id,
+				parameters: currentEpisodeRule.parameters,
+				action: currentEpisodeRule.action,
+			}) !== expectedRule.ruleFingerprint) ||
 		(currentEpisodeRule.scanMediaServerAfterDelete === true) !==
 			expectedRule.scanMediaServerAfterDelete
 	) {
@@ -4538,6 +4646,7 @@ async function executeQueuedCleanupItemsCore(
 			if (
 				!sharedPlexBlock &&
 				approvedPlan?.kind === "verified_sonarr_episode" &&
+				approvedPlan.watchProof.positiveProof === undefined &&
 				!approvedProviderEvidence?.dependencies.some(
 					(dependency) => dependency === "plex_episode" || dependency === "plex",
 				)
@@ -4852,6 +4961,12 @@ async function executeQueuedCleanupItemsCore(
 						options.assertExecutionAllowed,
 					);
 					if (safetyPlan!.kind === "verified_sonarr_episode") {
+						const positiveProof = safetyPlan!.watchProof.positiveProof;
+						if (positiveProof && positiveProof.ruleId !== approval.matchedRuleId) {
+							throw new ArrMutationAuthorityChangedDuringSafetyCheckError(
+								"Skipped for safety: the approved positive Plex proof did not match the queued cleanup rule.",
+							);
+						}
 						await assertCurrentEpisodeMutationAuthority(
 							deps,
 							userId,
@@ -4861,6 +4976,7 @@ async function executeQueuedCleanupItemsCore(
 								matchedRuleId: approval.matchedRuleId,
 								action,
 								scanMediaServerAfterDelete: approval.scanMediaServerAfterDelete === true,
+								...(positiveProof ? { ruleFingerprint: positiveProof.ruleFingerprint } : {}),
 							},
 							evidence && "liveEpisodeWatchSources" in evidence ? evidence : undefined,
 							expectedConfigFingerprint,
@@ -5535,11 +5651,19 @@ function buildMatchedProviderAuthority(
 	rule: LibraryCleanupRule,
 	evidenceConditions: RuleEvidenceCondition[],
 	snapshotsByCacheType: Map<ProviderCacheType, ProviderCacheSnapshot<unknown>>,
+	flaggedItem?: FlaggedItem,
 ): MatchedRuleProviderAuthority {
 	const requiredCacheTypes = providerCacheTypesForEvidence(rule, evidenceConditions);
 	const matchedSnapshots = [...requiredCacheTypes]
 		.map((cacheType) => snapshotsByCacheType.get(cacheType))
 		.filter((snapshot): snapshot is ProviderCacheSnapshot<unknown> => snapshot !== undefined);
+	const boundedPositiveOnly =
+		isSupportedEpisodeCleanupRule(rule) &&
+		flaggedItem?.episodeTarget?.plexWatchEvidence.some(
+			(evidence) => evidence.positiveProof !== undefined,
+		) === true &&
+		requiredCacheTypes.size === 1 &&
+		requiredCacheTypes.has("plex_episode");
 	return {
 		evidence: createSanitizedProviderEvidence(
 			matchedSnapshots.flatMap((snapshot) => snapshot.evidence.dependencies),
@@ -5548,7 +5672,8 @@ function buildMatchedProviderAuthority(
 			),
 		),
 		authorities: matchedSnapshots.map((snapshot) => snapshot.authority),
-		complete: matchedSnapshots.length === requiredCacheTypes.size,
+		complete: matchedSnapshots.length === requiredCacheTypes.size || boundedPositiveOnly,
+		boundedPositiveOnly,
 	};
 }
 
@@ -6894,7 +7019,7 @@ async function evaluateAllItems(
 					if (!matchedRule) continue;
 					providerAuthoritiesByTarget.set(
 						cleanupDeleteTargetKey(flaggedDeleteTarget(episodeItem)),
-						buildMatchedProviderAuthority(matchedRule, [], snapshotsByCacheType),
+						buildMatchedProviderAuthority(matchedRule, [], snapshotsByCacheType, episodeItem),
 					);
 				}
 			}
@@ -6968,9 +7093,74 @@ export async function prefetchFreshPlexEpisodeWatchData(
 		const plexInstances = instances.filter(
 			(instance) => instance.service === "PLEX" && instance.enabled,
 		);
+		const positiveResult = new Map<string, EpisodePlexWatchEvidence[]>();
+		const positiveEvidenceInstanceIds = new Set<string>();
+		for (const instance of plexInstances) {
+			const positive = await cleanupPlexAuthority(deps).readPositiveEpisodeEvidence({
+				userId: instance.userId,
+				instanceId: instance.id,
+				now,
+				maxAgeMs: PLEX_EPISODE_FRESHNESS_MS,
+			});
+			if (
+				!positive.available ||
+				positive.connectionGeneration !== instance.connectionGeneration ||
+				positive.identityGeneration !== instance.identityGeneration
+			) {
+				continue;
+			}
+			const sourceFingerprint = plexFingerprintById.get(instance.id);
+			const observedAt = new Date(positive.provenance.publishedAt);
+			if (!sourceFingerprint || !Number.isFinite(observedAt.getTime())) continue;
+			positiveEvidenceInstanceIds.add(instance.id);
+			for (const row of positive.rows) {
+				if (
+					row.sourceFingerprint !== sourceFingerprint ||
+					!Number.isSafeInteger(row.lowerBound) ||
+					row.lowerBound <= 0 ||
+					(options.coordinate &&
+						(row.showTmdbId !== options.coordinate.showTmdbId ||
+							row.seasonNumber !== options.coordinate.seasonNumber ||
+							row.episodeNumber !== options.coordinate.episodeNumber))
+				) {
+					continue;
+				}
+				const key = episodeCoordinateKey(row.showTmdbId, row.seasonNumber, row.episodeNumber);
+				const evidence: EpisodePlexWatchEvidence = {
+					plexInstanceId: instance.id,
+					sourceFingerprint,
+					ratingKey: row.ratingKey,
+					watchCount: 0,
+					lowerBound: row.lowerBound,
+					lastWatchedAt: null,
+					watchedByUsers: [],
+					refreshedAt: observedAt,
+					positiveProof: {
+						connectionGeneration: positive.connectionGeneration,
+						identityGeneration: positive.identityGeneration,
+						parentGenerationId: positive.provenance.parentPlexGenerationId,
+						parentPublicationLevel: positive.provenance.publicationLevel,
+						parentTargetDigest: positive.provenance.parentTargetDigest,
+						soleParentTargetFingerprint: evidenceFingerprint(row.soleParentTarget),
+						episodeGenerationId: positive.provenance.episodeGenerationId,
+						episodeDigest: positive.provenance.episodeDigest,
+						showTmdbId: row.showTmdbId,
+						observedLowerBound: row.lowerBound,
+						observedAt,
+					},
+				};
+				const current = positiveResult.get(key) ?? [];
+				current.push(evidence);
+				positiveResult.set(key, current);
+			}
+		}
+		const authoritativeInstances = plexInstances.filter(
+			(instance) => !positiveEvidenceInstanceIds.has(instance.id),
+		);
+		if (authoritativeInstances.length === 0) return positiveResult;
 		const generations = await loadCompleteCacheGenerations(
 			deps,
-			plexInstances,
+			authoritativeInstances,
 			"plex_episode",
 			now,
 		);
@@ -6981,7 +7171,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 			return new Map();
 		}
 		const repositoryEvidence = [];
-		for (const instance of plexInstances) {
+		for (const instance of authoritativeInstances) {
 			repositoryEvidence.push(
 				await cleanupPlexAuthority(deps).readInstanceEpisodes({
 					userId: instance.userId,
@@ -7008,9 +7198,9 @@ export async function prefetchFreshPlexEpisodeWatchData(
 						row.seasonNumber === options.coordinate.seasonNumber &&
 						row.episodeNumber === options.coordinate.episodeNumber),
 			);
-		const result = new Map<string, EpisodePlexWatchEvidence[]>();
+		const result = positiveResult;
 		const rowsByInstance = new Map<string, unknown[]>(
-			plexInstances.map((instance) => [instance.id, []]),
+			authoritativeInstances.map((instance) => [instance.id, []]),
 		);
 		let staleEvidenceCount = 0;
 		let incompleteEvidenceCount = 0;
@@ -7081,7 +7271,7 @@ export async function prefetchFreshPlexEpisodeWatchData(
 		const snapshot = createProviderCacheSnapshot(
 			result,
 			"plex_episode",
-			plexInstances,
+			authoritativeInstances,
 			generations,
 			rowsByInstance,
 		);
@@ -7265,15 +7455,34 @@ async function evaluateSeriesEpisodes(
 			// physical-path match on that server authorize a rule that only passed
 			// because a different server had enough watches.
 			const qualifyingWatchEvidence = watchEvidence.filter(
-				(evidence) => evidence.watchCount > watchCountThreshold,
+				(evidence) => (evidence.lowerBound ?? evidence.watchCount) > watchCountThreshold,
 			);
 			if (qualifyingWatchEvidence.length === 0) continue;
+			const ruleFingerprint = evidenceFingerprint({
+				id: rule.id,
+				parameters: rule.parameters,
+				action: rule.action,
+			});
 			const ruleCandidate: EpisodeCleanupCandidate = {
 				...candidate,
-				watchCount: qualifyingWatchEvidence[0]!.watchCount,
+				watchCount:
+					qualifyingWatchEvidence[0]!.lowerBound ?? qualifyingWatchEvidence[0]!.watchCount,
 				lastWatchedAt: qualifyingWatchEvidence[0]!.lastWatchedAt,
 				watchedByUsers: qualifyingWatchEvidence[0]!.watchedByUsers,
-				plexWatchEvidence: qualifyingWatchEvidence,
+				plexWatchEvidence: qualifyingWatchEvidence.map((evidence) => ({
+					...evidence,
+					...(evidence.positiveProof
+						? {
+								positiveProof: {
+									...evidence.positiveProof,
+									operator: "greater_than",
+									threshold: watchCountThreshold,
+									ruleId: rule.id,
+									ruleFingerprint,
+								},
+							}
+						: {}),
+				})),
 			};
 			const match = evaluateEpisodeWatchCountRule(ruleCandidate, rule);
 			if (!match) continue;
@@ -7651,8 +7860,20 @@ async function executeWithApproval(
 				evidence: createSanitizedProviderEvidence([], []),
 				authorities: [],
 				complete: false,
+				boundedPositiveOnly: false,
 			};
 			if (!matchedRuleAuthority.complete) {
+				throw new ProviderCacheAuthorityChangedError();
+			}
+			const executablePlan =
+				asExecutableSafetyPlan(safetyPlans.get(targetKey)) ??
+				(() => {
+					throw new Error("No executable cleanup safety plan was produced");
+				})();
+			const boundedPositiveAuthority = matchedRuleAuthority.boundedPositiveOnly
+				? boundedPositiveEpisodeAuthorityFromPlan(config.userId, executablePlan)
+				: undefined;
+			if (matchedRuleAuthority.boundedPositiveOnly && !boundedPositiveAuthority) {
 				throw new ProviderCacheAuthorityChangedError();
 			}
 			const approval = await createApprovalWithProviderCacheAuthority(
@@ -7680,14 +7901,12 @@ async function executeWithApproval(
 					rating: item.rating,
 					status: "pending",
 					safetySnapshot: serializeExecutableSafetyPlan(
-						asExecutableSafetyPlan(safetyPlans.get(targetKey)) ??
-							(() => {
-								throw new Error("No executable cleanup safety plan was produced");
-							})(),
+						executablePlan,
 						matchedRuleAuthority.evidence,
 					),
 					expiresAt,
 				},
+				boundedPositiveAuthority,
 			);
 
 			details.push(
@@ -8090,6 +8309,16 @@ export async function executeDirectRemoval(
 		let directMutationExecutionToken: string;
 		let directProviderEvidence = itemProviderEvidence;
 		try {
+			const boundedPositiveAuthority = matchedRuleAuthority?.boundedPositiveOnly
+				? boundedPositiveEpisodeAuthorityFromPlan(userId, safetyPlan)
+				: undefined;
+			if (
+				matchedRuleAuthority?.boundedPositiveOnly &&
+				(!boundedPositiveAuthority ||
+					!(await revalidateBoundedPositiveEpisodeAuthority(deps, boundedPositiveAuthority)))
+			) {
+				throw new Error("Bounded positive Plex episode authority changed after selection");
+			}
 			if (
 				!(
 					await Promise.all(

--- a/apps/api/src/lib/library-cleanup/episode-scope.test.ts
+++ b/apps/api/src/lib/library-cleanup/episode-scope.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
 	buildEpisodeTargetKey,
-	evaluateEpisodeWatchCountRule,
 	type EpisodeCleanupCandidate,
+	evaluateEpisodeWatchCountRule,
 } from "./episode-scope.js";
 
 function candidate(overrides: Partial<EpisodeCleanupCandidate> = {}): EpisodeCleanupCandidate {
@@ -118,6 +118,89 @@ describe("episode cleanup scope", () => {
 				parameters: JSON.stringify({ operator: "greater_than", count: 1 }),
 				action: "delete",
 			}),
+		).toBeNull();
+	});
+
+	it("selects an episode only when one positive lower-bound source is above the threshold", () => {
+		const positiveSource = {
+			...candidate().plexWatchEvidence[0]!,
+			watchCount: 0,
+			lowerBound: 2,
+		};
+		const rule = {
+			id: "rule-episode",
+			name: "Remove watched episodes",
+			parameters: JSON.stringify({ operator: "greater_than", count: 1 }),
+			action: "delete",
+		};
+
+		expect(
+			evaluateEpisodeWatchCountRule(
+				candidate({ watchCount: 0, plexWatchEvidence: [positiveSource] }),
+				rule,
+			),
+		).toMatchObject({ reason: "Plex watch count 2 > 1" });
+		expect(
+			evaluateEpisodeWatchCountRule(
+				candidate({ watchCount: 0, plexWatchEvidence: [positiveSource] }),
+				{ ...rule, parameters: JSON.stringify({ operator: "greater_than", count: 2 }) },
+			),
+		).toBeNull();
+		expect(
+			evaluateEpisodeWatchCountRule(candidate({ watchCount: 0, plexWatchEvidence: [] }), rule),
+		).toBeNull();
+	});
+
+	it("matches only reporter episode A while omitted and zero episodes remain unknown", () => {
+		const positiveSource = {
+			...candidate().plexWatchEvidence[0]!,
+			watchCount: 0,
+			lowerBound: 2,
+		};
+		const reporterRule = {
+			id: "reporter-episode-rule",
+			name: "Remove watched episodes",
+			parameters: JSON.stringify({ operator: "greater_than", count: 0 }),
+			action: "delete",
+		};
+		const reporterEpisodes = [
+			{ id: "A", plexWatchEvidence: [positiveSource] },
+			{ id: "B", plexWatchEvidence: [] },
+			{ id: "C", plexWatchEvidence: [] },
+		];
+
+		expect(
+			reporterEpisodes.flatMap((episode) =>
+				evaluateEpisodeWatchCountRule(
+					candidate({ watchCount: 0, plexWatchEvidence: episode.plexWatchEvidence }),
+					reporterRule,
+				)
+					? [episode.id]
+					: [],
+			),
+		).toEqual(["A"]);
+	});
+
+	it.each([
+		["negative threshold", "greater_than", -1],
+		["less-than", "less_than", 3],
+		["equality", "equals", 2],
+	] as const)("keeps positive-only %s rules unknown", (_case, operator, count) => {
+		expect(
+			evaluateEpisodeWatchCountRule(
+				candidate({
+					watchCount: 0,
+					plexWatchEvidence: [
+						{ ...candidate().plexWatchEvidence[0]!, watchCount: 0, lowerBound: 2 },
+					],
+				}),
+				{
+					id: "unsupported-positive-rule",
+					name: "Unsupported positive rule",
+					parameters: JSON.stringify({ operator, count }),
+					action: "delete",
+				},
+			),
 		).toBeNull();
 	});
 });

--- a/apps/api/src/lib/library-cleanup/episode-scope.test.ts
+++ b/apps/api/src/lib/library-cleanup/episode-scope.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	buildEpisodeTargetKey,
 	type EpisodeCleanupCandidate,
+	evaluateEpisodeWatchCountEvidence,
 	evaluateEpisodeWatchCountRule,
 } from "./episode-scope.js";
 
@@ -119,6 +120,28 @@ describe("episode cleanup scope", () => {
 				action: "delete",
 			}),
 		).toBeNull();
+	});
+
+	it("uses one independently qualifying lower bound instead of summing sources", () => {
+		const source = candidate().plexWatchEvidence[0]!;
+		const evaluation = evaluateEpisodeWatchCountEvidence(
+			[
+				{ ...source, plexInstanceId: "plex-a", watchCount: 0, lowerBound: 1 },
+				{ ...source, plexInstanceId: "plex-b", watchCount: 0, lowerBound: 3 },
+			],
+			{
+				id: "rule-episode",
+				name: "More than two plays",
+				parameters: JSON.stringify({ operator: "greater_than", count: 2 }),
+				action: "delete",
+			},
+		);
+
+		expect(evaluation).toMatchObject({
+			state: "true",
+			match: { reason: "Plex watch count 3 > 2" },
+			qualifyingEvidence: [{ plexInstanceId: "plex-b", lowerBound: 3 }],
+		});
 	});
 
 	it("selects an episode only when one positive lower-bound source is above the threshold", () => {

--- a/apps/api/src/lib/library-cleanup/episode-scope.ts
+++ b/apps/api/src/lib/library-cleanup/episode-scope.ts
@@ -170,25 +170,20 @@ export function evaluateEpisodeWatchCountRule(
 		Partial<Pick<EpisodeCleanupCandidate, "plexWatchEvidence">>,
 	rule: EpisodeWatchCountRule,
 ): RuleMatch | null {
+	if (candidate.plexWatchEvidence !== undefined) {
+		return evaluateEpisodeWatchCountEvidence(candidate.plexWatchEvidence, rule).match;
+	}
 	const params = safeJsonParse(rule.parameters) as PlexWatchCountParameters | null;
 	if (
 		params?.operator !== "greater_than" ||
 		typeof params.count !== "number" ||
 		!Number.isFinite(params.count) ||
-		params.count < 0 ||
-		(candidate.plexWatchEvidence !== undefined && candidate.plexWatchEvidence.length === 0)
+		params.count < 0
 	) {
 		return null;
 	}
 	const threshold = params.count;
-	const lowerBound = candidate.plexWatchEvidence
-		?.map((evidence) => evidence.lowerBound)
-		.filter(
-			(value): value is number =>
-				typeof value === "number" && Number.isSafeInteger(value) && value > 0,
-		)
-		.find((value) => value > threshold);
-	const count = lowerBound ?? candidate.watchCount;
+	const count = candidate.watchCount;
 	if (count <= threshold) return null;
 
 	if (rule.action !== "delete" && rule.action !== "delete_files" && rule.action !== "unmonitor") {
@@ -202,4 +197,54 @@ export function evaluateEpisodeWatchCountRule(
 		action,
 		...(rule.scanMediaServerAfterDelete === true ? { scanMediaServerAfterDelete: true } : {}),
 	};
+}
+
+export interface EpisodeWatchCountEvidenceEvaluation {
+	state: "true" | "false" | "unknown";
+	match: RuleMatch | null;
+	qualifyingEvidence: EpisodePlexWatchEvidence[];
+}
+
+/**
+ * Evaluate independent Plex episode sources without adding their counts.
+ * Positive-only rows can prove TRUE but can never prove FALSE; FALSE requires
+ * at least one exact row and no partial source whose exact count is unknown.
+ */
+export function evaluateEpisodeWatchCountEvidence(
+	evidence: EpisodePlexWatchEvidence[],
+	rule: EpisodeWatchCountRule,
+): EpisodeWatchCountEvidenceEvaluation {
+	const params = safeJsonParse(rule.parameters) as PlexWatchCountParameters | null;
+	if (
+		params?.operator !== "greater_than" ||
+		typeof params.count !== "number" ||
+		!Number.isFinite(params.count) ||
+		params.count < 0 ||
+		(rule.action !== "delete" && rule.action !== "delete_files" && rule.action !== "unmonitor")
+	) {
+		return { state: "unknown", match: null, qualifyingEvidence: [] };
+	}
+	const threshold = params.count;
+	const qualifyingEvidence = evidence.filter((source) => {
+		const count = source.lowerBound ?? source.watchCount;
+		return Number.isSafeInteger(count) && count >= 0 && count > threshold;
+	});
+	if (qualifyingEvidence.length > 0) {
+		const count = qualifyingEvidence[0]!.lowerBound ?? qualifyingEvidence[0]!.watchCount;
+		return {
+			state: "true",
+			qualifyingEvidence,
+			match: {
+				ruleId: rule.id,
+				ruleName: rule.name,
+				reason: `Plex watch count ${count} > ${threshold}`,
+				action: rule.action as RuleAction,
+				...(rule.scanMediaServerAfterDelete === true ? { scanMediaServerAfterDelete: true } : {}),
+			},
+		};
+	}
+	if (evidence.length === 0 || evidence.some((source) => source.lowerBound !== undefined)) {
+		return { state: "unknown", match: null, qualifyingEvidence: [] };
+	}
+	return { state: "false", match: null, qualifyingEvidence: [] };
 }

--- a/apps/api/src/lib/library-cleanup/episode-scope.ts
+++ b/apps/api/src/lib/library-cleanup/episode-scope.ts
@@ -14,6 +14,25 @@ export interface EpisodePlexWatchEvidence {
 	sourceFingerprint: string;
 	ratingKey: string;
 	watchCount: number;
+	/** Positive-only episode evidence is a lower bound, not an exact count. */
+	lowerBound?: number;
+	positiveProof?: {
+		connectionGeneration: number;
+		identityGeneration: number;
+		parentGenerationId: string;
+		parentPublicationLevel: "positive-only";
+		parentTargetDigest: string;
+		soleParentTargetFingerprint: string;
+		episodeGenerationId: string;
+		episodeDigest: string;
+		showTmdbId: number;
+		observedLowerBound: number;
+		observedAt: Date;
+		operator?: "greater_than";
+		threshold?: number;
+		ruleId?: string;
+		ruleFingerprint?: string;
+	};
 	lastWatchedAt: Date | null;
 	watchedByUsers: string[];
 	refreshedAt: Date;
@@ -109,7 +128,8 @@ export function isSupportedEpisodeCleanupRule(rule: EpisodeCleanupRuleShape): bo
 	return (
 		params?.operator === "greater_than" &&
 		typeof params.count === "number" &&
-		Number.isFinite(params.count)
+		Number.isFinite(params.count) &&
+		params.count >= 0
 	);
 }
 
@@ -125,6 +145,7 @@ export function toEpisodeTargetMetadata(candidate: EpisodeCleanupCandidate): Epi
 		episodeTitle: candidate.episodeTitle,
 		plexWatchEvidence: candidate.plexWatchEvidence.map((evidence) => ({
 			...evidence,
+			...(evidence.positiveProof ? { positiveProof: { ...evidence.positiveProof } } : {}),
 			watchedByUsers: [...evidence.watchedByUsers],
 		})),
 		fileInfoHash: candidate.file.infoHash,
@@ -145,18 +166,30 @@ export function buildEpisodeTargetKey(
 }
 
 export function evaluateEpisodeWatchCountRule(
-	candidate: Pick<EpisodeCleanupCandidate, "watchCount">,
+	candidate: Pick<EpisodeCleanupCandidate, "watchCount"> &
+		Partial<Pick<EpisodeCleanupCandidate, "plexWatchEvidence">>,
 	rule: EpisodeWatchCountRule,
 ): RuleMatch | null {
 	const params = safeJsonParse(rule.parameters) as PlexWatchCountParameters | null;
 	if (
 		params?.operator !== "greater_than" ||
 		typeof params.count !== "number" ||
-		!Number.isFinite(params.count)
+		!Number.isFinite(params.count) ||
+		params.count < 0 ||
+		(candidate.plexWatchEvidence !== undefined && candidate.plexWatchEvidence.length === 0)
 	) {
 		return null;
 	}
-	if (candidate.watchCount <= params.count) return null;
+	const threshold = params.count;
+	const lowerBound = candidate.plexWatchEvidence
+		?.map((evidence) => evidence.lowerBound)
+		.filter(
+			(value): value is number =>
+				typeof value === "number" && Number.isSafeInteger(value) && value > 0,
+		)
+		.find((value) => value > threshold);
+	const count = lowerBound ?? candidate.watchCount;
+	if (count <= threshold) return null;
 
 	if (rule.action !== "delete" && rule.action !== "delete_files" && rule.action !== "unmonitor") {
 		return null;
@@ -165,7 +198,7 @@ export function evaluateEpisodeWatchCountRule(
 	return {
 		ruleId: rule.id,
 		ruleName: rule.name,
-		reason: `Plex watch count ${candidate.watchCount} > ${params.count}`,
+		reason: `Plex watch count ${count} > ${threshold}`,
 		action,
 		...(rule.scanMediaServerAfterDelete === true ? { scanMediaServerAfterDelete: true } : {}),
 	};

--- a/apps/api/src/lib/library-cleanup/phase1-features.test.ts
+++ b/apps/api/src/lib/library-cleanup/phase1-features.test.ts
@@ -110,6 +110,20 @@ function makeCacheItem(overrides: Partial<CacheItemForEval> = {}): CacheItemForE
 	};
 }
 
+function exactEpisodeWatchEvidence(watchCount: number) {
+	return [
+		{
+			plexInstanceId: "plex-1",
+			sourceFingerprint: "source-1",
+			ratingKey: "episode-202",
+			watchCount,
+			lastWatchedAt: null,
+			watchedByUsers: [],
+			refreshedAt: new Date("2026-01-01T00:00:00.000Z"),
+		},
+	];
+}
+
 function makeRule(overrides: Partial<TestRule> = {}): TestRule {
 	return {
 		id: "rule-1",
@@ -524,8 +538,7 @@ describe("explainItemAgainstRules", () => {
 
 		const results = explainItemAgainstRules(makeCacheItem(), rules, "SONARR", ctx, {
 			arrEpisodeId: 202,
-			watchCount: 1,
-			available: true,
+			watchEvidence: exactEpisodeWatchEvidence(1),
 		});
 
 		expect(results[0]).toMatchObject({
@@ -549,8 +562,7 @@ describe("explainItemAgainstRules", () => {
 
 		const results = explainItemAgainstRules(makeCacheItem(), rules, "SONARR", ctx, {
 			arrEpisodeId: 202,
-			watchCount: 1,
-			available: true,
+			watchEvidence: exactEpisodeWatchEvidence(1),
 		});
 
 		expect(results[0]).toMatchObject({
@@ -593,8 +605,7 @@ describe("explainItemAgainstRules", () => {
 
 		const results = explainItemAgainstRules(makeCacheItem(), rules, "SONARR", ctx, {
 			arrEpisodeId: 202,
-			watchCount: null,
-			available: false,
+			watchEvidence: [],
 		});
 
 		expect(results[0]).toMatchObject({
@@ -618,8 +629,7 @@ describe("explainItemAgainstRules", () => {
 
 		const results = explainItemAgainstRules(makeCacheItem(), rules, "SONARR", ctx, {
 			arrEpisodeId: 202,
-			watchCount: 1,
-			available: true,
+			watchEvidence: exactEpisodeWatchEvidence(1),
 		});
 
 		expect(results[0]).toMatchObject({
@@ -646,7 +656,7 @@ describe("explainItemAgainstRules", () => {
 			rules,
 			"SONARR",
 			baseCtx(),
-			{ arrEpisodeId: 202, watchCount: 1, available: true },
+			{ arrEpisodeId: 202, watchEvidence: exactEpisodeWatchEvidence(1) },
 			new Set(["plex"]),
 		);
 

--- a/apps/api/src/lib/library-cleanup/rule-evaluators.ts
+++ b/apps/api/src/lib/library-cleanup/rule-evaluators.ts
@@ -71,7 +71,11 @@ import {
 } from "@arr/shared";
 import type { LibraryCleanupRule } from "../prisma.js";
 import { safeJsonParse } from "../utils/json.js";
-import { evaluateEpisodeWatchCountRule, isSupportedEpisodeCleanupRule } from "./episode-scope.js";
+import {
+	evaluateEpisodeWatchCountEvidence,
+	isSupportedEpisodeCleanupRule,
+	type EpisodePlexWatchEvidence,
+} from "./episode-scope.js";
 import type {
 	CacheItemForEval,
 	EvalContext,
@@ -89,8 +93,7 @@ import { listMembershipKey } from "./types.js";
 
 export interface EpisodeExplainEvidence {
 	arrEpisodeId: number;
-	watchCount: number | null;
-	available: boolean;
+	watchEvidence: EpisodePlexWatchEvidence[];
 }
 
 // ============================================================================
@@ -3010,18 +3013,6 @@ export function explainItemAgainstRules(
 			continue;
 		}
 
-		if (targetsEpisode && episodeEvidence && !episodeEvidence.available) {
-			results.push({
-				ruleId: rule.id,
-				ruleName: rule.name,
-				matched: false,
-				reason: null,
-				filteredBy: "evidence_unavailable",
-				retentionMode: rule.retentionMode,
-			});
-			continue;
-		}
-
 		// Check pre-filters and report which one blocked
 		const filteredBy = getFilterReason(item, rule, instanceService);
 		if (filteredBy) {
@@ -3039,15 +3030,11 @@ export function explainItemAgainstRules(
 		// Evaluate the rule
 		let evaluation: RuleEvaluation;
 		if (targetsEpisode) {
-			if (episodeEvidence?.watchCount === null || episodeEvidence?.watchCount === undefined) {
-				evaluation = { state: "unknown", match: null, evidenceConditions: [] };
-			} else {
-				const match = evaluateEpisodeWatchCountRule(
-					{ watchCount: episodeEvidence.watchCount },
-					rule,
-				);
-				evaluation = { state: match ? "true" : "false", match, evidenceConditions: [] };
-			}
+			const episodeEvaluation = evaluateEpisodeWatchCountEvidence(
+				episodeEvidence?.watchEvidence ?? [],
+				rule,
+			);
+			evaluation = { ...episodeEvaluation, evidenceConditions: [] };
 		} else {
 			evaluation = evaluateRuleState(item, rule, instanceService, ctx, failedSources);
 		}

--- a/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
+++ b/apps/api/src/lib/library-cleanup/shared-plex-safety.ts
@@ -13,10 +13,8 @@ import type {
 } from "arr-sdk/sonarr";
 import { evidenceFingerprint } from "../evidence-fingerprint.js";
 import { createOwnedJellyfinPublicationSnapshot } from "../jellyfin/jellyfin-cache-refresher.js";
-import { createOwnedPlexPublicationSnapshot } from "../plex/plex-cache-refresher.js";
 import { PlexAuthorityService } from "../plex/plex-authority-service.js";
-
-import { requirePlexTargetLedgerBinding } from "../plex/plex-generation-target-ledger.js";
+import { createOwnedPlexPublicationSnapshot } from "../plex/plex-cache-refresher.js";
 import {
 	createPlexClient,
 	type PlexClient,
@@ -24,6 +22,7 @@ import {
 	type PlexSeriesMediaItem,
 	PlexSeriesNotFoundError,
 } from "../plex/plex-client.js";
+import { requirePlexTargetLedgerBinding } from "../plex/plex-generation-target-ledger.js";
 import { plexConnectionFingerprint as plexEvidenceSourceFingerprint } from "../plex/service-instance-fingerprint.js";
 import type { ServiceInstance } from "../prisma.js";
 import {
@@ -64,6 +63,23 @@ export interface CleanupDeleteTarget {
 		ratingKey: string;
 		watchCount: number;
 		refreshedAt: Date | string;
+		positiveProof?: {
+			connectionGeneration?: number;
+			identityGeneration?: number;
+			parentGenerationId?: string;
+			parentPublicationLevel?: "positive-only";
+			parentTargetDigest?: string;
+			soleParentTargetFingerprint?: string;
+			episodeGenerationId?: string;
+			episodeDigest?: string;
+			showTmdbId?: number;
+			observedLowerBound?: number;
+			observedAt?: Date | string;
+			operator?: "greater_than";
+			threshold?: number;
+			ruleId?: string;
+			ruleFingerprint?: string;
+		};
 	}>;
 	respectQuiSeeding?: boolean;
 	episodeFileInfoHash?: string | null;
@@ -205,6 +221,23 @@ export interface VerifiedEpisodePlexWatchProof {
 	fullPath: NormalizedMediaPath;
 	size: number;
 	mapping: { from: NormalizedMediaPath; to: NormalizedMediaPath } | null;
+	positiveProof?: {
+		connectionGeneration: number;
+		identityGeneration: number;
+		parentGenerationId: string;
+		parentPublicationLevel: "positive-only";
+		parentTargetDigest: string;
+		soleParentTargetFingerprint: string;
+		episodeGenerationId: string;
+		episodeDigest: string;
+		showTmdbId: number;
+		observedLowerBound: number;
+		observedAt: string;
+		operator: "greater_than";
+		threshold: number;
+		ruleId: string;
+		ruleFingerprint: string;
+	};
 }
 
 export interface VerifiedEpisodePlexWatchSource {
@@ -415,6 +448,13 @@ function requiredNonEmptyString(value: unknown, label: string): string {
 	return value.trim();
 }
 
+function requiredSha256(value: unknown, label: string): string {
+	if (!isSha256(value)) {
+		throw new FileMatchVerificationError(`${label} is invalid`);
+	}
+	return value.toLowerCase();
+}
+
 function canonicalTargetIdentity(value: unknown): VerifiedArrTargetIdentity {
 	if (!value || typeof value !== "object") {
 		throw new FileMatchVerificationError("ARR target identity is invalid");
@@ -524,6 +564,69 @@ function canonicalEpisodeWatchProof(value: unknown): VerifiedEpisodePlexWatchPro
 		throw new FileMatchVerificationError("Plex watch refresh time is invalid");
 	}
 	const mapping = proof.mapping as Record<string, unknown> | null | undefined;
+	const rawPositiveProof = proof.positiveProof;
+	let positiveProof: VerifiedEpisodePlexWatchProof["positiveProof"];
+	if (rawPositiveProof !== undefined) {
+		if (!rawPositiveProof || typeof rawPositiveProof !== "object") {
+			throw new FileMatchVerificationError("Positive Plex episode proof is invalid");
+		}
+		const positive = rawPositiveProof as Record<string, unknown>;
+		const observedAt = requiredNonEmptyString(
+			positive.observedAt,
+			"Positive Plex observation time",
+		);
+		if (
+			!Number.isFinite(Date.parse(observedAt)) ||
+			positive.parentPublicationLevel !== "positive-only" ||
+			positive.operator !== "greater_than" ||
+			typeof positive.connectionGeneration !== "number" ||
+			!Number.isSafeInteger(positive.connectionGeneration) ||
+			positive.connectionGeneration < 0 ||
+			typeof positive.identityGeneration !== "number" ||
+			!Number.isSafeInteger(positive.identityGeneration) ||
+			positive.identityGeneration < 0 ||
+			typeof positive.showTmdbId !== "number" ||
+			!Number.isSafeInteger(positive.showTmdbId) ||
+			positive.showTmdbId <= 0 ||
+			typeof positive.observedLowerBound !== "number" ||
+			!Number.isSafeInteger(positive.observedLowerBound) ||
+			positive.observedLowerBound <= 0 ||
+			typeof positive.threshold !== "number" ||
+			!Number.isFinite(positive.threshold) ||
+			positive.threshold < 0
+		) {
+			throw new FileMatchVerificationError("Positive Plex episode proof is invalid");
+		}
+		positiveProof = {
+			connectionGeneration: positive.connectionGeneration,
+			identityGeneration: positive.identityGeneration,
+			parentGenerationId: requiredNonEmptyString(
+				positive.parentGenerationId,
+				"Positive Plex parent generation",
+			),
+			parentPublicationLevel: "positive-only",
+			parentTargetDigest: requiredSha256(
+				positive.parentTargetDigest,
+				"Positive Plex parent digest",
+			),
+			soleParentTargetFingerprint: requiredSha256(
+				positive.soleParentTargetFingerprint,
+				"Positive Plex parent fingerprint",
+			),
+			episodeGenerationId: requiredNonEmptyString(
+				positive.episodeGenerationId,
+				"Positive Plex episode generation",
+			),
+			episodeDigest: requiredSha256(positive.episodeDigest, "Positive Plex episode digest"),
+			showTmdbId: positive.showTmdbId,
+			observedLowerBound: positive.observedLowerBound,
+			observedAt: new Date(observedAt).toISOString(),
+			operator: "greater_than",
+			threshold: positive.threshold,
+			ruleId: requiredNonEmptyString(positive.ruleId, "Positive Plex rule ID"),
+			ruleFingerprint: requiredSha256(positive.ruleFingerprint, "Positive Plex rule fingerprint"),
+		};
+	}
 	return {
 		plexInstanceId: requiredNonEmptyString(proof.plexInstanceId, "Plex watch instance ID"),
 		sourceFingerprint: requiredNonEmptyString(
@@ -543,6 +646,7 @@ function canonicalEpisodeWatchProof(value: unknown): VerifiedEpisodePlexWatchPro
 						from: normalizeMediaPath((mapping?.from as Record<string, unknown> | undefined)?.value),
 						to: normalizeMediaPath((mapping?.to as Record<string, unknown> | undefined)?.value),
 					},
+		...(positiveProof ? { positiveProof } : {}),
 	};
 }
 
@@ -3888,37 +3992,124 @@ async function verifyEpisodePlexWatchProof(
 	const enabledPlexInstances = plexInstances.filter(
 		(instance) => instance.service === "PLEX" && instance.enabled === true,
 	);
-	const policyEvidence = [];
 	const authority = new PlexAuthorityService({
 		prisma: deps.prisma,
 		...(deps.encryptor ? { encryptor: deps.encryptor } : {}),
 		log: deps.log,
 		...(deps.plexCacheClientFactory ? { createClient: deps.plexCacheClientFactory } : {}),
 	});
-	for (const instance of enabledPlexInstances) {
-		policyEvidence.push(
-			await authority.readInstanceSelectedEpisodes({
+	type EpisodePolicyRow = {
+		instanceId: string;
+		showTmdbId: number;
+		seasonNumber: number;
+		episodeNumber: number;
+		ratingKey: string | null;
+		watchCount: number | null;
+		refreshedAt: Date | null;
+		sourceFingerprint: string | null;
+	};
+	let policyRows: EpisodePolicyRow[] = [];
+	const approvedPositiveSources = target.plexWatchEvidence?.filter(
+		(evidence) => evidence.positiveProof !== undefined,
+	);
+	if (approvedPositiveSources?.length) {
+		for (const evidence of approvedPositiveSources) {
+			const proof = evidence.positiveProof;
+			const threshold = proof?.threshold;
+			if (
+				proof?.parentPublicationLevel !== "positive-only" ||
+				proof.operator !== "greater_than" ||
+				typeof threshold !== "number" ||
+				!Number.isFinite(threshold) ||
+				threshold < 0 ||
+				proof.showTmdbId !== showTmdbId ||
+				(!(proof.observedAt instanceof Date) && typeof proof.observedAt !== "string")
+			) {
+				continue;
+			}
+			const instance = enabledPlexInstances.find(
+				(candidate) => candidate.id === evidence.plexInstanceId,
+			);
+			if (
+				!instance ||
+				instance.connectionGeneration !== proof.connectionGeneration ||
+				instance.identityGeneration !== proof.identityGeneration ||
+				plexEvidenceSourceFingerprint(instance) !== evidence.sourceFingerprint
+			) {
+				continue;
+			}
+			const current = await authority.readPositiveEpisodeEvidence({
 				userId: instance.userId,
 				instanceId: instance.id,
-				showTmdbIds: [showTmdbId],
-				mutation: true,
 				maxAgeMs: 24 * 60 * 60 * 1000,
-			}),
-		);
+			});
+			const approvedObservedAt =
+				proof.observedAt instanceof Date ? proof.observedAt : new Date(proof.observedAt);
+			if (
+				!current.available ||
+				current.connectionGeneration !== proof.connectionGeneration ||
+				current.identityGeneration !== proof.identityGeneration ||
+				current.provenance.publicationLevel !== "positive-only" ||
+				current.provenance.parentPlexGenerationId !== proof.parentGenerationId ||
+				current.provenance.parentTargetDigest !== proof.parentTargetDigest ||
+				current.provenance.episodeGenerationId !== proof.episodeGenerationId ||
+				current.provenance.episodeDigest !== proof.episodeDigest ||
+				!Number.isFinite(approvedObservedAt.getTime()) ||
+				current.provenance.publishedAt !== approvedObservedAt.toISOString()
+			) {
+				continue;
+			}
+			const row = current.rows.find(
+				(candidate) =>
+					candidate.showTmdbId === showTmdbId &&
+					candidate.seasonNumber === seasonNumber &&
+					candidate.episodeNumber === exactEpisodeNumber &&
+					candidate.ratingKey === evidence.ratingKey &&
+					candidate.sourceFingerprint === evidence.sourceFingerprint &&
+					evidenceFingerprint(candidate.soleParentTarget) === proof.soleParentTargetFingerprint &&
+					candidate.lowerBound === proof.observedLowerBound &&
+					candidate.lowerBound > threshold,
+			);
+			if (!row) continue;
+			policyRows.push({
+				instanceId: instance.id,
+				showTmdbId: row.showTmdbId,
+				seasonNumber: row.seasonNumber,
+				episodeNumber: row.episodeNumber,
+				ratingKey: row.ratingKey,
+				watchCount: row.lowerBound,
+				refreshedAt: new Date(current.provenance.publishedAt),
+				sourceFingerprint: row.sourceFingerprint,
+			});
+		}
 	}
-	if (policyEvidence.some((entry) => !entry.available)) {
-		throw new EpisodeWatchProofError(
-			"No complete Plex episode policy evidence was available at the mutation boundary",
-		);
+	if (policyRows.length === 0) {
+		const policyEvidence = [];
+		for (const instance of enabledPlexInstances) {
+			policyEvidence.push(
+				await authority.readInstanceSelectedEpisodes({
+					userId: instance.userId,
+					instanceId: instance.id,
+					showTmdbIds: [showTmdbId],
+					mutation: true,
+					maxAgeMs: 24 * 60 * 60 * 1000,
+				}),
+			);
+		}
+		if (policyEvidence.some((entry) => !entry.available)) {
+			throw new EpisodeWatchProofError(
+				"No complete Plex episode policy evidence was available at the mutation boundary",
+			);
+		}
+		policyRows = policyEvidence
+			.flatMap((entry) => (entry.available ? entry.rows : []))
+			.filter(
+				(row) =>
+					row.showTmdbId === showTmdbId &&
+					row.seasonNumber === seasonNumber &&
+					row.episodeNumber === exactEpisodeNumber,
+			);
 	}
-	const policyRows = policyEvidence
-		.flatMap((entry) => (entry.available ? entry.rows : []))
-		.filter(
-			(row) =>
-				row.showTmdbId === showTmdbId &&
-				row.seasonNumber === seasonNumber &&
-				row.episodeNumber === exactEpisodeNumber,
-		);
 	if (policyRows.length === 0) {
 		throw new EpisodeWatchProofError(
 			"No complete Plex episode policy evidence was available at the mutation boundary",
@@ -4114,6 +4305,84 @@ async function verifyEpisodePlexWatchProof(
 		const plexUpdatedAt = plexInstance.updatedAt.getTime();
 		const currentPlexFingerprint = plexEvidenceSourceFingerprint(plexInstance);
 		if (evidence.sourceFingerprint !== currentPlexFingerprint) continue;
+		const positiveProof = evidence.positiveProof;
+		if (
+			positiveProof?.operator === "greater_than" &&
+			typeof positiveProof.threshold === "number" &&
+			Number.isFinite(positiveProof.threshold) &&
+			positiveProof.threshold >= 0 &&
+			typeof positiveProof.connectionGeneration === "number" &&
+			Number.isSafeInteger(positiveProof.connectionGeneration) &&
+			positiveProof.connectionGeneration >= 0 &&
+			typeof positiveProof.identityGeneration === "number" &&
+			Number.isSafeInteger(positiveProof.identityGeneration) &&
+			positiveProof.identityGeneration >= 0 &&
+			typeof positiveProof.parentGenerationId === "string" &&
+			positiveProof.parentGenerationId.length > 0 &&
+			typeof positiveProof.parentTargetDigest === "string" &&
+			positiveProof.parentTargetDigest.length > 0 &&
+			typeof positiveProof.soleParentTargetFingerprint === "string" &&
+			positiveProof.soleParentTargetFingerprint.length > 0 &&
+			typeof positiveProof.episodeGenerationId === "string" &&
+			positiveProof.episodeGenerationId.length > 0 &&
+			typeof positiveProof.episodeDigest === "string" &&
+			positiveProof.episodeDigest.length > 0 &&
+			typeof positiveProof.showTmdbId === "number" &&
+			Number.isSafeInteger(positiveProof.showTmdbId) &&
+			positiveProof.showTmdbId > 0 &&
+			typeof positiveProof.observedLowerBound === "number" &&
+			Number.isSafeInteger(positiveProof.observedLowerBound) &&
+			positiveProof.observedLowerBound > 0 &&
+			typeof positiveProof.ruleId === "string" &&
+			positiveProof.ruleId.length > 0 &&
+			typeof positiveProof.ruleFingerprint === "string" &&
+			positiveProof.ruleFingerprint.length > 0
+		) {
+			const verifiedSource = verifiedPolicySources.get(`${plexInstance.id}:${evidence.ratingKey}`);
+			if (
+				verifiedSource &&
+				verifiedSource.sourceFingerprint === currentPlexFingerprint &&
+				verifiedSource.source.liveWatchCount > positiveProof.threshold
+			) {
+				const match = verifiedSource.match;
+				return {
+					proof: {
+						plexInstanceId: plexInstance.id,
+						sourceFingerprint: currentPlexFingerprint,
+						plexServerUrl: verifiedSource.serverUrl,
+						ratingKey: evidence.ratingKey,
+						watchCount: verifiedSource.source.liveWatchCount,
+						refreshedAt: new Date().toISOString(),
+						fullPath: normalizeMediaPath(match.part.file),
+						size: match.part.size,
+						mapping: match.mapping,
+						positiveProof: {
+							connectionGeneration: positiveProof.connectionGeneration!,
+							identityGeneration: positiveProof.identityGeneration!,
+							parentGenerationId: positiveProof.parentGenerationId!,
+							parentPublicationLevel: "positive-only",
+							parentTargetDigest: positiveProof.parentTargetDigest!,
+							soleParentTargetFingerprint: positiveProof.soleParentTargetFingerprint!,
+							episodeGenerationId: positiveProof.episodeGenerationId!,
+							episodeDigest: positiveProof.episodeDigest!,
+							showTmdbId: positiveProof.showTmdbId!,
+							observedLowerBound: positiveProof.observedLowerBound!,
+							observedAt:
+								positiveProof.observedAt instanceof Date
+									? positiveProof.observedAt.toISOString()
+									: positiveProof.observedAt!,
+							operator: "greater_than",
+							threshold: positiveProof.threshold,
+							ruleId: positiveProof.ruleId!,
+							ruleFingerprint: positiveProof.ruleFingerprint!,
+						},
+					},
+					liveWatchSources: [...verifiedPolicySources.values()].map(({ source }) => source),
+				};
+			}
+			continue;
+		}
+		if (positiveProof) continue;
 		if (!Number.isFinite(plexUpdatedAt) || approvedRefreshedAt.getTime() < plexUpdatedAt) {
 			continue;
 		}

--- a/apps/api/src/lib/plex/__tests__/plex-authority-architecture.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-architecture.test.ts
@@ -13,6 +13,9 @@ const directTargetLedgerAccessAllowlist = new Set([
 	path.normalize("src/lib/plex/plex-authority-service.ts"),
 	path.normalize("src/lib/plex/plex-generation-target-ledger.ts"),
 ]);
+const positiveV4ConsumerAllowlist = new Set([
+	path.normalize("src/lib/plex/plex-authority-service.ts"),
+]);
 const fixedPointMutationConsumers = [
 	path.normalize("src/lib/label-sync/dest-writers/plex-writer.ts"),
 	path.normalize("src/routes/plex/collection-routes.ts"),
@@ -46,6 +49,14 @@ function findPlexAuthorityViolations(relative: string, source: string): string[]
 		!rawObservationImportAllowlist.has(normalized)
 	) {
 		violations.push("imports the raw persisted-observation repository");
+	}
+	if (
+		/import\s*\{[^}]*\bloadPositiveEpisode(?:Parent)?Evidence\b[^}]*\}\s*from\s+["'][^"']*plex-evidence-repository\.js["']/.test(
+			source,
+		) &&
+		!positiveV4ConsumerAllowlist.has(normalized)
+	) {
+		violations.push("bypasses the explicit positive V4 authority reader");
 	}
 	if (
 		/\.updateMetadataTags\s*\(/.test(source) &&
@@ -91,6 +102,18 @@ describe("Plex authority architecture", () => {
 				'import { loadInstanceEvidence } from "../../lib/plex/plex-evidence-repository.js";',
 			),
 		).toContain("imports the raw persisted-observation repository");
+		expect(
+			findPlexAuthorityViolations(
+				"src/lib/library-cleanup/example.ts",
+				'import { loadPositiveEpisodeParentEvidence } from "../plex/plex-evidence-repository.js";',
+			),
+		).toContain("bypasses the explicit positive V4 authority reader");
+		expect(
+			findPlexAuthorityViolations(
+				"src/lib/library-cleanup/example.ts",
+				'import { loadPositiveEpisodeEvidence } from "../plex/plex-evidence-repository.js";',
+			),
+		).toContain("bypasses the explicit positive V4 authority reader");
 		expect(
 			findPlexAuthorityViolations(
 				"src/routes/plex/example.ts",

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { PlexCanonicalObservation } from "../plex-canonical-projection.js";
+import { createPositivePlexEpisodeDigest } from "../plex-episode-live-collector.js";
 
 const repositoryMocks = vi.hoisted(() => ({
 	loadInstanceSelectedEvidence: vi.fn(),
+	loadPositiveEpisodeEvidence: vi.fn(),
+	loadPositiveEpisodeParentEvidence: vi.fn(),
 	scanInstanceEpisodeParentPolicyEvidence: vi.fn(),
 }));
 
@@ -11,17 +14,19 @@ vi.mock("../plex-evidence-repository.js", async (importOriginal) => {
 	return {
 		...actual,
 		loadInstanceSelectedEvidence: repositoryMocks.loadInstanceSelectedEvidence,
+		loadPositiveEpisodeEvidence: repositoryMocks.loadPositiveEpisodeEvidence,
+		loadPositiveEpisodeParentEvidence: repositoryMocks.loadPositiveEpisodeParentEvidence,
 		scanInstanceEpisodeParentPolicyEvidence:
 			repositoryMocks.scanInstanceEpisodeParentPolicyEvidence,
 	};
 });
 
 import {
-	plexEpisodeParentAuthorityChanged,
 	PlexAuthorityService,
 	PlexAuthorityUnavailableError,
-	settlePlexAuthorityWindow,
 	type PlexPersistedSelectionObservation,
+	plexEpisodeParentAuthorityChanged,
+	settlePlexAuthorityWindow,
 } from "../plex-authority-service.js";
 import { createPlexTargetLedgerBinding } from "../plex-generation-target-ledger.js";
 
@@ -281,6 +286,497 @@ async function mutateWithLedgerEvidence(input: {
 }
 
 describe("PlexAuthorityService settlement window", () => {
+	it("exposes ledger-bound positive episode rows as lower bounds", async () => {
+		const target = {
+			id: "target-episode",
+			instanceId: "plex-1",
+			generationId: "generation-v4",
+			sectionId: "shows-a",
+			sectionUuid: "shows-a-uuid",
+			mediaType: "series" as const,
+			tmdbId: 42,
+			tvdbId: 84,
+			ratingKey: "show-42",
+		};
+		const targetBinding = createPlexTargetLedgerBinding({
+			instanceId: target.instanceId,
+			generationId: target.generationId,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			targets: [target],
+		});
+		const positiveEpisodeRow = {
+			id: "episode-1",
+			instanceId: "plex-1",
+			showTmdbId: 42,
+			seasonNumber: 1,
+			episodeNumber: 1,
+			ratingKey: "episode-1",
+			title: "Pilot",
+			watched: true,
+			watchedByUsers: "[]",
+			lastWatchedAt: null,
+			watchCount: 3,
+			refreshedAt: new Date("2026-08-20T12:00:00.000Z"),
+			sourceFingerprint: "source-1",
+			connectionGeneration: 4,
+			identityGeneration: 9,
+		};
+		const episodeDigest = createPositivePlexEpisodeDigest(
+			[
+				{
+					instanceId: target.instanceId,
+					generationId: target.generationId,
+					showTmdbId: target.tmdbId,
+					sectionId: target.sectionId,
+					sectionUuid: target.sectionUuid,
+					mediaType: "series",
+					tvdbId: target.tvdbId,
+					ratingKey: target.ratingKey,
+				},
+			],
+			[positiveEpisodeRow],
+		);
+		const observed = {
+			available: true,
+			instanceId: "plex-1",
+			generationId: "episode-generation-v3",
+			parentGenerationId: "generation-v4",
+			publishedAt: new Date("2026-08-20T12:00:00.000Z"),
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: {
+				version: 3,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				capability: {
+					domain: "episodes",
+					field: "watchCount",
+					semantics: "lower-bound",
+					operator: "greater_than",
+				},
+				parentPlexGenerationId: "generation-v4",
+				parentMetadataVersion: 4,
+				parentPublicationLevel: "positive-only",
+				parentTargetDigest: targetBinding.targetDigest,
+				episodeDigest,
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+			parentMetadata: {
+				version: 4,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				sections: [firstShowSection],
+				observedRoots: [
+					{ sectionKey: firstShowSection.key, domain: "episode-parents", digest: "a".repeat(64) },
+				],
+				capabilities: [
+					{
+						domain: "episode-parents",
+						field: "membership",
+						semantics: "observed-targets-only",
+						operators: [],
+					},
+				],
+				...targetBinding,
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			},
+			rows: [positiveEpisodeRow],
+			evidence: {
+				availability: "current",
+				authority: "positive-only",
+				attemptState: "partial",
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				reasonCodes: ["latest_attempt_partial"],
+			},
+		};
+		repositoryMocks.loadPositiveEpisodeEvidence.mockResolvedValue(observed);
+		const service = new PlexAuthorityService({
+			prisma: {
+				plexGenerationTarget: { findMany: vi.fn().mockResolvedValue([target]) },
+			} as never,
+			log: {} as never,
+		});
+
+		const result = await service.readPositiveEpisodeEvidence({
+			userId: "user-1",
+			instanceId: "plex-1",
+		});
+
+		expect(result).toMatchObject({
+			available: true,
+			capability: {
+				domain: "episodes",
+				field: "watchCount",
+				semantics: "lower-bound",
+				operator: "greater_than",
+			},
+			provenance: {
+				parentPlexGenerationId: "generation-v4",
+				parentTargetDigest: targetBinding.targetDigest,
+			},
+			rows: [
+				{
+					showTmdbId: 42,
+					seasonNumber: 1,
+					episodeNumber: 1,
+					ratingKey: "episode-1",
+					lowerBound: 3,
+					sourceFingerprint: "source-1",
+					soleParentTarget: expect.objectContaining({
+						generationId: "generation-v4",
+						sectionId: "shows-a",
+						ratingKey: "show-42",
+					}),
+				},
+			],
+		});
+		if (result.available) expect(result.rows[0]).not.toHaveProperty("watchCount");
+
+		repositoryMocks.loadPositiveEpisodeEvidence.mockResolvedValueOnce({
+			...observed,
+			metadata: { ...observed.metadata, episodeDigest: "d".repeat(64) },
+		});
+		const tampered = await service.readPositiveEpisodeEvidence({
+			userId: "user-1",
+			instanceId: "plex-1",
+		});
+		expect(tampered).toMatchObject({
+			available: false,
+			evidence: { reasonCodes: ["plex_content_digest_changed"] },
+		});
+	});
+
+	it("omits positive episode rows for duplicate parent targets", async () => {
+		const targets = [
+			{
+				id: "target-42-a",
+				instanceId: "plex-1",
+				generationId: "generation-v4-duplicate",
+				sectionId: "shows-a",
+				sectionUuid: "shows-a-uuid",
+				mediaType: "series" as const,
+				tmdbId: 42,
+				tvdbId: 84,
+				ratingKey: "show-42-a",
+			},
+			{
+				id: "target-42-b",
+				instanceId: "plex-1",
+				generationId: "generation-v4-duplicate",
+				sectionId: "shows-b",
+				sectionUuid: "shows-b-uuid",
+				mediaType: "series" as const,
+				tmdbId: 42,
+				tvdbId: 84,
+				ratingKey: "show-42-b",
+			},
+		];
+		const targetBinding = createPlexTargetLedgerBinding({
+			instanceId: "plex-1",
+			generationId: "generation-v4-duplicate",
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			targets,
+		});
+		repositoryMocks.loadPositiveEpisodeEvidence.mockResolvedValue({
+			available: true,
+			instanceId: "plex-1",
+			generationId: "episode-generation-v3-duplicate",
+			parentGenerationId: "generation-v4-duplicate",
+			publishedAt: new Date("2026-08-20T12:00:00.000Z"),
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: {
+				version: 3,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 0,
+				canonicalizationVersion: 1,
+				capability: {
+					domain: "episodes",
+					field: "watchCount",
+					semantics: "lower-bound",
+					operator: "greater_than",
+				},
+				parentPlexGenerationId: "generation-v4-duplicate",
+				parentMetadataVersion: 4,
+				parentPublicationLevel: "positive-only",
+				parentTargetDigest: targetBinding.targetDigest,
+				episodeDigest: createPositivePlexEpisodeDigest([], []),
+				partialReasons: [{ code: "ambiguous_episode_parent_targets", count: 2 }],
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+			parentMetadata: {
+				version: 4,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 2,
+				canonicalizationVersion: 1,
+				sections: [firstShowSection, secondShowSection],
+				observedRoots: [
+					{ sectionKey: firstShowSection.key, domain: "episode-parents", digest: "a".repeat(64) },
+				],
+				capabilities: [
+					{
+						domain: "episode-parents",
+						field: "membership",
+						semantics: "observed-targets-only",
+						operators: [],
+					},
+				],
+				...targetBinding,
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			},
+			rows: [],
+			evidence: {
+				availability: "current",
+				authority: "positive-only",
+				attemptState: "partial",
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				reasonCodes: ["latest_attempt_partial"],
+			},
+		});
+		const service = new PlexAuthorityService({
+			prisma: {
+				plexGenerationTarget: { findMany: vi.fn().mockResolvedValue(targets) },
+			} as never,
+			log: {} as never,
+		});
+
+		const result = await service.readPositiveEpisodeEvidence({
+			userId: "user-1",
+			instanceId: "plex-1",
+		});
+
+		expect(result).toMatchObject({ available: true, rows: [] });
+	});
+
+	it("reads only ledger-verified observed Show parents from a positive V4 generation", async () => {
+		const target = {
+			id: "target-1",
+			instanceId: "plex-1",
+			generationId: "generation-v4",
+			sectionId: "shows-a",
+			sectionUuid: "shows-a-uuid",
+			mediaType: "series" as const,
+			tmdbId: 42,
+			tvdbId: 84,
+			ratingKey: "show-42",
+		};
+		const duplicateTarget = {
+			...target,
+			id: "target-42-copy",
+			sectionId: "shows-b",
+			sectionUuid: "shows-b-uuid",
+			ratingKey: "show-42-copy",
+		};
+		const otherTarget = {
+			...duplicateTarget,
+			id: "target-99",
+			tmdbId: 99,
+			tvdbId: 198,
+			ratingKey: "show-99",
+		};
+		const targetBinding = createPlexTargetLedgerBinding({
+			instanceId: target.instanceId,
+			generationId: target.generationId,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			targets: [target, duplicateTarget, otherTarget],
+		});
+		repositoryMocks.loadPositiveEpisodeParentEvidence.mockResolvedValue({
+			available: true,
+			instanceId: "plex-1",
+			generationId: "generation-v4",
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: {
+				version: 4,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 2,
+				canonicalizationVersion: 1,
+				sections: [firstShowSection, secondShowSection],
+				observedRoots: [
+					{ sectionKey: firstShowSection.key, domain: "episode-parents", digest: "a".repeat(64) },
+				],
+				capabilities: [
+					{
+						domain: "episode-parents",
+						field: "membership",
+						semantics: "observed-targets-only",
+						operators: [],
+					},
+				],
+				...targetBinding,
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			},
+			rows: [
+				{
+					...rowA,
+					instanceId: "plex-1",
+					mediaType: "series",
+					tmdbId: 42,
+					sectionId: "shows-a",
+					ratingKey: "show-42",
+					connectionGeneration: 4,
+					identityGeneration: 9,
+				},
+				{
+					...rowA,
+					instanceId: "plex-1",
+					mediaType: "series",
+					tmdbId: 99,
+					sectionId: "shows-b",
+					ratingKey: "show-99",
+					connectionGeneration: 4,
+					identityGeneration: 9,
+				},
+			],
+			evidence: {
+				availability: "current",
+				authority: "positive-only",
+				attemptState: "partial",
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				reasonCodes: ["latest_attempt_partial"],
+			},
+		});
+		const service = new PlexAuthorityService({
+			prisma: {
+				serviceInstance: {
+					findFirst: vi.fn().mockResolvedValue({
+						id: "plex-1",
+						userId: "user-1",
+						service: "PLEX",
+						enabled: true,
+					}),
+				},
+				plexGenerationTarget: {
+					findMany: vi.fn().mockResolvedValue([target, duplicateTarget, otherTarget]),
+				},
+			} as never,
+			log: {} as never,
+		});
+
+		const result = await service.readPositiveEpisodeParents({
+			userId: "user-1",
+			instanceId: "plex-1",
+			showTmdbIds: [42, 99, 999],
+		});
+		expect(result.available).toBe(true);
+		if (!result.available) return;
+		expect(result).toMatchObject({
+			available: true,
+			capability: {
+				domain: "episode-parents",
+				field: "membership",
+				semantics: "observed-targets-only",
+			},
+			rows: expect.arrayContaining([
+				expect.objectContaining({ tmdbId: 42, sectionId: "shows-a", ratingKey: "show-42" }),
+				expect.objectContaining({ tmdbId: 99, sectionId: "shows-b", ratingKey: "show-99" }),
+			]),
+			targets: expect.arrayContaining([
+				expect.objectContaining({ tmdbId: 42, ratingKey: "show-42" }),
+				expect.objectContaining({ tmdbId: 99, ratingKey: "show-99" }),
+			]),
+		});
+		expect(result.targets).toHaveLength(2);
+		expect(result.targets).not.toContainEqual(
+			expect.objectContaining({ ratingKey: "show-42-copy" }),
+		);
+		expect(result).not.toMatchObject({
+			rows: [expect.objectContaining({ watchCount: expect.anything() })],
+		});
+	});
+
+	it("uses an authoritative V3 generation through the positive parent reader", async () => {
+		const target = {
+			id: "target-v3",
+			instanceId: "plex-1",
+			generationId: "generation-v3",
+			sectionId: "shows-a",
+			sectionUuid: "shows-a-uuid",
+			mediaType: "series" as const,
+			tmdbId: 42,
+			tvdbId: 84,
+			ratingKey: "show-42",
+		};
+		const targetBinding = createPlexTargetLedgerBinding({
+			instanceId: target.instanceId,
+			generationId: target.generationId,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			targets: [target],
+		});
+		repositoryMocks.loadPositiveEpisodeParentEvidence.mockResolvedValue({
+			available: true,
+			instanceId: "plex-1",
+			generationId: "generation-v3",
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: {
+				version: 3,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				sections: [firstShowSection],
+				roots: [{ sectionKey: "shows-a", domain: "episode-parents", digest: "a".repeat(64) }],
+				...targetBinding,
+			},
+			rows: [
+				{
+					...rowA,
+					instanceId: "plex-1",
+					mediaType: "series",
+					tmdbId: 42,
+					sectionId: "shows-a",
+					ratingKey: "show-42",
+					connectionGeneration: 4,
+					identityGeneration: 9,
+				},
+			],
+			evidence: {
+				availability: "current",
+				authority: "authoritative",
+				attemptState: "success",
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				reasonCodes: [],
+			},
+		});
+		const service = new PlexAuthorityService({
+			prisma: {
+				plexGenerationTarget: { findMany: vi.fn().mockResolvedValue([target]) },
+			} as never,
+			log: {} as never,
+		});
+
+		const result = await service.readPositiveEpisodeParents({
+			userId: "user-1",
+			instanceId: "plex-1",
+			showTmdbIds: [42],
+		});
+
+		expect(result).toMatchObject({
+			available: true,
+			provenance: { publicationLevel: "authoritative", completeness: "complete" },
+			partialReasons: [],
+			rows: [{ tmdbId: 42, ratingKey: "show-42" }],
+		});
+	});
 	it.each([
 		[
 			1,

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -580,6 +580,11 @@ describe("PlexAuthorityService settlement window", () => {
 			sectionUuid: "shows-b-uuid",
 			ratingKey: "show-42-copy",
 		};
+		const sameSectionDuplicateTarget = {
+			...target,
+			id: "target-42-same-section-copy",
+			ratingKey: "show-42-same-section-copy",
+		};
 		const otherTarget = {
 			...duplicateTarget,
 			id: "target-99",
@@ -592,7 +597,7 @@ describe("PlexAuthorityService settlement window", () => {
 			generationId: target.generationId,
 			connectionGeneration: 4,
 			identityGeneration: 9,
-			targets: [target, duplicateTarget, otherTarget],
+			targets: [target, sameSectionDuplicateTarget, duplicateTarget, otherTarget],
 		});
 		repositoryMocks.loadPositiveEpisodeParentEvidence.mockResolvedValue({
 			available: true,
@@ -663,7 +668,9 @@ describe("PlexAuthorityService settlement window", () => {
 					}),
 				},
 				plexGenerationTarget: {
-					findMany: vi.fn().mockResolvedValue([target, duplicateTarget, otherTarget]),
+					findMany: vi
+						.fn()
+						.mockResolvedValue([target, sameSectionDuplicateTarget, duplicateTarget, otherTarget]),
 				},
 			} as never,
 			log: {} as never,
@@ -689,10 +696,15 @@ describe("PlexAuthorityService settlement window", () => {
 			]),
 			targets: expect.arrayContaining([
 				expect.objectContaining({ tmdbId: 42, ratingKey: "show-42" }),
+				expect.objectContaining({
+					tmdbId: 42,
+					sectionId: "shows-a",
+					ratingKey: "show-42-same-section-copy",
+				}),
 				expect.objectContaining({ tmdbId: 99, ratingKey: "show-99" }),
 			]),
 		});
-		expect(result.targets).toHaveLength(2);
+		expect(result.targets).toHaveLength(3);
 		expect(result.targets).not.toContainEqual(
 			expect.objectContaining({ ratingKey: "show-42-copy" }),
 		);

--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -3,7 +3,11 @@
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
 import type { PrismaClient } from "../../prisma.js";
-import { collectPlexCacheLiveEvidence } from "../plex-cache-refresher.js";
+import {
+	canPublishPositivePlexObservation,
+	collectPlexCacheLiveEvidence,
+	collectSettledPlexCacheLiveEvidence,
+} from "../plex-cache-refresher.js";
 import type { PlexClient } from "../plex-client.js";
 
 const silentLog = {
@@ -29,6 +33,258 @@ async function refreshPlexCache(
 }
 
 describe("collectPlexCacheLiveEvidence", () => {
+	function positiveObservationClient(input: {
+		accounts?: Array<{ id: number; name: string }>;
+		librarySections?: Array<{ key: string; title: string; type: "movie" | "show" }>;
+		libraryItems?: Array<{
+			ratingKey: string;
+			title: string;
+			type: "movie" | "show";
+			Guid: Array<{ id: string }>;
+		}>;
+		libraryItemsBySection?: Record<
+			string,
+			Array<{
+				ratingKey: string;
+				title: string;
+				type: "movie" | "show";
+				Guid: Array<{ id: string }>;
+			}>
+		>;
+		history?: unknown[];
+		onDeck?: unknown[] | Error;
+		activities?: Array<{ type: string }>;
+		settlementSections?: Array<{
+			key: string;
+			uuid: string;
+			title: string;
+			type: "movie" | "show";
+			refreshing: boolean;
+			scannedAt: number | null;
+			updatedAt: number;
+		}>;
+	}) {
+		const librarySections = input.librarySections ?? [
+			{ key: "shows", title: "Shows", type: "show" },
+		];
+		const settlementSections = input.settlementSections ?? [
+			{
+				key: "shows",
+				uuid: "shows-uuid",
+				title: "Shows",
+				type: "show" as const,
+				refreshing: false,
+				scannedAt: 1,
+				updatedAt: 1,
+			},
+		];
+		return {
+			getActivities: vi.fn().mockResolvedValue(input.activities ?? []),
+			getLibrarySettlementSections: vi.fn().mockResolvedValue(settlementSections),
+			getAccounts: vi.fn().mockResolvedValue(input.accounts ?? [{ id: 1, name: "Alice" }]),
+			getLibrarySections: vi.fn().mockResolvedValue(librarySections),
+			getLibraryItems: vi.fn().mockImplementation((sectionId: string) =>
+				Promise.resolve(
+					input.libraryItemsBySection?.[sectionId] ??
+						input.libraryItems ?? [
+							{
+								ratingKey: "show-1",
+								title: "Mapped Show",
+								type: "show" as const,
+								Guid: [{ id: "tmdb://42" }, { id: "tvdb://42" }],
+							},
+							{
+								ratingKey: "legacy-movie",
+								title: "Legacy Movie",
+								type: "movie" as const,
+								Guid: [],
+							},
+						],
+				),
+			),
+			getHistory: vi.fn().mockResolvedValue(input.history ?? []),
+			verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+			getOnDeck:
+				input.onDeck instanceof Error
+					? vi.fn().mockRejectedValue(input.onDeck)
+					: vi.fn().mockResolvedValue(input.onDeck ?? []),
+		} as unknown as PlexClient;
+	}
+
+	it("returns a settled positive observation without a snapshot for mapped rows beside an unmappable item", async () => {
+		// Removing the positive-only branch, returning the rows under `snapshot`, or
+		// omitting its bound target/root must make this fail.
+		const result = await collectSettledPlexCacheLiveEvidence(
+			positiveObservationClient({}),
+			"inst-1",
+			silentLog,
+		);
+
+		expect(result).toMatchObject({
+			kind: "positive-observation",
+			complete: false,
+			observation: {
+				rows: [expect.objectContaining({ tmdbId: 42, ratingKey: "show-1" })],
+				observedTargets: [
+					expect.objectContaining({
+						tmdbId: 42,
+						tvdbId: 42,
+						ratingKey: "show-1",
+						sectionUuid: "shows-uuid",
+					}),
+				],
+				capabilities: [
+					{
+						domain: "episode-parents",
+						field: "membership",
+						semantics: "observed-targets-only",
+						operators: [],
+					},
+				],
+				observedRoots: [
+					expect.objectContaining({ sectionKey: "shows", domain: "episode-parents" }),
+				],
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+				settlement: { sections: [expect.objectContaining({ key: "shows", uuid: "shows-uuid" })] },
+			},
+		});
+		expect("snapshot" in result).toBe(false);
+	});
+
+	it("scopes settled positive evidence to Show parents and assigns its completion time only after settlement", async () => {
+		const librarySections = [
+			{ key: "movies", title: "Movies", type: "movie" as const },
+			{ key: "shows", title: "Shows", type: "show" as const },
+		];
+		const settlementSections = [
+			{
+				key: "movies",
+				uuid: "movies-uuid",
+				title: "Movies",
+				type: "movie" as const,
+				refreshing: false,
+				scannedAt: 1,
+				updatedAt: 1,
+			},
+			{
+				key: "shows",
+				uuid: "shows-uuid",
+				title: "Shows",
+				type: "show" as const,
+				refreshing: false,
+				scannedAt: 1,
+				updatedAt: 1,
+			},
+		];
+		const libraryItemsBySection = {
+			movies: [
+				{
+					ratingKey: "movie-1",
+					title: "Mapped Movie",
+					type: "movie" as const,
+					Guid: [{ id: "tmdb://1" }],
+				},
+				{ ratingKey: "legacy-1", title: "Legacy Movie", type: "movie" as const, Guid: [] },
+			],
+			shows: [
+				{
+					ratingKey: "show-1",
+					title: "Mapped Show",
+					type: "show" as const,
+					Guid: [{ id: "tmdb://42" }, { id: "tvdb://42" }],
+				},
+			],
+		};
+		const input = { librarySections, settlementSections, libraryItemsBySection };
+
+		const unsettled = await collectPlexCacheLiveEvidence(
+			positiveObservationClient(input),
+			"inst-1",
+			silentLog,
+		);
+		expect(unsettled.kind).toBe("positive-observation");
+		expect(unsettled.completedAt).toBeUndefined();
+
+		const settled = await collectSettledPlexCacheLiveEvidence(
+			positiveObservationClient(input),
+			"inst-1",
+			silentLog,
+		);
+
+		expect(settled).toMatchObject({ kind: "positive-observation", completedAt: expect.any(Date) });
+		if (settled.kind !== "positive-observation") throw new Error("Expected positive observation");
+		expect(settled.observation.rows.map((row) => row.ratingKey)).toEqual(["show-1"]);
+		expect(settled.observation.observedTargets.map((target) => target.ratingKey)).toEqual([
+			"show-1",
+		]);
+		expect(settled.observation.observedRoots.map((root) => root.sectionKey)).toEqual(["shows"]);
+		expect(settled.observation.settlement?.sections.map((section) => section.key)).toEqual([
+			"movies",
+			"shows",
+		]);
+	});
+
+	it.each([
+		"currentItemsWithoutTmdbMetadata",
+		"currentLibraryItemsWithoutRatingKeys",
+		"historyItemsWithoutUsableMediaKey",
+		"currentHistoryItemsWithoutMappedMetadata",
+		"historyItemsWithUnknownAccounts",
+		"onDeckItemsWithoutMappedMetadata",
+		"onDeckFetchFailures",
+	] as const)("allows only the declared positive-only reason %s", (reason) => {
+		expect(canPublishPositivePlexObservation({ [reason]: 1 })).toBe(true);
+	});
+
+	it("blocks unknown partial reasons by default", () => {
+		// Extending collection with a new incomplete reason must not silently grant
+		// observed-target authority before its policy is explicitly reviewed.
+		expect(canPublishPositivePlexObservation({ futureReason: 1 })).toBe(false);
+	});
+
+	it.each([
+		["no user accounts", positiveObservationClient({ accounts: [] })],
+		["no media libraries", positiveObservationClient({ librarySections: [] })],
+		[
+			"a library snapshot failure",
+			(() => {
+				const client = positiveObservationClient({});
+				vi.mocked(client.getLibraryItems).mockRejectedValue(new Error("section unavailable"));
+				return client;
+			})(),
+		],
+	] as const)("keeps partial evidence unpublished for %s", async (_caseName, client) => {
+		const result = await collectPlexCacheLiveEvidence(client, "inst-1", silentLog);
+
+		expect(result.kind).toBe("unpublished");
+	});
+
+	it.each([
+		[
+			"an active scan",
+			positiveObservationClient({
+				settlementSections: [
+					{
+						key: "shows",
+						uuid: "shows-uuid",
+						title: "Shows",
+						type: "show",
+						refreshing: true,
+						scannedAt: 1,
+						updatedAt: 1,
+					},
+				],
+			}),
+		],
+		[
+			"metadata activity",
+			positiveObservationClient({ activities: [{ type: "library.update.item.metadata" }] }),
+		],
+	] as const)("keeps a positive observation unpublished during %s", async (_caseName, client) => {
+		const result = await collectSettledPlexCacheLiveEvidence(client, "inst-1", silentLog);
+
+		expect(result.kind).toBe("unpublished");
+	});
 	it("collects a complete large-library snapshot without publishing", async () => {
 		// Stands in for "manual smoke on a Docker + SQLite deployment with a large
 		// Plex library" — runs the full refreshPlexCache path with >1,000 items

--- a/apps/api/src/lib/plex/__tests__/plex-evidence-repository.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-evidence-repository.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, it, vi } from "vitest";
+import { verifiedIdentityData } from "../../services/service-identity-lifecycle.js";
+import { createPositivePlexEpisodeDigest } from "../plex-episode-live-collector.js";
 import {
 	getPublishedEpisodeGenerationObservation,
 	loadInstanceEpisodeEvidence,
 	loadInstanceEvidence,
 	loadInstanceMutationEvidence,
 	loadInstanceSelectedEvidence,
-	scanInstancePolicyEvidence,
-	scanInstanceEpisodeParentPolicyEvidence,
-	scanUserPolicyEvidence,
+	loadPositiveEpisodeEvidence,
 	loadUserEvidence,
+	scanInstanceEpisodeParentPolicyEvidence,
+	scanInstancePolicyEvidence,
+	scanUserPolicyEvidence,
 } from "../plex-evidence-repository.js";
-import { verifiedIdentityData } from "../../services/service-identity-lifecycle.js";
 
 const now = new Date("2026-08-20T14:00:00.000Z");
 const sections = [
@@ -34,6 +36,40 @@ function v3Metadata(itemCount = 1) {
 		canonicalizationVersion: 1,
 		sections,
 		roots: [{ sectionKey: "movies", domain: "membership", digest: "a".repeat(64) }],
+	});
+}
+
+function v4Metadata(itemCount = 1) {
+	return JSON.stringify({
+		version: 4,
+		publicationLevel: "positive-only",
+		completeness: "partial",
+		itemCount,
+		canonicalizationVersion: 1,
+		sections: [
+			{
+				key: "shows",
+				uuid: "shows-uuid",
+				title: "Shows",
+				type: "show",
+				refreshing: false,
+				scannedAt: 1_777_000_000,
+				updatedAt: 1_777_000_100,
+			},
+		],
+		observedRoots: [{ sectionKey: "shows", domain: "episode-parents", digest: "a".repeat(64) }],
+		capabilities: [
+			{
+				domain: "episode-parents",
+				field: "membership",
+				semantics: "observed-targets-only",
+				operators: [],
+			},
+		],
+		targetLedgerVersion: 1,
+		targetCount: 1,
+		targetDigest: "b".repeat(64),
+		partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
 	});
 }
 
@@ -142,6 +178,45 @@ function episodeRow(overrides: Record<string, unknown> = {}) {
 	};
 }
 
+function positiveEpisodeMetadata(rows: ReturnType<typeof episodeRow>[]) {
+	const episodeDigest = createPositivePlexEpisodeDigest(
+		[
+			{
+				instanceId: "plex-1",
+				generationId: "generation-v4",
+				showTmdbId: 42,
+				sectionId: "shows",
+				sectionUuid: "shows-uuid",
+				mediaType: "series",
+				tvdbId: null,
+				ratingKey: "show-42",
+			},
+		],
+		rows,
+	);
+	return JSON.stringify({
+		version: 3,
+		publicationLevel: "positive-only",
+		completeness: "partial",
+		itemCount: rows.length,
+		canonicalizationVersion: 1,
+		capability: {
+			domain: "episodes",
+			field: "watchCount",
+			semantics: "lower-bound",
+			operator: "greater_than",
+		},
+		parentPlexGenerationId: "generation-v4",
+		parentMetadataVersion: 4,
+		parentPublicationLevel: "positive-only",
+		parentTargetDigest: "b".repeat(64),
+		episodeDigest,
+		partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+		connectionGeneration: 4,
+		identityGeneration: 9,
+	});
+}
+
 function fixture(
 	options: {
 		instance?: ReturnType<typeof instance> | null;
@@ -215,6 +290,55 @@ describe("Plex evidence repository", () => {
 				reasonCodes: [],
 			},
 		});
+	});
+
+	it("withholds V4 rows from the generic exact reader", async () => {
+		const positiveStatus = status({
+			generationMetadata: v4Metadata(),
+			lastAttemptResult: "partial",
+		});
+
+		const result = await load(
+			fixture({
+				statuses: [positiveStatus, { ...positiveStatus }],
+				rows: [
+					row({
+						mediaType: "series",
+						sectionId: "shows",
+						sectionTitle: "Shows",
+					}),
+				],
+			}),
+		);
+
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+		});
+	});
+
+	it("withholds V4 rows from generic policy scans", async () => {
+		const positiveStatus = status({
+			generationMetadata: v4Metadata(),
+			lastAttemptResult: "partial",
+		});
+		const testFixture = fixture({
+			statuses: [positiveStatus, { ...positiveStatus }],
+			rows: [row({ mediaType: "series", sectionId: "shows", sectionTitle: "Shows" })],
+		});
+
+		const result = await scanInstancePolicyEvidence(testFixture.prisma as never, {
+			userId: "user-1",
+			instanceId: "plex-1",
+			now,
+			maxAgeMs: 3 * 60 * 60 * 1000,
+		});
+
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+		});
+		expect(testFixture.events).toEqual(["instance", "status"]);
 	});
 
 	it("streams generation-bound policy rows without materializing them in the result", async () => {
@@ -411,7 +535,7 @@ describe("Plex evidence repository", () => {
 		});
 	});
 
-	it("loads valid V2 authoritative metadata", async () => {
+	it("withholds legacy V2 metadata from the generic exact reader", async () => {
 		const generationMetadata = JSON.stringify({
 			version: 2,
 			publicationLevel: "authoritative",
@@ -424,7 +548,10 @@ describe("Plex evidence repository", () => {
 				statuses: [status({ generationMetadata }), status({ generationMetadata })],
 			}),
 		);
-		expect(result).toMatchObject({ available: true, metadata: { version: 2 } });
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+		});
 	});
 
 	it("retains an earlier authoritative generation after the latest attempt fails", async () => {
@@ -973,6 +1100,95 @@ describe("Plex episode evidence repository", () => {
 		});
 	}
 
+	it("reads a V3 positive episode generation only when it is bound to the current V4 parent", async () => {
+		const rows = [episodeRow({ watchCount: 3, watched: true })];
+		const repository = episodeFixture({
+			parentStatus: status({
+				generationId: "generation-v4",
+				generationMetadata: v4Metadata(),
+				lastAttemptResult: "partial",
+			}),
+			episode: episodeStatus({
+				generationMetadata: positiveEpisodeMetadata(rows),
+				lastAttemptResult: "partial",
+			}),
+			episodeRows: rows,
+		});
+
+		const result = await loadPositiveEpisodeEvidence(repository as never, {
+			userId: "user-1",
+			instanceId: "plex-1",
+			instance: instance(),
+			now,
+			maxAgeMs: 3 * 60 * 60 * 1000,
+		});
+
+		expect(result).toMatchObject({
+			available: true,
+			generationId: "episode-generation-1",
+			parentGenerationId: "generation-v4",
+			metadata: {
+				capability: {
+					domain: "episodes",
+					field: "watchCount",
+					semantics: "lower-bound",
+					operator: "greater_than",
+				},
+			},
+			rows: [expect.objectContaining({ id: "episode-row-1", watchCount: 3 })],
+		});
+	});
+
+	it("rejects positive episode evidence when its parent target digest is not current", async () => {
+		const rows = [episodeRow({ watchCount: 3, watched: true })];
+		const metadata = JSON.parse(positiveEpisodeMetadata(rows)) as Record<string, unknown>;
+		metadata.parentTargetDigest = "c".repeat(64);
+		const repository = episodeFixture({
+			parentStatus: status({
+				generationId: "generation-v4",
+				generationMetadata: v4Metadata(),
+				lastAttemptResult: "partial",
+			}),
+			episode: episodeStatus({
+				generationMetadata: JSON.stringify(metadata),
+				lastAttemptResult: "partial",
+			}),
+			episodeRows: rows,
+		});
+
+		const result = await loadPositiveEpisodeEvidence(repository as never, {
+			userId: "user-1",
+			instanceId: "plex-1",
+			instance: instance(),
+			now,
+			maxAgeMs: 3 * 60 * 60 * 1000,
+		});
+
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { reasonCodes: ["target_digest_mismatch"] },
+		});
+	});
+
+	it("keeps the exact episode reader V2-only when a positive V3 episode generation exists", async () => {
+		const rows = [episodeRow({ watchCount: 3, watched: true })];
+		const result = await loadEpisode(
+			episodeFixture({
+				parentStatus: status({ generationId: "generation-v4" }),
+				episode: episodeStatus({
+					generationMetadata: positiveEpisodeMetadata(rows),
+					lastAttemptResult: "success",
+				}),
+				episodeRows: rows,
+			}),
+		);
+
+		expect(result).toMatchObject({
+			available: false,
+			evidence: { reasonCodes: ["malformed_metadata"] },
+		});
+	});
+
 	it("reads selected episode rows while rejecting a full-generation bound-count mismatch", async () => {
 		const repositoryModule = (await import("../plex-evidence-repository.js")) as Record<
 			string,
@@ -1205,6 +1421,42 @@ describe("Plex episode evidence repository", () => {
 		expect(result).toMatchObject({
 			available: false,
 			evidence: { reasonCodes: ["latest_attempt_failed"] },
+		});
+	});
+
+	it("reports a valid positive episode V3 publication as partial observation", async () => {
+		const rows = [episodeRow({ watchCount: 3, watched: true })];
+		const repository = episodeFixture({
+			parentStatus: status({
+				generationId: "generation-v4",
+				generationMetadata: v4Metadata(),
+				lastAttemptResult: "partial",
+			}),
+			episode: episodeStatus({
+				generationMetadata: positiveEpisodeMetadata(rows),
+				lastAttemptResult: "partial",
+			}),
+			episodeRows: rows,
+		});
+
+		const result = await getPublishedEpisodeGenerationObservation(repository as never, {
+			userId: "user-1",
+			instanceId: "plex-1",
+			instance: instance(),
+			now,
+			maxAgeMs: 3 * 60 * 60 * 1000,
+		});
+
+		expect(result).toMatchObject({
+			available: true,
+			itemCount: 1,
+			evidence: {
+				availability: "current",
+				authority: "positive-only",
+				attemptState: "partial",
+				publicationLevel: "positive-only",
+				completeness: "partial",
+			},
 		});
 	});
 

--- a/apps/api/src/lib/plex/__tests__/plex-generation-metadata.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-generation-metadata.test.ts
@@ -25,6 +25,36 @@ const v3Roots = [
 		digest: "a".repeat(64),
 	},
 ];
+const showSection = {
+	key: "shows",
+	uuid: "section-uuid-shows",
+	title: "Shows",
+	type: "show" as const,
+	refreshing: false as const,
+	scannedAt: 1_777_000_000,
+	updatedAt: 1_777_000_100,
+};
+const validV4Metadata = {
+	version: 4,
+	publicationLevel: "positive-only",
+	completeness: "partial",
+	itemCount: 1,
+	canonicalizationVersion: 1,
+	sections: [...v3Sections, showSection],
+	observedRoots: [{ sectionKey: "shows", domain: "episode-parents", digest: "a".repeat(64) }],
+	capabilities: [
+		{
+			domain: "episode-parents",
+			field: "membership",
+			semantics: "observed-targets-only",
+			operators: [],
+		},
+	],
+	targetLedgerVersion: 1,
+	targetCount: 1,
+	targetDigest: "b".repeat(64),
+	partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+} as const;
 const v3Metadata = JSON.stringify({
 	version: 3,
 	publicationLevel: "authoritative",
@@ -51,6 +81,12 @@ function status(overrides: Record<string, unknown> = {}) {
 }
 
 describe("Plex generation metadata", () => {
+	it("rejects a partial V4 envelope that does not explain why it is partial", () => {
+		expect(
+			decodePlexGenerationMetadata(JSON.stringify({ ...validV4Metadata, partialReasons: [] })),
+		).toEqual({ ok: false, reasonCode: "metadata_invalid" });
+	});
+
 	it("normalizes legacy sections-only metadata as authoritative", () => {
 		expect(decodePlexGenerationMetadata(JSON.stringify({ sections }))).toEqual({
 			ok: true,
@@ -101,7 +137,7 @@ describe("Plex generation metadata", () => {
 	});
 
 	it.each([
-		["unknown version", JSON.stringify({ version: 4, sections }), "unknown_metadata_version"],
+		["bare V4", JSON.stringify({ version: 4, sections }), "metadata_invalid"],
 		["null", null, "missing_metadata"],
 		["missing", undefined, "missing_metadata"],
 		["invalid JSON", "{", "malformed_metadata"],
@@ -319,14 +355,8 @@ describe("Plex generation metadata", () => {
 		});
 	});
 
-	it("recognizes a future positive-only publication without granting mutation authority", () => {
-		const partialMetadata = JSON.stringify({
-			version: 2,
-			publicationLevel: "positive-only",
-			completeness: "partial",
-			itemCount: 1,
-			sections,
-		});
+	it("recognizes a well-formed V4 positive-only publication without granting mutation authority", () => {
+		const partialMetadata = JSON.stringify(validV4Metadata);
 		const partialStatus = status({
 			generationMetadata: partialMetadata,
 			lastAttemptResult: "partial",
@@ -338,6 +368,7 @@ describe("Plex generation metadata", () => {
 
 		expect(evaluatePublishedPlexGeneration(partialStatus, options)).toMatchObject({
 			available: true,
+			metadata: { version: 4, publicationLevel: "positive-only" },
 			evidence: {
 				availability: "current",
 				authority: "positive-only",
@@ -349,6 +380,41 @@ describe("Plex generation metadata", () => {
 			},
 		});
 		expect(evaluatePlexMutationAuthority(partialStatus, options).available).toBe(false);
+	});
+
+	it.each([
+		["an unknown envelope field", { ...validV4Metadata, labelsComplete: true }],
+		[
+			"an unknown capability field",
+			{
+				...validV4Metadata,
+				capabilities: [{ ...validV4Metadata.capabilities[0], grantsAbsence: true }],
+			},
+		],
+		[
+			"an unknown reason field",
+			{
+				...validV4Metadata,
+				partialReasons: [
+					{ ...validV4Metadata.partialReasons[0], detail: "sensitive upstream material" },
+				],
+			},
+		],
+		[
+			"an episode-parent root on a Movie section",
+			{
+				...validV4Metadata,
+				observedRoots: [
+					{ sectionKey: "movies", domain: "episode-parents", digest: "a".repeat(64) },
+				],
+			},
+		],
+		["a missing Show section root", { ...validV4Metadata, observedRoots: [] }],
+	])("rejects V4 with %s", (_description, metadata) => {
+		expect(decodePlexGenerationMetadata(JSON.stringify(metadata))).toEqual({
+			ok: false,
+			reasonCode: "metadata_invalid",
+		});
 	});
 
 	it("bases freshness on the published generation timestamp", () => {

--- a/apps/api/src/lib/plex/__tests__/plex-positive-episode-generation-metadata.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-positive-episode-generation-metadata.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+	decodePlexPositiveEpisodeGenerationMetadata,
+	encodePlexPositiveEpisodeGenerationMetadata,
+} from "../plex-positive-episode-generation-metadata.js";
+
+const valid = {
+	version: 3,
+	publicationLevel: "positive-only",
+	completeness: "partial",
+	itemCount: 1,
+	canonicalizationVersion: 1,
+	capability: {
+		domain: "episodes",
+		field: "watchCount",
+		semantics: "lower-bound",
+		operator: "greater_than",
+	},
+	parentPlexGenerationId: "parent-generation-1",
+	parentMetadataVersion: 4,
+	parentPublicationLevel: "positive-only",
+	parentTargetDigest: "a".repeat(64),
+	episodeDigest: "b".repeat(64),
+	partialReasons: [
+		{ code: "ambiguous_episode_parent_targets", count: 2 },
+		{ code: "currentItemsWithoutTmdbMetadata", count: 1 },
+	],
+	connectionGeneration: 7,
+	identityGeneration: 11,
+} as const;
+
+describe("positive Plex episode generation metadata", () => {
+	it("accepts only the named lower-bound positive envelope", () => {
+		const encoded = encodePlexPositiveEpisodeGenerationMetadata(valid);
+
+		expect(decodePlexPositiveEpisodeGenerationMetadata(encoded)).toEqual({
+			ok: true,
+			metadata: valid,
+		});
+	});
+
+	it.each([
+		["an authoritative publication level", { ...valid, publicationLevel: "authoritative" }],
+		["a broader operator", { ...valid, capability: { ...valid.capability, operator: "equals" } }],
+		["an unexplained partial publication", { ...valid, partialReasons: [] }],
+		["an unsorted reason list", { ...valid, partialReasons: [...valid.partialReasons].reverse() }],
+		["a missing exact parent target digest", { ...valid, parentTargetDigest: "not-a-digest" }],
+	])("rejects %s", (_description, metadata) => {
+		expect(decodePlexPositiveEpisodeGenerationMetadata(JSON.stringify(metadata))).toEqual({
+			ok: false,
+		});
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-positive-episode-live-collector.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-positive-episode-live-collector.test.ts
@@ -1,0 +1,100 @@
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import type { PlexClient } from "../plex-client.js";
+import { collectPositivePlexEpisodeLiveEvidence } from "../plex-episode-live-collector.js";
+
+const log = { warn: vi.fn() } as unknown as FastifyBaseLogger;
+
+function parent(showTmdbId: number, ratingKey: string) {
+	return {
+		instanceId: "plex-1",
+		generationId: "parent-generation-1",
+		showTmdbId,
+		sectionId: "shows",
+		sectionUuid: "shows-uuid",
+		mediaType: "series" as const,
+		tvdbId: showTmdbId + 1000,
+		ratingKey,
+	};
+}
+
+function client(getEpisodes: PlexClient["getEpisodes"]): PlexClient {
+	return { getEpisodes } as unknown as PlexClient;
+}
+
+describe("collectPositivePlexEpisodeLiveEvidence", () => {
+	it("collects a sole live parent without history or episode TMDB metadata and omits zero", async () => {
+		const getEpisodes = vi.fn().mockResolvedValue([
+			{
+				ratingKey: "episode-positive",
+				title: "Pilot",
+				seasonNumber: 1,
+				episodeNumber: 1,
+				viewCount: 2,
+			},
+			{
+				ratingKey: "episode-zero",
+				title: "Second",
+				seasonNumber: 1,
+				episodeNumber: 2,
+				viewCount: 0,
+			},
+		]);
+
+		const result = await collectPositivePlexEpisodeLiveEvidence(
+			client(getEpisodes),
+			[parent(42, "show-1")],
+			log,
+			"connection-fingerprint",
+		);
+
+		expect(getEpisodes).toHaveBeenCalledWith("show-1");
+		expect(result).toMatchObject({
+			kind: "positive-observation",
+			eligibleShows: 1,
+			refreshedShows: 1,
+			errors: 0,
+			rows: [
+				{
+					instanceId: "plex-1",
+					showTmdbId: 42,
+					ratingKey: "episode-positive",
+					seasonNumber: 1,
+					episodeNumber: 1,
+					watchCount: 2,
+					sourceFingerprint: "connection-fingerprint",
+				},
+			],
+		});
+		expect(result.rows?.map((row) => row.ratingKey)).not.toContain("episode-zero");
+	});
+
+	it("excludes every duplicate parent group without summing and still collects a separate sole show", async () => {
+		const getEpisodes = vi.fn().mockResolvedValue([
+			{
+				ratingKey: "unique-episode",
+				title: "Pilot",
+				seasonNumber: 1,
+				episodeNumber: 1,
+				viewCount: 1,
+			},
+		]);
+
+		const result = await collectPositivePlexEpisodeLiveEvidence(
+			client(getEpisodes),
+			[parent(42, "show-copy-a"), parent(42, "show-copy-b"), parent(43, "show-unique")],
+			log,
+			"connection-fingerprint",
+		);
+
+		expect(getEpisodes).toHaveBeenCalledTimes(1);
+		expect(getEpisodes).toHaveBeenCalledWith("show-unique");
+		expect(result).toMatchObject({
+			kind: "positive-observation",
+			eligibleShows: 1,
+			refreshedShows: 1,
+			partialReasons: [{ code: "ambiguous_episode_parent_targets", count: 2 }],
+			rows: [expect.objectContaining({ showTmdbId: 43, watchCount: 1 })],
+		});
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-publication-authority.test.ts
@@ -5,6 +5,7 @@ import type { OwnedProviderPublicationSnapshot } from "../../services/provider-i
 import { refreshPlexCache } from "../plex-cache-refresher.js";
 import type { PlexClient } from "../plex-client.js";
 import { refreshPlexEpisodeCache } from "../plex-episode-cache-refresher.js";
+import { decodePlexGenerationMetadata } from "../plex-generation-metadata.js";
 
 const authority = vi.hoisted(() => ({
 	client: undefined as PlexClient | undefined,
@@ -146,6 +147,64 @@ function dataClient(itemCount = 1): PlexClient {
 	} as unknown as PlexClient;
 }
 
+function positiveDataClient(): PlexClient {
+	const settlementSections = [
+		{
+			key: "movies",
+			uuid: "movies-uuid",
+			title: "Movies",
+			type: "movie",
+			refreshing: false,
+			scannedAt: 1_777_000_000,
+			updatedAt: 1_777_000_100,
+		},
+		{
+			key: "shows",
+			uuid: "shows-uuid",
+			title: "Shows",
+			type: "show",
+			refreshing: false,
+			scannedAt: 1_777_000_000,
+			updatedAt: 1_777_000_100,
+		},
+	];
+	return {
+		getActivities: vi.fn().mockResolvedValue([]),
+		getLibrarySettlementSections: vi.fn().mockResolvedValue(settlementSections),
+		getAccounts: vi.fn(async () => {
+			authority.events.push("collect");
+			return [{ id: 1, name: "Alice" }];
+		}),
+		getLibrarySections: vi.fn().mockResolvedValue([
+			{ key: "movies", title: "Movies", type: "movie" },
+			{ key: "shows", title: "Shows", type: "show" },
+		]),
+		getLibraryItems: vi.fn(async (sectionId: string) =>
+			sectionId === "movies"
+				? [
+						{
+							ratingKey: "movie-1",
+							title: "Mapped Movie",
+							type: "movie",
+							Guid: [{ id: "tmdb://1" }],
+						},
+						{ ratingKey: "legacy-1", title: "Legacy Movie", type: "movie", Guid: [] },
+					]
+				: [
+						{
+							ratingKey: "show-1",
+							title: "Mapped Show",
+							type: "show",
+							Guid: [{ id: "tmdb://42" }, { id: "tvdb://42" }],
+						},
+					],
+		),
+		getHistory: vi.fn().mockResolvedValue([]),
+		verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+		getOnDeck: vi.fn().mockResolvedValue([]),
+	} as unknown as PlexClient;
+}
+
 function prisma(finalPredicateMatches = true, publicationClaimMatches = true) {
 	const rows: unknown[] = [];
 	const targetRows: unknown[] = [];
@@ -211,7 +270,12 @@ function prisma(finalPredicateMatches = true, publicationClaimMatches = true) {
 			}),
 			updateMany: vi.fn(async ({ data }: { data: Record<string, unknown> }) => {
 				authority.events.push(data.lastAttemptResult === "success" ? "status" : "failure");
-				if (data.lastAttemptResult === "success" && claimMatches) Object.assign(status, data);
+				if (
+					(data.lastAttemptResult === "success" || data.lastAttemptResult === "partial") &&
+					claimMatches
+				) {
+					Object.assign(status, data);
+				}
 				return { count: claimMatches ? 1 : 0 };
 			}),
 		},
@@ -339,6 +403,73 @@ describe("Plex publication authority", () => {
 		expect(metadata).toHaveProperty("roots");
 		expect(metadata).not.toHaveProperty("targets");
 		expect(metadata).not.toHaveProperty("ratingKeys");
+	});
+
+	it("atomically replaces V3 cache and ledger state with settled V4 positive-only evidence", async () => {
+		const fixture = prisma();
+		await expect(
+			refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log }),
+		).resolves.toMatchObject({ kind: "authoritative-snapshot", complete: true, upserted: 1 });
+		const previousGeneration = fixture.status.generationId;
+		authority.client = positiveDataClient();
+
+		const result = await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+
+		expect(result).toMatchObject({
+			kind: "positive-observation",
+			complete: false,
+			upserted: 1,
+			completedAt: expect.any(Date),
+		});
+		expect(fixture.status).toMatchObject({
+			lastResult: "success",
+			lastErrorMessage: null,
+			lastAttemptResult: "partial",
+			lastAttemptErrorMessage: null,
+			itemCount: 1,
+		});
+		expect(fixture.status.generationId).not.toBe(previousGeneration);
+		expect(fixture.rows).toEqual([
+			expect.objectContaining({ mediaType: "series", ratingKey: "show-1" }),
+		]);
+		expect(fixture.targetRows).toEqual([
+			expect.objectContaining({
+				generationId: fixture.status.generationId,
+				mediaType: "series",
+				ratingKey: "show-1",
+			}),
+		]);
+		const decoded = decodePlexGenerationMetadata(fixture.status.generationMetadata as string);
+		expect(decoded).toMatchObject({
+			ok: true,
+			metadata: {
+				version: 4,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: 1,
+				targetCount: 1,
+			},
+		});
+	});
+
+	it("rolls back V4 rows, ledger, metadata, and status when positive target replacement fails", async () => {
+		const fixture = prisma();
+		await refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log });
+		const previous = structuredClone({
+			rows: fixture.rows,
+			targetRows: fixture.targetRows,
+			status: fixture.status,
+		});
+		fixture.setTargetWriteError(new Error("target write failed"));
+		authority.client = positiveDataClient();
+
+		await expect(
+			refreshPlexCache({ prisma: fixture.db, instance: ownedSnapshot(), log }),
+		).resolves.toMatchObject({ kind: "unpublished", complete: false });
+
+		expect(fixture.rows).toEqual(previous.rows);
+		expect(fixture.targetRows).toEqual(previous.targetRows);
+		expect(fixture.status).toMatchObject(previous.status);
 	});
 
 	it("does not publish while a supported section scan is active", async () => {

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -1,4 +1,10 @@
-import type { PlexCanonicalDomain, PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
+import type {
+	PlexCanonicalDomain,
+	PlexCoverageReasonCode,
+	PlexEvidenceSummary,
+	PlexPartialReason,
+	PlexPositiveGenerationMetadataV4,
+} from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { Encryptor } from "../auth/encryption.js";
 import { evidenceFingerprint } from "../evidence-fingerprint.js";
@@ -9,50 +15,66 @@ import {
 	isPersonalMediaSection,
 } from "./plex-cache-refresher.js";
 import type { PlexCacheRowSelection } from "./plex-cache-storage.js";
-import { createPlexClient, type PlexClient } from "./plex-client.js";
-import { collectPlexEpisodeLiveEvidence } from "./plex-episode-live-collector.js";
 import {
 	createPlexSelectionProjection,
 	type PlexCanonicalObservation,
 	type PlexCanonicalSelection,
 } from "./plex-canonical-projection.js";
+import { createPlexClient, type PlexClient } from "./plex-client.js";
+import {
+	collectPlexEpisodeLiveEvidence,
+	createPositivePlexEpisodeDigest,
+	type PlexEpisodeRow,
+	type PlexPositiveEpisodeParentTarget,
+} from "./plex-episode-live-collector.js";
+import {
+	type AvailablePlexInstanceEvidence,
+	type AvailableSelectedPlexEvidence,
+	isCurrentAuthoritativePlexEvidence,
+	loadInstanceEpisodeEvidence,
+	loadInstanceEvidence,
+	loadInstanceSelectedEpisodeEvidence,
+	loadInstanceSelectedEvidence,
+	loadPositiveEpisodeEvidence,
+	loadPositiveEpisodeParentEvidence,
+	type PlexEpisodeParentPolicyBatchHandler,
+	type PlexInstanceEvidence,
+	type PlexPolicyBatchHandler,
+	type PlexPolicyScanEvidence,
+	type SelectedPlexEpisodeEvidence,
+	type SelectedPlexEvidence,
+	scanInstanceEpisodeParentPolicyEvidence,
+	scanInstancePolicyEvidence,
+	type UnavailablePlexInstanceEvidence,
+} from "./plex-evidence-repository.js";
 import type { DecodedPlexGenerationMetadata } from "./plex-generation-metadata.js";
 import {
 	normalizePlexGenerationTargets,
+	type PlexGenerationTarget,
 	readPlexGenerationTargetsForSelection,
 	requirePlexTargetLedgerBinding,
 	samePlexGenerationBinding,
 	samePlexGenerationTargetSet,
 	selectSinglePlexGenerationTarget,
 	verifyPersistedPlexGenerationTargets,
-	type PlexGenerationTarget,
 } from "./plex-generation-target-ledger.js";
 import {
 	evaluatePlexLiveSettlement,
 	type PlexLiveActivity,
 	type PlexLiveSection,
 } from "./plex-live-settlement.js";
-import {
-	isCurrentAuthoritativePlexEvidence,
-	loadInstanceEpisodeEvidence,
-	loadInstanceEvidence,
-	loadInstanceSelectedEpisodeEvidence,
-	loadInstanceSelectedEvidence,
-	scanInstanceEpisodeParentPolicyEvidence,
-	scanInstancePolicyEvidence,
-	type AvailablePlexInstanceEvidence,
-	type AvailableSelectedPlexEvidence,
-	type PlexInstanceEvidence,
-	type PlexPolicyBatchHandler,
-	type PlexEpisodeParentPolicyBatchHandler,
-	type PlexPolicyScanEvidence,
-	type SelectedPlexEvidence,
-	type SelectedPlexEpisodeEvidence,
-	type UnavailablePlexInstanceEvidence,
-} from "./plex-evidence-repository.js";
 import { plexConnectionFingerprint } from "./service-instance-fingerprint.js";
 
+export type {
+	AvailablePlexInstanceEvidence,
+	AvailablePlexPolicyEvidence,
+	PlexInstanceEvidence,
+	PlexPolicyScanEvidence,
+	SelectedPlexEpisodeEvidence,
+	SelectedPlexEvidence,
+} from "./plex-evidence-repository.js";
 export {
+	DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
 	hasAuthoritativePlexEvidence,
 	hasAuthoritativeSelectedPlexEvidence,
 	hasCompleteAuthoritativePlexEvidence,
@@ -60,15 +82,6 @@ export {
 	listPublishedSections,
 	summarizePlexEvidence,
 } from "./plex-evidence-repository.js";
-export type {
-	AvailablePlexInstanceEvidence,
-	AvailablePlexPolicyEvidence,
-	PlexInstanceEvidence,
-	PlexPolicyScanEvidence,
-	SelectedPlexEvidence,
-	SelectedPlexEpisodeEvidence,
-} from "./plex-evidence-repository.js";
-export { DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS } from "./plex-evidence-repository.js";
 
 export type PlexPersistedSelectionObservation = {
 	generationId: string;
@@ -94,6 +107,66 @@ export class PlexAuthorityUnavailableError extends Error {
 export type PlexAuthorityWindowResult =
 	| { ok: true; persisted: PlexPersistedSelectionObservation }
 	| { ok: false; reasonCode: PlexCoverageReasonCode };
+
+export type PositiveEpisodeParentAuthority =
+	| {
+			available: true;
+			instanceId: string;
+			generationId: string;
+			connectionGeneration: number;
+			identityGeneration: number;
+			capability: PlexPositiveGenerationMetadataV4["capabilities"][number];
+			partialReasons: readonly PlexPartialReason[];
+			provenance: {
+				publicationLevel: "authoritative" | "positive-only";
+				completeness: "complete" | "partial";
+				parentTargetDigest: string;
+				parentTargetCount: number;
+			};
+			rows: Array<{ instanceId: string; tmdbId: number; sectionId: string; ratingKey: string }>;
+			targets: PlexGenerationTarget[];
+			evidence: PlexEvidenceSummary;
+	  }
+	| UnavailablePlexInstanceEvidence;
+
+export type PositiveEpisodeAuthority =
+	| {
+			available: true;
+			instanceId: string;
+			generationId: string;
+			connectionGeneration: number;
+			identityGeneration: number;
+			capability: {
+				domain: "episodes";
+				field: "watchCount";
+				semantics: "lower-bound";
+				operator: "greater_than";
+			};
+			partialReasons: ReadonlyArray<{ code: string; count: number }>;
+			provenance: {
+				publicationLevel: "positive-only";
+				completeness: "partial";
+				connectionGeneration: number;
+				identityGeneration: number;
+				parentPlexGenerationId: string;
+				parentTargetDigest: string;
+				parentTargetCount: number;
+				episodeGenerationId: string;
+				episodeDigest: string;
+				publishedAt: string;
+			};
+			rows: Array<{
+				showTmdbId: number;
+				seasonNumber: number;
+				episodeNumber: number;
+				ratingKey: string;
+				lowerBound: number;
+				sourceFingerprint: string;
+				soleParentTarget: PlexPositiveEpisodeParentTarget;
+			}>;
+			evidence: PlexEvidenceSummary;
+	  }
+	| UnavailablePlexInstanceEvidence;
 
 function sectionCatalogIdentity(
 	sections: ReadonlyArray<{ key: string; uuid: string; type: string; title: string }>,
@@ -599,6 +672,269 @@ export class PlexAuthorityService {
 			mutation: input.mutation === true,
 			reread: async () => await loadInstanceEvidence(this.deps.prisma, input),
 		})) as PlexInstanceEvidence;
+	}
+
+	/**
+	 * The sole persisted positive-episode reader. Its rows are explicit lower
+	 * bounds, never an exact episode universe: omitted episodes are unknown.
+	 */
+	async readPositiveEpisodeEvidence(input: {
+		userId: string;
+		instanceId: string;
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<PositiveEpisodeAuthority> {
+		const observed = await loadPositiveEpisodeEvidence(this.deps.prisma, input);
+		if (!observed.available) return observed;
+		const binding = requirePlexTargetLedgerBinding(observed.parentMetadata);
+		if (!binding.ok) {
+			return unavailableEvidence(
+				input.instanceId,
+				observed.evidence,
+				"target_ledger_binding_missing",
+			);
+		}
+		if (binding.binding.targetDigest !== observed.metadata.parentTargetDigest) {
+			return unavailableEvidence(input.instanceId, observed.evidence, "target_digest_mismatch");
+		}
+		const ledgerTargets = await readPlexGenerationTargetsForSelection(this.deps.prisma, {
+			instanceId: observed.instanceId,
+			generationId: observed.parentGenerationId,
+		});
+		const targetLedger = await verifyPersistedPlexGenerationTargets(this.deps.prisma, {
+			expected: {
+				instanceId: observed.instanceId,
+				generationId: observed.parentGenerationId,
+				connectionGeneration: observed.connectionGeneration,
+				identityGeneration: observed.identityGeneration,
+				...binding.binding,
+			},
+			sections: observed.parentMetadata.sections,
+		});
+		if (!targetLedger.ok) {
+			return unavailableEvidence(
+				input.instanceId,
+				observed.evidence,
+				targetLedger.reason as PlexCoverageReasonCode,
+			);
+		}
+		const soleParentGroups = new Map<number, PlexGenerationTarget[]>();
+		for (const target of ledgerTargets) {
+			if (target.mediaType !== "series") continue;
+			const group = soleParentGroups.get(target.tmdbId) ?? [];
+			group.push(target);
+			soleParentGroups.set(target.tmdbId, group);
+		}
+		const soleParentTargets = [...soleParentGroups.values()]
+			.filter((group) => group.length === 1)
+			.map((group) => {
+				const target = group[0]!;
+				return {
+					instanceId: target.instanceId,
+					generationId: target.generationId,
+					showTmdbId: target.tmdbId,
+					sectionId: target.sectionId,
+					sectionUuid: target.sectionUuid,
+					mediaType: "series" as const,
+					tvdbId: target.tvdbId,
+					ratingKey: target.ratingKey,
+				};
+			});
+		const rows: PlexEpisodeRow[] = [];
+		for (const row of observed.rows) {
+			if (
+				typeof row.sourceFingerprint !== "string" ||
+				row.sourceFingerprint.trim() === "" ||
+				!(row.refreshedAt instanceof Date) ||
+				!Number.isFinite(row.refreshedAt.getTime()) ||
+				typeof row.watchCount !== "number" ||
+				!Number.isSafeInteger(row.watchCount) ||
+				row.watchCount <= 0
+			) {
+				return unavailableEvidence(
+					input.instanceId,
+					observed.evidence,
+					"plex_content_digest_changed",
+				);
+			}
+			rows.push({
+				instanceId: row.instanceId,
+				showTmdbId: row.showTmdbId,
+				seasonNumber: row.seasonNumber,
+				episodeNumber: row.episodeNumber,
+				ratingKey: row.ratingKey,
+				title: row.title,
+				watched: row.watched,
+				watchedByUsers: row.watchedByUsers,
+				lastWatchedAt: row.lastWatchedAt,
+				watchCount: row.watchCount,
+				refreshedAt: row.refreshedAt,
+				sourceFingerprint: row.sourceFingerprint,
+			});
+		}
+		if (
+			createPositivePlexEpisodeDigest(soleParentTargets, rows) !== observed.metadata.episodeDigest
+		) {
+			return unavailableEvidence(
+				input.instanceId,
+				observed.evidence,
+				"plex_content_digest_changed",
+			);
+		}
+		const soleParentByShow = new Map(
+			soleParentTargets.map((target) => [target.showTmdbId, target]),
+		);
+		return {
+			available: true,
+			instanceId: observed.instanceId,
+			generationId: observed.generationId,
+			connectionGeneration: observed.connectionGeneration,
+			identityGeneration: observed.identityGeneration,
+			capability: observed.metadata.capability,
+			partialReasons: observed.metadata.partialReasons,
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				connectionGeneration: observed.connectionGeneration,
+				identityGeneration: observed.identityGeneration,
+				parentPlexGenerationId: observed.parentGenerationId,
+				parentTargetDigest: observed.metadata.parentTargetDigest,
+				parentTargetCount: binding.binding.targetCount,
+				episodeGenerationId: observed.generationId,
+				episodeDigest: observed.metadata.episodeDigest,
+				publishedAt: observed.publishedAt.toISOString(),
+			},
+			rows: rows.flatMap((row) => {
+				const soleParentTarget = soleParentByShow.get(row.showTmdbId);
+				return soleParentTarget
+					? [
+							{
+								showTmdbId: row.showTmdbId,
+								seasonNumber: row.seasonNumber,
+								episodeNumber: row.episodeNumber,
+								ratingKey: row.ratingKey,
+								lowerBound: row.watchCount,
+								sourceFingerprint: row.sourceFingerprint,
+								soleParentTarget,
+							},
+						]
+					: [];
+			}),
+			evidence: observed.evidence,
+		};
+	}
+
+	/**
+	 * The sole V4 parent-reader. It intentionally returns only observed Show
+	 * parents and ledger targets. A requested Show absent from those arrays is
+	 * unknown; this method never produces a negative, zero, or exact-universe
+	 * assertion.
+	 */
+	async readPositiveEpisodeParents(input: {
+		userId: string;
+		instanceId: string;
+		showTmdbIds?: readonly number[];
+		now?: Date;
+		maxAgeMs?: number;
+	}): Promise<PositiveEpisodeParentAuthority> {
+		const observed = await loadPositiveEpisodeParentEvidence(this.deps.prisma, input);
+		if (!observed.available) return observed;
+		const binding = requirePlexTargetLedgerBinding(observed.metadata);
+		if (!binding.ok) {
+			return unavailableEvidence(
+				input.instanceId,
+				observed.evidence,
+				"target_ledger_binding_missing",
+			);
+		}
+		const ledgerTargets = await readPlexGenerationTargetsForSelection(this.deps.prisma, {
+			instanceId: observed.instanceId,
+			generationId: observed.generationId,
+		});
+		const targetLedger = await verifyPersistedPlexGenerationTargets(this.deps.prisma, {
+			expected: {
+				instanceId: observed.instanceId,
+				generationId: observed.generationId,
+				connectionGeneration: observed.connectionGeneration,
+				identityGeneration: observed.identityGeneration,
+				...binding.binding,
+			},
+			sections: observed.metadata.sections,
+		});
+		if (!targetLedger.ok) {
+			return unavailableEvidence(
+				input.instanceId,
+				observed.evidence,
+				targetLedger.reason as PlexCoverageReasonCode,
+			);
+		}
+		const selectedIds = input.showTmdbIds
+			? [...new Set(input.showTmdbIds)].filter(
+					(tmdbId) => Number.isSafeInteger(tmdbId) && tmdbId > 0,
+				)
+			: undefined;
+		if (input.showTmdbIds && selectedIds?.length !== input.showTmdbIds.length) {
+			return unavailableEvidence(input.instanceId, observed.evidence, "target_ledger_invalid");
+		}
+		const targets = ledgerTargets.filter(
+			(target) =>
+				target.mediaType === "series" &&
+				(selectedIds === undefined || selectedIds.includes(target.tmdbId)),
+		);
+		const targetsByRatingKey = new Map(targets.map((target) => [target.ratingKey, target]));
+		const observedTargets: PlexGenerationTarget[] = [];
+		let unmatchedObservedRow = false;
+		const rows = observed.rows.flatMap((row) => {
+			if (!row.ratingKey) {
+				unmatchedObservedRow = true;
+				return [];
+			}
+			const target = targetsByRatingKey.get(row.ratingKey);
+			if (
+				target &&
+				target.mediaType === "series" &&
+				target.tmdbId === row.tmdbId &&
+				target.sectionId === row.sectionId
+			) {
+				observedTargets.push(target);
+				return [
+					{
+						instanceId: row.instanceId,
+						tmdbId: row.tmdbId,
+						sectionId: row.sectionId,
+						ratingKey: row.ratingKey,
+					},
+				];
+			}
+			unmatchedObservedRow = true;
+			return [];
+		});
+		if (unmatchedObservedRow) {
+			return unavailableEvidence(input.instanceId, observed.evidence, "target_ledger_invalid");
+		}
+		return {
+			available: true,
+			instanceId: observed.instanceId,
+			generationId: observed.generationId,
+			connectionGeneration: observed.connectionGeneration,
+			identityGeneration: observed.identityGeneration,
+			capability: {
+				domain: "episode-parents",
+				field: "membership",
+				semantics: "observed-targets-only",
+				operators: [],
+			},
+			partialReasons: observed.metadata.version === 4 ? observed.metadata.partialReasons : [],
+			provenance: {
+				publicationLevel: observed.metadata.publicationLevel,
+				completeness: observed.metadata.completeness,
+				parentTargetDigest: binding.binding.targetDigest,
+				parentTargetCount: binding.binding.targetCount,
+			},
+			rows,
+			targets: observedTargets,
+			evidence: observed.evidence,
+		};
 	}
 
 	async scanInstancePolicy(input: {

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -882,7 +882,14 @@ export class PlexAuthorityService {
 				(selectedIds === undefined || selectedIds.includes(target.tmdbId)),
 		);
 		const targetsByRatingKey = new Map(targets.map((target) => [target.ratingKey, target]));
-		const observedTargets: PlexGenerationTarget[] = [];
+		const targetsByCoordinate = new Map<string, PlexGenerationTarget[]>();
+		for (const target of targets) {
+			const key = JSON.stringify([target.tmdbId, target.sectionId]);
+			const group = targetsByCoordinate.get(key) ?? [];
+			group.push(target);
+			targetsByCoordinate.set(key, group);
+		}
+		const observedTargets = new Map<string, PlexGenerationTarget>();
 		let unmatchedObservedRow = false;
 		const rows = observed.rows.flatMap((row) => {
 			if (!row.ratingKey) {
@@ -896,7 +903,11 @@ export class PlexAuthorityService {
 				target.tmdbId === row.tmdbId &&
 				target.sectionId === row.sectionId
 			) {
-				observedTargets.push(target);
+				for (const observedTarget of targetsByCoordinate.get(
+					JSON.stringify([row.tmdbId, row.sectionId]),
+				) ?? []) {
+					observedTargets.set(observedTarget.ratingKey, observedTarget);
+				}
 				return [
 					{
 						instanceId: row.instanceId,
@@ -932,7 +943,7 @@ export class PlexAuthorityService {
 				parentTargetCount: binding.binding.targetCount,
 			},
 			rows,
-			targets: observedTargets,
+			targets: [...observedTargets.values()],
 			evidence: observed.evidence,
 		};
 	}

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -19,6 +19,8 @@ import type {
 	PlexCanonicalDomain,
 	PlexGenerationDomainRoot,
 	PlexGenerationSectionV3,
+	PlexPartialReason,
+	PlexPartialReasonCode,
 } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import type { Encryptor } from "../auth/encryption.js";
@@ -40,13 +42,17 @@ import {
 	PLEX_CACHE_WRITE_CHUNK_SIZE,
 	PlexRefreshAttemptSupersededError,
 	publishAuthoritativePlexCacheGeneration,
+	publishPositivePlexCacheGeneration,
 } from "./plex-cache-storage.js";
+import {
+	createPlexSelectionProjection,
+	PLEX_CANONICALIZATION_VERSION,
+} from "./plex-canonical-projection.js";
 import { PlexClient } from "./plex-client.js";
 import {
-	PLEX_CANONICALIZATION_VERSION,
-	createPlexSelectionProjection,
-} from "./plex-canonical-projection.js";
-import { encodeAuthoritativePlexGenerationMetadata } from "./plex-generation-metadata.js";
+	encodeAuthoritativePlexGenerationMetadata,
+	encodePositivePlexGenerationMetadata,
+} from "./plex-generation-metadata.js";
 import {
 	createPlexTargetLedgerBinding,
 	normalizePlexGenerationTargets,
@@ -165,6 +171,17 @@ export interface PlexCacheSnapshot {
 	sections: Array<{ key: string; title: string; type: "movie" | "show" }>;
 }
 
+export type PlexPositiveCapability = {
+	domain: "episode-parents";
+	field: "membership";
+	semantics: "observed-targets-only";
+	operators: readonly [];
+};
+
+export type PlexPublicationBlock = {
+	reasons: readonly string[];
+};
+
 export interface PlexInventoryTarget {
 	sectionId: string;
 	sectionUuid?: string;
@@ -172,6 +189,18 @@ export interface PlexInventoryTarget {
 	tmdbId: number;
 	tvdbId?: number;
 	ratingKey: string;
+}
+
+export interface PlexCachePositiveObservation {
+	rows: PlexCacheSnapshotRow[];
+	observedTargets: PlexInventoryTarget[];
+	capabilities: readonly [PlexPositiveCapability];
+	observedRoots: PlexGenerationDomainRoot[];
+	partialReasons: readonly PlexPartialReason[];
+	settlement?: {
+		sections: PlexGenerationSectionV3[];
+		roots: PlexGenerationDomainRoot[];
+	};
 }
 
 export interface PlexPublicationContext {
@@ -195,6 +224,83 @@ export interface PlexCacheRefreshResult {
 	settlement?: {
 		sections: PlexGenerationSectionV3[];
 		roots: PlexGenerationDomainRoot[];
+	};
+	kind?: "authoritative-snapshot" | "positive-observation" | "unpublished";
+	observation?: PlexCachePositiveObservation;
+	block?: PlexPublicationBlock;
+}
+
+export type PlexCacheCollectionResult =
+	| (PlexCacheRefreshResult & {
+			kind: "authoritative-snapshot";
+			complete: true;
+			snapshot: PlexCacheSnapshot;
+			inventoryTargets: PlexInventoryTarget[];
+	  })
+	| (PlexCacheRefreshResult & {
+			kind: "positive-observation";
+			complete: false;
+			observation: PlexCachePositiveObservation;
+			snapshot?: never;
+			inventoryTargets?: never;
+	  })
+	| (PlexCacheRefreshResult & {
+			kind: "unpublished";
+			complete: false;
+			block: PlexPublicationBlock;
+			snapshot?: never;
+			inventoryTargets?: never;
+			observation?: never;
+	  });
+
+const POSITIVE_OBSERVATION_REASON_CODES = new Set<PlexPartialReasonCode>([
+	"currentItemsWithoutTmdbMetadata",
+	"currentLibraryItemsWithoutRatingKeys",
+	"historyItemsWithoutUsableMediaKey",
+	"currentHistoryItemsWithoutMappedMetadata",
+	"historyItemsWithUnknownAccounts",
+	"onDeckItemsWithoutMappedMetadata",
+	"onDeckFetchFailures",
+]);
+
+export function canPublishPositivePlexObservation(
+	incompleteReasons: Readonly<Record<string, number>>,
+): boolean {
+	const entries = Object.entries(incompleteReasons);
+	return (
+		entries.length > 0 &&
+		entries.length <= POSITIVE_OBSERVATION_REASON_CODES.size &&
+		entries.every(
+			([reason, count]) =>
+				POSITIVE_OBSERVATION_REASON_CODES.has(reason as PlexPartialReasonCode) &&
+				Number.isSafeInteger(count) &&
+				count > 0,
+		)
+	);
+}
+
+function sortedPartialReasons(
+	incompleteReasons: Readonly<Record<string, number>>,
+): PlexPartialReason[] {
+	return Object.entries(incompleteReasons)
+		.map(([code, count]) => ({ code: code as PlexPartialReasonCode, count }))
+		.sort((left, right) => left.code.localeCompare(right.code));
+}
+
+function unpublishedCollection(input: {
+	errors: number;
+	errorMessages: string[];
+	reasons: readonly string[];
+	superseded?: boolean;
+}): PlexCacheCollectionResult {
+	return {
+		kind: "unpublished",
+		upserted: 0,
+		errors: input.errors,
+		errorMessages: input.errorMessages,
+		complete: false,
+		...(input.superseded ? { superseded: true } : {}),
+		block: { reasons: [...input.reasons].sort((left, right) => left.localeCompare(right)) },
 	};
 }
 
@@ -305,24 +411,22 @@ function unpublishedResult(error: unknown): PlexCacheRefreshResult {
 		(error instanceof ProviderIdentityGuardError && error.code === "PUBLICATION_SUPERSEDED") ||
 		error instanceof PlexRefreshAttemptSupersededError
 	) {
-		return {
-			upserted: 0,
+		return unpublishedCollection({
 			errors: 0,
 			errorMessages: [],
-			complete: false,
+			reasons: ["superseded"],
 			superseded: true,
-		};
+		});
 	}
-	return {
-		upserted: 0,
+	return unpublishedCollection({
 		errors: 1,
 		errorMessages: [
 			error instanceof ProviderIdentityGuardError
 				? error.message
 				: `Atomic Plex cache publication failed: ${getErrorMessage(error)}`,
 		],
-		complete: false,
-	};
+		reasons: ["publication-error"],
+	});
 }
 
 /**
@@ -374,12 +478,12 @@ export async function refreshPlexCacheWithAttempt(
 				timeout: PLEX_CACHE_PUBLICATION_TRANSACTION_TIMEOUT_MS,
 			},
 		);
-		if (!result.complete || !result.completedAt) {
+		if (result.kind === "unpublished" || !result.completedAt) {
 			const finished = await finishPlexCacheRefreshAttemptFailure(
 				prisma,
 				"plex",
 				result.errorMessages.slice(0, 3).join("; ").slice(0, 500) ||
-					"Plex refresh did not produce a complete generation",
+					"Plex refresh did not publish a generation",
 				instance,
 				attempt,
 				log,
@@ -422,24 +526,24 @@ async function publishPlexCacheSnapshot(
 	tx: Prisma.TransactionClient,
 	instance: OwnedProviderPublicationSnapshot,
 	attempt: PlexCacheRefreshAttempt,
-	collected: PlexCacheRefreshResult,
-): Promise<PlexCacheRefreshResult> {
-	if (
-		!collected.complete ||
-		!collected.completedAt ||
-		!collected.snapshot ||
-		!collected.settlement
-	) {
+	collected: PlexCacheCollectionResult,
+): Promise<PlexCacheCollectionResult> {
+	if (collected.kind === "unpublished" || !collected.completedAt) {
 		return collected;
 	}
 
-	const rows = collected.snapshot.rows;
-	if (!collected.inventoryTargets) {
+	const positiveOnly = collected.kind === "positive-observation";
+	const rows = positiveOnly ? collected.observation.rows : collected.snapshot.rows;
+	const inventoryTargets = positiveOnly
+		? collected.observation.observedTargets
+		: collected.inventoryTargets;
+	const settlement = positiveOnly ? collected.observation.settlement : collected.settlement;
+	if (!inventoryTargets || !settlement) {
 		throw new Error("Plex settled collection lacked exact inventory targets");
 	}
 	const generationId = randomUUID();
 	const targets: PlexGenerationTarget[] = normalizePlexGenerationTargets(
-		collected.inventoryTargets.map((target) => {
+		inventoryTargets.map((target) => {
 			if (!target.sectionUuid) {
 				throw new Error("Plex settled inventory target lacked its section UUID");
 			}
@@ -463,31 +567,51 @@ async function publishPlexCacheSnapshot(
 		identityGeneration: instance.identityGeneration,
 		targets,
 	});
-	const generationMetadata = encodeAuthoritativePlexGenerationMetadata({
-		sections: collected.settlement.sections,
-		itemCount: rows.length,
-		canonicalizationVersion: PLEX_CANONICALIZATION_VERSION,
-		roots: collected.settlement.roots,
-		targetLedger,
-	});
-	await publishAuthoritativePlexCacheGeneration(tx, {
-		instance,
-		rows: rows.map((row) => ({
-			...row,
-			connectionGeneration: instance.connectionGeneration,
-			identityGeneration: instance.identityGeneration,
-		})),
-		completedAt: collected.completedAt,
-		generationId,
-		generationMetadata,
-		targets,
-		attempt,
-	});
+	const storedRows = rows.map((row) => ({
+		...row,
+		connectionGeneration: instance.connectionGeneration,
+		identityGeneration: instance.identityGeneration,
+	}));
+	if (positiveOnly) {
+		const generationMetadata = encodePositivePlexGenerationMetadata({
+			sections: settlement.sections,
+			itemCount: rows.length,
+			canonicalizationVersion: PLEX_CANONICALIZATION_VERSION,
+			observedRoots: collected.observation.observedRoots,
+			targetLedger,
+			partialReasons: collected.observation.partialReasons,
+		});
+		await publishPositivePlexCacheGeneration(tx, {
+			instance,
+			rows: storedRows,
+			completedAt: collected.completedAt,
+			generationId,
+			generationMetadata,
+			targets,
+			attempt,
+		});
+	} else {
+		const generationMetadata = encodeAuthoritativePlexGenerationMetadata({
+			sections: settlement.sections,
+			itemCount: rows.length,
+			canonicalizationVersion: PLEX_CANONICALIZATION_VERSION,
+			roots: settlement.roots,
+			targetLedger,
+		});
+		await publishAuthoritativePlexCacheGeneration(tx, {
+			instance,
+			rows: storedRows,
+			completedAt: collected.completedAt,
+			generationId,
+			generationMetadata,
+			targets,
+			attempt,
+		});
+	}
 	return {
 		...collected,
 		upserted: rows.length,
 		generationId,
-		inventoryTargets: collected.inventoryTargets,
 		targetLedger,
 	};
 }
@@ -558,6 +682,41 @@ function snapshotRoots(
 	return roots;
 }
 
+function positiveObservationRoots(
+	rows: readonly PlexCacheSnapshotRow[],
+	sections: readonly PlexGenerationSectionV3[],
+): PlexGenerationDomainRoot[] {
+	return sections.map((section) => {
+		const projection = createPlexSelectionProjection({
+			rows: rows.filter((row) => row.sectionId === section.key),
+			selection: { kind: "all" },
+			domains: ["episode-parents"],
+		});
+		const digest = projection.domains["episode-parents"];
+		if (!digest) throw new Error("Missing Plex canonical episode-parent root");
+		return { sectionKey: section.key, domain: "episode-parents", digest };
+	});
+}
+
+function positiveObservationSignature(observation: PlexCachePositiveObservation): string {
+	const projection = createPlexSelectionProjection({
+		rows: observation.rows,
+		selection: { kind: "all" },
+		domains: ["episode-parents"],
+	});
+	return JSON.stringify({
+		rows: projection.domains["episode-parents"],
+		targets: observation.observedTargets.map((target) => [
+			target.sectionId,
+			target.mediaType,
+			target.tmdbId,
+			target.tvdbId ?? null,
+			target.ratingKey,
+		]),
+		reasons: observation.partialReasons,
+	});
+}
+
 async function loadPublicationSettlementProbe(client: PlexClient) {
 	const [activities, sections] = await Promise.all([
 		client.getActivities({ uncached: true }),
@@ -593,11 +752,11 @@ export async function collectSettledPlexCacheLiveEvidence(
 	client: PlexClient,
 	instanceId: string,
 	log: FastifyBaseLogger,
-): Promise<PlexCacheRefreshResult> {
+): Promise<PlexCacheCollectionResult> {
 	try {
 		const startSections = await loadPublicationSettlementProbe(client);
 		const preliminary = await collectPlexCacheLiveEvidence(client, instanceId, log);
-		if (!preliminary.complete || !preliminary.snapshot) return preliminary;
+		if (preliminary.kind === "unpublished") return preliminary;
 
 		const endSections = await loadPublicationSettlementProbe(client);
 		if (settlementSectionIdentity(endSections) !== settlementSectionIdentity(startSections)) {
@@ -609,13 +768,48 @@ export async function collectSettledPlexCacheLiveEvidence(
 			throw new Error("Plex library section identity changed before final canonical pass");
 		}
 		const final = await collectPlexCacheLiveEvidence(client, instanceId, log);
-		if (!final.complete || !final.snapshot) return final;
+		if (final.kind === "unpublished") return final;
+		if (final.kind !== preliminary.kind) {
+			throw new Error("Plex collection kind changed during settlement");
+		}
 		if (
+			final.kind === "authoritative-snapshot" &&
+			preliminary.kind === "authoritative-snapshot" &&
 			snapshotProjection(final.snapshot).digest !== snapshotProjection(preliminary.snapshot).digest
 		) {
 			throw new Error("Plex canonical projection changed after the settlement end probe");
 		}
+		if (
+			final.kind === "positive-observation" &&
+			preliminary.kind === "positive-observation" &&
+			positiveObservationSignature(final.observation) !==
+				positiveObservationSignature(preliminary.observation)
+		) {
+			throw new Error("Plex observed targets changed after the settlement end probe");
+		}
+
 		const sectionUuids = new Map(finalSections.map((section) => [section.key, section.uuid]));
+		if (final.kind === "positive-observation") {
+			const positiveSections = finalSections.filter((section) => section.type === "show");
+			const roots = positiveObservationRoots(final.observation.rows, positiveSections);
+			const observedTargets = final.observation.observedTargets.map((target) => {
+				const sectionUuid = sectionUuids.get(target.sectionId);
+				if (!sectionUuid) {
+					throw new Error("Plex final observed target section was absent from settlement catalog");
+				}
+				return { ...target, sectionUuid };
+			});
+			return {
+				...final,
+				completedAt: new Date(),
+				observation: {
+					...final.observation,
+					observedTargets,
+					observedRoots: roots,
+					settlement: { sections: finalSections, roots },
+				},
+			};
+		}
 		const inventoryTargets = final.inventoryTargets?.map((target) => {
 			const sectionUuid = sectionUuids.get(target.sectionId);
 			if (!sectionUuid) {
@@ -634,12 +828,11 @@ export async function collectSettledPlexCacheLiveEvidence(
 			},
 		};
 	} catch (error) {
-		return {
-			upserted: 0,
+		return unpublishedCollection({
 			errors: 1,
 			errorMessages: [`Plex settlement publication failed: ${getErrorMessage(error)}`],
-			complete: false,
-		};
+			reasons: ["settlement-unavailable"],
+		});
 	}
 }
 
@@ -655,7 +848,7 @@ export async function collectPlexCacheLiveEvidence(
 	instanceId: string,
 	log: FastifyBaseLogger,
 	options: { preserveProviderDuplicates?: boolean } = {},
-): Promise<PlexCacheRefreshResult> {
+): Promise<PlexCacheCollectionResult> {
 	const upserted = 0;
 	let errors = 0;
 	let complete = true;
@@ -665,7 +858,6 @@ export async function collectPlexCacheLiveEvidence(
 	let totalLibraryItems = 0;
 	let mappedLibraryItems = 0;
 	let ignoredHistoricalItems = 0;
-	let verifiedInventoryTargets: PlexInventoryTarget[] | undefined;
 	const markIncomplete = (reason: string) => {
 		complete = false;
 		incompleteReasons[reason] = (incompleteReasons[reason] ?? 0) + 1;
@@ -952,6 +1144,36 @@ export async function collectPlexCacheLiveEvidence(
 		const aggregationsArray = [...aggregations.values()];
 		// Release Map hash table — aggregationsArray now owns all references (#239)
 		aggregations.clear();
+		const rows: PlexCacheSnapshotRow[] = aggregationsArray.map((agg) => ({
+			instanceId,
+			tmdbId: agg.tmdbId,
+			mediaType: agg.mediaType,
+			sectionId: agg.sectionId,
+			sectionTitle: agg.sectionTitle,
+			title: agg.title,
+			ratingKey: agg.ratingKey,
+			lastWatchedAt: agg.lastWatchedAt,
+			watchCount: agg.watchCount,
+			watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
+			onDeck: agg.onDeck,
+			userRating: agg.userRating,
+			collections: JSON.stringify([...agg.collections].sort()),
+			labels: JSON.stringify([...agg.labels].sort()),
+			addedAt: agg.addedAt,
+			thumb: agg.thumb,
+		}));
+		const snapshotSections = mediaLibs
+			.map((section) => ({
+				key: section.key,
+				title: section.title,
+				type: section.type as "movie" | "show",
+			}))
+			.sort(
+				(left, right) =>
+					left.key.localeCompare(right.key) ||
+					left.title.localeCompare(right.title) ||
+					left.type.localeCompare(right.type),
+			);
 
 		if (errors === 0 && complete) {
 			const latestSections = await client.getLibrarySections();
@@ -984,46 +1206,16 @@ export async function collectPlexCacheLiveEvidence(
 			if (JSON.stringify(latestOnDeckSignature) !== JSON.stringify(verifiedOnDeckSignature)) {
 				throw new Error("Plex on-deck state changed before cache publication");
 			}
-			verifiedInventoryTargets = inventoryTargets;
 			completedAt = new Date();
-			const sections = mediaLibs
-				.map((section) => ({
-					key: section.key,
-					title: section.title,
-					type: section.type as "movie" | "show",
-				}))
-				.sort(
-					(left, right) =>
-						left.key.localeCompare(right.key) ||
-						left.title.localeCompare(right.title) ||
-						left.type.localeCompare(right.type),
-				);
-			const rows: PlexCacheSnapshotRow[] = aggregationsArray.map((agg) => ({
-				instanceId,
-				tmdbId: agg.tmdbId,
-				mediaType: agg.mediaType,
-				sectionId: agg.sectionId,
-				sectionTitle: agg.sectionTitle,
-				title: agg.title,
-				ratingKey: agg.ratingKey,
-				lastWatchedAt: agg.lastWatchedAt,
-				watchCount: agg.watchCount,
-				watchedByUsers: JSON.stringify([...agg.watchedByUsers].sort()),
-				onDeck: agg.onDeck,
-				userRating: agg.userRating,
-				collections: JSON.stringify([...agg.collections].sort()),
-				labels: JSON.stringify([...agg.labels].sort()),
-				addedAt: agg.addedAt,
-				thumb: agg.thumb,
-			}));
 			return {
+				kind: "authoritative-snapshot",
 				upserted: 0,
 				errors: 0,
 				errorMessages: [],
 				complete: true,
 				completedAt,
 				inventoryTargets,
-				snapshot: { rows, sections },
+				snapshot: { rows, sections: snapshotSections },
 			};
 		}
 		log.warn(
@@ -1053,6 +1245,43 @@ export async function collectPlexCacheLiveEvidence(
 			},
 			"Plex cache refresh complete",
 		);
+
+		if (canPublishPositivePlexObservation(incompleteReasons)) {
+			appendIncompleteReasonMessages(errorMessages, incompleteReasons);
+			try {
+				await client.verifyHistorySnapshot(history);
+			} catch (error) {
+				errorMessages.push(
+					`Plex positive observation verification failed: ${getErrorMessage(error)}`,
+				);
+				return unpublishedCollection({
+					errors: errors + 1,
+					errorMessages,
+					reasons: [...Object.keys(incompleteReasons), "verification-exception"],
+				});
+			}
+			return {
+				kind: "positive-observation",
+				upserted: 0,
+				errors,
+				errorMessages,
+				complete: false,
+				observation: {
+					rows: rows.filter((row) => row.mediaType === "series"),
+					observedTargets: inventoryTargets.filter((target) => target.mediaType === "series"),
+					capabilities: [
+						{
+							domain: "episode-parents",
+							field: "membership",
+							semantics: "observed-targets-only",
+							operators: [],
+						},
+					],
+					observedRoots: [],
+					partialReasons: sortedPartialReasons(incompleteReasons),
+				},
+			};
+		}
 	} catch (error) {
 		complete = false;
 		const msg = `Plex cache refresh failed: ${getErrorMessage(error)}`;
@@ -1063,13 +1292,9 @@ export async function collectPlexCacheLiveEvidence(
 
 	appendIncompleteReasonMessages(errorMessages, incompleteReasons);
 
-	return {
-		upserted,
+	return unpublishedCollection({
 		errors,
 		errorMessages,
-		complete: complete && errors === 0,
-		completedAt,
-		inventoryTargets:
-			complete && errors === 0 && completedAt ? verifiedInventoryTargets : undefined,
-	};
+		reasons: Object.keys(incompleteReasons),
+	});
 }

--- a/apps/api/src/lib/plex/plex-cache-storage.ts
+++ b/apps/api/src/lib/plex/plex-cache-storage.ts
@@ -5,12 +5,12 @@ import type {
 	Prisma,
 	PrismaClientInstance,
 } from "../prisma.js";
-import type { OwnedProviderPublicationSnapshot } from "../services/provider-identity-guard.js";
 import type { PlexCacheRefreshAttempt } from "../services/provider-cache-status.js";
+import type { OwnedProviderPublicationSnapshot } from "../services/provider-identity-guard.js";
 import { selectPlexBoundedValueRows } from "./plex-canonical-projection.js";
 import {
-	replacePlexGenerationTargets,
 	type PlexGenerationTarget,
+	replacePlexGenerationTargets,
 } from "./plex-generation-target-ledger.js";
 
 export const PLEX_CACHE_READ_PAGE_SIZE = 500;
@@ -442,6 +442,55 @@ export async function publishAuthoritativePlexCacheGeneration(
 	});
 }
 
+export async function publishPositivePlexCacheGeneration(
+	tx: Prisma.TransactionClient,
+	input: {
+		instance: OwnedProviderPublicationSnapshot;
+		rows: Prisma.PlexCacheCreateManyInput[];
+		completedAt: Date;
+		generationId: string;
+		generationMetadata: string;
+		targets: readonly PlexGenerationTarget[];
+		attempt: PlexCacheRefreshAttempt;
+	},
+): Promise<void> {
+	const published = await tx.cacheRefreshStatus.updateMany({
+		where: {
+			instanceId: input.instance.id,
+			cacheType: "plex",
+			lastAttemptAt: input.attempt.attemptedAt,
+			lastAttemptResult: input.attempt.resultMarker,
+			connectionGeneration: input.instance.connectionGeneration,
+			identityGeneration: input.instance.identityGeneration,
+		},
+		data: {
+			lastRefreshedAt: input.completedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			itemCount: input.rows.length,
+			generationId: input.generationId,
+			generationMetadata: input.generationMetadata,
+			lastAttemptAt: input.completedAt,
+			lastAttemptResult: "partial",
+			lastAttemptErrorMessage: null,
+			connectionGeneration: input.instance.connectionGeneration,
+			identityGeneration: input.instance.identityGeneration,
+		},
+	});
+	if (published.count !== 1) throw new PlexRefreshAttemptSupersededError();
+	await tx.plexCache.deleteMany({ where: { instanceId: input.instance.id } });
+	for (let start = 0; start < input.rows.length; start += PLEX_CACHE_WRITE_CHUNK_SIZE) {
+		await tx.plexCache.createMany({
+			data: input.rows.slice(start, start + PLEX_CACHE_WRITE_CHUNK_SIZE),
+		});
+	}
+	await replacePlexGenerationTargets(tx, {
+		instanceId: input.instance.id,
+		generationId: input.generationId,
+		targets: input.targets,
+	});
+}
+
 export async function publishAuthoritativePlexEpisodeGeneration(
 	tx: Prisma.TransactionClient,
 	input: {
@@ -471,6 +520,50 @@ export async function publishAuthoritativePlexEpisodeGeneration(
 			generationMetadata: input.generationMetadata,
 			lastAttemptAt: input.completedAt,
 			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			connectionGeneration: input.instance.connectionGeneration,
+			identityGeneration: input.instance.identityGeneration,
+		},
+	});
+	if (published.count !== 1) throw new PlexRefreshAttemptSupersededError();
+	await tx.plexEpisodeCache.deleteMany({ where: { instanceId: input.instance.id } });
+	for (let start = 0; start < input.rows.length; start += PLEX_CACHE_WRITE_CHUNK_SIZE) {
+		await tx.plexEpisodeCache.createMany({
+			data: input.rows.slice(start, start + PLEX_CACHE_WRITE_CHUNK_SIZE),
+		});
+	}
+}
+
+/** Atomically replaces the current episode generation with bounded positive evidence. */
+export async function publishPositivePlexEpisodeGeneration(
+	tx: Prisma.TransactionClient,
+	input: {
+		instance: OwnedProviderPublicationSnapshot;
+		rows: Prisma.PlexEpisodeCacheCreateManyInput[];
+		completedAt: Date;
+		generationId: string;
+		generationMetadata: string;
+		attempt: PlexCacheRefreshAttempt;
+	},
+): Promise<void> {
+	const published = await tx.cacheRefreshStatus.updateMany({
+		where: {
+			instanceId: input.instance.id,
+			cacheType: "plex_episode",
+			lastAttemptAt: input.attempt.attemptedAt,
+			lastAttemptResult: input.attempt.resultMarker,
+			connectionGeneration: input.instance.connectionGeneration,
+			identityGeneration: input.instance.identityGeneration,
+		},
+		data: {
+			lastRefreshedAt: input.completedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			itemCount: input.rows.length,
+			generationId: input.generationId,
+			generationMetadata: input.generationMetadata,
+			lastAttemptAt: input.completedAt,
+			lastAttemptResult: "partial",
 			lastAttemptErrorMessage: null,
 			connectionGeneration: input.instance.connectionGeneration,
 			identityGeneration: input.instance.identityGeneration,

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.test.ts
@@ -1,10 +1,13 @@
 import type { FastifyBaseLogger } from "fastify";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrismaClientInstance } from "../prisma.js";
 import type { PlexClient } from "./plex-client.js";
 import { refreshPlexEpisodeCache as refreshGuardedPlexEpisodeCache } from "./plex-episode-cache-refresher.js";
 
-const publication = vi.hoisted(() => ({ client: undefined as PlexClient | undefined }));
+const publication = vi.hoisted(() => ({
+	client: undefined as PlexClient | undefined,
+	positiveParents: undefined as Array<Record<string, unknown>> | undefined,
+}));
 
 vi.mock("./plex-client.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./plex-client.js")>();
@@ -75,6 +78,12 @@ vi.mock("./plex-authority-service.js", async (importOriginal) => {
 					}>,
 				) => void | Promise<void>;
 			}) {
+				if (publication.positiveParents) {
+					return {
+						available: false,
+						evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+					};
+				}
 				const scanned = await repository.scanInstanceEpisodeParentPolicyEvidence(
 					this.prisma,
 					input,
@@ -96,6 +105,21 @@ vi.mock("./plex-authority-service.js", async (importOriginal) => {
 						})),
 				);
 				return scanned;
+			}
+
+			async readPositiveEpisodeParents() {
+				if (!publication.positiveParents) {
+					return {
+						available: false,
+						evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+					};
+				}
+				return (
+					publication.positiveParents.shift() ?? {
+						available: false,
+						evidence: { publicationLevel: "unavailable", completeness: "unknown" },
+					}
+				);
 			}
 		},
 	};
@@ -296,6 +320,280 @@ function prisma(
 }
 
 describe("refreshPlexEpisodeCache authoritative publication", () => {
+	beforeEach(() => {
+		publication.positiveParents = undefined;
+	});
+
+	function positiveParent(overrides: Record<string, unknown> = {}) {
+		const target = {
+			instanceId: "plex-1",
+			generationId: "parent-positive-generation-1",
+			sectionId: "shows",
+			sectionUuid: "shows-uuid",
+			mediaType: "series" as const,
+			tmdbId: 42,
+			tvdbId: 84,
+			ratingKey: "show-1",
+		};
+		return {
+			available: true,
+			instanceId: "plex-1",
+			generationId: "parent-positive-generation-1",
+			connectionGeneration: 7,
+			identityGeneration: 11,
+			capability: {
+				domain: "episode-parents",
+				field: "membership",
+				semantics: "observed-targets-only",
+				operators: [],
+			},
+			partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			provenance: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				parentTargetDigest: "a".repeat(64),
+				parentTargetCount: 1,
+			},
+			rows: [{ instanceId: "plex-1", tmdbId: 42, sectionId: "shows", ratingKey: "show-1" }],
+			targets: [target],
+			evidence: { publicationLevel: "positive-only", completeness: "partial" },
+			...overrides,
+		};
+	}
+
+	it("publishes settled V4 parent evidence as a partial V3 episode generation without history", async () => {
+		const fixture = prisma();
+		const getHistory = vi.fn();
+		publication.positiveParents = [positiveParent(), positiveParent(), positiveParent()];
+
+		const result = await refreshPlexEpisodeCache(
+			client({
+				getHistory,
+				getEpisodes: vi
+					.fn()
+					.mockResolvedValue([episode("episode-positive", 2), episode("episode-zero", 0)]),
+			} as Partial<PlexClient>),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({
+			publicationLevel: "positive-only",
+			complete: false,
+			errors: 0,
+			upserted: 1,
+		});
+		expect(getHistory).not.toHaveBeenCalled();
+		expect(fixture.published).toEqual([
+			expect.objectContaining({ ratingKey: "episode-positive", watchCount: 2 }),
+		]);
+		const metadata = JSON.parse(
+			fixture.tx.cacheRefreshStatus.updateMany.mock.calls[0]![0].data.generationMetadata,
+		);
+		expect(metadata).toMatchObject({
+			version: 3,
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			parentMetadataVersion: 4,
+			parentTargetDigest: "a".repeat(64),
+			capability: {
+				domain: "episodes",
+				field: "watchCount",
+				semantics: "lower-bound",
+				operator: "greater_than",
+			},
+		});
+		expect(fixture.tx.cacheRefreshStatus.updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ lastResult: "success", lastAttemptResult: "partial" }),
+			}),
+		);
+	});
+
+	it("queries only parents explicitly observed by V4 and leaves ledger-only parents unknown", async () => {
+		const fixture = prisma();
+		const observed = positiveParent();
+		const ledgerOnlyTarget = {
+			...observed.targets[0]!,
+			tmdbId: 84,
+			tvdbId: 168,
+			ratingKey: "show-ledger-only",
+		};
+		publication.positiveParents = [
+			positiveParent({ targets: [...observed.targets, ledgerOnlyTarget] }),
+			positiveParent({ targets: [...observed.targets, ledgerOnlyTarget] }),
+			positiveParent({ targets: [...observed.targets, ledgerOnlyTarget] }),
+		];
+		const getEpisodes = vi.fn().mockResolvedValue([episode("episode-positive", 2)]);
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes } as Partial<PlexClient>),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ publicationLevel: "positive-only", upserted: 1 });
+		expect(getEpisodes).toHaveBeenCalledTimes(2);
+		expect(getEpisodes).toHaveBeenNthCalledWith(1, "show-1");
+		expect(getEpisodes).toHaveBeenNthCalledWith(2, "show-1");
+		expect(getEpisodes).not.toHaveBeenCalledWith("show-ledger-only");
+	});
+
+	it("treats duplicate ledger parents as unknown even when stored parent rows are collapsed", async () => {
+		const fixture = prisma();
+		const duplicateTargets = [
+			{
+				instanceId: "plex-1",
+				generationId: "parent-positive-generation-1",
+				sectionId: "shows",
+				sectionUuid: "shows-uuid",
+				mediaType: "series" as const,
+				tmdbId: 42,
+				tvdbId: 84,
+				ratingKey: "show-copy-a",
+			},
+			{
+				instanceId: "plex-1",
+				generationId: "parent-positive-generation-1",
+				sectionId: "shows-4k",
+				sectionUuid: "shows-4k-uuid",
+				mediaType: "series" as const,
+				tmdbId: 42,
+				tvdbId: 84,
+				ratingKey: "show-copy-b",
+			},
+		];
+		publication.positiveParents = [
+			positiveParent({ targets: duplicateTargets }),
+			positiveParent({ targets: duplicateTargets }),
+			positiveParent({ targets: duplicateTargets }),
+		];
+		const getEpisodes = vi.fn().mockResolvedValue([episode("episode-positive", 2)]);
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes }),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(getEpisodes).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			publicationLevel: "positive-only",
+			upserted: 0,
+			partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+		});
+		expect(fixture.published).toEqual([]);
+	});
+
+	it("keeps the prior episode generation when the positive parent target digest changes", async () => {
+		const fixture = prisma();
+		publication.positiveParents = [
+			positiveParent(),
+			positiveParent({
+				provenance: {
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					parentTargetDigest: "b".repeat(64),
+					parentTargetCount: 1,
+				},
+			}),
+		];
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes: vi.fn().mockResolvedValue([episode("episode-positive", 2)]) }),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+		expect(result.errorMessages.join(" ")).toMatch(/positive parent Plex generation changed/i);
+		expect(fixture.tx.plexEpisodeCache.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("keeps the prior episode generation when the positive row digest changes", async () => {
+		const fixture = prisma();
+		publication.positiveParents = [positiveParent(), positiveParent(), positiveParent()];
+		const getEpisodes = vi
+			.fn()
+			.mockResolvedValueOnce([episode("episode-positive", 2)])
+			.mockResolvedValueOnce([episode("episode-positive", 3)]);
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes } as Partial<PlexClient>),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ complete: false, upserted: 0, errors: 1 });
+		expect(result.errorMessages.join(" ")).toMatch(/positive Plex episode evidence changed/i);
+		expect(fixture.tx.plexEpisodeCache.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("does not replace rows when the positive episode publication CAS is superseded", async () => {
+		const fixture = prisma();
+		fixture.tx.cacheRefreshStatus.updateMany.mockResolvedValue({ count: 0 });
+		publication.positiveParents = [positiveParent(), positiveParent(), positiveParent()];
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes: vi.fn().mockResolvedValue([episode("episode-positive", 2)]) }),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ superseded: true, errors: 0, upserted: 0 });
+		expect(fixture.tx.plexEpisodeCache.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rolls back positive episode row replacement when the atomic write fails", async () => {
+		const fixture = prisma();
+		const storedRows: Array<{ ratingKey: string }> = [{ ratingKey: "prior-episode" }];
+		fixture.tx.plexEpisodeCache.deleteMany.mockImplementation(async () => {
+			storedRows.splice(0, storedRows.length);
+			return { count: 1 };
+		});
+		fixture.tx.plexEpisodeCache.createMany.mockRejectedValue(new Error("episode write failed"));
+		fixture.db.$transaction = vi.fn(async (callback) => {
+			const before = [...storedRows];
+			try {
+				return await callback(fixture.tx);
+			} catch (error) {
+				storedRows.splice(0, storedRows.length, ...before);
+				throw error;
+			}
+		});
+		publication.positiveParents = [positiveParent(), positiveParent(), positiveParent()];
+
+		const result = await refreshPlexEpisodeCache(
+			client({ getEpisodes: vi.fn().mockResolvedValue([episode("episode-positive", 2)]) }),
+			fixture.db,
+			"plex-1",
+			log,
+			"fingerprint-1",
+			undefined,
+		);
+
+		expect(result).toMatchObject({ complete: false, errors: 1, upserted: 0 });
+		expect(storedRows).toEqual([{ ratingKey: "prior-episode" }]);
+	});
+
 	it("uses stable parent authority timestamps within one fixture", () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-episode-cache-refresher.ts
@@ -5,8 +5,8 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { Prisma } from "../prisma.js";
 import { evidenceFingerprint } from "../evidence-fingerprint.js";
+import type { Prisma } from "../prisma.js";
 import {
 	beginPlexCacheRefreshAttempt,
 	finishPlexCacheRefreshAttemptFailure,
@@ -17,21 +17,28 @@ import {
 	withGuardedProviderPublication,
 } from "../services/provider-identity-guard.js";
 import { getErrorMessage } from "../utils/error-message.js";
-import type { PlexPublicationContext } from "./plex-cache-refresher.js";
-import {
-	PlexRefreshAttemptSupersededError,
-	publishAuthoritativePlexEpisodeGeneration,
-} from "./plex-cache-storage.js";
-import { PlexClient } from "./plex-client.js";
-import {
-	collectPlexEpisodeLiveEvidence,
-	type PlexEpisodeRow,
-} from "./plex-episode-live-collector.js";
-import { createPlexSelectionProjection } from "./plex-canonical-projection.js";
 import {
 	DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
 	PlexAuthorityService,
 } from "./plex-authority-service.js";
+import type { PlexPublicationContext } from "./plex-cache-refresher.js";
+import {
+	PlexRefreshAttemptSupersededError,
+	publishAuthoritativePlexEpisodeGeneration,
+	publishPositivePlexEpisodeGeneration,
+} from "./plex-cache-storage.js";
+import { createPlexSelectionProjection } from "./plex-canonical-projection.js";
+import { PlexClient } from "./plex-client.js";
+import {
+	type CollectedPositivePlexEpisodeRefresh,
+	collectPlexEpisodeLiveEvidence,
+	collectPositivePlexEpisodeLiveEvidence,
+	type PlexEpisodeRow,
+} from "./plex-episode-live-collector.js";
+import {
+	encodePlexPositiveEpisodeGenerationMetadata,
+	type PlexPositiveEpisodePartialReason,
+} from "./plex-positive-episode-generation-metadata.js";
 import { plexConnectionFingerprint } from "./service-instance-fingerprint.js";
 
 export interface PlexEpisodeRefreshResult {
@@ -45,9 +52,12 @@ export interface PlexEpisodeRefreshResult {
 	complete: boolean;
 	completedAt?: Date;
 	superseded?: boolean;
+	publicationLevel?: "authoritative" | "positive-only";
+	partialReasons?: readonly PlexPositiveEpisodePartialReason[];
 }
 
 type CollectedPlexEpisodeRefresh = PlexEpisodeRefreshResult & {
+	kind?: undefined;
 	rows?: PlexEpisodeRow[];
 	parentAuthority?: {
 		generationId: string;
@@ -56,6 +66,19 @@ type CollectedPlexEpisodeRefresh = PlexEpisodeRefreshResult & {
 		identityGeneration: number;
 	};
 };
+
+type CollectedPositiveEpisodeRefresh = CollectedPositivePlexEpisodeRefresh & {
+	parentAuthority: {
+		generationId: string;
+		connectionGeneration: number;
+		identityGeneration: number;
+		parentTargetDigest: string;
+		parentTargetCount: number;
+		partialReasons: readonly { code: string; count: number }[];
+	};
+};
+
+type StagedPlexEpisodeRefresh = CollectedPlexEpisodeRefresh | CollectedPositiveEpisodeRefresh;
 
 function failedResult(
 	errorMessages: string[],
@@ -73,6 +96,65 @@ function failedResult(
 		capacityDegraded,
 		complete: false,
 	};
+}
+
+function positiveParentSignature(parent: {
+	generationId: string;
+	connectionGeneration: number;
+	identityGeneration: number;
+	provenance: { parentTargetDigest: string; parentTargetCount: number };
+	rows: readonly { instanceId: string; tmdbId: number; sectionId: string; ratingKey: string }[];
+}) {
+	return JSON.stringify({
+		generationId: parent.generationId,
+		connectionGeneration: parent.connectionGeneration,
+		identityGeneration: parent.identityGeneration,
+		parentTargetDigest: parent.provenance.parentTargetDigest,
+		parentTargetCount: parent.provenance.parentTargetCount,
+		rows: [...parent.rows]
+			.sort(
+				(left, right) =>
+					left.instanceId.localeCompare(right.instanceId) ||
+					left.tmdbId - right.tmdbId ||
+					left.sectionId.localeCompare(right.sectionId) ||
+					left.ratingKey.localeCompare(right.ratingKey),
+			)
+			.map((row) => [row.instanceId, row.tmdbId, row.sectionId, row.ratingKey]),
+	});
+}
+
+function observedPositiveParentTargets<
+	T extends { instanceId: string; tmdbId: number; sectionId: string; ratingKey: string },
+>(parent: {
+	rows: readonly { instanceId: string; tmdbId: number; sectionId: string; ratingKey: string }[];
+	targets: readonly T[];
+}): T[] {
+	const observed = new Set(
+		parent.rows.map(
+			(row) => `${row.instanceId}\u0000${row.tmdbId}\u0000${row.sectionId}\u0000${row.ratingKey}`,
+		),
+	);
+	return parent.targets.filter((target) =>
+		observed.has(
+			`${target.instanceId}\u0000${target.tmdbId}\u0000${target.sectionId}\u0000${target.ratingKey}`,
+		),
+	);
+}
+
+function mergePositivePartialReasons(
+	parentReasons: readonly { code: string; count: number }[],
+	ambiguityReasons: readonly { code: "ambiguous_episode_parent_targets"; count: number }[],
+): PlexPositiveEpisodePartialReason[] | null {
+	const counts = new Map<string, number>();
+	for (const reason of [...parentReasons, ...ambiguityReasons]) {
+		if (!Number.isSafeInteger(reason.count) || reason.count < 1) return null;
+		const current = counts.get(reason.code) ?? 0;
+		if (!Number.isSafeInteger(current + reason.count)) return null;
+		counts.set(reason.code, current + reason.count);
+	}
+	return [...counts.entries()]
+		.sort(([left], [right]) => left.localeCompare(right))
+		.map(([code, count]) => ({ code, count })) as PlexPositiveEpisodePartialReason[];
 }
 
 export async function refreshPlexEpisodeCache(
@@ -141,64 +223,169 @@ export async function refreshPlexEpisodeCacheWithAttempt(
 					},
 				});
 				if (
-					!parentBefore.available ||
-					parentBefore.evidence.publicationLevel !== "authoritative" ||
-					parentBefore.evidence.completeness !== "complete"
+					parentBefore.available &&
+					parentBefore.evidence.publicationLevel === "authoritative" &&
+					parentBefore.evidence.completeness === "complete"
 				) {
-					return failedResult(["Authoritative parent Plex generation is unavailable"], 0, 0);
+					const collected = await collectPlexEpisodeLiveEvidence(
+						client,
+						showMap,
+						instance.id,
+						log,
+						plexConnectionFingerprint(instance),
+					);
+					if (!collected.complete) return collected;
+					const postCollectionShowMap = new Map<number, Set<string>>();
+					const parentAfter = await authority.scanInstanceEpisodeParentPolicy({
+						userId: instance.userId,
+						instanceId: instance.id,
+						domains: ["membership", "episode-parents", "watch"],
+						mutation: true,
+						maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
+						onTargets: (targets) => {
+							for (const target of targets) {
+								const ratingKeys = postCollectionShowMap.get(target.tmdbId) ?? new Set<string>();
+								ratingKeys.add(target.ratingKey);
+								postCollectionShowMap.set(target.tmdbId, ratingKeys);
+							}
+						},
+					});
+					if (
+						!parentAfter.available ||
+						parentAfter.evidence.publicationLevel !== "authoritative" ||
+						parentAfter.evidence.completeness !== "complete" ||
+						parentAfter.generationId !== parentBefore.generationId ||
+						parentAfter.connectionGeneration !== parentBefore.connectionGeneration ||
+						parentAfter.identityGeneration !== parentBefore.identityGeneration ||
+						evidenceFingerprint(postCollectionShowMap) !== evidenceFingerprint(showMap)
+					) {
+						return failedResult(
+							["Authoritative parent Plex generation changed during episode collection"],
+							collected.eligibleShows,
+							collected.refreshedShows,
+						);
+					}
+					return {
+						...collected,
+						parentAuthority: {
+							generationId: parentBefore.generationId,
+							publicationLevel: "authoritative" as const,
+							connectionGeneration: parentBefore.connectionGeneration,
+							identityGeneration: parentBefore.identityGeneration,
+						},
+					};
 				}
-				const collected = await collectPlexEpisodeLiveEvidence(
+
+				const positiveBefore = await authority.readPositiveEpisodeParents({
+					userId: instance.userId,
+					instanceId: instance.id,
+					maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
+				});
+				if (
+					!positiveBefore.available ||
+					positiveBefore.provenance.publicationLevel !== "positive-only" ||
+					positiveBefore.provenance.completeness !== "partial"
+				) {
+					return failedResult(["Positive parent Plex generation is unavailable"], 0, 0);
+				}
+				const beforeSignature = positiveParentSignature(positiveBefore);
+				const first = await collectPositivePlexEpisodeLiveEvidence(
 					client,
-					showMap,
-					instance.id,
+					observedPositiveParentTargets(positiveBefore).map((target) => ({
+						instanceId: target.instanceId,
+						generationId: target.generationId,
+						showTmdbId: target.tmdbId,
+						sectionId: target.sectionId,
+						sectionUuid: target.sectionUuid,
+						mediaType: target.mediaType as "series",
+						tvdbId: target.tvdbId,
+						ratingKey: target.ratingKey,
+					})),
 					log,
 					plexConnectionFingerprint(instance),
 				);
-				if (!collected.complete) return collected;
-				const postCollectionShowMap = new Map<number, Set<string>>();
-				const parentAfter = await authority.scanInstanceEpisodeParentPolicy({
+				if (first.kind !== "positive-observation") return first;
+				const positiveMiddle = await authority.readPositiveEpisodeParents({
 					userId: instance.userId,
 					instanceId: instance.id,
-					domains: ["membership", "episode-parents", "watch"],
-					mutation: true,
 					maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
-					onTargets: (targets) => {
-						for (const target of targets) {
-							const ratingKeys = postCollectionShowMap.get(target.tmdbId) ?? new Set<string>();
-							ratingKeys.add(target.ratingKey);
-							postCollectionShowMap.set(target.tmdbId, ratingKeys);
-						}
-					},
 				});
 				if (
-					!parentAfter.available ||
-					parentAfter.evidence.publicationLevel !== "authoritative" ||
-					parentAfter.evidence.completeness !== "complete" ||
-					parentAfter.generationId !== parentBefore.generationId ||
-					parentAfter.connectionGeneration !== parentBefore.connectionGeneration ||
-					parentAfter.identityGeneration !== parentBefore.identityGeneration ||
-					evidenceFingerprint(postCollectionShowMap) !== evidenceFingerprint(showMap)
+					!positiveMiddle.available ||
+					positiveParentSignature(positiveMiddle) !== beforeSignature
 				) {
 					return failedResult(
-						["Authoritative parent Plex generation changed during episode collection"],
-						collected.eligibleShows,
-						collected.refreshedShows,
+						["Positive parent Plex generation changed during episode collection"],
+						first.eligibleShows,
+						first.refreshedShows,
+					);
+				}
+				const final = await collectPositivePlexEpisodeLiveEvidence(
+					client,
+					observedPositiveParentTargets(positiveMiddle).map((target) => ({
+						instanceId: target.instanceId,
+						generationId: target.generationId,
+						showTmdbId: target.tmdbId,
+						sectionId: target.sectionId,
+						sectionUuid: target.sectionUuid,
+						mediaType: target.mediaType as "series",
+						tvdbId: target.tvdbId,
+						ratingKey: target.ratingKey,
+					})),
+					log,
+					plexConnectionFingerprint(instance),
+				);
+				if (final.kind !== "positive-observation") return final;
+				const positiveAfter = await authority.readPositiveEpisodeParents({
+					userId: instance.userId,
+					instanceId: instance.id,
+					maxAgeMs: DEFAULT_PLEX_EVIDENCE_FRESHNESS_MS,
+				});
+				if (
+					!positiveAfter.available ||
+					positiveParentSignature(positiveAfter) !== beforeSignature ||
+					final.episodeDigest !== first.episodeDigest
+				) {
+					return failedResult(
+						["Positive Plex episode evidence changed during collection"],
+						final.eligibleShows,
+						final.refreshedShows,
+					);
+				}
+				const partialReasons = mergePositivePartialReasons(
+					positiveBefore.partialReasons,
+					final.partialReasons,
+				);
+				if (!partialReasons) {
+					return failedResult(
+						["Positive Plex episode partial reasons were invalid"],
+						final.eligibleShows,
+						final.refreshedShows,
 					);
 				}
 				return {
-					...collected,
+					...final,
+					partialReasons,
 					parentAuthority: {
-						generationId: parentBefore.generationId,
-						publicationLevel: "authoritative" as const,
-						connectionGeneration: parentBefore.connectionGeneration,
-						identityGeneration: parentBefore.identityGeneration,
+						generationId: positiveBefore.generationId,
+						connectionGeneration: positiveBefore.connectionGeneration,
+						identityGeneration: positiveBefore.identityGeneration,
+						parentTargetDigest: positiveBefore.provenance.parentTargetDigest,
+						parentTargetCount: positiveBefore.provenance.parentTargetCount,
+						partialReasons: positiveBefore.partialReasons,
 					},
 				};
 			},
-			async (tx, collected) => await publishPlexEpisodeCache(tx, instance, attempt!, collected),
+			async (tx, collected) =>
+				await publishPlexEpisodeCache(
+					tx,
+					instance,
+					attempt!,
+					collected as StagedPlexEpisodeRefresh,
+				),
 			{ cleanupRunClaimToken: context.cleanupRunClaimToken },
 		);
-		if (!result.complete || !result.completedAt) {
+		if ((!result.complete && result.publicationLevel !== "positive-only") || !result.completedAt) {
 			const finished = await finishPlexCacheRefreshAttemptFailure(
 				prisma,
 				"plex_episode",
@@ -263,9 +450,49 @@ async function publishPlexEpisodeCache(
 	tx: Prisma.TransactionClient,
 	instance: PlexPublicationContext["instance"],
 	attempt: PlexCacheRefreshAttempt,
-	collected: CollectedPlexEpisodeRefresh,
+	collected: StagedPlexEpisodeRefresh,
 ): Promise<PlexEpisodeRefreshResult> {
-	if (!collected.complete || !collected.completedAt || !collected.rows) return collected;
+	if (!collected.completedAt || !collected.rows) return collected;
+	const rows = collected.rows;
+	const generationId = randomUUID();
+	const storedRows = rows.map((row) => ({
+		...row,
+		connectionGeneration: instance.connectionGeneration,
+		identityGeneration: instance.identityGeneration,
+	}));
+	if (collected.kind === "positive-observation") {
+		const generationMetadata = encodePlexPositiveEpisodeGenerationMetadata({
+			version: 3,
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			itemCount: rows.length,
+			canonicalizationVersion: 1,
+			capability: {
+				domain: "episodes",
+				field: "watchCount",
+				semantics: "lower-bound",
+				operator: "greater_than",
+			},
+			parentPlexGenerationId: collected.parentAuthority.generationId,
+			parentMetadataVersion: 4,
+			parentPublicationLevel: "positive-only",
+			parentTargetDigest: collected.parentAuthority.parentTargetDigest,
+			episodeDigest: collected.episodeDigest,
+			partialReasons: collected.partialReasons,
+			connectionGeneration: collected.parentAuthority.connectionGeneration,
+			identityGeneration: collected.parentAuthority.identityGeneration,
+		});
+		await publishPositivePlexEpisodeGeneration(tx, {
+			instance,
+			rows: storedRows,
+			completedAt: collected.completedAt,
+			generationId,
+			generationMetadata,
+			attempt,
+		});
+		return { ...collected, upserted: rows.length, publicationLevel: "positive-only" };
+	}
+	if (!collected.complete) return collected;
 	if (!collected.parentAuthority) {
 		return failedResult(
 			["Authoritative parent Plex generation is unavailable"],
@@ -273,8 +500,6 @@ async function publishPlexEpisodeCache(
 			collected.refreshedShows,
 		);
 	}
-	const rows = collected.rows;
-	const generationId = randomUUID();
 	const episodeDigest = createPlexSelectionProjection({
 		rows: rows.map((row) => ({
 			sectionId: "",
@@ -304,11 +529,7 @@ async function publishPlexEpisodeCache(
 	});
 	await publishAuthoritativePlexEpisodeGeneration(tx, {
 		instance,
-		rows: rows.map((row) => ({
-			...row,
-			connectionGeneration: instance.connectionGeneration,
-			identityGeneration: instance.identityGeneration,
-		})),
+		rows: storedRows,
 		completedAt: collected.completedAt,
 		generationId,
 		generationMetadata,

--- a/apps/api/src/lib/plex/plex-episode-live-collector.ts
+++ b/apps/api/src/lib/plex/plex-episode-live-collector.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { FastifyBaseLogger } from "fastify";
 import { getErrorMessage } from "../utils/error-message.js";
 import type { PlexClient, PlexEpisodeItem } from "./plex-client.js";
@@ -34,6 +35,30 @@ export interface CollectedPlexEpisodeRefresh {
 	completedAt?: Date;
 	rows?: PlexEpisodeRow[];
 }
+
+export type PlexPositiveEpisodeParentTarget = {
+	instanceId: string;
+	generationId: string;
+	showTmdbId: number;
+	sectionId: string;
+	sectionUuid: string;
+	mediaType: "series";
+	tvdbId: number | null;
+	ratingKey: string;
+};
+
+export type CollectedPositivePlexEpisodeRefresh = Omit<CollectedPlexEpisodeRefresh, "kind"> & {
+	kind: "positive-observation";
+	partialReasons: ReadonlyArray<{ code: "ambiguous_episode_parent_targets"; count: number }>;
+	soleParentTargets: PlexPositiveEpisodeParentTarget[];
+	episodeDigest: string;
+	rows: PlexEpisodeRow[];
+	completedAt: Date;
+};
+
+export type PositivePlexEpisodeCollectionResult =
+	| CollectedPositivePlexEpisodeRefresh
+	| (CollectedPlexEpisodeRefresh & { kind?: undefined });
 
 function failedResult(
 	errorMessages: string[],
@@ -201,5 +226,172 @@ export async function collectPlexEpisodeLiveEvidence(
 		complete: true,
 		completedAt,
 		rows,
+	};
+}
+
+function comparePositiveParents(
+	left: PlexPositiveEpisodeParentTarget,
+	right: PlexPositiveEpisodeParentTarget,
+) {
+	return (
+		left.instanceId.localeCompare(right.instanceId) ||
+		left.generationId.localeCompare(right.generationId) ||
+		left.showTmdbId - right.showTmdbId ||
+		left.sectionId.localeCompare(right.sectionId) ||
+		left.sectionUuid.localeCompare(right.sectionUuid) ||
+		(left.tvdbId ?? -1) - (right.tvdbId ?? -1) ||
+		left.ratingKey.localeCompare(right.ratingKey)
+	);
+}
+
+export function createPositivePlexEpisodeDigest(
+	parents: readonly PlexPositiveEpisodeParentTarget[],
+	rows: readonly PlexEpisodeRow[],
+): string {
+	return createHash("sha256")
+		.update(
+			JSON.stringify({
+				version: 1,
+				parents: [...parents].sort(comparePositiveParents).map((parent) => ({
+					instanceId: parent.instanceId,
+					generationId: parent.generationId,
+					showTmdbId: parent.showTmdbId,
+					sectionId: parent.sectionId,
+					sectionUuid: parent.sectionUuid,
+					mediaType: parent.mediaType,
+					tvdbId: parent.tvdbId,
+					ratingKey: parent.ratingKey,
+				})),
+				rows: [...rows]
+					.sort(
+						(left, right) =>
+							left.instanceId.localeCompare(right.instanceId) ||
+							left.showTmdbId - right.showTmdbId ||
+							left.seasonNumber - right.seasonNumber ||
+							left.episodeNumber - right.episodeNumber ||
+							left.ratingKey.localeCompare(right.ratingKey),
+					)
+					.map((row) => ({
+						instanceId: row.instanceId,
+						showTmdbId: row.showTmdbId,
+						seasonNumber: row.seasonNumber,
+						episodeNumber: row.episodeNumber,
+						ratingKey: row.ratingKey,
+						watchCount: row.watchCount,
+						sourceFingerprint: row.sourceFingerprint,
+					})),
+			}),
+			"utf8",
+		)
+		.digest("hex");
+}
+
+/**
+ * Collects only monotonic live episode observations from the dedicated parent
+ * reader. This path intentionally does not call history/accounts and never
+ * collapses duplicate parent copies: without durable per-parent episode
+ * provenance, ambiguous copies remain unknown.
+ */
+export async function collectPositivePlexEpisodeLiveEvidence(
+	client: PlexClient,
+	parents: readonly PlexPositiveEpisodeParentTarget[],
+	log: FastifyBaseLogger,
+	sourceFingerprint: string,
+): Promise<PositivePlexEpisodeCollectionResult> {
+	const grouped = new Map<string, PlexPositiveEpisodeParentTarget[]>();
+	for (const parent of parents) {
+		if (
+			!parent.instanceId ||
+			!parent.generationId ||
+			!Number.isSafeInteger(parent.showTmdbId) ||
+			parent.showTmdbId <= 0 ||
+			!parent.sectionId ||
+			!parent.sectionUuid ||
+			parent.mediaType !== "series" ||
+			(parent.tvdbId !== null && (!Number.isSafeInteger(parent.tvdbId) || parent.tvdbId <= 0)) ||
+			!parent.ratingKey
+		) {
+			return failedResult(["Positive Plex episode parent target was invalid"], 0, 0);
+		}
+		const groupKey = `${parent.instanceId}\u0000${parent.showTmdbId}`;
+		const group = grouped.get(groupKey) ?? [];
+		group.push(parent);
+		grouped.set(groupKey, group);
+	}
+
+	const ambiguousTargets = [...grouped.values()]
+		.filter((group) => group.length > 1)
+		.reduce((count, group) => count + group.length, 0);
+	const soleParentTargets = [...grouped.values()]
+		.filter((group) => group.length === 1)
+		.map((group) => group[0]!)
+		.sort(comparePositiveParents);
+	const eligibleShows = soleParentTargets.length;
+	if (eligibleShows > MAX_COMPLETE_SHOWS) {
+		const message = `Plex positive episode inventory exceeded ${MAX_COMPLETE_SHOWS} eligible shows`;
+		log.warn({ eligibleShows, limit: MAX_COMPLETE_SHOWS }, message);
+		return failedResult([message], eligibleShows, 0, true);
+	}
+
+	const completedAt = new Date();
+	const rows: PlexEpisodeRow[] = [];
+	let refreshedShows = 0;
+	for (const parent of soleParentTargets) {
+		let episodes: PlexEpisodeItem[];
+		try {
+			episodes = await client.getEpisodes(parent.ratingKey);
+		} catch (error) {
+			const message = `Failed to fetch positive Plex episode evidence for show tmdb:${parent.showTmdbId}: ${getErrorMessage(error)}`;
+			log.warn({ err: error, instanceId: parent.instanceId, tmdbId: parent.showTmdbId }, message);
+			return failedResult([message], eligibleShows, refreshedShows);
+		}
+		refreshedShows++;
+		for (const episode of episodes) {
+			if (
+				!Number.isSafeInteger(episode.viewCount) ||
+				(episode.viewCount ?? 0) <= 0 ||
+				!Number.isSafeInteger(episode.seasonNumber) ||
+				!Number.isSafeInteger(episode.episodeNumber) ||
+				episode.seasonNumber < 0 ||
+				episode.episodeNumber < 0 ||
+				!episode.ratingKey.trim()
+			) {
+				continue;
+			}
+			rows.push({
+				instanceId: parent.instanceId,
+				showTmdbId: parent.showTmdbId,
+				seasonNumber: episode.seasonNumber,
+				episodeNumber: episode.episodeNumber,
+				ratingKey: episode.ratingKey,
+				title: episode.title,
+				watched: true,
+				watchedByUsers: "[]",
+				lastWatchedAt: null,
+				watchCount: episode.viewCount,
+				refreshedAt: completedAt,
+				sourceFingerprint,
+			});
+		}
+	}
+	const partialReasons =
+		ambiguousTargets === 0
+			? []
+			: [{ code: "ambiguous_episode_parent_targets" as const, count: ambiguousTargets }];
+	return {
+		kind: "positive-observation",
+		upserted: 0,
+		errors: 0,
+		errorMessages: [],
+		eligibleShows,
+		refreshedShows,
+		coverageIncomplete: true,
+		capacityDegraded: false,
+		complete: false,
+		completedAt,
+		rows,
+		partialReasons,
+		soleParentTargets,
+		episodeDigest: createPositivePlexEpisodeDigest(soleParentTargets, rows),
 	};
 }

--- a/apps/api/src/lib/plex/plex-evidence-repository.ts
+++ b/apps/api/src/lib/plex/plex-evidence-repository.ts
@@ -1,33 +1,39 @@
 import type {
 	PlexCoverageReasonCode,
 	PlexEvidenceSummary,
+	PlexGenerationMetadataV3,
 	PlexGenerationSection,
+	PlexPositiveGenerationMetadataV4,
 } from "@arr/shared";
-import type { PlexCache, PlexEpisodeCache, PrismaClientInstance } from "../prisma.js";
 import {
 	createEvidenceFingerprintArrayAccumulator,
 	type EvidenceFingerprintArrayAccumulator,
 } from "../evidence-fingerprint.js";
+import type { PlexCache, PlexEpisodeCache, PrismaClientInstance } from "../prisma.js";
 import {
-	countPlexEpisodeCacheRows,
 	countPlexCacheRows,
+	countPlexEpisodeCacheRows,
 	listPlexCacheRows,
 	listPlexEpisodeCacheRows,
 	listPlexEpisodeRowsForShows,
 	listSelectedPlexCacheRows,
-	scanPlexEpisodeParentPolicyRows,
-	scanPlexPolicyCacheRows,
 	type PlexCacheRowSelection,
 	type PlexEpisodeParentPolicyRow,
 	type PlexPolicyCacheRow,
 	readPlexEpisodeGenerationStatus,
 	readPlexGenerationStatus,
+	scanPlexEpisodeParentPolicyRows,
+	scanPlexPolicyCacheRows,
 } from "./plex-cache-storage.js";
 import {
 	type DecodedPlexGenerationMetadata,
 	evaluatePlexLatestAttemptTrust,
 	evaluatePublishedPlexGeneration,
 } from "./plex-generation-metadata.js";
+import {
+	decodePlexPositiveEpisodeGenerationMetadata,
+	type PlexPositiveEpisodeGenerationMetadataV3,
+} from "./plex-positive-episode-generation-metadata.js";
 
 // Mutation authority retains the established 24-hour cutoff. The schedulers'
 // 12-hour threshold is an earlier operational warning/refresh cadence, not a
@@ -91,6 +97,18 @@ export type UnavailablePlexInstanceEvidence = {
 
 export type PlexInstanceEvidence = AvailablePlexInstanceEvidence | UnavailablePlexInstanceEvidence;
 
+export type AvailablePositiveEpisodeParentEvidence = Omit<
+	AvailablePlexInstanceEvidence,
+	"metadata" | "rows"
+> & {
+	metadata: PlexGenerationMetadataV3 | PlexPositiveGenerationMetadataV4;
+	rows: PlexPolicyCacheRow[];
+};
+
+export type PositiveEpisodeParentEvidence =
+	| AvailablePositiveEpisodeParentEvidence
+	| UnavailablePlexInstanceEvidence;
+
 export type AvailablePlexPolicyEvidence = Omit<AvailablePlexInstanceEvidence, "rows"> & {
 	rowCount: number;
 	rowFingerprint: string;
@@ -126,6 +144,25 @@ export type AvailablePlexEpisodeEvidence = {
 export type PlexEpisodeEvidence = AvailablePlexEpisodeEvidence | UnavailablePlexInstanceEvidence;
 
 export type SelectedPlexEpisodeEvidence = PlexEpisodeEvidence;
+
+export type AvailablePositivePlexEpisodeEvidence = {
+	available: true;
+	instanceId: string;
+	generationId: string;
+	parentGenerationId: string;
+	publishedAt: Date;
+	connectionGeneration: number;
+	identityGeneration: number;
+	metadata: PlexPositiveEpisodeGenerationMetadataV3;
+	parentMetadata: PlexPositiveGenerationMetadataV4;
+	rows: PlexEpisodeCache[];
+	generationStatus: AvailablePlexInstanceEvidence["generationStatus"];
+	evidence: PlexEvidenceSummary;
+};
+
+export type PositivePlexEpisodeEvidence =
+	| AvailablePositivePlexEpisodeEvidence
+	| UnavailablePlexInstanceEvidence;
 
 function unavailable(reasonCode: PlexCoverageReasonCode): UnavailablePlexInstanceEvidence {
 	return {
@@ -168,6 +205,49 @@ function mutationUnavailable(evidence: {
 					: ["mutation_authority_unavailable"],
 		},
 	};
+}
+
+function exactReaderUnavailable(evidence: {
+	evidence: PlexEvidenceSummary;
+	metadata: DecodedPlexGenerationMetadata;
+}): UnavailablePlexInstanceEvidence | null {
+	return evidence.metadata.version === 3 &&
+		evidence.metadata.publicationLevel === "authoritative" &&
+		evidence.metadata.completeness === "complete"
+		? null
+		: mutationUnavailable(evidence);
+}
+
+function hasCurrentEpisodeParentReaderAuthority(evidence: {
+	evidence: PlexEvidenceSummary;
+	metadata: DecodedPlexGenerationMetadata;
+}): evidence is {
+	evidence: PlexEvidenceSummary;
+	metadata: PlexGenerationMetadataV3 | PlexPositiveGenerationMetadataV4;
+} {
+	return (
+		(evidence.metadata.version === 3 && isCurrentAuthoritativePlexEvidence(evidence.evidence)) ||
+		(evidence.metadata.version === 4 &&
+			evidence.metadata.publicationLevel === "positive-only" &&
+			evidence.metadata.completeness === "partial" &&
+			evidence.metadata.capabilities.length === 1 &&
+			evidence.metadata.capabilities[0].domain === "episode-parents" &&
+			evidence.metadata.capabilities[0].field === "membership" &&
+			evidence.metadata.capabilities[0].semantics === "observed-targets-only" &&
+			evidence.metadata.capabilities[0].operators.length === 0 &&
+			evidence.evidence.availability === "current" &&
+			evidence.evidence.authority === "positive-only")
+	);
+}
+
+function hasCurrentPositiveEpisodeReaderParentAuthority(evidence: {
+	evidence: PlexEvidenceSummary;
+	metadata: DecodedPlexGenerationMetadata;
+}): evidence is {
+	evidence: PlexEvidenceSummary;
+	metadata: PlexPositiveGenerationMetadataV4;
+} {
+	return hasCurrentEpisodeParentReaderAuthority(evidence) && evidence.metadata.version === 4;
 }
 
 export function hasCurrentPlexMutationAuthority(evidence: {
@@ -298,6 +378,8 @@ async function loadOwnedInstanceEvidence(
 		const before = await readPlexGenerationStatus(prisma, instance.id);
 		const publishedBefore = evaluatePublishedPlexGeneration(before, options);
 		if (!publishedBefore.available) return publishedBefore;
+		const exactUnavailable = exactReaderUnavailable(publishedBefore);
+		if (exactUnavailable) return exactUnavailable;
 		const beforeBinding = validateExplicitStatusGenerationBinding(instance, before!);
 		if (beforeBinding) return unavailable(beforeBinding);
 
@@ -367,6 +449,8 @@ async function scanOwnedPolicyEvidence(
 		const before = await readPlexGenerationStatus(prisma, instance.id);
 		const publishedBefore = evaluatePublishedPlexGeneration(before, options);
 		if (!publishedBefore.available) return publishedBefore;
+		const exactUnavailable = exactReaderUnavailable(publishedBefore);
+		if (exactUnavailable) return exactUnavailable;
 		const beforeBinding = validateExplicitStatusGenerationBinding(instance, before!);
 		if (beforeBinding) return unavailable(beforeBinding);
 
@@ -477,6 +561,8 @@ export async function scanInstanceEpisodeParentPolicyEvidence(
 		const before = await readPlexGenerationStatus(prisma, instance.id);
 		const publishedBefore = evaluatePublishedPlexGeneration(before, options);
 		if (!publishedBefore.available) return publishedBefore;
+		const exactUnavailable = exactReaderUnavailable(publishedBefore);
+		if (exactUnavailable) return exactUnavailable;
 		const beforeBinding = validateExplicitStatusGenerationBinding(instance, before!);
 		if (beforeBinding) return unavailable(beforeBinding);
 		const [totalCount, boundCount] = await Promise.all([
@@ -644,6 +730,101 @@ export async function loadInstanceEvidence(
 	}
 }
 
+/**
+ * Deliberately narrow V4 access seam. It exposes only observed Show-parent
+ * rows; callers must still verify the bound target ledger before interpreting
+ * a row as a positive parent fact. Absence is therefore never represented as
+ * an exact empty/zero result.
+ */
+export async function loadPositiveEpisodeParentEvidence(
+	prisma: PlexEvidencePrisma,
+	input: { userId: string; instanceId: string; now?: Date; maxAgeMs?: number },
+): Promise<PositiveEpisodeParentEvidence> {
+	try {
+		const instance = (await prisma.serviceInstance.findFirst({
+			where: { id: input.instanceId, userId: input.userId, service: "PLEX" },
+		})) as PlexEvidenceInstance | null;
+		if (!instance) return unavailable("missing_status");
+		if (!instance.enabled) return unavailable("disabled_instance");
+		if (!isCurrentVerifiedPlexInstance(instance))
+			return unavailable("identity_generation_mismatch");
+
+		const options = withDefaultFreshness(input);
+		const before = await readPlexGenerationStatus(prisma, instance.id);
+		const publishedBefore = evaluatePublishedPlexGeneration(before, options);
+		if (!publishedBefore.available) return publishedBefore;
+		if (!hasCurrentEpisodeParentReaderAuthority(publishedBefore)) {
+			return mutationUnavailable(publishedBefore);
+		}
+		const beforeBinding = validateExplicitStatusGenerationBinding(instance, before!);
+		if (beforeBinding) return unavailable(beforeBinding);
+
+		const [totalCount, boundCount, allRows] = await Promise.all([
+			countPlexCacheRows(prisma, { instanceId: instance.id }),
+			countPlexCacheRows(prisma, {
+				instanceId: instance.id,
+				connectionGeneration: instance.connectionGeneration,
+				identityGeneration: instance.identityGeneration,
+			}),
+			listPlexCacheRows(prisma, instance.id),
+		]);
+		const after = await readPlexGenerationStatus(prisma, instance.id);
+		const publishedAfter = evaluatePublishedPlexGeneration(after, options);
+		if (!publishedAfter.available) return publishedAfter;
+		if (!hasCurrentEpisodeParentReaderAuthority(publishedAfter)) {
+			return mutationUnavailable(publishedAfter);
+		}
+		const afterBinding = validateExplicitStatusGenerationBinding(instance, after!);
+		if (afterBinding) return unavailable(afterBinding);
+		const generationMismatch = publishedGenerationsMatch(publishedBefore, publishedAfter);
+		if (generationMismatch) return unavailable(generationMismatch);
+		if (totalCount !== publishedBefore.itemCount || boundCount !== totalCount) {
+			return unavailable("row_count_mismatch");
+		}
+		if (
+			allRows.some(
+				(row) =>
+					row.instanceId !== instance.id ||
+					row.connectionGeneration !== instance.connectionGeneration ||
+					row.identityGeneration !== instance.identityGeneration,
+			)
+		) {
+			return unavailable("identity_generation_mismatch");
+		}
+
+		return {
+			available: true,
+			instanceId: instance.id,
+			instanceName: instance.label,
+			generationId: publishedBefore.generationId,
+			publishedAt: publishedBefore.publishedAt,
+			itemCount: publishedBefore.itemCount,
+			connectionGeneration: instance.connectionGeneration,
+			identityGeneration: instance.identityGeneration,
+			metadata: publishedBefore.metadata,
+			generationStatus: {
+				instanceId: before!.instanceId,
+				lastRefreshedAt: before!.lastRefreshedAt,
+				lastResult: before!.lastResult,
+				lastErrorMessage: before!.lastErrorMessage,
+				lastAttemptAt: before!.lastAttemptAt,
+				lastAttemptResult: before!.lastAttemptResult,
+				lastAttemptErrorMessage: before!.lastAttemptErrorMessage,
+				itemCount: before!.itemCount,
+				connectionGeneration: before!.connectionGeneration,
+				identityGeneration: before!.identityGeneration,
+				generationId: before!.generationId,
+				generationMetadata: before!.generationMetadata,
+			},
+			sections: publishedBefore.metadata.sections,
+			rows: allRows.filter((row) => row.mediaType === "series" && row.ratingKey?.trim()),
+			evidence: publishedBefore.evidence,
+		};
+	} catch {
+		return unavailable("query_failed");
+	}
+}
+
 export async function loadInstanceMutationEvidence(
 	prisma: PlexEvidencePrisma,
 	input: { userId: string; instanceId: string; now?: Date; maxAgeMs?: number },
@@ -715,6 +896,8 @@ async function loadOwnedSelectedEvidence(
 		const before = await readPlexGenerationStatus(prisma, instance.id);
 		const publishedBefore = evaluatePublishedPlexGeneration(before, options);
 		if (!publishedBefore.available) return publishedBefore;
+		const exactUnavailable = exactReaderUnavailable(publishedBefore);
+		if (exactUnavailable) return exactUnavailable;
 		const beforeBinding = validateExplicitStatusGenerationBinding(instance, before!);
 		if (beforeBinding) return unavailable(beforeBinding);
 
@@ -1154,6 +1337,161 @@ export function decodePlexEpisodeGenerationMetadata(raw: string | null):
 	}
 }
 
+/**
+ * Deliberately narrow V4/V3 access seam for persisted positive episode facts.
+ * It accepts only positive lower-bound episode observations bound to the
+ * current positive parent generation; absent rows intentionally remain unknown.
+ */
+export async function loadPositiveEpisodeEvidence(
+	prisma: PlexEvidencePrisma,
+	input: {
+		userId: string;
+		instanceId: string;
+		instance?: PlexEvidenceInstance;
+		now?: Date;
+		maxAgeMs?: number;
+	},
+): Promise<PositivePlexEpisodeEvidence> {
+	try {
+		const options = withDefaultFreshness(input);
+		const instance =
+			input.instance ??
+			((await prisma.serviceInstance.findFirst({
+				where: { id: input.instanceId, userId: input.userId, service: "PLEX" },
+			})) as PlexEvidenceInstance | null);
+		if (!instance) return unavailable("missing_status");
+
+		const parentBefore = await loadOwnedPublishedGenerationObservation(prisma, instance, options);
+		if (!parentBefore.available) return parentBefore;
+		if (!hasCurrentPositiveEpisodeReaderParentAuthority(parentBefore)) {
+			return unavailableFromEvidence(parentBefore.evidence);
+		}
+
+		const before = await readPlexEpisodeGenerationStatus(prisma, instance.id);
+		if (before?.lastResult !== "success") return unavailable("missing_status");
+		if (!before.generationId?.trim()) return unavailable("missing_generation_id");
+		const episodeAttempt = evaluatePlexLatestAttemptTrust(before, options.now ?? new Date());
+		if (
+			episodeAttempt.attemptState !== "partial" ||
+			episodeAttempt.reasonCode !== "latest_attempt_partial"
+		) {
+			return unavailable(episodeAttempt.reasonCode ?? "metadata_invalid");
+		}
+		const episodePublishedAt = before.lastRefreshedAt.getTime();
+		const now = options.now ?? new Date();
+		if (!Number.isFinite(episodePublishedAt) || episodePublishedAt > now.getTime()) {
+			return unavailable("published_timestamp_changed");
+		}
+		if (now.getTime() - episodePublishedAt > options.maxAgeMs) {
+			return unavailable("published_generation_stale");
+		}
+		const binding = validateExplicitStatusGenerationBinding(instance, before);
+		if (binding) return unavailable(binding);
+		const decoded = decodePlexPositiveEpisodeGenerationMetadata(before.generationMetadata);
+		if (!decoded.ok) return unavailable("malformed_metadata");
+		const metadata = decoded.metadata;
+		if (metadata.itemCount !== before.itemCount) return unavailable("row_count_mismatch");
+		if (metadata.parentPlexGenerationId !== parentBefore.generationId) {
+			return unavailable("parent_generation_unavailable");
+		}
+		if (metadata.parentTargetDigest !== parentBefore.metadata.targetDigest) {
+			return unavailable("target_digest_mismatch");
+		}
+		if (
+			metadata.connectionGeneration !== instance.connectionGeneration ||
+			metadata.identityGeneration !== instance.identityGeneration
+		) {
+			return unavailable("parent_generation_unavailable");
+		}
+
+		const rows = await listPlexEpisodeCacheRows(prisma, instance.id);
+		if (rows.length !== before.itemCount) return unavailable("row_count_mismatch");
+		if (
+			rows.some(
+				(row) =>
+					row.instanceId !== instance.id ||
+					row.connectionGeneration !== instance.connectionGeneration ||
+					row.identityGeneration !== instance.identityGeneration,
+			)
+		) {
+			return unavailable("connection_generation_mismatch");
+		}
+		if (
+			rows.some((row) => !Number.isSafeInteger(row.watchCount) || (row.watchCount as number) <= 0)
+		) {
+			return unavailable("metadata_invalid");
+		}
+		const after = await readPlexEpisodeGenerationStatus(prisma, instance.id);
+		if (
+			after?.lastResult !== "success" ||
+			after.generationId !== before.generationId ||
+			after.lastRefreshedAt.getTime() !== before.lastRefreshedAt.getTime() ||
+			after.lastErrorMessage !== before.lastErrorMessage ||
+			after.lastAttemptAt?.getTime() !== before.lastAttemptAt?.getTime() ||
+			after.lastAttemptResult !== before.lastAttemptResult ||
+			after.lastAttemptErrorMessage !== before.lastAttemptErrorMessage ||
+			after.itemCount !== before.itemCount ||
+			after.generationMetadata !== before.generationMetadata
+		) {
+			return unavailable("generation_changed");
+		}
+		const afterBinding = validateExplicitStatusGenerationBinding(instance, after);
+		if (afterBinding) return unavailable(afterBinding);
+		const parentAfter = await loadOwnedPublishedGenerationObservation(prisma, instance, options);
+		if (
+			!parentAfter.available ||
+			!hasCurrentPositiveEpisodeReaderParentAuthority(parentAfter) ||
+			parentAfter.generationId !== parentBefore.generationId ||
+			parentAfter.metadata.targetDigest !== parentBefore.metadata.targetDigest
+		) {
+			return unavailable("parent_generation_unavailable");
+		}
+
+		return {
+			available: true,
+			instanceId: instance.id,
+			generationId: before.generationId,
+			parentGenerationId: metadata.parentPlexGenerationId,
+			publishedAt: before.lastRefreshedAt,
+			connectionGeneration: instance.connectionGeneration,
+			identityGeneration: instance.identityGeneration,
+			metadata,
+			parentMetadata: parentBefore.metadata,
+			rows,
+			generationStatus: {
+				instanceId: before.instanceId,
+				lastRefreshedAt: before.lastRefreshedAt,
+				lastResult: before.lastResult,
+				lastErrorMessage: before.lastErrorMessage,
+				lastAttemptAt: before.lastAttemptAt,
+				lastAttemptResult: before.lastAttemptResult,
+				lastAttemptErrorMessage: before.lastAttemptErrorMessage,
+				itemCount: before.itemCount,
+				connectionGeneration: before.connectionGeneration,
+				identityGeneration: before.identityGeneration,
+				generationId: before.generationId,
+				generationMetadata: before.generationMetadata,
+			},
+			evidence: {
+				availability: "current",
+				authority: "positive-only",
+				attemptState: "partial",
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				reasonCodes: ["latest_attempt_partial"],
+				publishedGeneration: {
+					generationId: before.generationId,
+					publicationLevel: "positive-only",
+					publishedAt: before.lastRefreshedAt.toISOString(),
+					itemCount: before.itemCount,
+				},
+			},
+		};
+	} catch {
+		return unavailable("query_failed");
+	}
+}
+
 export async function loadInstanceEpisodeEvidence(
 	prisma: PlexEvidencePrisma,
 	input: {
@@ -1467,6 +1805,27 @@ async function loadOwnedEpisodeGenerationObservation(
 	try {
 		const parentBefore = await loadOwnedPublishedGenerationObservation(prisma, instance, options);
 		if (!parentBefore.available) return unavailable("parent_generation_unavailable");
+		if (hasCurrentPositiveEpisodeReaderParentAuthority(parentBefore)) {
+			const positive = await loadPositiveEpisodeEvidence(prisma, {
+				...input,
+				userId: instance.userId,
+				instanceId: instance.id,
+				instance,
+			});
+			if (!positive.available) return positive;
+			return {
+				available: true as const,
+				instanceId: positive.instanceId,
+				generationId: positive.generationId,
+				parentGenerationId: positive.parentGenerationId,
+				publishedAt: positive.publishedAt,
+				itemCount: positive.metadata.itemCount,
+				connectionGeneration: positive.connectionGeneration,
+				identityGeneration: positive.identityGeneration,
+				generationStatus: positive.generationStatus,
+				evidence: positive.evidence,
+			};
+		}
 		const before = await readPlexEpisodeGenerationStatus(prisma, instance.id);
 		if (before?.lastResult !== "success") return unavailable("missing_status");
 		if (!before.generationId?.trim()) return unavailable("missing_generation_id");

--- a/apps/api/src/lib/plex/plex-generation-metadata.ts
+++ b/apps/api/src/lib/plex/plex-generation-metadata.ts
@@ -6,6 +6,9 @@ import type {
 	PlexGenerationMetadataV3,
 	PlexGenerationSection,
 	PlexGenerationSectionV3,
+	PlexPartialReason,
+	PlexPartialReasonCode,
+	PlexPositiveGenerationMetadataV4,
 	PlexPublicationLevel,
 } from "@arr/shared";
 import {
@@ -21,7 +24,8 @@ export type DecodedPlexGenerationMetadata =
 			itemCount: number | null;
 			sections: PlexGenerationSection[];
 	  }
-	| PlexGenerationMetadataV3;
+	| PlexGenerationMetadataV3
+	| PlexPositiveGenerationMetadataV4;
 
 export type PlexGenerationMetadataDecodeResult =
 	| { ok: true; metadata: DecodedPlexGenerationMetadata }
@@ -227,6 +231,152 @@ function normalizeV3Roots(
 	}
 	return roots;
 }
+const partialCodes = new Set<PlexPartialReasonCode>([
+	"currentItemsWithoutTmdbMetadata",
+	"currentLibraryItemsWithoutRatingKeys",
+	"historyItemsWithoutUsableMediaKey",
+	"currentHistoryItemsWithoutMappedMetadata",
+	"historyItemsWithUnknownAccounts",
+	"onDeckItemsWithoutMappedMetadata",
+	"onDeckFetchFailures",
+]);
+
+function hasExactObjectKeys(value: Record<string, unknown>, expectedKeys: readonly string[]) {
+	const actual = Object.keys(value).sort();
+	const expected = [...expectedKeys].sort();
+	return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function decodeV4(e: Record<string, unknown>): PlexGenerationMetadataDecodeResult {
+	if (
+		!hasExactObjectKeys(e, [
+			"version",
+			"publicationLevel",
+			"completeness",
+			"itemCount",
+			"canonicalizationVersion",
+			"sections",
+			"observedRoots",
+			"capabilities",
+			"targetLedgerVersion",
+			"targetCount",
+			"targetDigest",
+			"partialReasons",
+		]) ||
+		e.publicationLevel !== "positive-only" ||
+		e.completeness !== "partial" ||
+		e.canonicalizationVersion !== 1 ||
+		!Number.isSafeInteger(e.itemCount) ||
+		(e.itemCount as number) < 0
+	)
+		return { ok: false, reasonCode: "metadata_invalid" };
+	const sections = normalizeV3Sections(e.sections);
+	if (typeof sections === "string") return { ok: false, reasonCode: "metadata_invalid" };
+	if (
+		!(e.sections as unknown[]).every(
+			(section) =>
+				typeof section === "object" &&
+				section !== null &&
+				!Array.isArray(section) &&
+				hasExactObjectKeys(section as Record<string, unknown>, [
+					"key",
+					"uuid",
+					"title",
+					"type",
+					"refreshing",
+					"scannedAt",
+					"updatedAt",
+				]),
+		)
+	) {
+		return { ok: false, reasonCode: "metadata_invalid" };
+	}
+	if (sections.some((s) => s.refreshing)) return { ok: false, reasonCode: "metadata_invalid" };
+	const roots = normalizeV3Roots(e.observedRoots, new Set(sections.map((s) => s.key)));
+	const showSectionKeys = new Set(
+		sections.filter((section) => section.type === "show").map((s) => s.key),
+	);
+	if (
+		typeof roots === "string" ||
+		roots.some(
+			(root) =>
+				root.domain !== "episode-parents" ||
+				!showSectionKeys.has(root.sectionKey) ||
+				!hasExactObjectKeys(root as unknown as Record<string, unknown>, [
+					"sectionKey",
+					"domain",
+					"digest",
+				]),
+		) ||
+		roots.length !== showSectionKeys.size
+	)
+		return { ok: false, reasonCode: "metadata_invalid" };
+	const c = e.capabilities;
+	if (!Array.isArray(c) || c.length !== 1 || typeof c[0] !== "object" || c[0] === null)
+		return { ok: false, reasonCode: "metadata_invalid" };
+	const cap = c[0] as Record<string, unknown>;
+	if (
+		!hasExactObjectKeys(cap, ["domain", "field", "semantics", "operators"]) ||
+		cap.domain !== "episode-parents" ||
+		cap.field !== "membership" ||
+		cap.semantics !== "observed-targets-only" ||
+		!Array.isArray(cap.operators) ||
+		cap.operators.length
+	)
+		return { ok: false, reasonCode: "metadata_invalid" };
+	const b = decodePlexTargetLedgerBinding(e);
+	if (!b.ok || !b.binding) return { ok: false, reasonCode: "metadata_invalid" };
+	if (
+		!Array.isArray(e.partialReasons) ||
+		e.partialReasons.length < 1 ||
+		e.partialReasons.length > 7
+	)
+		return { ok: false, reasonCode: "metadata_invalid" };
+	let prev = "";
+	const reasons: PlexPartialReason[] = [];
+	for (const x of e.partialReasons) {
+		if (
+			typeof x !== "object" ||
+			x === null ||
+			Array.isArray(x) ||
+			!hasExactObjectKeys(x as Record<string, unknown>, ["code", "count"])
+		)
+			return { ok: false, reasonCode: "metadata_invalid" };
+		const r = x as Record<string, unknown>;
+		if (
+			typeof r.code !== "string" ||
+			!partialCodes.has(r.code as PlexPartialReasonCode) ||
+			!Number.isSafeInteger(r.count) ||
+			(r.count as number) < 1 ||
+			r.code <= prev
+		)
+			return { ok: false, reasonCode: "metadata_invalid" };
+		prev = r.code;
+		reasons.push({ code: r.code as PlexPartialReasonCode, count: r.count as number });
+	}
+	return {
+		ok: true,
+		metadata: {
+			version: 4,
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			itemCount: e.itemCount as number,
+			canonicalizationVersion: 1,
+			sections,
+			observedRoots: roots,
+			capabilities: [
+				{
+					domain: "episode-parents",
+					field: "membership",
+					semantics: "observed-targets-only",
+					operators: [],
+				},
+			],
+			...b.binding,
+			partialReasons: reasons,
+		},
+	};
+}
 
 export function decodePlexGenerationMetadata(
 	raw: string | null | undefined,
@@ -242,6 +392,7 @@ export function decodePlexGenerationMetadata(
 		return { ok: false, reasonCode: "malformed_metadata" };
 	}
 	const envelope = parsed as Record<string, unknown>;
+	if (envelope.version === 4) return decodeV4(envelope);
 	const normalizedSections =
 		envelope.version === 3
 			? normalizeV3Sections(envelope.sections)
@@ -344,6 +495,40 @@ export function encodeAuthoritativePlexGenerationMetadata(input: {
 	const decoded = decodePlexGenerationMetadata(JSON.stringify(metadata));
 	if (!decoded.ok || decoded.metadata.publicationLevel !== "authoritative") {
 		throw new Error("Invalid authoritative Plex generation metadata");
+	}
+	return JSON.stringify(metadata);
+}
+
+export function encodePositivePlexGenerationMetadata(input: {
+	sections: PlexGenerationSectionV3[];
+	itemCount: number;
+	canonicalizationVersion: 1;
+	observedRoots: PlexGenerationDomainRoot[];
+	targetLedger: PlexTargetLedgerBinding;
+	partialReasons: readonly PlexPartialReason[];
+}): string {
+	const metadata: PlexPositiveGenerationMetadataV4 = {
+		version: 4,
+		publicationLevel: "positive-only",
+		completeness: "partial",
+		itemCount: input.itemCount,
+		canonicalizationVersion: input.canonicalizationVersion,
+		sections: input.sections,
+		observedRoots: input.observedRoots,
+		capabilities: [
+			{
+				domain: "episode-parents",
+				field: "membership",
+				semantics: "observed-targets-only",
+				operators: [],
+			},
+		],
+		...input.targetLedger,
+		partialReasons: input.partialReasons,
+	};
+	const decoded = decodePlexGenerationMetadata(JSON.stringify(metadata));
+	if (!decoded.ok || decoded.metadata.publicationLevel !== "positive-only") {
+		throw new Error("Invalid positive-only Plex generation metadata");
 	}
 	return JSON.stringify(metadata);
 }

--- a/apps/api/src/lib/plex/plex-positive-episode-generation-metadata.ts
+++ b/apps/api/src/lib/plex/plex-positive-episode-generation-metadata.ts
@@ -1,0 +1,190 @@
+const POSITIVE_EPISODE_PARTIAL_REASON_CODES = [
+	"ambiguous_episode_parent_targets",
+	"currentItemsWithoutTmdbMetadata",
+	"currentLibraryItemsWithoutRatingKeys",
+	"currentHistoryItemsWithoutMappedMetadata",
+	"historyItemsWithoutUsableMediaKey",
+	"historyItemsWithUnknownAccounts",
+	"onDeckFetchFailures",
+	"onDeckItemsWithoutMappedMetadata",
+] as const;
+
+const allowedReasonCodes = new Set<string>(POSITIVE_EPISODE_PARTIAL_REASON_CODES);
+
+export type PlexPositiveEpisodePartialReason = {
+	code: (typeof POSITIVE_EPISODE_PARTIAL_REASON_CODES)[number];
+	count: number;
+};
+
+export type PlexPositiveEpisodeGenerationMetadataV3 = {
+	version: 3;
+	publicationLevel: "positive-only";
+	completeness: "partial";
+	itemCount: number;
+	canonicalizationVersion: 1;
+	capability: {
+		domain: "episodes";
+		field: "watchCount";
+		semantics: "lower-bound";
+		operator: "greater_than";
+	};
+	parentPlexGenerationId: string;
+	parentMetadataVersion: 4;
+	parentPublicationLevel: "positive-only";
+	parentTargetDigest: string;
+	episodeDigest: string;
+	partialReasons: readonly PlexPositiveEpisodePartialReason[];
+	connectionGeneration: number;
+	identityGeneration: number;
+};
+
+function isNonemptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim() !== "" && !value.includes("\0");
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]) {
+	const actual = Object.keys(value).sort();
+	const expected = [...keys].sort();
+	return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}
+
+function decodePartialReasons(value: unknown): PlexPositiveEpisodePartialReason[] | null {
+	if (
+		!Array.isArray(value) ||
+		value.length < 1 ||
+		value.length > POSITIVE_EPISODE_PARTIAL_REASON_CODES.length
+	)
+		return null;
+	const reasons: PlexPositiveEpisodePartialReason[] = [];
+	let previous = "";
+	for (const rawReason of value) {
+		if (typeof rawReason !== "object" || rawReason === null || Array.isArray(rawReason))
+			return null;
+		const reason = rawReason as Record<string, unknown>;
+		if (
+			!hasExactKeys(reason, ["code", "count"]) ||
+			typeof reason.code !== "string" ||
+			!allowedReasonCodes.has(reason.code) ||
+			typeof reason.count !== "number" ||
+			!Number.isSafeInteger(reason.count) ||
+			reason.count < 1 ||
+			reason.code <= previous
+		) {
+			return null;
+		}
+		previous = reason.code;
+		reasons.push({
+			code: reason.code as PlexPositiveEpisodePartialReason["code"],
+			count: reason.count,
+		});
+	}
+	return reasons;
+}
+
+/**
+ * Strictly decodes the positive-only episode envelope. It intentionally does
+ * not share the authoritative V2 decoder: a V3 envelope grants only the named
+ * lower-bound capability and existing exact readers must continue to reject it.
+ */
+export function decodePlexPositiveEpisodeGenerationMetadata(
+	raw: string | null | undefined,
+): { ok: true; metadata: PlexPositiveEpisodeGenerationMetadataV3 } | { ok: false } {
+	if (!raw) return { ok: false };
+	try {
+		const parsed = JSON.parse(raw) as unknown;
+		if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed))
+			return { ok: false };
+		const value = parsed as Record<string, unknown>;
+		if (
+			!hasExactKeys(value, [
+				"version",
+				"publicationLevel",
+				"completeness",
+				"itemCount",
+				"canonicalizationVersion",
+				"capability",
+				"parentPlexGenerationId",
+				"parentMetadataVersion",
+				"parentPublicationLevel",
+				"parentTargetDigest",
+				"episodeDigest",
+				"partialReasons",
+				"connectionGeneration",
+				"identityGeneration",
+			]) ||
+			value.version !== 3 ||
+			value.publicationLevel !== "positive-only" ||
+			value.completeness !== "partial" ||
+			typeof value.itemCount !== "number" ||
+			!Number.isSafeInteger(value.itemCount) ||
+			value.itemCount < 0 ||
+			value.canonicalizationVersion !== 1 ||
+			!isNonemptyString(value.parentPlexGenerationId) ||
+			value.parentMetadataVersion !== 4 ||
+			value.parentPublicationLevel !== "positive-only" ||
+			typeof value.parentTargetDigest !== "string" ||
+			!/^[a-f0-9]{64}$/.test(value.parentTargetDigest) ||
+			typeof value.episodeDigest !== "string" ||
+			!/^[a-f0-9]{64}$/.test(value.episodeDigest) ||
+			typeof value.connectionGeneration !== "number" ||
+			!Number.isSafeInteger(value.connectionGeneration) ||
+			value.connectionGeneration < 0 ||
+			typeof value.identityGeneration !== "number" ||
+			!Number.isSafeInteger(value.identityGeneration) ||
+			value.identityGeneration <= 0 ||
+			typeof value.capability !== "object" ||
+			value.capability === null ||
+			Array.isArray(value.capability)
+		) {
+			return { ok: false };
+		}
+		const capability = value.capability as Record<string, unknown>;
+		if (
+			!hasExactKeys(capability, ["domain", "field", "semantics", "operator"]) ||
+			capability.domain !== "episodes" ||
+			capability.field !== "watchCount" ||
+			capability.semantics !== "lower-bound" ||
+			capability.operator !== "greater_than"
+		) {
+			return { ok: false };
+		}
+		const partialReasons = decodePartialReasons(value.partialReasons);
+		if (!partialReasons) return { ok: false };
+		return {
+			ok: true,
+			metadata: {
+				version: 3,
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				itemCount: value.itemCount,
+				canonicalizationVersion: 1,
+				capability: {
+					domain: "episodes",
+					field: "watchCount",
+					semantics: "lower-bound",
+					operator: "greater_than",
+				},
+				parentPlexGenerationId: value.parentPlexGenerationId,
+				parentMetadataVersion: 4,
+				parentPublicationLevel: "positive-only",
+				parentTargetDigest: value.parentTargetDigest,
+				episodeDigest: value.episodeDigest,
+				partialReasons,
+				connectionGeneration: value.connectionGeneration,
+				identityGeneration: value.identityGeneration,
+			},
+		};
+	} catch {
+		return { ok: false };
+	}
+}
+
+export function encodePlexPositiveEpisodeGenerationMetadata(
+	metadata: PlexPositiveEpisodeGenerationMetadataV3,
+): string {
+	const encoded = JSON.stringify(metadata);
+	if (!decodePlexPositiveEpisodeGenerationMetadata(encoded).ok) {
+		throw new Error("Invalid positive-only Plex episode generation metadata");
+	}
+	return encoded;
+}

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -29,11 +29,13 @@ import {
 } from "../arr/client-helpers.js";
 import { QuiApiError, QuiInstanceUnreachableError } from "../errors.js";
 import { createJellyfinClient } from "../jellyfin/jellyfin-client.js";
+import { createPlexClient } from "../plex/plex-client.js";
+import { decodePlexGenerationMetadata } from "../plex/plex-generation-metadata.js";
+import { decodePlexPositiveEpisodeGenerationMetadata } from "../plex/plex-positive-episode-generation-metadata.js";
 import {
 	getPublishedEpisodeGenerationObservation,
 	loadUserGenerationObservations,
 } from "../plex/plex-persisted-observation-repository.js";
-import { createPlexClient } from "../plex/plex-client.js";
 import { createQuiClient } from "../qui/client-factory.js";
 import { listQuiInstances } from "../qui/instance-helpers.js";
 import {
@@ -685,6 +687,29 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				(evidence?.publicationLevel === "positive-only" || evidence?.completeness === "partial")
 			) {
 				effectiveResult = "partial";
+				const metadata = decodePlexGenerationMetadata(status.generationMetadata);
+				if (status.cacheType === "plex" && metadata.ok && metadata.metadata.version === 4) {
+					effectiveError = [
+						"publicationLevel: positive-only",
+						`observedItemCount: ${metadata.metadata.itemCount}`,
+						`partialReasons: ${metadata.metadata.partialReasons
+							.map((reason) => `${reason.code}=${reason.count}`)
+							.join(", ")}`,
+					].join("; ");
+				} else if (status.cacheType === "plex_episode") {
+					const episodeMetadata = decodePlexPositiveEpisodeGenerationMetadata(
+						status.generationMetadata,
+					);
+					if (episodeMetadata.ok) {
+						effectiveError = [
+							"publicationLevel: positive-only",
+							`observedItemCount: ${episodeMetadata.metadata.itemCount}`,
+							`partialReasons: ${episodeMetadata.metadata.partialReasons
+								.map((reason) => `${reason.code}=${reason.count}`)
+								.join(", ")}`,
+						].join("; ");
+					}
+				}
 			} else if (status.lastResult === "success" && !evidence) {
 				effectiveResult = "error";
 				effectiveError = "Published Plex evidence is unavailable (missing_status)";

--- a/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
@@ -29,13 +29,21 @@ vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => {
 					where: { userId: input.userId, service: "PLEX", enabled: true },
 				});
 				const instance = instances.find((entry) => entry.id === input.instanceId);
-				return repository.loadInstanceEpisodeEvidence(
+				return await repository.loadInstanceEpisodeEvidence(
 					this.prisma as never,
 					{
 						...input,
 						instance: instance as never,
 					} as never,
 				);
+			}
+
+			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
+				return {
+					available: false as const,
+					instanceId: input.instanceId,
+					evidence: { reasonCodes: ["positive_episode_unavailable"] },
+				};
 			}
 		},
 	};
@@ -96,10 +104,12 @@ beforeEach(async () => {
 		.mockResolvedValueOnce([
 			{
 				id: "plex-series",
+				instanceId: PLEX_INSTANCE_ID,
 				tmdbId: 12345,
 				mediaType: "series",
 				sectionId: "1",
 				sectionTitle: "TV",
+				ratingKey: "plex-show-12345",
 				lastWatchedAt: NOW,
 				watchCount: 99,
 				watchedByUsers: "[]",
@@ -108,6 +118,10 @@ beforeEach(async () => {
 				collections: "[]",
 				labels: "[]",
 				addedAt: NOW,
+				refreshedAt: NOW,
+				sourceFingerprint: plexConnectionFingerprint(plexInstance),
+				connectionGeneration: 4,
+				identityGeneration: 9,
 			},
 		])
 		.mockResolvedValueOnce([]);
@@ -224,6 +238,9 @@ beforeEach(async () => {
 										},
 									],
 									roots: [{ sectionKey: "1", domain: "membership", digest: "a".repeat(64) }],
+									targetLedgerVersion: 1,
+									targetCount: 1,
+									targetDigest: "c".repeat(64),
 								}),
 							}
 						: {

--- a/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-explain-episode.test.ts
@@ -4,6 +4,10 @@ import { plexConnectionFingerprint } from "../../lib/plex/service-instance-finge
 import { registerLibraryCleanupRoutes } from "../library-cleanup.js";
 import { createInjectAuthenticated, setupAuthInjection } from "./test-helpers.js";
 
+const authorityMock = vi.hoisted(() => ({
+	positiveEpisodeEvidence: new Map<string, unknown>(),
+}));
+
 vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../../lib/plex/plex-authority-service.js")>();
 	const repository = await import("../../lib/plex/plex-evidence-repository.js");
@@ -39,11 +43,13 @@ vi.mock("../../lib/plex/plex-authority-service.js", async (importOriginal) => {
 			}
 
 			async readPositiveEpisodeEvidence(input: { instanceId: string }) {
-				return {
-					available: false as const,
-					instanceId: input.instanceId,
-					evidence: { reasonCodes: ["positive_episode_unavailable"] },
-				};
+				return (
+					authorityMock.positiveEpisodeEvidence.get(input.instanceId) ?? {
+						available: false as const,
+						instanceId: input.instanceId,
+						evidence: { reasonCodes: ["positive_episode_unavailable"] },
+					}
+				);
 			}
 		},
 	};
@@ -85,6 +91,30 @@ const plexInstance = {
 	identityGeneration: 9,
 	updatedAt: NOW,
 };
+
+function episodeRule(threshold = 2) {
+	return {
+		id: "episode-rule",
+		configId: "cleanup-config",
+		name: "Watched episodes",
+		enabled: true,
+		priority: 0,
+		ruleType: "plex_watch_count",
+		parameters: JSON.stringify({ operator: "greater_than", count: threshold }),
+		serviceFilter: null,
+		instanceFilter: null,
+		excludeTags: null,
+		excludeTitles: null,
+		plexLibraryFilter: null,
+		targetScope: "episode",
+		action: "delete",
+		operator: null,
+		conditions: null,
+		retentionMode: false,
+		createdAt: NOW,
+		updatedAt: NOW,
+	};
+}
 
 let app: FastifyInstance;
 let plexEpisodeCacheFindMany: ReturnType<typeof vi.fn>;
@@ -146,29 +176,7 @@ beforeEach(async () => {
 	]);
 	libraryCleanupConfigFindUnique = vi.fn().mockResolvedValue({
 		id: "cleanup-config",
-		rules: [
-			{
-				id: "episode-rule",
-				configId: "cleanup-config",
-				name: "Watched episodes",
-				enabled: true,
-				priority: 0,
-				ruleType: "plex_watch_count",
-				parameters: JSON.stringify({ operator: "greater_than", count: 2 }),
-				serviceFilter: null,
-				instanceFilter: null,
-				excludeTags: null,
-				excludeTitles: null,
-				plexLibraryFilter: null,
-				targetScope: "episode",
-				action: "delete",
-				operator: null,
-				conditions: null,
-				retentionMode: false,
-				createdAt: NOW,
-				updatedAt: NOW,
-			},
-		],
+		rules: [episodeRule()],
 	});
 
 	app = Fastify({ logger: false });
@@ -287,6 +295,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+	authorityMock.positiveEpisodeEvidence.clear();
 	await app?.close();
 });
 
@@ -353,6 +362,90 @@ describe("POST /library-cleanup/explain episode scope", () => {
 					filteredBy: "evidence_unavailable",
 				},
 			],
+		});
+	});
+
+	it.each([
+		["lower bound 2 greater than 0", 0, true, null],
+		["lower bound 2 greater than 1", 1, true, null],
+		["lower bound 2 not proven greater than 2", 2, false, "evidence_unavailable"],
+		["lower bound 2 not proven greater than 3", 3, false, "evidence_unavailable"],
+	] as const)(
+		"uses positive-only episode semantics for %s",
+		async (_case, threshold, matched, filteredBy) => {
+			libraryCleanupConfigFindUnique.mockResolvedValue({
+				id: "cleanup-config",
+				rules: [episodeRule(threshold)],
+			});
+			authorityMock.positiveEpisodeEvidence.set(PLEX_INSTANCE_ID, {
+				available: true,
+				instanceId: PLEX_INSTANCE_ID,
+				connectionGeneration: 4,
+				identityGeneration: 9,
+				provenance: {
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					parentPlexGenerationId: "parent-v4",
+					parentTargetDigest: "parent-target-digest",
+					episodeGenerationId: "episode-v3",
+					episodeDigest: "episode-digest",
+					publishedAt: NOW.toISOString(),
+				},
+				rows: [
+					{
+						showTmdbId: 12345,
+						seasonNumber: 1,
+						episodeNumber: 2,
+						ratingKey: "plex-episode-202",
+						lowerBound: 2,
+						sourceFingerprint: plexConnectionFingerprint(plexInstance),
+						soleParentTarget: { ratingKey: "plex-show-12345" },
+					},
+				],
+			});
+
+			const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/explain", {
+				body: { instanceId: SONARR_INSTANCE_ID, arrItemId: 101, arrEpisodeId: 202 },
+			});
+
+			expect(response.statusCode).toBe(200);
+			expect(JSON.parse(response.payload)).toMatchObject({
+				results: [{ ruleId: "episode-rule", matched, filteredBy }],
+			});
+		},
+	);
+
+	it("reports an authoritative exact zero as false instead of unavailable", async () => {
+		libraryCleanupConfigFindUnique.mockResolvedValue({
+			id: "cleanup-config",
+			rules: [episodeRule(0)],
+		});
+		plexEpisodeCacheFindMany.mockResolvedValue([
+			{
+				id: "plex-episode-row-202",
+				instanceId: PLEX_INSTANCE_ID,
+				showTmdbId: 12345,
+				seasonNumber: 1,
+				episodeNumber: 2,
+				title: "The Second Episode",
+				watched: false,
+				watchCount: 0,
+				lastWatchedAt: null,
+				watchedByUsers: "[]",
+				ratingKey: "plex-episode-202",
+				refreshedAt: NOW,
+				sourceFingerprint: plexConnectionFingerprint(plexInstance),
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/library-cleanup/explain", {
+			body: { instanceId: SONARR_INSTANCE_ID, arrItemId: 101, arrEpisodeId: 202 },
+		});
+
+		expect(JSON.parse(response.payload)).toMatchObject({
+			results: [{ ruleId: "episode-rule", matched: false, filteredBy: null }],
 		});
 	});
 

--- a/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
+++ b/apps/api/src/routes/__tests__/library-cleanup-field-options.test.ts
@@ -436,4 +436,100 @@ describe("GET /library-cleanup/field-options — cursor pagination (issue #427)"
 			publishedGeneration: { publicationLevel: "authoritative" },
 		});
 	});
+
+	it("does not expose partial V4 rows as exact cleanup field options", async () => {
+		serviceInstanceFindMany.mockImplementation(({ where }: { where: { service: unknown } }) => {
+			if (where.service === "PLEX") {
+				return Promise.resolve([
+					{
+						id: PLEX_INSTANCE_ID,
+						userId: currentUserId,
+						service: "PLEX",
+						enabled: true,
+						label: "Plex",
+						expectedIdentity: "plex-machine-1",
+						identityKind: "PLEX_MACHINE_IDENTIFIER",
+						identityStatus: "VERIFIED",
+						identityVerifiedAt: new Date(0),
+						connectionGeneration: 1,
+						identityGeneration: 1,
+						updatedAt: new Date(0),
+					},
+				]);
+			}
+			return Promise.resolve([]);
+		});
+		plexCacheFindMany.mockResolvedValue([
+			makePlexRow("pc-1", {
+				sectionTitle: "TV Shows",
+				watchedByUsers: ["must-not-leak"],
+				collections: ["Partial Collection"],
+				labels: ["partial-label"],
+			}),
+		]);
+		const completedAt = new Date();
+		cacheRefreshStatusFindMany.mockResolvedValue([
+			{
+				instanceId: PLEX_INSTANCE_ID,
+				cacheType: "plex",
+				lastRefreshedAt: completedAt,
+				lastResult: "success",
+				lastErrorMessage: null,
+				lastAttemptAt: completedAt,
+				lastAttemptResult: "partial",
+				lastAttemptErrorMessage: null,
+				itemCount: 1,
+				connectionGeneration: 1,
+				identityGeneration: 1,
+				generationId: "generation-v4",
+				generationMetadata: JSON.stringify({
+					version: 4,
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					itemCount: 1,
+					canonicalizationVersion: 1,
+					sections: [
+						{
+							key: "shows",
+							title: "TV Shows",
+							type: "show",
+							uuid: "shows-uuid",
+							refreshing: false,
+							scannedAt: 1,
+							updatedAt: 1,
+						},
+					],
+					observedRoots: [
+						{ sectionKey: "shows", domain: "episode-parents", digest: "a".repeat(64) },
+					],
+					capabilities: [
+						{
+							domain: "episode-parents",
+							field: "membership",
+							semantics: "observed-targets-only",
+							operators: [],
+						},
+					],
+					targetLedgerVersion: 1,
+					targetCount: 1,
+					targetDigest: "b".repeat(64),
+					partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+				}),
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)("GET", "/library-cleanup/field-options");
+		const body = response.json();
+
+		expect(response.statusCode).toBe(200);
+		expect(body.plexUsers).toEqual([]);
+		expect(body.plexLibraries).toEqual([]);
+		expect(body.plexCollections).toEqual([]);
+		expect(body.plexLabels).toEqual([]);
+		expect(body.plexEvidence).toMatchObject({
+			authority: "unavailable",
+			publicationLevel: "unavailable",
+			completeness: "unknown",
+		});
+	});
 });

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -214,6 +214,137 @@ describe("GET /pulse — cache.refresh action emission", () => {
 		});
 	});
 
+	it("names positive-only coverage and observed count without implying an exact universe", async () => {
+		cacheStatuses = [
+			makeRow({
+				id: "positive-diagnostic",
+				itemCount: 7,
+				lastRefreshedAt: new Date(),
+				generationMetadata: JSON.stringify({
+					version: 4,
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					itemCount: 7,
+					canonicalizationVersion: 1,
+					sections: [
+						{
+							key: "shows",
+							uuid: "shows-uuid",
+							title: "Shows",
+							type: "show",
+							refreshing: false,
+							scannedAt: 1,
+							updatedAt: 1,
+						},
+					],
+					observedRoots: [
+						{ sectionKey: "shows", domain: "episode-parents", digest: "a".repeat(64) },
+					],
+					capabilities: [
+						{
+							domain: "episode-parents",
+							field: "membership",
+							semantics: "observed-targets-only",
+							operators: [],
+						},
+					],
+					targetLedgerVersion: 1,
+					targetCount: 1,
+					targetDigest: "b".repeat(64),
+					partialReasons: [
+						{ code: "currentItemsWithoutTmdbMetadata", count: 2 },
+						{ code: "onDeckFetchFailures", count: 1 },
+					],
+				}),
+			}),
+		];
+		evidenceMocks.loadUserGenerationObservations.mockResolvedValueOnce([
+			{
+				available: true,
+				instanceId: "inst-1",
+				metadata: {
+					version: 4,
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					partialReasons: [
+						{ code: "currentItemsWithoutTmdbMetadata", count: 2 },
+						{ code: "onDeckFetchFailures", count: 1 },
+					],
+				},
+				evidence: {
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					reasonCodes: [],
+				},
+			},
+		]);
+
+		const body = JSON.parse((await injectAuthenticated("GET", "/pulse")).payload);
+		const item = body.items.find((candidate: { id: string }) =>
+			candidate.id.includes("positive-diagnostic"),
+		);
+
+		expect(item).toMatchObject({
+			id: "cache-partial-positive-diagnostic",
+			detail:
+				"publicationLevel: positive-only; observedItemCount: 7; partialReasons: currentItemsWithoutTmdbMetadata=2, onDeckFetchFailures=1",
+		});
+		expect(item.detail).not.toContain("itemCount:");
+	});
+
+	it("names positive-only episode coverage and observed count without an exact denominator", async () => {
+		cacheStatuses = [
+			makeRow({
+				id: "positive-episode-diagnostic",
+				cacheType: "plex_episode",
+				itemCount: 1,
+				lastRefreshedAt: new Date(),
+				generationMetadata: JSON.stringify({
+					version: 3,
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					itemCount: 1,
+					canonicalizationVersion: 1,
+					capability: {
+						domain: "episodes",
+						field: "watchCount",
+						semantics: "lower-bound",
+						operator: "greater_than",
+					},
+					parentPlexGenerationId: "parent-v4",
+					parentMetadataVersion: 4,
+					parentPublicationLevel: "positive-only",
+					parentTargetDigest: "a".repeat(64),
+					episodeDigest: "b".repeat(64),
+					partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+					connectionGeneration: 1,
+					identityGeneration: 1,
+				}),
+			}),
+		];
+		evidenceMocks.getPublishedEpisodeGenerationObservation.mockResolvedValueOnce({
+			available: true,
+			instanceId: "inst-1",
+			evidence: {
+				publicationLevel: "positive-only",
+				completeness: "partial",
+				reasonCodes: ["latest_attempt_partial"],
+			},
+		});
+
+		const body = JSON.parse((await injectAuthenticated("GET", "/pulse")).payload);
+		const item = body.items.find((candidate: { id: string }) =>
+			candidate.id.includes("positive-episode-diagnostic"),
+		);
+
+		expect(item).toMatchObject({
+			id: "cache-partial-positive-episode-diagnostic",
+			detail:
+				"publicationLevel: positive-only; observedItemCount: 1; partialReasons: currentItemsWithoutTmdbMetadata=1",
+		});
+		expect(item.detail).not.toContain("itemCount:");
+	});
+
 	it("reports an opaque active Plex attempt as refreshing without exposing its token", async () => {
 		const token = "in_progress:do-not-expose";
 		cacheStatuses = [

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -47,6 +47,7 @@ import {
 	CleanupMaintenanceConflictError,
 	withCleanupOperationGuard,
 } from "../lib/library-cleanup/cleanup-maintenance-gate.js";
+import type { EpisodePlexWatchEvidence } from "../lib/library-cleanup/episode-scope.js";
 import {
 	type EpisodeExplainEvidence,
 	explainItemAgainstRules,
@@ -1995,7 +1996,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			}
 
 			const tmdbId = extractSeriesTmdbId(cacheItem.data);
-			let watchCount: number | null = null;
+			let watchEvidence: EpisodePlexWatchEvidence[] = [];
 			if (tmdbId !== null) {
 				const instances = await app.prisma.serviceInstance.findMany({
 					where: { userId, enabled: true },
@@ -2013,17 +2014,14 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 						coordinate: { showTmdbId: tmdbId, seasonNumber, episodeNumber },
 					},
 				);
-				const watchEvidence = watchMap.get(
-					episodeCoordinateKey(tmdbId, seasonNumber, episodeNumber),
-				)?.[0];
-				watchCount = watchEvidence?.watchCount ?? null;
+				watchEvidence =
+					watchMap.get(episodeCoordinateKey(tmdbId, seasonNumber, episodeNumber)) ?? [];
 				episodeEvidence = {
 					arrEpisodeId,
-					watchCount,
-					available: watchEvidence !== undefined,
+					watchEvidence,
 				};
 			}
-			episodeEvidence ??= { arrEpisodeId, watchCount, available: false };
+			episodeEvidence ??= { arrEpisodeId, watchEvidence: [] };
 			episodeDisplay = {
 				arrEpisodeId,
 				seasonNumber,

--- a/apps/api/src/routes/plex/__tests__/cache-health.test.ts
+++ b/apps/api/src/routes/plex/__tests__/cache-health.test.ts
@@ -164,6 +164,21 @@ describe("buildCacheHealthItems", () => {
 		expect(items[0]).toMatchObject({ lastResult: "partial", evidence });
 	});
 
+	it("names a V4 partial row count as observedItemCount, never an exact denominator", () => {
+		const evidence = {
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			reasonCodes: [],
+		} satisfies PlexEvidenceSummary;
+		const [item] = buildCacheHealthItems(
+			[makeRow({ itemCount: 7 })],
+			instanceNameMap,
+			baseDateMs,
+			new Map([["inst-1:plex", evidence]]),
+		);
+		expect(item).toMatchObject({ lastResult: "partial", itemCount: null, observedItemCount: 7 });
+	});
+
 	it("reports unavailable Plex evidence as an error instead of a successful empty cache", () => {
 		const evidence = {
 			publicationLevel: "unavailable",

--- a/apps/api/src/routes/plex/__tests__/cache-routes.test.ts
+++ b/apps/api/src/routes/plex/__tests__/cache-routes.test.ts
@@ -93,6 +93,34 @@ describe("POST /api/plex/cache/:instanceId/refresh publication authority", () =>
 		expect(mocks.refresh.mock.calls[0]).not.toContainEqual({ server: "caller-controlled" });
 	});
 
+	it("reports a committed positive-only generation as a successful partial refresh", async () => {
+		mocks.refresh.mockResolvedValue({
+			kind: "positive-observation",
+			complete: false,
+			completedAt: new Date("2026-08-24T12:00:00.000Z"),
+			upserted: 1,
+			errors: 0,
+			errorMessages: [],
+			observation: {
+				partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			},
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/api/plex/cache/plex-1/refresh");
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			success: true,
+			publicationLevel: "positive-only",
+			completeness: "partial",
+			complete: false,
+			observedItemCount: 1,
+			partialReasons: [{ code: "currentItemsWithoutTmdbMetadata", count: 1 }],
+			upserted: 1,
+			errors: 0,
+		});
+	});
+
 	it("returns an actionable sanitized response when preparation cannot publish", async () => {
 		mocks.refresh.mockResolvedValue({
 			complete: false,

--- a/apps/api/src/routes/plex/__tests__/section-routes-authority.test.ts
+++ b/apps/api/src/routes/plex/__tests__/section-routes-authority.test.ts
@@ -123,4 +123,29 @@ describe("GET /api/plex/sections authority", () => {
 		});
 		expect(response.json()).not.toHaveProperty("sections");
 	});
+
+	it("withholds section contents from a current V4 positive-only catalog", async () => {
+		mocks.loadUserSelectedEvidence.mockResolvedValue([
+			{
+				available: true,
+				instanceId: "plex-1",
+				instanceName: "Primary",
+				sections: [{ key: "shows", title: "Shows", type: "show" }],
+				rows: [],
+				evidence: {
+					availability: "current",
+					authority: "positive-only",
+					attemptState: "partial",
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					reasonCodes: ["latest_attempt_partial"],
+				},
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)("GET", "/api/plex/sections");
+
+		expect(response.statusCode).toBe(503);
+		expect(response.json()).not.toHaveProperty("sections");
+	});
 });

--- a/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
+++ b/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
@@ -130,6 +130,22 @@ const unavailable = {
 	evidence: unavailableEvidence,
 };
 
+const positiveOnly = {
+	available: true,
+	instanceId: "plex-1",
+	instanceName: "Primary",
+	rows: [],
+	sections: [],
+	evidence: {
+		availability: "current",
+		authority: "positive-only",
+		attemptState: "partial",
+		publicationLevel: "positive-only",
+		completeness: "partial",
+		reasonCodes: ["latest_attempt_partial"],
+	},
+};
+
 describe("Plex value route evidence contracts", () => {
 	let app: FastifyInstance;
 	let plexInstances: Array<{ id: string }>;
@@ -197,6 +213,36 @@ describe("Plex value route evidence contracts", () => {
 		expect(body).not.toHaveProperty(field);
 		expect(JSON.stringify(body)).not.toContain("in_progress:");
 	});
+
+	it.each([
+		["on-deck", "/api/plex/on-deck", "items"],
+		["recently added", "/api/plex/recently-added", "items"],
+		["collections", "/api/plex/plex-1/collections", "collections"],
+		["labels", "/api/plex/plex-1/labels", "labels"],
+		["collection statistics", "/api/plex/collection-stats", "collections"],
+		["series progress", "/api/plex/series-progress?tmdbIds=1", "progress"],
+		["episode status", "/api/plex/episodes?instanceId=plex-1&showTmdbId=1", "episodes"],
+		["episode completion", "/api/plex/user-episode-completion?tmdbIds=1", "shows"],
+		["watch enrichment", "/api/plex/watch-enrichment?tmdbIds=1&types=movie", "items"],
+	] as const)(
+		"withholds %s exact values from a current V4 generation",
+		async (_name, url, field) => {
+			mocks.loadInstanceEvidence.mockResolvedValue(positiveOnly);
+			mocks.loadInstanceEpisodeEvidence.mockResolvedValue(positiveOnly);
+			mocks.loadInstanceSelectedEpisodeEvidence.mockResolvedValue(positiveOnly);
+			mocks.loadUserEvidence.mockResolvedValue([positiveOnly]);
+			mocks.loadUserSelectedEvidence.mockResolvedValue([positiveOnly]);
+			mocks.scanInstancePolicyEvidence.mockResolvedValue(positiveOnly);
+			mocks.scanUserPolicyEvidence.mockResolvedValue([positiveOnly]);
+
+			const response = await createInjectAuthenticated(app)("GET", url);
+			const body = response.json();
+
+			expect(response.statusCode).toBe(503);
+			expect(body).not.toHaveProperty(field);
+			expect(JSON.stringify(body)).not.toContain('"watchCount":0');
+		},
+	);
 
 	it.each([
 		["on-deck", "/api/plex/on-deck", { items: [], evidence: authoritativeEvidence }],

--- a/apps/api/src/routes/plex/cache-routes.ts
+++ b/apps/api/src/routes/plex/cache-routes.ts
@@ -11,14 +11,14 @@ import { z } from "zod";
 import { requireEnabledInstance } from "../../lib/arr/instance-helpers.js";
 import { AppValidationError } from "../../lib/errors.js";
 import {
-	getPublishedEpisodeGenerationObservation,
-	loadUserGenerationObservations,
-} from "../../lib/plex/plex-persisted-observation-repository.js";
-import {
 	isCurrentAuthoritativePlexEvidence,
 	PlexAuthorityService,
 } from "../../lib/plex/plex-authority-service.js";
 import { requirePlexClient } from "../../lib/plex/plex-helpers.js";
+import {
+	getPublishedEpisodeGenerationObservation,
+	loadUserGenerationObservations,
+} from "../../lib/plex/plex-persisted-observation-repository.js";
 import { refreshOwnedPlexCache } from "../../lib/plex/plex-refresh-orchestration.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { buildCacheHealthItems } from "./lib/cache-health-helpers.js";
@@ -90,12 +90,28 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 				log: request.log,
 			});
 
-			if (!result.complete || !result.completedAt) {
+			const positiveObservation =
+				result.kind === "positive-observation" && result.completedAt && result.observation
+					? result.observation
+					: null;
+			if (!positiveObservation && (!result.complete || !result.completedAt)) {
 				return reply.status(503).send({
 					success: false,
 					upserted: result.upserted,
 					errors: result.errors,
 					error: result.errorMessages[0] ?? "Plex cache refresh did not publish a generation",
+				});
+			}
+			if (positiveObservation) {
+				return reply.send({
+					success: true,
+					publicationLevel: "positive-only",
+					completeness: "partial",
+					complete: false,
+					observedItemCount: result.upserted,
+					partialReasons: positiveObservation.partialReasons,
+					upserted: result.upserted,
+					errors: result.errors,
 				});
 			}
 

--- a/apps/api/src/routes/plex/lib/cache-health-helpers.ts
+++ b/apps/api/src/routes/plex/lib/cache-health-helpers.ts
@@ -98,6 +98,7 @@ export function buildCacheHealthItems(
 							(unavailable ? "Published Plex cache evidence is unavailable" : null)),
 			),
 			itemCount: unavailable || positiveOnly ? null : status.itemCount,
+			...(positiveOnly ? { observedItemCount: status.itemCount } : {}),
 			isStale: now - status.lastRefreshedAt.getTime() > STALE_THRESHOLD_MS,
 			...(evidence ? { evidence } : {}),
 		};

--- a/packages/shared/src/types/plex.ts
+++ b/packages/shared/src/types/plex.ts
@@ -130,6 +130,39 @@ export interface PlexGenerationMetadataV3 {
 	targetCount?: number;
 	targetDigest?: string;
 }
+export type PlexPartialReasonCode =
+	| "currentItemsWithoutTmdbMetadata"
+	| "currentLibraryItemsWithoutRatingKeys"
+	| "historyItemsWithoutUsableMediaKey"
+	| "currentHistoryItemsWithoutMappedMetadata"
+	| "historyItemsWithUnknownAccounts"
+	| "onDeckItemsWithoutMappedMetadata"
+	| "onDeckFetchFailures";
+export interface PlexPartialReason {
+	code: PlexPartialReasonCode;
+	count: number;
+}
+export interface PlexPositiveGenerationMetadataV4 {
+	version: 4;
+	publicationLevel: "positive-only";
+	completeness: "partial";
+	itemCount: number;
+	canonicalizationVersion: 1;
+	sections: PlexGenerationSectionV3[];
+	observedRoots: PlexGenerationDomainRoot[];
+	capabilities: readonly [
+		{
+			domain: "episode-parents";
+			field: "membership";
+			semantics: "observed-targets-only";
+			operators: readonly [];
+		},
+	];
+	targetLedgerVersion: 1;
+	targetCount: number;
+	targetDigest: string;
+	partialReasons: readonly PlexPartialReason[];
+}
 
 // ============================================================================
 // Watch Enrichment (F1)
@@ -337,6 +370,8 @@ export interface PlexAccountsResponse {
 // ============================================================================
 
 export interface CacheHealthItem {
+	/** Partial positive-only generations expose this bounded observed count, never an exact universe count. */
+	observedItemCount?: number;
 	instanceId: string;
 	instanceName: string;
 	cacheType:


### PR DESCRIPTION
## Summary

Publish settled positive-only Plex parent and episode evidence so a simple Sonarr episode rule can act when `plex_watch_count greater_than N` is proven. Missing, zero, equal, and below-threshold evidence remain unknown.

## Related issue

Related to #783

## Scope

- Add strict parent V4 positive-only metadata and episode V3 lower-bound metadata.
- Publish positive observed Show parents and watched episodes through the existing CAS and target-ledger boundary.
- Allow only simple episode `plex_watch_count greater_than N` rules with a finite `N >= 0`.
- Bind preview approval to bounded Plex, Sonarr, file, rule, and generation provenance, then reprove the current episode and live PMS count before execution and retry.
- Report partial publication through cache health and Pulse without exposing an exact item count.
- Keep exact readers, routes, label sync, field options, and Plex mutation authority isolated from partial evidence.

## Non-goals

- Absence, zero, false, non-membership, exact denominators, or percentage authority from partial evidence.
- Less-than, equality, negative thresholds, compound rules, series or movie positive-only cleanup, or Plex mutations.
- Schema changes, per-episode ledgers, durable parent manifests, same-instance duplicate-parent support, Tautulli, connection-test, frontend, `next`, or release work.
- Proving the reporter's exact historical root cause or closing #783.

## Acceptance criteria

- [x] A positive episode lower bound of 2 proves `greater_than 0` and `greater_than 1`.
- [x] Omitted, zero, equal, and below-threshold observations remain unknown and cannot select a cleanup target.
- [x] Preview approval and execution/retry use the same bounded rule shape and safety identities.
- [x] Execution and retry reacquire current Plex authority and require a live PMS count above the approved threshold immediately before Sonarr mutation.
- [x] Exact and mutation consumers fail closed on parent V4 and positive episode V3.
- [x] Partial publication remains atomic and can recover to authoritative V3 after settlement.
- [x] A valid positive episode proof from Plex A remains actionable when Plex B lacks complete exact episode evidence; Plex B remains degraded.
- [x] Preview and Explain share one three-valued episode predicate: qualifying lower bounds are TRUE, non-qualifying partial evidence is UNKNOWN, and complete exact zero is FALSE.
- [x] Independent Plex counts are never summed, and source independence does not weaken shared-Plex execution safety.

## Changes

- Added strict positive-only metadata codecs, publication state transitions, positive episode collection, and dedicated authority readers.
- Added three-valued cleanup evaluation, bounded approval proof, persisted pre-intent validation, and live execution/retry reproof.
- Added exact-consumer isolation and partial cache-health/Pulse diagnostics.
- Added reporter-shaped, CAS, settlement, ambiguity, retry, route, mutation-isolation, and production-data-shape coverage.
- Preserved validated positive episode facts across unrelated exact-source failures and centralized Preview/Explain truth semantics.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable
- [x] New queries use centralized query keys and polling constants, when applicable (N/A: no frontend queries)
- [x] New sensitive displays preserve incognito behavior, when applicable (N/A: no display changes)
- [x] New Prisma queries for user-owned resources include `userId`, when applicable (N/A: no new user-owned resource query)
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable (N/A: no new UI surface)
- [x] User-facing counts are precise rather than proxies, when applicable
- [x] Action links reach the correct page with required parameters, when applicable (N/A: no action-link changes)
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable (N/A: no duplicate UI surface)

Local verification on correction commit `aaeead834e32dfc9d1fb64515c5c57251605ceb8`:

- Prisma generated-client check passed with no drift; its script tests passed 17/17.
- Focused episode scope, Plex prefetch, Explain, shared Plex/Sonarr safety, provider execution authority, publication authority, and positive metadata tests passed 339/339.
- Full tests passed: shared 89/89, web 669/669, API 4,616 passed with 51 skipped across 307 passed and 7 skipped files.
- `CI=true pnpm run validate:pr` passed, including the 53/53 review-contract tests.
- Production build passed.
- Provider-cache heap tests passed 7/7 with 20,000 Plex rows in the policy-read fixture.
- `git diff --check` passed.
- No Prisma schema, generated-client, dependency, or lockfile drift entered the correction.

Real PMS acceptance used disposable `plexinc/pms-docker:1.43.3.10896-cb3ebc72d` state. It verified authoritative V3 settlement, a positive-only V4 subset after unmapped Movie evidence, a positive episode lower bound of 2 with zero siblings omitted, active scan and metadata-refresh publication blockers, and recovery to authoritative V3. The duplicate-parent case uses deterministic repository coverage because creating that real fixture was impractical. The disposable container, data, network attachment, and port were removed afterward.

## Review plan

- Initial broad-reviewed head: coherent pre-commit working-tree snapshot against `5126c58d2392b5ab49085952e981747a462c89d7`
- Consolidated correction head: `5987e56a7204f13c38616269b0cc98d3b40e960b`
- GitHub finding correction head: `276813f967002a98c6273090791cfe85634ff3df`
- Maintainer-directed MDR correction head: `aaeead834e32dfc9d1fb64515c5c57251605ceb8`
- Targeted MDR delta range: `276813f967002a98c6273090791cfe85634ff3df..aaeead834e32dfc9d1fb64515c5c57251605ceb8`
- Material-scope change declared? No
- Independent regression reviewer: cleanup/execution PASS; compatibility PASS
- Independent data-safety reviewer: targeted MDR delta PASS with required answers NO, NO, NO, YES, YES, NO
- GitHub Codex review head: `5987e56a7204f13c38616269b0cc98d3b40e960b`; its P1 was reproduced and fixed at `276813f967002a98c6273090791cfe85634ff3df`
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| PR3-1 | P1 | In scope | Episode refresh could query ledger targets omitted from the observed parent set. | Fixed by restricting refresh targets to observed matched Show parents, with defense-in-depth filtering. | None |
| PR3-2 | P1 | In scope | Exact provider completeness could block a selected positive candidate before its live execution proof. | Fixed with bounded positive provider authority plus persisted pre-intent validation. | None |
| PR3-3 | P2 | In scope | Positive episode V3 could be reported as malformed by cache health and Pulse. | Fixed with an explicit partial observation branch and diagnostic coverage. | None |
| PR3-4 | P1 | In scope | Final positive execution proof copied approval provenance instead of comparing the current chain. | Fixed by matching current generations, digests, source, target, coordinates, rating key, publication time, and observed lower bound before the live count check. | None |
| PR3-5 | P1 | In scope | A collapsed parent row could hide a second same-section ledger target with the same TMDb ID. | Fixed by returning every verified ledger target at the observed Show coordinates, preserving duplicate-parent ambiguity. | None |
| MDR-006 | P1 | contract-violation | Plex A positive evidence was discarded when Plex B lacked a complete exact episode generation. | Fixed by preserving validated per-source positive evidence while retaining degraded diagnostics; shared-Plex execution still fails closed. | None |
| MDR-007 | P2 | contract-violation | Explain read the synthetic `watchCount: 0` instead of positive `lowerBound`, producing FALSE where Preview proved TRUE or required UNKNOWN. | Fixed with one three-valued per-source evaluator used by Preview and Explain; counts are never summed. | None |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain from the local review epoch
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned: verify the merged SHA and keep #783 open for remaining phases


