### PR TITLE
fix(trash-guides): accept Sonarr's default language field after writes

### DIFF
--- a/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-custom-format-state.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	type CustomFormatRollbackState,
+	createIntendedCustomFormatPostStateToken,
+	matchesIntendedCustomFormatPostStateToken,
 	rollbackCustomFormatDeployment,
 } from "../deployment-custom-format-state.js";
 import { createUpstreamResourceStateToken } from "../deployment-target.js";
@@ -373,5 +375,132 @@ describe("rollbackCustomFormatDeployment", () => {
 				}),
 			),
 		).rejects.toThrow("ID is unknown");
+	});
+});
+
+describe("Custom Format intended post-state tokens", () => {
+	const intended = {
+		id: 7,
+		name: "Created CF",
+		includeCustomFormatWhenRenaming: false,
+		specifications: [
+			{
+				name: "Language: Not English",
+				implementation: "LanguageSpecification",
+				negate: true,
+				required: false,
+				fields: [{ name: "value", value: 1 }],
+			},
+		],
+	};
+	const metadataRichSonarrReadback = {
+		...intended,
+		specifications: [
+			{
+				...intended.specifications[0],
+				id: 12,
+				implementationName: "Language",
+				infoLink: "https://example.invalid/language",
+				fields: [
+					{ name: "value", value: 1, order: 0, label: "Language", type: "select" },
+					{
+						name: "exceptLanguage",
+						value: false,
+						order: 1,
+						label: "Except language",
+						type: "checkbox",
+					},
+				],
+			},
+		],
+	};
+
+	it("recognizes an exact state and Sonarr's one omitted false default despite readback metadata", () => {
+		const token = createIntendedCustomFormatPostStateToken(intended, "SONARR");
+		expect(matchesIntendedCustomFormatPostStateToken(intended, token)).toBe(true);
+		expect(matchesIntendedCustomFormatPostStateToken(metadataRichSonarrReadback, token)).toBe(true);
+	});
+
+	it("does not apply the Sonarr exception to a Radarr recovery token", () => {
+		const token = createIntendedCustomFormatPostStateToken(intended, "RADARR");
+		expect(matchesIntendedCustomFormatPostStateToken(metadataRichSonarrReadback, token)).toBe(
+			false,
+		);
+	});
+
+	it("never lets intended writable evidence override a different exact post-state token", async () => {
+		const current = {
+			...metadataRichSonarrReadback,
+			specifications: [
+				{
+					...metadataRichSonarrReadback.specifications[0],
+					infoLink: "https://example.invalid/changed-metadata",
+				},
+			],
+		};
+		const qualityProfileGetAll = vi.fn();
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([current]),
+				getById: vi.fn().mockResolvedValue(current),
+			},
+			qualityProfile: { getAll: qualityProfileGetAll },
+		};
+
+		await expect(
+			rollbackCustomFormatDeployment(
+				client as never,
+				appliedState({
+					status: "pending",
+					postStateToken: createUpstreamResourceStateToken(metadataRichSonarrReadback),
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intended, "SONARR"),
+				}),
+			),
+		).rejects.toThrow("unverified deployment state");
+		expect(qualityProfileGetAll).not.toHaveBeenCalled();
+	});
+
+	it("does not remove a false field when the intent explicitly defines exceptLanguage=true", () => {
+		const explicitTrue = {
+			...intended,
+			specifications: [
+				{
+					...intended.specifications[0],
+					fields: [...intended.specifications[0]!.fields, { name: "exceptLanguage", value: true }],
+				},
+			],
+		};
+		const conflictingReadback = {
+			...explicitTrue,
+			specifications: [
+				{
+					...explicitTrue.specifications[0],
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "exceptLanguage", value: false },
+						{ name: "exceptLanguage", value: true },
+					],
+				},
+			],
+		};
+		const token = createIntendedCustomFormatPostStateToken(explicitTrue, "SONARR");
+		expect(matchesIntendedCustomFormatPostStateToken(conflictingReadback, token)).toBe(false);
+	});
+
+	it("rejects real writable drift even when server metadata is present", () => {
+		const token = createIntendedCustomFormatPostStateToken(intended, "SONARR");
+		const drifted = {
+			...metadataRichSonarrReadback,
+			specifications: [
+				{
+					...metadataRichSonarrReadback.specifications[0],
+					fields: [
+						{ name: "value", value: 2, order: 0, label: "Language", type: "select" },
+						metadataRichSonarrReadback.specifications[0]!.fields[1],
+					],
+				},
+			],
+		};
+		expect(matchesIntendedCustomFormatPostStateToken(drifted, token)).toBe(false);
 	});
 });

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-sonarr.integration.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-sonarr.integration.test.ts
@@ -3,6 +3,8 @@ import { SonarrClient } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 
+// Reproducible fixture verified from local OCI metadata:
+// lscr.io/linuxserver/sonarr:4.0.19.2979-ls322@sha256:c19aa4ecdf03d73e1d5c901da33744cb7eb4d921f89bafed1ca264601d7fa224
 const sonarrUrl = process.env.SONARR_INTEGRATION_URL;
 const sonarrApiKey = process.env.SONARR_INTEGRATION_API_KEY;
 const hasLiveSonarr = Boolean(process.env.INTEGRATION_TESTS === "1" && sonarrUrl && sonarrApiKey);
@@ -26,17 +28,19 @@ describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", ()
 		const syntheticName = `ARR Dashboard Sonarr post-write integration ${runId}`;
 		const syntheticTrashId = `sonarr-except-language-integration-${runId}`;
 		let createdId: number | undefined;
