### PR TITLE
fix(tautulli): enforce current cache authority

### DIFF
--- a/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/mutation-policy-snapshot.test.ts
@@ -349,7 +349,6 @@ describe("authoritative mutation policy snapshots", () => {
 
 	it.each([
 		["Plex", "plex_watch_count", "PLEX", refreshMocks.plex, { complete: false }, "plex"],
-		["Tautulli", "tautulli_watch_count", "TAUTULLI", refreshMocks.tautulli, {}, "tautulli"],
 		[
 			"Jellyfin",
 			"jellyfin_watch_count",
@@ -375,6 +374,17 @@ describe("authoritative mutation policy snapshots", () => {
 			expect(refreshMock).toHaveBeenCalledOnce();
 		},
 	);
+
+	it("quarantines Tautulli mutation evidence without refreshing or reading cache rows", async () => {
+		const { deps } = makeDeps([rule("tautulli_watch_count")], [instance("TAUTULLI")]);
+
+		const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
+
+		expect(snapshot.failedSources).toEqual(new Set(["tautulli"]));
+		expect(snapshot.ctx.tautulliMap).toBeUndefined();
+		expect(refreshMocks.tautulli).not.toHaveBeenCalled();
+		expect(deps.prisma.tautulliCache.findMany).not.toHaveBeenCalled();
+	});
 
 	it("records an incomplete cleanup-triggered Jellyfin refresh without advancing freshness", async () => {
 		refreshMocks.jellyfin.mockResolvedValue({
@@ -423,7 +433,6 @@ describe("authoritative mutation policy snapshots", () => {
 
 	it.each([
 		["Plex", "plex_watch_count", "PLEX", refreshMocks.plex],
-		["Tautulli", "tautulli_watch_count", "TAUTULLI", refreshMocks.tautulli],
 		["Jellyfin", "jellyfin_watch_count", "JELLYFIN", refreshMocks.jellyfin],
 	] as const)(
 		"coordinates cleanup-owned %s publication with the active run lease",
@@ -437,6 +446,20 @@ describe("authoritative mutation policy snapshots", () => {
 			);
 		},
 	);
+
+	it("does not grant the cleanup run lease to a Tautulli publication", async () => {
+		const { deps } = makeDeps([rule("tautulli_watch_count")], [instance("TAUTULLI")]);
+
+		const snapshot = await createMutationPolicySnapshotGetter(
+			deps,
+			"user-1",
+			undefined,
+			"cleanup-run",
+		)();
+
+		expect(snapshot.failedSources).toEqual(new Set(["tautulli"]));
+		expect(refreshMocks.tautulli).not.toHaveBeenCalled();
+	});
 
 	it("rejects inventory identities that do not belong to the published Plex generation", async () => {
 		refreshMocks.plex.mockResolvedValue({
@@ -980,6 +1003,61 @@ describe("authoritative mutation policy snapshots", () => {
 		).resolves.toMatchObject({ rawItem });
 		expect(getById).toHaveBeenCalledOnce();
 	});
+
+	it.each(["approval", "direct", "retry"] as const)(
+		"blocks %s execution when the durable selection depends on quarantined Tautulli evidence",
+		async (_mode) => {
+			const tautulliRule = {
+				...rule("tautulli_watch_count"),
+				targetScope: "series",
+			};
+			const { deps } = makeDeps([tautulliRule], [instance("TAUTULLI")]);
+			const rawItem = {
+				id: 101,
+				tmdbId: 84,
+				title: "Tautulli-dependent candidate",
+				path: "/media/candidate",
+				monitored: true,
+				status: "released",
+				qualityProfileId: 1,
+				sizeOnDisk: 2_000,
+				added: "2025-01-01T00:00:00.000Z",
+				statistics: { movieFileCount: 1, sizeOnDisk: 2_000 },
+			};
+			const getById = vi.fn().mockResolvedValue(rawItem);
+			deps.arrClientFactory = {
+				create: vi.fn(() => ({ movie: { getById } })),
+			} as never;
+			const snapshot = await createMutationPolicySnapshotGetter(deps, "user-1")();
+			const upstreamMutation = vi.fn();
+			const radarr = {
+				...instance("PLEX"),
+				id: "radarr-1",
+				service: "RADARR",
+			};
+
+			await expect(
+				(async () => {
+					await assertCurrentSeriesMutationAuthority(
+						deps,
+						"user-1",
+						radarr as never,
+						101,
+						{
+							matchedRuleId: tautulliRule.id,
+							action: "delete",
+							scanMediaServerAfterDelete: false,
+							providerDependencies: ["tautulli"],
+						},
+						snapshot,
+					);
+					await upstreamMutation();
+				})(),
+			).rejects.toThrow(/provider evidence could not re-authorize/i);
+			expect(snapshot.failedSources).toContain("tautulli");
+			expect(upstreamMutation).not.toHaveBeenCalled();
+		},
+	);
 });
 
 describe("interactive preview live watch authority", () => {

--- a/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
+++ b/apps/api/src/lib/library-cleanup/__tests__/provider-execution-authority.test.ts
@@ -595,7 +595,9 @@ describe("provider execution authority", () => {
 		authorityCalls.persistedEpisodes.mockClear();
 	});
 
-	for (const cacheType of Object.keys(cacheCases) as Array<keyof typeof cacheCases>) {
+	for (const cacheType of Object.keys(cacheCases).filter(
+		(cacheType) => cacheType !== "tautulli",
+	) as Array<Exclude<keyof typeof cacheCases, "tautulli">>) {
 		it(`accepts unchanged real ${cacheType} evidence`, async () => {
 			const subject = cacheTypeFixture(cacheType);
 
@@ -609,6 +611,15 @@ describe("provider execution authority", () => {
 			}
 		});
 	}
+
+	it("rejects unchanged Tautulli evidence because cleanup has no B1 mutation authority", async () => {
+		const subject = cacheTypeFixture("tautulli");
+
+		await expect(
+			assertCurrentProviderEvidenceAuthority(subject.deps, "user-1", subject.evidence, vi.fn()),
+		).rejects.toThrow("Provider execution authority changed");
+		expect(subject.identityReader).not.toHaveBeenCalled();
+	});
 
 	it.each(["jellyfin", "tautulli"] as const)(
 		"keeps the publication-order check for non-Plex %s evidence",

--- a/apps/api/src/lib/library-cleanup/cleanup-executor.ts
+++ b/apps/api/src/lib/library-cleanup/cleanup-executor.ts
@@ -66,13 +66,6 @@ import {
 	providerIdentityAuthorityFingerprint,
 	providerInstanceAuthorityFingerprint,
 } from "../services/service-identity.js";
-import {
-	collectTautulliCacheLiveEvidence,
-	createOwnedTautulliPublicationSnapshot,
-	refreshTautulliCache,
-	type TautulliCacheSnapshotRow,
-} from "../tautulli/tautulli-cache-refresher.js";
-import { createTautulliClient } from "../tautulli/tautulli-client.js";
 import { createTmdbV3Client } from "../tmdb/list-client.js";
 import { createTraktClient } from "../trakt/list-client.js";
 import { getErrorMessage } from "../utils/error-message.js";
@@ -5909,34 +5902,6 @@ function snapshotUsers(value: string): string[] {
 	return parsed;
 }
 
-function tautulliSnapshotToWatchMap(rows: TautulliCacheSnapshotRow[]): TautulliWatchMap {
-	const map: TautulliWatchMap = new Map();
-	for (const row of rows) {
-		const key = `${row.mediaType}:${row.tmdbId}`;
-		const watchedByUsers = snapshotUsers(row.watchedByUsers);
-		const existing = map.get(key);
-		if (existing) {
-			if (
-				row.lastWatchedAt &&
-				(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
-			) {
-				existing.lastWatchedAt = row.lastWatchedAt;
-			}
-			existing.watchCount += row.watchCount;
-			for (const user of watchedByUsers) {
-				if (!existing.watchedByUsers.includes(user)) existing.watchedByUsers.push(user);
-			}
-		} else {
-			map.set(key, {
-				lastWatchedAt: row.lastWatchedAt,
-				watchCount: row.watchCount,
-				watchedByUsers: [...watchedByUsers],
-			});
-		}
-	}
-	return map;
-}
-
 function plexSnapshotToWatchMap(rows: PlexCacheSnapshotRow[]): PlexWatchMap {
 	const map: PlexWatchMap = new Map();
 	for (const row of rows) {
@@ -6041,131 +6006,6 @@ function jellyfinSnapshotToWatchMap(rows: JellyfinCacheSnapshotRow[]): JellyfinW
 		}
 	}
 	return map;
-}
-
-/**
- * Prefetch Tautulli watch data from the TautulliCache table and build a lookup map.
- * Returns undefined if no Tautulli instance is configured.
- */
-async function loadTautulliDataSnapshot(
-	deps: CleanupExecutorDeps,
-	userId: string,
-): Promise<ProviderCacheSnapshot<TautulliWatchMap> | undefined> {
-	const { prisma, log } = deps;
-
-	const tautulliInstances = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
-
-	// A Tautulli cache is an aggregate over a single PMS watch-history source.
-	// Combining multiple enabled sources would turn an ambiguous provider choice
-	// into a synthetic watch count, so it cannot authorize cleanup.
-	if (tautulliInstances.length !== 1) return undefined;
-
-	try {
-		const generations = await loadCompleteCacheGenerations(deps, tautulliInstances, "tautulli");
-		if (!generations) {
-			throw new Error("Tautulli cache did not have a complete fresh generation for every instance");
-		}
-		const map: TautulliWatchMap = new Map();
-		const rowCounts = new Map<string, number>();
-		const rowsByInstance = new Map<string, unknown[]>();
-		let cursor: string | undefined;
-		let totalRows = 0;
-
-		// Cursor-paginate to bound peak heap.
-		while (true) {
-			const batch = await prisma.tautulliCache.findMany({
-				where: { instanceId: { in: tautulliInstances.map((instance) => instance.id) } },
-				select: PROVIDER_CACHE_ROW_SELECTS.tautulli,
-				take: CACHE_QUERY_BATCH_SIZE,
-				...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
-				orderBy: { id: "asc" },
-			});
-
-			if (batch.length === 0) break;
-			totalRows += batch.length;
-
-			for (const row of batch) {
-				try {
-					const generation = generations.get(row.instanceId);
-					if (
-						!generation ||
-						row.connectionGeneration !== generation.connectionGeneration ||
-						row.identityGeneration !== generation.identityGeneration
-					) {
-						throw new Error("Tautulli cache row provenance was unavailable");
-					}
-					rowCounts.set(row.instanceId, (rowCounts.get(row.instanceId) ?? 0) + 1);
-					const sourceRows = rowsByInstance.get(row.instanceId) ?? [];
-					sourceRows.push(row);
-					rowsByInstance.set(row.instanceId, sourceRows);
-					const key = `${row.mediaType}:${row.tmdbId}`;
-					const watchedByUsers = (safeJsonParse(row.watchedByUsers) as string[]) ?? [];
-					const existing = map.get(key);
-					if (existing) {
-						if (
-							row.lastWatchedAt &&
-							(!existing.lastWatchedAt || row.lastWatchedAt > existing.lastWatchedAt)
-						) {
-							existing.lastWatchedAt = row.lastWatchedAt;
-						}
-						existing.watchCount += row.watchCount;
-						for (const user of watchedByUsers) {
-							if (!existing.watchedByUsers.includes(user)) existing.watchedByUsers.push(user);
-						}
-					} else {
-						map.set(key, {
-							lastWatchedAt: row.lastWatchedAt,
-							watchCount: row.watchCount,
-							watchedByUsers,
-						});
-					}
-				} catch (rowErr) {
-					log.warn(
-						{ err: rowErr, tmdbId: row.tmdbId },
-						"Skipping Tautulli cache row with bad data",
-					);
-				}
-			}
-
-			cursor = batch[batch.length - 1]!.id;
-			if (batch.length < CACHE_QUERY_BATCH_SIZE) break;
-		}
-		if (
-			(rowCounts.get(tautulliInstances[0]!.id) ?? 0) !==
-			generations.get(tautulliInstances[0]!.id)!.itemCount
-		) {
-			throw new Error("Tautulli cache row count did not match its published generation");
-		}
-
-		const snapshot = createProviderCacheSnapshot(
-			map,
-			"tautulli",
-			tautulliInstances,
-			generations,
-			rowsByInstance,
-		);
-		if (!(await revalidateProviderCacheAuthority(deps, snapshot.authority, false))) {
-			throw new Error("Tautulli cache generation changed while rows were read");
-		}
-		log.info(
-			{ totalRows, totalEntries: map.size },
-			"Tautulli watch data prefetch complete for cleanup",
-		);
-		return snapshot;
-	} catch (error) {
-		log.warn(
-			{ err: error },
-			"Failed to prefetch Tautulli data for cleanup — Tautulli rules will be skipped",
-		);
-		return undefined;
-	}
-}
-
-async function prefetchTautulliData(
-	deps: CleanupExecutorDeps,
-	userId: string,
-): Promise<TautulliWatchMap | undefined> {
-	return (await loadTautulliDataSnapshot(deps, userId))?.value;
 }
 
 /**
@@ -6752,7 +6592,8 @@ async function evaluateAllItems(
 	const seerrResult = hasSeerrRules ? await prefetchSeerrRequests(deps, config.userId) : undefined;
 	const seerrMap = hasSeerrRules ? seerrResult : undefined;
 
-	// Prefetch Tautulli watch data if any Tautulli rule types are active
+	// B1 containment: Tautulli-dependent cleanup stays UNKNOWN until the later
+	// mutation-authority track is explicitly implemented.
 	const TAUTULLI_RULE_TYPES = [
 		"tautulli_last_watched",
 		"tautulli_watch_count",
@@ -6760,10 +6601,13 @@ async function evaluateAllItems(
 		"user_retention", // Can use tautulli as source
 	];
 	const hasTautulliRules = TAUTULLI_RULE_TYPES.some((t) => activeTypes.has(t));
-	const tautulliSnapshot = hasTautulliRules
-		? await loadTautulliDataSnapshot(deps, config.userId)
-		: undefined;
-	const tautulliMap = tautulliSnapshot?.value;
+	const tautulliSnapshot: ProviderCacheSnapshot<TautulliWatchMap> | undefined = undefined;
+	const tautulliMap: TautulliWatchMap | undefined = undefined;
+	if (hasTautulliRules) {
+		warnings.push(
+			"Tautulli-dependent cleanup rules are unavailable and were evaluated as unknown.",
+		);
+	}
 
 	// Prefetch Plex watch data if any Plex rule types are active
 	const PLEX_RULE_TYPES = [
@@ -10355,46 +10199,6 @@ async function _collectLivePlexPolicyEvidence(
 	}
 }
 
-async function _collectLiveTautulliPolicyEvidence(
-	deps: CleanupExecutorDeps,
-	userId: string,
-): Promise<TautulliWatchMap | undefined> {
-	try {
-		const initial = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
-		if (initial.length === 0) return undefined;
-		const topology = providerTopologyFingerprint(initial);
-		let accepted: { map: TautulliWatchMap; fingerprint: string } | undefined;
-		for (let pass = 0; pass < 2; pass++) {
-			const rows: TautulliCacheSnapshotRow[] = [];
-			for (const instance of initial) {
-				const client =
-					deps.tautulliCacheClientFactory?.(instance) ??
-					(deps.encryptor ? createTautulliClient(deps.encryptor, instance, deps.log) : null);
-				if (!client) throw new Error("Tautulli credentials were unavailable");
-				const collected = await collectTautulliCacheLiveEvidence(client, instance.id, deps.log);
-				if (collected.errors > 0 || collected.complete !== true || !collected.snapshot) {
-					throw new Error("Tautulli live evidence collection was incomplete");
-				}
-				rows.push(...collected.snapshot.rows);
-			}
-			const after = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
-			if (providerTopologyFingerprint(after) !== topology) {
-				throw new Error("Tautulli topology changed during live evidence collection");
-			}
-			const sortedRows = sortProviderRows(rows);
-			const fingerprint = evidenceFingerprint([topology, sortedRows]);
-			if (accepted && accepted.fingerprint !== fingerprint) {
-				throw new Error("Tautulli evidence changed between verification passes");
-			}
-			accepted = { map: tautulliSnapshotToWatchMap(sortedRows), fingerprint };
-		}
-		return accepted?.map;
-	} catch (error) {
-		deps.log.warn({ err: error }, "Live read-only Tautulli policy evidence failed closed");
-		return undefined;
-	}
-}
-
 async function _collectLiveJellyfinPolicyEvidence(
 	deps: CleanupExecutorDeps,
 	userId: string,
@@ -10599,63 +10403,6 @@ async function refreshPlexMutationEvidence(
 			: undefined;
 	} catch (error) {
 		deps.log.warn({ err: error }, "Live Plex policy evidence refresh failed closed");
-		return undefined;
-	}
-}
-
-async function refreshTautulliMutationEvidence(
-	deps: CleanupExecutorDeps,
-	userId: string,
-	cleanupRunClaimToken?: string,
-): Promise<{ map: TautulliWatchMap; completedAt: Date } | undefined> {
-	try {
-		const initial = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
-		if (initial.length === 0) return undefined;
-		const topology = providerTopologyFingerprint(initial);
-		let accepted: { map: TautulliWatchMap; fingerprint: string; completedAt: Date } | undefined;
-		for (let pass = 0; pass < 2; pass++) {
-			for (const instance of initial) {
-				if (!deps.encryptor) throw new Error("Tautulli credentials were unavailable");
-				const publicationInstance = createOwnedTautulliPublicationSnapshot(
-					deps.encryptor,
-					instance,
-				);
-				const refreshed = await refreshTautulliCache({
-					prisma: deps.prisma,
-					instance: publicationInstance,
-					log: deps.log,
-					cleanupRunClaimToken,
-				});
-				if (refreshed.errors > 0 || refreshed.complete !== true) {
-					throw new Error("Tautulli cache refresh was incomplete");
-				}
-				if (!refreshed.completedAt) {
-					throw new Error("Tautulli refresh lacked a completion timestamp");
-				}
-			}
-			const after = await loadProviderInstances(deps, userId, ["TAUTULLI"]);
-			if (providerTopologyFingerprint(after) !== topology) {
-				throw new Error("Tautulli topology changed during policy revalidation");
-			}
-			const map = await prefetchTautulliData(deps, userId);
-			if (!map) throw new Error("Tautulli refreshed evidence could not be loaded");
-			const fingerprint = evidenceFingerprint(map);
-			if (accepted && accepted.fingerprint !== fingerprint) {
-				throw new Error("Tautulli evidence changed between verification passes");
-			}
-			const statuses = await loadCompleteCacheGenerations(deps, after, "tautulli");
-			if (!statuses) throw new Error("Tautulli completion timestamps were unavailable");
-			accepted = {
-				map,
-				fingerprint,
-				completedAt: new Date(
-					Math.min(...[...statuses.values()].map((status) => status.completedAt.getTime())),
-				),
-			};
-		}
-		return accepted ? { map: accepted.map, completedAt: accepted.completedAt } : undefined;
-	} catch (error) {
-		deps.log.warn({ err: error }, "Live Tautulli policy evidence refresh failed closed");
 		return undefined;
 	}
 }
@@ -10967,7 +10714,7 @@ async function buildMutationEvalContext(
 
 	const [seerrMap, tautulliMap, plexEvidence, jellyfinEvidence, listEvidence] = await Promise.all([
 		needsSeerr ? prefetchSeerrRequests(deps, userId) : undefined,
-		needsTautulli ? refreshTautulliMutationEvidence(deps, userId, cleanupRunClaimToken) : undefined,
+		undefined,
 		needsPlex || needsPlexSectionInventory
 			? refreshPlexMutationEvidence(
 					deps,
@@ -10999,7 +10746,6 @@ async function buildMutationEvalContext(
 	if (needsTrakt && !listEvidence.traktListMemberships) failedSources.add("trakt");
 	const sourceCompletedAt = new Map<Exclude<DataSourceDependency, null>, Date>();
 	if (needsSeerr && seerrMap) sourceCompletedAt.set("seerr", new Date());
-	if (tautulliMap) sourceCompletedAt.set("tautulli", tautulliMap.completedAt);
 	if (plexEvidence) sourceCompletedAt.set("plex", plexEvidence.completedAt);
 	if (jellyfinEvidence) sourceCompletedAt.set("jellyfin", jellyfinEvidence.completedAt);
 	if (listEvidence.tmdbCompletedAt) sourceCompletedAt.set("tmdb", listEvidence.tmdbCompletedAt);
@@ -11008,7 +10754,7 @@ async function buildMutationEvalContext(
 		ctx: {
 			now: new Date(),
 			seerrMap,
-			tautulliMap: tautulliMap?.map,
+			tautulliMap: undefined,
 			plexMap: plexEvidence?.plexMap,
 			plexSectionTitles: plexEvidence?.plexSectionTitles,
 			plexEpisodeMap: plexEvidence?.plexEpisodeMap,
@@ -11216,7 +10962,6 @@ export async function buildEvalContextWithHealth(
 		: undefined;
 	const [
 		seerrMap,
-		tautulliSnapshot,
 		plexSnapshot,
 		plexEpisodeSnapshot,
 		jellyfinSnapshot,
@@ -11224,7 +10969,6 @@ export async function buildEvalContextWithHealth(
 		listEvidence,
 	] = await Promise.all([
 		needsSeerr ? prefetchSeerrRequests(deps, userId) : undefined,
-		needsTautulli ? loadTautulliDataSnapshot(deps, userId) : undefined,
 		needsPlexSectionInventory
 			? plexEvidence?.snapshot
 			: needsPlex
@@ -11237,7 +10981,7 @@ export async function buildEvalContextWithHealth(
 	]);
 	const effectivePlexSnapshot = plexSnapshot;
 	const effectivePlexEvidence = plexEvidence;
-	const tautulliMap = tautulliSnapshot?.value;
+	const tautulliMap: TautulliWatchMap | undefined = undefined;
 	const plexEpisodeMap = plexEpisodeSnapshot?.value;
 	const jellyfinMap = jellyfinSnapshot?.value;
 	const jellyfinEpisodeMap = jellyfinEpisodeSnapshot?.value;
@@ -11266,7 +11010,6 @@ export async function buildEvalContextWithHealth(
 		traktListMemberships: listEvidence.traktListMemberships,
 	};
 	const contributingSnapshots = [
-		tautulliSnapshot,
 		effectivePlexSnapshot,
 		plexEpisodeSnapshot,
 		jellyfinSnapshot,

--- a/apps/api/src/lib/library-cleanup/provider-cache-evidence.ts
+++ b/apps/api/src/lib/library-cleanup/provider-cache-evidence.ts
@@ -178,13 +178,8 @@ export async function loadExactProviderCacheRows(
 				}),
 			);
 		case "tautulli":
-			return groupProviderRowsByInstance(
-				instanceIds,
-				await tx.tautulliCache.findMany({
-					where,
-					select: PROVIDER_CACHE_ROW_SELECTS.tautulli,
-					orderBy: { id: "asc" },
-				}),
-			);
+			// B1 containment: Tautulli is not cleanup-authoritative. Returning an
+			// empty grouped result makes every exact revalidation fail closed.
+			return groupProviderRowsByInstance(instanceIds, []);
 	}
 }

--- a/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
+++ b/apps/api/src/lib/plex/__tests__/provider-cache-heap.test.ts
@@ -383,6 +383,30 @@ function reportHeap(message: string): void {
 
 		async function refreshTautulli(): Promise<Awaited<ReturnType<typeof refreshTautulliCache>>> {
 			publication.tautulliClient = tautulliClient;
+			const attemptedAt = new Date();
+			const resultMarker = `in_progress:heap-${attemptedAt.getTime()}`;
+			await prisma.cacheRefreshStatus.upsert({
+				where: {
+					instanceId_cacheType: { instanceId: "heap-tautulli", cacheType: "tautulli" },
+				},
+				create: {
+					instanceId: "heap-tautulli",
+					cacheType: "tautulli",
+					lastRefreshedAt: attemptedAt,
+					lastResult: "error",
+					lastErrorMessage: "refresh_in_progress",
+					itemCount: 0,
+					lastAttemptAt: attemptedAt,
+					lastAttemptResult: resultMarker,
+					connectionGeneration: 0,
+					identityGeneration: 0,
+				},
+				update: {
+					lastAttemptAt: attemptedAt,
+					lastAttemptResult: resultMarker,
+					lastAttemptErrorMessage: null,
+				},
+			});
 			return await refreshTautulliCache({
 				prisma,
 				instance: {
@@ -404,6 +428,7 @@ function reportHeap(message: string): void {
 					identityGeneration: 0,
 				},
 				log: silentLog,
+				attempt: { attemptedAt, resultMarker },
 			});
 		}
 
@@ -877,7 +902,10 @@ function reportHeap(message: string): void {
 			await prisma.$executeRawUnsafe(`
 				CREATE TRIGGER fail_tautulli_success_status
 				BEFORE UPDATE ON cache_refresh_status
-				WHEN NEW.instanceId = 'heap-tautulli' AND NEW.cacheType = 'tautulli'
+				WHEN NEW.instanceId = 'heap-tautulli'
+					AND NEW.cacheType = 'tautulli'
+					AND NEW.lastResult = 'success'
+					AND NEW.lastAttemptResult = 'success'
 				BEGIN
 					SELECT RAISE(ABORT, 'injected Tautulli status failure');
 				END

--- a/apps/api/src/lib/pulse/__tests__/actions.test.ts
+++ b/apps/api/src/lib/pulse/__tests__/actions.test.ts
@@ -52,25 +52,20 @@ const plexInstance = {
 	connectionGeneration: 7,
 	identityGeneration: 3,
 };
-const refreshTautulliCache = vi.fn();
-const createOwnedTautulliPublicationSnapshot = vi.fn(
-	(_encryptor: unknown, instance: unknown) => instance,
-);
+const refreshOwnedTautulliCache = vi.fn();
 vi.mock("../../plex/plex-refresh-orchestration.js", () => ({
 	refreshOwnedPlexCache: (...args: unknown[]) => refreshOwnedPlexCache(...args),
 }));
 vi.mock("../../tautulli/tautulli-cache-refresher.js", () => ({
-	createOwnedTautulliPublicationSnapshot: (encryptor: unknown, instance: unknown) =>
-		createOwnedTautulliPublicationSnapshot(encryptor, instance),
-	refreshTautulliCache: (...args: unknown[]) => refreshTautulliCache(...args),
+	refreshOwnedTautulliCache: (...args: unknown[]) => refreshOwnedTautulliCache(...args),
 }));
 
-const requireTautulliClient = vi.fn();
-vi.mock("../../tautulli/tautulli-helpers.js", () => ({
-	requireTautulliClient: (...args: unknown[]) => requireTautulliClient(...args),
+const findOwnedEnabledTautulliInstance = vi.fn();
+vi.mock("../../tautulli/tautulli-cache-authority.js", () => ({
+	findOwnedEnabledTautulliInstance: (...args: unknown[]) =>
+		findOwnedEnabledTautulliInstance(...args),
 }));
 
-import { InstanceNotFoundError } from "../../errors.js";
 import { dispatchPulseAction } from "../actions.js";
 
 // -----------------------------------------------------------------------------
@@ -132,8 +127,8 @@ beforeEach(() => {
 	queueCleanerScheduler.isRunning.mockReset();
 	queueCleanerScheduler.start.mockReset();
 	refreshOwnedPlexCache.mockReset();
-	refreshTautulliCache.mockReset();
-	requireTautulliClient.mockReset();
+	refreshOwnedTautulliCache.mockReset();
+	findOwnedEnabledTautulliInstance.mockReset();
 	markEnabled.mockReset();
 	cacheStatusUpsert.mockReset();
 	cacheStatusUpsert.mockResolvedValue({});
@@ -256,7 +251,7 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		// don't yet know the upsert count at return time.
 		expect(result.status).toBe("ok");
 		expect(result.detail).toBeUndefined();
-		expect(requireTautulliClient).not.toHaveBeenCalled();
+		expect(findOwnedEnabledTautulliInstance).not.toHaveBeenCalled();
 
 		// Await the background task so the rest of the assertions see the
 		// post-refresh state. In production the route handler does NOT await
@@ -273,10 +268,9 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		expect(cacheStatusUpsert).not.toHaveBeenCalled();
 	});
 
-	it("refreshes Tautulli from the owned snapshot without forwarding the helper client", async () => {
-		const fakeClient = { id: "tautulli-client" };
-		requireTautulliClient.mockResolvedValue({ client: fakeClient, instance: tautulliInstance });
-		refreshTautulliCache.mockResolvedValue({
+	it("refreshes Tautulli through the attempt-owning credential boundary", async () => {
+		findOwnedEnabledTautulliInstance.mockResolvedValue(tautulliInstance);
+		refreshOwnedTautulliCache.mockResolvedValue({
 			upserted: 7,
 			errors: 0,
 			complete: true,
@@ -287,22 +281,21 @@ describe("dispatchPulseAction — cache.refresh", () => {
 
 		expect(result.status).toBe("ok");
 		expect(result.detail).toBeUndefined();
-		expect(requireTautulliClient).toHaveBeenCalledWith(fakeApp, "user-1", "inst-tautulli-1");
+		expect(findOwnedEnabledTautulliInstance).toHaveBeenCalledWith(fakeApp.prisma, {
+			userId: "user-1",
+			instanceId: "inst-tautulli-1",
+		});
 
 		// Wait for the fire-and-forget background refresh + write-through
 		// before asserting they ran.
 		await result.backgroundTask;
 
-		expect(createOwnedTautulliPublicationSnapshot).toHaveBeenCalledWith(
-			fakeApp.encryptor,
-			tautulliInstance,
-		);
-		expect(refreshTautulliCache).toHaveBeenCalledWith({
+		expect(refreshOwnedTautulliCache).toHaveBeenCalledWith({
 			prisma: fakeApp.prisma,
+			encryptor: fakeApp.encryptor,
 			instance: tautulliInstance,
 			log: fakeLog,
 		});
-		expect(refreshTautulliCache.mock.calls[0]).not.toContain(fakeClient);
 		expect(cacheStatusUpsert).not.toHaveBeenCalled();
 	});
 
@@ -414,15 +407,15 @@ describe("dispatchPulseAction — cache.refresh", () => {
 		expect(refreshOwnedPlexCache).not.toHaveBeenCalled();
 	});
 
-	it("propagates InstanceNotFoundError from requireTautulliClient", async () => {
-		requireTautulliClient.mockRejectedValue(new InstanceNotFoundError("inst-tautulli-1"));
+	it("propagates InstanceNotFoundError for a missing owned Tautulli instance", async () => {
+		findOwnedEnabledTautulliInstance.mockResolvedValue(null);
 
 		await expect(
 			dispatchPulseAction(fakeApp, "user-1", tautulliAction, fakeLog),
 		).rejects.toMatchObject({
 			statusCode: 404,
 		});
-		expect(refreshTautulliCache).not.toHaveBeenCalled();
+		expect(refreshOwnedTautulliCache).not.toHaveBeenCalled();
 	});
 });
 

--- a/apps/api/src/lib/pulse/actions.ts
+++ b/apps/api/src/lib/pulse/actions.ts
@@ -25,7 +25,7 @@ import {
 } from "../arr/client-helpers.js";
 import { requireEnabledInstance } from "../arr/instance-helpers.js";
 import { parseQueueId } from "../dashboard/queue-utils.js";
-import { AppValidationError, ConflictError } from "../errors.js";
+import { AppValidationError, ConflictError, InstanceNotFoundError } from "../errors.js";
 import { getHuntingScheduler } from "../hunting/scheduler.js";
 import {
 	createOwnedJellyfinPublicationSnapshot,
@@ -37,11 +37,8 @@ import { refreshOwnedPlexCache } from "../plex/plex-refresh-orchestration.js";
 import { getQueueCleanerScheduler } from "../queue-cleaner/scheduler.js";
 import { recordWatchProviderCacheRefreshFailure } from "../services/provider-cache-status.js";
 import type { OwnedProviderPublicationSnapshot } from "../services/provider-identity-guard.js";
-import {
-	createOwnedTautulliPublicationSnapshot,
-	refreshTautulliCache,
-} from "../tautulli/tautulli-cache-refresher.js";
-import { requireTautulliClient } from "../tautulli/tautulli-helpers.js";
+import { refreshOwnedTautulliCache } from "../tautulli/tautulli-cache-refresher.js";
+import { findOwnedEnabledTautulliInstance } from "../tautulli/tautulli-cache-authority.js";
 
 export interface PulseActionResult {
 	status: "ok";
@@ -213,15 +210,21 @@ async function dispatchCacheRefresh(
 	}
 
 	// tautulli
-	const { instance } = await requireTautulliClient(app, userId, instanceId);
-	const publicationInstance = createOwnedTautulliPublicationSnapshot(app.encryptor, instance);
+	const instance = await findOwnedEnabledTautulliInstance(app.prisma, { userId, instanceId });
+	if (!instance) throw new InstanceNotFoundError(instanceId);
 	const backgroundTask = runBackgroundCacheRefresh({
 		app,
 		log,
 		instanceId,
 		cacheType: "tautulli",
-		refresh: () => refreshTautulliCache({ prisma: app.prisma, instance: publicationInstance, log }),
-		publicationAuthority: publicationInstance,
+		refresh: () =>
+			refreshOwnedTautulliCache({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				instance,
+				log,
+			}),
+		failureRecordedByRefresh: true,
 	});
 	log.info({ instanceId, cacheType }, "pulse-action: tautulli cache refresh dispatched");
 	return { status: "ok", backgroundTask };
@@ -270,7 +273,12 @@ function runBackgroundCacheRefresh(opts: {
 					err instanceof Error ? err.message : String(err),
 				);
 			}
-			log.error({ err, instanceId, cacheType }, "pulse-action: cache refresh failed (background)");
+			log.error(
+				cacheType === "tautulli"
+					? { instanceId, cacheType, reasonCode: "unknown_failure" }
+					: { err, instanceId, cacheType },
+				"pulse-action: cache refresh failed (background)",
+			);
 		}
 	})();
 }

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -621,12 +621,17 @@ function cacheSource(cacheType: string, instanceService: string): string {
 }
 
 const collectCacheStaleness: Collector = async (app, userId) => {
-	const cacheStatuses = await app.prisma.cacheRefreshStatus.findMany({
-		where: { instance: { userId, enabled: true } },
-		include: { instance: { select: { label: true, service: true } } },
-	});
+	const [cacheStatuses, tautulliInstances] = await Promise.all([
+		app.prisma.cacheRefreshStatus.findMany({
+			where: { instance: { userId, enabled: true } },
+			include: { instance: { select: { label: true, service: true } } },
+		}),
+		app.prisma.serviceInstance.findMany({
+			where: { userId, enabled: true, service: "TAUTULLI" },
+			select: { id: true, label: true, createdAt: true },
+		}),
+	]);
 
-	if (cacheStatuses.length === 0) return [];
 	const plexEvidenceByStatus = new Map<
 		string,
 		Awaited<ReturnType<typeof loadUserGenerationObservations>>[number]["evidence"]
@@ -790,6 +795,49 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				...(action ? { action } : {}),
 			});
 		}
+	}
+
+	const tautulliStatusInstanceIds = new Set(
+		cacheStatuses
+			.filter((status) => status.cacheType === "tautulli")
+			.map((status) => status.instanceId),
+	);
+	for (const instance of tautulliInstances) {
+		if (tautulliStatusInstanceIds.has(instance.id)) continue;
+		const authority = await readOwnedTautulliCacheAuthority(app.prisma, {
+			userId,
+			instanceId: instance.id,
+		});
+		if (!authority || authority.available) continue;
+
+		const timestamp = authority.lastRefreshedAt?.toISOString() ?? instance.createdAt.toISOString();
+		if (authority.state === "in_progress") {
+			items.push({
+				id: `cache-refreshing-tautulli-${instance.id}`,
+				severity: "info",
+				category: "health",
+				title: `${instance.label}: Tautulli cache refresh is in progress`,
+				detail: authority.reasonCodes.join(", "),
+				actionUrl: "/settings",
+				actionLabel: "View status",
+				source: "tautulli",
+				timestamp,
+			});
+			continue;
+		}
+
+		items.push({
+			id: `cache-error-tautulli-${instance.id}`,
+			severity: "warning",
+			category: "health",
+			title: `${instance.label}: Tautulli cache refresh failed`,
+			detail: authority.reasonCodes.join(", "),
+			actionUrl: "/settings",
+			actionLabel: "Check settings",
+			source: "tautulli",
+			timestamp,
+			action: actionForCache(instance.id, "tautulli", "Retry refresh"),
+		});
 	}
 	return items;
 };

--- a/apps/api/src/lib/pulse/collectors.ts
+++ b/apps/api/src/lib/pulse/collectors.ts
@@ -45,6 +45,7 @@ import {
 	safeRequest,
 } from "../statistics/statistics-utils.js";
 import { createTautulliClient } from "../tautulli/tautulli-client.js";
+import { readOwnedTautulliCacheAuthority } from "../tautulli/tautulli-cache-authority.js";
 import { integrationHealth } from "../validation/integration-health.js";
 
 // ============================================================================
@@ -673,7 +674,19 @@ const collectCacheStaleness: Collector = async (app, userId) => {
 				? "partial"
 				: status.lastResult;
 		let effectiveError = status.lastAttemptErrorMessage ?? status.lastErrorMessage;
-		if (status.cacheType === "plex" || status.cacheType === "plex_episode") {
+		if (status.cacheType === "tautulli") {
+			const authority = await readOwnedTautulliCacheAuthority(app.prisma, {
+				userId,
+				instanceId: status.instanceId,
+			});
+			if (!authority?.available) {
+				effectiveResult = authority?.state === "in_progress" ? "in_progress" : "error";
+				effectiveError = (authority?.reasonCodes ?? ["no_publication"]).join(", ");
+			} else {
+				effectiveResult = "success";
+				effectiveError = null;
+			}
+		} else if (status.cacheType === "plex" || status.cacheType === "plex_episode") {
 			const evidence = plexEvidenceByStatus.get(`${status.instanceId}:${status.cacheType}`);
 			if (evidence?.attemptState === "in_progress") {
 				effectiveResult = "in_progress";

--- a/apps/api/src/lib/services/__tests__/watch-provider-publication-authority.test.ts
+++ b/apps/api/src/lib/services/__tests__/watch-provider-publication-authority.test.ts
@@ -72,6 +72,10 @@ const log = {
 	error: vi.fn(),
 	debug: vi.fn(),
 } as unknown as FastifyBaseLogger;
+const tautulliAttempt = {
+	attemptedAt: new Date("2026-08-28T12:00:00.000Z"),
+	resultMarker: "in_progress:test-publication",
+};
 
 function snapshot(
 	service: "JELLYFIN" | "EMBY" | "TAUTULLI",
@@ -184,6 +188,10 @@ function prisma(finalPredicateMatches = true) {
 			upsert: vi.fn(async () => {
 				authority.events.push("status");
 				return {};
+			}),
+			updateMany: vi.fn(async () => {
+				authority.events.push("status");
+				return { count: 1 };
 			}),
 		},
 	};
@@ -300,6 +308,7 @@ describe("watch-provider publication authority", () => {
 			prisma: state.db,
 			instance: snapshot("TAUTULLI"),
 			log,
+			attempt: tautulliAttempt,
 		});
 
 		expect(result).toMatchObject({ complete: false, superseded: true, upserted: 0 });
@@ -332,15 +341,20 @@ describe("watch-provider publication authority", () => {
 		const instance = snapshot("TAUTULLI");
 		const state = prisma();
 
-		const result = await refreshTautulliCache({ prisma: state.db, instance, log });
+		const result = await refreshTautulliCache({
+			prisma: state.db,
+			instance,
+			log,
+			attempt: tautulliAttempt,
+		});
 
 		expect(result).toMatchObject({ complete: true, upserted: 0 });
 		expect(authority.connections).toEqual([
 			[instance.baseUrl, instance.apiKey, log, undefined, instance.httpAuthHeaders],
 		]);
-		expect(state.tx.cacheRefreshStatus.upsert).toHaveBeenCalledWith(
+		expect(state.tx.cacheRefreshStatus.updateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				create: expect.objectContaining({ connectionGeneration: 4, identityGeneration: 9 }),
+				where: expect.objectContaining({ connectionGeneration: 4, identityGeneration: 9 }),
 			}),
 		);
 	});
@@ -352,6 +366,7 @@ describe("watch-provider publication authority", () => {
 			prisma: state.db,
 			instance: snapshot("TAUTULLI", { enabled: false }),
 			log,
+			attempt: tautulliAttempt,
 		});
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
@@ -367,6 +382,7 @@ describe("watch-provider publication authority", () => {
 			prisma: state.db,
 			instance: snapshot("TAUTULLI"),
 			log,
+			attempt: tautulliAttempt,
 		});
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
@@ -405,6 +421,7 @@ describe("watch-provider publication authority", () => {
 			prisma: state.db,
 			instance: snapshot("TAUTULLI"),
 			log,
+			attempt: tautulliAttempt,
 		});
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });

--- a/apps/api/src/lib/services/provider-cache-status.database.test.ts
+++ b/apps/api/src/lib/services/provider-cache-status.database.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PrismaClient } from "../../generated/prisma/client.js";
+import { createTestPgClient } from "../__tests__/test-prisma.js";
 import { publishAuthoritativePlexCacheGeneration } from "../plex/plex-cache-storage.js";
 import {
 	encodeAuthoritativePlexGenerationMetadata,
@@ -17,20 +18,26 @@ import {
 	finishPlexCacheRefreshAttemptFailure,
 } from "./provider-cache-status.js";
 import type { ProviderPublicationAuthority } from "./provider-identity-guard.js";
-import { readOwnedTautulliCacheAuthority } from "../tautulli/tautulli-cache-authority.js";
+import { clearDurableProviderCacheState } from "./service-identity-lifecycle.js";
+import {
+	readOwnedTautulliCacheAuthority,
+	readUserSelectedTautulliCache,
+} from "../tautulli/tautulli-cache-authority.js";
 
 const apiRoot = join(process.cwd());
 const log = { warn: vi.fn() };
-const databases: Array<{ client: PrismaClient; directory: string }> = [];
+const databases: Array<{
+	clients: PrismaClient[];
+	directory: string;
+	databasePath: string;
+}> = [];
 
 afterEach(async () => {
 	vi.unstubAllEnvs();
-	await Promise.all(
-		databases.splice(0).map(async ({ client, directory }) => {
-			await client.$disconnect();
-			await rm(directory, { recursive: true, force: true });
-		}),
-	);
+	for (const { clients, directory } of databases.splice(0)) {
+		await Promise.all(clients.map(async (client) => await client.$disconnect()));
+		await rm(directory, { recursive: true, force: true });
+	}
 });
 
 async function createDatabase(): Promise<PrismaClient> {
@@ -45,8 +52,19 @@ async function createDatabase(): Promise<PrismaClient> {
 		adapter: new PrismaBetterSqlite3({ url: databasePath, timeout: 1_000 }),
 	});
 	await client.$connect();
-	databases.push({ client, directory });
+	databases.push({ clients: [client], directory, databasePath });
 	return client;
+}
+
+async function createDatabasePeer(client: PrismaClient): Promise<PrismaClient> {
+	const database = databases.find((entry) => entry.clients.includes(client));
+	if (!database) throw new Error("SQLite test database is not registered");
+	const peer = new PrismaClient({
+		adapter: new PrismaBetterSqlite3({ url: database.databasePath, timeout: 1_000 }),
+	});
+	await peer.$connect();
+	database.clients.push(peer);
+	return peer;
 }
 
 const authority: ProviderPublicationAuthority = {
@@ -117,7 +135,116 @@ async function seedObsoleteStatus(
 	});
 }
 
+async function exerciseConcurrentTautulliSnapshot(
+	client: PrismaClient,
+	writer: PrismaClient,
+): Promise<void> {
+	const publishedAt = new Date("2026-08-28T12:00:00.000Z");
+	await client.user.create({
+		data: { id: tautulliAuthority.userId, username: "tautulli-snapshot", hashedPassword: "hash" },
+	});
+	await client.serviceInstance.create({
+		data: {
+			...tautulliAuthority,
+			label: "Tautulli",
+			identityKind: "TAUTULLI_PMS_IDENTIFIER",
+			identityVerifiedAt: publishedAt,
+		},
+	});
+	await client.cacheRefreshStatus.create({
+		data: {
+			instanceId: tautulliAuthority.id,
+			cacheType: "tautulli",
+			lastRefreshedAt: publishedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			itemCount: 1,
+			lastAttemptAt: publishedAt,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			connectionGeneration: tautulliAuthority.connectionGeneration,
+			identityGeneration: tautulliAuthority.identityGeneration,
+		},
+	});
+	await client.tautulliCache.create({
+		data: {
+			id: "tautulli-current-row",
+			instanceId: tautulliAuthority.id,
+			tmdbId: 42,
+			mediaType: "movie",
+			lastWatchedAt: publishedAt,
+			watchCount: 3,
+			watchedByUsers: "[]",
+			connectionGeneration: tautulliAuthority.connectionGeneration,
+			identityGeneration: tautulliAuthority.identityGeneration,
+		},
+	});
+
+	let selectedReadReached!: () => void;
+	const atSelectedRead = new Promise<void>((resolve) => {
+		selectedReadReached = resolve;
+	});
+	let releaseSelectedRead!: () => void;
+	const selectedReadRelease = new Promise<void>((resolve) => {
+		releaseSelectedRead = resolve;
+	});
+	const reader = client.$extends({
+		query: {
+			tautulliCache: {
+				async findMany({ args, query }) {
+					selectedReadReached();
+					await selectedReadRelease;
+					return await query(args);
+				},
+			},
+		},
+	});
+
+	const read = readUserSelectedTautulliCache(reader as never, {
+		userId: tautulliAuthority.userId,
+		targets: [{ tmdbId: 42, mediaType: "movie" }],
+		now: publishedAt,
+	});
+	await atSelectedRead;
+	const reset = writer.$transaction(
+		async (tx) => {
+			await tx.serviceInstance.update({
+				where: { id: tautulliAuthority.id },
+				data: { connectionGeneration: { increment: 1 } },
+			});
+			await clearDurableProviderCacheState(tx, tautulliAuthority.id);
+		},
+		{ isolationLevel: "Serializable" },
+	);
+	releaseSelectedRead();
+
+	const [result] = await Promise.all([read, reset]);
+	expect(result.available && result.rows.length === 0).toBe(false);
+	if (result.available) {
+		expect(result).toMatchObject({
+			configured: true,
+			reasonCodes: [],
+			rows: [{ id: "tautulli-current-row", tmdbId: 42, watchCount: 3 }],
+		});
+	} else {
+		expect(result.reasonCodes.length).toBeGreaterThan(0);
+	}
+	await expect(
+		writer.serviceInstance.findUniqueOrThrow({ where: { id: tautulliAuthority.id } }),
+	).resolves.toMatchObject({ connectionGeneration: 5 });
+	expect(
+		await writer.cacheRefreshStatus.count({ where: { instanceId: tautulliAuthority.id } }),
+	).toBe(0);
+	expect(await writer.tautulliCache.count({ where: { instanceId: tautulliAuthority.id } })).toBe(0);
+}
+
 describe("provider cache status SQLite takeover contract", () => {
+	it("serializes a lifecycle clear at the Tautulli validation-to-row-read boundary", async () => {
+		const client = await createDatabase();
+		const writer = await createDatabasePeer(client);
+		await exerciseConcurrentTautulliSnapshot(client, writer);
+	}, 30_000);
+
 	it("keeps overlap A unavailable, publishes B, and prevents A from finishing over B", async () => {
 		const client = await createDatabase();
 		await client.user.create({
@@ -470,4 +597,27 @@ describe("provider cache status SQLite takeover contract", () => {
 			),
 		).toBe("superseded");
 	}, 30_000);
+});
+
+describe("provider cache status PostgreSQL Serializable snapshot contract", () => {
+	it.runIf(Boolean(process.env.TAUTULLI_AUTHORITY_POSTGRES_URL))(
+		"serializes the same lifecycle clear without a mixed selected-cache snapshot",
+		async () => {
+			const connectionString = process.env.TAUTULLI_AUTHORITY_POSTGRES_URL!;
+			if (new URL(connectionString).pathname !== "/tautulli_authority_test") {
+				throw new Error(
+					"TAUTULLI_AUTHORITY_POSTGRES_URL must target the disposable tautulli_authority_test database",
+				);
+			}
+			const reader = await createTestPgClient(connectionString);
+			const writer = await createTestPgClient(connectionString);
+			try {
+				await exerciseConcurrentTautulliSnapshot(reader.prisma, writer.prisma);
+			} finally {
+				await writer.cleanup();
+				await reader.cleanup();
+			}
+		},
+		30_000,
+	);
 });

--- a/apps/api/src/lib/services/provider-cache-status.database.test.ts
+++ b/apps/api/src/lib/services/provider-cache-status.database.test.ts
@@ -238,11 +238,123 @@ async function exerciseConcurrentTautulliSnapshot(
 	expect(await writer.tautulliCache.count({ where: { instanceId: tautulliAuthority.id } })).toBe(0);
 }
 
+async function exerciseConcurrentTautulliAuthoritySnapshot(
+	client: PrismaClient,
+	writer: PrismaClient,
+): Promise<void> {
+	const publishedAt = new Date("2026-08-28T12:00:00.000Z");
+	const snapshotAuthority: ProviderPublicationAuthority = {
+		...tautulliAuthority,
+		id: "tautulli-authority-snapshot",
+		userId: "tautulli-authority-user",
+	};
+	await client.user.create({
+		data: { id: snapshotAuthority.userId, username: "tautulli-authority", hashedPassword: "hash" },
+	});
+	await client.serviceInstance.create({
+		data: {
+			...snapshotAuthority,
+			label: "Tautulli authority",
+			identityKind: "TAUTULLI_PMS_IDENTIFIER",
+			identityVerifiedAt: publishedAt,
+		},
+	});
+	await client.cacheRefreshStatus.create({
+		data: {
+			instanceId: snapshotAuthority.id,
+			cacheType: "tautulli",
+			lastRefreshedAt: publishedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			itemCount: 1,
+			lastAttemptAt: publishedAt,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+			connectionGeneration: snapshotAuthority.connectionGeneration,
+			identityGeneration: snapshotAuthority.identityGeneration,
+		},
+	});
+	await client.tautulliCache.create({
+		data: {
+			id: "tautulli-authority-row",
+			instanceId: snapshotAuthority.id,
+			tmdbId: 84,
+			mediaType: "movie",
+			lastWatchedAt: publishedAt,
+			watchCount: 4,
+			watchedByUsers: "[]",
+			connectionGeneration: snapshotAuthority.connectionGeneration,
+			identityGeneration: snapshotAuthority.identityGeneration,
+		},
+	});
+
+	let statusReadReached!: () => void;
+	const atStatusRead = new Promise<void>((resolve) => {
+		statusReadReached = resolve;
+	});
+	let releaseStatusRead!: () => void;
+	const statusReadRelease = new Promise<void>((resolve) => {
+		releaseStatusRead = resolve;
+	});
+	const reader = client.$extends({
+		query: {
+			cacheRefreshStatus: {
+				async findFirst({ args, query }) {
+					const result = await query(args);
+					statusReadReached();
+					await statusReadRelease;
+					return result;
+				},
+			},
+		},
+	});
+
+	const read = readOwnedTautulliCacheAuthority(reader as never, {
+		userId: snapshotAuthority.userId,
+		instanceId: snapshotAuthority.id,
+		now: publishedAt,
+	});
+	await atStatusRead;
+	const claim = beginProviderCacheRefreshAttempt(writer, "tautulli", snapshotAuthority);
+	releaseStatusRead();
+
+	const [result, attempt] = await Promise.all([read, claim]);
+	expect(attempt).not.toBeNull();
+	expect(result).not.toBeNull();
+	expect(result?.available && result.cachedItems === 0).toBe(false);
+	if (result?.available) {
+		expect(result).toMatchObject({
+			state: "healthy_complete",
+			reasonCodes: [],
+			cachedItems: 1,
+		});
+	} else {
+		expect(result?.cachedItems).toBeNull();
+		expect(result?.reasonCodes.length).toBeGreaterThan(0);
+	}
+	await expect(
+		writer.cacheRefreshStatus.findUniqueOrThrow({
+			where: {
+				instanceId_cacheType: {
+					instanceId: snapshotAuthority.id,
+					cacheType: "tautulli",
+				},
+			},
+		}),
+	).resolves.toMatchObject({ lastAttemptResult: expect.stringMatching(/^in_progress:/) });
+}
+
 describe("provider cache status SQLite takeover contract", () => {
 	it("serializes a lifecycle clear at the Tautulli validation-to-row-read boundary", async () => {
 		const client = await createDatabase();
 		const writer = await createDatabasePeer(client);
 		await exerciseConcurrentTautulliSnapshot(client, writer);
+	}, 30_000);
+
+	it("serializes an attempt claim at the Tautulli status-to-count boundary", async () => {
+		const client = await createDatabase();
+		const writer = await createDatabasePeer(client);
+		await exerciseConcurrentTautulliAuthoritySnapshot(client, writer);
 	}, 30_000);
 
 	it("keeps overlap A unavailable, publishes B, and prevents A from finishing over B", async () => {
@@ -613,6 +725,27 @@ describe("provider cache status PostgreSQL Serializable snapshot contract", () =
 			const writer = await createTestPgClient(connectionString);
 			try {
 				await exerciseConcurrentTautulliSnapshot(reader.prisma, writer.prisma);
+			} finally {
+				await writer.cleanup();
+				await reader.cleanup();
+			}
+		},
+		30_000,
+	);
+
+	it.runIf(Boolean(process.env.TAUTULLI_AUTHORITY_POSTGRES_URL))(
+		"serializes an attempt claim without a mixed authority projection",
+		async () => {
+			const connectionString = process.env.TAUTULLI_AUTHORITY_POSTGRES_URL!;
+			if (new URL(connectionString).pathname !== "/tautulli_authority_test") {
+				throw new Error(
+					"TAUTULLI_AUTHORITY_POSTGRES_URL must target the disposable tautulli_authority_test database",
+				);
+			}
+			const reader = await createTestPgClient(connectionString);
+			const writer = await createTestPgClient(connectionString);
+			try {
+				await exerciseConcurrentTautulliAuthoritySnapshot(reader.prisma, writer.prisma);
 			} finally {
 				await writer.cleanup();
 				await reader.cleanup();

--- a/apps/api/src/lib/services/provider-cache-status.database.test.ts
+++ b/apps/api/src/lib/services/provider-cache-status.database.test.ts
@@ -11,10 +11,13 @@ import {
 	evaluatePlexMutationAuthority,
 } from "../plex/plex-generation-metadata.js";
 import {
+	beginProviderCacheRefreshAttempt,
 	beginPlexCacheRefreshAttempt,
+	finishProviderCacheRefreshAttemptFailure,
 	finishPlexCacheRefreshAttemptFailure,
 } from "./provider-cache-status.js";
 import type { ProviderPublicationAuthority } from "./provider-identity-guard.js";
+import { readOwnedTautulliCacheAuthority } from "../tautulli/tautulli-cache-authority.js";
 
 const apiRoot = join(process.cwd());
 const log = { warn: vi.fn() };
@@ -62,6 +65,14 @@ const authority: ProviderPublicationAuthority = {
 	identityGeneration: 9,
 };
 
+const tautulliAuthority: ProviderPublicationAuthority = {
+	...authority,
+	id: "tautulli-1",
+	service: "TAUTULLI",
+	baseUrl: "https://tautulli.invalid",
+	expectedIdentity: "plex-machine-a",
+};
+
 type StatusGenerations = {
 	connectionGeneration: number | null;
 	identityGeneration: number | null;
@@ -107,6 +118,100 @@ async function seedObsoleteStatus(
 }
 
 describe("provider cache status SQLite takeover contract", () => {
+	it("keeps overlap A unavailable, publishes B, and prevents A from finishing over B", async () => {
+		const client = await createDatabase();
+		await client.user.create({
+			data: { id: tautulliAuthority.userId, username: "tautulli-status", hashedPassword: "hash" },
+		});
+		await client.serviceInstance.create({
+			data: {
+				...tautulliAuthority,
+				label: "Tautulli",
+				identityKind: "TAUTULLI_PMS_IDENTIFIER",
+				identityVerifiedAt: new Date("2026-08-28T10:00:00.000Z"),
+			},
+		});
+
+		const attemptA = await beginProviderCacheRefreshAttempt(client, "tautulli", tautulliAuthority);
+		expect(attemptA).not.toBeNull();
+		await expect(
+			readOwnedTautulliCacheAuthority(client, {
+				userId: tautulliAuthority.userId,
+				instanceId: tautulliAuthority.id,
+			}),
+		).resolves.toMatchObject({ available: false, state: "in_progress" });
+
+		const attemptB = await beginProviderCacheRefreshAttempt(client, "tautulli", tautulliAuthority);
+		expect(attemptB?.resultMarker).not.toBe(attemptA?.resultMarker);
+		const completedAt = new Date();
+		await client.$transaction(async (tx) => {
+			const claimed = await tx.cacheRefreshStatus.updateMany({
+				where: {
+					instanceId: tautulliAuthority.id,
+					cacheType: "tautulli",
+					lastAttemptAt: attemptB!.attemptedAt,
+					lastAttemptResult: attemptB!.resultMarker,
+					connectionGeneration: tautulliAuthority.connectionGeneration,
+					identityGeneration: tautulliAuthority.identityGeneration,
+				},
+				data: {
+					lastRefreshedAt: completedAt,
+					lastResult: "success",
+					lastErrorMessage: null,
+					itemCount: 1,
+					lastAttemptAt: completedAt,
+					lastAttemptResult: "success",
+					lastAttemptErrorMessage: null,
+				},
+			});
+			expect(claimed.count).toBe(1);
+			await tx.tautulliCache.create({
+				data: {
+					instanceId: tautulliAuthority.id,
+					tmdbId: 42,
+					mediaType: "movie",
+					lastWatchedAt: completedAt,
+					watchCount: 3,
+					watchedByUsers: "[]",
+					connectionGeneration: tautulliAuthority.connectionGeneration,
+					identityGeneration: tautulliAuthority.identityGeneration,
+				},
+			});
+		});
+
+		expect(
+			await finishProviderCacheRefreshAttemptFailure(
+				client,
+				"tautulli",
+				"provider_response_invalid",
+				tautulliAuthority,
+				attemptA!,
+				log,
+			),
+		).toBe("superseded");
+		await expect(
+			readOwnedTautulliCacheAuthority(client, {
+				userId: tautulliAuthority.userId,
+				instanceId: tautulliAuthority.id,
+				now: completedAt,
+			}),
+		).resolves.toMatchObject({
+			available: true,
+			state: "healthy_complete",
+			cachedItems: 1,
+		});
+		await expect(
+			client.cacheRefreshStatus.findUniqueOrThrow({
+				where: {
+					instanceId_cacheType: {
+						instanceId: tautulliAuthority.id,
+						cacheType: "tautulli",
+					},
+				},
+			}),
+		).resolves.toMatchObject({ lastResult: "success", lastAttemptResult: "success" });
+	}, 30_000);
+
 	it.each([
 		["plex", "null/null", { connectionGeneration: null, identityGeneration: null }],
 		["plex_episode", "null/null", { connectionGeneration: null, identityGeneration: null }],

--- a/apps/api/src/lib/services/provider-cache-status.test.ts
+++ b/apps/api/src/lib/services/provider-cache-status.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
 	beginPlexCacheRefreshAttempt,
 	classifyProviderCacheStatusGeneration,
+	finishProviderCacheRefreshAttemptFailure,
 	finishPlexCacheRefreshAttemptFailure,
 	recordPlexCacheRefreshFailure,
 	recordWatchProviderCacheRefreshFailure,
@@ -154,6 +155,32 @@ describe("provider cache status generation classifier", () => {
 });
 
 describe("Plex cache refresh attempt lifecycle", () => {
+	it("claims a Tautulli attempt with a bounded non-secret initial reason", async () => {
+		const current = plexSnapshot({
+			id: "tautulli-1",
+			service: "TAUTULLI",
+			expectedIdentity: "tautulli-pms-a",
+		});
+		const state = publicationFixture(current, null);
+
+		const attempt = await beginPlexCacheRefreshAttempt(
+			state.prisma as never,
+			"tautulli" as never,
+			current,
+		);
+
+		expect(attempt?.resultMarker).toMatch(/^in_progress:/);
+		expect(state.tx.cacheRefreshStatus.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				create: expect.objectContaining({
+					cacheType: "tautulli",
+					lastErrorMessage: "refresh_in_progress",
+					lastAttemptResult: attempt?.resultMarker,
+				}),
+			}),
+		);
+	});
+
 	it("creates an unpublished current-generation in-progress status when none exists", async () => {
 		const current = plexSnapshot();
 		const state = publicationFixture(current, null);
@@ -408,6 +435,33 @@ describe("Plex cache refresh attempt lifecycle", () => {
 				lastAttemptErrorMessage: "upstream failed",
 			},
 		});
+	});
+
+	it("redacts non-allowlisted Tautulli failure text before persistence", async () => {
+		const current = plexSnapshot({ id: "tautulli-1", service: "TAUTULLI" });
+		const state = publicationFixture(current, {
+			connectionGeneration: 4,
+			identityGeneration: 9,
+		});
+		const attempt = {
+			attemptedAt: new Date("2026-08-20T12:00:00.000Z"),
+			resultMarker: "in_progress:tautulli-a",
+		};
+
+		await finishProviderCacheRefreshAttemptFailure(
+			state.prisma as never,
+			"tautulli",
+			"https://tautulli.invalid?apikey=secret ratingKey=42",
+			current,
+			attempt,
+			log,
+		);
+
+		expect(state.tx.cacheRefreshStatus.updateMany).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: { lastAttemptResult: "error", lastAttemptErrorMessage: "legacy_error_redacted" },
+			}),
+		);
 	});
 
 	it("cannot overwrite a newer attempt marker with an older failure", async () => {

--- a/apps/api/src/lib/services/provider-cache-status.ts
+++ b/apps/api/src/lib/services/provider-cache-status.ts
@@ -16,15 +16,40 @@ export type WatchProviderCacheRefreshType =
 	| "tautulli";
 export type PlexCacheRefreshType = Extract<WatchProviderCacheRefreshType, "plex" | "plex_episode">;
 
-export type PlexCacheRefreshAttempt = {
+export type ProviderCacheRefreshAttempt = {
 	attemptedAt: Date;
 	resultMarker: string;
 };
+export type PlexCacheRefreshAttempt = ProviderCacheRefreshAttempt;
 
 export type ProviderCacheStatusGenerationRelation =
 	| "current"
 	| "obsolete"
 	| "future-or-inconsistent";
+
+const TAUTULLI_STATUS_REASON_CODES = new Set([
+	"refresh_in_progress",
+	"refresh_failed",
+	"credential_unavailable",
+	"provider_identity_changed",
+	"publication_superseded",
+	"no_supported_libraries",
+	"provider_response_invalid",
+	"legacy_error_redacted",
+	"cache_generation_stale",
+	"cache_rows_stale",
+	"cache_stale",
+	"tautulli_mapping_required",
+	"unknown_failure",
+]);
+
+function boundedProviderStatusMessage(
+	cacheType: WatchProviderCacheRefreshType,
+	message: string,
+): string {
+	if (cacheType !== "tautulli") return message.slice(0, 500);
+	return TAUTULLI_STATUS_REASON_CODES.has(message) ? message : "legacy_error_redacted";
+}
 
 type ProviderCacheStatusGeneration = {
 	connectionGeneration: number | null;
@@ -69,8 +94,24 @@ export async function beginPlexCacheRefreshAttempt(
 	instance: ProviderPublicationAuthority,
 	options: ProviderIdentityGuardOptions = {},
 ): Promise<PlexCacheRefreshAttempt | null> {
+	return await beginProviderCacheRefreshAttempt(prisma, cacheType, instance, options);
+}
+
+export async function beginProviderCacheRefreshAttempt(
+	prisma: Pick<PrismaClient, "$transaction">,
+	cacheType: WatchProviderCacheRefreshType,
+	instance: ProviderPublicationAuthority,
+	options: ProviderIdentityGuardOptions = {},
+): Promise<ProviderCacheRefreshAttempt | null> {
+	if (!supportsCacheType(instance.service, cacheType)) {
+		throw new Error("Provider cache type does not match publication service");
+	}
 	const attemptedAt = new Date();
 	const resultMarker = `in_progress:${randomUUID()}`;
+	const initialFailureMessage =
+		cacheType === "tautulli"
+			? "refresh_in_progress"
+			: "Plex cache refresh has not published a generation";
 	const result = await withCurrentProviderPublicationAuthority(
 		prisma,
 		instance,
@@ -102,7 +143,7 @@ export async function beginPlexCacheRefreshAttempt(
 						data: {
 							lastRefreshedAt: attemptedAt,
 							lastResult: "error",
-							lastErrorMessage: "Plex cache refresh has not published a generation",
+							lastErrorMessage: initialFailureMessage,
 							itemCount: 0,
 							generationId: null,
 							generationMetadata: null,
@@ -123,7 +164,7 @@ export async function beginPlexCacheRefreshAttempt(
 					cacheType,
 					lastRefreshedAt: attemptedAt,
 					lastResult: "error",
-					lastErrorMessage: "Plex cache refresh has not published a generation",
+					lastErrorMessage: initialFailureMessage,
 					itemCount: 0,
 					lastAttemptAt: attemptedAt,
 					lastAttemptResult: resultMarker,
@@ -185,7 +226,30 @@ export async function finishPlexCacheRefreshAttemptFailure(
 	log: Pick<FastifyBaseLogger, "warn">,
 	options: ProviderIdentityGuardOptions = {},
 ): Promise<"recorded" | "superseded" | "failed"> {
+	return await finishProviderCacheRefreshAttemptFailure(
+		prisma,
+		cacheType,
+		message,
+		instance,
+		attempt,
+		log,
+		options,
+	);
+}
+
+export async function finishProviderCacheRefreshAttemptFailure(
+	prisma: Pick<PrismaClient, "$transaction">,
+	cacheType: WatchProviderCacheRefreshType,
+	message: string,
+	instance: ProviderPublicationAuthority,
+	attempt: ProviderCacheRefreshAttempt,
+	log: Pick<FastifyBaseLogger, "warn">,
+	options: ProviderIdentityGuardOptions = {},
+): Promise<"recorded" | "superseded" | "failed"> {
 	try {
+		if (!supportsCacheType(instance.service, cacheType)) {
+			throw new Error("Provider cache type does not match publication service");
+		}
 		const result = await withCurrentProviderPublicationAuthority(
 			prisma,
 			instance,
@@ -201,7 +265,7 @@ export async function finishPlexCacheRefreshAttemptFailure(
 					},
 					data: {
 						lastAttemptResult: "error",
-						lastAttemptErrorMessage: message.slice(0, 500),
+						lastAttemptErrorMessage: boundedProviderStatusMessage(cacheType, message),
 					},
 				});
 				return updated.count === 1;
@@ -210,9 +274,10 @@ export async function finishPlexCacheRefreshAttemptFailure(
 		);
 		return result.matched && result.value ? "recorded" : "superseded";
 	} catch (error) {
+		void error;
 		log.warn(
-			{ err: error, instanceId: instance.id, cacheType },
-			"Failed to finish Plex cache refresh attempt",
+			{ instanceId: instance.id, cacheType, reasonCode: "attempt_status_write_failed" },
+			"Failed to finish provider cache refresh attempt",
 		);
 		return "failed";
 	}
@@ -253,7 +318,7 @@ export async function recordWatchProviderCacheRefreshFailure(
 				});
 				if (status && !hasAuthoritativeProviderCacheGeneration(status, instance)) return false;
 
-				const safeMessage = message.slice(0, 500);
+				const safeMessage = boundedProviderStatusMessage(cacheType, message);
 				await tx.cacheRefreshStatus.upsert({
 					where: { instanceId_cacheType: { instanceId: instance.id, cacheType } },
 					create: {

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
@@ -129,6 +129,9 @@ describe("Tautulli cache authority", () => {
 
 	it("scopes every status and row query through the owned instance relation", async () => {
 		const prisma = {
+			$transaction: vi.fn(
+				async (operation: (tx: unknown) => Promise<unknown>) => await operation(prisma),
+			),
 			serviceInstance: { findFirst: vi.fn().mockResolvedValue(instance) },
 			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue(status) },
 			tautulliCache: { count: vi.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(2) },
@@ -146,20 +149,139 @@ describe("Tautulli cache authority", () => {
 				where: expect.objectContaining({ id: "tautulli-1", userId: "user-1" }),
 			}),
 		);
-		expect(prisma.cacheRefreshStatus.findFirst).toHaveBeenCalledWith({
-			where: {
-				instanceId: "tautulli-1",
-				cacheType: "tautulli",
-				instance: { userId: "user-1" },
-			},
-		});
+		expect(prisma.cacheRefreshStatus.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: {
+					instanceId: "tautulli-1",
+					cacheType: "tautulli",
+					instance: { userId: "user-1" },
+				},
+				select: expect.objectContaining({
+					connectionGeneration: true,
+					identityGeneration: true,
+					lastAttemptResult: true,
+				}),
+			}),
+		);
 		for (const call of prisma.tautulliCache.count.mock.calls) {
 			expect(call[0].where.instance).toEqual({ userId: "user-1" });
 		}
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+			timeout: expect.any(Number),
+		});
+	});
+
+	it("does not combine a pre-claim status with reads after a new attempt claim", async () => {
+		let durableStatus = { ...status };
+		const postClaimSnapshot = {
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(instance) },
+			cacheRefreshStatus: {
+				findFirst: vi.fn(async () => durableStatus),
+			},
+			tautulliCache: { count: vi.fn().mockResolvedValue(2) },
+		};
+		const prisma = {
+			$transaction: vi.fn(async (operation: (tx: typeof postClaimSnapshot) => Promise<unknown>) => {
+				durableStatus = { ...status, lastAttemptResult: "in_progress:new-token" };
+				return await operation(postClaimSnapshot);
+			}),
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(instance) },
+			cacheRefreshStatus: {
+				findFirst: vi.fn(async () => {
+					const observed = durableStatus;
+					durableStatus = { ...status, lastAttemptResult: "in_progress:new-token" };
+					return observed;
+				}),
+			},
+			tautulliCache: { count: vi.fn().mockResolvedValue(2) },
+		};
+
+		await expect(
+			readOwnedTautulliCacheAuthority(prisma as never, {
+				userId: "user-1",
+				instanceId: "tautulli-1",
+				now,
+			}),
+		).resolves.toMatchObject({
+			available: false,
+			state: "in_progress",
+			reasonCodes: ["refresh_in_progress"],
+			cachedItems: null,
+		});
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+			timeout: expect.any(Number),
+		});
+		expect(prisma.serviceInstance.findFirst).not.toHaveBeenCalled();
+		expect(prisma.cacheRefreshStatus.findFirst).not.toHaveBeenCalled();
+		expect(prisma.tautulliCache.count).not.toHaveBeenCalled();
+	});
+
+	it("retries the complete authority snapshot after a transaction conflict", async () => {
+		const postClaimSnapshot = {
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(instance) },
+			cacheRefreshStatus: {
+				findFirst: vi.fn().mockResolvedValue({
+					...status,
+					lastAttemptResult: "in_progress:new-token",
+				}),
+			},
+			tautulliCache: { count: vi.fn().mockResolvedValue(2) },
+		};
+		const transaction = vi
+			.fn()
+			.mockRejectedValueOnce(Object.assign(new Error("transaction conflict"), { code: "P2034" }))
+			.mockImplementationOnce(
+				async (operation: (tx: typeof postClaimSnapshot) => Promise<unknown>) =>
+					await operation(postClaimSnapshot),
+			);
+
+		await expect(
+			readOwnedTautulliCacheAuthority({ $transaction: transaction } as never, {
+				userId: "user-1",
+				instanceId: "tautulli-1",
+				now,
+			}),
+		).resolves.toMatchObject({
+			available: false,
+			state: "in_progress",
+			reasonCodes: ["refresh_in_progress"],
+			cachedItems: null,
+		});
+		expect(transaction).toHaveBeenCalledTimes(2);
+		expect(postClaimSnapshot.serviceInstance.findFirst).toHaveBeenCalledOnce();
+	});
+
+	it("returns bounded unavailable after exhausting authority snapshot retries", async () => {
+		const transaction = vi.fn().mockRejectedValue(
+			Object.assign(new Error("database is locked: secret-provider-path"), {
+				code: "SQLITE_BUSY",
+			}),
+		);
+
+		const result = await readOwnedTautulliCacheAuthority({ $transaction: transaction } as never, {
+			userId: "user-1",
+			instanceId: "tautulli-1",
+			now,
+		});
+
+		expect(result).toEqual({
+			available: false,
+			state: "failed_unavailable",
+			reasonCodes: ["unknown_failure"],
+			cachedItems: null,
+			lastRefreshedAt: null,
+		});
+		expect(JSON.stringify(result)).not.toContain("secret-provider-path");
+		expect(transaction).toHaveBeenCalledTimes(3);
 	});
 
 	it("makes a foreign instance indistinguishable from a missing instance", async () => {
 		const prisma = {
+			$transaction: vi.fn(
+				async (operation: (tx: unknown) => Promise<unknown>) => await operation(prisma),
+			),
 			serviceInstance: { findFirst: vi.fn().mockResolvedValue(null) },
 			cacheRefreshStatus: { findFirst: vi.fn() },
 			tautulliCache: { count: vi.fn() },

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
@@ -1,0 +1,256 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+	evaluateTautulliCacheAuthority,
+	readOwnedTautulliCacheAuthority,
+	readUserSelectedTautulliCache,
+} from "../tautulli-cache-authority.js";
+
+const allowedProductionAccess = new Set([
+	path.normalize("src/lib/tautulli/tautulli-cache-authority.ts"),
+	path.normalize("src/lib/tautulli/tautulli-cache-refresher.ts"),
+	path.normalize("src/lib/services/service-identity-lifecycle.ts"),
+]);
+
+async function productionTypeScriptFiles(directory: string): Promise<string[]> {
+	const entries = await readdir(directory, { withFileTypes: true });
+	const files: string[] = [];
+	for (const entry of entries) {
+		const absolute = path.join(directory, entry.name);
+		if (entry.isDirectory()) {
+			if (
+				["__tests__", "fixtures", "generated", "node_modules", "dist", ".next"].includes(entry.name)
+			) {
+				continue;
+			}
+			files.push(...(await productionTypeScriptFiles(absolute)));
+			continue;
+		}
+		if (!entry.name.endsWith(".ts") || entry.name.endsWith(".test.ts")) continue;
+		files.push(absolute);
+	}
+	return files;
+}
+
+const now = new Date("2026-08-28T12:00:00.000Z");
+const instance = {
+	id: "tautulli-1",
+	userId: "user-1",
+	service: "TAUTULLI",
+	enabled: true,
+	expectedIdentity: "pms-a",
+	identityStatus: "VERIFIED",
+	connectionGeneration: 4,
+	identityGeneration: 9,
+};
+const status = {
+	lastRefreshedAt: new Date("2026-08-28T11:00:00.000Z"),
+	lastResult: "success",
+	lastErrorMessage: null,
+	itemCount: 2,
+	lastAttemptAt: new Date("2026-08-28T11:00:00.000Z"),
+	lastAttemptResult: "success",
+	lastAttemptErrorMessage: null,
+	connectionGeneration: 4,
+	identityGeneration: 9,
+};
+
+describe("Tautulli cache authority", () => {
+	it("recognizes only a fresh complete exact-generation publication", () => {
+		expect(
+			evaluateTautulliCacheAuthority(instance, status, { total: 2, exact: 2 }, { now }),
+		).toEqual(
+			expect.objectContaining({
+				available: true,
+				state: "healthy_complete",
+				reasonCodes: [],
+				cachedItems: 2,
+			}),
+		);
+	});
+
+	it.each([
+		["disabled", { instance: { enabled: false }, reason: "instance_disabled" }],
+		["unverified", { instance: { identityStatus: "UNVERIFIED" }, reason: "identity_unverified" }],
+		["missing identity", { instance: { expectedIdentity: null }, reason: "identity_unverified" }],
+		["missing status", { status: null, reason: "no_publication", state: "no_publication" }],
+		[
+			"in progress",
+			{
+				status: { lastAttemptResult: "in_progress:new" },
+				reason: "refresh_in_progress",
+				state: "in_progress",
+			},
+		],
+		[
+			"failed attempt",
+			{
+				status: { lastAttemptResult: "error", lastAttemptErrorMessage: "provider leaked text" },
+				reason: "refresh_failed",
+			},
+		],
+		[
+			"stale status generation",
+			{ status: { identityGeneration: 8 }, reason: "cache_generation_stale" },
+		],
+		["mixed row generations", { counts: { total: 2, exact: 1 }, reason: "cache_rows_stale" }],
+		["row count mismatch", { counts: { total: 1, exact: 1 }, reason: "cache_rows_stale" }],
+		[
+			"expired publication",
+			{
+				status: {
+					lastRefreshedAt: new Date("2026-08-27T22:00:00.000Z"),
+					lastAttemptAt: new Date("2026-08-27T22:00:00.000Z"),
+				},
+				reason: "cache_stale",
+			},
+		],
+	] as const)("fails closed for %s", (_label, scenario) => {
+		const scenarioRecord = scenario as {
+			instance?: Partial<typeof instance>;
+			status?: Partial<typeof status> | null;
+			counts?: { total: number; exact: number };
+			reason: string;
+			state?: string;
+		};
+		const evaluated = evaluateTautulliCacheAuthority(
+			{ ...instance, ...(scenarioRecord.instance ?? {}) },
+			scenarioRecord.status === null ? null : { ...status, ...(scenarioRecord.status ?? {}) },
+			scenarioRecord.counts ?? { total: 2, exact: 2 },
+			{ now },
+		);
+		expect(evaluated.available).toBe(false);
+		expect(evaluated.state).toBe(scenarioRecord.state ?? "failed_unavailable");
+		expect(evaluated.reasonCodes).toContain(scenarioRecord.reason);
+		expect(JSON.stringify(evaluated)).not.toContain("provider leaked text");
+	});
+
+	it("scopes every status and row query through the owned instance relation", async () => {
+		const prisma = {
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(instance) },
+			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue(status) },
+			tautulliCache: { count: vi.fn().mockResolvedValueOnce(2).mockResolvedValueOnce(2) },
+		};
+
+		const result = await readOwnedTautulliCacheAuthority(prisma as never, {
+			userId: "user-1",
+			instanceId: "tautulli-1",
+			now,
+		});
+
+		expect(result?.available).toBe(true);
+		expect(prisma.serviceInstance.findFirst).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ id: "tautulli-1", userId: "user-1" }),
+			}),
+		);
+		expect(prisma.cacheRefreshStatus.findFirst).toHaveBeenCalledWith({
+			where: {
+				instanceId: "tautulli-1",
+				cacheType: "tautulli",
+				instance: { userId: "user-1" },
+			},
+		});
+		for (const call of prisma.tautulliCache.count.mock.calls) {
+			expect(call[0].where.instance).toEqual({ userId: "user-1" });
+		}
+	});
+
+	it("makes a foreign instance indistinguishable from a missing instance", async () => {
+		const prisma = {
+			serviceInstance: { findFirst: vi.fn().mockResolvedValue(null) },
+			cacheRefreshStatus: { findFirst: vi.fn() },
+			tautulliCache: { count: vi.fn() },
+		};
+		await expect(
+			readOwnedTautulliCacheAuthority(prisma as never, {
+				userId: "user-2",
+				instanceId: "tautulli-1",
+				now,
+			}),
+		).resolves.toBeNull();
+		expect(prisma.cacheRefreshStatus.findFirst).not.toHaveBeenCalled();
+		expect(prisma.tautulliCache.count).not.toHaveBeenCalled();
+	});
+
+	it("cursor-paginates selected rows with tenant and exact-generation scope on every page", async () => {
+		const rows = [
+			{ id: "row-1", instanceId: "tautulli-1", tmdbId: 1, mediaType: "movie" },
+			{ id: "row-2", instanceId: "tautulli-1", tmdbId: 2, mediaType: "series" },
+		];
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([instance]),
+				findFirst: vi.fn().mockResolvedValue(instance),
+			},
+			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue(status) },
+			tautulliCache: {
+				count: vi.fn().mockResolvedValue(2),
+				findMany: vi.fn().mockResolvedValueOnce([rows[0]]).mockResolvedValueOnce([rows[1]]),
+			},
+		};
+
+		const result = await readUserSelectedTautulliCache(prisma as never, {
+			userId: "user-1",
+			targets: [
+				{ tmdbId: 1, mediaType: "movie" },
+				{ tmdbId: 2, mediaType: "series" },
+			],
+			now,
+			pageSize: 1,
+		});
+
+		expect(result).toMatchObject({ configured: true, available: true, rows });
+		expect(prisma.tautulliCache.findMany).toHaveBeenCalledTimes(2);
+		for (const call of prisma.tautulliCache.findMany.mock.calls) {
+			expect(call[0].where).toEqual(
+				expect.objectContaining({
+					instance: { userId: "user-1" },
+					instanceId: "tautulli-1",
+					connectionGeneration: 4,
+					identityGeneration: 9,
+				}),
+			);
+		}
+	});
+
+	it("quarantines ambiguous multiple Tautulli sources before any row read", async () => {
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([instance, { ...instance, id: "tautulli-2" }]),
+			},
+			tautulliCache: { findMany: vi.fn() },
+		};
+		await expect(
+			readUserSelectedTautulliCache(prisma as never, {
+				userId: "user-1",
+				targets: [{ tmdbId: 1, mediaType: "movie" }],
+			}),
+		).resolves.toMatchObject({
+			configured: true,
+			available: false,
+			reasonCodes: ["tautulli_mapping_required"],
+			rows: [],
+		});
+		expect(prisma.tautulliCache.findMany).not.toHaveBeenCalled();
+	});
+
+	it("keeps every production Prisma access behind publication, lifecycle, or currentness", async () => {
+		const sourceRoot = path.resolve(process.cwd(), "src");
+		const bypasses: string[] = [];
+		for (const file of await productionTypeScriptFiles(sourceRoot)) {
+			const relative = path.normalize(path.relative(process.cwd(), file));
+			if (allowedProductionAccess.has(relative)) continue;
+			const source = await readFile(file, "utf8");
+			for (const [index, line] of source.split("\n").entries()) {
+				if (/\.tautulliCache\s*(?:\?\.|\.)/.test(line)) {
+					bypasses.push(`${relative}:${index + 1}: ${line.trim()}`);
+				}
+			}
+		}
+		expect(bypasses, `Direct production Tautulli cache access:\n${bypasses.join("\n")}`).toEqual(
+			[],
+		);
+	});
+});

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-authority.test.ts
@@ -123,6 +123,7 @@ describe("Tautulli cache authority", () => {
 		expect(evaluated.available).toBe(false);
 		expect(evaluated.state).toBe(scenarioRecord.state ?? "failed_unavailable");
 		expect(evaluated.reasonCodes).toContain(scenarioRecord.reason);
+		expect(evaluated.cachedItems).toBeNull();
 		expect(JSON.stringify(evaluated)).not.toContain("provider leaked text");
 	});
 
@@ -175,30 +176,39 @@ describe("Tautulli cache authority", () => {
 	});
 
 	it("cursor-paginates selected rows with tenant and exact-generation scope on every page", async () => {
-		const rows = [
-			{ id: "row-1", instanceId: "tautulli-1", tmdbId: 1, mediaType: "movie" },
-			{ id: "row-2", instanceId: "tautulli-1", tmdbId: 2, mediaType: "series" },
-		];
+		const rows = Array.from({ length: 101 }, (_, index) => ({
+			id: `row-${String(index + 1).padStart(3, "0")}`,
+			instanceId: "tautulli-1",
+			tmdbId: index + 1,
+			mediaType: index % 2 === 0 ? "movie" : "series",
+		}));
 		const prisma = {
+			$transaction: vi.fn(
+				async (operation: (tx: unknown) => Promise<unknown>) => await operation(prisma),
+			),
 			serviceInstance: {
 				findMany: vi.fn().mockResolvedValue([instance]),
 				findFirst: vi.fn().mockResolvedValue(instance),
 			},
-			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue(status) },
+			cacheRefreshStatus: {
+				findFirst: vi.fn().mockResolvedValue({ ...status, itemCount: rows.length }),
+			},
 			tautulliCache: {
-				count: vi.fn().mockResolvedValue(2),
-				findMany: vi.fn().mockResolvedValueOnce([rows[0]]).mockResolvedValueOnce([rows[1]]),
+				count: vi.fn().mockResolvedValue(rows.length),
+				findMany: vi
+					.fn()
+					.mockResolvedValueOnce(rows.slice(0, 100))
+					.mockResolvedValueOnce(rows.slice(100)),
 			},
 		};
 
 		const result = await readUserSelectedTautulliCache(prisma as never, {
 			userId: "user-1",
-			targets: [
-				{ tmdbId: 1, mediaType: "movie" },
-				{ tmdbId: 2, mediaType: "series" },
-			],
+			targets: rows.map((row) => ({
+				tmdbId: row.tmdbId,
+				mediaType: row.mediaType as "movie" | "series",
+			})),
 			now,
-			pageSize: 1,
 		});
 
 		expect(result).toMatchObject({ configured: true, available: true, rows });
@@ -213,10 +223,74 @@ describe("Tautulli cache authority", () => {
 				}),
 			);
 		}
+		expect(prisma.tautulliCache.findMany.mock.calls.map(([query]) => query.take)).toEqual([
+			100, 100,
+		]);
+	});
+
+	it("keeps lifecycle clearing between validation and row loading inside one Serializable snapshot", async () => {
+		const selectedRow = {
+			id: "row-1",
+			instanceId: "tautulli-1",
+			tmdbId: 1,
+			mediaType: "movie",
+			lastWatchedAt: now,
+			watchCount: 2,
+			watchedByUsers: "[]",
+		};
+		const snapshotPrisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([instance]),
+				findFirst: vi.fn().mockResolvedValue(instance),
+			},
+			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue({ ...status, itemCount: 1 }) },
+			tautulliCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([selectedRow]),
+			},
+		};
+		const prisma = {
+			$transaction: vi.fn(
+				async (operation: (tx: typeof snapshotPrisma) => Promise<unknown>) =>
+					await operation(snapshotPrisma),
+			),
+			// These root delegates model the mixed split-read result after the
+			// lifecycle reset clears status and rows between validation and use.
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([instance]),
+				findFirst: vi.fn().mockResolvedValue(instance),
+			},
+			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue({ ...status, itemCount: 1 }) },
+			tautulliCache: {
+				count: vi.fn().mockResolvedValue(1),
+				findMany: vi.fn().mockResolvedValue([]),
+			},
+		};
+
+		await expect(
+			readUserSelectedTautulliCache(prisma as never, {
+				userId: "user-1",
+				targets: [{ tmdbId: 1, mediaType: "movie" }],
+				now,
+			}),
+		).resolves.toMatchObject({
+			configured: true,
+			available: true,
+			reasonCodes: [],
+			rows: [selectedRow],
+		});
+		expect(prisma.$transaction).toHaveBeenCalledWith(expect.any(Function), {
+			isolationLevel: "Serializable",
+			timeout: expect.any(Number),
+		});
+		expect(prisma.serviceInstance.findMany).not.toHaveBeenCalled();
 	});
 
 	it("quarantines ambiguous multiple Tautulli sources before any row read", async () => {
 		const prisma = {
+			$transaction: vi.fn(
+				async (operation: (tx: unknown) => Promise<unknown>) => await operation(prisma),
+			),
 			serviceInstance: {
 				findMany: vi.fn().mockResolvedValue([instance, { ...instance, id: "tautulli-2" }]),
 			},
@@ -234,6 +308,88 @@ describe("Tautulli cache authority", () => {
 			rows: [],
 		});
 		expect(prisma.tautulliCache.findMany).not.toHaveBeenCalled();
+	});
+
+	it("retries the complete Serializable snapshot after a transaction conflict", async () => {
+		const postResetSnapshot = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([{ ...instance, connectionGeneration: 5 }]),
+				findFirst: vi.fn().mockResolvedValue({ ...instance, connectionGeneration: 5 }),
+			},
+			cacheRefreshStatus: { findFirst: vi.fn().mockResolvedValue(null) },
+			tautulliCache: { count: vi.fn().mockResolvedValue(0), findMany: vi.fn() },
+		};
+		const transaction = vi
+			.fn()
+			.mockRejectedValueOnce(
+				Object.assign(new Error("transaction conflict"), {
+					code: "P2010",
+					meta: { driverAdapterError: { cause: { originalCode: "40001" } } },
+				}),
+			)
+			.mockImplementationOnce(
+				async (operation: (tx: typeof postResetSnapshot) => Promise<unknown>) =>
+					await operation(postResetSnapshot),
+			);
+
+		await expect(
+			readUserSelectedTautulliCache({ $transaction: transaction } as never, {
+				userId: "user-1",
+				targets: [{ tmdbId: 1, mediaType: "movie" }],
+				now,
+			}),
+		).resolves.toMatchObject({
+			configured: true,
+			available: false,
+			reasonCodes: ["no_publication"],
+			rows: [],
+		});
+		expect(transaction).toHaveBeenCalledTimes(2);
+		expect(postResetSnapshot.serviceInstance.findMany).toHaveBeenCalledOnce();
+	});
+
+	it("returns bounded unavailable after exhausting transaction retries", async () => {
+		const transaction = vi.fn().mockRejectedValue(
+			Object.assign(new Error("database is locked: secret-provider-path"), {
+				code: "SQLITE_BUSY",
+			}),
+		);
+
+		const result = await readUserSelectedTautulliCache({ $transaction: transaction } as never, {
+			userId: "user-1",
+			targets: [{ tmdbId: 1, mediaType: "movie" }],
+			now,
+		});
+
+		expect(result).toEqual({
+			configured: true,
+			available: false,
+			reasonCodes: ["unknown_failure"],
+			rows: [],
+		});
+		expect(JSON.stringify(result)).not.toContain("secret-provider-path");
+		expect(transaction).toHaveBeenCalledTimes(3);
+	});
+
+	it("rejects an oversized selection before opening a transaction", async () => {
+		const transaction = vi.fn();
+		const targets = Array.from({ length: 201 }, (_, index) => ({
+			tmdbId: index + 1,
+			mediaType: "movie" as const,
+		}));
+
+		await expect(
+			readUserSelectedTautulliCache({ $transaction: transaction } as never, {
+				userId: "user-1",
+				targets,
+			}),
+		).resolves.toEqual({
+			configured: true,
+			available: false,
+			reasonCodes: ["unknown_failure"],
+			rows: [],
+		});
+		expect(transaction).not.toHaveBeenCalled();
 	});
 
 	it("keeps every production Prisma access behind publication, lifecycle, or currentness", async () => {

--- a/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
+++ b/apps/api/src/lib/tautulli/__tests__/tautulli-cache-refresher.test.ts
@@ -10,6 +10,16 @@ import {
 import type { TautulliClient } from "../tautulli-client.js";
 
 const publication = vi.hoisted(() => ({ client: undefined as TautulliClient | undefined }));
+const attemptLifecycle = vi.hoisted(() => ({
+	begin: vi.fn(),
+	finishFailure: vi.fn(),
+}));
+
+vi.mock("../../services/provider-cache-status.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../../services/provider-cache-status.js")>()),
+	beginProviderCacheRefreshAttempt: attemptLifecycle.begin,
+	finishProviderCacheRefreshAttemptFailure: attemptLifecycle.finishFailure,
+}));
 
 vi.mock("../tautulli-client.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("../tautulli-client.js")>();
@@ -77,6 +87,10 @@ async function refreshTautulliCache(
 			identityGeneration: 2,
 		},
 		log,
+		attempt: {
+			attemptedAt: new Date("2026-08-28T12:00:00.000Z"),
+			resultMarker: "in_progress:test-publication",
+		},
 	});
 }
 
@@ -100,6 +114,63 @@ const silentLog = {
 // ---------------------------------------------------------------------------
 
 describe("refreshTautulliCache (end-to-end)", () => {
+	it("owns the durable attempt before decrypting credentials and records only a bounded failure", async () => {
+		const events: string[] = [];
+		attemptLifecycle.begin.mockImplementationOnce(async () => {
+			events.push("attempt");
+			return {
+				attemptedAt: new Date("2026-08-28T12:00:00.000Z"),
+				resultMarker: "in_progress:test-attempt",
+			};
+		});
+		attemptLifecycle.finishFailure.mockImplementationOnce(async () => {
+			events.push("failure");
+			return "recorded";
+		});
+		const encryptor = {
+			decrypt: vi.fn(() => {
+				events.push("decrypt");
+				throw new Error("secret token decrypt failure");
+			}),
+		};
+		const module = (await import("../tautulli-cache-refresher.js")) as unknown as {
+			refreshOwnedTautulliCache: (input: Record<string, unknown>) => Promise<unknown>;
+		};
+
+		await module.refreshOwnedTautulliCache({
+			prisma: {},
+			encryptor,
+			instance: {
+				id: "tautulli-1",
+				userId: "user-1",
+				service: "TAUTULLI",
+				baseUrl: "https://tautulli.invalid",
+				enabled: true,
+				encryptedApiKey: "ciphertext",
+				encryptionIv: "iv",
+				encryptedHttpAuthCredentials: null,
+				httpAuthEncryptionIv: null,
+				expectedIdentity: "tautulli-pms-a",
+				identityStatus: "VERIFIED",
+				connectionGeneration: 4,
+				identityGeneration: 9,
+			},
+			log: silentLog,
+		});
+
+		expect(events).toEqual(["attempt", "decrypt", "failure"]);
+		expect(attemptLifecycle.finishFailure).toHaveBeenCalledWith(
+			expect.anything(),
+			"tautulli",
+			"credential_unavailable",
+			expect.objectContaining({ id: "tautulli-1" }),
+			expect.objectContaining({ resultMarker: "in_progress:test-attempt" }),
+			silentLog,
+			expect.anything(),
+		);
+		expect(JSON.stringify(attemptLifecycle.finishFailure.mock.calls)).not.toContain("secret token");
+	});
+
 	it("large stale-tail regression: refresh succeeds with only bounded DELETEs", async () => {
 		// Models the real failure mode: a cache that accumulated many rows over
 		// previous refreshes, where one refresh returns a smaller fresh set. The
@@ -155,7 +226,7 @@ describe("refreshTautulliCache (end-to-end)", () => {
 					return { count: data.length };
 				}),
 			},
-			cacheRefreshStatus: { upsert: vi.fn().mockResolvedValue({}) },
+			cacheRefreshStatus: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
 		};
 
 		const mockPrisma = {
@@ -181,10 +252,10 @@ describe("refreshTautulliCache (end-to-end)", () => {
 		expect(publishedRows[0]).toEqual(
 			expect.objectContaining({ connectionGeneration: 4, identityGeneration: 2 }),
 		);
-		expect(tx.cacheRefreshStatus.upsert).toHaveBeenCalledWith(
+		expect(tx.cacheRefreshStatus.updateMany).toHaveBeenCalledWith(
 			expect.objectContaining({
-				create: expect.objectContaining({ connectionGeneration: 4, identityGeneration: 2 }),
-				update: expect.objectContaining({ connectionGeneration: 4, identityGeneration: 2 }),
+				where: expect.objectContaining({ connectionGeneration: 4, identityGeneration: 2 }),
+				data: expect.objectContaining({ lastResult: "success", lastAttemptResult: "success" }),
 			}),
 		);
 	});
@@ -239,7 +310,7 @@ describe("refreshTautulliCache (end-to-end)", () => {
 		);
 
 		expect(result.errors).toBe(1);
-		expect(result.errorMessages).toContain("Tautulli metadata inventory exceeded 500 unique items");
+		expect(result.errorMessages).toContain("provider_response_invalid");
 		expect(mockClient.getMetadata).toHaveBeenCalledTimes(500);
 		expect(result.upserted).toBe(0);
 	});
@@ -261,7 +332,7 @@ describe("refreshTautulliCache (end-to-end)", () => {
 		const deleteMany = vi.fn().mockResolvedValue({ count: 2 });
 		const tx = {
 			tautulliCache: { deleteMany, createMany: vi.fn() },
-			cacheRefreshStatus: { upsert: vi.fn().mockResolvedValue({}) },
+			cacheRefreshStatus: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
 		};
 		const prisma = {
 			$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
@@ -450,13 +521,13 @@ describe("refreshTautulliCache — sparse metadata handling (#497)", () => {
 		expect(result.errors).toBe(1);
 		expect(result.complete).toBe(false);
 		expect(result.errorMessages).toHaveLength(1);
-		expect(result.errorMessages[0]).toContain("rk-error");
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 
 		// The crucial regression assertion: the empty-metadata item must NOT
 		// produce a "failed to fetch metadata for item" warning. Before the fix,
 		// it would — one warning per missing rating_key, flooding the operator
 		// dashboards. With the schema tolerant of sparse responses, only the
-		// genuine ECONNREFUSED logs a warning.
+		// genuine failure logs one bounded warning without the rating key or raw error.
 		const metadataWarnings = (
 			log.warn as unknown as { mock: { calls: unknown[][] } }
 		).mock.calls.filter((call) => {
@@ -464,8 +535,8 @@ describe("refreshTautulliCache — sparse metadata handling (#497)", () => {
 			return typeof msg === "string" && msg.includes("failed to fetch metadata");
 		});
 		expect(metadataWarnings).toHaveLength(1);
-		const errCallArg = metadataWarnings[0]?.[0] as { ratingKey?: string } | undefined;
-		expect(errCallArg?.ratingKey).toBe("rk-error");
+		expect(JSON.stringify(metadataWarnings)).not.toContain("rk-error");
+		expect(JSON.stringify(metadataWarnings)).not.toContain("ECONNREFUSED");
 	});
 });
 
@@ -511,7 +582,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 					return { count: data.length };
 				}),
 			},
-			cacheRefreshStatus: { upsert: vi.fn().mockResolvedValue({}) },
+			cacheRefreshStatus: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
 		};
 		const prisma = {
 			$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
@@ -564,7 +635,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/exceeding the safe 100000-row refresh limit/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(getHistory).toHaveBeenCalledOnce();
 		expect(mockClient.getMetadata).not.toHaveBeenCalled();
 		expect(prisma.$transaction).not.toHaveBeenCalled();
@@ -637,7 +708,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/100001 aggregate rows/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(getHistory).toHaveBeenCalledTimes(2);
 		expect(mockClient.getMetadata).not.toHaveBeenCalled();
 		expect(prisma.$transaction).not.toHaveBeenCalled();
@@ -692,7 +763,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/changed before the snapshot/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 		expect(getHistory).toHaveBeenNthCalledWith(1, expect.objectContaining({ order_dir: "asc" }));
 		expect(getHistory).toHaveBeenNthCalledWith(2, {
@@ -737,7 +808,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/changed before the snapshot/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(getHistory).toHaveBeenCalledTimes(2);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
@@ -782,7 +853,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/changed before the snapshot/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(getHistory).toHaveBeenCalledTimes(2);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
@@ -844,7 +915,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 					return { count: data.length };
 				}),
 			},
-			cacheRefreshStatus: { upsert: vi.fn().mockResolvedValue({}) },
+			cacheRefreshStatus: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
 		};
 		const prisma = {
 			$transaction: vi.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) =>
@@ -894,7 +965,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/grouped play rows/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
 
@@ -929,7 +1000,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/stable row ordering/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});
 
@@ -971,7 +1042,7 @@ describe("refreshTautulliCache — authoritative completeness", () => {
 		const result = await refreshTautulliCache(mockClient, prisma, "inst-1", silentLog, undefined);
 
 		expect(result).toMatchObject({ complete: false, upserted: 0 });
-		expect(result.errorMessages.join(" ")).toMatch(/changed before the snapshot/i);
+		expect(result.errorMessages).toEqual(["provider_response_invalid"]);
 		expect(getHistory).toHaveBeenCalledTimes(6);
 		expect(prisma.$transaction).not.toHaveBeenCalled();
 	});

--- a/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
@@ -1,0 +1,297 @@
+import type { PrismaClient, ServiceInstance } from "../prisma.js";
+
+export const TAUTULLI_CACHE_FRESHNESS_MS = 12 * 60 * 60 * 1000;
+
+export type TautulliCacheAuthorityReason =
+	| "no_publication"
+	| "instance_disabled"
+	| "identity_unverified"
+	| "refresh_in_progress"
+	| "refresh_failed"
+	| "credential_unavailable"
+	| "provider_identity_changed"
+	| "publication_superseded"
+	| "no_supported_libraries"
+	| "provider_response_invalid"
+	| "legacy_error_redacted"
+	| "cache_generation_stale"
+	| "cache_rows_stale"
+	| "cache_stale"
+	| "tautulli_mapping_required"
+	| "unknown_failure";
+
+export type TautulliCacheAuthorityState =
+	| "in_progress"
+	| "failed_unavailable"
+	| "healthy_complete"
+	| "no_publication";
+
+export interface TautulliCacheAuthorityProjection {
+	available: boolean;
+	state: TautulliCacheAuthorityState;
+	reasonCodes: TautulliCacheAuthorityReason[];
+	cachedItems: number;
+	lastRefreshedAt: Date | null;
+}
+
+export interface TautulliSelectedCacheRow {
+	id: string;
+	instanceId: string;
+	tmdbId: number;
+	mediaType: string;
+	lastWatchedAt: Date | null;
+	watchCount: number;
+	watchedByUsers: string;
+}
+
+export interface TautulliSelectedCacheResult {
+	configured: boolean;
+	available: boolean;
+	reasonCodes: TautulliCacheAuthorityReason[];
+	rows: TautulliSelectedCacheRow[];
+}
+
+type TautulliAuthorityInstance = {
+	service: string;
+	enabled: boolean;
+	expectedIdentity: string | null;
+	identityStatus: string;
+	connectionGeneration: number;
+	identityGeneration: number;
+};
+
+type TautulliAuthorityStatus = {
+	lastRefreshedAt: Date;
+	lastResult: string;
+	lastErrorMessage: string | null;
+	itemCount: number;
+	lastAttemptAt: Date | null;
+	lastAttemptResult: string | null;
+	lastAttemptErrorMessage: string | null;
+	connectionGeneration: number | null;
+	identityGeneration: number | null;
+};
+
+const PERSISTABLE_REASON_CODES = new Set<TautulliCacheAuthorityReason>([
+	"credential_unavailable",
+	"provider_identity_changed",
+	"publication_superseded",
+	"no_supported_libraries",
+	"provider_response_invalid",
+	"cache_generation_stale",
+	"cache_rows_stale",
+	"cache_stale",
+	"tautulli_mapping_required",
+	"unknown_failure",
+]);
+
+function failed(
+	reasonCodes: TautulliCacheAuthorityReason[],
+	status: TautulliAuthorityStatus | null,
+	state: TautulliCacheAuthorityState = "failed_unavailable",
+): TautulliCacheAuthorityProjection {
+	return {
+		available: false,
+		state,
+		reasonCodes: [...new Set(reasonCodes)],
+		cachedItems: 0,
+		lastRefreshedAt: status?.lastRefreshedAt ?? null,
+	};
+}
+
+function persistedFailureReason(message: string | null): TautulliCacheAuthorityReason {
+	return message && PERSISTABLE_REASON_CODES.has(message as TautulliCacheAuthorityReason)
+		? (message as TautulliCacheAuthorityReason)
+		: "legacy_error_redacted";
+}
+
+export function evaluateTautulliCacheAuthority(
+	instance: TautulliAuthorityInstance,
+	status: TautulliAuthorityStatus | null,
+	counts: { total: number; exact: number },
+	options: { now?: Date; maxAgeMs?: number } = {},
+): TautulliCacheAuthorityProjection {
+	if (instance.service !== "TAUTULLI" || !instance.enabled) {
+		return failed(["instance_disabled"], status);
+	}
+	if (instance.identityStatus !== "VERIFIED" || !instance.expectedIdentity) {
+		return failed(["identity_unverified"], status);
+	}
+	if (!status) return failed(["no_publication"], null, "no_publication");
+	if (status.lastAttemptResult?.startsWith("in_progress:")) {
+		return failed(["refresh_in_progress"], status, "in_progress");
+	}
+	if (
+		status.lastResult !== "success" ||
+		status.lastAttemptResult !== "success" ||
+		status.lastErrorMessage !== null ||
+		status.lastAttemptErrorMessage !== null
+	) {
+		return failed(
+			[
+				"refresh_failed",
+				persistedFailureReason(status.lastAttemptErrorMessage ?? status.lastErrorMessage),
+			],
+			status,
+		);
+	}
+	if (
+		status.connectionGeneration !== instance.connectionGeneration ||
+		status.identityGeneration !== instance.identityGeneration ||
+		status.lastAttemptAt?.getTime() !== status.lastRefreshedAt.getTime()
+	) {
+		return failed(["cache_generation_stale"], status);
+	}
+	if (counts.total !== counts.exact || counts.exact !== status.itemCount) {
+		return failed(["cache_rows_stale"], status);
+	}
+	const now = options.now ?? new Date();
+	const maxAgeMs = options.maxAgeMs ?? TAUTULLI_CACHE_FRESHNESS_MS;
+	if (now.getTime() - status.lastRefreshedAt.getTime() > maxAgeMs) {
+		return failed(["cache_stale"], status);
+	}
+	return {
+		available: true,
+		state: "healthy_complete",
+		reasonCodes: [],
+		cachedItems: counts.exact,
+		lastRefreshedAt: status.lastRefreshedAt,
+	};
+}
+
+export async function readOwnedTautulliCacheAuthority(
+	prisma: PrismaClient,
+	input: { userId: string; instanceId: string; now?: Date },
+): Promise<TautulliCacheAuthorityProjection | null> {
+	const instance = await prisma.serviceInstance.findFirst({
+		where: { id: input.instanceId, userId: input.userId, service: "TAUTULLI" },
+		select: {
+			service: true,
+			enabled: true,
+			expectedIdentity: true,
+			identityStatus: true,
+			connectionGeneration: true,
+			identityGeneration: true,
+		},
+	});
+	if (!instance) return null;
+
+	const status = await prisma.cacheRefreshStatus.findFirst({
+		where: {
+			instanceId: input.instanceId,
+			cacheType: "tautulli",
+			instance: { userId: input.userId },
+		},
+	});
+	const baseWhere = {
+		instanceId: input.instanceId,
+		instance: { userId: input.userId },
+	};
+	const [total, exact] = await Promise.all([
+		prisma.tautulliCache.count({ where: baseWhere }),
+		prisma.tautulliCache.count({
+			where: {
+				...baseWhere,
+				connectionGeneration: instance.connectionGeneration,
+				identityGeneration: instance.identityGeneration,
+			},
+		}),
+	]);
+	return evaluateTautulliCacheAuthority(instance, status, { total, exact }, { now: input.now });
+}
+
+export async function findOwnedEnabledTautulliInstance(
+	prisma: PrismaClient,
+	input: { userId: string; instanceId: string },
+): Promise<ServiceInstance | null> {
+	return await prisma.serviceInstance.findFirst({
+		where: {
+			id: input.instanceId,
+			userId: input.userId,
+			service: "TAUTULLI",
+			enabled: true,
+		},
+	});
+}
+
+export async function readUserSelectedTautulliCache(
+	prisma: PrismaClient,
+	input: {
+		userId: string;
+		targets: Array<{ tmdbId: number; mediaType: "movie" | "series" }>;
+		now?: Date;
+		pageSize?: number;
+	},
+): Promise<TautulliSelectedCacheResult> {
+	const instances = await prisma.serviceInstance.findMany({
+		where: { userId: input.userId, service: "TAUTULLI", enabled: true },
+		select: {
+			id: true,
+			connectionGeneration: true,
+			identityGeneration: true,
+		},
+	});
+	if (instances.length === 0) {
+		return { configured: false, available: true, reasonCodes: [], rows: [] };
+	}
+	if (instances.length !== 1) {
+		return {
+			configured: true,
+			available: false,
+			reasonCodes: ["tautulli_mapping_required"],
+			rows: [],
+		};
+	}
+	const instance = instances[0]!;
+	const authority = await readOwnedTautulliCacheAuthority(prisma, {
+		userId: input.userId,
+		instanceId: instance.id,
+		now: input.now,
+	});
+	if (!authority?.available) {
+		return {
+			configured: true,
+			available: false,
+			reasonCodes: authority?.reasonCodes ?? ["no_publication"],
+			rows: [],
+		};
+	}
+	if (input.targets.length === 0) {
+		return { configured: true, available: true, reasonCodes: [], rows: [] };
+	}
+
+	const pageSize = Math.max(1, Math.min(input.pageSize ?? 500, 500));
+	const rows: TautulliSelectedCacheRow[] = [];
+	let cursor: string | undefined;
+	while (rows.length < input.targets.length) {
+		const page = await prisma.tautulliCache.findMany({
+			where: {
+				instanceId: instance.id,
+				instance: { userId: input.userId },
+				connectionGeneration: instance.connectionGeneration,
+				identityGeneration: instance.identityGeneration,
+				OR: input.targets.map((target) => ({
+					tmdbId: target.tmdbId,
+					mediaType: target.mediaType,
+				})),
+			},
+			select: {
+				id: true,
+				instanceId: true,
+				tmdbId: true,
+				mediaType: true,
+				lastWatchedAt: true,
+				watchCount: true,
+				watchedByUsers: true,
+			},
+			take: pageSize,
+			...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
+			orderBy: { id: "asc" },
+		});
+		if (page.length === 0) break;
+		rows.push(...page);
+		cursor = page[page.length - 1]!.id;
+		if (page.length < pageSize) break;
+	}
+	return { configured: true, available: true, reasonCodes: [], rows };
+}

--- a/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
@@ -1,6 +1,12 @@
-import type { PrismaClient, ServiceInstance } from "../prisma.js";
+import type { Prisma, PrismaClient, ServiceInstance } from "../prisma.js";
 
 export const TAUTULLI_CACHE_FRESHNESS_MS = 12 * 60 * 60 * 1000;
+const TAUTULLI_SELECTED_CACHE_PAGE_SIZE = 100;
+const TAUTULLI_SELECTED_CACHE_MAX_ROWS = 200;
+const TAUTULLI_SELECTED_CACHE_MAX_PAGES = 2;
+const TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS = 3;
+const TAUTULLI_SELECTED_CACHE_TRANSACTION_TIMEOUT_MS = 10_000;
+const TAUTULLI_SELECTED_CACHE_RETRY_DELAY_MS = 15;
 
 export type TautulliCacheAuthorityReason =
 	| "no_publication"
@@ -30,7 +36,7 @@ export interface TautulliCacheAuthorityProjection {
 	available: boolean;
 	state: TautulliCacheAuthorityState;
 	reasonCodes: TautulliCacheAuthorityReason[];
-	cachedItems: number;
+	cachedItems: number | null;
 	lastRefreshedAt: Date | null;
 }
 
@@ -72,6 +78,11 @@ type TautulliAuthorityStatus = {
 	identityGeneration: number | null;
 };
 
+type TautulliAuthorityReader = Pick<
+	Prisma.TransactionClient,
+	"serviceInstance" | "cacheRefreshStatus" | "tautulliCache"
+>;
+
 const PERSISTABLE_REASON_CODES = new Set<TautulliCacheAuthorityReason>([
 	"credential_unavailable",
 	"provider_identity_changed",
@@ -94,7 +105,7 @@ function failed(
 		available: false,
 		state,
 		reasonCodes: [...new Set(reasonCodes)],
-		cachedItems: 0,
+		cachedItems: null,
 		lastRefreshedAt: status?.lastRefreshedAt ?? null,
 	};
 }
@@ -160,7 +171,7 @@ export function evaluateTautulliCacheAuthority(
 }
 
 export async function readOwnedTautulliCacheAuthority(
-	prisma: PrismaClient,
+	prisma: TautulliAuthorityReader,
 	input: { userId: string; instanceId: string; now?: Date },
 ): Promise<TautulliCacheAuthorityProjection | null> {
 	const instance = await prisma.serviceInstance.findFirst({
@@ -215,12 +226,56 @@ export async function findOwnedEnabledTautulliInstance(
 }
 
 export async function readUserSelectedTautulliCache(
-	prisma: PrismaClient,
+	prisma: Pick<PrismaClient, "$transaction">,
 	input: {
 		userId: string;
 		targets: Array<{ tmdbId: number; mediaType: "movie" | "series" }>;
 		now?: Date;
-		pageSize?: number;
+	},
+): Promise<TautulliSelectedCacheResult> {
+	const targets = [
+		...new Map(
+			input.targets.map((target) => [`${target.mediaType}:${target.tmdbId}`, target]),
+		).values(),
+	];
+	if (targets.length > TAUTULLI_SELECTED_CACHE_MAX_ROWS) {
+		return unavailableSelectedTautulliCache();
+	}
+
+	for (let attempt = 1; attempt <= TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS; attempt++) {
+		try {
+			return await prisma.$transaction(
+				async (tx) =>
+					await readUserSelectedTautulliCacheSnapshot(tx, {
+						...input,
+						targets,
+					}),
+				{
+					isolationLevel: "Serializable",
+					timeout: TAUTULLI_SELECTED_CACHE_TRANSACTION_TIMEOUT_MS,
+				},
+			);
+		} catch (error) {
+			if (
+				attempt === TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS ||
+				!isRetryableTautulliReadTransactionError(error)
+			) {
+				return unavailableSelectedTautulliCache();
+			}
+			await new Promise<void>((resolve) =>
+				setTimeout(resolve, attempt * TAUTULLI_SELECTED_CACHE_RETRY_DELAY_MS),
+			);
+		}
+	}
+	return unavailableSelectedTautulliCache();
+}
+
+async function readUserSelectedTautulliCacheSnapshot(
+	prisma: TautulliAuthorityReader,
+	input: {
+		userId: string;
+		targets: Array<{ tmdbId: number; mediaType: "movie" | "series" }>;
+		now?: Date;
 	},
 ): Promise<TautulliSelectedCacheResult> {
 	const instances = await prisma.serviceInstance.findMany({
@@ -260,10 +315,13 @@ export async function readUserSelectedTautulliCache(
 		return { configured: true, available: true, reasonCodes: [], rows: [] };
 	}
 
-	const pageSize = Math.max(1, Math.min(input.pageSize ?? 500, 500));
 	const rows: TautulliSelectedCacheRow[] = [];
 	let cursor: string | undefined;
-	while (rows.length < input.targets.length) {
+	for (
+		let pageNumber = 0;
+		pageNumber < TAUTULLI_SELECTED_CACHE_MAX_PAGES && rows.length < input.targets.length;
+		pageNumber++
+	) {
 		const page = await prisma.tautulliCache.findMany({
 			where: {
 				instanceId: instance.id,
@@ -284,14 +342,52 @@ export async function readUserSelectedTautulliCache(
 				watchCount: true,
 				watchedByUsers: true,
 			},
-			take: pageSize,
+			take: Math.min(
+				TAUTULLI_SELECTED_CACHE_PAGE_SIZE,
+				TAUTULLI_SELECTED_CACHE_MAX_ROWS - rows.length,
+			),
 			...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
 			orderBy: { id: "asc" },
 		});
 		if (page.length === 0) break;
 		rows.push(...page);
 		cursor = page[page.length - 1]!.id;
-		if (page.length < pageSize) break;
+		if (page.length < TAUTULLI_SELECTED_CACHE_PAGE_SIZE) break;
 	}
 	return { configured: true, available: true, reasonCodes: [], rows };
+}
+
+function unavailableSelectedTautulliCache(): TautulliSelectedCacheResult {
+	return {
+		configured: true,
+		available: false,
+		reasonCodes: ["unknown_failure"],
+		rows: [],
+	};
+}
+
+function isRetryableTautulliReadTransactionError(error: unknown): boolean {
+	const pending: unknown[] = [error];
+	const visited = new Set<object>();
+	while (pending.length > 0) {
+		const candidate = pending.pop();
+		if (!candidate || typeof candidate !== "object" || visited.has(candidate)) continue;
+		visited.add(candidate);
+		const record = candidate as Record<string, unknown>;
+		const code = typeof record.code === "string" ? record.code : "";
+		const originalCode = typeof record.originalCode === "string" ? record.originalCode : "";
+		const message = typeof record.message === "string" ? record.message : "";
+		const kind = typeof record.kind === "string" ? record.kind : "";
+		if (
+			code === "P2034" ||
+			code === "SQLITE_BUSY" ||
+			code === "40001" ||
+			originalCode === "40001" ||
+			/serializ|deadlock|database is locked|transactionwriteconflict/i.test(`${kind} ${message}`)
+		) {
+			return true;
+		}
+		pending.push(record.cause, record.meta, record.driverAdapterError);
+	}
+	return false;
 }

--- a/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-authority.ts
@@ -4,9 +4,9 @@ export const TAUTULLI_CACHE_FRESHNESS_MS = 12 * 60 * 60 * 1000;
 const TAUTULLI_SELECTED_CACHE_PAGE_SIZE = 100;
 const TAUTULLI_SELECTED_CACHE_MAX_ROWS = 200;
 const TAUTULLI_SELECTED_CACHE_MAX_PAGES = 2;
-const TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS = 3;
-const TAUTULLI_SELECTED_CACHE_TRANSACTION_TIMEOUT_MS = 10_000;
-const TAUTULLI_SELECTED_CACHE_RETRY_DELAY_MS = 15;
+const TAUTULLI_CACHE_READ_TRANSACTION_ATTEMPTS = 3;
+const TAUTULLI_CACHE_READ_TRANSACTION_TIMEOUT_MS = 10_000;
+const TAUTULLI_CACHE_READ_RETRY_DELAY_MS = 15;
 
 export type TautulliCacheAuthorityReason =
 	| "no_publication"
@@ -171,6 +171,17 @@ export function evaluateTautulliCacheAuthority(
 }
 
 export async function readOwnedTautulliCacheAuthority(
+	prisma: Pick<PrismaClient, "$transaction">,
+	input: { userId: string; instanceId: string; now?: Date },
+): Promise<TautulliCacheAuthorityProjection | null> {
+	return await runBoundedSerializableTautulliRead(
+		prisma,
+		async (tx) => await readOwnedTautulliCacheAuthoritySnapshot(tx, input),
+		() => failed(["unknown_failure"], null),
+	);
+}
+
+async function readOwnedTautulliCacheAuthoritySnapshot(
 	prisma: TautulliAuthorityReader,
 	input: { userId: string; instanceId: string; now?: Date },
 ): Promise<TautulliCacheAuthorityProjection | null> {
@@ -192,6 +203,17 @@ export async function readOwnedTautulliCacheAuthority(
 			instanceId: input.instanceId,
 			cacheType: "tautulli",
 			instance: { userId: input.userId },
+		},
+		select: {
+			lastRefreshedAt: true,
+			lastResult: true,
+			lastErrorMessage: true,
+			itemCount: true,
+			lastAttemptAt: true,
+			lastAttemptResult: true,
+			lastAttemptErrorMessage: true,
+			connectionGeneration: true,
+			identityGeneration: true,
 		},
 	});
 	const baseWhere = {
@@ -242,32 +264,15 @@ export async function readUserSelectedTautulliCache(
 		return unavailableSelectedTautulliCache();
 	}
 
-	for (let attempt = 1; attempt <= TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS; attempt++) {
-		try {
-			return await prisma.$transaction(
-				async (tx) =>
-					await readUserSelectedTautulliCacheSnapshot(tx, {
-						...input,
-						targets,
-					}),
-				{
-					isolationLevel: "Serializable",
-					timeout: TAUTULLI_SELECTED_CACHE_TRANSACTION_TIMEOUT_MS,
-				},
-			);
-		} catch (error) {
-			if (
-				attempt === TAUTULLI_SELECTED_CACHE_TRANSACTION_ATTEMPTS ||
-				!isRetryableTautulliReadTransactionError(error)
-			) {
-				return unavailableSelectedTautulliCache();
-			}
-			await new Promise<void>((resolve) =>
-				setTimeout(resolve, attempt * TAUTULLI_SELECTED_CACHE_RETRY_DELAY_MS),
-			);
-		}
-	}
-	return unavailableSelectedTautulliCache();
+	return await runBoundedSerializableTautulliRead(
+		prisma,
+		async (tx) =>
+			await readUserSelectedTautulliCacheSnapshot(tx, {
+				...input,
+				targets,
+			}),
+		unavailableSelectedTautulliCache,
+	);
 }
 
 async function readUserSelectedTautulliCacheSnapshot(
@@ -298,7 +303,7 @@ async function readUserSelectedTautulliCacheSnapshot(
 		};
 	}
 	const instance = instances[0]!;
-	const authority = await readOwnedTautulliCacheAuthority(prisma, {
+	const authority = await readOwnedTautulliCacheAuthoritySnapshot(prisma, {
 		userId: input.userId,
 		instanceId: instance.id,
 		now: input.now,
@@ -364,6 +369,32 @@ function unavailableSelectedTautulliCache(): TautulliSelectedCacheResult {
 		reasonCodes: ["unknown_failure"],
 		rows: [],
 	};
+}
+
+async function runBoundedSerializableTautulliRead<T>(
+	prisma: Pick<PrismaClient, "$transaction">,
+	operation: (tx: TautulliAuthorityReader) => Promise<T>,
+	unavailable: () => T,
+): Promise<T> {
+	for (let attempt = 1; attempt <= TAUTULLI_CACHE_READ_TRANSACTION_ATTEMPTS; attempt++) {
+		try {
+			return await prisma.$transaction(async (tx) => await operation(tx), {
+				isolationLevel: "Serializable",
+				timeout: TAUTULLI_CACHE_READ_TRANSACTION_TIMEOUT_MS,
+			});
+		} catch (error) {
+			if (
+				attempt === TAUTULLI_CACHE_READ_TRANSACTION_ATTEMPTS ||
+				!isRetryableTautulliReadTransactionError(error)
+			) {
+				return unavailable();
+			}
+			await new Promise<void>((resolve) =>
+				setTimeout(resolve, attempt * TAUTULLI_CACHE_READ_RETRY_DELAY_MS),
+			);
+		}
+	}
+	return unavailable();
 }
 
 function isRetryableTautulliReadTransactionError(error: unknown): boolean {

--- a/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
+++ b/apps/api/src/lib/tautulli/tautulli-cache-refresher.ts
@@ -20,11 +20,16 @@ import { getStoredHttpAuthHeaders } from "../services/http-auth.js";
 import {
 	createProviderPublicationAuthority,
 	type OwnedProviderPublicationSnapshot,
+	type ProviderIdentityGuardOptions,
 	ProviderIdentityGuardError,
 	withGuardedProviderPublication,
 } from "../services/provider-identity-guard.js";
+import {
+	beginProviderCacheRefreshAttempt,
+	finishProviderCacheRefreshAttemptFailure,
+	type ProviderCacheRefreshAttempt,
+} from "../services/provider-cache-status.js";
 import { delay } from "../utils/delay.js";
-import { getErrorMessage } from "../utils/error-message.js";
 import { TautulliClient } from "./tautulli-client.js";
 
 // Tautulli exposes offset/length pagination without a documented page-count
@@ -61,6 +66,15 @@ export interface TautulliPublicationContext {
 	prisma: PrismaClient;
 	instance: OwnedProviderPublicationSnapshot;
 	log: FastifyBaseLogger;
+	attempt: ProviderCacheRefreshAttempt;
+	cleanupRunClaimToken?: string;
+}
+
+export interface OwnedTautulliCacheRefreshContext {
+	prisma: PrismaClient;
+	encryptor: Pick<Encryptor, "decrypt">;
+	instance: ServiceInstance;
+	log: FastifyBaseLogger;
 	cleanupRunClaimToken?: string;
 }
 
@@ -72,6 +86,111 @@ export interface TautulliCacheRefreshResult {
 	completedAt?: Date;
 	superseded?: boolean;
 	snapshot?: TautulliCacheSnapshot;
+}
+
+/**
+ * Own the durable attempt before decrypting credentials or contacting Tautulli.
+ * Every failure exposed from this boundary is a bounded, non-secret reason code.
+ */
+export async function refreshOwnedTautulliCache(
+	context: OwnedTautulliCacheRefreshContext,
+): Promise<TautulliCacheRefreshResult> {
+	const { prisma, encryptor, instance, log } = context;
+	const authority = createProviderPublicationAuthority(instance);
+	const guardOptions: ProviderIdentityGuardOptions = {
+		cleanupRunClaimToken: context.cleanupRunClaimToken,
+	};
+	let attempt: ProviderCacheRefreshAttempt | null = null;
+	try {
+		attempt = await beginProviderCacheRefreshAttempt(prisma, "tautulli", authority, guardOptions);
+		if (!attempt) {
+			return {
+				upserted: 0,
+				errors: 0,
+				errorMessages: ["publication_superseded"],
+				complete: false,
+				superseded: true,
+			};
+		}
+
+		let ownedSnapshot: OwnedProviderPublicationSnapshot;
+		try {
+			ownedSnapshot = createOwnedTautulliPublicationSnapshot(encryptor, instance);
+		} catch {
+			await finishProviderCacheRefreshAttemptFailure(
+				prisma,
+				"tautulli",
+				"credential_unavailable",
+				authority,
+				attempt,
+				log,
+				guardOptions,
+			);
+			return {
+				upserted: 0,
+				errors: 1,
+				errorMessages: ["credential_unavailable"],
+				complete: false,
+			};
+		}
+
+		const result = await refreshTautulliCache({
+			prisma,
+			instance: ownedSnapshot,
+			log,
+			attempt,
+			cleanupRunClaimToken: context.cleanupRunClaimToken,
+		});
+		if (!result.complete && !result.superseded) {
+			await finishProviderCacheRefreshAttemptFailure(
+				prisma,
+				"tautulli",
+				boundedTautulliFailureReason(result.errorMessages),
+				authority,
+				attempt,
+				log,
+				guardOptions,
+			);
+		}
+		return result;
+	} catch {
+		if (attempt) {
+			await finishProviderCacheRefreshAttemptFailure(
+				prisma,
+				"tautulli",
+				"unknown_failure",
+				authority,
+				attempt,
+				log,
+				guardOptions,
+			);
+		}
+		log.warn(
+			{ instanceId: instance.id, reasonCode: "unknown_failure" },
+			"Tautulli cache refresh failed",
+		);
+		return {
+			upserted: 0,
+			errors: 1,
+			errorMessages: ["unknown_failure"],
+			complete: false,
+		};
+	}
+}
+
+const TAUTULLI_REFRESH_FAILURE_REASONS = new Set([
+	"no_supported_libraries",
+	"provider_response_invalid",
+	"provider_identity_changed",
+	"publication_superseded",
+	"unknown_failure",
+]);
+
+function boundedTautulliFailureReason(errorMessages: string[]): string {
+	return (
+		errorMessages.find((message) => TAUTULLI_REFRESH_FAILURE_REASONS.has(message)) ??
+		"provider_response_invalid"
+	);
 }
 
 /**
@@ -121,11 +240,20 @@ export async function refreshTautulliCache(
 					instance.id,
 					log,
 				),
-			async (tx, collected) => await publishTautulliCache(tx, instance, collected),
+			async (tx, collected) => await publishTautulliCache(tx, instance, context.attempt, collected),
 			{ cleanupRunClaimToken: context.cleanupRunClaimToken },
 		);
 	} catch (error) {
-		log.error({ err: error, instanceId: instance.id }, "Tautulli cache publication rejected");
+		log.error(
+			{
+				instanceId: instance.id,
+				reasonCode:
+					error instanceof ProviderIdentityGuardError
+						? "provider_identity_changed"
+						: "unknown_failure",
+			},
+			"Tautulli cache publication rejected",
+		);
 		if (error instanceof ProviderIdentityGuardError && error.code === "PUBLICATION_SUPERSEDED") {
 			return { upserted: 0, errors: 0, errorMessages: [], complete: false, superseded: true };
 		}
@@ -134,8 +262,8 @@ export async function refreshTautulliCache(
 			errors: 1,
 			errorMessages: [
 				error instanceof ProviderIdentityGuardError
-					? error.message
-					: `Atomic cache publication failed: ${getErrorMessage(error)}`,
+					? "provider_identity_changed"
+					: "unknown_failure",
 			],
 			complete: false,
 		};
@@ -145,10 +273,36 @@ export async function refreshTautulliCache(
 async function publishTautulliCache(
 	tx: Prisma.TransactionClient,
 	instance: OwnedProviderPublicationSnapshot,
+	attempt: ProviderCacheRefreshAttempt,
 	collected: TautulliCacheRefreshResult,
 ): Promise<TautulliCacheRefreshResult> {
 	if (!collected.complete || !collected.completedAt || !collected.snapshot) return collected;
 	const rows = collected.snapshot.rows;
+	const claimed = await tx.cacheRefreshStatus.updateMany({
+		where: {
+			instanceId: instance.id,
+			cacheType: "tautulli",
+			lastAttemptAt: attempt.attemptedAt,
+			lastAttemptResult: attempt.resultMarker,
+			connectionGeneration: instance.connectionGeneration,
+			identityGeneration: instance.identityGeneration,
+		},
+		data: {
+			lastRefreshedAt: collected.completedAt,
+			lastResult: "success",
+			lastErrorMessage: null,
+			itemCount: rows.length,
+			lastAttemptAt: collected.completedAt,
+			lastAttemptResult: "success",
+			lastAttemptErrorMessage: null,
+		},
+	});
+	if (claimed.count !== 1) {
+		throw new ProviderIdentityGuardError(
+			"PUBLICATION_SUPERSEDED",
+			"Provider cache publication was superseded by a newer refresh attempt.",
+		);
+	}
 	await tx.tautulliCache.deleteMany({ where: { instanceId: instance.id } });
 	for (let start = 0; start < rows.length; start += TAUTULLI_CACHE_PUBLICATION_CHUNK_SIZE) {
 		await tx.tautulliCache.createMany({
@@ -159,31 +313,6 @@ async function publishTautulliCache(
 			})),
 		});
 	}
-	await tx.cacheRefreshStatus.upsert({
-		where: { instanceId_cacheType: { instanceId: instance.id, cacheType: "tautulli" } },
-		create: {
-			instanceId: instance.id,
-			cacheType: "tautulli",
-			lastRefreshedAt: collected.completedAt,
-			lastResult: "success",
-			itemCount: rows.length,
-			lastAttemptAt: collected.completedAt,
-			lastAttemptResult: "success",
-			connectionGeneration: instance.connectionGeneration,
-			identityGeneration: instance.identityGeneration,
-		},
-		update: {
-			lastRefreshedAt: collected.completedAt,
-			lastResult: "success",
-			lastErrorMessage: null,
-			itemCount: rows.length,
-			lastAttemptAt: collected.completedAt,
-			lastAttemptResult: "success",
-			lastAttemptErrorMessage: null,
-			connectionGeneration: instance.connectionGeneration,
-			identityGeneration: instance.identityGeneration,
-		},
-	});
 	return { ...collected, upserted: rows.length };
 }
 
@@ -206,7 +335,7 @@ export async function collectTautulliCacheLiveEvidence(
 		if (movieAndShowLibs.length === 0) {
 			complete = false;
 			errors++;
-			errorMessages.push("Tautulli returned no movie or show libraries");
+			errorMessages.push("no_supported_libraries");
 			log.warn({ instanceId }, "Tautulli cache refresh: no movie or show libraries discovered");
 		}
 
@@ -477,9 +606,7 @@ export async function collectTautulliCacheLiveEvidence(
 		if (itemMap.size > MAX_METADATA_LOOKUPS) {
 			complete = false;
 			errors++;
-			errorMessages.push(
-				`Tautulli metadata inventory exceeded ${MAX_METADATA_LOOKUPS} unique items`,
-			);
+			errorMessages.push("provider_response_invalid");
 			log.warn(
 				{ limit: MAX_METADATA_LOOKUPS, itemCount: itemMap.size },
 				"Tautulli cache refresh: hit metadata lookup limit",
@@ -504,14 +631,15 @@ export async function collectTautulliCacheLiveEvidence(
 				} else {
 					complete = false;
 				}
-			} catch (error) {
+			} catch {
 				complete = false;
 				errors++;
-				log.warn({ err: error, ratingKey }, "Tautulli cache: failed to fetch metadata for item");
+				log.warn(
+					{ instanceId, reasonCode: "provider_response_invalid" },
+					"Tautulli cache: failed to fetch metadata for item",
+				);
 				if (errorMessages.length < 5) {
-					errorMessages.push(
-						`Failed to fetch metadata for ratingKey ${ratingKey}: ${getErrorMessage(error)}`,
-					);
+					errorMessages.push("provider_response_invalid");
 				}
 			}
 		}
@@ -565,11 +693,14 @@ export async function collectTautulliCacheLiveEvidence(
 			complete: complete && errors === 0,
 			completedAt,
 		};
-	} catch (error) {
+	} catch {
 		complete = false;
-		log.error({ err: error, instanceId }, "Tautulli cache refresh failed");
+		log.error(
+			{ instanceId, reasonCode: "provider_response_invalid" },
+			"Tautulli cache refresh failed",
+		);
 		errors++;
-		errorMessages.push(`Tautulli cache refresh failed: ${getErrorMessage(error)}`);
+		errorMessages.push("provider_response_invalid");
 	}
 
 	return { upserted, errors, errorMessages, complete: false };

--- a/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
+++ b/apps/api/src/plugins/__tests__/tautulli-cache-scheduler.test.ts
@@ -1,63 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	expectPreservedSuccessWithSanitizedDecryptFailure,
-	watchSchedulerDecryptFailureFixture,
-} from "./watch-scheduler-decrypt-failure-fixture.js";
+import { watchSchedulerDecryptFailureFixture } from "./watch-scheduler-decrypt-failure-fixture.js";
 
 const mocks = vi.hoisted(() => ({
-	createSnapshot: vi.fn(),
 	refresh: vi.fn(),
 }));
 
 vi.mock("../../lib/tautulli/tautulli-cache-refresher.js", () => ({
-	createOwnedTautulliPublicationSnapshot: mocks.createSnapshot,
-	refreshTautulliCache: mocks.refresh,
+	refreshOwnedTautulliCache: mocks.refresh,
 }));
 
 import { refreshScheduledTautulliCacheInstance } from "../tautulli-cache-scheduler.js";
 
-const publicationInstance = {
-	id: "tautulli-1",
-	userId: "user-1",
-	service: "TAUTULLI",
-	label: "TAUTULLI",
-	baseUrl: "https://tautulli.example.com",
-	apiKey: "decrypted",
-	httpAuthHeaders: {},
-	enabled: true,
-	encryptedApiKey: "encrypted-secret-token",
-	encryptionIv: "token-iv",
-	encryptedHttpAuthCredentials: "encrypted-proxy-secret",
-	httpAuthEncryptionIv: "proxy-iv",
-	expectedIdentity: "tautulli-server-a",
-	identityStatus: "VERIFIED",
-	connectionGeneration: 4,
-	identityGeneration: 9,
-};
-
 describe("refreshScheduledTautulliCacheInstance", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
-		mocks.createSnapshot.mockReturnValue(publicationInstance);
+		mocks.refresh.mockResolvedValue({
+			complete: true,
+			completedAt: new Date(),
+			upserted: 1,
+			errors: 0,
+			errorMessages: [],
+		});
 	});
 
-	it("records a sanitized failed attempt without replacing the prior success on decrypt failure", async () => {
+	it("delegates credential handling to the attempt-owning refresher", async () => {
 		const state = watchSchedulerDecryptFailureFixture("TAUTULLI");
-		mocks.createSnapshot.mockImplementation(() => {
-			throw new Error("secret-token decrypt failed");
-		});
 
 		await refreshScheduledTautulliCacheInstance(state.app as never, state.instance as never);
 
-		expect(mocks.refresh).not.toHaveBeenCalled();
-		expectPreservedSuccessWithSanitizedDecryptFailure(state);
+		expect(mocks.refresh).toHaveBeenCalledWith({
+			prisma: state.app.prisma,
+			encryptor: state.app.encryptor,
+			instance: state.instance,
+			log: state.app.log,
+		});
 	});
 
-	it("does not record decrypt failure after a concurrent proxy credential change", async () => {
+	it("does not perform a second status write for a bounded credential failure", async () => {
 		const state = watchSchedulerDecryptFailureFixture("TAUTULLI");
-		mocks.createSnapshot.mockImplementation(() => {
-			state.current.encryptedHttpAuthCredentials = "replacement-proxy-ciphertext";
-			throw new Error("proxy-secret decrypt failed");
+		mocks.refresh.mockResolvedValue({
+			complete: false,
+			upserted: 0,
+			errors: 1,
+			errorMessages: ["credential_unavailable"],
 		});
 
 		await refreshScheduledTautulliCacheInstance(state.app as never, state.instance as never);
@@ -80,24 +65,27 @@ describe("refreshScheduledTautulliCacheInstance", () => {
 
 		expect(mocks.refresh).toHaveBeenCalledWith({
 			prisma: state.app.prisma,
-			instance: publicationInstance,
+			encryptor: state.app.encryptor,
+			instance: state.instance,
 			log: state.app.log,
 		});
 		expect(state.tx.cacheRefreshStatus.upsert).not.toHaveBeenCalled();
 	});
 
-	it("records incomplete attempts with the exact publication snapshot", async () => {
+	it("does not persist or log raw provider failure text outside the refresher", async () => {
 		mocks.refresh.mockResolvedValue({
 			complete: false,
 			upserted: 0,
 			errors: 1,
-			errorMessages: ["history failed"],
+			errorMessages: ["provider_response_invalid"],
 		});
 
 		const state = watchSchedulerDecryptFailureFixture("TAUTULLI");
 		await refreshScheduledTautulliCacheInstance(state.app as never, state.instance as never);
 
-		expect(state.status.lastAttemptResult).toBe("error");
-		expect(state.status.lastAttemptErrorMessage).toBe("history failed");
+		expect(state.status.lastAttemptResult).toBe("success");
+		expect(JSON.stringify(state.app.log.info.mock.calls)).not.toContain(
+			"provider_response_invalid",
+		);
 	});
 });

--- a/apps/api/src/plugins/tautulli-cache-scheduler.ts
+++ b/apps/api/src/plugins/tautulli-cache-scheduler.ts
@@ -13,16 +13,7 @@ import type { FastifyInstance } from "fastify";
 import fastifyPlugin from "fastify-plugin";
 import type { ServiceInstance } from "../lib/prisma.js";
 import { JOB_ID } from "../lib/scheduler-registry/job-definitions.js";
-import { recordWatchProviderCacheRefreshFailure } from "../lib/services/provider-cache-status.js";
-import {
-	createProviderPublicationAuthority,
-	type ProviderPublicationAuthority,
-} from "../lib/services/provider-identity-guard.js";
-import {
-	createOwnedTautulliPublicationSnapshot,
-	refreshTautulliCache,
-} from "../lib/tautulli/tautulli-cache-refresher.js";
-import { getErrorMessage } from "../lib/utils/error-message.js";
+import { refreshOwnedTautulliCache } from "../lib/tautulli/tautulli-cache-refresher.js";
 
 const INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const STARTUP_DELAY_MS = 2 * 60_000; // 2 minutes — staggered after plex-cache (30s) to reduce peak memory
@@ -31,60 +22,27 @@ export async function refreshScheduledTautulliCacheInstance(
 	app: Pick<FastifyInstance, "encryptor" | "prisma" | "log">,
 	instance: ServiceInstance,
 ): Promise<void> {
-	const authority = createProviderPublicationAuthority(instance);
-	let publicationInstance: ReturnType<typeof createOwnedTautulliPublicationSnapshot> | undefined;
 	try {
-		publicationInstance = createOwnedTautulliPublicationSnapshot(app.encryptor, instance);
-		const result = await refreshTautulliCache({
+		const result = await refreshOwnedTautulliCache({
 			prisma: app.prisma,
-			instance: publicationInstance,
+			encryptor: app.encryptor,
+			instance,
 			log: app.log,
 		});
 		app.log.info(
-			{ instanceId: instance.id, label: instance.label, ...result },
+			{
+				instanceId: instance.id,
+				complete: result.complete,
+				upserted: result.upserted,
+				errors: result.errors,
+				superseded: result.superseded === true,
+			},
 			"Tautulli cache refresh completed for instance",
 		);
-
-		if ((!result.complete || !result.completedAt) && !result.superseded) {
-			await recordScheduledTautulliFailure(
-				app,
-				publicationInstance,
-				result.errorMessages.slice(0, 3).join("; ").slice(0, 200) ||
-					"Tautulli refresh did not produce a complete generation",
-			);
-		}
-	} catch (err) {
+	} catch {
 		app.log.error(
-			{ err, instanceId: instance.id, label: instance.label },
+			{ instanceId: instance.id, reasonCode: "unknown_failure" },
 			"Tautulli cache refresh failed for instance",
-		);
-		await recordScheduledTautulliFailure(
-			app,
-			publicationInstance ?? authority,
-			publicationInstance
-				? getErrorMessage(err, "Unknown error")
-				: "Provider credentials could not be decrypted.",
-		);
-	}
-}
-
-async function recordScheduledTautulliFailure(
-	app: Pick<FastifyInstance, "prisma" | "log">,
-	publicationInstance: ProviderPublicationAuthority,
-	message: string,
-): Promise<void> {
-	try {
-		await recordWatchProviderCacheRefreshFailure(
-			app.prisma,
-			"tautulli",
-			message,
-			publicationInstance,
-			app.log,
-		);
-	} catch (trackErr) {
-		app.log.warn(
-			{ err: trackErr, instanceId: publicationInstance.id },
-			"Tautulli cache refresh failed to record status",
 		);
 	}
 }

--- a/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-action-e2e-cache.test.ts
@@ -196,9 +196,18 @@ beforeEach(async () => {
 	app.decorate("prisma", {
 		serviceInstance: {
 			findFirst: findPlexInstance,
-			findMany: async () =>
+			findMany: async ({
+				where,
+			}: {
+				where: { service: string; userId: string; enabled: boolean };
+			}) =>
 				cacheStatuses
-					.filter((status) => status.cacheType === "plex")
+					.filter(
+						(status) =>
+							status.instance.service === where.service &&
+							status.instance.enabled === where.enabled &&
+							where.userId === `e2e-cache-user-${userCounter}`,
+					)
 					.map((status) => ({
 						...status.instance,
 						id: status.instanceId,

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -17,11 +17,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const evidenceMocks = vi.hoisted(() => ({
 	loadUserGenerationObservations: vi.fn(),
 	getPublishedEpisodeGenerationObservation: vi.fn(),
+	readOwnedTautulliCacheAuthority: vi.fn(),
 }));
 
 vi.mock("../../lib/plex/plex-evidence-repository.js", () => ({
 	loadUserGenerationObservations: evidenceMocks.loadUserGenerationObservations,
 	getPublishedEpisodeGenerationObservation: evidenceMocks.getPublishedEpisodeGenerationObservation,
+}));
+vi.mock("../../lib/tautulli/tautulli-cache-authority.js", () => ({
+	readOwnedTautulliCacheAuthority: evidenceMocks.readOwnedTautulliCacheAuthority,
 }));
 
 vi.mock("../../lib/pulse/collectors.js", async () => {
@@ -103,6 +107,7 @@ beforeEach(async () => {
 			},
 		}),
 	);
+	evidenceMocks.readOwnedTautulliCacheAuthority.mockResolvedValue(null);
 	app.decorate("prisma", {
 		cacheRefreshStatus: {
 			findMany: findCacheStatuses,
@@ -386,13 +391,21 @@ describe("GET /pulse — cache.refresh action emission", () => {
 
 	it("emits a cache.refresh action on a stale Tautulli cache row", async () => {
 		cacheStatuses = [makeRow({ id: "taut-row", cacheType: "tautulli", instanceId: "inst-taut" })];
+		evidenceMocks.readOwnedTautulliCacheAuthority.mockResolvedValueOnce({
+			available: false,
+			state: "failed_unavailable",
+			reasonCodes: ["cache_stale"],
+			cachedItems: 0,
+			lastRefreshedAt: cacheStatuses[0]!.lastRefreshedAt,
+		});
 
 		const res = await injectAuthenticated("GET", "/pulse");
 		const body = JSON.parse(res.payload);
-		const item = body.items.find((i: { id: string }) => i.id === "cache-stale-taut-row");
+		const item = body.items.find((i: { id: string }) => i.id.includes("taut-row"));
 
 		expect(item.action?.kind).toBe("cache.refresh");
 		expect(item.action?.target).toEqual({ instanceId: "inst-taut", cacheType: "tautulli" });
+		expect(item.detail).toContain("cache_stale");
 	});
 
 	it("does NOT emit an action for unsupported cacheType (plex_episode)", async () => {

--- a/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
+++ b/apps/api/src/routes/__tests__/pulse-cache-staleness.test.ts
@@ -42,6 +42,7 @@ let app: ReturnType<typeof Fastify>;
 let injectAuthenticated: ReturnType<typeof createInjectAuthenticated>;
 let cacheStatuses: CacheStatusRow[];
 let findCacheStatuses: ReturnType<typeof vi.fn>;
+let findTautulliInstances: ReturnType<typeof vi.fn>;
 let userCounter = 0;
 
 type CacheStatusRow = {
@@ -83,6 +84,7 @@ beforeEach(async () => {
 	app = Fastify({ logger: false });
 	setupAuthInjection(app, { id: `user-cache-${userCounter}`, username: "admin" });
 	findCacheStatuses = vi.fn(async () => cacheStatuses.filter((row) => row.instance.enabled));
+	findTautulliInstances = vi.fn().mockResolvedValue([]);
 	evidenceMocks.loadUserGenerationObservations.mockImplementation(async () =>
 		cacheStatuses
 			.filter((row) => row.cacheType === "plex")
@@ -111,6 +113,9 @@ beforeEach(async () => {
 	app.decorate("prisma", {
 		cacheRefreshStatus: {
 			findMany: findCacheStatuses,
+		},
+		serviceInstance: {
+			findMany: findTautulliInstances,
 		},
 	} as unknown as never);
 	await app.register(registerPulseRoutes);
@@ -406,6 +411,44 @@ describe("GET /pulse — cache.refresh action emission", () => {
 		expect(item.action?.kind).toBe("cache.refresh");
 		expect(item.action?.target).toEqual({ instanceId: "inst-taut", cacheType: "tautulli" });
 		expect(item.detail).toContain("cache_stale");
+	});
+
+	it("reports no publication for an enabled owned Tautulli instance without a status row", async () => {
+		cacheStatuses = [];
+		findTautulliInstances.mockResolvedValueOnce([
+			{
+				id: "inst-taut-missing",
+				label: "Home Tautulli",
+				createdAt: new Date("2026-08-28T12:00:00.000Z"),
+			},
+		]);
+		evidenceMocks.readOwnedTautulliCacheAuthority.mockResolvedValueOnce({
+			available: false,
+			state: "no_publication",
+			reasonCodes: ["no_publication"],
+			cachedItems: null,
+			lastRefreshedAt: null,
+		});
+
+		const body = JSON.parse((await injectAuthenticated("GET", "/pulse")).payload);
+		const item = body.items.find(
+			(candidate: { id: string }) => candidate.id === "cache-error-tautulli-inst-taut-missing",
+		);
+
+		expect(findTautulliInstances).toHaveBeenCalledWith({
+			where: { userId: expect.any(String), enabled: true, service: "TAUTULLI" },
+			select: { id: true, label: true, createdAt: true },
+		});
+		expect(item).toMatchObject({
+			severity: "warning",
+			title: "Home Tautulli: Tautulli cache refresh failed",
+			detail: "no_publication",
+			source: "tautulli",
+			action: {
+				kind: "cache.refresh",
+				target: { instanceId: "inst-taut-missing", cacheType: "tautulli" },
+			},
+		});
 	});
 
 	it("does NOT emit an action for unsupported cacheType (plex_episode)", async () => {

--- a/apps/api/src/routes/__tests__/service-lifecycle.test.ts
+++ b/apps/api/src/routes/__tests__/service-lifecycle.test.ts
@@ -443,7 +443,9 @@ describe("Service instance lifecycle", () => {
 		await app?.close();
 	});
 
-	async function createExistingUnverifiedProvider(service: "PLEX" | "JELLYFIN" = "PLEX") {
+	async function createExistingUnverifiedProvider(
+		service: "PLEX" | "JELLYFIN" | "EMBY" | "TAUTULLI" = "PLEX",
+	) {
 		const created = await inject("POST", "/services", {
 			body: {
 				label: "Legacy provider",
@@ -465,12 +467,20 @@ describe("Service instance lifecycle", () => {
 		return id;
 	}
 
-	async function createExistingVerifiedProvider() {
-		const id = await createExistingUnverifiedProvider();
+	async function createExistingVerifiedProvider(
+		service: "PLEX" | "JELLYFIN" | "EMBY" | "TAUTULLI" = "PLEX",
+	) {
+		const id = await createExistingUnverifiedProvider(service);
 		const instance = prisma._instances.get(id);
 		if (!instance) throw new Error("created service fixture is missing");
-		instance.expectedIdentity = "enrolled-plex-machine";
-		instance.identityKind = "PLEX_MACHINE_IDENTIFIER";
+		const identityByService = {
+			PLEX: ["enrolled-plex-machine", "PLEX_MACHINE_IDENTIFIER"],
+			JELLYFIN: ["enrolled-jellyfin-server", "JELLYFIN_SERVER_ID"],
+			EMBY: ["enrolled-emby-server", "EMBY_SERVER_ID"],
+			TAUTULLI: ["enrolled-tautulli-pms", "TAUTULLI_PMS_IDENTIFIER"],
+		} as const;
+		instance.expectedIdentity = identityByService[service][0];
+		instance.identityKind = identityByService[service][1];
 		instance.identityStatus = "VERIFIED";
 		instance.identityGeneration = 3;
 		instance.identityVerifiedAt = new Date("2026-08-15T00:00:00.000Z");
@@ -654,6 +664,97 @@ describe("Service instance lifecycle", () => {
 		expect(prisma._instances.get(id)?.identityVerifiedAt.getTime()).toBeGreaterThan(
 			previouslyVerifiedAt.getTime(),
 		);
+	});
+
+	it("atomically clears Tautulli rows and status when mismatch re-verification advances identity", async () => {
+		const id = await createExistingVerifiedProvider("TAUTULLI");
+		const enrolled = prisma._instances.get(id);
+		if (!enrolled) throw new Error("verified Tautulli fixture is missing");
+		enrolled.identityStatus = "MISMATCH";
+		const observation = {
+			service: "TAUTULLI" as const,
+			identityKind: "tautulli-pms-identifier" as const,
+			rawIdentity: "enrolled-tautulli-pms",
+			fingerprint: "safe-fingerprint",
+			confirmationDigest: "a".repeat(64),
+		};
+		mockReadProviderIdentity.mockResolvedValueOnce(observation).mockResolvedValueOnce(observation);
+
+		const inspected = await inject("POST", `/services/${id}/identity/inspect`, { body: {} });
+		const verified = await inject("POST", `/services/${id}/identity/verify`, {
+			body: {
+				confirmationDigest: JSON.parse(inspected.payload).candidate.confirmationDigest,
+				expectedConnectionGeneration: 0,
+				expectedIdentityGeneration: 3,
+			},
+		});
+
+		expect(verified.statusCode).toBe(200);
+		expect(prisma._instances.get(id)).toMatchObject({
+			identityStatus: "VERIFIED",
+			identityGeneration: 4,
+		});
+		expect(prisma.tautulliCache.deleteMany).toHaveBeenCalledWith({ where: { instanceId: id } });
+		expect(prisma.cacheRefreshStatus.deleteMany).toHaveBeenCalledWith({
+			where: { instanceId: id },
+		});
+	});
+
+	it("preserves current Tautulli state when same-identity verification does not advance", async () => {
+		const id = await createExistingVerifiedProvider("TAUTULLI");
+		const observation = {
+			service: "TAUTULLI" as const,
+			identityKind: "tautulli-pms-identifier" as const,
+			rawIdentity: "enrolled-tautulli-pms",
+			fingerprint: "safe-fingerprint",
+			confirmationDigest: "a".repeat(64),
+		};
+		mockReadProviderIdentity.mockResolvedValueOnce(observation).mockResolvedValueOnce(observation);
+
+		const inspected = await inject("POST", `/services/${id}/identity/inspect`, { body: {} });
+		const verified = await inject("POST", `/services/${id}/identity/verify`, {
+			body: {
+				confirmationDigest: JSON.parse(inspected.payload).candidate.confirmationDigest,
+				expectedConnectionGeneration: 0,
+				expectedIdentityGeneration: 3,
+			},
+		});
+
+		expect(verified.statusCode).toBe(200);
+		expect(prisma._instances.get(id)?.identityGeneration).toBe(3);
+		expect(prisma.tautulliCache.deleteMany).not.toHaveBeenCalled();
+		expect(prisma.cacheRefreshStatus.deleteMany).not.toHaveBeenCalled();
+	});
+
+	it("rolls back Tautulli identity advancement when durable reset fails", async () => {
+		const id = await createExistingVerifiedProvider("TAUTULLI");
+		const enrolled = prisma._instances.get(id);
+		if (!enrolled) throw new Error("verified Tautulli fixture is missing");
+		enrolled.identityStatus = "MISMATCH";
+		const observation = {
+			service: "TAUTULLI" as const,
+			identityKind: "tautulli-pms-identifier" as const,
+			rawIdentity: "enrolled-tautulli-pms",
+			fingerprint: "safe-fingerprint",
+			confirmationDigest: "a".repeat(64),
+		};
+		mockReadProviderIdentity.mockResolvedValueOnce(observation).mockResolvedValueOnce(observation);
+		prisma.tautulliCache.deleteMany.mockRejectedValueOnce(new Error("injected reset failure"));
+
+		const inspected = await inject("POST", `/services/${id}/identity/inspect`, { body: {} });
+		const verified = await inject("POST", `/services/${id}/identity/verify`, {
+			body: {
+				confirmationDigest: JSON.parse(inspected.payload).candidate.confirmationDigest,
+				expectedConnectionGeneration: 0,
+				expectedIdentityGeneration: 3,
+			},
+		});
+
+		expect(verified.statusCode).toBe(500);
+		expect(prisma._instances.get(id)).toMatchObject({
+			identityStatus: "MISMATCH",
+			identityGeneration: 3,
+		});
 	});
 
 	it("rejects verification when the provider changes after inspection", async () => {

--- a/apps/api/src/routes/jellyfin/watch-enrichment-routes.ts
+++ b/apps/api/src/routes/jellyfin/watch-enrichment-routes.ts
@@ -7,6 +7,7 @@
 
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
+import { readUserSelectedTautulliCache } from "../../lib/tautulli/tautulli-cache-authority.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 const enrichmentQuery = z.object({
@@ -68,32 +69,31 @@ export async function registerWatchEnrichmentRoutes(
 			where: { userId, service: { in: ["JELLYFIN", "EMBY"] }, enabled: true },
 			select: { id: true },
 		});
-		const tautulliInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "TAUTULLI", enabled: true },
-			select: { id: true },
+		const tautulliEvidence = await readUserSelectedTautulliCache(app.prisma, {
+			userId,
+			targets: [...uniqueKeys.values()].map((target) => ({
+				tmdbId: target.tmdbId,
+				mediaType: target.mediaType as "movie" | "series",
+			})),
 		});
+		if (tautulliEvidence.configured && !tautulliEvidence.available) {
+			return reply.status(503).send({
+				error: "Tautulli cache evidence is unavailable",
+				reasonCodes: tautulliEvidence.reasonCodes,
+			});
+		}
 
 		const jellyfinInstanceIds = jellyfinInstances.map((i) => i.id);
-		const tautulliInstanceIds = tautulliInstances.map((i) => i.id);
 
-		const [jellyfinEntries, tautulliEntries] = await Promise.all([
-			jellyfinInstanceIds.length > 0
-				? app.prisma.jellyfinCache.findMany({
-						where: {
-							instanceId: { in: jellyfinInstanceIds },
-							tmdbId: { in: tmdbIdList },
-						},
-					})
-				: [],
-			tautulliInstanceIds.length > 0
-				? app.prisma.tautulliCache.findMany({
-						where: {
-							instanceId: { in: tautulliInstanceIds },
-							tmdbId: { in: tmdbIdList },
-						},
-					})
-				: [],
-		]);
+		const jellyfinEntries = await (jellyfinInstanceIds.length > 0
+			? app.prisma.jellyfinCache.findMany({
+					where: {
+						instanceId: { in: jellyfinInstanceIds },
+						tmdbId: { in: tmdbIdList },
+					},
+				})
+			: []);
+		const tautulliEntries = tautulliEvidence.rows;
 
 		// Aggregate enrichment data
 		const items: Record<

--- a/apps/api/src/routes/library-cleanup.ts
+++ b/apps/api/src/routes/library-cleanup.ts
@@ -491,29 +491,9 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			}
 		};
 
-		// Extract distinct Tautulli users (cursor-paginated)
+		// B1 containment: do not offer Tautulli-dependent rule values while
+		// Tautulli is deliberately non-actionable for cleanup.
 		const tautulliUsers = new Set<string>();
-		const tautulliInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "TAUTULLI" },
-			select: { id: true },
-		});
-		if (tautulliInstances.length > 0) {
-			const tautulliInstanceIds = tautulliInstances.map((i) => i.id);
-			let cursor: string | undefined;
-			while (true) {
-				const batch = await app.prisma.tautulliCache.findMany({
-					where: { instanceId: { in: tautulliInstanceIds } },
-					select: { id: true, watchedByUsers: true },
-					take: FIELD_OPTIONS_BATCH_SIZE,
-					...(cursor ? { skip: 1, cursor: { id: cursor } } : {}),
-					orderBy: { id: "asc" },
-				});
-				if (batch.length === 0) break;
-				for (const row of batch) collectStrings(row.watchedByUsers, tautulliUsers);
-				cursor = batch[batch.length - 1]!.id;
-				if (batch.length < FIELD_OPTIONS_BATCH_SIZE) break;
-			}
-		}
 
 		// Extract distinct Plex users / libraries / collections / labels in
 		// ONE cursor-paginated scan. The previous shape did three separate
@@ -616,7 +596,7 @@ export const registerLibraryCleanupRoutes: FastifyPluginCallback = (app, _opts, 
 			jellyfinLibraries: sorted(jellyfinLibraries),
 			arrTags,
 			hasPlex: plexEvidence.length > 0,
-			hasTautulli: tautulliInstances.length > 0,
+			hasTautulli: false,
 			hasJellyfin: jellyfinInstances.length > 0,
 			...(plexEvidence.length > 0 ? { plexEvidence: summarizePlexEvidence(plexEvidence) } : {}),
 		};

--- a/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
+++ b/apps/api/src/routes/plex/__tests__/value-routes-authority.test.ts
@@ -165,6 +165,8 @@ describe("Plex value route evidence contracts", () => {
 		app = Fastify({ logger: false });
 		setupAuthInjection(app);
 		app.decorate("prisma", {
+			$transaction: async (operation: (tx: unknown) => Promise<unknown>) =>
+				await operation(app.prisma),
 			serviceInstance: {
 				findFirst: findPlexInstance,
 				findMany: vi.fn(async ({ where }: { where?: { service?: string } }) =>

--- a/apps/api/src/routes/plex/watch-enrichment-routes.ts
+++ b/apps/api/src/routes/plex/watch-enrichment-routes.ts
@@ -13,6 +13,7 @@ import {
 	summarizePlexEvidence,
 } from "../../lib/plex/plex-authority-service.js";
 import { PlexAuthorityService } from "../../lib/plex/plex-authority-service.js";
+import { readUserSelectedTautulliCache } from "../../lib/tautulli/tautulli-cache-authority.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 import { aggregateWatchEnrichment } from "./lib/watch-enrichment-helpers.js";
 
@@ -98,27 +99,24 @@ export async function registerWatchEnrichmentRoutes(
 				evidence: evidenceSummary,
 			});
 		}
-		const tautulliInstances = await app.prisma.serviceInstance.findMany({
-			where: { userId, service: "TAUTULLI", enabled: true },
-			select: { id: true },
+		const tautulliEvidence = await readUserSelectedTautulliCache(app.prisma, {
+			userId,
+			targets: [...uniqueKeys.values()].map((target) => ({
+				tmdbId: target.tmdbId,
+				mediaType: target.mediaType as "movie" | "series",
+			})),
 		});
+		if (tautulliEvidence.configured && !tautulliEvidence.available) {
+			return reply.status(503).send({
+				error: "Tautulli cache evidence is unavailable",
+				reasonCodes: tautulliEvidence.reasonCodes,
+			});
+		}
 
-		const tautulliInstanceIds = tautulliInstances.map((i) => i.id);
-
-		// Query PlexCache and TautulliCache in parallel
-		const [plexEntries, tautulliEntries] = await Promise.all([
-			hasAuthoritativeSelectedPlexEvidence(plexEvidence)
-				? plexEvidence.flatMap((entry) => entry.rows)
-				: [],
-			tautulliInstanceIds.length > 0
-				? app.prisma.tautulliCache.findMany({
-						where: {
-							instanceId: { in: tautulliInstanceIds },
-							tmdbId: { in: tmdbIdList },
-						},
-					})
-				: [],
-		]);
+		const plexEntries = hasAuthoritativeSelectedPlexEvidence(plexEvidence)
+			? plexEvidence.flatMap((entry) => entry.rows)
+			: [];
+		const tautulliEntries = tautulliEvidence.rows;
 
 		// Aggregate into enrichment items using extracted pure helper
 		const items = aggregateWatchEnrichment(

--- a/apps/api/src/routes/services.ts
+++ b/apps/api/src/routes/services.ts
@@ -915,8 +915,8 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 				}
 
 				const verified = verifiedIdentityData(existing, observation);
-				const updated = await app.prisma.$transaction(async (tx) =>
-					tx.serviceInstance.updateMany({
+				const updated = await app.prisma.$transaction(async (tx) => {
+					const result = await tx.serviceInstance.updateMany({
 						where: {
 							id,
 							userId,
@@ -924,8 +924,12 @@ const servicesRoute: FastifyPluginCallback = (app, _opts, done) => {
 							identityGeneration: confirmation.expectedIdentityGeneration,
 						},
 						data: verified,
-					}),
-				);
+					});
+					if (result.count === 1 && verified.identityGeneration !== existing.identityGeneration) {
+						await clearDurableProviderCacheState(tx, id);
+					}
+					return result;
+				});
 				if (updated.count !== 1) {
 					const current = await requireInstance(app, userId, id);
 					throw createIdentityConflict(

--- a/apps/api/src/routes/tautulli/__tests__/cache-routes.test.ts
+++ b/apps/api/src/routes/tautulli/__tests__/cache-routes.test.ts
@@ -3,35 +3,35 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createInjectAuthenticated, setupAuthInjection } from "../../__tests__/test-helpers.js";
 
 const routeMocks = vi.hoisted(() => ({
-	requireClient: vi.fn(),
-	createSnapshot: vi.fn(),
+	findInstance: vi.fn(),
 	refresh: vi.fn(),
-	recordFailure: vi.fn(),
+	readAuthority: vi.fn(),
 }));
 
-vi.mock("../../../lib/tautulli/tautulli-helpers.js", () => ({
-	requireTautulliClient: routeMocks.requireClient,
-}));
 vi.mock("../../../lib/tautulli/tautulli-cache-refresher.js", () => ({
-	createOwnedTautulliPublicationSnapshot: routeMocks.createSnapshot,
-	refreshTautulliCache: routeMocks.refresh,
+	refreshOwnedTautulliCache: routeMocks.refresh,
 }));
-vi.mock("../../../lib/services/provider-cache-status.js", () => ({
-	recordWatchProviderCacheRefreshFailure: routeMocks.recordFailure,
+vi.mock("../../../lib/tautulli/tautulli-cache-authority.js", () => ({
+	findOwnedEnabledTautulliInstance: routeMocks.findInstance,
+	readOwnedTautulliCacheAuthority: routeMocks.readAuthority,
 }));
 
 import { registerCacheRoutes } from "../cache-routes.js";
 
 describe("POST /api/tautulli/cache/:instanceId/refresh", () => {
 	let app: FastifyInstance;
-	const helperClient = { source: "caller-supplied-client" };
 	const storedInstance = { id: "tautulli-1", service: "TAUTULLI" };
-	const publicationInstance = { id: "tautulli-1", identityGeneration: 6 };
 
 	beforeEach(async () => {
 		vi.clearAllMocks();
-		routeMocks.requireClient.mockResolvedValue({ client: helperClient, instance: storedInstance });
-		routeMocks.createSnapshot.mockReturnValue(publicationInstance);
+		routeMocks.findInstance.mockResolvedValue(storedInstance);
+		routeMocks.readAuthority.mockResolvedValue({
+			available: true,
+			state: "healthy_complete",
+			reasonCodes: [],
+			cachedItems: 5,
+			lastRefreshedAt: new Date("2026-08-28T11:00:00.000Z"),
+		});
 		routeMocks.refresh.mockResolvedValue({
 			complete: true,
 			completedAt: new Date(),
@@ -51,18 +51,41 @@ describe("POST /api/tautulli/cache/:instanceId/refresh", () => {
 		await app.close();
 	});
 
-	it("publishes from the sealed owned snapshot without forwarding the helper client", async () => {
+	it("owns the attempt before the refresher decrypts the stored instance", async () => {
 		const response = await createInjectAuthenticated(app)(
 			"POST",
 			"/api/tautulli/cache/tautulli-1/refresh",
 		);
 
 		expect(response.statusCode).toBe(200);
-		expect(routeMocks.createSnapshot).toHaveBeenCalledWith(app.encryptor, storedInstance);
 		expect(routeMocks.refresh).toHaveBeenCalledWith(
-			expect.objectContaining({ prisma: app.prisma, instance: publicationInstance }),
+			expect.objectContaining({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				instance: storedInstance,
+			}),
 		);
-		expect(routeMocks.refresh.mock.calls.flat()).not.toContain(helperClient);
-		expect(routeMocks.recordFailure).not.toHaveBeenCalled();
+	});
+
+	it("returns the bounded shared currentness projection", async () => {
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/api/tautulli/cache/tautulli-1/status",
+		);
+
+		expect(response.statusCode).toBe(200);
+		expect(routeMocks.readAuthority).toHaveBeenCalledWith(app.prisma, {
+			userId: "user-1",
+			instanceId: "tautulli-1",
+		});
+		expect(response.json()).toEqual({
+			instanceId: "tautulli-1",
+			available: true,
+			state: "healthy_complete",
+			reasonCodes: [],
+			cachedItems: 5,
+			hasCacheData: true,
+			lastRefreshedAt: "2026-08-28T11:00:00.000Z",
+		});
 	});
 });

--- a/apps/api/src/routes/tautulli/__tests__/cache-routes.test.ts
+++ b/apps/api/src/routes/tautulli/__tests__/cache-routes.test.ts
@@ -88,4 +88,30 @@ describe("POST /api/tautulli/cache/:instanceId/refresh", () => {
 			lastRefreshedAt: "2026-08-28T11:00:00.000Z",
 		});
 	});
+
+	it("keeps cache count and presence unknown when current evidence is unavailable", async () => {
+		routeMocks.readAuthority.mockResolvedValueOnce({
+			available: false,
+			state: "no_publication",
+			reasonCodes: ["no_publication"],
+			cachedItems: null,
+			lastRefreshedAt: null,
+		});
+
+		const response = await createInjectAuthenticated(app)(
+			"GET",
+			"/api/tautulli/cache/tautulli-1/status",
+		);
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({
+			instanceId: "tautulli-1",
+			available: false,
+			state: "no_publication",
+			reasonCodes: ["no_publication"],
+			cachedItems: null,
+			hasCacheData: null,
+			lastRefreshedAt: null,
+		});
+	});
 });

--- a/apps/api/src/routes/tautulli/cache-routes.ts
+++ b/apps/api/src/routes/tautulli/cache-routes.ts
@@ -36,7 +36,8 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 		return reply.send({
 			instanceId,
 			...authority,
-			hasCacheData: authority.available && authority.cachedItems > 0,
+			hasCacheData:
+				authority.available && authority.cachedItems !== null ? authority.cachedItems > 0 : null,
 		});
 	});
 

--- a/apps/api/src/routes/tautulli/cache-routes.ts
+++ b/apps/api/src/routes/tautulli/cache-routes.ts
@@ -7,13 +7,12 @@
 
 import type { FastifyInstance, FastifyPluginOptions } from "fastify";
 import { z } from "zod";
-import { recordWatchProviderCacheRefreshFailure } from "../../lib/services/provider-cache-status.js";
 import {
-	createOwnedTautulliPublicationSnapshot,
-	refreshTautulliCache,
-} from "../../lib/tautulli/tautulli-cache-refresher.js";
-import { requireTautulliClient } from "../../lib/tautulli/tautulli-helpers.js";
-import { getErrorMessage } from "../../lib/utils/error-message.js";
+	findOwnedEnabledTautulliInstance,
+	readOwnedTautulliCacheAuthority,
+} from "../../lib/tautulli/tautulli-cache-authority.js";
+import { refreshOwnedTautulliCache } from "../../lib/tautulli/tautulli-cache-refresher.js";
+import { InstanceNotFoundError } from "../../lib/errors.js";
 import { validateRequest } from "../../lib/utils/validate.js";
 
 const instanceParams = z.object({
@@ -31,15 +30,13 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 		const { instanceId } = validateRequest(instanceParams, request.params);
 		const userId = request.currentUser!.id;
 
-		// Verify ownership
-		await requireTautulliClient(app, userId, instanceId);
-
-		const count = await app.prisma.tautulliCache.count({ where: { instanceId } });
+		const authority = await readOwnedTautulliCacheAuthority(app.prisma, { userId, instanceId });
+		if (!authority) throw new InstanceNotFoundError(instanceId);
 
 		return reply.send({
 			instanceId,
-			cachedItems: count,
-			hasCacheData: count > 0,
+			...authority,
+			hasCacheData: authority.available && authority.cachedItems > 0,
 		});
 	});
 
@@ -56,41 +53,23 @@ export async function registerCacheRoutes(app: FastifyInstance, _opts: FastifyPl
 			const { instanceId } = validateRequest(instanceParams, request.params);
 			const userId = request.currentUser!.id;
 
-			const { instance } = await requireTautulliClient(app, userId, instanceId);
-			const publicationInstance = createOwnedTautulliPublicationSnapshot(app.encryptor, instance);
+			const instance = await findOwnedEnabledTautulliInstance(app.prisma, {
+				userId,
+				instanceId,
+			});
+			if (!instance) throw new InstanceNotFoundError(instanceId);
+			const result = await refreshOwnedTautulliCache({
+				prisma: app.prisma,
+				encryptor: app.encryptor,
+				instance,
+				log: request.log,
+			});
 
-			try {
-				const result = await refreshTautulliCache({
-					prisma: app.prisma,
-					instance: publicationInstance,
-					log: request.log,
-				});
-				if ((!result.complete || !result.completedAt) && !result.superseded) {
-					await recordWatchProviderCacheRefreshFailure(
-						app.prisma,
-						"tautulli",
-						result.errorMessages.slice(0, 3).join("; ").slice(0, 200) ||
-							"Tautulli refresh did not publish a complete generation",
-						publicationInstance,
-						request.log,
-					);
-				}
-
-				return reply.send({
-					success: result.complete && Boolean(result.completedAt),
-					upserted: result.upserted,
-					errors: result.errors,
-				});
-			} catch (err) {
-				await recordWatchProviderCacheRefreshFailure(
-					app.prisma,
-					"tautulli",
-					getErrorMessage(err, "Unknown error"),
-					publicationInstance,
-					request.log,
-				);
-				throw err;
-			}
+			return reply.send({
+				success: result.complete && Boolean(result.completedAt),
+				upserted: result.upserted,
+				errors: result.errors,
+			});
 		},
 	);
 }


### PR DESCRIPTION
## Summary

Implements Issue #783 B1: Tautulli cache authority lifecycle, currentness, and consumer containment. The change is a safe intermediate state: complete aggregate publication remains readable only when current, while all Tautulli-derived cleanup mutation remains unavailable until later mapping/actionability work.

## Related issue

Related to #783

## Scope

- Atomically clear Tautulli cache rows and status whenever connection or identity authority generations advance.
- Preserve valid state when MISMATCH re-verification confirms the same identity without a generation advance.
- Claim each refresh attempt before credential decryption and bind terminal publication/failure to attempt and generation CAS.
- Evaluate ownership, current generations, status, row generations, and selected rows through tenant-scoped readers.
- Read both the authority/status projection and selected rows inside bounded Serializable snapshots beginning before the owned-instance lookup, with complete-transaction retry and fail-closed exhaustion.
- Share bounded currentness semantics across status and Pulse, including explicit `no_publication` when no status row exists.
- Keep unavailable counts and presence unknown (`null`), never synthetic zero or false.
- Quarantine Tautulli from Preview, Explain, approval, direct execution, retry, and all cleanup mutation authority with `tautulli_mapping_required`.

## Acceptance criteria

- [x] Authority generations clear durable Tautulli state atomically and remain revalidated at read/publication time.
- [x] Selected request reads return one current internally consistent Serializable snapshot or bounded unavailable.
- [x] Authority status/count reads return one current internally consistent Serializable snapshot or bounded unavailable.
- [x] Every request-facing query/page remains authenticated-tenant scoped.
- [x] Attempt CAS prevents stale or overlapping refresh completion.
- [x] Unavailable evidence never becomes zero, false, unwatched, absent, or empty-current evidence.
- [x] Status and Pulse share bounded currentness semantics without leaking provider data.
- [x] Tautulli remains unable to authorize cleanup mutation.
- [x] Complete-only publication and Plex/Jellyfin behavior remain unchanged.

## Changes

- Add central Tautulli authority projection plus bounded Serializable authority and selected-row readers using one shared retry contract.
- Bind refresh ownership/publication/failure to current provider generations and attempt tokens.
- Extend lifecycle resets to Tautulli rows and status.
- Route status and Pulse through the shared projection, including status-less instances.
- Quarantine cleanup consumers and focused field-option/enrichment paths from raw or destructive Tautulli authority.
- Add deterministic, real SQLite, conditional PostgreSQL, route/Pulse, containment, CAS, lifecycle, and heap coverage.

## Non-goals

- No Prisma schema or generated-client change.
- No B2 exact target catalog, B3 positive-only publication, or T2 section-to-ARR mapping/actionability.
- No #787 work, frontend redesign, dependency/lockfile change, release/version work, or `next` work.
- No Plex or Jellyfin semantic change.
- No issue closure and no change to PR #803.

## Authority generation lifecycle

- A connection or identity generation advance clears `TautulliCache` and its Tautulli `CacheRefreshStatus` in the same lifecycle transaction.
- A same-identity verification that does not advance the identity generation preserves the current publication.
- Rollback preserves the prior generation and publication; stale refresh attempts cannot republish after a reset.

## Durable attempt ownership

- Scheduled and manual refreshes claim an opaque attempt token before decrypting credentials or performing provider I/O.
- Publication and terminal failure updates require the same attempt token and current provider generations.
- Superseded attempts cannot overwrite a newer attempt or publication.

## Currentness and Serializable reads

- Both public readers start a Serializable transaction before their authenticated owned-instance lookup.
- The authority projection reads instance authority, status, total/matching counts, and evaluation through one transaction client.
- The selected-cache reader reads instance authority, status, row counts, and both fixed 100-row cursor pages through one transaction client.
- Status and rows must match the current `connectionGeneration` and `identityGeneration`.
- A shared runner limits both readers to three complete-transaction attempts with a 10-second transaction timeout and bounded 15/30 ms retry delays for known serialization or SQLite-busy conflicts. Exhaustion returns bounded unavailable with no split-read fallback.
- Selection remains capped at 200 rows/two pages.
- Concurrent lifecycle clearing can return only the internally consistent pre-clear snapshot or bounded post-clear unavailable state, never authoritative empty evidence.
- A concurrent refresh-attempt claim can return only a coherent pre-claim healthy projection or a post-claim in-progress/unavailable projection, never stale healthy authority assembled from split reads.

## Tenant scoping

- Every request-facing status, count, and selected-row query includes authenticated tenant scope; every cursor page retains the same tenant and generation filters.
- Foreign and missing instances remain indistinguishable.

## Status / Pulse

- Route and Pulse both use the central authority evaluator.
- Missing status is represented as `no_publication` in both surfaces.
- Unavailable `cachedItems` and `hasCacheData` are `null`; exact count/boolean values exist only for healthy complete authority.
- Identity verification remains independent from cache health.

## Privacy / diagnostics

- User-visible and logged errors are reduced to bounded allowlisted reason codes and counts.
- No raw title, username, URL, token, rating key, TMDB ID, GUID, provider payload, credential, or database error is returned or logged by the new paths.
- No provider network I/O, credential handling, mutation, or raw-row logging occurs inside the read transaction.

## Consumer quarantine

- Tautulli cannot authorize deletion, unmonitoring, or ARR mutation.
- Preview and Explain return unavailable/UNKNOWN; approval, direct execution, and retry fail closed.
- The legacy aggregate path is not actionable and raw aggregate reads remain behind the central authority boundary.

## Complete publication behavior

- Existing complete-only Tautulli collection and replacement behavior is preserved.
- Ordinary refresh failure preserves physical rows but revokes current trust; a later complete success restores healthy current authority.
- B1 introduces no partial or positive-only evidence semantics.

## Disposable provider evidence

- A fresh SQLite-backed Tautulli-wire fixture exercised real client HTTP commands for server identity, libraries, history, and metadata.
- It verified valid identity, complete refresh, credential-preparation failure, redacted latest-error status, later recovery, generation clearing, same-identity preservation, rollback, stale-attempt supersession, and status/Pulse parity.
- Privacy canaries for provider URL, title, username, rating key, TMDB/GUID values, and token material did not escape.
- All fixture resources were removed after validation.

## Independent reviews

### Lifecycle / concurrency

- Initial review reproduced the split-read lifecycle race.
- The Serializable correction and its final amendment delta passed targeted review with no actionable P0/P1/P2.
- Final exact-head applicability check confirmed the last amendment changed only a focused test transaction fake.
- The final authority status/count correction passed one targeted read-only review: all 11 required invariants answered as required, with no actionable P0/P1/P2.

### Data safety / containment

- Full candidate review found no P0/P1 and identified unavailable zero/false projection as P2.
- The correction makes count/presence unknown when unavailable; targeted correction review passed with no actionable P0/P1/P2.

### Tenancy / privacy / status

- Full candidate review found no P0/P1 and identified missing-status Pulse omission as P2.
- Pulse now enumerates tenant-owned enabled Tautulli instances and delegates currentness to the central reader; targeted correction review passed with no actionable P0/P1/P2.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Deterministic RED reproduced lifecycle clearing between validation and selected-row loading.
- [x] Deterministic RED reproduced the authority split-read race: old successful status plus unchanged rows returned stale `healthy_complete` after a new attempt claim.
- [x] Focused authority suite: 23/23 passed.
- [x] Focused authority/route/Pulse suite: 45/45 passed.
- [x] Real SQLite database suite: 16 passed, 2 conditional PostgreSQL tests skipped; both selected-row lifecycle clearing and authority attempt-claim interleavings remained coherent.
- [x] Real PostgreSQL 16 two-connection Serializable boundaries: 2/2 passed, 16 unrelated tests skipped; both selected-row lifecycle clearing and authority attempt claim obeyed the same invariant.
- [x] `pnpm run check:prisma-generated`
- [x] `node --test scripts/check-prisma-generated.test.mjs`: 17 passed.
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`
- [x] `pnpm run typecheck`: 3 package tasks passed.
- [x] `pnpm run test`: API 4,665 passed / 53 skipped; web 669 passed; shared 89 passed (5,423 passed total / 53 skipped).
- [x] `pnpm run lint`: 3 package tasks passed.
- [x] `CI=true pnpm run validate:pr`, including 53 PR review-contract tests.
- [x] `pnpm run build`: API/shared/web passed; all 25 web routes generated.
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7 passed.
- [x] Disposable Tautulli-wire lifecycle fixture passed.
- [x] Fresh disposable integration stack: 104/104 passed; containers, volumes, network, and generated environment removed.
- [x] Exact-image Docker runtime validation passed.
- [x] Docker smoke contracts: image-cache permissions 122/122, supervision 34/34, launcher 15/15, live restart 14/14, heap dump 21/21, shutdown grace 15/15, stop timing 12/12.
- [x] `git diff --check`

## Changed files

- 28 files: 13 production files and 15 focused tests.
- No schema/generated Prisma, dependency/lockfile, frontend, release/version, `next`, or `config-dev` files.

## Review plan

- Initial candidate: `03eac4c42c2ab507de2e791ec54ca314d6da0dc4`
- Consolidated correction: `23182768fca75d7f912bd229804a22c55139d07b`
- Final authority status-snapshot correction: `de3e652bd82012a957c9835eac721a73f7dea708`
- Targeted Serializable review: PASS
- Targeted status-snapshot micro-review: PASS, no actionable P0/P1/P2
- Data-safety review and correction delta: PASS
- Tenancy/privacy/status review and correction delta: PASS
- Material scope change declared? No; reviewer P2 corrections stayed inside B1 status/currentness semantics and focused tests.
- GitHub Codex corrected-head result: no findings (ready-trigger completion 👍 with no new submitted review or inline comment on unchanged head `de3e652bd82012a957c9835eac721a73f7dea708`)
- Maintainer decision: Pending

## Finding disposition

| ID | Severity | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- |
| Serializable selected-read race | P1 | Lifecycle clear between validation and row read could create authoritative empty evidence | Fixed by one bounded Serializable snapshot with complete retry | None |
| Unavailable count/presence | P2 | Status projected `0`/`false` while authority was unavailable | Fixed with explicit `null` unknown values | None |
| Missing-status Pulse omission | P2 | Lifecycle reset removed status, leaving route `no_publication` but no Pulse item | Fixed by tenant-owned instance enumeration plus central authority evaluation | None |
| Split authority status/count snapshot | P2 | A new `in_progress` attempt claimed after the ordinary status read could leave the helper returning stale `healthy_complete` from old status and rows | Fixed by one bounded Serializable authority transaction beginning before ownership lookup, with complete retry and unavailable exhaustion | None |

## Final merge gate

- [x] Exact-head GitHub CI is green across all 14 unique check names; every synchronize, ready-trigger, and PR-body review-contract rerun is also green.
- [x] Local acceptance criteria and validation passed
- [x] No unresolved in-scope GitHub review threads remain
- [x] Local findings are dispositioned
- [x] Current production head is covered by independent review
- [x] Base is unchanged at `788403abd7b3aad2f4c6ee0e0374918ebe9e90b9`
- [x] Maintainer approved merge
- [x] Post-merge verification is planned
