### PR TITLE
fix(trash-guides): keep runtime binding data out of Prisma filters

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -85,8 +85,9 @@ describe("BulkScoreManager canonical profile identity", () => {
 			},
 			templateQualityProfileMapping: { findMany: findMappings },
 			trashTemplate: {
-				findMany: vi.fn(async ({ where }) =>
-					where.id.in.map((id: string) => ({
+				findMany: vi.fn(async ({ where }) => {
+					expect(where).toMatchObject({ userId });
+					return where.id.in.map((id: string) => ({
 						id,
 						configData: JSON.stringify({
 							qualityProfile: { trash_score_set: "default" },
@@ -98,8 +99,8 @@ describe("BulkScoreManager canonical profile identity", () => {
 								},
 							],
 						}),
-					})),
-				),
+					}));
+				}),
 			},
 		};
 		const clientFactory = {

--- a/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/bulk-score-manager.test.ts
@@ -33,6 +33,9 @@ describe("BulkScoreManager canonical profile identity", () => {
 		]);
 		const findMappings = vi.fn(async ({ where }) => {
 			const bindings = Array.isArray(where.OR) ? where.OR : [];
+			expect(bindings).not.toContainEqual(
+				expect.objectContaining({ credentialIdentity: expect.anything() }),
+			);
 			const managedCustomFormats = JSON.stringify([
 				{
 					trashId: "trash-reject",

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-target.test.ts
@@ -5,16 +5,17 @@ import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBinding,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createDeploymentStateToken,
 	createLegacyDeploymentConnectionBindings,
 	createQualityProfileStateToken,
+	type DeploymentProfileMapping,
 	getEquivalentServiceInstanceIds,
 	isDeploymentBackupEndpointIdentityCurrent,
 	isVerifiedClonedProfileSourceConnection,
 	resolveDeploymentTarget,
-	type DeploymentProfileMapping,
 } from "../deployment-target.js";
 
 const profiles = [
@@ -655,6 +656,25 @@ describe("getEquivalentServiceInstanceIds", () => {
 
 		expect(createDeploymentConnectionBindingCandidates(connection)).toEqual([
 			createDeploymentConnectionBinding(connection),
+		]);
+	});
+
+	it("removes credential-only evidence before using connection bindings in persistence filters", () => {
+		expect(
+			createDeploymentConnectionPersistenceBindings([
+				{
+					instanceId: "radarr-1",
+					connectionGeneration: 2,
+					connectionStateToken: "state-token",
+					credentialIdentity: "credential-only-evidence",
+				},
+			]),
+		).toEqual([
+			{
+				instanceId: "radarr-1",
+				connectionGeneration: 2,
+				connectionStateToken: "state-token",
+			},
 		]);
 	});
 

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -248,6 +248,7 @@ export class BulkScoreManager {
 				? await this.prisma.trashTemplate.findMany({
 						where: {
 							id: { in: templateIds },
+							userId,
 						},
 						select: {
 							id: true,

--- a/apps/api/src/lib/trash-guides/bulk-score-manager.ts
+++ b/apps/api/src/lib/trash-guides/bulk-score-manager.ts
@@ -26,6 +26,7 @@ import { readPersistedManagedCustomFormatIdentities } from "./deployment-managed
 import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	getEquivalentServiceInstanceIds,
 } from "./deployment-target.js";
 
@@ -170,7 +171,7 @@ export class BulkScoreManager {
 		// Resolve management through every current alias for the physical ARR endpoint.
 		const templateMappings = await this.prisma.templateQualityProfileMapping.findMany({
 			where: {
-				OR: connectionBindings,
+				OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 				template: { userId },
 			},
 			select: {

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -56,6 +56,7 @@ import {
 	assertEquivalentDeploymentMappingAuthority,
 	createAutomationCatchUpTemplateStateToken,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createDeploymentMappingAuthorityState,
@@ -2415,7 +2416,9 @@ export class DeploymentExecutorService {
 										userId: orphanedOverrideCleanup.userId,
 										qualityProfileId: orphanedOverrideCleanup.qualityProfileId,
 										customFormatId: { in: orphanedOverrideCleanup.customFormatIds },
-										OR: orphanedOverrideCleanup.connectionReadBindings,
+										OR: createDeploymentConnectionPersistenceBindings(
+											orphanedOverrideCleanup.connectionReadBindings,
+										),
 									},
 								});
 							}

--- a/apps/api/src/lib/trash-guides/deployment-target.ts
+++ b/apps/api/src/lib/trash-guides/deployment-target.ts
@@ -39,6 +39,11 @@ export interface DeploymentConnectionBinding {
 	credentialIdentity?: string;
 }
 
+export type DeploymentConnectionPersistenceBinding = Pick<
+	DeploymentConnectionBinding,
+	"instanceId" | "connectionGeneration" | "connectionStateToken"
+>;
+
 export interface AutomationCatchUpTemplateState {
 	configData: string;
 	instanceOverrides: string | null;
@@ -397,6 +402,17 @@ export function createDeploymentConnectionBindingCandidates(
 	credentialIdentity?: string,
 ): DeploymentConnectionBinding[] {
 	return [createDeploymentConnectionBinding(instance, credentialIdentity)];
+}
+
+/** Project in-memory connection evidence to fields that exist on persisted ownership rows. */
+export function createDeploymentConnectionPersistenceBindings(
+	bindings: DeploymentConnectionBinding[],
+): DeploymentConnectionPersistenceBinding[] {
+	return bindings.map(({ instanceId, connectionGeneration, connectionStateToken }) => ({
+		instanceId,
+		connectionGeneration,
+		connectionStateToken,
+	}));
 }
 
 /** Locate pre-binding mappings so callers can reject them without trusting them as ownership. */

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
@@ -1,0 +1,276 @@
+import { randomUUID } from "node:crypto";
+import Fastify, { type FastifyInstance } from "fastify";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createTestPgClient, createTestPrismaClient } from "../../../lib/__tests__/test-prisma.js";
+import type { PrismaClientInstance } from "../../../lib/prisma.js";
+import { createDeploymentConnectionStateToken } from "../../../lib/trash-guides/deployment-target.js";
+import {
+	createInjectAuthenticated,
+	registerTestErrorHandler,
+	setupAuthInjection,
+} from "../../__tests__/test-helpers.js";
+import registerInstanceQualityProfileRoutes from "../instance-quality-profile-routes.js";
+
+const databaseUrl = process.env.OVERRIDE_ROUTE_DATABASE_URL;
+const runDatabaseTests =
+	process.env.INTEGRATION_TESTS === "1" && databaseUrl ? describe : describe.skip;
+
+const runId = randomUUID();
+const ids = {
+	user: `override-route-database-user-${runId}`,
+	foreignUser: `override-route-database-foreign-user-${runId}`,
+	primary: `override-route-database-primary-${runId}`,
+	alias: `override-route-database-alias-${runId}`,
+	otherCredential: `override-route-database-other-credential-${runId}`,
+	otherEndpoint: `override-route-database-other-endpoint-${runId}`,
+	foreignInstance: `override-route-database-foreign-instance-${runId}`,
+};
+
+const sharedConnection = {
+	service: "SONARR" as const,
+	baseUrl: "http://sonarr-override-route.test:8989",
+	encryptedApiKey: "synthetic-encrypted-api-key",
+	encryptionIv: "synthetic-encryption-iv",
+	encryptedHttpAuthCredentials: null,
+	httpAuthEncryptionIv: null,
+	connectionGeneration: 3,
+};
+const otherCredentialConnection = {
+	...sharedConnection,
+	encryptedApiKey: `synthetic-other-encrypted-api-key-${runId}`,
+	encryptionIv: `synthetic-other-encryption-iv-${runId}`,
+};
+
+runDatabaseTests("instance quality-profile override route Prisma contract", () => {
+	let app: FastifyInstance;
+	let prisma: PrismaClientInstance;
+	let cleanupDatabaseClient: (() => Promise<void>) | undefined;
+	const createdUserIds: string[] = [];
+
+	beforeAll(async () => {
+		if (!databaseUrl) throw new Error("OVERRIDE_ROUTE_DATABASE_URL is required");
+		if (/^postgres(ql)?:\/\//i.test(databaseUrl)) {
+			const client = await createTestPgClient(databaseUrl);
+			prisma = client.prisma;
+			cleanupDatabaseClient = client.cleanup;
+		} else {
+			prisma = createTestPrismaClient(databaseUrl.replace(/^file:/, ""));
+			cleanupDatabaseClient = () => prisma.$disconnect();
+		}
+
+		await prisma.user.create({ data: { id: ids.user, username: ids.user } });
+		createdUserIds.push(ids.user);
+		await prisma.user.create({
+			data: { id: ids.foreignUser, username: ids.foreignUser },
+		});
+		createdUserIds.push(ids.foreignUser);
+		await prisma.serviceInstance.createMany({
+			data: [
+				{
+					id: ids.primary,
+					userId: ids.user,
+					label: "Primary Sonarr",
+					...sharedConnection,
+				},
+				{
+					id: ids.alias,
+					userId: ids.user,
+					label: "Alias Sonarr",
+					...sharedConnection,
+				},
+				{
+					id: ids.otherCredential,
+					userId: ids.user,
+					label: "Same endpoint with other credentials",
+					...otherCredentialConnection,
+				},
+				{
+					id: ids.otherEndpoint,
+					userId: ids.user,
+					label: "Other Sonarr endpoint",
+					...sharedConnection,
+					baseUrl: "http://other-sonarr-override-route.test:8989",
+				},
+				{
+					id: ids.foreignInstance,
+					userId: ids.foreignUser,
+					label: "Foreign Sonarr",
+					...sharedConnection,
+				},
+			],
+		});
+
+		const connectionStateToken = createDeploymentConnectionStateToken(sharedConnection);
+		await prisma.instanceQualityProfileOverride.createMany({
+			data: [
+				{
+					id: `override-route-database-primary-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-applied-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-uncertain-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 8,
+					score: 25,
+					status: "UNCERTAIN",
+					intentOperation: "SET_SCORE",
+					intendedScore: 25,
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-other-credential-applied-${runId}`,
+					instanceId: ids.otherCredential,
+					qualityProfileId: 4,
+					customFormatId: 11,
+					score: 1_100,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: otherCredentialConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(otherCredentialConnection),
+				},
+				{
+					id: `override-route-database-other-credential-uncertain-${runId}`,
+					instanceId: ids.otherCredential,
+					qualityProfileId: 4,
+					customFormatId: 12,
+					score: 1_200,
+					status: "UNCERTAIN",
+					intentOperation: "SET_SCORE",
+					intendedScore: 1_200,
+					userId: ids.user,
+					connectionGeneration: otherCredentialConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(otherCredentialConnection),
+				},
+				{
+					id: `override-route-database-other-endpoint-${runId}`,
+					instanceId: ids.otherEndpoint,
+					qualityProfileId: 4,
+					customFormatId: 9,
+					score: 900,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken({
+						...sharedConnection,
+						baseUrl: "http://other-sonarr-override-route.test:8989",
+					}),
+				},
+				{
+					id: `override-route-database-foreign-user-${runId}`,
+					instanceId: ids.foreignInstance,
+					qualityProfileId: 4,
+					customFormatId: 10,
+					score: 1_000,
+					status: "APPLIED",
+					userId: ids.foreignUser,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+			],
+		});
+
+		app = Fastify({ logger: false });
+		setupAuthInjection(app, { id: ids.user, username: ids.user });
+		registerTestErrorHandler(app);
+		app.decorate("prisma", prisma);
+		app.decorate("arrClientFactory", {
+			createConnectionCredentialIdentity: vi.fn(
+				(instance: typeof sharedConnection) =>
+					`${instance.encryptedApiKey}:${instance.encryptionIv}`,
+			),
+		} as never);
+		app.decorate("deploymentExecutor", {} as never);
+		await app.register(registerInstanceQualityProfileRoutes, {
+			prefix: "/api/trash-guides/instances",
+		});
+		await app.ready();
+	});
+
+	afterAll(async () => {
+		await app?.close();
+		if (prisma) {
+			if (createdUserIds.length > 0) {
+				await prisma.user.deleteMany({
+					where: { id: { in: createdUserIds } },
+				});
+			}
+			await cleanupDatabaseClient?.();
+		}
+	});
+
+	it("returns alias-bound overrides and recovery without leaking users, endpoints, or secrets", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			`/api/trash-guides/instances/${ids.primary}/quality-profiles/4/overrides`,
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		const body = response.json();
+		expect(body.overrides).toHaveLength(1);
+		expect(body.overrides[0]).toMatchObject({
+			customFormatId: 7,
+			score: 100,
+			status: "APPLIED",
+			userId: ids.user,
+		});
+		expect(body.recoveryPlans).toMatchObject([
+			{
+				qualityProfileId: 4,
+				retryable: true,
+				requiresManualReconciliation: false,
+				entries: [
+					{
+						customFormatId: 8,
+						operation: "SET_SCORE",
+						intendedScore: 25,
+						status: "UNCERTAIN",
+					},
+				],
+				retryAction: {
+					method: "PATCH",
+					recoveryToken: expect.stringMatching(/^[a-f0-9]{64}$/),
+					scoreUpdates: [{ customFormatId: 8, score: 25 }],
+				},
+			},
+		]);
+		expect(response.body).not.toContain(ids.otherEndpoint);
+		expect(response.body).not.toContain(ids.otherCredential);
+		expect(response.body).not.toContain(ids.foreignInstance);
+		expect(response.body).not.toContain(ids.foreignUser);
+		expect(response.body).not.toContain(sharedConnection.encryptedApiKey);
+		expect(response.body).not.toContain(sharedConnection.encryptionIv);
+		expect(response.body).not.toContain(otherCredentialConnection.encryptedApiKey);
+		expect(response.body).not.toContain(otherCredentialConnection.encryptionIv);
+		expect(body.overrides).not.toEqual(
+			expect.arrayContaining([expect.objectContaining({ customFormatId: 11 })]),
+		);
+		expect(body.recoveryPlans).not.toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					entries: expect.arrayContaining([expect.objectContaining({ customFormatId: 12 })]),
+				}),
+			]),
+		);
+	});
+});

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts
@@ -126,6 +126,17 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 					connectionStateToken,
 				},
 				{
+					id: `override-route-database-alias-unique-applied-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 16,
+					score: 1_600,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
 					id: `override-route-database-alias-uncertain-${runId}`,
 					instanceId: ids.alias,
 					qualityProfileId: 4,
@@ -137,6 +148,41 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 					userId: ids.user,
 					connectionGeneration: sharedConnection.connectionGeneration,
 					connectionStateToken,
+				},
+				{
+					id: `override-route-database-alias-pending-${runId}`,
+					instanceId: ids.alias,
+					qualityProfileId: 4,
+					customFormatId: 15,
+					score: 75,
+					status: "PENDING",
+					intentOperation: "SET_SCORE",
+					intendedScore: 75,
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-stale-generation-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 13,
+					score: 1_300,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration - 1,
+					connectionStateToken,
+				},
+				{
+					id: `override-route-database-stale-token-applied-${runId}`,
+					instanceId: ids.primary,
+					qualityProfileId: 4,
+					customFormatId: 14,
+					score: 1_400,
+					status: "APPLIED",
+					userId: ids.user,
+					connectionGeneration: sharedConnection.connectionGeneration,
+					connectionStateToken: `stale-connection-state-token-${runId}`,
 				},
 				{
 					id: `override-route-database-other-credential-applied-${runId}`,
@@ -227,33 +273,57 @@ runDatabaseTests("instance quality-profile override route Prisma contract", () =
 
 		expect(response.statusCode, response.body).toBe(200);
 		const body = response.json();
-		expect(body.overrides).toHaveLength(1);
-		expect(body.overrides[0]).toMatchObject({
-			customFormatId: 7,
-			score: 100,
-			status: "APPLIED",
-			userId: ids.user,
-		});
+		expect(body.overrides).toHaveLength(2);
+		expect(body.overrides).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					customFormatId: 7,
+					score: 100,
+					status: "APPLIED",
+					userId: ids.user,
+				}),
+				expect.objectContaining({
+					customFormatId: 16,
+					score: 1_600,
+					status: "APPLIED",
+					userId: ids.user,
+				}),
+			]),
+		);
 		expect(body.recoveryPlans).toMatchObject([
 			{
 				qualityProfileId: 4,
 				retryable: true,
 				requiresManualReconciliation: false,
-				entries: [
+				entries: expect.arrayContaining([
 					{
 						customFormatId: 8,
 						operation: "SET_SCORE",
 						intendedScore: 25,
 						status: "UNCERTAIN",
 					},
-				],
+					{
+						customFormatId: 15,
+						operation: "SET_SCORE",
+						intendedScore: 75,
+						status: "PENDING",
+					},
+				]),
 				retryAction: {
 					method: "PATCH",
 					recoveryToken: expect.stringMatching(/^[a-f0-9]{64}$/),
-					scoreUpdates: [{ customFormatId: 8, score: 25 }],
+					scoreUpdates: expect.arrayContaining([
+						{ customFormatId: 8, score: 25 },
+						{ customFormatId: 15, score: 75 },
+					]),
 				},
 			},
 		]);
+		for (const staleCustomFormatId of [13, 14]) {
+			expect(body.overrides).not.toEqual(
+				expect.arrayContaining([expect.objectContaining({ customFormatId: staleCustomFormatId })]),
+			);
+		}
 		expect(response.body).not.toContain(ids.otherEndpoint);
 		expect(response.body).not.toContain(ids.otherCredential);
 		expect(response.body).not.toContain(ids.foreignInstance);

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -727,6 +727,46 @@ describe("instance quality profile score persistence", () => {
 		expect(updateProfile).not.toHaveBeenCalled();
 	});
 
+	it("rebinds a saved score retry only through its owner and exact prior connection", async () => {
+		const updatedAt = new Date("2026-08-09T00:00:00Z");
+		const connectionStateToken = createDeploymentConnectionStateToken(instance);
+		findOverrides.mockResolvedValue([
+			{
+				id: "intent-7",
+				instanceId: instance.id,
+				qualityProfileId: 4,
+				customFormatId: 7,
+				intentOperation: "SET_SCORE",
+				intendedScore: -10_000,
+				status: "UNCERTAIN",
+				updatedAt,
+				connectionGeneration: instance.connectionGeneration,
+				connectionStateToken,
+			},
+		]);
+
+		const response = await createInjectAuthenticated(app)(
+			"PATCH",
+			"/instance-1/quality-profiles/4/scores",
+			{ body: { scoreUpdates: [{ customFormatId: 7, score: -10_000 }] } },
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(updateOverrides).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				where: expect.objectContaining({
+					id: "intent-7",
+					userId,
+					instanceId: instance.id,
+					connectionGeneration: instance.connectionGeneration,
+					connectionStateToken,
+					updatedAt,
+				}),
+			}),
+		);
+	});
+
 	it("rejects a recovery token after the saved intent changes", async () => {
 		findOverrides.mockResolvedValue([
 			{
@@ -1154,6 +1194,18 @@ describe("instance quality profile score persistence", () => {
 		);
 		expect(updateOverrides.mock.invocationCallOrder[0]).toBeLessThan(
 			updateProfile.mock.invocationCallOrder[0]!,
+		);
+		expect(updateOverrides).toHaveBeenNthCalledWith(
+			1,
+			expect.objectContaining({
+				where: expect.objectContaining({
+					id: "override-1",
+					userId,
+					instanceId: instance.id,
+					connectionGeneration: instance.connectionGeneration,
+					connectionStateToken: createDeploymentConnectionStateToken(instance),
+				}),
+			}),
 		);
 		expect(deleteOverrides.mock.invocationCallOrder[0]).toBeGreaterThan(
 			updateProfile.mock.invocationCallOrder[0]!,

--- a/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
+++ b/apps/api/src/routes/trash-guides/__tests__/instance-quality-profile-routes.test.ts
@@ -811,6 +811,26 @@ describe("instance quality profile score persistence", () => {
 				}),
 			}),
 		);
+		expect(findOverrides.mock.calls[0]?.[0].where.OR[0].OR[0]).not.toHaveProperty(
+			"credentialIdentity",
+		);
+	});
+
+	it("does not pass runtime credential identity evidence to Prisma override reads", async () => {
+		findOverrides.mockImplementationOnce(async ({ where }) => {
+			if (JSON.stringify(where).includes("credentialIdentity")) {
+				throw new Error("Unknown argument `credentialIdentity`");
+			}
+			return [];
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/instance-1/quality-profiles/4/overrides",
+		);
+
+		expect(response.statusCode, response.body).toBe(200);
+		expect(findOverrides).toHaveBeenCalledOnce();
 	});
 
 	it("exposes retryable uncertain intent without treating it as an applied override", async () => {

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -14,13 +14,14 @@ import { assertNoPendingDeploymentOperation } from "../../lib/trash-guides/deplo
 import {
 	assertNoLegacyDeploymentConnectionMappings,
 	createDeploymentConnectionBindingCandidates,
+	createDeploymentConnectionPersistenceBindings,
 	createDeploymentConnectionStateToken,
 	createDeploymentEndpointKey,
 	createQualityProfileStateToken,
 	createUpstreamResourceStateToken,
 	getEquivalentServiceInstanceIds,
-	isVerifiedClonedProfileSourceConnection,
 	isCurrentDeploymentConnectionMapping,
+	isVerifiedClonedProfileSourceConnection,
 } from "../../lib/trash-guides/deployment-target.js";
 import { getErrorMessage } from "../../lib/utils/error-message.js";
 import { validateRequest } from "../../lib/utils/validate.js";
@@ -475,7 +476,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				const mappings = await app.prisma.templateQualityProfileMapping.findMany({
 					where: {
 						qualityProfileId: profileId,
-						OR: connectionBindings,
+						OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 						template: { userId },
 					},
 					include: { template: true },
@@ -636,7 +637,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						qualityProfileId: profileId,
 						customFormatId: { in: customFormatIds },
 						status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
-						OR: connectionBindings,
+						OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 					},
 				});
 				assertCurrentConnectionRows(overrides, connectionBindings, "saved score override");
@@ -1327,7 +1328,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 				userId,
 				qualityProfileId: profileIdNum,
 				OR: [
-					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: "APPLIED",
+						OR: createDeploymentConnectionPersistenceBindings(
+							connectionContext.connectionReadBindings,
+						),
+					},
 					{
 						status: { in: ["PENDING", "UNCERTAIN"] },
 						instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1421,7 +1427,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						customFormatId,
 						userId,
 						OR: [
-							{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+							{
+								status: "APPLIED",
+								OR: createDeploymentConnectionPersistenceBindings(
+									connectionContext.connectionReadBindings,
+								),
+							},
 							{
 								status: { in: ["PENDING", "UNCERTAIN"] },
 								instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1461,7 +1472,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					{
 						where: {
 							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
+							OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 							template: { userId },
 						},
 						include: { template: true },
@@ -1552,7 +1563,7 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					const transactionMappings = await transaction.templateQualityProfileMapping.findMany({
 						where: {
 							qualityProfileId: profileIdNum,
-							OR: connectionBindings,
+							OR: createDeploymentConnectionPersistenceBindings(connectionBindings),
 							template: { userId },
 						},
 						select: {
@@ -1598,7 +1609,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 							customFormatId,
 							userId,
 							OR: [
-								{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+								{
+									status: "APPLIED",
+									OR: createDeploymentConnectionPersistenceBindings(
+										connectionContext.connectionReadBindings,
+									),
+								},
 								{
 									status: { in: ["PENDING", "UNCERTAIN"] },
 									instanceId: { in: connectionContext.equivalentInstanceIds },
@@ -1676,7 +1692,12 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 					in: profileIds,
 				},
 				OR: [
-					{ status: "APPLIED", OR: connectionContext.connectionReadBindings },
+					{
+						status: "APPLIED",
+						OR: createDeploymentConnectionPersistenceBindings(
+							connectionContext.connectionReadBindings,
+						),
+					},
 					{
 						status: { in: ["PENDING", "UNCERTAIN"] },
 						instanceId: { in: connectionContext.equivalentInstanceIds },

--- a/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
+++ b/apps/api/src/routes/trash-guides/instance-quality-profile-routes.ts
@@ -665,6 +665,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 						const write = await transaction.instanceQualityProfileOverride.updateMany({
 							where: {
 								id: override.id,
+								userId,
+								instanceId: override.instanceId,
+								connectionGeneration: override.connectionGeneration,
+								connectionStateToken: override.connectionStateToken,
 								updatedAt: override.updatedAt,
 								status: { in: ["APPLIED", "PENDING", "UNCERTAIN"] },
 							},
@@ -1069,6 +1073,10 @@ const registerInstanceQualityProfileRoutes: FastifyPluginCallback = (app, _opts,
 								const write = await transaction.instanceQualityProfileOverride.updateMany({
 									where: {
 										id: intent.id,
+										userId,
+										instanceId: intent.instanceId,
+										connectionGeneration: intent.connectionGeneration,
+										connectionStateToken: intent.connectionStateToken,
 										updatedAt: intent.updatedAt,
 										status: { in: ["PENDING", "UNCERTAIN"] },
 										intentOperation: "SET_SCORE",


### PR DESCRIPTION
## Summary

Keep runtime-only `credentialIdentity` evidence out of every Prisma filter while retaining the persisted endpoint bindings required for user, URL, credential, generation, and state-token isolation. The exact helper is `createDeploymentConnectionPersistenceBindings`.

Final head: `1b5de2d6fc488b741166cf5e7e2bb54a96125067`.

## Related issue

Related architectural context: #774 and merged PR #778. This independently reproduced Prisma validation defect has no dedicated tracking issue.

## Scope

- Typed runtime-to-persistence projection for deployment connection bindings.
- All current Prisma consumers in override reads/writes, reset/retry flows, bulk score management, template mappings, and orphan cleanup.
- SQLite/PostgreSQL route contracts and isolation/recovery evidence.

## Non-goals

- No change to endpoint equivalence or credential identity semantics.
- No schema, migration, generated-client, or unrelated query refactor.
- No broadening across users, URLs, credentials, generations, or state tokens.

## Acceptance criteria

- [x] Base contract reproduces HTTP 500; final head returns HTTP 200.
- [x] No current Prisma filter receives `credentialIdentity`.
- [x] All 10 current persistence consumers use `createDeploymentConnectionPersistenceBindings` at the Prisma boundary.
- [x] Equivalent aliases remain visible without crossing user/endpoint/credential/generation/state-token boundaries.
- [x] APPLIED reads use exact current bindings; PENDING/UNCERTAIN recovery evidence remains discoverable only across equivalent instance IDs; stale evidence stays manual-only.
- [x] Responses contain no credential material or secrets.
- [x] SQLite and PostgreSQL contracts pass.

## Root cause and fix

`credentialIdentity` is computed runtime evidence and is intentionally present in in-memory deployment bindings, but it is not a `ServiceInstance` column. Spreading that runtime shape into Prisma `where`/`OR` inputs causes Prisma to reject the query before route serialization.

`createDeploymentConnectionPersistenceBindings` is the typed persistence boundary. It projects only `instanceId`, `connectionGeneration`, and `connectionStateToken` from each candidate; surrounding queries retain `userId` and their domain predicates. The audit covered one bulk-score query, eight route query sites, and one deployment-executor orphan-cleanup query. Reset and `SET_SCORE` CAS predicates also retain user/instance/generation/token/timestamp/status evidence.

## Reproduction

Base `04674303fdecf2a13cfa734765e7cc66a400875b` with the final database contract mounted read-only fails with actual HTTP 500 versus expected 200. The same test on this head passes.

SQLite:

```bash
docker build --target builder -t arrdash-followup-799:1b5de2d6 .
docker run --rm \
  -e INTEGRATION_TESTS=1 \
  -e DATABASE_URL=file:/tmp/override-route.db \
  -e OVERRIDE_ROUTE_DATABASE_URL=file:/tmp/override-route.db \
  arrdash-followup-799:1b5de2d6 sh -lc \
  'cd /app/apps/api && pnpm exec prisma db push --schema prisma/schema.prisma && pnpm exec vitest run src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts'
```

PostgreSQL with one copyable synthetic password variable:

```bash
PG_TEST_PASSWORD='synthetic-test-password'
docker network create arrdash-overrides-pg
docker run -d --name arrdash-overrides-pg --network arrdash-overrides-pg \
  -e POSTGRES_USER=arrdash \
  -e POSTGRES_PASSWORD="$PG_TEST_PASSWORD" \
  -e POSTGRES_DB=arrdash postgres:16-alpine
until docker exec arrdash-overrides-pg pg_isready -U arrdash; do sleep 2; done
docker run --rm --network arrdash-overrides-pg \
  -e INTEGRATION_TESTS=1 \
  -e DATABASE_URL="postgresql://arrdash:${PG_TEST_PASSWORD}@arrdash-overrides-pg:5432/arrdash" \
  -e OVERRIDE_ROUTE_DATABASE_URL="postgresql://arrdash:${PG_TEST_PASSWORD}@arrdash-overrides-pg:5432/arrdash" \
  arrdash-followup-799:1b5de2d6 sh -lc \
  'sed -i '\''s/provider = "sqlite"/provider = "postgresql"/'\'' /app/apps/api/prisma/schema.prisma && cd /app/apps/api && pnpm exec prisma generate --schema prisma/schema.prisma && pnpm exec prisma db push --schema prisma/schema.prisma && pnpm exec vitest run src/routes/trash-guides/__tests__/instance-quality-profile-routes.database.test.ts'
docker rm -f arrdash-overrides-pg
docker network rm arrdash-overrides-pg
unset PG_TEST_PASSWORD
```

## Changes

- Add and type the persistence projection without weakening runtime identity checks.
- Project all 10 Prisma consumers at their database boundary.
- Preserve complete reset/score CAS predicates.
- Fix the indirect `trashTemplate.findMany` user scope.
- Cover primary/alias deduplication, alias-only bindings, APPLIED/PENDING/UNCERTAIN behavior, and isolation failures.

## Local validation on the exact final head

| Command/check | Environment | Result |
| --- | --- | --- |
| Focused target/route/bulk-score suite | Node 22 builder | 101 passed; DB-gated test separately executed |
| Route DB contract | Real SQLite | 1/1 passed, HTTP 200 |
| Route DB contract | PostgreSQL 16 | 1/1 passed, HTTP 200 |
| Mounted final DB contract on base | Baseline builder + SQLite | failed as expected: actual 500 vs expected 200 |
| `pnpm run test` | Exact builder image with exact contract directories read-only | 4 Turbo tasks passed; API 4,619 passed/52 skipped; web/shared passed |
| `pnpm run typecheck` and `pnpm run lint` | Exact builder image | 3/3 packages passed for each |
| `pnpm run test:pr-review-contract` | Exact files read-only | 53/53 passed |
| Docker builder/production build | `arrdash-followup-799:1b5de2d6` | passed |
| `check:prisma-generated` | Disposable Linux Git index, Prisma 7.9.0 | up to date |
| Changed-file Biome and `git diff --check` | Repository configuration | passed |

`pnpm run format` is blocked by checkout-wide CRLF normalization in untouched files and fails identically on the unchanged base image. All 8 changed files pass their repository formatter/linter and the final diff has no whitespace error; no blanket line-ending rewrite is included.

## Database and migration impact

No schema, migration, or generated-client change. Query predicates become Prisma-valid while remaining at least as narrow as before. Real SQLite and PostgreSQL route contracts pass.

## Security and privacy

Only synthetic aliases/users/endpoints and disposable databases were used. No credential value is serialized. A different user, URL, credential identity, connection generation, or state token remains excluded.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [ ] `pnpm run format` ? exact checkout-wide CRLF blocker documented above; changed files pass Biome
- [x] `pnpm --filter @arr/shared build`, when shared changed ? shared unchanged; build passed in gauntlet
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable ? real provider route contracts verified
- [x] New queries use centralized query keys and polling constants, when applicable ? N/A
- [x] New sensitive displays preserve incognito behavior, when applicable ? N/A
- [x] New Prisma queries for user-owned resources include `userId`, when applicable
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable ? N/A
- [x] User-facing counts are precise rather than proxies, when applicable ? N/A
- [x] Action links reach the correct page with required parameters, when applicable ? N/A
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

## External CI blocker

For exact head `1b5de2d6fc488b741166cf5e7e2bb54a96125067`, CI `32946610546`, Semgrep `32946610460`, CodeQL `32946610529`, and Docker Smoke Test `32946610680` all completed `action_required` with `jobs: []`. An upstream maintainer must choose **Approve and run workflows**. This PR does not claim GitHub CI is green.

## Review plan

- Initial broad-reviewed head: `f3b10e99a6913bc28fcea47877f8fd468eea59db`
- Correction head: `1b5de2d6fc488b741166cf5e7e2bb54a96125067`
- Targeted delta range: `f3b10e99a6913bc28fcea47877f8fd468eea59db..1b5de2d6fc488b741166cf5e7e2bb54a96125067`
- Material-scope change declared? Yes ? the follow-up audit expanded verification to every existing Prisma consumer and added narrowly scoped missing projections/tests without changing the PR domain.
- Independent regression reviewer: Internal Codex subagent Fermat ? PASS for baseline 500/head 200 and regression boundaries. Not a GitHub review or maintainer approval.
- Independent data-safety reviewer, when required: Internal Codex subagents Arendt/Tesla ? PASS for call sites and isolation. Not a GitHub review or maintainer approval.
- GitHub Codex review head: pending external review availability
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| 799-A | P1 | Valid | Runtime binding reached multiple Prisma consumers | All 10 consumers now project through the exact helper | Focused and DB contracts pass |
| 799-B | P1 | Valid safety requirement | Projection could not be allowed to broaden endpoint ownership | User/URL/credential/generation/token isolation retained and tested | SQLite/PostgreSQL pass |
| 799-C | P3 | Valid documentation defect | Body named a non-existent helper | Corrected to `createDeploymentConnectionPersistenceBindings` | This body is authoritative |
| 799-D | P3 | Valid reproduction defect | DSN masked a required synthetic password | Copyable `PG_TEST_PASSWORD` flow supplied | Provider repro passed |

## Final merge gate

- [ ] Exact-head CI is green ? externally blocked by `action_required`/zero jobs
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [ ] Maintainer approved merge
- [x] Post-merge verification is planned ? rerun the SQLite/PostgreSQL route contract and alias isolation on the merged image
