### PR TITLE
fix(plex): recognize Personal Media agent alias

### DIFF
--- a/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts
@@ -7,6 +7,7 @@ import {
 	canPublishPositivePlexObservation,
 	collectPlexCacheLiveEvidence,
 	collectSettledPlexCacheLiveEvidence,
+	isPersonalMediaSection,
 } from "../plex-cache-refresher.js";
 import type { PlexClient } from "../plex-client.js";
 
@@ -1096,6 +1097,147 @@ describe("collectPlexCacheLiveEvidence", () => {
 			{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
 			{ key: "2", title: "Other Videos", type: "movie", agent: "com.plexapp.agents.none" },
 		];
+
+		it.each([
+			["com.plexapp.agents.none", true],
+			["tv.plex.agents.none", true],
+			["tv.plex.agents.movie", false],
+			["tv.plex.agents.series", false],
+			["example.plex.agents.none", false],
+			["tv.plex.agents.none.custom", false],
+			["tv.plex.agent.none", false],
+			["agents.none", false],
+			[undefined, false],
+		] as const)("classifies only the exact Personal Media agent %s", (agent, expected) => {
+			expect(isPersonalMediaSection({ type: "movie", agent })).toBe(expected);
+		});
+
+		it("excludes a Show-type section using the modern Personal Media agent", async () => {
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue([
+					{ key: "1", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+					{ key: "2", title: "Personal", type: "show", agent: "tv.plex.agents.none" },
+				]),
+				getLibraryItems: vi
+					.fn()
+					.mockImplementation((key: string) =>
+						key === "1"
+							? [supportedMovie]
+							: [{ ratingKey: "", title: "Personal", type: "show", Guid: [] }],
+					),
+				getHistory: vi.fn().mockResolvedValue([]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+			expect(result).toMatchObject({ kind: "authoritative-snapshot", complete: true });
+			expect(result.snapshot?.rows.map((row) => row.ratingKey)).toEqual(["movie-1"]);
+			expect(result.inventoryTargets).toEqual([
+				{ sectionId: "1", mediaType: "movie", tmdbId: 42, ratingKey: "movie-1" },
+			]);
+		});
+
+		it("publishes only fully mapped Movie/Show evidence for the reporter topology", async () => {
+			const sections = [
+				{ key: "movies", title: "Movies", type: "movie", agent: "tv.plex.agents.movie" },
+				{ key: "shows", title: "Shows", type: "show", agent: "tv.plex.agents.series" },
+				{ key: "personal", title: "Other", type: "movie", agent: "tv.plex.agents.none" },
+				{ key: "music", title: "Music", type: "artist", agent: "tv.plex.agents.music" },
+			];
+			const mockClient = {
+				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "Alice" }]),
+				getLibrarySections: vi.fn().mockResolvedValue(sections),
+				getLibraryItems: vi.fn().mockImplementation((key: string) => {
+					if (key === "movies") {
+						return [
+							{
+								ratingKey: "movie-1",
+								title: "Movie",
+								type: "movie",
+								Guid: [{ id: "tmdb://10" }],
+							},
+						];
+					}
+					if (key === "shows") {
+						return [
+							{
+								ratingKey: "show-1",
+								title: "Show",
+								type: "show",
+								Guid: [{ id: "tmdb://20" }, { id: "tvdb://30" }],
+							},
+						];
+					}
+					if (key === "personal") {
+						return [
+							{ ratingKey: "personal-1", title: "Personal", type: "movie", Guid: [] },
+							{ ratingKey: "", title: "Keyless Personal", type: "movie", Guid: [] },
+						];
+					}
+					throw new Error("Unsupported section type entered Movie/Show collection");
+				}),
+				getHistory: vi.fn().mockResolvedValue([
+					{
+						historyKey: "history-personal-movie",
+						type: "movie",
+						ratingKey: "",
+						librarySectionID: "personal",
+						accountID: 1,
+						viewedAt: 1_700_000_000,
+					},
+					{
+						historyKey: "history-personal-episode",
+						type: "episode",
+						ratingKey: "personal-episode",
+						librarySectionID: "personal",
+						accountID: 1,
+						viewedAt: 1_700_000_001,
+					},
+					{
+						historyKey: "history-stale-supported",
+						type: "movie",
+						ratingKey: "stale-supported",
+						librarySectionID: "movies",
+						accountID: 1,
+						viewedAt: 1_700_000_002,
+					},
+				]),
+				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
+				getOnDeck: vi.fn().mockResolvedValue([]),
+			} as unknown as PlexClient;
+			const prisma = { $transaction: vi.fn() } as unknown as PrismaClient;
+
+			const result = await refreshPlexCache(mockClient, prisma, "inst-1", silentLog);
+
+			expect(result).toMatchObject({
+				kind: "authoritative-snapshot",
+				complete: true,
+				errors: 0,
+				errorMessages: [],
+			});
+			expect(result.snapshot?.sections).toEqual([
+				{ key: "movies", title: "Movies", type: "movie" },
+				{ key: "shows", title: "Shows", type: "show" },
+			]);
+			expect(result.snapshot?.rows.map((row) => row.ratingKey).sort()).toEqual([
+				"movie-1",
+				"show-1",
+			]);
+			expect(result.inventoryTargets).toEqual([
+				{ sectionId: "movies", mediaType: "movie", tmdbId: 10, ratingKey: "movie-1" },
+				{
+					sectionId: "shows",
+					mediaType: "series",
+					tmdbId: 20,
+					tvdbId: 30,
+					ratingKey: "show-1",
+				},
+			]);
+		});
 
 		it("excludes a Personal Media section from the supported-media authority domain", async () => {
 			const mockClient = {

--- a/apps/api/src/lib/plex/plex-cache-refresher.ts
+++ b/apps/api/src/lib/plex/plex-cache-refresher.ts
@@ -119,7 +119,7 @@ function parsePlexTvdbId(guids: Array<{ id: string }> | undefined): number | nul
  * source, not a section-level primary agent, and is not equivalent to a
  * Personal Media library.
  */
-const PERSONAL_MEDIA_AGENTS = new Set(["com.plexapp.agents.none"]);
+const PERSONAL_MEDIA_AGENTS = new Set(["com.plexapp.agents.none", "tv.plex.agents.none"]);
 
 export function isPersonalMediaSection(section: { type: string; agent?: string }): boolean {
 	return section.agent !== undefined && PERSONAL_MEDIA_AGENTS.has(section.agent);


### PR DESCRIPTION
## Summary

Real PMS confirmed `tv.plex.agents.none` as a Personal Media primary-agent identifier. This change recognizes that exact value alongside `com.plexapp.agents.none` so Personal Media sections stay outside Movie/Show authority.

## Related issue

Related to #783
Related to #793

## Root cause

The closed Personal Media allowlist contained only `com.plexapp.agents.none`. A genuine Personal Media section reporting `tv.plex.agents.none` therefore remained inside supported Movie/Show authority.

## Scope

- Add the confirmed `tv.plex.agents.none` value to the existing exact Personal Media allowlist.
- Add focused regression coverage for exact aliases, similar and unknown values, history attribution, the reporter's section topology, V3/V4 publication, and target-ledger exclusion.
- Change only the Plex cache refresher and its nearest focused test file.

## Non-goals

- No wildcard, prefix, suffix, substring, regex, trimming, case normalization, title, or scanner fallback.
- No change to V4 semantics, Plex mutation authority, schema, dependencies, frontend, Tautulli, connection testing, release files, or the `next` branch.
- No issue closure or v2.24.2 release preparation.

## Acceptance criteria

- [x] Both confirmed Personal Media identifiers are excluded through exact matching.
- [x] Unknown, missing, malformed, and similar Movie/Show agents remain fail closed.
- [x] Standard Movie and Show agents remain supported; Music remains outside authority because of section type.
- [x] Personal Media current items and explicitly attributed missing-key history do not enter authoritative rows or `PlexGenerationTarget`.
- [x] Supported-section missing-key history remains non-authoritative and cannot establish absence.
- [x] Complete supported evidence publishes V3; genuine incompleteness retains positive-only V4 behavior.
- [x] V4 and excluded Personal Media evidence cannot authorize Plex mutation.

## Changes

- Extend `PERSONAL_MEDIA_AGENTS` with the exact value `tv.plex.agents.none`.
- Cover both accepted aliases and reject similar-looking or unknown agents.
- Add a deterministic reporter-shaped topology with supported Movie/Show sections, Personal Media, Music, missing-key history, and valid-key stale history.

## Fix

The allowlist contains exactly:

```text
com.plexapp.agents.none
tv.plex.agents.none
```

The predicate remains an exact, case-sensitive `Set.has()` lookup.

## Safety

- Unknown, missing, malformed, and merely similar agents remain inside the authority domain.
- `tv.plex.agents.movie` and `tv.plex.agents.series` remain supported.
- Music remains outside Movie/Show authority because its section type is unsupported.
- Personal Media sections are removed before current inventory, history completeness, settlement metadata, cache rows, and target-ledger construction.
- Personal Media missing-key history is ignored only when `librarySectionID` explicitly names a recognized Personal Media section.
- Supported or unattributed missing-key history remains non-authoritative.
- V4 remains positive-only and cannot prove zero, absence, negative membership, or exact denominators.
- V4 and excluded Personal Media evidence cannot authorize Plex mutation.

## Real PMS

A disposable `plexinc/pms-docker:1.43.3.10896-cb3ebc72d` fixture returned a genuine movie-type Personal Media section with agent `tv.plex.agents.none` and scanner `Plex Movie`. Direct `/library/sections` output and current-main `PlexClient.getLibrarySections()` agreed on the section key, type, and exact agent. The value remained stable after a scan, same-agent metadata configuration, and PMS restart.

## RED / GREEN

- RED before the correction: 3 failed, 21 passed, 41 skipped.
- GREEN after the correction: 24 passed, 41 skipped, 0 failed.
- Parent focused Plex safety matrix: 19 files, 692 tests passed.

## Independent reviews

### Data-safety review

- Context: `tx_a1_68615462b0a58a7763ff2b0b_repo_reviewer`
- Reviewed head: `d472b30de3e9bfa7fd8e1219d949017f9071cfb0`
- Tests: 3 files and 133 tests passed; a single-file confirmation also passed 65 tests.
- Findings: none at P0 through P3.
- Verified exact matching, fail-closed unknown and missing agents, explicit `librarySectionID` history attribution, stale-history proof, authoritative-row exclusion, target-ledger exclusion, and execution-time mutation authority.
- Verdict: PASS, independent data-safety review satisfied.

### V3/V4 regression review

- Context: `tx_a2_68615462b0a58a7763ff2b0b_repo_reviewer`
- Reviewed head: `d472b30de3e9bfa7fd8e1219d949017f9071cfb0`
- Tests: 6 files and 269 tests passed; a second 5-file matrix passed 91 tests.
- Findings: none at P0 through P3.
- Verified V3 completeness, identical alias behavior, standard-agent and Music handling, bounded V4 evidence, exact ledger authority, positive episode lower bounds, non-summed independent sources, and preserved #693, #792, #795, and #796 contracts.
- Verdict: PASS, independent regression/V3-V4 review satisfied.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed: parent focused matrix, 19 files and 692 tests.
- [x] Focused tests passed, including both independent review matrices.
- [x] `pnpm run check:prisma-generated`
- [x] `node --test scripts/check-prisma-generated.test.mjs`: 17 passed.
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`: 3 package tasks passed.
- [x] `pnpm run test`: API 4,627 passed and 51 skipped; web 669 passed; shared 89 passed.
- [x] `pnpm run lint`: 3 package tasks passed.
- [x] `CI=true pnpm run validate:pr`, including 53 PR review-contract tests.
- [x] `pnpm run build`: API, shared, and web passed.
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7 passed.
- [x] `git diff --check 63776100645449f2f088758ac8963b8309b38fce..HEAD`
- [x] User-visible behavior was live-verified with a disposable real PMS fixture.
- [x] Query-key, incognito, user-owned Prisma, optional-service, action-link, and duplicate-UI checks are not applicable because this PR changes no API route or frontend surface.

## Changed files

- `apps/api/src/lib/plex/plex-cache-refresher.ts`
- `apps/api/src/lib/plex/__tests__/plex-cache-refresher.test.ts`

## Review plan

- Initial broad-reviewed head: `d472b30de3e9bfa7fd8e1219d949017f9071cfb0`
- Correction head: N/A
- Targeted delta range: N/A
- Material-scope change declared? No
- Independent regression reviewer: `tx_a2_68615462b0a58a7763ff2b0b_repo_reviewer`, PASS
- Independent data-safety reviewer, when required: `tx_a1_68615462b0a58a7763ff2b0b_repo_reviewer`, PASS
- GitHub Codex review head: `d472b30de3e9bfa7fd8e1219d949017f9071cfb0`, no-findings `+1` reaction
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| N/A | N/A | N/A | Both independent reviews found no actionable findings | No correction required | N/A |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned; none were reported
- [x] Current head is covered by the independent broad reviews
- [x] Base is unchanged
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