-		const persistMutationState = vi
-			.fn()
-			.mockImplementation(
-				async (state: { action: "created" | "updated"; resourceId: number | null }) => {
-					if (state.action !== "created" || state.resourceId === null) return;
-					if (createdId !== undefined && createdId !== state.resourceId) {
-						throw new Error("Live Sonarr test observed more than one created resource ID");
-					}
-					createdId = state.resourceId;
-				},
-			);
+		const persistMutationState = vi.fn().mockResolvedValue(undefined);
+		const createCustomFormat = client.customFormat.create.bind(client.customFormat);
+		vi.spyOn(client.customFormat, "create").mockImplementation(async (format) => {
+			const created = await createCustomFormat(format);
+			if (!Number.isSafeInteger(created.id) || (created.id ?? 0) <= 0) {
+				throw new Error("Live Sonarr test POST returned no exact positive resource ID");
+			}
+			if (createdId !== undefined && createdId !== created.id) {
+				throw new Error("Live Sonarr test observed more than one created resource ID");
+			}
+			createdId = created.id;
+			return created;
+		});
 		const specification = {
 			name: "Language: Not English",
 			implementation: "LanguageSpecification",
@@ -46,6 +50,8 @@ describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", ()
 		};
 		let operationError: unknown;
 		try {
+			const systemStatus = await client.system.get();
+			expect(systemStatus.version).toBe("4.0.19.2979");
 			const createResult = await deployCustomFormats(
 				client,
 				[
@@ -59,6 +65,7 @@ describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", ()
 				new Map(),
 				undefined,
 				persistMutationState,
+				"SONARR",
 			);
 			expect(createResult.created).toBe(1);
 			expect(createdId).toEqual(expect.any(Number));
@@ -86,6 +93,7 @@ describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", ()
 				new Map([[syntheticName, created]]),
 				undefined,
 				persistMutationState,
+				"SONARR",
 			);
 			expect(updateResult.updated).toBe(1);
 		} catch (error) {
@@ -97,18 +105,25 @@ describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", ()
 			if (createdId !== undefined) {
 				const current = await client.customFormat.getById(createdId);
 				const currentSpecification = current.specifications?.[0];
-				const currentValue = currentSpecification?.fields?.find(
-					(field) => field.name === "value",
-				)?.value;
+				const currentFields = currentSpecification?.fields?.map(({ name, value }) => ({
+					name,
+					value,
+				}));
 				if (
+					current.id !== createdId ||
 					current.name !== syntheticName ||
+					current.includeCustomFormatWhenRenaming !== false ||
 					current.specifications?.length !== 1 ||
 					currentSpecification?.name !== specification.name ||
 					currentSpecification.implementation !== specification.implementation ||
-					currentValue !== 1
+					currentSpecification.negate !== specification.negate ||
+					currentSpecification.required !== specification.required ||
+					currentFields?.length !== 2 ||
+					!currentFields.some((field) => field.name === "value" && field.value === 1) ||
+					!currentFields.some((field) => field.name === "exceptLanguage" && field.value === false)
 				) {
 					cleanupError = new Error(
-						"Refusing to clean up a live Sonarr resource whose identity or contents changed",
+						`Refusing to clean up live Sonarr Custom Format "${syntheticName}" with exact ID ${createdId} because its identity or contents changed`,
 					);
 				} else {
 					await client.customFormat.delete(createdId);

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor-sonarr.integration.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor-sonarr.integration.test.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto";
+import { SonarrClient } from "arr-sdk";
+import { describe, expect, it, vi } from "vitest";
+import { DeploymentExecutorService } from "../deployment-executor.js";
+
+const sonarrUrl = process.env.SONARR_INTEGRATION_URL;
+const sonarrApiKey = process.env.SONARR_INTEGRATION_API_KEY;
+const hasLiveSonarr = Boolean(process.env.INTEGRATION_TESTS === "1" && sonarrUrl && sonarrApiKey);
+
+describe.skipIf(!hasLiveSonarr)("DeploymentExecutorService with live Sonarr", () => {
+	it("verifies create and update when Sonarr adds exceptLanguage=false", async () => {
+		const client = new SonarrClient({
+			baseUrl: sonarrUrl!,
+			apiKey: sonarrApiKey!,
+		});
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const deployCustomFormats = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<{
+					created: number;
+					updated: number;
+				}>;
+			}
+		).deployCustomFormats.bind(executor);
+		const runId = randomUUID();
+		const syntheticName = `ARR Dashboard Sonarr post-write integration ${runId}`;
+		const syntheticTrashId = `sonarr-except-language-integration-${runId}`;
+		let createdId: number | undefined;
+		const persistMutationState = vi
+			.fn()
+			.mockImplementation(
+				async (state: { action: "created" | "updated"; resourceId: number | null }) => {
+					if (state.action !== "created" || state.resourceId === null) return;
+					if (createdId !== undefined && createdId !== state.resourceId) {
+						throw new Error("Live Sonarr test observed more than one created resource ID");
+					}
+					createdId = state.resourceId;
+				},
+			);
+		const specification = {
+			name: "Language: Not English",
+			implementation: "LanguageSpecification",
+			negate: true,
+			required: false,
+			fields: [{ name: "value", value: 1 }],
+		};
+		let operationError: unknown;
+		try {
+			const createResult = await deployCustomFormats(
+				client,
+				[
+					{
+						trashId: syntheticTrashId,
+						name: syntheticName,
+						originalConfig: { specifications: [specification] },
+					},
+				],
+				new Map(),
+				new Map(),
+				undefined,
+				persistMutationState,
+			);
+			expect(createResult.created).toBe(1);
+			expect(createdId).toEqual(expect.any(Number));
+
+			const created = await client.customFormat.getById(createdId!);
+			expect(created.name).toBe(syntheticName);
+			const fields = created.specifications?.[0]?.fields;
+			expect(fields).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "value", value: 1 }),
+					expect.objectContaining({ name: "exceptLanguage", value: false }),
+				]),
+			);
+
+			const updateResult = await deployCustomFormats(
+				client,
+				[
+					{
+						trashId: syntheticTrashId,
+						name: syntheticName,
+						originalConfig: { specifications: [specification] },
+					},
+				],
+				new Map([[syntheticTrashId, created]]),
+				new Map([[syntheticName, created]]),
+				undefined,
+				persistMutationState,
+			);
+			expect(updateResult.updated).toBe(1);
+		} catch (error) {
+			operationError = error;
+		}
+
+		let cleanupError: unknown;
+		try {
+			if (createdId !== undefined) {
+				const current = await client.customFormat.getById(createdId);
+				const currentSpecification = current.specifications?.[0];
+				const currentValue = currentSpecification?.fields?.find(
+					(field) => field.name === "value",
+				)?.value;
+				if (
+					current.name !== syntheticName ||
+					current.specifications?.length !== 1 ||
+					currentSpecification?.name !== specification.name ||
+					currentSpecification.implementation !== specification.implementation ||
+					currentValue !== 1
+				) {
+					cleanupError = new Error(
+						"Refusing to clean up a live Sonarr resource whose identity or contents changed",
+					);
+				} else {
+					await client.customFormat.delete(createdId);
+				}
+			}
+		} catch (error) {
+			cleanupError = error;
+		}
+
+		if (operationError !== undefined && cleanupError !== undefined) {
+			throw new AggregateError(
+				[operationError, cleanupError],
+				"Live Sonarr verification and its scoped cleanup both failed",
+			);
+		}
+		if (operationError !== undefined) throw operationError;
+		if (cleanupError !== undefined) throw cleanupError;
+	}, 30_000);
+});

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -8,6 +8,11 @@ import type { SonarrClient } from "arr-sdk";
 import { describe, expect, it, vi } from "vitest";
 import { ConflictError } from "../../errors.js";
 import { extractTrashId } from "../cf-field-utils.js";
+import {
+	type CustomFormatRollbackState,
+	createIntendedCustomFormatPostStateToken,
+	rollbackCustomFormatDeployment,
+} from "../deployment-custom-format-state.js";
 import { DeploymentExecutorService } from "../deployment-executor.js";
 import {
 	createDeploymentEndpointKey,
@@ -62,19 +67,53 @@ const sonarrLanguageReadbackSpecification = {
 	],
 };
 
-function runCustomFormatUpdateVerification(
+const metadataRichSonarrLanguageReadbackSpecification = {
+	...sonarrLanguageReadbackSpecification,
+	id: 12,
+	implementationName: "Language",
+	infoLink: "https://example.invalid/language",
+	fields: [
+		{ name: "value", value: 1, order: 0, label: "Language", type: "select" },
+		{
+			name: "exceptLanguage",
+			value: false,
+			order: 1,
+			label: "Except language",
+			type: "checkbox",
+		},
+	],
+};
+
+function runCustomFormatVerification(
+	method: "POST" | "PUT",
 	readbackSpecifications: unknown[],
 	intendedSpecifications: unknown[] = [intendedLanguageSpecification],
+	service: "SONARR" | "RADARR" = "SONARR",
+	readbackOverrides: Record<string, unknown> = {},
 ): Promise<unknown> {
-	const before = { id: 1, name: "Test CF", specifications: [] } as SdkCustomFormat;
+	const before = {
+		id: 1,
+		name: "Test CF",
+		includeCustomFormatWhenRenaming: false,
+		specifications: [],
+	} as SdkCustomFormat;
+	const readback = {
+		...before,
+		specifications: readbackSpecifications,
+		...readbackOverrides,
+	};
 	const client = {
-		customFormat: {
-			getById: vi
-				.fn()
-				.mockResolvedValueOnce(before)
-				.mockResolvedValueOnce({ ...before, specifications: readbackSpecifications }),
-			update: vi.fn().mockResolvedValue(undefined),
-		},
+		customFormat:
+			method === "PUT"
+				? {
+						getById: vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(readback),
+						update: vi.fn().mockResolvedValue(undefined),
+					}
+				: {
+						getAll: vi.fn().mockResolvedValue([]),
+						create: vi.fn().mockResolvedValue({ id: 1 }),
+						getById: vi.fn().mockResolvedValue(readback),
+					},
 	};
 	const executor = new DeploymentExecutorService({} as never, {} as never);
 	const run = (
@@ -91,10 +130,11 @@ function runCustomFormatUpdateVerification(
 				originalConfig: { specifications: intendedSpecifications },
 			},
 		],
-		new Map([["cf-1", before]]),
-		new Map([["Test CF", before]]),
+		method === "PUT" ? new Map([["cf-1", before]]) : new Map(),
+		method === "PUT" ? new Map([["Test CF", before]]) : new Map(),
 		undefined,
 		vi.fn().mockResolvedValue(undefined),
+		service,
 	);
 }
 
@@ -252,6 +292,8 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 					byTrashId: Map<string, SdkCustomFormat>,
 					byName: Map<string, SdkCustomFormat>,
 					resolutions: undefined,
+					persist: undefined,
+					service: "SONARR" | "RADARR",
 				) => Promise<unknown>;
 			}
 		).deployCustomFormats(
@@ -266,6 +308,8 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 			new Map([["cf-1", existing]]),
 			new Map([["Test CF", existing]]),
 			undefined,
+			undefined,
+			"SONARR",
 		);
 
 	it("aborts instead of overwriting an existing format changed after preview", async () => {
@@ -313,6 +357,8 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 				new Map([["cf-1", existing]]),
 				new Map([["Test CF", existing]]),
 				{ "cf-1": "keep_existing" },
+				undefined,
+				"SONARR",
 			),
 		).rejects.toThrow("changed during deployment");
 		expect(client.customFormat.getById).toHaveBeenCalledWith(1);
@@ -336,7 +382,7 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 		expect(create).not.toHaveBeenCalled();
 	});
 
