### PR TITLE
fix(docker): make Next image cache writable

### DIFF
--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -301,6 +301,8 @@ jobs:
           test -x docker/test-dump-heap.sh
           test -x docker/test-shutdown-grace.sh
           test -x docker/test-stop-timing.sh
+          test -x docker/test-web-cache-permissions.sh
+          docker/test-web-cache-permissions.sh arr-dashboard:smoke
           docker/test-combined-supervision.sh arr-dashboard:smoke
           docker/test-launcher-contract.sh arr-dashboard:smoke
           docker/test-combined-restart.sh arr-dashboard:smoke

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,9 +115,17 @@ COPY --from=builder --chown=abc:abc /app/deploy-api ./api
 RUN printf '{"compilerOptions":{"target":"ES2022","module":"ESNext","moduleResolution":"Bundler","esModuleInterop":true,"skipLibCheck":true}}\n' > /app/api/tsconfig.json
 
 # Copy Web (single layer: standalone + static + public + custom server)
-COPY --from=builder --chown=abc:abc /app/apps/web/.next/standalone ./web
-COPY --from=builder --chown=abc:abc /app/apps/web/.next/static ./web/apps/web/.next/static
-COPY --from=builder --chown=abc:abc /app/apps/web/public ./web/apps/web/public
+COPY --from=builder --chown=root:root /app/apps/web/.next/standalone ./web
+COPY --from=builder --chown=root:root /app/apps/web/.next/static ./web/apps/web/.next/static
+COPY --from=builder --chown=root:root /app/apps/web/public ./web/apps/web/public
+
+# The standalone web application is immutable at runtime. Next's optimized
+# image cache is the sole writable exception: it is disposable, contains no
+# secrets, and must support image-default, remapped PUID/PGID, and arbitrary
+# rootless users without a recursive startup chown.
+RUN chown root:root /app/web \
+    && mkdir -p /app/web/apps/web/.next/cache \
+    && chmod 1777 /app/web/apps/web/.next/cache
 
 # Copy startup scripts and fix line endings (single layer)
 COPY --chown=abc:abc docker/start-combined.sh ./

--- a/docker/start-combined.sh
+++ b/docker/start-combined.sh
@@ -118,6 +118,23 @@ run_as_user() {
     fi
 }
 
+# Next writes optimized image artifacts at runtime. The image creates only
+# this disposable cache with a cross-UID writable mode; verify it as the actual
+# runtime user before either service can accept traffic.
+NEXT_IMAGE_CACHE=/app/web/apps/web/.next/cache
+NEXT_IMAGE_CACHE_PROBE="$NEXT_IMAGE_CACHE/.startup-check-$$"
+if [ ! -d "$NEXT_IMAGE_CACHE" ] || ! run_as_user sh -c '
+    probe=$1
+    printf first > "$probe" &&
+    printf second >> "$probe" &&
+    rm -f "$probe"
+' sh "$NEXT_IMAGE_CACHE_PROBE"; then
+    run_as_user rm -f "$NEXT_IMAGE_CACHE_PROBE" 2>/dev/null || true
+    echo "ERROR: Next image cache is not writable: $NEXT_IMAGE_CACHE (UID:$PUID GID:$PGID)" >&2
+    exit 1
+fi
+echo "Next image cache ready: $NEXT_IMAGE_CACHE (UID:$PUID GID:$PGID)"
+
 # ============================================
 # Process supervision helpers
 # ============================================

