### PR TITLE
fix(plex): redact label-sync mutation logs

### DIFF
--- a/apps/api/src/__tests__/server-plex-validation.test.ts
+++ b/apps/api/src/__tests__/server-plex-validation.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const routeMocks = vi.hoisted(() => ({
+	runPlexRead: vi.fn(),
+}));
+
+vi.mock("../bootstrap/index.js", () => ({
+	registerInfrastructure(app: { decorate: (name: string, value: unknown) => void }) {
+		app.decorate("sessionService", { validateRequest: vi.fn().mockResolvedValue(null) });
+	},
+	registerSchedulers() {},
+	registerProtectedRoutes() {},
+	registerPublicRoutes(app: { get: (path: string, handler: () => Promise<unknown>) => void }) {
+		app.get("/plex-validation-probe", async () => await routeMocks.runPlexRead());
+	},
+}));
+
+import { envSchema } from "../config/env.js";
+import { PlexClient } from "../lib/plex/plex-client.js";
+import { buildServer } from "../server.js";
+
+const log = { warn: vi.fn() } as never;
+
+describe("production Plex validation error handling", () => {
+	let app: ReturnType<typeof buildServer>;
+
+	beforeEach(async () => {
+		const client = new PlexClient(
+			"https://CANARY_ROUTE_HOST_787.invalid",
+			"CANARY_ROUTE_TOKEN_787",
+			log,
+		);
+		routeMocks.runPlexRead.mockReset().mockImplementation(async () => await client.getActivities());
+		app = buildServer({ logger: false, env: envSchema.parse({ NODE_ENV: "test" }) });
+		await app.ready();
+	});
+
+	afterEach(async () => {
+		vi.unstubAllGlobals();
+		await app.close();
+	});
+
+	it("returns a bounded 502 for a schema-invalid successful Plex response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				new Response(
+					JSON.stringify({
+						MediaContainer: {
+							size: "CANARY_ROUTE_PAYLOAD_787",
+							Activity: [{ type: "CANARY_ROUTE_STATUS_787" }],
+						},
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				),
+			),
+		);
+		const response = await app.inject({ method: "GET", url: "/plex-validation-probe" });
+
+		expect(response.statusCode).toBe(502);
+		expect(response.json()).toEqual({
+			error: "PlexRequestError",
+			message: "Plex API request failed",
+		});
+		const serialized = JSON.stringify(response.json());
+		for (const canary of [
+			"CANARY_ROUTE_HOST_787.invalid",
+			"CANARY_ROUTE_TOKEN_787",
+			"CANARY_ROUTE_PAYLOAD_787",
+			"CANARY_ROUTE_STATUS_787",
+			"Zod",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
+	it("preserves an ordinary valid Plex route response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				new Response(JSON.stringify({ MediaContainer: { size: 0, Activity: [] } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+
+		const response = await app.inject({ method: "GET", url: "/plex-validation-probe" });
+
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual([]);
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/plex-source-whole-execution-logging.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-source-whole-execution-logging.test.ts
@@ -1,0 +1,256 @@
+import type { FastifyBaseLogger } from "fastify";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../prisma.js";
+
+const repositoryMocks = vi.hoisted(() => ({
+	loadInstanceSelectedEvidence: vi.fn(),
+}));
+
+vi.mock("../../plex/plex-evidence-repository.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../../plex/plex-evidence-repository.js")>();
+	return {
+		...actual,
+		loadInstanceSelectedEvidence: repositoryMocks.loadInstanceSelectedEvidence,
+	};
+});
+
+import { plexDestWriter } from "../dest-writers/plex-writer.js";
+import { executeLabelSyncRule } from "../execute-rule.js";
+
+const canaries = {
+	title: "CANARY_SOURCE_TITLE_787",
+	tmdbId: 987_654_321,
+	ratingKey: "CANARY_SOURCE_RATING_KEY_787",
+	sectionId: "CANARY_SOURCE_SECTION_ID_787",
+	sectionTitle: "CANARY_SOURCE_SECTION_TITLE_787",
+	guid: "plex://CANARY_SOURCE_GUID_787",
+	username: "CANARY_SOURCE_USERNAME_787",
+	baseUrl: "https://CANARY_SOURCE_HOST_787.invalid",
+	hostname: "CANARY_SOURCE_HOST_787.invalid",
+	token: "CANARY_SOURCE_TOKEN_787",
+	statusText: "CANARY_SOURCE_STATUS_TEXT_787",
+	rawError: "CANARY_SOURCE_RAW_ERROR_787",
+	responseBody: "CANARY_SOURCE_RESPONSE_BODY_787",
+	requestPath: "/library/sections/CANARY_SOURCE_PATH_787/all?private=CANARY_SOURCE_QUERY_787",
+} as const;
+
+function createLogger(): FastifyBaseLogger {
+	const logger = {
+		child: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+	} as unknown as FastifyBaseLogger;
+	(logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+	return logger;
+}
+
+function allLogText(log: FastifyBaseLogger, diagnostics: unknown): string {
+	const calls = [log.info, log.warn, log.error, log.debug, log.trace, log.fatal].flatMap(
+		(method) => (method as unknown as ReturnType<typeof vi.fn>).mock.calls,
+	);
+	return JSON.stringify({ calls, diagnostics });
+}
+
+function instance(id: string): ServiceInstance {
+	return {
+		id,
+		userId: "user-1",
+		service: "PLEX",
+		label: id,
+		baseUrl: canaries.baseUrl,
+		externalUrl: null,
+		encryptedApiKey: "encrypted-token",
+		encryptionIv: "token-iv",
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		expectedIdentity: "plex-machine-787",
+		identityKind: "PLEX_MACHINE_IDENTIFIER",
+		identityStatus: "VERIFIED",
+		identityVerifiedAt: new Date("2026-08-28T00:00:00.000Z"),
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		createdAt: new Date("2026-08-28T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-28T00:00:00.000Z"),
+	} as ServiceInstance;
+}
+
+function jsonResponse(value: unknown): Response {
+	return new Response(JSON.stringify(value), {
+		status: 200,
+		headers: { "content-type": "application/json" },
+	});
+}
+
+describe("Plex label-sync whole-execution source logging", () => {
+	beforeEach(() => {
+		repositoryMocks.loadInstanceSelectedEvidence.mockReset().mockResolvedValue({
+			available: true,
+			instanceId: "plex-source",
+			instanceName: canaries.username,
+			generationId: "generation-787",
+			publishedAt: new Date("2026-08-28T00:00:00.000Z"),
+			itemCount: 1,
+			connectionGeneration: 4,
+			identityGeneration: 9,
+			metadata: {
+				version: 3,
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				itemCount: 1,
+				canonicalizationVersion: 1,
+				sections: [
+					{
+						key: canaries.sectionId,
+						uuid: "section-uuid-787",
+						title: canaries.sectionTitle,
+						type: "movie",
+						refreshing: false,
+						scannedAt: 1_777_000_000,
+						updatedAt: 1_777_000_100,
+					},
+				],
+				roots: [],
+			},
+			generationStatus: {},
+			sections: [],
+			rows: [
+				{
+					instanceId: "plex-source",
+					tmdbId: canaries.tmdbId,
+					mediaType: "movie",
+					sectionId: canaries.sectionId,
+					sectionTitle: canaries.sectionTitle,
+					title: canaries.title,
+					ratingKey: canaries.ratingKey,
+					labels: '["Private"]',
+					guid: canaries.guid,
+				},
+			],
+			evidence: {
+				availability: "current",
+				authority: "authoritative",
+				attemptState: "success",
+				publicationLevel: "authoritative",
+				completeness: "complete",
+				reasonCodes: [],
+			},
+		});
+
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request) => {
+				const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+				if (url.pathname === "/activities") {
+					return jsonResponse({
+						MediaContainer: { offset: 0, size: 0, totalSize: 0, Activity: [] },
+					});
+				}
+				if (url.pathname === "/library/sections") {
+					return jsonResponse({
+						MediaContainer: {
+							offset: 0,
+							size: 1,
+							totalSize: 1,
+							Directory: [
+								{
+									key: canaries.sectionId,
+									uuid: "section-uuid-787",
+									title: canaries.sectionTitle,
+									type: "movie",
+									agent: "tv.plex.agents.movie",
+									refreshing: false,
+									scannedAt: 1_777_000_000,
+									updatedAt: 1_777_000_100,
+								},
+							],
+						},
+					});
+				}
+				if (url.pathname === "/accounts") {
+					return jsonResponse({
+						MediaContainer: {
+							offset: 0,
+							size: 1,
+							totalSize: 1,
+							Account: [{ id: 1, name: canaries.username }],
+						},
+					});
+				}
+				if (url.pathname.startsWith("/library/sections/") && url.pathname.endsWith("/all")) {
+					return new Response(canaries.responseBody, {
+						status: 503,
+						statusText: `${canaries.statusText} ${canaries.rawError} ${canaries.requestPath}`,
+					});
+				}
+				throw new Error(`Unhandled Plex test URL: ${url.toString()}`);
+			}),
+		);
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	it("contains nested provider diagnostics and emits one bounded source terminal event", async () => {
+		const source = instance("plex-source");
+		const destination = instance("plex-dest");
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([source]),
+				findFirst: vi.fn(async ({ where }: { where: { id: string } }) =>
+					where.id === source.id ? source : destination,
+				),
+			},
+		};
+		const log = createLogger();
+		const destinationSpy = vi.spyOn(plexDestWriter, "applyLabels");
+
+		const result = await executeLabelSyncRule({
+			rule: {
+				id: "rule-787",
+				userId: "user-1",
+				sourceService: "plex",
+				sourceInstanceId: source.id,
+				sourceTagName: "Private",
+				destService: "plex",
+				destInstanceId: destination.id,
+				destTagName: "Private destination",
+			},
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: { decrypt: vi.fn().mockReturnValue(canaries.token) } as never,
+			log,
+		});
+
+		expect(result).toMatchObject({
+			status: "failed",
+			totals: { labelsApplied: 0, failures: 1 },
+		});
+		expect(destinationSpy).not.toHaveBeenCalled();
+		const serialized = allLogText(log, result);
+		for (const value of Object.values(canaries)) {
+			expect(serialized).not.toContain(String(value));
+		}
+		const terminalEvents = (log.warn as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+			([fields, message]) =>
+				(fields as { operation?: string })?.operation === "source_read" &&
+				message === "Plex label-sync source read failed",
+		);
+		expect(terminalEvents).toHaveLength(1);
+		expect(terminalEvents[0]).toEqual([
+			{
+				operation: "source_read",
+				state: "failed",
+				stage: "source_authority",
+				reasonCode: "source_evidence_changed",
+			},
+			"Plex label-sync source read failed",
+		]);
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/plex-source-whole-execution-logging.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-source-whole-execution-logging.test.ts
@@ -253,4 +253,86 @@ describe("Plex label-sync whole-execution source logging", () => {
 			"Plex label-sync source read failed",
 		]);
 	});
+
+	it("contains a schema-invalid successful Plex response at the source terminal boundary", async () => {
+		const ordinaryFetch = fetch;
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async (input: string | URL | Request) => {
+				const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url);
+				if (url.pathname.startsWith("/library/sections/") && url.pathname.endsWith("/all")) {
+					return jsonResponse({
+						MediaContainer: {
+							offset: 0,
+							size: "CANARY_SOURCE_SCHEMA_SIZE_787",
+							totalSize: 1,
+							Metadata: [
+								{
+									ratingKey: canaries.ratingKey,
+									title: canaries.title,
+									type: "movie",
+									Guid: [{ id: canaries.guid }],
+								},
+							],
+						},
+					});
+				}
+				return await ordinaryFetch(input);
+			}),
+		);
+		const source = instance("plex-source");
+		const destination = instance("plex-dest");
+		const prisma = {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([source]),
+				findFirst: vi.fn(async ({ where }: { where: { id: string } }) =>
+					where.id === source.id ? source : destination,
+				),
+			},
+		};
+		const log = createLogger();
+		const destinationSpy = vi.spyOn(plexDestWriter, "applyLabels");
+
+		const result = await executeLabelSyncRule({
+			rule: {
+				id: "rule-787",
+				userId: "user-1",
+				sourceService: "plex",
+				sourceInstanceId: source.id,
+				sourceTagName: "Private",
+				destService: "plex",
+				destInstanceId: destination.id,
+				destTagName: "Private destination",
+			},
+			prisma: prisma as never,
+			arrClientFactory: {} as never,
+			encryptor: { decrypt: vi.fn().mockReturnValue(canaries.token) } as never,
+			log,
+		});
+
+		expect(result).toMatchObject({
+			status: "failed",
+			totals: { labelsApplied: 0, failures: 1 },
+		});
+		expect(destinationSpy).not.toHaveBeenCalled();
+		const terminalEvents = (log.warn as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+			([fields, message]) =>
+				(fields as { operation?: string })?.operation === "source_read" &&
+				message === "Plex label-sync source read failed",
+		);
+		expect(terminalEvents).toHaveLength(1);
+		expect(terminalEvents[0]).toEqual([
+			{
+				operation: "source_read",
+				state: "failed",
+				stage: "source_authority",
+				reasonCode: "source_evidence_changed",
+			},
+			"Plex label-sync source read failed",
+		]);
+		const serialized = allLogText(log, result);
+		for (const value of [...Object.values(canaries), "CANARY_SOURCE_SCHEMA_SIZE_787", "Zod"]) {
+			expect(serialized).not.toContain(String(value));
+		}
+	});
 });

--- a/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-strategies.test.ts
@@ -7,9 +7,13 @@ const mocks = vi.hoisted(() => ({
 	loadInstanceSelectedEvidence: vi.fn(),
 	updateMetadataTags: vi.fn(),
 	createPlexClient: vi.fn(),
+	PlexMetadataTagWriteError: class PlexMetadataTagWriteError extends Error {
+		readonly code = "upstream_write_failed";
+	},
 }));
 
 vi.mock("../../plex/plex-authority-service.js", () => ({
+	PlexMetadataTagWriteError: mocks.PlexMetadataTagWriteError,
 	PlexAuthorityService: class {
 		private readonly prisma: {
 			serviceInstance?: { findFirst: (input: unknown) => Promise<Record<string, unknown> | null> };

--- a/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
@@ -1,0 +1,403 @@
+import type { FastifyBaseLogger } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServiceInstance } from "../../prisma.js";
+
+const mocks = vi.hoisted(() => {
+	class PlexMetadataTagWriteError extends Error {
+		readonly code = "upstream_write_failed" as const;
+		readonly responseCategory: "client_error" | "server_error" | "timeout" | "unavailable";
+
+		constructor(
+			responseCategory: "client_error" | "server_error" | "timeout" | "unavailable" = "unavailable",
+		) {
+			super("Plex metadata tag write failed");
+			this.name = "PlexMetadataTagWriteError";
+			this.responseCategory = responseCategory;
+			delete this.stack;
+		}
+	}
+	return {
+		readInstanceSelected: vi.fn(),
+		mutateMetadataTag: vi.fn(),
+		emitNestedReadLog: vi.fn(),
+		emitNestedMutationLog: vi.fn(),
+		PlexMetadataTagWriteError,
+	};
+});
+
+vi.mock("../../plex/plex-authority-service.js", () => ({
+	PlexMetadataTagWriteError: mocks.PlexMetadataTagWriteError,
+	PlexAuthorityService: class {
+		private readonly log: FastifyBaseLogger;
+
+		constructor(input: { log: FastifyBaseLogger }) {
+			this.log = input.log;
+		}
+
+		async readInstanceSelected(input: unknown) {
+			await mocks.emitNestedReadLog(this.log, input);
+			return await mocks.readInstanceSelected(input);
+		}
+
+		async mutateMetadataTag(input: unknown) {
+			await mocks.emitNestedMutationLog(this.log, input);
+			return await mocks.mutateMetadataTag(input);
+		}
+	},
+}));
+
+import { executeLabelSyncRule } from "../execute-rule.js";
+
+const canaries = {
+	title: "CANARY_RULE_TITLE_787",
+	tmdbId: 987_654_321,
+	ratingKey: "987650123456789",
+	sectionId: "CANARY_RULE_SECTION_ID_787",
+	sectionTitle: "CANARY_RULE_SECTION_TITLE_787",
+	guid: "plex://CANARY_RULE_GUID_787",
+	username: "CANARY_RULE_USERNAME_787",
+	url: "https://CANARY_RULE_HOST_787.invalid/private",
+	token: "CANARY_RULE_TOKEN_787",
+	statusText: "CANARY_RULE_STATUS_TEXT_787",
+	rawError: "CANARY_RULE_RAW_ERROR_787",
+	responseBody: "CANARY_RULE_RESPONSE_BODY_787",
+	path: "/library/metadata/CANARY_RULE_PATH_787?token=CANARY_RULE_QUERY_787",
+} as const;
+
+const rule = {
+	id: "rule-787",
+	userId: "user-1",
+	sourceService: "plex",
+	sourceInstanceId: "plex-source",
+	sourceTagName: "Private source",
+	destService: "plex",
+	destInstanceId: "plex-dest",
+	destTagName: "Private destination",
+};
+
+function instance(id: string): ServiceInstance {
+	return {
+		id,
+		userId: "user-1",
+		service: "PLEX",
+		label: id,
+		baseUrl: "http://plex.invalid",
+		externalUrl: null,
+		encryptedApiKey: "encrypted",
+		encryptionIv: "iv",
+		enabled: true,
+		isDefault: false,
+		storageGroupId: null,
+		createdAt: new Date("2026-08-28T00:00:00.000Z"),
+		updatedAt: new Date("2026-08-28T00:00:00.000Z"),
+	} as ServiceInstance;
+}
+
+function createLogger(): FastifyBaseLogger {
+	const logger = {
+		child: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+	} as unknown as FastifyBaseLogger;
+	(logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+	return logger;
+}
+
+function sourceEvidence() {
+	return {
+		available: true,
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		evidence: {
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			reasonCodes: [],
+		},
+		rows: [
+			{
+				tmdbId: canaries.tmdbId,
+				mediaType: "movie",
+				title: canaries.title,
+				labels: '["Private source"]',
+				ratingKey: canaries.ratingKey,
+				thumb: `/library/metadata/${canaries.ratingKey}/thumb/1`,
+				sectionId: canaries.sectionId,
+				sectionTitle: canaries.sectionTitle,
+				guid: canaries.guid,
+			},
+		],
+	};
+}
+
+function destinationEvidence() {
+	return sourceEvidence();
+}
+
+function unavailableEvidence(reasonCode: string) {
+	return {
+		available: false,
+		evidence: {
+			publicationLevel: "unavailable",
+			completeness: "unknown",
+			reasonCodes: [reasonCode],
+		},
+		rows: [],
+	};
+}
+
+function nestedPrivateLog(log: FastifyBaseLogger) {
+	log.warn(
+		{
+			err: new Error(`${canaries.rawError} ${canaries.statusText} ${canaries.url}`),
+			sectionId: canaries.sectionId,
+			sectionTitle: canaries.sectionTitle,
+			path: canaries.path,
+			response: canaries.responseBody,
+			token: canaries.token,
+		},
+		`${canaries.rawError} ${canaries.statusText}`,
+	);
+}
+
+function terminalEvents(log: FastifyBaseLogger): unknown[][] {
+	return [log.info, log.warn, log.error, log.debug, log.trace, log.fatal]
+		.flatMap((method) => (method as unknown as ReturnType<typeof vi.fn>).mock.calls)
+		.filter(([fields]) => {
+			const operation = (fields as { operation?: string } | undefined)?.operation;
+			return operation === "source_read" || operation === "destination_write";
+		});
+}
+
+function expectNoCanary(log: FastifyBaseLogger, diagnostics: unknown): void {
+	const serialized = JSON.stringify({
+		logs: [log.info, log.warn, log.error, log.debug, log.trace, log.fatal].flatMap(
+			(method) => (method as unknown as ReturnType<typeof vi.fn>).mock.calls,
+		),
+		diagnostics,
+	});
+	for (const value of Object.values(canaries)) {
+		expect(serialized).not.toContain(String(value));
+	}
+}
+
+async function execute(log: FastifyBaseLogger) {
+	const source = instance("plex-source");
+	const destination = instance("plex-dest");
+	return await executeLabelSyncRule({
+		rule,
+		prisma: {
+			serviceInstance: {
+				findMany: vi.fn().mockResolvedValue([source]),
+				findFirst: vi.fn().mockResolvedValue(destination),
+			},
+		} as never,
+		arrClientFactory: {} as never,
+		encryptor: {} as never,
+		log,
+	});
+}
+
+function sourceSelection(input: unknown): boolean {
+	return (input as { selection?: { kind?: string } })?.selection?.kind === "label-membership";
+}
+
+describe("complete Plex-to-Plex label-sync terminal logging", () => {
+	beforeEach(() => {
+		mocks.readInstanceSelected
+			.mockReset()
+			.mockImplementation(async (input: unknown) =>
+				sourceSelection(input) ? sourceEvidence() : destinationEvidence(),
+			);
+		mocks.mutateMetadataTag.mockReset().mockResolvedValue({ ok: true });
+		mocks.emitNestedReadLog.mockReset().mockResolvedValue(undefined);
+		mocks.emitNestedMutationLog.mockReset().mockResolvedValue(undefined);
+	});
+
+	it("emits one source-authority failure and never invokes the destination", async () => {
+		mocks.readInstanceSelected.mockImplementation(async (input: unknown) =>
+			sourceSelection(input) ? unavailableEvidence("missing_status") : destinationEvidence(),
+		);
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({ status: "failed", totals: { labelsApplied: 0, failures: 1 } });
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 0,
+			destMatchesFound: 0,
+			labelsApplied: 0,
+			failures: 1,
+		});
+		expect(mocks.readInstanceSelected).toHaveBeenCalledOnce();
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expect(terminalEvents(log)).toEqual([
+			[
+				{
+					operation: "source_read",
+					state: "failed",
+					stage: "source_authority",
+					reasonCode: "source_authority_unavailable",
+				},
+				"Plex label-sync source read failed",
+			],
+		]);
+		expectNoCanary(log, result);
+	});
+
+	it("emits one source-read failure and contains a thrown provider error", async () => {
+		mocks.readInstanceSelected.mockImplementation(async (input: unknown) => {
+			if (!sourceSelection(input)) return destinationEvidence();
+			throw new Error(
+				`${canaries.rawError} ${canaries.statusText} ${canaries.url} ${canaries.path} ${canaries.token}`,
+			);
+		});
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({ status: "failed", totals: { labelsApplied: 0, failures: 1 } });
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 0,
+			destMatchesFound: 0,
+			labelsApplied: 0,
+			failures: 1,
+		});
+		expect(mocks.readInstanceSelected).toHaveBeenCalledOnce();
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expect(terminalEvents(log)).toEqual([
+			[
+				{
+					operation: "source_read",
+					state: "failed",
+					stage: "source_read",
+					reasonCode: "source_read_failed",
+				},
+				"Plex label-sync source read failed",
+			],
+		]);
+		expectNoCanary(log, result);
+	});
+
+	it("emits one destination cached-authority failure", async () => {
+		mocks.readInstanceSelected.mockImplementation(async (input: unknown) =>
+			sourceSelection(input) ? sourceEvidence() : unavailableEvidence("missing_status"),
+		);
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({ status: "failed", totals: { labelsApplied: 0, failures: 1 } });
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 1,
+			destMatchesFound: 0,
+			labelsApplied: 0,
+			failures: 1,
+		});
+		expect(mocks.mutateMetadataTag).not.toHaveBeenCalled();
+		expect(terminalEvents(log)).toEqual([
+			[
+				{
+					operation: "destination_write",
+					state: "failed",
+					stage: "destination_authority",
+					reasonCode: "provider_attempt_unavailable",
+					candidateCount: 1,
+				},
+				"Plex label-sync destination write failed",
+			],
+		]);
+		expectNoCanary(log, result);
+	});
+
+	it("emits one destination live-authority failure despite nested diagnostics", async () => {
+		mocks.emitNestedMutationLog.mockImplementation(async (log: FastifyBaseLogger) =>
+			nestedPrivateLog(log),
+		);
+		mocks.mutateMetadataTag.mockResolvedValue({
+			ok: false,
+			reasonCode: "live_target_changed",
+			evidence: unavailableEvidence("plex_content_digest_changed").evidence,
+		});
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({ status: "failed", totals: { labelsApplied: 0, failures: 1 } });
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 1,
+			destMatchesFound: 1,
+			labelsApplied: 0,
+			failures: 1,
+		});
+		expect(terminalEvents(log)).toEqual([
+			[
+				{
+					operation: "destination_write",
+					state: "failed",
+					stage: "destination_authority",
+					reasonCode: "live_target_changed",
+					mediaCategory: "movie",
+				},
+				"Plex label-sync destination write failed",
+			],
+		]);
+		expectNoCanary(log, result);
+	});
+
+	it("emits one upstream-write failure after authority succeeds", async () => {
+		mocks.emitNestedMutationLog.mockImplementation(async (log: FastifyBaseLogger) =>
+			nestedPrivateLog(log),
+		);
+		mocks.mutateMetadataTag.mockRejectedValue(new mocks.PlexMetadataTagWriteError("unavailable"));
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({ status: "failed", totals: { labelsApplied: 0, failures: 1 } });
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 1,
+			destMatchesFound: 1,
+			labelsApplied: 0,
+			failures: 1,
+		});
+		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expect(terminalEvents(log)).toEqual([
+			[
+				{
+					operation: "destination_write",
+					state: "failed",
+					stage: "upstream_write",
+					reasonCode: "upstream_write_failed",
+					mediaCategory: "movie",
+					upstreamCategory: "unavailable",
+				},
+				"Plex label-sync destination write failed",
+			],
+		]);
+		expectNoCanary(log, result);
+	});
+
+	it("writes once and keeps the successful rule private", async () => {
+		const log = createLogger();
+		const result = await execute(log);
+
+		expect(result).toMatchObject({
+			status: "success",
+			totals: { destMatchesFound: 1, labelsApplied: 1, failures: 0 },
+		});
+		expect(result.totals).toEqual({
+			sourceInstancesScanned: 1,
+			taggedItemsFound: 1,
+			destMatchesFound: 1,
+			labelsApplied: 1,
+			failures: 0,
+		});
+		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expect(terminalEvents(log)).toHaveLength(0);
+		expectNoCanary(log, result);
+	});
+});