-	it("records the exact created Custom Format state before the follow-up read", async () => {
+	it("records the created Custom Format ID without treating the POST response as materialized state", async () => {
 		const created = {
 			id: 7,
 			name: "Test CF",
@@ -366,6 +412,7 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 				new Map(),
 				undefined,
 				persistMutationState,
+				"SONARR",
 			),
 		).rejects.toThrow("post-write state could not be verified");
 		expect(persistMutationState).toHaveBeenNthCalledWith(
@@ -373,30 +420,185 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 			expect.objectContaining({
 				resourceId: 7,
 				status: "pending",
-				postStateToken: createUpstreamResourceStateToken(created),
+				postStateToken: null,
+				intendedPostStateToken: createIntendedCustomFormatPostStateToken(created, "SONARR"),
 			}),
 			false,
 		);
 	});
 
-	it("preserves a verified creation when final ledger persistence fails", async () => {
-		const created = {
+	it.each(["POST", "PUT"] as const)(
+		"does not start a Custom Format %s when the initial pending ledger cannot be persisted",
+		async (method) => {
+			const before = {
+				id: 1,
+				name: "Test CF",
+				includeCustomFormatWhenRenaming: false,
+				specifications: [],
+			} as SdkCustomFormat;
+			const create = vi.fn();
+			const update = vi.fn();
+			const client = {
+				customFormat:
+					method === "POST"
+						? { getAll: vi.fn().mockResolvedValue([]), create }
+						: { getById: vi.fn().mockResolvedValue(before), update },
+			};
+			const executor = new DeploymentExecutorService({} as never, {} as never);
+			const run = (
+				executor as unknown as {
+					deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+				}
+			).deployCustomFormats.bind(executor);
+
+			await expect(
+				run(
+					client,
+					[{ trashId: "cf-1", name: "Test CF", originalConfig: { specifications: [] } }],
+					method === "PUT" ? new Map([["cf-1", before]]) : new Map(),
+					method === "PUT" ? new Map([["Test CF", before]]) : new Map(),
+					undefined,
+					vi.fn().mockRejectedValue(new Error("ledger unavailable")),
+					"SONARR",
+				),
+			).resolves.toMatchObject({ created: 0, updated: 0, details: { failed: ["Test CF"] } });
+			expect(create).not.toHaveBeenCalled();
+			expect(update).not.toHaveBeenCalled();
+		},
+	);
+
+	it("stops after POST when the returned ID cannot be made durable", async () => {
+		const durableStates: CustomFormatRollbackState[] = [];
+		const persist = vi.fn(async (state: CustomFormatRollbackState) => {
+			if (durableStates.length === 1) throw new Error("ID checkpoint unavailable");
+			durableStates.push(structuredClone(state));
+		});
+		const create = vi.fn().mockResolvedValue({ id: 7 });
+		const getById = vi.fn();
+		const client = {
+			customFormat: { getAll: vi.fn().mockResolvedValue([]), create, getById },
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[{ trashId: "cf-1", name: "Test CF", originalConfig: { specifications: [] } }],
+				new Map(),
+				new Map(),
+				undefined,
+				persist,
+				"SONARR",
+			),
+		).rejects.toMatchObject({
+			deploymentResultUncertain: true,
+			partialDeployment: { created: 0, updated: 0 },
+		});
+		expect(durableStates).toEqual([
+			expect.objectContaining({ resourceId: null, postStateToken: null }),
+		]);
+		expect(create).toHaveBeenCalledOnce();
+		expect(getById).not.toHaveBeenCalled();
+	});
+
+	it("reconciles metadata-rich Sonarr state when the exact POST token checkpoint fails", async () => {
+		const intended = {
 			id: 7,
 			name: "Test CF",
 			includeCustomFormatWhenRenaming: false,
-			specifications: [],
+			specifications: [intendedLanguageSpecification],
 		};
-		const persistMutationState = vi
-			.fn()
-			.mockResolvedValueOnce(undefined)
-			.mockResolvedValueOnce(undefined)
-			.mockRejectedValueOnce(new Error("final ledger unavailable"));
+		const materialized = {
+			...intended,
+			specifications: [metadataRichSonarrLanguageReadbackSpecification],
+		};
+		const durableStates: CustomFormatRollbackState[] = [];
+		const persist = vi.fn(async (state: CustomFormatRollbackState) => {
+			if (durableStates.length === 2) throw new Error("exact token checkpoint unavailable");
+			durableStates.push(structuredClone(state));
+		});
+		const create = vi.fn().mockResolvedValue({ id: 7 });
 		const client = {
 			customFormat: {
-				getAll: vi.fn().mockResolvedValue([]),
-				create: vi.fn().mockResolvedValue(created),
-				getById: vi.fn().mockResolvedValue(created),
+				getAll: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([materialized]),
+				create,
+				getById: vi.fn().mockResolvedValue(materialized),
 			},
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: [intendedLanguageSpecification] },
+					},
+				],
+				new Map(),
+				new Map(),
+				undefined,
+				persist,
+				"SONARR",
+			),
+		).rejects.toMatchObject({
+			deploymentResultUncertain: true,
+			partialDeployment: {
+				created: 1,
+				updated: 0,
+				details: { created: ["Test CF"] },
+			},
+		});
+		expect(durableStates[1]).toMatchObject({
+			resourceId: 7,
+			status: "pending",
+			postStateToken: null,
+			intendedPostStateToken: createIntendedCustomFormatPostStateToken(intended, "SONARR"),
+		});
+		await expect(
+			rollbackCustomFormatDeployment(client as never, durableStates[1]!),
+		).rejects.toThrow("cannot be deleted safely");
+		expect(create).toHaveBeenCalledOnce();
+	});
+
+	it("preserves exact Sonarr recovery evidence when final POST ledger persistence fails", async () => {
+		const intended = {
+			id: 7,
+			name: "Test CF",
+			includeCustomFormatWhenRenaming: false,
+			specifications: [intendedLanguageSpecification],
+		};
+		const materialized = {
+			...intended,
+			specifications: [metadataRichSonarrLanguageReadbackSpecification],
+		};
+		const durableStates: CustomFormatRollbackState[] = [];
+		const persistMutationState = vi.fn(
+			async (state: CustomFormatRollbackState, _append: boolean) => {
+				if (durableStates.length === 3) throw new Error("final ledger unavailable");
+				durableStates.push(structuredClone(state));
+			},
+		);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValueOnce([]).mockResolvedValue([materialized]),
+				create: vi.fn().mockResolvedValue({ id: 7 }),
+				getById: vi.fn().mockResolvedValue(materialized),
+			},
+			qualityProfile: { getAll: vi.fn().mockResolvedValue([]) },
 		};
 		const executor = new DeploymentExecutorService({} as never, {} as never);
 		const run = (
@@ -409,11 +611,18 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 		try {
 			await run(
 				client,
-				[{ trashId: "cf-1", name: "Test CF", originalConfig: { specifications: [] } }],
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: [intendedLanguageSpecification] },
+					},
+				],
 				new Map(),
 				new Map(),
 				undefined,
 				persistMutationState,
+				"SONARR",
 			);
 		} catch (error) {
 			conflict = error;
@@ -427,6 +636,15 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 				details: { created: ["Test CF"], updated: [], failed: [] },
 			},
 		});