--- a/docker/test-web-cache-permissions.sh
+++ b/docker/test-web-cache-permissions.sh
@@ -1,0 +1,328 @@
+#!/bin/sh
+# Next.js runtime image-cache permission regression.
+#
+# Exercises the real combined image and the real Next image optimizer across
+# image-default, LinuxServer-remapped, and arbitrary rootless users. Only the
+# disposable `.next/cache` boundary may be writable by the web process.
+#
+# Usage: docker/test-web-cache-permissions.sh [image]
+
+set -eu
+
+IMAGE="${1:-arr-dashboard:smoke}"
+WORK=$(mktemp -d /tmp/test-web-cache-permissions.XXXXXX)
+HOST_UID=$(id -u)
+HOST_GID=$(id -g)
+PASS=0
+FAIL=0
+CURRENT_CTR=""
+
+cleanup() {
+    if [ -n "$CURRENT_CTR" ]; then
+        docker rm -f "$CURRENT_CTR" >/dev/null 2>&1 || true
+    fi
+    for config_name in remapped-1000-config default-911-config remapped-12345-config rootless-1000-config rootless-12345-config read-only-config; do
+        config_dir="$WORK/$config_name"
+        if [ -d "$config_dir" ]; then
+            docker run --rm --entrypoint sh \
+                -v "$config_dir:/cleanup" "$IMAGE" \
+                -c "chown -R $HOST_UID:$HOST_GID /cleanup" >/dev/null 2>&1 || true
+        fi
+    done
+    rm -rf -- "${WORK:?}" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+ok() {
+    echo "  PASS: $*"
+    PASS=$((PASS + 1))
+}
+
+bad() {
+    echo "  FAIL: $*" >&2
+    FAIL=$((FAIL + 1))
+}
+
+wait_health() {
+    ctr=$1
+    api_port=$2
+    web_port=$3
+    elapsed=0
+    while [ "$elapsed" -lt 120 ]; do
+        api_health=$(curl -fsS "http://127.0.0.1:$api_port/health" 2>/dev/null || true)
+        web_health=$(curl -fsS "http://127.0.0.1:$web_port/health" 2>/dev/null || true)
+        if [ -n "$api_health" ] && [ -n "$web_health" ]; then
+            return 0
+        fi
+        state=$(docker inspect -f '{{.State.Status}}' "$ctr" 2>/dev/null || true)
+        if [ "$state" != running ]; then
+            return 1
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+process_id() {
+    ctr=$1
+    pid=$2
+    field=$3
+    docker exec "$ctr" sh -c "awk '/^$field:/ {print \$2}' /proc/$pid/status"
+}
+
+prepare_config() {
+    config_dir=$1
+    uid=$2
+    gid=$3
+    mkdir -p "$config_dir"
+    docker run --rm --entrypoint sh \
+        -v "$config_dir:/config" "$IMAGE" \
+        -c "chown -R $uid:$gid /config && chmod 700 /config" >/dev/null
+}
+
+assert_optimizer_request() {
+    ctr=$1
+    web_port=$2
+    case_name=$3
+    headers="$WORK/$case_name.headers"
+    body="$WORK/$case_name.body"
+
+    status=$(curl -sS -D "$headers" -o "$body" -w '%{http_code}' \
+        "http://127.0.0.1:$web_port/_next/image?url=%2Ficon.png&w=64&q=75")
+    if [ "$status" = 200 ]; then
+        ok "$case_name optimizer returned HTTP 200"
+    else
+        bad "$case_name optimizer returned HTTP $status"
+    fi
+
+    content_type=$(sed -n 's/^[Cc]ontent-[Tt]ype:[[:space:]]*\([^[:space:]]*\).*/\1/p' "$headers" | tr -d '\r' | tail -1)
+    case "$content_type" in
+        image/*) ok "$case_name optimizer returned $content_type" ;;
+        *) bad "$case_name optimizer content type is '$content_type'" ;;
+    esac
+
+    if [ -s "$body" ]; then
+        ok "$case_name optimizer returned a non-empty image body"
+    else
+        bad "$case_name optimizer returned an empty body"
+    fi
+
+    if docker exec "$ctr" sh -c "find /app/web/apps/web/.next/cache -mindepth 1 -print -quit 2>/dev/null | grep -q ."; then
+        ok "$case_name optimizer created a cache artifact"
+    else
+        bad "$case_name optimizer created no cache artifact"
+    fi
+}
+
+assert_cache_logs_clean() {
+    ctr=$1
+    case_name=$2
+    logs=$(docker logs "$ctr" 2>&1 || true)
+    if echo "$logs" | grep -Eqi "EACCES.*\.next/cache|Failed to write image to cache|image optimizer.*(error|fail)"; then
+        bad "$case_name logs contain a Next image-cache failure"
+        echo "$logs" | grep -Ei "EACCES|\.next/cache|Failed to write image|image optimizer" >&2 || true
+    else
+        ok "$case_name logs contain no Next image-cache failure"
+    fi
+}
+
+assert_runtime_boundaries() {
+    ctr=$1
+    ids=$2
+    mode=$3
+
+    cache_stat=$(docker exec "$ctr" stat -c '%u:%g %a' /app/web/apps/web/.next/cache 2>/dev/null || true)
+    if [ "$cache_stat" = "0:0 1777" ]; then
+        ok "$mode cache is the only sticky world-writable runtime boundary"
+    else
+        bad "$mode cache ownership/mode is '$cache_stat' (expected '0:0 1777')"
+    fi
+
+    for path in /app/web /app/web/apps/web /app/web/apps/web/.next /app/web/apps/web/.next/server; do
+        path_stat=$(docker exec "$ctr" stat -c '%u:%g %a' "$path" 2>/dev/null || true)
+        case "$path_stat" in
+            "0:0 "*) ok "$mode keeps $path root-owned ($path_stat)" ;;
+            *) bad "$mode does not keep $path root-owned ($path_stat)" ;;
+        esac
+    done
+
+    if docker exec -u "$ids" "$ctr" sh -c '
+        probe=/app/web/apps/web/.next/cache/.permission-probe
+        probe_dir=/app/web/apps/web/.next/cache/.permission-probe-dir
+        mkdir "$probe_dir" &&
+        printf first > "$probe" &&
+        printf second >> "$probe" &&
+        rm -f "$probe" &&
+        rmdir "$probe_dir"
+    '; then
+        ok "$mode runtime user can create, update, and remove cache entries"
+    else
+        bad "$mode runtime user cannot update the exact cache boundary"
+    fi
+
+    for target in /app/web/server.js /app/web/apps/web/server.js; do
+        if docker exec -u "$ids" "$ctr" touch "$target" 2>/dev/null; then
+            bad "$mode runtime user can modify $target"
+        else
+            ok "$mode runtime user cannot modify $target"
+        fi
+    done
+
+    immutable_probe=/app/web/apps/web/.next/server/.permission-probe
+    if docker exec -u "$ids" "$ctr" touch "$immutable_probe" 2>/dev/null; then
+        bad "$mode runtime user can create content under .next/server"
+        docker exec "$ctr" rm -f "$immutable_probe" >/dev/null 2>&1 || true
+    else
+        ok "$mode runtime user cannot create content under .next/server"
+    fi
+}
+
+run_case() {
+    mode=$1
+    uid=$2
+    gid=$3
+    rootless=$4
+    config_dir="$WORK/$mode-config"
+    prepare_config "$config_dir" "$uid" "$gid"
+
+    CURRENT_CTR="test-web-cache-${mode}-$$"
+    echo ""
+    echo "========== $mode ($uid:$gid) =========="
+
+    if [ "$rootless" = true ]; then
+        docker run -d --name "$CURRENT_CTR" \
+            --user "$uid:$gid" \
+            -p 127.0.0.1::3000 -p 127.0.0.1::3001 \
+            -v "$config_dir:/config" \
+            "$IMAGE" >/dev/null
+    else
+        docker run -d --name "$CURRENT_CTR" \
+            -e PUID="$uid" -e PGID="$gid" \
+            -p 127.0.0.1::3000 -p 127.0.0.1::3001 \
+            -v "$config_dir:/config" \
+            "$IMAGE" >/dev/null
+    fi
+
+    web_port=$(docker port "$CURRENT_CTR" 3000/tcp | sed -n '1s/.*://p')
+    api_port=$(docker port "$CURRENT_CTR" 3001/tcp | sed -n '1s/.*://p')
+    if wait_health "$CURRENT_CTR" "$api_port" "$web_port"; then
+        ok "$mode API and web are healthy"
+    else
+        bad "$mode services did not become healthy"
+        docker logs "$CURRENT_CTR" 2>&1 | tail -60 >&2 || true
+        docker rm -f "$CURRENT_CTR" >/dev/null 2>&1 || true
+        CURRENT_CTR=""
+        return
+    fi
+
+    web_pid=$(docker logs "$CURRENT_CTR" 2>&1 | sed -n 's/.*Web started with PID \([0-9][0-9]*\).*/\1/p' | tail -1)
+    actual_uid=$(process_id "$CURRENT_CTR" "$web_pid" Uid)
+    actual_gid=$(process_id "$CURRENT_CTR" "$web_pid" Gid)
+    if [ "$actual_uid:$actual_gid" = "$uid:$gid" ]; then
+        ok "$mode web process runs as $uid:$gid"
+    else
+        bad "$mode web process runs as $actual_uid:$actual_gid (expected $uid:$gid)"
+    fi
+
+    if docker logs "$CURRENT_CTR" 2>&1 | grep -q "Next image cache ready: /app/web/apps/web/.next/cache (UID:$uid GID:$gid)"; then
+        ok "$mode startup verified the cache as the runtime user"
+    else
+        bad "$mode startup did not log successful runtime-user cache verification"
+    fi
+
+    assert_optimizer_request "$CURRENT_CTR" "$web_port" "$mode"
+    assert_runtime_boundaries "$CURRENT_CTR" "$uid:$gid" "$mode"
+    assert_cache_logs_clean "$CURRENT_CTR" "$mode"
+
+    if docker restart --time 15 "$CURRENT_CTR" >/dev/null; then
+        web_port=$(docker port "$CURRENT_CTR" 3000/tcp | sed -n '1s/.*://p')
+        api_port=$(docker port "$CURRENT_CTR" 3001/tcp | sed -n '1s/.*://p')
+    fi
+    if [ -n "${web_port:-}" ] && [ -n "${api_port:-}" ] && wait_health "$CURRENT_CTR" "$api_port" "$web_port"; then
+        ok "$mode container restart is healthy"
+        assert_optimizer_request "$CURRENT_CTR" "$web_port" "$mode-restart"
+        assert_cache_logs_clean "$CURRENT_CTR" "$mode-restart"
+    else
+        bad "$mode container restart did not recover"
+        docker logs "$CURRENT_CTR" 2>&1 | tail -60 >&2 || true
+    fi
+
+    if docker stop --time 15 "$CURRENT_CTR" >/dev/null; then
+        exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$CURRENT_CTR")
+        if [ "$exit_code" = 0 ]; then
+            ok "$mode container stopped gracefully"
+        else
+            bad "$mode container stopped with exit code $exit_code"
+        fi
+    else
+        bad "$mode container did not stop gracefully"
+    fi
+
+    docker rm -f "$CURRENT_CTR" >/dev/null 2>&1 || true
+    CURRENT_CTR=""
+}
+
+assert_unwritable_cache_fails_fast() {
+    config_dir="$WORK/read-only-config"
+    prepare_config "$config_dir" 1000 1000
+    CURRENT_CTR="test-web-cache-read-only-$$"
+
+    echo ""
+    echo "========== fail-fast read-only cache =========="
+    docker run -d --name "$CURRENT_CTR" \
+        --read-only --user 1000:1000 \
+        -v "$config_dir:/config" \
+        "$IMAGE" >/dev/null
+
+    elapsed=0
+    state=running
+    while [ "$elapsed" -lt 30 ]; do
+        state=$(docker inspect -f '{{.State.Status}}' "$CURRENT_CTR" 2>/dev/null || true)
+        [ "$state" = running ] || break
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    if [ "$state" = exited ]; then
+        exit_code=$(docker inspect -f '{{.State.ExitCode}}' "$CURRENT_CTR")
+        if [ "$exit_code" != 0 ]; then
+            ok "unwritable rootless cache stops startup with a non-zero exit"
+        else
+            bad "unwritable rootless cache stopped with exit code 0"
+        fi
+    else
+        bad "unwritable rootless cache did not fail before serving traffic"
+    fi
+
+    logs=$(docker logs "$CURRENT_CTR" 2>&1 || true)
+    if echo "$logs" | grep -q "ERROR: Next image cache is not writable: /app/web/apps/web/.next/cache (UID:1000 GID:1000)"; then
+        ok "unwritable rootless cache reports path and runtime UID/GID"
+    else
+        bad "unwritable rootless cache lacks an actionable startup error"
+        echo "$logs" | tail -40 >&2
+    fi
+
+    docker rm -f "$CURRENT_CTR" >/dev/null 2>&1 || true
+    CURRENT_CTR=""
+}
+
+echo "########## NEXT IMAGE CACHE PERMISSIONS (image: $IMAGE) ##########"
+
+# Lead with the exact current-main regression so RED cannot be masked by the
+# image-default user owning the build-time tree.
+run_case remapped-1000 1000 1000 false
+run_case default-911 911 911 false
+run_case remapped-12345 12345 12345 false
+run_case rootless-1000 1000 1000 true
+run_case rootless-12345 12345 12345 true
+assert_unwritable_cache_fails_fast
+
+echo ""
+echo "=========================================="
+echo "Next image cache results: PASS=$PASS FAIL=$FAIL"
+echo "=========================================="
+
+if [ "$FAIL" -gt 0 ]; then
+    exit 1
+fi


### PR DESCRIPTION
## Summary

The standalone web runtime was copied into the image with numeric ownership `911:911`. When `PUID` and `PGID` remapped the runtime account, Next could not create `/app/web/apps/web/.next/cache`, which caused image optimizer requests to fail with `EACCES`.

The web runtime is now immutable `root:root`. Only the disposable `.next/cache` directory is writable, with owner `root:root` and mode `1777`. Startup verifies that the actual runtime UID and GID can create, update, and remove a cache object before the API or web service accepts traffic.

## Related issue

Related to #779

## Scope

- Dockerfile web ownership and cache boundary
- Startup runtime-user cache probe
- Focused Docker permission regression
- Docker smoke invocation

## Non-goals

- No library-sync change
- No integration fixture or test change
- No CSP change
- No application feature change
- No release work

## Acceptance criteria

- [x] Default `911:911`, remapped `1000:1000`, remapped `12345:12345`, rootless `1000:1000`, and rootless `12345:12345` pass
- [x] A real `/_next/image` request returns HTTP 200 with an image response
- [x] `.next/cache` is writable by the actual runtime UID and GID
- [x] Unrelated runtime paths remain immutable
- [x] Startup performs no recursive `chown` over `/app`, `/app/web`, or the standalone runtime
- [x] Runtime logs contain no EACCES or image-cache write failure
- [x] Image optimizer requests produce no HTTP 500
- [x] Restart and graceful-stop contracts pass
- [x] Readiness-gated navigation passes 10/10 with retries disabled
- [x] A separate cold integration cycle passes 104/104 with retries disabled
- [x] No result depends on a Playwright retry

## Changes

- Copy the standalone web runtime, static output, and public assets as `root:root`.
- Create `/app/web/apps/web/.next/cache` as the sole `root:root 1777` runtime write boundary.
- Probe cache create, append, and remove access as the configured runtime identity before service launch.
- Add a five-mode Docker regression that exercises the real Next image optimizer, restart, stop, log, and immutability contracts.
- Run the focused regression in the Docker smoke workflow after an executable preflight.

## L4 `/library` disposition

The original permanent loading failure did not reproduce under controlled comparison. The untouched baseline passed 3/3 targeted cycles. The candidate passed 3/3 targeted cycles and three complete cold suites, totaling 312/312 tests, with the same pinned external-service image digests.

The first run of the later 9/10 navigation sample began before the initial library cache existed. Its first `/api/library` request started normal synchronization. Lidarr then published Radiohead, and repetitions 2 through 10 passed. Final validation separated explicit library readiness from repeated navigation reliability, while a separate untouched cold suite retained first-start synchronization coverage. No candidate regression or separate product correction was established.

## Risk classification

- [ ] Trivial
- [x] Standard
- [ ] Safety-critical

## Validation

- [x] `sh -n docker/start-combined.sh`
- [x] `sh -n docker/test-web-cache-permissions.sh`
- [x] `docker/test-web-cache-permissions.sh arr-dashboard:779-publish`: 122/122
- [x] `docker/test-combined-supervision.sh arr-dashboard:779-publish`: 34/34
- [x] `docker/test-launcher-contract.sh arr-dashboard:779-publish`: 15/15
- [x] `docker/test-combined-restart.sh arr-dashboard:779-publish`: 14/14
- [x] `docker/test-dump-heap.sh arr-dashboard:779-publish`: 21/21
- [x] `docker/test-shutdown-grace.sh arr-dashboard:779-publish`: 15/15
- [x] `docker/test-stop-timing.sh arr-dashboard:779-publish --quick`: 12/12
- [x] Supported library sync API readiness: 1.175 seconds, 3 persisted rows, no sync errors
- [x] `CI=true pnpm exec playwright test e2e/integration/specs/16-navigation.spec.ts --config=e2e/integration/playwright.integration.config.ts --project=integration --grep 'should navigate to every sidebar page without errors' --repeat-each=10 --retries=0 --workers=1 --no-deps`: 10/10
- [x] `CI=true pnpm run e2e:integration -- --retries=0 --workers=1`: 104/104 in 186.28 seconds
- [x] Integration log scans: 0 EACCES, 0 cache-write failures, 0 optimizer failures, 0 unexpected HTTP 500, 0 web crashes or restarts
- [x] `pnpm run check:prisma-generated`
- [x] `node --test scripts/check-prisma-generated.test.mjs`: 17/17
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`
- [x] `pnpm run test`: shared 89/89, web 669/669, API 4,616 passed with 51 intentional skips
- [x] `pnpm run lint`
- [x] `CI=true pnpm run validate:pr`, including PR contract tests 53/53
- [x] `pnpm run build`
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7/7
- [x] `git diff --check`
- [x] User-visible behavior was verified with populated disposable fixtures
- [x] Query-key, incognito, Prisma ownership, optional-service, count, action-link, and duplicate-surface checks are not applicable because this PR changes no application source or query behavior

## Review plan

- Initial broad-reviewed head: `98edacb8749cccd6871c56e4cd6b7eb9cd582497`, byte-identical to tracked patch `cc24703ea740383aae9d9255802ac378f8e65f0186b5e1feeca7208015c7590f` plus script `fb9f2d7c3302c9faa521df585ed39cb90684e50647d839ad96b59e432e500ba8`
- Correction head: N/A, no findings required a correction
- Targeted delta range: N/A, the reviewed candidate did not change
- Material-scope change declared? No
- Independent regression reviewer: Not run; delegation was not authorized for this session. The local Standard-risk broad review found no findings.
- Independent data-safety reviewer, when required: N/A, this change is not safety-critical
- GitHub Codex review head: `98edacb8749cccd6871c56e4cd6b7eb9cd582497` — no findings / `+1`
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| None | N/A | N/A | The completed Standard-risk review found no candidate findings | No correction required | N/A |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned

