### PR TITLE
fix(queue-cleaner): require blocklist for retained torrents

### DIFF
--- a/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
+++ b/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
@@ -284,6 +284,60 @@ describe("executeQueueCleaner — integration", () => {
 		expect(del).not.toHaveBeenCalled();
 	});
 
+	it("fails closed when a retained torrent would be recategorized without blocklisting", async () => {
+		const del = vi.fn();
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+
+		const result = await executeQueueCleaner(
+			app,
+			makeInstance(),
+			makeConfig({
+				removeFromClient: false,
+				addToBlocklist: false,
+				changeCategoryEnabled: true,
+			}),
+		);
+
+		expect(result.itemsCleaned).toBe(0);
+		expect(result.skippedItems).toEqual([
+			expect.objectContaining({
+				id: 42,
+				reason: expect.stringContaining("blocklist"),
+			}),
+		]);
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("retains and recategorizes a torrent when the exact release is blocklisted", async () => {
+		const del = vi.fn().mockResolvedValue(undefined);
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+
+		const result = await executeQueueCleaner(
+			app,
+			makeInstance(),
+			makeConfig({
+				removeFromClient: false,
+				addToBlocklist: true,
+				searchAfterRemoval: false,
+				changeCategoryEnabled: true,
+			}),
+		);
+
+		expect(result.itemsCleaned).toBe(1);
+		expect(del).toHaveBeenCalledWith(42, {
+			removeFromClient: false,
+			blocklist: true,
+			skipRedownload: true,
+			changeCategory: true,
+		});
+	});
+
 	it("silent-failure contract: ARR queue.get throwing yields status:error, NOT an unhandled rejection", async () => {
 		const del = vi.fn();
 		const app = makeApp({

--- a/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
+++ b/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
@@ -31,6 +31,10 @@ const quiMocks = vi.hoisted(() => ({
 	listQuiInstances: vi.fn(),
 }));
 
+const autoImportMocks = vi.hoisted(() => ({
+	attemptAutoImport: vi.fn(),
+}));
+
 vi.mock("../../qui/client-factory.js", () => ({
 	createQuiClient: quiMocks.createQuiClient,
 }));
@@ -38,6 +42,14 @@ vi.mock("../../qui/client-factory.js", () => ({
 vi.mock("../../qui/instance-helpers.js", () => ({
 	listQuiInstances: quiMocks.listQuiInstances,
 }));
+
+vi.mock("../auto-import-handler.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../auto-import-handler.js")>();
+	return {
+		...actual,
+		attemptAutoImport: autoImportMocks.attemptAutoImport,
+	};
+});
 
 import { executeEnhancedPreview, executeQueueCleaner } from "../cleaner-executor.js";
 
@@ -287,7 +299,7 @@ describe("executeQueueCleaner — integration", () => {
 	it("keeps both previews aligned when execution blocks unsafe retained-torrent recategorization", async () => {
 		const del = vi.fn();
 		const app = makeApp({
-			get: async () => ({ records: [STALLED_ITEM] }),
+			get: async () => ({ records: [{ ...STALLED_ITEM, protocol: "Torrent" }] }),
 			del,
 		});
 		const config = makeConfig({
@@ -325,6 +337,114 @@ describe("executeQueueCleaner — integration", () => {
 			}),
 		]);
 		expect(enhancedPreview.wouldRemove).toBe(0);
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("blocks unsafe retained torrents before auto-import or import-attempt persistence", async () => {
+		autoImportMocks.attemptAutoImport.mockReset();
+		autoImportMocks.attemptAutoImport.mockResolvedValue({ attempted: true, success: true });
+		const del = vi.fn();
+		const importPendingItem = {
+			...STALLED_ITEM,
+			trackedDownloadState: "importPending",
+			statusMessages: [],
+			errorMessage: undefined,
+		};
+		const app = makeApp({
+			get: async () => ({ records: [importPendingItem] }),
+			del,
+		});
+		const config = makeConfig({
+			stalledEnabled: false,
+			importPendingEnabled: true,
+			importPendingThresholdMins: 0,
+			autoImportEnabled: true,
+			autoImportMaxAttempts: 2,
+			autoImportCooldownMins: 0,
+			autoImportSafeOnly: false,
+			autoImportCustomPatterns: null,
+			autoImportNeverPatterns: null,
+			removeFromClient: false,
+			addToBlocklist: false,
+			changeCategoryEnabled: true,
+		});
+
+		const execution = await executeQueueCleaner(app, makeInstance(), config);
+		const dryRun = await executeQueueCleaner(app, makeInstance(), {
+			...config,
+			dryRunMode: true,
+		});
+		const enhancedPreview = await executeEnhancedPreview(app, makeInstance(), config);
+
+		expect(execution.skippedItems).toEqual([
+			expect.objectContaining({ id: 42, reason: expect.stringContaining("blocklist") }),
+		]);
+		expect(dryRun.skippedItems).toEqual([
+			expect.objectContaining({ id: 42, reason: expect.stringContaining("blocklist") }),
+		]);
+		expect(enhancedPreview.previewItems).toEqual([
+			expect.objectContaining({
+				id: 42,
+				action: "skip",
+				reason: expect.stringContaining("blocklist"),
+			}),
+		]);
+		expect(autoImportMocks.attemptAutoImport).not.toHaveBeenCalled();
+		expect(app.prisma.queueCleanerStrike.create).not.toHaveBeenCalled();
+		expect(app.prisma.queueCleanerStrike.update).not.toHaveBeenCalled();
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("applies the removal cap after retained-torrent authorization in every mode", async () => {
+		const unsafeTorrent = { ...STALLED_ITEM, id: 42 };
+		const safeUsenet = {
+			...STALLED_ITEM,
+			id: 43,
+			title: "Stalled.Show.S01E02",
+			downloadId: "dl-43",
+			protocol: "usenet",
+		};
+		const del = vi.fn().mockResolvedValue(undefined);
+		const app = makeApp({
+			get: async () => ({ records: [unsafeTorrent, safeUsenet] }),
+			del,
+		});
+		const config = makeConfig({
+			maxRemovalsPerRun: 1,
+			removeFromClient: false,
+			addToBlocklist: false,
+			changeCategoryEnabled: true,
+		});
+
+		const execution = await executeQueueCleaner(app, makeInstance(), config);
+		expect(execution.cleanedItems).toEqual([expect.objectContaining({ id: 43 })]);
+		expect(execution.skippedItems).toEqual([
+			expect.objectContaining({ id: 42, reason: expect.stringContaining("blocklist") }),
+		]);
+		expect(del).toHaveBeenCalledTimes(1);
+		expect(del).toHaveBeenCalledWith(43, expect.any(Object));
+
+		del.mockClear();
+		const dryRun = await executeQueueCleaner(app, makeInstance(), {
+			...config,
+			dryRunMode: true,
+		});
+		expect(dryRun.skippedItems).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: 42, reason: expect.stringContaining("blocklist") }),
+				expect.objectContaining({ id: 43, reason: expect.stringContaining("Would remove") }),
+			]),
+		);
+		expect(del).not.toHaveBeenCalled();
+
+		const enhancedPreview = await executeEnhancedPreview(app, makeInstance(), config);
+		expect(enhancedPreview.previewItems).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ id: 42, action: "skip" }),
+				expect.objectContaining({ id: 43, action: "remove" }),
+			]),
+		);
+		expect(enhancedPreview.wouldRemove).toBe(1);
 		expect(del).not.toHaveBeenCalled();
 	});
 

--- a/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
+++ b/apps/api/src/lib/queue-cleaner/__tests__/cleaner-executor-integration.test.ts
@@ -284,30 +284,81 @@ describe("executeQueueCleaner — integration", () => {
 		expect(del).not.toHaveBeenCalled();
 	});
 
-	it("fails closed when a retained torrent would be recategorized without blocklisting", async () => {
+	it("keeps both previews aligned when execution blocks unsafe retained-torrent recategorization", async () => {
+		const del = vi.fn();
+		const app = makeApp({
+			get: async () => ({ records: [STALLED_ITEM] }),
+			del,
+		});
+		const config = makeConfig({
+			removeFromClient: false,
+			addToBlocklist: false,
+			changeCategoryEnabled: true,
+		});
+
+		const execution = await executeQueueCleaner(app, makeInstance(), config);
+		const dryRun = await executeQueueCleaner(app, makeInstance(), {
+			...config,
+			dryRunMode: true,
+		});
+		const enhancedPreview = await executeEnhancedPreview(app, makeInstance(), config);
+
+		expect(execution.itemsCleaned).toBe(0);
+		expect(execution.skippedItems).toEqual([
+			expect.objectContaining({
+				id: 42,
+				reason: expect.stringContaining("blocklist"),
+			}),
+		]);
+		expect(dryRun.itemsCleaned).toBe(0);
+		expect(dryRun.skippedItems).toEqual([
+			expect.objectContaining({
+				id: 42,
+				reason: expect.stringContaining("blocklist"),
+			}),
+		]);
+		expect(enhancedPreview.previewItems).toEqual([
+			expect.objectContaining({
+				id: 42,
+				action: "skip",
+				reason: expect.stringContaining("blocklist"),
+			}),
+		]);
+		expect(enhancedPreview.wouldRemove).toBe(0);
+		expect(del).not.toHaveBeenCalled();
+	});
+
+	it("preserves a strike warning until the retained-torrent policy would authorize removal", async () => {
 		const del = vi.fn();
 		const app = makeApp({
 			get: async () => ({ records: [STALLED_ITEM] }),
 			del,
 		});
 
-		const result = await executeQueueCleaner(
+		const preview = await executeEnhancedPreview(
 			app,
 			makeInstance(),
 			makeConfig({
 				removeFromClient: false,
 				addToBlocklist: false,
 				changeCategoryEnabled: true,
+				strikeSystemEnabled: true,
+				maxStrikes: 3,
 			}),
 		);
 
-		expect(result.itemsCleaned).toBe(0);
-		expect(result.skippedItems).toEqual([
+		expect(preview.previewItems).toEqual([
 			expect.objectContaining({
 				id: 42,
-				reason: expect.stringContaining("blocklist"),
+				action: "warn",
+				strikeInfo: {
+					currentStrikes: 1,
+					maxStrikes: 3,
+					wouldTriggerRemoval: false,
+				},
 			}),
 		]);
+		expect(preview.wouldWarn).toBe(1);
 		expect(del).not.toHaveBeenCalled();
 	});
 
@@ -440,6 +491,7 @@ describe("executeQueueCleaner — integration", () => {
 				fileExtensionAllowlistEnabled: true,
 				allowedFileExtensions: '["mkv"]',
 				removeFromClient: false,
+				addToBlocklist: false,
 				changeCategoryEnabled: true,
 				lastSeedProtection: false,
 			}),
@@ -451,7 +503,7 @@ describe("executeQueueCleaner — integration", () => {
 		});
 		expect(del).toHaveBeenCalledWith(55, {
 			removeFromClient: true,
-			blocklist: true,
+			blocklist: false,
 			skipRedownload: true,
 			changeCategory: false,
 		});
@@ -576,6 +628,9 @@ describe("executeQueueCleaner — integration", () => {
 				failedEnabled: false,
 				fileExtensionAllowlistEnabled: true,
 				allowedFileExtensions: '["mkv"]',
+				removeFromClient: false,
+				addToBlocklist: false,
+				changeCategoryEnabled: true,
 				lastSeedProtection: false,
 			}),
 		);

--- a/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
+++ b/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
@@ -53,6 +53,17 @@ import {
 
 const log = loggers.queueCleaner;
 
+function isUnsafeRetainedTorrentAction(
+	item: Pick<CleanerResultItem, "protocol" | "rule">,
+	config: QueueCleanerConfig,
+): boolean {
+	return (
+		item.protocol === "torrent" &&
+		item.rule !== "disallowed_file_extension" &&
+		isUnsafeRetainedTorrentPolicy(config)
+	);
+}
+
 function isEligibleForFilePolicy(
 	item: RawQueueItem,
 	config: QueueCleanerConfig,
@@ -724,6 +735,12 @@ export async function executeQueueCleaner(
 		}
 
 		const previewRemove = dryRunToRemove.slice(0, config.maxRemovalsPerRun);
+		const policyBlocked = previewRemove.filter((item) =>
+			isUnsafeRetainedTorrentAction(item, config),
+		);
+		const authorizedPreviewRemove = previewRemove.filter(
+			(item) => !isUnsafeRetainedTorrentAction(item, config),
+		);
 
 		return {
 			itemsCleaned: 0,
@@ -731,9 +748,13 @@ export async function executeQueueCleaner(
 			itemsWarned: dryRunWarned.length,
 			cleanedItems: [],
 			skippedItems: [
-				...previewRemove.map((i) => ({
+				...authorizedPreviewRemove.map((i) => ({
 					...i,
 					reason: `[DRY RUN] Would remove: ${i.reason}${i.strikeCount ? ` (strike ${i.strikeCount}/${i.maxStrikes})` : ""}`,
+				})),
+				...policyBlocked.map((item) => ({
+					...item,
+					reason: RETAINED_TORRENT_BLOCKLIST_ERROR,
 				})),
 				...skipped,
 			],
@@ -744,11 +765,13 @@ export async function executeQueueCleaner(
 			isDryRun: true,
 			status: "completed",
 			message:
-				previewRemove.length > 0
-					? `Dry run: would remove ${previewRemove.length} item(s)${dryRunWarned.length > 0 ? `, warn ${dryRunWarned.length}` : ""}`
+				authorizedPreviewRemove.length > 0
+					? `Dry run: would remove ${authorizedPreviewRemove.length} item(s)${dryRunWarned.length > 0 ? `, warn ${dryRunWarned.length}` : ""}`
 					: dryRunWarned.length > 0
 						? `Dry run: would warn ${dryRunWarned.length} item(s)`
-						: "Dry run: no items match removal rules",
+						: policyBlocked.length > 0
+							? `Dry run: would skip ${policyBlocked.length} item(s) blocked by the retained-torrent policy`
+							: "Dry run: no items match removal rules",
 		};
 	}
 
@@ -871,7 +894,7 @@ export async function executeQueueCleaner(
 			const isTorrent = item.protocol === "torrent";
 			const isFilePolicyRemoval = item.rule === "disallowed_file_extension";
 			const useChangeCategory = !isFilePolicyRemoval && config.changeCategoryEnabled && isTorrent;
-			if (isTorrent && !isFilePolicyRemoval && isUnsafeRetainedTorrentPolicy(config)) {
+			if (isUnsafeRetainedTorrentAction(item, config)) {
 				skipped.push({ ...item, reason: RETAINED_TORRENT_BLOCKLIST_ERROR });
 				continue;
 			}
@@ -1347,6 +1370,36 @@ export async function executeEnhancedPreview(
 			const simulatedStrikeCount = (existingStrike?.strikeCount ?? 0) + 1;
 			const wouldTriggerRemoval =
 				!config.strikeSystemEnabled || simulatedStrikeCount >= config.maxStrikes;
+			if (
+				wouldTriggerRemoval &&
+				isUnsafeRetainedTorrentAction(
+					{
+						protocol: typeof item.protocol === "string" ? item.protocol : undefined,
+						rule: evaluation.rule,
+					},
+					config,
+				)
+			) {
+				previewItems.push({
+					id,
+					title,
+					action: "skip",
+					rule: evaluation.rule,
+					reason: RETAINED_TORRENT_BLOCKLIST_ERROR,
+					detailedReason: `${generateDetailedReason(evaluation.rule, item, config, now)} ${RETAINED_TORRENT_BLOCKLIST_ERROR}.`,
+					queueAge: ageMins,
+					size,
+					sizeleft,
+					progress,
+					protocol: typeof item.protocol === "string" ? item.protocol : undefined,
+					indexer: typeof item.indexer === "string" ? item.indexer : undefined,
+					downloadClient: typeof item.downloadClient === "string" ? item.downloadClient : undefined,
+					status:
+						typeof item.trackedDownloadStatus === "string" ? item.trackedDownloadStatus : undefined,
+					downloadId: typeof item.downloadId === "string" ? item.downloadId : undefined,
+				});
+				continue;
+			}
 
 			let autoImportEligible: boolean | undefined;
 			let autoImportReason: string | undefined;

--- a/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
+++ b/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
@@ -37,6 +37,10 @@ import {
 } from "./queue-item-utils.js";
 import { normalizeDownloadId, resolveQuiAwareGateReasons } from "./qui-gate.js";
 import {
+	isUnsafeRetainedTorrentPolicy,
+	RETAINED_TORRENT_BLOCKLIST_ERROR,
+} from "./retained-torrent-policy.js";
+import {
 	evaluateQueueItem,
 	shouldSkipByProfileFilter,
 	shouldSkipByTagFilter,
@@ -867,6 +871,10 @@ export async function executeQueueCleaner(
 			const isTorrent = item.protocol === "torrent";
 			const isFilePolicyRemoval = item.rule === "disallowed_file_extension";
 			const useChangeCategory = !isFilePolicyRemoval && config.changeCategoryEnabled && isTorrent;
+			if (isTorrent && !isFilePolicyRemoval && isUnsafeRetainedTorrentPolicy(config)) {
+				skipped.push({ ...item, reason: RETAINED_TORRENT_BLOCKLIST_ERROR });
+				continue;
+			}
 
 			await client.queue.delete(item.id, {
 				removeFromClient: isFilePolicyRemoval ? true : config.removeFromClient,

--- a/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
+++ b/apps/api/src/lib/queue-cleaner/cleaner-executor.ts
@@ -57,8 +57,10 @@ function isUnsafeRetainedTorrentAction(
 	item: Pick<CleanerResultItem, "protocol" | "rule">,
 	config: QueueCleanerConfig,
 ): boolean {
+	const normalizedProtocol =
+		typeof item.protocol === "string" ? item.protocol.toLowerCase() : undefined;
 	return (
-		item.protocol === "torrent" &&
+		normalizedProtocol !== "usenet" &&
 		item.rule !== "disallowed_file_extension" &&
 		isUnsafeRetainedTorrentPolicy(config)
 	);
@@ -690,17 +692,6 @@ export async function executeQueueCleaner(
 		toRemove = matched;
 	}
 
-	// Cap matches at maxRemovalsPerRun
-	const cappedToRemove = toRemove.slice(0, config.maxRemovalsPerRun);
-	const cappedSkip = toRemove.slice(config.maxRemovalsPerRun);
-
-	for (const item of cappedSkip) {
-		skipped.push({
-			...item,
-			reason: `Exceeded max removals per run (${config.maxRemovalsPerRun})`,
-		});
-	}
-
 	// Dry run mode: return preview
 	if (config.dryRunMode) {
 		const dryRunWarned: CleanerResultItem[] = [];
@@ -734,17 +725,19 @@ export async function executeQueueCleaner(
 			dryRunToRemove = matched;
 		}
 
-		const previewRemove = dryRunToRemove.slice(0, config.maxRemovalsPerRun);
-		const policyBlocked = previewRemove.filter((item) =>
+		const policyBlocked = dryRunToRemove.filter((item) =>
 			isUnsafeRetainedTorrentAction(item, config),
 		);
-		const authorizedPreviewRemove = previewRemove.filter(
+		const authorizedCandidates = dryRunToRemove.filter(
 			(item) => !isUnsafeRetainedTorrentAction(item, config),
 		);
+		const authorizedPreviewRemove = authorizedCandidates.slice(0, config.maxRemovalsPerRun);
+		const cappedSkip = authorizedCandidates.slice(config.maxRemovalsPerRun);
 
 		return {
 			itemsCleaned: 0,
-			itemsSkipped: previewRemove.length + skipped.length,
+			itemsSkipped:
+				authorizedPreviewRemove.length + policyBlocked.length + cappedSkip.length + skipped.length,
 			itemsWarned: dryRunWarned.length,
 			cleanedItems: [],
 			skippedItems: [
@@ -755,6 +748,10 @@ export async function executeQueueCleaner(
 				...policyBlocked.map((item) => ({
 					...item,
 					reason: RETAINED_TORRENT_BLOCKLIST_ERROR,
+				})),
+				...cappedSkip.map((item) => ({
+					...item,
+					reason: `Exceeded max removals per run (${config.maxRemovalsPerRun})`,
 				})),
 				...skipped,
 			],
@@ -773,6 +770,24 @@ export async function executeQueueCleaner(
 							? `Dry run: would skip ${policyBlocked.length} item(s) blocked by the retained-torrent policy`
 							: "Dry run: no items match removal rules",
 		};
+	}
+
+	const policyBlocked = toRemove.filter((item) => isUnsafeRetainedTorrentAction(item, config));
+	const authorizedToRemove = toRemove.filter(
+		(item) => !isUnsafeRetainedTorrentAction(item, config),
+	);
+	for (const item of policyBlocked) {
+		skipped.push({ ...item, reason: RETAINED_TORRENT_BLOCKLIST_ERROR });
+	}
+
+	// The cap throttles authorized mutations; policy-blocked items do not consume it.
+	const cappedToRemove = authorizedToRemove.slice(0, config.maxRemovalsPerRun);
+	const cappedSkip = authorizedToRemove.slice(config.maxRemovalsPerRun);
+	for (const item of cappedSkip) {
+		skipped.push({
+			...item,
+			reason: `Exceeded max removals per run (${config.maxRemovalsPerRun})`,
+		});
 	}
 
 	// Live mode: remove items (with auto-import support)

--- a/apps/api/src/lib/queue-cleaner/retained-torrent-policy.ts
+++ b/apps/api/src/lib/queue-cleaner/retained-torrent-policy.ts
@@ -1,0 +1,12 @@
+export const RETAINED_TORRENT_BLOCKLIST_ERROR =
+	"Retaining and recategorizing a torrent requires blocklisting the exact release";
+
+type RetainedTorrentPolicy = {
+	removeFromClient: boolean;
+	addToBlocklist: boolean;
+	changeCategoryEnabled: boolean;
+};
+
+export function isUnsafeRetainedTorrentPolicy(policy: RetainedTorrentPolicy): boolean {
+	return !policy.removeFromClient && policy.changeCategoryEnabled && !policy.addToBlocklist;
+}

--- a/apps/api/src/routes/__tests__/queue-cleaner-config-routes.test.ts
+++ b/apps/api/src/routes/__tests__/queue-cleaner-config-routes.test.ts
@@ -33,6 +33,9 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 		instanceId: instance.id,
 		fileExtensionAllowlistEnabled: false,
 		allowedFileExtensions: null,
+		removeFromClient: true,
+		addToBlocklist: true,
+		changeCategoryEnabled: false,
 		lastRunAt: null,
 		createdAt: new Date("2026-01-01T00:00:00Z"),
 		updatedAt: new Date("2026-01-01T00:00:00Z"),
@@ -40,7 +43,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
 	};
 }
 
-describe("Queue Cleaner file-allowlist config routes", () => {
+describe("Queue Cleaner config routes", () => {
 	let app: ReturnType<typeof Fastify>;
 	let prisma: {
 		queueCleanerConfig: {
@@ -149,5 +152,52 @@ describe("Queue Cleaner file-allowlist config routes", () => {
 				data: { fileExtensionAllowlistEnabled: false },
 			}),
 		);
+	});
+
+	it("rejects retaining and recategorizing torrents without blocklisting", async () => {
+		const response = await injectAuthenticated("PATCH", "/queue-cleaner/configs/arr-1", {
+			body: {
+				removeFromClient: false,
+				addToBlocklist: false,
+				changeCategoryEnabled: true,
+			},
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().error).toContain("blocklist");
+		expect(prisma.queueCleanerConfig.update).not.toHaveBeenCalled();
+	});
+
+	it("rejects a partial update that makes an existing retained-torrent policy unsafe", async () => {
+		const existingConfig = makeConfig({
+			removeFromClient: false,
+			addToBlocklist: false,
+			changeCategoryEnabled: false,
+		});
+		mocks.requireInstance.mockResolvedValue({
+			...instance,
+			queueCleanerConfig: existingConfig,
+		});
+
+		const response = await injectAuthenticated("PATCH", "/queue-cleaner/configs/arr-1", {
+			body: { changeCategoryEnabled: true },
+		});
+
+		expect(response.statusCode).toBe(400);
+		expect(response.json().error).toContain("blocklist");
+		expect(prisma.queueCleanerConfig.update).not.toHaveBeenCalled();
+	});
+
+	it("allows retaining and recategorizing torrents when blocklisting is enabled", async () => {
+		const response = await injectAuthenticated("PATCH", "/queue-cleaner/configs/arr-1", {
+			body: {
+				removeFromClient: false,
+				addToBlocklist: true,
+				changeCategoryEnabled: true,
+			},
+		});
+
+		expect(response.statusCode).toBe(200);
+		expect(prisma.queueCleanerConfig.update).toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/routes/queue-cleaner.ts
+++ b/apps/api/src/routes/queue-cleaner.ts
@@ -32,6 +32,10 @@ import {
 	MIN_STALLED_THRESHOLD_MINS,
 	MIN_STRIKE_DECAY_HOURS,
 } from "../lib/queue-cleaner/constants.js";
+import {
+	isUnsafeRetainedTorrentPolicy,
+	RETAINED_TORRENT_BLOCKLIST_ERROR,
+} from "../lib/queue-cleaner/retained-torrent-policy.js";
 import { getQueueCleanerScheduler } from "../lib/queue-cleaner/scheduler.js";
 import { parseAllowedFileExtensions } from "../lib/queue-cleaner/torrent-file-policy.js";
 import { getErrorMessage } from "../lib/utils/error-message.js";
@@ -453,6 +457,16 @@ const queueCleanerRoute: FastifyPluginCallback = (app, _opts, done) => {
 
 		if (!instance.queueCleanerConfig) {
 			return reply.status(404).send({ error: "Queue cleaner config not found for this instance" });
+		}
+
+		const effectiveRetainedTorrentPolicy = {
+			removeFromClient: data.removeFromClient ?? instance.queueCleanerConfig.removeFromClient,
+			addToBlocklist: data.addToBlocklist ?? instance.queueCleanerConfig.addToBlocklist,
+			changeCategoryEnabled:
+				data.changeCategoryEnabled ?? instance.queueCleanerConfig.changeCategoryEnabled,
+		};
+		if (isUnsafeRetainedTorrentPolicy(effectiveRetainedTorrentPolicy)) {
+			return reply.status(400).send({ error: RETAINED_TORRENT_BLOCKLIST_ERROR });
 		}
 
 		const filePolicyEnabled =


### PR DESCRIPTION
## Summary

- reject queue-cleaner configurations that retain and recategorize torrents without blocklisting the exact release
- enforce the same fail-closed policy for persisted legacy configurations before auto-import or queue deletion
- keep legacy dry-run, enhanced preview, and live execution aligned after authorization and removal caps

## Related issue

Closes #808

## Scope

- Queue-cleaner configuration validation for retained torrent recategorization
- Queue-cleaner live execution, legacy dry-run, and enhanced-preview parity
- Focused route and executor regression coverage

## Non-goals

- No change to file-policy removals, normal deletion behavior, qUI policy, or strike thresholds
- No database schema, frontend, release, or `next` branch changes

## Acceptance criteria

- [x] Unsafe retained-torrent configurations are rejected after partial or full config updates
- [x] Persisted unsafe configurations fail closed before auto-import, import-attempt persistence, or queue deletion
- [x] Policy-blocked items do not consume the executable per-run removal cap
- [x] Legacy dry-run, enhanced preview, and live execution agree for mixed-case and unknown protocol identity
- [x] File-policy removals remain explicitly exempt

## Changes

- Add a shared retained-torrent policy predicate and apply it to effective config validation
- Partition policy-blocked actions before mutation and before applying `maxRemovalsPerRun`
- Normalize protocol identity at the shared execution/preview policy boundary
- Add binding-faithful route and executor integration regressions for preview parity, auto-import ordering, cap ordering, strike warnings, and file-policy behavior

## Risk classification

- [ ] Trivial
- [ ] Standard
- [x] Safety-critical

## Validation

- [x] Relevant deterministic validation passed
- [x] Focused tests passed, when applicable — 55/55 queue-cleaner and config-route tests
- [x] `pnpm run format`
- [x] `pnpm --filter @arr/shared build`, when shared changed
- [x] `pnpm run typecheck`
- [x] `pnpm run test` — API 4,730 passed / 53 skipped; web and shared suites passed
- [x] `pnpm run lint`
- [x] `pnpm run build`, when required by the change
- [x] User-visible behavior was live-verified, when applicable — N/A; API safety boundary is covered at the real executor and route bindings
- [x] New queries use centralized query keys and polling constants, when applicable — N/A
- [x] New sensitive displays preserve incognito behavior, when applicable — N/A
- [x] New Prisma queries for user-owned resources include `userId`, when applicable — N/A; no new user-owned query
- [x] Optional-service gating is verified for new pages, panels, or signals, when applicable — N/A
- [x] User-facing counts are precise rather than proxies, when applicable — executable removal-cap counts are regression-covered
- [x] Action links reach the correct page with required parameters, when applicable — N/A
- [x] Duplicate surfaces were checked and any overlap is justified, when applicable — one shared policy predicate covers config and executor surfaces

## Review plan

- Initial broad-reviewed head: `9a39e3dac2fe812aa37dbd57d18312584d25821e` on staged exact-main preview tree `23b9effc35b4e45547b1c795ef24b184bb07b9ec`
- Correction head: `001ecc7580db77a5ee64599dedd27ec56c30039e`; patch-equivalent rebuilt head `412ade94d050eac6f5401b2a9c2aa948b12b4e34`
- Targeted delta range: `9a39e3dac2fe812aa37dbd57d18312584d25821e..001ecc7580db77a5ee64599dedd27ec56c30039e` — data-safety and regression reviewers PASS
- Material-scope change declared? No
- Independent regression reviewer: PASS on the broad review and targeted correction delta
- Independent data-safety reviewer, when required: PASS on the broad review and targeted correction delta
- GitHub Codex review head: `9b95bad41d428626572f1ac5e07e4443696d2ecc`; its sole P1 is fixed and resolved, and later corrections are covered by targeted delta review
- Maintainer decision: Merge after exact-head CI and review surfaces pass under the standing convergence authorization

## Finding disposition

| ID | Severity | Classification | Reproduced evidence | Disposition | Follow-up |
| --- | --- | --- | --- | --- | --- |
| GH-1 | P1 | In scope | Original live-only guard allowed both previews to report removal | Fixed by `9b473413`; preview/execution parity regression passes | None |
| R-1 | P1 | In scope | Eligible import-pending torrent mutated upstream before the policy guard | Fixed by `412ade94`; no auto-import, attempt persistence, or deletion occurs | None |
| R-2 | P1 | In scope | A blocked first item consumed a cap of one and starved a safe Usenet item | Fixed by `412ade94`; cap-one three-mode regression passes | None |
| R-3 | P2 | In scope | Raw `Torrent` protocol previewed removal while normalized execution skipped it | Fixed by `412ade94`; mixed-case parity regression passes | None |

## Final merge gate

- [x] Exact-head CI is green
- [x] Acceptance criteria passed
- [x] No unresolved in-scope review threads remain
- [x] Valid out-of-scope findings are linked or dispositioned
- [x] Current head is covered by the broad review or a targeted delta review
- [x] Base is unchanged, or meaningful overlap was reviewed
- [x] Maintainer approved merge
- [x] Post-merge verification is planned — fetch merged `main`, prove the merge SHA, and rerun focused queue-cleaner tests from a fresh detached worktree