+		expect(durableStates[2]).toMatchObject({
+			resourceId: 7,
+			status: "pending",
+			postStateToken: createUpstreamResourceStateToken(materialized),
+			intendedPostStateToken: createIntendedCustomFormatPostStateToken(intended, "SONARR"),
+		});
+		await expect(
+			rollbackCustomFormatDeployment(client as never, durableStates[2]!),
+		).rejects.toThrow("cannot be deleted safely");
 	});
 
 	it("attaches earlier successful writes when a later format drifts", async () => {
@@ -464,6 +682,8 @@ describe("DeploymentExecutorService - Custom Format drift", () => {
 				new Map(),
 				new Map(),
 				undefined,
+				undefined,
+				"SONARR",
 			);
 		} catch (error) {
 			conflict = error;
@@ -688,6 +908,7 @@ describe("DeploymentExecutorService - backup parity", () => {
 			new Map([["Test CF", before]]),
 			undefined,
 			persist,
+			"SONARR",
 		);
 
 		expect(persisted[0]).toMatchObject({
@@ -695,6 +916,14 @@ describe("DeploymentExecutorService - backup parity", () => {
 			state: { status: "pending", resourceId: 1, action: "updated" },
 		});
 		expect(persisted[1]).toMatchObject({
+			append: false,
+			state: {
+				status: "pending",
+				resourceId: 1,
+				postStateToken: expect.any(String),
+			},
+		});
+		expect(persisted[2]).toMatchObject({
 			append: false,
 			state: {
 				status: "applied",
@@ -728,7 +957,10 @@ describe("DeploymentExecutorService - backup parity", () => {
 				},
 			],
 		};
-		const persist = vi.fn().mockResolvedValue(undefined);
+		const persisted: Array<{ state: Record<string, unknown>; append: boolean }> = [];
+		const persist = vi.fn(async (state: Record<string, unknown>, append: boolean) => {
+			persisted.push({ state: structuredClone(state), append });
+		});
 		const client = {
 			customFormat: {
 				getById: vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(sonarrReadback),
@@ -756,22 +988,204 @@ describe("DeploymentExecutorService - backup parity", () => {
 				new Map([["Test CF", before]]),
 				undefined,
 				persist,
+				"SONARR",
 			),
 		).resolves.toMatchObject({ updated: 1 });
-		expect(persist).toHaveBeenLastCalledWith(
-			expect.objectContaining({ status: "applied", postStateToken: expect.any(String) }),
-			false,
+		const intendedState = { ...before, specifications: intendedSpecifications };
+		expect(persisted).toEqual([
+			{
+				append: true,
+				state: expect.objectContaining({
+					status: "pending",
+					postStateToken: null,
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+			{
+				append: false,
+				state: expect.objectContaining({
+					status: "pending",
+					postStateToken: createUpstreamResourceStateToken(sonarrReadback),
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+			{
+				append: false,
+				state: expect.objectContaining({
+					status: "applied",
+					postStateToken: createUpstreamResourceStateToken(sonarrReadback),
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+		]);
+		expect(createUpstreamResourceStateToken(sonarrReadback)).not.toBe(
+			createUpstreamResourceStateToken(intendedState),
 		);
 	});
 
-	it("accepts Sonarr's default false exceptLanguage field after a Custom Format POST", async () => {
-		const readback = {
+	it("preserves exact Sonarr recovery evidence when final PUT ledger persistence fails", async () => {
+		const before = {
 			id: 1,
 			name: "Test CF",
 			includeCustomFormatWhenRenaming: false,
+			specifications: [],
+		} as SdkCustomFormat;
+		const intended = {
+			...before,
+			specifications: [intendedLanguageSpecification],
+		};
+		const materialized = {
+			...intended,
+			specifications: [metadataRichSonarrLanguageReadbackSpecification],
+		};
+		const durableStates: CustomFormatRollbackState[] = [];
+		const persist = vi.fn(async (state: CustomFormatRollbackState, _append: boolean) => {
+			if (durableStates.length === 2) throw new Error("final ledger unavailable");
+			durableStates.push(structuredClone(state));
+		});
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([materialized]),
+				getById: vi
+					.fn()
+					.mockResolvedValueOnce(before)
+					.mockResolvedValueOnce(materialized)
+					.mockResolvedValue(materialized),
+				update: vi.fn().mockResolvedValue(undefined),
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: [intendedLanguageSpecification] },
+					},
+				],
+				new Map([["cf-1", before]]),
+				new Map([["Test CF", before]]),
+				undefined,
+				persist,
+				"SONARR",
+			),
+		).rejects.toMatchObject({
+			deploymentResultUncertain: true,
+			partialDeployment: {
+				created: 0,
+				updated: 1,
+				details: { updated: ["Test CF"] },
+			},
+		});
+		expect(durableStates[1]).toMatchObject({
+			resourceId: 1,
+			status: "pending",
+			postStateToken: createUpstreamResourceStateToken(materialized),
+			intendedPostStateToken: createIntendedCustomFormatPostStateToken(intended, "SONARR"),
+		});
+		await expect(
+			rollbackCustomFormatDeployment(client as never, durableStates[1]!),
+		).rejects.toThrow("cannot be restored safely");
+	});
+
+	it("reconciles metadata-rich Sonarr state when the exact PUT token checkpoint fails", async () => {
+		const before = {
+			id: 1,
+			name: "Test CF",
+			includeCustomFormatWhenRenaming: false,
+			specifications: [],
+		} as SdkCustomFormat;
+		const intended = {
+			...before,
+			specifications: [intendedLanguageSpecification],
+		};
+		const materialized = {
+			...intended,
+			specifications: [metadataRichSonarrLanguageReadbackSpecification],
+		};
+		const durableStates: CustomFormatRollbackState[] = [];
+		const persist = vi.fn(async (state: CustomFormatRollbackState) => {
+			if (durableStates.length === 1) throw new Error("exact token checkpoint unavailable");
+			durableStates.push(structuredClone(state));
+		});
+		const update = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([materialized]),
+				getById: vi
+					.fn()
+					.mockResolvedValueOnce(before)
+					.mockResolvedValueOnce(materialized)
+					.mockResolvedValue(materialized),
+				update,
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: [intendedLanguageSpecification] },
+					},
+				],
+				new Map([["cf-1", before]]),
+				new Map([["Test CF", before]]),
+				undefined,
+				persist,
+				"SONARR",
+			),
+		).rejects.toMatchObject({
+			deploymentResultUncertain: true,
+			partialDeployment: {
+				created: 0,
+				updated: 1,
+				details: { updated: ["Test CF"] },
+			},
+		});
+		expect(durableStates[0]).toMatchObject({
+			resourceId: 1,
+			status: "pending",
+			postStateToken: null,
+			intendedPostStateToken: createIntendedCustomFormatPostStateToken(intended, "SONARR"),
+		});
+		await expect(
+			rollbackCustomFormatDeployment(client as never, durableStates[0]!),
+		).rejects.toThrow("cannot be restored safely");
+		expect(update).toHaveBeenCalledOnce();
+	});
+
+	it("accepts Sonarr's default false exceptLanguage field after a Custom Format POST", async () => {
+		const intendedState = {
+			id: 1,
+			name: "Test CF",
+			includeCustomFormatWhenRenaming: false,
+			specifications: [intendedLanguageSpecification],
+		};
+		const readback = {
+			...intendedState,
 			specifications: [sonarrLanguageReadbackSpecification],
 		};
-		const persist = vi.fn().mockResolvedValue(undefined);
+		const persisted: Array<{ state: Record<string, unknown>; append: boolean }> = [];
+		const persist = vi.fn(async (state: Record<string, unknown>, append: boolean) => {
+			persisted.push({ state: structuredClone(state), append });
+		});
 		const client = {
 			customFormat: {
 				getAll: vi.fn().mockResolvedValue([]),
@@ -800,15 +1214,51 @@ describe("DeploymentExecutorService - backup parity", () => {
 				new Map(),
 				undefined,
 				persist,
+				"SONARR",
 			),
 		).resolves.toMatchObject({ created: 1 });
-		expect(persist).toHaveBeenLastCalledWith(
-			expect.objectContaining({ status: "applied", postStateToken: expect.any(String) }),
-			false,
-		);
+		expect(persisted).toEqual([
+			{
+				append: true,
+				state: expect.objectContaining({
+					resourceId: null,
+					status: "pending",
+					postStateToken: null,
+					intendedPostStateToken: null,
+				}),
+			},
+			{
+				append: false,
+				state: expect.objectContaining({
+					resourceId: 1,
+					status: "pending",
+					postStateToken: null,
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+			{
+				append: false,
+				state: expect.objectContaining({
+					resourceId: 1,
+					status: "pending",
+					postStateToken: createUpstreamResourceStateToken(readback),
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+			{
+				append: false,
+				state: expect.objectContaining({
+					resourceId: 1,
+					status: "applied",
+					postStateToken: createUpstreamResourceStateToken(readback),
+					intendedPostStateToken: createIntendedCustomFormatPostStateToken(intendedState, "SONARR"),
+				}),
+			},
+		]);
 	});
 
 	it.each([
+		["missing specification", []],
 		["specification name", [{ ...sonarrLanguageReadbackSpecification, name: "Language: English" }]],
 		[
 			"implementation",
@@ -836,6 +1286,44 @@ describe("DeploymentExecutorService - backup parity", () => {
 					fields: [
 						{ name: "value", value: 1 },
 						{ name: "exceptLanguage", value: true },
+					],
+				},
+			],
+		],
+		[
+			"duplicate default exceptLanguage fields",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "exceptLanguage", value: false },
+						{ name: "exceptLanguage", value: false },
+					],
+				},
+			],
+		],
+		[
+			"conflicting false and true exceptLanguage fields",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "exceptLanguage", value: false },
+						{ name: "exceptLanguage", value: true },
+					],
+				},
+			],
+		],
+		[
+			"wrong field name",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "language", value: 1 },
+						{ name: "exceptLanguage", value: false },
 					],
 				},
 			],
@@ -876,9 +1364,11 @@ describe("DeploymentExecutorService - backup parity", () => {
 			],
 		],
 	])("rejects Custom Format drift in %s after Sonarr normalization", async (_label, readback) => {
-		await expect(runCustomFormatUpdateVerification(readback)).rejects.toMatchObject({
-			deploymentResultUncertain: true,
-		});
+		for (const method of ["POST", "PUT"] as const) {
+			await expect(runCustomFormatVerification(method, readback)).rejects.toMatchObject({
+				deploymentResultUncertain: true,
+			});
+		}
 	});
 
 	it("rejects a changed regex after Sonarr normalization", async () => {
@@ -894,12 +1384,15 @@ describe("DeploymentExecutorService - backup parity", () => {
 			fields: [{ name: "value", value: "changed-regex" }],
 		};
 
-		await expect(
-			runCustomFormatUpdateVerification(
-				[sonarrLanguageReadbackSpecification, changedRegexSpecification],
-				[intendedLanguageSpecification, intendedRegexSpecification],
-			),
-		).rejects.toMatchObject({ deploymentResultUncertain: true });
+		for (const method of ["POST", "PUT"] as const) {
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[sonarrLanguageReadbackSpecification, changedRegexSpecification],
+					[intendedLanguageSpecification, intendedRegexSpecification],
+				),
+			).rejects.toMatchObject({ deploymentResultUncertain: true });
+		}
 	});
 
 	it("rejects swapped specification association after Sonarr normalization", async () => {
@@ -911,13 +1404,104 @@ describe("DeploymentExecutorService - backup parity", () => {
 			fields: [{ name: "value", value: "original-regex" }],
 		};
 
-		await expect(
-			runCustomFormatUpdateVerification(
-				[intendedRegexSpecification, sonarrLanguageReadbackSpecification],
-				[intendedLanguageSpecification, intendedRegexSpecification],
-			),
-		).rejects.toMatchObject({ deploymentResultUncertain: true });
+		for (const method of ["POST", "PUT"] as const) {
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[intendedRegexSpecification, sonarrLanguageReadbackSpecification],
+					[intendedLanguageSpecification, intendedRegexSpecification],
+				),
+			).rejects.toMatchObject({ deploymentResultUncertain: true });
+		}
 	});
+
+	it.each(["POST", "PUT"] as const)(
+		"keeps Radarr strict when exceptLanguage=false appears after %s",
+		async (method) => {
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[sonarrLanguageReadbackSpecification],
+					[intendedLanguageSpecification],
+					"RADARR",
+				),
+			).rejects.toMatchObject({ deploymentResultUncertain: true });
+		},
+	);
+
+	it.each(["POST", "PUT"] as const)(
+		"accepts an exact Radarr LanguageSpecification state after %s",
+		async (method) => {
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[intendedLanguageSpecification],
+					[intendedLanguageSpecification],
+					"RADARR",
+				),
+			).resolves.toMatchObject(method === "POST" ? { created: 1 } : { updated: 1 });
+		},
+	);
+
+	it.each([false, true])(
+		"accepts an explicitly intended exceptLanguage=%s value exactly after POST and PUT",
+		async (exceptLanguage) => {
+			const intended = {
+				...intendedLanguageSpecification,
+				fields: [
+					...intendedLanguageSpecification.fields,
+					{ name: "exceptLanguage", value: exceptLanguage },
+				],
+			};
+			for (const method of ["POST", "PUT"] as const) {
+				await expect(
+					runCustomFormatVerification(method, [intended], [intended]),
+				).resolves.toMatchObject(method === "POST" ? { created: 1 } : { updated: 1 });
+			}
+		},
+	);
+
+	it.each([
+		["name", { name: "Changed CF" }],
+		["includeCustomFormatWhenRenaming", { includeCustomFormatWhenRenaming: true }],
+	] as const)("rejects top-level %s drift after POST and PUT", async (_label, overrides) => {
+		for (const method of ["POST", "PUT"] as const) {
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[sonarrLanguageReadbackSpecification],
+					[intendedLanguageSpecification],
+					"SONARR",
+					overrides,
+				),
+			).rejects.toMatchObject({ deploymentResultUncertain: true });
+		}
+	});
+
+	it.each(["POST", "PUT"] as const)(
+		"rejects exceptLanguage=false on a non-language specification after %s",
+		async (method) => {
+			const intended = {
+				name: "Release title",
+				implementation: "ReleaseTitleSpecification",
+				negate: false,
+				required: false,
+				fields: [{ name: "value", value: "original-regex" }],
+			};
+			await expect(
+				runCustomFormatVerification(
+					method,
+					[
+						{
+							...intended,
+							fields: [...intended.fields, { name: "exceptLanguage", value: false }],
+						},
+					],
+					[intended],
+				),
+			).rejects.toMatchObject({ deploymentResultUncertain: true });
+		},
+	);
 
 	it("keeps a Custom Format pending when ARR returns a different writable state", async () => {
 		const before = { id: 1, name: "Test CF", specifications: [] } as SdkCustomFormat;
@@ -952,6 +1536,7 @@ describe("DeploymentExecutorService - backup parity", () => {
 				new Map([["Test CF", before]]),
 				undefined,
 				persist,
+				"SONARR",
 			),
 		).rejects.toMatchObject({
 			message: expect.stringContaining("post-write state could not be verified"),
@@ -997,6 +1582,7 @@ describe("DeploymentExecutorService - backup parity", () => {
 				]),
 				undefined,
 				vi.fn().mockResolvedValue(undefined),
+				"SONARR",
 			),
 		).rejects.toMatchObject({
 			message: expect.stringContaining("post-write state could not be verified"),

--- a/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
+++ b/apps/api/src/lib/trash-guides/__tests__/deployment-executor.test.ts
@@ -46,6 +46,58 @@ const createSpecWithObjectFields = (
 	fields: fields as unknown as SdkSpecification["fields"],
 });
 
+const intendedLanguageSpecification = {
+	name: "Language: Not English",
+	implementation: "LanguageSpecification",
+	negate: true,
+	required: false,
+	fields: [{ name: "value", value: 1 }],
+};
+
+const sonarrLanguageReadbackSpecification = {
+	...intendedLanguageSpecification,
+	fields: [
+		{ name: "value", value: 1 },
+		{ name: "exceptLanguage", value: false },
+	],
+};
+
+function runCustomFormatUpdateVerification(
+	readbackSpecifications: unknown[],
+	intendedSpecifications: unknown[] = [intendedLanguageSpecification],
+): Promise<unknown> {
+	const before = { id: 1, name: "Test CF", specifications: [] } as SdkCustomFormat;
+	const client = {
+		customFormat: {
+			getById: vi
+				.fn()
+				.mockResolvedValueOnce(before)
+				.mockResolvedValueOnce({ ...before, specifications: readbackSpecifications }),
+			update: vi.fn().mockResolvedValue(undefined),
+		},
+	};
+	const executor = new DeploymentExecutorService({} as never, {} as never);
+	const run = (
+		executor as unknown as {
+			deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+		}
+	).deployCustomFormats.bind(executor);
+	return run(
+		client,
+		[
+			{
+				trashId: "cf-1",
+				name: "Test CF",
+				originalConfig: { specifications: intendedSpecifications },
+			},
+		],
+		new Map([["cf-1", before]]),
+		new Map([["Test CF", before]]),
+		undefined,
+		vi.fn().mockResolvedValue(undefined),
+	);
+}
+
 describe("extractTrashId", () => {
 	it("should extract trash_id from array format fields", () => {
 		const cf: SdkCustomFormat = {
@@ -651,6 +703,220 @@ describe("DeploymentExecutorService - backup parity", () => {
 			},
 		});
 		expect(persist.mock.invocationCallOrder[0]).toBeLessThan(update.mock.invocationCallOrder[0]!);
+	});
+
+	it("accepts Sonarr's default false exceptLanguage field after a Custom Format PUT", async () => {
+		const before = { id: 1, name: "Test CF", specifications: [] } as SdkCustomFormat;
+		const intendedSpecifications = [
+			{
+				name: "Language: Not English",
+				implementation: "LanguageSpecification",
+				negate: true,
+				required: false,
+				fields: [{ name: "value", value: 1 }],
+			},
+		];
+		const sonarrReadback = {
+			...before,
+			specifications: [
+				{
+					...intendedSpecifications[0],
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "exceptLanguage", value: false },
+					],
+				},
+			],
+		};
+		const persist = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getById: vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(sonarrReadback),
+				update: vi.fn().mockResolvedValue(undefined),
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: intendedSpecifications },
+					},
+				],
+				new Map([["cf-1", before]]),
+				new Map([["Test CF", before]]),
+				undefined,
+				persist,
+			),
+		).resolves.toMatchObject({ updated: 1 });
+		expect(persist).toHaveBeenLastCalledWith(
+			expect.objectContaining({ status: "applied", postStateToken: expect.any(String) }),
+			false,
+		);
+	});
+
+	it("accepts Sonarr's default false exceptLanguage field after a Custom Format POST", async () => {
+		const readback = {
+			id: 1,
+			name: "Test CF",
+			includeCustomFormatWhenRenaming: false,
+			specifications: [sonarrLanguageReadbackSpecification],
+		};
+		const persist = vi.fn().mockResolvedValue(undefined);
+		const client = {
+			customFormat: {
+				getAll: vi.fn().mockResolvedValue([]),
+				create: vi.fn().mockResolvedValue({ id: 1 }),
+				getById: vi.fn().mockResolvedValue(readback),
+			},
+		};
+		const executor = new DeploymentExecutorService({} as never, {} as never);
+		const run = (
+			executor as unknown as {
+				deployCustomFormats: (...args: unknown[]) => Promise<unknown>;
+			}
+		).deployCustomFormats.bind(executor);
+
+		await expect(
+			run(
+				client,
+				[
+					{
+						trashId: "cf-1",
+						name: "Test CF",
+						originalConfig: { specifications: [intendedLanguageSpecification] },
+					},
+				],
+				new Map(),
+				new Map(),
+				undefined,
+				persist,
+			),
+		).resolves.toMatchObject({ created: 1 });
+		expect(persist).toHaveBeenLastCalledWith(
+			expect.objectContaining({ status: "applied", postStateToken: expect.any(String) }),
+			false,
+		);
+	});
+
+	it.each([
+		["specification name", [{ ...sonarrLanguageReadbackSpecification, name: "Language: English" }]],
+		[
+			"implementation",
+			[{ ...sonarrLanguageReadbackSpecification, implementation: "ReleaseTitleSpecification" }],
+		],
+		["negate", [{ ...sonarrLanguageReadbackSpecification, negate: false }]],
+		["required", [{ ...sonarrLanguageReadbackSpecification, required: true }]],
+		[
+			"selected language",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "value", value: 2 },
+						{ name: "exceptLanguage", value: false },
+					],
+				},
+			],
+		],
+		[
+			"semantic exceptLanguage value",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "exceptLanguage", value: true },
+					],
+				},
+			],
+		],
+		[
+			"missing intended field",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [{ name: "exceptLanguage", value: false }],
+				},
+			],
+		],
+		[
+			"unexpected semantic field",
+			[
+				{
+					...sonarrLanguageReadbackSpecification,
+					fields: [
+						{ name: "value", value: 1 },
+						{ name: "unexpected", value: false },
+						{ name: "exceptLanguage", value: false },
+					],
+				},
+			],
+		],
+		[
+			"specification count",
+			[
+				sonarrLanguageReadbackSpecification,
+				{
+					name: "Unexpected",
+					implementation: "ReleaseTitleSpecification",
+					negate: false,
+					required: false,
+					fields: [{ name: "value", value: "unexpected" }],
+				},
+			],
+		],
+	])("rejects Custom Format drift in %s after Sonarr normalization", async (_label, readback) => {
+		await expect(runCustomFormatUpdateVerification(readback)).rejects.toMatchObject({
+			deploymentResultUncertain: true,
+		});
+	});
+
+	it("rejects a changed regex after Sonarr normalization", async () => {
+		const intendedRegexSpecification = {
+			name: "Release title",
+			implementation: "ReleaseTitleSpecification",
+			negate: false,
+			required: false,
+			fields: [{ name: "value", value: "original-regex" }],
+		};
+		const changedRegexSpecification = {
+			...intendedRegexSpecification,
+			fields: [{ name: "value", value: "changed-regex" }],
+		};
+
+		await expect(
+			runCustomFormatUpdateVerification(
+				[sonarrLanguageReadbackSpecification, changedRegexSpecification],
+				[intendedLanguageSpecification, intendedRegexSpecification],
+			),
+		).rejects.toMatchObject({ deploymentResultUncertain: true });
+	});
+
+	it("rejects swapped specification association after Sonarr normalization", async () => {
+		const intendedRegexSpecification = {
+			name: "Release title",
+			implementation: "ReleaseTitleSpecification",
+			negate: false,
+			required: false,
+			fields: [{ name: "value", value: "original-regex" }],
+		};
+
+		await expect(
+			runCustomFormatUpdateVerification(
+				[intendedRegexSpecification, sonarrLanguageReadbackSpecification],
+				[intendedLanguageSpecification, intendedRegexSpecification],
+			),
+		).rejects.toMatchObject({ deploymentResultUncertain: true });
 	});
 
 	it("keeps a Custom Format pending when ARR returns a different writable state", async () => {

--- a/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
+++ b/apps/api/src/lib/trash-guides/deployment-custom-format-state.ts
@@ -3,6 +3,150 @@ import { z } from "zod";
 import { createUpstreamResourceStateToken } from "./deployment-target.js";
 
 type ArrClient = SonarrClient | RadarrClient;
+const intendedWritableStateTokenPrefix = "arr-dashboard-custom-format-writable-v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function projectWritableCustomFormatState(value: unknown): unknown {
+	if (!isRecord(value)) return value;
+	return {
+		name: value.name,
+		includeCustomFormatWhenRenaming: value.includeCustomFormatWhenRenaming,
+		specifications: Array.isArray(value.specifications)
+			? value.specifications.map((specification) => {
+					if (!isRecord(specification)) return specification;
+					return {
+						name: specification.name,
+						implementation: specification.implementation,
+						negate: specification.negate,
+						required: specification.required,
+						fields: Array.isArray(specification.fields)
+							? specification.fields.map((field) =>
+									isRecord(field) ? { name: field.name, value: field.value } : field,
+								)
+							: specification.fields,
+					};
+				})
+			: value.specifications,
+	};
+}
+
+function getDefaultableSonarrLanguageSpecificationIndexes(
+	intended: Record<string, unknown>,
+): number[] {
+	if (!Array.isArray(intended.specifications)) return [];
+	return intended.specifications.flatMap((specification, index) => {
+		if (
+			!isRecord(specification) ||
+			specification.implementation !== "LanguageSpecification" ||
+			!Array.isArray(specification.fields) ||
+			specification.fields.some((field) => isRecord(field) && field.name === "exceptLanguage")
+		) {
+			return [];
+		}
+		return [index];
+	});
+}
+
+function removeMaterializedSonarrDefaults(actual: unknown, defaultableIndexes: number[]): unknown {
+	if (!isRecord(actual) || !Array.isArray(actual.specifications)) return actual;
+	const defaultableIndexSet = new Set(defaultableIndexes);
+	return {
+		...actual,
+		specifications: actual.specifications.map((specification, index) => {
+			if (
+				!defaultableIndexSet.has(index) ||
+				!isRecord(specification) ||
+				specification.implementation !== "LanguageSpecification" ||
+				!Array.isArray(specification.fields)
+			) {
+				return specification;
+			}
+			const exceptLanguageFields = specification.fields.flatMap((field, fieldIndex) =>
+				isRecord(field) && field.name === "exceptLanguage" ? [{ field, fieldIndex }] : [],
+			);
+			if (exceptLanguageFields.length !== 1 || exceptLanguageFields[0]?.field.value !== false) {
+				return specification;
+			}
+			return {
+				...specification,
+				fields: specification.fields.filter(
+					(_, fieldIndex) => fieldIndex !== exceptLanguageFields[0]?.fieldIndex,
+				),
+			};
+		}),
+	};
+}
+
+function createWritableCustomFormatStateToken(value: unknown): string {
+	return createUpstreamResourceStateToken(projectWritableCustomFormatState(value));
+}
+
+/**
+ * Persist a versioned token in the same writable-state domain used by post-write verification.
+ * The token records exactly which Sonarr LanguageSpecifications omitted exceptLanguage, so
+ * recovery cannot apply Sonarr's false-default exception to Radarr or to an explicit value.
+ */
+export function createIntendedCustomFormatPostStateToken(
+	intended: Record<string, unknown>,
+	service: string,
+): string {
+	if (service !== "SONARR" && service !== "RADARR") {
+		throw new Error(`Unsupported Custom Format mutation service: ${service}`);
+	}
+	const defaultableIndexes =
+		service === "SONARR" ? getDefaultableSonarrLanguageSpecificationIndexes(intended) : [];
+	return [
+		intendedWritableStateTokenPrefix,
+		service,
+		defaultableIndexes.length > 0 ? defaultableIndexes.join(",") : "-",
+		createWritableCustomFormatStateToken(intended),
+	].join(":");
+}
+
+/** Reconcile a pending mutation without accepting any state the original verifier rejected. */
+export function matchesIntendedCustomFormatPostStateToken(
+	actual: unknown,
+	intendedToken: string,
+): boolean {
+	const [prefix, service, rawIndexes, expectedHash, ...extra] = intendedToken.split(":");
+	if (
+		prefix !== intendedWritableStateTokenPrefix ||
+		(service !== "SONARR" && service !== "RADARR") ||
+		extra.length > 0 ||
+		!/^[a-f0-9]{64}$/.test(expectedHash ?? "")
+	) {
+		return false;
+	}
+	const defaultableIndexes =
+		rawIndexes === "-"
+			? []
+			: /^\d+(?:,\d+)*$/.test(rawIndexes ?? "")
+				? rawIndexes!.split(",").map(Number)
+				: null;
+	if (
+		defaultableIndexes === null ||
+		defaultableIndexes.some(
+			(index, position) =>
+				!Number.isSafeInteger(index) ||
+				index < 0 ||
+				index <= (defaultableIndexes[position - 1] ?? -1),
+		)
+	) {
+		return false;
+	}
+	if (createWritableCustomFormatStateToken(actual) === expectedHash) return true;
+	return (
+		service === "SONARR" &&
+		defaultableIndexes.length > 0 &&
+		createWritableCustomFormatStateToken(
+			removeMaterializedSonarrDefaults(actual, defaultableIndexes),
+		) === expectedHash
+	);
+}
+
 const restorableCustomFormatFieldSchema = z.looseObject({
 	name: z.string().min(1),
 	type: z.string().min(1),
@@ -77,10 +221,19 @@ export async function rollbackCustomFormatDeployment(
 		) {
 			return "noop";
 		}
-		if (state.postStateToken && currentToken === state.postStateToken) {
+		if (state.postStateToken) {
+			if (currentToken !== state.postStateToken) {
+				throw new Error(
+					`Custom Format "${state.name}" has an unverified deployment state and was not changed.`,
+				);
+			}
 			verifiedPostStateToken = state.postStateToken;
-		} else if (state.intendedPostStateToken && currentToken === state.intendedPostStateToken) {
-			verifiedPostStateToken = state.intendedPostStateToken;
+		} else if (
+			state.intendedPostStateToken &&
+			(currentToken === state.intendedPostStateToken ||
+				matchesIntendedCustomFormatPostStateToken(current, state.intendedPostStateToken))
+		) {
+			verifiedPostStateToken = currentToken;
 		} else {
 			throw new Error(
 				`Custom Format "${state.name}" has an unverified deployment state and was not changed.`,

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -32,7 +32,10 @@ import {
 } from "./cf-field-utils.js";
 import { checkMutualExclusions } from "./conflict-checker.js";
 import { shouldRetainDeploymentBackup } from "./deployment-backup-state.js";
-import type { CustomFormatRollbackState } from "./deployment-custom-format-state.js";
+import {
+	type CustomFormatRollbackState,
+	createIntendedCustomFormatPostStateToken,
+} from "./deployment-custom-format-state.js";
 import {
 	finalizeDeploymentHistory,
 	finalizeDeploymentHistoryWithFailure,
@@ -336,7 +339,15 @@ function assertIntendedCustomFormatWritableState(
 	actual: unknown,
 	intended: Record<string, unknown>,
 	resourceLabel: string,
+	service: ServiceType,
 ): void {
+	try {
+		assertIntendedWritableState(actual, intended, resourceLabel);
+		return;
+	} catch (error) {
+		if (!(error instanceof ConflictError) || service !== "SONARR") throw error;
+	}
+
 	assertIntendedWritableState(
 		normalizeCustomFormatReadbackDefaults(actual, intended),
 		intended,
@@ -744,6 +755,7 @@ export class DeploymentExecutorService {
 			state: CustomFormatRollbackState,
 			append: boolean,
 		) => Promise<void> = async () => {},
+		service: ServiceType = "RADARR",
 	): Promise<DeployCustomFormatsResult> {
 		const errors: string[] = [];
 		const details: DeploymentDetails = {
@@ -827,7 +839,10 @@ export class DeploymentExecutorService {
 						name: templateCF.name,
 						status: "pending",
 						postStateToken: null,
-						intendedPostStateToken: createUpstreamResourceStateToken(updatedCF),
+						intendedPostStateToken: createIntendedCustomFormatPostStateToken(
+							updatedCF as Record<string, unknown>,
+							service,
+						),
 					};
 					await persistMutationState(mutationState, true);
 
@@ -841,12 +856,14 @@ export class DeploymentExecutorService {
 						postWriteFormat,
 						updatedCF as Record<string, unknown>,
 						`Custom Format "${templateCF.name}"`,
+						service,
 					);
-					mutationState.status = "applied";
-					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
-					await persistMutationState(mutationState, false);
 					updated++;
 					details.updated.push(templateCF.name);
+					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
+					await persistMutationState(mutationState, false);
+					mutationState.status = "applied";
+					await persistMutationState(mutationState, false);
 				} else {
 					const freshFormats = await client.customFormat.getAll();
 					const appearedDuringDeployment = freshFormats.find(
@@ -888,18 +905,23 @@ export class DeploymentExecutorService {
 						throw new Error("ARR created the Custom Format without returning its ID");
 					}
 					mutationState.resourceId = createdFormat.id;
-					mutationState.postStateToken = createUpstreamResourceStateToken(createdFormat);
+					mutationState.intendedPostStateToken = createIntendedCustomFormatPostStateToken(
+						{ ...newCF, id: createdFormat.id },
+						service,
+					);
 					await persistMutationState(mutationState, false);
 					const postWriteFormat = await client.customFormat.getById(createdFormat.id);
 					assertIntendedCustomFormatWritableState(
 						postWriteFormat,
 						newCF as Record<string, unknown>,
 						`Custom Format "${templateCF.name}"`,
+						service,
 					);
-					mutationState.status = "applied";
-					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
 					created++;
 					details.created.push(templateCF.name);
+					mutationState.postStateToken = createUpstreamResourceStateToken(postWriteFormat);
+					await persistMutationState(mutationState, false);
+					mutationState.status = "applied";
 					await persistMutationState(mutationState, false);
 					resolvedResourceIds.set(templateCF.trashId, createdFormat.id);
 				}
@@ -2258,6 +2280,7 @@ export class DeploymentExecutorService {
 						throw error;
 					}
 				},
+				instance.service,
 			);
 			partialCFResult = cfResult;
 			deploymentPhase = "quality_profile";

--- a/apps/api/src/lib/trash-guides/deployment-executor.ts
+++ b/apps/api/src/lib/trash-guides/deployment-executor.ts
@@ -268,6 +268,82 @@ function assertIntendedWritableState(
 	}
 }
 
+function normalizeCustomFormatReadbackDefaults(
+	actual: unknown,
+	intended: Record<string, unknown>,
+): unknown {
+	if (!actual || typeof actual !== "object" || Array.isArray(actual)) return actual;
+	const actualRecord = actual as Record<string, unknown>;
+	const actualSpecifications = actualRecord.specifications;
+	const intendedSpecifications = intended.specifications;
+	if (!Array.isArray(actualSpecifications) || !Array.isArray(intendedSpecifications)) {
+		return actual;
+	}
+
+	return {
+		...actualRecord,
+		specifications: actualSpecifications.map((actualSpecification, index) => {
+			const intendedSpecification = intendedSpecifications[index];
+			if (
+				!actualSpecification ||
+				typeof actualSpecification !== "object" ||
+				Array.isArray(actualSpecification) ||
+				!intendedSpecification ||
+				typeof intendedSpecification !== "object" ||
+				Array.isArray(intendedSpecification)
+			) {
+				return actualSpecification;
+			}
+			const actualSpec = actualSpecification as Record<string, unknown>;
+			const intendedSpec = intendedSpecification as Record<string, unknown>;
+			if (
+				actualSpec.implementation !== "LanguageSpecification" ||
+				intendedSpec.implementation !== "LanguageSpecification" ||
+				!Array.isArray(actualSpec.fields) ||
+				!Array.isArray(intendedSpec.fields)
+			) {
+				return actualSpecification;
+			}
+			const intendedDefinesExceptLanguage = intendedSpec.fields.some(
+				(field) =>
+					field !== null &&
+					typeof field === "object" &&
+					!Array.isArray(field) &&
+					(field as Record<string, unknown>).name === "exceptLanguage",
+			);
+			if (intendedDefinesExceptLanguage) return actualSpecification;
+
+			const defaultFieldIndexes = actualSpec.fields.flatMap((field, fieldIndex) =>
+				field !== null &&
+				typeof field === "object" &&
+				!Array.isArray(field) &&
+				(field as Record<string, unknown>).name === "exceptLanguage" &&
+				(field as Record<string, unknown>).value === false
+					? [fieldIndex]
+					: [],
+			);
+			if (defaultFieldIndexes.length !== 1) return actualSpecification;
+
+			return {
+				...actualSpec,
+				fields: actualSpec.fields.filter((_, fieldIndex) => fieldIndex !== defaultFieldIndexes[0]),
+			};
+		}),
+	};
+}
+
+function assertIntendedCustomFormatWritableState(
+	actual: unknown,
+	intended: Record<string, unknown>,
+	resourceLabel: string,
+): void {
+	assertIntendedWritableState(
+		normalizeCustomFormatReadbackDefaults(actual, intended),
+		intended,
+		resourceLabel,
+	);
+}
+
 function toPublicQualityProfileMutation(
 	mutation: QualityProfileMutation | undefined,
 ): DeploymentResult["qualityProfileApplied"] {
@@ -761,7 +837,7 @@ export class DeploymentExecutorService {
 						updatedCF as unknown as Parameters<typeof client.customFormat.update>[1],
 					);
 					const postWriteFormat = await client.customFormat.getById(existingCF.id);
-					assertIntendedWritableState(
+					assertIntendedCustomFormatWritableState(
 						postWriteFormat,
 						updatedCF as Record<string, unknown>,
 						`Custom Format "${templateCF.name}"`,
@@ -815,7 +891,7 @@ export class DeploymentExecutorService {
 					mutationState.postStateToken = createUpstreamResourceStateToken(createdFormat);
 					await persistMutationState(mutationState, false);
 					const postWriteFormat = await client.customFormat.getById(createdFormat.id);
-					assertIntendedWritableState(
+					assertIntendedCustomFormatWritableState(
 						postWriteFormat,
 						newCF as Record<string, unknown>,
 						`Custom Format "${templateCF.name}"`,


### PR DESCRIPTION
## Summary

Make Custom Format post-write verification exact-first and Sonarr-specific for the single proven no-op: when the request omitted `exceptLanguage`, Sonarr may materialize exactly one `LanguageSpecification` field with `exceptLanguage=false`. Radarr and every semantic drift remain strict/fail-closed. Recovery now records both a versioned intended writable-state token and the exact verified readback token with exact-token priority.

Final head: `97d5e80c385a833c415810da7d5c2735b7d55521`.

## Related issue

Related to #774 and merged recovery PR #778. This PR fixes one independently verified Sonarr interruption cause; it does not assert that Radarr has the same API behavior.

## Scope

- Sonarr Custom Format POST/PUT readback verification.
- Intended/exact post-state evidence and rollback recovery matching.
- Checkpoint accounting after verified writes.
- Deterministic unit matrix and gated live Sonarr integration test.

## Non-goals

- No Radarr normalization.
- No general unknown-field stripping, lossy canonicalization, retry, or extra upstream mutation.
- No schema, migration, endpoint-ownership, or unrelated deployment change.

## Acceptance criteria

- [x] Exact writable-state comparison is attempted first.
- [x] Only Sonarr may use the narrow fallback, and only for one non-intended `exceptLanguage=false` on the same `LanguageSpecification` index.
- [x] Explicit false/true, duplicates, false+true, wrong/missing fields, wrong language, missing/extra/swapped specifications, changed implementation/name/regex/flags/order/count/top-level fields all remain fail-closed.
- [x] POST and PUT have identical safety boundaries.
- [x] A present exact `postStateToken` is exclusive; mismatch cannot be overridden by intended/legacy semantic fallback.
- [x] Verified POST/PUT counts are durable even if a later exact-token/final-ledger checkpoint fails.
- [x] Live test uses a pinned tag+digest and exact-ID/content fail-closed cleanup.

## Root cause and fix

Sonarr 4 materializes an omitted boolean default in `LanguageSpecification.fields`. Structural equality therefore rejected a successful write and correctly stopped as uncertain, but for a semantic no-op. The earlier normalization also lacked an explicit service parameter, so its code-level scope was wider than the Sonarr-specific claim.

The final comparator preserves the existing exact check first and catches only its `ConflictError`. Only for `service=SONARR` does it remove exactly one actual-only `exceptLanguage=false` at the corresponding language-specification index, then rerun the strict comparator. Radarr never enters the fallback.

`intendedPostStateToken` is now a versioned, service-bound internal token over the writable Custom Format projection plus the exact Sonarr default indexes. The actual GET checkpoint still stores a full exact token. During recovery, a matching before-state no-op is checked first; otherwise a present exact token is authoritative and any mismatch fails immediately. Intended/legacy fallback is reachable only when no exact token exists. After a successful intended match, the current full exact token is captured for subsequent fail-closed checks.

## Reproduction

The base commit with the final PUT regression mounted read-only fails as expected with a verification `ConflictError`; this head passes.

Pinned live image:

```text
lscr.io/linuxserver/sonarr:4.0.19.2979-ls322@sha256:c19aa4ecdf03d73e1d5c901da33744cb7eb4d921f89bafed1ca264601d7fa224
```

Complete disposable live reproduction; the API key is captured but never printed:

```bash
SONARR_IMAGE='lscr.io/linuxserver/sonarr:4.0.19.2979-ls322@sha256:c19aa4ecdf03d73e1d5c901da33744cb7eb4d921f89bafed1ca264601d7fa224'
docker network create arrdash-sonarr-repro
docker volume create arrdash-sonarr-repro-config
docker run -d --name arrdash-sonarr-repro --network arrdash-sonarr-repro \
  -v arrdash-sonarr-repro-config:/config "$SONARR_IMAGE"
until docker exec arrdash-sonarr-repro test -s /config/config.xml; do sleep 2; done
SONARR_API_KEY="$(docker exec arrdash-sonarr-repro sh -c \
  "sed -n 's:.*<ApiKey>\(.*\)</ApiKey>.*:\1:p' /config/config.xml")"
until docker exec arrdash-sonarr-repro curl -fsS \
  -H "X-Api-Key: $SONARR_API_KEY" \
  http://127.0.0.1:8989/api/v3/system/status >/dev/null; do sleep 2; done
docker build --target builder -t arrdash-followup-800:97d5e80c .
docker run --rm --network arrdash-sonarr-repro \
  -e INTEGRATION_TESTS=1 \
  -e SONARR_INTEGRATION_URL=http://arrdash-sonarr-repro:8989 \
  -e SONARR_INTEGRATION_API_KEY="$SONARR_API_KEY" \
  arrdash-followup-800:97d5e80c \
  corepack pnpm --filter @arr/api exec vitest run \
  src/lib/trash-guides/__tests__/deployment-executor-sonarr.integration.test.ts
unset SONARR_API_KEY
docker rm -f arrdash-sonarr-repro
docker volume rm arrdash-sonarr-repro-config
docker network rm arrdash-sonarr-repro
```

The status endpoint reported Sonarr `4.0.19.2979`. The test creates one UUID-named Custom Format, captures its exact numeric ID, verifies POST and PUT, and deletes only when ID, random name, implementation, specification identity/flag, and both fields still match. On drift it refuses deletion and reports the synthetic ID/name without a secret.

## Changes

- Pass service context into exact-first readback verification and keep Radarr strict.
- Add the full positive/negative POST+PUT matrix.
- Add versioned intended writable-state evidence without changing Prisma fields.
- Give exact actual-state tokens priority during rollback recovery.
- Persist verified mutation counts before later exact-token/final-ledger checkpoints.
- Pin the live Sonarr image and strengthen exact-ID cleanup evidence.

## Local validation on the exact final head

| Command/check | Environment | Result |
| --- | --- | --- |
| Final focused executor/state/live-file suite (live gated) | Node 22 builder | 134 passed, 1 live skip |
| Root rerun after exact-token priority fix | Node 22 builder | 106 passed, 1 live skip |
| Pinned live integration | Sonarr 4.0.19.2979, exact digest above | 1/1 passed; zero test CFs left |
| Mounted PUT regression on base | Baseline builder | 1 failed as expected with strict verification conflict |
| `pnpm run test` | Exact builder image with exact contract directories read-only | 4 Turbo tasks passed; API 4,654 passed/52 skipped; web/shared passed |
| `pnpm run typecheck` and `pnpm run lint` | Exact builder image | 3/3 packages passed for each |
| `pnpm run test:pr-review-contract` | Exact files read-only | 53/53 passed |
| Docker builder/production build | `arrdash-followup-800:97d5e80c` | passed |
| `check:prisma-generated` | Disposable Linux Git index, Prisma 7.9.0 | up to date |
| Changed-file Biome and `git diff --check` | Repository configuration | passed |

`pnpm run format` is blocked by checkout-wide CRLF normalization in untouched files and fails identically on the unchanged base image. All 5 changed files pass repository Biome and the final diff has no whitespace error; no unrelated line-ending churn is included.

## Database and migration impact

No schema, migration, Prisma field, generated-client, or stored-secret change. The intended token remains an internal backup string; the exact actual token remains the strongest recovery evidence.

## Security and privacy

Only a disposable local Sonarr container and a UUID-named synthetic Custom Format were used. The API key was never printed. Cleanup removed the exact test ID and verified zero matching resources remained; all dedicated container/network/volume resources were removed.

## Cross-PR integration

#799 and #800 both touch `deployment-executor.ts` but in disjoint hunks. `git merge-tree` in both directions reports no conflict. #799 should merge first, then #800 should be updated and both focused suites rerun on the combined head; this is a process gate, not a current P0-P2 defect.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable
- [ ] `pnpm run format` ? exact checkout-wide CRLF blocker documented above; changed files pass Biome
- [x] `pnpm --filter @arr/shared build`, when shared changed ? shared unchanged; build passed in gauntlet
- [x] `pnpm run typecheck`
- [x] `pnpm run test`
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable ? pinned Sonarr 4.0.19.2979 passed
- [x] New queries use centralized query keys and polling constants, when applicable ? N/A
- [x] New sensitive displays preserve incognito behavior, when applicable ? N/A
- [x] New Prisma queries for user-owned resources include `userId`, when applicable ? N/A
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable ? N/A
- [x] User-facing counts are precise rather than proxies, when applicable ? verified writes counted at the exact checkpoint
- [x] Action links reach the correct page with required parameters, when applicable ? N/A
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable

## External CI blocker

For exact head `97d5e80c385a833c415810da7d5c2735b7d55521`, Semgrep `32946610565`, CI `32946610632`, CodeQL `32946610594`, and Docker Smoke Test `32946610693` all completed `action_required` with `jobs: []`. An upstream maintainer must choose **Approve and run workflows**. This PR does not claim GitHub CI is green.

## Review plan

- Initial broad-reviewed head: `487dbc868e6b5cacd4c98360054aeb1861921efe`
- Correction head: `97d5e80c385a833c415810da7d5c2735b7d55521`
- Targeted delta range: `487dbc868e6b5cacd4c98360054aeb1861921efe..97d5e80c385a833c415810da7d5c2735b7d55521`
- Material-scope change declared? Yes ? follow-up audit narrowed service scope and completed recovery/checkpoint evidence within the existing post-write verification domain.
- Independent regression reviewer: Internal Codex subagent Tesla ? final exact-delta PASS, no P0-P3. Not a GitHub review or maintainer approval.
- Independent data-safety reviewer, when required: Internal Codex subagent Arendt ? found the exact-token fallback defect; the fix delta then passed. Not a GitHub review or maintainer approval.
- GitHub Codex review head: pending external review availability
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| 800-A | P1 | Valid | Normalizer had no service context | Sonarr-only fallback; Radarr strict test | Focused matrix passes |
| 800-B | P1 | Valid safety boundary | Negative matrix incomplete | Full POST/PUT drift matrix added | All semantic drift rejects |
| 800-C1 | P2 | Valid | Intended token domain did not encode writable Sonarr semantics | Versioned service-bound intended token | Recovery tests pass |
| 800-C2 | P1 | Valid review finding | Intended fallback could override a mismatching exact token | Exact token is exclusive and fails immediately | Delta review PASS |
| 800-C3 | P2 | Valid | Verified PUT count could remain zero after later checkpoint failure | Count persisted immediately after verified GET | POST/PUT error tests pass |
| 800-E/F | P3 | Valid reproducibility/cleanup gap | `latest` was unpinned and cleanup proof incomplete | Exact tag+digest and fail-closed identity checks | Live test 1/1, zero leftovers |

## Final merge gate

- [ ] Exact-head CI is green ? externally blocked by `action_required`/zero jobs
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [ ] Maintainer approved merge
- [x] Post-merge verification is planned ? after #799 merges, update #800 and rerun both focused suites plus the pinned live test