--- a/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
+++ b/apps/api/src/lib/label-sync/__tests__/plex-whole-execution-logging.test.ts
@@ -1,32 +1,18 @@
 import type { FastifyBaseLogger } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlexMetadataTagWriteError } from "../../plex/plex-label-sync-logging.js";
 import type { ServiceInstance } from "../../prisma.js";
 
 const mocks = vi.hoisted(() => {
-	class PlexMetadataTagWriteError extends Error {
-		readonly code = "upstream_write_failed" as const;
-		readonly responseCategory: "client_error" | "server_error" | "timeout" | "unavailable";
-
-		constructor(
-			responseCategory: "client_error" | "server_error" | "timeout" | "unavailable" = "unavailable",
-		) {
-			super("Plex metadata tag write failed");
-			this.name = "PlexMetadataTagWriteError";
-			this.responseCategory = responseCategory;
-			delete this.stack;
-		}
-	}
 	return {
 		readInstanceSelected: vi.fn(),
 		mutateMetadataTag: vi.fn(),
 		emitNestedReadLog: vi.fn(),
 		emitNestedMutationLog: vi.fn(),
-		PlexMetadataTagWriteError,
 	};
 });
 
 vi.mock("../../plex/plex-authority-service.js", () => ({
-	PlexMetadataTagWriteError: mocks.PlexMetadataTagWriteError,
 	PlexAuthorityService: class {
 		private readonly log: FastifyBaseLogger;
 
@@ -352,7 +338,7 @@ describe("complete Plex-to-Plex label-sync terminal logging", () => {
 		mocks.emitNestedMutationLog.mockImplementation(async (log: FastifyBaseLogger) =>
 			nestedPrivateLog(log),
 		);
-		mocks.mutateMetadataTag.mockRejectedValue(new mocks.PlexMetadataTagWriteError("unavailable"));
+		mocks.mutateMetadataTag.mockRejectedValue(new PlexMetadataTagWriteError("unavailable"));
 		const log = createLogger();
 		const result = await execute(log);
 

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
@@ -230,6 +230,7 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 
 	it.each([
 		["changed cached evidence", "live_target_changed", "live_target_changed"],
+		["incomplete live settlement", "live_evidence_unavailable", "live_evidence_unavailable"],
 		["missing live target", "live_target_missing", "live_target_missing"],
 		["ambiguous live target", "live_target_ambiguous", "live_target_ambiguous"],
 		["changed or reused rating key", "live_target_changed", "live_target_changed"],
@@ -285,7 +286,7 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 		expectPrivate(log, result);
 	});
 
-	it("maps a changed Plex content digest to a changed live target", async () => {
+	it("maps a generic Plex content digest failure to unavailable live evidence", async () => {
 		mocks.readInstanceSelected.mockResolvedValue(
 			unavailableEvidence("plex_content_digest_changed"),
 		);
@@ -293,7 +294,7 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 		const result = await apply(log);
 
 		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
-		expectReason(log, "live_target_changed");
+		expectReason(log, "live_evidence_unavailable");
 		expectPrivate(log, result);
 	});
 

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
@@ -1,31 +1,19 @@
 import type { FastifyBaseLogger } from "fastify";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlexMetadataTagWriteError } from "../../../plex/plex-label-sync-logging.js";
 import type { LabelSyncRuleInput } from "../../execute-rule.js";
 import type { DestWriterOpts } from "../../strategy-types.js";
 
 const mocks = vi.hoisted(() => {
-	class PlexMetadataTagWriteError extends Error {
-		readonly code = "upstream_write_failed";
-		readonly responseCategory: "client_error" | "server_error" | "timeout" | "unavailable";
-
-		constructor(
-			responseCategory: "client_error" | "server_error" | "timeout" | "unavailable" = "unavailable",
-		) {
-			super("Plex metadata tag write failed");
-			this.name = "PlexMetadataTagWriteError";
-			this.responseCategory = responseCategory;
-		}
-	}
 	return {
 		readInstanceSelected: vi.fn(),
 		mutateMetadataTag: vi.fn(),
+		upstreamWrite: vi.fn(),
 		emitProviderLog: vi.fn(),
-		PlexMetadataTagWriteError,
 	};
 });
 
 vi.mock("../../../plex/plex-authority-service.js", () => ({
-	PlexMetadataTagWriteError: mocks.PlexMetadataTagWriteError,
 	PlexAuthorityService: class {
 		private readonly log: FastifyBaseLogger;
 
@@ -196,7 +184,11 @@ async function apply(
 describe("Plex label writer privacy-safe mutation logging", () => {
 	beforeEach(() => {
 		mocks.readInstanceSelected.mockReset().mockResolvedValue(authoritativeEvidence([canaryRow()]));
-		mocks.mutateMetadataTag.mockReset().mockResolvedValue({ ok: true });
+		mocks.upstreamWrite.mockReset().mockResolvedValue(undefined);
+		mocks.mutateMetadataTag.mockReset().mockImplementation(async () => {
+			await mocks.upstreamWrite();
+			return { ok: true };
+		});
 		mocks.emitProviderLog.mockReset().mockResolvedValue(undefined);
 	});
 
@@ -320,32 +312,62 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 				`${canaries.rawError} ${canaries.url}`,
 			);
 		});
-		mocks.mutateMetadataTag.mockRejectedValueOnce(
-			new mocks.PlexMetadataTagWriteError(responseCategory),
-		);
+		mocks.mutateMetadataTag.mockImplementationOnce(async () => {
+			await mocks.upstreamWrite();
+			throw new PlexMetadataTagWriteError(responseCategory);
+		});
 		const log = createLogger();
 		const result = await apply(log);
 
 		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expect(mocks.upstreamWrite).toHaveBeenCalledOnce();
 		expect(log.warn).toHaveBeenCalledTimes(1);
-		expectReason(
-			log,
-			responseCategory === "client_error" ? "upstream_write_rejected" : "upstream_write_failed",
+		expect(log.warn).toHaveBeenCalledWith(
+			{
+				operation: "destination_write",
+				state: "failed",
+				stage: "upstream_write",
+				reasonCode:
+					responseCategory === "client_error" ? "upstream_write_rejected" : "upstream_write_failed",
+				mediaCategory: "movie",
+				upstreamCategory: responseCategory,
+			},
+			"Plex label-sync destination write failed",
 		);
 		expectPrivate(log, result);
 	});
 
-	it("maps an unknown outer exception to a bounded fallback", async () => {
-		mocks.mutateMetadataTag.mockRejectedValueOnce(
-			new Error(`${canaries.rawError} ${canaries.url} ${canaries.responseBody}`),
-		);
-		const log = createLogger();
-		const result = await apply(log);
+	it.each([
+		["Error", new Error(`${canaries.rawError} ${canaries.url} ${canaries.responseBody}`)],
+		["string", `${canaries.rawError} ${canaries.token}`],
+		["object", { privatePath: canaries.url, privateBody: canaries.responseBody }],
+		["null", null],
+		["undefined", undefined],
+	] as const)(
+		"classifies a pre-write %s as an unknown authority failure",
+		async (_name, thrown) => {
+			mocks.mutateMetadataTag.mockImplementationOnce(async () => {
+				throw thrown;
+			});
+			const log = createLogger();
+			const result = await apply(log);
 
-		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
-		expectReason(log, "unknown_failure");
-		expectPrivate(log, result);
-	});
+			expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+			expect(mocks.upstreamWrite).not.toHaveBeenCalled();
+			expect(log.warn).toHaveBeenCalledTimes(1);
+			expect(log.warn).toHaveBeenCalledWith(
+				{
+					operation: "destination_write",
+					state: "failed",
+					stage: "destination_authority",
+					reasonCode: "unknown_failure",
+					mediaCategory: "movie",
+				},
+				"Plex label-sync destination write failed",
+			);
+			expectPrivate(log, result);
+		},
+	);
 
 	it("keeps a successful write private and records exactly one success", async () => {
 		const log = createLogger();
@@ -353,6 +375,7 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 
 		expect(result).toEqual({ matchesFound: 1, labelsApplied: 1, failures: 0 });
 		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expect(mocks.upstreamWrite).toHaveBeenCalledOnce();
 		expect(log.warn).not.toHaveBeenCalled();
 		expect(log.error).not.toHaveBeenCalled();
 		expectPrivate(log, result);

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
@@ -1,0 +1,332 @@
+import type { FastifyBaseLogger } from "fastify";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LabelSyncRuleInput } from "../../execute-rule.js";
+import type { DestWriterOpts } from "../../strategy-types.js";
+
+const mocks = vi.hoisted(() => {
+	class PlexMetadataTagWriteError extends Error {
+		readonly code = "upstream_write_failed";
+
+		constructor() {
+			super("Plex metadata tag write failed");
+			this.name = "PlexMetadataTagWriteError";
+		}
+	}
+	return {
+		readInstanceSelected: vi.fn(),
+		mutateMetadataTag: vi.fn(),
+		emitProviderLog: vi.fn(),
+		PlexMetadataTagWriteError,
+	};
+});
+
+vi.mock("../../../plex/plex-authority-service.js", () => ({
+	PlexMetadataTagWriteError: mocks.PlexMetadataTagWriteError,
+	PlexAuthorityService: class {
+		private readonly log: FastifyBaseLogger;
+
+		constructor(input: { log: FastifyBaseLogger }) {
+			this.log = input.log;
+		}
+
+		async readInstanceSelected(input: unknown) {
+			return await mocks.readInstanceSelected(input);
+		}
+
+		async mutateMetadataTag(input: unknown) {
+			await mocks.emitProviderLog(this.log);
+			return await mocks.mutateMetadataTag(input);
+		}
+	},
+}));
+
+import { plexDestWriter } from "../plex-writer.js";
+
+const canaries = {
+	title: "CANARY_TITLE_A9F4",
+	tmdbId: 987654321,
+	ratingKey: "987650123456789",
+	guid: "plex://CANARY_GUID_C3E8",
+	sectionId: "CANARY_SECTION_ID_D6A1",
+	sectionTitle: "CANARY_SECTION_TITLE_E5B9",
+	username: "CANARY_USERNAME_F2C7",
+	url: "https://CANARY_HOST_G8D4.invalid/library/metadata/private",
+	hostname: "CANARY_HOST_G8D4.invalid",
+	token: "CANARY_TOKEN_H1E6",
+	apiKey: "CANARY_API_KEY_J4B3",
+	rawError: "CANARY_RAW_ERROR_K7F5",
+	responseBody: "CANARY_RESPONSE_BODY_L2A8",
+} as const;
+
+const rule = {
+	id: "rule-1",
+	userId: "user-1",
+	sourceService: "plex",
+	destService: "plex",
+	sourceInstanceId: "plex-source",
+	destInstanceId: "plex-dest",
+	sourceTagName: "Kids",
+	destTagName: "Family",
+} as LabelSyncRuleInput;
+
+const instance = {
+	id: "plex-dest",
+	userId: "user-1",
+	service: "PLEX",
+	label: "Plex",
+} as DestWriterOpts["destInstance"];
+
+function createLogger() {
+	return {
+		child: vi.fn().mockReturnThis(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+	} as unknown as FastifyBaseLogger;
+}
+
+function canaryRow(overrides: Record<string, unknown> = {}) {
+	return {
+		tmdbId: canaries.tmdbId,
+		mediaType: "movie",
+		title: canaries.title,
+		ratingKey: canaries.ratingKey,
+		thumb: `/library/metadata/${canaries.ratingKey}/thumb/1`,
+		guid: canaries.guid,
+		sectionId: canaries.sectionId,
+		sectionTitle: canaries.sectionTitle,
+		username: canaries.username,
+		provider: {
+			url: canaries.url,
+			hostname: canaries.hostname,
+			token: canaries.token,
+			apiKey: canaries.apiKey,
+			responseBody: canaries.responseBody,
+		},
+		...overrides,
+	};
+}
+
+function authoritativeEvidence(rows: unknown[]) {
+	return {
+		available: true,
+		connectionGeneration: 4,
+		identityGeneration: 9,
+		evidence: {
+			publicationLevel: "authoritative",
+			completeness: "complete",
+			reasonCodes: [],
+		},
+		rows,
+	};
+}
+
+function unavailableEvidence(reasonCode: string) {
+	return {
+		available: false,
+		evidence: {
+			publicationLevel: "unavailable",
+			completeness: "unknown",
+			reasonCodes: [reasonCode],
+			provider: canaryRow(),
+		},
+	};
+}
+
+function allLogText(log: FastifyBaseLogger, diagnostics?: unknown): string {
+	const calls = [log.info, log.warn, log.error, log.debug, log.trace, log.fatal].flatMap(
+		(method) => (method as unknown as ReturnType<typeof vi.fn>).mock.calls,
+	);
+	return JSON.stringify({ calls, diagnostics });
+}
+
+function expectPrivate(log: FastifyBaseLogger, diagnostics?: unknown) {
+	const allowedKeys = new Set([
+		"operation",
+		"reasonCode",
+		"mediaCategory",
+		"candidateCount",
+		"responseCategory",
+	]);
+	for (const method of [log.info, log.warn, log.error, log.debug, log.trace, log.fatal]) {
+		for (const [fields] of (method as unknown as ReturnType<typeof vi.fn>).mock.calls) {
+			if (!fields || typeof fields !== "object") continue;
+			expect(Object.keys(fields).every((key) => allowedKeys.has(key))).toBe(true);
+		}
+	}
+	const serialized = allLogText(log, diagnostics);
+	for (const value of Object.values(canaries)) {
+		expect(serialized).not.toContain(String(value));
+	}
+}
+
+function expectReason(log: FastifyBaseLogger, reasonCode: string) {
+	expect(log.warn).toHaveBeenCalledWith(
+		expect.objectContaining({ operation: "plex_label_mutation", reasonCode }),
+		"Plex label mutation failed",
+	);
+}
+
+async function apply(
+	log: FastifyBaseLogger,
+	candidates: DestWriterOpts["candidates"] = [
+		{ tmdbId: canaries.tmdbId, mediaType: "movie", title: canaries.title },
+	],
+) {
+	return await plexDestWriter.applyLabels({
+		rule,
+		destInstance: instance,
+		candidates,
+		prisma: {} as DestWriterOpts["prisma"],
+		arrClientFactory: {} as DestWriterOpts["arrClientFactory"],
+		encryptor: {} as DestWriterOpts["encryptor"],
+		log,
+	});
+}
+
+describe("Plex label writer privacy-safe mutation logging", () => {
+	beforeEach(() => {
+		mocks.readInstanceSelected.mockReset().mockResolvedValue(authoritativeEvidence([canaryRow()]));
+		mocks.mutateMetadataTag.mockReset().mockResolvedValue({ ok: true });
+		mocks.emitProviderLog.mockReset().mockResolvedValue(undefined);
+	});
+
+	it("redacts missing cached target evidence", async () => {
+		mocks.readInstanceSelected.mockResolvedValue(
+			authoritativeEvidence([canaryRow({ ratingKey: null, thumb: null })]),
+		);
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expectReason(log, "cached_target_unavailable");
+		expectPrivate(log, result);
+	});
+
+	it("redacts inconsistent cached target evidence", async () => {
+		mocks.readInstanceSelected.mockResolvedValue(
+			authoritativeEvidence([canaryRow({ thumb: "/library/metadata/123456789/thumb/1" })]),
+		);
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expectReason(log, "cached_target_inconsistent");
+		expectPrivate(log, result);
+	});
+
+	it("logs ambiguous candidates without exposing either logical identity", async () => {
+		const log = createLogger();
+		const result = await apply(log, [
+			{ tmdbId: canaries.tmdbId, mediaType: "movie", title: canaries.title },
+			{ tmdbId: canaries.tmdbId, mediaType: "series", title: `${canaries.title}_SERIES` },
+		]);
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 2 });
+		expectReason(log, "cached_target_ambiguous");
+		expectPrivate(log, result);
+	});
+
+	it.each([
+		["changed cached evidence", "live_target_changed"],
+		["missing live target", "live_target_missing"],
+		["ambiguous live target", "live_target_ambiguous"],
+		["changed or reused rating key", "live_target_changed"],
+		["connection generation change", "provider_connection_changed"],
+		["identity generation change", "provider_identity_changed"],
+		["disabled or unowned provider", "provider_authority_unavailable"],
+		["Plex read failure", "provider_authority_unavailable"],
+		["duplicate-edition ambiguity", "live_target_ambiguous"],
+	] as const)("redacts %s diagnostics", async (_name, reasonCode) => {
+		mocks.mutateMetadataTag.mockResolvedValue({
+			ok: false,
+			reasonCode,
+			evidence: unavailableEvidence("provider_private_reason").evidence,
+		});
+		mocks.emitProviderLog.mockImplementationOnce(async (providerLog: FastifyBaseLogger) => {
+			providerLog.error(
+				{
+					err: new Error(`${canaries.rawError} ${canaries.url} ${canaries.token}`),
+					response: canaries.responseBody,
+					row: canaryRow(),
+				},
+				`${canaries.rawError} ${canaries.sectionTitle}`,
+			);
+		});
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expectReason(log, reasonCode);
+		expectPrivate(log, result);
+	});
+
+	it.each([
+		["failed", "latest_attempt_failed"],
+		["in progress", "latest_attempt_in_progress"],
+		["unavailable", "missing_status"],
+	] as const)("redacts a %s publication attempt", async (_name, providerReason) => {
+		mocks.readInstanceSelected.mockResolvedValue(unavailableEvidence(providerReason));
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
+		expectReason(
+			log,
+			providerReason.startsWith("latest_attempt_")
+				? "publication_superseded"
+				: "provider_authority_unavailable",
+		);
+		expectPrivate(log, result);
+	});
+
+	it.each([
+		["rejected response", "client_error"],
+		["write exception", "unavailable"],
+	] as const)("redacts an upstream metadata-tag %s", async (_name, responseCategory) => {
+		mocks.emitProviderLog.mockImplementationOnce(async (providerLog: FastifyBaseLogger) => {
+			providerLog.warn(
+				{
+					operation: "plex_api_request",
+					responseCategory,
+					path: `/library/metadata/${canaries.ratingKey}?token=${canaries.token}`,
+					body: canaries.responseBody,
+				},
+				`${canaries.rawError} ${canaries.url}`,
+			);
+		});
+		mocks.mutateMetadataTag.mockRejectedValueOnce(new mocks.PlexMetadataTagWriteError());
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expectReason(log, "upstream_write_failed");
+		expectPrivate(log, result);
+	});
+
+	it("maps an unknown outer exception to a bounded fallback", async () => {
+		mocks.mutateMetadataTag.mockRejectedValueOnce(
+			new Error(`${canaries.rawError} ${canaries.url} ${canaries.responseBody}`),
+		);
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
+		expectReason(log, "unknown_failure");
+		expectPrivate(log, result);
+	});
+
+	it("keeps a successful write private and records exactly one success", async () => {
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 1, labelsApplied: 1, failures: 0 });
+		expect(mocks.mutateMetadataTag).toHaveBeenCalledOnce();
+		expect(log.warn).not.toHaveBeenCalled();
+		expect(log.error).not.toHaveBeenCalled();
+		expectPrivate(log, result);
+	});
+});

--- a/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/__tests__/plex-writer-logging.test.ts
@@ -6,10 +6,14 @@ import type { DestWriterOpts } from "../../strategy-types.js";
 const mocks = vi.hoisted(() => {
 	class PlexMetadataTagWriteError extends Error {
 		readonly code = "upstream_write_failed";
+		readonly responseCategory: "client_error" | "server_error" | "timeout" | "unavailable";
 
-		constructor() {
+		constructor(
+			responseCategory: "client_error" | "server_error" | "timeout" | "unavailable" = "unavailable",
+		) {
 			super("Plex metadata tag write failed");
 			this.name = "PlexMetadataTagWriteError";
+			this.responseCategory = responseCategory;
 		}
 	}
 	return {
@@ -146,10 +150,12 @@ function allLogText(log: FastifyBaseLogger, diagnostics?: unknown): string {
 function expectPrivate(log: FastifyBaseLogger, diagnostics?: unknown) {
 	const allowedKeys = new Set([
 		"operation",
+		"state",
+		"stage",
 		"reasonCode",
 		"mediaCategory",
 		"candidateCount",
-		"responseCategory",
+		"upstreamCategory",
 	]);
 	for (const method of [log.info, log.warn, log.error, log.debug, log.trace, log.fatal]) {
 		for (const [fields] of (method as unknown as ReturnType<typeof vi.fn>).mock.calls) {
@@ -165,8 +171,8 @@ function expectPrivate(log: FastifyBaseLogger, diagnostics?: unknown) {
 
 function expectReason(log: FastifyBaseLogger, reasonCode: string) {
 	expect(log.warn).toHaveBeenCalledWith(
-		expect.objectContaining({ operation: "plex_label_mutation", reasonCode }),
-		"Plex label mutation failed",
+		expect.objectContaining({ operation: "destination_write", state: "failed", reasonCode }),
+		"Plex label-sync destination write failed",
 	);
 }
 
@@ -231,19 +237,23 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 	});
 
 	it.each([
-		["changed cached evidence", "live_target_changed"],
-		["missing live target", "live_target_missing"],
-		["ambiguous live target", "live_target_ambiguous"],
-		["changed or reused rating key", "live_target_changed"],
-		["connection generation change", "provider_connection_changed"],
-		["identity generation change", "provider_identity_changed"],
-		["disabled or unowned provider", "provider_authority_unavailable"],
-		["Plex read failure", "provider_authority_unavailable"],
-		["duplicate-edition ambiguity", "live_target_ambiguous"],
-	] as const)("redacts %s diagnostics", async (_name, reasonCode) => {
+		["changed cached evidence", "live_target_changed", "live_target_changed"],
+		["missing live target", "live_target_missing", "live_target_missing"],
+		["ambiguous live target", "live_target_ambiguous", "live_target_ambiguous"],
+		["changed or reused rating key", "live_target_changed", "live_target_changed"],
+		["connection generation change", "provider_connection_changed", "provider_connection_changed"],
+		["identity generation change", "provider_identity_changed", "provider_identity_changed"],
+		[
+			"disabled or unowned provider",
+			"provider_authority_unavailable",
+			"provider_attempt_unavailable",
+		],
+		["Plex read failure", "provider_authority_unavailable", "provider_attempt_unavailable"],
+		["duplicate-edition ambiguity", "live_target_ambiguous", "live_target_ambiguous"],
+	] as const)("redacts %s diagnostics", async (_name, authorityReason, terminalReason) => {
 		mocks.mutateMetadataTag.mockResolvedValue({
 			ok: false,
-			reasonCode,
+			reasonCode: authorityReason,
 			evidence: unavailableEvidence("provider_private_reason").evidence,
 		});
 		mocks.emitProviderLog.mockImplementationOnce(async (providerLog: FastifyBaseLogger) => {
@@ -260,7 +270,7 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 		const result = await apply(log);
 
 		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
-		expectReason(log, reasonCode);
+		expectReason(log, terminalReason);
 		expectPrivate(log, result);
 	});
 
@@ -278,8 +288,20 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 			log,
 			providerReason.startsWith("latest_attempt_")
 				? "publication_superseded"
-				: "provider_authority_unavailable",
+				: "provider_attempt_unavailable",
 		);
+		expectPrivate(log, result);
+	});
+
+	it("maps a changed Plex content digest to a changed live target", async () => {
+		mocks.readInstanceSelected.mockResolvedValue(
+			unavailableEvidence("plex_content_digest_changed"),
+		);
+		const log = createLogger();
+		const result = await apply(log);
+
+		expect(result).toEqual({ matchesFound: 0, labelsApplied: 0, failures: 1 });
+		expectReason(log, "live_target_changed");
 		expectPrivate(log, result);
 	});
 
@@ -298,12 +320,18 @@ describe("Plex label writer privacy-safe mutation logging", () => {
 				`${canaries.rawError} ${canaries.url}`,
 			);
 		});
-		mocks.mutateMetadataTag.mockRejectedValueOnce(new mocks.PlexMetadataTagWriteError());
+		mocks.mutateMetadataTag.mockRejectedValueOnce(
+			new mocks.PlexMetadataTagWriteError(responseCategory),
+		);
 		const log = createLogger();
 		const result = await apply(log);
 
 		expect(result).toEqual({ matchesFound: 1, labelsApplied: 0, failures: 1 });
-		expectReason(log, "upstream_write_failed");
+		expect(log.warn).toHaveBeenCalledTimes(1);
+		expectReason(
+			log,
+			responseCategory === "client_error" ? "upstream_write_rejected" : "upstream_write_failed",
+		);
 		expectPrivate(log, result);
 	});
 

--- a/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
@@ -6,96 +6,41 @@
  * apply the destination label.
  */
 
-import type { PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import {
 	PlexAuthorityService,
-	PlexMetadataTagWriteError,
 	type PlexMetadataTagMutationFailureReason,
+	PlexMetadataTagWriteError,
 } from "../../plex/plex-authority-service.js";
+import type { PlexResponseCategory } from "../../plex/plex-client.js";
+import {
+	classifyPlexLabelSyncTerminalReason,
+	classifyPlexMetadataTagEvidenceFailure,
+	classifyUnknownPlexLabelSyncTerminalReason,
+	createLabelSyncPlexProviderLogSink,
+	logPlexLabelSyncTerminal,
+} from "../../plex/plex-label-sync-logging.js";
 import type { DestWriteResult, DestWriter, DestWriterOpts } from "../strategy-types.js";
 
-type PlexResponseCategory = "client_error" | "server_error" | "timeout" | "unavailable";
-
-function logPlexLabelMutationFailure(
+function logDestinationAuthorityFailure(
 	log: FastifyBaseLogger,
 	reasonCode: PlexMetadataTagMutationFailureReason,
 	options: {
 		mediaCategory?: "movie" | "series";
 		candidateCount?: number;
-		responseCategory?: PlexResponseCategory;
 	} = {},
-) {
-	const projection: {
-		operation: "plex_label_mutation";
-		reasonCode: PlexMetadataTagMutationFailureReason;
-		mediaCategory?: "movie" | "series";
-		candidateCount?: number;
-		responseCategory?: PlexResponseCategory;
-	} = { operation: "plex_label_mutation", reasonCode };
-	if (options.mediaCategory) projection.mediaCategory = options.mediaCategory;
-	if (
-		options.candidateCount !== undefined &&
-		Number.isSafeInteger(options.candidateCount) &&
-		options.candidateCount >= 0
-	) {
-		projection.candidateCount = options.candidateCount;
-	}
-	if (options.responseCategory) projection.responseCategory = options.responseCategory;
-	log.warn(projection, "Plex label mutation failed");
-}
-
-function readSafeResponseCategory(args: unknown[]): PlexResponseCategory | undefined {
-	const fields = args[0];
-	if (!fields || typeof fields !== "object" || !("responseCategory" in fields)) return undefined;
-	const category = fields.responseCategory;
-	return category === "client_error" ||
-		category === "server_error" ||
-		category === "timeout" ||
-		category === "unavailable"
-		? category
-		: undefined;
-}
-
-function createPlexLabelMutationProviderLogger(log: FastifyBaseLogger): FastifyBaseLogger {
-	let safeLogger: FastifyBaseLogger;
-	const reproject = (...args: unknown[]) => {
-		logPlexLabelMutationFailure(log, "provider_authority_unavailable", {
-			responseCategory: readSafeResponseCategory(args),
-		});
-	};
-	const ignore = () => undefined;
-	safeLogger = {
-		child: () => safeLogger,
-		info: ignore,
-		warn: reproject,
-		error: reproject,
-		debug: ignore,
-		trace: ignore,
-		fatal: reproject,
-	} as unknown as FastifyBaseLogger;
-	return safeLogger;
-}
-
-function classifyEvidenceFailure(
-	evidence: PlexEvidenceSummary,
-): PlexMetadataTagMutationFailureReason {
-	const codes = new Set<PlexCoverageReasonCode>(evidence.reasonCodes);
-	if (codes.has("connection_generation_mismatch")) return "provider_connection_changed";
-	if (codes.has("identity_generation_mismatch")) return "provider_identity_changed";
-	if (
-		codes.has("latest_attempt_failed") ||
-		codes.has("latest_attempt_in_progress") ||
-		codes.has("latest_attempt_partial") ||
-		codes.has("latest_attempt_unknown") ||
-		codes.has("latest_attempt_missing") ||
-		codes.has("latest_attempt_future_dated") ||
-		codes.has("generation_changed") ||
-		codes.has("published_timestamp_changed")
-	) {
-		return "publication_superseded";
-	}
-	return "provider_authority_unavailable";
+): void {
+	logPlexLabelSyncTerminal(log, {
+		operation: "destination_write",
+		state: "failed",
+		stage: "destination_authority",
+		reasonCode: classifyUnknownPlexLabelSyncTerminalReason({
+			stage: "destination_authority",
+			code: reasonCode,
+		}),
+		...(options.mediaCategory ? { mediaCategory: options.mediaCategory } : {}),
+		...(options.candidateCount === undefined ? {} : { candidateCount: options.candidateCount }),
+	});
 }
 
 export const plexDestWriter: DestWriter = {
@@ -117,7 +62,7 @@ export const plexDestWriter: DestWriter = {
 		);
 		const ambiguousCandidateCount = candidates.length - unambiguousCandidates.length;
 		if (ambiguousCandidateCount > 0) {
-			logPlexLabelMutationFailure(log, "cached_target_ambiguous", {
+			logDestinationAuthorityFailure(log, "cached_target_ambiguous", {
 				candidateCount: ambiguousCandidateCount,
 			});
 		}
@@ -131,23 +76,35 @@ export const plexDestWriter: DestWriter = {
 		const authority = new PlexAuthorityService({
 			prisma,
 			encryptor,
-			log: createPlexLabelMutationProviderLogger(log),
+			log: createLabelSyncPlexProviderLogSink(),
 		});
-		const evidence = await authority.readInstanceSelected({
-			userId: rule.userId,
-			instanceId: rule.destInstanceId,
-			selection: { kind: "targets", targets },
-			domains: ["membership"],
-		});
+		let evidence: Awaited<ReturnType<PlexAuthorityService["readInstanceSelected"]>>;
+		try {
+			evidence = await authority.readInstanceSelected({
+				userId: rule.userId,
+				instanceId: rule.destInstanceId,
+				selection: { kind: "targets", targets },
+				domains: ["membership"],
+			});
+		} catch {
+			logDestinationAuthorityFailure(log, "provider_authority_unavailable", {
+				candidateCount: candidates.length,
+			});
+			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
+		}
 		if (
 			!evidence.available ||
 			evidence.evidence.publicationLevel !== "authoritative" ||
 			evidence.evidence.completeness !== "complete" ||
 			evidence.evidence.reasonCodes.length > 0
 		) {
-			logPlexLabelMutationFailure(log, classifyEvidenceFailure(evidence.evidence), {
-				candidateCount: candidates.length,
-			});
+			logDestinationAuthorityFailure(
+				log,
+				classifyPlexMetadataTagEvidenceFailure(evidence.evidence),
+				{
+					candidateCount: candidates.length,
+				},
+			);
 			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
 		}
 
@@ -159,13 +116,13 @@ export const plexDestWriter: DestWriter = {
 		const attemptedRatingKeys = new Set<string>();
 		for (const row of matched) {
 			if (row.mediaType !== "movie" && row.mediaType !== "series") {
-				logPlexLabelMutationFailure(log, "unknown_failure");
+				logDestinationAuthorityFailure(log, "unknown_failure");
 				failures++;
 				continue;
 			}
 			const cachedKey = resolveParitySafeCachedRatingKey(row);
 			if (!cachedKey.ok) {
-				logPlexLabelMutationFailure(log, cachedKey.reasonCode, {
+				logDestinationAuthorityFailure(log, cachedKey.reasonCode, {
 					mediaCategory: row.mediaType,
 				});
 				failures++;
@@ -186,16 +143,26 @@ export const plexDestWriter: DestWriter = {
 					name: rule.destTagName,
 				});
 			} catch (error) {
-				logPlexLabelMutationFailure(
-					log,
-					error instanceof PlexMetadataTagWriteError ? "upstream_write_failed" : "unknown_failure",
-					{ mediaCategory: row.mediaType },
-				);
+				const responseCategory: PlexResponseCategory | undefined =
+					error instanceof PlexMetadataTagWriteError ? error.responseCategory : undefined;
+				logPlexLabelSyncTerminal(log, {
+					operation: "destination_write",
+					state: "failed",
+					stage: "upstream_write",
+					reasonCode: responseCategory
+						? classifyPlexLabelSyncTerminalReason({
+								stage: "upstream_write",
+								code: responseCategory,
+							})
+						: "unknown_failure",
+					mediaCategory: row.mediaType,
+					...(responseCategory ? { upstreamCategory: responseCategory } : {}),
+				});
 				failures++;
 				continue;
 			}
 			if (!mutation.ok) {
-				logPlexLabelMutationFailure(log, mutation.reasonCode, {
+				logDestinationAuthorityFailure(log, mutation.reasonCode, {
 					mediaCategory: row.mediaType,
 				});
 				failures++;

--- a/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
@@ -10,11 +10,9 @@ import type { FastifyBaseLogger } from "fastify";
 import {
 	PlexAuthorityService,
 	type PlexMetadataTagMutationFailureReason,
-	PlexMetadataTagWriteError,
 } from "../../plex/plex-authority-service.js";
-import type { PlexResponseCategory } from "../../plex/plex-client.js";
 import {
-	classifyPlexLabelSyncTerminalReason,
+	classifyPlexLabelMutationCaughtError,
 	classifyPlexMetadataTagEvidenceFailure,
 	classifyUnknownPlexLabelSyncTerminalReason,
 	createLabelSyncPlexProviderLogSink,
@@ -143,20 +141,12 @@ export const plexDestWriter: DestWriter = {
 					name: rule.destTagName,
 				});
 			} catch (error) {
-				const responseCategory: PlexResponseCategory | undefined =
-					error instanceof PlexMetadataTagWriteError ? error.responseCategory : undefined;
+				const classification = classifyPlexLabelMutationCaughtError(error);
 				logPlexLabelSyncTerminal(log, {
 					operation: "destination_write",
 					state: "failed",
-					stage: "upstream_write",
-					reasonCode: responseCategory
-						? classifyPlexLabelSyncTerminalReason({
-								stage: "upstream_write",
-								code: responseCategory,
-							})
-						: "unknown_failure",
+					...classification,
 					mediaCategory: row.mediaType,
-					...(responseCategory ? { upstreamCategory: responseCategory } : {}),
 				});
 				failures++;
 				continue;

--- a/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
+++ b/apps/api/src/lib/label-sync/dest-writers/plex-writer.ts
@@ -6,8 +6,97 @@
  * apply the destination label.
  */
 
-import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
+import type { PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
+import type { FastifyBaseLogger } from "fastify";
+import {
+	PlexAuthorityService,
+	PlexMetadataTagWriteError,
+	type PlexMetadataTagMutationFailureReason,
+} from "../../plex/plex-authority-service.js";
 import type { DestWriteResult, DestWriter, DestWriterOpts } from "../strategy-types.js";
+
+type PlexResponseCategory = "client_error" | "server_error" | "timeout" | "unavailable";
+
+function logPlexLabelMutationFailure(
+	log: FastifyBaseLogger,
+	reasonCode: PlexMetadataTagMutationFailureReason,
+	options: {
+		mediaCategory?: "movie" | "series";
+		candidateCount?: number;
+		responseCategory?: PlexResponseCategory;
+	} = {},
+) {
+	const projection: {
+		operation: "plex_label_mutation";
+		reasonCode: PlexMetadataTagMutationFailureReason;
+		mediaCategory?: "movie" | "series";
+		candidateCount?: number;
+		responseCategory?: PlexResponseCategory;
+	} = { operation: "plex_label_mutation", reasonCode };
+	if (options.mediaCategory) projection.mediaCategory = options.mediaCategory;
+	if (
+		options.candidateCount !== undefined &&
+		Number.isSafeInteger(options.candidateCount) &&
+		options.candidateCount >= 0
+	) {
+		projection.candidateCount = options.candidateCount;
+	}
+	if (options.responseCategory) projection.responseCategory = options.responseCategory;
+	log.warn(projection, "Plex label mutation failed");
+}
+
+function readSafeResponseCategory(args: unknown[]): PlexResponseCategory | undefined {
+	const fields = args[0];
+	if (!fields || typeof fields !== "object" || !("responseCategory" in fields)) return undefined;
+	const category = fields.responseCategory;
+	return category === "client_error" ||
+		category === "server_error" ||
+		category === "timeout" ||
+		category === "unavailable"
+		? category
+		: undefined;
+}
+
+function createPlexLabelMutationProviderLogger(log: FastifyBaseLogger): FastifyBaseLogger {
+	let safeLogger: FastifyBaseLogger;
+	const reproject = (...args: unknown[]) => {
+		logPlexLabelMutationFailure(log, "provider_authority_unavailable", {
+			responseCategory: readSafeResponseCategory(args),
+		});
+	};
+	const ignore = () => undefined;
+	safeLogger = {
+		child: () => safeLogger,
+		info: ignore,
+		warn: reproject,
+		error: reproject,
+		debug: ignore,
+		trace: ignore,
+		fatal: reproject,
+	} as unknown as FastifyBaseLogger;
+	return safeLogger;
+}
+
+function classifyEvidenceFailure(
+	evidence: PlexEvidenceSummary,
+): PlexMetadataTagMutationFailureReason {
+	const codes = new Set<PlexCoverageReasonCode>(evidence.reasonCodes);
+	if (codes.has("connection_generation_mismatch")) return "provider_connection_changed";
+	if (codes.has("identity_generation_mismatch")) return "provider_identity_changed";
+	if (
+		codes.has("latest_attempt_failed") ||
+		codes.has("latest_attempt_in_progress") ||
+		codes.has("latest_attempt_partial") ||
+		codes.has("latest_attempt_unknown") ||
+		codes.has("latest_attempt_missing") ||
+		codes.has("latest_attempt_future_dated") ||
+		codes.has("generation_changed") ||
+		codes.has("published_timestamp_changed")
+	) {
+		return "publication_superseded";
+	}
+	return "provider_authority_unavailable";
+}
 
 export const plexDestWriter: DestWriter = {
 	prismaService: "PLEX",
@@ -27,6 +116,11 @@ export const plexDestWriter: DestWriter = {
 			(candidate) => mediaTypesByTmdbId.get(candidate.tmdbId)?.size === 1,
 		);
 		const ambiguousCandidateCount = candidates.length - unambiguousCandidates.length;
+		if (ambiguousCandidateCount > 0) {
+			logPlexLabelMutationFailure(log, "cached_target_ambiguous", {
+				candidateCount: ambiguousCandidateCount,
+			});
+		}
 		if (unambiguousCandidates.length === 0) {
 			return { matchesFound: 0, labelsApplied: 0, failures: ambiguousCandidateCount };
 		}
@@ -34,7 +128,11 @@ export const plexDestWriter: DestWriter = {
 			tmdbId: candidate.tmdbId,
 			mediaType: candidate.mediaType,
 		}));
-		const authority = new PlexAuthorityService({ prisma, encryptor, log });
+		const authority = new PlexAuthorityService({
+			prisma,
+			encryptor,
+			log: createPlexLabelMutationProviderLogger(log),
+		});
 		const evidence = await authority.readInstanceSelected({
 			userId: rule.userId,
 			instanceId: rule.destInstanceId,
@@ -47,7 +145,9 @@ export const plexDestWriter: DestWriter = {
 			evidence.evidence.completeness !== "complete" ||
 			evidence.evidence.reasonCodes.length > 0
 		) {
-			log.warn({ instanceId: rule.destInstanceId }, "Plex label destination evidence unavailable");
+			logPlexLabelMutationFailure(log, classifyEvidenceFailure(evidence.evidence), {
+				candidateCount: candidates.length,
+			});
 			return { matchesFound: 0, labelsApplied: 0, failures: candidates.length };
 		}
 
@@ -59,18 +159,19 @@ export const plexDestWriter: DestWriter = {
 		const attemptedRatingKeys = new Set<string>();
 		for (const row of matched) {
 			if (row.mediaType !== "movie" && row.mediaType !== "series") {
+				logPlexLabelMutationFailure(log, "unknown_failure");
 				failures++;
 				continue;
 			}
-			const ratingKey = resolveParitySafeCachedRatingKey(row);
-			if (!ratingKey) {
-				log.warn(
-					{ tmdbId: row.tmdbId, title: row.title },
-					"Plex label target lacks matching cached rating-key evidence",
-				);
+			const cachedKey = resolveParitySafeCachedRatingKey(row);
+			if (!cachedKey.ok) {
+				logPlexLabelMutationFailure(log, cachedKey.reasonCode, {
+					mediaCategory: row.mediaType,
+				});
 				failures++;
 				continue;
 			}
+			const ratingKey = cachedKey.ratingKey;
 			if (attemptedRatingKeys.has(ratingKey)) continue;
 			attemptedRatingKeys.add(ratingKey);
 			let mutation: Awaited<ReturnType<PlexAuthorityService["mutateMetadataTag"]>>;
@@ -84,16 +185,19 @@ export const plexDestWriter: DestWriter = {
 					action: "add",
 					name: rule.destTagName,
 				});
-			} catch (err) {
-				log.warn({ ratingKey, err }, "Failed to apply Plex label");
+			} catch (error) {
+				logPlexLabelMutationFailure(
+					log,
+					error instanceof PlexMetadataTagWriteError ? "upstream_write_failed" : "unknown_failure",
+					{ mediaCategory: row.mediaType },
+				);
 				failures++;
 				continue;
 			}
 			if (!mutation.ok) {
-				log.warn(
-					{ tmdbId: row.tmdbId, ratingKey },
-					"Plex label target evidence changed before mutation",
-				);
+				logPlexLabelMutationFailure(log, mutation.reasonCode, {
+					mediaCategory: row.mediaType,
+				});
 				failures++;
 				continue;
 			}
@@ -107,9 +211,16 @@ export const plexDestWriter: DestWriter = {
 function resolveParitySafeCachedRatingKey(row: {
 	ratingKey: string | null;
 	thumb: string | null;
-}): string | undefined {
+}):
+	| { ok: true; ratingKey: string }
+	| { ok: false; reasonCode: "cached_target_unavailable" | "cached_target_inconsistent" } {
 	const explicitRatingKey = row.ratingKey?.trim();
-	if (!explicitRatingKey || !row.thumb) return undefined;
+	if (!explicitRatingKey || !row.thumb) {
+		return { ok: false, reasonCode: "cached_target_unavailable" };
+	}
 	const legacyRatingKey = row.thumb.match(/\/library\/metadata\/(\d+)/)?.[1];
-	return legacyRatingKey === explicitRatingKey ? explicitRatingKey : undefined;
+	if (!legacyRatingKey) return { ok: false, reasonCode: "cached_target_unavailable" };
+	return legacyRatingKey === explicitRatingKey
+		? { ok: true, ratingKey: explicitRatingKey }
+		: { ok: false, reasonCode: "cached_target_inconsistent" };
 }

--- a/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
+++ b/apps/api/src/lib/label-sync/source-readers/plex-reader.ts
@@ -13,18 +13,24 @@ import type {
 	SourceReadResult,
 } from "../strategy-types.js";
 import { PlexAuthorityService } from "../../plex/plex-authority-service.js";
+import {
+	classifyPlexLabelSyncTerminalReason,
+	createLabelSyncPlexProviderLogSink,
+	logPlexLabelSyncTerminal,
+} from "../../plex/plex-label-sync-logging.js";
 
 export const plexSourceReader: SourceReader = {
 	prismaService: "PLEX",
 	async readTaggedItems(opts: SourceReaderOpts): Promise<SourceReadResult> {
 		const { rule, sourceInstance, prisma, log } = opts;
+		const providerLog = createLabelSyncPlexProviderLogSink();
 
 		let rows: Array<{ tmdbId: number; mediaType: string; title: string; labels: string }>;
 		try {
 			const evidence = await new PlexAuthorityService({
 				prisma,
 				encryptor: opts.encryptor,
-				log,
+				log: providerLog,
 			}).readInstanceSelected({
 				userId: rule.userId,
 				instanceId: sourceInstance.id,
@@ -40,11 +46,31 @@ export const plexSourceReader: SourceReader = {
 				evidence.evidence.completeness !== "complete" ||
 				evidence.evidence.reasonCodes.length > 0
 			) {
+				const reasonCode = evidence.evidence.reasonCodes[0];
+				logPlexLabelSyncTerminal(log, {
+					operation: "source_read",
+					state: "failed",
+					stage: "source_authority",
+					reasonCode: reasonCode
+						? classifyPlexLabelSyncTerminalReason({
+								stage: "source_authority",
+								code: reasonCode,
+							})
+						: "unknown_failure",
+				});
 				return { matches: [], failed: true };
 			}
 			rows = evidence.rows;
-		} catch (err) {
-			log.warn({ err }, "Failed to query PlexCache for source labels");
+		} catch {
+			logPlexLabelSyncTerminal(log, {
+				operation: "source_read",
+				state: "failed",
+				stage: "source_read",
+				reasonCode: classifyPlexLabelSyncTerminalReason({
+					stage: "source_read",
+					code: "source_read_failed",
+				}),
+			});
 			return { matches: [], failed: true };
 		}
 

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -1658,6 +1658,77 @@ describe("PlexAuthorityService settlement window", () => {
 		},
 	);
 
+	it.each([
+		{
+			name: "connection generation change",
+			reread: { connectionGeneration: 5 },
+			expectedReason: "provider_connection_changed",
+			expectedDecision: { available: false, targetRatingKeys: [], writeCount: 0 },
+		},
+		{
+			name: "identity generation change",
+			reread: { identityGeneration: 10 },
+			expectedReason: "provider_identity_changed",
+			expectedDecision: { available: false, targetRatingKeys: [], writeCount: 0 },
+		},
+		{
+			name: "missing live target",
+			liveRatingKeys: [],
+			ledgerRatingKeys: ["101"],
+			expectedReason: "live_target_missing",
+			expectedDecision: { available: false, targetRatingKeys: [], writeCount: 0 },
+		},
+		{
+			name: "ambiguous live target",
+			liveRatingKeys: ["101", "102"],
+			ledgerRatingKeys: ["101", "102"],
+			expectedReason: "live_target_ambiguous",
+			expectedDecision: { available: false, targetRatingKeys: [], writeCount: 0 },
+		},
+		{
+			name: "changed live target",
+			liveRatingKeys: ["102"],
+			ledgerRatingKeys: ["101"],
+			expectedReason: "live_target_changed",
+			expectedDecision: { available: false, targetRatingKeys: [], writeCount: 0 },
+		},
+		{
+			name: "authorized target",
+			expectedDecision: { available: true, targetRatingKeys: ["101"], writeCount: 1 },
+		},
+	] as const)(
+		"keeps the authority decision and selected write targets unchanged when annotating $name",
+		async (testCase) => {
+			const input: Parameters<typeof mutateWithLedgerEvidence>[0] = { withBinding: true };
+			if ("reread" in testCase) input.reread = testCase.reread;
+			if ("liveRatingKeys" in testCase && testCase.liveRatingKeys) {
+				input.liveRatingKeys = [...testCase.liveRatingKeys];
+			}
+			if ("ledgerRatingKeys" in testCase && testCase.ledgerRatingKeys) {
+				input.ledgerRatingKeys = [...testCase.ledgerRatingKeys];
+			}
+
+			const { result, updateMetadataTags } = await mutateWithLedgerEvidence(input);
+			const decisionWithoutReasonProjection = {
+				available: result.ok,
+				targetRatingKeys: updateMetadataTags.mock.calls.map((call) => call[0]),
+				writeCount: updateMetadataTags.mock.calls.length,
+			};
+			const decisionWithReasonProjection = result.ok
+				? decisionWithoutReasonProjection
+				: { ...decisionWithoutReasonProjection, reasonCode: result.reasonCode };
+			const { reasonCode: _reasonCode, ...decisionIgnoringReason } =
+				"reasonCode" in decisionWithReasonProjection
+					? decisionWithReasonProjection
+					: { ...decisionWithReasonProjection, reasonCode: undefined };
+
+			expect(decisionIgnoringReason).toEqual(testCase.expectedDecision);
+			if ("expectedReason" in testCase) {
+				expect(decisionWithReasonProjection).toMatchObject({ reasonCode: testCase.expectedReason });
+			}
+		},
+	);
+
 	it("keeps an authorized mutation result and single-write accounting unchanged", async () => {
 		const { result, updateMetadataTags } = await mutateWithLedgerEvidence({ withBinding: true });
 
@@ -1681,10 +1752,22 @@ describe("PlexAuthorityService settlement window", () => {
 		} catch (error) {
 			thrown = error;
 		}
-		const serialized = JSON.stringify(thrown);
+		const loggerSerialization = vi.fn();
+		loggerSerialization({ err: thrown });
+		const inspection =
+			thrown instanceof Error
+				? Object.fromEntries(
+						Object.getOwnPropertyNames(thrown).map((key) => [
+							key,
+							(thrown as unknown as Record<string, unknown>)[key],
+						]),
+					)
+				: thrown;
+		const serialized = JSON.stringify({ thrown, inspection, logs: loggerSerialization.mock.calls });
 		expect(thrown).toMatchObject({
 			name: "PlexMetadataTagWriteError",
 			code: "upstream_write_failed",
+			responseCategory: "unavailable",
 			message: "Plex metadata tag write failed",
 		});
 		expect(thrown).not.toHaveProperty("cause");

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -170,6 +170,7 @@ async function mutateWithLedgerEvidence(input: {
 	ledgerRows?: unknown[];
 	ledgerRatingKeys?: string[];
 	liveRatingKeys?: string[];
+	liveCollectionFailure?: "timeout" | "settlement_probe" | "positive_only";
 	withBinding?: boolean;
 	updateError?: Error;
 }) {
@@ -246,6 +247,36 @@ async function mutateWithLedgerEvidence(input: {
 			throw new Error("synthetic cache backfill");
 		}),
 	};
+	const getActivities = vi.fn().mockResolvedValue([]);
+	const getLibrarySettlementSections = vi.fn().mockResolvedValue([section, musicSection]);
+	if (input.liveCollectionFailure === "timeout") {
+		getActivities
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockResolvedValueOnce([])
+			.mockRejectedValue(new DOMException("CANARY_LIVE_TIMEOUT_787", "TimeoutError"));
+	}
+	if (input.liveCollectionFailure === "settlement_probe") {
+		getLibrarySettlementSections
+			.mockResolvedValueOnce([section, musicSection])
+			.mockResolvedValueOnce([section, musicSection])
+			.mockResolvedValueOnce([section, musicSection])
+			.mockRejectedValue(new Error("CANARY_SETTLEMENT_PROBE_787"));
+	}
+	const positiveOnlySection = {
+		...section,
+		key: "shows",
+		uuid: "shows-uuid",
+		title: "Shows",
+		type: "show" as const,
+	};
+	if (input.liveCollectionFailure === "positive_only") {
+		getLibrarySettlementSections
+			.mockResolvedValueOnce([section, musicSection])
+			.mockResolvedValueOnce([section, musicSection])
+			.mockResolvedValueOnce([section, musicSection])
+			.mockResolvedValue([positiveOnlySection, musicSection]);
+	}
 	const service = new PlexAuthorityService({
 		prisma: {
 			serviceInstance: {
@@ -265,19 +296,38 @@ async function mutateWithLedgerEvidence(input: {
 		log: {} as never,
 		createClient: () =>
 			({
-				getActivities: vi.fn().mockResolvedValue([]),
-				getLibrarySettlementSections: vi.fn().mockResolvedValue([section, musicSection]),
+				getActivities,
+				getLibrarySettlementSections,
 				getAccounts: vi.fn().mockResolvedValue([{ id: 1, name: "admin" }]),
 				getLibrarySections: vi
 					.fn()
-					.mockResolvedValue([{ key: "movies", title: "Movies", type: "movie" }]),
+					.mockResolvedValue(
+						input.liveCollectionFailure === "positive_only"
+							? [{ key: "shows", title: "Shows", type: "show" }]
+							: [{ key: "movies", title: "Movies", type: "movie" }],
+					),
 				getLibraryItems: vi.fn().mockResolvedValue(
-					(input.liveRatingKeys ?? ["101"]).map((ratingKey) => ({
-						ratingKey,
-						title: "A",
-						type: "movie",
-						Guid: [{ id: "tmdb://1" }],
-					})),
+					input.liveCollectionFailure === "positive_only"
+						? [
+								{
+									ratingKey: "show-1",
+									title: "Mapped Show",
+									type: "show",
+									Guid: [{ id: "tmdb://1" }, { id: "tvdb://1" }],
+								},
+								{
+									ratingKey: "legacy-show",
+									title: "Legacy Show",
+									type: "show",
+									Guid: [],
+								},
+							]
+						: (input.liveRatingKeys ?? ["101"]).map((ratingKey) => ({
+								ratingKey,
+								title: "A",
+								type: "movie",
+								Guid: [{ id: "tmdb://1" }],
+							})),
 				),
 				getHistory: vi.fn().mockResolvedValue([]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
@@ -1654,6 +1704,27 @@ describe("PlexAuthorityService settlement window", () => {
 			});
 
 			expect(result).toMatchObject({ ok: false, reasonCode });
+			expect(updateMetadataTags).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		["a live request timeout", "timeout"],
+		["a settlement probe failure", "settlement_probe"],
+		["a positive-only live catalog", "positive_only"],
+	] as const)(
+		"classifies %s as unavailable evidence without reporting target drift",
+		async (_name, liveCollectionFailure) => {
+			const { result, updateMetadataTags } = await mutateWithLedgerEvidence({
+				withBinding: true,
+				liveCollectionFailure,
+			});
+
+			expect(result).toMatchObject({
+				ok: false,
+				reasonCode: "live_evidence_unavailable",
+			});
+			expect(result).not.toMatchObject({ reasonCode: "live_target_changed" });
 			expect(updateMetadataTags).not.toHaveBeenCalled();
 		},
 	);

--- a/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-authority-service.test.ts
@@ -168,7 +168,10 @@ async function mutateWithLedgerEvidence(input: {
 		identityGeneration: number;
 	}>;
 	ledgerRows?: unknown[];
+	ledgerRatingKeys?: string[];
+	liveRatingKeys?: string[];
 	withBinding?: boolean;
+	updateError?: Error;
 }) {
 	const targetRow = { ...rowA, thumb: "/library/metadata/101/thumb/1" };
 	const ledgerTarget = {
@@ -182,6 +185,11 @@ async function mutateWithLedgerEvidence(input: {
 		tvdbId: null,
 		ratingKey: "101",
 	};
+	const ledgerTargets = (input.ledgerRatingKeys ?? ["101"]).map((ratingKey) => ({
+		...ledgerTarget,
+		id: `target-${ratingKey}`,
+		ratingKey,
+	}));
 	const metadata =
 		input.metadata ??
 		(input.withBinding
@@ -193,7 +201,7 @@ async function mutateWithLedgerEvidence(input: {
 						generationId: "generation-1",
 						connectionGeneration: 4,
 						identityGeneration: 9,
-						targets: [ledgerTarget],
+						targets: ledgerTargets,
 					}),
 				}
 			: { ...persisted().metadata, itemCount: 1 });
@@ -223,12 +231,15 @@ async function mutateWithLedgerEvidence(input: {
 	repositoryMocks.loadInstanceSelectedEvidence.mockReset();
 	repositoryMocks.loadInstanceSelectedEvidence
 		.mockResolvedValueOnce(evidence)
-		.mockResolvedValueOnce(reread);
-	const updateMetadataTags = vi.fn().mockResolvedValue(undefined);
+		.mockResolvedValueOnce(reread)
+		.mockResolvedValue(evidence);
+	const updateMetadataTags = input.updateError
+		? vi.fn().mockRejectedValue(input.updateError)
+		: vi.fn().mockResolvedValue(undefined);
 	const plexGenerationTarget = {
 		findMany: vi
 			.fn()
-			.mockResolvedValue(input.ledgerRows ?? (input.withBinding ? [ledgerTarget] : [])),
+			.mockResolvedValue(input.ledgerRows ?? (input.withBinding ? ledgerTargets : [])),
 	};
 	const plexCache = {
 		findMany: vi.fn(() => {
@@ -244,6 +255,8 @@ async function mutateWithLedgerEvidence(input: {
 					service: "PLEX",
 					enabled: true,
 					expectedIdentity: "plex-machine-a",
+					connectionGeneration: 4,
+					identityGeneration: 9,
 				}),
 			},
 			plexGenerationTarget,
@@ -258,11 +271,14 @@ async function mutateWithLedgerEvidence(input: {
 				getLibrarySections: vi
 					.fn()
 					.mockResolvedValue([{ key: "movies", title: "Movies", type: "movie" }]),
-				getLibraryItems: vi
-					.fn()
-					.mockResolvedValue([
-						{ ratingKey: "101", title: "A", type: "movie", Guid: [{ id: "tmdb://1" }] },
-					]),
+				getLibraryItems: vi.fn().mockResolvedValue(
+					(input.liveRatingKeys ?? ["101"]).map((ratingKey) => ({
+						ratingKey,
+						title: "A",
+						type: "movie",
+						Guid: [{ id: "tmdb://1" }],
+					})),
+				),
 				getHistory: vi.fn().mockResolvedValue([]),
 				verifyHistorySnapshot: vi.fn().mockResolvedValue(undefined),
 				getOnDeck: vi.fn().mockResolvedValue([]),
@@ -1606,5 +1622,73 @@ describe("PlexAuthorityService settlement window", () => {
 		});
 		expect(updateMetadataTags).not.toHaveBeenCalled();
 		expect(plexGenerationTarget.findMany).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["connection generation", { connectionGeneration: 5 }, "provider_connection_changed"],
+		["identity generation", { identityGeneration: 10 }, "provider_identity_changed"],
+	] as const)(
+		"adds a bounded diagnostic when %s changes without authorizing a write",
+		async (_name, reread, reasonCode) => {
+			const { result, updateMetadataTags } = await mutateWithLedgerEvidence({
+				reread,
+				withBinding: true,
+			});
+
+			expect(result).toMatchObject({ ok: false, reasonCode });
+			expect(updateMetadataTags).not.toHaveBeenCalled();
+		},
+	);
+
+	it.each([
+		["missing", [], ["101"], "live_target_missing"],
+		["ambiguous", ["101", "102"], ["101", "102"], "live_target_ambiguous"],
+		["changed or reused", ["102"], ["101"], "live_target_changed"],
+	] as const)(
+		"classifies a %s live target without changing the fail-closed result",
+		async (_name, liveRatingKeys, ledgerRatingKeys, reasonCode) => {
+			const { result, updateMetadataTags } = await mutateWithLedgerEvidence({
+				withBinding: true,
+				liveRatingKeys: [...liveRatingKeys],
+				ledgerRatingKeys: [...ledgerRatingKeys],
+			});
+
+			expect(result).toMatchObject({ ok: false, reasonCode });
+			expect(updateMetadataTags).not.toHaveBeenCalled();
+		},
+	);
+
+	it("keeps an authorized mutation result and single-write accounting unchanged", async () => {
+		const { result, updateMetadataTags } = await mutateWithLedgerEvidence({ withBinding: true });
+
+		expect(result).toEqual({ ok: true });
+		expect(updateMetadataTags).toHaveBeenCalledOnce();
+	});
+
+	it("wraps an upstream write exception without retaining provider content", async () => {
+		const canaries = [
+			"CANARY_WRITE_ERROR_787",
+			"https://CANARY_WRITE_HOST_787.invalid/private",
+			"CANARY_WRITE_TOKEN_787",
+			"CANARY_WRITE_RESPONSE_787",
+		];
+		let thrown: unknown;
+		try {
+			await mutateWithLedgerEvidence({
+				withBinding: true,
+				updateError: new Error(canaries.join(" ")),
+			});
+		} catch (error) {
+			thrown = error;
+		}
+		const serialized = JSON.stringify(thrown);
+		expect(thrown).toMatchObject({
+			name: "PlexMetadataTagWriteError",
+			code: "upstream_write_failed",
+			message: "Plex metadata tag write failed",
+		});
+		expect(thrown).not.toHaveProperty("cause");
+		expect(thrown).not.toHaveProperty("stack");
+		for (const canary of canaries) expect(serialized).not.toContain(canary);
 	});
 });

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PlexClient } from "../plex-client.js";
+import { PlexClient, PlexRequestError } from "../plex-client.js";
 
 const warn = vi.fn();
 const log = { warn } as never;
@@ -515,15 +515,38 @@ describe("PlexClient authoritative inventory completeness", () => {
 		vi.stubGlobal("fetch", fetchMock);
 		const client = new PlexClient("https://CANARY_HOST_787.invalid", token, log);
 
-		await expect(
-			client.updateMetadataTags(ratingKey, "movie", "label", "add", label),
-		).rejects.toThrow();
+		let thrown: unknown;
+		try {
+			await client.updateMetadataTags(ratingKey, "movie", "label", "add", label);
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			name: "PlexRequestError",
+			code: "plex_request_failed",
+			responseCategory: "client_error",
+			message: "Plex API request failed",
+		});
+		expect(thrown).not.toHaveProperty("cause");
 
 		expect(warn).toHaveBeenCalledWith(
 			{ operation: "plex_api_request", responseCategory: "client_error" },
 			"Plex API request failed",
 		);
-		const serialized = JSON.stringify(warn.mock.calls);
+		const serialized = JSON.stringify({
+			logs: warn.mock.calls,
+			error: thrown,
+			inspection:
+				thrown instanceof Error
+					? Object.fromEntries(
+							Object.getOwnPropertyNames(thrown).map((key) => [
+								key,
+								(thrown as unknown as Record<string, unknown>)[key],
+							]),
+						)
+					: thrown,
+		});
 		for (const canary of [
 			ratingKey,
 			label,
@@ -552,18 +575,128 @@ describe("PlexClient authoritative inventory completeness", () => {
 			log,
 		);
 
-		await expect(client.getActivities()).rejects.toThrow();
+		let thrown: unknown;
+		try {
+			await client.getActivities();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			code: "plex_request_failed",
+			responseCategory: "server_error",
+			message: "Plex API request failed",
+		});
 		expect(warn).toHaveBeenCalledWith(
 			{ operation: "plex_api_request", responseCategory: "server_error" },
 			"Plex API request failed",
 		);
-		const serialized = JSON.stringify(warn.mock.calls);
+		const serialized = JSON.stringify({
+			logs: warn.mock.calls,
+			error: thrown,
+			text: String(thrown),
+		});
 		for (const canary of [
 			"/activities",
 			"CANARY_NON_LABEL_BODY_787",
 			"CANARY_NON_LABEL_STATUS_787",
 			"CANARY_NON_LABEL_HOST_787.invalid",
 			"CANARY_NON_LABEL_TOKEN_787",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
+	it("preserves another ordinary Plex read's non-OK rejection contract", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				new Response("CANARY_SECTIONS_BODY_787", {
+					status: 401,
+					statusText: "CANARY_SECTIONS_STATUS_787",
+				}),
+			),
+		);
+		const client = new PlexClient(
+			"https://CANARY_SECTIONS_HOST_787.invalid",
+			"CANARY_SECTIONS_TOKEN_787",
+			log,
+		);
+
+		let thrown: unknown;
+		try {
+			await client.getLibrarySections();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			code: "plex_request_failed",
+			responseCategory: "client_error",
+			message: "Plex API request failed",
+		});
+		expect(warn).toHaveBeenCalledWith(
+			{ operation: "plex_api_request", responseCategory: "client_error" },
+			"Plex API request failed",
+		);
+		const serialized = JSON.stringify({
+			logs: warn.mock.calls,
+			error: thrown,
+			text: String(thrown),
+		});
+		for (const canary of [
+			"/library/sections",
+			"CANARY_SECTIONS_BODY_787",
+			"CANARY_SECTIONS_STATUS_787",
+			"CANARY_SECTIONS_HOST_787.invalid",
+			"CANARY_SECTIONS_TOKEN_787",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
+	it.each([
+		["TimeoutError", "timeout"],
+		["TypeError", "unavailable"],
+	] as const)("bounds a %s transport failure", async (name, responseCategory) => {
+		const providerError = Object.assign(
+			new Error(
+				"CANARY_TRANSPORT_ERROR_787 https://CANARY_TRANSPORT_HOST_787.invalid/?token=CANARY_TRANSPORT_TOKEN_787",
+			),
+			{ name },
+		);
+		vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(providerError));
+		const client = new PlexClient(
+			"https://CANARY_TRANSPORT_HOST_787.invalid",
+			"CANARY_TRANSPORT_TOKEN_787",
+			log,
+		);
+
+		let thrown: unknown;
+		try {
+			await client.getActivities();
+		} catch (error) {
+			thrown = error;
+		}
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			code: "plex_request_failed",
+			responseCategory,
+			message: "Plex API request failed",
+		});
+		expect(warn).toHaveBeenCalledWith(
+			{ operation: "plex_api_request", responseCategory },
+			"Plex API request failed",
+		);
+		const serialized = JSON.stringify({
+			logs: warn.mock.calls,
+			error: thrown,
+			text: String(thrown),
+		});
+		for (const canary of [
+			"CANARY_TRANSPORT_ERROR_787",
+			"CANARY_TRANSPORT_HOST_787.invalid",
+			"CANARY_TRANSPORT_TOKEN_787",
 		]) {
 			expect(serialized).not.toContain(canary);
 		}

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -655,6 +655,100 @@ describe("PlexClient authoritative inventory completeness", () => {
 		}
 	});
 
+	it("preserves a bounded 502 contract for a schema-invalid JSON response", async () => {
+		const canaries = [
+			"CANARY_SCHEMA_PAYLOAD_787",
+			"CANARY_SCHEMA_ISSUE_787",
+			"CANARY_SCHEMA_PATH_787",
+			"CANARY_SCHEMA_TOKEN_787",
+		];
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				response({
+					size: canaries[0],
+					Activity: [{ type: canaries[1], Context: { librarySectionID: canaries[2] } }],
+				}),
+			),
+		);
+		const client = new PlexClient("https://CANARY_SCHEMA_HOST_787.invalid", canaries[3]!, log);
+
+		let thrown: unknown;
+		try {
+			await client.getActivities();
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			name: "PlexRequestError",
+			code: "plex_request_failed",
+			responseCategory: "unavailable",
+			statusCode: 502,
+			message: "Plex API request failed",
+		});
+		expect(thrown).not.toHaveProperty("cause");
+		expect(thrown).not.toHaveProperty("stack");
+		expect(thrown).not.toHaveProperty("details");
+		expect(thrown).not.toHaveProperty("issues");
+		const serialized = JSON.stringify({
+			logs: warn.mock.calls,
+			error: thrown,
+			inspection:
+				thrown instanceof Error
+					? Object.fromEntries(
+							Object.getOwnPropertyNames(thrown).map((key) => [
+								key,
+								(thrown as unknown as Record<string, unknown>)[key],
+							]),
+						)
+					: thrown,
+		});
+		for (const canary of [...canaries, "CANARY_SCHEMA_HOST_787.invalid", "Zod"]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
+	it("keeps malformed JSON on the bounded generic request-failure contract", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				new Response("CANARY_MALFORMED_BODY_787", {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+		const client = new PlexClient(
+			"https://CANARY_MALFORMED_HOST_787.invalid",
+			"CANARY_MALFORMED_TOKEN_787",
+			log,
+		);
+
+		let thrown: unknown;
+		try {
+			await client.getActivities();
+		} catch (error) {
+			thrown = error;
+		}
+
+		expect(thrown).toBeInstanceOf(PlexRequestError);
+		expect(thrown).toMatchObject({
+			code: "plex_request_failed",
+			responseCategory: "unavailable",
+		});
+		expect(thrown).not.toHaveProperty("statusCode");
+		const serialized = JSON.stringify({ logs: warn.mock.calls, error: thrown });
+		for (const canary of [
+			"CANARY_MALFORMED_BODY_787",
+			"CANARY_MALFORMED_HOST_787.invalid",
+			"CANARY_MALFORMED_TOKEN_787",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
 	it.each([
 		["TimeoutError", "timeout"],
 		["TypeError", "unavailable"],

--- a/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-client-completeness.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { PlexClient } from "../plex-client.js";
 
-const log = { warn: vi.fn() } as never;
+const warn = vi.fn();
+const log = { warn } as never;
 
 function response(MediaContainer: Record<string, unknown>): Response {
 	return new Response(JSON.stringify({ MediaContainer }), {
@@ -499,6 +500,73 @@ describe("PlexClient authoritative inventory completeness", () => {
 		expect(url.searchParams.get("label.locked")).toBe("1");
 		expect(url.searchParams.get("label[0].tag.tag")).toBe("Family");
 		expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({ method: "PUT" });
+	});
+
+	it("logs only a coarse category when a metadata-tag write is rejected", async () => {
+		const ratingKey = "CANARY_RATING_KEY_787";
+		const label = "CANARY_LABEL_787";
+		const token = "CANARY_TOKEN_787";
+		const fetchMock = vi.fn().mockResolvedValueOnce(
+			new Response("CANARY_RESPONSE_BODY_787", {
+				status: 422,
+				statusText: "CANARY_STATUS_TEXT_787",
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const client = new PlexClient("https://CANARY_HOST_787.invalid", token, log);
+
+		await expect(
+			client.updateMetadataTags(ratingKey, "movie", "label", "add", label),
+		).rejects.toThrow();
+
+		expect(warn).toHaveBeenCalledWith(
+			{ operation: "plex_api_request", responseCategory: "client_error" },
+			"Plex API request failed",
+		);
+		const serialized = JSON.stringify(warn.mock.calls);
+		for (const canary of [
+			ratingKey,
+			label,
+			token,
+			"CANARY_HOST_787.invalid",
+			"CANARY_RESPONSE_BODY_787",
+			"CANARY_STATUS_TEXT_787",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
+	});
+
+	it("preserves a non-label caller's rejection contract with sanitized logging", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValueOnce(
+				new Response("CANARY_NON_LABEL_BODY_787", {
+					status: 503,
+					statusText: "CANARY_NON_LABEL_STATUS_787",
+				}),
+			),
+		);
+		const client = new PlexClient(
+			"https://CANARY_NON_LABEL_HOST_787.invalid",
+			"CANARY_NON_LABEL_TOKEN_787",
+			log,
+		);
+
+		await expect(client.getActivities()).rejects.toThrow();
+		expect(warn).toHaveBeenCalledWith(
+			{ operation: "plex_api_request", responseCategory: "server_error" },
+			"Plex API request failed",
+		);
+		const serialized = JSON.stringify(warn.mock.calls);
+		for (const canary of [
+			"/activities",
+			"CANARY_NON_LABEL_BODY_787",
+			"CANARY_NON_LABEL_STATUS_787",
+			"CANARY_NON_LABEL_HOST_787.invalid",
+			"CANARY_NON_LABEL_TOKEN_787",
+		]) {
+			expect(serialized).not.toContain(canary);
+		}
 	});
 
 	it("loads a complete bounded activity inventory", async () => {

--- a/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
@@ -57,7 +57,7 @@ const coverageMatrix = [
 	],
 	["plex_library_activity_unknown", "source_read_failed", "provider_authority_unavailable"],
 	["plex_library_revision_changed", "source_evidence_changed", "provider_authority_unavailable"],
-	["plex_content_digest_changed", "source_evidence_changed", "live_target_changed"],
+	["plex_content_digest_changed", "source_evidence_changed", "live_evidence_unavailable"],
 	[
 		"plex_settlement_metadata_missing",
 		"source_authority_unavailable",
@@ -84,6 +84,7 @@ const mutationMatrix = [
 	["live_target_missing", "live_target_missing"],
 	["live_target_ambiguous", "live_target_ambiguous"],
 	["live_target_changed", "live_target_changed"],
+	["live_evidence_unavailable", "live_evidence_unavailable"],
 	["provider_identity_changed", "provider_identity_changed"],
 	["provider_connection_changed", "provider_connection_changed"],
 	["upstream_write_failed", "upstream_write_failed"],

--- a/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
@@ -1,0 +1,211 @@
+import type { PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
+import type { FastifyBaseLogger } from "fastify";
+import { describe, expect, it, vi } from "vitest";
+import {
+	classifyPlexLabelSyncTerminalReason,
+	classifyPlexMetadataTagEvidenceFailure,
+	classifyUnknownPlexLabelSyncTerminalReason,
+	createLabelSyncPlexProviderLogSink,
+	logPlexLabelSyncTerminal,
+	type PlexMetadataTagMutationFailureReason,
+} from "../plex-label-sync-logging.js";
+
+const coverageMatrix = [
+	["disabled_instance", "source_authority_unavailable", "provider_authority_unavailable"],
+	["missing_status", "source_authority_unavailable", "provider_authority_unavailable"],
+	["unpublished_generation", "source_authority_unavailable", "provider_authority_unavailable"],
+	["missing_generation_id", "source_authority_unavailable", "provider_authority_unavailable"],
+	["missing_metadata", "source_authority_unavailable", "provider_authority_unavailable"],
+	["malformed_metadata", "source_authority_unavailable", "provider_authority_unavailable"],
+	["unknown_metadata_version", "source_authority_unavailable", "provider_authority_unavailable"],
+	["invalid_publication_level", "source_authority_unavailable", "provider_authority_unavailable"],
+	["invalid_completeness", "source_authority_unavailable", "provider_authority_unavailable"],
+	["invalid_item_count", "source_authority_unavailable", "provider_authority_unavailable"],
+	["invalid_sections", "source_authority_unavailable", "provider_authority_unavailable"],
+	["duplicate_sections", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["stale_generation", "source_authority_unavailable", "provider_authority_unavailable"],
+	["generation_changed", "source_evidence_changed", "publication_superseded"],
+	["published_timestamp_changed", "source_evidence_changed", "publication_superseded"],
+	["row_count_mismatch", "source_authority_unavailable", "provider_authority_unavailable"],
+	["connection_generation_mismatch", "source_evidence_changed", "provider_connection_changed"],
+	["identity_generation_mismatch", "source_evidence_changed", "provider_identity_changed"],
+	["latest_attempt_failed", "source_authority_unavailable", "publication_superseded"],
+	["latest_attempt_in_progress", "source_authority_unavailable", "publication_superseded"],
+	["latest_attempt_partial", "source_authority_unavailable", "publication_superseded"],
+	["latest_attempt_unknown", "source_authority_unavailable", "publication_superseded"],
+	["latest_attempt_missing", "source_authority_unavailable", "publication_superseded"],
+	["latest_attempt_future_dated", "source_authority_unavailable", "publication_superseded"],
+	["published_generation_stale", "source_authority_unavailable", "provider_authority_unavailable"],
+	["metadata_invalid", "source_authority_unavailable", "provider_authority_unavailable"],
+	["mutation_authority_unavailable", "source_read_failed", "provider_authority_unavailable"],
+	["query_failed", "source_read_failed", "provider_authority_unavailable"],
+	[
+		"parent_generation_unavailable",
+		"source_authority_unavailable",
+		"provider_authority_unavailable",
+	],
+	["plex_activity_unavailable", "source_read_failed", "provider_authority_unavailable"],
+	["plex_section_state_unavailable", "source_read_failed", "provider_authority_unavailable"],
+	["plex_library_scan_in_progress", "source_evidence_changed", "provider_authority_unavailable"],
+	[
+		"plex_metadata_refresh_in_progress",
+		"source_evidence_changed",
+		"provider_authority_unavailable",
+	],
+	["plex_library_activity_unknown", "source_read_failed", "provider_authority_unavailable"],
+	["plex_library_revision_changed", "source_evidence_changed", "provider_authority_unavailable"],
+	["plex_content_digest_changed", "source_evidence_changed", "live_target_changed"],
+	[
+		"plex_settlement_metadata_missing",
+		"source_authority_unavailable",
+		"provider_authority_unavailable",
+	],
+	["target_ledger_binding_missing", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["target_ledger_invalid", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["target_ledger_unavailable", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["target_count_mismatch", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["target_digest_mismatch", "source_evidence_ambiguous", "provider_authority_unavailable"],
+	["target_section_mismatch", "source_evidence_ambiguous", "provider_authority_unavailable"],
+] as const satisfies ReadonlyArray<
+	readonly [PlexCoverageReasonCode, string, PlexMetadataTagMutationFailureReason]
+>;
+
+type MissingCoverageReason = Exclude<PlexCoverageReasonCode, (typeof coverageMatrix)[number][0]>;
+const coverageMatrixIsExhaustive: MissingCoverageReason extends never ? true : never = true;
+
+const mutationMatrix = [
+	["cached_target_unavailable", "cached_target_unavailable"],
+	["cached_target_ambiguous", "cached_target_ambiguous"],
+	["cached_target_inconsistent", "cached_target_inconsistent"],
+	["provider_authority_unavailable", "provider_attempt_unavailable"],
+	["live_target_missing", "live_target_missing"],
+	["live_target_ambiguous", "live_target_ambiguous"],
+	["live_target_changed", "live_target_changed"],
+	["provider_identity_changed", "provider_identity_changed"],
+	["provider_connection_changed", "provider_connection_changed"],
+	["upstream_write_failed", "upstream_write_failed"],
+	["publication_superseded", "publication_superseded"],
+	["unknown_failure", "unknown_failure"],
+] as const satisfies ReadonlyArray<readonly [PlexMetadataTagMutationFailureReason, string]>;
+
+type MissingMutationReason = Exclude<
+	PlexMetadataTagMutationFailureReason,
+	(typeof mutationMatrix)[number][0]
+>;
+const mutationMatrixIsExhaustive: MissingMutationReason extends never ? true : never = true;
+
+function evidence(reasonCode: PlexCoverageReasonCode): PlexEvidenceSummary {
+	return {
+		publicationLevel: "unavailable",
+		completeness: "unknown",
+		reasonCodes: [reasonCode],
+	};
+}
+
+function createLogger(): FastifyBaseLogger {
+	const logger = {
+		child: vi.fn(),
+		info: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+		debug: vi.fn(),
+		trace: vi.fn(),
+		fatal: vi.fn(),
+	} as unknown as FastifyBaseLogger;
+	(logger.child as unknown as ReturnType<typeof vi.fn>).mockReturnValue(logger);
+	return logger;
+}
+
+describe("Plex label-sync logging boundary", () => {
+	it.each(coverageMatrix)(
+		"classifies coverage reason %s exhaustively",
+		(reasonCode, sourceReason, destinationReason) => {
+			expect(coverageMatrixIsExhaustive).toBe(true);
+			expect(classifyPlexLabelSyncTerminalReason({ stage: "source_read", code: reasonCode })).toBe(
+				sourceReason,
+			);
+			expect(classifyPlexMetadataTagEvidenceFailure(evidence(reasonCode))).toBe(destinationReason);
+		},
+	);
+
+	it.each(mutationMatrix)("classifies mutation reason %s exhaustively", (reasonCode, terminal) => {
+		expect(mutationMatrixIsExhaustive).toBe(true);
+		expect(
+			classifyPlexLabelSyncTerminalReason({
+				stage: "destination_authority",
+				code: reasonCode,
+			}),
+		).toBe(terminal);
+	});
+
+	it.each([
+		["client_error", "upstream_write_rejected"],
+		["server_error", "upstream_write_failed"],
+		["timeout", "upstream_write_failed"],
+		["unavailable", "upstream_write_failed"],
+	] as const)("classifies %s write failures", (category, reasonCode) => {
+		expect(classifyPlexLabelSyncTerminalReason({ stage: "upstream_write", code: category })).toBe(
+			reasonCode,
+		);
+	});
+
+	it("maps unknown runtime input to the closed fallback", () => {
+		expect(
+			classifyUnknownPlexLabelSyncTerminalReason({
+				stage: "private",
+				code: new Error("private"),
+			}),
+		).toBe("unknown_failure");
+	});
+
+	it("drops every nested provider log argument without retaining or forwarding it", () => {
+		const parent = createLogger();
+		const sink = createLabelSyncPlexProviderLogSink();
+		const privateError = new Error("CANARY_PROVIDER_ERROR_787");
+		const privateFields = { err: privateError, token: "CANARY_PROVIDER_TOKEN_787" };
+
+		sink.warn(privateFields, "CANARY_PROVIDER_MESSAGE_787");
+		sink.error(privateFields, "CANARY_PROVIDER_MESSAGE_787");
+		sink.fatal(privateFields, "CANARY_PROVIDER_MESSAGE_787");
+		sink.child(privateFields).warn(privateFields, "CANARY_PROVIDER_MESSAGE_787");
+
+		for (const method of [
+			parent.info,
+			parent.warn,
+			parent.error,
+			parent.debug,
+			parent.trace,
+			parent.fatal,
+		]) {
+			expect(method).not.toHaveBeenCalled();
+		}
+		expect(JSON.stringify(sink)).not.toContain("CANARY_PROVIDER");
+	});
+
+	it("constructs an exact fresh terminal projection", () => {
+		const log = createLogger();
+		logPlexLabelSyncTerminal(log, {
+			operation: "destination_write",
+			state: "failed",
+			stage: "upstream_write",
+			reasonCode: "upstream_write_rejected",
+			mediaCategory: "movie",
+			candidateCount: 1,
+			upstreamCategory: "client_error",
+		});
+
+		expect(log.warn).toHaveBeenCalledOnce();
+		expect(log.warn).toHaveBeenCalledWith(
+			{
+				operation: "destination_write",
+				state: "failed",
+				stage: "upstream_write",
+				reasonCode: "upstream_write_rejected",
+				mediaCategory: "movie",
+				candidateCount: 1,
+				upstreamCategory: "client_error",
+			},
+			"Plex label-sync destination write failed",
+		);
+	});
+});

--- a/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
+++ b/apps/api/src/lib/plex/__tests__/plex-label-sync-logging.test.ts
@@ -1,12 +1,15 @@
 import type { PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
 import type { FastifyBaseLogger } from "fastify";
 import { describe, expect, it, vi } from "vitest";
+import type { PlexResponseCategory } from "../plex-client.js";
 import {
+	classifyPlexLabelMutationCaughtError,
 	classifyPlexLabelSyncTerminalReason,
 	classifyPlexMetadataTagEvidenceFailure,
 	classifyUnknownPlexLabelSyncTerminalReason,
 	createLabelSyncPlexProviderLogSink,
 	logPlexLabelSyncTerminal,
+	PlexMetadataTagWriteError,
 	type PlexMetadataTagMutationFailureReason,
 } from "../plex-label-sync-logging.js";
 
@@ -94,6 +97,19 @@ type MissingMutationReason = Exclude<
 >;
 const mutationMatrixIsExhaustive: MissingMutationReason extends never ? true : never = true;
 
+const upstreamWriteMatrix = [
+	["client_error", "upstream_write_rejected"],
+	["server_error", "upstream_write_failed"],
+	["timeout", "upstream_write_failed"],
+	["unavailable", "upstream_write_failed"],
+] as const satisfies ReadonlyArray<readonly [PlexResponseCategory, string]>;
+
+type MissingUpstreamCategory = Exclude<
+	PlexResponseCategory,
+	(typeof upstreamWriteMatrix)[number][0]
+>;
+const upstreamWriteMatrixIsExhaustive: MissingUpstreamCategory extends never ? true : never = true;
+
 function evidence(reasonCode: PlexCoverageReasonCode): PlexEvidenceSummary {
 	return {
 		publicationLevel: "unavailable",
@@ -138,16 +154,47 @@ describe("Plex label-sync logging boundary", () => {
 		).toBe(terminal);
 	});
 
-	it.each([
-		["client_error", "upstream_write_rejected"],
-		["server_error", "upstream_write_failed"],
-		["timeout", "upstream_write_failed"],
-		["unavailable", "upstream_write_failed"],
-	] as const)("classifies %s write failures", (category, reasonCode) => {
+	it.each(upstreamWriteMatrix)("classifies %s write failures", (category, reasonCode) => {
+		expect(upstreamWriteMatrixIsExhaustive).toBe(true);
 		expect(classifyPlexLabelSyncTerminalReason({ stage: "upstream_write", code: category })).toBe(
 			reasonCode,
 		);
 	});
+
+	it.each(upstreamWriteMatrix)(
+		"classifies a typed %s mutation exception as an attempted write",
+		(category, reasonCode) => {
+			expect(upstreamWriteMatrixIsExhaustive).toBe(true);
+			const classification = classifyPlexLabelMutationCaughtError(
+				new PlexMetadataTagWriteError(category),
+			);
+
+			expect(classification).toEqual({
+				stage: "upstream_write",
+				reasonCode,
+				upstreamCategory: category,
+			});
+		},
+	);
+
+	it.each([
+		["Error", new Error("CANARY_PRE_WRITE_ERROR_787")],
+		["string", "CANARY_PRE_WRITE_STRING_787"],
+		["object", { privateField: "CANARY_PRE_WRITE_FIELD_787" }],
+		["null", null],
+		["undefined", undefined],
+	] as const)(
+		"classifies an untyped pre-write %s without projecting its content",
+		(_name, caught) => {
+			const classification = classifyPlexLabelMutationCaughtError(caught);
+
+			expect(classification).toEqual({
+				stage: "destination_authority",
+				reasonCode: "unknown_failure",
+			});
+			expect(JSON.stringify(classification)).not.toContain("CANARY_PRE_WRITE");
+		},
+	);
 
 	it("maps unknown runtime input to the closed fallback", () => {
 		expect(

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -104,6 +104,75 @@ export class PlexAuthorityUnavailableError extends Error {
 	}
 }
 
+export type PlexMetadataTagMutationFailureReason =
+	| "cached_target_unavailable"
+	| "cached_target_ambiguous"
+	| "cached_target_inconsistent"
+	| "provider_authority_unavailable"
+	| "live_target_missing"
+	| "live_target_ambiguous"
+	| "live_target_changed"
+	| "provider_identity_changed"
+	| "provider_connection_changed"
+	| "upstream_write_failed"
+	| "publication_superseded"
+	| "unknown_failure";
+
+export type PlexMetadataTagMutationResult =
+	| { ok: true }
+	| {
+			ok: false;
+			reasonCode: PlexMetadataTagMutationFailureReason;
+			evidence: PlexEvidenceSummary;
+	  };
+
+export class PlexMetadataTagWriteError extends Error {
+	readonly code = "upstream_write_failed" as const;
+
+	constructor() {
+		super("Plex metadata tag write failed");
+		this.name = "PlexMetadataTagWriteError";
+		delete this.stack;
+	}
+}
+
+function classifyMetadataTagEvidenceFailure(
+	evidence: PlexEvidenceSummary,
+): PlexMetadataTagMutationFailureReason {
+	if (evidence.reasonCodes.includes("connection_generation_mismatch")) {
+		return "provider_connection_changed";
+	}
+	if (evidence.reasonCodes.includes("identity_generation_mismatch")) {
+		return "provider_identity_changed";
+	}
+	if (
+		evidence.reasonCodes.some(
+			(reasonCode) =>
+				reasonCode === "latest_attempt_failed" ||
+				reasonCode === "latest_attempt_in_progress" ||
+				reasonCode === "latest_attempt_partial" ||
+				reasonCode === "latest_attempt_unknown" ||
+				reasonCode === "latest_attempt_missing" ||
+				reasonCode === "latest_attempt_future_dated" ||
+				reasonCode === "generation_changed" ||
+				reasonCode === "published_timestamp_changed",
+		)
+	) {
+		return "publication_superseded";
+	}
+	if (evidence.reasonCodes.includes("plex_content_digest_changed")) {
+		return "live_target_changed";
+	}
+	return "provider_authority_unavailable";
+}
+
+function failedMetadataTagMutation(
+	evidence: PlexEvidenceSummary,
+	reasonCode: PlexMetadataTagMutationFailureReason,
+): PlexMetadataTagMutationResult {
+	return { ok: false, reasonCode, evidence };
+}
+
 export type PlexAuthorityWindowResult =
 	| { ok: true; persisted: PlexPersistedSelectionObservation }
 	| { ok: false; reasonCode: PlexCoverageReasonCode };
@@ -1207,12 +1276,11 @@ export class PlexAuthorityService {
 		type: "collection" | "label";
 		action: "add" | "remove";
 		name: string;
-	}): Promise<{ ok: true } | { ok: false; evidence: PlexEvidenceSummary }> {
+	}): Promise<PlexMetadataTagMutationResult> {
 		const instance = await this.ownedInstance(input.userId, input.instanceId);
 		if (!instance) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
+			return failedMetadataTagMutation(
+				unavailableEvidence(
 					input.instanceId,
 					{
 						availability: "unavailable",
@@ -1224,7 +1292,8 @@ export class PlexAuthorityService {
 					},
 					"missing_status",
 				).evidence,
-			};
+				"provider_authority_unavailable",
+			);
 		}
 		const selection: PlexCacheRowSelection = { kind: "targets", targets: [input.target] };
 		const before = await loadInstanceSelectedEvidence(this.deps.prisma, {
@@ -1232,7 +1301,12 @@ export class PlexAuthorityService {
 			instanceId: input.instanceId,
 			selection,
 		});
-		if (!before.available) return { ok: false, evidence: before.evidence };
+		if (!before.available) {
+			return failedMetadataTagMutation(
+				before.evidence,
+				classifyMetadataTagEvidenceFailure(before.evidence),
+			);
+		}
 		const client = this.client(instance);
 		const current = await this.settle({
 			userId: input.userId,
@@ -1250,17 +1324,19 @@ export class PlexAuthorityService {
 					selection,
 				}),
 		});
-		if (!current.available) return { ok: false, evidence: current.evidence };
+		if (!current.available) {
+			return failedMetadataTagMutation(
+				current.evidence,
+				classifyMetadataTagEvidenceFailure(current.evidence),
+			);
+		}
 		const targetBinding = requirePlexTargetLedgerBinding(current.metadata);
 		if (!targetBinding.ok) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
-					input.instanceId,
-					current.evidence,
-					"target_ledger_binding_missing",
-				).evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "target_ledger_binding_missing")
+					.evidence,
+				"provider_authority_unavailable",
+			);
 		}
 		const targetLedger = await verifyPersistedPlexGenerationTargets(this.deps.prisma, {
 			expected: {
@@ -1278,10 +1354,10 @@ export class PlexAuthorityService {
 		});
 		if (!targetLedger.ok) {
 			const reasonCode = targetLedger.reason as PlexCoverageReasonCode;
-			return {
-				ok: false,
-				evidence: unavailableEvidence(input.instanceId, current.evidence, reasonCode).evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, reasonCode).evidence,
+				"provider_authority_unavailable",
+			);
 		}
 		const persistedTargets = await readPlexGenerationTargetsForSelection(
 			this.deps.prisma,
@@ -1290,14 +1366,11 @@ export class PlexAuthorityService {
 		);
 		const live = await collectSettledPlexCacheLiveEvidence(client, input.instanceId, this.deps.log);
 		if (!live.complete || !live.inventoryTargets) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
-					input.instanceId,
-					current.evidence,
-					"plex_content_digest_changed",
-				).evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "plex_content_digest_changed")
+					.evidence,
+				"provider_authority_unavailable",
+			);
 		}
 		let liveTargets: PlexGenerationTarget[];
 		try {
@@ -1320,21 +1393,23 @@ export class PlexAuthorityService {
 				{ instanceId: input.instanceId, generationId: current.generationId },
 			);
 		} catch {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(input.instanceId, current.evidence, "target_ledger_invalid")
-					.evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "target_ledger_invalid").evidence,
+				"provider_authority_unavailable",
+			);
 		}
 		if (!samePlexGenerationTargetSet(persistedTargets, liveTargets)) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
-					input.instanceId,
-					current.evidence,
-					"plex_content_digest_changed",
-				).evidence,
-			};
+			const reasonCode =
+				liveTargets.length === 0
+					? "live_target_missing"
+					: liveTargets.length > 1 || persistedTargets.length > 1
+						? "live_target_ambiguous"
+						: "live_target_changed";
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "plex_content_digest_changed")
+					.evidence,
+				reasonCode,
+			);
 		}
 		const after = await loadInstanceSelectedEvidence(this.deps.prisma, {
 			userId: input.userId,
@@ -1349,22 +1424,29 @@ export class PlexAuthorityService {
 			!samePlexGenerationBinding(current, after) ||
 			!samePlexGenerationBinding(current, afterInstance)
 		) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(input.instanceId, current.evidence, "generation_changed")
-					.evidence,
-			};
+			const reasonCode = !after.available
+				? classifyMetadataTagEvidenceFailure(after.evidence)
+				: !afterInstance
+					? "provider_authority_unavailable"
+					: after.connectionGeneration !== current.connectionGeneration ||
+							afterInstance.connectionGeneration !== current.connectionGeneration
+						? "provider_connection_changed"
+						: after.identityGeneration !== current.identityGeneration ||
+								afterInstance.identityGeneration !== current.identityGeneration
+							? "provider_identity_changed"
+							: "publication_superseded";
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "generation_changed").evidence,
+				reasonCode,
+			);
 		}
 		const singleTarget = selectSinglePlexGenerationTarget(persistedTargets);
 		if (!singleTarget.ok) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
-					input.instanceId,
-					current.evidence,
-					"mutation_authority_unavailable",
-				).evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "mutation_authority_unavailable")
+					.evidence,
+				persistedTargets.length === 0 ? "live_target_missing" : "live_target_ambiguous",
+			);
 		}
 		const ratingKeys = [
 			...new Set(
@@ -1385,25 +1467,26 @@ export class PlexAuthorityService {
 			ratingKeys[0] !== singleTarget.target.ratingKey ||
 			(input.expectedRatingKey !== undefined && ratingKeys[0] !== input.expectedRatingKey)
 		) {
-			return {
-				ok: false,
-				evidence: unavailableEvidence(
-					input.instanceId,
-					current.evidence,
-					"mutation_authority_unavailable",
-				).evidence,
-			};
+			return failedMetadataTagMutation(
+				unavailableEvidence(input.instanceId, current.evidence, "mutation_authority_unavailable")
+					.evidence,
+				"live_target_changed",
+			);
 		}
 		// This I/O immediately follows the terminal selected live observation.
 		// Plex has no mutation lock, so a change can begin afterward; the fixed
 		// point eliminates stale/cached authorization but cannot make Plex atomic.
-		await client.updateMetadataTags(
-			ratingKeys[0]!,
-			input.target.mediaType,
-			input.type,
-			input.action,
-			input.name,
-		);
+		try {
+			await client.updateMetadataTags(
+				ratingKeys[0]!,
+				input.target.mediaType,
+				input.type,
+				input.action,
+				input.name,
+			);
+		} catch {
+			throw new PlexMetadataTagWriteError();
+		}
 		return { ok: true };
 	}
 

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -20,7 +20,12 @@ import {
 	type PlexCanonicalObservation,
 	type PlexCanonicalSelection,
 } from "./plex-canonical-projection.js";
-import { createPlexClient, type PlexClient } from "./plex-client.js";
+import { createPlexClient, type PlexClient, PlexRequestError } from "./plex-client.js";
+import {
+	classifyPlexMetadataTagEvidenceFailure,
+	PlexMetadataTagWriteError,
+	type PlexMetadataTagMutationFailureReason,
+} from "./plex-label-sync-logging.js";
 import {
 	collectPlexEpisodeLiveEvidence,
 	createPositivePlexEpisodeDigest,
@@ -104,19 +109,10 @@ export class PlexAuthorityUnavailableError extends Error {
 	}
 }
 
-export type PlexMetadataTagMutationFailureReason =
-	| "cached_target_unavailable"
-	| "cached_target_ambiguous"
-	| "cached_target_inconsistent"
-	| "provider_authority_unavailable"
-	| "live_target_missing"
-	| "live_target_ambiguous"
-	| "live_target_changed"
-	| "provider_identity_changed"
-	| "provider_connection_changed"
-	| "upstream_write_failed"
-	| "publication_superseded"
-	| "unknown_failure";
+export {
+	PlexMetadataTagWriteError,
+	type PlexMetadataTagMutationFailureReason,
+} from "./plex-label-sync-logging.js";
 
 export type PlexMetadataTagMutationResult =
 	| { ok: true }
@@ -125,46 +121,6 @@ export type PlexMetadataTagMutationResult =
 			reasonCode: PlexMetadataTagMutationFailureReason;
 			evidence: PlexEvidenceSummary;
 	  };
-
-export class PlexMetadataTagWriteError extends Error {
-	readonly code = "upstream_write_failed" as const;
-
-	constructor() {
-		super("Plex metadata tag write failed");
-		this.name = "PlexMetadataTagWriteError";
-		delete this.stack;
-	}
-}
-
-function classifyMetadataTagEvidenceFailure(
-	evidence: PlexEvidenceSummary,
-): PlexMetadataTagMutationFailureReason {
-	if (evidence.reasonCodes.includes("connection_generation_mismatch")) {
-		return "provider_connection_changed";
-	}
-	if (evidence.reasonCodes.includes("identity_generation_mismatch")) {
-		return "provider_identity_changed";
-	}
-	if (
-		evidence.reasonCodes.some(
-			(reasonCode) =>
-				reasonCode === "latest_attempt_failed" ||
-				reasonCode === "latest_attempt_in_progress" ||
-				reasonCode === "latest_attempt_partial" ||
-				reasonCode === "latest_attempt_unknown" ||
-				reasonCode === "latest_attempt_missing" ||
-				reasonCode === "latest_attempt_future_dated" ||
-				reasonCode === "generation_changed" ||
-				reasonCode === "published_timestamp_changed",
-		)
-	) {
-		return "publication_superseded";
-	}
-	if (evidence.reasonCodes.includes("plex_content_digest_changed")) {
-		return "live_target_changed";
-	}
-	return "provider_authority_unavailable";
-}
 
 function failedMetadataTagMutation(
 	evidence: PlexEvidenceSummary,
@@ -1304,7 +1260,7 @@ export class PlexAuthorityService {
 		if (!before.available) {
 			return failedMetadataTagMutation(
 				before.evidence,
-				classifyMetadataTagEvidenceFailure(before.evidence),
+				classifyPlexMetadataTagEvidenceFailure(before.evidence),
 			);
 		}
 		const client = this.client(instance);
@@ -1327,7 +1283,7 @@ export class PlexAuthorityService {
 		if (!current.available) {
 			return failedMetadataTagMutation(
 				current.evidence,
-				classifyMetadataTagEvidenceFailure(current.evidence),
+				classifyPlexMetadataTagEvidenceFailure(current.evidence),
 			);
 		}
 		const targetBinding = requirePlexTargetLedgerBinding(current.metadata);
@@ -1366,11 +1322,12 @@ export class PlexAuthorityService {
 		);
 		const live = await collectSettledPlexCacheLiveEvidence(client, input.instanceId, this.deps.log);
 		if (!live.complete || !live.inventoryTargets) {
-			return failedMetadataTagMutation(
-				unavailableEvidence(input.instanceId, current.evidence, "plex_content_digest_changed")
-					.evidence,
-				"provider_authority_unavailable",
-			);
+			const evidence = unavailableEvidence(
+				input.instanceId,
+				current.evidence,
+				"plex_content_digest_changed",
+			).evidence;
+			return failedMetadataTagMutation(evidence, classifyPlexMetadataTagEvidenceFailure(evidence));
 		}
 		let liveTargets: PlexGenerationTarget[];
 		try {
@@ -1425,7 +1382,7 @@ export class PlexAuthorityService {
 			!samePlexGenerationBinding(current, afterInstance)
 		) {
 			const reasonCode = !after.available
-				? classifyMetadataTagEvidenceFailure(after.evidence)
+				? classifyPlexMetadataTagEvidenceFailure(after.evidence)
 				: !afterInstance
 					? "provider_authority_unavailable"
 					: after.connectionGeneration !== current.connectionGeneration ||
@@ -1484,8 +1441,10 @@ export class PlexAuthorityService {
 				input.action,
 				input.name,
 			);
-		} catch {
-			throw new PlexMetadataTagWriteError();
+		} catch (error) {
+			throw new PlexMetadataTagWriteError(
+				error instanceof PlexRequestError ? error.responseCategory : "unavailable",
+			);
 		}
 		return { ok: true };
 	}

--- a/apps/api/src/lib/plex/plex-authority-service.ts
+++ b/apps/api/src/lib/plex/plex-authority-service.ts
@@ -1327,7 +1327,7 @@ export class PlexAuthorityService {
 				current.evidence,
 				"plex_content_digest_changed",
 			).evidence;
-			return failedMetadataTagMutation(evidence, classifyPlexMetadataTagEvidenceFailure(evidence));
+			return failedMetadataTagMutation(evidence, "live_evidence_unavailable");
 		}
 		let liveTargets: PlexGenerationTarget[];
 		try {

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -10,7 +10,7 @@ import type { z } from "zod";
 import type { ClientInstanceData } from "../arr/client-factory.js";
 import type { Encryptor } from "../auth/encryption.js";
 import { getStoredHttpAuthHeaders } from "../services/http-auth.js";
-import { parseUpstreamOrThrow } from "../validation/parse-upstream.js";
+import { parseUpstreamOrThrow, UpstreamValidationError } from "../validation/parse-upstream.js";
 import {
 	plexActivitiesResponseSchema,
 	plexAccountsResponseSchema,
@@ -177,10 +177,22 @@ export type PlexResponseCategory = "client_error" | "server_error" | "timeout" |
 
 export class PlexRequestError extends Error {
 	readonly code = "plex_request_failed" as const;
+	declare readonly statusCode?: number;
 
-	constructor(readonly responseCategory: PlexResponseCategory) {
+	constructor(
+		readonly responseCategory: PlexResponseCategory,
+		statusCode?: number,
+	) {
 		super("Plex API request failed");
 		this.name = "PlexRequestError";
+		if (statusCode !== undefined) {
+			Object.defineProperty(this, "statusCode", {
+				value: statusCode,
+				enumerable: true,
+				configurable: false,
+				writable: false,
+			});
+		}
 		delete this.stack;
 	}
 }
@@ -919,12 +931,15 @@ export class PlexClient {
 			const category = path.split("?")[0] ?? path;
 			try {
 				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
-			} catch {
+			} catch (error) {
 				this.log.warn(
 					{ operation: "plex_api_request", responseCategory: "unavailable" },
 					"Plex API request failed",
 				);
-				throw new PlexRequestError("unavailable");
+				throw new PlexRequestError(
+					"unavailable",
+					error instanceof UpstreamValidationError ? error.statusCode : undefined,
+				);
 			}
 		}
 

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -173,6 +173,24 @@ const SAFETY_PAGE_SIZE = 200;
 const SAFETY_MAX_ITEMS = 100_000;
 const HISTORY_SORT = "viewedAt:desc";
 
+export type PlexResponseCategory = "client_error" | "server_error" | "timeout" | "unavailable";
+
+export class PlexRequestError extends Error {
+	readonly code = "plex_request_failed" as const;
+
+	constructor(readonly responseCategory: PlexResponseCategory) {
+		super("Plex API request failed");
+		this.name = "PlexRequestError";
+		delete this.stack;
+	}
+}
+
+function transportResponseCategory(error: unknown): PlexResponseCategory {
+	return error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError")
+		? "timeout"
+		: "unavailable";
+}
+
 /**
  * Extract a ratingKey from a Plex path like "/library/metadata/65486".
  * The history API returns `grandparentKey` (full path) instead of
@@ -863,17 +881,24 @@ export class PlexClient {
 			fetchOptions.body = JSON.stringify(options.body);
 		}
 
-		const response = await fetch(url.toString(), fetchOptions);
+		let response: Response;
+		try {
+			response = await fetch(url.toString(), fetchOptions);
+		} catch (error) {
+			const responseCategory = transportResponseCategory(error);
+			this.log.warn({ operation: "plex_api_request", responseCategory }, "Plex API request failed");
+			throw new PlexRequestError(responseCategory);
+		}
 
 		if (!response.ok) {
-			const responseCategory =
+			const responseCategory: PlexResponseCategory =
 				response.status >= 400 && response.status < 500
 					? "client_error"
 					: response.status >= 500
 						? "server_error"
 						: "unavailable";
 			this.log.warn({ operation: "plex_api_request", responseCategory }, "Plex API request failed");
-			throw new Error(`Plex API error: HTTP ${response.status} ${response.statusText}`);
+			throw new PlexRequestError(responseCategory);
 		}
 
 		const contentType = response.headers.get("content-type") ?? "";
@@ -882,20 +907,34 @@ export class PlexClient {
 			try {
 				raw = await response.json();
 			} catch {
-				throw new Error(
-					`Plex API: invalid JSON response (path: ${path}, status: ${response.status})`,
+				this.log.warn(
+					{ operation: "plex_api_request", responseCategory: "unavailable" },
+					"Plex API request failed",
 				);
+				throw new PlexRequestError("unavailable");
 			}
 			if (!options?.schema) {
-				throw new Error(`Plex API: schema required for JSON responses (path: ${path})`);
+				throw new Error("Plex API schema required for JSON response");
 			}
 			const category = path.split("?")[0] ?? path;
-			return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
+			try {
+				return parseUpstreamOrThrow(raw, options.schema, { integration: "plex", category });
+			} catch {
+				this.log.warn(
+					{ operation: "plex_api_request", responseCategory: "unavailable" },
+					"Plex API request failed",
+				);
+				throw new PlexRequestError("unavailable");
+			}
 		}
 
 		// Non-JSON responses (e.g., from POST /library/sections/{id}/refresh)
 		if (options?.schema) {
-			throw new Error(`Plex API: expected JSON response but got ${contentType} (path: ${path})`);
+			this.log.warn(
+				{ operation: "plex_api_request", responseCategory: "unavailable" },
+				"Plex API request failed",
+			);
+			throw new PlexRequestError("unavailable");
 		}
 		return undefined as T;
 	}

--- a/apps/api/src/lib/plex/plex-client.ts
+++ b/apps/api/src/lib/plex/plex-client.ts
@@ -866,7 +866,13 @@ export class PlexClient {
 		const response = await fetch(url.toString(), fetchOptions);
 
 		if (!response.ok) {
-			this.log.warn({ status: response.status, path }, "Plex API non-OK response");
+			const responseCategory =
+				response.status >= 400 && response.status < 500
+					? "client_error"
+					: response.status >= 500
+						? "server_error"
+						: "unavailable";
+			this.log.warn({ operation: "plex_api_request", responseCategory }, "Plex API request failed");
 			throw new Error(`Plex API error: HTTP ${response.status} ${response.statusText}`);
 		}
 

--- a/apps/api/src/lib/plex/plex-label-sync-logging.ts
+++ b/apps/api/src/lib/plex/plex-label-sync-logging.ts
@@ -10,6 +10,7 @@ export type PlexMetadataTagMutationFailureReason =
 	| "live_target_missing"
 	| "live_target_ambiguous"
 	| "live_target_changed"
+	| "live_evidence_unavailable"
 	| "provider_identity_changed"
 	| "provider_connection_changed"
 	| "upstream_write_failed"
@@ -149,6 +150,7 @@ const PLEX_MUTATION_FAILURE_REASONS = new Set<PlexMetadataTagMutationFailureReas
 	"live_target_missing",
 	"live_target_ambiguous",
 	"live_target_changed",
+	"live_evidence_unavailable",
 	"provider_identity_changed",
 	"provider_connection_changed",
 	"upstream_write_failed",
@@ -233,7 +235,7 @@ function classifyDestinationCoverageReason(
 		case "latest_attempt_future_dated":
 			return "publication_superseded";
 		case "plex_content_digest_changed":
-			return "live_target_changed";
+			return "live_evidence_unavailable";
 		case "disabled_instance":
 		case "missing_status":
 		case "unpublished_generation":
@@ -281,6 +283,7 @@ function classifyMutationReason(
 		case "live_target_missing":
 		case "live_target_ambiguous":
 		case "live_target_changed":
+		case "live_evidence_unavailable":
 		case "provider_identity_changed":
 		case "provider_connection_changed":
 		case "upstream_write_failed":

--- a/apps/api/src/lib/plex/plex-label-sync-logging.ts
+++ b/apps/api/src/lib/plex/plex-label-sync-logging.ts
@@ -1,0 +1,398 @@
+import type { PlexCoverageReasonCode, PlexEvidenceSummary } from "@arr/shared";
+import type { FastifyBaseLogger } from "fastify";
+import type { PlexResponseCategory } from "./plex-client.js";
+
+export type PlexMetadataTagMutationFailureReason =
+	| "cached_target_unavailable"
+	| "cached_target_ambiguous"
+	| "cached_target_inconsistent"
+	| "provider_authority_unavailable"
+	| "live_target_missing"
+	| "live_target_ambiguous"
+	| "live_target_changed"
+	| "provider_identity_changed"
+	| "provider_connection_changed"
+	| "upstream_write_failed"
+	| "publication_superseded"
+	| "unknown_failure";
+
+export type PlexLabelSyncTerminalReason =
+	| Exclude<PlexMetadataTagMutationFailureReason, "provider_authority_unavailable">
+	| "source_authority_unavailable"
+	| "source_read_failed"
+	| "source_evidence_changed"
+	| "source_evidence_ambiguous"
+	| "provider_attempt_unavailable"
+	| "upstream_write_rejected"
+	| "success";
+
+export type PlexLabelSyncTerminalClassificationInput =
+	| {
+			stage: "source_authority" | "source_read";
+			code: PlexCoverageReasonCode | "source_read_failed";
+	  }
+	| {
+			stage: "destination_authority";
+			code: PlexMetadataTagMutationFailureReason;
+	  }
+	| {
+			stage: "upstream_write";
+			code: PlexResponseCategory;
+	  }
+	| {
+			stage: "success";
+			code: "success";
+	  };
+
+export class PlexMetadataTagWriteError extends Error {
+	readonly code = "upstream_write_failed" as const;
+
+	constructor(readonly responseCategory: PlexResponseCategory = "unavailable") {
+		super("Plex metadata tag write failed");
+		this.name = "PlexMetadataTagWriteError";
+		delete this.stack;
+	}
+}
+
+const PLEX_COVERAGE_REASON_CODES = new Set<PlexCoverageReasonCode>([
+	"disabled_instance",
+	"missing_status",
+	"unpublished_generation",
+	"missing_generation_id",
+	"missing_metadata",
+	"malformed_metadata",
+	"unknown_metadata_version",
+	"invalid_publication_level",
+	"invalid_completeness",
+	"invalid_item_count",
+	"invalid_sections",
+	"duplicate_sections",
+	"stale_generation",
+	"generation_changed",
+	"published_timestamp_changed",
+	"row_count_mismatch",
+	"connection_generation_mismatch",
+	"identity_generation_mismatch",
+	"latest_attempt_failed",
+	"latest_attempt_in_progress",
+	"latest_attempt_partial",
+	"latest_attempt_unknown",
+	"latest_attempt_missing",
+	"latest_attempt_future_dated",
+	"published_generation_stale",
+	"metadata_invalid",
+	"mutation_authority_unavailable",
+	"query_failed",
+	"parent_generation_unavailable",
+	"plex_activity_unavailable",
+	"plex_section_state_unavailable",
+	"plex_library_scan_in_progress",
+	"plex_metadata_refresh_in_progress",
+	"plex_library_activity_unknown",
+	"plex_library_revision_changed",
+	"plex_content_digest_changed",
+	"plex_settlement_metadata_missing",
+	"target_ledger_binding_missing",
+	"target_ledger_invalid",
+	"target_ledger_unavailable",
+	"target_count_mismatch",
+	"target_digest_mismatch",
+	"target_section_mismatch",
+]);
+
+const PLEX_MUTATION_FAILURE_REASONS = new Set<PlexMetadataTagMutationFailureReason>([
+	"cached_target_unavailable",
+	"cached_target_ambiguous",
+	"cached_target_inconsistent",
+	"provider_authority_unavailable",
+	"live_target_missing",
+	"live_target_ambiguous",
+	"live_target_changed",
+	"provider_identity_changed",
+	"provider_connection_changed",
+	"upstream_write_failed",
+	"publication_superseded",
+	"unknown_failure",
+]);
+
+function assertNever(value: never): never {
+	throw new Error(typeof value === "string" ? "Unclassified Plex reason" : "Unclassified value");
+}
+
+function classifySourceCoverageReason(
+	reasonCode: PlexCoverageReasonCode,
+): PlexLabelSyncTerminalReason {
+	switch (reasonCode) {
+		case "disabled_instance":
+		case "missing_status":
+		case "unpublished_generation":
+		case "missing_generation_id":
+		case "missing_metadata":
+		case "malformed_metadata":
+		case "unknown_metadata_version":
+		case "invalid_publication_level":
+		case "invalid_completeness":
+		case "invalid_item_count":
+		case "invalid_sections":
+		case "stale_generation":
+		case "row_count_mismatch":
+		case "latest_attempt_failed":
+		case "latest_attempt_in_progress":
+		case "latest_attempt_partial":
+		case "latest_attempt_unknown":
+		case "latest_attempt_missing":
+		case "latest_attempt_future_dated":
+		case "published_generation_stale":
+		case "metadata_invalid":
+		case "parent_generation_unavailable":
+		case "plex_settlement_metadata_missing":
+			return "source_authority_unavailable";
+		case "generation_changed":
+		case "published_timestamp_changed":
+		case "connection_generation_mismatch":
+		case "identity_generation_mismatch":
+		case "plex_library_scan_in_progress":
+		case "plex_metadata_refresh_in_progress":
+		case "plex_library_revision_changed":
+		case "plex_content_digest_changed":
+			return "source_evidence_changed";
+		case "duplicate_sections":
+		case "target_ledger_binding_missing":
+		case "target_ledger_invalid":
+		case "target_ledger_unavailable":
+		case "target_count_mismatch":
+		case "target_digest_mismatch":
+		case "target_section_mismatch":
+			return "source_evidence_ambiguous";
+		case "mutation_authority_unavailable":
+		case "query_failed":
+		case "plex_activity_unavailable":
+		case "plex_section_state_unavailable":
+		case "plex_library_activity_unknown":
+			return "source_read_failed";
+	}
+	return assertNever(reasonCode);
+}
+
+function classifyDestinationCoverageReason(
+	reasonCode: PlexCoverageReasonCode,
+): PlexMetadataTagMutationFailureReason {
+	switch (reasonCode) {
+		case "connection_generation_mismatch":
+			return "provider_connection_changed";
+		case "identity_generation_mismatch":
+			return "provider_identity_changed";
+		case "generation_changed":
+		case "published_timestamp_changed":
+		case "latest_attempt_failed":
+		case "latest_attempt_in_progress":
+		case "latest_attempt_partial":
+		case "latest_attempt_unknown":
+		case "latest_attempt_missing":
+		case "latest_attempt_future_dated":
+			return "publication_superseded";
+		case "plex_content_digest_changed":
+			return "live_target_changed";
+		case "disabled_instance":
+		case "missing_status":
+		case "unpublished_generation":
+		case "missing_generation_id":
+		case "missing_metadata":
+		case "malformed_metadata":
+		case "unknown_metadata_version":
+		case "invalid_publication_level":
+		case "invalid_completeness":
+		case "invalid_item_count":
+		case "invalid_sections":
+		case "duplicate_sections":
+		case "stale_generation":
+		case "row_count_mismatch":
+		case "published_generation_stale":
+		case "metadata_invalid":
+		case "mutation_authority_unavailable":
+		case "query_failed":
+		case "parent_generation_unavailable":
+		case "plex_activity_unavailable":
+		case "plex_section_state_unavailable":
+		case "plex_library_scan_in_progress":
+		case "plex_metadata_refresh_in_progress":
+		case "plex_library_activity_unknown":
+		case "plex_library_revision_changed":
+		case "plex_settlement_metadata_missing":
+		case "target_ledger_binding_missing":
+		case "target_ledger_invalid":
+		case "target_ledger_unavailable":
+		case "target_count_mismatch":
+		case "target_digest_mismatch":
+		case "target_section_mismatch":
+			return "provider_authority_unavailable";
+	}
+	return assertNever(reasonCode);
+}
+
+function classifyMutationReason(
+	reasonCode: PlexMetadataTagMutationFailureReason,
+): PlexLabelSyncTerminalReason {
+	switch (reasonCode) {
+		case "cached_target_unavailable":
+		case "cached_target_ambiguous":
+		case "cached_target_inconsistent":
+		case "live_target_missing":
+		case "live_target_ambiguous":
+		case "live_target_changed":
+		case "provider_identity_changed":
+		case "provider_connection_changed":
+		case "upstream_write_failed":
+		case "publication_superseded":
+		case "unknown_failure":
+			return reasonCode;
+		case "provider_authority_unavailable":
+			return "provider_attempt_unavailable";
+	}
+	return assertNever(reasonCode);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object";
+}
+
+function isCoverageReason(value: unknown): value is PlexCoverageReasonCode {
+	return (
+		typeof value === "string" && PLEX_COVERAGE_REASON_CODES.has(value as PlexCoverageReasonCode)
+	);
+}
+
+function isMutationReason(value: unknown): value is PlexMetadataTagMutationFailureReason {
+	return (
+		typeof value === "string" &&
+		PLEX_MUTATION_FAILURE_REASONS.has(value as PlexMetadataTagMutationFailureReason)
+	);
+}
+
+function isResponseCategory(value: unknown): value is PlexResponseCategory {
+	return (
+		value === "client_error" ||
+		value === "server_error" ||
+		value === "timeout" ||
+		value === "unavailable"
+	);
+}
+
+export function classifyPlexLabelSyncTerminalReason(
+	input: PlexLabelSyncTerminalClassificationInput,
+): PlexLabelSyncTerminalReason {
+	switch (input.stage) {
+		case "source_authority":
+		case "source_read":
+			if (input.code === "source_read_failed") return "source_read_failed";
+			return classifySourceCoverageReason(input.code);
+		case "destination_authority":
+			return classifyMutationReason(input.code);
+		case "upstream_write":
+			return input.code === "client_error" ? "upstream_write_rejected" : "upstream_write_failed";
+		case "success":
+			return "success";
+	}
+	return assertNever(input);
+}
+
+export function classifyUnknownPlexLabelSyncTerminalReason(
+	input: unknown,
+): PlexLabelSyncTerminalReason {
+	if (!isRecord(input) || typeof input.stage !== "string") return "unknown_failure";
+	switch (input.stage) {
+		case "source_authority":
+		case "source_read":
+			if (input.code === "source_read_failed") return "source_read_failed";
+			return isCoverageReason(input.code)
+				? classifySourceCoverageReason(input.code)
+				: "unknown_failure";
+		case "destination_authority":
+			return isMutationReason(input.code) ? classifyMutationReason(input.code) : "unknown_failure";
+		case "upstream_write":
+			return isResponseCategory(input.code)
+				? input.code === "client_error"
+					? "upstream_write_rejected"
+					: "upstream_write_failed"
+				: "unknown_failure";
+		case "success":
+			return input.code === "success" ? "success" : "unknown_failure";
+		default:
+			return "unknown_failure";
+	}
+}
+
+export function classifyPlexMetadataTagEvidenceFailure(
+	evidence: PlexEvidenceSummary,
+): PlexMetadataTagMutationFailureReason {
+	for (const reasonCode of evidence.reasonCodes) {
+		const classified = classifyDestinationCoverageReason(reasonCode);
+		if (classified !== "provider_authority_unavailable") return classified;
+	}
+	return "provider_authority_unavailable";
+}
+
+export function createLabelSyncPlexProviderLogSink(): FastifyBaseLogger {
+	let sink: FastifyBaseLogger;
+	const ignore = (..._args: unknown[]) => undefined;
+	sink = {
+		child: () => sink,
+		info: ignore,
+		warn: ignore,
+		error: ignore,
+		debug: ignore,
+		trace: ignore,
+		fatal: ignore,
+	} as unknown as FastifyBaseLogger;
+	return sink;
+}
+
+export type PlexLabelSyncTerminalEvent = {
+	operation: "source_read" | "destination_write";
+	state: "failed" | "success";
+	stage:
+		| "source_authority"
+		| "source_read"
+		| "destination_authority"
+		| "upstream_write"
+		| "success";
+	reasonCode: PlexLabelSyncTerminalReason;
+	mediaCategory?: "movie" | "series";
+	candidateCount?: number;
+	upstreamCategory?: PlexResponseCategory;
+};
+
+export function logPlexLabelSyncTerminal(
+	log: FastifyBaseLogger,
+	event: PlexLabelSyncTerminalEvent,
+): void {
+	const projection: PlexLabelSyncTerminalEvent = {
+		operation: event.operation,
+		state: event.state,
+		stage: event.stage,
+		reasonCode: event.reasonCode,
+	};
+	if (event.mediaCategory === "movie" || event.mediaCategory === "series") {
+		projection.mediaCategory = event.mediaCategory;
+	}
+	if (
+		event.candidateCount !== undefined &&
+		Number.isSafeInteger(event.candidateCount) &&
+		event.candidateCount >= 0
+	) {
+		projection.candidateCount = event.candidateCount;
+	}
+	if (event.upstreamCategory && isResponseCategory(event.upstreamCategory)) {
+		projection.upstreamCategory = event.upstreamCategory;
+	}
+	const message =
+		event.operation === "source_read"
+			? event.state === "success"
+				? "Plex label-sync source read succeeded"
+				: "Plex label-sync source read failed"
+			: event.state === "success"
+				? "Plex label-sync destination write succeeded"
+				: "Plex label-sync destination write failed";
+	if (event.state === "success") log.info(projection, message);
+	else log.warn(projection, message);
+}

--- a/apps/api/src/lib/plex/plex-label-sync-logging.ts
+++ b/apps/api/src/lib/plex/plex-label-sync-logging.ts
@@ -54,6 +54,47 @@ export class PlexMetadataTagWriteError extends Error {
 	}
 }
 
+export type PlexLabelMutationCaughtErrorClassification =
+	| {
+			stage: "destination_authority";
+			reasonCode: "unknown_failure";
+	  }
+	| {
+			stage: "upstream_write";
+			reasonCode: "upstream_write_rejected" | "upstream_write_failed";
+			upstreamCategory: PlexResponseCategory;
+	  };
+
+function classifyPlexUpstreamWriteReason(
+	responseCategory: PlexResponseCategory,
+): "upstream_write_rejected" | "upstream_write_failed" {
+	switch (responseCategory) {
+		case "client_error":
+			return "upstream_write_rejected";
+		case "server_error":
+		case "timeout":
+		case "unavailable":
+			return "upstream_write_failed";
+	}
+	return assertNever(responseCategory);
+}
+
+export function classifyPlexLabelMutationCaughtError(
+	error: unknown,
+): PlexLabelMutationCaughtErrorClassification {
+	if (!(error instanceof PlexMetadataTagWriteError)) {
+		return {
+			stage: "destination_authority",
+			reasonCode: "unknown_failure",
+		};
+	}
+	return {
+		stage: "upstream_write",
+		reasonCode: classifyPlexUpstreamWriteReason(error.responseCategory),
+		upstreamCategory: error.responseCategory,
+	};
+}
+
 const PLEX_COVERAGE_REASON_CODES = new Set<PlexCoverageReasonCode>([
 	"disabled_instance",
 	"missing_status",
@@ -289,7 +330,7 @@ export function classifyPlexLabelSyncTerminalReason(
 		case "destination_authority":
 			return classifyMutationReason(input.code);
 		case "upstream_write":
-			return input.code === "client_error" ? "upstream_write_rejected" : "upstream_write_failed";
+			return classifyPlexUpstreamWriteReason(input.code);
 		case "success":
 			return "success";
 	}


### PR DESCRIPTION
## Summary

Contains Plex provider diagnostics for label-sync operations and emits one bounded, causally accurate terminal event for each failed Plex source read or destination mutation.

The final correction preserves the distinction between incomplete live evidence and a completed catalog that disproves the cached target. It also returns a sanitized HTTP 502 when Plex returns successful JSON that fails the expected response schema.

## Related issue

Related to #787

## Scope

- Plex label-sync source and destination logging boundaries.
- Shared, exhaustive classification of Plex source authority, source read, destination authority, and upstream write outcomes.
- Settlement classification for incomplete live evidence and complete-set target mismatch.
- Content-free Plex request and metadata-write errors.
- Sanitized HTTP 502 handling for schema-invalid successful Plex JSON.
- Focused whole-execution privacy, terminal-event, authority-parity, client-regression, settlement, and production error-handler tests.

## Non-goals

- No target-authority, target-matching, retry, notification, audit, or counter redesign.
- No global Plex cache-refresher logging change.
- No schema, generated Prisma, dependency, frontend, release, version, or `next` work.
- No Tautulli implementation. B2, B3, and T2 are stopped for v2.24.2 because Tautulli v2.17.2 does not expose a trustworthy completed catalog generation. B1 remains the final fail-closed Tautulli state for this release.

## Acceptance criteria

- [x] Plex source and destination operations give nested authority, cache, and client code an execution-scoped sink that drops arbitrary objects, messages, and errors.
- [x] Each failed Plex source or destination stage emits exactly one terminal event with a closed projection and accurate reason.
- [x] Incomplete timeout, failed settlement, unpublished inventory, and positive-only live evidence map to `destination_authority` / `live_evidence_unavailable`.
- [x] Only a proven complete-set mismatch maps to `live_target_missing`, `live_target_ambiguous`, or `live_target_changed`.
- [x] Only `PlexMetadataTagWriteError` proves an upstream metadata write was attempted.
- [x] Generic caught values map to `destination_authority` / `unknown_failure` without inspecting or projecting their contents.
- [x] Typed metadata PUT failures map only to `upstream_write_rejected` or `upstream_write_failed`.
- [x] Schema-invalid successful Plex JSON reaches the production error handler as a content-free 502; malformed JSON, transport failures, and non-OK responses retain their existing behavior.
- [x] Typed Plex request and metadata-write errors contain only stable internal values and a coarse response category, with no cause or stack.
- [x] Success performs one upstream write, increments success once, and does not expose provider or media identity in logs.
- [x] Authority availability, selected targets, ambiguity, generation checks, mutation counts, and executor counters remain unchanged.
- [x] Both final targeted reviews passed the immutable correction head.

## Changes

- Replaced the destination writer's warning-reprojection logger with a no-op Plex provider sink scoped to each label-sync operation. This removes the original destination leak and prevents nested provider warnings from creating a second terminal reason.
- Applied the same sink to the Plex source reader. This closes the source-side execution-graph leak through authority, live/cache refresh, and `PlexClient`.
- Added a shared exhaustive terminal classifier and a fresh allowlisted projection. Incomplete live evidence reports `live_evidence_unavailable`. A completed catalog that disproves the cached target reports the specific missing, ambiguous, or changed reason.
- Added a closed caught-error classifier. `PlexMetadataTagWriteError` maps to the upstream-write stage; every other caught value maps to `destination_authority` / `unknown_failure` without reading message, cause, stack, or arbitrary fields.
- Retained content-free `PlexRequestError` and `PlexMetadataTagWriteError` values. Shared Plex client logs retain only a stable operation and coarse response category.
- Added an optional bounded status code to `PlexRequestError`. Only an `UpstreamValidationError` from successful Plex JSON receives 502. The production Fastify error handler uses that safe status without serializing the rejected payload.
- Added production-path canary tests, complete Plex-to-Plex source/destination cases, exact terminal-event counts, success-path privacy coverage, exhaustive reason matrices, authority decision/target parity cases, incomplete-settlement cases, and production HTTP error-handler coverage.

## Settlement classification

| Evidence | Destination terminal classification | Mutation |
| --- | --- | --- |
| Live refresh timeout | `destination_authority` / `live_evidence_unavailable` | Blocked |
| Settlement probe failure | `destination_authority` / `live_evidence_unavailable` | Blocked |
| Inventory not published or positive-only | `destination_authority` / `live_evidence_unavailable` | Blocked |
| Complete inventory has no target | `destination_authority` / `live_target_missing` | Blocked |
| Complete inventory has multiple targets | `destination_authority` / `live_target_ambiguous` | Blocked |
| Complete inventory has one target with changed digest | `destination_authority` / `live_target_changed` | Blocked |
| Complete inventory proves the authorized target unchanged | Success path | One write |

The reason annotation does not alter availability, selected rows, ambiguity, exact target identity, generation checks, or upstream call counts.

## HTTP 502 contract

The production `buildServer` error-handler path is covered with the real `PlexClient` through a synthetic test route:

- Schema-invalid successful Plex JSON returns HTTP 502 with the bounded internal message.
- Valid successful JSON returns the same 200 payload as before.
- Malformed JSON is not reclassified as validation failure.
- Transport and non-OK response behavior is unchanged.
- The error has no cause, provider message, response body, path, URL, headers, token, or stack.

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] RED at `c3f34c20`: 184 passed and 8 failed across 5 focused files. The failures were limited to incomplete-settlement classification, exhaustive mapping, writer classification, bounded status propagation, and the production 500/502 contract.
- [x] Pre-review GREEN at `ab4d0704`: 295/295 passed across 9 focused files.
- [x] Post-review affected-surface run: 256/256 passed across 12 test files.
- [x] Causal diagnostics and mutation-parity reviewer: 200/200 focused tests; all 6 required answers passed with no P0/P1/P2 finding.
- [x] HTTP semantics and privacy reviewer: 67/67 focused tests; all 6 required answers passed with no P0/P1/P2 finding.
- [x] `pnpm run check:prisma-generated`: generated client is current.
- [x] `node --test scripts/check-prisma-generated.test.mjs`: 17/17 passed.
- [x] `pnpm run format`: 3/3 packages passed; no fixes applied.
- [x] `pnpm --filter @arr/shared build`.
- [x] `pnpm run typecheck`: 3/3 packages passed.
- [x] `pnpm run test`: API 4,795 passed and 53 skipped; web 669 passed; shared 89 passed. Total: 5,553 passed and 53 skipped.
- [x] `pnpm run lint`: 3/3 packages passed.
- [x] `CI=true pnpm run validate:pr`, including 53/53 PR review-contract tests.
- [x] `pnpm run build`: 3/3 packages passed.
- [x] `pnpm --filter @arr/api test:provider-cache-heap`: 7/7 passed.
- [x] `git diff --check`.
- [ ] User-visible behavior was live-verified, when applicable. Not applicable because this change has no UI surface.
- [ ] New queries use centralized query keys and polling constants, when applicable. Not applicable; no query was added.
- [ ] New sensitive displays preserve incognito behavior, when applicable. Not applicable; no display was changed.
- [ ] New Prisma queries for user-owned resources include `userId`, when applicable. Not applicable; no Prisma query was added.
- [ ] Optional-service gating is verified for new pages, panels, or signals, when applicable. Not applicable; no page, panel, or signal was added.
- [x] User-facing counts are precise rather than proxies, when applicable. Existing source, match, success, and failure counters have exact parity coverage.
- [ ] Action links reach the correct page with required parameters, when applicable. Not applicable; no action link was changed.
- [ ] Duplicate surfaces were checked and any overlap is justified, when applicable. Not applicable; no UI surface was added.

Docker and external provider stacks are not applicable to this API-only correction. The change does not touch container behavior, runtime permissions, schema, or service fixtures. Production error-handler coverage, the real label-sync executor path, Plex authority/client tests, the full build, and CI-mode validation cover the affected runtime boundary.

## Review plan

- Initial broad-reviewed head: `5284905cf8e744d47f8731009cc52e316d219d66`
- Whole-execution correction head: `83277518dc72f0e5aed70c9fc26bf86bec1c2245`
- Pre-write correction head: `c3f34c202168869532232d4c5b7fdc5308d134bb`
- Settlement and validation correction head: `ab4d07042803ab2d339e313667efe1c68f130646`
- Final targeted range: `c3f34c202168869532232d4c5b7fdc5308d134bb..ab4d07042803ab2d339e313667efe1c68f130646`
- Material-scope change declared? No. The maintainer authorized this two-finding final scope-reduction correction.
- Causal diagnostics and mutation-parity reviewer: PASS at `ab4d0704`; no authority, target selection, write-count, or counter regression.
- HTTP semantics and privacy reviewer: PASS at `ab4d0704`; no payload disclosure or unrelated client behavior change.
- Maintainer decision: Pending.

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| P1 | P1 | In scope | Real Plex source authority/cache/client failure exposed source and provider canaries at `5284905c` | Fixed at `83277518`; production-path canary test is green | None |
| P2-A | P2 | In scope | Metadata PUT emitted contradictory authority/write reasons and content digest drift mapped to provider unavailable at `5284905c` | Fixed at `83277518`; strict single-event and exhaustive mapping tests are green | None |
| P2-B | P2 | In scope | Generic pre-write exceptions were labeled `upstream_write` at `83277518`; five RED cases reproduced the false stage | Fixed at `c3f34c20`; unknown-value matrix, typed contrast, exact event count, privacy, write-count, and counter tests are green | None |
| P2-C | P2 | In scope | Incomplete live evidence collapsed into `live_target_changed` at `c3f34c20` | Fixed at `ab4d0704`; incomplete evidence remains fail-closed and only a completed mismatch reports target drift | None |
| P2-D | P2 | In scope | Schema-invalid successful Plex JSON reached the production error handler as HTTP 500 at `c3f34c20` | Fixed at `ab4d0704`; bounded 502 and valid-response parity tests are green | None |
| F3 | P2 | Pre-existing follow-up | Unchanged non-Plex label-sync source readers may log raw non-Plex provider exceptions before a Plex destination | Outside the authorized Plex source/destination diagnostic delta; no scope-expanding edit made | Maintainer disposition after #787 |

## Final merge gate

- [ ] Exact-head CI is green
- [x] Acceptance criteria passed locally
- [ ] No unresolved in-scope review threads remain. Resolve after exact-head checks pass.
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the recorded targeted reviews
- [x] Base remains `ed6dcfbb6d2fbf3a803efda5a160e455b38652f3`
- [ ] Maintainer approved merge
- [x] Post-merge verification is planned: rerun the exact-main release audit after #787 merges.
