### PR TITLE
fix(trash-guides): make recovery claims atomic

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/cleanup-run-lease.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	acquireCleanupRunLease,
 	CleanupPolicyMutationConflictError,
+	CleanupRunLeaseLostError,
 	CleanupTopologyMutationConflictError,
 	releaseCleanupRunLease,
 	renewCleanupRunLease,
-	withCleanupTopologyMutationLease,
 	withCleanupPolicyMutationLease,
+	withCleanupTopologyMutationLease,
 } from "../cleanup-executor.js";
 import type { CleanupExecutorDeps } from "../types.js";
 
@@ -184,6 +185,54 @@ describe("library cleanup database run lease", () => {
 			}),
 		).resolves.toBe("created");
 		expect(calls).toEqual(["upsert", "acquire", "mutate", "release"]);
+	});
+
+	it("renews a topology lease through the callback ownership assertion", async () => {
+		const calls: string[] = [];
+		const updateMany = vi.fn(async ({ data }: { data: { runClaimToken?: string | null } }) => {
+			calls.push(
+				data.runClaimToken === null
+					? "release"
+					: typeof data.runClaimToken === "string"
+						? "acquire"
+						: "renew",
+			);
+			return { count: 1 };
+		});
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn(async () => ({ id: "config-1" })),
+				updateMany,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = { warn: vi.fn(), error: vi.fn() } as unknown as CleanupExecutorDeps["log"];
+
+		await withCleanupTopologyMutationLease({ prisma, log }, "user-1", async (runLease) => {
+			await runLease.assertOwnership();
+		});
+
+		expect(calls).toEqual(["acquire", "renew", "release"]);
+	});
+
+	it("fails closed when a topology callback loses lease ownership", async () => {
+		const updateMany = vi
+			.fn()
+			.mockResolvedValueOnce({ count: 1 })
+			.mockResolvedValueOnce({ count: 0 })
+			.mockResolvedValueOnce({ count: 0 });
+		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn(async () => ({ id: "config-1" })),
+				updateMany,
+			},
+		} as unknown as CleanupExecutorDeps["prisma"];
+		const log = { warn: vi.fn(), error: vi.fn() } as unknown as CleanupExecutorDeps["log"];
+
+		await expect(
+			withCleanupTopologyMutationLease({ prisma, log }, "user-1", async (runLease) => {
+				await runLease.assertOwnership();
+			}),
+		).rejects.toBeInstanceOf(CleanupRunLeaseLostError);
 	});
 
 	it("rejects a service topology mutation while cleanup owns the lease", async () => {

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -95,6 +95,7 @@ import {
 	acquireCleanupRunLease,
 	CLEANUP_RUN_LEASE_MS,
 	CleanupRunAlreadyInProgressError,
+	type CleanupRunLease,
 	CleanupRunLeaseLostError,
 	releaseCleanupRunLease,
 	renewCleanupRunLease,
@@ -103,8 +104,8 @@ import {
 import {
 	type EpisodeCleanupCandidate,
 	type EpisodePlexWatchEvidence,
-	evaluateEpisodeWatchCountRule,
 	evaluateEpisodeWatchCountEvidence,
+	evaluateEpisodeWatchCountRule,
 	isSupportedEpisodeCleanupRule,
 	toEpisodeTargetMetadata,
 } from "./episode-scope.js";
@@ -986,7 +987,7 @@ export class CleanupPolicyMutationConflictError extends Error {
 async function withCleanupMutationLease<T>(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
-	mutate: () => Promise<T>,
+	mutate: (runLease: CleanupRunLease) => Promise<T>,
 	conflictError: () => Error,
 	options: {
 		configId?: string;
@@ -998,7 +999,7 @@ async function withCleanupMutationLease<T>(
 		? withExclusiveCleanupOperationGuard
 		: withCleanupOperationGuard;
 	return await runWithOperationGuard(async () => {
-		const { prisma, log } = deps;
+		const { prisma } = deps;
 		// Ensure the per-user coordination row exists when the caller does not
 		// already have its ID. This closes the initialization race between a
 		// cleanup-sensitive write and the first cleanup run.
@@ -1010,27 +1011,20 @@ async function withCleanupMutationLease<T>(
 					create: { userId },
 					select: { id: true },
 				});
-		const runClaimToken = await acquireCleanupRunLease(prisma, userId, config.id);
-		if (!runClaimToken) throw conflictError();
+		let runLease: CleanupRunLease;
+		try {
+			runLease = await startCleanupRunLease(deps, userId, config.id, {
+				leaseRowMayBeDeleted: options.leaseRowMayBeDeleted,
+			});
+		} catch (error) {
+			if (error instanceof CleanupRunAlreadyInProgressError) throw conflictError();
+			throw error;
+		}
 
 		try {
-			return await mutate();
+			return await mutate(runLease);
 		} finally {
-			await releaseCleanupRunLease(prisma, userId, config.id, runClaimToken)
-				.then((released) => {
-					if (!released && !options.leaseRowMayBeDeleted) {
-						log.warn(
-							{ configId: config.id },
-							"Service topology mutation finished after its cleanup lease ownership changed",
-						);
-					}
-				})
-				.catch((error) => {
-					log.error(
-						{ err: error, configId: config.id },
-						"Service topology mutation finished but its cleanup lease could not be released",
-					);
-				});
+			await runLease.release();
 		}
 	});
 }
@@ -1038,7 +1032,7 @@ async function withCleanupMutationLease<T>(
 export async function withCleanupTopologyMutationLease<T>(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
-	mutate: () => Promise<T>,
+	mutate: (runLease: CleanupRunLease) => Promise<T>,
 	options: { leaseRowMayBeDeleted?: boolean } = {},
 ): Promise<T> {
 	return await withCleanupMutationLease(
@@ -1054,7 +1048,7 @@ export async function withCleanupTopologyMutationLease<T>(
 export async function withExclusiveCleanupTopologyMutationLease<T>(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
-	mutate: () => Promise<T>,
+	mutate: (runLease: CleanupRunLease) => Promise<T>,
 	options: { leaseRowMayBeDeleted?: boolean } = {},
 ): Promise<T> {
 	return await withCleanupMutationLease(
@@ -1069,7 +1063,7 @@ export async function withExclusiveCleanupTopologyMutationLease<T>(
 export async function withCleanupPolicyMutationLease<T>(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
-	mutate: () => Promise<T>,
+	mutate: (runLease: CleanupRunLease) => Promise<T>,
 	options: { configId?: string } = {},
 ): Promise<T> {
 	return await withCleanupMutationLease(

--- a/apps/api/src/lib/library-cleanup/cleanup-run-lease.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-run-lease.ts
@@ -78,6 +78,7 @@ export async function startCleanupRunLease(
 	deps: Pick<CleanupExecutorDeps, "prisma" | "log">,
 	userId: string,
 	configId: string,
+	options: { leaseRowMayBeDeleted?: boolean } = {},
 ): Promise<CleanupRunLease> {
 	const { prisma, log } = deps;
 	const runClaimToken = await acquireCleanupRunLease(prisma, userId, configId);
@@ -115,7 +116,7 @@ export async function startCleanupRunLease(
 			clearInterval(heartbeat);
 			await releaseCleanupRunLease(prisma, userId, configId, runClaimToken)
 				.then((released) => {
-					if (!released) {
+					if (!released && !options.leaseRowMayBeDeleted) {
 						log.warn(
 							{ configId },
 							"Library cleanup finished after its database run lease ownership changed",

--- a/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts
@@ -21,7 +21,32 @@ const ids = {
 	syncA: `recovery-claim-sync-a-${runId}`,
 	syncB: `recovery-claim-sync-b-${runId}`,
 	deployment: `recovery-claim-deployment-${runId}`,
+	deploymentLater: `recovery-claim-deployment-z-${runId}`,
 };
+const syncRecoveryStateSelect = {
+	id: true,
+	userId: true,
+	instanceId: true,
+	templateId: true,
+	backupId: true,
+	status: true,
+	rolledBack: true,
+	rollbackStatus: true,
+	rollbackAttemptedAt: true,
+	rollbackProgress: true,
+} as const;
+const deploymentRecoveryStateSelect = {
+	id: true,
+	userId: true,
+	instanceId: true,
+	templateId: true,
+	backupId: true,
+	status: true,
+	rolledBack: true,
+	undeployStatus: true,
+	undeployAttemptedAt: true,
+	undeployProgress: true,
+} as const;
 
 runDatabaseTests("recovery history group claim Prisma contract", () => {
 	let prisma: PrismaClientInstance;
@@ -87,9 +112,9 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 				backupId: ids.backup,
 			})),
 		});
-		await prisma.templateDeploymentHistory.create({
-			data: {
-				id: ids.deployment,
+		await prisma.templateDeploymentHistory.createMany({
+			data: [ids.deployment, ids.deploymentLater].map((id) => ({
+				id,
 				templateId: ids.template,
 				instanceId: ids.instance,
 				userId: ids.user,
@@ -97,7 +122,7 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 				status: "SUCCESS",
 				backupId: ids.backup,
 				canRollback: true,
-			},
+			})),
 		});
 	});
 
@@ -106,6 +131,8 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 			prisma.trashSyncHistory.updateMany({
 				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
 				data: {
+					status: "SUCCESS",
+					backupId: ids.backup,
 					rolledBack: false,
 					rolledBackAt: null,
 					rollbackStatus: null,
@@ -114,9 +141,13 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 				},
 			}),
 			prisma.templateDeploymentHistory.updateMany({
-				where: { id: ids.deployment, userId: ids.user },
+				where: {
+					id: { in: [ids.deployment, ids.deploymentLater] },
+					userId: ids.user,
+				},
 				data: {
 					status: "SUCCESS",
+					backupId: ids.backup,
 					rolledBack: false,
 					rolledBackAt: null,
 					rolledBackBy: null,
@@ -131,7 +162,10 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 	afterAll(async () => {
 		if (prisma) {
 			await prisma.templateDeploymentHistory.deleteMany({
-				where: { id: ids.deployment, userId: ids.user },
+				where: {
+					id: { in: [ids.deployment, ids.deploymentLater] },
+					userId: ids.user,
+				},
 			});
 			await prisma.trashSyncHistory.deleteMany({
 				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
@@ -151,27 +185,18 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 		const syncStates = await prisma.trashSyncHistory.findMany({
 			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
 			orderBy: { id: "asc" },
-			select: {
-				id: true,
-				rolledBack: true,
-				rollbackStatus: true,
-				rollbackAttemptedAt: true,
-				rollbackProgress: true,
-			},
+			select: syncRecoveryStateSelect,
 		});
-		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
-			where: { id: ids.deployment, userId: ids.user },
-			select: {
-				id: true,
-				status: true,
-				rolledBack: true,
-				undeployStatus: true,
-				undeployAttemptedAt: true,
-				undeployProgress: true,
+		const deploymentStates = await prisma.templateDeploymentHistory.findMany({
+			where: {
+				id: { in: [ids.deployment, ids.deploymentLater] },
+				userId: ids.user,
 			},
+			orderBy: { id: "asc" },
+			select: deploymentRecoveryStateSelect,
 		});
 		await prisma.templateDeploymentHistory.update({
-			where: { id: ids.deployment },
+			where: { id: ids.deploymentLater },
 			data: {
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: new Date("2026-08-08T11:00:00.000Z"),
@@ -182,13 +207,28 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 			prisma,
 			ids.user,
 			syncStates,
-			[deploymentState],
+			deploymentStates,
 			new Date("2026-08-08T12:00:00.000Z"),
 		);
 
 		expect(claimed).toBe(false);
+		expect(
+			await prisma.templateDeploymentHistory.findMany({
+				where: { id: { in: [ids.deployment, ids.deploymentLater] }, userId: ids.user },
+				orderBy: { id: "asc" },
+				select: { id: true, undeployStatus: true, undeployAttemptedAt: true },
+			}),
+		).toEqual([
+			{ id: ids.deployment, undeployStatus: null, undeployAttemptedAt: null },
+			{
+				id: ids.deploymentLater,
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: new Date("2026-08-08T11:00:00.000Z"),
+			},
+		]);
 		const syncRows = await prisma.trashSyncHistory.findMany({
 			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
 			select: { rollbackStatus: true, rollbackAttemptedAt: true },
 		});
 		expect(syncRows).toEqual([
@@ -200,25 +240,12 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 	it("rolls back an undeploy target claim when a later sync CAS misses", async () => {
 		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
 			where: { id: ids.deployment, userId: ids.user },
-			select: {
-				id: true,
-				status: true,
-				rolledBack: true,
-				undeployStatus: true,
-				undeployAttemptedAt: true,
-				undeployProgress: true,
-			},
+			select: deploymentRecoveryStateSelect,
 		});
 		const syncStates = await prisma.trashSyncHistory.findMany({
 			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
 			orderBy: { id: "asc" },
-			select: {
-				id: true,
-				rolledBack: true,
-				rollbackStatus: true,
-				rollbackAttemptedAt: true,
-				rollbackProgress: true,
-			},
+			select: syncRecoveryStateSelect,
 		});
 		await prisma.trashSyncHistory.updateMany({
 			where: { id: ids.syncB, userId: ids.user },
@@ -251,30 +278,81 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 		).toEqual({ rollbackStatus: null, rollbackAttemptedAt: null });
 	});
 
+	it("rejects a claim when a snapshotted sync status changes", async () => {
+		const syncStates = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
+			select: syncRecoveryStateSelect,
+		});
+		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+			where: { id: ids.deployment, userId: ids.user },
+			select: deploymentRecoveryStateSelect,
+		});
+		await prisma.trashSyncHistory.update({
+			where: { id: ids.syncB },
+			data: { status: "FAILED" },
+		});
+
+		await expect(
+			claimRollbackRecoveryGroup(
+				prisma,
+				ids.user,
+				syncStates,
+				[deploymentState],
+				new Date("2026-08-08T12:00:00.000Z"),
+			),
+		).resolves.toBe(false);
+		expect(
+			await prisma.templateDeploymentHistory.findUniqueOrThrow({
+				where: { id: ids.deployment },
+				select: { undeployStatus: true },
+			}),
+		).toEqual({ undeployStatus: null });
+	});
+
+	it("rejects a claim when a snapshotted backup grouping changes", async () => {
+		const syncStates = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
+			select: syncRecoveryStateSelect,
+		});
+		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+			where: { id: ids.deployment, userId: ids.user },
+			select: deploymentRecoveryStateSelect,
+		});
+		await prisma.templateDeploymentHistory.update({
+			where: { id: ids.deployment },
+			data: { backupId: null },
+		});
+
+		await expect(
+			claimUndeployRecoveryGroup(
+				prisma,
+				ids.user,
+				deploymentState,
+				syncStates,
+				new Date("2026-08-08T12:00:00.000Z"),
+			),
+		).resolves.toBe(false);
+		expect(
+			await prisma.trashSyncHistory.findMany({
+				where: { id: { in: [ids.syncA, ids.syncB] } },
+				select: { rollbackStatus: true },
+			}),
+		).toEqual([{ rollbackStatus: null }, { rollbackStatus: null }]);
+	});
+
 	it.runIf(isPostgresDatabase)(
 		"allows exactly one concurrent claimant across two PostgreSQL clients",
 		async () => {
 			const syncStates = await prisma.trashSyncHistory.findMany({
 				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
 				orderBy: { id: "asc" },
-				select: {
-					id: true,
-					rolledBack: true,
-					rollbackStatus: true,
-					rollbackAttemptedAt: true,
-					rollbackProgress: true,
-				},
+				select: syncRecoveryStateSelect,
 			});
 			const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
 				where: { id: ids.deployment, userId: ids.user },
-				select: {
-					id: true,
-					status: true,
-					rolledBack: true,
-					undeployStatus: true,
-					undeployAttemptedAt: true,
-					undeployProgress: true,
-				},
+				select: deploymentRecoveryStateSelect,
 			});
 			const attemptedAtA = new Date("2026-08-08T12:30:00.000Z");
 			const attemptedAtB = new Date("2026-08-08T12:31:00.000Z");
@@ -311,28 +389,68 @@ runDatabaseTests("recovery history group claim Prisma contract", () => {
 		},
 	);
 
+	it.runIf(isPostgresDatabase)(
+		"serializes concurrent undeploy and rollback entrypoints with opposite input order",
+		async () => {
+			const syncStates = await prisma.trashSyncHistory.findMany({
+				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+				orderBy: { id: "asc" },
+				select: syncRecoveryStateSelect,
+			});
+			const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+				where: { id: ids.deployment, userId: ids.user },
+				select: deploymentRecoveryStateSelect,
+			});
+			const undeployAttemptedAt = new Date("2026-08-08T12:40:00.000Z");
+			const rollbackAttemptedAt = new Date("2026-08-08T12:41:00.000Z");
+
+			const results = await Promise.all([
+				claimUndeployRecoveryGroup(
+					prisma,
+					ids.user,
+					deploymentState,
+					[...syncStates].reverse(),
+					undeployAttemptedAt,
+				),
+				claimRollbackRecoveryGroup(
+					peerPrisma,
+					ids.user,
+					syncStates,
+					[deploymentState],
+					rollbackAttemptedAt,
+				),
+			]);
+
+			expect(results.filter(Boolean)).toHaveLength(1);
+			const winningAttemptedAt = results[0] ? undeployAttemptedAt : rollbackAttemptedAt;
+			expect(
+				await prisma.templateDeploymentHistory.findUniqueOrThrow({
+					where: { id: ids.deployment },
+					select: { undeployStatus: true, undeployAttemptedAt: true },
+				}),
+			).toEqual({ undeployStatus: "IN_PROGRESS", undeployAttemptedAt: winningAttemptedAt });
+			expect(
+				await prisma.trashSyncHistory.findMany({
+					where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+					orderBy: { id: "asc" },
+					select: { rollbackStatus: true, rollbackAttemptedAt: true },
+				}),
+			).toEqual([
+				{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: winningAttemptedAt },
+				{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: winningAttemptedAt },
+			]);
+		},
+	);
+
 	it("claims an undeploy target and every paired sync with one timestamp", async () => {
 		const syncStates = await prisma.trashSyncHistory.findMany({
 			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
 			orderBy: { id: "asc" },
-			select: {
-				id: true,
-				rolledBack: true,
-				rollbackStatus: true,
-				rollbackAttemptedAt: true,
-				rollbackProgress: true,
-			},
+			select: syncRecoveryStateSelect,
 		});
 		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
 			where: { id: ids.deployment, userId: ids.user },
-			select: {
-				id: true,
-				status: true,
-				rolledBack: true,
-				undeployStatus: true,
-				undeployAttemptedAt: true,
-				undeployProgress: true,
-			},
+			select: deploymentRecoveryStateSelect,
 		});
 		const attemptedAt = new Date("2026-08-08T13:00:00.000Z");
 

--- a/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createTestPgClient, createTestPrismaClient } from "../../__tests__/test-prisma.js";
+import type { PrismaClientInstance } from "../../prisma.js";
+import {
+	claimRollbackRecoveryGroup,
+	claimUndeployRecoveryGroup,
+} from "../recovery-history-claim.js";
+
+const databaseUrl = process.env.RECOVERY_CLAIM_DATABASE_URL;
+const isPostgresDatabase = Boolean(databaseUrl && /^postgres(ql)?:\/\//i.test(databaseUrl));
+const runDatabaseTests =
+	process.env.INTEGRATION_TESTS === "1" && databaseUrl ? describe : describe.skip;
+
+const runId = randomUUID();
+const ids = {
+	user: `recovery-claim-user-${runId}`,
+	instance: `recovery-claim-instance-${runId}`,
+	template: `recovery-claim-template-${runId}`,
+	backup: `recovery-claim-backup-${runId}`,
+	syncA: `recovery-claim-sync-a-${runId}`,
+	syncB: `recovery-claim-sync-b-${runId}`,
+	deployment: `recovery-claim-deployment-${runId}`,
+};
+
+runDatabaseTests("recovery history group claim Prisma contract", () => {
+	let prisma: PrismaClientInstance;
+	let peerPrisma: PrismaClientInstance;
+	let cleanupDatabaseClient: (() => Promise<void>) | undefined;
+	let cleanupPeerDatabaseClient: (() => Promise<void>) | undefined;
+
+	beforeAll(async () => {
+		if (!databaseUrl) throw new Error("RECOVERY_CLAIM_DATABASE_URL is required");
+		if (/^postgres(ql)?:\/\//i.test(databaseUrl)) {
+			const client = await createTestPgClient(databaseUrl);
+			const peerClient = await createTestPgClient(databaseUrl);
+			prisma = client.prisma;
+			peerPrisma = peerClient.prisma;
+			cleanupDatabaseClient = client.cleanup;
+			cleanupPeerDatabaseClient = peerClient.cleanup;
+		} else {
+			const sqlitePath = databaseUrl.replace(/^file:/, "");
+			prisma = createTestPrismaClient(sqlitePath);
+			peerPrisma = createTestPrismaClient(sqlitePath);
+			cleanupDatabaseClient = () => prisma.$disconnect();
+			cleanupPeerDatabaseClient = () => peerPrisma.$disconnect();
+		}
+
+		await prisma.user.create({ data: { id: ids.user, username: ids.user } });
+		await prisma.serviceInstance.create({
+			data: {
+				id: ids.instance,
+				userId: ids.user,
+				service: "SONARR",
+				label: "Recovery claim Sonarr",
+				baseUrl: "http://recovery-claim-sonarr.test:8989",
+				encryptedApiKey: "synthetic-encrypted-api-key",
+				encryptionIv: "synthetic-encryption-iv",
+			},
+		});
+		await prisma.trashTemplate.create({
+			data: {
+				id: ids.template,
+				userId: ids.user,
+				name: "Recovery claim template",
+				serviceType: "SONARR",
+				configData: "{}",
+			},
+		});
+		await prisma.trashBackup.create({
+			data: {
+				id: ids.backup,
+				instanceId: ids.instance,
+				userId: ids.user,
+				backupData: "{}",
+			},
+		});
+		await prisma.trashSyncHistory.createMany({
+			data: [ids.syncA, ids.syncB].map((id) => ({
+				id,
+				instanceId: ids.instance,
+				templateId: ids.template,
+				userId: ids.user,
+				syncType: "MANUAL",
+				status: "SUCCESS",
+				appliedConfigs: "[]",
+				backupId: ids.backup,
+			})),
+		});
+		await prisma.templateDeploymentHistory.create({
+			data: {
+				id: ids.deployment,
+				templateId: ids.template,
+				instanceId: ids.instance,
+				userId: ids.user,
+				deployedBy: ids.user,
+				status: "SUCCESS",
+				backupId: ids.backup,
+				canRollback: true,
+			},
+		});
+	});
+
+	beforeEach(async () => {
+		await prisma.$transaction([
+			prisma.trashSyncHistory.updateMany({
+				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+				data: {
+					rolledBack: false,
+					rolledBackAt: null,
+					rollbackStatus: null,
+					rollbackAttemptedAt: null,
+					rollbackProgress: null,
+				},
+			}),
+			prisma.templateDeploymentHistory.updateMany({
+				where: { id: ids.deployment, userId: ids.user },
+				data: {
+					status: "SUCCESS",
+					rolledBack: false,
+					rolledBackAt: null,
+					rolledBackBy: null,
+					undeployStatus: null,
+					undeployAttemptedAt: null,
+					undeployProgress: null,
+				},
+			}),
+		]);
+	});
+
+	afterAll(async () => {
+		if (prisma) {
+			await prisma.templateDeploymentHistory.deleteMany({
+				where: { id: ids.deployment, userId: ids.user },
+			});
+			await prisma.trashSyncHistory.deleteMany({
+				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			});
+			await prisma.trashBackup.deleteMany({ where: { id: ids.backup, userId: ids.user } });
+			await prisma.trashTemplate.deleteMany({ where: { id: ids.template, userId: ids.user } });
+			await prisma.serviceInstance.deleteMany({
+				where: { id: ids.instance, userId: ids.user },
+			});
+			await prisma.user.deleteMany({ where: { id: ids.user } });
+		}
+		await cleanupPeerDatabaseClient?.();
+		await cleanupDatabaseClient?.();
+	});
+
+	it("rolls back earlier peer claims when a later deployment CAS misses", async () => {
+		const syncStates = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
+			select: {
+				id: true,
+				rolledBack: true,
+				rollbackStatus: true,
+				rollbackAttemptedAt: true,
+				rollbackProgress: true,
+			},
+		});
+		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+			where: { id: ids.deployment, userId: ids.user },
+			select: {
+				id: true,
+				status: true,
+				rolledBack: true,
+				undeployStatus: true,
+				undeployAttemptedAt: true,
+				undeployProgress: true,
+			},
+		});
+		await prisma.templateDeploymentHistory.update({
+			where: { id: ids.deployment },
+			data: {
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: new Date("2026-08-08T11:00:00.000Z"),
+			},
+		});
+
+		const claimed = await claimRollbackRecoveryGroup(
+			prisma,
+			ids.user,
+			syncStates,
+			[deploymentState],
+			new Date("2026-08-08T12:00:00.000Z"),
+		);
+
+		expect(claimed).toBe(false);
+		const syncRows = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			select: { rollbackStatus: true, rollbackAttemptedAt: true },
+		});
+		expect(syncRows).toEqual([
+			{ rollbackStatus: null, rollbackAttemptedAt: null },
+			{ rollbackStatus: null, rollbackAttemptedAt: null },
+		]);
+	});
+
+	it("rolls back an undeploy target claim when a later sync CAS misses", async () => {
+		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+			where: { id: ids.deployment, userId: ids.user },
+			select: {
+				id: true,
+				status: true,
+				rolledBack: true,
+				undeployStatus: true,
+				undeployAttemptedAt: true,
+				undeployProgress: true,
+			},
+		});
+		const syncStates = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
+			select: {
+				id: true,
+				rolledBack: true,
+				rollbackStatus: true,
+				rollbackAttemptedAt: true,
+				rollbackProgress: true,
+			},
+		});
+		await prisma.trashSyncHistory.updateMany({
+			where: { id: ids.syncB, userId: ids.user },
+			data: {
+				rollbackStatus: "IN_PROGRESS",
+				rollbackAttemptedAt: new Date("2026-08-08T11:30:00.000Z"),
+			},
+		});
+
+		const claimed = await claimUndeployRecoveryGroup(
+			prisma,
+			ids.user,
+			deploymentState,
+			syncStates,
+			new Date("2026-08-08T12:00:00.000Z"),
+		);
+
+		expect(claimed).toBe(false);
+		expect(
+			await prisma.templateDeploymentHistory.findFirstOrThrow({
+				where: { id: ids.deployment, userId: ids.user },
+				select: { undeployStatus: true, undeployAttemptedAt: true },
+			}),
+		).toEqual({ undeployStatus: null, undeployAttemptedAt: null });
+		expect(
+			await prisma.trashSyncHistory.findFirstOrThrow({
+				where: { id: ids.syncA, userId: ids.user },
+				select: { rollbackStatus: true, rollbackAttemptedAt: true },
+			}),
+		).toEqual({ rollbackStatus: null, rollbackAttemptedAt: null });
+	});
+
+	it.runIf(isPostgresDatabase)(
+		"allows exactly one concurrent claimant across two PostgreSQL clients",
+		async () => {
+			const syncStates = await prisma.trashSyncHistory.findMany({
+				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+				orderBy: { id: "asc" },
+				select: {
+					id: true,
+					rolledBack: true,
+					rollbackStatus: true,
+					rollbackAttemptedAt: true,
+					rollbackProgress: true,
+				},
+			});
+			const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+				where: { id: ids.deployment, userId: ids.user },
+				select: {
+					id: true,
+					status: true,
+					rolledBack: true,
+					undeployStatus: true,
+					undeployAttemptedAt: true,
+					undeployProgress: true,
+				},
+			});
+			const attemptedAtA = new Date("2026-08-08T12:30:00.000Z");
+			const attemptedAtB = new Date("2026-08-08T12:31:00.000Z");
+
+			const results = await Promise.all([
+				claimRollbackRecoveryGroup(prisma, ids.user, syncStates, [deploymentState], attemptedAtA),
+				claimRollbackRecoveryGroup(
+					peerPrisma,
+					ids.user,
+					syncStates,
+					[deploymentState],
+					attemptedAtB,
+				),
+			]);
+
+			expect(results.filter(Boolean)).toHaveLength(1);
+			const winningAttemptedAt = results[0] ? attemptedAtA : attemptedAtB;
+			expect(
+				await prisma.trashSyncHistory.findMany({
+					where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+					orderBy: { id: "asc" },
+					select: { rollbackStatus: true, rollbackAttemptedAt: true },
+				}),
+			).toEqual([
+				{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: winningAttemptedAt },
+				{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: winningAttemptedAt },
+			]);
+			expect(
+				await prisma.templateDeploymentHistory.findFirstOrThrow({
+					where: { id: ids.deployment, userId: ids.user },
+					select: { undeployStatus: true, undeployAttemptedAt: true },
+				}),
+			).toEqual({ undeployStatus: "IN_PROGRESS", undeployAttemptedAt: winningAttemptedAt });
+		},
+	);
+
+	it("claims an undeploy target and every paired sync with one timestamp", async () => {
+		const syncStates = await prisma.trashSyncHistory.findMany({
+			where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+			orderBy: { id: "asc" },
+			select: {
+				id: true,
+				rolledBack: true,
+				rollbackStatus: true,
+				rollbackAttemptedAt: true,
+				rollbackProgress: true,
+			},
+		});
+		const deploymentState = await prisma.templateDeploymentHistory.findFirstOrThrow({
+			where: { id: ids.deployment, userId: ids.user },
+			select: {
+				id: true,
+				status: true,
+				rolledBack: true,
+				undeployStatus: true,
+				undeployAttemptedAt: true,
+				undeployProgress: true,
+			},
+		});
+		const attemptedAt = new Date("2026-08-08T13:00:00.000Z");
+
+		const claimed = await claimUndeployRecoveryGroup(
+			prisma,
+			ids.user,
+			deploymentState,
+			syncStates,
+			attemptedAt,
+		);
+
+		expect(claimed).toBe(true);
+		expect(
+			await prisma.templateDeploymentHistory.findUniqueOrThrow({
+				where: { id: ids.deployment },
+				select: { undeployStatus: true, undeployAttemptedAt: true },
+			}),
+		).toEqual({ undeployStatus: "IN_PROGRESS", undeployAttemptedAt: attemptedAt });
+		expect(
+			await prisma.trashSyncHistory.findMany({
+				where: { id: { in: [ids.syncA, ids.syncB] }, userId: ids.user },
+				orderBy: { id: "asc" },
+				select: { rollbackStatus: true, rollbackAttemptedAt: true },
+			}),
+		).toEqual([
+			{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: attemptedAt },
+			{ rollbackStatus: "IN_PROGRESS", rollbackAttemptedAt: attemptedAt },
+		]);
+	});
+});

--- a/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/recovery-history-claim.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrismaClientInstance } from "../../prisma.js";
+import {
+	claimRollbackRecoveryGroup,
+	type DeploymentRecoveryState,
+	mutateClaimedRecoveryGroup,
+	type SyncRecoveryState,
+} from "../recovery-history-claim.js";
+
+const userId = "recovery-user";
+const attemptedAt = new Date("2026-08-26T12:00:00.000Z");
+
+function deployment(id: string): DeploymentRecoveryState {
+	return {
+		id,
+		userId,
+		instanceId: "instance-1",
+		templateId: "template-1",
+		backupId: "backup-1",
+		status: "SUCCESS",
+		rolledBack: false,
+		undeployStatus: null,
+		undeployAttemptedAt: null,
+		undeployProgress: null,
+	};
+}
+
+function sync(id: string): SyncRecoveryState {
+	return {
+		id,
+		userId,
+		instanceId: "instance-1",
+		templateId: "template-1",
+		backupId: "backup-1",
+		status: "SUCCESS",
+		rolledBack: false,
+		rollbackStatus: null,
+		rollbackAttemptedAt: null,
+		rollbackProgress: null,
+	};
+}
+
+function prismaRecorder(calls: string[]) {
+	const deploymentUpdateMany = vi.fn(async ({ where }: { where: { id: string } }) => {
+		calls.push(`deployment:${where.id}`);
+		return { count: 1 };
+	});
+	const syncUpdateMany = vi.fn(async ({ where }: { where: { id: string } }) => {
+		calls.push(`sync:${where.id}`);
+		return { count: 1 };
+	});
+	const transactionClient = {
+		templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+		trashSyncHistory: { updateMany: syncUpdateMany },
+	};
+	const prisma = {
+		$transaction: vi.fn(async (callback) => callback(transactionClient)),
+	} as unknown as PrismaClientInstance;
+	return { prisma, deploymentUpdateMany, syncUpdateMany };
+}
+
+describe("recovery history claim ordering", () => {
+	it("rejects terminal deployment and sync snapshots before opening a transaction", async () => {
+		const calls: string[] = [];
+		const { prisma } = prismaRecorder(calls);
+		const terminalDeployment = { ...deployment("deployment-a"), rolledBack: true };
+		const terminalSync = { ...sync("sync-a"), rolledBack: true };
+
+		await expect(
+			claimRollbackRecoveryGroup(
+				prisma,
+				userId,
+				[sync("sync-current")],
+				[terminalDeployment],
+				attemptedAt,
+			),
+		).resolves.toBe(false);
+		await expect(
+			claimRollbackRecoveryGroup(
+				prisma,
+				userId,
+				[terminalSync],
+				[deployment("deployment-current")],
+				attemptedAt,
+			),
+		).resolves.toBe(false);
+
+		expect(prisma.$transaction).not.toHaveBeenCalled();
+		expect(calls).toEqual([]);
+	});
+
+	it("claims deployment rows before sync rows, sorts IDs, and CASes the full topology", async () => {
+		const calls: string[] = [];
+		const { prisma, deploymentUpdateMany, syncUpdateMany } = prismaRecorder(calls);
+
+		await expect(
+			claimRollbackRecoveryGroup(
+				prisma,
+				userId,
+				[sync("sync-z"), sync("sync-a")],
+				[deployment("deployment-z"), deployment("deployment-a")],
+				attemptedAt,
+			),
+		).resolves.toBe(true);
+
+		expect(calls).toEqual([
+			"deployment:deployment-a",
+			"deployment:deployment-z",
+			"sync:sync-a",
+			"sync:sync-z",
+		]);
+		expect(deploymentUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					userId,
+					instanceId: "instance-1",
+					templateId: "template-1",
+					backupId: "backup-1",
+					status: "SUCCESS",
+				}),
+			}),
+		);
+		expect(syncUpdateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({
+					userId,
+					instanceId: "instance-1",
+					templateId: "template-1",
+					backupId: "backup-1",
+					status: "SUCCESS",
+				}),
+			}),
+		);
+	});
+
+	it("uses the same canonical order for claimed progress and terminal transitions", async () => {
+		const calls: string[] = [];
+		const { prisma } = prismaRecorder(calls);
+
+		await mutateClaimedRecoveryGroup(
+			prisma,
+			userId,
+			[deployment("deployment-z"), deployment("deployment-a")],
+			[sync("sync-z"), sync("sync-a")],
+			attemptedAt,
+			{
+				deploymentData: () => ({ undeployStatus: "COMPLETED" }),
+				syncData: () => ({ rollbackStatus: "COMPLETED" }),
+				conflictMessage: "claim changed",
+			},
+		);
+
+		expect(calls).toEqual([
+			"deployment:deployment-a",
+			"deployment:deployment-z",
+			"sync:sync-a",
+			"sync:sync-z",
+		]);
+	});
+});

--- a/apps/api/src/lib/trash-guides/recovery-history-claim.ts
+++ b/apps/api/src/lib/trash-guides/recovery-history-claim.ts
@@ -1,0 +1,124 @@
+import type { PrismaClientInstance } from "../prisma.js";
+
+export interface SyncRecoveryState {
+	id: string;
+	rolledBack: boolean;
+	rollbackStatus: string | null;
+	rollbackAttemptedAt: Date | null;
+	rollbackProgress: string | null;
+}
+
+export interface DeploymentRecoveryState {
+	id: string;
+	status: string;
+	rolledBack: boolean;
+	undeployStatus: string | null;
+	undeployAttemptedAt: Date | null;
+	undeployProgress: string | null;
+}
+
+class RecoveryHistoryConflictError extends Error {}
+
+export async function claimUndeployRecoveryGroup(
+	prisma: PrismaClientInstance,
+	userId: string,
+	deployment: DeploymentRecoveryState,
+	pairedSyncs: SyncRecoveryState[],
+	attemptedAt: Date,
+): Promise<boolean> {
+	try {
+		await prisma.$transaction(async (tx) => {
+			const deploymentClaim = await tx.templateDeploymentHistory.updateMany({
+				where: {
+					id: deployment.id,
+					userId,
+					status: deployment.status,
+					rolledBack: false,
+					undeployStatus: deployment.undeployStatus,
+					undeployAttemptedAt: deployment.undeployAttemptedAt,
+					undeployProgress: deployment.undeployProgress,
+				},
+				data: {
+					undeployStatus: "IN_PROGRESS",
+					undeployAttemptedAt: attemptedAt,
+				},
+			});
+			if (deploymentClaim.count !== 1) throw new RecoveryHistoryConflictError();
+
+			for (const sync of pairedSyncs) {
+				const syncClaim = await tx.trashSyncHistory.updateMany({
+					where: {
+						id: sync.id,
+						userId,
+						rolledBack: false,
+						rollbackStatus: sync.rollbackStatus,
+						rollbackAttemptedAt: sync.rollbackAttemptedAt,
+						rollbackProgress: sync.rollbackProgress,
+					},
+					data: {
+						rollbackStatus: "IN_PROGRESS",
+						rollbackAttemptedAt: attemptedAt,
+					},
+				});
+				if (syncClaim.count !== 1) throw new RecoveryHistoryConflictError();
+			}
+		});
+		return true;
+	} catch (error) {
+		if (error instanceof RecoveryHistoryConflictError) return false;
+		throw error;
+	}
+}
+
+export async function claimRollbackRecoveryGroup(
+	prisma: PrismaClientInstance,
+	userId: string,
+	pairedSyncs: SyncRecoveryState[],
+	pairedDeployments: DeploymentRecoveryState[],
+	attemptedAt: Date,
+): Promise<boolean> {
+	try {
+		await prisma.$transaction(async (tx) => {
+			for (const sync of pairedSyncs) {
+				const syncClaim = await tx.trashSyncHistory.updateMany({
+					where: {
+						id: sync.id,
+						userId,
+						rolledBack: false,
+						rollbackStatus: sync.rollbackStatus,
+						rollbackAttemptedAt: sync.rollbackAttemptedAt,
+						rollbackProgress: sync.rollbackProgress,
+					},
+					data: {
+						rollbackStatus: "IN_PROGRESS",
+						rollbackAttemptedAt: attemptedAt,
+					},
+				});
+				if (syncClaim.count !== 1) throw new RecoveryHistoryConflictError();
+			}
+
+			for (const deployment of pairedDeployments) {
+				const deploymentClaim = await tx.templateDeploymentHistory.updateMany({
+					where: {
+						id: deployment.id,
+						userId,
+						status: deployment.status,
+						rolledBack: false,
+						undeployStatus: deployment.undeployStatus,
+						undeployAttemptedAt: deployment.undeployAttemptedAt,
+						undeployProgress: deployment.undeployProgress,
+					},
+					data: {
+						undeployStatus: "IN_PROGRESS",
+						undeployAttemptedAt: attemptedAt,
+					},
+				});
+				if (deploymentClaim.count !== 1) throw new RecoveryHistoryConflictError();
+			}
+		});
+		return true;
+	} catch (error) {
+		if (error instanceof RecoveryHistoryConflictError) return false;
+		throw error;
+	}
+}

--- a/apps/api/src/lib/trash-guides/recovery-history-claim.ts
+++ b/apps/api/src/lib/trash-guides/recovery-history-claim.ts
@@ -1,7 +1,12 @@
-import type { PrismaClientInstance } from "../prisma.js";
+import type { Prisma, PrismaClientInstance } from "../prisma.js";
 
 export interface SyncRecoveryState {
 	id: string;
+	userId: string;
+	instanceId: string;
+	templateId: string | null;
+	backupId: string | null;
+	status: string;
 	rolledBack: boolean;
 	rollbackStatus: string | null;
 	rollbackAttemptedAt: Date | null;
@@ -10,6 +15,10 @@ export interface SyncRecoveryState {
 
 export interface DeploymentRecoveryState {
 	id: string;
+	userId: string;
+	instanceId: string;
+	templateId: string;
+	backupId: string | null;
 	status: string;
 	rolledBack: boolean;
 	undeployStatus: string | null;
@@ -19,90 +28,60 @@ export interface DeploymentRecoveryState {
 
 class RecoveryHistoryConflictError extends Error {}
 
-export async function claimUndeployRecoveryGroup(
-	prisma: PrismaClientInstance,
-	userId: string,
-	deployment: DeploymentRecoveryState,
-	pairedSyncs: SyncRecoveryState[],
-	attemptedAt: Date,
-): Promise<boolean> {
-	try {
-		await prisma.$transaction(async (tx) => {
-			const deploymentClaim = await tx.templateDeploymentHistory.updateMany({
-				where: {
-					id: deployment.id,
-					userId,
-					status: deployment.status,
-					rolledBack: false,
-					undeployStatus: deployment.undeployStatus,
-					undeployAttemptedAt: deployment.undeployAttemptedAt,
-					undeployProgress: deployment.undeployProgress,
-				},
-				data: {
-					undeployStatus: "IN_PROGRESS",
-					undeployAttemptedAt: attemptedAt,
-				},
-			});
-			if (deploymentClaim.count !== 1) throw new RecoveryHistoryConflictError();
-
-			for (const sync of pairedSyncs) {
-				const syncClaim = await tx.trashSyncHistory.updateMany({
-					where: {
-						id: sync.id,
-						userId,
-						rolledBack: false,
-						rollbackStatus: sync.rollbackStatus,
-						rollbackAttemptedAt: sync.rollbackAttemptedAt,
-						rollbackProgress: sync.rollbackProgress,
-					},
-					data: {
-						rollbackStatus: "IN_PROGRESS",
-						rollbackAttemptedAt: attemptedAt,
-					},
-				});
-				if (syncClaim.count !== 1) throw new RecoveryHistoryConflictError();
-			}
-		});
-		return true;
-	} catch (error) {
-		if (error instanceof RecoveryHistoryConflictError) return false;
-		throw error;
-	}
+function canonicalRecoveryRows<T extends { id: string }>(rows: T[]): T[] {
+	return [...rows].sort((left, right) => (left.id < right.id ? -1 : left.id > right.id ? 1 : 0));
 }
 
-export async function claimRollbackRecoveryGroup(
+function assertSnapshotOwner(userId: string, state: { userId: string }): void {
+	if (state.userId !== userId) throw new RecoveryHistoryConflictError();
+}
+
+function deploymentSnapshotWhere(userId: string, deployment: DeploymentRecoveryState) {
+	assertSnapshotOwner(userId, deployment);
+	return {
+		id: deployment.id,
+		userId: deployment.userId,
+		instanceId: deployment.instanceId,
+		templateId: deployment.templateId,
+		backupId: deployment.backupId,
+		status: deployment.status,
+	};
+}
+
+function syncSnapshotWhere(userId: string, sync: SyncRecoveryState) {
+	assertSnapshotOwner(userId, sync);
+	return {
+		id: sync.id,
+		userId: sync.userId,
+		instanceId: sync.instanceId,
+		templateId: sync.templateId,
+		backupId: sync.backupId,
+		status: sync.status,
+	};
+}
+
+async function claimRecoveryGroup(
 	prisma: PrismaClientInstance,
 	userId: string,
+	deployments: DeploymentRecoveryState[],
 	pairedSyncs: SyncRecoveryState[],
-	pairedDeployments: DeploymentRecoveryState[],
 	attemptedAt: Date,
 ): Promise<boolean> {
+	if (
+		deployments.some((deployment) => deployment.rolledBack) ||
+		pairedSyncs.some((sync) => sync.rolledBack)
+	) {
+		return false;
+	}
 	try {
 		await prisma.$transaction(async (tx) => {
-			for (const sync of pairedSyncs) {
-				const syncClaim = await tx.trashSyncHistory.updateMany({
-					where: {
-						id: sync.id,
-						userId,
-						rolledBack: false,
-						rollbackStatus: sync.rollbackStatus,
-						rollbackAttemptedAt: sync.rollbackAttemptedAt,
-						rollbackProgress: sync.rollbackProgress,
-					},
-					data: {
-						rollbackStatus: "IN_PROGRESS",
-						rollbackAttemptedAt: attemptedAt,
-					},
-				});
-				if (syncClaim.count !== 1) throw new RecoveryHistoryConflictError();
-			}
-
-			for (const deployment of pairedDeployments) {
+			// Every recovery transaction takes model locks in the same order, then
+			// row locks by stable ID. PostgreSQL callers must never be able to enter
+			// the same deployment/sync group through an inverse lock order.
+			for (const deployment of canonicalRecoveryRows(deployments)) {
 				const deploymentClaim = await tx.templateDeploymentHistory.updateMany({
 					where: {
-						id: deployment.id,
-						userId,
-						status: deployment.status,
+						...deploymentSnapshotWhere(userId, deployment),
 						rolledBack: false,
 						undeployStatus: deployment.undeployStatus,
 						undeployAttemptedAt: deployment.undeployAttemptedAt,
@@ -115,10 +94,96 @@ export async function claimRollbackRecoveryGroup(
 				});
 				if (deploymentClaim.count !== 1) throw new RecoveryHistoryConflictError();
 			}
+
+			for (const sync of canonicalRecoveryRows(pairedSyncs)) {
+				const syncClaim = await tx.trashSyncHistory.updateMany({
+					where: {
+						...syncSnapshotWhere(userId, sync),
+						rolledBack: false,
+						rollbackStatus: sync.rollbackStatus,
+						rollbackAttemptedAt: sync.rollbackAttemptedAt,
+						rollbackProgress: sync.rollbackProgress,
+					},
+					data: {
+						rollbackStatus: "IN_PROGRESS",
+						rollbackAttemptedAt: attemptedAt,
+					},
+				});
+				if (syncClaim.count !== 1) throw new RecoveryHistoryConflictError();
+			}
 		});
 		return true;
 	} catch (error) {
 		if (error instanceof RecoveryHistoryConflictError) return false;
 		throw error;
 	}
+}
+
+export async function claimUndeployRecoveryGroup(
+	prisma: PrismaClientInstance,
+	userId: string,
+	deployment: DeploymentRecoveryState,
+	pairedSyncs: SyncRecoveryState[],
+	attemptedAt: Date,
+): Promise<boolean> {
+	return await claimRecoveryGroup(prisma, userId, [deployment], pairedSyncs, attemptedAt);
+}
+
+export async function claimRollbackRecoveryGroup(
+	prisma: PrismaClientInstance,
+	userId: string,
+	pairedSyncs: SyncRecoveryState[],
+	pairedDeployments: DeploymentRecoveryState[],
+	attemptedAt: Date,
+): Promise<boolean> {
+	return await claimRecoveryGroup(prisma, userId, pairedDeployments, pairedSyncs, attemptedAt);
+}
+
+export interface ClaimedRecoveryGroupMutation {
+	deploymentData: (
+		state: DeploymentRecoveryState,
+	) => Prisma.TemplateDeploymentHistoryUpdateManyMutationInput;
+	syncData: (state: SyncRecoveryState) => Prisma.TrashSyncHistoryUpdateManyMutationInput;
+	conflictMessage: string;
+}
+
+/**
+ * Persist a claimed recovery-group transition in the same model/ID lock order
+ * used by claims. Snapshot topology remains part of every compare-and-set.
+ */
+export async function mutateClaimedRecoveryGroup(
+	prisma: PrismaClientInstance,
+	userId: string,
+	deployments: DeploymentRecoveryState[],
+	pairedSyncs: SyncRecoveryState[],
+	attemptedAt: Date,
+	mutation: ClaimedRecoveryGroupMutation,
+): Promise<void> {
+	await prisma.$transaction(async (tx) => {
+		for (const deployment of canonicalRecoveryRows(deployments)) {
+			const result = await tx.templateDeploymentHistory.updateMany({
+				where: {
+					...deploymentSnapshotWhere(userId, deployment),
+					rolledBack: false,
+					undeployStatus: "IN_PROGRESS",
+					undeployAttemptedAt: attemptedAt,
+				},
+				data: mutation.deploymentData(deployment),
+			});
+			if (result.count !== 1) throw new Error(mutation.conflictMessage);
+		}
+
+		for (const sync of canonicalRecoveryRows(pairedSyncs)) {
+			const result = await tx.trashSyncHistory.updateMany({
+				where: {
+					...syncSnapshotWhere(userId, sync),
+					rolledBack: false,
+					rollbackStatus: "IN_PROGRESS",
+					rollbackAttemptedAt: attemptedAt,
+				},
+				data: mutation.syncData(sync),
+			});
+			if (result.count !== 1) throw new Error(mutation.conflictMessage);
+		}
+	});
 }

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
@@ -84,6 +84,22 @@ function backupData(overrides: Record<string, unknown> = {}) {
 	});
 }
 
+function pairedSyncState(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "sync-paired",
+		userId,
+		instanceId: instance.id,
+		templateId: "template-1",
+		backupId: "backup-1",
+		status: "SUCCESS",
+		rolledBack: false,
+		rollbackStatus: null,
+		rollbackAttemptedAt: null,
+		rollbackProgress: null,
+		...overrides,
+	};
+}
+
 describe("deployment history undeploy", () => {
 	let app: FastifyInstance;
 	const historyFindFirst = vi.fn();
@@ -252,6 +268,9 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
 				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "PARTIAL",
@@ -296,6 +315,85 @@ describe("deployment history undeploy", () => {
 		);
 	});
 
+	it("restores the full claim when topology ownership is lost before an ARR mutation", async () => {
+		const targetFormat = { id: 7, name: "Created CF", specifications: [] };
+		const history = currentHistory(
+			backupData({
+				customFormatDeployments: [
+					{
+						beforeFormat: null,
+						action: "created",
+						resourceId: 7,
+						name: "Created CF",
+						status: "applied",
+						postStateToken: createUpstreamResourceStateToken(targetFormat),
+						intendedPostStateToken: null,
+					},
+				],
+			}),
+		);
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+		getFormatById.mockResolvedValue(targetFormat);
+		let renewals = 0;
+		cleanupUpdateMany.mockImplementation(async ({ data }) => {
+			if (!("runClaimToken" in data) && ++renewals === 3) return { count: 0 };
+			return { count: 1 };
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(500);
+		expect(deleteFormat).not.toHaveBeenCalled();
+		expect(historyUpdateMany).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({ status: "SUCCESS", undeployStatus: null }),
+			}),
+		);
+	});
+
+	it("marks the full claim partial when ownership is lost after entering an ARR mutation boundary", async () => {
+		const targetFormat = { id: 7, name: "Created CF", specifications: [] };
+		const history = currentHistory(
+			backupData({
+				customFormatDeployments: [
+					{
+						beforeFormat: null,
+						action: "created",
+						resourceId: 7,
+						name: "Created CF",
+						status: "applied",
+						postStateToken: createUpstreamResourceStateToken(targetFormat),
+						intendedPostStateToken: null,
+					},
+				],
+			}),
+		);
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+		getAllFormats.mockResolvedValue([targetFormat]);
+		getAllProfiles.mockResolvedValue([]);
+		getFormatById.mockResolvedValue(targetFormat);
+		let renewals = 0;
+		cleanupUpdateMany.mockImplementation(async ({ data }) => {
+			if (!("runClaimToken" in data) && ++renewals === 4) return { count: 0 };
+			return { count: 1 };
+		});
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(207);
+		expect(getFormatById).toHaveBeenCalled();
+		expect(historyUpdateMany).toHaveBeenLastCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					status: "PARTIAL_UNDEPLOY",
+					undeployStatus: "PARTIAL",
+				}),
+			}),
+		);
+	});
+
 	it("stops before ARR access when another undeploy owns the claim", async () => {
 		const history = currentHistory(backupData());
 		historyFindFirst.mockResolvedValue(history);
@@ -319,13 +417,12 @@ describe("deployment history undeploy", () => {
 			syncFindMany.mockImplementation(async (args) =>
 				args.select?.rollbackProgress
 					? [
-							{
-								id: "sync-paired",
+							pairedSyncState({
 								rolledBack,
 								rollbackStatus: status,
 								rollbackAttemptedAt: new Date("2026-08-08T12:00:00.000Z"),
 								rollbackProgress: "[]",
-							},
+							}),
 						]
 					: [],
 			);
@@ -343,17 +440,7 @@ describe("deployment history undeploy", () => {
 		const history = currentHistory(backupData());
 		historyFindFirst.mockResolvedValue(history);
 		syncFindMany.mockImplementation(async (args) =>
-			args.select?.rollbackProgress
-				? [
-						{
-							id: "sync-paired",
-							rolledBack: false,
-							rollbackStatus: null,
-							rollbackAttemptedAt: null,
-							rollbackProgress: null,
-						},
-					]
-				: [],
+			args.select?.rollbackProgress ? [pairedSyncState()] : [],
 		);
 		syncUpdateMany.mockResolvedValueOnce({ count: 0 });
 
@@ -381,6 +468,9 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
 				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
@@ -424,6 +514,9 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
 				status: "PARTIAL_UNDEPLOY",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
@@ -448,12 +541,11 @@ describe("deployment history undeploy", () => {
 		syncFindMany.mockImplementation(async (args) =>
 			args.select?.rollbackProgress
 				? [
-						{
-							id: "sync-paired",
+						pairedSyncState({
 							rollbackStatus: "PARTIAL",
 							rollbackAttemptedAt: priorRollbackAttemptedAt,
 							rollbackProgress: priorRollbackProgress,
-						},
+						}),
 					]
 				: [],
 		);
@@ -474,6 +566,10 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "sync-paired",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: claimTimestamp,
@@ -502,6 +598,9 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
 				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
@@ -1373,17 +1472,7 @@ describe("deployment history undeploy", () => {
 		historyFindFirst.mockResolvedValue(history);
 		historyFindMany.mockResolvedValue([history, legacy]);
 		syncFindMany.mockImplementation(async (args) =>
-			args.select?.rollbackProgress
-				? [
-						{
-							id: "sync-paired",
-							rolledBack: false,
-							rollbackStatus: null,
-							rollbackAttemptedAt: null,
-							rollbackProgress: null,
-						},
-					]
-				: [],
+			args.select?.rollbackProgress ? [pairedSyncState()] : [],
 		);
 		getAllFormats.mockResolvedValue([]);
 

--- a/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/deployment-history-routes.test.ts
@@ -107,6 +107,7 @@ describe("deployment history undeploy", () => {
 	const rawRequest = vi.fn();
 	const systemGet = vi.fn();
 	const transaction = vi.fn();
+	const cleanupUpdateMany = vi.fn();
 	let transactionClient: Record<string, unknown>;
 
 	beforeEach(async () => {
@@ -115,14 +116,14 @@ describe("deployment history undeploy", () => {
 		setupAuthInjection(app, { id: userId, username: "admin" });
 		registerTestErrorHandler(app);
 		transactionClient = {
-			templateDeploymentHistory: { update: historyUpdate },
+			templateDeploymentHistory: { update: historyUpdate, updateMany: historyUpdateMany },
 			trashSyncHistory: { updateMany: syncUpdateMany },
 		};
 		transaction.mockImplementation(async (callback) => callback(transactionClient));
 		const prisma = {
 			libraryCleanupConfig: {
 				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
-				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+				updateMany: cleanupUpdateMany.mockResolvedValue({ count: 1 }),
 			},
 			templateDeploymentHistory: {
 				findFirst: historyFindFirst,
@@ -201,6 +202,8 @@ describe("deployment history undeploy", () => {
 			userId,
 			status: "SUCCESS",
 			rolledBack: false,
+			undeployStatus: null,
+			undeployAttemptedAt: null,
 			undeployProgress: null,
 			backupId: "backup-1",
 			deployedAt: new Date("2026-01-01"),
@@ -222,7 +225,7 @@ describe("deployment history undeploy", () => {
 		expect(response.json()).toMatchObject({
 			message: "This deployment has already been undeployed",
 		});
-		expect(historyUpdate).not.toHaveBeenCalled();
+		expect(historyUpdateMany).not.toHaveBeenCalled();
 		expect(deleteFormat).not.toHaveBeenCalled();
 	});
 
@@ -249,8 +252,11 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				status: "SUCCESS",
 				rolledBack: false,
-				OR: [{ undeployStatus: null }, { undeployStatus: "PARTIAL" }],
+				undeployStatus: "PARTIAL",
+				undeployAttemptedAt: null,
+				undeployProgress: history.undeployProgress,
 			},
 			data: {
 				undeployStatus: "IN_PROGRESS",
@@ -259,6 +265,34 @@ describe("deployment history undeploy", () => {
 		});
 		expect(historyUpdateMany.mock.invocationCallOrder[0]).toBeLessThan(
 			systemGet.mock.invocationCallOrder[0]!,
+		);
+	});
+
+	it("acquires the topology lease before claiming an undeploy", async () => {
+		const history = currentHistory(backupData());
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode, response.body).toBe(200);
+		const acquireIndexes = cleanupUpdateMany.mock.calls.flatMap(([args], index) =>
+			args.data.runClaimToken ? [index] : [],
+		);
+		const releaseIndexes = cleanupUpdateMany.mock.calls.flatMap(([args], index) =>
+			args.data.runClaimToken === null ? [index] : [],
+		);
+		expect(acquireIndexes).toHaveLength(1);
+		expect(releaseIndexes).toHaveLength(1);
+		const finalWriteIndex = historyUpdateMany.mock.calls.findIndex(
+			([args]) => args.data.rolledBack === true,
+		);
+		expect(finalWriteIndex).toBeGreaterThanOrEqual(0);
+		expect(cleanupUpdateMany.mock.invocationCallOrder[acquireIndexes[0]!]).toBeLessThan(
+			historyUpdateMany.mock.invocationCallOrder[0]!,
+		);
+		expect(historyUpdateMany.mock.invocationCallOrder[finalWriteIndex]).toBeLessThan(
+			cleanupUpdateMany.mock.invocationCallOrder[releaseIndexes[0]!]!,
 		);
 	});
 
@@ -271,7 +305,63 @@ describe("deployment history undeploy", () => {
 
 		expect(response.statusCode).toBe(409);
 		expect(systemGet).not.toHaveBeenCalled();
-		expect(historyFindFirst).toHaveBeenCalledOnce();
+		expect(historyFindFirst).toHaveBeenCalledTimes(2);
+	});
+
+	it.each([
+		["already active", false, "IN_PROGRESS"],
+		["already completed", true, "COMPLETED"],
+	])(
+		"rejects a paired sync that is %s before claiming the group",
+		async (_case, rolledBack, status) => {
+			const history = currentHistory(backupData());
+			historyFindFirst.mockResolvedValue(history);
+			syncFindMany.mockImplementation(async (args) =>
+				args.select?.rollbackProgress
+					? [
+							{
+								id: "sync-paired",
+								rolledBack,
+								rollbackStatus: status,
+								rollbackAttemptedAt: new Date("2026-08-08T12:00:00.000Z"),
+								rollbackProgress: "[]",
+							},
+						]
+					: [],
+			);
+
+			const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+			expect(response.statusCode).toBe(409);
+			expect(transaction).not.toHaveBeenCalled();
+			expect(systemGet).not.toHaveBeenCalled();
+			expect(historyUpdateMany).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rolls back the whole claim when a paired sync CAS misses", async () => {
+		const history = currentHistory(backupData());
+		historyFindFirst.mockResolvedValue(history);
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-paired",
+							rolledBack: false,
+							rollbackStatus: null,
+							rollbackAttemptedAt: null,
+							rollbackProgress: null,
+						},
+					]
+				: [],
+		);
+		syncUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(409);
+		expect(transaction).toHaveBeenCalledOnce();
+		expect(systemGet).not.toHaveBeenCalled();
 	});
 
 	it("releases the undeploy claim back to null when ARR is unreachable", async () => {
@@ -291,6 +381,7 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: expect.any(Date),
@@ -333,6 +424,7 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				status: "PARTIAL_UNDEPLOY",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: expect.any(Date),
@@ -345,6 +437,53 @@ describe("deployment history undeploy", () => {
 			},
 		});
 		expect(deleteFormat).not.toHaveBeenCalled();
+	});
+
+	it("restores paired rollback state when final persistence fails before an ARR mutation", async () => {
+		const priorRollbackAttemptedAt = new Date("2026-08-08T12:00:00.000Z");
+		const priorRollbackProgress = JSON.stringify([{ key: "prior", outcome: "restored" }]);
+		const history = currentHistory(backupData());
+		historyFindFirst.mockResolvedValue(history);
+		historyFindMany.mockResolvedValue([history]);
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-paired",
+							rollbackStatus: "PARTIAL",
+							rollbackAttemptedAt: priorRollbackAttemptedAt,
+							rollbackProgress: priorRollbackProgress,
+						},
+					]
+				: [],
+		);
+		transaction
+			.mockReset()
+			.mockImplementationOnce(async (callback) => callback(transactionClient))
+			.mockRejectedValueOnce(new Error("final deployment history write failed"))
+			.mockImplementationOnce(async (callback) => callback(transactionClient));
+
+		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
+
+		expect(response.statusCode).toBe(500);
+		expect(deleteFormat).not.toHaveBeenCalled();
+		expect(updateFormat).not.toHaveBeenCalled();
+		expect(updateProfile).not.toHaveBeenCalled();
+		const claimTimestamp = historyUpdateMany.mock.calls[0]?.[0].data.undeployAttemptedAt;
+		expect(syncUpdateMany).toHaveBeenCalledWith({
+			where: {
+				id: "sync-paired",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+				rollbackAttemptedAt: claimTimestamp,
+			},
+			data: {
+				rollbackStatus: "PARTIAL",
+				rollbackAttemptedAt: priorRollbackAttemptedAt,
+				rollbackProgress: priorRollbackProgress,
+			},
+		});
 	});
 
 	it("releases the undeploy claim when a legacy backup cannot be undeployed", async () => {
@@ -363,6 +502,7 @@ describe("deployment history undeploy", () => {
 			where: {
 				id: "history-1",
 				userId,
+				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: expect.any(Date),
@@ -505,9 +645,9 @@ describe("deployment history undeploy", () => {
 		expect(response.json().data.errors[0]).toContain("older target cannot restore it safely");
 		expect(deleteFormat).not.toHaveBeenCalled();
 		expect(updateFormat).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining('"outcome":"failed"'),
@@ -593,9 +733,9 @@ describe("deployment history undeploy", () => {
 		});
 		expect(response.json().data.errors[0]).toContain("upstream API has no conditional update");
 		expect(updateFormat).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining(
@@ -708,7 +848,7 @@ describe("deployment history undeploy", () => {
 		expect(response.json().success).toBe(false);
 		expect(response.json().data.errors[0]).toContain("upstream API has no conditional update");
 		expect(updateProfile).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
@@ -817,7 +957,7 @@ describe("deployment history undeploy", () => {
 			"/api/v3/config/naming",
 			expect.objectContaining({ method: "PUT" }),
 		);
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
@@ -879,7 +1019,7 @@ describe("deployment history undeploy", () => {
 			"/api/v3/config/naming",
 			expect.objectContaining({ method: "PUT" }),
 		);
-		for (const [args] of historyUpdate.mock.calls) {
+		for (const [args] of historyUpdateMany.mock.calls) {
 			expect(args.data).not.toHaveProperty("errors");
 		}
 	});
@@ -916,9 +1056,9 @@ describe("deployment history undeploy", () => {
 			"/api/v3/config/naming",
 			expect.objectContaining({ method: "PUT" }),
 		);
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining(
@@ -927,7 +1067,7 @@ describe("deployment history undeploy", () => {
 				}),
 			}),
 		);
-		for (const [args] of historyUpdate.mock.calls) {
+		for (const [args] of historyUpdateMany.mock.calls) {
 			expect(args.data).not.toHaveProperty("errors");
 		}
 	});
@@ -964,7 +1104,7 @@ describe("deployment history undeploy", () => {
 			"/api/v3/config/naming",
 			expect.objectContaining({ method: "PUT" }),
 		);
-		for (const [args] of historyUpdate.mock.calls) {
+		for (const [args] of historyUpdateMany.mock.calls) {
 			expect(args.data).not.toHaveProperty("errors");
 		}
 	});
@@ -1010,18 +1150,18 @@ describe("deployment history undeploy", () => {
 		expect(response.json().data.errors[0]).toContain("cannot be deleted safely");
 		expect(updateProfile).not.toHaveBeenCalled();
 		expect(deleteFormat).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({ undeployStatus: "IN_PROGRESS" }),
 			}),
 		);
-		for (const [args] of historyUpdate.mock.calls) {
+		for (const [args] of historyUpdateMany.mock.calls) {
 			expect(args.data).not.toHaveProperty("errors");
 		}
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining(
@@ -1030,9 +1170,9 @@ describe("deployment history undeploy", () => {
 				}),
 			}),
 		);
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining('"outcome":"failed"'),
@@ -1084,9 +1224,9 @@ describe("deployment history undeploy", () => {
 		expect(updateProfile).not.toHaveBeenCalled();
 		expect(getAllFormats).not.toHaveBeenCalled();
 		expect(deleteFormat).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					undeployStatus: "PARTIAL",
 					undeployProgress: expect.stringContaining(
@@ -1232,6 +1372,19 @@ describe("deployment history undeploy", () => {
 		};
 		historyFindFirst.mockResolvedValue(history);
 		historyFindMany.mockResolvedValue([history, legacy]);
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-paired",
+							rolledBack: false,
+							rollbackStatus: null,
+							rollbackAttemptedAt: null,
+							rollbackProgress: null,
+						},
+					]
+				: [],
+		);
 		getAllFormats.mockResolvedValue([]);
 
 		const response = await createInjectAuthenticated(app)("POST", "/history/history-1/undeploy");
@@ -1239,9 +1392,9 @@ describe("deployment history undeploy", () => {
 		expect(response.statusCode, response.body).toBe(200);
 		expect(response.json().success).toBe(true);
 		expect(deleteFormat).not.toHaveBeenCalled();
-		expect(historyUpdate).toHaveBeenCalledWith(
+		expect(historyUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { id: "history-1" },
+				where: expect.objectContaining({ id: "history-1", userId, rolledBack: false }),
 				data: expect.objectContaining({
 					rolledBack: true,
 					undeployStatus: "COMPLETED",
@@ -1250,7 +1403,13 @@ describe("deployment history undeploy", () => {
 		);
 		expect(syncUpdateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				where: { backupId: "backup-1", userId },
+				where: expect.objectContaining({
+					id: "sync-paired",
+					userId,
+					rolledBack: false,
+					rollbackStatus: "IN_PROGRESS",
+					rollbackAttemptedAt: expect.any(Date),
+				}),
 				data: expect.objectContaining({
 					rolledBack: true,
 					rollbackStatus: "COMPLETED",
@@ -1266,6 +1425,7 @@ describe("deployment history delete", () => {
 	const historyDeleteMany = vi.fn();
 	const syncFindMany = vi.fn();
 	const backupFindFirst = vi.fn();
+	const cleanupUpdateMany = vi.fn();
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
@@ -1273,6 +1433,10 @@ describe("deployment history delete", () => {
 		setupAuthInjection(app, { id: userId, username: "admin" });
 		registerTestErrorHandler(app);
 		const prisma = {
+			libraryCleanupConfig: {
+				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
+				updateMany: cleanupUpdateMany.mockResolvedValue({ count: 1 }),
+			},
 			templateDeploymentHistory: {
 				findFirst: historyFindFirst,
 				deleteMany: historyDeleteMany,
@@ -1463,6 +1627,28 @@ describe("deployment history delete", () => {
 
 		expect(response.statusCode).toBe(200);
 		expect(historyDeleteMany).toHaveBeenCalled();
+	});
+
+	it("holds the topology lease while checking paired recovery state and deleting", async () => {
+		let leaseHeld = false;
+		cleanupUpdateMany.mockImplementation(async ({ data }) => {
+			leaseHeld = data.runClaimToken !== null;
+			return { count: 1 };
+		});
+		historyFindFirst.mockResolvedValue(historyRow({ undeployStatus: "COMPLETED" }));
+		syncFindMany.mockImplementation(async () => {
+			expect(leaseHeld).toBe(true);
+			return [];
+		});
+		historyDeleteMany.mockImplementation(async () => {
+			expect(leaseHeld).toBe(true);
+			return { count: 1 };
+		});
+
+		const response = await createInjectAuthenticated(app)("DELETE", "/history/history-1");
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(leaseHeld).toBe(false);
 	});
 
 	it("allows deleting an ordinary terminal audit row that cannot block new work", async () => {

--- a/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
@@ -42,6 +42,38 @@ function qualityProfile(formatItems: Array<{ format: number; score: number }>) {
 	};
 }
 
+function pairedSyncState(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "sync-paired",
+		userId,
+		instanceId: instance.id,
+		templateId: "template-1",
+		backupId: "backup-1",
+		status: "SUCCESS",
+		rolledBack: false,
+		rollbackStatus: null,
+		rollbackAttemptedAt: null,
+		rollbackProgress: null,
+		...overrides,
+	};
+}
+
+function pairedDeploymentState(overrides: Record<string, unknown> = {}) {
+	return {
+		id: "deployment-paired",
+		userId,
+		instanceId: instance.id,
+		templateId: "template-1",
+		backupId: "backup-1",
+		status: "SUCCESS",
+		rolledBack: false,
+		undeployStatus: null,
+		undeployAttemptedAt: null,
+		undeployProgress: null,
+		...overrides,
+	};
+}
+
 describe("sync rollback route", () => {
 	let app: FastifyInstance;
 	const callOrder: string[] = [];
@@ -61,6 +93,15 @@ describe("sync rollback route", () => {
 	const cleanupUpdateMany = vi.fn();
 	const transaction = vi.fn();
 	let syncRecord: Record<string, unknown>;
+	const mockDeploymentOwnershipRows = (rows: Record<string, unknown>[]) => {
+		deploymentFindMany.mockImplementation(async (args) =>
+			args.select?.id && !args.select?.undeployStatus
+				? [{ id: "deployment-paired" }]
+				: args.select?.undeployProgress
+					? [pairedDeploymentState()]
+					: rows,
+		);
+	};
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
@@ -112,6 +153,7 @@ describe("sync rollback route", () => {
 			templateId: "template-1",
 			userId,
 			backupId: "backup-1",
+			status: "SUCCESS",
 			rolledBack: false,
 			appliedConfigs: "[]",
 			instance,
@@ -161,6 +203,8 @@ describe("sync rollback route", () => {
 				findMany: deploymentFindMany.mockResolvedValue([
 					{
 						id: "deployment-paired",
+						userId,
+						instanceId: instance.id,
 						templateId: sync.templateId,
 						backupId: sync.backupId,
 						status: "SUCCESS",
@@ -381,12 +425,11 @@ describe("sync rollback route", () => {
 		syncFindMany.mockImplementation(async (args) =>
 			args.select?.rollbackProgress
 				? [
-						{
-							id: "sync-paired",
+						pairedSyncState({
 							rollbackStatus: "PARTIAL",
 							rollbackAttemptedAt: priorSyncAttemptedAt,
 							rollbackProgress: priorSyncProgress,
-						},
+						}),
 					]
 				: [],
 		);
@@ -395,12 +438,11 @@ describe("sync rollback route", () => {
 				? [{ id: "deployment-paired" }]
 				: args.select?.undeployProgress
 					? [
-							{
-								id: "deployment-paired",
+							pairedDeploymentState({
 								undeployStatus: "PARTIAL",
 								undeployAttemptedAt: priorUndeployAttemptedAt,
 								undeployProgress: priorUndeployProgress,
-							},
+							}),
 						]
 					: [
 							{
@@ -447,6 +489,10 @@ describe("sync rollback route", () => {
 			where: {
 				id: "sync-paired",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: claimTimestamp,
@@ -461,12 +507,16 @@ describe("sync rollback route", () => {
 			where: {
 				id: "deployment-paired",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: claimTimestamp,
 			},
 			data: {
-				status: undefined,
+				status: "SUCCESS",
 				undeployStatus: "PARTIAL",
 				undeployAttemptedAt: priorUndeployAttemptedAt,
 				undeployProgress: priorUndeployProgress,
@@ -476,16 +526,7 @@ describe("sync rollback route", () => {
 
 	it("marks every paired recovery row partial after a mutation-attempt persistence failure", async () => {
 		syncFindMany.mockImplementation(async (args) =>
-			args.select?.rollbackProgress
-				? [
-						{
-							id: "sync-paired",
-							rollbackStatus: null,
-							rollbackAttemptedAt: null,
-							rollbackProgress: null,
-						},
-					]
-				: [],
+			args.select?.rollbackProgress ? [pairedSyncState()] : [],
 		);
 		const ownershipHistory = {
 			templateId: "template-1",
@@ -498,14 +539,7 @@ describe("sync rollback route", () => {
 			args.select?.id && !args.select?.undeployStatus
 				? [{ id: "deployment-paired" }]
 				: args.select?.undeployProgress
-					? [
-							{
-								id: "deployment-paired",
-								undeployStatus: null,
-								undeployAttemptedAt: null,
-								undeployProgress: null,
-							},
-						]
+					? [pairedDeploymentState()]
 					: [ownershipHistory],
 		);
 		transaction
@@ -538,6 +572,10 @@ describe("sync rollback route", () => {
 			where: {
 				id: "sync-paired",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: claimTimestamp,
@@ -548,6 +586,10 @@ describe("sync rollback route", () => {
 			where: {
 				id: "deployment-paired",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				undeployStatus: "IN_PROGRESS",
 				undeployAttemptedAt: claimTimestamp,
@@ -641,6 +683,10 @@ describe("sync rollback route", () => {
 			where: {
 				id: "sync-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: expect.any(Date),
@@ -682,6 +728,10 @@ describe("sync rollback route", () => {
 			where: {
 				id: "sync-1",
 				userId,
+				instanceId: instance.id,
+				templateId: "template-1",
+				backupId: "backup-1",
+				status: "SUCCESS",
 				rolledBack: false,
 				rollbackStatus: "IN_PROGRESS",
 				rollbackAttemptedAt: expect.any(Date),
@@ -815,6 +865,11 @@ describe("sync rollback route", () => {
 				args.select?.rollbackProgress
 					? [...rows.values()].map((row) => ({
 							id: row.id,
+							userId: row.userId,
+							instanceId: row.instanceId,
+							templateId: row.templateId,
+							backupId: row.backupId,
+							status: row.status,
 							rolledBack: row.rolledBack,
 							rollbackStatus: row.rollbackStatus,
 							rollbackAttemptedAt: row.rollbackAttemptedAt ?? null,
@@ -1005,7 +1060,7 @@ describe("sync rollback route", () => {
 				intendedPostStateToken: createUpstreamResourceStateToken(survivorNaming),
 			},
 		};
-		deploymentFindMany.mockResolvedValue([
+		mockDeploymentOwnershipRows([
 			{
 				templateId: "template-1",
 				backupId: "backup-1",
@@ -1077,7 +1132,7 @@ describe("sync rollback route", () => {
 				intendedPostStateToken: createUpstreamResourceStateToken(survivorNaming),
 			},
 		};
-		deploymentFindMany.mockResolvedValue([
+		mockDeploymentOwnershipRows([
 			{
 				templateId: "template-1",
 				backupId: "backup-1",
@@ -1191,7 +1246,7 @@ describe("sync rollback route", () => {
 				intendedPostStateToken: null,
 			},
 		};
-		deploymentFindMany.mockResolvedValue([
+		mockDeploymentOwnershipRows([
 			{
 				templateId: "template-1",
 				backupId: "backup-1",

--- a/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/sync-rollback-route.test.ts
@@ -49,18 +49,23 @@ describe("sync rollback route", () => {
 	const formatDelete = vi.fn();
 	const syncUpdate = vi.fn().mockResolvedValue({});
 	const syncFindFirst = vi.fn();
+	const syncFindMany = vi.fn();
 	const deploymentFindMany = vi.fn();
 	const deploymentUpdateMany = vi.fn();
 	const formatGetAll = vi.fn();
 	const formatGetById = vi.fn();
 	const formatUpdate = vi.fn();
 	const profileGetById = vi.fn();
+	const profileGetAll = vi.fn();
 	const rawRequest = vi.fn();
+	const cleanupUpdateMany = vi.fn();
+	const transaction = vi.fn();
 	let syncRecord: Record<string, unknown>;
 
 	beforeEach(async () => {
 		vi.resetAllMocks();
 		syncUpdate.mockResolvedValue({ count: 1 });
+		deploymentUpdateMany.mockResolvedValue({ count: 1 });
 		const beforeProfile = qualityProfile([]);
 		const deployedProfile = qualityProfile([{ format: 7, score: 100 }]);
 		const beforeFormat = {
@@ -120,7 +125,9 @@ describe("sync rollback route", () => {
 		syncFindFirst.mockResolvedValue(syncRecord);
 		const client = {
 			qualityProfile: {
-				getAll: vi.fn().mockResolvedValueOnce([deployedProfile]).mockResolvedValue([beforeProfile]),
+				getAll: profileGetAll
+					.mockResolvedValueOnce([deployedProfile])
+					.mockResolvedValue([beforeProfile]),
 				getById: profileGetById
 					.mockResolvedValueOnce(deployedProfile)
 					.mockResolvedValue(beforeProfile),
@@ -142,20 +149,25 @@ describe("sync rollback route", () => {
 		const prisma = {
 			libraryCleanupConfig: {
 				upsert: vi.fn().mockResolvedValue({ id: "cleanup-config" }),
-				updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+				updateMany: cleanupUpdateMany.mockResolvedValue({ count: 1 }),
 			},
 			trashSyncHistory: {
 				findFirst: syncFindFirst,
-				findMany: vi.fn().mockResolvedValue([]),
+				findMany: syncFindMany.mockResolvedValue([]),
 				update: syncUpdate,
 				updateMany: syncUpdate,
 			},
 			templateDeploymentHistory: {
 				findMany: deploymentFindMany.mockResolvedValue([
 					{
+						id: "deployment-paired",
 						templateId: sync.templateId,
 						backupId: sync.backupId,
 						status: "SUCCESS",
+						rolledBack: false,
+						undeployStatus: null,
+						undeployAttemptedAt: null,
+						undeployProgress: null,
 						deployedAt: new Date("2026-01-01"),
 						backup: sync.backup,
 					},
@@ -165,11 +177,11 @@ describe("sync rollback route", () => {
 				findFirst: vi.fn().mockResolvedValue(instance),
 				findMany: vi.fn().mockResolvedValue([instance]),
 			},
-			$transaction: vi.fn(async (callback) =>
+			$transaction: transaction.mockImplementation(async (callback) =>
 				callback({
 					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
 					templateDeploymentHistory: {
-						updateMany: deploymentUpdateMany.mockResolvedValue({ count: 1 }),
+						updateMany: deploymentUpdateMany,
 					},
 				}),
 			),
@@ -203,6 +215,345 @@ describe("sync rollback route", () => {
 		await app.close();
 		callOrder.length = 0;
 		vi.clearAllMocks();
+	});
+
+	it("acquires the topology lease before claiming a rollback", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode, response.body).toBe(200);
+		const acquireIndexes = cleanupUpdateMany.mock.calls.flatMap(([args], index) =>
+			args.data.runClaimToken ? [index] : [],
+		);
+		const releaseIndexes = cleanupUpdateMany.mock.calls.flatMap(([args], index) =>
+			args.data.runClaimToken === null ? [index] : [],
+		);
+		expect(acquireIndexes).toHaveLength(1);
+		expect(releaseIndexes).toHaveLength(1);
+		const finalWriteIndex = syncUpdate.mock.calls.findIndex(
+			([args]) => args.data.rollbackStatus === "PARTIAL",
+		);
+		expect(finalWriteIndex).toBeGreaterThanOrEqual(0);
+		expect(cleanupUpdateMany.mock.invocationCallOrder[acquireIndexes[0]!]).toBeLessThan(
+			syncUpdate.mock.invocationCallOrder[0]!,
+		);
+		expect(syncUpdate.mock.invocationCallOrder[finalWriteIndex]).toBeLessThan(
+			cleanupUpdateMany.mock.invocationCallOrder[releaseIndexes[0]!]!,
+		);
+	});
+
+	it("uses the exact claim timestamp for paired rollback progress", async () => {
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode, response.body).toBe(200);
+		const claimTimestamp = syncUpdate.mock.calls.find(
+			([call]) => call.data?.rollbackStatus === "IN_PROGRESS" && !call.data.rollbackProgress,
+		)?.[0].data.rollbackAttemptedAt;
+		const pairedTimestamp = deploymentUpdateMany.mock.calls.find(
+			([call]) => call.data?.undeployStatus === "IN_PROGRESS",
+		)?.[0].data.undeployAttemptedAt;
+		expect(pairedTimestamp).toBe(claimTimestamp);
+	});
+
+	it("refuses a rollback claim when paired deployment history disappears before the lease", async () => {
+		deploymentFindMany
+			.mockReset()
+			.mockResolvedValueOnce([{ id: "deployment-paired" }])
+			.mockResolvedValueOnce([]);
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toMatchObject({ error: "ROLLBACK_HISTORY_CHANGED" });
+		expect(syncUpdate).not.toHaveBeenCalled();
+		expect(profileUpdate).not.toHaveBeenCalled();
+		expect(formatUpdate).not.toHaveBeenCalled();
+		expect(formatDelete).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["already active", false, "IN_PROGRESS"],
+		["already completed", true, "COMPLETED"],
+	])(
+		"rejects paired deployment history that is %s before claiming the group",
+		async (_case, rolledBack, undeployStatus) => {
+			deploymentFindMany.mockImplementation(async (args) =>
+				args.select?.id && !args.select?.undeployStatus
+					? [{ id: "deployment-paired" }]
+					: [
+							{
+								id: "deployment-paired",
+								status: "SUCCESS",
+								rolledBack,
+								undeployStatus,
+								undeployAttemptedAt: new Date("2026-08-08T12:00:00.000Z"),
+								undeployProgress: "[]",
+							},
+						],
+			);
+
+			const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+			expect(response.statusCode).toBe(409);
+			expect(response.json()).toMatchObject({ error: "ROLLBACK_HISTORY_CONFLICT" });
+			expect(transaction).not.toHaveBeenCalled();
+			expect(profileUpdate).not.toHaveBeenCalled();
+		},
+	);
+
+	it("rejects a terminal paired sync before claiming the group", async () => {
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-terminal",
+							rolledBack: true,
+							rollbackStatus: "COMPLETED",
+							rollbackAttemptedAt: new Date("2026-08-08T12:00:00.000Z"),
+							rollbackProgress: "[]",
+						},
+					]
+				: [],
+		);
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toMatchObject({ error: "ROLLBACK_HISTORY_CONFLICT" });
+		expect(transaction).not.toHaveBeenCalled();
+		expect(profileUpdate).not.toHaveBeenCalled();
+	});
+
+	it("rolls back the whole claim when a paired deployment CAS misses", async () => {
+		deploymentUpdateMany.mockResolvedValueOnce({ count: 0 });
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(409);
+		expect(response.json()).toMatchObject({ error: "ROLLBACK_HISTORY_CONFLICT" });
+		expect(transaction).toHaveBeenCalledOnce();
+		expect(profileUpdate).not.toHaveBeenCalled();
+	});
+
+	it("restores every paired recovery row after a late pre-write persistence failure", async () => {
+		const priorSyncAttemptedAt = new Date("2026-08-08T12:00:00.000Z");
+		const priorSyncProgress = JSON.stringify([{ key: "sync-prior", outcome: "restored" }]);
+		const priorUndeployAttemptedAt = new Date("2026-08-08T12:05:00.000Z");
+		const priorUndeployProgress = JSON.stringify([
+			{ key: "deployment-prior", outcome: "restored" },
+		]);
+		const survivorNaming = { id: 1, standardMovieFormat: "Survivor" };
+		const targetBackup = JSON.parse(
+			(syncRecord.backup as { backupData: string }).backupData,
+		) as Record<string, unknown>;
+		targetBackup.customFormatDeployments = [];
+		targetBackup.managedCustomFormats = [];
+		targetBackup.qualityProfileDeployment = {
+			beforeProfile: null,
+			status: "not_started",
+			action: "created",
+			profileId: null,
+			profileName: null,
+			postStateToken: null,
+			intendedPostStateToken: null,
+		};
+		targetBackup.namingDeployment = {
+			beforeConfig: { id: 1, standardMovieFormat: "Before" },
+			status: "pending",
+			postStateToken: null,
+			intendedPostStateToken: null,
+		};
+		const targetBackupRecord = { id: "backup-1", backupData: JSON.stringify(targetBackup) };
+		syncRecord.backup = targetBackupRecord;
+		const survivorBackup = {
+			...targetBackup,
+			namingDeployment: {
+				beforeConfig: { id: 1, standardMovieFormat: "Older" },
+				status: "applied",
+				postStateToken: createUpstreamResourceStateToken(survivorNaming),
+				intendedPostStateToken: createUpstreamResourceStateToken(survivorNaming),
+			},
+		};
+		rawRequest.mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: vi.fn().mockResolvedValue(survivorNaming),
+		});
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-paired",
+							rollbackStatus: "PARTIAL",
+							rollbackAttemptedAt: priorSyncAttemptedAt,
+							rollbackProgress: priorSyncProgress,
+						},
+					]
+				: [],
+		);
+		deploymentFindMany.mockImplementation(async (args) =>
+			args.select?.id && !args.select?.undeployStatus
+				? [{ id: "deployment-paired" }]
+				: args.select?.undeployProgress
+					? [
+							{
+								id: "deployment-paired",
+								undeployStatus: "PARTIAL",
+								undeployAttemptedAt: priorUndeployAttemptedAt,
+								undeployProgress: priorUndeployProgress,
+							},
+						]
+					: [
+							{
+								templateId: "template-1",
+								backupId: "backup-1",
+								status: "SUCCESS",
+								deployedAt: new Date("2026-01-02"),
+								backup: targetBackupRecord,
+							},
+							{
+								templateId: "template-survivor",
+								backupId: "backup-survivor",
+								status: "SUCCESS",
+								deployedAt: new Date("2026-01-01"),
+								backup: { id: "backup-survivor", backupData: JSON.stringify(survivorBackup) },
+							},
+						],
+		);
+		transaction
+			.mockReset()
+			.mockImplementationOnce(async (callback) =>
+				callback({
+					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				}),
+			)
+			.mockRejectedValueOnce(new Error("late rollback progress write failed"))
+			.mockImplementationOnce(async (callback) =>
+				callback({
+					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				}),
+			);
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(500);
+		expect(profileUpdate).not.toHaveBeenCalled();
+		expect(formatUpdate).not.toHaveBeenCalled();
+		expect(formatDelete).not.toHaveBeenCalled();
+		expect(transaction).toHaveBeenCalledTimes(3);
+		const claimTimestamp = syncUpdate.mock.calls[0]?.[0].data.rollbackAttemptedAt;
+		expect(syncUpdate).toHaveBeenCalledWith({
+			where: {
+				id: "sync-paired",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+				rollbackAttemptedAt: claimTimestamp,
+			},
+			data: {
+				rollbackStatus: "PARTIAL",
+				rollbackAttemptedAt: priorSyncAttemptedAt,
+				rollbackProgress: priorSyncProgress,
+			},
+		});
+		expect(deploymentUpdateMany).toHaveBeenCalledWith({
+			where: {
+				id: "deployment-paired",
+				userId,
+				rolledBack: false,
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: claimTimestamp,
+			},
+			data: {
+				status: undefined,
+				undeployStatus: "PARTIAL",
+				undeployAttemptedAt: priorUndeployAttemptedAt,
+				undeployProgress: priorUndeployProgress,
+			},
+		});
+	});
+
+	it("marks every paired recovery row partial after a mutation-attempt persistence failure", async () => {
+		syncFindMany.mockImplementation(async (args) =>
+			args.select?.rollbackProgress
+				? [
+						{
+							id: "sync-paired",
+							rollbackStatus: null,
+							rollbackAttemptedAt: null,
+							rollbackProgress: null,
+						},
+					]
+				: [],
+		);
+		const ownershipHistory = {
+			templateId: "template-1",
+			backupId: "backup-1",
+			status: "SUCCESS",
+			deployedAt: new Date("2026-01-01"),
+			backup: (syncRecord as { backup: unknown }).backup,
+		};
+		deploymentFindMany.mockImplementation(async (args) =>
+			args.select?.id && !args.select?.undeployStatus
+				? [{ id: "deployment-paired" }]
+				: args.select?.undeployProgress
+					? [
+							{
+								id: "deployment-paired",
+								undeployStatus: null,
+								undeployAttemptedAt: null,
+								undeployProgress: null,
+							},
+						]
+					: [ownershipHistory],
+		);
+		transaction
+			.mockReset()
+			.mockImplementationOnce(async (callback) =>
+				callback({
+					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				}),
+			)
+			.mockImplementationOnce(async (callback) =>
+				callback({
+					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				}),
+			)
+			.mockRejectedValueOnce(new Error("post-write rollback progress failed"))
+			.mockImplementationOnce(async (callback) =>
+				callback({
+					trashSyncHistory: { update: syncUpdate, updateMany: syncUpdate },
+					templateDeploymentHistory: { updateMany: deploymentUpdateMany },
+				}),
+			);
+
+		const response = await createInjectAuthenticated(app)("POST", "/sync-1/rollback");
+
+		expect(response.statusCode).toBe(207);
+		const claimTimestamp = syncUpdate.mock.calls[0]?.[0].data.rollbackAttemptedAt;
+		expect(syncUpdate).toHaveBeenCalledWith({
+			where: {
+				id: "sync-paired",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+				rollbackAttemptedAt: claimTimestamp,
+			},
+			data: { rollbackStatus: "PARTIAL" },
+		});
+		expect(deploymentUpdateMany).toHaveBeenCalledWith({
+			where: {
+				id: "deployment-paired",
+				userId,
+				rolledBack: false,
+				undeployStatus: "IN_PROGRESS",
+				undeployAttemptedAt: claimTimestamp,
+			},
+			data: { status: "PARTIAL_UNDEPLOY", undeployStatus: "PARTIAL" },
+		});
 	});
 
 	it("acknowledges a backup-less uncertain sync only after explicit review", async () => {
@@ -410,7 +761,12 @@ describe("sync rollback route", () => {
 			expect.objectContaining({ data: expect.objectContaining({ undeployStatus: "PARTIAL" }) }),
 		);
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({
 				rollbackStatus: "PARTIAL",
 				rollbackProgress: expect.stringContaining(
@@ -455,6 +811,17 @@ describe("sync rollback route", () => {
 				]),
 			);
 			syncFindFirst.mockImplementation(async ({ where }) => rows.get(where.id) ?? null);
+			syncFindMany.mockImplementation(async (args) =>
+				args.select?.rollbackProgress
+					? [...rows.values()].map((row) => ({
+							id: row.id,
+							rolledBack: row.rolledBack,
+							rollbackStatus: row.rollbackStatus,
+							rollbackAttemptedAt: row.rollbackAttemptedAt ?? null,
+							rollbackProgress: row.rollbackProgress,
+						}))
+					: [],
+			);
 			syncUpdate.mockImplementation(async ({ where, data }) => {
 				let count = 0;
 				for (const row of rows.values()) {
@@ -554,7 +921,12 @@ describe("sync rollback route", () => {
 			expect.objectContaining({ data: expect.objectContaining({ undeployStatus: "PARTIAL" }) }),
 		);
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({
 				rollbackStatus: "PARTIAL",
 				rollbackProgress: expect.stringContaining("no conditional update"),
@@ -586,7 +958,12 @@ describe("sync rollback route", () => {
 		expect(formatUpdate).not.toHaveBeenCalled();
 		expect(formatDelete).not.toHaveBeenCalled();
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({
 				rollbackStatus: "PARTIAL",
 				rollbackProgress: expect.stringContaining('"key":"custom_format:7"'),
@@ -657,7 +1034,12 @@ describe("sync rollback route", () => {
 		expect(response.json().errors[0]).toContain("post-deployment state was not verified");
 		expect(rawRequest).toHaveBeenCalledWith(instance, "/api/v3/config/naming");
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({ rollbackStatus: "PARTIAL" }),
 		});
 	});
@@ -731,7 +1113,12 @@ describe("sync rollback route", () => {
 			expect.objectContaining({ method: "PUT" }),
 		);
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({ rollbackStatus: "COMPLETED" }),
 		});
 	});
@@ -854,7 +1241,12 @@ describe("sync rollback route", () => {
 		expect(formatUpdate).not.toHaveBeenCalled();
 		expect(formatDelete).not.toHaveBeenCalled();
 		expect(syncUpdate).toHaveBeenCalledWith({
-			where: { backupId: "backup-1", userId, rolledBack: false },
+			where: expect.objectContaining({
+				id: "sync-1",
+				userId,
+				rolledBack: false,
+				rollbackStatus: "IN_PROGRESS",
+			}),
 			data: expect.objectContaining({
 				rollbackStatus: "PARTIAL",
 				rollbackProgress: expect.stringContaining(

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -10,12 +10,12 @@ import { requireInstance } from "../../lib/arr/instance-helpers.js";
 import { isNonterminalUndeploy } from "../../lib/backup/backup-validation.js";
 import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
 import {
+	type ActiveDeploymentOwnership,
 	assertSharedDeploymentRestorationAllowed,
 	assertSharedDeploymentState,
 	getExpectedSharedDeploymentStateToken,
 	resolveActiveDeploymentOwnership,
 	UNVERIFIABLE_DEPLOYMENT_OWNERSHIP,
-	type ActiveDeploymentOwnership,
 } from "../../lib/trash-guides/deployment-active-ownership.js";
 import {
 	type DeploymentBackupState,
@@ -33,6 +33,7 @@ import {
 	getEquivalentServiceInstanceIds,
 	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
+import { claimUndeployRecoveryGroup } from "../../lib/trash-guides/recovery-history-claim.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 
 interface UndeployStep {
@@ -41,6 +42,10 @@ interface UndeployStep {
 	name: string;
 	outcome: "restored" | "deleted" | "already_reversed" | "skipped_shared" | "failed";
 	error?: string;
+}
+
+function isClaimableRecoveryStatus(status: string | null | undefined): boolean {
+	return status == null || status === "PARTIAL";
 }
 
 function parseUndeployProgress(value: string | null): UndeployStep[] {
@@ -347,111 +352,116 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 		const { historyId } = request.params;
 
 		const userId = request.currentUser!.id; // preHandler guarantees authentication
-
-		// Get deployment history - verify ownership by including userId in where clause.
-		// Including userId ensures non-owned histories return null,
-		// preventing enumeration attacks (all non-owned histories return 404).
-		const history = await app.prisma.templateDeploymentHistory.findFirst({
-			where: {
-				id: historyId,
-				userId,
-			},
-			include: {
-				template: {
-					select: {
-						userId: true,
+		return withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				// Get deployment history - verify ownership by including userId in where clause.
+				// Including userId ensures non-owned histories return null,
+				// preventing enumeration attacks (all non-owned histories return 404).
+				const history = await app.prisma.templateDeploymentHistory.findFirst({
+					where: {
+						id: historyId,
+						userId,
 					},
-				},
-			},
-		});
-
-		if (!history) {
-			return reply.status(404).send({
-				statusCode: 404,
-				error: "NotFound",
-				message: "Deployment history not found",
-			});
-		}
-
-		if (isNonterminalUndeploy(history)) {
-			return reply.status(409).send({
-				statusCode: 409,
-				error: "Conflict",
-				message:
-					"Complete or explicitly resolve the undeploy before deleting its deployment history.",
-			});
-		}
-
-		// A deployment that still blocks new work must not lose its recovery handle.
-		// Deleting only TemplateDeploymentHistory while a paired TrashSyncHistory (or a
-		// schema-v2 pending ledger) still requires recovery would leave an invisible
-		// assertNoPendingDeploymentOperation blocker with no supported way to resolve it.
-		if (history.backupId) {
-			const [pairedSyncs, backup] = await Promise.all([
-				app.prisma.trashSyncHistory.findMany({
-					where: { backupId: history.backupId, userId, rolledBack: false },
-					select: { id: true, status: true, rollbackStatus: true },
-				}),
-				app.prisma.trashBackup.findFirst({
-					where: { id: history.backupId, userId },
-					select: { backupData: true },
-				}),
-			]);
-			const pairedSyncUnresolved = pairedSyncs.some(
-				(sync) =>
-					sync.status === "UNCERTAIN" ||
-					sync.status === "IN_PROGRESS" ||
-					sync.status === "RUNNING" ||
-					sync.rollbackStatus === "IN_PROGRESS" ||
-					sync.rollbackStatus === "PARTIAL",
-			);
-			// If any unrolled paired sync row will remain after this deletion, its
-			// backup must not independently block new work. Mirror the new-work gate:
-			// invalid JSON, malformed schema-v2, and pending v2 mutations all block.
-			const backupBlocksNewWork =
-				pairedSyncs.length > 0 &&
-				backup !== null &&
-				deploymentBackupBlocksNewWork(backup.backupData);
-			if (pairedSyncUnresolved || backupBlocksNewWork) {
-				return reply.status(409).send({
-					statusCode: 409,
-					error: "Conflict",
-					message:
-						"This deployment still requires recovery. Complete or explicitly resolve it before deleting its deployment history.",
+					include: {
+						template: {
+							select: {
+								userId: true,
+							},
+						},
+					},
 				});
-			}
-		}
 
-		// Delete only if ownership and terminal undeploy state still match at mutation time.
-		// Note: Associated backup will be cascade deleted if configured, otherwise it remains.
-		const deletion = await app.prisma.templateDeploymentHistory.deleteMany({
-			where: {
-				id: historyId,
-				userId,
-				OR: [
-					{ rolledBack: true },
-					{ undeployStatus: "COMPLETED" },
-					{
-						undeployStatus: null,
-						NOT: { status: "PARTIAL_UNDEPLOY" },
+				if (!history) {
+					return reply.status(404).send({
+						statusCode: 404,
+						error: "NotFound",
+						message: "Deployment history not found",
+					});
+				}
+
+				if (isNonterminalUndeploy(history)) {
+					return reply.status(409).send({
+						statusCode: 409,
+						error: "Conflict",
+						message:
+							"Complete or explicitly resolve the undeploy before deleting its deployment history.",
+					});
+				}
+
+				// A deployment that still blocks new work must not lose its recovery handle.
+				// Deleting only TemplateDeploymentHistory while a paired TrashSyncHistory (or a
+				// schema-v2 pending ledger) still requires recovery would leave an invisible
+				// assertNoPendingDeploymentOperation blocker with no supported way to resolve it.
+				if (history.backupId) {
+					const [pairedSyncs, backup] = await Promise.all([
+						app.prisma.trashSyncHistory.findMany({
+							where: { backupId: history.backupId, userId, rolledBack: false },
+							select: { id: true, status: true, rollbackStatus: true },
+						}),
+						app.prisma.trashBackup.findFirst({
+							where: { id: history.backupId, userId },
+							select: { backupData: true },
+						}),
+					]);
+					const pairedSyncUnresolved = pairedSyncs.some(
+						(sync) =>
+							sync.status === "UNCERTAIN" ||
+							sync.status === "IN_PROGRESS" ||
+							sync.status === "RUNNING" ||
+							sync.rollbackStatus === "IN_PROGRESS" ||
+							sync.rollbackStatus === "PARTIAL",
+					);
+					// If any unrolled paired sync row will remain after this deletion, its
+					// backup must not independently block new work. Mirror the new-work gate:
+					// invalid JSON, malformed schema-v2, and pending v2 mutations all block.
+					const backupBlocksNewWork =
+						pairedSyncs.length > 0 &&
+						backup !== null &&
+						deploymentBackupBlocksNewWork(backup.backupData);
+					if (pairedSyncUnresolved || backupBlocksNewWork) {
+						return reply.status(409).send({
+							statusCode: 409,
+							error: "Conflict",
+							message:
+								"This deployment still requires recovery. Complete or explicitly resolve it before deleting its deployment history.",
+						});
+					}
+				}
+
+				// Delete only if ownership and terminal undeploy state still match at mutation time.
+				// Note: Associated backup will be cascade deleted if configured, otherwise it remains.
+				const deletion = await app.prisma.templateDeploymentHistory.deleteMany({
+					where: {
+						id: historyId,
+						userId,
+						OR: [
+							{ rolledBack: true },
+							{ undeployStatus: "COMPLETED" },
+							{
+								undeployStatus: null,
+								NOT: { status: "PARTIAL_UNDEPLOY" },
+							},
+						],
 					},
-				],
+				});
+
+				if (deletion.count !== 1) {
+					return reply.status(409).send({
+						statusCode: 409,
+						error: "Conflict",
+						message:
+							"Complete or explicitly resolve the undeploy before deleting its deployment history.",
+					});
+				}
+
+				return reply.send({
+					success: true,
+					message: "Deployment history deleted successfully",
+				});
 			},
-		});
-
-		if (deletion.count !== 1) {
-			return reply.status(409).send({
-				statusCode: 409,
-				error: "Conflict",
-				message:
-					"Complete or explicitly resolve the undeploy before deleting its deployment history.",
-			});
-		}
-
-		return reply.send({
-			success: true,
-			message: "Deployment history deleted successfully",
-		});
+		);
 	});
 
 	/**
@@ -512,697 +522,894 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 			});
 		}
 
-		const priorUndeployStatus = history.undeployStatus;
-		const priorUndeployAttemptedAt = history.undeployAttemptedAt;
-		const priorUndeployProgress = history.undeployProgress;
-		const priorStatus = history.status;
-		const undeployAttemptedAt = new Date();
-		const claim = await app.prisma.templateDeploymentHistory.updateMany({
-			where: {
-				id: historyId,
-				userId,
-				rolledBack: false,
-				OR: [{ undeployStatus: null }, { undeployStatus: "PARTIAL" }],
-			},
-			data: {
-				undeployStatus: "IN_PROGRESS",
-				undeployAttemptedAt,
-			},
-		});
-		if (claim.count !== 1) {
-			return reply.status(409).send({
-				statusCode: 409,
-				error: "Conflict",
-				message: "An undeploy is already active or requires explicit recovery resolution.",
-			});
-		}
-
-		const persistPartialUndeploy = async () => {
-			const result = await app.prisma.templateDeploymentHistory.updateMany({
-				where: {
-					id: historyId,
-					userId,
-					rolledBack: false,
-					undeployStatus: "IN_PROGRESS",
-					undeployAttemptedAt,
-				},
-				data: {
-					status: "PARTIAL_UNDEPLOY",
-					undeployStatus: "PARTIAL",
-				},
-			});
-			if (result.count !== 1) {
-				throw new Error("Undeploy recovery state changed before progress could be persisted");
-			}
-		};
-		// Release this request's claim back to the exact recovery state that existed
-		// before the claim. The compare-and-set guard ensures a stale request cannot
-		// release a newer claim that another process has since taken over.
-		const releaseUndeployClaim = async () => {
-			const result = await app.prisma.templateDeploymentHistory.updateMany({
-				where: {
-					id: historyId,
-					userId,
-					rolledBack: false,
-					undeployStatus: "IN_PROGRESS",
-					undeployAttemptedAt,
-				},
-				data: {
-					status: priorStatus,
-					undeployStatus: priorUndeployStatus,
-					undeployAttemptedAt: priorUndeployAttemptedAt,
-					undeployProgress: priorUndeployProgress,
-				},
-			});
-			if (result.count !== 1) {
-				throw new Error("Undeploy recovery state changed before the claim could be released");
-			}
-		};
-		const stopClaimedUndeploy = async (statusCode: number, payload: Record<string, unknown>) => {
-			await releaseUndeployClaim();
-			return reply.status(statusCode).send(payload);
-		};
-		let upstreamMutationAttempted = false;
-
-		return withCleanupTopologyMutationLease({ prisma: app.prisma, log: request.log }, userId, () =>
-			app.deploymentExecutor.runWithEndpointMutation(
-				userId,
-				history.instance,
-				"Undeploy",
-				async (endpointKey) => {
-					const history = await app.prisma.templateDeploymentHistory.findFirst({
-						where: { id: historyId, userId },
-						include: {
-							instance: true,
-							backup: true,
-							template: {
-								select: {
-									id: true,
-									name: true,
-									userId: true,
-									configData: true,
-								},
-							},
+		return withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const leasedHistory = await app.prisma.templateDeploymentHistory.findFirst({
+					where: { id: historyId, userId },
+					include: {
+						instance: true,
+						backup: true,
+						template: {
+							select: { id: true, name: true, userId: true, configData: true },
 						},
+					},
+				});
+				if (!leasedHistory) {
+					return reply.status(404).send({
+						statusCode: 404,
+						error: "NotFound",
+						message: "Deployment history not found",
 					});
-					if (!history) {
-						return reply.status(404).send({
-							statusCode: 404,
-							error: "NotFound",
-							message: "Deployment history not found",
-						});
-					}
-					if (history.rolledBack) {
-						return reply.status(400).send({
-							statusCode: 400,
-							error: "BadRequest",
-							message: "This deployment has already been undeployed",
-						});
-					}
-					if (!history.backup) {
-						return stopClaimedUndeploy(409, {
-							success: false,
-							message:
-								"This legacy deployment has no identity-bound backup and cannot be undeployed safely.",
-						});
-					}
-					const deploymentBackup = history.backup;
-					const currentInstance = await app.prisma.serviceInstance.findFirst({
-						where: { id: history.instanceId, userId },
+				}
+				if (leasedHistory.rolledBack) {
+					return reply.status(400).send({
+						statusCode: 400,
+						error: "BadRequest",
+						message: "This deployment has already been undeployed",
 					});
-					const currentCredentialIdentity = currentInstance
-						? app.arrClientFactory.createConnectionCredentialIdentity(currentInstance)
-						: null;
-					if (
-						!currentInstance ||
-						createDeploymentEndpointKey(userId, {
-							service: currentInstance.service,
-							baseUrl: currentInstance.baseUrl,
-							credentialIdentity: currentCredentialIdentity!,
-						}) !== endpointKey
-					) {
-						return stopClaimedUndeploy(409, {
-							success: false,
-							message: "The ARR service connection changed while undeploy was starting.",
-						});
-					}
-
-					let backupState: DeploymentBackupState;
-					try {
-						backupState = parseDeploymentBackupState(deploymentBackup.backupData);
-					} catch (error) {
-						request.log.warn({ err: error, historyId }, "Unsafe undeploy backup rejected");
-						return stopClaimedUndeploy(409, {
-							success: false,
-							message:
-								"This deployment backup is legacy or incomplete and cannot be undeployed safely.",
-						});
-					}
-					if (
-						!isDeploymentBackupEndpointIdentityCurrent({
-							userId,
-							backupEndpointKey: backupState.endpointKey,
-							backupConnectionStateToken: backupState.connectionStateToken,
-							instance: currentInstance,
-							credentialIdentity: currentCredentialIdentity!,
+				}
+				if (!leasedHistory.backup) {
+					return reply.status(409).send({
+						success: false,
+						message:
+							"This legacy deployment has no identity-bound backup and cannot be undeployed safely.",
+					});
+				}
+				const priorPairedSyncStates = leasedHistory.backupId
+					? await app.prisma.trashSyncHistory.findMany({
+							where: { backupId: leasedHistory.backupId, userId },
+							select: {
+								id: true,
+								rolledBack: true,
+								rollbackStatus: true,
+								rollbackAttemptedAt: true,
+								rollbackProgress: true,
+							},
 						})
-					) {
-						return stopClaimedUndeploy(409, {
-							success: false,
-							message: "The deployment backup is not bound to this ARR service connection.",
-						});
-					}
+					: [];
 
-					const client = app.arrClientFactory.create(currentInstance) as
-						| SonarrClient
-						| RadarrClient;
-					await client.system.get();
-
-					const aliases = await app.prisma.serviceInstance.findMany({
-						where: { userId, service: currentInstance.service },
+				const priorUndeployStatus = leasedHistory.undeployStatus;
+				const priorUndeployAttemptedAt = leasedHistory.undeployAttemptedAt;
+				const priorUndeployProgress = leasedHistory.undeployProgress;
+				const priorStatus = leasedHistory.status;
+				if (
+					!isClaimableRecoveryStatus(priorUndeployStatus) ||
+					priorPairedSyncStates.some(
+						(paired) => paired.rolledBack || !isClaimableRecoveryStatus(paired.rollbackStatus),
+					)
+				) {
+					return reply.status(409).send({
+						statusCode: 409,
+						error: "Conflict",
+						message:
+							"Paired recovery history is already active or terminal and cannot be claimed safely.",
 					});
-					const credentialIdentity =
-						app.arrClientFactory.createConnectionCredentialIdentity(currentInstance);
-					const equivalentInstanceIds = getEquivalentServiceInstanceIds(
-						aliases.map((alias) => ({
-							...alias,
-							credentialIdentity: app.arrClientFactory.createConnectionCredentialIdentity(alias),
-						})),
-						{ ...currentInstance, credentialIdentity },
-					);
-					let ownership: ActiveDeploymentOwnership | null;
-					try {
-						ownership = await resolveActiveDeploymentOwnership(
-							app.prisma,
-							userId,
-							equivalentInstanceIds,
-							{ backupId: deploymentBackup.id, templateId: history.templateId },
-						);
-					} catch (error) {
-						// Competing ownership could not be resolved because an unrolled
-						// history carries legacy or invalid ownership metadata. If every
-						// mutation owned by THIS deployment is already reversed on the live
-						// ARR endpoint, no upstream write remains, so competing ownership is
-						// not required to authorize anything. Other ownership conflicts (e.g.
-						// a newer deployment) still fail closed.
-						const reason =
-							error && typeof error === "object" && "details" in error
-								? (error as { details?: { reason?: string } }).details?.reason
-								: undefined;
-						if (reason !== UNVERIFIABLE_DEPLOYMENT_OWNERSHIP) {
-							throw error;
-						}
-						const targetReversal = await classifyTargetReversal(
-							client,
-							app.arrClientFactory,
-							currentInstance,
-							backupState,
-						);
-						if (targetReversal !== "already_reversed") {
-							throw error;
-						}
-						ownership = null;
-					}
-					// When every target mutation is already reversed, no write is required,
-					// so competing ownership is not consulted. The empty ownership view keeps
-					// the per-resource loops on their no-op path (no shared resources, no
-					// writes) while still recording durable "already_reversed" steps.
-					const ownershipView: ActiveDeploymentOwnership = ownership ?? {
-						sharedCustomFormatIds: new Set(),
-						sharedQualityProfileIds: new Set(),
-						namingOwnedByAnotherDeployment: false,
-						restorableSharedCustomFormatIds: new Set(),
-						restorableSharedQualityProfileIds: new Set(),
-						sharedNamingRestorationAllowed: false,
-						sharedCustomFormatStateTokens: new Map(),
-						sharedQualityProfileStateTokens: new Map(),
-						sharedNamingStateTokens: new Set(),
-					};
+				}
+				const undeployAttemptedAt = new Date();
+				const claimed = await claimUndeployRecoveryGroup(
+					app.prisma,
+					userId,
+					{
+						id: historyId,
+						status: priorStatus,
+						rolledBack: false,
+						undeployStatus: priorUndeployStatus,
+						undeployAttemptedAt: priorUndeployAttemptedAt,
+						undeployProgress: priorUndeployProgress,
+					},
+					priorPairedSyncStates,
+					undeployAttemptedAt,
+				);
+				if (!claimed) {
+					return reply.status(409).send({
+						statusCode: 409,
+						error: "Conflict",
+						message:
+							"Paired recovery history changed, is already active, or requires explicit resolution.",
+					});
+				}
+				let pairedProgressPersisted = true;
 
-					let existingProgress: UndeployStep[];
-					try {
-						existingProgress = parseUndeployProgress(history.undeployProgress);
-					} catch (error) {
-						request.log.warn({ err: error, historyId }, "Invalid undeploy progress rejected");
-						return stopClaimedUndeploy(409, {
-							success: false,
-							message: "The saved undeploy progress is invalid, so no upstream changes were made.",
+				const persistPartialUndeploy = async () => {
+					if (!pairedProgressPersisted) {
+						const result = await app.prisma.templateDeploymentHistory.updateMany({
+							where: {
+								id: historyId,
+								userId,
+								status: priorStatus,
+								rolledBack: false,
+								undeployStatus: "IN_PROGRESS",
+								undeployAttemptedAt,
+							},
+							data: {
+								status: "PARTIAL_UNDEPLOY",
+								undeployStatus: "PARTIAL",
+							},
 						});
+						if (result.count !== 1) {
+							throw new Error("Undeploy recovery state changed before progress could be persisted");
+						}
+						return;
 					}
-					const stepByKey = new Map(existingProgress.map((step) => [step.key, step]));
-					const attemptedAt = undeployAttemptedAt;
-					const setStep = (step: UndeployStep): void => {
-						stepByKey.set(step.key, step);
-					};
-					const persistProgress = async (undeployStatus: "IN_PROGRESS" | "PARTIAL") => {
-						const progress = [...stepByKey.values()];
-						const progressJson = JSON.stringify(progress);
+					await app.prisma.$transaction(async (tx) => {
+						const result = await tx.templateDeploymentHistory.updateMany({
+							where: {
+								id: historyId,
+								userId,
+								status: priorStatus,
+								rolledBack: false,
+								undeployStatus: "IN_PROGRESS",
+								undeployAttemptedAt,
+							},
+							data: { status: "PARTIAL_UNDEPLOY", undeployStatus: "PARTIAL" },
+						});
+						if (result.count !== 1) {
+							throw new Error("Undeploy recovery state changed before progress could be persisted");
+						}
+						for (const prior of priorPairedSyncStates) {
+							const paired = await tx.trashSyncHistory.updateMany({
+								where: {
+									id: prior.id,
+									userId,
+									rolledBack: false,
+									rollbackStatus: "IN_PROGRESS",
+									rollbackAttemptedAt: undeployAttemptedAt,
+								},
+								data: { rollbackStatus: "PARTIAL" },
+							});
+							if (paired.count !== 1) {
+								throw new Error("Paired rollback state changed before progress could be persisted");
+							}
+						}
+					});
+				};
+				// Release this request's claim back to the exact recovery state that existed
+				// before the claim. The compare-and-set guard ensures a stale request cannot
+				// release a newer claim that another process has since taken over.
+				const releaseUndeployClaim = async () => {
+					if (pairedProgressPersisted) {
 						await app.prisma.$transaction(async (tx) => {
-							await tx.templateDeploymentHistory.update({
-								where: { id: historyId },
+							const result = await tx.templateDeploymentHistory.updateMany({
+								where: {
+									id: historyId,
+									userId,
+									status: priorStatus,
+									rolledBack: false,
+									undeployStatus: "IN_PROGRESS",
+									undeployAttemptedAt,
+								},
 								data: {
-									undeployStatus,
-									undeployAttemptedAt: attemptedAt,
-									undeployProgress: progressJson,
+									status: priorStatus,
+									undeployStatus: priorUndeployStatus,
+									undeployAttemptedAt: priorUndeployAttemptedAt,
+									undeployProgress: priorUndeployProgress,
 								},
 							});
-							if (history.backupId) {
-								await tx.trashSyncHistory.updateMany({
-									where: { backupId: history.backupId, userId },
+							if (result.count !== 1) {
+								throw new Error(
+									"Undeploy recovery state changed before the claim could be released",
+								);
+							}
+							for (const prior of priorPairedSyncStates) {
+								const paired = await tx.trashSyncHistory.updateMany({
+									where: {
+										id: prior.id,
+										userId,
+										rolledBack: false,
+										rollbackStatus: "IN_PROGRESS",
+										rollbackAttemptedAt: undeployAttemptedAt,
+									},
 									data: {
-										rollbackStatus: undeployStatus,
-										rollbackAttemptedAt: attemptedAt,
-										rollbackProgress: progressJson,
+										rollbackStatus: prior.rollbackStatus,
+										rollbackAttemptedAt: prior.rollbackAttemptedAt,
+										rollbackProgress: prior.rollbackProgress,
 									},
 								});
+								if (paired.count !== 1) {
+									throw new Error(
+										"Paired rollback state changed before the claim could be released",
+									);
+								}
 							}
 						});
-					};
-					const isFinished = (key: string): boolean => {
-						const outcome = stepByKey.get(key)?.outcome;
-						return (
-							outcome === "restored" ||
-							outcome === "deleted" ||
-							outcome === "already_reversed" ||
-							outcome === "skipped_shared"
-						);
-					};
+						return;
+					}
+					const result = await app.prisma.templateDeploymentHistory.updateMany({
+						where: {
+							id: historyId,
+							userId,
+							status: priorStatus,
+							rolledBack: false,
+							undeployStatus: "IN_PROGRESS",
+							undeployAttemptedAt,
+						},
+						data: {
+							status: priorStatus,
+							undeployStatus: priorUndeployStatus,
+							undeployAttemptedAt: priorUndeployAttemptedAt,
+							undeployProgress: priorUndeployProgress,
+						},
+					});
+					if (result.count !== 1) {
+						throw new Error("Undeploy recovery state changed before the claim could be released");
+					}
+				};
+				const stopClaimedUndeploy = async (
+					statusCode: number,
+					payload: Record<string, unknown>,
+				) => {
+					await releaseUndeployClaim();
+					return reply.status(statusCode).send(payload);
+				};
+				let upstreamMutationAttempted = false;
 
-					// Write intent before the first upstream mutation. An interrupted attempt is
-					// reconciled to PARTIAL on startup and blocks competing mutations.
-					await persistProgress("IN_PROGRESS");
-					let stopAfterProfileFailure = false;
-					const profileState = backupState.qualityProfileDeployment;
-					const profileStatus = profileState.status;
-					if (profileStatus !== "not_started") {
-						const key = `quality_profile:${profileState.profileId ?? profileState.profileName ?? "unknown"}`;
-						if (!isFinished(key)) {
+				return app.deploymentExecutor
+					.runWithEndpointMutation(
+						userId,
+						leasedHistory.instance,
+						"Undeploy",
+						async (endpointKey) => {
+							const history = await app.prisma.templateDeploymentHistory.findFirst({
+								where: { id: historyId, userId },
+								include: {
+									instance: true,
+									backup: true,
+									template: {
+										select: {
+											id: true,
+											name: true,
+											userId: true,
+											configData: true,
+										},
+									},
+								},
+							});
+							if (!history) {
+								return reply.status(404).send({
+									statusCode: 404,
+									error: "NotFound",
+									message: "Deployment history not found",
+								});
+							}
+							if (history.rolledBack) {
+								return reply.status(400).send({
+									statusCode: 400,
+									error: "BadRequest",
+									message: "This deployment has already been undeployed",
+								});
+							}
+							if (!history.backup) {
+								return stopClaimedUndeploy(409, {
+									success: false,
+									message:
+										"This legacy deployment has no identity-bound backup and cannot be undeployed safely.",
+								});
+							}
+							const deploymentBackup = history.backup;
+							const currentInstance = await app.prisma.serviceInstance.findFirst({
+								where: { id: history.instanceId, userId },
+							});
+							const currentCredentialIdentity = currentInstance
+								? app.arrClientFactory.createConnectionCredentialIdentity(currentInstance)
+								: null;
 							if (
-								profileState.profileId !== null &&
-								ownershipView.sharedQualityProfileIds.has(profileState.profileId)
+								!currentInstance ||
+								createDeploymentEndpointKey(userId, {
+									service: currentInstance.service,
+									baseUrl: currentInstance.baseUrl,
+									credentialIdentity: currentCredentialIdentity!,
+								}) !== endpointKey
 							) {
-								try {
-									const currentProfile = await client.qualityProfile.getById(
-										profileState.profileId,
-									);
-									const resourceLabel = `quality profile "${profileState.profileName ?? profileState.profileId}"`;
-									const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-										ownershipView.sharedQualityProfileStateTokens.get(profileState.profileId),
-										resourceLabel,
-									);
-									if (createQualityProfileStateToken(currentProfile) === expectedSurvivorToken) {
-										setStep({
-											key,
-											kind: "quality_profile",
-											name: profileState.profileName ?? "Quality profile",
-											outcome: "skipped_shared",
+								return stopClaimedUndeploy(409, {
+									success: false,
+									message: "The ARR service connection changed while undeploy was starting.",
+								});
+							}
+
+							let backupState: DeploymentBackupState;
+							try {
+								backupState = parseDeploymentBackupState(deploymentBackup.backupData);
+							} catch (error) {
+								request.log.warn({ err: error, historyId }, "Unsafe undeploy backup rejected");
+								return stopClaimedUndeploy(409, {
+									success: false,
+									message:
+										"This deployment backup is legacy or incomplete and cannot be undeployed safely.",
+								});
+							}
+							if (
+								!isDeploymentBackupEndpointIdentityCurrent({
+									userId,
+									backupEndpointKey: backupState.endpointKey,
+									backupConnectionStateToken: backupState.connectionStateToken,
+									instance: currentInstance,
+									credentialIdentity: currentCredentialIdentity!,
+								})
+							) {
+								return stopClaimedUndeploy(409, {
+									success: false,
+									message: "The deployment backup is not bound to this ARR service connection.",
+								});
+							}
+
+							const client = app.arrClientFactory.create(currentInstance) as
+								| SonarrClient
+								| RadarrClient;
+							await client.system.get();
+
+							const aliases = await app.prisma.serviceInstance.findMany({
+								where: { userId, service: currentInstance.service },
+							});
+							const credentialIdentity =
+								app.arrClientFactory.createConnectionCredentialIdentity(currentInstance);
+							const equivalentInstanceIds = getEquivalentServiceInstanceIds(
+								aliases.map((alias) => ({
+									...alias,
+									credentialIdentity:
+										app.arrClientFactory.createConnectionCredentialIdentity(alias),
+								})),
+								{ ...currentInstance, credentialIdentity },
+							);
+							let ownership: ActiveDeploymentOwnership | null;
+							try {
+								ownership = await resolveActiveDeploymentOwnership(
+									app.prisma,
+									userId,
+									equivalentInstanceIds,
+									{ backupId: deploymentBackup.id, templateId: history.templateId },
+								);
+							} catch (error) {
+								// Competing ownership could not be resolved because an unrolled
+								// history carries legacy or invalid ownership metadata. If every
+								// mutation owned by THIS deployment is already reversed on the live
+								// ARR endpoint, no upstream write remains, so competing ownership is
+								// not required to authorize anything. Other ownership conflicts (e.g.
+								// a newer deployment) still fail closed.
+								const reason =
+									error && typeof error === "object" && "details" in error
+										? (error as { details?: { reason?: string } }).details?.reason
+										: undefined;
+								if (reason !== UNVERIFIABLE_DEPLOYMENT_OWNERSHIP) {
+									throw error;
+								}
+								const targetReversal = await classifyTargetReversal(
+									client,
+									app.arrClientFactory,
+									currentInstance,
+									backupState,
+								);
+								if (targetReversal !== "already_reversed") {
+									throw error;
+								}
+								ownership = null;
+							}
+							// When every target mutation is already reversed, no write is required,
+							// so competing ownership is not consulted. The empty ownership view keeps
+							// the per-resource loops on their no-op path (no shared resources, no
+							// writes) while still recording durable "already_reversed" steps.
+							const ownershipView: ActiveDeploymentOwnership = ownership ?? {
+								sharedCustomFormatIds: new Set(),
+								sharedQualityProfileIds: new Set(),
+								namingOwnedByAnotherDeployment: false,
+								restorableSharedCustomFormatIds: new Set(),
+								restorableSharedQualityProfileIds: new Set(),
+								sharedNamingRestorationAllowed: false,
+								sharedCustomFormatStateTokens: new Map(),
+								sharedQualityProfileStateTokens: new Map(),
+								sharedNamingStateTokens: new Set(),
+							};
+
+							let existingProgress: UndeployStep[];
+							try {
+								existingProgress = parseUndeployProgress(history.undeployProgress);
+							} catch (error) {
+								request.log.warn({ err: error, historyId }, "Invalid undeploy progress rejected");
+								return stopClaimedUndeploy(409, {
+									success: false,
+									message:
+										"The saved undeploy progress is invalid, so no upstream changes were made.",
+								});
+							}
+							const stepByKey = new Map(existingProgress.map((step) => [step.key, step]));
+							const attemptedAt = undeployAttemptedAt;
+							const setStep = (step: UndeployStep): void => {
+								stepByKey.set(step.key, step);
+							};
+							const persistProgress = async (undeployStatus: "IN_PROGRESS" | "PARTIAL") => {
+								const progress = [...stepByKey.values()];
+								const progressJson = JSON.stringify(progress);
+								await app.prisma.$transaction(async (tx) => {
+									const deployment = await tx.templateDeploymentHistory.updateMany({
+										where: {
+											id: historyId,
+											userId,
+											rolledBack: false,
+											undeployStatus: "IN_PROGRESS",
+											undeployAttemptedAt: attemptedAt,
+										},
+										data: {
+											undeployStatus,
+											undeployAttemptedAt: attemptedAt,
+											undeployProgress: progressJson,
+										},
+									});
+									if (deployment.count !== 1) {
+										throw new Error("Undeploy claim changed before progress could be persisted");
+									}
+									for (const prior of priorPairedSyncStates) {
+										const paired = await tx.trashSyncHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												rollbackStatus: "IN_PROGRESS",
+												rollbackAttemptedAt: attemptedAt,
+											},
+											data: {
+												rollbackStatus: undeployStatus,
+												rollbackAttemptedAt: attemptedAt,
+												rollbackProgress: progressJson,
+											},
 										});
-									} else {
-										assertSharedDeploymentRestorationAllowed(
-											ownershipView.restorableSharedQualityProfileIds.has(profileState.profileId),
-											resourceLabel,
-										);
-										if (profileState.action === "created") {
+										if (paired.count !== 1) {
 											throw new Error(
-												`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
+												"Paired rollback claim changed before progress could be persisted",
 											);
 										}
-										if (!profileState.beforeProfile) {
-											throw new Error(`${resourceLabel} has no prior state to verify.`);
+									}
+								});
+								pairedProgressPersisted = true;
+							};
+							const isFinished = (key: string): boolean => {
+								const outcome = stepByKey.get(key)?.outcome;
+								return (
+									outcome === "restored" ||
+									outcome === "deleted" ||
+									outcome === "already_reversed" ||
+									outcome === "skipped_shared"
+								);
+							};
+
+							// Write intent before the first upstream mutation. An interrupted attempt is
+							// reconciled to PARTIAL on startup and blocks competing mutations.
+							await persistProgress("IN_PROGRESS");
+							let stopAfterProfileFailure = false;
+							const profileState = backupState.qualityProfileDeployment;
+							const profileStatus = profileState.status;
+							if (profileStatus !== "not_started") {
+								const key = `quality_profile:${profileState.profileId ?? profileState.profileName ?? "unknown"}`;
+								if (!isFinished(key)) {
+									if (
+										profileState.profileId !== null &&
+										ownershipView.sharedQualityProfileIds.has(profileState.profileId)
+									) {
+										try {
+											const currentProfile = await client.qualityProfile.getById(
+												profileState.profileId,
+											);
+											const resourceLabel = `quality profile "${profileState.profileName ?? profileState.profileId}"`;
+											const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
+												ownershipView.sharedQualityProfileStateTokens.get(profileState.profileId),
+												resourceLabel,
+											);
+											if (
+												createQualityProfileStateToken(currentProfile) === expectedSurvivorToken
+											) {
+												setStep({
+													key,
+													kind: "quality_profile",
+													name: profileState.profileName ?? "Quality profile",
+													outcome: "skipped_shared",
+												});
+											} else {
+												assertSharedDeploymentRestorationAllowed(
+													ownershipView.restorableSharedQualityProfileIds.has(
+														profileState.profileId,
+													),
+													resourceLabel,
+												);
+												if (profileState.action === "created") {
+													throw new Error(
+														`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
+													);
+												}
+												if (!profileState.beforeProfile) {
+													throw new Error(`${resourceLabel} has no prior state to verify.`);
+												}
+												assertSharedDeploymentState(
+													new Set([expectedSurvivorToken]),
+													createQualityProfileStateToken(profileState.beforeProfile),
+													resourceLabel,
+												);
+												upstreamMutationAttempted = true;
+												await rollbackQualityProfileDeployment(client, {
+													...profileState,
+													status: profileStatus,
+												});
+												const restoredProfile = await client.qualityProfile.getById(
+													profileState.profileId,
+												);
+												assertSharedDeploymentState(
+													new Set([expectedSurvivorToken]),
+													createQualityProfileStateToken(restoredProfile),
+													resourceLabel,
+												);
+												setStep({
+													key,
+													kind: "quality_profile",
+													name: profileState.profileName ?? "Quality profile",
+													outcome: "restored",
+												});
+											}
+										} catch (error) {
+											const message = `Failed to verify shared quality profile: ${getErrorMessage(error)}`;
+											setStep({
+												key,
+												kind: "quality_profile",
+												name: profileState.profileName ?? "Quality profile",
+												outcome: "failed",
+												error: message,
+											});
+											stopAfterProfileFailure = true;
 										}
-										assertSharedDeploymentState(
-											new Set([expectedSurvivorToken]),
-											createQualityProfileStateToken(profileState.beforeProfile),
+									} else {
+										try {
+											upstreamMutationAttempted = true;
+											await rollbackQualityProfileDeployment(client, {
+												...profileState,
+												status: profileStatus,
+											});
+											setStep({
+												key,
+												kind: "quality_profile",
+												name: profileState.profileName ?? "Quality profile",
+												outcome: "restored",
+											});
+										} catch (error) {
+											const message = `Failed to restore quality profile: ${getErrorMessage(error)}`;
+											setStep({
+												key,
+												kind: "quality_profile",
+												name: profileState.profileName ?? "Quality profile",
+												outcome: "failed",
+												error: message,
+											});
+											stopAfterProfileFailure = true;
+										}
+									}
+									await persistProgress("IN_PROGRESS");
+								}
+							}
+
+							for (const state of stopAfterProfileFailure
+								? []
+								: backupState.customFormatDeployments) {
+								const key = `custom_format:${state.resourceId ?? state.name}`;
+								if (isFinished(key)) continue;
+								if (
+									state.resourceId !== null &&
+									ownershipView.sharedCustomFormatIds.has(state.resourceId)
+								) {
+									try {
+										const currentFormat = await client.customFormat.getById(state.resourceId);
+										const resourceLabel = `Custom Format "${state.name}"`;
+										const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
+											ownershipView.sharedCustomFormatStateTokens.get(state.resourceId),
 											resourceLabel,
 										);
-										upstreamMutationAttempted = true;
-										await rollbackQualityProfileDeployment(client, {
-											...profileState,
-											status: profileStatus,
-										});
-										const restoredProfile = await client.qualityProfile.getById(
-											profileState.profileId,
-										);
-										assertSharedDeploymentState(
-											new Set([expectedSurvivorToken]),
-											createQualityProfileStateToken(restoredProfile),
-											resourceLabel,
-										);
+										if (createUpstreamResourceStateToken(currentFormat) === expectedSurvivorToken) {
+											setStep({
+												key,
+												kind: "custom_format",
+												name: state.name,
+												outcome: "skipped_shared",
+											});
+										} else {
+											assertSharedDeploymentRestorationAllowed(
+												ownershipView.restorableSharedCustomFormatIds.has(state.resourceId),
+												resourceLabel,
+											);
+											if (state.action === "created") {
+												throw new Error(
+													`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
+												);
+											}
+											if (!state.beforeFormat) {
+												throw new Error(`${resourceLabel} has no prior state to verify.`);
+											}
+											assertSharedDeploymentState(
+												new Set([expectedSurvivorToken]),
+												createUpstreamResourceStateToken(state.beforeFormat),
+												resourceLabel,
+											);
+											upstreamMutationAttempted = true;
+											await rollbackCustomFormatDeployment(client, state);
+											const restoredFormat = await client.customFormat.getById(state.resourceId);
+											assertSharedDeploymentState(
+												new Set([expectedSurvivorToken]),
+												createUpstreamResourceStateToken(restoredFormat),
+												resourceLabel,
+											);
+											setStep({
+												key,
+												kind: "custom_format",
+												name: state.name,
+												outcome: "restored",
+											});
+										}
+									} catch (error) {
+										const message = `Failed to verify shared Custom Format "${state.name}": ${getErrorMessage(error)}`;
 										setStep({
 											key,
-											kind: "quality_profile",
-											name: profileState.profileName ?? "Quality profile",
-											outcome: "restored",
+											kind: "custom_format",
+											name: state.name,
+											outcome: "failed",
+											error: message,
 										});
 									}
-								} catch (error) {
-									const message = `Failed to verify shared quality profile: ${getErrorMessage(error)}`;
-									setStep({
-										key,
-										kind: "quality_profile",
-										name: profileState.profileName ?? "Quality profile",
-										outcome: "failed",
-										error: message,
-									});
-									stopAfterProfileFailure = true;
+									await persistProgress("IN_PROGRESS");
+									continue;
 								}
-							} else {
 								try {
 									upstreamMutationAttempted = true;
-									await rollbackQualityProfileDeployment(client, {
-										...profileState,
-										status: profileStatus,
-									});
-									setStep({
-										key,
-										kind: "quality_profile",
-										name: profileState.profileName ?? "Quality profile",
-										outcome: "restored",
-									});
-								} catch (error) {
-									const message = `Failed to restore quality profile: ${getErrorMessage(error)}`;
-									setStep({
-										key,
-										kind: "quality_profile",
-										name: profileState.profileName ?? "Quality profile",
-										outcome: "failed",
-										error: message,
-									});
-									stopAfterProfileFailure = true;
-								}
-							}
-							await persistProgress("IN_PROGRESS");
-						}
-					}
-
-					for (const state of stopAfterProfileFailure ? [] : backupState.customFormatDeployments) {
-						const key = `custom_format:${state.resourceId ?? state.name}`;
-						if (isFinished(key)) continue;
-						if (
-							state.resourceId !== null &&
-							ownershipView.sharedCustomFormatIds.has(state.resourceId)
-						) {
-							try {
-								const currentFormat = await client.customFormat.getById(state.resourceId);
-								const resourceLabel = `Custom Format "${state.name}"`;
-								const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-									ownershipView.sharedCustomFormatStateTokens.get(state.resourceId),
-									resourceLabel,
-								);
-								if (createUpstreamResourceStateToken(currentFormat) === expectedSurvivorToken) {
+									const result = await rollbackCustomFormatDeployment(client, state);
 									setStep({
 										key,
 										kind: "custom_format",
 										name: state.name,
-										outcome: "skipped_shared",
+										outcome: result === "noop" ? "already_reversed" : result,
 									});
-								} else {
-									assertSharedDeploymentRestorationAllowed(
-										ownershipView.restorableSharedCustomFormatIds.has(state.resourceId),
-										resourceLabel,
-									);
-									if (state.action === "created") {
-										throw new Error(
-											`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
-										);
-									}
-									if (!state.beforeFormat) {
-										throw new Error(`${resourceLabel} has no prior state to verify.`);
-									}
-									assertSharedDeploymentState(
-										new Set([expectedSurvivorToken]),
-										createUpstreamResourceStateToken(state.beforeFormat),
-										resourceLabel,
-									);
-									upstreamMutationAttempted = true;
-									await rollbackCustomFormatDeployment(client, state);
-									const restoredFormat = await client.customFormat.getById(state.resourceId);
-									assertSharedDeploymentState(
-										new Set([expectedSurvivorToken]),
-										createUpstreamResourceStateToken(restoredFormat),
-										resourceLabel,
-									);
+								} catch (error) {
+									const message = `Failed to undeploy "${state.name}": ${getErrorMessage(error)}`;
 									setStep({
 										key,
 										kind: "custom_format",
 										name: state.name,
-										outcome: "restored",
+										outcome: "failed",
+										error: message,
 									});
 								}
-							} catch (error) {
-								const message = `Failed to verify shared Custom Format "${state.name}": ${getErrorMessage(error)}`;
-								setStep({
-									key,
-									kind: "custom_format",
-									name: state.name,
-									outcome: "failed",
-									error: message,
-								});
+								await persistProgress("IN_PROGRESS");
 							}
-							await persistProgress("IN_PROGRESS");
-							continue;
-						}
-						try {
-							upstreamMutationAttempted = true;
-							const result = await rollbackCustomFormatDeployment(client, state);
-							setStep({
-								key,
-								kind: "custom_format",
-								name: state.name,
-								outcome: result === "noop" ? "already_reversed" : result,
-							});
-						} catch (error) {
-							const message = `Failed to undeploy "${state.name}": ${getErrorMessage(error)}`;
-							setStep({
-								key,
-								kind: "custom_format",
-								name: state.name,
-								outcome: "failed",
-								error: message,
-							});
-						}
-						await persistProgress("IN_PROGRESS");
-					}
 
-					const namingState = backupState.namingDeployment;
-					if (namingState && namingState.status !== "not_started" && !stopAfterProfileFailure) {
-						const key = "naming:configuration";
-						const rollbackNamingStateToken =
-							namingState.postStateToken ??
-							(namingState.status === "pending" ? namingState.intendedPostStateToken : null);
-						if (!isFinished(key)) {
-							if (ownershipView.namingOwnedByAnotherDeployment) {
-								try {
-									const currentResponse = await app.arrClientFactory.rawRequest(
-										currentInstance,
-										"/api/v3/config/naming",
-									);
-									if (!currentResponse.ok) {
-										throw new Error(`HTTP ${currentResponse.status}`);
-									}
-									const currentConfig = (await currentResponse.json()) as Record<string, unknown>;
-									const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
-										ownershipView.sharedNamingStateTokens,
-										"naming configuration",
-									);
-									if (createUpstreamResourceStateToken(currentConfig) === expectedSurvivorToken) {
+							const namingState = backupState.namingDeployment;
+							if (namingState && namingState.status !== "not_started" && !stopAfterProfileFailure) {
+								const key = "naming:configuration";
+								const rollbackNamingStateToken =
+									namingState.postStateToken ??
+									(namingState.status === "pending" ? namingState.intendedPostStateToken : null);
+								if (!isFinished(key)) {
+									if (ownershipView.namingOwnedByAnotherDeployment) {
+										try {
+											const currentResponse = await app.arrClientFactory.rawRequest(
+												currentInstance,
+												"/api/v3/config/naming",
+											);
+											if (!currentResponse.ok) {
+												throw new Error(`HTTP ${currentResponse.status}`);
+											}
+											const currentConfig = (await currentResponse.json()) as Record<
+												string,
+												unknown
+											>;
+											const expectedSurvivorToken = getExpectedSharedDeploymentStateToken(
+												ownershipView.sharedNamingStateTokens,
+												"naming configuration",
+											);
+											if (
+												createUpstreamResourceStateToken(currentConfig) === expectedSurvivorToken
+											) {
+												setStep({
+													key,
+													kind: "naming",
+													name: "Naming configuration",
+													outcome: "skipped_shared",
+												});
+											} else {
+												assertSharedDeploymentRestorationAllowed(
+													ownershipView.sharedNamingRestorationAllowed,
+													"naming configuration",
+												);
+												if (!rollbackNamingStateToken) {
+													throw new Error("The deployment has no verifiable naming post-state.");
+												}
+												assertSharedDeploymentState(
+													new Set([expectedSurvivorToken]),
+													createUpstreamResourceStateToken(namingState.beforeConfig),
+													"naming configuration",
+												);
+												upstreamMutationAttempted = true;
+												await restoreNamingDeployment(
+													app.arrClientFactory,
+													currentInstance,
+													namingState.beforeConfig,
+													rollbackNamingStateToken,
+												);
+												const restoredResponse = await app.arrClientFactory.rawRequest(
+													currentInstance,
+													"/api/v3/config/naming",
+												);
+												if (!restoredResponse.ok) {
+													throw new Error(`HTTP ${restoredResponse.status}`);
+												}
+												const restoredConfig = (await restoredResponse.json()) as Record<
+													string,
+													unknown
+												>;
+												assertSharedDeploymentState(
+													new Set([expectedSurvivorToken]),
+													createUpstreamResourceStateToken(restoredConfig),
+													"naming configuration",
+												);
+												setStep({
+													key,
+													kind: "naming",
+													name: "Naming configuration",
+													outcome: "restored",
+												});
+											}
+										} catch (error) {
+											const message = `Failed to verify shared naming configuration: ${getErrorMessage(error)}`;
+											setStep({
+												key,
+												kind: "naming",
+												name: "Naming configuration",
+												outcome: "failed",
+												error: message,
+											});
+										}
+									} else if (!rollbackNamingStateToken) {
+										const message =
+											"Naming may have changed, but its post-deployment state was not verified.";
 										setStep({
 											key,
 											kind: "naming",
 											name: "Naming configuration",
-											outcome: "skipped_shared",
+											outcome: "failed",
+											error: message,
 										});
 									} else {
-										assertSharedDeploymentRestorationAllowed(
-											ownershipView.sharedNamingRestorationAllowed,
-											"naming configuration",
-										);
-										if (!rollbackNamingStateToken) {
-											throw new Error("The deployment has no verifiable naming post-state.");
+										try {
+											upstreamMutationAttempted = true;
+											await restoreNamingDeployment(
+												app.arrClientFactory,
+												currentInstance,
+												namingState.beforeConfig,
+												rollbackNamingStateToken,
+											);
+											setStep({
+												key,
+												kind: "naming",
+												name: "Naming configuration",
+												outcome: "restored",
+											});
+										} catch (error) {
+											const message = `Failed to restore naming configuration: ${getErrorMessage(error)}`;
+											setStep({
+												key,
+												kind: "naming",
+												name: "Naming configuration",
+												outcome: "failed",
+												error: message,
+											});
 										}
-										assertSharedDeploymentState(
-											new Set([expectedSurvivorToken]),
-											createUpstreamResourceStateToken(namingState.beforeConfig),
-											"naming configuration",
-										);
-										upstreamMutationAttempted = true;
-										await restoreNamingDeployment(
-											app.arrClientFactory,
-											currentInstance,
-											namingState.beforeConfig,
-											rollbackNamingStateToken,
-										);
-										const restoredResponse = await app.arrClientFactory.rawRequest(
-											currentInstance,
-											"/api/v3/config/naming",
-										);
-										if (!restoredResponse.ok) {
-											throw new Error(`HTTP ${restoredResponse.status}`);
-										}
-										const restoredConfig = (await restoredResponse.json()) as Record<
-											string,
-											unknown
-										>;
-										assertSharedDeploymentState(
-											new Set([expectedSurvivorToken]),
-											createUpstreamResourceStateToken(restoredConfig),
-											"naming configuration",
-										);
-										setStep({
-											key,
-											kind: "naming",
-											name: "Naming configuration",
-											outcome: "restored",
-										});
 									}
-								} catch (error) {
-									const message = `Failed to verify shared naming configuration: ${getErrorMessage(error)}`;
-									setStep({
-										key,
-										kind: "naming",
-										name: "Naming configuration",
-										outcome: "failed",
-										error: message,
-									});
+									await persistProgress("IN_PROGRESS");
 								}
-							} else if (!rollbackNamingStateToken) {
-								const message =
-									"Naming may have changed, but its post-deployment state was not verified.";
-								setStep({
-									key,
-									kind: "naming",
-									name: "Naming configuration",
-									outcome: "failed",
-									error: message,
+							}
+
+							const progress = [...stepByKey.values()];
+							const errors = progress.flatMap((step) =>
+								step.outcome === "failed" && step.error ? [step.error] : [],
+							);
+							const deletedCFs = progress
+								.filter((step) => step.kind === "custom_format" && step.outcome === "deleted")
+								.map((step) => step.name);
+							const restoredCFs = progress
+								.filter((step) => step.kind === "custom_format" && step.outcome === "restored")
+								.map((step) => step.name);
+							const skippedShared = progress
+								.filter((step) => step.outcome === "skipped_shared")
+								.map((step) => step.name);
+
+							if (errors.length === 0) {
+								const now = new Date();
+								await app.prisma.$transaction(async (tx) => {
+									const deployment = await tx.templateDeploymentHistory.updateMany({
+										where: {
+											id: historyId,
+											userId,
+											rolledBack: false,
+											undeployStatus: "IN_PROGRESS",
+											undeployAttemptedAt: attemptedAt,
+										},
+										data: {
+											rolledBack: true,
+											rolledBackAt: now,
+											rolledBackBy: userId,
+											undeployStatus: "COMPLETED",
+											undeployAttemptedAt: attemptedAt,
+											undeployProgress: JSON.stringify(progress),
+										},
+									});
+									if (deployment.count !== 1) {
+										throw new Error("Undeploy claim changed before completion could be persisted");
+									}
+									for (const prior of priorPairedSyncStates) {
+										const paired = await tx.trashSyncHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												rollbackStatus: "IN_PROGRESS",
+												rollbackAttemptedAt: attemptedAt,
+											},
+											data: {
+												rolledBack: true,
+												rolledBackAt: now,
+												rollbackStatus: "COMPLETED",
+												rollbackAttemptedAt: attemptedAt,
+												rollbackProgress: JSON.stringify(progress),
+											},
+										});
+										if (paired.count !== 1) {
+											throw new Error(
+												"Paired rollback claim changed before completion could be persisted",
+											);
+										}
+									}
 								});
 							} else {
-								try {
-									upstreamMutationAttempted = true;
-									await restoreNamingDeployment(
-										app.arrClientFactory,
-										currentInstance,
-										namingState.beforeConfig,
-										rollbackNamingStateToken,
-									);
-									setStep({
-										key,
-										kind: "naming",
-										name: "Naming configuration",
-										outcome: "restored",
-									});
-								} catch (error) {
-									const message = `Failed to restore naming configuration: ${getErrorMessage(error)}`;
-									setStep({
-										key,
-										kind: "naming",
-										name: "Naming configuration",
-										outcome: "failed",
-										error: message,
-									});
-								}
+								await persistProgress("PARTIAL");
 							}
-							await persistProgress("IN_PROGRESS");
-						}
-					}
-
-					const progress = [...stepByKey.values()];
-					const errors = progress.flatMap((step) =>
-						step.outcome === "failed" && step.error ? [step.error] : [],
-					);
-					const deletedCFs = progress
-						.filter((step) => step.kind === "custom_format" && step.outcome === "deleted")
-						.map((step) => step.name);
-					const restoredCFs = progress
-						.filter((step) => step.kind === "custom_format" && step.outcome === "restored")
-						.map((step) => step.name);
-					const skippedShared = progress
-						.filter((step) => step.outcome === "skipped_shared")
-						.map((step) => step.name);
-
-					if (errors.length === 0) {
-						const now = new Date();
-						await app.prisma.$transaction(async (tx) => {
-							await tx.templateDeploymentHistory.update({
-								where: { id: historyId },
+							return reply.send({
+								success: errors.length === 0,
+								message:
+									errors.length === 0
+										? "Deployment changes were reversed using exact upstream identities."
+										: "Undeploy completed with errors; it remains retryable.",
 								data: {
-									rolledBack: true,
-									rolledBackAt: now,
-									rolledBackBy: userId,
-									undeployStatus: "COMPLETED",
-									undeployAttemptedAt: attemptedAt,
-									undeployProgress: JSON.stringify(progress),
+									deleted: deletedCFs.length,
+									deletedCFs,
+									restoredCFs,
+									skippedShared,
+									errors,
 								},
 							});
-							if (history.backupId) {
-								await tx.trashSyncHistory.updateMany({
-									where: { backupId: history.backupId, userId },
-									data: {
-										rolledBack: true,
-										rolledBackAt: now,
-										rollbackStatus: "COMPLETED",
-										rollbackAttemptedAt: attemptedAt,
-										rollbackProgress: JSON.stringify(progress),
-									},
-								});
-							}
-						});
-					} else {
-						await persistProgress("PARTIAL");
-						if (history.backupId) {
-							await app.prisma.trashSyncHistory.updateMany({
-								where: { backupId: history.backupId, userId },
-								data: {
-									rollbackStatus: "PARTIAL",
-									rollbackAttemptedAt: attemptedAt,
-									rollbackProgress: JSON.stringify(progress),
-								},
-							});
-						}
-					}
-					return reply.send({
-						success: errors.length === 0,
-						message:
-							errors.length === 0
-								? "Deployment changes were reversed using exact upstream identities."
-								: "Undeploy completed with errors; it remains retryable.",
-						data: {
-							deleted: deletedCFs.length,
-							deletedCFs,
-							restoredCFs,
-							skippedShared,
-							errors,
 						},
+					)
+					.catch(async (error) => {
+						const message = getErrorMessage(error, "Undeploy failed");
+						try {
+							if (upstreamMutationAttempted) {
+								await persistPartialUndeploy();
+							} else {
+								await releaseUndeployClaim();
+							}
+						} catch (stateError) {
+							request.log.error(
+								{ err: stateError, historyId, undeployAttemptedAt },
+								"Failed to persist undeploy failure state",
+							);
+						}
+						request.log.error({ err: error, historyId }, "Deployment undeploy failed");
+						const statusCode =
+							error &&
+							typeof error === "object" &&
+							"statusCode" in error &&
+							typeof error.statusCode === "number"
+								? error.statusCode
+								: 500;
+						return reply.status(upstreamMutationAttempted ? 207 : statusCode).send({
+							success: false,
+							message: upstreamMutationAttempted
+								? "ARR changes may have completed, but recovery state could not be finalized. The undeploy remains retryable."
+								: message,
+						});
 					});
-				},
-			),
-		).catch(async (error) => {
-			const message = getErrorMessage(error, "Undeploy failed");
-			try {
-				if (upstreamMutationAttempted) {
-					await persistPartialUndeploy();
-				} else {
-					await releaseUndeployClaim();
-				}
-			} catch (stateError) {
-				request.log.error(
-					{ err: stateError, historyId, undeployAttemptedAt },
-					"Failed to persist undeploy failure state",
-				);
-			}
-			request.log.error({ err: error, historyId }, "Deployment undeploy failed");
-			const statusCode =
-				error &&
-				typeof error === "object" &&
-				"statusCode" in error &&
-				typeof error.statusCode === "number"
-					? error.statusCode
-					: 500;
-			return reply.status(upstreamMutationAttempted ? 207 : statusCode).send({
-				success: false,
-				message: upstreamMutationAttempted
-					? "ARR changes may have completed, but recovery state could not be finalized. The undeploy remains retryable."
-					: message,
-			});
-		});
+			},
+		);
 	});
 };

--- a/apps/api/src/routes/trash-guides/deployment-history-routes.ts
+++ b/apps/api/src/routes/trash-guides/deployment-history-routes.ts
@@ -8,7 +8,10 @@ import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyPluginAsync } from "fastify";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
 import { isNonterminalUndeploy } from "../../lib/backup/backup-validation.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import {
+	CleanupRunLeaseLostError,
+	withCleanupTopologyMutationLease,
+} from "../../lib/library-cleanup/cleanup-executor.js";
 import {
 	type ActiveDeploymentOwnership,
 	assertSharedDeploymentRestorationAllowed,
@@ -33,7 +36,10 @@ import {
 	getEquivalentServiceInstanceIds,
 	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
-import { claimUndeployRecoveryGroup } from "../../lib/trash-guides/recovery-history-claim.js";
+import {
+	claimUndeployRecoveryGroup,
+	mutateClaimedRecoveryGroup,
+} from "../../lib/trash-guides/recovery-history-claim.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 
 interface UndeployStep {
@@ -525,7 +531,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 		return withCleanupTopologyMutationLease(
 			{ prisma: app.prisma, log: request.log },
 			userId,
-			async () => {
+			async (topologyLease) => {
 				const leasedHistory = await app.prisma.templateDeploymentHistory.findFirst({
 					where: { id: historyId, userId },
 					include: {
@@ -562,6 +568,11 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 							where: { backupId: leasedHistory.backupId, userId },
 							select: {
 								id: true,
+								userId: true,
+								instanceId: true,
+								templateId: true,
+								backupId: true,
+								status: true,
 								rolledBack: true,
 								rollbackStatus: true,
 								rollbackAttemptedAt: true,
@@ -588,17 +599,23 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 					});
 				}
 				const undeployAttemptedAt = new Date();
+				const deploymentRecoveryState = {
+					id: historyId,
+					userId: leasedHistory.userId,
+					instanceId: leasedHistory.instanceId,
+					templateId: leasedHistory.templateId,
+					backupId: leasedHistory.backupId,
+					status: priorStatus,
+					rolledBack: false,
+					undeployStatus: priorUndeployStatus,
+					undeployAttemptedAt: priorUndeployAttemptedAt,
+					undeployProgress: priorUndeployProgress,
+				};
+				await topologyLease.assertOwnership();
 				const claimed = await claimUndeployRecoveryGroup(
 					app.prisma,
 					userId,
-					{
-						id: historyId,
-						status: priorStatus,
-						rolledBack: false,
-						undeployStatus: priorUndeployStatus,
-						undeployAttemptedAt: priorUndeployAttemptedAt,
-						undeployProgress: priorUndeployProgress,
-					},
+					deploymentRecoveryState,
 					priorPairedSyncStates,
 					undeployAttemptedAt,
 				);
@@ -610,131 +627,48 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 							"Paired recovery history changed, is already active, or requires explicit resolution.",
 					});
 				}
-				let pairedProgressPersisted = true;
-
 				const persistPartialUndeploy = async () => {
-					if (!pairedProgressPersisted) {
-						const result = await app.prisma.templateDeploymentHistory.updateMany({
-							where: {
-								id: historyId,
-								userId,
-								status: priorStatus,
-								rolledBack: false,
-								undeployStatus: "IN_PROGRESS",
-								undeployAttemptedAt,
-							},
-							data: {
+					await mutateClaimedRecoveryGroup(
+						app.prisma,
+						userId,
+						[deploymentRecoveryState],
+						priorPairedSyncStates,
+						undeployAttemptedAt,
+						{
+							deploymentData: () => ({
 								status: "PARTIAL_UNDEPLOY",
 								undeployStatus: "PARTIAL",
-							},
-						});
-						if (result.count !== 1) {
-							throw new Error("Undeploy recovery state changed before progress could be persisted");
-						}
-						return;
-					}
-					await app.prisma.$transaction(async (tx) => {
-						const result = await tx.templateDeploymentHistory.updateMany({
-							where: {
-								id: historyId,
-								userId,
-								status: priorStatus,
-								rolledBack: false,
-								undeployStatus: "IN_PROGRESS",
-								undeployAttemptedAt,
-							},
-							data: { status: "PARTIAL_UNDEPLOY", undeployStatus: "PARTIAL" },
-						});
-						if (result.count !== 1) {
-							throw new Error("Undeploy recovery state changed before progress could be persisted");
-						}
-						for (const prior of priorPairedSyncStates) {
-							const paired = await tx.trashSyncHistory.updateMany({
-								where: {
-									id: prior.id,
-									userId,
-									rolledBack: false,
-									rollbackStatus: "IN_PROGRESS",
-									rollbackAttemptedAt: undeployAttemptedAt,
-								},
-								data: { rollbackStatus: "PARTIAL" },
-							});
-							if (paired.count !== 1) {
-								throw new Error("Paired rollback state changed before progress could be persisted");
-							}
-						}
-					});
+							}),
+							syncData: () => ({ rollbackStatus: "PARTIAL" }),
+							conflictMessage: "Recovery state changed before partial undeploy could be persisted",
+						},
+					);
 				};
 				// Release this request's claim back to the exact recovery state that existed
 				// before the claim. The compare-and-set guard ensures a stale request cannot
 				// release a newer claim that another process has since taken over.
 				const releaseUndeployClaim = async () => {
-					if (pairedProgressPersisted) {
-						await app.prisma.$transaction(async (tx) => {
-							const result = await tx.templateDeploymentHistory.updateMany({
-								where: {
-									id: historyId,
-									userId,
-									status: priorStatus,
-									rolledBack: false,
-									undeployStatus: "IN_PROGRESS",
-									undeployAttemptedAt,
-								},
-								data: {
-									status: priorStatus,
-									undeployStatus: priorUndeployStatus,
-									undeployAttemptedAt: priorUndeployAttemptedAt,
-									undeployProgress: priorUndeployProgress,
-								},
-							});
-							if (result.count !== 1) {
-								throw new Error(
-									"Undeploy recovery state changed before the claim could be released",
-								);
-							}
-							for (const prior of priorPairedSyncStates) {
-								const paired = await tx.trashSyncHistory.updateMany({
-									where: {
-										id: prior.id,
-										userId,
-										rolledBack: false,
-										rollbackStatus: "IN_PROGRESS",
-										rollbackAttemptedAt: undeployAttemptedAt,
-									},
-									data: {
-										rollbackStatus: prior.rollbackStatus,
-										rollbackAttemptedAt: prior.rollbackAttemptedAt,
-										rollbackProgress: prior.rollbackProgress,
-									},
-								});
-								if (paired.count !== 1) {
-									throw new Error(
-										"Paired rollback state changed before the claim could be released",
-									);
-								}
-							}
-						});
-						return;
-					}
-					const result = await app.prisma.templateDeploymentHistory.updateMany({
-						where: {
-							id: historyId,
-							userId,
-							status: priorStatus,
-							rolledBack: false,
-							undeployStatus: "IN_PROGRESS",
-							undeployAttemptedAt,
+					await mutateClaimedRecoveryGroup(
+						app.prisma,
+						userId,
+						[deploymentRecoveryState],
+						priorPairedSyncStates,
+						undeployAttemptedAt,
+						{
+							deploymentData: () => ({
+								status: priorStatus,
+								undeployStatus: priorUndeployStatus,
+								undeployAttemptedAt: priorUndeployAttemptedAt,
+								undeployProgress: priorUndeployProgress,
+							}),
+							syncData: (prior) => ({
+								rollbackStatus: prior.rollbackStatus,
+								rollbackAttemptedAt: prior.rollbackAttemptedAt,
+								rollbackProgress: prior.rollbackProgress,
+							}),
+							conflictMessage: "Recovery state changed before the undeploy claim could be released",
 						},
-						data: {
-							status: priorStatus,
-							undeployStatus: priorUndeployStatus,
-							undeployAttemptedAt: priorUndeployAttemptedAt,
-							undeployProgress: priorUndeployProgress,
-						},
-					});
-					if (result.count !== 1) {
-						throw new Error("Undeploy recovery state changed before the claim could be released");
-					}
+					);
 				};
 				const stopClaimedUndeploy = async (
 					statusCode: number,
@@ -918,49 +852,29 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 								stepByKey.set(step.key, step);
 							};
 							const persistProgress = async (undeployStatus: "IN_PROGRESS" | "PARTIAL") => {
+								await topologyLease.assertOwnership();
 								const progress = [...stepByKey.values()];
 								const progressJson = JSON.stringify(progress);
-								await app.prisma.$transaction(async (tx) => {
-									const deployment = await tx.templateDeploymentHistory.updateMany({
-										where: {
-											id: historyId,
-											userId,
-											rolledBack: false,
-											undeployStatus: "IN_PROGRESS",
-											undeployAttemptedAt: attemptedAt,
-										},
-										data: {
+								await mutateClaimedRecoveryGroup(
+									app.prisma,
+									userId,
+									[deploymentRecoveryState],
+									priorPairedSyncStates,
+									attemptedAt,
+									{
+										deploymentData: () => ({
 											undeployStatus,
 											undeployAttemptedAt: attemptedAt,
 											undeployProgress: progressJson,
-										},
-									});
-									if (deployment.count !== 1) {
-										throw new Error("Undeploy claim changed before progress could be persisted");
-									}
-									for (const prior of priorPairedSyncStates) {
-										const paired = await tx.trashSyncHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												rollbackStatus: "IN_PROGRESS",
-												rollbackAttemptedAt: attemptedAt,
-											},
-											data: {
-												rollbackStatus: undeployStatus,
-												rollbackAttemptedAt: attemptedAt,
-												rollbackProgress: progressJson,
-											},
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired rollback claim changed before progress could be persisted",
-											);
-										}
-									}
-								});
-								pairedProgressPersisted = true;
+										}),
+										syncData: () => ({
+											rollbackStatus: undeployStatus,
+											rollbackAttemptedAt: attemptedAt,
+											rollbackProgress: progressJson,
+										}),
+										conflictMessage: "Recovery claim changed before progress could be persisted",
+									},
+								);
 							};
 							const isFinished = (key: string): boolean => {
 								const outcome = stepByKey.get(key)?.outcome;
@@ -1023,6 +937,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 													createQualityProfileStateToken(profileState.beforeProfile),
 													resourceLabel,
 												);
+												await topologyLease.assertOwnership();
 												upstreamMutationAttempted = true;
 												await rollbackQualityProfileDeployment(client, {
 													...profileState,
@@ -1044,6 +959,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 												});
 											}
 										} catch (error) {
+											if (error instanceof CleanupRunLeaseLostError) throw error;
 											const message = `Failed to verify shared quality profile: ${getErrorMessage(error)}`;
 											setStep({
 												key,
@@ -1056,6 +972,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 										}
 									} else {
 										try {
+											await topologyLease.assertOwnership();
 											upstreamMutationAttempted = true;
 											await rollbackQualityProfileDeployment(client, {
 												...profileState,
@@ -1068,6 +985,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 												outcome: "restored",
 											});
 										} catch (error) {
+											if (error instanceof CleanupRunLeaseLostError) throw error;
 											const message = `Failed to restore quality profile: ${getErrorMessage(error)}`;
 											setStep({
 												key,
@@ -1124,6 +1042,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 												createUpstreamResourceStateToken(state.beforeFormat),
 												resourceLabel,
 											);
+											await topologyLease.assertOwnership();
 											upstreamMutationAttempted = true;
 											await rollbackCustomFormatDeployment(client, state);
 											const restoredFormat = await client.customFormat.getById(state.resourceId);
@@ -1140,6 +1059,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 											});
 										}
 									} catch (error) {
+										if (error instanceof CleanupRunLeaseLostError) throw error;
 										const message = `Failed to verify shared Custom Format "${state.name}": ${getErrorMessage(error)}`;
 										setStep({
 											key,
@@ -1153,6 +1073,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 									continue;
 								}
 								try {
+									await topologyLease.assertOwnership();
 									upstreamMutationAttempted = true;
 									const result = await rollbackCustomFormatDeployment(client, state);
 									setStep({
@@ -1162,6 +1083,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 										outcome: result === "noop" ? "already_reversed" : result,
 									});
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to undeploy "${state.name}": ${getErrorMessage(error)}`;
 									setStep({
 										key,
@@ -1220,6 +1142,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 													createUpstreamResourceStateToken(namingState.beforeConfig),
 													"naming configuration",
 												);
+												await topologyLease.assertOwnership();
 												upstreamMutationAttempted = true;
 												await restoreNamingDeployment(
 													app.arrClientFactory,
@@ -1251,6 +1174,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 												});
 											}
 										} catch (error) {
+											if (error instanceof CleanupRunLeaseLostError) throw error;
 											const message = `Failed to verify shared naming configuration: ${getErrorMessage(error)}`;
 											setStep({
 												key,
@@ -1272,6 +1196,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 										});
 									} else {
 										try {
+											await topologyLease.assertOwnership();
 											upstreamMutationAttempted = true;
 											await restoreNamingDeployment(
 												app.arrClientFactory,
@@ -1286,6 +1211,7 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 												outcome: "restored",
 											});
 										} catch (error) {
+											if (error instanceof CleanupRunLeaseLostError) throw error;
 											const message = `Failed to restore naming configuration: ${getErrorMessage(error)}`;
 											setStep({
 												key,
@@ -1316,51 +1242,32 @@ export const deploymentHistoryRoutes: FastifyPluginAsync = async (app) => {
 
 							if (errors.length === 0) {
 								const now = new Date();
-								await app.prisma.$transaction(async (tx) => {
-									const deployment = await tx.templateDeploymentHistory.updateMany({
-										where: {
-											id: historyId,
-											userId,
-											rolledBack: false,
-											undeployStatus: "IN_PROGRESS",
-											undeployAttemptedAt: attemptedAt,
-										},
-										data: {
+								await topologyLease.assertOwnership();
+								await mutateClaimedRecoveryGroup(
+									app.prisma,
+									userId,
+									[deploymentRecoveryState],
+									priorPairedSyncStates,
+									attemptedAt,
+									{
+										deploymentData: () => ({
 											rolledBack: true,
 											rolledBackAt: now,
 											rolledBackBy: userId,
 											undeployStatus: "COMPLETED",
 											undeployAttemptedAt: attemptedAt,
 											undeployProgress: JSON.stringify(progress),
-										},
-									});
-									if (deployment.count !== 1) {
-										throw new Error("Undeploy claim changed before completion could be persisted");
-									}
-									for (const prior of priorPairedSyncStates) {
-										const paired = await tx.trashSyncHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												rollbackStatus: "IN_PROGRESS",
-												rollbackAttemptedAt: attemptedAt,
-											},
-											data: {
-												rolledBack: true,
-												rolledBackAt: now,
-												rollbackStatus: "COMPLETED",
-												rollbackAttemptedAt: attemptedAt,
-												rollbackProgress: JSON.stringify(progress),
-											},
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired rollback claim changed before completion could be persisted",
-											);
-										}
-									}
-								});
+										}),
+										syncData: () => ({
+											rolledBack: true,
+											rolledBackAt: now,
+											rollbackStatus: "COMPLETED",
+											rollbackAttemptedAt: attemptedAt,
+											rollbackProgress: JSON.stringify(progress),
+										}),
+										conflictMessage: "Recovery claim changed before completion could be persisted",
+									},
+								);
 							} else {
 								await persistProgress("PARTIAL");
 							}

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -8,7 +8,10 @@ import type { RadarrClient, SonarrClient } from "arr-sdk";
 import type { FastifyInstance, FastifyPluginOptions, FastifyRequest } from "fastify";
 import { z } from "zod";
 import { requireInstance } from "../../lib/arr/instance-helpers.js";
-import { withCleanupTopologyMutationLease } from "../../lib/library-cleanup/cleanup-executor.js";
+import {
+	CleanupRunLeaseLostError,
+	withCleanupTopologyMutationLease,
+} from "../../lib/library-cleanup/cleanup-executor.js";
 import { createCacheManager } from "../../lib/trash-guides/cache-manager.js";
 import {
 	assertSharedDeploymentRestorationAllowed,
@@ -35,7 +38,10 @@ import {
 	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
 import { createTrashFetcher } from "../../lib/trash-guides/github-fetcher.js";
-import { claimRollbackRecoveryGroup } from "../../lib/trash-guides/recovery-history-claim.js";
+import {
+	claimRollbackRecoveryGroup,
+	mutateClaimedRecoveryGroup,
+} from "../../lib/trash-guides/recovery-history-claim.js";
 import { getRepoConfig } from "../../lib/trash-guides/repo-config.js";
 import type { SyncProgress } from "../../lib/trash-guides/sync-engine.js";
 import { createSyncEngine } from "../../lib/trash-guides/sync-engine.js";
@@ -654,7 +660,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 		return await withCleanupTopologyMutationLease(
 			{ prisma: app.prisma, log: request.log },
 			userId,
-			async () => {
+			async (topologyLease) => {
 				const leasedSync = await app.prisma.trashSyncHistory.findFirst({
 					where: { id: syncId, userId },
 					include: { backup: true, instance: true, template: true },
@@ -678,6 +684,11 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 					where: { backupId: leasedSync.backupId, userId },
 					select: {
 						id: true,
+						userId: true,
+						instanceId: true,
+						templateId: true,
+						backupId: true,
+						status: true,
 						rolledBack: true,
 						rollbackStatus: true,
 						rollbackAttemptedAt: true,
@@ -688,6 +699,11 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 				if (!priorPairedSyncStates.some((paired) => paired.id === leasedSync.id)) {
 					priorPairedSyncStates.push({
 						id: leasedSync.id,
+						userId: leasedSync.userId,
+						instanceId: leasedSync.instanceId,
+						templateId: leasedSync.templateId,
+						backupId: leasedSync.backupId,
+						status: leasedSync.status,
 						rolledBack: leasedSync.rolledBack,
 						rollbackStatus: leasedSync.rollbackStatus,
 						rollbackAttemptedAt: leasedSync.rollbackAttemptedAt,
@@ -698,6 +714,10 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 					where: { backupId: leasedSync.backupId, userId },
 					select: {
 						id: true,
+						userId: true,
+						instanceId: true,
+						templateId: true,
+						backupId: true,
 						status: true,
 						rolledBack: true,
 						undeployStatus: true,
@@ -719,9 +739,6 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 					});
 				}
 
-				const priorRollbackStatus = leasedSync.rollbackStatus;
-				const priorRollbackAttemptedAt = leasedSync.rollbackAttemptedAt;
-				const priorRollbackProgress = leasedSync.rollbackProgress;
 				if (
 					priorPairedSyncStates.some(
 						(paired) => paired.rolledBack || !isClaimableRecoveryStatus(paired.rollbackStatus),
@@ -737,6 +754,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 					});
 				}
 				const rollbackAttemptedAt = new Date();
+				await topologyLease.assertOwnership();
 				const claimed = await claimRollbackRecoveryGroup(
 					app.prisma,
 					userId,
@@ -751,133 +769,48 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 							"Paired recovery history changed, is already active, or requires explicit resolution.",
 					});
 				}
-				let pairedProgressPersisted = true;
-
 				const persistPartialRollback = async () => {
-					if (pairedProgressPersisted) {
-						await app.prisma.$transaction(async (tx) => {
-							for (const prior of priorPairedSyncStates) {
-								const paired = await tx.trashSyncHistory.updateMany({
-									where: {
-										id: prior.id,
-										userId,
-										rolledBack: false,
-										rollbackStatus: "IN_PROGRESS",
-										rollbackAttemptedAt,
-									},
-									data: { rollbackStatus: "PARTIAL" },
-								});
-								if (paired.count !== 1) {
-									throw new Error(
-										"Paired rollback state changed before progress could be persisted",
-									);
-								}
-							}
-							for (const prior of priorPairedDeploymentStates) {
-								const paired = await tx.templateDeploymentHistory.updateMany({
-									where: {
-										id: prior.id,
-										userId,
-										rolledBack: false,
-										undeployStatus: "IN_PROGRESS",
-										undeployAttemptedAt: rollbackAttemptedAt,
-									},
-									data: { status: "PARTIAL_UNDEPLOY", undeployStatus: "PARTIAL" },
-								});
-								if (paired.count !== 1) {
-									throw new Error(
-										"Paired undeploy state changed before progress could be persisted",
-									);
-								}
-							}
-						});
-						return;
-					}
-					const result = await app.prisma.trashSyncHistory.updateMany({
-						where: {
-							id: syncId,
-							userId,
-							rolledBack: false,
-							rollbackStatus: "IN_PROGRESS",
-							rollbackAttemptedAt,
+					await mutateClaimedRecoveryGroup(
+						app.prisma,
+						userId,
+						priorPairedDeploymentStates,
+						priorPairedSyncStates,
+						rollbackAttemptedAt,
+						{
+							deploymentData: () => ({
+								status: "PARTIAL_UNDEPLOY",
+								undeployStatus: "PARTIAL",
+							}),
+							syncData: () => ({ rollbackStatus: "PARTIAL" }),
+							conflictMessage: "Recovery state changed before partial rollback could be persisted",
 						},
-						data: {
-							rollbackStatus: "PARTIAL",
-						},
-					});
-					if (result.count !== 1) {
-						throw new Error("Rollback recovery state changed before progress could be persisted");
-					}
+					);
 				};
 				// Release this request's claim back to the exact recovery state that existed
 				// before the claim. The compare-and-set guard ensures a stale request cannot
 				// release a newer claim that another process has since taken over.
 				const releaseRollbackClaim = async () => {
-					if (pairedProgressPersisted) {
-						await app.prisma.$transaction(async (tx) => {
-							for (const prior of priorPairedSyncStates) {
-								const paired = await tx.trashSyncHistory.updateMany({
-									where: {
-										id: prior.id,
-										userId,
-										rolledBack: false,
-										rollbackStatus: "IN_PROGRESS",
-										rollbackAttemptedAt,
-									},
-									data: {
-										rollbackStatus: prior.rollbackStatus,
-										rollbackAttemptedAt: prior.rollbackAttemptedAt,
-										rollbackProgress: prior.rollbackProgress,
-									},
-								});
-								if (paired.count !== 1) {
-									throw new Error(
-										"Paired rollback state changed before the claim could be released",
-									);
-								}
-							}
-							for (const prior of priorPairedDeploymentStates) {
-								const paired = await tx.templateDeploymentHistory.updateMany({
-									where: {
-										id: prior.id,
-										userId,
-										rolledBack: false,
-										undeployStatus: "IN_PROGRESS",
-										undeployAttemptedAt: rollbackAttemptedAt,
-									},
-									data: {
-										status: prior.status,
-										undeployStatus: prior.undeployStatus,
-										undeployAttemptedAt: prior.undeployAttemptedAt,
-										undeployProgress: prior.undeployProgress,
-									},
-								});
-								if (paired.count !== 1) {
-									throw new Error(
-										"Paired undeploy state changed before the claim could be released",
-									);
-								}
-							}
-						});
-						return;
-					}
-					const result = await app.prisma.trashSyncHistory.updateMany({
-						where: {
-							id: syncId,
-							userId,
-							rolledBack: false,
-							rollbackStatus: "IN_PROGRESS",
-							rollbackAttemptedAt,
+					await mutateClaimedRecoveryGroup(
+						app.prisma,
+						userId,
+						priorPairedDeploymentStates,
+						priorPairedSyncStates,
+						rollbackAttemptedAt,
+						{
+							deploymentData: (prior) => ({
+								status: prior.status,
+								undeployStatus: prior.undeployStatus,
+								undeployAttemptedAt: prior.undeployAttemptedAt,
+								undeployProgress: prior.undeployProgress,
+							}),
+							syncData: (prior) => ({
+								rollbackStatus: prior.rollbackStatus,
+								rollbackAttemptedAt: prior.rollbackAttemptedAt,
+								rollbackProgress: prior.rollbackProgress,
+							}),
+							conflictMessage: "Recovery state changed before the rollback claim could be released",
 						},
-						data: {
-							rollbackStatus: priorRollbackStatus,
-							rollbackAttemptedAt: priorRollbackAttemptedAt,
-							rollbackProgress: priorRollbackProgress,
-						},
-					});
-					if (result.count !== 1) {
-						throw new Error("Rollback recovery state changed before the claim could be released");
-					}
+					);
 				};
 				const stopClaimedRollback = async (
 					statusCode: number,
@@ -1128,48 +1061,28 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 							const persistRollbackProgress = async (
 								rollbackStatus: "IN_PROGRESS" | "PARTIAL",
 							): Promise<void> => {
+								await topologyLease.assertOwnership();
 								const rollbackProgress = JSON.stringify([...stepByKey.values()]);
-								await app.prisma.$transaction(async (tx) => {
-									for (const prior of priorPairedSyncStates) {
-										const paired = await tx.trashSyncHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												rollbackStatus: "IN_PROGRESS",
-												rollbackAttemptedAt,
-											},
-											data: { rollbackStatus, rollbackAttemptedAt, rollbackProgress },
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired rollback claim changed before progress was persisted",
-											);
-										}
-									}
-									for (const prior of priorPairedDeploymentStates) {
-										const paired = await tx.templateDeploymentHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												undeployStatus: "IN_PROGRESS",
-												undeployAttemptedAt: rollbackAttemptedAt,
-											},
-											data: {
-												undeployStatus: rollbackStatus,
-												undeployAttemptedAt: rollbackAttemptedAt,
-												undeployProgress: rollbackProgress,
-											},
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired undeploy claim changed before progress was persisted",
-											);
-										}
-									}
-								});
-								pairedProgressPersisted = true;
+								await mutateClaimedRecoveryGroup(
+									app.prisma,
+									userId,
+									priorPairedDeploymentStates,
+									priorPairedSyncStates,
+									rollbackAttemptedAt,
+									{
+										deploymentData: () => ({
+											undeployStatus: rollbackStatus,
+											undeployAttemptedAt: rollbackAttemptedAt,
+											undeployProgress: rollbackProgress,
+										}),
+										syncData: () => ({
+											rollbackStatus,
+											rollbackAttemptedAt,
+											rollbackProgress,
+										}),
+										conflictMessage: "Recovery claim changed before progress was persisted",
+									},
+								);
 							};
 							await persistRollbackProgress("IN_PROGRESS");
 							if (
@@ -1263,6 +1176,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 												`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
 											);
 										}
+										await topologyLease.assertOwnership();
 										upstreamMutationAttempted = true;
 										await rollbackQualityProfileDeployment(client, backupQualityProfileDeployment);
 										const restoredProfile = await client.qualityProfile.getById(
@@ -1281,6 +1195,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										});
 									}
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to verify shared quality profile: ${getErrorMessage(error, "Unknown error")}`;
 									setStep({
 										key: profileStepKey,
@@ -1297,6 +1212,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 								!isFinished(profileStepKey, "quality_profile", profileStepName)
 							) {
 								try {
+									await topologyLease.assertOwnership();
 									upstreamMutationAttempted = true;
 									await rollbackQualityProfileDeployment(client, backupQualityProfileDeployment);
 									request.log.info(
@@ -1313,6 +1229,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										outcome: "restored",
 									});
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to roll back quality profile: ${getErrorMessage(error, "Unknown error")}`;
 									setStep({
 										key: profileStepKey,
@@ -1376,6 +1293,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 													`${resourceLabel} is shared, but this deployment has no prior state from which to restore the surviving deployment state.`,
 												);
 											}
+											await topologyLease.assertOwnership();
 											upstreamMutationAttempted = true;
 											await rollbackCustomFormatDeployment(client, state);
 											const restoredFormat = await client.customFormat.getById(state.resourceId);
@@ -1392,6 +1310,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 											});
 										}
 									} catch (error) {
+										if (error instanceof CleanupRunLeaseLostError) throw error;
 										const message = `Failed to verify shared Custom Format "${state.name}": ${getErrorMessage(error, "Unknown error")}`;
 										setStep({
 											key: stepKey,
@@ -1405,6 +1324,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 									continue;
 								}
 								try {
+									await topologyLease.assertOwnership();
 									upstreamMutationAttempted = true;
 									const result = await rollbackCustomFormatDeployment(client, state);
 									if (result === "restored") {
@@ -1432,6 +1352,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										});
 									}
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to roll back Custom Format "${state.name}": ${getErrorMessage(error, "Unknown error")}`;
 									setStep({
 										key: stepKey,
@@ -1474,6 +1395,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 											ownership.sharedNamingRestorationAllowed,
 											"naming configuration",
 										);
+										await topologyLease.assertOwnership();
 										upstreamMutationAttempted = true;
 										await restoreNamingDeployment(
 											app.arrClientFactory,
@@ -1503,6 +1425,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										});
 									}
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to verify shared naming configuration: ${getErrorMessage(error, "Unknown error")}`;
 									setStep({
 										key: "naming:configuration",
@@ -1519,6 +1442,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 								!isFinished("naming:configuration", "naming", "Naming configuration")
 							) {
 								try {
+									await topologyLease.assertOwnership();
 									upstreamMutationAttempted = true;
 									await restoreNamingDeployment(
 										app.arrClientFactory,
@@ -1533,6 +1457,7 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										outcome: "restored",
 									});
 								} catch (error) {
+									if (error instanceof CleanupRunLeaseLostError) throw error;
 									const message = `Failed to restore naming configuration: ${getErrorMessage(error, "Unknown error")}`;
 									setStep({
 										key: "naming:configuration",
@@ -1560,55 +1485,32 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 							// Partial failures leave rolledBack=false so the user can retry.
 							if (failedCount === 0) {
 								const rolledBackAt = new Date();
-								await app.prisma.$transaction(async (tx) => {
-									for (const prior of priorPairedSyncStates) {
-										const paired = await tx.trashSyncHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												rollbackStatus: "IN_PROGRESS",
-												rollbackAttemptedAt,
-											},
-											data: {
-												rolledBack: true,
-												rolledBackAt,
-												rollbackStatus: "COMPLETED",
-												rollbackAttemptedAt,
-												rollbackProgress: JSON.stringify(rollbackSteps),
-											},
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired rollback claim changed before completion was persisted",
-											);
-										}
-									}
-									for (const prior of priorPairedDeploymentStates) {
-										const paired = await tx.templateDeploymentHistory.updateMany({
-											where: {
-												id: prior.id,
-												userId,
-												rolledBack: false,
-												undeployStatus: "IN_PROGRESS",
-												undeployAttemptedAt: rollbackAttemptedAt,
-											},
-											data: {
-												rolledBack: true,
-												rolledBackAt,
-												rolledBackBy: userId,
-												undeployStatus: "COMPLETED",
-												undeployAttemptedAt: rollbackAttemptedAt,
-												undeployProgress: JSON.stringify(rollbackSteps),
-											},
-										});
-										if (paired.count !== 1) {
-											throw new Error(
-												"Paired undeploy claim changed before completion was persisted",
-											);
-										}
-									}
-								});
+								await topologyLease.assertOwnership();
+								await mutateClaimedRecoveryGroup(
+									app.prisma,
+									userId,
+									priorPairedDeploymentStates,
+									priorPairedSyncStates,
+									rollbackAttemptedAt,
+									{
+										deploymentData: () => ({
+											rolledBack: true,
+											rolledBackAt,
+											rolledBackBy: userId,
+											undeployStatus: "COMPLETED",
+											undeployAttemptedAt: rollbackAttemptedAt,
+											undeployProgress: JSON.stringify(rollbackSteps),
+										}),
+										syncData: () => ({
+											rolledBack: true,
+											rolledBackAt,
+											rollbackStatus: "COMPLETED",
+											rollbackAttemptedAt,
+											rollbackProgress: JSON.stringify(rollbackSteps),
+										}),
+										conflictMessage: "Recovery claim changed before completion was persisted",
+									},
+								);
 							} else {
 								await persistRollbackProgress("PARTIAL");
 								request.log.warn(

--- a/apps/api/src/routes/trash-guides/sync-routes.ts
+++ b/apps/api/src/routes/trash-guides/sync-routes.ts
@@ -35,6 +35,7 @@ import {
 	isDeploymentBackupEndpointIdentityCurrent,
 } from "../../lib/trash-guides/deployment-target.js";
 import { createTrashFetcher } from "../../lib/trash-guides/github-fetcher.js";
+import { claimRollbackRecoveryGroup } from "../../lib/trash-guides/recovery-history-claim.js";
 import { getRepoConfig } from "../../lib/trash-guides/repo-config.js";
 import type { SyncProgress } from "../../lib/trash-guides/sync-engine.js";
 import { createSyncEngine } from "../../lib/trash-guides/sync-engine.js";
@@ -86,6 +87,10 @@ const rollbackAppliedConfigsSchema = z.array(
 );
 
 type AppliedConfig = z.infer<typeof rollbackAppliedConfigsSchema>[number];
+
+function isClaimableRecoveryStatus(status: string | null | undefined): boolean {
+	return status == null || status === "PARTIAL";
+}
 
 // ============================================================================
 // In-Memory Progress Tracking (temporary - will move to Redis/cache later)
@@ -638,91 +643,259 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 				message: "This sync has already been rolled back",
 			});
 		}
-
-		const priorRollbackStatus = sync.rollbackStatus;
-		const priorRollbackAttemptedAt = sync.rollbackAttemptedAt;
-		const priorRollbackProgress = sync.rollbackProgress;
-		const rollbackAttemptedAt = new Date();
-		const claim = await app.prisma.trashSyncHistory.updateMany({
-			where: {
-				id: syncId,
-				userId,
-				rolledBack: false,
-				OR: [{ rollbackStatus: null }, { rollbackStatus: "PARTIAL" }],
-			},
-			data: {
-				rollbackStatus: "IN_PROGRESS",
-				rollbackAttemptedAt,
-			},
+		const initialPairedDeploymentRows = await app.prisma.templateDeploymentHistory.findMany({
+			where: { backupId: sync.backupId, userId },
+			select: { id: true },
 		});
+		const initialPairedDeploymentIds = new Set(
+			initialPairedDeploymentRows.map((deployment) => deployment.id),
+		);
 
-		if (claim.count !== 1) {
-			return reply.status(409).send({
-				error: "ROLLBACK_IN_PROGRESS",
-				message: "A rollback is already in progress for this sync operation",
-			});
-		}
+		return await withCleanupTopologyMutationLease(
+			{ prisma: app.prisma, log: request.log },
+			userId,
+			async () => {
+				const leasedSync = await app.prisma.trashSyncHistory.findFirst({
+					where: { id: syncId, userId },
+					include: { backup: true, instance: true, template: true },
+				});
+				if (!leasedSync) {
+					return reply.status(404).send({ error: "NOT_FOUND", message: "Sync not found" });
+				}
+				if (!leasedSync.backupId || !leasedSync.backup) {
+					return reply.status(400).send({
+						error: "NO_BACKUP",
+						message: "No backup available for this sync operation",
+					});
+				}
+				if (leasedSync.rolledBack) {
+					return reply.status(400).send({
+						error: "ALREADY_ROLLED_BACK",
+						message: "This sync has already been rolled back",
+					});
+				}
+				const persistedPairedSyncStates = await app.prisma.trashSyncHistory.findMany({
+					where: { backupId: leasedSync.backupId, userId },
+					select: {
+						id: true,
+						rolledBack: true,
+						rollbackStatus: true,
+						rollbackAttemptedAt: true,
+						rollbackProgress: true,
+					},
+				});
+				const priorPairedSyncStates = [...persistedPairedSyncStates];
+				if (!priorPairedSyncStates.some((paired) => paired.id === leasedSync.id)) {
+					priorPairedSyncStates.push({
+						id: leasedSync.id,
+						rolledBack: leasedSync.rolledBack,
+						rollbackStatus: leasedSync.rollbackStatus,
+						rollbackAttemptedAt: leasedSync.rollbackAttemptedAt,
+						rollbackProgress: leasedSync.rollbackProgress,
+					});
+				}
+				const priorPairedDeploymentStates = await app.prisma.templateDeploymentHistory.findMany({
+					where: { backupId: leasedSync.backupId, userId },
+					select: {
+						id: true,
+						status: true,
+						rolledBack: true,
+						undeployStatus: true,
+						undeployAttemptedAt: true,
+						undeployProgress: true,
+					},
+				});
+				const currentPairedDeploymentIds = new Set(
+					priorPairedDeploymentStates.map((deployment) => deployment.id),
+				);
+				if (
+					initialPairedDeploymentIds.size !== currentPairedDeploymentIds.size ||
+					[...initialPairedDeploymentIds].some((id) => !currentPairedDeploymentIds.has(id))
+				) {
+					return reply.status(409).send({
+						error: "ROLLBACK_HISTORY_CHANGED",
+						message:
+							"Paired deployment history changed while rollback was starting. Refresh and try again.",
+					});
+				}
 
-		const persistPartialRollback = async () => {
-			const result = await app.prisma.trashSyncHistory.updateMany({
-				where: {
-					id: syncId,
+				const priorRollbackStatus = leasedSync.rollbackStatus;
+				const priorRollbackAttemptedAt = leasedSync.rollbackAttemptedAt;
+				const priorRollbackProgress = leasedSync.rollbackProgress;
+				if (
+					priorPairedSyncStates.some(
+						(paired) => paired.rolledBack || !isClaimableRecoveryStatus(paired.rollbackStatus),
+					) ||
+					priorPairedDeploymentStates.some(
+						(paired) => paired.rolledBack || !isClaimableRecoveryStatus(paired.undeployStatus),
+					)
+				) {
+					return reply.status(409).send({
+						error: "ROLLBACK_HISTORY_CONFLICT",
+						message:
+							"Paired recovery history is already active or terminal and cannot be claimed safely.",
+					});
+				}
+				const rollbackAttemptedAt = new Date();
+				const claimed = await claimRollbackRecoveryGroup(
+					app.prisma,
 					userId,
-					rolledBack: false,
-					rollbackStatus: "IN_PROGRESS",
+					priorPairedSyncStates,
+					priorPairedDeploymentStates,
 					rollbackAttemptedAt,
-				},
-				data: {
-					rollbackStatus: "PARTIAL",
-				},
-			});
-			if (result.count !== 1) {
-				throw new Error("Rollback recovery state changed before progress could be persisted");
-			}
-		};
-		// Release this request's claim back to the exact recovery state that existed
-		// before the claim. The compare-and-set guard ensures a stale request cannot
-		// release a newer claim that another process has since taken over.
-		const releaseRollbackClaim = async () => {
-			const result = await app.prisma.trashSyncHistory.updateMany({
-				where: {
-					id: syncId,
-					userId,
-					rolledBack: false,
-					rollbackStatus: "IN_PROGRESS",
-					rollbackAttemptedAt,
-				},
-				data: {
-					rollbackStatus: priorRollbackStatus,
-					rollbackAttemptedAt: priorRollbackAttemptedAt,
-					rollbackProgress: priorRollbackProgress,
-				},
-			});
-			if (result.count !== 1) {
-				throw new Error("Rollback recovery state changed before the claim could be released");
-			}
-		};
-		const stopClaimedRollback = async (
-			statusCode: number,
-			payload: { error: string; message: string },
-		) => {
-			await releaseRollbackClaim();
-			return reply.status(statusCode).send(payload);
-		};
-		let upstreamMutationAttempted = false;
+				);
+				if (!claimed) {
+					return reply.status(409).send({
+						error: "ROLLBACK_HISTORY_CONFLICT",
+						message:
+							"Paired recovery history changed, is already active, or requires explicit resolution.",
+					});
+				}
+				let pairedProgressPersisted = true;
 
-		// Start metrics tracking
-		const metrics = getSyncMetrics();
-		const completeMetrics = metrics.startOperation("rollback");
+				const persistPartialRollback = async () => {
+					if (pairedProgressPersisted) {
+						await app.prisma.$transaction(async (tx) => {
+							for (const prior of priorPairedSyncStates) {
+								const paired = await tx.trashSyncHistory.updateMany({
+									where: {
+										id: prior.id,
+										userId,
+										rolledBack: false,
+										rollbackStatus: "IN_PROGRESS",
+										rollbackAttemptedAt,
+									},
+									data: { rollbackStatus: "PARTIAL" },
+								});
+								if (paired.count !== 1) {
+									throw new Error(
+										"Paired rollback state changed before progress could be persisted",
+									);
+								}
+							}
+							for (const prior of priorPairedDeploymentStates) {
+								const paired = await tx.templateDeploymentHistory.updateMany({
+									where: {
+										id: prior.id,
+										userId,
+										rolledBack: false,
+										undeployStatus: "IN_PROGRESS",
+										undeployAttemptedAt: rollbackAttemptedAt,
+									},
+									data: { status: "PARTIAL_UNDEPLOY", undeployStatus: "PARTIAL" },
+								});
+								if (paired.count !== 1) {
+									throw new Error(
+										"Paired undeploy state changed before progress could be persisted",
+									);
+								}
+							}
+						});
+						return;
+					}
+					const result = await app.prisma.trashSyncHistory.updateMany({
+						where: {
+							id: syncId,
+							userId,
+							rolledBack: false,
+							rollbackStatus: "IN_PROGRESS",
+							rollbackAttemptedAt,
+						},
+						data: {
+							rollbackStatus: "PARTIAL",
+						},
+					});
+					if (result.count !== 1) {
+						throw new Error("Rollback recovery state changed before progress could be persisted");
+					}
+				};
+				// Release this request's claim back to the exact recovery state that existed
+				// before the claim. The compare-and-set guard ensures a stale request cannot
+				// release a newer claim that another process has since taken over.
+				const releaseRollbackClaim = async () => {
+					if (pairedProgressPersisted) {
+						await app.prisma.$transaction(async (tx) => {
+							for (const prior of priorPairedSyncStates) {
+								const paired = await tx.trashSyncHistory.updateMany({
+									where: {
+										id: prior.id,
+										userId,
+										rolledBack: false,
+										rollbackStatus: "IN_PROGRESS",
+										rollbackAttemptedAt,
+									},
+									data: {
+										rollbackStatus: prior.rollbackStatus,
+										rollbackAttemptedAt: prior.rollbackAttemptedAt,
+										rollbackProgress: prior.rollbackProgress,
+									},
+								});
+								if (paired.count !== 1) {
+									throw new Error(
+										"Paired rollback state changed before the claim could be released",
+									);
+								}
+							}
+							for (const prior of priorPairedDeploymentStates) {
+								const paired = await tx.templateDeploymentHistory.updateMany({
+									where: {
+										id: prior.id,
+										userId,
+										rolledBack: false,
+										undeployStatus: "IN_PROGRESS",
+										undeployAttemptedAt: rollbackAttemptedAt,
+									},
+									data: {
+										status: prior.status,
+										undeployStatus: prior.undeployStatus,
+										undeployAttemptedAt: prior.undeployAttemptedAt,
+										undeployProgress: prior.undeployProgress,
+									},
+								});
+								if (paired.count !== 1) {
+									throw new Error(
+										"Paired undeploy state changed before the claim could be released",
+									);
+								}
+							}
+						});
+						return;
+					}
+					const result = await app.prisma.trashSyncHistory.updateMany({
+						where: {
+							id: syncId,
+							userId,
+							rolledBack: false,
+							rollbackStatus: "IN_PROGRESS",
+							rollbackAttemptedAt,
+						},
+						data: {
+							rollbackStatus: priorRollbackStatus,
+							rollbackAttemptedAt: priorRollbackAttemptedAt,
+							rollbackProgress: priorRollbackProgress,
+						},
+					});
+					if (result.count !== 1) {
+						throw new Error("Rollback recovery state changed before the claim could be released");
+					}
+				};
+				const stopClaimedRollback = async (
+					statusCode: number,
+					payload: { error: string; message: string },
+				) => {
+					await releaseRollbackClaim();
+					return reply.status(statusCode).send(payload);
+				};
+				let upstreamMutationAttempted = false;
 
-		try {
-			return await withCleanupTopologyMutationLease(
-				{ prisma: app.prisma, log: request.log },
-				userId,
-				() =>
-					app.deploymentExecutor.runWithEndpointMutation(
+				// Start metrics tracking
+				const metrics = getSyncMetrics();
+				const completeMetrics = metrics.startOperation("rollback");
+
+				try {
+					return await app.deploymentExecutor.runWithEndpointMutation(
 						userId,
-						sync.instance,
+						leasedSync.instance,
 						"Rollback",
 						async (endpointKey) => {
 							const sync = await app.prisma.trashSyncHistory.findFirst({
@@ -952,25 +1125,51 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 											step.outcome === "skipped_shared"),
 								);
 							};
-							const rollbackAttemptedAt = new Date();
 							const persistRollbackProgress = async (
 								rollbackStatus: "IN_PROGRESS" | "PARTIAL",
 							): Promise<void> => {
 								const rollbackProgress = JSON.stringify([...stepByKey.values()]);
 								await app.prisma.$transaction(async (tx) => {
-									await tx.trashSyncHistory.updateMany({
-										where: { backupId: sync.backupId, userId, rolledBack: false },
-										data: { rollbackStatus, rollbackAttemptedAt, rollbackProgress },
-									});
-									await tx.templateDeploymentHistory.updateMany({
-										where: { backupId: sync.backupId, userId },
-										data: {
-											undeployStatus: rollbackStatus,
-											undeployAttemptedAt: rollbackAttemptedAt,
-											undeployProgress: rollbackProgress,
-										},
-									});
+									for (const prior of priorPairedSyncStates) {
+										const paired = await tx.trashSyncHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												rollbackStatus: "IN_PROGRESS",
+												rollbackAttemptedAt,
+											},
+											data: { rollbackStatus, rollbackAttemptedAt, rollbackProgress },
+										});
+										if (paired.count !== 1) {
+											throw new Error(
+												"Paired rollback claim changed before progress was persisted",
+											);
+										}
+									}
+									for (const prior of priorPairedDeploymentStates) {
+										const paired = await tx.templateDeploymentHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												undeployStatus: "IN_PROGRESS",
+												undeployAttemptedAt: rollbackAttemptedAt,
+											},
+											data: {
+												undeployStatus: rollbackStatus,
+												undeployAttemptedAt: rollbackAttemptedAt,
+												undeployProgress: rollbackProgress,
+											},
+										});
+										if (paired.count !== 1) {
+											throw new Error(
+												"Paired undeploy claim changed before progress was persisted",
+											);
+										}
+									}
 								});
+								pairedProgressPersisted = true;
 							};
 							await persistRollbackProgress("IN_PROGRESS");
 							if (
@@ -1362,19 +1561,38 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 							if (failedCount === 0) {
 								const rolledBackAt = new Date();
 								await app.prisma.$transaction(async (tx) => {
-									await tx.trashSyncHistory.updateMany({
-										where: { backupId: sync.backupId, userId, rolledBack: false },
-										data: {
-											rolledBack: true,
-											rolledBackAt,
-											rollbackStatus: "COMPLETED",
-											rollbackAttemptedAt,
-											rollbackProgress: JSON.stringify(rollbackSteps),
-										},
-									});
-									if (sync.backupId) {
-										await tx.templateDeploymentHistory.updateMany({
-											where: { backupId: sync.backupId, userId },
+									for (const prior of priorPairedSyncStates) {
+										const paired = await tx.trashSyncHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												rollbackStatus: "IN_PROGRESS",
+												rollbackAttemptedAt,
+											},
+											data: {
+												rolledBack: true,
+												rolledBackAt,
+												rollbackStatus: "COMPLETED",
+												rollbackAttemptedAt,
+												rollbackProgress: JSON.stringify(rollbackSteps),
+											},
+										});
+										if (paired.count !== 1) {
+											throw new Error(
+												"Paired rollback claim changed before completion was persisted",
+											);
+										}
+									}
+									for (const prior of priorPairedDeploymentStates) {
+										const paired = await tx.templateDeploymentHistory.updateMany({
+											where: {
+												id: prior.id,
+												userId,
+												rolledBack: false,
+												undeployStatus: "IN_PROGRESS",
+												undeployAttemptedAt: rollbackAttemptedAt,
+											},
 											data: {
 												rolledBack: true,
 												rolledBackAt,
@@ -1384,6 +1602,11 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 												undeployProgress: JSON.stringify(rollbackSteps),
 											},
 										});
+										if (paired.count !== 1) {
+											throw new Error(
+												"Paired undeploy claim changed before completion was persisted",
+											);
+										}
 									}
 								});
 							} else {
@@ -1426,39 +1649,40 @@ export async function registerSyncRoutes(app: FastifyInstance, _opts: FastifyPlu
 										: `Rollback completed with errors: ${restoredCount} restored, ${deletedCount} deleted, ${failedCount} failed`,
 							});
 						},
-					),
-			);
-		} catch (error) {
-			// Specialized catch: records failure metrics before propagating
-			const errorMessage = getErrorMessage(error, "Rollback failed");
-			try {
-				if (upstreamMutationAttempted) {
-					await persistPartialRollback();
-				} else {
-					await releaseRollbackClaim();
-				}
-			} catch (stateError) {
-				request.log.error(
-					{ err: stateError, syncId, rollbackAttemptedAt },
-					"Failed to persist rollback failure state",
-				);
-			}
-			const metricsResult = completeMetrics();
-			metricsResult.recordFailure(errorMessage);
+					);
+				} catch (error) {
+					// Specialized catch: records failure metrics before propagating
+					const errorMessage = getErrorMessage(error, "Rollback failed");
+					try {
+						if (upstreamMutationAttempted) {
+							await persistPartialRollback();
+						} else {
+							await releaseRollbackClaim();
+						}
+					} catch (stateError) {
+						request.log.error(
+							{ err: stateError, syncId, rollbackAttemptedAt },
+							"Failed to persist rollback failure state",
+						);
+					}
+					const metricsResult = completeMetrics();
+					metricsResult.recordFailure(errorMessage);
 
-			request.log.error({ error, syncId }, "Sync rollback failed");
-			const statusCode =
-				error &&
-				typeof error === "object" &&
-				"statusCode" in error &&
-				typeof error.statusCode === "number"
-					? error.statusCode
-					: 500;
-			return reply.status(upstreamMutationAttempted ? 207 : statusCode).send({
-				error: "ROLLBACK_FAILED",
-				message: errorMessage,
-			});
-		}
+					request.log.error({ error, syncId }, "Sync rollback failed");
+					const statusCode =
+						error &&
+						typeof error === "object" &&
+						"statusCode" in error &&
+						typeof error.statusCode === "number"
+							? error.statusCode
+							: 500;
+					return reply.status(upstreamMutationAttempted ? 207 : statusCode).send({
+						error: "ROLLBACK_FAILED",
+						message: errorMessage,
+					});
+				}
+			},
+		);
 	});
 
 	/**


### PR DESCRIPTION
## Summary

Harden recovery claims for deployment-history undeploy and sync rollback. The final head uses the repository's renewable cleanup-run lease, verifies ownership at every mutation boundary, binds claims to the complete authorization/group snapshot, and applies one canonical row-lock order across claim, restore, PARTIAL persistence, and finalization.

Final head: `4098b4e4bd4d7fb8183da43b3b823ba1e4935ca1`.

## Related issue

Follow-up to #774 and merged recovery PR #778. This PR does not rewrite production history or add a second lock service; it closes concurrency windows around the existing recovery model.

## Scope

- Deployment-history delete/undeploy and sync rollback.
- Renewable topology-lease ownership and lease-loss handling.
- Exact, atomic deployment/sync recovery-group claims.
- Deterministic multi-row lock ordering on SQLite and PostgreSQL.
- Focused route/helper/database regression coverage.

## Non-goals

- No schema, migration, backfill, production access, or direct history manipulation.
- No new distributed lock implementation.
- No blind retry or additional ARR mutation.
- No unrelated cleanup/deployment refactor.

## Acceptance criteria

- [x] The topology lease renews for operations whose ARR request count is not statically bounded below two hours.
- [x] Lease ownership is checked before claims, ARR mutation boundaries, progress writes, and finalization.
- [x] Lease loss before a possible ARR mutation restores the complete prior group; lease loss after a possible mutation persists the complete exact group as `PARTIAL` and stops further writes.
- [x] `status`, `backupId`, `rolledBack`, rollback status/timestamp/progress, IDs, and group membership are bound into snapshot/CAS checks.
- [x] Every multi-row transition sorts model and ID canonically.
- [x] Opposite-order PostgreSQL claimers do not deadlock or leave a partial claim.
- [x] Terminal `rolledBack=true` histories cannot be claimed through direct helper calls.
- [x] Dead `pairedProgressPersisted` branches were removed.

## Root cause and fix

The earlier head held an acquired lease across the operation but did not renew it. Because each ARR request has a timeout while the number of resources/requests is unbounded, total recovery time was not guaranteed to remain below the two-hour lease. It also omitted mutable authorization/group fields from parts of the CAS snapshot and accepted caller order for multi-row updates.

The final implementation reuses `startCleanupRunLease` and its heartbeat. Ownership assertions surround every claim, possible upstream mutation, progress write, and terminal transition. Route catch paths rethrow lease loss instead of converting it into an ordinary retry. Before the first possible mutation, all exact rows are restored from their full typed snapshots; afterward, all exact claimed rows become durable `PARTIAL`. Claims and later transitions share one lexical model/ID order and exact count/CAS checks, so a miss rolls back the transaction rather than exposing a partial group.

## State transitions

| Event | Durable result |
| --- | --- |
| Exact snapshot claim succeeds | Whole group becomes `IN_PROGRESS` under one claim timestamp |
| Snapshot/CAS mismatch | Transaction rolls back; zero claims; HTTP 409 before ARR |
| Lease loss before possible ARR mutation | Whole exact group restored to the complete prior snapshot |
| Lease loss/failure after possible ARR mutation | Whole exact group becomes fail-closed `PARTIAL`; no further ARR write |
| Successful reversal | Exact claimed group finalized atomically |
| Terminal history passed directly to helper | Rejected; fixed `rolledBack=false` CAS remains authoritative |

## Reproduction

SQLite:

```bash
docker build --target builder -t arrdash-followup-798:4098b4e4 .
docker run --rm \
  -e INTEGRATION_TESTS=1 \
  -e DATABASE_URL=file:/tmp/recovery-claim.db \
  -e RECOVERY_CLAIM_DATABASE_URL=file:/tmp/recovery-claim.db \
  arrdash-followup-798:4098b4e4 sh -lc \
  'cd /app/apps/api && pnpm exec prisma db push --schema prisma/schema.prisma && pnpm exec vitest run src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts'
```

PostgreSQL (all credentials are disposable synthetic fixtures and the same variable is used in the container and DSN):

```bash
PG_TEST_PASSWORD='synthetic-test-password'
docker network create arrdash-recovery-pg
docker run -d --name arrdash-recovery-pg --network arrdash-recovery-pg \
  -e POSTGRES_USER=arrdash \
  -e POSTGRES_PASSWORD="$PG_TEST_PASSWORD" \
  -e POSTGRES_DB=arrdash postgres:16-alpine
until docker exec arrdash-recovery-pg pg_isready -U arrdash; do sleep 2; done
docker run --rm --network arrdash-recovery-pg \
  -e INTEGRATION_TESTS=1 \
  -e DATABASE_URL="postgresql://arrdash:${PG_TEST_PASSWORD}@arrdash-recovery-pg:5432/arrdash" \
  -e RECOVERY_CLAIM_DATABASE_URL="postgresql://arrdash:${PG_TEST_PASSWORD}@arrdash-recovery-pg:5432/arrdash" \
  arrdash-followup-798:4098b4e4 sh -lc \
  'sed -i '\''s/provider = "sqlite"/provider = "postgresql"/'\'' /app/apps/api/prisma/schema.prisma && cd /app/apps/api && pnpm exec prisma generate --schema prisma/schema.prisma && pnpm exec prisma db push --schema prisma/schema.prisma && pnpm exec vitest run src/lib/trash-guides/__tests__/recovery-history-claim.database.test.ts'
docker rm -f arrdash-recovery-pg
docker network rm arrdash-recovery-pg
unset PG_TEST_PASSWORD
```

## Changes

- Reuse the renewable cleanup-run lease and expose explicit ownership assertions.
- Bind deployment and sync claims to the full mutable authorization/group snapshot.
- Centralize canonical ordering for all recovery-group state transitions.
- Restore or mark the whole exact group according to the upstream-mutation boundary.
- Remove unreachable persistence branches and add route/helper/provider regressions.

## Local validation on the exact final head

| Command/check | Environment | Result |
| --- | --- | --- |
| Four focused lease/claim/route files | Node 22 builder | 83/83 passed |
| Exact DB contract | SQLite 3.53.2, better-sqlite3 12.11.1, Prisma 7.9.0 | 5 passed, 2 PostgreSQL-only skipped |
| Exact DB concurrency contract | PostgreSQL 16.15, two clients including opposite input order | 7/7 passed |
| `pnpm run test` | Exact builder image with exact `docs/` and `docker/` mounted read-only | 4 Turbo tasks passed; API 4,638 passed/58 skipped; web/shared passed |
| `pnpm run typecheck` | Exact builder image | 3/3 packages passed |
| `pnpm run lint` | Exact builder image, generated `packages/shared/dist` removed first | 3/3 packages passed |
| `pnpm run test:pr-review-contract` | Exact files mounted read-only | 53/53 passed |
| Docker builder/production build | `arrdash-followup-798:4098b4e4` | passed |
| `check:prisma-generated` | Disposable Linux Git index, Prisma 7.9.0 | up to date |
| Changed-file Biome and `git diff --check` | Repository configuration | passed; no changed-file whitespace error |

`pnpm run format` remains unchecked because the Docker build context reproduces checkout-wide CRLF normalization errors in many untouched files; the unchanged base image fails the same command. No repository-wide line-ending rewrite is included. All 10 changed files pass the repository Biome configuration and the final diff has no whitespace error.

## Database and migration impact

No schema, migration, generated-client, or stored-data rewrite. The change only strengthens transaction predicates/order and recovery state transitions. Real SQLite and PostgreSQL provider contracts pass.

## Security and privacy

Only random synthetic histories, users, instances, backups, and disposable databases were used. No production endpoint, identifier, credential, token, or deployment history was accessed. Unknown ownership and lease loss remain fail-closed.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [ ] `pnpm run format` ? exact checkout-wide CRLF blocker documented above; changed files pass Biome
- [x] `pnpm --filter @arr/shared build`, when shared changed ? shared unchanged; build passed in gauntlet
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable ? real provider concurrency verified
- [x] New queries use centralized query keys and polling constants, when applicable ? N/A
- [x] New sensitive displays preserve incognito behavior, when applicable ? N/A
- [x] New Prisma queries for user-owned resources include `userId`, when applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable ? N/A
- [x] User-facing counts are precise rather than proxies, when applicable ? exact group cardinality is checked
- [x] Action links reach the correct page with required parameters, when applicable ? N/A
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

## External CI blocker

For exact head `4098b4e4bd4d7fb8183da43b3b823ba1e4935ca1`, CI `32946610090`, CodeQL `32946610111`, Docker Smoke Test `32946610113`, and Semgrep `32946610140` all completed `action_required` with `jobs: []`. An upstream maintainer must choose **Approve and run workflows**. No workflow, token, or repository workaround is included, and this PR does not claim GitHub CI is green.

## Review plan

- Initial broad-reviewed head: `92d7393ac086761be2160f0f6494247616f27325`
- Correction head: `4098b4e4bd4d7fb8183da43b3b823ba1e4935ca1`
- Targeted delta range: `92d7393ac086761be2160f0f6494247616f27325..4098b4e4bd4d7fb8183da43b3b823ba1e4935ca1`
- Material-scope change declared? Yes ? follow-up safety audit required renewable lease, complete CAS binding, canonical lock order, and matching regressions within the existing recovery scope.
- Independent regression reviewer: Internal Codex subagent Fermat ? production PASS; its P3 test-evidence finding was fixed and revalidated. Not a GitHub review or maintainer approval.
- Independent data-safety reviewer, when required: Internal Codex subagent Arendt ? PASS after the terminal-history fix. Not a GitHub review or maintainer approval.
- GitHub Codex review head: pending external review availability
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| 798-A | P1 | Valid | Non-renewing two-hour lease around unbounded operation count | Fixed with renewable lease and mutation-boundary assertions | Exact lease-loss tests pass |
| 798-B | P1 | Valid | `status`/`backupId` absent from parts of snapshot CAS | Fixed with full typed snapshot/CAS | Status/group drift returns null claim/409 |
| 798-C | P1 | Valid | Caller-order multi-row locks | Fixed with canonical model/ID order | Opposite-order PostgreSQL test passes |
| 798-D | P3 | Valid | Unreachable `pairedProgressPersisted=false` branches | Removed | Focused suite passes |
| R798-1 | P3 | Valid test-evidence gap | Earlier fixture did not prove whole deployment group restoration | Two deployments plus sync peers now asserted unchanged | SQLite and PostgreSQL reruns pass |

## Final merge gate

- [ ] Exact-head CI is green ? externally blocked by `action_required`/zero jobs
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [ ] Maintainer approved merge
- [x] Post-merge verification is planned ? rerun the PostgreSQL contention and persisted PARTIAL recovery contracts on the merged image
